### PR TITLE
dasLLAMA: q4_0 native KqFmt tier - QAT files on full kq rails

### DIFF
--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -107,13 +107,16 @@ def private wbytes(q : QuantMode; wscale16 : bool = false) : double {
 // 256-weight superblock) when kq-tagged, else the model-wide q8 figure.
 def private kq_wbytes(f : KqFmt; q8wb : double) : double {
     if (f == KqFmt.k4) {
-        return (128.0lf + 32.0lf) / 256.0lf   // nibbles + f16 (d*sc, dmin*m) pairs per 32
+        return (128.0lf + 20.0lf) / 256.0lf   // nibbles + kq v2 scale rows (16B disk block + pad)
     }
     if (f == KqFmt.k5) {
-        return (160.0lf + 32.0lf) / 256.0lf   // nibbles + high-bit plane + scale pairs
+        return (160.0lf + 20.0lf) / 256.0lf   // nibbles + high-bit plane + kq v2 scale rows
     }
     if (f == KqFmt.k6) {
         return (192.0lf + 18.0lf) / 256.0lf   // ql + qh + native int8 sub-scales + f16 d
+    }
+    if (f == KqFmt.q40) {
+        return (128.0lf + 16.0lf) / 256.0lf   // nibbles + 8 x f16 d
     }
     return q8wb
 }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -12,6 +12,7 @@ require ?llvm/daslib/llvm_tune llvm/daslib/llvm_tune public  // re-export ONLY l
 require ?das_metal dasllama/dasllama_math_metal  // nolint:STYLE030 — [init]-only: registers "metal" (the GPU prefill-GEMM batch donor). STRICT guard: the C++ das_metal module exists on Apple builds only, so non-Apple lanes never compile the Metal driver
 require dasllama/dasllama_quant
 require dasllama/dasllama_gguf
+require dasllama/dasllama_gemm_schema  // kq_qsb/kq_ssb — the fmt-id plane strides
 require dasllama/dasllama_tokenizer  // Model owns its tokenizer; load_model populates it
 require dasllama/dasllama_par  // maybe_parallel_for (+ get_total_hw_jobs): thread the prefill attention over heads
 require dasllama/dasllama_tune  // box_profile_path: the runtime half of the app tune sidecar applies at load_model
@@ -39,11 +40,14 @@ enum QuantMode {
 //! q8 = qblob/qscales as always; k4/k5/k6 = the tensor's element offset indexes that format's
 //! plane pair (Model.k4q/k4s etc). A Q4_K_M file mixes formats PER TENSOR (attn_v/ffn_down and
 //! the tied embedding go Q6_K), so the tag rides per layer next to each offset array.
+//! q40 = native Q4_0 (the QAT-file format): the k4 nibble pairing with per-32 f16 d scales —
+//! same superblock walkers, the −8 offset correction rides the Q8_K bsum pairs.
 enum KqFmt : uint8 {
     q8
     k4
     k5
     k6
+    q40
 }
 
 //! FFN gate activation: silu = SwiGLU (Llama family), gelu = GeGLU (Gemma), swiglu_oai = the
@@ -448,6 +452,9 @@ struct Model {
     k5s : array<uint8>
     k6q : array<uint8>
     k6s : array<uint8>
+    // the q40 tier's plane pair (128B nibbles — the k4 pairing — + 16B of f16 d per superblock)
+    q40q : array<uint8>
+    q40s : array<uint8>
     kquant_native : bool = false
     // kq stage 4: the kq planes were repacked at load into the active backend's grp<mr> layout
     // (kernel_backend_has_kq at load time). From then on every kq matmul MUST run the backend
@@ -457,6 +464,7 @@ struct Model {
     kq_repack_mr4 : int64 = 4l   // per-FORMAT repack interleaves (kq v2: the families tune separately)
     kq_repack_mr5 : int64 = 4l
     kq_repack_mr6 : int64 = 4l
+    kq_repack_mr40 : int64 = 4l
     // per-layer weight format tags (KqFmt; empty = all q8). Filled by detect_kq_formats before
     // layout_offsets so the layout walks each tensor into its format's cursor.
     wq_fmt : array<KqFmt>
@@ -645,6 +653,7 @@ struct private LayoutSizes {
     k4_n : int64      // element counts of the native K-quant planes (0 unless kquant_native)
     k5_n : int64
     k6_n : int64
+    q40_n : int64
 }
 
 // The big-weight layout cursors: one element cursor per storage plane. kq_take advances the
@@ -654,6 +663,7 @@ struct private KqCursors {
     k4 : int64
     k5 : int64
     k6 : int64
+    q40 : int64
 }
 
 def private kq_take(var cur : KqCursors; f : KqFmt; n : int64) : int64 {
@@ -670,6 +680,11 @@ def private kq_take(var cur : KqCursors; f : KqFmt; n : int64) : int64 {
     if (f == KqFmt.k6) {
         let o = cur.k6
         cur.k6 += n
+        return o
+    }
+    if (f == KqFmt.q40) {
+        let o = cur.q40
+        cur.q40 += n
         return o
     }
     let o = cur.wo
@@ -967,7 +982,7 @@ def private layout_offsets(var t : Model) : LayoutSizes {
         fo += dim
     }
     return LayoutSizes(fblob_n = fo, wblob_n = cur.wo, mx_n = mx, bf16_n = bf16,
-                       k4_n = cur.k4, k5_n = cur.k5, k6_n = cur.k6)
+                       k4_n = cur.k4, k5_n = cur.k5, k6_n = cur.k6, q40_n = cur.q40)
 }
 
 // Reserve exact capacity then size — avoids the array allocator's power-of-2 rounding on big arrays.
@@ -1076,6 +1091,8 @@ def private load_big(m : GGUFMeta; bytes : array<uint8> | #; name : string; var 
         gguf_transcode_q5k(m, bytes, name, t.k5q, t.k5s, woff, n, src_off)
     } elif (fmt == KqFmt.k6) {
         gguf_transcode_q6k(m, bytes, name, t.k6q, t.k6s, woff, n, src_off)
+    } elif (fmt == KqFmt.q40) {
+        gguf_transcode_q40(m, bytes, name, t.q40q, t.q40s, woff, n, src_off)
     } elif (t.quant == QuantMode.q8) {
         let gt = gguf_tensor_type(m, name)
         if (gt == GGML_TYPE_Q8_0) {
@@ -1239,6 +1256,19 @@ def public get_kquant_native() : bool {
     return g_kquant_native
 }
 
+// The q40 tier's bring-up knob (like kquant_native had): OFF keeps Q4_0 tensors on the
+// q8-requant fallback (2x memory, exact) — the zero-risk A/B rail while the tier proves out.
+var private g_kq_q40_native = true
+
+//! Enable/disable the native Q4_0 plane tier for subsequent loads (A/B rail; default ON —
+//! flipped after the QAT parity gate; requires kquant_native).
+def public set_kq_q40_native(on : bool) {
+    g_kq_q40_native = on
+}
+def public get_kq_q40_native() : bool {
+    return g_kq_q40_native
+}
+
 // GGML disk type -> plane format tag (non-K-quant types ride the classic q8 path)
 def private kq_fmt_of(gt : int) : KqFmt {
     if (gt == GGML_TYPE_Q4_K) {
@@ -1250,8 +1280,16 @@ def private kq_fmt_of(gt : int) : KqFmt {
     if (gt == GGML_TYPE_Q6_K) {
         return KqFmt.k6
     }
+    if (gt == GGML_TYPE_Q4_0 && g_kq_q40_native) {
+        return KqFmt.q40
+    }
     return KqFmt.q8
 }
+
+// q40 demotion: Q4_0 guarantees rows % 32 only (K-quants are % 256 by construction), and the
+// kq tier's superblock walkers/activation image need % 256 — a misaligned tensor falls back to
+// the q8 requant path per tensor. `n` = the tensor's ROW length (the matmul's input dim).
+def private kq_fmt_row_ok(f : KqFmt; n : int64) : KqFmt => f == KqFmt.q40 && n % 256l != 0l ? KqFmt.q8 : f
 
 // Fill the per-kind weight format tags from the file's tensor types (q8-mode loads with the
 // kquant_native knob on). Fused-projection arches (Phi3) split attn_qkv / ffn_up ([gate; up])
@@ -1273,24 +1311,26 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
     t.w2_fmt |> resize(layers)
     t.w3_fmt |> resize(layers)
     var any = false
+    // q40 tags additionally demote per tensor when the row length isn't % 256 (kq_fmt_row_ok) —
+    // Q4_0 only guarantees % 32, unlike the K-quants
     for (l in range64(layers)) {
         if (t.config.fused_qkv) {
-            let fqkv = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_qkv.weight"))
+            let fqkv = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_qkv.weight")), t.config.dim)
             t.wq_fmt[l] = fqkv
             t.wk_fmt[l] = fqkv
             t.wv_fmt[l] = fqkv
-            let fgu = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight"))
+            let fgu = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight")), t.config.dim)
             t.w1_fmt[l] = fgu
             t.w3_fmt[l] = fgu
         } else {
-            t.wq_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_q.weight"))
-            t.wk_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_k.weight"))
-            t.wv_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_v.weight"))
-            t.w1_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate.weight"))
-            t.w3_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight"))
+            t.wq_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_q.weight")), t.config.dim)
+            t.wk_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_k.weight")), t.config.dim)
+            t.wv_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_v.weight")), t.config.dim)
+            t.w1_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate.weight")), t.config.dim)
+            t.w3_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up.weight")), t.config.dim)
         }
-        t.wo_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_output.weight"))
-        t.w2_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down.weight"))
+        t.wo_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.attn_output.weight")), layer_qd(t.config, l))
+        t.w2_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down.weight")), layer_hidden(t, l))
         any ||= t.wq_fmt[l] != KqFmt.q8 || t.wk_fmt[l] != KqFmt.q8 || t.wv_fmt[l] != KqFmt.q8
         any ||= t.wo_fmt[l] != KqFmt.q8 || t.w1_fmt[l] != KqFmt.q8 || t.w2_fmt[l] != KqFmt.q8
         any ||= t.w3_fmt[l] != KqFmt.q8
@@ -1307,26 +1347,26 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
         let fused_gu = t.config.moe_dense_shexp   // gemma4: experts ship fused as ffn_gate_up_exps
         for (l in range64(layers)) {
             if (fused_gu) {
-                let f = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_up_exps.weight"))
+                let f = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_up_exps.weight")), t.config.dim)
                 t.we1_fmt[l] = f
                 t.we3_fmt[l] = f
             } else {
-                t.we1_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_exps.weight"))
-                t.we3_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up_exps.weight"))
+                t.we1_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_exps.weight")), t.config.dim)
+                t.we3_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up_exps.weight")), t.config.dim)
             }
-            t.we2_fmt[l] = kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down_exps.weight"))
+            t.we2_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down_exps.weight")), t.config.n_ff_exp)
             any ||= t.we1_fmt[l] != KqFmt.q8 || t.we2_fmt[l] != KqFmt.q8 || t.we3_fmt[l] != KqFmt.q8
         }
     }
     if (t.config.shared_weights) {
-        t.emb_fmt = kq_fmt_of(gguf_tensor_type(m, "token_embd.weight"))
+        t.emb_fmt = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "token_embd.weight")), t.config.dim)
         any ||= t.emb_fmt != KqFmt.q8
     } else {
-        t.wcls_fmt = kq_fmt_of(gguf_tensor_type(m, "output.weight"))
+        t.wcls_fmt = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "output.weight")), t.config.dim)
         any ||= t.wcls_fmt != KqFmt.q8
     }
     if (t.config.n_layer_nextn > 0l) {
-        t.mtp_ehproj_fmt = kq_fmt_of(gguf_tensor_type(m, "blk.{t.config.n_layers}.nextn.eh_proj.weight"))
+        t.mtp_ehproj_fmt = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{t.config.n_layers}.nextn.eh_proj.weight")), 2l * t.config.dim)
         any ||= t.mtp_ehproj_fmt != KqFmt.q8
     }
     // E-series PLE token table: gather-only whole rows of layers*ple — row length must be
@@ -1430,6 +1470,8 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
         var k5sp : uint8? = null
         var k6qp : uint8? = null
         var k6sp : uint8? = null
+        var q40qp : uint8? = null
+        var q40sp : uint8? = null
         if (!empty(t.qblob)) { qbp = addr(t.qblob[0]) }
         if (!empty(t.qscales)) { qsp = addr(t.qscales[0]) }
         if (!empty(t.mxq)) { mxqp = addr(t.mxq[0]) }
@@ -1440,6 +1482,8 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
         if (!empty(t.k5s)) { k5sp = addr(t.k5s[0]) }
         if (!empty(t.k6q)) { k6qp = addr(t.k6q[0]) }
         if (!empty(t.k6s)) { k6sp = addr(t.k6s[0]) }
+        if (!empty(t.q40q)) { q40qp = addr(t.q40q[0]) }
+        if (!empty(t.q40s)) { q40sp = addr(t.q40s[0]) }
         let rp = addr<RepackReg const?>(regs[0])
         let nr = length(regs)
         let njobs = is_job_que_available() ? min(nr, 4 * (get_total_hw_jobs() + 1)) : 1
@@ -1453,10 +1497,10 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
                         invoke(rmx, mxqp + rp[i].off / 2l, mxsp + rp[i].off / 32l, rp[i].n, rp[i].d)
                     } else {
                         let sb = rp[i].off / 256l
-                        let qsb = f == 4 ? 128l : (f == 5 ? 160l : 192l)
-                        let ssb = f == 6 ? 18l : 20l
-                        var kqp = f == 4 ? k4qp : (f == 5 ? k5qp : k6qp)
-                        var ksp = f == 4 ? k4sp : (f == 5 ? k5sp : k6sp)
+                        let qsb = kq_qsb(f)
+                        let ssb = kq_ssb(f)
+                        var kqp = f == 4 ? k4qp : (f == 5 ? k5qp : (f == 6 ? k6qp : q40qp))
+                        var ksp = f == 4 ? k4sp : (f == 5 ? k5sp : (f == 6 ? k6sp : q40sp))
                         invoke(rkq, f, kqp + sb * qsb, ksp + sb * ssb, rp[i].n, rp[i].d)
                     }
                 }
@@ -1576,6 +1620,8 @@ def private push_repack_kq(var regs : array<RepackReg>; fmt : KqFmt; woff, n, d 
         push_repack(regs, 5, woff, n, d)
     } elif (fmt == KqFmt.k6) {
         push_repack(regs, 6, woff, n, d)
+    } elif (fmt == KqFmt.q40) {
+        push_repack(regs, 40, woff, n, d)
     }
 }
 
@@ -2211,6 +2257,12 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             t.k6s |> reserve((sz.k6_n / 256l) * K6_SSB)
             t.k6s |> resize((sz.k6_n / 256l) * K6_SSB)
         }
