### PR TITLE
dasLLAMA: Qwen3.5-122B — native split-GGUF loading + grouped-prefill shexp fix + >2^31 wscale

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1231,7 +1231,7 @@ def private wscale_convert_f16(var t : Model) {
     if (n == 0l) {   // every big weight lives in a native plane (kq/mx4) — nothing to convert
         return
     }
-    t.qscales16 |> resize(int(n))
+    t.qscales16 |> resize(n)   // int64 resize — an 80B-weight Q8 model has >2^31 scales
     unsafe {
         var dp = addr(t.qscales16[0])
         let sp = addr<float const?>(t.qscales[0])
@@ -1530,13 +1530,40 @@ def private load_gguf_impl(path : string; mode : QuantMode) : Model {
     var t = Model()
     t.quant = mode
     let ts_load = ref_time_ticks()
-    var ts_stage = ref_time_ticks()
+    let shards <- gguf_shard_paths(path)
+    if (length(shards) > 1) {
+        to_log(LOG_INFO, "dasLLAMA: split gguf — {length(shards)} shards\n")
+        var bases : array<void?>
+        var sizes : array<int64>
+        gguf_map_shards(shards, 0, bases, sizes) {
+            var m <- parse_gguf_meta_shards(bases, sizes)
+            unsafe {
+                load_gguf_parsed(t, m, temp_array(reinterpret<uint8?>(bases[0]), sizes[0], type<uint8>), mode, ts_load)
+            }
+            delete m
+        }
+        bases |> clear()   // borrowed mapping bases — clear so delete frees only the buffer
+        delete bases
+        delete sizes
+        return <- t
+    }
     let f = fopen(path, "rb")
     if (f == null) {
         panic("dasLLAMA: cannot open gguf '{path}'")
     }
     fmap(f) $(var bytes : array<uint8>#) {
         let m <- parse_gguf_meta(bytes)
+        load_gguf_parsed(t, m, bytes, mode, ts_load)
+    }
+    fclose(f)
+    return <- t
+}
+
+// The load once metadata is parsed and the byte view carrying the KVs (shard 0 for splits) is
+// mapped — config, vocab, plane sizing, tensor reads/transcodes, repack, wscale.
+def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> | #; mode : QuantMode; ts_load : int64) {
+    var ts_stage = ref_time_ticks()
+    {
         let arch = gguf_str(m, bytes, "general.architecture")
         resolve_arch(t, arch)   // registry lookup: apply config flags + bind the arch's block kernels
         if (gguf_has(m, "tokenizer.chat_template")) {
@@ -2227,8 +2254,6 @@ def private load_gguf_impl(path : string; mode : QuantMode) : Model {
         }
         to_log(LOG_INFO, "dasLLAMA: load stage wscale: {get_time_usec(ts_stage) / 1000} ms, total {get_time_usec(ts_load) / 1000} ms\n")
     }
-    fclose(f)
-    return <- t
 }
 
 //! Quantize a fp32-loaded model's big weights to Q8_0 in place and switch forward onto the Q8 path.
@@ -8273,6 +8298,11 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         s.kxsb |> resize(npos * dim / 256l)
         s.kxbsb |> resize(npos * dim / 16l)
         requant_rows_q8k_bs(s.xb_b, dim, npos, s.kxqb, s.kxsb, s.kxbsb)
+        if (nsh > 0l && !c.moe_dense_shexp) {
+            // the q8 shexp batch (step 4) reads the Q8_0 image — without this it consumes whatever
+            // the last quantize left there and the shared expert silently corrupts (#3450's prefill twin)
+            requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
+        }
     } else {
         requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -4,6 +4,9 @@ module dasllama_gguf shared public
 
 require daslib/array_boost // nolint:STYLE030 — temp_array is [template]; STYLE030 misses template-fn refs
 require strings
+require daslib/fio                  // shard-path expansion + mapping (split GGUF)
+require daslib/strings_boost        // trim_suffix / pad_left (split shard names)
+require daslib/strings_convert     // try_to_int (validating shard-index parse)
 require llvm/daslib/f16_cvt public  // f16_to_f32 / f32_to_f16 (re-export: whisper/vad/parakeet/audio callers)
 require dasllama/dasllama_par       // maybe_parallel_for — the transcode hot loops thread when a jobque is up
 require dasllama/dasllama_math      // count_inline_run / count_parallel_dispatch_thru (the par macro's emitted counters)
@@ -108,19 +111,25 @@ struct GGUFKVLoc {
 struct GGUFTensorInfo {
     name : string
     ggml_type : int
-    offset : int64   // relative to the tensor data blob start
+    offset : int64   // relative to the tensor data blob start (of the shard holding it)
     n_elem : int64
     dims : array<int64>
+    shard : int      // which shard's data blob holds this tensor (0 for single-file models)
 }
 
 //! Parsed GGUF metadata: version, alignment, the KV table, the tensor list, and the
-//! absolute byte offset where tensor data begins.
+//! absolute byte offset where tensor data begins. For multi-part (split) models the
+//! shard_* arrays hold one entry per mapped shard (see parse_gguf_meta_shards); empty
+//! for a plain single-file parse — tensor reads then resolve within the caller's bytes.
 struct GGUFMeta {
     version : uint
     alignment : int64
     data_offset : int64
     kv : table<string; GGUFKVLoc>
     tensors : array<GGUFTensorInfo>
+    @do_not_delete shard_base : array<void?>   // borrowed mapped base per shard (owned by gguf_map_shards)
+    shard_size : array<int64>
+    shard_data_off : array<int64>              // per-shard data-blob offset (each shard pads independently)
 }
 
 def private gguf_scalar_size(gtype : int) : int64 {
@@ -217,6 +226,124 @@ def parse_gguf_meta(bytes : array<uint8> | #) : GGUFMeta {
     m.data_offset = off
     if (n_tensors > 0l) {
         m.data_offset = ((off + m.alignment - 1l) / m.alignment) * m.alignment
+    }
+    return <- m
+}
+
+// ===== multi-part (split) GGUF support =====
+
+// Invoke blk with the byte view holding tensor ti plus the tensor's data base offset within that
+// view. Single-file metas resolve within the caller's bytes; sharded metas resolve the tensor's
+// own mapped shard. The one choke point every tensor-data reader goes through.
+def private with_tensor_view(m : GGUFMeta; srcbytes : array<uint8> | #; ti : int; blk : block<(bytes : array<uint8>; tbase : int64) : void>) {
+    if (empty(m.shard_base)) {
+        unsafe {
+            invoke(blk, temp_array(addr<uint8?>(srcbytes[0]), long_length(srcbytes), type<uint8>),
+                m.data_offset + m.tensors[ti].offset)
+        }
+        return
+    }
+    let sh = m.tensors[ti].shard
+    unsafe {
+        invoke(blk, temp_array(reinterpret<uint8?>(m.shard_base[sh]), m.shard_size[sh], type<uint8>),
+            m.shard_data_off[sh] + m.tensors[ti].offset)
+    }
+}
+
+//! Expand a model path into its shard list. A llama.cpp split file name
+//! ("<prefix>-00001-of-00003.gguf") yields every sibling shard (normalized from any shard index,
+//! so pointing at shard 2 works); anything else yields just [path]. A missing sibling panics
+//! (the loader must not run on a partial split), or yields [] with `missing_ok` (presence gates).
+def gguf_shard_paths(path : string; missing_ok : bool = false) : array<string> {
+    var res : array<string>
+    let name = base_name(path)
+    let stem_part = trim_suffix(name, ".gguf")
+    let sl = length(stem_part)
+    // tail shape: "-NNNNN-of-NNNNN" = 15 chars, with at least 1 prefix char before it
+    if (name == stem_part || sl < 16) {
+        res |> push(path)
+        return <- res
+    }
+    let tail = slice(stem_part, sl - 15)
+    if (slice(tail, 0, 1) != "-" || slice(tail, 6, 10) != "-of-") {
+        res |> push(path)
+        return <- res
+    }
+    let ridx = try_to_int(slice(tail, 1, 6))
+    let rcnt = try_to_int(slice(tail, 10, 15))
+    if (!ridx._is_ok || !rcnt._is_ok) {
+        res |> push(path)
+        return <- res
+    }
+    let cnt = rcnt._value
+    if (ridx._value < 1 || cnt < 1 || ridx._value > cnt) {
+        res |> push(path)
+        return <- res
+    }
+    let prefix = slice(stem_part, 0, sl - 15)
+    let dir = dir_name(path)
+    let cnt5 = pad_left("{cnt}", 5, '0')
+    res |> reserve(cnt)
+    for (i in range(1, cnt + 1)) {
+        let i5 = pad_left("{i}", 5, '0')
+        let shard = path_join(dir, "{prefix}-{i5}-of-{cnt5}.gguf")
+        if (!fexist(shard)) {
+            if (missing_ok) {
+                res |> clear()
+                return <- res
+            }
+            panic("gguf: split model '{name}' is missing shard '{shard}'")
+        }
+        res |> push(shard)
+    }
+    return <- res
+}
+
+//! Map every shard and invoke blk once with ALL mappings alive (bases/sizes gain one entry per
+//! shard, in order). The mappings die when blk returns — nothing derived from them may escape.
+def gguf_map_shards(paths : array<string>; idx : int; var bases : array<void?>; var sizes : array<int64>; blk : block<() : void>) {
+    if (idx >= length(paths)) {
+        invoke(blk)
+        return
+    }
+    fopen(paths[idx], "rb") $(f) {
+        if (f == null) {
+            panic("gguf: cannot open shard '{paths[idx]}'")
+        }
+        fmap(f) $(var bytes : array<uint8>#) {
+            unsafe {
+                bases |> push(addr<void?>(bytes[0]))
+            }
+            sizes |> push(long_length(bytes))
+            gguf_map_shards(paths, idx + 1, bases, sizes, blk)
+        }
+    }
+}
+
+//! Parse a mapped shard set into one unified meta: shard 0 carries the model KVs (config, vocab,
+//! chat template — llama.cpp split convention), tensor directories merge across all shards with
+//! each tensor stamped with its shard. Tensor reads then resolve through the shard_* arrays.
+def parse_gguf_meta_shards(bases : array<void?>; sizes : array<int64>) : GGUFMeta {
+    var m : GGUFMeta
+    unsafe {
+        m <- parse_gguf_meta(temp_array(reinterpret<uint8?>(bases[0]), sizes[0], type<uint8>))
+    }
+    m.shard_base := bases
+    m.shard_size := sizes
+    m.shard_data_off |> reserve(length(bases))
+    m.shard_data_off |> push(m.data_offset)
+    for (k in range(1, length(bases))) {
+        var mk : GGUFMeta
+        unsafe {
+            mk <- parse_gguf_meta(temp_array(reinterpret<uint8?>(bases[k]), sizes[k], type<uint8>))
+        }
+        m.shard_data_off |> push(mk.data_offset)
+        m.tensors |> reserve(length(m.tensors) + length(mk.tensors))
+        for (i in range(length(mk.tensors))) {
+            mk.tensors[i].shard = k
+            m.tensors |> emplace(mk.tensors[i])
+        }
+        delete mk
     }
     return <- m
 }
@@ -793,8 +920,8 @@ def private guard_dst(name : string; what : string; off, need, have : int64) {
 }
 
 // Shared header for the three file-level transcodes: locate + type-check + bounds-check, return
-// the superblock-aligned disk cursor.
-def private kq_transcode_base(m : GGUFMeta; name : string; want_type : int; type_name : string; src_off, expect_n, disk_sb : int64) : int64 {
+// the tensor index (the caller resolves its view/base through with_tensor_view).
+def private kq_transcode_check(m : GGUFMeta; name : string; want_type : int; type_name : string; src_off, expect_n : int64) : int {
     let ti = gguf_find_tensor(m, name)
     if (ti < 0) {
         panic("gguf: tensor '{name}' not found")
@@ -808,30 +935,33 @@ def private kq_transcode_base(m : GGUFMeta; name : string; want_type : int; type
     if (src_off + expect_n > m.tensors[ti].n_elem) {
         panic("gguf: tensor '{name}' slice [{src_off}, {src_off + expect_n}) exceeds {m.tensors[ti].n_elem} elems")
     }
-    return m.data_offset + m.tensors[ti].offset + (src_off / 256l) * disk_sb
+    return ti
 }
 
 //! Transcode a Q4_K tensor into the k4 planes at plane-local element offset `eloff` (from the
 //! layout's k4 cursor): quant bytes at (eloff/256)*128, scale blocks at (eloff/256)*20.
-def gguf_transcode_q4k(m : GGUFMeta; bytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
-    let bo = kq_transcode_base(m, name, GGML_TYPE_Q4_K, "Q4_K", src_off, expect_n, 144l)
+def gguf_transcode_q4k(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    let ti = kq_transcode_check(m, name, GGML_TYPE_Q4_K, "Q4_K", src_off, expect_n)
     let nb = expect_n / 256l
     if (nb <= 0l) {
         return
     }
     guard_dst(name, "k4 quant plane", (eloff / 256l) * K4_QSB, nb * K4_QSB, long_length(kq))
     guard_dst(name, "k4 scale plane", (eloff / 256l) * K4_SSB, nb * K4_SSB, long_length(ks))
-    unsafe {   // per-superblock byte shuffle (see transcode_q4k_superblock), threaded + pointerized
-        let srcp = addr<uint8 const?>(bytes[bo])
-        var kqp = addr(kq[(eloff / 256l) * K4_QSB])
-        var ksp = addr(ks[(eloff / 256l) * K4_SSB])
-        maybe_parallel_for(0, int(nb), transcode_jobs(nb, 144l)) $(rb, re) {
-            unsafe {
-                for (blk in range64(int64(rb), int64(re))) {
-                    bcopy(ksp + blk * K4_SSB, srcp + blk * 144l, 16l)
-                    var pad = reinterpret<uint?>(ksp + blk * K4_SSB + 16l)
-                    pad[0] = 0u
-                    bcopy(kqp + blk * K4_QSB, srcp + blk * 144l + 16l, 128l)
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        let bo = tbase + (src_off / 256l) * 144l
+        unsafe {   // per-superblock byte shuffle (see transcode_q4k_superblock), threaded + pointerized
+            let srcp = addr<uint8 const?>(bytes[bo])
+            var kqp = addr(kq[(eloff / 256l) * K4_QSB])
+            var ksp = addr(ks[(eloff / 256l) * K4_SSB])
+            maybe_parallel_for(0, int(nb), transcode_jobs(nb, 144l)) $(rb, re) {
+                unsafe {
+                    for (blk in range64(int64(rb), int64(re))) {
+                        bcopy(ksp + blk * K4_SSB, srcp + blk * 144l, 16l)
+                        var pad = reinterpret<uint?>(ksp + blk * K4_SSB + 16l)
+                        pad[0] = 0u
+                        bcopy(kqp + blk * K4_QSB, srcp + blk * 144l + 16l, 128l)
+                    }
                 }
             }
         }
@@ -839,26 +969,29 @@ def gguf_transcode_q4k(m : GGUFMeta; bytes : array<uint8> | #; name : string; va
 }
 
 //! Transcode a Q5_K tensor into the k5 planes (see gguf_transcode_q4k; strides 160/20).
-def gguf_transcode_q5k(m : GGUFMeta; bytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
-    let bo = kq_transcode_base(m, name, GGML_TYPE_Q5_K, "Q5_K", src_off, expect_n, 176l)
+def gguf_transcode_q5k(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    let ti = kq_transcode_check(m, name, GGML_TYPE_Q5_K, "Q5_K", src_off, expect_n)
     let nb = expect_n / 256l
     if (nb <= 0l) {
         return
     }
     guard_dst(name, "k5 quant plane", (eloff / 256l) * K5_QSB, nb * K5_QSB, long_length(kq))
     guard_dst(name, "k5 scale plane", (eloff / 256l) * K5_SSB, nb * K5_SSB, long_length(ks))
-    unsafe {   // per-superblock byte shuffle (see transcode_q5k_superblock), threaded + pointerized
-        let srcp = addr<uint8 const?>(bytes[bo])
-        var kqp = addr(kq[(eloff / 256l) * K5_QSB])
-        var ksp = addr(ks[(eloff / 256l) * K5_SSB])
-        maybe_parallel_for(0, int(nb), transcode_jobs(nb, 176l)) $(rb, re) {
-            unsafe {
-                for (blk in range64(int64(rb), int64(re))) {
-                    bcopy(ksp + blk * K5_SSB, srcp + blk * 176l, 16l)
-                    var pad = reinterpret<uint?>(ksp + blk * K5_SSB + 16l)
-                    pad[0] = 0u
-                    bcopy(kqp + blk * K5_QSB, srcp + blk * 176l + 48l, 128l)   // qs
-                    bcopy(kqp + blk * K5_QSB + 128l, srcp + blk * 176l + 16l, 32l)   // qh
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        let bo = tbase + (src_off / 256l) * 176l
+        unsafe {   // per-superblock byte shuffle (see transcode_q5k_superblock), threaded + pointerized
+            let srcp = addr<uint8 const?>(bytes[bo])
+            var kqp = addr(kq[(eloff / 256l) * K5_QSB])
+            var ksp = addr(ks[(eloff / 256l) * K5_SSB])
+            maybe_parallel_for(0, int(nb), transcode_jobs(nb, 176l)) $(rb, re) {
+                unsafe {
+                    for (blk in range64(int64(rb), int64(re))) {
+                        bcopy(ksp + blk * K5_SSB, srcp + blk * 176l, 16l)
+                        var pad = reinterpret<uint?>(ksp + blk * K5_SSB + 16l)
+                        pad[0] = 0u
+                        bcopy(kqp + blk * K5_QSB, srcp + blk * 176l + 48l, 128l)   // qs
+                        bcopy(kqp + blk * K5_QSB + 128l, srcp + blk * 176l + 16l, 32l)   // qh
+                    }
                 }
             }
         }
@@ -866,23 +999,26 @@ def gguf_transcode_q5k(m : GGUFMeta; bytes : array<uint8> | #; name : string; va
 }
 
 //! Transcode a Q6_K tensor into the k6 planes (see gguf_transcode_q4k; strides 192/18, exact).
-def gguf_transcode_q6k(m : GGUFMeta; bytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
-    let bo = kq_transcode_base(m, name, GGML_TYPE_Q6_K, "Q6_K", src_off, expect_n, 210l)
+def gguf_transcode_q6k(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    let ti = kq_transcode_check(m, name, GGML_TYPE_Q6_K, "Q6_K", src_off, expect_n)
     let nb = expect_n / 256l
     if (nb <= 0l) {
         return
     }
     guard_dst(name, "k6 quant plane", (eloff / 256l) * K6_QSB, nb * K6_QSB, long_length(kq))
     guard_dst(name, "k6 scale plane", (eloff / 256l) * K6_SSB, nb * K6_SSB, long_length(ks))
-    unsafe {   // per-superblock byte shuffle (see transcode_q6k_superblock), threaded + pointerized
-        let srcp = addr<uint8 const?>(bytes[bo])
-        var kqp = addr(kq[(eloff / 256l) * K6_QSB])
-        var ksp = addr(ks[(eloff / 256l) * K6_SSB])
-        maybe_parallel_for(0, int(nb), transcode_jobs(nb, 210l)) $(rb, re) {
-            unsafe {
-                for (blk in range64(int64(rb), int64(re))) {
-                    bcopy(kqp + blk * K6_QSB, srcp + blk * 210l, 192l)   // ql then qh — disk order
-                    bcopy(ksp + blk * K6_SSB, srcp + blk * 210l + 192l, 18l)   // 16 sub-scales + f16 d
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        let bo = tbase + (src_off / 256l) * 210l
+        unsafe {   // per-superblock byte shuffle (see transcode_q6k_superblock), threaded + pointerized
+            let srcp = addr<uint8 const?>(bytes[bo])
+            var kqp = addr(kq[(eloff / 256l) * K6_QSB])
+            var ksp = addr(ks[(eloff / 256l) * K6_SSB])
+            maybe_parallel_for(0, int(nb), transcode_jobs(nb, 210l)) $(rb, re) {
+                unsafe {
+                    for (blk in range64(int64(rb), int64(re))) {
+                        bcopy(kqp + blk * K6_QSB, srcp + blk * 210l, 192l)   // ql then qh — disk order
+                        bcopy(ksp + blk * K6_SSB, srcp + blk * 210l + 192l, 18l)   // 16 sub-scales + f16 d
+                    }
                 }
             }
         }
@@ -892,7 +1028,7 @@ def gguf_transcode_q6k(m : GGUFMeta; bytes : array<uint8> | #; name : string; va
 //! Decode tensor `name` (F32 or F16 on disk) into dst[dst_off ..] as fp32. Panics if the
 //! tensor is missing, has a different element count than expected, or uses a type we don't
 //! yet read (quantized types are wired in a later step).
-def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; var dst : array<float>; dst_off, expect_n : int64; src_off : int64 = 0l) {
+def gguf_read_tensor_f32(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var dst : array<float>; dst_off, expect_n : int64; src_off : int64 = 0l) {
     let ti = gguf_find_tensor(m, name)
     if (ti < 0) {
         panic("gguf: tensor '{name}' not found")
@@ -905,8 +1041,8 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
         panic("gguf: tensor '{name}' slice [{src_off}, {src_off + expect_n}) exceeds {nelem} elems")
     }
     let gtype = m.tensors[ti].ggml_type
-    let base = m.data_offset + m.tensors[ti].offset
     guard_dst(name, "f32 dst", dst_off, expect_n, long_length(dst))
+    with_tensor_view(m, srcbytes, ti) $(bytes, base) {
     if (gtype == GGML_TYPE_F32) {
         unsafe {   // raw copy, threaded in u64 words (+ one odd-float tail)
             let sp = addr<uint64 const?>(bytes[base + src_off * 4l])
@@ -1020,11 +1156,12 @@ def gguf_read_tensor_f32(m : GGUFMeta; bytes : array<uint8> | #; name : string; 
     } else {
         panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/BF16/Q8_0/Q4_0/Q4_K/Q5_K/Q6_K/MXFP4)")
     }
+    }
 }
 
 //! Copy a BF16 tensor's raw halfwords into dst[dst_off..] — no fp32 expand (read kernels widen
 //! in-loop by the exact bit shift). Requires the tensor to be BF16 on disk (check gguf_tensor_type).
-def gguf_transcode_bf16(m : GGUFMeta; bytes : array<uint8> | #; name : string; var dst : array<uint16>; dst_off, expect_n : int64) {
+def gguf_transcode_bf16(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var dst : array<uint16>; dst_off, expect_n : int64) {
     let ti = gguf_find_tensor(m, name)
     if (ti < 0) {
         panic("gguf: tensor '{name}' not found")
@@ -1035,11 +1172,12 @@ def gguf_transcode_bf16(m : GGUFMeta; bytes : array<uint8> | #; name : string; v
     if (expect_n != m.tensors[ti].n_elem) {
         panic("gguf: tensor '{name}' has {m.tensors[ti].n_elem} elems, expected {expect_n}")
     }
-    let base = m.data_offset + m.tensors[ti].offset
-    unsafe {
-        let src = temp_array(addr<uint16?>(bytes[base]), expect_n, type<uint16>)
-        for (i in range64(expect_n)) {
-            dst[dst_off + i] = src[i]
+    with_tensor_view(m, srcbytes, ti) $(bytes, base) {
+        unsafe {
+            let src = temp_array(addr<uint16?>(bytes[base]), expect_n, type<uint16>)
+            for (i in range64(expect_n)) {
+                dst[dst_off + i] = src[i]
+            }
         }
     }
 }
@@ -1055,7 +1193,7 @@ def gguf_tensor_type(m : GGUFMeta; name : string) : int {
 //! copy verbatim to qdst[qoff..]; the per-block fp16 scale widens to fp32 in sdst[soff..]. Requires
 //! the tensor to be Q8_0 on disk (check gguf_tensor_type first). qoff is the weight-element offset,
 //! soff = qoff / 32. This is the memory-honest load of a pre-quantized GGUF.
-def gguf_transcode_q8_0(m : GGUFMeta; bytes : array<uint8> | #; name : string; var qdst : array<int8>; var sdst : array<float>; qoff, soff, expect_n : int64; src_off : int64 = 0l) {
+def gguf_transcode_q8_0(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var qdst : array<int8>; var sdst : array<float>; qoff, soff, expect_n : int64; src_off : int64 = 0l) {
     let ti = gguf_find_tensor(m, name)
     if (ti < 0) {
         panic("gguf: tensor '{name}' not found")
@@ -1077,23 +1215,25 @@ def gguf_transcode_q8_0(m : GGUFMeta; bytes : array<uint8> | #; name : string; v
     // pointerized + threaded: the quant copy is a bit-reinterpret (uint8 -> int8, same bits), so a
     // block is 4 unaligned u64 moves + one f16 scale widen. Blocks are disjoint — bit-exact at any
     // lane count; jobs are floored to ~1MB of source each so small tensors stay inline.
-    let base = m.data_offset + m.tensors[ti].offset + (src_off / 32l) * 34l
-    unsafe {
-        let srcp = addr<uint8 const?>(bytes[base])
-        var qdp = addr(qdst[qoff])
-        var sdp = addr(sdst[soff])
-        let njobs = is_job_que_available() ? int(clamp(nb / 32768l, 1l, 64l)) : 1
-        maybe_parallel_for(0, int(nb), njobs) $(rb, re) {
-            unsafe {
-                for (blk in range64(int64(rb), int64(re))) {
-                    let bo = blk * 34l
-                    sdp[blk] = f16_to_f32(uint(srcp[bo]) | (uint(srcp[bo + 1l]) << 8u))
-                    let s64 = reinterpret<uint64 const?>(srcp + bo + 2l)
-                    var d64 = reinterpret<uint64?>(qdp + blk * 32l)
-                    d64[0] = s64[0]
-                    d64[1] = s64[1]
-                    d64[2] = s64[2]
-                    d64[3] = s64[3]
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        let base = tbase + (src_off / 32l) * 34l
+        unsafe {
+            let srcp = addr<uint8 const?>(bytes[base])
+            var qdp = addr(qdst[qoff])
+            var sdp = addr(sdst[soff])
+            let njobs = is_job_que_available() ? int(clamp(nb / 32768l, 1l, 64l)) : 1
+            maybe_parallel_for(0, int(nb), njobs) $(rb, re) {
+                unsafe {
+                    for (blk in range64(int64(rb), int64(re))) {
+                        let bo = blk * 34l
+                        sdp[blk] = f16_to_f32(uint(srcp[bo]) | (uint(srcp[bo + 1l]) << 8u))
+                        let s64 = reinterpret<uint64 const?>(srcp + bo + 2l)
+                        var d64 = reinterpret<uint64?>(qdp + blk * 32l)
+                        d64[0] = s64[0]
+                        d64[1] = s64[1]
+                        d64[2] = s64[2]
+                        d64[3] = s64[3]
+                    }
                 }
             }
         }
@@ -1104,7 +1244,7 @@ def gguf_transcode_q8_0(m : GGUFMeta; bytes : array<uint8> | #; name : string; v
 //! GGML's exact split-half nibble packing, so the 16 packed bytes per block copy verbatim to
 //! qdst[qoff_bytes..] (qoff_bytes = weight-element-offset / 2); the per-block fp16 scale widens to
 //! fp32 in sdst[soff..]. Requires the tensor to be Q4_0 on disk (check gguf_tensor_type first).
-def gguf_transcode_q4_0(m : GGUFMeta; bytes : array<uint8> | #; name : string; var qdst : array<uint8>; var sdst : array<float>; qoff_bytes, soff, expect_n : int64; src_off : int64 = 0l) {
+def gguf_transcode_q4_0(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var qdst : array<uint8>; var sdst : array<float>; qoff_bytes, soff, expect_n : int64; src_off : int64 = 0l) {
     let ti = gguf_find_tensor(m, name)
     if (ti < 0) {
         panic("gguf: tensor '{name}' not found")
@@ -1116,14 +1256,16 @@ def gguf_transcode_q4_0(m : GGUFMeta; bytes : array<uint8> | #; name : string; v
         panic("gguf: tensor '{name}' slice [{src_off}, {src_off + expect_n}) exceeds {m.tensors[ti].n_elem} elems")
     }
     let nb = expect_n / 32l
-    var bo = m.data_offset + m.tensors[ti].offset + (src_off / 32l) * 18l
-    for (blk in range64(nb)) {
-        sdst[soff + blk] = f16_to_f32(rd_u16(bytes, bo))
-        bo += 2l
-        for (j in range64(16l)) {
-            qdst[qoff_bytes + blk * 16l + j] = bytes[bo + j]
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        var bo = tbase + (src_off / 32l) * 18l
+        for (blk in range64(nb)) {
+            sdst[soff + blk] = f16_to_f32(rd_u16(bytes, bo))
+            bo += 2l
+            for (j in range64(16l)) {
+                qdst[qoff_bytes + blk * 16l + j] = bytes[bo + j]
+            }
+            bo += 16l
         }
-        bo += 16l
     }
 }
 
@@ -1133,7 +1275,7 @@ def gguf_transcode_q4_0(m : GGUFMeta; bytes : array<uint8> | #; name : string; v
 //! (eoff = offset / 32). Exact by construction (vs the old dequant->requantize-to-Q8 path, which
 //! paid an amax error) and reads 17 bytes/block instead of writing 33+. Requires the tensor to be
 //! MXFP4 on disk (check gguf_tensor_type first).
-def gguf_transcode_mx4(m : GGUFMeta; bytes : array<uint8> | #; name : string; var ndst : array<uint8>; var edst : array<uint8>; noff_bytes, eoff, expect_n : int64; src_off : int64 = 0l) {
+def gguf_transcode_mx4(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var ndst : array<uint8>; var edst : array<uint8>; noff_bytes, eoff, expect_n : int64; src_off : int64 = 0l) {
     let ti = gguf_find_tensor(m, name)
     if (ti < 0) {
         panic("gguf: tensor '{name}' not found")
@@ -1145,13 +1287,15 @@ def gguf_transcode_mx4(m : GGUFMeta; bytes : array<uint8> | #; name : string; va
         panic("gguf: tensor '{name}' slice [{src_off}, {src_off + expect_n}) exceeds {m.tensors[ti].n_elem} elems")
     }
     let nb = expect_n / 32l
-    var bo = m.data_offset + m.tensors[ti].offset + (src_off / 32l) * 17l
-    for (blk in range64(nb)) {
-        edst[eoff + blk] = bytes[bo]
-        bo++
-        for (j in range64(16l)) {
-            ndst[noff_bytes + blk * 16l + j] = bytes[bo + j]
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        var bo = tbase + (src_off / 32l) * 17l
+        for (blk in range64(nb)) {
+            edst[eoff + blk] = bytes[bo]
+            bo++
+            for (j in range64(16l)) {
+                ndst[noff_bytes + blk * 16l + j] = bytes[bo + j]
+            }
+            bo += 16l
         }
-        bo += 16l
     }
 }

--- a/modules/dasLLAMA/harness/gguf_dump.das
+++ b/modules/dasLLAMA/harness/gguf_dump.das
@@ -2,6 +2,7 @@ options gen2
 
 require daslib/fio
 require daslib/array_boost // nolint:STYLE030 — temp_array is [template]; STYLE030 misses template-fn refs
+require daslib/strings_boost
 require dasllama/dasllama_gguf
 require strings
 require math
@@ -17,7 +18,7 @@ def gtype_name(t : int) : string {
     return t >= 0 && t < length(names) ? names[t] : "?{t}"
 }
 
-def dump_kv(m : GGUFMeta; bytes : array<uint8>#; key : string) {
+def dump_kv(m : GGUFMeta; bytes : array<uint8> | #; key : string) {
     if (!gguf_has(m, key)) {
         return
     }
@@ -43,12 +44,36 @@ def main {
         path = args[length(args) - 1]
     }
     print("=== dasllama_gguf parse: {path} ===\n")
+    let shards <- gguf_shard_paths(path)
+    if (length(shards) > 1) {
+        print("split model:  {length(shards)} shards\n")
+        var bases : array<void?>
+        var sizes : array<int64>
+        gguf_map_shards(shards, 0, bases, sizes) {
+            var m <- parse_gguf_meta_shards(bases, sizes)
+            unsafe {
+                dump_meta(m, temp_array(reinterpret<uint8?>(bases[0]), sizes[0], type<uint8>))
+            }
+            delete m
+        }
+        bases |> clear()
+        delete bases
+        delete sizes
+        return
+    }
     let f = fopen(path, "rb")
     if (f == null) {
         panic("cannot open {path}")
     }
     fmap(f) $(var bytes : array<uint8>#) {
-        var m <- parse_gguf_meta(bytes)
+        let m <- parse_gguf_meta(bytes)
+        dump_meta(m, bytes)
+    }
+    fclose(f)
+}
+
+def dump_meta(m : GGUFMeta; bytes : array<uint8> | #) {
+    {
         print("version:     {int(m.version)}\n")
         print("alignment:   {m.alignment}\n")
         print("data offset: {m.data_offset}\n")
@@ -68,13 +93,12 @@ def main {
         if (nt > 0) {
             print("--- first 6 tensors ---\n")
             for (i in range(min(6, nt))) {
-                var dimstr = ""
-                for (d in m.tensors[i].dims) {
-                    dimstr += "{d} "
-                }
-                print("  [{i}] {m.tensors[i].name}  type={m.tensors[i].ggml_type} dims=[{dimstr}] off={m.tensors[i].offset} nelem={m.tensors[i].n_elem}\n")
+                let dimstr = join(m.tensors[i].dims, " ")
+                print("  [{i}] {m.tensors[i].name}  type={m.tensors[i].ggml_type} dims=[{dimstr}] off={m.tensors[i].offset} nelem={m.tensors[i].n_elem} shard={m.tensors[i].shard}\n")
             }
+            print("--- last tensor ---\n")
+            let dimstr = join(m.tensors[nt - 1].dims, " ")
+            print("  [{nt - 1}] {m.tensors[nt - 1].name}  type={m.tensors[nt - 1].ggml_type} dims=[{dimstr}] off={m.tensors[nt - 1].offset} nelem={m.tensors[nt - 1].n_elem} shard={m.tensors[nt - 1].shard}\n")
         }
     }
-    fclose(f)
 }

--- a/skills/strings.md
+++ b/skills/strings.md
@@ -48,12 +48,14 @@ require daslib/strings_convert
 
 let n = to_int(s)              // silent — returns 0 for "foo", 12 for "12abc"
 let r = try_to_int(s)          // Result<int; ConversionError>
-if (r is value) {
-    use(r as value)
+if (r._is_ok) {
+    use(r._value)
 } else {
-    bail("bad input: {s} ({r as error})")
+    bail("bad input: {s} ({r._error})")
 }
 ```
+
+`Result<T; E>` (daslib/result) is a **structural tuple** `tuple<_is_ok : bool; _value : T; _error : E>` — access via `r._is_ok` / `r._value` / `r._error`, NOT variant `is value`/`as value` (that's `error[30190] is value only allowed for variants`; the variant form belongs to fio's `fs_result_*` types, which are real variants).
 
 - **`to_int(s)` / `to_float(s)`** silently return `0` / `0.0` for unparseable input and partial-parse for `"12abc"`. Fine for trusted internal data; **never** for user input, env vars, file contents, command-line args, or anything that flows into a shell call, file path, or system call. `";rm -rf;"` parses as `0` with `to_int`.
 - **`try_to_int` / `try_to_float`** in `daslib/strings_convert` return a `Result<T; ConversionError>` distinguishing `invalid_argument` (no digits), `out_of_range` (overflow), and `trailing_garbage` (`"12abc"`). The whole `try_to_*` family covers `int8`/`uint8`/.../`int64`/`uint64`/`float`/`double`.

--- a/tests/dasLLAMA/_model_tier.das
+++ b/tests/dasLLAMA/_model_tier.das
@@ -13,6 +13,7 @@ module _model_tier shared public
 require dastest/testing_boost public
 require daslib/fio public
 require strings public
+require dasllama/dasllama_gguf   // gguf_shard_paths — split models tier on their TOTAL size
 
 // Models larger than this are large-tier. 6 GiB cleanly splits the ~5GB-and-under carriers
 // (incl. gemma-4-E2B at 4.97GB) from the 7.7GB+ heavies.
@@ -40,8 +41,21 @@ def model_available(t : T?; path : string) : bool {
         t |> skip("{base_name(path)} not present")
         return false
     }
-    if (!parity_full_mode() && st.size > LARGE_TIER_BYTES) {
-        t |> skip("{base_name(path)} is large-tier ({int64(st.size / (1024ul * 1024ul * 1024ul))} GB) — set DASLLAMA_PARITY_FULL=1 to run")
+    var total = st.size
+    // split models tier on their TOTAL size; an incomplete split is "not present" (skip), not a panic
+    let shards <- gguf_shard_paths(path, [missing_ok = true])
+    if (empty(shards)) {
+        t |> skip("{base_name(path)} split is incomplete (missing sibling shard)")
+        return false
+    }
+    if (length(shards) > 1) {
+        total = 0ul
+        for (s in shards) {
+            total += stat(s).size
+        }
+    }
+    if (!parity_full_mode() && total > LARGE_TIER_BYTES) {
+        t |> skip("{base_name(path)} is large-tier ({int64(total / (1024ul * 1024ul * 1024ul))} GB) — set DASLLAMA_PARITY_FULL=1 to run")
         return false
     }
     return true

--- a/tests/dasLLAMA/test_gguf_shards.das
+++ b/tests/dasLLAMA/test_gguf_shards.das
@@ -1,0 +1,49 @@
+options gen2
+
+require dastest/testing_boost public
+require dasllama/dasllama_gguf
+require daslib/fio
+
+// gguf_shard_paths: llama.cpp split-name expansion ("<prefix>-NNNNN-of-NNNNN.gguf"), the
+// non-split passthrough arms, and the missing_ok presence gate model_available rides
+// (incomplete split yields [] instead of the loader's panic). Name/filesystem only — no models.
+
+[test]
+def test_shard_name_passthrough(t : T?) {
+    t |> run("non-split shapes yield just [path]") @(t : T?) {
+        for (p in ["model.gguf", "m-1-of-3.gguf", "m-00000-of-00003.gguf",
+                   "m-00004-of-00003.gguf", "m-abcde-of-00003.gguf", "m-00001-of-00003.bin"]) {
+            var shards <- gguf_shard_paths(p)
+            t |> equal(length(shards), 1, "single path for '{p}'")
+            t |> equal(shards[0], p, "path unchanged for '{p}'")
+            delete shards
+        }
+    }
+}
+
+[test]
+def test_shard_split_expansion(t : T?) {
+    var terr = ""
+    let dir = temp_directory(terr)
+    t |> success(terr == "", "temp_directory resolves")
+    let names <- [for (i in range(1, 4)); "dasllama_shard_toy-0000{i}-of-00003.gguf"]
+    let paths <- [for (n in names); path_join(dir, n)]
+    for (p in paths) {
+        t |> success(fwrite(p, "x"), "shard written: {base_name(p)}")
+    }
+    // complete split: expands from ANY shard index, normalized and in order
+    var shards <- gguf_shard_paths(paths[1])
+    t |> equal(length(shards), 3, "3 shards from the shard-2 path")
+    for (i in range(3)) {
+        t |> equal(base_name(shards[i]), names[i], "shard {i + 1} in order")
+        t |> success(fexist(shards[i]), "shard {i + 1} exists")
+    }
+    delete shards
+    // incomplete split (partial download): the presence-gate arm yields [] instead of a panic
+    remove(paths[2])
+    var missing <- gguf_shard_paths(paths[0], [missing_ok = true])
+    t |> equal(length(missing), 0, "missing sibling with missing_ok yields empty")
+    delete missing
+    remove(paths[0])
+    remove(paths[1])
+}

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -201,40 +201,37 @@ def private perturb_quants(var blkb : array<uint8>; qoff, qlen : int) {
     }
 }
 
-// Kernel-vs-reference gate core: transcode two distinct superblocks of `fmt`, quantize a smooth
+// Kernel-vs-reference gate core: transcode nsb distinct superblocks of `fmt` (per-superblock
+// LCG over the quant plane so an inter-superblock offset bug can't cancel), quantize a smooth
 // activation with the bs quantizer, and compare the integer-domain kernel dot against the fp64
 // elementwise dot over the plane dequant (the kernels' declared oracle).
-def private kq_dot_gate(t : T?; fmt : int) {
-    let n = 512l
+def private kq_dot_gate(t : T?; fmt : int; n : int64 = 512l) {
+    let nsb = n / 256l
     let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
-    var blk2 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
-    if (fmt == 4) {
-        perturb_quants(blk2, 16, 128)
-    } elif (fmt == 5) {
-        perturb_quants(blk2, 16, 160)   // qh + qs
-    } else {
-        perturb_quants(blk2, 0, 192)    // ql + qh
-    }
     let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
     let ssb = fmt == 6 ? 18l : 20l
     var kq : array<uint8>
     var ks : array<uint8>
-    kq |> resize(2l * qsb)
-    ks |> resize(2l * ssb)
-    if (fmt == 4) {
-        transcode_q4k_superblock(blk1, 0l, kq, 0l, ks, 0l)
-        transcode_q4k_superblock(blk2, 0l, kq, qsb, ks, ssb)
-    } elif (fmt == 5) {
-        transcode_q5k_superblock(blk1, 0l, kq, 0l, ks, 0l)
-        transcode_q5k_superblock(blk2, 0l, kq, qsb, ks, ssb)
-    } else {
-        transcode_q6k_superblock(blk1, 0l, kq, 0l, ks, 0l)
-        transcode_q6k_superblock(blk2, 0l, kq, qsb, ks, ssb)
+    kq |> resize(nsb * qsb)
+    ks |> resize(nsb * ssb)
+    for (s in range64(nsb)) {
+        if (fmt == 4) {
+            transcode_q4k_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
+        } elif (fmt == 5) {
+            transcode_q5k_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
+        } else {
+            transcode_q6k_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
+        }
+    }
+    var st = 0x12345u
+    for (i in range64(nsb * qsb)) {
+        st = st * 1664525u + 1013904223u
+        kq[i] = uint8(uint(kq[i]) ^ (st >> 16u))
     }
     // plane dequant = the reference weights
     var w : array<float>
     w |> resize(n)
-    for (s in range64(2l)) {
+    for (s in range64(nsb)) {
         if (fmt == 4) {
             dequant_k4_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
         } elif (fmt == 5) {
@@ -287,6 +284,15 @@ def test_kq_dots(t : T?) {
     t |> run("dot_k6q8 matches the fp64 plane-dequant reference") @(t : T?) {
         kq_dot_gate(t, 6)
     }
+    // 122B-class row widths: n=3072 (12 superblocks — qwen35moe-122B gate/up/cls) and n=1024
+    // (its k5 down_exps). Every earlier kq model kept n at 512..2560.
+    for (fmt in [4, 5, 6]) {
+        for (nn in [1024l, 3072l]) {
+            t |> run("dot_k{fmt}q8 matches the fp64 reference at n={int(nn)}") @(t : T?) {
+                kq_dot_gate(t, fmt, nn)
+            }
+        }
+    }
 }
 
 // Portable multi-row GEMV gate: matmul_kq (the disk-order kq_gemv_kernel rail — what a
@@ -294,8 +300,7 @@ def test_kq_dots(t : T?) {
 // dots. Guards the k*_rows_kernel PER-ROW plane strides, which the single-superblock dot
 // gate above never exercises (a k4 scale-row stride miss shipped when K4_SSB went 32 -> 20:
 // row 0 dotted clean, every later row read the wrong scale rows).
-def private kq_gemv_rows_gate(t : T?; fmt : int) {
-    let n = 512l
+def private kq_gemv_rows_gate(t : T?; fmt : int; n : int64 = 512l) {
     let d = 8l
     let nsb = n / 256l
     let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
@@ -376,6 +381,13 @@ def test_kq_gemv_rows(t : T?) {
     t |> run("portable k6 GEMV rows bit-match per-row disk dots") @(t : T?) {
         kq_gemv_rows_gate(t, 6)
     }
+    for (fmt in [4, 5, 6]) {
+        for (nn in [1024l, 3072l]) {
+            t |> run("portable k{fmt} GEMV rows bit-match per-row disk dots at n={int(nn)}") @(t : T?) {
+                kq_gemv_rows_gate(t, fmt, nn)
+            }
+        }
+    }
 }
 
 // Stage-4 repack oracle core: build a d-row disk plane of `fmt` (transcoded synthetic
@@ -384,8 +396,7 @@ def test_kq_gemv_rows(t : T?) {
 // grp<mr> scalar reference (kq_grp_row_dot — the stamped cores' decline body) and the grp row
 // dequant to reproduce them BIT-EXACTLY (same block order, exact integer sub-sums — only the
 // plane layout moved).
-def private kq_repack_gate(t : T?; fmt : int; mr : int64) {
-    let n = 512l
+def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
     let d = 32l
     let nsb = n / 256l
     let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
@@ -497,6 +508,11 @@ def test_kq_repack_grp(t : T?) {
                 kq_repack_gate(t, fmt, mr)
             }
         }
+        for (nn in [1024l, 3072l]) {
+            t |> run("repack_k{fmt}_grp mr=8 preserves dots and row dequants at n={int(nn)}") @(t : T?) {
+                kq_repack_gate(t, fmt, 8l, nn)
+            }
+        }
     }
 }
 
@@ -504,8 +520,7 @@ def test_kq_repack_grp(t : T?) {
 // repacked planes (the tile's per-token fold order IS the GEMV's). Repack at the layout
 // companion's mr — the same value the stubs/kernels read, so this holds on the reference
 // bodies (interp) AND the stamped kernels (-jit) alike.
-def private kq_tile_gate(t : T?; fmt : int) {
-    let n = 512l
+def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
     let d = 32l
     let ntok = 7l   // 4-token tile + a 3-token gemv tail
     let nsb = n / 256l
@@ -633,6 +648,11 @@ def test_kq_tile(t : T?) {
         t |> run("k{fmt} 4-token tile bit-matches per-token GEMVs") @(t : T?) {
             kq_tile_gate(t, fmt)
         }
+        for (nn in [1024l, 3072l]) {
+            t |> run("k{fmt} 4-token tile bit-matches per-token GEMVs at n={int(nn)}") @(t : T?) {
+                kq_tile_gate(t, fmt, nn)
+            }
+        }
     }
 }
 
@@ -641,10 +661,7 @@ def test_kq_tile(t : T?) {
 // per-region grp slices, the per-expert-slice repack shape). Regions carry distinct LCG
 // payloads; both offs forms run — the shared activation image (gate/up, xoff 0) and
 // per-region activation rows (down, xoff = r*n).
-def private kq_groupn_gate(t : T?; fmt : int) {
-    let n = 512l
-    let d = 32l
-    let nreg = 3l
+def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l; nreg : int64 = 3l) {
     let nsb = n / 256l
     let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
     let ssb = fmt == 6 ? 18l : 20l
@@ -805,6 +822,157 @@ def test_kq_groupn(t : T?) {
         t |> run("k{fmt} region-list GEMV bit-matches per-row dots (disk + grp slices)") @(t : T?) {
             kq_groupn_gate(t, fmt)
         }
+        for (nn in [1024l, 3072l]) {
+            t |> run("k{fmt} region-list GEMV bit-matches per-row dots at n={int(nn)}") @(t : T?) {
+                kq_groupn_gate(t, fmt, nn)
+            }
+        }
+    }
+    // the qwen35moe-122B expert slice shapes: gate/up k4 n=3072 d=1024, down k5 n=1024 d=3072,
+    // top-8 regions — the small-d arms above never walk >4 mr-groups per region
+    t |> run("k4 region-list GEMV at the 122B gate/up slice shape (n=3072 d=1024 nreg=8)") @(t : T?) {
+        kq_groupn_gate(t, 4, 3072l, 1024l, 8l)
+    }
+    t |> run("k5 region-list GEMV at the 122B down slice shape (n=1024 d=3072 nreg=8)") @(t : T?) {
+        kq_groupn_gate(t, 5, 1024l, 3072l, 8l)
+    }
+}
+
+// Batch-groupn gate: the fused MoE prefill's kq batch GEMM (matmul_kq_batch_groupn — triple offs
+// (woff, row0, cnt), token-major y over the gathered image) must bit-match per-(region, token)
+// rows-core calls over the same repacked planes. This drives kq_batch_cell_gen's TB/tile/tail
+// walk over bucket-shaped token runs — the rail no per-region gate above reaches.
+def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l) {
+    let prev_backend = active_kernel_backend()
+    // matmul_kq_batch_groupn dispatches through the active backend and only the gen tier carries
+    // the slot; a failed pin (interp, no avx2, declined stamp) keeps the previous backend un-pinned
+    pin_kernel_backend(get_architecture_name() == "arm64" ? "arm64-gen" : "x64-gen")
+    if (!kernel_backend_has_kq_batch_groupn()) {
+        t |> skip("no gen backend registered (kq_batch_groupn is JIT-only)")
+        return
+    }
+    let nsb = n / 256l
+    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
+    let ssb = fmt == 6 ? 18l : 20l
+    let mr = kq_layout_of(fmt)
+    // bucket mix: a 1-row run (pure gemv tail), whole tiles, tile+tail, and a TB-spanning run
+    var cnts <- [1l, 4l, 6l, 13l]
+    let nreg = int64(length(cnts))
+    var nk = 0l
+    for (c in cnts) {
+        nk += c
+    }
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    var kq : array<uint8>
+    var ks : array<uint8>
+    kq |> resize(int(nreg * d * nsb * qsb))
+    ks |> resize(int(nreg * d * nsb * ssb))
+    for (r in range64(nreg * d)) {
+        for (s in range64(nsb)) {
+            if (fmt == 4) {
+                transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 5) {
+                transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } else {
+                transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            }
+        }
+        var st = 0x7F4A7C15u + uint(r) * 0x85EBCA6Bu
+        for (i in range64(nsb * qsb)) {
+            st = st * 1664525u + 1013904223u
+            kq[r * nsb * qsb + i] = uint8(uint(kq[r * nsb * qsb + i]) ^ (st >> 16u))
+        }
+    }
+    unsafe {
+        for (r in range64(nreg)) {   // per-region grp repack — the per-expert-slice shape
+            if (fmt == 4) {
+                repack_k4_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            } elif (fmt == 5) {
+                repack_k5_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            } else {
+                repack_k6_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            }
+        }
+    }
+    // gathered activation image: nk rows, Q8_K-quantized per row
+    var src : array<float>
+    src |> resize(int(nk * n))
+    for (i in range64(nk * n)) {
+        src[i] = 0.8 * sin(float(i) * 0.29) - 0.4 * cos(float(i) * 0.057)
+    }
+    var xq : array<int8>
+    var xs : array<float>
+    var xbs : array<int>
+    xq |> resize(int(nk * n))
+    xs |> resize(int(nk * n / 256l))
+    xbs |> resize(int(nk * n / 16l))
+    unsafe {
+        for (p in range64(nk)) {
+            quantize_q8_k_into_ptr(addr(src[p * n]), n, addr(xq[0]), addr(xs[0]), addr(xbs[0]), p * n, p * (n / 256l), p * (n / 16l))
+        }
+    }
+    // region triples + per-(region, token) rows-core references
+    var offs : array<int64>
+    offs |> reserve(nreg * 3l)
+    var want : array<float>
+    var y : array<float>
+    want |> resize(int(nk * d))
+    y |> resize(int(nk * d))
+    var row0 = 0l
+    unsafe {
+        for (r in range64(nreg)) {
+            offs |> push(r * d * n)   // nolint:STYLE012 — triple stream, not a collectable comprehension
+            offs |> push(row0)
+            offs |> push(cnts[r])
+            let kqr = addr(kq[r * d * nsb * qsb])
+            let ksr = addr(ks[r * d * nsb * ssb])
+            for (tk in range64(row0, row0 + cnts[r])) {
+                if (fmt == 4) {
+                    k4q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
+                } elif (fmt == 5) {
+                    k5q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
+                } else {
+                    k6q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
+                }
+            }
+            row0 += cnts[r]
+        }
+    }
+    matmul_kq_batch_groupn(fmt, y, kq, ks, offs, nreg, xq, xs, xbs, n, d)
+    var bad = 0
+    for (i in range64(nk * d)) {
+        if (y[i] != want[i]) {
+            bad++
+        }
+    }
+    t |> success(bad == 0, "kq batch groupn bit-matches per-(region, token) rows-core calls")
+    clear_kernel_backend_pin()   // restore without leaving a pin that wasn't there on entry
+    select_kernel_backend(prev_backend)
+    delete cnts
+    delete kq
+    delete ks
+    delete src
+    delete xq
+    delete xs
+    delete xbs
+    delete offs
+    delete want
+    delete y
+}
+
+[test]
+def test_kq_batch_groupn(t : T?) {
+    for (fmt in [4, 5, 6]) {
+        t |> run("k{fmt} batch groupn bit-matches per-token rows-core calls") @(t : T?) {
+            kq_batch_groupn_gate(t, fmt)
+        }
+    }
+    // the qwen35moe-122B fused-prefill slice shapes
+    t |> run("k4 batch groupn at the 122B gate/up slice shape (n=3072 d=1024)") @(t : T?) {
+        kq_batch_groupn_gate(t, 4, 3072l, 1024l)
+    }
+    t |> run("k5 batch groupn at the 122B down slice shape (n=1024 d=3072)") @(t : T?) {
+        kq_batch_groupn_gate(t, 5, 1024l, 3072l)
     }
 }
 

--- a/tests/dasLLAMA/test_parity.das
+++ b/tests/dasLLAMA/test_parity.das
@@ -397,6 +397,70 @@ def test_parity_qwen3next(t : T?) {
     }
 }
 
+// Qwen3.5-122B-A10B Q4_K_M — the qwen35moe arch at 122B geometry (48L hybrid, dim 3072,
+// 248320 vocab), and the first NATIVE SPLIT fixture: the model ships as 3 shards and loads
+// through gguf_shard_paths / parse_gguf_meta_shards (shard 0 = metadata+vocab only). Huge
+// tier (~71 GB total): DASLLAMA_PARITY_FULL=1.
+[test]
+def test_parity_qwen35moe_122b(t : T?) {
+    t |> run("qwen35moe forward (Qwen3.5-122B-A10B Q4_K_M, 3-shard split gguf)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3.5-122B-A10B/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_gguf(path, QuantMode.q8)
+        if (tr.config.seq_len > 2048l) {   // KV RAM cap, same as parity_ok
+            tr.config.seq_len = 2048l
+        }
+        t |> success(parity_gen_ok(tr, QWEN3_PROMPT, QWEN3_GEN), "qwen35moe-122b token-for-token")
+        t |> success(parity_gen_ok(tr, QWEN3_PROMPT, QWEN3_GEN, [dn_chunked = true]), "qwen35moe-122b chunked-prefill token-for-token")
+        delete tr
+    }
+}
+
+// Same model, Q8_0 — a 4-shard split riding the q8 transcode rail (>2^31 weight-scale blocks,
+// the wscale int64 regression shape). Huge tier (~130 GB resident): DASLLAMA_PARITY_FULL=1.
+[test]
+def test_parity_qwen35moe_122b_q8(t : T?) {
+    t |> run("qwen35moe forward (Qwen3.5-122B-A10B Q8_0, 4-shard split gguf)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3.5-122B-A10B/Q8_0/Qwen3.5-122B-A10B-Q8_0-00001-of-00004.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_gguf(path, QuantMode.q8)
+        if (tr.config.seq_len > 2048l) {   // KV RAM cap, same as parity_ok
+            tr.config.seq_len = 2048l
+        }
+        t |> success(parity_gen_ok(tr, QWEN3_PROMPT, QWEN3_GEN), "qwen35moe-122b Q8_0 token-for-token")
+        delete tr
+    }
+}
+
+// Qwen3-Coder-Next again, Q8_0 (merged locally from its 3-part split download) — rides the q8
+// transcode rail instead of the kq/dequant arms the Q4_K_M fixture exercises. Huge tier (~79 GB).
+[test]
+def test_parity_qwen3next_q8(t : T?) {
+    t |> run("qwen3next forward (Qwen3-Coder-Next Q8_0, merged single file)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3-Coder-Next-Q8_0.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_gguf(path, QuantMode.q8)
+        if (tr.config.seq_len > 2048l) {   // KV RAM cap, same as parity_ok
+            tr.config.seq_len = 2048l
+        }
+        t |> success(parity_gen_ok(tr, QWEN3_PROMPT, QWEN3_GEN), "qwen3next Q8_0 token-for-token")
+        t |> success(parity_gen_ok(tr, QWEN3_PROMPT, QWEN3_GEN, [dn_chunked = true]), "qwen3next Q8_0 chunked-prefill token-for-token")
+        delete tr
+    }
+}
+
 // Native K-quant rail: the same counting fixture over the Q4_K_M / Q5_K_M / Q6_K files of the
 // SAME model, forced through kquant_native planes (grp repack + kq kernels + kq embed gather).
 // The oracles were produced per-file by simple_ids (all three continue identically, equal to


### PR DESCRIPTION
Brings up **Qwen3.5-122B-A10B** (arch `qwen35moe` — zero new arch work, geometry comes from the KV prefix). The model exposed three latent bugs, each the first time a size threshold or rail was crossed.

## The real prize: #3450's prefill twin

`ffn_moe_prefill_grouped` on K-quant layers filled ONLY the Q8_K activation image; the q8 **shared-expert** batch GEMMs (step 4) read the **stale Q8_0 image** — whatever the last quantize left there. The shexp silently corrupted on **every kform+shexp model's grouped prefill** (Coder-Next and the 35B survived the counting fixture by luck; the 122B flipped at token 0, generating an ordered letters walk instead of digits). #3450 fixed exactly this in *decode*; this is the prefill side. Fix: fill the q8 image alongside when the layer has a non-dense shexp. gemma4's grouped prefill is clean — its dense shexp runs `mm_b_f` off float rows.

Debug ladder that localized it: `simple_ids` oracle transfers to the 122B (llama-cli chat mode does **not** — this build ignores `-no-cnv`) → merged-single-file A/B produced **identical wrong ids**, exonerating the split loader → kq-native-off green → per-family fmt-force bisects in `detect_kq_formats` → reference-prefill green ⇒ grouped prefill → code read.

## Native split-GGUF loading

All five big-model downloads ship multi-part (Qwen3.5-122B, Mistral-Medium-3.5, GLM-4.5-Air, both quants each) — merge-first would churn >1TB of disk, and llama.cpp reads splits natively.

- `gguf_shard_paths` — llama.cpp shard-name expansion (`-NNNNN-of-NNNNN.gguf`), normalized from any shard index, panics on a missing sibling
- `gguf_map_shards` — recursive `fmap`, all mappings alive for the block
- `parse_gguf_meta_shards` — union tensor directory (shard 0 carries the model KVs per the llama.cpp convention), per-tensor `shard` index, borrowed `@do_not_delete` bases
- `with_tensor_view` — the one choke point every tensor reader resolves its view/base through; single-file metas resolve within the caller's bytes exactly as before

Single-file rail proven byte-identical: the 46-fixture small-tier sweep, and split-vs-merged producing identical outputs during the bug hunt.

## >2^31 weight scales

`wscale_convert_f16` resized the f16 scale plane through `int()` — Coder-Next Q8_0 is the first model past 2^31 per-32-block scales (2.478e9), so the resize wrapped negative and panicked. int64 resize; the rest of the q8 rail was already 64-bit clean (122B Q8_0 pushes it to 3.8e9 scales).

## Tests

- Fixtures: Coder-Next Q8_0, 122B Q4_K_M (3-shard), 122B Q8_0 (4-shard) — huge-tier gated, self-skip without the model; `_model_tier` tiers split models on their **total** size
- `test_kquant`: dot/rows/repack/tile/groupn gates parameterized by shape (n; d/nreg for groupn) + a new **batch-groupn** gate driving `kq_batch_cell_gen`'s TB/tile/tail walk over bucket-shaped token runs (pins the `x64-gen` backend — the dispatcher panics on portable)
- `skills/strings.md`: corrected the `try_to_int` example — `Result<T;E>` is a structural tuple (`._is_ok`/`._value`/`._error`), not a variant

Verified on this branch (rebased on 376b8ce7e, rebuilt): kquant **81/81**, small-tier parity **47 pass / 0 fail**, Coder-Next Q4_K_M + Q8_0, 35B, 122B Q4_K_M — all token-for-token vs llama.cpp. The 122B Q8_0 fixture passed standalone pre-rebase (345s; ~155GB peak das heap); the post-rebase rerun hit box commit pressure from a concurrently running model server at 18s into load (identical deterministic allocation sizes, before any changed-code behavior) — not a code failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)