### PR TITLE
dasLLAMA: GPU tier serves mixed q8/kq expert triples (opens glm4moe)

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2059,12 +2059,13 @@ def moe_gpu_upload_resident(var t : Model) {
         let f1 = fmt_at(t.we1_fmt, l)
         let f2 = fmt_at(t.we2_fmt, l)
         let f3 = fmt_at(t.we3_fmt, l)
-        let all_q8 = f1 == KqFmt.q8 && f2 == KqFmt.q8 && f3 == KqFmt.q8
-        let all_kq = moe_gpu_fmt_kq(f1) && moe_gpu_fmt_kq(f2) && moe_gpu_fmt_kq(f3)
-        // dense-lead layers carry no expert stacks; the tier offloads plain-q8 or all-K-quant
-        // stack triples (a q8/kq mix would need two activation forms in one chain) — either way
-        // the walk stops so the resident set stays contiguous from the end
-        if (l < t.config.n_layer_dense_lead || t.we1_offs[l] < 0l || !(all_q8 || all_kq)) {
+        // gate/up must share a form (one activation image); down is free. llama.cpp's Q4_K_M MoE
+        // recipe bumps ffn_down_exps to Q5_0/Q8_0, so k4/k4/q8 is the COMMON shape (glm4moe,
+        // gemma). The walk stops on refusal so the resident set stays contiguous from the end.
+        let gu_ok = ((f1 == KqFmt.q8) == (f3 == KqFmt.q8)
+            && (f1 == KqFmt.q8 || (moe_gpu_fmt_kq(f1) && moe_gpu_fmt_kq(f3))))
+        let dn_ok = f2 == KqFmt.q8 || moe_gpu_fmt_kq(f2)
+        if (l < t.config.n_layer_dense_lead || t.we1_offs[l] < 0l || !(gu_ok && dn_ok)) {
             break
         }
         var got = 0
@@ -2100,9 +2101,10 @@ def moe_gpu_upload_resident(var t : Model) {
         let f1 = fmt_at(t.we1_fmt, l)
         let f2 = fmt_at(t.we2_fmt, l)
         let f3 = fmt_at(t.we3_fmt, l)
-        let all_q8 = f1 == KqFmt.q8 && f2 == KqFmt.q8 && f3 == KqFmt.q8
-        let all_kq = moe_gpu_fmt_kq(f1) && moe_gpu_fmt_kq(f2) && moe_gpu_fmt_kq(f3)
-        if (!(all_q8 || all_kq)) {
+        // same rule as the resident walk: gate/up share one activation image, down is free
+        let gu_ok = ((f1 == KqFmt.q8) == (f3 == KqFmt.q8)
+            && (f1 == KqFmt.q8 || (moe_gpu_fmt_kq(f1) && moe_gpu_fmt_kq(f3))))
+        if (!(gu_ok && (f2 == KqFmt.q8 || moe_gpu_fmt_kq(f2)))) {
             break
         }
         var got = 0

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -2592,12 +2592,12 @@ def private ensure_batch_set(si : int; ybuf, xqbuf, xsbuf : uint64; xqbytes, xsb
 }
 
 // chunk row cap: the gathered x window, both hidden planes, the requant planes, and the down
-// output (which reuses y1) must all fit their buffers. xunit = the activation scale block size
-// (32 for Q8_0 chains, 256 for Q8_K)
-def private ffn_chunk_rows(n, nfe, xunit : int64) : int64 {
-    var r = min(BATCH_XQ_BYTES / n, BATCH_XS_BYTES / ((n / xunit) * 4l))
+// output (which reuses y1) must all fit their buffers. Two activation units: `in` = gate/up
+// image, `mid` = intermediate (follows the DOWN stack, may differ). 32 for Q8_0, 256 for Q8_K.
+def private ffn_chunk_rows(n, nfe, xunit_in, xunit_mid : int64) : int64 {
+    var r = min(BATCH_XQ_BYTES / n, BATCH_XS_BYTES / ((n / xunit_in) * 4l))
     r = min(r, BATCH_Y_BYTES / (max(nfe, n) * 4l))
-    r = min(r, min(BATCH_HQ_BYTES / nfe, BATCH_HS_BYTES / ((nfe / xunit) * 4l)))
+    r = min(r, min(BATCH_HQ_BYTES / nfe, BATCH_HS_BYTES / ((nfe / xunit_mid) * 4l)))
     return min(r, BATCH_CHUNK_ROWS)
 }
 
@@ -2792,11 +2792,12 @@ def private vk_moe_ffn_batch(var goutp : float?; offs1 : int64 const?; offs3 : i
     let s1 = find_stack(unsafe(offs1[0]), f1)
     let s3 = find_stack(unsafe(offs3[0]), f3)
     let s2 = find_stack(unsafe(offs2[0]), f2)
-    // upload walk only admits all-q8 or all-kq triples, so kq-ness must agree across the three stacks
-    let kq = f1 != 0
-    assert((f3 != 0) == kq && (f2 != 0) == kq,
-        "dasLLAMA vulkan tier: q8/kq mixed stack triple in one FFN chain")
-    let xunit = kq ? 256l : 32l
+    // gate/up share one activation image (forms must agree); down's intermediate is its own unit
+    let kq_in = f1 != 0
+    assert((f3 != 0) == kq_in,
+        "dasLLAMA vulkan tier: gate/up form mismatch — they share one activation image")
+    let xunit_in = kq_in ? 256l : 32l
+    let xunit_mid = f2 != 0 ? 256l : 32l
     ensure_batch_state()
     ensure_batch_set(s1, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
     ensure_batch_set(s3, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
@@ -2815,7 +2816,7 @@ def private vk_moe_ffn_batch(var goutp : float?; offs1 : int64 const?; offs3 : i
             par_memcpy(reinterpret<void?>(cp + COMB_WI_BYTES), reinterpret<void? -const>(invp), nrows * 4l)
         }
     }
-    let chunk = ffn_chunk_rows(n, nfe, xunit)
+    let chunk = ffn_chunk_rows(n, nfe, xunit_in, xunit_mid)
     var r0 = 0l
     while (r0 < nrows) {
         let r1 = min(r0 + chunk, nrows)
@@ -2826,10 +2827,10 @@ def private vk_moe_ffn_batch(var goutp : float?; offs1 : int64 const?; offs3 : i
         assert(nwg1 == nwg3, "dasLLAMA vulkan tier: fused batch pair region mismatch")
         let nwg2 = fill_batch_meta(s2, offs2, nregions, nfe, n, r0, r1)
         let ts1 = ref_time_ticks()
-        upload_batch_acts(xqp, xsp, r0, rows, n, xunit)
+        upload_batch_acts(xqp, xsp, r0, rows, n, xunit_in)
         let ts2 = ref_time_ticks()
-        fill_ffn_meta(rows * nfe, rows * nfe / xunit, is_gelu, comb ? n : 0l, comb_k, r0, r1)
-        record_ffn_batch_cmd(s1, s3, s2, nwg1, nwg2, rows, nfe, rows * n * 4l, rows * n, rows * (n / xunit) * 4l,
+        fill_ffn_meta(rows * nfe, rows * nfe / xunit_mid, is_gelu, comb ? n : 0l, comb_k, r0, r1)
+        record_ffn_batch_cmd(s1, s3, s2, nwg1, nwg2, rows, nfe, rows * n * 4l, rows * n, rows * (n / xunit_in) * 4l,
             [comb_npos = comb ? uint(npos) : 0u, comb_first = r0 == 0l, comb_last = r1 == nrows,
              comb_wi_bytes = nrows * 4l, comb_y_bytes = npos * n * 4l])
         let ts3 = ref_time_ticks()
@@ -3647,20 +3648,21 @@ def private ffn_gemv_prep(offs1 : int64 const?; offs3 : int64 const?; offs2 : in
     let s3 = find_stack(unsafe(offs3[0]), f3)
     let s2 = find_stack(unsafe(offs2[0]), f2)
     assert(nrows * max(nfe, n) * 4l <= Y_BYTES, "dasLLAMA vulkan tier: FFN dispatch exceeds output capacity")
-    // upload walk only admits all-q8 or all-kq triples, so kq-ness must agree across the three stacks
-    let kq = f1 != 0
-    assert((f3 != 0) == kq && (f2 != 0) == kq,
-        "dasLLAMA vulkan tier: q8/kq mixed stack triple in one FFN chain")
-    let xunit = kq ? 256l : 32l
+    // gate/up share one activation image (same xqp below) so forms must agree; down's is its own
+    let kq_in = f1 != 0
+    assert((f3 != 0) == kq_in,
+        "dasLLAMA vulkan tier: gate/up form mismatch — they share one activation image")
+    let xunit_in = kq_in ? 256l : 32l
+    let xunit_mid = f2 != 0 ? 256l : 32l
     ensure_gemv_scratch(s1)
     ensure_gemv_scratch(s3)
     ensure_gemv_scratch(s2)
-    fill_stack_meta_rows(s1, offs1, nregions, n, nfe, nrows, n / xunit)
-    fill_stack_meta_rows(s3, offs3, nregions, n, nfe, nrows, n / xunit)
-    fill_stack_meta_rows(s2, offs2, nregions, nfe, n, nrows, nfe / xunit)
+    fill_stack_meta_rows(s1, offs1, nregions, n, nfe, nrows, n / xunit_in)
+    fill_stack_meta_rows(s3, offs3, nregions, n, nfe, nrows, n / xunit_in)
+    fill_stack_meta_rows(s2, offs2, nregions, nfe, n, nrows, nfe / xunit_mid)
     fill_stack_acts(s1, xqp, xsp, nrows * n)
     fill_stack_acts(s3, xqp, xsp, nrows * n)
-    fill_ffn_meta(nrows * nfe, nrows * nfe / xunit, is_gelu)
+    fill_ffn_meta(nrows * nfe, nrows * nfe / xunit_mid, is_gelu)
     return (cmd = ffn_cmd_for(s1, s3, s2, nrows, n, nfe), s2 = s2)
 }
 

--- a/modules/dasLLAMA/tests/test_vulkan_tier.das
+++ b/modules/dasLLAMA/tests/test_vulkan_tier.das
@@ -684,6 +684,9 @@ def private ref_ffn_kq(offs1, offs3, offs2 : array<int64>; nreg : int;
                        w1, w3, w2 : array<float>;
                        xq : array<int8>; xs : array<float>; nrows : int64; var gout : array<float>;
                        midblk : int = 256) {
+    // a midblk that does not divide KNFE would silently drop h's tail and produce a WRONG
+    // baseline — masking a real kernel failure. verify, not assert: this must hold in release too
+    verify(int(KNFE) % midblk == 0, "ref_ffn_kq: midblk must divide KNFE")
     gout |> resize(int(nrows * KN))
     let nsb = int(KN / 256l)
     let nsbh = int(KNFE) / midblk
@@ -990,6 +993,19 @@ def test_vulkan_moe_ffn_mixed(t : T?) {
             t |> success(c.maxref > 0.0, "mixed batch arm produced non-trivial outputs")
             t |> success(c.maxdiff <= float(REL_TOL) * c.maxref,
                 "mixed k4/k4/q8 batch arm within tolerance (maxdiff {c.maxdiff} vs {float(REL_TOL) * c.maxref} bar, maxref {c.maxref})")
+            delete wq1
+            delete ws1
+            delete wq3
+            delete ws3
+            delete dq2
+            delete ds2
+            delete wqb
+            delete wsb
+            delete w1
+            delete w3
+            delete w2
+            delete xq
+            delete xs
             delete gout
             delete refv
         } else {

--- a/modules/dasLLAMA/tests/test_vulkan_tier.das
+++ b/modules/dasLLAMA/tests/test_vulkan_tier.das
@@ -678,12 +678,15 @@ def private fill_acts_kq(var xq : array<int8>; var xs : array<float>; nrows : in
 // the CPU reference of the kq FFN contract: dequantized weights against the Q8_K activation
 // image (per-256 scales), silu, per-256 Q8_K requant, dequantized-down GEMM — double
 // accumulation, judged by the same relative-tolerance bar as the q8 arms
+// midblk = the INTERMEDIATE's requant block: 256 when down is a K-quant, 32 when down is q8.
+// The gate/up dots always ride the kq 256-block activation image; only the h -> down hop changes.
 def private ref_ffn_kq(offs1, offs3, offs2 : array<int64>; nreg : int;
                        w1, w3, w2 : array<float>;
-                       xq : array<int8>; xs : array<float>; nrows : int64; var gout : array<float>) {
+                       xq : array<int8>; xs : array<float>; nrows : int64; var gout : array<float>;
+                       midblk : int = 256) {
     gout |> resize(int(nrows * KN))
     let nsb = int(KN / 256l)
-    let nsbh = int(KNFE / 256l)
+    let nsbh = int(KNFE) / midblk
     var gate : array<float>
     var up : array<float>
     var h : array<float>
@@ -724,22 +727,22 @@ def private ref_ffn_kq(offs1, offs3, offs2 : array<int64>; nreg : int;
             }
             for (sb in range(nsbh)) {
                 var amax = 0.0
-                for (j in range(256)) {
-                    amax = max(amax, abs(h[sb * 256 + j]))
+                for (j in range(midblk)) {
+                    amax = max(amax, abs(h[sb * midblk + j]))
                 }
                 let d = amax / 127.0
                 let id = d != 0.0 ? 1.0 / d : 0.0
                 hs[sb] = d
-                for (j in range(256)) {
-                    hq[sb * 256 + j] = int(round(h[sb * 256 + j] * id))
+                for (j in range(midblk)) {
+                    hq[sb * midblk + j] = int(round(h[sb * midblk + j] * id))
                 }
             }
             for (o in range(int(KN))) {
                 var y = 0.0lf
                 for (sb in range(nsbh)) {
                     var dd = 0.0lf
-                    for (j in range(256)) {
-                        dd += double(w2[(rb2 + o) * int(KNFE) + sb * 256 + j]) * double(hq[sb * 256 + j])
+                    for (j in range(midblk)) {
+                        dd += double(w2[(rb2 + o) * int(KNFE) + sb * midblk + j]) * double(hq[sb * midblk + j])
                     }
                     y += dd * double(hs[sb])
                 }
@@ -895,6 +898,105 @@ let KDWOFF = 31000000l  // k4 dense plane base (kq offset space, clear of KWOFF*
 let DROP_WOFF = 32000000l   // drop-arm scratch plane (q8 space)
 let DD = 160l           // dense output dim (%32)
 let DNR = 40l           // batch rows — one full 32-tile plus an unpadded remainder
+
+// llama.cpp's Q4_K_M MoE recipe bumps ffn_down_exps to Q5_0/Q8_0 while gate/up stay Q4_K, so
+// k4/k4/q8 is the shape real files ship (glm4moe, gemma). gate/up must agree (one activation
+// image); down is free — the chain requants the intermediate in the DOWN stack's form.
+let MXOFF1 = 210000000l
+let MXOFF3 = 220000000l
+let MXOFF2 = 230000000l
+
+def private dequant_q8_stack(wq : array<int8>; ws : array<float>; rows, n : int64; var w : array<float>) {
+    let nb = int(n / 32l)
+    w |> resize(int(rows * n))
+    for (r in range64(rows)) {
+        for (i in range64(n)) {
+            w[int(r * n + i)] = float(wq[int(r * n + i)]) * ws[int(r) * nb + int(i / 32l)]
+        }
+    }
+}
+
+[test]
+def test_vulkan_moe_ffn_mixed(t : T?) {
+    t |> run("vulkan MoE mixed triple (k4 gate/up + q8 down) == CPU reference") @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            install_moe_gpu_tier(@@vk_moe_ffn, @@vk_moe_upload_stack, @@vk_moe_cls, @@vk_moe_dense, @@vk_moe_drop_stacks, @@vk_moe_dn, @@vk_moe_attn)
+            var wq1 : array<uint8>
+            var ws1 : array<uint8>
+            var wq3 : array<uint8>
+            var ws3 : array<uint8>
+            fill_kq_stack(1, NE * KNFE, KN, 61l, true, wq1, ws1)
+            fill_kq_stack(1, NE * KNFE, KN, 67l, true, wq3, ws3)
+            var up_ok = moe_gpu_upload_stack(wq1, ws1, MXOFF1, KN, NE * KNFE, 1)
+            if (!up_ok) {
+                feint("no Vulkan device (or probe/budget refused the upload); skipping\n")
+                return
+            }
+            up_ok = moe_gpu_upload_stack(wq3, ws3, MXOFF3, KN, NE * KNFE, 1)
+            t |> success(up_ok, "k4 up stack uploaded")
+            // down: plain q8, the format the Q5_0/Q8_0 downs land in after the loader's transcode
+            var dq2 : array<int8>
+            var ds2 : array<float>
+            fill_stack(dq2, ds2, NE * KN, KNFE, 71l, false)
+            var wqb : array<uint8>
+            var wsb : array<uint8>
+            pack_upload(dq2, ds2, wqb, wsb)
+            up_ok = moe_gpu_upload_stack(wqb, wsb, MXOFF2, KNFE, NE * KN, 0)
+            t |> success(up_ok, "q8 down stack uploaded")
+
+            var w1 : array<float>
+            var w3 : array<float>
+            var w2 : array<float>
+            dequant_kq_stack(1, wq1, ws1, NE * KNFE, KN, w1)
+            dequant_kq_stack(1, wq3, ws3, NE * KNFE, KN, w3)
+            dequant_q8_stack(dq2, ds2, NE * KN, KNFE, w2)
+            let ege1 = KNFE * KN
+            let ege2 = KN * KNFE
+
+            var xq : array<int8>
+            var xs : array<float>
+            fill_acts_kq(xq, xs, 2l)
+            var offs1 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], MXOFF1, ege1)
+            var offs3 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], MXOFF3, ege1)
+            var offs2 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], MXOFF2, ege2)
+            var gout : array<float>
+            gout |> resize(int(2l * KN))
+            matmul_moe_gpu_ffn(gout, offs1, offs3, offs2, 2l, xq, xs, KN, KNFE, 2l, 1, 1, 0, false)
+            // ref_ffn_kq derives its row bases against the KWOFF* constants, so the reference
+            // gets its own offsets over the same regions (the GPU side rides the MXOFF* stacks)
+            let refoffs1 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], KWOFF1, ege1)
+            let refoffs3 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], KWOFF3, ege1)
+            let refoffs2 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], KWOFF2, ege2)
+            var refv : array<float>
+            ref_ffn_kq(refoffs1, refoffs3, refoffs2, 2, w1, w3, w2, xq, xs, 2l, refv, 32)
+            var c = compare_gout(gout, refv)
+            t |> success(c.maxref > 0.0, "mixed decode arm produced non-trivial outputs")
+            t |> success(c.maxdiff <= float(REL_TOL) * c.maxref,
+                "mixed k4/k4/q8 decode arm within tolerance (maxdiff {c.maxdiff} vs {float(REL_TOL) * c.maxref} bar, maxref {c.maxref})")
+
+            // batch arm: 40 rows (>= the 32-row tile, unpadded) — vk_moe_ffn_batch carries its own
+            // xunit split and chunk sizing, so the decode arm above does NOT cover it
+            fill_acts_kq(xq, xs, 40l)
+            var boffs1 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], MXOFF1, ege1)
+            var boffs3 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], MXOFF3, ege1)
+            var boffs2 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], MXOFF2, ege2)
+            gout |> resize(int(40l * KN))
+            matmul_moe_gpu_ffn(gout, boffs1, boffs3, boffs2, 2l, xq, xs, KN, KNFE, 40l, 1, 1, 0, false)
+            let rboffs1 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], KWOFF1, ege1)
+            let rboffs3 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], KWOFF3, ege1)
+            let rboffs2 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], KWOFF2, ege2)
+            ref_ffn_kq(rboffs1, rboffs3, rboffs2, 2, w1, w3, w2, xq, xs, 40l, refv, 32)
+            c = compare_gout(gout, refv)
+            t |> success(c.maxref > 0.0, "mixed batch arm produced non-trivial outputs")
+            t |> success(c.maxdiff <= float(REL_TOL) * c.maxref,
+                "mixed k4/k4/q8 batch arm within tolerance (maxdiff {c.maxdiff} vs {float(REL_TOL) * c.maxref} bar, maxref {c.maxref})")
+            delete gout
+            delete refv
+        } else {
+            feint("vulkan module not built; skipping\n")
+        }
+    }
+}
 
 [test]
 def test_vulkan_dense_gemm(t : T?) {


### PR DESCRIPTION
Follow-on to #3521 — this commit was pushed to that branch after the merge snapshot was taken, so it didn't land. Self-contained: opens the GPU expert rail for `glm4moe` (and any other model llama.cpp's Q4_K recipes touch).

## The problem

llama.cpp's Q4_K MoE recipes bump `ffn_down_exps` to Q5_0/Q8_0 while `gate`/`up` stay Q4_K. After the loader's exact Q5_0→Q8 transcode, **every** layer's expert triple is `k4/k4/q8`. The upload walk demanded `all_q8 || all_kq`, so on GLM-4.5-Air it broke at the *first* layer and no expert stack could ever be tier-resident — with 2.8GB of a 4.2GB budget unspent.

This is not a VRAM problem and not model-specific: it's a property of the quantizer. Gemma hits the same shape, and **both** GLM quants mix (`Q4_K_M`: down = Q5_0×24 / Q8_0×22; `Q4_K_S`: Q5_0×42 / Q5_1×4), so "use a different quant" was not an escape — I downloaded Q4_K_S to check, and it doesn't even load (Q5_1 unsupported).

## The device side was already mixed-capable

Both `ffn_cmd_for` and `record_ffn_batch_cmd` already bind per-stack pipelines (with an explicit rebind when `gate != up`) and select the requant pipeline **off the down stack** — `actrq_k_pipeline` vs `actrq_pipeline`, with the matching `256:32` dispatch. Their comments state the intent outright. Only host-side guards blocked it.

## The fix

Split the single `xunit` into two. `gate`/`up` genuinely must agree — `fill_stack_acts` hands both the **same** `xqp` buffer, so one activation form. `down` consumes the *intermediate*, a separate activation, so it gets its own unit:

- `ffn_gemv_prep` (decode) and `vk_moe_ffn_batch` (batch), plus `ffn_chunk_rows`, whose chunk cap sizes the input window and the intermediate planes against different buffers
- the resident **and** streamed upload walks now require only that `gate`/`up` share a class

## Measured — GLM-4.5-Air Q4_K_M (RTX 3060 Ti, 16 lanes, `tg-real64`)

| config | VRAM | t/s | Δ |
|---|---|---|---|
| tier off | 0 | 5.20 | — |
| + classifier | 514MB | 5.45 | +4.8% |
| + shared expert | 1359MB | 5.72 | +5.0% |
| **+ 1 expert layer** | 2997MB | **5.80** | **+1.4%** |

+1.4% is small because one 1.85GB triple is all the 4.2GB cap holds. **The point is the slope**: each resident layer is `1/46` of routed-expert traffic, so this model now scales with VRAM instead of being capped at classifier+shexp forever. Extrapolating the measured slope (`t(L) ≈ 175ms − 2.24ms·L`), 10 t/s would need ~34 resident layers ≈ 64GB.

## Tests

New `k4/k4/q8` arm in `test_vulkan_tier` with **both** decode and batch (40-row) cells against the CPU reference; `ref_ffn_kq` takes a `midblk` so the intermediate requant matches the down form.

Red-then-green verified by reverting only the two engine files — the arm trips `q8/kq mixed stack triple in one FFN chain` at `dasllama_math_vulkan.das:3652` without the change:

```
without engine change : 18 tests, 16 passed, 2 errors
with engine change    : 18 tests, 18 passed, 0 errors
```

`test_mtp` 8/8 unaffected. Lint + format clean.

## Known gaps (recorded, not fixed here)

- **auto doesn't clamp `nstream`** against the tier's slot reserve — 46 layers throws `stream slots exceed STREAM_RESERVE`. Auto clamps *resident* layers via the walk's budget stops, but nothing bounds streaming against tier capacity. Worked around in measurement with `DASLLAMA_GPU_MOE_STREAM=0` (streaming is prefill-only anyway — the dense/stream rails gate on `npos >= 32`).
- **No unit coverage on the upload-walk gate.** `test_vulkan_tier` uploads synthetic stacks directly and never enters `moe_gpu_upload_resident`, so the `dasllama_common` half is exercised only by the real-model run.
- **Q5_1 unsupported**, which is what blocks Q4_K_S entirely.
- **No text-level correctness check** for GLM with the tier engaged — the unit arms validate the kernel against a CPU reference, which is not the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
