### PR TITLE
Fix v_ldu over-read of by-value float3 in math builtins

### DIFF
--- a/include/daScript/simulate/aot_builtin_matrix.h
+++ b/include/daScript/simulate/aot_builtin_matrix.h
@@ -77,7 +77,7 @@ namespace das {
     inline float3 float3x4_mul_vec3p(const float3x4 &a, float3 b) {
         mat44f va;
         v_mat44_make_from_43cu_unsafe(va, &a.m[0].x);
-        return v_mat44_mul_vec3p(va, v_ldu(&b.x));
+        return v_mat44_mul_vec3p(va, vec_loadu3(&b.x));
     }
 
     inline float4 float4x4_mul_vec4(const float4x4 &a, float4 b) {
@@ -94,7 +94,7 @@ namespace das {
     inline float3 rotate(const float3x4 &a, float3 b) {
         mat44f va;
         v_mat44_make_from_43cu_unsafe(va, &a.m[0].x);
-        return v_mat44_mul_vec3v(va, v_ldu(&b.x));
+        return v_mat44_mul_vec3v(va, vec_loadu3(&b.x));
     }
 
     __forceinline bool float4x4_equ ( const float4x4 & a, const float4x4 & b ) {

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -518,15 +518,15 @@ namespace das {
     }
 
     float4 quat_from_unit_arc(float3 v0, float3 v1) {
-        return v_quat_from_unit_arc(v_ldu_p3(&v0.x), v_ldu_p3(&v1.x));
+        return v_quat_from_unit_arc(vec_loadu3(&v0.x), vec_loadu3(&v1.x));
     }
 
     float4 quat_from_unit_vec_ang(float3 v, float ang) {
-        return v_quat_from_unit_vec_ang(v_ldu_p3(&v.x), v_splats(ang));
+        return v_quat_from_unit_vec_ang(vec_loadu3(&v.x), v_splats(ang));
     }
 
     float4 quat_from_euler_vec(float3 v) {
-        return v_quat_from_euler(v_ldu_p3(&v.x));
+        return v_quat_from_euler(vec_loadu3(&v.x));
     }
 
     float4 quat_from_euler(float x, float y, float z) {


### PR DESCRIPTION
v_ldu/v_ldu_p3(&v.x) load 16 bytes from a 12 byte float3. These arguments are by-value locals, so the optimizer knows the object extent and is free to act on the over-read: clang 21 folds every one of these to an unconditional trap under -fsanitize=object-size, and the same UB class has been observed silently dropping stores in release codegen in downstream engine bindings.

Load exactly 12 bytes with vec_loadu3, which vec3::operator vec4f and WrapVec3Arg already use. No behavior change: every consumer here reads xyz only, and on non-clang vec_loadu3 still lowers to v_ldu_p3.