### PR TITLE
Keep Telegram imports after malformed timestamps

### DIFF
--- a/examples/telegram/dictation/telegram_history_import.das
+++ b/examples/telegram/dictation/telegram_history_import.das
@@ -181,7 +181,9 @@ def parse_telegram_export_page(
             var message_date = 0l
             var date_error = ""
             if (!parse_telegram_export_timestamp(timestamp, message_date, date_error)) {
-                error = date_error
+                // A bad timestamp is local to this message. Keep the page importable and let the
+                // caller's InvalidDate accounting report MessageDate == 0.
+                message_date = 0l
             }
             let reply_href = selected_attribute(
                 node, ".//div[contains(concat(' ',normalize-space(@class),' '),' reply_to ')]//a[1]/@href")

--- a/examples/telegram/dictation/test_telegram_history_import.das
+++ b/examples/telegram/dictation/test_telegram_history_import.das
@@ -59,4 +59,25 @@ def test_telegram_export_parser(t : T?) {
             t |> equal(messages[0].Text, "Proxy")
         }
     }
+
+    t |> run("one malformed timestamp does not discard the page") @(t : T?) {
+        let html = ("<!DOCTYPE html><html><body>" +
+                    "<div class='message default clearfix' id='message4'>" +
+                    "<div class='pull_right date details' title='not a timestamp'></div>" +
+                    "<div class='from_name'>Alice</div>" +
+                    "<div class='text'>Broken date</div></div>" +
+                    "<div class='message default clearfix joined' id='message5'>" +
+                    "<div class='pull_right date details' title='14.06.2022 15:21:58 UTC-08:00'></div>" +
+                    "<div class='text'>Valid date</div></div>" +
+                    "</body></html>")
+        var sender = ""
+        var error = ""
+        let messages <- parse_telegram_export_page(html, sender, error)
+        t |> equal(error, "")
+        t |> equal(length(messages), 2)
+        if (length(messages) == 2) {
+            t |> equal(messages[0].MessageDate, 0l)
+            t |> equal(messages[1].MessageDate, 1655248918l)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- keep parsing a Telegram export page when one message has a malformed timestamp
- leave that message's `MessageDate` at zero so the importer's existing invalid-date accounting reports it
- add regression coverage proving the malformed message and later valid messages are both preserved

Follow-up to #3482, based on a Copilot finding that landed just as that PR was merged.

## Validation

- focused Telegram history importer tests: 5/5 passed
- changed-file lint: 0 issues
- CI is the requested full validation authority for this follow-up
