### PR TITLE
SQL: close typed query gaps used by Cadmus

### DIFF
--- a/daslib/sql_boost.das
+++ b/daslib/sql_boost.das
@@ -543,6 +543,21 @@ def private derive_index_name(table_name : string; sql_cols : array<string>) : s
     }
 }
 
+def private build_field_unique_indexes_sql(table_name : string; fields : array<FieldInfo>) : string {
+    var stmt_count = 0
+    return build_string() $(var w) {
+        for (info in fields) {
+            if (!info.is_unique || info.is_pk) continue
+            if (stmt_count > 0) {
+                w |> write("; ")
+            }
+            stmt_count++
+            w |> write("CREATE UNIQUE INDEX \"uq_{table_name}_{info.col_name}\"")
+            w |> write(" ON \"{table_name}\" (\"{info.col_name}\")")
+        }
+    }
+}
+
 [structure_macro(name=sql_index)]
 class SqlIndexMacro : AstStructureAnnotation {
     //! Stackable struct-level annotation: ``[sql_index(fields="A"|("A","B"), unique=?, name=?)]``.
@@ -731,6 +746,10 @@ class SqlTableMacro : AstStructureAnnotation {
                 errors := "[sql_table]: field '{fname}' cannot be both @sql_primary_key and @sql_computed — SQLite rejects PRIMARY KEY on a generated column."
                 return false
             }
+            if (is_computed && is_unique) {
+                errors := "[sql_table]: field '{fname}' cannot be both @sql_unique and @sql_computed — declare an explicit [sql_index(fields=\"{fname}\", unique=true)] if the provider supports indexing that generated expression."
+                return false
+            }
             if (is_computed && field.init != null) {
                 errors := "[sql_table]: field '{fname}' is @sql_computed; remove the daslang field initializer (the SQL expression provides the value)."
                 return false
@@ -896,8 +915,10 @@ class SqlTableMacro : AstStructureAnnotation {
             // finish-pass) returns the 1-arg form whose body owns the burned-in SQL.
             var fn_indexes_named = make_create_indexes_sql_named_fn(st, table_name)
             compiling_module() |> add_function(fn_indexes_named)
-            // Empty `_sql_create_indexes_sql` placeholder; [sql_index] siblings accumulate into it.
-            var fn_indexes = make_create_indexes_sql_fn(st, "")
+            // Field-level @sql_unique constraints start the provider-neutral
+            // CREATE INDEX list; [sql_index] siblings append to the same helper.
+            let unique_indexes_sql = build_field_unique_indexes_sql(table_name, fields)
+            var fn_indexes = make_create_indexes_sql_fn(st, unique_indexes_sql)
             compiling_module() |> add_function(fn_indexes)
             var fn_ins_pk_named = make_insert_sql_named_fn(st, fields, true)
             compiling_module() |> add_function(fn_ins_pk_named)
@@ -1096,11 +1117,13 @@ class SqlTableMacro : AstStructureAnnotation {
         //! ``[sql_index(name=...)]`` is preserved.
         let orig_quoted = "\"{table_name}\""
         let orig_idx_prefix = "\"idx_{table_name}_"
+        let orig_unique_prefix = "\"uq_{table_name}_"
         var fn = qmacro_function("_sql_create_indexes_sql") $(typ : $t(st); name : string) : string {
             let escaped_name = name |> replace("\"", "\"\"")
             return (_sql_create_indexes_sql(default<$t(st)>)
                 |> replace($v(orig_quoted), "\"" + escaped_name + "\"")
-                |> replace($v(orig_idx_prefix), "\"idx_" + escaped_name + "_"))
+                |> replace($v(orig_idx_prefix), "\"idx_" + escaped_name + "_")
+                |> replace($v(orig_unique_prefix), "\"uq_" + escaped_name + "_"))
         }
         fn.flags.generated = true
         fn.body |> force_at(st.at)
@@ -1143,9 +1166,6 @@ class SqlTableMacro : AstStructureAnnotation {
                     suffix = " PRIMARY KEY"
                 } elif (!info.is_optional) {
                     suffix = " NOT NULL"
-                }
-                if (info.is_unique && !info.is_pk) {
-                    suffix += " UNIQUE"
                 }
                 suffix += info.default_clause
                 suffix += info.references_clause

--- a/daslib/sql_boost.das
+++ b/daslib/sql_boost.das
@@ -382,6 +382,7 @@ struct FieldInfo {
     is_json : bool
     is_blob : bool
     is_fts_rank : bool   // [sql_fts5] only — read-only, emits `rank`, skipped on INSERT
+    is_fts_unindexed : bool   // [sql_fts5] only — stored metadata excluded from the inverted index
     computed_sql : string
     default_clause : string
     references_clause : string

--- a/daslib/sql_linq.das
+++ b/daslib/sql_linq.das
@@ -5331,50 +5331,29 @@ def private analyze_upsert_set_clause(var setExpr : ExpressionPtr; var rootT : T
 }
 
 [macro_function]
-def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
-                             var rootT : TypeDeclPtr;
-                             isTry : bool; isReturning : bool) : ExpressionPtr {
-    if (rootT == null || rootT.structType == null) {
-        macro_error(prog, call.at, "_sql_upsert: row type must be a [sql_table] struct (got {describe(rootT)})")
-        return null
+def private build_upsert_sql(rootT : TypeDeclPtr; tableName : string;
+                             conflictCols : array<string>;
+                             setSqlClauses : array<string>;
+                             includePk : bool; isReturning : bool;
+                             var nRowBinds : int&) : string {
+    var insertCols : array<string>
+    for (field in rootT.structType.fields) {
+        if (is_field_computed(field)) continue
+        let isPk = find_annotation(field.annotation, "sql_primary_key", false)
+        if (!includePk && isPk) continue
+        insertCols |> push(field_to_column_name(rootT, string(field.name)))
     }
-    var st = rootT.structType
-    var dbE = call.arguments[0]
-    var rowE = call.arguments[1]
-    var conflictE = call.arguments[2]
-    var doUpdateE = call.arguments[3]
-    let tableName = sql_table_name_from_type(rootT)
-    let provIdx = find_sql_provider_by_runner(dbE._type)
-    if (provIdx < 0) {
-        macro_error(prog, call.at, "_sql_upsert: no SQL provider registered for runner type {describe(dbE._type)} (registered: {sql_provider_names()})")
-        return null
-    }
-    // 1) on_conflict columns
-    var conflictCols : array<string>
-    if (!analyze_upsert_conflict_inner(conflictE, rootT, conflictCols, prog, call.at)) return null
-    // 2) do_update SET clauses (with upsertMode=true so `_excluded.Col` resolves)
-    var setSqlClauses : array<string>
-    var setBindExprs : array<ExpressionPtr>
-    if (!analyze_upsert_set_clause(doUpdateE, rootT, tableName, provIdx, setSqlClauses, setBindExprs, prog, call.at)) return null
-    // 3) INSERT column list (non-computed only) — SQL-side names, positional bind indices.
-    var nonComputedCols : array<string>
-    var nRowBinds = 0
-    for (f in st.fields) {
-        if (is_field_computed(f)) continue
-        nonComputedCols |> push(field_to_column_name(rootT, string(f.name)))
-        nRowBinds++
-    }
-    // 4) Assemble SQL. conflictCols arrive in daslang names — translate via field_to_column_name at emission.
+    nRowBinds = length(insertCols)
     var sql = build_string() $(var w) {
         w |> write("INSERT INTO \"{tableName}\" (")
-        for (i in range(length(nonComputedCols))) {
+        for (i in range(length(insertCols))) {
             if (i > 0) {
                 w |> write(", ")
             }
-            w |> write("\"{nonComputedCols[i]}\"")
+            w |> write("\"{insertCols[i]}\"")
         }
         w |> write(") VALUES (")
-        for (i in range(length(nonComputedCols))) {
+        for (i in range(length(insertCols))) {
             if (i > 0) {
                 w |> write(", ")
             }
@@ -5399,27 +5378,91 @@ def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
     if (isReturning) {
         sql += build_returning_clause(rootT)
     }
-    // 5) Bind order: row binds (1..N_row) via `_sql_bind_row`, then SET binds (N_row+1..).
+    return sql
+}
+
+[macro_function]
+def private emit_upsert_variant(var dbE : ExpressionPtr; var rootT : TypeDeclPtr;
+                                sql : string; nRowBinds : int; includePk : bool;
+                                setBindExprs : array<ExpressionPtr>;
+                                isTry : bool; isReturning : bool;
+                                provIdx : int; at : LineInfo) : ExpressionPtr {
     var bindStmts : array<ExpressionPtr>
     bindStmts |> reserve(1 + length(setBindExprs))
     bindStmts |> push <| qmacro_expr(${
-        _::_sql_bind_row(_sql_stmt, $e(rowE), true);
+        _::_sql_bind_row(_sql_stmt, _sql_upsert_row, $v(includePk));
     })
     for (i in range(length(setBindExprs))) {
         let bindIdx = nRowBinds + i + 1
-        var be = setBindExprs[i]
         bindStmts |> push <| qmacro_expr(${
-            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(be));
+            sql_bind_to_stmt(_sql_stmt, $v(bindIdx), $e(setBindExprs[i]));
         })
     }
-    // Row binds come from `_sql_bind_row` (not enumerated as `?` walking targets); pass empty binds to fold.
     var noBinds : array<ExpressionPtr>
     var frags : array<SqlFrag>
     sql_to_frags(sql, noBinds, frags)
     var sqlExpr : ExpressionPtr
     var bindExprs : array<ExpressionPtr>
-    fold_to_builder(frags, provIdx, call.at, sqlExpr, bindExprs)
-    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, provIdx, call.at)
+    fold_to_builder(frags, provIdx, at, sqlExpr, bindExprs)
+    return emit_dml_call(dbE, sqlExpr, bindStmts, isTry, isReturning, rootT, provIdx, at)
+}
+
+[macro_function]
+def private emit_upsert_body(prog : ProgramPtr; var call : ExprCallMacro?;
+                             var rootT : TypeDeclPtr;
+                             isTry : bool; isReturning : bool) : ExpressionPtr {
+    if (rootT == null || rootT.structType == null) {
+        macro_error(prog, call.at, "_sql_upsert: row type must be a [sql_table] struct (got {describe(rootT)})")
+        return null
+    }
+    var dbE = call.arguments[0]
+    var rowE = call.arguments[1]
+    var conflictE = call.arguments[2]
+    var doUpdateE = call.arguments[3]
+    let tableName = sql_table_name_from_type(rootT)
+    let provIdx = find_sql_provider_by_runner(dbE._type)
+    if (provIdx < 0) {
+        macro_error(prog, call.at, "_sql_upsert: no SQL provider registered for runner type {describe(dbE._type)} (registered: {sql_provider_names()})")
+        return null
+    }
+    // 1) on_conflict columns
+    var conflictCols : array<string>
+    if (!analyze_upsert_conflict_inner(conflictE, rootT, conflictCols, prog, call.at)) return null
+    // 2) do_update SET clauses (with upsertMode=true so `_excluded.Col` resolves)
+    var setSqlClauses : array<string>
+    var setBindExprs : array<ExpressionPtr>
+    if (!analyze_upsert_set_clause(doUpdateE, rootT, tableName, provIdx, setSqlClauses, setBindExprs, prog, call.at)) return null
+    // 3) Build both INSERT spellings. An unset integer primary key must be
+    // omitted so each provider's auto-assignment mechanism can run.
+    var nWithoutPk = 0
+    let sqlWithoutPk = build_upsert_sql(rootT, tableName, conflictCols, setSqlClauses,
+        false, isReturning, nWithoutPk)
+    var nWithPk = 0
+    let sqlWithPk = build_upsert_sql(rootT, tableName, conflictCols, setSqlClauses,
+        true, isReturning, nWithPk)
+    var withoutPkCall = emit_upsert_variant(clone_expression(dbE), rootT,
+        sqlWithoutPk, nWithoutPk, false, setBindExprs,
+        isTry, isReturning, provIdx, call.at)
+    var withPkCall = emit_upsert_variant(clone_expression(dbE), rootT,
+        sqlWithPk, nWithPk, true, setBindExprs,
+        isTry, isReturning, provIdx, call.at)
+    var dispatchT = clone_type(rootT)
+    dispatchT.flags.constant = true
+    var dispatchBlock : ExpressionPtr
+    if (isReturning) {
+        dispatchBlock = qmacro($(_sql_upsert_row : $t(dispatchT)) {
+            if (_::_sql_pk_is_unset(_sql_upsert_row)) {
+                return <- $e(withoutPkCall)
+            }
+            return <- $e(withPkCall)
+        })
+    } else {
+        dispatchBlock = qmacro($(_sql_upsert_row : $t(dispatchT)) =>
+            _::_sql_pk_is_unset(_sql_upsert_row) ? $e(withoutPkCall) : $e(withPkCall))
+    }
+    var res = qmacro(invoke($e(dispatchBlock), $e(rowE)))
+    res |> force_at(call.at)
+    return res
 }
 
 [call_macro(name="_sql_upsert")]

--- a/daslib/sql_linq.das
+++ b/daslib/sql_linq.das
@@ -3611,9 +3611,15 @@ def private fn_call_to_sql(var call : ExprCall?; var q : SqlQuery&; prog : Progr
             return "{lhs} LIKE ? ESCAPE '\\'"
         }
     }
-    // ---- FTS5 (tut 40): text_match(_.Body, q) on [sql_fts5] → `Body MATCH ?`; non-FTS5 is a compile error.
+    // ---- FTS5 (tut 40): text_match(_.Body, q) on indexed [sql_fts5] content → `Body MATCH ?`.
     if (fname == "text_match" && argc == 2) {
         if (!has_struct_annotation(q.rootType, "sql_fts5")) return pred_fail(q, prog, at, "_sql: text_match() requires an [sql_fts5] struct, got '{describe(q.rootType)}'. Options: use contains(_.Col, q) for LIKE-based substring match, or annotate the struct with [sql_fts5] for indexed full-text search.")
+        var receiver : ExpressionPtr
+        var fieldName : string
+        if (qmatch(call.arguments[0], $e(receiver).$f(fieldName)).matched
+            && has_field_annotation(q.rootType, fieldName, "sql_fts_unindexed")) {
+            return pred_fail(q, prog, at, "_sql: text_match() cannot target @sql_fts_unindexed field '{fieldName}' — UNINDEXED metadata is stored and filterable with ordinary comparisons, but deliberately excluded from FTS5 MATCH. Match an indexed string field instead.")
+        }
         let lhs = pred_to_sql(call.arguments[0], q, prog, at)
         return "" if (q.hadError)
         if (q.inHaving) {

--- a/daslib/sql_linq.das
+++ b/daslib/sql_linq.das
@@ -159,6 +159,10 @@ struct private JoinSpec {
 
 struct private SqlQuery {
     rootType    : TypeDeclPtr
+    // Exact struct type reconstructed by a whole-source join projection (`$(l, r) => r`).
+    // rootType remains the FROM root (source 0), so materialization and subquery wrapping
+    // consult this override whenever proj == FullRow.
+    projectedRowType : TypeDeclPtr
     tableName   : string
     rootAlias   : string
     selectCols  : array<string>
@@ -961,6 +965,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     var projType = inner_projection_type(q, at)
     // Reset q to wrap state. Clear all join/where/projection state so outer can re-fill.
     q.rootType = null
+    q.projectedRowType = null
     q.tableName := ""
     q.rootAlias := ""
     q.selectCols |> clear
@@ -1480,7 +1485,9 @@ def private fromrow_alias_list(rowT : TypeDeclPtr) : string {
 // fromRowType is the witness pred_to_sql consults to know "is this an over-subquery outer Q, and what aliases does it expose?"
 [macro_function]
 def private inner_projection_type(var inner : SqlQuery&; at : LineInfo) : TypeDeclPtr {
-    if (inner.proj == ProjectionShape.FullRow) return inner.rootType
+    if (inner.proj == ProjectionShape.FullRow) {
+        return inner.projectedRowType != null ? inner.projectedRowType : inner.rootType
+    }
     if (inner.proj == ProjectionShape.NamedTuple) {
         let n = length(inner.selectCols)
         var tupT = new TypeDecl(at = at, baseType = Type.tTuple)
@@ -1555,9 +1562,11 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
         q.providerIdx = subQ.providerIdx
     }
     if (subQ.proj == ProjectionShape.FullRow) {
-        // FullRow inner: outer treats wrapped subquery as the original table; v1 path — unchanged.
+        // FullRow inner: outer treats the wrapped subquery as its exact projected struct.
+        // Usually this is the original table type; a whole-source join projection may instead
+        // return one joined source (`$(l, r) => r`).
         if (q.rootType == null) {
-            q.rootType = subQ.rootType
+            q.rootType = q.fromRowType
         }
         if (q.proj == ProjectionShape.FullRow && empty(q.selectCols) && q.rootType != null) {
             fill_default_columns(q, q.rootType, prog, at)
@@ -2290,10 +2299,48 @@ def private analyze_projection_impl(var body : ExpressionPtr; var q : SqlQuery&;
             return false
         }
     }
-    // Bare-var (identity / whole-row `$(x)=>x`) projection has no SQL column form — reject cleanly (else the computed-scalar `pred_to_sql` path below null-derefs on the whole-row var → SIGSEGV).
+    q.projectedRowType = null
+    // A join's bare source variable projects that exact source struct. Expand it to the
+    // source's qualified columns and reconstruct the nominal struct in build_row_builder.
+    // Single-source identity and scalar identity remain unsupported.
     if (body is ExprVar) {
-        macro_error(prog, at, "_sql: identity / whole-row `_select` (e.g. `$(x) => x`) is not supported — project named columns off the row, e.g. `_select($(x) => (Name = x.name, City = x.city))`")
-        return false
+        let argName = string((body as ExprVar).name)
+        if (!q.seenJoin) {
+            macro_error(prog, at, "_sql: identity `_select` (e.g. `$(x) => x`) is not supported in single-source mode — omit the `_select` for a full row, or project named columns")
+            return false
+        }
+        let srcIdx = resolve_proj_arg_to_source(q, argName, prog, at)
+        if (srcIdx < 0) return false
+        let srcType = source_rootType_for_idx(q, srcIdx)
+        let bodyType = body._type
+        if (srcType == null || srcType.structType == null
+                || bodyType == null || bodyType.structType == null) {
+            macro_error(prog, at, "_sql: whole-source join projection `{argName}` must be a non-nullable struct row — nullable outer-join sides and scalar/tuple identities are not supported; project named scalar fields instead")
+            return false
+        }
+        let n = length(srcType.structType.fields)
+        q.selectCols |> clear
+        q.selectColAliases |> clear
+        q.selectColTypes |> clear
+        q.selectColSqlFragments |> clear
+        q.projRecordNames |> clear
+        q.selectCols |> reserve(n)
+        q.selectColAliases |> reserve(n)
+        q.selectColTypes |> reserve(n)
+        q.selectColSqlFragments |> reserve(n)
+        q.projRecordNames |> reserve(n)
+        let sourceAlias = source_alias_for_idx(q, srcIdx)
+        for (field in srcType.structType.fields) {
+            let fieldName = string(field.name)
+            q.selectCols |> push(fieldName) // nolint:PERF006 reserved above
+            q.selectColAliases |> push(sourceAlias) // nolint:PERF006 reserved above
+            q.selectColTypes |> push(clone_type(field._type)) // nolint:PERF006 reserved above
+            q.selectColSqlFragments |> push("") // nolint:PERF006 reserved above
+            q.projRecordNames |> push(fieldName) // nolint:PERF006 reserved above
+        }
+        q.projectedRowType = clone_type(srcType)
+        q.proj = ProjectionShape.FullRow
+        return true
     }
     // Multi-level field chain `<arg>.Col.path…` — descends via json_extract for @sql_json.
     {
@@ -4580,8 +4627,8 @@ def private build_row_builder(var q : SqlQuery&; prog : ProgramPtr; at : LineInf
         return mkTup
     }
     // FullRow (default)
-    var rootType = clone_type(q.rootType)
-    return qmacro(_::_sql_read_row(_sql_stmt, type<$t(rootType)>))
+    var rowType = clone_type(q.projectedRowType != null ? q.projectedRowType : q.rootType)
+    return qmacro(_::_sql_read_row(_sql_stmt, type<$t(rowType)>))
 }
 
 // nolint:STYLE015 Single-source row-var normalization: `_sql` resolves one source against placeholder `_`,

--- a/daslib/sql_linq.das
+++ b/daslib/sql_linq.das
@@ -57,6 +57,43 @@ def _first(arr : array<auto(TT)>) : TT -const -& {
     return first(arr)
 }
 
+def _aggregate_rows(rows : array<auto(TT)>; aggregate_block : block<(rows : array<TT>) : auto(RR)>) {
+    //! Compute several global aggregates from one source. In ordinary in-memory
+    //! chains the block runs over ``rows`` directly. Inside ``_sql(...)`` the
+    //! terminal lowers a named tuple of ``count`` / ``long_count`` / ``sum`` /
+    //! ``average`` / ``min`` / ``max`` expressions into one SQL SELECT row.
+    static_if (typeinfo can_copy(default<RR -const -#>)) {
+        return invoke(aggregate_block, rows)
+    } else {
+        return <- invoke(aggregate_block, rows)
+    }
+}
+
+[call_macro(name="_aggregate")]
+class private SqlGlobalAggregate : AstCallMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
+        macro_verify(call.arguments |> length == 2, prog, call.at, "_aggregate expects `(source, aggregate_block)`")
+        assume sourceType = call.arguments[0]._type
+        macro_verify(sourceType != null, prog, call.at, "_aggregate source is not inferred yet")
+        macro_verify(sourceType.isGoodArrayType, prog, call.at, "_aggregate expects an array-backed source")
+        macro_verify(!sourceType.firstType.isAutoOrAlias, prog, call.at, "_aggregate source element type cannot be auto or alias")
+        macro_verify(call.arguments[1] is ExprMakeBlock, prog, call.at, "_aggregate expects a one-argument block returning a named tuple")
+        var aggregateLambda = call.arguments[1] as ExprMakeBlock
+        var aggregateBlock = aggregateLambda._block as ExprBlock
+        macro_verify(aggregateBlock != null && aggregateBlock.arguments |> length == 1,
+            prog, call.at, "_aggregate block must take exactly one rowset argument")
+        if (aggregateBlock.arguments[0]._type == null || aggregateBlock.arguments[0]._type.isAutoOrAlias) {
+            var rowsType = clone_type(sourceType)
+            rowsType.flags.constant = true
+            aggregateBlock.arguments[0]._type = rowsType
+        }
+        aggregateBlock.arguments[0].flags.can_shadow = true
+        var res = qmacro(_aggregate_rows($e(call.arguments[0]), $e(call.arguments[1])))
+        res.force_at(call.at)
+        return res
+    }
+}
+
 // ===== to_sql_literal — runtime stringifier for `_create_view` body inlining =====
 // `_::` resolution lets users extend with a one-line overload in their own module
 // (`def to_sql_literal(s : Status) : string => "{int(s)}"`).
@@ -1665,6 +1702,40 @@ def private analyze_chain(var node : ExpressionPtr; var q : SqlQuery&; prog : Pr
             return analyze_chain(foCall.arguments[0], q, prog, at)
         }
     }
+    // Peel `_aggregate(prev, block)` — one named row containing several
+    // global aggregates, all evaluated by one SQL source scan.
+    {
+        var gaCall = match_call_in_module(node, "_aggregate_rows", "sql_linq")
+        if (gaCall != null) {
+            if (q.seenTerminal || q.seenToArray) {
+                macro_error(prog, at, "_sql: only one terminal allowed per chain")
+                return false
+            }
+            if (gaCall.arguments |> length != 2) {
+                macro_error(prog, at, "_sql: `_aggregate` expects `(source, aggregate_block)`")
+                return false
+            }
+            // Pre-set terminal state so a join source does not mistake this
+            // outer terminal for a terminal embedded in its own LHS/RHS.
+            q.matr = Materializer.One
+            q.seenTerminal = true
+            if (!analyze_chain(gaCall.arguments[0], q, prog, at)) return false
+            if (q.seenGroupBy || q.seenHaving) {
+                macro_error(prog, at, "_sql: `_aggregate` is a global aggregate and cannot follow `_group_by` / `_having`; use grouped `_select` aggregates instead")
+                return false
+            }
+            if (q.seenDistinct || !empty(q.distinctByCol) || q.seenSetOp
+                    || q.seenTake || q.seenSkip || q.seenOrderBy) {
+                macro_error(prog, at, "_sql: `_aggregate` v1 supports filtered table/join sources only — `distinct`, `_distinct_by`, set ops, ordering, take, and skip need an explicit subquery-composition rail")
+                return false
+            }
+            if (q.seenSelect && !q.seenJoin) {
+                macro_error(prog, at, "_sql: `_aggregate` v1 cannot follow a standalone `_select`; aggregate fields directly from the source row inside the `_aggregate` block")
+                return false
+            }
+            return analyze_global_aggregate_projection(gaCall.arguments[1], q, prog, at)
+        }
+    }
     // Peel count(prev) / long_count(prev) → SELECT COUNT(*) (or COUNT(DISTINCT col) when fronted by `_distinct_by(_.col)`).
     {
         if (peel_count_terminal(node, q, "count", false, prog, at)
@@ -2605,6 +2676,181 @@ def private try_translate_group_aggregate(var node : ExpressionPtr; var q : SqlQ
         }
     }
     return false
+}
+
+// nolint:STYLE015 Translates one `_aggregate` tuple slot. The terminal's block argument represents the full filtered rowset: `rows |> count` becomes COUNT(*), while `rows |> _select($(r:T) => r.Field) |> min/max/sum/average` wraps the exact source column. Post-join fields resolve through the join's `into` projection registry, so a whole-source projection (`$(l,r)=>r`) remains fully qualified.
+[macro_function]
+def private try_translate_global_aggregate(var node : ExpressionPtr; rowsArgName : string;
+                                           var q : SqlQuery&; prog : ProgramPtr; at : LineInfo;
+                                           var sqlOut : string&; var typeOut : TypeDeclPtr&) : bool {
+    var n = node
+    if (n is ExprRef2Value) {
+        n = (n as ExprRef2Value).subexpr
+    }
+    if (n == null || !(n is ExprCall)) return false
+    var call = n as ExprCall
+    if (call.func == null) return false
+    var fname = string(call.func.name)
+    if (call.func.fromGeneric != null) {
+        fname = string(call.func.fromGeneric.name)
+    }
+    let argc = user_arg_count(call)
+    if ((fname == "count" || fname == "long_count") && argc == 1) {
+        var rowsArg = call.arguments[0]
+        if (rowsArg is ExprRef2Value) {
+            rowsArg = (rowsArg as ExprRef2Value).subexpr
+        }
+        if (rowsArg != null && rowsArg is ExprVar
+                && (rowsArg as ExprVar).name == rowsArgName) {
+            sqlOut = "COUNT(*)"
+            typeOut = new TypeDecl(
+                at = at,
+                baseType = fname == "long_count" ? Type.tInt64 : Type.tInt)
+            return true
+        }
+        macro_error(prog, at, "_sql: `_aggregate` {fname} must consume the aggregate block's `{rowsArgName}` rowset directly")
+        return true
+    }
+    if ((fname == "sum" || fname == "average" || fname == "min" || fname == "max") && argc == 1) {
+        var innerCall = match_call_in_linq(call.arguments[0], "select")
+        if (innerCall == null || innerCall.arguments |> length != 2) {
+            macro_error(prog, at, "_sql: `_aggregate` {fname} requires `{rowsArgName} |> _select($(row : T) => row.Field) |> {fname}`")
+            return true
+        }
+        var selectRows = innerCall.arguments[0]
+        if (selectRows is ExprRef2Value) {
+            selectRows = (selectRows as ExprRef2Value).subexpr
+        }
+        if (selectRows == null || !(selectRows is ExprVar)
+                || (selectRows as ExprVar).name != rowsArgName) {
+            macro_error(prog, at, "_sql: `_aggregate` {fname} must select from the aggregate block's `{rowsArgName}` rowset")
+            return true
+        }
+        var selector = innerCall.arguments[1]
+        if (selector == null || !(selector is ExprMakeBlock)) {
+            macro_error(prog, at, "_sql: `_aggregate` {fname} selector has unexpected shape")
+            return true
+        }
+        var selectorBlock = (selector as ExprMakeBlock)._block as ExprBlock
+        if (selectorBlock == null || selectorBlock.arguments |> length != 1) {
+            macro_error(prog, at, "_sql: `_aggregate` {fname} selector must take exactly one row argument")
+            return true
+        }
+        let selectorArgName = string(selectorBlock.arguments[0].name)
+        var selectorBody = peel_lambda_single_return(selector)
+        if (selectorBody == null) {
+            macro_error(prog, at, "_sql: `_aggregate` {fname} selector lambda has unexpected shape")
+            return true
+        }
+        var receiver : ExpressionPtr
+        var fieldName : string
+        if (!qmatch(selectorBody, $e(receiver).$f(fieldName)).matched
+                || receiver == null || !(receiver is ExprVar)
+                || (receiver as ExprVar).name != selectorArgName) {
+            macro_error(prog, at, "_sql: `_aggregate` {fname} selector must be `<row>.<field>` and may not read an outer capture; got: {describe(selectorBody)}")
+            return true
+        }
+        var sqlArg : string
+        var fieldType : TypeDeclPtr
+        if (q.seenJoin) {
+            let aliasIdx = find_projection_alias(q, fieldName)
+            if (aliasIdx < 0) {
+                macro_error(prog, at, "_sql: `_aggregate` {fname} field '{fieldName}' is not an alias of the preceding join projection (valid aliases: {projection_alias_list(q)})")
+                return true
+            }
+            sqlArg = render_projection_alias_sql(q, aliasIdx)
+            if (empty(sqlArg)) {
+                macro_error(prog, at, "_sql: `_aggregate` {fname} cannot render join projection field '{fieldName}'")
+                return true
+            }
+            fieldType = clone_type(q.joinSelectColTypes[aliasIdx])
+        } else {
+            fieldType = lookup_struct_field_type(q.rootType, fieldName)
+            if (fieldType == null) {
+                macro_error(prog, at, "_sql: `_aggregate` {fname} cannot resolve field '{fieldName}' on the source row")
+                return true
+            }
+            sqlArg = column_sql_for_alias("", q.rootType, fieldName)
+        }
+        var sqlOp : string
+        if (fname == "sum") {
+            sqlOp = "SUM"
+        } elif (fname == "average") {
+            sqlOp = "AVG"
+        } elif (fname == "min") {
+            sqlOp = "MIN"
+        } else {
+            sqlOp = "MAX"
+        }
+        sqlOut = "{sqlOp}({sqlArg})"
+        if (fname == "average") {
+            typeOut = new TypeDecl(at = at, baseType = Type.tDouble)
+        } else {
+            typeOut = fieldType
+        }
+        return true
+    }
+    return false
+}
+
+[macro_function]
+def private analyze_global_aggregate_projection(var aggregateLambda : ExpressionPtr;
+                                                var q : SqlQuery&; prog : ProgramPtr; at : LineInfo) : bool {
+    if (aggregateLambda == null || !(aggregateLambda is ExprMakeBlock)) {
+        macro_error(prog, at, "_sql: `_aggregate` expects a one-argument block returning a named tuple")
+        return false
+    }
+    var aggregateBlock = (aggregateLambda as ExprMakeBlock)._block as ExprBlock
+    if (aggregateBlock == null || aggregateBlock.arguments |> length != 1) {
+        macro_error(prog, at, "_sql: `_aggregate` block must take exactly one rowset argument")
+        return false
+    }
+    let rowsArgName = string(aggregateBlock.arguments[0].name)
+    var body = peel_lambda_single_return(aggregateLambda)
+    if (body is ExprRef2Value) {
+        body = (body as ExprRef2Value).subexpr
+    }
+    if (body == null || !(body is ExprMakeTuple)) {
+        macro_error(prog, at, "_sql: `_aggregate` block must return a named tuple such as `(N = rows |> count, MinX = rows |> _select($(r:T) => r.X) |> min)`")
+        return false
+    }
+    var mkTup = body as ExprMakeTuple
+    var tupT = mkTup._type
+    if (tupT == null || tupT.baseType != Type.tTuple
+            || empty(tupT.argNames)
+            || length(tupT.argNames) != length(mkTup.values)) {
+        macro_error(prog, at, "_sql: `_aggregate` result must be a NAMED tuple — every aggregate needs `Name = expression`")
+        return false
+    }
+    q.selectCols |> clear
+    q.selectColAliases |> clear
+    q.selectColTypes |> clear
+    q.selectColSqlFragments |> clear
+    q.projRecordNames |> clear
+    q.projBindExprs |> clear
+    let n = length(mkTup.values)
+    q.selectCols |> reserve(n)
+    q.selectColAliases |> reserve(n)
+    q.selectColTypes |> reserve(n)
+    q.selectColSqlFragments |> reserve(n)
+    q.projRecordNames |> reserve(n)
+    for (i in range(n)) {
+        var sqlFrag : string
+        var resultType : TypeDeclPtr
+        if (!try_translate_global_aggregate(
+                mkTup.values[i], rowsArgName, q, prog, at, sqlFrag, resultType)) {
+            macro_error(prog, at, "_sql: `_aggregate` tuple values must be `rows |> count/long_count` or `rows |> _select($(row:T) => row.Field) |> sum/average/min/max`; got: {describe(mkTup.values[i])}")
+            return false
+        }
+        if (empty(sqlFrag) || resultType == null) return false
+        push_computed_proj_slot(q, sqlFrag, resultType, string(tupT.argNames[i]))
+    }
+    q.projectedRowType = null
+    q.proj = ProjectionShape.NamedTuple
+    q.matr = Materializer.One
+    q.seenSelect = true
+    q.seenTerminal = true
+    return true
 }
 
 // nolint:STYLE015 Recognizes `_._1 |> first()` (== `first(_._1)`) in a `_select` after `_group_by`. Mirrors `try_translate_group_aggregate`'s name+receiver match shape — qmatch's `_._1.first()` doesn't match the call form.

--- a/doc/source/reference/tutorials/sql_13_aggregates.rst
+++ b/doc/source/reference/tutorials/sql_13_aggregates.rst
@@ -14,20 +14,36 @@ SQL-13 --- Aggregates: ``sum``/``avg``/...
     single: Tutorial; MAX
     single: Tutorial; COUNT
 
-==============================================  ============================  ========================
-Source shape                                    Emitted SQL                   Result type
-==============================================  ============================  ========================
-``... |> count()``                              ``SELECT COUNT(*) ...``       ``int``
-``... |> _select(_.Col) |> sum()``              ``SELECT SUM("Col") ...``     column type
-``... |> _select(_.Col) |> average()``          ``SELECT AVG("Col") ...``     ``double``
-``... |> _select(_.Col) |> min()``              ``SELECT MIN("Col") ...``     column type
-``... |> _select(_.Col) |> max()``              ``SELECT MAX("Col") ...``     column type
-==============================================  ============================  ========================
+.. list-table::
+    :header-rows: 1
 
-All five are *terminals* --- they end the chain and produce a
-scalar, not an array. The four column-driven aggregates need a
-``_select(_.Col)`` to pick the column; ``count`` operates on rows,
-not values, and stands alone.
+    * - Source shape
+      - Emitted SQL
+      - Result type
+    * - ``... |> count()``
+      - ``SELECT COUNT(*) ...``
+      - ``int``
+    * - ``... |> _select(_.Col) |> sum()``
+      - ``SELECT SUM("Col") ...``
+      - column type
+    * - ``... |> _select(_.Col) |> average()``
+      - ``SELECT AVG("Col") ...``
+      - ``double``
+    * - ``... |> _select(_.Col) |> min()``
+      - ``SELECT MIN("Col") ...``
+      - column type
+    * - ``... |> _select(_.Col) |> max()``
+      - ``SELECT MAX("Col") ...``
+      - column type
+    * - ``... |> _aggregate($(rows) => (...))``
+      - several aggregates, one row
+      - named tuple
+
+The five scalar forms are *terminals* --- they end the chain and
+produce one scalar, not an array. The four column-driven aggregates
+need a ``_select(_.Col)`` to pick the column; ``count`` operates on
+rows, not values, and stands alone. ``_aggregate`` is the typed
+one-row counterpart when several scalar facts are needed together.
 
 ``count`` --- whole-source row count
 ====================================
@@ -98,6 +114,48 @@ A ``_where`` predicate filters the input rows the aggregate sees:
                                 |> _select(_.Price)
                                 |> sum())
     // SELECT SUM("Price") FROM "Cars" WHERE "Price" > ?
+
+Several global aggregates in one scan
+======================================
+
+``_aggregate`` returns a named tuple containing several global
+aggregates while executing one SQL statement and scanning the filtered
+source once:
+
+.. code-block:: das
+
+    let stats = _sql(
+        db |> select_from(type<Car>)
+           |> _where(_.Price >= cutoff)
+           |> _aggregate($(rows) => (
+                N = rows |> count,
+                Total = rows |> _select(_.Price) |> sum,
+                Cheapest = rows |> _select(_.Price) |> min,
+                Priciest = rows |> _select(_.Price) |> max,
+                Mean = rows |> _select(_.Price) |> average)))
+
+The emitted query has one aggregate expression per named tuple field:
+
+.. code-block:: sql
+
+    SELECT COUNT(*) AS "N",
+           SUM("Price") AS "Total",
+           MIN("Price") AS "Cheapest",
+           MAX("Price") AS "Priciest",
+           AVG("Price") AS "Mean"
+    FROM "Cars"
+    WHERE "Price" >= ?
+    LIMIT 1
+
+The same ``_aggregate`` expression also works on an in-memory array,
+where its block runs directly over the array. An empty SQL source
+returns the daslang type default for every slot: zero for the numeric
+aggregates shown above.
+
+The first version deliberately accepts filtered table and join sources.
+It rejects prior ``distinct``, paging, ordering, grouping, set
+operations, and standalone projections because those shapes require an
+explicit subquery-composition rail.
 
 Per-bucket aggregates --- ``_group_by``
 =======================================

--- a/doc/source/reference/tutorials/sql_15_join.rst
+++ b/doc/source/reference/tutorials/sql_15_join.rst
@@ -91,6 +91,34 @@ Single-column and named-tuple projections both work. Per-source
 projections (``_select(...)`` on the right side) are rejected ---
 the join's ``into`` lambda is the only projection.
 
+Returning one source row
+========================
+
+When the result should be one of the joined table rows, return that
+source argument directly from ``into``. ``_sql`` expands the source
+to its qualified columns and reconstructs the exact nominal struct:
+
+.. code-block:: das
+
+    let large_orders : array<Order> <- _sql(
+        db |> select_from(type<User>)
+           |> _join(db |> select_from(type<Order>),
+                    $(u : User, o : Order) => u.Id == o.UserId,
+                    $(u : User, o : Order) => o)
+           |> _where(_.Total >= 100)
+           |> _order_by(_.Total))
+    // SELECT "t1"."Id", "t1"."UserId", "t1"."Total"
+    //   FROM "Users" AS "t0"
+    //   INNER JOIN "Orders" AS "t1"
+    //     ON "t0"."Id" = "t1"."UserId"
+    //  WHERE "t1"."Total" >= ?
+
+The result type is ``array<Order>``, not a generated tuple. This form
+is useful when the other source only supplies filtering, ranking, or
+existence context. A nullable side of an outer join cannot be returned
+as a bare struct; project named scalar fields (including an
+``is_some`` probe) when unmatched rows must be represented.
+
 Joining + grouping
 ==================
 

--- a/doc/source/reference/tutorials/sql_21_upsert.rst
+++ b/doc/source/reference/tutorials/sql_21_upsert.rst
@@ -14,6 +14,7 @@ SQL-21 --- UPSERT
     single: Tutorial; _sql_upsert
     single: Tutorial; _sql_upsert_returning
     single: Tutorial; _excluded
+    single: Tutorial; auto-assigned primary key
 
 Three SQL shapes for "INSERT but, if it collides with a UNIQUE / PK
 constraint, do something instead":
@@ -79,6 +80,45 @@ ON CONFLICT ... DO UPDATE --- the proper merge
     //   ON CONFLICT("Id") DO UPDATE SET
     //     "Hits" = ("Hits") + (?),
     //     "Last" = excluded."Last"
+
+Auto-assigned integer primary keys
+==================================
+
+An integer primary key at its default value (usually ``Id = 0``) is
+treated as unset, just like it is by ``insert``. ``_sql_upsert`` omits
+that column from the attempted ``INSERT``, allowing the provider to
+assign it: SQLite uses its rowid alias, DuckDB uses a sequence, and
+PostgreSQL uses an identity column.
+
+This is most useful when the conflict target is a different UNIQUE
+column. The first call inserts with a generated ID; later calls with
+the same key update the existing row without replacing its ID.
+
+.. code-block:: das
+
+    [sql_table(name = "WordHits"),
+     sql_index(fields = "Word", unique = true)]
+    struct WordHit {
+        @sql_primary_key Id : int
+        Word : string
+        Hits : int
+        Last : int64
+    }
+
+    let created <- db |> _sql_upsert_returning(
+        WordHit(Id = 0, Word = "automatic", Hits = 1, Last = 2000l),
+        _.Word,
+        (Hits = _.Hits + _excluded.Hits, Last = _excluded.Last))
+
+    // `created[0].Id` is provider-assigned and non-zero.
+    db |> _sql_upsert(
+        WordHit(Id = 0, Word = "automatic", Hits = 4, Last = 3000l),
+        _.Word,
+        (Hits = _.Hits + _excluded.Hits, Last = _excluded.Last))
+
+The rule applies equally to ``_sql_try_upsert``,
+``_sql_upsert_returning``, and ``_sql_try_upsert_returning``. An
+explicit non-default primary key remains part of the ``INSERT``.
 
 Composite conflict targets
 ==========================

--- a/doc/source/reference/tutorials/sql_24_indexes.rst
+++ b/doc/source/reference/tutorials/sql_24_indexes.rst
@@ -10,12 +10,14 @@ SQL-24 --- Indexes
     single: Tutorial; index
     single: Tutorial; CREATE INDEX
     single: Tutorial; sql_index
+    single: Tutorial; sql_unique
     single: Tutorial; UNIQUE INDEX
     single: Tutorial; composite index
 
-``[sql_index]`` is a sibling annotation to ``[sql_table]``: each
-``[sql_index]`` emits one ``CREATE [UNIQUE] INDEX`` statement, run
-right after the ``CREATE TABLE`` inside the same transaction.
+``@sql_unique`` is the concise field-level form for one-column
+uniqueness. ``[sql_index]`` is the configurable sibling annotation for
+named, non-unique, unique, and composite indexes. Both emit portable
+``CREATE [UNIQUE] INDEX`` statements after ``CREATE TABLE``.
 
 Sibling-annotation shape
 ========================
@@ -32,6 +34,7 @@ with ``[sql_table]`` first.
     struct User {
         @sql_primary_key Id : int
         Email : string
+        @sql_unique
         Name : string
         City : string
         LastSeen : int64
@@ -58,6 +61,7 @@ DDL emitted
 .. code-block:: text
 
     CREATE TABLE "Users" (...);
+    CREATE UNIQUE INDEX "uq_Users_Name" ON "Users" ("Name");
     CREATE UNIQUE INDEX "idx_Users_Email" ON "Users" ("Email");
     CREATE INDEX "idx_Users_City_LastSeen" ON "Users" ("City", "LastSeen");
     CREATE INDEX "ix_users_lastseen" ON "Users" ("LastSeen");
@@ -68,6 +72,28 @@ and asserts.
 .. code-block:: das
 
     let idx_sql = _sql_create_indexes_sql(type<User>)
+
+Field-level single-column uniqueness
+====================================
+
+``@sql_unique`` creates a provider-neutral UNIQUE INDEX with the
+generated name ``uq_<table>_<column>``. It goes through
+``_sql_create_indexes_sql`` instead of being embedded in SQLite-style
+column DDL, so the same annotation is enforced by SQLite, DuckDB, and
+PostgreSQL.
+
+.. code-block:: das
+
+    struct User {
+        @sql_primary_key Id : int
+        @sql_unique
+        Name : string
+    }
+
+    // CREATE UNIQUE INDEX "uq_Users_Name" ON "Users" ("Name")
+
+Use ``[sql_index(fields = "Name", unique = true, name = "...")]``
+instead when the index name must be controlled explicitly.
 
 Indexes are transparent at the query side
 =========================================
@@ -104,10 +130,9 @@ is how you declare one --- there is no separate
 ``[sql_unique]`` table-level annotation.
 
 Single-column uniqueness can use either ``@sql_unique`` on the field
-(emits ``UNIQUE`` directly in the column DDL) or
-``[sql_index(unique = true, fields = "Col")]`` (separate
-``CREATE UNIQUE INDEX``). Both work for the upsert path; the index
-form is preferable when you also need to control the index name.
+or ``[sql_index(unique = true, fields = "Col")]``. Both work on
+SQLite, DuckDB, and PostgreSQL and both satisfy the upsert conflict
+target. The index form is preferable when you need to control its name.
 
 .. seealso::
 

--- a/doc/source/reference/tutorials/sql_40_fts5.rst
+++ b/doc/source/reference/tutorials/sql_40_fts5.rst
@@ -79,6 +79,21 @@ ascending BM25 score (lower = more relevant first):
     //   SELECT "Body", rank FROM "docs_idx"
     //   WHERE "Body" MATCH ? ORDER BY rank
 
+Typed predicate DELETE
+======================
+
+FTS5 virtual tables have no declared daslang primary key, but predicate
+deletes use the regular typed DML macro:
+
+.. code-block:: das
+
+    let removed = db |> _sql_delete(
+        type<Doc>,
+        _.Body |> text_match("obsolete"))
+
+This emits a bound ``DELETE FROM "docs_idx" WHERE "Body" MATCH ?`` and
+returns the number of removed rows.
+
 FTS5 query syntax (passed through to ``MATCH``)
 ===============================================
 
@@ -171,8 +186,10 @@ v1 limitations
 * **Default tokenizer is unicode61** (case-fold + Unicode word
   boundaries). Custom tokenizers (``porter``, ``ascii``,
   ``unicode61 remove_diacritics 2``) need raw DDL.
-* **No typed UPDATE / DELETE.** Drop and re-INSERT, or use raw
-  ``db |> exec("DELETE FROM docs_idx WHERE rowid = ?", id)``.
+* **No row-shaped UPDATE / DELETE-by-PK helpers.** The virtual table has
+  no declared daslang primary key. Predicate DELETE is typed via
+  ``_sql_delete(type<Doc>, predicate)``; update by deleting and
+  re-inserting, or use raw SQL.
 * **BM25 weighting, snippet/highlight helpers, per-column query
   filters (``Body:fox``)** all work via the FTS5 query string
   but don't have typed wrappers in v1.

--- a/doc/source/reference/tutorials/sql_40_fts5.rst
+++ b/doc/source/reference/tutorials/sql_40_fts5.rst
@@ -25,6 +25,8 @@ API surface added in this chunk
 
 * ``[sql_fts5(name = "...")]`` --- struct annotation: the type
   is materialized as a SQLite FTS5 virtual table.
+* ``@sql_fts_unindexed`` --- stored typed metadata column that is
+  excluded from the inverted index and cannot be a ``MATCH`` target.
 * ``@sql_fts_rank`` --- read-only ``float`` column annotation:
   maps to FTS5's hidden ``rank`` column on SELECT, skipped on
   INSERT.
@@ -47,6 +49,7 @@ Declaring the virtual table
 
     [sql_fts5(name = "docs_idx")]
     struct Doc {
+        @sql_fts_unindexed Id : int64
         Body : string
         @sql_fts_rank Rank : float
     }
@@ -54,15 +57,32 @@ Declaring the virtual table
     db |> create_table(type<Doc>)
     // emits:
     //   CREATE VIRTUAL TABLE IF NOT EXISTS "docs_idx"
-    //       USING fts5("Body", tokenize='unicode61')
+    //       USING fts5("Id" UNINDEXED, "Body", tokenize='unicode61')
 
 INSERT works like any ``[sql_table]``; the ``Rank`` column is
 skipped automatically (FTS5 has no user-writable rank).
 
 .. code-block:: das
 
-    db |> insert(Doc(Body = "The quick brown fox jumps over the lazy dog"))
-    db |> insert(Doc(Body = "A swift red fox escaped at dawn"))
+    db |> insert(Doc(Id = 1l, Body = "The quick brown fox jumps over the lazy dog"))
+    db |> insert(Doc(Id = 2l, Body = "A swift red fox escaped at dawn"))
+
+Typed metadata with ``@sql_fts_unindexed``
+===============================================
+
+Use unindexed columns for row IDs, tenant/chat IDs, kinds, timestamps,
+or other metadata that must travel with each search hit without being
+tokenized:
+
+.. code-block:: das
+
+    let hits <- _sql(db |> select_from(type<Doc>)
+                        |> _where(_.Id == 1l
+                            && (_.Body |> text_match("fox"))))
+
+``Id`` remains an ``int64`` through INSERT and SELECT and supports
+ordinary typed comparisons. ``text_match(_.Id, ...)`` is rejected:
+UNINDEXED metadata is deliberately not part of the FTS5 index.
 
 Querying
 ========

--- a/examples/telegram/dictation/README.md
+++ b/examples/telegram/dictation/README.md
@@ -64,8 +64,10 @@ The database is created automatically. Migration 1 creates message/state storage
 the FTS5 index, migration 3 records outgoing transcript-delivery IDs, migration 4 adds resumable
 Telegram-export media checkpoints, and migration 5 records the database sources behind Cadmus
 answers. Migration 6 adds the durable live-audio queue, and migration 7 checkpoints successful live
-ASR results so cleanup retries do not retranscribe the same audio. Telegram update offsets are persisted, and
-`(chat_id, message_id)` makes replayed updates and edits idempotent. History is retained indefinitely.
+ASR results so cleanup retries do not retranscribe the same audio. Migration 8 rebuilds the FTS5
+index with typed, unindexed chat/message keys so only message text is tokenized. Telegram update
+offsets are persisted, and `(chat_id, message_id)` makes replayed updates and edits idempotent.
+History is retained indefinitely.
 
 Before sending an answer, Cadmus validates every model-written HTTP(S) link against exact URLs
 returned by Brave Search or chat-history tools in the current turn. An unverified link triggers up to

--- a/examples/telegram/dictation/cadmus_history.das
+++ b/examples/telegram/dictation/cadmus_history.das
@@ -6,7 +6,6 @@ require sqlite/sqlite_migrate
 require daslib/sql_linq
 require daslib/linq_das
 require daslib/strings_boost
-require daslib/strings_convert
 require math
 
 let CADMUS_ROLE_USER = "user"
@@ -95,8 +94,8 @@ struct CadmusLiveAudio {
 
 [sql_fts5(name = "cadmus_message_fts")]
 struct CadmusSearchRow {
-    ChatId : string
-    TelegramMessageId : string
+    @sql_fts_unindexed ChatId : int64
+    @sql_fts_unindexed TelegramMessageId : int64
     Body : string
     @sql_fts_rank Rank : float
 }
@@ -233,6 +232,23 @@ def cadmus_migration_007(db : SqlRunner) {
     db |> exec("ALTER TABLE cadmus_live_audio ADD COLUMN TranscriptLanguage TEXT NOT NULL DEFAULT ''")
 }
 
+// FTS keys are relational metadata, not searchable prose. Rebuild once so new typed queries bind
+// int64 directly and FTS5 stops tokenizing chat/message IDs into its inverted index.
+[sql_migration(version = 8, description = "store Cadmus FTS keys as typed unindexed metadata")]
+def cadmus_migration_008(db : SqlRunner) {
+    db |> exec("DROP TABLE cadmus_message_fts")
+    db |> exec(
+        "CREATE VIRTUAL TABLE cadmus_message_fts USING fts5(" +
+        "\"ChatId\" UNINDEXED, \"TelegramMessageId\" UNINDEXED, \"Body\", " +
+        "tokenize='unicode61')")
+    db |> exec(
+        "INSERT INTO cadmus_message_fts(ChatId, TelegramMessageId, Body) " +
+        "SELECT ChatId, TelegramMessageId, " +
+        "trim(Content || char(10) || Caption || char(10) || RawTranscript) " +
+        "FROM cadmus_messages WHERE Deleted = 0 AND " +
+        "length(trim(Content || Caption || RawTranscript)) > 0")
+}
+
 def with_cadmus_database(path : string; blk : block<(db : SqlRunner) : void>) {
     with_latest_sqlite(path) $(db) {
         db |> set_pragma("busy_timeout", 120000l)
@@ -353,12 +369,10 @@ def load_cadmus_assistant_sources(
     return <- result
 }
 
-// FTS5 v1 has typed INSERT + SELECT but no typed UPDATE/DELETE. Keep that narrow
-// provider gap here; every ordinary application read/write uses LINQ/_sql below.
 def private sync_cadmus_search(db : SqlRunner; msg : CadmusMessage) {
-    db |> exec(
-        "DELETE FROM cadmus_message_fts WHERE ChatId = ? AND TelegramMessageId = ?",
-        "{msg.ChatId}", "{msg.TelegramMessageId}")
+    db |> _sql_delete(
+        type<CadmusSearchRow>,
+        _.ChatId == msg.ChatId && _.TelegramMessageId == msg.TelegramMessageId)
     if (!msg.Deleted && !empty(strip("{msg.Content}{msg.Caption}{msg.RawTranscript}"))) {
         let body = build_string() $(var writer) {
             if (!empty(strip(msg.Content))) {
@@ -374,8 +388,8 @@ def private sync_cadmus_search(db : SqlRunner; msg : CadmusMessage) {
             }
         }
         db |> insert(CadmusSearchRow(
-            ChatId = "{msg.ChatId}",
-            TelegramMessageId = "{msg.TelegramMessageId}",
+            ChatId = msg.ChatId,
+            TelegramMessageId = msg.TelegramMessageId,
             Body = body,
             Rank = 0.0))
     }
@@ -427,8 +441,7 @@ def upsert_cadmus_import_media_db(db : SqlRunner; item : CadmusImportMedia) {
         return
     }
     var upsert_item = item
-    upsert_item.Id = db |> query_scalar(
-        "SELECT COALESCE(MAX(Id), 0) + 1 FROM cadmus_import_media", type<int>)
+    upsert_item.Id = 0
     db |> _sql_upsert(
         upsert_item,
         tuple(_.ChatId, _.TelegramMessageId),
@@ -680,9 +693,9 @@ def mark_cadmus_message_deleted(path : string; chat_id, message_id, edited_at : 
                 type<CadmusMessage>,
                 _.ChatId == chat_id && _.TelegramMessageId == message_id,
                 (Deleted = true, EditedAt = edited_at))
-            db |> exec(
-                "DELETE FROM cadmus_message_fts WHERE ChatId = ? AND TelegramMessageId = ?",
-                "{chat_id}", "{message_id}")
+            db |> _sql_delete(
+                type<CadmusSearchRow>,
+                _.ChatId == chat_id && _.TelegramMessageId == message_id)
         }
     }
 }
@@ -737,15 +750,6 @@ def private cadmus_fts_query(
     return terms |> join(require_all ? " AND " : " OR ")
 }
 
-def private parse_stored_int64(value : string; var result : int64&) : bool {
-    let parsed = try_to_int64(value)
-    if (parsed |> is_err) {
-        return false
-    }
-    result = parsed |> unwrap
-    return true
-}
-
 def search_cadmus_messages(path : string; chat_id : int64; question : string; count : int) : array<CadmusMessage> {
     var result : array<CadmusMessage>
     let query_text = cadmus_fts_query(question)
@@ -753,19 +757,15 @@ def search_cadmus_messages(path : string; chat_id : int64; question : string; co
         return <- result
     }
     with_cadmus_database(path) $(db) {
-        let chat_key = "{chat_id}"
         let hits <- _sql(
             db |> select_from(type<CadmusSearchRow>)
-               |> _where(_.ChatId == chat_key && _.Body |> text_match(query_text))
+               |> _where(_.ChatId == chat_id && _.Body |> text_match(query_text))
                |> _order_by(_.Rank)
                |> take(count))
         for (hit in hits) {
-            var message_id = 0l
-            if (!parse_stored_int64(hit.TelegramMessageId, message_id)) {
-                continue
-            }
             let rows <- %linq! from m : CadmusMessage in db
-                               where m.ChatId == chat_id && m.TelegramMessageId == message_id && !m.Deleted
+                               where m.ChatId == chat_id &&
+                                     m.TelegramMessageId == hit.TelegramMessageId && !m.Deleted
                                select m %%
             if (!empty(rows)) {
                 result |> push(rows[0])
@@ -811,20 +811,16 @@ def private search_cadmus_message_variant(
         return <- result
     }
     with_cadmus_database(path) $(db) {
-        let chat_key = "{chat_id}"
         let candidate_count = clamp(count * 6, 24, 100)
         let hits <- _sql(
             db |> select_from(type<CadmusSearchRow>)
-               |> _where(_.ChatId == chat_key && _.Body |> text_match(query_text))
+               |> _where(_.ChatId == chat_id && _.Body |> text_match(query_text))
                |> _order_by(_.Rank)
                |> take(candidate_count))
         for (hit in hits) {
-            var message_id = 0l
-            if (!parse_stored_int64(hit.TelegramMessageId, message_id)) {
-                continue
-            }
             let rows <- %linq! from m : CadmusMessage in db
-                               where m.ChatId == chat_id && m.TelegramMessageId == message_id &&
+                               where m.ChatId == chat_id &&
+                                     m.TelegramMessageId == hit.TelegramMessageId &&
                                      m.Role == CADMUS_ROLE_USER && !m.Deleted &&
                                      (sender_id == 0l || m.SenderId == sender_id) &&
                                      (before_message_id == 0l ||
@@ -884,13 +880,17 @@ def search_cadmus_messages_chronological(
         return <- result
     }
     with_cadmus_database(path) $(db) {
-        result <- db |> query(
-            "SELECT m.* FROM cadmus_message_fts f JOIN cadmus_messages m " +
-            "ON m.ChatId = CAST(f.ChatId AS INTEGER) " +
-            "AND m.TelegramMessageId = CAST(f.TelegramMessageId AS INTEGER) " +
-            "WHERE f.ChatId = ? AND f.Body MATCH ? AND m.Deleted = 0 " +
-            "ORDER BY m.MessageDate ASC, m.TelegramMessageId ASC LIMIT ?",
-            type<CadmusMessage>, "{chat_id}", query_text, count)
+        result <- _sql(
+            db |> select_from(type<CadmusSearchRow>)
+               |> _where(_.ChatId == chat_id && _.Body |> text_match(query_text))
+               |> _join(
+                    db |> select_from(type<CadmusMessage>)
+                       |> _where(_.ChatId == chat_id && !_.Deleted),
+                    $(f : CadmusSearchRow, m : CadmusMessage) =>
+                        f.TelegramMessageId == m.TelegramMessageId,
+                    $(f : CadmusSearchRow, m : CadmusMessage) => m)
+               |> _order_by((_.MessageDate, _.TelegramMessageId))
+               |> take(count))
     }
     return <- result
 }
@@ -902,15 +902,16 @@ def cadmus_mention_stats(path : string; chat_id : int64; question : string) : Ca
         return result
     }
     with_cadmus_database(path) $(db) {
+        // Global multi-aggregate projection is the remaining typed-query gap here; keep this
+        // one raw statement so FTS is scanned once rather than issuing COUNT/MIN/MAX separately.
         result <- db |> query_one(
             "SELECT COUNT(*) AS Total, " +
             "COALESCE(MIN(m.MessageDate), 0) AS FirstDate, " +
             "COALESCE(MAX(m.MessageDate), 0) AS LastDate " +
             "FROM cadmus_message_fts f JOIN cadmus_messages m " +
-            "ON m.ChatId = CAST(f.ChatId AS INTEGER) " +
-            "AND m.TelegramMessageId = CAST(f.TelegramMessageId AS INTEGER) " +
+            "ON m.ChatId = f.ChatId AND m.TelegramMessageId = f.TelegramMessageId " +
             "WHERE f.ChatId = ? AND f.Body MATCH ? AND m.Deleted = 0",
-            type<CadmusMentionStats>, "{chat_id}", query_text)
+            type<CadmusMentionStats>, chat_id, query_text)
     }
     return result
 }
@@ -1000,20 +1001,16 @@ def search_cadmus_user_messages(
         return <- result
     }
     with_cadmus_database(path) $(db) {
-        let chat_key = "{chat_id}"
         let candidate_count = count * 4 <= 100 ? count * 4 : 100
         let hits <- _sql(
             db |> select_from(type<CadmusSearchRow>)
-               |> _where(_.ChatId == chat_key && _.Body |> text_match(query_text))
+               |> _where(_.ChatId == chat_id && _.Body |> text_match(query_text))
                |> _order_by(_.Rank)
                |> take(candidate_count))
         for (hit in hits) {
-            var message_id = 0l
-            if (!parse_stored_int64(hit.TelegramMessageId, message_id)) {
-                continue
-            }
             let rows <- %linq! from m : CadmusMessage in db
-                               where m.ChatId == chat_id && m.TelegramMessageId == message_id &&
+                               where m.ChatId == chat_id &&
+                                     m.TelegramMessageId == hit.TelegramMessageId &&
                                      m.Role == CADMUS_ROLE_USER && !m.Deleted
                                select m %%
             if (!empty(rows)) {

--- a/examples/telegram/dictation/cadmus_history.das
+++ b/examples/telegram/dictation/cadmus_history.das
@@ -100,7 +100,6 @@ struct CadmusSearchRow {
     @sql_fts_rank Rank : float
 }
 
-[sql_table(name = "_cadmus_mention_stats_row")]
 struct CadmusMentionStats {
     Total : int
     FirstDate : int64
@@ -902,16 +901,23 @@ def cadmus_mention_stats(path : string; chat_id : int64; question : string) : Ca
         return result
     }
     with_cadmus_database(path) $(db) {
-        // Global multi-aggregate projection is the remaining typed-query gap here; keep this
-        // one raw statement so FTS is scanned once rather than issuing COUNT/MIN/MAX separately.
-        result <- db |> query_one(
-            "SELECT COUNT(*) AS Total, " +
-            "COALESCE(MIN(m.MessageDate), 0) AS FirstDate, " +
-            "COALESCE(MAX(m.MessageDate), 0) AS LastDate " +
-            "FROM cadmus_message_fts f JOIN cadmus_messages m " +
-            "ON m.ChatId = f.ChatId AND m.TelegramMessageId = f.TelegramMessageId " +
-            "WHERE f.ChatId = ? AND f.Body MATCH ? AND m.Deleted = 0",
-            type<CadmusMentionStats>, chat_id, query_text)
+        let stats = _sql(
+            (db |> select_from(type<CadmusSearchRow>)
+                |> _where(_.ChatId == chat_id && _.Body |> text_match(query_text)))
+            |> _join(
+                db |> select_from(type<CadmusMessage>)
+                   |> _where(_.ChatId == chat_id && !_.Deleted),
+                $(f : CadmusSearchRow, m : CadmusMessage) =>
+                    f.TelegramMessageId == m.TelegramMessageId,
+                $(f : CadmusSearchRow, m : CadmusMessage) => m)
+            |> _aggregate($(_rows) => (
+                Total = _rows |> count,
+                FirstDate = _rows |> _select(_.MessageDate) |> min,
+                LastDate = _rows |> _select(_.MessageDate) |> max)))
+        result = CadmusMentionStats(
+            Total = stats.Total,
+            FirstDate = stats.FirstDate,
+            LastDate = stats.LastDate)
     }
     return result
 }

--- a/examples/telegram/dictation/test_cadmus_history.das
+++ b/examples/telegram/dictation/test_cadmus_history.das
@@ -37,9 +37,14 @@ def test_history_migrations_linq_and_fts(t : T?) {
     remove(path)
     ensure_cadmus_database(path)
 
-    t |> run("starts at migration seven") @(t : T?) {
+    t |> run("starts at migration eight with unindexed typed FTS keys") @(t : T?) {
         with_sqlite(path) $(db) {
-            t |> equal(db |> current_schema_version(), 7)
+            t |> equal(db |> current_schema_version(), 8)
+            let ddl = db |> query_scalar(
+                "SELECT sql FROM sqlite_master WHERE name = 'cadmus_message_fts'",
+                type<string>)
+            t |> success(find(ddl, "\"ChatId\" UNINDEXED") >= 0)
+            t |> success(find(ddl, "\"TelegramMessageId\" UNINDEXED") >= 0)
         }
     }
 
@@ -342,5 +347,42 @@ def test_history_migrations_linq_and_fts(t : T?) {
         t |> success(has_ready_cadmus_live_audio(path, 3100l))
     }
 
+    remove(path)
+}
+
+[test]
+def test_history_v8_rebuild_preserves_existing_search_rows(t : T?) {
+    var error : string
+    let path = path_join(temp_directory(error), "cadmus_history_v7_upgrade_test.db")
+    remove(path)
+    with_sqlite(path) $(db) {
+        cadmus_migration_001(db)
+        cadmus_migration_002(db)
+        cadmus_migration_003(db)
+        cadmus_migration_004(db)
+        cadmus_migration_005(db)
+        cadmus_migration_006(db)
+        cadmus_migration_007(db)
+        db |> baseline(7)
+        db |> insert(test_message(77l, 1l, 5l, 100l, "legacy migration needle"))
+        db |> exec(
+            "INSERT INTO cadmus_message_fts(ChatId, TelegramMessageId, Body) VALUES (?, ?, ?)",
+            "77", "1", "legacy migration needle")
+    }
+
+    ensure_cadmus_database(path)
+    let rows <- search_cadmus_messages(path, 77l, "migration needle", 10)
+    t |> equal(length(rows), 1)
+    if (length(rows) == 1) {
+        t |> equal(rows[0].TelegramMessageId, 1l)
+    }
+    with_sqlite(path) $(db) {
+        t |> equal(db |> current_schema_version(), 8)
+        t |> equal(
+            db |> query_scalar(
+                "SELECT typeof(ChatId) FROM cadmus_message_fts WHERE TelegramMessageId = 1",
+                type<string>),
+            "integer")
+    }
     remove(path)
 }

--- a/modules/dasSQLITE/TUTORIALS.md
+++ b/modules/dasSQLITE/TUTORIALS.md
@@ -128,10 +128,12 @@ part re-uses the same [sql_table] from Part 1.
     subqueries — they need a multi-source emitter. Covers API_MISSING §22.
     **Shipped:** [tutorials/sql/12-distinct.das](../../tutorials/sql/12-distinct.das) (chunk 4).
 13. **Aggregates — `count` / `sum` / `average` / `min` / `max`** —
-    terminal aggregates on the whole source. `count` stands alone;
-    the four column-driven aggregates compose with `_select(_.Col)`
-    upstream. AVG promotes to `double`; SUM/MIN/MAX inherit the
-    column type. Covers API_MISSING §18.
+    scalar terminal aggregates on the whole source. `count` stands
+    alone; the four column-driven aggregates compose with
+    `_select(_.Col)` upstream. `_aggregate($(rows) => (...))` returns
+    several named global aggregates from one provider-neutral SELECT.
+    AVG promotes to `double`; SUM/MIN/MAX inherit the column type.
+    Covers API_MISSING §18.
     **Shipped:** [tutorials/sql/13-aggregates.das](../../tutorials/sql/13-aggregates.das) (chunk 4).
 14. **`_group_by` + `_having`** — aggregate per bucket, post-aggregate
     filter. Group rows surface as IGrouping-shaped tuples (`_._0` =
@@ -423,7 +425,7 @@ E. **Forward-looking: `dasSQL` abstraction layer** — the roadmap beyond
 | 10 | `_order_by` / `_order_by_descending` (+ tuple key) | `10-order_by.das` | **Shipped** (chunk 4); `_then_by` and per-column ASC/DESC mix deferred |
 | 11 | `take` / `skip` (LIMIT / OFFSET) | `11-take_skip.das` | **Shipped** (chunk 4); keyset pagination is a future concept tut |
 | 12 | `distinct` (set ops deferred) | `12-distinct.das` | **Shipped** (chunk 4); UNION/INTERSECT/EXCEPT punted to chunk 5 alongside joins/subqueries |
-| 13 | Aggregates — `count` / `sum` / `average` / `min` / `max` | `13-aggregates.das` | **Shipped** (chunk 4) |
+| 13 | Aggregates — scalar terminals + one-scan `_aggregate` summaries | `13-aggregates.das` | **Shipped** (chunk 4; `_aggregate` extension shipped later) |
 | 14 | `_group_by` + `_having` | `14-group_by.das` (`19-group_by.das.mockup` superseded — IGrouping shape, see API_REWORK §19) | **Shipped** (chunk 4) |
 | 15 | `_join` — inner equi-join | `23-joins.das` | Has mockup |
 | 16 | `_left_join` — outer | `23-joins.das` | Has mockup (shared) |

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -1775,8 +1775,8 @@ class private SqlFts5Macro : AstStructureAnnotation {
         let select_all_sql = build_fts5_select_all_sql(table_name, fields)
         let insert_sql = build_fts5_insert_sql(table_name, fields)
         let st_name = string(st.name)
-        let panic_msg_pk = "[sql_fts5] {st_name}: cannot {0} on an FTS5 virtual table — UPDATE/DELETE-by-PK is not supported in v1. Drop and re-INSERT, or use raw `db |> exec(\"DELETE FROM ... WHERE rowid = ?\", id)`."
-        let panic_msg_bind = "[sql_fts5] {st_name}: cannot {0} on an FTS5 virtual table — not supported in v1. Use raw `db |> exec(...)` for DELETE/UPDATE."
+        let panic_msg_pk = "[sql_fts5] {st_name}: cannot {0} on an FTS5 virtual table — row-shaped UPDATE/DELETE-by-PK is not supported. Use `_sql_delete(type<{st_name}>, predicate)` for typed predicate deletes; UPDATE still requires delete + re-INSERT or raw SQL."
+        let panic_msg_bind = "[sql_fts5] {st_name}: cannot {0} on an FTS5 virtual table — row-shaped mutation helpers are not supported. Use `_sql_delete(type<{st_name}>, predicate)` for typed predicate deletes; UPDATE still requires delete + re-INSERT or raw SQL."
         var fn_table_name = make_const_string_helper_fn(st, "_sql_table_name", table_name)
         compiling_module() |> add_function(fn_table_name)
         var fn_drop = make_const_string_helper_fn(st, "_sql_drop_table_if_exists_sql",
@@ -1801,7 +1801,8 @@ class private SqlFts5Macro : AstStructureAnnotation {
         compiling_module() |> add_function(fn_bind)
         var fn_col_info = make_fts5_column_info_fn(st, fields)
         compiling_module() |> add_function(fn_col_info)
-        // UPDATE/DELETE not supported in v1 — runtime panic stubs (compile error would be nicer but the macro expander generates the calls unconditionally for `[sql_table]`-shape APIs).
+        // Row-shaped UPDATE/DELETE-by-PK helpers are unsupported — runtime panic stubs
+        // (predicate `_sql_delete(type<T>, predicate)` uses table metadata directly and works).
         var fn_upd_pk = make_string_panic_stub_helper_fn(st, "_sql_update_by_pk_sql",
             panic_msg_pk |> replace("{0}", "update by primary key"))
         compiling_module() |> add_function(fn_upd_pk)

--- a/modules/dasSQLITE/daslib/sqlite_boost.das
+++ b/modules/dasSQLITE/daslib/sqlite_boost.das
@@ -1650,8 +1650,9 @@ let private FTS5_REJECTED_ANNOTATIONS = fixed_array(
         why = "FTS5 columns are tokenized text, not JSON. Drop the annotation or use a regular [sql_table]."),
     FtsRejectedAnnotation(name = "sql_blob", is_bool = true,
         why = "FTS5 columns are tokenized text, not BLOB. Drop the annotation or use a regular [sql_table]."))
-// Self-contained mode only: content fields must be string/Option<string>;
-// @sql_fts_rank is read-only and maps to FTS5's hidden `rank` on SELECT.
+// Self-contained mode only: indexed content fields must be string/Option<string>;
+// @sql_fts_unindexed stores typed metadata without tokenizing it; @sql_fts_rank is
+// read-only and maps to FTS5's hidden `rank` on SELECT.
 
 [structure_macro(name=sql_fts5)]
 class private SqlFts5Macro : AstStructureAnnotation {
@@ -1666,6 +1667,7 @@ class private SqlFts5Macro : AstStructureAnnotation {
             let fname = string(field.name)
             let is_optional = is_option_field_type(field._type)
             let is_fts_rank = find_annotation(field.annotation, "sql_fts_rank", false)
+            let is_fts_unindexed = find_annotation(field.annotation, "sql_fts_unindexed", false)
             // Reject every annotation that doesn't apply to a virtual table.
             for (rej in FTS5_REJECTED_ANNOTATIONS) {
                 var present = false
@@ -1701,6 +1703,10 @@ class private SqlFts5Macro : AstStructureAnnotation {
             }
             // @sql_fts_rank: read-only float column, reads FTS5's hidden `rank`. No daslang init allowed.
             if (is_fts_rank) {
+                if (is_fts_unindexed) {
+                    errors := "[sql_fts5]: field '{fname}' cannot be both @sql_fts_rank and @sql_fts_unindexed — rank is FTS5's hidden relevance column, not stored metadata."
+                    return false
+                }
                 col_name = "rank"   // FTS5 hidden column — not a declared content column
                 if (field.init != null) {
                     errors := "[sql_fts5]: field '{fname}' is @sql_fts_rank — read-only column populated from FTS5's hidden `rank` on SELECT. Remove the daslang field initializer."
@@ -1715,6 +1721,9 @@ class private SqlFts5Macro : AstStructureAnnotation {
                     return false
                 }
                 rank_count++
+            } elif (is_fts_unindexed) {
+                // Stored metadata: the ordinary sql_bind/sql_extract adapter rail provides
+                // its typed representation; FTS5's UNINDEXED suffix excludes it from MATCH.
             } else {
                 // Content column: string or Option<string>.
                 let bt = field._type.baseType
@@ -1738,12 +1747,13 @@ class private SqlFts5Macro : AstStructureAnnotation {
                 is_json = false,
                 is_blob = false,
                 is_fts_rank = is_fts_rank,
+                is_fts_unindexed = is_fts_unindexed,
                 computed_sql = "",
                 default_clause = "",
                 references_clause = ""))
         }
         if (content_count == 0) {
-            errors := "[sql_fts5] on struct '{st.name}': must declare at least one content column (`string` or `Option<string>`). A struct with only @sql_fts_rank fields has nothing to index."
+            errors := "[sql_fts5] on struct '{st.name}': must declare at least one indexed content column (`string` or `Option<string>`). A struct with only @sql_fts_unindexed metadata / @sql_fts_rank fields has nothing to index."
             return false
         }
         if (rank_count > 1) {
@@ -1830,6 +1840,9 @@ def private build_fts5_create_table_sql(table_name : string; fields : array<Fiel
             w |> write("\"")
             w |> write(info.col_name)
             w |> write("\"")
+            if (info.is_fts_unindexed) {
+                w |> write(" UNINDEXED")
+            }
             first = false
         }
     }

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -210,7 +210,7 @@ let cars <- _sql(db |> select_from(type<Car>)
 | **Distinct** | `distinct()` |
 | **Distinct-by** | `_distinct_by(_.K)` — one row per key: first in pk order; `reverse() \|> _distinct_by(_.K)` picks the last. Terminators: row-returning (`to_array` / `_first`, trailing `_order_by`/`take`/`skip` OK), `count()` (→ `COUNT(DISTINCT K)`), `_count(p)`, `_select(_.X) \|> sum/min/max/average()`. Provider-lowered via `caps.distinct_on`: `DISTINCT ON (K)` (PG, DuckDB) or SQLite's bare-aggregate `GROUP BY`. Requires a single `@sql_primary_key`; composing with `_where`/`_join`/`_group_by`/set ops is a compile error (v1) |
 | **Aggregate** | `count()`, `sum`, `average`, `min`, `max` (terminal) |
-| **Joins** | `_join(other, $(l, r) => l.X == r.Y, $(l, r) => projection)`, `_left_join(...)` (right side flows as `Option<TB>` through `into`) |
+| **Joins** | `_join(other, $(l, r) => l.X == r.Y, $(l, r) => projection)`, including exact whole-source results (`$(l, r) => r` returns `array<TRight>`); `_left_join(...)` flows the right side as `Option<TB>` through `into` |
 | **Subqueries** | `x._in(subq)`, `x._not_in(subq)`, `subq._any()`, `subq._any(p)`, `subq._none()`, `subq._none(p)` |
 | **Terminals** | `_to_array()` (default), `_first()` (panic on empty), `_first_opt()` (Option<T>) |
 | **String predicates** | `\|> starts_with(s)`, `\|> ends_with(s)`, `\|> contains(s)` (LIKE patterns); `\|> to_lower()`, `\|> to_upper()` (LOWER/UPPER); `length(s)` (LENGTH) |
@@ -225,7 +225,7 @@ let cars <- _sql(db |> select_from(type<Car>)
 Compile-time `macro_error` pointing at the offending node:
 
 - Unknown function calls in `_where` / `_select`
-- `_select` struct-type projection — a whole-struct project is a deferred follow-up; `_.Field`, named-tuple, and computed-scalar `_.A + _.B` projections are supported, including workhorse casts (`int64(_.A) * int64(_.B)` lowers to `CAST(...)`)
+- Single-source identity `_select($(x) => x)` remains unsupported (omit `_select` to return the full row). A join's `into` may return one non-nullable source struct directly (`$(l, r) => r`); `_.Field`, named-tuple, and computed-scalar `_.A + _.B` projections are also supported, including workhorse casts (`int64(_.A) * int64(_.B)` lowers to `CAST(...)`)
 - Multiple `_select` calls in one chain
 - Multiple terminals in one chain (`_to_array() |> _first()`)
 - `text_match` on a non-`[sql_fts5]` column (suggests `contains` or `[sql_fts5]`)

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -493,13 +493,15 @@ let foxes <- _sql(db |> select_from(type<Doc>)
                      |> _where(_.Body |> text_match("quick fox"))
                      |> _order_by(_.Rank))
 // SELECT "Body", rank FROM "docs_idx" WHERE "Body" MATCH ? ORDER BY rank
+
+let removed = db |> _sql_delete(type<Doc>, _.Body |> text_match("obsolete"))
 ```
 
 `text_match(col, query)` lowers to `col MATCH ?`. The same predicate is also a `daslib/strings_boost` (via `daslib/fts5_query`) in-memory matcher — one call site for both SQL and in-memory filtering. `text_match` on a non-`[sql_fts5]` column is a compile error pointing at `contains` (LIKE-based) or adding `[sql_fts5]`.
 
 Query-string syntax: whitespace-AND, `*` prefix (`quick*` matches `quicksand`), `"phrase match"` (quoted), Boolean `AND` / `OR` / `NOT` (uppercase), `NEAR(a b, N)` proximity. Default tokenizer is `unicode61` (Unicode word boundaries + ASCII case-fold).
 
-v1 limitations: self-contained mode only (FTS5 holds both content and index); UPDATE / DELETE on FTS5 rows aren't typed (drop and re-insert, or raw `exec`); BM25 weighting / snippet helpers / per-column query filters work via the FTS5 query string but lack typed wrappers.
+Limitations: self-contained mode only (FTS5 holds both content and index); row-shaped UPDATE / DELETE-by-PK helpers are unavailable because the virtual table has no declared daslang PK. Predicate DELETE is typed through `_sql_delete(type<T>, predicate)`; update by deleting and re-inserting, or use raw SQL. BM25 weighting / snippet helpers / per-column query filters work via the FTS5 query string but lack typed wrappers.
 
 ## User-defined SQL functions — `register_function` / `[sql_function]` (`caps.client_udfs`)
 

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -126,7 +126,7 @@ Field annotations:
 |---|---|
 | `@sql_primary_key` | INTEGER PRIMARY KEY (AUTOINCREMENT for `int`); rejected on `Option<T>` and `@sql_computed` |
 | `@sql_column = "..."` | Rename the on-disk column (escape hatch for daslang field names that clash with SQL keywords or the existing schema) |
-| `@sql_unique` | Single-column UNIQUE in the column DDL |
+| `@sql_unique` | Single-column UNIQUE via portable generated index `uq_<table>_<column>` |
 | `@sql_references = "Parent"` | Foreign key to another `[sql_table]` struct's primary key |
 | `@sql_on_delete` / `@sql_on_update` | One of `cascade` / `set_null` / `set_default` / `restrict` / `no_action`. Only valid with `@sql_references` |
 | `@sql_default_fn = "FN"` | Whitelisted SQL built-in (`CURRENT_TIMESTAMP` / `CURRENT_DATE` / `CURRENT_TIME`); emits ` DEFAULT FN` |
@@ -144,7 +144,7 @@ Sibling annotation `[sql_index(fields = ..., unique = ..., name = ...)]` lives i
 struct UserAcct { ... }
 ```
 
-`fields` is a single string or a tuple of strings. `unique` defaults to `false`. `name` defaults to `idx_<table>_<col1>_<col2>`. Multiple `[sql_index]` lines are stackable. Composite UNIQUE via `[sql_index(unique = true, fields = (...))]` is the prerequisite for `_sql_upsert` composite-conflict targets.
+`fields` is a single string or a tuple of strings. `unique` defaults to `false`. `name` defaults to `idx_<table>_<col1>_<col2>`. Multiple `[sql_index]` lines are stackable. `@sql_unique` uses the same provider-neutral index rail for the one-column case; `[sql_index]` adds explicit naming and composite keys. Composite UNIQUE via `[sql_index(unique = true, fields = (...))]` is the prerequisite for `_sql_upsert` composite-conflict targets.
 
 `db |> create_table(type<T>)` issues the CREATE TABLE + every `[sql_index]` DDL. `db |> drop_table_if_exists(type<T>)` is the idempotent teardown. `db |> check_schema(type<T>)` validates the open DB matches the struct on (name, type, NOT NULL, PRIMARY KEY) — recommended startup pattern for code that opens a DB it didn't just create.
 

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -313,9 +313,18 @@ db |> _sql_upsert(
     UserAcct(Id = 999, Email = "x@y.com", Name = "alice2", Tenant = "acme"),
     tuple(_.Email, _.Tenant),
     (Name = _excluded.Name))
+
+// Default integer PK is unset: omit it so the provider auto-assigns it.
+// Useful when conflict targets another UNIQUE column.
+let inserted <- db |> _sql_upsert_returning(
+    WordHit(Id = 0, Word = "new", Hits = 1, Last = 1234l),
+    _.Word,
+    (Hits = _.Hits + _excluded.Hits))
 ```
 
 Each macro has the four-way fan-out: `_sql_update` / `_sql_try_update` / `_sql_update_returning` / `_sql_try_update_returning`, parallel for `_sql_delete` and `_sql_upsert`.
+
+For `_sql_upsert`, a default-valued integer `@sql_primary_key` is treated as unset just like `insert`: the macro omits that column so SQLite can assign rowid, DuckDB can draw from its sequence, and PostgreSQL can use its identity column. Explicit non-default primary keys remain in the INSERT. This applies to strict/`try_` and returning/non-returning variants.
 
 The `_sql_` prefix is deliberate — it carries SQL provenance to the call site and avoids name collisions with hypothetical future non-SQL `_update` / `_delete` macros. Function siblings stay unprefixed (`update` / `delete_` / `delete_by_id`).
 

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -22,7 +22,7 @@ Capability gates are **compile-time** `macro_error`s naming the provider (`caps`
 
 ```das
 require sqlite/sqlite_boost         // provider: SqlRunner, exec/query runtime, [sql_fts5], [sql_function]
-require daslib/sql_linq             // _sql / _try_sql / _each_sql / _sql_update / _sql_delete / _sql_upsert / _create_view / _sql_text
+require daslib/sql_linq             // _sql / _try_sql / _each_sql / _aggregate / _sql_update / _sql_delete / _sql_upsert / _create_view / _sql_text
 require daslib/linq_das             // OPTIONAL: `%linq! from row : T in db ... %%`; lowers through the same SQL analyzer
 require sqlite/sqlite_migrate       // OPTIONAL — [sql_migration], migrate_to_latest, with_latest_sqlite, baseline
 ```
@@ -209,7 +209,7 @@ let cars <- _sql(db |> select_from(type<Car>)
 | **Page** | `take(n)`, `skip(m)` — canonical fast form is `skip(m) \|> take(n)`. `take`/`skip` BEFORE an aggregate (`take(n) \|> count()`, `_select(_.X) \|> take(n) \|> sum()`) wraps the bounded rows into an inner subquery so the LIMIT applies pre-aggregate |
 | **Distinct** | `distinct()` |
 | **Distinct-by** | `_distinct_by(_.K)` — one row per key: first in pk order; `reverse() \|> _distinct_by(_.K)` picks the last. Terminators: row-returning (`to_array` / `_first`, trailing `_order_by`/`take`/`skip` OK), `count()` (→ `COUNT(DISTINCT K)`), `_count(p)`, `_select(_.X) \|> sum/min/max/average()`. Provider-lowered via `caps.distinct_on`: `DISTINCT ON (K)` (PG, DuckDB) or SQLite's bare-aggregate `GROUP BY`. Requires a single `@sql_primary_key`; composing with `_where`/`_join`/`_group_by`/set ops is a compile error (v1) |
-| **Aggregate** | `count()`, `sum`, `average`, `min`, `max` (terminal) |
+| **Aggregate** | Scalar terminals: `count()`, `sum`, `average`, `min`, `max`. One-row summary: `_aggregate($(rows) => (N = rows \|> count, Total = rows \|> _select(_.X) \|> sum, ...))` lowers all named slots into one SELECT |
 | **Joins** | `_join(other, $(l, r) => l.X == r.Y, $(l, r) => projection)`, including exact whole-source results (`$(l, r) => r` returns `array<TRight>`); `_left_join(...)` flows the right side as `Option<TB>` through `into` |
 | **Subqueries** | `x._in(subq)`, `x._not_in(subq)`, `subq._any()`, `subq._any(p)`, `subq._none()`, `subq._none(p)` |
 | **Terminals** | `_to_array()` (default), `_first()` (panic on empty), `_first_opt()` (Option<T>) |
@@ -243,6 +243,28 @@ to_log(LOG_INFO, "SQL: {_sql_text(db |> select_from(type<Car>) |> _where(_.Price
 ```
 
 `options log` on the file dumps the post-macro daslang code — useful for seeing the runtime helper call the analyzer emits.
+
+### Several global aggregates in one scan
+
+Use `_aggregate` when one answer needs several facts about the same
+filtered source:
+
+```das
+let stats = _sql(
+    db |> select_from(type<Order>)
+       |> _where(_.State == wanted)
+       |> _aggregate($(rows) => (
+            N = rows |> count,
+            Total = rows |> _select(_.Amount) |> sum,
+            First = rows |> _select(_.CreatedAt) |> min,
+            Last = rows |> _select(_.CreatedAt) |> max)))
+```
+
+The result is a typed named tuple and the provider executes one query
+with one result row. The same expression works on an in-memory array.
+V1 accepts filtered table or join sources and field selectors; it
+compile-errors on pre-projection, grouping, distinct/set operations,
+ordering, or paging until explicit subquery composition exists.
 
 ### Composability
 

--- a/skills/sql.md
+++ b/skills/sql.md
@@ -482,20 +482,23 @@ For window functions, recursive CTEs, custom helpers the chain doesn't translate
 ```das
 [sql_fts5(name = "docs_idx")]
 struct Doc {
+    @sql_fts_unindexed Id : int64  // stored/filterable metadata, excluded from MATCH
     Body : string
     @sql_fts_rank Rank : float       // FTS5 fills on SELECT (BM25); INSERT skips
 }
 
 db |> create_table(type<Doc>)                    // CREATE VIRTUAL TABLE … USING fts5(...)
-db |> insert(Doc(Body = "The quick brown fox jumps"))
+db |> insert(Doc(Id = 42l, Body = "The quick brown fox jumps"))
 
 let foxes <- _sql(db |> select_from(type<Doc>)
-                     |> _where(_.Body |> text_match("quick fox"))
+                     |> _where(_.Id == 42l && (_.Body |> text_match("quick fox")))
                      |> _order_by(_.Rank))
-// SELECT "Body", rank FROM "docs_idx" WHERE "Body" MATCH ? ORDER BY rank
+// SELECT "Id", "Body", rank FROM "docs_idx" WHERE "Id" = ? AND "Body" MATCH ? ORDER BY rank
 
 let removed = db |> _sql_delete(type<Doc>, _.Body |> text_match("obsolete"))
 ```
+
+`@sql_fts_unindexed` emits FTS5's `UNINDEXED` column suffix. Use it for typed IDs, timestamps, kinds, or tenant/chat metadata that must round-trip with hits and participate in ordinary comparisons without being tokenized. The normal `sql_bind` / `sql_extract` adapter rail supplies its storage type. `text_match` on an unindexed field is a compile error.
 
 `text_match(col, query)` lowers to `col MATCH ?`. The same predicate is also a `daslib/strings_boost` (via `daslib/fts5_query`) in-memory matcher — one call site for both SQL and in-memory filtering. `text_match` on a non-`[sql_fts5]` column is a compile error pointing at `contains` (LIKE-based) or adding `[sql_fts5]`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -260,13 +260,14 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_91_sql_vacuum_into_macro.das | `_sql_vacuum_into(path)` macro form (vacuum into file path, runtime string path, verification across reopen) | |
 | test_92_order_by_runtime.das | Runtime `_order_by(string)` column-name binding (const string folds to compile-time, runtime path uses sql_quote_id) | |
 | test_93_attach.das | `with_attached(path, alias)` attach secondary database file (query across attached, temp-file cleanup) | |
-| test_94_fts5.das | `[sql_fts5]` full-text search (CREATE VIRTUAL TABLE fts5, `@sql_fts_rank` hidden rank column, INSERT skips rank, typed predicate DELETE) | |
+| test_94_fts5.das | `[sql_fts5]` full-text search (`@sql_fts_unindexed` typed metadata, `@sql_fts_rank`, MATCH, INSERT, typed predicate DELETE) | |
 | failed_create_view.das | `_create_view` macro validation failures (column count/type mismatches, non-annotated struct, bound parameters) | **expect** `40104:7` |
 | failed_each_sql_terminals.das | `_each_sql` rejects materializing terminals (`_to_array`, `_first`, `_first_opt`, aggregates) | **expect** `40104:4` |
 | failed_pred_json_path_typo.das | Predicate-side JSON-path validation (typo detection in `_.Field.nested` chains) | **expect** `40104:3, 30503:3` |
 | failed_register_function.das | `register_function` compile-time type validation (struct args, struct returns, pointers, non-function references) | **expect** `40104:5` |
 | failed_sql_column.das | `@sql_column` annotation validation (empty value, embedded quotes/backslashes, cross-field collisions) | **expect** `30111:5` |
-| failed_sql_fts5.das | `[sql_fts5]` field-annotation rejections (`@sql_column` on `@sql_fts_rank`) | **expect** `30111:1` |
+| failed_sql_fts5.das | `[sql_fts5]` field-annotation rejections (`@sql_column` / `@sql_fts_unindexed` on rank) | **expect** `20800:2` |
+| failed_sql_fts5_unindexed_match.das | `_sql` rejects `text_match` on `@sql_fts_unindexed` metadata | **expect** `50503:1` |
 | failed_sql_index.das | `[sql_index]` validation (missing fields, nonexistent columns, ordering with `[sql_table]`) | **expect** `30111:4` |
 | failed_sql_json_blob_kind_collision.das | Payload type kind collision rejection (same type in `@sql_json` vs `@sql_blob`) | **expect** `30111:3` |
 | failed_sql_macro.das | `_sql` / `_sql_text` analyzer failures (22 malformed chains: invalid roots, duplicate modifiers, unsupported expressions) | **expect** `40104:22, 30304:2, 30503:2` |

--- a/tests/README.md
+++ b/tests/README.md
@@ -268,6 +268,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | failed_sql_column.das | `@sql_column` annotation validation (empty value, embedded quotes/backslashes, cross-field collisions) | **expect** `30111:5` |
 | failed_sql_fts5.das | `[sql_fts5]` field-annotation rejections (`@sql_column` / `@sql_fts_unindexed` on rank) | **expect** `20800:2` |
 | failed_sql_fts5_unindexed_match.das | `_sql` rejects `text_match` on `@sql_fts_unindexed` metadata | **expect** `50503:1` |
+| failed_sql_global_aggregate.das | `_aggregate` rejects unnamed/non-aggregate results and unsupported pre-projection/distinct/grouped/ordered/paged source shapes | **expect** `50503:9` |
 | failed_sql_index.das | `[sql_index]` validation (missing fields, nonexistent columns, ordering with `[sql_table]`) | **expect** `30111:4` |
 | failed_sql_json_blob_kind_collision.das | Payload type kind collision rejection (same type in `@sql_json` vs `@sql_blob`) | **expect** `30111:3` |
 | failed_sql_macro.das | `_sql` / `_sql_text` analyzer failures (22 malformed chains: invalid roots, duplicate modifiers, unsupported expressions) | **expect** `40104:22, 30304:2, 30503:2` |
@@ -1023,8 +1024,8 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | _conformance_provider.das | *(shim)* Provider under test — `with_conf_db` scoped runner + `CONF_HAS_*` capability constants | |
 | test_conf_table_crud.das | `[sql_table]` DDL round-trip, check_schema, column_info, insert single+bulk, update / delete_ / delete_by_id | |
 | test_conf_sql_select.das | `_sql` reads — _where + captured binds, _order_by, take/skip, distinct, _first/_first_opt, _sql_text shape | |
-| test_conf_projection_agg.das | _select forms (column / named-tuple / computed), aggregates, _group_by + _having | |
-| test_conf_joins_subq.das | _join, _left_join (Option right side), _in / _not_in, _any / _none | |
+| test_conf_projection_agg.das | _select forms (column / named-tuple / computed), scalar aggregates, one-scan `_aggregate`, _group_by + _having | |
+| test_conf_joins_subq.das | _join (including exact whole-source projections and `_aggregate`), _left_join (Option right side), _in / _not_in, _any / _none | |
 | test_conf_nullability.das | Option<T> columns — DDL nullability, some/none round-trip, is_some / is_none / unwrap_or | |
 | test_conf_adapters.das | sql_bind / sql_extract rail — custom type, enum, Option-over-custom, @sql_json + path descent | |
 | test_conf_dml_macros.das | _sql_update / _sql_delete / _sql_upsert + returning variants (capability-checked) | |

--- a/tests/README.md
+++ b/tests/README.md
@@ -260,7 +260,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_91_sql_vacuum_into_macro.das | `_sql_vacuum_into(path)` macro form (vacuum into file path, runtime string path, verification across reopen) | |
 | test_92_order_by_runtime.das | Runtime `_order_by(string)` column-name binding (const string folds to compile-time, runtime path uses sql_quote_id) | |
 | test_93_attach.das | `with_attached(path, alias)` attach secondary database file (query across attached, temp-file cleanup) | |
-| test_94_fts5.das | `[sql_fts5]` full-text search (CREATE VIRTUAL TABLE fts5, `@sql_fts_rank` hidden rank column, INSERT skips rank) | |
+| test_94_fts5.das | `[sql_fts5]` full-text search (CREATE VIRTUAL TABLE fts5, `@sql_fts_rank` hidden rank column, INSERT skips rank, typed predicate DELETE) | |
 | failed_create_view.das | `_create_view` macro validation failures (column count/type mismatches, non-annotated struct, bound parameters) | **expect** `40104:7` |
 | failed_each_sql_terminals.das | `_each_sql` rejects materializing terminals (`_to_array`, `_first`, `_first_opt`, aggregates) | **expect** `40104:4` |
 | failed_pred_json_path_typo.das | Predicate-side JSON-path validation (typo detection in `_.Field.nested` chains) | **expect** `40104:3, 30503:3` |

--- a/tests/README.md
+++ b/tests/README.md
@@ -232,7 +232,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_54_upsert_single_col.das | `_sql_upsert(row, _.Col, set_dict)` single-column ON CONFLICT key (insert vs merge branch, _excluded reference) | |
 | test_55_upsert_composite.das | `_sql_upsert` multi-column composite conflict keys via tuple `(_.Email, _.Tenant)` | |
 | test_56_upsert_returning.das | `_sql_upsert_returning` UPSERT ... RETURNING (post-merge row on conflict, fresh row on insert) | |
-| test_57_sql_unique.das | `@sql_unique` column annotation (DDL emission, constraint enforcement, distinct values allowed) | |
+| test_57_sql_unique.das | `@sql_unique` portable generated-index emission, named-table rewrite, constraint enforcement, distinct values allowed | |
 | test_58_sql_references.das | `@sql_references` / `@sql_on_delete` foreign-key relationships (DDL REFERENCES clause, CASCADE delete semantics) | |
 | test_59_sql_index.das | `[sql_index]` DDL emission (single-col, composite, unique indexes with auto-naming) | |
 | test_60_defaults_computed.das | Defaults (native field init → DEFAULT, `@sql_default_fn` built-ins) and computed columns (`@sql_computed` VIRTUAL/STORED) | |
@@ -271,7 +271,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | failed_sql_json_blob_kind_collision.das | Payload type kind collision rejection (same type in `@sql_json` vs `@sql_blob`) | **expect** `30111:3` |
 | failed_sql_macro.das | `_sql` / `_sql_text` analyzer failures (22 malformed chains: invalid roots, duplicate modifiers, unsupported expressions) | **expect** `40104:22, 30304:2, 30503:2` |
 | failed_sql_pragma_vacuum.das | `_sql_pragma` / `_sql_vacuum_into` argument-shape validation (wrong types, arg counts) | **expect** `40104:5` |
-| failed_sql_table_schema.das | `[sql_table]` schema-validation failures (computed+PK collision, defaults+initializers, FK actions, reference resolution) | **expect** `30111:12` |
+| failed_sql_table_schema.das | `[sql_table]` schema-validation failures (computed+PK/UNIQUE collisions, defaults+initializers, FK actions, reference resolution) | **expect** `20800:13` |
 | failed_sql_update_delete.das | `_sql_update` / `_sql_delete` analyzer failures (wrong arity, non-type args, typos, duplicate columns) | **expect** `40104:7` |
 | failed_sql_upsert.das | `_sql_upsert` analyzer failures (wrong arity, on_conflict/do_update validation, duplicate columns) | **expect** `40104:10` |
 | failed_sql_view_mutations.das | `_sql_update` / `_sql_delete` / `_sql_upsert` against `[sql_view]` types (read-only rejection) | **expect** `40104:8` |

--- a/tests/dasSQLITE/failed_sql_fts5.das
+++ b/tests/dasSQLITE/failed_sql_fts5.das
@@ -1,11 +1,12 @@
 options gen2
 
 // `[sql_fts5]` field-annotation rejections. Each struct below trips one
-// validation path in the FTS5 macro:
+// validation paths in the FTS5 structure macro:
 //   1. @sql_column on @sql_fts_rank — rank is hardcoded to FTS5's hidden id.
+//   2. @sql_fts_rank combined with @sql_fts_unindexed.
 //
-// All fail with 30111 ("macro [sql_fts5] failed to apply").
-expect 20800
+// Both use 20800 ("macro [sql_fts5] failed to apply").
+expect 20800:2
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -15,5 +16,13 @@ struct F1 {
     Body : string
     @sql_fts_rank
     @sql_column = "score"        //!< @sql_column on @sql_fts_rank is rejected
+    Rank : float
+}
+
+[sql_fts5(name = "F2_idx")]
+struct F2 {
+    Body : string
+    @sql_fts_rank
+    @sql_fts_unindexed
     Rank : float
 }

--- a/tests/dasSQLITE/failed_sql_fts5_unindexed_match.das
+++ b/tests/dasSQLITE/failed_sql_fts5_unindexed_match.das
@@ -1,0 +1,22 @@
+options gen2
+
+// UNINDEXED metadata is stored and filterable, but cannot be a MATCH target.
+expect 50503
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/sql_linq
+require daslib/fts5_query
+
+[sql_fts5(name = "docs_idx")]
+struct Doc {
+    @sql_fts_unindexed Kind : string
+    Body : string
+}
+
+[export]
+def main() {
+    var db = SqlRunner()
+    let invalid = _sql(db |> select_from(type<Doc>)
+                          |> _where(_.Kind |> text_match("metadata")))
+}

--- a/tests/dasSQLITE/failed_sql_global_aggregate.das
+++ b/tests/dasSQLITE/failed_sql_global_aggregate.das
@@ -1,0 +1,55 @@
+options gen2
+
+expect 50503:9
+
+require daslib/sql
+require sqlite/sqlite_boost
+require daslib/sql_linq
+
+[sql_table(name = "GlobalAggregateRows")]
+struct GlobalAggregateRow {
+    @sql_primary_key Id : int
+    Amount : int
+}
+
+[export]
+def main() {
+    var db = SqlRunner()
+
+    // Result must be a named tuple.
+    let bad1 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _aggregate($(_rows) => _rows |> count))
+    let bad2 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _aggregate($(_rows) => (
+            _rows |> count,
+            _rows |> _select(_.Amount) |> sum)))
+
+    // Every tuple slot must be an aggregate over the block's rowset.
+    let bad3 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _aggregate($(_rows) => (N = 1)))
+
+    var captured = GlobalAggregateRow(Id = 0, Amount = 10)
+    let bad4 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _aggregate($(_rows) => (
+            Total = _rows
+                |> _select($(row : GlobalAggregateRow) => captured.Amount)
+                |> sum)))
+
+    // V1 aggregates the filtered source directly; pre-projection and DISTINCT
+    // need a separate inner-query composition rail.
+    let bad5 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _select(_.Amount)
+        |> _aggregate($(_rows) => (N = _rows |> count)))
+    let bad6 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> distinct()
+        |> _aggregate($(_rows) => (N = _rows |> count)))
+    let bad7 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _group_by(_.Amount)
+        |> _aggregate($(_rows) => (N = _rows |> count)))
+    let bad8 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> _order_by(_.Amount)
+        |> _aggregate($(_rows) => (N = _rows |> count)))
+    let bad9 = _sql(db |> select_from(type<GlobalAggregateRow>)
+        |> take(10)
+        |> _aggregate($(_rows) => (N = _rows |> count)))
+}

--- a/tests/dasSQLITE/failed_sql_join_identity_select.das
+++ b/tests/dasSQLITE/failed_sql_join_identity_select.das
@@ -1,9 +1,10 @@
 options gen2
 
-// Regression: an identity / whole-row `_select($(x) => x)` over a SQL `_join` previously crashed the
-// `_sql` analyzer (SIGSEGV — `pred_to_sql` dereferenced a null rendering the bare-variable row). It must
-// instead be a clean macro_error (50503): a whole-row select has no SQL column form. One reject (the
-// trailing cascade from the now-untyped result is expected).
+// Regression: an identity `_select($(x) => x)` over a scalar SQL join projection previously crashed the
+// `_sql` analyzer (SIGSEGV — `pred_to_sql` dereferenced a null rendering the bare variable). It must
+// instead be a clean macro_error (50503). A join's `into` may now return one source struct directly,
+// but a later scalar/tuple identity projection still has no SQL row shape. One reject (the trailing
+// cascade from the now-untyped result is expected).
 expect 50503
 
 require daslib/sql

--- a/tests/dasSQLITE/failed_sql_macro.das
+++ b/tests/dasSQLITE/failed_sql_macro.das
@@ -6,7 +6,7 @@ options gen2
 // some malformed chains additionally cascade real type errors before the
 // analyzer ever runs — e.g. `_select(_.Name) |> _select(_.Price)` is a
 // genuine type bug (string has no `Price` field). Those cascades are expected.
-expect 30341, 30928:2, 50503:24
+expect 30341, 30928:2, 50503:23
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -92,20 +92,6 @@ def main() {
                         |> _join(db |> select_from(type<Owner>),
                                  $(c : Car, o : Owner) => c.Id == o.CarId && c.Name == o.Name,
                                  $(c : Car, o : Owner) => (Name = c.Name, Owner = o.Name)))
-
-    // 16. Two joins in one chain (3+ table). Chunk 5 ships single-join
-    //     only — the `q.joins` slot is one-deep. The second `_join`'s
-    //     `on` must be a valid single-column equi-join (`==`), or
-    //     linq_boost rejects it before sql_linq's multi-join guard
-    //     fires; here we equi-join on `.Name` (cosmetically meaningless
-    //     but well-formed) so the diagnostic comes from sql_linq.
-    let bad16 <- _sql(db |> select_from(type<Car>)
-                        |> _join(db |> select_from(type<Owner>),
-                                 $(c : Car, o : Owner) => c.Id == o.CarId,
-                                 $(c : Car, o : Owner) => o)
-                        |> _join(db |> select_from(type<Owner>),
-                                 $(t : Owner, o : Owner) => t.Id == o.Id,
-                                 $(t : Owner, o : Owner) => o))
 
     // 17. Set-op nested inside a set-op — chunk 5 restricts to one set-op
     //     per chain (chained set-ops would need parenthesization

--- a/tests/dasSQLITE/failed_sql_table_schema.das
+++ b/tests/dasSQLITE/failed_sql_table_schema.das
@@ -5,7 +5,7 @@ options gen2
 // failure produces error 30111 = "macro [sql_table] failed to apply to the
 // structure". Validation is fail-fast (first error aborts that struct's
 // apply()) so each struct contributes exactly one error.
-expect 20800:12
+expect 20800:13
 
 require daslib/sql
 require sqlite/sqlite_boost
@@ -138,6 +138,16 @@ struct C12 {
     @sql_primary_key Id : int
     @sql_references = "C12NoPk"
     ParentId : int
+}
+
+// 13. @sql_unique on a generated column — use an explicit [sql_index] only
+//     when the target provider supports indexing that expression.
+[sql_table(name = "C13")]
+struct C13 {
+    @sql_primary_key Id : int
+    @sql_unique
+    @sql_computed = "Id * 2"
+    DoubleId : int
 }
 
 [export]

--- a/tests/dasSQLITE/test_57_sql_unique.das
+++ b/tests/dasSQLITE/test_57_sql_unique.das
@@ -18,14 +18,19 @@ def private fixture(db : SqlRunner) {
 }
 
 [test]
-def test_unique_emitted_in_ddl(t : T?) {
-    let ddl = _sql_create_table_sql(type<User>)
-    t |> success(ddl |> ends_with("\"Email\" TEXT NOT NULL UNIQUE, \"Name\" TEXT NOT NULL)"),
-                 "@sql_unique appends UNIQUE to the column declaration")
+def test_unique_emitted_as_portable_index(t : T?) {
+    let table_ddl = _sql_create_table_sql(type<User>)
+    t |> success(table_ddl |> find("\"Email\" TEXT NOT NULL UNIQUE") < 0,
+        "@sql_unique is emitted through the provider-neutral index helper")
+    t |> equal(_sql_create_indexes_sql(type<User>),
+        "CREATE UNIQUE INDEX \"uq_Users_Email\" ON \"Users\" (\"Email\")")
+    t |> equal(_::_sql_create_indexes_sql(default<User>, "UsersNext"),
+        "CREATE UNIQUE INDEX \"uq_UsersNext_Email\" ON \"UsersNext\" (\"Email\")",
+        "named-table helper rewrites both the table and generated index name")
 }
 
 [test]
-def test_unique_constraint_rejects_duplicate(t : T?) {
+def test_unique_index_rejects_duplicate(t : T?) {
     with_sqlite(":memory:") $(db) {
         fixture(db)
         let r = db |> try_insert(User(Id = 2, Email = "a@x.com", Name = "anne"))

--- a/tests/dasSQLITE/test_70_sql_column_upsert.das
+++ b/tests/dasSQLITE/test_70_sql_column_upsert.das
@@ -25,10 +25,13 @@ struct Counter {
 [test]
 def test_create_table_uses_renamed_unique_column(t : T?) {
     let ddl = _::_sql_create_table_sql(type<Counter>)
-    t |> success(ddl |> find("\"for\" TEXT NOT NULL UNIQUE") >= 0,
-        "renamed UNIQUE column shows up as 'for' in DDL")
+    t |> success(ddl |> find("\"for\" TEXT NOT NULL") >= 0,
+        "renamed column shows up as 'for' in table DDL")
     t |> success(ddl |> find("\"col_for\"") < 0,
         "daslang field 'col_for' must NOT appear in DDL")
+    t |> equal(_::_sql_create_indexes_sql(type<Counter>),
+        "CREATE UNIQUE INDEX \"uq_Counters_for\" ON \"Counters\" (\"for\")",
+        "@sql_unique uses the renamed SQL column in its portable index")
 }
 
 [test]

--- a/tests/dasSQLITE/test_94_fts5.das
+++ b/tests/dasSQLITE/test_94_fts5.das
@@ -12,6 +12,14 @@ struct Doc {
     @sql_fts_rank Rank : float
 }
 
+[sql_fts5(name="messages_idx")]
+struct MessageDoc {
+    @sql_fts_unindexed ChatId : int64
+    @sql_fts_unindexed TelegramMessageId : int64
+    Body : string
+    @sql_fts_rank Rank : float
+}
+
 [test]
 def test_fts5_emits_create_virtual_table(t : T?) {
     t |> equal(_::_sql_create_table_sql(type<Doc>),
@@ -96,6 +104,25 @@ def test_fts5_runtime_phrase_match(t : T?) {
         let hits <- _sql(db |> select_from(type<Doc>)
                            |> _where(_.Body |> text_match("\"quick brown\"")))
         t |> equal(length(hits), 1, "phrase match only finds adjacent tokens in order")
+    }
+}
+
+[test]
+def test_fts5_unindexed_metadata_emits_ddl_and_round_trips(t : T?) {
+    t |> equal(_::_sql_create_table_sql(type<MessageDoc>),
+        "CREATE VIRTUAL TABLE IF NOT EXISTS \"messages_idx\" USING fts5(\"ChatId\" UNINDEXED, \"TelegramMessageId\" UNINDEXED, \"Body\", tokenize='unicode61')",
+        "@sql_fts_unindexed stores metadata without adding it to the inverted index")
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<MessageDoc>)
+        db |> insert(MessageDoc(ChatId = 42l, TelegramMessageId = 1001l, Body = "first fox note"))
+        db |> insert(MessageDoc(ChatId = 7l, TelegramMessageId = 1002l, Body = "second fox note"))
+
+        let hits <- _sql(db |> select_from(type<MessageDoc>)
+                           |> _where(_.ChatId == 42l && (_.Body |> text_match("fox"))))
+        t |> equal(length(hits), 1)
+        t |> equal(hits[0].ChatId, 42l)
+        t |> equal(hits[0].TelegramMessageId, 1001l)
+        t |> equal(hits[0].Body, "first fox note")
     }
 }
 

--- a/tests/dasSQLITE/test_94_fts5.das
+++ b/tests/dasSQLITE/test_94_fts5.das
@@ -98,3 +98,20 @@ def test_fts5_runtime_phrase_match(t : T?) {
         t |> equal(length(hits), 1, "phrase match only finds adjacent tokens in order")
     }
 }
+
+[test]
+def test_fts5_runtime_typed_predicate_delete(t : T?) {
+    with_sqlite(":memory:") $(db) {
+        db |> create_table(type<Doc>)
+        db |> insert(Doc(Body = "obsolete fox note"))
+        db |> insert(Doc(Body = "obsolete turtle note"))
+        db |> insert(Doc(Body = "current fox note"))
+
+        let removed = db |> _sql_delete(type<Doc>, _.Body |> text_match("obsolete"))
+        t |> equal(removed, 2, "_sql_delete removes every matching FTS5 row")
+
+        let remaining <- _sql(db |> select_from(type<Doc>))
+        t |> equal(length(remaining), 1)
+        t |> equal(remaining[0].Body, "current fox note")
+    }
+}

--- a/tests/sql_conformance/README.md
+++ b/tests/sql_conformance/README.md
@@ -29,8 +29,8 @@ rewrites only the shim:
 |---|---|
 | `test_conf_table_crud.das` | `[sql_table]` DDL round-trip, check_schema, column_info, insert single+bulk, update/delete_/delete_by_id |
 | `test_conf_sql_select.das` | `_sql` reads: _where + captured binds, _order_by, take/skip, distinct, _first/_first_opt, _sql_text shape |
-| `test_conf_projection_agg.das` | _select forms (column / named-tuple / computed), aggregates, _group_by + _having |
-| `test_conf_joins_subq.das` | _join (named/scalar and exact whole-source projections), _left_join (Option right side), _in/_not_in, _any/_none |
+| `test_conf_projection_agg.das` | _select forms (column / named-tuple / computed), scalar aggregates, one-scan `_aggregate`, _group_by + _having |
+| `test_conf_joins_subq.das` | _join (named/scalar and exact whole-source projections), `_aggregate` over whole-source joins, _left_join (Option right side), _in/_not_in, _any/_none |
 | `test_conf_nullability.das` | Option<T> columns, is_some/is_none/unwrap_or translations |
 | `test_conf_adapters.das` | sql_bind/sql_extract rail: custom type, enum, Option-over-custom, @sql_json (+path descent) |
 | `test_conf_dml_macros.das` | _sql_update/_sql_delete/_sql_upsert (+ returning, capability-checked) |

--- a/tests/sql_conformance/README.md
+++ b/tests/sql_conformance/README.md
@@ -30,7 +30,7 @@ rewrites only the shim:
 | `test_conf_table_crud.das` | `[sql_table]` DDL round-trip, check_schema, column_info, insert single+bulk, update/delete_/delete_by_id |
 | `test_conf_sql_select.das` | `_sql` reads: _where + captured binds, _order_by, take/skip, distinct, _first/_first_opt, _sql_text shape |
 | `test_conf_projection_agg.das` | _select forms (column / named-tuple / computed), aggregates, _group_by + _having |
-| `test_conf_joins_subq.das` | _join, _left_join (Option right side), _in/_not_in, _any/_none |
+| `test_conf_joins_subq.das` | _join (named/scalar and exact whole-source projections), _left_join (Option right side), _in/_not_in, _any/_none |
 | `test_conf_nullability.das` | Option<T> columns, is_some/is_none/unwrap_or translations |
 | `test_conf_adapters.das` | sql_bind/sql_extract rail: custom type, enum, Option-over-custom, @sql_json (+path descent) |
 | `test_conf_dml_macros.das` | _sql_update/_sql_delete/_sql_upsert (+ returning, capability-checked) |

--- a/tests/sql_conformance/test_conf_dml_macros.das
+++ b/tests/sql_conformance/test_conf_dml_macros.das
@@ -9,7 +9,8 @@ options no_unused_function_arguments = false
 require dastest/testing_boost public
 require _conformance_provider
 
-[sql_table(name = "ConfHits")]
+[sql_table(name = "ConfHits"),
+ sql_index(fields = "Word", unique = true)]
 struct ConfHit {
     @sql_primary_key Id : int
     Word : string
@@ -77,6 +78,36 @@ def test_conf_sql_upsert(t : T?) {
             t |> equal(_sql(db |> select_from(type<ConfHit>) |> count()), 4)
         }
     }
+    t |> run("unset integer primary key is auto-assigned") @(t : T?) {
+        with_conf_db() $(db) {
+            db |> create_table(type<ConfHit>)
+            db |> _sql_upsert(
+                ConfHit(Id = 0, Word = "first", Hits = 1, Active = true),
+                _.Word,
+                (Hits = _excluded.Hits))
+            db |> _sql_upsert(
+                ConfHit(Id = 0, Word = "second", Hits = 2, Active = true),
+                _.Word,
+                (Hits = _excluded.Hits))
+            db |> _sql_upsert(
+                ConfHit(Id = 0, Word = "first", Hits = 7, Active = true),
+                _.Word,
+                (Hits = _excluded.Hits))
+            let tried = db |> _sql_try_upsert(
+                ConfHit(Id = 0, Word = "third", Hits = 3, Active = true),
+                _.Word,
+                (Hits = _excluded.Hits))
+            t |> success(tried |> is_ok)
+            t |> equal(tried |> unwrap, 1)
+            let rows <- _sql(db |> select_from(type<ConfHit>) |> _order_by(_.Id))
+            t |> equal(length(rows), 3)
+            t |> success(rows[0].Id != 0 && rows[1].Id != 0 && rows[2].Id != 0)
+            t |> success(rows[0].Id != rows[1].Id && rows[1].Id != rows[2].Id)
+            t |> equal(rows[0].Hits, 7)
+            t |> equal(rows[1].Hits, 2)
+            t |> equal(rows[2].Hits, 3)
+        }
+    }
 }
 
 [test]
@@ -100,6 +131,26 @@ def test_conf_returning(t : T?) {
             let gone <- db |> _sql_delete_returning(type<ConfHit>, _.Hits >= 5)
             t |> equal(length(gone), 1)
             t |> equal(gone[0].Word, "world")
+        }
+    }
+    t |> run("upsert returning auto-assigns an unset integer primary key") @(t : T?) {
+        with_conf_db() $(db) {
+            db |> create_table(type<ConfHit>)
+            let inserted <- db |> _sql_upsert_returning(
+                ConfHit(Id = 0, Word = "returning", Hits = 4, Active = true),
+                _.Word,
+                (Hits = _excluded.Hits))
+            t |> equal(length(inserted), 1)
+            t |> success(inserted[0].Id != 0)
+            let tried <- db |> _sql_try_upsert_returning(
+                ConfHit(Id = 0, Word = "try-returning", Hits = 5, Active = true),
+                _.Word,
+                (Hits = _excluded.Hits))
+            t |> success(tried |> is_ok)
+            let tried_rows <- tried |> unwrap
+            t |> equal(length(tried_rows), 1)
+            t |> success(tried_rows[0].Id != 0)
+            t |> success(tried_rows[0].Id != inserted[0].Id)
         }
     }
 }

--- a/tests/sql_conformance/test_conf_joins_subq.das
+++ b/tests/sql_conformance/test_conf_joins_subq.das
@@ -19,6 +19,7 @@ struct ConfCust {
 struct ConfOrder {
     @sql_primary_key Id : int
     CustId : int
+    @sql_column = "amount_value"
     Amount : int
 }
 
@@ -49,6 +50,38 @@ def test_conf_join(t : T?) {
             t |> equal(pairs[0].Who, "alice")
             t |> equal(pairs[0].HowMuch, 100)
             t |> equal(pairs[2].Who, "bob")
+        }
+    }
+    t |> run("_join may return one exact source row") @(t : T?) {
+        with_conf_db() $(db) {
+            seed(db)
+            let orders : array<ConfOrder> <- _sql(db |> select_from(type<ConfCust>)
+                |> _join(db |> select_from(type<ConfOrder>),
+                         $(c : ConfCust, o : ConfOrder) => c.Id == o.CustId,
+                         $(c : ConfCust, o : ConfOrder) => o)
+                |> _where(_.Amount >= 100)
+                |> _order_by(_.Amount))
+            t |> equal(length(orders), 2)
+            t |> equal(orders[0].CustId, 1)
+            t |> equal(orders[0].Amount, 100)
+            t |> equal(orders[1].Amount, 250)
+        }
+    }
+    t |> run("whole-source join results may feed another join") @(t : T?) {
+        with_conf_db() $(db) {
+            seed(db)
+            let orders : array<ConfOrder> <- _sql(db |> select_from(type<ConfCust>)
+                |> _join(db |> select_from(type<ConfOrder>),
+                         $(c : ConfCust, o : ConfOrder) => c.Id == o.CustId,
+                         $(c : ConfCust, o : ConfOrder) => o)
+                |> _join(db |> select_from(type<ConfOrder>),
+                         $(left : ConfOrder, right : ConfOrder) => left.Id == right.Id,
+                         $(left : ConfOrder, right : ConfOrder) => right)
+                |> _order_by(_.Amount))
+            t |> equal(length(orders), 3)
+            t |> equal(orders[0].Amount, 50)
+            t |> equal(orders[1].Amount, 100)
+            t |> equal(orders[2].Amount, 250)
         }
     }
     t |> run("_left_join flows unmatched right side as none") @(t : T?) {

--- a/tests/sql_conformance/test_conf_joins_subq.das
+++ b/tests/sql_conformance/test_conf_joins_subq.das
@@ -67,6 +67,25 @@ def test_conf_join(t : T?) {
             t |> equal(orders[1].Amount, 250)
         }
     }
+    t |> run("_aggregate consumes a whole-source join projection") @(tt : T?) {
+        with_conf_db() $(db) {
+            seed(db)
+            let stats = _sql(db |> select_from(type<ConfCust>)
+                |> _join(db |> select_from(type<ConfOrder>),
+                         $(c : ConfCust, o : ConfOrder) => c.Id == o.CustId,
+                         $(c : ConfCust, o : ConfOrder) => o)
+                |> _where(_.Amount >= 100)
+                |> _aggregate($(_rows) => (
+                    N = _rows |> count,
+                    Total = _rows |> _select(_.Amount) |> sum,
+                    First = _rows |> _select(_.Amount) |> min,
+                    Last = _rows |> _select(_.Amount) |> max)))
+            tt |> equal(stats.N, 2)
+            tt |> equal(stats.Total, 350)
+            tt |> equal(stats.First, 100)
+            tt |> equal(stats.Last, 250)
+        }
+    }
     t |> run("whole-source join results may feed another join") @(t : T?) {
         with_conf_db() $(db) {
             seed(db)

--- a/tests/sql_conformance/test_conf_projection_agg.das
+++ b/tests/sql_conformance/test_conf_projection_agg.das
@@ -8,6 +8,7 @@ options no_unused_function_arguments = false
 
 require dastest/testing_boost public
 require _conformance_provider
+require daslib/strings_boost
 
 [sql_table(name = "ConfSales")]
 struct ConfSale {
@@ -82,6 +83,70 @@ def test_conf_aggregates(t : T?) {
                 |> _where(_.Region == "east") |> _select(_.Amount) |> average())
             t |> numericEqual(avg, 200.0lf)
         }
+    }
+    t |> run("_aggregate returns several global aggregates from one scan") @(tt : T?) {
+        with_conf_db() $(db) {
+            seed(db)
+            let stats = _sql(
+                db |> select_from(type<ConfSale>)
+                   |> _where(_.Region != "north")
+                   |> _aggregate($(_rows) => (
+                        N = _rows |> count,
+                        LongN = _rows |> long_count,
+                        Total = _rows |> _select(_.Amount) |> sum,
+                        MinAmount = _rows |> _select(_.Amount) |> min,
+                        MaxAmount = _rows |> _select(_.Amount) |> max,
+                        Average = _rows |> _select(_.Amount) |> average)))
+            tt |> equal(stats.N, 4)
+            tt |> equal(stats.LongN, 4l)
+            tt |> equal(stats.Total, 650)
+            tt |> equal(stats.MinAmount, 50)
+            tt |> equal(stats.MaxAmount, 300)
+            tt |> numericEqual(stats.Average, 162.5lf)
+            let sql = _sql_text(
+                db |> select_from(type<ConfSale>)
+                   |> _aggregate($(_rows) => (
+                        N = _rows |> count,
+                        Total = _rows |> _select(_.Amount) |> sum)))
+            tt |> success(sql |> contains("COUNT(*) AS \"N\""))
+            tt |> success(sql |> contains("SUM(\"Amount\") AS \"Total\""))
+        }
+    }
+    t |> run("_aggregate returns type defaults for an empty source") @(tt : T?) {
+        with_conf_db() $(db) {
+            seed(db)
+            let stats = _sql(
+                db |> select_from(type<ConfSale>)
+                   |> _where(_.Region == "missing")
+                   |> _aggregate($(_rows) => (
+                        N = _rows |> count,
+                        Total = _rows |> _select(_.Amount) |> sum,
+                        MinAmount = _rows |> _select(_.Amount) |> min,
+                        MaxAmount = _rows |> _select(_.Amount) |> max,
+                        Average = _rows |> _select(_.Amount) |> average)))
+            tt |> equal(stats.N, 0)
+            tt |> equal(stats.Total, 0)
+            tt |> equal(stats.MinAmount, 0)
+            tt |> equal(stats.MaxAmount, 0)
+            tt |> numericEqual(stats.Average, 0.0lf)
+        }
+    }
+    t |> run("_aggregate keeps the same shape for in-memory arrays") @(tt : T?) {
+        let rows = [
+            ConfSale(Id = 1, Region = "east", Amount = 100),
+            ConfSale(Id = 2, Region = "east", Amount = 300),
+            ConfSale(Id = 3, Region = "west", Amount = 50)]
+        let stats = rows |> _aggregate($(_rows) => (
+            N = _rows |> count,
+            LongN = _rows |> long_count,
+            Total = _rows |> _select(_.Amount) |> sum,
+            MinAmount = _rows |> _select(_.Amount) |> min,
+            MaxAmount = _rows |> _select(_.Amount) |> max))
+        tt |> equal(stats.N, 3)
+        tt |> equal(stats.LongN, 3l)
+        tt |> equal(stats.Total, 450)
+        tt |> equal(stats.MinAmount, 50)
+        tt |> equal(stats.MaxAmount, 300)
     }
 }
 

--- a/tests/sql_conformance/test_conf_table_crud.das
+++ b/tests/sql_conformance/test_conf_table_crud.das
@@ -12,6 +12,7 @@ require _conformance_provider
 [sql_table(name = "ConfCars")]
 struct ConfCar {
     @sql_primary_key Id : int
+    @sql_unique
     Name : string
     Price : int
 }
@@ -57,6 +58,15 @@ def test_conf_insert_select(t : T?) {
                 ConfCar(Id = 0, Name = "c", Price = 3)])
             let rows <- db |> select_from(type<ConfCar>)
             t |> equal(length(rows), 3)
+        }
+    }
+    t |> run("@sql_unique rejects duplicate field values") @(t : T?) {
+        with_conf_db() $(db) {
+            db |> create_table(type<ConfCar>)
+            db |> insert(ConfCar(Id = 0, Name = "same", Price = 1))
+            let duplicate = db |> try_insert(ConfCar(Id = 0, Name = "same", Price = 2))
+            t |> success(duplicate |> is_err)
+            t |> equal(_sql(db |> select_from(type<ConfCar>) |> count()), 1)
         }
     }
 }

--- a/tutorials/sql/13-aggregates.das
+++ b/tutorials/sql/13-aggregates.das
@@ -5,7 +5,8 @@ require sqlite/sqlite_boost
 require daslib/sql_linq
 
 // Tutorial 13 — Column aggregates: `sum`, `average`, `min`, `max`,
-// plus `count` (already shown in tutorial 6).
+// plus `count` (already shown in tutorial 6) and `_aggregate`, which
+// returns several named global aggregates from one source scan.
 //
 // All five are *terminals* — they end the chain and produce a
 // scalar, not an array. The translation pattern is the same for the
@@ -74,6 +75,22 @@ def main() {
                                     |> sum())
         to_log(LOG_INFO, "SUM(Price) WHERE Price>100 = {total_over_100}\n")
 
+        // ── Several global aggregates in one scan ───────────────────────────
+        // `_aggregate` receives the filtered rowset and returns a named tuple.
+        // Each tuple slot must be a global aggregate over that rowset.
+        let stats = _sql(
+            db |> select_from(type<Car>)
+               |> _where(_.Price >= cutoff)
+               |> _aggregate($(_rows) => (
+                    N = _rows |> count,
+                    Total = _rows |> _select(_.Price) |> sum,
+                    Cheapest = _rows |> _select(_.Price) |> min,
+                    Priciest = _rows |> _select(_.Price) |> max,
+                    Mean = _rows |> _select(_.Price) |> average)))
+        to_log(LOG_INFO,
+            "one-scan stats: count={stats.N}, total={stats.Total}, " +
+            "min={stats.Cheapest}, max={stats.Priciest}, avg={stats.Mean}\n")
+
         // ── Aggregating a computed expression ────────────────────────────
         // `_select` takes a computed scalar, not just a bare column —
         // the expression lowers into the aggregate's argument.
@@ -99,8 +116,18 @@ def main() {
         let sql_expr = _sql_text(db |> select_from(type<Car>)
                                    |> _select(int64(_.Price) * int64(_.Id))
                                    |> sum())
+        let sql_stats = _sql_text(
+            db |> select_from(type<Car>)
+               |> _where(_.Price >= cutoff)
+               |> _aggregate($(_rows) => (
+                    N = _rows |> count,
+                    Total = _rows |> _select(_.Price) |> sum,
+                    Cheapest = _rows |> _select(_.Price) |> min,
+                    Priciest = _rows |> _select(_.Price) |> max,
+                    Mean = _rows |> _select(_.Price) |> average)))
         to_log(LOG_INFO, "  SUM SQL: {sql_sum}\n")
         to_log(LOG_INFO, "  AVG SQL: {sql_avg}\n")
         to_log(LOG_INFO, "  computed SUM SQL: {sql_expr}\n")
+        to_log(LOG_INFO, "  one-scan stats SQL: {sql_stats}\n")
     }
 }

--- a/tutorials/sql/15-join.das
+++ b/tutorials/sql/15-join.das
@@ -78,6 +78,27 @@ def main {
         //   Alice placed an order of 250
         //   Bob   placed an order of  50
 
+        // The `into` projection may also return one source row directly.
+        // `_sql` selects every qualified column from that source and
+        // reconstructs the exact nominal struct — no `(Id=o.Id, ...)`
+        // tuple is needed. This is especially useful when a join only
+        // supplies filtering/ranking context but the caller wants table rows.
+        let large_orders : array<Order> <- _sql(db |> select_from(type<User>)
+                                                   |> _join(db |> select_from(type<Order>),
+                                                            $(u : User, o : Order) => u.Id == o.UserId,
+                                                            $(u : User, o : Order) => o)
+                                                   |> _where(_.Total >= 100)
+                                                   |> _order_by(_.Total))
+        to_log(LOG_INFO, "whole Order rows from join: {length(large_orders)}")
+        for (o in large_orders) {
+            to_log(LOG_INFO, "  order {o.Id}: {o.Total}")
+        }
+        // SELECT "t1"."Id", "t1"."UserId", "t1"."Total"
+        //   FROM "Users" AS "t0"
+        //   INNER JOIN "Orders" AS "t1"
+        //     ON "t0"."Id" = "t1"."UserId"
+        //  WHERE "t1"."Total" >= ?
+
         // Pre-join `_where` filters the LEFT source before the join.
         // Column refs qualify with the left alias `t0` automatically.
         let active_only <- _sql(db |> select_from(type<User>)

--- a/tutorials/sql/21-upsert.das
+++ b/tutorials/sql/21-upsert.das
@@ -23,7 +23,8 @@ require daslib/sql_linq
 // `tuple(_.A, _.B)` and the underlying UNIQUE constraint must be a
 // composite index (see tutorial 24).
 
-[sql_table(name = "WordHits")]
+[sql_table(name = "WordHits"),
+ sql_index(fields = "Word", unique = true)]
 struct WordHit {
     @sql_primary_key Id : int
     Word : string
@@ -88,6 +89,24 @@ def main {
             _.Id,
             (Hits = _.Hits + 1, Last = _excluded.Last))
         to_log(LOG_INFO, "single-key upsert touched {bumped} row(s)\n")
+
+        // Auto-assigned integer primary key -------------------------------
+        // Id=0 is the same "unset primary key" convention used by insert().
+        // When the conflict target is another UNIQUE column, `_sql_upsert`
+        // omits Id from INSERT so the provider assigns it. This is portable:
+        // SQLite uses rowid, DuckDB a sequence, PostgreSQL an identity.
+        let created <- db |> _sql_upsert_returning(
+            WordHit(Id = 0, Word = "automatic", Hits = 1, Last = 2000l),
+            _.Word,
+            (Hits = _.Hits + _excluded.Hits, Last = _excluded.Last))
+        to_log(LOG_INFO, "auto-assigned upsert Id = {created[0].Id}\n")
+
+        // The same UNIQUE Word now takes the UPDATE path. Id=0 remains
+        // omitted and never overwrites the stored primary key.
+        db |> _sql_upsert(
+            WordHit(Id = 0, Word = "automatic", Hits = 4, Last = 3000l),
+            _.Word,
+            (Hits = _.Hits + _excluded.Hits, Last = _excluded.Last))
 
         // Composite conflict target — `tuple(_.Email, _.Tenant)` resolves
         // against the UNIQUE index on `(Email, Tenant)` declared on the

--- a/tutorials/sql/24-indexes.das
+++ b/tutorials/sql/24-indexes.das
@@ -6,10 +6,13 @@ require daslib/sql_linq
 
 // Tutorial 24 — indexes: declaring `CREATE INDEX` from struct annotations.
 //
-// SHAPE: `[sql_index(fields = ..., unique = ..., name = ...)]` is a
-// sibling annotation alongside `[sql_table]`. Both must live in the
-// **same** bracket pair, comma-separated, and `[sql_table]` must come
-// first — `[sql_index]` rewrites a helper that `[sql_table]` emits.
+// `@sql_unique` is the concise single-column form. It emits a portable
+// `CREATE UNIQUE INDEX` through the same helper used by `[sql_index]`.
+//
+// SHAPE: `[sql_index(fields = ..., unique = ..., name = ...)]` is the
+// configurable sibling annotation alongside `[sql_table]`. Both must
+// live in the **same** bracket pair, comma-separated, and `[sql_table]`
+// must come first — `[sql_index]` rewrites a helper emitted there.
 //
 //   [sql_table(name = "Users"),
 //    sql_index(fields = "Email", unique = true),
@@ -37,6 +40,7 @@ require daslib/sql_linq
 struct User {
     @sql_primary_key Id : int
     Email : string
+    @sql_unique
     Name : string
     City : string
     LastSeen : int64
@@ -51,6 +55,7 @@ def main {
         // creation back).
         // SQL emitted:
         //   CREATE TABLE "Users" (...);
+        //   CREATE UNIQUE INDEX "uq_Users_Name" ON "Users" ("Name");
         //   CREATE UNIQUE INDEX "idx_Users_Email" ON "Users" ("Email");
         //   CREATE INDEX "idx_Users_City_LastSeen" ON "Users" ("City", "LastSeen");
         //   CREATE INDEX "ix_users_lastseen" ON "Users" ("LastSeen");
@@ -108,7 +113,7 @@ def main {
 // separate `[sql_unique]` table-level annotation.
 //
 // Single-column uniqueness can use either `@sql_unique` on the field
-// (emits `UNIQUE` directly in the column DDL) or `[sql_index(unique =
-// true, fields = "Col")]` (separate `CREATE UNIQUE INDEX`). Both work
-// for the upsert path; the index form is preferable when you also need
-// to control the index name.
+// (portable generated name `uq_<table>_<column>`) or
+// `[sql_index(unique = true, fields = "Col")]` (configurable index
+// name). Both work on SQLite, DuckDB, and PostgreSQL and both satisfy
+// the upsert conflict-target requirement.

--- a/tutorials/sql/40-fts5.das
+++ b/tutorials/sql/40-fts5.das
@@ -91,6 +91,12 @@ def main {
                            |> _order_by(_.Rank)
                            |> take(2))
         to_log(LOG_INFO, "top 2 fox results: {length(top2)}")
+
+        // --- Typed predicate DELETE --------------------------------------
+        // FTS5 virtual tables have no declared daslang primary key, but the
+        // predicate form is fully typed and reports the affected row count.
+        let removed = db |> _sql_delete(type<Doc>, _.Body |> text_match("quicksand"))
+        to_log(LOG_INFO, "removed {removed} obsolete search row")
     }
 
     // --- text_match outside SQL --- nolint:STYLE014
@@ -121,9 +127,10 @@ def main {
     // Self-contained mode only — the FTS5 table holds both content and
     // index. External-content mode (FTS5 indexing rows of a separate
     // [sql_table]) ships when asked. Default tokenizer is unicode61
-    // (case-fold + Unicode word boundaries). UPDATE / DELETE on FTS5
-    // rows aren't typed in v1 — drop and re-INSERT, or use raw
-    // `db |> exec("DELETE FROM docs_idx WHERE rowid = ?", id)`.
+    // (case-fold + Unicode word boundaries). Predicate DELETE is typed:
+    // `_sql_delete(type<Doc>, predicate)`. Row-shaped UPDATE /
+    // DELETE-by-PK helpers are unavailable because the virtual table has no
+    // declared daslang PK; update by deleting and re-inserting, or use raw SQL.
     // BM25 weighting, snippet/highlight helpers, and per-column query
     // filters (`Body:fox`) all work via the FTS5 query string but
     // don't have typed wrappers in v1.

--- a/tutorials/sql/40-fts5.das
+++ b/tutorials/sql/40-fts5.das
@@ -18,6 +18,7 @@ require daslib/fts5_query   // for in-memory text_match against the same query s
 // API surface:
 //
 //   [sql_fts5(name="...")]    — struct annotation: virtual table
+//   @sql_fts_unindexed        — stored typed metadata, excluded from MATCH
 //   @sql_fts_rank             — read-only float column → FTS5 `rank`
 //   text_match(col, query)    — _where predicate → `col MATCH ?`
 //
@@ -27,6 +28,7 @@ require daslib/fts5_query   // for in-memory text_match against the same query s
 
 [sql_fts5(name = "docs_idx")]
 struct Doc {
+    @sql_fts_unindexed Id : int64
     Body : string
     @sql_fts_rank Rank : float
     // FTS5 fills `Rank` on SELECT (BM25 score; lower = more relevant).
@@ -39,13 +41,20 @@ def main {
         db |> apply_recommended_pragmas()
         db |> create_table(type<Doc>)
         // => CREATE VIRTUAL TABLE IF NOT EXISTS "docs_idx"
-        //        USING fts5("Body", tokenize='unicode61')
+        //        USING fts5("Id" UNINDEXED, "Body", tokenize='unicode61')
 
         // --- INSERT: just like a regular [sql_table] ----------------------
-        db |> insert(Doc(Body = "The quick brown fox jumps over the lazy dog"))
-        db |> insert(Doc(Body = "A swift red fox escaped the hounds at dawn"))
-        db |> insert(Doc(Body = "Quicksand swallowed the hiker's boot yesterday"))
-        db |> insert(Doc(Body = "Code review is the most cost-effective bug filter"))
+        db |> insert(Doc(Id = 1l, Body = "The quick brown fox jumps over the lazy dog"))
+        db |> insert(Doc(Id = 2l, Body = "A swift red fox escaped the hounds at dawn"))
+        db |> insert(Doc(Id = 3l, Body = "Quicksand swallowed the hiker's boot yesterday"))
+        db |> insert(Doc(Id = 4l, Body = "Code review is the most cost-effective bug filter"))
+
+        // --- Typed metadata ----------------------------------------------
+        // `Id` round-trips as int64 and supports ordinary predicates, but
+        // FTS5 does not tokenize it or allow text_match(Id, ...).
+        let first_fox <- _sql(db |> select_from(type<Doc>)
+                                |> _where(_.Id == 1l && (_.Body |> text_match("fox"))))
+        to_log(LOG_INFO, "metadata-filtered fox hits: {length(first_fox)}")
 
         // --- text_match: simple keyword search ---------------------------
         // Whitespace-AND: both tokens must appear (any order, any
@@ -95,7 +104,7 @@ def main {
         // --- Typed predicate DELETE --------------------------------------
         // FTS5 virtual tables have no declared daslang primary key, but the
         // predicate form is fully typed and reports the affected row count.
-        let removed = db |> _sql_delete(type<Doc>, _.Body |> text_match("quicksand"))
+        let removed = db |> _sql_delete(type<Doc>, _.Id == 3l)
         to_log(LOG_INFO, "removed {removed} obsolete search row")
     }
 


### PR DESCRIPTION
## Summary

Closes the typed SQL API gaps found while moving Cadmus away from raw provider calls:

- omit unset integer primary keys from typed upserts so provider-generated IDs work
- implement portable `@sql_unique` indexes for SQLite, DuckDB, and PostgreSQL
- document typed FTS predicate deletes
- add typed `@sql_fts_unindexed` metadata
- support whole-source projections from joins
- refactor Cadmus mention statistics onto typed SQL APIs
- add `_aggregate` for multiple global aggregates in a single SQL scan

Each feature is kept in its own commit and includes provider-appropriate tests and tutorial/documentation updates.

## Validation

- full preflight: 13 passed, 0 failed (expected skips: no C++ diff, latexmk unavailable, DLL-host relink locks)
- SQL conformance AOT: 94/94 passed
- SQLite SQL conformance: 94/94 passed
- DuckDB SQL conformance: 89/89 passed
- PostgreSQL SQL conformance: 87/87 passed
- Cadmus tests: 19/19 passed
- packaged sequence smoke test: passed
- Release build: passed
