### PR TITLE
pages: deploy sitemap.xml + the Search Console token

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -345,6 +345,8 @@ jobs:
         cp site/examples.html _site/
         cp site/dasllama.html _site/
         cp site/robots.txt _site/
+        cp site/sitemap.xml _site/
+        cp site/google2cfdec88941bbdfc.html _site/   # Search Console ownership token — must stay deployed
         cp -r site/files _site/files
 
         # Cross-origin isolation worker — must sit at site root so its scope (/) can


### PR DESCRIPTION
The Pages staging step cherry-picks site/ files by name, so the two files #3469 added (root sitemap.xml + the GSC ownership token) never reached _site/ — the token 404'd and Search Console verification failed. Two cp lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)