### PR TITLE
Fix terminal app compatibility lint

### DIFF
--- a/modules/dasTerminal/tests/app_compat.das
+++ b/modules/dasTerminal/tests/app_compat.das
@@ -143,9 +143,7 @@ def assert_checkpoint(var terminal : Terminal; expected : CompatExpectedCheckpoi
     terminal_drain_replies_bytes(terminal, reply_chunks)
     var replies : array<uint8>
     for (chunk in reply_chunks) {
-        for (byte in chunk) {
-            replies |> push(byte)
-        }
+        replies |> push_from(chunk)
     }
     check(length(replies) == length(expected.replies),
         "{context}: reply byte count {length(replies)}, expected {length(expected.replies)}")


### PR DESCRIPTION
Fix the changed-file lint failure discovered after #3514 merged by flattening terminal reply chunks with the array-native push_from operation.

Local verification:
- daslang utils/lint/main.das -- modules/dasTerminal/tests/app_compat.das --quiet
- daslang modules/dasTerminal/tests/app_compat.das