### PR TITLE
dasLLAMA: the prepared-model image (.dlim) — 70B gguf load 78.7 s → 34 ms map

### DIFF
--- a/daslib/archive.das
+++ b/daslib/archive.das
@@ -66,7 +66,9 @@ class public MemSerializer : Serializer {
         let newOffset = readOffset + size
         let maxOffset = length(data)
         if (newOffset > maxOffset) {
-            error("reading past the end of stream")
+            // self-> matters: a bare error(...) resolves to the BUILTIN error (a stderr
+            // print), leaving lastError unset — OK() then reports a truncated stream as fine
+            self->error("reading past the end of stream")   // nolint:STYLE028 — dropping self-> rebinds to the builtin, probe-verified 2026-07-17
             readOffset = maxOffset
             return false
         }

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -93,8 +93,10 @@ def fsave(f : file; buf : auto(BufType) const) {
         let len = int(len64)
         let dfh = df_header(magic = df_magic, size = len)
         r1 = _builtin_write(f, dfh, typeinfo sizeof(type<df_header>))
-        unsafe {
-            r2 = _builtin_write(f, addr(data[0]), len)
+        if (len > 0) {   // addr(data[0]) on an empty payload is out of bounds
+            unsafe {
+                r2 = _builtin_write(f, addr(data[0]), len)
+            }
         }
     }
     if (r1 < 0) return r1

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -109,9 +109,28 @@ def fread(f : file; buf : auto(BufType) const implicit) {
 [generic]
 def fread(f : file; buf : array<auto(BufType)> const implicit) {
     concept_assert(typeinfo is_raw(type<BufType>), "'fread' accepts only raw POD type arrays")
-    unsafe {
-        return _builtin_read(f, addr(buf[0]), length(buf) * (typeinfo sizeof(type<BufType>)))
+    let nbytes = long_length(buf) * typeinfo sizeof(type<BufType>)
+    if (nbytes <= int64(INT_MAX)) {
+        unsafe {
+            return _builtin_read(f, addr(buf[0]), int(nbytes))
+        }
     }
+    // past 2 GiB an int32 byte count wraps negative and the C runtime sign-extends it to a
+    // huge size_t — out-of-bounds. Chunk in int64; the return clamps to INT_MAX by necessity.
+    var p = unsafe(addr<uint8?>(buf[0]))
+    var done = 0l
+    while (done < nbytes) {
+        let chunk = min(nbytes - done, int64(0x40000000))
+        var got = 0
+        unsafe {
+            got = _builtin_read(f, p + done, int(chunk))
+        }
+        done += int64(got)
+        if (int64(got) != chunk) {
+            break
+        }
+    }
+    return int(min(done, int64(INT_MAX)))
 }
 
 [generic]
@@ -125,9 +144,29 @@ def fwrite(f : file; buf : auto(BufType) const implicit) {
 [generic]
 def fwrite(f : file; buf : array<auto(BufType)> const implicit) {
     concept_assert(typeinfo is_raw(type<BufType>), "'fwrite' accepts only raw POD type arrays")
-    unsafe {
-        return _builtin_write(f, addr(buf[0]), length(buf) * (typeinfo sizeof(type<BufType>)))
+    let nbytes = long_length(buf) * typeinfo sizeof(type<BufType>)
+    if (nbytes <= int64(INT_MAX)) {
+        unsafe {
+            return _builtin_write(f, addr(buf[0]), int(nbytes))
+        }
     }
+    // past 2 GiB an int32 byte count wraps negative and the C runtime sign-extends it to a
+    // huge size_t — fwrite then streams heap garbage past the buffer into the file, silently.
+    // Chunk in int64; the return clamps to INT_MAX by necessity.
+    var p = unsafe(addr<uint8?>(buf[0]))
+    var done = 0l
+    while (done < nbytes) {
+        let chunk = min(nbytes - done, int64(0x40000000))
+        var wrote = 0
+        unsafe {
+            wrote = _builtin_write(f, p + done, int(chunk))
+        }
+        done += int64(wrote)
+        if (int64(wrote) != chunk) {
+            break
+        }
+    }
+    return int(min(done, int64(INT_MAX)))
 }
 
 [generic]

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -71,7 +71,7 @@ def fload(file : file; size : int64; blk : block<(data : array<uint8>) : void>) 
 def fload(f : file; buf : auto(BufType) -const) {
     var dfh : df_header
     let r1 = _builtin_read(f, dfh, typeinfo sizeof(type<df_header>))
-    if (r1 < 0 || dfh.magic != df_magic) return false
+    if (r1 < 0 || dfh.magic != df_magic || dfh.size < 0) return false
     var loaded = false
     _builtin_load(f, int64(dfh.size)) $(data : array<uint8>) {
         if (length(data) != 0) {
@@ -86,7 +86,11 @@ def fload(f : file; buf : auto(BufType) -const) {
 def fsave(f : file; buf : auto(BufType) const) {
     var r1, r2 : int
     binary_save(buf) $(data) {
-        let len = length(data)
+        let len64 = long_length(data)
+        if (len64 > int64(INT_MAX)) {
+            panic("fsave: {len64}-byte payload does not fit the df_header int size field")
+        }
+        let len = int(len64)
         let dfh = df_header(magic = df_magic, size = len)
         r1 = _builtin_write(f, dfh, typeinfo sizeof(type<df_header>))
         unsafe {
@@ -110,27 +114,22 @@ def fread(f : file; buf : auto(BufType) const implicit) {
 def fread(f : file; buf : array<auto(BufType)> const implicit) {
     concept_assert(typeinfo is_raw(type<BufType>), "'fread' accepts only raw POD type arrays")
     let nbytes = long_length(buf) * typeinfo sizeof(type<BufType>)
-    if (nbytes <= int64(INT_MAX)) {
-        unsafe {
-            return _builtin_read(f, addr(buf[0]), int(nbytes))
-        }
+    if (nbytes > int64(INT_MAX)) {
+        panic("fread: {nbytes} bytes does not fit the int byte count — use long_fread")
     }
-    // past 2 GiB an int32 byte count wraps negative and the C runtime sign-extends it to a
-    // huge size_t — out-of-bounds. Chunk in int64; the return clamps to INT_MAX by necessity.
-    var p = unsafe(addr<uint8?>(buf[0]))
-    var done = 0l
-    while (done < nbytes) {
-        let chunk = min(nbytes - done, int64(0x40000000))
-        var got = 0
-        unsafe {
-            got = _builtin_read(f, p + done, int(chunk))
-        }
-        done += int64(got)
-        if (int64(got) != chunk) {
-            break
-        }
+    unsafe {
+        return _builtin_read(f, addr(buf[0]), int(nbytes))
     }
-    return int(min(done, int64(INT_MAX)))
+}
+
+//! 64-bit fread: fills the whole array regardless of size (fread panics past 2 GiB).
+//! Returns bytes read as int64.
+[generic]
+def long_fread(f : file; buf : array<auto(BufType)> const implicit) : int64 {
+    concept_assert(typeinfo is_raw(type<BufType>), "'long_fread' accepts only raw POD type arrays")
+    unsafe {
+        return _builtin_read64(f, addr(buf[0]), long_length(buf) * typeinfo sizeof(type<BufType>))
+    }
 }
 
 [generic]
@@ -145,28 +144,22 @@ def fwrite(f : file; buf : auto(BufType) const implicit) {
 def fwrite(f : file; buf : array<auto(BufType)> const implicit) {
     concept_assert(typeinfo is_raw(type<BufType>), "'fwrite' accepts only raw POD type arrays")
     let nbytes = long_length(buf) * typeinfo sizeof(type<BufType>)
-    if (nbytes <= int64(INT_MAX)) {
-        unsafe {
-            return _builtin_write(f, addr(buf[0]), int(nbytes))
-        }
+    if (nbytes > int64(INT_MAX)) {
+        panic("fwrite: {nbytes} bytes does not fit the int byte count — use long_fwrite")
     }
-    // past 2 GiB an int32 byte count wraps negative and the C runtime sign-extends it to a
-    // huge size_t — fwrite then streams heap garbage past the buffer into the file, silently.
-    // Chunk in int64; the return clamps to INT_MAX by necessity.
-    var p = unsafe(addr<uint8?>(buf[0]))
-    var done = 0l
-    while (done < nbytes) {
-        let chunk = min(nbytes - done, int64(0x40000000))
-        var wrote = 0
-        unsafe {
-            wrote = _builtin_write(f, p + done, int(chunk))
-        }
-        done += int64(wrote)
-        if (int64(wrote) != chunk) {
-            break
-        }
+    unsafe {
+        return _builtin_write(f, addr(buf[0]), int(nbytes))
     }
-    return int(min(done, int64(INT_MAX)))
+}
+
+//! 64-bit fwrite: writes the whole array regardless of size (fwrite panics past 2 GiB).
+//! Returns bytes written as int64.
+[generic]
+def long_fwrite(f : file; buf : array<auto(BufType)> const implicit) : int64 {
+    concept_assert(typeinfo is_raw(type<BufType>), "'long_fwrite' accepts only raw POD type arrays")
+    unsafe {
+        return _builtin_write64(f, addr(buf[0]), long_length(buf) * typeinfo sizeof(type<BufType>))
+    }
 }
 
 [generic]

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -113,6 +113,7 @@ def fread(f : file; buf : auto(BufType) const implicit) {
 [generic]
 def fread(f : file; buf : array<auto(BufType)> const implicit) {
     concept_assert(typeinfo is_raw(type<BufType>), "'fread' accepts only raw POD type arrays")
+    return 0 if (empty(buf))   // a 0-byte read; addr(buf[0]) on an empty array is out of bounds
     let nbytes = long_length(buf) * typeinfo sizeof(type<BufType>)
     if (nbytes > int64(INT_MAX)) {
         panic("fread: {nbytes} bytes does not fit the int byte count — use long_fread")
@@ -127,6 +128,7 @@ def fread(f : file; buf : array<auto(BufType)> const implicit) {
 [generic]
 def long_fread(f : file; buf : array<auto(BufType)> const implicit) : int64 {
     concept_assert(typeinfo is_raw(type<BufType>), "'long_fread' accepts only raw POD type arrays")
+    return 0l if (empty(buf))   // a 0-byte read; addr(buf[0]) on an empty array is out of bounds
     unsafe {
         return _builtin_read64(f, addr(buf[0]), long_length(buf) * typeinfo sizeof(type<BufType>))
     }
@@ -143,6 +145,7 @@ def fwrite(f : file; buf : auto(BufType) const implicit) {
 [generic]
 def fwrite(f : file; buf : array<auto(BufType)> const implicit) {
     concept_assert(typeinfo is_raw(type<BufType>), "'fwrite' accepts only raw POD type arrays")
+    return 0 if (empty(buf))   // a 0-byte write; addr(buf[0]) on an empty array is out of bounds
     let nbytes = long_length(buf) * typeinfo sizeof(type<BufType>)
     if (nbytes > int64(INT_MAX)) {
         panic("fwrite: {nbytes} bytes does not fit the int byte count — use long_fwrite")
@@ -157,6 +160,7 @@ def fwrite(f : file; buf : array<auto(BufType)> const implicit) {
 [generic]
 def long_fwrite(f : file; buf : array<auto(BufType)> const implicit) : int64 {
     concept_assert(typeinfo is_raw(type<BufType>), "'long_fwrite' accepts only raw POD type arrays")
+    return 0l if (empty(buf))   // a 0-byte write; addr(buf[0]) on an empty array is out of bounds
     unsafe {
         return _builtin_write64(f, addr(buf[0]), long_length(buf) * typeinfo sizeof(type<BufType>))
     }

--- a/doc/source/stdlib/handmade/function-fio-fmap_close-0x346879859533802d.rst
+++ b/doc/source/stdlib/handmade/function-fio-fmap_close-0x346879859533802d.rst
@@ -1,0 +1,1 @@
+Unmaps a mapping produced by ``fmap_open``. ``data`` and ``size`` must be exactly the base pointer and byte count that ``fmap_open`` returned; every pointer or borrowed view into the mapping is invalid after the call.

--- a/doc/source/stdlib/handmade/function-fio-fmap_open-0x714a3315cb03fcef.rst
+++ b/doc/source/stdlib/handmade/function-fio-fmap_open-0x714a3315cb03fcef.rst
@@ -1,0 +1,1 @@
+Memory-maps the file at ``path`` read-only and returns the mapping's base pointer, writing the mapped byte count through ``size``. Unlike ``fmap`` the mapping is not scope-bound: it stays valid until passed to ``fmap_close``, so long-lived borrowed views (e.g. dasLLAMA's prepared-model images) can be built over it. Returns null when the file cannot be opened or mapped.

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -183,6 +183,7 @@ namespace das {
         friend DAS_API int builtin_array_lock_count ( const Array & arr );
         friend DAS_API void array_mark_locked(Array &arr, void *data, uint64_t capacity);
         friend DAS_API void array_mark_locked(Array &arr, void *data, uint64_t size, uint64_t capacity);
+        friend DAS_API bool array_forget_locked(Array &arr);
         friend DAS_API void array_lock(Context &context, Array &arr, LineInfo *at);
         friend DAS_API void array_unlock(Context &context, Array &arr, LineInfo *at);
         friend DAS_API void table_lock(Context &context, Table &arr, LineInfo *at);

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -168,6 +168,7 @@ namespace das {
                 bool hopeless : 1;          // needs to be deleted without fuss (exceptions)
                 bool forego_lock_check : 1; // don't need to check if elements are locked
                 bool tableNoHash : 1;       // Table only: key type stores no per-slot hash (non-string) - see tableHashSlotBytes
+                bool borrowed : 1;          // a mark_locked view over foreign storage (fmap/temp_array) — array_forget_locked requires it, so an owned array that merely holds a lock can never be "forgotten" (leaked)
             };
             uint32_t flags;
         };

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -105,6 +105,7 @@ namespace das {
     DAS_API void builtin_temp_array ( void * data, int size, const Block & block, Context * context, LineInfoArg * lineinfo );
     DAS_API void builtin_make_temp_array ( Array & arr, void * data, int size );
     DAS_API void builtin_make_temp_array_i64 ( Array & arr, void * data, int64_t size );
+    DAS_API void builtin_forget_temp_array ( Array & arr, Context * context, LineInfoArg * at );
     DAS_API void builtin_array_free ( Array & dim, int szt, Context * __context__, LineInfoArg * at );
     DAS_API void builtin_table_free ( Table & tab, int szk, int szv, Context * __context__, LineInfoArg * at );
     DAS_API vec4f builtin_collect_local_and_zero ( Context & context, SimNode_CallBase * call, vec4f * args );

--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -83,6 +83,8 @@ namespace das {
     DAS_API int64_t builtin_fseek ( const FILE * f, int64_t offset, int32_t mode, Context * context, LineInfoArg * at );
     DAS_API vec4f builtin_read ( Context &, SimNode_CallBase * call, vec4f * args );
     DAS_API vec4f builtin_write ( Context &, SimNode_CallBase * call, vec4f * args );
+    DAS_API vec4f builtin_read64 ( Context &, SimNode_CallBase * call, vec4f * args );
+    DAS_API vec4f builtin_write64 ( Context &, SimNode_CallBase * call, vec4f * args );
     DAS_API vec4f builtin_load ( Context & context, SimNode_CallBase *, vec4f * args );
     DAS_API void builtin_map_file ( const FILE* _f, const TBlock<void, TTemporary<TArray<uint8_t>>>& blk, Context*, LineInfoArg * at );
     DAS_API void * builtin_fmap_open ( const char * name, uint64_t * size, Context * context, LineInfoArg * at );

--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -85,6 +85,8 @@ namespace das {
     DAS_API vec4f builtin_write ( Context &, SimNode_CallBase * call, vec4f * args );
     DAS_API vec4f builtin_load ( Context & context, SimNode_CallBase *, vec4f * args );
     DAS_API void builtin_map_file ( const FILE* _f, const TBlock<void, TTemporary<TArray<uint8_t>>>& blk, Context*, LineInfoArg * at );
+    DAS_API void * builtin_fmap_open ( const char * name, uint64_t * size, Context * context, LineInfoArg * at );
+    DAS_API void builtin_fmap_close ( void * data, uint64_t size, Context * context, LineInfoArg * at );
     DAS_API char * builtin_dirname ( const char * name, Context * context, LineInfoArg * at );
     DAS_API char * builtin_basename ( const char * name, Context * context, LineInfoArg * at );
     DAS_API bool builtin_fstat ( const FILE * f, FStat & fs, Context * context, LineInfoArg * at );

--- a/modules/dasLLAMA/.das_module
+++ b/modules/dasLLAMA/.das_module
@@ -6,7 +6,7 @@ def initialize(project_path : string) {
     let dasllama_paths = [
         "dasllama_par", "dasllama_tune", "dasllama_math", "dasllama_math_default", "dasllama_math_aarch64_neon", "dasllama_math_gen", "dasllama_math_metal", "dasllama_metal_common", "dasllama_metal_kernels", "dasllama_metal_prefill", "dasllama_metal_llama", "dasllama_gemm_gen", "dasllama_gemm_register", "dasllama_gemm_schema", "dasllama_quant", "dasllama_gguf",
         "dasllama_unicode", "dasllama_tokenizer", "dasllama_bpe", "dasllama_common", "dasllama_prefix", "dasllama_audio", "dasllama_audio_io", "dasllama_whisper", "dasllama_qwen3a", "dasllama_parakeet", "dasllama_canary", "dasllama_gemma4a", "dasllama_vad", "dasllama_asr",
-        "dasllama_arch_llama", "dasllama_arch_qwen2", "dasllama_arch_qwen3", "dasllama_arch_phi3", "dasllama_arch_gemma2", "dasllama_arch_gemma3", "dasllama_arch_gemma4", "dasllama_arch_qwen2moe", "dasllama_arch_qwen3moe", "dasllama_arch_qwen35", "dasllama_arch_gptoss", "dasllama_arch_mistral3", "dasllama_arch_glm4moe",
+        "dasllama_arch_llama", "dasllama_arch_qwen2", "dasllama_arch_qwen3", "dasllama_arch_phi3", "dasllama_arch_gemma2", "dasllama_arch_gemma3", "dasllama_arch_gemma4", "dasllama_arch_qwen2moe", "dasllama_arch_qwen3moe", "dasllama_arch_qwen35", "dasllama_arch_gptoss", "dasllama_arch_mistral3", "dasllama_arch_glm4moe", "dasllama_image",
         "dasllama_transformer", "dasllama_chat", "dasllama"
     ]
     for (path in dasllama_paths) {

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -47,7 +47,8 @@ def load_model(path : string; mode : QuantMode = QuantMode.fp32) : Model {
     //! Q8 loads keep a PREPARED IMAGE next to the gguf (box + knob specific): the first load
     //! saves it, later loads map it in milliseconds with zero-copy weight planes.
     //! ``DASLLAMA_IMAGE=0`` disables the cache. Passing a ``.dlim`` path loads that image
-    //! DIRECTLY (no gguf needed — wrong identity panics; there is nothing to regenerate from).
+    //! DIRECTLY (no gguf needed — wrong identity panics; there is nothing to regenerate from);
+    //! the image's baked-in quantization applies and ``mode`` is ignored on that path.
     if (path |> ends_with(".dlim")) {
         // a prepared image named directly — first-class once the source gguf is gone. No
         // fallback exists here, so a wrong box/knob/version identity panics instead of hiding.

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -16,6 +16,8 @@ options gen2
 module dasllama shared public
 
 require dasllama/dasllama_transformer public   // the engine + arch registry; every arch [init] fires
+require dasllama/dasllama_image   // the prepared-image cache: load_model maps it when present
+require daslib/fio   // the DASLLAMA_IMAGE kill switch
 require dasllama/dasllama_prefix public        // page-granular prefix cache over the paged pool
 require dasllama/dasllama_chat public          // layer 2: chat sessions over the same engine
 require dasllama/dasllama_audio public         // audio tower (mel frontend + whisper encoder + projectors)
@@ -41,6 +43,25 @@ def load_model(path : string; mode : QuantMode = QuantMode.fp32) : Model {
     //! Load a model AND its tokenizer from a GGUF file — the one entry point. The architecture and
     //! tokenizer backend are auto-selected from GGUF metadata; ``mode`` picks the weight quantization
     //! (``QuantMode.fp32`` = the token-exact reference, ``QuantMode.q8`` = the fast int8 path).
+    //! Q8 loads keep a PREPARED IMAGE next to the gguf (box + knob specific): the first load
+    //! saves it, later loads map it in milliseconds with zero-copy weight planes.
+    //! ``DASLLAMA_IMAGE=0`` disables the cache.
+    if (mode == QuantMode.q8 && get_env_variable("DASLLAMA_IMAGE") != "0") {
+        apply_box_profile_runtime()   // a backend pin must precede the identity (it names the backend)
+        let img = image_path_for(path)
+        let ts_img = ref_time_ticks()
+        var t = Model()
+        if (load_model_image(img, t)) {
+            to_log(LOG_INFO, "dasLLAMA: prepared image mapped in {get_time_usec(ts_img) / 1000} ms — {img}\n")
+            return <- t
+        }
+        var m <- load_model_(path, mode)
+        let ts_save = ref_time_ticks()
+        if (save_model_image(m, img)) {
+            to_log(LOG_INFO, "dasLLAMA: prepared image saved in {get_time_usec(ts_save) / 1000} ms — {img}\n")
+        }
+        return <- m
+    }
     return <- load_model_(path, mode)
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -18,6 +18,7 @@ module dasllama shared public
 require dasllama/dasllama_transformer public   // the engine + arch registry; every arch [init] fires
 require dasllama/dasllama_image   // the prepared-image cache: load_model maps it when present
 require daslib/fio   // the DASLLAMA_IMAGE kill switch
+require strings   // ends_with — the direct .dlim path form
 require dasllama/dasllama_prefix public        // page-granular prefix cache over the paged pool
 require dasllama/dasllama_chat public          // layer 2: chat sessions over the same engine
 require dasllama/dasllama_audio public         // audio tower (mel frontend + whisper encoder + projectors)
@@ -45,7 +46,20 @@ def load_model(path : string; mode : QuantMode = QuantMode.fp32) : Model {
     //! (``QuantMode.fp32`` = the token-exact reference, ``QuantMode.q8`` = the fast int8 path).
     //! Q8 loads keep a PREPARED IMAGE next to the gguf (box + knob specific): the first load
     //! saves it, later loads map it in milliseconds with zero-copy weight planes.
-    //! ``DASLLAMA_IMAGE=0`` disables the cache.
+    //! ``DASLLAMA_IMAGE=0`` disables the cache. Passing a ``.dlim`` path loads that image
+    //! DIRECTLY (no gguf needed — wrong identity panics; there is nothing to regenerate from).
+    if (path |> ends_with(".dlim")) {
+        // a prepared image named directly — first-class once the source gguf is gone. No
+        // fallback exists here, so a wrong box/knob/version identity panics instead of hiding.
+        apply_box_profile_runtime()
+        let ts_img = ref_time_ticks()
+        var t = Model()
+        if (!load_model_image(path, t)) {
+            panic("dasLLAMA: '{path}' is not a prepared image for this box/knobs (identity {image_identity()}) — regenerate it from the source gguf")
+        }
+        to_log(LOG_INFO, "dasLLAMA: prepared image mapped in {get_time_usec(ts_img) / 1000} ms — {path}\n")
+        return <- t
+    }
     if (mode == QuantMode.q8 && get_env_variable("DASLLAMA_IMAGE") != "0") {
         apply_box_profile_runtime()   // a backend pin must precede the identity (it names the backend)
         let img = image_path_for(path)

--- a/modules/dasLLAMA/dasllama/dasllama_audio.das
+++ b/modules/dasLLAMA/dasllama/dasllama_audio.das
@@ -662,8 +662,9 @@ def finalize(var t : AudioTower) {
 // are deliberate skips. A new non-array AudioTower field trips this until BOTH agree.
 let private TOWER_META_FIELDS = 28 + 2
 
-// every non-array AudioTower field, explicitly, both directions (see dasllama_image)
-def private serialize_image_meta(var arch : Archive; var t : AudioTower) {
+// every non-array AudioTower field, explicitly, both directions (see dasllama_image).
+// Public: WhisperModel's serialize_image_meta reuses it for its nested `enc` tower.
+def serialize_image_meta(var arch : Archive; var t : AudioTower) {
     verify(count_meta_fields(t) == TOWER_META_FIELDS)   // grew AudioTower? extend this list
     arch |> serialize_raw(t.n_mel)
     arch |> serialize_raw(t.d_model)

--- a/modules/dasLLAMA/dasllama/dasllama_audio.das
+++ b/modules/dasLLAMA/dasllama/dasllama_audio.das
@@ -3,11 +3,16 @@ options gen2
 module dasllama_audio shared public
 
 require math
+require strings
 require daslib/fio
+require daslib/apply
+require daslib/archive
 require dasllama/dasllama_math
 require dasllama/dasllama_par
 require dasllama/dasllama_gguf
 require dasllama/dasllama_quant
+require dasllama/dasllama_common   // apply_box_profile_runtime for the tower-image identity
+require dasllama/dasllama_image
 
 // Whisper-family audio frontend: 16 kHz mono PCM -> log-mel chunks, in two oracle-exact
 // flavors: log_mel_chunks mirrors llama.cpp mtmd (tools/mtmd/mtmd-audio.cpp, qwen2a tower),
@@ -628,7 +633,70 @@ struct AudioTower {
     normpre_off : int64       // ultravox RMS-pre weight [d·stack]
     normmid_off : int64       // ultravox RMS-mid weight [mm1_out/2]
     mm2_w_off : int64         // ultravox/voxtral second projector matrix
+    image_map : void?         // non-null when the planes borrow a mapped .dlim (dasllama_image)
+    image_bytes : uint64
 }
+
+def finalize(var t : AudioTower) {
+    apply(t) $ [unused_argument(name)] (name : string; var field) {
+        static_if (typeinfo is_array(field)) {
+            if (lock_count(field) != 0) {
+                unsafe {
+                    _builtin_forget_temp_array(field)
+                }
+            } else {
+                delete field
+            }
+        }
+    }
+    if (t.image_map != null) {
+        unsafe {
+            fmap_close(t.image_map, t.image_bytes)
+        }
+        t.image_map = null
+        t.image_bytes = 0ul
+    }
+}
+
+// the tripwire: serialize_image_meta(AudioTower) covers 28 fields; image_map + image_bytes
+// are deliberate skips. A new non-array AudioTower field trips this until BOTH agree.
+let private TOWER_META_FIELDS = 28 + 2
+
+// every non-array AudioTower field, explicitly, both directions (see dasllama_image)
+def private serialize_image_meta(var arch : Archive; var t : AudioTower) {
+    verify(count_meta_fields(t) == TOWER_META_FIELDS)   // grew AudioTower? extend this list
+    arch |> serialize_raw(t.n_mel)
+    arch |> serialize_raw(t.d_model)
+    arch |> serialize_raw(t.n_head)
+    arch |> serialize_raw(t.n_layer)
+    arch |> serialize_raw(t.n_ff)
+    arch |> serialize_raw(t.n_ctx)
+    arch |> serialize_raw(t.proj_dim)
+    arch |> serialize_raw(t.gelu_tanh)
+    arch |> serialize_raw(t.eps)
+    arch |> serialize_raw(t.proj_kind)
+    arch |> serialize_raw(t.stack_factor)
+    arch |> serialize_raw(t.mm1_out)
+    arch |> serialize_raw(t.has_k_bias)
+    arch |> serialize_raw(t.q8)
+    arch |> serialize_raw(t.conv1_w_off)
+    arch |> serialize_raw(t.conv1_b_off)
+    arch |> serialize_raw(t.conv2_w_off)
+    arch |> serialize_raw(t.conv2_b_off)
+    arch |> serialize_raw(t.pos_off)
+    arch |> serialize_raw(t.layers_off)
+    arch |> serialize_raw(t.layer_stride)
+    arch |> serialize_raw(t.lnp_w_off)
+    arch |> serialize_raw(t.lnp_b_off)
+    arch |> serialize_raw(t.proj_w_off)
+    arch |> serialize_raw(t.proj_b_off)
+    arch |> serialize_raw(t.normpre_off)
+    arch |> serialize_raw(t.normmid_off)
+    arch |> serialize_raw(t.mm2_w_off)
+}
+
+[unused_argument(t)]
+def private image_post_load(var t : AudioTower) {}   // no derived state — offsets ARE the meta
 
 def audio_has_avgpool(t : AudioTower) : bool => (
     t.proj_kind == AudioProjKind.qwen2a || t.proj_kind == AudioProjKind.voxtral)
@@ -910,7 +978,42 @@ def private load_conv_permuted(m : GGUFMeta; bytes : array<uint8> | #; name : st
 //! into an AudioTower: hparams from the ``clip.audio.*`` keys, every tensor fp32 into the blob
 //! in ``enc_layer_offsets`` order, conv weights permuted for im2col. Vision tensors in a
 //! combined omni mmproj are skipped (the loader only reads ``a.*`` / ``mm.a.*`` names).
+//! Like ``load_model``, keeps a PREPARED IMAGE next to the mmproj (box + knob specific):
+//! the first load saves it, later loads map it in milliseconds with zero-copy planes.
+//! ``DASLLAMA_IMAGE=0`` disables the cache; a ``.dlim`` path loads that image directly.
 def load_audio_tower(path : string; q8 : bool = false) : AudioTower {
+    let tag = q8 ? "tower-q8" : "tower-f32"
+    if (path |> ends_with(".dlim")) {
+        // named directly — no mmproj to regenerate from, so a wrong identity panics
+        apply_box_profile_runtime()
+        let ts_img = ref_time_ticks()
+        var t = AudioTower()
+        if (!load_image(path, t, tag)) {
+            panic("dasLLAMA: '{path}' is not a prepared audio-tower image for this box/knobs (identity {image_identity(tag)}) — regenerate it from the source mmproj gguf")
+        }
+        to_log(LOG_INFO, "dasLLAMA: prepared tower image mapped in {get_time_usec(ts_img) / 1000} ms — {path}\n")
+        return <- t
+    }
+    if (get_env_variable("DASLLAMA_IMAGE") != "0") {
+        apply_box_profile_runtime()   // a backend pin must precede the identity (it names the backend)
+        let img = image_path_for(path, tag)
+        let ts_img = ref_time_ticks()
+        var t = AudioTower()
+        if (load_image(img, t, tag)) {
+            to_log(LOG_INFO, "dasLLAMA: prepared tower image mapped in {get_time_usec(ts_img) / 1000} ms — {img}\n")
+            return <- t
+        }
+        var m <- load_audio_tower_(path, q8)
+        let ts_save = ref_time_ticks()
+        if (save_image(m, img, tag)) {
+            to_log(LOG_INFO, "dasLLAMA: prepared tower image saved in {get_time_usec(ts_save) / 1000} ms — {img}\n")
+        }
+        return <- m
+    }
+    return <- load_audio_tower_(path, q8)
+}
+
+def private load_audio_tower_(path : string; q8 : bool = false) : AudioTower {
     var t = AudioTower()
     let f = fopen(path, "rb")
     if (f == null) {

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1807,6 +1807,13 @@ def public weights_epoch() : int64 {
     return g_weights_epoch
 }
 
+//! The image loader's half of the same contract: mapping a prepared image lands planes at
+//! fresh (possibly recycled) addresses exactly like a gguf load does, so it must move the
+//! epoch too — dasllama_image calls this on every successful load_image.
+def public bump_weights_epoch() {
+    g_weights_epoch++
+}
+
 def load_gguf(path : string; mode : QuantMode = QuantMode.fp32) : Model {
     //! The conversion passes (transcode/repack/wscale) thread across the jobque; spin a scoped one
     //! for the load when the caller hasn't (the server/tools start theirs after the model loads).

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1309,15 +1309,21 @@ def caps_(m : Model) : LlmCaps {
 
 // Look the arch up, apply its config flags, and copy its (copyable) block kernels onto the model.
 // The full descriptor stays in the registry; only the hot-path pointers ride on the Model.
-// public: the image loader re-binds blocks + re-runs the arch's configure (idempotent) after
-// deserializing the model meta — same registry path as load_gguf
 def resolve_arch(var t : Model; arch : string) {
+    rebind_arch_blocks(t, arch)
+    g_arch_registry[arch].configure(t.config)
+}
+
+// The image loader's post-read half of resolve_arch: block kernels re-bind from the registry,
+// but configure must NOT re-run — the serialized config already carries configure's flags PLUS
+// the gguf's overrides, and configures set overridable fallbacks (gemma4's sliding_window = 1024
+// clobbered the E2B's real 512 and drifted tokens past the window).
+def rebind_arch_blocks(var t : Model; arch : string) {
     if (!key_exists(g_arch_registry, arch)) {
         let registered = join(arch_names(), ", ")
         panic("dasLLAMA: unsupported architecture '{arch}' (registered: {registered})")
     }
     t.arch = arch
-    g_arch_registry[arch].configure(t.config)
     t.blocks = g_arch_registry[arch].blocks
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -20,6 +20,7 @@ require daslib/json_boost  // read_json / read_json_field for the box profile's 
 require math
 require daslib/random  // int4 RNG state + random_float for token sampling
 require daslib/strings_boost  // join() for the arch-registry diagnostic
+require daslib/apply  // the Model finalizer + the image save/load walk both iterate Model fields
 
 // dasLLAMA inference engine. A model is split into two regions by role: a small fp32 aux blob
 // (the embedding table + the norm weights, which forward always reads as fp32) and the big 2D
@@ -630,6 +631,38 @@ struct Model {
     mtp_enorm_off : int64 = -1      // fblob: nextn.enorm (token-embedding RMS weight), dim
     mtp_hnorm_off : int64 = -1      // fblob: nextn.hnorm (trunk-hidden RMS weight), dim
     mtp_headnorm_off : int64 = -1   // fblob: nextn.shared_head_norm, dim (-1 = output_norm)
+    // prepared-model image backing (dasllama_image): when set, every locked array field above
+    // is a borrowed VIEW into this mapping (zero-copy) and the finalizer below unmaps it.
+    // Both fields are skipped by the image save/load field walk.
+    image_map : void?
+    image_bytes : uint64
+}
+
+// Model's finalizer (every `delete model` site lowers to _::finalize and lands here): image-
+// backed models hold locked BORROWED views over the mapping — those must be forgotten (reset
+// without freeing) before the mapping unmaps; everything owned deletes as usual. The apply walk
+// keeps this valid for future fields without maintenance.
+def finalize(var t : Model) {
+    apply(t) $ [unused_argument(name)] (name : string; var field) {
+        static_if (typeinfo is_array(field)) {
+            if (lock_count(field) != 0) {
+                unsafe {
+                    _builtin_forget_temp_array(field)
+                }
+            } else {
+                delete field
+            }
+        } static_elif (typeinfo is_struct(field)) {
+            delete field
+        }
+    }
+    if (t.image_map != null) {
+        unsafe {
+            fmap_close(t.image_map, t.image_bytes)
+        }
+        t.image_map = null
+        t.image_bytes = 0ul
+    }
 }
 
 // ===== Arch registry: per-architecture blocks + chat template =====
@@ -1276,7 +1309,9 @@ def caps_(m : Model) : LlmCaps {
 
 // Look the arch up, apply its config flags, and copy its (copyable) block kernels onto the model.
 // The full descriptor stays in the registry; only the hot-path pointers ride on the Model.
-def private resolve_arch(var t : Model; arch : string) {
+// public: the image loader re-binds blocks + re-runs the arch's configure (idempotent) after
+// deserializing the model meta — same registry path as load_gguf
+def resolve_arch(var t : Model; arch : string) {
     if (!key_exists(g_arch_registry, arch)) {
         let registered = join(arch_names(), ", ")
         panic("dasLLAMA: unsupported architecture '{arch}' (registered: {registered})")

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1309,7 +1309,7 @@ def caps_(m : Model) : LlmCaps {
 
 // Look the arch up, apply its config flags, and copy its (copyable) block kernels onto the model.
 // The full descriptor stays in the registry; only the hot-path pointers ride on the Model.
-def resolve_arch(var t : Model; arch : string) {
+def private resolve_arch(var t : Model; arch : string) {
     rebind_arch_blocks(t, arch)
     g_arch_registry[arch].configure(t.config)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -526,6 +526,21 @@ def load_image(path : string; var t; tag : string = "") : bool {
     }
     var by_name <- {for (sec in sections); sec.name => sec}
     _::serialize_image_meta(rarch, t)
+    // a truncated/corrupt meta blob reads back as silent zero-progress (MemSerializer sets
+    // lastError, no panic) — decline BEFORE post_load, which would panic on garbage (e.g. an
+    // unreadable arch name), and before any plane borrows
+    if (!meta->OK()) {
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — meta blob is truncated/corrupt ({meta->getLastError()})\n")
+        delete t   // half-deserialized, all owned — nothing is borrowed yet
+        delete meta_blob
+        delete sections
+        delete by_name
+        unsafe {
+            delete meta
+        }
+        unsafe(fmap_close(base, msize))
+        return false
+    }
     _::image_post_load(t)
     var ok = true
     apply(t) $(name : string; var field) {

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -26,7 +26,8 @@ let IMAGE_PAGE = 16384l          // Apple-Silicon page: the bytesNoCopy alignmen
 let IMAGE_HEADER_BYTES = 64l     // magic..identity, inside the first page
 let IMAGE_MAGIC = 0x314D4C44u    // 'DLM1'
 
-struct private ImgSection {
+// public only for the save_image/load_image generics — they instantiate from caller modules
+struct ImgSection {
     name : string
     off : uint64      // absolute byte offset, page-aligned
     bytes : uint64
@@ -35,16 +36,18 @@ struct private ImgSection {
 // the box + knob identity an image is valid for; folded into the file name AND the header.
 // It names the exact plane layout, so it must be computed AFTER the same backend select the
 // gguf loader runs at repack time — the entry-time auto default is a different backend.
-def image_identity : string {
+// `tag` distinguishes image kinds sharing one source path (e.g. "tower-f32" vs "tower-q8").
+def image_identity(tag : string = "") : string {
     select_matmul_backend_for_load()
     return ("v{IMAGE_VERSION}|{active_kernel_backend()}|{get_wscale_f16() ? "s16" : "s32"}"
         + "|q8 mr{active_q8_layout_mr()} b{active_q8_wbias()} g{active_q8_kgroup()}"
-        + "|kq {active_kq_layout_mr(4)}/{active_kq_layout_mr(5)}/{active_kq_layout_mr(6)}/{active_kq_layout_mr(40)}")
+        + "|kq {active_kq_layout_mr(4)}/{active_kq_layout_mr(5)}/{active_kq_layout_mr(6)}/{active_kq_layout_mr(40)}"
+        + (tag != "" ? "|{tag}" : ""))
 }
 
 // the image path for (gguf, current identity) — knob combos coexist as separate files
-def image_path_for(gguf_path : string) : string {
-    return "{gguf_path}.{hash(image_identity()) & 0xFFFFFFFFul}.dlim"
+def image_path_for(gguf_path : string; tag : string = "") : string {
+    return "{gguf_path}.{hash(image_identity(tag)) & 0xFFFFFFFFul}.dlim"
 }
 
 def private pad_to_page(cur : uint64) : uint64 {
@@ -64,14 +67,14 @@ def private write_zeros(f : file; n : uint64) {
 
 def private store_u32(var b : array<uint8>; at : int; v : uint) {
     unsafe {
-        var p = unsafe(addr < uint ? > (b[at]))
+        var p = unsafe(addr < uint? >(b[at]))
         p[0] = v
     }
 }
 
 def private store_u64(var b : array<uint8>; at : int; v : uint64) {
     unsafe {
-        var p = unsafe(addr < uint64 ? > (b[at]))
+        var p = unsafe(addr < uint64? >(b[at]))
         p[0] = v
     }
 }
@@ -147,7 +150,7 @@ def private serialize_strings(var arch : Archive; var a : array<string>) {
             let n = lens[i]
             if (n > 0) {
                 unsafe {
-                    a[i] = string(temp_array(addr < uint8 ? > (blob[at]), n, type<uint8>))
+                    a[i] = string(temp_array(addr < uint8? >(blob[at]), n, type<uint8>))
                 }
             } else {
                 a[i] = ""
@@ -200,9 +203,10 @@ def private serialize_tokenizer(var arch : Archive; var tk : Tokenizer) {
 }
 
 // every non-array Model field, explicitly, both directions (the archive is bidirectional).
-// blocks is NOT serialized — resolve_arch re-binds it from the registry after the read.
-// The count tripwire below forces this list to grow with the struct.
-def private serialize_model_meta(var arch : Archive; var t : Model) {
+// blocks is NOT serialized — image_post_load re-binds it from the registry after the read.
+// The count tripwire forces this list to grow with the struct.
+def private serialize_image_meta(var arch : Archive; var t : Model) {
+    verify(count_meta_fields(t) == IMAGE_META_FIELDS)   // grew Model? extend this list
     arch |> serialize(t.config)
     arch |> serialize(t.arch)
     arch |> serialize(t.chat_template_str)
@@ -268,11 +272,13 @@ def private serialize_model_meta(var arch : Archive; var t : Model) {
     arch |> serialize_raw(t.mtp_headnorm_off)
 }
 
-// the tripwire: serialize_model_meta covers 63 fields; blocks + image_map + image_bytes are
-// deliberate skips. A new non-array Model field trips this until BOTH lists agree.
+// the tripwire: serialize_image_meta(Model) covers 63 fields; blocks + image_map +
+// image_bytes are deliberate skips. A new non-array Model field trips this until BOTH agree.
 let IMAGE_META_FIELDS = 63 + 3
 
-def private count_meta_fields(var t : Model) : int {
+//! Count of non-array fields of any struct — pair with a per-type field-count constant to
+//! tripwire an explicit serialize_image_meta list against struct growth.
+def count_meta_fields(var t) : int {
     var n = 0
     apply(t) $ [unused_argument(name, field)] (name : string; var field) {
         static_if (!typeinfo is_array(field)) {
@@ -282,12 +288,22 @@ def private count_meta_fields(var t : Model) : int {
     return n
 }
 
+// Model's post-read fix-up: blocks re-bind from the registry (+ the arch's idempotent configure)
+def private image_post_load(var t : Model) {
+    resolve_arch(t, t.arch)
+}
+
 // ===== save =====
 
-//! Serialize a loaded Model as a prepared image: planes page-aligned raw (borrowed back at
-//! load), everything else archived. Atomic (tmp + rename). Returns false on any IO failure.
-def save_model_image(var t : Model; path : string) : bool {
-    let tmp_path = "{path}.tmp"
+//! Serialize a loaded weight-carrying struct as a prepared image: array planes page-aligned
+//! raw (borrowed back at load), everything else archived. Atomic (tmp + rename). Returns
+//! false on any IO failure. The caller's module must provide `serialize_image_meta(Archive,
+//! T)` for every non-array field and `image_post_load(T)` for post-read fix-ups (`_::`
+//! dispatch — Model's live here, AudioTower's in dasllama_audio).
+def save_image(var t; path : string; tag : string = "") : bool {
+    // per-writer tmp name: concurrent savers (parallel test workers on one cache miss) must
+    // not clobber each other's half-written file; last atomic rename wins with same content
+    let tmp_path = "{path}.{ref_time_ticks()}.tmp"
     var ok = true
     var meta <- new MemSerializer()
     var warch = Archive(reading = false, stream = meta)
@@ -300,9 +316,8 @@ def save_model_image(var t : Model; path : string) : bool {
         // page 0: header placeholder — patched after the walk (fseek back)
         write_zeros(f, uint64(IMAGE_PAGE))
         var cur = uint64(IMAGE_PAGE)
-        verify(count_meta_fields(t) == IMAGE_META_FIELDS)   // grew Model? extend serialize_model_meta
         let ts_meta = ref_time_ticks()
-        serialize_model_meta(warch, t)
+        _::serialize_image_meta(warch, t)
         to_log(LOG_INFO, "dasLLAMA image: meta serialize {get_time_usec(ts_meta) / 1000}ms\n")
         let ts_planes = ref_time_ticks()
         apply(t) $(name : string; var field) {
@@ -350,7 +365,7 @@ def save_model_image(var t : Model; path : string) : bool {
         store_u64(hdr, 16, meta_off)
         store_u64(hdr, 24, meta_bytes)
         store_u64(hdr, 32, fend)
-        store_u64(hdr, 40, hash(image_identity()))
+        store_u64(hdr, 40, hash(image_identity(tag)))
         fseek(f, 0l, seek_set)
         f |> fwrite(hdr)
         delete hdr
@@ -376,12 +391,18 @@ def save_model_image(var t : Model; path : string) : bool {
     return true
 }
 
+//! Model entry point (the AudioTower one is load_audio_tower's cache in dasllama_audio).
+def save_model_image(var t : Model; path : string) : bool {
+    return save_image(t, path)
+}
+
 // ===== load =====
 
-//! Map a prepared image and rebuild the Model with zero O(model) work: plane fields borrow
-//! the mapping (the Model finalizer forgets + unmaps), the archive blob restores everything
+//! Map a prepared image and rebuild the struct with zero O(model) work: array plane fields
+//! borrow the mapping (the finalizer forgets + unmaps), the archive blob restores everything
 //! else. false = absent / wrong identity / wrong version — the caller regenerates from gguf.
-def load_model_image(path : string; var t : Model) : bool {
+//! Same `_::` contract as save_image.
+def load_image(path : string; var t; tag : string = "") : bool {
     if (!stat(path).is_valid) {
         return false
     }
@@ -393,19 +414,14 @@ def load_model_image(path : string; var t : Model) : bool {
     unsafe {
         base = fmap_open(path, addr(msize))
     }
-    var bp : uint8 const?
-    unsafe {
-        bp = reinterpret<uint8 const?>(base)
-    }
+    var bp = unsafe(reinterpret<uint8 const?>(base))
     if (int64(msize) < IMAGE_HEADER_BYTES ||
             (read_u32(bp, 0l) != IMAGE_MAGIC || read_u32(bp, 4l) != uint(IMAGE_VERSION)) ||
-            (read_u32(bp, 8l) != uint(IMAGE_PAGE) || read_u64(bp, 40l) != hash(image_identity()))) {
+            (read_u32(bp, 8l) != uint(IMAGE_PAGE) || read_u64(bp, 40l) != hash(image_identity(tag)))) {
         // every decline is loud (short of the file simply not existing) — a silently
         // regenerating cache is undebuggable
-        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — size {msize} magic {read_u32(bp, 0l)} version {read_u32(bp, 4l)} (want {IMAGE_VERSION}) page {read_u32(bp, 8l)} identity {read_u64(bp, 40l)} (want {hash(image_identity())} = '{image_identity()}')\n")
-        unsafe {
-            fmap_close(base, msize)
-        }
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — size {msize} magic {read_u32(bp, 0l)} version {read_u32(bp, 4l)} (want {IMAGE_VERSION}) page {read_u32(bp, 8l)} identity {read_u64(bp, 40l)} (want {hash(image_identity(tag))} = '{image_identity(tag)}')\n")
+        unsafe(fmap_close(base, msize))
         return false
     }
     let nsections = int(read_u32(bp, 12l))
@@ -414,9 +430,7 @@ def load_model_image(path : string; var t : Model) : bool {
     let file_bytes = read_u64(bp, 32l)
     if (file_bytes != msize || meta_off + meta_bytes > msize) {
         to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — header says {file_bytes} bytes / meta {meta_off}+{meta_bytes}, mapped {msize}\n")
-        unsafe {
-            fmap_close(base, msize)
-        }
+        unsafe(fmap_close(base, msize))
         return false
     }
     // the meta blob is the ONE copied+parsed piece (small); planes stay lazy in the mapping
@@ -430,8 +444,8 @@ def load_model_image(path : string; var t : Model) : bool {
     var sections : array<ImgSection>
     rarch |> serialize(sections)
     var by_name <- {for (sec in sections); sec.name => sec}
-    serialize_model_meta(rarch, t)
-    resolve_arch(t, t.arch)   // blocks re-bind + the arch's (idempotent) configure
+    _::serialize_image_meta(rarch, t)
+    _::image_post_load(t)
     var ok = true
     apply(t) $(name : string; var field) {
         static_if (typeinfo is_array(field)) {
@@ -463,4 +477,9 @@ def load_model_image(path : string; var t : Model) : bool {
     t.image_map = base
     t.image_bytes = msize
     return true
+}
+
+//! Model entry point — see load_image.
+def load_model_image(path : string; var t : Model) : bool {
+    return load_image(path, t)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -19,6 +19,9 @@ require dasllama/dasllama_math   // active_kernel_backend — half the image ide
 // Images are BOX + KNOB specific (identity below) and versioned — a mismatch regenerates,
 // never migrates. The load path touches only the header + meta blob: bigger-than-RAM images
 // stay lazy (full verification belongs to the offline tool, not load).
+// Nested weight-carriers (a struct field that itself declares image_map, e.g.
+// WhisperModel.enc) contribute their planes under dotted names ("enc.fblob"); string-array
+// fields ride the meta blob via serialize_strings — raw string pointers can't be planes.
 
 // bump on ANY layout/serialization change — a mismatched image regenerates from the gguf
 let IMAGE_VERSION = 2
@@ -115,8 +118,10 @@ def private serialize_pod_array(var arch : Archive; var a : array<auto(TT)>) {
     }
 }
 
-// string arrays as [lengths][one blob] — two bulk payloads instead of per-string dispatch
-def private serialize_strings(var arch : Archive; var a : array<string>) {
+//! String arrays as [lengths][one blob] — two bulk payloads instead of per-string dispatch.
+//! Public because string-array fields cannot be raw planes (they hold pointers) — a type's
+//! serialize_image_meta must route them through this instead.
+def serialize_strings(var arch : Archive; var a : array<string>) {
     var lens : array<int>
     var blob : array<uint8>
     if (!arch.reading) {
@@ -276,12 +281,15 @@ def private serialize_image_meta(var arch : Archive; var t : Model) {
 // image_bytes are deliberate skips. A new non-array Model field trips this until BOTH agree.
 let IMAGE_META_FIELDS = 63 + 3
 
-//! Count of non-array fields of any struct — pair with a per-type field-count constant to
+//! Count of meta-carried fields of any struct: non-arrays plus string arrays (those cannot
+//! be raw planes — see serialize_strings). Pair with a per-type field-count constant to
 //! tripwire an explicit serialize_image_meta list against struct growth.
 def count_meta_fields(var t) : int {
     var n = 0
     apply(t) $ [unused_argument(name, field)] (name : string; var field) {
         static_if (!typeinfo is_array(field)) {
+            n++
+        } static_elif (typeinfo is_string(field[0])) {
             n++
         }
     }
@@ -294,6 +302,27 @@ def private image_post_load(var t : Model) {
 }
 
 // ===== save =====
+
+// one plane: pad to a page, bulk-write, account. long_ forms: a plane past 2 GiB
+// (voxtral-mini qblob = 3.6 G elements) does not fit the int32 length/byte-count rail
+def private write_plane(f : file; var sections : array<ImgSection>; var cur : uint64&;
+                        var ok : bool&; name : string; var field : array<auto(TT)>) {
+    if (empty(field)) {
+        return
+    }
+    let nbytes = uint64(long_length(field)) * uint64(typeinfo sizeof(field[0]))
+    let at = pad_to_page(cur)
+    write_zeros(f, at - cur)
+    f |> long_fwrite(field)
+    sections |> push(ImgSection(name = name, off = at, bytes = nbytes))
+    cur = at + nbytes
+    // fwrite and the section table must agree byte-for-byte, or the mapped planes land at
+    // the wrong offsets — fail the save loudly, not the load
+    if (uint64(ftell(f)) != cur) {
+        to_log(LOG_ERROR, "dasLLAMA image: plane '{name}' wrote {ftell(f)} != accounted {cur} (nbytes {nbytes}) — image save aborted\n")
+        ok = false
+    }
+}
 
 //! Serialize a loaded weight-carrying struct as a prepared image: array planes page-aligned
 //! raw (borrowed back at load), everything else archived. Atomic (tmp + rename). Returns
@@ -322,20 +351,18 @@ def save_image(var t; path : string; tag : string = "") : bool {
         let ts_planes = ref_time_ticks()
         apply(t) $(name : string; var field) {
             static_if (typeinfo is_array(field)) {
-                if (!empty(field)) {
-                    // long_ forms: a plane past 2 GiB (voxtral-mini qblob = 3.6 G elements)
-                    // does not fit the int32 length/byte-count rail
-                    let nbytes = uint64(long_length(field)) * uint64(typeinfo sizeof(field[0]))
-                    let at = pad_to_page(cur)
-                    write_zeros(f, at - cur)
-                    f |> long_fwrite(field)
-                    sections |> push(ImgSection(name = name, off = at, bytes = nbytes))
-                    cur = at + nbytes
-                    // fwrite and the section table must agree byte-for-byte, or the mapped
-                    // planes land at the wrong offsets — fail the save loudly, not the load
-                    if (uint64(ftell(f)) != cur) {
-                        to_log(LOG_ERROR, "dasLLAMA image: plane '{name}' wrote {ftell(f)} != accounted {cur} (nbytes {nbytes}) — image save aborted\n")
-                        ok = false
+                static_if (!typeinfo is_string(field[0])) {   // string arrays ride the meta blob
+                    write_plane(f, sections, cur, ok, name, field)
+                }
+            } static_elif (typeinfo safe_has_field < image_map > (field)) {
+                // a nested weight-carrier on the image rail (marker: it declares image_map) —
+                // its planes join this image under dotted names; scalars ride the meta blob
+                // via the outer type's serialize_image_meta (e.g. WhisperModel.enc)
+                apply(field) $(iname : string; var ifield) {
+                    static_if (typeinfo is_array(ifield)) {
+                        static_if (!typeinfo is_string(ifield[0])) {
+                            write_plane(f, sections, cur, ok, "{name}.{iname}", ifield)
+                        }
                     }
                 }
             }
@@ -398,6 +425,25 @@ def save_model_image(var t : Model; path : string) : bool {
 
 // ===== load =====
 
+// one plane: validate the section against the mapping, then borrow it in place
+def private borrow_plane(bp : uint8 const?; msize : uint64; path : string;
+                         by_name : table<string; ImgSection>; var ok : bool&;
+                         name : string; var field : array<auto(TT)>) {
+    if (!key_exists(by_name, name)) {
+        return
+    }
+    let sec = by_name?[name] ?? ImgSection()
+    let esz = uint64(typeinfo sizeof(field[0]))
+    if (sec.off % uint64(IMAGE_PAGE) != 0ul || sec.off + sec.bytes > msize || sec.bytes % esz != 0ul) {
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — section '{name}' at {sec.off}+{sec.bytes} (esz {esz}) is malformed\n")
+        ok = false
+    } else {
+        unsafe {
+            _builtin_make_temp_array_i64(field, reinterpret<void?>(bp + int64(sec.off)), int64(sec.bytes / esz))
+        }
+    }
+}
+
 //! Map a prepared image and rebuild the struct with zero O(model) work: array plane fields
 //! borrow the mapping (the finalizer forgets + unmaps), the archive blob restores everything
 //! else. false = absent / wrong identity / wrong version — the caller regenerates from gguf.
@@ -449,15 +495,16 @@ def load_image(path : string; var t; tag : string = "") : bool {
     var ok = true
     apply(t) $(name : string; var field) {
         static_if (typeinfo is_array(field)) {
-            if (key_exists(by_name, name)) {
-                let sec = by_name?[name] ?? ImgSection()
-                let esz = uint64(typeinfo sizeof(field[0]))
-                if (sec.off % uint64(IMAGE_PAGE) != 0ul || sec.off + sec.bytes > msize || sec.bytes % esz != 0ul) {
-                    to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — section '{name}' at {sec.off}+{sec.bytes} (esz {esz}) is malformed\n")
-                    ok = false
-                } else {
-                    unsafe {
-                        _builtin_make_temp_array_i64(field, reinterpret<void?>(bp + int64(sec.off)), int64(sec.bytes / esz))
+            static_if (!typeinfo is_string(field[0])) {   // string arrays ride the meta blob
+                borrow_plane(bp, msize, path, by_name, ok, name, field)
+            }
+        } static_elif (typeinfo safe_has_field < image_map > (field)) {
+            // nested weight-carrier: borrow its planes back from the dotted sections (the
+            // nested image_map stays null — the OUTER struct owns this mapping)
+            apply(field) $(iname : string; var ifield) {
+                static_if (typeinfo is_array(ifield)) {
+                    static_if (!typeinfo is_string(ifield[0])) {
+                        borrow_plane(bp, msize, path, by_name, ok, "{name}.{iname}", ifield)
                     }
                 }
             }

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -49,8 +49,10 @@ def image_identity(tag : string = "") : string {
 }
 
 // the image path for (gguf, current identity) — knob combos coexist as separate files
+// (the full 64-bit hash keeps that deterministic in practice; the header check would catch
+// a collision loudly, but two identities fighting over one path re-save forever)
 def image_path_for(gguf_path : string; tag : string = "") : string {
-    return "{gguf_path}.{hash(image_identity(tag)) & 0xFFFFFFFFul}.dlim"
+    return "{gguf_path}.{hash(image_identity(tag))}.dlim"
 }
 
 def private pad_to_page(cur : uint64) : uint64 {

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -296,9 +296,11 @@ def count_meta_fields(var t) : int {
     return n
 }
 
-// Model's post-read fix-up: blocks re-bind from the registry (+ the arch's idempotent configure)
+// Model's post-read fix-up: blocks re-bind from the registry. Deliberately NOT resolve_arch —
+// its configure would clobber serialized gguf overrides with the arch's fallbacks (see
+// rebind_arch_blocks).
 def private image_post_load(var t : Model) {
-    resolve_arch(t, t.arch)
+    rebind_arch_blocks(t, t.arch)
 }
 
 // ===== save =====

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -323,12 +323,12 @@ def save_image(var t; path : string; tag : string = "") : bool {
         apply(t) $(name : string; var field) {
             static_if (typeinfo is_array(field)) {
                 if (!empty(field)) {
-                    // long_length, NOT length: a >2 GiB plane (voxtral-mini qblob = 3.6 G elements)
-                    // wraps int32 length negative, and -jit inlines length() without the C++ guard
+                    // long_ forms: a plane past 2 GiB (voxtral-mini qblob = 3.6 G elements)
+                    // does not fit the int32 length/byte-count rail
                     let nbytes = uint64(long_length(field)) * uint64(typeinfo sizeof(field[0]))
                     let at = pad_to_page(cur)
                     write_zeros(f, at - cur)
-                    f |> fwrite(field)
+                    f |> long_fwrite(field)
                     sections |> push(ImgSection(name = name, off = at, bytes = nbytes))
                     cur = at + nbytes
                     // fwrite and the section table must agree byte-for-byte, or the mapped

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -1,0 +1,444 @@
+options gen2
+
+module dasllama_image shared public
+
+require daslib/fio
+require daslib/apply
+require strings
+require dasllama/dasllama_tokenizer   // Tokenizer — the bulk tokenizer serializer below
+require daslib/archive
+require daslib/array_boost   // nolint:STYLE030 — temp_array is [template]; STYLE030 misses template-fn refs (same note as dasllama_common)
+require dasllama/dasllama_common
+require dasllama/dasllama_math   // active_kernel_backend — half the image identity
+
+// The prepared-model image (spec: fmap-model-image plan, locked 2026-07-16): the post-load
+// Model dumped once — planes POST-repack, page-aligned — then mapped back with zero O(model)
+// allocation or copying. Plane fields become borrowed views over the mapping (the Model
+// finalizer forgets them and unmaps); everything else (config, scalars, tokenizer, arch
+// blocks) rides a daslib/archive blob and is PARSED at load (the small-structure carve-out).
+// Images are BOX + KNOB specific (identity below) and versioned — a mismatch regenerates,
+// never migrates. The load path touches only the header + meta blob: bigger-than-RAM images
+// stay lazy (full verification belongs to the offline tool, not load).
+
+// bump on ANY layout/serialization change — a mismatched image regenerates from the gguf
+let IMAGE_VERSION = 1
+let IMAGE_PAGE = 16384l          // Apple-Silicon page: the bytesNoCopy alignment contract
+let IMAGE_HEADER_BYTES = 64l     // magic..identity, inside the first page
+let IMAGE_MAGIC = 0x314D4C44u    // 'DLM1'
+
+struct private ImgSection {
+    name : string
+    off : uint64      // absolute byte offset, page-aligned
+    bytes : uint64
+}
+
+// the box + knob identity an image is valid for; folded into the file name AND the header
+def image_identity : string {
+    return "v{IMAGE_VERSION}|{active_kernel_backend()}|{get_wscale_f16() ? "s16" : "s32"}"
+}
+
+// the image path for (gguf, current identity) — knob combos coexist as separate files
+def image_path_for(gguf_path : string) : string {
+    return "{gguf_path}.{hash(image_identity()) & 0xFFFFFFFFul}.dlim"
+}
+
+def private pad_to_page(cur : uint64) : uint64 {
+    let page = uint64(IMAGE_PAGE)
+    return (cur + page - 1ul) / page * page
+}
+
+def private write_zeros(f : file; n : uint64) {
+    if (n == 0ul) {
+        return
+    }
+    var z : array<uint8>
+    z |> resize(int(n))
+    f |> fwrite(z)
+    delete z
+}
+
+def private store_u32(var b : array<uint8>; at : int; v : uint) {
+    unsafe {
+        var p = unsafe(addr<uint?>(b[at]))
+        p[0] = v
+    }
+}
+
+def private store_u64(var b : array<uint8>; at : int; v : uint64) {
+    unsafe {
+        var p = unsafe(addr<uint64?>(b[at]))
+        p[0] = v
+    }
+}
+
+def private read_u32(p : uint8 const?; at : int64) : uint {
+    unsafe {
+        var q = reinterpret<uint const?>(p + at)
+        return q[0]
+    }
+}
+
+def private read_u64(p : uint8 const?; at : int64) : uint64 {
+    unsafe {
+        var q = reinterpret<uint64 const?>(p + at)
+        return q[0]
+    }
+}
+
+
+
+// bulk POD-array serialize: ONE stream call for the payload. daslib/archive's per-element
+// generic dispatch measured ~340us/element — a 128k-vocab tokenizer took 238s through it.
+def private serialize_pod_array(var arch : Archive; var a : array<auto(TT)>) {
+    var n = length(a)
+    arch |> serialize_raw(n)
+    if (arch.reading) {
+        a |> resize(n)
+    }
+    if (n > 0) {
+        let nbytes = n * typeinfo sizeof(type<TT>)
+        unsafe {
+            if (arch.reading) {
+                arch.stream->read(addr(a[0]), nbytes)
+            } else {
+                arch.stream->write(addr(a[0]), nbytes)
+            }
+        }
+    }
+}
+
+// string arrays as [lengths][one blob] — two bulk payloads instead of per-string dispatch
+def private serialize_strings(var arch : Archive; var a : array<string>) {
+    var lens : array<int>
+    var blob : array<uint8>
+    if (!arch.reading) {
+        lens |> reserve(length(a))
+        var total = 0
+        for (v in a) {
+            let n = length(v)
+            lens |> push(n)
+            total += n
+        }
+        blob |> resize(total)
+        var at = 0
+        for (v in a) {
+            let n = length(v)
+            if (n > 0) {
+                peek_data(v) $(bytes : array<uint8> const#) {
+                    unsafe {
+                        memcpy(addr(blob[at]), addr(bytes[0]), n)
+                    }
+                }
+            }
+            at += n
+        }
+    }
+    serialize_pod_array(arch, lens)
+    serialize_pod_array(arch, blob)
+    if (arch.reading) {
+        a |> resize(length(lens))
+        var at = 0
+        for (i in range(length(lens))) {
+            let n = lens[i]
+            if (n > 0) {
+                unsafe {
+                    a[i] = string(temp_array(addr<uint8?>(blob[at]), n, type<uint8>))
+                }
+            } else {
+                a[i] = ""
+            }
+            at += n
+        }
+    }
+    delete lens
+    delete blob
+}
+
+// the tokenizer, bulk: vocab/scores/token_type/merges as flat payloads; the lookup tables are
+// DERIVED (piece -> index, merge -> rank-order index) and rebuild in milliseconds at load —
+// exactly the "parse at load" carve-out the format spec allows
+def private serialize_tokenizer(var arch : Archive; var tk : Tokenizer) {
+    arch |> serialize_raw(tk.kind)
+    serialize_strings(arch, tk.spm.vocab)
+    serialize_pod_array(arch, tk.spm.scores)
+    arch |> serialize_raw(tk.spm.max_token_length)
+    arch |> serialize_raw(tk.spm.add_space_prefix)
+    arch |> serialize_raw(tk.spm.bos_id)
+    arch |> serialize_raw(tk.spm.eos_id)
+    serialize_strings(arch, tk.bpe.vocab)
+    serialize_pod_array(arch, tk.bpe.token_type)
+    arch |> serialize(tk.bpe.pre)
+    arch |> serialize_raw(tk.bpe.bos_id)
+    arch |> serialize_raw(tk.bpe.eos_id)
+    arch |> serialize_raw(tk.bpe.spm_space)
+    arch |> serialize_raw(tk.bpe.add_bos)
+    var merges : array<string>
+    if (!arch.reading) {
+        merges |> resize(length(tk.bpe.merge_rank))
+        for (k, v in keys(tk.bpe.merge_rank), values(tk.bpe.merge_rank)) {
+            merges[int(v)] := k
+        }
+    }
+    serialize_strings(arch, merges)
+    if (arch.reading) {
+        for (i, v in count(), tk.spm.vocab) {
+            tk.spm.lookup[v] = int64(i)
+        }
+        for (i, v in count(), tk.bpe.vocab) {
+            tk.bpe.lookup[v] = int64(i)
+        }
+        for (i, v in count(), merges) {
+            tk.bpe.merge_rank[v] = int64(i)
+        }
+    }
+    delete merges
+}
+
+// every non-array Model field, explicitly, both directions (the archive is bidirectional).
+// blocks is NOT serialized — resolve_arch re-binds it from the registry after the read.
+// The count tripwire below forces this list to grow with the struct.
+def private serialize_model_meta(var arch : Archive; var t : Model) {
+    arch |> serialize(t.config)
+    arch |> serialize(t.arch)
+    arch |> serialize(t.chat_template_str)
+    serialize_tokenizer(arch, t.tok)
+    arch |> serialize_raw(t.tok_emb_off)
+    arch |> serialize_raw(t.rms_att_off)
+    arch |> serialize_raw(t.rms_ffn_off)
+    arch |> serialize_raw(t.rms_final_off)
+    arch |> serialize_raw(t.rms_post_att_off)
+    arch |> serialize_raw(t.rms_post_ffn_off)
+    arch |> serialize_raw(t.rms_ones_off)
+    arch |> serialize_raw(t.out_scale_off)
+    arch |> serialize_raw(t.ple_emb_off)
+    arch |> serialize_raw(t.ple_model_off)
+    arch |> serialize_raw(t.ple_pnorm_off)
+    arch |> serialize_raw(t.ple_gate_off)
+    arch |> serialize_raw(t.ple_proj_off)
+    arch |> serialize_raw(t.ple_post_off)
+    arch |> serialize_raw(t.wscale_f16)
+    arch |> serialize_raw(t.experts_mx4)
+    arch |> serialize_raw(t.ple_model_bf16)
+    arch |> serialize_raw(t.kquant_native)
+    arch |> serialize_raw(t.kq_repacked)
+    arch |> serialize_raw(t.kq_repack_mr4)
+    arch |> serialize_raw(t.kq_repack_mr5)
+    arch |> serialize_raw(t.kq_repack_mr6)
+    arch |> serialize_raw(t.kq_repack_mr40)
+    arch |> serialize_raw(t.wcls_fmt)
+    arch |> serialize_raw(t.emb_fmt)
+    arch |> serialize_raw(t.ple_emb_fmt)
+    arch |> serialize_raw(t.router_off)
+    arch |> serialize_raw(t.shexp_gate_off)
+    arch |> serialize_raw(t.moe_router_scale_off)
+    arch |> serialize_raw(t.moe_down_scale_off)
+    arch |> serialize_raw(t.rms_pre_ffn2_off)
+    arch |> serialize_raw(t.rms_post_ffn1_off)
+    arch |> serialize_raw(t.rms_post_ffn2_off)
+    arch |> serialize_raw(t.router_b_off)
+    arch |> serialize_raw(t.exp_probs_off)
+    arch |> serialize_raw(t.web1_off)
+    arch |> serialize_raw(t.web2_off)
+    arch |> serialize_raw(t.web3_off)
+    arch |> serialize_raw(t.sinks_off)
+    arch |> serialize_raw(t.wsh1_off)
+    arch |> serialize_raw(t.wsh2_off)
+    arch |> serialize_raw(t.wsh3_off)
+    arch |> serialize_raw(t.wcls_off)
+    arch |> serialize_raw(t.cls_q8)
+    arch |> serialize_raw(t.emb_q8_off)
+    arch |> serialize_raw(t.quant)
+    arch |> serialize_raw(t.dn_conv_off)
+    arch |> serialize_raw(t.dn_dt_off)
+    arch |> serialize_raw(t.dn_a_off)
+    arch |> serialize_raw(t.dn_norm_off)
+    arch |> serialize_raw(t.dn_ba_f32)
+    arch |> serialize_raw(t.dn_betaf_off)
+    arch |> serialize_raw(t.dn_alphaf_off)
+    arch |> serialize_raw(t.dn_grouped)
+    arch |> serialize_raw(t.mtp_ehproj_off)
+    arch |> serialize_raw(t.mtp_ehproj_fmt)
+    arch |> serialize_raw(t.mtp_enorm_off)
+    arch |> serialize_raw(t.mtp_hnorm_off)
+    arch |> serialize_raw(t.mtp_headnorm_off)
+}
+
+// the tripwire: serialize_model_meta covers 63 fields; blocks + image_map + image_bytes are
+// deliberate skips. A new non-array Model field trips this until BOTH lists agree.
+let IMAGE_META_FIELDS = 63 + 3
+
+def private count_meta_fields(var t : Model) : int {
+    var n = 0
+    apply(t) $ [unused_argument(name, field)] (name : string; var field) {
+        static_if (!typeinfo is_array(field)) {
+            n++
+        }
+    }
+    return n
+}
+
+// ===== save =====
+
+//! Serialize a loaded Model as a prepared image: planes page-aligned raw (borrowed back at
+//! load), everything else archived. Atomic (tmp + rename). Returns false on any IO failure.
+def save_model_image(var t : Model; path : string) : bool {
+    let tmp_path = "{path}.tmp"
+    var ok = true
+    var meta <- new MemSerializer()
+    var warch = Archive(reading = false, stream = meta)
+    var sections : array<ImgSection>
+    fopen(tmp_path, "wb") $(f) {
+        if (f == null) {
+            ok = false
+            return
+        }
+        // page 0: header placeholder — patched after the walk (fseek back)
+        write_zeros(f, uint64(IMAGE_PAGE))
+        var cur = uint64(IMAGE_PAGE)
+        verify(count_meta_fields(t) == IMAGE_META_FIELDS)   // grew Model? extend serialize_model_meta
+        let ts_meta = ref_time_ticks()
+        serialize_model_meta(warch, t)
+        to_log(LOG_INFO, "dasLLAMA image: meta serialize {get_time_usec(ts_meta) / 1000}ms\n")
+        let ts_planes = ref_time_ticks()
+        apply(t) $(name : string; var field) {
+            static_if (typeinfo is_array(field)) {
+                if (!empty(field)) {
+                    let nbytes = uint64(length(field)) * uint64(typeinfo sizeof(field[0]))
+                    let at = pad_to_page(cur)
+                    write_zeros(f, at - cur)
+                    f |> fwrite(field)
+                    sections |> push(ImgSection(name = name, off = at, bytes = nbytes))
+                    cur = at + nbytes
+                }
+            }
+        }
+        to_log(LOG_INFO, "dasLLAMA image: planes write {get_time_usec(ts_planes) / 1000}ms\n")
+        // meta = [sections][the walk's scalar stream], one blob at the tail
+        var smeta <- new MemSerializer()
+        var sarch = Archive(reading = false, stream = smeta)
+        sarch |> serialize(sections)
+        var meta_blob <- smeta->extractData()
+        var scalar_blob <- meta->extractData()
+        meta_blob |> push_from(scalar_blob)
+        let meta_off = cur
+        let meta_bytes = uint64(length(meta_blob))
+        f |> fwrite(meta_blob)
+        cur += meta_bytes
+        // pad the file itself to a page multiple (the whole-file bytesNoCopy wrap needs it)
+        let fend = pad_to_page(cur)
+        write_zeros(f, fend - cur)
+        // patch the header
+        var hdr : array<uint8>
+        hdr |> resize(int(IMAGE_HEADER_BYTES))
+        store_u32(hdr, 0, IMAGE_MAGIC)
+        store_u32(hdr, 4, uint(IMAGE_VERSION))
+        store_u32(hdr, 8, uint(IMAGE_PAGE))
+        store_u32(hdr, 12, uint(length(sections)))
+        store_u64(hdr, 16, meta_off)
+        store_u64(hdr, 24, meta_bytes)
+        store_u64(hdr, 32, fend)
+        store_u64(hdr, 40, hash(image_identity()))
+        fseek(f, 0l, seek_set)
+        f |> fwrite(hdr)
+        delete hdr
+        delete meta_blob
+        delete scalar_blob
+        unsafe {
+            delete smeta
+        }
+        delete sections
+    }
+    unsafe {
+        delete meta
+    }
+    if (!ok) {
+        return false
+    }
+    remove(path)   // rename-over is not portable — drop any stale image first
+    if (!rename(tmp_path, path)) {
+        remove(tmp_path)
+        return false
+    }
+    return true
+}
+
+// ===== load =====
+
+//! Map a prepared image and rebuild the Model with zero O(model) work: plane fields borrow
+//! the mapping (the Model finalizer forgets + unmaps), the archive blob restores everything
+//! else. false = absent / wrong identity / wrong version — the caller regenerates from gguf.
+def load_model_image(path : string; var t : Model) : bool {
+    if (!stat(path).is_valid) {
+        return false
+    }
+    var msize = 0ul
+    var base : void?
+    unsafe {
+        base = fmap_open(path, addr(msize))
+    }
+    var bp : uint8 const?
+    unsafe {
+        bp = reinterpret<uint8 const?>(base)
+    }
+    if (int64(msize) < IMAGE_HEADER_BYTES ||
+            (read_u32(bp, 0l) != IMAGE_MAGIC || read_u32(bp, 4l) != uint(IMAGE_VERSION)) ||
+            (read_u32(bp, 8l) != uint(IMAGE_PAGE) || read_u64(bp, 40l) != hash(image_identity()))) {
+        unsafe {
+            fmap_close(base, msize)
+        }
+        return false
+    }
+    let nsections = int(read_u32(bp, 12l))
+    let meta_off = read_u64(bp, 16l)
+    let meta_bytes = read_u64(bp, 24l)
+    let file_bytes = read_u64(bp, 32l)
+    if (file_bytes != msize || meta_off + meta_bytes > msize) {
+        unsafe {
+            fmap_close(base, msize)
+        }
+        return false
+    }
+    // the meta blob is the ONE copied+parsed piece (small); planes stay lazy in the mapping
+    var meta_blob : array<uint8>
+    meta_blob |> resize(int(meta_bytes))
+    unsafe {
+        memcpy(addr(meta_blob[0]), reinterpret<void?>(bp + int64(meta_off)), int(meta_bytes))
+    }
+    var meta <- new MemSerializer(meta_blob)
+    var rarch = Archive(reading = true, stream = meta)
+    var sections : array<ImgSection>
+    rarch |> serialize(sections)
+    var by_name <- {for (sec in sections); sec.name => sec}
+    serialize_model_meta(rarch, t)
+    resolve_arch(t, t.arch)   // blocks re-bind + the arch's (idempotent) configure
+    var ok = true
+    apply(t) $(name : string; var field) {
+        static_if (typeinfo is_array(field)) {
+            if (key_exists(by_name, name)) {
+                let sec = by_name?[name] ?? ImgSection()
+                let esz = uint64(typeinfo sizeof(field[0]))
+                if (sec.off % uint64(IMAGE_PAGE) != 0ul || sec.off + sec.bytes > msize || sec.bytes % esz != 0ul) {
+                    ok = false
+                } else {
+                    unsafe {
+                        _builtin_make_temp_array_i64(field, reinterpret<void?>(bp + int64(sec.off)), int64(sec.bytes / esz))
+                    }
+                }
+            }
+        }
+    }
+    delete meta_blob
+    delete sections
+    delete by_name
+    unsafe {
+        delete meta
+    }
+    if (!ok || nsections < 0) {
+        // a malformed section table: forget whatever was borrowed and unmap
+        delete t
+        return false
+    }
+    t.image_map = base
+    t.image_bytes = msize
+    return true
+}

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -436,7 +436,8 @@ def private borrow_plane(bp : uint8 const?; msize : uint64; path : string;
     }
     let sec = by_name?[name] ?? ImgSection()
     let esz = uint64(typeinfo sizeof(field[0]))
-    if (sec.off % uint64(IMAGE_PAGE) != 0ul || sec.off + sec.bytes > msize || sec.bytes % esz != 0ul) {
+    // bytes-then-offset ordering keeps the bounds math wrap-free (off + bytes could overflow)
+    if (sec.off % uint64(IMAGE_PAGE) != 0ul || sec.bytes > msize || sec.off > msize - sec.bytes || sec.bytes % esz != 0ul) {
         to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — section '{name}' at {sec.off}+{sec.bytes} (esz {esz}) is malformed\n")
         ok = false
     } else {
@@ -462,9 +463,17 @@ def load_image(path : string; var t; tag : string = "") : bool {
     unsafe {
         base = fmap_open(path, addr(msize))
     }
+    if (base == null || int64(msize) < IMAGE_HEADER_BYTES) {
+        // fmap_open declines with null (vanished file, mmap failure, >size_t on 32-bit) —
+        // treat it like any other decline; the header reads below need a real mapping
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — cannot map ({msize} bytes)\n")
+        if (base != null) {
+            unsafe(fmap_close(base, msize))
+        }
+        return false
+    }
     var bp = unsafe(reinterpret<uint8 const?>(base))
-    if (int64(msize) < IMAGE_HEADER_BYTES ||
-            (read_u32(bp, 0l) != IMAGE_MAGIC || read_u32(bp, 4l) != uint(IMAGE_VERSION)) ||
+    if ((read_u32(bp, 0l) != IMAGE_MAGIC || read_u32(bp, 4l) != uint(IMAGE_VERSION)) ||
             (read_u32(bp, 8l) != uint(IMAGE_PAGE) || read_u64(bp, 40l) != hash(image_identity(tag)))) {
         // every decline is loud (short of the file simply not existing) — a silently
         // regenerating cache is undebuggable
@@ -476,7 +485,9 @@ def load_image(path : string; var t; tag : string = "") : bool {
     let meta_off = read_u64(bp, 16l)
     let meta_bytes = read_u64(bp, 24l)
     let file_bytes = read_u64(bp, 32l)
-    if (file_bytes != msize || meta_off + meta_bytes > msize) {
+    // bytes-first ordering keeps meta_off + meta_bytes wrap-free; the INT_MAX cap bounds the
+    // int() casts the copy below takes (real meta blobs are a few MB)
+    if (file_bytes != msize || meta_bytes > msize || meta_off > msize - meta_bytes || meta_bytes > uint64(INT_MAX)) {
         to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — header says {file_bytes} bytes / meta {meta_off}+{meta_bytes}, mapped {msize}\n")
         unsafe(fmap_close(base, msize))
         return false
@@ -519,8 +530,10 @@ def load_image(path : string; var t; tag : string = "") : bool {
         delete meta
     }
     if (!ok || nsections < 0) {
-        // a malformed section table: forget whatever was borrowed and unmap
+        // a malformed section table: forget whatever was borrowed (the finalizer), THEN unmap —
+        // image_map was never set, so the finalizer alone would leak the mapping
         delete t
+        unsafe(fmap_close(base, msize))
         return false
     }
     t.image_map = base

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -21,7 +21,7 @@ require dasllama/dasllama_math   // active_kernel_backend — half the image ide
 // stay lazy (full verification belongs to the offline tool, not load).
 
 // bump on ANY layout/serialization change — a mismatched image regenerates from the gguf
-let IMAGE_VERSION = 1
+let IMAGE_VERSION = 2
 let IMAGE_PAGE = 16384l          // Apple-Silicon page: the bytesNoCopy alignment contract
 let IMAGE_HEADER_BYTES = 64l     // magic..identity, inside the first page
 let IMAGE_MAGIC = 0x314D4C44u    // 'DLM1'
@@ -32,9 +32,14 @@ struct private ImgSection {
     bytes : uint64
 }
 
-// the box + knob identity an image is valid for; folded into the file name AND the header
+// the box + knob identity an image is valid for; folded into the file name AND the header.
+// It names the exact plane layout, so it must be computed AFTER the same backend select the
+// gguf loader runs at repack time — the entry-time auto default is a different backend.
 def image_identity : string {
-    return "v{IMAGE_VERSION}|{active_kernel_backend()}|{get_wscale_f16() ? "s16" : "s32"}"
+    select_matmul_backend_for_load()
+    return ("v{IMAGE_VERSION}|{active_kernel_backend()}|{get_wscale_f16() ? "s16" : "s32"}"
+        + "|q8 mr{active_q8_layout_mr()} b{active_q8_wbias()} g{active_q8_kgroup()}"
+        + "|kq {active_kq_layout_mr(4)}/{active_kq_layout_mr(5)}/{active_kq_layout_mr(6)}/{active_kq_layout_mr(40)}")
 }
 
 // the image path for (gguf, current identity) — knob combos coexist as separate files
@@ -59,14 +64,14 @@ def private write_zeros(f : file; n : uint64) {
 
 def private store_u32(var b : array<uint8>; at : int; v : uint) {
     unsafe {
-        var p = unsafe(addr<uint?>(b[at]))
+        var p = unsafe(addr < uint ? > (b[at]))
         p[0] = v
     }
 }
 
 def private store_u64(var b : array<uint8>; at : int; v : uint64) {
     unsafe {
-        var p = unsafe(addr<uint64?>(b[at]))
+        var p = unsafe(addr < uint64 ? > (b[at]))
         p[0] = v
     }
 }
@@ -142,7 +147,7 @@ def private serialize_strings(var arch : Archive; var a : array<string>) {
             let n = lens[i]
             if (n > 0) {
                 unsafe {
-                    a[i] = string(temp_array(addr<uint8?>(blob[at]), n, type<uint8>))
+                    a[i] = string(temp_array(addr < uint8 ? > (blob[at]), n, type<uint8>))
                 }
             } else {
                 a[i] = ""
@@ -303,12 +308,20 @@ def save_model_image(var t : Model; path : string) : bool {
         apply(t) $(name : string; var field) {
             static_if (typeinfo is_array(field)) {
                 if (!empty(field)) {
-                    let nbytes = uint64(length(field)) * uint64(typeinfo sizeof(field[0]))
+                    // long_length, NOT length: a >2 GiB plane (voxtral-mini qblob = 3.6 G elements)
+                    // wraps int32 length negative, and -jit inlines length() without the C++ guard
+                    let nbytes = uint64(long_length(field)) * uint64(typeinfo sizeof(field[0]))
                     let at = pad_to_page(cur)
                     write_zeros(f, at - cur)
                     f |> fwrite(field)
                     sections |> push(ImgSection(name = name, off = at, bytes = nbytes))
                     cur = at + nbytes
+                    // fwrite and the section table must agree byte-for-byte, or the mapped
+                    // planes land at the wrong offsets — fail the save loudly, not the load
+                    if (uint64(ftell(f)) != cur) {
+                        to_log(LOG_ERROR, "dasLLAMA image: plane '{name}' wrote {ftell(f)} != accounted {cur} (nbytes {nbytes}) — image save aborted\n")
+                        ok = false
+                    }
                 }
             }
         }
@@ -352,6 +365,7 @@ def save_model_image(var t : Model; path : string) : bool {
         delete meta
     }
     if (!ok) {
+        remove(tmp_path)
         return false
     }
     remove(path)   // rename-over is not portable — drop any stale image first
@@ -371,6 +385,9 @@ def load_model_image(path : string; var t : Model) : bool {
     if (!stat(path).is_valid) {
         return false
     }
+    // the mapped planes are packed for the load backend — activate it before any kernel runs
+    // (same select the gguf loader does; the identity check below then names that backend)
+    select_matmul_backend_for_load()
     var msize = 0ul
     var base : void?
     unsafe {
@@ -383,6 +400,9 @@ def load_model_image(path : string; var t : Model) : bool {
     if (int64(msize) < IMAGE_HEADER_BYTES ||
             (read_u32(bp, 0l) != IMAGE_MAGIC || read_u32(bp, 4l) != uint(IMAGE_VERSION)) ||
             (read_u32(bp, 8l) != uint(IMAGE_PAGE) || read_u64(bp, 40l) != hash(image_identity()))) {
+        // every decline is loud (short of the file simply not existing) — a silently
+        // regenerating cache is undebuggable
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — size {msize} magic {read_u32(bp, 0l)} version {read_u32(bp, 4l)} (want {IMAGE_VERSION}) page {read_u32(bp, 8l)} identity {read_u64(bp, 40l)} (want {hash(image_identity())} = '{image_identity()}')\n")
         unsafe {
             fmap_close(base, msize)
         }
@@ -393,6 +413,7 @@ def load_model_image(path : string; var t : Model) : bool {
     let meta_bytes = read_u64(bp, 24l)
     let file_bytes = read_u64(bp, 32l)
     if (file_bytes != msize || meta_off + meta_bytes > msize) {
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — header says {file_bytes} bytes / meta {meta_off}+{meta_bytes}, mapped {msize}\n")
         unsafe {
             fmap_close(base, msize)
         }
@@ -418,6 +439,7 @@ def load_model_image(path : string; var t : Model) : bool {
                 let sec = by_name?[name] ?? ImgSection()
                 let esz = uint64(typeinfo sizeof(field[0]))
                 if (sec.off % uint64(IMAGE_PAGE) != 0ul || sec.off + sec.bytes > msize || sec.bytes % esz != 0ul) {
+                    to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — section '{name}' at {sec.off}+{sec.bytes} (esz {esz}) is malformed\n")
                     ok = false
                 } else {
                     unsafe {

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -495,8 +495,9 @@ def load_image(path : string; var t; tag : string = "") : bool {
     let meta_bytes = read_u64(bp, 24l)
     let file_bytes = read_u64(bp, 32l)
     // bytes-first ordering keeps meta_off + meta_bytes wrap-free; the INT_MAX cap bounds the
-    // int() casts the copy below takes (real meta blobs are a few MB)
-    if (file_bytes != msize || meta_bytes > msize || meta_off > msize - meta_bytes || meta_bytes > uint64(INT_MAX)) {
+    // int() casts the copy below takes (real meta blobs are a few MB, never empty — the
+    // section table always rides there, and addr(meta_blob[0]) needs a nonzero resize)
+    if (file_bytes != msize || meta_bytes == 0ul || meta_bytes > msize || meta_off > msize - meta_bytes || meta_bytes > uint64(INT_MAX)) {
         to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — header says {file_bytes} bytes / meta {meta_off}+{meta_bytes}, mapped {msize}\n")
         unsafe(fmap_close(base, msize))
         return false

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -413,7 +413,9 @@ def save_image(var t; path : string; tag : string = "") : bool {
         delete meta
     }
     if (!ok) {
-        remove(tmp_path)
+        if (!remove(tmp_path)) {
+            to_log(LOG_WARNING, "dasLLAMA image: orphaned tmp '{tmp_path}' could not be removed — clean it up by hand\n")
+        }
         return false
     }
     if (rename(tmp_path, path)) {
@@ -423,7 +425,9 @@ def save_image(var t; path : string; tag : string = "") : bool {
     // brief missing-file window only costs a concurrent reader a regenerate
     remove(path)
     if (!rename(tmp_path, path)) {
-        remove(tmp_path)
+        if (!remove(tmp_path)) {
+            to_log(LOG_WARNING, "dasLLAMA image: orphaned tmp '{tmp_path}' could not be removed — clean it up by hand\n")
+        }
         return false
     }
     return true

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -504,6 +504,19 @@ def load_image(path : string; var t; tag : string = "") : bool {
     var rarch = Archive(reading = true, stream = meta)
     var sections : array<ImgSection>
     rarch |> serialize(sections)
+    // the header count must agree with the meta blob's own section list — a disagreement
+    // means header/meta corruption, and silently-absent sections would leave planes EMPTY
+    // (indistinguishable from legitimately-empty ones)
+    if (length(sections) != nsections) {
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — header says {nsections} sections, meta carries {length(sections)}\n")
+        delete sections
+        delete meta_blob
+        unsafe {
+            delete meta
+        }
+        unsafe(fmap_close(base, msize))
+        return false
+    }
     var by_name <- {for (sec in sections); sec.name => sec}
     _::serialize_image_meta(rarch, t)
     _::image_post_load(t)
@@ -531,7 +544,7 @@ def load_image(path : string; var t; tag : string = "") : bool {
     unsafe {
         delete meta
     }
-    if (!ok || nsections < 0) {
+    if (!ok) {
         // a malformed section table: forget whatever was borrowed (the finalizer), THEN unmap —
         // image_map was never set, so the finalizer alone would leak the mapping
         delete t

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -526,6 +526,19 @@ def load_image(path : string; var t; tag : string = "") : bool {
         return false
     }
     var by_name <- {for (sec in sections); sec.name => sec}
+    // duplicate section names would silently overwrite table entries and borrow the wrong
+    // plane — a valid save never produces them, so a collision is corruption
+    if (length(by_name) != length(sections)) {
+        to_log(LOG_WARNING, "dasLLAMA image: '{path}' declined — {length(sections)} sections carry duplicate names\n")
+        delete by_name
+        delete sections
+        delete meta_blob
+        unsafe {
+            delete meta
+        }
+        unsafe(fmap_close(base, msize))
+        return false
+    }
     _::serialize_image_meta(rarch, t)
     // a truncated/corrupt meta blob reads back as silent zero-progress (MemSerializer sets
     // lastError, no panic) — decline BEFORE post_load, which would panic on garbage (e.g. an

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -329,10 +329,12 @@ def private write_plane(f : file; var sections : array<ImgSection>; var cur : ui
 }
 
 //! Serialize a loaded weight-carrying struct as a prepared image: array planes page-aligned
-//! raw (borrowed back at load), everything else archived. Atomic (tmp + rename). Returns
-//! false on any IO failure. The caller's module must provide `serialize_image_meta(Archive,
-//! T)` for every non-array field and `image_post_load(T)` for post-read fix-ups (`_::`
-//! dispatch — Model's live here, AudioTower's in dasllama_audio).
+//! raw (borrowed back at load), everything else archived. Tmp + rename: atomic replace where
+//! rename-over-existing works (POSIX); where it doesn't (Windows) a brief missing-file window
+//! exists and a concurrent reader just regenerates. Returns false on any IO failure. The
+//! caller's module must provide `serialize_image_meta(Archive, T)` for every non-array field
+//! and `image_post_load(T)` for post-read fix-ups (`_::` dispatch — Model's live here,
+//! AudioTower's in dasllama_audio).
 def save_image(var t; path : string; tag : string = "") : bool {
     // per-writer tmp name: concurrent savers (parallel test workers on one cache miss) must
     // not clobber each other's half-written file; last atomic rename wins with same content
@@ -414,7 +416,12 @@ def save_image(var t; path : string; tag : string = "") : bool {
         remove(tmp_path)
         return false
     }
-    remove(path)   // rename-over is not portable — drop any stale image first
+    if (rename(tmp_path, path)) {
+        return true   // the atomic replace (POSIX rename-over)
+    }
+    // rename-over-existing is not portable (Windows) — drop the stale image and retry; the
+    // brief missing-file window only costs a concurrent reader a regenerate
+    remove(path)
     if (!rename(tmp_path, path)) {
         remove(tmp_path)
         return false

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -523,6 +523,10 @@ def load_image(path : string; var t; tag : string = "") : bool {
     }
     t.image_map = base
     t.image_bytes = msize
+    // address-keyed weight caches (the Metal drivers' resident regions) flush on the weights
+    // epoch; this mapping may sit at a deleted model's recycled addresses, so it counts as a
+    // load exactly like load_gguf's own bump does
+    bump_weights_epoch()
     return true
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_whisper.das
+++ b/modules/dasLLAMA/dasllama/dasllama_whisper.das
@@ -5,12 +5,16 @@ module dasllama_whisper shared public
 require math
 require daslib/fio
 require daslib/array_boost // nolint:STYLE030 — temp_array is [template]; STYLE030 misses template-fn refs
+require daslib/apply
+require daslib/archive
 require strings
 require dasllama/dasllama_math
 require dasllama/dasllama_par
 require dasllama/dasllama_gguf
 require dasllama/dasllama_quant
 require dasllama/dasllama_audio
+require dasllama/dasllama_common   // apply_box_profile_runtime for the whisper-image identity
+require dasllama/dasllama_image
 
 // Whisper-proper ASR: reads ggerganov/whisper.cpp ggml-*.bin models directly (drop-in HF
 // models, no converter), reuses the validated encoder tower from dasllama_audio, adds the
@@ -55,6 +59,72 @@ struct WhisperModel {
     d_ln_b_off : int64
     dlayers_off : int64
     dlayer_stride : int64
+    image_map : void?         // non-null when the planes borrow a mapped .dlim (dasllama_image)
+    image_bytes : uint64
+}
+
+def finalize(var t : WhisperModel) {
+    apply(t) $ [unused_argument(name)] (name : string; var field) {
+        static_if (typeinfo is_array(field)) {
+            if (lock_count(field) != 0) {
+                unsafe {
+                    _builtin_forget_temp_array(field)
+                }
+            } else {
+                delete field
+            }
+        } static_elif (typeinfo is_struct(field)) {
+            delete field   // enc's own finalizer forgets ITS borrowed planes
+        }
+    }
+    if (t.image_map != null) {
+        unsafe {
+            fmap_close(t.image_map, t.image_bytes)
+        }
+        t.image_map = null
+        t.image_bytes = 0ul
+    }
+}
+
+// the tripwire: serialize_image_meta(WhisperModel) covers 27 fields (vocab rides the meta
+// blob — string arrays can't be raw planes; enc reuses AudioTower's list); mel (rebuilt at
+// load) + image_map + image_bytes are deliberate skips.
+let private WHISPER_META_FIELDS = 27 + 3
+
+// every meta-carried WhisperModel field, explicitly, both directions (see dasllama_image)
+def private serialize_image_meta(var arch : Archive; var t : WhisperModel) {
+    verify(count_meta_fields(t) == WHISPER_META_FIELDS)   // grew WhisperModel? extend this list
+    arch |> serialize_raw(t.n_vocab)
+    arch |> serialize_raw(t.n_text_ctx)
+    arch |> serialize_raw(t.n_text_state)
+    arch |> serialize_raw(t.n_text_head)
+    arch |> serialize_raw(t.n_text_layer)
+    arch |> serialize_raw(t.eps)
+    arch |> serialize_raw(t.multilingual)
+    arch |> serialize_raw(t.n_lang)
+    arch |> serialize_raw(t.tok_eot)
+    arch |> serialize_raw(t.tok_sot)
+    arch |> serialize_raw(t.tok_translate)
+    arch |> serialize_raw(t.tok_transcribe)
+    arch |> serialize_raw(t.tok_solm)
+    arch |> serialize_raw(t.tok_prev)
+    arch |> serialize_raw(t.tok_nosp)
+    arch |> serialize_raw(t.tok_not)
+    arch |> serialize_raw(t.tok_beg)
+    arch |> serialize_raw(t.tok_space)
+    serialize_strings(arch, t.vocab)
+    serialize_image_meta(arch, t.enc)
+    arch |> serialize_raw(t.dq8)
+    arch |> serialize_raw(t.d_pe_off)
+    arch |> serialize_raw(t.d_te_off)
+    arch |> serialize_raw(t.d_ln_w_off)
+    arch |> serialize_raw(t.d_ln_b_off)
+    arch |> serialize_raw(t.dlayers_off)
+    arch |> serialize_raw(t.dlayer_stride)
+}
+
+def private image_post_load(var t : WhisperModel) {
+    t.mel <- build_whisper_mel_plan(AUDIO_N_FFT)   // derived tables — the parse-at-load carve-out
 }
 
 // Per-layer decoder tensor offsets inside dblob, in layout order (24 tensors: self-attn
@@ -252,7 +322,43 @@ def private wt_read_conv_permuted(recs : table<string; WTensorRec>; b : array<ui
 
 //! Load a whisper.cpp ggml-*.bin model (f32/f16 tensor types; quantized whisper bins are not
 //! supported). Verified against whisper.cpp's whisper_model_load, byte for byte.
+//! Like ``load_model``, keeps a PREPARED IMAGE next to the bin (box + knob specific): the
+//! first load saves it, later loads map it in milliseconds with zero-copy weight planes.
+//! ``DASLLAMA_IMAGE=0`` disables the cache; a ``.dlim`` path loads that image directly.
 def load_whisper_model(path : string; q8 : bool = false) : WhisperModel {
+    let tag = q8 ? "whisper-q8" : "whisper-f32"
+    if (path |> ends_with(".dlim")) {
+        // named directly — no source bin to regenerate from, so a wrong identity panics
+        apply_box_profile_runtime()
+        let ts_img = ref_time_ticks()
+        var t = WhisperModel()
+        if (!load_image(path, t, tag)) {
+            panic("dasLLAMA: '{path}' is not a prepared whisper image for this box/knobs (identity {image_identity(tag)}) — regenerate it from the source model")
+        }
+        to_log(LOG_INFO, "dasLLAMA: prepared whisper image mapped in {get_time_usec(ts_img) / 1000} ms — {path}\n")
+        return <- t
+    }
+    if (get_env_variable("DASLLAMA_IMAGE") != "0") {
+        apply_box_profile_runtime()   // a backend pin must precede the identity (it names the backend)
+        let img = image_path_for(path, tag)
+        let ts_img = ref_time_ticks()
+        var t = WhisperModel()
+        if (load_image(img, t, tag)) {
+            to_log(LOG_INFO, "dasLLAMA: prepared whisper image mapped in {get_time_usec(ts_img) / 1000} ms — {img}\n")
+            return <- t
+        }
+        var m <- load_whisper_model_(path, q8)
+        let ts_save = ref_time_ticks()
+        if (save_image(m, img, tag)) {
+            to_log(LOG_INFO, "dasLLAMA: prepared whisper image saved in {get_time_usec(ts_save) / 1000} ms — {img}\n")
+        }
+        return <- m
+    }
+    return <- load_whisper_model_(path, q8)
+}
+
+// the ggml-bin reader proper (see load_whisper_model's doc for the container contract)
+def private load_whisper_model_(path : string; q8 : bool = false) : WhisperModel {
     var w = WhisperModel()
     // the record walk runs until EOF, so it needs the true byte count — length(bytes) is
     // int32 and wraps negative on >2 GB bins (large-v3); stat's st_size is 64-bit

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1556,6 +1556,23 @@ class public LlvmJitVisitor : AstVisitor {
     }
 
     def make_call(expr : ExprCallFunc?; doesNotNeedSp : bool) {
+        // $::length over an array truncates Array.size (u64) to i32 — guard the truncation to
+        // match the ALWAYS-ON C++ builtin_array_size panic (interp + AOT). Deliberately not
+        // gated on option_no_range_check: the C++ guard is not a bounds check and never
+        // disables, so the hint must not reintroduce the divergence.
+        if (expr.func.name == "length" && expr.func._module.name == "$" &&
+                (length(expr.arguments) == 1 && expr.arguments[0]._type.isGoodArrayType)) {
+            var arr0 = LLVMBuildLoad2(g_builder, type_to_llvm_type(expr.arguments[0]._type), getE(expr.arguments[0]), "arr.lenguard")
+            var size_i64 = LLVMBuildExtractValue(g_builder, arr0, uint(JIT_ARRAY.SIZE), "array.size.guard")
+            var guard_fail = append_basic_block("len_guard_fail")
+            var guard_end = append_basic_block("len_guard_end")
+            var too_big = LLVMBuildICmp(g_builder, LLVMIntPredicate.LLVMIntUGT, size_i64, LLVMConstInt(types.t_int64, uint64(INT_MAX), 0), "len_over_i32")
+            LLVMBuildCondBr(g_builder, too_big, guard_fail, guard_end)
+            LLVMPositionBuilderAtEnd(g_builder, guard_fail)
+            build_exception("array size exceeds INT_MAX; use long_length() instead", expr.at)
+            LLVMBuildBr(g_builder, guard_end)
+            LLVMPositionBuilderAtEnd(g_builder, guard_end)
+        }
         // lookup intrinsics first
         var intrin_call = lookup_intinsic(g_ctx, g_builder, types, expr, [for (x in expr.arguments); getE(x)])
         if (intrin_call != null) {

--- a/modules/dasLLVM/daslib/llvm_jit_intrin.das
+++ b/modules/dasLLVM/daslib/llvm_jit_intrin.das
@@ -370,8 +370,9 @@ def intrinsic_builtin_length(var ctx : JitCtx; expr : ExprCallFunc?; arguments :
     if (argType.isGoodArrayType) {
         var arr = LLVMBuildLoad2(ctx.builder, type_to_llvm_type(expr.arguments[0]._type), arguments[0], "arr")
         var size_i64 = LLVMBuildExtractValue(ctx.builder, arr, uint(JIT_ARRAY.SIZE), "array.size")
-        // builtin length() returns int32; Array.size is uint64. Truncate.
-        // TODO Phase 7: emit panic if size > INT32_MAX to match C++ builtin_array_size.
+        // builtin length() returns int32; Array.size is uint64. Truncate — the >INT_MAX panic
+        // matching C++ builtin_array_size is emitted by make_call before this intrinsic runs
+        // (it needs basic blocks + the exception rail, which live with the visitor).
         return LLVMBuildTruncOrBitCast(ctx.builder, size_i64, ctx.types.t_int32, "array.size.i32")
     } else {
         return null

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -33,7 +33,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x42ul   // full-stack prologue emission reads LlvmJitFlags (0x41: bounded kq i16 pair-sum chains)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x43ul   // length() emits the >INT_MAX guard (0x42: full-stack prologue emission reads LlvmJitFlags)
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasMetal/src/dasMetal.h
+++ b/modules/dasMetal/src/dasMetal.h
@@ -36,6 +36,8 @@ namespace das {
 
     DAS_MOD_API MetalBuffer * metal_new_buffer ( MetalDevice * dev, uint64_t bytes, Context * ctx, LineInfoArg * at );
     DAS_MOD_API MetalBuffer * metal_new_buffer_untracked ( MetalDevice * dev, uint64_t bytes, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API MetalBuffer * metal_new_buffer_no_copy ( MetalDevice * dev, void * data, uint64_t bytes, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API uint64_t metal_max_buffer_length ( MetalDevice * dev, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void * metal_buffer_contents ( MetalBuffer * buf, Context * ctx, LineInfoArg * at );
 
     DAS_MOD_API MetalCommandBuffer * metal_new_command_buffer ( MetalCommandQueue * queue, Context * ctx, LineInfoArg * at );

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -190,6 +190,37 @@ namespace das {
         }
     }
 
+    // ZERO-COPY buffer over caller-owned memory (the prepared-model-image mappings): wraps the
+    // pages instead of copying — unified memory makes the same bytes GPU-visible. Both pointer
+    // and length must be PAGE-ALIGNED (Metal's bytesNoCopy contract; 16KB on Apple Silicon —
+    // the image format page-aligns every GPU-bound plane). No deallocator: the caller's
+    // mapping must outlive the buffer (release the buffer before fmap_close). Untracked like
+    // the weight buffers above — the wrapped planes are GPU-read-only.
+    MetalBuffer * metal_new_buffer_no_copy ( MetalDevice * dev, void * data, uint64_t bytes, Context * ctx, LineInfoArg * at ) {
+        if ( !dev ) ctx->throw_error_at(at, "metal_new_buffer_no_copy: null device");
+        if ( !data ) ctx->throw_error_at(at, "metal_new_buffer_no_copy: null data");
+        if ( bytes == 0 ) ctx->throw_error_at(at, "metal_new_buffer_no_copy: zero size");
+        uint64_t page = uint64_t(getpagesize());
+        if ( (uintptr_t(data) % page) != 0 || (bytes % page) != 0 ) {
+            ctx->throw_error_at(at, "metal_new_buffer_no_copy: pointer and length must be page-aligned (%llu)",
+                (unsigned long long)page);
+        }
+        @autoreleasepool {
+            id<MTLDevice> d = (__bridge id<MTLDevice>)(void *) dev;
+            id<MTLBuffer> b = [d newBufferWithBytesNoCopy:data length:bytes
+                options:MTLResourceStorageModeShared | MTLResourceHazardTrackingModeUntracked
+                deallocator:nil];
+            if ( !b ) ctx->throw_error_at(at, "metal_new_buffer_no_copy: wrap failed (%llu bytes)", (unsigned long long)bytes);
+            return retain_handle<MetalBuffer>(b);
+        }
+    }
+
+    uint64_t metal_max_buffer_length ( MetalDevice * dev, Context * ctx, LineInfoArg * at ) {
+        if ( !dev ) ctx->throw_error_at(at, "metal_max_buffer_length: null device");
+        id<MTLDevice> d = (__bridge id<MTLDevice>)(void *) dev;
+        return (uint64_t) d.maxBufferLength;
+    }
+
     void * metal_buffer_contents ( MetalBuffer * buf, Context * ctx, LineInfoArg * at ) {
         if ( !buf ) ctx->throw_error_at(at, "metal_buffer_contents: null buffer");
         id<MTLBuffer> b = (__bridge id<MTLBuffer>)(void *) buf;
@@ -511,6 +542,12 @@ namespace das {
             addExtern<DAS_BIND_FUN(metal_new_buffer_untracked)>(*this, lib, "metal_new_buffer_untracked",
                 SideEffects::modifyExternal, "metal_new_buffer_untracked")
                     ->args({"device", "bytes", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_new_buffer_no_copy)>(*this, lib, "metal_new_buffer_no_copy",
+                SideEffects::modifyExternal, "metal_new_buffer_no_copy")
+                    ->args({"device", "data", "bytes", "context", "at"})->unsafeOperation = true;
+            addExtern<DAS_BIND_FUN(metal_max_buffer_length)>(*this, lib, "metal_max_buffer_length",
+                SideEffects::accessExternal, "metal_max_buffer_length")
+                    ->args({"device", "context", "at"});
             addExtern<DAS_BIND_FUN(metal_buffer_contents)>(*this, lib, "metal_buffer_contents",
                 SideEffects::modifyExternal, "metal_buffer_contents")
                     ->args({"buffer", "context", "at"});

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -427,6 +427,11 @@ namespace das {
 #ifdef _MSC_VER
         return _fseeki64((FILE *)f, offset, mode);
 #else
+        // off_t can be 32-bit (no _FILE_OFFSET_BITS=64) — a truncated offset would silently
+        // seek to the wrong position; fail loudly instead
+        if ( int64_t(off_t(offset)) != offset ) {
+            context->throw_error_at(at, "fseek: offset %lli does not fit off_t", (long long int)offset);
+        }
         return fseeko((FILE *)f, off_t(offset), mode);
 #endif
     }

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -376,8 +376,11 @@ namespace das {
     }
 
     // split fmap (the prepared-model-image loader): the mapping OUTLIVES the call — the caller
-    // owns it and unmaps via fmap_close. Read-only shared pages: clean (droppable under memory
-    // pressure, never swapped) and shared across processes through the OS page cache. The FILE
+    // owns it and unmaps via fmap_close. POSIX maps PROT_READ/MAP_SHARED: OS-enforced
+    // read-only, clean droppable pages shared across processes through the page cache. The
+    // win32 mmap shim below ignores prot and maps PAGE_WRITECOPY/FILE_MAP_COPY instead —
+    // copy-on-write, so an accidental write does NOT fault there (it just privatizes the
+    // page); pages stay clean and shareable only as long as nothing writes them. The FILE
     // closes right after mapping — both POSIX and the win32 shim keep the view alive through
     // the mapping's own file reference. Failure returns null (size stays 0) rather than
     // throwing: this is a cache probe — the caller declines and regenerates from the source.

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -238,6 +238,8 @@ namespace das {
     const FILE * builtin_fopen  ( const char *, const char *, Context *, LineInfoArg * ) GENERATE_IO_STUB_RET
     vec4f builtin_read ( Context &, SimNode_CallBase *, vec4f * ) GENERATE_IO_STUB_RET
     vec4f builtin_write ( Context &, SimNode_CallBase *, vec4f * ) GENERATE_IO_STUB_RET
+    vec4f builtin_read64 ( Context &, SimNode_CallBase *, vec4f * ) GENERATE_IO_STUB_RET
+    vec4f builtin_write64 ( Context &, SimNode_CallBase *, vec4f * ) GENERATE_IO_STUB_RET
     vec4f builtin_load ( Context &, SimNode_CallBase *, vec4f * ) GENERATE_IO_STUB_RET
     bool builtin_stat ( const char *, FStat & ) GENERATE_IO_STUB_RET
     bool builtin_chdir ( const char * ) GENERATE_IO_STUB_RET
@@ -408,14 +410,24 @@ namespace das {
         munmap(data, size_t(size));
     }
 
+    // plain ftell/fseek take `long`, which is 32-bit on Windows (LLP64) — use the explicit
+    // 64-bit forms so offsets past 2GB survive on every platform
     int64_t builtin_ftell ( const FILE * f, Context * context, LineInfoArg * at ) {
         if ( !f ) context->throw_error_at(at, "can't ftell NULL");
-        return ftell((FILE *)f);
+#ifdef _MSC_VER
+        return _ftelli64((FILE *)f);
+#else
+        return ftello((FILE *)f);
+#endif
     }
 
     int64_t builtin_fseek ( const FILE * f, int64_t offset, int32_t mode, Context * context, LineInfoArg * at ) {
         if ( !f ) context->throw_error_at(at, "can't fseek NULL");
-        return fseek((FILE *)f, long(offset), mode);
+#ifdef _MSC_VER
+        return _fseeki64((FILE *)f, offset, mode);
+#else
+        return fseeko((FILE *)f, off_t(offset), mode);
+#endif
     }
 
     char * builtin_fread ( const FILE * f, Context * context, LineInfoArg * at ) {
@@ -480,6 +492,9 @@ namespace das {
         if ( !fp ) context.throw_error_at(call->debugInfo, "can't read NULL");
         auto buf = cast<void *>::to(args[1]);
         auto len = cast<int32_t>::to(args[2]);
+        // a negative count is an int32 wrap upstream; fread would sign-extend it to a huge
+        // size_t and stream out of bounds — refuse loudly instead
+        if ( len < 0 ) context.throw_error_at(call->debugInfo, "read of negative byte count %i (int32 wrap?) — use the 64-bit rail (long_fread)", len);
         int32_t res = (int32_t) fread(buf,1,len,fp);
         return cast<int32_t>::from(res);
     }
@@ -491,8 +506,35 @@ namespace das {
         if ( !fp ) context.throw_error_at(call->debugInfo, "can't write NULL");
         auto buf = cast<void *>::to(args[1]);
         auto len = cast<int32_t>::to(args[2]);
+        if ( len < 0 ) context.throw_error_at(call->debugInfo, "write of negative byte count %i (int32 wrap?) — use the 64-bit rail (long_fwrite)", len);
         int32_t res = (int32_t) fwrite(buf,1,len,fp);
         return cast<int32_t>::from(res);
+    }
+
+    vec4f builtin_read64 ( Context & context, SimNode_CallBase * call, vec4f * args ) {
+        DAS_ASSERT ( call->types[1]->isRef() || call->types[1]->isRefType()
+            || call->types[1]->type==Type::tString || call->types[1]->type==Type::tPointer);
+        auto fp = cast<FILE *>::to(args[0]);
+        if ( !fp ) context.throw_error_at(call->debugInfo, "can't read NULL");
+        auto buf = cast<void *>::to(args[1]);
+        auto len = cast<int64_t>::to(args[2]);
+        if ( len < 0 ) context.throw_error_at(call->debugInfo, "read of negative byte count %lli", (long long)len);
+        if ( sizeof(size_t) < 8 && uint64_t(len) > uint64_t(SIZE_MAX) ) context.throw_error_at(call->debugInfo, "read of %lli bytes exceeds this platform's address space", (long long)len);
+        int64_t res = (int64_t) fread(buf,1,size_t(len),fp);
+        return cast<int64_t>::from(res);
+    }
+
+    vec4f builtin_write64 ( Context & context, SimNode_CallBase * call, vec4f * args ) {
+        DAS_ASSERT ( call->types[1]->isRef() || call->types[1]->isRefType()
+            || call->types[1]->type==Type::tString || call->types[1]->type==Type::tPointer);
+        auto fp = cast<FILE *>::to(args[0]);
+        if ( !fp ) context.throw_error_at(call->debugInfo, "can't write NULL");
+        auto buf = cast<void *>::to(args[1]);
+        auto len = cast<int64_t>::to(args[2]);
+        if ( len < 0 ) context.throw_error_at(call->debugInfo, "write of negative byte count %lli", (long long)len);
+        if ( sizeof(size_t) < 8 && uint64_t(len) > uint64_t(SIZE_MAX) ) context.throw_error_at(call->debugInfo, "write of %lli bytes exceeds this platform's address space", (long long)len);
+        int64_t res = (int64_t) fwrite(buf,1,size_t(len),fp);
+        return cast<int64_t>::from(res);
     }
 
 #ifdef _MSC_VER
@@ -1985,6 +2027,12 @@ namespace das {
                     ->args({"file","buffer","length"});
             addInterop<builtin_write,int,const FILE*,vec4f,int32_t>(*this, lib, "_builtin_write",
                 SideEffects::modifyExternal, "builtin_write")
+                    ->args({"file","buffer","length"});
+            addInterop<builtin_read64,int64_t,const FILE*,vec4f,int64_t>(*this, lib, "_builtin_read64",
+                SideEffects::modifyExternal, "builtin_read64")
+                    ->args({"file","buffer","length"});
+            addInterop<builtin_write64,int64_t,const FILE*,vec4f,int64_t>(*this, lib, "_builtin_write64",
+                SideEffects::modifyExternal, "builtin_write64")
                     ->args({"file","buffer","length"});
             addInterop<builtin_load,void,const FILE*,int64_t,const Block &>(*this, lib, "_builtin_load",
                 das::SideEffects::modifyExternal, "builtin_load")

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -171,6 +171,8 @@ namespace das {
     void builtin_fclose ( const FILE * f, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     void builtin_fflush ( const FILE * f, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     void builtin_map_file(const FILE* f, const TBlock<void, TTemporary<TArray<uint8_t>>>& blk, Context* context, LineInfoArg * at) GENERATE_IO_STUB
+    void * builtin_fmap_open ( const char * name, uint64_t * size, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
+    void builtin_fmap_close ( void * data, uint64_t size, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     int64_t builtin_ftell ( const FILE * f, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     int64_t builtin_fseek ( const FILE * f, int64_t offset, int32_t mode, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     char * builtin_fread ( const FILE * f, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
@@ -369,6 +371,41 @@ namespace das {
         args[0] = cast<Array *>::from(&arr);
         context->invoke(blk, args, nullptr, at);
         munmap(data, size_t(st.st_size));
+    }
+
+    // split fmap (the prepared-model-image loader): the mapping OUTLIVES the call — the caller
+    // owns it and unmaps via fmap_close. Read-only shared pages: clean (droppable under memory
+    // pressure, never swapped) and shared across processes through the OS page cache. The FILE
+    // closes right after mapping — both POSIX and the win32 shim keep the view alive through
+    // the mapping's own file reference.
+    void * builtin_fmap_open ( const char * name, uint64_t * size, Context * context, LineInfoArg * at ) {
+        if ( !size ) context->throw_error_at(at, "fmap_open: null size out-param");
+        *size = 0;
+        if ( !name ) context->throw_error_at(at, "fmap_open: null path");
+        FILE * f = fopen(name, "rb");
+        if ( !f ) context->throw_error_at(at, "fmap_open: can't open '%s'", name);
+        das_filestat st;
+        int fd = fileno(f);
+        if ( das_fstat64(fd, st) != 0 ) {
+            fclose(f);
+            context->throw_error_at(at, "fmap_open: can't stat '%s'", name);
+        }
+        if ( st.st_size == 0 ) {
+            fclose(f);
+            context->throw_error_at(at, "fmap_open: '%s' is empty", name);
+        }
+        void * data = mmap(nullptr, size_t(st.st_size), PROT_READ, MAP_SHARED, fd, 0);
+        fclose(f);
+        if ( data == MAP_FAILED ) {
+            context->throw_error_at(at, "fmap_open: can't map '%s' (%llu bytes)", name, (unsigned long long)st.st_size);
+        }
+        *size = uint64_t(st.st_size);
+        return data;
+    }
+
+    void builtin_fmap_close ( void * data, uint64_t size, Context * context, LineInfoArg * at ) {
+        if ( !data ) context->throw_error_at(at, "fmap_close: null mapping");
+        munmap(data, size_t(size));
     }
 
     int64_t builtin_ftell ( const FILE * f, Context * context, LineInfoArg * at ) {
@@ -1921,6 +1958,12 @@ namespace das {
             addExtern<DAS_BIND_FUN(builtin_map_file)>(*this, lib, "fmap",
                 SideEffects::modifyExternal, "builtin_map_file")
                     ->args({"file","block","context","line"});
+            addExtern<DAS_BIND_FUN(builtin_fmap_open)>(*this, lib, "fmap_open",
+                SideEffects::modifyExternal, "builtin_fmap_open")
+                    ->args({"path","size","context","line"})->unsafeOperation = true;
+            addExtern<DAS_BIND_FUN(builtin_fmap_close)>(*this, lib, "fmap_close",
+                SideEffects::modifyExternal, "builtin_fmap_close")
+                    ->args({"data","size","context","line"})->unsafeOperation = true;
             addExtern<DAS_BIND_FUN(builtin_fgets)>(*this, lib, "fgets",
                 SideEffects::modifyExternal, "builtin_fgets")
                     ->args({"file","context","line"});

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -379,28 +379,29 @@ namespace das {
     // owns it and unmaps via fmap_close. Read-only shared pages: clean (droppable under memory
     // pressure, never swapped) and shared across processes through the OS page cache. The FILE
     // closes right after mapping — both POSIX and the win32 shim keep the view alive through
-    // the mapping's own file reference.
+    // the mapping's own file reference. Failure returns null (size stays 0) rather than
+    // throwing: this is a cache probe — the caller declines and regenerates from the source.
     void * builtin_fmap_open ( const char * name, uint64_t * size, Context * context, LineInfoArg * at ) {
         if ( !size ) context->throw_error_at(at, "fmap_open: null size out-param");
         *size = 0;
         if ( !name ) context->throw_error_at(at, "fmap_open: null path");
         FILE * f = fopen(name, "rb");
-        if ( !f ) context->throw_error_at(at, "fmap_open: can't open '%s'", name);
+        if ( !f ) return nullptr;
         das_filestat st;
         int fd = fileno(f);
         if ( das_fstat64(fd, st) != 0 ) {
             fclose(f);
-            context->throw_error_at(at, "fmap_open: can't stat '%s'", name);
+            return nullptr;
         }
-        if ( st.st_size == 0 ) {
+        // empty files can't map (mmap(0) is EINVAL); a size that doesn't survive the size_t
+        // round-trip would truncate the mapping on 32-bit targets
+        if ( st.st_size == 0 || uint64_t(st.st_size) != uint64_t(size_t(st.st_size)) ) {
             fclose(f);
-            context->throw_error_at(at, "fmap_open: '%s' is empty", name);
+            return nullptr;
         }
         void * data = mmap(nullptr, size_t(st.st_size), PROT_READ, MAP_SHARED, fd, 0);
         fclose(f);
-        if ( data == MAP_FAILED ) {
-            context->throw_error_at(at, "fmap_open: can't map '%s' (%llu bytes)", name, (unsigned long long)st.st_size);
-        }
+        if ( data == MAP_FAILED ) return nullptr;
         *size = uint64_t(st.st_size);
         return data;
     }

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1688,6 +1688,16 @@ namespace das
         array_mark_locked(arr, (char *)data, size < 0 ? uint64_t(0) : uint64_t(size));
     }
 
+    // release a borrowed (mark_locked) array view WITHOUT freeing the storage — the bytes
+    // belong to someone else (a file mapping, another allocator). The inverse of
+    // builtin_make_temp_array for views that outlive a temp scope (the model-image loader
+    // resets its borrowed plane views through this before unmapping).
+    void builtin_forget_temp_array ( Array & arr, Context * context, LineInfoArg * at ) {
+        if ( !array_forget_locked(arr) ) {
+            context->throw_error_at(at, "forget_temp_array: not a borrowed (locked) array view");
+        }
+    }
+
     void toLog ( int level, const char * text, Context * context, LineInfoArg * at ) {
         context->to_out(at, level, text);
     }
@@ -2520,6 +2530,10 @@ namespace das
             SideEffects::modifyArgument, "builtin_make_temp_array_i64")
                 ->args({"array","data","size"});
         bmta64->unsafeOperation = true;
+        auto bfta = addExtern<DAS_BIND_FUN(builtin_forget_temp_array)>(*this, lib, "_builtin_forget_temp_array",
+            SideEffects::modifyArgument, "builtin_forget_temp_array")
+                ->args({"array","context","line"});
+        bfta->unsafeOperation = true;
         // migrate data
         addExtern<DAS_BIND_FUN(das_is_dll_build)>(*this, lib, "das_is_dll_build",
             SideEffects::worstDefault, "das_is_dll_build");

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -14,6 +14,7 @@ namespace das
         arr.size = arr.capacity = capacity;
         arr.lock = 1;
         arr.magic = DAS_ARRAY_MAGIC;
+        arr.borrowed = true;
     }
 
     void array_mark_locked ( Array & arr, void * data, uint64_t size, uint64_t capacity ) {
@@ -22,18 +23,22 @@ namespace das
         arr.capacity = capacity;
         arr.lock = 1;
         arr.magic = DAS_ARRAY_MAGIC;
+        arr.borrowed = true;
     }
 
     // the inverse of array_mark_locked for views that outlive a temp scope: reset the view
     // WITHOUT freeing the storage (it belongs to a file mapping / another allocator). false =
-    // not a mark_locked view (untouched) — callers turn that into a runtime error.
+    // not a mark_locked view (untouched) — callers turn that into a runtime error. The
+    // borrowed bit is the discriminator: an OWNED array that merely holds a lock has the same
+    // lock/magic signature, and "forgetting" it would leak its storage.
     bool array_forget_locked ( Array & arr ) {
-        if ( arr.lock != 1 || arr.magic != DAS_ARRAY_MAGIC ) return false;
+        if ( arr.lock != 1 || arr.magic != DAS_ARRAY_MAGIC || !arr.borrowed ) return false;
         arr.data = nullptr;
         arr.size = 0;
         arr.capacity = 0;
         arr.lock = 0;
         arr.magic = 0;
+        arr.borrowed = false;
         return true;
     }
 

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -38,7 +38,7 @@ namespace das
         arr.capacity = 0;
         arr.lock = 0;
         arr.magic = 0;
-        arr.borrowed = false;
+        arr.flags = 0;  // the whole word (incl. borrowed) — back to the fresh-empty-array state
         return true;
     }
 

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -24,6 +24,19 @@ namespace das
         arr.magic = DAS_ARRAY_MAGIC;
     }
 
+    // the inverse of array_mark_locked for views that outlive a temp scope: reset the view
+    // WITHOUT freeing the storage (it belongs to a file mapping / another allocator). false =
+    // not a mark_locked view (untouched) — callers turn that into a runtime error.
+    bool array_forget_locked ( Array & arr ) {
+        if ( arr.lock != 1 || arr.magic != DAS_ARRAY_MAGIC ) return false;
+        arr.data = nullptr;
+        arr.size = 0;
+        arr.capacity = 0;
+        arr.lock = 0;
+        arr.magic = 0;
+        return true;
+    }
+
     void array_lock ( Context & context, Array & arr, LineInfo * at ) {
         if ( arr.shared || arr.hopeless ) return;
         if ( arr.lock==0 ) {

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -139,6 +139,7 @@ SET(AOT_DASLLAMA_MODULE_FILES
     modules/dasLLAMA/dasllama/dasllama_arch_gptoss.das
     modules/dasLLAMA/dasllama/dasllama_arch_mistral3.das
     modules/dasLLAMA/dasllama/dasllama_arch_glm4moe.das
+    modules/dasLLAMA/dasllama/dasllama_image.das
     modules/dasLLAMA/dasllama/dasllama_transformer.das
     modules/dasLLAMA/dasllama/dasllama_asr.das
     modules/dasLLAMA/dasllama/dasllama_chat.das

--- a/tests/dasLLAMA/CLAUDE.md
+++ b/tests/dasLLAMA/CLAUDE.md
@@ -42,6 +42,9 @@ batch test: `batch` (whole test), `batchB7-partd`, `batchB8-kq`. Prefill parity:
 kq cont dim qkv`. Support matrix: `cells-q8 window cells-s16 mode kq dim8b dim70b`. The
 `kernels` suite (test_metal_prefill_kernels — model-less kernel units, ~80s) has no arms;
 remember it exists — kernel uniform/binding changes MUST update its hand-bound dispatches.
+The `image` suite (test_model_image — the prepared-image .dlim rail): `mechanics` (synthetic
+carrier, model-free, runs in CI) `smol tower whisper voxtral`; the voxtral arm re-saves a
+5.4 GB image from cold every run by design (it IS the >2 GiB-plane IO coverage).
 
 ## Model tiers
 

--- a/tests/dasLLAMA/run.das
+++ b/tests/dasLLAMA/run.das
@@ -23,7 +23,7 @@ struct RunArgs {
     full : bool
 
     @clarg_short = "s"
-    @clarg_doc = "Suite: decode | prefill | matrix | kernels | all (default all)"
+    @clarg_doc = "Suite: decode | prefill | matrix | kernels | image | all (default all)"
     suite : string = "all"
 
     @clarg_short = "n"
@@ -48,11 +48,14 @@ def private suite_files(name : string) : array<string> {
         return <- [ "tests/dasLLAMA/test_metal_support_matrix.das" ]
     } elif (name == "kernels") {
         return <- [ "tests/dasLLAMA/test_metal_prefill_kernels.das" ]
+    } elif (name == "image") {
+        return <- [ "tests/dasLLAMA/test_model_image.das" ]
     } elif (name == "all") {
         return <- [ "tests/dasLLAMA/test_metal_decode_parity.das",
                     "tests/dasLLAMA/test_metal_prefill_parity.das",
                     "tests/dasLLAMA/test_metal_support_matrix.das",
-                    "tests/dasLLAMA/test_metal_prefill_kernels.das" ]
+                    "tests/dasLLAMA/test_metal_prefill_kernels.das",
+                    "tests/dasLLAMA/test_model_image.das" ]
     }
     var none : array<string>
     return <- none
@@ -103,7 +106,7 @@ def main() : int {
     }
     var files <- suite_files(cfg.suite)
     if (empty(files)) {
-        to_log(LOG_ERROR, "unknown --suite '{cfg.suite}' (decode | prefill | matrix | kernels | all)\n")
+        to_log(LOG_ERROR, "unknown --suite '{cfg.suite}' (decode | prefill | matrix | kernels | image | all)\n")
         return 2
     }
     let tmp = empty(get_env_variable("TMPDIR")) ? "/tmp" : get_env_variable("TMPDIR")

--- a/tests/dasLLAMA/test_audio.das
+++ b/tests/dasLLAMA/test_audio.das
@@ -162,7 +162,7 @@ def test_ultravox_tower(t : T?) {
             t |> success(abs(float(sum / double(187l * tw.proj_dim)) - 0.002889) < 5e-4, "mean")
             t |> success(abs(mx - 4.306354) < 5e-2, "max")
         }
-        delete tw.fblob
+        delete tw   // image-backed planes are locked views — only the finalizer may release them
     }
 }
 
@@ -204,7 +204,7 @@ def test_voxtral_tower(t : T?) {
             t |> success(abs(float(sum / double(187l * tw.proj_dim)) + 0.001517) < 5e-4, "mean")
             t |> success(abs(mx - 1.459851) < 5e-2, "max")
         }
-        delete tw.fblob
+        delete tw   // image-backed planes are locked views — only the finalizer may release them
     }
 }
 
@@ -218,7 +218,7 @@ def test_omni_tower(t : T?) {
         t |> equal(tw.proj_dim, 2048l, "proj_dim (3B decoder)")
         t |> equal(tw.n_layer, 32l, "layers")
         t |> equal(audio_tokens_per_chunk(tw), 750l, "tokens per 30 s chunk")
-        delete tw.fblob
+        delete tw   // image-backed planes are locked views — only the finalizer may release them
     }
 }
 
@@ -265,6 +265,6 @@ def test_encoder_oracle(t : T?) {
         let mean = sum / double(750l * tw.proj_dim)
         t |> success(abs(float(mean) - 0.009261) < 5e-4, "mean")
         t |> success(abs(mx - 7.527778) < 5e-2, "max")
-        delete tw.fblob
+        delete tw   // image-backed planes are locked views — only the finalizer may release them
     }
 }

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -226,6 +226,9 @@ def test_image_mechanics(t : T?) {
         patch_u32(t, path, 24l, mb - 4u)   // truncate the meta tail: the archive under-reads its last field
         var m5c = ImgProbe()
         t |> success(!load_image(path, m5c, "img-probe"), "truncated meta blob declines")
+        patch_u32(t, path, 24l, 0u)   // an empty meta blob is malformed, not an OOB addr
+        var m5d = ImgProbe()
+        t |> success(!load_image(path, m5d, "img-probe"), "zero-size meta blob declines")
         patch_u32(t, path, 24l, mb)
         patch_u32(t, path, 12l, 7u)   // header now lies about the section count
         var m5b = ImgProbe()

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -197,6 +197,10 @@ def test_image_mechanics(t : T?) {
         var m5 = ImgProbe()
         t |> success(load_image(path, m5, "img-probe"), "restored version maps again")
         delete m5
+        patch_u32(t, path, 12l, 7u)   // header now lies about the section count
+        var m5b = ImgProbe()
+        t |> success(!load_image(path, m5b, "img-probe"), "section-count-lying header declines")
+        patch_u32(t, path, 12l, 3u)   // the probe's true count: plane_f, plane_b, nested.blob
         patch_u32(t, path, 32l, 0x1u)   // header now lies about the file size
         var m6 = ImgProbe()
         t |> success(!load_image(path, m6, "img-probe"), "size-lying header declines")

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -223,12 +223,36 @@ def private gen_ids(tr : Model; prompt : array<int64>; n_gen : int) : array<int6
     return <- out
 }
 
+// first config field whose value differs between two loads ("" = none) — catches an arch
+// configure clobbering serialized gguf overrides even when short gens can't (sliding_window
+// only bites past the window)
+def private config_diff_field(a, b : Config) : string {
+    var names : array<string>
+    var vals : array<string>
+    apply(a) $(name : string; field) {
+        names |> push(name)
+        vals |> push("{field}")
+    }
+    var bad = ""
+    var i = 0
+    apply(b) $ [unused_argument(name)] (name : string; field) {
+        if (empty(bad) && "{field}" != vals[i]) {
+            bad = "{names[i]}: gguf={vals[i]} image={field}"
+        }
+        i++
+    }
+    delete names
+    delete vals
+    return bad
+}
+
 def private text_image_roundtrip(t : T?; path : string; n_gen : int) {
     let img = image_path_for(path)
     remove(img)   // cold start: the first facade load must regenerate + save
     var a <- load_model(path, QuantMode.q8)
     t |> success(a.image_map == null, "cold load is gguf-backed")
     t |> success(stat(img).is_valid, "cold load saved an image")
+    var cfg_a := a.config   // the gguf truth, kept past delete for the round-trip compare
     if (a.config.seq_len > 2048l) {
         a.config.seq_len = 2048l
     }
@@ -237,6 +261,9 @@ def private text_image_roundtrip(t : T?; path : string; n_gen : int) {
     delete a
     var b <- load_model(path, QuantMode.q8)
     t |> success(b.image_map != null, "warm load is image-backed")
+    let cfg_diff = config_diff_field(cfg_a, b.config)
+    t |> success(empty(cfg_diff), "config round-trips exactly ({cfg_diff})")
+    delete cfg_a
     if (b.config.seq_len > 2048l) {
         b.config.seq_len = 2048l
     }
@@ -292,6 +319,27 @@ def test_voxtral_mini_image(t : T?) {
         text_image_roundtrip(t, path, 12)
         // the arm exists for the 64-bit plane IO: the q8 image must actually cross 2 GiB
         t |> success(stat(image_path_for(path)).size > 0x80000000ul, "image crosses 2 GiB")
+    }
+}
+
+[test]
+def test_gemma4_image_roundtrip(t : T?) {
+    t |> run("gemma-4-E2B q8: arch-configure fallbacks must not clobber mapped config") @(t : T?) {
+        // gemma4's configure sets gguf-overridable fallbacks (sliding_window, swa_pattern);
+        // re-running it on an image load stomped the serialized overrides (caught 2026-07-16:
+        // token drift on the mapped E2B while every llama-arch carrier round-tripped clean)
+        if (!arm_on(t, "gemma")) {
+            return
+        }
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "gemma-4-E2B-it-Q8_0.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        text_image_roundtrip(t, path, 16)
     }
 }
 

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -213,6 +213,25 @@ def test_image_mechanics(t : T?) {
         var m7 = ImgProbe()
         t |> success(!load_image(path, m7, "img-probe"), "absent file declines")
         delete p
+
+        // an OWNED array that merely holds a lock has the same lock/magic signature as a
+        // borrowed view — forget must refuse it loudly (silently "forgetting" leaks storage)
+        var owned : array<float>
+        owned |> resize(4)
+        var caught = false
+        for (x in owned) {
+            feint("{x}")
+            try {
+                unsafe {
+                    _builtin_forget_temp_array(owned)
+                }
+            } recover {
+                caught = true
+            }
+            break
+        }
+        t |> success(caught, "forget on an owned locked array is a loud error")
+        delete owned
     }
 }
 

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -237,7 +237,7 @@ def test_image_mechanics(t : T?) {
         patch_u32(t, path, 32l, 0x1u)   // header now lies about the file size
         var m6 = ImgProbe()
         t |> success(!load_image(path, m6, "img-probe"), "size-lying header declines")
-        remove(path)
+        t |> success(remove(path), "probe image removed")   // also makes the absent-decline below honest
         var m7 = ImgProbe()
         t |> success(!load_image(path, m7, "img-probe"), "absent file declines")
         delete p

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -188,6 +188,11 @@ def test_image_mechanics(t : T?) {
         t |> equal(long_length(m2.nested.blob), 2048l)
         delete m2
 
+        t |> success(save_image(p, path, "img-probe"), "re-save over an existing image")
+        var m2b = ImgProbe()
+        t |> success(load_image(path, m2b, "img-probe"), "re-saved image maps")
+        delete m2b
+
         var m3 = ImgProbe()
         t |> success(!load_image(path, m3, "wrong-tag"), "identity mismatch declines")
         patch_u32(t, path, 4l, 0xDEADu)

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -131,6 +131,25 @@ def private make_probe() : ImgProbe {
     return <- p
 }
 
+def private read_u32_at(t : T?; path : string; at : int64) : uint {
+    var v = 0u
+    let f = fopen(path, "rb")
+    if (f == null) {
+        t |> failure("cannot open {path} for reading")
+        return v
+    }
+    fseek(f, at, seek_set)
+    var b : array<uint8>
+    b |> resize(4)
+    f |> fread(b)
+    for (i in range(4)) {
+        v |= uint(b[i]) << uint(i * 8)
+    }
+    delete b
+    fclose(f)
+    return v
+}
+
 def private patch_u32(t : T?; path : string; at : int64; v : uint) {
     let f = fopen(path, "r+b")
     if (f == null) {
@@ -203,6 +222,11 @@ def test_image_mechanics(t : T?) {
         var m5 = ImgProbe()
         t |> success(load_image(path, m5, "img-probe"), "restored version maps again")
         delete m5
+        let mb = read_u32_at(t, path, 24l)
+        patch_u32(t, path, 24l, mb - 4u)   // truncate the meta tail: the archive under-reads its last field
+        var m5c = ImgProbe()
+        t |> success(!load_image(path, m5c, "img-probe"), "truncated meta blob declines")
+        patch_u32(t, path, 24l, mb)
         patch_u32(t, path, 12l, 7u)   // header now lies about the section count
         var m5b = ImgProbe()
         t |> success(!load_image(path, m5b, "img-probe"), "section-count-lying header declines")

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -162,7 +162,12 @@ def test_image_mechanics(t : T?) {
         t |> equal(stat(path).size % uint64(IMAGE_PAGE), 0ul, "file is a page multiple")
 
         var m = ImgProbe()
+        let epoch0 = weights_epoch()
         t |> success(load_image(path, m, "img-probe"), "load")
+        // the Metal drivers' weight caches key by HOST ADDRESS and flush on the weights epoch;
+        // an image load that lands planes at a deleted model's recycled addresses without
+        // moving the epoch makes them serve the dead model's buffers (arm10-kq, 2026-07-16)
+        t |> success(weights_epoch() > epoch0, "an image load moves the weights epoch")
         t |> success(m.image_map != null, "image-backed")
         t |> equal(m.tagv, p.tagv)
         t |> equal(m.n, p.n)

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -1,0 +1,408 @@
+options gen2
+options persistent_heap   // + explicit deletes: each arm frees its model before the next loads
+options stack = 131072
+
+require dastest/testing_boost public
+require dasllama/dasllama            // the facade: load_model's image cache is the surface under test
+require dasllama/dasllama_whisper
+require dasllama/dasllama_gguf       // rd_u32/rd_u16 — the wav fixture reader
+require dasllama/dasllama_image
+require daslib/jobque_boost
+require daslib/archive
+require daslib/apply
+require daslib/fio
+require strings
+require math
+require _model_tier
+
+// The prepared-model image (.dlim) rail. The mechanics arm exercises save/load on a synthetic
+// carrier (no models, runs everywhere incl. CI): value round trip, dotted nested-carrier
+// planes, string-array meta rail, every decline shape, and the unmap-remap cycle. The model
+// arms compare a gguf-backed load against a mapped image load of the same file — token-exact
+// for text models, element-exact planes for towers, transcript-exact for whisper. The
+// voxtral-mini arm is the designated >2 GiB-plane coverage (its q8 image is 5.4 GB), so it
+// re-saves the image from cold on every run by design. Drive through tests/dasLLAMA/run.das
+// (--suite image); model arms follow the suite's presence/tier gates.
+
+def private whisper_dir() : string {
+    let env = get_env_variable("DASLLAMA_WHISPER_DIR")
+    return empty(env) ? "/Users/borisbatkin/Work/whisper.cpp/models/" : env
+}
+
+// element-exact plane compare: -1 = length mismatch, else the number of differing elements
+def private count_mismatch(a, b : array<auto(TT)>) : int64 {
+    if (long_length(a) != long_length(b)) {
+        return -1l
+    }
+    var bad = 0l
+    for (x, y in a, b) {
+        if (x != y) {
+            bad++
+        }
+    }
+    return bad
+}
+
+// ===== the synthetic carrier (mechanics arm) =====
+
+struct ImgProbeInner {
+    image_map : void?    // the nested-carrier marker: planes join the outer image as "nested.blob"
+    image_bytes : uint64
+    k : int64
+    blob : array<float>
+}
+
+def finalize(var t : ImgProbeInner) {
+    apply(t) $ [unused_argument(name)] (name : string; var field) {
+        static_if (typeinfo is_array(field)) {
+            if (lock_count(field) != 0) {
+                unsafe {
+                    _builtin_forget_temp_array(field)
+                }
+            } else {
+                delete field
+            }
+        }
+    }
+}
+
+struct ImgProbe {
+    tagv : int
+    plane_f : array<float>
+    labels : array<string>   // string-array rail: must ride the meta blob, never a raw plane
+    n : int64
+    nested : ImgProbeInner = ImgProbeInner()
+    plane_b : array<int8>
+    name : string
+    image_map : void?
+    image_bytes : uint64
+}
+
+def finalize(var t : ImgProbe) {
+    apply(t) $ [unused_argument(name)] (name : string; var field) {
+        static_if (typeinfo is_array(field)) {
+            if (lock_count(field) != 0) {
+                unsafe {
+                    _builtin_forget_temp_array(field)
+                }
+            } else {
+                delete field
+            }
+        } static_elif (typeinfo is_struct(field)) {
+            delete field
+        }
+    }
+    if (t.image_map != null) {
+        unsafe {
+            fmap_close(t.image_map, t.image_bytes)
+        }
+        t.image_map = null
+        t.image_bytes = 0ul
+    }
+}
+
+def private serialize_image_meta(var arch : Archive; var t : ImgProbe) {
+    arch |> serialize_raw(t.tagv)
+    arch |> serialize_raw(t.n)
+    arch |> serialize(t.name)
+    serialize_strings(arch, t.labels)
+    arch |> serialize_raw(t.nested.k)
+}
+
+[unused_argument(t)]
+def private image_post_load(var t : ImgProbe) {}
+
+def private make_probe() : ImgProbe {
+    var p = ImgProbe(tagv = 7, n = 12345l, name = "probe")
+    p.labels <- ["alpha", "", "omega"]
+    p.plane_f |> resize(1000)
+    for (i in range(1000)) {
+        p.plane_f[i] = float(i) * 0.25
+    }
+    p.plane_b |> resize(4099)   // deliberately page-unaligned byte count
+    for (i in range(4099)) {
+        p.plane_b[i] = int8(i % 251 - 125)
+    }
+    p.nested.k = 99l
+    p.nested.blob |> resize(2048)
+    for (i in range(2048)) {
+        p.nested.blob[i] = 1.0 / float(i + 1)
+    }
+    return <- p
+}
+
+def private patch_u32(t : T?; path : string; at : int64; v : uint) {
+    let f = fopen(path, "r+b")
+    if (f == null) {
+        t |> failure("cannot reopen {path} for patching")
+        return
+    }
+    fseek(f, at, seek_set)
+    var b : array<uint8>
+    b |> resize(4)
+    for (i in range(4)) {
+        b[i] = uint8((v >> uint(i * 8)) & 0xFFu)
+    }
+    f |> fwrite(b)
+    delete b
+    fclose(f)
+}
+
+[test]
+def test_image_mechanics(t : T?) {
+    t |> run("synthetic carrier: round trip, nested planes, declines, unmap-remap") @(t : T?) {
+        if (!arm_on(t, "mechanics")) {
+            return
+        }
+        let tmp = empty(get_env_variable("TMPDIR")) ? "/tmp" : get_env_variable("TMPDIR")
+        let path = path_join(tmp, "dasllama_img_probe_{ref_time_ticks()}.dlim")
+        var p <- make_probe()
+        t |> success(save_image(p, path, "img-probe"), "save")
+        t |> success(stat(path).is_valid, "file exists")
+        t |> equal(stat(path).size % uint64(IMAGE_PAGE), 0ul, "file is a page multiple")
+
+        var m = ImgProbe()
+        t |> success(load_image(path, m, "img-probe"), "load")
+        t |> success(m.image_map != null, "image-backed")
+        t |> equal(m.tagv, p.tagv)
+        t |> equal(m.n, p.n)
+        t |> equal(m.name, p.name)
+        t |> equal(length(m.labels), 3)
+        t |> equal(m.labels[0], "alpha")
+        t |> equal(m.labels[1], "")
+        t |> equal(m.labels[2], "omega")
+        t |> equal(m.nested.k, 99l)
+        t |> success(m.nested.image_map == null, "the OUTER struct owns the mapping")
+        t |> equal(count_mismatch(m.plane_f, p.plane_f), 0l, "plane_f element-exact")
+        t |> equal(count_mismatch(m.plane_b, p.plane_b), 0l, "plane_b element-exact")
+        t |> equal(count_mismatch(m.nested.blob, p.nested.blob), 0l, "nested.blob element-exact")
+        delete m   // forgets the borrowed planes + unmaps
+
+        var m2 = ImgProbe()
+        t |> success(load_image(path, m2, "img-probe"), "re-map after unmap")
+        t |> equal(long_length(m2.nested.blob), 2048l)
+        delete m2
+
+        var m3 = ImgProbe()
+        t |> success(!load_image(path, m3, "wrong-tag"), "identity mismatch declines")
+        patch_u32(t, path, 4l, 0xDEADu)
+        var m4 = ImgProbe()
+        t |> success(!load_image(path, m4, "img-probe"), "version mismatch declines")
+        patch_u32(t, path, 4l, uint(IMAGE_VERSION))
+        var m5 = ImgProbe()
+        t |> success(load_image(path, m5, "img-probe"), "restored version maps again")
+        delete m5
+        patch_u32(t, path, 32l, 0x1u)   // header now lies about the file size
+        var m6 = ImgProbe()
+        t |> success(!load_image(path, m6, "img-probe"), "size-lying header declines")
+        remove(path)
+        var m7 = ImgProbe()
+        t |> success(!load_image(path, m7, "img-probe"), "absent file declines")
+        delete p
+    }
+}
+
+// ===== real carriers: gguf load vs mapped image load =====
+
+// greedy continuation ids on a loaded model (no kernel pins: both sides of every compare run
+// in this process with identical knobs, so determinism is per-run, not per-fixture)
+def private gen_ids(tr : Model; prompt : array<int64>; n_gen : int) : array<int64> {
+    var out : array<int64>
+    with_job_que() {
+        setup_dasllama_jobque()
+        var s = make_run_state(tr.config)
+        var ids <- generate(tr, s, prompt, length(prompt) + n_gen)
+        out <- ids
+        delete s
+    }
+    return <- out
+}
+
+def private text_image_roundtrip(t : T?; path : string; n_gen : int) {
+    let img = image_path_for(path)
+    remove(img)   // cold start: the first facade load must regenerate + save
+    var a <- load_model(path, QuantMode.q8)
+    t |> success(a.image_map == null, "cold load is gguf-backed")
+    t |> success(stat(img).is_valid, "cold load saved an image")
+    if (a.config.seq_len > 2048l) {
+        a.config.seq_len = 2048l
+    }
+    var prompt <- encode(a, "Once upon a time")
+    var ga <- gen_ids(a, prompt, n_gen)
+    delete a
+    var b <- load_model(path, QuantMode.q8)
+    t |> success(b.image_map != null, "warm load is image-backed")
+    if (b.config.seq_len > 2048l) {
+        b.config.seq_len = 2048l
+    }
+    var gb <- gen_ids(b, prompt, n_gen)
+    t |> success(!empty(ga) && count_mismatch(ga, gb) == 0l, "gguf vs image tokens")
+    delete b   // unmaps
+    var c <- load_model(path, QuantMode.q8)   // the file survives an unmap — map again
+    t |> success(c.image_map != null, "re-mapped after delete")
+    if (c.config.seq_len > 2048l) {
+        c.config.seq_len = 2048l
+    }
+    var gc <- gen_ids(c, prompt, n_gen)
+    t |> success(count_mismatch(ga, gc) == 0l, "re-mapped tokens")
+    delete c
+    delete ga
+    delete gb
+    delete gc
+    delete prompt
+}
+
+[test]
+def test_model_image_roundtrip(t : T?) {
+    t |> run("SmolLM2-135M q8: gguf load vs mapped image, token-for-token") @(t : T?) {
+        if (!arm_on(t, "smol")) {
+            return
+        }
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        text_image_roundtrip(t, path, 24)
+    }
+}
+
+[test]
+def test_voxtral_mini_image(t : T?) {
+    t |> run("voxtral-mini q8: the >2 GiB-plane image round trip") @(t : T?) {
+        if (!arm_on(t, "voxtral")) {
+            return
+        }
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "voxtral-mini-3b-q8_0.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        text_image_roundtrip(t, path, 12)
+        // the arm exists for the 64-bit plane IO: the q8 image must actually cross 2 GiB
+        t |> success(stat(image_path_for(path)).size > 0x80000000ul, "image crosses 2 GiB")
+    }
+}
+
+[test]
+def test_tower_image_roundtrip(t : T?) {
+    t |> run("ultravox-1b tower: mapped image planes are element-exact vs gguf") @(t : T?) {
+        if (!arm_on(t, "tower")) {
+            return
+        }
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "mmproj-ultravox-1b-f32.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        let img = image_path_for(path, "tower-f32")
+        remove(img)
+        var a <- load_audio_tower(path)
+        t |> success(a.image_map == null, "cold load is gguf-backed")
+        t |> success(stat(img).is_valid, "cold load saved an image")
+        var b <- load_audio_tower(path)
+        t |> success(b.image_map != null, "warm load is image-backed")
+        t |> equal(b.d_model, a.d_model)
+        t |> equal(b.n_layer, a.n_layer)
+        t |> equal(b.n_ff, a.n_ff)
+        t |> equal(b.n_ctx, a.n_ctx)
+        t |> equal(b.proj_dim, a.proj_dim)
+        t |> equal(b.stack_factor, a.stack_factor)
+        t |> equal(b.mm1_out, a.mm1_out)
+        t |> success(b.proj_kind == a.proj_kind, "proj_kind")
+        t |> equal(b.layers_off, a.layers_off)
+        t |> equal(b.layer_stride, a.layer_stride)
+        t |> equal(count_mismatch(a.fblob, b.fblob), 0l, "fblob element-exact")
+        delete a
+        delete b
+    }
+}
+
+// minimal RIFF/WAVE reader for the 16-bit PCM mono fixture (jfk.wav) — test_whisper's twin
+def private read_wav_pcm16_mono(path : string) : array<float> {
+    var out : array<float>
+    let f = fopen(path, "rb")
+    if (f == null) {
+        return <- out
+    }
+    fmap(f) $(var bytes : array<uint8>#) {
+        let n = int64(length(bytes))
+        var o = 12l
+        while (o + 8l <= n) {
+            let id = rd_u32(bytes, o)
+            let sz = int64(rd_u32(bytes, o + 4l))
+            if (id == 0x61746164u) {
+                let cnt = min(sz, n - o - 8l) / 2l
+                out |> resize(int(cnt))
+                for (i in range64(cnt)) {
+                    var v = int(rd_u16(bytes, o + 8l + i * 2l))
+                    if (v >= 32768) {
+                        v -= 65536
+                    }
+                    out[i] = float(v) / 32768.0
+                }
+                break
+            }
+            o += 8l + sz + (sz & 1l)
+        }
+    }
+    fclose(f)
+    return <- out
+}
+
+def private whisper_transcribe_text(path : string; samples : array<float>) : tuple<text : string; mapped : bool> {
+    var w <- load_whisper_model(path)
+    var text = ""
+    with_job_que() {
+        setup_dasllama_jobque()
+        var s <- create_session(w)
+        transcribe(w, s, samples) $(seg) {
+            text += seg.text
+        }
+        delete s
+    }
+    let mapped = w.image_map != null
+    delete w
+    return (text = text, mapped = mapped)
+}
+
+[test]
+def test_whisper_image_roundtrip(t : T?) {
+    t |> run("whisper tiny: gguf load vs mapped image, transcript-exact") @(t : T?) {
+        if (!arm_on(t, "whisper")) {
+            return
+        }
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(whisper_dir(), "ggml-tiny.bin")
+        if (!model_available(t, path)) {
+            return
+        }
+        var samples <- read_wav_pcm16_mono(path_join(models_dir(), "jfk.wav"))
+        if (empty(samples)) {
+            t |> skip("jfk.wav not present")
+            return
+        }
+        let img = image_path_for(path, "whisper-f32")
+        remove(img)
+        let a = whisper_transcribe_text(path, samples)
+        t |> success(!a.mapped, "cold load is gguf-backed")
+        t |> success(stat(img).is_valid, "cold load saved an image")
+        let b = whisper_transcribe_text(path, samples)
+        t |> success(b.mapped, "warm load is image-backed")
+        t |> success(!empty(a.text), "non-empty transcript")
+        t |> success(a.text == b.text, "transcripts match")
+        delete samples
+    }
+}

--- a/tests/dasLLAMA/test_model_image.das
+++ b/tests/dasLLAMA/test_model_image.das
@@ -154,8 +154,9 @@ def test_image_mechanics(t : T?) {
         if (!arm_on(t, "mechanics")) {
             return
         }
-        let tmp = empty(get_env_variable("TMPDIR")) ? "/tmp" : get_env_variable("TMPDIR")
-        let path = path_join(tmp, "dasllama_img_probe_{ref_time_ticks()}.dlim")
+        var terr : string
+        let tmp = temp_directory(terr)   // portable (no /tmp on Windows); cwd as a last resort
+        let path = path_join(empty(tmp) ? "." : tmp, "dasllama_img_probe_{ref_time_ticks()}.dlim")
         var p <- make_probe()
         t |> success(save_image(p, path, "img-probe"), "save")
         t |> success(stat(path).is_valid, "file exists")

--- a/tests/dasLLAMA/test_whisper.das
+++ b/tests/dasLLAMA/test_whisper.das
@@ -279,8 +279,7 @@ def test_asr_surface(t : T?) {
         // "auto" on a multilingual model is accepted; a junk code still panics loudly
         let s <- create_session(m, "auto")
         t |> equal(s.w.lang_id, -1, "auto defers detection")
-        delete m.whisper.dblob
-        delete m.whisper.enc.fblob
+        delete m   // whole-model delete: image-backed planes are locked views, only the finalizer may release them
     }
 }
 
@@ -555,10 +554,9 @@ def test_whisper_q8_gate(t : T?) {
             }
             t |> success(mismatches == 0, "q8/fp32 token-identical ({mismatches}/{total} flips)")
         }
-        delete m.whisper.dblob
-        delete m.whisper.enc.fblob
-        delete mf.whisper.dblob
-        delete mf.whisper.enc.fblob
+        // whole-model deletes: image-backed planes are locked views, only the finalizer may release them
+        delete m
+        delete mf
     }
 }
 

--- a/tests/fio/fio_big_io.das
+++ b/tests/fio/fio_big_io.das
@@ -1,12 +1,13 @@
 options gen2
 require dastest/testing_boost
 require daslib/fio
-require math
 
-// Regression: fwrite/fread of an array past 2 GiB. The pre-fix rail computed the byte count
-// as int32 `length * sizeof`, which wraps negative past INT_MAX; the C runtime sign-extends
-// that to a huge size_t and streams out-of-bounds heap garbage into the file (or back over
-// the heap on read) with no diagnostic. The fixed rail chunks in int64.
+// Regression: file IO past 2 GiB. The pre-fix rail computed byte counts as int32
+// `length * sizeof`, which wraps negative past INT_MAX; the C runtime sign-extends that to
+// a huge size_t and streams out-of-bounds heap garbage into the file (or back over the heap
+// on read) with no diagnostic. Now: long_fwrite/long_fread carry int64 counts end to end,
+// the int32 fwrite/fread PANIC past INT_MAX, and ftell/fseek use the 64-bit C forms (plain
+// ftell/fseek take `long` = 32-bit on Windows).
 //
 // Costs ~2.2 GB of RAM and of disk for a few seconds, so it only runs when DAS_BIG_IO=1 —
 // the dasLLAMA image suite exercises the same rail end-to-end on real >2 GiB weight planes.
@@ -20,7 +21,7 @@ def test_big_write_read(t : T?) {
         t |> skip("big-IO regression needs DAS_BIG_IO=1 (2.2 GB RAM + disk)")
         return
     }
-    t |> run("fwrite/fread past 2 GiB") @@(t : T?) {
+    t |> run("long_fwrite/long_fread past 2 GiB") @@(t : T?) {
         var terr : string
         let path = "{temp_directory(terr)}/das_big_io_test.bin"
         var buf : array<uint8>
@@ -31,7 +32,7 @@ def test_big_write_read(t : T?) {
         buf[BIG - 1l] = uint8(0xAB)
         fopen(path, "wb") $(f) {
             t |> success(f != null)
-            f |> fwrite(buf)
+            t |> equal(f |> long_fwrite(buf), BIG)
         }
         t |> equal(int64(stat(path).size), BIG)   // pre-fix: garbage-padded file, wrong size
         for (k in range64(0l, BIG / PROBE_STEP)) {
@@ -40,13 +41,54 @@ def test_big_write_read(t : T?) {
         buf[BIG - 1l] = uint8(0)
         fopen(path, "rb") $(f) {
             t |> success(f != null)
-            f |> fread(buf)
+            t |> equal(f |> long_fread(buf), BIG)
         }
         for (k in range64(0l, BIG / PROBE_STEP)) {
             t |> equal(buf[k * PROBE_STEP], uint8(k + 1l))
         }
         t |> equal(buf[BIG - 1l], uint8(0xAB))
         delete buf
+        remove(path)
+    }
+    t |> run("int32 fwrite/fread panic past 2 GiB") @@(t : T?) {
+        var terr : string
+        let path = "{temp_directory(terr)}/das_big_io_panic.bin"
+        var buf : array<uint8>
+        buf |> resize(BIG)
+        var wrote_panicked = false
+        fopen(path, "wb") $(f) {
+            t |> success(f != null)
+            try {
+                f |> fwrite(buf)
+            } recover {
+                wrote_panicked = true
+            }
+        }
+        t |> success(wrote_panicked)
+        var read_panicked = false
+        fopen(path, "rb") $(f) {
+            t |> success(f != null)
+            try {
+                f |> fread(buf)
+            } recover {
+                read_panicked = true
+            }
+        }
+        t |> success(read_panicked)
+        delete buf
+        remove(path)
+    }
+    t |> run("fseek/ftell past 2 GiB") @@(t : T?) {
+        var terr : string
+        let path = "{temp_directory(terr)}/das_big_io_seek.bin"
+        let pos = int64(0xC0000000)   // 3 GiB — sparse on every filesystem we test on
+        fopen(path, "wb") $(f) {
+            t |> success(f != null)
+            fseek(f, pos, seek_set)
+            f |> fwrite(uint8(7))
+            t |> equal(ftell(f), pos + 1l)   // pre-fix on Windows: 32-bit ftell truncates
+        }
+        t |> equal(int64(stat(path).size), pos + 1l)
         remove(path)
     }
 }

--- a/tests/fio/fio_big_io.das
+++ b/tests/fio/fio_big_io.das
@@ -1,0 +1,52 @@
+options gen2
+require dastest/testing_boost
+require daslib/fio
+require math
+
+// Regression: fwrite/fread of an array past 2 GiB. The pre-fix rail computed the byte count
+// as int32 `length * sizeof`, which wraps negative past INT_MAX; the C runtime sign-extends
+// that to a huge size_t and streams out-of-bounds heap garbage into the file (or back over
+// the heap on read) with no diagnostic. The fixed rail chunks in int64.
+//
+// Costs ~2.2 GB of RAM and of disk for a few seconds, so it only runs when DAS_BIG_IO=1 —
+// the dasLLAMA image suite exercises the same rail end-to-end on real >2 GiB weight planes.
+
+let BIG = int64(0x80000000) + 65536l   // just past the int32 wrap
+let PROBE_STEP = int64(0x2000000)      // spot-check every 32 MiB — full compare would double the cost
+
+[test]
+def test_big_write_read(t : T?) {
+    if (get_env_variable("DAS_BIG_IO") != "1") {
+        t |> skip("big-IO regression needs DAS_BIG_IO=1 (2.2 GB RAM + disk)")
+        return
+    }
+    t |> run("fwrite/fread past 2 GiB") @@(t : T?) {
+        var terr : string
+        let path = "{temp_directory(terr)}/das_big_io_test.bin"
+        var buf : array<uint8>
+        buf |> resize(BIG)
+        for (k in range64(0l, BIG / PROBE_STEP)) {
+            buf[k * PROBE_STEP] = uint8(k + 1l)
+        }
+        buf[BIG - 1l] = uint8(0xAB)
+        fopen(path, "wb") $(f) {
+            t |> success(f != null)
+            f |> fwrite(buf)
+        }
+        t |> equal(int64(stat(path).size), BIG)   // pre-fix: garbage-padded file, wrong size
+        for (k in range64(0l, BIG / PROBE_STEP)) {
+            buf[k * PROBE_STEP] = uint8(0)
+        }
+        buf[BIG - 1l] = uint8(0)
+        fopen(path, "rb") $(f) {
+            t |> success(f != null)
+            f |> fread(buf)
+        }
+        for (k in range64(0l, BIG / PROBE_STEP)) {
+            t |> equal(buf[k * PROBE_STEP], uint8(k + 1l))
+        }
+        t |> equal(buf[BIG - 1l], uint8(0xAB))
+        delete buf
+        remove(path)
+    }
+}

--- a/tests/fio/fio_big_io.das
+++ b/tests/fio/fio_big_io.das
@@ -54,7 +54,7 @@ def test_big_write_read(t : T?) {
         }
         t |> equal(buf[BIG - 1l], uint8(0xAB))
         delete buf
-        remove(path)
+        t |> success(remove(path))   // a stuck multi-GiB temp file poisons later runs
     }
     t |> run("int32 fwrite/fread panic past 2 GiB") @@(t : T?) {
         let path = big_io_path("das_big_io_panic.bin")
@@ -81,7 +81,7 @@ def test_big_write_read(t : T?) {
         }
         t |> success(read_panicked)
         delete buf
-        remove(path)
+        t |> success(remove(path))   // a stuck multi-GiB temp file poisons later runs
     }
     t |> run("fseek/ftell past 2 GiB") @@(t : T?) {
         let path = big_io_path("das_big_io_seek.bin")
@@ -93,6 +93,6 @@ def test_big_write_read(t : T?) {
             t |> equal(ftell(f), pos + 1l)   // pre-fix on Windows: 32-bit ftell truncates
         }
         t |> equal(int64(stat(path).size), pos + 1l)
-        remove(path)
+        t |> success(remove(path))   // a stuck multi-GiB temp file poisons later runs
     }
 }

--- a/tests/fio/fio_big_io.das
+++ b/tests/fio/fio_big_io.das
@@ -15,6 +15,13 @@ require daslib/fio
 let BIG = int64(0x80000000) + 65536l   // just past the int32 wrap
 let PROBE_STEP = int64(0x2000000)      // spot-check every 32 MiB — full compare would double the cost
 
+// portable probe path: temp_directory + path_join (cwd as a last resort — never a bare "/name")
+def private big_io_path(name : string) : string {
+    var terr : string
+    let tmp = temp_directory(terr)
+    return path_join(empty(tmp) ? "." : tmp, name)
+}
+
 [test]
 def test_big_write_read(t : T?) {
     if (get_env_variable("DAS_BIG_IO") != "1") {
@@ -22,8 +29,7 @@ def test_big_write_read(t : T?) {
         return
     }
     t |> run("long_fwrite/long_fread past 2 GiB") @@(t : T?) {
-        var terr : string
-        let path = "{temp_directory(terr)}/das_big_io_test.bin"
+        let path = big_io_path("das_big_io_test.bin")
         var buf : array<uint8>
         buf |> resize(BIG)
         for (k in range64(0l, BIG / PROBE_STEP)) {
@@ -51,8 +57,7 @@ def test_big_write_read(t : T?) {
         remove(path)
     }
     t |> run("int32 fwrite/fread panic past 2 GiB") @@(t : T?) {
-        var terr : string
-        let path = "{temp_directory(terr)}/das_big_io_panic.bin"
+        let path = big_io_path("das_big_io_panic.bin")
         var buf : array<uint8>
         buf |> resize(BIG)
         var wrote_panicked = false
@@ -79,8 +84,7 @@ def test_big_write_read(t : T?) {
         remove(path)
     }
     t |> run("fseek/ftell past 2 GiB") @@(t : T?) {
-        var terr : string
-        let path = "{temp_directory(terr)}/das_big_io_seek.bin"
+        let path = big_io_path("das_big_io_seek.bin")
         let pos = int64(0xC0000000)   // 3 GiB — sparse on every filesystem we test on
         fopen(path, "wb") $(f) {
             t |> success(f != null)

--- a/tests/fio/fio_file.das
+++ b/tests/fio/fio_file.das
@@ -23,8 +23,9 @@ def operator ==(a, b : array<uint8> implicit) {
 [test]
 def test_empty_array_io(t : T?) {
     t |> run("fwrite/fread of an empty array is a 0-byte no-op, not an OOB addr") @(t : T?) {
-        let tmp = empty(get_env_variable("TMPDIR")) ? "/tmp" : get_env_variable("TMPDIR")
-        let fname = "{tmp}/fio_empty_io_{ref_time_ticks()}.bin"
+        var terr : string
+        let tmp = temp_directory(terr)   // portable (no /tmp on Windows); cwd as a last resort
+        let fname = path_join(empty(tmp) ? "." : tmp, "fio_empty_io_{ref_time_ticks()}.bin")
         var none : array<int>
         var wrote = false
         fopen(fname, "wb") $(f) {

--- a/tests/fio/fio_file.das
+++ b/tests/fio/fio_file.das
@@ -21,6 +21,32 @@ def operator ==(a, b : array<uint8> implicit) {
 }
 
 [test]
+def test_empty_array_io(t : T?) {
+    t |> run("fwrite/fread of an empty array is a 0-byte no-op, not an OOB addr") @(t : T?) {
+        let tmp = empty(get_env_variable("TMPDIR")) ? "/tmp" : get_env_variable("TMPDIR")
+        let fname = "{tmp}/fio_empty_io_{ref_time_ticks()}.bin"
+        var none : array<int>
+        var wrote = false
+        fopen(fname, "wb") $(f) {
+            if (f != null) {
+                t |> equal(fwrite(f, none), 0)
+                t |> equal(long_fwrite(f, none), 0l)
+                wrote = true
+            }
+        }
+        t |> success(wrote, "opened for write")
+        fopen(fname, "rb") $(f) {
+            if (f != null) {
+                t |> equal(fread(f, none), 0)
+                t |> equal(long_fread(f, none), 0l)
+            }
+        }
+        t |> success(remove(fname))
+        delete none
+    }
+}
+
+[test]
 def test_fopen(t : T?) {
     t |> run("fuzz fopen") @@(t : T?) {
         var fake <- Faker()

--- a/tests/fio/fio_file.das
+++ b/tests/fio/fio_file.das
@@ -36,12 +36,15 @@ def test_empty_array_io(t : T?) {
             }
         }
         t |> success(wrote, "opened for write")
+        var read_back = false
         fopen(fname, "rb") $(f) {
             if (f != null) {
                 t |> equal(fread(f, none), 0)
                 t |> equal(long_fread(f, none), 0l)
+                read_back = true
             }
         }
+        t |> success(read_back, "opened for read")
         t |> success(remove(fname))
         delete none
     }


### PR DESCRIPTION
## The prepared-model image (.dlim)

dasLLAMA model loads currently pay the full gguf parse + repack on every process start — 10.8 s for an 8B, 78.7 s for a 70B — which dominates measurement rounds and multi-process serving. This PR adds a **prepared-model image**: the post-load, post-repack model dumped once next to its gguf, then **mmap-mapped back in ~25 ms at any size** with zero O(model) allocation or copying. Plane fields become borrowed views over the mapping (the finalizer forgets them and unmaps); config/tokenizer/offsets ride a small archive blob parsed at load. Clean file-backed pages degrade gracefully under memory pressure and are shared across processes by the OS page cache.

| model | gguf load | image map |
|---|---|---|
| Llama-3.2-1B Q8 | ~1.5 s | 27 ms |
| Meta-Llama-3.1-8B Q8 (10.1 GB image) | 10.8 s | 24 ms |
| Voxtral-Small-24B Q4_K_M (16.9 GB image) | 13.6 s | 24 ms |
| Llama-3.3-70B Q4_K_M (47 GB image) | 78.7 s | 34 ms |

Round trips are token-exact (text), element-exact (tower planes), and transcript-exact (whisper) — asserted by the new test suite, and verified by hand on 1B/3B/8B/70B, voxtral-mini, Voxtral-Small-24B.

### How it works

- **Facade-only caching.** `load_model(gguf, q8)` keeps a `.dlim` next to the gguf: first load saves it, later loads map it. `DASLLAMA_IMAGE=0` disables the cache; passing a `.dlim` path loads that image directly (no gguf needed — wrong identity panics; there is nothing to regenerate from). Same contract on `load_audio_tower` (tags `tower-f32`/`tower-q8`) and `load_whisper_model` (`whisper-f32`/`whisper-q8`).
- **Box + knob identity.** Images are specific to the backend repack they were saved with: the identity folds format version, kernel backend, wscale width, and the full q8/kq plane-layout knobs — computed AFTER the same backend select the gguf loader runs, so lookup and save always agree. Knob combos coexist as separate files; every load decline logs its reason (a silently regenerating cache is undebuggable).
- **Generic serialization rail.** A weight-carrying struct opts in with `serialize_image_meta(Archive, T)` + `image_post_load(T)` (`_::` dispatch). The plane walk handles top-level POD arrays, recurses one level into nested carriers (marker: the field's type declares `image_map` — `WhisperModel.enc` contributes `enc.fblob` etc.), and routes string arrays through the meta blob (raw string pointers can't be planes). `count_meta_fields` tripwires each explicit field list against struct growth. Derived state (tokenizer lookups, whisper mel tables) rebuilds at load — the parse-at-load carve-out.
- **File layout.** Page 0 header (magic/version/page/identity), every plane 16 KB-page-aligned (the Metal `bytesNoCopy` contract), meta blob at the tail, atomic tmp+rename save with per-writer tmp names. Save verifies `ftell` against plane accounting and aborts loudly on drift. The load path touches only the header + meta blob — mapping is O(#planes), which is why 47 GB maps in 34 ms.
- **Metal serves straight off the mapping**: the decode/prefill parity suites load through the facade, so their GPU arms now run mirror uploads from borrowed mapped planes (verified green on M1 Max).

### Two latent bugs the full gates caught (both fixed here, with regression arms)

- **An image load now moves the weights epoch.** The Metal drivers' resident weight regions key by host address and flush on the weights epoch, which only `load_gguf` bumped — a mapped image landing planes at a deleted model's recycled addresses made the GPU silently serve the dead model's buffers (kq single-step logits off by 23.5 in the full decode sweep). `load_image` bumps like a gguf load; the mechanics arm asserts the contract.
- **An image load no longer re-runs the arch configure.** Configures set gguf-overridable fallbacks (gemma4: `sliding_window = 1024`); re-running one over the deserialized config stomped the E2B's real 512 window and drifted tokens once the context crossed it. `image_post_load` now re-binds block kernels only — the serialized config already carries configure's flags plus the file's overrides. The image round trip gains a full config field-diff (fails on any clobber regardless of gen length) and a gemma-E2B regression arm.

### 64-bit file IO (the bug the tripwire caught)

Voxtral-mini's q8 plane is 3.6 G elements — past `INT_MAX`, where the int32 `fwrite`/`fread` rail silently corrupted. fio grows first-class 64-bit IO: `long_fread`/`long_fwrite` (C++ interop twins `_builtin_read64/_builtin_write64`), int32 forms now throw on overflow instead of truncating, `ftell`/`fseek` use `_ftelli64`/`ftello` (C `long` is 32-bit on Windows), `fsave` panics on &gt;2 GiB payloads, and `-jit` emits the &gt;INT_MAX guard on `length()` (`LLVM_JIT_CODEGEN_VERSION` → 0x43). Regression coverage in `tests/fio/fio_big_io.das` (gated by `DAS_BIG_IO=1`).

### New bindings

- fio: split `fmap_open`/`fmap_close` (today's `fmap` is scope-bound; the image mapping outlives the call).
- dasMetal: `metal_new_buffer_no_copy` (`newBufferWithBytesNoCopy`, null deallocator — buffers release before munmap).
- runtime: `_builtin_forget_temp_array` — reset a borrowed array view without freeing its memory.

### Tests

`tests/dasLLAMA/test_model_image.das`, driven through the runner rail (`tests/dasLLAMA/run.das -- --suite image`):

- **mechanics** (model-free synthetic carrier, runs in CI): value round trip, dotted nested-carrier planes, string-array meta rail, identity/version/size-lie declines, unmap-remap cycle.
- **smol / gemma / tower / whisper**: gguf-load vs mapped-image compare — token-exact + full config field-diff (SmolLM2 q8, gemma-4-E2B q8), element-exact fblob (ultravox tower), transcript-exact (whisper tiny) — plus cold-save/warm-map/re-map-after-delete state checks.
- **voxtral**: the designated &gt;2 GiB-plane coverage — re-saves voxtral-mini's 5.4 GB image from cold every run and asserts it crosses 2 GiB.

Tests that hand-deleted individual plane arrays now delete the whole model — image-backed planes are locked views only the finalizer may release.

### Notes / follow-ups

- **Disk cost**: images live next to their ggufs at roughly repacked size (8B → 10.1 GB, 24B → 16.9 GB, 70B → 47 GB). The gguf stays deletable (images are self-sufficient), but keeping both doubles disk per model.
- **Orphans**: editing dasLLAMA sources re-tunes the box, which changes the identity stamp — the old image stays behind as an orphan (correct by design: knob combos coexist). Cleanup is manual for now (`rm *.dlim` is always safe — they regenerate).
- **Offline box-to-box converter** (re-repack an image for another box without the gguf, per-plane repack descriptors are already stored) — follow-up.
- Whisper is on the rail; parakeet/canary/gemma4a ASR carriers are natural next candidates for the same generic pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)