+        if (sz.q40_n > 0l) {
+            t.q40q |> reserve((sz.q40_n / 256l) * Q40_QSB)
+            t.q40q |> resize((sz.q40_n / 256l) * Q40_QSB)
+            t.q40s |> reserve((sz.q40_n / 256l) * Q40_SSB)
+            t.q40s |> resize((sz.q40_n / 256l) * Q40_SSB)
+        }
         if (mode == QuantMode.q8) {
             t.qblob |> reserve(sz.wblob_n)
             t.qblob |> resize(sz.wblob_n)
@@ -2496,7 +2548,8 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
                 t.kq_repack_mr4 = active_kq_layout_mr(4)
                 t.kq_repack_mr5 = active_kq_layout_mr(5)
                 t.kq_repack_mr6 = active_kq_layout_mr(6)
-                to_log(LOG_INFO, "dasLLAMA: K-quant planes repacked to the '{active_kernel_backend()}' layouts (k4 grp{t.kq_repack_mr4}, k5 grp{t.kq_repack_mr5}, k6 grp{t.kq_repack_mr6})\n")
+                t.kq_repack_mr40 = active_kq_layout_mr(40)
+                to_log(LOG_INFO, "dasLLAMA: K-quant planes repacked to the '{active_kernel_backend()}' layouts (k4 grp{t.kq_repack_mr4}, k5 grp{t.kq_repack_mr5}, k6 grp{t.kq_repack_mr6}, q40 grp{t.kq_repack_mr40})\n")
             }
         }
         to_log(LOG_INFO, "dasLLAMA: load stage repack: {get_time_usec(ts_stage) / 1000} ms\n")
@@ -2548,8 +2601,8 @@ struct MemFootprint {
     q4_scale_bytes : int64
     mx4_bytes : int64
     mx4_scale_bytes : int64
-    kq_bytes : int64         // native K-quant planes: quant payloads (k4q+k5q+k6q)
-    kq_scale_bytes : int64   // ... and their scale planes (k4s+k5s+k6s)
+    kq_bytes : int64         // native K-quant planes: quant payloads (k4q+k5q+k6q+q40q)
+    kq_scale_bytes : int64   // ... and their scale planes (k4s+k5s+k6s+q40s)
     total : int64
 }
 
@@ -2564,8 +2617,8 @@ def footprint(t : Model) : MemFootprint {
     let q4s = long_length(t.q4scales) * 4l
     let mx4 = long_length(t.mxq)                  // uint8 (two nibbles) -> 1 byte each
     let mx4s = long_length(t.mxs)                 // raw E8M0 -> 1 byte per 32-block
-    let kq = long_length(t.k4q) + long_length(t.k5q) + long_length(t.k6q)
-    let kqs = long_length(t.k4s) + long_length(t.k5s) + long_length(t.k6s)
+    let kq = long_length(t.k4q) + long_length(t.k5q) + long_length(t.k6q) + long_length(t.q40q)
+    let kqs = long_length(t.k4s) + long_length(t.k5s) + long_length(t.k6s) + long_length(t.q40s)
     return MemFootprint(aux_fp32_bytes = aux, weight_fp32_bytes = wf, q8_bytes = q8, q8_scale_bytes = q8s,
                         q4_bytes = q4, q4_scale_bytes = q4s, mx4_bytes = mx4, mx4_scale_bytes = mx4s,
                         kq_bytes = kq, kq_scale_bytes = kqs,
@@ -4276,6 +4329,12 @@ def private mm_at_mx4_groupn(var y : array<float>; t : Model; offs, boffs : arra
 
 // ===== native K-quant dispatch (kquant_native; fmt != q8 tags) =====
 
+// KqFmt -> the kernel-layer format id (matmul_kq*/kq_rows_fn/kq_qsb take the int form).
+// q8 deliberately maps to 0, a poison id no kq kernel accepts — the fused-chain hoists call
+// this for EVERY tag (kq_rows_for) and their q8 branches never read the result, so it must
+// stay total; only q40 claims the 40 slot.
+def private kq_fi(fmt : KqFmt) : int => fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : (fmt == KqFmt.k6 ? 6 : (fmt == KqFmt.q40 ? 40 : 0)))
+
 // K-quant GEMV against a PRE-quantized activation (xq/xs/xbs already filled by the bs quantizer).
 // kq_repacked loads run the backend's stamped cores; disk-order loads run the portable kernels.
 def private mm_at_kq_pre(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64; yoff : int64 = 0l) {
@@ -4284,15 +4343,23 @@ def private mm_at_kq_pre(var y : array<float>; t : Model; fmt : KqFmt; woff : in
             matmul_kq_active(4, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, yoff)
         } elif (fmt == KqFmt.k5) {
             matmul_kq_active(5, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, yoff)
-        } else {
+        } elif (fmt == KqFmt.k6) {
             matmul_kq_active(6, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, yoff)
+        } elif (fmt == KqFmt.q40) {
+            matmul_kq_active(40, y, t.q40q, t.q40s, woff, xq, xs, xbs, n, d, yoff)
+        } else {
+            panic("mm_at_kq_pre: '{fmt}' has no kq plane pair")   // a new KqFmt must claim its arm, never ride q40's
         }
     } elif (fmt == KqFmt.k4) {
         matmul_kq(4, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, yoff)
     } elif (fmt == KqFmt.k5) {
         matmul_kq(5, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, yoff)
-    } else {
+    } elif (fmt == KqFmt.k6) {
         matmul_kq(6, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, yoff)
+    } elif (fmt == KqFmt.q40) {
+        matmul_kq(40, y, t.q40q, t.q40s, woff, xq, xs, xbs, n, d, yoff)
+    } else {
+        panic("mm_at_kq_pre: '{fmt}' has no kq plane pair")
     }
 }
 
@@ -4312,13 +4379,16 @@ def private mm_b_kq(var s : Session; var y : array<float>; t : Model; fmt : KqFm
     if (t.kq_repacked && kernel_backend_has_kq_batch()) {
         requant_rows_q8k_bs(x, n, npos, s.xqb, s.xsb, s.xbsb)   // kq v2: Q8_K-form image
         let ts_gemm = ref_time_ticks()
-        let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
         if (fmt == KqFmt.k4) {
-            matmul_kq_batch(fi, y, t.k4q, t.k4s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+            matmul_kq_batch(4, y, t.k4q, t.k4s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
         } elif (fmt == KqFmt.k5) {
-            matmul_kq_batch(fi, y, t.k5q, t.k5s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+            matmul_kq_batch(5, y, t.k5q, t.k5s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+        } elif (fmt == KqFmt.k6) {
+            matmul_kq_batch(6, y, t.k6q, t.k6s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+        } elif (fmt == KqFmt.q40) {
+            matmul_kq_batch(40, y, t.q40q, t.q40s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
         } else {
-            matmul_kq_batch(fi, y, t.k6q, t.k6s, woff, s.xqb, s.xsb, s.xbsb, n, d, npos)
+            panic("mm_b_kq: '{fmt}' has no kq plane pair")
         }
         prof_add("mm_gemm", ts_gemm)
         return
@@ -4338,34 +4408,44 @@ def private mm_b_kq(var s : Session; var y : array<float>; t : Model; fmt : KqFm
 // Repacked loads run the backend's kq_groupn (registered with the other kq slots — a kq
 // backend without one panics via the stub); disk-order loads run the portable region walk.
 def private mm_at_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64) {
-    let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
     if (t.kq_repacked) {
         if (fmt == KqFmt.k4) {
-            matmul_kq_groupn_active(fi, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
+            matmul_kq_groupn_active(4, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
         } elif (fmt == KqFmt.k5) {
-            matmul_kq_groupn_active(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+            matmul_kq_groupn_active(5, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+        } elif (fmt == KqFmt.k6) {
+            matmul_kq_groupn_active(6, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+        } elif (fmt == KqFmt.q40) {
+            matmul_kq_groupn_active(40, y, t.q40q, t.q40s, offs, nregions, xq, xs, xbs, n, d)
         } else {
-            matmul_kq_groupn_active(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+            panic("mm_at_kq_groupn: '{fmt}' has no kq plane pair")
         }
     } elif (fmt == KqFmt.k4) {
-        matmul_kq_groupn(fi, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
+        matmul_kq_groupn(4, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
     } elif (fmt == KqFmt.k5) {
-        matmul_kq_groupn(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+        matmul_kq_groupn(5, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+    } elif (fmt == KqFmt.k6) {
+        matmul_kq_groupn(6, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+    } elif (fmt == KqFmt.q40) {
+        matmul_kq_groupn(40, y, t.q40q, t.q40s, offs, nregions, xq, xs, xbs, n, d)
     } else {
-        matmul_kq_groupn(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+        panic("mm_at_kq_groupn: '{fmt}' has no kq plane pair")
     }
 }
 
 // Fused batched region-list kq GEMM (the fused MoE prefill's kq twin of the mx4 batch groupn;
 // triple offs). Callers guard with kq_repacked && kernel_backend_has_kq_batch_groupn().
 def private mm_b_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d : int64) {
-    let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
     if (fmt == KqFmt.k4) {
-        matmul_kq_batch_groupn(fi, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
+        matmul_kq_batch_groupn(4, y, t.k4q, t.k4s, offs, nregions, xq, xs, xbs, n, d)
     } elif (fmt == KqFmt.k5) {
-        matmul_kq_batch_groupn(fi, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+        matmul_kq_batch_groupn(5, y, t.k5q, t.k5s, offs, nregions, xq, xs, xbs, n, d)
+    } elif (fmt == KqFmt.k6) {
+        matmul_kq_batch_groupn(6, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+    } elif (fmt == KqFmt.q40) {
+        matmul_kq_batch_groupn(40, y, t.q40q, t.q40s, offs, nregions, xq, xs, xbs, n, d)
     } else {
-        matmul_kq_batch_groupn(fi, y, t.k6q, t.k6s, offs, nregions, xq, xs, xbs, n, d)
+        panic("mm_b_kq_groupn: '{fmt}' has no kq plane pair")
     }
 }
 
@@ -4373,13 +4453,16 @@ def private mm_b_kq_groupn(var y : array<float>; t : Model; fmt : KqFmt; offs : 
 // mm_b_q8_pre). Callers guard with kq_repacked && kernel_backend_has_kq_batch() — the prefill
 // gate routes kq-expert layers to the per-position reference path otherwise.
 def private mm_b_kq_pre(var y : array<float>; t : Model; fmt : KqFmt; woff : int64; xq : array<int8>; xs : array<float>; xbs : array<int>; n, d, ntok : int64) {
-    let fi = fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6)
     if (fmt == KqFmt.k4) {
-        matmul_kq_batch(fi, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, ntok)
+        matmul_kq_batch(4, y, t.k4q, t.k4s, woff, xq, xs, xbs, n, d, ntok)
     } elif (fmt == KqFmt.k5) {
-        matmul_kq_batch(fi, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, ntok)
+        matmul_kq_batch(5, y, t.k5q, t.k5s, woff, xq, xs, xbs, n, d, ntok)
+    } elif (fmt == KqFmt.k6) {
+        matmul_kq_batch(6, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, ntok)
+    } elif (fmt == KqFmt.q40) {
+        matmul_kq_batch(40, y, t.q40q, t.q40s, woff, xq, xs, xbs, n, d, ntok)
     } else {
-        matmul_kq_batch(fi, y, t.k6q, t.k6s, woff, xq, xs, xbs, n, d, ntok)
+        panic("mm_b_kq_pre: '{fmt}' has no kq plane pair")
     }
 }
 
@@ -4388,6 +4471,7 @@ def private kq_plane_q(t : Model; fmt : KqFmt; woff : int64) : uint8 const? {
     if (fmt == KqFmt.k4) return unsafe(addr<uint8 const?>(t.k4q[sb * K4_QSB]))
     if (fmt == KqFmt.k5) return unsafe(addr<uint8 const?>(t.k5q[sb * K5_QSB]))
     if (fmt == KqFmt.k6) return unsafe(addr<uint8 const?>(t.k6q[sb * K6_QSB]))
+    if (fmt == KqFmt.q40) return unsafe(addr<uint8 const?>(t.q40q[sb * Q40_QSB]))
     return null
 }
 
@@ -4396,11 +4480,12 @@ def private kq_plane_s(t : Model; fmt : KqFmt; woff : int64) : uint8 const? {
     if (fmt == KqFmt.k4) return unsafe(addr<uint8 const?>(t.k4s[sb * K4_SSB]))
     if (fmt == KqFmt.k5) return unsafe(addr<uint8 const?>(t.k5s[sb * K5_SSB]))
     if (fmt == KqFmt.k6) return unsafe(addr<uint8 const?>(t.k6s[sb * K6_SSB]))
+    if (fmt == KqFmt.q40) return unsafe(addr<uint8 const?>(t.q40s[sb * Q40_SSB]))
     return null
 }
 
 def private kq_rows_for(fmt : KqFmt) : MatmulKqRowsFn {
-    return kq_rows_fn(fmt == KqFmt.k4 ? 4 : (fmt == KqFmt.k5 ? 5 : 6))
+    return kq_rows_fn(kq_fi(fmt))
 }
 
 // Can the fused chains serve a weight of this format? q8 always; kq only off a repacked load
@@ -6420,8 +6505,12 @@ def private ple_gather_row(t : Model; row : int64; var dst : array<float>; doff 
             dequant_k4_plane_superblock(t.k4q, sb * K4_QSB, t.k4s, sb * K4_SSB, dst, doff + blk * 256l)
         } elif (t.ple_emb_fmt == KqFmt.k5) {
             dequant_k5_plane_superblock(t.k5q, sb * K5_QSB, t.k5s, sb * K5_SSB, dst, doff + blk * 256l)
-        } else {
+        } elif (t.ple_emb_fmt == KqFmt.k6) {
             dequant_k6_plane_superblock(t.k6q, sb * K6_QSB, t.k6s, sb * K6_SSB, dst, doff + blk * 256l)
+        } elif (t.ple_emb_fmt == KqFmt.q40) {
+            dequant_q40_plane_superblock(t.q40q, sb * Q40_QSB, t.q40s, sb * Q40_SSB, dst, doff + blk * 256l)
+        } else {
+            panic("ple_gather_row: '{t.ple_emb_fmt}' has no kq plane pair")
         }
     }
 }
@@ -6667,21 +6756,27 @@ def private embed_row(t : Model; token : int64; var dst : float?) {
     if (t.cls_q8) {
         dequant_q8_row(t, t.emb_q8_off + token * dim, dim, dst)
     } elif (cls_kq(t)) {
-        let mr = t.emb_fmt == KqFmt.k4 ? t.kq_repack_mr4 : (t.emb_fmt == KqFmt.k5 ? t.kq_repack_mr5 : t.kq_repack_mr6)
+        let mr = (t.emb_fmt == KqFmt.k4 ? t.kq_repack_mr4
+            : (t.emb_fmt == KqFmt.k5 ? t.kq_repack_mr5
+            : (t.emb_fmt == KqFmt.k6 ? t.kq_repack_mr6 : t.kq_repack_mr40)))
         if (t.kq_repacked && token < (t.config.vocab_size / mr) * mr) {
             // repacked plane: gather the row through the grp<mr> layout (tail rows below stay
             // disk-order — the repack leaves them verbatim)
             unsafe {
                 let nsb = dim / 256l
                 let g = token / mr
-                let fmt = t.emb_fmt == KqFmt.k4 ? 4l : (t.emb_fmt == KqFmt.k5 ? 5l : 6l)
+                let fmt = int64(kq_fi(t.emb_fmt))
                 let sb0t = t.wcls_off / 256l
                 if (t.emb_fmt == KqFmt.k4) {
                     dequant_kq_row_grp(fmt, addr(t.k4q[(sb0t + g * mr * nsb) * K4_QSB]), addr(t.k4s[(sb0t + g * mr * nsb) * K4_SSB]), token % mr, mr, dim, dst)
                 } elif (t.emb_fmt == KqFmt.k5) {
                     dequant_kq_row_grp(fmt, addr(t.k5q[(sb0t + g * mr * nsb) * K5_QSB]), addr(t.k5s[(sb0t + g * mr * nsb) * K5_SSB]), token % mr, mr, dim, dst)
-                } else {
+                } elif (t.emb_fmt == KqFmt.k6) {
                     dequant_kq_row_grp(fmt, addr(t.k6q[(sb0t + g * mr * nsb) * K6_QSB]), addr(t.k6s[(sb0t + g * mr * nsb) * K6_SSB]), token % mr, mr, dim, dst)
+                } elif (t.emb_fmt == KqFmt.q40) {
+                    dequant_kq_row_grp(fmt, addr(t.q40q[(sb0t + g * mr * nsb) * Q40_QSB]), addr(t.q40s[(sb0t + g * mr * nsb) * Q40_SSB]), token % mr, mr, dim, dst)
+                } else {
+                    panic("embed_row: '{t.emb_fmt}' has no kq plane pair")
                 }
             }
         } else {
@@ -6693,8 +6788,12 @@ def private embed_row(t : Model; token : int64; var dst : float?) {
                         dequant_k4_plane_superblock(t.k4q, (sb0 + s) * K4_QSB, t.k4s, (sb0 + s) * K4_SSB, row, s * 256l)
                     } elif (t.emb_fmt == KqFmt.k5) {
                         dequant_k5_plane_superblock(t.k5q, (sb0 + s) * K5_QSB, t.k5s, (sb0 + s) * K5_SSB, row, s * 256l)
-                    } else {
+                    } elif (t.emb_fmt == KqFmt.k6) {
                         dequant_k6_plane_superblock(t.k6q, (sb0 + s) * K6_QSB, t.k6s, (sb0 + s) * K6_SSB, row, s * 256l)
+                    } elif (t.emb_fmt == KqFmt.q40) {
+                        dequant_q40_plane_superblock(t.q40q, (sb0 + s) * Q40_QSB, t.q40s, (sb0 + s) * Q40_SSB, row, s * 256l)
+                    } else {
+                        panic("embed_row: '{t.emb_fmt}' has no kq plane pair")
                     }
                 }
             }

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
@@ -895,9 +895,10 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
     let mr = te.interleave
     let w8 = te.width / 8
     let k6 = te.kq == 6
-    let qsb = te.kq == 4 ? 128 : (te.kqBytes ? 256 : (te.kq == 5 ? 160 : 192))
+    let q40 = te.kq == 40
+    let qsb = (te.kq == 4 || q40) ? 128 : (te.kqBytes ? 256 : (te.kq == 5 ? 160 : 192))
     var wb = LLVMBuildMul(b, sbi, te.types->ConstI64(uint64(mr * qsb)), "wb")
-    var sb = LLVMBuildMul(b, sbi, te.types->ConstI64(uint64(mr * (k6 ? 18 : 20))), "sb")
+    var sb = LLVMBuildMul(b, sbi, te.types->ConstI64(uint64(mr * (k6 ? 18 : (q40 ? 16 : 20)))), "sb")
     var xb = LLVMBuildMul(b, sbi, te.types->ConstI64(0x100ul), "xb")
     var gb = LLVMBuildShl(b, sbi, te.types->ConstI64(3ul), "gb")
     var maskLoElems <- [for (i in range(w8)); LLVMConstInt(te.types.t_int8, uint64(1 << (i % 4)), 0)]
@@ -909,22 +910,27 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
     let memBcast = te.dotKind != DOT_SDOT && te.dotKind != DOT_SMMLA
     let madd16 = memBcast && te.dotKind == DOT_MADDUBS
     var vri8 = LLVMVectorType(te.types.t_int8, uint(te.rv))
-    // weight-side superblock scale rows: k4/k5 f16 d/dmin; k6 its f16 d row (dmin unused)
+    // weight-side superblock scale rows: k4/k5 f16 d/dmin; k6 its f16 d row (dmin unused).
+    // q40 has none — its per-32 f16 d loads live in the per-block fold below.
     var dv : LLVMOpaqueValue? [2]
     var mv : LLVMOpaqueValue? [2]
-    for (qd in range(rq)) {
-        if (k6) {
-            dv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(16 * mr + 2 * (qd * te.rv))), ""), "d{qd}")
-        } else {
-            dv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * (qd * te.rv))), ""), "d{qd}")
-            mv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * mr + 2 * (qd * te.rv))), ""), "dm{qd}")
+    if (!q40) {
+        for (qd in range(rq)) {
+            if (k6) {
+                dv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(16 * mr + 2 * (qd * te.rv))), ""), "d{qd}")
+            } else {
+                dv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * (qd * te.rv))), ""), "d{qd}")
+                mv[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * mr + 2 * (qd * te.rv))), ""), "dm{qd}")
+            }
         }
     }
     var iacc : LLVMOpaqueValue? [8]
     var bacc : LLVMOpaqueValue? [8]
+    var facc : LLVMOpaqueValue? [8]   // q40: float superblock accumulators (per-block d fold)
     for (i in range(tokCount * rq)) {
         iacc[i] = LLVMConstNull(te.vni32)
         bacc[i] = LLVMConstNull(te.vni32)
+        facc[i] = LLVMConstNull(te.vnf32)
     }
     for (blk in range(8)) {
         var xoff0 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32)), "")
@@ -1012,8 +1018,9 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
                 }
             }
             // i16 chain flushes at the format's overflow bound: k5 after 4 madds (j 1/3),
