### PR TITLE
dasLLAMA: auto GPU tier config + resident classifier offload (+11-15%) + MTP/tier crash fix

### DIFF
--- a/modules/dasLLAMA/benchmarks/decode_real_bench.das
+++ b/modules/dasLLAMA/benchmarks/decode_real_bench.das
@@ -60,6 +60,18 @@ struct Args {
     @clarg_doc = "Run the timed reps twice in-process — attention q/k/v group OFF then ON (needs DASLLAMA_GPU_QKV=1 for the uploads)"
     qkv_ab : bool
 
+    @clarg_doc = "Run the timed reps twice in-process — MTP/NextN self-speculation OFF then ON (needs a NextN head in the GGUF; the ON arm also reports draft accept rate)"
+    mtp_ab : bool
+
+    @clarg_doc = "Force the per-position MoE prefill instead of the grouped buckets (bit-identical, pure perf lever) — the grouped path is tuned for large npos, so this probes whether it loses at the MTP verify's npos=2"
+    grouped_off : bool
+
+    @clarg_doc = "Run the timed reps twice in-process with MTP ON both times — batched verify classifier OFF then ON. Drift-cancelled measurement of the one-classifier-stream-per-verify win"
+    batchcls_ab : bool
+
+    @clarg_doc = "Run the timed reps twice in-process — resident GPU classifier plane OFF then ON (needs DASLLAMA_GPU_CLS=1, which arms the tier by itself so the classifier offload is measured alone)"
+    cls_ab : bool
+
     @clarg_short = "?"
     @clarg_doc = "Show this help and exit"
     help : bool
@@ -148,6 +160,9 @@ def main() {
     if (cfg.reuse) {
         set_expert_reuse(true)
     }
+    if (cfg.grouped_off) {
+        set_moe_grouped_prefill(false)
+    }
     var tk <- load_tokenizer_auto(cfg.model)
     print("loading {cfg.model}\n")
     with_job_que() {
@@ -162,7 +177,7 @@ def main() {
         }
         t.config.seq_len = min(t.config.seq_len, maxlen + ngen + 8l)
         let c = t.config
-        print("config: dim={c.dim} layers={c.n_layers} experts={c.n_expert} k={c.n_expert_used} | backend {active_kernel_backend()} | t{threads} affinity {pinned ? "hard" : "env/off"} | {length(toks)} prompts x {ngen} tok x {reps} reps\n")
+        print("config: dim={c.dim} layers={c.n_layers} experts={c.n_expert} k={c.n_expert_used} | backend {active_kernel_backend()} | t{threads} affinity {pinned ? "hard" : "env/off"} | moe-prefill {get_moe_grouped_prefill() ? "grouped" : "per-pos"} | {length(toks)} prompts x {ngen} tok x {reps} reps\n")
         // loud tier line — a silent GPU no-engage (absent DLL, failed probe) must never pass as a row
         let gs = gpu_tier_status()
         let gname = empty(gs.backend) ? "OFF" : "{gs.backend} {gs.device}"
@@ -179,10 +194,20 @@ def main() {
             }
             delete s
         }
-        if ((cfg.dnd_ab ? 1 : 0) + (cfg.heat_ab ? 1 : 0) + (cfg.shexp_ab ? 1 : 0) + (cfg.qkv_ab ? 1 : 0) > 1) {
+        if ((cfg.dnd_ab ? 1 : 0) + (cfg.heat_ab ? 1 : 0) + (cfg.shexp_ab ? 1 : 0) + (cfg.qkv_ab ? 1 : 0)
+                + (cfg.mtp_ab ? 1 : 0) + (cfg.batchcls_ab ? 1 : 0) + (cfg.cls_ab ? 1 : 0) > 1) {
             panic("decode_real_bench: the --*-ab levers are mutually exclusive (one route flip per run)")
         }
-        let narms = cfg.dnd_ab || cfg.heat_ab || cfg.shexp_ab || cfg.qkv_ab ? 2 : 1
+        // a silent no-engage must never pass as an A/B row — both arms would be identical
+        if (cfg.cls_ab && !gs.cls_resident) {
+            panic("decode_real_bench: --cls-ab needs the classifier plane resident on the tier (set DASLLAMA_GPU_CLS=1)")
+        }
+        // a model with no NextN head silently no-ops the gate — that must never pass as an A/B row
+        if ((cfg.mtp_ab || cfg.batchcls_ab) && c.n_layer_nextn <= 0l) {
+            panic("decode_real_bench: --mtp-ab / --batchcls-ab need a NextN draft head, and {cfg.model} has none")
+        }
+        let narms = (cfg.dnd_ab || cfg.heat_ab || cfg.shexp_ab || cfg.qkv_ab || cfg.mtp_ab
+            || cfg.batchcls_ab || cfg.cls_ab) ? 2 : 1
         for (ai in range(narms)) {
             if (cfg.dnd_ab) {
                 set_moe_gpu_dnd_route(ai == 1)   // route flip only — uploads and residency stay
@@ -194,24 +219,50 @@ def main() {
                 // OFF first so the ON arm's counters/pins warm during its own reps (rep 1 runs
                 // partly cold — the mean understates ON slightly; the delta stays the judge)
                 set_moe_gpu_heat_route(ai == 1)
+            } elif (cfg.mtp_ab) {
+                set_mtp_spec(ai == 1)   // must be live BEFORE the prefill: it warms the draft head's KV
+            } elif (cfg.batchcls_ab) {
+                set_mtp_spec(true)   // MTP on in BOTH arms — the flip under test is the classifier route
+                set_mtp_batch_cls(ai == 1)
+            } elif (cfg.cls_ab) {
+                set_moe_gpu_cls_route(ai == 1)   // route flip only — the upload and its VRAM stay
             }
+            let mtp_on = (cfg.mtp_ab && ai == 1) || cfg.batchcls_ab
+            var drafted = 0l
+            var accepted = 0l
             var tps : array<double>
             for (_rep in range(reps)) {
                 var total_us = 0l
+                var rep_gen = 0l
                 for (pi in range(length(toks))) {
                     var s <- make_run_state(c)   // fresh session per prompt — no KV/DN-state bleed
                     let plen = int64(length(toks[pi]))
                     forward_prefill(t, s, toks[pi], plen, 0l)   // untimed, as llama-bench excludes the prompt
                     let t0 = ref_time_ticks()
-                    var pos = plen
-                    for (_g in range64(ngen)) {
-                        forward(t, s, argmax_logit(s, c.vocab_size), pos)
-                        pos++
+                    if (mtp_on) {
+                        s.n_past = plen   // forward_prefill leaves n_past alone; mtp_spec_eval drives it
+                        var tok = argmax_logit(s, c.vocab_size)
+                        var gen = 0l
+                        while (gen < ngen) {
+                            var acc = 0l   // the accepted id itself is unused here — only the 1-vs-2 advance counts
+                            gen += mtp_spec_eval(t, s, tok, acc) ? 2l : 1l
+                            tok = argmax_logit(s, c.vocab_size)
+                        }
+                        rep_gen += gen   // may overshoot ngen by 1 on a trailing accept — count what ran
+                    } else {
+                        var pos = plen
+                        for (_g in range64(ngen)) {
+                            forward(t, s, argmax_logit(s, c.vocab_size), pos)
+                            pos++
+                        }
+                        rep_gen += ngen
                     }
                     total_us += int64(get_time_usec(t0))
+                    drafted += s.mtp_drafted   // session-lifetime counters; harvest before the free
+                    accepted += s.mtp_accepted
                     delete s
                 }
-                tps |> push(double(int64(length(toks)) * ngen) * 1.0e6lf / double(total_us))
+                tps |> push(double(rep_gen) * 1.0e6lf / double(total_us))
             }
             var tag = "tg-real{ngen}"
             if (cfg.dnd_ab) {
@@ -222,8 +273,18 @@ def main() {
                 tag = "tg-real{ngen} shexp-{ai == 1 ? "on" : "off"}"
             } elif (cfg.qkv_ab) {
                 tag = "tg-real{ngen} qkv-{ai == 1 ? "on" : "off"}"
+            } elif (cfg.mtp_ab) {
+                tag = "tg-real{ngen} mtp-{ai == 1 ? "on" : "off"}"
+            } elif (cfg.batchcls_ab) {
+                tag = "tg-real{ngen} batchcls-{ai == 1 ? "on" : "off"}"
+            } elif (cfg.cls_ab) {
+                tag = "tg-real{ngen} gpucls-{ai == 1 ? "on" : "off"}"
             }
             report(tag, tps)
+            if (mtp_on) {
+                let rate = drafted > 0l ? double(accepted) * 100.0lf / double(drafted) : 0.0lf
+                print("  mtp: {accepted}/{drafted} drafts accepted ({rate:.1f}%)\n")
+            }
             delete tps
         }
         if (cfg.prof) {

--- a/modules/dasLLAMA/benchmarks/decode_real_bench.das
+++ b/modules/dasLLAMA/benchmarks/decode_real_bench.das
@@ -108,7 +108,7 @@ def private load_corpus(path : string) : array<string> {
     var texts : array<string>
     fopen(path, "rb") $(f) {
         if (f == null) {
-            panic("can't open prompt corpus")
+            panic("can't open prompt corpus {path}")
         }
         for (p in split(fread(f), "%%")) {
             let tp = strip(p)

--- a/modules/dasLLAMA/benchmarks/verify_batch_probe.das
+++ b/modules/dasLLAMA/benchmarks/verify_batch_probe.das
@@ -60,7 +60,7 @@ def private load_corpus(path : string) : array<string> {
     var texts : array<string>
     fopen(path, "rb") $(f) {
         if (f == null) {
-            panic("can't open prompt corpus")
+            panic("can't open prompt corpus {path}")
         }
         for (p in split(fread(f), "%%")) {
             let tp = strip(p)

--- a/modules/dasLLAMA/benchmarks/verify_batch_probe.das
+++ b/modules/dasLLAMA/benchmarks/verify_batch_probe.das
@@ -1,0 +1,212 @@
+options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
+options _jit_fast_math = true   // ggml-parity FP laxity — matches how llama.cpp is benched
+
+require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
+require dasllama/dasllama_math   // setup_dasllama_jobque_ + apply_box_profile_runtime (engine-level, not re-exported)
+require dasllama/dasllama_image   // load_model_cached — the .dlim rail, without the full facade's compile weight
+require dasllama/dasllama_tokenizer
+require ../performance/profile_common.das   // profile_threads + affinity_on — the standing per-box methodology
+require daslib/jobque_boost
+require daslib/module_path
+require daslib/strings_boost
+require daslib/clargs
+require daslib/fio
+require math
+
+// Measures `b` — the marginal cost of one extra row in a batched verify — which is the single
+// quantity deciding whether ANY speculative decoding scheme can pay on a model. Each arm advances
+// the same number of positions through forward_prefill at a different batch width, over REAL
+// corpus tokens (routing realism matters on MoE), and reports per-position cost against plain
+// single-token decode. b = T(2)/T(1) - 1 in per-step terms: ~0 means extra rows ride the same
+// weight stream and speculation can pay; ~1 means an extra row costs a whole step and it cannot.
+// The width-1 arm is the control — same work as decode, different code path — so a slow width-1
+// indicts the prefill path itself rather than batching.
+//   bin/daslang -jit modules/dasLLAMA/benchmarks/verify_batch_probe.das -- -m <model.gguf>
+
+[CommandLineArgs]
+struct Args {
+    @clarg_required
+    @clarg_short = "m"
+    @clarg_doc = "Model GGUF path"
+    model : string
+
+    @clarg_doc = "Prompt corpus (segments separated by lines of two percent signs; default: data/wikitext2_prompts.txt beside this bench)"
+    prompts : string = ""
+
+    @clarg_short = "p"
+    @clarg_doc = "Prefill length before the timed window (default: 128)"
+    plen : int = 128
+
+    @clarg_short = "n"
+    @clarg_doc = "Positions advanced per width arm (default: 64)"
+    npos : int = 64
+
+    @clarg_short = "q"
+    @clarg_doc = "Weight quant mode (default: q8)"
+    quant : QuantMode = QuantMode.q8
+
+    @clarg_doc = "Dump the forward_profile section buckets per arm (untimed extra window)"
+    prof : bool
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+let WARM_STEPS = 6l
+
+def private load_corpus(path : string) : array<string> {
+    var texts : array<string>
+    fopen(path, "rb") $(f) {
+        if (f == null) {
+            panic("can't open prompt corpus")
+        }
+        for (p in split(fread(f), "%%")) {
+            let tp = strip(p)
+            if (!empty(tp) && !starts_with(tp, "#")) {
+                texts |> push(clone_string(tp))
+            }
+        }
+    }
+    return <- texts
+}
+
+[export]
+def main() {
+    allow_cpu_prefill()   // CPU-protocol probe by intent — disarm the Metal-build tripwire
+    if (!jit_enabled()) {
+        print("This probe is JIT-only — run with: daslang -jit <file>\n")
+        return
+    }
+    var r <- parse_args(type<Args>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Args>), "verify_batch_probe")
+        return
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Args>), "verify_batch_probe")
+        return
+    }
+    let plen = max(int64(cfg.plen), 1l)
+    let want = max(int64(cfg.npos), 8l)
+    let corpus = empty(cfg.prompts) ? path_join(get_this_module_dir(), "data/wikitext2_prompts.txt") : cfg.prompts
+    var texts <- load_corpus(corpus)
+    if (empty(texts)) {
+        print("error: no prompts in {corpus}\n")
+        return
+    }
+    let threads = has_env_variable("DAS_JOBQUE_THREADS") ? to_int(get_env_variable("DAS_JOBQUE_THREADS")) : profile_threads()
+    if (!has_env_variable("DAS_JOBQUE_THREADS")) {
+        set_jobque_threads_cap(max(threads - 1, 1))
+    }
+    let pinned = affinity_on() && !has_env_variable("DAS_JOBQUE_AFFINITY")
+    if (pinned) {
+        set_jobque_affinity(2)
+    }
+    apply_box_profile_runtime()
+    set_mtp_spec(false)   // the draft head must not ride along — this probe times the trunk alone
+    var tk <- load_tokenizer_auto(cfg.model)
+    print("loading {cfg.model}\n")
+    with_job_que() {
+        setup_dasllama_jobque_()
+        var t <- load_model_cached(cfg.model, cfg.quant)
+        // one long real-token stream: routing on a MoE is content-dependent, so synthetic ids
+        // would understate the union cost the batched arms are here to expose
+        var ids : array<int64>
+        for (tx in texts) {
+            var seg <- encode(tk, tx, false)
+            ids |> push_from(seg)
+            delete seg
+        }
+        let need = plen + WARM_STEPS * 8l + want + 16l
+        if (int64(length(ids)) < need) {
+            print("error: corpus tokenizes to {length(ids)} ids, need {need} — pass a longer --prompts\n")
+            delete ids
+            delete t
+            return
+        }
+        t.config.seq_len = min(t.config.seq_len, need + 8l)
+        let c = t.config
+        print("config: dim={c.dim} layers={c.n_layers} experts={c.n_expert} k={c.n_expert_used} | backend {active_kernel_backend()} (batch {active_batch_backend()}) | t{threads} affinity {pinned ? "hard" : "env/off"} | prefill {plen} + {want} positions per arm\n")
+        var pre : array<int64>
+        pre |> reserve(plen)
+        for (i in range64(plen)) {
+            pre |> push(ids[i])
+        }
+        // control: plain single-token decode, the cost every speculative scheme is measured against
+        var decode_us = 0.0lf
+        {
+            var s <- make_run_state(c)
+            forward_prefill(t, s, pre, plen, 0l)
+            var pos = plen
+            for (_w in range64(WARM_STEPS)) {
+                forward(t, s, ids[pos], pos)
+                pos++
+            }
+            if (cfg.prof) {
+                forward_profile_reset()
+            }
+            let t0 = ref_time_ticks()
+            for (_i in range64(want)) {
+                forward(t, s, ids[pos], pos)
+                pos++
+            }
+            decode_us = double(get_time_usec(t0)) / double(want)
+            if (cfg.prof) {
+                print("--- forward_profile: decode ---\n")
+                forward_profile_report()
+            }
+            delete s
+        }
+        print("decode (forward)      : {decode_us:.0f} us/position  (baseline)\n")
+        let widths = fixed_array(1l, 2l, 4l, 8l)
+        for (w in widths) {
+            var s <- make_run_state(c)
+            forward_prefill(t, s, pre, plen, 0l)
+            var batch : array<int64>
+            batch |> resize(w)
+            var pos = plen
+            for (_w in range64(WARM_STEPS)) {
+                for (j in range64(w)) {
+                    batch[j] = ids[pos + j]
+                }
+                forward_prefill(t, s, batch, w, pos)
+                pos += w
+            }
+            let steps = max(want / w, 1l)
+            if (cfg.prof && w == 2l) {
+                forward_profile_reset()
+            }
+            let t0 = ref_time_ticks()
+            for (_i in range64(steps)) {
+                for (j in range64(w)) {
+                    batch[j] = ids[pos + j]
+                }
+                forward_prefill(t, s, batch, w, pos)
+                pos += w
+            }
+            let us = double(get_time_usec(t0))
+            if (cfg.prof && w == 2l) {
+                print("--- forward_profile: width 2 ---\n")
+                forward_profile_report()
+            }
+            let per_step = us / double(steps)
+            let per_pos = per_step / double(w)
+            // b = marginal cost of one extra row, in units of a plain decode step
+            let b = w > 1l ? (per_step / decode_us - 1.0lf) / double(w - 1l) : per_step / decode_us - 1.0lf
+            let btag = w > 1l ? "b={b:.2f}" : "path overhead {b * 100.0lf:.0f}%"
+            print("prefill width {w}       : {per_step:.0f} us/step  {per_pos:.0f} us/position  ({per_step / decode_us:.2f}x decode)  {btag}\n")
+            delete batch
+            delete s
+        }
+        print("\nb ~ 0 -> extra verify rows are ~free, speculation pays; b ~ 1 -> an extra row costs a whole step, no scheme pays\n")
+        delete pre
+        delete ids
+        delete t
+    }
+    delete tk
+    delete texts
+}

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1787,8 +1787,9 @@ def moe_gpu_upload_resident(var t : Model) {
     let nstream = nstream_want < 0l ? t.config.n_layers : nstream_want
     let dn_want = gpu_want_dn() || gpu_want_dnd()   // the decode step rides the same dn uploads
     let at_want = gpu_want_attn()
+    // layer count tests == 0, NOT <= 0: -1 is the auto sentinel and must read as a REQUEST
     if (!moe_gpu_tier_installed()
-            || (moe_gpu_layer_count() <= 0l && nstream <= 0l && !dn_want && !at_want
+            || (moe_gpu_layer_count() == 0l && nstream <= 0l && !dn_want && !at_want
                 && !gpu_want_shexp() && !gpu_want_qkv() && !gpu_want_cls())) {
         return   // tier absent or nothing requested
     }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1785,7 +1785,7 @@ def moe_gpu_upload_resident(var t : Model) {
     let at_want = gpu_want_attn()
     if (!moe_gpu_tier_installed()
             || (moe_gpu_layer_count() <= 0l && nstream <= 0l && !dn_want && !at_want
-                && !gpu_want_shexp() && !gpu_want_qkv())) {
+                && !gpu_want_shexp() && !gpu_want_qkv() && !gpu_want_cls())) {
         return   // tier absent or nothing requested
     }
     // capability guard: the tier serves q8-mode MoE models only — record WHY for the status
@@ -3727,6 +3727,8 @@ struct Session {
     mtp_xb_save : array<float>     // prompt-warm x_b preservation (the warm's eh_proj output rides x_b for the arch blocks; consumers like mtp_verify_row0 / embed_forward need the trunk hiddens back)
     mtp_logits : array<float>      // verify-batch row-0 logits (vocab; the draft check reads its argmax)
     mtp_vbatch : array<int64>      // the 2-row verify batch [tok, draft] (persistent — no per-step alloc)
+    mtp_norm_b : array<float>      // verify-batch final-normed rows (npos x dim), input to the batched classifier
+    mtp_logits_b : array<float>    // verify-batch logits (npos x vocab) — ONE classifier pass covers every row
     mtp_drafted : int64            // session-lifetime telemetry: drafts attempted / accepted
     mtp_accepted : int64
     // deltanet rollback for a rejected verify batch (sized lazily on first snapshot)
@@ -8260,6 +8262,17 @@ def set_mtp_spec(on : bool) {
 //! Current state of the [[set_mtp_spec]] gate.
 def get_mtp_spec() : bool => g_mtp_spec
 
+var private g_mtp_batch_cls = true
+
+//! One batched classifier pass over the whole MTP verify window instead of a per-row GEMV each —
+//! the plane (vocab x dim) is a step's largest weight read. Pure perf lever; A/B only.
+def set_mtp_batch_cls(on : bool) {
+    g_mtp_batch_cls = on
+}
+
+//! Current state of the [[set_mtp_batch_cls]] gate.
+def get_mtp_batch_cls() : bool => g_mtp_batch_cls
+
 def forward_mtp(t : Model; var s : Session; token, pos : int64; want_logits : bool = true) {
     let c = t.config
     let dim = c.dim
@@ -8333,6 +8346,40 @@ def private mtp_verify_row0(t : Model; var s : Session) {
     }
 }
 
+// The tied-fp32 classifier (mm_fblob) and the GPU-resident plane have no batched form — those keep
+// the per-row path.
+def private mtp_cls_batch_ok(t : Model) : bool {
+    let c = t.config
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
+    return g_mtp_batch_cls && !tied_f32 && !moe_gpu_cls_on_gpu(t.wcls_off)
+}
+
+// One classifier pass for the whole verify window: normalize every row, then a single batched GEMM
+// over the plane. Row 0 feeds the draft check, the last row feeds the next step — the same values
+// the per-row path produces, from one weight stream instead of npos of them.
+def private mtp_verify_logits(t : Model; var s : Session; npos : int64) {
+    let c = t.config
+    let dim = c.dim
+    let vocab = c.vocab_size
+    let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
+    s.mtp_norm_b |> scratch_resize(npos * dim)
+    s.mtp_logits_b |> scratch_resize(npos * vocab)
+    rms_batch(s.mtp_norm_b, s.x_b, t, t.rms_final_off, dim, npos)
+    mm_b_f(s, s.mtp_logits_b, t, cls_fmt, t.wcls_off, s.mtp_norm_b, dim, vocab, npos)
+    copy_floats(s.mtp_logits_b, 0l, s.mtp_logits, 0l, vocab)
+    copy_floats(s.mtp_logits_b, (npos - 1l) * vocab, s.logits, 0l, vocab)
+    // mirror the plain classifier tail exactly — `truth` must match plain decode BY CONSTRUCTION
+    if (c.final_logit_softcap > 0.0) {
+        softcap4(s.mtp_logits, vocab, c.final_logit_softcap)
+        softcap4(s.logits, vocab, c.final_logit_softcap)
+    }
+    for (id in t.suppress) {
+        s.mtp_logits[id] = -1.0e30
+        s.logits[id] = -1.0e30
+    }
+}
+
 // Write the draft head's IN-CHUNK KV rows for a just-prefilled [start_pos, start_pos+npos) window.
 // Rows start_pos..start_pos+npos-2 ride one batched eh_proj GEMM + the arch's blocks at l = n_layers.
 // x_b is saved/restored around the pass: post-prefill contents are load-bearing for mtp_verify_row0.
@@ -8384,8 +8431,13 @@ def mtp_spec_eval(t : Model; var s : Session; tok : int64; var accepted : int64&
     mtp_state_snapshot(s)
     s.mtp_vbatch[0] = tok
     s.mtp_vbatch[1] = d
-    forward_prefill(t, s, s.mtp_vbatch, 2l, pos)
-    mtp_verify_row0(t, s)
+    let batch_cls = mtp_cls_batch_ok(t)
+    forward_prefill(t, s, s.mtp_vbatch, 2l, pos, batch_cls)
+    if (batch_cls) {
+        mtp_verify_logits(t, s, 2l)   // both rows from one classifier stream
+    } else {
+        mtp_verify_row0(t, s)
+    }
     let truth = parallel_argmax(s.mtp_logits, c.vocab_size)
     if (truth == d) {
         s.mtp_accepted++
@@ -10850,7 +10902,7 @@ def private ffn_moe_prefill(t : Model; var s : Session; l : int64; npos : int64)
     }
 }
 
-def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, start_pos : int64) {
+def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, start_pos : int64; skip_logits : bool = false) {
     let c = t.config
     if (npos <= 0l) {
         return
@@ -10887,7 +10939,7 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
     if (g_mtp_spec && c.n_layer_nextn > 0l && start_pos > 0l && s.mtp_h_pos1 == start_pos) {
         forward_mtp(t, s, tokens[0], start_pos - 1l, false)
     }
-    forward_prefill_body(t, s, npos, start_pos)
+    forward_prefill_body(t, s, npos, start_pos, skip_logits)
     if (g_mtp_spec && c.n_layer_nextn > 0l) {   // spec on: maintain the draft head's KV alongside the trunk's
         mtp_prefill_warm(t, s, tokens, npos, start_pos)
     }
@@ -11071,7 +11123,7 @@ def private forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : 
 
 // the shared prefill core: rope table + layer stack + final norm/classifier, over a pre-filled
 // s.x_b residual stream (token or embedding sourced)
-def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : int64) {
+def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : int64; skip_logits : bool = false) {
     let c = t.config
     let dim = c.dim
 
@@ -11120,6 +11172,10 @@ def private forward_prefill_body(t : Model; var s : Session; npos, start_pos : i
     if (c.n_layer_nextn > 0l) {   // stash the last position's h_nextn for the MTP draft head
         copy_floats(s.xb, 0l, s.mtp_h, 0l, dim)
         s.mtp_h_pos1 = start_pos + last + 1l
+    }
+    if (skip_logits) {   // MTP verify: the caller runs ONE batched classifier covering every row
+        prof_add("final", ts_final)
+        return
     }
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1780,7 +1780,11 @@ def moe_gpu_upload_resident(var t : Model) {
     reset_moe_gpu_shexp_layers()
     reset_moe_gpu_qkv_layers()
     set_moe_gpu_model_support("")
-    let nstream = gpu_want_moe_stream()
+    // -1 = auto: ask for every layer and let the walk's own budget stops place the split (the
+    // resident loop drops a partial triple and breaks, the streamed loop does the same on the
+    // pinned-mirror budget) — that is what makes auto degrade on a smaller card instead of failing
+    let nstream_want = gpu_want_moe_stream()
+    let nstream = nstream_want < 0l ? t.config.n_layers : nstream_want
     let dn_want = gpu_want_dn() || gpu_want_dnd()   // the decode step rides the same dn uploads
     let at_want = gpu_want_attn()
     if (!moe_gpu_tier_installed()
@@ -1810,7 +1814,9 @@ def moe_gpu_upload_resident(var t : Model) {
     let dim = t.config.dim
     let ne = t.config.n_expert
     let nfe = t.config.n_ff_exp
-    let want = min(moe_gpu_layer_count(), layers)
+    let want_raw = moe_gpu_layer_count()
+    let want = want_raw < 0l ? layers : min(want_raw, layers)   // -1 = auto: fill the budget
+    set_moe_gpu_layer_count(want)   // publish the resolved count — downstream status reads it
     let repacked = kernel_backend_needs_repack(active_kernel_backend())
     let mr = repacked ? active_q8_layout_mr() : 1l
     let kgroup = repacked ? active_q8_kgroup() : 4l

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1439,7 +1439,11 @@ def public set_moe_gpu_from_layer(from_layer : int64) {
 }
 
 def public moe_gpu_layer_on_gpu(l : int64) : bool {
-    return g_moe_gpu_installed && l >= g_moe_gpu_from_layer
+    // upper bound is load-bearing: the MTP draft block sits at index n_layers, above every uploaded
+    // range, so an unbounded `l >= from_layer` dispatches against a region never uploaded.
+    // total 0 = loader never reported it; keep the old unbounded answer
+    return (g_moe_gpu_installed && l >= g_moe_gpu_from_layer
+        && (g_moe_gpu_total_layers <= 0l || l < g_moe_gpu_total_layers))
 }
 
 //! Loader contract: first streamed layer (streamed range = [from, the resident set); reset per
@@ -1758,8 +1762,9 @@ def public matmul_moe_gpu_ffn_join(var gout : array<float>) {
 //! (an env var present in the environment overrides its field). Set BEFORE ``load_model``,
 //! then call ``moe_gpu_tier_arm`` so a backend can install its hooks.
 struct GpuTierWant {
-    moe_layers : int64   //!< resident expert-stack layers K, offloaded from the end
-    moe_stream : int64   //!< streamed prefill layers S below the resident set
+    auto_tier : bool     //!< request the measured-best rail set; individual knobs below still override
+    moe_layers : int64   //!< resident expert-stack layers K, offloaded from the end (auto: -1 = fill the budget)
+    moe_stream : int64   //!< streamed prefill layers S below the resident set (auto: -1 = all of them)
     vram_mb : int64      //!< resident-weight VRAM cap override in MB (0 = query the device)
     dn : bool            //!< recurrent (deltanet) layers through the device chain
     attn : bool          //!< full-attention layers through the device chain
@@ -1788,34 +1793,44 @@ def public set_gpu_tier_want(want : GpuTierWant) {
 
 def private env_int64(name : string) : int64 => int64(to_int(get_env_variable(name)))
 
+//! One switch for the measured-best rail set: expert stacks sized to the VRAM budget, plus the
+//! deltanet/attention/dense/shared-expert/classifier rails. qkv and heat stay off (measured
+//! negative and a wash). Any DASLLAMA_GPU_* knob still overrides individually.
+def public gpu_want_auto : bool
+    => has_env_variable("DASLLAMA_GPU") ? get_env_variable("DASLLAMA_GPU") == "1" : g_gpu_want.auto_tier
+
 //! Effective tier request, env-else-programmatic — the load walk and the GPU backends read
 //! these instead of the raw env vars.
+
+// -1 = auto: the upload walk resolves it against n_layers and lets its budget stops place the split
 def public gpu_want_moe_layers : int64
-    => has_env_variable("DASLLAMA_GPU_MOE_LAYERS") ? env_int64("DASLLAMA_GPU_MOE_LAYERS") : g_gpu_want.moe_layers
+    => (has_env_variable("DASLLAMA_GPU_MOE_LAYERS") ? env_int64("DASLLAMA_GPU_MOE_LAYERS")
+        : (g_gpu_want.moe_layers != 0l ? g_gpu_want.moe_layers : (gpu_want_auto() ? -1l : 0l)))
 
 def public gpu_want_moe_stream : int64
-    => has_env_variable("DASLLAMA_GPU_MOE_STREAM") ? env_int64("DASLLAMA_GPU_MOE_STREAM") : g_gpu_want.moe_stream
+    => (has_env_variable("DASLLAMA_GPU_MOE_STREAM") ? env_int64("DASLLAMA_GPU_MOE_STREAM")
+        : (g_gpu_want.moe_stream != 0l ? g_gpu_want.moe_stream : (gpu_want_auto() ? -1l : 0l)))
 
 def public gpu_want_vram_mb : int64
     => has_env_variable("DASLLAMA_GPU_VRAM_MB") ? env_int64("DASLLAMA_GPU_VRAM_MB") : g_gpu_want.vram_mb
 
 def public gpu_want_dn : bool
-    => has_env_variable("DASLLAMA_GPU_DN") ? get_env_variable("DASLLAMA_GPU_DN") == "1" : g_gpu_want.dn
+    => has_env_variable("DASLLAMA_GPU_DN") ? get_env_variable("DASLLAMA_GPU_DN") == "1" : (g_gpu_want.dn || gpu_want_auto())
 
 def public gpu_want_attn : bool
-    => has_env_variable("DASLLAMA_GPU_ATTN") ? get_env_variable("DASLLAMA_GPU_ATTN") == "1" : g_gpu_want.attn
+    => has_env_variable("DASLLAMA_GPU_ATTN") ? get_env_variable("DASLLAMA_GPU_ATTN") == "1" : (g_gpu_want.attn || gpu_want_auto())
 
 def public gpu_want_dense : bool
-    => has_env_variable("DASLLAMA_GPU_DENSE") ? get_env_variable("DASLLAMA_GPU_DENSE") == "1" : g_gpu_want.dense
+    => has_env_variable("DASLLAMA_GPU_DENSE") ? get_env_variable("DASLLAMA_GPU_DENSE") == "1" : (g_gpu_want.dense || gpu_want_auto())
 
 def public gpu_want_dnd : bool
-    => has_env_variable("DASLLAMA_GPU_DND") ? get_env_variable("DASLLAMA_GPU_DND") == "1" : g_gpu_want.dnd
+    => has_env_variable("DASLLAMA_GPU_DND") ? get_env_variable("DASLLAMA_GPU_DND") == "1" : (g_gpu_want.dnd || gpu_want_auto())
 
 def public gpu_want_heat : int64
     => has_env_variable("DASLLAMA_GPU_HEAT") ? env_int64("DASLLAMA_GPU_HEAT") : g_gpu_want.heat
 
 def public gpu_want_shexp : bool
-    => has_env_variable("DASLLAMA_GPU_SHEXP") ? get_env_variable("DASLLAMA_GPU_SHEXP") == "1" : g_gpu_want.shexp
+    => has_env_variable("DASLLAMA_GPU_SHEXP") ? get_env_variable("DASLLAMA_GPU_SHEXP") == "1" : (g_gpu_want.shexp || gpu_want_auto())
 
 def public gpu_want_qkv : bool
     => has_env_variable("DASLLAMA_GPU_QKV") ? get_env_variable("DASLLAMA_GPU_QKV") == "1" : g_gpu_want.qkv

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1404,6 +1404,7 @@ var g_moe_gpu_installed = false
 var g_moe_gpu_layer_count = 0l         // K = layers offloaded from the END (env-driven, set by the tier)
 var g_moe_gpu_from_layer = 1000000l    // first offloaded layer (n_layers - K, set by the loader)
 var g_moe_gpu_cls_off = -1l            // element offset of the resident classifier plane (loader contract)
+var g_moe_gpu_cls_route = true         // runtime routing gate over the resident classifier (--cls-ab lever)
 var g_moe_gpu_stream_from = 1000000l   // first STREAMED layer (streamed range = [stream_from, from_layer))
 var g_moe_gpu_dense_offs : table<int64>   // resident dense planes, keyed woff * 8 + fmt (per-format offset spaces)
 var g_moe_gpu_dense_route = true       // runtime routing gate over the marks (in-process A/B lever)
@@ -1458,7 +1459,13 @@ def public set_moe_gpu_cls_off(woff : int64) {
 }
 
 def public moe_gpu_cls_on_gpu(woff : int64) : bool {
-    return g_moe_gpu_installed && woff == g_moe_gpu_cls_off
+    return g_moe_gpu_installed && g_moe_gpu_cls_route && woff == g_moe_gpu_cls_off
+}
+
+//! Runtime routing gate over the resident classifier plane (the --cls-ab in-process lever).
+//! Route flip only — the upload and its VRAM residency stay, matching the other tier gates.
+def public set_moe_gpu_cls_route(on : bool) {
+    g_moe_gpu_cls_route = on
 }
 
 //! Loader contract: mark one dense (attention-side) plane resident on the tier. Keyed by
@@ -1812,6 +1819,12 @@ def public gpu_want_shexp : bool
 
 def public gpu_want_qkv : bool
     => has_env_variable("DASLLAMA_GPU_QKV") ? get_env_variable("DASLLAMA_GPU_QKV") == "1" : g_gpu_want.qkv
+
+//! Arm-intent for the classifier plane. The UPLOAD is opt-OUT (DASLLAMA_GPU_CLS=0 declines it), so
+//! this is only the stronger "=1 arms the tier by itself" signal — letting the classifier offload be
+//! measured without also offloading expert layers. Unset keeps today's behavior exactly.
+def public gpu_want_cls : bool
+    => get_env_variable("DASLLAMA_GPU_CLS") == "1"
 
 //! A GPU backend registers its arm probe here at ``[init]`` so config-driven arming works
 //! after module init (the env path arms at ``[init]`` directly).

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4164,7 +4164,7 @@ def private vk_device_name : string {
 def vulkan_moe_gpu_arm : bool {
     let layers = gpu_want_moe_layers()
     if ((layers <= 0l && gpu_want_moe_stream() <= 0l && !gpu_want_dn() && !gpu_want_attn() && !gpu_want_dnd()
-                && gpu_want_heat() <= 0l && !gpu_want_shexp() && !gpu_want_qkv())
+                && gpu_want_heat() <= 0l && !gpu_want_shexp() && !gpu_want_qkv() && !gpu_want_cls())
             || !vulkan_backend_available()) {
         return false   // nothing requested (checked first — the device probe is not free)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4163,7 +4163,9 @@ def private vk_device_name : string {
 //! Idempotent — re-arming after ``set_gpu_tier_want`` just refreshes the layer count.
 def vulkan_moe_gpu_arm : bool {
     let layers = gpu_want_moe_layers()
-    if ((layers <= 0l && gpu_want_moe_stream() <= 0l && !gpu_want_dn() && !gpu_want_attn() && !gpu_want_dnd()
+    // counts test == 0, NOT <= 0: -1 is the auto sentinel and must read as a REQUEST, or an
+    // auto-sized-layers-only want would silently fail to arm
+    if ((layers == 0l && gpu_want_moe_stream() == 0l && !gpu_want_dn() && !gpu_want_attn() && !gpu_want_dnd()
                 && gpu_want_heat() <= 0l && !gpu_want_shexp() && !gpu_want_qkv() && !gpu_want_cls())
             || !vulkan_backend_available()) {
         return false   // nothing requested (checked first — the device probe is not free)

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -154,10 +154,12 @@ first — Windows locks the exe.
 Config precedence: `defaults < config TOML < explicit CLI flags` — unless the TOML carries
 `authoritative = true` (what the control page saves), which flips the top: `defaults < CLI <
 authoritative TOML`. The `gpu` key (`off | metal | metal-required | vulkan`) is the first-class
-backend selector; `gpu = vulkan` arms the MoE tier with the blessed shape (K=2 resident + S=35
-streamed expert stacks + DN + ATTN) unless the `gpu_layers` / `gpu_stream` / `gpu_dn` / `gpu_attn`
-/ `gpu_dense` / `gpu_vram_mb` keys override it. The `DASLLAMA_GPU_*` env vars still override
-everything (they remain the A/B levers).
+backend selector; `gpu = vulkan` arms the MoE tier in its blessed shape — expert stacks sized
+**automatically** (resident layers fill the VRAM budget, the rest stream) plus DN + ATTN + dense +
+the resident shared expert. `gpu_layers` / `gpu_stream` are `0` = auto by default; set either to a
+positive value to pin it exactly, and `gpu_dn` / `gpu_attn` / `gpu_dense` / `gpu_vram_mb` override
+the rest. The `DASLLAMA_GPU_*` env vars still override everything (they remain the A/B levers), and
+`DASLLAMA_GPU=1` requests the same auto shape without a config file.
 
 ### Chat
 

--- a/utils/dasllama-server/control.html
+++ b/utils/dasllama-server/control.html
@@ -1219,16 +1219,12 @@ function renderForm(surface, status) {
         if (f.t === "bool") cell.append(input, label); else cell.append(label, input);
         form.append(cell);
     }
-    // switching gpu to vulkan while every detail knob still shows its raw unset sentinel would
-    // SAVE those zeros as explicit authoritative values and disarm the tier on restart — fill
-    // in the blessed serving shape (K=2 + S=35 + DN + ATTN) so the form shows what will run
+    // gpu_layers / gpu_stream 0 means AUTO server-side (fill the VRAM budget, stream the rest), so
+    // the zeros are safe to save now and the form no longer invents box-specific counts — only the
+    // rail toggles need filling in so the page shows what will actually run
     $("f-gpu").addEventListener("change", () => {
         if ($("f-gpu").value === "vulkan"
-            && Math.trunc(Number($("f-gpu_layers").value)) === 0
-            && Math.trunc(Number($("f-gpu_stream").value)) === 0
             && !$("f-gpu_dn").checked && !$("f-gpu_attn").checked) {
-            $("f-gpu_layers").value = "2";
-            $("f-gpu_stream").value = "35";
             $("f-gpu_dn").checked = true;
             $("f-gpu_attn").checked = true;
         }

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -403,11 +403,15 @@ def private cfg_sourced(key : string) : bool
 
 // vulkan detail knobs — explicit config/CLI wins; unset gets the blessed serving shape
 // (K=2 resident + S=35 streamed + DN + ATTN) under gpu = vulkan
+// 0 / unset = auto (-1): the loader fills the VRAM budget and streams the rest; a positive value
+// pins it exactly. The old hardcoded K=2/S=35 was tuned to one 3060 Ti, and auto measured slightly
+// BETTER there (4/36, 26.30 vs 26.11 tg-real256). Treating 0 as auto also removes the control-page
+// trap where saving the raw unset sentinels wrote explicit zeros and disarmed the tier on restart.
 def private gpu_detail_layers(cfg : ServerArgs) : int64
-    => int64(cfg_sourced("gpu_layers") ? cfg.gpu_layers : 2)
+    => int64(cfg_sourced("gpu_layers") && cfg.gpu_layers > 0 ? cfg.gpu_layers : -1)
 
 def private gpu_detail_stream(cfg : ServerArgs) : int64
-    => int64(cfg_sourced("gpu_stream") ? cfg.gpu_stream : 35)
+    => int64(cfg_sourced("gpu_stream") && cfg.gpu_stream > 0 ? cfg.gpu_stream : -1)
 
 def private gpu_detail_dn(cfg : ServerArgs) : bool
     => cfg_sourced("gpu_dn") ? cfg.gpu_dn : true
@@ -653,12 +657,17 @@ def init() {
     set_metal_mode(metal_mode)
     to_log(LOG_INFO, "dasllama-server: metal mode {get_metal_mode()}\n")
     if (gpu == "vulkan") {
+        // shexp rides the blessed shape: the resident shared expert measured +8.3% on decode
+        // (decode-arc S2) and was missing here. The booleans stay explicit rather than riding
+        // auto_tier, so an explicit `gpu_dn = false` still turns its rail off.
         set_gpu_tier_want(GpuTierWant(
             moe_layers = gpu_detail_layers(g_cfg), moe_stream = gpu_detail_stream(g_cfg),
             vram_mb = int64(g_cfg.gpu_vram_mb), dn = gpu_detail_dn(g_cfg),
-            attn = gpu_detail_attn(g_cfg), dense = g_cfg.gpu_dense))
+            attn = gpu_detail_attn(g_cfg), dense = g_cfg.gpu_dense, shexp = true))
         if (moe_gpu_tier_arm()) {
-            to_log(LOG_INFO, "dasllama-server: vulkan GPU tier armed (K={gpu_detail_layers(g_cfg)}, S={gpu_detail_stream(g_cfg)}, dn={gpu_detail_dn(g_cfg)}, attn={gpu_detail_attn(g_cfg)})\n")
+            let ktag = gpu_detail_layers(g_cfg) < 0l ? "auto" : "{gpu_detail_layers(g_cfg)}"
+            let stag = gpu_detail_stream(g_cfg) < 0l ? "auto" : "{gpu_detail_stream(g_cfg)}"
+            to_log(LOG_INFO, "dasllama-server: vulkan GPU tier armed (K={ktag}, S={stag}, dn={gpu_detail_dn(g_cfg)}, attn={gpu_detail_attn(g_cfg)})\n")
         } else {
             to_log(LOG_WARNING, "dasllama-server: gpu = vulkan requested but the tier did not arm (no vulkan device, or this build lacks the vulkan module)\n")
         }


### PR DESCRIPTION
Session goal was to find out whether anything MTP-related could beat our best non-MTP GPU decode baseline on `Qwen3.6-35B-A3B`. The answer is **no**, with a measured reason — but getting there turned up one real crash, one solid GPU win, and a config simplification.

All numbers: `decode_real_bench`, `tg-real256`, 8 prompts, 16 lanes, RTX 3060 Ti, in-process A/B (route flip only, so box drift cancels).

## 1. `auto` GPU tier config

Reproducing 26 tg took seven env vars, two of which are counts tuned to one box (`MOE_LAYERS=2`, `MOE_STREAM=35`). `DASLLAMA_GPU=1` (or `GpuTierWant.auto_tier`) now requests the measured-best set — `dn`/`attn`/`dense`/`shexp` on, `qkv` and `heat` off, both measured negative/wash in the S1+S3 decode-arc commits — and resolves the counts to `-1` = "ask for every layer", letting the upload walk's existing budget stops place the split.

On this box auto finds a **better** split than the hand-tuned one, with headroom left:

| config | split | VRAM | tg-real256 |
|---|---|---|---|
| explicit `MOE_LAYERS=2 MOE_STREAM=35 …` | 2 resident / 35 streamed | 2979MB | 26.11 ± 0.12 |
| `DASLLAMA_GPU=1` | 4 resident / 36 streamed | 3977MB | **26.30 ± 0.15** |

Both upload loops already drop a partial triple and break when VRAM or the pinned-mirror budget runs out, so this degrades on a smaller card rather than failing. Every `DASLLAMA_GPU_*` knob still overrides individually and arming is unchanged — existing invocations behave exactly as before. Not yet validated on other GPUs; the per-knob overrides are the escape hatch.

## 2. Resident GPU classifier route (`--cls-ab`)

The classifier plane (`vocab × dim`) is a decode step's largest single weight read — ~27% on A3B, where the trunk touches only 3B of 35B params but the classifier still reads 100% of itself. Measured **in isolation** (`DASLLAMA_GPU_CLS=1` now arms the tier by itself, so no expert layers are offloaded — `resident 0L`, 421MB VRAM, classifier only):

```
gpucls-off 15.68 ± 0.21  ->  gpucls-on 17.43 ± 0.19   (+11.2%, MTP file)
gpucls-off 14.55 ± 0.66  ->  gpucls-on 16.77 ± 0.61   (+15.3%, non-MTP file)
```

It composes with the resident shared expert rather than competing: `shexp-off 16.69 ± 0.38 -> shexp-on 17.57 ± 0.06` (+5.3% on top), for +20.8% cumulative over CPU-only.

Worth noting this is a **synchronous** offload that pays, which bounds the decode-arc rule: sync offload fails when the work is too small to amortize the submit (qkv 0, heat negative), not because it's synchronous. 413MB against a ~0.3ms submit is firmly on the paying side. It's also the cheapest possible use of a GPU — one fixed plane, no streaming, fits any card with ~500MB free.

Getting there needed three gates that all omitted `cls`: the arm condition, the upload condition (a separate "nothing requested" check), and a missing `g_moe_gpu_cls_route` A/B gate that every other tier surface already had.

## 3. Crash fix: MTP draft block vs the tier

`moe_gpu_layer_on_gpu()` was `l >= from_layer` with **no upper bound**. The MTP draft block sits at layer index `n_layers` — above every uploaded range — so it satisfied the test, routed to the tier, and hit:

```
EXCEPTION: vulkan tier: dispatch against a region that is neither resident nor streamed
           (fmt 1 element offset 10868490240)
```

Reproducible with any NextN model plus any tier offload. Nobody hit it because the MTP arc ran tier-off and the server ships `mtp = false`. Bounded by `g_moe_gpu_total_layers`, with `total == 0` keeping the old unbounded answer so the synthetic-stack tier tests are unaffected.

## 4. Batched MTP verify classifier

The 2-row verify streamed the whole classifier plane **twice** (`forward_prefill`'s tail for row 1, `mtp_verify_row0` for row 0). `mtp_verify_logits` now does one `rms_batch` + one `mm_b_f` covering every row:

```
batchcls-off 11.46 ± 0.07  ->  batchcls-on 11.89 ± 0.01   (+3.8%)
```

Below the ~10–17% a fully eliminated stream is worth, so `mm_b_kq` recovers only part of it at `npos=2`. Output-invariant — accept counts identical across the flip, and `test_mtp` passes including the K-quant 27B case that covers `mm_b_kq`.

`forward_prefill`/`_body` take `skip_logits` (defaulted, all existing callers byte-identical); when set, the tail returns after the `rms` + `mtp_h` stash so the caller owns the classifier. `mtp_cls_batch_ok` keeps tied-fp32 and GPU-resident classifiers on the per-row path — neither has a batched form.

## Why the MTP-side change is deliberately small

Under the full tier, MTP measures **0.45x** (`mtp-off 27.91` vs `mtp-on 12.55`, 70.9% accept) — a spec step costs 3.80 decode-equivalents. The new `verify_batch_probe` isolates why:

```
decode (forward)  : 36902 us/position
prefill width 1   : 72178 us/step   (1.96x decode)   path overhead 96%
prefill width 2   : 90189 us/step   (2.44x decode)
prefill width 8   : 157236 us/step  (4.26x decode)
```

Identical work through `forward_prefill` instead of `forward` costs **96%**, because every GPU decode win (deltanet decode-step chain, resident shared expert, GPU classifier) lives on the `forward` path only, and a verify uses the prefill path. At depth 1 that's fatal in a way no drafter can fix: `verify(2) = 90189` exceeds `2 × decode = 73804`, so speculation loses even at 100% acceptance.

Speculation only regains room at width ≥ 4 (`3.10 < 4`, `4.26 < 8`), which needs recursive drafting plus routing narrow verifies through the decode chain. Left as future work — at 78% acceptance even width 8 pencils out near 0.67x.

## Benches

- `verify_batch_probe.das` (new) — measures `b`, the marginal cost of an extra verify row, the quantity that decides whether any speculative scheme can pay. Includes a width-1 control isolating path-switch cost from batching.
- `decode_real_bench.das` — `--mtp-ab`, `--batchcls-ab`, `--cls-ab`, `--grouped-off`.

## Gates

- `test_mtp` 8/8 (incl. K-quant 27B invariance)
- `test_vulkan_tier` 16/16
- lint + format clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
