### PR TITLE
dasLLAMA: MTP/NextN self-speculative decode - 1.39x decode on Qwen3.6-27B + user-facing README + dasllama.html refresh/SEO

### DIFF
--- a/modules/dasLLAMA/README.md
+++ b/modules/dasLLAMA/README.md
@@ -1,12 +1,66 @@
 # dasLLAMA
 
-daslang-native **CPU** LLM inference (Llama / Qwen / Phi / Gemma dense + MoE transformers,
-Qwen3.5/3.6 hybrid-DeltaNet, gpt-oss). Loads GGUF (or llama2.c `.bin`), runs the forward
-pass + KV cache, tokenizes, and decodes — all in daslang, JIT tier. Verified token-for-token
-against `llama.cpp` / `llama2.c`.
+dasLLAMA is a **CPU LLM + speech stack written entirely in daslang** — no C++ kernels, no
+hand-written assembly. The daslang JIT compiles the whole engine, and a per-box auto-tuner
+picks the kernel forms for *your* machine, so the same source ships tuned code on an M1 and
+a Threadripper alike. It loads stock GGUF files (llama.cpp's format — single-file or
+multi-shard splits, F32/F16/Q8_0/Q4_0/MXFP4 and native Q4_K/Q5_K/Q6_K planes), runs text
+LLMs, audio-input "omni" chat models, speech-to-text, and voice-activity detection, and it
+is fast: consistently ahead of llama.cpp's CPU inference on prompt processing (up to ~1.7×),
+trading blows on generation, and up to ~6× ahead on audio/omni workloads — live scoreboard +
+methodology at [daslang.io/dasllama.html](https://daslang.io/dasllama.html). Every supported
+model is **verified token-for-token** against its reference implementation before it lands
+in the support table.
 
-Run a model: `bin/daslang -jit examples/dasLLAMA/run.das -- <model.gguf>`
-Chat: `bin/daslang -jit examples/dasLLAMA/chat.das -- <model.gguf>`
+## Quick start
+
+**Serve it over HTTP** — `utils/dasllama-server/` is a drop-in OpenAI-compatible server
+(chat/completions with streaming + tool calling, embeddings, audio transcription); point
+opencode, Open WebUI, or the `openai` SDK at `http://127.0.0.1:8080/v1`:
+
+```sh
+bin/daslang -jit utils/dasllama-server/main.das -- --model <model.gguf> [--port 8080] \
+    [--asr <asr-model>] [--streams 4] [--ctx 4096]
+```
+
+Flag table, TOML config, and the scheduler/paged-KV details live in
+[utils/dasllama-server/README.md](../../utils/dasllama-server/README.md).
+
+Or drive it from the command line:
+
+```sh
+# greedy/sampled completion + tok/s stats
+bin/daslang -jit examples/dasLLAMA/run.das -- <model.gguf>
+
+# interactive chat REPL — the arch registry picks the template + stop tokens
+bin/daslang -jit examples/dasLLAMA/chat.das -- <model.gguf>
+
+# audio chat (omni models: decoder GGUF + audio mmproj)
+bin/daslang -jit examples/dasLLAMA/audio.das -- <decoder.gguf> <mmproj.gguf> <audio-file> [prompt]
+
+# speech-to-text: whisper / parakeet / canary ggml bins, or qwen3-asr GGUF pairs
+bin/daslang -jit examples/dasLLAMA/transcribe.das -- <ggml-model.bin | decoder.gguf mmproj.gguf> <audio-file>
+
+# live dictation from the microphone
+bin/daslang -jit examples/dasLLAMA/dictate.das -- <asr-model.bin>
+```
+
+## Supported model families
+
+- **Text LLMs** (GGUF, arch auto-detected): Llama-2 / Llama-3 (incl. TinyLlama, SmolLM2,
+  Mistral-7B), Qwen2.5, Qwen3, Qwen-MoE (Qwen1.5-MoE, Qwen3-30B-A3B), the Qwen3.5 / Qwen3.6
+  hybrid-DeltaNet family — dense 0.8B–27B and MoE 35B-A3B / 122B-A10B, including the `-MTP-`
+  files' NextN head for **self-speculative decode** (~1.4× decode on the 27B, output-invariant) —
+  Qwen3-Coder-Next (80B-A3B), Phi-3.5, Gemma-2, Gemma-3, Gemma-4 (dense 12B/31B, 26B-A4B MoE,
+  and the E2B/E4B edge models with per-layer embeddings + cross-layer KV sharing), gpt-oss-20b.
+- **Audio-in chat (omni)**: Qwen2-Audio, Qwen2.5-Omni, Qwen3-Omni-30B-A3B, Ultravox v0.5,
+  Voxtral-Mini-3B, Gemma-4 E-series audio.
+- **Speech-to-text**: the whole Whisper family (tiny → large-v3-turbo, stock whisper.cpp bins),
+  Parakeet-TDT 0.6b v2/v3, Qwen3-ASR 0.6B/1.7B, Canary-Qwen 2.5B.
+- **Voice activity detection**: Silero-VAD v6 (weights checked in — works with zero setup).
+
+The full per-model table — exact files tested, arch notes, and the token-for-token oracle
+evidence — is in [Supported models](#supported-models--what-runs-for-sure) below.
 
 ---
 
@@ -29,6 +83,8 @@ modules/dasLLAMA/
     dasllama_math.das         #   numeric primitives + matmul/dot kernels (fp32, Q8, Q4) + Q8·Q8 kernel-backend registry
     dasllama_math_default.das #   the portable Q8·Q8 kernel backend (the fallback; platform backends out-rank it)
     dasllama_math_aarch64_neon.das # arm64 SDOT row-major Q8·Q8 backend + the laneq dot leaves the gen tier composes ([init]-registered; no-op off-ARM)
+    dasllama_math_metal.das   #   Metal GPU prefill-GEMM backend (batch-only donor; decode GEMV stays CPU)
+    dasllama_metal_prefill.das #  Metal full-GPU-resident prefill kernel set (requant, rmsnorm, rope, attention)
     dasllama_math_gen.das     #   the generated GEMM tier — registers "arm64-gen"/"x64-gen" (load-select repack backends; traversals read the stamped layout)
     dasllama_gemm_schema.das  #   tune_perm grid + layout schema shared by the generator and the runtime
     dasllama_gemm_gen.das     #   the GEMM tile generator (emits per-perm kernels under llvm_tune)
@@ -40,9 +96,13 @@ modules/dasLLAMA/
     dasllama_unicode.das      #   Unicode classification + UTF-8 codec
     dasllama_tokenizer.das    #   SentencePiece tokenizer (Llama-2 family, Phi-3, Gemma)
     dasllama_bpe.das          #   byte-level BPE / tiktoken tokenizer (Llama-3 + Qwen2 pre-tokenizers)
-    dasllama_common.das       #   engine core — Config / Model / Session, load + forward + generate + sample
+    dasllama_common.das       #   engine core — Config / Model / Session, load + forward + generate + sample (incl. MTP/NextN self-spec decode)
+    dasllama_prefix.das       #   vLLM-style page-granular prefix cache over the paged KV pool
+    dasllama_audio_io.das     #   miniaudio decode (wav/mp3/flac/ogg -> 16 kHz mono f32) + mic capture
     dasllama_audio.das        #   audio tower — whisper mel frontends + encoder core + qwen2a projector (soft-token splice)
     dasllama_whisper.das      #   whisper-proper ASR — ggml-bin loader, cross-attn decoder, greedy driver, transcribe API
+    dasllama_parakeet.das     #   Parakeet-TDT ASR — FastConformer + LSTM predictor + duration-skip transducer
+    dasllama_canary.das       #   Canary-Qwen ASR — FastConformer-32 encoder + projector over a stock Qwen3 decoder
     dasllama_qwen3a.das       #   Qwen3-ASR audio encoder — conv2d chunk frontend, windowed transformer, MLP projector
     dasllama_gemma4a.das      #   Gemma-4 E-series audio encoder — gemma4a Conformer (macaron FFN, chunked-local RPE attn, conv module, per-op activation clamps) + mm embedder
     dasllama_asr.das          #   uniform ASR surface — load_asr_model (format-sniffed), caps(), family-free verbs
@@ -50,6 +110,7 @@ modules/dasLLAMA/
     dasllama_arch_llama.das   #   Llama / Llama-2 / Llama-3 / TinyLlama arch (config + chat template)
     dasllama_arch_qwen2.das   #   Qwen2 arch  (per-arch: config setter + [init] registration)
     dasllama_arch_qwen3.das   #   Qwen3 arch (QK-norm)
+    dasllama_arch_qwen35.das  #   Qwen3.5/3.6 + Qwen3-Next hybrid arches (Gated-DeltaNet + gated attention; qwen35 / qwen35moe / qwen3next)
     dasllama_arch_phi3.das    #   Phi-3 arch
     dasllama_arch_gemma2.das  #   Gemma-2 arch
     dasllama_arch_gemma3.das  #   Gemma-3 arch (SWA pattern + dual rope θ)
@@ -192,6 +253,7 @@ What a model needs to "just work" today:
 | Attention biases | **Qwen2** — Q/K/V projection biases; **gpt-oss** — Q/K/V + output-projection biases |
 | Sampling | greedy, temperature, top-k, repetition penalty (`SamplingParams`; greedy = temp 0, bit-identical to argmax) |
 | Chat | per-arch data-driven templates in the registry + one segment-accumulation renderer (`dasllama_chat`) — reproduces the reference prefills token-for-token (`test_chat.das`); the template is auto-detected by sniffing the GGUF's embedded `tokenizer.chat_template` (never executed), falling back to the arch heuristic; Qwen3-style `<think>` blocks are stripped from chat history (`strip_think`); Gemma-4 uses its channel-based turn format (`<|turn>` / `<turn|>`, non-thinking opener closes an empty `thought` channel); gpt-oss uses the Harmony-lite template (`<|start|>role<|message|>...<|end|>`, replies end at `<|return|>` / `<|call|>`, channel markers render in decoded text as in llama.cpp) |
+| Self-speculative decode (MTP/NextN) | qwen35-family `-MTP-` GGUFs load natively (`nextn_predict_layers == 1`): the in-file NextN draft block — one trunk-shaped attention layer at index `n_layers` plus `nextn.eh_proj/enorm/hnorm/shared_head_norm` — drafts one token ahead and a 2-row batched trunk forward verifies it, so accepted steps stream the weights once for two tokens. **Output-invariant vs plain greedy** (`generate_mtp_greedy`, gated by `tests/dasLLAMA/test_mtp.das`); 1.39× decode on Qwen3.6-27B Q8 (zen2, ~94% accept on list continuation). The prompt warm runs the draft block batched (same prefill blocks at `l = n_layers`). Greedy-only v1; the DeltaNet recurrent state snapshots and rolls back around rejected drafts; `mtp_only` sidecar files and per-head `nextn.embed_tokens`/`shared_head_head` panic honestly |
 | Performance | KV cache, SIMD + JobQue-threaded matmul, activation-quant Q8·Q8 behind a pluggable kernel-backend registry (ARM SDOT/laneq + the generated x64 AVX2 maddubs/vpdpbusd tier — `x64_arch.md`), flash-attention batched prefill, per-box kernel tuning (`tune_for_this_box.md`) |
 
 ## Optimization guidelines

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1612,6 +1612,9 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             panic("dasLLAMA: nextn_predict_layers = {nextn} not supported (single NextN head only)")
         }
         let layers = gguf_int(m, bytes, "{arch}.block_count") - nextn
+        if (layers < 1l) {   // fail closed on a malformed file before "blk.-1..." confusion downstream
+            panic("dasLLAMA: {arch}.block_count = {layers + nextn} with nextn_predict_layers = {nextn} leaves no trunk layers")
+        }
         t.config.n_layer_nextn = nextn
         // FFN width: a scalar for uniform arches, or a per-layer array (gemma-4 E2B: the elastic
         // MatFormer sub-model, 6144 for layers 0-14 then 12288). ffn_w holds the per-layer widths;

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -6673,18 +6673,6 @@ def private mtp_verify_row0(t : Model; var s : Session) {
     }
 }
 