-            // k6 after 2 madds per chain (j 1/3); k4 runs the full 8 to the post-loop flush
-            if (madd16 && (j == 1 || j == 3) && te.kq != 4) {
+            // k6 after 2 madds per chain (j 1/3); k4/q40 (nibbles <= 15) run the full 8 to
+            // the post-loop flush
+            if (madd16 && (j == 1 || j == 3) && te.kq != 4 && !q40) {
                 for (k in range(tokCount * rq)) {
                     a0[k] = madd16_flush(te, a0[k], p16lo[k])
                     p16lo[k] = null
@@ -1024,18 +1031,23 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
                 }
             }
         }
-        if (madd16 && te.kq == 4) {   // k4: one widen per (token, qd) for the whole sub-block
+        if (madd16 && (te.kq == 4 || q40)) {   // one widen per (token, qd) for the whole sub-block
             for (k in range(tokCount * rq)) {
                 a0[k] = madd16_flush(te, a0[k], p16lo[k])
                 p16lo[k] = null
             }
         }
         // the integer fold — no float ops per block. k4/k5: iacc += sc·(lo+hi), bacc += mn·Σa32
-        // (u8 zext rows); k6: iacc += sc0·lo + sc1·hi, bacc += sc0·Σa16lo + sc1·Σa16hi (i8 sext)
+        // (u8 zext rows); k6: iacc += sc0·lo + sc1·hi, bacc += sc0·Σa16lo + sc1·Σa16hi (i8 sext).
+        // q40 instead pays its per-block float fma here: facc += float(lo+hi − 8·Σa32)·d(blk)
+        // — the per-32 f16 d admits no cross-block integer fold.
         var scv : LLVMOpaqueValue? [2]
         var mnv : LLVMOpaqueValue? [2]
+        var dvb : LLVMOpaqueValue? [2]
         for (qd in range(rq)) {
-            if (k6) {
+            if (q40) {
+                dvb[qd] = load_f16_vec_at(te, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(blk * 2 * mr + 2 * (qd * te.rv))), ""), "d{blk}_{qd}")
+            } elif (k6) {
                 var sc0p = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(2 * blk * mr + qd * te.rv)), ""), "scp{blk}_{qd}a")
                 var sc1p = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64((2 * blk + 1) * mr + qd * te.rv)), ""), "scp{blk}_{qd}b")
                 scv[qd] = LLVMBuildSExt(b, LLVMBuildLoad2Aligned(b, vri8, sc0p, 1u, ""), te.vni32, "sc{blk}_{qd}a")
@@ -1056,7 +1068,15 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
             var bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{tk}_{blk}a")
             var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2b, "bp{tk}_{blk}b")
             var bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{tk}_{blk}b")
-            if (k6) {
+            if (q40) {
+                var a32 = LLVMBuildAdd(b, bs0, bs1, "a32{tk}_{blk}")
+                var a32v = splat_i32(te, a32, "a32v{tk}_{blk}")
+                for (qd in range(rq)) {
+                    var acc = LLVMBuildAdd(b, a0[i * rq + qd], a1[i * rq + qd], "acc{tk}_{blk}_{qd}")
+                    var isub = LLVMBuildSub(b, acc, LLVMBuildMul(b, a32v, splat_i32n(te, 8), ""), "is{tk}_{blk}_{qd}")
+                    facc[i * rq + qd] = fold_fma(te, LLVMBuildSIToFP(b, isub, te.vnf32, ""), dvb[qd], facc[i * rq + qd], "fa{tk}_{blk}_{qd}")
+                }
+            } elif (k6) {
                 var bs0v = splat_i32(te, bs0, "bs0v{tk}_{blk}")
                 var bs1v = splat_i32(te, bs1, "bs1v{tk}_{blk}")
                 for (qd in range(rq)) {
@@ -1077,13 +1097,18 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
         }
     }
     // the superblock fold: k4/k5 f += float(iacc)·(d·d8); f -= float(bacc)·(dmin·d8);
-    // k6 f += float(iacc − 32·bacc)·(d·d8) — the −32 quant offset closed in exact int32
+    // k6 f += float(iacc − 32·bacc)·(d·d8) — the −32 quant offset closed in exact int32;
+    // q40 f += facc·d8 (the per-block d already folded above)
     for (i in range(tokCount)) {
         let tk = tokBase + i
         var qp = LLVMBuildGEP2(b, te.types.t_float, te.xs[tk], sbi, "qp{tk}")
         var d8 = LLVMBuildLoad2Aligned(b, te.types.t_float, qp, 4u, "d8{tk}")
         var d8v = splat_f32(te, d8, "d8v{tk}")
         for (qd in range(rq)) {
+            if (q40) {
+                f[i * rq + qd] = fold_fma(te, facc[i * rq + qd], d8v, f[i * rq + qd], "f{tk}_{qd}s")
+                continue
+            }
             var ds = LLVMBuildFMul(b, dv[qd], d8v, "ds{tk}_{qd}")
             if (k6) {
                 var isub = LLVMBuildSub(b, iacc[i * rq + qd], LLVMBuildMul(b, bacc[i * rq + qd], splat_i32n(te, 32), ""), "is{tk}_{qd}")
@@ -2278,8 +2303,8 @@ def private kq_gemv_gen_impl(var gc : LlvmCodeCtx; fmt : int) : bool {
     let rbv = LLVMGetParam(gc.impl, 7u)
     let rev = LLVMGetParam(gc.impl, 8u)
     sa.nb = LLVMBuildSDiv(b, n, te.types->ConstI64(0x100ul), "nsb")
-    var qrow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(uint64(fmt == 4 ? 128 : (fmt == 5 ? 160 : 192))), "qrow")
-    var srow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(uint64(fmt == 6 ? 18 : 20)), "srow")
+    var qrow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(uint64(kq_qsb(fmt))), "qrow")
+    var srow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(uint64(kq_ssb(fmt))), "srow")
     sa.d = te.types->ConstI64(0ul)
     sa.t0 = te.types->ConstI64(0ul)
     let mrC = te.types->ConstI64(uint64(te.interleave))
@@ -2315,6 +2340,7 @@ def private kq_gemv_gen_impl(var gc : LlvmCodeCtx; fmt : int) : bool {
 def private k4_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 4)
 def private k5_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 5)
 def private k6_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 6)
+def private q40_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 40)
 
 // The K-quant 4-token TILE (the kq batch family — weight-stationary prefill): same 10-arg
 // contract as the q8 tile (yp, kqg, ksg, xq image, xs, xbs, n, d, g, t0 — kqg/ksg are the
@@ -2331,7 +2357,7 @@ def private kq_tile_gen_impl(var gc : LlvmCodeCtx; fmt : int) : bool {
     if (perm_declines(gc, p0)) return false
     let p = companion_perm(p0)
 
-    var te = TileEmit(kq = fmt, kqBytes = fmt != 4)
+    var te = TileEmit(kq = fmt, kqBytes = fmt == 5 || fmt == 6)   // k4/q40 tiles read the packed planes
     if (!setup_tile_emit(te, gc, p, false)) return false
 
     let b = gc.jit.builder
@@ -2376,6 +2402,7 @@ def private kq_tile_gen_impl(var gc : LlvmCodeCtx; fmt : int) : bool {
 def private k4_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 4)
 def private k5_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 5)
 def private k6_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 6)
+def private q40_tile_gen(var gc : LlvmCodeCtx) : bool => kq_tile_gen_impl(gc, 40)
 
 // Called from llvm_user_modules::register_user_llvm_code_generators — the JIT invokes that in the
 // context that reads the registry, so the direct call lands in the right table copy.
@@ -2398,5 +2425,7 @@ def public register_dasllama_gemm_generators {
     register_llvm_code_generator("dasllama_gemm_gen::k4_tile", @@k4_tile_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k5_tile", @@k5_tile_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k6_tile", @@k6_tile_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::q40_gemv", @@q40_gemv_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::q40_tile", @@q40_tile_gen)
     register_llvm_code_generator("dasllama_gemm_gen::q8q8_witness", @@witness_gen)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_schema.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_schema.das
@@ -38,3 +38,24 @@ def q8q8_repack_type(mr : int; wbias : int = 0; kgroup : int = 4) : Q8RepackType
 //! the tile generator emits the grp<mr> kernel and the layout companion reports mr to the
 //! runtime repack — stamped from one manifest entry, declining in lockstep (M4).
 let GEMM_REFERENCE_MR = 4
+
+//! Quant-plane bytes per 256-weight superblock per row for a kq format id (4/5/6 = Q4_K/Q5_K/
+//! Q6_K, 40 = Q4_0). The ONE stride source for every fmt-branched kq walker/kernel/repack —
+//! an unknown id panics instead of silently walking another format's stride.
+def kq_qsb(fmt : int) : int64 {
+    if (fmt == 4 || fmt == 40) return 128l
+    if (fmt == 5) return 160l
+    if (fmt == 6) return 192l
+    panic("kq_qsb: unknown kq format id {fmt}")
+    return 0l
+}
+
+//! Scale-plane bytes per 256-weight superblock per row (see kq_qsb): k4/k5 20 (16B disk block
+//! + 4B pad, decoded in place at repack), k6 18 (native), q40 16 (8 x f16 d, verbatim).
+def kq_ssb(fmt : int) : int64 {
+    if (fmt == 4 || fmt == 5) return 20l
+    if (fmt == 6) return 18l
+    if (fmt == 40) return 16l
+    panic("kq_ssb: unknown kq format id {fmt}")
+    return 0l
+}

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -880,6 +880,31 @@ def dequant_k6_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<u
     }
 }
 
