### PR TITLE
CMRES elision vs heap-mode array literal: decline the alias on collision

### DIFF
--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -127,6 +127,12 @@ namespace das {
         VariablePtr             cmresVAR = nullptr;
         bool                    failedToCMRES = false;
         bool                    isEverything = false;
+        // SimNode_MakeArrayHeap repoints abiCMRES at the heap block while constructing
+        // elements, so a CMRES-aliased local read inside a heap-mode literal would resolve
+        // into the (zeroed) heap buffer instead of the return slot. Track such reads and
+        // decline the elision for that variable — an extra move at return, always correct.
+        das_hash_set<Variable *> usedInHeapLiteral;
+        int                     heapLiteralDepth = 0;
     protected:
 
         virtual bool canVisitStructureFieldInit ( Structure * ) override { return false; }
@@ -140,12 +146,30 @@ namespace das {
             func = f;
         }
         virtual FunctionPtr visit ( Function * that ) override {
-            if ( cmresVAR && !failedToCMRES ) cmresVAR->aliasCMRES = true;
+            if ( cmresVAR && !failedToCMRES
+                && usedInHeapLiteral.find(cmresVAR) == usedInHeapLiteral.end() ) cmresVAR->aliasCMRES = true;
             func = nullptr;
             cmresVAR = nullptr;
             failedToCMRES = false;
+            usedInHeapLiteral.clear();
             DAS_ASSERT(blocks.size()==0);
+            DAS_ASSERT(heapLiteralDepth==0);
             return Visitor::visit(that);
+        }
+    // heap-mode array literal (gen2 [..] feeding to_array_move/to_table_move)
+        virtual void preVisit ( ExprMakeArray * expr ) override {
+            Visitor::preVisit(expr);
+            if ( expr->makeArrayOnHeap ) heapLiteralDepth ++;
+        }
+        virtual ExpressionPtr visit ( ExprMakeArray * expr ) override {
+            if ( expr->makeArrayOnHeap ) heapLiteralDepth --;
+            return Visitor::visit(expr);
+        }
+        virtual void preVisit ( ExprVar * expr ) override {
+            Visitor::preVisit(expr);
+            if ( heapLiteralDepth && expr->local && expr->variable ) {
+                usedInHeapLiteral.insert(expr->variable);
+            }
         }
     // ExprBlock
         virtual void preVisit ( ExprBlock * block ) override {

--- a/tests/language/cmres_heap_literal.das
+++ b/tests/language/cmres_heap_literal.das
@@ -1,0 +1,80 @@
+options gen2
+options indenting = 4
+
+// A local that aliases the return CMRES (`var r` + `return <- r` copy elision) read as a
+// call argument inside a HEAP-mode array literal: SimNode_MakeArrayHeap repoints abiCMRES
+// at the heap block while constructing elements, so without the VarCMRes fence those reads
+// resolved into the zeroed heap buffer instead of r (all args read 0). Auto-inline
+// manufactures this shape when a by-ref callee splices into a CMRES-elided local.
+
+require dastest/testing_boost public
+
+struct Rec {
+    s : uint64
+    bind : uint
+    items : array<int>
+}
+
+struct MiniRes {
+    set0 : uint64
+    set1 : uint64
+}
+
+def private mk(h : uint64; b : uint) : Rec {
+    var w = Rec(s = h, bind = b)
+    w.items |> push(int(b))
+    return <- w
+}
+
+def private consume(r : MiniRes) : uint64 {
+    // any gen2 [..] literal lowers to to_array_move(make-array) and is flagged heap-mode
+    // unconditionally (element count is irrelevant; probe-verified with a 3-element literal)
+    var writes <- [
+        mk(r.set0, 0u), mk(r.set0, 1u), mk(r.set0, 2u), mk(r.set0, 3u), mk(r.set0, 4u),
+        mk(r.set0, 5u), mk(r.set0, 6u), mk(r.set0, 7u), mk(r.set0, 8u),
+        mk(r.set1, 9u), mk(r.set1, 10u), mk(r.set1, 11u), mk(r.set1, 12u), mk(r.set1, 13u),
+        mk(r.set1, 14u), mk(r.set1, 15u), mk(r.set1, 16u), mk(r.set1, 17u), mk(r.set1, 18u)]
+    var sum = 0ul
+    for (w in writes) {
+        sum += w.s
+    }
+    return sum
+}
+
+def build_direct : MiniRes {
+    // the literal lives in THIS function, next to the elided return local
+    var r = MiniRes(set0 = 0x1111ul, set1 = 0x2222ul)
+    var writes <- [
+        mk(r.set0, 0u), mk(r.set0, 1u), mk(r.set0, 2u), mk(r.set0, 3u), mk(r.set0, 4u),
+        mk(r.set0, 5u), mk(r.set0, 6u), mk(r.set0, 7u), mk(r.set0, 8u),
+        mk(r.set1, 9u), mk(r.set1, 10u), mk(r.set1, 11u), mk(r.set1, 12u), mk(r.set1, 13u),
+        mk(r.set1, 14u), mk(r.set1, 15u), mk(r.set1, 16u), mk(r.set1, 17u), mk(r.set1, 18u)]
+    var sum = 0ul
+    for (w in writes) {
+        sum += w.s
+    }
+    r.set0 = sum        // 9*0x1111 + 10*0x2222 = 0x9999 + 0x15554 = 0x1EEED
+    return <- r
+}
+
+def build_via_callee : MiniRes {
+    // the literal arrives via a by-ref callee — the shape auto-inline splices into
+    // the CMRES-elided local (works with the heuristic tier on OR off)
+    var r = MiniRes(set0 = 0x1111ul, set1 = 0x2222ul)
+    r.set0 = consume(r)
+    return <- r
+}
+
+[test]
+def test_cmres_heap_literal_direct(t : T?) {
+    let r <- build_direct()
+    t |> equal(r.set0, 0x1EEEDul)
+    t |> equal(r.set1, 0x2222ul)
+}
+
+[test]
+def test_cmres_heap_literal_via_callee(t : T?) {
+    let r <- build_via_callee()
+    t |> equal(r.set0, 0x1EEEDul)
+    t |> equal(r.set1, 0x2222ul)
+}


### PR DESCRIPTION
## The bug

`SimNode_MakeArrayHeap` (the gen2 `[..]`-feeding-`to_array_move` heap-literal optimization) repoints `context.abiCMRES` at the heap block while its element children construct in place. Any **other** CMRES-relative access inside those children breaks — specifically, reads of a return-elided local (`var r` + `return <- r`, `aliasCMRES`) lower to `GetCMResOfsR2V` and resolve into the freshly-zeroed heap buffer instead of `r`. Element call arguments silently read zeros; `r` itself is untouched, so nothing panics.

Latent since `makeArrayOnHeap` landed. #3441 (auto-inline) merely **manufactures** the colliding shape — a spliced by-ref callee's `var r` parameter becomes the caller's elided return local — which is how `dasVulkan`'s deferred tutorial regressed on CI (all 19 `VkWriteDescriptorSet.dstSet` handles zeroed → `vkUpdateDescriptorSets` → lavapipe SIGSEGV at null+0x40). The inline pass's own `to_array_move` corruption hazard note was very likely this same bug observed from another angle. A 55-line pure-das no-inline repro confirms the pass is innocent.

## The fix

`VarCMRes` (ast_allocate_stack.cpp) now tracks locals referenced inside `makeArrayOnHeap` literals and declines the elision for them. Cost: one extra move at return in exactly the colliding shape; correct in interp/JIT/AOT alike since all tiers consume the same `aliasCMRES` decision.

Follow-up worth considering (not in this PR): give heap-literal element construction its own base register instead of borrowing `abiCMRES`, so the elision survives the shape; same review should look at the `MakeLocalCMRes`/make-struct in-place paths for sibling borrows.

## Verification

| Gate | Result |
|---|---|
| new `tests/language/cmres_heap_literal.das` (direct + by-ref-callee shapes) | FAILS on pre-fix binary, 2/2 PASS post-fix, interp and `-jit` |
| tests/language full | 1436/1436 (also `--ser` round-trip) |
| decs / strudel / interfaces / lint fixtures | all pass |
| `test_aot_subset` | builds clean (new test AOT-compiles) |
| **end-to-end cure**: dasVulkan `test_deferred` (real pixel-oracle, lavapipe, WSL CI-mirror) with this fix applied at the original bad commit `bae98f7b1` | **PASSES** (was SIGSEGV twice + on two CI control runs) |
| changed-set lint / format | 0 issues / clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)