### PR TITLE
Preserve watcher failure state after process exit

### DIFF
--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -38,6 +38,9 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(!empty(failed.session_id), "failed PTY launch retains its diagnostic session")
         t |> success(find(watcher_snapshot_json(failed.session_id), "\"state\":\"failed\"") >= 0,
             "failed PTY launch is retained in watcher state")
+        watcher_tick()
+        t |> success(find(watcher_snapshot_json(failed.session_id), "\"state\":\"failed\"") >= 0,
+            "process exit observation preserves the failed state")
 
         let quick = watcher_launch(WatcherLaunchRequest(
             command_line = "powershell.exe -NoProfile -Command \"Write-Output watcher-core-ok\"",

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -264,7 +264,9 @@ def private observe_exit(var session : WatcherSession?; now_ms : int64) {
     if (session.exit_seen_ms >= 0l || !terminal_process_exited(session.terminal)) return
     session.exit_seen_ms = now_ms
     session.exit_code = terminal_exit_code(session.terminal)
-    session.state = "exited"
+    if (session.state != "failed") {
+        session.state = "exited"
+    }
     session.status_revision++
     if (session.last_data_ms == 0l) {
         session.last_data_ms = now_ms


### PR DESCRIPTION
## Summary
- keep watcher sessions in the ailed state when later process-exit observation records exit metadata
- cover failed-launch sessions across a watcher tick

## Focused validation
- changed-file daScript lint: 0 issues
- watcher tests with LLVM JIT: 2/2 passed
- watcher tests in interpreter mode: 2/2 passed
- formatter verification passed for both changed files