### PR TITLE
dasLLAMA: lcpp_bench llama-bench mirror + Voxtral-Small/GLM-4.5-Air scoreboard rows

### DIFF
--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -1,0 +1,144 @@
+options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
+options _jit_fast_math = true   // ggml-parity FP laxity — matches how llama.cpp is benched
+
+require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
+require dasllama/dasllama_math   // setup_dasllama_jobque_ + apply_box_profile_runtime (engine-level, not re-exported)
+require ../performance/profile_common.das   // profile_threads + affinity_on — the standing per-box methodology
+require daslib/jobque_boost
+require daslib/clargs
+require daslib/fio
+require math
+
+// llama-bench mirror — EXACTLY llama.cpp's test shapes, rep counts, and timing boundaries, and
+// NOTHING else. Two independent rows, each = one untimed warmup + -r timed reps, mean ± stdev:
+//   pp: one batched forward_prefill of -p tokens from an empty cache per rep
+//   tg: -n single-token forwards at pos 0.. per rep, feeding synthetic ids with NO logit read
+//       (llama-bench never samples — sampling cost is excluded by design)
+//   ours:   bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m <model.gguf>
+//   theirs: llama-bench -m <model.gguf> -t 16 -p 512 -n 128 [--cpu-mask 0x55555555 --cpu-strict 1]
+
+[CommandLineArgs]
+struct Args {
+    @clarg_required
+    @clarg_short = "m"
+    @clarg_doc = "Model GGUF path"
+    model : string
+
+    @clarg_short = "p"
+    @clarg_doc = "Prompt tokens per pp rep (default: 512, llama-bench -p)"
+    plen : int = 512
+
+    @clarg_short = "n"
+    @clarg_doc = "Generated tokens per tg rep (default: 128, llama-bench -n)"
+    ngen : int = 128
+
+    @clarg_short = "r"
+    @clarg_doc = "Timed repetitions per row (default: 5, llama-bench -r)"
+    reps : int = 5
+
+    @clarg_short = "q"
+    @clarg_doc = "Weight quant mode (default: q8)"
+    quant : QuantMode = QuantMode.q8
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+// deterministic synthetic ids (vocab-safe low range, the decode_prof convention); llama-bench
+// feeds std::rand() — token content doesn't affect speed, determinism keeps runs comparable
+def private synth_id(i, seed : int64) : int64 => 1000l + ((i * 17l + seed * 131l) % 5000l)
+
+def private build_prompt(n : int64; seed : int64) : array<int64> {
+    return <- [for (i in range64(n)); synth_id(i, seed)]
+}
+
+def private report(tag : string; tps : array<double>) {
+    var sum = 0.0lf
+    for (v in tps) {
+        sum += v
+    }
+    let n = length(tps)
+    let mean = sum / double(n)
+    var vsum = 0.0lf
+    for (v in tps) {
+        vsum += (v - mean) * (v - mean)
+    }
+    let sd = n > 1 ? double(sqrt(float(vsum / double(n - 1)))) : 0.0lf
+    print("{tag}: {mean:.2f} ± {sd:.2f} tok/s ({n} reps)\n")
+}
+
+[export]
+def main() {
+    if (!jit_enabled()) {
+        print("This benchmark is JIT-only — run with: daslang -jit <file>\n")
+        return
+    }
+    var r <- parse_args(type<Args>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Args>), "lcpp_bench")
+        return
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Args>), "lcpp_bench")
+        return
+    }
+    let plen = max(int64(cfg.plen), 0l)
+    let ngen = max(int64(cfg.ngen), 0l)
+    let reps = max(cfg.reps, 1)
+    // the standing per-box methodology, enforced here rather than left to the environment
+    // (gen_profile's pattern): cap the future que's workers (computing main is the last lane) and
+    // hard-pin lanes to distinct physical cores on the boxes that pin. Explicit DAS_JOBQUE_THREADS
+    // / DAS_JOBQUE_AFFINITY envs still win. Must run before any with_job_que.
+    let threads = has_env_variable("DAS_JOBQUE_THREADS") ? to_int(get_env_variable("DAS_JOBQUE_THREADS")) : profile_threads()
+    if (!has_env_variable("DAS_JOBQUE_THREADS")) {
+        set_jobque_threads_cap(max(threads - 1, 1))
+    }
+    let pinned = affinity_on() && !has_env_variable("DAS_JOBQUE_AFFINITY")
+    if (pinned) {
+        set_jobque_affinity(2)   // 2 = hard mask, the llama-bench --cpu-strict mirror (mode 1 re-rolls SMT placement)
+    }
+    apply_box_profile_runtime()   // the tuned per-box stack — what load_model users get
+    print("loading {cfg.model}\n")
+    var t <- load_gguf(cfg.model, cfg.quant)
+    t.config.seq_len = min(t.config.seq_len, max(plen, ngen) + 8l)   // cap the KV allocation
+    let c = t.config
+    print("config: dim={c.dim} layers={c.n_layers} vocab={c.vocab_size} | backend {active_kernel_backend()} (batch {active_batch_backend()}) | t{threads} affinity {pinned ? "hard" : "env/off"} | pp{plen} tg{ngen} x {reps} reps\n")
+    with_job_que() {
+        setup_dasllama_jobque_()
+        var s <- make_run_state(c)
+        if (plen > 0l) {
+            let warm <- build_prompt(plen, 999l)
+            forward_prefill(t, s, warm, plen, 0l)   // warmup — untimed full-size run, as llama-bench does
+            var tps : array<double>
+            for (rep in range(reps)) {
+                let prompt <- build_prompt(plen, int64(rep))
+                let t0 = ref_time_ticks()
+                forward_prefill(t, s, prompt, plen, 0l)
+                let us = get_time_usec(t0)
+                tps |> push(double(plen) * 1.0e6lf / double(us))
+            }
+            report("pp{plen}", tps)
+            delete tps
+        }
+        if (ngen > 0l) {
+            forward(t, s, synth_id(0l, 999l), 0l)   // warmup — one untimed token, llama-bench's test_gen(ctx, 1)
+            var tps : array<double>
+            for (rep in range(reps)) {
+                let t0 = ref_time_ticks()
+                for (i in range64(ngen)) {
+                    forward(t, s, synth_id(i, int64(rep)), i)
+                }
+                let us = get_time_usec(t0)
+                tps |> push(double(ngen) * 1.0e6lf / double(us))
+            }
+            report("tg{ngen}", tps)
+            delete tps
+        }
+        delete s
+    }
+    delete t
+}

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -9,11 +9,11 @@ require strings
 require math
 require dasllama/dasllama_math  // setup_dasllama_jobque_ + the runtime knob setters (engine-level, not re-exported)
 