-def private mtp_argmax(a : array<float>; n : int64) : int64 {
-    var best = 0l
-    var bestv = a[0]
-    for (i in range64(n)) {
-        if (a[i] > bestv) {
-            bestv = a[i]
-            best = i
-        }
-    }
-    return best
-}
-
 //! Greedy decode with MTP/NextN depth-1 self-speculation (config.n_layer_nextn == 1; flat KV
 //! cache only). Mirrors generate()'s contract — returns prompt[1..] echoed, then the greedy
 //! continuation, `total` ids overall — and is OUTPUT-INVARIANT vs plain greedy decode: the
@@ -6715,7 +6703,7 @@ def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total
     // batched trunk prefill (stashes h_{np-1}); the prompt's next token BEFORE the warm pass
     // clobbers s.logits
     forward_prefill(t, s, prompt, np, 0l)
-    var tok = mtp_argmax(s.logits, c.vocab_size)
+    var tok = parallel_argmax(s.logits, c.vocab_size)
     let dim = c.dim
     if (np > 1l) {
         // MTP prompt warm, batched: rows 0..np-2 hold (h_p, x_{p+1}) — every position's trunk
@@ -6752,7 +6740,7 @@ def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total
         break if (int64(length(ids)) >= total)
         // draft x_{pos+1} from (h_{pos-1}, tok) at row pos-1
         forward_mtp(t, s, tok, pos - 1l)
-        let d = mtp_argmax(s.logits, c.vocab_size)
+        let d = parallel_argmax(s.logits, c.vocab_size)
         n_drafted++
         // batched verify: trunk over [tok@pos, d@pos+1] — weights stream once for both rows
         mtp_state_snapshot(s)
@@ -6760,7 +6748,7 @@ def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total
         vbatch[1] = d
         forward_prefill(t, s, vbatch, 2l, pos)
         mtp_verify_row0(t, s)
-        let truth = mtp_argmax(s.mtp_logits, c.vocab_size)
+        let truth = parallel_argmax(s.mtp_logits, c.vocab_size)
         if (truth == d) {
             n_accepted++
             break if (d == 1l)   // BOS: generate() stops before emitting it — mirror that
@@ -6768,7 +6756,7 @@ def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total
             // Backfill MTP row pos with the pair (h_pos = mtp_h0, d) — preserve row 1's h first.
             copy_floats(s.mtp_h, 0l, htmp, 0l, c.dim)
             copy_floats(s.mtp_h0, 0l, s.mtp_h, 0l, c.dim)
-            let next = mtp_argmax(s.logits, c.vocab_size)
+            let next = parallel_argmax(s.logits, c.vocab_size)
             forward_mtp(t, s, d, pos, false)   // KV backfill only — no draft here
             copy_floats(htmp, 0l, s.mtp_h, 0l, c.dim)
             ids |> push(d)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1732,7 +1732,10 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
                 if (gguf_find_tensor(m, "blk.0.attn_norm.weight") < 0) {
                     panic("dasLLAMA: MTP-only sidecar GGUF (no trunk tensors) is not supported — use the full -MTP file")
                 }
-            } elif (gguf_find_tensor(m, "blk.{layers}.nextn.eh_proj.weight") >= 0) {
+            } elif (gguf_find_tensor(m, "blk.{layers}.nextn.eh_proj.weight") >= 0
+                    || gguf_find_tensor(m, "blk.{layers - 1l}.nextn.eh_proj.weight") >= 0) {
+                // the second probe catches a malformed file whose block_count already counts the
+                // draft block — its nextn tensors sit one below the first probe's index
                 panic("dasLLAMA: file ships NextN tensors but no nextn_predict_layers key — refusing to guess")
             }
         }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -189,6 +189,9 @@ struct Config {
     ssm_n_group : int64 = 0            // deltanet k-head count (16)
     ssm_dt_rank : int64 = 0            // deltanet v-head count (0.8B: 16, 35B: 32)
     ssm_d_inner : int64 = 0            // deltanet value width = ssm_dt_rank * ssm_d_state
+    // MTP/NextN (qwen35 family -MTP files): block_count includes the appended draft block(s).
+    // n_layers stays the TRUNK count everywhere; the MTP block lives at layer index n_layers.
+    n_layer_nextn : int64 = 0          // 0 = no MTP block; 1 = single NextN head (only value supported)
 }
 
 // Swappable block kernels — one per (attention|ffn) × (decode|prefill). Decode is the fused
@@ -459,6 +462,14 @@ struct Model {
     // qwen3next-layout file (detected via fused ssm_ba): v-indexed tensors ship in HF GROUPED
     // v-head order; the loader permutes them to the TILED order the kernels (and qwen35 files) use
     dn_grouped : bool = false
+    // MTP/NextN extras (config.n_layer_nextn == 1). The draft block's standard attention/FFN
+    // tensors ride the per-layer arrays above at index n_layers; only the nextn-specific ones
+    // need their own slots. -1 = absent; mtp_headnorm_off falls back to rms_final_off.
+    mtp_ehproj_off : int64 = -1     // nextn.eh_proj (quant plane): 2*dim -> dim
+    mtp_ehproj_fmt : KqFmt = KqFmt.q8
+    mtp_enorm_off : int64 = -1      // fblob: nextn.enorm (token-embedding RMS weight), dim
+    mtp_hnorm_off : int64 = -1      // fblob: nextn.hnorm (trunk-hidden RMS weight), dim
+    mtp_headnorm_off : int64 = -1   // fblob: nextn.shared_head_norm, dim (-1 = output_norm)
 }
 
 // ===== Arch registry: per-architecture blocks + chat template =====
