### PR TITLE
dasLLAMA: GPU-prefill MTP warm — NextN models serve wholly on Metal, the planar engagement phase is gone

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -272,6 +272,16 @@ def register_mtp_spec_override(name : string; fn : MtpSpecOverrideFn) {
     g_mtp_spec_overrides[name] = fn
 }
 
+// The MTP seam-row override: writes the draft head's row pos-1 on a blob model BEFORE a
+// continuation window's trunk body (forward_mtp(..., false)'s GPU twin) — the body's own
+// tail overwrites mtp_h, so the seam must consume the pre-window handoff first
+typedef MtpSeamOverrideFn = function<(t : Model; var s : Session; token, pos : int64) : bool>
+var private g_mtp_seam_overrides : table<string; MtpSeamOverrideFn>
+
+def register_mtp_seam_override(name : string; fn : MtpSeamOverrideFn) {
+    g_mtp_seam_overrides[name] = fn
+}
+
 // "would the metal drivers serve this loaded model?" — the model-level gate, registered by the
 // metal driver module at [init] (it owns the path masks). load_model consults it to pick the
 // image flavor: servable -> the blob-only metal flavor, else the planar CPU flavor.
@@ -11003,8 +11013,14 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
 
     // spec on: the draft head's SEAM row (start_pos-1) must be written BEFORE the body — the body's
     // own tail overwrites mtp_h with THIS window's last hidden. Cold/foreign handoff just skips it.