-// Prompt-processing (TTFT) profile for a Llama-3 GGUF (Q8): the OLD per-token path (N× forward,
-// decode-style gemv per token) vs ONE batched forward_prefill. Token content doesn't affect speed,
-// so synthetic ids are fine. One run state is reused — each run overwrites the cache positions it
-// reads, so no reset is needed between runs.
-//   bin/daslang -jit modules/dasLLAMA/dasllama_prefill_perf.das -- <model.gguf>
+// Prompt-processing (TTFT) profile for a GGUF: ONE batched forward_prefill per size — the
+// llama-bench `-p N -n 0` counterpart. Token content doesn't affect speed, so synthetic ids are
+// fine. One run state is reused — each run overwrites the cache positions it reads, so no reset
+// is needed between runs.
+//   bin/daslang -jit modules/dasLLAMA/benchmarks/prefill_perf.das -- <model.gguf>
 let DEFAULT_MODEL = "/Users/borisbatkin/Work/llama.cpp/models/Llama-3.2-1B-Instruct-Q8_0.gguf"
 
 def build_prompt(n : int64) : array<int64> {
@@ -72,7 +72,7 @@ def main {
     let c = t.config
     print("config: dim={c.dim} hidden={c.hidden_dim} layers={c.n_layers} heads={c.n_heads}/{c.n_kv_heads} vocab={c.vocab_size}\n")
     print("active backend: {active_kernel_backend()}\n")
-    print("prompt processing: per-token forward (decode-style) vs one batched forward_prefill\n\n")
+    print("prompt processing: one batched forward_prefill per size\n\n")
 
     var s <- make_run_state(c)
     with_job_que() {
@@ -120,27 +120,13 @@ def main {
         // team dispatch profile over each batched prefill (per-op publish/serve/join costs +
         // caller/solo shares — the starved-shape diagnostic)
         let teamProf = has_env_variable("DASLLAMA_TEAM_PROF")
-        // warmup — JIT both paths
+        // warmup — JIT the batched path
         let warm <- build_prompt(8l)
-        for (p in range64(8l)) {
-            forward(t, s, warm[p], p)
-        }
         forward_prefill(t, s, warm, 8l, 0l)
 
-        // DASLLAMA_PREFILL_ONLY=1 skips the per-token (decode-style) arm — the fast A/B loop
-        // for side-by-side runs against llama-bench -p N -n 0
-        let prefillOnly = has_env_variable("DASLLAMA_PREFILL_ONLY")
         let sizes <- [64l, 256l, 512l]
         for (n in sizes) {
             let prompt <- build_prompt(n)
-            var us_old = 1
-            if (!prefillOnly) {
-                let t0 = ref_time_ticks()
-                for (p in range64(n)) {
-                    forward(t, s, prompt[p], p)
-                }
-                us_old = get_time_usec(t0)
-            }
             forward_profile_reset()   // per-section table over the LAST batched prefill only
             if (teamProf) {
                 set_jobque_team_prof(true)
@@ -155,7 +141,7 @@ def main {
             }
             let t1 = ref_time_ticks()
             forward_prefill(t, s, prompt, n, 0l)
-            let us_new = get_time_usec(t1)
+            let us = get_time_usec(t1)
             if (doTrace) {
                 set_trace_tags(false)
                 jobque_trace_stop()
@@ -175,14 +161,8 @@ def main {
                 let soloShare = counts.x > 0 ? 100 * counts.w / counts.x : 0
                 print("team prof N={n}: avg ns/op publish {prof.x} serve {prof.y} join-tail {prof.z} total {prof.w} | ops {counts.x} chunks {counts.y} caller-share {callerShare}% solo {soloShare}% | claims first +{react.x}ns last +{react.y}ns\n")
             }
-            let tps_new = double(n) / (double(us_new) * 1.0e-6lf)
-            if (prefillOnly) {
-                print("N={n}: prefill {us_new}us {tps_new} tok/s\n")
-            } else {
-                let tps_old = double(n) / (double(us_old) * 1.0e-6lf)
-                let speedup = double(us_old) / double(us_new)
-                print("N={n}: per-token {us_old}us {tps_old} tok/s  |  prefill {us_new}us {tps_new} tok/s  |  {speedup}x\n")
-            }
+            let tps = double(n) / (double(us) * 1.0e-6lf)
+            print("N={n}: prefill {us}us {tps} tok/s\n")
         }
         forward_profile_report()   // buckets for the N=512 batched prefill (set against GGML_OP_PROFILE pp512)
     }

--- a/site/dasllama.html
+++ b/site/dasllama.html
@@ -207,8 +207,8 @@
                     <a class="forge-btn-secondary" href="#method">methodology</a>
                 </div>
                 <div class="forge-stats">
-                    <div class="forge-stat"><div class="forge-stat__n" id="stat-prefill-n">up to 1.74×</div><div class="forge-stat__l" id="stat-prefill-l">LLM prefill vs llama.cpp · gpt-oss-20b, Apple M1 Max</div></div>
-                    <div class="forge-stat"><div class="forge-stat__n" id="stat-wins-n">54 / 56</div><div class="forge-stat__l" id="stat-wins-l">runs das ≥ llama.cpp · 28 models × both phases, 3990X</div></div>
+                    <div class="forge-stat"><div class="forge-stat__n" id="stat-prefill-n">up to 2.25×</div><div class="forge-stat__l" id="stat-prefill-l">LLM prefill vs llama.cpp · Voxtral-Small-24B-q4k, Ryzen Threadripper 3990X</div></div>
+                    <div class="forge-stat"><div class="forge-stat__n" id="stat-wins-n">57 / 60</div><div class="forge-stat__l" id="stat-wins-l">runs das ≥ llama.cpp · 30 models × both phases, 3990X</div></div>
                     <div class="forge-stat"><div class="forge-stat__n" id="stat-audio-n">~6×</div><div class="forge-stat__l">Qwen3-Omni audio vs mtmd, CPU-only (M1)</div></div>
                 </div>
             </div>

--- a/site/files/dasllama/profile_llm_zen2.json
+++ b/site/files/dasllama/profile_llm_zen2.json
@@ -459,6 +459,38 @@
         "das_tok_s": 5.947793981799007,
         "llama_cpp_tok_s": 4.983295
       }
+    },
+    {
+      "model": "Voxtral-Small-24B-q4k",
+      "arch": "llama",
+      "quant": "q4_k_m",
+      "active_b": 23.5724032,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 73.23,
+        "llama_cpp_tok_s": 32.55
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 4.01,
+        "llama_cpp_tok_s": 3.86
+      }
+    },
+    {
+      "model": "GLM-4.5-Air-q4k",
+      "arch": "glm4moe",
+      "quant": "q4_k_m",
+      "active_b": 12.0,
+      "prefill": {
+        "context": 512,
+        "das_tok_s": 59.12,
+        "llama_cpp_tok_s": 35.75
+      },
+      "emission": {
+        "context": 128,
+        "das_tok_s": 5.54,
+        "llama_cpp_tok_s": 5.76
+      }
     }
   ]
 }


