### PR TITLE
dasllama site: fresh zen2 scoreboard (28 models), Threadripper default tab, hero copy

### DIFF
--- a/site/dasllama.html
+++ b/site/dasllama.html
@@ -67,7 +67,7 @@
 
   /* diverging ratio bars (LLM) */
   .dl-bars { display: flex; flex-direction: column; gap: 7px; }
-  .dl-bar { display: grid; grid-template-columns: 150px 1fr 58px; align-items: center; gap: 14px; }
+  .dl-bar { display: grid; grid-template-columns: 172px 1fr 58px; align-items: center; gap: 14px; }
   .dl-bar__label { font-family: var(--font-mono); font-size: 12px; color: var(--fg-dim); text-align: right; }
   .dl-bar__track { position: relative; height: 20px; background: var(--bg-2); border: 1px solid var(--rule); border-radius: 4px; }
   .dl-bar__center { position: absolute; left: 50%; top: -3px; bottom: -3px; width: 1px; background: var(--fg-faint); opacity: 0.7; }
@@ -80,7 +80,7 @@
   .dl-bar--tie .dl-bar__fill { background: var(--fg-faint); }
   .dl-bar--tie .dl-bar__val { color: var(--fg-dim); }
   .dl-caption { font-family: var(--font-mono); font-size: 12px; color: var(--fg-dim); margin-top: 18px; }
-  .dl-axis { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); margin: 10px 0 0; padding: 0 58px 0 150px; }
+  .dl-axis { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); margin: 10px 0 0; padding: 0 58px 0 172px; }
 
   .dl-win { color: var(--amber); }
   .dl-loss { color: var(--fg-dim); }
@@ -208,7 +208,7 @@
                 </div>
                 <div class="forge-stats">
                     <div class="forge-stat"><div class="forge-stat__n" id="stat-prefill-n">up to 1.74×</div><div class="forge-stat__l" id="stat-prefill-l">LLM prefill vs llama.cpp · gpt-oss-20b, Apple M1 Max</div></div>
-                    <div class="forge-stat"><div class="forge-stat__n" id="stat-wins-n">40 / 42</div><div class="forge-stat__l" id="stat-wins-l">runs das ≥ llama.cpp · 21 models × both phases, 3990X</div></div>
+                    <div class="forge-stat"><div class="forge-stat__n" id="stat-wins-n">54 / 56</div><div class="forge-stat__l" id="stat-wins-l">runs das ≥ llama.cpp · 28 models × both phases, 3990X</div></div>
                     <div class="forge-stat"><div class="forge-stat__n" id="stat-audio-n">~6×</div><div class="forge-stat__l">Qwen3-Omni audio vs mtmd, CPU-only (M1)</div></div>
                 </div>
             </div>