-    if (g_mtp_spec && c.n_layer_nextn > 0l && !t.metal_blob && start_pos > 0l && s.mtp_h_pos1 == start_pos) {
-        forward_mtp(t, s, tokens[0], start_pos - 1l, false)
+    if (g_mtp_spec && c.n_layer_nextn > 0l && start_pos > 0l && s.mtp_h_pos1 == start_pos) {
+        if (t.metal_blob) {
+            if (!empty(g_decode_override_name) && key_exists(g_mtp_seam_overrides, g_decode_override_name)) {
+                invoke(g_mtp_seam_overrides[g_decode_override_name], t, s, tokens[0], start_pos)
+            }
+        } else {
+            forward_mtp(t, s, tokens[0], start_pos - 1l, false)
+        }
     }
     forward_prefill_body(t, s, npos, start_pos, skip_logits)
     // spec on: maintain the draft head's KV alongside the trunk's — CPU rail only (on a blob

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -11016,7 +11016,11 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
     if (g_mtp_spec && c.n_layer_nextn > 0l && start_pos > 0l && s.mtp_h_pos1 == start_pos) {
         if (t.metal_blob) {
             if (!empty(g_decode_override_name) && key_exists(g_mtp_seam_overrides, g_decode_override_name)) {
-                invoke(g_mtp_seam_overrides[g_decode_override_name], t, s, tokens[0], start_pos)
+                if (!invoke(g_mtp_seam_overrides[g_decode_override_name], t, s, tokens[0], start_pos)) {
+                    // quality-only miss: the stale seam row dents draft acceptance until the next
+                    // draft rewrites it (the verify keeps outputs exact) — loud so a dip is traceable
+                    to_log(LOG_WARNING, "dasLLAMA: MTP seam row declined at pos {start_pos} — draft acceptance may dip this window\n")
+                }
             }
         } else {
             forward_mtp(t, s, tokens[0], start_pos - 1l, false)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -148,8 +148,8 @@ def private kq_fmt_at(a : array<KqFmt>; l : int64) : KqFmt => empty(a) ? KqFmt.q
 // and have no fp32-table GEMV.
 def private metal_model_servable_impl(t : Model) : bool {
     let cls_fmt = t.config.shared_weights ? t.emb_fmt : t.wcls_fmt
-    // tied-fp32 classifier (no fp32-table GEMV); MTP stays planar until stage 4 (GPU logits skip the mtp_h stash)
-    if ((t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) || t.config.n_layer_nextn > 0l) {
+    // tied-fp32 classifier declines (no fp32-table GEMV); NextN serves — prefill stashes mtp_h + warms the slab
+    if (t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) {
         return false
     }
     return decode_shape_decline(t, DECODE_NEEDS_OK, true) == MetalDecodeDecline.none

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -982,9 +982,9 @@ def private encode_cls_tail(t : Model; var r : StepRes; enc : MetalComputeEncode
 }
 
 // encode the MTP draft-head step: [enorm(embed) ; hnorm(mtp_h)] -> eh_proj -> the trunk-shaped
-// block at l == n_layers -> shared-head norm + classifier. The caller poked bx = raw embed row,
-// bxb2 = mtp_h, bcos/bsin = the DRAFT row's rope table; r.pos is the draft row (trunk pos - 1)
-def private encode_draft_step(t : Model; var r : StepRes) {
+// block at l == n_layers -> shared-head norm + classifier (skipped for the seam-row variant).
+// The caller poked bx = raw embed row, bxb2 = mtp_h, bcos/bsin = the DRAFT row's rope table
+def private encode_draft_step(t : Model; var r : StepRes; with_cls : bool = true) {
     let c = t.config
     let dim = c.dim
     var cb = metal_new_command_buffer_unretained(g_queue)
@@ -1002,7 +1002,9 @@ def private encode_draft_step(t : Model; var r : StepRes) {
     }
     var dn0 = 0l
     encode_layer(t, r, enc, c.n_layers, dn0)
-    encode_cls_tail(t, r, enc, t.mtp_headnorm_off >= 0l ? t.mtp_headnorm_off : t.rms_final_off)
+    if (with_cls) {
+        encode_cls_tail(t, r, enc, t.mtp_headnorm_off >= 0l ? t.mtp_headnorm_off : t.rms_final_off)
+    }
     metal_end_encoding(enc)
     metal_release(enc)
     metal_commit(cb)
@@ -1010,10 +1012,10 @@ def private encode_draft_step(t : Model; var r : StepRes) {
     r.cb = cb
 }
 
-// land the draft step: the draft-slab KV row back to the CPU cache, logits, the mtp_h handoff.
-// NO watermark/dn-cursor touch — the draft rewrites a row BELOW the watermark in its OWN slab,
-// and never runs the recurrent branch (layer_is_recurrent is false at n_layers by construction)
-def private finish_draft_step(t : Model; var s : Session; r : StepRes) : bool {
+// land the draft step: the draft-slab KV row back to the CPU cache, logits + mtp_h handoff
+// (the seam variant lands the KV row ONLY). NO watermark/dn-cursor touch — the draft rewrites
+// a row BELOW the watermark in its OWN slab and never runs the recurrent branch
+def private finish_draft_step(t : Model; var s : Session; r : StepRes; seam : bool = false) : bool {
     metal_wait_until_completed(r.cb)
     let err = metal_command_buffer_error(r.cb)
     let ok = empty(err)
@@ -1031,13 +1033,17 @@ def private finish_draft_step(t : Model; var s : Session; r : StepRes) : bool {
                 reinterpret<void?>(kmp + lb + dpos * rowb), int(rowb))
             memcpy(reinterpret<void?>(kv_layer_vbase(s, l, c.seq_len) + prow * rowb),
                 reinterpret<void?>(vmp + lb + dpos * rowb), int(rowb))
-            if (r.bnc == null) {
-                memcpy(addr < void? >(s.logits[0]), metal_buffer_contents(r.blog), int(r.bytes_log))
+            if (!seam) {
+                if (r.bnc == null) {
+                    memcpy(addr < void? >(s.logits[0]), metal_buffer_contents(r.blog), int(r.bytes_log))
+                }
+                // the head's own h_nextn — recursive drafting handoff (forward_mtp's contract)
+                memcpy(addr < void? >(s.mtp_h[0]), metal_buffer_contents(r.bxf), int(r.bytes_x))
             }
-            // the head's own h_nextn — recursive drafting handoff (forward_mtp's contract)
-            memcpy(addr < void? >(s.mtp_h[0]), metal_buffer_contents(r.bxf), int(r.bytes_x))
         }
-        s.mtp_h_pos1 = 0l   // NOT a trunk hidden: the warm's seam row must not consume it
+        if (!seam) {
+            s.mtp_h_pos1 = 0l   // NOT a trunk hidden: the warm's seam row must not consume it
+        }
     } else {
         to_log(LOG_ERROR, "dasLLAMA metal MTP draft: dispatch failed ({err})\n")
         decline(MetalDecodeDecline.gpu_error)
@@ -1048,7 +1054,7 @@ def private finish_draft_step(t : Model; var s : Session; r : StepRes) : bool {
 //! forward_mtp's GPU twin: the draft head against a resident blob model. `pos` is the trunk
 //! position (n_past); the draft row lands at pos-1 (rotary is delta-invariant). Needs a
 //! GPU-current session (KV mirror holds rows [0, pos)) and GPU logits. false = declined.
-def metal_mtp_draft_forward(t : Model; var s : Session; token, pos : int64) : bool {
+def metal_mtp_draft_forward(t : Model; var s : Session; token, pos : int64; seam : bool = false) : bool {
     let c = t.config
     if (g_dev == null || !t.metal_blob || c.n_layer_nextn <= 0l || pos < 1l ||
             weight_caches_stale() || !key_exists(g_mirrors, s.uid)) {
@@ -1072,10 +1078,16 @@ def metal_mtp_draft_forward(t : Model; var s : Session; token, pos : int64) : bo
         memcpy(metal_buffer_contents(r.bcos), addr < void? >(s.rope_cos[0]), int(r.bytes_tab))
         memcpy(metal_buffer_contents(r.bsin), addr < void? >(s.rope_sin[0]), int(r.bytes_tab))
     }
-    encode_draft_step(t, r)
-    let ok = finish_draft_step(t, s, r)
+    encode_draft_step(t, r, !seam)
+    let ok = finish_draft_step(t, s, r, seam)
     release_step(r)
     return ok
+}
+
+//! forward_mtp(..., false)'s GPU twin — the continuation-window SEAM: write the draft head's
+//! KV row pos-1 from (embed(token), the pre-window mtp_h) without touching logits or mtp_h.
+def metal_mtp_seam_row(t : Model; var s : Session; token, pos : int64) : bool {
+    return metal_mtp_draft_forward(t, s, token, pos, true)
 }
 
 // ===== MTP B=2 same-slab verify (the spec step's trunk forward) =====
@@ -3201,6 +3213,7 @@ def dasllama_metal_llama_register() {
     register_decode_override("metal", @@metal_decode_forward)
     register_batch_decode_override("metal", @@metal_batch_decode_forward)
     register_mtp_spec_override("metal", @@metal_mtp_spec_eval)
+    register_mtp_seam_override("metal", @@metal_mtp_seam_row)
     register_metal_servable(@@metal_model_servable_impl)   // load_model's image-flavor gate
     if (has_env_variable("DASLLAMA_METAL_DECODE_SKIP")) {
         g_skip = get_env_variable("DASLLAMA_METAL_DECODE_SKIP")

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -5892,9 +5892,16 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             memcpy(addr < void? >(s.x_b[0]), metal_buffer_contents(bx), int(npos * dim * 4l))
             if (gpu_logits) {
                 memcpy(addr < void? >(s.logits[0]), metal_buffer_contents(blog), int(c.vocab_size * 4l))
+                if (c.n_layer_nextn > 0l) {
+                    // forward_prefill's mtp_h contract — bxf holds the last row's post-final-norm hidden
+                    memcpy(addr < void? >(s.mtp_h[0]), metal_buffer_contents(bxf), int(dim * 4l))
+                }
             }
         }
         if (gpu_logits) {
+            if (c.n_layer_nextn > 0l) {
+                s.mtp_h_pos1 = start_pos + npos
+            }
             prefill_override_logits_done()
         }
         readback_us += int64(get_time_usec(ts_rb))

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -5449,9 +5449,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     // command-buffer split (DASLLAMA_METAL_NCB chunks): each chunk commits as soon as encoded, so
     // the scheduler analyzes chunk k while chunk k-1 executes. DASLLAMA_METAL_UNRETAINED=1 skips
     // per-dispatch retain/release too. Default ~4 layers/chunk (3B: slack 57ms -> 9ms, +10% pp512).
-    let ncb = clamp(int64(pf_env_int("DASLLAMA_METAL_NCB", int((c.n_layers + 3l) / 4l))), 1l, c.n_layers)
+    let ncb = clamp(int64(pf_env_int("DASLLAMA_METAL_NCB", int((n_enc_layers + 3l) / 4l))), 1l, n_enc_layers)
     let unret = get_env_variable("DASLLAMA_METAL_UNRETAINED") == "1"
-    let layers_per_cb = (c.n_layers + ncb - 1l) / ncb
+    let layers_per_cb = (n_enc_layers + ncb - 1l) / ncb
     var cbs : array<MetalCommandBuffer?>
     cbs |> reserve(int(ncb))
     var cb : MetalCommandBuffer?

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -3645,6 +3645,28 @@ class MetalPfCopy {
     }
 }
 
+// Interleave two [npos x d] panels into the [npos x 2d] MTP eh_proj input — the draft-warm
+// cat rows [enorm(embed) ; hnorm(hidden)]; one thread per source element.
+class MetalPfCat2 {
+    @ssbo @binding = 0 y : array<float>
+    @ssbo @binding = 1 a : array<float>
+    @ssbo @binding = 2 b : array<float>
+    @uniform @binding = 3 d : uint
+    @uniform @binding = 4 total : uint      // grid guard: npos * d
+
+    [metal_kernel(name="metal_pf_cat2_msl")]
+    def metal_pf_cat2 {
+        let gid = gl_GlobalInvocationID.x
+        if (gid >= total) {
+            return
+        }
+        let p = gid / d
+        let i = gid % d
+        y[p * 2u * d + i] = a[gid]
+        y[p * 2u * d + d + i] = b[gid]
+    }
+}
+
 // Suppress-token pinning (gemma4): logits[ids[i]] = -1e30 after the soft cap — the CPU
 // forward's pin value exactly; one thread per suppressed id.
 class MetalSuppressRow {
@@ -4065,6 +4087,7 @@ var private g_pf_zero : MetalBuffer?        // persistent 0u — the sink/hass i
 var private g_pf_pso_softcap : MetalComputePipeline?
 var private g_pf_pso_suppress : MetalComputePipeline?
 var private g_pf_pso_copy : MetalComputePipeline?
+var private g_pf_pso_cat2 : MetalComputePipeline?
 var private g_pf_pso_add : MetalComputePipeline?
 var private g_pf_pso_mm : MetalComputePipeline?    // the production das mul_mm (34B q8 blocks + f32 X)
 var private g_pso_qkmm : MetalComputePipeline?
@@ -4260,6 +4283,10 @@ def public metal_prefill_shutdown {
         metal_release(g_pf_pso_copy)
         g_pf_pso_copy = null
     }
+    if (g_pf_pso_cat2 != null) {
+        metal_release(g_pf_pso_cat2)
+        g_pf_pso_cat2 = null
+    }
     if (g_pf_pso_add != null) {
         metal_release(g_pf_pso_add)
         g_pf_pso_add = null
@@ -4375,6 +4402,7 @@ def private metal_prefill_init : bool {
     g_pf_pso_softcap = pf_compile_pso(metal_softcap_row_msl, metal_softcap_row_msl_entry, metal_softcap_row_msl_fastmath, ok)
     g_pf_pso_suppress = pf_compile_pso(metal_suppress_row_msl, metal_suppress_row_msl_entry, metal_suppress_row_msl_fastmath, ok)
     g_pf_pso_copy = pf_compile_pso(metal_pf_copy_msl, metal_pf_copy_msl_entry, metal_pf_copy_msl_fastmath, ok)
+    g_pf_pso_cat2 = pf_compile_pso(metal_pf_cat2_msl, metal_pf_cat2_msl_entry, metal_pf_cat2_msl_fastmath, ok)
     g_pf_pso_add = pf_compile_pso(metal_add_msl, metal_add_msl_entry, metal_add_msl_fastmath, ok)
     g_pf_pso_mm = pf_compile_pso(metal_q8_mulmm_msl, metal_q8_mulmm_msl_entry, metal_q8_mulmm_msl_fastmath, ok)
     g_pso_kq_mm4 = pf_compile_pso(metal_kq_mulmm_k4_msl, metal_kq_mulmm_k4_msl_entry, metal_kq_mulmm_k4_msl_fastmath, ok)
@@ -5227,10 +5255,10 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var bsin_swa = dual_rope ? pool_acquire_untracked(g_pf_upool, g_pf_dev, bytes_tab_sw) : null
     var bks : array<MetalBuffer?>
     var bvs : array<MetalBuffer?>
-    bks |> reserve(int(c.n_layers))
-    bvs |> reserve(int(c.n_layers))
+    bks |> reserve(int(c.n_layers + c.n_layer_nextn))
+    bvs |> reserve(int(c.n_layers + c.n_layer_nextn))
     var no_panel : MetalBuffer?   // recurrent layers' null K/V slot
-    for (l in range64(c.n_layers)) {
+    for (l in range64(c.n_layers + c.n_layer_nextn)) {
         if (layer_kv_dim(c, l) == 0l) {   // recurrent layer (deltanet): no K/V at all
             bks |> push(no_panel)
             bvs |> push(no_panel)
@@ -5259,7 +5287,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             let gather_nrun = kv_runs(s, 0l, start_pos, s.kv_runs)
             let runsg = addr < KVRun const? >(s.kv_runs[0])
             let sgp = (s.kv_dtype_k == KVDtype.tq4 || s.kv_dtype_v == KVDtype.tq4) ? addr < float const? >(s.kv_signs[0]) : null
-            for (l in range64(c.n_layers)) {
+            for (l in range64(c.n_layers + c.n_layer_nextn)) {
                 if (bks[l] == null) {   // recurrent layer — no rows to gather
                     continue
                 }
@@ -5359,9 +5387,10 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     let tied_f32 = c.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8
     // knockout mode keeps gpu logits: constant across skip configs (deltas stay clean), and a
-    // blob-only metal-flavor load HAS no CPU classifier to fall back to
+    // blob-only metal-flavor load HAS no CPU classifier to fall back to. NextN models serve
+    // too — the readback stashes mtp_h from bxf (forward_prefill's handoff contract)
     let gpu_logits = (!g_pf_logits_cpu && get_env_variable("DASLLAMA_METAL_LOGITS") != "0" &&
-        !tied_f32 && c.n_layer_nextn == 0l &&
+        !tied_f32 &&
         t.wcls_off >= 0l)
     var bxf = gpu_logits ? pool_acquire(g_pf_pool, g_pf_dev, uint64(dim * 4l)) : null
     var blog = gpu_logits ? pool_acquire(g_pf_pool, g_pf_dev, uint64(c.vocab_size * 4l)) : null
@@ -5380,6 +5409,33 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             }
         }
         u_nsupp = pf_uniform_u32(uint(nsupp))
+    }
+    // MTP draft-slab warm (spec on): ONE extra loop iteration runs the draft block at FULL
+    // npos so every trunk uniform reuses verbatim — the last warm row is garbage by design
+    // (needs the unknown next token), causally unread, rewritten by the next draft/seam
+    let warm = (get_mtp_spec() && c.n_layer_nextn == 1l && gpu_logits && t.mtp_ehproj_off >= 0l &&
+        (dim % 64l) == 0l)
+    let n_enc_layers = c.n_layers + (warm ? 1l : 0l)
+    var bwm_res : MetalBuffer?    // warm: trunk residual save (x_b readback + the cls tail read it)
+    var bwm_emb : MetalBuffer?    // warm: shifted embed rows
+    var bwm_cat : MetalBuffer?    // warm: [mp x 2dim] eh_proj input
+    var bwm_tmp : MetalBuffer?    // warm: rms_final intermediate
+    var u_dim2 : MetalBuffer?
+    var u_wm_tot : MetalBuffer?
+    if (warm) {
+        bwm_res = pool_acquire(g_pf_pool, g_pf_dev, uint64(npos * dim * 4l))
+        bwm_emb = pool_acquire(g_pf_pool, g_pf_dev, uint64(npos * dim * 4l))
+        bwm_cat = pool_acquire(g_pf_pool, g_pf_dev, uint64(mp * 2l * dim * 4l))
+        bwm_tmp = pool_acquire(g_pf_pool, g_pf_dev, uint64(npos * dim * 4l))
+        u_dim2 = pf_uniform_u32(uint(2l * dim))
+        u_wm_tot = pf_uniform_u32(uint(npos * dim))
+        // shifted embeds: row p pairs the NEXT position's embed with hidden p — s.x_b still
+        // holds the window's embed panel here; the garbage last row reuses row 0
+        unsafe {
+            var dst = reinterpret<uint8?>(metal_buffer_contents(bwm_emb))
+            memcpy(reinterpret<void?>(dst), addr < void? >(s.x_b[dim]), int((npos - 1l) * dim * 4l))
+            memcpy(reinterpret<void?>(dst + (npos - 1l) * dim * 4l), addr < void? >(s.x_b[0]), int(dim * 4l))
+        }
     }
     // ggml-geometry QK/AV (default): ~10x the old trio GEMMs' rate; needs hs % 64 (the AV grid;
     // BOTH classes) and mp % 64 (the QK key grid — true by construction). DASLLAMA_METAL_ATTN=0
@@ -5402,7 +5458,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var enc : MetalComputeEncoder?
     var dnli = 0l   // recurrent-layer index — addresses the dn state/conv mirror slices in order
     {
-        for (l in range64(c.n_layers)) {
+        for (l in range64(n_enc_layers)) {
             if (l % layers_per_cb == 0l) {
                 if (enc != null) {
                     metal_end_encoding(enc)
@@ -5412,6 +5468,37 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 }
                 cb = unret ? metal_new_command_buffer_unretained(g_pf_queue) : metal_new_command_buffer(g_pf_queue)
                 enc = metal_new_compute_encoder(cb)
+            }
+            if (warm && l == c.n_layers) {
+                // trunk done — save the residual panel (x_b readback + cls read it), then swap
+                // bx to the draft block's eh_proj input; the body below runs the draft layer
+                // verbatim (same uniforms, npos rows, K/V panel + weight arrays at index l)
+                unsafe {
+                    metal_set_pipeline(enc, g_pf_pso_copy)
+                    metal_set_buffer(enc, bwm_res, 0ul, 0)
+                    metal_set_buffer(enc, bx, 0ul, 1)
+                    metal_set_buffer(enc, u_wm_tot, 0ul, 2)
+                    metal_dispatch_threadgroups(enc, uint3(uint((npos * dim + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
+                    var bw_en = pf_upload_region(addr < void? >(t.fblob[t.mtp_enorm_off]), uint64(dim * 4l))
+                    pf_enc_rms(enc, bwm_emb, bw_en, bxb, u_dim, u_eps, npos)
+                    var bw_fin = pf_upload_region(addr < void? >(t.fblob[t.rms_final_off]), uint64(dim * 4l))
+                    pf_enc_rms(enc, bx, bw_fin, bwm_tmp, u_dim, u_eps, npos)
+                    var bw_hn = pf_upload_region(addr < void? >(t.fblob[t.mtp_hnorm_off]), uint64(dim * 4l))
+                    pf_enc_rms(enc, bwm_tmp, bw_hn, bxb2, u_dim, u_eps, npos)
+                    metal_set_pipeline(enc, g_pf_pso_cat2)
+                    metal_set_buffer(enc, bwm_cat, 0ul, 0)
+                    metal_set_buffer(enc, bxb, 0ul, 1)
+                    metal_set_buffer(enc, bxb2, 0ul, 2)
+                    metal_set_buffer(enc, u_dim, 0ul, 3)
+                    metal_set_buffer(enc, u_wm_tot, 0ul, 4)
+                    metal_dispatch_threadgroups(enc, uint3(uint((npos * dim + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
+                    if (t.mtp_ehproj_fmt == KqFmt.q8) {
+                        let behp = pf_blob_of(t, t.mtp_ehproj_off)
+                        enc_gemm_mm(enc, behp.buf, behp.boff, bwm_cat, bx, u_dim2, u_dim, mp, dim)
+                    } else {
+                        pf_enc_kq_site_mm(enc, t, t.mtp_ehproj_fmt, t.mtp_ehproj_off, dim, bwm_cat, bx, u_dim2, u_dim, mp)
+                    }
+                }
             }
             unsafe {
                 var bw_att = pf_upload_region(addr < void? >(t.fblob[t.rms_att_off + l * dim]), uint64(dim * 4l))
@@ -5785,7 +5872,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             // s.logits, so this closes the whole forward inside the GPU window
             unsafe {
                 var bwfin = pf_upload_region(addr < void? >(t.fblob[t.rms_final_off]), uint64(dim * 4l))
-                enc_rms_last(enc, bx, uint64((npos - 1l) * dim * 4l), bwfin, bxf, u_dim, u_eps)
+                enc_rms_last(enc, warm ? bwm_res : bx, uint64((npos - 1l) * dim * 4l), bwfin, bxf, u_dim, u_eps)
                 if (cls_fmt != KqFmt.q8) {
                     pf_enc_kq_gemv(enc, t, cls_fmt, t.wcls_off, c.vocab_size, bxf, 0ul, blog, u_dim, u_vocab)
                 } else {
@@ -5844,7 +5931,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             metal_release(cbi)
             if (ran) {
                 let ts_rb = ref_time_ticks()
-                let l1 = min(int64(i + 1) * layers_per_cb, c.n_layers)
+                let l1 = min(int64(i + 1) * layers_per_cb, n_enc_layers)
                 for (l in range64(int64(i) * layers_per_cb, l1)) {
                     if (bks[l] == null) {   // recurrent layer — no K/V rows to store
                         continue
@@ -5889,7 +5976,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         }
         let ts_rb = ref_time_ticks()
         unsafe {
-            memcpy(addr < void? >(s.x_b[0]), metal_buffer_contents(bx), int(npos * dim * 4l))
+            memcpy(addr < void? >(s.x_b[0]), metal_buffer_contents(warm ? bwm_res : bx), int(npos * dim * 4l))
             if (gpu_logits) {
                 memcpy(addr < void? >(s.logits[0]), metal_buffer_contents(blog), int(c.vocab_size * 4l))
                 if (c.n_layer_nextn > 0l) {
@@ -5963,13 +6050,21 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         pool_release(g_pf_pool, blog, uint64(c.vocab_size * 4l))
         pool_release(g_pf_upool, u_vocab, 4ul)
     }
+    if (warm) {
+        pool_release(g_pf_pool, bwm_res, uint64(npos * dim * 4l))
+        pool_release(g_pf_pool, bwm_emb, uint64(npos * dim * 4l))
+        pool_release(g_pf_pool, bwm_cat, uint64(mp * 2l * dim * 4l))
+        pool_release(g_pf_pool, bwm_tmp, uint64(npos * dim * 4l))
+        pool_release(g_pf_upool, u_dim2, 4ul)
+        pool_release(g_pf_upool, u_wm_tot, 4ul)
+    }
     pool_release(g_pf_upool, bcos, bytes_tab)
     if (dual_rope) {
         pool_release(g_pf_upool, bcos_swa, bytes_tab_sw)
         pool_release(g_pf_upool, bsin_swa, bytes_tab_sw)
     }
     pool_release(g_pf_upool, bsin, bytes_tab)
-    for (l in range64(c.n_layers)) {
+    for (l in range64(c.n_layers + c.n_layer_nextn)) {
         if (bks[l] == null) {
             continue
         }


### PR DESCRIPTION
Follow-up to #3527: the Metal prefill now stashes the MTP handoff and warms the draft slab, so a NextN model under metal mode mints the blob flavor and runs everything — prompt processing included — on the GPU. The v1 engagement's planar-CPU-prefill phase (spec-warm prefill on the de-tuned portable backend, then blob conversion) is deleted end to end.

## Why

Prompt processing was the dominant cost of using GPU MTP at all: a 27B measurement cycle spent ~85 of its ~90 minutes in 18 planar CPU prefills, and any real serving flow paid the same phase per prompt. Iteration time is the resource; this removes the wall at the source instead of parking it.

| cell (8 wikitext2 prompts x 256 tok) | before | after | ratio | acceptance |
|---|---|---|---|---|
| 0.8B Q8 | ~36s | **18s** (prefill 1.1s, all 16 windows) | 1.235x | 92.8% |
| 27B Q4KM | **~90 min** | **5.4 min** (prefill 40.5s) | 1.246x | 86.3% |

Ratios and acceptance match the #3527 ladder — the GPU warm is functionally identical to the CPU warm it replaces.

## How

- **mtp_h stash**: the prefill's classifier tail already computes the last row's post-final-norm hidden (`bxf`); the readback copies it into `s.mtp_h` and sets `mtp_h_pos1` — `forward_prefill`'s existing handoff contract. The prefill `gpu_logits` gate drops its `n_layer_nextn` exclusion (the stash was the reason it existed).
- **Draft-slab warm**: ONE extra iteration of the existing layer loop at `l = n_layers`. A prologue saves the residual panel (the `x_b` readback and cls tail read the save), builds `[enorm(shifted embeds) ; hnorm(rms_final(residuals))]` via a new `cat2` interleave kernel, runs eh_proj as a mul_mm into `bx`, and falls through — the loop body runs the draft block verbatim. The warm runs at FULL npos so every trunk uniform is reused: the last warm row is garbage by construction (it needs the next window's unknown token), is causally unread inside the pass, and is rewritten by the next draft or seam before any read. K/V panels, the continuation gather, and the per-chunk writeback widen by `n_layer_nextn`.
- **Continuation seam**: `register_mtp_seam_override` (keyed by the decode-override name, like the spec twin from #3527); `forward_prefill`'s seam hook serves blob models through `metal_mtp_seam_row` — a draft-forward variant that writes the draft head's KV row `pos-1` from the pre-window `mtp_h`, with no classifier and no `mtp_h` clobber. Planar models keep `forward_mtp(..., false)`.
- **Servable flip**: `metal_model_servable_impl` drops the `n_layer_nextn` clause. Flavor selection was already metal-mode-gated at load, so CPU-only flows (`test_mtp`, the `--mtp-ab` bench) keep the planar flavor untouched.

## Tests

- Probes: spec engages off a PURE GPU prefill with 24/24 stream parity vs plain GPU decode at the CPU-warm flow's exact acceptance; the two-window continuation probe (seam firing at the boundary) matches identically.
- Gates green after each step: prefill base+cont parity, `arm2-hybrid` decode, `fam-qwen35` support matrix, image mechanics, `test_mtp` (CPU rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)