### PR TITLE
dasLLAMA: GLM stack - native Q4_0 GPU tier, gemma-4 MoE prefill, Q5_K encoder, noisy rail, SPIR-V loop hints

### DIFF
--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -75,6 +75,12 @@ struct Args {
     @clarg_doc = "Native K-quant planes A/B: 1 = keep Q4_K/Q5_K/Q6_K packed at load, 0 = q8-requant fallback, -1 = keep default"
     kquant_native : int = -1
 
+    @clarg_doc = "Q5_0 -> k5 re-encode A/B: 1 = re-quantize Q5_0 into the k5 plane at load (LOSSY, 9.0 -> 5.625 bits), 0 = bit-exact Q5_0 -> Q8, -1 = keep default"
+    q50_native : int = -1
+
+    @clarg_doc = "Noisy diagnostics: the loader reports backend, format tags and plane bytes (also DASLLAMA_NOISY=1)"
+    noisy : bool
+
     @clarg_doc = "A/B: size chunk counts to workers only (the pre-fix split), not workers + caller lane"
     legacy_lanes : bool
 
@@ -310,6 +316,13 @@ def main() {
     if (cfg.kquant_native >= 0) {
         set_kquant_native(cfg.kquant_native != 0)
         print("kquant_native override: {cfg.kquant_native != 0}\n")
+    }
+    if (cfg.q50_native >= 0) {
+        set_kq_q50_native(cfg.q50_native != 0)
+        print("q50_native override: {cfg.q50_native != 0}\n")
+    }
+    if (cfg.noisy) {
+        set_dasllama_noisy(true)
     }
     // the resident whole-decode override (dasMetal emission arc): claims the ENTIRE layer stack
     // per token; needs the f32 scale plane + a row-major backend (like DASLLAMA_PIN_PREFILL)

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -54,6 +54,9 @@ struct Args {
     @clarg_doc = "A/B the attention GPU chain in-process: every row runs twice, attention routing OFF then ON. Needs DASLLAMA_GPU_ATTN=1 (uploads + marks); mutually exclusive with the other A/B levers"
     attn_ab : bool
 
+    @clarg_doc = "A/B the GPU MoE prefill arm in-process: every row runs twice, device-side prefill OFF then ON. Needs resident expert layers (DASLLAMA_GPU_MOE_LAYERS); decode has no npos gate so tg reads as a wash. Mutually exclusive with the other A/B levers"
+    prefill_ab : bool
+
     @clarg_short = "?"
     @clarg_doc = "Show this help and exit"
     help : bool
@@ -125,6 +128,9 @@ def main() {
     if (cfg.attn_ab && !has_env_variable("DASLLAMA_GPU_ATTN")) {
         print("warning: --attn-ab without DASLLAMA_GPU_ATTN=1 — no attention marks, both arms identical\n")
     }
+    if (cfg.prefill_ab && !has_env_variable("DASLLAMA_GPU_MOE_LAYERS") && !has_env_variable("DASLLAMA_GPU_MOE_STREAM")) {
+        print("warning: --prefill-ab without DASLLAMA_GPU_MOE_LAYERS/_STREAM — no resident expert layers, both arms identical\n")
+    }
     print("loading {cfg.model}\n")
     with_job_que() {
         setup_dasllama_jobque_()
@@ -136,10 +142,10 @@ def main() {
         let c = t.config
         print("config: dim={c.dim} layers={c.n_layers} vocab={c.vocab_size} | backend {active_kernel_backend()} (batch {active_batch_backend()}) | t{threads} affinity {pinned ? "hard" : "env/off"} | pp{plen} tg{ngen} x {reps} reps\n")
         var s <- make_run_state(c)
-        if ((cfg.dense_ab ? 1 : 0) + (cfg.comb_ab ? 1 : 0) + (cfg.dn_ab ? 1 : 0) + (cfg.attn_ab ? 1 : 0) > 1) {
-            print("warning: --dense-ab / --comb-ab / --dn-ab / --attn-ab are mutually exclusive — running the first only\n")
+        if ((cfg.dense_ab ? 1 : 0) + (cfg.comb_ab ? 1 : 0) + (cfg.dn_ab ? 1 : 0) + (cfg.attn_ab ? 1 : 0) + (cfg.prefill_ab ? 1 : 0) > 1) {
+            print("warning: --dense-ab / --comb-ab / --dn-ab / --attn-ab / --prefill-ab are mutually exclusive — running the first only\n")
         }
-        let ab = cfg.dense_ab || cfg.comb_ab || cfg.dn_ab || cfg.attn_ab
+        let ab = cfg.dense_ab || cfg.comb_ab || cfg.dn_ab || cfg.attn_ab || cfg.prefill_ab
         for (arm in range(ab ? 2 : 1)) {
             var dtag = ""
             if (cfg.dense_ab) {
@@ -154,6 +160,9 @@ def main() {
             } elif (cfg.attn_ab) {
                 dtag = arm == 0 ? " attn=off" : " attn=on"
                 set_moe_gpu_attn_route(arm != 0)
+            } elif (cfg.prefill_ab) {
+                dtag = arm == 0 ? " gpuprefill=off" : " gpuprefill=on"
+                set_moe_gpu_prefill_route(arm != 0)
             }
             if (plen > 0l) {
                 let warm <- build_prompt(plen, 999l)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1789,6 +1789,19 @@ def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice
 
 def private moe_gpu_fmt_kq(f : KqFmt) : bool => f == KqFmt.k4 || f == KqFmt.k5 || f == KqFmt.k6 || f == KqFmt.q40
 
+// a plane the dense rail can serve: a format the tier has kernels for, repacked if native-kq
+def private dense_plane_ok(t : Model; f : KqFmt) : bool => (f == KqFmt.q8 || moe_gpu_fmt_kq(f)) && kq_servable(t, f)
+
+// layer l carries a parallel-dense shared expert whose whole w1/w3/w2 triple the tier can serve
+def private dense_shexp_uploadable(t : Model; l : int64) : bool {
+    if (!t.config.moe_dense_shexp || !gpu_want_dense_shexp() || int64(length(t.w1_offs)) <= l
+            || t.w1_offs[l] < 0l || t.w2_offs[l] < 0l || t.w3_offs[l] < 0l) {
+        return false
+    }
+    return (dense_plane_ok(t, fmt_at(t.w1_fmt, l)) && dense_plane_ok(t, fmt_at(t.w2_fmt, l))
+        && dense_plane_ok(t, fmt_at(t.w3_fmt, l)))
+}
+
 // Gather one stack through its format's reader (q8 planes or native kq planes) and hand it to
 // the tier's upload hook with the format tag.
 def private moe_gpu_gather_upload(t : Model; f : KqFmt; woff : int64; n, rows, slice_rows : int64;
@@ -1891,12 +1904,19 @@ def moe_gpu_upload_resident(var t : Model) {
                 let qd = layer_qd(t.config, l)
                 let fq = fmt_at(t.wq_fmt, l)
                 let fo = fmt_at(t.wo_fmt, l)
-                if (t.wq_offs[l] >= 0l && t.wo_offs[l] >= 0l
+                if (gpu_want_dense_attn() && t.wq_offs[l] >= 0l && t.wo_offs[l] >= 0l
                         && (fq == KqFmt.q8 || moe_gpu_fmt_kq(fq)) && (fo == KqFmt.q8 || moe_gpu_fmt_kq(fo))
                         && kq_servable(t, fq) && kq_servable(t, fo)) {
                     uploads |> push((f = fq, woff = t.wq_offs[l], n = dim, rows = t.config.q_gated ? 2l * qd : qd))
                     uploads |> push((f = fo, woff = t.wo_offs[l], n = qd, rows = dim))
                 }
+            }
+            // gemma-4's parallel dense shared expert triple — opt-in, measured a wash (see the gate's doc)
+            if (dense_shexp_uploadable(t, l)) {
+                let hid = empty(t.ffn_w) ? t.config.hidden_dim : t.ffn_w[l]
+                uploads |> push((f = fmt_at(t.w1_fmt, l), woff = t.w1_offs[l], n = dim, rows = hid))
+                uploads |> push((f = fmt_at(t.w3_fmt, l), woff = t.w3_offs[l], n = dim, rows = hid))
+                uploads |> push((f = fmt_at(t.w2_fmt, l), woff = t.w2_offs[l], n = hid, rows = dim))
             }
             for (u in uploads) {
                 if (!moe_gpu_gather_upload(t, u.f, u.woff, u.n, u.rows, u.rows, mr, kgroup, wbias, wq, ws)) {

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1656,8 +1656,8 @@ def private kq_disk_nib6(rowq : uint8 const?; k : int64) : uint {
 def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice_rows : int64;
                             repacked : bool; mr : int64; var wq : array<uint8>; var ws : array<uint8>) {
     let nsb = n / 256l
-    let qsb = fmt == KqFmt.k4 ? 128l : (fmt == KqFmt.k5 ? 160l : 192l)
-    let dssb = fmt == KqFmt.k6 ? 18l : 20l   // disk/plane scale stride; device rows are 20B for all
+    let qsb = fmt == KqFmt.k5 ? 160l : (fmt == KqFmt.k6 ? 192l : 128l)   // k4 and q40 share the 128B nibble region
+    let dssb = fmt == KqFmt.k6 ? 18l : (fmt == KqFmt.q40 ? 16l : 20l)   // disk/plane scale stride; device rows are 20B for all
     assert(n % 256l == 0l, "GPU MoE kq gather: row length must be a superblock multiple")
     assert(rows * nsb * qsb <= 2147483647l, "GPU MoE kq stack exceeds the int32 gather-buffer rail")
     wq |> resize(int(rows * nsb * qsb))
@@ -1669,9 +1669,11 @@ def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice
     unsafe {
         let sb0 = woff / 256l
         let qp = (fmt == KqFmt.k4 ? addr<uint8 const?>(t.k4q[sb0 * 128l])
-            : (fmt == KqFmt.k5 ? addr<uint8 const?>(t.k5q[sb0 * 160l]) : addr<uint8 const?>(t.k6q[sb0 * 192l])))
+            : (fmt == KqFmt.k5 ? addr<uint8 const?>(t.k5q[sb0 * 160l])
+            : (fmt == KqFmt.k6 ? addr<uint8 const?>(t.k6q[sb0 * 192l]) : addr<uint8 const?>(t.q40q[sb0 * 128l]))))
         let sp = (fmt == KqFmt.k4 ? addr<uint8 const?>(t.k4s[sb0 * 20l])
-            : (fmt == KqFmt.k5 ? addr<uint8 const?>(t.k5s[sb0 * 20l]) : addr<uint8 const?>(t.k6s[sb0 * 18l])))
+            : (fmt == KqFmt.k5 ? addr<uint8 const?>(t.k5s[sb0 * 20l])
+            : (fmt == KqFmt.k6 ? addr<uint8 const?>(t.k6s[sb0 * 18l]) : addr<uint8 const?>(t.q40s[sb0 * 16l]))))
         var wqp = addr(wq[0])
         var wsp = addr(ws[0])
         let njobs = is_job_que_available() ? min(nslices, 4 * (get_total_hw_jobs() + 1)) : 1
@@ -1711,6 +1713,14 @@ def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice
                                     dsc[17] = gs[16l * mr + 2l * r + 1l]
                                     dsc[18] = uint8(0)
                                     dsc[19] = uint8(0)
+                                } elif (fmt == KqFmt.q40) {
+                                    for (blk in range64(8l)) {   // 8 per-block f16 d, mr-interleaved
+                                        dsc[blk * 2l] = gs[blk * 2l * mr + 2l * r]
+                                        dsc[blk * 2l + 1l] = gs[blk * 2l * mr + 2l * r + 1l]
+                                    }
+                                    for (idx in range64(16l, 20l)) {
+                                        dsc[idx] = uint8(0)
+                                    }
                                 } else {
                                     dsc[0] = gs[2l * r]
                                     dsc[1] = gs[2l * r + 1l]
@@ -1724,11 +1734,17 @@ def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice
                             } else {
                                 let rq = qp + sliceQ + ri * qrow + sbi * qsb
                                 let rs = sp + sliceS + ri * srow + sbi * dssb
-                                for (m in range64(128l)) {   // re-pair disk k/k+32 nibbles to k/k+16
-                                    let k = (m / 16l) * 32l + m % 16l
-                                    let lo = fmt == KqFmt.k6 ? kq_disk_nib6(rq, k) : kq_disk_nib45(rq, k)
-                                    let hi = fmt == KqFmt.k6 ? kq_disk_nib6(rq, k + 16l) : kq_disk_nib45(rq, k + 16l)
-                                    dq[m] = uint8(lo | (hi << 4u))
+                                if (fmt == KqFmt.q40) {
+                                    for (m in range64(128l)) {   // Q4_0 bytes already pair k / k+16
+                                        dq[m] = rq[m]
+                                    }
+                                } else {
+                                    for (m in range64(128l)) {   // re-pair disk k/k+32 nibbles to k/k+16
+                                        let k = (m / 16l) * 32l + m % 16l
+                                        let lo = fmt == KqFmt.k6 ? kq_disk_nib6(rq, k) : kq_disk_nib45(rq, k)
+                                        let hi = fmt == KqFmt.k6 ? kq_disk_nib6(rq, k + 16l) : kq_disk_nib45(rq, k + 16l)
+                                        dq[m] = uint8(lo | (hi << 4u))
+                                    }
                                 }
                                 if (fmt == KqFmt.k5) {
                                     for (bj in range64(32l)) {
@@ -1745,12 +1761,13 @@ def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice
                                         dq[128l + p] = rq[128l + p]
                                     }
                                 }
-                                if (fmt == KqFmt.k6) {
-                                    for (idx in range64(18l)) {
+                                if (fmt == KqFmt.k6 || fmt == KqFmt.q40) {
+                                    for (idx in range64(dssb)) {
                                         dsc[idx] = rs[idx]
                                     }
-                                    dsc[18] = uint8(0)
-                                    dsc[19] = uint8(0)
+                                    for (idx in range64(dssb, 20l)) {
+                                        dsc[idx] = uint8(0)
+                                    }
                                 } else {
                                     for (idx in range64(4l)) {   // f16 d + f16 dmin verbatim
                                         dsc[idx] = rs[idx]
@@ -1770,7 +1787,7 @@ def moe_gpu_gather_stack_kq(t : Model; fmt : KqFmt; woff : int64; n, rows, slice
     }
 }
 
-def private moe_gpu_fmt_kq(f : KqFmt) : bool => f == KqFmt.k4 || f == KqFmt.k5 || f == KqFmt.k6
+def private moe_gpu_fmt_kq(f : KqFmt) : bool => f == KqFmt.k4 || f == KqFmt.k5 || f == KqFmt.k6 || f == KqFmt.q40
 
 // Gather one stack through its format's reader (q8 planes or native kq planes) and hand it to
 // the tier's upload hook with the format tag.
@@ -1780,7 +1797,9 @@ def private moe_gpu_gather_upload(t : Model; f : KqFmt; woff : int64; n, rows, s
     if (f == KqFmt.q8) {
         moe_gpu_gather_stack(t, woff, n, rows, slice_rows, mr, kgroup, wbias, wq, ws)
     } else {
-        let kmr = t.kq_repacked ? (f == KqFmt.k4 ? t.kq_repack_mr4 : (f == KqFmt.k5 ? t.kq_repack_mr5 : t.kq_repack_mr6)) : 1l
+        let kmr = t.kq_repacked ? (f == KqFmt.k4 ? t.kq_repack_mr4
+            : (f == KqFmt.k5 ? t.kq_repack_mr5
+            : (f == KqFmt.k6 ? t.kq_repack_mr6 : t.kq_repack_mr40))) : 1l
         moe_gpu_gather_stack_kq(t, f, woff, n, rows, slice_rows, t.kq_repacked, kmr, wq, ws)
     }
     return moe_gpu_upload_stack(wq, ws, woff, n, rows, int(f), stream)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -10385,6 +10385,17 @@ def set_gpu_combine_route(on : bool) {
     g_gpu_combine = on
 }
 
+var private g_gpu_prefill_route = true
+
+//! Runtime routing gate over the GPU MoE PREFILL arm (`fused_gpu`) in both grouped prefills —
+//! the generic one and gemma-4's twin. Routing-only: uploads and residency stay put, so an
+//! in-process A/B isolates device-side prefill against the same resident set (decode is untouched).
+def set_moe_gpu_prefill_route(on : bool) {
+    g_gpu_prefill_route = on
+}
+
+def private gpu_prefill_route_on() : bool => g_gpu_prefill_route
+
 def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos : int64) {
     let c = t.config
     let dim = c.dim
@@ -10405,7 +10416,7 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         && t.kq_repacked && kernel_backend_has_kq_batch_groupn() && g_moe_fused_expert_gemms)
     // GPU MoE tier: offloaded layers run the whole expert FFN chain device-side; tiny batches stay CPU (GPU submit cost > the GEMM)
     let fused_gpu = (!c.moe_exps_bias && !t.experts_mx4 && c.ffn_act != FfnAct.swiglu_oai
-        && (moe_gpu_layer_on_gpu(l) || moe_gpu_layer_streamed(l)) && g_moe_fused_expert_gemms && npos >= 32l)
+        && (moe_gpu_layer_on_gpu(l) || moe_gpu_layer_streamed(l)) && g_moe_fused_expert_gemms && npos >= 32l && gpu_prefill_route_on())
     // device-side combine rides fused_gpu; DASLLAMA_GPU_COMBINE=0 falls back to park + CPU reduce
     let gpu_comb = fused_gpu && gpu_combine_on()
     let fused = (t.experts_mx4 && g_active_mx4_native_batch && g_moe_fused_expert_gemms) || fused_kq || fused_gpu
@@ -10816,7 +10827,7 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
     let f3 = fmt_at(t.we3_fmt, l)
     // GPU tier: offloaded layers run the routed chain device-side; the fused arm gathers ALL nk bucket rows at once (grows)
     let fused_gpu = (!c.moe_exps_bias && !t.experts_mx4 && c.ffn_act != FfnAct.swiglu_oai
-        && (moe_gpu_layer_on_gpu(l) || moe_gpu_layer_streamed(l)) && g_moe_fused_expert_gemms && npos >= 32l)
+        && (moe_gpu_layer_on_gpu(l) || moe_gpu_layer_streamed(l)) && g_moe_fused_expert_gemms && npos >= 32l && gpu_prefill_route_on())
     let gpu_comb = fused_gpu && gpu_combine_on()
     let grows = fused_gpu ? nk : npos
     s.moe_rlog |> resize(npos * ne)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1203,7 +1203,13 @@ def private load_big(m : GGUFMeta; bytes : array<uint8> | #; name : string; var 
     if (fmt == KqFmt.k4) {
         gguf_transcode_q4k(m, bytes, name, t.k4q, t.k4s, woff, n, src_off)
     } elif (fmt == KqFmt.k5) {
-        gguf_transcode_q5k(m, bytes, name, t.k5q, t.k5s, woff, n, src_off)
+        if (gguf_tensor_type(m, name) == GGML_TYPE_Q5_K) {
+            gguf_transcode_q5k(m, bytes, name, t.k5q, t.k5s, woff, n, src_off)
+        } else {   // Q5_0 source: no exact embedding exists, so dequant and re-encode (lossy)
+            scratch |> resize(n)
+            gguf_read_tensor_f32(m, bytes, name, scratch, 0l, n, src_off)
+            quantize_k5_plane(scratch, n, t.k5q, t.k5s, woff)
+        }
     } elif (fmt == KqFmt.k6) {
         gguf_transcode_q6k(m, bytes, name, t.k6q, t.k6s, woff, n, src_off)
     } elif (fmt == KqFmt.q40) {
@@ -1404,6 +1410,51 @@ def public get_kq_q40_native() : bool {
     return g_kq_q40_native
 }
 
+// Q5_0 -> k5 re-encode knob. Unlike the other tags this one is NOT a relabel: Q5_0 has no exact
+// Q5_K embedding, so the load re-quantizes (measured +0.031 rel-rmse on GLM's ffn_down) to buy
+// 9.0 -> 5.625 bits. OFF keeps the bit-exact Q5_0 -> Q8 path — the A/B rail, and the quality out.
+var private g_kq_q50_native = false
+
+//! Enable/disable re-encoding Q5_0 tensors into the k5 plane for subsequent loads. LOSSY by
+//! construction (see g_kq_q50_native); default OFF. Requires kquant_native.
+def public set_kq_q50_native(on : bool) {
+    g_kq_q50_native = on
+}
+def public get_kq_q50_native() : bool {
+    return g_kq_q50_native
+}
+
+def private count_fmt(a : array<KqFmt>; f : KqFmt) : int {
+    var n = 0
+    for (x in a) {
+        if (x == f) {
+            n++
+        }
+    }
+    return n
+}
+
+def private tally_fmt(t : Model; f : KqFmt) : int {
+    return (count_fmt(t.wq_fmt, f) + count_fmt(t.wk_fmt, f) + count_fmt(t.wv_fmt, f)
+        + count_fmt(t.wo_fmt, f) + count_fmt(t.w1_fmt, f) + count_fmt(t.w2_fmt, f)
+        + count_fmt(t.w3_fmt, f) + count_fmt(t.we1_fmt, f) + count_fmt(t.we2_fmt, f)
+        + count_fmt(t.we3_fmt, f))
+}
+
+// The load's self-report: knob states, per-tensor format tags, and plane bytes. Plane bytes are
+// the ONLY direct evidence that a format tag actually engaged — a timing delta can never prove it.
+def private log_load_report(t : Model) {
+    if (!dasllama_noisy()) {
+        return
+    }
+    let mb = 1048576.0
+    to_log(LOG_INFO, "dasLLAMA noisy: backend '{active_kernel_backend()}' | kquant_native {g_kquant_native} q40_native {g_kq_q40_native} q50_native {g_kq_q50_native}\n")
+    // the tier arms at [init], before a --noisy CLI flag can land — restate it here so the flag alone suffices
+    to_log(LOG_INFO, "dasLLAMA noisy: GPU tier installed {moe_gpu_tier_installed()} | want auto {gpu_want_auto()}, moe layers {gpu_want_moe_layers()}, stream {gpu_want_moe_stream()}\n")
+    to_log(LOG_INFO, "dasLLAMA noisy: format tags — q8 {tally_fmt(t, KqFmt.q8)}, k4 {tally_fmt(t, KqFmt.k4)}, k5 {tally_fmt(t, KqFmt.k5)}, k6 {tally_fmt(t, KqFmt.k6)}, q40 {tally_fmt(t, KqFmt.q40)}\n")
+    to_log(LOG_INFO, "dasLLAMA noisy: plane MB — q8 {float(long_length(t.qblob)) / mb} (+scales {float(long_length(t.qscales) * 4l) / mb}), k4 {float(long_length(t.k4q) + long_length(t.k4s)) / mb}, k5 {float(long_length(t.k5q) + long_length(t.k5s)) / mb}, k6 {float(long_length(t.k6q) + long_length(t.k6s)) / mb}, q40 {float(long_length(t.q40q) + long_length(t.q40s)) / mb}, f32 {float(long_length(t.wblob) * 4l) / mb}\n")
+}
+
 // GGML disk type -> plane format tag (non-K-quant types ride the classic q8 path)
 def private kq_fmt_of(gt : int) : KqFmt {
     if (gt == GGML_TYPE_Q4_K) {
@@ -1418,13 +1469,16 @@ def private kq_fmt_of(gt : int) : KqFmt {
     if (gt == GGML_TYPE_Q4_0 && g_kq_q40_native) {
         return KqFmt.q40
     }
+    if (gt == GGML_TYPE_Q5_0 && g_kq_q50_native) {
+        return KqFmt.k5
+    }
     return KqFmt.q8
 }
 
-// q40 demotion: Q4_0 guarantees rows % 32 only (K-quants are % 256 by construction), and the
-// kq tier's superblock walkers/activation image need % 256 — a misaligned tensor falls back to
-// the q8 requant path per tensor. `n` = the tensor's ROW length (the matmul's input dim).
-def private kq_fmt_row_ok(f : KqFmt; n : int64) : KqFmt => f == KqFmt.q40 && n % 256l != 0l ? KqFmt.q8 : f
+// q40/q50 demotion: Q4_0 and Q5_0 guarantee rows % 32 only, but the kq tier's superblock walkers
+// need % 256 — a misaligned tensor falls back to the q8 requant path. `n` = the tensor's ROW length.
+// The k5 arm fires only for a Q5_0 source; a genuine Q5_K row is always % 256.
+def private kq_fmt_row_ok(f : KqFmt; n : int64) : KqFmt => (f == KqFmt.q40 || f == KqFmt.k5) && n % 256l != 0l ? KqFmt.q8 : f
 
 // Fill the per-kind weight format tags from the file's tensor types (q8-mode loads with the
 // kquant_native knob on). Fused-projection arches (Phi3) split attn_qkv/ffn_up at row-aligned
@@ -3505,6 +3559,7 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             wscale_convert_f16(t)
         }
         to_log(LOG_INFO, "dasLLAMA: load stage wscale: {get_time_usec(ts_stage) / 1000} ms, total {get_time_usec(ts_load) / 1000} ms\n")
+        log_load_report(t)
         moe_gpu_upload_resident(t)
     }
 }
@@ -4086,6 +4141,9 @@ def apply_box_profile_runtime(path : string = "") {
     apply_i64_knob(rt, "gemv_chunks_per_lane") $(v) { set_gemv_chunks_per_lane(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "wscale_f16") $(v) { set_wscale_f16(v != 0l) }
     apply_i64_knob(rt, "kquant_native") $(v) { set_kquant_native(v != 0l) }
+    apply_i64_knob(rt, "kq_q40_native") $(v) { set_kq_q40_native(v != 0l) }
+    apply_i64_knob(rt, "kq_q50_native") $(v) { set_kq_q50_native(v != 0l) }
+    apply_i64_knob(rt, "noisy") $(v) { set_dasllama_noisy(v != 0l) }
     apply_i64_knob(rt, "gemv_lane_cap") $(v) { set_gemv_lane_cap(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "batch_lane_cap") $(v) { set_batch_lane_cap(int(min(v, 2147483647l))) }
     apply_i64_knob(rt, "batch_grid_2d") $(v) { set_batch_grid_2d(int(min(v, 2l))) }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -10814,22 +10814,27 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
     let f1 = fmt_at(t.we1_fmt, l)
     let f2 = fmt_at(t.we2_fmt, l)
     let f3 = fmt_at(t.we3_fmt, l)
+    // GPU tier: offloaded layers run the routed chain device-side; the fused arm gathers ALL nk bucket rows at once (grows)
+    let fused_gpu = (!c.moe_exps_bias && !t.experts_mx4 && c.ffn_act != FfnAct.swiglu_oai
+        && (moe_gpu_layer_on_gpu(l) || moe_gpu_layer_streamed(l)) && g_moe_fused_expert_gemms && npos >= 32l)
+    let gpu_comb = fused_gpu && gpu_combine_on()
+    let grows = fused_gpu ? nk : npos
     s.moe_rlog |> resize(npos * ne)
     s.moe_idx_b |> resize(nk)
     s.moe_w_b |> resize(nk)
     s.moe_cnt |> resize(ne)
     s.moe_bkt |> resize(nk)
-    s.moe_gxq |> resize(npos * dim)
-    s.moe_gxs |> resize(npos * nb)
-    s.moe_ghb |> resize(npos * nfe)
-    s.moe_ghb2 |> resize(npos * nfe)
-    s.moe_hq |> resize(npos * nfe)
-    s.moe_hs |> resize(npos * nfe / 32l)
-    s.moe_gout |> resize(npos * dim)
+    s.moe_gxq |> resize(grows * dim)
+    s.moe_gxs |> resize(grows * nb)
+    s.moe_ghb |> resize(grows * nfe)
+    s.moe_ghb2 |> resize(grows * nfe)
+    s.moe_hq |> resize(grows * nfe)
+    s.moe_hs |> resize(grows * nfe / 32l)
+    s.moe_gout |> resize(grows * dim)
     s.moe_eout |> resize(nk * dim)
     if (kq_layer) {
-        s.moe_gxbs |> resize(npos * dim / 16l)
-        s.moe_hbs |> resize(npos * nfe / 16l)
+        s.moe_gxbs |> resize(grows * dim / 16l)
+        s.moe_hbs |> resize(grows * nfe / 16l)
     }
 
     // 1. route every position: double-RMS router input, one batched GEMM, per-row select + down-scale fold
@@ -10876,9 +10881,83 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
         requant_rows_q8(s.xb_b, dim, npos, s.xqb, s.xsb)
     }
 
-    // 3. one batched GEMM chain per touched expert; raw down-projection rows park for the ordered reduce
-    trace_tag(TRACE_TAG_MOE)
-    for (e in range64(ne)) {
+    // 3F. GPU tier: gate/up -> act -> requant -> down as ONE region-list dispatch for the layer
+    if (fused_gpu) {
+        trace_tag(TRACE_TAG_MOE)
+        let ts_gather = ref_time_ticks()
+        // the GPU tile computes activation block sums in-kernel — skip the per-16 sum gather
+        moe_gather_rows(s, 0l, nk, dim, k, false, moe_kform)
+        prof_add("moe_gather", ts_gather)
+        // region triples (woff, row0, cnt) per touched expert; the three planes share row0/cnt
+        s.moe_offs1 |> clear(); s.moe_offs1 |> reserve(ne * 3l)
+        s.moe_offs3 |> clear(); s.moe_offs3 |> reserve(ne * 3l)
+        s.moe_offs2 |> clear(); s.moe_offs2 |> reserve(ne * 3l)
+        // LPT order (biggest buckets first) front-loads expensive spans
+        s.moe_ord |> clear()
+        s.moe_ord |> reserve(int(ne))   // capacity persists across layers — no per-layer alloc
+        for (e in range64(ne)) {
+            let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
+            let cnt = s.moe_cnt[e] - b0
+            if (cnt > 0l) {
+                s.moe_ord |> push(int2(int(e), int(cnt)))
+            }
+        }
+        lpt_order(s.moe_ord)
+        var nreg = 0l
+        for (oe in s.moe_ord) {
+            let e = int64(oe.x)
+            let cnt = int64(oe.y)
+            let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
+            let base = e * dim * nfe
+            s.moe_offs1 |> push(t.we1_offs[l] + base)   // nolint:STYLE012 — loop-append into reused scratch
+            s.moe_offs1 |> push(b0)
+            s.moe_offs1 |> push(cnt)
+            s.moe_offs3 |> push(t.we3_offs[l] + base)   // nolint:STYLE012 — loop-append into reused scratch
+            s.moe_offs3 |> push(b0)
+            s.moe_offs3 |> push(cnt)
+            s.moe_offs2 |> push(t.we2_offs[l] + base)   // nolint:STYLE012 — loop-append into reused scratch
+            s.moe_offs2 |> push(b0)
+            s.moe_offs2 |> push(cnt)
+            nreg++
+        }
+        let ts_g1 = ref_time_ticks()
+        if (gpu_comb) {   // gout comes back as npos combined rows — the park + CPU reduce disappear
+            s.moe_inv |> resize(nk)
+            for (j in range64(nk)) {
+                s.moe_inv[s.moe_bkt[j]] = uint(j)
+            }
+            matmul_moe_gpu_ffn_combined(s.moe_eout, s.moe_offs1, s.moe_offs3, s.moe_offs2, nreg,
+                s.moe_gxq, s.moe_gxs, s.moe_w_b, s.moe_inv, dim, nfe, nk, npos, int(f1), int(f3), int(f2), c.ffn_act == FfnAct.gelu)
+        } else {
+            matmul_moe_gpu_ffn(s.moe_gout, s.moe_offs1, s.moe_offs3, s.moe_offs2, nreg,
+                s.moe_gxq, s.moe_gxs, dim, nfe, nk, int(f1), int(f3), int(f2), c.ffn_act == FfnAct.gelu)
+        }
+        prof_add("moe_gpu", ts_g1)
+        if (!gpu_comb) {   // combine off: park the raw down rows in bucket order for the reduce
+            trace_tag(TRACE_TAG_PARK)
+            let ts_park = ref_time_ticks()
+            unsafe {
+                let gp = addr<float const?>(s.moe_gout[0])
+                var ep = addr(s.moe_eout[0])
+                let bp = addr<int64 const?>(s.moe_bkt[0])
+                maybe_parallel_for(nk * dim >= g_act_par_threshold, 0, int(nk), get_dispatch_lanes()) $(rb, re) {
+                    unsafe {
+                        for (j in range(rb, re)) {
+                            let jj = int64(j)
+                            copy_floats(ep + bp[jj] * dim, gp + jj * dim, dim)
+                        }
+                    }
+                }
+            }
+            prof_add("moe_park", ts_park)
+        }
+    }
+
+    // 3. one batched GEMM chain per touched expert, parking raw down rows (skipped when 3F ran)
+    if (!fused_gpu) {
+        trace_tag(TRACE_TAG_MOE)
+    }
+    for (e in range64(fused_gpu ? 0l : ne)) {
         let b0 = e == 0l ? 0l : s.moe_cnt[e - 1l]
         let cnt = s.moe_cnt[e] - b0
         if (cnt == 0l) {
@@ -10927,14 +11006,21 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
                 for (p in range(rb, re)) {
                     let pp = int64(p)
                     var arow = ap + pp * dim
-                    for (i in range64(dim)) {
-                        arow[i] = 0.0
-                    }
-                    for (j in range64(k)) {
-                        let w = wp[pp * k + j]
-                        let er = ep + (pp * k + j) * dim
+                    if (gpu_comb) {   // the device already reduced: eout's head IS the combined row
+                        let cr = ep + pp * dim
                         for (i in range64(dim)) {
-                            arow[i] += w * er[i]
+                            arow[i] = cr[i]
+                        }
+                    } else {
+                        for (i in range64(dim)) {
+                            arow[i] = 0.0
+                        }
+                        for (j in range64(k)) {
+                            let w = wp[pp * k + j]
+                            let er = ep + (pp * k + j) * dim
+                            for (i in range64(dim)) {
+                                arow[i] += w * er[i]
+                            }
                         }
                     }
                 }

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -1018,6 +1018,10 @@ def quantize_k5_plane(src : array<float> | #; n : int64; var kq : array<uint8>; 
     if (n % 256l != 0l) {
         panic("quantize_k5_plane: n={n} is not a multiple of 256")
     }
+    // O(1) source guard — the loop below reads n weights through a raw pointer, bypassing bounds checks
+    if (n > long_length(src)) {
+        panic("quantize_k5_plane: n={n} exceeds src length {long_length(src)}")
+    }
     let nb = n / 256l
     if (nb <= 0l) {
         return

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -5,6 +5,7 @@ module dasllama_gguf shared public
 
 require daslib/array_boost // nolint:STYLE030 — temp_array is [template]; STYLE030 misses template-fn refs
 require strings
+require math                        // sqrt/abs/clamp — the Q5_K encoder's per-sub-block fit
 require daslib/fio                  // shard-path expansion + mapping (split GGUF)
 require daslib/strings_boost        // trim_suffix / pad_left (split shard names)
 require daslib/strings_convert     // try_to_int (validating shard-index parse)
@@ -836,6 +837,206 @@ def dequant_k5_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<u
             dst[dsto + 32l + l] = d2 * float((b >> 4) + ((h & u2) != 0 ? 16 : 0)) - m2
         }
         dsto += 64l
+    }
+}
+
+// llama.cpp's nearest_int — round-half-to-even via the fp32 add-magic trick, replicated bit-for-bit
+// so encoder output stays byte-comparable against llama.cpp's. Caller guarantees |fval| <= 4194303.
+def private nearest_int(fval : float) : int {
+    let v = fval + 12582912.0
+    let i = int(unsafe(reinterpret<uint>(v)))
+    return (i & int(0x007fffff)) - int(0x00400000)
+}
+
+// Weighted joint scale/min fit for one 32-weight sub-block (llama.cpp make_qkx2_quants, nmax=31,
+// rmin=-0.5, rdelta=0.1, 16 steps): sweeps iscale around the naive max/min fit and keeps the
+// weighted-least-squares (scale, min) with the lowest weighted square error. Returns (scale, -min).
+def private k5_fit_sub(x : float const?; wt : float const?; var lout : int?) : float2 {
+    unsafe {
+        var vmin = x[0]
+        var vmax = x[0]
+        var sum_w = wt[0]
+        var sum_x = wt[0] * x[0]
+        for (i in range64(1l, 32l)) {
+            vmin = min(vmin, x[i])
+            vmax = max(vmax, x[i])
+            sum_w += wt[i]
+            sum_x += wt[i] * x[i]
+        }
+        if (vmin > 0.0) {
+            vmin = 0.0
+        }
+        if (vmax == vmin) {
+            for (i in range64(32l)) {
+                lout[i] = 0
+            }
+            return float2(0.0, -vmin)
+        }
+        let iscale0 = 31.0 / (vmax - vmin)
+        var scale = 1.0 / iscale0
+        var best_mad = 0.0
+        for (i in range64(32l)) {
+            let l = clamp(nearest_int(iscale0 * (x[i] - vmin)), 0, 31)
+            lout[i] = l
+            let diff = scale * float(l) + vmin - x[i]
+            best_mad += wt[i] * diff * diff
+        }
+        var laux : int[32]
+        for (istep in range64(16l)) {
+            let isc = (30.5 + 0.1 * float(istep)) / (vmax - vmin)
+            var sum_l = 0.0
+            var sum_l2 = 0.0
+            var sum_xl = 0.0
+            for (i in range64(32l)) {
+                let l = clamp(nearest_int(isc * (x[i] - vmin)), 0, 31)
+                laux[i] = l
+                let fl = float(l)
+                sum_l += wt[i] * fl
+                sum_l2 += wt[i] * fl * fl
+                sum_xl += wt[i] * fl * x[i]
+            }
+            let dd = sum_w * sum_l2 - sum_l * sum_l
+            if (dd <= 0.0) {
+                continue
+            }
+            var this_scale = (sum_w * sum_xl - sum_x * sum_l) / dd
+            var this_min = (sum_l2 * sum_x - sum_l * sum_xl) / dd
+            if (this_min > 0.0) {   // min is clamped non-positive; refit scale alone
+                this_min = 0.0
+                this_scale = sum_xl / sum_l2
+            }
+            var mad = 0.0
+            for (i in range64(32l)) {
+                let diff = this_scale * float(laux[i]) + this_min - x[i]
+                mad += wt[i] * diff * diff
+            }
+            if (mad < best_mad) {
+                for (i in range64(32l)) {
+                    lout[i] = laux[i]
+                }
+                best_mad = mad
+                scale = this_scale
+                vmin = this_min
+            }
+        }
+        return float2(scale, -vmin)
+    }
+}
+
+// Encode one 256-weight superblock into the k5 planes — the exact inverse of
+// dequant_k5_plane_superblock, following llama.cpp quantize_row_q5_K_ref op-for-op.
+def private quantize_k5_superblock_p(x : float const?; var kq : uint8?; kqo : int64; var ks : uint8?; kso : int64) {
+    unsafe {
+        var lq : int[256]
+        var lsub : int[32]
+        var wt : float[32]
+        var scales : float[8]
+        var mins : float[8]
+        var max_scale = 0.0
+        var max_min = 0.0
+        for (j in range64(8l)) {
+            var sum_x2 = 0.0
+            for (l in range64(32l)) {
+                sum_x2 += x[j * 32l + l] * x[j * 32l + l]
+            }
+            let av_x = sqrt(sum_x2 / 32.0)
+            for (l in range64(32l)) {
+                wt[l] = av_x + abs(x[j * 32l + l])
+            }
+            let sm = k5_fit_sub(x + j * 32l, addr(wt[0]), addr(lsub[0]))
+            scales[j] = sm.x
+            mins[j] = sm.y
+            max_scale = max(max_scale, sm.x)
+            max_min = max(max_min, sm.y)
+            for (l in range64(32l)) {
+                lq[j * 32l + l] = lsub[l]
+            }
+        }
+        let inv_scale = max_scale > 0.0 ? 63.0 / max_scale : 0.0
+        let inv_min = max_min > 0.0 ? 63.0 / max_min : 0.0
+        for (b in range64(16l)) {   // the |= packing below needs a zeroed strip; also clears the 4B pad
+            ks[kso + 4l + b] = uint8(0)
+        }
+        for (j in range64(8l)) {
+            let ls = min(63, nearest_int(inv_scale * scales[j]))
+            let lm = min(63, nearest_int(inv_min * mins[j]))
+            if (j < 4l) {
+                ks[kso + 4l + j] = uint8(ls)
+                ks[kso + 8l + j] = uint8(lm)
+            } else {
+                ks[kso + 8l + j] = uint8((ls & 15) | ((lm & 15) << 4))
+                ks[kso + j] = uint8(int(ks[kso + j]) | ((ls >> 4) << 6))
+                ks[kso + 4l + j] = uint8(int(ks[kso + 4l + j]) | ((lm >> 4) << 6))
+            }
+        }
+        let d = f32_to_f16(max_scale / 63.0)
+        let dmin = f32_to_f16(max_min / 63.0)
+        ks[kso] = uint8(d & 0xFFu)
+        ks[kso + 1l] = uint8((d >> 8u) & 0xFFu)
+        ks[kso + 2l] = uint8(dmin & 0xFFu)
+        ks[kso + 3l] = uint8((dmin >> 8u) & 0xFFu)
+        // second pass: re-derive quants against the ROUNDED 6-bit sc/mn, not the fitted floats
+        let df = f16_to_f32(d)
+        let dmf = f16_to_f32(dmin)
+        for (j in range64(8l)) {
+            let sm = q4k_scale_min_p(ks, kso + 4l, j)
+            let dj = df * float(sm.x)
+            if (dj == 0.0) {
+                continue
+            }
+            let mj = dmf * float(sm.y)
+            for (l in range64(32l)) {
+                lq[j * 32l + l] = clamp(nearest_int((x[j * 32l + l] + mj) / dj), 0, 31)
+            }
+        }
+        for (l in range64(32l)) {
+            kq[kqo + 128l + l] = uint8(0)
+        }
+        for (js in range64(4l)) {   // sub-blocks 2js/2js+1 share 32 nibble bytes; qh bit 2js / 2js+1
+            for (l in range64(32l)) {
+                var l1 = lq[js * 64l + l]
+                var l2 = lq[js * 64l + l + 32l]
+                var h = 0
+                if (l1 > 15) {
+                    l1 -= 16
+                    h |= 1 << int(2l * js)
+                }
+                if (l2 > 15) {
+                    l2 -= 16
+                    h |= 2 << int(2l * js)
+                }
+                kq[kqo + 128l + l] = uint8(int(kq[kqo + 128l + l]) | h)
+                kq[kqo + js * 32l + l] = uint8(l1 | (l2 << 4))
+            }
+        }
+    }
+}
+
+//! Encode n fp32 weights (n % 256 == 0) into the k5 planes at plane-local element offset `eloff` —
+//! the encode counterpart of gguf_transcode_q5k, for disk types that are not already Q5_K.
+def quantize_k5_plane(src : array<float> | #; n : int64; var kq : array<uint8>; var ks : array<uint8>; eloff : int64) {
+    if (n % 256l != 0l) {
+        panic("quantize_k5_plane: n={n} is not a multiple of 256")
+    }
+    let nb = n / 256l
+    if (nb <= 0l) {
+        return
+    }
+    guard_dst("<k5 encode>", "k5 quant plane", (eloff / 256l) * K5_QSB, nb * K5_QSB, long_length(kq))
+    guard_dst("<k5 encode>", "k5 scale plane", (eloff / 256l) * K5_SSB, nb * K5_SSB, long_length(ks))
+    unsafe {
+        let srcp = addr<float const?>(src[0])
+        var kqp = addr(kq[(eloff / 256l) * K5_QSB])
+        var ksp = addr(ks[(eloff / 256l) * K5_SSB])
+        // the qkx2 sweep is ~100x a byte copy per superblock, so thread far earlier than transcode_jobs
+        let njobs = is_job_que_available() ? int(clamp(nb / 64l, 1l, 64l)) : 1
+        maybe_parallel_for(0, int(nb), njobs) $(rb, re) {
+            unsafe {
+                for (blk in range64(int64(rb), int64(re))) {
+                    quantize_k5_superblock_p(srcp + blk * 256l, kqp, blk * K5_QSB, ksp, blk * K5_SSB)
+                }
+            }
+        }
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1823,6 +1823,18 @@ def public gpu_want_attn : bool
 def public gpu_want_dense : bool
     => has_env_variable("DASLLAMA_GPU_DENSE") ? get_env_variable("DASLLAMA_GPU_DENSE") == "1" : (g_gpu_want.dense || gpu_want_auto())
 
+//! Dense-rail sub-arm for gemma-4's parallel dense shared expert (moe_dense_shexp) w1/w3/w2 triple.
+//! Opt-IN: MEASURED a wash-to-loss (3 dispatches each paying acts-up + y-down around a CPU gate)
+//! and the uploads displace 1-2 expert layers. Kept as the upload half of a future FUSED chain.
+def public gpu_want_dense_shexp : bool
+    => get_env_variable("DASLLAMA_GPU_DENSE_SHEXP") == "1"
+
+//! The dense rail's attention half (per-layer q/o pairs). Opt-OUT (``DASLLAMA_GPU_DENSE_ATTN=0``)
+//! — measured a LOSS on gemma-4 where the shexp triple is a large win, so the two halves need
+//! independent control rather than one DENSE gate.
+def public gpu_want_dense_attn : bool
+    => get_env_variable("DASLLAMA_GPU_DENSE_ATTN") != "0"
+
 def public gpu_want_dnd : bool
     => has_env_variable("DASLLAMA_GPU_DND") ? get_env_variable("DASLLAMA_GPU_DND") == "1" : (g_gpu_want.dnd || gpu_want_auto())
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1793,6 +1793,21 @@ def public set_gpu_tier_want(want : GpuTierWant) {
 
 def private env_int64(name : string) : int64 => int64(to_int(get_env_variable(name)))
 
+// Noisy mode: the engine says what it did instead of leaving it to be inferred from timings.
+// Lives here (not dasllama_common) so the GPU drivers can report too.
+var private g_noisy = -1
+
+//! Enable/disable noisy diagnostics. Also DASLLAMA_NOISY=1.
+def public set_dasllama_noisy(on : bool) {
+    g_noisy = on ? 1 : 0
+}
+def public dasllama_noisy() : bool {
+    if (g_noisy < 0) {
+        g_noisy = get_env_variable("DASLLAMA_NOISY") == "1" ? 1 : 0
+    }
+    return g_noisy == 1
+}
+
 //! One switch for the measured-best rail set: expert stacks sized to the VRAM budget, plus the
 //! deltanet/attention/dense/shared-expert/classifier rails. qkv and heat stay off (measured
 //! negative and a wash). Any DASLLAMA_GPU_* knob still overrides individually.

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4283,6 +4283,8 @@ def vk_moe_cls(var yp : float?; woff : int64; xqp : int8 const?; xsp : float con
 
 var private g_vk_probed = false
 var private g_vk_available = false
+var private g_vk_why = ""   // why the device probe said no — discarded before, which made it silent
+var private g_vk_arm_said = -1   // last logged arm outcome; -1 = nothing said yet
 
 def private vulkan_backend_available : bool {
     if (g_vk_probed) {
@@ -4291,11 +4293,14 @@ def private vulkan_backend_available : bool {
     g_vk_probed = true
     // raw calls, not boost creators — those panic on failure instead of reporting absence
     if (volkInitialize() != 0) {
+        g_vk_why = "no vulkan loader (volkInitialize failed)"
         return false
     }
     let ci = VkInstanceCreateInfo()
     var inst : VkInstance
-    if (vkCreateInstance(ci, null, inst) != VkResult.SUCCESS) {
+    let cr = vkCreateInstance(ci, null, inst)
+    if (cr != VkResult.SUCCESS) {
+        g_vk_why = "vkCreateInstance refused ({cr})"
         return false
     }
     volkLoadInstance(inst)
@@ -4303,6 +4308,7 @@ def private vulkan_backend_available : bool {
     vkEnumeratePhysicalDevices(inst, count, null)
     vkDestroyInstance(inst, null)
     g_vk_available = count > 0u
+    g_vk_why = g_vk_available ? "" : "vulkan loader present but 0 physical devices"
     return g_vk_available
 }
 
@@ -4337,6 +4343,16 @@ def private vk_device_name : string {
     }
 }
 
+// vulkan_moe_gpu_arm is idempotent and re-runs on every re-arm, so log only on OUTCOME CHANGE.
+// An unconditional line here floods the log (14k lines in one GLM run) and gets tuned out.
+def private arm_say(outcome : int; msg : string) {
+    if (!dasllama_noisy() || g_vk_arm_said == outcome) {
+        return
+    }
+    g_vk_arm_said = outcome
+    to_log(LOG_INFO, "dasLLAMA noisy: {msg}\n")
+}
+
 //! Arm the vulkan MoE tier from the effective GPU want (env-else-programmatic). Registered as
 //! the ``moe_gpu_tier_arm`` probe; ``[init]`` also runs it directly for the env-only path.
 //! Idempotent — re-arming after ``set_gpu_tier_want`` just refreshes the layer count.
@@ -4344,15 +4360,21 @@ def vulkan_moe_gpu_arm : bool {
     let layers = gpu_want_moe_layers()
     // counts test == 0, NOT <= 0: -1 is the auto sentinel and must read as a REQUEST, or an
     // auto-sized-layers-only want would silently fail to arm
-    if ((layers == 0l && gpu_want_moe_stream() == 0l && !gpu_want_dn() && !gpu_want_attn() && !gpu_want_dnd()
-                && gpu_want_heat() <= 0l && !gpu_want_shexp() && !gpu_want_qkv() && !gpu_want_cls())
-            || !vulkan_backend_available()) {
-        return false   // nothing requested (checked first — the device probe is not free)
+    let nothing_wanted = (layers == 0l && gpu_want_moe_stream() == 0l && !gpu_want_dn() && !gpu_want_attn() && !gpu_want_dnd()
+        && gpu_want_heat() <= 0l && !gpu_want_shexp() && !gpu_want_qkv() && !gpu_want_cls())
+    if (nothing_wanted) {   // checked first — the device probe is not free
+        arm_say(0, "GPU tier NOT armed — no rail requested (set DASLLAMA_GPU=1 or call set_gpu_tier_want)")
+        return false
+    }
+    if (!vulkan_backend_available()) {
+        arm_say(2, "GPU tier NOT armed — {g_vk_why}")
+        return false
     }
     set_moe_gpu_layer_count(layers)
     if (!moe_gpu_tier_installed()) {
         install_moe_gpu_tier(@@vk_moe_ffn, @@vk_moe_upload_stack, @@vk_moe_cls, @@vk_moe_dense, @@vk_moe_drop_stacks, @@vk_moe_dn, @@vk_moe_attn)
     }
+    arm_say(1, "GPU tier armed — vulkan, moe layers {layers}{layers < 0l ? " (auto)" : ""}, stream {gpu_want_moe_stream()}")
     return true
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -14,7 +14,7 @@ require daslib/fio
 
 // dasLLAMA Vulkan GPU tier — per-layer MoE expert-stack offload. The loader gathers offloaded
 // layers' PREPARED planes into row-major device planes — q8 stacks as int8 quant words + f16
-// scales, native K-quant stacks (k4/k5/k6, fmt-tagged) as superblock quant payloads + decoded
+// scales, native K-quant stacks (k4/k5/k6/q40, fmt-tagged) as superblock quant payloads + decoded
 // 20B scale rows — and hands them to vk_moe_upload_stack (moe_gpu_upload_resident — every load
 // rail, gguf and mapped image alike); the MoE dispatches then route those layers' whole expert
 // FFN chain (gate+up GEMMs -> act -> requant -> down) through vk_moe_ffn — decode row counts on
@@ -1137,6 +1137,52 @@ def kq_moe_gemv_k4 {
     }
 }
 
+// Q4_0: w = d*(q - 8), q in [0,15] — the k4 nibble tiling with no min plane, so the -8 folds as an
+// integer subtract against the block sums and one f16 d per 32-block scales the whole term.
+[compute_shader(local_size_x=64, local_size_x_id=0, name="kq_moe_gemv_q40_spv")]
+def kq_moe_gemv_q40 {
+    let n = vk_meta[0u]
+    let d = vk_meta[1u]
+    let nreg = vk_meta[2u]
+    let rg = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
+    if (rg < nreg * d) {
+        let r = rg / d
+        let row = rg % d
+        let nsb = n / 256u
+        let wsb0 = vk_meta[4u + r * 2u] + row * nsb
+        let xsb0 = vk_meta[5u + r * 2u]
+        let lane = gl_SubgroupInvocationID
+        let j = lane % 4u
+        let brel = lane / 4u
+        let bstride = gl_SubgroupSize / 4u
+        let nb = nsb * 8u
+        var acc = 0.0
+        var b0 = 0u
+        while (b0 < nb) {
+            let bb = b0 + brel
+            if (bb < nb) {
+                let sb = bb / 8u
+                let blk = bb % 8u
+                let wsb = wsb0 + sb
+                let w = vk_wq[wsb * 32u + blk * 4u + j]
+                let xw = (xsb0 + sb) * 64u + blk * 8u + j
+                let xlo = vk_xq[xw]
+                let xhi = vk_xq[xw + 4u]
+                let idot = sdot4(w & 0x0F0F0F0F, xlo) + sdot4((w >> 4u) & 0x0F0F0F0F, xhi)
+                let bs = sdot4(xlo, 0x01010101) + sdot4(xhi, 0x01010101)
+                let dp = unpackHalf2x16(vk_wsu[wsb * 5u + blk / 2u])   // 8 f16 d packed in words 0..3
+                let dv = blk % 2u == 0u ? dp.x : dp.y
+                acc += vk_xs[xsb0 + sb] * dv * float(idot - 8 * bs)
+            }
+            b0 += bstride
+        }
+        let total = subgroupAdd(acc)
+        if (subgroupElect()) {
+            vk_y[vk_meta[3u] + rg] = total
+        }
+    }
+}
+
 // Q5_K: the k4 fold with the 5th bit OR'd in from the 32B qh region (quants in [0, 31])
 [compute_shader(local_size_x=64, local_size_x_id=0, name="kq_moe_gemv_k5_spv")]
 def kq_moe_gemv_k5 {
@@ -1346,6 +1392,123 @@ def kq_moe_batch_k4 {
             f1 += xscl * (bt_ws[bu * 32u + word + 8u] * float(i1) - bt_wsb[bu * 32u + word + 8u] * float(bs))
             f2 += xscl * (bt_ws[bu * 32u + word + 16u] * float(i2) - bt_wsb[bu * 32u + word + 16u] * float(bs))
             f3 += xscl * (bt_ws[bu * 32u + word + 24u] * float(i3) - bt_wsb[bu * 32u + word + 24u] * float(bs))
+        }
+        barrier()
+        s++
+    }
+    if (xrow < cnt) {
+        let yb = (row0 + xrow) * d + wt * 32u + word
+        if (wt * 32u + word < d) {
+            vk_y[yb] = f0
+        }
+        if (wt * 32u + word + 8u < d) {
+            vk_y[yb + 8u] = f1
+        }
+        if (wt * 32u + word + 16u < d) {
+            vk_y[yb + 16u] = f2
+        }
+        if (wt * 32u + word + 24u < d) {
+            vk_y[yb + 24u] = f3
+        }
+    }
+}
+
+// Q4_0 tile: the k4 staging with one scale plane — per block acc += xs * d * (idot - 8*bsum)
+[compute_shader(local_size_x=256, name="kq_moe_batch_q40_spv")]
+def kq_moe_batch_q40 {
+    let n = vk_meta[0u]
+    let d = vk_meta[1u]
+    let rid = vk_meta[vk_meta[3u] + gl_WorkGroupID.x]
+    let rb = 4u + rid * 4u
+    let wsb0 = vk_meta[rb]
+    let row0 = vk_meta[rb + 1u]
+    let cnt = vk_meta[rb + 2u]
+    let tix = gl_WorkGroupID.x - vk_meta[rb + 3u]
+    let wtiles = (d + 31u) / 32u
+    let xt = tix / wtiles
+    let wt = tix % wtiles
+    let nsb = n / 256u
+    let tid = gl_LocalInvocationID.x
+    let word = tid % 8u
+    let grp = tid / 8u
+    let xrow = xt * 32u + grp
+    let wcol = wt * 32u + grp
+    let slane = tid % 32u
+    let sblk = tid / 32u
+    var f0 = 0.0
+    var f1 = 0.0
+    var f2 = 0.0
+    var f3 = 0.0
+    var s = 0u
+    while (s < nsb) {
+        for (ki in range(2)) {
+            let k = word + uint(ki) * 8u
+            let bu = k / 2u
+            let hh = k % 2u          // 0 = lo-nibble words 0..3 of the block, 1 = hi words 4..7
+            var xv = uint4(0u)
+            if (xrow < cnt) {
+                let xb4 = ((row0 + xrow) * nsb + s) * 64u + bu * 8u + hh * 4u
+                xv = uint4(vk_xq[xb4], vk_xq[xb4 + 1u], vk_xq[xb4 + 2u], vk_xq[xb4 + 3u])
+            }
+            bt_xw4[grp * 17u + k] = xv
+            var wv = uint4(0u)
+            if (wcol < d) {
+                let wsb = wsb0 + wcol * nsb + s
+                let rb4 = wsb * 32u + bu * 4u
+                let r0 = vk_wq[rb4]
+                let r1 = vk_wq[rb4 + 1u]
+                let r2 = vk_wq[rb4 + 2u]
+                let r3 = vk_wq[rb4 + 3u]
+                if (hh == 0u) {
+                    wv = uint4(r0 & 0x0F0F0F0F, r1 & 0x0F0F0F0F, r2 & 0x0F0F0F0F, r3 & 0x0F0F0F0F)
+                } else {
+                    wv = uint4((r0 >> 4u) & 0x0F0F0F0F, (r1 >> 4u) & 0x0F0F0F0F,
+                        (r2 >> 4u) & 0x0F0F0F0F, (r3 >> 4u) & 0x0F0F0F0F)
+                }
+            }
+            bt_ww4[grp * 17u + k] = wv
+        }
+        if (tid < 32u) {
+            var xs = 0.0
+            if (xt * 32u + tid < cnt) {
+                xs = vk_xs[(row0 + xt * 32u + tid) * nsb + s]
+            }
+            bt_xs[tid] = xs
+        }
+        var sa = 0.0
+        if (wt * 32u + slane < d) {
+            let wsb = wsb0 + (wt * 32u + slane) * nsb + s
+            let dp = unpackHalf2x16(vk_wsu[wsb * 5u + sblk / 2u])
+            sa = sblk % 2u == 0u ? dp.x : dp.y
+        }
+        bt_ws[sblk * 32u + slane] = sa
+        barrier()
+        let xscl = bt_xs[grp]
+        for (bb in range(8)) {
+            let bu = uint(bb)
+            var i0 = 0
+            var i1 = 0
+            var i2 = 0
+            var i3 = 0
+            var bs = 0
+            for (kk in range(2)) {
+                let k = bu * 2u + uint(kk)
+                let xw = bt_xw4[grp * 17u + k]
+                let wv0 = bt_ww4[word * 17u + k]
+                let wv1 = bt_ww4[(word + 8u) * 17u + k]
+                let wv2 = bt_ww4[(word + 16u) * 17u + k]
+                let wv3 = bt_ww4[(word + 24u) * 17u + k]
+                bs += sdot4(xw.x, 0x01010101) + sdot4(xw.y, 0x01010101) + sdot4(xw.z, 0x01010101) + sdot4(xw.w, 0x01010101)
+                i0 += sdot4(wv0.x, xw.x) + sdot4(wv0.y, xw.y) + sdot4(wv0.z, xw.z) + sdot4(wv0.w, xw.w)
+                i1 += sdot4(wv1.x, xw.x) + sdot4(wv1.y, xw.y) + sdot4(wv1.z, xw.z) + sdot4(wv1.w, xw.w)
+                i2 += sdot4(wv2.x, xw.x) + sdot4(wv2.y, xw.y) + sdot4(wv2.z, xw.z) + sdot4(wv2.w, xw.w)
+                i3 += sdot4(wv3.x, xw.x) + sdot4(wv3.y, xw.y) + sdot4(wv3.z, xw.z) + sdot4(wv3.w, xw.w)
+            }
+            let off = 8 * bs
+            f0 += xscl * bt_ws[bu * 32u + word] * float(i0 - off)
+            f1 += xscl * bt_ws[bu * 32u + word + 8u] * float(i1 - off)
+            f2 += xscl * bt_ws[bu * 32u + word + 16u] * float(i2 - off)
+            f3 += xscl * bt_ws[bu * 32u + word + 24u] * float(i3 - off)
         }
         barrier()
         s++
@@ -1852,10 +2015,12 @@ struct private GpuState {
     gemv_k4 : Pipeline          // native K-quant GEMVs (per-format decode kernels)
     gemv_k5 : Pipeline
     gemv_k6 : Pipeline
+    gemv_q40 : Pipeline
     actrq_k_pipeline : Pipeline // fused act + Q8_K requant twin (per-256 scale) for the kq chains
     batch_k4 : Pipeline         // native K-quant prefill tiles (per-format batch kernels)
     batch_k5 : Pipeline
     batch_k6 : Pipeline
+    batch_q40 : Pipeline
     comb_pipeline : Pipeline    // routed weighted-sum combine (device-side reduce, prefill batches)
     dn_conv_pipeline : Pipeline // deltanet conv + SiLU + q/k L2-norm (one workgroup per position)
     dnd_fused_pipeline : Pipeline // deltanet decode step, whole chain fused (one workgroup per v-head)
@@ -2147,6 +2312,8 @@ def private vk_moe_init : bool {
     g_gpu.gemv_k5 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, k5shader)
     var k6shader <- create_shader_module(g_gpu.device, kq_moe_gemv_k6_spv)
     g_gpu.gemv_k6 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, k6shader)
+    var q40shader <- create_shader_module(g_gpu.device, kq_moe_gemv_q40_spv)
+    g_gpu.gemv_q40 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, q40shader)
     var rkshader <- create_shader_module(g_gpu.device, q8k_moe_actrq_spv)
     g_gpu.actrq_k_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, rkshader)
     var bk4shader <- create_shader_module(g_gpu.device, kq_moe_batch_k4_spv)
@@ -2155,6 +2322,8 @@ def private vk_moe_init : bool {
     g_gpu.batch_k5 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bk5shader)
     var bk6shader <- create_shader_module(g_gpu.device, kq_moe_batch_k6_spv)
     g_gpu.batch_k6 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bk6shader)
+    var bq40shader <- create_shader_module(g_gpu.device, kq_moe_batch_q40_spv)
+    g_gpu.batch_q40 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bq40shader)
     var cshader <- create_shader_module(g_gpu.device, moe_combine_spv)
     g_gpu.comb_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cshader)
     var dcshader <- create_shader_module(g_gpu.device, dn_conv_spv)
@@ -2230,7 +2399,7 @@ def private write_buf_desc(var writes : array<WriteDescriptorSet>; set_ : VkDesc
 def private stack_plane_bytes(n, rows : int64; fmt : int) : tuple<wq : int64; ws : int64> {
     assert(fmt == 0 || n % 256l == 0l, "dasLLAMA vulkan tier: kq stack row length must be a superblock multiple")
     let nsb = rows * (n / 256l)
-    let wqbytes = fmt == 0 ? rows * n : nsb * (fmt == 1 ? 128l : (fmt == 2 ? 160l : 192l))
+    let wqbytes = fmt == 0 ? rows * n : nsb * (fmt == 2 ? 160l : (fmt == 3 ? 192l : 128l))   // k4 and q40 share 128B
     let wsbytes = fmt == 0 ? rows * (n / 32l) * 2l : nsb * 20l
     return (wq = wqbytes, ws = wsbytes)
 }
@@ -2381,7 +2550,7 @@ def private cmd_bind_dispatch(raw : VkCommandBuffer; var set_ : VkDescriptorSet;
     vkCmdDispatch(raw, groups, 1u, 1u)
 }
 
-// bind the GEMV pipeline for a stack's format (0 = the q8 kernel, 1/2/3 = kq_moe_gemv_k4/5/6)
+// bind the GEMV pipeline for a stack's format (0 = the q8 kernel, 1/2/3/4 = kq_moe_gemv_k4/5/6/q40)
 def private bind_gemv_pipe(raw : VkCommandBuffer; fmt : int) {
     if (fmt == 0) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.pipeline, VkPipelineBindPoint.COMPUTE)
@@ -2389,12 +2558,16 @@ def private bind_gemv_pipe(raw : VkCommandBuffer; fmt : int) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_k4, VkPipelineBindPoint.COMPUTE)
     } elif (fmt == 2) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_k5, VkPipelineBindPoint.COMPUTE)
-    } else {
+    } elif (fmt == 3) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_k6, VkPipelineBindPoint.COMPUTE)
+    } elif (fmt == 4) {
+        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_q40, VkPipelineBindPoint.COMPUTE)
+    } else {
+        panic("dasLLAMA vulkan tier: no GEMV kernel for stack format {fmt}")
     }
 }
 
-// ... and the batch-tile twin (0 = q8_moe_batch, 1/2/3 = kq_moe_batch_k4/5/6)
+// ... and the batch-tile twin (0 = q8_moe_batch, 1/2/3/4 = kq_moe_batch_k4/5/6/q40)
 def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int) {
     if (fmt == 0) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_pipeline, VkPipelineBindPoint.COMPUTE)
@@ -2402,8 +2575,12 @@ def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k4, VkPipelineBindPoint.COMPUTE)
     } elif (fmt == 2) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k5, VkPipelineBindPoint.COMPUTE)
-    } else {
+    } elif (fmt == 3) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k6, VkPipelineBindPoint.COMPUTE)
+    } elif (fmt == 4) {
+        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_q40, VkPipelineBindPoint.COMPUTE)
+    } else {
+        panic("dasLLAMA vulkan tier: no batch tile for stack format {fmt}")
     }
 }
 

--- a/modules/dasLLAMA/tests/test_gguf_quant.das
+++ b/modules/dasLLAMA/tests/test_gguf_quant.das
@@ -128,3 +128,83 @@ def test_gguf_q5_0(t : T?) {
         delete m
     }
 }
+
+// Deterministic pseudo-weights with a per-sub-block scale ladder (1x..8x across the 8 sub-blocks
+// of a superblock), so a packing regression in the 6-bit split-nibble scale strip shows up as ONE
+// band blowing up rather than a slightly worse whole-tensor average.
+def private k5_src(sb, i : int64) : float {
+    let amp = 0.001 * float(i / 32l + 1l)
+    return amp * float(int((i * 37l + sb * 11l) % 31l) - 15)
+}
+
+def private sub_rel(x, y : array<float>; off : int64) : float {
+    var se = 0.0
+    var sx = 0.0
+    for (l in range64(32l)) {
+        let d = y[off + l] - x[off + l]
+        se += d * d
+        sx += x[off + l] * x[off + l]
+    }
+    return sx == 0.0 ? 0.0 : sqrt(se / 32.0) / sqrt(sx / 32.0)
+}
+
+[test]
+def test_q5k_encoder(t : T?) {
+    let nsb = 8l
+    let n = nsb * 256l
+    // The ceiling is a regression gate, not a spec: measured rel-rmse is ~0.036 on synthetic
+    // gaussian and ~0.031 on GLM-4.5-Air's real ffn_down. A mis-packed scale strip lands near 1.0.
+    t |> run("q5_k encode round-trip stays within the 5-bit budget") @(t : T?) {
+        var x : array<float>
+        var y : array<float>
+        x |> resize(n)
+        y |> resize(n)
+        for (sb in range64(nsb)) {
+            for (i in range64(256l)) {
+                x[sb * 256l + i] = k5_src(sb, i)
+            }
+        }
+        var kq : array<uint8>
+        var ks : array<uint8>
+        kq |> resize(nsb * 160l)
+        ks |> resize(nsb * 20l)
+        quantize_k5_plane(x, n, kq, ks, 0l)
+        for (sb in range64(nsb)) {
+            dequant_k5_plane_superblock(kq, sb * 160l, ks, sb * 20l, y, sb * 256l)
+        }
+        for (sb in range64(nsb)) {
+            for (j in range64(8l)) {
+                let rel = sub_rel(x, y, sb * 256l + j * 32l)
+                t |> success(rel < 0.15, "superblock {sb} sub-block {j} rel-rmse {rel} must stay under 0.15")
+            }
+            // the repack + GPU upload read the 20B scale block whole; the 4B tail must stay zeroed
+            for (b in range64(16l, 20l)) {
+                t |> equal(int(ks[sb * 20l + b]), 0)
+            }
+        }
+        delete x
+        delete y
+        delete kq
+        delete ks
+    }
+    // All-zero input takes the d == 0 early-out; it must still emit a well-formed, zeroed block.
+    t |> run("q5_k encode handles an all-zero superblock") @(t : T?) {
+        var x : array<float>
+        var y : array<float>
+        x |> resize(256l)
+        y |> resize(256l)
+        var kq : array<uint8>
+        var ks : array<uint8>
+        kq |> resize(160l)
+        ks |> resize(20l)
+        quantize_k5_plane(x, 256l, kq, ks, 0l)
+        dequant_k5_plane_superblock(kq, 0l, ks, 0l, y, 0l)
+        for (i in range64(256l)) {
+            t |> equal(y[i], 0.0)
+        }
+        delete x
+        delete y
+        delete kq
+        delete ks
+    }
+}

--- a/modules/dasLLAMA/tests/test_vulkan_tier.das
+++ b/modules/dasLLAMA/tests/test_vulkan_tier.das
@@ -570,12 +570,12 @@ def private lcg_byte(var st : uint64&) : uint8 {
 }
 
 // synthesize one kq stack directly in the tier's DEVICE layout: quant payload (any bytes are
-// valid nibble/qh payloads) + 20B scale rows (f16 d/dmin from the pow2 sets, 6-bit sc/mn or
-// signed i8 sub-scales)
+// valid nibble/qh payloads) + 20B scale rows (f16 d/dmin from the pow2 sets, 6-bit sc/mn,
+// signed i8 sub-scales, or q40's 8 per-block f16 d)
 def private fill_kq_stack(fmt : int; rows, n : int64; seed : int64; tiny_d : bool;
                           var wqb : array<uint8>; var wsb : array<uint8>) {
     let nsb = n / 256l
-    let qsb = fmt == 1 ? 128l : (fmt == 2 ? 160l : 192l)
+    let qsb = fmt == 2 ? 160l : (fmt == 3 ? 192l : 128l)
     wqb |> resize(int(rows * nsb * qsb))
     wsb |> resize(int(rows * nsb * 20l))
     var st = uint64(seed) * 2654435761ul + 12345ul
@@ -594,6 +594,15 @@ def private fill_kq_stack(fmt : int; rows, n : int64; seed : int64; tiny_d : boo
             wsb[so + 17] = uint8((h >> 8u) & 0xFFu)
             wsb[so + 18] = uint8(0)
             wsb[so + 19] = uint8(0)
+        } elif (fmt == 4) {
+            for (blk in range(8)) {   // one f16 d per 32-block, words 0..3; 16..19 pad
+                let h = f32_to_f16(tiny_d ? pow2_tiny(sb + seed + int64(blk)) : pow2_small(sb + seed + int64(blk)))
+                wsb[so + blk * 2] = uint8(h & 0xFFu)
+                wsb[so + blk * 2 + 1] = uint8((h >> 8u) & 0xFFu)
+            }
+            for (i in range(16, 20)) {
+                wsb[so + i] = uint8(0)
+            }
         } else {
             let hd = f32_to_f16(tiny_d ? pow2_tiny(sb + seed) : pow2_small(sb + seed))
             let hm = f32_to_f16(tiny_d ? pow2_tiny(sb + seed + 1l) : pow2_small(sb + seed + 1l))
@@ -614,14 +623,23 @@ def private fill_kq_stack(fmt : int; rows, n : int64; seed : int64; tiny_d : boo
 def private dequant_kq_stack(fmt : int; wqb : array<uint8>; wsb : array<uint8>; rows, n : int64;
                              var w : array<float>) {
     let nsb = n / 256l
-    let qsb = fmt == 1 ? 128l : (fmt == 2 ? 160l : 192l)
+    let qsb = fmt == 2 ? 160l : (fmt == 3 ? 192l : 128l)
     w |> resize(int(rows * n))
     for (rr in range64(rows)) {
         for (sbi in range64(nsb)) {
             let qo = (rr * nsb + sbi) * qsb
             let so = (rr * nsb + sbi) * 20l
             let wo = rr * n + sbi * 256l
-            if (fmt == 3) {
+            if (fmt == 4) {
+                for (blk in range64(8l)) {
+                    let d = f16_to_f32(uint(wsb[int(so + blk * 2l)]) | (uint(wsb[int(so + blk * 2l + 1l)]) << 8u))
+                    for (m in range64(16l)) {
+                        let b = int(wqb[int(qo + blk * 16l + m)])
+                        w[int(wo + blk * 32l + m)] = d * float((b & 15) - 8)
+                        w[int(wo + blk * 32l + 16l + m)] = d * float((b >> 4) - 8)
+                    }
+                }
+            } elif (fmt == 3) {
                 let d = f16_to_f32(uint(wsb[int(so) + 16]) | (uint(wsb[int(so) + 17]) << 8u))
                 for (blk in range64(8l)) {
                     let shift = int(2l * (blk % 4l))
@@ -888,6 +906,115 @@ def test_vulkan_moe_ffn_kq(t : T?) {
             delete xs
             delete gout
             delete refv
+        } else {
+            feint("dasVulkan not installed; vulkan MoE tier untestable here\n")
+        }
+    }
+}
+
+// ===== q40 arms (native Q4_0 stacks — the all-q40 triple a Q4_0 file ships) =====
+
+let QWOFF1 = 41000000l
+let QWOFF3 = 42000000l
+let QWOFF2 = 43000000l
+
+// Q4_0 rides the k4 nibble tiling with one f16 d per 32-block and no min plane, so its quants
+// carry an implicit -8: the kernel folds that as an integer subtract against the block sums,
+// and a sign error there is exactly what this arm catches.
+[test]
+def test_vulkan_moe_ffn_q40(t : T?) {
+    t |> run("vulkan MoE q40 tier (all-Q4_0 triple) == CPU reference") @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            install_moe_gpu_tier(@@vk_moe_ffn, @@vk_moe_upload_stack, @@vk_moe_cls, @@vk_moe_dense, @@vk_moe_drop_stacks, @@vk_moe_dn, @@vk_moe_attn)
+            var wq1 : array<uint8>
+            var ws1 : array<uint8>
+            var wq3 : array<uint8>
+            var ws3 : array<uint8>
+            var wq2 : array<uint8>
+            var ws2 : array<uint8>
+            fill_kq_stack(4, NE * KNFE, KN, 83l, false, wq1, ws1)
+            fill_kq_stack(4, NE * KNFE, KN, 97l, false, wq3, ws3)
+            fill_kq_stack(4, NE * KN, KNFE, 101l, false, wq2, ws2)
+            var up_ok = moe_gpu_upload_stack(wq1, ws1, QWOFF1, KN, NE * KNFE, 4)
+            if (!up_ok) {
+                feint("no Vulkan device (or probe/budget refused the upload); skipping\n")
+                return
+            }
+            up_ok = moe_gpu_upload_stack(wq3, ws3, QWOFF3, KN, NE * KNFE, 4)
+            t |> success(up_ok, "q40 up stack uploaded")
+            up_ok = moe_gpu_upload_stack(wq2, ws2, QWOFF2, KNFE, NE * KN, 4)
+            t |> success(up_ok, "q40 down stack uploaded")
+            var w1 : array<float>
+            var w3 : array<float>
+            var w2 : array<float>
+            dequant_kq_stack(4, wq1, ws1, NE * KNFE, KN, w1)
+            dequant_kq_stack(4, wq3, ws3, NE * KNFE, KN, w3)
+            dequant_kq_stack(4, wq2, ws2, NE * KN, KNFE, w2)
+            let ege1 = KNFE * KN
+            let ege2 = KN * KNFE
+            var xq : array<int8>
+            var xs : array<float>
+            var gout : array<float>
+            var refv : array<float>
+
+            // decode arm: 2 rows, 1 per region (the GEMV kernel)
+            fill_acts_kq(xq, xs, 2l)
+            var offs1 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], QWOFF1, ege1)
+            var offs3 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], QWOFF3, ege1)
+            var offs2 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], QWOFF2, ege2)
+            gout |> resize(int(2l * KN))
+            matmul_moe_gpu_ffn(gout, offs1, offs3, offs2, 2l, xq, xs, KN, KNFE, 2l, 4, 4, 4, false)
+            // ref_ffn_kq derives its row bases against the KWOFF* constants
+            var refoffs1 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], KWOFF1, ege1)
+            var refoffs3 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], KWOFF3, ege1)
+            var refoffs2 <- make_offs([1l, 2l], [0l, 1l], [1l, 1l], KWOFF2, ege2)
+            ref_ffn_kq(refoffs1, refoffs3, refoffs2, 2, w1, w3, w2, xq, xs, 2l, refv)
+            var c = compare_gout(gout, refv)
+            t |> success(c.maxref > 0.0, "q40 decode arm produced non-trivial outputs")
+            t |> success(c.maxdiff <= float(REL_TOL) * c.maxref,
+                "q40 decode arm within tolerance (maxdiff {c.maxdiff} vs {float(REL_TOL) * c.maxref} bar, maxref {c.maxref})")
+
+            // batch arm (the q40 tile): 40 rows (>= the 32-row tile, unpadded), 2 regions
+            fill_acts_kq(xq, xs, 40l)
+            var boffs1 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], QWOFF1, ege1)
+            var boffs3 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], QWOFF3, ege1)
+            var boffs2 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], QWOFF2, ege2)
+            gout |> resize(int(40l * KN))
+            matmul_moe_gpu_ffn(gout, boffs1, boffs3, boffs2, 2l, xq, xs, KN, KNFE, 40l, 4, 4, 4, false)
+            var rboffs1 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], KWOFF1, ege1)
+            var rboffs3 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], KWOFF3, ege1)
+            var rboffs2 <- make_offs([0l, 2l], [0l, 24l], [24l, 16l], KWOFF2, ege2)
+            ref_ffn_kq(rboffs1, rboffs3, rboffs2, 2, w1, w3, w2, xq, xs, 40l, refv)
+            c = compare_gout(gout, refv)
+            t |> success(c.maxref > 0.0, "q40 batch arm produced non-trivial outputs")
+            t |> success(c.maxdiff <= float(REL_TOL) * c.maxref,
+                "q40 batch arm within tolerance (maxdiff {c.maxdiff} vs {float(REL_TOL) * c.maxref} bar, maxref {c.maxref})")
+
+            delete wq1
+            delete ws1
+            delete wq3
+            delete ws3
+            delete wq2
+            delete ws2
+            delete w1
+            delete w3
+            delete w2
+            delete xq
+            delete xs
+            delete gout
+            delete refv
+            delete offs1
+            delete offs3
+            delete offs2
+            delete refoffs1
+            delete refoffs3
+            delete refoffs2
+            delete boffs1
+            delete boffs3
+            delete boffs2
+            delete rboffs1
+            delete rboffs3
+            delete rboffs2
         } else {
             feint("dasVulkan not installed; vulkan MoE tier untestable here\n")
         }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -4990,6 +4990,21 @@ class SpirvEmit : AstVisitor {
         return expr
     }
 
