### PR TITLE
dasllama-server: JIT-only deploy (jobque from config, JIT guard, daspkg refuses -exe)

### DIFF
--- a/daslib/daspkg.das
+++ b/daslib/daspkg.das
@@ -143,6 +143,7 @@ struct ReleaseSpec {
     web_shell : string                  //!< optional emcc `--shell-file` HTML for `release wasm`; empty = daslang's minimal canvas shell
     wasm_build_command : string         //!< shell command that builds this EXTERNAL module's wasm archives (run with cwd = module dir); empty = in-tree module built by `daspkg build --wasm`
     wasm_archives : array<string>       //!< archives (relative to module dir) produced by wasm_build_command, staged into the release wasm lib dir
+    requires_jit : bool                 //!< app is JIT-only (per-box [tune]/[llvm_code] kernels); a baked -exe would run broken, so `daspkg release` refuses it
 }
 
 var _release_spec : ReleaseSpec
@@ -153,6 +154,13 @@ def release_name(name : string) {
 
 def release_main(script : string) {
     _release_spec.main_script = script
+}
+
+//! Mark the app JIT-only: its kernels are per-box JIT-compiled/tuned ([llvm_code]/[tune]) and a
+//! baked standalone -exe would run broken (or refuse to start). `daspkg release` then fails with
+//! a clear message instead of producing a dead binary. Such an app deploys as `daslang -jit <main>`.
+def release_requires_jit() {
+    _release_spec.requires_jit = true
 }
 
 //! Entry script for `daspkg release wasm` (the wasm64 build) when it differs from the native release_main() — e.g. a live_stub variant that drops the desktop live-reload stack (which can't cross-compile). Falls back to release_main() when unset.

--- a/utils/dasllama-server/.das_package
+++ b/utils/dasllama-server/.das_package
@@ -12,6 +12,9 @@ def package() {
 def release() {
     release_main("main.das")
     release_name("dasllama-server")
+    // JIT-only: per-box [tune]/[llvm_code] kernels + a shared-module [init] global (the vulkan
+    // GPU-tier arm probe) that a baked -exe mis-wires. daspkg release refuses; deploy via -jit.
+    release_requires_jit()
     release_include("watchdog.py")
-    release_include("control.html")   // the control page — SERVE_FILE reads it from <exe_dir> at runtime
+    release_include("control.html")
 }

--- a/utils/dasllama-server/deploy-jit.ps1
+++ b/utils/dasllama-server/deploy-jit.ps1
@@ -1,0 +1,71 @@
+# Deploy dasllama-server as a self-contained JIT bundle.
+#
+# dasllama-server is JIT-only (per-box [tune]/[llvm_code] kernels), so it cannot be a baked
+# daspkg -exe — it needs the live daslang toolchain to JIT-compile + lld-link its kernels at
+# startup. This mirrors the minimal SDK layout the JIT expects (daslang under bin/Release,
+# lld-link under bin/, the runtime import libs under lib/Release, LLVM.dll under lib/) plus the
+# daslib/modules the server requires and the server sources. Launched from the bundle root,
+# getDasRoot() resolves to the bundle (daslang lives in bin/Release), so daslib/modules/lib/bin
+# all resolve.
+#
+# Run:  powershell -File utils/dasllama-server/deploy-jit.ps1 [-Dest E:\dasllama-server]
+# Then, from the bundle:  python watchdog.py    (finds bin/Release/daslang.exe, runs -jit main.das)
+#
+# The config (dasllama-server.toml) is PRESERVED if it already exists.
+
+param(
+    [string]$Dest = "E:\dasllama-server"
+)
+
+$ErrorActionPreference = "Stop"
+$Repo = (Resolve-Path "$PSScriptRoot\..\..").Path
+$rc = @("/MIR","/NFL","/NDL","/NJH","/NJS","/NP")   # mirror + quiet
+
+Write-Host "deploy-jit: repo=$Repo -> dest=$Dest"
+New-Item -ItemType Directory -Force -Path $Dest | Out-Null
+
+# 1. bin/: the JIT toolchain. daslang + its runtime/LLVM DLLs under bin/Release (so getDasRoot()
+#    resolves the bundle root), the linker set (lld-link/lld/llvm-lib) under bin/.
+robocopy (Join-Path $Repo "bin\Release") (Join-Path $Dest "bin\Release") *.exe *.dll @rc | Out-Null
+foreach ($t in @("lld-link.exe","lld.exe","llvm-lib.exe")) {
+    $src = Join-Path $Repo "bin\$t"
+    if (Test-Path $src) { New-Item -ItemType Directory -Force -Path (Join-Path $Dest "bin") | Out-Null; Copy-Item $src (Join-Path $Dest "bin") -Force }
+}
+
+# 2. lib/: LLVM.dll (dasLLVM binding target) + the runtime import libs the JIT links kernels against.
+New-Item -ItemType Directory -Force -Path (Join-Path $Dest "lib") | Out-Null
+Copy-Item (Join-Path $Repo "lib\LLVM.dll") (Join-Path $Dest "lib") -Force
+robocopy (Join-Path $Repo "lib\Release") (Join-Path $Dest "lib\Release") libDaScriptDyn.lib libDaScriptDyn_runtime.lib @rc | Out-Null
+
+# 3. daslib (whole) + the module dirs in the server's require closure.
+robocopy (Join-Path $Repo "daslib") (Join-Path $Dest "daslib") @rc | Out-Null
+foreach ($m in @("dasLLAMA","dasLLVM","dasVulkan","dasHV","dasSpirv","dasAudio","dasLiveHost","dasTreeSitter")) {
+    robocopy (Join-Path $Repo "modules\$m") (Join-Path $Dest "modules\$m") @rc | Out-Null
+}
+
+# 4. server sources + control page + watchdog at the bundle root (main.das's require siblings
+#    live beside it; SERVE_FILE reads control.html from the main.das dir).
+foreach ($f in @("main.das","openai_server.das","llm_scheduler.das","ask.das","wav2txt.das","control.html","watchdog.py",".das_package")) {
+    Copy-Item (Join-Path $PSScriptRoot $f) $Dest -Force
+}
+# ship the box tune sidecar (main.das's app sidecar) so first launch runs the tuned kernels
+# instead of re-tuning (which would exit 3 restart-loop under the watchdog).
+$tune = Join-Path $PSScriptRoot "main.tune.json"
+if (Test-Path $tune) { Copy-Item $tune (Join-Path $Dest "main.tune.json") -Force }
+
+# 5. config: ship a default only when none exists; never clobber a deployed one.
+$cfg = Join-Path $Dest "dasllama-server.toml"
+if (-not (Test-Path $cfg)) {
+    Copy-Item (Join-Path $PSScriptRoot "dasllama-server.toml") $cfg -Force
+    Write-Host "deploy-jit: shipped default dasllama-server.toml"
+} else {
+    Write-Host "deploy-jit: preserved existing dasllama-server.toml"
+}
+
+# 6. remove any dead baked exe from a prior daspkg release (it would refuse to start now).
+foreach ($stale in @("dasllama-server.exe","dasllama-server.lib","dasllama-server.map","dasllama-server.tune.json")) {
+    $p = Join-Path $Dest $stale
+    if (Test-Path $p) { Remove-Item $p -Force }
+}
+
+Write-Host "deploy-jit: done. Launch from $Dest with:  python watchdog.py"

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -470,8 +470,11 @@ def parse_args() {
     g_args_parsed = true
     g_args_ready = false
     g_exit_code = 0
-    if (!jit_enabled() && !is_standalone_exe()) {
-        to_log(LOG_ERROR, "dasllama-server: run under the JIT — bin/daslang -jit utils/dasllama-server/main.das -- ...\n")
+    // JIT is mandatory: the kernels are per-box JIT-tuned [llvm_code], the tune framework needs
+    // a live JIT, and a baked standalone -exe additionally mis-wires shared-module [init] globals
+    // (the vulkan GPU-tier arm probe bakes null -> crash). There is no correct non-JIT path here.
+    if (!jit_enabled()) {
+        to_log(LOG_ERROR, "dasllama-server requires the JIT — run: daslang -jit main.das -- ... (a baked -exe is unsupported)\n")
         g_exit_code = 1
         request_exit()
         return
@@ -612,9 +615,16 @@ def init() {
     let team_dispatch = dispatch_mode != "inline"
     let asr_team_dispatch = dispatch_mode == "team"
     // matmul dispatch lane cap: LLM decode saturates memory bandwidth long before big core
-    // counts, and an uncapped dispatch fights every other process on the box. -1 = all cores.
+    // counts, and an uncapped dispatch fights every other process on the box. A negative config
+    // value maps to 0 here, which set_dispatch_worker_limit reads as "no limit" = all cores.
     let threads = g_cfg.threads > 0 ? g_cfg.threads : (g_cfg.threads < 0 ? 0 : 16)
     set_dispatch_worker_limit(threads)
+    // Cap the jobque WORKER count at construction from the config (total lanes = workers + the
+    // computing main, so `threads` lanes -> threads-1 workers, floored at 1 worker). Without this
+    // the queue spawns cores-1 workers on a big box and parks the surplus — which is why
+    // DAS_JOBQUE_THREADS used to be mandatory. Must land before the jobque exists, same as affinity
+    // below; the env still overrides. threads<=0 means "all cores" -> cap 0 (off, the stock default).
+    set_jobque_threads_cap(threads > 0 ? max(1, threads - 1) : 0)
     // worker CPU affinity — must land before the jobque exists (applied at worker spawn)
     set_jobque_affinity(g_cfg.affinity)
     let lanes_desc = threads > 0 ? "{threads}" : "all"

--- a/utils/dasllama-server/watchdog.py
+++ b/utils/dasllama-server/watchdog.py
@@ -44,17 +44,22 @@ WER_LOCAL_DUMPS = r"SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDump
 
 
 def find_daslang() -> Path:
-    names = (
+    # dasllama-server is JIT-only (per-box [tune]/[llvm_code] kernels), so the watchdog always
+    # runs `daslang -jit main.das`, never a baked exe. Prefer a daslang inside a deployed JIT
+    # bundle (bin/Release beside this script — the layout getDasRoot() resolves the bundle from),
+    # then the source-repo build tree, then bare name on PATH.
+    rel = (
         "bin/Release/daslang.exe",
         "bin/daslang.exe",
         "bin/Release/daslang",
         "bin/daslang",
         "build/daslang",
     )
-    for name in names:
-        candidate = SOURCE_REPO_ROOT / name
-        if candidate.is_file():
-            return candidate
+    for root in (SCRIPT_DIR, SOURCE_REPO_ROOT):
+        for name in rel:
+            candidate = root / name
+            if candidate.is_file():
+                return candidate
     return Path("daslang.exe" if IS_WINDOWS else "daslang")
 
 

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -965,7 +965,7 @@ def cmd_update_all(root : string; is_global : bool = false) {
     var names : array<string>
     names |> reserve(length(lf.packages))
     for (entry in lf.packages) {
-        names |> push_clone(entry.name)
+        names |> push(entry.name)
     }
     var rc = 0
     for (name in names) {
@@ -1530,7 +1530,7 @@ def private ship_dep_assets(pkg_dir, bundle_modules_dir : string; var shipped : 
     var dep_files : array<string>
     glob_filtered(pkg_dir, dep_spec.include_globs, dep_spec.exclude_globs) $(rel_path, is_dir) {
         if (!is_dir) {
-            dep_files |> push_clone(rel_path)
+            dep_files |> push(rel_path)
         }
     }
     shipped |> reserve(length(shipped) + length(dep_files))
@@ -1551,7 +1551,7 @@ def private ship_dep_assets(pkg_dir, bundle_modules_dir : string; var shipped : 
     var dep_starter_files : array<string>
     glob_filtered(pkg_dir, dep_spec.include_if_missing_globs, dep_spec.exclude_globs) $(rel_path, is_dir) {
         if (!is_dir) {
-            dep_starter_files |> push_clone(rel_path)
+            dep_starter_files |> push(rel_path)
         }
     }
     var dep_starter_copies = 0
@@ -1664,7 +1664,7 @@ def list_lc_rpaths(path : string) : array<string> {
             let after = slice(s, 5)
             let off = find(after, " (offset")
             let p = (off >= 0 ? slice(after, 0, off) : after)
-            rpaths |> push_clone(p)
+            rpaths |> push(p)
             in_rpath = false
         } elif (starts_with(s, "Load command ")) {
             in_rpath = false
@@ -1757,7 +1757,7 @@ def private scrub_external_rpaths(path : string) {
         let e = strip(entry)
         if (empty(e)) continue
         if (starts_with(e, "$ORIGIN")) {
-            kept |> push_clone(e)
+            kept |> push(e)
         }
     }
     var op_out : string
@@ -2017,6 +2017,13 @@ def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
         to_log(LOG_ERROR, "release: {das_package} has no release() hook, or release() didn't call release_main(<script.das>)\n")
         return 1
     }
+    if (spec.requires_jit) {
+        // release_requires_jit(): a baked -exe drops the per-box JIT kernels/tune (and can
+        // mis-wire shared-module [init] globals), so it would ship a broken binary. Deploy the
+        // app as `daslang -jit {spec.main_script}` instead.
+        to_log(LOG_ERROR, "release: {das_package} declares release_requires_jit() — this app is JIT-only and cannot be baked into a standalone -exe. Deploy it as: daslang -jit {spec.main_script}\n")
+        return 1
+    }
 
     // Pick bundle name: explicit release_name() > package_name() > root dir name.
     var pkg : PackageMeta
@@ -2046,7 +2053,7 @@ def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
     var preserve_project_files : array<string>
     glob_filtered(root, spec.include_if_missing_globs, spec.exclude_globs) $(rel_path, is_dir) {
         if (!is_dir) {
-            preserve_project_files |> push_clone(rel_path)
+            preserve_project_files |> push(rel_path)
         }
     }
     // The macOS .app is wholly daspkg-owned: full wipe. A flat bundle dir is NOT — it
@@ -2186,7 +2193,7 @@ def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
         }
         log("  ship: {e.rel}\n")
         finalize_shipped_binary(e.abs, dst, shipped, e.rel)
-        shipped |> push_clone(e.rel)
+        shipped |> push(e.rel)
     }
 
     // 2.5 Ship daslang runtime dylibs next to the exe. Without these the bundle
@@ -2275,7 +2282,7 @@ def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
     var asset_files : array<string>
     glob_filtered(root, spec.include_globs, spec.exclude_globs) $(rel_path, is_dir) {
         if (!is_dir) {
-            asset_files |> push_clone(rel_path)
+            asset_files |> push(rel_path)
         }
     }
     shipped |> reserve(length(shipped) + length(asset_files))
@@ -2288,7 +2295,7 @@ def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
             to_log(LOG_ERROR, "release: copy_file({src} -> {dst}) failed: {err}\n")
             return 1
         }
-        shipped |> push_clone(rel_path)
+        shipped |> push(rel_path)
     }
     if (!empty(asset_files)) {
         log("  shipped {length(asset_files)} project asset file(s)\n")
@@ -2299,7 +2306,7 @@ def cmd_release(root : string; out_dir : string; tune_fast = false) : int {
     var starter_files : array<string>
     glob_filtered(root, spec.include_if_missing_globs, spec.exclude_globs) $(rel_path, is_dir) {
         if (!is_dir) {
-            starter_files |> push_clone(rel_path)
+            starter_files |> push(rel_path)
         }
     }
     var starter_copies = 0
@@ -2599,7 +2606,7 @@ def private release_one_wasm_app(root, out_dir, app_name, main_script : string;
     var asset_files : array<string>
     glob_filtered(root, include_globs, exclude_globs) $(rel_path, is_dir) {
         if (!is_dir) {
-            asset_files |> push_clone(rel_path)
+            asset_files |> push(rel_path)
         }
     }
     for (rel_path in asset_files) {

--- a/utils/daspkg/package_runner.das
+++ b/utils/daspkg/package_runner.das
@@ -45,6 +45,7 @@ struct PackageReleaseInfo {
     web_shell : string
     wasm_build_command : string
     wasm_archives : array<string>
+    requires_jit : bool
 }
 
 
@@ -62,7 +63,7 @@ def run_das_package_meta(das_package_path : string; var meta : PackageMeta) : bo
             meta.license = clone_string(src.license)
             meta.min_sdk = clone_string(src.min_sdk)
             for (t in src.tags) {
-                meta.tags |> push_clone(clone_string(t))
+                meta.tags |> push(clone_string(t))
             }
         }
     }
@@ -121,32 +122,33 @@ def run_das_package_release(das_package_path : string; var info : PackageRelease
             info.main_script = clone_string(src.main_script)
             info.wasm_main_script = clone_string(src.wasm_main_script)
             for (g in src.include_globs) {
-                info.include_globs |> push_clone(clone_string(g))
+                info.include_globs |> push(clone_string(g))
             }
             for (g in src.include_if_missing_globs) {
-                info.include_if_missing_globs |> push_clone(clone_string(g))
+                info.include_if_missing_globs |> push(clone_string(g))
             }
             for (g in src.exclude_globs) {
-                info.exclude_globs |> push_clone(clone_string(g))
+                info.exclude_globs |> push(clone_string(g))
             }
             for (m in src.forced_modules) {
-                info.forced_modules |> push_clone(clone_string(m))
+                info.forced_modules |> push(clone_string(m))
             }
             for (d in src.native_dlls) {
-                info.native_dlls |> push_clone(clone_string(d))
+                info.native_dlls |> push(clone_string(d))
             }
             info.bundle_id = clone_string(src.bundle_id)
             for (a in src.emcc_args) {
-                info.emcc_args |> push_clone(clone_string(a))
+                info.emcc_args |> push(clone_string(a))
             }
             for (e in src.embed_paths) {
-                info.embed_paths |> push_clone(clone_string(e))
+                info.embed_paths |> push(clone_string(e))
             }
             info.web_shell = clone_string(src.web_shell)
             info.wasm_build_command = clone_string(src.wasm_build_command)
             for (a in src.wasm_archives) {
-                info.wasm_archives |> push_clone(clone_string(a))
+                info.wasm_archives |> push(clone_string(a))
             }
+            info.requires_jit = src.requires_jit
         }
     }
     return ok


### PR DESCRIPTION
dasllama-server is a **JIT-only** app — its kernels are per-box JIT-compiled/tuned (`[llvm_code]`/`[tune]`), and a baked standalone `-exe` additionally mis-wires shared-module `[init]` globals (the vulkan GPU-tier arm probe bakes **null** and crashes on `gpu=vulkan`). So it must run as `daslang -jit main.das`, never a baked exe. This makes every layer enforce that, and lets the config (not an env var) size the jobque.

## Jobque worker count from the TOML, not `DAS_JOBQUE_THREADS`
The server read `threads` and set the dasLLAMA *dispatch* limit, but that only parks surplus workers **after** the jobque already spawned `cores-1` of them at construction — so `DAS_JOBQUE_THREADS` was effectively mandatory to stop a 64-core box from spawning 63 workers.

`init()` now also calls `set_jobque_threads_cap(threads - 1)` from the config, beside the existing `set_jobque_affinity()` — same "must land before the jobque exists" timing (the queue is first created at `load_model`'s `with_job_que`, after `init()`; the JIT codegen path has no `with_job_que`). `threads` is *total lanes*, so the worker cap is `threads - 1`. `threads == 0` ("all cores") → cap 0 = the stock `cores-1` default. `DAS_JOBQUE_THREADS` reverts to a pure override.

**Verified:** `threads = 16` with **no env** spawns **17 OS threads** (15 workers + main + overhead), not ~66.

## JIT-required guard
`parse_args()` now rejects any non-JIT start (baked `-exe` included) with a clear message, replacing the previous `is_standalone_exe()` escape hatch. There is no correct non-JIT path — the old escape let a baked exe through, and that exe crashes on the null GPU-arm probe.

## Watchdog runs `daslang -jit`
`find_daslang()` prefers a `daslang` beside `watchdog.py` (a deployed JIT bundle), then the source-repo build tree — no baked-exe path. `python watchdog.py` runs `daslang -jit main.das`.

## daspkg refuses to bake a JIT-only app
New `release_requires_jit()` hook (`daslib/daspkg`) + `ReleaseSpec`/`PackageReleaseInfo` field; `cmd_release` fails early with *"JIT-only … deploy as daslang -jit <main>"* instead of shipping a broken binary. dasllama-server's `.das_package` declares it.

**Verified:** `daspkg release --root utils/dasllama-server` now exits 1 with the guard message, no exe built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
