### PR TITLE
aot.h: exact-match __bit_set overload for local-bitfield field assigns

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -113,6 +113,12 @@ namespace das {
     __forceinline void __bit_set ( uint32_t & value, uint32_t mask, bool on ) {
         value = on ? (value | mask) : (value & ~mask);
     }
+    // Mixed overload: a LOCAL das bitfield's field-assign emits a raw uint literal mask
+    // (`__bit_set(bf, 0x1u, on)`) — without this exact match, the Bitfield and raw-uint32
+    // overloads above are one user-conversion each and the call is ambiguous.
+    __forceinline void __bit_set ( Bitfield & value, uint32_t mask, bool on ) {
+        value.value = on ? (value.value | mask) : (value.value & ~mask);
+    }
     __forceinline void __bit_set ( uint8_t & value, uint8_t mask, bool on ) {
         value = on ? uint8_t(value | mask) : uint8_t(value & ~mask);
     }

--- a/tests/language/bitfields.das
+++ b/tests/language/bitfields.das
@@ -257,3 +257,27 @@ def test_bitfield_64(t : T?) {
         }
     }
 }
+
+[test]
+def test_bitfield_field_assign(t : T?) {
+    t |> run("field assign on a LOCAL bitfield (the AOT __bit_set lowering)") @(t : T?) {
+        // `bf.field = bool` on a local das-typed bitfield AOT-emits `__bit_set(bf, <uint
+        // literal>, on)` — the aot.h overload set must resolve it unambiguously (the mixed
+        // (Bitfield&, uint32_t) overload; regression for the metal_needs-shaped derivation)
+        var n : Baz
+        n.bit0 = true
+        n.bit2 = true
+        t |> equal(Baz.bit0 | Baz.bit2, n)
+        n.bit0 = false
+        t |> equal(Baz.bit2, n)
+        // expression RHS, both polarities in one pass
+        let src = 5
+        n.bit0 = src > 0
+        n.bit1 = src < 0
+        n.bit2 = src != 5
+        t |> equal(Baz.bit0, n)
+        // read-back through the field form
+        t |> success(n.bit0)
+        t |> success(!n.bit1)
+    }
+}


### PR DESCRIPTION
A LOCAL das-typed bitfield's field-assign (`bf.field = expr`) AOT-emits `__bit_set(bf, 0x1u, on)` — a `Bitfield&` value with a raw uint literal mask. The `(Bitfield&, Bitfield, bool)` overload needs a uint→Bitfield conversion on the mask, and the raw `(uint32_t&, uint32_t, bool)` overload (added for handle-bound bitfield fields) needs Bitfield→uint32_t& on the value: one user conversion each, so the call is ambiguous and the generated TU fails to build. Nothing in the tree AOT'd this shape until a local-bitfield feature-set derivation hit it; the failure blocked `preflight --full` at the tests-aot gate.

Fix: a mixed `(Bitfield&, uint32_t, bool)` overload — the exact match for the emitted call. Added overloads keep every previously bound signature, so there is no AOT-hash churn (the same pattern as the raw-integer overloads' own comment block and the `das_memcpy` const-source overloads).

Regression test: `tests/language/bitfields.das` grows a field-assign case on a local bitfield (constant and expression RHS, both polarities, read-back). The generated TU emits the `__bit_set` lowering and is part of the per-PR `test_aot_subset` compile gate, so any future regression fails PR CI directly. Verified interp, `-jit`, and `test_aot_subset -use-aot` (14/14), plus the full 604-TU subset build against the new header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)