### PR TITLE
Fix and lint string clone semantics

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1021,12 +1021,12 @@ class public AotDebugInfoHelper {
             let bits = uint64(val.value)
             var cppLit : string
             if (bits == 0x8000000000000000ul) {
-                cppLit := "(-INT64_C(0x7fffffffffffffff) - INT64_C(1))"
+                cppLit = "(-INT64_C(0x7fffffffffffffff) - INT64_C(1))"
             } elif (val.value < 0l) {
                 let absBits = uint64(-val.value)
-                cppLit := "-INT64_C(0x{absBits:x})"
+                cppLit = "-INT64_C(0x{absBits:x})"
             } else {
-                cppLit := "INT64_C(0x{bits:x})"
+                cppLit = "INT64_C(0x{bits:x})"
             }
             write(*writer, "EnumValueInfo {enumInfoName(einfo)}_value_{v} = \{ \"{val.name}\", {cppLit} \};\n")
         }

--- a/daslib/daspkg.das
+++ b/daslib/daspkg.das
@@ -49,7 +49,7 @@ def package_license(license : string) {
 }
 
 def package_tag(tag : string) {
-    _pkg_meta.tags |> push_clone(tag)
+    _pkg_meta.tags |> push(tag)
 }
 
 def package_tags(tags : array<string>) {

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -650,9 +650,9 @@ def run_and_capture(args : array<string>; var output : string&; timeout_sec : fl
     var captured : string
     let exit_code = unsafe(popen_argv(args, timeout_sec, $(f) {
         if (f != null) {
-            captured := unsafe(fread_to_eof(f))
+            captured = unsafe(fread_to_eof(f))
         }
     }))
-    output := captured
+    output = captured
     return exit_code
 }

--- a/daslib/linq_fold_decs.das
+++ b/daslib/linq_fold_decs.das
@@ -926,7 +926,7 @@ def compute_decs_chain_info(var calls : array<tuple<ExprCall?; LinqCall?>>;
             curType = clone_type(peeled._type)
         } elif (opName != "where_") return null
     }
