### PR TITLE
Add dockable worktree Git inspection

### DIFF
--- a/modules/dasTerminal/CMakeLists.txt
+++ b/modules/dasTerminal/CMakeLists.txt
@@ -13,6 +13,7 @@ IF ((NOT DAS_TERMINAL_INCLUDED) AND (NOT DAS_TERMINAL_DISABLED))
     ADD_MODULE_DAS(terminal daslib terminal)
     ADD_EXAMPLE_RUN(modules/dasTerminal/tests/snapshot_smoke.das)
     ADD_EXAMPLE_RUN(modules/dasTerminal/tests/terminal_semantics.das)
+    ADD_EXAMPLE_RUN(modules/dasTerminal/tests/ownership_semantics.das)
     ADD_EXAMPLE_RUN(modules/dasTerminal/tests/app_compat.das)
     ADD_MODULE_LIB(libDasModuleTerminal dasModuleTerminal ${DAS_TERMINAL_MODULE_SRC})
 

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -181,6 +181,18 @@ struct private TerminalBuffer {
     scroll_bottom : int
 }
 
+def private clear_rows(var rows : array<TerminalRow>) {
+    for (index in range(length(rows))) {
+        delete rows[index].cells
+    }
+    rows |> clear()
+}
+
+def private delete_rows(var rows : array<TerminalRow>) {
+    clear_rows(rows)
+    delete rows
+}
+
 typedef public Pty = smart_ptr<pty_handle>
 
 struct public Terminal {
@@ -225,14 +237,14 @@ def private blank_row(columns, row : int) : TerminalRow {
 }
 
 def private reset_buffer(var buffer : TerminalBuffer; columns, rows : int) {
-    buffer.screen |> clear()
+    clear_rows(buffer.screen)
     buffer.screen |> reserve(rows)
     for (row in range(rows)) {
         var next <- blank_row(columns, row)
         buffer.screen |> emplace(next)
     }
     buffer.screen_start = 0
-    buffer.history |> clear()
+    clear_rows(buffer.history)
     buffer.history_start = 0
     buffer.cursor = TerminalCursor()
     buffer.saved_cursor = TerminalCursor()
@@ -645,7 +657,7 @@ def private erase_display(terminal : Terminal const; var buffer : TerminalBuffer
             reset_row(buffer.screen[physical], buffer, terminal.columns, row)
         }
         if (mode == 3) {
-            buffer.history |> clear()
+            clear_rows(buffer.history)
             buffer.history_start = 0
         }
     } elif (mode == 0) {
@@ -996,10 +1008,10 @@ def public terminal_create(columns : int = 80; rows : int = 25) : Terminal {
 }
 
 def public terminal_dispose(var terminal : Terminal&) {
-    delete terminal.normal.screen
-    delete terminal.normal.history
-    delete terminal.alternate.screen
-    delete terminal.alternate.history
+    delete_rows(terminal.normal.screen)
+    delete_rows(terminal.normal.history)
+    delete_rows(terminal.alternate.screen)
+    delete_rows(terminal.alternate.history)
     delete terminal.unknown_sequences
     delete terminal.replies
     delete terminal.events
@@ -1108,7 +1120,7 @@ def private resize_buffer(var buffer : TerminalBuffer; old_columns, old_rows,
         }
         replacement |> emplace(next)
     }
-    delete buffer.screen
+    delete_rows(buffer.screen)
     buffer.screen <- replacement
     buffer.screen_start = 0
     for (logical in range(length(buffer.history))) {

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -1145,7 +1145,7 @@ def private resize_buffer(var buffer : TerminalBuffer; old_columns, old_rows,
     buffer.scroll_bottom = rows - 1
 }
 
-def public terminal_resize(var terminal : Terminal; columns_, rows_ : int) {
+def public terminal_resize(var terminal : Terminal; columns_ : int; rows_ : int) {
     let columns = max(1, columns_)
     let rows = max(1, rows_)
     if ((columns == terminal.columns && rows == terminal.rows) ||

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -182,8 +182,8 @@ struct private TerminalBuffer {
 }
 
 def private clear_rows(var rows : array<TerminalRow>) {
-    for (index in range(length(rows))) {
-        delete rows[index].cells
+    for (row in rows) {
+        delete row.cells
     }
     rows |> clear()
 }

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -274,7 +274,7 @@ def private push_ascii(var bytes : array<uint8>; value : int) {
 
 def private bytes_slice_string(bytes : array<uint8> const; first, past_last : int) : string {
     if (past_last <= first) return ""
-    var slice : array<uint8>
+    var inscope slice : array<uint8>
     slice |> resize_no_init(past_last - first)
     unsafe {
         memcpy(addr(slice[0]), addr(bytes[first]), past_last - first)
@@ -397,13 +397,13 @@ def private erased_cell(buffer : TerminalBuffer const; row, column : int) : Term
         background = buffer.pen.background)
 }
 
-def private erased_row(buffer : TerminalBuffer const; columns, row : int) : TerminalRow {
-    var result = TerminalRow()
-    result.cells |> reserve(columns)
+def private reset_row(var target : TerminalRow; buffer : TerminalBuffer const;
+                      columns, row : int) {
+    target.cells |> clear()
+    target.cells |> reserve(columns)
     for (column in range(columns)) {
-        result.cells |> push(erased_cell(buffer, row, column))
+        target.cells |> push(erased_cell(buffer, row, column))
     }
-    return <- result
 }
 
 def private clear_cell(terminal : Terminal const; var buffer : TerminalBuffer;
@@ -428,6 +428,7 @@ def private append_history_row(var buffer : TerminalBuffer; var row : TerminalRo
     if (length(buffer.history) < MAX_SCROLLBACK_ROWS) {
         buffer.history |> emplace(row)
     } else {
+        delete buffer.history[buffer.history_start].cells
         buffer.history[buffer.history_start] <- row
         buffer.history_start = (buffer.history_start + 1) % MAX_SCROLLBACK_ROWS
     }
@@ -438,7 +439,7 @@ def private scroll_up(terminal : Terminal const; var buffer : TerminalBuffer; no
     if (normal) append_history_row(buffer, buffer.screen[first])
     buffer.screen_start = (buffer.screen_start + 1) % terminal.rows
     let last = screen_index(buffer, terminal.rows - 1)
-    buffer.screen[last] <- erased_row(buffer, terminal.columns, terminal.rows - 1)
+    reset_row(buffer.screen[last], buffer, terminal.columns, terminal.rows - 1)
 }
 
 def private scroll_rows_up(terminal : Terminal const; var buffer : TerminalBuffer;
@@ -456,11 +457,12 @@ def private scroll_rows_up(terminal : Terminal const; var buffer : TerminalBuffe
     for (row in range(first, last - count + 1)) {
         let destination = screen_index(buffer, row)
         let source = screen_index(buffer, row + count)
+        delete buffer.screen[destination].cells
         buffer.screen[destination] <- buffer.screen[source]
     }
     for (row in range(last - count + 1, last + 1)) {
         let destination = screen_index(buffer, row)
-        buffer.screen[destination] <- erased_row(buffer, terminal.columns, row)
+        reset_row(buffer.screen[destination], buffer, terminal.columns, row)
     }
 }
 
@@ -474,7 +476,7 @@ def private scroll_rows_down(terminal : Terminal const; var buffer : TerminalBuf
         for (_ in range(count)) {
             buffer.screen_start = (buffer.screen_start + terminal.rows - 1) % terminal.rows
             let top = screen_index(buffer, 0)
-            buffer.screen[top] <- erased_row(buffer, terminal.columns, 0)
+            reset_row(buffer.screen[top], buffer, terminal.columns, 0)
         }
         return
     }
@@ -482,12 +484,13 @@ def private scroll_rows_down(terminal : Terminal const; var buffer : TerminalBuf
     while (row >= first + count) {
         let destination = screen_index(buffer, row)
         let source = screen_index(buffer, row - count)
+        delete buffer.screen[destination].cells
         buffer.screen[destination] <- buffer.screen[source]
         row--
     }
     for (blank in range(first, first + count)) {
         let destination = screen_index(buffer, blank)
-        buffer.screen[destination] <- erased_row(buffer, terminal.columns, blank)
+        reset_row(buffer.screen[destination], buffer, terminal.columns, blank)
     }
 }
 
@@ -601,7 +604,7 @@ def private record_unknown_text(var terminal : Terminal; value : string) {
         } else {
             let suffix = "...[truncated]"
             let suffix_length = length(suffix)
-            var bytes : array<uint8>
+            var inscope bytes : array<uint8>
             bytes |> resize_no_init(MAX_UNKNOWN_SEQUENCE_BYTES)
             peek_data(value) $(data) {
                 for (index in range(MAX_UNKNOWN_SEQUENCE_BYTES - suffix_length)) {
@@ -639,7 +642,7 @@ def private erase_display(terminal : Terminal const; var buffer : TerminalBuffer
     if (mode == 2 || mode == 3) {
         for (row in range(terminal.rows)) {
             let physical = screen_index(buffer, row)
-            buffer.screen[physical] <- erased_row(buffer, terminal.columns, row)
+            reset_row(buffer.screen[physical], buffer, terminal.columns, row)
         }
         if (mode == 3) {
             buffer.history |> clear()
@@ -649,13 +652,13 @@ def private erase_display(terminal : Terminal const; var buffer : TerminalBuffer
         erase_line(terminal, buffer, 0)
         for (row in range(buffer.cursor.row + 1, terminal.rows)) {
             let physical = screen_index(buffer, row)
-            buffer.screen[physical] <- erased_row(buffer, terminal.columns, row)
+            reset_row(buffer.screen[physical], buffer, terminal.columns, row)
         }
     } elif (mode == 1) {
         erase_line(terminal, buffer, 1)
         for (row in range(0, buffer.cursor.row)) {
             let physical = screen_index(buffer, row)
-            buffer.screen[physical] <- erased_row(buffer, terminal.columns, row)
+            reset_row(buffer.screen[physical], buffer, terminal.columns, row)
         }
     }
 }
@@ -744,7 +747,7 @@ def private select_graphic_rendition(var buffer : TerminalBuffer;
 }
 
 def private append_reply_text(var terminal : Terminal; text : string) {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     append_string_bytes(bytes, text)
     terminal.replies |> emplace(bytes)
 }
@@ -752,7 +755,7 @@ def private append_reply_text(var terminal : Terminal; text : string) {
 def private process_csi(var terminal : Terminal; final_byte : int) {
     terminal.parse_state = TerminalParseState.ground
     var private_marker = 0
-    var parameters : array<int>
+    var inscope parameters : array<int>
     parse_parameters(terminal.csi_parameters, private_marker, parameters)
     var buffer = active_buffer(terminal)
     let first = parameter_or(parameters, 0, 1)
@@ -1018,6 +1021,16 @@ def public terminal_launch(command_line : string;
     return <- terminal
 }
 
+def public terminal_launch_argv(arguments : array<string> const;
+                                working_directory : string = "";
+                                columns : int = 80; rows : int = 25) : Terminal {
+    var inscope terminal <- terminal_create(columns, rows)
+    var inscope pty <- _pty_launch_argv(arguments,
+        working_directory, length(working_directory), columns, rows)
+    move(terminal.transport) <| pty
+    return <- terminal
+}
+
 def public terminal_feed_bytes(var terminal : Terminal; bytes : array<uint8> const) {
     if (empty(bytes)) return
     terminal.revision++
@@ -1095,6 +1108,7 @@ def private resize_buffer(var buffer : TerminalBuffer; old_columns, old_rows,
         }
         replacement |> emplace(next)
     }
+    delete buffer.screen
     buffer.screen <- replacement
     buffer.screen_start = 0
     for (logical in range(length(buffer.history))) {
@@ -1167,6 +1181,15 @@ def public terminal_snapshot(terminal : Terminal const; var snapshot : TerminalS
     snapshot.unknown_sequences := terminal.unknown_sequences
 }
 
+def public terminal_snapshot_dispose(var snapshot : TerminalSnapshot) {
+    delete snapshot.normal.cells
+    delete snapshot.normal.scrollback
+    delete snapshot.alternate.cells
+    delete snapshot.alternate.scrollback
+    delete snapshot.unknown_sequences
+    snapshot = default<TerminalSnapshot>
+}
+
 def public terminal_drain_replies_bytes(var terminal : Terminal;
                                         var replies : array<array<uint8>>) {
     replies <- terminal.replies
@@ -1175,7 +1198,7 @@ def public terminal_drain_replies_bytes(var terminal : Terminal;
 //! Compatibility boundary for callers which still consume terminal replies as
 //! strings. Parser and transport storage remain raw bytes end to end.
 def public terminal_drain_replies(var terminal : Terminal; var replies : array<string>) {
-    var raw_replies : array<array<uint8>>
+    var inscope raw_replies : array<array<uint8>>
     terminal_drain_replies_bytes(terminal, raw_replies)
     replies |> clear()
     replies |> reserve(length(raw_replies))
@@ -1194,7 +1217,7 @@ def private string_to_bytes(text : string; var bytes : array<uint8>) {
 }
 
 def public terminal_write(terminal : Terminal const; text : string) : bool {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     string_to_bytes(text, bytes)
     return terminal_write_bytes(terminal, bytes)
 }
@@ -1289,7 +1312,7 @@ def public terminal_encode_key_bytes(terminal : Terminal const;
 
 def public terminal_encode_key(terminal : Terminal const;
                                event : TerminalKeyEvent const) : string {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     terminal_encode_key_bytes(terminal, event, bytes)
     return string(bytes)
 }
@@ -1303,19 +1326,19 @@ def public terminal_encode_paste_bytes(terminal : Terminal const; text : string;
 }
 
 def public terminal_encode_paste(terminal : Terminal const; text : string) : string {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     terminal_encode_paste_bytes(terminal, text, bytes)
     return string(bytes)
 }
 
 def public terminal_send_key(terminal : Terminal const; event : TerminalKeyEvent const) : bool {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     terminal_encode_key_bytes(terminal, event, bytes)
     return terminal_write_bytes(terminal, bytes)
 }
 
 def public terminal_send_paste(terminal : Terminal const; text : string) : bool {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     terminal_encode_paste_bytes(terminal, text, bytes)
     return terminal_write_bytes(terminal, bytes)
 }
@@ -1361,7 +1384,7 @@ def private emit_group(group : TerminalTextRunGroup const; global_row : int;
 
 def private append_text_runs_for_row(row : TerminalRow const; global_row : int;
                                      var runs : array<TerminalTextRun>) {
-    var groups : array<TerminalTextRunGroup>
+    var inscope groups : array<TerminalTextRunGroup>
     groups |> reserve(17)
     var too_many_colors = false
     for (column in range(length(row.cells))) {
@@ -1414,7 +1437,7 @@ def private append_text_runs_for_row(row : TerminalRow const; global_row : int;
         let run_start = column
         var ink_end = column
         var glyph_cells = 0
-        var text : array<uint8>
+        var inscope text : array<uint8>
         while (column < length(row.cells)) {
             let cell = row.cells[column]
             let cell_background = (cell.attributes & TERMINAL_ATTR_INVERSE) != 0
@@ -1444,7 +1467,7 @@ def private append_paint_cells_for_row(row : TerminalRow const; logical_row : in
 }
 
 def private screen_text(buffer : TerminalBuffer const; rows : int) : string {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     var last_content_end = 0
     for (row in range(rows)) {
         if (row != 0) bytes |> push(uint8('\n'))
@@ -1501,4 +1524,11 @@ def public terminal_viewport_snapshot(terminal : Terminal const; scroll_offset :
     snapshot.text_run_projection_us = get_time_usec(runs_started)
     snapshot.buffer.scrollback_rows = history_rows
     snapshot.buffer.cursor = buffer.cursor
+}
+
+def public terminal_viewport_snapshot_dispose(var snapshot : TerminalViewportSnapshot) {
+    delete snapshot.buffer.cells
+    delete snapshot.buffer.scrollback
+    delete snapshot.text_runs
+    snapshot = default<TerminalViewportSnapshot>
 }

--- a/modules/dasTerminal/src/aot_builtin_terminal.h
+++ b/modules/dasTerminal/src/aot_builtin_terminal.h
@@ -20,6 +20,11 @@ das::smart_ptr<PtyHandle> builtin_pty_launch(
     const char * command_line, int32_t command_count,
     const char * working_directory, int32_t directory_count,
     int32_t columns, int32_t rows);
+das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
+    const das::Array & arguments,
+    const char * working_directory, int32_t directory_count,
+    int32_t columns, int32_t rows, das::Context * context,
+    das::LineInfoArg * at);
 int32_t builtin_pty_read(
     const das::smart_ptr<PtyHandle> & pty, das::TArray<uint8_t> & bytes,
     int32_t maximum_bytes, das::Context * context, das::LineInfoArg * at);

--- a/modules/dasTerminal/src/aot_builtin_terminal.h
+++ b/modules/dasTerminal/src/aot_builtin_terminal.h
@@ -21,7 +21,7 @@ das::smart_ptr<PtyHandle> builtin_pty_launch(
     const char * working_directory, int32_t directory_count,
     int32_t columns, int32_t rows);
 das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
-    const das::Array & arguments,
+    const das::TArray<char *> & arguments,
     const char * working_directory, int32_t directory_count,
     int32_t columns, int32_t rows, das::Context * context,
     das::LineInfoArg * at);

--- a/modules/dasTerminal/src/dasTerminal.cpp
+++ b/modules/dasTerminal/src/dasTerminal.cpp
@@ -50,6 +50,35 @@ das::smart_ptr<PtyHandle> builtin_pty_launch(
     return pty;
 }
 
+das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
+    const das::Array & arguments,
+    const char * working_directory, int32_t directory_count,
+    int32_t columns, int32_t rows, das::Context * context,
+    das::LineInfoArg * at) {
+    das::smart_ptr<PtyHandle> pty = das::make_smart<PtyHandle>();
+    if (!arguments.size) {
+        pty->error = "PTY argument array is empty";
+        return pty;
+    }
+    const char * const * values = reinterpret_cast<const char * const *>(arguments.data);
+    PtyProcessOptions options;
+    options.arguments.reserve(arguments.size);
+    for (uint32_t index = 0; index != arguments.size; ++index) {
+        if (!values[index]) {
+            context->throw_error_at(at, "PTY argument %u is null", index);
+            return pty;
+        }
+        options.arguments.emplace_back(values[index]);
+    }
+    if (working_directory && directory_count > 0)
+        options.working_directory.assign(
+            working_directory, static_cast<size_t>(directory_count));
+    options.columns = columns;
+    options.rows = rows;
+    pty->process = launchPtyProcess(options, pty->error);
+    return pty;
+}
+
 int32_t builtin_pty_read(
     const das::smart_ptr<PtyHandle> & pty, das::TArray<uint8_t> & bytes,
     int32_t maximum_bytes, das::Context * context, das::LineInfoArg * at) {
@@ -152,6 +181,11 @@ public:
             "das_terminal::builtin_pty_launch")
                 ->args({"command_line", "command_count", "working_directory",
                     "directory_count", "columns", "rows"});
+        addExtern<DAS_BIND_FUN(das_terminal::builtin_pty_launch_argv)>(*this, lib,
+            "_pty_launch_argv", SideEffects::modifyExternal,
+            "das_terminal::builtin_pty_launch_argv")
+                ->args({"arguments", "working_directory", "directory_count",
+                    "columns", "rows", "context", "at"});
         addExtern<DAS_BIND_FUN(das_terminal::builtin_pty_read)>(*this, lib,
             "_pty_read", SideEffects::modifyArgumentAndExternal,
             "das_terminal::builtin_pty_read")

--- a/modules/dasTerminal/src/dasTerminal.cpp
+++ b/modules/dasTerminal/src/dasTerminal.cpp
@@ -51,7 +51,7 @@ das::smart_ptr<PtyHandle> builtin_pty_launch(
 }
 
 das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
-    const das::Array & arguments,
+    const das::TArray<char *> & arguments,
     const char * working_directory, int32_t directory_count,
     int32_t columns, int32_t rows, das::Context * context,
     das::LineInfoArg * at) {
@@ -60,15 +60,15 @@ das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
         pty->error = "PTY argument array is empty";
         return pty;
     }
-    const char * const * values = reinterpret_cast<const char * const *>(arguments.data);
     PtyProcessOptions options;
     options.arguments.reserve(arguments.size);
     for (uint32_t index = 0; index != arguments.size; ++index) {
-        if (!values[index]) {
+        const char * value = arguments[index];
+        if (!value) {
             context->throw_error_at(at, "PTY argument %u is null", index);
             return pty;
         }
-        options.arguments.emplace_back(values[index]);
+        options.arguments.emplace_back(value);
     }
     if (working_directory && directory_count > 0)
         options.working_directory.assign(

--- a/modules/dasTerminal/src/pty.cpp
+++ b/modules/dasTerminal/src/pty.cpp
@@ -118,6 +118,41 @@ void ConPtyProcess::closePty() {
     pseudo_console_ = nullptr;
 }
 
+std::string escapeWindowsArgument(const std::string & argument) {
+    if (!argument.empty() &&
+        argument.find_first_of(" \t\n\v\"") == std::string::npos)
+        return argument;
+    std::string result = "\"";
+    for (size_t index = 0; index < argument.size();) {
+        size_t backslashes = 0;
+        while (index < argument.size() && argument[index] == '\\') {
+            ++backslashes;
+            ++index;
+        }
+        if (index == argument.size()) {
+            result.append(backslashes * 2, '\\');
+        } else if (argument[index] == '"') {
+            result.append(backslashes * 2 + 1, '\\');
+            result += '"';
+            ++index;
+        } else {
+            result.append(backslashes, '\\');
+            result += argument[index++];
+        }
+    }
+    result += '"';
+    return result;
+}
+
+std::string buildWindowsCommandLine(const std::vector<std::string> & arguments) {
+    std::string result;
+    for (const std::string & argument : arguments) {
+        if (!result.empty()) result += ' ';
+        result += escapeWindowsArgument(argument);
+    }
+    return result;
+}
+
 ConPtyProcess::~ConPtyProcess() {
     closePty();
     closeHandle(process_);
@@ -128,7 +163,7 @@ bool ConPtyProcess::launch(const PtyProcessOptions & options, std::string & erro
         error = "ConPTY process is already launched";
         return false;
     }
-    if (options.command_line.empty()) {
+    if (options.command_line.empty() && options.arguments.empty()) {
         error = "ConPTY command line is empty";
         return false;
     }
@@ -200,7 +235,9 @@ bool ConPtyProcess::launch(const PtyProcessOptions & options, std::string & erro
         return false;
     }
 
-    std::wstring command = utf8ToWide(options.command_line, error);
+    const std::string command_line = options.arguments.empty()
+        ? options.command_line : buildWindowsCommandLine(options.arguments);
+    std::wstring command = utf8ToWide(command_line, error);
     std::wstring directory = utf8ToWide(options.working_directory, error);
     if (command.empty() || (!options.working_directory.empty() && directory.empty())) {
         DeleteProcThreadAttributeList(startup.lpAttributeList);

--- a/modules/dasTerminal/src/pty.h
+++ b/modules/dasTerminal/src/pty.h
@@ -4,11 +4,13 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace das_terminal {
 
 struct PtyProcessOptions {
     std::string command_line;
+    std::vector<std::string> arguments;
     std::string working_directory;
     int columns = 80;
     int rows = 25;

--- a/modules/dasTerminal/tests/ownership_semantics.das
+++ b/modules/dasTerminal/tests/ownership_semantics.das
@@ -19,6 +19,14 @@ def main {
     assert(after_repaint_bytes <= live_grid_bytes + 1024ul,
         "replacing terminal rows must release or reuse their owned cell arrays")
 
+    for (_ in range(20)) {
+        terminal_feed(terminal, "history\r\n{to_char(27)}[3J")
+    }
+
+    let after_scrollback_clear_bytes = heap_bytes_allocated()
+    assert(after_scrollback_clear_bytes <= after_repaint_bytes + 1024ul,
+        "clearing scrollback must release its owned cell arrays")
+
     terminal_dispose(terminal)
     let after_dispose_bytes = heap_bytes_allocated()
     assert(after_dispose_bytes == 0ul,

--- a/modules/dasTerminal/tests/ownership_semantics.das
+++ b/modules/dasTerminal/tests/ownership_semantics.das
@@ -1,0 +1,26 @@
+options gen2
+options persistent_heap
+options gc
+
+require terminal/terminal
+require strings
+
+[export]
+def main {
+    unsafe { heap_collect(true, true) }
+    var inscope terminal <- terminal_create(240, 100)
+    let live_grid_bytes = heap_bytes_allocated()
+
+    for (_ in range(20)) {
+        terminal_feed(terminal, "{to_char(27)}[2J{to_char(27)}[Hgit status\r\n")
+    }
+
+    let after_repaint_bytes = heap_bytes_allocated()
+    assert(after_repaint_bytes <= live_grid_bytes + 1024ul,
+        "replacing terminal rows must release or reuse their owned cell arrays")
+
+    terminal_dispose(terminal)
+    let after_dispose_bytes = heap_bytes_allocated()
+    assert(after_dispose_bytes == 0ul,
+        "disposing a terminal must release all owned arrays")
+}

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -298,10 +298,42 @@ namespace das {
         return mode && strchr("rwa", mode[0]) && mode[1 + strspn(mode + 1, "+btx")] == '\0';
     }
 
+#if defined(_WIN32)
+    static wstring utf8_file_path_to_wide ( const char * path ) {
+        if ( !path || !*path ) return wstring();
+        const int count = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+            path, -1, nullptr, 0);
+        if ( count <= 0 ) return wstring();
+        wstring result(size_t(count), L'\0');
+        if ( MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                path, -1, result.data(), count) != count ) {
+            return wstring();
+        }
+        result.resize(size_t(count - 1));
+        return result;
+    }
+
+    static FILE * das_fopen_utf8 ( const char * name, const char * mode ) {
+        auto wideName = utf8_file_path_to_wide(name);
+        if ( wideName.empty() ) return nullptr;
+        wchar_t wideMode[8] = {};
+        size_t index = 0;
+        while ( mode[index] && index + 1 < sizeof(wideMode) / sizeof(wideMode[0]) ) {
+            wideMode[index] = wchar_t(uint8_t(mode[index]));
+            ++index;
+        }
+        return _wfopen(wideName.c_str(), wideMode);
+    }
+#else
+    static FILE * das_fopen_utf8 ( const char * name, const char * mode ) {
+        return fopen(name, mode);
+    }
+#endif
+
     const FILE * builtin_fopen  ( const char * name, const char * mode, Context * context, LineInfoArg * at ) {
         if ( !name ) context->throw_error_at(at, "can't fopen NULL name");
         if ( !is_valid_fopen_mode(mode) ) context->throw_error_at(at, "invalid fopen mode '%s'", mode ? mode : "<null>");
-        FILE * f = fopen(name, mode);
+        FILE * f = das_fopen_utf8(name, mode);
         if ( f ) setvbuf(f, NULL, _IOFBF, 65536);
         return f;
     }
@@ -337,7 +369,8 @@ namespace das {
     // stat/fstat truncate st_size to 32 bits and FAIL outright past 2GB.
     static int das_stat64 ( const char * path, das_filestat & st ) {
 #if defined(_WIN32)
-        return _stat64(path, &st);
+        auto widePath = utf8_file_path_to_wide(path);
+        return widePath.empty() ? -1 : _wstat64(widePath.c_str(), &st);
 #else
         return stat(path, &st);
 #endif
@@ -389,7 +422,7 @@ namespace das {
         if ( !size ) context->throw_error_at(at, "fmap_open: null size out-param");
         *size = 0;
         if ( !name ) context->throw_error_at(at, "fmap_open: null path");
-        FILE * f = fopen(name, "rb");
+        FILE * f = das_fopen_utf8(name, "rb");
         if ( !f ) return nullptr;
         das_filestat st;
         int fd = fileno(f);
@@ -1477,12 +1510,24 @@ namespace das {
 
     bool builtin_remove_file ( const char * path ) {
         if ( !path ) return false;
+#if defined(_WIN32)
+        auto widePath = utf8_file_path_to_wide(path);
+        return !widePath.empty() && _wremove(widePath.c_str()) == 0;
+#else
         return remove(path) == 0;
+#endif
     }
 
     bool builtin_rename_file ( const char * old_path, const char * new_path ) {
         if ( !old_path || !new_path ) return false;
+#if defined(_WIN32)
+        auto wideOldPath = utf8_file_path_to_wide(old_path);
+        auto wideNewPath = utf8_file_path_to_wide(new_path);
+        return !wideOldPath.empty() && !wideNewPath.empty()
+            && _wrename(wideOldPath.c_str(), wideNewPath.c_str()) == 0;
+#else
         return rename(old_path, new_path) == 0;
+#endif
     }
 
     bool builtin_rmdir ( const char * path ) {

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -299,15 +299,15 @@ namespace das {
     }
 
 #if defined(_WIN32)
-    static wstring utf8_file_path_to_wide ( const char * path ) {
-        if ( !path || !*path ) return wstring();
+    static std::wstring utf8_file_path_to_wide ( const char * path ) {
+        if ( !path || !*path ) return std::wstring();
         const int count = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
             path, -1, nullptr, 0);
-        if ( count <= 0 ) return wstring();
-        wstring result(size_t(count), L'\0');
+        if ( count <= 0 ) return std::wstring();
+        std::wstring result(size_t(count), L'\0');
         if ( MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
                 path, -1, result.data(), count) != count ) {
-            return wstring();
+            return std::wstring();
         }
         result.resize(size_t(count - 1));
         return result;

--- a/tests/fio/fio_utils.das
+++ b/tests/fio/fio_utils.das
@@ -50,6 +50,14 @@ def test_fread_path(t : T?) {
         let content = fread("{get_das_root()}/_no_such_file_12345.tmp")
         t |> success(empty(content), "expected empty string for missing file")
     }
+    t |> run("UTF-8 Windows path round-trips through file IO") @(t : T?) {
+        let tmp = "{get_das_root()}/_test_unicode-Привет.tmp"
+        let content = "Unicode path contents"
+        t |> success(fwrite(tmp, content), "fwrite should accept a UTF-8 path")
+        t |> success(fexist(tmp), "fexist should accept a UTF-8 path")
+        t |> equal(fread(tmp), content)
+        t |> success(remove(tmp), "remove should accept a UTF-8 path")
+    }
 }
 
 [test]

--- a/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
+++ b/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
@@ -182,7 +182,7 @@ live-command terminal schema.
 
 ## Section 1: repository, base, and worktree identity
 
-Discussion status: open
+Discussion status: initial identity and configuration decisions settled
 
 The first model needs to distinguish:
 
@@ -200,24 +200,38 @@ therefore include at least `target ID + repository Git-common-dir` for a
 repository and `repository ID + canonical worktree path` for an initial
 worktree identity. Session records get their own generated IDs.
 
+Repositories are registered explicitly by checkout path; dasHerd does not
+recursively scan arbitrary directory trees. One global user configuration owns
+per-repository records. A repository record may contain its display name,
+target ID, checkout path, default/base ref, managed-worktree parent and naming
+rule, setup trust and recipe selection, protected branches/removal policy, and
+preferred Git remote. Targets themselves remain global. Repository-local
+configuration is deferred; a future shared file must never execute setup merely
+because a repository was opened.
+
+The main checkout is the first, visually distinct worktree row. Linked
+worktrees remain ordinary children of the registered repository. Interactive
+sessions retain the worktree association chosen at launch even if their live
+shell working directory later changes; current-directory observation is
+separate from ownership.
+
 Questions to settle:
 
-- Is the base ref stored per repository, per worktree, or both with an
-  override?
 - Are externally created worktrees fully manageable or initially read-only?
 - Where are default managed worktrees placed, and how editable is that path?
-- Do we show a virtual base row, or show the base only in the repository header
-  until it has a real worktree?
+- Whether a worktree needs an explicit base override in addition to the
+  repository default.
 
 ## Section 2: asynchronous Git observation
 
-Discussion status: open
+Discussion status: first local slice implemented; SSH transport deferred
 
 Background observation needs structured, non-interactive results. It submits
 commands through the detachable host, uses Git's porcelain/plumbing output
 without color, and publishes versioned snapshots to the UI. Its hosted
-terminal and log remain addressable for diagnostics, but terminal text is
-never the authority for repository state.
+terminal and log remain addressable for diagnostics. The intended authority is
+an unbounded machine-output sidecar; the bounded first slice below uses the
+terminal model only with explicit overflow detection.
 
 The initial observer covers:
 
@@ -245,6 +259,19 @@ Worker rules:
 - refresh after every mutation;
 - do not fetch the network implicitly.
 
+The first implementation registers explicit repositories in the global user
+configuration, resolves the first Git 2.17 porcelain worktree as Main, and
+runs inventory/status queries as watcher-owned structured-argv task sessions.
+It publishes staged, unstaged, untracked, conflicted, ahead/behind, locked, and
+prunable state plus filenames. Selecting a worktree requests an immediate local
+refresh; no fetch is implied. ConPTY's raw bytes contain console-generated VT
+cursor operations, so this slice parses the terminal model's reconstructed
+240x100 screen and fails visibly if output reaches scrollback. An unbounded
+machine-output sidecar is a follow-up, not a reason to parse truncated state.
+Completed observation terminals compact to 160x50. A replacement refresh keeps
+only the newest matching emulator in memory while preserving every older raw,
+event, and launch log on disk; interactive sessions are unaffected.
+
 Questions to settle:
 
 - Refresh triggers and cadence for selected and unselected worktrees.
@@ -255,7 +282,7 @@ Questions to settle:
 
 ## Section 3: execution targets and command sessions
 
-Discussion status: open
+Discussion status: partially settled
 
 Git cannot be designed as "run a Windows process in this local directory."
 Commands run against an execution target. The first target implementation is
@@ -272,6 +299,20 @@ Target-specific path syntax stays behind this boundary. UI and persisted
 records carry a target ID together with paths rather than treating local
 absolute paths as universal.
 
+The data model includes `target_id` from the first version, but the UI does not
+offer inert SSH checkboxes or disabled remote controls. It shows the active
+Local target in repository context. A target selector appears only when more
+than one functional target exists; SSH will be a structured target containing
+host, authentication, remote paths, shell, and capabilities rather than a
+boolean session option.
+
+The initial Commands menu has one immediate action: PowerShell in the selected
+worktree, using `powershell.exe -NoLogo -NoProfile`. A successful launch opens,
+selects, controls, and focuses that session's terminal. A later dockable Session
+Launcher will customize shell or agent, new/resume mode, worktree, target,
+arguments, environment, and command preview. `Codex` and `Codex resume` are
+modes of that launcher, not separate proliferating profiles.
+
 Questions to settle:
 
 - How much of the target protocol is defined before implementing local-only
@@ -283,7 +324,7 @@ Questions to settle:
 
 ## Section 4: Git and setup task terminals
 
-Discussion status: open
+Discussion status: initial dockspace and session behavior settled
 
 User-initiated Git mutations, setup recipes, and repair work are activities
 with terminals. Their terminal provides:
@@ -358,16 +399,28 @@ Questions to settle:
 
 ## Section 6: basic application layout and navigation
 
-Discussion status: open
+Discussion status: partially settled
 
-The first application shape is:
+The rich client is a real ImGui dockspace. Repositories/worktrees,
+sessions/activity, Git status, settings, session launchers, diffs, and every
+open terminal are independent dockable windows. Opening an item creates or
+focuses its window; users may dock, float, tab, or arrange multiple instances
+side by side. Closing a terminal window detaches its client and never
+terminates the watcher-owned session.
 
-- a repository header that shows target and base;
-- a draggable left rail containing the main checkout and linked worktrees;
-- a right workspace for inspection and the selected terminal;
+The default layout is:
+
+- a left repository/worktree rail with the main checkout visually distinct;
+- Git status above an always-visible terminal on the right;
 - a Git/tasks activity window containing running and retained jobs;
 - status and failure affordances that always navigate to the relevant
   terminal or recovery terminal.
+
+The top menu bar owns File, Commands, Edit, View, and Settings. View contains
+zoom, the exited-session filter, and Reset Layout. Docking state and window
+visibility persist in global user configuration; Reset Layout restores the
+default arrangement. Exited sessions are retained but hidden by default. A
+newly launched session becomes the active controlled terminal immediately.
 
 Each worktree row eventually shows branch/HEAD, dirty/conflict state,
 refresh/error state, setup state, and live terminal/agent activity. Switching
@@ -377,13 +430,61 @@ The Git/tasks window is a terminal when a task has a terminal, not a custom
 plain-text log approximation. Structured Git observations may appear as debug
 records beside the terminal activities.
 
-Questions to settle:
+### Git file inspection workspace
 
-- Default docking: fixed worktree rail plus terminal, or fully dockable
-  inspector/activity windows from the first version.
-- Whether inspection sits above the terminal, in a separate dock, or behind a
-  tab.
+The useful center of Git inspection is a selected file with two instantly
+switchable projections, not a longer status table:
+
+- **Diff** is a synchronized side-by-side comparison. Both sides remain plain
+  source text and use extension-driven syntax highlighting for daScript, C,
+  C++, Markdown, and other installed syntax providers.
+- **View** shows the resulting file without diff furniture. Source files use
+  the shared read-only source view with a thin changed-line gutter. Markdown
+  uses the shared rich Markdown viewer; it is not flattened into code text.
+
+File selection updates the inspector immediately. Loading is asynchronous and
+must never block the UI thread; a new selection supersedes stale work without
+requiring an Apply/Open button. The inspector is an independent dockable
+window so status, file view/diff, and terminal can be arranged together.
+
+Comparison scope is explicit and shares the same inspector:
+
+- **Working** compares the index with unstaged and untracked content.
+- **Staged** compares `HEAD` with the index.
+- **PR** compares the selected PR/head with its merge base. PR discovery,
+  selection, and base policy are a later slice, but this is the primary review
+  surface and must not be modeled as an alias for staged files.
+
+The first file list is flat, grouped by conflicts, staged, modified, and
+untracked, and shows the full repository-relative path. A tree projection may
+be added as a switch over the same model; it must not become a separate data
+path. Files which have both index and working-tree changes legitimately appear
+in both comparison groups.
+
+The document/source model owns exact UTF-8 bytes, syntax spans, aligned diff
+rows, and changed-line marks. Rendering owns layout, synchronized scrolling,
+selection, the narrow View gutter, and Diff line tint. This keeps live-command
+inspection semantic and avoids screenshot-only validation.
+
+The implemented working-tree path deliberately separates compact Diff from
+complete View. Git emits three context lines into the hosted terminal, while
+the resulting working file is read as exact bytes after the task succeeds.
+Large unwrapped Views virtualize visible lines; disconnected daScript hunks use
+lexical recovery for Tree-sitter gaps. The current measured stress case is a
+628 KiB/12,116-line file: Diff is ready in about 0.6 seconds, synchronized
+scrolling is exact in both directions, and the prepared View renders at roughly
+50 FPS at 4K/150% zoom. Full-file syntax preparation is still a one-time
+multi-second cost and remains the next focused optimization, not a reason to
+replace Git's native diff.
+
+Questions still to settle:
+
 - How completed task terminals are grouped and pruned from the activity UI.
+- Whether closing the last visible window for a running session should leave a
+  persistent reopen affordance beyond the Sessions window.
+- Exact PR/base discovery and multi-PR selection policy.
+- Whether flat or tree file projection becomes the eventual default after both
+  can be tested with large real changesets.
 
 ## Section 7: worktree creation and setup recipes
 

--- a/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
+++ b/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
@@ -268,9 +268,10 @@ refresh; no fetch is implied. ConPTY's raw bytes contain console-generated VT
 cursor operations, so this slice parses the terminal model's reconstructed
 240x100 screen and fails visibly if output reaches scrollback. An unbounded
 machine-output sidecar is a follow-up, not a reason to parse truncated state.
-Completed observation terminals compact to 160x50. A replacement refresh keeps
-only the newest matching emulator in memory while preserving every older raw,
-event, and launch log on disk; interactive sessions are unaffected.
+Completed repository-refresh observation terminals compact to 160x50, while
+file Diff/View task terminals compact to 80x25. A replacement refresh keeps only
+the newest matching emulator in memory while preserving every older raw, event,
+and launch log on disk; interactive sessions are unaffected.
 
 Questions to settle:
 

--- a/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
+++ b/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
@@ -477,6 +477,66 @@ scrolling is exact in both directions, and the prepared View renders at roughly
 multi-second cost and remains the next focused optimization, not a reason to
 replace Git's native diff.
 
+### Diff vertical slice
+
+Discussion status: scope agreed; implementation in progress
+
+Diff is the first inspector projection taken to near-production depth before
+the rest of Git inspection expands. It establishes the reusable cost and test
+baseline for later View, PR, history, and other asynchronous projections.
+The slice includes failure, replacement, large-input, and binary behavior; it
+is not complete merely when the happy-path text comparison renders.
+
+The first complete Diff surface has:
+
+- one vertical scroll position and one visible vertical scrollbar for both
+  panes, including wheel, keyboard, live-command, and scrollbar-drag input;
+- a draggable center splitter with a useful minimum width on both sides;
+- absolute old/new line-number gutters, with absent lines rendered as gaps;
+- retained hunk identity and previous/next-change navigation;
+- compact, expanded-context, and full-file modes over the same aligned-row
+  model;
+- automatic syntax selection plus an explicit override for Plain, daScript,
+  C, C++, Markdown, and JSON; compound suffixes such as `.md.local` resolve to
+  the underlying Markdown language;
+- Git-native binary detection and an image preview only when the bundled
+  stb_image decoder accepts the bytes.
+
+The bundled stb_image 2.30 build currently enables its stock PNG, JPEG, BMP,
+TGA, PSD-composite, GIF-first-frame, HDR, PIC, and binary PNM decoders. This is
+a capability boundary, not a promise to grow an extension list. WebP,
+animation, and video are deferred; future video work belongs with dasVideo.
+The watcher transports exact bytes, because a rich client must not assume it
+can open a target-local path once execution targets include SSH. CPU decoding
+may run on a worker; ImGui and graphics-resource creation remain on the UI
+thread.
+
+Each inspector projection exposes request state separately from retained
+content. Request state is idle, queued, or running; content is absent, ready,
+or failed. Starting a refresh does not erase the last successful content, and
+a failed refresh may report its error while leaving that content inspectable.
+Every request carries a monotonically increasing generation. The UI installs
+only results matching the current generation, so selecting another file
+supersedes work without waiting for or joining the old request.
+
+One persistent rich-client worker initially services preparation jobs through
+bounded/coalescing queues. It performs CPU-only parsing, syntax preparation,
+and image decoding and catches failures into result events. The UI thread
+drains those events once per frame. Watcher-hosted Git remains a separate
+asynchronous stage, and any graphics upload is an explicit final UI-thread
+stage. Shutdown closes the worker channel and releases captured channel
+references; it must neither leak a thread nor stall client exit.
+
+The dedicated fixture worktree covers at least staged and unstaged text,
+untracked files, rename, deletion, conflicts where practical, Markdown and a
+compound Markdown suffix, JSON, daScript, C/C++, a decodable image, an
+unsupported binary, no-final-newline input, Unicode paths/content, separated
+hunks, and a large file. Test coverage is counted in six groups: pure diff and
+language models, deterministic worker-state transitions, widget/render
+behavior, real watcher/Git integration, semantic live-command inspection, and
+performance/regression probes. The resulting count and the defects these tests
+catch become the estimating baseline for later projections.
+
 Questions still to settle:
 
 - How completed task terminals are grouped and pruned from the activity UI.

--- a/utils/dasHerd/chunk0/git_terminal_window.das
+++ b/utils/dasHerd/chunk0/git_terminal_window.das
@@ -190,7 +190,9 @@ def shutdown() {
         fclose(g_log_file)
         g_log_file = null
     }
+    terminal_viewport_snapshot_dispose(g_terminal_cache.snapshot)
     terminal_dispose(g_terminal)
+    delete g_font_sources
     harness_shutdown()
 }
 

--- a/utils/dasHerd/watcher/README.md
+++ b/utils/dasHerd/watcher/README.md
@@ -68,11 +68,12 @@ daScript fragments receive a lexical recovery pass only where Tree-sitter left
 unstyled ranges, preserving keyword/type/function colors across disconnected
 hunks and parser recovery nodes.
 
-Completed observation terminals are compacted to 160x50. When a later refresh
-replaces the same repository/worktree observation, only the newest emulator is
-kept in memory; every older `session.json`, `output.raw`, and `events.jsonl`
-remains on disk for postmortem inspection. Interactive sessions are not pruned
-by this policy.
+Completed repository-refresh observation terminals are compacted to 160x50;
+the shorter-lived file Diff/View task terminals compact to 80x25. When a later
+refresh replaces the same repository/worktree observation, only the newest
+emulator is kept in memory; every older `session.json`, `output.raw`, and
+`events.jsonl` remains on disk for postmortem inspection. Interactive sessions
+are not pruned by this policy.
 
 The script exposes `init`, `update`, and `shutdown` for lifecycle hosts. Its
 standalone loop performs optional GC only after `update` returns, when request

--- a/utils/dasHerd/watcher/README.md
+++ b/utils/dasHerd/watcher/README.md
@@ -17,25 +17,62 @@ Run the docked native client with the token printed by the watcher:
 bin\Release\daslang-live.exe utils\dasHerd\watcher\rich_client.das -- --token=<token>
 ```
 
-The client opens maximized at 150% zoom. Its left pane lists sessions and can
-launch or terminate them; the right pane attaches with control and renders raw
-PTY bytes through the daScript terminal emulator. `--port=9191` is available on
-both processes when the default port is occupied.
+The client opens maximized at 150% zoom. It is a real ImGui dockspace with
+repository/worktree, Git status, session/activity, terminal, and settings
+windows. Windows can be resized, rearranged, tabbed, floated, closed, and
+reopened from the View menu. Commands > PowerShell launches in the selected
+worktree, attaches with control, and raises the terminal. `--port=9191` is
+available on both processes when the default port is occupied.
 
 The watcher prints a token-bearing control-panel URL. Optional arguments after
-`--` are `--port=9191`, `--token=<token>`, and `--log-root=<directory>`.
+`--` are `--port=9191`, `--token=<token>`, `--log-root=<directory>`, and
+`--config=<path>`. The default global configuration is
+`%APPDATA%\daScript\dasHerd.json` on Windows. Repositories are registered by
+explicit checkout path; the Git observer resolves the first porcelain entry as
+the visually distinct main checkout and lists linked worktrees without scanning
+unrelated directories.
 
 This first slice binds only to `127.0.0.1`. Its startup token prevents
 accidental access from an unrelated local page; it is not the future remote
 authentication design. Do not expose this port through a proxy or tunnel.
 
-HTTP endpoints under `/api/v1/` provide health, session listing, launch,
-input, resize, termination, and a deferred `POST /gc` diagnostic. `/ws` provides attach/detach, controller
-leases, heartbeats, session listing/launch/termination, input, resize, terminal
-snapshots, and bounded raw PTY replay.
+HTTP endpoints under `/api/v1/` provide health, session and repository listing,
+session launch/input/resize/termination, repository registration/refresh, and a
+deferred `POST /gc` diagnostic. `/ws` provides attach/detach, controller leases,
+heartbeats, session and repository updates, launch/termination, input, resize,
+terminal snapshots, and bounded raw PTY replay. A launch accepts either the
+existing interactive `command_line` or a structured `argv`; repository Git
+observation always uses the latter.
 Raw output is delivered as binary WebSocket frames, so the browser can render
 the same color and control sequences and send keyboard input back to the PTY.
 Every request must include the startup token as the `token` query parameter.
+
+Git observation runs exclusively inside watcher-owned task sessions and never
+blocks the UI thread. The current local-first slice uses Git 2.17-compatible
+`worktree list --porcelain` and `status --porcelain=1 --branch`, retaining the
+branch/HEAD, staged, unstaged, untracked, conflicted, ahead/behind, locked, and
+prunable state. ConPTY rewrites console output into VT cursor operations, so the
+structured parser consumes the terminal model's reconstructed 240x100 screen;
+if output enters scrollback it reports a visible error and points at the task
+session rather than silently parsing truncated data. An unbounded structured
+capture sidecar remains a follow-up.
+
+File inspection uses the same hosted-task primitive and a 15-second external
+timeout. Working-tree diffs request three context lines, then read the complete
+working file separately for View; this keeps a 12,000-line file out of the PTY
+diff stream without changing Git semantics. The rich client aligns compact
+hunks for Diff, synchronizes both vertical scroll positions, and lazily prepares
+the complete View. Unwrapped source files at least 128 KiB use a clipped
+large-file renderer, so frame cost follows visible lines rather than file size.
+daScript fragments receive a lexical recovery pass only where Tree-sitter left
+unstyled ranges, preserving keyword/type/function colors across disconnected
+hunks and parser recovery nodes.
+
+Completed observation terminals are compacted to 160x50. When a later refresh
+replaces the same repository/worktree observation, only the newest emulator is
+kept in memory; every older `session.json`, `output.raw`, and `events.jsonl`
+remains on disk for postmortem inspection. Interactive sessions are not pruned
+by this policy.
 
 The script exposes `init`, `update`, and `shutdown` for lifecycle hosts. Its
 standalone loop performs optional GC only after `update` returns, when request
@@ -56,3 +93,9 @@ The native terminal registers its full `ImGuiTerminalState` with the live-comman
 surface. `imgui_snapshot` can therefore read terminal text, selection, geometry,
 cursor/blink state, performance counters, and input revisions without a screenshot;
 `imgui_click` plus `imgui_key_type` drives the same input path as a human user.
+
+The Git inspector is likewise semantic: `herder_file_inspector_open` selects a
+repository/worktree/file/comparison, `herder_file_inspector_mode` switches Diff
+or View, `herder_file_inspector_state` exposes loading, byte/row/change counts,
+syntax and renderer telemetry, and `herder_file_inspector_text` returns exact
+before/after/View text. Visual inspection is therefore optional for automation.

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -16,6 +16,92 @@ enum public GitDiffLineKind {
     empty
 }
 
+enum public InspectorRequestState {
+    idle
+    queued
+    running
+}
+
+enum public InspectorContentState {
+    absent
+    ready
+    failed
+}
+
+// Request lifetime and installed content deliberately do not collapse into a
+// single state. A replacement can be running while the previous successful
+// payload remains visible, and a failed replacement does not destroy it.
+struct public InspectorLoadState {
+    generation : int
+    request : InspectorRequestState = InspectorRequestState.idle
+    latest_outcome : InspectorContentState = InspectorContentState.absent
+    has_retained_content : bool
+    retained_generation : int
+    status : string
+    error : string
+}
+
+def public inspector_load_queue(var state : InspectorLoadState;
+                                status : string = "Queued") : int {
+    state.generation++
+    state.request = InspectorRequestState.queued
+    state.status = status
+    state.error = ""
+    return state.generation
+}
+
+def public inspector_load_start(var state : InspectorLoadState;
+                                generation : int;
+                                status : string = "Loading") : bool {
+    if (generation != state.generation
+            || state.request != InspectorRequestState.queued) return false
+    state.request = InspectorRequestState.running
+    state.status = status
+    return true
+}
+
+def public inspector_load_succeed(var state : InspectorLoadState;
+                                  generation : int;
+                                  status : string = "Ready") : bool {
+    if (generation != state.generation) return false
+    state.request = InspectorRequestState.idle
+    state.latest_outcome = InspectorContentState.ready
+    state.has_retained_content = true
+    state.retained_generation = generation
+    state.status = status
+    state.error = ""
+    return true
+}
+
+def public inspector_load_fail(var state : InspectorLoadState;
+                               generation : int;
+                               error : string) : bool {
+    if (generation != state.generation) return false
+    state.request = InspectorRequestState.idle
+    state.latest_outcome = InspectorContentState.failed
+    state.status = "Failed"
+    state.error = error
+    return true
+}
+
+def public inspector_load_reset(var state : InspectorLoadState) {
+    state.generation++
+    state.request = InspectorRequestState.idle
+    state.latest_outcome = InspectorContentState.absent
+    state.has_retained_content = false
+    state.retained_generation = 0
+    state.status = ""
+    state.error = ""
+}
+
+def public inspector_load_supersede(var state : InspectorLoadState;
+                                    status : string = "Refreshing") {
+    state.generation++
+    state.request = InspectorRequestState.idle
+    state.status = status
+    state.error = ""
+}
+
 struct public GitDiffRow {
     old_text : string
     new_text : string

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -28,6 +28,40 @@ enum public InspectorContentState {
     failed
 }
 
+def private strip_local_suffix(path : string) : string {
+    let lower = to_lower(path)
+    if (ends_with(lower, ".local")) {
+        return slice(lower, 0, length(lower) - length(".local"))
+    }
+    return lower
+}
+
+def public inspector_language_for_path(path : string;
+                                       requested : string = "auto") : string {
+    //! Resolve the syntax producer independently from the renderer. An empty
+    //! result deliberately means plain text. `.local` is a Git/worktree
+    //! convention in this repository, so `notes.md.local` remains Markdown.
+    let choice = to_lower(requested)
+    if (!empty(choice) && choice != "auto") {
+        if (choice == "plain" || choice == "text") return ""
+        if (choice == "das" || choice == "dascript") return "daslang"
+        if (choice == "c++") return "cpp"
+        if (choice == "md") return "markdown"
+        return choice
+    }
+    let candidate = strip_local_suffix(path)
+    if (ends_with(candidate, ".das")) return "daslang"
+    if (ends_with(candidate, ".c")) return "c"
+    if (ends_with(candidate, ".cc") || ends_with(candidate, ".cpp")
+            || ends_with(candidate, ".cxx") || ends_with(candidate, ".h")
+            || ends_with(candidate, ".hh") || ends_with(candidate, ".hpp")
+            || ends_with(candidate, ".hxx")) return "cpp"
+    if (ends_with(candidate, ".md")
+            || ends_with(candidate, ".markdown")) return "markdown"
+    if (ends_with(candidate, ".json")) return "json"
+    return ""
+}
+
 // Request lifetime and installed content deliberately do not collapse into a
 // single state. A replacement can be running while the previous successful
 // payload remains visible, and a failed replacement does not destroy it.
@@ -111,12 +145,20 @@ struct public GitDiffRow {
     new_kind : GitDiffLineKind = GitDiffLineKind.empty
 }
 
+struct public GitDiffHunk {
+    row_start : int
+    row_count : int
+    old_start : int
+    new_start : int
+}
+
 struct public GitParsedPatch {
     old_text : string
     new_text : string
     old_aligned_text : string
     new_aligned_text : string
     rows : array<GitDiffRow>
+    hunks : array<GitDiffHunk>
     old_changed_lines : array<int>
     new_changed_lines : array<int>
     new_deleted_anchors : array<int>
@@ -126,6 +168,7 @@ struct public GitParsedPatch {
 
 def public git_parsed_patch_dispose(var patch : GitParsedPatch) {
     delete patch.rows
+    delete patch.hunks
     delete patch.old_changed_lines
     delete patch.new_changed_lines
     delete patch.new_deleted_anchors
@@ -147,7 +190,7 @@ def private byte_at(value : string; index : int) : int {
     return result
 }
 
-def private parse_decimal(value : string; var index : int) : int {
+def private parse_decimal(value : string; var index : int&) : int {
     var result = 0
     let value_length = length(value)
     while (index < value_length && is_number(byte_at(value, index))) {
@@ -157,12 +200,13 @@ def private parse_decimal(value : string; var index : int) : int {
     return result
 }
 
-def private parse_hunk_starts(header : string; var old_line, new_line : int) : bool {
+def private parse_hunk_starts(header : string;
+                              var old_line : int&; var new_line : int&) : bool {
     let old_marker = find(header, "-")
     let new_marker = find(header, "+", max(0, old_marker + 1))
     if (old_marker < 0 || new_marker < 0) return false
-    let old_at = old_marker + 1
-    let new_at = new_marker + 1
+    var old_at = old_marker + 1
+    var new_at = new_marker + 1
     old_line = parse_decimal(header, old_at)
     new_line = parse_decimal(header, new_at)
     return old_line >= 0 && new_line >= 0
@@ -214,10 +258,17 @@ def public git_parse_unified_patch(patch : string) : GitParsedPatch {
         if (starts_with(line, "@@")) {
             append_change_rows(result, removed_text, removed_lines,
                 added_text, added_lines)
+            if (!empty(result.hunks)) {
+                let previous = length(result.hunks) - 1
+                result.hunks[previous].row_count = length(result.rows) - result.hunks[previous].row_start
+            }
             if (!parse_hunk_starts(line, old_line, new_line)) {
                 result.error = "invalid unified diff hunk header"
                 return <- result
             }
+            result.hunks |> push(GitDiffHunk(
+                row_start = length(result.rows), old_start = old_line,
+                new_start = new_line))
             in_hunk = true
             continue
         }
@@ -252,6 +303,10 @@ def public git_parse_unified_patch(patch : string) : GitParsedPatch {
     }
     append_change_rows(result, removed_text, removed_lines,
         added_text, added_lines)
+    if (!empty(result.hunks)) {
+        let last = length(result.hunks) - 1
+        result.hunks[last].row_count = length(result.rows) - result.hunks[last].row_start
+    }
     if (!in_hunk && !result.binary) {
         result.error = "diff contains no text hunks"
         return <- result

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -276,10 +276,14 @@ def public git_parse_unified_patch(patch : string) : GitParsedPatch {
     var inscope added_lines : array<int>
     var inscope lines <- split(patch, "\n")
     var in_hunk = false
+    var saw_diff_header = false
     var old_line = 0
     var new_line = 0
     for (raw_line in lines) {
         let line = trim_cr(raw_line)
+        if (starts_with(line, "diff --git ")) {
+            saw_diff_header = true
+        }
         if (git_patch_line_is_binary(line)) {
             result.binary = true
         }
@@ -335,7 +339,7 @@ def public git_parse_unified_patch(patch : string) : GitParsedPatch {
         let last = length(result.hunks) - 1
         result.hunks[last].row_count = length(result.rows) - result.hunks[last].row_start
     }
-    if (!in_hunk && !result.binary) {
+    if (!in_hunk && !result.binary && !saw_diff_header) {
         result.error = "diff contains no text hunks"
         return <- result
     }

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -326,12 +326,23 @@ def public git_parse_unified_patch(patch : string) : GitParsedPatch {
     }
     old_aligned |> reserve(length(result.rows))
     new_aligned |> reserve(length(result.rows))
-    for (row in result.rows) {
+    var hunk_index = 0
+    var new_cursor = 0
+    for (row_index in range(length(result.rows))) {
+        if (hunk_index < length(result.hunks)
+                && result.hunks[hunk_index].row_start == row_index) {
+            new_cursor = max(0, result.hunks[hunk_index].new_start - 1)
+            hunk_index++
+        }
+        let row = result.rows[row_index]
         old_aligned |> push(row.old_text)
         new_aligned |> push(row.new_text)
         if (row.old_kind == GitDiffLineKind.removed
                 && row.new_kind == GitDiffLineKind.empty) {
-            result.new_deleted_anchors |> push(max(0, row.new_line - 1))
+            result.new_deleted_anchors |> push(new_cursor)
+        }
+        if (row.new_line > 0) {
+            new_cursor = row.new_line
         }
     }
     result.old_text = join(old_lines, "\n")

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -236,6 +236,19 @@ def private append_change_rows(var result : GitParsedPatch;
     delete added_lines
 }
 
+def private git_patch_line_is_binary(line : string) : bool {
+    return (line == "GIT binary patch"
+        || starts_with(line, "Binary files ") && ends_with(line, " differ"))
+}
+
+def public git_patch_is_binary(patch : string) : bool {
+    var inscope lines <- split(patch, "\n")
+    for (raw_line in lines) {
+        if (git_patch_line_is_binary(trim_cr(raw_line))) return true
+    }
+    return false
+}
+
 def public git_parse_unified_patch(patch : string) : GitParsedPatch {
     var result = GitParsedPatch()
     var inscope old_lines : array<string>
@@ -252,7 +265,7 @@ def public git_parse_unified_patch(patch : string) : GitParsedPatch {
     var new_line = 0
     for (raw_line in lines) {
         let line = trim_cr(raw_line)
-        if (starts_with(line, "Binary files ") || starts_with(line, "GIT binary patch")) {
+        if (git_patch_line_is_binary(line)) {
             result.binary = true
         }
         if (starts_with(line, "@@")) {

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -9,10 +9,10 @@ require strings public
 require daslib/strings_boost
 require math
 
-//! Raw binary bytes embedded into the JSON/base64 fallback preview path.
-//! 8 MiB becomes roughly 10.7 MiB on the wire while bounding simultaneous
-//! mapped/raw/encoded/decoded allocations in the watcher and rich client.
-let public MAX_BINARY_PREVIEW_RAW_BYTES = 8 * 1024 * 1024
+//! Raw bytes embedded into a file View response. 8 MiB bounds text JSON and
+//! becomes roughly 10.7 MiB for the binary base64 fallback while limiting
+//! simultaneous mapped/raw/encoded/decoded allocations across both clients.
+let public MAX_FILE_PREVIEW_RAW_BYTES = 8 * 1024 * 1024
 
 enum public GitDiffLineKind {
     context
@@ -250,6 +250,16 @@ def public git_patch_is_binary(patch : string) : bool {
     var inscope lines <- split(patch, "\n")
     for (raw_line in lines) {
         if (git_patch_line_is_binary(trim_cr(raw_line))) return true
+    }
+    return false
+}
+
+def public git_patch_result_is_deleted(patch : string) : bool {
+    for (raw_line in split(patch, "\n")) {
+        let line = trim_cr(raw_line)
+        if (line == "+++ /dev/null" || starts_with(line, "deleted file mode ")
+                || (starts_with(line, "Binary files ")
+                    && find(line, " and /dev/null differ") >= 0)) return true
     }
     return false
 }

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -1,0 +1,188 @@
+options gen2
+options persistent_heap
+options gc
+options indenting = 4
+
+module file_inspection shared public
+
+require strings public
+require daslib/strings_boost
+require math
+
+enum public GitDiffLineKind {
+    context
+    removed
+    added
+    empty
+}
+
+struct public GitDiffRow {
+    old_text : string
+    new_text : string
+    old_line : int = -1
+    new_line : int = -1
+    old_kind : GitDiffLineKind = GitDiffLineKind.empty
+    new_kind : GitDiffLineKind = GitDiffLineKind.empty
+}
+
+struct public GitParsedPatch {
+    old_text : string
+    new_text : string
+    old_aligned_text : string
+    new_aligned_text : string
+    rows : array<GitDiffRow>
+    old_changed_lines : array<int>
+    new_changed_lines : array<int>
+    new_deleted_anchors : array<int>
+    binary : bool
+    error : string
+}
+
+def public git_parsed_patch_dispose(var patch : GitParsedPatch) {
+    delete patch.rows
+    delete patch.old_changed_lines
+    delete patch.new_changed_lines
+    delete patch.new_deleted_anchors
+    patch = GitParsedPatch()
+}
+
+def private trim_cr(value : string) : string {
+    if (!empty(value) && ends_with(value, "\r")) {
+        return slice(value, 0, length(value) - 1)
+    }
+    return value
+}
+
+def private byte_at(value : string; index : int) : int {
+    var result = 0
+    peek_data(value) $(data) {
+        result = int(data[index])
+    }
+    return result
+}
+
+def private parse_decimal(value : string; var index : int) : int {
+    var result = 0
+    let value_length = length(value)
+    while (index < value_length && is_number(byte_at(value, index))) {
+        result = result * 10 + byte_at(value, index) - '0'
+        index++
+    }
+    return result
+}
+
+def private parse_hunk_starts(header : string; var old_line, new_line : int) : bool {
+    let old_marker = find(header, "-")
+    let new_marker = find(header, "+", max(0, old_marker + 1))
+    if (old_marker < 0 || new_marker < 0) return false
+    let old_at = old_marker + 1
+    let new_at = new_marker + 1
+    old_line = parse_decimal(header, old_at)
+    new_line = parse_decimal(header, new_at)
+    return old_line >= 0 && new_line >= 0
+}
+
+def private append_change_rows(var result : GitParsedPatch;
+                               var removed_text : array<string>;
+                               var removed_lines : array<int>;
+                               var added_text : array<string>;
+                               var added_lines : array<int>) {
+    let count = max(length(removed_text), length(added_text))
+    result.rows |> reserve(length(result.rows) + count)
+    for (index in range(count)) {
+        let has_old = index < length(removed_text)
+        let has_new = index < length(added_text)
+        result.rows |> push(GitDiffRow(
+            old_text = has_old ? removed_text[index] : "",
+            new_text = has_new ? added_text[index] : "",
+            old_line = has_old ? removed_lines[index] : -1,
+            new_line = has_new ? added_lines[index] : -1,
+            old_kind = has_old ? GitDiffLineKind.removed : GitDiffLineKind.empty,
+            new_kind = has_new ? GitDiffLineKind.added : GitDiffLineKind.empty))
+    }
+    delete removed_text
+    delete removed_lines
+    delete added_text
+    delete added_lines
+}
+
+def public git_parse_unified_patch(patch : string) : GitParsedPatch {
+    var result = GitParsedPatch()
+    var inscope old_lines : array<string>
+    var inscope new_lines : array<string>
+    var inscope old_aligned : array<string>
+    var inscope new_aligned : array<string>
+    var inscope removed_text : array<string>
+    var inscope removed_lines : array<int>
+    var inscope added_text : array<string>
+    var inscope added_lines : array<int>
+    var inscope lines <- split(patch, "\n")
+    var in_hunk = false
+    var old_line = 0
+    var new_line = 0
+    for (raw_line in lines) {
+        let line = trim_cr(raw_line)
+        if (starts_with(line, "Binary files ") || starts_with(line, "GIT binary patch")) {
+            result.binary = true
+        }
+        if (starts_with(line, "@@")) {
+            append_change_rows(result, removed_text, removed_lines,
+                added_text, added_lines)
+            if (!parse_hunk_starts(line, old_line, new_line)) {
+                result.error = "invalid unified diff hunk header"
+                return <- result
+            }
+            in_hunk = true
+            continue
+        }
+        if (!in_hunk || empty(line) || starts_with(line, "\\ No newline")) continue
+        let prefix = byte_at(line, 0)
+        let text = slice(line, 1)
+        if (prefix == ' ') {
+            append_change_rows(result, removed_text, removed_lines,
+                added_text, added_lines)
+            result.rows |> push(GitDiffRow(
+                old_text = text, new_text = text,
+                old_line = old_line, new_line = new_line,
+                old_kind = GitDiffLineKind.context,
+                new_kind = GitDiffLineKind.context))
+            old_lines |> push(text)
+            new_lines |> push(text)
+            old_line++
+            new_line++
+        } elif (prefix == '-') {
+            removed_text |> push(text)
+            removed_lines |> push(old_line)
+            old_lines |> push(text)
+            result.old_changed_lines |> push(old_line - 1)
+            old_line++
+        } elif (prefix == '+') {
+            added_text |> push(text)
+            added_lines |> push(new_line)
+            new_lines |> push(text)
+            result.new_changed_lines |> push(new_line - 1)
+            new_line++
+        }
+    }
+    append_change_rows(result, removed_text, removed_lines,
+        added_text, added_lines)
+    if (!in_hunk && !result.binary) {
+        result.error = "diff contains no text hunks"
+        return <- result
+    }
+    old_aligned |> reserve(length(result.rows))
+    new_aligned |> reserve(length(result.rows))
+    for (row in result.rows) {
+        old_aligned |> push(row.old_text)
+        new_aligned |> push(row.new_text)
+        if (row.old_kind == GitDiffLineKind.removed
+                && row.new_kind == GitDiffLineKind.empty) {
+            result.new_deleted_anchors |> push(max(0, row.new_line - 1))
+        }
+    }
+    result.old_text = join(old_lines, "\n")
+    result.new_text = join(new_lines, "\n")
+    result.old_aligned_text = join(old_aligned, "\n")
+    result.new_aligned_text = join(new_aligned, "\n")
+    return <- result
+}

--- a/utils/dasHerd/watcher/file_inspection.das
+++ b/utils/dasHerd/watcher/file_inspection.das
@@ -9,6 +9,11 @@ require strings public
 require daslib/strings_boost
 require math
 
+//! Raw binary bytes embedded into the JSON/base64 fallback preview path.
+//! 8 MiB becomes roughly 10.7 MiB on the wire while bounding simultaneous
+//! mapped/raw/encoded/decoded allocations in the watcher and rich client.
+let public MAX_BINARY_PREVIEW_RAW_BYTES = 8 * 1024 * 1024
+
 enum public GitDiffLineKind {
     context
     removed

--- a/utils/dasHerd/watcher/image_preview_gl.das
+++ b/utils/dasHerd/watcher/image_preview_gl.das
@@ -1,0 +1,38 @@
+options gen2
+options indenting = 4
+
+module image_preview_gl shared public
+
+require imgui
+require opengl/opengl_boost
+require daslib/safe_addr
+
+//! Main-thread GL bridge for decoded inspector pixels. Keeping backend calls
+//! here preserves imgui_harness' rule that application files use the harness
+//! lifecycle rather than reaching into the backend directly.
+
+def public inspector_preview_texture_upload(pixels : array<uint8># const;
+                                            width, height : int;
+                                            var texture : uint&) {
+    if (empty(pixels) || width <= 0 || height <= 0) return
+    glGenTextures(1, unsafe(addr(texture)))
+    glBindTexture(GL_TEXTURE_2D, texture)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+    glTexImage2D(GL_TEXTURE_2D, 0, int(GL_RGBA), width, height, 0,
+        GL_RGBA, GL_UNSIGNED_BYTE, unsafe(addr(pixels[0])))
+}
+
+def public inspector_preview_texture_release(var texture : uint&) {
+    if (texture == 0u) return
+    glDeleteTextures(1, unsafe(addr(texture)))
+    texture = 0u
+}
+
+def public inspector_preview_texture_ref(texture : uint) : ImTextureRef {
+    unsafe {
+        var result : ImTextureRef
+        result._TexID = uint64(texture)
+        return result
+    }
+}

--- a/utils/dasHerd/watcher/image_preview_gl.das
+++ b/utils/dasHerd/watcher/image_preview_gl.das
@@ -12,7 +12,7 @@ require daslib/safe_addr
 //! lifecycle rather than reaching into the backend directly.
 
 def public inspector_preview_texture_upload(pixels : array<uint8># const;
-                                            width, height : int;
+                                            width : int; height : int;
                                             var texture : uint&) {
     if (empty(pixels) || width <= 0 || height <= 0) return
     glGenTextures(1, unsafe(addr(texture)))

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -14,7 +14,6 @@ require imgui/imgui_markdown_tree_sitter
 require stbimage/stbimage_boost
 require ./file_inspection.das
 
-let private MAX_BINARY_PREVIEW_BYTES = 32 * 1024 * 1024
 let private MAX_BINARY_PREVIEW_PIXELS = 64l * 1024l * 1024l
 
 enum public InspectorPrepareEventKind {
@@ -216,10 +215,10 @@ def private prepare_worker_main(var jobs : Channel?&;
                         }
                     }
                     if (prepared_patch.binary) {
-                        if (job.view_byte_count > MAX_BINARY_PREVIEW_BYTES) {
-                            preview_error = "Binary preview exceeds the 32 MiB raw-byte limit"
+                        if (job.view_byte_count > MAX_BINARY_PREVIEW_RAW_BYTES) {
+                            preview_error = "Binary preview exceeds the 8 MiB raw-byte limit"
                         } elif (empty(job.view_base64)) {
-                            preview_error = "No working-file bytes were provided"
+                            preview_error = "Binary preview bytes are unavailable for this comparison"
                         } else {
                             var inscope encoded : array<uint8>
                             let decoded = base64_decode(job.view_base64, encoded)

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -218,6 +218,10 @@ def private prepare_worker_main(var jobs : Channel?&;
                     if (prepared_patch.binary) {
                         if (job.view_byte_count > MAX_FILE_PREVIEW_RAW_BYTES) {
                             preview_error = "Binary preview exceeds the 8 MiB raw-byte limit"
+                        } elif (job.view_byte_count == 0) {
+                            preview_error = "Binary preview is empty"
+                        } elif (job.view_byte_count < 0) {
+                            preview_error = "Binary transport reported an invalid byte count"
                         } elif (empty(job.view_base64)) {
                             preview_error = "Binary preview bytes are unavailable for this comparison"
                         } else {

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -30,6 +30,7 @@ struct public InspectorPrepareJob {
     view_text : string
     view_base64 : string
     view_byte_count : int
+    view_available : bool
     language : string
     stop : bool
 }
@@ -186,7 +187,7 @@ def private prepare_worker_main(var jobs : Channel?&;
                                 kind = TextSourceLineMarkKind.added))
                         }
                     }
-                    view_source = !empty(job.view_text) ? job.view_text : prepared_patch.new_text
+                    view_source = (job.view_available || !empty(job.view_text)) ? job.view_text : prepared_patch.new_text
                     if (!prepared_patch.binary) {
                         var prepared_view <- tree_sitter_source_document(
                             view_source, job.language, job.generation)
@@ -215,7 +216,7 @@ def private prepare_worker_main(var jobs : Channel?&;
                         }
                     }
                     if (prepared_patch.binary) {
-                        if (job.view_byte_count > MAX_BINARY_PREVIEW_RAW_BYTES) {
+                        if (job.view_byte_count > MAX_FILE_PREVIEW_RAW_BYTES) {
                             preview_error = "Binary preview exceeds the 8 MiB raw-byte limit"
                         } elif (empty(job.view_base64)) {
                             preview_error = "Binary preview bytes are unavailable for this comparison"
@@ -325,12 +326,14 @@ def public inspector_prepare_worker_queue(var worker : InspectorPrepareWorker;
                                           generation : int;
                                           patch, view_text, language : string;
                                           view_base64 : string = "";
-                                          view_byte_count : int = 0) : bool {
+                                          view_byte_count : int = 0;
+                                          view_available : bool = false) : bool {
     if (!worker.started || worker.stopped || worker.jobs == null) return false
     worker.jobs |> push_clone(InspectorPrepareJob(
         generation = generation, patch = patch, view_text = view_text,
         language = language, view_base64 = view_base64,
-        view_byte_count = view_byte_count))
+        view_byte_count = view_byte_count,
+        view_available = view_available))
     return true
 }
 

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -1,0 +1,230 @@
+options gen2
+options gc
+options persistent_heap
+options indenting = 4
+
+module inspection_worker shared public
+
+require daslib/jobque_boost
+require daslib/rtti
+require imgui/imgui_text_tree_sitter
+require ./file_inspection.das
+
+enum public InspectorPrepareEventKind {
+    ready
+    started
+    completed
+    failed
+    stopped
+}
+
+struct public InspectorPrepareJob {
+    generation : int
+    patch : string
+    view_text : string
+    language : string
+    stop : bool
+}
+
+[safe_when_uninitialized]
+struct public InspectorPrepareEvent {
+    kind : InspectorPrepareEventKind
+    generation : int
+    parsed : GitParsedPatch = GitParsedPatch()
+    old_document : TextSourceDocument = TextSourceDocument()
+    new_document : TextSourceDocument = TextSourceDocument()
+    view_source : string
+    error : string
+    elapsed_usec : int64
+}
+
+struct public InspectorPrepareWorker {
+    jobs : Channel?
+    events : Channel?
+    started : bool
+    stopped : bool
+}
+
+def private emit_prepare_event(events : Channel?;
+                               event : InspectorPrepareEvent) {
+    events |> push_clone(event)
+}
+
+def private catch_prepare_panic(var failure : string&;
+                                blk : block<() : void>) : bool {
+    var caught = false
+    try {
+        invoke(blk)
+    } recover {
+        caught = true
+        failure = this_context().last_exception
+    }
+    return caught
+}
+
+def private prepare_worker_main(var jobs : Channel?&;
+                                var events : Channel?&) {
+    this_context().name := "dasHerd_inspector_prepare"
+    emit_prepare_event(events, InspectorPrepareEvent(
+        kind = InspectorPrepareEventKind.ready))
+    var stopping = false
+    while (!stopping) {
+        jobs |> pop_with_timeout_clone(250) $(first : InspectorPrepareJob#) {
+            var job : InspectorPrepareJob
+            job := first
+
+            // Only the newest waiting projection matters. This bounds rapid
+            // file-selection churn without trying to interrupt native parsing
+            // which is already in progress.
+            var draining = true
+            while (draining) {
+                draining = jobs |> try_pop_clone() $(next : InspectorPrepareJob#) {
+                    delete job
+                    job := next
+                }
+            }
+            if (job.stop) {
+                stopping = true
+                delete job
+                return
+            }
+
+            emit_prepare_event(events, InspectorPrepareEvent(
+                kind = InspectorPrepareEventKind.started,
+                generation = job.generation))
+            let started_at = ref_time_ticks()
+            var failure = ""
+            var parsed = GitParsedPatch()
+            var old_document = TextSourceDocument()
+            var new_document = TextSourceDocument()
+            var view_source = ""
+            let failed = catch_prepare_panic(failure) {
+                var prepared_patch <- git_parse_unified_patch(job.patch)
+                if (!empty(prepared_patch.error)) {
+                    failure = prepared_patch.error
+                } else {
+                    var prepared_old <- tree_sitter_source_document(
+                        prepared_patch.old_aligned_text, job.language,
+                        job.generation)
+                    var prepared_new <- tree_sitter_source_document(
+                        prepared_patch.new_aligned_text, job.language,
+                        job.generation)
+                    for (index in range(length(prepared_patch.rows))) {
+                        if (prepared_patch.rows[index].old_kind
+                                == GitDiffLineKind.removed) {
+                            prepared_old.line_marks |> push(TextSourceLineMark(
+                                line_index = index,
+                                kind = TextSourceLineMarkKind.removed))
+                        }
+                        if (prepared_patch.rows[index].new_kind
+                                == GitDiffLineKind.added) {
+                            prepared_new.line_marks |> push(TextSourceLineMark(
+                                line_index = index,
+                                kind = TextSourceLineMarkKind.added))
+                        }
+                    }
+                    view_source = !empty(job.view_text) ? job.view_text : prepared_patch.new_text
+                    parsed <- prepared_patch
+                    old_document <- prepared_old
+                    new_document <- prepared_new
+                }
+            }
+            let elapsed_usec = int64(get_time_usec(started_at))
+            if (failed || !empty(failure)) {
+                emit_prepare_event(events, InspectorPrepareEvent(
+                    kind = InspectorPrepareEventKind.failed,
+                    generation = job.generation,
+                    error = failure,
+                    elapsed_usec = elapsed_usec))
+            } else {
+                var event = InspectorPrepareEvent(
+                    kind = InspectorPrepareEventKind.completed,
+                    generation = job.generation,
+                    view_source = view_source,
+                    elapsed_usec = elapsed_usec)
+                event.parsed <- parsed
+                event.old_document <- old_document
+                event.new_document <- new_document
+                emit_prepare_event(events, event)
+                git_parsed_patch_dispose(event.parsed)
+                text_source_document_dispose(event.old_document)
+                text_source_document_dispose(event.new_document)
+            }
+            git_parsed_patch_dispose(parsed)
+            text_source_document_dispose(old_document)
+            text_source_document_dispose(new_document)
+            delete job
+        }
+    }
+    emit_prepare_event(events, InspectorPrepareEvent(
+        kind = InspectorPrepareEventKind.stopped))
+    jobs |> release
+    events |> release
+}
+
+def public inspector_prepare_worker_start(var worker : InspectorPrepareWorker) : bool {
+    if (worker.started) return false
+    worker.jobs = unsafe(channel_create())
+    worker.events = unsafe(channel_create())
+    worker.started = true
+    worker.stopped = false
+    var jobs_capture = worker.jobs
+    var events_capture = worker.events
+    new_thread() <| @capture(= jobs_capture, = events_capture) {
+        prepare_worker_main(jobs_capture, events_capture)
+    }
+    return true
+}
+
+def public inspector_prepare_worker_queue(var worker : InspectorPrepareWorker;
+                                          generation : int;
+                                          patch, view_text, language : string) : bool {
+    if (!worker.started || worker.stopped || worker.jobs == null) return false
+    worker.jobs |> push_clone(InspectorPrepareJob(
+        generation = generation, patch = patch, view_text = view_text,
+        language = language))
+    return true
+}
+
+def public inspector_prepare_worker_try_event(
+        var worker : InspectorPrepareWorker;
+        blk : block<(event : InspectorPrepareEvent#) : void>) : bool {
+    if (!worker.started || worker.events == null) return false
+    return worker.events |> try_pop_clone() $(event : InspectorPrepareEvent#) {
+        if (event.kind == InspectorPrepareEventKind.stopped) {
+            worker.stopped = true
+        }
+        invoke(blk, event)
+    }
+}
+
+def public inspector_prepare_worker_shutdown(var worker : InspectorPrepareWorker;
+                                             timeout_ms : int = 10000) : bool {
+    if (!worker.started) return true
+    if (!worker.stopped && worker.jobs != null) {
+        worker.jobs |> push_clone(InspectorPrepareJob(stop = true))
+    }
+    let started_at = ref_time_ticks()
+    while (!worker.stopped
+            && int64(get_time_usec(started_at)) < int64(timeout_ms) * 1000l) {
+        if (worker.events != null) {
+            worker.events |> pop_with_timeout_clone(50) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.stopped) {
+                    worker.stopped = true
+                }
+            }
+        }
+    }
+    if (!worker.stopped) return false
+
+    var jobs = worker.jobs
+    var events = worker.events
+    worker.jobs = null
+    worker.events = null
+    worker.started = false
+    unsafe {
+        if (jobs != null) jobs |> channel_remove
+        if (events != null) events |> channel_remove
+    }
+    return true
+}

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -10,6 +10,7 @@ require daslib/rtti
 require daslib/base64
 require daslib/safe_addr
 require imgui/imgui_text_tree_sitter
+require imgui/imgui_markdown_tree_sitter
 require stbimage/stbimage_boost
 require ./file_inspection.das
 
@@ -41,6 +42,10 @@ struct public InspectorPrepareEvent {
     parsed : GitParsedPatch = GitParsedPatch()
     old_document : TextSourceDocument = TextSourceDocument()
     new_document : TextSourceDocument = TextSourceDocument()
+    view_document : TextSourceDocument = TextSourceDocument()
+    markdown_document : RichDocument = RichDocument()
+    markdown_view : MarkdownViewState = MarkdownViewState()
+    changed_source_ranges : array<TextSourceRange>
     view_source : string
     preview_pixels : array<uint8>
     preview_width : int
@@ -73,6 +78,38 @@ def private catch_prepare_panic(var failure : string&;
         failure = this_context().last_exception
     }
     return caught
+}
+
+def private prepare_changed_source_ranges(source : string;
+                                          lines : array<int> const) : array<TextSourceRange> {
+    var result : array<TextSourceRange>
+    if (empty(lines)) return <- result
+    var target = 0
+    var line_index = 0
+    var line_start = 0
+    peek_data(source) $(bytes) {
+        for (at in range(length(bytes))) {
+            if (int(bytes[at]) != '\n') continue
+            while (target < length(lines) && lines[target] < line_index) {
+                target++
+            }
+            if (target < length(lines) && lines[target] == line_index) {
+                result |> push(TextSourceRange(start_byte = line_start, end_byte = at + 1))
+                while (target < length(lines) && lines[target] == line_index) {
+                    target++
+                }
+            }
+            line_index++
+            line_start = at + 1
+        }
+    }
+    while (target < length(lines) && lines[target] < line_index) {
+        target++
+    }
+    if (target < length(lines) && lines[target] == line_index) {
+        result |> push(TextSourceRange(start_byte = line_start, end_byte = length(source)))
+    }
+    return <- result
 }
 
 def private prepare_worker_main(var jobs : Channel?&;
@@ -110,6 +147,10 @@ def private prepare_worker_main(var jobs : Channel?&;
             var parsed = GitParsedPatch()
             var old_document = TextSourceDocument()
             var new_document = TextSourceDocument()
+            var view_document = TextSourceDocument()
+            var markdown_document = RichDocument()
+            var markdown_view = MarkdownViewState()
+            var changed_ranges : array<TextSourceRange>
             var view_source = ""
             var preview_pixels : array<uint8>
             var preview_width = 0
@@ -147,9 +188,36 @@ def private prepare_worker_main(var jobs : Channel?&;
                         }
                     }
                     view_source = !empty(job.view_text) ? job.view_text : prepared_patch.new_text
+                    if (!prepared_patch.binary) {
+                        var prepared_view <- tree_sitter_source_document(
+                            view_source, job.language, job.generation)
+                        prepared_view.line_marks |> reserve(
+                            length(prepared_patch.new_changed_lines))
+                        for (line in prepared_patch.new_changed_lines) {
+                            prepared_view.line_marks |> push(TextSourceLineMark(
+                                line_index = line, kind = TextSourceLineMarkKind.added))
+                        }
+                        view_document <- prepared_view
+                        if (job.language == "markdown") {
+                            var prepared_markdown <- md_parse(view_source)
+                            if (!prepared_markdown.ok) {
+                                failure = (empty(prepared_markdown.error)
+                                    ? "Markdown preparation failed"
+                                    : prepared_markdown.error)
+                            } else {
+                                var prepared_markdown_view = MarkdownViewState()
+                                let _ = markdown_tree_sitter_prepare(prepared_markdown,
+                                    prepared_markdown_view, job.generation)
+                                markdown_document <- prepared_markdown
+                                markdown_view <- prepared_markdown_view
+                                changed_ranges <- prepare_changed_source_ranges(
+                                    view_source, prepared_patch.new_changed_lines)
+                            }
+                        }
+                    }
                     if (prepared_patch.binary) {
                         if (job.view_byte_count > MAX_BINARY_PREVIEW_BYTES) {
-                            preview_error = "Binary preview exceeds the 32 MiB transport limit"
+                            preview_error = "Binary preview exceeds the 32 MiB raw-byte limit"
                         } elif (empty(job.view_base64)) {
                             preview_error = "No working-file bytes were provided"
                         } else {
@@ -208,16 +276,28 @@ def private prepare_worker_main(var jobs : Channel?&;
                 event.parsed <- parsed
                 event.old_document <- old_document
                 event.new_document <- new_document
+                event.view_document <- view_document
+                event.markdown_document <- markdown_document
+                event.markdown_view <- markdown_view
+                event.changed_source_ranges <- changed_ranges
                 event.preview_pixels <- preview_pixels
                 emit_prepare_event(events, event)
                 git_parsed_patch_dispose(event.parsed)
                 text_source_document_dispose(event.old_document)
                 text_source_document_dispose(event.new_document)
+                text_source_document_dispose(event.view_document)
+                rich_document_dispose(event.markdown_document)
+                markdown_view_dispose(event.markdown_view)
+                delete event.changed_source_ranges
                 delete event.preview_pixels
             }
             git_parsed_patch_dispose(parsed)
             text_source_document_dispose(old_document)
             text_source_document_dispose(new_document)
+            text_source_document_dispose(view_document)
+            rich_document_dispose(markdown_document)
+            markdown_view_dispose(markdown_view)
+            delete changed_ranges
             delete preview_pixels
             delete job
         }

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -328,7 +328,9 @@ def public inspector_prepare_worker_start(var worker : InspectorPrepareWorker) :
 
 def public inspector_prepare_worker_queue(var worker : InspectorPrepareWorker;
                                           generation : int;
-                                          patch, view_text, language : string;
+                                          patch : string;
+                                          view_text : string;
+                                          language : string;
                                           view_base64 : string = "";
                                           view_byte_count : int = 0;
                                           view_available : bool = false) : bool {

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -7,8 +7,14 @@ module inspection_worker shared public
 
 require daslib/jobque_boost
 require daslib/rtti
+require daslib/base64
+require daslib/safe_addr
 require imgui/imgui_text_tree_sitter
+require stbimage/stbimage_boost
 require ./file_inspection.das
+
+let private MAX_BINARY_PREVIEW_BYTES = 32 * 1024 * 1024
+let private MAX_BINARY_PREVIEW_PIXELS = 64l * 1024l * 1024l
 
 enum public InspectorPrepareEventKind {
     ready
@@ -22,6 +28,8 @@ struct public InspectorPrepareJob {
     generation : int
     patch : string
     view_text : string
+    view_base64 : string
+    view_byte_count : int
     language : string
     stop : bool
 }
@@ -34,6 +42,11 @@ struct public InspectorPrepareEvent {
     old_document : TextSourceDocument = TextSourceDocument()
     new_document : TextSourceDocument = TextSourceDocument()
     view_source : string
+    preview_pixels : array<uint8>
+    preview_width : int
+    preview_height : int
+    preview_byte_count : int
+    preview_error : string
     error : string
     elapsed_usec : int64
 }
@@ -98,6 +111,10 @@ def private prepare_worker_main(var jobs : Channel?&;
             var old_document = TextSourceDocument()
             var new_document = TextSourceDocument()
             var view_source = ""
+            var preview_pixels : array<uint8>
+            var preview_width = 0
+            var preview_height = 0
+            var preview_error = ""
             let failed = catch_prepare_panic(failure) {
                 var prepared_patch <- git_parse_unified_patch(job.patch)
                 if (!empty(prepared_patch.error)) {
@@ -109,7 +126,13 @@ def private prepare_worker_main(var jobs : Channel?&;
                     var prepared_new <- tree_sitter_source_document(
                         prepared_patch.new_aligned_text, job.language,
                         job.generation)
+                    prepared_old.line_numbers |> reserve(length(prepared_patch.rows))
+                    prepared_new.line_numbers |> reserve(length(prepared_patch.rows))
                     for (index in range(length(prepared_patch.rows))) {
+                        prepared_old.line_numbers |> push(
+                            prepared_patch.rows[index].old_line)
+                        prepared_new.line_numbers |> push(
+                            prepared_patch.rows[index].new_line)
                         if (prepared_patch.rows[index].old_kind
                                 == GitDiffLineKind.removed) {
                             prepared_old.line_marks |> push(TextSourceLineMark(
@@ -124,6 +147,42 @@ def private prepare_worker_main(var jobs : Channel?&;
                         }
                     }
                     view_source = !empty(job.view_text) ? job.view_text : prepared_patch.new_text
+                    if (prepared_patch.binary) {
+                        if (job.view_byte_count > MAX_BINARY_PREVIEW_BYTES) {
+                            preview_error = "Binary preview exceeds the 32 MiB transport limit"
+                        } elif (empty(job.view_base64)) {
+                            preview_error = "No working-file bytes were provided"
+                        } else {
+                            var inscope encoded : array<uint8>
+                            let decoded = base64_decode(job.view_base64, encoded)
+                            if (decoded < 0 || decoded != job.view_byte_count) {
+                                preview_error = "Binary transport failed exact-byte validation"
+                            } else {
+                                var width, height, channels : int
+                                let image_info = stbi_info_from_memory(
+                                    unsafe(addr<uint8 const?>(encoded[0])),
+                                    length(encoded), safe_addr(width),
+                                    safe_addr(height), safe_addr(channels))
+                                if (image_info == 0) {
+                                    preview_error = stbi_failure_reason()
+                                } elif (width <= 0 || height <= 0 ||
+                                        int64(width) * int64(height)
+                                            > MAX_BINARY_PREVIEW_PIXELS) {
+                                    preview_error = "Image dimensions exceed the 64 megapixel preview limit"
+                                } else {
+                                    var image : Image
+                                    let (image_ok, image_error) = image->load_from_memory(encoded, 4)
+                                    if (image_ok) {
+                                        preview_width = image.width
+                                        preview_height = image.height
+                                        preview_pixels <- image.bytes
+                                    } else {
+                                        preview_error = image_error
+                                    }
+                                }
+                            }
+                        }
+                    }
                     parsed <- prepared_patch
                     old_document <- prepared_old
                     new_document <- prepared_new
@@ -141,18 +200,25 @@ def private prepare_worker_main(var jobs : Channel?&;
                     kind = InspectorPrepareEventKind.completed,
                     generation = job.generation,
                     view_source = view_source,
+                    preview_width = preview_width,
+                    preview_height = preview_height,
+                    preview_byte_count = job.view_byte_count,
+                    preview_error = preview_error,
                     elapsed_usec = elapsed_usec)
                 event.parsed <- parsed
                 event.old_document <- old_document
                 event.new_document <- new_document
+                event.preview_pixels <- preview_pixels
                 emit_prepare_event(events, event)
                 git_parsed_patch_dispose(event.parsed)
                 text_source_document_dispose(event.old_document)
                 text_source_document_dispose(event.new_document)
+                delete event.preview_pixels
             }
             git_parsed_patch_dispose(parsed)
             text_source_document_dispose(old_document)
             text_source_document_dispose(new_document)
+            delete preview_pixels
             delete job
         }
     }
@@ -178,11 +244,14 @@ def public inspector_prepare_worker_start(var worker : InspectorPrepareWorker) :
 
 def public inspector_prepare_worker_queue(var worker : InspectorPrepareWorker;
                                           generation : int;
-                                          patch, view_text, language : string) : bool {
+                                          patch, view_text, language : string;
+                                          view_base64 : string = "";
+                                          view_byte_count : int = 0) : bool {
     if (!worker.started || worker.stopped || worker.jobs == null) return false
     worker.jobs |> push_clone(InspectorPrepareJob(
         generation = generation, patch = patch, view_text = view_text,
-        language = language))
+        language = language, view_base64 = view_base64,
+        view_byte_count = view_byte_count))
     return true
 }
 

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -334,16 +334,28 @@ def public inspector_prepare_worker_queue(var worker : InspectorPrepareWorker;
     return true
 }
 
-def public inspector_prepare_worker_try_event(
-        var worker : InspectorPrepareWorker;
-        blk : block<(event : InspectorPrepareEvent#) : void>) : bool {
+def public inspector_prepare_worker_take_event(var worker : InspectorPrepareWorker;
+                                               var event : InspectorPrepareEvent) : bool {
     if (!worker.started || worker.events == null) return false
-    return worker.events |> try_pop_clone() $(event : InspectorPrepareEvent#) {
-        if (event.kind == InspectorPrepareEventKind.stopped) {
-            worker.stopped = true
-        }
-        invoke(blk, event)
+    delete event
+    let popped = _builtin_channel_try_pop(worker.events) $(data) {
+        event := *(unsafe(reinterpret<InspectorPrepareEvent?#>(data)))
     }
+    if (!popped) return false
+    if (event.kind == InspectorPrepareEventKind.stopped) {
+        worker.stopped = true
+    }
+    return true
+}
+
+def public inspector_prepare_worker_try_event(
+                                              var worker : InspectorPrepareWorker;
+                                              blk : block<(event : InspectorPrepareEvent#) : void>) : bool {
+    var event : InspectorPrepareEvent
+    if (!inspector_prepare_worker_take_event(worker, event)) return false
+    invoke(blk, unsafe(reinterpret<InspectorPrepareEvent -& -const#>(event)))
+    delete event
+    return true
 }
 
 def public inspector_prepare_worker_shutdown(var worker : InspectorPrepareWorker;

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -359,10 +359,10 @@ def public inspector_prepare_worker_take_event(var worker : InspectorPrepareWork
 
 def public inspector_prepare_worker_try_event(
                                               var worker : InspectorPrepareWorker;
-                                              blk : block<(event : InspectorPrepareEvent#) : void>) : bool {
+                                              blk : block<(event : InspectorPrepareEvent const) : void>) : bool {
     var event : InspectorPrepareEvent
     if (!inspector_prepare_worker_take_event(worker, event)) return false
-    invoke(blk, unsafe(reinterpret<InspectorPrepareEvent -& -const#>(event)))
+    invoke(blk, event)
     delete event
     return true
 }

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -341,8 +341,8 @@ def public inspector_prepare_worker_take_event(var worker : InspectorPrepareWork
                                                var event : InspectorPrepareEvent) : bool {
     if (!worker.started || worker.events == null) return false
     delete event
-    let popped = _builtin_channel_try_pop(worker.events) $(data) {
-        event := *(unsafe(reinterpret<InspectorPrepareEvent?#>(data)))
+    let popped = worker.events |> try_pop_clone() $(next : InspectorPrepareEvent#) {
+        event := next
     }
     if (!popped) return false
     if (event.kind == InspectorPrepareEventKind.stopped) {

--- a/utils/dasHerd/watcher/main.das
+++ b/utils/dasHerd/watcher/main.das
@@ -205,9 +205,6 @@ def shutdown() {
     g_server_started = false
     if (g_server != null) {
         g_server->cleanup_clients()
-        g_server->cleanup()
-        unsafe { delete g_server }
-        g_server = null
     }
     if (g_watcher_initialized) {
         if (g_repositories_initialized) {
@@ -216,6 +213,14 @@ def shutdown() {
         }
         watcher_shutdown()
         g_watcher_initialized = false
+    }
+    if (g_server != null) {
+        // Watcher shutdown releases any staged-view file handles before the
+        // final artifact-removal retry.
+        g_server->cleanup_inspection_artifacts()
+        g_server->cleanup()
+        unsafe { delete g_server }
+        g_server = null
     }
     watcher_reset_gc_request()
 }

--- a/utils/dasHerd/watcher/main.das
+++ b/utils/dasHerd/watcher/main.das
@@ -18,11 +18,13 @@ require math
 var private g_server : DasHerdWatcherServer?
 var private g_args_parsed = false
 var private g_watcher_initialized = false
+var private g_repositories_initialized = false
 var private g_server_started = false
 var private g_exit_code = 0
 var private g_port = 9191
 var private g_token : string
 var private g_log_root : string
+var private g_config_path : string
 var private g_last_memory_log_at = 0l
 var private g_last_gc_at = 0l
 let GC_MIN_INTERVAL_SECONDS = 60l
@@ -53,6 +55,7 @@ def private parse_watcher_args() {
     }
     g_log_root = option_value("--log-root=",
         path_join(get_das_root(), "logs/dasHerd/watcher/sessions"))
+    g_config_path = option_value("--config=", repository_default_config_path())
 }
 
 // Log das-managed memory independently of process RSS. All formatting temporaries die before
@@ -140,6 +143,14 @@ def init() {
         return
     }
     g_watcher_initialized = true
+    let repository_error = repository_init(g_config_path, get_das_root())
+    if (!empty(repository_error)) {
+        print("dasHerd watcher: could not initialize repositories: {repository_error}\n")
+        g_exit_code = 5
+        request_exit()
+        return
+    }
+    g_repositories_initialized = true
 
     g_server = new DasHerdWatcherServer()
     g_server.token = g_token
@@ -170,6 +181,7 @@ def init() {
     print("dasHerd watcher ready\n")
     print("  control: http://127.0.0.1:{g_port}/?token={g_token}\n")
     print("  logs:    {g_log_root}\n")
+    print("  config:  {g_config_path}\n")
     print("  bind:    127.0.0.1:{g_port}\n")
 }
 
@@ -198,6 +210,10 @@ def shutdown() {
         g_server = null
     }
     if (g_watcher_initialized) {
+        if (g_repositories_initialized) {
+            repository_shutdown()
+            g_repositories_initialized = false
+        }
         watcher_shutdown()
         g_watcher_initialized = false
     }

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -163,7 +163,7 @@ def private load_config : string {
     return ""
 }
 
-def public repository_init(config_path, bootstrap_checkout : string) : string {
+def public repository_init(config_path : string; bootstrap_checkout : string) : string {
     g_config_path = config_path
     let load_error = load_config()
     if (!empty(load_error)) return load_error
@@ -274,7 +274,9 @@ def public repository_build_file_diff_argv(worktree_path : string;
     return ""
 }
 
-def public repository_file_diff_argv(repository_id, worktree_path, file_path,
+def public repository_file_diff_argv(repository_id : string;
+                                     worktree_path : string;
+                                     file_path : string;
                                      comparison : string;
                                      var argv : array<string>&;
                                      var expected_exit_code : int64&;
@@ -359,7 +361,8 @@ def public repository_read_file_bytes(path : string; max_bytes : int;
     return loaded ? "" : "could not read file bytes"
 }
 
-def public repository_working_preview_path(worktree_path, file_path : string;
+def public repository_working_preview_path(worktree_path : string;
+                                           file_path : string;
                                            var absolute_path : string&) : string {
     absolute_path = ""
     if (!repository_valid_relative_file_path(file_path)) {

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -311,11 +311,15 @@ def public repository_file_diff_argv(repository_id, worktree_path, file_path,
         diff_context)
 }
 
-def public repository_read_text_file(path : string; var text : string&) : string {
+def public repository_read_text_file(path : string; max_bytes : int;
+                                     var text : string&) : string {
     text = ""
     let file_status = stat(path)
     if (!file_status.is_valid || !file_status.is_reg) {
-        return "could not read working file text"
+        return "could not read file text"
+    }
+    if (file_status.size > uint64(max_bytes)) {
+        return "file exceeds the raw-byte View limit"
     }
     var loaded = false
     fopen(path, "rb") $(file) {
@@ -324,11 +328,35 @@ def public repository_read_text_file(path : string; var text : string&) : string
             loaded = true
         }
     }
-    return loaded ? "" : "could not read working file text"
+    return loaded ? "" : "could not read file text"
+}
+
+def public repository_read_file_bytes(path : string; max_bytes : int;
+                                      var bytes : array<uint8>;
+                                      var byte_count : int&) : string {
+    delete bytes
+    byte_count = 0
+    let file_status = stat(path)
+    if (!file_status.is_valid || !file_status.is_reg) {
+        return "could not read file bytes"
+    }
+    var loaded = false
+    fopen(path, "rb") $(file) {
+        if (file != null) {
+            fmap(file) $(var data : array<uint8>#) {
+                byte_count = length(data)
+                if (byte_count <= max_bytes) {
+                    bytes := data
+                }
+                loaded = true
+            }
+        }
+    }
+    return loaded ? "" : "could not read file bytes"
 }
 
 def public repository_working_file_text(repository_id, worktree_path, file_path : string;
-                                        var text : string&) : string {
+                                        max_bytes : int; var text : string&) : string {
     text = ""
     let repository_index = find_repository(repository_id)
     if (repository_index < 0 || g_repositories[repository_index] == null) {
@@ -349,7 +377,7 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
     }
     let absolute_path = path_join(worktree_path, file_path)
     if (!fexist(absolute_path)) return "working file does not exist"
-    return repository_read_text_file(absolute_path, text)
+    return repository_read_text_file(absolute_path, max_bytes, text)
 }
 
 def public repository_working_file_bytes(repository_id, worktree_path, file_path : string;
@@ -377,19 +405,23 @@ def public repository_working_file_bytes(repository_id, worktree_path, file_path
     }
     let absolute_path = path_join(worktree_path, file_path)
     if (!fexist(absolute_path)) return "working file does not exist"
-    var loaded = false
-    fopen(absolute_path, "rb") $(file) {
-        if (file != null) {
-            fmap(file) $(var data : array<uint8>#) {
-                byte_count = length(data)
-                if (byte_count <= max_bytes) {
-                    bytes := data
-                }
-                loaded = true
-            }
-        }
+    let read_error = repository_read_file_bytes(
+        absolute_path, max_bytes, bytes, byte_count)
+    return empty(read_error) ? "" : "could not read working file bytes"
+}
+
+def public repository_staged_file_view_argv(worktree_path, file_path,
+                                            output_path : string;
+                                            var argv : array<string>&) : string {
+    delete argv
+    if (!repository_valid_relative_file_path(file_path)) {
+        return "invalid worktree-relative file path"
     }
-    return loaded ? "" : "could not read working file bytes"
+    if (empty(output_path)) return "staged view output path is required"
+    var inscope command <- ["git", "-C", worktree_path, "--no-pager", "show",
+        "--format=", "--output={output_path}", ":0:{file_path}"]
+    argv := command
+    return ""
 }
 
 def private launch_git(var runtime : RepositoryRuntime?; argv : array<string>;

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -246,7 +246,6 @@ def public repository_build_file_diff_argv(worktree_path : string;
         expected_exit_code = 1l
     }
     argv |> push("--no-ext-diff")
-    argv |> push("--text")
     argv |> push(comparison == "working" ? "--unified=3" : "--unified=1000000")
     argv |> push("--")
     if (comparison == "working" && file.code == "??") argv |> push("NUL")
@@ -313,6 +312,41 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
     if (!fexist(absolute_path)) return "working file does not exist"
     text = fread(absolute_path)
     return ""
+}
+
+def public repository_working_file_bytes(repository_id, worktree_path, file_path : string;
+                                         var bytes : array<uint8>) : string {
+    delete bytes
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    let runtime = g_repositories[repository_index]
+    var file_found = false
+    for (file in runtime.snapshot.files) {
+        if (file.worktree_path == worktree_path && file.path == file_path
+                && (file.code == "??" || byte_at(file.code, 1) != ' ')) {
+            file_found = true
+            break
+        }
+    }
+    if (!file_found) return "file has no observed working-tree change"
+    if (starts_with(file_path, "/") || starts_with(file_path, "\\")
+            || find(file_path, "../") >= 0 || find(file_path, "..\\") >= 0) {
+        return "invalid worktree-relative file path"
+    }
+    let absolute_path = path_join(worktree_path, file_path)
+    if (!fexist(absolute_path)) return "working file does not exist"
+    var loaded = false
+    fopen(absolute_path, "rb") $(file) {
+        if (file != null) {
+            fmap(file) $(var data : array<uint8>#) {
+                bytes := data
+                loaded = true
+            }
+        }
+    }
+    return loaded ? "" : "could not read working file bytes"
 }
 
 def private launch_git(var runtime : RepositoryRuntime?; argv : array<string>;

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -173,6 +173,7 @@ def public repository_shutdown() {
             unsafe { delete runtime }
         }
     }
+    g_repositories |> clear()
     unsafe { delete g_repositories }
     g_config_path = ""
     g_revision = 0l
@@ -257,7 +258,9 @@ def public repository_build_file_diff_argv(worktree_path : string;
     argv |> push("--no-ext-diff")
     argv |> push("--unified={context_lines}")
     argv |> push("--")
-    if (comparison == "working" && file.code == "??") argv |> push("NUL")
+    if (comparison == "working" && file.code == "??") {
+        argv |> push(get_platform_name() == "windows" ? "NUL" : "/dev/null")
+    }
     argv |> push(file.path)
     return ""
 }

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -121,9 +121,8 @@ def private repository_id(target_id, path : string) : string {
 
 def public repository_valid_relative_file_path(path : string) : bool {
     if (!valid_path(path) || starts_with(path, "/") || starts_with(path, "\\")
-            || is_absolute(path)) return false
-    if (get_platform_name() == "windows" && length(path) >= 2
-            && byte_at(path, 1) == ':') return false
+            || is_absolute(path) || (get_platform_name() == "windows"
+                && length(path) >= 2 && byte_at(path, 1) == ':')) return false
     return (path != ".." && !ends_with(path, "/..") && !ends_with(path, "\\..")
         && find(path, "../") < 0 && find(path, "..\\") < 0)
 }
@@ -501,7 +500,7 @@ def private byte_at(value : string; index : int) : int {
 }
 
 def private append_worktree(var worktrees : array<WorktreeState>;
-                            var current : WorktreeState) {
+                            current : WorktreeState) {
     worktrees |> push(WorktreeState(path = current.path, head = current.head,
         branch = current.branch, is_main = empty(worktrees), detached = current.detached,
         bare = current.bare, locked = current.locked, prunable = current.prunable))
@@ -554,7 +553,8 @@ def private parse_counter(text, marker : string) : int {
     if (start < 0) return 0
     let value_start = start + length(marker)
     var value_end = value_start
-    while (value_end < length(text) && is_number(byte_at(text, value_end))) {
+    let text_length = length(text)
+    while (value_end < text_length && is_number(byte_at(text, value_end))) {
         value_end++
     }
     return to_int(slice(text, value_start, value_end))
@@ -630,7 +630,7 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
     }
     var info = WatcherSessionInfo()
     if (!watcher_get_session_info(runtime.snapshot.task_session_id, info) || !info.drained) return
-    var scrollback_rows = 0
+    let scrollback_rows = 0
     let output = watcher_terminal_text(runtime.snapshot.task_session_id, scrollback_rows)
     if (scrollback_rows > 0) {
         let _compacted_overflow = watcher_compact_session(runtime.snapshot.task_session_id)

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -435,7 +435,7 @@ def public repository_working_file_bytes(repository_id, worktree_path, file_path
     if (!empty(path_error)) return path_error
     let read_error = repository_read_file_bytes(
         absolute_path, max_bytes, bytes, byte_count)
-    return empty(read_error) ? "" : "could not read working file bytes"
+    return read_error
 }
 
 def public repository_staged_file_view_argv(worktree_path, file_path,

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -115,7 +115,17 @@ def private normalized_path(path : string) : string {
 }
 
 def private repository_id(target_id, path : string) : string {
-    return "{target_id}:{to_lower(path)}"
+    let identity_path = get_platform_name() == "windows" ? to_lower(path) : path
+    return "{target_id}:{identity_path}"
+}
+
+def public repository_valid_relative_file_path(path : string) : bool {
+    if (!valid_path(path) || starts_with(path, "/") || starts_with(path, "\\")
+            || is_absolute(path)) return false
+    if (get_platform_name() == "windows" && length(path) >= 2
+            && byte_at(path, 1) == ':') return false
+    return (path != ".." && !ends_with(path, "/..") && !ends_with(path, "\\..")
+        && find(path, "../") < 0 && find(path, "..\\") < 0)
 }
 
 def private changed(var runtime : RepositoryRuntime?) {
@@ -318,8 +328,7 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
         }
     }
     if (!file_found) return "file has no observed working-tree change"
-    if (starts_with(file_path, "/") || starts_with(file_path, "\\")
-            || find(file_path, "../") >= 0 || find(file_path, "..\\") >= 0) {
+    if (!repository_valid_relative_file_path(file_path)) {
         return "invalid worktree-relative file path"
     }
     let absolute_path = path_join(worktree_path, file_path)
@@ -348,8 +357,7 @@ def public repository_working_file_bytes(repository_id, worktree_path, file_path
         }
     }
     if (!file_found) return "file has no observed working-tree change"
-    if (starts_with(file_path, "/") || starts_with(file_path, "\\")
-            || find(file_path, "../") >= 0 || find(file_path, "..\\") >= 0) {
+    if (!repository_valid_relative_file_path(file_path)) {
         return "invalid worktree-relative file path"
     }
     let absolute_path = path_join(worktree_path, file_path)

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -621,6 +621,10 @@ def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
     runtime.snapshot.refreshing = false
     runtime.snapshot.error = message
     changed(runtime)
+    if (runtime.rerun_pending) {
+        runtime.rerun_pending = false
+        runtime.refresh_pending = true
+    }
 }
 
 def private advance_repository(var runtime : RepositoryRuntime?) {

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -569,14 +569,22 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
             fail_refresh(runtime, "git returned no worktrees")
             return
         }
+        let main_path = worktrees[0].path
+        let resolved_id = repository_id(runtime.snapshot.record.target_id, main_path)
+        let collision_index = find_repository(resolved_id)
+        if (collision_index >= 0 && g_repositories[collision_index] != runtime) {
+            delete worktrees
+            fail_refresh(runtime,
+                "main checkout is already registered: {main_path}")
+            return
+        }
         delete runtime.snapshot.worktrees
         runtime.snapshot.worktrees <- worktrees
         runtime.snapshot.files |> clear()
-        let main_path = runtime.snapshot.worktrees[0].path
         if (runtime.snapshot.record.checkout_path != main_path) {
             let old_default_name = base_name(runtime.snapshot.record.checkout_path)
             runtime.snapshot.record.checkout_path = main_path
-            runtime.snapshot.record.id = repository_id(runtime.snapshot.record.target_id, main_path)
+            runtime.snapshot.record.id = resolved_id
             if (empty(runtime.snapshot.record.display_name) || runtime.snapshot.record.display_name == old_default_name) {
                 runtime.snapshot.record.display_name = base_name(main_path)
             }

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -355,6 +355,31 @@ def public repository_read_file_bytes(path : string; max_bytes : int;
     return loaded ? "" : "could not read file bytes"
 }
 
+def public repository_working_preview_path(worktree_path, file_path : string;
+                                           var absolute_path : string&) : string {
+    absolute_path = ""
+    if (!repository_valid_relative_file_path(file_path)) {
+        return "invalid worktree-relative file path"
+    }
+    let candidate = path_join(worktree_path, file_path)
+    if (!fexist(candidate)) return "working file does not exist"
+    var current = worktree_path
+    var inscope components <- split(replace(file_path, "\\", "/"), "/")
+    for (component in components) {
+        if (empty(component) || component == ".") continue
+        current = path_join(current, component)
+        var symlink_error = ""
+        if (is_symlink(current, symlink_error)) {
+            return "working file path contains a symlink"
+        }
+        if (!empty(symlink_error)) {
+            return "could not inspect working file path: {symlink_error}"
+        }
+    }
+    absolute_path = candidate
+    return ""
+}
+
 def public repository_working_file_text(repository_id, worktree_path, file_path : string;
                                         max_bytes : int; var text : string&) : string {
     text = ""
@@ -372,11 +397,10 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
         }
     }
     if (!file_found) return "file has no observed working-tree change"
-    if (!repository_valid_relative_file_path(file_path)) {
-        return "invalid worktree-relative file path"
-    }
-    let absolute_path = path_join(worktree_path, file_path)
-    if (!fexist(absolute_path)) return "working file does not exist"
+    var absolute_path = ""
+    let path_error = repository_working_preview_path(
+        worktree_path, file_path, absolute_path)
+    if (!empty(path_error)) return path_error
     return repository_read_text_file(absolute_path, max_bytes, text)
 }
 
@@ -400,11 +424,10 @@ def public repository_working_file_bytes(repository_id, worktree_path, file_path
         }
     }
     if (!file_found) return "file has no observed working-tree change"
-    if (!repository_valid_relative_file_path(file_path)) {
-        return "invalid worktree-relative file path"
-    }
-    let absolute_path = path_join(worktree_path, file_path)
-    if (!fexist(absolute_path)) return "working file does not exist"
+    var absolute_path = ""
+    let path_error = repository_working_preview_path(
+        worktree_path, file_path, absolute_path)
+    if (!empty(path_error)) return path_error
     let read_error = repository_read_file_bytes(
         absolute_path, max_bytes, bytes, byte_count)
     return empty(read_error) ? "" : "could not read working file bytes"

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -311,6 +311,22 @@ def public repository_file_diff_argv(repository_id, worktree_path, file_path,
         diff_context)
 }
 
+def public repository_read_text_file(path : string; var text : string&) : string {
+    text = ""
+    let file_status = stat(path)
+    if (!file_status.is_valid || !file_status.is_reg) {
+        return "could not read working file text"
+    }
+    var loaded = false
+    fopen(path, "rb") $(file) {
+        if (file != null) {
+            text = fread(file)
+            loaded = true
+        }
+    }
+    return loaded ? "" : "could not read working file text"
+}
+
 def public repository_working_file_text(repository_id, worktree_path, file_path : string;
                                         var text : string&) : string {
     text = ""
@@ -333,8 +349,7 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
     }
     let absolute_path = path_join(worktree_path, file_path)
     if (!fexist(absolute_path)) return "working file does not exist"
-    text = fread(absolute_path)
-    return ""
+    return repository_read_text_file(absolute_path, text)
 }
 
 def public repository_working_file_bytes(repository_id, worktree_path, file_path : string;

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -257,8 +257,8 @@ def public repository_build_file_diff_argv(worktree_path : string;
     } elif (diff_context != "compact") {
         return "diff context is not implemented"
     }
-    var inscope common <- ["git", "-C", worktree_path, "--no-pager", "-c",
-        "color.ui=false", "diff"]
+    var inscope common <- ["git", "--literal-pathspecs", "-C", worktree_path,
+        "--no-pager", "-c", "color.ui=false", "diff"]
     argv := common
     if (comparison == "staged") argv |> push("--cached")
     if (comparison == "working" && file.code == "??") {

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -329,8 +329,11 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
 }
 
 def public repository_working_file_bytes(repository_id, worktree_path, file_path : string;
-                                         var bytes : array<uint8>) : string {
+                                         max_bytes : int;
+                                         var bytes : array<uint8>;
+                                         var byte_count : int&) : string {
     delete bytes
+    byte_count = 0
     let repository_index = find_repository(repository_id)
     if (repository_index < 0 || g_repositories[repository_index] == null) {
         return "unknown repository"
@@ -355,7 +358,10 @@ def public repository_working_file_bytes(repository_id, worktree_path, file_path
     fopen(absolute_path, "rb") $(file) {
         if (file != null) {
             fmap(file) $(var data : array<uint8>#) {
-                bytes := data
+                byte_count = length(data)
+                if (byte_count <= max_bytes) {
+                    bytes := data
+                }
                 loaded = true
             }
         }

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -227,7 +227,8 @@ def public repository_build_file_diff_argv(worktree_path : string;
                                            file : GitFileState const;
                                            comparison : string;
                                            var argv : array<string>&;
-                                           var expected_exit_code : int64&) : string {
+                                           var expected_exit_code : int64&;
+                                           diff_context : string = "compact") : string {
     delete argv
     expected_exit_code = 0l
     let staged = file.code != "??" && byte_at(file.code, 0) != ' '
@@ -236,6 +237,14 @@ def public repository_build_file_diff_argv(worktree_path : string;
     if (comparison == "working" && !working) return "file has no working-tree change"
     if (comparison != "staged" && comparison != "working") {
         return "comparison is not implemented"
+    }
+    var context_lines = 3
+    if (diff_context == "expanded") {
+        context_lines = 20
+    } elif (diff_context == "full") {
+        context_lines = 1000000
+    } elif (diff_context != "compact") {
+        return "diff context is not implemented"
     }
     var inscope common <- ["git", "-C", worktree_path, "--no-pager", "-c",
         "color.ui=false", "diff"]
@@ -246,7 +255,7 @@ def public repository_build_file_diff_argv(worktree_path : string;
         expected_exit_code = 1l
     }
     argv |> push("--no-ext-diff")
-    argv |> push(comparison == "working" ? "--unified=3" : "--unified=1000000")
+    argv |> push("--unified={context_lines}")
     argv |> push("--")
     if (comparison == "working" && file.code == "??") argv |> push("NUL")
     argv |> push(file.path)
@@ -256,7 +265,8 @@ def public repository_build_file_diff_argv(worktree_path : string;
 def public repository_file_diff_argv(repository_id, worktree_path, file_path,
                                      comparison : string;
                                      var argv : array<string>&;
-                                     var expected_exit_code : int64&) : string {
+                                     var expected_exit_code : int64&;
+                                     diff_context : string = "compact") : string {
     delete argv
     expected_exit_code = 0l
     let repository_index = find_repository(repository_id)
@@ -284,7 +294,8 @@ def public repository_file_diff_argv(repository_id, worktree_path, file_path,
     if (file_index < 0) return "file is not present in the observed Git status"
     let file = runtime.snapshot.files[file_index]
     return repository_build_file_diff_argv(
-        worktree_path, file, comparison, argv, expected_exit_code)
+        worktree_path, file, comparison, argv, expected_exit_code,
+        diff_context)
 }
 
 def public repository_working_file_text(repository_id, worktree_path, file_path : string;

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -318,16 +318,21 @@ def public repository_read_text_file(path : string; max_bytes : int;
     if (!file_status.is_valid || !file_status.is_reg) {
         return "could not read file text"
     }
-    if (file_status.size > uint64(max_bytes)) {
-        return "file exceeds the raw-byte View limit"
-    }
     var loaded = false
+    var too_large = false
     fopen(path, "rb") $(file) {
         if (file != null) {
-            text = fread(file)
-            loaded = true
+            fmap(file) $(var data : array<uint8>#) {
+                if (length(data) <= max_bytes) {
+                    text = string(data)
+                } else {
+                    too_large = true
+                }
+                loaded = true
+            }
         }
     }
+    if (too_large) return "file exceeds the raw-byte View limit"
     return loaded ? "" : "could not read file text"
 }
 

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -387,7 +387,9 @@ def public repository_working_preview_path(worktree_path : string;
     return ""
 }
 
-def public repository_working_file_text(repository_id, worktree_path, file_path : string;
+def public repository_working_file_text(repository_id : string;
+                                        worktree_path : string;
+                                        file_path : string;
                                         max_bytes : int; var text : string&) : string {
     text = ""
     let repository_index = find_repository(repository_id)
@@ -411,7 +413,9 @@ def public repository_working_file_text(repository_id, worktree_path, file_path 
     return repository_read_text_file(absolute_path, max_bytes, text)
 }
 
-def public repository_working_file_bytes(repository_id, worktree_path, file_path : string;
+def public repository_working_file_bytes(repository_id : string;
+                                         worktree_path : string;
+                                         file_path : string;
                                          max_bytes : int;
                                          var bytes : array<uint8>;
                                          var byte_count : int&) : string {
@@ -440,7 +444,8 @@ def public repository_working_file_bytes(repository_id, worktree_path, file_path
     return read_error
 }
 
-def public repository_staged_file_view_argv(worktree_path, file_path,
+def public repository_staged_file_view_argv(worktree_path : string;
+                                            file_path : string;
                                             output_path : string;
                                             var argv : array<string>&) : string {
     delete argv

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1,0 +1,543 @@
+options gen2
+options rtti
+options persistent_heap
+options gc
+options indenting = 4
+
+module repository_core shared public
+
+require ./watcher_core.das public
+require daslib/fio public
+require daslib/json_boost public
+require daslib/strings_boost
+require strings public
+
+let private REPOSITORY_CONFIG_VERSION = 1
+let private GIT_TIMEOUT_MS = 15000l
+let private GIT_CAPTURE_COLUMNS = 240
+let private GIT_CAPTURE_ROWS = 100
+
+struct public RepositoryRecord {
+    id : string
+    target_id : string = "local"
+    checkout_path : string
+    display_name : string
+    base_ref : string
+}
+
+struct public GitFileState {
+    worktree_path : string
+    code : string
+    path : string
+    old_path : string
+}
+
+struct public WorktreeState {
+    path : string
+    head : string
+    branch : string
+    is_main : bool
+    detached : bool
+    bare : bool
+    locked : bool
+    prunable : bool
+    ahead : int
+    behind : int
+    staged : int
+    unstaged : int
+    untracked : int
+    conflicted : int
+    error : string
+}
+
+struct public RepositorySnapshot {
+    record : RepositoryRecord = RepositoryRecord()
+    worktrees : array<WorktreeState>
+    files : array<GitFileState>
+    refreshing : bool
+    error : string
+    revision : int64
+    last_success_ms : int64
+    task_session_id : string
+}
+
+struct public RepositoryAddRequest {
+    path : string
+    display_name : string
+    target_id : string = "local"
+}
+
+struct public RepositoryRefreshRequest {
+    repository_id : string
+}
+
+struct private RepositoryConfigFile {
+    version : int = REPOSITORY_CONFIG_VERSION
+    repositories : array<RepositoryRecord>
+}
+
+class private RepositoryRuntime {
+    snapshot : RepositorySnapshot = RepositorySnapshot()
+    phase : int
+    worktree_index : int
+    refresh_pending : bool = true
+    rerun_pending : bool
+    def operator delete {
+        delete snapshot.worktrees
+        delete snapshot.files
+    }
+}
+
+var private g_repositories : array<RepositoryRuntime?>
+var private g_config_path : string
+var private g_revision : int64
+
+def public repository_default_config_path : string {
+    var base : string
+    if (has_env_variable("APPDATA")) {
+        base = get_env_variable("APPDATA")
+    } elif (has_env_variable("XDG_CONFIG_HOME")) {
+        base = get_env_variable("XDG_CONFIG_HOME")
+    } elif (has_env_variable("HOME")) {
+        base = path_join(get_env_variable("HOME"), ".config")
+    } else {
+        base = "."
+    }
+    return path_join(path_join(base, "daScript"), "dasHerd.json")
+}
+
+def private valid_path(path : string) : bool {
+    return !empty(path) && find(path, "\r") < 0 && find(path, "\n") < 0
+}
+
+def private normalized_path(path : string) : string {
+    return get_full_file_name(path)
+}
+
+def private repository_id(target_id, path : string) : string {
+    return "{target_id}:{to_lower(path)}"
+}
+
+def private changed(var runtime : RepositoryRuntime?) {
+    runtime.snapshot.revision++
+    g_revision++
+}
+
+def private save_config : string {
+    var inscope config = RepositoryConfigFile()
+    config.repositories |> reserve(length(g_repositories))
+    for (runtime in g_repositories) {
+        if (runtime != null) config.repositories |> push(runtime.snapshot.record)
+    }
+    var error : string
+    if (!mkdir_rec(dir_name(g_config_path), error)) return "could not create config directory: {error}"
+    if (!fwrite(g_config_path, sprint_json(config, true))) return "could not write {g_config_path}"
+    return ""
+}
+
+def private add_runtime(record : RepositoryRecord) {
+    g_repositories |> push(new RepositoryRuntime(
+        snapshot = RepositorySnapshot(record = record)))
+    g_revision++
+}
+
+def private load_config : string {
+    if (!fexist(g_config_path)) return ""
+    var inscope config = RepositoryConfigFile()
+    if (!sscan_json(fread(g_config_path), config)) return "invalid repository config JSON"
+    if (config.version != REPOSITORY_CONFIG_VERSION) {
+        return "unsupported repository config version {config.version}"
+    }
+    for (record in config.repositories) {
+        if (valid_path(record.checkout_path)) add_runtime(record)
+    }
+    return ""
+}
+
+def public repository_init(config_path, bootstrap_checkout : string) : string {
+    g_config_path = config_path
+    let load_error = load_config()
+    if (!empty(load_error)) return load_error
+    if (empty(g_repositories) && valid_path(bootstrap_checkout)) {
+        let path = normalized_path(bootstrap_checkout)
+        add_runtime(RepositoryRecord(id = repository_id("local", path), target_id = "local",
+            checkout_path = path, display_name = base_name(path)))
+        return save_config()
+    }
+    return ""
+}
+
+def public repository_shutdown() {
+    for (runtime in g_repositories) {
+        if (runtime != null) {
+            unsafe { delete runtime }
+        }
+    }
+    unsafe { delete g_repositories }
+    g_config_path = ""
+    g_revision = 0l
+}
+
+def public repository_revision : int64 {
+    return g_revision
+}
+
+def public repository_list_json : string {
+    var inscope parts : array<string>
+    parts |> reserve(length(g_repositories))
+    for (runtime in g_repositories) {
+        if (runtime != null) parts |> push(sprint_json(runtime.snapshot, false))
+    }
+    return "[" + join(parts, ",") + "]"
+}
+
+def private find_repository(id : string) : int {
+    for (index in range(length(g_repositories))) {
+        if (g_repositories[index] != null && g_repositories[index].snapshot.record.id == id) return index
+    }
+    return -1
+}
+
+def public repository_add(request : RepositoryAddRequest) : string {
+    if (request.target_id != "local" && !empty(request.target_id)) return "only the local target is implemented"
+    if (!valid_path(request.path)) return "repository path is required and cannot contain CR/LF"
+    let path = normalized_path(request.path)
+    let id = repository_id("local", path)
+    if (find_repository(id) >= 0) return "repository is already registered"
+    add_runtime(RepositoryRecord(id = id, target_id = "local", checkout_path = path,
+        display_name = !empty(request.display_name) ? request.display_name : base_name(path)))
+    let error = save_config()
+    if (!empty(error)) return error
+    return ""
+}
+
+def public repository_refresh(id : string) : string {
+    let index = find_repository(id)
+    if (index < 0) return "unknown repository"
+    var runtime = g_repositories[index]
+    if (runtime.phase != 0) {
+        runtime.rerun_pending = true
+    } else {
+        runtime.refresh_pending = true
+    }
+    return ""
+}
+
+def public repository_build_file_diff_argv(worktree_path : string;
+                                           file : GitFileState const;
+                                           comparison : string;
+                                           var argv : array<string>&;
+                                           var expected_exit_code : int64&) : string {
+    delete argv
+    expected_exit_code = 0l
+    let staged = file.code != "??" && byte_at(file.code, 0) != ' '
+    let working = file.code == "??" || byte_at(file.code, 1) != ' '
+    if (comparison == "staged" && !staged) return "file has no staged change"
+    if (comparison == "working" && !working) return "file has no working-tree change"
+    if (comparison != "staged" && comparison != "working") {
+        return "comparison is not implemented"
+    }
+    var inscope common <- ["git", "-C", worktree_path, "--no-pager", "-c",
+        "color.ui=false", "diff"]
+    argv := common
+    if (comparison == "staged") argv |> push("--cached")
+    if (comparison == "working" && file.code == "??") {
+        argv |> push("--no-index")
+        expected_exit_code = 1l
+    }
+    argv |> push("--no-ext-diff")
+    argv |> push("--text")
+    argv |> push(comparison == "working" ? "--unified=3" : "--unified=1000000")
+    argv |> push("--")
+    if (comparison == "working" && file.code == "??") argv |> push("NUL")
+    argv |> push(file.path)
+    return ""
+}
+
+def public repository_file_diff_argv(repository_id, worktree_path, file_path,
+                                     comparison : string;
+                                     var argv : array<string>&;
+                                     var expected_exit_code : int64&) : string {
+    delete argv
+    expected_exit_code = 0l
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    let runtime = g_repositories[repository_index]
+    var worktree_found = false
+    for (worktree in runtime.snapshot.worktrees) {
+        if (worktree.path == worktree_path) {
+            worktree_found = true
+            break
+        }
+    }
+    if (!worktree_found) return "unknown worktree"
+
+    var file_index = -1
+    for (index in range(length(runtime.snapshot.files))) {
+        let file = runtime.snapshot.files[index]
+        if (file.worktree_path == worktree_path && file.path == file_path) {
+            file_index = index
+            break
+        }
+    }
+    if (file_index < 0) return "file is not present in the observed Git status"
+    let file = runtime.snapshot.files[file_index]
+    return repository_build_file_diff_argv(
+        worktree_path, file, comparison, argv, expected_exit_code)
+}
+
+def public repository_working_file_text(repository_id, worktree_path, file_path : string;
+                                        var text : string&) : string {
+    text = ""
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    let runtime = g_repositories[repository_index]
+    var file_found = false
+    for (file in runtime.snapshot.files) {
+        if (file.worktree_path == worktree_path && file.path == file_path
+                && (file.code == "??" || byte_at(file.code, 1) != ' ')) {
+            file_found = true
+            break
+        }
+    }
+    if (!file_found) return "file has no observed working-tree change"
+    if (starts_with(file_path, "/") || starts_with(file_path, "\\")
+            || find(file_path, "../") >= 0 || find(file_path, "..\\") >= 0) {
+        return "invalid worktree-relative file path"
+    }
+    let absolute_path = path_join(worktree_path, file_path)
+    if (!fexist(absolute_path)) return "working file does not exist"
+    text = fread(absolute_path)
+    return ""
+}
+
+def private launch_git(var runtime : RepositoryRuntime?; argv : array<string>;
+                       kind, worktree_path : string) : bool {
+    var inscope request = WatcherLaunchRequest(
+        cwd = runtime.snapshot.record.checkout_path,
+        display_name = "Git: " + join(argv, " "), kind = kind,
+        target_id = runtime.snapshot.record.target_id,
+        repository_id = runtime.snapshot.record.id,
+        worktree_path = worktree_path,
+        columns = GIT_CAPTURE_COLUMNS, rows = GIT_CAPTURE_ROWS, timeout_ms = GIT_TIMEOUT_MS)
+    request.argv := argv
+    let _pruned = watcher_prune_completed_sessions(kind,
+        runtime.snapshot.record.id, worktree_path)
+    let result = watcher_launch(request)
+    runtime.snapshot.task_session_id = result.session_id
+    if (!result.ok) {
+        runtime.snapshot.error = result.error
+        runtime.snapshot.refreshing = false
+        runtime.phase = 0
+        changed(runtime)
+        return false
+    }
+    return true
+}
+
+def private launch_inventory(var runtime : RepositoryRuntime?) {
+    runtime.refresh_pending = false
+    runtime.snapshot.refreshing = true
+    runtime.snapshot.error = ""
+    runtime.phase = 1
+    changed(runtime)
+    let _ = launch_git(runtime, ["git", "-C", runtime.snapshot.record.checkout_path,
+        "worktree", "list", "--porcelain"], "git-inventory",
+        runtime.snapshot.record.checkout_path)
+}
+
+def private trim_cr(value : string) : string {
+    if (!empty(value) && ends_with(value, "\r")) return slice(value, 0, length(value) - 1)
+    return value
+}
+
+def private byte_at(value : string; index : int) : int {
+    var result = 0
+    peek_data(value) $(data) {
+        result = int(data[index])
+    }
+    return result
+}
+
+def private append_worktree(var worktrees : array<WorktreeState>;
+                            var current : WorktreeState) {
+    worktrees |> push(WorktreeState(path = current.path, head = current.head,
+        branch = current.branch, is_main = empty(worktrees), detached = current.detached,
+        bare = current.bare, locked = current.locked, prunable = current.prunable))
+}
+
+def public repository_parse_inventory(text : string; var worktrees : array<WorktreeState>) {
+    var current <- WorktreeState()
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (empty(line)) {
+            if (!empty(current.path)) {
+                append_worktree(worktrees, current)
+                current <- WorktreeState()
+            }
+        } elif (starts_with(line, "worktree ")) {
+            current.path = slice(line, 9)
+        } elif (starts_with(line, "HEAD ")) {
+            current.head = slice(line, 5)
+        } elif (starts_with(line, "branch ")) {
+            current.branch = slice(line, 7)
+            if (starts_with(current.branch, "refs/heads/")) {
+                current.branch = slice(current.branch, 11)
+            }
+        } elif (line == "detached") {
+            current.detached = true
+        } elif (line == "bare") {
+            current.bare = true
+        } elif (starts_with(line, "locked")) {
+            current.locked = true
+        } elif (starts_with(line, "prunable")) {
+            current.prunable = true
+        }
+    }
+    if (!empty(current.path)) {
+        append_worktree(worktrees, current)
+    }
+}
+
+def private conflict_code(code : string) : bool {
+    return code == "DD" || code == "AU" || code == "UD" || code == "UA" || code == "DU" || code == "AA" || code == "UU"
+}
+
+def private parse_counter(text, marker : string) : int {
+    let start = find(text, marker)
+    if (start < 0) return 0
+    let value_start = start + length(marker)
+    var value_end = value_start
+    while (value_end < length(text) && is_number(byte_at(text, value_end))) {
+        value_end++
+    }
+    return to_int(slice(text, value_start, value_end))
+}
+
+def public repository_parse_status(text : string; var worktree : WorktreeState;
+                                   var files : array<GitFileState>) {
+    worktree.ahead = 0
+    worktree.behind = 0
+    worktree.staged = 0
+    worktree.unstaged = 0
+    worktree.untracked = 0
+    worktree.conflicted = 0
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (starts_with(line, "## ")) {
+            worktree.ahead = parse_counter(line, "ahead ")
+            worktree.behind = parse_counter(line, "behind ")
+            continue
+        }
+        if (length(line) < 3) continue
+        let code = slice(line, 0, 2)
+        var path = slice(line, 3)
+        var old_path : string
+        let rename_separator = find(path, " -> ")
+        if (rename_separator >= 0) {
+            old_path = slice(path, 0, rename_separator)
+            path = slice(path, rename_separator + 4)
+        }
+        files |> push(GitFileState(worktree_path = worktree.path, code = code,
+            path = path, old_path = old_path))
+        if (code == "??") worktree.untracked++
+        else {
+            if (byte_at(line, 0) != ' ') worktree.staged++
+            if (byte_at(line, 1) != ' ') worktree.unstaged++
+            if (conflict_code(code)) worktree.conflicted++
+        }
+    }
+}
+
+def private launch_status(var runtime : RepositoryRuntime?) : bool {
+    if (runtime.worktree_index >= length(runtime.snapshot.worktrees)) return false
+    let path = runtime.snapshot.worktrees[runtime.worktree_index].path
+    runtime.snapshot.record.checkout_path = runtime.snapshot.worktrees[0].path
+    return launch_git(runtime, ["git", "-C", path, "-c", "core.quotePath=false",
+        "status", "--porcelain=1", "--branch", "--untracked-files=all"],
+        "git-status", path)
+}
+
+def private finish_refresh(var runtime : RepositoryRuntime?) {
+    runtime.phase = 0
+    runtime.snapshot.refreshing = false
+    runtime.snapshot.last_success_ms = int64(get_clock()) * 1000l
+    runtime.snapshot.task_session_id = ""
+    changed(runtime)
+    if (runtime.rerun_pending) {
+        runtime.rerun_pending = false
+        runtime.refresh_pending = true
+    }
+}
+
+def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
+    runtime.phase = 0
+    runtime.snapshot.refreshing = false
+    runtime.snapshot.error = message
+    changed(runtime)
+}
+
+def private advance_repository(var runtime : RepositoryRuntime?) {
+    if (runtime.phase == 0) {
+        if (runtime.refresh_pending) launch_inventory(runtime)
+        return
+    }
+    var info = WatcherSessionInfo()
+    if (!watcher_get_session_info(runtime.snapshot.task_session_id, info) || !info.drained) return
+    var scrollback_rows = 0
+    let output = watcher_terminal_text(runtime.snapshot.task_session_id, scrollback_rows)
+    if (scrollback_rows > 0) {
+        let _compacted_overflow = watcher_compact_session(runtime.snapshot.task_session_id)
+        fail_refresh(runtime, "Git structured output exceeded the {GIT_CAPTURE_ROWS}-row capture window; inspect session {runtime.snapshot.task_session_id}")
+        return
+    }
+    let _compacted = watcher_compact_session(runtime.snapshot.task_session_id)
+    if (info.exit_code != 0l) {
+        fail_refresh(runtime, "git exited with {info.exit_code}: {output}")
+        return
+    }
+    if (runtime.phase == 1) {
+        var worktrees : array<WorktreeState>
+        repository_parse_inventory(output, worktrees)
+        if (empty(worktrees)) {
+            fail_refresh(runtime, "git returned no worktrees")
+            return
+        }
+        delete runtime.snapshot.worktrees
+        runtime.snapshot.worktrees <- worktrees
+        runtime.snapshot.files |> clear()
+        let main_path = runtime.snapshot.worktrees[0].path
+        if (runtime.snapshot.record.checkout_path != main_path) {
+            let old_default_name = base_name(runtime.snapshot.record.checkout_path)
+            runtime.snapshot.record.checkout_path = main_path
+            runtime.snapshot.record.id = repository_id(runtime.snapshot.record.target_id, main_path)
+            if (empty(runtime.snapshot.record.display_name) || runtime.snapshot.record.display_name == old_default_name) {
+                runtime.snapshot.record.display_name = base_name(main_path)
+            }
+            let _save_error = save_config()
+        }
+        runtime.phase = 2
+        runtime.worktree_index = 0
+        let _status_started = launch_status(runtime)
+        changed(runtime)
+        return
+    }
+    repository_parse_status(output, runtime.snapshot.worktrees[runtime.worktree_index], runtime.snapshot.files)
+    runtime.worktree_index++
+    if (runtime.worktree_index < length(runtime.snapshot.worktrees)) {
+        let _next_status_started = launch_status(runtime)
+        changed(runtime)
+    } else {
+        finish_refresh(runtime)
+    }
+}
+
+def public repository_tick() {
+    for (runtime in g_repositories) {
+        if (runtime != null) advance_repository(runtime)
+    }
+}

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -539,6 +539,11 @@ def private conflict_code(code : string) : bool {
     return code == "DD" || code == "AU" || code == "UD" || code == "UA" || code == "DU" || code == "AA" || code == "UU"
 }
 
+def private rename_or_copy_code(code : string) : bool {
+    if (length(code) != 2) return false
+    return byte_at(code, 0) == 'R' || byte_at(code, 0) == 'C' || byte_at(code, 1) == 'R' || byte_at(code, 1) == 'C'
+}
+
 def private parse_counter(text, marker : string) : int {
     let start = find(text, marker)
     if (start < 0) return 0
@@ -570,7 +575,7 @@ def public repository_parse_status(text : string; var worktree : WorktreeState;
         var path = slice(line, 3)
         var old_path : string
         let rename_separator = find(path, " -> ")
-        if (rename_separator >= 0) {
+        if (rename_separator >= 0 && rename_or_copy_code(code)) {
             old_path = slice(path, 0, rename_separator)
             path = slice(path, rename_separator + 4)
         }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -1513,7 +1513,6 @@ def shutdown() {
         g_client = null
     }
     release_inspector_content()
-    markdown_view_dispose(g_inspector.markdown_view)
     text_source_view_dispose(g_inspector.old_view)
     text_source_view_dispose(g_inspector.new_view)
     text_source_view_dispose(g_inspector.view)

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -75,6 +75,7 @@ struct private WatcherFileInspectionMessage {
     view_text : string
     view_base64 : string
     view_byte_count : int
+    view_available : bool
     status : string
     error : string
 }
@@ -146,6 +147,7 @@ struct private GitInspectorState {
     source_view_text : string
     source_view_base64 : string
     source_view_byte_count : int
+    source_view_available : bool
     syntax_choice : int
     diff_context_choice : int
     resolved_language : string
@@ -289,7 +291,8 @@ def private queue_inspector_prepare(status : string) {
     if (!inspector_prepare_worker_queue(g_prepare_worker, generation,
             g_inspector.source_patch, g_inspector.source_view_text,
             g_inspector.resolved_language, g_inspector.source_view_base64,
-            g_inspector.source_view_byte_count)) {
+            g_inspector.source_view_byte_count,
+            g_inspector.source_view_available)) {
         let failure = "File inspection preparation worker is unavailable"
         inspector_load_fail(g_inspector.prepare, generation,
             failure)
@@ -313,6 +316,7 @@ def private install_file_inspection(message : WatcherFileInspectionMessage const
     g_inspector.source_view_text = clone_string(message.view_text)
     g_inspector.source_view_base64 = clone_string(message.view_base64)
     g_inspector.source_view_byte_count = message.view_byte_count
+    g_inspector.source_view_available = message.view_available
     queue_inspector_prepare("Preparing diff...")
 }
 
@@ -377,6 +381,7 @@ def private begin_file_inspection(repository_id, worktree_path, file_path,
         g_inspector.source_view_text = ""
         g_inspector.source_view_base64 = ""
         g_inspector.source_view_byte_count = 0
+        g_inspector.source_view_available = false
         g_inspector.syntax_choice = 0
         g_inspector.resolved_language = inspector_language_for_path(file_path)
         DIFF_SYNTAX.value = 0

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -138,7 +138,6 @@ struct private GitInspectorState {
     view : TextSourceViewState = TextSourceViewState()
     markdown_document : RichDocument = RichDocument()
     markdown_view : MarkdownViewState = MarkdownViewState()
-    markdown_syntax : MarkdownTreeSitterState = MarkdownTreeSitterState()
     changed_source_ranges : array<TextSourceRange>
     view_source : string
     view_prepared : bool
@@ -240,38 +239,6 @@ def private feed_terminal_frame(message : string#; byte_count : int) {
     }
 }
 
-def private changed_source_ranges(source : string;
-                                  lines : array<int> const) : array<TextSourceRange> {
-    var result : array<TextSourceRange>
-    if (empty(lines)) return <- result
-    var target = 0
-    var line_index = 0
-    var line_start = 0
-    peek_data(source) $(bytes) {
-        for (at in range(length(bytes))) {
-            if (int(bytes[at]) != '\n') continue
-            while (target < length(lines) && lines[target] < line_index) {
-                target++
-            }
-            if (target < length(lines) && lines[target] == line_index) {
-                result |> push(TextSourceRange(start_byte = line_start, end_byte = at + 1))
-                while (target < length(lines) && lines[target] == line_index) {
-                    target++
-                }
-            }
-            line_index++
-            line_start = at + 1
-        }
-    }
-    while (target < length(lines) && lines[target] < line_index) {
-        target++
-    }
-    if (target < length(lines) && lines[target] == line_index) {
-        result |> push(TextSourceRange(start_byte = line_start, end_byte = length(source)))
-    }
-    return <- result
-}
-
 def private upload_inspector_preview(event : InspectorPrepareEvent#) {
     g_inspector.preview_width = event.preview_width
     g_inspector.preview_height = event.preview_height
@@ -294,10 +261,9 @@ def private release_inspector_content() {
     text_source_document_dispose(g_inspector.old_document)
     text_source_document_dispose(g_inspector.new_document)
     text_source_document_dispose(g_inspector.view_document)
-    markdown_view_invalidate(g_inspector.markdown_view)
-    delete g_inspector.markdown_document.nodes
+    markdown_view_dispose(g_inspector.markdown_view)
+    rich_document_dispose(g_inspector.markdown_document)
     delete g_inspector.changed_source_ranges
-    g_inspector.markdown_document = RichDocument()
     g_inspector.view_source = ""
     g_inspector.view_prepared = false
     g_inspector.markdown_gutter_segments = 0
@@ -365,11 +331,16 @@ def private drain_inspector_prepare_events() {
                 if (!inspector_load_succeed(g_inspector.prepare,
                         event.generation)) return
                 release_inspector_content()
-                g_inspector.revision++
+                g_inspector.revision = event.generation
                 g_inspector.parsed := event.parsed
                 g_inspector.old_document := event.old_document
                 g_inspector.new_document := event.new_document
+                g_inspector.view_document := event.view_document
+                g_inspector.markdown_document := event.markdown_document
+                g_inspector.markdown_view := event.markdown_view
+                g_inspector.changed_source_ranges := event.changed_source_ranges
                 g_inspector.view_source = clone_string(event.view_source)
+                g_inspector.view_prepared = !event.parsed.binary
                 upload_inspector_preview(event)
                 g_inspector.error = ""
                 g_inspector.prepare_elapsed_usec = event.elapsed_usec
@@ -1190,33 +1161,11 @@ def private draw_side_by_side_diff() {
     g_inspector.diff_scroll_jump_pending = false
 }
 
-def private prepare_file_view() {
-    if (g_inspector.view_prepared) return
-    var view_document <- tree_sitter_source_document(
-        g_inspector.view_source, g_inspector.resolved_language,
-        g_inspector.revision)
-    view_document.line_marks |> reserve(length(g_inspector.parsed.new_changed_lines))
-    for (line in g_inspector.parsed.new_changed_lines) {
-        view_document.line_marks |> push(TextSourceLineMark(
-            line_index = line, kind = TextSourceLineMarkKind.added))
-    }
-    g_inspector.view_document <- view_document
-    if (g_inspector.resolved_language == "markdown") {
-        var markdown_document <- md_parse(g_inspector.view_source)
-        var markdown_changes <- changed_source_ranges(
-            g_inspector.view_source, g_inspector.parsed.new_changed_lines)
-        g_inspector.markdown_document <- markdown_document
-        g_inspector.changed_source_ranges <- markdown_changes
-    }
-    g_inspector.view_prepared = true
-}
-
 def private draw_file_view() {
     if (g_inspector.parsed.binary) {
         draw_binary_preview()
         return
     }
-    prepare_file_view()
     child(FILE_VIEW_PANE, (text = "file view", size = float2(0.0f, 0.0f),
             child_flags = ImGuiChildFlags.None,
             window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
@@ -1227,9 +1176,6 @@ def private draw_file_view() {
                     inline_code_scale = 0.84f, code_block_scale = 0.90f),
                 zoom = float(g_zoom_percent) / 100.0f,
                 write_system_clipboard = !harness_is_headless())
-            markdown_tree_sitter_prepare(g_inspector.markdown_document,
-                g_inspector.markdown_syntax, g_inspector.markdown_view,
-                g_inspector.revision)
             let _ <- markdown_view_with_change_gutter("git markdown view",
                 g_inspector.markdown_document, g_inspector.markdown_view,
                 style, g_inspector.revision, g_inspector.changed_source_ranges,
@@ -1565,7 +1511,6 @@ def shutdown() {
         g_client = null
     }
     release_inspector_content()
-    markdown_tree_sitter_dispose(g_inspector.markdown_syntax)
     markdown_view_dispose(g_inspector.markdown_view)
     text_source_view_dispose(g_inspector.old_view)
     text_source_view_dispose(g_inspector.new_view)

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -68,6 +68,7 @@ struct private WatcherFileInspectionMessage {
     worktree_path : string
     file_path : string
     comparison : string
+    diff_context : string
     task_session_id : string
     loading : bool
     patch : string
@@ -92,6 +93,7 @@ struct private HerderInspectorOpenArgs {
     worktree_path : string
     file_path : string
     comparison : string = "working"
+    diff_context : string = "compact"
 }
 
 struct private HerderInspectorModeArgs {
@@ -107,6 +109,10 @@ let INSPECTOR_SYNTAX_LABELS : array<string> <- [
     "Auto", "Plain text", "daScript", "C", "C++", "Markdown", "JSON"]
 let INSPECTOR_SYNTAX_VALUES : array<string> <- [
     "auto", "plain", "daslang", "c", "cpp", "markdown", "json"]
+let INSPECTOR_CONTEXT_LABELS : array<string> <- [
+    "Compact (3)", "Expanded (20)", "Full file"]
+let INSPECTOR_CONTEXT_VALUES : array<string> <- [
+    "compact", "expanded", "full"]
 
 struct private GitInspectorState {
     request_id : int
@@ -114,6 +120,7 @@ struct private GitInspectorState {
     worktree_path : string
     file_path : string
     comparison : string
+    diff_context : string = "compact"
     task_session_id : string
     loading : bool
     status : string
@@ -141,6 +148,7 @@ struct private GitInspectorState {
     source_view_base64 : string
     source_view_byte_count : int
     syntax_choice : int
+    diff_context_choice : int
     resolved_language : string
     preview_texture : uint
     preview_width : int
@@ -365,7 +373,7 @@ def private drain_inspector_prepare_events() {
 }
 
 def private begin_file_inspection(repository_id, worktree_path, file_path,
-                                  comparison : string) {
+                                  comparison, diff_context : string) {
     let same_identity = g_inspector.repository_id == repository_id && g_inspector.worktree_path == worktree_path && g_inspector.file_path == file_path && g_inspector.comparison == comparison
     let same_content = g_inspector.prepare.has_retained_content && same_identity
     g_inspector.request_id++
@@ -373,6 +381,14 @@ def private begin_file_inspection(repository_id, worktree_path, file_path,
     g_inspector.worktree_path = worktree_path
     g_inspector.file_path = file_path
     g_inspector.comparison = comparison
+    g_inspector.diff_context = diff_context
+    g_inspector.diff_context_choice = 0
+    if (diff_context == "expanded") {
+        g_inspector.diff_context_choice = 1
+    } elif (diff_context == "full") {
+        g_inspector.diff_context_choice = 2
+    }
+    DIFF_CONTEXT.value = g_inspector.diff_context_choice
     g_inspector.task_session_id = ""
     g_inspector.loading = true
     g_inspector.status = "Requesting diff..."
@@ -587,15 +603,18 @@ class private WatcherRichClient : HvWebSocketClient {
     }
 
     def inspect_file(repository_id, worktree_path, file_path,
-                     comparison : string) {
+                     comparison : string;
+                     diff_context : string = "compact") {
         if (!connected || empty(repository_id) || empty(worktree_path)
                 || empty(file_path)) return
-        begin_file_inspection(repository_id, worktree_path, file_path, comparison)
+        begin_file_inspection(repository_id, worktree_path, file_path,
+            comparison, diff_context)
         send("\{\"op\":\"file_inspect\",\"request_id\":{g_inspector.request_id}," +
             "\"repository_id\":{sprint_json(repository_id, false)}," +
             "\"worktree_path\":{sprint_json(worktree_path, false)}," +
             "\"file_path\":{sprint_json(file_path, false)}," +
-            "\"comparison\":{sprint_json(comparison, false)}\}")
+            "\"comparison\":{sprint_json(comparison, false)}," +
+            "\"diff_context\":{sprint_json(diff_context, false)}\}")
     }
 
     def send_input(text : string) {
@@ -1039,6 +1058,18 @@ def private draw_side_by_side_diff() {
     let hunk_count = length(g_inspector.parsed.hunks)
     g_inspector.diff_current_hunk = hunk_count > 0 ? clamp(g_inspector.diff_current_hunk, 0, hunk_count - 1) : 0
     SetNextItemWidth(150.0f)
+    combo(DIFF_CONTEXT,
+        (text = "Context", items <- INSPECTOR_CONTEXT_LABELS))
+    let selected_context = clamp(DIFF_CONTEXT.value, 0,
+        length(INSPECTOR_CONTEXT_VALUES) - 1)
+    if (selected_context != g_inspector.diff_context_choice
+            && g_client != null && g_client.connected) {
+        g_client->inspect_file(g_inspector.repository_id,
+            g_inspector.worktree_path, g_inspector.file_path,
+            g_inspector.comparison, INSPECTOR_CONTEXT_VALUES[selected_context])
+    }
+    same_line()
+    SetNextItemWidth(150.0f)
     combo(DIFF_SYNTAX, (text = "Syntax", items <- INSPECTOR_SYNTAX_LABELS))
     let selected_syntax = clamp(DIFF_SYNTAX.value, 0,
         length(INSPECTOR_SYNTAX_VALUES) - 1)
@@ -1204,6 +1235,8 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         worktree_path = g_inspector.worktree_path,
         file_path = g_inspector.file_path,
         comparison = g_inspector.comparison,
+        diff_context = g_inspector.diff_context,
+        diff_context_choice = g_inspector.diff_context_choice,
         mode = g_inspector.mode == GitInspectorMode.diff ? "diff" : "view",
         loading = g_inspector.loading,
         prepare_request = inspector_request_state_name(g_inspector.prepare.request),
@@ -1296,7 +1329,7 @@ def herder_file_inspector_open(input : JsonValue?) : JsonValue? {
     }
     let comparison = empty(args.comparison) ? "working" : args.comparison
     g_client->inspect_file(args.repository_id, args.worktree_path,
-        args.file_path, comparison)
+        args.file_path, comparison, args.diff_context)
     FILE_INSPECTOR_WIN.open = true
     FILE_INSPECTOR_WIN.pending_raise = true
     return JV((ok = true, request_id = g_inspector.request_id,
@@ -1427,6 +1460,7 @@ def init() {
     harness_init("dasHerd", 1280, 800)
     harness_maximize_window()
     DIFF_SYNTAX.value = 0
+    DIFF_CONTEXT.value = 0
     var io & = unsafe(GetIO())
     io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
     g_fonts = load_unicode_font_roles(14.0f, g_font_sources)

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -6,11 +6,19 @@ options no_unused_function_arguments = false
 require imgui/imgui_harness
 require imgui/imgui_terminal
 require imgui/imgui_fonts
+require imgui/imgui_docking_builtin
+require imgui/imgui_markdown_tree_sitter
+require imgui/imgui_text_source_view
+require imgui/imgui_text_tree_sitter
 require dashv/dashv_boost
 require clipboard/clipboard
 require daslib/safe_addr
+require daslib/json
 require daslib/json_boost
+require live/live_commands
 require ./watcher_core.das
+require ./repository_core.das
+require ./file_inspection.das
 require math
 require strings
 
@@ -44,21 +52,130 @@ struct private WatcherSessionsMessage {
     data : array<WatcherSessionInfo>
 }
 
+struct private WatcherRepositoriesMessage {
+    @rename = "type" _type : string
+    data : array<RepositorySnapshot>
+}
+
+struct private WatcherFileInspectionMessage {
+    @rename = "type" _type : string
+    request_id : int
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    comparison : string
+    task_session_id : string
+    loading : bool
+    patch : string
+    view_text : string
+    status : string
+    error : string
+}
+
 struct private WatcherRawResetMessage {
     @rename = "type" _type : string
     offset : int64
+}
+
+struct private HerderInspectorTextArgs {
+    side : string = "view"
+}
+
+struct private HerderInspectorOpenArgs {
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    comparison : string = "working"
+}
+
+struct private HerderInspectorModeArgs {
+    mode : string
+}
+
+enum private GitInspectorMode {
+    diff
+    view
+}
+
+struct private GitInspectorState {
+    request_id : int
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    comparison : string
+    task_session_id : string
+    loading : bool
+    status : string
+    error : string
+    revision : int
+    mode : GitInspectorMode = GitInspectorMode.diff
+    parsed : GitParsedPatch = GitParsedPatch()
+    old_document : TextSourceDocument = TextSourceDocument()
+    new_document : TextSourceDocument = TextSourceDocument()
+    view_document : TextSourceDocument = TextSourceDocument()
+    old_view : TextSourceViewState = TextSourceViewState()
+    new_view : TextSourceViewState = TextSourceViewState()
+    view : TextSourceViewState = TextSourceViewState()
+    markdown_document : RichDocument = RichDocument()
+    markdown_view : MarkdownViewState = MarkdownViewState()
+    markdown_syntax : MarkdownTreeSitterState = MarkdownTreeSitterState()
+    changed_source_ranges : array<TextSourceRange>
+    view_source : string
+    view_prepared : bool
+    markdown_gutter_segments : int
+    diff_scroll_y : float
+    diff_left_hovered_last : bool
+    diff_right_hovered_last : bool
 }
 
 var private g_terminal = Terminal()
 var private g_terminal_view = ImGuiTerminalState()
 var private g_terminal_cache = ImGuiTerminalCache()
 var private g_terminal_font : ImFont?
+var private g_fonts = FontRoleSet()
 var private g_font_sources : array<string>
 var private g_zoom_percent = 150
 var private g_status = "Starting"
 var private g_url : string
 var private g_token : string
+var private g_selected_worktree_path : string
+var private g_selected_repository_id : string
+var private g_focus_terminal_pending = false
+var private g_inspector = GitInspectorState()
 var private SESSION_ROW : table<int; ToggleState>
+var private WORKTREE_ROW : table<int; ToggleState>
+var private GIT_FILE_ROW : table<int; ToggleState>
+var private REPOSITORY_ERROR : table<int; NarrativeState>
+var private REPOSITORY_TITLE : table<int; NarrativeState>
+var private REPOSITORY_EMPTY : table<int; NarrativeState>
+var private GIT_GROUP_TITLE : table<int; NarrativeState>
+var private REPOSITORY_SEPARATOR : table<int; EmptyMarkerState>
+var private WORKTREE_SEPARATOR : table<int; EmptyMarkerState>
+var private GIT_GROUP_SEPARATOR : table<int; EmptyMarkerState>
+var private GIT_GROUP_SPACING : table<int; EmptyMarkerState>
+
+def private setup_default_layout(dock_id : uint) {
+    DockBuilderRemoveNode(dock_id)
+    DockBuilderAddDockSpaceNode(dock_id, ImGuiDockNodeFlags.None)
+    let viewport = GetMainViewport()
+    DockBuilderSetNodeSize(dock_id, viewport.Size)
+    var left_id : uint = 0u
+    var right_id : uint = 0u
+    DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.24f, left_id, right_id)
+    var upper_id : uint = 0u
+    var terminal_id : uint = 0u
+    DockBuilderSplitNode(right_id, ImGuiDir.Down, 0.34f, terminal_id, upper_id)
+    var git_id : uint = 0u
+    var inspector_id : uint = 0u
+    DockBuilderSplitNode(upper_id, ImGuiDir.Left, 0.34f, git_id, inspector_id)
+    DockBuilderDockWindow("Sessions & Activity", left_id)
+    DockBuilderDockWindow("Repositories & Worktrees", left_id)
+    DockBuilderDockWindow("Git Status", git_id)
+    DockBuilderDockWindow("File Inspector", inspector_id)
+    DockBuilderDockWindow("Terminal", terminal_id)
+    DockBuilderDockWindow("Settings", git_id)
+    DockBuilderFinish(dock_id)
+}
 
 def private option_value(prefix : string; fallback : string = "") : string {
     for (argument in get_command_line_arguments()) {
@@ -69,6 +186,7 @@ def private option_value(prefix : string; fallback : string = "") : string {
 
 def private reset_terminal(columns : int = 100; rows : int = 30) {
     terminal_dispose(g_terminal)
+    terminal_viewport_snapshot_dispose(g_terminal_cache.snapshot)
     var inscope created <- terminal_create(columns, rows)
     g_terminal := created
     g_terminal_view = ImGuiTerminalState()
@@ -76,12 +194,126 @@ def private reset_terminal(columns : int = 100; rows : int = 30) {
 }
 
 def private feed_terminal_frame(message : string#; byte_count : int) {
-    var bytes : array<uint8>
+    var inscope bytes : array<uint8>
     bytes |> resize(byte_count)
     if (byte_count > 0) {
         unsafe { memcpy(addr(bytes[0]), reinterpret<void?>(message), byte_count) }
         terminal_feed_bytes(g_terminal, bytes)
     }
+}
+
+def private markdown_file(path : string) : bool {
+    let lower = to_lower(path)
+    return ends_with(lower, ".md") || ends_with(lower, ".markdown")
+}
+
+def private changed_source_ranges(source : string;
+                                  lines : array<int> const) : array<TextSourceRange> {
+    var result : array<TextSourceRange>
+    if (empty(lines)) return <- result
+    var target = 0
+    var line_index = 0
+    var line_start = 0
+    peek_data(source) $(bytes) {
+        for (at in range(length(bytes))) {
+            if (int(bytes[at]) != '\n') continue
+            while (target < length(lines) && lines[target] < line_index) {
+                target++
+            }
+            if (target < length(lines) && lines[target] == line_index) {
+                result |> push(TextSourceRange(start_byte = line_start, end_byte = at + 1))
+                while (target < length(lines) && lines[target] == line_index) {
+                    target++
+                }
+            }
+            line_index++
+            line_start = at + 1
+        }
+    }
+    while (target < length(lines) && lines[target] < line_index) {
+        target++
+    }
+    if (target < length(lines) && lines[target] == line_index) {
+        result |> push(TextSourceRange(start_byte = line_start, end_byte = length(source)))
+    }
+    return <- result
+}
+
+def private release_inspector_content() {
+    git_parsed_patch_dispose(g_inspector.parsed)
+    text_source_view_invalidate(g_inspector.old_view)
+    text_source_view_invalidate(g_inspector.new_view)
+    text_source_view_invalidate(g_inspector.view)
+    text_source_document_dispose(g_inspector.old_document)
+    text_source_document_dispose(g_inspector.new_document)
+    text_source_document_dispose(g_inspector.view_document)
+    markdown_view_invalidate(g_inspector.markdown_view)
+    delete g_inspector.markdown_document.nodes
+    delete g_inspector.changed_source_ranges
+    g_inspector.markdown_document = RichDocument()
+    g_inspector.view_source = ""
+    g_inspector.view_prepared = false
+    g_inspector.markdown_gutter_segments = 0
+    g_inspector.diff_scroll_y = 0.0f
+    g_inspector.diff_left_hovered_last = false
+    g_inspector.diff_right_hovered_last = false
+}
+
+def private install_file_inspection(message : WatcherFileInspectionMessage const) {
+    if (message.request_id != g_inspector.request_id) return
+    g_inspector.task_session_id = message.task_session_id
+    g_inspector.loading = message.loading
+    g_inspector.status = message.status
+    if (message.loading) return
+    g_inspector.error = message.error
+    if (!empty(message.error)) return
+
+    var inscope parsed <- git_parse_unified_patch(message.patch)
+    if (!empty(parsed.error)) {
+        g_inspector.error = parsed.error
+        return
+    }
+    release_inspector_content()
+    g_inspector.revision++
+    let language = extension(g_inspector.file_path)
+    let view_source = (!empty(message.view_text)
+        ? message.view_text : parsed.new_text)
+    var old_document <- tree_sitter_source_document(
+        parsed.old_aligned_text, language, g_inspector.revision)
+    var new_document <- tree_sitter_source_document(
+        parsed.new_aligned_text, language, g_inspector.revision)
+    old_document.line_marks |> reserve(length(parsed.old_changed_lines))
+    new_document.line_marks |> reserve(length(parsed.new_changed_lines))
+    for (index in range(length(parsed.rows))) {
+        if (parsed.rows[index].old_kind == GitDiffLineKind.removed) {
+            old_document.line_marks |> push(TextSourceLineMark(
+                line_index = index, kind = TextSourceLineMarkKind.removed))
+        }
+        if (parsed.rows[index].new_kind == GitDiffLineKind.added) {
+            new_document.line_marks |> push(TextSourceLineMark(
+                line_index = index, kind = TextSourceLineMarkKind.added))
+        }
+    }
+    g_inspector.parsed <- parsed
+    g_inspector.old_document <- old_document
+    g_inspector.new_document <- new_document
+    g_inspector.view_source = view_source
+}
+
+def private begin_file_inspection(repository_id, worktree_path, file_path,
+                                  comparison : string) {
+    g_inspector.request_id++
+    g_inspector.repository_id = repository_id
+    g_inspector.worktree_path = worktree_path
+    g_inspector.file_path = file_path
+    g_inspector.comparison = comparison
+    g_inspector.task_session_id = ""
+    g_inspector.loading = true
+    g_inspector.status = "Requesting diff..."
+    g_inspector.error = ""
+    release_inspector_content()
+    g_inspector.mode = GitInspectorMode.diff
+    INSPECTOR_DIFF_TAB.pending_select = true
 }
 
 class private WatcherRichClient : HvWebSocketClient {
@@ -92,6 +324,7 @@ class private WatcherRichClient : HvWebSocketClient {
     selected_id : string
     attached_id : string
     sessions : array<WatcherSessionInfo>
+    repositories : array<RepositorySnapshot>
     error : string
     last_heartbeat : int64
     last_list : int64
@@ -133,6 +366,7 @@ class private WatcherRichClient : HvWebSocketClient {
         } elif (envelope._type == "sessions") {
             var incoming : WatcherSessionsMessage
             if (sscan_json(body, incoming)) {
+                delete sessions
                 sessions <- incoming.data
                 if (empty(selected_id)) {
                     for (session in sessions) {
@@ -147,6 +381,40 @@ class private WatcherRichClient : HvWebSocketClient {
             var incoming : WatcherSessionMessage
             if (sscan_json(body, incoming)) {
                 attach_session(incoming.session_id)
+                TERMINAL_WIN.open = true
+                TERMINAL_WIN.pending_raise = true
+                g_focus_terminal_pending = true
+            }
+        } elif (envelope._type == "repositories") {
+            var incoming : WatcherRepositoriesMessage
+            if (sscan_json(body, incoming)) {
+                delete repositories
+                repositories <- incoming.data
+                var selection_found = false
+                for (repository in repositories) {
+                    if (repository.record.id != g_selected_repository_id) continue
+                    if (empty(repository.worktrees)) {
+                        selection_found = true
+                    }
+                    for (worktree in repository.worktrees) {
+                        if (worktree.path == g_selected_worktree_path) {
+                            selection_found = true
+                        }
+                    }
+                }
+                if (!selection_found && !empty(repositories)) {
+                    g_selected_repository_id = repositories[0].record.id
+                    if (!empty(repositories[0].worktrees)) {
+                        g_selected_worktree_path = repositories[0].worktrees[0].path
+                    } else {
+                        g_selected_worktree_path = repositories[0].record.checkout_path
+                    }
+                }
+            }
+        } elif (envelope._type == "file_inspection") {
+            var incoming : WatcherFileInspectionMessage
+            if (sscan_json(body, incoming)) {
+                install_file_inspection(incoming)
             }
         } elif (envelope._type == "attached") {
             var incoming : WatcherAttachedMessage
@@ -213,14 +481,41 @@ class private WatcherRichClient : HvWebSocketClient {
             "\"control\":true,\"raw\":true\}")
     }
 
-    def launch(command_line, cwd : string) {
+    def launch(command_line, cwd : string; repository_id : string = "";
+               worktree_path : string = "") {
         if (!connected) {
             error = "watcher is not connected"
             return
         }
         send("\{\"op\":\"launch\",\"command_line\":{sprint_json(command_line, false)}," +
             "\"cwd\":{sprint_json(cwd, false)},\"columns\":100,\"rows\":30," +
-            "\"timeout_ms\":0\}")
+            "\"timeout_ms\":0,\"display_name\":\"PowerShell\",\"kind\":\"interactive-shell\"," +
+            "\"target_id\":\"local\",\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}\}")
+    }
+
+    def add_repository(path : string) {
+        if (!connected || empty(path)) return
+        send("\{\"op\":\"repository_add\",\"repository_path\":{sprint_json(path, false)}," +
+            "\"target_id\":\"local\"\}")
+    }
+
+    def refresh_repository(repository_id : string) {
+        if (!connected || empty(repository_id)) return
+        send("\{\"op\":\"repository_refresh\",\"repository_id\":" +
+            "{sprint_json(repository_id, false)}\}")
+    }
+
+    def inspect_file(repository_id, worktree_path, file_path,
+                     comparison : string) {
+        if (!connected || empty(repository_id) || empty(worktree_path)
+                || empty(file_path)) return
+        begin_file_inspection(repository_id, worktree_path, file_path, comparison)
+        send("\{\"op\":\"file_inspect\",\"request_id\":{g_inspector.request_id}," +
+            "\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}," +
+            "\"file_path\":{sprint_json(file_path, false)}," +
+            "\"comparison\":{sprint_json(comparison, false)}\}")
     }
 
     def send_input(text : string) {
@@ -295,73 +590,31 @@ def private draw_session_list() {
     separator()
     child(SESSIONS_CHILD, (text = "sessions", size = float2(0.0f, -150.0f),
             child_flags = ImGuiChildFlags.Borders, window_flags = ImGuiWindowFlags.None)) {
-        if (g_client != null && empty(g_client.sessions)) {
-            text_disabled("No sessions")
-        } elif (g_client != null) {
+        var visible_sessions = 0
+        if (g_client != null) {
             for (index in range(length(g_client.sessions))) {
                 let session = g_client.sessions[index]
+                if (!SHOW_EXITED.value && session.state == "exited") continue
+                visible_sessions++
                 let row_text = "[{session.state}] {session.command_line}##{session.id}"
                 if (selectable(SESSION_ROW[index], (text = row_text))) {
                     g_client->attach_session(session.id)
+                    TERMINAL_WIN.open = true
+                    TERMINAL_WIN.pending_raise = true
+                    g_focus_terminal_pending = true
                 }
                 SESSION_ROW[index].value = session.id == g_client.selected_id
             }
         }
+        if (visible_sessions == 0) {
+            text_disabled(NO_SESSION_LABEL,
+                (text = SHOW_EXITED.value ? "No sessions" : "No active sessions"))
+        }
     }
-    text("New terminal")
-    input_text_growable(LAUNCH_COMMAND, (text = "Command"))
-    input_text_growable(LAUNCH_CWD, (text = "Working directory"))
-    if (button(LAUNCH_SESSION, (text = "Launch and attach")) && g_client != null) {
-        g_client->launch(LAUNCH_COMMAND.value, LAUNCH_CWD.value)
-    }
+    text_disabled("Exited sessions are retained and hidden by default.")
 }
 
 def private draw_terminal_footer() {
-    if (small_button(TERMINAL_EDIT_MENU, (text = "Edit"))) {
-        open_popup("terminal_edit_menu")
-    }
-    popup_window(TERMINAL_EDIT_POPUP,
-            (str_id = "terminal_edit_menu", flags = ImGuiWindowFlags.AlwaysAutoResize)) {
-        if (menu_label(TERMINAL_COPY, (text = "Copy", shortcut = "Ctrl+C",
-                enabled = g_terminal_view.selection_active))) {
-            g_status = (imgui_terminal_copy_selection(g_terminal, g_terminal_view)
-                ? "Selection copied" : "Nothing selected")
-        }
-        if (menu_label(TERMINAL_PASTE, (text = "Paste", shortcut = "Ctrl+V"))) {
-            var pasted = ""
-            if (clipboard_get_text(pasted) == ClipboardStatus.ok && g_client != null) {
-                g_client->send_input(terminal_encode_paste(g_terminal, pasted))
-                g_status = "Clipboard pasted"
-            } else {
-                g_status = "Clipboard unavailable"
-            }
-        }
-        separator()
-        if (menu_label(TERMINAL_SELECT_ALL, (text = "Select all"))) {
-            imgui_terminal_select_all(g_terminal, g_terminal_view)
-        }
-        if (menu_label(TERMINAL_CLEAR_SELECTION,
-                (text = "Clear selection", enabled = g_terminal_view.selection_active))) {
-            imgui_terminal_clear_selection(g_terminal_view)
-        }
-    }
-    same_line()
-    if (small_button(TERMINAL_VIEW_MENU, (text = "View"))) {
-        open_popup("terminal_view_menu")
-    }
-    popup_window(TERMINAL_VIEW_POPUP,
-            (str_id = "terminal_view_menu", flags = ImGuiWindowFlags.AlwaysAutoResize)) {
-        if (menu_label(TERMINAL_ZOOM_IN, (text = "Zoom in", shortcut = "Ctrl++"))) zoom_by(5)
-        if (menu_label(TERMINAL_ZOOM_OUT, (text = "Zoom out", shortcut = "Ctrl+-"))) zoom_by(-5)
-        if (menu_label(TERMINAL_ZOOM_RESET, (text = "Reset zoom", shortcut = "Ctrl+0"))) {
-            g_zoom_percent = 100
-        }
-        separator()
-        if (menu_label(TERMINAL_SCROLL_BOTTOM, (text = "Scroll to bottom"))) {
-            g_terminal_view.scroll_offset = 0
-        }
-    }
-    same_line()
     if (small_button(TERMINAL_ZOOM_OUT_BUTTON, (text = "-5%"))) zoom_by(-5)
     same_line()
     if (small_button(TERMINAL_ZOOM_IN_BUTTON, (text = "+5%"))) zoom_by(5)
@@ -375,14 +628,580 @@ def private draw_terminal_footer() {
     }
 }
 
+def private copy_terminal_selection() {
+    g_status = (imgui_terminal_copy_selection(g_terminal, g_terminal_view)
+        ? "Selection copied" : "Nothing selected")
+}
+
+def private paste_terminal_clipboard() {
+    var pasted = ""
+    if (clipboard_get_text(pasted) == ClipboardStatus.ok && g_client != null) {
+        g_client->send_input(terminal_encode_paste(g_terminal, pasted))
+        g_status = "Clipboard pasted"
+    } else {
+        g_status = "Clipboard unavailable"
+    }
+}
+
+def private open_dock_window(var state : DockWindowState) {
+    state.open = true
+    state.pending_raise = true
+}
+
+def private reset_layout() {
+    REPOSITORIES_WIN.open = true
+    SESSIONS_WIN.open = true
+    GIT_STATUS_WIN.open = true
+    FILE_INSPECTOR_WIN.open = true
+    TERMINAL_WIN.open = true
+    SETTINGS_WIN.open = false
+    DOCK_ROOT.pending_reset = true
+}
+
+def private draw_main_menu() {
+    main_menu_bar(MAIN_MENU) {
+        menu(FILE_MENU, (text = "File", enabled = true)) {
+            if (menu_label(FILE_EXIT, (text = "Exit", shortcut = "Alt+F4"))) {
+                request_exit()
+            }
+        }
+        menu(COMMANDS_MENU, (text = "Commands", enabled = true)) {
+            if (menu_label(COMMAND_POWERSHELL,
+                    (text = "PowerShell", enabled = g_client != null && g_client.connected))) {
+                g_client->launch("powershell.exe -NoLogo -NoProfile", g_selected_worktree_path,
+                    g_selected_repository_id, g_selected_worktree_path)
+            }
+        }
+        menu(EDIT_MENU, (text = "Edit", enabled = true)) {
+            if (menu_label(EDIT_COPY, (text = "Copy", shortcut = "Ctrl+C",
+                    enabled = g_terminal_view.selection_active))) copy_terminal_selection()
+            if (menu_label(EDIT_PASTE, (text = "Paste", shortcut = "Ctrl+V"))) {
+                paste_terminal_clipboard()
+            }
+            separator(EDIT_SELECTION_SEPARATOR)
+            if (menu_label(EDIT_SELECT_ALL, (text = "Select all"))) {
+                imgui_terminal_select_all(g_terminal, g_terminal_view)
+            }
+            if (menu_label(EDIT_CLEAR_SELECTION,
+                    (text = "Clear selection", enabled = g_terminal_view.selection_active))) {
+                imgui_terminal_clear_selection(g_terminal_view)
+            }
+        }
+        menu(VIEW_MENU, (text = "View", enabled = true)) {
+            if (menu_label(VIEW_REPOSITORIES,
+                    (text = "Repositories & Worktrees", selected = REPOSITORIES_WIN.open))) {
+                open_dock_window(REPOSITORIES_WIN)
+            }
+            if (menu_label(VIEW_SESSIONS,
+                    (text = "Sessions & Activity", selected = SESSIONS_WIN.open))) {
+                open_dock_window(SESSIONS_WIN)
+            }
+            if (menu_label(VIEW_GIT_STATUS,
+                    (text = "Git Status", selected = GIT_STATUS_WIN.open))) {
+                open_dock_window(GIT_STATUS_WIN)
+            }
+            if (menu_label(VIEW_FILE_INSPECTOR,
+                    (text = "File Inspector", selected = FILE_INSPECTOR_WIN.open))) {
+                open_dock_window(FILE_INSPECTOR_WIN)
+            }
+            if (menu_label(VIEW_TERMINAL,
+                    (text = "Terminal", selected = TERMINAL_WIN.open))) {
+                open_dock_window(TERMINAL_WIN)
+            }
+            separator(VIEW_WINDOWS_SEPARATOR)
+            menu_item(SHOW_EXITED, (text = "Show exited sessions"))
+            separator(VIEW_ZOOM_SEPARATOR)
+            if (menu_label(VIEW_ZOOM_IN, (text = "Zoom in", shortcut = "Ctrl++"))) zoom_by(5)
+            if (menu_label(VIEW_ZOOM_OUT, (text = "Zoom out", shortcut = "Ctrl+-"))) zoom_by(-5)
+            if (menu_label(VIEW_ZOOM_RESET, (text = "Reset zoom", shortcut = "Ctrl+0"))) {
+                g_zoom_percent = 100
+            }
+            if (menu_label(VIEW_SCROLL_BOTTOM, (text = "Scroll terminal to bottom"))) {
+                g_terminal_view.scroll_offset = 0
+            }
+            separator(VIEW_LAYOUT_SEPARATOR)
+            if (menu_label(VIEW_RESET_LAYOUT, (text = "Reset layout"))) reset_layout()
+        }
+        menu(SETTINGS_MENU, (text = "Settings", enabled = true)) {
+            if (menu_label(OPEN_SETTINGS, (text = "Open Settings"))) {
+                open_dock_window(SETTINGS_WIN)
+            }
+        }
+    }
+}
+
+def private draw_repositories_window() {
+    text_disabled("Target: Local")
+    separator()
+    input_text_growable(ADD_REPOSITORY_PATH, (text = "Repository checkout"))
+    same_line()
+    if (button(ADD_REPOSITORY, (text = "Add")) && g_client != null) {
+        g_client->add_repository(ADD_REPOSITORY_PATH.value)
+    }
+    separator()
+    var row = 0
+    var repository_row = 0
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            let refreshing = repository.refreshing ? "  refreshing..." : ""
+            text(REPOSITORY_TITLE[repository_row],
+                (text = "{repository.record.display_name}  [Local]{refreshing}"))
+            if (!empty(repository.error)) {
+                text_colored(REPOSITORY_ERROR[repository_row], (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+                    text = repository.error))
+            }
+            for (worktree in repository.worktrees) {
+                var branch = worktree.branch
+                if (worktree.detached) {
+                    branch = "detached {slice(worktree.head, 0, min(8, length(worktree.head)))}"
+                }
+                let prefix = worktree.is_main ? "MAIN  " : "      "
+                let dirty = worktree.staged + worktree.unstaged + worktree.untracked + worktree.conflicted
+                let dirty_label = dirty > 0 ? "  *{dirty}" : ""
+                let row_label = "{prefix}{branch}{dirty_label}##{repository.record.id}:{worktree.path}"
+                if (selectable(WORKTREE_ROW[row], (text = row_label))) {
+                    g_selected_repository_id = repository.record.id
+                    g_selected_worktree_path = worktree.path
+                    g_client->refresh_repository(repository.record.id)
+                    GIT_STATUS_WIN.open = true
+                    GIT_STATUS_WIN.pending_raise = true
+                }
+                WORKTREE_ROW[row].value = (repository.record.id == g_selected_repository_id && worktree.path == g_selected_worktree_path)
+                if (worktree.is_main) separator(WORKTREE_SEPARATOR[row])
+                row++
+            }
+            if (empty(repository.worktrees)) {
+                text_disabled(REPOSITORY_EMPTY[repository_row],
+                    (text = "Waiting for Git worktree inventory..."))
+            }
+            separator(REPOSITORY_SEPARATOR[repository_row])
+            repository_row++
+        }
+    }
+    if (g_client == null || empty(g_client.repositories)) text_disabled("No repositories registered")
+}
+
+def private git_status_byte(code : string; index : int) : int {
+    if (index < 0 || index >= length(code)) return ' '
+    var result = ' '
+    peek_data(code) $(data) {
+        result = int(data[index])
+    }
+    return result
+}
+
+def private git_conflict(code : string) : bool {
+    return (code == "DD" || code == "AU" || code == "UD" || code == "UA"
+        || code == "DU" || code == "AA" || code == "UU")
+}
+
+def private git_file_in_group(file : GitFileState const; group : int) : bool {
+    if (group == 0) return git_conflict(file.code)
+    if (git_conflict(file.code)) return false
+    if (group == 1) return file.code != "??" && git_status_byte(file.code, 0) != ' '
+    if (group == 2) return file.code != "??" && git_status_byte(file.code, 1) != ' '
+    return file.code == "??"
+}
+
+def private git_group_scope(group : int) : string {
+    return group == 1 ? "staged" : "working"
+}
+
+def private draw_git_file_group(repository : RepositorySnapshot const;
+                                worktree : WorktreeState const;
+                                group : int; var file_row : int&) : int {
+    var count = 0
+    for (file in repository.files) {
+        if (file.worktree_path == worktree.path && git_file_in_group(file, group)) count++
+    }
+    if (count == 0) return 0
+    let title = group == 0 ? "CONFLICTS" : (group == 1 ? "STAGED"
+        : (group == 2 ? "MODIFIED" : "UNTRACKED"))
+    text(GIT_GROUP_TITLE[group], (text = "{title}  {count}"))
+    separator(GIT_GROUP_SEPARATOR[group])
+    let comparison = git_group_scope(group)
+    for (file in repository.files) {
+        if (file.worktree_path != worktree.path || !git_file_in_group(file, group)) continue
+        GIT_FILE_ROW[file_row].value = (g_inspector.repository_id == repository.record.id
+            && g_inspector.worktree_path == worktree.path
+            && g_inspector.file_path == file.path
+            && g_inspector.comparison == comparison)
+        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
+        if (selectable(GIT_FILE_ROW[file_row],
+                (text = "{file.code}  {file.path}{old_label}##{comparison}:{file.path}"))) {
+            if (g_client != null) {
+                g_client->inspect_file(repository.record.id, worktree.path,
+                    file.path, comparison)
+                FILE_INSPECTOR_WIN.open = true
+                FILE_INSPECTOR_WIN.pending_raise = true
+            }
+        }
+        file_row++
+    }
+    dummy(GIT_GROUP_SPACING[group], (size = float2(0.0f, GetStyle().ItemSpacing.y)))
+    return count
+}
+
+def private draw_git_status_window() {
+    var found = false
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id != g_selected_repository_id) continue
+            for (worktree in repository.worktrees) {
+                if (worktree.path != g_selected_worktree_path) continue
+                found = true
+                let title = worktree.is_main ? "MAIN - {worktree.branch}" : worktree.branch
+                text(GIT_TITLE, (text = title))
+                same_line()
+                if (small_button(REFRESH_GIT, (text = repository.refreshing ? "Refreshing..." : "Refresh",
+                        enabled = !repository.refreshing))) {
+                    g_client->refresh_repository(repository.record.id)
+                }
+                text_disabled(GIT_WORKTREE_PATH, (text = worktree.path))
+                let status_summary = "staged {worktree.staged}   unstaged {worktree.unstaged}   untracked {worktree.untracked}   conflicted {worktree.conflicted}"
+                text(GIT_STATUS_SUMMARY, (text = status_summary))
+                if (worktree.ahead != 0 || worktree.behind != 0) {
+                    text(GIT_AHEAD_BEHIND,
+                        (text = "ahead {worktree.ahead}   behind {worktree.behind}"))
+                }
+                if (!empty(repository.error)) {
+                    text_colored(GIT_ERROR, (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+                        text = repository.error))
+                }
+                separator()
+                var file_row = 0
+                let conflicts = draw_git_file_group(repository, worktree, 0, file_row)
+                let staged = draw_git_file_group(repository, worktree, 1, file_row)
+                let modified = draw_git_file_group(repository, worktree, 2, file_row)
+                let untracked = draw_git_file_group(repository, worktree, 3, file_row)
+                if (file_row == 0 && !repository.refreshing && empty(repository.error)) {
+                    text_disabled("Working tree clean")
+                }
+            }
+        }
+    }
+    if (!found) text_disabled("Select a worktree to inspect Git status")
+}
+
+def private source_view_style(diff_background : bool = false) : TextSourceViewStyle {
+    return TextSourceViewStyle(
+        fonts = g_fonts,
+        zoom = float(g_zoom_percent) / 100.0f,
+        wrap = false,
+        line_mark_background_alpha = diff_background ? 0.11f : 0.0f,
+        line_mark_width = 2.0f,
+        write_system_clipboard = !harness_is_headless())
+}
+
+def private syntax_cell_count(state : TextSourceViewState const) : int {
+    var count = 0
+    for (cell in state.cells) {
+        if (cell.style_id > 1) count++
+    }
+    return count
+}
+
+def private syntax_style_cell_count(state : TextSourceViewState const;
+                                    style : TextSourceSyntaxStyle) : int {
+    var count = 0
+    let style_id = 1 + int(style)
+    for (cell in state.cells) {
+        if (cell.style_id == style_id) count++
+    }
+    return count
+}
+
+def private draw_side_by_side_diff() {
+    let available = GetContentRegionAvail()
+    let gap = GetStyle().ItemSpacing.x
+    let pane_width = max(1.0f, (available.x - gap) * 0.5f)
+    child(DIFF_LEFT_PANE, (text = "before", size = float2(pane_width, available.y),
+            child_flags = ImGuiChildFlags.Borders,
+            window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+        let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
+        let entering = hovered && !g_inspector.diff_left_hovered_last
+        if (!hovered || entering) SetScrollY(g_inspector.diff_scroll_y)
+        text_disabled("BEFORE")
+        separator()
+        var style = source_view_style(true)
+        let _ = text_source_view("git diff before", g_inspector.old_document,
+            g_inspector.old_view, style)
+        if (hovered) {
+            g_inspector.diff_scroll_y = GetScrollY()
+        }
+        g_inspector.diff_left_hovered_last = hovered
+    }
+    same_line()
+    child(DIFF_RIGHT_PANE, (text = "after", size = float2(pane_width, available.y),
+            child_flags = ImGuiChildFlags.Borders,
+            window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+        let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
+        let entering = hovered && !g_inspector.diff_right_hovered_last
+        if (!hovered || entering) SetScrollY(g_inspector.diff_scroll_y)
+        text_disabled("AFTER")
+        separator()
+        var style = source_view_style(true)
+        let _ = text_source_view("git diff after", g_inspector.new_document,
+            g_inspector.new_view, style)
+        if (hovered) {
+            g_inspector.diff_scroll_y = GetScrollY()
+        }
+        g_inspector.diff_right_hovered_last = hovered
+    }
+}
+
+def private prepare_file_view() {
+    if (g_inspector.view_prepared) return
+    let language = extension(g_inspector.file_path)
+    var view_document <- tree_sitter_source_document(
+        g_inspector.view_source, language, g_inspector.revision)
+    view_document.line_marks |> reserve(length(g_inspector.parsed.new_changed_lines))
+    for (line in g_inspector.parsed.new_changed_lines) {
+        view_document.line_marks |> push(TextSourceLineMark(
+            line_index = line, kind = TextSourceLineMarkKind.added))
+    }
+    g_inspector.view_document <- view_document
+    if (markdown_file(g_inspector.file_path)) {
+        var markdown_document <- md_parse(g_inspector.view_source)
+        var markdown_changes <- changed_source_ranges(
+            g_inspector.view_source, g_inspector.parsed.new_changed_lines)
+        g_inspector.markdown_document <- markdown_document
+        g_inspector.changed_source_ranges <- markdown_changes
+    }
+    g_inspector.view_prepared = true
+}
+
+def private draw_file_view() {
+    prepare_file_view()
+    child(FILE_VIEW_PANE, (text = "file view", size = float2(0.0f, 0.0f),
+            child_flags = ImGuiChildFlags.None,
+            window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+        if (markdown_file(g_inspector.file_path)) {
+            var style = MarkdownViewStyle(
+                fonts = g_fonts,
+                typography = MarkdownTypography(
+                    inline_code_scale = 0.84f, code_block_scale = 0.90f),
+                zoom = float(g_zoom_percent) / 100.0f,
+                write_system_clipboard = !harness_is_headless())
+            markdown_tree_sitter_prepare(g_inspector.markdown_document,
+                g_inspector.markdown_syntax, g_inspector.markdown_view,
+                g_inspector.revision)
+            let _ <- markdown_view_with_change_gutter("git markdown view",
+                g_inspector.markdown_document, g_inspector.markdown_view,
+                style, g_inspector.revision, g_inspector.changed_source_ranges,
+                g_inspector.markdown_gutter_segments,
+                max(1.0f, 2.0f * float(g_zoom_percent) / 100.0f))
+        } else {
+            var style = source_view_style(false)
+            let _ = text_source_view("git file view", g_inspector.view_document,
+                g_inspector.view, style)
+        }
+    }
+}
+
+[live_command(description = "Inspect the selected Git file, comparison, render mode, and changed-line telemetry.")]
+def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
+    let view_selection = text_source_view_selection(g_inspector.view)
+    return JV((
+        ok = !empty(g_inspector.file_path) && !g_inspector.loading
+            && empty(g_inspector.error),
+        repository_id = g_inspector.repository_id,
+        worktree_path = g_inspector.worktree_path,
+        file_path = g_inspector.file_path,
+        comparison = g_inspector.comparison,
+        mode = g_inspector.mode == GitInspectorMode.diff ? "diff" : "view",
+        loading = g_inspector.loading,
+        status = g_inspector.status,
+        error = g_inspector.error,
+        task_session_id = g_inspector.task_session_id,
+        revision = g_inspector.revision,
+        diff_row_count = length(g_inspector.parsed.rows),
+        old_changed_line_count = length(g_inspector.parsed.old_changed_lines),
+        new_changed_line_count = length(g_inspector.parsed.new_changed_lines),
+        old_byte_count = length(g_inspector.parsed.old_text),
+        new_byte_count = length(g_inspector.parsed.new_text),
+        view_byte_count = length(g_inspector.view_source),
+        view_prepared = g_inspector.view_prepared,
+        old_line_mark_count = length(g_inspector.old_document.line_marks),
+        new_line_mark_count = length(g_inspector.new_document.line_marks),
+        view_line_mark_count = length(g_inspector.view_document.line_marks),
+        changed_source_range_count = length(g_inspector.changed_source_ranges),
+        old_syntax_span_count = length(g_inspector.old_document.spans),
+        new_syntax_span_count = length(g_inspector.new_document.spans),
+        view_syntax_span_count = length(g_inspector.view_document.spans),
+        old_syntax_cell_count = syntax_cell_count(g_inspector.old_view),
+        new_syntax_cell_count = syntax_cell_count(g_inspector.new_view),
+        view_syntax_cell_count = syntax_cell_count(g_inspector.view),
+        view_virtual_mode = g_inspector.view.virtual_mode,
+        view_visible_syntax_runs = g_inspector.view.virtual_visible_syntax_runs,
+        view_selection_start = view_selection.start_byte,
+        view_selection_end = view_selection.end_byte,
+        view_selection_revision = g_inspector.view.selection_revision,
+        view_selection_copy_revision = g_inspector.view.selection_copy_revision,
+        old_keyword_cell_count = syntax_style_cell_count(
+            g_inspector.old_view, TextSourceSyntaxStyle.keyword),
+        new_keyword_cell_count = syntax_style_cell_count(
+            g_inspector.new_view, TextSourceSyntaxStyle.keyword),
+        old_type_cell_count = syntax_style_cell_count(
+            g_inspector.old_view, TextSourceSyntaxStyle.type_),
+        new_type_cell_count = syntax_style_cell_count(
+            g_inspector.new_view, TextSourceSyntaxStyle.type_),
+        old_function_cell_count = syntax_style_cell_count(
+            g_inspector.old_view, TextSourceSyntaxStyle.function_),
+        new_function_cell_count = syntax_style_cell_count(
+            g_inspector.new_view, TextSourceSyntaxStyle.function_),
+        old_render_revision = g_inspector.old_view.render_revision,
+        new_render_revision = g_inspector.new_view.render_revision,
+        view_render_revision = g_inspector.view.render_revision,
+        markdown_render_revision = g_inspector.markdown_view.render_revision,
+        markdown_current_layout_count = markdown_view_current_layout_count(
+            g_inspector.markdown_view),
+        markdown_changed_layout_count = markdown_view_changed_layout_count(
+            g_inspector.markdown_document, g_inspector.markdown_view,
+            g_inspector.changed_source_ranges),
+        markdown_gutter_segments = g_inspector.markdown_gutter_segments))
+}
+
+[live_command(description = "Open a changed Git file immediately. Args: repository_id, worktree_path, file_path, comparison.")]
+def herder_file_inspector_open(input : JsonValue?) : JsonValue? {
+    if (g_client == null || !g_client.connected) {
+        return JV((ok = false, error = "watcher is not connected"))
+    }
+    let args = from_JV(input, type<HerderInspectorOpenArgs>)
+    if (empty(args.repository_id) || empty(args.worktree_path)
+            || empty(args.file_path)) {
+        return JV((ok = false,
+            error = "repository_id, worktree_path, and file_path are required"))
+    }
+    let comparison = empty(args.comparison) ? "working" : args.comparison
+    g_client->inspect_file(args.repository_id, args.worktree_path,
+        args.file_path, comparison)
+    FILE_INSPECTOR_WIN.open = true
+    FILE_INSPECTOR_WIN.pending_raise = true
+    return JV((ok = true, request_id = g_inspector.request_id,
+        file_path = args.file_path, comparison = comparison))
+}
+
+[live_command(description = "Read exact inspector text. Args: side = before | after | view.")]
+def herder_file_inspector_text(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<HerderInspectorTextArgs>)
+    let side = to_lower(args.side)
+    if (side == "before" || side == "old") {
+        return JV((ok = true, side = "before",
+            text = g_inspector.parsed.old_text,
+            line_mark_count = length(g_inspector.old_document.line_marks),
+            syntax_span_count = length(g_inspector.old_document.spans)))
+    }
+    if (side == "after" || side == "new" || side == "view") {
+        let source = (side == "view"
+            ? g_inspector.view_source : g_inspector.parsed.new_text)
+        return JV((ok = true, side = side == "view" ? "view" : "after",
+            text = source,
+            line_mark_count = length(g_inspector.view_document.line_marks),
+            syntax_span_count = length(g_inspector.view_document.spans)))
+    }
+    return JV((ok = false, error = "side must be before, after, or view"))
+}
+
+[live_command(description = "Switch the Git file inspector between Diff and View without mouse input.")]
+def herder_file_inspector_mode(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<HerderInspectorModeArgs>)
+    let mode = to_lower(args.mode)
+    if (mode == "diff") {
+        INSPECTOR_DIFF_TAB.pending_select = true
+    } elif (mode == "view") {
+        INSPECTOR_VIEW_TAB.pending_select = true
+    } else {
+        return JV((ok = false, error = "mode must be diff or view"))
+    }
+    return JV((ok = true, mode = mode))
+}
+
+def private draw_file_inspector_window() {
+    if (empty(g_inspector.file_path)) {
+        text_disabled("Select a changed file")
+        return
+    }
+    text(INSPECTOR_PATH, (text = g_inspector.file_path))
+    same_line()
+    text_disabled(INSPECTOR_SCOPE, (text = to_upper(g_inspector.comparison)))
+    if (g_inspector.loading) {
+        text_disabled(INSPECTOR_LOADING,
+            (text = empty(g_inspector.status) ? "Loading diff..." : g_inspector.status))
+        return
+    }
+    if (!empty(g_inspector.error)) {
+        text_colored(INSPECTOR_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f), text = g_inspector.error))
+        if (!empty(g_inspector.task_session_id)) {
+            text_disabled("Task: {g_inspector.task_session_id}")
+        }
+        return
+    }
+    tab_bar(INSPECTOR_MODE_TABS,
+            (text = "InspectorModes", flags = ImGuiTabBarFlags.None)) {
+        tab_item(INSPECTOR_DIFF_TAB, (text = "Diff", closable = false,
+                flags = ImGuiTabItemFlags.None)) {
+            g_inspector.mode = GitInspectorMode.diff
+            draw_side_by_side_diff()
+        }
+        tab_item(INSPECTOR_VIEW_TAB, (text = "View", closable = false,
+                flags = ImGuiTabItemFlags.None)) {
+            g_inspector.mode = GitInspectorMode.view
+            draw_file_view()
+        }
+    }
+}
+
+def private draw_settings_window() {
+    text("Global user configuration")
+    text_disabled("Repository registration and layout settings will be stored here.")
+}
+
+def private draw_terminal_window() {
+    let io & = unsafe(GetIO())
+    if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
+        if (io.MouseWheel > 0.0f) zoom_by(5)
+        elif (io.MouseWheel < 0.0f) zoom_by(-5)
+    }
+    text(SESSION_LABEL, (text = selected_session_label()))
+    if (g_client != null && !empty(g_client.error)) {
+        text_colored(CLIENT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f), text = g_client.error))
+    }
+    separator()
+    let terminal_style = ImGuiTerminalStyle(
+        external_input = true,
+        view_height = max(GetTextLineHeight(),
+            GetContentRegionAvail().y - GetFrameHeightWithSpacing()
+                - GetStyle().ItemSpacing.y))
+    with_font(g_terminal_font) {
+        if (g_focus_terminal_pending) {
+            set_keyboard_focus_here()
+            g_focus_terminal_pending = false
+        }
+        let result <- imgui_terminal("watcher", g_terminal, g_terminal_view,
+            g_terminal_cache, terminal_style)
+        if (g_client != null) {
+            if (!empty(result.input_text)) g_client->send_input(result.input_text)
+            if (result.resized) g_client->request_resize(result.columns, result.rows)
+        }
+    }
+    separator()
+    draw_terminal_footer()
+}
+
 [export]
 def init() {
     harness_init("dasHerd", 1280, 800)
     harness_maximize_window()
-    g_terminal_font = load_unicode_ui_font(14.0f, g_font_sources)
+    var io & = unsafe(GetIO())
+    io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
+    g_fonts = load_unicode_font_roles(14.0f, g_font_sources)
+    g_terminal_font = g_fonts.monospace
     reset_terminal()
-    LAUNCH_COMMAND.value = "powershell.exe -NoLogo -NoProfile"
-    LAUNCH_CWD.value = get_das_root()
+    g_selected_worktree_path = get_das_root()
+    SETTINGS_WIN.open = false
     let port = clamp(to_int(option_value("--port=", "9191")), 1024, 65535)
     g_token = option_value("--token=")
     g_url = "ws://127.0.0.1:{port}/ws?token={g_token}"
@@ -403,44 +1222,35 @@ def update() {
     if (g_client != null) g_client->pump()
     harness_new_frame()
     GetStyle().FontScaleMain = float(g_zoom_percent) / 100.0f
-    let viewport = GetMainViewport()
-    SetNextWindowPos(viewport.WorkPos, ImGuiCond.Always)
-    SetNextWindowSize(viewport.WorkSize, ImGuiCond.Always)
-    window(HERDER_WIN, (text = "dasHerd", closable = false,
-            flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove)) {
-        let io & = unsafe(GetIO())
-        if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
-            if (io.MouseWheel > 0.0f) zoom_by(5)
-            elif (io.MouseWheel < 0.0f) zoom_by(-5)
+    draw_main_menu()
+    dockspace(DOCK_ROOT, (flags = ImGuiDockNodeFlags.PassthruCentralNode)) {
+        if (!DOCK_ROOT.has_initial_layout && DOCK_ROOT.dock_id != 0u) {
+            setup_default_layout(DOCK_ROOT.dock_id)
+            DOCK_ROOT.has_initial_layout = true
         }
-        child(SIDEBAR_CHILD, (text = "sidebar", size = float2(330.0f, 0.0f),
-                child_flags = ImGuiChildFlags.None, window_flags = ImGuiWindowFlags.None)) {
+        dock_window(REPOSITORIES_WIN, (text = "Repositories & Worktrees", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_repositories_window()
+        }
+        dock_window(SESSIONS_WIN, (text = "Sessions & Activity", closable = true,
+                flags = ImGuiWindowFlags.None)) {
             draw_session_list()
         }
-        same_line()
-        child(TERMINAL_CHILD, (text = "terminal", size = float2(0.0f, 0.0f),
-                child_flags = ImGuiChildFlags.None, window_flags = ImGuiWindowFlags.None)) {
-            text(SESSION_LABEL, (text = selected_session_label()))
-            if (g_client != null && !empty(g_client.error)) {
-                text_colored(CLIENT_ERROR,
-                    (color = float4(1.0f, 0.35f, 0.30f, 1.0f), text = g_client.error))
-            }
-            separator()
-            let terminal_style = ImGuiTerminalStyle(
-                external_input = true,
-                view_height = max(GetTextLineHeight(),
-                    GetContentRegionAvail().y - GetFrameHeightWithSpacing()
-                        - GetStyle().ItemSpacing.y))
-            with_font(g_terminal_font) {
-                let result <- imgui_terminal("watcher", g_terminal, g_terminal_view,
-                    g_terminal_cache, terminal_style)
-                if (g_client != null) {
-                    if (!empty(result.input_text)) g_client->send_input(result.input_text)
-                    if (result.resized) g_client->request_resize(result.columns, result.rows)
-                }
-            }
-            separator()
-            draw_terminal_footer()
+        dock_window(GIT_STATUS_WIN, (text = "Git Status", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_git_status_window()
+        }
+        dock_window(FILE_INSPECTOR_WIN, (text = "File Inspector", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_file_inspector_window()
+        }
+        dock_window(TERMINAL_WIN, (text = "Terminal", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_terminal_window()
+        }
+        dock_window(SETTINGS_WIN, (text = "Settings", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_settings_window()
         }
     }
     harness_end_frame()
@@ -451,10 +1261,20 @@ def shutdown() {
     if (g_client != null) {
         g_client->close()
         g_client->cleanup()
+        delete g_client.sessions
+        delete g_client.repositories
         unsafe { delete g_client }
         g_client = null
     }
+    release_inspector_content()
+    markdown_tree_sitter_dispose(g_inspector.markdown_syntax)
+    markdown_view_dispose(g_inspector.markdown_view)
+    text_source_view_dispose(g_inspector.old_view)
+    text_source_view_dispose(g_inspector.new_view)
+    text_source_view_dispose(g_inspector.view)
+    terminal_viewport_snapshot_dispose(g_terminal_cache.snapshot)
     terminal_dispose(g_terminal)
+    delete g_font_sources
     harness_shutdown()
 }
 

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -159,6 +159,9 @@ struct private GitInspectorState {
     diff_scroll_jump_pending : bool
     diff_split_fraction : float = 0.5f
     diff_current_hunk : int
+    diff_left_rect : float4
+    diff_right_rect : float4
+    diff_scrollbar_rect : float4
 }
 
 var private g_terminal = Terminal()
@@ -305,6 +308,9 @@ def private release_inspector_content() {
     g_inspector.diff_scroll_y = 0.0f
     g_inspector.diff_scroll_jump_pending = false
     g_inspector.diff_current_hunk = 0
+    g_inspector.diff_left_rect = float4()
+    g_inspector.diff_right_rect = float4()
+    g_inspector.diff_scrollbar_rect = float4()
 }
 
 def private queue_inspector_prepare(status : string) {
@@ -1129,6 +1135,10 @@ def private draw_side_by_side_diff() {
     child(DIFF_LEFT_PANE, (text = "before", size = float2(left_width, available.y),
             child_flags = ImGuiChildFlags.Borders,
             window_flags = ImGuiWindowFlags.NoScrollbar)) {
+        let window_pos = GetWindowPos()
+        let window_size = GetWindowSize()
+        g_inspector.diff_left_rect = float4(window_pos.x, window_pos.y,
+            window_pos.x + window_size.x, window_pos.y + window_size.y)
         let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
         if (g_inspector.diff_scroll_jump_pending || !hovered) {
             SetScrollY(g_inspector.diff_scroll_y)
@@ -1157,6 +1167,14 @@ def private draw_side_by_side_diff() {
     child(DIFF_RIGHT_PANE, (text = "after", size = float2(right_width, available.y),
             child_flags = ImGuiChildFlags.Borders,
             window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+        let window_pos = GetWindowPos()
+        let window_size = GetWindowSize()
+        let scrollbar_width = GetStyle().ScrollbarSize
+        g_inspector.diff_right_rect = float4(window_pos.x, window_pos.y,
+            window_pos.x + window_size.x, window_pos.y + window_size.y)
+        g_inspector.diff_scrollbar_rect = float4(
+            window_pos.x + window_size.x - scrollbar_width, window_pos.y,
+            window_pos.x + window_size.x, window_pos.y + window_size.y)
         let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
         if (g_inspector.diff_scroll_jump_pending || !hovered) {
             SetScrollY(g_inspector.diff_scroll_y)
@@ -1257,6 +1275,9 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         diff_current_hunk = g_inspector.diff_current_hunk,
         diff_scroll_y = g_inspector.diff_scroll_y,
         diff_split_fraction = g_inspector.diff_split_fraction,
+        diff_left_rect = g_inspector.diff_left_rect,
+        diff_right_rect = g_inspector.diff_right_rect,
+        diff_scrollbar_rect = g_inspector.diff_scrollbar_rect,
         syntax_choice = g_inspector.syntax_choice,
         resolved_language = g_inspector.resolved_language,
         binary = g_inspector.parsed.binary,

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -1139,7 +1139,7 @@ def private draw_side_by_side_diff() {
         let window_size = GetWindowSize()
         g_inspector.diff_left_rect = float4(window_pos.x, window_pos.y,
             window_pos.x + window_size.x, window_pos.y + window_size.y)
-        let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
+        let hovered = IsWindowHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem)
         if (g_inspector.diff_scroll_jump_pending || !hovered) {
             SetScrollY(g_inspector.diff_scroll_y)
         } else {
@@ -1175,7 +1175,7 @@ def private draw_side_by_side_diff() {
         g_inspector.diff_scrollbar_rect = float4(
             window_pos.x + window_size.x - scrollbar_width, window_pos.y,
             window_pos.x + window_size.x, window_pos.y + window_size.y)
-        let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
+        let hovered = IsWindowHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem)
         if (g_inspector.diff_scroll_jump_pending || !hovered) {
             SetScrollY(g_inspector.diff_scroll_y)
         } else {
@@ -1253,6 +1253,7 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         worktree_path = g_inspector.worktree_path,
         file_path = g_inspector.file_path,
         comparison = g_inspector.comparison,
+        zoom_percent = g_zoom_percent,
         diff_context = g_inspector.diff_context,
         diff_context_choice = g_inspector.diff_context_choice,
         mode = g_inspector.mode == GitInspectorMode.diff ? "diff" : "view",
@@ -1397,6 +1398,11 @@ def herder_file_inspector_mode(input : JsonValue?) : JsonValue? {
 }
 
 def private draw_file_inspector_window() {
+    let io & = unsafe(GetIO())
+    if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
+        if (io.MouseWheel > 0.0f) zoom_by(5)
+        elif (io.MouseWheel < 0.0f) zoom_by(-5)
+    }
     if (empty(g_inspector.file_path)) {
         text_disabled("Select a changed file")
         return

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -290,8 +290,10 @@ def private queue_inspector_prepare(status : string) {
             g_inspector.source_patch, g_inspector.source_view_text,
             g_inspector.resolved_language, g_inspector.source_view_base64,
             g_inspector.source_view_byte_count)) {
+        let failure = "File inspection preparation worker is unavailable"
         inspector_load_fail(g_inspector.prepare, generation,
-            "Diff preparation worker is unavailable")
+            failure)
+        g_inspector.error = failure
     }
 }
 

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -317,36 +317,36 @@ def private install_file_inspection(message : WatcherFileInspectionMessage const
 }
 
 def private drain_inspector_prepare_events() {
-    var draining = true
-    while (draining) {
-        draining = inspector_prepare_worker_try_event(g_prepare_worker) $(event : InspectorPrepareEvent#) {
-            if (event.kind == InspectorPrepareEventKind.started) {
-                inspector_load_start(g_inspector.prepare, event.generation,
-                    "Preparing diff...")
-            } elif (event.kind == InspectorPrepareEventKind.failed) {
-                if (inspector_load_fail(g_inspector.prepare,
-                        event.generation, clone_string(event.error))) {
-                    g_inspector.error = clone_string(event.error)
-                    g_inspector.prepare_elapsed_usec = event.elapsed_usec
-                }
-            } elif (event.kind == InspectorPrepareEventKind.completed) {
-                if (!inspector_load_succeed(g_inspector.prepare,
-                        event.generation)) return
-                release_inspector_content()
-                g_inspector.revision = event.generation
-                g_inspector.parsed := event.parsed
-                g_inspector.old_document := event.old_document
-                g_inspector.new_document := event.new_document
-                g_inspector.view_document := event.view_document
-                g_inspector.markdown_document := event.markdown_document
-                g_inspector.markdown_view := event.markdown_view
-                g_inspector.changed_source_ranges := event.changed_source_ranges
-                g_inspector.view_source = clone_string(event.view_source)
-                g_inspector.view_prepared = !event.parsed.binary
-                upload_inspector_preview(event)
-                g_inspector.error = ""
+    while (true) {
+        var event : InspectorPrepareEvent
+        if (!inspector_prepare_worker_take_event(g_prepare_worker, event)) break
+        if (event.kind == InspectorPrepareEventKind.started) {
+            inspector_load_start(g_inspector.prepare, event.generation,
+                "Preparing diff...")
+        } elif (event.kind == InspectorPrepareEventKind.failed) {
+            if (inspector_load_fail(g_inspector.prepare,
+                    event.generation, clone_string(event.error))) {
+                g_inspector.error = clone_string(event.error)
                 g_inspector.prepare_elapsed_usec = event.elapsed_usec
             }
+        } elif (event.kind == InspectorPrepareEventKind.completed) {
+            if (!inspector_load_succeed(g_inspector.prepare,
+                    event.generation)) continue
+            release_inspector_content()
+            g_inspector.revision = event.generation
+            g_inspector.parsed <- event.parsed
+            g_inspector.old_document <- event.old_document
+            g_inspector.new_document <- event.new_document
+            g_inspector.view_document <- event.view_document
+            g_inspector.markdown_document <- event.markdown_document
+            g_inspector.markdown_view <- event.markdown_view
+            g_inspector.changed_source_ranges <- event.changed_source_ranges
+            g_inspector.view_source = clone_string(event.view_source)
+            g_inspector.view_prepared = !g_inspector.parsed.binary
+            upload_inspector_preview(
+                unsafe(reinterpret<InspectorPrepareEvent const#>(event)))
+            g_inspector.error = ""
+            g_inspector.prepare_elapsed_usec = event.elapsed_usec
         }
     }
 }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -15,10 +15,13 @@ require clipboard/clipboard
 require daslib/safe_addr
 require daslib/json
 require daslib/json_boost
+require daslib/jobque_boost
+require daslib/utf8_utils
 require live/live_commands
 require ./watcher_core.das
 require ./repository_core.das
 require ./file_inspection.das
+require ./inspection_worker.das
 require math
 require strings
 
@@ -108,6 +111,8 @@ struct private GitInspectorState {
     status : string
     error : string
     revision : int
+    prepare : InspectorLoadState = InspectorLoadState()
+    prepare_elapsed_usec : int64
     mode : GitInspectorMode = GitInspectorMode.diff
     parsed : GitParsedPatch = GitParsedPatch()
     old_document : TextSourceDocument = TextSourceDocument()
@@ -142,6 +147,8 @@ var private g_selected_worktree_path : string
 var private g_selected_repository_id : string
 var private g_focus_terminal_pending = false
 var private g_inspector = GitInspectorState()
+var private g_prepare_worker = InspectorPrepareWorker()
+var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
@@ -266,42 +273,54 @@ def private install_file_inspection(message : WatcherFileInspectionMessage const
     g_inspector.status = message.status
     if (message.loading) return
     g_inspector.error = message.error
-    if (!empty(message.error)) return
-
-    var inscope parsed <- git_parse_unified_patch(message.patch)
-    if (!empty(parsed.error)) {
-        g_inspector.error = parsed.error
+    if (!empty(message.error)) {
+        inspector_load_fail(g_inspector.prepare,
+            g_inspector.prepare.generation, message.error)
         return
     }
-    release_inspector_content()
-    g_inspector.revision++
     let language = extension(g_inspector.file_path)
-    let view_source = (!empty(message.view_text)
-        ? message.view_text : parsed.new_text)
-    var old_document <- tree_sitter_source_document(
-        parsed.old_aligned_text, language, g_inspector.revision)
-    var new_document <- tree_sitter_source_document(
-        parsed.new_aligned_text, language, g_inspector.revision)
-    old_document.line_marks |> reserve(length(parsed.old_changed_lines))
-    new_document.line_marks |> reserve(length(parsed.new_changed_lines))
-    for (index in range(length(parsed.rows))) {
-        if (parsed.rows[index].old_kind == GitDiffLineKind.removed) {
-            old_document.line_marks |> push(TextSourceLineMark(
-                line_index = index, kind = TextSourceLineMarkKind.removed))
-        }
-        if (parsed.rows[index].new_kind == GitDiffLineKind.added) {
-            new_document.line_marks |> push(TextSourceLineMark(
-                line_index = index, kind = TextSourceLineMarkKind.added))
+    let generation = inspector_load_queue(
+        g_inspector.prepare, "Preparing diff...")
+    if (!inspector_prepare_worker_queue(g_prepare_worker, generation,
+            message.patch, message.view_text, language)) {
+        inspector_load_fail(g_inspector.prepare, generation,
+            "Diff preparation worker is unavailable")
+    }
+}
+
+def private drain_inspector_prepare_events() {
+    var draining = true
+    while (draining) {
+        draining = inspector_prepare_worker_try_event(g_prepare_worker) $(event : InspectorPrepareEvent#) {
+            if (event.kind == InspectorPrepareEventKind.started) {
+                inspector_load_start(g_inspector.prepare, event.generation,
+                    "Preparing diff...")
+            } elif (event.kind == InspectorPrepareEventKind.failed) {
+                if (inspector_load_fail(g_inspector.prepare,
+                        event.generation, clone_string(event.error))) {
+                    g_inspector.error = clone_string(event.error)
+                    g_inspector.prepare_elapsed_usec = event.elapsed_usec
+                }
+            } elif (event.kind == InspectorPrepareEventKind.completed) {
+                if (!inspector_load_succeed(g_inspector.prepare,
+                        event.generation)) return
+                release_inspector_content()
+                g_inspector.revision++
+                g_inspector.parsed := event.parsed
+                g_inspector.old_document := event.old_document
+                g_inspector.new_document := event.new_document
+                g_inspector.view_source = clone_string(event.view_source)
+                g_inspector.error = ""
+                g_inspector.prepare_elapsed_usec = event.elapsed_usec
+            }
         }
     }
-    g_inspector.parsed <- parsed
-    g_inspector.old_document <- old_document
-    g_inspector.new_document <- new_document
-    g_inspector.view_source = view_source
 }
 
 def private begin_file_inspection(repository_id, worktree_path, file_path,
                                   comparison : string) {
+    let same_identity = g_inspector.repository_id == repository_id && g_inspector.worktree_path == worktree_path && g_inspector.file_path == file_path && g_inspector.comparison == comparison
+    let same_content = g_inspector.prepare.has_retained_content && same_identity
     g_inspector.request_id++
     g_inspector.repository_id = repository_id
     g_inspector.worktree_path = worktree_path
@@ -311,7 +330,12 @@ def private begin_file_inspection(repository_id, worktree_path, file_path,
     g_inspector.loading = true
     g_inspector.status = "Requesting diff..."
     g_inspector.error = ""
-    release_inspector_content()
+    if (same_content) {
+        inspector_load_supersede(g_inspector.prepare, "Requesting diff...")
+    } else {
+        release_inspector_content()
+        inspector_load_reset(g_inspector.prepare)
+    }
     g_inspector.mode = GitInspectorMode.diff
     INSPECTOR_DIFF_TAB.pending_select = true
 }
@@ -911,6 +935,18 @@ def private syntax_style_cell_count(state : TextSourceViewState const;
     return count
 }
 
+def private inspector_request_state_name(state : InspectorRequestState) : string {
+    if (state == InspectorRequestState.queued) return "queued"
+    if (state == InspectorRequestState.running) return "running"
+    return "idle"
+}
+
+def private inspector_content_state_name(state : InspectorContentState) : string {
+    if (state == InspectorContentState.ready) return "ready"
+    if (state == InspectorContentState.failed) return "failed"
+    return "absent"
+}
+
 def private draw_side_by_side_diff() {
     let available = GetContentRegionAvail()
     let gap = GetStyle().ItemSpacing.x
@@ -1011,6 +1047,15 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         comparison = g_inspector.comparison,
         mode = g_inspector.mode == GitInspectorMode.diff ? "diff" : "view",
         loading = g_inspector.loading,
+        prepare_request = inspector_request_state_name(g_inspector.prepare.request),
+        prepare_outcome = inspector_content_state_name(
+            g_inspector.prepare.latest_outcome),
+        prepare_generation = g_inspector.prepare.generation,
+        prepare_has_retained_content = g_inspector.prepare.has_retained_content,
+        prepare_retained_generation = g_inspector.prepare.retained_generation,
+        prepare_status = g_inspector.prepare.status,
+        prepare_error = g_inspector.prepare.error,
+        prepare_elapsed_usec = g_inspector.prepare_elapsed_usec,
         status = g_inspector.status,
         error = g_inspector.error,
         task_session_id = g_inspector.task_session_id,
@@ -1020,6 +1065,9 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         new_changed_line_count = length(g_inspector.parsed.new_changed_lines),
         old_byte_count = length(g_inspector.parsed.old_text),
         new_byte_count = length(g_inspector.parsed.new_text),
+        new_document_byte_count = length(g_inspector.new_document.source),
+        new_document_utf8_valid = is_utf8_string_valid(
+            g_inspector.new_document.source),
         view_byte_count = length(g_inspector.view_source),
         view_prepared = g_inspector.view_prepared,
         old_line_mark_count = length(g_inspector.old_document.line_marks),
@@ -1093,12 +1141,16 @@ def herder_file_inspector_text(input : JsonValue?) : JsonValue? {
             syntax_span_count = length(g_inspector.old_document.spans)))
     }
     if (side == "after" || side == "new" || side == "view") {
-        let source = (side == "view"
-            ? g_inspector.view_source : g_inspector.parsed.new_text)
+        let is_view = side == "view"
+        let source = is_view ? g_inspector.view_source : g_inspector.parsed.new_text
         return JV((ok = true, side = side == "view" ? "view" : "after",
             text = source,
-            line_mark_count = length(g_inspector.view_document.line_marks),
-            syntax_span_count = length(g_inspector.view_document.spans)))
+            line_mark_count = is_view
+                ? length(g_inspector.view_document.line_marks)
+                : length(g_inspector.new_document.line_marks),
+            syntax_span_count = is_view
+                ? length(g_inspector.view_document.spans)
+                : length(g_inspector.new_document.spans)))
     }
     return JV((ok = false, error = "side must be before, after, or view"))
 }
@@ -1128,7 +1180,7 @@ def private draw_file_inspector_window() {
     if (g_inspector.loading) {
         text_disabled(INSPECTOR_LOADING,
             (text = empty(g_inspector.status) ? "Loading diff..." : g_inspector.status))
-        return
+        if (!g_inspector.prepare.has_retained_content) return
     }
     if (!empty(g_inspector.error)) {
         text_colored(INSPECTOR_ERROR,
@@ -1136,7 +1188,13 @@ def private draw_file_inspector_window() {
         if (!empty(g_inspector.task_session_id)) {
             text_disabled("Task: {g_inspector.task_session_id}")
         }
-        return
+        if (!g_inspector.prepare.has_retained_content) return
+    }
+    if (g_inspector.prepare.request != InspectorRequestState.idle) {
+        text_disabled(INSPECTOR_LOADING,
+            (text = empty(g_inspector.prepare.status)
+                ? "Preparing diff..." : g_inspector.prepare.status))
+        if (!g_inspector.prepare.has_retained_content) return
     }
     tab_bar(INSPECTOR_MODE_TABS,
             (text = "InspectorModes", flags = ImGuiTabBarFlags.None)) {
@@ -1200,6 +1258,9 @@ def init() {
     g_fonts = load_unicode_font_roles(14.0f, g_font_sources)
     g_terminal_font = g_fonts.monospace
     reset_terminal()
+    create_job_que()
+    g_jobque_owned = true
+    inspector_prepare_worker_start(g_prepare_worker)
     g_selected_worktree_path = get_das_root()
     SETTINGS_WIN.open = false
     let port = clamp(to_int(option_value("--port=", "9191")), 1024, 65535)
@@ -1220,6 +1281,7 @@ def init() {
 def update() {
     if (!harness_begin_frame()) return
     if (g_client != null) g_client->pump()
+    drain_inspector_prepare_events()
     harness_new_frame()
     GetStyle().FontScaleMain = float(g_zoom_percent) / 100.0f
     draw_main_menu()
@@ -1258,6 +1320,7 @@ def update() {
 
 [export]
 def shutdown() {
+    let prepare_stopped = inspector_prepare_worker_shutdown(g_prepare_worker)
     if (g_client != null) {
         g_client->close()
         g_client->cleanup()
@@ -1276,6 +1339,10 @@ def shutdown() {
     terminal_dispose(g_terminal)
     delete g_font_sources
     harness_shutdown()
+    if (g_jobque_owned && prepare_stopped) {
+        destroy_job_que()
+        g_jobque_owned = false
+    }
 }
 
 [export]

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -22,6 +22,7 @@ require ./watcher_core.das
 require ./repository_core.das
 require ./file_inspection.das
 require ./inspection_worker.das
+require ./image_preview_gl.das
 require math
 require strings
 
@@ -71,6 +72,8 @@ struct private WatcherFileInspectionMessage {
     loading : bool
     patch : string
     view_text : string
+    view_base64 : string
+    view_byte_count : int
     status : string
     error : string
 }
@@ -100,6 +103,11 @@ enum private GitInspectorMode {
     view
 }
 
+let INSPECTOR_SYNTAX_LABELS : array<string> <- [
+    "Auto", "Plain text", "daScript", "C", "C++", "Markdown", "JSON"]
+let INSPECTOR_SYNTAX_VALUES : array<string> <- [
+    "auto", "plain", "daslang", "c", "cpp", "markdown", "json"]
+
 struct private GitInspectorState {
     request_id : int
     repository_id : string
@@ -128,9 +136,21 @@ struct private GitInspectorState {
     view_source : string
     view_prepared : bool
     markdown_gutter_segments : int
+    source_patch : string
+    source_view_text : string
+    source_view_base64 : string
+    source_view_byte_count : int
+    syntax_choice : int
+    resolved_language : string
+    preview_texture : uint
+    preview_width : int
+    preview_height : int
+    preview_byte_count : int
+    preview_error : string
     diff_scroll_y : float
-    diff_left_hovered_last : bool
-    diff_right_hovered_last : bool
+    diff_scroll_jump_pending : bool
+    diff_split_fraction : float = 0.5f
+    diff_current_hunk : int
 }
 
 var private g_terminal = Terminal()
@@ -209,11 +229,6 @@ def private feed_terminal_frame(message : string#; byte_count : int) {
     }
 }
 
-def private markdown_file(path : string) : bool {
-    let lower = to_lower(path)
-    return ends_with(lower, ".md") || ends_with(lower, ".markdown")
-}
-
 def private changed_source_ranges(source : string;
                                   lines : array<int> const) : array<TextSourceRange> {
     var result : array<TextSourceRange>
@@ -246,7 +261,21 @@ def private changed_source_ranges(source : string;
     return <- result
 }
 
+def private upload_inspector_preview(event : InspectorPrepareEvent#) {
+    g_inspector.preview_width = event.preview_width
+    g_inspector.preview_height = event.preview_height
+    g_inspector.preview_byte_count = event.preview_byte_count
+    g_inspector.preview_error = clone_string(event.preview_error)
+    if (empty(event.preview_pixels)) return
+    inspector_preview_texture_upload(event.preview_pixels,
+        event.preview_width, event.preview_height,
+        g_inspector.preview_texture)
+}
+
 def private release_inspector_content() {
+    if (g_inspector.preview_texture != 0u) {
+        inspector_preview_texture_release(g_inspector.preview_texture)
+    }
     git_parsed_patch_dispose(g_inspector.parsed)
     text_source_view_invalidate(g_inspector.old_view)
     text_source_view_invalidate(g_inspector.new_view)
@@ -261,9 +290,29 @@ def private release_inspector_content() {
     g_inspector.view_source = ""
     g_inspector.view_prepared = false
     g_inspector.markdown_gutter_segments = 0
+    g_inspector.preview_width = 0
+    g_inspector.preview_height = 0
+    g_inspector.preview_byte_count = 0
+    g_inspector.preview_error = ""
     g_inspector.diff_scroll_y = 0.0f
-    g_inspector.diff_left_hovered_last = false
-    g_inspector.diff_right_hovered_last = false
+    g_inspector.diff_scroll_jump_pending = false
+    g_inspector.diff_current_hunk = 0
+}
+
+def private queue_inspector_prepare(status : string) {
+    let choice = clamp(g_inspector.syntax_choice, 0,
+        length(INSPECTOR_SYNTAX_VALUES) - 1)
+    g_inspector.resolved_language = inspector_language_for_path(
+        g_inspector.file_path, INSPECTOR_SYNTAX_VALUES[choice])
+    let generation = inspector_load_queue(g_inspector.prepare, status)
+    g_inspector.error = ""
+    if (!inspector_prepare_worker_queue(g_prepare_worker, generation,
+            g_inspector.source_patch, g_inspector.source_view_text,
+            g_inspector.resolved_language, g_inspector.source_view_base64,
+            g_inspector.source_view_byte_count)) {
+        inspector_load_fail(g_inspector.prepare, generation,
+            "Diff preparation worker is unavailable")
+    }
 }
 
 def private install_file_inspection(message : WatcherFileInspectionMessage const) {
@@ -278,14 +327,11 @@ def private install_file_inspection(message : WatcherFileInspectionMessage const
             g_inspector.prepare.generation, message.error)
         return
     }
-    let language = extension(g_inspector.file_path)
-    let generation = inspector_load_queue(
-        g_inspector.prepare, "Preparing diff...")
-    if (!inspector_prepare_worker_queue(g_prepare_worker, generation,
-            message.patch, message.view_text, language)) {
-        inspector_load_fail(g_inspector.prepare, generation,
-            "Diff preparation worker is unavailable")
-    }
+    g_inspector.source_patch = clone_string(message.patch)
+    g_inspector.source_view_text = clone_string(message.view_text)
+    g_inspector.source_view_base64 = clone_string(message.view_base64)
+    g_inspector.source_view_byte_count = message.view_byte_count
+    queue_inspector_prepare("Preparing diff...")
 }
 
 def private drain_inspector_prepare_events() {
@@ -310,6 +356,7 @@ def private drain_inspector_prepare_events() {
                 g_inspector.old_document := event.old_document
                 g_inspector.new_document := event.new_document
                 g_inspector.view_source = clone_string(event.view_source)
+                upload_inspector_preview(event)
                 g_inspector.error = ""
                 g_inspector.prepare_elapsed_usec = event.elapsed_usec
             }
@@ -330,6 +377,15 @@ def private begin_file_inspection(repository_id, worktree_path, file_path,
     g_inspector.loading = true
     g_inspector.status = "Requesting diff..."
     g_inspector.error = ""
+    if (!same_identity) {
+        g_inspector.source_patch = ""
+        g_inspector.source_view_text = ""
+        g_inspector.source_view_base64 = ""
+        g_inspector.source_view_byte_count = 0
+        g_inspector.syntax_choice = 0
+        g_inspector.resolved_language = inspector_language_for_path(file_path)
+        DIFF_SYNTAX.value = 0
+    }
     if (same_content) {
         inspector_load_supersede(g_inspector.prepare, "Requesting diff...")
     } else {
@@ -947,57 +1003,156 @@ def private inspector_content_state_name(state : InspectorContentState) : string
     return "absent"
 }
 
-def private draw_side_by_side_diff() {
+def private draw_binary_preview() {
+    text("Binary file ({g_inspector.preview_byte_count} bytes)")
+    if (g_inspector.preview_texture == 0u) {
+        text_disabled(INSPECTOR_BINARY_UNAVAILABLE,
+            (text = empty(g_inspector.preview_error)
+                ? "Preview unavailable"
+                : "Preview unavailable: {g_inspector.preview_error}"))
+        return
+    }
+    text_disabled(INSPECTOR_BINARY_DIMENSIONS,
+        (text = "Decoded by the bundled stb_image: " +
+            "{g_inspector.preview_width} x {g_inspector.preview_height}"))
     let available = GetContentRegionAvail()
-    let gap = GetStyle().ItemSpacing.x
-    let pane_width = max(1.0f, (available.x - gap) * 0.5f)
-    child(DIFF_LEFT_PANE, (text = "before", size = float2(pane_width, available.y),
+    let scale = min(1.0f, min(
+        available.x / max(1.0f, float(g_inspector.preview_width)),
+        available.y / max(1.0f, float(g_inspector.preview_height))))
+    unsafe {
+        image(INSPECTOR_BINARY_PREVIEW,
+            (user_texture_id = inspector_preview_texture_ref(
+                g_inspector.preview_texture),
+             size = float2(max(1.0f, float(g_inspector.preview_width) * scale),
+                           max(1.0f, float(g_inspector.preview_height) * scale)),
+             uv0 = float2(0.0f, 0.0f), uv1 = float2(1.0f, 1.0f),
+             tint_col = float4(1.0f, 1.0f, 1.0f, 1.0f),
+             border_col = float4(0.35f, 0.35f, 0.35f, 1.0f)))
+    }
+}
+
+def private draw_side_by_side_diff() {
+    if (g_inspector.parsed.binary) {
+        draw_binary_preview()
+        return
+    }
+    let hunk_count = length(g_inspector.parsed.hunks)
+    g_inspector.diff_current_hunk = hunk_count > 0 ? clamp(g_inspector.diff_current_hunk, 0, hunk_count - 1) : 0
+    SetNextItemWidth(150.0f)
+    combo(DIFF_SYNTAX, (text = "Syntax", items <- INSPECTOR_SYNTAX_LABELS))
+    let selected_syntax = clamp(DIFF_SYNTAX.value, 0,
+        length(INSPECTOR_SYNTAX_VALUES) - 1)
+    if (selected_syntax != g_inspector.syntax_choice) {
+        g_inspector.syntax_choice = selected_syntax
+        g_inspector.resolved_language = inspector_language_for_path(
+            g_inspector.file_path,
+            INSPECTOR_SYNTAX_VALUES[g_inspector.syntax_choice])
+        if (!empty(g_inspector.source_patch)) {
+            queue_inspector_prepare("Applying syntax...")
+        }
+    }
+    same_line()
+    if (small_button(DIFF_PREVIOUS_CHANGE, (text = "Previous change",
+            enabled = g_inspector.diff_current_hunk > 0))) {
+        g_inspector.diff_current_hunk = max(0,
+            g_inspector.diff_current_hunk - 1)
+        if (g_inspector.diff_current_hunk < hunk_count) {
+            let row = g_inspector.parsed.hunks[g_inspector.diff_current_hunk].row_start
+            g_inspector.diff_scroll_y = float(row) * max(
+                GetTextLineHeight(), g_inspector.new_view.key.line_height)
+            g_inspector.diff_scroll_jump_pending = true
+        }
+    }
+    same_line()
+    if (small_button(DIFF_NEXT_CHANGE, (text = "Next change",
+            enabled = g_inspector.diff_current_hunk + 1 < hunk_count))) {
+        g_inspector.diff_current_hunk = min(hunk_count - 1,
+            g_inspector.diff_current_hunk + 1)
+        if (g_inspector.diff_current_hunk >= 0
+                && g_inspector.diff_current_hunk < hunk_count) {
+            let row = g_inspector.parsed.hunks[g_inspector.diff_current_hunk].row_start
+            g_inspector.diff_scroll_y = float(row) * max(
+                GetTextLineHeight(), g_inspector.new_view.key.line_height)
+            g_inspector.diff_scroll_jump_pending = true
+        }
+    }
+    same_line()
+    text_disabled(DIFF_CHANGE_POSITION, (text = hunk_count > 0
+        ? "Change {g_inspector.diff_current_hunk + 1} of {hunk_count}"
+        : "No text changes"))
+
+    let available = GetContentRegionAvail()
+    let splitter_width = 8.0f
+    let usable_width = max(2.0f, available.x - splitter_width)
+    var left_width = usable_width * clamp(
+        g_inspector.diff_split_fraction, 0.12f, 0.88f)
+    var right_width = usable_width - left_width
+    let origin = GetCursorScreenPos()
+    let split_min = min(120.0f, usable_width * 0.4f)
+    let split_box = float4(origin.x + left_width, origin.y,
+        origin.x + left_width + splitter_width, origin.y + available.y)
+    let splitting = SplitterBehavior(split_box, GetID("git_diff_splitter"),
+        ImGuiAxis.X, left_width, right_width, split_min, split_min)
+    g_inspector.diff_split_fraction = left_width / max(1.0f, left_width + right_width)
+
+    child(DIFF_LEFT_PANE, (text = "before", size = float2(left_width, available.y),
             child_flags = ImGuiChildFlags.Borders,
-            window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+            window_flags = ImGuiWindowFlags.NoScrollbar)) {
         let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
-        let entering = hovered && !g_inspector.diff_left_hovered_last
-        if (!hovered || entering) SetScrollY(g_inspector.diff_scroll_y)
+        if (g_inspector.diff_scroll_jump_pending || !hovered) {
+            SetScrollY(g_inspector.diff_scroll_y)
+        } else {
+            g_inspector.diff_scroll_y = GetScrollY()
+        }
         text_disabled("BEFORE")
         separator()
         var style = source_view_style(true)
         let _ = text_source_view("git diff before", g_inspector.old_document,
             g_inspector.old_view, style)
-        if (hovered) {
-            g_inspector.diff_scroll_y = GetScrollY()
-        }
-        g_inspector.diff_left_hovered_last = hovered
     }
-    same_line()
-    child(DIFF_RIGHT_PANE, (text = "after", size = float2(pane_width, available.y),
+    same_line((spacing = 0.0f))
+    dummy(DIFF_SPLITTER_SPACE, (size = float2(splitter_width, available.y)))
+    let splitter_hot = IsItemHovered() || splitting
+    if (splitter_hot) SetMouseCursor(ImGuiMouseCursor.ResizeEW)
+    let splitter_color = GetColorU32(splitter_hot
+        ? ImGuiCol.SeparatorActive : ImGuiCol.Separator)
+    with_window_drawlist() $(var dl) {
+        dl |> add_line(
+            float2(origin.x + left_width + splitter_width * 0.5f, origin.y),
+            float2(origin.x + left_width + splitter_width * 0.5f,
+                origin.y + available.y), splitter_color, 1.0f)
+    }
+    same_line((spacing = 0.0f))
+    child(DIFF_RIGHT_PANE, (text = "after", size = float2(right_width, available.y),
             child_flags = ImGuiChildFlags.Borders,
             window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
         let hovered = IsWindowHovered(ImGuiHoveredFlags.None)
-        let entering = hovered && !g_inspector.diff_right_hovered_last
-        if (!hovered || entering) SetScrollY(g_inspector.diff_scroll_y)
+        if (g_inspector.diff_scroll_jump_pending || !hovered) {
+            SetScrollY(g_inspector.diff_scroll_y)
+        } else {
+            g_inspector.diff_scroll_y = GetScrollY()
+        }
         text_disabled("AFTER")
         separator()
         var style = source_view_style(true)
         let _ = text_source_view("git diff after", g_inspector.new_document,
             g_inspector.new_view, style)
-        if (hovered) {
-            g_inspector.diff_scroll_y = GetScrollY()
-        }
-        g_inspector.diff_right_hovered_last = hovered
     }
+    g_inspector.diff_scroll_jump_pending = false
 }
 
 def private prepare_file_view() {
     if (g_inspector.view_prepared) return
-    let language = extension(g_inspector.file_path)
     var view_document <- tree_sitter_source_document(
-        g_inspector.view_source, language, g_inspector.revision)
+        g_inspector.view_source, g_inspector.resolved_language,
+        g_inspector.revision)
     view_document.line_marks |> reserve(length(g_inspector.parsed.new_changed_lines))
     for (line in g_inspector.parsed.new_changed_lines) {
         view_document.line_marks |> push(TextSourceLineMark(
             line_index = line, kind = TextSourceLineMarkKind.added))
     }
     g_inspector.view_document <- view_document
-    if (markdown_file(g_inspector.file_path)) {
+    if (g_inspector.resolved_language == "markdown") {
         var markdown_document <- md_parse(g_inspector.view_source)
         var markdown_changes <- changed_source_ranges(
             g_inspector.view_source, g_inspector.parsed.new_changed_lines)
@@ -1008,11 +1163,15 @@ def private prepare_file_view() {
 }
 
 def private draw_file_view() {
+    if (g_inspector.parsed.binary) {
+        draw_binary_preview()
+        return
+    }
     prepare_file_view()
     child(FILE_VIEW_PANE, (text = "file view", size = float2(0.0f, 0.0f),
             child_flags = ImGuiChildFlags.None,
             window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
-        if (markdown_file(g_inspector.file_path)) {
+        if (g_inspector.resolved_language == "markdown") {
             var style = MarkdownViewStyle(
                 fonts = g_fonts,
                 typography = MarkdownTypography(
@@ -1061,6 +1220,18 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         task_session_id = g_inspector.task_session_id,
         revision = g_inspector.revision,
         diff_row_count = length(g_inspector.parsed.rows),
+        diff_hunk_count = length(g_inspector.parsed.hunks),
+        diff_current_hunk = g_inspector.diff_current_hunk,
+        diff_scroll_y = g_inspector.diff_scroll_y,
+        diff_split_fraction = g_inspector.diff_split_fraction,
+        syntax_choice = g_inspector.syntax_choice,
+        resolved_language = g_inspector.resolved_language,
+        binary = g_inspector.parsed.binary,
+        preview_texture_ready = g_inspector.preview_texture != 0u,
+        preview_width = g_inspector.preview_width,
+        preview_height = g_inspector.preview_height,
+        preview_byte_count = g_inspector.preview_byte_count,
+        preview_error = g_inspector.preview_error,
         old_changed_line_count = length(g_inspector.parsed.old_changed_lines),
         new_changed_line_count = length(g_inspector.parsed.new_changed_lines),
         old_byte_count = length(g_inspector.parsed.old_text),
@@ -1072,6 +1243,8 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         view_prepared = g_inspector.view_prepared,
         old_line_mark_count = length(g_inspector.old_document.line_marks),
         new_line_mark_count = length(g_inspector.new_document.line_marks),
+        old_line_number_count = length(g_inspector.old_document.line_numbers),
+        new_line_number_count = length(g_inspector.new_document.line_numbers),
         view_line_mark_count = length(g_inspector.view_document.line_marks),
         changed_source_range_count = length(g_inspector.changed_source_ranges),
         old_syntax_span_count = length(g_inspector.old_document.spans),
@@ -1253,6 +1426,7 @@ def private draw_terminal_window() {
 def init() {
     harness_init("dasHerd", 1280, 800)
     harness_maximize_window()
+    DIFF_SYNTAX.value = 0
     var io & = unsafe(GetIO())
     io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
     g_fonts = load_unicode_font_roles(14.0f, g_font_sources)

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -67,6 +67,9 @@ def test_binary_patch_detection(t : T?) {
         t |> equal(git_patch_is_binary(binary_patch), true)
         let literal_patch = "diff --git a/image.png b/image.png\nGIT binary patch\nliteral 0\n"
         t |> equal(git_patch_is_binary(literal_patch), true)
+        let deleted_patch = "diff --git a/old.txt b/old.txt\ndeleted file mode 100644\n--- a/old.txt\n+++ /dev/null\n"
+        t |> equal(git_patch_result_is_deleted(deleted_patch), true)
+        t |> equal(git_patch_result_is_deleted(text_patch), false)
     }
 }
 

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -1,0 +1,23 @@
+options gen2
+
+require dastest/testing_boost public
+require ../file_inspection.das
+
+[test]
+def test_unified_patch_projection(t : T?) {
+    t |> run("unified hunks become aligned Diff and resulting View text") <| @(t : T?) {
+        let source = "diff --git a/sample.das b/sample.das\n--- a/sample.das\n+++ b/sample.das\n@@ -1,4 +1,5 @@\n options gen2\n-let old = 1\n+let next = 2\n+let added = 3\n keep()\n-last()\n"
+        var inscope parsed <- git_parse_unified_patch(source)
+        t |> equal(parsed.error, "")
+        t |> equal(parsed.old_text, "options gen2\nlet old = 1\nkeep()\nlast()")
+        t |> equal(parsed.new_text, "options gen2\nlet next = 2\nlet added = 3\nkeep()")
+        t |> equal(length(parsed.rows), 5)
+        t |> equal(parsed.rows[1].old_kind, GitDiffLineKind.removed)
+        t |> equal(parsed.rows[1].new_kind, GitDiffLineKind.added)
+        t |> equal(parsed.rows[2].old_kind, GitDiffLineKind.empty)
+        t |> equal(parsed.rows[2].new_kind, GitDiffLineKind.added)
+        t |> equal(parsed.rows[4].old_kind, GitDiffLineKind.removed)
+        t |> equal(parsed.rows[4].new_kind, GitDiffLineKind.empty)
+        t |> equal(length(parsed.new_changed_lines), 2)
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -38,6 +38,9 @@ def test_unified_patch_projection(t : T?) {
         t |> equal(parsed.rows[4].old_kind, GitDiffLineKind.removed)
         t |> equal(parsed.rows[4].new_kind, GitDiffLineKind.empty)
         t |> equal(length(parsed.new_changed_lines), 2)
+        t |> equal(length(parsed.new_deleted_anchors), 1)
+        t |> equal(parsed.new_deleted_anchors[0], 4,
+            "EOF deletion is anchored after the fourth resulting line")
     }
     t |> run("separated hunks retain navigation boundaries") <| @(tt : T?) {
         let source = "diff --git a/a.das b/a.das\n--- a/a.das\n+++ b/a.das\n@@ -2,2 +2,2 @@\n-old one\n+new one\n keep\n@@ -20 +20 @@\n-old two\n+new two\n"

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -4,6 +4,22 @@ require dastest/testing_boost public
 require ../file_inspection.das
 
 [test]
+def test_inspector_language_resolution(t : T?) {
+    t |> run("auto syntax resolves compound local filenames") <| @(tt : T?) {
+        tt |> equal(inspector_language_for_path("notes.md.local"), "markdown")
+        tt |> equal(inspector_language_for_path("DATA.JSON.LOCAL"), "json")
+        tt |> equal(inspector_language_for_path("src/widget.cpp"), "cpp")
+        tt |> equal(inspector_language_for_path("script.das"), "daslang")
+        tt |> equal(inspector_language_for_path("README"), "")
+    }
+    t |> run("explicit syntax overrides auto and supports plain text") <| @(tt : T?) {
+        tt |> equal(inspector_language_for_path("wrong.bin", "C++"), "cpp")
+        tt |> equal(inspector_language_for_path("sample.das", "plain"), "")
+        tt |> equal(inspector_language_for_path("sample.txt", "markdown"), "markdown")
+    }
+}
+
+[test]
 def test_unified_patch_projection(t : T?) {
     t |> run("unified hunks become aligned Diff and resulting View text") <| @(t : T?) {
         let source = "diff --git a/sample.das b/sample.das\n--- a/sample.das\n+++ b/sample.das\n@@ -1,4 +1,5 @@\n options gen2\n-let old = 1\n+let next = 2\n+let added = 3\n keep()\n-last()\n"
@@ -12,6 +28,9 @@ def test_unified_patch_projection(t : T?) {
         t |> equal(parsed.old_text, "options gen2\nlet old = 1\nkeep()\nlast()")
         t |> equal(parsed.new_text, "options gen2\nlet next = 2\nlet added = 3\nkeep()")
         t |> equal(length(parsed.rows), 5)
+        t |> equal(length(parsed.hunks), 1)
+        t |> equal(parsed.hunks[0].row_start, 0)
+        t |> equal(parsed.hunks[0].row_count, 5)
         t |> equal(parsed.rows[1].old_kind, GitDiffLineKind.removed)
         t |> equal(parsed.rows[1].new_kind, GitDiffLineKind.added)
         t |> equal(parsed.rows[2].old_kind, GitDiffLineKind.empty)
@@ -19,6 +38,20 @@ def test_unified_patch_projection(t : T?) {
         t |> equal(parsed.rows[4].old_kind, GitDiffLineKind.removed)
         t |> equal(parsed.rows[4].new_kind, GitDiffLineKind.empty)
         t |> equal(length(parsed.new_changed_lines), 2)
+    }
+    t |> run("separated hunks retain navigation boundaries") <| @(tt : T?) {
+        let source = "diff --git a/a.das b/a.das\n--- a/a.das\n+++ b/a.das\n@@ -2,2 +2,2 @@\n-old one\n+new one\n keep\n@@ -20 +20 @@\n-old two\n+new two\n"
+        var inscope parsed <- git_parse_unified_patch(source)
+        tt |> equal(parsed.error, "")
+        tt |> equal(length(parsed.hunks), 2)
+        tt |> equal(parsed.hunks[0].row_start, 0)
+        tt |> equal(parsed.hunks[0].row_count, 2)
+        tt |> equal(parsed.hunks[0].old_start, 2)
+        tt |> equal(parsed.hunks[0].new_start, 2)
+        tt |> equal(parsed.hunks[1].row_start, 2)
+        tt |> equal(parsed.hunks[1].row_count, 1)
+        tt |> equal(parsed.hunks[1].old_start, 20)
+        tt |> equal(parsed.hunks[1].new_start, 20)
     }
 }
 

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -56,6 +56,17 @@ def test_unified_patch_projection(t : T?) {
         tt |> equal(parsed.hunks[1].old_start, 20)
         tt |> equal(parsed.hunks[1].new_start, 20)
     }
+    t |> run("header-only Git diffs remain valid") <| @(tt : T?) {
+        let source = "diff --git a/old.das b/new.das\nsimilarity index 100%\nrename from old.das\nrename to new.das\n"
+        var inscope parsed <- git_parse_unified_patch(source)
+        tt |> equal(parsed.error, "")
+        tt |> equal(parsed.binary, false)
+        tt |> equal(length(parsed.hunks), 0)
+        tt |> equal(length(parsed.rows), 0)
+
+        var inscope invalid <- git_parse_unified_patch("not a Git diff")
+        tt |> equal(invalid.error, "diff contains no text hunks")
+    }
 }
 
 [test]

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -56,6 +56,18 @@ def test_unified_patch_projection(t : T?) {
 }
 
 [test]
+def test_binary_patch_detection(t : T?) {
+    t |> run("binary markers are metadata lines, not text payload substrings") <| @(t : T?) {
+        let text_patch = "diff --git a/note.txt b/note.txt\n@@ -1 +1 @@\n-old\n+Binary files are discussed here\n+GIT binary patch\n"
+        t |> equal(git_patch_is_binary(text_patch), false)
+        let binary_patch = "diff --git a/image.png b/image.png\nBinary files a/image.png and b/image.png differ\n"
+        t |> equal(git_patch_is_binary(binary_patch), true)
+        let literal_patch = "diff --git a/image.png b/image.png\nGIT binary patch\nliteral 0\n"
+        t |> equal(git_patch_is_binary(literal_patch), true)
+    }
+}
+
+[test]
 def test_inspector_load_state(t : T?) {
     t |> run("replacement retains ready content until the matching result arrives") <| @(t : T?) {
         var state = InspectorLoadState()

--- a/utils/dasHerd/watcher/tests/test_file_inspection.das
+++ b/utils/dasHerd/watcher/tests/test_file_inspection.das
@@ -21,3 +21,69 @@ def test_unified_patch_projection(t : T?) {
         t |> equal(length(parsed.new_changed_lines), 2)
     }
 }
+
+[test]
+def test_inspector_load_state(t : T?) {
+    t |> run("replacement retains ready content until the matching result arrives") <| @(t : T?) {
+        var state = InspectorLoadState()
+        let first = inspector_load_queue(state, "Queued first")
+        t |> equal(first, 1)
+        t |> equal(state.request, InspectorRequestState.queued)
+        t |> equal(inspector_load_start(state, first), true)
+        t |> equal(inspector_load_succeed(state, first), true)
+        t |> equal(state.has_retained_content, true)
+        t |> equal(state.retained_generation, first)
+
+        let replacement = inspector_load_queue(state, "Queued replacement")
+        t |> equal(state.request, InspectorRequestState.queued)
+        t |> equal(state.has_retained_content, true)
+        t |> equal(state.retained_generation, first)
+        t |> equal(inspector_load_start(state, replacement), true)
+        t |> equal(inspector_load_fail(state, replacement, "parse failed"), true)
+        t |> equal(state.latest_outcome, InspectorContentState.failed)
+        t |> equal(state.has_retained_content, true)
+        t |> equal(state.retained_generation, first)
+        t |> equal(state.error, "parse failed")
+    }
+
+    t |> run("superseded worker events cannot mutate the current generation") <| @(t : T?) {
+        var state = InspectorLoadState()
+        let stale = inspector_load_queue(state)
+        let current = inspector_load_queue(state)
+        t |> equal(inspector_load_start(state, stale), false)
+        t |> equal(inspector_load_succeed(state, stale), false)
+        t |> equal(inspector_load_fail(state, stale, "stale failure"), false)
+        t |> equal(state.generation, current)
+        t |> equal(state.request, InspectorRequestState.queued)
+        t |> equal(state.error, "")
+        t |> equal(inspector_load_start(state, current), true)
+        t |> equal(inspector_load_succeed(state, current), true)
+        t |> equal(state.retained_generation, current)
+    }
+
+    t |> run("reset invalidates in-flight events and removes retained content") <| @(t : T?) {
+        var state = InspectorLoadState()
+        let generation = inspector_load_queue(state)
+        t |> equal(inspector_load_start(state, generation), true)
+        inspector_load_reset(state)
+        t |> equal(inspector_load_succeed(state, generation), false)
+        t |> equal(state.request, InspectorRequestState.idle)
+        t |> equal(state.latest_outcome, InspectorContentState.absent)
+        t |> equal(state.has_retained_content, false)
+    }
+
+    t |> run("superseding a refresh invalidates work but retains installed content") <| @(t : T?) {
+        var state = InspectorLoadState()
+        let ready = inspector_load_queue(state)
+        let started = inspector_load_start(state, ready)
+        let succeeded = inspector_load_succeed(state, ready)
+        t |> equal(started && succeeded, true)
+        inspector_load_supersede(state, "Requesting diff...")
+        t |> equal(state.generation, ready + 1)
+        t |> equal(state.request, InspectorRequestState.idle)
+        t |> equal(state.has_retained_content, true)
+        t |> equal(state.retained_generation, ready)
+        t |> equal(state.status, "Requesting diff...")
+        t |> equal(inspector_load_fail(state, ready, "stale"), false)
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -180,11 +180,34 @@ def test_inspection_prepare_worker(t : T?) {
         tt |> equal(inspector_prepare_worker_shutdown(worker), true)
         destroy_job_que()
     }
-    t |> run("explicit empty full View does not fall back to diff context") <| @(tt : T?) {
+    t |> run("empty binary preview completes without decoding") <| @(tt : T?) {
         create_job_que()
         var worker = InspectorPrepareWorker()
         tt |> equal(inspector_prepare_worker_start(worker), true)
         tt |> equal(inspector_prepare_worker_queue(worker, 15,
+            "diff --git a/empty.bin b/empty.bin\nBinary files a/empty.bin and b/empty.bin differ\n",
+            "", "", "", 0), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> equal(event.parsed.binary, true)
+                    tt |> equal(event.preview_error, "Binary preview is empty")
+                    tt |> equal(empty(event.preview_pixels), true)
+                }
+            }
+        }
+        tt |> equal(completed, true)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+    t |> run("explicit empty full View does not fall back to diff context") <| @(tt : T?) {
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 16,
             "diff --git a/old.txt b/old.txt\ndeleted file mode 100644\n--- a/old.txt\n+++ /dev/null\n@@ -1 +0,0 @@\n-old\n",
             "", "plain", "", 0, true), true)
         var completed = false

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -156,7 +156,7 @@ def test_inspection_prepare_worker(t : T?) {
         destroy_job_que()
     }
     t |> run("unsupported binary completes with an unavailable-preview reason") <| @(tt : T?) {
-        var bytes : array<uint8> <- [uint8(0), uint8(1), uint8(2), uint8(3)]
+        let bytes : array<uint8> <- [uint8(0), uint8(1), uint8(2), uint8(3)]
         let encoded = base64_encode(bytes)
         create_job_que()
         var worker = InspectorPrepareWorker()

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -180,4 +180,26 @@ def test_inspection_prepare_worker(t : T?) {
         tt |> equal(inspector_prepare_worker_shutdown(worker), true)
         destroy_job_que()
     }
+    t |> run("explicit empty full View does not fall back to diff context") <| @(tt : T?) {
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 15,
+            "diff --git a/old.txt b/old.txt\ndeleted file mode 100644\n--- a/old.txt\n+++ /dev/null\n@@ -1 +0,0 @@\n-old\n",
+            "", "plain", "", 0, true), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> equal(event.view_source, "")
+                    tt |> equal(event.view_document.source, "")
+                }
+            }
+        }
+        tt |> equal(completed, true)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
 }

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -6,6 +6,8 @@ require dastest/testing_boost public
 require ../inspection_worker.das
 require daslib/jobque_boost
 require daslib/utf8_utils
+require daslib/base64
+require daslib/fio
 require imgui/imgui_text_tree_sitter
 
 [test]
@@ -42,6 +44,10 @@ def test_inspection_prepare_worker(t : T?) {
                     span_count = length(event.new_document.spans)
                     t |> equal(event.generation, 7)
                     t |> equal(length(event.parsed.rows), 1)
+                    t |> equal(length(event.old_document.line_numbers), 1)
+                    t |> equal(length(event.new_document.line_numbers), 1)
+                    t |> equal(event.old_document.line_numbers[0], 1)
+                    t |> equal(event.new_document.line_numbers[0], 1)
                     t |> equal(event.view_source,
                         "options gen2\nlet answer = \"🐑\"\n")
                 }
@@ -74,6 +80,69 @@ def test_inspection_prepare_worker(t : T?) {
         }
         tt |> equal(failed, true)
         tt |> equal(empty(failure), false)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+    t |> run("binary image bytes decode off-thread with exact transport size") <| @(tt : T?) {
+        var encoded = ""
+        var byte_count = 0
+        fopen("3rdparty/fmt/doc/html/_static/file.png", "rb") $(file) {
+            if (file != null) {
+                fmap(file) $(var data : array<uint8>#) {
+                    byte_count = length(data)
+                    encoded = base64_encode(data)
+                }
+            }
+        }
+        tt |> success(byte_count > 0, "tracked PNG fixture is readable")
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 13,
+            "diff --git a/file.png b/file.png\nBinary files a/file.png and b/file.png differ\n",
+            "", "", encoded, byte_count), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> equal(event.parsed.binary, true)
+                    tt |> equal(event.preview_byte_count, byte_count)
+                    tt |> equal(event.preview_error, "")
+                    tt |> success(event.preview_width > 0 && event.preview_height > 0,
+                        "stb_image reports image dimensions")
+                    tt |> equal(length(event.preview_pixels),
+                        event.preview_width * event.preview_height * 4)
+                }
+            }
+        }
+        tt |> equal(completed, true)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+    t |> run("unsupported binary completes with an unavailable-preview reason") <| @(tt : T?) {
+        var bytes : array<uint8> <- [uint8(0), uint8(1), uint8(2), uint8(3)]
+        let encoded = base64_encode(bytes)
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 14,
+            "diff --git a/file.bin b/file.bin\nBinary files a/file.bin and b/file.bin differ\n",
+            "", "", encoded, length(bytes)), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> equal(event.parsed.binary, true)
+                    tt |> equal(empty(event.preview_pixels), true)
+                    tt |> equal(empty(event.preview_error), false)
+                }
+            }
+        }
+        tt |> equal(completed, true)
         tt |> equal(inspector_prepare_worker_shutdown(worker), true)
         destroy_job_que()
     }

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -1,0 +1,80 @@
+options gen2
+options gc
+options persistent_heap
+
+require dastest/testing_boost public
+require ../inspection_worker.das
+require daslib/jobque_boost
+require daslib/utf8_utils
+require imgui/imgui_text_tree_sitter
+
+[test]
+def test_inspection_prepare_worker(t : T?) {
+    t |> run("installed syntax providers highlight representative Diff sources") <| @(tt : T?) {
+        var cpp <- tree_sitter_source_document(
+            "#include <string>\n\nstatic std::string greeting() \{\n    const auto value = std::string\{\"working tree\"\};\n    return value;\n\}\n",
+            "cpp", 1)
+        tt |> equal(length(cpp.spans) > 1, true)
+        text_source_document_dispose(cpp)
+    }
+    t |> run("worker prepares syntax off-thread and shuts down cleanly") <| @(t : T?) {
+        t |> equal(is_utf8_string_valid("Καλημέρα, мир, こんにちは, 🐑"), true)
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        t |> equal(inspector_prepare_worker_start(worker), true)
+        t |> equal(inspector_prepare_worker_queue(worker, 7,
+            "diff --git a/a.das b/a.das\n--- a/a.das\n+++ b/a.das\n@@ -1 +1 @@\n-let answer = 41\n+let answer = \"🐑\"\n",
+            "options gen2\nlet answer = \"🐑\"\n", "das"), true)
+
+        var ready = false
+        var started = false
+        var completed = false
+        var span_count = 0
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.ready) {
+                    ready = true
+                } elif (event.kind == InspectorPrepareEventKind.started) {
+                    started = true
+                } elif (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    span_count = length(event.new_document.spans)
+                    t |> equal(event.generation, 7)
+                    t |> equal(length(event.parsed.rows), 1)
+                    t |> equal(event.view_source,
+                        "options gen2\nlet answer = \"🐑\"\n")
+                }
+            }
+        }
+        t |> equal(ready, true)
+        t |> equal(started, true)
+        t |> equal(completed, true)
+        t |> equal(span_count > 1, true)
+        t |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+    t |> run("worker reports malformed patches and still shuts down") <| @(tt : T?) {
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 11,
+            "not a unified patch", "", "das"), true)
+        var failed = false
+        var failure = ""
+        let wait_started = ref_time_ticks()
+        while (!failed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.failed) {
+                    failed = true
+                    failure = clone_string(event.error)
+                    tt |> equal(event.generation, 11)
+                }
+            }
+        }
+        tt |> equal(failed, true)
+        tt |> equal(empty(failure), false)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -50,6 +50,10 @@ def test_inspection_prepare_worker(t : T?) {
                     t |> equal(event.new_document.line_numbers[0], 1)
                     t |> equal(event.view_source,
                         "options gen2\nlet answer = \"🐑\"\n")
+                    t |> success(length(event.view_document.spans) > 1,
+                        "full View syntax is prepared by the worker")
+                    t |> equal(length(event.view_document.line_marks), 1,
+                        "full View change marks are prepared by the worker")
                 }
             }
         }
@@ -58,6 +62,35 @@ def test_inspection_prepare_worker(t : T?) {
         t |> equal(completed, true)
         t |> equal(span_count > 1, true)
         t |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+    t |> run("worker prepares Markdown View parsing and fenced syntax") <| @(tt : T?) {
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        let patch = "diff --git a/readme.md b/readme.md\n--- a/readme.md\n+++ b/readme.md\n@@ -1,5 +1,5 @@\n-# Old\n+# New\n \n ```das\n let answer = 42\n ```\n"
+        let view = "# New\n\n```das\nlet answer = 42\n```\n"
+        tt |> equal(inspector_prepare_worker_queue(
+            worker, 9, patch, view, "markdown"), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> success(event.markdown_document.ok,
+                        "Markdown View parses off-thread")
+                    tt |> success(length(event.view_document.spans) > 1,
+                        "Markdown source View is styled off-thread")
+                    tt |> equal(length(event.changed_source_ranges), 1,
+                        "Markdown change gutter ranges are prepared off-thread")
+                    tt |> success(!empty(event.markdown_view.syntax_bindings),
+                        "fenced code syntax is prepared off-thread")
+                }
+            }
+        }
+        tt |> equal(completed, true)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
         destroy_job_que()
     }
     t |> run("worker reports malformed patches and still shuts down") <| @(tt : T?) {

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -76,7 +76,7 @@ def test_inspection_prepare_worker(t : T?) {
         var completed = false
         let wait_started = ref_time_ticks()
         while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
                 if (event.kind == InspectorPrepareEventKind.completed) {
                     completed = true
                     tt |> success(event.markdown_document.ok,
@@ -104,7 +104,7 @@ def test_inspection_prepare_worker(t : T?) {
         var failure = ""
         let wait_started = ref_time_ticks()
         while (!failed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
                 if (event.kind == InspectorPrepareEventKind.failed) {
                     failed = true
                     failure = clone_string(event.error)
@@ -138,7 +138,7 @@ def test_inspection_prepare_worker(t : T?) {
         var completed = false
         let wait_started = ref_time_ticks()
         while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
                 if (event.kind == InspectorPrepareEventKind.completed) {
                     completed = true
                     tt |> equal(event.parsed.binary, true)
@@ -167,7 +167,7 @@ def test_inspection_prepare_worker(t : T?) {
         var completed = false
         let wait_started = ref_time_ticks()
         while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
                 if (event.kind == InspectorPrepareEventKind.completed) {
                     completed = true
                     tt |> equal(event.parsed.binary, true)
@@ -190,7 +190,7 @@ def test_inspection_prepare_worker(t : T?) {
         var completed = false
         let wait_started = ref_time_ticks()
         while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
                 if (event.kind == InspectorPrepareEventKind.completed) {
                     completed = true
                     tt |> equal(event.parsed.binary, true)
@@ -213,7 +213,7 @@ def test_inspection_prepare_worker(t : T?) {
         var completed = false
         let wait_started = ref_time_ticks()
         while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
                 if (event.kind == InspectorPrepareEventKind.completed) {
                     completed = true
                     tt |> equal(event.view_source, "")

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -34,7 +34,8 @@ def test_inspection_prepare_worker(t : T?) {
         var span_count = 0
         let wait_started = ref_time_ticks()
         while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
-            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent#) {
+            var event : InspectorPrepareEvent
+            if (inspector_prepare_worker_take_event(worker, event)) {
                 if (event.kind == InspectorPrepareEventKind.ready) {
                     ready = true
                 } elif (event.kind == InspectorPrepareEventKind.started) {

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -51,8 +51,9 @@ def test_repository_untracked_diff_contract(t : T?) {
             "D:/Work/tree", file, "working", argv, expected_exit_code)
         t |> equal(error, "")
         t |> equal(expected_exit_code, 1l)
-        t |> equal(argv[7], "--no-index")
-        t |> equal(argv[9], "--unified=3")
+        t |> equal(argv[1], "--literal-pathspecs")
+        t |> equal(argv[8], "--no-index")
+        t |> equal(argv[10], "--unified=3")
         var forces_text = false
         for (argument in argv) {
             if (argument == "--text") {
@@ -70,21 +71,28 @@ def test_repository_untracked_diff_contract(t : T?) {
             "D:/Work/tree", staged_file, "staged", argv, expected_exit_code)
         t |> equal(staged_error, "")
         t |> equal(expected_exit_code, 0l)
-        t |> equal(argv[7], "--cached")
-        t |> equal(argv[9], "--unified=3")
+        t |> equal(argv[8], "--cached")
+        t |> equal(argv[10], "--unified=3")
         t |> equal(argv[length(argv) - 1], "staged.das")
 
         let full_error = repository_build_file_diff_argv(
             "D:/Work/tree", staged_file, "staged", argv,
             expected_exit_code, "full")
         t |> equal(full_error, "")
-        t |> equal(argv[9], "--unified=1000000")
+        t |> equal(argv[10], "--unified=1000000")
 
         let expanded_error = repository_build_file_diff_argv(
             "D:/Work/tree", staged_file, "staged", argv,
             expected_exit_code, "expanded")
         t |> equal(expanded_error, "")
-        t |> equal(argv[9], "--unified=20")
+        t |> equal(argv[10], "--unified=20")
+
+        let magic_file = GitFileState(code = " M", path = ":(glob)**.das")
+        let magic_error = repository_build_file_diff_argv(
+            "D:/Work/tree", magic_file, "working", argv, expected_exit_code)
+        t |> equal(magic_error, "")
+        t |> equal(argv[1], "--literal-pathspecs")
+        t |> equal(argv[length(argv) - 1], ":(glob)**.das")
 
         let staged_view_error = repository_staged_file_view_argv(
             "D:/Work/tree", "staged.das", "D:/Temp/staged-view.raw", argv)

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -130,6 +130,10 @@ def test_repository_text_read_contract(t : T?) {
 
         let bytes_path = path_join(root, "bytes.bin")
         t |> success(fwrite(bytes_path, "abc"), "byte fixture is written")
+        var preview_path = ""
+        t |> equal(repository_working_preview_path(
+            root, "bytes.bin", preview_path), "")
+        t |> equal(preview_path, bytes_path)
         t |> success(!empty(repository_read_text_file(bytes_path, 2, text)),
             "text View rejects files beyond its raw-byte limit")
         var bytes : array<uint8>

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -60,7 +60,8 @@ def test_repository_untracked_diff_contract(t : T?) {
             }
         }
         t |> equal(forces_text, false, "Git retains native binary detection")
-        t |> equal(argv[length(argv) - 2], "NUL")
+        let null_device = get_platform_name() == "windows" ? "NUL" : "/dev/null"
+        t |> equal(argv[length(argv) - 2], null_device)
         t |> equal(argv[length(argv) - 1], "new file.das")
 
         let staged_file = GitFileState(code = "M ", path = "staged.das")

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -87,3 +87,18 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(argv[9], "--unified=20")
     }
 }
+
+[test]
+def test_repository_relative_file_path_contract(t : T?) {
+    t |> run("file previews cannot escape their observed worktree") <| @(t : T?) {
+        t |> success(repository_valid_relative_file_path("src/main.das"))
+        t |> success(!repository_valid_relative_file_path("../outside.txt"))
+        t |> success(!repository_valid_relative_file_path("src/../../outside.txt"))
+        t |> success(!repository_valid_relative_file_path("/etc/passwd"))
+        t |> success(!repository_valid_relative_file_path("\\\\server\\share\\file.txt"))
+        if (get_platform_name() == "windows") {
+            t |> success(!repository_valid_relative_file_path("C:\\Windows\\win.ini"))
+            t |> success(!repository_valid_relative_file_path("C:drive-relative.txt"))
+        }
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -85,6 +85,13 @@ def test_repository_untracked_diff_contract(t : T?) {
             expected_exit_code, "expanded")
         t |> equal(expanded_error, "")
         t |> equal(argv[9], "--unified=20")
+
+        let staged_view_error = repository_staged_file_view_argv(
+            "D:/Work/tree", "staged.das", "D:/Temp/staged-view.raw", argv)
+        t |> equal(staged_view_error, "")
+        t |> equal(argv[length(argv) - 2],
+            "--output=D:/Temp/staged-view.raw")
+        t |> equal(argv[length(argv) - 1], ":0:staged.das")
     }
 }
 
@@ -116,10 +123,21 @@ def test_repository_text_read_contract(t : T?) {
         t |> success(fwrite(empty_path, ""), "empty fixture is written")
 
         var text : string
-        t |> equal(repository_read_text_file(empty_path, text), "")
+        t |> equal(repository_read_text_file(empty_path, 1024, text), "")
         t |> equal(text, "", "an opened empty file is a successful preview")
-        t |> success(!empty(repository_read_text_file(root, text)),
+        t |> success(!empty(repository_read_text_file(root, 1024, text)),
             "a path that cannot be read as a regular file reports an error")
+
+        let bytes_path = path_join(root, "bytes.bin")
+        t |> success(fwrite(bytes_path, "abc"), "byte fixture is written")
+        t |> success(!empty(repository_read_text_file(bytes_path, 2, text)),
+            "text View rejects files beyond its raw-byte limit")
+        var bytes : array<uint8>
+        var byte_count = 0
+        t |> equal(repository_read_file_bytes(
+            bytes_path, 3, bytes, byte_count), "")
+        t |> equal(byte_count, 3)
+        t |> equal(string(bytes), "abc")
 
         rmdir_rec(root)
     }

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -19,16 +19,18 @@ def test_repository_porcelain_parsing(t : T?) {
             "detached, locked, and prunable markers are retained")
 
         var files : array<GitFileState>
-        repository_parse_status("## main-feature...origin/main [ahead 2, behind 3]\r\nM  staged file.das\r\n M unstaged file.das\r\n?? new file.txt\r\nUU conflict.txt\r\nR  old name -> new name\r\n", worktrees[0], files)
+        repository_parse_status("## main-feature...origin/main [ahead 2, behind 3]\r\nM  staged file.das\r\n M unstaged file.das\r\n?? new file.txt\r\nUU conflict.txt\r\nR  old name -> new name\r\n M literal -> name.txt\r\n", worktrees[0], files)
         t |> equal(worktrees[0].ahead, 2)
         t |> equal(worktrees[0].behind, 3)
         t |> equal(worktrees[0].staged, 3)
-        t |> equal(worktrees[0].unstaged, 2)
+        t |> equal(worktrees[0].unstaged, 3)
         t |> equal(worktrees[0].untracked, 1)
         t |> equal(worktrees[0].conflicted, 1)
-        t |> equal(length(files), 5)
+        t |> equal(length(files), 6)
         t |> equal(files[4].old_path, "old name")
         t |> equal(files[4].path, "new name")
+        t |> equal(files[5].old_path, "")
+        t |> equal(files[5].path, "literal -> name.txt")
         t |> equal(files[0].worktree_path, "D:/Work/daScript")
     }
     t |> run("unquoted porcelain retains UTF-8 file paths") <| @(t : T?) {

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -44,7 +44,14 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(error, "")
         t |> equal(expected_exit_code, 1l)
         t |> equal(argv[7], "--no-index")
-        t |> equal(argv[10], "--unified=3")
+        t |> equal(argv[9], "--unified=3")
+        var forces_text = false
+        for (argument in argv) {
+            if (argument == "--text") {
+                forces_text = true
+            }
+        }
+        t |> equal(forces_text, false, "Git retains native binary detection")
         t |> equal(argv[length(argv) - 2], "NUL")
         t |> equal(argv[length(argv) - 1], "new file.das")
 
@@ -55,7 +62,7 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(staged_error, "")
         t |> equal(expected_exit_code, 0l)
         t |> equal(argv[7], "--cached")
-        t |> equal(argv[10], "--unified=1000000")
+        t |> equal(argv[9], "--unified=1000000")
         t |> equal(argv[length(argv) - 1], "staged.das")
     }
 }

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -102,3 +102,25 @@ def test_repository_relative_file_path_contract(t : T?) {
         }
     }
 }
+
+[test]
+def test_repository_text_read_contract(t : T?) {
+    t |> run("empty files remain distinct from read failures") <| @(t : T?) {
+        let temp = create_temp_directory_result("dasherd_repository_text_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let root = temp as value
+        let empty_path = path_join(root, "empty.txt")
+        t |> success(fwrite(empty_path, ""), "empty fixture is written")
+
+        var text : string
+        t |> equal(repository_read_text_file(empty_path, text), "")
+        t |> equal(text, "", "an opened empty file is a successful preview")
+        t |> success(!empty(repository_read_text_file(root, text)),
+            "a path that cannot be read as a regular file reports an error")
+
+        rmdir_rec(root)
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -31,6 +31,14 @@ def test_repository_porcelain_parsing(t : T?) {
         t |> equal(files[4].path, "new name")
         t |> equal(files[0].worktree_path, "D:/Work/daScript")
     }
+    t |> run("unquoted porcelain retains UTF-8 file paths") <| @(t : T?) {
+        var worktree = WorktreeState(path = "D:/Work/fixture")
+        var files : array<GitFileState>
+        repository_parse_status("## fixture\r\n M unicode-Привет.txt\r\n",
+            worktree, files)
+        t |> equal(length(files), 1)
+        t |> equal(files[0].path, "unicode-Привет.txt")
+    }
 }
 
 [test]

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -144,8 +144,11 @@ def test_repository_text_read_contract(t : T?) {
         t |> equal(repository_working_preview_path(
             root, "bytes.bin", preview_path), "")
         t |> equal(preview_path, bytes_path)
-        t |> success(!empty(repository_read_text_file(bytes_path, 2, text)),
-            "text View rejects files beyond its raw-byte limit")
+        t |> equal(repository_read_text_file(bytes_path, 2, text),
+            "file exceeds the raw-byte View limit")
+        t |> equal(text, "", "oversized mapped text is never materialized")
+        t |> equal(repository_read_text_file(bytes_path, 3, text), "")
+        t |> equal(text, "abc", "mapped text at the raw-byte limit is materialized")
         var bytes : array<uint8>
         var byte_count = 0
         t |> equal(repository_read_file_bytes(

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -62,7 +62,19 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(staged_error, "")
         t |> equal(expected_exit_code, 0l)
         t |> equal(argv[7], "--cached")
-        t |> equal(argv[9], "--unified=1000000")
+        t |> equal(argv[9], "--unified=3")
         t |> equal(argv[length(argv) - 1], "staged.das")
+
+        let full_error = repository_build_file_diff_argv(
+            "D:/Work/tree", staged_file, "staged", argv,
+            expected_exit_code, "full")
+        t |> equal(full_error, "")
+        t |> equal(argv[9], "--unified=1000000")
+
+        let expanded_error = repository_build_file_diff_argv(
+            "D:/Work/tree", staged_file, "staged", argv,
+            expected_exit_code, "expanded")
+        t |> equal(expanded_error, "")
+        t |> equal(argv[9], "--unified=20")
     }
 }

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -1,0 +1,61 @@
+options gen2
+options rtti
+
+require dastest/testing_boost public
+require ../repository_core.das
+require strings
+
+[test]
+def test_repository_porcelain_parsing(t : T?) {
+    t |> run("Git 2.17 worktree and status porcelain become structured state") <| @(t : T?) {
+        let inventory = "worktree D:/Work/daScript\r\nHEAD 0123456789012345678901234567890123456789\r\nbranch refs/heads/main-feature\r\n\r\nworktree D:/Work/daScript/.codex/worktrees/space tree\r\nHEAD abcdefabcdefabcdefabcdefabcdefabcdefabcd\r\ndetached\r\nlocked reason\r\nprunable reason\r\n\r\n"
+        var worktrees : array<WorktreeState>
+        repository_parse_inventory(inventory, worktrees)
+        t |> equal(length(worktrees), 2)
+        t |> success(worktrees[0].is_main, "first porcelain entry is the visually distinct main checkout")
+        t |> equal(worktrees[0].branch, "main-feature")
+        t |> equal(worktrees[1].path, "D:/Work/daScript/.codex/worktrees/space tree")
+        t |> success(worktrees[1].detached && worktrees[1].locked && worktrees[1].prunable,
+            "detached, locked, and prunable markers are retained")
+
+        var files : array<GitFileState>
+        repository_parse_status("## main-feature...origin/main [ahead 2, behind 3]\r\nM  staged file.das\r\n M unstaged file.das\r\n?? new file.txt\r\nUU conflict.txt\r\nR  old name -> new name\r\n", worktrees[0], files)
+        t |> equal(worktrees[0].ahead, 2)
+        t |> equal(worktrees[0].behind, 3)
+        t |> equal(worktrees[0].staged, 3)
+        t |> equal(worktrees[0].unstaged, 2)
+        t |> equal(worktrees[0].untracked, 1)
+        t |> equal(worktrees[0].conflicted, 1)
+        t |> equal(length(files), 5)
+        t |> equal(files[4].old_path, "old name")
+        t |> equal(files[4].path, "new name")
+        t |> equal(files[0].worktree_path, "D:/Work/daScript")
+    }
+}
+
+[test]
+def test_repository_untracked_diff_contract(t : T?) {
+    t |> run("Untracked diffs accept git --no-index exit 1") <| @(t : T?) {
+        let file = GitFileState(code = "??", path = "new file.das")
+        var argv : array<string>
+        var expected_exit_code = 0l
+        let error = repository_build_file_diff_argv(
+            "D:/Work/tree", file, "working", argv, expected_exit_code)
+        t |> equal(error, "")
+        t |> equal(expected_exit_code, 1l)
+        t |> equal(argv[7], "--no-index")
+        t |> equal(argv[10], "--unified=3")
+        t |> equal(argv[length(argv) - 2], "NUL")
+        t |> equal(argv[length(argv) - 1], "new file.das")
+
+        let staged_file = GitFileState(code = "M ", path = "staged.das")
+        expected_exit_code = -1l
+        let staged_error = repository_build_file_diff_argv(
+            "D:/Work/tree", staged_file, "staged", argv, expected_exit_code)
+        t |> equal(staged_error, "")
+        t |> equal(expected_exit_code, 0l)
+        t |> equal(argv[7], "--cached")
+        t |> equal(argv[10], "--unified=1000000")
+        t |> equal(argv[length(argv) - 1], "staged.das")
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -62,8 +62,11 @@ def test_watcher_process_lifecycle(t : T?) {
             columns = 1, rows = 999, timeout_ms = 5000l))
         t |> success(!failed.ok, "failed PTY launch is reported to the caller")
         t |> success(!empty(failed.session_id), "failed PTY launch retains its diagnostic session")
-        t |> success(find(watcher_snapshot_json(failed.session_id), "\"state\":\"failed\"") >= 0,
+        let failed_snapshot = watcher_snapshot_json(failed.session_id)
+        t |> success(find(failed_snapshot, "\"state\":\"failed\"") >= 0,
             "failed PTY launch is retained in watcher state")
+        t |> success(find(failed_snapshot, "\"pid\":0") >= 0,
+            "failed PTY launch retains a deterministic zero process id")
         let failed_metadata = fread(path_join(path_join(path_join(root, "sessions"),
             failed.session_id), "session.json"))
         t |> success(find(failed_metadata, "\"columns\":20") >= 0

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -8,6 +8,10 @@ require strings
 
 [test]
 def test_watcher_machine_output(t : T?) {
+    t |> run("empty transport target defaults to local") <| @(t : T?) {
+        t |> equal(watcher_target_id_or_local(""), "local")
+        t |> equal(watcher_target_id_or_local("ssh-build"), "ssh-build")
+    }
     t |> run("ConPTY wrapper controls are removed without changing task text") <| @(t : T?) {
         let esc = to_char(27)
         let bel = to_char(7)

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -43,6 +43,19 @@ def test_watcher_process_lifecycle(t : T?) {
         let root = temp as value
         t |> equal(watcher_init(path_join(root, "sessions")), "")
 
+        let oversized_display = watcher_launch(WatcherLaunchRequest(
+            command_line = "cmd.exe /d /c exit 0", cwd = root,
+            display_name = repeat("x", 32 * 1024 + 1)))
+        t |> success(!oversized_display.ok
+                && find(oversized_display.error, "display_name") >= 0,
+            "oversized display metadata is rejected before session allocation")
+        var oversized_argv <- ["cmd.exe", repeat("x", 32 * 1024)]
+        let oversized_arguments = watcher_launch(WatcherLaunchRequest(
+            argv <- oversized_argv, cwd = root))
+        t |> success(!oversized_arguments.ok
+                && find(oversized_arguments.error, "argv") >= 0,
+            "oversized structured argv is rejected before display joining")
+
         let missing_command = path_join(root, "missing-watcher-command.exe")
         let failed = watcher_launch(WatcherLaunchRequest(
             command_line = "\"{missing_command}\"", cwd = root,

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -46,11 +46,16 @@ def test_watcher_process_lifecycle(t : T?) {
         let missing_command = path_join(root, "missing-watcher-command.exe")
         let failed = watcher_launch(WatcherLaunchRequest(
             command_line = "\"{missing_command}\"", cwd = root,
-            columns = 80, rows = 20, timeout_ms = 5000l))
+            columns = 1, rows = 999, timeout_ms = 5000l))
         t |> success(!failed.ok, "failed PTY launch is reported to the caller")
         t |> success(!empty(failed.session_id), "failed PTY launch retains its diagnostic session")
         t |> success(find(watcher_snapshot_json(failed.session_id), "\"state\":\"failed\"") >= 0,
             "failed PTY launch is retained in watcher state")
+        let failed_metadata = fread(path_join(path_join(path_join(root, "sessions"),
+            failed.session_id), "session.json"))
+        t |> success(find(failed_metadata, "\"columns\":20") >= 0
+                && find(failed_metadata, "\"rows\":200") >= 0,
+            "session metadata retains the clamped launch dimensions")
         watcher_tick()
         t |> success(find(watcher_snapshot_json(failed.session_id), "\"state\":\"failed\"") >= 0,
             "process exit observation preserves the failed state")

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -67,6 +67,10 @@ def test_watcher_process_lifecycle(t : T?) {
             "failed PTY launch is retained in watcher state")
         t |> success(find(failed_snapshot, "\"pid\":0") >= 0,
             "failed PTY launch retains a deterministic zero process id")
+        t |> equal(base_name(watcher_session_artifact_path(
+            failed.session_id, "staged-view.raw")), "staged-view.raw")
+        t |> equal(watcher_session_artifact_path(
+            failed.session_id, "../outside.raw"), "")
         let failed_metadata = fread(path_join(path_join(path_join(root, "sessions"),
             failed.session_id), "session.json"))
         t |> success(find(failed_metadata, "\"columns\":20") >= 0

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -13,6 +13,9 @@ def test_watcher_machine_output(t : T?) {
         let bel = to_char(7)
         let wrapped = "{esc}[?9001h{esc}[2J{esc}[Hfirst\r\nsecond\tvalue{esc}]0;git.exe{bel}{esc}[?25h"
         t |> equal(watcher_strip_terminal_controls(wrapped), "first\r\nsecond\tvalue")
+        let unicode_wrapped = "{esc}[31mΚαλημέρα, мир, こんにちは, 🐑{esc}[0m"
+        t |> equal(watcher_strip_terminal_controls(unicode_wrapped),
+            "Καλημέρα, мир, こんにちは, 🐑")
     }
 }
 

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -6,6 +6,16 @@ require ../watcher_core.das
 require daslib/fio
 require strings
 
+[test]
+def test_watcher_machine_output(t : T?) {
+    t |> run("ConPTY wrapper controls are removed without changing task text") <| @(t : T?) {
+        let esc = to_char(27)
+        let bel = to_char(7)
+        let wrapped = "{esc}[?9001h{esc}[2J{esc}[Hfirst\r\nsecond\tvalue{esc}]0;git.exe{bel}{esc}[?25h"
+        t |> equal(watcher_strip_terminal_controls(wrapped), "first\r\nsecond\tvalue")
+    }
+}
+
 def private wait_for(session_id, state : string; timeout_ms : int64) : bool {
     let started = ref_time_ticks()
     while (get_time_nsec(started) / 1000000l < timeout_ms) {
@@ -58,6 +68,47 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> equal(length(raw_tail.bytes), 0, "raw replay offset does not duplicate output")
         t |> success(fexist(path_join(path_join(path_join(root, "sessions"), quick.session_id), "output.raw")),
             "raw output log exists")
+
+        let spaced_dir = path_join(root, "argv space")
+        var mkdir_error : string
+        t |> success(mkdir_rec(spaced_dir, mkdir_error), mkdir_error)
+        let echo_script = path_join(spaced_dir, "echo args.ps1")
+        t |> success(fwrite(echo_script, "[Console]::Write(($args -join '|'))"),
+            "argv echo script is written")
+        var structured_argv <- ["powershell.exe", "-NoLogo", "-NoProfile", "-File", echo_script,
+            "space value", "quote\"value", "trailing\\"]
+        let structured = watcher_launch(WatcherLaunchRequest(argv <- structured_argv,
+            cwd = root, display_name = "structured argv test", kind = "test",
+            target_id = "local", repository_id = "test-repository", worktree_path = root,
+            columns = 80, rows = 20, timeout_ms = 5000l))
+        t |> success(structured.ok, structured.error)
+        t |> success(wait_for(structured.session_id, "exited", 5000l),
+            "structured argv command exits and drains")
+        let structured_snapshot = watcher_snapshot_json(structured.session_id)
+        t |> success(find(structured_snapshot, "space value|quote\\\"value|trailing\\\\") >= 0,
+            "structured argv preserves spaces, quotes, and trailing backslashes")
+        t |> success(find(structured_snapshot, "\"worktree_path\":") >= 0,
+            "session snapshot retains launch worktree association")
+        var before_compact = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(structured.session_id, before_compact),
+            "completed structured session remains addressable")
+        t |> success(watcher_compact_session(structured.session_id, 60, 10),
+            "completed session can release its oversized terminal state")
+        var after_compact = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(structured.session_id, after_compact),
+            "compacted session remains addressable")
+        t |> equal(after_compact.pid, before_compact.pid,
+            "compaction retains the original process id")
+        t |> equal(after_compact.exit_code, before_compact.exit_code,
+            "compaction retains the exit code")
+        t |> success(find(watcher_snapshot_json(structured.session_id), "space value") >= 0,
+            "compaction replays retained raw output into an inspectable terminal")
+        let structured_log = path_join(path_join(path_join(root, "sessions"), structured.session_id), "output.raw")
+        t |> equal(watcher_prune_completed_sessions("test", "test-repository", root), 1,
+            "completed observation session can leave the in-memory working set")
+        t |> equal(watcher_find_session(structured.session_id), -1,
+            "pruned observation session is removed from the live list")
+        t |> success(fexist(structured_log), "pruning preserves its durable raw log")
 
         for (iteration in range(6)) {
             let close_race = watcher_launch(WatcherLaunchRequest(

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -71,6 +71,8 @@ def test_watcher_process_lifecycle(t : T?) {
             failed.session_id, "staged-view.raw")), "staged-view.raw")
         t |> equal(watcher_session_artifact_path(
             failed.session_id, "../outside.raw"), "")
+        t |> equal(watcher_session_artifact_path(
+            failed.session_id, "C:outside.raw"), "")
         let failed_metadata = fread(path_join(path_join(path_join(root, "sessions"),
             failed.session_id), "session.json"))
         t |> success(find(failed_metadata, "\"columns\":20") >= 0

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -66,7 +66,7 @@ struct public WatcherSessionInfo {
     worktree_path : string
     state : string
     reason : string
-    pid : int
+    pid : int = 0
     exit_code : int64 = -1l
     elapsed_ms : int64
     output_bytes : int64
@@ -117,7 +117,7 @@ class private WatcherSession {
     events_path : string
     state : string = "starting"
     reason : string
-    pid : int
+    pid : int = 0
     terminal : Terminal = Terminal()
     output_file : FILE const? = null
     events_file : FILE const? = null

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -515,7 +515,7 @@ def public watcher_compact_session(session_id : string;
     return true
 }
 
-def public watcher_session_artifact_path(session_id, name : string) : string {
+def public watcher_session_artifact_path(session_id : string; name : string) : string {
     if (empty(name) || name == "." || name == ".." || find(name, "/") >= 0
             || find(name, "\\") >= 0 || find(name, ":") >= 0) return ""
     let index = watcher_find_session(session_id)

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -511,7 +511,9 @@ def public watcher_compact_session(session_id : string;
     return true
 }
 
-def public watcher_prune_completed_sessions(kind, repository_id, worktree_path : string) : int {
+def public watcher_prune_completed_sessions(kind : string;
+                                            repository_id : string;
+                                            worktree_path : string) : int {
     var removed = 0
     var index = length(g_sessions)
     while (index > 0) {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -260,13 +260,16 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not open session logs")
     }
-    if (!write_text_file(path_join(session_dir, "session.json"), sprint_json(request, true))) {
+    let columns = clamp(request.columns, 20, 400)
+    let rows = clamp(request.rows, 5, 200)
+    var inscope persisted_request := request
+    persisted_request.columns = columns
+    persisted_request.rows = rows
+    if (!write_text_file(path_join(session_dir, "session.json"), sprint_json(persisted_request, true))) {
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not write session metadata")
     }
 
-    let columns = clamp(request.columns, 20, 400)
-    let rows = clamp(request.rows, 5, 200)
     if (!empty(request.argv)) {
         var inscope launched <- terminal_launch_argv(request.argv, request.cwd, columns, rows)
         session.terminal := launched

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -230,6 +230,16 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
     if (length(request.command_line) > MAX_COMMAND_BYTES) {
         return WatcherLaunchResult(error = "command_line is too large")
     }
+    if (length(request.display_name) > MAX_COMMAND_BYTES) {
+        return WatcherLaunchResult(error = "display_name is too large")
+    }
+    var argv_bytes = max(0, length(request.argv) - 1)
+    for (argument in request.argv) {
+        argv_bytes += length(argument)
+        if (argv_bytes > MAX_COMMAND_BYTES) {
+            return WatcherLaunchResult(error = "argv is too large")
+        }
+    }
     if (empty(g_log_root)) {
         return WatcherLaunchResult(error = "watcher core is not initialized")
     }

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -513,7 +513,7 @@ def public watcher_compact_session(session_id : string;
 
 def public watcher_session_artifact_path(session_id, name : string) : string {
     if (empty(name) || name == "." || name == ".." || find(name, "/") >= 0
-            || find(name, "\\") >= 0) return ""
+            || find(name, "\\") >= 0 || find(name, ":") >= 0) return ""
     let index = watcher_find_session(session_id)
     if (index < 0 || g_sessions[index] == null) return ""
     return path_join(g_sessions[index].session_dir, name)

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -571,8 +571,8 @@ def public watcher_resize(session_id : string; columns, rows, client_id : int) :
 }
 
 def private terminate_session(var session : WatcherSession?; detail : string) : string {
-    if (session.state != "running" && session.state != "terminating") return ""
-    if (terminal_process_exited(session.terminal)) return ""
+    if ((session.state != "running" && session.state != "terminating")
+            || terminal_process_exited(session.terminal)) return ""
     session.reason = detail
     session.state = "terminating"
     session.status_revision++

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -643,5 +643,6 @@ def public watcher_shutdown(terminate_running : bool = false) {
         }
         unsafe { delete session }
     }
+    g_sessions |> clear()
     unsafe { delete g_sessions }
 }

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -511,6 +511,14 @@ def public watcher_compact_session(session_id : string;
     return true
 }
 
+def public watcher_session_artifact_path(session_id, name : string) : string {
+    if (empty(name) || name == "." || name == ".." || find(name, "/") >= 0
+            || find(name, "\\") >= 0) return ""
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return ""
+    return path_join(g_sessions[index].session_dir, name)
+}
+
 def public watcher_prune_completed_sessions(kind : string;
                                             repository_id : string;
                                             worktree_path : string) : int {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -9,6 +9,7 @@ module watcher_core shared public
 require terminal/terminal public
 require daslib/fio public
 require daslib/json_boost public
+require daslib/strings_boost
 require strings public
 require math
 
@@ -20,7 +21,13 @@ let private RAW_HISTORY_TRIM_SLACK = 1024 * 1024
 
 struct public WatcherLaunchRequest {
     command_line : string
+    argv : array<string>
     cwd : string
+    display_name : string
+    kind : string
+    target_id : string = "local"
+    repository_id : string
+    worktree_path : string
     columns : int = 100
     rows : int = 30
     timeout_ms : int64
@@ -52,6 +59,11 @@ struct public WatcherSessionInfo {
     id : string
     command_line : string
     cwd : string
+    display_name : string
+    kind : string
+    target_id : string
+    repository_id : string
+    worktree_path : string
     state : string
     reason : string
     pid : int
@@ -95,11 +107,17 @@ class private WatcherSession {
     id : string
     command_line : string
     cwd : string
+    display_name : string
+    kind : string
+    target_id : string
+    repository_id : string
+    worktree_path : string
     session_dir : string
     output_path : string
     events_path : string
     state : string = "starting"
     reason : string
+    pid : int
     terminal : Terminal = Terminal()
     output_file : FILE const? = null
     events_file : FILE const? = null
@@ -127,6 +145,7 @@ class private WatcherSession {
             events_file = null
         }
         terminal_dispose(terminal)
+        delete raw_history
     }
 }
 
@@ -171,8 +190,11 @@ def private append_event(session : WatcherSession?; event, detail : string) {
 
 def private session_info(session : WatcherSession?) : WatcherSessionInfo {
     return WatcherSessionInfo(id = session.id, command_line = session.command_line,
-        cwd = session.cwd, state = session.state, reason = session.reason,
-        pid = terminal_process_id(session.terminal), exit_code = session.exit_code,
+        cwd = session.cwd, display_name = session.display_name, kind = session.kind,
+        target_id = session.target_id, repository_id = session.repository_id,
+        worktree_path = session.worktree_path,
+        state = session.state, reason = session.reason,
+        pid = session.pid, exit_code = session.exit_code,
         elapsed_ms = elapsed_ms(session), output_bytes = session.output_bytes,
         input_bytes = session.input_bytes,
         columns = session.terminal.columns, rows = session.terminal.rows,
@@ -202,8 +224,8 @@ def public watcher_accepts_input(session_id : string) : bool {
 }
 
 def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult {
-    if (empty(request.command_line)) {
-        return WatcherLaunchResult(error = "command_line is required")
+    if (empty(request.command_line) && empty(request.argv)) {
+        return WatcherLaunchResult(error = "command_line or argv is required")
     }
     if (length(request.command_line) > MAX_COMMAND_BYTES) {
         return WatcherLaunchResult(error = "command_line is too large")
@@ -219,8 +241,15 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         return WatcherLaunchResult(error = "could not create session directory: {mkdir_error}")
     }
 
+    var visible_command = request.display_name
+    if (empty(visible_command)) {
+        visible_command = !empty(request.command_line) ? request.command_line : join(request.argv, " ")
+    }
     var session = new WatcherSession(id = session_id,
-        command_line = request.command_line, cwd = request.cwd,
+        command_line = visible_command, cwd = request.cwd,
+        display_name = request.display_name, kind = request.kind,
+        target_id = request.target_id, repository_id = request.repository_id,
+        worktree_path = request.worktree_path,
         session_dir = session_dir,
         output_path = path_join(session_dir, "output.raw"),
         events_path = path_join(session_dir, "events.jsonl"),
@@ -231,16 +260,20 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not open session logs")
     }
-    let spec = WatcherLaunchRequest(command_line = request.command_line, cwd = request.cwd,
-        columns = clamp(request.columns, 20, 400), rows = clamp(request.rows, 5, 200),
-        timeout_ms = max(0l, request.timeout_ms))
-    if (!write_text_file(path_join(session_dir, "session.json"), sprint_json(spec, true))) {
+    if (!write_text_file(path_join(session_dir, "session.json"), sprint_json(request, true))) {
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not write session metadata")
     }
 
-    var inscope launched <- terminal_launch(spec.command_line, spec.cwd, spec.columns, spec.rows)
-    session.terminal := launched
+    let columns = clamp(request.columns, 20, 400)
+    let rows = clamp(request.rows, 5, 200)
+    if (!empty(request.argv)) {
+        var inscope launched <- terminal_launch_argv(request.argv, request.cwd, columns, rows)
+        session.terminal := launched
+    } else {
+        var inscope launched <- terminal_launch(request.command_line, request.cwd, columns, rows)
+        session.terminal := launched
+    }
     if (terminal_process_id(session.terminal) == 0) {
         session.state = "failed"
         session.reason = terminal_transport_error(session.terminal)
@@ -249,6 +282,7 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         session.status_revision++
         append_event(session, "launch_failed", session.reason)
     } else {
+        session.pid = terminal_process_id(session.terminal)
         session.state = "running"
         session.status_revision++
         append_event(session, "launched", "pid={terminal_process_id(session.terminal)}")
@@ -358,6 +392,129 @@ def public watcher_output_since(session_id : string; requested_offset : int64;
     return <- result
 }
 
+def public watcher_get_session_info(session_id : string; var info : WatcherSessionInfo) : bool {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return false
+    info = session_info(g_sessions[index])
+    return true
+}
+
+def public watcher_output_text(session_id : string) : string {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return ""
+    return string(g_sessions[index].raw_history)
+}
+
+def public watcher_strip_terminal_controls(value : string) : string {
+    // Task processes launched through ConPTY are wrapped in cursor, screen,
+    // title, and mode sequences even when the child itself emits plain text.
+    // Machine consumers need the original printable byte stream, not a
+    // bounded reconstructed screen.
+    var inscope output : array<uint8>
+    output |> reserve(length(value))
+    var state = 0 // 0=text, 1=ESC, 2=CSI, 3=OSC, 4=OSC ESC, 5=ST string, 6=ST ESC
+    peek_data(value) $(bytes) {
+        for (index in range(length(value))) {
+            let byte = int(bytes[index])
+            if (state == 0) {
+                if (byte == 0x1b) {
+                    state = 1
+                }
+                elif (byte == '\t' || byte == '\r' || byte == '\n' || byte >= 0x20) {
+                    output |> push(uint8(byte))
+                }
+            } elif (state == 1) {
+                if (byte == '[') {
+                    state = 2
+                } elif (byte == ']') {
+                    state = 3
+                } elif (byte == 'P' || byte == '^' || byte == '_' || byte == 'X') {
+                    state = 5
+                } else {
+                    state = 0
+                }
+            } elif (state == 2) {
+                if (byte >= 0x40 && byte <= 0x7e) {
+                    state = 0
+                }
+            } elif (state == 3) {
+                if (byte == 0x07) {
+                    state = 0
+                } elif (byte == 0x1b) {
+                    state = 4
+                }
+            } elif (state == 4) {
+                state = byte == '\\' ? 0 : 3
+            } elif (state == 5) {
+                if (byte == 0x1b) {
+                    state = 6
+                }
+            } else {
+                state = byte == '\\' ? 0 : 5
+            }
+        }
+    }
+    return string(output)
+}
+
+def public watcher_machine_output_text(session_id : string;
+                                       var truncated : bool) : string {
+    truncated = false
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return ""
+    let session = g_sessions[index]
+    truncated = session.raw_history_start != 0l
+    return watcher_strip_terminal_controls(string(session.raw_history))
+}
+
+def public watcher_terminal_text(session_id : string; var scrollback_rows : int) : string {
+    scrollback_rows = 0
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return ""
+    var viewport = TerminalViewportSnapshot()
+    terminal_viewport_snapshot(g_sessions[index].terminal, 0, viewport)
+    scrollback_rows = viewport.buffer.scrollback_rows
+    let result = viewport.screen_text
+    terminal_viewport_snapshot_dispose(viewport)
+    return result
+}
+
+def public watcher_compact_session(session_id : string;
+                                   columns : int = 160; rows : int = 50) : bool {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return false
+    var session = g_sessions[index]
+    if (!session.drained || session.state == "running" || session.state == "terminating") return false
+    let compact_columns = clamp(columns, 20, 400)
+    let compact_rows = clamp(rows, 5, 200)
+    if (session.terminal.transport == null && session.terminal.columns == compact_columns
+            && session.terminal.rows == compact_rows) return true
+    var inscope compact <- terminal_create(compact_columns, compact_rows)
+    terminal_feed_bytes(compact, session.raw_history)
+    terminal_dispose(session.terminal)
+    session.terminal := compact
+    session.status_revision++
+    append_event(session, "terminal_compacted", "{compact_columns}x{compact_rows}")
+    return true
+}
+
+def public watcher_prune_completed_sessions(kind, repository_id, worktree_path : string) : int {
+    var removed = 0
+    var index = length(g_sessions)
+    while (index > 0) {
+        index--
+        var session = g_sessions[index]
+        if (session == null || !session.drained || session.state == "running"
+                || session.state == "terminating" || session.kind != kind
+                || session.repository_id != repository_id
+                || session.worktree_path != worktree_path) continue
+        unsafe { delete session }
+        g_sessions |> erase(index)
+        removed++
+    }
+    return removed
+}
+
 def private input_session(var session : WatcherSession?; text : string; client_id : int) : string {
     if (session.controller_id != 0 && session.controller_id != client_id) return "controller lease is held by another client"
     if (session.state != "running" || session.drained) return "session is not running"
@@ -387,6 +544,7 @@ def public watcher_resize(session_id : string; columns, rows, client_id : int) :
 }
 
 def private terminate_session(var session : WatcherSession?; detail : string) : string {
+    if (session.state != "running" && session.state != "terminating") return ""
     if (terminal_process_exited(session.terminal)) return ""
     session.reason = detail
     session.state = "terminating"
@@ -430,7 +588,7 @@ def public watcher_release_controller(session_id : string; client_id : int; deta
 }
 
 def public watcher_list_json : string {
-    var result : array<WatcherSessionInfo>
+    var inscope result : array<WatcherSessionInfo>
     result |> reserve(length(g_sessions))
     for (session in g_sessions) {
         if (session != null) result |> push(session_info(session))
@@ -448,7 +606,9 @@ def private snapshot_session_json(session : WatcherSession?) : string {
         scrollback_rows = viewport.buffer.scrollback_rows,
         cursor_row = cursor.row, cursor_column = cursor.column,
         cursor_visible = cursor.visible, cursor_blinking = cursor.blinking)
-    return sprint_json(snapshot, false)
+    let result = sprint_json(snapshot, false)
+    terminal_viewport_snapshot_dispose(viewport)
+    return result
 }
 
 def public watcher_snapshot_json(session_id : string) : string {
@@ -483,5 +643,5 @@ def public watcher_shutdown(terminate_running : bool = false) {
         }
         unsafe { delete session }
     }
-    g_sessions |> clear()
+    unsafe { delete g_sessions }
 }

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -33,6 +33,10 @@ struct public WatcherLaunchRequest {
     timeout_ms : int64
 }
 
+def public watcher_target_id_or_local(target_id : string) : string {
+    return empty(target_id) ? "local" : target_id
+}
+
 struct public WatcherInputRequest {
     session_id : string
     text : string

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -550,7 +550,7 @@ def private input_session(var session : WatcherSession?; text : string; client_i
     return ""
 }
 
-def public watcher_input(session_id, text : string; client_id : int = 0) : string {
+def public watcher_input(session_id : string; text : string; client_id : int = 0) : string {
     let index = watcher_find_session(session_id)
     if (index < 0) return "unknown session"
     if (length(text) > MAX_INPUT_BYTES) return "input is too large"
@@ -564,7 +564,8 @@ def private resize_session(var session : WatcherSession?; columns, rows, client_
     return ""
 }
 
-def public watcher_resize(session_id : string; columns, rows, client_id : int) : string {
+def public watcher_resize(session_id : string; columns : int; rows : int;
+                          client_id : int) : string {
     let index = watcher_find_session(session_id)
     if (index < 0) return "unknown session"
     return resize_session(g_sessions[index], columns, rows, client_id)

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -175,6 +175,7 @@ class DasHerdWatcherServer : HvWebServer {
     xterm_unicode_js : string
     xterm_web_links_js : string
     clients : array<WatcherClient?>
+    pending_inspection_artifacts : array<string>
     next_client_id : int
 
     def authorized(url : string) : bool {
@@ -363,10 +364,29 @@ class DasHerdWatcherServer : HvWebServer {
             ws_opcode.WS_OPCODE_TEXT, true)
     }
 
+    def remember_inspection_artifact(path : string) {
+        for (pending in pending_inspection_artifacts) {
+            if (pending == path) return
+        }
+        pending_inspection_artifacts |> push(clone_string(path))
+    }
+
+    def retry_inspection_artifact_cleanup() {
+        var index = length(pending_inspection_artifacts)
+        while (index > 0) {
+            index--
+            let path = pending_inspection_artifacts[index]
+            if (!fexist(path) || remove(path)) {
+                pending_inspection_artifacts |> erase(index)
+            }
+        }
+    }
+
     def cleanup_inspection_artifact(var client : WatcherClient?) {
         if (client == null || empty(client.inspection_artifact_path)) return
-        if (fexist(client.inspection_artifact_path)) {
-            let _removed = remove(client.inspection_artifact_path)
+        let path = client.inspection_artifact_path
+        if (fexist(path) && !remove(path)) {
+            self.remember_inspection_artifact(path)
         }
         client.inspection_artifact_path = ""
     }
@@ -742,6 +762,7 @@ class DasHerdWatcherServer : HvWebServer {
     def override onTick {
         watcher_tick()
         repository_tick()
+        self.retry_inspection_artifact_cleanup()
         for (index in range(length(clients))) {
             var client = clients[index]
             if (client == null) continue
@@ -768,5 +789,10 @@ class DasHerdWatcherServer : HvWebServer {
         }
         clients |> clear()
         unsafe { delete clients }
+    }
+
+    def cleanup_inspection_artifacts {
+        self.retry_inspection_artifact_cleanup()
+        delete pending_inspection_artifacts
     }
 }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -11,6 +11,7 @@ module watcher_server shared public
 require dashv/dashv_boost public
 require ./watcher_core.das public
 require ./repository_core.das public
+require ./file_inspection.das
 require daslib/json_boost
 require daslib/base64
 require strings
@@ -429,18 +430,18 @@ class DasHerdWatcherServer : HvWebServer {
             var view_base64 = ""
             var view_byte_count = 0
             if (client.inspection_comparison == "working") {
-                let binary = find(patch, "Binary files ") >= 0 || find(patch, "GIT binary patch") >= 0
+                let binary = git_patch_is_binary(patch)
                 var view_error = ""
                 if (binary) {
                     var inscope bytes : array<uint8>
+                    view_byte_count = 0
                     view_error = repository_working_file_bytes(
                         client.inspection_repository_id,
                         client.inspection_worktree_path,
-                        client.inspection_file_path, bytes)
+                        client.inspection_file_path,
+                        MAX_BINARY_PREVIEW_BYTES, bytes, view_byte_count)
                     if (empty(view_error)) {
-                        view_byte_count = length(bytes)
-                        if (!empty(bytes)
-                                && view_byte_count <= MAX_BINARY_PREVIEW_BYTES) {
+                        if (!empty(bytes)) {
                             view_base64 = base64_encode(bytes)
                         }
                     }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -75,6 +75,7 @@ struct public RepositoryFileInspectionMessage {
     view_text : string
     view_base64 : string
     view_byte_count : int
+    view_available : bool
     status : string
     error : string
 }
@@ -99,6 +100,9 @@ class private WatcherClient {
     inspection_session_id : string
     inspection_expected_exit_code : int64
     inspection_delivered : bool = true
+    inspection_phase : string
+    inspection_patch : string
+    inspection_artifact_path : string
 }
 
 struct private WatcherOk {
@@ -340,7 +344,8 @@ class DasHerdWatcherServer : HvWebServer {
                              loading : bool; patch, error : string;
                              view_text : string = ""; status : string = "";
                              view_base64 : string = "";
-                             view_byte_count : int = 0) {
+                             view_byte_count : int = 0;
+                             view_available : bool = false) {
         if (client == null) return
         let message = RepositoryFileInspectionMessage(
             request_id = client.inspection_request_id,
@@ -352,9 +357,60 @@ class DasHerdWatcherServer : HvWebServer {
             task_session_id = client.inspection_session_id,
             loading = loading, patch = patch, view_text = view_text,
             view_base64 = view_base64, view_byte_count = view_byte_count,
+            view_available = view_available,
             status = status, error = error)
         send(client.channel, sprint_json(message, false),
             ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def cleanup_inspection_artifact(var client : WatcherClient?) {
+        if (client == null || empty(client.inspection_artifact_path)) return
+        if (fexist(client.inspection_artifact_path)) {
+            let _removed = remove(client.inspection_artifact_path)
+        }
+        client.inspection_artifact_path = ""
+    }
+
+    def start_staged_file_view(var client : WatcherClient?; patch : string) {
+        if (client == null) return
+        let artifact_path = watcher_session_artifact_path(
+            client.inspection_session_id, "staged-view.raw")
+        var inscope argv : array<string>
+        let command_error = repository_staged_file_view_argv(
+            client.inspection_worktree_path, client.inspection_file_path,
+            artifact_path, argv)
+        if (!empty(command_error)) {
+            client.inspection_delivered = true
+            self.send_file_inspection(client, false, "", command_error)
+            return
+        }
+        let _pruned = watcher_prune_completed_sessions(
+            "git-file-view", client.inspection_repository_id,
+            client.inspection_worktree_path)
+        var inscope request = WatcherLaunchRequest(
+            cwd = client.inspection_worktree_path,
+            display_name = "Git staged view: {client.inspection_file_path}",
+            kind = "git-file-view", target_id = "local",
+            repository_id = client.inspection_repository_id,
+            worktree_path = client.inspection_worktree_path,
+            columns = 80, rows = 25, timeout_ms = 15000l)
+        request.argv := argv
+        let result = watcher_launch(request)
+        client.inspection_phase = "staged-view"
+        client.inspection_patch = clone_string(patch)
+        client.inspection_artifact_path = artifact_path
+        client.inspection_session_id = result.session_id
+        client.inspection_expected_exit_code = 0l
+        if (!result.ok) {
+            client.inspection_delivered = true
+            self.cleanup_inspection_artifact(client)
+            client.inspection_patch = ""
+            self.send_file_inspection(client, false, "", result.error)
+            return
+        }
+        client.inspection_delivered = false
+        self.send_file_inspection(client, true, "", "", "",
+            "Reading full staged file (15 second limit)...")
     }
 
     def start_file_inspection(var client : WatcherClient?;
@@ -364,6 +420,7 @@ class DasHerdWatcherServer : HvWebServer {
                 && watcher_accepts_input(client.inspection_session_id)) {
             let _ = watcher_terminate(client.inspection_session_id, "superseded")
         }
+        self.cleanup_inspection_artifact(client)
         client.inspection_request_id = incoming.request_id
         client.inspection_repository_id = incoming.repository_id
         client.inspection_worktree_path = incoming.worktree_path
@@ -374,6 +431,8 @@ class DasHerdWatcherServer : HvWebServer {
             client.inspection_diff_context = "compact"
         }
         client.inspection_session_id = ""
+        client.inspection_phase = "diff"
+        client.inspection_patch = ""
         client.inspection_delivered = true
 
         var inscope argv : array<string>
@@ -415,21 +474,74 @@ class DasHerdWatcherServer : HvWebServer {
         if (!watcher_get_session_info(client.inspection_session_id, info)
                 || !info.drained) return
         var truncated = false
-        let patch = watcher_machine_output_text(client.inspection_session_id, truncated)
+        let output = watcher_machine_output_text(client.inspection_session_id, truncated)
         let _compacted = watcher_compact_session(client.inspection_session_id, 80, 25)
+        if (client.inspection_phase == "staged-view") {
+            client.inspection_delivered = true
+            if (truncated) {
+                self.cleanup_inspection_artifact(client)
+                client.inspection_patch = ""
+                self.send_file_inspection(client, false, "",
+                    "staged file command exceeded the retained machine-output limit")
+                return
+            }
+            if (info.exit_code != client.inspection_expected_exit_code) {
+                self.cleanup_inspection_artifact(client)
+                client.inspection_patch = ""
+                self.send_file_inspection(client, false, "",
+                    "git show exited with {info.exit_code}: {output}")
+                return
+            }
+            var view_text = ""
+            var view_base64 = ""
+            var view_byte_count = 0
+            var view_error = ""
+            if (git_patch_is_binary(client.inspection_patch)) {
+                var inscope bytes : array<uint8>
+                view_error = repository_read_file_bytes(
+                    client.inspection_artifact_path,
+                    MAX_FILE_PREVIEW_RAW_BYTES, bytes, view_byte_count)
+                if (empty(view_error) && !empty(bytes)) {
+                    view_base64 = base64_encode(bytes)
+                }
+            } else {
+                view_error = repository_read_text_file(
+                    client.inspection_artifact_path,
+                    MAX_FILE_PREVIEW_RAW_BYTES, view_text)
+            }
+            self.cleanup_inspection_artifact(client)
+            let patch = client.inspection_patch
+            client.inspection_patch = ""
+            if (!empty(view_error)) {
+                self.send_file_inspection(client, false, "", view_error)
+                return
+            }
+            self.send_file_inspection(client, false, patch, "", view_text,
+                "", view_base64, view_byte_count, true)
+            return
+        }
         client.inspection_delivered = true
         if (truncated) {
             self.send_file_inspection(client, false, "",
                 "diff exceeded the retained machine-output limit")
         } elif (info.exit_code != client.inspection_expected_exit_code) {
             self.send_file_inspection(client, false, "",
-                "git diff exited with {info.exit_code}: {patch}")
+                "git diff exited with {info.exit_code}: {output}")
         } else {
+            if (client.inspection_comparison == "staged") {
+                if (git_patch_result_is_deleted(output)) {
+                    self.send_file_inspection(client, false, output, "",
+                        "", "", "", 0, true)
+                    return
+                }
+                self.start_staged_file_view(client, output)
+                return
+            }
             var view_text = ""
             var view_base64 = ""
             var view_byte_count = 0
             if (client.inspection_comparison == "working") {
-                let binary = git_patch_is_binary(patch)
+                let binary = git_patch_is_binary(output)
                 var view_error = ""
                 if (binary) {
                     var inscope bytes : array<uint8>
@@ -438,7 +550,7 @@ class DasHerdWatcherServer : HvWebServer {
                         client.inspection_repository_id,
                         client.inspection_worktree_path,
                         client.inspection_file_path,
-                        MAX_BINARY_PREVIEW_RAW_BYTES, bytes, view_byte_count)
+                        MAX_FILE_PREVIEW_RAW_BYTES, bytes, view_byte_count)
                     if (empty(view_error)) {
                         if (!empty(bytes)) {
                             view_base64 = base64_encode(bytes)
@@ -448,15 +560,16 @@ class DasHerdWatcherServer : HvWebServer {
                     view_error = repository_working_file_text(
                         client.inspection_repository_id,
                         client.inspection_worktree_path,
-                        client.inspection_file_path, view_text)
+                        client.inspection_file_path,
+                        MAX_FILE_PREVIEW_RAW_BYTES, view_text)
                 }
                 if (!empty(view_error)) {
                     self.send_file_inspection(client, false, "", view_error)
                     return
                 }
             }
-            self.send_file_inspection(client, false, patch, "", view_text,
-                "", view_base64, view_byte_count)
+            self.send_file_inspection(client, false, output, "", view_text,
+                "", view_base64, view_byte_count, true)
         }
     }
 
@@ -523,6 +636,7 @@ class DasHerdWatcherServer : HvWebServer {
         if (index < 0) return
         var client = clients[index]
         detach(client, "client_closed")
+        self.cleanup_inspection_artifact(client)
         clients |> erase(index)
         unsafe { delete client }
     }
@@ -644,6 +758,7 @@ class DasHerdWatcherServer : HvWebServer {
             var client = clients[index]
             if (client != null) {
                 detach(client, "server_shutdown")
+                self.cleanup_inspection_artifact(client)
                 unsafe { delete client }
             }
         }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -647,6 +647,7 @@ class DasHerdWatcherServer : HvWebServer {
                 unsafe { delete client }
             }
         }
+        clients |> clear()
         unsafe { delete clients }
     }
 }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -480,15 +480,17 @@ class DasHerdWatcherServer : HvWebServer {
             client.inspection_delivered = true
             if (truncated) {
                 self.cleanup_inspection_artifact(client)
+                let patch = client.inspection_patch
                 client.inspection_patch = ""
-                self.send_file_inspection(client, false, "",
+                self.send_file_inspection(client, false, patch,
                     "staged file command exceeded the retained machine-output limit")
                 return
             }
             if (info.exit_code != client.inspection_expected_exit_code) {
                 self.cleanup_inspection_artifact(client)
+                let patch = client.inspection_patch
                 client.inspection_patch = ""
-                self.send_file_inspection(client, false, "",
+                self.send_file_inspection(client, false, patch,
                     "git show exited with {info.exit_code}: {output}")
                 return
             }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -513,7 +513,7 @@ class DasHerdWatcherServer : HvWebServer {
             let patch = client.inspection_patch
             client.inspection_patch = ""
             if (!empty(view_error)) {
-                self.send_file_inspection(client, false, "", view_error)
+                self.send_file_inspection(client, false, patch, view_error)
                 return
             }
             self.send_file_inspection(client, false, patch, "", view_text,
@@ -564,7 +564,7 @@ class DasHerdWatcherServer : HvWebServer {
                         MAX_FILE_PREVIEW_RAW_BYTES, view_text)
                 }
                 if (!empty(view_error)) {
-                    self.send_file_inspection(client, false, "", view_error)
+                    self.send_file_inspection(client, false, output, view_error)
                     return
                 }
             }
@@ -659,7 +659,8 @@ class DasHerdWatcherServer : HvWebServer {
             send_repositories(client, true)
         } elif (incoming.op == "repository_add") {
             let error = repository_add(RepositoryAddRequest(path = incoming.repository_path,
-                display_name = incoming.display_name, target_id = incoming.target_id))
+                display_name = incoming.display_name,
+                target_id = watcher_target_id_or_local(incoming.target_id)))
             if (!empty(error)) {
                 send_error(channel, error)
                 return
@@ -675,7 +676,8 @@ class DasHerdWatcherServer : HvWebServer {
             var inscope launch = WatcherLaunchRequest(
                 command_line = incoming.command_line, cwd = incoming.cwd,
                 display_name = incoming.display_name, kind = incoming.kind,
-                target_id = incoming.target_id, repository_id = incoming.repository_id,
+                target_id = watcher_target_id_or_local(incoming.target_id),
+                repository_id = incoming.repository_id,
                 worktree_path = incoming.worktree_path,
                 columns = incoming.columns, rows = incoming.rows,
                 timeout_ms = incoming.timeout_ms)

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -381,7 +381,7 @@ class DasHerdWatcherServer : HvWebServer {
             artifact_path, argv)
         if (!empty(command_error)) {
             client.inspection_delivered = true
-            self.send_file_inspection(client, false, "", command_error)
+            self.send_file_inspection(client, false, patch, command_error)
             return
         }
         let _pruned = watcher_prune_completed_sessions(
@@ -405,7 +405,7 @@ class DasHerdWatcherServer : HvWebServer {
             client.inspection_delivered = true
             self.cleanup_inspection_artifact(client)
             client.inspection_patch = ""
-            self.send_file_inspection(client, false, "", result.error)
+            self.send_file_inspection(client, false, patch, result.error)
             return
         }
         client.inspection_delivered = false

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -17,7 +17,6 @@ require daslib/base64
 require strings
 
 let private MAX_REQUEST_BODY_BYTES = 1024 * 1024
-let private MAX_BINARY_PREVIEW_BYTES = 32 * 1024 * 1024
 let private CONTROLLER_HEARTBEAT_TIMEOUT_MS = 5000l
 var private g_watcher_gc_requested = false
 
@@ -439,7 +438,7 @@ class DasHerdWatcherServer : HvWebServer {
                         client.inspection_repository_id,
                         client.inspection_worktree_path,
                         client.inspection_file_path,
-                        MAX_BINARY_PREVIEW_BYTES, bytes, view_byte_count)
+                        MAX_BINARY_PREVIEW_RAW_BYTES, bytes, view_byte_count)
                     if (empty(view_error)) {
                         if (!empty(bytes)) {
                             view_base64 = base64_encode(bytes)

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -12,9 +12,11 @@ require dashv/dashv_boost public
 require ./watcher_core.das public
 require ./repository_core.das public
 require daslib/json_boost
+require daslib/base64
 require strings
 
 let private MAX_REQUEST_BODY_BYTES = 1024 * 1024
+let private MAX_BINARY_PREVIEW_BYTES = 32 * 1024 * 1024
 let private CONTROLLER_HEARTBEAT_TIMEOUT_MS = 5000l
 var private g_watcher_gc_requested = false
 
@@ -69,6 +71,8 @@ struct public RepositoryFileInspectionMessage {
     loading : bool
     patch : string
     view_text : string
+    view_base64 : string
+    view_byte_count : int
     status : string
     error : string
 }
@@ -331,7 +335,9 @@ class DasHerdWatcherServer : HvWebServer {
 
     def send_file_inspection(var client : WatcherClient?;
                              loading : bool; patch, error : string;
-                             view_text : string = ""; status : string = "") {
+                             view_text : string = ""; status : string = "";
+                             view_base64 : string = "";
+                             view_byte_count : int = 0) {
         if (client == null) return
         let message = RepositoryFileInspectionMessage(
             request_id = client.inspection_request_id,
@@ -341,6 +347,7 @@ class DasHerdWatcherServer : HvWebServer {
             comparison = client.inspection_comparison,
             task_session_id = client.inspection_session_id,
             loading = loading, patch = patch, view_text = view_text,
+            view_base64 = view_base64, view_byte_count = view_byte_count,
             status = status, error = error)
         send(client.channel, sprint_json(message, false),
             ws_opcode.WS_OPCODE_TEXT, true)
@@ -411,17 +418,37 @@ class DasHerdWatcherServer : HvWebServer {
                 "git diff exited with {info.exit_code}: {patch}")
         } else {
             var view_text = ""
+            var view_base64 = ""
+            var view_byte_count = 0
             if (client.inspection_comparison == "working") {
-                let view_error = repository_working_file_text(
-                    client.inspection_repository_id,
-                    client.inspection_worktree_path,
-                    client.inspection_file_path, view_text)
+                let binary = find(patch, "Binary files ") >= 0 || find(patch, "GIT binary patch") >= 0
+                var view_error = ""
+                if (binary) {
+                    var inscope bytes : array<uint8>
+                    view_error = repository_working_file_bytes(
+                        client.inspection_repository_id,
+                        client.inspection_worktree_path,
+                        client.inspection_file_path, bytes)
+                    if (empty(view_error)) {
+                        view_byte_count = length(bytes)
+                        if (!empty(bytes)
+                                && view_byte_count <= MAX_BINARY_PREVIEW_BYTES) {
+                            view_base64 = base64_encode(bytes)
+                        }
+                    }
+                } else {
+                    view_error = repository_working_file_text(
+                        client.inspection_repository_id,
+                        client.inspection_worktree_path,
+                        client.inspection_file_path, view_text)
+                }
                 if (!empty(view_error)) {
                     self.send_file_inspection(client, false, "", view_error)
                     return
                 }
             }
-            self.send_file_inspection(client, false, patch, "", view_text)
+            self.send_file_inspection(client, false, patch, "", view_text,
+                "", view_base64, view_byte_count)
         }
     }
 

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -50,6 +50,7 @@ struct private WatcherWsMessage {
     worktree_path : string
     file_path : string
     comparison : string
+    diff_context : string
     request_id : int
     text : string
     columns : int
@@ -67,6 +68,7 @@ struct public RepositoryFileInspectionMessage {
     worktree_path : string
     file_path : string
     comparison : string
+    diff_context : string
     task_session_id : string
     loading : bool
     patch : string
@@ -93,6 +95,7 @@ class private WatcherClient {
     inspection_worktree_path : string
     inspection_file_path : string
     inspection_comparison : string
+    inspection_diff_context : string
     inspection_session_id : string
     inspection_expected_exit_code : int64
     inspection_delivered : bool = true
@@ -345,6 +348,7 @@ class DasHerdWatcherServer : HvWebServer {
             worktree_path = client.inspection_worktree_path,
             file_path = client.inspection_file_path,
             comparison = client.inspection_comparison,
+            diff_context = client.inspection_diff_context,
             task_session_id = client.inspection_session_id,
             loading = loading, patch = patch, view_text = view_text,
             view_base64 = view_base64, view_byte_count = view_byte_count,
@@ -365,6 +369,10 @@ class DasHerdWatcherServer : HvWebServer {
         client.inspection_worktree_path = incoming.worktree_path
         client.inspection_file_path = incoming.file_path
         client.inspection_comparison = incoming.comparison
+        client.inspection_diff_context = incoming.diff_context
+        if (empty(client.inspection_diff_context)) {
+            client.inspection_diff_context = "compact"
+        }
         client.inspection_session_id = ""
         client.inspection_delivered = true
 
@@ -373,7 +381,7 @@ class DasHerdWatcherServer : HvWebServer {
         let command_error = repository_file_diff_argv(
             incoming.repository_id, incoming.worktree_path,
             incoming.file_path, incoming.comparison,
-            argv, expected_exit_code)
+            argv, expected_exit_code, client.inspection_diff_context)
         if (!empty(command_error)) {
             self.send_file_inspection(client, false, "", command_error)
             return
@@ -397,7 +405,7 @@ class DasHerdWatcherServer : HvWebServer {
         }
         client.inspection_delivered = false
         self.send_file_inspection(client, true, "", "", "",
-            "Computing compact Git diff (15 second limit)...")
+            "Computing {client.inspection_diff_context} Git diff (15 second limit)...")
     }
 
     def poll_file_inspection(var client : WatcherClient?) {

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -10,6 +10,7 @@ module watcher_server shared public
 
 require dashv/dashv_boost public
 require ./watcher_core.das public
+require ./repository_core.das public
 require daslib/json_boost
 require strings
 
@@ -37,13 +38,39 @@ struct private WatcherWsMessage {
     op : string
     session_id : string
     command_line : string
+    argv : array<string>
     cwd : string
+    display_name : string
+    kind : string
+    target_id : string
+    repository_id : string
+    repository_path : string
+    worktree_path : string
+    file_path : string
+    comparison : string
+    request_id : int
     text : string
     columns : int
     rows : int
     timeout_ms : int64
     control : bool
     raw : bool
+}
+
+struct public RepositoryFileInspectionMessage {
+    @rename = "type"
+    _type : string = "file_inspection"
+    request_id : int
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    comparison : string
+    task_session_id : string
+    loading : bool
+    patch : string
+    view_text : string
+    status : string
+    error : string
 }
 
 class private WatcherClient {
@@ -56,6 +83,15 @@ class private WatcherClient {
     last_update_key : string
     raw : bool
     raw_offset : int64
+    repository_revision : int64 = -1l
+    inspection_request_id : int
+    inspection_repository_id : string
+    inspection_worktree_path : string
+    inspection_file_path : string
+    inspection_comparison : string
+    inspection_session_id : string
+    inspection_expected_exit_code : int64
+    inspection_delivered : bool = true
 }
 
 struct private WatcherOk {
@@ -79,7 +115,7 @@ def private hex_nibble(value : int) : int {
 }
 
 def private percent_decode(value : string) : string {
-    var decoded : array<uint8>
+    var inscope decoded : array<uint8>
     decoded |> reserve(length(value))
     peek_data(value) $(data) {
         var index = 0
@@ -177,6 +213,10 @@ class DasHerdWatcherServer : HvWebServer {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
             return resp |> JSON(watcher_list_json(), http_status.OK)
         }
+        GET("/api/v1/repositories") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            return resp |> JSON(repository_list_json(), http_status.OK)
+        }
         POST("/api/v1/gc") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
             let coalesced = watcher_request_gc()
@@ -188,13 +228,39 @@ class DasHerdWatcherServer : HvWebServer {
             if (req == null || length(req.body) > MAX_REQUEST_BODY_BYTES) {
                 return self.respond_error(resp, http_status.BAD_REQUEST, "request body is too large")
             }
-            var launch = WatcherLaunchRequest()
+            var inscope launch = WatcherLaunchRequest()
             if (!sscan_json(string(req.body), launch)) {
                 return self.respond_error(resp, http_status.BAD_REQUEST, "invalid launch JSON")
             }
             let result = watcher_launch(launch)
             return resp |> JSON(sprint_json(result, false),
                 result.ok ? http_status.CREATED : http_status.BAD_REQUEST)
+        }
+        POST("/api/v1/repositories") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            if (req == null || length(req.body) > MAX_REQUEST_BODY_BYTES) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "request body is too large")
+            }
+            var request = RepositoryAddRequest()
+            if (!sscan_json(string(req.body), request)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "invalid repository JSON")
+            }
+            let error = repository_add(request)
+            if (!empty(error)) return self.respond_error(resp, http_status.CONFLICT, error)
+            return resp |> JSON(sprint_json(WatcherOk(), false), http_status.CREATED)
+        }
+        POST("/api/v1/repositories/refresh") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            if (req == null || length(req.body) > MAX_REQUEST_BODY_BYTES) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "request body is too large")
+            }
+            var request = RepositoryRefreshRequest()
+            if (!sscan_json(string(req.body), request)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "invalid refresh JSON")
+            }
+            let error = repository_refresh(request.repository_id)
+            if (!empty(error)) return self.respond_error(resp, http_status.CONFLICT, error)
+            return resp |> JSON(sprint_json(WatcherOk(), false), http_status.ACCEPTED)
         }
         POST("/api/v1/input") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
@@ -254,6 +320,111 @@ class DasHerdWatcherServer : HvWebServer {
             ws_opcode.WS_OPCODE_TEXT, true)
     }
 
+    def send_repositories(var client : WatcherClient?; force : bool = false) {
+        if (client == null) return
+        let revision = repository_revision()
+        if (!force && client.repository_revision == revision) return
+        client.repository_revision = revision
+        send(client.channel, "\{\"type\":\"repositories\",\"data\":{repository_list_json()}\}",
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def send_file_inspection(var client : WatcherClient?;
+                             loading : bool; patch, error : string;
+                             view_text : string = ""; status : string = "") {
+        if (client == null) return
+        let message = RepositoryFileInspectionMessage(
+            request_id = client.inspection_request_id,
+            repository_id = client.inspection_repository_id,
+            worktree_path = client.inspection_worktree_path,
+            file_path = client.inspection_file_path,
+            comparison = client.inspection_comparison,
+            task_session_id = client.inspection_session_id,
+            loading = loading, patch = patch, view_text = view_text,
+            status = status, error = error)
+        send(client.channel, sprint_json(message, false),
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def start_file_inspection(var client : WatcherClient?;
+                              incoming : WatcherWsMessage const) {
+        if (client == null) return
+        if (!empty(client.inspection_session_id)
+                && watcher_accepts_input(client.inspection_session_id)) {
+            let _ = watcher_terminate(client.inspection_session_id, "superseded")
+        }
+        client.inspection_request_id = incoming.request_id
+        client.inspection_repository_id = incoming.repository_id
+        client.inspection_worktree_path = incoming.worktree_path
+        client.inspection_file_path = incoming.file_path
+        client.inspection_comparison = incoming.comparison
+        client.inspection_session_id = ""
+        client.inspection_delivered = true
+
+        var inscope argv : array<string>
+        var expected_exit_code = 0l
+        let command_error = repository_file_diff_argv(
+            incoming.repository_id, incoming.worktree_path,
+            incoming.file_path, incoming.comparison,
+            argv, expected_exit_code)
+        if (!empty(command_error)) {
+            self.send_file_inspection(client, false, "", command_error)
+            return
+        }
+        let _pruned = watcher_prune_completed_sessions(
+            "git-file-diff", incoming.repository_id, incoming.worktree_path)
+        var inscope request = WatcherLaunchRequest(
+            cwd = incoming.worktree_path,
+            display_name = "Git diff: {incoming.file_path}",
+            kind = "git-file-diff", target_id = "local",
+            repository_id = incoming.repository_id,
+            worktree_path = incoming.worktree_path,
+            columns = 80, rows = 25, timeout_ms = 15000l)
+        request.argv := argv
+        let result = watcher_launch(request)
+        client.inspection_session_id = result.session_id
+        client.inspection_expected_exit_code = expected_exit_code
+        if (!result.ok) {
+            self.send_file_inspection(client, false, "", result.error)
+            return
+        }
+        client.inspection_delivered = false
+        self.send_file_inspection(client, true, "", "", "",
+            "Computing compact Git diff (15 second limit)...")
+    }
+
+    def poll_file_inspection(var client : WatcherClient?) {
+        if (client == null || client.inspection_delivered
+                || empty(client.inspection_session_id)) return
+        var info = WatcherSessionInfo()
+        if (!watcher_get_session_info(client.inspection_session_id, info)
+                || !info.drained) return
+        var truncated = false
+        let patch = watcher_machine_output_text(client.inspection_session_id, truncated)
+        let _compacted = watcher_compact_session(client.inspection_session_id, 80, 25)
+        client.inspection_delivered = true
+        if (truncated) {
+            self.send_file_inspection(client, false, "",
+                "diff exceeded the retained machine-output limit")
+        } elif (info.exit_code != client.inspection_expected_exit_code) {
+            self.send_file_inspection(client, false, "",
+                "git diff exited with {info.exit_code}: {patch}")
+        } else {
+            var view_text = ""
+            if (client.inspection_comparison == "working") {
+                let view_error = repository_working_file_text(
+                    client.inspection_repository_id,
+                    client.inspection_worktree_path,
+                    client.inspection_file_path, view_text)
+                if (!empty(view_error)) {
+                    self.send_file_inspection(client, false, "", view_error)
+                    return
+                }
+            }
+            self.send_file_inspection(client, false, patch, "", view_text)
+        }
+    }
+
     def send_snapshot(var client : WatcherClient?; force : bool = false) {
         if (client == null || empty(client.session_id)) return
         let update_key = watcher_update_key(client.session_id)
@@ -270,7 +441,7 @@ class DasHerdWatcherServer : HvWebServer {
 
     def send_raw_output(var client : WatcherClient?) {
         if (client == null || !client.raw || empty(client.session_id)) return
-        var chunk <- watcher_output_since(client.session_id, client.raw_offset)
+        var inscope chunk <- watcher_output_since(client.session_id, client.raw_offset)
         if (chunk.reset) {
             let start_offset = chunk.next_offset - int64(length(chunk.bytes))
             send(client.channel, "\{\"type\":\"raw_reset\",\"offset\":{start_offset}\}",
@@ -309,6 +480,7 @@ class DasHerdWatcherServer : HvWebServer {
         send(channel, "\{\"type\":\"connected\",\"client_id\":{next_client_id}\}",
             ws_opcode.WS_OPCODE_TEXT, true)
         send_sessions(channel)
+        send_repositories(clients[length(clients) - 1], true)
     }
 
     def override onWsClose(channel : WebSocketChannel) {
@@ -323,7 +495,7 @@ class DasHerdWatcherServer : HvWebServer {
     def override onWsMessage(channel : WebSocketChannel; message : string#) {
         let index = find_client(channel)
         if (index < 0) return
-        var incoming : WatcherWsMessage
+        var inscope incoming : WatcherWsMessage
         if (length(message) > MAX_REQUEST_BODY_BYTES || !sscan_json(string(message), incoming)) {
             send_error(channel, "invalid WebSocket message")
             return
@@ -335,11 +507,31 @@ class DasHerdWatcherServer : HvWebServer {
             send(channel, "\{\"type\":\"heartbeat\"\}", ws_opcode.WS_OPCODE_TEXT, true)
         } elif (incoming.op == "list") {
             send_sessions(channel)
+            send_repositories(client, true)
+        } elif (incoming.op == "repository_add") {
+            let error = repository_add(RepositoryAddRequest(path = incoming.repository_path,
+                display_name = incoming.display_name, target_id = incoming.target_id))
+            if (!empty(error)) {
+                send_error(channel, error)
+                return
+            }
+            send_repositories(client, true)
+        } elif (incoming.op == "repository_refresh") {
+            let error = repository_refresh(incoming.repository_id)
+            if (!empty(error)) send_error(channel, error)
+            send_repositories(client, true)
+        } elif (incoming.op == "file_inspect") {
+            self.start_file_inspection(client, incoming)
         } elif (incoming.op == "launch") {
-            let result = watcher_launch(WatcherLaunchRequest(
+            var inscope launch = WatcherLaunchRequest(
                 command_line = incoming.command_line, cwd = incoming.cwd,
+                display_name = incoming.display_name, kind = incoming.kind,
+                target_id = incoming.target_id, repository_id = incoming.repository_id,
+                worktree_path = incoming.worktree_path,
                 columns = incoming.columns, rows = incoming.rows,
-                timeout_ms = incoming.timeout_ms))
+                timeout_ms = incoming.timeout_ms)
+            launch.argv := incoming.argv
+            let result = watcher_launch(launch)
             if (!result.ok) {
                 send_error(channel, result.error)
                 return
@@ -396,6 +588,7 @@ class DasHerdWatcherServer : HvWebServer {
 
     def override onTick {
         watcher_tick()
+        repository_tick()
         for (index in range(length(clients))) {
             var client = clients[index]
             if (client == null) continue
@@ -406,6 +599,8 @@ class DasHerdWatcherServer : HvWebServer {
             }
             send_snapshot(client)
             send_raw_output(client)
+            send_repositories(client)
+            self.poll_file_inspection(client)
         }
     }
 
@@ -417,6 +612,6 @@ class DasHerdWatcherServer : HvWebServer {
                 unsafe { delete client }
             }
         }
-        clients |> clear()
+        unsafe { delete clients }
     }
 }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -473,7 +473,7 @@ class DasHerdWatcherServer : HvWebServer {
         var info = WatcherSessionInfo()
         if (!watcher_get_session_info(client.inspection_session_id, info)
                 || !info.drained) return
-        var truncated = false
+        let truncated = false
         let output = watcher_machine_output_text(client.inspection_session_id, truncated)
         let _compacted = watcher_compact_session(client.inspection_session_id, 80, 25)
         if (client.inspection_phase == "staged-view") {


### PR DESCRIPTION
## Summary
- add the dockable dasHerd worktree/status/file-inspector vertical slice on top of the detachable watcher primitive
- prepare diffs asynchronously with compact, expanded, and full-file contexts; synchronized side-by-side scrolling; syntax highlighting; Markdown view; and bundled image previews
- make watcher Git observation robust and inspectable, including Unicode Windows paths and live pane geometry
- extend the terminal host seam needed by watcher-owned structured Git tasks

## Validation
- 43 focused watcher, inspection-worker, repository, lifecycle, and UTF-8 file-I/O assertions pass
- Release `daslang` and `daslang-live` rebuilt successfully
- live Unicode fixture opens with valid UTF-8 content
- native scrollbar drag verified both panes at the same `2257 / 3904` position
- Ctrl+wheel inspector zoom verified at a 5% step

## Dependency
- borisbat/dasImgui#230 provides the source-view and Markdown rendering primitives used by the rich client