### PR TITLE
dasLLAMA: steer q4_0 files onto the native rails, rename QuantMode.q4 to q4_0

### DIFF
--- a/modules/dasLLAMA/API_REWORK.md
+++ b/modules/dasLLAMA/API_REWORK.md
@@ -654,7 +654,9 @@ what it costs today and what the fix would change.
   test/ship parity for is Q8_0 on disk (plus gpt-oss MXFP4→Q8); no Q4_0 GGUF anywhere in the
   fixture set. q4 only fires when a user opts into `QuantMode q4` for footprint. Priority rises
   only if the MXFP4→Q4_0 halfway house above lands (q4 becomes the resident format of a real
-  20B model).
+  20B model). **RESOLVED DIFFERENTLY (2026-07-16):** Q4_0 *files* now serve natively on the kq
+  rails under q8 mode (KqFmt.q40, #3481) — batched prefill included; the legacy tier was renamed
+  `QuantMode.q4_0` and remains the requant-from-f32 footprint option, per-row kernels unchanged.
 - **LOW PRIORITY: f32 projection GEMM is untiled — dot-per-token, no token block.**
   `matmul_batch` (dasllama_math.das) is the exact pre-#3315 shape the Q8 path had: weight-
   stationary nest with one horizontal-reduce `dot()` per (row, token), zero register reuse

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -97,7 +97,7 @@ def private wbytes(q : QuantMode; wscale16 : bool = false) : double {
     if (q == QuantMode.q8) {
         return 1.0lf + (wscale16 ? 2.0lf : 4.0lf) / 32.0lf
     }
-    if (q == QuantMode.q4) {
+    if (q == QuantMode.q4_0) {
         return 0.5lf + 4.0lf / 32.0lf
     }
     return 4.0lf

--- a/modules/dasLLAMA/benchmarks/gguf_perf.das
+++ b/modules/dasLLAMA/benchmarks/gguf_perf.das
@@ -89,12 +89,12 @@ def main {
         quantize_weights(t)
         let q8_ids <- run_capture(t, c, "q8  ", q8)
         quantize_weights_q4(t)
-        let q4_ids <- run_capture(t, c, "q4  ", q4)
+        let q4_ids <- run_capture(t, c, "q4_0", q4)
 
-        print("\nspeedup: q8 {q8 / fp}x, q4 {q4 / fp}x\n")
-        print("tracks fp32 greedy: q8 {match_len(fp32_ids, q8_ids)}/{length(fp32_ids)}, q4 {match_len(fp32_ids, q4_ids)}/{length(fp32_ids)} tokens\n")
+        print("\nspeedup: q8 {q8 / fp}x, q4_0 {q4 / fp}x\n")
+        print("tracks fp32 greedy: q8 {match_len(fp32_ids, q8_ids)}/{length(fp32_ids)}, q4_0 {match_len(fp32_ids, q4_ids)}/{length(fp32_ids)} tokens\n")
         print("\nfp32: {decode_ids(tok, fp32_ids, 48)}\n")
         print("q8  : {decode_ids(tok, q8_ids, 48)}\n")
-        print("q4  : {decode_ids(tok, q4_ids, 48)}\n")
+        print("q4_0: {decode_ids(tok, q4_ids, 48)}\n")
     }
 }

--- a/modules/dasLLAMA/benchmarks/perf.das
+++ b/modules/dasLLAMA/benchmarks/perf.das
@@ -48,8 +48,8 @@ def main {
         let fp32 = run_once(t, c, "fp32 ")  // quant defaults to fp32
         quantize_weights(t)                 // sets t.quant = q8
         let q8 = run_once(t, c, "q8   ")
-        quantize_weights_q4(t)              // sets t.quant = q4
-        let q4 = run_once(t, c, "q4   ")
-        print("  q8 speedup: {q8 / fp32}x, q4 speedup: {q4 / fp32}x\n")
+        quantize_weights_q4(t)              // sets t.quant = q4_0
+        let q4 = run_once(t, c, "q4_0 ")
+        print("  q8 speedup: {q8 / fp32}x, q4_0 speedup: {q4 / fp32}x\n")
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -29,11 +29,12 @@ require daslib/strings_boost  // join() for the arch-registry diagnostic
 // allocator's power-of-2 rounding.
 
 //! Which weight representation forward routes its 2D matmuls through. fp32 is the default;
-//! q8/q4 select the quantized kernels (and the matching big-weight storage).
+//! q8 selects the fast integer rails (K-quant / mxfp4 / Q4_0 files keep their native planes);
+//! q4_0 is the legacy requant tier — weights held as q4_0 blocks, per-row kernels only.
 enum QuantMode {
     fp32
     q8
-    q4
+    q4_0
 }
 
 //! Per-weight storage format under a q8-mode load with native K-quant planes (kquant_native):
@@ -1104,7 +1105,7 @@ def private load_big(m : GGUFMeta; bytes : array<uint8> | #; name : string; var 
             gguf_read_tensor_f32(m, bytes, name, scratch, 0l, n, src_off)
             quantize_q8_0_into(scratch, n, t.qblob, t.qscales, woff, woff / 32l)
         }
-    } elif (t.quant == QuantMode.q4) {
+    } elif (t.quant == QuantMode.q4_0) {
         if (gguf_tensor_type(m, name) == GGML_TYPE_Q4_0) {
             gguf_transcode_q4_0(m, bytes, name, t.q4blob, t.q4scales, woff / 2l, woff / 32l, n, src_off)
         } else {
@@ -1169,7 +1170,7 @@ def private load_dn_grouped(m : GGUFMeta; bytes : array<uint8> | #; var t : Mode
     let woff = t.dnout_offs[l]
     if (t.quant == QuantMode.q8) {
         quantize_q8_0_into(scratch, n, t.qblob, t.qscales, woff, woff / 32l)
-    } elif (t.quant == QuantMode.q4) {
+    } elif (t.quant == QuantMode.q4_0) {
         quantize_q4_0_into(scratch, n, t.q4blob, t.q4scales, woff / 2l, woff / 32l)
     } else {
         for (i in range64(n)) {
@@ -2268,7 +2269,7 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             t.qblob |> resize(sz.wblob_n)
             t.qscales |> reserve(sz.wblob_n / 32l)
             t.qscales |> resize(sz.wblob_n / 32l)
-        } elif (mode == QuantMode.q4) {
+        } elif (mode == QuantMode.q4_0) {
             t.q4blob |> reserve(sz.wblob_n / 2l)
             t.q4blob |> resize(sz.wblob_n / 2l)
             t.q4scales |> reserve(sz.wblob_n / 32l)
@@ -2586,7 +2587,7 @@ def quantize_weights_q4(var t : Model) {
     var qt <- quantize_q4_0(t.wblob, n)
     t.q4blob <- qt.q
     t.q4scales <- qt.scales
-    t.quant = QuantMode.q4
+    t.quant = QuantMode.q4_0
 }
 
 //! Resident memory footprint of a loaded model, in bytes, broken down by region. aux_fp32 is the
@@ -4538,7 +4539,7 @@ def private mm_b_f(var s : Session; var y : array<float>; t : Model; fmt : KqFmt
 def private mm(var y : array<float>; t : Model; woff : int64; x : array<float>; var xq : array<int8>; var xs : array<float>; n, d : int64) {
     if (t.quant == QuantMode.q8) {
         mm_at_q8(y, t, woff, x, xq, xs, n, d)
-    } elif (t.quant == QuantMode.q4) {
+    } elif (t.quant == QuantMode.q4_0) {
         mm_at_q4(y, t, woff, x, n, d)
     } else {
         mm_at(y, t, woff, x, n, d)
@@ -6382,7 +6383,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
         }
         prof_add("moe_reduce", ts_red)
     } else {
-        // fp32 reference path: the per-expert loop (q4 never routes here — MoE loads are q8/fp32)
+        // fp32 reference path: the per-expert loop (q4_0 never routes here — MoE loads are q8/fp32)
         for (j in range64(k)) {
             let e = l * ne + s.moe_idx[j]
             let base = s.moe_idx[j] * ege
@@ -6942,7 +6943,7 @@ def forward(t : Model; var s : Session; token, pos : int64) {
         cls_softcap_chain(t, s, c.final_logit_softcap)
     } else {
         if (tied_f32) {
-            // tied weights (fp32/q4 loads): the classifier IS the fp32 embedding table
+            // tied weights (fp32/q4_0 loads): the classifier IS the fp32 embedding table
             mm_fblob(s.logits, t, t.tok_emb_off, s.xb, dim, c.vocab_size)
         } elif (cls_fmt != KqFmt.q8) {
             // K-quant classifier (tied plane copy or untied kq output.weight)
@@ -7112,7 +7113,7 @@ def private mtp_prefill_warm(t : Model; var s : Session; tokens : array<int64>; 
 //! position's logits — else one position, plain-eval semantics. Advances ``n_past``; telemetry
 //! accumulates in ``mtp_drafted``/``mtp_accepted``. Output-invariant vs plain greedy decode by
 //! construction: the draft only gates acceptance. Falls back to a plain eval step (returning
-//! false) when the model has no head, the handoff is cold (fresh/foreign session), q4 mode has
+//! false) when the model has no head, the handoff is cold (fresh/foreign session), q4_0 mode has
 //! no batch rail, or the context can't fit two rows. Requires [[set_mtp_spec]] ON so prefills
 //! maintain the head's KV.
 def mtp_spec_eval(t : Model; var s : Session; tok : int64; var accepted : int64&) : bool {
@@ -7120,7 +7121,7 @@ def mtp_spec_eval(t : Model; var s : Session; tok : int64; var accepted : int64&
     let pos = s.n_past
     // pos < 1: nothing evaled yet — the zero-init mtp_h_pos1 sentinel COLLIDES with pos == 0
     // (0 != 0 would pass the cold check and draft at row -1), so gate it explicitly
-    if (c.n_layer_nextn <= 0l || t.quant == QuantMode.q4 || pos < 1l || s.mtp_h_pos1 != pos
+    if (c.n_layer_nextn <= 0l || t.quant == QuantMode.q4_0 || pos < 1l || s.mtp_h_pos1 != pos
             || pos + 2l > c.seq_len) {
         forward(t, s, tok, pos)   // plain step (forward re-stashes the handoff for the next tick)
         s.n_past = pos + 1l
@@ -7162,8 +7163,8 @@ def generate_mtp_greedy(t : Model; var s : Session; prompt : array<int64>; total
                         var n_drafted, n_accepted : int64&) : array<int64> {
     let c = t.config
     assert(c.n_layer_nextn > 0l)
-    if (t.quant == QuantMode.q4) {   // no batched prefill rail: the 2-row verify (and the warm) need it
-        panic("dasLLAMA: MTP self-spec decode needs the batched prefill path — load q8 or fp32, not q4")
+    if (t.quant == QuantMode.q4_0) {   // no batched prefill rail: the 2-row verify (and the warm) need it
+        panic("dasLLAMA: MTP self-spec decode needs the batched prefill path — load q8 or fp32, not q4_0")
     }
     let np = int64(length(prompt))
     var ids : array<int64>
@@ -9493,7 +9494,7 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
 }
 
 // MoE FFN, prefill: norm, then either the grouped expert-bucketed path (Q8, default) or the
-// per-position reference path through the decode scratch (fp32 models — q4 never prefills — and
+// per-position reference path through the decode scratch (fp32 models — q4_0 never prefills — and
 // the bit-identical A/B switch).
 def private ffn_moe_prefill(t : Model; var s : Session; l : int64; npos : int64) {
     let c = t.config
@@ -9536,7 +9537,7 @@ def private ffn_moe_prefill(t : Model; var s : Session; l : int64; npos : int64)
 
 def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, start_pos : int64) {
     let c = t.config
-    if (t.quant == QuantMode.q4 || npos <= 0l) {
+    if (t.quant == QuantMode.q4_0 || npos <= 0l) {
         for (p in range64(npos)) {
             forward(t, s, tokens[p], start_pos + p)
         }
@@ -9588,8 +9589,8 @@ def forward_prefill_embd(t : Model; var s : Session; embd : array<float>; npos, 
     if (npos <= 0l) {
         return
     }
-    if (t.quant == QuantMode.q4) {
-        panic("forward_prefill_embd: q4 mode has no batched prefill path (use q8 or fp32)")
+    if (t.quant == QuantMode.q4_0) {
+        panic("forward_prefill_embd: q4_0 mode has no batched prefill path (use q8 or fp32)")
     }
     if (int64(length(embd)) < npos * t.config.dim) {
         panic("forward_prefill_embd: embd has {length(embd)} floats — npos={npos} rows of dim={t.config.dim} need {npos * t.config.dim}")
@@ -9648,7 +9649,7 @@ def embed_forward(t : Model; var s : Session; tokens : array<int64>; npos : int6
     if (npos <= 0l) {
         return
     }
-    if (t.quant != QuantMode.q4 && npos > 1l) {
+    if (t.quant != QuantMode.q4_0 && npos > 1l) {
         // batched prefill fills s.x_b (npos × dim residual) and leaves it intact; the body norms only
         // the last position, so re-apply the final RMSNorm to EVERY position and accumulate.
         forward_prefill(t, s, tokens, npos, 0l)
@@ -9657,7 +9658,7 @@ def embed_forward(t : Model; var s : Session; tokens : array<int64>; npos : int6
             add_inplace(unsafe(addr(out[0])), unsafe(addr(s.xb[0])), dim)
         }
     } else {
-        // q4 (no batched prefill) or a single token: per-token forward leaves s.xb = post-final-norm hidden.
+        // q4_0 (no batched prefill) or a single token: per-token forward leaves s.xb = post-final-norm hidden.
         for (p in range64(npos)) {
             forward(t, s, tokens[p], p)
             add_inplace(unsafe(addr(out[0])), unsafe(addr(s.xb[0])), dim)
@@ -10055,7 +10056,7 @@ def private attention_batch_decode(t : Model; var ws : BatchWorkspace; sessions 
 //! scatter into sessions[i].logits, and each session advances by one. Sessions must be distinct,
 //! same-geometry (one model, equal cache sizes, uniform KV dtype; paged sessions share ONE pool —
 //! never mix paged and flat rows) and have room for one position. Ragged batches: pass only the
-//! still-active sessions (B may shrink between calls). B == 1, q4 weights, a non-std attention
+//! still-active sessions (B may shrink between calls). B == 1, q4_0 weights, a non-std attention
 //! arch, or the classic (non-table) rope path fall back to the exact per-row forward() loop.
 def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session?>; tokens : array<int64>) {   // nolint:LINT014 — rows mutate THROUGH the pointers; a const array constifies the pointees
     let c = t.config
@@ -10092,10 +10093,10 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
             panic("eval_batch: sessions[{i}] cache size differs from sessions[0] — same model + same seq_len required")
         }
     }
-    // per-row fallback keeps every configuration correct: B == 1 keeps the fused decode chain, q4
+    // per-row fallback keeps every configuration correct: B == 1 keeps the fused decode chain, q4_0
     // has no batched kernels, non-std arches have no batch attention worker, and the classic rope
     // path can't express per-row positions
-    if (nrows == 1l || t.quant == QuantMode.q4 || !t.blocks.attn_is_std || !g_use_rope_table) {
+    if (nrows == 1l || t.quant == QuantMode.q4_0 || !t.blocks.attn_is_std || !g_use_rope_table) {
         for (i in range64(nrows)) {
             var sp = sessions[i]
             forward(t, *sp, tokens[i], sp.n_past)
@@ -10179,7 +10180,7 @@ def eval_batch_(t : Model; var ws : BatchWorkspace; var sessions : array<Session
         ws.logits_b |> resize(nrows * vocab)
         let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
         if (c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) {
-            // tied weights (fp32/q4 loads): the classifier IS the fp32 embedding table
+            // tied weights (fp32/q4_0 loads): the classifier IS the fp32 embedding table
             mm_fblob_b(ws.logits_b, t, t.tok_emb_off, ws.scr.xb_b, dim, vocab, nrows)
         } elif (cls_fmt != KqFmt.q8) {
             mm_b_kq(ws.scr, ws.logits_b, t, cls_fmt, t.wcls_off, ws.scr.xb_b, dim, vocab, nrows)

--- a/modules/dasLLAMA/harness/README.md
+++ b/modules/dasLLAMA/harness/README.md
@@ -32,7 +32,8 @@ clang++ -std=c++17 -O2 -I include -I ggml/include simple_ids.cpp \
 ### Run a parity check
 
 ```sh
-# fp32 storage for an F16/F32 file; q8 for a Q8_0 file; q4 for Q4_0
+# fp32 storage for an F16/F32 file; q8 for everything quantized (Q8_0, and the K-quant /
+# mxfp4 / Q4_0 formats serve their native planes under q8)
 modules/dasLLAMA/harness/parity.sh ~/Work/llama.cpp/models/tinyllama-1.1b-v0.3-f16.gguf 40 fp32
 modules/dasLLAMA/harness/parity.sh ~/Work/llama.cpp/models/Qwen2.5-0.5B-Instruct-Q8_0.gguf 40 q8
 ```

--- a/modules/dasLLAMA/harness/parity.sh
+++ b/modules/dasLLAMA/harness/parity.sh
@@ -3,7 +3,8 @@
 #
 # Usage:   parity.sh <model.gguf> [N] [quant] [prompt] [kv] [ctk]
 #   N       generated tokens to compare (default 40)
-#   quant   dasLLAMA storage: fp32|q8|q4 — pick the file's native type (default q8; use fp32 for F16/F32)
+#   quant   dasLLAMA storage: fp32|q8|q4_0 — default q8 (K-quant/mxfp4/Q4_0 files serve their native
+#           planes under q8; use fp32 for F16/F32; q4_0 = legacy requant tier)
 #   prompt  raw continuation prompt (default "Once upon a time")
 #   kv      dasLLAMA KV-cache dtype: f32|f16|q8_0 (default f32)
 #   ctk     ORACLE KV-cache type: f16|q8_0 (default: llama.cpp's own default; pass q8_0 with kv=q8_0

--- a/modules/dasLLAMA/harness/quant_eval_q4.das
+++ b/modules/dasLLAMA/harness/quant_eval_q4.das
@@ -49,7 +49,7 @@ def main {
     with_job_que() {
         var sref <- make_run_state(c)
         let ref_ids <- generate(t, sref, [1l], N_TOKENS)  // gold: fp32 (quant defaults fp32)
-        quantize_weights_q4(t)                            // sets t.quant = q4
+        quantize_weights_q4(t)                            // sets t.quant = q4_0
         var sq <- make_run_state(c)
         let q_ids <- generate(t, sq, [1l], N_TOKENS)
 

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -159,8 +159,8 @@ def quant_str(q : QuantMode) : string {
     if (q == QuantMode.q8) {
         return "q8"
     }
-    if (q == QuantMode.q4) {
-        return "q4"
+    if (q == QuantMode.q4_0) {
+        return "q4_0"
     }
     return "fp32"
 }

--- a/tests/dasLLAMA/test_batch_decode.das
+++ b/tests/dasLLAMA/test_batch_decode.das
@@ -324,11 +324,11 @@ def test_batch_decode_q4_fallback(t : T?) {
             return
         }
         var tr <- load_checkpoint(MODEL_PATH)
-        quantize_weights_q4(tr)  // all 2D weights -> Q4_0, tr.quant = q4 => eval_batch_ per-row path
+        quantize_weights_q4(tr)  // all 2D weights -> Q4_0, tr.quant = q4_0 => eval_batch_ per-row path
         let prev_fused = get_fused_decode()
         set_fused_decode(false)
         with_job_que() {
-            batch_vs_ref(t, tr, KVDtype.f32, 6l, 0.0, "q4")   // fallback IS forward(): bit-exact
+            batch_vs_ref(t, tr, KVDtype.f32, 6l, 0.0, "q4_0")   // fallback IS forward(): bit-exact
         }
         set_fused_decode(prev_fused)
         delete tr

--- a/tutorials/dasLLAMA/05_performance.das
+++ b/tutorials/dasLLAMA/05_performance.das
@@ -14,7 +14,7 @@ require math
 // This tutorial covers:
 //   - Why model programs always run with -jit (and _jit_fast_math)
 //   - Threading the kernels: with_job_que + the jobque dispatch knobs
-//   - Quantization: fp32 vs q8 vs q4 — memory and speed
+//   - Quantization: fp32 vs q8 vs q4_0 — memory and speed
 //   - Reading stats(): prefill vs generation, time to first token
 //
 // Prerequisites: tutorial 01.
@@ -89,9 +89,10 @@ def section_threads(m : Model) {
 //
 // QuantMode picks the in-memory weight representation, whatever the GGUF stores:
 //   fp32 — the token-exact reference (4 bytes/weight); what the test suite validates
-//   q8   — int8 blocks (~1 byte/weight), the fast everyday choice
-//   q4   — 4-bit blocks, half of q8 again — but currently served by a scalar kernel
-//          with no batched prefill, so it's the smallest footprint, not the fastest
+//   q8   — the fast everyday choice: int8 blocks (~1 byte/weight); a K-quant / mxfp4 /
+//          Q4_0 file keeps its native 4-6 bit planes on the same fast rails
+//   q4_0 — the legacy requant tier: squeeze THIS f32/q8 load down to 4-bit blocks —
+//          per-row kernels, no batched prefill, so smallest footprint, not fastest
 // Generation is bandwidth-bound, so between fp32 and q8, smaller is also faster.
 
 def section_quant(path : string; mode : QuantMode; tag : string) {
@@ -134,7 +135,7 @@ def main() {
     print("\n")
     section_quant(path, QuantMode.fp32, "fp32")
     section_quant(path, QuantMode.q8, "q8  ")
-    section_quant(path, QuantMode.q4, "q4  ")
+    section_quant(path, QuantMode.q4_0, "q4_0")
 
     // Where to go deeper: modules/dasLLAMA/tune_for_this_box.md covers kernel tuning
     // (token-block size, unrolls, the [dasllama_grid] tuner) when you want to squeeze

--- a/utils/dasllama-server/ask.das
+++ b/utils/dasllama-server/ask.das
@@ -61,7 +61,7 @@ struct AskArgs {
     @clarg_doc = "Override the sampling seed, 0 = keep the session's fixed default seed (default 0)"
     seed : int
 
-    @clarg_doc = "Weight quantization: fp32 | q8 | q4 (default q8)"
+    @clarg_doc = "Weight serving mode: fp32 | q8 (default; file-format spellings serve natively under q8) | q4 = legacy requant"
     quant : string
 
     @clarg_doc = "Re-tune this box's dasLLAMA kernels, then relaunch"
@@ -75,7 +75,7 @@ struct AskArgs {
 
 def pick_quant(s : string) : QuantMode {
     if (s == "fp32") return QuantMode.fp32
-    if (s == "q4") return QuantMode.q4
+    if (s == "q4") return QuantMode.q4_0
     return QuantMode.q8
 }
 

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -47,7 +47,7 @@ struct ServerArgs {
     port : int
 
     @clarg_short = "q"
-    @clarg_doc = "Weight serving mode: fp32 | q8 | q4 (default q8); file-format spellings q4_k | q5_k | q6_k | mxfp4 | f16 | bf16 select q8, where those planes serve natively"
+    @clarg_doc = "Weight serving mode: fp32 | q8 (default); file-format spellings q8_0 | q4_0 | q4_k | q5_k | q6_k | mxfp4 | f16 | bf16 select q8, where those planes serve natively; q4 = legacy requant tier"
     quant : string
 
     @clarg_doc = "KV cache codec: f32 | f16 | q8_0 | tq4 (default f16)"
@@ -221,20 +221,21 @@ def apply_config(var cfg : ServerArgs) : bool {
     return true
 }
 
-// Besides the serving modes (fp32 | q8 | q4), the FILE formats the gguf loader reads are
-// first-class spellings too: q4_k / q5_k / q6_k (any case, _M/_S suffixes fine), mxfp4,
-// f16 / bf16, q8_0 — all of those serve under QuantMode.q8 (K-quant and mx4 planes run
-// NATIVELY on the kq tier). "q4" stays the legacy q4_0 requant tier — do not use it for
-// K-quant files (per-row fallback paths, the 14x prefill stall).
+// The serving modes are QuantMode fp32/q8/q4_0, CLI spellings "fp32" | "q8" | "q4" — "q4"
+// selects the legacy q4_0 requant tier (per-row kernels only, no batched prefill), whose one
+// use is squeezing an f16/f32 file down to 4 bits for RAM. The FILE formats the gguf loader
+// reads are first-class spellings too: q8_0 / q4_0 / q4_k / q5_k / q6_k (any case, _M/_S
+// suffixes fine), mxfp4, f16 / bf16 — all of those serve under QuantMode.q8 (K-quant, mx4,
+// and Q4_0 planes run NATIVELY on the kq tier).
 def pick_quant(s : string) : QuantMode {
     let l = to_lower(s)
     if (l == "fp32" || l == "f32") {
         return QuantMode.fp32
-    } elif (l == "q4" || l == "q4_0") {
-        return QuantMode.q4
-    } elif (!empty(l) && l != "q8" && l != "q8_0" && l != "mxfp4" && l != "f16" && l != "bf16"
+    } elif (l == "q4") {
+        return QuantMode.q4_0
+    } elif (!empty(l) && l != "q8" && l != "q8_0" && l != "q4_0" && l != "mxfp4" && l != "f16" && l != "bf16"
             && !(starts_with(l, "q4_k") || starts_with(l, "q5_k") || starts_with(l, "q6_k"))) {
-        to_log(LOG_WARNING, "dasllama-server: unknown --quant '{s}', using q8 (valid: fp32 | q8 | q4 | q4_k | q5_k | q6_k | mxfp4 | f16 | bf16)\n")
+        to_log(LOG_WARNING, "dasllama-server: unknown --quant '{s}', using q8 (valid: fp32 | q8 | q8_0 | q4_0 | q4_k | q5_k | q6_k | mxfp4 | f16 | bf16 | q4 = legacy requant)\n")
     }
     return QuantMode.q8
 }


### PR DESCRIPTION
Since #3481, a Q4_0 file under q8 mode serves its native planes on the kq rails (`KqFmt.q40`) — 4.5 bits/weight, batched prefill, MoE rails. That made the legacy `QuantMode.q4` tier strictly worse for Q4_0 *files* on every axis (speed, memory: 5.0 bpw with f32 scales, features), yet the server's `--quant q4_0` spelling still landed on it. This PR steers the spellings and renames the enum honestly:

- **`dasllama-server --quant q4_0` now selects q8 mode** (native q40 planes), consistent with every other file-format spelling (`q4_k` / `q5_k` / `q6_k` / `mxfp4` / `f16` / `bf16` / `q8_0`). Plain `q4` remains the explicit legacy opt-in.
- **`QuantMode.q4` → `QuantMode.q4_0`**: the mode names what it holds — the legacy requant tier storing weights as q4_0 blocks (per-row kernels, no batched prefill / MTP / eval_batch). Its remaining purpose is squeezing an f32/f16 load down to 4 bits for RAM.
- Scoreboard spelling for the legacy mode follows (`quant_str` → `"q4_0"`); no catalog rows use the mode, so no data changes.
- Comments, panic messages, tutorial 05 quant section, parity harness docs, and the API_REWORK backlog entry updated to match (the "q4 has no batched prefill" backlog item is annotated resolved-differently: native Q4_0 serving landed via the kq tier instead).

No behavior change for any current catalog/test configuration — all rows already load under q8. Verified: all changed `.das` files compile (`-compile-only`), lint 0 issues, format verify clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