+//! Transcode one Q4_0 superblock (8 x 18-byte disk blocks at `bo`) into the q40 planes: per
+//! block the f16 d halfword to ks[kso + 2*blk), the 16 nibble bytes verbatim to kq (exact).
+def transcode_q40_superblock(bytes : array<uint8> | #; bo : int64; var kq : array<uint8>; kqo : int64; var ks : array<uint8>; kso : int64) {
+    for (blk in range64(8l)) {
+        ks[kso + blk * 2l] = bytes[bo + blk * 18l]
+        ks[kso + blk * 2l + 1l] = bytes[bo + blk * 18l + 1l]
+        for (i in range64(16l)) {
+            kq[kqo + blk * 16l + i] = bytes[bo + blk * 18l + 2l + i]
+        }
+    }
+}
+
+//! Reference dequant of one q40-plane superblock: w = d * (q - 8) per 32-block, q = nibble
+//! (low = k, high = k+16 — the disk pairing, kept verbatim by the transcode).
+def dequant_q40_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float> | #; doff : int64) {
+    for (blk in range64(8l)) {
+        let d = f16_to_f32(rd_u16(ks, kso + blk * 2l))
+        for (l in range64(16l)) {
+            let b = int(kq[kqo + blk * 16l + l])
+            dst[doff + blk * 32l + l] = d * float((b & 15) - 8)
+            dst[doff + blk * 32l + 16l + l] = d * float((b >> 4) - 8)
+        }
+    }
+}
+
 // K-quant plane strides (bytes per 256-weight superblock)
 let K4_QSB = 128l
 let K4_SSB = 20l   // kq v2: 16B verbatim disk scale block + 4B pad (repack decodes in place)
@@ -887,6 +912,8 @@ let K5_QSB = 160l
 let K5_SSB = 20l   // kq v2: 16B verbatim disk scale block + 4B pad (the k4 form)
 let K6_QSB = 192l
 let K6_SSB = 18l
+let Q40_QSB = 128l   // q40 tier: 8 x 16 nibble bytes (the k4 pairing, k / k+16 per 32-block)
+let Q40_SSB = 16l    // 8 x f16 d, verbatim disk halfwords
 
 // Raw byte copy via unaligned u64 moves + byte tail — the workhorse of the pointerized transcode
 // loops (uint8 source and destination regions never overlap).