+    // Parameterised hints take a NON-NEGATIVE int literal. A wrong type must not fall through to
+    // "unknown hint" (the hint is known, the value is not), and a negative would wrap to a huge
+    // uint and emit invalid SPIR-V that only fails later, at pipeline creation.
+    def loop_hint_literal(a : AnnotationArgument) : uint {
+        if (a.basicType != Type.tInt) {
+            errs |> push("vulkan loop hint '{a.name}' takes an int value")
+            return 0u
+        }
+        if (a.iValue < 0) {
+            errs |> push("vulkan loop hint '{a.name}' must be >= 0, got {a.iValue}")
+            return 0u
+        }
+        return uint(a.iValue)
+    }
+
     // Vulkan-native loop hints: argument names map 1:1 onto SPIR-V LoopControl bits, so nothing is
     // translated from another backend's vocabulary and no hint can alias onto an assertion.
     def loop_control_of(args : AnnotationArgumentList; var lits : array<uint>) : uint {
@@ -5007,24 +5022,24 @@ class SpirvEmit : AstVisitor {
                 mask |= uint(SpvLoopControl.DontUnroll)
             } elif (a.name == "dependency_infinite") {
                 mask |= uint(SpvLoopControl.DependencyInfinite)
-            } elif (a.name == "dependency_length" && a.basicType == Type.tInt) {
+            } elif (a.name == "dependency_length") {
                 mask |= uint(SpvLoopControl.DependencyLength)
-                dep_len = uint(a.iValue)
-            } elif (a.name == "min_iterations" && a.basicType == Type.tInt) {
+                dep_len = loop_hint_literal(a)
+            } elif (a.name == "min_iterations") {
                 mask |= uint(SpvLoopControl.MinIterations)
-                min_it = uint(a.iValue)
-            } elif (a.name == "max_iterations" && a.basicType == Type.tInt) {
+                min_it = loop_hint_literal(a)
+            } elif (a.name == "max_iterations") {
                 mask |= uint(SpvLoopControl.MaxIterations)
-                max_it = uint(a.iValue)
-            } elif (a.name == "iteration_multiple" && a.basicType == Type.tInt) {
+                max_it = loop_hint_literal(a)
+            } elif (a.name == "iteration_multiple") {
                 mask |= uint(SpvLoopControl.IterationMultiple)
-                it_mul = uint(a.iValue)
-            } elif (a.name == "peel_count" && a.basicType == Type.tInt) {
+                it_mul = loop_hint_literal(a)
+            } elif (a.name == "peel_count") {
                 mask |= uint(SpvLoopControl.PeelCount)
-                peel = uint(a.iValue)
-            } elif (a.name == "partial_count" && a.basicType == Type.tInt) {
+                peel = loop_hint_literal(a)
+            } elif (a.name == "partial_count") {
                 mask |= uint(SpvLoopControl.PartialCount)
-                partial = uint(a.iValue)
+                partial = loop_hint_literal(a)
             } else {
                 errs |> push("unknown vulkan loop hint '{a.name}'")
             }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -4990,6 +4990,84 @@ class SpirvEmit : AstVisitor {
         return expr
     }
 
+    // Vulkan-native loop hints: argument names map 1:1 onto SPIR-V LoopControl bits, so nothing is
+    // translated from another backend's vocabulary and no hint can alias onto an assertion.
+    def loop_control_of(args : AnnotationArgumentList; var lits : array<uint>) : uint {
+        var mask = 0u
+        var dep_len = 0u
+        var min_it = 0u
+        var max_it = 0u
+        var it_mul = 0u
+        var peel = 0u
+        var partial = 0u
+        for (a in args) {
+            if (a.name == "unroll") {
+                mask |= uint(SpvLoopControl.Unroll)
+            } elif (a.name == "dont_unroll") {
+                mask |= uint(SpvLoopControl.DontUnroll)
+            } elif (a.name == "dependency_infinite") {
+                mask |= uint(SpvLoopControl.DependencyInfinite)
+            } elif (a.name == "dependency_length" && a.basicType == Type.tInt) {
+                mask |= uint(SpvLoopControl.DependencyLength)
+                dep_len = uint(a.iValue)
+            } elif (a.name == "min_iterations" && a.basicType == Type.tInt) {
+                mask |= uint(SpvLoopControl.MinIterations)
+                min_it = uint(a.iValue)
+            } elif (a.name == "max_iterations" && a.basicType == Type.tInt) {
+                mask |= uint(SpvLoopControl.MaxIterations)
+                max_it = uint(a.iValue)
+            } elif (a.name == "iteration_multiple" && a.basicType == Type.tInt) {
+                mask |= uint(SpvLoopControl.IterationMultiple)
+                it_mul = uint(a.iValue)
+            } elif (a.name == "peel_count" && a.basicType == Type.tInt) {
+                mask |= uint(SpvLoopControl.PeelCount)
+                peel = uint(a.iValue)
+            } elif (a.name == "partial_count" && a.basicType == Type.tInt) {
+                mask |= uint(SpvLoopControl.PartialCount)
+                partial = uint(a.iValue)
+            } else {
+                errs |> push("unknown vulkan loop hint '{a.name}'")
+            }
+        }
+        if ((mask & uint(SpvLoopControl.Unroll)) != 0u && (mask & uint(SpvLoopControl.DontUnroll)) != 0u) {
+            errs |> push("loop hints 'unroll' and 'dont_unroll' are mutually exclusive")
+        }
+        // parameterised bits append their literal to OpLoopMerge in ASCENDING BIT ORDER (SPIR-V spec)
+        if ((mask & uint(SpvLoopControl.DependencyLength)) != 0u) {
+            lits |> push(dep_len)
+        }
+        if ((mask & uint(SpvLoopControl.MinIterations)) != 0u) {
+            lits |> push(min_it)
+        }
+        if ((mask & uint(SpvLoopControl.MaxIterations)) != 0u) {
+            lits |> push(max_it)
+        }
+        if ((mask & uint(SpvLoopControl.IterationMultiple)) != 0u) {
+            lits |> push(it_mul)
+        }
+        if ((mask & uint(SpvLoopControl.PeelCount)) != 0u) {
+            lits |> push(peel)
+        }
+        if ((mask & uint(SpvLoopControl.PartialCount)) != 0u) {
+            lits |> push(partial)
+        }
+        return mask
+    }
+
+    def emit_loop_merge(var bm : SpirvModule; ids : LoopIds; args : AnnotationArgumentList) {
+        var lits : array<uint>
+        let mask = loop_control_of(args, lits)
+        if (empty(lits)) {
+            emit(bm, SEC_FUNCS, SpvOp.LoopMerge, ids.merge, ids.cont_l, mask)
+        } else {
+            var ops <- [ids.merge, ids.cont_l, mask]
+            ops |> push_from(lits)
+            emit_n(bm, SEC_FUNCS, SpvOp.LoopMerge, ops)
+            delete ops
+        }
+        delete lits
+    }
+
     // ----- while (OpLoopMerge 4-block, multi-phase) -----
     def override preVisitExprWhile(var expr : ExprWhile?) : void {
         var bm & = unsafe(*m)
@@ -4999,7 +5077,7 @@ class SpirvEmit : AstVisitor {
         emit(bm, SEC_FUNCS, SpvOp.Branch, ids.header)
         emit(bm, SEC_FUNCS, SpvOp.Label, ids.header)
         ctx.terminated = false
-        emit(bm, SEC_FUNCS, SpvOp.LoopMerge, ids.merge, ids.cont_l, uint(SpvLoopControl.None))
+        emit_loop_merge(bm, ids, expr.annotations)
         emit(bm, SEC_FUNCS, SpvOp.Branch, ids.cond_l)
         emit(bm, SEC_FUNCS, SpvOp.Label, ids.cond_l)
         ctx.terminated = false
@@ -5091,7 +5169,7 @@ class SpirvEmit : AstVisitor {
         emit(bm, SEC_FUNCS, SpvOp.Branch, ids.header)
         emit(bm, SEC_FUNCS, SpvOp.Label, ids.header)
         ctx.terminated = false
-        emit(bm, SEC_FUNCS, SpvOp.LoopMerge, ids.merge, ids.cont_l, uint(SpvLoopControl.None))
+        emit_loop_merge(bm, ids, expr.annotations)
         emit(bm, SEC_FUNCS, SpvOp.Branch, ids.cond_l)
         emit(bm, SEC_FUNCS, SpvOp.Label, ids.cond_l)
         ctx.terminated = false


### PR DESCRIPTION
The GLM-4.5-Air stack: native Q4_0 expert stacks on the GPU tier, gemma-4's missing MoE prefill arm, a Q5_K encoder, a noisy diagnostic rail, and per-loop SPIR-V LoopControl hints.

## Commits

| commit | what |
|---|---|
| `dasLLAMA vulkan: native Q4_0 expert stacks` | Q4_0 expert stacks served natively on the GPU tier — q4_0's plane pair *is* the k4 nibble tiling (`repack_q40_grp` writes the k4 grouped layout byte-for-byte), so the gather's grouped arm is shared and the disk arm is a verbatim copy. Only the two kernels are genuinely new. |
| `wire the GPU tier into gemma-4's MoE prefill` | gemma-4 has its own `gemma4_moe_prefill_grouped`, which had **zero** `fused_gpu` / `matmul_moe_gpu*` references — so every gemma-4 26B-A4B load prefilled on CPU with the tier on. Ports the fused arm across. `prefill batch tier engaged` + `device-side moe combine engaged` now log where neither did; IDS token-identical x32 vs the tier-off CPU baseline. |
| `--prefill-ab lever` | In-process A/B for the GPU MoE prefill arm. |
| `dense-rail sub-arms` | gemma's shexp triple + the attn pair, both opt-out/in. |
| `Q5_K encoder + noisy rail` | See below. |
| `dasSpirv: per-loop LoopControl hints` | See below. |

## Q5_K encoder

`quantize_k5_plane` in `dasllama_gguf.das` — llama.cpp `make_qkx2_quants` + `quantize_row_q5_K_ref` op-for-op, threaded per superblock, writing the k5 plane pair directly. `nearest_int` replicates llama.cpp's fp32 add-magic trick bit-for-bit so output stays byte-comparable with theirs.

Measured relative RMSE tracks the analytic step/sqrt(12) for each bit width, which is the correctness check:

```
Q8_0   0.0052 @ 9.000 bits
Q5_K   0.0357 @ 5.625 bits
Q4_0   0.0843 @ 5.000 bits
```

**Honest scope: this does not help GLM, and the reason is geometry.** `blk.N.ffn_down_exps` has dims `[1408, 4096, 128]` — the reduction dim is **1408**, and `1408 % 256 = 128`. A K-quant superblock is 256 and cannot straddle a row, so Q4_K/Q5_K are structurally impossible on those tensors. That is *why* llama.cpp emits Q5_0 there. `kq_fmt_row_ok` demotes it correctly.

So the `Q5_0 -> k5` routing is wired behind `kq_q50_native` (**default OFF** — it is the only lossy tag) but is **UNEXERCISED end-to-end**: it would fire on a Q5_0 tensor with `% 256` rows, which no local model has. The encoder itself is validated and is the path for a Q5_1 or fp32 source later. The measured answer for GLM is a native Q5_0 plane (5.5 bits, bit-exact, and 32 divides 1408), which beats Q5_K on both size and quality — that is a separate change.

## Noisy diagnostic rail

`DASLLAMA_NOISY=1`, a `noisy` runtime knob, and `--noisy` on `decode_prof`. Reports backend, knob states, per-tensor format-tag histogram, plane bytes, tier-install state and the GPU want; the vulkan arm probe now reports **why** it declined instead of returning a bare `false`.

Plane bytes are the load-bearing part — they are the only thing that can *prove* a format tag engaged. This caught the q50 routing silently doing nothing while a 6.4% timing delta looked like a win (it was drift; every untargeted bucket had moved the same). The arm log fires on outcome change only: unconditional logging there emitted **14334 lines** in a single GLM run.

## SPIR-V loop hints

The llvm-jit backend has had a loop-hint vocabulary for a while; the SPIR-V emitter hardcoded `uint(SpvLoopControl.None)` at both `OpLoopMerge` sites, so a Vulkan kernel could not say anything about a loop at all.

Argument names are Vulkan's **own**, 1:1 with the LoopControl bits, rather than a translation of llvm's vocabulary. That is deliberate: llvm's `vectorize` is a *hint* the compiler may ignore if it proves a dependency, while SPIR-V's `DependencyInfinite` is an *assertion* the driver trusts. Aliasing one onto the other would silently convert a safe request into an unchecked promise.

```
flag bits       unroll  dont_unroll  dependency_infinite
bit + literal   dependency_length  min_iterations  max_iterations
                iteration_multiple  peel_count  partial_count
```

Parameterised bits append their literal in ascending bit order per the spec (emit goes through `emit_n`). Because the vocabulary is Vulkan-only, an unrecognised argument is unambiguously a typo and **errors**; `unroll` + `dont_unroll` together is rejected.

Verified by inspecting emitted SPIR-V: LoopControl reads `None` / `Unroll` / `PartialCount` as written, the literal follows the mask, and word counts confirm the encoding (flag bits add 0 words, `partial_count` adds exactly 1).

**No measurable effect** on the kernel tried (`q8_moe_groupn`, qkv decode arm: 6.976 hinted vs 7.029 unhinted max). Expected — that loop is subgroup-cooperative and streams weights from VRAM, so it is bandwidth-bound whether or not the driver honours the hint. Note a timing test cannot distinguish "honoured but useless" from "ignored"; `VK_KHR_pipeline_executable_properties` (`get_pipeline_executable_statistics_k_h_r`, already bound) is the deterministic instrument for that and is the natural follow-up.

Also fixes a pre-existing LINT016 in the same file.

## Gates

- Rebased onto current `origin/master` (branch was 57 behind; `spirv_emit.das` 3-way merged, hint output re-verified after).
- Lint: **9 changed `.das`, 0 issues**. Format: all already formatted. All compile.
- `tests/`: full suite green: **12911 tests, 12910 passed, 0 failed, 0 errors, 1 skipped**. An earlier local run showed 4 failures + 10 errors in `tests/dasHV/*`, `tests/live_host/test_port_override` and `tests/mcp/test_mcp_jsonrpc`, and they reproduced at `origin/master` too — but that was an artifact of a local `daslang` binary 57 commits behind the rebased sources (the shape was `type inference exceeded 50 passes` / `casting to undefined type auto`, i.e. new daslib against old compiled-in bindings). Both sides of that comparison used the same stale binary, so it showed the failures were not caused by this diff but did not show they were real. After a clean rebuild of `libDaScriptDyn_runtime` + `daslang` they all pass: dasHV 16/16, mcp jsonrpc 8/8.
- New tests: 2 in `test_gguf_quant.das` (round-trip asserted **per sub-block** against a 1x-8x scale ladder, so a regression in the 6-bit split-nibble scale packing blows up one band rather than nudging a whole-tensor average; plus a zeroed-pad gate and an all-zero superblock for the `d == 0` early-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
