### PR TITLE
Improve per-box tuning and preserve release configs

### DIFF
--- a/daslib/daspkg.das
+++ b/daslib/daspkg.das
@@ -133,6 +133,7 @@ struct ReleaseSpec {
     main_script : string                //!< path to project's main .das (relative to root)
     wasm_main_script : string           //!< entry for `daspkg release wasm` when it differs from main_script (e.g. a live_stub variant); falls back to main_script
     include_globs : array<string>       //!< asset globs to ship
+    include_if_missing_globs : array<string> //!< mutable starter files to copy only when absent; never release-owned or overwritten
     exclude_globs : array<string>       //!< asset globs to skip
     forced_modules : array<string>      //!< force-include shared module by das_name (auto-detection misses media-only or runtime-loaded packages)
     native_dlls : array<string>         //!< native shared libraries to ship next to this package's .shared_module (e.g. "glfw3.dll" / "libglfw.so.3.4"); resolved against <das_root>/bin/ (Windows) or <das_root>/lib/ (POSIX)
@@ -164,6 +165,14 @@ def release_wasm_main(script : string) {
 
 def release_include(pattern : string) {
     _release_spec.include_globs |> push(pattern)
+}
+
+//! Ship starter content only when the destination does not already exist.
+//! Unlike `release_include`, these files are deliberately omitted from the
+//! release manifest, so later releases neither delete nor overwrite the
+//! deployed copy. Use this for editable configs and other user-owned files.
+def release_include_if_missing(pattern : string) {
+    _release_spec.include_if_missing_globs |> push(pattern)
 }
 
 def release_exclude(pattern : string) {

--- a/examples/telegram/dictation/.das_package
+++ b/examples/telegram/dictation/.das_package
@@ -17,5 +17,5 @@ def dependencies(version : string) {
 def release() {
     release_main("main.das")
     release_name("dictation-bot")
-    release_include("dictation.toml")   // ship the config template next to the exe
+    release_include_if_missing("dictation.toml") // initialize once; preserve deployed edits on upgrades
 }

--- a/examples/telegram/dictation/README.md
+++ b/examples/telegram/dictation/README.md
@@ -173,8 +173,9 @@ Telegram Desktop produces more pages; use `--include-last-page` only after the e
 bin/daslang utils/daspkg/main.das -- release --root examples/telegram/dictation --out <staging>
 ```
 
-The release contains a standalone executable, runtime DLLs, required shared modules, and the config
-template. Preserve deployed `dictation.toml` and `cadmus.db` when re-releasing.
+The release contains a standalone executable, runtime DLLs, required shared modules, and initializes
+the config template only when `dictation.toml` is absent. Re-releasing preserves the deployed
+`dictation.toml`; `cadmus.db` is not release-owned and is preserved as well.
 
 For a supervised deployment, use the watchdog shipped by the dasllama-server release to run the
 released bot without an HTTP health probe. It records process memory, shows a Windows notification

--- a/modules/dasLLAMA/harness/dasllama_tuner.das
+++ b/modules/dasLLAMA/harness/dasllama_tuner.das
@@ -14,6 +14,9 @@ require math
 // A child failure is reported but does not abort the other half — the completeness check
 // upstream names whatever ends up missing.
 
+// The default is the roughly one-minute 20-round full-grid / 80-round finalist budget.
+// Append `-- --tune-fast` for progressive 4/8 screening and a 20-round cap;
+// `daspkg release --tune-fast` forwards the same flag here.
 // Both halves take real measurements (the confirm gate is a full prefill), so they must run
 // under the box measurement regime — 16 cores with affinity on the big-SMT x64 boxes, not the
 // fresh-que default (all cores): a crown confirmed at the wrong width ships the wrong kernel.
@@ -33,9 +36,20 @@ def private regime_env_prefix() : string {
     return pfx
 }
 
-def private run_half(name : string) : bool {
+def private tune_fast_requested() : bool {
+    for (arg in get_command_line_arguments()) {
+        if (arg == "--tune-fast" || arg == "-tune-fast") {
+            return true
+        }
+    }
+    return false
+}
+
+def private run_half(name : string; fast : bool) : bool {
+    let t0 = ref_time_ticks()
     let pfx = regime_env_prefix()
-    let cmd = "{pfx}\"{get_das_exe()}\" -jit \"{path_join(get_this_module_dir(), name)}\" -dasroot \"{get_das_root()}\" 2>&1"
+    let user_args = fast ? " -- --tune-fast" : ""
+    let cmd = "{pfx}\"{get_das_exe()}\" -jit \"{path_join(get_this_module_dir(), name)}\" -dasroot \"{get_das_root()}\"{user_args} 2>&1"
     // cmd.exe strips the first and last quote of a line that starts with a quote — wrap in a
     // sacrificial outer pair on windows UNLESS the env prefix already leads (the daspkg popen trap)
     let full = get_platform_name() == "windows" && empty(pfx) ? "\"{cmd}\"" : cmd
@@ -51,6 +65,8 @@ def private run_half(name : string) : bool {
             }
         }
     }
+    let elapsed_ms = get_time_usec(t0) / 1000
+    print("dasllama_tuner: {name} finished in {elapsed_ms} ms (rc={rc})\n")
     if (rc != 0) {
         print("dasllama_tuner: {name} FAILED (rc={rc})\n")
     }
@@ -59,8 +75,12 @@ def private run_half(name : string) : bool {
 
 [export]
 def main : int {
+    let t0 = ref_time_ticks()
+    let fast = tune_fast_requested()
     print("dasllama_tuner: sidecar = {get_env_variable("DAS_TUNE_MANIFEST")}\n")
-    let ok1 = run_half("gen_tune_probe.das")
-    let ok2 = run_half("tune_kernels.das")
+    print("dasllama_tuner: mode = {fast ? "FAST (progressive 4/8 screening / 20 max)" : "default (20 screening / 80 max)"}\n")
+    let ok1 = run_half("gen_tune_probe.das", fast)
+    let ok2 = run_half("tune_kernels.das", fast)
+    print("dasllama_tuner: total {get_time_usec(t0) / 1000} ms\n")
     return ok1 && ok2 ? 0 : 1
 }

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -1095,9 +1095,24 @@ def private parse_confirm_pp(outp : string) : double {
     return 0.0lf
 }
 
-// What a manifest-less normal run would stamp on this box: a compile-only child prints the
-// `llvm_tune: q8q8_tile_gen <- <suffix> (fallback)` line during its [tune] macro pass.
+def private compile_fallback(fname : string) : string {
+    for (entry in split(get_env_variable("DAS_TUNE_COMPILE_FALLBACKS"), ";")) {
+        let eq = find(entry, "=")
+        if (eq > 0 && slice(entry, 0, eq) == fname) {
+            return slice(entry, eq + 1)
+        }
+    }
+    return ""
+}
+
+// A release compile reports the fallback it just selected on this same host. Direct/manual
+// tuner runs have no such handoff, so retain the compile-only child as their safe fallback.
 def private discover_fallback_stamp() : string {
+    let inherited = compile_fallback("q8q8_tile_gen")
+    if (!empty(inherited)) {
+        print("confirm: using q8q8 fallback '{inherited}' from the release compile on this host\n")
+        return inherited
+    }
     var envs <- [("DAS_TUNE_MODE" => "normal"), ("DAS_TUNE_MANIFEST" => ""), ("GEN_TUNE_COMPILE_ONLY" => "1")]
     let cmd = env_cmd(envs, "\"{get_das_exe()}\" -jit \"{harness_dir()}/gen_tune_probe.das\"")
     delete envs
@@ -1169,6 +1184,7 @@ def private confirm_and_write(winner : string) : bool {
 }
 
 def tune_mode_run : bool {
+    let tune_total_t0 = ref_time_ticks()
     var fx <- build_fixture(2048l, 512l, 64l)      // batch shape (the kv projection)
     var gfx <- build_fixture(2048l, 8192l, 1l)     // streamed decode shape (DRAM-bound ffn GEMV)
     var hfx <- build_fixture(2048l, 512l, 1l)      // hot decode shape (cache-resident — the
@@ -1345,9 +1361,12 @@ def tune_mode_run : bool {
     // child-process confirm gate here: the kq stamp only moves the kq planes' interleave,
     // and the e2e exposure (a tile-optimal mr shaving decode kernel rate) is bounded by the
     // decode path staying DRAM-bound — validated end-to-end when the entries first landed.
+    print("TUNE_GEN_TIME q8q8_family {get_time_usec(tune_total_t0) / 1000} ms\n")
     var kok = true
     for (fmt in fixed_array(4l, 5l, 6l, 40l)) {
+        let kq_t0 = ref_time_ticks()
         let w = kq_tune_family(fmt)
+        print("TUNE_GEN_TIME k{fmt}_family {get_time_usec(kq_t0) / 1000} ms\n")
         let entry = fmt == 40l ? "q40q8_tile_gen" : "k{fmt}q8_tile_gen"
         if (empty(w)) {
             kok = false
@@ -1357,7 +1376,10 @@ def tune_mode_run : bool {
             kok = kok && wok
         }
     }
+    let confirm_t0 = ref_time_ticks()
     let ok = confirm_and_write(vs[merged]._0) && kok
+    print("TUNE_GEN_TIME confirm {get_time_usec(confirm_t0) / 1000} ms\n")
+    print("TUNE_GEN_TIME total {get_time_usec(tune_total_t0) / 1000} ms\n")
     delete y
     delete yg
     delete yh

--- a/modules/dasLLAMA/harness/tune_kernels.das
+++ b/modules/dasLLAMA/harness/tune_kernels.das
@@ -11,6 +11,7 @@ options gen2
 // noise is obvious.
 //
 // Run:  bin/daslang -jit modules/dasLLAMA/harness/tune_kernels.das
+// Quick pass: append `-- --tune-fast` for progressive 4/8 screening / 20 maximum rounds.
 //   then rebuild/rerun the model with -jit to pick up box_profile.json (it re-keys the JIT DLL cache).
 
 require dasllama/dasllama_math   // nolint:STYLE030 — side-effect: loads the *_template kernels for the cross-module scan
@@ -86,12 +87,61 @@ typedef AxpyFn = function<(var d : float?; s : float const?; scale : float; n : 
 typedef ScaleFn = function<(var d : float?; scale : float; n : int64) : void>
 
 let N = 4096l
-let ROUNDS = 80
+var private FAST_MODE = false
+var private SCREEN_ROUNDS = 20
+var private ROUNDS = 80
+let MIN_FINALISTS = 4
+let FINALIST_MARGIN = 1.05lf
+let FAST_MID_ROUNDS = 8
+let FAST_MID_FINALISTS = 8
+let FAST_MID_MARGIN = 1.10lf
 let REPS = 2000
 let TOL = 1.0e-3lf
 let BASELINE = "vec8_u2"   // the majority hand default; kernels with their own [tuned(fallback=)] pass it to report()
 
 // ===== shared reporting =====
+
+// Keep the fastest rows plus anything within the supplied leader margin. Normal mode measures
+// the full grid for 20 rounds before the 80-round finalist phase. Fast mode narrows progressively:
+// full grid through round 4, top 8 / within 10% through round 8, then top 4 / within 5% to round 20.
+def screening_keep(best : array<double>; ok : array<bool>; i : int;
+                   min_finalists : int; margin : double) : bool {
+    if (!ok[i]) {
+        return false
+    }
+    var leader = 1.0e30lf
+    var faster = 0
+    for (j in range(length(best))) {
+        if (ok[j]) {
+            if (best[j] < leader) {
+                leader = best[j]
+            }
+            if (best[j] < best[i]) {
+                faster ++
+            }
+        }
+    }
+    return faster < min_finalists || best[i] <= leader * margin
+}
+
+def private tune_candidate_active(round : int; best : array<double>; ok : array<bool>; i : int) : bool {
+    if (round < SCREEN_ROUNDS) {
+        return true
+    }
+    if (FAST_MODE && round < FAST_MID_ROUNDS) {
+        return screening_keep(best, ok, i, FAST_MID_FINALISTS, FAST_MID_MARGIN)
+    }
+    return screening_keep(best, ok, i, MIN_FINALISTS, FINALIST_MARGIN)
+}
+
+def private tune_fast_requested() : bool {
+    for (arg in get_command_line_arguments()) {
+        if (arg == "--tune-fast" || arg == "-tune-fast") {
+            return true
+        }
+    }
+    return false
+}
 
 // Print each passing variant's best time as a % delta vs the kernel's SHIPPED baseline (its
 // [tuned] fallback perm — vec8_u2 for most, but e.g. dot_q8q8 ships vec16), mark the winner, and
@@ -186,9 +236,11 @@ def bench_dot() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -197,7 +249,7 @@ def bench_dot() : string {
                 sink += f(pa, pb, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -245,9 +297,11 @@ def bench_binary(kernel : string; vs : array<tuple<string; BinFn>>;
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(d, d0)
@@ -257,7 +311,7 @@ def bench_binary(kernel : string; vs : array<tuple<string; BinFn>>;
                 invoke(f, dp, sp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -310,9 +364,11 @@ def bench_axpy() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(d, d0)
@@ -322,7 +378,7 @@ def bench_axpy() : string {
                 invoke(f, dp, sp, scale, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -369,9 +425,11 @@ def bench_dot_f16() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -380,7 +438,7 @@ def bench_dot_f16() : string {
                 sink += f(pa, pb, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -432,9 +490,11 @@ def bench_axpy_f16() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(d, d0)
@@ -444,7 +504,7 @@ def bench_axpy_f16() : string {
                 invoke(f, dp, sp, scale, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -487,9 +547,11 @@ def bench_cvt_f32_to_f16() : string {
         ok[i] = exact
     }
 
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -498,7 +560,7 @@ def bench_cvt_f32_to_f16() : string {
                 invoke(f, dp, sp, N)   // pure overwrite — no reset needed
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -537,9 +599,11 @@ def bench_cvt_f16_to_f32() : string {
         ok[i] = exact
     }
 
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -548,7 +612,7 @@ def bench_cvt_f16_to_f32() : string {
                 invoke(f, dp, sp, N)   // pure overwrite — no reset needed
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -595,9 +659,11 @@ def bench_scale() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(d, d0)
@@ -607,7 +673,7 @@ def bench_scale() : string {
                 invoke(f, dp, scale, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -670,9 +736,11 @@ def bench_softmax() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(d, d0)
@@ -682,7 +750,7 @@ def bench_softmax() : string {
                 invoke(f, dp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -740,9 +808,11 @@ def bench_rmsnorm() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -751,7 +821,7 @@ def bench_rmsnorm() : string {
                 invoke(f, op, xp, wp, N, eps)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -802,9 +872,11 @@ def bench_dot_q4() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -813,7 +885,7 @@ def bench_dot_q4() : string {
                 sink += f(wqp, wsp, xp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -866,9 +938,11 @@ def bench_dot_q8q8() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -877,7 +951,7 @@ def bench_dot_q8q8() : string {
                 sink += f(wqp, wsp, xqp, xsp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -959,9 +1033,11 @@ def bench_dot_q8kv() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -970,7 +1046,7 @@ def bench_dot_q8kv() : string {
                 sink += f(pa, pb, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1024,9 +1100,11 @@ def bench_dot_q8q8kv() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1035,7 +1113,7 @@ def bench_dot_q8q8kv() : string {
                 sink += f(qp, sp, pb, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1089,9 +1167,11 @@ def bench_axpy_q8kv() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(d, d0)
@@ -1101,7 +1181,7 @@ def bench_axpy_q8kv() : string {
                 invoke(f, dp, sp, scale, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1148,9 +1228,11 @@ def bench_cvt_q8kv_to_f32() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1159,7 +1241,7 @@ def bench_cvt_q8kv_to_f32() : string {
                 invoke(f, dp, sp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1206,9 +1288,11 @@ def bench_quantize_q8kv_row() : string {
     }
 
     var sink = 0
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1217,7 +1301,7 @@ def bench_quantize_q8kv_row() : string {
                 invoke(f, dp, sp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1284,9 +1368,11 @@ def bench_dot_mx4q8() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1295,7 +1381,7 @@ def bench_dot_mx4q8() : string {
                 sink += f(lutp, wnp, wep, xqp, xsp, N)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1353,9 +1439,11 @@ def bench_quantize() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1364,7 +1452,7 @@ def bench_quantize() : string {
                 invoke(f, srcp, N, qp, sp, 0l, 0l)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1436,9 +1524,11 @@ def bench_quantize_bs() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1447,7 +1537,7 @@ def bench_quantize_bs() : string {
                 invoke(f, srcp, N, qp, sp, bp, 0l, 0l, 0l)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1515,9 +1605,11 @@ def bench_rope_tab() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             reset(v, v0)
@@ -1527,7 +1619,7 @@ def bench_rope_tab() : string {
                 invoke(f, vp, head_size, N, cp, sp)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1592,9 +1684,11 @@ def bench_gemm_tile() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             for (j in range(int(4l * NN))) {
@@ -1606,7 +1700,7 @@ def bench_gemm_tile() : string {
                 invoke(f, cp, ap, bp, 0l, 0l, K, NN)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1702,9 +1796,11 @@ def bench_laneq4x4() : string {
     }
 
     var sink = 0.0f
-    for (_round in range(ROUNDS)) {
-        for (i in range(nv)) {
-            if (!ok[i]) {
+    for (tpass in range(ROUNDS + 1)) {
+        let round = tpass - 1   // pass 0 warms every valid row; measured rounds start at 0
+        for (slot in range(nv)) {
+            let i = (slot + tpass) % nv   // rotate order so every row occupies every slot
+            if (!ok[i] || !tune_candidate_active(round, best, ok, i)) {
                 continue
             }
             let f = vs[i]._1
@@ -1713,7 +1809,7 @@ def bench_laneq4x4() : string {
                 invoke(f, yp, wgp, sgp, xqp, xsp, n, d, 0l, 0l)
             }
             let us = double(get_time_usec(t0))
-            if (us < best[i]) {
+            if (round >= 0 && us < best[i]) {
                 best[i] = us
             }
         }
@@ -1727,8 +1823,18 @@ def bench_laneq4x4() : string {
 // policy must not fire a nested tuner off this program's own missing per-app sidecar
 [export, tune_policy(missing = "fallback")]
 def main {
-    create_job_que()   // the benches are single-thread, but the runtime snapshot reads get_total_hw_jobs()
-    print("kernel tuner: N={N}, {ROUNDS} rounds x {REPS} reps, interleaved best-of\n\n")
+    FAST_MODE = tune_fast_requested()
+    if (FAST_MODE) {
+        SCREEN_ROUNDS = 4
+        ROUNDS = 20
+    }
+    let affinity_inherited = has_env_variable("DAS_JOBQUE_AFFINITY")
+    if (!affinity_inherited) {
+        set_jobque_affinity(2)   // JobQue pins its creator (this measurement thread) to physical CPU 0
+    }
+    create_job_que()   // child process exit restores affinity; runtime snapshot also reads its lane count
+    let affinity_desc = affinity_inherited ? "DAS_JOBQUE_AFFINITY={get_env_variable("DAS_JOBQUE_AFFINITY")}" : "hard CPU0 (tuner default)"
+    print("kernel tuner: {FAST_MODE ? "FAST" : "default"}, N={N}, {SCREEN_ROUNDS} full-grid screening rounds, finalists up to {ROUNDS} rounds x {REPS} reps, measurement affinity {affinity_desc}\n\n")
 
     // add / mul / copy share the (var d, s) signature — one bench, per-kernel data + reference.
     var add_d0 : array<float>
@@ -1760,31 +1866,81 @@ def main {
     let mul_vs <- mul_inplace_template_variants()
     let cpy_vs <- copy_floats_template_variants()
 
+    var kernel_t0 = ref_time_ticks()
     let dotw = bench_dot()
+    print("TUNE_KERNEL_TIME dot {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let axpyw = bench_axpy()
+    print("TUNE_KERNEL_TIME axpy {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let dotf16w = bench_dot_f16()
+    print("TUNE_KERNEL_TIME dot_f16 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let axpyf16w = bench_axpy_f16()
+    print("TUNE_KERNEL_TIME axpy_f16 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let cvt16w = bench_cvt_f32_to_f16()
+    print("TUNE_KERNEL_TIME cvt_f32_to_f16 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let cvt32w = bench_cvt_f16_to_f32()
+    print("TUNE_KERNEL_TIME cvt_f16_to_f32 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let addw = bench_binary("add_inplace", add_vs, add_d0, add_s, @@(a, b : float) : double => double(a) + double(b))
+    print("TUNE_KERNEL_TIME add_inplace {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let mulw = bench_binary("mul_inplace", mul_vs, mul_d0, mul_s, @@(a, b : float) : double => double(a) * double(b))
+    print("TUNE_KERNEL_TIME mul_inplace {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let scalew = bench_scale()
+    print("TUNE_KERNEL_TIME scale_inplace {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let copyw = bench_binary("copy_floats", cpy_vs, cpy_d0, cpy_s, @@(_a, b : float) : double => double(b))
+    print("TUNE_KERNEL_TIME copy_floats {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let softmaxw = bench_softmax()
+    print("TUNE_KERNEL_TIME softmax {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let rmsw = bench_rmsnorm()
+    print("TUNE_KERNEL_TIME rmsnorm {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let dq4w = bench_dot_q4()
+    print("TUNE_KERNEL_TIME dot_q4 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let dq8w = bench_dot_q8q8()
+    print("TUNE_KERNEL_TIME dot_q8q8 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let dq8kvw = bench_dot_q8kv()
+    print("TUNE_KERNEL_TIME dot_q8kv {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let dq8q8kvw = bench_dot_q8q8kv()
+    print("TUNE_KERNEL_TIME dot_q8q8kv {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let axq8kvw = bench_axpy_q8kv()
+    print("TUNE_KERNEL_TIME axpy_q8kv {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let cvtq8kvw = bench_cvt_q8kv_to_f32()
+    print("TUNE_KERNEL_TIME cvt_q8kv_to_f32 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let quantq8kvw = bench_quantize_q8kv_row()
+    print("TUNE_KERNEL_TIME quantize_q8kv_row {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let dmx4w = bench_dot_mx4q8()
+    print("TUNE_KERNEL_TIME dot_mx4q8 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let quantw = bench_quantize()
+    print("TUNE_KERNEL_TIME quantize_q8_0_into_ptr {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let quantbsw = bench_quantize_bs()
+    print("TUNE_KERNEL_TIME quantize_q8_0_bs_into_ptr {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let ropew = bench_rope_tab()
+    print("TUNE_KERNEL_TIME rope_scaled_neox_tab {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let gemmw = bench_gemm_tile()
+    print("TUNE_KERNEL_TIME gemm_f32_uk_4x16 {get_time_usec(kernel_t0) / 1000} ms\n")
+    kernel_t0 = ref_time_ticks()
     let laneqw = bench_laneq4x4()   // last: it pins the repack backend (sticks until process exit)
+    print("TUNE_KERNEL_TIME dot_q8q8_laneq4x4 {get_time_usec(kernel_t0) / 1000} ms\n")
 
     // Summary: which kernels the tuner re-tuned away from THEIR OWN shipped fallback (the
     // [tuned(fallback=...)] perm; bare [tuned] ships the vec8_u2 majority = BASELINE).

--- a/modules/dasLLAMA/tune_for_this_box.md
+++ b/modules/dasLLAMA/tune_for_this_box.md
@@ -110,13 +110,25 @@ stale — every reader treats it as absent, and the next tuner write resets it.
 
 ```
 bin/daslang -jit modules/dasLLAMA/harness/tune_kernels.das
+
+# quick mode: progressive 4/8-round screening, finalists stop at 20
+bin/daslang -jit modules/dasLLAMA/harness/tune_kernels.das -- --tune-fast
+
+# full generator + kernel scope (also available as `daspkg release --tune-fast`)
+bin/daslang -jit modules/dasLLAMA/harness/dasllama_tuner.das -- --tune-fast
 ```
 
 Sweeps every `[tuned]` kernel (15: the float elementwise set, softmax, rmsnorm, the quantized
 dots, the activation requant, the NEOX rope-table leaf, the fp32 GEMM tile, and — arm64+JIT
 only, clean skip elsewhere — the laneq4x4 tile) across the 20-permutation grid
-(`{plain, u2, u4, u8} ∪ {vec4,vec8,vec16,vec32} × {-, u2, u4, u8}`), interleaved best-of-N
-(80 rounds × 2000 reps at N=4096), correctness gate per variant (f64 reference; EXACT
+(`{plain, u2, u4, u8} ∪ {vec4,vec8,vec16,vec32} × {-, u2, u4, u8}`), interleaved best-of-N.
+The default screens the full valid grid for 20 rounds, retains the four fastest rows plus
+anything within 5% of the leader, and continues those finalists to at most 80 rounds.
+`--tune-fast` narrows progressively after rounds 4 and 8 and stops at 20. Every mode runs
+one unscored warm-up pass and rotates row order each round; the measured minimum remains the
+score. The measurement thread is hard-pinned by its child-process JobQue and is automatically
+unpinned when that tuner child exits. Each round runs 2000 reps at N=4096. The correctness
+gate per variant (f64 reference; EXACT
 quant/scale equality for the requant), reports each variant as %Δ vs that kernel's SHIPPED
 fallback perm (`vec8_u2` for most; dot_q8q8 ships `vec16`, dot_q4 `vec4_u4`, the tile k-loops
 `u2`, rmsnorm/requant `plain`), and UPSERTS the winners into the app sidecar's `"kernels"`

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -779,6 +779,7 @@ struct private TuneScopeDep {
     manifest : string               //!< the app tune sidecar the winners live in
     tuner : string                  //!< tuner harness path ("" = none declared)
     complete : bool                 //!< every [tune] kernel of this scope has a fresh sidecar entry
+    fallbacks : string              //!< fallback stamps selected by this same compile/host
 }
 
 struct private ReleaseDeps {
@@ -897,7 +898,7 @@ def private write_release_deps(prog : Program?) {
     deps.tune_scopes |> reserve(length(tstat))
     for (ts in tstat) {
         deps.tune_scopes |> push(TuneScopeDep(name = ts.name, manifest = ts.manifest,
-            tuner = ts.tuner, complete = ts.complete))
+            tuner = ts.tuner, complete = ts.complete, fallbacks = ts.fallbacks))
     }
     delete tstat
     let dst_path = cfg.list_shared_modules

--- a/modules/dasLLVM/daslib/llvm_tune.das
+++ b/modules/dasLLVM/daslib/llvm_tune.das
@@ -390,6 +390,7 @@ struct TuneScopeStatus {
     manifest : string   //!< the app sidecar the winners live in
     tuner : string      //!< tuner harness path ("" = none declared)
     complete : bool     //!< every [tune] kernel of this scope has a fresh sidecar entry
+    fallbacks : string  //!< ';'-joined fname=suffix stamps selected by this compile/host
 }
 
 //! Every declared scope in `prog` with its per-key completeness against the app sidecar,
@@ -426,6 +427,7 @@ def tune_scopes_status(prog : Program?) : array<TuneScopeStatus> {
     var rows : array<TuneScopeStatus>
     rows |> reserve(length(found))
     let mpath = tune_manifest_path()
+    var compileStatus <- collect_status(prog)
     for (sc in found) {
         var wanted : table<string>
         wanted |> insert(sc.modName)
@@ -440,12 +442,24 @@ def tune_scopes_status(prog : Program?) : array<TuneScopeStatus> {
                 module_kernel_fnames(mod, fnames)
             }
         }
+        var fallbacks : array<string>
+        for (fname in fnames) {
+            for (st in compileStatus) {
+                if (st.fname == fname && st.source != "manifest") {
+                    fallbacks |> push("{fname}={st.suffix}")
+                    break
+                }
+            }
+        }
         rows |> push(TuneScopeStatus(name = sc.scopeName, manifest = mpath,
             tuner = sc.tunerPath,
-            complete = tune_sidecar_entries_complete(mpath, join(fnames, ";"))))
+            complete = tune_sidecar_entries_complete(mpath, join(fnames, ";")),
+            fallbacks = join(fallbacks, ";")))
         delete wanted
         delete fnames
+        delete fallbacks
     }
+    delete compileStatus
     delete found
     delete seen
     return <- rows
@@ -1099,10 +1113,10 @@ def tune_restart_needed(scopeName : string; manifestPath : string; tunerPath : s
 // final stamped truth per [tune] function, read off the AST (the tune_suffix/tune_from args
 // stamp_llvm_code records) — no macro-state bank, so shared-context reuse across compiles
 // can't pollute it
-def private collect_status() : array<TuneStatus> {
+def private collect_status(prog : Program?) : array<TuneStatus> {
     var rows : array<TuneStatus>
     let sidecar = tune_manifest_path()
-    program_for_each_module(compiling_program()) $(mod) {
+    prog |> for_each_module() $(mod) {
         let modName = "{mod.name}"
         var scopeName = ""
         if (g_scopes |> key_exists(modName)) {
@@ -1148,7 +1162,7 @@ def private tune_policy_gated() : bool {
 // truth — emitted by policy runs AND by -exe builds (an artifact must be able to report
 // which perms it carries: log_tune_status / tune_status work inside a standalone exe)
 def private emit_status_init(var errors : string&) {
-    var rows <- collect_status()
+    var rows <- collect_status(get_ptr(compiling_program()))
     if (!empty(rows)) {
         var body : array<ExpressionPtr>
         body |> reserve(length(rows))

--- a/utils/daspkg/README.md
+++ b/utils/daspkg/README.md
@@ -38,7 +38,7 @@ daslang utils/daspkg/main.das -- install --global dasImgui
 | `build` | Build all C/C++ packages (cmake) |
 | `check` | Verify installed packages are present |
 | `doctor` | Check environment (git, cmake, gh) |
-| `release [--out <dir>]` | Bundle project as a redistributable standalone |
+| `release [--out <dir>] [--tune-fast]` | Bundle project as a redistributable standalone; tuning defaults to 20/80, with an opt-in quick 4/8/20 pass |
 | `introduce [url]` | Submit a package to the index via PR |
 | `withdraw <name>` | Remove a package from the index via PR |
 
@@ -56,6 +56,7 @@ All package commands accept `--global` / `-g` to operate on global modules.
 | `--json` | Machine-readable JSON output (`search`, `list`, `check`) |
 | `--branch <name>`, `-b <name>` | Install from a git branch (e.g. `master`) instead of a tag |
 | `--out <path>` | Output directory for `release` (default: current directory) |
+| `--tune-fast` | During `release`, tune with progressive 4/8-round screening and a 20-round cap instead of the default 20/80 budget |
 
 ## Global modules
 
@@ -112,7 +113,18 @@ def dependencies(version : string) {
 def build() {
     cmake_build()       // or: custom_build("make all"), or: no_build()
 }
+
+[export]
+def release() {
+    release_main("main.das")
+    release_include("assets/**")                 // release-owned; refreshed every time
+    release_include_if_missing("app.toml")       // user-owned after initialization
+}
 ```
+
+Use `release_include_if_missing` for editable deployment files. They are copied only when absent,
+excluded from `.daspkg_release.manifest`, and preserved even when upgrading from an older manifest
+that previously treated the same path as release-owned.
 
 All functions except `package()` are optional. A repo without `.das_package` gets a "dumb clone" — no version resolution, no deps, no build.
 

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -65,6 +65,10 @@ struct DaspkgArgs {
     @clarg_doc = "Output directory for `release` (default: current directory)"
     out : string = "."
 
+    @clarg_name = "tune-fast"
+    @clarg_doc = "Use the tuner's quick progressive 4/8-round screen / 20-round cap during `release`"
+    tune_fast : bool
+
     @clarg_name = "wasm"
     @clarg_doc = "Target wasm64 (memory64): `build --wasm` builds the wasm64 runtime + module archives; `release wasm` ships compiled .wasm artifacts"
     wasm : bool
@@ -1393,6 +1397,7 @@ struct private TuneScopeDep {
     manifest : string               //!< the app tune sidecar the winners live in
     tuner : string                  //!< tuner harness path ("" = none declared)
     complete : bool                 //!< every [tune] kernel of this scope has a fresh sidecar entry
+    fallbacks : string              //!< fallback stamps selected by this same compile/host
 }
 
 struct private ReleaseDeps {
@@ -1421,12 +1426,17 @@ def private read_release_deps(path : string; var deps : ReleaseDeps) : bool {
 
 // the exact env+cmd shape llvm_tune's policy rail uses for scope tuners (the env prefix
 // leads so the line never starts with a quote — cmd.exe strips a LEADING one)
-def private release_tuner_cmd(daslang : string; ts : TuneScopeDep) : string {
+def private release_tuner_cmd(daslang : string; ts : TuneScopeDep; tune_fast : bool) : string {
     let win = get_platform_name() == "windows"
     let envs = (win ?
-        "set \"DAS_TUNE_MODE=tune\"&& set \"DAS_TUNE_MANIFEST={ts.manifest}\"&& " :
-        "DAS_TUNE_MODE=tune DAS_TUNE_MANIFEST=\"{ts.manifest}\" ")
-    return "{envs}\"{daslang}\" -jit \"{ts.tuner}\" -dasroot \"{get_das_root()}\""
+        "set \"DAS_TUNE_MODE=tune\"&& set \"DAS_TUNE_MANIFEST={ts.manifest}\"&& set \"DAS_TUNE_COMPILE_FALLBACKS={ts.fallbacks}\"&& " :
+        "DAS_TUNE_MODE=tune DAS_TUNE_MANIFEST=\"{ts.manifest}\" DAS_TUNE_COMPILE_FALLBACKS=\"{ts.fallbacks}\" ")
+    let tune_args = tune_fast ? " -- --tune-fast" : ""
+    return "{envs}\"{daslang}\" -jit \"{ts.tuner}\" -dasroot \"{get_das_root()}\"{tune_args}"
+}
+
+def private release_elapsed(t0 : int64) : string {
+    return fmt(":.1f", float(double(get_time_usec(t0)) / 1000000.0lf))
 }
 
 // Bundle path for the standalone exe (daslang -exe appends `.exe` itself).
@@ -1513,7 +1523,8 @@ def private ship_dep_assets(pkg_dir, bundle_modules_dir : string; var shipped : 
     if (!fexist(dep_pkg_file)) return 0
     var dep_spec : PackageReleaseInfo
     if (!run_das_package_release(dep_pkg_file, dep_spec) ||
-        (empty(dep_spec.include_globs) && empty(dep_spec.native_dlls))) return 0
+        (empty(dep_spec.include_globs) && empty(dep_spec.include_if_missing_globs) &&
+            empty(dep_spec.native_dlls))) return 0
     let dep_name = base_name(pkg_dir)
     let dep_dst_dir = "{bundle_modules_dir}/{dep_name}"
     var dep_files : array<string>
@@ -1536,6 +1547,28 @@ def private ship_dep_assets(pkg_dir, bundle_modules_dir : string; var shipped : 
     }
     if (!empty(dep_files)) {
         log("  ship dep `{dep_name}`: {length(dep_files)} file(s)\n")
+    }
+    var dep_starter_files : array<string>
+    glob_filtered(pkg_dir, dep_spec.include_if_missing_globs, dep_spec.exclude_globs) $(rel_path, is_dir) {
+        if (!is_dir) {
+            dep_starter_files |> push_clone(rel_path)
+        }
+    }
+    var dep_starter_copies = 0
+    for (rel in dep_starter_files) {
+        let src = path_join(pkg_dir, rel)
+        let dst = path_join(dep_dst_dir, rel)
+        if (fexist(dst)) continue
+        mkdir_rec(dir_name(dst))
+        var err : string
+        if (!copy_file(src, dst, false, err)) {
+            to_log(LOG_ERROR, "release: copy_file({src} -> {dst}) failed: {err}\n")
+            return 1
+        }
+        dep_starter_copies++
+    }
+    if (dep_starter_copies > 0) {
+        log("  initialize dep `{dep_name}`: {dep_starter_copies} user-owned file(s)\n")
     }
     if (!empty(dep_spec.native_dlls)) {
         let rc = ship_native_dlls(dep_name, dep_dst_dir, dep_spec.native_dlls, shipped, "modules/{dep_name}/")
@@ -1908,7 +1941,15 @@ def private ship_native_dlls(dep_name, dst_dir : string; native_dlls : array<str
 // <name>.toml config, logs — that the old whole-dir wipe destroyed on every re-release.
 let RELEASE_MANIFEST = ".daspkg_release.manifest"
 
-def private clean_previous_release(bundle_dir : string) {
+def private release_path_is_preserved(rel : string; preserve_paths : array<string>) : bool {
+    let generic_rel = to_generic_path(rel)
+    for (p in preserve_paths) {
+        if (to_generic_path(p) == generic_rel) return true
+    }
+    return false
+}
+
+def private clean_previous_release(bundle_dir : string; preserve_paths : array<string>) {
     let mpath = path_join(bundle_dir, RELEASE_MANIFEST)
     if (!fexist(mpath)) {
         return   // first release into this dir (or a pre-manifest bundle): nothing to clean
@@ -1920,9 +1961,12 @@ def private clean_previous_release(bundle_dir : string) {
     }
     for (line in split(body, "\n")) {
         let rel = strip(line)
+        // A file may have been release-owned by an older package manifest and become
+        // release_include_if_missing now. Preserve that deployed copy during migration.
         // skip blanks; stay inside the bundle even on a corrupt or hostile manifest —
         // reject `..`, drive colons, and both absolute spellings (`/x`, `\x` = drive root)
-        if (empty(rel) || find(rel, "..") >= 0 || starts_with(rel, "/") || starts_with(rel, "\\") || find(rel, ":") >= 0) {
+        if (empty(rel) || find(rel, "..") >= 0 || starts_with(rel, "/") || starts_with(rel, "\\")
+                || find(rel, ":") >= 0 || release_path_is_preserved(rel, preserve_paths)) {
             continue
         }
         let p = path_join(bundle_dir, rel)
@@ -1951,7 +1995,8 @@ def private get_daslang_path() : string {
     return get_platform_name() == "windows" ? replace(joined, "/", "\\") : joined
 }
 
-def cmd_release(root : string; out_dir : string) : int {
+def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
+    let release_t0 = ref_time_ticks()
     // Reset the patchelf availability cache so a daspkg process that releases
     // multiple bundles can pick up a patchelf install between calls.
     patchelf_state = -1
@@ -1998,6 +2043,12 @@ def cmd_release(root : string; out_dir : string) : int {
     let is_mac_app = get_platform_name() == "darwin"
     let app_root = is_mac_app ? path_join(out_dir, "{bundle_name}.app") : ""
     let bundle_dir = is_mac_app ? path_join(app_root, "Contents/MacOS") : path_join(out_dir, bundle_name)
+    var preserve_project_files : array<string>
+    glob_filtered(root, spec.include_if_missing_globs, spec.exclude_globs) $(rel_path, is_dir) {
+        if (!is_dir) {
+            preserve_project_files |> push_clone(rel_path)
+        }
+    }
     // The macOS .app is wholly daspkg-owned: full wipe. A flat bundle dir is NOT — it
     // accumulates user files next to daspkg's output — so it cleans via the previous
     // release's manifest instead (empty dirs from removed deps may linger; harmless).
@@ -2006,7 +2057,7 @@ def cmd_release(root : string; out_dir : string) : int {
             force_rmdir(app_root)
         }
     } elif (fexist(bundle_dir)) {
-        clean_previous_release(bundle_dir)
+        clean_previous_release(bundle_dir, preserve_project_files)
     }
     mkdir_rec(bundle_dir)
     var shipped : array<string>   // bundle-relative paths -> RELEASE_MANIFEST at the end
@@ -2031,6 +2082,7 @@ def cmd_release(root : string; out_dir : string) : int {
         }
     }
     let cmd = "\"{daslang}\" -exe -output \"{exe_path}\" --list-shared-modules \"{deps_file}\"{force_args} \"{main_path}\""
+    let build_t0 = ref_time_ticks()
     let rc = run_cmd(cmd, output)
     if (rc != 0) {
         to_log(LOG_ERROR, "release: daslang -exe failed (rc={rc}):\n{output}\n")
@@ -2039,6 +2091,7 @@ def cmd_release(root : string; out_dir : string) : int {
         }
         return 1
     }
+    log("  build: standalone exe in {release_elapsed(build_t0)}s\n")
     // 1.5 Build-time tuning: the deps JSON reports each [tune_scope] with per-key
     //     completeness against the app sidecar. Run the tuners of incomplete scopes and
     //     REBUILD, so the shipped exe bakes measured winners instead of the generic
@@ -2055,16 +2108,20 @@ def cmd_release(root : string; out_dir : string) : int {
                     continue
                 }
                 log("  tune: scope `{ts.name}` -> {ts.manifest}\n")
+                let tune_t0 = ref_time_ticks()
                 var tout : string
-                let trc = run_cmd(release_tuner_cmd(daslang, ts), tout)
+                let trc = run_cmd(release_tuner_cmd(daslang, ts, tune_fast), tout)
+                let tune_seconds = release_elapsed(tune_t0)
                 if (trc != 0) {
-                    to_log(LOG_WARNING, "release: tuner for scope `{ts.name}` failed (rc={trc}) — shipping fallback stamps\n{tout}\n")
+                    to_log(LOG_WARNING, "release: tuner for scope `{ts.name}` failed after {tune_seconds}s (rc={trc}) — shipping fallback stamps\n{tout}\n")
                 } else {
+                    log("  tune: scope `{ts.name}` finished in {tune_seconds}s\n")
                     tuned_any = true
                 }
             }
             if (tuned_any) {
                 log("  rebuild: baking the fresh tune winners into the exe\n")
+                let rebuild_t0 = ref_time_ticks()
                 var out2 : string
                 let rc2 = run_cmd(cmd, out2)
                 if (rc2 != 0) {
@@ -2074,6 +2131,7 @@ def cmd_release(root : string; out_dir : string) : int {
                     }
                     return 1
                 }
+                log("  rebuild: standalone exe in {release_elapsed(rebuild_t0)}s\n")
             }
         }
     }
@@ -2235,6 +2293,31 @@ def cmd_release(root : string; out_dir : string) : int {
     if (!empty(asset_files)) {
         log("  shipped {length(asset_files)} project asset file(s)\n")
     }
+    // Mutable starter files are copied only for a new deployment. They are
+    // intentionally not added to `shipped`, so the next manifest cleanup
+    // treats the deployed copy as user-owned and leaves it alone.
+    var starter_files : array<string>
+    glob_filtered(root, spec.include_if_missing_globs, spec.exclude_globs) $(rel_path, is_dir) {
+        if (!is_dir) {
+            starter_files |> push_clone(rel_path)
+        }
+    }
+    var starter_copies = 0
+    for (rel_path in starter_files) {
+        let src = path_join(root, rel_path)
+        let dst = path_join(bundle_dir, rel_path)
+        if (fexist(dst)) continue
+        mkdir_rec(dir_name(dst))
+        var err : string
+        if (!copy_file(src, dst, false, err)) {
+            to_log(LOG_ERROR, "release: copy_file({src} -> {dst}) failed: {err}\n")
+            return 1
+        }
+        starter_copies++
+    }
+    if (starter_copies > 0) {
+        log("  initialized {starter_copies} user-owned project file(s)\n")
+    }
     // Project-declared native deps land next to the exe (the project has no
     // .shared_module to colocate with — its deps are loaded directly by the exe).
     if (!empty(spec.native_dlls)) {
@@ -2259,7 +2342,7 @@ def cmd_release(root : string; out_dir : string) : int {
             return 1
         }
         log("  wrote: Contents/Info.plist (CFBundleIdentifier={bundle_id})\n")
-        log("Released to: {app_root}\n")
+        log("Released to: {app_root} ({release_elapsed(release_t0)}s)\n")
     } else {
         let mbody = build_string() $(var writer) {
             for (s in shipped) {
@@ -2271,7 +2354,7 @@ def cmd_release(root : string; out_dir : string) : int {
             to_log(LOG_ERROR, "release: cannot write {RELEASE_MANIFEST}\n")
             return 1
         }
-        log("Released to: {bundle_dir}\n")
+        log("Released to: {bundle_dir} ({release_elapsed(release_t0)}s)\n")
     }
     return 0
 }

--- a/utils/daspkg/fixtures/test_release.das_package
+++ b/utils/daspkg/fixtures/test_release.das_package
@@ -13,6 +13,7 @@ def release() {
     release_main("main.das")
     release_include("*.png")
     release_include("data/**/*.json")
+    release_include_if_missing("config/*.toml")
     release_exclude("data/internal/**")
     release_shared_module("dasSQLITE")
     release_shared_module("dasGlfw")

--- a/utils/daspkg/main.das
+++ b/utils/daspkg/main.das
@@ -31,7 +31,8 @@ def print_usage() {
     print("  check                              Verify installed packages\n")
     print("  cleanup                            Remove modules/ and daspkg.lock for a fresh install\n")
     print("  doctor                             Check environment (git, cmake, gh)\n")
-    print("  release [--out <dir>]              Bundle project as a redistributable standalone\n\n")
+    print("  release [--out <dir>] [--tune-fast]\n")
+    print("                                       Bundle project as a redistributable standalone\n\n")
     print(format_help_with_auto_help(get_command_info(type<DaspkgArgs>), "daspkg"))
 }
 
@@ -110,7 +111,7 @@ def main() {
         if (command_arg == "wasm") {
             rc = cmd_release_wasm(root, parsed.out, parsed.wasm_lib_dir)
         } else {
-            rc = cmd_release(root, parsed.out)
+            rc = cmd_release(root, parsed.out, parsed.tune_fast)
         }
     } elif (command == "doctor") {
         rc = cmd_doctor()

--- a/utils/daspkg/package_runner.das
+++ b/utils/daspkg/package_runner.das
@@ -35,6 +35,7 @@ struct PackageReleaseInfo {
     main_script : string
     wasm_main_script : string
     include_globs : array<string>
+    include_if_missing_globs : array<string>
     exclude_globs : array<string>
     forced_modules : array<string>
     native_dlls : array<string>
@@ -121,6 +122,9 @@ def run_das_package_release(das_package_path : string; var info : PackageRelease
             info.wasm_main_script = clone_string(src.wasm_main_script)
             for (g in src.include_globs) {
                 info.include_globs |> push_clone(clone_string(g))
+            }
+            for (g in src.include_if_missing_globs) {
+                info.include_if_missing_globs |> push_clone(clone_string(g))
             }
             for (g in src.exclude_globs) {
                 info.exclude_globs |> push_clone(clone_string(g))

--- a/utils/daspkg/test_daspkg.das
+++ b/utils/daspkg/test_daspkg.das
@@ -194,6 +194,14 @@ def test_parse_args(t : T?) {
         t |> equal(parsed.command ?? "", "list")
         t |> success(parsed.command_arg |> is_none)
     }
+    t |> run("release with fast tuning") @(t : T?) {
+        var r <- parse_args(type<DaspkgArgs>, ["release", "--out", "E:/", "--tune-fast"])
+        t |> success(r |> is_ok, "parse succeeds")
+        let parsed <- r |> move_unwrap
+        t |> equal(parsed.command ?? "", "release")
+        t |> equal(parsed.out, "E:/")
+        t |> success(parsed.tune_fast)
+    }
     t |> run("no command") @(t : T?) {
         let empty_args : array<string>
         var r <- parse_args(type<DaspkgArgs>, empty_args)
@@ -1694,6 +1702,8 @@ def test_run_das_package_release(t : T?) {
         tt |> equal(2, length(info.include_globs))
         tt |> equal("*.png", info.include_globs[0])
         tt |> equal("data/**/*.json", info.include_globs[1])
+        tt |> equal(1, length(info.include_if_missing_globs))
+        tt |> equal("config/*.toml", info.include_if_missing_globs[0])
         tt |> equal(1, length(info.exclude_globs))
         tt |> equal("data/internal/**", info.exclude_globs[0])
         tt |> equal(2, length(info.forced_modules))
@@ -1726,10 +1736,13 @@ def test_cmd_release_pure_daslang(t : T?) {
             fwrite(f, "options gen2\n[export]\ndef main() \{\n    print(\"hello\\n\")\n\}\n")
         }
         fopen("{tmp_root}/.das_package", "wb") $(f) {
-            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"smoke\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n    release_include(\"*.txt\")\n\}\n")
+            fwrite(f, "options gen2\nrequire daslib/daspkg\n[export]\ndef package() \{\n    package_name(\"smoke\")\n\}\n[export]\ndef release() \{\n    release_main(\"main.das\")\n    release_include(\"*.txt\")\n    release_include_if_missing(\"config.toml\")\n\}\n")
         }
         fopen("{tmp_root}/data.txt", "wb") $(f) {
             fwrite(f, "asset")
+        }
+        fopen("{tmp_root}/config.toml", "wb") $(f) {
+            fwrite(f, "value = \"template\"\n")
         }
 
         let rc = cmd_release(tmp_root, out_dir)
@@ -1738,7 +1751,28 @@ def test_cmd_release_pure_daslang(t : T?) {
         let artifacts = bundle_artifacts_dir(out_dir, "smoke")
         tt |> success(fexist(exe_path), "exe shipped at {exe_path}")
         tt |> success(fexist(path_join(artifacts, "data.txt")), "asset shipped")
+        let deployed_config = path_join(artifacts, "config.toml")
+        tt |> equal("value = \"template\"\n", fread(deployed_config), "starter config shipped on first release")
         tt |> success(!fexist(path_join(artifacts, "smoke.o")), ".o build artifact dropped")
+
+        fopen(deployed_config, "wb") $(f) {
+            fwrite(f, "value = \"user-edited\"\n")
+        }
+        // Simulate upgrading from the old release_include("config.toml")
+        // behavior: the previous manifest still claims ownership. The new
+        // if-missing declaration must protect the deployed edit during that
+        // one-time migration cleanup.
+        let old_manifest = path_join(artifacts, ".daspkg_release.manifest")
+        fopen(old_manifest, "ab") $(f) {
+            fwrite(f, "config.toml\n")
+        }
+        let rc2 = cmd_release(tmp_root, out_dir)
+        tt |> equal(0, rc2, "second cmd_release returns 0")
+        tt |> equal("value = \"user-edited\"\n", fread(deployed_config),
+            "release_include_if_missing preserves deployed edits")
+        let manifest = fread(old_manifest)
+        tt |> success(find(manifest, "config.toml") < 0,
+            "user-owned starter config is omitted from release manifest")
 
         force_rmdir(tmp_root)
         force_rmdir(out_dir)


### PR DESCRIPTION
## Summary
- preserve existing deployment config files during daspkg release while still installing defaults when absent
- make dasLLAMA tuning deterministic and faster with minimum-time scoring, rotating candidates, warmup, pinned measurement affinity, and a fast mode
- add tune timing/fallback handoff coverage plus release regression tests and documentation

## Verification
- full preflight: 13 passed, 0 failed, 4 environment/no-change skips
- focused daspkg release regressions: 5/5 passed
- argument parsing tests: 19/19 passed
- released dasllama-server and dictation-bot to E: with existing TOML files preserved; services left stopped