@@ -1019,6 +1046,38 @@ def gguf_transcode_q6k(m : GGUFMeta; srcbytes : array<uint8> | #; name : string;
                     for (blk in range64(int64(rb), int64(re))) {
                         bcopy(kqp + blk * K6_QSB, srcp + blk * 210l, 192l)   // ql then qh — disk order
                         bcopy(ksp + blk * K6_SSB, srcp + blk * 210l + 192l, 18l)   // 16 sub-scales + f16 d
+                    }
+                }
+            }
+        }
+    }
+}
+
+//! Transcode a Q4_0 tensor into the q40 planes (see gguf_transcode_q4k; strides 128/16, exact):
+//! per 32-block the 18 disk bytes split into 2B f16 d (scale plane) + 16B nibbles (quant plane).
+def gguf_transcode_q40(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    let ti = kq_transcode_check(m, name, GGML_TYPE_Q4_0, "Q4_0", src_off, expect_n)
+    let nb = expect_n / 256l
+    if (nb <= 0l) {
+        return
+    }
+    guard_dst(name, "q40 quant plane", (eloff / 256l) * Q40_QSB, nb * Q40_QSB, long_length(kq))
+    guard_dst(name, "q40 scale plane", (eloff / 256l) * Q40_SSB, nb * Q40_SSB, long_length(ks))
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        let bo = tbase + (src_off / 256l) * 144l   // 8 x 18B disk blocks per superblock
+        unsafe {
+            let srcp = addr<uint8 const?>(bytes[bo])
+            var kqp = addr(kq[(eloff / 256l) * Q40_QSB])
+            var ksp = addr(ks[(eloff / 256l) * Q40_SSB])
+            maybe_parallel_for(0, int(nb), transcode_jobs(nb, 144l)) $(rb, re) {
+                unsafe {
+                    for (sb in range64(int64(rb), int64(re))) {
+                        for (blk in range64(8l)) {
+                            let src = srcp + sb * 144l + blk * 18l
+                            ksp[sb * Q40_SSB + blk * 2l] = src[0]        // f16 d
+                            ksp[sb * Q40_SSB + blk * 2l + 1l] = src[1]
+                            bcopy(kqp + sb * Q40_QSB + blk * 16l, src + 2l, 16l)
+                        }
                     }
                 }
             }

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -9,6 +9,7 @@ require daslib/jobque_boost public  // matmul's threaded path expands parallel_f
 require daslib/jobque_profile  // named trace categories + unit markers (set_trace_tags registers them)
 require dasllama/dasllama_par  // maybe_parallel_for: thread-or-inline a kernel body on a runtime size flag
 require dasllama/dasllama_tune  // [tuned]: reconstitute dot from dot_template with per-box loop hints
+require dasllama/dasllama_gemm_schema  // kq_qsb/kq_ssb — the fmt-id kq plane strides
 require llvm/daslib/f16_cvt  // f16<->f32 converts: JIT half intrinsics on aarch64 / x64+F16C, exact bit-twiddle elsewhere
 
 // dasLLAMA numeric primitives — naive fp32 baseline (curriculum step 1).
@@ -1375,6 +1376,7 @@ struct KernelBackend {
     kq_rows_k4 : MatmulKqRowsFn = @@kq_unset_rows
     kq_rows_k5 : MatmulKqRowsFn = @@kq_unset_rows
     kq_rows_k6 : MatmulKqRowsFn = @@kq_unset_rows
+    kq_rows_q40 : MatmulKqRowsFn = @@kq_unset_rows
     kq_batch : MatmulKqBatchFn = @@kq_unset_batch
     kq_groupn : MatmulKqGroupNFn = @@kq_unset_groupn
     kq_batch_groupn : MatmulKqBatchGroupNFn = @@kq_unset_batch_groupn
@@ -1436,6 +1438,7 @@ var g_mm_kq = @@kq_unset_kernel
 var g_kq_rows_k4 = @@kq_unset_rows
 var g_kq_rows_k5 = @@kq_unset_rows
 var g_kq_rows_k6 = @@kq_unset_rows
+var g_kq_rows_q40 = @@kq_unset_rows
 var g_mm_kq_batch = @@kq_unset_batch
 var g_mm_kq_groupn = @@kq_unset_groupn
 var g_mm_kq_batch_groupn = @@kq_unset_batch_groupn
@@ -1595,6 +1598,7 @@ def private activate(be : KernelBackend) {
     g_kq_rows_k4 = be.kq_rows_k4
     g_kq_rows_k5 = be.kq_rows_k5
     g_kq_rows_k6 = be.kq_rows_k6
+    g_kq_rows_q40 = be.kq_rows_q40
     g_mm_kq_batch = be.kq_batch
     g_mm_kq_groupn = be.kq_groupn
     g_mm_kq_batch_groupn = be.kq_batch_groupn
@@ -1770,12 +1774,15 @@ def kernel_backend_has_kq() : bool {
     return g_active_has_kq
 }
 
-//! The active backend's K-quant rows core for `fmt` (4/5/6) — the chains' kq twin of
-//! mm_q8q8_rows_fn. Same read-into-a-local-then-capture rule.
+//! The active backend's K-quant rows core for `fmt` (4/5/6/40) — the chains' kq twin of
+//! mm_q8q8_rows_fn. Same read-into-a-local-then-capture rule. Any other id (kq_fi's q8
+//! poison 0 included) gets the panic stub — never a silently-wrong format's core.
 def kq_rows_fn(fmt : int) : MatmulKqRowsFn {
     if (fmt == 4) return g_kq_rows_k4
     if (fmt == 5) return g_kq_rows_k5
-    return g_kq_rows_k6
+    if (fmt == 6) return g_kq_rows_k6
+    if (fmt == 40) return g_kq_rows_q40
+    return @@kq_unset_rows
 }
 
 //! Does the active backend carry the batched kq GEMM (kq_batch — the prefill tile)? The
@@ -1835,8 +1842,8 @@ def matmul_kq_groupn_active(fmt : int; var y : array<float> | #; kq : array<uint
 //! matmul_kq_active. Callers guard with kq_repacked && kernel_backend_has_kq_batch().
 def matmul_kq_batch(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; woff : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d, ntok : int64) {
     let sb = woff / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     unsafe {
         invoke(g_mm_kq_batch, fmt, addr(y[0]),
             addr<uint8 const?>(kq[sb * qsb]), addr<uint8 const?>(ks[sb * ssb]),
@@ -1850,8 +1857,8 @@ def matmul_kq_batch(fmt : int; var y : array<float> | #; kq : array<uint8> | #; 
 //! to the active backend's mm_kq; callers guard with the model's kq_repacked record.
 def matmul_kq_active(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; woff : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64; yoff : int64 = 0l) {
     let sb = woff / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     unsafe {
         invoke(g_mm_kq, fmt, addr(y[yoff]),
             addr<uint8 const?>(kq[sb * qsb]), addr<uint8 const?>(ks[sb * ssb]),
@@ -1865,8 +1872,8 @@ def matmul_kq_active(fmt : int; var y : array<float> | #; kq : array<uint8> | #;
 //! backend is active. n % 256 == 0 (the ggml K-quant row invariant).
 def repack_kq_weight(fmt : int; var kq : array<uint8>; var ks : array<uint8>; woff, n, d : int64) {
     let sb = woff / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     unsafe {
         invoke(g_repack_kq, fmt, addr(kq[sb * qsb]), addr(ks[sb * ssb]), n, d)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_math_default.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_default.das
@@ -4,6 +4,7 @@ module dasllama_math_default shared public
 
 require dasllama/dasllama_math       // KernelBackend + register_kernel_backend + the matmul_chunks shapers + repack_q8q8_identity
 require dasllama/dasllama_tune       // [tuned]: reconstitute dot_q8q8 from its template with per-box loop hints
+require dasllama/dasllama_gemm_schema  // kq_qsb/kq_ssb — the fmt-id kq plane strides
 require llvm/daslib/f16_cvt          // dot_q8q8_f16s widens the binary16 weight scale in-loop
 require daslib/jobque_boost public   // parallel_for / notify_and_release (the kernels expand parallel_for)
 require dasllama/dasllama_par        // maybe_parallel_for
@@ -437,6 +438,40 @@ def dot_k6q8(kqrow : uint8 const?; ksrow : uint8 const?; xqp : int8 const?; xsp 
     return acc
 }
 
+// q40 (native Q4_0): Q8_K-form activations like the K-quants; w = d·(q − 8) with a PER-32 f16
+// d, so the fold is per BLOCK — facc accumulates float(ilo + ihi − 8·Σa32)·d over the
+// superblock's 8 blocks (Σa32 = the two per-16 bsums), closed by ONE ·d8. Ints exact; the
+// float order (per-block fma into facc, per-superblock fma into acc) is the contract every
+// q40 kernel reproduces.
+[hint(unsafe_range_check, noalias = kqrow, noalias = ksrow, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def dot_q40q8(kqrow : uint8 const?; ksrow : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    var acc = 0.0
+    unsafe {
+        for (sb in range64(n / 256l)) {
+            let kqo = sb * 128l
+            let kso = sb * 16l
+            var facc = 0.0
+            for (blk in range64(8l)) {
+                let qb = kqo + 16l * blk
+                let b = sb * 8l + blk
+                let ab = b * 32l
+                var ilo = 0
+                var ihi = 0
+                for (l in range64(16l)) {
+                    let q = int(kqrow[qb + l])
+                    ilo += (q & 15) * int(xqp[ab + l])
+                    ihi += (q >> 4) * int(xqp[ab + 16l + l])
+                }
+                let isub = ilo + ihi - 8 * (xbsp[b * 2l] + xbsp[b * 2l + 1l])
+                let d = f16_to_f32(uint(ksrow[kso + 2l * blk]) | (uint(ksrow[kso + 2l * blk + 1l]) << 8u))
+                facc += float(isub) * d
+            }
+            acc += facc * xsp[sb]
+        }
+    }
+    return acc
+}
+
 // Row-range cores + full GEMVs per format. Not `private`: invoked through hoisted function
 // pointers from lifted worker lambdas (the fused chains) and the dispatch wrappers in common.
 def k4_rows_kernel(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
@@ -466,6 +501,15 @@ def k6_rows_kernel(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp 
     }
 }
 
+def q40_rows_kernel(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) {
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            yp[i] = dot_q40q8(kqp + i * nsb * 128l, ksp + i * nsb * 16l, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
 def private kq_gemv_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
     var myp = yp
     maybe_parallel_for(0, int(d), matmul_chunks_gemv(int(d), 1, n * d)) $(rb, re) {
@@ -473,6 +517,8 @@ def private kq_gemv_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp :
             k4_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
         } elif (fmt == 5) {
             k5_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
+        } elif (fmt == 40) {
+            q40_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
         } else {
             k6_rows_kernel(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb), int64(re))
         }
@@ -485,8 +531,29 @@ def private kq_gemv_kernel(fmt : int; var yp : float?; kqp : uint8 const?; ksp :
 //! per-token, so scalar is fine.
 def dequant_kq_row_grp(fmt : int64; kqg : uint8 const?; ksg : uint8 const?; r, mr, n : int64; var dst : float?) {
     let nsb = n / 256l
-    let qsb = fmt == 4l ? 128l : (fmt == 5l ? 160l : 192l)
-    let ssb = fmt == 6l ? 18l : 20l
+    let qsb = kq_qsb(int(fmt))
+    let ssb = kq_ssb(int(fmt))
+    if (fmt == 40l) {
+        // q40 grp: the k4 nibble tiling with a per-block f16 d plane — w = d·(q − 8)
+        unsafe {
+            for (sbi in range64(nsb)) {
+                let qb = sbi * qsb * mr
+                let sb = sbi * ssb * mr
+                for (blk in range64(8l)) {
+                    let kb = sbi * 256l + blk * 32l
+                    let d = f16_to_f32(uint(ksg[sb + blk * 2l * mr + 2l * r]) | (uint(ksg[sb + blk * 2l * mr + 2l * r + 1l]) << 8u))
+                    for (j in range64(4l)) {
+                        for (t in range64(4l)) {
+                            let nib = uint(kqg[qb + ((blk * 4l + j) * mr + r) * 4l + t])
+                            dst[kb + j * 4l + t] = d * float(int(nib & 15u) - 8)
+                            dst[kb + 16l + j * 4l + t] = d * float(int(nib >> 4u) - 8)
+                        }
+                    }
+                }
+            }
+        }
+        return
+    }
     unsafe {
         for (sbi in range64(nsb)) {
             let qb = sbi * qsb * mr
@@ -544,8 +611,8 @@ def dequant_kq_row_grp(fmt : int64; kqg : uint8 const?; ksg : uint8 const?; r, m
 //! y[yoff .. yoff+d) (batched callers pass the token row base).
 def matmul_kq(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; woff : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64; yoff : int64 = 0l) {
     let sb = woff / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     unsafe {
         kq_gemv_kernel(fmt, addr(y[yoff]), addr(kq[sb * qsb]), addr(ks[sb * ssb]),
                        addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d)
@@ -558,8 +625,8 @@ def matmul_kq(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : a
 //! stack is one tensor. No bias form (the only biased-experts arch, gpt-oss, is mx4).
 def matmul_kq_groupn(fmt : int; var y : array<float> | #; kq : array<uint8> | #; ks : array<uint8> | #; offs : array<int64> | #; nregions : int64; xq : array<int8> | #; xs : array<float> | #; xbs : array<int> | #; n, d : int64) {
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     unsafe {
         let kqp = addr<uint8 const?>(kq[0])
         let ksp = addr<uint8 const?>(ks[0])
@@ -580,6 +647,8 @@ def matmul_kq_groupn(fmt : int; var y : array<float> | #; kq : array<uint8> | #;
                         myp[ii] = dot_k4q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
                     } elif (fmt == 5) {
                         myp[ii] = dot_k5q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
+                    } elif (fmt == 40) {
+                        myp[ii] = dot_q40q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
                     } else {
                         myp[ii] = dot_k6q8(kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
                     }

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -28,8 +28,8 @@ require math
 // biased busd512 on AVX512-VNNI boxes / biased busd256 on VEX-VNNI / maddubs on plain AVX2 /
 // kstep2 elsewhere — each ISA's measured tune winner as the manifest-less default);
 // DAS_TUNE_MODE=tune/test stamps the grid + the *_variants() registries for the harness
-// (gen_parity_probe / gen_tune_probe). The K-quant kernels are their OWN three [tune]
-// families (k4/k5/k6q8_tile_gen + gemv/layout companions, one manifest entry per format) —
+// (gen_parity_probe / gen_tune_probe). The K-quant kernels are their OWN four [tune]
+// families (k4/k5/k6/q40q8_tile_gen + gemv/layout companions, one manifest entry per format) —
 // the kq tiles measurably prefer different (mr, nrsplit) than the q8 crown (M1 2026-07-12:
 // k5 tile +30% on grp4/single-unpack vs the q8 grp8/nrsplit2 stamp), and per-format layout
 // companions let each format's planes take their own interleave. This module registers TWO
@@ -264,6 +264,10 @@ def k6q8_layout_gen() : int {
     return q8q8_repack_type(GEMM_REFERENCE_MR).interleave
 }
 
+def q40q8_layout_gen() : int {
+    return q8q8_repack_type(GEMM_REFERENCE_MR).interleave
+}
+
 // the KernelBackend.kq_layout slot form of kq_layout_of (registered on both gen backends)
 def private kq_layout_fmt_gen(fmt : int) : int => int(kq_layout_of(fmt))
 
@@ -276,7 +280,43 @@ def kq_layout_of(fmt : int) : int64 {
     if (fmt == 5) {
         return int64(k5q8_layout_gen())
     }
+    if (fmt == 40) {
+        return int64(q40q8_layout_gen())
+    }
     return int64(k6q8_layout_gen())
+}
+
+//! One row's dot off the grp<mr> q40 planes, scalar — the q40 stubs' reference body and the
+//! tests' repack oracle (kq_grp_row_dot's q40 sibling; the quant plane IS the k4 tiling, only
+//! the scale plane differs: per-block f16 d at [blk][mr f16]). Same float order as dot_q40q8:
+//! per-block fma of float(ilo + ihi − 8·Σa32)·d into facc, per-superblock fma of facc·d8.
+def q40_grp_row_dot(kqg : uint8 const?; ksg : uint8 const?; r, mr : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    var acc = 0.0
+    let nsb = n / 256l
+    unsafe {
+        for (sbi in range64(nsb)) {
+            let qb = sbi * 128l * mr
+            let sb = sbi * 16l * mr
+            var facc = 0.0
+            for (blk in range64(8l)) {
+                let b = sbi * 8l + blk
+                var ilo = 0
+                var ihi = 0
+                for (j in range64(4l)) {
+                    for (t in range64(4l)) {
+                        let nib = uint(kqg[qb + ((blk * 4l + j) * mr + r) * 4l + t])
+                        ilo += int(nib & 15u) * int(xqp[b * 32l + j * 4l + t])
+                        ihi += int(nib >> 4u) * int(xqp[b * 32l + 16l + j * 4l + t])
+                    }
+                }
+                let isub = ilo + ihi - 8 * (xbsp[b * 2l] + xbsp[b * 2l + 1l])
+                let d = f16_to_f32(uint(ksg[sb + blk * 2l * mr + 2l * r]) | (uint(ksg[sb + blk * 2l * mr + 2l * r + 1l]) << 8u))
+                facc += float(isub) * d
+            }
+            acc += facc * xsp[sbi]
+        }
+    }
+    return acc
 }
 
 //! The K-quant GEMV kernels (kq stage 4): rows [rb, re) of one plane-region pair off the
@@ -317,6 +357,18 @@ def k6q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp :
         for (i in range64(rb, re)) {
             let g = i / mr
             yp[i] = kq_grp_row_dot(6l, kqp + g * mr * nsb * 192l, ksp + g * mr * nsb * 18l, i % mr, mr, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+[hint(unsafe_range_check, noalias = kqp, noalias = ksp, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def q40q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) : void {
+    let mr = int64(q40q8_layout_gen())
+    let nsb = n / 256l
+    unsafe {
+        for (i in range64(rb, re)) {
+            let g = i / mr
+            yp[i] = q40_grp_row_dot(kqp + g * mr * nsb * 128l, ksp + g * mr * nsb * 16l, i % mr, mr, xqp, xsp, xbsp, n)
         }
     }
 }
@@ -394,6 +446,26 @@ def k6q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp :
         for (t in range64(4l)) {
             for (r in range64(mr)) {
                 yp[(t0 + t) * d + g * mr + r] = kq_grp_row_dot_b(6l, kqg, ksg, r, mr, xqp + (t0 + t) * n, xsp + (t0 + t) * (n / 256l), xbsp + (t0 + t) * (n / 16l), n)
+            }
+        }
+    }
+}
+
+[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8, nrsplit = 2),
+ tune_perm(dot = "maddubs", width = 256, mr = 8, requires = "avx2"), tune_perm(dot = "maddubs", width = 256, mr = 8, nrsplit = 2, requires = "avx2"),
+ tune_perm(dot = "vpdpbusd", width = 256, mr = 8, requires = "avxvnni|avx512vnni"), tune_perm(dot = "vpdpbusd", width = 256, mr = 8, nrsplit = 2, requires = "avxvnni|avx512vnni"),
+ tune_perm(dot = "vpdpbusd", width = 512, mr = 16, requires = "avx512vnni,avx512bw"), tune_perm(dot = "vpdpbusd", width = 512, mr = 16, nrsplit = 2, requires = "avx512vnni,avx512bw"),
+ tune_companion(fn = "q40q8_gemv_gen", gen = "dasllama_gemm_gen::q40_gemv"),
+ tune_companion(fn = "q40q8_layout_gen", gen = "dasllama_gemm_gen::q8q8_layout"),
+ tune(gen = "dasllama_gemm_gen::q40_tile",
+      fallback = "dot_vpdpbusd_width512_mr16;dot_vpdpbusd_width256_mr8;dot_maddubs_width256_mr8;mr4"),
+ hint(unsafe_range_check, noalias = kqg, noalias = ksg, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def q40q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, g, t0 : int64) : void {
+    let mr = int64(q40q8_layout_gen())
+    unsafe {
+        for (t in range64(4l)) {
+            for (r in range64(mr)) {
+                yp[(t0 + t) * d + g * mr + r] = q40_grp_row_dot(kqg, ksg, r, mr, xqp + (t0 + t) * n, xsp + (t0 + t) * (n / 256l), xbsp + (t0 + t) * (n / 16l), n)
             }
         }
     }
@@ -826,6 +898,51 @@ def repack_k6_grp(var kq : uint8?; var ks : uint8?; n, d, mr : int64) {
     delete ts
 }
 
+def repack_q40_grp(var kq : uint8?; var ks : uint8?; n, d, mr : int64) {
+    // q40 grp layout: quants land byte-for-byte in the k4 tiling — the disk bytes already carry
+    // the k / k+16 nibble pairing, so byte t of (blk, j) is disk byte blk*16 + j*4 + t (a pure
+    // gather); scales interleave per block: [blk 0..7][mr x f16 d]
+    let nsb = n / 256l
+    let qrow = nsb * 128l
+    let srow = nsb * 16l
+    let ng = d / mr
+    var tq : array<uint8>
+    var ts : array<uint8>
+    tq |> resize(int(d * qrow))
+    ts |> resize(int(d * srow))
+    unsafe {
+        var tqp = addr(tq[0])
+        var tsp = addr(ts[0])
+        for (i in range64(d * qrow)) {
+            tqp[i] = kq[i]
+        }
+        for (i in range64(d * srow)) {
+            tsp[i] = ks[i]
+        }
+        for (g in range64(ng)) {
+            for (sbi in range64(nsb)) {
+                let dq = g * mr * qrow + sbi * 128l * mr
+                let ds = g * mr * srow + sbi * 16l * mr
+                for (r in range64(mr)) {
+                    let sq = (g * mr + r) * qrow + sbi * 128l
+                    let ss = (g * mr + r) * srow + sbi * 16l
+                    for (blk in range64(8l)) {
+                        for (j in range64(4l)) {
+                            for (t in range64(4l)) {
+                                kq[dq + ((blk * 4l + j) * mr + r) * 4l + t] = tqp[sq + blk * 16l + j * 4l + t]
+                            }
+                        }
+                        ks[ds + blk * 2l * mr + 2l * r] = tsp[ss + blk * 2l]        // f16 d
+                        ks[ds + blk * 2l * mr + 2l * r + 1l] = tsp[ss + blk * 2l + 1l]
+                    }
+                }
+            }
+        }
+    }
+    delete tq
+    delete ts
+}
+
 //! Unpack ONE group's packed grp<mr> k5/k6 quant panel (nsb superblocks x mr rows) into the
 //! BYTE-EXPANDED tile form: per superblock [blk][j][row][4B] full-byte weight k (128*mr), then
 //! the k+16 region at +128*mr — the wlo/whi images the kqBytes tile stamps load verbatim
@@ -951,6 +1068,8 @@ def private repack_kq_gen(fmt : int; var kq : uint8?; var ks : uint8?; n, d : in
         repack_k4_grp(kq, ks, n, d, int64(k4q8_layout_gen()))
     } elif (fmt == 5) {
         repack_k5_grp(kq, ks, n, d, int64(k5q8_layout_gen()))
+    } elif (fmt == 40) {
+        repack_q40_grp(kq, ks, n, d, int64(q40q8_layout_gen()))
     } else {
         repack_k6_grp(kq, ks, n, d, int64(k6q8_layout_gen()))
     }
@@ -1491,6 +1610,8 @@ def private kq_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : 
             k4q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
         } elif (fmt == 5) {
             k5q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
+        } elif (fmt == 40) {
+            q40q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
         } else {
             k6q8_gemv_gen(myp, kqp, ksp, xqp, xsp, xbsp, n, int64(rb) * mr, int64(re) * mr)
         }
@@ -1501,6 +1622,8 @@ def private kq_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : 
                 myp[i] = dot_k4q8(kqp + i * nsb * 128l, ksp + i * nsb * 20l, xqp, xsp, xbsp, n)
             } elif (fmt == 5) {
                 myp[i] = dot_k5q8(kqp + i * nsb * 160l, ksp + i * nsb * 20l, xqp, xsp, xbsp, n)
+            } elif (fmt == 40) {
+                myp[i] = dot_q40q8(kqp + i * nsb * 128l, ksp + i * nsb * 16l, xqp, xsp, xbsp, n)
             } else {
                 myp[i] = dot_k6q8(kqp + i * nsb * 192l, ksp + i * nsb * 18l, xqp, xsp, xbsp, n)
             }
@@ -1516,15 +1639,16 @@ def private kq_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : 
 // keep the packed form the gemv tails (and the bandwidth-bound decode path) stream.
 def private kq_batch_cell_gen(fmt : int; var myp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d, mr, TB : int64; ub, ue : int; tb0, tend : int64) {
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     let nb16 = n / 16l
+    let packed = fmt == 4 || fmt == 40   // pure-nibble planes: the tile reads them directly
     var scratch : array<uint8>
-    if (fmt != 4) {
+    if (!packed) {
         scratch |> resize(int(mr * nsb * 256l))
     }
     unsafe {
-        var scp = fmt != 4 ? addr(scratch[0]) : reinterpret<uint8?>(null)
+        var scp = !packed ? addr(scratch[0]) : reinterpret<uint8?>(null)
         var tb = tb0
         while (tb < tend) {
             let tbe = min(tb + TB, tend)
@@ -1534,7 +1658,7 @@ def private kq_batch_cell_gen(fmt : int; var myp : float?; kqp : uint8 const?; k
                 let kqg = kqp + g * mr * nsb * qsb
                 let ksg = ksp + g * mr * nsb * ssb
                 var tk = tb
-                if (tk < tb4 && fmt != 4) {
+                if (tk < tb4 && !packed) {
                     unpack_kq_panel_grp(int64(fmt), kqg, scp, mr, nsb)
                 }
                 while (tk < tb4) {
@@ -1542,6 +1666,8 @@ def private kq_batch_cell_gen(fmt : int; var myp : float?; kqp : uint8 const?; k
                         k4q8_tile_gen(myp, kqg, ksg, xqp, xsp, xbsp, n, d, g, tk)
                     } elif (fmt == 5) {
                         k5q8_tile_gen(myp, scp, ksg, xqp, xsp, xbsp, n, d, g, tk)
+                    } elif (fmt == 40) {
+                        q40q8_tile_gen(myp, kqg, ksg, xqp, xsp, xbsp, n, d, g, tk)
                     } else {
                         k6q8_tile_gen(myp, scp, ksg, xqp, xsp, xbsp, n, d, g, tk)
                     }
@@ -1552,6 +1678,8 @@ def private kq_batch_cell_gen(fmt : int; var myp : float?; kqp : uint8 const?; k
                         k4q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
                     } elif (fmt == 5) {
                         k5q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
+                    } elif (fmt == 40) {
+                        q40q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
                     } else {
                         k6q8_gemv_gen(myp + tk * d, kqp, ksp, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n, g * mr, (g + 1l) * mr)
                     }
@@ -1585,6 +1713,8 @@ def private kq_batch_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
                     myp[tk * d + i] = dot_k4q8(kqp + i * nsb * 128l, ksp + i * nsb * 20l, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * (n / 16l), n)
                 } elif (fmt == 5) {
                     myp[tk * d + i] = dot_k5q8(kqp + i * nsb * 160l, ksp + i * nsb * 20l, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * (n / 16l), n)
+                } elif (fmt == 40) {
+                    myp[tk * d + i] = dot_q40q8(kqp + i * nsb * 128l, ksp + i * nsb * 16l, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * (n / 16l), n)
                 } else {
                     myp[tk * d + i] = dot_k6q8(kqp + i * nsb * 192l, ksp + i * nsb * 18l, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * (n / 16l), n)
                 }
@@ -1600,8 +1730,8 @@ def private kq_batch_kernel_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
 // of kq_batch_kernel_gen; row tails (d % mr) disk-order per (region, token).
 def private kq_batch_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     let mr = kq_layout_of(fmt)
     let ng = d / mr
     let nb16 = n / 16l
@@ -1633,6 +1763,8 @@ def private kq_batch_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
                         myp[tk * d + i] = dot_k4q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n)
                     } elif (fmt == 5) {
                         myp[tk * d + i] = dot_k5q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n)
+                    } elif (fmt == 40) {
+                        myp[tk * d + i] = dot_q40q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n)
                     } else {
                         myp[tk * d + i] = dot_k6q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + tk * n, xsp + tk * (n / 256l), xbsp + tk * nb16, n)
                     }
@@ -1648,8 +1780,8 @@ def private kq_batch_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; 
 // the groupn bit-exactness gate in test_kquant drives it directly over per-region grp slices.
 def kq_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, d : int64) {
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     let mr = kq_layout_of(fmt)
     let ng = d / mr
     var myp = yp
@@ -1666,6 +1798,8 @@ def kq_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 co
                     k4q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
                 } elif (fmt == 5) {
                     k5q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
+                } elif (fmt == 40) {
+                    q40q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
                 } else {
                     k6q8_gemv_gen(myp + r * d, kqp + sb * qsb, ksp + sb * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n, gLocal * mr, gEnd * mr)
                 }
@@ -1682,6 +1816,8 @@ def kq_groupn_gen(fmt : int; var yp : float?; kqp : uint8 const?; ksp : uint8 co
                     myp[r * d + i] = dot_k4q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
                 } elif (fmt == 5) {
                     myp[r * d + i] = dot_k5q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
+                } elif (fmt == 40) {
+                    myp[r * d + i] = dot_q40q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
                 } else {
                     myp[r * d + i] = dot_k6q8(kqp + (sb + i * nsb) * qsb, ksp + (sb + i * nsb) * ssb, xqp + xoff, xsp + xoff / 256l, xbsp + xoff / 16l, n)
                 }
@@ -1970,7 +2106,8 @@ def dasllama_math_gen_register() {
             // the no-witness stance above covers kq too
             mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
             kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
-            kq_rows_k6 = @@k6q8_gemv_gen, kq_batch = @@kq_batch_kernel_gen,
+            kq_rows_k6 = @@k6q8_gemv_gen, kq_rows_q40 = @@q40q8_gemv_gen,
+            kq_batch = @@kq_batch_kernel_gen,
             kq_groupn = @@kq_groupn_gen, kq_batch_groupn = @@kq_batch_groupn_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, kq_layout = @@kq_layout_fmt_gen, q8_wbias = @@q8q8_wbias_gen,
@@ -1996,7 +2133,8 @@ def dasllama_math_gen_register() {
             mm_rows_s16 = @@q8q8_gemv_s16_gen,
             mm_kq = @@kq_kernel_gen, repack_kq = @@repack_kq_gen,
             kq_rows_k4 = @@k4q8_gemv_gen, kq_rows_k5 = @@k5q8_gemv_gen,
-            kq_rows_k6 = @@k6q8_gemv_gen, kq_batch = @@kq_batch_kernel_gen,
+            kq_rows_k6 = @@k6q8_gemv_gen, kq_rows_q40 = @@q40q8_gemv_gen,
+            kq_batch = @@kq_batch_kernel_gen,
             kq_groupn = @@kq_groupn_gen, kq_batch_groupn = @@kq_batch_groupn_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, kq_layout = @@kq_layout_fmt_gen, q8_wbias = @@q8q8_wbias_gen,

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -338,7 +338,7 @@ typedef KqRowsFn = function<(var yp : float?; kqp : uint8 const?; ksp : uint8 co
 typedef KqTileFn = function<(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64; d : int64; g : int64; t0 : int64) : void>
 
 struct KqFixture {
-    fmt : int64           // 4 / 5 / 6
+    fmt : int64           // 4 / 5 / 6 / 40
     n, d, ntok, nsb : int64
     kq : array<uint8>     // row-major master planes — repacked per variant into a copy
     ks : array<uint8>
@@ -348,8 +348,10 @@ struct KqFixture {
     yref : array<float>
 }
 
-def kq_qsb(fmt : int64) : int64 => fmt == 4l ? 128l : (fmt == 5l ? 160l : 192l)
-def kq_ssb(fmt : int64) : int64 => fmt == 6l ? 18l : 20l
+// int64 forwards to the ONE stride source (dasllama_gemm_schema) — the fixtures carry fmt as
+// int64; the schema helpers keep the panic-on-unknown contract
+def kq_qsb(fmt : int64) : int64 => dasllama_gemm_schema::kq_qsb(int(fmt))
+def kq_ssb(fmt : int64) : int64 => dasllama_gemm_schema::kq_ssb(int(fmt))
 
 // synthetic disk superblocks, varied per (row, superblock) so no two blocks repeat: any byte
 // is a legal quant, and the small d/dmin keep the f16 (s, o) pairs finite and row sums tame
@@ -372,7 +374,16 @@ def pack_kq_scale_header(var blkb : array<uint8>; base : int) {
 }
 
 def pack_kq_disk_block(fmt : int64; var blkb : array<uint8>; base : int) {
-    if (fmt == 4l) {
+    if (fmt == 40l) {
+        for (blk in range(8)) {   // 8 x 18B q4_0 disk blocks: f16 d + 16 nibble bytes
+            let dbits = f32_to_f16(0.002 + 0.0001 * float((base + blk) % 13))
+            blkb[blk * 18] = uint8(dbits & 0xFF)
+            blkb[blk * 18 + 1] = uint8(dbits >> 8u)
+            for (i in range(16)) {
+                blkb[blk * 18 + 2 + i] = uint8((base * 37 + blk * 59 + i * 101 + 29) % 256)
+            }
+        }
+    } elif (fmt == 4l) {
         pack_kq_scale_header(blkb, base)
         for (i in range(128)) {
             blkb[16 + i] = uint8((base * 37 + i * 101 + 29) % 256)
@@ -406,6 +417,8 @@ def repack_kq_grp_fmt(fmt : int64; var kq : uint8?; var ks : uint8?; n, d, mr : 
         repack_k4_grp(kq, ks, n, d, mr)
     } elif (fmt == 5l) {
         repack_k5_grp(kq, ks, n, d, mr)
+    } elif (fmt == 40l) {
+        repack_q40_grp(kq, ks, n, d, mr)
     } else {
         repack_k6_grp(kq, ks, n, d, mr)
     }
@@ -418,18 +431,20 @@ def build_kq_fixture(fmt : int64; n, d, ntok : int64) : KqFixture {
     fx.kq |> resize(int(d * fx.nsb * qsb))
     fx.ks |> resize(int(d * fx.nsb * ssb))
     var blkb : array<uint8>
-    blkb |> resize(int(fmt == 4l ? 144l : (fmt == 5l ? 176l : 210l)))
+    blkb |> resize(int(fmt == 4l || fmt == 40l ? 144l : (fmt == 5l ? 176l : 210l)))
     for (r in range64(d)) {
         for (s in range64(fx.nsb)) {
             let base = int(r * 31l + s * 7l)
             pack_kq_disk_block(fmt, blkb, base)
             let sb = r * fx.nsb + s
             if (fmt == 4l) {
-                transcode_q4k_superblock(blkb, 0l, fx.kq, sb * 128l, fx.ks, sb * 20l)
+                transcode_q4k_superblock(blkb, 0l, fx.kq, sb * qsb, fx.ks, sb * ssb)
             } elif (fmt == 5l) {
-                transcode_q5k_superblock(blkb, 0l, fx.kq, sb * 160l, fx.ks, sb * 20l)
+                transcode_q5k_superblock(blkb, 0l, fx.kq, sb * qsb, fx.ks, sb * ssb)
+            } elif (fmt == 40l) {
+                transcode_q40_superblock(blkb, 0l, fx.kq, sb * qsb, fx.ks, sb * ssb)
             } else {
-                transcode_q6k_superblock(blkb, 0l, fx.kq, sb * 192l, fx.ks, sb * 18l)
+                transcode_q6k_superblock(blkb, 0l, fx.kq, sb * qsb, fx.ks, sb * ssb)
             }
         }
     }
@@ -459,8 +474,11 @@ def build_kq_fixture(fmt : int64; n, d, ntok : int64) : KqFixture {
             let ksg = addr(s4[0]) + g * 4l * fx.nsb * ssb
             for (tk in range64(ntok)) {
                 for (r in range64(4l)) {
-                    fx.yref[tk * d + g * 4l + r] = kq_grp_row_dot(fmt, kqg, ksg, r, 4l,
-                        addr(fx.xq[0]) + tk * n, addr(fx.xs[0]) + tk * (n / 256l), addr(fx.xbs[0]) + tk * (n / 16l), n)
+                    fx.yref[tk * d + g * 4l + r] = (fmt == 40l
+                        ? q40_grp_row_dot(kqg, ksg, r, 4l,
+                            addr(fx.xq[0]) + tk * n, addr(fx.xs[0]) + tk * (n / 256l), addr(fx.xbs[0]) + tk * (n / 16l), n)
+                        : kq_grp_row_dot(fmt, kqg, ksg, r, 4l,
+                            addr(fx.xq[0]) + tk * n, addr(fx.xs[0]) + tk * (n / 256l), addr(fx.xbs[0]) + tk * (n / 16l), n))
                 }
             }
         }
@@ -479,6 +497,9 @@ def kq_tile_variants(fmt : int64) : array<tuple<string; KqTileFn>> {
     if (fmt == 5l) {
         return <- k5q8_tile_gen_variants()
     }
+    if (fmt == 40l) {
+        return <- q40q8_tile_gen_variants()
+    }
     return <- k6q8_tile_gen_variants()
 }
 
@@ -492,6 +513,12 @@ def kq_gemv_variants_by_suffix(fmt : int64) : table<string; KqRowsFn> {
         delete gvs
     } elif (fmt == 5l) {
         var gvs <- k5q8_gemv_gen_variants()
+        for (v in gvs) {
+            tab[v._0] = v._1
+        }
+        delete gvs
+    } elif (fmt == 40l) {
+        var gvs <- q40q8_gemv_gen_variants()
         for (v in gvs) {
             tab[v._0] = v._1
         }
@@ -522,6 +549,12 @@ def kq_layout_mrs(fmt : int64) : table<string; int> {
             mrs[v._0] = invoke(v._1)
         }
         delete lvs
+    } elif (fmt == 40l) {
+        var lvs <- q40q8_layout_gen_variants()
+        for (v in lvs) {
+            mrs[v._0] = invoke(v._1)
+        }
+        delete lvs
     } else {
         var lvs <- k6q8_layout_gen_variants()
         for (v in lvs) {
@@ -539,8 +572,9 @@ def kq_layout_mrs(fmt : int64) : table<string; int> {
 def run_kq_tile(tile; fx : KqFixture; kq : array<uint8>; ks : array<uint8>; mr : int64; var y : array<float>) {
     let ng = fx.d / mr
     verify(fx.ntok % 4l == 0l)
+    let packed = fx.fmt == 4l || fx.fmt == 40l   // pure-nibble planes: the tile reads them directly
     var panel : array<uint8>
-    if (fx.fmt != 4l) {
+    if (!packed) {
         panel |> resize(int(mr * fx.nsb * 256l))
     }
     unsafe {
@@ -553,7 +587,7 @@ def run_kq_tile(tile; fx : KqFixture; kq : array<uint8>; ks : array<uint8>; mr :
         for (g in range64(ng)) {
             var kqg = kqp + g * mr * fx.nsb * kq_qsb(fx.fmt)
             let ksg = ksp + g * mr * fx.nsb * kq_ssb(fx.fmt)
-            if (fx.fmt != 4l) {
+            if (!packed) {
                 unpack_kq_panel_grp(fx.fmt, kqg, addr(panel[0]), mr, fx.nsb)
                 kqg = addr(panel[0])
             }
@@ -828,6 +862,7 @@ def test_mode : bool {
     var kfxs4 <- [ <- build_kq_fixture(4l, 256l, 32l, 8l), <- build_kq_fixture(4l, 768l, 32l, 8l), <- build_kq_fixture(4l, 2048l, 32l, 8l)]
     var kfxs5 <- [ <- build_kq_fixture(5l, 256l, 32l, 8l), <- build_kq_fixture(5l, 768l, 32l, 8l), <- build_kq_fixture(5l, 2048l, 32l, 8l)]
     var kfxs6 <- [ <- build_kq_fixture(6l, 256l, 32l, 8l), <- build_kq_fixture(6l, 768l, 32l, 8l), <- build_kq_fixture(6l, 2048l, 32l, 8l)]
+    var kfxs40 <- [ <- build_kq_fixture(40l, 256l, 32l, 8l), <- build_kq_fixture(40l, 768l, 32l, 8l), <- build_kq_fixture(40l, 2048l, 32l, 8l)]
     var vs <- q8q8_tile_gen_variants()
     var mrs <- variant_mrs()
     var wbs <- variant_wbias()
@@ -951,6 +986,7 @@ def test_mode : bool {
     allok = kq_test_family(4l, kfxs4) && allok
     allok = kq_test_family(5l, kfxs5) && allok
     allok = kq_test_family(6l, kfxs6) && allok
+    allok = kq_test_family(40l, kfxs40) && allok
     delete wtab
     delete mtab
     delete gtab
@@ -965,6 +1001,7 @@ def test_mode : bool {
     delete kfxs4
     delete kfxs5
     delete kfxs6
+    delete kfxs40
     return allok
 }
 
@@ -1309,13 +1346,14 @@ def tune_mode_run : bool {
     // and the e2e exposure (a tile-optimal mr shaving decode kernel rate) is bounded by the
     // decode path staying DRAM-bound — validated end-to-end when the entries first landed.
     var kok = true
-    for (fmt in fixed_array(4l, 5l, 6l)) {
+    for (fmt in fixed_array(4l, 5l, 6l, 40l)) {
         let w = kq_tune_family(fmt)
+        let entry = fmt == 40l ? "q40q8_tile_gen" : "k{fmt}q8_tile_gen"
         if (empty(w)) {
             kok = false
         } else {
-            let wok = tune_manifest_set("k{fmt}q8_tile_gen", w)
-            print("k{fmt} winner: {w} {wok ? "->" : "-> FAILED TO WRITE"} {tune_manifest_path()}\n")
+            let wok = tune_manifest_set(entry, w)
+            print("{entry} winner: {w} {wok ? "->" : "-> FAILED TO WRITE"} {tune_manifest_path()}\n")
             kok = kok && wok
         }
     }

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -113,9 +113,9 @@ def llm_catalog() : array<LlmModel> {
         LlmModel(file="gpt-oss-20b-mxfp4.gguf", display="gpt-oss-20b", quant=QuantMode.q8, quant_label="mxfp4", prefill_ctx=512, emission_ctx=128),
         LlmModel(file="gemma-4-26B-A4B-it-Q8_0.gguf", display="gemma-4-26B-A4B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),
         LlmModel(file="gemma-4-26B-A4B-it-Q4_K_M.gguf", display="gemma-4-26B-A4B-q4k", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
-        // gemma-4-26B_q4_0-it.gguf (QAT) intentionally NOT listed: QuantMode.q4 has no batched MoE
-        // prefill rail (falls back to the generic path — measured 9.5 pp / 9.7 tg vs llama.cpp
-        // 146.6 / 18.8 on 2026-07-15); re-add once the q4 MoE kernels land
+        // the QAT file rides the q40 KqFmt tier (native Q4_0 planes on the kq rails) — quant is
+        // the loader mode (q8), the label the on-disk format, like the Q4_K_M rows
+        LlmModel(file="gemma-4-26B_q4_0-it.gguf", display="gemma-4-26B-A4B-q40", quant=QuantMode.q8, quant_label="q4_0", prefill_ctx=512, emission_ctx=128),
         LlmModel(file="Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf", display="Qwen3-30B-A3B", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
         LlmModel(file="Qwen3.6-35B-A3B-UD-Q4_K_M.gguf", display="Qwen3.6-35B-A3B", quant=QuantMode.q8, quant_label="q4_k_m", prefill_ctx=512, emission_ctx=128),
         LlmModel(file="Qwen3-Coder-30B-A3B-Instruct-Q8_0.gguf", display="Qwen3-Coder-30B", quant=QuantMode.q8, prefill_ctx=512, emission_ctx=128),

--- a/tests/dasLLAMA/test_kquant.das
+++ b/tests/dasLLAMA/test_kquant.das
@@ -7,8 +7,9 @@ require _model_tier
 require dasllama/dasllama_gguf
 require dasllama/dasllama_quant
 require dasllama/dasllama_math   // pin_kernel_backend — the layout arm needs disk-order planes
-require dasllama/dasllama_math_default   // dot_k4q8/k5/k6 — the kernel arms gate them vs the plane dequant
-require dasllama/dasllama_math_gen   // repack_k4/k5/k6_grp + kq_grp_row_dot — the stage-4 repack oracle
+require dasllama/dasllama_math_default   // dot_k4q8/k5/k6/q40q8 — the kernel arms gate them vs the plane dequant
+require dasllama/dasllama_math_gen   // repack_k4/k5/k6/q40_grp + kq_grp_row_dot — the stage-4 repack oracle
+require dasllama/dasllama_gemm_schema   // kq_qsb/kq_ssb — the fmt-id plane strides
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration for load_gguf
 require math
 
@@ -94,6 +95,28 @@ def private build_q6k_block() : array<uint8> {
     let dbits = f32_to_f16(0.25)
     blkb[208] = uint8(dbits & 0xFF)
     blkb[209] = uint8(dbits >> 8u)
+    return <- blkb
+}
+
+// loop-generated test labels: "k4"/"k5"/"k6" for the K-quants, "q40" for fmt 40 — matches the
+// kernel/repack function names (dot_q40q8, repack_q40_grp) so failures grep 1:1
+def private kq_tag(fmt : int) : string => fmt == 40 ? "q40" : "k{fmt}"
+
+// q40 synthetic superblock: 8 x 18B q4_0 disk blocks, per-block f16-exact d = (blk+1)/16 and
+// the shared nibble pattern — weight k = d(k/32) * (q4_pat(k) - 8)
+def private q40_d(blk : int) : float => float(blk + 1) * 0.0625
+
+def private build_q40_block() : array<uint8> {
+    var blkb : array<uint8>
+    blkb |> resize(144)
+    for (blk in range(8)) {
+        let dbits = f32_to_f16(q40_d(blk))
+        blkb[blk * 18] = uint8(dbits & 0xFF)
+        blkb[blk * 18 + 1] = uint8(dbits >> 8u)
+        for (j in range(16)) {   // byte j: weight blk*32+j in the low nibble, +16 in the high
+            blkb[blk * 18 + 2 + j] = uint8(q4_pat(blk * 32 + j) | (q4_pat(blk * 32 + 16 + j) << 4))
+        }
+    }
     return <- blkb
 }
 
@@ -188,6 +211,21 @@ def test_kq_transcode_planes(t : T?) {
             t |> success(dst[k] == want[k], "k6 plane element must equal the file dequant bit-exactly")
         }
     }
+    t |> run("q40 planes unpack the hand-packed Q4_0 blocks exactly") @(t : T?) {
+        let blkb <- build_q40_block()
+        var kq : array<uint8>
+        var ks : array<uint8>
+        kq |> resize(128)
+        ks |> resize(16)
+        transcode_q40_superblock(blkb, 0l, kq, 0l, ks, 0l)
+        var dst : array<float>
+        dst |> resize(256)
+        dequant_q40_plane_superblock(kq, 0l, ks, 0l, dst, 0l)
+        for (k in range(256)) {
+            let expected = q40_d(k / 32) * float(q4_pat(k) - 8)
+            t |> success(dst[k] == expected, "q40 plane element must match hand-packed value exactly")
+        }
+    }
 }
 
 // XOR the quant payload of a synthetic superblock with an LCG byte stream — every quant bit
@@ -207,9 +245,9 @@ def private perturb_quants(var blkb : array<uint8>; qoff, qlen : int) {
 // elementwise dot over the plane dequant (the kernels' declared oracle).
 def private kq_dot_gate(t : T?; fmt : int; n : int64 = 512l) {
     let nsb = n / 256l
-    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : (fmt == 40 ? build_q40_block() : build_q6k_block()))
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     var kq : array<uint8>
     var ks : array<uint8>
     kq |> resize(nsb * qsb)
@@ -219,6 +257,8 @@ def private kq_dot_gate(t : T?; fmt : int; n : int64 = 512l) {
             transcode_q4k_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
         } elif (fmt == 5) {
             transcode_q5k_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
+        } elif (fmt == 40) {
+            transcode_q40_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
         } else {
             transcode_q6k_superblock(blk1, 0l, kq, s * qsb, ks, s * ssb)
         }
@@ -236,6 +276,8 @@ def private kq_dot_gate(t : T?; fmt : int; n : int64 = 512l) {
             dequant_k4_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
         } elif (fmt == 5) {
             dequant_k5_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
+        } elif (fmt == 40) {
+            dequant_q40_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
         } else {
             dequant_k6_plane_superblock(kq, s * qsb, ks, s * ssb, w, s * 256l)
         }
@@ -265,6 +307,8 @@ def private kq_dot_gate(t : T?; fmt : int; n : int64 = 512l) {
             got = dot_k4q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
         } elif (fmt == 5) {
             got = dot_k5q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+        } elif (fmt == 40) {
+            got = dot_q40q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
         } else {
             got = dot_k6q8(addr(kq[0]), addr(ks[0]), addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
         }
@@ -284,11 +328,14 @@ def test_kq_dots(t : T?) {
     t |> run("dot_k6q8 matches the fp64 plane-dequant reference") @(t : T?) {
         kq_dot_gate(t, 6)
     }
+    t |> run("dot_q40q8 matches the fp64 plane-dequant reference") @(t : T?) {
+        kq_dot_gate(t, 40)
+    }
     // 122B-class row widths: n=3072 (12 superblocks — qwen35moe-122B gate/up/cls) and n=1024
     // (its k5 down_exps). Every earlier kq model kept n at 512..2560.
-    for (fmt in [4, 5, 6]) {
+    for (fmt in [4, 5, 6, 40]) {
         for (nn in [1024l, 3072l]) {
-            t |> run("dot_k{fmt}q8 matches the fp64 reference at n={int(nn)}") @(t : T?) {
+            t |> run("dot_{kq_tag(fmt)}q8 matches the fp64 reference at n={int(nn)}") @(t : T?) {
                 kq_dot_gate(t, fmt, nn)
             }
         }
@@ -303,9 +350,9 @@ def test_kq_dots(t : T?) {
 def private kq_gemv_rows_gate(t : T?; fmt : int; n : int64 = 512l) {
     let d = 8l
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
-    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : (fmt == 40 ? build_q40_block() : build_q6k_block()))
     var kq : array<uint8>
     var ks : array<uint8>
     kq |> resize(int(d * nsb * qsb))
@@ -316,6 +363,8 @@ def private kq_gemv_rows_gate(t : T?; fmt : int; n : int64 = 512l) {
                 transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } elif (fmt == 5) {
                 transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 40) {
+                transcode_q40_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } else {
                 transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             }
@@ -352,6 +401,8 @@ def private kq_gemv_rows_gate(t : T?; fmt : int; n : int64 = 512l) {
                 want = dot_k4q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
             } elif (fmt == 5) {
                 want = dot_k5q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            } elif (fmt == 40) {
+                want = dot_q40q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
             } else {
                 want = dot_k6q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
             }
@@ -381,9 +432,12 @@ def test_kq_gemv_rows(t : T?) {
     t |> run("portable k6 GEMV rows bit-match per-row disk dots") @(t : T?) {
         kq_gemv_rows_gate(t, 6)
     }
-    for (fmt in [4, 5, 6]) {
+    t |> run("portable q40 GEMV rows bit-match per-row disk dots") @(t : T?) {
+        kq_gemv_rows_gate(t, 40)
+    }
+    for (fmt in [4, 5, 6, 40]) {
         for (nn in [1024l, 3072l]) {
-            t |> run("portable k{fmt} GEMV rows bit-match per-row disk dots at n={int(nn)}") @(t : T?) {
+            t |> run("portable {kq_tag(fmt)} GEMV rows bit-match per-row disk dots at n={int(nn)}") @(t : T?) {
                 kq_gemv_rows_gate(t, fmt, nn)
             }
         }
@@ -399,9 +453,9 @@ def test_kq_gemv_rows(t : T?) {
 def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
     let d = 32l
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
-    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : (fmt == 40 ? build_q40_block() : build_q6k_block()))
     var kq : array<uint8>
     var ks : array<uint8>
     kq |> resize(int(d * nsb * qsb))
@@ -412,6 +466,8 @@ def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
                 transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } elif (fmt == 5) {
                 transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 40) {
+                transcode_q40_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } else {
                 transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             }
@@ -447,6 +503,8 @@ def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
                 want[r] = dot_k4q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
             } elif (fmt == 5) {
                 want[r] = dot_k5q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            } elif (fmt == 40) {
+                want[r] = dot_q40q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
             } else {
                 want[r] = dot_k6q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
             }
@@ -455,6 +513,8 @@ def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
                     dequant_k4_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
                 } elif (fmt == 5) {
                     dequant_k5_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
+                } elif (fmt == 40) {
+                    dequant_q40_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
                 } else {
                     dequant_k6_plane_superblock(kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb, wrow, r * n + s * 256l)
                 }
@@ -464,6 +524,8 @@ def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
             repack_k4_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
         } elif (fmt == 5) {
             repack_k5_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        } elif (fmt == 40) {
+            repack_q40_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
         } else {
             repack_k6_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
         }
@@ -475,7 +537,9 @@ def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
             let g = r / mr
             let kqg = addr(kq[g * mr * nsb * qsb])
             let ksg = addr(ks[g * mr * nsb * ssb])
-            let got = kq_grp_row_dot(int64(fmt), kqg, ksg, r % mr, mr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+            let got = (fmt == 40
+                ? q40_grp_row_dot(kqg, ksg, r % mr, mr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+                : kq_grp_row_dot(int64(fmt), kqg, ksg, r % mr, mr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n))
             if (got != want[r]) {
                 dotbad++
             }
@@ -502,14 +566,14 @@ def private kq_repack_gate(t : T?; fmt : int; mr : int64; n : int64 = 512l) {
 
 [test]
 def test_kq_repack_grp(t : T?) {
-    for (fmt in [4, 5, 6]) {
+    for (fmt in [4, 5, 6, 40]) {
         for (mr in [4l, 8l, 16l]) {
-            t |> run("repack_k{fmt}_grp mr={mr} preserves dots and row dequants") @(t : T?) {
+            t |> run("repack_{kq_tag(fmt)}_grp mr={mr} preserves dots and row dequants") @(t : T?) {
                 kq_repack_gate(t, fmt, mr)
             }
         }
         for (nn in [1024l, 3072l]) {
-            t |> run("repack_k{fmt}_grp mr=8 preserves dots and row dequants at n={int(nn)}") @(t : T?) {
+            t |> run("repack_{kq_tag(fmt)}_grp mr=8 preserves dots and row dequants at n={int(nn)}") @(t : T?) {
                 kq_repack_gate(t, fmt, 8l, nn)
             }
         }
@@ -525,9 +589,9 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
     let ntok = 7l   // 4-token tile + a 3-token gemv tail
     let nsb = n / 256l
     let mr = kq_layout_of(fmt)   // the format's OWN layout companion (per-format tune families)
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
-    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : (fmt == 40 ? build_q40_block() : build_q6k_block()))
     var kq : array<uint8>
     var ks : array<uint8>
     kq |> resize(int(d * nsb * qsb))
@@ -538,6 +602,8 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
                 transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } elif (fmt == 5) {
                 transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 40) {
+                transcode_q40_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } else {
                 transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             }
@@ -553,6 +619,8 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
             repack_k4_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
         } elif (fmt == 5) {
             repack_k5_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
+        } elif (fmt == 40) {
+            repack_q40_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
         } else {
             repack_k6_grp(addr(kq[0]), addr(ks[0]), n, d, mr)
         }
@@ -579,9 +647,11 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
     ytile |> resize(int(ntok * d))
     ygemv |> resize(int(ntok * d))
     // k5/k6 tiles read the byte-expanded panel the batch cell unpacks per (group, token-block)
-    // — the gate covers unpack_kq_panel_grp too (tile-over-panel vs gemv-over-packed planes)
+    // — the gate covers unpack_kq_panel_grp too (tile-over-panel vs gemv-over-packed planes);
+    // k4/q40 tiles read the packed planes directly
+    let packed = fmt == 4 || fmt == 40
     var panel : array<uint8>
-    if (fmt != 4) {
+    if (!packed) {
         panel |> resize(int(mr * nsb * 256l))
     }
     unsafe {
@@ -589,7 +659,7 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
         for (g in range64(ng)) {
             let kqg = addr(kq[g * mr * nsb * qsb])
             let ksg = addr(ks[g * mr * nsb * ssb])
-            if (fmt != 4) {
+            if (!packed) {
                 unpack_kq_panel_grp(int64(fmt), kqg, addr(panel[0]), mr, nsb)
             }
             var tk = 0l
@@ -598,6 +668,8 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
                     k4q8_tile_gen(addr(ytile[0]), kqg, ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
                 } elif (fmt == 5) {
                     k5q8_tile_gen(addr(ytile[0]), addr(panel[0]), ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
+                } elif (fmt == 40) {
+                    q40q8_tile_gen(addr(ytile[0]), kqg, ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
                 } else {
                     k6q8_tile_gen(addr(ytile[0]), addr(panel[0]), ksg, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, d, g, tk)
                 }
@@ -608,6 +680,8 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
                     k4q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
                 } elif (fmt == 5) {
                     k5q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
+                } elif (fmt == 40) {
+                    q40q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
                 } else {
                     k6q8_gemv_gen(addr(ytile[tk * d]), addr(kq[0]), addr(ks[0]), addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, g * mr, (g + 1l) * mr)
                 }
@@ -619,6 +693,8 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
                 k4q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 256l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
             } elif (fmt == 5) {
                 k5q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 256l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
+            } elif (fmt == 40) {
+                q40q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 256l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
             } else {
                 k6q8_gemv_gen(addr(ygemv[p * d]), addr(kq[0]), addr(ks[0]), addr(xq[p * n]), addr(xs[p * (n / 256l)]), addr(xbs[p * (n / 16l)]), n, 0l, d)
             }
@@ -644,12 +720,12 @@ def private kq_tile_gate(t : T?; fmt : int; n : int64 = 512l) {
 
 [test]
 def test_kq_tile(t : T?) {
-    for (fmt in [4, 5, 6]) {
-        t |> run("k{fmt} 4-token tile bit-matches per-token GEMVs") @(t : T?) {
+    for (fmt in [4, 5, 6, 40]) {
+        t |> run("{kq_tag(fmt)} 4-token tile bit-matches per-token GEMVs") @(t : T?) {
             kq_tile_gate(t, fmt)
         }
         for (nn in [1024l, 3072l]) {
-            t |> run("k{fmt} 4-token tile bit-matches per-token GEMVs at n={int(nn)}") @(t : T?) {
+            t |> run("{kq_tag(fmt)} 4-token tile bit-matches per-token GEMVs at n={int(nn)}") @(t : T?) {
                 kq_tile_gate(t, fmt, nn)
             }
         }
@@ -663,9 +739,9 @@ def test_kq_tile(t : T?) {
 // per-region activation rows (down, xoff = r*n).
 def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l; nreg : int64 = 3l) {
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
-    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : (fmt == 40 ? build_q40_block() : build_q6k_block()))
     var kq : array<uint8>
     var ks : array<uint8>
     kq |> resize(int(nreg * d * nsb * qsb))
@@ -676,6 +752,8 @@ def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l;
                 transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } elif (fmt == 5) {
                 transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 40) {
+                transcode_q40_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } else {
                 transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             }
@@ -730,6 +808,9 @@ def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l;
                 } elif (fmt == 5) {
                     want_sh[r * d + row] = dot_k5q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
                     want_pr[r * d + row] = dot_k5q8(kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 256l)]), addr(xbs[r * (n / 16l)]), n)
+                } elif (fmt == 40) {
+                    want_sh[r * d + row] = dot_q40q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+                    want_pr[r * d + row] = dot_q40q8(kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 256l)]), addr(xbs[r * (n / 16l)]), n)
                 } else {
                     want_sh[r * d + row] = dot_k6q8(kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
                     want_pr[r * d + row] = dot_k6q8(kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 256l)]), addr(xbs[r * (n / 16l)]), n)
@@ -770,6 +851,8 @@ def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l;
                 repack_k4_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
             } elif (fmt == 5) {
                 repack_k5_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            } elif (fmt == 40) {
+                repack_q40_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
             } else {
                 repack_k6_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
             }
@@ -783,6 +866,9 @@ def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l;
             } elif (fmt == 5) {
                 k5q8_gemv_gen(addr(want_sh[r * d]), kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, 0l, d)
                 k5q8_gemv_gen(addr(want_pr[r * d]), kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 256l)]), addr(xbs[r * (n / 16l)]), n, 0l, d)
+            } elif (fmt == 40) {
+                q40q8_gemv_gen(addr(want_sh[r * d]), kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, 0l, d)
+                q40q8_gemv_gen(addr(want_pr[r * d]), kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 256l)]), addr(xbs[r * (n / 16l)]), n, 0l, d)
             } else {
                 k6q8_gemv_gen(addr(want_sh[r * d]), kqr, ksr, addr(xq[0]), addr(xs[0]), addr(xbs[0]), n, 0l, d)
                 k6q8_gemv_gen(addr(want_pr[r * d]), kqr, ksr, addr(xq[r * n]), addr(xs[r * (n / 256l)]), addr(xbs[r * (n / 16l)]), n, 0l, d)
@@ -818,12 +904,12 @@ def private kq_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 = 32l;
 
 [test]
 def test_kq_groupn(t : T?) {
-    for (fmt in [4, 5, 6]) {
-        t |> run("k{fmt} region-list GEMV bit-matches per-row dots (disk + grp slices)") @(t : T?) {
+    for (fmt in [4, 5, 6, 40]) {
+        t |> run("{kq_tag(fmt)} region-list GEMV bit-matches per-row dots (disk + grp slices)") @(t : T?) {
             kq_groupn_gate(t, fmt)
         }
         for (nn in [1024l, 3072l]) {
-            t |> run("k{fmt} region-list GEMV bit-matches per-row dots at n={int(nn)}") @(t : T?) {
+            t |> run("{kq_tag(fmt)} region-list GEMV bit-matches per-row dots at n={int(nn)}") @(t : T?) {
                 kq_groupn_gate(t, fmt, nn)
             }
         }
@@ -852,8 +938,8 @@ def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 
         return
     }
     let nsb = n / 256l
-    let qsb = fmt == 4 ? 128l : (fmt == 5 ? 160l : 192l)
-    let ssb = fmt == 6 ? 18l : 20l
+    let qsb = kq_qsb(fmt)
+    let ssb = kq_ssb(fmt)
     let mr = kq_layout_of(fmt)
     // bucket mix: a 1-row run (pure gemv tail), whole tiles, tile+tail, and a TB-spanning run
     var cnts <- [1l, 4l, 6l, 13l]
@@ -862,7 +948,7 @@ def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 
     for (c in cnts) {
         nk += c
     }
-    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : build_q6k_block())
+    let blk1 <- fmt == 4 ? build_q4k_block() : (fmt == 5 ? build_q5k_block() : (fmt == 40 ? build_q40_block() : build_q6k_block()))
     var kq : array<uint8>
     var ks : array<uint8>
     kq |> resize(int(nreg * d * nsb * qsb))
@@ -873,6 +959,8 @@ def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 
                 transcode_q4k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } elif (fmt == 5) {
                 transcode_q5k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
+            } elif (fmt == 40) {
+                transcode_q40_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             } else {
                 transcode_q6k_superblock(blk1, 0l, kq, (r * nsb + s) * qsb, ks, (r * nsb + s) * ssb)
             }
@@ -889,6 +977,8 @@ def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 
                 repack_k4_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
             } elif (fmt == 5) {
                 repack_k5_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
+            } elif (fmt == 40) {
+                repack_q40_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
             } else {
                 repack_k6_grp(addr(kq[r * d * nsb * qsb]), addr(ks[r * d * nsb * ssb]), n, d, mr)
             }
@@ -931,6 +1021,8 @@ def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 
                     k4q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
                 } elif (fmt == 5) {
                     k5q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
+                } elif (fmt == 40) {
+                    q40q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
                 } else {
                     k6q8_gemv_gen(addr(want[tk * d]), kqr, ksr, addr(xq[tk * n]), addr(xs[tk * (n / 256l)]), addr(xbs[tk * (n / 16l)]), n, 0l, d)
                 }
@@ -962,8 +1054,8 @@ def private kq_batch_groupn_gate(t : T?; fmt : int; n : int64 = 512l; d : int64 
 
 [test]
 def test_kq_batch_groupn(t : T?) {
-    for (fmt in [4, 5, 6]) {
-        t |> run("k{fmt} batch groupn bit-matches per-token rows-core calls") @(t : T?) {
+    for (fmt in [4, 5, 6, 40]) {
+        t |> run("{kq_tag(fmt)} batch groupn bit-matches per-token rows-core calls") @(t : T?) {
             kq_batch_groupn_gate(t, fmt)
         }
     }
@@ -1031,6 +1123,8 @@ def private dequant_plane_prefix(tr : Model; fmt : KqFmt; eloff, n : int64; var 
             dequant_k5_plane_superblock(tr.k5q, sb * K5_QSB, tr.k5s, sb * K5_SSB, dst, blk * 256l)
         } elif (fmt == KqFmt.k6) {
             dequant_k6_plane_superblock(tr.k6q, sb * K6_QSB, tr.k6s, sb * K6_SSB, dst, blk * 256l)
+        } elif (fmt == KqFmt.q40) {
+            dequant_q40_plane_superblock(tr.q40q, sb * Q40_QSB, tr.q40s, sb * Q40_SSB, dst, blk * 256l)
         } else {
             panic("dequant_plane_prefix: not a kq format")
         }
@@ -1087,6 +1181,50 @@ def test_kq_load_layout(t : T?) {
         }
         t |> success(bad == 0, "k6 classifier plane bit-matches the file dequant")
         delete fdq6
+        delete have
+        delete tr
+    }
+    // the q40 tier's end-to-end placement oracle: the QAT gemma file is 265 x Q4_0 + F32
+    // norms/router + one Q6_K embd — its q40 planes are VERBATIM disk splits, so every
+    // plane-dequant prefix must bit-match the file dequant (the k6 exactness class).
+    t |> run("q40 load places Q4_0 tensors at their cursor offsets (gemma-4-26B QAT q4_0)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "gemma-4-26B_q4_0-it.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        pin_kernel_backend("portable")   // disk-order planes (the placement oracle)
+        let prev_kq = get_kquant_native()
+        let prev_q40 = get_kq_q40_native()
+        set_kquant_native(true)
+        set_kq_q40_native(true)
+        var tr <- load_gguf(path, QuantMode.q8)
+        set_kquant_native(prev_kq)
+        set_kq_q40_native(prev_q40)
+        clear_kernel_backend_pin()
+        t |> success(!tr.kq_repacked, "portable-pinned load keeps the q40 planes disk-order")
+        t |> success(tr.kquant_native, "load detected native Q4_0 tensors")
+        t |> success(tr.wq_fmt[0] == KqFmt.q40, "blk.0.attn_q tagged q40")
+        let n = 262144l
+        var have : array<float>
+        have |> resize(n)
+        var gt = 0
+        // deep-layer q40 tensor: catches cursor drift accumulated across every earlier tensor
+        let l = tr.config.n_layers - 1l
+        dequant_plane_prefix(tr, tr.wq_fmt[l], tr.wq_offs[l], n, have)
+        var fdq <- read_prefix(path, "blk.{l}.attn_q.weight", n, gt)
+        t |> equal(gt, GGML_TYPE_Q4_0)
+        var bad = 0
+        for (i in range64(n)) {
+            if (have[i] != fdq[i]) {
+                bad++
+            }
+        }
+        t |> success(bad == 0, "deep-layer q40 plane bit-matches the file dequant (verbatim split)")
+        delete fdq
         delete have
         delete tr
     }


### PR DESCRIPTION
## What

`KqFmt.q40` — a native Q4_0 tier in the kquant_native plane system, so QAT q4_0 files (gemma-4-26B QAT et al.) ride the full kq rails: grp`<mr>` repack, stamped gemv/tile kernels, batched MoE prefill, fused decode chains, embed/cls/PLE gather. Previously a Q4_0 file either took the q8-requant fallback (2x memory) or `QuantMode.q4` (no batched prefill at all — 0.06x llama.cpp prefill on MoE).

## Design

- **The q40 quant plane IS the k4 tiling.** A q4_0 disk block's nibble pairing (weight k low, k+16 high) is byte-for-byte k4's grp plane layout, so `repack_q40_grp` is a pure byte gather and the whole kq dot lattice — nibble split, madd16 i16 bounds (nibbles ≤ 15, k4's chain), sdot/maddubs/vpdpbusd primitives, tile/gemv loop machinery — is reused with `kq = 40`. q40 tiles read the packed planes directly (no unpack scratch, like k4).
- **Scale fold is the only new kernel logic.** q4_0's f16 `d` is per-32, so instead of k4's superblock integer sc/mn folds each block pays one fma: `facc += float(Σq·a − 8·Σa32)·d`, closed by one `·d8` per superblock. The −8 offset correction folds off the existing Q8_K activation bsum pairs — zero new activation plumbing. One shared float order across the portable dot, the grp reference, and the generated IR.
- **`kq_qsb`/`kq_ssb` in `dasllama_gemm_schema`**: the one fmt-id stride source (4/5/6/40, panics on unknown) — replaces the else-is-k6 ternary chains that would have silently misrouted any new format.
- **Own `[tune]` family** `q40q8_tile_gen` (k4's perm grid; generators `dasllama_gemm_gen::q40_tile`/`::q40_gemv` share the emitter + decline predicate, so witness lockstep holds with no new rails).
- Per-tensor q40 tags demote to q8 when a row length isn't %256 (`kq_fmt_row_ok` — Q4_0 only guarantees %32, unlike the K-quants); bring-up knob `set_kq_q40_native` (default ON).
- Catalog: `gemma-4-26B-A4B-q40` re-listed (the d89e8ffc4 `QuantMode.q4` exclusion is resolved by this tier); decode_prof traffic table gets the q40 row + a kq v2 scale-byte drift fix (k4/k5 32 → 20).

## Validation

- `test_kquant` **102/102**, interp AND `-jit`: q40 arms in every gate — dots vs fp64 plane-dequant reference, portable GEMV rows, repack at mr 4/8/16 (dots + row dequants bit-exact after repack), 4-token tile vs per-token GEMVs, region-list groupn (disk + grp), batch groupn on the pinned gen backend — plus the QAT gemma 14.4 GB end-to-end load-layout arm: every Q4_0 tensor tagged q40, deep-layer plane dequant **bit-exact** vs the file dequant (the planes are verbatim disk splits).
- `gen_tune_probe` DAS_TUNE_MODE=test: the k40 family passes **all 10 grid variants with maxdiff 0**, including the live generated maddubs mr8 stamps (zen2); k4/k5/k6 grids unchanged.
- Parity vs the `simple_ids` oracle on the QAT file: matches through every decisive-margin step; the single greedy flip sits at a **0.0442** oracle top-1/top-2 margin (margin-oracle-verified — the oracle's own top-2 is das's pick). Token-exact parity is not expected by design: llama.cpp runs q4_0 dots on Q8_0-form activations, this tier rides the kq v2 Q8_K form — the same acceptance class as flash attention / chunked deltanet.
- `tests/dasLLAMA/` full sweep: 549 tests, 0 failed. Lint: 11 files, 0 issues. Formatter verify clean.

Profile row on the quiet box (target ≥1x of the llama-bench TSV reference 146.6 pp / 18.8 tg) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