@@ -594,7 +605,10 @@ def private layout_offsets(var t : Model) : LayoutSizes {
     let c = t.config
     let dim = c.dim
     let hidden = c.hidden_dim
-    let layers = c.n_layers
+    // The MTP/NextN draft block is one extra trunk-shaped attention layer at index n_layers
+    // (both arches: dense FFN on qwen35, expert stacks on qwen35moe) — every per-layer walk
+    // here covers it; its recr_mask bit is unset so the standard attention arm applies.
+    let layers = c.n_layers + c.n_layer_nextn
     var fo = 0l
     var bf16 = 0l
     if (t.cls_q8 || cls_kq(t)) {
@@ -745,8 +759,9 @@ def private layout_offsets(var t : Model) : LayoutSizes {
     t.wv_offs |> clear()
     t.wv_offs |> reserve(layers)
     for (l in range64(layers)) {
-        // -1 marks a V-from-K layer (gemma4 global), a shared-KV layer (E-series), or a deltanet layer
-        if (t.kv_src[l] != l || ((c.v_from_k_mask >> uint64(l)) & 1ul) != 0ul || layer_is_recurrent(c, l)) {
+        // -1 marks a V-from-K layer (gemma4 global), a shared-KV layer (E-series), or a deltanet
+        // layer. The l < n_layers guard kills the shift-by-64 wrap at the MTP index (27B: l=64)
+        if (t.kv_src[l] != l || (l < c.n_layers && ((c.v_from_k_mask >> uint64(l)) & 1ul) != 0ul) || layer_is_recurrent(c, l)) {
             t.wv_offs |> push(-1l)
         } else {
             t.wv_offs |> push(kq_take(cur, fmt_at(t.wv_fmt, l), dim * layer_kv_dim(c, l)))
@@ -834,6 +849,15 @@ def private layout_offsets(var t : Model) : LayoutSizes {
         }
     } else {
         t.wcls_off = kq_take(cur, t.wcls_fmt, c.vocab_size * dim)
+    }
+    if (c.n_layer_nextn > 0l) {   // MTP/NextN extras (the block's standard tensors rode the walks above)
+        t.mtp_ehproj_off = kq_take(cur, t.mtp_ehproj_fmt, 2l * dim * dim)
+        t.mtp_enorm_off = fo
+        fo += dim
+        t.mtp_hnorm_off = fo
+        fo += dim
+        t.mtp_headnorm_off = fo   // loaded only when the tensor exists; reads fall back to rms_final_off
+        fo += dim
     }
     return LayoutSizes(fblob_n = fo, wblob_n = cur.wo, mx_n = mx, bf16_n = bf16,
                        k4_n = cur.k4, k5_n = cur.k5, k6_n = cur.k6)
@@ -1130,7 +1154,7 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
             || (t.config.fused_qkv && t.config.dim % 256l != 0l)) {   // fused slice offsets are dim-multiples
         return
     }
-    let layers = t.config.n_layers
+    let layers = t.config.n_layers + t.config.n_layer_nextn   // + the MTP block's tags at index n_layers
     t.wq_fmt |> resize(layers)
     t.wk_fmt |> resize(layers)
     t.wv_fmt |> resize(layers)
@@ -1190,6 +1214,10 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
     } else {
         t.wcls_fmt = kq_fmt_of(gguf_tensor_type(m, "output.weight"))
         any ||= t.wcls_fmt != KqFmt.q8
+    }
+    if (t.config.n_layer_nextn > 0l) {
+        t.mtp_ehproj_fmt = kq_fmt_of(gguf_tensor_type(m, "blk.{t.config.n_layers}.nextn.eh_proj.weight"))
+        any ||= t.mtp_ehproj_fmt != KqFmt.q8
     }
     // E-series PLE token table: gather-only whole rows of layers*ple — row length must be
     // superblock-aligned for the plane walk (256 % holds on E2B/E4B: ple 256)
@@ -1337,7 +1365,7 @@ def private repack_q8_weights(var t : Model) {
     let dim = c.dim
     let hidden = c.hidden_dim
     var regs : array<RepackReg>
-    for (l in range64(c.n_layers)) {
+    for (l in range64(c.n_layers + c.n_layer_nextn)) {   // + the MTP/NextN block at index n_layers
         let kv = layer_kv_dim(c, l)
         let qd = layer_qd(c, l)
         // K-quant-tagged weights live in the kq planes (disk order, never repacked) — their
@@ -1421,6 +1449,9 @@ def private repack_q8_weights(var t : Model) {
         // indexes it directly. K-quant classifiers (either tying) stay in their plane, unpacked.
         push_repack(regs, 0, t.wcls_off, dim, c.vocab_size)
     }
+    if (c.n_layer_nextn > 0l && t.mtp_ehproj_fmt == KqFmt.q8) {   // NextN eh_proj: 2*dim -> dim
+        push_repack(regs, 0, t.mtp_ehproj_off, 2l * dim, dim)
+    }
     repack_regions(t, regs)
     delete regs
 }
@@ -1444,7 +1475,7 @@ def private repack_kq_weights(var t : Model) {
     let c = t.config
     let dim = c.dim
     var regs : array<RepackReg>
-    for (l in range64(c.n_layers)) {
+    for (l in range64(c.n_layers + c.n_layer_nextn)) {   // + the MTP/NextN block at index n_layers
         let kv = layer_kv_dim(c, l)
         let qd = layer_qd(c, l)
         // recurrent (deltanet) layers carry no attention projections (offsets -1); their own
@@ -1484,6 +1515,9 @@ def private repack_kq_weights(var t : Model) {
     }
     if ((!c.shared_weights && t.wcls_fmt != KqFmt.q8) || cls_kq(t)) {
         push_repack_kq(regs, c.shared_weights ? t.emb_fmt : t.wcls_fmt, t.wcls_off, dim, c.vocab_size)
+    }
+    if (c.n_layer_nextn > 0l) {   // NextN eh_proj (no-op for q8 tags)
+        push_repack_kq(regs, t.mtp_ehproj_fmt, t.mtp_ehproj_off, 2l * dim, dim)
     }
     repack_regions(t, regs)
     delete regs
@@ -1571,7 +1605,14 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
         }
         // GGUF uses the architecture name as the metadata key prefix (llama.*, qwen2.*, gemma2.*, ...)
         let dim = gguf_int(m, bytes, "{arch}.embedding_length")
-        let layers = gguf_int(m, bytes, "{arch}.block_count")
+        // MTP/NextN: block_count INCLUDES the appended draft block(s) (llama.cpp n_layer_all);
+        // `layers` below is the TRUNK count — every per-layer validation/mask walks the trunk only.
+        let nextn = gguf_has(m, "{arch}.nextn_predict_layers") ? gguf_int(m, bytes, "{arch}.nextn_predict_layers") : 0l
+        if (nextn < 0l || nextn > 1l) {
+            panic("dasLLAMA: nextn_predict_layers = {nextn} not supported (single NextN head only)")
+        }
+        let layers = gguf_int(m, bytes, "{arch}.block_count") - nextn
+        t.config.n_layer_nextn = nextn
         // FFN width: a scalar for uniform arches, or a per-layer array (gemma-4 E2B: the elastic
         // MatFormer sub-model, 6144 for layers 0-14 then 12288). ffn_w holds the per-layer widths;
         // hidden_dim is the MAX (scratch sizing). Set before layout_offsets so the offsets vary per layer.
@@ -1679,10 +1720,17 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             if (dn_conv_dim(t.config) % 4l != 0l) {   // the batched conv reads float4 rows (validate-at-load, kv_validate_q8 precedent)
                 panic("dasLLAMA: deltanet conv_dim {dn_conv_dim(t.config)} must be a multiple of 4")
             }
-            // MTP/NextN decoder blocks are not modeled — refuse files that ship the tensors
-            // (regular GGUFs strip them; the metadata key alone is tolerated and ignored)
-            if (gguf_find_tensor(m, "blk.{layers}.nextn.eh_proj.weight") >= 0) {
-                panic("dasLLAMA: MTP/NextN layers are not supported — use a non-MTP GGUF")
+            // MTP/NextN consistency: the metadata and the tensor directory must agree, and an
+            // MTP-only sidecar (trunk stripped, llama.cpp mtp_only) is not loadable standalone
+            if (t.config.n_layer_nextn > 0l) {
+                if (gguf_find_tensor(m, "blk.{layers}.nextn.eh_proj.weight") < 0) {
+                    panic("dasLLAMA: nextn_predict_layers = {t.config.n_layer_nextn} but blk.{layers}.nextn.eh_proj.weight is missing")
+                }
+                if (gguf_find_tensor(m, "blk.0.attn_norm.weight") < 0) {
+                    panic("dasLLAMA: MTP-only sidecar GGUF (no trunk tensors) is not supported — use the full -MTP file")
+                }
+            } elif (gguf_find_tensor(m, "blk.{layers}.nextn.eh_proj.weight") >= 0) {
+                panic("dasLLAMA: file ships NextN tensors but no nextn_predict_layers key — refusing to guess")
             }
         }
         // KV-head count: scalar (uniform), or gemma4's per-layer array — which must collapse to the
@@ -1928,7 +1976,8 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
         // detected from the tensor table so layout_offsets can skip their V slot
         if (!t.config.fused_qkv) {
             for (l in range64(layers)) {
-                if (gguf_find_tensor(m, "blk.{l}.attn_v.weight") < 0) {
+                // recurrent (deltanet) layers legitimately have no attn_v — they are NOT V-from-K
+                if (gguf_find_tensor(m, "blk.{l}.attn_v.weight") < 0 && !layer_is_recurrent(t.config, l)) {
                     if (l >= 64l) {
                         panic("dasLLAMA: V-from-K layers need n_layers <= 64 (got layer {l})")
                     }
@@ -2003,7 +2052,10 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
         }
         // gpt-oss names its pre-FFN norm post_attention_norm (same graph role as ffn_norm)
         let ffn_norm_name = t.config.post_attn_is_ffn_norm ? "post_attention_norm" : "ffn_norm"
-        for (l in range64(layers)) {
+        // per-layer walks below include the MTP/NextN block (index n_layers) — a trunk-shaped
+        // attention layer whose norms/weights load through the standard arms
+        let layers_ld = layers + t.config.n_layer_nextn
+        for (l in range64(layers_ld)) {
             gguf_read_tensor_f32(m, bytes, "blk.{l}.attn_norm.weight", t.fblob, t.rms_att_off + l * dim, dim)
             gguf_read_tensor_f32(m, bytes, "blk.{l}.{ffn_norm_name}.weight", t.fblob, t.rms_ffn_off + l * dim, dim)
             if (t.config.pre_post_norm) {  // Gemma2: post-attn + post-FFN norms (already +1-baked in the GGUF)
@@ -2088,7 +2140,7 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
         ts_stage = ref_time_ticks()
         // big 2D weights -> active precision. ggml stores them row-major [out x in] = our convention.
         var scratch : array<float>
-        for (l in range64(layers)) {
+        for (l in range64(layers_ld)) {
             let kv_l = layer_kv_dim(t.config, l)
             let qd_l = layer_qd(t.config, l)
             if (layer_is_recurrent(t.config, l)) {
@@ -2194,6 +2246,21 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
                 let ple = t.config.n_embd_per_layer
                 load_big(m, bytes, "blk.{l}.inp_gate.weight", t, t.ple_gate_off + l * dim * ple, dim * ple, scratch)
                 load_big(m, bytes, "blk.{l}.proj.weight", t, t.ple_proj_off + l * ple * dim, ple * dim, scratch)
+            }
+        }
+        if (t.config.n_layer_nextn > 0l) {   // MTP/NextN extras (block index n_layers = `layers`)
+            load_big(m, bytes, "blk.{layers}.nextn.eh_proj.weight", t, t.mtp_ehproj_off, 2l * dim * dim, scratch, 0l, t.mtp_ehproj_fmt)
+            gguf_read_tensor_f32(m, bytes, "blk.{layers}.nextn.enorm.weight", t.fblob, t.mtp_enorm_off, dim)
+            gguf_read_tensor_f32(m, bytes, "blk.{layers}.nextn.hnorm.weight", t.fblob, t.mtp_hnorm_off, dim)
+            if (gguf_find_tensor(m, "blk.{layers}.nextn.shared_head_norm.weight") >= 0) {
+                gguf_read_tensor_f32(m, bytes, "blk.{layers}.nextn.shared_head_norm.weight", t.fblob, t.mtp_headnorm_off, dim)
+            } else {
+                t.mtp_headnorm_off = -1l   // reads fall back to output_norm (rms_final_off)
+            }
+            // optional per-head embedding/classifier: no known qwen35 file ships them — fail closed
+            if (gguf_find_tensor(m, "blk.{layers}.nextn.embed_tokens.weight") >= 0
+                    || gguf_find_tensor(m, "blk.{layers}.nextn.shared_head_head.weight") >= 0) {
+                panic("dasLLAMA: NextN per-head embed_tokens/shared_head_head are not supported yet")
             }
         }
         if (has_ple(t.config)) {  // the per-layer token-embedding table [vocab x (ple*layers)], gathered per token, never repacked
@@ -2530,6 +2597,18 @@ struct Session {
     dn_conv_b : array<float>       // batched conv + SiLU output (npos x conv_dim)
     dn_wtap : array<float>         // conv weights transposed tap-major for the batched form (d_conv x conv_dim)
     dn_cws : array<float>          // per-v-head chunk workspace slabs (dt_rank x dn_cws_head_size)
+    // MTP/NextN self-spec state (empty unless config.n_layer_nextn > 0). mtp_h is the trunk's
+    // post-output-norm hidden of the LAST evaluated position — llama.cpp's t_h_nextn handoff,
+    // stashed by forward()/forward_prefill() right after the final rms_at.
+    mtp_h : array<float>           // h_nextn (dim)
+    mtp_cat : array<float>         // eh_proj input [enorm(embed(tok)) ; hnorm(h)] (2*dim)
+    mtp_cat_b : array<float>       // prompt-warm eh_proj concat image ((np-1) x 2*dim, scratch-sized per warm)
+    mtp_h0 : array<float>          // verify-batch row-0 h_nextn (dim) — the accept-path MTP backfill pair
+    mtp_logits : array<float>      // verify-batch row-0 logits (vocab; the draft check reads its argmax)
+    // deltanet rollback for a rejected verify batch (sized lazily on first snapshot)
+    mtp_snap_conv : array<float>
+    mtp_snap_state : array<float>
+    mtp_snap_pos : int64
 }
 
 // Block-codec KV (q8_0 / tq4) needs whole 32-blocks everywhere the cache is sliced: rows (kv_dim)
@@ -2541,7 +2620,7 @@ def private kv_validate_q8(c : Config; kdt, vdt : KVDtype) {
     if (kdt != KVDtype.q8_0 && vdt != KVDtype.q8_0 && !tq4) {
         return
     }
-    for (l in range64(c.n_layers)) {
+    for (l in range64(c.n_layers + c.n_layer_nextn)) {   // + the MTP/NextN block's KV slab
         let kvd = layer_kv_dim(c, l)
         let hs = layer_head_size(c, l)
         if (kvd % 32l != 0l || hs % 32l != 0l) {
@@ -2633,9 +2712,17 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
         s.dn_qg |> resize(2l * qd)
         s.dn_qgate |> resize(qd)
     }
+    if (c.n_layer_nextn > 0l) {   // MTP/NextN: h_nextn handoff + eh_proj concat input + verify row-0 outputs
+        s.mtp_h |> resize(c.dim)
+        s.mtp_cat |> resize(2l * c.dim)
+        s.mtp_h0 |> resize(c.dim)
+        s.mtp_logits |> resize(c.vocab_size)
+    }
     s.ffn_offs |> resize(4)
     s.ffn_gu |> resize(2l * ffw)
-    let maxn = max(xdim, ffw)   // the Q8·Q8 path quantizes whichever activation feeds a matmul
+    // the Q8·Q8 path quantizes whichever activation feeds a matmul; the MTP eh_proj feeds a
+    // 2*dim concat row (don't rely on qd/ffw happening to cover it — 35B-A3B's qd == 2*dim is luck)
+    let maxn = max(max(xdim, ffw), c.n_layer_nextn > 0l ? 2l * c.dim : 0l)
     s.xq |> resize(maxn)
     s.xs |> resize(maxn / 32l)
     s.xq2 |> resize(ffw)        // fused-FFN chain requant (see the Session field comment)
@@ -2665,11 +2752,13 @@ def make_run_state(c : Config; kdt : KVDtype = KVDtype.f32; vdt : KVDtype = KVDt
     // (which counted shared layers) at identical addresses.
     s.kv_dtype_k = kdt
     s.kv_dtype_v = vdt
-    s.kv_bprefix_k |> reserve(int(c.n_layers))
-    s.kv_bprefix_v |> reserve(int(c.n_layers))
+    // + the MTP/NextN draft block's slab (index n_layers) — one attention layer's rows
+    let kv_layers = c.n_layers + c.n_layer_nextn
+    s.kv_bprefix_k |> reserve(int(kv_layers))
+    s.kv_bprefix_v |> reserve(int(kv_layers))
     var krow = 0l
     var vrow = 0l
-    for (l in range64(c.n_layers)) {
+    for (l in range64(kv_layers)) {
         let src = layer_kv_source(c, l)
         if (src != l) {
             s.kv_bprefix_k |> push(s.kv_bprefix_k[src])
@@ -4237,7 +4326,7 @@ def private mm_b(var y : array<float>; t : Model; woff : int64; x : array<float>
 //! Per-layer attention pattern: with SWA on, an explicit per-layer mask (gemma4's GGUF bool array)
 //! wins; otherwise every swa_pattern-th layer (l % p == p-1) is global and the rest slide — Gemma2
 //! alternates (p=2, even layers slide), Gemma3 runs 5 local : 1 global (p=6).
-def layer_is_sliding(c : Config; l : int64) : bool => (c.sliding_window > 0l
+def layer_is_sliding(c : Config; l : int64) : bool => (c.sliding_window > 0l && l < c.n_layers
     && (c.swa_mask != 0ul ? ((c.swa_mask >> uint64(l)) & 1ul) != 0ul : l % c.swa_pattern != c.swa_pattern - 1l))
 
 // ===== Per-layer attention geometry (gemma4: sliding vs global layer classes differ) =====
@@ -4248,7 +4337,9 @@ def layer_is_sliding(c : Config; l : int64) : bool => (c.sliding_window > 0l
 def has_ple(c : Config) : bool => c.n_embd_per_layer > 0l
 
 //! Layer `l` runs the Gated-DeltaNet recurrent block instead of attention (qwen35 hybrid).
-def layer_is_recurrent(c : Config; l : int64) : bool => ((c.recr_mask >> uint64(l)) & 1ul) != 0ul
+// the l < n_layers guard is load-bearing: the MTP/NextN block sits at index n_layers, which on
+// a 64-trunk-layer model (27B) means a shift by 64 — x86 wraps that to bit 0 (a recurrent layer)
+def layer_is_recurrent(c : Config; l : int64) : bool => l < c.n_layers && ((c.recr_mask >> uint64(l)) & 1ul) != 0ul
 
 //! deltanet q/k projection width (n_group heads of d_state each).
 def dn_key_dim(c : Config) : int64 => c.ssm_n_group * c.ssm_d_state
@@ -6458,6 +6549,9 @@ def forward(t : Model; var s : Session; token, pos : int64) {
     let ts_final = ref_time_ticks()
     trace_tag(TRACE_TAG_CLS)
     rms_at(s.xb, t, t.rms_final_off, s.x, dim)
+    if (c.n_layer_nextn > 0l) {   // stash h_nextn (llama.cpp t_h_nextn) for the MTP draft head
+        copy_floats(s.xb, 0l, s.mtp_h, 0l, dim)
+    }
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
     if (c.final_logit_softcap > 0.0 && !tied_f32 && fused_cls_ok(t)) {
@@ -6482,6 +6576,207 @@ def forward(t : Model; var s : Session; token, pos : int64) {
         s.logits[id] = -1.0e30
     }
     prof_add("final", ts_final)
+}
+
+//! One MTP/NextN draft step (config.n_layer_nextn == 1): from the stashed trunk hidden `s.mtp_h`
+//! (h_p) and `token` (x_{p+1}), produce draft logits for x_{p+2} in s.logits. `pos` is the MTP
+//! KV row p — one BELOW llama.cpp's convention: their draft context ropes this row at p+1 and
+//! masks the missing row 0 by cache occupancy; our flat cache can't mask, and rotary attention
+//! is position-delta-invariant, so shifting every MTP row down by one is mathematically
+//! identical and leaves no garbage row. Overwrites s.mtp_h with the head's own h_nextn
+//! (the recursive-drafting handoff) and s.logits/s.x/s.xb scratch.
+def forward_mtp(t : Model; var s : Session; token, pos : int64; want_logits : bool = true) {
+    let c = t.config
+    let dim = c.dim
+    assert(c.n_layer_nextn > 0l)
+    kv_ensure(s, pos + 1l)
+    // eh_proj input: [enorm(embed(token)) ; hnorm(h)] — embedding first (llama.cpp concat order)
+    embed_row(t, token, unsafe(addr(s.x[0])))
+    rms_at(s.xb, t, t.mtp_enorm_off, s.x, dim)
+    copy_floats(s.xb, 0l, s.mtp_cat, 0l, dim)
+    rms_at(s.xb, t, t.mtp_hnorm_off, s.mtp_h, dim)
+    copy_floats(s.xb, 0l, s.mtp_cat, dim, dim)
+    // eh_proj: 2*dim -> dim into the residual stream (xq/xs cover 2*dim — sized max(xdim, ffw))
+    if (t.mtp_ehproj_fmt != KqFmt.q8) {
+        mm_kq(s.x, t, t.mtp_ehproj_fmt, t.mtp_ehproj_off, s.mtp_cat, s.xq, s.xs, s.xbs, 2l * dim, dim)
+    } else {
+        mm(s.x, t, t.mtp_ehproj_off, s.mtp_cat, s.xq, s.xs, 2l * dim, dim)
+    }
+    // this row's RoPE table (partial rotary span, like forward)
+    if (g_use_rope_table) {
+        build_rope_table(s.rope_cos, s.rope_sin, t, c.rope_freq_base, c.rope_freq_scale, pos, 1l,
+                         c.rope_dim > 0l ? c.rope_dim : c.head_size, true)
+    }
+    // the draft block IS one trunk-shaped attention layer at index n_layers — reuse the arch blocks
+    t.blocks.attn_decode(t, s, c.n_layers, pos)
+    t.blocks.ffn_decode(t, s, c.n_layers)
+    // warm/backfill calls only need the KV row written — the head norm + classifier (a large
+    // share of the head's cost on small models: vocab x dim) run only when drafting
+    return if (!want_logits)
+    // head norm (shared_head_norm when shipped, else output_norm) + the trunk classifier
+    rms_at(s.xb, t, t.mtp_headnorm_off >= 0l ? t.mtp_headnorm_off : t.rms_final_off, s.x, dim)
+    copy_floats(s.xb, 0l, s.mtp_h, 0l, dim)   // the head's own h_nextn — recursive drafting handoff
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
+    if (tied_f32) {
+        mm_fblob(s.logits, t, t.tok_emb_off, s.xb, dim, c.vocab_size)
+    } elif (cls_fmt != KqFmt.q8) {
+        mm_kq(s.logits, t, cls_fmt, t.wcls_off, s.xb, s.xq, s.xs, s.xbs, dim, c.vocab_size)
+    } else {
+        mm(s.logits, t, t.wcls_off, s.xb, s.xq, s.xs, dim, c.vocab_size)
+    }
+}
+
+//! Snapshot / restore the deltanet recurrent state (conv history + S + dn_pos) around a
+//! speculative verify batch: a rejected draft has already advanced the state past itself.
+//! The MTP head itself is stateless attention — only the TRUNK verify needs this. A rejected
+//! batch's KV row for the accepted token is CORRECT (its input was right); only the recurrent
+//! state rolls back, then one plain forward re-advances it.
+def mtp_state_snapshot(var s : Session) {
+    let nc = int64(length(s.dn_conv_state))
+    let ns = int64(length(s.dn_state))
+    s.mtp_snap_conv |> resize(nc)   // no-op after the first call
+    s.mtp_snap_state |> resize(ns)
+    copy_floats(s.dn_conv_state, 0l, s.mtp_snap_conv, 0l, nc)
+    copy_floats(s.dn_state, 0l, s.mtp_snap_state, 0l, ns)
+    s.mtp_snap_pos = s.dn_pos
+}
+
+def mtp_state_restore(var s : Session) {
+    copy_floats(s.mtp_snap_conv, 0l, s.dn_conv_state, 0l, int64(length(s.mtp_snap_conv)))
+    copy_floats(s.mtp_snap_state, 0l, s.dn_state, 0l, int64(length(s.mtp_snap_state)))
+    s.dn_pos = s.mtp_snap_pos
+}
+
+// After a 2-row verify forward_prefill([tok, draft], 2, pos): row 0's post-norm hidden and
+// logits (forward_prefill's own tail only produced row 1's). Reads s.x_b row 0 — still intact,
+// the prefill tail never overwrites the batch residual stream.
+def private mtp_verify_row0(t : Model; var s : Session) {
+    let c = t.config
+    let dim = c.dim
+    rms_at(s.xb, t, t.rms_final_off, s.x_b, 0l, dim)
+    copy_floats(s.xb, 0l, s.mtp_h0, 0l, dim)
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
+    if (tied_f32) {
+        mm_fblob(s.mtp_logits, t, t.tok_emb_off, s.xb, dim, c.vocab_size)
+    } elif (cls_fmt != KqFmt.q8) {
+        mm_kq(s.mtp_logits, t, cls_fmt, t.wcls_off, s.xb, s.xq, s.xs, s.xbs, dim, c.vocab_size)
+    } else {
+        mm(s.mtp_logits, t, t.wcls_off, s.xb, s.xq, s.xs, dim, c.vocab_size)
+    }
+}
+
+def private mtp_argmax(a : array<float>; n : int64) : int64 {
+    var best = 0l
+    var bestv = a[0]
+    for (i in range64(n)) {
+        if (a[i] > bestv) {
+            bestv = a[i]
+            best = i
+        }
+    }
+    return best
+}
+
+//! Greedy decode with MTP/NextN depth-1 self-speculation (config.n_layer_nextn == 1; flat KV
+//! cache only). Mirrors generate()'s contract — returns prompt[1..] echoed, then the greedy
+//! continuation, `total` ids overall — and is OUTPUT-INVARIANT vs plain greedy decode: the
+//! draft only decides whether two tokens ride one batched trunk forward (weights read once)
+//! or one token rides a plain forward after a state rollback. Accept telemetry in the returns.
+def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total : int64;
+                        var n_drafted, n_accepted : int64&) : array<int64> {
+    let c = t.config
+    assert(c.n_layer_nextn > 0l)
+    if (t.quant == QuantMode.q4) {   // no batched prefill rail: the 2-row verify (and the warm) need it
+        panic("dasLLAMA: MTP self-spec decode needs the batched prefill path — load q8 or fp32, not q4")
+    }
+    let np = int64(length(prompt))
+    var ids : array<int64>
+    if (total <= 0l || np <= 0l) {
+        return <- ids
+    }
+    ids |> reserve(total)
+    for (i in range64(1l, np)) {   // generate()'s echo convention (incl. budget + BOS delimiter)
+        if (int64(length(ids)) >= total || prompt[i] == 1l) {
+            return <- ids
+        }
+        ids |> push(prompt[i])
+    }
+    // batched trunk prefill (stashes h_{np-1}); the prompt's next token BEFORE the warm pass
+    // clobbers s.logits
+    forward_prefill(t, s, prompt, np, 0l)
+    var tok = mtp_argmax(s.logits, c.vocab_size)
+    let dim = c.dim
+    if (np > 1l) {
+        // MTP prompt warm, batched: rows 0..np-2 hold (h_p, x_{p+1}) — every position's trunk
+        // hidden is still in s.x_b, so build the np-1 eh_proj concat rows, run ONE batched
+        // eh_proj GEMM back into s.x_b (row np-1 stays untouched), then the draft block through
+        // the arch's batched prefill blocks at l = n_layers. This pass only writes the head's KV
+        // rows (no head norm / classifier), and s.mtp_h — h_{np-1}, stashed by the trunk prefill
+        // tail — deliberately survives it to feed the first draft. The trunk prefill's rope table
+        // ([0, np) at start_pos 0) and batch scratch (sized for np rows) cover the np-1-row pass.
+        s.mtp_cat_b |> scratch_resize((np - 1l) * 2l * dim)
+        for (p in range64(np - 1l)) {
+            embed_row(t, prompt[p + 1l], unsafe(addr(s.x[0])))
+            rms_at(s.xb, t, t.mtp_enorm_off, s.x, dim)
+            copy_floats(s.xb, 0l, s.mtp_cat_b, p * 2l * dim, dim)
+            rms_at(s.xb, t, t.rms_final_off, s.x_b, p * dim, dim)   // h_p
+            copy_floats(s.xb, 0l, s.mtp_h0, 0l, dim)
+            rms_at(s.xb, t, t.mtp_hnorm_off, s.mtp_h0, dim)
+            copy_floats(s.xb, 0l, s.mtp_cat_b, p * 2l * dim + dim, dim)
+        }
+        mm_b_f(s, s.x_b, t, t.mtp_ehproj_fmt, t.mtp_ehproj_off, s.mtp_cat_b, 2l * dim, dim, np - 1l)
+        t.blocks.attn_prefill(t, s, c.n_layers, np - 1l, 0l)
+        t.blocks.ffn_prefill(t, s, c.n_layers, np - 1l)
+    }
+    var htmp : array<float>
+    htmp |> resize(dim)
+    var pos = np
+    n_drafted = 0l
+    n_accepted = 0l
+    var vbatch : array<int64>
+    vbatch |> resize(2)
+    while (int64(length(ids)) < total) {
+        break if (tok == 1l)   // BOS delimits sequences (generate()'s contract)
+        ids |> push(tok)
+        break if (int64(length(ids)) >= total)
+        // draft x_{pos+1} from (h_{pos-1}, tok) at row pos-1
+        forward_mtp(t, s, tok, pos - 1l)
+        let d = mtp_argmax(s.logits, c.vocab_size)
+        n_drafted++
+        // batched verify: trunk over [tok@pos, d@pos+1] — weights stream once for both rows
+        mtp_state_snapshot(s)
+        vbatch[0] = tok
+        vbatch[1] = d
+        forward_prefill(t, s, vbatch, 2l, pos)
+        mtp_verify_row0(t, s)
+        let truth = mtp_argmax(s.mtp_logits, c.vocab_size)
+        if (truth == d) {
+            n_accepted++
+            break if (d == 1l)   // BOS: generate() stops before emitting it — mirror that
+            // both rows commit: emit d, take the continuation from row 1's logits.
+            // Backfill MTP row pos with the pair (h_pos = mtp_h0, d) — preserve row 1's h first.
+            copy_floats(s.mtp_h, 0l, htmp, 0l, c.dim)
+            copy_floats(s.mtp_h0, 0l, s.mtp_h, 0l, c.dim)
+            let next = mtp_argmax(s.logits, c.vocab_size)
+            forward_mtp(t, s, d, pos, false)   // KV backfill only — no draft here
+            copy_floats(htmp, 0l, s.mtp_h, 0l, c.dim)
+            ids |> push(d)
+            tok = next
+            pos += 2l
+        } else {
+            // reject: the accepted row's KV is already correct; roll the recurrent state back
+            // and re-advance it through tok alone (also re-stashes h_pos for the next draft)
+            mtp_state_restore(s)
+            forward(t, s, tok, pos)
+            tok = truth
+            pos++
+        }
+    }
+    delete htmp
+    delete vbatch
+    return <- ids
 }
 
 // ----- forward section profiler (decode AND prefill feed the same buckets) -----
@@ -9081,6 +9376,9 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     let ts_final = ref_time_ticks()
     let last = npos - 1l
     rms_at(s.xb, t, t.rms_final_off, s.x_b, last * dim, dim)
+    if (c.n_layer_nextn > 0l) {   // stash the last position's h_nextn for the MTP draft head
+        copy_floats(s.xb, 0l, s.mtp_h, 0l, dim)
+    }
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
     if (c.final_logit_softcap > 0.0 && !tied_f32 && fused_cls_ok(t)) {

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -6592,6 +6592,9 @@ def forward_mtp(t : Model; var s : Session; token, pos : int64; want_logits : bo
     let c = t.config
     let dim = c.dim
     assert(c.n_layer_nextn > 0l)
+    if (s.kv_pool != null) {   // paged pools size blob_of for trunk layers only — flat sessions only (v1)
+        panic("dasLLAMA: forward_mtp needs a flat-KV session — the paged pool has no slab for the draft block")
+    }
     kv_ensure(s, pos + 1l)
     // eh_proj input: [enorm(embed(token)) ; hnorm(h)] — embedding first (llama.cpp concat order)
     embed_row(t, token, unsafe(addr(s.x[0])))
@@ -6693,6 +6696,9 @@ def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total
     assert(c.n_layer_nextn > 0l)
     if (t.quant == QuantMode.q4) {   // no batched prefill rail: the 2-row verify (and the warm) need it
         panic("dasLLAMA: MTP self-spec decode needs the batched prefill path — load q8 or fp32, not q4")
+    }
+    if (s.kv_pool != null) {   // paged pools size blob_of for trunk layers only — flat sessions only (v1)
+        panic("dasLLAMA: MTP self-spec decode needs a flat-KV session — the paged pool has no slab for the draft block")
     }
     let np = int64(length(prompt))
     var ids : array<int64>

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -6674,6 +6674,14 @@ def private mtp_verify_row0(t : Model; var s : Session) {
     } else {
         mm(s.mtp_logits, t, t.wcls_off, s.xb, s.xq, s.xs, dim, c.vocab_size)
     }
+    // mirror the plain classifier tail exactly — `truth` is the invariance contract's load-bearing
+    // edge, so it must match plain decode BY CONSTRUCTION (inert on qwen35: no softcap, no suppress)
+    if (c.final_logit_softcap > 0.0) {
+        softcap4(s.mtp_logits, c.vocab_size, c.final_logit_softcap)
+    }
+    for (id in t.suppress) {
+        s.mtp_logits[id] = -1.0e30
+    }
 }
 
 //! Greedy decode with MTP/NextN depth-1 self-speculation (config.n_layer_nextn == 1; flat KV

--- a/modules/dasLLAMA/performance/gen_profile.das
+++ b/modules/dasLLAMA/performance/gen_profile.das
@@ -1,5 +1,5 @@
 options gen2
-options stack = 65536   // the forward/prefill chain + generated kernels need more than the 16K default on arm64
+options stack = 524288   // the forward/prefill chain needs more than the 16K default; the 122B/Coder-Next hybrid eval frames outgrew the old 64K (scratch probes needed 512K)
 options _jit_fast_math = true   // ggml-parity FP laxity (non-bit-exact, ~+10%); the profile is a speed measurement
 
 // The das-side half of the profiling suite: for each tier-selected model it measures prefill (one

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -110,8 +110,18 @@ def llm_catalog() : array<LlmModel> {
         LlmModel(file="gemma-4-E4B-it-Q8_0.gguf", display="gemma-4-E4B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
         LlmModel(file="Meta-Llama-3.1-8B-Instruct-Q8_0.gguf", display="Llama-3.1-8B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
         LlmModel(file="gpt-oss-20b-mxfp4.gguf", display="gpt-oss-20b", quant=QuantMode.q8, quant_label="mxfp4", prefill_ctx=512, emission_ctx=128),
+        LlmModel(file="gemma-4-26B-A4B-it-Q8_0.gguf", display="gemma-4-26B-A4B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
         LlmModel(file="Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf", display="Qwen3-30B-A3B", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
-        LlmModel(file="Qwen3.6-35B-A3B-UD-Q4_K_M.gguf", display="Qwen3.6-35B-A3B", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128)
+        LlmModel(file="Qwen3.6-35B-A3B-UD-Q4_K_M.gguf", display="Qwen3.6-35B-A3B", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
+        LlmModel(file="Qwen3-Coder-30B-A3B-Instruct-Q8_0.gguf", display="Qwen3-Coder-30B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
+        LlmModel(file="Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf", display="Qwen3-Coder-30B-q4k", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
+        LlmModel(file="Qwen3-Coder-Next-Q8_0.gguf", display="Qwen3-Coder-Next", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
+        LlmModel(file="Qwen3-Coder-Next-Q4_K_M.gguf", display="Qwen3-Coder-Next-q4k", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
+        // split GGUFs: any shard path loads both sides (das gguf_shard_paths normalizes; llama.cpp
+        // reads siblings natively) — shard 1 is metadata-only (~10MB), so use -t all + --only, never
+        // the size tier gate, to select these
+        LlmModel(file="Qwen3.5-122B-A10B/Q8_0/Qwen3.5-122B-A10B-Q8_0-00001-of-00004.gguf", display="Qwen3.5-122B-A10B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
+        LlmModel(file="Qwen3.5-122B-A10B/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf", display="Qwen3.5-122B-A10B-q4k", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128)
     ]
 }
 

--- a/site/dasllama.html
+++ b/site/dasllama.html
@@ -5,7 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>dasLLAMA — CPU inference benchmarks · daslang</title>
     <meta name="description" content="dasLLAMA — a CPU LLM + speech-to-text inference engine written in daslang and JIT-compiled. Measured CPU-only benchmarks vs llama.cpp, whisper.cpp, parakeet, ONNX-Runtime and NeMo, on Apple M1 and AMD Threadripper." />
-    <meta name="keywords" content="daslang, dasLLAMA, llama.cpp, CPU inference, LLM benchmark, whisper, parakeet, speech to text, ASR" />
+    <meta name="keywords" content="daslang, dasLLAMA, llama.cpp, CPU inference, local LLM, LLM benchmark, whisper, parakeet, speech to text, ASR, omni model" />
+    <link rel="canonical" href="https://daslang.io/dasllama.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://daslang.io/dasllama.html" />
+    <meta property="og:site_name" content="daslang" />
+    <meta property="og:title" content="dasLLAMA — local LLMs with audio in, up to 6× faster on CPU" />
+    <meta property="og:description" content="A CPU LLM + speech-to-text stack written in daslang, JIT-compiled. Auto-tuned kernels beat llama.cpp's on most LLMs; audio/omni workloads run up to ~6× faster. Measured CPU-only benchmarks, methodology included." />
+    <meta name="twitter:card" content="summary" />
 
     <link rel="icon" type="image/svg+xml" href="files/daslang-favicon.svg" />
     <link rel="alternate icon" type="image/x-icon" href="files/daslang.ico" />
@@ -186,22 +193,23 @@
         <div class="forge-container forge-hero__grid">
             <div>
                 <span class="dl-hero__badge"><span class="dot"></span>dasLLAMA · CPU inference</span>
-                <h1>A scripting language that <em>holds its own on CPU.</em></h1>
+                <h1>Local LLMs with audio in — <em>up to 6× faster on CPU.</em></h1>
                 <p class="forge-hero__lede">
                     dasLLAMA is an LLM + speech-to-text stack written entirely in daslang and
-                    JIT-compiled — no hand-written assembly. These are CPU-only comparisons. llama.cpp
-                    is a broader, more mature engine with GPU backends we don't try to match; on the
-                    CPU path alone, das is ahead on prompt processing across the board and trades
-                    blows on generation.
+                    JIT-compiled — no hand-written assembly. Its auto-tuned JIT kernels consistently
+                    outperform llama.cpp's hand-written universal kernels — up to 30% faster on most
+                    LLMs — and the advantage grows with batching and with audio input (Whisper,
+                    Parakeet) or omni models (Gemma, Qwen), reaching ~6× llama.cpp. CPU-only
+                    comparisons; llama.cpp's GPU backends are out of scope here.
                 </p>
                 <div class="forge-hero__ctas">
                     <a class="forge-btn-primary" href="#llm">$ view the scoreboard →</a>
                     <a class="forge-btn-secondary" href="#method">methodology</a>
                 </div>
                 <div class="forge-stats">
-                    <div class="forge-stat"><div class="forge-stat__n" id="stat-prefill-n">up to 1.69×</div><div class="forge-stat__l" id="stat-prefill-l">LLM prefill vs llama.cpp · gemma-4 E4B, M1</div></div>
-                    <div class="forge-stat"><div class="forge-stat__n" id="stat-wins-n">35 / 36</div><div class="forge-stat__l" id="stat-wins-l">runs das ≥ llama.cpp · 18 models × both phases, 3990X</div></div>
-                    <div class="forge-stat"><div class="forge-stat__n" id="stat-audio-n">~5×</div><div class="forge-stat__l">Qwen3-Omni audio vs mtmd, CPU-only (M1)</div></div>
+                    <div class="forge-stat"><div class="forge-stat__n" id="stat-prefill-n">up to 1.74×</div><div class="forge-stat__l" id="stat-prefill-l">LLM prefill vs llama.cpp · gpt-oss-20b, Apple M1 Max</div></div>
+                    <div class="forge-stat"><div class="forge-stat__n" id="stat-wins-n">40 / 42</div><div class="forge-stat__l" id="stat-wins-l">runs das ≥ llama.cpp · 21 models × both phases, 3990X</div></div>
+                    <div class="forge-stat"><div class="forge-stat__n" id="stat-audio-n">~6×</div><div class="forge-stat__l">Qwen3-Omni audio vs mtmd, CPU-only (M1)</div></div>
                 </div>
             </div>
 

--- a/site/google2cfdec88941bbdfc.html
+++ b/site/google2cfdec88941bbdfc.html
@@ -1,0 +1,1 @@
+google-site-verification: google2cfdec88941bbdfc.html

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
 
+Sitemap: https://daslang.io/sitemap.xml
 Sitemap: https://daslang.io/doc/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Root-level pages. The Sphinx docs ship their own sitemap at /doc/sitemap.xml;
+     both are referenced from robots.txt. -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>https://daslang.io/</loc></url>
+    <url><loc>https://daslang.io/dasllama.html</loc></url>
+    <url><loc>https://daslang.io/daspkg.html</loc></url>
+    <url><loc>https://daslang.io/downloads.html</loc></url>
+    <url><loc>https://daslang.io/examples.html</loc></url>
+    <url><loc>https://daslang.io/changelist.html</loc></url>
+</urlset>

--- a/skills/writing_tests.md
+++ b/skills/writing_tests.md
@@ -51,6 +51,20 @@ still calls jitted workers). Beware Release-blind divergence: memory bugs (doubl
 reuse-after-collect) only trip the Debug memory_model.h assert, so a green local Release
 sweep does NOT prove a lifted skip is sound — Debug CI is the oracle.
 
+## Deep-engine model tests (dasLLAMA and friends)
+
+Two hard-won rules for tests that drive a deep JIT engine chain (`forward`/`forward_prefill`/
+`generate`):
+
+1. **The test file is the program root under dastest**, so `options stack = 524288` in the test
+   file DOES apply (the "main-module-only" rule works in your favor). Without it, driving the
+   engine directly trips `stack overflow` deep in the module (reported at some engine function's
+   entry line).
+2. **Keep heavy helpers free of `T?`** — a `T?` param keeps the helper off the JIT (dastest's
+   class), so its engine calls run on the interpreter stack. Structure like `test_parity.das`:
+   plain private functions do the model work and return values/arrays; the `[test]` run-lambda
+   only asserts. (`tests/dasLLAMA/test_mtp.das` hit both failure modes before landing on this.)
+
 ## Test file structure
 
 ```das

--- a/tests/dasLLAMA/test_mtp.das
+++ b/tests/dasLLAMA/test_mtp.das
@@ -1,0 +1,250 @@
+options gen2
+options stack = 524288   // the forward/prefill chain outgrows the 16K default when driven directly (the probes' value); the test file is the program root under dastest, so the option applies
+options persistent_heap   // + explicit deletes below: each test frees its model/session before the next loads, so multi-GB weights never accumulate in the process
+
+require dastest/testing_boost public
+require dasllama/dasllama   // the public facade — engine + arch registrations (incl. forward_mtp / generate_mtp_greedy)
+require dasllama/dasllama_math   // parallel_argmax (engine-level, not re-exported by the facade)
+require daslib/jobque_boost
+require daslib/fio
+require _model_tier   // models_dir() + model_available() presence/size-tier gate (see the file's header)
+
+// MTP/NextN self-speculative decode gates, on the qwen35-family -MTP- GGUFs (the files ship one
+// extra trunk-shaped draft block at layer index n_layers plus nextn.{eh_proj,enorm,hnorm,...}).
+// Three layers of gate, mirroring how the feature was proven in:
+//   1. loader: nextn extras load, and with spec OFF the trunk continues the fixture EXACTLY like
+//      the plain (non-MTP) file — trunk equality was proven via llama.cpp simple_ids on both files;
+//   2. output-invariance: generate_mtp_greedy() == generate() token-for-token — greedy self-spec
+//      changes wall time, never tokens (accept path reads batch-kernel logits, so this holds only
+//      under the PINNED bit-exact kernels, same reasoning as test_parity's parity_gen_ok);
+//   3. rollback: a poisoned 2-row verify batch + mtp_state_restore replays plain decode exactly
+//      (the deltanet conv+S state is the only thing a rejected draft leaves behind — KV rows get
+//      overwritten by construction).
+// The GGUFs are gitignored multi-GB files, so each case skips cleanly when its model is absent.
+
+// Qwen3.5-0.8B word-counting fixture: "Count from one to twenty: one, two, three," and its greedy
+// 40-token continuation (" four, five, ... twenty.\nCount from one to twenty"). Frozen from
+// llama.cpp simple_ids on the PLAIN Qwen3.5-0.8B-Q8_0 file; simple_ids on the -MTP- file produced
+// the identical PROMPT+GEN ids, so this single fixture gates the loader AND trunk equality of the
+// MTP conversion. Confident list momentum — near-tie-free under the pinned kernels.
+let MTP_PROMPT <- [2427l, 494l, 799l, 310l, 16570l, 25l, 799l, 11l, 1330l, 11l, 2250l, 11l]
+let MTP_WANT <- [2943l, 11l, 4097l, 11l, 4590l, 11l, 7840l, 11l, 7810l, 11l, 11292l, 11l, 5600l, 11l,
+                 42744l, 11l, 28279l, 11l, 58614l, 11l, 60163l, 11l, 35442l, 11l, 56091l, 11l, 78592l,
+                 11l, 59942l, 11l, 90600l, 11l, 16570l, 13l, 198l, 2427l, 494l, 799l, 310l, 16570l]
+
+def private same(a, b : array<int64>) : bool {
+    if (length(a) != length(b)) {
+        return false
+    }
+    for (i in range(length(a))) {
+        if (a[i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+// Pin the bit-exact kernel modes around `body` and restore the previous modes — classic prefill
+// attention (not flash), scalar libm activations (not exp4), per-token recurrent deltanet prefill
+// (not chunked). Token-exact gates must not ride near-tie kernel variance; see parity_gen_ok.
+def private with_pinned_kernels(body : block) {
+    let prev_attn = get_prefill_attn_mode()
+    set_prefill_attn_mode(AttnPrefillMode.classic)
+    let prev_act = get_act_vec()
+    set_act_vec(false)
+    let prev_dn = get_deltanet_prefill_mode()
+    set_deltanet_prefill_mode(DnPrefillMode.recurrent)
+    invoke(body)
+    set_prefill_attn_mode(prev_attn)
+    set_act_vec(prev_act)
+    set_deltanet_prefill_mode(prev_dn)
+}
+
+// Plain greedy reference over one fresh session (generate()'s echo contract: prompt[1..] then the
+// continuation).
+def private gen_plain(tr : Model; prompt : array<int64>; total : int) : array<int64> {
+    var out : array<int64>
+    with_job_que() {
+        setup_dasllama_jobque()
+        var s = make_run_state(tr.config)
+        out <- generate(tr, s, prompt, total)
+        delete s
+    }
+    return <- out
+}
+
+// Depth-1 self-spec greedy over one fresh session; accept telemetry lands in nd/na.
+def private gen_spec(tr : Model; prompt : array<int64>; total : int; var nd, na : int64&) : array<int64> {
+    var out : array<int64>
+    with_job_que() {
+        setup_dasllama_jobque()
+        var s = make_run_state(tr.config)
+        out <- generate_mtp_greedy(tr, s, prompt, int64(total), nd, na)
+        delete s
+    }
+    return <- out
+}
+
+// Spec-off pinned generate-and-compare (parity_gen_ok's shape). Helpers like this stay plain
+// functions on purpose: they JIT-compile, so the deep forward chain runs on the native stack —
+// calling the engine from the [test] run-lambda's interpreted frame overflows its 16K das stack.
+def private specoff_gen_ok(tr : Model; prompt, want : array<int64>) : bool {
+    var ok = false
+    with_job_que() {
+        setup_dasllama_jobque()
+        var s = make_run_state(tr.config)
+        let ids <- generate(tr, s, prompt, length(prompt) + length(want))
+        let echo = length(prompt) - 1
+        let got <- [for (i in range(length(want))); ids[echo + i]; where echo + i < length(ids)]
+        ok = same(got, want)
+        delete s
+    }
+    return ok
+}
+
+// The forced-reject rollback sequence (see test_mtp_reject_rollback for the WHY): returns the
+// tokens decoded after the poisoned-verify rollback (first = the prefill argmax) and fills
+// `want` with the plain-decode reference slice they must equal. Free of T? like specoff_gen_ok —
+// a T? param keeps the helper off the JIT, and the engine chain overflows the interpreter stack.
+def private reject_rollback_ids(tr : Model; n_check : int64; var want : array<int64>) : array<int64> {
+    var got : array<int64>
+    with_job_que() {
+        setup_dasllama_jobque()
+        let np = int64(length(MTP_PROMPT))
+        // plain-decode reference (echo convention: ids[np-1] is the first generated token)
+        var s1 = make_run_state(tr.config)
+        let ref_ids <- generate(tr, s1, MTP_PROMPT, int(np + n_check + 1l))
+        delete s1
+        want <- [for (i in range64(n_check + 1l)); ref_ids[np - 1l + i]]
+        var s = make_run_state(tr.config)
+        forward_prefill(tr, s, MTP_PROMPT, np, 0l)
+        let tok = parallel_argmax(s.logits, tr.config.vocab_size)
+        got |> push(tok)
+        mtp_state_snapshot(s)
+        var vbatch <- [tok, 42l]   // 42 = arbitrary garbage draft
+        forward_prefill(tr, s, vbatch, 2l, np)
+        mtp_state_restore(s)
+        forward(tr, s, tok, np)   // re-advance through the accepted token alone
+        var pos = np + 1l
+        for (_i in range64(n_check)) {
+            let next = parallel_argmax(s.logits, tr.config.vocab_size)
+            got |> push(next)
+            forward(tr, s, next, pos)
+            pos++
+        }
+        delete s
+        delete vbatch
+    }
+    return <- got
+}
+
+// Run the plain-vs-spec invariance pair on a loaded model and assert token-for-token equality
+// plus sane accept telemetry. `tag` distinguishes the arms in the report.
+def private invariance_ok(t : T?; tr : Model; prompt : array<int64>; n_gen : int; tag : string) {
+    let total = length(prompt) + n_gen
+    let ref_ids <- gen_plain(tr, prompt, total)
+    var nd = 0l
+    var na = 0l
+    let spec_ids <- gen_spec(tr, prompt, total, nd, na)
+    t |> success(same(ref_ids, spec_ids), "{tag}: spec decode token-for-token vs plain")
+    t |> success(nd > 0l, "{tag}: the draft head actually drafted ({nd} drafts)")
+}
+
+[test]
+def test_mtp_loader(t : T?) {
+    t |> run("MTP/NextN loader (Qwen3.5-0.8B-MTP Q8): nextn extras + spec-off trunk parity") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3.5-0.8B-MTP-Q8_0.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_gguf(path, QuantMode.q8)
+        // block_count INCLUDES the draft block: n_layers stays the trunk count, nextn rides extra
+        t |> equal(tr.config.n_layer_nextn, 1l)
+        t |> equal(tr.config.n_layers, 24l)
+        t |> success(tr.mtp_ehproj_off >= 0l && tr.mtp_enorm_off >= 0l && tr.mtp_hnorm_off >= 0l,
+                     "nextn eh_proj/enorm/hnorm loaded")
+        t |> success(tr.mtp_headnorm_off >= 0l, "nextn shared_head_norm loaded (qwen35 MTP files ship it)")
+        tr.config.seq_len = 2048l
+        // spec OFF: the -MTP- file's trunk must continue the fixture exactly like the plain file
+        with_pinned_kernels() {
+            t |> success(specoff_gen_ok(tr, MTP_PROMPT, MTP_WANT), "spec-off token-for-token vs the plain-file oracle")
+        }
+        delete tr
+    }
+}
+
+[test]
+def test_mtp_output_invariance(t : T?) {
+    t |> run("MTP self-spec greedy decode is output-invariant (Qwen3.5-0.8B-MTP Q8)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3.5-0.8B-MTP-Q8_0.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_model(path, QuantMode.q8)   // load_model: the prose arm encodes in-test
+        tr.config.seq_len = 2048l
+        with_pinned_kernels() {
+            // the counting fixture is accept-heavy: exercises the 2-row batched accept path + backfill
+            t |> invariance_ok(tr, MTP_PROMPT, 48, "counting")
+            // prose is reject-heavier: exercises rollback + single-token re-advance mid-loop
+            let prose <- encode(tr, "Once upon a time, there was a", true, false)
+            t |> invariance_ok(tr, prose, 40, "prose")
+        }
+        delete tr
+    }
+}
+
+[test]
+def test_mtp_reject_rollback(t : T?) {
+    t |> run("MTP rollback: poisoned 2-row verify + restore replays plain decode exactly") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3.5-0.8B-MTP-Q8_0.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_gguf(path, QuantMode.q8)
+        tr.config.seq_len = 2048l
+        // manual reject flow, exactly as generate_mtp_greedy's reject arm runs it: the draft is
+        // a fixed garbage token, so the verify batch advances the deltanet state past a WRONG
+        // row; restore + one plain forward must leave the state bit-identical to never having
+        // seen the poisoned batch — every subsequent plain-decode token must match a reference
+        // run. (Truth vs draft isn't even compared — an unconditional reject is the hardest
+        // case, and the KV row the poisoned batch wrote at np+1 gets overwritten by the next
+        // decode, by construction.)
+        with_pinned_kernels() {
+            var want : array<int64>
+            let got <- reject_rollback_ids(tr, 6l, want)
+            t |> success(same(got, want), "post-rollback decode token-for-token vs plain")
+        }
+        delete tr
+    }
+}
+
+// Qwen3.6-27B-MTP Q8 — the 64-trunk-layer carrier: its draft block sits at layer index 64, the
+// exact index where the pre-fix per-layer masks wrapped (mask >> 64 == mask >> 0 on x86) — this
+// arm regresses that whole bug class (layer_is_recurrent / layer_is_sliding / wv_offs guards)
+// besides being the model the feature is FOR (1.39x decode when frozen). Large tier (~25 GB):
+// DASLLAMA_PARITY_FULL=1.
+[test]
+def test_mtp_invariance_27b(t : T?) {
+    t |> run("MTP self-spec output-invariance (Qwen3.6-27B-MTP Q8, draft block at layer 64)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "Qwen3.6-27B-MTP-Q8_0.gguf")
+        if (!model_available(t, path)) return
+        var tr <- load_gguf(path, QuantMode.q8)
+        t |> equal(tr.config.n_layer_nextn, 1l)
+        t |> equal(tr.config.n_layers, 64l)
+        tr.config.seq_len = 2048l
+        with_pinned_kernels() {
+            t |> invariance_ok(tr, MTP_PROMPT, 48, "counting-27b")
+        }
+        delete tr
+    }
+}


### PR DESCRIPTION
dasLLAMA: MTP/NextN self-speculative decode for the qwen35 family — native `-MTP-` GGUF loading, depth-1 greedy self-spec, batched prompt warm, `test_mtp` gates.

## What

- **Loader (Stage 1)**: `-MTP-` GGUFs load natively instead of panicking. `{arch}.nextn_predict_layers` is parsed (only `1` supported — chain-head archs panic honestly); `block_count` includes the draft block, so `n_layers` stays the trunk count everywhere and the NextN block rides every per-layer walk (layout, kq detection, both repack walkers, KV prefixes, big-weight loads) as one extra trunk-shaped attention layer at index `n_layers`. The nextn extras (`eh_proj` quant plane + `enorm`/`hnorm`/`shared_head_norm` f32) get their own slots; metadata↔tensor-directory consistency, `mtp_only` sidecars, and per-head `embed_tokens`/`shared_head_head` all fail closed.
- **Self-spec decode (Stage 2)**: `forward_mtp` (concat `[enorm(embed(tok)); hnorm(h)]` → `eh_proj` → the arch's own `attn_decode`/`ffn_decode` at `l = n_layers` → head norm → trunk classifier) + `generate_mtp_greedy` — draft one token, verify with a 2-row batched trunk `forward_prefill` (weights stream once for both rows), emit two on accept / roll back the DeltaNet state and re-advance on reject. Mirrors `generate()`'s echo/BOS contract; q4 mode panics (no batched-prefill rail).
- **Row-shift convention**: MTP KV row `p` holds the pair `(h_p, x_{p+1})` roped at `p` — llama.cpp ropes it at `p+1` in a separate draft context whose occupancy mask hides the missing row 0; a flat cache can't mask, and rotary attention is position-delta-invariant, so the −1 shift is mathematically identical with no garbage row.
- **Batched prompt warm**: the MTP head's prompt KV (rows `0..np-2`) is built with one batched `eh_proj` GEMM off the trunk prefill's still-intact `s.x_b` + the arch's batched `attn_prefill`/`ffn_prefill` blocks at `l = n_layers` — no per-row decode-shaped head steps on long prompts.
- **DeltaNet rollback**: the MTP head itself is stateless attention; only the trunk's 2-row verify advances the recurrent conv+S state past a rejected draft, so `mtp_state_snapshot`/`mtp_state_restore` bracket each verify (~63 MB ≈ 3%/step on 35B; the accepted row's KV from the verify batch is already correct).

## Bugs fixed en route (the 27B/64-trunk-layer fixture flushed a shift-wrap class)

- `mask >> uint64(l)` at `l = n_layers = 64` wraps to bit 0 on x86 — fixed in `layer_is_recurrent`, `layer_is_sliding`, and the `wv_offs` walk's V-from-K read (was a matmul at `woff = -1`).
- V-from-K detection no longer collects recurrent layers (they legitimately have no `attn_v`).
- `make_run_state` now explicitly guarantees the quant scratch covers the `2*dim` eh_proj activation (35B-A3B's `qd == 2*dim` was luck, not a guarantee).

## Measured (zen2, 16T pinned, counting fixture, N_GEN=64)

| Model | decode speedup | accept |
|---|---|---|
| Qwen3.6-27B-MTP Q8 | **1.39× (1.86 → 2.59 tok/s)** | 31/33 |
| Qwen3.5-4B-MTP Q8 | 1.11× | 31/34 |
| Qwen3.5-0.8B-MTP Q8 | 0.92× (248k-vocab classifier dwarfs the trunk — structural) | 31/33 |

Output-invariance (spec ids == plain greedy ids) holds on all three.

## Tests — `tests/dasLLAMA/test_mtp.das` (model-gated self-skip)

- **Loader gate**: nextn fields load; spec-off pinned-kernel generate reproduces the plain-file oracle token-for-token (trunk equality was proven via llama.cpp `simple_ids` on both files — identical PROMPT+GEN ids).
- **Output-invariance**: `generate_mtp_greedy` == `generate` token-for-token under the pinned bit-exact kernels, on the counting fixture (accept-heavy) and a prose prompt (reject-heavier).
- **Forced-reject rollback**: a poisoned 2-row verify (garbage draft) + `mtp_state_restore` + one plain forward replays plain decode exactly for the following tokens.
- **27B large-tier arm** (`DASLLAMA_PARITY_FULL=1`): invariance on the 64-trunk-layer carrier — the exact index where the shift-wrap class lived.

Full `tests/dasLLAMA` suite green (464 tests: 422 pass, 0 fail, 41 model-gated skips; one environmental 1200s timeout on `test_whisper` under a busy box reproduced clean solo — 35/35 in 88s).

## Bundled (separate commits)

- **README rework** (user-facing opening: OpenAI-compatible server first in quick start, supported-family summary, layout-tree staleness fixes) + `skills/writing_tests.md` deep-engine test notes.
- **Profiling catalog rows** for gemma-4-26B-A4B / Coder-30B / Coder-Next / 122B splits + `gen_profile` stack 64K→512K (catalog only — measured rows wait for a clean quiet-box run).
- **site/dasllama.html**: new factual hero ("Local LLMs with audio in — up to 6× faster on CPU."), refreshed stat fallbacks, and SEO — the page wasn't indexed: new root `sitemap.xml`, second `Sitemap:` line in `robots.txt`, `rel=canonical` + OpenGraph tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
