### PR TITLE
dasLLAMA Metal Wave D: Gated-DeltaNet hybrids whole-graph on GPU (qwen35/qwen35moe + qwen2moe)

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2157,11 +2157,20 @@ def private metal_blob_layout_ok(t : Model) : bool {
     let has_ffn = int64(length(t.w1_offs)) >= c.n_layers
     let has_exps = (c.moe && int64(length(t.we1_offs)) >= c.n_layers &&
         int64(length(t.we2_offs)) >= c.n_layers && int64(length(t.we3_offs)) >= c.n_layers)
+    let has_dn = c.recr_mask != 0ul && int64(length(t.dnqkv_offs)) >= c.n_layers
     if (!has_ffn && !has_exps) {
         return false
     }
     for (l in range64(c.n_layers)) {
-        if (!metal_blob_off_ok(t.wq_offs[l], metal_blob_fmt_at(t.wq_fmt, l)) ||
+        // recurrent layers (Wave D): no attention tensors (offs -1, off_ok true), q8 dn planes instead
+        let dn_bad = (has_dn && layer_is_recurrent(c, l) &&
+            (!metal_blob_off_ok(t.dnqkv_offs[l], KqFmt.q8) ||
+             !metal_blob_off_ok(t.dngate_offs[l], KqFmt.q8) ||
+             !metal_blob_off_ok(t.dnbeta_offs[l], KqFmt.q8) ||
+             !metal_blob_off_ok(t.dnalpha_offs[l], KqFmt.q8) ||
+             !metal_blob_off_ok(t.dnout_offs[l], KqFmt.q8)))
+        if (dn_bad ||
+                !metal_blob_off_ok(t.wq_offs[l], metal_blob_fmt_at(t.wq_fmt, l)) ||
                 !metal_blob_off_ok(t.wk_offs[l], metal_blob_fmt_at(t.wk_fmt, l)) ||
                 !metal_blob_off_ok(t.wv_offs[l], metal_blob_fmt_at(t.wv_fmt, l)) ||
                 !metal_blob_off_ok(t.wo_offs[l], metal_blob_fmt_at(t.wo_fmt, l)) ||

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2183,6 +2183,16 @@ def private metal_blob_layout_ok(t : Model) : bool {
             return false
         }
     }
+    // shexp planes: always q8, contiguous at base + l*she — base + stride covers every layer
+    if (c.n_ff_shexp > 0l) {
+        let she = c.dim * c.n_ff_shexp
+        if ((she % 256l) != 0l ||
+                !metal_blob_off_ok(t.wsh1_off, KqFmt.q8) ||
+                !metal_blob_off_ok(t.wsh2_off, KqFmt.q8) ||
+                !metal_blob_off_ok(t.wsh3_off, KqFmt.q8)) {
+            return false
+        }
+    }
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     return (metal_blob_off_ok(t.wcls_off, cls_fmt) &&
         (!t.cls_q8 || metal_blob_off_ok(t.emb_q8_off, KqFmt.q8)))

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -1426,6 +1426,7 @@ enum MetalPrefillDecline {
     device              // metal_prefill_init failed (no device / PSO build failure)
     gpu_error           // dispatch failed at execution time
     planar              // weights not in the blob-image form (the drivers are blob-only)
+    dn_state            // recurrent state not GPU-resident and no CPU prefix to sync from
 }
 
 var g_prefill_declines = 0l

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -63,6 +63,8 @@ enum MetalDecodeDecline {
     gpu_error           // dispatch failed at execution time
     planar              // weights not in the blob-image form (the drivers are blob-only —
                         // load_model under metal mode transforms/maps the metal flavor)
+    dn_state            // deltanet recurrent state not GPU-resident for this position (state is
+                        // forward-only and NOT re-derivable — no watermark repair exists)
 }
 
 //! Layer-stack features a model's graph needs beyond the base llama dense block — ONE derivation
@@ -929,6 +931,91 @@ def mirror_prepare(t : Model; var s : Session; pos : int64) : tuple<ok : bool; k
 }
 
 
+// ===== deltanet recurrent-state mirrors (Wave D) — per-session GPU S + conv state =====
+// Forward-only, NOT re-derivable: pos 0 zeroes, s.dn_pos == pos syncs from CPU, else decline;
+// own buffers (KV-arena rebuild re-uploads from CPU — impossible for state); layout == Session's.
+
+struct DnMirror {
+    uid : uint64
+    @do_not_delete buf : MetalBuffer?   // [state planes f32][conv planes f32]
+    conv_off : uint64                   // byte offset of the conv-history region
+    bytes : uint64
+    pos : int64                         // next position the GPU state expects (forward-only)
+    tick : int64
+}
+var g_dn_mirrors : table<uint64; DnMirror>
+let DN_MIRRORS_MAX = 4      // per-session state is big (35B: ~60MB) — oldest evicts; a returning
+                            // evicted session declines unless it restarts at pos 0 or off CPU state
+
+def dn_mirror_release(mr : DnMirror) {
+    if (mr.buf != null) {
+        metal_release(mr.buf)
+    }
+}
+
+def dn_mirror_prepare(var s : Session; pos : int64) : tuple<ok : bool; buf : MetalBuffer?; conv_off : uint64> {
+    let sbytes = uint64(length(s.dn_state)) * 4ul
+    let cbytes = uint64(length(s.dn_conv_state)) * 4ul
+    if (sbytes == 0ul) {
+        return (ok = false, buf = null, conv_off = 0ul)
+    }
+    if (key_exists(g_dn_mirrors, s.uid) && g_dn_mirrors[s.uid].bytes != sbytes + cbytes) {
+        dn_mirror_release(g_dn_mirrors[s.uid])
+        g_dn_mirrors |> erase(s.uid)
+    }
+    let have = key_exists(g_dn_mirrors, s.uid)
+    let cpu_prefix = s.dn_pos == pos
+    if (!have && pos != 0l && !cpu_prefix) {
+        return (ok = false, buf = null, conv_off = 0ul)
+    }
+    if (!have) {
+        while (length(g_dn_mirrors) >= DN_MIRRORS_MAX) {
+            var victim = 0ul
+            var vtick = 0l
+            for (uid, mr in keys(g_dn_mirrors), values(g_dn_mirrors)) {
+                if (victim == 0ul || mr.tick < vtick) {
+                    victim = uid
+                    vtick = mr.tick
+                }
+            }
+            dn_mirror_release(g_dn_mirrors[victim])
+            g_dn_mirrors |> erase(victim)
+        }
+        g_dn_mirrors[s.uid] = DnMirror(uid = s.uid, buf = metal_new_buffer(g_dev, sbytes + cbytes),
+            conv_off = sbytes, bytes = sbytes + cbytes, pos = -1l)
+    }
+    if (pos == 0l) {
+        // fresh conversation: zero both regions (dn_reset's GPU half). Safe on unified memory —
+        // no step of this session is in flight at pos 0 (spec is clipped for recurrent models)
+        unsafe {
+            memset8(metal_buffer_contents(g_dn_mirrors[s.uid].buf), uint8(0), int(sbytes + cbytes))
+        }
+        g_dn_mirrors[s.uid].pos = 0l
+    } elif (g_dn_mirrors[s.uid].pos != pos) {
+        if (!cpu_prefix) {
+            return (ok = false, buf = null, conv_off = 0ul)
+        }
+        // the CPU ran positions [0, pos) — its state is the source of truth; sync it up
+        unsafe {
+            var dst = reinterpret<uint8?>(metal_buffer_contents(g_dn_mirrors[s.uid].buf))
+            memcpy(reinterpret<void?>(dst), addr<void?>(s.dn_state[0]), int(sbytes))
+            memcpy(reinterpret<void?>(dst + sbytes), addr<void?>(s.dn_conv_state[0]), int(cbytes))
+        }
+        g_dn_mirrors[s.uid].pos = pos
+    }
+    g_tick++
+    g_dn_mirrors[s.uid].tick = g_tick
+    let mr = g_dn_mirrors[s.uid]   // cheap copy — one lookup per statement (table re-hash safety)
+    return (ok = true, buf = mr.buf, conv_off = mr.conv_off)
+}
+
+// the step served and its command buffer completed — the GPU state now holds position pos's update
+def dn_mirror_advance(uid : uint64; pos : int64) {
+    if (key_exists(g_dn_mirrors, uid)) {
+        g_dn_mirrors[uid].pos = pos + 1l
+    }
+}
+
 def signs_buffer() : MetalBuffer? {
     if (g_signs == null) {
         var signs : array<float>
@@ -1264,6 +1351,12 @@ def metal_common_release {
     }
     unsafe {
         delete g_mirrors
+    }
+    for (dmr in values(g_dn_mirrors)) {
+        dn_mirror_release(dmr)
+    }
+    unsafe {
+        delete g_dn_mirrors
     }
     g_mirror_bytes = 0ul
     if (g_arena != null) {

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -931,6 +931,13 @@ def mirror_prepare(t : Model; var s : Session; pos : int64) : tuple<ok : bool; k
 }
 
 
+// Wave D serve gate for the deltanet kernel set: fixed d_state 128 (the scan/l2/gate lane math
+// bakes 32 lanes x 4), conv taps <= 8 (hist registers), q8 β/α planes (f32-on-disk = stage 3).
+def dn_metal_ok(t : Model) : bool {
+    let c = t.config
+    return c.ssm_d_state == 128l && c.ssm_d_conv >= 2l && c.ssm_d_conv <= 8l && !t.dn_ba_f32
+}
+
 // ===== deltanet recurrent-state mirrors (Wave D) — per-session GPU S + conv state =====
 // Forward-only, NOT re-derivable: pos 0 zeroes, s.dn_pos == pos syncs from CPU, else decline;
 // own buffers (KV-arena rebuild re-uploads from CPU — impossible for state); layout == Session's.

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -932,10 +932,11 @@ def mirror_prepare(t : Model; var s : Session; pos : int64) : tuple<ok : bool; k
 
 
 // Wave D serve gate for the deltanet kernel set: fixed d_state 128 (the scan/l2/gate lane math
-// bakes 32 lanes x 4), conv taps <= 8 (hist registers), q8 β/α planes (f32-on-disk = stage 3).
+// bakes 32 lanes x 4), conv taps <= 8 (hist registers). β/α projections: q8 planes ride the
+// site GEMVs; f32-on-disk (dn_ba_f32) rides the router-slab f32 GEMV off the fblob offsets.
 def dn_metal_ok(t : Model) : bool {
     let c = t.config
-    return c.ssm_d_state == 128l && c.ssm_d_conv >= 2l && c.ssm_d_conv <= 8l && !t.dn_ba_f32
+    return c.ssm_d_state == 128l && c.ssm_d_conv >= 2l && c.ssm_d_conv <= 8l
 }
 
 // ===== deltanet recurrent-state mirrors (Wave D) — per-session GPU S + conv state =====
@@ -1057,12 +1058,12 @@ def moe_site_ok(fmt : KqFmt; off, ege : int64) : bool {
     return false
 }
 
-// The MoE serve gate — the covered graph shapes (Wave C): the plain routed FFN (qwen3moe, silu,
-// no biases), gemma4's dense-shared + routed dual branch (gelu, router norm, down scales), and
-// gpt-oss's mx4 experts (softmax_weight, router/expert biases, disk-order). No shexp / dense-lead.
+// The MoE serve gate — covered graph shapes: plain routed FFN (qwen3moe, silu, no biases)
+// + optional sigmoid-gated shared expert (qwen35moe), gemma4's dense-shared dual branch, and
+// gpt-oss's mx4 experts (softmax_weight, biases, disk-order). No dense-lead / selection bias.
 def moe_metal_ok(t : Model) : bool {
     let c = t.config
-    if (!c.moe || c.n_ff_shexp > 0l || c.n_layer_dense_lead > 0l || c.moe_exp_probs ||
+    if (!c.moe || c.n_layer_dense_lead > 0l || c.moe_exp_probs ||
             (c.expert_weights_scale != 0.0 && c.expert_weights_scale != 1.0)) {
         return false
     }
@@ -1070,21 +1071,33 @@ def moe_metal_ok(t : Model) : bool {
         // gpt-oss: softmax_weight top-k on raw logits, router + per-expert biases, clamped
         // swiglu, disk-order mx4 stacks (the CPU laneq repack has no GPU carry)
         if (c.moe_gate != MoeGate.softmax_weight || c.ffn_act != FfnAct.swiglu_oai ||
-                !c.moe_router_bias || !c.moe_exps_bias || c.moe_dense_shexp || t.mx4_repacked ||
+                !c.moe_router_bias || !c.moe_exps_bias || c.moe_dense_shexp || c.n_ff_shexp > 0l ||
+                t.mx4_repacked ||
                 t.router_b_off < 0l || t.web1_off < 0l || t.web2_off < 0l || t.web3_off < 0l) {
             return false
         }
     } elif (c.moe_dense_shexp) {
         if (c.moe_gate != MoeGate.softmax || !c.norm_topk_prob ||
-                c.moe_router_bias || c.moe_exps_bias ||
+                c.moe_router_bias || c.moe_exps_bias || c.n_ff_shexp > 0l ||
                 c.ffn_act != FfnAct.gelu || t.moe_router_scale_off < 0l || t.moe_down_scale_off < 0l ||
                 t.rms_pre_ffn2_off < 0l || t.rms_post_ffn1_off < 0l || t.rms_post_ffn2_off < 0l ||
                 int64(length(t.w1_offs)) < c.n_layers) {
             return false
         }
-    } elif (c.moe_gate != MoeGate.softmax || !c.norm_topk_prob ||
+    } elif (c.moe_gate != MoeGate.softmax ||
             c.moe_router_bias || c.moe_exps_bias || c.ffn_act != FfnAct.silu) {
+        // norm_topk_prob both ways: renorm = select gmode 0 (qwen3moe/qwen35moe), no-renorm =
+        // gmode 2 (qwen2moe)
         return false
+    } elif (c.n_ff_shexp > 0l) {
+        // sigmoid-gated shared expert (qwen35moe): q8 wsh planes at base + l*she ride the
+        // dense site kernels — base + stride %256 (bind), nsh %64 (prefill C tiles)
+        let she = c.dim * c.n_ff_shexp
+        if (!c.moe_shexp_gated ||
+                (c.n_ff_shexp % 64l) != 0l || (she % 256l) != 0l ||
+                (t.wsh1_off % 256l) != 0l || (t.wsh2_off % 256l) != 0l || (t.wsh3_off % 256l) != 0l) {
+            return false
+        }
     }
     let ne = c.n_expert
     let k = c.n_expert_used

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -1012,7 +1012,7 @@ def dn_mirror_prepare(var s : Session; pos : int64) : tuple<ok : bool; buf : Met
     }
     g_tick++
     g_dn_mirrors[s.uid].tick = g_tick
-    let mr = g_dn_mirrors[s.uid]   // cheap copy — one lookup per statement (table re-hash safety)
+    var mr = g_dn_mirrors[s.uid]   // cheap copy — one lookup per statement (table re-hash safety)
     return (ok = true, buf = mr.buf, conv_off = mr.conv_off)
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -5707,6 +5707,7 @@ var g_pso_dn_scan : MetalComputePipeline?      // the fused sequential delta rul
 var g_pso_dn_gate : MetalComputePipeline?      // z-gated out-norm
 var g_pso_dn_deint : MetalComputePipeline?     // 2x-wide [q|gate] deinterleave
 var g_pso_sigmul : MetalComputePipeline?       // x ⊙ σ(g) — the gated-attention out-gate
+var g_pso_axpy_sig : MetalComputePipeline?     // y += x ⊙ σ(g[row]) — the shexp combine (stage 3)
 var g_pso_qkvrs16 : MetalComputePipeline?   // fused QKV+rope+store (s16 path)
 var g_pso_qkvrs32 : MetalComputePipeline?
 var g_pso_w13sw : MetalComputePipeline?
@@ -5840,6 +5841,7 @@ def metal_decode_init : bool {
     g_pso_dn_gate = compile_pso(metal_dn_gate_msl, metal_dn_gate_msl_entry, metal_dn_gate_msl_fastmath, ok)
     g_pso_dn_deint = compile_pso(metal_dn_deint_msl, metal_dn_deint_msl_entry, metal_dn_deint_msl_fastmath, ok)
     g_pso_sigmul = compile_pso(metal_sigmul_msl, metal_sigmul_msl_entry, metal_sigmul_msl_fastmath, ok)
+    g_pso_axpy_sig = compile_pso(metal_axpy_sig_msl, metal_axpy_sig_msl_entry, metal_axpy_sig_msl_fastmath, ok)
     g_e8m0_tab = metal_new_buffer(g_dev, 1024ul)
     unsafe {
         var ep = reinterpret<uint?>(metal_buffer_contents(g_e8m0_tab))
@@ -6276,7 +6278,7 @@ def enc_moe_router(enc : MetalComputeEncoder?; bw, bx, by, bn, bd, bxs, brb, bha
 }
 
 // the selection buffer binds twice (uint idx + float w views, both at 0); one tg per stream
-// row; bgm = gating mode (0 = softmax + norm_topk, 1 = gpt-oss softmax_weight)
+// row; bgm = gating mode (0 = softmax + norm_topk, 1 = gpt-oss softmax_weight, 2 = softmax no-renorm)
 def enc_moe_select(enc : MetalComputeEncoder?; blg, bsel, bne, bnk, bgm : MetalBuffer?; nst : int64) {
     metal_set_pipeline(enc, g_pso_moe_select)
     metal_set_buffer(enc, blg, 0ul, 0)
@@ -6470,6 +6472,16 @@ def enc_moe_combine(enc : MetalComputeEncoder?; bdn, bsel, by, bdim, bnk : Metal
     metal_set_buffer(enc, bdim, 0ul, 3)
     metal_set_buffer(enc, bnk, 0ul, 4)
     metal_dispatch_threadgroups(enc, uint3(uint((dim + 255l) / 256l), uint(nst), 1u), uint3(256u, 1u, 1u))
+}
+
+def enc_axpy_sig(enc : MetalComputeEncoder?; by, bx, bg, btot, bdim : MetalBuffer?; total : int64) {
+    metal_set_pipeline(enc, g_pso_axpy_sig)
+    metal_set_buffer(enc, by, 0ul, 0)
+    metal_set_buffer(enc, bx, 0ul, 1)
+    metal_set_buffer(enc, bg, 0ul, 2)
+    metal_set_buffer(enc, btot, 0ul, 3)
+    metal_set_buffer(enc, bdim, 0ul, 4)
+    metal_dispatch_threadgroups(enc, uint3(uint((total + 255l) / 256l), 1u, 1u), uint3(256u, 1u, 1u))
 }
 
 // fused add + rms when dim fits the kernel's row slab, the unfused pair otherwise
@@ -7265,6 +7277,7 @@ def metal_kernels_release {
     release_pso(g_pso_dn_gate)
     release_pso(g_pso_dn_deint)
     release_pso(g_pso_sigmul)
+    release_pso(g_pso_axpy_sig)
     if (g_e8m0_tab != null) {
         metal_release(g_e8m0_tab)
         g_e8m0_tab = null

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -2027,6 +2027,7 @@ class MetalRopeStoreF16 {
     @uniform @binding = 10 neox : uint      // pair (j, j+half) instead of (2j, 2j+1); same table row j
     @ssbo @binding = 11 bias : array<float> // [qd | kvd | kvd] QKV bias (dummy-bound when has_bias == 0)
     @uniform @binding = 12 has_bias : uint
+    @uniform @binding = 13 rot : uint       // partial rotary width (qwen35: 64 of 256); == head_size for full
 
     [metal_kernel(name="metal_rope_store16_msl")]
     def metal_rope_store16 {
@@ -2037,12 +2038,15 @@ class MetalRopeStoreF16 {
         let isK = gid >= npairs_q
         let lgid = isK ? gid - npairs_q : gid
         let half = head_size / 2u
+        let halfr = rot / 2u
         let j = lgid % half
         let hbase = (lgid / half) * head_size
-        let i = neox != 0u ? hbase + j : hbase + 2u * j
-        let i2 = neox != 0u ? i + half : i + 1u
-        let fcr = tcos[j]
-        let fci = tsin[j]
+        // threads j < rot/2 rotate the (j, j+rot/2) pair; the rest identity-cover [rot, hs)
+        let rotp = j < halfr
+        let i = neox != 0u ? (rotp ? hbase + j : hbase + rot + (j - halfr)) : hbase + 2u * j
+        let i2 = neox != 0u ? (rotp ? i + halfr : i + (half - halfr)) : i + 1u
+        let fcr = rotp ? tcos[j] : 1.0
+        let fci = rotp ? tsin[j] : 0.0
         let kvd = npairs * 2u - qd   // grid = (qd + kvd)/2 pairs
         if (isK) {
             let v0 = qk[qd + i] + (has_bias != 0u ? bias[qd + i] : 0.0)
@@ -2084,6 +2088,7 @@ class MetalRopeStoreHF16 {
     @uniform @binding = 13 has_bias : uint
     @uniform @binding = 14 has_norm : uint
     @uniform @binding = 15 eps : float
+    @uniform @binding = 16 rot : uint       // partial rotary width; == head_size for full
     @workgroup buf : float[512]     // <= max head_size (gemma4 global heads are 512)
     @workgroup part : float[16]
 
@@ -2092,7 +2097,6 @@ class MetalRopeStoreHF16 {
         let tgid = gl_WorkGroupID.x
         let lid = gl_LocalInvocationID.x
         let hs = head_size
-        let half = hs / 2u
         let nkvh = nheads / kv_mul
         let kvd = nkvh * hs
         let isQ = tgid < nheads
@@ -2117,14 +2121,17 @@ class MetalRopeStoreHF16 {
                 let inv = 1.0 / sqrt(total / float(hs) + eps)
                 v = w[(isK ? hs : 0u) + lid] * (v * inv)
             }
-            // rope via the tgmem-staged partner (the whole head is resident in this tg)
+            // rope via the tgmem-staged partner (the whole head is resident in this tg);
+            // partial rot: lanes >= rot pass through (identity coefficients, self partner)
             buf[lid] = v
             barrier()
-            let isHi = neox != 0u ? lid >= half : (lid & 1u) != 0u
-            let j = neox != 0u ? (isHi ? lid - half : lid) : lid / 2u
-            let fcr = tcos[j]
-            let fci = tsin[j]
-            let other = buf[neox != 0u ? (isHi ? lid - half : lid + half) : (lid ^ 1u)]
+            let halfr = rot / 2u
+            let inrot = lid < rot
+            let isHi = neox != 0u ? (lid >= halfr && inrot) : ((lid & 1u) != 0u && inrot)
+            let j = min(neox != 0u ? (isHi ? lid - halfr : lid) : lid / 2u, halfr - 1u)
+            let fcr = inrot ? tcos[j] : 1.0
+            let fci = inrot ? tsin[j] : 0.0
+            let other = buf[neox != 0u ? (isHi ? lid - halfr : (inrot ? lid + halfr : lid)) : (lid ^ 1u)]
             v = isHi ? other * fci + v * fcr : v * fcr - other * fci
         }
         if (isQ) {
@@ -2152,6 +2159,7 @@ class MetalRopeStoreF32 {
     @uniform @binding = 10 neox : uint
     @ssbo @binding = 11 bias : array<float>
     @uniform @binding = 12 has_bias : uint
+    @uniform @binding = 13 rot : uint       // partial rotary width; == head_size for full
 
     [metal_kernel(name="metal_rope_store32_msl")]
     def metal_rope_store32 {
@@ -2162,12 +2170,14 @@ class MetalRopeStoreF32 {
         let isK = gid >= npairs_q
         let lgid = isK ? gid - npairs_q : gid
         let half = head_size / 2u
+        let halfr = rot / 2u
         let j = lgid % half
         let hbase = (lgid / half) * head_size
-        let i = neox != 0u ? hbase + j : hbase + 2u * j
-        let i2 = neox != 0u ? i + half : i + 1u
-        let fcr = tcos[j]
-        let fci = tsin[j]
+        let rotp = j < halfr
+        let i = neox != 0u ? (rotp ? hbase + j : hbase + rot + (j - halfr)) : hbase + 2u * j
+        let i2 = neox != 0u ? (rotp ? i + halfr : i + (half - halfr)) : i + 1u
+        let fcr = rotp ? tcos[j] : 1.0
+        let fci = rotp ? tsin[j] : 0.0
         let kvd = npairs * 2u - qd
         if (isK) {
             let v0 = qk[qd + i] + (has_bias != 0u ? bias[qd + i] : 0.0)
@@ -6034,7 +6044,8 @@ def enc_rms(enc : MetalComputeEncoder?; bx, bw, by, bdim, beps : MetalBuffer?) {
 // fused rope + KV-row store: the v source binds the SAME QKV buffer at its v byte offset
 def enc_rope_store(enc : MetalComputeEncoder?; f16 : bool; bqkv : MetalBuffer?; vsoff : uint64;
                    kmb, vmb : MetalBuffer?; koff, voff : uint64;
-                   bcos, bsin, bqd, bhs, bnpq, bnpall, bneox, bbias, bhasb : MetalBuffer?; npairs : int64) {
+                   bcos, bsin, bqd, bhs, bnpq, bnpall, bneox, bbias, bhasb : MetalBuffer?; npairs : int64;
+                   brot : MetalBuffer? = null) {
     metal_set_pipeline(enc, f16 ? g_pso_rpst16 : g_pso_rpst32)
     metal_set_buffer(enc, bqkv, 0ul, 0)
     metal_set_buffer(enc, bqkv, vsoff, 1)
@@ -6049,6 +6060,7 @@ def enc_rope_store(enc : MetalComputeEncoder?; f16 : bool; bqkv : MetalBuffer?; 
     metal_set_buffer(enc, bneox, 0ul, 10)
     metal_set_buffer(enc, bbias, 0ul, 11)
     metal_set_buffer(enc, bhasb, 0ul, 12)
+    metal_set_buffer(enc, brot != null ? brot : bhs, 0ul, 13)   // rot defaults to head_size (full rope)
     metal_dispatch_threadgroups(enc, uint3(uint((npairs + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
 }
 
@@ -6057,7 +6069,7 @@ def enc_rope_store(enc : MetalComputeEncoder?; f16 : bool; bqkv : MetalBuffer?; 
 def enc_rope_store_h16(enc : MetalComputeEncoder?; bqkv : MetalBuffer?; vsoff : uint64;
                        kmb, vmb : MetalBuffer?; koff, voff : uint64;
                        bcos, bsin, bqkw, bbias, bqd, bhs, bnh, bkvm, bneox, bhasb, bhasn, beps : MetalBuffer?;
-                       ntg, head_size : int64) {
+                       ntg, head_size : int64; brot : MetalBuffer? = null) {
     metal_set_pipeline(enc, g_pso_rpst_h16)
     metal_set_threadgroup_memory_length(enc, metal_rope_store_h16_msl_tgmem, 0)
     metal_set_buffer(enc, bqkv, 0ul, 0)
@@ -6076,6 +6088,7 @@ def enc_rope_store_h16(enc : MetalComputeEncoder?; bqkv : MetalBuffer?; vsoff : 
     metal_set_buffer(enc, bhasb, 0ul, 13)
     metal_set_buffer(enc, bhasn, 0ul, 14)
     metal_set_buffer(enc, beps, 0ul, 15)
+    metal_set_buffer(enc, brot != null ? brot : bhs, 0ul, 16)   // rot defaults to head_size (full rope)
     metal_dispatch_threadgroups(enc, uint3(uint(ntg), 1u, 1u), uint3(uint(head_size), 1u, 1u))
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -5690,6 +5690,13 @@ var g_pso_moe_wscale : MetalComputePipeline?   // gemma4 per-expert down-scale f
 var g_pso_swiglu_oai : MetalComputePipeline?   // gpt-oss clamped swiglu (stage 4)
 var g_pso_moe_gemv_mx4 : MetalComputePipeline?  // gpt-oss MXFP4 expert GEMV
 var g_e8m0_tab : MetalBuffer?                   // [256] exact e8m0_half scales
+var g_pso_dn_conv : MetalComputePipeline?      // deltanet (Wave D): causal conv + SiLU
+var g_pso_dn_hist : MetalComputePipeline?      // conv-history advance
+var g_pso_dn_l2 : MetalComputePipeline?        // q/k per-head L2 norm + q pre-scale
+var g_pso_dn_scan : MetalComputePipeline?      // the fused sequential delta rule
+var g_pso_dn_gate : MetalComputePipeline?      // z-gated out-norm
+var g_pso_dn_deint : MetalComputePipeline?     // 2x-wide [q|gate] deinterleave
+var g_pso_sigmul : MetalComputePipeline?       // x ⊙ σ(g) — the gated-attention out-gate
 var g_pso_qkvrs16 : MetalComputePipeline?   // fused QKV+rope+store (s16 path)
 var g_pso_qkvrs32 : MetalComputePipeline?
 var g_pso_w13sw : MetalComputePipeline?
@@ -5816,6 +5823,13 @@ def metal_decode_init : bool {
     g_pso_moe_wscale = compile_pso(metal_moe_wscale_msl, metal_moe_wscale_msl_entry, metal_moe_wscale_msl_fastmath, ok)
     g_pso_swiglu_oai = compile_pso(metal_swiglu_oai_msl, metal_swiglu_oai_msl_entry, metal_swiglu_oai_msl_fastmath, ok)
     g_pso_moe_gemv_mx4 = compile_pso(metal_moe_gemv_mx4_msl, metal_moe_gemv_mx4_msl_entry, metal_moe_gemv_mx4_msl_fastmath, ok)
+    g_pso_dn_conv = compile_pso(metal_dn_conv_msl, metal_dn_conv_msl_entry, metal_dn_conv_msl_fastmath, ok)
+    g_pso_dn_hist = compile_pso(metal_dn_conv_hist_msl, metal_dn_conv_hist_msl_entry, metal_dn_conv_hist_msl_fastmath, ok)
+    g_pso_dn_l2 = compile_pso(metal_dn_l2norm_msl, metal_dn_l2norm_msl_entry, metal_dn_l2norm_msl_fastmath, ok)
+    g_pso_dn_scan = compile_pso(metal_dn_scan_msl, metal_dn_scan_msl_entry, metal_dn_scan_msl_fastmath, ok)
+    g_pso_dn_gate = compile_pso(metal_dn_gate_msl, metal_dn_gate_msl_entry, metal_dn_gate_msl_fastmath, ok)
+    g_pso_dn_deint = compile_pso(metal_dn_deint_msl, metal_dn_deint_msl_entry, metal_dn_deint_msl_fastmath, ok)
+    g_pso_sigmul = compile_pso(metal_sigmul_msl, metal_sigmul_msl_entry, metal_sigmul_msl_fastmath, ok)
     g_e8m0_tab = metal_new_buffer(g_dev, 1024ul)
     unsafe {
         var ep = reinterpret<uint?>(metal_buffer_contents(g_e8m0_tab))
@@ -6353,6 +6367,86 @@ def enc_moe_gemv_mx4(enc : MetalComputeEncoder?; t : Model; stack_off, rows, k, 
     metal_set_buffer(enc, bhasb, 0ul, 13)
     metal_set_buffer(enc, g_e8m0_tab, 0ul, 14)
     metal_dispatch_threadgroups(enc, uint3(uint((rows + g_gemv_rows - 1l) / g_gemv_rows), uint(k), uint(nst)), uint3(uint(g_gemv_rows * 32l), 1u, 1u))
+}
+
+// ===== deltanet (Wave D) — the recurrent-layer chain encoders =====
+// hist/state bind the per-session arena at the layer's byte offset; the rest are step scratch.
+
+def enc_dn_conv(enc : MetalComputeEncoder?; bx, bhist : MetalBuffer?; hoff : uint64;
+                bw, by, bcd, bdconv, bnp : MetalBuffer?; cd, npos : int64) {
+    metal_set_pipeline(enc, g_pso_dn_conv)
+    metal_set_buffer(enc, bx, 0ul, 0)
+    metal_set_buffer(enc, bhist, hoff, 1)
+    metal_set_buffer(enc, bw, 0ul, 2)
+    metal_set_buffer(enc, by, 0ul, 3)
+    metal_set_buffer(enc, bcd, 0ul, 4)
+    metal_set_buffer(enc, bdconv, 0ul, 5)
+    metal_set_buffer(enc, bnp, 0ul, 6)
+    metal_dispatch_threadgroups(enc, uint3(uint((cd + 255l) / 256l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def enc_dn_conv_hist(enc : MetalComputeEncoder?; bx, bhist : MetalBuffer?; hoff : uint64;
+                     bcd, bdconv, bnp : MetalBuffer?; cd : int64) {
+    metal_set_pipeline(enc, g_pso_dn_hist)
+    metal_set_buffer(enc, bx, 0ul, 0)
+    metal_set_buffer(enc, bhist, hoff, 1)
+    metal_set_buffer(enc, bcd, 0ul, 2)
+    metal_set_buffer(enc, bdconv, 0ul, 3)
+    metal_set_buffer(enc, bnp, 0ul, 4)
+    metal_dispatch_threadgroups(enc, uint3(uint((cd + 255l) / 256l), 1u, 1u), uint3(256u, 1u, 1u))
+}
+
+def enc_dn_l2norm(enc : MetalComputeEncoder?; by, bcd, bkd, bds, beps, bqscale : MetalBuffer?; nblk, npos : int64) {
+    metal_set_pipeline(enc, g_pso_dn_l2)
+    metal_set_buffer(enc, by, 0ul, 0)
+    metal_set_buffer(enc, bcd, 0ul, 1)
+    metal_set_buffer(enc, bkd, 0ul, 2)
+    metal_set_buffer(enc, bds, 0ul, 3)
+    metal_set_buffer(enc, beps, 0ul, 4)
+    metal_set_buffer(enc, bqscale, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((nblk + 7l) / 8l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def enc_dn_scan(enc : MetalComputeEncoder?; bcv, bst : MetalBuffer?; stoff : uint64;
+                bbraw, bgraw, baa, bdtb, bo, bcd, bkd, bds, bnvh, bnkh, bdi, bnp : MetalBuffer?; ds, nvh : int64) {
+    metal_set_pipeline(enc, g_pso_dn_scan)
+    metal_set_buffer(enc, bcv, 0ul, 0)
+    metal_set_buffer(enc, bst, stoff, 1)
+    metal_set_buffer(enc, bbraw, 0ul, 2)
+    metal_set_buffer(enc, bgraw, 0ul, 3)
+    metal_set_buffer(enc, baa, 0ul, 4)
+    metal_set_buffer(enc, bdtb, 0ul, 5)
+    metal_set_buffer(enc, bo, 0ul, 6)
+    metal_set_buffer(enc, bcd, 0ul, 7)
+    metal_set_buffer(enc, bkd, 0ul, 8)
+    metal_set_buffer(enc, bds, 0ul, 9)
+    metal_set_buffer(enc, bnvh, 0ul, 10)
+    metal_set_buffer(enc, bnkh, 0ul, 11)
+    metal_set_buffer(enc, bdi, 0ul, 12)
+    metal_set_buffer(enc, bnp, 0ul, 13)
+    metal_dispatch_threadgroups(enc, uint3(uint(ds / 4l), uint(nvh), 1u), uint3(128u, 1u, 1u))
+}
+
+def enc_dn_gate(enc : MetalComputeEncoder?; bo, bz, bwn, bds, bdi, beps : MetalBuffer?; nvh, npos : int64) {
+    metal_set_pipeline(enc, g_pso_dn_gate)
+    metal_set_buffer(enc, bo, 0ul, 0)
+    metal_set_buffer(enc, bz, 0ul, 1)
+    metal_set_buffer(enc, bwn, 0ul, 2)
+    metal_set_buffer(enc, bds, 0ul, 3)
+    metal_set_buffer(enc, bdi, 0ul, 4)
+    metal_set_buffer(enc, beps, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((nvh + 7l) / 8l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def enc_dn_deint(enc : MetalComputeEncoder?; bqg, bq, bgt, bhs, bqd, bqs : MetalBuffer?; qd, npos : int64) {
+    metal_set_pipeline(enc, g_pso_dn_deint)
+    metal_set_buffer(enc, bqg, 0ul, 0)
+    metal_set_buffer(enc, bq, 0ul, 1)
+    metal_set_buffer(enc, bgt, 0ul, 2)
+    metal_set_buffer(enc, bhs, 0ul, 3)
+    metal_set_buffer(enc, bqd, 0ul, 4)
+    metal_set_buffer(enc, bqs, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((qd + 255l) / 256l), uint(npos), 1u), uint3(256u, 1u, 1u))
 }
 
 def enc_moe_combine(enc : MetalComputeEncoder?; bdn, bsel, by, bdim, bnk : MetalBuffer?; dim, nst : int64) {
@@ -7151,6 +7245,13 @@ def metal_kernels_release {
     release_pso(g_pso_moe_wscale)
     release_pso(g_pso_swiglu_oai)
     release_pso(g_pso_moe_gemv_mx4)
+    release_pso(g_pso_dn_conv)
+    release_pso(g_pso_dn_hist)
+    release_pso(g_pso_dn_l2)
+    release_pso(g_pso_dn_scan)
+    release_pso(g_pso_dn_gate)
+    release_pso(g_pso_dn_deint)
+    release_pso(g_pso_sigmul)
     if (g_e8m0_tab != null) {
         metal_release(g_e8m0_tab)
         g_e8m0_tab = null

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -296,6 +296,7 @@ struct private StepRes {
     bmoe_rt : MetalBuffer?     // gemma4: router-input row, reused as the routed-branch acc
     u_moe_invd : MetalBuffer?  // gemma4: 1/sqrt(dim) router scale
     u_moe_gmode : MetalBuffer? // select gating mode (1 = gpt-oss softmax_weight)
+    u_moe_nsh : MetalBuffer?   // shexp width (qwen35moe; null = no shared expert)
     u_hass : MetalBuffer?      // attention sinks present (binds hass on the attn dispatches)
     // deltanet (Wave D) — recurrent-layer scratch + the gated-attention twins; dn steps only
     dn : bool
@@ -317,7 +318,7 @@ struct private StepRes {
     u_di : MetalBuffer?
     u_dconv : MetalBuffer?
     u_qscale : MetalBuffer?
-    u_one32 : MetalBuffer?     // npos = 1 (the decode window)
+    u_one32 : MetalBuffer?     // constant 1 (dn npos, the shexp gate's 1-row GEMV) — unconditional
     u_dn_qd2 : MetalBuffer?    // 2*qd — the packed [q|gate] GEMV width
     u_rot : MetalBuffer?       // partial rotary width (null = full; rope binds default to hs)
     bytes_dn_cd : uint64
@@ -367,7 +368,8 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
     let qkvd_mx = max(qkvd, qkvd_sw)
     let moe = !t.blocks.ffn_is_dense
     let knfe = moe ? c.n_expert_used * c.n_ff_exp : 0l
-    let h2 = max(2l * hidden, 2l * knfe)   // moe: bh12 holds k gate rows | k up rows
+    let nsh = moe ? c.n_ff_shexp : 0l
+    let h2 = max(2l * hidden, max(2l * knfe, 2l * nsh))   // moe: bh12 holds k gate rows | k up rows (+ the shexp pair)
     let rot = c.rope_dim > 0l ? c.rope_dim : head_size   // partial-rope tables are rot/2 wide
     var r = StepRes(valid = true, pos = pos, uid = s.uid,
         kdt = s.kv_dtype_k, s16 = t.wscale_f16, hetero = hetero, moe = moe,
@@ -424,6 +426,7 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
     r.u_hasn = uniform_u32(c.qk_norm ? 1u : 0u)
     r.u_softcap = uniform_f32(c.attn_logit_softcap)
     r.u_zero32 = uniform_u32(0u)
+    r.u_one32 = uniform_u32(1u)
     if (c.sliding_window > 0l) {
         let wstart = pos + 1l > c.sliding_window ? pos + 1l - c.sliding_window : 0l
         r.u_winsl = uniform_u32(uint(c.sliding_window))
@@ -453,7 +456,10 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
             r.bmoe_rt = pool_acquire(g_pool, g_dev, r.bytes_x)
             r.u_moe_invd = uniform_f32(1.0 / sqrt(float(dim)))
         }
-        r.u_moe_gmode = uniform_u32(c.moe_gate == MoeGate.softmax_weight ? 1u : 0u)
+        if (nsh > 0l) {
+            r.u_moe_nsh = uniform_u32(uint(nsh))
+        }
+        r.u_moe_gmode = uniform_u32(c.moe_gate == MoeGate.softmax_weight ? 1u : (c.norm_topk_prob ? 0u : 2u))
     }
     if (c.attn_sinks) {
         r.u_hass = uniform_u32(1u)
@@ -478,7 +484,6 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
         r.u_di = uniform_u32(uint(di))
         r.u_dconv = uniform_u32(uint(c.ssm_d_conv))
         r.u_qscale = uniform_f32(1.0 / sqrt(float(c.ssm_d_state)))
-        r.u_one32 = uniform_u32(1u)
     }
     if (c.q_gated) {
         r.bdn_qg = pool_acquire(g_pool, g_dev, 2ul * r.bytes_q)
@@ -623,8 +628,16 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                 if (g_skip != "gemv") {
                     enc_site_gemv(enc, t, KqFmt.q8, t.dnqkv_offs[l], cd, dim, r.bxb, r.bdn_qkv, r.u_dim, r.u_cd)
                     enc_site_gemv(enc, t, KqFmt.q8, t.dngate_offs[l], di, dim, r.bxb, r.bdn_z, r.u_dim, r.u_di)
-                    enc_site_gemv(enc, t, KqFmt.q8, t.dnbeta_offs[l], nvh, dim, r.bxb, r.bdn_b, r.u_dim, r.u_nvh)
-                    enc_site_gemv(enc, t, KqFmt.q8, t.dnalpha_offs[l], nvh, dim, r.bxb, r.bdn_g, r.u_dim, r.u_nvh)
+                    if (t.dn_ba_f32) {
+                        // F32-on-disk β/α (35B): fblob slabs ride the router f32 GEMV
+                        var bw_bt = upload_region(addr < void? >(t.fblob[t.dn_betaf_off + l * dim * nvh]), uint64(dim * nvh * 4l))
+                        enc_moe_router(enc, bw_bt, r.bxb, r.bdn_b, r.u_dim, r.u_nvh, r.u_dim, g_one, g_zero, nvh, 1l)
+                        var bw_al = upload_region(addr < void? >(t.fblob[t.dn_alphaf_off + l * dim * nvh]), uint64(dim * nvh * 4l))
+                        enc_moe_router(enc, bw_al, r.bxb, r.bdn_g, r.u_dim, r.u_nvh, r.u_dim, g_one, g_zero, nvh, 1l)
+                    } else {
+                        enc_site_gemv(enc, t, KqFmt.q8, t.dnbeta_offs[l], nvh, dim, r.bxb, r.bdn_b, r.u_dim, r.u_nvh)
+                        enc_site_gemv(enc, t, KqFmt.q8, t.dnalpha_offs[l], nvh, dim, r.bxb, r.bdn_g, r.u_dim, r.u_nvh)
+                    }
                 }
                 if (g_skip != "attn") {
                     let soff = uint64(dnli * nvh * c.ssm_d_state * c.ssm_d_state * 4l)
@@ -817,6 +830,11 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                         var bw_ds = upload_region(addr < void? >(t.fblob[t.moe_down_scale_off + l * c.n_expert]), uint64(c.n_expert * 4l))
                         enc_moe_wscale(enc, r.bmoe_sel, bw_ds, r.u_moe_k, 1l)
                     }
+                    if (r.u_moe_nsh != null) {
+                        // shexp raw gate dot (σ in the combine) — bmoe_lg[0] is free once select consumed it
+                        var bw_shg = upload_region(addr < void? >(t.fblob[t.shexp_gate_off + l * dim]), uint64(dim * 4l))
+                        enc_moe_router(enc, bw_shg, r.bxb, r.bmoe_lg, r.u_dim, r.u_one32, r.u_dim, g_one, g_zero, 1l, 1l)
+                    }
                     if (t.experts_mx4) {
                         // gpt-oss: mx4 expert planes + per-expert biases fold into the twins
                         var bwb1 = upload_region(addr < void? >(t.fblob[t.web1_off + l * c.n_expert * c.n_ff_exp]), uint64(c.n_expert * c.n_ff_exp * 4l))
@@ -851,7 +869,20 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                             r.u_moe_nfe, r.u_dim, r.bmoe_sel, fe2 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_moe_xs_dn,
                             r.u_zero32, r.u_zero32, r.u_zero32)
                     }
+                    if (r.u_moe_nsh != null) {
+                        // shexp FFN reads bxb BEFORE combine overwrites it; bh12/bxb2 are free here
+                        let nsh = c.n_ff_shexp
+                        let she = dim * nsh
+                        let bwsh1 = blob_of(g_dev, t, t.wsh1_off + l * she)
+                        enc_gemv_w13sw(enc, bwsh1.buf, bwsh1.boff, uint64(((t.wsh3_off + l * she) / 32l) * 34l),
+                            r.bxb, r.bh12, r.u_dim, r.u_moe_nsh, nsh)
+                        enc_site_gemv(enc, t, KqFmt.q8, t.wsh2_off + l * she, dim, nsh, r.bh12, r.bxb2, r.u_moe_nsh, r.u_dim)
+                    }
                     enc_moe_combine(enc, r.bmoe_dn, r.bmoe_sel, g4 ? r.bmoe_rt : r.bxb, r.u_dim, r.u_moe_k, dim, 1l)
+                    if (r.u_moe_nsh != null && g_skip != "ew") {
+                        // routed sum lands in bxb first — the shexp branch adds σ(gate)-scaled on top
+                        enc_axpy_sig(enc, r.bxb, r.bxb2, r.bmoe_lg, r.u_dim, r.u_dim, dim)
+                    }
                 }
                 if (g4) {
                     // routed post-norm + the dense shared branch, summed into bxb for the epilogue
@@ -1058,6 +1089,7 @@ def private release_step(var r : StepRes) {
     pool_release(g_upool, r.u_eps, 4ul)
     pool_release(g_upool, r.u_softcap, 4ul)
     pool_release(g_upool, r.u_zero32, 4ul)
+    pool_release(g_upool, r.u_one32, 4ul)
     if (r.u_winsl != null) {
         pool_release(g_upool, r.u_winsl, 4ul)
     }
@@ -1108,6 +1140,9 @@ def private release_step(var r : StepRes) {
             pool_release(g_pool, r.bmoe_rt, r.bytes_x)
             pool_release(g_upool, r.u_moe_invd, 4ul)
         }
+        if (r.u_moe_nsh != null) {
+            pool_release(g_upool, r.u_moe_nsh, 4ul)
+        }
         pool_release(g_upool, r.u_moe_gmode, 4ul)
     }
     if (r.u_hass != null) {
@@ -1128,7 +1163,6 @@ def private release_step(var r : StepRes) {
         pool_release(g_upool, r.u_di, 4ul)
         pool_release(g_upool, r.u_dconv, 4ul)
         pool_release(g_upool, r.u_qscale, 4ul)
-        pool_release(g_upool, r.u_one32, 4ul)
         r.bdn_state = null   // mirror-owned
     }
     if (r.bdn_qg != null) {
@@ -1390,6 +1424,10 @@ def private batch_decode_decline(t : Model; ws : BatchWorkspace; sessions : arra
                 return MetalDecodeDecline.kquant_native
             }
         }
+    }
+    // shexp MoE has no batch arm — a std-attention shexp model (qwen2moe-class) must decline
+    if (!t.blocks.ffn_is_dense && t.config.n_ff_shexp > 0l) {
+        return MetalDecodeDecline.graph
     }
     let shape = decode_shape_decline(t, BATCH_NEEDS_OK, true)
     if (shape != MetalDecodeDecline.none) {
@@ -1739,7 +1777,7 @@ def metal_batch_decode_forward(t : Model; var ws : BatchWorkspace; var sessions 
     var u_moe_kdim = moe ? uniform_u32(uint(c.n_expert_used * dim)) : null
     var u_moe_tot = moe ? uniform_u32(uint(nrows * knfe)) : null
     var u_moe_invd = g4moe ? uniform_f32(1.0 / sqrt(float(dim))) : null
-    var u_moe_gmode = moe ? uniform_u32(c.moe_gate == MoeGate.softmax_weight ? 1u : 0u) : null
+    var u_moe_gmode = moe ? uniform_u32(c.moe_gate == MoeGate.softmax_weight ? 1u : (c.norm_topk_prob ? 0u : 2u)) : null
     var u_hass = c.attn_sinks ? uniform_u32(1u) : null
     var u_xs4_dim = mv ? uniform_u32(uint(dim / 4l)) : null
     var u_xs4_qd = mv ? uniform_u32(uint(qd / 4l)) : null

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -764,7 +764,11 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                     enc_fwht_unsign(enc, r.bxb, u_hs_l, u_qd_l, n_heads, 1l, head_size)
                 }
             }
-            if (g_skip != "gemv") {
+            if (!recr && c.q_gated && g_skip != "ew") {
+                // gated-attention epilogue: out ⊙ σ(gate) between the attention output and wo (the CPU order)
+                enc_ew2(enc, g_pso_sigmul, r.bxb, 0ul, r.bdn_gate, 0ul, u_qd_l, qd)
+            }
+            if (!recr && g_skip != "gemv") {   // recurrent layers have no wo — ssm_out (already in bxb2) is their out projection
                 enc_site_gemv(enc, t, kq_fmt_at(t.wo_fmt, l), t.wo_offs[l], dim, qd, r.bxb, r.bxb2, u_qd_l, r.u_dim)
                 if (c.attn_out_bias) {
                     var bwo_b = upload_region(addr < void? >(t.bo[l * dim]), uint64(dim * 4l))

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -148,8 +148,8 @@ def private kq_fmt_at(a : array<KqFmt>; l : int64) : KqFmt => empty(a) ? KqFmt.q
 // and have no fp32-table GEMV.
 def private metal_model_servable_impl(t : Model) : bool {
     let cls_fmt = t.config.shared_weights ? t.emb_fmt : t.wcls_fmt
-    // tied-fp32 classifier (no fp32-table GEMV); deltanet hybrids stay planar until Wave D stage 2 (prefill)
-    if ((t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) || t.config.recr_mask != 0ul) {
+    // tied-fp32 classifier (no fp32-table GEMV); MTP stays planar until stage 4 (GPU logits skip the mtp_h stash)
+    if ((t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) || t.config.n_layer_nextn > 0l) {
         return false
     }
     return decode_shape_decline(t, DECODE_NEEDS_OK, true) == MetalDecodeDecline.none

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -57,7 +57,8 @@ def public metal_decode_shutdown {
 let DECODE_NEEDS_OK = (MetalNeed.neox | MetalNeed.qkv_bias | MetalNeed.qk_norm | MetalNeed.qd_neq_dim |
     MetalNeed.softcap | MetalNeed.sliding | MetalNeed.pre_post_norm | MetalNeed.geglu |
     MetalNeed.v_norm | MetalNeed.attn_scale | MetalNeed.out_scale |
-    MetalNeed.sinks | MetalNeed.out_bias)
+    MetalNeed.sinks | MetalNeed.out_bias | MetalNeed.partial_rope | MetalNeed.q_gated)
+// q_gated/partial_rope only occur on hybrid models (attn_is_std false), which batch graph-declines
 let BATCH_NEEDS_OK = DECODE_NEEDS_OK
 
 def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bool = false) : MetalDecodeDecline {
@@ -67,8 +68,9 @@ def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bo
     if (!kq_load_gpu_supported(t)) {   // a fmt without a GPU kernel (the q4_0 QAT tier, ...) must not dispatch
         return MetalDecodeDecline.kquant_native
     }
-    // non-std graphs decline here; MoE serves single-decode when the routing kernels cover it (Wave C)
-    if (!t.blocks.attn_is_std || (!t.blocks.ffn_is_dense && !(allow_moe && moe_metal_ok(t)))) {
+    // non-std graphs decline; MoE (Wave C) + deltanet hybrid (Wave D) serve when their kernels cover it
+    if ((!t.blocks.attn_is_std && !(t.config.hybrid_deltanet && dn_metal_ok(t))) ||
+            (!t.blocks.ffn_is_dense && !(allow_moe && moe_metal_ok(t)))) {
         return MetalDecodeDecline.graph
     }
     if (kernel_backend_needs_repack(active_kernel_backend())) {
@@ -89,6 +91,12 @@ def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bo
     }
     // per-CLASS: whole simdgroups; red[16] + the epl <= 16 q-register hoist cap the threadgroup width at 512 (gemma4's global class)
     for (l in range64(c.n_layers)) {
+        if (layer_is_recurrent(c, l)) {   // no KV, no attention tensors — only the FFN uniformity applies
+            if (layer_hidden(t, l) != hidden) {
+                return MetalDecodeDecline.layers
+            }
+            continue
+        }
         let hs_l = layer_head_size(c, l)
         if ((hs_l % 32l) != 0l || hs_l > 512l || (layer_kv_dim(c, l) % 32l) != 0l) {
             return MetalDecodeDecline.shape
@@ -104,10 +112,12 @@ def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bo
 // ... plus the decode-specific gates (uniform f16/f32 KV, attention depth, a real session uid)
 [unused_argument(pos)]   // depth retired (M2.4) — pos stays in the gate signature for future clauses
 def private decode_decline(t : Model; s : Session; pos : int64) : MetalDecodeDecline {
-    // mirror + writeback move raw row bytes, so the session codec must equal the mirror dtype; depth is capacity-bounded by the mirror arena, not gated here
+    // mirror + writeback move raw row bytes, so the session codec must equal the mirror dtype; depth is capacity-bounded by the mirror arena, not gated here. Partial rope has no q8_0/tq4 rope-store arm yet (f16/f32 mirrors only)
+    let partial_rope = t.config.rope_dim > 0l && t.config.rope_dim != t.config.head_size
     if (s.kv_dtype_k != s.kv_dtype_v ||
             (s.kv_dtype_k != KVDtype.f16 && s.kv_dtype_k != KVDtype.f32 &&
-             s.kv_dtype_k != KVDtype.q8_0 && s.kv_dtype_k != KVDtype.tq4)) {
+             s.kv_dtype_k != KVDtype.q8_0 && s.kv_dtype_k != KVDtype.tq4) ||
+            (partial_rope && s.kv_dtype_k != KVDtype.f16 && s.kv_dtype_k != KVDtype.f32)) {
         return MetalDecodeDecline.kv_dtype
     }
     if (s.uid == 0ul) {
@@ -121,9 +131,10 @@ def private decode_decline(t : Model; s : Session; pos : int64) : MetalDecodeDec
     if (!t.metal_blob) {
         return MetalDecodeDecline.planar
     }
-    // forward() built this position's rope row(s) right before the hook (dual-rope: both classes, each at ITS class's width)
+    // forward() built this position's rope row(s) before the hook (dual-rope both classes; partial rope rot/2 wide)
+    let rot = t.config.rope_dim > 0l ? t.config.rope_dim : t.config.head_size
     let swa_hs = t.config.head_size_swa > 0l ? t.config.head_size_swa : t.config.head_size
-    if (int64(length(s.rope_cos)) < t.config.head_size / 2l ||
+    if (int64(length(s.rope_cos)) < rot / 2l ||
             (has_dual_rope(t.config) && int64(length(s.rope_cos_swa)) < swa_hs / 2l)) {
         return MetalDecodeDecline.rope_rows
     }
@@ -137,10 +148,10 @@ def private kq_fmt_at(a : array<KqFmt>; l : int64) : KqFmt => empty(a) ? KqFmt.q
 // and have no fp32-table GEMV.
 def private metal_model_servable_impl(t : Model) : bool {
     let cls_fmt = t.config.shared_weights ? t.emb_fmt : t.wcls_fmt
-    if (t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) {
+    // tied-fp32 classifier (no fp32-table GEMV); deltanet hybrids stay planar until Wave D stage 2 (prefill)
+    if ((t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) || t.config.recr_mask != 0ul) {
         return false
     }
-    // MoE included since stage 2b (all three paths serve; the gate's %256 dims imply the prefill %64)
     return decode_shape_decline(t, DECODE_NEEDS_OK, true) == MetalDecodeDecline.none
 }
 
@@ -148,7 +159,8 @@ def private metal_model_servable_impl(t : Model) : bool {
 // argmax winner: the q8 linear copy (cls_q8), or a tied k6 classifier (every K-quant file on
 // the current boards ties a Q6_K token_embd — MetalEmbedK6 gathers straight off the kq planes).
 def private spec_cls_capable(t : Model) : bool {
-    return t.cls_q8 || (t.config.shared_weights && t.emb_fmt == KqFmt.k6)
+    // recurrent models never chain: a mispredicted spec step already advanced the GPU dn state (no repair)
+    return (t.cls_q8 || (t.config.shared_weights && t.emb_fmt == KqFmt.k6)) && t.config.recr_mask == 0ul
 }
 
 // One weight site's GEMV — a q8-tagged tensor rides the planar q8 kernels, a kq tensor the
@@ -285,6 +297,32 @@ struct private StepRes {
     u_moe_invd : MetalBuffer?  // gemma4: 1/sqrt(dim) router scale
     u_moe_gmode : MetalBuffer? // select gating mode (1 = gpt-oss softmax_weight)
     u_hass : MetalBuffer?      // attention sinks present (binds hass on the attn dispatches)
+    // deltanet (Wave D) — recurrent-layer scratch + the gated-attention twins; dn steps only
+    dn : bool
+    bdn_state : MetalBuffer?   // the session's DnMirror buffer (mirror-owned, never released here)
+    dn_conv_base : uint64      // byte offset of the conv-history region inside bdn_state
+    bdn_qkv : MetalBuffer?     // [cd] fused qkv projection row
+    bdn_cv : MetalBuffer?      // [cd] conv output (l2-normed in place)
+    bdn_z : MetalBuffer?       // [di] z gate row
+    bdn_b : MetalBuffer?       // [nvh] raw beta projections
+    bdn_g : MetalBuffer?       // [nvh] raw alpha projections
+    bdn_o : MetalBuffer?       // [di] delta-rule output (gated in place)
+    bdn_qg : MetalBuffer?      // [2*qd] packed [q|gate] projection (gated-attention layers)
+    bdn_gate : MetalBuffer?    // [qd] deinterleaved sigmoid-gate rows
+    u_cd : MetalBuffer?
+    u_dn_kd : MetalBuffer?
+    u_ds : MetalBuffer?
+    u_nvh : MetalBuffer?
+    u_nkh : MetalBuffer?
+    u_di : MetalBuffer?
+    u_dconv : MetalBuffer?
+    u_qscale : MetalBuffer?
+    u_one32 : MetalBuffer?     // npos = 1 (the decode window)
+    u_dn_qd2 : MetalBuffer?    // 2*qd — the packed [q|gate] GEMV width
+    u_rot : MetalBuffer?       // partial rotary width (null = full; rope binds default to hs)
+    bytes_dn_cd : uint64
+    bytes_dn_di : uint64
+    bytes_dn_h : uint64        // nvh floats (β / α rows)
     bytes_moe_lg : uint64
     bytes_moe_dn : uint64
     bytes_supp : uint64
@@ -330,12 +368,14 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
     let moe = !t.blocks.ffn_is_dense
     let knfe = moe ? c.n_expert_used * c.n_ff_exp : 0l
     let h2 = max(2l * hidden, 2l * knfe)   // moe: bh12 holds k gate rows | k up rows
+    let rot = c.rope_dim > 0l ? c.rope_dim : head_size   // partial-rope tables are rot/2 wide
     var r = StepRes(valid = true, pos = pos, uid = s.uid,
         kdt = s.kv_dtype_k, s16 = t.wscale_f16, hetero = hetero, moe = moe,
+        dn = c.recr_mask != 0ul,
         koff = koff, voff = voff, cap = cap, arena_epoch = g_arena_epoch,
         bytes_x = uint64(dim * 4l), bytes_q = uint64(qd_mx * 4l), bytes_xb = uint64(max(dim, qd_mx) * 4l),
         bytes_qkv = uint64(qkvd_mx * 4l),
-        bytes_h2 = uint64(h2 * 4l), bytes_tab = uint64((head_size / 2l) * 4l),
+        bytes_h2 = uint64(h2 * 4l), bytes_tab = uint64((rot / 2l) * 4l),
         bytes_tab_sw = uint64((hs_sw / 2l) * 4l),
         bytes_log = uint64(c.vocab_size * 4l))
     r.bx = pool_acquire(g_pool, g_dev, r.bytes_x)
@@ -417,6 +457,36 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
     }
     if (c.attn_sinks) {
         r.u_hass = uniform_u32(1u)
+    }
+    if (r.dn) {
+        let cd = dn_conv_dim(c)
+        let di = c.ssm_d_inner
+        r.bytes_dn_cd = uint64(cd * 4l)
+        r.bytes_dn_di = uint64(di * 4l)
+        r.bytes_dn_h = uint64(c.ssm_dt_rank * 4l)
+        r.bdn_qkv = pool_acquire(g_pool, g_dev, r.bytes_dn_cd)
+        r.bdn_cv = pool_acquire(g_pool, g_dev, r.bytes_dn_cd)
+        r.bdn_z = pool_acquire(g_pool, g_dev, r.bytes_dn_di)
+        r.bdn_o = pool_acquire(g_pool, g_dev, r.bytes_dn_di)
+        r.bdn_b = pool_acquire(g_pool, g_dev, r.bytes_dn_h)
+        r.bdn_g = pool_acquire(g_pool, g_dev, r.bytes_dn_h)
+        r.u_cd = uniform_u32(uint(cd))
+        r.u_dn_kd = uniform_u32(uint(dn_key_dim(c)))
+        r.u_ds = uniform_u32(uint(c.ssm_d_state))
+        r.u_nvh = uniform_u32(uint(c.ssm_dt_rank))
+        r.u_nkh = uniform_u32(uint(c.ssm_n_group))
+        r.u_di = uniform_u32(uint(di))
+        r.u_dconv = uniform_u32(uint(c.ssm_d_conv))
+        r.u_qscale = uniform_f32(1.0 / sqrt(float(c.ssm_d_state)))
+        r.u_one32 = uniform_u32(1u)
+    }
+    if (c.q_gated) {
+        r.bdn_qg = pool_acquire(g_pool, g_dev, 2ul * r.bytes_q)
+        r.bdn_gate = pool_acquire(g_pool, g_dev, r.bytes_q)
+        r.u_dn_qd2 = uniform_u32(uint(2l * qd))
+    }
+    if (rot != head_size) {
+        r.u_rot = uniform_u32(uint(rot))
     }
     // logits-on-GPU (default ON, DASLLAMA_METAL_LOGITS=0 pins the CPU classifier) mirrors the prefill gates
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
@@ -513,8 +583,10 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
             enc_rms(enc, r.bx, bw_att0, r.bxb, r.u_dim, r.u_eps)
         }
     }
+    var dnli = 0l   // recurrent-layer index — addresses the dn state/conv mirror slices in order
     for (l in range64(c.n_layers)) {
         unsafe {
+            let recr = layer_is_recurrent(c, l)
             // attention: fused QKV GEMV -> single-query attention -> out-proj -> fused add+norm; K-quant sites (mixed PER TENSOR formats) split into per-tensor plane GEMVs
             let fq = kq_fmt_at(t.wq_fmt, l)
             let fk = kq_fmt_at(t.wk_fmt, l)
@@ -541,8 +613,38 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
             var u_scale_l = het ? r.u_scale_sw : r.u_scale
             var u_npq_l = het ? r.u_npq_sw : r.u_npq
             var u_npall_l = het ? r.u_npall_sw : r.u_npall
-            // qk_norm needs the head-wide prepass between GEMV and rope — the fused form stands down (hetero too: its row map bakes one class geometry)
-            let fused_qkv = scalar_kv && qkv_q8 && !c.qk_norm && !r.hetero
+            // qk_norm needs the head-wide prepass between GEMV and rope — the fused form stands down (hetero too: its row map bakes one class geometry); q_gated packs [q|gate] (deint first)
+            let fused_qkv = scalar_kv && qkv_q8 && !c.qk_norm && !r.hetero && !c.q_gated
+            if (recr) {
+                // deltanet layer (Wave D): projections -> conv+SiLU -> q/k L2 -> delta rule -> gated out-norm -> out-proj
+                let cd = dn_conv_dim(c)
+                let di = c.ssm_d_inner
+                let nvh = c.ssm_dt_rank
+                if (g_skip != "gemv") {
+                    enc_site_gemv(enc, t, KqFmt.q8, t.dnqkv_offs[l], cd, dim, r.bxb, r.bdn_qkv, r.u_dim, r.u_cd)
+                    enc_site_gemv(enc, t, KqFmt.q8, t.dngate_offs[l], di, dim, r.bxb, r.bdn_z, r.u_dim, r.u_di)
+                    enc_site_gemv(enc, t, KqFmt.q8, t.dnbeta_offs[l], nvh, dim, r.bxb, r.bdn_b, r.u_dim, r.u_nvh)
+                    enc_site_gemv(enc, t, KqFmt.q8, t.dnalpha_offs[l], nvh, dim, r.bxb, r.bdn_g, r.u_dim, r.u_nvh)
+                }
+                if (g_skip != "attn") {
+                    let soff = uint64(dnli * nvh * c.ssm_d_state * c.ssm_d_state * 4l)
+                    let hoff = r.dn_conv_base + uint64(dnli * (c.ssm_d_conv - 1l) * cd * 4l)
+                    var bw_cv = upload_region(addr < void? >(t.fblob[t.dn_conv_off + l * c.ssm_d_conv * cd]), uint64(c.ssm_d_conv * cd * 4l))
+                    enc_dn_conv(enc, r.bdn_qkv, r.bdn_state, hoff, bw_cv, r.bdn_cv, r.u_cd, r.u_dconv, r.u_one32, cd, 1l)
+                    enc_dn_conv_hist(enc, r.bdn_qkv, r.bdn_state, hoff, r.u_cd, r.u_dconv, r.u_one32, cd)
+                    enc_dn_l2norm(enc, r.bdn_cv, r.u_cd, r.u_dn_kd, r.u_ds, r.u_eps, r.u_qscale, 2l * c.ssm_n_group, 1l)
+                    var baa = upload_region(addr < void? >(t.fblob[t.dn_a_off + l * nvh]), uint64(nvh * 4l))
+                    var bdt = upload_region(addr < void? >(t.fblob[t.dn_dt_off + l * nvh]), uint64(nvh * 4l))
+                    enc_dn_scan(enc, r.bdn_cv, r.bdn_state, soff, r.bdn_b, r.bdn_g, baa, bdt, r.bdn_o,
+                        r.u_cd, r.u_dn_kd, r.u_ds, r.u_nvh, r.u_nkh, r.u_di, r.u_one32, c.ssm_d_state, nvh)
+                    var bwn = upload_region(addr < void? >(t.fblob[t.dn_norm_off + l * c.ssm_d_state]), uint64(c.ssm_d_state * 4l))
+                    enc_dn_gate(enc, r.bdn_o, r.bdn_z, bwn, r.u_ds, r.u_di, r.u_eps, nvh, 1l)
+                }
+                if (g_skip != "gemv") {
+                    enc_site_gemv(enc, t, KqFmt.q8, t.dnout_offs[l], dim, di, r.bdn_o, r.bxb2, r.u_di, r.u_dim)
+                }
+                dnli++
+            }
             // the [bq | bk | bv] bias plane matches the fused QKV index space, added pre-rope; no bias -> the qkv buffer dummy-binds the slot
             var bbias = r.bqkv
             if (c.attn_qkv_bias) {
@@ -551,7 +653,7 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                     addr < void? >(t.bk[l * kv_dim]), uint64(kv_dim * 4l),
                     addr < void? >(t.bv[l * kv_dim]), uint64(kv_dim * 4l))
             }
-            if (g_skip != "gemv") {
+            if (!recr && g_skip != "gemv") {
                 if (fused_qkv && t.wv_offs[l] >= 0l) {
                     // one dispatch over all three segments — the kernel binds each tensor's blob slice separately (kind-major layout keeps q/k/v apart)
                     let bwq_ = blob_of(g_dev, t, t.wq_offs[l])
@@ -562,14 +664,20 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                         bcos_l, bsin_l, r.u_dim, r.u_qkvd, r.u_qd, r.u_kvd, r.u_hs, r.u_neox,
                         bbias, r.u_hasb, qkvd)
                 } else {
-                    enc_site_gemv(enc, t, fq, t.wq_offs[l], qd, dim, r.bxb, r.bqkv, r.u_dim, u_qd_l)
+                    if (c.q_gated) {
+                        // 2x-wide packed [q|gate] projection, deinterleaved into the qkv q segment + gate rows
+                        enc_site_gemv(enc, t, fq, t.wq_offs[l], 2l * qd, dim, r.bxb, r.bdn_qg, r.u_dim, r.u_dn_qd2)
+                        enc_dn_deint(enc, r.bdn_qg, r.bqkv, r.bdn_gate, u_hs_l, u_qd_l, u_qd_l, qd, 1l)
+                    } else {
+                        enc_site_gemv(enc, t, fq, t.wq_offs[l], qd, dim, r.bxb, r.bqkv, r.u_dim, u_qd_l)
+                    }
                     enc_site_gemv(enc, t, fk, t.wk_offs[l], kv_dim, dim, r.bxb, r.bqkv, r.u_dim, u_kvd_l, uint64(qd * 4l))
                     if (t.wv_offs[l] >= 0l) {
                         enc_site_gemv(enc, t, fv, t.wv_offs[l], kv_dim, dim, r.bxb, r.bqkv, r.u_dim, u_kvd_l, uint64((qd + kv_dim) * 4l))
                     }
                 }
             }
-            if (g_skip != "ew" && (t.wv_offs[l] < 0l || c.v_norm)) {
+            if (!recr && g_skip != "ew" && (t.wv_offs[l] < 0l || c.v_norm)) {
                 // gemma4 V: no-wv layers fill the v segment from the PRE-norm/PRE-rope K projection (the CPU mm_qkv order, BEFORE qk_norm touches k); with v_norm the copy FUSES into the ones-RMS
                 if (t.wv_offs[l] < 0l && !c.v_norm) {
                     enc_copy_row(enc, r.bqkv, uint64(qd * 4l), r.bqkv, u_kvd_l, kv_dim, uint64((qd + kv_dim) * 4l))
@@ -583,7 +691,7 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                         kv_dim / head_size, 1l, head_size)
                 }
             }
-            if (c.qk_norm && g_skip != "ew" && !f16v) {
+            if (!recr && c.qk_norm && g_skip != "ew" && !f16v) {
                 // per-head QK RMSNorm before rope (qwen3) — the f16 mirror rides the fused H-form rope-store instead of this prepass
                 var bqkw = upload_region_cat3(
                     addr < void? >(t.fblob[t.rms_q_offs[l]]), uint64(head_size * 4l),
@@ -591,7 +699,7 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                 enc_qk_norm(enc, r.bqkv, bqkw, r.u_nh, u_qd_l, u_qkvd_l, u_hs_l, u_hs_l, r.u_eps,
                     u_qd_l, n_heads + kv_dim / head_size, 1l, head_size)
             }
-            if (g_skip != "ew" && !fused_qkv) {
+            if (!recr && g_skip != "ew" && !fused_qkv) {
                 if (r.kdt == KVDtype.q8_0) {
                     enc_rope_store_q8(enc, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                         lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
@@ -610,15 +718,16 @@ def private encode_step(t : Model; var r : StepRes; commit_now : bool; var prev_
                     enc_rope_store_h16(enc, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                         lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
                         bcos_l, bsin_l, bqkw, bbias, u_qd_l, u_hs_l, r.u_nh, u_kvm_l, r.u_neox,
-                        r.u_hasb, r.u_hasn, r.u_eps, n_heads + 2l * (kv_dim / head_size), head_size)
+                        r.u_hasb, r.u_hasn, r.u_eps, n_heads + 2l * (kv_dim / head_size), head_size,
+                        [brot = r.u_rot])
                 } else {
                     enc_rope_store(enc, f16v, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                         lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
                         bcos_l, bsin_l, u_qd_l, u_hs_l, u_npq_l, u_npall_l, r.u_neox, bbias, r.u_hasb,
-                        (qd + kv_dim) / 2l)
+                        (qd + kv_dim) / 2l, [brot = r.u_rot])
                 }
             }
-            if (g_skip != "attn") {
+            if (!recr && g_skip != "attn") {
                 // sliding layers bind `window` (wstart = cnt - window) + the first-live-chunk comb start, global bind 0; sliding only surfaces chunked (the gate pins window >= 128 >= the single-form ceiling)
                 var bwin = lsl ? r.u_winsl : r.u_zero32
                 var bchlo = lsl ? r.u_chlo : r.u_zero32
@@ -996,6 +1105,32 @@ def private release_step(var r : StepRes) {
     }
     if (r.u_hass != null) {
         pool_release(g_upool, r.u_hass, 4ul)
+    }
+    if (r.dn) {
+        pool_release(g_pool, r.bdn_qkv, r.bytes_dn_cd)
+        pool_release(g_pool, r.bdn_cv, r.bytes_dn_cd)
+        pool_release(g_pool, r.bdn_z, r.bytes_dn_di)
+        pool_release(g_pool, r.bdn_o, r.bytes_dn_di)
+        pool_release(g_pool, r.bdn_b, r.bytes_dn_h)
+        pool_release(g_pool, r.bdn_g, r.bytes_dn_h)
+        pool_release(g_upool, r.u_cd, 4ul)
+        pool_release(g_upool, r.u_dn_kd, 4ul)
+        pool_release(g_upool, r.u_ds, 4ul)
+        pool_release(g_upool, r.u_nvh, 4ul)
+        pool_release(g_upool, r.u_nkh, 4ul)
+        pool_release(g_upool, r.u_di, 4ul)
+        pool_release(g_upool, r.u_dconv, 4ul)
+        pool_release(g_upool, r.u_qscale, 4ul)
+        pool_release(g_upool, r.u_one32, 4ul)
+        r.bdn_state = null   // mirror-owned
+    }
+    if (r.bdn_qg != null) {
+        pool_release(g_pool, r.bdn_qg, 2ul * r.bytes_q)
+        pool_release(g_pool, r.bdn_gate, r.bytes_q)
+        pool_release(g_upool, r.u_dn_qd2, 4ul)
+    }
+    if (r.u_rot != null) {
+        pool_release(g_upool, r.u_rot, 4ul)
     }
     r.valid = false
 }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -982,6 +982,9 @@ def private finish_step(t : Model; var s : Session; r : StepRes) : bool {
             decode_override_logits_done()
         }
         g_mirrors[s.uid].watermark = r.pos + 1l
+        if (r.dn) {   // the GPU state now holds pos's update — advance the mirror's forward-only cursor
+            dn_mirror_advance(s.uid, r.pos)
+        }
         g_us_readback += int64(get_time_usec(ts_rb))
         g_decodes++
         if (int64(length(g_step_trace)) < g_step_trace_cap) {
@@ -1158,8 +1161,9 @@ def private discard_pre {
 // GPU. When speculation gates pass, the cb commits AND chains itself (argmax + embed gather, no
 // CPU poke); otherwise it stays uncommitted. Quietly declines when gates fail — slow path serves those.
 def private pre_encode_next(t : Model; s : Session; npos : int64; var prev_blog : MetalBuffer?) {
-    // quiet non-decline: skipping the pre-encode just means the slow path serves the next step
-    if (decode_decline(t, s, npos) != MetalDecodeDecline.none || !key_exists(g_mirrors, s.uid)) {
+    // no encode-ahead for recurrent (two cbs race the one dn state buffer); a declined/absent-mirror skip = slow path serves it
+    if (t.config.recr_mask != 0ul ||
+            decode_decline(t, s, npos) != MetalDecodeDecline.none || !key_exists(g_mirrors, s.uid)) {
         return
     }
     let mr = g_mirrors[s.uid]   // cheap copy, capacity check ONLY — row npos-1 is in flight on the GPU
@@ -1205,6 +1209,16 @@ def private metal_decode_slow(t : Model; var s : Session; pos : int64) : bool {
         return false
     }
     var r = acquire_step(t, s, pos, mir.koff, mir.voff, mir.cap)
+    if (r.dn) {
+        var dm = dn_mirror_prepare(s, pos)
+        if (!dm.ok) {   // state not resident and no CPU prefix to sync from — decline this step
+            release_step(r)
+            decline(MetalDecodeDecline.dn_state)
+            return false
+        }
+        r.bdn_state = dm.buf
+        r.dn_conv_base = dm.conv_off
+    }
     poke_step(s, r)
     g_us_setup += int64(get_time_usec(ts_all))
     let ts_enc = ref_time_ticks()

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -3925,6 +3925,65 @@ class MetalSigmul {
     }
 }
 
+// Batched narrow q8 GEMV for the β/α projections (d = dt_rank, 16..64 — under every GEMM
+// N tile): one simdgroup per (output row, position), the MetalQ8Gemv stream walk per row.
+class MetalDnBa {
+    @ssbo @binding = 0 wsh : array<float16> // 34B-block W blob, half-scale view (block b at 17*b)
+    @ssbo @binding = 1 wqb : array<int8>    // the same blob buffer, byte view (quants at 34*b + 2)
+    @ssbo @binding = 2 x : array<float4>    // [npos x n] f32 rows, float4 view
+    @ssbo @binding = 3 y : array<float>     // [npos x d]
+    @uniform @binding = 4 ndim : uint       // n (reduction dim, % 32)
+    @uniform @binding = 5 ddim : uint       // d (output rows per position)
+
+    [metal_kernel(name="metal_dn_ba_msl")]
+    def metal_dn_ba {
+        let row = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
+        let p = gl_WorkGroupID.y
+        if (row >= ddim) {
+            return
+        }
+        let lane = gl_SubgroupInvocationID
+        let nb = ndim / 32u
+        let nb4 = ndim / 4u
+        var sp = unsafe(addr(wsh[(row * nb + lane / 8u) * 17u]))
+        var qp = unsafe(addr(wqb[(row * nb + lane / 8u) * 34u + 2u + (lane % 8u) * 4u]))
+        var x0 = unsafe(addr(x[p * nb4 + lane]))
+        var acc = 0.0
+        var lw : float4[4]
+        var k = lane
+        while (k + 96u < nb4) {
+            // all 4 chunk dequants batch AHEAD of the fma chains (the MvB2 load batching)
+            for [unroll_full] (c in range(4)) {
+                let d = float(unsafe(sp[uint(c) * 68u]))   // chunk c sits 4 blocks (68 halves) on
+                let qb = uint(c) * 136u                    // ... and 136 quant bytes
+                lw[c] = float4(float(unsafe(qp[qb])), float(unsafe(qp[qb + 1u])),
+                    float(unsafe(qp[qb + 2u])), float(unsafe(qp[qb + 3u]))) * d
+            }
+            for [unroll_full] (c in range(4)) {
+                let xv = unsafe(x0[uint(c) * 32u])
+                acc += lw[c].x * xv.x + lw[c].y * xv.y + lw[c].z * xv.z + lw[c].w * xv.w
+            }
+            sp = unsafe(sp + 272)           // 16 blocks x 17 halves per stripe
+            qp = unsafe(qp + 544)           // 16 blocks x 34 bytes
+            x0 = unsafe(x0 + 128)
+            k += 128u
+        }
+        while (k < nb4) {
+            let bi = row * nb + k / 8u
+            let d = float(wsh[bi * 17u])
+            let qb = bi * 34u + 2u + (k % 8u) * 4u
+            let xv = x[p * nb4 + k]
+            acc += (float(wqb[qb]) * xv.x + float(wqb[qb + 1u]) * xv.y +
+                float(wqb[qb + 2u]) * xv.z + float(wqb[qb + 3u]) * xv.w) * d
+            k += gl_SubgroupSize
+        }
+        acc = simd_sum(acc)
+        if (lane == 0u) {
+            y[p * ddim + row] = acc
+        }
+    }
+}
+
 // ===== the whole-prefill driver =====
 // Registered as prefill override "metal" (DASLLAMA_PIN_PREFILL). One command buffer per prefill;
 // ONE commit+wait, then unified-memory readback hands x_b + per-layer roped-K/raw-V back to the CPU.
@@ -3939,11 +3998,19 @@ var private g_pf_upool : MetalBufferPool     // UNTRACKED pool: uniforms + rope 
 let PF_NEEDS_OK = (MetalNeed.neox | MetalNeed.qkv_bias | MetalNeed.qk_norm | MetalNeed.qd_neq_dim |
     MetalNeed.softcap | MetalNeed.sliding | MetalNeed.pre_post_norm | MetalNeed.geglu |
     MetalNeed.v_norm | MetalNeed.attn_scale | MetalNeed.out_scale |
-    MetalNeed.sinks | MetalNeed.out_bias)
+    MetalNeed.sinks | MetalNeed.out_bias | MetalNeed.partial_rope | MetalNeed.q_gated)
 
 var private g_min_npos = 64l
 var private g_max_npos = 2048l          // naive-attention P footprint cap: heads x npos^2 floats
 var private g_prefills = 0l
+var private g_pf_pso_dn_conv : MetalComputePipeline?    // deltanet (Wave D) — prefill-local PSO set
+var private g_pf_pso_dn_hist : MetalComputePipeline?
+var private g_pf_pso_dn_l2 : MetalComputePipeline?
+var private g_pf_pso_dn_scan : MetalComputePipeline?
+var private g_pf_pso_dn_gate : MetalComputePipeline?
+var private g_pf_pso_dn_deint : MetalComputePipeline?
+var private g_pf_pso_dn_ba : MetalComputePipeline?
+var private g_pf_pso_sigmul : MetalComputePipeline?
 var private g_pso_gemm : MetalComputePipeline?
 var private g_pso_gemm64 : MetalComputePipeline?
 var private g_pf_pso_rms : MetalComputePipeline?
@@ -4070,6 +4137,38 @@ def public metal_prefill_shutdown {
     if (g_pso_rope != null) {
         metal_release(g_pso_rope)
         g_pso_rope = null
+    }
+    if (g_pf_pso_dn_conv != null) {
+        metal_release(g_pf_pso_dn_conv)
+        g_pf_pso_dn_conv = null
+    }
+    if (g_pf_pso_dn_hist != null) {
+        metal_release(g_pf_pso_dn_hist)
+        g_pf_pso_dn_hist = null
+    }
+    if (g_pf_pso_dn_l2 != null) {
+        metal_release(g_pf_pso_dn_l2)
+        g_pf_pso_dn_l2 = null
+    }
+    if (g_pf_pso_dn_scan != null) {
+        metal_release(g_pf_pso_dn_scan)
+        g_pf_pso_dn_scan = null
+    }
+    if (g_pf_pso_dn_gate != null) {
+        metal_release(g_pf_pso_dn_gate)
+        g_pf_pso_dn_gate = null
+    }
+    if (g_pf_pso_dn_deint != null) {
+        metal_release(g_pf_pso_dn_deint)
+        g_pf_pso_dn_deint = null
+    }
+    if (g_pf_pso_dn_ba != null) {
+        metal_release(g_pf_pso_dn_ba)
+        g_pf_pso_dn_ba = null
+    }
+    if (g_pf_pso_sigmul != null) {
+        metal_release(g_pf_pso_sigmul)
+        g_pf_pso_sigmul = null
     }
     if (g_pso_addbias != null) {
         metal_release(g_pso_addbias)
@@ -4261,6 +4360,14 @@ def private metal_prefill_init : bool {
     g_pf_pso_swiglu_oai = pf_compile_pso(metal_swiglu_oai_msl, metal_swiglu_oai_msl_entry, metal_swiglu_oai_msl_fastmath, ok)
     g_pf_pso_moe_mm_mx4 = pf_compile_pso(metal_moe_mulmm_mx4_msl, metal_moe_mulmm_mx4_msl_entry, metal_moe_mulmm_mx4_msl_fastmath, ok)
     g_pf_pso_moe_bias_rows = pf_compile_pso(metal_moe_bias_rows_msl, metal_moe_bias_rows_msl_entry, metal_moe_bias_rows_msl_fastmath, ok)
+    g_pf_pso_dn_conv = pf_compile_pso(metal_dn_conv_msl, metal_dn_conv_msl_entry, metal_dn_conv_msl_fastmath, ok)
+    g_pf_pso_dn_hist = pf_compile_pso(metal_dn_conv_hist_msl, metal_dn_conv_hist_msl_entry, metal_dn_conv_hist_msl_fastmath, ok)
+    g_pf_pso_dn_l2 = pf_compile_pso(metal_dn_l2norm_msl, metal_dn_l2norm_msl_entry, metal_dn_l2norm_msl_fastmath, ok)
+    g_pf_pso_dn_scan = pf_compile_pso(metal_dn_scan_msl, metal_dn_scan_msl_entry, metal_dn_scan_msl_fastmath, ok)
+    g_pf_pso_dn_gate = pf_compile_pso(metal_dn_gate_msl, metal_dn_gate_msl_entry, metal_dn_gate_msl_fastmath, ok)
+    g_pf_pso_dn_deint = pf_compile_pso(metal_dn_deint_msl, metal_dn_deint_msl_entry, metal_dn_deint_msl_fastmath, ok)
+    g_pf_pso_dn_ba = pf_compile_pso(metal_dn_ba_msl, metal_dn_ba_msl_entry, metal_dn_ba_msl_fastmath, ok)
+    g_pf_pso_sigmul = pf_compile_pso(metal_sigmul_msl, metal_sigmul_msl_entry, metal_sigmul_msl_fastmath, ok)
     g_pf_e8m0_tab = metal_new_buffer(g_pf_dev, 1024ul)
     unsafe {
         var ep = reinterpret<uint?>(metal_buffer_contents(g_pf_e8m0_tab))
@@ -4349,8 +4456,8 @@ def private prefill_decline(t : Model; s : Session; npos, start_pos : int64) : M
             return MetalPrefillDecline.wscale_f16
         }
     }
-    // non-std graphs decline; MoE serves via the gathered mul_mm twins (C tiles = 64 cols -> %64)
-    if (!t.blocks.attn_is_std ||
+    // non-std graphs decline; deltanet hybrids serve via dn_metal_ok (ds == 128 makes every dn GEMM width %128)
+    if ((!t.blocks.attn_is_std && !(t.config.hybrid_deltanet && dn_metal_ok(t))) ||
             (!t.blocks.ffn_is_dense && (!moe_metal_ok(t) ||
              (t.config.n_ff_exp % 64l) != 0l || (t.config.dim % 64l) != 0l))) {
         return MetalPrefillDecline.graph
@@ -4381,9 +4488,9 @@ def private prefill_decline(t : Model; s : Session; npos, start_pos : int64) : M
             !pf_mm_shape64(t)) {
         return MetalPrefillDecline.planar
     }
-    // rope tables are the kernel's input — forward_prefill_body builds them right before the hook (dual-rope: the sliding class's rows at ITS width)
+    // rope tables are the hook's input (partial rope: rows rope_dim/2 wide; dual-rope: swa class width)
     let swa_hs = c.head_size_swa > 0l ? c.head_size_swa : c.head_size
-    if (int64(length(s.rope_cos)) < npos * (c.head_size / 2l) ||
+    if (int64(length(s.rope_cos)) < npos * ((c.rope_dim > 0l ? c.rope_dim : c.head_size) / 2l) ||
             (has_dual_rope(c) && int64(length(s.rope_cos_swa)) < npos * (swa_hs / 2l))) {
         return MetalPrefillDecline.rope_rows
     }
@@ -4795,6 +4902,97 @@ def private enc_av(enc : MetalComputeEncoder?; batt, bv, bxb, bqd, bkvd, bhs, bk
 }
 
 // swiglu and add share the (a, b, total) elementwise shape
+// ===== deltanet prefill encoders (Wave D) — the prefill-local twins of the decode-side set =====
+// hist/state bind the per-session DnMirror arena at the layer's byte offset; the rest is window scratch.
+
+def private pf_enc_dn_conv(enc : MetalComputeEncoder?; bx, bhist : MetalBuffer?; hoff : uint64;
+                           bw, by, bcd, bdconv, bnp : MetalBuffer?; cd, npos : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_conv)
+    metal_set_buffer(enc, bx, 0ul, 0)
+    metal_set_buffer(enc, bhist, hoff, 1)
+    metal_set_buffer(enc, bw, 0ul, 2)
+    metal_set_buffer(enc, by, 0ul, 3)
+    metal_set_buffer(enc, bcd, 0ul, 4)
+    metal_set_buffer(enc, bdconv, 0ul, 5)
+    metal_set_buffer(enc, bnp, 0ul, 6)
+    metal_dispatch_threadgroups(enc, uint3(uint((cd + 255l) / 256l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def private pf_enc_dn_conv_hist(enc : MetalComputeEncoder?; bx, bhist : MetalBuffer?; hoff : uint64;
+                                bcd, bdconv, bnp : MetalBuffer?; cd : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_hist)
+    metal_set_buffer(enc, bx, 0ul, 0)
+    metal_set_buffer(enc, bhist, hoff, 1)
+    metal_set_buffer(enc, bcd, 0ul, 2)
+    metal_set_buffer(enc, bdconv, 0ul, 3)
+    metal_set_buffer(enc, bnp, 0ul, 4)
+    metal_dispatch_threadgroups(enc, uint3(uint((cd + 255l) / 256l), 1u, 1u), uint3(256u, 1u, 1u))
+}
+
+def private pf_enc_dn_l2norm(enc : MetalComputeEncoder?; by, bcd, bkd, bds, beps, bqscale : MetalBuffer?; nblk, npos : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_l2)
+    metal_set_buffer(enc, by, 0ul, 0)
+    metal_set_buffer(enc, bcd, 0ul, 1)
+    metal_set_buffer(enc, bkd, 0ul, 2)
+    metal_set_buffer(enc, bds, 0ul, 3)
+    metal_set_buffer(enc, beps, 0ul, 4)
+    metal_set_buffer(enc, bqscale, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((nblk + 7l) / 8l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def private pf_enc_dn_scan(enc : MetalComputeEncoder?; bcv, bst : MetalBuffer?; stoff : uint64;
+                           bbraw, bgraw, baa, bdtb, bo, bcd, bkd, bds, bnvh, bnkh, bdi, bnp : MetalBuffer?; ds, nvh : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_scan)
+    metal_set_buffer(enc, bcv, 0ul, 0)
+    metal_set_buffer(enc, bst, stoff, 1)
+    metal_set_buffer(enc, bbraw, 0ul, 2)
+    metal_set_buffer(enc, bgraw, 0ul, 3)
+    metal_set_buffer(enc, baa, 0ul, 4)
+    metal_set_buffer(enc, bdtb, 0ul, 5)
+    metal_set_buffer(enc, bo, 0ul, 6)
+    metal_set_buffer(enc, bcd, 0ul, 7)
+    metal_set_buffer(enc, bkd, 0ul, 8)
+    metal_set_buffer(enc, bds, 0ul, 9)
+    metal_set_buffer(enc, bnvh, 0ul, 10)
+    metal_set_buffer(enc, bnkh, 0ul, 11)
+    metal_set_buffer(enc, bdi, 0ul, 12)
+    metal_set_buffer(enc, bnp, 0ul, 13)
+    metal_dispatch_threadgroups(enc, uint3(uint(ds / 4l), uint(nvh), 1u), uint3(128u, 1u, 1u))
+}
+
+def private pf_enc_dn_gate(enc : MetalComputeEncoder?; bo, bz, bwn, bds, bdi, beps : MetalBuffer?; nvh, npos : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_gate)
+    metal_set_buffer(enc, bo, 0ul, 0)
+    metal_set_buffer(enc, bz, 0ul, 1)
+    metal_set_buffer(enc, bwn, 0ul, 2)
+    metal_set_buffer(enc, bds, 0ul, 3)
+    metal_set_buffer(enc, bdi, 0ul, 4)
+    metal_set_buffer(enc, beps, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((nvh + 7l) / 8l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def private pf_enc_dn_deint(enc : MetalComputeEncoder?; bqg, bq, bgt, bhs, bqd, bqs : MetalBuffer?; qd, npos : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_deint)
+    metal_set_buffer(enc, bqg, 0ul, 0)
+    metal_set_buffer(enc, bq, 0ul, 1)
+    metal_set_buffer(enc, bgt, 0ul, 2)
+    metal_set_buffer(enc, bhs, 0ul, 3)
+    metal_set_buffer(enc, bqd, 0ul, 4)
+    metal_set_buffer(enc, bqs, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((qd + 255l) / 256l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
+def private pf_enc_dn_ba(enc : MetalComputeEncoder?; bw : MetalBuffer?; boff : uint64; bx, by, bn, bd : MetalBuffer?; d, npos : int64) {
+    metal_set_pipeline(enc, g_pf_pso_dn_ba)
+    metal_set_buffer(enc, bw, boff, 0)   // half-scale view
+    metal_set_buffer(enc, bw, boff, 1)   // byte view — the same blob slice
+    metal_set_buffer(enc, bx, 0ul, 2)
+    metal_set_buffer(enc, by, 0ul, 3)
+    metal_set_buffer(enc, bn, 0ul, 4)
+    metal_set_buffer(enc, bd, 0ul, 5)
+    metal_dispatch_threadgroups(enc, uint3(uint((d + 7l) / 8l), uint(npos), 1u), uint3(256u, 1u, 1u))
+}
+
 def private pf_enc_ew2(enc : MetalComputeEncoder?; pso : MetalComputePipeline?; ba, bb, btot : MetalBuffer?; total : int64; bascale : MetalBuffer? = null) {
     metal_set_pipeline(enc, pso)
     metal_set_buffer(enc, ba, 0ul, 0)
@@ -4849,7 +5047,25 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let hidden = layer_hidden(t, 0l)
     let kv_mul = n_heads / c.n_kv_heads
     let scale = c.attn_scale > 0.0 ? c.attn_scale : 1.0 / sqrt(float(head_size))
-    let half = head_size / 2l
+    let half = (c.rope_dim > 0l ? c.rope_dim : head_size) / 2l   // partial rope: table rows are rope_dim/2 wide
+    // deltanet (Wave D): the recurrent-state mirror must be resident/synced BEFORE encoding —
+    // prepare zeroes at pos 0 or syncs a CPU prefix; a cold mid-stream window has no repair path
+    let dn = c.recr_mask != 0ul
+    var bdn_state : MetalBuffer?
+    var dn_conv_base = 0ul
+    if (dn) {
+        if (!metal_common_init()) {   // the mirror allocates on the shared decode-side device
+            decline(MetalPrefillDecline.device)
+            return false
+        }
+        var dm = dn_mirror_prepare(s, start_pos)
+        if (!dm.ok) {
+            decline(MetalPrefillDecline.dn_state)
+            return false
+        }
+        bdn_state = dm.buf
+        dn_conv_base = dm.conv_off
+    }
     // the two-class attention geometry (gemma4): the config fields describe the GLOBAL class,
     // the _sw twins the SLIDING class (the loader guarantees at most two) — buffers size to the
     // class maxima and each layer binds its class's uniform set
@@ -4910,6 +5126,22 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var bmg2 = moe ? pool_acquire(g_pf_pool, g_pf_dev, bytes_mg) : null
     var bmdn = moe ? pool_acquire(g_pf_pool, g_pf_dev, bytes_mdn) : null
     var bmg4rt = g4moe ? pool_acquire(g_pf_pool, g_pf_dev, bytes_x) : null
+    // deltanet scratch (recurrent layers) — GEMM outputs pad to mp rows like every panel
+    let cd_dn = dn ? dn_conv_dim(c) : 0l
+    let di_dn = dn ? c.ssm_d_inner : 0l
+    let nvh_dn = dn ? c.ssm_dt_rank : 0l
+    let bytes_dn_cd = uint64(mp * cd_dn * 4l)
+    let bytes_dn_di = uint64(mp * di_dn * 4l)
+    let bytes_dn_h = uint64(mp * nvh_dn * 4l)
+    let bytes_dn_qg = uint64(mp * 2l * qd * 4l)
+    var bdnqkv = dn ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_cd) : null
+    var bdncv = dn ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_cd) : null
+    var bdnz = dn ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_di) : null
+    var bdno = dn ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_di) : null
+    var bdnb = dn ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_h) : null
+    var bdng = dn ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_h) : null
+    var bdnqg = c.q_gated ? pool_acquire(g_pf_pool, g_pf_dev, bytes_dn_qg) : null
+    var bdngate = c.q_gated ? pool_acquire(g_pf_pool, g_pf_dev, bytes_q) : null
     var batt = pool_acquire(g_pf_pool, g_pf_dev, bytes_att)
     var bcos = pool_acquire_untracked(g_pf_upool, g_pf_dev, bytes_tab)
     var bsin = pool_acquire_untracked(g_pf_upool, g_pf_dev, bytes_tab)
@@ -4920,7 +5152,13 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var bvs : array<MetalBuffer?>
     bks |> reserve(int(c.n_layers))
     bvs |> reserve(int(c.n_layers))
+    var no_panel : MetalBuffer?   // recurrent layers' null K/V slot
     for (l in range64(c.n_layers)) {
+        if (layer_kv_dim(c, l) == 0l) {   // recurrent layer (deltanet): no K/V at all
+            bks |> push(no_panel)
+            bvs |> push(no_panel)
+            continue
+        }
         let bytes_kv_l = uint64(kvrows * layer_kv_dim(c, l) * 4l)   // per-layer panels: each class's width
         bks |> push(pool_acquire(g_pf_pool, g_pf_dev, bytes_kv_l))
         bvs |> push(pool_acquire(g_pf_pool, g_pf_dev, bytes_kv_l))
@@ -4945,6 +5183,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             let runsg = addr < KVRun const? >(s.kv_runs[0])
             let sgp = (s.kv_dtype_k == KVDtype.tq4 || s.kv_dtype_v == KVDtype.tq4) ? addr < float const? >(s.kv_signs[0]) : null
             for (l in range64(c.n_layers)) {
+                if (bks[l] == null) {   // recurrent layer — no rows to gather
+                    continue
+                }
                 var kdst = reinterpret<float?>(metal_buffer_contents(bks[l]))
                 var vdst = reinterpret<float?>(metal_buffer_contents(bvs[l]))
                 let kcp = kv_layer_kbase(s, l, c.seq_len)
@@ -5006,6 +5247,19 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var u_softcap = pf_uniform_f32(c.attn_logit_softcap)
     var u_win0 = pf_uniform_u32(0u)          // global layers' window bind
     var u_winsl = c.sliding_window > 0l ? pf_uniform_u32(uint(c.sliding_window)) : null
+    // deltanet + gated-attention uniforms (Wave D)
+    var u_dn_cd = dn ? pf_uniform_u32(uint(cd_dn)) : null
+    var u_dn_di = dn ? pf_uniform_u32(uint(di_dn)) : null
+    var u_dn_nvh = dn ? pf_uniform_u32(uint(nvh_dn)) : null
+    var u_dn_kd = dn ? pf_uniform_u32(uint(dn_key_dim(c))) : null
+    var u_dn_ds = dn ? pf_uniform_u32(uint(c.ssm_d_state)) : null
+    var u_dn_nkh = dn ? pf_uniform_u32(uint(c.ssm_n_group)) : null
+    var u_dn_dconv = dn ? pf_uniform_u32(uint(c.ssm_d_conv)) : null
+    var u_dn_np = dn ? pf_uniform_u32(uint(npos)) : null
+    var u_dn_qscale = dn ? pf_uniform_f32(1.0 / sqrt(float(c.ssm_d_state))) : null
+    var u_dn_qd2 = c.q_gated ? pf_uniform_u32(uint(2l * qd)) : null
+    var u_qtot = c.q_gated ? pf_uniform_u32(uint(npos * qd)) : null
+    var u_rot = (c.rope_dim > 0l && c.rope_dim != head_size) ? pf_uniform_u32(uint(c.rope_dim)) : null
     // the SLIDING-class uniform twins (hetero models — uniform models leave these null and
     // every layer binds the base set)
     var u_qd_sw = hetero ? pf_uniform_u32(uint(qd_sw)) : null
@@ -5065,6 +5319,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     cbs |> reserve(int(ncb))
     var cb : MetalCommandBuffer?
     var enc : MetalComputeEncoder?
+    var dnli = 0l   // recurrent-layer index — addresses the dn state/conv mirror slices in order
     {
         for (l in range64(c.n_layers)) {
             if (l % layers_per_cb == 0l) {
@@ -5096,20 +5351,63 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 var u_npairs_q_l = het ? u_npairs_q_sw : u_npairs_q
                 var u_npairs_k_l = het ? u_npairs_k_sw : u_npairs_k
                 let has_wv = t.wv_offs[l] >= 0l
+                let recr = layer_is_recurrent(c, l)
                 // attention: [pending W2 residual +] norm -> [requant ->] Q/K/V -> rope ->
                 // scores+softmax -> P.V -> out-proj (fused path folds each residual add into the
                 // FOLLOWING add+rms+quant; the lcpp path feeds normed f32 rows straight to mul_mm)
                 if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     pf_enc_rms(enc, bx, bw_att, bxb, u_dim, u_eps, npos)
                 }
-                if (g_pf_skip != "gemm") {
+                if (recr) {
+                    // deltanet layer (Wave D): batched projections -> conv+SiLU -> q/k L2 -> fused
+                    // sequential scan (state walks the whole window in-kernel) -> gated out-norm -> out-proj
+                    if (g_pf_skip != "gemm") {
+                        let bwqkv = pf_blob_of(t, t.dnqkv_offs[l])
+                        enc_gemm_mm(enc, bwqkv.buf, bwqkv.boff, bxb, bdnqkv, u_dim, u_dn_cd, mp, cd_dn)
+                        let bwz = pf_blob_of(t, t.dngate_offs[l])
+                        enc_gemm_mm(enc, bwz.buf, bwz.boff, bxb, bdnz, u_dim, u_dn_di, mp, di_dn)
+                        let bwb = pf_blob_of(t, t.dnbeta_offs[l])
+                        pf_enc_dn_ba(enc, bwb.buf, bwb.boff, bxb, bdnb, u_dim, u_dn_nvh, nvh_dn, npos)
+                        let bwa = pf_blob_of(t, t.dnalpha_offs[l])
+                        pf_enc_dn_ba(enc, bwa.buf, bwa.boff, bxb, bdng, u_dim, u_dn_nvh, nvh_dn, npos)
+                    }
+                    if (g_pf_skip != "attn" && g_pf_skip != "nongemm") {
+                        let soff = uint64(dnli * nvh_dn * c.ssm_d_state * c.ssm_d_state * 4l)
+                        let hoff = dn_conv_base + uint64(dnli * (c.ssm_d_conv - 1l) * cd_dn * 4l)
+                        var bw_cv = pf_upload_region(addr < void? >(t.fblob[t.dn_conv_off + l * c.ssm_d_conv * cd_dn]), uint64(c.ssm_d_conv * cd_dn * 4l))
+                        pf_enc_dn_conv(enc, bdnqkv, bdn_state, hoff, bw_cv, bdncv, u_dn_cd, u_dn_dconv, u_dn_np, cd_dn, npos)
+                        pf_enc_dn_conv_hist(enc, bdnqkv, bdn_state, hoff, u_dn_cd, u_dn_dconv, u_dn_np, cd_dn)
+                        pf_enc_dn_l2norm(enc, bdncv, u_dn_cd, u_dn_kd, u_dn_ds, u_eps, u_dn_qscale, 2l * c.ssm_n_group, npos)
+                        var baa = pf_upload_region(addr < void? >(t.fblob[t.dn_a_off + l * nvh_dn]), uint64(nvh_dn * 4l))
+                        var bdt = pf_upload_region(addr < void? >(t.fblob[t.dn_dt_off + l * nvh_dn]), uint64(nvh_dn * 4l))
+                        pf_enc_dn_scan(enc, bdncv, bdn_state, soff, bdnb, bdng, baa, bdt, bdno,
+                            u_dn_cd, u_dn_kd, u_dn_ds, u_dn_nvh, u_dn_nkh, u_dn_di, u_dn_np, c.ssm_d_state, nvh_dn)
+                        var bwn = pf_upload_region(addr < void? >(t.fblob[t.dn_norm_off + l * c.ssm_d_state]), uint64(c.ssm_d_state * 4l))
+                        pf_enc_dn_gate(enc, bdno, bdnz, bwn, u_dn_ds, u_dn_di, u_eps, nvh_dn, npos)
+                    }
+                    if (g_pf_skip != "gemm") {
+                        let bwo = pf_blob_of(t, t.dnout_offs[l])
+                        enc_gemm_mm(enc, bwo.buf, bwo.boff, bdno, bxb2, u_dn_di, u_dim, mp, dim)
+                    }
+                    dnli++
+                }
+                if (!recr && g_pf_skip != "gemm") {
                     // K-quant tensors take their mul_mm twins per tensor (the gate pins the
                     // mm shape for kquant loads); q8-tagged tensors keep the blob path
                     let fq = pf_fmt_at(t.wq_fmt, l)
                     let fk = pf_fmt_at(t.wk_fmt, l)
                     let fv = has_wv ? pf_fmt_at(t.wv_fmt, l) : KqFmt.q8
                     if (fq != KqFmt.q8 || fk != KqFmt.q8 || fv != KqFmt.q8) {
-                        if (fq != KqFmt.q8) {
+                        if (c.q_gated) {
+                            // 2x-wide packed [q|gate] projection, deinterleaved into the q panel + gate rows
+                            if (fq != KqFmt.q8) {
+                                pf_enc_kq_site_mm(enc, t, fq, t.wq_offs[l], 2l * qd_l, bxb, bdnqg, u_dim, u_dn_qd2, mp)
+                            } else {
+                                let bwqb = pf_blob_of(t, t.wq_offs[l])
+                                enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l)
+                            }
+                            pf_enc_dn_deint(enc, bdnqg, bq, bdngate, u_hs_l, u_qd_l, u_qd_l, qd_l, npos)
+                        } elif (fq != KqFmt.q8) {
                             pf_enc_kq_site_mm(enc, t, fq, t.wq_offs[l], qd_l, bxb, bq, u_dim, u_qd_l, mp)
                         } else {
                             let bwqb = pf_blob_of(t, t.wq_offs[l])
@@ -5132,7 +5430,13 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     } else {
                         let bwqb = pf_blob_of(t, t.wq_offs[l])
                         let bwkb = pf_blob_of(t, t.wk_offs[l])
-                        enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l)
+                        if (c.q_gated) {
+                            // 2x-wide packed [q|gate] projection, deinterleaved into the q panel + gate rows
+                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l)
+                            pf_enc_dn_deint(enc, bdnqg, bq, bdngate, u_hs_l, u_qd_l, u_qd_l, qd_l, npos)
+                        } else {
+                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l)
+                        }
                         enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
                         if (has_wv) {
                             let bwvb = pf_blob_of(t, t.wv_offs[l])
@@ -5140,7 +5444,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         }
                     }
                 }
-                if ((!has_wv || c.v_norm) && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                if (!recr && (!has_wv || c.v_norm) && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // gemma4 V: no-wv layers copy the PRE-norm/PRE-rope K panel rows into the V
                     // panel; v_norm then runs the weightless per-head RMS (ones plane) in place —
                     // the CPU mm_qkv order exactly, BEFORE qk_norm touches k
@@ -5159,7 +5463,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             u_zero, kvd_l / hs_l, npos, hs_l, koff)
                     }
                 }
-                if (has_bias && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                if (!recr && has_bias && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // QKV bias before rope — chunk rows only (existing rows stored biased+roped).
                     // Per-layer widths for the offsets; the count uniforms stay base-class (no
                     // hetero model carries QKV bias — the CPU bias-plane layout is uniform too)
@@ -5170,7 +5474,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     enc_add_bias_rows(enc, bks[l], bbk, u_kvd, u_totkv, npos * kv_dim, koff)
                     enc_add_bias_rows(enc, bvs[l], bbv, u_kvd, u_totkv, npos * kv_dim, koff)
                 }
-                if (has_qkn && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                if (!recr && has_qkn && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // per-head QK-norm before rope — the chunk's q panel and its new K rows
                     var bqw = pf_upload_region(addr < void? >(t.fblob[t.rms_q_offs[l]]), uint64(hs_l * 4l))
                     var bkw = pf_upload_region(addr < void? >(t.fblob[t.rms_k_offs[l]]), uint64(hs_l * 4l))
@@ -5178,15 +5482,15 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     enc_qk_norm_pf(enc, bks[l], bkw, u_zero, u_zero, u_kvd_l, u_hs_l, u_zero, u_eps,
                         u_zero, kvd_l / hs_l, npos, hs_l, koff)
                 }
-                if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                if (!recr && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // sliding layers rope with the swa row pair (dual-rope configs — gemma3/4;
                     // hetero: the swa pair's rows are hs_sw/2 wide — the class's own width)
                     var bcos_l = lsl && dual_rope ? bcos_swa : bcos
                     var bsin_l = lsl && dual_rope ? bsin_swa : bsin
-                    enc_rope(enc, bq, bcos_l, bsin_l, u_qd_l, u_hs_l, u_npairs_q_l, u_neox, npos * qd_l / 2l)
-                    enc_rope(enc, bks[l], bcos_l, bsin_l, u_kvd_l, u_hs_l, u_npairs_k_l, u_neox, npos * kvd_l / 2l, koff)
+                    enc_rope(enc, bq, bcos_l, bsin_l, u_qd_l, u_hs_l, u_npairs_q_l, u_neox, npos * qd_l / 2l, [brot = u_rot])
+                    enc_rope(enc, bks[l], bcos_l, bsin_l, u_kvd_l, u_hs_l, u_npairs_k_l, u_neox, npos * kvd_l / 2l, koff, [brot = u_rot])
                 }
-                if (g_pf_skip != "attn" && g_pf_skip != "nongemm") {
+                if (!recr && g_pf_skip != "attn" && g_pf_skip != "nongemm") {
                     // sliding layers bind the span — the QK forms skip fully-below-window blocks,
                     // the softmax masks + zeroes the below-window prefix; global layers bind 0
                     var bwin = lsl && u_winsl != null ? u_winsl : u_win0
@@ -5212,7 +5516,11 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         }
                     }
                 }
-                if (g_pf_skip != "gemm") {
+                if (!recr && c.q_gated && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                    // gated-attention epilogue: out ⊙ σ(gate) between the attention output and wo (the CPU order)
+                    pf_enc_ew2(enc, g_pf_pso_sigmul, bxb, bdngate, u_qtot, npos * qd)
+                }
+                if (!recr && g_pf_skip != "gemm") {
                     let fo = pf_fmt_at(t.wo_fmt, l)
                     if (fo != KqFmt.q8) {
                         pf_enc_kq_site_mm(enc, t, fo, t.wo_offs[l], dim, bxb, bxb2, u_qd_l, u_dim, mp)
@@ -5425,6 +5733,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 let ts_rb = ref_time_ticks()
                 let l1 = min(int64(i + 1) * layers_per_cb, c.n_layers)
                 for (l in range64(int64(i) * layers_per_cb, l1)) {
+                    if (bks[l] == null) {   // recurrent layer — no K/V rows to store
+                        continue
+                    }
                     // the chunk's rows sit past a continuation's gathered panel head
                     var kpan = reinterpret<uint8?>(metal_buffer_contents(bks[l]))
                     var vpan = reinterpret<uint8?>(metal_buffer_contents(bvs[l]))
@@ -5460,6 +5771,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let encwait_us = get_time_usec(ts_enc)
     let ok = ran
     if (ran) {
+        if (dn) {   // the window completed — the GPU state now holds position start_pos+npos-1's update
+            dn_mirror_advance(s.uid, start_pos + npos - 1l)
+        }
         let ts_rb = ref_time_ticks()
         unsafe {
             memcpy(addr < void? >(s.x_b[0]), metal_buffer_contents(bx), int(npos * dim * 4l))
@@ -5497,6 +5811,32 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             pool_release(g_pf_pool, bmg4rt, bytes_x)
         }
     }
+    if (dn) {
+        pool_release(g_pf_pool, bdnqkv, bytes_dn_cd)
+        pool_release(g_pf_pool, bdncv, bytes_dn_cd)
+        pool_release(g_pf_pool, bdnz, bytes_dn_di)
+        pool_release(g_pf_pool, bdno, bytes_dn_di)
+        pool_release(g_pf_pool, bdnb, bytes_dn_h)
+        pool_release(g_pf_pool, bdng, bytes_dn_h)
+        pool_release(g_pf_upool, u_dn_cd, 4ul)
+        pool_release(g_pf_upool, u_dn_di, 4ul)
+        pool_release(g_pf_upool, u_dn_nvh, 4ul)
+        pool_release(g_pf_upool, u_dn_kd, 4ul)
+        pool_release(g_pf_upool, u_dn_ds, 4ul)
+        pool_release(g_pf_upool, u_dn_nkh, 4ul)
+        pool_release(g_pf_upool, u_dn_dconv, 4ul)
+        pool_release(g_pf_upool, u_dn_np, 4ul)
+        pool_release(g_pf_upool, u_dn_qscale, 4ul)
+    }
+    if (c.q_gated) {
+        pool_release(g_pf_pool, bdnqg, bytes_dn_qg)
+        pool_release(g_pf_pool, bdngate, bytes_q)
+        pool_release(g_pf_upool, u_dn_qd2, 4ul)
+        pool_release(g_pf_upool, u_qtot, 4ul)
+    }
+    if (u_rot != null) {
+        pool_release(g_pf_upool, u_rot, 4ul)
+    }
     pool_release(g_pf_pool, batt, bytes_att)
     if (gpu_logits) {
         pool_release(g_pf_pool, bxf, uint64(dim * 4l))
@@ -5510,6 +5850,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     }
     pool_release(g_pf_upool, bsin, bytes_tab)
     for (l in range64(c.n_layers)) {
+        if (bks[l] == null) {
+            continue
+        }
         let bytes_kv_l = uint64(kvrows * layer_kv_dim(c, l) * 4l)
         pool_release(g_pf_pool, bks[l], bytes_kv_l)
         pool_release(g_pf_pool, bvs[l], bytes_kv_l)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -577,7 +577,7 @@ class MetalMoeSelect {
     @ssbo @binding = 2 selw : array<float>   // the same buffer, float view — w of stream s at s*2k + k
     @uniform @binding = 3 ne : uint
     @uniform @binding = 4 nk : uint
-    @uniform @binding = 5 gmode : uint       // 0 = softmax + norm_topk; 1 = softmax_weight (gpt-oss)
+    @uniform @binding = 5 gmode : uint       // 0 = softmax + norm_topk; 1 = softmax_weight (gpt-oss); 2 = softmax, no renorm (qwen2moe)
 
     [metal_kernel(name="metal_moe_select_msl")]
     def metal_moe_select {
@@ -590,9 +590,9 @@ class MetalMoeSelect {
             let j = lane + uint(t) * 32u
             v[t] = j < ne ? lg[lg0 + j] : -3.0e38
         }
-        // gmode 0: softmax over all ne (the CPU order: max, exp with the -80 floor, sum,
+        // gmode 0/2: softmax over all ne (the CPU order: max, exp with the -80 floor, sum,
         // divide-all); gmode 1 (gpt-oss softmax_weight) selects on the RAW logits instead
-        if (gmode == 0u) {
+        if (gmode != 1u) {
             var mx = v[0]
             for [unroll_full] (t in range(8)) {
                 mx = max(mx, v[t])
@@ -670,8 +670,9 @@ class MetalMoeSelect {
                     i++
                 }
             }
-        } else {
-            // norm_topk renorm to sum 1 (the CPU f16-min clamp)
+        } elif (gmode == 0u) {
+            // norm_topk renorm to sum 1 (the CPU f16-min clamp); gmode 2 (qwen2moe) keeps
+            // the softmax weights as selected — no renorm
             ws = max(ws, 6.103515625e-5)
             if (lane == 0u) {
                 var i = 0u
@@ -3925,6 +3926,25 @@ class MetalSigmul {
     }
 }
 
+// Shared-expert combine (qwen35moe): y += x ⊙ σ(g[row]) — one raw gate dot per position
+// (decode total = dim; prefill total = npos x dim, row = the position).
+class MetalAxpySig {
+    @ssbo @binding = 0 y : array<float>
+    @ssbo @binding = 1 x : array<float>
+    @ssbo @binding = 2 g : array<float>     // per-position raw gate dots (σ applied here)
+    @uniform @binding = 3 total : uint      // grid guard
+    @uniform @binding = 4 dim : uint
+
+    [metal_kernel(name="metal_axpy_sig_msl")]
+    def metal_axpy_sig {
+        let gid = gl_GlobalInvocationID.x
+        if (gid >= total) {
+            return
+        }
+        y[gid] += x[gid] / (1.0 + exp(-g[gid / dim]))
+    }
+}
+
 // Batched narrow q8 GEMV for the β/α projections (d = dt_rank, 16..64 — under every GEMM
 // N tile): one simdgroup per (output row, position), the MetalQ8Gemv stream walk per row.
 class MetalDnBa {
@@ -4011,6 +4031,7 @@ var private g_pf_pso_dn_gate : MetalComputePipeline?
 var private g_pf_pso_dn_deint : MetalComputePipeline?
 var private g_pf_pso_dn_ba : MetalComputePipeline?
 var private g_pf_pso_sigmul : MetalComputePipeline?
+var private g_pf_pso_axpy_sig : MetalComputePipeline?   // shexp combine (Wave D stage 3)
 var private g_pso_gemm : MetalComputePipeline?
 var private g_pso_gemm64 : MetalComputePipeline?
 var private g_pf_pso_rms : MetalComputePipeline?
@@ -4169,6 +4190,10 @@ def public metal_prefill_shutdown {
     if (g_pf_pso_sigmul != null) {
         metal_release(g_pf_pso_sigmul)
         g_pf_pso_sigmul = null
+    }
+    if (g_pf_pso_axpy_sig != null) {
+        metal_release(g_pf_pso_axpy_sig)
+        g_pf_pso_axpy_sig = null
     }
     if (g_pso_addbias != null) {
         metal_release(g_pso_addbias)
@@ -4368,6 +4393,7 @@ def private metal_prefill_init : bool {
     g_pf_pso_dn_deint = pf_compile_pso(metal_dn_deint_msl, metal_dn_deint_msl_entry, metal_dn_deint_msl_fastmath, ok)
     g_pf_pso_dn_ba = pf_compile_pso(metal_dn_ba_msl, metal_dn_ba_msl_entry, metal_dn_ba_msl_fastmath, ok)
     g_pf_pso_sigmul = pf_compile_pso(metal_sigmul_msl, metal_sigmul_msl_entry, metal_sigmul_msl_fastmath, ok)
+    g_pf_pso_axpy_sig = pf_compile_pso(metal_axpy_sig_msl, metal_axpy_sig_msl_entry, metal_axpy_sig_msl_fastmath, ok)
     g_pf_e8m0_tab = metal_new_buffer(g_pf_dev, 1024ul)
     unsafe {
         var ep = reinterpret<uint?>(metal_buffer_contents(g_pf_e8m0_tab))
@@ -4993,6 +5019,32 @@ def private pf_enc_dn_ba(enc : MetalComputeEncoder?; bw : MetalBuffer?; boff : u
     metal_dispatch_threadgroups(enc, uint3(uint((d + 7l) / 8l), uint(npos), 1u), uint3(256u, 1u, 1u))
 }
 
+// batched f32-slab GEMV riding MetalMoeRouterB: d rows per position (dn_ba_f32 β/α d = dt_rank;
+// the shexp gate d = 1); y[p*d + row] — the pf_enc_dn_ba layout
+def private pf_enc_slab_gemv_b(enc : MetalComputeEncoder?; bw, bx, by, bn, bd, bnp : MetalBuffer?; d, npos : int64) {
+    metal_set_pipeline(enc, g_pf_pso_moe_router_b)
+    metal_set_buffer(enc, bw, 0ul, 0)
+    metal_set_buffer(enc, bx, 0ul, 1)
+    metal_set_buffer(enc, by, 0ul, 2)
+    metal_set_buffer(enc, bn, 0ul, 3)
+    metal_set_buffer(enc, bd, 0ul, 4)
+    metal_set_buffer(enc, bn, 0ul, 5)   // per-position x stride = dim
+    metal_set_buffer(enc, g_pf_one, 0ul, 6)
+    metal_set_buffer(enc, g_pf_zero, 0ul, 7)
+    metal_set_buffer(enc, bnp, 0ul, 8)
+    metal_dispatch_threadgroups(enc, uint3(uint((d + 3l) / 4l), uint((npos + 7l) / 8l), 1u), uint3(128u, 1u, 1u))
+}
+
+def private pf_enc_axpy_sig(enc : MetalComputeEncoder?; by, bx, bg, btot, bdim : MetalBuffer?; total : int64) {
+    metal_set_pipeline(enc, g_pf_pso_axpy_sig)
+    metal_set_buffer(enc, by, 0ul, 0)
+    metal_set_buffer(enc, bx, 0ul, 1)
+    metal_set_buffer(enc, bg, 0ul, 2)
+    metal_set_buffer(enc, btot, 0ul, 3)
+    metal_set_buffer(enc, bdim, 0ul, 4)
+    metal_dispatch_threadgroups(enc, uint3(uint((total + 255l) / 256l), 1u, 1u), uint3(256u, 1u, 1u))
+}
+
 def private pf_enc_ew2(enc : MetalComputeEncoder?; pso : MetalComputePipeline?; ba, bb, btot : MetalBuffer?; total : int64; bascale : MetalBuffer? = null) {
     metal_set_pipeline(enc, pso)
     metal_set_buffer(enc, ba, 0ul, 0)
@@ -5092,7 +5144,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let bytes_x = uint64(mp * dim * 4l)
     let bytes_xb = uint64(mp * max(dim, qd_mx) * 4l)   // dim-wide norm outs AND the qd-wide AV out
     let bytes_q = uint64(mp * qd_mx * 4l)
-    let bytes_h = uint64(mp * hidden * 4l)
+    let nsh = !t.blocks.ffn_is_dense ? c.n_ff_shexp : 0l   // shared expert (qwen35moe) rides bhb/bhb2
+    let bytes_h = uint64(mp * max(hidden, nsh) * 4l)
     let bytes_att = uint64(n_heads * mp * nk64 * 4l)   // per-head score slabs: mp queries x nk64 keys
     let bytes_tab = uint64(npos * half * 4l)
     let bytes_tab_sw = uint64(npos * half_sw * 4l)   // the swa pair's row width is ITS class's hs/2
@@ -5240,7 +5293,11 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var u_moe_g1 = moe ? pf_uniform_u32(1u) : null
     var u_moe_ptot = moe ? pf_uniform_u32(uint(mpad * c.n_ff_exp)) : null
     var u_moe_invd = g4moe ? pf_uniform_f32(1.0 / sqrt(float(dim))) : null
-    var u_moe_gmode = moe ? pf_uniform_u32(c.moe_gate == MoeGate.softmax_weight ? 1u : 0u) : null
+    var u_moe_gmode = moe ? pf_uniform_u32(c.moe_gate == MoeGate.softmax_weight ? 1u : (c.norm_topk_prob ? 0u : 2u)) : null
+    // shared expert (qwen35moe): nsh width + npos*nsh act span + the gate GEMV's 1-row bound
+    var u_moe_nsh = nsh > 0l ? pf_uniform_u32(uint(nsh)) : null
+    var u_moe_shtot = nsh > 0l ? pf_uniform_u32(uint(npos * nsh)) : null
+    var u_moe_one = nsh > 0l ? pf_uniform_u32(1u) : null
     var u_hass = c.attn_sinks ? pf_uniform_u32(1u) : null
     var u_scale = pf_uniform_f32(scale)
     var u_eps = pf_uniform_f32(c.norm_eps)
@@ -5366,10 +5423,18 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         enc_gemm_mm(enc, bwqkv.buf, bwqkv.boff, bxb, bdnqkv, u_dim, u_dn_cd, mp, cd_dn)
                         let bwz = pf_blob_of(t, t.dngate_offs[l])
                         enc_gemm_mm(enc, bwz.buf, bwz.boff, bxb, bdnz, u_dim, u_dn_di, mp, di_dn)
-                        let bwb = pf_blob_of(t, t.dnbeta_offs[l])
-                        pf_enc_dn_ba(enc, bwb.buf, bwb.boff, bxb, bdnb, u_dim, u_dn_nvh, nvh_dn, npos)
-                        let bwa = pf_blob_of(t, t.dnalpha_offs[l])
-                        pf_enc_dn_ba(enc, bwa.buf, bwa.boff, bxb, bdng, u_dim, u_dn_nvh, nvh_dn, npos)
+                        if (t.dn_ba_f32) {
+                            // F32-on-disk β/α (35B): fblob slabs ride the router-b f32 GEMV
+                            var bw_bt = pf_upload_region(addr < void? >(t.fblob[t.dn_betaf_off + l * dim * nvh_dn]), uint64(dim * nvh_dn * 4l))
+                            pf_enc_slab_gemv_b(enc, bw_bt, bxb, bdnb, u_dim, u_dn_nvh, u_dn_np, nvh_dn, npos)
+                            var bw_al = pf_upload_region(addr < void? >(t.fblob[t.dn_alphaf_off + l * dim * nvh_dn]), uint64(dim * nvh_dn * 4l))
+                            pf_enc_slab_gemv_b(enc, bw_al, bxb, bdng, u_dim, u_dn_nvh, u_dn_np, nvh_dn, npos)
+                        } else {
+                            let bwb = pf_blob_of(t, t.dnbeta_offs[l])
+                            pf_enc_dn_ba(enc, bwb.buf, bwb.boff, bxb, bdnb, u_dim, u_dn_nvh, nvh_dn, npos)
+                            let bwa = pf_blob_of(t, t.dnalpha_offs[l])
+                            pf_enc_dn_ba(enc, bwa.buf, bwa.boff, bxb, bdng, u_dim, u_dn_nvh, nvh_dn, npos)
+                        }
                     }
                     if (g_pf_skip != "attn" && g_pf_skip != "nongemm") {
                         let soff = uint64(dnli * nvh_dn * c.ssm_d_state * c.ssm_d_state * 4l)
@@ -5568,6 +5633,11 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         var bw_ds = pf_upload_region(unsafe(addr < void? >(t.fblob[t.moe_down_scale_off + l * c.n_expert])), uint64(c.n_expert * 4l))
                         pf_enc_moe_wscale(enc, bmsel, bw_ds, u_moe_nk, npos)
                     }
+                    if (nsh > 0l) {
+                        // shexp raw gate dots (σ in the combine) — bmlg is free once select consumed it
+                        var bw_shg = pf_upload_region(unsafe(addr < void? >(t.fblob[t.shexp_gate_off + l * dim])), uint64(dim * 4l))
+                        pf_enc_slab_gemv_b(enc, bw_shg, bxb, bmlg, u_dim, u_moe_one, u_moe_np, 1l, npos)
+                    }
                     if (!pf_skip_moe_mm()) {
                         if (t.experts_mx4) {
                             var bwb1 = pf_upload_region(unsafe(addr < void? >(t.fblob[t.web1_off + l * c.n_expert * c.n_ff_exp])), uint64(c.n_expert * c.n_ff_exp * 4l))
@@ -5584,11 +5654,21 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             pf_enc_moe_mm(enc, t, fe3, t.we3_offs[l], c.n_ff_exp, npos, g4moe ? bxb2 : bxb, bmg2,
                                 u_dim, u_moe_nfe, bmcnt, bmbase, bmbkt, fe3 == KqFmt.q8 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g1)
                         }
+                        if (nsh > 0l) {
+                            // shexp gate/up: dense q8 mul_mm at the wsh planes (bhb/bhb2 sized max(hidden, nsh))
+                            let bwsh1 = pf_blob_of(t, t.wsh1_off + l * dim * nsh)
+                            enc_gemm_mm(enc, bwsh1.buf, bwsh1.boff, bxb, bhb, u_dim, u_moe_nsh, mp, nsh)
+                            let bwsh3 = pf_blob_of(t, t.wsh3_off + l * dim * nsh)
+                            enc_gemm_mm(enc, bwsh3.buf, bwsh3.boff, bxb, bhb2, u_dim, u_moe_nsh, mp, nsh)
+                        }
                     }
                 }
                 if (moe && g_pf_skip != "ew" && g_pf_skip != "nongemm" && g_pf_skip != "moe" && !pf_skip_moe_act()) {
                     let pso_act = c.ffn_act == FfnAct.swiglu_oai ? g_pf_pso_swiglu_oai : (g4moe ? g_pf_pso_geglu : g_pf_pso_swiglu)
                     pf_enc_ew2(enc, pso_act, bmg, bmg2, u_moe_ptot, mpad * c.n_ff_exp)
+                    if (nsh > 0l) {
+                        pf_enc_ew2(enc, g_pf_pso_swiglu, bhb, bhb2, u_moe_shtot, npos * nsh)
+                    }
                 }
                 if (moe && g_pf_skip != "gemm" && g_pf_skip != "moe") {
                     let fe2 = pf_fmt_at(t.we2_fmt, l)
@@ -5602,9 +5682,18 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             pf_enc_moe_mm(enc, t, fe2, t.we2_offs[l], dim, npos, bmg, bmdn,
                                 u_moe_nfe, u_dim, bmcnt, bmbase, bmbkt, fe2 == KqFmt.q8 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g0)
                         }
+                        if (nsh > 0l) {
+                            // shexp down into bxb2 (free post-residual) — bxb still feeds the reduce
+                            let bwsh2 = pf_blob_of(t, t.wsh2_off + l * dim * nsh)
+                            enc_gemm_mm(enc, bwsh2.buf, bwsh2.boff, bhb, bxb2, u_moe_nsh, u_dim, mp, dim)
+                        }
                     }
                     if (!pf_skip_moe_reduce()) {
                         pf_enc_moe_reduce(enc, bmdn, bmsel, bminv, g4moe ? bmg4rt : bxb, u_dim, u_moe_nk, dim, npos)
+                        if (nsh > 0l) {
+                            // routed sum lands in bxb first — the shexp branch adds σ(gate)-scaled on top
+                            pf_enc_axpy_sig(enc, bxb, bxb2, bmlg, u_total_dim, u_dim, npos * dim)
+                        }
                     }
                     if (g4moe && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                         var bw_pf2 = pf_upload_region(unsafe(addr < void? >(t.fblob[t.rms_post_ffn2_off + l * dim])), uint64(dim * 4l))
@@ -5922,6 +6011,11 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             pool_release(g_pf_upool, u_moe_invd, 4ul)
         }
         pool_release(g_pf_upool, u_moe_gmode, 4ul)
+        if (nsh > 0l) {
+            pool_release(g_pf_upool, u_moe_nsh, 4ul)
+            pool_release(g_pf_upool, u_moe_shtot, 4ul)
+            pool_release(g_pf_upool, u_moe_one, 4ul)
+        }
     }
     if (u_hass != null) {
         pool_release(g_pf_upool, u_hass, 4ul)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -3017,6 +3017,7 @@ class MetalRope {
     @uniform @binding = 4 head_size : uint
     @uniform @binding = 5 npairs : uint     // ntok * n/2 — grid guard
     @uniform @binding = 6 neox : uint       // pair (j, j+half) instead of (2j, 2j+1); same table row j
+    @uniform @binding = 7 rot : uint        // partial rotary width; == head_size for full (table rows rot/2 wide)
 
     [metal_kernel(name="metal_rope_msl")]
     def metal_rope {
@@ -3028,12 +3029,16 @@ class MetalRope {
         let p = gid / pairs_per_row
         let rem = gid % pairs_per_row
         let half = head_size / 2u
+        let halfr = rot / 2u
         let h = rem / half
         let j = rem % half
-        let i = p * n + h * head_size + (neox != 0u ? j : 2u * j)
-        let i2 = neox != 0u ? i + half : i + 1u
-        let fcr = tcos[p * half + j]
-        let fci = tsin[p * half + j]
+        // threads j < rot/2 rotate the (j, j+rot/2) pair; the rest identity-cover [rot, hs)
+        let rotp = j < halfr
+        let hb = p * n + h * head_size
+        let i = neox != 0u ? (rotp ? hb + j : hb + rot + (j - halfr)) : hb + 2u * j
+        let i2 = neox != 0u ? (rotp ? i + halfr : i + (half - halfr)) : i + 1u
+        let fcr = rotp ? tcos[p * halfr + j] : 1.0
+        let fci = rotp ? tsin[p * halfr + j] : 0.0
         let v0 = v[i]
         let v1 = v[i2]
         v[i] = v0 * fcr - v1 * fci
@@ -4684,7 +4689,7 @@ def private enc_qk_norm_pf(enc : MetalComputeEncoder?; bx, bw, bnq, bkoffe, brst
     metal_dispatch_threadgroups(enc, uint3(uint(ntg), uint(nrows), 1u), uint3(uint(hs), 1u, 1u))
 }
 
-def private enc_rope(enc : MetalComputeEncoder?; bv, bcos, bsin, bn, bhs, bnpairs, bneox : MetalBuffer?; npairs : int64; off : uint64 = 0ul) {
+def private enc_rope(enc : MetalComputeEncoder?; bv, bcos, bsin, bn, bhs, bnpairs, bneox : MetalBuffer?; npairs : int64; off : uint64 = 0ul; brot : MetalBuffer? = null) {
     metal_set_pipeline(enc, g_pso_rope)
     metal_set_buffer(enc, bv, off, 0)
     metal_set_buffer(enc, bcos, 0ul, 1)
@@ -4693,6 +4698,7 @@ def private enc_rope(enc : MetalComputeEncoder?; bv, bcos, bsin, bn, bhs, bnpair
     metal_set_buffer(enc, bhs, 0ul, 4)
     metal_set_buffer(enc, bnpairs, 0ul, 5)
     metal_set_buffer(enc, bneox, 0ul, 6)
+    metal_set_buffer(enc, brot != null ? brot : bhs, 0ul, 7)   // rot defaults to head_size (full rope)
     metal_dispatch_threadgroups(enc, uint3(uint((npairs + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -3674,6 +3674,252 @@ class MetalSoftcapRow {
     }
 }
 
+// ===== DeltaNet (Wave D) — the qwen35 recurrent-layer chain =====
+
+// Causal depthwise conv over the fused [q;k;v] rows + SiLU (dn_conv_step's batch form): one
+// thread per (channel, position); positions reaching before the window read the channel-major
+// history taps (the CPU dn_conv_state layout). Never writes history — MetalDnConvHist advances.
+class MetalDnConv {
+    @ssbo @binding = 0 x : array<float>     // [npos x cd] fused qkv projection rows
+    @ssbo @binding = 1 hist : array<float>  // [cd x taps] channel-major history (layer slice)
+    @ssbo @binding = 2 w : array<float>     // [cd x dconv] conv taps (raw fblob layout)
+    @ssbo @binding = 3 y : array<float>     // [npos x cd] conv output, silu'd
+    @uniform @binding = 4 cd : uint
+    @uniform @binding = 5 dconv : uint
+    @uniform @binding = 6 npos : uint
+
+    [metal_kernel(name="metal_dn_conv_msl")]
+    def metal_dn_conv {
+        let ch = gl_GlobalInvocationID.x
+        let p = gl_GlobalInvocationID.y
+        if (ch >= cd) {
+            return
+        }
+        let taps = dconv - 1u
+        var acc = 0.0
+        var k = 0u
+        while (k < dconv) {
+            let sp = int(p + k) - int(taps)
+            let xv = sp >= 0 ? x[uint(sp) * cd + ch] : hist[ch * taps + (p + k)]
+            acc += xv * w[ch * dconv + k]
+            k++
+        }
+        y[p * cd + ch] = acc / (1.0 + exp(-acc))
+    }
+}
+
+// Advance the channel-major conv history past an npos window: the new taps are the window's
+// last `taps` input rows, shifted in from the old history when npos < taps (straddle). Reads
+// land in registers before any write, so the in-place buffer update is safe per channel.
+class MetalDnConvHist {
+    @ssbo @binding = 0 x : array<float>     // [npos x cd] the window's fused qkv rows
+    @ssbo @binding = 1 hist : array<float>  // [cd x taps] channel-major history (layer slice)
+    @uniform @binding = 2 cd : uint
+    @uniform @binding = 3 dconv : uint
+    @uniform @binding = 4 npos : uint
+
+    [metal_kernel(name="metal_dn_conv_hist_msl")]
+    def metal_dn_conv_hist {
+        let ch = gl_GlobalInvocationID.x
+        if (ch >= cd) {
+            return
+        }
+        let taps = dconv - 1u
+        var nh : float[8]                   // dconv <= 8 by the serve gate
+        var k = 0u
+        while (k < taps) {
+            let src = int(npos + k) - int(taps)
+            nh[k] = src >= 0 ? x[uint(src) * cd + ch] : hist[ch * taps + uint(src + int(taps))]
+            k++
+        }
+        k = 0u
+        while (k < taps) {
+            hist[ch * taps + k] = nh[k]
+            k++
+        }
+    }
+}
+
+// Per-head L2 norm over the conv-out q/k regions in place, q pre-scale folded (l2_norm_rows +
+// scale_inplace): one simdgroup per (head block, position). CPU accumulates the square-sum in
+// DOUBLE — the f32 simd tree here is the deltanet drift class (same as the Vulkan tier).
+class MetalDnL2Norm {
+    @ssbo @binding = 0 y : array<float>     // [npos x cd] conv rows: q at 0, k at kd
+    @uniform @binding = 1 cd : uint
+    @uniform @binding = 2 kd : uint         // key_dim = nkh * ds
+    @uniform @binding = 3 ds : uint         // 128 (gated)
+    @uniform @binding = 4 eps : float
+    @uniform @binding = 5 qscale : float    // 1/sqrt(ds); k blocks get 1
+
+    [metal_kernel(name="metal_dn_l2norm_msl")]
+    def metal_dn_l2norm {
+        let blk = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
+        let p = gl_WorkGroupID.y
+        let nblk = (2u * kd) / ds
+        if (blk >= nblk) {
+            return
+        }
+        let lane = gl_SubgroupInvocationID
+        let base = p * cd + blk * ds + lane * 4u
+        var v : float[4]
+        var ss = 0.0
+        for [unroll_full] (c in range(4)) {
+            v[c] = y[base + uint(c)]
+            ss += v[c] * v[c]
+        }
+        ss = simd_sum(ss)
+        let sc = (1.0 / max(sqrt(ss), eps)) * (blk < kd / ds ? qscale : 1.0)
+        for [unroll_full] (c in range(4)) {
+            y[base + uint(c)] = v[c] * sc
+        }
+    }
+}
+
+// The fused sequential delta rule (llama.cpp's gated_delta_net shape): one simdgroup per
+// (state column j, v-head) holds S[:,j] in registers and walks ALL npos tokens in-kernel —
+// zero per-token state traffic; β/σ/softplus fold into the loop (redundant per column, trivial).
+class MetalDnScan {
+    @ssbo @binding = 0 cv : array<float>    // [npos x cd] conv rows: q at 0 / k at kd / v at 2kd
+    @ssbo @binding = 1 st : array<float>    // state layer slice [nvh x ds x ds] row-major (i·ds + j)
+    @ssbo @binding = 2 braw : array<float>  // [npos x nvh] raw beta projections
+    @ssbo @binding = 3 graw : array<float>  // [npos x nvh] raw alpha projections
+    @ssbo @binding = 4 aa : array<float>    // [nvh] ssm_a = -exp(A_log) (fblob row)
+    @ssbo @binding = 5 dtb : array<float>   // [nvh] dt_bias (fblob row)
+    @ssbo @binding = 6 o : array<float>     // [npos x di] delta-rule output rows
+    @uniform @binding = 7 cd : uint
+    @uniform @binding = 8 kd : uint
+    @uniform @binding = 9 ds : uint         // 128 (gated)
+    @uniform @binding = 10 nvh : uint
+    @uniform @binding = 11 nkh : uint
+    @uniform @binding = 12 di : uint        // nvh * ds
+    @uniform @binding = 13 npos : uint
+
+    [metal_kernel(name="metal_dn_scan_msl")]
+    def metal_dn_scan {
+        let j = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
+        let h = gl_WorkGroupID.y
+        if (j >= ds) {
+            return
+        }
+        let lane = gl_SubgroupInvocationID
+        let kh = h % nkh
+        let qoff = kh * ds + lane * 4u
+        let koff = kd + kh * ds + lane * 4u
+        let voff = 2u * kd + h * ds + j
+        let a_h = aa[h]
+        let dt_h = dtb[h]
+        let s0 = h * ds * ds + (lane * 4u) * ds + j
+        var ls : float[4]
+        for [unroll_full] (c in range(4)) {
+            ls[c] = st[s0 + uint(c) * ds]
+        }
+        var p = 0u
+        while (p < npos) {
+            let gr = graw[p * nvh + h] + dt_h
+            let dec = exp(a_h * (gr > 20.0 ? gr : log(1.0 + exp(gr))))
+            let beta = 1.0 / (1.0 + exp(-braw[p * nvh + h]))
+            let cb = p * cd
+            var kv4 : float[4]
+            var sk = 0.0
+            for [unroll_full] (c in range(4)) {
+                kv4[c] = cv[cb + koff + uint(c)]
+                ls[c] *= dec
+                sk += kv4[c] * ls[c]
+            }
+            sk = simd_sum(sk)
+            let d = (cv[cb + voff] - sk) * beta
+            var yy = 0.0
+            for [unroll_full] (c in range(4)) {
+                ls[c] += kv4[c] * d
+                yy += cv[cb + qoff + uint(c)] * ls[c]
+            }
+            yy = simd_sum(yy)
+            if (lane == 0u) {
+                o[p * di + h * ds + j] = yy
+            }
+            p++
+        }
+        for [unroll_full] (c in range(4)) {
+            st[s0 + uint(c) * ds] = ls[c]
+        }
+    }
+}
+
+// Gated out-norm (dn_token_core's tail): per (v-head, position) RMSNorm over ds with the
+// SHARED ssm_norm row, then ⊙ SiLU(z) — in place on o, one simdgroup per (head, position).
+class MetalDnGate {
+    @ssbo @binding = 0 o : array<float>     // [npos x di] delta-rule output, gated in place
+    @ssbo @binding = 1 z : array<float>     // [npos x di] raw gate projections
+    @ssbo @binding = 2 wn : array<float>    // [ds] shared norm weight (fblob row)
+    @uniform @binding = 3 ds : uint         // 128 (gated)
+    @uniform @binding = 4 di : uint
+    @uniform @binding = 5 eps : float
+
+    [metal_kernel(name="metal_dn_gate_msl")]
+    def metal_dn_gate {
+        let h = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
+        let p = gl_WorkGroupID.y
+        if (h >= di / ds) {
+            return
+        }
+        let lane = gl_SubgroupInvocationID
+        let base = p * di + h * ds + lane * 4u
+        var v : float[4]
+        var ss = 0.0
+        for [unroll_full] (c in range(4)) {
+            v[c] = o[base + uint(c)]
+            ss += v[c] * v[c]
+        }
+        ss = simd_sum(ss)
+        let inv = rsqrt(ss / float(ds) + eps)
+        for [unroll_full] (c in range(4)) {
+            let zz = z[base + uint(c)]
+            o[base + uint(c)] = (wn[lane * 4u + uint(c)] * (v[c] * inv)) * (zz / (1.0 + exp(-zz)))
+        }
+    }
+}
+
+// Deinterleave the 2x-wide gated-attention Q projection (head h's q at 2h·hs, its gate at
+// (2h+1)·hs): q lands in the qkv panel's q segment, the gate in its own rows — keeps the
+// rope/attention classes untouched by the packing.
+class MetalDnDeint {
+    @ssbo @binding = 0 qg : array<float>    // [npos x 2qd] packed [q|gate] projection rows
+    @ssbo @binding = 1 q : array<float>     // qkv panel, q segment at row stride qs
+    @ssbo @binding = 2 gt : array<float>    // [npos x qd] sigmoid-gate rows
+    @uniform @binding = 3 hs : uint
+    @uniform @binding = 4 qd : uint
+    @uniform @binding = 5 qs : uint         // q panel row stride, elements (qkvd; decode binds qd)
+
+    [metal_kernel(name="metal_dn_deint_msl")]
+    def metal_dn_deint {
+        let i = gl_GlobalInvocationID.x
+        let p = gl_GlobalInvocationID.y
+        if (i >= qd) {
+            return
+        }
+        let sb = p * 2u * qd + (i / hs) * 2u * hs + i % hs
+        q[p * qs + i] = qg[sb]
+        gt[p * qd + i] = qg[sb + hs]
+    }
+}
+
+// Per-head sigmoid output gate (sigmoid_gate): x ⊙ σ(g) in place — the gated-attention
+// epilogue between the attention output and the out projection.
+class MetalSigmul {
+    @ssbo @binding = 0 x : array<float>
+    @ssbo @binding = 1 g : array<float>
+    @uniform @binding = 2 total : uint      // grid guard
+
+    [metal_kernel(name="metal_sigmul_msl")]
+    def metal_sigmul {
+        let gid = gl_GlobalInvocationID.x
+        if (gid >= total) {
+            return
+        }
+        x[gid] = x[gid] / (1.0 + exp(-g[gid]))
+    }
+}
+
 // ===== the whole-prefill driver =====
 // Registered as prefill override "metal" (DASLLAMA_PIN_PREFILL). One command buffer per prefill;
 // ONE commit+wait, then unified-memory readback hands x_b + per-layer roped-K/raw-V back to the CPU.

--- a/modules/dasLLAMA/performance/baseline_metal_qwen35_m1.tsv
+++ b/modules/dasLLAMA/performance/baseline_metal_qwen35_m1.tsv
@@ -1,0 +1,11 @@
+model	format	shape	lcpp_toks	source
+4b	q8	pp512	974.24	llama-bench -r 1, lcpp 7642f1c, M1 Max, 2026-07-20 settled window, Parsec off
+4b	q8	tg128_b1	57.41	llama-bench -r 1
+4b	q4km	pp512	847.69	llama-bench -r 1 (local requant from Q8, --allow-requantize)
+4b	q4km	tg128_b1	64.55	llama-bench -r 1
+4b	q5km	pp512	767.92	llama-bench -r 1 (local requant from Q8)
+4b	q5km	tg128_b1	55.71	llama-bench -r 1
+4b	q6k	pp512	835.87	llama-bench -r 1 (local requant from Q8)
+4b	q6k	tg128_b1	63.90	llama-bench -r 1
+35b	q4km	pp512	830.97	llama-bench -r 1 (Qwen3.6-35B-A3B-UD-Q4_K_M)
+35b	q4km	tg128_b1	54.21	llama-bench -r 1

--- a/modules/dasLLAMA/performance/results_metal_qwen35.md
+++ b/modules/dasLLAMA/performance/results_metal_qwen35.md
@@ -1,0 +1,63 @@
+# Metal Qwen3.5/3.6 hybrid (qwen35) scoreboard (living doc — CURRENT numbers only; history in git)
+
+Qwen3.5-4B (dense hybrid) + Qwen3.6-35B-A3B (hybrid MoE) — the Wave D showcase: 3-of-4
+layers Gated-DeltaNet (GPU state mirror + fused sequential scan), gated full attention
+(2x-wide Q, partial NEOX rope 64/256, σ out-gate); the 35B adds grouped MoE routing + the
+sigmoid-gated shared expert + f32-on-disk β/α. Metal vs Metal, the 3B methodology
+(`results_metal_3b.md`): das = dasLLAMA (`-jit`, mapped metal-flavor `.dlim`,
+`DASLLAMA_PIN_DECODE=metal` = MetalMode.required); llama.cpp = stock flags, Metal default
+(its GPU gated-delta-net kernel is default-on — an honest fully-GPU baseline), `-fa auto`;
+single-stream from `llama-bench -r 1`. das rails: `prefill_perf.das` N=512 (REPS=3, settled
+rep) + `batch_decode_perf.das -p 512 -n 128 -b 1 --kv f16` (GREEDY sequential). NO batch
+ladder — Wave D is batchless by design (multistream MoE+state traffic doesn't amortize;
+per-row batch rides the decode driver). BOTH sides measured interleaved in one Parsec-off
+window; lcpp side recorded in `baseline_metal_qwen35_m1.tsv`. Requants are local
+(`llama-quantize --allow-requantize` from the Q8), each parity-smoked 90 positions
+token-exact first. Ratio = das / llama.cpp, >1 = das faster; winners bold.
+
+## Apple M1 Max — daslang branch `bbatkin/dasllama-metal-wave-d` @ be6d8bea2, llama.cpp 7642f1c, 2026-07-20 settled window (Parsec off)
+
+### Qwen3.5-4B Q8_0
+
+| shape | das tok/s | lcpp tok/s | das/lcpp |
+| :--- | ---: | ---: | ---: |
+| pp512 | 1001.5 | 974.2 | **1.03x** |
+| tg128 B=1 | 58.5 | 57.4 | **1.02x** |
+
+### Qwen3.5-4B Q4_K_M (local requant from Q8)
+
+| shape | das tok/s | lcpp tok/s | das/lcpp |
+| :--- | ---: | ---: | ---: |
+| pp512 | 925.6 | 847.7 | **1.09x** |
+| tg128 B=1 | 72.0 | 64.6 | **1.11x** |
+
+### Qwen3.5-4B Q5_K_M (local requant from Q8)
+
+| shape | das tok/s | lcpp tok/s | das/lcpp |
+| :--- | ---: | ---: | ---: |
+| pp512 | 851.9 | 767.9 | **1.11x** |
+| tg128 B=1 | 61.4 | 55.7 | **1.10x** |
+
+### Qwen3.5-4B Q6_K (local requant from Q8)
+
+| shape | das tok/s | lcpp tok/s | das/lcpp |
+| :--- | ---: | ---: | ---: |
+| pp512 | 919.4 | 835.9 | **1.10x** |
+| tg128 B=1 | 66.4 | 63.9 | **1.04x** |
+
+Parity note (documented finding, not a blocker): the Q6_K requant's lockstep probe is
+90/90 token-exact but shows a deterministic single-position logits spike (maxd 10.3 at
+one comma step; every other position ~0.35, no compounding, argmax intact) — the k6
+CPU-Q8_K-activations-vs-GPU-f32 class amplified on an outlier channel.
+
+### Qwen3.6-35B-A3B Q4_K_M (UD; deltanet + grouped MoE + shexp whole-graph GPU)
+
+| shape | das tok/s | lcpp tok/s | das/lcpp |
+| :--- | ---: | ---: | ---: |
+| pp512 | 852.3 | 831.0 | **1.03x** |
+| tg128 B=1 | 58.4 | 54.2 | **1.08x** |
+
+das leads every cell on the wave: the K-quant 4B rows 1.04-1.11x, Q8 at 1.02-1.03x, and
+the whole-graph 35B (deltanet scan + routed experts + shexp + f32 β/α slabs all
+GPU-resident) 1.03x prefill / 1.08x decode against llama.cpp's default-on fused GPU
+gated-delta-net path.

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -43,11 +43,16 @@ arm6-churn arm7-q8kv arm7b-tq4kv arm8-s16 arm9-reload arm10-kq arm11-depth arm12
 batch test: `batch` (whole test), `batchB7-partd`, `batchB8-kq`. Prefill parity: `base s16
 kq cont dim qkv`. Support matrix: `cells-q8 window cells-s16 mode kq dim8b dim70b` + the
 family matrix `fam-qwen3 fam-qwen2 fam-phi3 fam-gemma2 fam-gemma3 fam-gemma4 fam-qwen3moe
-fam-gemma4moe fam-gptoss` (needs-derivation pins + per-path cells; fam-gemma2 also carries the
-sliding-window masking parity row; fam-gemma4/fam-qwen3moe/fam-gemma4moe/fam-gptoss are
-DASLLAMA_PARITY_FULL-gated — 7.4/18.5/26.9/12.1GB; fam-gemma4moe and fam-gptoss are ENGAGE
+fam-gemma4moe fam-gptoss fam-qwen35 fam-qwen35moe fam-qwen2moe` (needs-derivation pins +
+per-path cells; fam-gemma2 also carries the sliding-window masking parity row;
+fam-gemma4/fam-qwen3moe/fam-gemma4moe/fam-gptoss/fam-qwen35moe/fam-qwen2moe are
+DASLLAMA_PARITY_FULL-gated — 7.4/18.5/26.9/12.1/22/15GB; fam-gemma4moe and fam-gptoss are ENGAGE
 + shallow logits TOLERANCE cells only — token parity is not a valid instrument for the 26B, whose double-router
-CPU differs from any float implementation by ~2.5 logits/step by construction). The
+CPU differs from any float implementation by ~2.5 logits/step by construction;
+fam-qwen35/fam-qwen35moe are deltanet hybrids whose batch cell asserts the per-row FALLBACK
+shape — metal batch steps 0, both rows served on the single-decode path; fam-qwen2moe's
+batch cell asserts the `graph` DECLINE on the planar model — shexp has no batch arm, and a
+blob twin's CPU batch fallback would trip the blob-only panic). The
 `kernels` suite (test_metal_prefill_kernels — model-less kernel units, ~80s) has no arms;
 remember it exists — kernel uniform/binding changes MUST update its hand-bound dispatches.
 The `image` suite (test_model_image — the prepared-image .dlim rail): `mechanics` (synthetic
@@ -77,7 +82,7 @@ model blocks tagged with a listed family run — `family_on(t, name)` in
 `_model_tier.das`, EXACT token match, loud `t |> skip` like the arm filter. Model-free blocks
 (the `kernels` suite, the image `mechanics` arm) carry no tag and always run. Family tokens
 today: `llama` (all four metal suites + the image smol arm), `qwen2`, `qwen3`, `phi3`,
-`gemma2`, `gemma3`, `gemma4`, `qwen3moe`, `gemma4moe`, `gptoss` (the support-matrix family cells), `gemma`,
+`gemma2`, `gemma3`, `gemma4`, `qwen3moe`, `gemma4moe`, `gptoss`, `qwen35`, `qwen35moe`, `qwen2moe` (the support-matrix family cells), `gemma`,
 `ultravox`, `whisper`, `voxtral` (image suite arms).
 When profiling one family across formats, gate each round with
 `--arm <arms> --family <fam>` instead of the whole zoo. Tag every NEW model-loading block

--- a/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
@@ -482,6 +482,8 @@ def test_metal_prefill_kernels(t : T?) {
                 dn_chain_gate(t, dev, queue, 2, 4, 4, 2)
                 dn_chain_gate(t, dev, queue, 4, 4, 4, 3)
                 dn_deint_sigmul_gate(t, dev, queue, 3, 64, 2)
+                axpy_sig_gate(t, dev, queue, 1, 96)    // shexp combine (stage 3): decode shape
+                axpy_sig_gate(t, dev, queue, 5, 64)    // ... and the per-position prefill shape
 
                 metal_release(queue)
             }
@@ -1412,6 +1414,60 @@ def private dn_deint_sigmul_gate(t : T?; dev, queue; nh, hs, npos : int) {
     delete qgot
     delete xv
     delete swant
+}
+
+def private axpy_sig_gate(t : T?; dev, queue; npos, dim : int) {
+    var err : string
+    var pso = pipeline_from_source(dev, metal_axpy_sig_msl, metal_axpy_sig_msl_entry, metal_axpy_sig_msl_fastmath, err)
+    t |> success(pso != null, "axpy_sig pipeline: {err}")
+    if (pso == null) {
+        return
+    }
+    let total = npos * dim
+    var yv : array<float>
+    var xv : array<float>
+    var gv : array<float>
+    var want : array<float>
+    yv |> resize(total)
+    xv |> resize(total)
+    gv |> resize(npos)
+    want |> resize(total)
+    for (k in range(total)) {
+        yv[k] = 0.05 * float(k % 37) - 0.9
+        xv[k] = 0.07 * float(k % 41) - 1.3
+    }
+    for (p in range(npos)) {
+        gv[p] = 0.6 * float(p) - 1.2
+    }
+    for (k in range(total)) {
+        want[k] = yv[k] + xv[k] / (1.0 + exp(-gv[k / dim]))
+    }
+    var by = buf_upload(dev, yv)
+    var bx = buf_upload(dev, xv)
+    var bg = buf_upload(dev, gv)
+    var btot = buf_u32(dev, uint(total))
+    var bdim = buf_u32(dev, uint(dim))
+    let ran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso)
+        metal_set_buffer(enc, by, 0ul, 0)
+        metal_set_buffer(enc, bx, 0ul, 1)
+        metal_set_buffer(enc, bg, 0ul, 2)
+        metal_set_buffer(enc, btot, 0ul, 3)
+        metal_set_buffer(enc, bdim, 0ul, 4)
+        metal_dispatch_threadgroups(enc, uint3(uint((total + 255) / 256), 1u, 1u), uint3(256u, 1u, 1u))
+    }
+    t |> success(ran, "axpy_sig dispatch: {err}")
+    t |> equal(buf_mismatch_approx(by, want), 0)
+    metal_release(by)
+    metal_release(bx)
+    metal_release(bg)
+    metal_release(btot)
+    metal_release(bdim)
+    metal_release(pso)
+    delete yv
+    delete xv
+    delete gv
+    delete want
 }
 
 // ===== local GPU plumbing (generic bodies instantiate only inside the static_if above) =====

--- a/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
@@ -282,7 +282,7 @@ def test_metal_prefill_kernels(t : T?) {
                 var brhs = buf_u32(dev, uint(HEAD_SIZE))
                 var brnp = buf_u32(dev, uint(NPOS * QD / 2))
                 var brnx = buf_u32(dev, 0u)
-                var ropebufs <- [brv, brc, brs, brn, brhs, brnp, brnx]
+                var ropebufs <- [brv, brc, brs, brn, brhs, brnp, brnx, brhs]   // trailing brhs = rot (full rope)
                 let roperan = run_compute_1d(queue, pso_rope, ropebufs, uint(NPOS * QD / 2), 64u, err)
                 t |> success(roperan, "rope dispatch: {err}")
                 t |> equal(buf_mismatch_approx(brv, rvwant), 0)
@@ -306,7 +306,7 @@ def test_metal_prefill_kernels(t : T?) {
                 }
                 var brv2 = buf_upload(dev, rv)
                 var brnx1 = buf_u32(dev, 1u)
-                var ropebufs2 <- [brv2, brc, brs, brn, brhs, brnp, brnx1]
+                var ropebufs2 <- [brv2, brc, brs, brn, brhs, brnp, brnx1, brhs]
                 let roperan2 = run_compute_1d(queue, pso_rope, ropebufs2, uint(NPOS * QD / 2), 64u, err)
                 t |> success(roperan2, "rope NEOX dispatch: {err}")
                 t |> equal(buf_mismatch_approx(brv2, rvwant), 0)
@@ -316,6 +316,49 @@ def test_metal_prefill_kernels(t : T?) {
                 }
                 metal_release(brv2)
                 metal_release(brnx1)
+
+                // ===== partial NEOX (rot < head_size, Wave D) — vs rope_scaled_neox_tab_part;
+                // the table rows are rot/2 wide, dims >= rot pass through untouched
+                let prot = HEAD_SIZE / 2
+                let phalf = prot / 2
+                var rcosp : array<float>
+                var rsinp : array<float>
+                rcosp |> resize(NPOS * phalf)
+                rsinp |> resize(NPOS * phalf)
+                for (k in range(NPOS * phalf)) {
+                    rcosp[k] = cos(0.02 * float(k % 89))
+                    rsinp[k] = sin(0.02 * float(k % 89))
+                }
+                for (k in range(NPOS * QD)) {
+                    rv[k] = 0.17 * float(k % 33) - 2.4
+                    rvwant[k] = rv[k]
+                }
+                unsafe {
+                    for (p in range(NPOS)) {
+                        rope_scaled_neox_tab_part(addr(rvwant[p * QD]), int64(HEAD_SIZE), int64(prot),
+                            int64(QD), addr<float const?>(rcosp[p * phalf]), addr<float const?>(rsinp[p * phalf]))
+                    }
+                }
+                var brv3 = buf_upload(dev, rv)
+                var brcp = buf_upload(dev, rcosp)
+                var brsp = buf_upload(dev, rsinp)
+                var brnx2 = buf_u32(dev, 1u)
+                var brot = buf_u32(dev, uint(prot))
+                var ropebufs3 <- [brv3, brcp, brsp, brn, brhs, brnp, brnx2, brot]
+                let roperan3 = run_compute_1d(queue, pso_rope, ropebufs3, uint(NPOS * QD / 2), 64u, err)
+                t |> success(roperan3, "rope partial-NEOX dispatch: {err}")
+                t |> equal(buf_mismatch_approx(brv3, rvwant), 0)
+                ropebufs3 |> clear()
+                unsafe {
+                    delete ropebufs3
+                }
+                delete rcosp
+                delete rsinp
+                metal_release(brv3)
+                metal_release(brcp)
+                metal_release(brsp)
+                metal_release(brnx2)
+                metal_release(brot)
                 metal_release(brc)
                 metal_release(brs)
                 metal_release(brn)

--- a/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
@@ -430,6 +430,16 @@ def test_metal_prefill_kernels(t : T?) {
                 moe_gemv_gate(t, dev, queue, 64, 24, 5, 3, 3, true)    // batch streams, down form
                 moe_combine_gate(t, dev, queue, 200, 4)
 
+                // ===== deltanet kernels (Wave D) =====
+                // the chain gates compare each stage at its seam vs a sequential CPU mirror;
+                // shapes: decode (npos 1), a batch window, npos < taps (history straddle),
+                // and nkh == nvh (the 0.8B class; the rest exercise the h % nkh fan-out)
+                dn_chain_gate(t, dev, queue, 2, 4, 4, 1)
+                dn_chain_gate(t, dev, queue, 2, 4, 4, 5)
+                dn_chain_gate(t, dev, queue, 2, 4, 4, 2)
+                dn_chain_gate(t, dev, queue, 4, 4, 4, 3)
+                dn_deint_sigmul_gate(t, dev, queue, 3, 64, 2)
+
                 metal_release(queue)
             }
             t |> equal(metal_live_object_count(), 0l)
@@ -957,6 +967,408 @@ def private moe_combine_gate(t : T?; dev, queue; dim, k : int) {
     delete dn
     delete selw
     delete want
+}
+
+// ===== deltanet kernel gates (Wave D) =====
+
+// The whole recurrent chain vs a sequential CPU mirror — conv+SiLU (history straddle), q/k L2
+// norm + q pre-scale, the fused sequential delta rule, the z-gated out-norm — compared at each
+// stage's seam so a red localizes to (stage). ds pinned 128 (the serve gate's shape).
+def private dn_chain_gate(t : T?; dev, queue; nkh, nvh, dconv, npos : int) {
+    let ds = 128
+    let kd = nkh * ds
+    let di = nvh * ds
+    let cd = 2 * kd + di
+    let taps = dconv - 1
+    let qscale = 1.0 / sqrt(float(ds))
+    var err : string
+    var pso_conv = pipeline_from_source(dev, metal_dn_conv_msl, metal_dn_conv_msl_entry, metal_dn_conv_msl_fastmath, err)
+    t |> success(pso_conv != null, "dn conv pipeline: {err}")
+    var pso_hist = pipeline_from_source(dev, metal_dn_conv_hist_msl, metal_dn_conv_hist_msl_entry, metal_dn_conv_hist_msl_fastmath, err)
+    t |> success(pso_hist != null, "dn hist pipeline: {err}")
+    var pso_l2 = pipeline_from_source(dev, metal_dn_l2norm_msl, metal_dn_l2norm_msl_entry, metal_dn_l2norm_msl_fastmath, err)
+    t |> success(pso_l2 != null, "dn l2norm pipeline: {err}")
+    var pso_scan = pipeline_from_source(dev, metal_dn_scan_msl, metal_dn_scan_msl_entry, metal_dn_scan_msl_fastmath, err)
+    t |> success(pso_scan != null, "dn scan pipeline: {err}")
+    var pso_gate = pipeline_from_source(dev, metal_dn_gate_msl, metal_dn_gate_msl_entry, metal_dn_gate_msl_fastmath, err)
+    t |> success(pso_gate != null, "dn gate pipeline: {err}")
+    if (pso_conv == null || pso_hist == null || pso_l2 == null || pso_scan == null || pso_gate == null) {
+        return
+    }
+    // inputs — hash patterns; ssm_a strictly negative (= -exp(A_log)), nonzero history + state
+    var xq : array<float>
+    var hist : array<float>
+    var cw : array<float>
+    var braw : array<float>
+    var graw : array<float>
+    var aa : array<float>
+    var dtb : array<float>
+    var st0 : array<float>
+    var zz : array<float>
+    var wn : array<float>
+    xq |> resize(npos * cd)
+    hist |> resize(cd * taps)
+    cw |> resize(cd * dconv)
+    braw |> resize(npos * nvh)
+    graw |> resize(npos * nvh)
+    aa |> resize(nvh)
+    dtb |> resize(nvh)
+    st0 |> resize(nvh * ds * ds)
+    zz |> resize(npos * di)
+    wn |> resize(ds)
+    for (k in range(npos * cd)) {
+        xq[k] = 0.03 * float(k % 53) - 0.8
+    }
+    for (k in range(cd * taps)) {
+        hist[k] = 0.05 * float(k % 31) - 0.7
+    }
+    for (k in range(cd * dconv)) {
+        cw[k] = 0.04 * float(k % 23) - 0.4
+    }
+    for (k in range(npos * nvh)) {
+        braw[k] = 0.3 * float(k % 11) - 1.5
+        graw[k] = 0.2 * float(k % 13) - 1.0
+    }
+    for (k in range(nvh)) {
+        aa[k] = -(0.4 + 0.15 * float(k))
+        dtb[k] = 0.1 * float(k) - 0.2
+    }
+    for (k in range(nvh * ds * ds)) {
+        st0[k] = 0.01 * float(k % 37) - 0.18
+    }
+    for (k in range(npos * di)) {
+        zz[k] = 0.07 * float(k % 27) - 0.9
+    }
+    for (k in range(ds)) {
+        wn[k] = 0.6 + 0.02 * float(k % 17)
+    }
+    // stage 1 mirror: conv + SiLU (window rows or history straddle), then the history advance
+    var cv : array<float>
+    var hwant : array<float>
+    cv |> resize(npos * cd)
+    hwant |> resize(cd * taps)
+    for (p in range(npos)) {
+        for (ch in range(cd)) {
+            var acc = 0.0
+            for (k in range(dconv)) {
+                let sp = p + k - taps
+                let xv = sp >= 0 ? xq[sp * cd + ch] : hist[ch * taps + p + k]
+                acc += xv * cw[ch * dconv + k]
+            }
+            cv[p * cd + ch] = acc / (1.0 + exp(-acc))
+        }
+    }
+    for (ch in range(cd)) {
+        for (k in range(taps)) {
+            let src = npos - taps + k
+            hwant[ch * taps + k] = src >= 0 ? xq[src * cd + ch] : hist[ch * taps + src + taps]
+        }
+    }
+    var bx = buf_upload(dev, xq)
+    var bh = buf_upload(dev, hist)
+    var bw = buf_upload(dev, cw)
+    var by = buf_fill(dev, npos * cd, 0.0)
+    var bcd = buf_u32(dev, uint(cd))
+    var bdc = buf_u32(dev, uint(dconv))
+    var bnp = buf_u32(dev, uint(npos))
+    let cran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_conv)
+        metal_set_buffer(enc, bx, 0ul, 0)
+        metal_set_buffer(enc, bh, 0ul, 1)
+        metal_set_buffer(enc, bw, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bcd, 0ul, 4)
+        metal_set_buffer(enc, bdc, 0ul, 5)
+        metal_set_buffer(enc, bnp, 0ul, 6)
+        metal_dispatch_threadgroups(enc, uint3(uint((cd + 255) / 256), uint(npos), 1u), uint3(256u, 1u, 1u))
+    }
+    t |> success(cran, "dn conv dispatch npos={npos}: {err}")
+    t |> equal(buf_mismatch_approx(by, cv), 0)
+    let hran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_hist)
+        metal_set_buffer(enc, bx, 0ul, 0)
+        metal_set_buffer(enc, bh, 0ul, 1)
+        metal_set_buffer(enc, bcd, 0ul, 2)
+        metal_set_buffer(enc, bdc, 0ul, 3)
+        metal_set_buffer(enc, bnp, 0ul, 4)
+        metal_dispatch_threadgroups(enc, uint3(uint((cd + 255) / 256), 1u, 1u), uint3(256u, 1u, 1u))
+    }
+    t |> success(hran, "dn hist dispatch npos={npos}: {err}")
+    t |> equal(buf_mismatch_approx(bh, hwant), 0)
+    // stage 2 mirror: per-head L2 over q/k + q pre-scale (double square-sum like the CPU)
+    for (p in range(npos)) {
+        for (blk in range(2 * nkh)) {
+            var sum = 0.0lf
+            for (j in range(ds)) {
+                let v = cv[p * cd + blk * ds + j]
+                sum += double(v * v)
+            }
+            let sc = (1.0 / max(sqrt(float(sum)), EPS)) * (blk < nkh ? qscale : 1.0)
+            for (j in range(ds)) {
+                cv[p * cd + blk * ds + j] *= sc
+            }
+        }
+    }
+    var bkd = buf_u32(dev, uint(kd))
+    var bds = buf_u32(dev, uint(ds))
+    var beps = buf_f32(dev, EPS)
+    var bqs = buf_f32(dev, qscale)
+    let lran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_l2)
+        metal_set_buffer(enc, by, 0ul, 0)
+        metal_set_buffer(enc, bcd, 0ul, 1)
+        metal_set_buffer(enc, bkd, 0ul, 2)
+        metal_set_buffer(enc, bds, 0ul, 3)
+        metal_set_buffer(enc, beps, 0ul, 4)
+        metal_set_buffer(enc, bqs, 0ul, 5)
+        metal_dispatch_threadgroups(enc, uint3(uint((2 * nkh + 7) / 8), uint(npos), 1u), uint3(256u, 1u, 1u))
+    }
+    t |> success(lran, "dn l2norm dispatch npos={npos}: {err}")
+    t |> equal(buf_mismatch_approx(by, cv), 0)
+    // stage 3 mirror: the sequential delta rule per v-head (k-heads fan via h % nkh)
+    var owant : array<float>
+    var stw : array<float>
+    var skd : array<float>
+    owant |> resize(npos * di)
+    stw := st0
+    skd |> resize(ds)
+    for (h in range(nvh)) {
+        let kh = h % nkh
+        let sb = h * ds * ds
+        for (p in range(npos)) {
+            let gr = graw[p * nvh + h] + dtb[h]
+            let dec = exp(aa[h] * (gr > 20.0 ? gr : log(1.0 + exp(gr))))
+            let beta = 1.0 / (1.0 + exp(-braw[p * nvh + h]))
+            let qb = p * cd + kh * ds
+            let kb = p * cd + kd + kh * ds
+            let vb = p * cd + 2 * kd + h * ds
+            for (j in range(ds)) {
+                skd[j] = 0.0
+            }
+            for (i in range(ds)) {
+                let ki = cv[kb + i]
+                for (j in range(ds)) {
+                    let sv = stw[sb + i * ds + j] * dec
+                    stw[sb + i * ds + j] = sv
+                    skd[j] += ki * sv
+                }
+            }
+            for (j in range(ds)) {
+                skd[j] = (cv[vb + j] - skd[j]) * beta
+                owant[p * di + h * ds + j] = 0.0
+            }
+            for (i in range(ds)) {
+                let ki = cv[kb + i]
+                let qi = cv[qb + i]
+                for (j in range(ds)) {
+                    let sv = stw[sb + i * ds + j] + ki * skd[j]
+                    stw[sb + i * ds + j] = sv
+                    owant[p * di + h * ds + j] += qi * sv
+                }
+            }
+        }
+    }
+    var bst = buf_upload(dev, st0)
+    var bbr = buf_upload(dev, braw)
+    var bgr = buf_upload(dev, graw)
+    var baa = buf_upload(dev, aa)
+    var bdt = buf_upload(dev, dtb)
+    var bo = buf_fill(dev, npos * di, 0.0)
+    var bnvh = buf_u32(dev, uint(nvh))
+    var bnkh = buf_u32(dev, uint(nkh))
+    var bdi = buf_u32(dev, uint(di))
+    let sran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_scan)
+        metal_set_buffer(enc, by, 0ul, 0)
+        metal_set_buffer(enc, bst, 0ul, 1)
+        metal_set_buffer(enc, bbr, 0ul, 2)
+        metal_set_buffer(enc, bgr, 0ul, 3)
+        metal_set_buffer(enc, baa, 0ul, 4)
+        metal_set_buffer(enc, bdt, 0ul, 5)
+        metal_set_buffer(enc, bo, 0ul, 6)
+        metal_set_buffer(enc, bcd, 0ul, 7)
+        metal_set_buffer(enc, bkd, 0ul, 8)
+        metal_set_buffer(enc, bds, 0ul, 9)
+        metal_set_buffer(enc, bnvh, 0ul, 10)
+        metal_set_buffer(enc, bnkh, 0ul, 11)
+        metal_set_buffer(enc, bdi, 0ul, 12)
+        metal_set_buffer(enc, bnp, 0ul, 13)
+        metal_dispatch_threadgroups(enc, uint3(uint(ds / 4), uint(nvh), 1u), uint3(128u, 1u, 1u))
+    }
+    t |> success(sran, "dn scan dispatch npos={npos} nkh={nkh} nvh={nvh}: {err}")
+    t |> equal(buf_mismatch_approx(bo, owant), 0)
+    t |> equal(buf_mismatch_approx(bst, stw), 0)
+    // stage 4 mirror: per-head RMS with the shared weight, ⊙ SiLU(z)
+    var gwant : array<float>
+    gwant |> resize(npos * di)
+    for (p in range(npos)) {
+        for (h in range(nvh)) {
+            var ms = 0.0lf
+            for (j in range(ds)) {
+                let v = owant[p * di + h * ds + j]
+                ms += double(v * v)
+            }
+            let inv = 1.0 / sqrt(float(ms) / float(ds) + EPS)
+            for (j in range(ds)) {
+                let v = owant[p * di + h * ds + j]
+                let zv = zz[p * di + h * ds + j]
+                gwant[p * di + h * ds + j] = (wn[j] * (v * inv)) * (zv / (1.0 + exp(-zv)))
+            }
+        }
+    }
+    var bz = buf_upload(dev, zz)
+    var bwn = buf_upload(dev, wn)
+    let gran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_gate)
+        metal_set_buffer(enc, bo, 0ul, 0)
+        metal_set_buffer(enc, bz, 0ul, 1)
+        metal_set_buffer(enc, bwn, 0ul, 2)
+        metal_set_buffer(enc, bds, 0ul, 3)
+        metal_set_buffer(enc, bdi, 0ul, 4)
+        metal_set_buffer(enc, beps, 0ul, 5)
+        metal_dispatch_threadgroups(enc, uint3(uint((nvh + 7) / 8), uint(npos), 1u), uint3(256u, 1u, 1u))
+    }
+    t |> success(gran, "dn gate dispatch npos={npos}: {err}")
+    t |> equal(buf_mismatch_approx(bo, gwant), 0)
+    metal_release(bx)
+    metal_release(bh)
+    metal_release(bw)
+    metal_release(by)
+    metal_release(bcd)
+    metal_release(bdc)
+    metal_release(bnp)
+    metal_release(bkd)
+    metal_release(bds)
+    metal_release(beps)
+    metal_release(bqs)
+    metal_release(bst)
+    metal_release(bbr)
+    metal_release(bgr)
+    metal_release(baa)
+    metal_release(bdt)
+    metal_release(bo)
+    metal_release(bnvh)
+    metal_release(bnkh)
+    metal_release(bdi)
+    metal_release(bz)
+    metal_release(bwn)
+    metal_release(pso_conv)
+    metal_release(pso_hist)
+    metal_release(pso_l2)
+    metal_release(pso_scan)
+    metal_release(pso_gate)
+    delete xq
+    delete hist
+    delete cw
+    delete braw
+    delete graw
+    delete aa
+    delete dtb
+    delete st0
+    delete zz
+    delete wn
+    delete cv
+    delete hwant
+    delete owant
+    delete stw
+    delete skd
+    delete gwant
+}
+
+// The 2x-wide [q|gate] deinterleave + the σ(g) out-gate — trivial mirrors, bit-exact.
+def private dn_deint_sigmul_gate(t : T?; dev, queue; nh, hs, npos : int) {
+    let qd = nh * hs
+    var err : string
+    var pso_de = pipeline_from_source(dev, metal_dn_deint_msl, metal_dn_deint_msl_entry, metal_dn_deint_msl_fastmath, err)
+    t |> success(pso_de != null, "dn deint pipeline: {err}")
+    var pso_sg = pipeline_from_source(dev, metal_sigmul_msl, metal_sigmul_msl_entry, metal_sigmul_msl_fastmath, err)
+    t |> success(pso_sg != null, "sigmul pipeline: {err}")
+    if (pso_de == null || pso_sg == null) {
+        return
+    }
+    let qs = qd + 64          // a wider destination row stride (the qkv panel form)
+    var qg : array<float>
+    var qwant : array<float>
+    var gwant : array<float>
+    qg |> resize(npos * 2 * qd)
+    qwant |> resize(npos * qs)
+    gwant |> resize(npos * qd)
+    for (k in range(npos * 2 * qd)) {
+        qg[k] = 0.09 * float(k % 43) - 1.7
+    }
+    for (p in range(npos)) {
+        for (i in range(qd)) {
+            let h = i / hs
+            let ii = i % hs
+            qwant[p * qs + i] = qg[p * 2 * qd + h * 2 * hs + ii]
+            gwant[p * qd + i] = qg[p * 2 * qd + h * 2 * hs + hs + ii]
+        }
+    }
+    var bqg = buf_upload(dev, qg)
+    var bq = buf_fill(dev, npos * qs, 0.0)
+    var bgt = buf_fill(dev, npos * qd, 0.0)
+    var bhs = buf_u32(dev, uint(hs))
+    var bqd = buf_u32(dev, uint(qd))
+    var bqs = buf_u32(dev, uint(qs))
+    let dran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_de)
+        metal_set_buffer(enc, bqg, 0ul, 0)
+        metal_set_buffer(enc, bq, 0ul, 1)
+        metal_set_buffer(enc, bgt, 0ul, 2)
+        metal_set_buffer(enc, bhs, 0ul, 3)
+        metal_set_buffer(enc, bqd, 0ul, 4)
+        metal_set_buffer(enc, bqs, 0ul, 5)
+        metal_dispatch_threadgroups(enc, uint3(uint((qd + 255) / 256), uint(npos), 1u), uint3(256u, 1u, 1u))
+    }
+    t |> success(dran, "dn deint dispatch: {err}")
+    // the pad tail of each destination row is unwritten — compare only the written columns
+    var qgot <- buf_download(bq, npos * qs, type<float>)
+    var dbad = 0
+    for (p in range(npos)) {
+        for (i in range(qd)) {
+            if (qgot[p * qs + i] != qwant[p * qs + i]) {
+                dbad++
+            }
+        }
+    }
+    t |> equal(dbad, 0)
+    t |> equal(buf_mismatch_exact(bgt, gwant), 0)
+    // sigmul: x ⊙ σ(g) on the deinterleaved gate rows
+    var xv : array<float>
+    var swant : array<float>
+    xv |> resize(npos * qd)
+    swant |> resize(npos * qd)
+    for (k in range(npos * qd)) {
+        xv[k] = 0.06 * float(k % 39) - 1.1
+        swant[k] = xv[k] / (1.0 + exp(-gwant[k]))
+    }
+    var bxv = buf_upload(dev, xv)
+    var btot = buf_u32(dev, uint(npos * qd))
+    let sran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso_sg)
+        metal_set_buffer(enc, bxv, 0ul, 0)
+        metal_set_buffer(enc, bgt, 0ul, 1)
+        metal_set_buffer(enc, btot, 0ul, 2)
+        metal_dispatch_threadgroups(enc, uint3(uint((npos * qd + 63) / 64), 1u, 1u), uint3(64u, 1u, 1u))
+    }
+    t |> success(sran, "sigmul dispatch: {err}")
+    t |> equal(buf_mismatch_approx(bxv, swant), 0)
+    metal_release(bqg)
+    metal_release(bq)
+    metal_release(bgt)
+    metal_release(bhs)
+    metal_release(bqd)
+    metal_release(bqs)
+    metal_release(bxv)
+    metal_release(btot)
+    metal_release(pso_de)
+    metal_release(pso_sg)
+    delete qg
+    delete qwant
+    delete gwant
+    delete qgot
+    delete xv
+    delete swant
 }
 
 // ===== local GPU plumbing (generic bodies instantiate only inside the static_if above) =====

--- a/modules/dasLLAMA/tests/test_metal_support_matrix.das
+++ b/modules/dasLLAMA/tests/test_metal_support_matrix.das
@@ -652,6 +652,211 @@ def private family_cells(t : T?; path, family, tag : string; expect_needs : uint
     }
 }
 
+[unused_argument(t, path, family, tag, expect_needs, cont_tol)]   // off-Apple the gated body is empty
+def private qwen35_row(t : T?; path, family, tag : string; expect_needs : uint; cont_tol : float) {
+    // qwen3.5/3.6 hybrid (Wave D): 3-in-4 Gated-DeltaNet layers + gated attention. Prefill +
+    // decode ENGAGE on the blob twin; batch has NO metal arm by design — eval_batch CPU-declines
+    // hybrids (attn_is_std false) into per-row forward, which rides the metal DECODE override.
+    // The batch cell therefore asserts the FALLBACK shape: metal batch steps stay 0 while the
+    // single-decode counter serves both rows.
+    static_if (typeinfo builtin_module_exists(das_metal)) {
+        if (!family_on(t, family) || !arm_on(t, "fam-{family}") || !model_available(t, path)) {
+            return
+        }
+        var tr <- load_model(path, QuantMode.q8)
+        tr.config.seq_len = min(tr.config.seq_len, 512l)
+        let derived = metal_needs(tr)
+        let expected = MetalNeed(expect_needs)   // nolint:LINT005 — uint→named-bitfield relabel so the message prints bit NAMES
+        t |> success((uint(derived) & expect_needs) == expect_needs,
+            "{tag}: metal_needs derives {expected} (got {derived})")
+        var trg <- blob_twin(t, path, 512l)
+        let c = trg.config
+        let vocab = c.vocab_size
+        let pf0 = metal_prefill_stats().prefills
+        let de0 = metal_decode_stats().decodes
+        let ba0 = metal_batch_decode_stats().steps
+        with_job_que() {
+            setup_dasllama_jobque()
+            var sa = make_run_state(c, KVDtype.f16, KVDtype.f16)
+            var sb = make_run_state(c, KVDtype.f16, KVDtype.f16)
+            let pa <- encode(trg, counting_prompt(1, 40), true, false)
+            let pb <- encode(trg, counting_prompt(5, 44), true, false)
+            t |> success(select_prefill_override("metal"), "{tag}: prefill override registered")
+            t |> success(select_decode_override("metal"), "{tag}: decode override registered")
+            set_metal_prefill_min_npos(1l)
+            eval_(trg, sa, pa)
+            eval_(trg, sb, pb)
+            var cura = greedy_top(sa.logits, vocab)
+            let curb = greedy_top(sb.logits, vocab)
+            for (_i in range(2)) {
+                var one <- [cura]
+                eval_(trg, sa, one)
+                delete one
+                cura = greedy_top(sa.logits, vocab)
+            }
+            let de1 = metal_decode_stats().decodes
+            var ws <- create_batch_workspace_(trg)
+            var sess : array<Session?>
+            unsafe {
+                sess |> push(addr(sa))
+                sess |> push(addr(sb))
+            }
+            var cur <- [cura, curb]
+            eval_batch_(trg, ws, sess, cur)
+            t |> success(metal_decode_stats().decodes - de1 >= 2l,
+                "{tag} batch: per-row fallback serves each row on the GPU decode path")
+            select_decode_override("")
+            select_prefill_override("")
+            set_metal_prefill_min_npos(64l)
+            sess |> clear()   // drop the borrowed handles: delete of array<T?> cascades to the pointees
+            unsafe {
+                delete ws
+                delete sess
+            }
+            delete cur
+            delete sa
+            delete sb
+        }
+        t |> success(metal_prefill_stats().prefills - pf0 > 0l, "{tag} prefill: ENGAGES on the GPU")
+        t |> success(metal_decode_stats().decodes - de0 > 0l, "{tag} decode: ENGAGES on the GPU")
+        t |> equal(metal_batch_decode_stats().steps - ba0, 0l)
+        let prompt <- encode(tr, counting_prompt(1, 30), true, false)
+        var cpu_ids : array<int64>
+        var gpu_ids : array<int64>
+        with_job_que() {
+            setup_dasllama_jobque()
+            var s = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            let ids <- generate(tr, s, prompt, length(prompt) + 8)
+            cpu_ids := ids
+            delete s
+            select_decode_override("metal")
+            select_prefill_override("metal")
+            set_metal_prefill_min_npos(1l)
+            var s2 = make_run_state(trg.config, KVDtype.f16, KVDtype.f16)
+            let ids2 <- generate(trg, s2, prompt, length(prompt) + 8)
+            gpu_ids := ids2
+            delete s2
+            set_metal_prefill_min_npos(64l)
+            select_decode_override("")
+            select_prefill_override("")
+        }
+        t |> success(same(cpu_ids, gpu_ids),
+            "{tag}: metal-overrides generate matches the CPU truth token-for-token")
+        delete cpu_ids
+        delete gpu_ids
+        if (cont_tol > 0.0) {
+            cont_logits_cell(t, tr, trg, tag, cont_tol)
+        }
+        delete trg
+        delete tr
+    }
+}
+
+[unused_argument(t, path)]   // off-Apple the gated body is empty
+def private qwen2moe_row(t : T?; path : string) {
+    // qwen2moe (Qwen1.5-MoE-A2.7B): std attention + softmax-no-renorm select (gmode 2) + the
+    // sigmoid-gated shared expert. Decode + prefill ENGAGE; batch DECLINES by design (shexp
+    // has no batch arm) — the decline cell runs on the PLANAR model: the blob twin's CPU
+    // batch fallback would trip the blob-only panic (std attention runs the CPU batch stack).
+    static_if (typeinfo builtin_module_exists(das_metal)) {
+        if (!family_on(t, "qwen2moe") || !arm_on(t, "fam-qwen2moe") || !model_available(t, path)) {
+            return
+        }
+        var tr <- load_model(path, QuantMode.q8)
+        tr.config.seq_len = min(tr.config.seq_len, 512l)
+        let derived = metal_needs(tr)
+        t |> success((uint(derived) & uint(MetalNeed.neox | MetalNeed.qkv_bias)) == uint(MetalNeed.neox | MetalNeed.qkv_bias),
+            "qwen2moe: metal_needs derives neox|qkv_bias (got {derived})")
+        var trg <- blob_twin(t, path, 512l)
+        let c = trg.config
+        let vocab = c.vocab_size
+        let pf0 = metal_prefill_stats().prefills
+        let de0 = metal_decode_stats().decodes
+        let ba0 = metal_batch_decode_stats().steps
+        var bad0 <- metal_batch_decode_declines()
+        with_job_que() {
+            setup_dasllama_jobque()
+            var sa = make_run_state(c, KVDtype.f16, KVDtype.f16)
+            var sb = make_run_state(c, KVDtype.f16, KVDtype.f16)
+            let pa <- encode(trg, counting_prompt(1, 40), true, false)
+            let pb <- encode(trg, counting_prompt(5, 44), true, false)
+            t |> success(select_prefill_override("metal"), "qwen2moe: prefill override registered")
+            t |> success(select_decode_override("metal"), "qwen2moe: decode override registered")
+            set_metal_prefill_min_npos(1l)
+            eval_(trg, sa, pa)
+            eval_(trg, sb, pb)
+            var cura = greedy_top(sa.logits, vocab)
+            for (_i in range(2)) {
+                var one <- [cura]
+                eval_(trg, sa, one)
+                delete one
+                cura = greedy_top(sa.logits, vocab)
+            }
+            // batch decline cell on the PLANAR model: the gate records `graph`, CPU serves
+            var sc = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            var sd = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            eval_(tr, sc, pa)
+            eval_(tr, sd, pb)
+            var ws <- create_batch_workspace_(tr)
+            var sess : array<Session?>
+            unsafe {
+                sess |> push(addr(sc))
+                sess |> push(addr(sd))
+            }
+            var cur <- [greedy_top(sc.logits, vocab), greedy_top(sd.logits, vocab)]
+            eval_batch_(tr, ws, sess, cur)
+            select_decode_override("")
+            select_prefill_override("")
+            set_metal_prefill_min_npos(64l)
+            sess |> clear()   // drop the borrowed handles: delete of array<T?> cascades to the pointees
+            unsafe {
+                delete ws
+                delete sess
+            }
+            delete cur
+            delete sa
+            delete sb
+            delete sc
+            delete sd
+        }
+        t |> success(metal_prefill_stats().prefills - pf0 > 0l, "qwen2moe prefill: ENGAGES on the GPU")
+        t |> success(metal_decode_stats().decodes - de0 > 0l, "qwen2moe decode: ENGAGES on the GPU")
+        var bad <- metal_batch_decode_declines()
+        t |> equal(metal_batch_decode_stats().steps - ba0, 0l)
+        t |> success((bad?["graph"] ?? 0l) - (bad0?["graph"] ?? 0l) > 0l,
+            "qwen2moe batch: declines with reason 'graph' (no shexp batch arm)")
+        delete bad0
+        delete bad
+        let prompt <- encode(tr, counting_prompt(1, 30), true, false)
+        var cpu_ids : array<int64>
+        var gpu_ids : array<int64>
+        with_job_que() {
+            setup_dasllama_jobque()
+            var s = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            let ids <- generate(tr, s, prompt, length(prompt) + 8)
+            cpu_ids := ids
+            delete s
+            select_decode_override("metal")
+            select_prefill_override("metal")
+            set_metal_prefill_min_npos(1l)
+            var s2 = make_run_state(trg.config, KVDtype.f16, KVDtype.f16)
+            let ids2 <- generate(trg, s2, prompt, length(prompt) + 8)
+            gpu_ids := ids2
+            delete s2
+            set_metal_prefill_min_npos(64l)
+            select_decode_override("")
+            select_prefill_override("")
+        }
+        t |> success(same(cpu_ids, gpu_ids),
+            "qwen2moe: metal-overrides generate matches the CPU truth token-for-token")
+        delete cpu_ids
+        delete gpu_ids
+        cont_logits_cell(t, tr, trg, "qwen2moe-a2.7b/q8/f16", 4.0)
+        delete trg
+        delete tr
+    }
+}
+
 [unused_argument(t, path)]   // off-Apple the gated body is empty
 def private gemma4moe_row(t : T?; path : string) {
     // gemma4-26B-A4B (Wave C stage 3): the parallel dense-shared + routed MoE graph. TOKEN
@@ -1227,6 +1432,21 @@ def test_metal_family_matrix(t : T?) {
             gemma4moe_row(t, path_join(models_dir(), "gemma-4-26B-A4B-it-Q8_0.gguf"))
             // gpt-oss-20b (Wave C stage 4): mx4 experts + sinks + softmax_weight + biases
             gptoss_row(t, path_join(models_dir(), "gpt-oss-20b-mxfp4.gguf"))
+            // qwen35 (Wave D): the Gated-DeltaNet hybrid — 3-in-4 recurrent layers (state
+            // mirror, fused sequential scan) + gated attention (2x-wide Q, partial rope 64/256,
+            // σ out-gate). Decode + prefill serve; batch = per-row fallback (see qwen35_row).
+            qwen35_row(t, path_join(models_dir(), "Qwen3.5-0.8B-Q8_0.gguf"), "qwen35",
+                "qwen35-0.8b/q8/f16", uint(MetalNeed.neox | MetalNeed.qk_norm | MetalNeed.qd_neq_dim |
+                    MetalNeed.partial_rope | MetalNeed.q_gated), 4.0)
+            // qwen35moe (Wave D stage 3): deltanet + grouped MoE + the sigmoid-gated shared
+            // expert + f32-on-disk β/α — the whole-surface hybrid MoE. 22GB > the 6GiB tier —
+            // DASLLAMA_PARITY_FULL-gated.
+            qwen35_row(t, path_join(models_dir(), "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"), "qwen35moe",
+                "qwen35moe-35b/k4/f16", uint(MetalNeed.neox | MetalNeed.qk_norm | MetalNeed.qd_neq_dim |
+                    MetalNeed.partial_rope | MetalNeed.q_gated), 6.0)
+            // qwen2moe (Wave D ride-along): softmax-no-renorm select + sigmoid shexp on std
+            // attention; batch declines by design. 15GB — DASLLAMA_PARITY_FULL-gated.
+            qwen2moe_row(t, path_join(models_dir(), "Qwen1.5-MoE-A2.7B-Chat.Q8_0.gguf"))
             metal_decode_shutdown()
             metal_prefill_shutdown()
             t |> equal(metal_live_object_count(), 0l)

--- a/modules/dasMetal/metal/msl_emit.das
+++ b/modules/dasMetal/metal/msl_emit.das
@@ -739,7 +739,7 @@ def private sgmat_zero_fill(sgname : string) : string {
 // float-family (abs also signed-int); min/max take any numeric class. Fastmath is a kernel-level
 // property; single ops stay correctly rounded under MTLMathModeSafe (Phase-4 measured fact).
 let private MSL_MATH_UNARY : table<string> <- {
-    "exp", "sqrt", "rsqrt", "sin", "cos", "tanh", "abs", "saturate", "round"
+    "exp", "log", "sqrt", "rsqrt", "sin", "cos", "tanh", "abs", "saturate", "round"
 }
 
 // simdgroup intrinsics, the math whitelist, + the ctor/convert/saturating-narrow family are the

--- a/tests/metal/test_metal_math.das
+++ b/tests/metal/test_metal_math.das
@@ -1,7 +1,7 @@
 options gen2
 options indenting = 4
 
-// Real-GPU behavioral gate for the Phase-6 math builtins (exp/sqrt/rsqrt/sin/cos/tanh/abs/
+// Real-GPU behavioral gate for the Phase-6 math builtins (exp/log/sqrt/rsqrt/sin/cos/tanh/abs/
 // saturate/min/max — float scalar + float4 + int/uint classes). fastmath=false pins the precise
 // MSL math path: fast::sin/cos carry an ABSOLUTE ~2^-11 error bound that would swamp the oracle
 // tolerance, while the precise set stays within a few ULP of the CPU libm reference. abs/min/max/
@@ -39,6 +39,7 @@ class MathCalls {
         c[i] = (((exp(min(x, 4.0)) + sqrt(abs(x))) + (rsqrt(abs(y) + 1.0) + tanh(x))) +
             ((sin(x) + cos(y)) + (saturate(x) + max(x, y))))
         c[i] += float(qa[i])
+        c[i] += log(abs(x) + 1.0)
         let u = va[i]
         let v = vb[i]
         vc[i] = (((exp(min(u, float4(4.0))) + sqrt(abs(u))) + (rsqrt(abs(v) + float4(1.0)) + tanh(u))) +
@@ -84,9 +85,9 @@ def test_math_gpu_vs_cpu(t : T?) {
             oracle->mathcalls()
         }
         // k=0: x=-11, y=-4: exp(-11)+sqrt(11)+rsqrt(5)+tanh(-11)+sin(-11)+cos(-4)+saturate(-11)+max(-11,-4),
-        // then += float(qa[0]) = -125
+        // then += float(qa[0]) = -125, then += log(|x|+1) = log(12)
         t |> success(fapprox(oracle.c[0], exp(-11.0) + sqrt(11.0) + rsqrt(5.0) + tanh(-11.0) +
-            sin(-11.0) + cos(-4.0) + 0.0 + (-4.0) - 125.0), "the oracle itself computed")
+            sin(-11.0) + cos(-4.0) + 0.0 + (-4.0) - 125.0 + log(12.0)), "the oracle itself computed")
         t |> equal(oracle.ic[0], min(9, -3) + max(-9, -3))
         static_if (typeinfo builtin_module_exists(das_metal)) {
             var gpu_bad = -1

--- a/tests/msl/_msl_common.das
+++ b/tests/msl/_msl_common.das
@@ -525,6 +525,7 @@ class MathCalls {
         c[i] = (((exp(min(x, 4.0)) + sqrt(abs(x))) + (rsqrt(abs(y) + 1.0) + tanh(x))) +
             ((sin(x) + cos(y)) + (saturate(x) + max(x, y))))
         c[i] += float(qa[i])
+        c[i] += log(abs(x) + 1.0)
         let u = va[i]
         let v = vb[i]
         vc[i] = (((exp(min(u, float4(4.0))) + sqrt(abs(u))) + (rsqrt(abs(v) + float4(1.0)) + tanh(u))) +
@@ -748,6 +749,7 @@ def public declared_msl_census : table<string> {
         // math builtins (Phase 6): 1:1 MSL spellings — float scalar + vector classes
         // (abs also signed int; min/max any numeric class)
         "call.math.exp.f32",
+        "call.math.log.f32",
         "call.math.sqrt.f32",
         "call.math.rsqrt.f32",
         "call.math.sin.f32",

--- a/tests/msl/test_msl_math.das
+++ b/tests/msl/test_msl_math.das
@@ -31,6 +31,7 @@ kernel void mathcalls(device const float* a [[buffer(0)]],
     float y = b[i];
     c[i] = (((exp(min(x, 4.0f)) + sqrt(abs(x))) + (rsqrt((abs(y) + 1.0f)) + tanh(x))) + ((sin(x) + cos(y)) + (saturate(x) + max(x, y))));
     c[i] += float(qa[i]);
+    c[i] += log((abs(x) + 1.0f));
     float4 u = va[i];
     float4 v = vb[i];
     vc[i] = (((exp(min(u, float4(4.0f, 4.0f, 4.0f, 4.0f))) + sqrt(abs(u))) + (rsqrt((abs(v) + float4(1.0f, 1.0f, 1.0f, 1.0f))) + tanh(u))) + ((sin(u) + cos(v)) + (saturate(u) + max(u, v))));
@@ -47,6 +48,7 @@ def test_mathcalls_shape(t : T?) {
         t |> success(contains(mathcalls_msl, "exp(min(x, 4.0f))"), "exp + scalar min")
         t |> success(contains(mathcalls_msl, "sqrt(abs(x))"), "sqrt + float abs")
         t |> success(contains(mathcalls_msl, "rsqrt((abs(y) + 1.0f))"), "rsqrt")
+        t |> success(contains(mathcalls_msl, "log((abs(x) + 1.0f))"), "log")
         t |> success(contains(mathcalls_msl, "tanh(x)"), "tanh")
         t |> success(contains(mathcalls_msl, "sin(x)") && contains(mathcalls_msl, "cos(y)"), "sin/cos")
         t |> success(contains(mathcalls_msl, "saturate(x)"), "saturate")


### PR DESCRIPTION
dasLLAMA Metal Wave D: the Gated-DeltaNet hybrid family (qwen35 / qwen35moe / qwen3next) serves the whole graph on the GPU — recurrent linear-attention layers, gated full attention, and (on the MoE variants) grouped routing with a sigmoid-gated shared expert. qwen2moe rides the same machinery.

## What ships

**Deltanet on Metal.** 3 of every 4 layers in the qwen3.5/3.6 line are Gated-DeltaNet recurrent layers (no KV): causal conv + SiLU, q/k L2 norm, the fused sequential delta rule (one simdgroup per (state column, v-head), the state walks the whole window in-kernel — the same shape llama.cpp's fused GPU kernel uses by default), and a z-gated shared-weight out-norm. Recurrent state lives in a per-session persistent GPU arena (the KV-mirror analog): forward-only, pos-0 zeroed, CPU-prefix synced, declined on rewind — state is not re-derivable, so the speculative chain stays off for recurrent models.

**Gated attention.** The 1-in-4 attention layers use a 2x-wide fused [q|gate] projection (deinterleave kernel), partial NEOX rope (a `rot` uniform on the existing rope kernels — only the first rope_dim of head_size rotates), QK-norm reuse, and a sigmoid out-gate before the out projection.

**The MoE payoff (Qwen3.6-35B-A3B class).** On top of the Wave C routing: the sigmoid-gated shared expert (gate dot via the router f32 GEMV, gate+up through the fused w13sw kernel on decode / dense mul_mm on prefill, one new MetalAxpySig combine kernel shared by both drivers), and f32-on-disk beta/alpha projections (the 35B layout) served from the fblob slabs through the router kernels. The select kernel grows gmode 2 — softmax over all logits without the top-k renorm — which is exactly qwen2moe's gate, so Qwen1.5-MoE-class models serve too.

**Batchless by design.** Multistream batch is out of scope for this wave (recurrent state and routed-expert traffic do not amortize across streams); eval_batch's per-row fallback rides the Metal decode driver, so batched callers still land on the GPU row by row. The batch driver declines shexp MoE explicitly.

**Gates.** decode/prefill graph clauses admit hybrids via `dn_metal_ok`; `moe_metal_ok` grows the shexp clause and accepts `norm_topk_prob` both ways; `metal_blob_layout_ok` checks the dn and wsh planes; new `MetalNeed` bits partial_rope / q_gated join the OK masks. Servability flips for the family (MTP twins stay planar — the draft-block arm is a follow-up arc).

## Parity and tests

Lockstep planar-CPU-vs-blob-GPU probes: dense 0.8B/4B/9B and the 35B token-exact across prompt prefill, decode, continuation prefill at start_pos &gt; 0, and post-continuation decode; qwen2moe token-exact on the same phases. The support matrix grows `fam-qwen35`, `fam-qwen35moe`, and `fam-qwen2moe` rows (needs-derivation pins, per-path cells — the hybrid batch cell asserts the per-row-fallback shape, the qwen2moe batch cell asserts the graph decline — generate token parity, continuation tolerance cells); the kernel-units suite grows dn chain/deint/sigmul and axpy_sig gates. A per-decode-step pooled-uniform leak on dn models was found by the new fam-row leak gate and fixed.

## Scoreboard

`modules/dasLLAMA/performance/results_metal_qwen35.md` (+ pinned lcpp TSV): Qwen3.5-4B across Q8_0 and local K-quant requants plus Qwen3.6-35B-A3B Q4_K_M, pp512 + tg128 B=1, both sides measured interleaved in one settled window against llama.cpp's default-on fully-GPU gated-delta-net path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)