-    info.finalBind := curBind
+    info.finalBind = curBind
     info.finalType = curType
     if (info.finalType != null) {
         info.finalType.flags.constant = false

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -51,6 +51,7 @@ class LintVisitor : AstVisitor {
     compile_time_errors : bool
     noLint : bool = false
     genericDepth : int = 0
+    multiple_contexts : bool = false
     // collection mode — when true, errors are appended to `errors` instead of error()
     collect_errors : bool = false
     errors : array<string>
@@ -87,6 +88,122 @@ class LintVisitor : AstVisitor {
         } else {
             error("{text} at {describe(at)}\n")
         }
+    }
+    def private source_operator_is_clone(at : LineInfo) : bool {
+        //! Inference lowers a string ExprClone to ExprCopy in ordinary mode, but preserves the clone operator's LineInfo. Check that source token so a regular '=' copy stays silent.
+        if (at.fileInfo == null || at.line == 0u || at.line != at.last_line) return false
+        var found = false
+        get_file_source_line(at.fileInfo, at.line) $(line) {
+            var start = int(at.column) - 1
+            if (start < 0) {
+                start = 0
+            }
+            var finish = int(at.last_column) + 1
+            if (finish < start + 3) {
+                finish = start + 3
+            }
+            if (finish > length(line)) {
+                finish = length(line)
+            }
+            if (finish > start) {
+                found = find(slice(line, start, finish), ":=") >= 0
+            }
+        }
+        return found
+    }
+    def private root_generic(fn : Function const?) : Function const? {
+        var root = fn
+        while (root != null && root.fromGeneric != null) {
+            root = root.fromGeneric
+        }
+        return root
+    }
+    def private is_temporary_string_source(expr : Expression?) : bool {
+        if (expr == null) return false
+        if (expr._type != null && expr._type.flags.temporary) return true
+        var inner = expr
+        if (inner is ExprRef2Value) {
+            inner = (inner as ExprRef2Value).subexpr
+        }
+        if (inner is ExprVar) {
+            let variable = (inner as ExprVar).variable
+            return variable != null && variable._type != null && variable._type.flags.temporary
+        }
+        return false
+    }
+    def private is_inferred_temp_string_clone(expr : Expression?; clone_at : LineInfo) : bool {
+        //! InferTypes rewrites `dst := string#_expr` to `dst = clone_string(string#_expr)` and gives the injected call the original := token location. A source-written clone_string call keeps its own location.
+        if (expr == null || !(expr is ExprCall)) return false
+        let call = expr as ExprCall
+        return (call.func != null && call.func.name == "clone_string"
+            && call.at.line == clone_at.line && call.at.column == clone_at.column)
+    }
+    def private is_inferred_temp_string_init(expr : Expression?; init_at : LineInfo) : bool {
+        //! InferTypes rewrites `var dst := string#_expr` through clone_string. The wrapper result is a regular string, so inspect its source argument to preserve the temporary-string exception.
+        if (expr == null || !(expr is ExprCall)) return false
+        let call = expr as ExprCall
+        let root = root_generic(call.func)
+        return (root != null && root.name == "clone_string"
+            && root._module != null && root._module.name == "builtin"
+            && call.at.line == init_at.line && call.at.column == init_at.column
+            && !empty(call.arguments) && is_temporary_string_source(call.arguments[0]))
+    }
+    def private source_variable_init_is_clone(v : VariablePtr) : bool {
+        //! String clone initialization is lowered before lint runs. Search only between the source variable name and its initializer, so another declaration or := inside the RHS cannot produce a false positive.
+        if (v == null || v.init == null || v.at.fileInfo == null || v.at.line == 0u) return false
+        var found = false
+        get_file_source_line(v.at.fileInfo, v.at.line) $(line) {
+            var start = int(v.at.column) - 1
+            if (start < 0) {
+                start = 0
+            }
+            var finish = length(line)
+            if (v.init.at.line == v.at.line && int(v.init.at.column) > start) {
+                finish = int(v.init.at.column) + 1
+                if (finish > length(line)) {
+                    finish = length(line)
+                }
+            }
+            if (finish > start) {
+                found = find(slice(line, start, finish), ":=") >= 0
+            }
+        }
+        return found
+    }
+    def private check_string_clone_init(v : VariablePtr) : void {
+        if (v == null || multiple_contexts || noLint || genericDepth > 0
+                || v.flags.generated || v._type == null || v.init == null
+                || v._type.baseType != Type.tString
+                || is_temporary_string_source(v.init)
+                || is_inferred_temp_string_init(v.init, v.at)
+                || !source_variable_init_is_clone(v)) return
+        lint_error("LINT016: ':=' does not clone a string variable without 'options multiple_contexts'; use '=' for same-context storage, or did you mean '= clone_string(value)' for a cross-context copy", v.at)
+    }
+    def private check_string_clone_assign(expr : ExprCopy?) : void {
+        if (expr == null || multiple_contexts || noLint || genericDepth > 0 || expr.genFlags.generated
+                || expr.left == null || expr.right == null
+                || expr.left._type == null || expr.right._type == null
+                || expr.left._type.baseType != Type.tString
+                || expr.right._type.baseType != Type.tString
+                || is_temporary_string_source(expr.right)
+                || is_inferred_temp_string_clone(expr.right, expr.at)
+                || !source_operator_is_clone(expr.at)) return
+        lint_error("LINT016: ':=' does not clone a string without 'options multiple_contexts'; use '=' for same-context storage, or did you mean 'clone_string(value)' for a cross-context copy", expr.at)
+    }
+    def private check_string_push_clone(expr : ExprCall?) : void {
+        if (expr == null || multiple_contexts || noLint || genericDepth > 0 || expr.genFlags.generated
+                || expr.func == null || length(expr.arguments) < 2) return
+        let root = root_generic(expr.func)
+        if (root == null || root.name != "push_clone"
+                || root._module == null || root._module.name != "builtin") return
+        let dst = expr.arguments[0]
+        let value = expr.arguments[1]
+        if (dst == null || value == null || dst._type == null || value._type == null
+                || dst._type.baseType != Type.tArray || dst._type.firstType == null
+                || dst._type.firstType.baseType != Type.tString
+                || value._type.baseType != Type.tString
+                || is_temporary_string_source(value)) return
+        lint_error("LINT016: 'push_clone' does not clone a string without 'options multiple_contexts'; use 'push(value)' for same-context storage, or did you mean 'push(clone_string(value))' for a cross-context copy", expr.at)
     }
     def override preVisitFunction(fun : FunctionPtr) : void {
         noLint = false
@@ -271,6 +388,10 @@ class LintVisitor : AstVisitor {
         validate_argument(arg, "LINT013", "block argument")
     }
 
+    def override preVisitExprCall(expr : ExprCall?) : void {
+        check_string_push_clone(expr)
+    }
+
     // `assume name = <block>` keeps a template block at the alias-definition site; every use of
     // `name` is replaced with a *clone* of that block.
     // The template is never invoked directly, so its block arguments keep isAccessUnused == true and
@@ -364,6 +485,7 @@ class LintVisitor : AstVisitor {
     }
 
     def override preVisitExprLetVariable(_let : ExprLet?; v : VariablePtr; _last : bool) : void {
+        check_string_clone_init(v)
         // Skip reference bindings (`var r & = x`) and inscope smart_ptr vars — these have aliasing or scope-exit semantics we don't reason about.
         if (noLint || genericDepth > 0
             || (v._type != null && v._type.flags.ref)
@@ -379,6 +501,10 @@ class LintVisitor : AstVisitor {
             has_pending = has_init,
             pending_pure = init_pure
         ))
+    }
+
+    def override preVisitGlobalLetVariable(v : VariablePtr; _last : bool) : void {
+        check_string_clone_init(v)
     }
 
     def override preVisitExprVar(expr : ExprVar?) : void {
@@ -412,6 +538,7 @@ class LintVisitor : AstVisitor {
     }
 
     def override visitExprCopy(var expr : ExprCopy?) : ExpressionPtr {
+        check_string_clone_assign(expr)
         ds_handle_store(expr.left, expr.right, expr)
         return <- expr
     }
@@ -474,7 +601,9 @@ def public paranoid(prog : ProgramPtr; compile_time_errors : bool; disabled_code
     //! Filter-aware compile-time variant. ``disabled_codes`` suppresses
     //! the listed rule IDs (e.g. "LINT003") alongside the usual
     //! ``// nolint:CODE`` directives.
-    var astVisitor = new LintVisitor(compile_time_errors = compile_time_errors)
+    var astVisitor = new LintVisitor(
+        compile_time_errors = compile_time_errors,
+        multiple_contexts = prog._options |> find_arg("multiple_contexts") ?as tBool ?? prog.policies.multiple_contexts)
     astVisitor.disabled_codes := disabled_codes
     make_visitor(*astVisitor) $(adapter) {
         astVisitor.astVisitorAdapter = adapter
@@ -496,7 +625,10 @@ def public paranoid_collect(prog : ProgramPtr; var errors : array<string>;
                             disabled_codes, enabled_codes : table<string>) : int {
     //! Filter-aware overload. `disabled_codes` is a denylist; `enabled_codes`
     //! is a whitelist (empty == all). Codes use the bare form (e.g. "LINT002").
-    var astVisitor = new LintVisitor(compile_time_errors = false, collect_errors = true)
+    var astVisitor = new LintVisitor(
+        compile_time_errors = false,
+        collect_errors = true,
+        multiple_contexts = prog._options |> find_arg("multiple_contexts") ?as tBool ?? prog.policies.multiple_contexts)
     astVisitor.disabled_codes := disabled_codes
     astVisitor.enabled_codes := enabled_codes
     make_visitor(*astVisitor) $(adapter) {
@@ -515,7 +647,10 @@ def public paranoid_collect_issues(prog : ProgramPtr; var issues : array<LintIss
                                    disabled_codes, enabled_codes : table<string>) : int {
     //! Structured twin of ``paranoid_collect`` — same filters, but emits
     //! ``LintIssue`` records (rule code + position) instead of display strings.
-    var astVisitor = new LintVisitor(compile_time_errors = false, collect_errors = true)
+    var astVisitor = new LintVisitor(
+        compile_time_errors = false,
+        collect_errors = true,
+        multiple_contexts = prog._options |> find_arg("multiple_contexts") ?as tBool ?? prog.policies.multiple_contexts)
     astVisitor.disabled_codes := disabled_codes
     astVisitor.enabled_codes := enabled_codes
     make_visitor(*astVisitor) $(adapter) {

--- a/daslib/perf_lint.das
+++ b/daslib/perf_lint.das
@@ -260,22 +260,22 @@ class PerfLintVisitor : AstVisitor {
         if (expr is ExprRef2Value) return find_expr_path((expr as ExprRef2Value.subexpr), path)
         if (expr is ExprField) {
             var field = expr as ExprField
-            path := ".{field.name}{path}"
+            path = ".{field.name}{path}"
             return find_expr_path(field.value, path)
         }
         if (expr is ExprSafeField) {
             var field = expr as ExprSafeField
-            path := ".{field.name}{path}"
+            path = ".{field.name}{path}"
             return find_expr_path(field.value, path)
         }
         if (expr is ExprAt) {
             var at = expr as ExprAt
-            path := "[*]{path}"
+            path = "[*]{path}"
             return find_expr_path(at.subexpr, path)
         }
         if (expr is ExprSafeAt) {
             var at = expr as ExprSafeAt
-            path := "[*]{path}"
+            path = "[*]{path}"
             return find_expr_path(at.subexpr, path)
         }
         if (expr is ExprSwizzle) {

--- a/daslib/sql_linq.das
+++ b/daslib/sql_linq.das
@@ -660,10 +660,10 @@ def private finalize_distinct_by_count_wrap(var q : SqlQuery&; isLong : bool; pr
         q.hadError = true
         return
     }
-    q.innerSql := build_distinct_by_inner_subquery(q, pkField, false)
+    q.innerSql = build_distinct_by_inner_subquery(q, pkField, false)
     q.fromRowType = q.rootType
-    q.whereSql := predSql
-    q.aggregateExpr := "COUNT(*)"
+    q.whereSql = predSql
+    q.aggregateExpr = "COUNT(*)"
     let countBaseType = isLong ? Type.tInt64 : Type.tInt
     q.aggregateType = new TypeDecl(at = at, baseType = countBaseType)
     q.proj = ProjectionShape.Aggregate
@@ -680,9 +680,9 @@ def private finalize_distinct_by_aggregate_wrap(var q : SqlQuery&; sqlOp : strin
         q.hadError = true
         return
     }
-    q.innerSql := build_distinct_by_inner_subquery(q, pkField, false)
+    q.innerSql = build_distinct_by_inner_subquery(q, pkField, false)
     q.fromRowType = q.rootType
-    q.aggregateExpr := "{sqlOp}(\"{sqlCol}\")"
+    q.aggregateExpr = "{sqlOp}(\"{sqlCol}\")"
     q.aggregateType = aggregateType
     q.proj = ProjectionShape.Aggregate
     q.matr = Materializer.One
@@ -697,7 +697,7 @@ def private finalize_distinct_by_passthrough_wrap(var q : SqlQuery&; prog : Prog
         q.hadError = true
         return
     }
-    q.innerSql := build_distinct_by_inner_subquery(q, pkField, q.distinctByLast)
+    q.innerSql = build_distinct_by_inner_subquery(q, pkField, q.distinctByLast)
     q.fromRowType = q.rootType
 }
 
@@ -957,7 +957,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     let savedSeenTerminal = q.seenTerminal
     let savedSeenToArray = q.seenToArray
     // Aggregate state save: inner subquery emits projection cols, outer renders COUNT/SUM.
-    let savedAggExpr := q.aggregateExpr
+    let savedAggExpr = q.aggregateExpr
     var savedAggType = q.aggregateType
     // Clear them on q so the inner SQL emits without outer-only clauses.
     q.matr = Materializer.Array
@@ -972,7 +972,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.seenDistinct = false
     q.seenTerminal = false
     q.seenToArray = false
-    q.aggregateExpr := ""
+    q.aggregateExpr = ""
     q.aggregateType = null
     if (savedAggExpr != "") {
         if (keepLimitInner) {
@@ -1000,29 +1000,29 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     // Reset q to wrap state. Clear all join/where/projection state so outer can re-fill.
     q.rootType = null
     q.projectedRowType = null
-    q.tableName := ""
-    q.rootAlias := ""
+    q.tableName = ""
+    q.rootAlias = ""
     q.selectCols |> clear
     q.selectColAliases |> clear
     q.selectColTypes |> clear
     q.selectColSqlFragments |> clear
     q.projRecordNames |> clear
-    q.aggregateExpr := ""
+    q.aggregateExpr = ""
     q.aggregateType = null
-    q.whereSql := ""
+    q.whereSql = ""
     q.bindExprs |> clear
     q.projBindExprs |> clear
     q.limitBindExpr = null
     q.offsetBindExpr = null
     q.distinctFlag = false
-    q.distinctByCol := ""
+    q.distinctByCol = ""
     q.distinctByLast = false
     q.orderByCols |> clear
     q.orderByInlineExprs |> clear
     q.groupByCols |> clear
     q.groupByKeyExprs |> clear
     q.groupByKeyTypes |> clear
-    q.havingSql := ""
+    q.havingSql = ""
     q.havingBindExprs |> clear
     q.groupedSelectExprs |> clear
     q.groupedSelectTypes |> clear
@@ -1041,7 +1041,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.seenJoin = false
     q.joins |> clear
     q.setOpKind = SetOpKind.None
-    q.setOpRhsSql := ""
+    q.setOpRhsSql = ""
     q.setOpRhsBinds |> clear
     q.seenSetOp = false
     q.argNames |> clear
@@ -1049,7 +1049,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.upsertMode = false
     q.minPhaseSeen = INT_MAX_PHASE
     // Install wrap state.
-    q.innerSql := innerSql
+    q.innerSql = innerSql
     q.innerBindExprs <- innerBinds
     q.fromRowType = projType
     q.dbExpr = savedDb
@@ -1071,7 +1071,7 @@ def private snapshot_q_to_subquery_wrap(var q : SqlQuery&; prog : ProgramPtr; at
     q.seenDistinct = savedSeenDistinct
     q.seenTerminal = savedSeenTerminal
     q.seenToArray = savedSeenToArray
-    q.aggregateExpr := savedAggExpr
+    q.aggregateExpr = savedAggExpr
     q.aggregateType = savedAggType
     if (savedAggExpr != "") {
         // Override FullRow installed by reset; aggregate outer ignores fillPassthrough.
@@ -1232,12 +1232,12 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
         // SELECT * propagates underlying column names; outer references t1.<col> by name.
         // Inner AS "t1" is required because subQ.whereSql may carry refs like `"t1"."Total"`
         // built when subQ.rootAlias was "t1". Outer-most "t1" shadows inner via parens-scope.
-        rhsTableName := "(SELECT * FROM \"{subQ.tableName}\" AS \"t1\" WHERE {subQ.whereSql})"
-        rhsRightWhereSql := ""
+        rhsTableName = "(SELECT * FROM \"{subQ.tableName}\" AS \"t1\" WHERE {subQ.whereSql})"
+        rhsRightWhereSql = ""
         rhsTableSqlIsRaw = true
     } else {
-        rhsTableName := subQ.tableName
-        rhsRightWhereSql := subQ.whereSql
+        rhsTableName = subQ.tableName
+        rhsRightWhereSql = subQ.whereSql
     }
     var spec <- JoinSpec(
         kind = kind,
@@ -1280,7 +1280,7 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     // nolint:STYLE015 — save/restore explanation: analyze_projection clobbers proj=Aggregate
     // set by outer-peeled `_count`/`_sum`/etc. We still need it to populate selectCols for
     // the inner subquery, so run normally then restore. Invariant: aggregateExpr non-empty ⇒ proj=Aggregate.
-    let savedAggExpr := q.aggregateExpr
+    let savedAggExpr = q.aggregateExpr
     var savedAggType = q.aggregateType
     let savedAggProj = q.proj == ProjectionShape.Aggregate
     let projOk = analyze_projection(iret.subexpr, q, prog, at)
@@ -1288,7 +1288,7 @@ def private process_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     q.argSourceIdx |> clear
     if (!projOk) return false
     if (savedAggExpr != "") {
-        q.aggregateExpr := savedAggExpr
+        q.aggregateExpr = savedAggExpr
         q.aggregateType = savedAggType
         if (savedAggProj) {
             q.proj = ProjectionShape.Aggregate
@@ -1393,9 +1393,9 @@ def private process_cross_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     // Hoist any RHS WHERE into the outer q.whereSql — Cross has no ON clause to attach it to.
     if (!empty(subQ.whereSql)) {
         if (empty(q.whereSql)) {
-            q.whereSql := subQ.whereSql
+            q.whereSql = subQ.whereSql
         } else {
-            q.whereSql := "({q.whereSql}) AND ({subQ.whereSql})"
+            q.whereSql = "({q.whereSql}) AND ({subQ.whereSql})"
         }
         q.bindExprs |> reserve(q.bindExprs |> length + length(subQ.bindExprs))
         for (b in subQ.bindExprs) {
@@ -1422,7 +1422,7 @@ def private process_cross_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     q.argSourceIdx |> push(0)
     q.argNames |> push(arg1Name)
     q.argSourceIdx |> push(1)
-    let savedAggExpr := q.aggregateExpr
+    let savedAggExpr = q.aggregateExpr
     var savedAggType = q.aggregateType
     let savedAggProj = q.proj == ProjectionShape.Aggregate
     let projOk = analyze_projection(iret.subexpr, q, prog, at)
@@ -1430,7 +1430,7 @@ def private process_cross_join_call(var jCall : ExprCall?; var q : SqlQuery&;
     q.argSourceIdx |> clear
     if (!projOk) return false
     if (savedAggExpr != "") {
-        q.aggregateExpr := savedAggExpr
+        q.aggregateExpr = savedAggExpr
         q.aggregateType = savedAggType
         if (savedAggProj) {
             q.proj = ProjectionShape.Aggregate
@@ -1585,11 +1585,11 @@ def private divert_to_inner(var node : ExpressionPtr; var q : SqlQuery&;
     let innerSql = build_sql_string(subQ, true)
     var innerBinds : array<ExpressionPtr>
     collect_query_binds(subQ, innerBinds)
-    q.innerSql := innerSql
+    q.innerSql = innerSql
     q.innerBindExprs <- innerBinds
     q.fromRowType = inner_projection_type(subQ, at)
     if (empty(q.tableName)) {
-        q.tableName := subQ.tableName
+        q.tableName = subQ.tableName
     }
     if (q.dbExpr == null) {
         q.dbExpr = subQ.dbExpr

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -559,6 +559,41 @@ and unary, so a split binary ``a + b`` orphans as a valid unary statement.
 
 Wrap any multi-line arithmetic RHS in ``(...)``.
 
+LINT016 — ineffective string clone syntax
+===========================================
+
+In the default single-context mode, copying a regular ``string`` only copies
+its pointer. Consequently,
+``dst := src``, ``var dst := src``, and ``strings |> push_clone(src)`` do not
+clone the character data when ``src`` is an ordinary ``string``; their clone
+spelling is misleading.
+
+Use ordinary copy syntax for same-context storage, and make a cross-context
+copy explicit with ``clone_string`` in the receiving context:
+
+.. code-block:: das
+
+    dst = src
+    var local = src
+    strings |> push(src)
+
+    dst = clone_string(src)
+    var local_copy = clone_string(src)
+    strings |> push(clone_string(src))
+
+The rule stays silent in two cases where clone syntax has real semantics:
+
+* ``options multiple_contexts`` is enabled. The compiler then lowers string
+  ``:=`` — including variable initialization and the assignment inside
+  ``push_clone`` — to ``clone_string``.
+* The source expression has temporary type ``string#``. A real clone is
+  required to retain the borrowed characters beyond the temporary's lifetime,
+  and the compiler inserts it automatically.
+
+Only user-written, non-generated code is reported. Generic templates and their
+instantiated functions are skipped; a direct call from ordinary user code is
+still checked.
+
 .. _perf_lint:
 
 -----------------

--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -551,6 +551,7 @@ namespace das {
         virtual void preVisitLetInit(ExprLet *expr, const VariablePtr &var, Expression *init) override;
         bool isEmptyInit(const VariablePtr &var) const;
         virtual VariablePtr visitLet(ExprLet *expr, const VariablePtr &var, bool last) override;
+        ExpressionPtr promoteStringInitToClone(const VariablePtr &var);
         ExpressionPtr promoteToCloneToMove(const VariablePtr &var);
         bool canRelaxAssign(Expression *init) const;
         virtual ExpressionPtr visitLetInit(ExprLet *expr, const VariablePtr &var, Expression *init) override;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -524,6 +524,9 @@ namespace das {
                       var->at, CompilationError::invalid_global_init_type);
             } else {
                 varT->ref = false;
+                if (var->init_via_clone && varT->isString()) {
+                    varT->temporary = false;
+                }
                 TypeDecl::applyAutoContracts(varT, var->type);
                 if (!relaxedPointerConst) { // var a = Foo? const -> var a : Foo const? = Foo? const
                     if (varT->isPointer() && !varT->constant && var->init->type->constant && varT->firstType) {
@@ -577,7 +580,9 @@ namespace das {
             }
         } else {
             if (var->init_via_clone) {
-                if (var->init->type->isWorkhorseType()) {
+                if (var->init->type->isString() && (var->init->type->isTemp() || multiContext)) {
+                    return promoteStringInitToClone(var);
+                } else if (var->init->type->isWorkhorseType()) {
                     var->init_via_clone = false;
                     var->init_via_move = false;
                     reportAstChanged();
@@ -5452,6 +5457,9 @@ namespace das {
                       var->at, CompilationError::invalid_local_init_type);
             } else {
                 varT->ref = false;
+                if (var->init_via_clone && varT->isString()) {
+                    varT->temporary = false;
+                }
                 TypeDecl::applyAutoContracts(varT, var->type);
                 if (!relaxedPointerConst) { // var a = Foo? const -> var a : Foo const? = Foo? const
                     if (varT->isPointer() && varT->firstType && !varT->constant && var->init->type->constant) {
@@ -5515,7 +5523,9 @@ namespace das {
             }
         } else {
             if (var->init_via_clone) {
-                if (var->init->type->isWorkhorseType()) {
+                if (var->init->type->isString() && (var->init->type->isTemp() || multiContext)) {
+                    return promoteStringInitToClone(var);
+                } else if (var->init->type->isWorkhorseType()) {
                     var->init_via_clone = false;
                     var->init_via_move = false;
                     reportAstChanged();

--- a/src/ast/ast_infer_type_helper.cpp
+++ b/src/ast/ast_infer_type_helper.cpp
@@ -1296,6 +1296,15 @@ namespace das {
         c2m->arguments.push_back(var->init);
         return c2m;
     }
+
+    ExpressionPtr InferTypes::promoteStringInitToClone(const VariablePtr &var) {
+        reportAstChanged();
+        var->init_via_clone = false;
+        var->init_via_move = false;
+        auto cloneString = new ExprCall(var->at, "clone_string");
+        cloneString->arguments.push_back(var->init);
+        return cloneString;
+    }
     bool InferTypes::canRelaxAssign(Expression *init) const {
         if (!relaxedAssign)
             return false;

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -639,6 +639,7 @@ SET(AOT_LANGUAGE_MODULE_FILES
     tests/language/_lambda_vis_mid.das
     tests/language/_operators_derived.das
     tests/language/_operators_parent.das
+    tests/language/_string_clone_init_helper.das
 )
 
 add_custom_target(test_aot_algorithm)

--- a/tests/language/_string_clone_init_helper.das
+++ b/tests/language/_string_clone_init_helper.das
@@ -1,0 +1,15 @@
+options gen2
+
+module _string_clone_init_helper public
+
+require strings
+
+def public same_string_storage(a, b : string) : bool {
+    var same = false
+    peek_data(a) $(aa) {
+        peek_data(b) $(bb) {
+            same = addr(aa[0]) == addr(bb[0])
+        }
+    }
+    return same
+}

--- a/tests/language/string_clone_init_multiple_contexts.das
+++ b/tests/language/string_clone_init_multiple_contexts.das
@@ -1,0 +1,27 @@
+options gen2
+options multiple_contexts
+
+require UnitTest
+require dastest/testing_boost public
+require _string_clone_init_helper
+
+var global_source = get_das_root()
+var global_clone := global_source
+
+[test]
+def test_string_clone_local_init_multiple_contexts(t : T?) {
+    t |> run("string := local initialization clones with multiple_contexts") @(t : T?) {
+        let source = get_das_root()
+        let cloned := source
+        t |> equal(cloned, source)
+        t |> success(!same_string_storage(cloned, source))
+    }
+}
+
+[test]
+def test_string_clone_global_init_multiple_contexts(t : T?) {
+    t |> run("string := global initialization clones with multiple_contexts") @(t : T?) {
+        t |> equal(global_clone, global_source)
+        t |> success(!same_string_storage(global_clone, global_source))
+    }
+}

--- a/tests/language/string_clone_init_temporary.das
+++ b/tests/language/string_clone_init_temporary.das
@@ -1,0 +1,21 @@
+options gen2
+
+require UnitTest
+require dastest/testing_boost public
+require _string_clone_init_helper
+
+def borrow_string(src : string) : string# {
+    unsafe {
+        return reinterpret<string#>(src)
+    }
+}
+
+[test]
+def test_temporary_string_clone_initialization(t : T?) {
+    t |> run("string# := initialization retains a cloned string") @(t : T?) {
+        let source = get_das_root()
+        let retained := borrow_string(source)
+        t |> equal(retained, source)
+        t |> success(!same_string_storage(retained, source))
+    }
+}

--- a/utils/lint/tests/lint016_multiple_contexts.das
+++ b/utils/lint/tests/lint016_multiple_contexts.das
@@ -1,0 +1,23 @@
+options gen2
+options auto_inline_functions = false
+options multiple_contexts
+
+// LINT016 stays silent here: multiple_contexts makes := and push_clone perform
+// the string clone that their spelling promises.
+
+require daslib/lint
+
+var global_clone := "global"
+
+def clone_for_context(var dst : string; var arr : array<string>; src : string) {
+    var local := src
+    dst := src
+    print(local)
+    local = dst
+    arr |> push_clone(src)
+    print(local)
+}
+
+[export]
+def main() {
+}

--- a/utils/lint/tests/lint016_redundant_string_clone.das
+++ b/utils/lint/tests/lint016_redundant_string_clone.das
@@ -1,0 +1,90 @@
+options gen2
+options auto_inline_functions = false   // lint fixtures assert source call/assignment shapes
+
+// LINT016: string clone syntax is a pointer copy unless multiple_contexts is enabled.
+// Use ordinary copy/push for same-context storage, and clone_string explicitly when
+// a string crosses contexts. Temporary string# sources are the lifetime-safe exception.
+
+expect 50503:11
+
+var bad_global := "global"                       // LINT016
+
+require daslib/lint
+
+def bad_assign(var dst : string; src : string) {
+    dst := src                                      // LINT016
+}
+
+def bad_redundant_assign_wrapper(var dst : string; src : string) {
+    dst := clone_string(src)                        // LINT016
+}
+
+def bad_local_init(src : string) {
+    var dst := src                                  // LINT016
+    print(dst)
+}
+
+def bad_redundant_init_wrapper(src : string) {
+    var dst := clone_string(src)                    // LINT016
+    print(dst)
+}
+
+def bad_pipe_push(var dst : array<string>; src : string) {
+    dst |> push_clone(src)                          // LINT016
+}
+
+def bad_dot_push(var dst : array<string>; src : string) {
+    dst.push_clone(src)                             // LINT016
+}
+
+def bad_plain_push(var dst : array<string>; src : string) {
+    push_clone(dst, src)                            // LINT016
+}
+
+def bad_indexed_push(var dst : array<string>; src : string) {
+    dst |> push_clone(src, 0)                       // LINT016
+}
+
+def bad_redundant_wrapper(var dst : array<string>; src : string) {
+    dst |> push_clone(clone_string(src))            // LINT016
+}
+
+def good_same_context(var dst : string; var arr : array<string>; src : string) {
+    dst = src
+    arr |> push(src)
+}
+
+def good_cross_context(var dst : string; var arr : array<string>; src : string) {
+    dst = clone_string(src)
+    arr |> push(clone_string(src))
+}
+
+def borrow_string(src : string) : string# {
+    unsafe {
+        return reinterpret<string#>(src)
+    }
+}
+
+def bad_redundant_temp_init_wrapper(src : string) {
+    let dst := clone_string(borrow_string(src))     // LINT016
+    print(dst)
+}
+
+def good_temporary(var dst : string; var arr : array<string>; src : string) {
+    let retained := borrow_string(src)
+    dst := borrow_string(src)
+    arr |> push_clone(borrow_string(src))
+    print(retained)
+}
+
+def good_non_string(var dst : array<int>; value : int) {
+    dst |> push_clone(value)
+}
+
+def generic_clone(var dst : auto(T); src : T) {
+    dst := src
+}
+
+def good_generic_instance(var dst : string; src : string) {
+    generic_clone(dst, src)
+}


### PR DESCRIPTION
## Summary
- add LINT016 for ineffective ordinary-string `:=` and `push_clone` syntax in single-context code
- make local/global string clone initialization honor `multiple_contexts` and retain `string#` temporaries safely
- sweep daslib same-context clone spellings and document the behavior

## Testing
- full preflight: format, lint, dasgen, CI das compile sweep, docs, C++ tests, interpreter, JIT
- full AOT target and sequence runtime modules built successfully from a plain shell
- language: 1442/1442
- lint fixtures: 51/51
- daslib lint: 142 files, 0 warnings
- LINQ: 2007/2007; SQLite: 908/908; DECS: 245/245; FIO: 189 pass, 1 expected skip
- Sphinx `-W` latex/html

## Local environment skips
- clang syntax-only: clang-cl resource headers unavailable; covered by CI toolchains
- PDF compile: latexmk unavailable
- hosted AOT/sequence execution: Windows DLL host pins Release runtime; their native targets were prebuilt successfully outside the host