### PR TITLE
ci: drop the windows/32/Debug matrix cell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,13 @@ jobs:
           - target: windows
             architecture: arm64 # todo https://github.com/actions/partner-runner-images/tree/main?tab=readme-ov-file#available-images
 
+          # win32 Debug outgrew its test budgets (the interpreter sweep double-times-out at
+          # 1800s + 5400s on master's own scheduled runs, ~2.5h wall before failing) and the
+          # 32-bit rail is legacy — win32 Release stays as the 32-bit compile+test gate.
+          - target: windows
+            architecture: 32
+            cmake_preset: Debug
+
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4


### PR DESCRIPTION
The lane's interpreter sweep double-times-out (1800s, then the isolated retry at 5400s — ~2.5h wall before failing) on master's own scheduled runs, e.g. last night's cron on 49845f340. It has outgrown its budgets and the 32-bit rail is legacy; win32 Release stays as the 32-bit compile+test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)