### PR DESCRIPTION
New `benchmarks/lcpp_bench.das` — a llama-bench mirror that measures EXACTLY llama.cpp's test shapes, rep counts, and timing boundaries, and nothing else:

- **pp row**: one batched `forward_prefill` of `-p` tokens from an empty cache per rep
- **tg row**: `-n` single-token forwards feeding synthetic ids with **no logit read** (llama-bench never samples — sampling cost is excluded by design)
- each row = one untimed warmup + `-r` timed reps, reported mean ± stdev; defaults `-p 512 -n 128 -r 5`
- self-enforces the per-box measurement methodology **in code** (worker cap + hard-mask affinity via `profile_common`, `DASLLAMA_BOX` identity, env rails still win for A/B) — raw shell-env `DAS_JOBQUE_AFFINITY` pinning proved to SMT-pack lanes: pp512 read 28.3 t/s where the in-code pin reads 73.2 on the same binary/model

`prefill_perf.das`: the per-token (decode-style) arm and its `DASLLAMA_PREFILL_ONLY` gate are gone — batched-only, ~10x faster sweeps, same `N=…` output shape (`run_all_models.sh`'s grep unaffected).

Website scoreboard (`site/`): two new zen2 rows, measured cold-box with this bench, both sides pinned t16, llama.cpp b9860 (`fdb1db877`):

| model | pp512 das / lcpp | tg128 das / lcpp |
|---|---|---|
| Voxtral-Small-24B q4_k_m | 73.23 / 32.55 = **2.25x** | 4.01 / 3.86 = 1.04x |
| GLM-4.5-Air (106B·A12B) q4_k_m | 59.12 / 35.75 = **1.65x** | 5.54 / 5.76 = 0.96x |

Hero stat fallbacks resynced to what the JS derives from the updated JSON: `up to 2.25×` (Voxtral prefill, 3990X) and `57 / 60` runs das ≥ llama.cpp over 30 models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
