### PR TITLE
dasllama-server: OpenAI tool calling (Hermes/ChatML) + unhandled-request logging

### DIFF
--- a/daslib/json.das
+++ b/daslib/json.das
@@ -613,6 +613,69 @@ def write_json(val : JsonValue?) : string {
     return st
 }
 
+def private write_value_compact(var writer : StringBuilderWriter; jsv : JsonValue?) {
+    if (jsv == null) {
+        write(writer, "null")
+    } elif (jsv.value is _string) {
+        write(writer, "\"")
+        write_escape_string(writer, jsv.value as _string)
+        write(writer, "\"")
+    } elif (jsv.value is _number) {
+        if (no_trailing_zeros) {
+            write(writer, fmt(":.17f", jsv.value as _number) |> rtrim("0") |> rtrim("."))
+        } else {
+            write(writer, jsv.value as _number)
+        }
+    } elif (jsv.value is _longint) {
+        write(writer, jsv.value as _longint)
+    } elif (jsv.value is _array) {
+        write(writer, "[")
+        var first = true
+        for (elem in jsv.value as _array) {
+            if (first) {
+                first = false
+            } else {
+                write(writer, ", ")
+            }
+            write_value_compact(writer, elem)
+        }
+        write(writer, "]")
+    } elif (jsv.value is _object) {
+        write(writer, "\{")
+        var first = true
+        for (elemK, elemV in keys(jsv.value as _object), values(jsv.value as _object)) {
+            if (no_empty_arrays && elemV.value is _array && empty(elemV.value as _array)) {
+                continue
+            }
+            if (first) {
+                first = false
+            } else {
+                write(writer, ", ")
+            }
+            write(writer, "\"")
+            write_escape_string(writer, elemK)
+            write(writer, "\": ")
+            write_value_compact(writer, elemV)
+        }
+        write(writer, "\}")
+    } elif (jsv.value is _bool) {
+        write(writer, (jsv.value as _bool) ? "true" : "false")
+    } elif (jsv.value is _null) {
+        write(writer, "null")
+    } else {
+        panic("unexpected {jsv}")
+    }
+}
+
+def write_json_compact(val : JsonValue?) : string {
+    //! ``write_json`` on one line: no newlines or indentation, ``", "`` / ``": "`` separators —
+    //! the python ``json.dumps`` / jinja ``tojson`` shape chat templates and wire protocols carry.
+    let st = build_string() $(var writer) {
+        write_value_compact(writer, val)
+    }
+    return st
+}
+
 def write_json(val : JsonValue?#) : string {
     //! Overload accepting temporary type
     unsafe {// Fine, as json doesn't escape the function

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -309,7 +309,8 @@ def document_module_dasllama(_root : string) {
         group_by_regex("Evaluation and sampling", mod, %regex~(eval|eval_embd|eval_batch|sample|set_seed|stats)$%%),
         group_by_regex("Generation", mod, %regex~(generate|generate_embd)$%%),
         group_by_regex("Embeddings", mod, %regex~(embed)$%%),
-        group_by_regex("Chat", mod, %regex~(create_chat|create_chat_renderer|add_user|add_user_audio|add_assistant|render_turn|render_assistant|render_close|respond)$%%)
+        group_by_regex("Chat", mod, %regex~(create_chat|create_chat_renderer|add_user|add_user_audio|add_assistant|render_turn|render_assistant|render_close|respond)$%%),
+        group_by_regex("Tool calling", mod, %regex~(set_tools|add_tool_results|render_assistant_calls)$%%)
     )
     var hook = DocsHook()
     hook.afterEnums <- @(var f : FILE const?; _was_enums : bool) {
@@ -509,7 +510,7 @@ def document_module_json(_root : string) {
     var mod = find_module("json")
     var groups <- array<DocGroup>(
         group_by_regex("Value conversion", mod, %regex~(JV|JVNull)$%%),
-        group_by_regex("Read and write", mod, %regex~(read_json|write_json)$%%),
+        group_by_regex("Read and write", mod, %regex~(read_json|write_json|write_json_compact)$%%),
         group_by_regex("Memory management", mod, %regex~(delete_json|update|json_null_sentinel)$%%),
         group_by_regex("JSON properties", mod, %regex~(set_no_trailing_zeros|set_no_empty_arrays|set_allow_duplicate_keys)$%%),
         group_by_regex("Broken JSON", mod, %regex~(try_fixing_broken_json)$%%)

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -299,6 +299,26 @@ def render_close(model : Model; chat : ChatSession) : array<int64> {
     return <- render_close_(model, chat)
 }
 
+def set_tools(var chat : ChatSession; var tools : array<string>) {
+    //! Declare the conversation's tools (verbatim JSON objects, one per tool — the OpenAI
+    //! ``tools[]`` entries, moved in) BEFORE the first turn renders; the system turn then carries
+    //! the family's tool block. Families with no tool format (``tmpl.tool_call_open`` empty)
+    //! ignore them.
+    set_tools_(chat, tools)
+}
+
+def add_tool_results(var chat : ChatSession; results : array<string>) {
+    //! Queue tool results as the next pending turn — the reply to an assistant turn that called
+    //! tools. Call in place of ``add_user``, then ``respond``/``render_turn`` as usual.
+    add_tool_results_(chat, results)
+}
+
+def render_assistant_calls(model : Model; var chat : ChatSession; text : string; calls : array<string>; var out : array<int64>) {
+    //! ``render_assistant``'s tool-calling twin: replay an assistant turn that emitted tool calls
+    //! (verbatim ``\{"name":…,"arguments":…}`` objects) plus any ``text`` alongside.
+    render_assistant_calls_(model, chat, text, calls, out)
+}
+
 def respond(model : Model; var chat : ChatSession; params : SamplingParams;
             blk : block<(piece : string) : bool>) : string {
     //! Generate the assistant's reply to the queued user message: render the turn, prefill it, then

--- a/modules/dasLLAMA/dasllama/dasllama_arch_qwen2.das
+++ b/modules/dasLLAMA/dasllama/dasllama_arch_qwen2.das
@@ -18,6 +18,7 @@ def register_arch_qwen2() {
     d.chat.user.parts <- [chat_special("<|im_start|>"), chat_text("user\n"), chat_content(), chat_special("<|im_end|>"), chat_text("\n")]
     d.chat.assistant_open.parts <- [chat_special("<|im_start|>"), chat_text("assistant\n")]
     d.chat.stop <- ["<|im_end|>", "<|endoftext|>"]
+    hermes_tools(d.chat)
     // audio-capable qwen2 family (Qwen2-Audio, Qwen2.5-Omni) wraps the soft-token span in
     // audio markers; renders only on audio turns, so text-only qwen2 vocabs never resolve these
     d.chat.audio_pre.parts <- [chat_special("<|audio_bos|>")]

--- a/modules/dasLLAMA/dasllama/dasllama_arch_qwen3.das
+++ b/modules/dasLLAMA/dasllama/dasllama_arch_qwen3.das
@@ -18,6 +18,7 @@ def register_arch_qwen3() {
     d.chat.user.parts <- [chat_special("<|im_start|>"), chat_text("user\n"), chat_content(), chat_special("<|im_end|>"), chat_text("\n")]
     d.chat.assistant_open.parts <- [chat_special("<|im_start|>"), chat_text("assistant\n")]
     d.chat.stop <- ["<|im_end|>", "<|endoftext|>"]
+    hermes_tools(d.chat)
     // Qwen3-ASR's decoder converts as `qwen3vl` — M-RoPE + deepstack. For text + audio input
     // every M-RoPE coordinate equals the linear position (angles depend only on the coordinate
     // and the dim's frequency, so ANY section layout degenerates to standard rope), and the

--- a/modules/dasLLAMA/dasllama/dasllama_arch_qwen3moe.das
+++ b/modules/dasLLAMA/dasllama/dasllama_arch_qwen3moe.das
@@ -25,6 +25,7 @@ def register_arch_qwen3moe() {
     d.chat.user.parts <- [chat_special("<|im_start|>"), chat_text("user\n"), chat_content(), chat_special("<|im_end|>"), chat_text("\n")]
     d.chat.assistant_open.parts <- [chat_special("<|im_start|>"), chat_text("assistant\n")]
     d.chat.stop <- ["<|im_end|>", "<|endoftext|>"]
+    hermes_tools(d.chat)
     // Qwen3-Omni-30B's thinker converts as `qwen3vlmoe` — qwen3moe + M-RoPE + deepstack. For
     // text + audio input every M-RoPE coordinate equals the linear position (so any section
     // layout degenerates to standard rope), and the deepstack merge is inactive without vision

--- a/modules/dasLLAMA/dasllama/dasllama_chat.das
+++ b/modules/dasLLAMA/dasllama/dasllama_chat.das
@@ -36,8 +36,10 @@ struct ChatSession {
     close_parts : array<ChatPart>   // how a turn terminates (the user template after its content slot)
     stop_ids : array<int64>         // resolved stop-token ids
     system : string = ""
+    tools_json : array<string>      // verbatim tool JSONs; non-empty => the system turn carries the family's tool block
     pending : string = ""           // the user text awaiting the next respond()
     has_pending : bool = false
+    pending_is_tool : bool = false  // pending is a tool-results block: marker-split at render
     first : bool = true             // first turn emits add_bos + the system turn
     max_new : int64 = 256l          // per-reply token budget
     history : array<Message>
@@ -164,20 +166,107 @@ def private render_parts(m : Model; parts : array<ChatPart>; content : string; v
     }
 }
 
+// Split `s` into template parts at every occurrence of a tool marker that resolves in the vocab —
+// HF added-token splitting: vocab markers tokenize as their single ids, the prose around them as
+// text (probe-verified: encode() does NOT match added tokens inline, so a marker left in a text
+// run tokenizes as plain BPE — not what the model saw in training). Markers absent from the
+// vocab stay in the text run, exactly what the family's own tokenizer does (Qwen2.5 has
+// <tool_call> but not <tool_response>; Qwen3 has both).
+def private split_on_tool_markers(m : Model; c : ChatSession; s : string; var parts : array<ChatPart>) {
+    let markers = fixed_array(c.tmpl.tool_call_open, c.tmpl.tool_call_close,
+                              c.tmpl.tool_resp_open, c.tmpl.tool_resp_close)
+    var pos = 0
+    let n = length(s)
+    while (pos < n) {
+        var best = -1
+        var best_mark = ""
+        for (mk in markers) {
+            if (!empty(mk) && special_id(m, mk) >= 0l) {
+                let f = find(s, mk, pos)
+                if (f >= 0 && (best < 0 || f < best)) {
+                    best = f
+                    best_mark = mk
+                }
+            }
+        }
+        if (best < 0) {
+            break
+        }
+        if (best > pos) {
+            parts |> push(chat_text(slice(s, pos, best)))
+        }
+        parts |> push(chat_special(best_mark))
+        pos = best + length(best_mark)
+    }
+    if (pos < n) {
+        parts |> push(chat_text(slice(s, pos, n)))
+    }
+}
+
+// Render a turn with its content slot replaced by pre-split parts.
+def private render_parts_spliced(m : Model; turn_parts : array<ChatPart>; spliced : array<ChatPart>; var out : array<int64>) {
+    var parts : array<ChatPart>
+    parts |> reserve(length(turn_parts) + length(spliced))
+    for (p in turn_parts) {
+        if (p.kind == ChatPartKind.content) {
+            parts |> push_from(spliced)
+        } else {
+            parts |> push(p)
+        }
+    }
+    render_parts(m, parts, "", out)
+    delete parts
+}
+
+// The system-turn content on the first turn: the user system prompt, and — when tools are
+// declared and the family has a tool format — the tool block wrapping the verbatim tool JSONs
+// (one per line, the Qwen/Hermes shape).
+def private system_content(c : ChatSession) : string {
+    if (empty(c.tools_json) || empty(c.tmpl.tool_call_open)) {
+        return c.system
+    }
+    var parts : array<string>
+    parts |> push(empty(c.system) ? c.tmpl.tool_sys_prelude : "{c.system}\n\n{c.tmpl.tool_sys_prelude}")
+    parts |> push_from(c.tools_json)
+    parts |> push(c.tmpl.tool_sys_epilogue)
+    let s = join(parts, "\n")
+    delete parts
+    return s
+}
+
 // Render this turn's prefill: (first turn) BOS + system, then the user turn and the generation prompt.
 def private render_prompt(m : Model; c : ChatSession; var out : array<int64>) {
     if (c.first && c.tmpl.add_bos) {
         out |> push(bos_id(m))
     }
     var user_content = c.pending
-    if (c.first && !empty(c.system)) {
-        if (!empty(c.tmpl.system.parts)) {
-            render_parts(m, c.tmpl.system.parts, c.system, out)
-        } else {
-            user_content = "{c.system}\n\n{c.pending}"   // no system role (Gemma): fold into the first user turn
+    if (c.first) {
+        let sys = system_content(c)
+        if (!empty(sys)) {
+            if (!empty(c.tmpl.system.parts)) {
+                if (empty(c.tools_json)) {
+                    render_parts(m, c.tmpl.system.parts, sys, out)
+                } else {
+                    // the tool block quotes the call markers (format instructions) — marker-split
+                    var sp : array<ChatPart>
+                    split_on_tool_markers(m, c, sys, sp)
+                    render_parts_spliced(m, c.tmpl.system.parts, sp, out)
+                    delete sp
+                }
+            } else {
+                user_content = "{sys}\n\n{c.pending}"   // no system role (Gemma): fold into the first user turn
+            }
         }
     }
-    render_parts(m, c.tmpl.user.parts, user_content, out)
+    if (c.pending_is_tool) {
+        // tool results ride the user turn frames; their response markers split like the system block's
+        var tp : array<ChatPart>
+        split_on_tool_markers(m, c, user_content, tp)
+        render_parts_spliced(m, c.tmpl.user.parts, tp, out)
+        delete tp
+    } else {
+        render_parts(m, c.tmpl.user.parts, user_content, out)
+    }
     render_parts(m, c.tmpl.assistant_open.parts, "", out)
 }
 
@@ -191,11 +280,14 @@ def private render_prompt_audio(m : Model; c : ChatSession; var head : array<int
         head |> push(bos_id(m))
     }
     var user_content = c.pending
-    if (c.first && !empty(c.system)) {
-        if (!empty(c.tmpl.system.parts)) {
-            render_parts(m, c.tmpl.system.parts, c.system, head)
-        } else {
-            user_content = "{c.system}\n\n{c.pending}"
+    if (c.first) {
+        let sys = system_content(c)
+        if (!empty(sys)) {
+            if (!empty(c.tmpl.system.parts)) {
+                render_parts(m, c.tmpl.system.parts, sys, head)
+            } else {
+                user_content = "{sys}\n\n{c.pending}"
+            }
         }
     }
     var before : array<ChatPart>
@@ -227,6 +319,7 @@ def private consume_pending_(var c : ChatSession) {
     c.first = false
     c.has_pending = false
     c.pending = ""
+    c.pending_is_tool = false
 }
 
 //! `create_chat_`'s RENDER-ONLY twin: resolves the chat template, stop ids, and turn close exactly
@@ -339,7 +432,61 @@ def render_assistant_(m : Model; var c : ChatSession; text : string; var out : a
 def add_user_(var c : ChatSession; text : string) {
     c.pending = text
     c.has_pending = true
+    c.pending_is_tool = false
     c.history |> push(Message(role = Role.user, content = text))
+}
+
+//! Declare the conversation's tools (verbatim JSON objects, one per tool — the OpenAI ``tools[]``
+//! entries, moved in). The first rendered turn then carries the family's tool block in its system
+//! turn. Families with no tool format (``tmpl.tool_call_open`` empty) ignore them.
+def set_tools_(var c : ChatSession; var tools : array<string>) {
+    c.tools_json <- tools
+}
+
+//! Queue TOOL RESULTS as the next pending turn — the reply to an assistant turn that called
+//! tools. Each result wraps in the family's tool-response markers; consecutive results share one
+//! turn, riding the user turn frames (the ChatML/Hermes convention). Call in place of
+//! ``add_user_``, then respond/render as usual.
+def add_tool_results_(var c : ChatSession; results : array<string>) {
+    var parts : array<string>
+    parts |> reserve(length(results))
+    c.history |> reserve(length(c.history) + length(results))
+    for (r in results) {
+        parts |> push("{c.tmpl.tool_resp_open}\n{r}\n{c.tmpl.tool_resp_close}")
+        c.history |> push(Message(role = Role.tool, content = r))
+    }
+    c.pending = join(parts, "\n")
+    c.has_pending = true
+    c.pending_is_tool = true
+    delete parts
+}
+
+//! `render_assistant_`'s tool-calling twin: replay an assistant turn that emitted tool calls.
+//! ``calls`` are the verbatim ``\{"name":…,"arguments":…}`` JSON objects, one per call; ``text``
+//! is any content alongside (empty for a pure tool-call turn). Precondition: a pending user or
+//! tool turn; a no-op otherwise.
+def render_assistant_calls_(m : Model; var c : ChatSession; text : string; calls : array<string>; var out : array<int64>) {
+    if (!c.has_pending) {
+        return
+    }
+    render_prompt(m, c, out)
+    var parts : array<string>
+    parts |> reserve(length(calls) + 1)
+    if (!empty(text)) {
+        parts |> push(text)
+    }
+    for (cj in calls) {
+        parts |> push("{c.tmpl.tool_call_open}\n{cj}\n{c.tmpl.tool_call_close}")
+    }
+    let body = join(parts, "\n")
+    delete parts
+    var bp : array<ChatPart>
+    split_on_tool_markers(m, c, body, bp)   // call markers tokenize as their ids where the vocab has them
+    render_parts(m, bp, "", out)
+    delete bp
+    consume_pending_(c)
+    render_parts(m, c.close_parts, "", out)
+    c.history |> push(Message(role = Role.assistant, content = body))
 }
 
 //! Inject a KNOWN assistant reply into the conversation WITHOUT generating: prefills the pending

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -496,6 +496,13 @@ struct ChatTemplate {
     audio_pre : ChatTurn = ChatTurn()
     audio_post : ChatTurn = ChatTurn()
     stop : array<string>
+    // tool-calling format (empty tool_call_open = the family declares none; see hermes_tools)
+    tool_sys_prelude : string = ""    // opens the tool-definitions block in the system turn
+    tool_sys_epilogue : string = ""   // closes the block + the call-format instructions
+    tool_call_open : string = ""      // marker opening one call in assistant output
+    tool_call_close : string = ""
+    tool_resp_open : string = ""      // wraps one tool result in the reply turn
+    tool_resp_close : string = ""
 }
 
 //! What a decoder honestly supports at the chat layer — declared by each arch registration,
@@ -9671,6 +9678,18 @@ def chat_special(s : string) : ChatPart {
 }
 def chat_content() : ChatPart {
     return ChatPart(kind = ChatPartKind.content, s = "")
+}
+
+//! Install the Hermes-style tool-calling format (the Qwen2.5/Qwen3 chat template's tool block):
+//! ``<tools>`` JSON definitions in the system turn, ``<tool_call>`` JSON calls in assistant
+//! output, ``<tool_response>`` results riding user turns.
+def hermes_tools(var ct : ChatTemplate) {
+    ct.tool_sys_prelude = "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>"
+    ct.tool_sys_epilogue = "</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n\{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>"
+    ct.tool_call_open = "<tool_call>"
+    ct.tool_call_close = "</tool_call>"
+    ct.tool_resp_open = "<tool_response>"
+    ct.tool_resp_close = "</tool_response>"
 }
 
 //! The default llama-family blocks (std attention, dense gated FFN), shared by every dense arch.

--- a/tests/dasLLAMA/test_chat.das
+++ b/tests/dasLLAMA/test_chat.das
@@ -238,6 +238,115 @@ def test_chat_end_to_end(t : T?) {
     }
 }
 
+// ===== Hermes tool-calling render (Qwen family) =====
+
+// The reference is the Qwen2.5/Qwen3 chat template + HF added-token tokenization: tool JSONs one
+// per line inside <tools>, and EVERY <tool_call>/</tool_call> spelling — the prose mentions in the
+// format instructions included — encodes as its single vocab id. <tools> and (on Qwen2.5, which
+// lacks the token) <tool_response> stay in the text runs.
+
+[test]
+def test_chat_tools_hermes(t : T?) {
+    t |> run("Qwen ChatML renders the Hermes tool block token-for-token (needs Qwen2.5-0.5B)") @(t : T?) {
+        let path = path_join(models_dir(), "Qwen2.5-0.5B-Instruct-Q8_0.gguf")
+        if (!stat(path).is_valid) {
+            t |> skip("{path} not present")
+            return
+        }
+        var m <- load_capped(path)
+        var raw <- load_bpe_tokenizer_gguf(path)
+        let ims = special_id(raw, "<|im_start|>")
+        let ime = special_id(raw, "<|im_end|>")
+        let tco = special_id(m, "<tool_call>")
+        let tcc = special_id(m, "</tool_call>")
+        t |> success(tco >= 0l && tcc >= 0l, "the vocab carries the tool-call markers")
+        t |> equal(special_id(m, "<tool_response>"), -1l)   // NOT a Qwen2.5 token — stays text below
+
+        let tooldef = "\{\"type\": \"function\", \"function\": \{\"name\": \"get_weather\", \"parameters\": \{}}}"
+        var c = create_chat_renderer(m, SYS, 8l)
+        var tools : array<string>
+        tools |> push(tooldef)
+        set_tools(c, tools)
+        add_user(c, USR)
+        let got <- render_turn(m, c)
+
+        var want : array<int64>
+        want |> push(ims)
+        want |> push_from(bpe_encode(raw, "system\n{SYS}\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{tooldef}\n</tools>\n\nFor each function call, return a json object with function name and arguments within "))
+        want |> push(tco)
+        want |> push(tcc)
+        want |> push_from(bpe_encode(raw, " XML tags:\n"))
+        want |> push(tco)
+        want |> push_from(bpe_encode(raw, "\n\{\"name\": <function-name>, \"arguments\": <args-json-object>}\n"))
+        want |> push(tcc)
+        want |> push(ime)
+        want |> push_from(bpe_encode(raw, "\n"))
+        want |> push(ims)
+        want |> push_from(bpe_encode(raw, "user\n{USR}"))
+        want |> push(ime)
+        want |> push_from(bpe_encode(raw, "\n"))
+        want |> push(ims)
+        want |> push_from(bpe_encode(raw, "assistant\n"))
+        t |> success(same(got, want), "system tool block token-for-token")
+        delete c
+        delete raw
+        delete m
+    }
+    t |> run("tool-call replay + tool-results turn render token-for-token (needs Qwen2.5-0.5B)") @(t : T?) {
+        let path = path_join(models_dir(), "Qwen2.5-0.5B-Instruct-Q8_0.gguf")
+        if (!stat(path).is_valid) {
+            t |> skip("{path} not present")
+            return
+        }
+        var m <- load_capped(path)
+        var raw <- load_bpe_tokenizer_gguf(path)
+        let ims = special_id(raw, "<|im_start|>")
+        let ime = special_id(raw, "<|im_end|>")
+        let tco = special_id(m, "<tool_call>")
+        let tcc = special_id(m, "</tool_call>")
+
+        // no system, no tools: the replay shape alone. The assistant called get_weather...
+        var c = create_chat_renderer(m, "", 8l)
+        add_user(c, USR)
+        var toks : array<int64>
+        let call = "\{\"name\": \"get_weather\", \"arguments\": \{\"city\": \"Paris\"}}"
+        var calls : array<string>
+        calls |> push(call)
+        render_assistant_calls(m, c, "", calls, toks)
+        var want : array<int64>
+        want |> push(ims)
+        want |> push_from(bpe_encode(raw, "user\n{USR}"))
+        want |> push(ime)
+        want |> push_from(bpe_encode(raw, "\n"))
+        want |> push(ims)
+        want |> push_from(bpe_encode(raw, "assistant\n"))
+        want |> push(tco)
+        want |> push_from(bpe_encode(raw, "\n{call}\n"))
+        want |> push(tcc)
+        want |> push(ime)
+        want |> push_from(bpe_encode(raw, "\n"))
+        t |> success(same(toks, want), "assistant tool-call turn token-for-token")
+
+        // ...and its result arrives: a user-framed turn, <tool_response> as plain text
+        var results : array<string>
+        results |> push("\{\"temp_c\": 21}")
+        add_tool_results(c, results)
+        let got2 <- render_turn(m, c)
+        var want2 : array<int64>
+        want2 |> push(ims)
+        want2 |> push_from(bpe_encode(raw, "user\n<tool_response>\n\{\"temp_c\": 21}\n</tool_response>"))
+        want2 |> push(ime)
+        want2 |> push_from(bpe_encode(raw, "\n"))
+        want2 |> push(ims)
+        want2 |> push_from(bpe_encode(raw, "assistant\n"))
+        t |> success(same(got2, want2), "tool-results turn token-for-token")
+        t |> success(c.history[2].role == Role.tool, "tool result recorded in the transcript")
+        delete c
+        delete raw
+        delete m
+    }
+}
+
 // ===== Template detection (model-free) =====
 
 // Distinctive first special of a template's user turn — "" when the user turn opens with plain

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -82,7 +82,7 @@ so the deployed config survives. Stop a running server first — Windows locks t
 | Method | Path | Notes |
 |---|---|---|
 | `GET`  | `/v1/models` | Lists the served model (and `--asr` if loaded) |
-| `POST` | `/v1/chat/completions` | Chat; `stream: true` → SSE, else buffered |
+| `POST` | `/v1/chat/completions` | Chat; `stream: true` → SSE, else buffered; OpenAI function calling (`tools`) |
 | `POST` | `/v1/completions` | Raw completion; `stream: true` → SSE, else buffered |
 | `POST` | `/v1/embeddings` | Mean-pooled, L2-normalized sentence embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech→text (multipart upload; needs `--asr`) |
@@ -98,6 +98,24 @@ curl http://127.0.0.1:8080/v1/chat/completions -H 'Content-Type: application/jso
   "max_tokens": 16, "stream": false
 }'
 ```
+
+### Tool / function calling
+
+`/v1/chat/completions` speaks the OpenAI function-calling protocol: pass `tools` (and optionally
+`tool_choice`; `"none"` disables, the forced-function object form is not honored), get back
+`finish_reason: "tool_calls"` with `message.tool_calls`, send the results as `role: "tool"`
+messages, repeat. Assistant `tool_calls` turns and `role: "tool"` results replay exactly through
+the chat template on each stateless resend, so agent loops (opencode, pi, …) work end-to-end.
+
+The wire format is per model family: the ChatML/Hermes shape (Qwen2.5 / Qwen3 — tool JSONs in a
+`<tools>` system block, calls as `<tool_call>{"name":…,"arguments":…}</tool_call>`) is
+implemented; a model whose chat template declares no tool format gets an honest 400. Streaming
+with tools streams content up to the first tool-call marker, then buffers and emits the parsed
+calls as one `delta.tool_calls` chunk at finish.
+
+Requests the server does NOT fully understand are visible in the log: unknown endpoints 404
+through a catch-all that logs method + path + body head, and known routes warn per ignored field
+(`response_format`, `stop`, multimodal content parts, …).
 
 ### Embeddings
 
@@ -127,8 +145,9 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 All tests in this directory are model-gated and JIT-only (they skip cleanly when the GGUF is
 absent; set `DASLLAMA_MODELS_DIR`):
 
-- `test_openai_server.das` — endpoint conformance (`/v1/models`, `/v1/embeddings`, buffered chat)
-  over the real dashv HTTP client; needs `tinyllama-1.1b-chat-v1.0.Q8_0.gguf`.
+- `test_openai_server.das` — endpoint conformance (`/v1/models`, `/v1/embeddings`, buffered chat,
+  the tools-unsupported 400, the unknown-endpoint 404) over the real dashv HTTP client, plus
+  model-free `parse_tool_calls` unit tests; needs `tinyllama-1.1b-chat-v1.0.Q8_0.gguf`.
 - `test_llm_scheduler.das` — the continuous-batching scheduler against `generate()` references
   (bit-exact single stream, chunk invariance, staggered admits, eviction); needs
   `SmolLM2-135M-Instruct-Q8_0.gguf`.
@@ -147,4 +166,5 @@ and warm-vs-cold TTFT for the prefix cache.
 
 ## Not yet implemented
 
-Tool / function calling (`tools`, `tool_choice`) — parked as a follow-up.
+Multimodal content arrays in chat messages, the request's `stop` / `response_format` fields, and
+the forced-function `tool_choice` object form — all logged when a request carries them.

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -322,7 +322,8 @@ def private send_chat_tool_calls_chunk(srv : WebSocketServer; var writer : HttpR
 
 //! Extract Hermes-style tool calls from a finished reply: every well-formed open…close span becomes
 //! one call; returns the content BEFORE the first opener (everything when nothing parses, so no
-//! reply text is silently dropped). Malformed spans log and end the scan.
+//! reply text is silently dropped). Unparseable call JSON logs and is skipped; an unterminated
+//! span logs and ends the scan.
 def parse_tool_calls(full : string; open_mark, close_mark, id_base : string;
                      var calls : array<OaiToolCall>) : string {
     var content_end = -1
@@ -338,7 +339,7 @@ def parse_tool_calls(full : string; open_mark, close_mark, id_base : string;
         let bstart = o + length(open_mark)
         let cl = find(full, close_mark, bstart)
         if (cl < 0) {
-            to_log(LOG_WARNING, "dasllama-server: unterminated {open_mark} span (token budget cut?) — kept as content\n")
+            to_log(LOG_WARNING, "dasllama-server: unterminated {open_mark} span (token budget cut?) — scan stopped\n")
             break
         }
         let body = strip(slice(full, bstart, cl))
@@ -579,7 +580,11 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     var tools : array<string>
     defer() { delete tools }
     let tools_v = js?["tools"]
-    if (tools_v != null && tools_v.value is _array) {
+    if (tools_v != null && !(tools_v.value is _null)) {
+        if (!(tools_v.value is _array)) {
+            bad_request(srv, writer, "'tools' must be an array of tool definitions")
+            return
+        }
         tools |> reserve(length(tools_v.value as _array))
         for (tv in (tools_v.value as _array)) {
             tools |> push(write_json_compact(tv))   // the template's one-tool-per-line tojson shape

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -49,6 +49,7 @@ struct private StreamWire {
     utf8_tail : string              // streaming: held-back bytes of a multi-byte char split across tokens
     has_tools : bool                // chat request declared tools on a tool-capable template
     hold : bool                     // streaming: tool-call opener seen — buffer instead of stream
+    held_pieces : int               // pieces buffered since hold engaged (drives keepalive chunks)
     call_open : string              // the family's tool-call markers (copied from the chat template)
     call_close : string
 }
@@ -741,7 +742,15 @@ def private flush_events(srv : WebSocketServer) {
             if (!w.streaming || w.has_tools) {
                 w.reply_parts |> push(e.text)   // buffered reply, and/or the finish-time tool-call parse
             }
-            if (w.streaming && !w.hold) {
+            if (w.streaming && w.hold) {
+                // a long tool-call body buffers for minutes at decode speed; with no bytes on the
+                // wire the client's idle timeout kills the stream (pi: "terminated" + retry loop).
+                // An empty delta {} is protocol-legal liveness every ~16 tokens.
+                w.held_pieces ++
+                if (w.held_pieces % 16 == 0) {
+                    send_chat_chunk(srv, w.writer, w.id, w.created, "", "", "")
+                }
+            } elif (w.streaming) {
                 // re-join any held-back partial character, then hold the new incomplete tail
                 // so every delta on the wire is valid UTF-8 by itself
                 let whole = "{w.utf8_tail}{e.text}"
@@ -752,6 +761,7 @@ def private flush_events(srv : WebSocketServer) {
                     if (o >= 0) {
                         w.hold = true
                         w.utf8_tail = ""
+                        to_log(LOG_INFO, "stream {w.id}: tool-call opener — buffering the call body (keepalives on)\n")
                         let head = slice(whole, 0, o)   // the opener starts on a char boundary (ascii)
                         if (!empty(head)) {
                             send_chat_chunk(srv, w.writer, w.id, w.created, "", head, "")

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -644,7 +644,11 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
                 calls |> reserve(length(tc.value as _array))
                 for (tcall in (tc.value as _array)) {
                     let fv = tcall?["function"]
-                    let cname = fv?["name"] ?? ""
+                    var nv = JV(fv?["name"] ?? "")   // JSON-escape the name (quotes/backslashes)
+                    let cname = write_json_compact(nv)
+                    unsafe {
+                        delete nv
+                    }
                     let av = fv?["arguments"]
                     var argstr = "\{}"
                     if (av != null && av.value is _string) {
@@ -655,7 +659,7 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
                     } elif (av != null && !(av.value is _null)) {
                         argstr = write_json_compact(av)   // tolerated: arguments sent as an object
                     }
-                    calls |> push("\{\"name\": \"{cname}\", \"arguments\": {argstr}}")
+                    calls |> push("\{\"name\": {cname}, \"arguments\": {argstr}}")
                 }
             }
             if (pending) {

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -396,7 +396,8 @@ def private tmpdir() : string {
 
 // Top-level fields each JSON route reads; anything else in a request logs a warning instead of
 // silently vanishing — the diagnostic for "agent X immediately fails against this server".
-let CHAT_FIELDS : table<string> <- { "model", "messages", "stream", "temperature", "top_k", "max_tokens", "tools", "tool_choice" }
+let CHAT_FIELDS : table<string> <- { "model", "messages", "stream", "temperature", "top_k", "max_tokens",
+                                     "max_completion_tokens", "tools", "tool_choice" }
 let COMPL_FIELDS : table<string> <- { "model", "prompt", "stream", "temperature", "top_k", "max_tokens" }
 let EMB_FIELDS : table<string> <- { "model", "input" }
 
@@ -409,6 +410,35 @@ def private warn_ignored_fields(js : JsonValue?; known : table<string>; route : 
             to_log(LOG_WARNING, "{route}: ignoring unsupported request field '{k}'\n")
         }
     }
+}
+
+// A message's text content: a plain string, or the OpenAI content-parts array (agents send
+// [\{type:"text", text:"..."}] even for pure text) — text parts concatenate; other part kinds
+// (image_url, ...) log and are skipped.
+def private message_text(mv : JsonValue?; route : string) : string {
+    let cv = mv?["content"]
+    if (cv == null || cv.value is _null) {
+        return ""
+    }
+    if (cv.value is _string) {
+        return cv ?? ""
+    }
+    if (cv.value is _array) {
+        var parts : array<string>
+        for (pv in (cv.value as _array)) {
+            let ptype = pv?["type"] ?? ""
+            if (ptype == "text") {
+                parts |> push(pv?["text"] ?? "")
+            } else {
+                to_log(LOG_WARNING, "{route}: skipping non-text content part '{ptype}'\n")
+            }
+        }
+        let s = join(parts, "")
+        delete parts
+        return s
+    }
+    to_log(LOG_WARNING, "{route}: message content is neither a string nor a parts array — parsed as empty\n")
+    return ""
 }
 
 // Unknown endpoint: log the probe (method, path, body head) and 404 with an OpenAI error body.
@@ -537,7 +567,11 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     var params = SamplingParams()
     params.temp = js?["temperature"] ?? 0.0
     params.top_k = js?["top_k"] ?? 0l
-    let max_new = clamp_max(js?["max_tokens"] ?? g_default_max_new)
+    var req_max = js?["max_tokens"] ?? 0l
+    if (req_max <= 0l) {
+        req_max = js?["max_completion_tokens"] ?? g_default_max_new   // the newer OpenAI spelling
+    }
+    let max_new = clamp_max(req_max)
 
     // tools: each tools[] entry re-serialized verbatim into the system turn's tool block.
     // tool_choice: "none" drops them; the object form (forced function) is not honored.
@@ -570,7 +604,7 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     var system = ""
     for (mv in (msgs_v.value as _array)) {
         if ((mv?["role"] ?? "") == "system") {
-            let sc = mv?["content"] ?? ""
+            let sc = message_text(mv, "/v1/chat/completions")
             system = empty(system) ? sc : "{system}\n{sc}"
         }
     }
@@ -591,11 +625,7 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     defer() { delete tool_results }
     for (mv in (msgs_v.value as _array)) {
         let role = mv?["role"] ?? ""
-        let cv = mv?["content"]
-        if (cv != null && !(cv.value is _string) && !(cv.value is _null)) {
-            to_log(LOG_WARNING, "/v1/chat/completions: non-string message content (multimodal parts?) parsed as empty\n")
-        }
-        let content = mv?["content"] ?? ""
+        let content = message_text(mv, "/v1/chat/completions")
         if (role != "tool" && !empty(tool_results)) {
             add_tool_results(chat, tool_results)   // flush the consecutive tool-result run
             tool_results |> clear()

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -45,8 +45,12 @@ struct private StreamWire {
     is_chat : bool                  // chat.completion.chunk vs text_completion framing
     id : string                     // "chatcmpl-N" / "cmpl-N"
     created : int64
-    reply_parts : array<string>     // non-streaming: pieces accumulate until the finished event
+    reply_parts : array<string>     // non-streaming (or has_tools): pieces accumulate until the finished event
     utf8_tail : string              // streaming: held-back bytes of a multi-byte char split across tokens
+    has_tools : bool                // chat request declared tools on a tool-capable template
+    hold : bool                     // streaming: tool-call opener seen — buffer instead of stream
+    call_open : string              // the family's tool-call markers (copied from the chat template)
+    call_close : string
 }
 
 var g_wires : table<int64; StreamWire>
@@ -78,9 +82,23 @@ def request_stop() {
 
 // ===== OpenAI wire shapes (response) =====
 
+// Function-calling shapes: `arguments` is JSON TEXT (the OpenAI wire carries it as a string).
+// Public (with parse_tool_calls) for the sibling test.
+struct OaiToolCallFn {
+    name : string
+    arguments : string
+}
+
+struct OaiToolCall {
+    id : string
+    @rename = "type" _type : string
+    @rename = "function" _function : OaiToolCallFn   // `function` is a das keyword
+}
+
 struct private OaiMessage {
     role : string
     content : string
+    @optional tool_calls : array<OaiToolCall>
 }
 
 struct private OaiChoice {
@@ -106,9 +124,17 @@ struct private OaiChatResponse {
 
 // Streaming (stream=true) chunk shapes. @optional so an empty delta emits `{}` and an absent
 // finish_reason is dropped (clients read absent as null) — matching OpenAI's chunk framing.
+struct private OaiStreamToolCall {
+    index : int
+    id : string
+    @rename = "type" _type : string
+    @rename = "function" _function : OaiToolCallFn
+}
+
 struct private OaiDelta {
     @optional role : string
     @optional content : string
+    @optional tool_calls : array<OaiStreamToolCall>
 }
 
 struct private OaiStreamChoice {
@@ -173,13 +199,6 @@ struct private OaiErrDetail {
 
 struct private OaiErr {
     error : OaiErrDetail
-}
-
-// request shape — text fields only. Multimodal content arrays and the request's `stop` field are NOT
-// read: content is parsed as a plain string, and stop sequences are not honored.
-struct private OaiReqMessage {
-    role : string
-    content : string
 }
 
 // /v1/audio/transcriptions response shapes.
@@ -276,9 +295,77 @@ def private utf8_hold_bytes(s : string) : int {
 def private send_chat_chunk(srv : WebSocketServer; var writer : HttpResponseWriter?;
                             id : string; created : int64; role, content, finish : string) {
     var chunk = OaiStreamChunk(id = id, _object = "chat.completion.chunk", created = created, model = g_model_name)
-    chunk.choices |> push(OaiStreamChoice(index = 0, delta = OaiDelta(role = role, content = content),
-                                          finish_reason = finish))
+    chunk.choices |> emplace(OaiStreamChoice(index = 0, delta <- OaiDelta(role = role, content = content),
+                                             finish_reason = finish))
     sse_event(srv, writer, sprint_json(chunk, false), "")
+    delete chunk
+}
+
+// The whole call set of a streaming reply as ONE tool_calls delta (index enumerates calls per the
+// OpenAI incremental framing); the caller follows with the finish_reason="tool_calls" chunk.
+def private send_chat_tool_calls_chunk(srv : WebSocketServer; var writer : HttpResponseWriter?;
+                                       id : string; created : int64; calls : array<OaiToolCall>) {
+    var chunk = OaiStreamChunk(id = id, _object = "chat.completion.chunk", created = created, model = g_model_name)
+    var delta = OaiDelta()
+    delta.tool_calls |> reserve(length(calls))
+    var idx = 0
+    for (c in calls) {
+        delta.tool_calls |> push(OaiStreamToolCall(index = idx, id = c.id, _type = c._type,
+                                                   _function = c._function))
+        idx ++
+    }
+    chunk.choices |> emplace(OaiStreamChoice(index = 0, delta <- delta))
+    sse_event(srv, writer, sprint_json(chunk, false), "")
+    delete chunk
+}
+
+//! Extract Hermes-style tool calls from a finished reply: every well-formed open…close span becomes
+//! one call; returns the content BEFORE the first opener (everything when nothing parses, so no
+//! reply text is silently dropped). Malformed spans log and end the scan.
+def parse_tool_calls(full : string; open_mark, close_mark, id_base : string;
+                     var calls : array<OaiToolCall>) : string {
+    var content_end = -1
+    var pos = 0
+    while (true) {
+        let o = find(full, open_mark, pos)
+        if (o < 0) {
+            break
+        }
+        if (content_end < 0) {
+            content_end = o
+        }
+        let bstart = o + length(open_mark)
+        let cl = find(full, close_mark, bstart)
+        if (cl < 0) {
+            to_log(LOG_WARNING, "dasllama-server: unterminated {open_mark} span (token budget cut?) — kept as content\n")
+            break
+        }
+        let body = strip(slice(full, bstart, cl))
+        var perr = ""
+        var cjs = read_json(body, perr)
+        if (cjs == null) {
+            to_log(LOG_WARNING, "dasllama-server: unparseable tool-call JSON ({perr}): {body}\n")
+        } else {
+            let cname = cjs?["name"] ?? ""
+            let av = cjs?["arguments"]
+            var args = "\{}"
+            if (av != null && av.value is _string) {   // non-spec but seen: arguments emitted as a string
+                let s = av ?? ""
+                args = empty(s) ? "\{}" : s
+            } elif (av != null && !(av.value is _null)) {
+                args = write_json_compact(av)   // the OpenAI wire carries arguments as compact JSON text
+            }
+            if (!empty(cname)) {
+                calls |> push(OaiToolCall(id = "{id_base}_{length(calls)}", _type = "function",
+                                          _function = OaiToolCallFn(name = cname, arguments = args)))
+            } else {
+                to_log(LOG_WARNING, "dasllama-server: tool call without a name — skipped: {body}\n")
+            }
+            unsafe { delete cjs }
+        }
+        pos = cl + length(close_mark)
+    }
+    return (content_end < 0 || empty(calls)) ? full : strip(slice(full, 0, content_end))
 }
 
 def private send_compl_chunk(srv : WebSocketServer; var writer : HttpResponseWriter?;
@@ -286,6 +373,7 @@ def private send_compl_chunk(srv : WebSocketServer; var writer : HttpResponseWri
     var chunk = OaiComplStreamChunk(id = id, _object = "text_completion", created = created, model = g_model_name)
     chunk.choices |> push(OaiComplStreamChoice(index = 0, text = text, finish_reason = finish))
     sse_event(srv, writer, sprint_json(chunk, false), "")
+    delete chunk
 }
 
 // Clamp a requested reply budget to [1, model context].
@@ -302,6 +390,37 @@ def private tmpdir() : string {
     var err = ""
     let d = temp_directory(err)   // fio: platform temp dir (Windows GetTempPath, POSIX $TMPDIR/tmp)
     return empty(d) ? "/tmp" : d
+}
+
+// ===== Unhandled-request visibility =====
+
+// Top-level fields each JSON route reads; anything else in a request logs a warning instead of
+// silently vanishing — the diagnostic for "agent X immediately fails against this server".
+let CHAT_FIELDS : table<string> <- { "model", "messages", "stream", "temperature", "top_k", "max_tokens", "tools", "tool_choice" }
+let COMPL_FIELDS : table<string> <- { "model", "prompt", "stream", "temperature", "top_k", "max_tokens" }
+let EMB_FIELDS : table<string> <- { "model", "input" }
+
+def private warn_ignored_fields(js : JsonValue?; known : table<string>; route : string) {
+    if (js == null || !(js.value is _object)) {
+        return
+    }
+    for (k in keys(js.value as _object)) {
+        if (!key_exists(known, k)) {
+            to_log(LOG_WARNING, "{route}: ignoring unsupported request field '{k}'\n")
+        }
+    }
+}
+
+// Unknown endpoint: log the probe (method, path, body head) and 404 with an OpenAI error body.
+def private handle_unknown(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let body = string(req.body)
+    let head = length(body) > 400 ? slice(body, 0, 400) : body
+    if (empty(head)) {
+        to_log(LOG_WARNING, "unhandled request: {req.method} {req.path}\n")
+    } else {
+        to_log(LOG_WARNING, "unhandled request: {req.method} {req.path} body: {head}\n")
+    }
+    return resp_error(resp, http_status.NOT_FOUND, "unknown endpoint: {req.path}")
 }
 
 // ===== Handlers =====
@@ -325,6 +444,7 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
         return resp_error(resp, http_status.BAD_REQUEST, "invalid JSON: {perr}")
     }
     defer() { unsafe { delete js } }
+    warn_ignored_fields(js, EMB_FIELDS, "/v1/embeddings")
     let iv = js?["input"]
     if (iv == null) {
         return resp_error(resp, http_status.BAD_REQUEST, "'input' is required (a string or array of strings)")
@@ -364,7 +484,8 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
 def private register_request(srv : WebSocketServer; var writer : HttpResponseWriter?;
                              var prompt, stop_ids, close_toks : array<int64>;
                              params : SamplingParams; max_new : int64;
-                             streaming, is_chat : bool; prefix : string) {
+                             streaming, is_chat : bool; prefix : string;
+                             tools_declared : bool = false; call_open : string = ""; call_close : string = "") {
     let np = int64(length(prompt))
     if (np + 1l > g_model.config.seq_len) {
         bad_request(srv, writer, "the rendered prompt is {np} tokens; the model context is {g_model.config.seq_len} — shorten the conversation or raise --ctx")
@@ -386,7 +507,9 @@ def private register_request(srv : WebSocketServer; var writer : HttpResponseWri
     }
     to_log(LOG_INFO, "[req {rid}] {prefix}: prompt={np} tok, stream={streaming}, max_new={max_new}\n")
     var wire <- StreamWire(writer = writer, streaming = streaming, is_chat = is_chat,
-                           id = cid, created = created)
+                           id = cid, created = created,
+                           has_tools = tools_declared && !empty(call_open),
+                           call_open = call_open, call_close = call_close)
     g_wires[rid] <- wire
     if (streaming && is_chat) {
         send_chat_chunk(srv, writer, cid, created, "assistant", "", "")   // opening role delta
@@ -404,42 +527,127 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
         return
     }
     defer() { unsafe { delete js } }
+    warn_ignored_fields(js, CHAT_FIELDS, "/v1/chat/completions")
     let msgs_v = js?["messages"]
     if (msgs_v == null || !(msgs_v.value is _array)) {
         bad_request(srv, writer, "'messages' must be an array")
         return
     }
-    let messages = from_JV(msgs_v, type<array<OaiReqMessage>>)
     let streaming = js?["stream"] ?? false
     var params = SamplingParams()
     params.temp = js?["temperature"] ?? 0.0
     params.top_k = js?["top_k"] ?? 0l
     let max_new = clamp_max(js?["max_tokens"] ?? g_default_max_new)
 
-    // OpenAI is stateless — the client resends the whole transcript. Fold system turns, replay prior
-    // user/assistant pairs through the renderer, then render the trailing user turn + generation prompt.
+    // tools: each tools[] entry re-serialized verbatim into the system turn's tool block.
+    // tool_choice: "none" drops them; the object form (forced function) is not honored.
+    var tools : array<string>
+    defer() { delete tools }
+    let tools_v = js?["tools"]
+    if (tools_v != null && tools_v.value is _array) {
+        tools |> reserve(length(tools_v.value as _array))
+        for (tv in (tools_v.value as _array)) {
+            tools |> push(write_json_compact(tv))   // the template's one-tool-per-line tojson shape
+        }
+    }
+    let tcv = js?["tool_choice"]
+    if (tcv != null && !(tcv.value is _null)) {   // ?[] yields the null SENTINEL for a missing key
+        if (tcv.value is _string) {
+            let choice = tcv ?? ""
+            if (choice == "none") {
+                tools |> clear()
+            } elif (choice != "auto" && choice != "required") {
+                to_log(LOG_WARNING, "/v1/chat/completions: unknown tool_choice '{choice}' — treating as auto\n")
+            }
+        } else {
+            to_log(LOG_WARNING, "/v1/chat/completions: forced tool_choice is not honored — treating as auto\n")
+        }
+    }
+
+    // OpenAI is stateless — the client resends the whole transcript. Fold system turns, replay
+    // prior user/assistant/tool turns through the renderer, then render the trailing turn + the
+    // generation prompt.
     var system = ""
-    for (msg in messages) {
-        if (msg.role == "system") {
-            system = empty(system) ? msg.content : "{system}\n{msg.content}"
+    for (mv in (msgs_v.value as _array)) {
+        if ((mv?["role"] ?? "") == "system") {
+            let sc = mv?["content"] ?? ""
+            system = empty(system) ? sc : "{system}\n{sc}"
         }
     }
     var chat <- create_chat_renderer(g_model, system, max_new)
     defer() { delete chat }
+    let has_tools = !empty(tools)
+    if (has_tools) {
+        if (empty(chat.tmpl.tool_call_open)) {
+            bad_request(srv, writer, "'tools' is not supported: the {g_model_name} chat template declares no tool-call format")
+            return
+        }
+        set_tools(chat, tools)   // moved in; `tools` is empty from here
+    }
     var prompt : array<int64>
     defer() { delete prompt }
-    var pending_user = false
-    for (msg in messages) {
-        if (msg.role == "user") {
-            add_user(chat, msg.content)
-            pending_user = true
-        } elif (msg.role == "assistant" && pending_user) {
-            render_assistant(g_model, chat, msg.content, prompt)
-            pending_user = false
+    var pending = false
+    var tool_results : array<string>
+    defer() { delete tool_results }
+    for (mv in (msgs_v.value as _array)) {
+        let role = mv?["role"] ?? ""
+        let cv = mv?["content"]
+        if (cv != null && !(cv.value is _string) && !(cv.value is _null)) {
+            to_log(LOG_WARNING, "/v1/chat/completions: non-string message content (multimodal parts?) parsed as empty\n")
+        }
+        let content = mv?["content"] ?? ""
+        if (role != "tool" && !empty(tool_results)) {
+            add_tool_results(chat, tool_results)   // flush the consecutive tool-result run
+            tool_results |> clear()
+            pending = true
+        }
+        if (role == "user") {
+            add_user(chat, content)
+            pending = true
+        } elif (role == "assistant") {
+            // rebuild any tool calls this turn made as the {"name","arguments"} objects the
+            // template renders (the wire carries arguments as JSON text — spliced verbatim)
+            var calls : array<string>
+            let tc = mv?["tool_calls"]
+            if (tc != null && tc.value is _array) {
+                calls |> reserve(length(tc.value as _array))
+                for (tcall in (tc.value as _array)) {
+                    let fv = tcall?["function"]
+                    let cname = fv?["name"] ?? ""
+                    let av = fv?["arguments"]
+                    var argstr = "\{}"
+                    if (av != null && av.value is _string) {
+                        let s = av ?? ""
+                        if (!empty(s)) {
+                            argstr = s
+                        }
+                    } elif (av != null && !(av.value is _null)) {
+                        argstr = write_json_compact(av)   // tolerated: arguments sent as an object
+                    }
+                    calls |> push("\{\"name\": \"{cname}\", \"arguments\": {argstr}}")
+                }
+            }
+            if (pending) {
+                if (!empty(calls)) {
+                    render_assistant_calls(g_model, chat, content, calls, prompt)
+                } else {
+                    render_assistant(g_model, chat, content, prompt)
+                }
+                pending = false
+            }
+            delete calls
+        } elif (role == "tool") {
+            tool_results |> push(content)
+        } elif (role != "system") {
+            to_log(LOG_WARNING, "/v1/chat/completions: dropping message with unsupported role '{role}'\n")
         }
     }
-    if (!pending_user) {
-        bad_request(srv, writer, "the last message must be from the user")
+    if (!empty(tool_results)) {
+        add_tool_results(chat, tool_results)   // trailing tool results: generation continues from them
+        pending = true
+    }
+    if (!pending) {
+        bad_request(srv, writer, "the last message must be a user or tool message")
         return
     }
     var turn <- render_turn(g_model, chat)
@@ -447,7 +655,8 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     delete turn
     var close <- render_close(g_model, chat)
     defer() { delete close }   // register_request moves it on success; the 400/503 paths leave it here
-    register_request(srv, writer, prompt, chat.stop_ids, close, params, max_new, streaming, true, "chatcmpl")
+    register_request(srv, writer, prompt, chat.stop_ids, close, params, max_new, streaming, true, "chatcmpl",
+                     has_tools, chat.tmpl.tool_call_open, chat.tmpl.tool_call_close)
 }
 
 def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var writer : HttpResponseWriter?) {
@@ -458,6 +667,7 @@ def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var
         return
     }
     defer() { unsafe { delete js } }
+    warn_ignored_fields(js, COMPL_FIELDS, "/v1/completions")
     let prompt = js?["prompt"] ?? ""
     if (empty(prompt)) {
         bad_request(srv, writer, "'prompt' must be a non-empty string")
@@ -498,12 +708,27 @@ def private flush_events(srv : WebSocketServer) {
             continue
         }
         if (e.kind == SchedEventKind.piece) {
-            if (!w.streaming) {
-                w.reply_parts |> push(e.text)
-            } else {
+            if (!w.streaming || w.has_tools) {
+                w.reply_parts |> push(e.text)   // buffered reply, and/or the finish-time tool-call parse
+            }
+            if (w.streaming && !w.hold) {
                 // re-join any held-back partial character, then hold the new incomplete tail
                 // so every delta on the wire is valid UTF-8 by itself
                 let whole = "{w.utf8_tail}{e.text}"
+                if (w.has_tools) {
+                    // the ChatML tool-call opener is one vocab token, so per-piece detection is
+                    // exact; from the opener on the reply is tool-call body — buffer, don't stream
+                    let o = find(whole, w.call_open)
+                    if (o >= 0) {
+                        w.hold = true
+                        w.utf8_tail = ""
+                        let head = slice(whole, 0, o)   // the opener starts on a char boundary (ascii)
+                        if (!empty(head)) {
+                            send_chat_chunk(srv, w.writer, w.id, w.created, "", head, "")
+                        }
+                        continue
+                    }
+                }
                 let hold = utf8_hold_bytes(whole)
                 let cut = length(whole) - hold
                 let emit_now = hold > 0 ? slice(whole, 0, cut) : whole
@@ -526,18 +751,44 @@ def private flush_events(srv : WebSocketServer) {
                 // complete, and emitting them would put invalid UTF-8 on the wire — drop loudly
                 to_log(LOG_WARNING, "dasllama-server: stream {w.id} ended mid-UTF-8-sequence; dropped {length(w.utf8_tail)} byte(s)\n")
             }
+            var finish = e.finish
+            if (w.hold) {
+                // the buffered tail is tool-call body: parse it into a tool_calls delta (the
+                // pre-opener content already streamed); nothing parseable => release it as text
+                let full = join(w.reply_parts, "")
+                var calls : array<OaiToolCall>
+                parse_tool_calls(full, w.call_open, w.call_close, "call_{e.stream}", calls)
+                if (!empty(calls)) {
+                    send_chat_tool_calls_chunk(srv, w.writer, w.id, w.created, calls)
+                    finish = "tool_calls"
+                } else {
+                    send_chat_chunk(srv, w.writer, w.id, w.created, "", slice(full, find(full, w.call_open)), "")
+                }
+                delete calls
+            }
             if (w.is_chat) {
-                send_chat_chunk(srv, w.writer, w.id, w.created, "", "", e.finish)
+                send_chat_chunk(srv, w.writer, w.id, w.created, "", "", finish)
             } else {
-                send_compl_chunk(srv, w.writer, w.id, w.created, "", e.finish)
+                send_compl_chunk(srv, w.writer, w.id, w.created, "", finish)
             }
             sse_event(srv, w.writer, "[DONE]", "")
             close_writer(srv, w.writer)
         } elif (w.is_chat) {
+            let full = join(w.reply_parts, "")
+            var content = full
+            var finish = e.finish
+            var calls : array<OaiToolCall>
+            if (w.has_tools && find(full, w.call_open) >= 0) {
+                content = parse_tool_calls(full, w.call_open, w.call_close, "call_{e.stream}", calls)
+                if (!empty(calls)) {
+                    finish = "tool_calls"
+                }
+            }
             var out = OaiChatResponse(id = w.id, _object = "chat.completion", created = w.created, model = g_model_name)
-            out.choices |> push(OaiChoice(index = 0,
-                                          message = OaiMessage(role = "assistant", content = join(w.reply_parts, "")),
-                                          finish_reason = e.finish))
+            out.choices |> emplace(OaiChoice(index = 0,
+                                             message <- OaiMessage(role = "assistant", content = content,
+                                                                   tool_calls <- calls),
+                                             finish_reason = finish))
             out.usage = OaiUsage(prompt_tokens = e.n_prompt, completion_tokens = e.n_gen,
                                  total_tokens = e.n_prompt + e.n_gen)
             respond(srv, w.writer, int(http_status.OK), "application/json", sprint_json(out, false))
@@ -666,6 +917,9 @@ class OpenAiServer : HvWebServer {
         POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             g_should_stop = true
             return resp |> JSON("\{\"ok\":true}", http_status.OK)
+        }
+        ANY("*") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_unknown(req, resp)
         }
     }
 }

--- a/utils/dasllama-server/test_openai_server.das
+++ b/utils/dasllama-server/test_openai_server.das
@@ -180,6 +180,79 @@ def test_openai_server(t : T?) {
                     }
                 }
             }
+            // tools on a template with no tool format (TinyLlama resolves Zephyr) — honest 400
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":\"hi\"}],\"tools\":[\{\"type\":\"function\",\"function\":\{\"name\":\"f\"}}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+            }
+            // unknown endpoint hits the ANY("*") catch-all: logged server-side, OpenAI-shaped 404 back
+            POST("{base_url}/v1/responses", "\{\"input\":\"hi\"}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.NOT_FOUND))
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null && js?["error"] != null, "404 body is an OpenAI error object")
+                if (js != null) {
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
         }
+    }
+}
+
+// ===== parse_tool_calls (model-free) =====
+
+[test]
+def test_parse_tool_calls(t : T?) {
+    t |> run("single call: content prefix, name, compact arguments, id/type") @(t : T?) {
+        var calls : array<OaiToolCall>
+        let pre = parse_tool_calls("Let me check.\n<tool_call>\n\{\"name\": \"get_weather\", \"arguments\": \{\"city\": \"Paris\"}}\n</tool_call>",
+                                   "<tool_call>", "</tool_call>", "call_7", calls)
+        t |> equal(pre, "Let me check.")
+        t |> equal(length(calls), 1)
+        if (length(calls) == 1) {
+            t |> equal(calls[0]._function.name, "get_weather")
+            t |> equal(calls[0]._function.arguments, "\{\"city\": \"Paris\"}")
+            t |> equal(calls[0].id, "call_7_0")
+            t |> equal(calls[0]._type, "function")
+        }
+        delete calls
+    }
+    t |> run("two calls parse in order; empty content strips clean") @(t : T?) {
+        var calls : array<OaiToolCall>
+        let pre = parse_tool_calls("<tool_call>\n\{\"name\": \"a\", \"arguments\": \{}}\n</tool_call>\n<tool_call>\n\{\"name\": \"b\", \"arguments\": \{\"n\": 1}}\n</tool_call>",
+                                   "<tool_call>", "</tool_call>", "call_1", calls)
+        t |> equal(pre, "")
+        t |> equal(length(calls), 2)
+        if (length(calls) == 2) {
+            t |> equal(calls[0]._function.name, "a")
+            t |> equal(calls[0]._function.arguments, "\{}")
+            t |> equal(calls[1]._function.name, "b")
+            t |> equal(calls[1].id, "call_1_1")
+        }
+        delete calls
+    }
+    t |> run("malformed spans keep the reply as content") @(t : T?) {
+        var calls : array<OaiToolCall>
+        // unterminated span (token budget cut): no calls, full text back
+        let full1 = "text <tool_call>\n\{\"name\": \"a\""
+        t |> equal(parse_tool_calls(full1, "<tool_call>", "</tool_call>", "c", calls), full1)
+        t |> equal(length(calls), 0)
+        // unparseable JSON inside a well-formed span: no calls, full text back
+        let full2 = "<tool_call>\nnot json\n</tool_call>"
+        t |> equal(parse_tool_calls(full2, "<tool_call>", "</tool_call>", "c", calls), full2)
+        t |> equal(length(calls), 0)
+        delete calls
+    }
+    t |> run("arguments emitted as a JSON string pass through verbatim") @(t : T?) {
+        var calls : array<OaiToolCall>
+        parse_tool_calls("<tool_call>\n\{\"name\": \"a\", \"arguments\": \"\{\\\"x\\\": 1}\"}\n</tool_call>",
+                         "<tool_call>", "</tool_call>", "c", calls)
+        t |> equal(length(calls), 1)
+        if (length(calls) == 1) {
+            t |> equal(calls[0]._function.arguments, "\{\"x\": 1}")
+        }
+        delete calls
     }
 }

--- a/utils/dasllama-server/test_openai_server.das
+++ b/utils/dasllama-server/test_openai_server.das
@@ -180,6 +180,21 @@ def test_openai_server(t : T?) {
                     }
                 }
             }
+            // content-parts array form (what pi/opencode send even for pure text): the text
+            // must reach the prompt — an empty-parse would render a near-empty user turn
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":[\{\"type\":\"text\",\"text\":\"Please repeat the word strawberry twenty times, then count the letters in it, then explain why.\"}]}],\"max_tokens\":4}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null, "parts-form chat JSON parses")
+                if (js != null) {
+                    t |> success(int(js?["usage"]?["prompt_tokens"] ?? 0l) > 40, "parts text reached the prompt")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
             // tools on a template with no tool format (TinyLlama resolves Zephyr) — honest 400
             POST("{base_url}/v1/chat/completions",
                  "\{\"messages\":[\{\"role\":\"user\",\"content\":\"hi\"}],\"tools\":[\{\"type\":\"function\",\"function\":\{\"name\":\"f\"}}]}") $(resp) {


### PR DESCRIPTION
Adds OpenAI function calling to `dasllama-server` and makes every request the server does not fully understand visible in the log. Live-verified end-to-end with the `pi` coding agent driving Qwen3-30B-A3B-Instruct-2507 (multi-round tool loops: read → write → answer).

## Facade (`dasLLAMA` chat layer)

- `ChatTemplate` grows a per-family tool format; `hermes_tools()` installs the Qwen2.5/Qwen3 shape (tool JSONs in a `<tools>` system block, calls as `<tool_call>{"name":…,"arguments":…}</tool_call>`, results as `<tool_response>` blocks riding user turns) on `qwen2`/`qwen3`/`qwen3moe`.
- New verbs: `set_tools` (render tool definitions into the system turn), `add_tool_results` (queue tool results as the pending turn), `render_assistant_calls` (replay an assistant tool-call turn on stateless resend).
- **Marker splitting:** our `encode()` does not match added tokens inline (probe-verified), so tool spans are split into `ChatPart` lists and vocab markers resolve to their single ids — exactly HF added-token tokenization, including the marker mentions inside the format-instructions prose. Markers absent from a vocab stay text (Qwen2.5 has `<tool_call>` but not `<tool_response>`; Qwen3 has both).

## Server (`utils/dasllama-server`)

- Parses `tools` / `tool_choice` / assistant `tool_calls` / `role:"tool"` messages; renders through the facade verbs; answers with `message.tool_calls` / `delta.tool_calls` and `finish_reason:"tool_calls"`. A model whose template declares no tool format gets an honest 400.
- Streaming: content streams until the tool-call opener (one vocab token on ChatML), then the body buffers and the parsed calls emit as one `delta.tool_calls` chunk at finish. While buffering, an empty `delta:{}` keepalive goes out every 16 tokens — without it, a long `write`-tool body (minutes of decode, zero bytes on the wire) trips client idle timeouts (pi: "terminated" + retry loop; found live).
- Message content accepts the OpenAI content-parts array form (`[{type:"text",…}]`) — pi sends it even for pure text; the old string-only parse rendered the user turn empty. Also honors `max_completion_tokens`.
- **Unhandled-request visibility:** unknown endpoints 404 through an `ANY("*")` catch-all logging method + path + body head; known routes warn per ignored request field. Both pi findings above were diagnosed from these logs on the first failing request.

## daslib

- `json.das`: `write_json_compact` — one-line `JsonValue` serialization with the python `json.dumps` / jinja `tojson` separators chat templates carry (the existing `write_json` pretty-prints with tabs). `write_value_compact` deliberately mirrors `write_value` as a sibling walker.

## Tests

- `tests/dasLLAMA/test_chat.das`: token-for-token Hermes render pins against Qwen2.5-0.5B (system tool block incl. prose-marker ids, tool-call replay, tool-results turn).
- `utils/dasllama-server/test_openai_server.das`: model-free `parse_tool_calls` unit tests; parts-form content pinned via `usage.prompt_tokens`; tools-unsupported 400; catch-all 404.
- All four dasLLAMA/server suites green locally (47 tests, JIT), Sphinx latex+html clean, lint 0 issues on the changed set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)