@@ -260,8 +260,8 @@ def main() {
             <div class="dl-toggles">
                 <span class="dl-seg__caption">machine</span>
                 <div class="dl-seg">
-                    <button class="js-llm-box is-active" data-box="m1" type="button">Apple M1 Max</button>
-                    <button class="js-llm-box" data-box="zen2" type="button">Threadripper 3990X</button>
+                    <button class="js-llm-box" data-box="m1" type="button">Apple M1 Max</button>
+                    <button class="js-llm-box is-active" data-box="zen2" type="button">Threadripper 3990X</button>
                 </div>
                 <span class="dl-seg__caption">phase</span>
                 <div class="dl-seg">
@@ -300,8 +300,8 @@ def main() {
             <div class="dl-toggles">
                 <span class="dl-seg__caption">machine</span>
                 <div class="dl-seg">
-                    <button class="js-asr-box is-active" data-box="m1" type="button">Apple M1 Max</button>
-                    <button class="js-asr-box" data-box="zen2" type="button">Threadripper 3990X</button>
+                    <button class="js-asr-box" data-box="m1" type="button">Apple M1 Max</button>
+                    <button class="js-asr-box is-active" data-box="zen2" type="button">Threadripper 3990X</button>
                 </div>
             </div>
 

--- a/site/files/dasllama/profile_llm_zen2.json
+++ b/site/files/dasllama/profile_llm_zen2.json
@@ -1,351 +1,463 @@
 {
-  "platform":{
-    "cpu":"AMD Ryzen Threadripper 3990X 64-Core Processor",
-    "os":"Microsoft Windows [Version 10.0.26200.8655]",
-    "threads":16,
-    "daslang":"0.6.3",
-    "llama_cpp":"fdb1db877",
-    "date":"2026-07-13",
-    "box_profile":"gen_profile.tune.json",
-    "parsec_off":true,
-    "affinity":"das jobque mode 2; llama-bench --cpu-mask 0x55555555 --cpu-strict 1",
-    "tune":"k4q8_tile_gen=dot_maddubs_width256_mr8 (manifest); k5q8_tile_gen=dot_maddubs_width256_mr8_nrsplit2 (manifest); k6q8_tile_gen=dot_maddubs_width256_mr8 (manifest); q8q8_tile_gen=dot_maddubs_width256_mr8_kstep2 (manifest)"
+  "platform": {
+    "cpu": "AMD Ryzen Threadripper 3990X 64-Core Processor",
+    "os": "Microsoft Windows [Version 10.0.26200.8875]",
+    "threads": 16,
+    "daslang": "0.6.3",
+    "llama_cpp": "fdb1db877",
+    "date": "2026-07-15",
+    "box_profile": "gen_profile.tune.json",
+    "parsec_off": true,
+    "affinity": "das jobque mode 2; llama-bench --cpu-mask 0x55555555 --cpu-strict 1",
+    "tune": "k4q8_tile_gen=dot_maddubs_width256_mr8 (manifest); k5q8_tile_gen=dot_maddubs_width256_mr8_nrsplit2 (manifest); k6q8_tile_gen=dot_maddubs_width256_mr8 (manifest); q8q8_tile_gen=dot_maddubs_width256_mr8_kstep2 (manifest)"
   },
-  "tests":[
+  "tests": [
     {
-      "model":"SmolLM2-135M",
-      "arch":"llama",
-      "quant":"q8",
-      "active_b":0.134479872,
-      "prefill":{
-        "context":512,
-        "das_tok_s":2499.4630059948058,
-        "llama_cpp_tok_s":2414.7431160000001
+      "model": "SmolLM2-135M",
+      "arch": "llama",
+      "quant": "q8",
+      "active_b": 0.134479872,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 2499.463005994806,
+        "llama_cpp_tok_s": 2414.743116
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":231.84625695085947,
-        "llama_cpp_tok_s":226.31643500000001
+      "emission": {
+        "context": 128,
+        "das_tok_s": 231.84625695085947,
+        "llama_cpp_tok_s": 226.316435
       }
     },
     {
-      "model":"Qwen2.5-0.5B",
-      "arch":"qwen2",
-      "quant":"q8",
-      "active_b":0.49396121599999998,
-      "prefill":{
-        "context":512,
-        "das_tok_s":1294.4100195425576,
-        "llama_cpp_tok_s":1048.1715919999999
+      "model": "Qwen2.5-0.5B",
+      "arch": "qwen2",
+      "quant": "q8",
+      "active_b": 0.493961216,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 1294.4100195425576,
+        "llama_cpp_tok_s": 1048.171592
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":89.645082511995284,
-        "llama_cpp_tok_s":87.492925999999997
+      "emission": {
+        "context": 128,
+        "das_tok_s": 89.64508251199528,
+        "llama_cpp_tok_s": 87.492926
       }
     },
     {
-      "model":"Qwen3-0.6B",
-      "arch":"qwen3",
-      "quant":"q8",
-      "active_b":0.59598438399999998,
-      "prefill":{
-        "context":512,
-        "das_tok_s":954.71268182894619,
-        "llama_cpp_tok_s":781.60196099999996
+      "model": "Qwen3-0.6B",
+      "arch": "qwen3",
+      "quant": "q8",
+      "active_b": 0.595984384,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 954.7126818289462,
+        "llama_cpp_tok_s": 781.601961
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":72.559766856399122,
-        "llama_cpp_tok_s":71.394169000000005
+      "emission": {
+        "context": 128,
+        "das_tok_s": 72.55976685639912,
+        "llama_cpp_tok_s": 71.394169
       }
     },
     {
-      "model":"gemma-3-1B",
-      "arch":"gemma3",
-      "quant":"q8",
-      "active_b":0.99975168000000003,
-      "prefill":{
-        "context":512,
-        "das_tok_s":653.49049439363864,
-        "llama_cpp_tok_s":564.05555400000003
+      "model": "gemma-3-1B",
+      "arch": "gemma3",
+      "quant": "q8",
+      "active_b": 0.99975168,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 653.4904943936386,
+        "llama_cpp_tok_s": 564.055554
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":47.373281099356205,
-        "llama_cpp_tok_s":44.800516000000002
+      "emission": {
+        "context": 128,
+        "das_tok_s": 47.373281099356205,
+        "llama_cpp_tok_s": 44.800516
       }
     },
     {
-      "model":"TinyLlama-1.1B",
-      "arch":"llama",
-      "quant":"q8",
-      "active_b":1.099956224,
-      "prefill":{
-        "context":512,
-        "das_tok_s":630.94592596243899,
-        "llama_cpp_tok_s":441.89621799999998
+      "model": "TinyLlama-1.1B",
+      "arch": "llama",
+      "quant": "q8",
+      "active_b": 1.099956224,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 630.945925962439,
+        "llama_cpp_tok_s": 441.896218
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":46.16313981480647,
-        "llama_cpp_tok_s":44.984614999999998
+      "emission": {
+        "context": 128,
+        "das_tok_s": 46.16313981480647,
+        "llama_cpp_tok_s": 44.984615
       }
     },
     {
-      "model":"Llama-3.2-1B",
-      "arch":"llama",
-      "quant":"q8",
-      "active_b":1.235746816,
-      "prefill":{
-        "context":512,
-        "das_tok_s":670.83053274688075,
-        "llama_cpp_tok_s":455.273121
+      "model": "Llama-3.2-1B",
+      "arch": "llama",
+      "quant": "q8",
+      "active_b": 1.235746816,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 670.8305327468807,
+        "llama_cpp_tok_s": 455.273121
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":40.281378013353908,
-        "llama_cpp_tok_s":39.840736999999997
+      "emission": {
+        "context": 128,
+        "das_tok_s": 40.28137801335391,
+        "llama_cpp_tok_s": 39.840737
       }
     },
     {
-      "model":"Qwen2.5-1.5B",
-      "arch":"qwen2",
-      "quant":"q8",
-      "active_b":1.543569408,
-      "prefill":{
-        "context":512,
-        "das_tok_s":440.20706927844731,
-        "llama_cpp_tok_s":329.69905699999998
+      "model": "Qwen2.5-1.5B",
+      "arch": "qwen2",
+      "quant": "q8",
+      "active_b": 1.543569408,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 440.2070692784473,
+        "llama_cpp_tok_s": 329.699057
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":31.536888674043833,
-        "llama_cpp_tok_s":30.810911999999998
+      "emission": {
+        "context": 128,
+        "das_tok_s": 31.536888674043833,
+        "llama_cpp_tok_s": 30.810912
       }
     },
     {
-      "model":"SmolLM2-1.7B",
-      "arch":"llama",
-      "quant":"q8",
-      "active_b":1.711276032,
-      "prefill":{
-        "context":512,
-        "das_tok_s":404.66502903787728,
-        "llama_cpp_tok_s":272.19165199999998
+      "model": "SmolLM2-1.7B",
+      "arch": "llama",
+      "quant": "q8",
+      "active_b": 1.711276032,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 404.6650290378773,
+        "llama_cpp_tok_s": 272.191652
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":28.883368956155046,
-        "llama_cpp_tok_s":28.386243
+      "emission": {
+        "context": 128,
+        "das_tok_s": 28.883368956155046,
+        "llama_cpp_tok_s": 28.386243
       }
     },
     {
-      "model":"gemma-2-2B",
-      "arch":"gemma2",
-      "quant":"q8",
-      "active_b":2.6140999680000001,
-      "prefill":{
-        "context":512,
-        "das_tok_s":313.45755313319802,
-        "llama_cpp_tok_s":219.956683
+      "model": "gemma-2-2B",
+      "arch": "gemma2",
+      "quant": "q8",
+      "active_b": 2.614099968,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 313.457553133198,
+        "llama_cpp_tok_s": 219.956683
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":19.333557179675054,
-        "llama_cpp_tok_s":17.877075000000001
+      "emission": {
+        "context": 128,
+        "das_tok_s": 19.333557179675054,
+        "llama_cpp_tok_s": 17.877075
       }
     },
     {
-      "model":"Phi-3.5-mini",
-      "arch":"phi3",
-      "quant":"q8",
-      "active_b":3.8208798719999999,
-      "prefill":{
-        "context":512,
-        "das_tok_s":185.03353371404947,
-        "llama_cpp_tok_s":123.845068
+      "model": "Phi-3.5-mini",
+      "arch": "phi3",
+      "quant": "q8",
+      "active_b": 3.820879872,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 185.03353371404947,
+        "llama_cpp_tok_s": 123.845068
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":13.517635022164699,
-        "llama_cpp_tok_s":13.582352999999999
+      "emission": {
+        "context": 128,
+        "das_tok_s": 13.517635022164699,
+        "llama_cpp_tok_s": 13.582353
       }
     },
     {
-      "model":"gemma-3-4B",
-      "arch":"gemma3",
-      "quant":"q8",
-      "active_b":3.8798950400000001,
-      "prefill":{
-        "context":512,
-        "das_tok_s":200.12210575358873,
-        "llama_cpp_tok_s":138.39662999999999
+      "model": "gemma-3-4B",
+      "arch": "gemma3",
+      "quant": "q8",
+      "active_b": 3.87989504,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 200.12210575358873,
+        "llama_cpp_tok_s": 138.39663
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":13.066272337456084,
-        "llama_cpp_tok_s":12.454217999999999
+      "emission": {
+        "context": 128,
+        "das_tok_s": 13.066272337456084,
+        "llama_cpp_tok_s": 12.454218
       }
     },
     {
-      "model":"Qwen3-4B",
-      "arch":"qwen3",
-      "quant":"q8",
-      "active_b":4.0222720000000001,
-      "prefill":{
-        "context":512,
-        "das_tok_s":176.24493640036241,
-        "llama_cpp_tok_s":120.28776999999999
+      "model": "Qwen3-4B",
+      "arch": "qwen3",
+      "quant": "q8",
+      "active_b": 4.022272,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 176.2449364003624,
+        "llama_cpp_tok_s": 120.28777
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":12.54447039255078,
-        "llama_cpp_tok_s":12.3986
+      "emission": {
+        "context": 128,
+        "das_tok_s": 12.54447039255078,
+        "llama_cpp_tok_s": 12.3986
       }
     },
     {
-      "model":"gemma-4-E2B",
-      "arch":"gemma4",
-      "quant":"q8",
-      "active_b":2.2476226559999999,
-      "prefill":{
-        "context":512,
-        "das_tok_s":273.26516648360035,
-        "llama_cpp_tok_s":215.793621
+      "model": "gemma-4-E2B",
+      "arch": "gemma4",
+      "quant": "q8",
+      "active_b": 2.247622656,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 273.26516648360035,
+        "llama_cpp_tok_s": 215.793621
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":21.22874989696593,
-        "llama_cpp_tok_s":19.137046999999999
+      "emission": {
+        "context": 128,
+        "das_tok_s": 21.22874989696593,
+        "llama_cpp_tok_s": 19.137047
       }
     },
     {
-      "model":"Mistral-7B",
-      "arch":"llama",
-      "quant":"q8",
-      "active_b":7.2477573120000001,
-      "prefill":{
-        "context":512,
-        "das_tok_s":101.61389458868304,
-        "llama_cpp_tok_s":66.577089000000001
+      "model": "Mistral-7B",
+      "arch": "llama",
+      "quant": "q8",
+      "active_b": 7.247757312,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 101.61389458868304,
+        "llama_cpp_tok_s": 66.577089
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":7.3000335459354044,
-        "llama_cpp_tok_s":7.1539469999999996
+      "emission": {
+        "context": 128,
+        "das_tok_s": 7.300033545935404,
+        "llama_cpp_tok_s": 7.153947
       }
     },
     {
-      "model":"gemma-4-E4B",
-      "arch":"gemma4",
-      "quant":"q8",
-      "active_b":4.5888307199999998,
-      "prefill":{
-        "context":512,
-        "das_tok_s":147.26417957025896,
-        "llama_cpp_tok_s":107.799064
+      "model": "gemma-4-E4B",
+      "arch": "gemma4",
+      "quant": "q8",
+      "active_b": 4.58883072,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 147.26417957025896,
+        "llama_cpp_tok_s": 107.799064
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":10.655108537680418,
-        "llama_cpp_tok_s":9.90944
+      "emission": {
+        "context": 128,
+        "das_tok_s": 10.655108537680418,
+        "llama_cpp_tok_s": 9.90944
       }
     },
     {
-      "model":"Llama-3.1-8B",
-      "arch":"llama",
-      "quant":"q8",
-      "active_b":8.0299950080000002,
-      "prefill":{
-        "context":512,
-        "das_tok_s":99.797889781417283,
-        "llama_cpp_tok_s":65.886958000000007
+      "model": "Llama-3.1-8B",
+      "arch": "llama",
+      "quant": "q8",
+      "active_b": 8.029995008,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 99.79788978141728,
+        "llama_cpp_tok_s": 65.886958
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":6.9493601213792608,
-        "llama_cpp_tok_s":6.7469400000000004
+      "emission": {
+        "context": 128,
+        "das_tok_s": 6.949360121379261,
+        "llama_cpp_tok_s": 6.74694
       }
     },
     {
-      "model":"Qwen3-4B-q4k",
-      "arch":"qwen3",
-      "quant":"q4_k_m",
-      "active_b":4.0222720000000001,
-      "prefill":{
-        "context":512,
-        "das_tok_s":184.94083157633523,
-        "llama_cpp_tok_s":187.75493700000001
+      "model": "Qwen3-4B-q4k",
+      "arch": "qwen3",
+      "quant": "q4_k_m",
+      "active_b": 4.022272,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 184.94083157633523,
+        "llama_cpp_tok_s": 187.754937
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":20.417085974594446,
-        "llama_cpp_tok_s":19.849736
+      "emission": {
+        "context": 128,
+        "das_tok_s": 20.417085974594446,
+        "llama_cpp_tok_s": 19.849736
       }
     },
     {
-      "model":"Qwen3.6-35B-A3B",
-      "arch":"qwen35moe",
-      "quant":"q4_k_m",
-      "active_b":2.8626124800000001,
-      "prefill":{
-        "context":512,
-        "das_tok_s":142.17238290354882,
-        "llama_cpp_tok_s":103.709287
+      "model": "Qwen3.6-35B-A3B",
+      "arch": "qwen35moe",
+      "quant": "q4_k_m",
+      "active_b": 2.86261248,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 147.20147569479386,
+        "llama_cpp_tok_s": 103.709287
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":16.463693760890315,
-        "llama_cpp_tok_s":13.036918999999999
+      "emission": {
+        "context": 128,
+        "das_tok_s": 16.195973301444138,
+        "llama_cpp_tok_s": 13.036919
       }
     },
     {
-      "model":"Qwen3.5-0.8B",
-      "arch":"qwen35",
-      "quant":"q8",
-      "active_b":0.62547558400000003,
-      "prefill":{
-        "context":512,
-        "das_tok_s":820.32220077065438,
-        "llama_cpp_tok_s":536.37608399999999
+      "model": "Qwen3.5-0.8B",
+      "arch": "qwen35",
+      "quant": "q8",
+      "active_b": 0.625475584,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 820.3222007706544,
+        "llama_cpp_tok_s": 536.376084
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":53.561460520600662,
-        "llama_cpp_tok_s":43.369441999999999
+      "emission": {
+        "context": 128,
+        "das_tok_s": 53.56146052060066,
+        "llama_cpp_tok_s": 43.369442
       }
     },
     {
-      "model":"gpt-oss-20b",
-      "arch":"gpt-oss",
-      "quant":"mxfp4",
-      "active_b":4.1862758400000004,
-      "prefill":{
-        "context":512,
-        "das_tok_s":164.96976574615471,
-        "llama_cpp_tok_s":143.900982
+      "model": "gpt-oss-20b",
+      "arch": "gpt-oss",
+      "quant": "mxfp4",
+      "active_b": 4.18627584,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 164.9697657461547,
+        "llama_cpp_tok_s": 143.900982
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":19.321851323184532,
-        "llama_cpp_tok_s":19.647666999999998
+      "emission": {
+        "context": 128,
+        "das_tok_s": 19.321851323184532,
+        "llama_cpp_tok_s": 19.647667
       }
     },
     {
-      "model":"Qwen3-30B-A3B",
-      "arch":"qwen3moe",
-      "quant":"q4_k_m",
-      "active_b":3.3528217599999999,
-      "prefill":{
-        "context":512,
-        "das_tok_s":171.1125288794168,
-        "llama_cpp_tok_s":150.74888200000001
+      "model": "Qwen3-30B-A3B",
+      "arch": "qwen3moe",
+      "quant": "q4_k_m",
+      "active_b": 3.35282176,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 171.1125288794168,
+        "llama_cpp_tok_s": 150.748882
       },
-      "emission":{
-        "context":128,
-        "das_tok_s":23.088801876975285,
-        "llama_cpp_tok_s":22.939775000000001
+      "emission": {
+        "context": 128,
+        "das_tok_s": 23.088801876975285,
+        "llama_cpp_tok_s": 22.939775
+      }
+    },
+    {
+      "model": "gemma-4-26B-A4B",
+      "arch": "gemma4",
+      "quant": "q8",
+      "active_b": 3.286564864,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 120.78214934193781,
+        "llama_cpp_tok_s": 100.330479
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 11.571128768131304,
+        "llama_cpp_tok_s": 11.139292
+      }
+    },
+    {
+      "model": "gemma-4-26B-A4B-q4k",
+      "arch": "gemma4",
+      "quant": "q4_k_m",
+      "active_b": 3.286564864,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 152.2911187507845,
+        "llama_cpp_tok_s": 127.149546
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 17.94434868673303,
+        "llama_cpp_tok_s": 17.171315
+      }
+    },
+    {
+      "model": "Qwen3-Coder-30B",
+      "arch": "qwen3moe",
+      "quant": "q8",
+      "active_b": 3.35282176,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 122.78987223378041,
+        "llama_cpp_tok_s": 103.500491
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 15.058499328779158,
+        "llama_cpp_tok_s": 14.738287
+      }
+    },
+    {
+      "model": "Qwen3-Coder-30B-q4k",
+      "arch": "qwen3moe",
+      "quant": "q4_k_m",
+      "active_b": 3.35282176,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 162.52704154756216,
+        "llama_cpp_tok_s": 146.895093
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 23.16165660129832,
+        "llama_cpp_tok_s": 22.919679
+      }
+    },
+    {
+      "model": "Qwen3-Coder-Next",
+      "arch": "qwen3next",
+      "quant": "q8",
+      "active_b": 3.16407808,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 88.16620155551354,
+        "llama_cpp_tok_s": 69.074222
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 11.785420274992525,
+        "llama_cpp_tok_s": 9.293619
+      }
+    },
+    {
+      "model": "Qwen3-Coder-Next-q4k",
+      "arch": "qwen3next",
+      "quant": "q4_k_m",
+      "active_b": 3.16407808,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 100.91620879878964,
+        "llama_cpp_tok_s": 81.264151
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 14.127498911741101,
+        "llama_cpp_tok_s": 12.310183
+      }
+    },
+    {
+      "model": "Qwen3.5-122B-A10B-q4k",
+      "arch": "qwen35moe",
+      "quant": "q4_k_m",
+      "active_b": 8.093958144,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 51.58957870358009,
+        "llama_cpp_tok_s": 39.972824
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 5.947793981799007,
+        "llama_cpp_tok_s": 4.983295
       }
     }
   ]


### PR DESCRIPTION
Site half of #3476 (the repo tables merged without it - follow-up). Fresh 2026-07-15 zen2 data JSON (28 models incl. gemma-4-26B-A4B pair, Coder pairs, 122B-q4k), hero stat fallbacks synced to computed values (54/56 runs >= llama.cpp), scoreboard opens on the Threadripper tab, 122B bar label un-wrapped (label column 150->172px). Previewed live at localhost with the deployed JS - stats compute, all 28 rows render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)