### PR TITLE
dasLLAMA: public benchmarks rail + native Q5_1 tier + E4B Metal + gpt-oss mxfp4 fix

### DIFF
--- a/modules/dasLLAMA/PUBLIC_BENCH_PLAN.md
+++ b/modules/dasLLAMA/PUBLIC_BENCH_PLAN.md
@@ -1,0 +1,119 @@
+# dasLLAMA public benchmarks — records, tool, site
+
+One measurement rail feeding a GGUF-keyed record store, rendered as a per-model leaderboard on
+daslang.io, open to community submissions. Replaces the bottom (2D table) portion of
+`site/dasllama.html`; the top hand-picked scoreboard bars stay as-is. ASR/audio-chat sections are
+out of scope (separate arc). Internal ladder drivers keep their rails until migrated.
+
+## Metrics
+
+Community-standard pair, exactly llama-bench semantics and naming: **pp512** (prompt processing,
+tok/s) and **tg128** (token generation, tok/s), mean ± stdev over `-r` reps after one untimed
+warmup. The test key set is open-ended (`pp512`, `tg128`, later `pp512@d4096`, `tg128@b4`, ...);
+depth/batch variants are internal-only until deliberately published.
+
+## Record schema
+
+One record per run — `(gguf, box, engine, backend, flavor)` is the identity. References are
+first-class runs, not fields nested inside das records; pairing and ratios are derived at render
+time and never stored.
+
+```json
+{ "gguf": "Qwen3-30B-A3B-Q4_K_M.gguf", "arch": "qwen3moe", "quant": "Q4_K_M",
+  "params_b": 30.5, "active_b": 3.3, "size_bytes": 18600000000,
+  "runs": [
+    { "engine": "das", "backend": "metal", "flavor": "tuned",
+      "box": "m1max", "threads": 8, "date": "2026-07-21", "source": "official",
+      "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m ... -ngl 99 -o json",
+      "sha": "6832e6dcd", "version": "0.6.3",
+      "tune": "k4q8_tile_gen=mr4; ...",
+      "hardware": { "cpu": "Apple M1 Max", "arch": "arm64", "perf_cores": 8, "total_cores": 10,
+                    "ram_gb": 64, "gpu": "Apple M1 Max (32-core)", "os": "macOS 26.4.1" },
+      "tests": { "pp512": { "tok_s": 612.4, "stddev": 3.1 },
+                 "tg128": { "tok_s": 48.2, "stddev": 0.4 } } },
+    { "engine": "llama.cpp", "backend": "metal", "flavor": "stock", "box": "m1max",
+      "cmd": "llama-bench -m ... -ngl 99 -t 8 -p 512 -n 128 -o json", "sha": "ebd048f",
+      "...": "same shape" } ] }
+```
+
+- `flavor` — das: `tuned` (the only sanctioned mode; the tool auto-tunes first). llama.cpp:
+  `clean-cpu` (no Accelerate/BLAS/Metal — kernel-vs-kernel), `stock` (release defaults, what
+  users actually get), `metal`.
+- `tune` — the applied kernel winners/fallbacks. Required on das runs: `[tune]` makes two
+  identical machines legitimately differ, so a record without the fingerprint is not reproducible.
+- `hardware` — auto-gathered, never typed by the submitter (community submissions depend on this
+  block being trustworthy and complete).
+- `source` — `official` | `community`; community rows render tagged and are accepted via reviewed
+  PR (v1) or the hosted submission server (v2).
+- Upsert key = `(gguf, box, engine, backend, flavor)`. Re-measures replace in place with a fresh
+  date/sha; git history is the archive. No superseded copies, ever.
+
+Store: `modules/dasLLAMA/performance/records/<box>.json` (official) +
+`records/community/*.json`; site build merges into one `site/files/dasllama/bench_records.json`.
+
+## Tool — `benchmarks/lcpp_bench.das` (name kept)
+
+Already a llama-bench mirror (`-m -p -n -r`, same test shapes, no-sampling tg, warmup+reps).
+Grows into the one user-facing bench; everything else becomes a driver of it.
+
+- Add: `-t` (threads), `-ngl` (0 = CPU, >0 = Metal — llama.cpp's spelling), `-o json|md`
+  (`md` = the community-legible llama-bench-style table; `json` = complete records).
+- Auto-tune-first, then relaunch with winners (the existing server-bench-child behavior).
+- `--ref <llama-bench>`: also runs llama-bench on the same GGUF (parses its `-o json`, which
+  self-reports `build_commit` — provenance is automatic whatever binary is supplied) and emits
+  the sibling llama.cpp record in the same output.
+- Advanced/internal flags (the `--*-ab` levers; later `-d`, `-b` — also llama-bench spellings)
+  remain but are not part of the user-facing story.
+- No shipped das binaries — `[tune]` rules them out. Users run the `.das` under `-jit` from a
+  repo build or `daspkg release -jit`; 0.7 (brew/pip, ~September) widens the audience.
+
+## Reference supply chain
+
+- `benchmarks/setup_lcpp_ref` (new, executable — not prose): checks out llama.cpp at a pinned
+  sha and builds per flavor with pinned flags. `clean-cpu` = `-DGGML_ACCELERATE=OFF
+  -DGGML_BLAS=OFF -DGGML_METAL=OFF`; `metal`/`stock` = release defaults. Any box reproduces the
+  identical ref binary.
+- Community users skip building: official llama.cpp GitHub release binaries include llama-bench;
+  `build_commit` in its JSON output pins what they ran.
+- A run with no ref binary is still valid — das-only record, missing cells render `-`.
+
+## Site — leaderboard per (GGUF × box)
+
+The self-defending presentation: every configuration is a row, sorted by speed. No editorial
+"which ref is fair" — stock/accelerated rows sit next to ours.
+
+- GGUF list; each model a card; within, one group per box.
+- Rows = all runs: engine + backend + tags (`metal` / `cpu` / `accel` / `raw` / `tuned` /
+  `community`), pp512, tg128, horizontal bar scaled to the group's fastest.
+- Sort by tg128 default (perceived speed), toggle pp512.
+- das rows amber, llama.cpp rows gray, group winner bold.
+- Ratio column on das rows: vs the best llama.cpp row of the same backend class (das metal /
+  lcpp metal; das cpu / best lcpp cpu incl. accelerated). >1.0 amber-bold, <1.0 dim.
+- Row expands to the receipt: full command lines, shas, date, tune fingerprint, hardware.
+- Filter chips: platform, backend.
+
+## Server unification
+
+`dasllama-server` control page's Test button (`POST /bench`) becomes a thin wrapper over the
+tool: one child invocation with `--ref -o json`, no more two-child orchestration or markdown
+parsing in `openai_server.das`. Result panel gains a "copy record" affordance — the v1
+submission funnel (paste into a prefilled GitHub issue).
+
+## Fleet & catalog
+
+Boxes: M1 Max, M3 (ssh), M5 (incoming), zen2 (3990X), rented Zen 3/4, rented Intel.
+Catalog: community-popular GGUFs, one popular quant each (not the internal quant matrix) —
+Qwen3-30B-A3B (MoE), gemma-3 sizes, a Llama-3.x-8B, Qwen3-4B/8B, a small-end model; final list
+fixed at first sweep. Measurement discipline per the standing protocol: one model process at a
+time, quiesced box, batch cells into one invocation, interleave engines per cell.
+
+## Build order
+
+1. Tool: `-t` / `-ngl` / `-o json|md`, hardware + tune block, `--ref` sibling records.
+2. Ref supply chain: `setup_lcpp_ref` + flavor pinning.
+3. Record store + catalog driver (official upserts); server Test button rebased onto the tool.
+4. Site leaderboard section (community tag from day 1).
+5. Clean-window sweeps per box, clean + stock ref passes.
+
+v2: hosted submission server (also hosts/auto-fetches pinned ref binaries), select-two compare
+widget (maybe), publishing depth/batch variants.

--- a/modules/dasLLAMA/PUBLIC_BENCH_PLAN.md
+++ b/modules/dasLLAMA/PUBLIC_BENCH_PLAN.md
@@ -56,8 +56,11 @@ Store: `modules/dasLLAMA/performance/records/<box>.json` (official) +
 Already a llama-bench mirror (`-m -p -n -r`, same test shapes, no-sampling tg, warmup+reps).
 Grows into the one user-facing bench; everything else becomes a driver of it.
 
-- Add: `-t` (threads), `-ngl` (0 = CPU, >0 = Metal — llama.cpp's spelling), `-o json|md`
+- Add: `-t` (threads), `--ngl` (0 = CPU, else Metal `required` — llama.cpp's spelling), `-o json|md`
   (`md` = the community-legible llama-bench-style table; `json` = complete records).
+- `--json-path <file>` is the machine rail: engine `[I]`/tune logs share stdout, and an untuned
+  box's tune-then-relaunch merges stderr into stdout, so record consumers (the driver, the server
+  button) read the file, never the pipe. `-o json` still prints the records last on stdout.
 - Auto-tune-first, then relaunch with winners (the existing server-bench-child behavior).
 - `--ref <llama-bench>`: also runs llama-bench on the same GGUF (parses its `-o json`, which
   self-reports `build_commit` — provenance is automatic whatever binary is supplied) and emits

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -124,6 +124,9 @@ def private kq_wbytes(f : KqFmt; q8wb : double) : double {
     if (f == KqFmt.q40) {
         return (128.0lf + 16.0lf) / 256.0lf   // nibbles + 8 x f16 d
     }
+    if (f == KqFmt.q51) {
+        return (20.0lf + 4.0lf) / 32.0lf   // per 32-block: nibbles + qh, f16 d + m
+    }
     return q8wb
 }
 

--- a/modules/dasLLAMA/benchmarks/decode_prof.das
+++ b/modules/dasLLAMA/benchmarks/decode_prof.das
@@ -78,6 +78,9 @@ struct Args {
     @clarg_doc = "Q5_0 -> k5 re-encode A/B: 1 = re-quantize Q5_0 into the k5 plane at load (LOSSY, 9.0 -> 5.625 bits), 0 = bit-exact Q5_0 -> Q8, -1 = keep default"
     q50_native : int = -1
 
+    @clarg_doc = "Native Q5_1 plane tier A/B: 1 = per-32 q51 planes (expert stacks), 0 = q8-requant fallback (exact), -1 = keep default"
+    q51_native : int = -1
+
     @clarg_doc = "Noisy diagnostics: the loader reports backend, format tags and plane bytes (also DASLLAMA_NOISY=1)"
     noisy : bool
 
@@ -323,6 +326,10 @@ def main() {
     if (cfg.q50_native >= 0) {
         set_kq_q50_native(cfg.q50_native != 0)
         print("q50_native override: {cfg.q50_native != 0}\n")
+    }
+    if (cfg.q51_native >= 0) {
+        set_kq_q51_native(cfg.q51_native != 0)
+        print("q51_native override: {cfg.q51_native != 0}\n")
     }
     if (cfg.noisy) {
         set_dasllama_noisy(true)

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -5,10 +5,11 @@ options _jit_fast_math = true   // ggml-parity FP laxity — matches how llama.c
 require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
 require dasllama/dasllama_math   // setup_dasllama_jobque_ + apply_box_profile_runtime (engine-level, not re-exported)
 require dasllama/dasllama_image   // load_model_cached — the .dlim rail, without the full facade's compile weight
-require ../performance/profile_common.das   // profile_threads + affinity_on — the standing per-box methodology
+require ../performance/profile_common.das   // profile_threads + affinity_on + bench records — the standing per-box methodology
 require daslib/jobque_boost
 require daslib/clargs
 require daslib/fio
+require daslib/md_boost
 require math
 
 // llama-bench mirror — EXACTLY llama.cpp's test shapes, rep counts, and timing boundaries, and
@@ -17,7 +18,16 @@ require math
 //   tg: -n single-token forwards at pos 0.. per rep, feeding synthetic ids with NO logit read
 //       (llama-bench never samples — sampling cost is excluded by design)
 //   ours:   bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m <model.gguf>
-//   theirs: llama-bench -m <model.gguf> -t 16 -p 512 -n 128 [--cpu-mask 0x55555555 --cpu-strict 1]
+//   theirs: --ref <llama-bench> runs it on the same GGUF with the same -t/-p/-n/-r/--ngl
+// `-o json` emits public bench records (PUBLIC_BENCH_PLAN.md) on stdout — progress goes to
+// stderr then, like llama-bench itself. `--ngl` != 0 is the whole graph on Metal
+// (MetalMode.required — a CPU fallback fails the run, never silently mismeasures).
+
+enum private OutFmt {
+    txt
+    md
+    json
+}
 
 [CommandLineArgs]
 struct Args {
@@ -37,6 +47,28 @@ struct Args {
     @clarg_short = "r"
     @clarg_doc = "Timed repetitions per row (default: 5, llama-bench -r)"
     reps : int = 5
+
+    @clarg_short = "t"
+    @clarg_doc = "Worker threads (default: the box profile; DAS_JOBQUE_THREADS still wins)"
+    threads : int = 0
+
+    @clarg_doc = "GPU layers, llama-bench spelling: 0 = CPU, anything else = Metal, required (default: 0)"
+    ngl : int = 0
+
+    @clarg_short = "o"
+    @clarg_doc = "Output format: txt, md (llama-bench-style table), json (public bench records) (default: txt)"
+    output : OutFmt = OutFmt.txt
+
+    @clarg_doc = "Path to a llama-bench binary — also bench llama.cpp on the same GGUF, same shapes"
+    ref : string
+
+    @clarg_name = "ref-flavor"
+    @clarg_doc = "The --ref binary's build flavor tag for the record: stock | clean-cpu (default: stock)"
+    ref_flavor : string = "stock"
+
+    @clarg_name = "json-path"
+    @clarg_doc = "With -o json: also write the records to this file — the machine rail (stdout carries engine logs too, and an untuned box's tune-relaunch merges stderr into it)"
+    json_path : string
 
     @clarg_short = "q"
     @clarg_doc = "Weight quant mode (default: q8)"
@@ -67,7 +99,22 @@ def private build_prompt(n : int64; seed : int64) : array<int64> {
     return <- [for (i in range64(n)); synth_id(i, seed)]
 }
 
-def private report(tag : string; tps : array<double>) {
+// progress line — stdout in txt mode, stderr when stdout carries the md table / json records
+def private say(fmt : OutFmt; text : string) {
+    if (fmt == OutFmt.txt) {
+        print(text)
+    } else {
+        fwrite(fstderr(), text)
+    }
+}
+
+struct private RowStat {
+    test : string
+    mean : double
+    sd : double
+}
+
+def private row_stat(tag : string; tps : array<double>) : RowStat {
     var sum = 0.0lf
     for (v in tps) {
         sum += v
@@ -79,12 +126,15 @@ def private report(tag : string; tps : array<double>) {
         vsum += (v - mean) * (v - mean)
     }
     let sd = n > 1 ? double(sqrt(float(vsum / double(n - 1)))) : 0.0lf
-    print("{tag}: {mean:.2f} ± {sd:.2f} tok/s ({n} reps)\n")
+    return RowStat(test = tag, mean = mean, sd = sd)
+}
+
+def private tests_of(rows : array<RowStat>) : table<string; BenchTest> {
+    return <- { for (r in rows); r.test => BenchTest(tok_s = r.mean, stddev = r.sd) }
 }
 
 [export]
 def main() {
-    allow_cpu_prefill()   // CPU-protocol bench by intent — disarm the Metal-build tripwire
     if (!jit_enabled()) {
         print("This benchmark is JIT-only — run with: daslang -jit <file>\n")
         return
@@ -100,15 +150,32 @@ def main() {
         print_help(get_command_info(type<Args>), "lcpp_bench")
         return
     }
+    let gpu = cfg.ngl != 0
+    if (!gpu) {
+        allow_cpu_prefill()   // CPU-protocol bench by intent — disarm the Metal-build tripwire
+    }
     let plen = max(int64(cfg.plen), 0l)
     let ngen = max(int64(cfg.ngen), 0l)
     let reps = max(cfg.reps, 1)
+    if ((cfg.dense_ab ? 1 : 0) + (cfg.comb_ab ? 1 : 0) + (cfg.dn_ab ? 1 : 0) + (cfg.attn_ab ? 1 : 0) > 1) {
+        print("warning: --dense-ab / --comb-ab / --dn-ab / --attn-ab are mutually exclusive — running the first only\n")
+    }
+    let ab = cfg.dense_ab || cfg.comb_ab || cfg.dn_ab || cfg.attn_ab
+    var fmt = cfg.output
+    if (ab && fmt != OutFmt.txt) {
+        print("warning: -o {cfg.output} with an A/B lever — records cover the plain protocol only, falling back to txt\n")
+        fmt = OutFmt.txt
+    }
     // the standing per-box methodology, enforced here rather than left to the environment
     // (gen_profile's pattern): cap the future que's workers (computing main is the last lane) and
-    // hard-pin lanes to distinct physical cores on the boxes that pin. Explicit DAS_JOBQUE_THREADS
-    // / DAS_JOBQUE_AFFINITY envs still win. Must run before any with_job_que.
-    let threads = has_env_variable("DAS_JOBQUE_THREADS") ? to_int(get_env_variable("DAS_JOBQUE_THREADS")) : profile_threads()
-    if (!has_env_variable("DAS_JOBQUE_THREADS")) {
+    // hard-pin lanes to distinct physical cores on the boxes that pin. -t is the explicit ask, but
+    // DAS_JOBQUE_THREADS / DAS_JOBQUE_AFFINITY envs still win the que's actual lane count.
+    let t_env = has_env_variable("DAS_JOBQUE_THREADS")
+    var threads = cfg.threads > 0 ? cfg.threads : (t_env ? to_int(get_env_variable("DAS_JOBQUE_THREADS")) : profile_threads())
+    if (t_env && to_int(get_env_variable("DAS_JOBQUE_THREADS")) != threads) {
+        threads = to_int(get_env_variable("DAS_JOBQUE_THREADS"))
+        say(fmt, "warning: DAS_JOBQUE_THREADS overrides -t — running {threads} lanes\n")
+    } elif (!t_env) {
         set_jobque_threads_cap(max(threads - 1, 1))
     }
     let pinned = affinity_on() && !has_env_variable("DAS_JOBQUE_AFFINITY")
@@ -116,6 +183,9 @@ def main() {
         set_jobque_affinity(2)   // 2 = hard mask, the llama-bench --cpu-strict mirror (mode 1 re-rolls SMT placement)
     }
     apply_box_profile_runtime()   // the tuned per-box stack — what load_model users get
+    if (gpu) {
+        set_metal_mode(MetalMode.required)   // before load_model — pins the portable backend, activates the metal overrides
+    }
     if (cfg.dense_ab && !has_env_variable("DASLLAMA_GPU_DENSE")) {
         print("warning: --dense-ab without DASLLAMA_GPU_DENSE=1 — no dense marks, both arms identical\n")
     }
@@ -125,7 +195,10 @@ def main() {
     if (cfg.attn_ab && !has_env_variable("DASLLAMA_GPU_ATTN")) {
         print("warning: --attn-ab without DASLLAMA_GPU_ATTN=1 — no attention marks, both arms identical\n")
     }
-    print("loading {cfg.model}\n")
+    say(fmt, "loading {cfg.model}\n")
+    var results : array<RowStat>
+    var modelArch = ""
+    var activeB = 0.0lf
     with_job_que() {
         setup_dasllama_jobque_()
         // load INSIDE the que, on the image rail: the .dlim maps in ms, and the GPU tier's
@@ -134,12 +207,10 @@ def main() {
         var t <- load_model_cached(cfg.model, cfg.quant)
         t.config.seq_len = min(t.config.seq_len, max(plen, ngen) + 8l)   // cap the KV allocation
         let c = t.config
-        print("config: dim={c.dim} layers={c.n_layers} vocab={c.vocab_size} | backend {active_kernel_backend()} (batch {active_batch_backend()}) | t{threads} affinity {pinned ? "hard" : "env/off"} | pp{plen} tg{ngen} x {reps} reps\n")
+        say(fmt, "config: dim={c.dim} layers={c.n_layers} vocab={c.vocab_size} | backend {active_kernel_backend()} (batch {active_batch_backend()}) | t{threads} affinity {pinned ? "hard" : "env/off"} | pp{plen} tg{ngen} x {reps} reps\n")
+        modelArch = "{t.arch}"
+        activeB = active_params_b(t)
         var s <- make_run_state(c)
-        if ((cfg.dense_ab ? 1 : 0) + (cfg.comb_ab ? 1 : 0) + (cfg.dn_ab ? 1 : 0) + (cfg.attn_ab ? 1 : 0) > 1) {
-            print("warning: --dense-ab / --comb-ab / --dn-ab / --attn-ab are mutually exclusive — running the first only\n")
-        }
-        let ab = cfg.dense_ab || cfg.comb_ab || cfg.dn_ab || cfg.attn_ab
         for (arm in range(ab ? 2 : 1)) {
             var dtag = ""
             if (cfg.dense_ab) {
@@ -166,7 +237,9 @@ def main() {
                     let us = get_time_usec(t0)
                     tps |> push(double(plen) * 1.0e6lf / double(us))
                 }
-                report("pp{plen}{dtag}", tps)
+                let st = row_stat("pp{plen}{dtag}", tps)
+                say(fmt, "{st.test}: {st.mean:.2f} ± {st.sd:.2f} tok/s ({reps} reps)\n")
+                results |> push(st)
                 delete tps
             }
             if (ngen > 0l) {
@@ -180,11 +253,108 @@ def main() {
                     let us = get_time_usec(t0)
                     tps |> push(double(ngen) * 1.0e6lf / double(us))
                 }
-                report("tg{ngen}{dtag}", tps)
+                let st = row_stat("tg{ngen}{dtag}", tps)
+                say(fmt, "{st.test}: {st.mean:.2f} ± {st.sd:.2f} tok/s ({reps} reps)\n")
+                results |> push(st)
                 delete tps
             }
         }
         delete s
         delete t
     }
+    // the reference runs AFTER our model is freed — one model process at a time, per the protocol
+    var refRows : array<LlamaBenchRow>
+    var refCmd = ""
+    if (!empty(cfg.ref)) {
+        let aff = (!gpu && affinity_on()) ? lcpp_affinity_args(threads) : ""
+        refCmd = "{cfg.ref} -m {cfg.model} -ngl {cfg.ngl} -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {reps} -o json"
+        say(fmt, "ref: {refCmd}\n")
+        if (!run_llama_bench(refCmd, refRows)) {
+            say(fmt, "warning: llama-bench run/parse failed — no ref rows\n")
+        }
+        for (rr in refRows) {
+            let tag = rr.n_gen == 0 ? "pp{rr.n_prompt}" : "tg{rr.n_gen}"
+            say(fmt, "ref {tag}: {rr.avg_ts:.2f} tok/s\n")
+        }
+    }
+    if (fmt == OutFmt.txt) {
+        return
+    }
+    let backend = gpu ? "metal" : "cpu"
+    let gguf = base_name(cfg.model)
+    if (fmt == OutFmt.md) {
+        let headers <- ["engine", "model", "backend", "ngl", "threads", "test", "t/s"]
+        let aligns <- [ColAlign.left, ColAlign.left, ColAlign.left, ColAlign.right, ColAlign.right, ColAlign.left, ColAlign.right]
+        var rows : array<array<string>>
+        rows |> reserve(length(results) + length(refRows))
+        for (st in results) {
+            var row <- ["das", gguf, backend, "{cfg.ngl}", "{threads}", st.test, "{st.mean:.2f} ± {st.sd:.2f}"]
+            rows |> emplace(row)
+        }
+        for (rr in refRows) {
+            let tag = rr.n_gen == 0 ? "pp{rr.n_prompt}" : "tg{rr.n_gen}"
+            let sd = rr.stddev_ts
+            var row <- ["llama.cpp", gguf, backend, "{cfg.ngl}", "{threads}", tag, "{rr.avg_ts:.2f} ± {sd:.2f}"]
+            rows |> emplace(row)
+        }
+        print(render_md_table(headers, aligns, rows))
+        return
+    }
+    // -o json: the public bench records — one BenchModel, das run + optional llama.cpp sibling
+    let hw = gather_hardware()
+    let date = format_time(get_clock(), "%Y-%m-%d")
+    let box = box_name()
+    var m = BenchModel(
+        gguf = gguf,
+        arch = modelArch,
+        quant = quant_str(cfg.quant),
+        active_b = activeB,
+        size_bytes = int64(stat(cfg.model).size))
+    if (!empty(refRows)) {
+        m.params_b = double(refRows[0].model_n_params) / 1.0e9lf
+    }
+    let argstr = join(get_cli_arguments(), " ")
+    var dr = BenchRun(
+        engine = "das",
+        backend = backend,
+        flavor = "tuned",
+        box = box,
+        threads = threads,
+        date = date,
+        cmd = "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- {argstr}",
+        sha = run_capture("git rev-parse --short HEAD", true),
+        version = das_version(),
+        tune = tune_summary(),
+        hardware = hw,
+        tests <- tests_of(results))
+    m.runs |> emplace(dr)
+    if (!empty(refRows)) {
+        var rr = BenchRun(
+            engine = "llama.cpp",
+            backend = backend,
+            flavor = cfg.ref_flavor,
+            box = box,
+            threads = threads,
+            date = date,
+            cmd = refCmd,
+            sha = refRows[0].build_commit,
+            hardware = hw)
+        for (row in refRows) {
+            let tag = row.n_gen == 0 ? "pp{row.n_prompt}" : "tg{row.n_gen}"
+            rr.tests |> insert(tag, BenchTest(tok_s = row.avg_ts, stddev = row.stddev_ts))
+        }
+        m.runs |> emplace(rr)
+    }
+    var models : array<BenchModel>
+    models |> emplace(m)
+    let text = sprint_json(models, true)
+    if (!empty(cfg.json_path)) {
+        fopen(cfg.json_path, "wb") $(f) {
+            if (f != null) {
+                fwrite(f, text)
+            }
+        }
+        say(fmt, "records written to {cfg.json_path}\n")
+    }
+    print("{text}\n")
 }

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -362,12 +362,18 @@ def main() {
     models |> emplace(m)
     let text = sprint_json(models, true)
     if (!empty(cfg.json_path)) {
+        var wrote = false
         fopen(cfg.json_path, "wb") $(f) {
             if (f != null) {
                 fwrite(f, text)
+                wrote = true
             }
         }
-        say(fmt, "records written to {cfg.json_path}\n")
+        if (wrote) {
+            say(fmt, "records written to {cfg.json_path}\n")
+        } else {
+            say(fmt, "warning: could not open {cfg.json_path} for writing — no records file\n")
+        }
     }
     print("{text}\n")
 }

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -199,6 +199,7 @@ def main() {
     var results : array<RowStat>
     var modelArch = ""
     var activeB = 0.0lf
+    var execFmt = ""
     with_job_que() {
         setup_dasllama_jobque_()
         // load INSIDE the que, on the image rail: the .dlim maps in ms, and the GPU tier's
@@ -210,6 +211,7 @@ def main() {
         say(fmt, "config: dim={c.dim} layers={c.n_layers} vocab={c.vocab_size} | backend {active_kernel_backend()} (batch {active_batch_backend()}) | t{threads} affinity {pinned ? "hard" : "env/off"} | pp{plen} tg{ngen} x {reps} reps\n")
         modelArch = "{t.arch}"
         activeB = active_params_b(t)
+        execFmt = model_exec_fmt(t)
         var s <- make_run_state(c)
         for (arm in range(ab ? 2 : 1)) {
             var dtag = ""
@@ -325,6 +327,7 @@ def main() {
         sha = run_capture("git rev-parse --short HEAD", true),
         version = das_version(),
         tune = tune_summary(),
+        exec_fmt = execFmt,
         hardware = hw,
         tests <- tests_of(results))
     m.runs |> emplace(dr)
@@ -338,6 +341,7 @@ def main() {
             date = date,
             cmd = refCmd,
             sha = refRows[0].build_commit,
+            exec_fmt = lcpp_exec_fmt(backend),
             hardware = hw)
         for (row in refRows) {
             let tag = row.n_gen == 0 ? "pp{row.n_prompt}" : "tg{row.n_gen}"

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -278,7 +278,7 @@ def main() {
     var refCmd = ""
     if (!empty(cfg.ref)) {
         let aff = (!gpu && affinity_on()) ? lcpp_affinity_args(threads) : ""
-        refCmd = "{cfg.ref} -m {cfg.model} -ngl {cfg.ngl} -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {reps} -o json"
+        refCmd = "\"{cfg.ref}\" -m \"{cfg.model}\" -ngl {cfg.ngl} -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {reps} -o json"
         say(fmt, "ref: {refCmd}\n")
         if (!run_llama_bench(refCmd, refRows)) {
             say(fmt, "warning: llama-bench run/parse failed — no ref rows\n")

--- a/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
+++ b/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
@@ -116,7 +116,7 @@ def main : int {
         return 1
     }
     let want = empty(cfg.sha) ? DEFAULT_REF_SHA : cfg.sha
-    let full = capture_out("git -C \"{src}\" rev-parse --verify --quiet {want}^\{commit\}")
+    let full = capture_out("git -C \"{src}\" rev-parse --verify --quiet \"{want}^\{commit\}\"")
     if (empty(full)) {
         print("error: `{want}` is not a commit in {src} — fetch it first (git -C \"{src}\" fetch origin)\n")
         return 1

--- a/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
+++ b/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
@@ -45,7 +45,9 @@ def private capture_out(cmd : string) : string {
     var out = ""
     unsafe {
         popen(cmd) $(f) {
-            out = fread_to_eof(f)
+            if (f != null) {   // popen returns null on spawn failure (missing git / bad PATH) — don't deref
+                out = fread_to_eof(f)
+            }
         }
     }
     return strip(out)

--- a/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
+++ b/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
@@ -1,0 +1,167 @@
+options gen2
+
+require daslib/fio
+require daslib/clargs
+require strings
+require daslib/strings_boost
+
+// The reference supply chain (modules/dasLLAMA/PUBLIC_BENCH_PLAN.md): build pinned llama-bench
+// binaries per build flavor, so every box — and any community user who wants our exact reference —
+// benches against the identical binary. One git worktree at the pinned sha, one build dir per flavor:
+//   clean-cpu: -DGGML_ACCELERATE=OFF -DGGML_BLAS=OFF -DGGML_METAL=OFF — kernel-vs-kernel fair
+//              (on Apple Silicon, Accelerate routes GEMM through the AMX coprocessor; das's own
+//              kernels don't use it)
+//   stock:     release defaults — llama.cpp as people actually run it (Accelerate + Metal on
+//              macOS); one build serves CPU rows (-ngl 0) and Metal rows (-ngl 99)
+// Usage: bin/daslang modules/dasLLAMA/benchmarks/setup_lcpp_ref.das -- --src ~/Work/llama.cpp
+// Point lcpp_bench --ref (or LLAMA_BENCH) at the reported binaries.
+
+// bump deliberately; the sha a record carries is what pins its ref, this is just the default
+let DEFAULT_REF_SHA = "ebd048fc5e4b43ec4e0b4abe0b9bf66e1724dad0"
+
+[CommandLineArgs]
+struct Args {
+    @clarg_required
+    @clarg_doc = "Path to a llama.cpp git checkout (worktrees and builds are created NEXT to it)"
+    src : string
+
+    @clarg_doc = "llama.cpp commit to pin (default: the standing reference sha)"
+    sha : string
+
+    @clarg_doc = "Build flavor, repeatable: clean-cpu | stock (default: both)"
+    flavor : array<string>
+
+    @clarg_short = "j"
+    @clarg_doc = "Parallel build jobs (default: 8)"
+    jobs : int = 8
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+// Run `cmd`, return its trimmed stdout (pipe-safe fread_to_eof; stderr stays on the console).
+def private capture_out(cmd : string) : string {
+    var out = ""
+    unsafe {
+        popen(cmd) $(f) {
+            out = fread_to_eof(f)
+        }
+    }
+    return strip(out)
+}
+
+// Run a command with inherited stdio so git/cmake progress streams live.
+def private run_visible(cmd : string) : int {
+    print("$ {cmd}\n")
+    return unsafe(system(cmd))
+}
+
+// Reject paths that could break out of the double-quoted shell commands below — the quote itself,
+// POSIX command substitution, cmd.exe variable expansion, and newlines (the mcp/setup.das guard).
+def private shell_unsafe(s : string) : bool {
+    return (find(s, "\"") >= 0 || find(s, "`") >= 0 || find(s, "$") >= 0 ||
+        find(s, "%") >= 0 || find(s, "\n") >= 0 || find(s, "\r") >= 0)
+}
+
+def private flavor_flags(flavor : string) : string {
+    if (flavor == "clean-cpu") {
+        return " -DGGML_ACCELERATE=OFF -DGGML_BLAS=OFF -DGGML_METAL=OFF"
+    }
+    return ""   // stock: release defaults
+}
+
+// The built llama-bench, wherever this platform's generator put it; "" when the build failed.
+def private locate_bench(build_dir : string) : string {
+    let candidates = ["bin/llama-bench", "bin/Release/llama-bench.exe", "bin/llama-bench.exe"]
+    for (rel in candidates) {
+        let p = path_join(build_dir, rel)
+        if (fexist(p)) {
+            return p
+        }
+    }
+    return ""
+}
+
+[export]
+def main : int {
+    var r <- parse_args(type<Args>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Args>), "setup_lcpp_ref")
+        return 1
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Args>), "setup_lcpp_ref")
+        return 0
+    }
+    var flavors := cfg.flavor
+    if (empty(flavors)) {
+        flavors <- ["clean-cpu", "stock"]
+    }
+    for (f in flavors) {
+        if (f != "clean-cpu" && f != "stock") {
+            print("error: unknown flavor `{f}` — expected clean-cpu | stock\n")
+            return 1
+        }
+    }
+    let src = cfg.src
+    if (shell_unsafe(src) || shell_unsafe(cfg.sha)) {
+        print("error: --src / --sha contain shell-special characters\n")
+        return 1
+    }
+    if (!stat(src).is_valid) {
+        print("error: --src `{src}` does not exist\n")
+        return 1
+    }
+    let want = empty(cfg.sha) ? DEFAULT_REF_SHA : cfg.sha
+    let full = capture_out("git -C \"{src}\" rev-parse --verify --quiet {want}^\{commit\}")
+    if (empty(full)) {
+        print("error: `{want}` is not a commit in {src} — fetch it first (git -C \"{src}\" fetch origin)\n")
+        return 1
+    }
+    let short_sha = slice(full, 0, 7)
+    let dest = "{src}-ref-{short_sha}"
+    if (!stat(dest).is_valid) {
+        print("creating worktree {dest} @ {short_sha}\n")
+        if (run_visible("git -C \"{src}\" worktree add \"{dest}\" {full}") != 0) {
+            print("error: worktree add failed\n")
+            return 1
+        }
+    } else {
+        let head = capture_out("git -C \"{dest}\" rev-parse HEAD")
+        if (head != full) {
+            print("error: {dest} exists but is at {head}, not {full} — remove it (git -C \"{src}\" worktree remove \"{dest}\") and re-run\n")
+            return 1
+        }
+        print("worktree {dest} already at {short_sha}\n")
+    }
+    var rc = 0
+    for (f in flavors) {
+        let build_dir = path_join(dest, "build-{f}")
+        print("=== {f} -> {build_dir} (minutes-class: configure + build llama-bench)\n")
+        if (!fexist(path_join(build_dir, "CMakeCache.txt"))) {
+            let cfg_cmd = "cmake -S \"{dest}\" -B \"{build_dir}\" -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF{flavor_flags(f)}"
+            if (run_visible(cfg_cmd) != 0) {
+                print("error: cmake configure failed for {f}\n")
+                rc = 1
+                continue
+            }
+        }
+        if (run_visible("cmake --build \"{build_dir}\" --config Release --target llama-bench -j {cfg.jobs}") != 0) {
+            print("error: build failed for {f}\n")
+            rc = 1
+            continue
+        }
+        let bench = locate_bench(build_dir)
+        if (empty(bench)) {
+            print("error: {f} built but llama-bench not found under {build_dir}\n")
+            rc = 1
+            continue
+        }
+        print("{f}: {bench} (llama.cpp {short_sha})\n")
+        print("    lcpp_bench: --ref \"{bench}\" --ref-flavor {f}\n")
+    }
+    return rc
+}

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -40,16 +40,22 @@ enum QuantMode {
     q4_0
 }
 
-//! Per-weight storage format under a q8-mode load with native K-quant planes (kquant_native):
-//! q8 = qblob/qscales; k4/k5/k6 = the tensor's element offset indexes that format's plane pair. A
-//! Q4_K_M file mixes formats PER TENSOR, so the tag rides per layer next to each offset array.
+//! Per-weight storage format under a q8-mode load with native planes: q8 = qblob/qscales;
+//! k4/k5/k6/q40 = superblock plane pairs (a file mixes formats PER TENSOR — tags ride per layer);
+//! q51 = native Q5_1, per-32-BLOCK planes + Q8_0-form activations (rows % 32, expert stacks only).
 enum KqFmt : uint8 {
     q8
     k4
     k5
     k6
     q40
+    q51
 }
+
+// The superblock-lattice formats (Q8_K-form activations, % 256 rows, repack + stamped kq
+// kernels). q51 deliberately fails this: it rides per-32 planes with Q8_0-form activations —
+// a `fmt != KqFmt.q8` test no longer implies the kq lattice; branch on kq_sb where it does.
+def private kq_sb(f : KqFmt) : bool => f == KqFmt.k4 || f == KqFmt.k5 || f == KqFmt.k6 || f == KqFmt.q40
 
 //! FFN gate activation: silu = SwiGLU (Llama family), gelu = GeGLU (Gemma), swiglu_oai = the
 //! clamped SwiGLU with +1 on the up branch (gpt-oss).
@@ -545,6 +551,9 @@ struct Model {
     // the q40 tier's plane pair (128B nibbles — the k4 pairing — + 16B of f16 d per superblock)
     q40q : array<uint8>
     q40s : array<uint8>
+    // the q51 tier's plane pair, per 32-BLOCK: 20B nibbles+qh / 4B f16 d+m (never repacked)
+    q51q : array<uint8>
+    q51s : array<uint8>
     kquant_native : bool = false
     // kq stage 4: the kq planes were repacked at load into the active backend's grp<mr> layout.
     // From then on every kq matmul MUST run the backend slots — disk-order portable kernels would
@@ -783,6 +792,7 @@ struct private LayoutSizes {
     k5_n : int64
     k6_n : int64
     q40_n : int64
+    q51_n : int64
 }
 
 // The big-weight layout cursors: one element cursor per storage plane. kq_take advances the
@@ -793,6 +803,7 @@ struct private KqCursors {
     k5 : int64
     k6 : int64
     q40 : int64
+    q51 : int64
 }
 
 def private kq_take(var cur : KqCursors; f : KqFmt; n : int64) : int64 {
@@ -814,6 +825,11 @@ def private kq_take(var cur : KqCursors; f : KqFmt; n : int64) : int64 {
     if (f == KqFmt.q40) {
         let o = cur.q40
         cur.q40 += n
+        return o
+    }
+    if (f == KqFmt.q51) {
+        let o = cur.q51
+        cur.q51 += n
         return o
     }
     let o = cur.wo
@@ -1099,7 +1115,7 @@ def private layout_offsets(var t : Model) : LayoutSizes {
         fo += dim
     }
     return LayoutSizes(fblob_n = fo, wblob_n = cur.wo, mx_n = mx, bf16_n = bf16,
-                       k4_n = cur.k4, k5_n = cur.k5, k6_n = cur.k6, q40_n = cur.q40)
+                       k4_n = cur.k4, k5_n = cur.k5, k6_n = cur.k6, q40_n = cur.q40, q51_n = cur.q51)
 }
 
 // Reserve exact capacity then size — avoids the array allocator's power-of-2 rounding on big arrays.
@@ -1214,6 +1230,8 @@ def private load_big(m : GGUFMeta; bytes : array<uint8> | #; name : string; var 
         gguf_transcode_q6k(m, bytes, name, t.k6q, t.k6s, woff, n, src_off)
     } elif (fmt == KqFmt.q40) {
         gguf_transcode_q40(m, bytes, name, t.q40q, t.q40s, woff, n, src_off)
+    } elif (fmt == KqFmt.q51) {
+        gguf_transcode_q51(m, bytes, name, t.q51q, t.q51s, woff, n, src_off)
     } elif (t.quant == QuantMode.q8) {
         let gt = gguf_tensor_type(m, name)
         if (gt == GGML_TYPE_Q8_0) {
@@ -1425,6 +1443,19 @@ def public get_kq_q50_native() : bool {
     return g_kq_q50_native
 }
 
+// The q51 tier's bring-up knob: OFF keeps Q5_1 tensors on the q8-requant fallback (~1.4x expert
+// memory, exact) — the zero-risk A/B rail while the tier proves out.
+var private g_kq_q51_native = true
+
+//! Enable/disable the native Q5_1 plane tier for subsequent loads (A/B rail; default ON;
+//! requires kquant_native). Expert stacks only — dense positions always requant to q8.
+def public set_kq_q51_native(on : bool) {
+    g_kq_q51_native = on
+}
+def public get_kq_q51_native() : bool {
+    return g_kq_q51_native
+}
+
 def private count_fmt(a : array<KqFmt>; f : KqFmt) : int {
     var n = 0
     for (x in a) {
@@ -1452,8 +1483,8 @@ def private log_load_report(t : Model) {
     to_log(LOG_INFO, "dasLLAMA noisy: backend '{active_kernel_backend()}' | kquant_native {g_kquant_native} q40_native {g_kq_q40_native} q50_native {g_kq_q50_native}\n")
     // the tier arms at [init], before a --noisy CLI flag can land — restate it here so the flag alone suffices
     to_log(LOG_INFO, "dasLLAMA noisy: GPU tier installed {moe_gpu_tier_installed()} | want auto {gpu_want_auto()}, moe layers {gpu_want_moe_layers()}, stream {gpu_want_moe_stream()}\n")
-    to_log(LOG_INFO, "dasLLAMA noisy: format tags — q8 {tally_fmt(t, KqFmt.q8)}, k4 {tally_fmt(t, KqFmt.k4)}, k5 {tally_fmt(t, KqFmt.k5)}, k6 {tally_fmt(t, KqFmt.k6)}, q40 {tally_fmt(t, KqFmt.q40)}\n")
-    to_log(LOG_INFO, "dasLLAMA noisy: plane MB — q8 {float(long_length(t.qblob)) / mb} (+scales {float(long_length(t.qscales) * 4l) / mb}), k4 {float(long_length(t.k4q) + long_length(t.k4s)) / mb}, k5 {float(long_length(t.k5q) + long_length(t.k5s)) / mb}, k6 {float(long_length(t.k6q) + long_length(t.k6s)) / mb}, q40 {float(long_length(t.q40q) + long_length(t.q40s)) / mb}, f32 {float(long_length(t.wblob) * 4l) / mb}\n")
+    to_log(LOG_INFO, "dasLLAMA noisy: format tags — q8 {tally_fmt(t, KqFmt.q8)}, k4 {tally_fmt(t, KqFmt.k4)}, k5 {tally_fmt(t, KqFmt.k5)}, k6 {tally_fmt(t, KqFmt.k6)}, q40 {tally_fmt(t, KqFmt.q40)}, q51 {tally_fmt(t, KqFmt.q51)}\n")
+    to_log(LOG_INFO, "dasLLAMA noisy: plane MB — q8 {float(long_length(t.qblob)) / mb} (+scales {float(long_length(t.qscales) * 4l) / mb}), k4 {float(long_length(t.k4q) + long_length(t.k4s)) / mb}, k5 {float(long_length(t.k5q) + long_length(t.k5s)) / mb}, k6 {float(long_length(t.k6q) + long_length(t.k6s)) / mb}, q40 {float(long_length(t.q40q) + long_length(t.q40s)) / mb}, q51 {float(long_length(t.q51q) + long_length(t.q51s)) / mb}, f32 {float(long_length(t.wblob) * 4l) / mb}\n")
 }
 
 // GGML disk type -> plane format tag (non-K-quant types ride the classic q8 path)
@@ -1473,13 +1504,25 @@ def private kq_fmt_of(gt : int) : KqFmt {
     if (gt == GGML_TYPE_Q5_0 && g_kq_q50_native) {
         return KqFmt.k5
     }
+    if (gt == GGML_TYPE_Q5_1 && g_kq_q51_native) {
+        return KqFmt.q51
+    }
     return KqFmt.q8
 }
 
-// q40/q50 demotion: Q4_0 and Q5_0 guarantee rows % 32 only, but the kq tier's superblock walkers
-// need % 256 — a misaligned tensor falls back to the q8 requant path. `n` = the tensor's ROW length.
-// The k5 arm fires only for a Q5_0 source; a genuine Q5_K row is always % 256.
-def private kq_fmt_row_ok(f : KqFmt; n : int64) : KqFmt => (f == KqFmt.q40 || f == KqFmt.k5) && n % 256l != 0l ? KqFmt.q8 : f
+// Dense-position demotion: q40/k5-from-Q5_0 need % 256 rows (superblock walkers); q51 always
+// demotes — dense positions have no q51 dispatch (v1 is expert stacks — kq_fmt_expert_ok).
+def private kq_fmt_row_ok(f : KqFmt; n : int64) : KqFmt {
+    if (f == KqFmt.q51) return KqFmt.q8
+    return (f == KqFmt.q40 || f == KqFmt.k5) && n % 256l != 0l ? KqFmt.q8 : f
+}
+
+// Expert-stack tag rule: q51 serves natively off per-32 planes (its whole reason to exist — the
+// 26B-A4B down stacks are 704-wide); the superblock formats keep the % 256 rule.
+def private kq_fmt_expert_ok(f : KqFmt; n : int64) : KqFmt {
+    if (f == KqFmt.q51) return n % 32l == 0l ? f : KqFmt.q8
+    return kq_fmt_row_ok(f, n)
+}
 
 // Fill the per-kind weight format tags from the file's tensor types (q8-mode loads with the
 // kquant_native knob on). Fused-projection arches (Phi3) split attn_qkv/ffn_up at row-aligned
@@ -1530,14 +1573,14 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
         let fused_gu = t.config.moe_dense_shexp   // gemma4: experts ship fused as ffn_gate_up_exps
         for (l in range64(layers)) {
             if (fused_gu) {
-                let f = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_up_exps.weight")), t.config.dim)
+                let f = kq_fmt_expert_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_up_exps.weight")), t.config.dim)
                 t.we1_fmt[l] = f
                 t.we3_fmt[l] = f
             } else {
-                t.we1_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_exps.weight")), t.config.dim)
-                t.we3_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up_exps.weight")), t.config.dim)
+                t.we1_fmt[l] = kq_fmt_expert_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_gate_exps.weight")), t.config.dim)
+                t.we3_fmt[l] = kq_fmt_expert_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_up_exps.weight")), t.config.dim)
             }
-            t.we2_fmt[l] = kq_fmt_row_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down_exps.weight")), t.config.n_ff_exp)
+            t.we2_fmt[l] = kq_fmt_expert_ok(kq_fmt_of(gguf_tensor_type(m, "blk.{l}.ffn_down_exps.weight")), t.config.n_ff_exp)
             any ||= t.we1_fmt[l] != KqFmt.q8 || t.we2_fmt[l] != KqFmt.q8 || t.we3_fmt[l] != KqFmt.q8
         }
     }
@@ -1575,6 +1618,12 @@ def private detect_kq_formats(var t : Model; m : GGUFMeta) {
 // Any K-quant-tagged expert stack in layer `l`? (The MoE dispatch and prefill gates branch on this.)
 def private moe_layer_kq(t : Model; l : int64) : bool {
     return fmt_at(t.we1_fmt, l) != KqFmt.q8 || fmt_at(t.we2_fmt, l) != KqFmt.q8 || fmt_at(t.we3_fmt, l) != KqFmt.q8
+}
+
+// Any expert stack on the SUPERBLOCK kq lattice? (q51 excluded — its grouped-prefill kernels are
+// always available, so it never gates on kq_repacked / the kq batch tile.)
+def private moe_layer_sb_kq(t : Model; l : int64) : bool {
+    return kq_sb(fmt_at(t.we1_fmt, l)) || kq_sb(fmt_at(t.we2_fmt, l)) || kq_sb(fmt_at(t.we3_fmt, l))
 }
 
 // Convert the (already repacked/permuted) f32 scale plane to raw binary16 halfwords and free the
@@ -3276,6 +3325,12 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             t.q40s |> reserve((sz.q40_n / 256l) * Q40_SSB)
             t.q40s |> resize((sz.q40_n / 256l) * Q40_SSB)
         }
+        if (sz.q51_n > 0l) {
+            t.q51q |> reserve((sz.q51_n / 32l) * Q51_QB)
+            t.q51q |> resize((sz.q51_n / 32l) * Q51_QB)
+            t.q51s |> reserve((sz.q51_n / 32l) * Q51_SB)
+            t.q51s |> resize((sz.q51_n / 32l) * Q51_SB)
+        }
         if (mode == QuantMode.q8) {
             t.qblob |> reserve(sz.wblob_n)
             t.qblob |> resize(sz.wblob_n)
@@ -3631,8 +3686,8 @@ def footprint(t : Model) : MemFootprint {
     let q4s = long_length(t.q4scales) * 4l
     let mx4 = long_length(t.mxq)                  // uint8 (two nibbles) -> 1 byte each
     let mx4s = long_length(t.mxs)                 // raw E8M0 -> 1 byte per 32-block
-    let kq = long_length(t.k4q) + long_length(t.k5q) + long_length(t.k6q) + long_length(t.q40q)
-    let kqs = long_length(t.k4s) + long_length(t.k5s) + long_length(t.k6s) + long_length(t.q40s)
+    let kq = long_length(t.k4q) + long_length(t.k5q) + long_length(t.k6q) + long_length(t.q40q) + long_length(t.q51q)
+    let kqs = long_length(t.k4s) + long_length(t.k5s) + long_length(t.k6s) + long_length(t.q40s) + long_length(t.q51s)
     return MemFootprint(aux_fp32_bytes = aux, weight_fp32_bytes = wf, q8_bytes = q8, q8_scale_bytes = q8s,
                         q4_bytes = q4, q4_scale_bytes = q4s, mx4_bytes = mx4, mx4_scale_bytes = mx4s,
                         kq_bytes = kq, kq_scale_bytes = kqs,
@@ -5354,6 +5409,20 @@ def private mm_at_mx4_groupn(var y : array<float>; t : Model; offs, boffs : arra
     matmul_mx4q8_groupn(y, t.mxq, t.mxs, offs, nregions, xq, xs, t.fblob, boffs, n, d)
 }
 
+// ===== native q51 dispatch (Q8_0-form activations — NOT the kq Q8_K image) =====
+
+def private mm_at_q51_groupn(var y : array<float>; t : Model; offs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; n, d : int64) {
+    matmul_q51q8_groupn(y, t.q51q, t.q51s, offs, nregions, xq, xs, n, d)
+}
+
+def private mm_b_q51_pre(var y : array<float>; t : Model; woff : int64; xqb : array<int8>; xsb : array<float>; n, d, npos : int64) {
+    matmul_q51q8_batch(y, t.q51q, t.q51s, woff, xqb, xsb, n, d, npos)
+}
+
+def private mm_b_q51_groupn(var y : array<float>; t : Model; offs : array<int64>; nregions : int64; xq : array<int8>; xs : array<float>; n, d : int64) {
+    matmul_q51q8_batch_groupn(y, t.q51q, t.q51s, offs, nregions, xq, xs, n, d)
+}
+
 // ===== native K-quant dispatch (kquant_native; fmt != q8 tags) =====
 
 // KqFmt -> the kernel-layer format id (matmul_kq*/kq_rows_fn/kq_qsb take the int form). q8 maps
@@ -5513,18 +5582,18 @@ def private kq_rows_for(fmt : KqFmt) : MatmulKqRowsFn {
     return kq_rows_fn(kq_fi(fmt))
 }
 
-// Can the fused chains serve a weight of this format? q8 always; kq only off a repacked load
-// (the backend rows cores read the grp layout the loader wrote).
-def private kq_servable(t : Model; fmt : KqFmt) : bool => fmt == KqFmt.q8 || t.kq_repacked
+// Can the fused chains serve a weight of this format? q8 always; superblock kq only off a
+// repacked load (the backend rows cores read the grp layout). q51 NEVER — no chain/rows arms.
+def private kq_servable(t : Model; fmt : KqFmt) : bool => fmt == KqFmt.q8 || (kq_sb(fmt) && t.kq_repacked)
 
-// kq v2 activation form: every kq format reads Q8_K-form activations (per-256 scale + per-16
-// bsums). The MoE gate/up pair shares ONE gathered/quantized activation plane, so its two
-// stacks must agree on the form: both kq (Q8_K) or both q8 (Q8_0).
+// Do the gate/up stacks read the Q8_K-form scratch? Superblock formats only — q8 AND q51 read
+// the Q8_0-form image. The pair shares ONE gathered activation plane, so both stacks must
+// agree on the form (mixed sb/non-sb panics).
 def private moe_pair_kform(f1, f3 : KqFmt) : bool {
-    let k1 = f1 != KqFmt.q8
-    let k3 = f3 != KqFmt.q8
+    let k1 = kq_sb(f1)
+    let k3 = kq_sb(f3)
     if (k1 != k3) {
-        panic("dasLLAMA: MoE gate/up expert stacks mix q8 and K-quant weights — unsupported until per-stack activation planes land")
+        panic("dasLLAMA: MoE gate/up expert stacks mix Q8_K-form and Q8_0-form weights — unsupported until per-stack activation planes land")
     }
     return k1
 }
@@ -7311,6 +7380,14 @@ def private heat_armed() : bool {
 
 def private heat_advise_layer(t : Model; l : int64; h : HeatLayer) {
     let c = t.config
+    // same fmt rule as the resident walk: a stack the tier has no kernels for (q51) never pools
+    let hf1 = fmt_at(t.we1_fmt, l)
+    let hf2 = fmt_at(t.we2_fmt, l)
+    let hf3 = fmt_at(t.we3_fmt, l)
+    if (!((hf1 == KqFmt.q8 || moe_gpu_fmt_kq(hf1)) && (hf2 == KqFmt.q8 || moe_gpu_fmt_kq(hf2))
+            && (hf3 == KqFmt.q8 || moe_gpu_fmt_kq(hf3)))) {
+        return
+    }
     var ids <- [for (i in range(length(h.cnt))); int64(i)]
     ids |> sort() $(a, b) => h.cnt[a] > h.cnt[b]
     var want = min(g_heat_want, int64(length(ids)))
@@ -7632,8 +7709,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                         mi++
                     }
                 }
-                if (f1 != KqFmt.q8) {
+                if (kq_sb(f1)) {
                     mm_at_kq_groupn(s.moe_gu, t, f1, s.moe_offs, m, s.kxq, s.kxs, s.kxbs, dim, nfe)
+                } elif (f1 == KqFmt.q51) {
+                    mm_at_q51_groupn(s.moe_gu, t, s.moe_offs, m, s.moe_xq, s.moe_xs, dim, nfe)
                 } else {
                     mm_at_q8_groupn(s.moe_gu, t, s.moe_offs, m, s.moe_xq, s.moe_xs, dim, nfe)
                 }
@@ -7645,8 +7724,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                         mi++
                     }
                 }
-                if (f3 != KqFmt.q8) {
+                if (kq_sb(f3)) {
                     mm_at_kq_groupn(s.moe_gu2, t, f3, s.moe_offs, m, s.kxq, s.kxs, s.kxbs, dim, nfe)
+                } elif (f3 == KqFmt.q51) {
+                    mm_at_q51_groupn(s.moe_gu2, t, s.moe_offs, m, s.moe_xq, s.moe_xs, dim, nfe)
                 } else {
                     mm_at_q8_groupn(s.moe_gu2, t, s.moe_offs, m, s.moe_xq, s.moe_xs, dim, nfe)
                 }
@@ -7654,7 +7735,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                 let ts_act = ref_time_ticks()
                 gate_batch(s.moe_gu, s.moe_gu2, c.ffn_act, nfe, m)
                 prof_add("act", ts_act)
-                if (f2 != KqFmt.q8) {
+                if (kq_sb(f2)) {
                     requant_rows_q8k_bs(s.moe_gu, nfe, m, s.moe_dq, s.moe_ds, s.moe_dbs)
                 } else {
                     requant_rows_q8(s.moe_gu, nfe, m, s.moe_dq, s.moe_ds)
@@ -7668,8 +7749,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                         mi++
                     }
                 }
-                if (f2 != KqFmt.q8) {
+                if (kq_sb(f2)) {
                     mm_at_kq_groupn(s.moe_dn, t, f2, s.moe_offs, m, s.moe_dq, s.moe_ds, s.moe_dbs, nfe, dim)
+                } elif (f2 == KqFmt.q51) {
+                    mm_at_q51_groupn(s.moe_dn, t, s.moe_offs, m, s.moe_dq, s.moe_ds, nfe, dim)
                 } else {
                     mm_at_q8_groupn(s.moe_dn, t, s.moe_offs, m, s.moe_dq, s.moe_ds, nfe, dim)
                 }
@@ -7699,8 +7782,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                 s.moe_offs[j * 2l + 1l] = 0l   // gates share the single hoisted xb image
                 s.moe_boffs[j] = t.web1_off + e * nfe
             }
-            if (f1 != KqFmt.q8) {   // native K-quant expert stack reads the Q8_K-form scratch (never biased — detect guards that)
+            if (kq_sb(f1)) {   // native K-quant expert stack reads the Q8_K-form scratch (never biased — detect guards that)
                 mm_at_kq_groupn(s.moe_gu, t, f1, s.moe_offs, k, s.kxq, s.kxs, s.kxbs, dim, nfe)
+            } elif (f1 == KqFmt.q51) {   // native Q5_1 stack reads the Q8_0-form image (never biased)
+                mm_at_q51_groupn(s.moe_gu, t, s.moe_offs, k, s.moe_xq, s.moe_xs, dim, nfe)
             } elif (t.experts_mx4) {   // native 4-bit expert weights — half the Q8 traffic
                 if (biased) {
                     mm_at_mx4_groupn(s.moe_gu, t, s.moe_offs, s.moe_boffs, k, s.moe_xq, s.moe_xs, dim, nfe)
@@ -7718,8 +7803,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                 s.moe_offs[j * 2l + 1l] = 0l   // ups read the same hoisted xb image (explicit, not inherited from the gate pass)
                 s.moe_boffs[j] = t.web3_off + e * nfe
             }
-            if (f3 != KqFmt.q8) {   // kq v2: Q8_K-form scratch
+            if (kq_sb(f3)) {   // kq v2: Q8_K-form scratch
                 mm_at_kq_groupn(s.moe_gu2, t, f3, s.moe_offs, k, s.kxq, s.kxs, s.kxbs, dim, nfe)
+            } elif (f3 == KqFmt.q51) {
+                mm_at_q51_groupn(s.moe_gu2, t, s.moe_offs, k, s.moe_xq, s.moe_xs, dim, nfe)
             } elif (t.experts_mx4) {
                 if (biased) {
                     mm_at_mx4_groupn(s.moe_gu2, t, s.moe_offs, s.moe_boffs, k, s.moe_xq, s.moe_xs, dim, nfe)
@@ -7735,7 +7822,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
             let ts_act = ref_time_ticks()
             gate_batch(s.moe_gu, s.moe_gu2, c.ffn_act, nfe, k)
             prof_add("act", ts_act)
-            if (f2 != KqFmt.q8) {   // kq v2: the down stack reads Q8_K-form rows
+            if (kq_sb(f2)) {   // kq v2: the down stack reads Q8_K-form rows; q51/q8 the Q8_0 form
                 requant_rows_q8k_bs(s.moe_gu, nfe, k, s.moe_dq, s.moe_ds, s.moe_dbs)
             } else {
                 requant_rows_q8(s.moe_gu, nfe, k, s.moe_dq, s.moe_ds)   // books mm_requant
@@ -7747,8 +7834,10 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                 s.moe_offs[j * 2l + 1l] = j * nfe   // each down reads its own requantized row
                 s.moe_boffs[j] = t.web2_off + e * dim   // down bias inside the routed weight (ggml_add_id order)
             }
-            if (f2 != KqFmt.q8) {
+            if (kq_sb(f2)) {
                 mm_at_kq_groupn(s.moe_dn, t, f2, s.moe_offs, k, s.moe_dq, s.moe_ds, s.moe_dbs, nfe, dim)
+            } elif (f2 == KqFmt.q51) {
+                mm_at_q51_groupn(s.moe_dn, t, s.moe_offs, k, s.moe_dq, s.moe_ds, nfe, dim)
             } elif (t.experts_mx4) {
                 if (biased) {
                     mm_at_mx4_groupn(s.moe_dn, t, s.moe_offs, s.moe_boffs, k, s.moe_dq, s.moe_ds, nfe, dim)
@@ -8080,7 +8169,7 @@ def private ffn_gemma4_prefill(t : Model; var s : Session; l : int64; npos : int
     }
     let dim = c.dim
     // kq-expert layers ride grouped buckets via the kq batch tile; portable/no-kq backends take the per-position path
-    let kq_grouped_ok = !moe_layer_kq(t, l) || (t.kq_repacked && kernel_backend_has_kq_batch())
+    let kq_grouped_ok = !moe_layer_sb_kq(t, l) || (t.kq_repacked && kernel_backend_has_kq_batch())
     if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && kq_grouped_ok) {
         gemma4_moe_prefill_grouped(t, s, l, npos)
     } else {
@@ -10499,9 +10588,12 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
     let f1 = fmt_at(t.we1_fmt, l)
     let f2 = fmt_at(t.we2_fmt, l)
     let f3 = fmt_at(t.we3_fmt, l)
-    // fused single-dispatch GEMMs: native mx4-batch backends, or kq layers whose stacks are ALL K-quant
-    let fused_kq = (kq_layer && f1 != KqFmt.q8 && f2 != KqFmt.q8 && f3 != KqFmt.q8
-        && t.kq_repacked && kernel_backend_has_kq_batch_groupn() && g_moe_fused_expert_gemms)
+    // fused single-dispatch GEMMs: all stacks native-plane (sb-kq needs repack+tile; q51 always)
+    let sb_fusable = t.kq_repacked && kernel_backend_has_kq_batch_groupn()
+    let fused_kq = (kq_layer && g_moe_fused_expert_gemms
+        && (kq_sb(f1) ? sb_fusable : f1 == KqFmt.q51)
+        && (kq_sb(f2) ? sb_fusable : f2 == KqFmt.q51)
+        && (kq_sb(f3) ? sb_fusable : f3 == KqFmt.q51))
     // GPU MoE tier: offloaded layers run the whole expert FFN chain device-side; tiny batches stay CPU (GPU submit cost > the GEMM)
     let fused_gpu = (!c.moe_exps_bias && !t.experts_mx4 && c.ffn_act != FfnAct.swiglu_oai
         && (moe_gpu_layer_on_gpu(l) || moe_gpu_layer_streamed(l)) && g_moe_fused_expert_gemms && npos >= 32l && gpu_prefill_route_on())
@@ -10665,9 +10757,17 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
                 s.moe_gxq, s.moe_gxs, dim, nfe, nk, int(f1), int(f3), int(f2), c.ffn_act == FfnAct.gelu)
             prof_add("moe_gpu", ts_g1)
         } else {
-            if (fused_kq) {   // native kq: one batched region-list GEMM per projection (never biased)
-                mm_b_kq_groupn(s.moe_ghb, t, f1, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
-                mm_b_kq_groupn(s.moe_ghb2, t, f3, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+            if (fused_kq) {   // native-plane: one batched region-list GEMM per projection (never biased)
+                if (kq_sb(f1)) {
+                    mm_b_kq_groupn(s.moe_ghb, t, f1, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+                } else {
+                    mm_b_q51_groupn(s.moe_ghb, t, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, dim, nfe)
+                }
+                if (kq_sb(f3)) {
+                    mm_b_kq_groupn(s.moe_ghb2, t, f3, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe)
+                } else {
+                    mm_b_q51_groupn(s.moe_ghb2, t, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, dim, nfe)
+                }
             } elif (c.moe_exps_bias) {   // gpt-oss: gate/up biases fold into the stores, before the act
                 matmul_mx4q8_batch_groupn(s.moe_ghb, t.mxq, t.mxs, s.moe_offs1, nreg, s.moe_gxq, s.moe_gxs, t.fblob, s.moe_boffs1, dim, nfe)
                 matmul_mx4q8_batch_groupn(s.moe_ghb2, t.mxq, t.mxs, s.moe_offs3, nreg, s.moe_gxq, s.moe_gxs, t.fblob, s.moe_boffs3, dim, nfe)
@@ -10679,14 +10779,16 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
             let ts_act = ref_time_ticks()
             gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, nk)
             prof_add("act", ts_act)
-            if (fused_kq) {   // kq v2: the down stacks read Q8_K-form rows (+ the per-16 sums the fold consumes)
+            if (fused_kq && kq_sb(f2)) {   // kq v2: sb down stacks read Q8_K-form rows (+ per-16 sums); q51/q8 the Q8_0 form
                 requant_rows_q8k_bs(s.moe_ghb, nfe, nk, s.moe_hq, s.moe_hs, s.moe_hbs)
             } else {
                 requant_rows_q8(s.moe_ghb, nfe, nk, s.moe_hq, s.moe_hs)
             }
             let ts_g3 = ref_time_ticks()
-            if (fused_kq) {
+            if (fused_kq && kq_sb(f2)) {
                 mm_b_kq_groupn(s.moe_gout, t, f2, s.moe_offs2, nreg, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim)
+            } elif (fused_kq) {
+                mm_b_q51_groupn(s.moe_gout, t, s.moe_offs2, nreg, s.moe_hq, s.moe_hs, nfe, dim)
             } elif (c.moe_exps_bias) {   // ... and the down biases, inside the routed weight (ggml_add_id order)
                 matmul_mx4q8_batch_groupn(s.moe_gout, t.mxq, t.mxs, s.moe_offs2, nreg, s.moe_hq, s.moe_hs, t.fblob, s.moe_boffs2, nfe, dim)
             } else {
@@ -10731,13 +10833,17 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         let eg = l * ne + e
         let base = e * dim * nfe
         if (kq_layer) {   // native kq batch tiles off the repacked planes, per-kind fmt (down may differ)
-            if (f1 != KqFmt.q8) {
+            if (kq_sb(f1)) {
                 mm_b_kq_pre(s.moe_ghb, t, f1, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+            } elif (f1 == KqFmt.q51) {
+                mm_b_q51_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             } else {
                 mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             }
-            if (f3 != KqFmt.q8) {
+            if (kq_sb(f3)) {
                 mm_b_kq_pre(s.moe_ghb2, t, f3, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+            } elif (f3 == KqFmt.q51) {
+                mm_b_q51_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             } else {
                 mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
             }
@@ -10771,13 +10877,15 @@ def private ffn_moe_prefill_grouped(t : Model; var s : Session; l : int64; npos 
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, cnt)
         prof_add("act", ts_act)
-        if (f2 != KqFmt.q8) {   // kq v2: Q8_K-form rows + the per-16 sums the fold consumes
+        if (kq_sb(f2)) {   // kq v2: Q8_K-form rows + the per-16 sums the fold consumes; q51/q8 the Q8_0 form
             requant_rows_q8k_bs(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs, s.moe_hbs)
         } else {
             requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
         }
-        if (f2 != KqFmt.q8) {
+        if (kq_sb(f2)) {
             mm_b_kq_pre(s.moe_gout, t, f2, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim, cnt)
+        } elif (f2 == KqFmt.q51) {
+            mm_b_q51_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         } elif (t.experts_mx4 && g_active_mx4_native_batch) {
             mm_b_mx4_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         } elif (t.experts_mx4) {
@@ -11066,23 +11174,30 @@ def private gemma4_moe_prefill_grouped(t : Model; var s : Session; l : int64; np
         moe_gather_rows(s, b0, cnt, dim, k, moe_kform, moe_kform)
         prof_add("moe_gather", ts_gather)
         let base = e * dim * nfe
-        if (f1 != KqFmt.q8) {
+        if (kq_sb(f1)) {
             mm_b_kq_pre(s.moe_ghb, t, f1, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+        } elif (f1 == KqFmt.q51) {
+            mm_b_q51_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         } else {
             mm_b_q8_pre(s.moe_ghb, t, t.we1_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         }
-        if (f3 != KqFmt.q8) {
+        if (kq_sb(f3)) {
             mm_b_kq_pre(s.moe_ghb2, t, f3, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, s.moe_gxbs, dim, nfe, cnt)
+        } elif (f3 == KqFmt.q51) {
+            mm_b_q51_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         } else {
             mm_b_q8_pre(s.moe_ghb2, t, t.we3_offs[l] + base, s.moe_gxq, s.moe_gxs, dim, nfe, cnt)
         }
         let ts_act = ref_time_ticks()
         gate_batch(s.moe_ghb, s.moe_ghb2, c.ffn_act, nfe, cnt)
         prof_add("act", ts_act)
-        if (f2 != KqFmt.q8) {
+        if (kq_sb(f2)) {
             // kq v2: Q8_K-form rows + the per-16 sums the fold consumes
             requant_rows_q8k_bs(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs, s.moe_hbs)
             mm_b_kq_pre(s.moe_gout, t, f2, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, s.moe_hbs, nfe, dim, cnt)
+        } elif (f2 == KqFmt.q51) {
+            requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
+            mm_b_q51_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
         } else {
             requant_rows_q8(s.moe_ghb, nfe, cnt, s.moe_hq, s.moe_hs)
             mm_b_q8_pre(s.moe_gout, t, t.we2_offs[l] + base, s.moe_hq, s.moe_hs, nfe, dim, cnt)
@@ -11163,7 +11278,7 @@ def private ffn_moe_prefill(t : Model; var s : Session; l : int64; npos : int64)
     // native-MXFP4 grouped path pays a per-touched-expert Q8 expansion (~120MB/expert); under ~8 rows/expert the per-position mx4 GEMVs are cheaper
     let mx4_grouped_pays = !t.experts_mx4 || npos * c.n_expert_used >= 8l * c.n_expert
     // kq-expert layers ride grouped buckets via the kq batch tile; portable/no-kq backends take the per-position path
-    let kq_grouped_ok = !moe_layer_kq(t, l) || (t.kq_repacked && kernel_backend_has_kq_batch())
+    let kq_grouped_ok = !moe_layer_sb_kq(t, l) || (t.kq_repacked && kernel_backend_has_kq_batch())
     if (t.quant == QuantMode.q8 && g_moe_grouped_prefill && mx4_grouped_pays && kq_grouped_ok) {
         ffn_moe_prefill_grouped(t, s, l, npos)
     } else {

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1347,9 +1347,10 @@ def rebind_arch_blocks(var t : Model; arch : string) {
     }
     t.arch = arch
     t.blocks = g_arch_registry[arch].blocks
-    if (t.config.moe_optional && !t.config.moe && t.config.n_embd_per_layer == 0l) {
-        // the file-resolved dense flavor of a moe-optional arch (gemma4 12B/31B) — mirror the
-        // load_gguf patch so the GPU drivers' graph gate serves image loads too
+    if (t.config.moe_optional && !t.config.moe) {
+        // the file-resolved dense flavor of a moe-optional arch (gemma4 12B/31B/E-series) — mirror
+        // the load_gguf patch so the GPU drivers' graph gate serves image loads too. The E-series
+        // PLE block is a dense-stack epilogue, expressed as MetalNeed.ple, not a MoE graph.
         t.blocks.ffn_is_dense = true
     }
 }
@@ -2222,6 +2223,15 @@ def private metal_blob_layout_ok(t : Model) : bool {
             return false
         }
     }
+    // E-series PLE gate/proj q8 planes bind per layer; the token table / model-proj stay CPU-side
+    if (has_ple(c)) {
+        let ples = c.dim * c.n_embd_per_layer
+        if ((ples % 256l) != 0l ||
+                !metal_blob_off_ok(t.ple_gate_off, KqFmt.q8) ||
+                !metal_blob_off_ok(t.ple_proj_off, KqFmt.q8)) {
+            return false
+        }
+    }
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     return (metal_blob_off_ok(t.wcls_off, cls_fmt) &&
         (!t.cls_q8 || metal_blob_off_ok(t.emb_q8_off, KqFmt.q8)))
@@ -2886,10 +2896,10 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
                 && gguf_has(m, "{arch}.expert_count") && gguf_int(m, bytes, "{arch}.expert_count") > 0l) {
             t.config.moe = true
         }
-        if (t.config.moe_optional && !t.config.moe && t.config.n_embd_per_layer == 0l) {
+        if (t.config.moe_optional && !t.config.moe) {
             // the moe-optional arch registers ffn_is_dense = false for the shared descriptor, but
-            // THIS file resolved dense with no PLE (12B/31B) — its ffn IS the std dense stack
-            // (+ out_scale), so the GPU drivers' graph gate may serve it
+            // THIS file resolved dense (12B/31B/E-series) — its ffn IS the std dense stack
+            // (+ out_scale; the E-series PLE epilogue is MetalNeed.ple, not a MoE graph)
             t.blocks.ffn_is_dense = true
         }
         if (t.config.moe) {

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2317,6 +2317,7 @@ def private metal_blob_off_ok(off : int64; fmt : KqFmt) : bool {
     if (off < 0l) return true
     if (fmt == KqFmt.q8) return off % 256l == 0l
     if (fmt == KqFmt.k6) return off % 512l == 0l
+    if (fmt == KqFmt.q51) return off % 128l == 0l   // (off/32)*20 and (off/32)*4 both 16B-aligned
     return true
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_gguf.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gguf.das
@@ -43,6 +43,7 @@ let GGML_TYPE_F32 = 0
 let GGML_TYPE_F16 = 1
 let GGML_TYPE_Q4_0 = 2
 let GGML_TYPE_Q5_0 = 6
+let GGML_TYPE_Q5_1 = 7
 let GGML_TYPE_Q8_0 = 8
 let GGML_TYPE_Q4_K = 12
 let GGML_TYPE_Q5_K = 13
@@ -1104,6 +1105,34 @@ def dequant_q40_plane_superblock(kq : array<uint8> | #; kqo : int64; ks : array<
     }
 }
 
+//! Transcode one Q5_1 disk block (24 bytes at `bo`: d f16, m f16, qh u32, 16 nibble bytes) into
+//! the q51 planes — verbatim splits, exact. The per-block array form the tests drive; the bulk
+//! loader (gguf_transcode_q51) runs the same split pointerized and threaded.
+def transcode_q51_block(bytes : array<uint8> | #; bo : int64; var kq : array<uint8>; kqo : int64; var ks : array<uint8>; kso : int64) {
+    for (i in range64(4l)) {
+        ks[kso + i] = bytes[bo + i]
+        kq[kqo + 16l + i] = bytes[bo + 4l + i]
+    }
+    for (i in range64(16l)) {
+        kq[kqo + i] = bytes[bo + 8l + i]
+    }
+}
+
+//! Reference dequant of one q51-plane 32-block: w = d * q + m with q = nibble | qh_bit << 4
+//! (elem k reads qh bit k, elem k+16 bit k+16 — the llama.cpp Q5_1 bit map, kept verbatim).
+def dequant_q51_plane_block(kq : array<uint8> | #; kqo : int64; ks : array<uint8> | #; kso : int64; var dst : array<float> | #; doff : int64) {
+    let d = f16_to_f32(rd_u16(ks, kso))
+    let m = f16_to_f32(rd_u16(ks, kso + 2l))
+    let qh = rd_u32(kq, kqo + 16l)
+    for (k in range64(16l)) {
+        let b = int(kq[kqo + k])
+        let h0 = (int(qh >> uint(k)) & 1) << 4
+        let h1 = (int(qh >> uint(k + 16l)) & 1) << 4
+        dst[doff + k] = d * float((b & 15) | h0) + m
+        dst[doff + k + 16l] = d * float((b >> 4) | h1) + m
+    }
+}
+
 // K-quant plane strides (bytes per 256-weight superblock)
 let K4_QSB = 128l
 let K4_SSB = 20l   // kq v2: 16B verbatim disk scale block + 4B pad (repack decodes in place)
@@ -1113,6 +1142,10 @@ let K6_QSB = 192l
 let K6_SSB = 18l
 let Q40_QSB = 128l   // q40 tier: 8 x 16 nibble bytes (the k4 pairing, k / k+16 per 32-block)
 let Q40_SSB = 16l    // 8 x f16 d, verbatim disk halfwords
+// q51 tier strides are per 32-block, NOT per superblock: Q5_1 exists precisely for rows that are
+// % 32 but not % 256 (llama.cpp's quantizer fallback), so the planes carry no superblock structure
+let Q51_QB = 20l   // 16 nibble bytes (k / k+16 pairing) + 4 qh bytes, verbatim disk splits
+let Q51_SB = 4l    // d, m f16 halfwords, verbatim
 
 // Raw byte copy via unaligned u64 moves + byte tail — the workhorse of the pointerized transcode
 // loops (uint8 source and destination regions never overlap).
@@ -1284,6 +1317,40 @@ def gguf_transcode_q40(m : GGUFMeta; srcbytes : array<uint8> | #; name : string;
     }
 }
 
+//! Transcode a Q5_1 tensor into the q51 planes (per 32-BLOCK strides 20/4 — see Q51_QB): each
+//! 24B disk block splits into 2B d + 2B m (scale plane) and 16B nibbles + 4B qh (quant plane),
+//! all verbatim. Exact; `eloff`/`src_off`/`expect_n` are element offsets, % 32.
+def gguf_transcode_q51(m : GGUFMeta; srcbytes : array<uint8> | #; name : string; var kq : array<uint8>; var ks : array<uint8>; eloff, expect_n : int64; src_off : int64 = 0l) {
+    let ti = kq_transcode_check(m, name, GGML_TYPE_Q5_1, "Q5_1", src_off, expect_n)
+    let nb = expect_n / 32l
+    if (nb <= 0l) {
+        return
+    }
+    if (eloff % 32l != 0l || src_off % 32l != 0l || expect_n % 32l != 0l) {
+        panic("gguf: tensor '{name}' Q5_1 slice [{src_off}, +{expect_n}) @ {eloff} is not block-aligned")
+    }
+    guard_dst(name, "q51 quant plane", (eloff / 32l) * Q51_QB, nb * Q51_QB, long_length(kq))
+    guard_dst(name, "q51 scale plane", (eloff / 32l) * Q51_SB, nb * Q51_SB, long_length(ks))
+    with_tensor_view(m, srcbytes, ti) $(bytes, tbase) {
+        let bo = tbase + (src_off / 32l) * 24l
+        unsafe {
+            let srcp = addr<uint8 const?>(bytes[bo])
+            var kqp = addr(kq[(eloff / 32l) * Q51_QB])
+            var ksp = addr(ks[(eloff / 32l) * Q51_SB])
+            maybe_parallel_for(0, int(nb), transcode_jobs(nb, 24l)) $(rb, re) {
+                unsafe {
+                    for (blk in range64(int64(rb), int64(re))) {
+                        let src = srcp + blk * 24l
+                        bcopy(ksp + blk * Q51_SB, src, 4l)               // f16 d, f16 m
+                        bcopy(kqp + blk * Q51_QB, src + 8l, 16l)         // nibbles
+                        bcopy(kqp + blk * Q51_QB + 16l, src + 4l, 4l)    // qh
+                    }
+                }
+            }
+        }
+    }
+}
+
 //! Decode tensor `name` (F32 or F16 on disk) into dst[dst_off ..] as fp32. Panics if the
 //! tensor is missing, has a different element count than expected, or uses a type we don't
 //! yet read (quantized types are wired in a later step).
@@ -1391,6 +1458,28 @@ def gguf_read_tensor_f32(m : GGUFMeta; srcbytes : array<uint8> | #; name : strin
             }
             bo += 16l
         }
+    } elif (gtype == GGML_TYPE_Q5_1) {
+        // block of 32: fp16 d + fp16 min m (4 bytes) + 4 bytes of high bits + 16 bytes (split-half
+        // nibbles); x = (nibble | high_bit << 4) * d + m — the min carries the offset, q is unsigned
+        if (src_off % 32l != 0l || expect_n % 32l != 0l) {
+            panic("gguf: tensor '{name}' Q5_1 slice [{src_off}, +{expect_n}) is not block-aligned")
+        }
+        let nb = expect_n / 32l
+        var bo = base + (src_off / 32l) * 24l
+        for (blk in range64(nb)) {
+            let d = f16_to_f32(rd_u16(bytes, bo))
+            let mn = f16_to_f32(rd_u16(bytes, bo + 2l))
+            let qh = rd_u32(bytes, bo + 4l)
+            bo += 8l
+            for (k in range64(16l)) {
+                let b = int(bytes[bo + k])
+                let h0 = (int(qh >> uint(k)) & 1) << 4
+                let h1 = (int(qh >> uint(k + 16l)) & 1) << 4
+                dst[dst_off + blk * 32l + k] = float((b & 15) | h0) * d + mn
+                dst[dst_off + blk * 32l + k + 16l] = float((b >> 4) | h1) * d + mn
+            }
+            bo += 16l
+        }
     } elif (gtype == GGML_TYPE_Q4_K || gtype == GGML_TYPE_Q5_K || gtype == GGML_TYPE_Q6_K) {
         if (src_off % 256l != 0l || expect_n % 256l != 0l) {
             panic("gguf: tensor '{name}' K-quant slice [{src_off}, +{expect_n}) is not superblock-aligned")
@@ -1434,7 +1523,7 @@ def gguf_read_tensor_f32(m : GGUFMeta; srcbytes : array<uint8> | #; name : strin
             bo += 16l
         }
     } else {
-        panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/BF16/Q8_0/Q4_0/Q5_0/Q4_K/Q5_K/Q6_K/MXFP4)")
+        panic("gguf: tensor '{name}' type {gtype} not supported (have F32/F16/BF16/Q8_0/Q4_0/Q5_0/Q5_1/Q4_K/Q5_K/Q6_K/MXFP4)")
     }
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1194,6 +1194,12 @@ typedef BackendAvailableFn = function<() : bool>
 // shape: ONE dispatch runs every routed expert's [d x n] GEMM over its own row range of a shared
 // token-row image. `offs` packs TRIPLES [weight offset, row0, cnt]; bit-exact vs a per-region loop.
 typedef MatmulMx4Q8BatchGroupNFn = function<(var yp : float?; wn : uint8 const?; we : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; bp : float const?; boffs : int64 const?; n : int64; d : int64) : void>
+// q51 (native Q5_1) kernels — mx4's shape with per-32-BLOCK planes: wq = 20B/block nibbles+qh
+// (row stride (n/32)*20), ws = 4B/block f16 d+m (row stride (n/32)*4), Q8_0-form activations.
+// No bias forms (no biased-q51 arch); offs conventions match the mx4/q8 groupn twins.
+typedef MatmulQ51Q8BatchFn = function<(var yp : float?; wq : uint8 const?; ws : uint8 const?; xqp : int8 const?; xsp : float const?; n : int64; d : int64; ntok : int64) : void>
+typedef MatmulQ51GroupNFn = function<(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n : int64; d : int64) : void>
+typedef MatmulQ51Q8BatchGroupNFn = function<(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n : int64; d : int64) : void>
 // Native K-quant rows-range GEMV core (kq stage 4): rows [rb, re) of one plane-region pair
 // (kqp/ksp = the format's quant/scale plane bases). One typedef per format; a backend's cores
 // read ITS repacked kq layout — mixing backends across a load is as illegal as for the Q8 plane.
@@ -1232,6 +1238,12 @@ struct KernelBackend {
     repack_mx4 : RepackMx4Fn = @@repack_mx4_identity
     groupn : MatmulQ8Q8GroupNFn = @@q8q8_unset_groupn
     groupn_mx4 : MatmulMx4GroupNFn = @@mx4q8_unset_groupn
+    // q51 slots DEFAULT to the portable kernels (not panic stubs): the q51 planes are never
+    // repacked, so the portable disk-order forms are correct on every backend — a native/tuned
+    // backend overrides them explicitly.
+    q51_batch : MatmulQ51Q8BatchFn = @@q51q8_batch_kernel
+    groupn_q51 : MatmulQ51GroupNFn = @@q51q8_groupn_kernel
+    q51_batch_groupn : MatmulQ51Q8BatchGroupNFn = @@q51q8_batch_groupn_kernel
     // Optional row-range GEMV core (see MatmulQ8Q8RowsFn) — backends without one keep the panic
     // stub, and the fused multi-stage decode falls back to the per-op dispatch path.
     mm_rows : MatmulQ8Q8RowsFn = @@q8q8_unset_rows
@@ -1293,6 +1305,9 @@ var g_mm_mx4q8_batch = @@mx4q8_unset_batch
 var g_mm_mx4q8_batch_groupn = @@mx4q8_unset_batch_groupn
 var g_mm_q8q8_groupn = @@q8q8_unset_groupn
 var g_mm_mx4q8_groupn = @@mx4q8_unset_groupn
+var g_mm_q51q8_batch = @@q51q8_batch_kernel
+var g_mm_q51q8_groupn = @@q51q8_groupn_kernel
+var g_mm_q51q8_batch_groupn = @@q51q8_batch_groupn_kernel
 var g_mm_q8q8_rows = @@q8q8_unset_rows
 var g_active_has_rows = false       // does the active backend carry a row-range GEMV core?
 var g_mm_q8q8_s16 = @@q8q8_unset_kernel_s16
@@ -2067,6 +2082,105 @@ def repack_mx4_identity(var np : uint8?; var ep : uint8?; n, d : int64) {}
 [unused_argument(fmt, kq, ks, n, d)]
 def repack_kq_identity(fmt : int; var kq : uint8?; var ks : uint8?; n, d : int64) {}
 
+//! Q5_1·Q8 dot, scalar reference form — THE q51 float-order contract every q51 kernel
+//! reproduces: per 32-block isum = Σ q·a (q = nibble | qh_bit << 4, unsigned [0,31]), asum = Σ a
+//! computed INLINE (Q8_0-form activations carry no block sums); f += (d·isum + m·asum)·xs[b].
+[hint(unsafe_range_check, noalias = wq, noalias = ws, noalias = xq, noalias = xs)]
+def dot_q51q8_scalar(wq : uint8 const?; ws : uint8 const?; xq : int8 const?; xs : float const?; n : int64) : float {
+    let nb = n / 32l
+    var f = 0.0
+    unsafe {
+        for (bi in range64(nb)) {
+            let wb = bi * 20l
+            let xb = bi * 32l
+            let qh = uint(wq[wb + 16l]) | (uint(wq[wb + 17l]) << 8u) | (uint(wq[wb + 18l]) << 16u) | (uint(wq[wb + 19l]) << 24u)
+            var isum = 0
+            var asum = 0
+            for (j in range64(16l)) {
+                let b = int(wq[wb + j])
+                let h0 = (int(qh >> uint(j)) & 1) << 4
+                let h1 = (int(qh >> uint(j + 16l)) & 1) << 4
+                let a0 = int(xq[xb + j])
+                let a1 = int(xq[xb + j + 16l])
+                isum += ((b & 15) | h0) * a0 + ((b >> 4) | h1) * a1
+                asum += a0 + a1
+            }
+            let d = f16_to_f32(uint(ws[bi * 4l]) | (uint(ws[bi * 4l + 1l]) << 8u))
+            let m = f16_to_f32(uint(ws[bi * 4l + 2l]) | (uint(ws[bi * 4l + 3l]) << 8u))
+            f += (d * float(isum) + m * float(asum)) * xs[bi]
+        }
+    }
+    return f
+}
+
+// Portable q51 batch (the KernelBackend.q51_batch default): rows-outer/tokens-inner over the
+// scalar row dot — the mm_b_q51_pre core (one expert region, ntok token rows).
+def q51q8_batch_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
+    let nb = n / 32l
+    var myp = yp
+    unsafe {
+        maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
+            unsafe {
+                for (i in range(rb, re)) {
+                    let wrow = wq + int64(i) * nb * 20l
+                    let srow = ws + int64(i) * nb * 4l
+                    for (tk in range64(ntok)) {
+                        myp[tk * d + int64(i)] = dot_q51q8_scalar(wrow, srow, xqp + tk * n, xsp + tk * nb, n)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Portable q51 groupN (the groupn_q51 default — MoE decode dispatch): (element woff, activation
+// xoff) pairs, one scalar row dot per (region, row). No bias form — no biased-q51 arch exists.
+def q51q8_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
+    let nb = n / 32l
+    var myp = yp
+    unsafe {
+        maybe_parallel_for(0, int(nregions * d), matmul_chunks_gemv(int(nregions * d), 1, n * d * nregions)) $(rb, re) {
+            unsafe {
+                for (i in range(rb, re)) {
+                    let ii = int64(i)
+                    let r = ii / d
+                    let row = ii % d
+                    let woff = offs[r * 2l]
+                    let xoff = offs[r * 2l + 1l]
+                    myp[ii] = dot_q51q8_scalar(wq + (woff / 32l + row * nb) * 20l, ws + (woff / 32l + row * nb) * 4l,
+                        xqp + xoff, xsp + xoff / 32l, n)
+                }
+            }
+        }
+    }
+}
+
+// Portable q51 batch groupN (the q51_batch_groupn default — fused MoE prefill): (element woff,
+// row0, cnt) triples, per (region, row) scalar dots over the region's token-row range.
+def q51q8_batch_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
+    let nb = n / 32l
+    var myp = yp
+    unsafe {
+        maybe_parallel_for(0, int(nregions * d), matmul_chunks(int(nregions * d), get_q8_batch_chunks_per_job(), n * d * nregions)) $(rb, re) {
+            unsafe {
+                for (i in range(rb, re)) {
+                    let ii = int64(i)
+                    let r = ii / d
+                    let row = ii % d
+                    let woff = offs[r * 3l]
+                    let row0 = offs[r * 3l + 1l]
+                    let cnt = offs[r * 3l + 2l]
+                    let wrow = wq + (woff / 32l + row * nb) * 20l
+                    let srow = ws + (woff / 32l + row * nb) * 4l
+                    for (tk in range64(cnt)) {
+                        myp[(row0 + tk) * d + row] = dot_q51q8_scalar(wrow, srow, xqp + (row0 + tk) * n, xsp + (row0 + tk) * nb, n)
+                    }
+                }
+            }
+        }
+    }
+}
+
 def private no_backend() {
     panic("dasLLAMA: no Q8·Q8 kernel backend registered — require dasllama/dasllama_math_default")
 }
@@ -2175,6 +2289,9 @@ def private activate(be : KernelBackend) {
     g_mm_mx4q8_batch_groupn = be.mx4_batch_groupn
     g_mm_q8q8_groupn = be.groupn
     g_mm_mx4q8_groupn = be.groupn_mx4
+    g_mm_q51q8_batch = be.q51_batch
+    g_mm_q51q8_groupn = be.groupn_q51
+    g_mm_q51q8_batch_groupn = be.q51_batch_groupn
     g_mm_q8q8_rows = be.mm_rows
     g_active_has_rows = !(be.mm_rows == @@q8q8_unset_rows)
     g_mm_q8q8_s16 = be.mm_s16
@@ -2230,6 +2347,8 @@ def private apply_batch_override(name : string) {
     g_mm_q8q8_batch = be.batch
     g_mm_mx4q8_batch = be.mx4_batch
     g_mm_mx4q8_batch_groupn = be.mx4_batch_groupn
+    g_mm_q51q8_batch = be.q51_batch
+    g_mm_q51q8_batch_groupn = be.q51_batch_groupn
     g_active_mx4_native_batch = be.mx4_native_batch
     g_active_batch_backend = be.name
 }
@@ -2756,6 +2875,40 @@ def matmul_mx4q8_groupn(var y : array<float>; wn : array<uint8> | #; we : array<
             addr<int64 const?>(offs[0]), nregions,
             addr<int8 const?>(xq[0]), addr<float const?>(xs[0]),
             addr<float const?>(bias[0]), addr<int64 const?>(boffs[0]), n, d)
+    }
+}
+
+//! Batched Q5_1·Q8 GEMM (blob+offset form): weight region at ELEMENT offset `woff` in the whole
+//! q51 planes (quants at (woff/32)*20, d+m at (woff/32)*4) — the mm_b_q51_pre core. n % 32 == 0.
+def matmul_q51q8_batch(var y : array<float>; wq : array<uint8>; ws : array<uint8>; woff : int64; xq : array<int8>; xs : array<float>; n, d, ntok : int64) {
+    unsafe {
+        invoke(g_mm_q51q8_batch, addr(y[0]),
+            addr<uint8 const?>(wq[(woff / 32l) * 20l]), addr<uint8 const?>(ws[(woff / 32l) * 4l]),
+            addr<int8 const?>(xq[0]), addr<float const?>(xs[0]), n, d, ntok)
+    }
+}
+
+//! Region-list Q5_1·Q8 GEMV — the q51 twin of matmul_mx4q8_groupn (offs pack (weight element
+//! offset, activation element offset) PAIRS; kernels derive the /32*20 and /32*4 byte positions).
+def matmul_q51q8_groupn(var y : array<float>; wq : array<uint8> | #; ws : array<uint8> | #; offs : array<int64>; nregions : int64;
+                        xq : array<int8>; xs : array<float>; n, d : int64) {
+    unsafe {
+        invoke(g_mm_q51q8_groupn, addr(y[0]),
+            addr<uint8 const?>(wq[0]), addr<uint8 const?>(ws[0]),
+            addr<int64 const?>(offs[0]), nregions,
+            addr<int8 const?>(xq[0]), addr<float const?>(xs[0]), n, d)
+    }
+}
+
+//! Region-list batched Q5_1·Q8 GEMM — the q51 twin of matmul_mx4q8_batch_groupn (offs pack
+//! (weight element offset, row0, cnt) TRIPLES over one token-row image). n % 32 == 0.
+def matmul_q51q8_batch_groupn(var y : array<float>; wq : array<uint8> | #; ws : array<uint8> | #; offs : array<int64>; nregions : int64;
+                              xq : array<int8>; xs : array<float>; n, d : int64) {
+    unsafe {
+        invoke(g_mm_q51q8_batch_groupn, addr(y[0]),
+            addr<uint8 const?>(wq[0]), addr<uint8 const?>(ws[0]),
+            addr<int64 const?>(offs[0]), nregions,
+            addr<int8 const?>(xq[0]), addr<float const?>(xs[0]), n, d)
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -2113,56 +2113,116 @@ def dot_q51q8_scalar(wq : uint8 const?; ws : uint8 const?; xq : int8 const?; xs 
     return f
 }
 
-// Portable q51 batch (the KernelBackend.q51_batch default): rows-outer/tokens-inner over the
-// scalar row dot — the mm_b_q51_pre core (one expert region, ntok token rows).
+//! Expand one q51 plane row's 5-bit quants to full bytes in `qe` (n bytes): nibbles via u64
+//! masks + the qh bits ORd in at 0x10 via the u64 bit-spread. Exact. The fast kernels MAC over
+//! the expanded row — a MAC over just-stored STACK bytes defeats the vectorizer (1.95 vs 8.1 GB/s).
+[hint(unsafe_range_check, noalias = wq, noalias = qe)]
+def expand_q51_row(wq : uint8 const?; var qe : int8?; nb : int64) {
+    unsafe {
+        var qp64 = reinterpret<uint64?>(qe)
+        for (bi in range64(nb)) {
+            let wb = bi * 20l
+            let wp64 = reinterpret<uint64 const?>(wq + wb)
+            let w0 = wp64[0]
+            let w1 = wp64[1]
+            let s0 = ((((0x0101010101010101ul * uint64(wq[wb + 16l])) & 0x8040201008040201ul) + 0x7f7f7f7f7f7f7f7ful) >> 3ul) & 0x1010101010101010ul
+            let s1 = ((((0x0101010101010101ul * uint64(wq[wb + 17l])) & 0x8040201008040201ul) + 0x7f7f7f7f7f7f7f7ful) >> 3ul) & 0x1010101010101010ul
+            let s2 = ((((0x0101010101010101ul * uint64(wq[wb + 18l])) & 0x8040201008040201ul) + 0x7f7f7f7f7f7f7f7ful) >> 3ul) & 0x1010101010101010ul
+            let s3 = ((((0x0101010101010101ul * uint64(wq[wb + 19l])) & 0x8040201008040201ul) + 0x7f7f7f7f7f7f7f7ful) >> 3ul) & 0x1010101010101010ul
+            qp64[bi * 4l] = (w0 & 0x0f0f0f0f0f0f0f0ful) | s0
+            qp64[bi * 4l + 1l] = (w1 & 0x0f0f0f0f0f0f0f0ful) | s1
+            qp64[bi * 4l + 2l] = ((w0 >> 4ul) & 0x0f0f0f0f0f0f0f0ful) | s2
+            qp64[bi * 4l + 3l] = ((w1 >> 4ul) & 0x0f0f0f0f0f0f0f0ful) | s3
+        }
+    }
+}
+
+[hint(unsafe_range_check, noalias = qe, noalias = ws, noalias = xq, noalias = xs)]
+def template dot_q51e_template(qe : int8 const ?; ws : uint8 const ?; xq : int8 const ?; xs : float const ?; n : int64) : float {
+    let nb = n / 32l
+    var f = 0.0
+    for (bi in range64(nb)) {
+        let xb = bi * 32l
+        var isum = 0
+        var asum = 0
+        for [tune = 1] (k in range64(32l)) {
+            let a = int(unsafe(xq[xb + k]))
+            isum += int(unsafe(qe[xb + k])) * a
+            asum += a
+        }
+        let d = f16_to_f32(uint(unsafe(ws[bi * 4l])) | (uint(unsafe(ws[bi * 4l + 1l])) << 8u))
+        let m = f16_to_f32(uint(unsafe(ws[bi * 4l + 2l])) | (uint(unsafe(ws[bi * 4l + 3l])) << 8u))
+        f += (d * float(isum) + m * float(asum)) * unsafe(xs[bi])
+    }
+    return f
+}
+
+//! The q51 MAC over an expand_q51_row-expanded row — the fast kernels' core. Bit-identical to
+//! dot_q51q8_scalar (exact int sums, same per-block fold order); vectorizes like dot_q8q8.
+[hint(unsafe_range_check, noalias = qe, noalias = ws, noalias = xq, noalias = xs), tuned(fallback = "vec16")]
+def dot_q51e(qe : int8 const?; ws : uint8 const?; xq : int8 const?; xs : float const?; n : int64) : float {}
+
+// Portable q51 batch (the KernelBackend.q51_batch default): rows-outer/tokens-inner — each row
+// expands ONCE into the worker's scratch, then ntok MAC passes (the mm_b_q51_pre core).
 def q51q8_batch_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
     var myp = yp
     unsafe {
         maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
+            var qe : array<int8>
+            qe |> resize(n)
             unsafe {
+                var qep = addr(qe[0])
                 for (i in range(rb, re)) {
-                    let wrow = wq + int64(i) * nb * 20l
+                    expand_q51_row(wq + int64(i) * nb * 20l, qep, nb)
                     let srow = ws + int64(i) * nb * 4l
                     for (tk in range64(ntok)) {
-                        myp[tk * d + int64(i)] = dot_q51q8_scalar(wrow, srow, xqp + tk * n, xsp + tk * nb, n)
+                        myp[tk * d + int64(i)] = dot_q51e(qep, srow, xqp + tk * n, xsp + tk * nb, n)
                     }
                 }
             }
+            delete qe
         }
     }
 }
 
 // Portable q51 groupN (the groupn_q51 default — MoE decode dispatch): (element woff, activation
-// xoff) pairs, one scalar row dot per (region, row). No bias form — no biased-q51 arch exists.
+// xoff) pairs, expand-then-MAC per (region, row). No bias form — no biased-q51 arch exists.
 def q51q8_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
     unsafe {
         maybe_parallel_for(0, int(nregions * d), matmul_chunks_gemv(int(nregions * d), 1, n * d * nregions)) $(rb, re) {
+            var qe : array<int8>
+            qe |> resize(n)
             unsafe {
+                var qep = addr(qe[0])
                 for (i in range(rb, re)) {
                     let ii = int64(i)
                     let r = ii / d
                     let row = ii % d
                     let woff = offs[r * 2l]
                     let xoff = offs[r * 2l + 1l]
-                    myp[ii] = dot_q51q8_scalar(wq + (woff / 32l + row * nb) * 20l, ws + (woff / 32l + row * nb) * 4l,
-                        xqp + xoff, xsp + xoff / 32l, n)
+                    expand_q51_row(wq + (woff / 32l + row * nb) * 20l, qep, nb)
+                    myp[ii] = dot_q51e(qep, ws + (woff / 32l + row * nb) * 4l, xqp + xoff, xsp + xoff / 32l, n)
                 }
             }
+            delete qe
         }
     }
 }
 
 // Portable q51 batch groupN (the q51_batch_groupn default — fused MoE prefill): (element woff,
-// row0, cnt) triples, per (region, row) scalar dots over the region's token-row range.
+// row0, cnt) triples; each (region, row) expands once, then cnt token MACs.
 def q51q8_batch_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
     var myp = yp
     unsafe {
         maybe_parallel_for(0, int(nregions * d), matmul_chunks(int(nregions * d), get_q8_batch_chunks_per_job(), n * d * nregions)) $(rb, re) {
+            var qe : array<int8>
+            qe |> resize(n)
             unsafe {
+                var qep = addr(qe[0])
                 for (i in range(rb, re)) {
                     let ii = int64(i)
                     let r = ii / d
@@ -2170,13 +2230,14 @@ def q51q8_batch_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 con
                     let woff = offs[r * 3l]
                     let row0 = offs[r * 3l + 1l]
                     let cnt = offs[r * 3l + 2l]
-                    let wrow = wq + (woff / 32l + row * nb) * 20l
+                    expand_q51_row(wq + (woff / 32l + row * nb) * 20l, qep, nb)
                     let srow = ws + (woff / 32l + row * nb) * 4l
                     for (tk in range64(cnt)) {
-                        myp[(row0 + tk) * d + row] = dot_q51q8_scalar(wrow, srow, xqp + (row0 + tk) * n, xsp + (row0 + tk) * nb, n)
+                        myp[(row0 + tk) * d + row] = dot_q51e(qep, srow, xqp + (row0 + tk) * n, xsp + (row0 + tk) * nb, n)
                     }
                 }
             }
+            delete qe
         }
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -684,6 +684,20 @@ def kq_scales_of(dev : MetalDevice?; t : Model; fmt : KqFmt; off : int64) : tupl
     }
 }
 
+//! One q51 tensor's plane pair bind: quant plane (20B/block, uint-viewable) at (off/32)*20 and
+//! the f16 d+m scale plane at (off/32)*4 — both verbatim disk splits, never rebaked (the blob
+//! transform leaves q51 planes untouched). off % 128 keeps both binds 16B-aligned.
+def q51_planes_of(dev : MetalDevice?; t : Model; off : int64) : tuple<qbuf : MetalBuffer?; qoff : uint64; sbuf : MetalBuffer?; soff : uint64> {
+    assert(t.metal_blob)
+    let b0 = off / 32l
+    unsafe {
+        return (qbuf = plane_buffer(dev, addr < void? >(t.q51q[0]), uint64(long_length(t.q51q)), t.image_map != null),
+                qoff = uint64(b0 * 20l),
+                sbuf = plane_buffer(dev, addr < void? >(t.q51s[0]), uint64(long_length(t.q51s)), t.image_map != null),
+                soff = uint64(b0 * 4l))
+    }
+}
+
 def uniform_u32(v : uint) : MetalBuffer? {
     var buf = pool_acquire_untracked(g_upool, g_dev, 4ul)
     var p = unsafe(reinterpret<uint?>(metal_buffer_contents(buf)))
@@ -1100,6 +1114,9 @@ def moe_site_ok(fmt : KqFmt; off, ege : int64) : bool {
     if (fmt == KqFmt.k6) {
         return off >= 0l && (off % 512l) == 0l && (ege % 256l) == 0l
     }
+    if (fmt == KqFmt.q51) {   // per-32 planes: off % 128 keeps the 20B/4B binds 16B-aligned
+        return off >= 0l && (off % 128l) == 0l && (ege % 32l) == 0l
+    }
     return false
 }
 
@@ -1173,12 +1190,18 @@ def moe_metal_ok(t : Model) : bool {
         let f1 = moe_fmt_at(t.we1_fmt, l)
         let f2 = moe_fmt_at(t.we2_fmt, l)
         let f3 = moe_fmt_at(t.we3_fmt, l)
-        // per-site alignment + (kq kernels iterate whole superblock rows) reduction dims %256
+        // per-site alignment + reduction dims: superblock kq kernels iterate whole 256-rows,
+        // q51 whole 32-blocks (+ the mul_mm's 64-col output tiles)
+        let sb1 = f1 == KqFmt.k4 || f1 == KqFmt.k5 || f1 == KqFmt.k6
+        let sb3 = f3 == KqFmt.k4 || f3 == KqFmt.k5 || f3 == KqFmt.k6
+        let sb2 = f2 == KqFmt.k4 || f2 == KqFmt.k5 || f2 == KqFmt.k6
         if (!moe_site_ok(f1, t.we1_offs[l], ege) ||
                 !moe_site_ok(f2, t.we2_offs[l], ege) ||
                 !moe_site_ok(f3, t.we3_offs[l], ege) ||
-                ((f1 != KqFmt.q8 || f3 != KqFmt.q8) && (c.dim % 256l) != 0l) ||
-                (f2 != KqFmt.q8 && (nfe % 256l) != 0l)) {
+                ((sb1 || sb3) && (c.dim % 256l) != 0l) ||
+                (sb2 && (nfe % 256l) != 0l) ||
+                ((f1 == KqFmt.q51 || f3 == KqFmt.q51) && ((c.dim % 32l) != 0l || (nfe % 64l) != 0l)) ||
+                (f2 == KqFmt.q51 && ((nfe % 32l) != 0l || (c.dim % 64l) != 0l))) {
             return false
         }
     }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -720,6 +720,27 @@ def mirror_evict_to_cap(cap_bytes : uint64; keep : uint64) {
     }
 }
 
+//! Cross-layer KV sharing (gemma-4 E-series): does layer l either own its rows or share a
+//! byte-compatible source? A shared layer aliases its source's mirror slab / prefill panel via
+//! kv_row_prefix, so the source must own rows and match l's class geometry exactly.
+def kv_share_ok(t : Model; l : int64) : bool {
+    if (l >= int64(length(t.kv_src))) {   // the MTP draft slab owns its rows
+        return true
+    }
+    let src = t.kv_src[l]
+    if (src == l) {
+        return true
+    }
+    return (src >= 0l && src < l && t.kv_src[src] == src && !layer_is_recurrent(t.config, src) &&
+        layer_kv_dim(t.config, l) == layer_kv_dim(t.config, src) &&
+        layer_head_size(t.config, l) == layer_head_size(t.config, src))
+}
+
+//! true when layer l reads another layer's KV (no rows of its own — Q-only attention)
+def kv_shared_layer(t : Model; l : int64) : bool {
+    return l < int64(length(t.kv_src)) && t.kv_src[l] != l
+}
+
 // Hetero-safe per-layer mirror addressing (gemma4's two kv-head classes): every KV codec is
 // linear bytes-per-element for kvd % 32 == 0, so the layout_offsets element prefix scales
 // straight to bytes. Uniform models reduce to the old l * cap * rowb addresses exactly.
@@ -727,7 +748,9 @@ def mirror_row_total(t : Model) : int64 {
     let c = t.config
     var tot = 0l
     for (l in range64(c.n_layers + c.n_layer_nextn)) {   // + the MTP draft slab (trunk-shaped attention)
-        tot += layer_kv_dim(c, l)   // the GPU gate pins kv_src[l] == l, so every layer owns rows
+        if (!kv_shared_layer(t, l)) {   // shared layers (E-series) alias their source's slab
+            tot += layer_kv_dim(c, l)
+        }
     }
     return tot
 }
@@ -907,6 +930,7 @@ def mirror_prepare(t : Model; var s : Session; pos : int64) : tuple<ok : bool; k
             var kdst = reinterpret<uint8?>(metal_buffer_contents(g_arena)) + koff
             var vdst = reinterpret<uint8?>(metal_buffer_contents(g_arena)) + voff
             for (l in range64(c.n_layers + c.n_layer_nextn)) {   // draft slab rides the watermark contract
+                continue if (kv_shared_layer(t, l))   // aliases the source slab — its upload covers l
                 let kvd_l = layer_kv_dim(c, l)
                 let krow = kv_row_bytes(s.kv_dtype_k, kvd_l)
                 let vrow = kv_row_bytes(s.kv_dtype_v, kvd_l)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -5709,6 +5709,7 @@ var g_pso_swiglu_oai : MetalComputePipeline?   // gpt-oss clamped swiglu (stage 
 var g_pso_moe_gemv_mx4 : MetalComputePipeline?  // gpt-oss MXFP4 expert GEMV
 var g_pso_moe_gemv_q51 : MetalComputePipeline?  // Q5_1 expert GEMV (per-32 planes)
 var g_e8m0_tab : MetalBuffer?                   // [256] exact e8m0_half scales
+var g_mx4_vtab : MetalBuffer?                   // [16] signed doubled-e2m1 values
 var g_pso_dn_conv : MetalComputePipeline?      // deltanet (Wave D): causal conv + SiLU
 var g_pso_dn_hist : MetalComputePipeline?      // conv-history advance
 var g_pso_dn_l2 : MetalComputePipeline?        // q/k per-head L2 norm + q pre-scale
@@ -5857,6 +5858,14 @@ def metal_decode_init : bool {
         var ep = reinterpret<uint?>(metal_buffer_contents(g_e8m0_tab))
         for (ei in range(256)) {
             ep[ei] = ei < 2 ? (0x00200000u << uint(ei)) : (uint(ei - 1) << 23u)
+        }
+    }
+    g_mx4_vtab = metal_new_buffer(g_dev, 64ul)
+    unsafe {
+        var vp = reinterpret<float?>(metal_buffer_contents(g_mx4_vtab))
+        let mags = fixed_array(0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0)
+        for (vi in range(16)) {
+            vp[vi] = vi < 8 ? mags[vi] : -mags[vi - 8]
         }
     }
     g_pso_copy_row = compile_pso(metal_copy_row_msl, metal_copy_row_msl_entry, metal_copy_row_msl_fastmath, ok)
@@ -6407,7 +6416,8 @@ def enc_moe_gemv_mx4(enc : MetalComputeEncoder?; t : Model; stack_off, rows, k, 
     metal_set_buffer(enc, bwb, 0ul, 12)
     metal_set_buffer(enc, bhasb, 0ul, 13)
     metal_set_buffer(enc, g_e8m0_tab, 0ul, 14)
-    metal_dispatch_threadgroups(enc, uint3(uint((rows + g_gemv_rows - 1l) / g_gemv_rows), uint(k), uint(nst)), uint3(uint(g_gemv_rows * 32l), 1u, 1u))
+    metal_set_buffer(enc, g_mx4_vtab, 0ul, 15)
+    metal_dispatch_threadgroups(enc, uint3(uint((rows + 3l) / 4l), uint(k), uint(nst)), uint3(64u, 1u, 1u))
 }
 
 // ===== deltanet (Wave D) — the recurrent-layer chain encoders =====
@@ -7311,6 +7321,10 @@ def metal_kernels_release {
     release_pso(g_pso_dn_deint)
     release_pso(g_pso_sigmul)
     release_pso(g_pso_axpy_sig)
+    if (g_mx4_vtab != null) {
+        metal_release(g_mx4_vtab)
+        g_mx4_vtab = null
+    }
     if (g_e8m0_tab != null) {
         metal_release(g_e8m0_tab)
         g_e8m0_tab = null

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -5707,6 +5707,7 @@ var g_pso_g4rnorm : MetalComputePipeline?      // gemma4 MoE router-input norm (
 var g_pso_moe_wscale : MetalComputePipeline?   // gemma4 per-expert down-scale fold
 var g_pso_swiglu_oai : MetalComputePipeline?   // gpt-oss clamped swiglu (stage 4)
 var g_pso_moe_gemv_mx4 : MetalComputePipeline?  // gpt-oss MXFP4 expert GEMV
+var g_pso_moe_gemv_q51 : MetalComputePipeline?  // Q5_1 expert GEMV (per-32 planes)
 var g_e8m0_tab : MetalBuffer?                   // [256] exact e8m0_half scales
 var g_pso_dn_conv : MetalComputePipeline?      // deltanet (Wave D): causal conv + SiLU
 var g_pso_dn_hist : MetalComputePipeline?      // conv-history advance
@@ -5842,6 +5843,7 @@ def metal_decode_init : bool {
     g_pso_moe_wscale = compile_pso(metal_moe_wscale_msl, metal_moe_wscale_msl_entry, metal_moe_wscale_msl_fastmath, ok)
     g_pso_swiglu_oai = compile_pso(metal_swiglu_oai_msl, metal_swiglu_oai_msl_entry, metal_swiglu_oai_msl_fastmath, ok)
     g_pso_moe_gemv_mx4 = compile_pso(metal_moe_gemv_mx4_msl, metal_moe_gemv_mx4_msl_entry, metal_moe_gemv_mx4_msl_fastmath, ok)
+    g_pso_moe_gemv_q51 = compile_pso(metal_moe_gemv_q51_msl, metal_moe_gemv_q51_msl_entry, metal_moe_gemv_q51_msl_fastmath, ok)
     g_pso_dn_conv = compile_pso(metal_dn_conv_msl, metal_dn_conv_msl_entry, metal_dn_conv_msl_fastmath, ok)
     g_pso_dn_hist = compile_pso(metal_dn_conv_hist_msl, metal_dn_conv_hist_msl_entry, metal_dn_conv_hist_msl_fastmath, ok)
     g_pso_dn_l2 = compile_pso(metal_dn_l2norm_msl, metal_dn_l2norm_msl_entry, metal_dn_l2norm_msl_fastmath, ok)
@@ -6319,6 +6321,22 @@ def enc_moe_gemv(enc : MetalComputeEncoder?; t : Model; fmt : KqFmt; stack_off, 
         metal_set_buffer(enc, bbxs, 0ul, 10)
         metal_set_buffer(enc, bbys, 0ul, 11)
         metal_dispatch_threadgroups(enc, uint3(uint((rows + g_gemv_rows - 1l) / g_gemv_rows), uint(k), uint(nst)), uint3(uint(g_gemv_rows * 32l), 1u, 1u))
+    } elif (fmt == KqFmt.q51) {
+        let qp = q51_planes_of(g_dev, t, stack_off)
+        metal_set_pipeline(enc, g_pso_moe_gemv_q51)
+        metal_set_buffer(enc, qp.qbuf, qp.qoff, 0)
+        metal_set_buffer(enc, qp.sbuf, qp.soff, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, yoff, 3)
+        metal_set_buffer(enc, bn, 0ul, 4)
+        metal_set_buffer(enc, bd, 0ul, 5)
+        metal_set_buffer(enc, bsel, 0ul, 6)
+        metal_set_buffer(enc, bes, 0ul, 7)
+        metal_set_buffer(enc, bxs, 0ul, 8)
+        metal_set_buffer(enc, bss, 0ul, 9)
+        metal_set_buffer(enc, bbxs, 0ul, 10)
+        metal_set_buffer(enc, bbys, 0ul, 11)
+        metal_dispatch_threadgroups(enc, uint3(uint((rows + 3l) / 4l), uint(k), uint(nst)), uint3(64u, 1u, 1u))
     } else {
         let bq = kq_quants_of(g_dev, t, fmt, stack_off)
         let bs = kq_scales_of(g_dev, t, fmt, stack_off)
@@ -7284,6 +7302,7 @@ def metal_kernels_release {
     release_pso(g_pso_moe_wscale)
     release_pso(g_pso_swiglu_oai)
     release_pso(g_pso_moe_gemv_mx4)
+    release_pso(g_pso_moe_gemv_q51)
     release_pso(g_pso_dn_conv)
     release_pso(g_pso_dn_hist)
     release_pso(g_pso_dn_l2)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -57,11 +57,13 @@ def public metal_decode_shutdown {
 let DECODE_NEEDS_OK = (MetalNeed.neox | MetalNeed.qkv_bias | MetalNeed.qk_norm | MetalNeed.qd_neq_dim |
     MetalNeed.softcap | MetalNeed.sliding | MetalNeed.pre_post_norm | MetalNeed.geglu |
     MetalNeed.v_norm | MetalNeed.attn_scale | MetalNeed.out_scale |
-    MetalNeed.sinks | MetalNeed.out_bias | MetalNeed.partial_rope | MetalNeed.q_gated)
-// q_gated/partial_rope only occur on hybrid models (attn_is_std false), which batch graph-declines
-let BATCH_NEEDS_OK = DECODE_NEEDS_OK
+    MetalNeed.sinks | MetalNeed.out_bias | MetalNeed.partial_rope | MetalNeed.q_gated |
+    MetalNeed.ple)
+// q_gated/partial_rope only occur on hybrid models (attn_is_std false), which batch graph-declines;
+// ple (E-series) has no batch arm either — batched steps decline `feature` and fall back per-row
+let BATCH_NEEDS_OK = DECODE_NEEDS_OK ^ MetalNeed.ple
 
-def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bool = false) : MetalDecodeDecline {
+def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bool = false; allow_kv_share : bool = false) : MetalDecodeDecline {
     if (t.quant != QuantMode.q8) {
         return MetalDecodeDecline.quant_mode
     }
@@ -101,7 +103,8 @@ def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bo
         if ((hs_l % 32l) != 0l || hs_l > 512l || (layer_kv_dim(c, l) % 32l) != 0l) {
             return MetalDecodeDecline.shape
         }
-        if (t.kv_src[l] != l || layer_hidden(t, l) != hidden) {
+        // E-series KV sharing: only the single-stream driver has the Q-only arm (allow_kv_share)
+        if ((t.kv_src[l] != l && !(allow_kv_share && kv_share_ok(t, l))) || layer_hidden(t, l) != hidden) {
             return MetalDecodeDecline.layers
         }
         // a missing attn_v (V = the pre-norm K projection) serves — raw copy without v_norm; both encoded (the CPU mm_qkv shapes)
@@ -123,7 +126,7 @@ def private decode_decline(t : Model; s : Session; pos : int64) : MetalDecodeDec
     if (s.uid == 0ul) {
         return MetalDecodeDecline.no_uid
     }
-    let shape = decode_shape_decline(t, DECODE_NEEDS_OK, true)
+    let shape = decode_shape_decline(t, DECODE_NEEDS_OK, true, true)
     if (shape != MetalDecodeDecline.none) {
         return shape
     }
@@ -152,7 +155,7 @@ def private metal_model_servable_impl(t : Model) : bool {
     if (t.config.shared_weights && !t.cls_q8 && cls_fmt == KqFmt.q8) {
         return false
     }
-    return decode_shape_decline(t, DECODE_NEEDS_OK, true) == MetalDecodeDecline.none
+    return decode_shape_decline(t, DECODE_NEEDS_OK, true, true) == MetalDecodeDecline.none
 }
 
 // Can the speculative chain feed itself on this model? It needs a GPU embed gather for the
@@ -310,6 +313,12 @@ struct private StepRes {
     u_moe_gmode : MetalBuffer? // select gating mode (1 = gpt-oss softmax_weight)
     u_moe_nsh : MetalBuffer?   // shexp width (qwen35moe; null = no shared expert)
     u_hass : MetalBuffer?      // attention sinks present (binds hass on the attn dispatches)
+    // gemma-4 E-series per-layer embeddings — ple steps only; the CPU pre-step's side input
+    // (s.ple_inp, [layers x ple]) pokes into bple each step alongside the embed row
+    ple : bool
+    bple : MetalBuffer?        // the token's per-layer side input rows (poked, GPU-read-only)
+    u_ple : MetalBuffer?       // n_embd_per_layer
+    bytes_ple : uint64
     // deltanet (Wave D) — recurrent-layer scratch + the gated-attention twins; dn steps only
     dn : bool
     bdn_state : MetalBuffer?   // the session's DnMirror buffer (mirror-owned, never released here)
@@ -510,6 +519,12 @@ def private acquire_step(t : Model; s : Session; pos : int64; koff, voff : uint6
         r.bdn_gate = pool_acquire(g_pool, g_dev, r.bytes_q)
         r.u_dn_qd2 = uniform_u32(uint(2l * qd))
     }
+    if (has_ple(c)) {   // E-series: the poked side-input rows (CPU pre-step) + the ple width uniform
+        r.ple = true
+        r.bytes_ple = uint64(c.n_layers * c.n_embd_per_layer * 4l)
+        r.bple = pool_acquire_untracked(g_upool, g_dev, r.bytes_ple)
+        r.u_ple = uniform_u32(uint(c.n_embd_per_layer))
+    }
     if (rot != head_size) {
         r.u_rot = uniform_u32(uint(rot))
     }
@@ -579,6 +594,9 @@ def private poke_step(s : Session; r : StepRes) {
             memcpy(metal_buffer_contents(r.bcos_swa), addr < void? >(s.rope_cos_swa[0]), int(r.bytes_tab_sw))
             memcpy(metal_buffer_contents(r.bsin_swa), addr < void? >(s.rope_sin_swa[0]), int(r.bytes_tab_sw))
         }
+        if (r.ple) {   // forward()'s ple_pre_decode filled s.ple_inp before the hook
+            memcpy(metal_buffer_contents(r.bple), addr < void? >(s.ple_inp[0]), int(r.bytes_ple))
+        }
     }
 }
 
@@ -624,8 +642,10 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
         var u_scale_l = het ? r.u_scale_sw : r.u_scale
         var u_npq_l = het ? r.u_npq_sw : r.u_npq
         var u_npall_l = het ? r.u_npall_sw : r.u_npall
+        // E-series shared-KV layer: Q-only — lkoff/lvoff alias the source slab via kv_row_prefix
+        let kvsh = kv_shared_layer(t, l)
         // qk_norm needs the head-wide prepass between GEMV and rope — the fused form stands down (hetero too: its row map bakes one class geometry); q_gated packs [q|gate] (deint first)
-        let fused_qkv = scalar_kv && qkv_q8 && !c.qk_norm && !r.hetero && !c.q_gated
+        let fused_qkv = scalar_kv && qkv_q8 && !c.qk_norm && !r.hetero && !c.q_gated && !kvsh
         if (recr) {
             // deltanet layer (Wave D): projections -> conv+SiLU -> q/k L2 -> delta rule -> gated out-norm -> out-proj
             let cd = dn_conv_dim(c)
@@ -690,13 +710,15 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
                 } else {
                     enc_site_gemv(enc, t, fq, t.wq_offs[l], qd, dim, r.bxb, r.bqkv, r.u_dim, u_qd_l)
                 }
-                enc_site_gemv(enc, t, fk, t.wk_offs[l], kv_dim, dim, r.bxb, r.bqkv, r.u_dim, u_kvd_l, uint64(qd * 4l))
-                if (t.wv_offs[l] >= 0l) {
-                    enc_site_gemv(enc, t, fv, t.wv_offs[l], kv_dim, dim, r.bxb, r.bqkv, r.u_dim, u_kvd_l, uint64((qd + kv_dim) * 4l))
+                if (!kvsh) {
+                    enc_site_gemv(enc, t, fk, t.wk_offs[l], kv_dim, dim, r.bxb, r.bqkv, r.u_dim, u_kvd_l, uint64(qd * 4l))
+                    if (t.wv_offs[l] >= 0l) {
+                        enc_site_gemv(enc, t, fv, t.wv_offs[l], kv_dim, dim, r.bxb, r.bqkv, r.u_dim, u_kvd_l, uint64((qd + kv_dim) * 4l))
+                    }
                 }
             }
         }
-        if (!recr && g_skip != "ew" && (t.wv_offs[l] < 0l || c.v_norm)) {
+        if (!recr && !kvsh && g_skip != "ew" && (t.wv_offs[l] < 0l || c.v_norm)) {
             // gemma4 V: no-wv layers fill the v segment from the PRE-norm/PRE-rope K projection (the CPU mm_qkv order, BEFORE qk_norm touches k); with v_norm the copy FUSES into the ones-RMS
             if (t.wv_offs[l] < 0l && !c.v_norm) {
                 enc_copy_row(enc, r.bqkv, uint64(qd * 4l), r.bqkv, u_kvd_l, kv_dim, uint64((qd + kv_dim) * 4l))
@@ -716,19 +738,20 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
                 addr < void? >(t.fblob[t.rms_q_offs[l]]), uint64(head_size * 4l),
                 addr < void? >(t.fblob[t.rms_k_offs[l]]), uint64(head_size * 4l), null, 0ul)
             enc_qk_norm(enc, r.bqkv, bqkw, r.u_nh, u_qd_l, u_qkvd_l, u_hs_l, u_hs_l, r.u_eps,
-                u_qd_l, n_heads + kv_dim / head_size, 1l, head_size)
+                u_qd_l, kvsh ? n_heads : n_heads + kv_dim / head_size, 1l, head_size)
         }
         if (!recr && g_skip != "ew" && !fused_qkv) {
+            // shared-KV layers dispatch the Q rows only — no K rope, no mirror row store
             if (r.kdt == KVDtype.q8_0) {
                 enc_rope_store_q8(enc, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                     lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
                     bcos_l, bsin_l, u_qd_l, u_hs_l, u_npq_l, u_nblk_l, r.u_neox, bbias, r.u_hasb,
-                    qd / 2l + 2l * (kv_dim / 32l))
+                    kvsh ? qd / 2l : qd / 2l + 2l * (kv_dim / 32l))
             } elif (r.kdt == KVDtype.tq4) {
                 enc_rope_store_tq4(enc, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                     lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
                     bcos_l, bsin_l, u_qd_l, u_hs_l, r.u_nh, u_kvm_l, r.u_neox, bbias, r.u_hasb,
-                    n_heads + 2l * (kv_dim / head_size), head_size)
+                    kvsh ? n_heads : n_heads + 2l * (kv_dim / head_size), head_size)
             } elif (c.qk_norm && f16v) {
                 // QK-norm x f16 mirror: bias + per-head RMS + rope + store fold into ONE head-cooperative dispatch
                 var bqkw = upload_region_cat3(
@@ -737,13 +760,13 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
                 enc_rope_store_h16(enc, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                     lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
                     bcos_l, bsin_l, bqkw, bbias, u_qd_l, u_hs_l, r.u_nh, u_kvm_l, r.u_neox,
-                    r.u_hasb, r.u_hasn, r.u_eps, n_heads + 2l * (kv_dim / head_size), head_size,
+                    r.u_hasb, r.u_hasn, r.u_eps, kvsh ? n_heads : n_heads + 2l * (kv_dim / head_size), head_size,
                     [brot = r.u_rot])
             } else {
                 enc_rope_store(enc, f16v, r.bqkv, uint64((qd + kv_dim) * 4l), g_arena, g_arena,
                     lkoff + uint64(pos * rowb), lvoff + uint64(pos * rowb),
                     bcos_l, bsin_l, u_qd_l, u_hs_l, u_npq_l, u_npall_l, r.u_neox, bbias, r.u_hasb,
-                    (qd + kv_dim) / 2l, [brot = r.u_rot])
+                    kvsh ? qd / 2l : (qd + kv_dim) / 2l, [brot = r.u_rot])
             }
         }
         if (!recr && g_skip != "attn") {
@@ -939,6 +962,28 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
                 var bw_pf = upload_region(addr < void? >(t.fblob[t.rms_post_ffn_off + l * dim]), uint64(dim * 4l))
                 enc_rms(enc, r.bxb, bw_pf, r.bxb, r.u_dim, r.u_eps)
             }
+        }
+        if (r.ple) {
+            // PLE between FFN residual and out_scale: branch = post_norm(proj·(gelu(gate·x) ⊙ side[l]))
+            let ple = c.n_embd_per_layer
+            if (g_skip != "ew") {
+                enc_ew2(enc, g_pso_add, r.bx, 0ul, r.bxb, 0ul, r.u_dim, dim)
+            }
+            if (g_skip != "gemv") {
+                enc_site_gemv(enc, t, KqFmt.q8, t.ple_gate_off + l * dim * ple, ple, dim, r.bx, r.bh12, r.u_dim, r.u_ple)
+            }
+            if (g_skip != "ew") {
+                enc_ew2(enc, g_pso_geglu, r.bh12, 0ul, r.bple, uint64(l * ple * 4l), r.u_ple, ple)
+            }
+            if (g_skip != "gemv") {
+                enc_site_gemv(enc, t, KqFmt.q8, t.ple_proj_off + l * ple * dim, dim, ple, r.bh12, r.bxb, r.u_ple, r.u_dim)
+            }
+            if (g_skip != "ew") {
+                var bw_pp = upload_region(addr < void? >(t.fblob[t.ple_post_off + l * dim]), uint64(dim * 4l))
+                enc_rms(enc, r.bxb, bw_pp, r.bxb, r.u_dim, r.u_eps)
+            }
+        }
+        if (g_skip != "ew") {
             // gemma4 layer_out_scale: (x + branch) * s folds into the residual add (a 4-byte view into the weights blob)
             var bosc : MetalBuffer?
             if (c.layer_out_scale) {
@@ -1610,6 +1655,7 @@ def private finish_step(t : Model; var s : Session; r : StepRes) : bool {
             var vmp = reinterpret<uint8?>(metal_buffer_contents(g_arena)) + r.voff
             let prow = kv_phys_row(s, pos)
             for (l in range64(c.n_layers)) {
+                continue if (kv_shared_layer(t, l))   // no rows of its own — the source's copy covers it
                 let rowb = kv_row_bytes(s.kv_dtype_k, layer_kv_dim(c, l))
                 let lb = mirror_lbase(t, s.kv_dtype_k, cap, l)
                 memcpy(reinterpret<void?>(kv_layer_kbase(s, l, c.seq_len) + prow * rowb),
@@ -1797,6 +1843,10 @@ def private release_step(var r : StepRes) {
     }
     if (r.u_rot != null) {
         pool_release(g_upool, r.u_rot, 4ul)
+    }
+    if (r.ple) {
+        pool_release(g_upool, r.bple, r.bytes_ple)
+        pool_release(g_upool, r.u_ple, 4ul)
     }
     r.valid = false
 }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -61,7 +61,7 @@ let DECODE_NEEDS_OK = (MetalNeed.neox | MetalNeed.qkv_bias | MetalNeed.qk_norm |
     MetalNeed.ple)
 // q_gated/partial_rope only occur on hybrid models (attn_is_std false), which batch graph-declines;
 // ple (E-series) has no batch arm either — batched steps decline `feature` and fall back per-row
-let BATCH_NEEDS_OK = DECODE_NEEDS_OK ^ MetalNeed.ple
+let BATCH_NEEDS_OK = DECODE_NEEDS_OK & ~MetalNeed.ple   // clear ple explicitly (XOR would re-add it if DECODE ever drops it)
 
 def private decode_shape_decline(t : Model; needs_ok : MetalNeed; allow_moe : bool = false; allow_kv_share : bool = false) : MetalDecodeDecline {
     if (t.quant != QuantMode.q8) {

--- a/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_llama.das
@@ -876,10 +876,10 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
                         r.u_zero32, r.u_zero32, r.u_zero32, bwb3, r.u_moe_gmode, uint64(knfe * 4l))
                 } else {
                     enc_moe_gemv(enc, t, fe1, t.we1_offs[l], c.n_ff_exp, c.n_expert_used, 1l, bmx, r.bh12,
-                        r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe1 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
+                        r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe1 == KqFmt.q8 || fe1 == KqFmt.q51 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
                         r.u_zero32, r.u_zero32, r.u_zero32)
                     enc_moe_gemv(enc, t, fe3, t.we3_offs[l], c.n_ff_exp, c.n_expert_used, 1l, bmx, r.bh12,
-                        r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe3 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
+                        r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe3 == KqFmt.q8 || fe3 == KqFmt.q51 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
                         r.u_zero32, r.u_zero32, r.u_zero32, uint64(knfe * 4l))
                 }
             }
@@ -895,7 +895,7 @@ def private encode_layer(t : Model; var r : StepRes; enc : MetalComputeEncoder?;
                         r.u_zero32, r.u_zero32, r.u_zero32, bwb2, r.u_moe_gmode)
                 } else {
                     enc_moe_gemv(enc, t, fe2, t.we2_offs[l], dim, c.n_expert_used, 1l, r.bh12, r.bmoe_dn,
-                        r.u_moe_nfe, r.u_dim, r.bmoe_sel, fe2 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_moe_xs_dn,
+                        r.u_moe_nfe, r.u_dim, r.bmoe_sel, fe2 == KqFmt.q8 || fe2 == KqFmt.q51 ? r.u_moe_eblk : r.u_moe_esb, r.u_moe_xs_dn,
                         r.u_zero32, r.u_zero32, r.u_zero32)
                 }
                 if (r.u_moe_nsh != null) {
@@ -1299,14 +1299,14 @@ def private encode_verify_layer(t : Model; var r : StepRes; enc : MetalComputeEn
                 enc_moe_router(enc, bw_shg, r.bxb, r.bmoe_lg, r.u_dim, r.u_one32, r.u_dim, g_one, g_zero, 1l, 2l)
             }
             enc_moe_gemv(enc, t, fe1, t.we1_offs[l], c.n_ff_exp, c.n_expert_used, 2l, r.bxb, r.bh12,
-                r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe1 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
+                r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe1 == KqFmt.q8 || fe1 == KqFmt.q51 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
                 r.u_moe_ss, r.u_dim, r.u_moe_knfe)
             enc_moe_gemv(enc, t, fe3, t.we3_offs[l], c.n_ff_exp, c.n_expert_used, 2l, r.bxb, r.bh12,
-                r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe3 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
+                r.u_dim, r.u_moe_nfe, r.bmoe_sel, fe3 == KqFmt.q8 || fe3 == KqFmt.q51 ? r.u_moe_eblk : r.u_moe_esb, r.u_zero32,
                 r.u_moe_ss, r.u_dim, r.u_moe_knfe, uint64(2l * knfe * 4l))
             enc_ew2(enc, g_pso_swiglu, r.bh12, 0ul, r.bh12, uint64(2l * knfe * 4l), r.u_moe_tot, 2l * knfe)
             enc_moe_gemv(enc, t, fe2, t.we2_offs[l], dim, c.n_expert_used, 2l, r.bh12, r.bmoe_dn,
-                r.u_moe_nfe, r.u_dim, r.bmoe_sel, fe2 == KqFmt.q8 ? r.u_moe_eblk : r.u_moe_esb, r.u_moe_xs_dn,
+                r.u_moe_nfe, r.u_dim, r.bmoe_sel, fe2 == KqFmt.q8 || fe2 == KqFmt.q51 ? r.u_moe_eblk : r.u_moe_esb, r.u_moe_xs_dn,
                 r.u_moe_ss, r.u_moe_knfe, r.u_moe_kdim)
             if (r.u_moe_nsh != null) {
                 // shexp FFN reads bxb BEFORE combine overwrites it; bh12 is free after expert W2

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -1020,9 +1020,9 @@ class MetalMoeGemvK6 {
 // b LOW / b+16 HIGH — the split-half layout) + one E8M0 scale byte; value = doubled-e2m1
 // magnitude x halved scale (2^(e-128)). Optional per-expert bias rows — gpt-oss's biased MoE.
 class MetalMoeGemvMx4 {
-    @ssbo @binding = 0 mxn : array<uint8>   // nibble plane, bound at the layer stack's off/2
+    @ssbo @binding = 0 mxu : array<uint>    // nibble plane, uint view (block at 4*blk; off/2 % 4)
     @ssbo @binding = 1 mxe : array<uint8>   // E8M0 plane, bound at off/32
-    @ssbo @binding = 2 x : array<float>
+    @ssbo @binding = 2 xf : array<float4>   // activations, float4 view (xoff always % 4)
     @ssbo @binding = 3 y : array<float>
     @uniform @binding = 4 ndim : uint
     @uniform @binding = 5 ddim : uint
@@ -1035,51 +1035,50 @@ class MetalMoeGemvMx4 {
     @ssbo @binding = 12 wb : array<float>   // [ne x ddim] per-expert bias rows (hasb models)
     @uniform @binding = 13 hasb : uint
     @ssbo @binding = 14 etab : array<float> // [256] exact e8m0_half scales (host-built)
+    @ssbo @binding = 15 vtab : array<float> // [16] signed doubled-e2m1 values (host-built)
 
     [metal_kernel(name="metal_moe_gemv_mx4_msl")]
     def metal_moe_gemv_mx4 {
-        let row = gl_WorkGroupID.x * gl_NumSubgroups + gl_SubgroupID
-        if (row >= ddim) {
-            return
-        }
+        // the q51 GEMV shape (2 rows per sg off one shared float4 x load) — the 1-row scalar-x
+        // form was the gpt-oss 0.40x decode red; the value LUT replaces the per-nibble csel chain
+        let lane = gl_SubgroupInvocationID
+        let ix = lane / 8u    // 4-way block stride
+        let it = lane % 8u    // 8 threads per block, one float4 (4 elems) each
+        let nb = ndim / 32u
         let slot = gl_WorkGroupID.y
         let st = gl_WorkGroupID.z
         let e = sel[st * ss + slot]
         let eb = e * eblk
-        let lane = gl_SubgroupInvocationID
-        let nb = ndim / 32u
         let xoff = st * bxs + slot * xs
-        var acc = 0.0
-        var kb = lane
-        while (kb < nb) {
-            let blk = eb + row * nb + kb
-            let sc = uint(mxe[blk])
-            let d = etab[sc]   // host-built exact e8m0_half table (incl. the denormal e < 2)
-            let qb = blk * 16u
-            let xb = xoff + kb * 32u
-            var lo = 0.0
-            var hi = 0.0
-            for [unroll_full] (bi in range(16)) {
-                let nby = uint(mxn[qb + uint(bi)])
-                let nl = nby & 15u
-                let nh = nby >> 4u
-                let ml = nl & 7u
-                let mh = nh & 7u
-                let vl = float(ml <= 4u ? ml : (ml == 5u ? 6u : (ml == 6u ? 8u : 12u)))
-                let vh = float(mh <= 4u ? mh : (mh == 5u ? 6u : (mh == 6u ? 8u : 12u)))
-                lo += ((nl & 8u) != 0u ? -vl : vl) * x[xb + uint(bi)]
-                hi += ((nh & 8u) != 0u ? -vh : vh) * x[xb + 16u + uint(bi)]
+        let y0 = st * bys + slot * ddim
+        let first_row = (gl_WorkGroupID.x * 2u + gl_SubgroupID) * 2u
+        let half = it / 4u
+        let ku = it % 4u
+        let nsh = half * 4u
+        var sumf : float[2]
+        var ib = ix
+        while (ib < nb) {
+            let xv = xf[(xoff + ib * 32u) / 4u + it]
+            for [unroll_full] (r in range(2)) {
+                let blk = eb + (first_row + uint(r)) * nb + ib
+                let u = mxu[blk * 4u + ku]
+                var qx = vtab[(u >> nsh) & 15u] * xv.x
+                qx += vtab[(u >> (8u + nsh)) & 15u] * xv.y
+                qx += vtab[(u >> (16u + nsh)) & 15u] * xv.z
+                qx += vtab[(u >> (24u + nsh)) & 15u] * xv.w
+                sumf[r] += etab[uint(mxe[blk])] * qx
             }
-            acc += (lo + hi) * d
-            kb += gl_SubgroupSize
+            ib += 4u
         }
-        acc = simd_sum(acc)
-        if (lane == 0u) {
-            var outv = acc
-            if (hasb != 0u) {
-                outv += wb[e * ddim + row]
+        for [unroll_full] (r in range(2)) {
+            let sr = simd_sum(sumf[r])
+            if (lane == 0u && first_row + uint(r) < ddim) {
+                var outv = sr
+                if (hasb != 0u) {
+                    outv += wb[e * ddim + first_row + uint(r)]
+                }
+                y[y0 + first_row + uint(r)] = outv
             }
-            y[st * bys + slot * ddim + row] = outv
         }
     }
 }
@@ -1165,6 +1164,7 @@ class MetalMoeMulMmMx4 {
     @uniform @binding = 10 nk : uint
     @uniform @binding = 11 gather : uint
     @ssbo @binding = 12 etab : array<float> // [256] exact e8m0_half scales (host-built)
+    @ssbo @binding = 13 vtab : array<float> // [16] signed doubled-e2m1 values (host-built)
     @workgroup ta : float16[2048]
     @workgroup tb : float16[1024]
 
@@ -1212,10 +1212,7 @@ class MetalMoeMulMmMx4 {
             let qb = blk * 16u
             for [unroll_full] (i in range(16)) {
                 let nby = uint(mxn[qb + uint(i)])
-                let nn = il0 == 0u ? (nby & 15u) : (nby >> 4u)
-                let m = nn & 7u
-                let mv = float(m <= 4u ? m : (m == 5u ? 6u : (m == 6u ? 8u : 12u)))
-                va[i] = float16((((nn & 8u) != 0u ? -mv : mv)) * d)
+                va[i] = float16(vtab[il0 == 0u ? (nby & 15u) : (nby >> 4u)] * d)
             }
             barrier()
             for [unroll_full] (i in range(16)) {
@@ -4287,6 +4284,7 @@ var private g_pf_pso_moe_mm_mx4 : MetalComputePipeline?
 var private g_pf_pso_moe_mm_q51 : MetalComputePipeline?
 var private g_pf_pso_moe_bias_rows : MetalComputePipeline?
 var private g_pf_e8m0_tab : MetalBuffer?
+var private g_pf_mx4_vtab : MetalBuffer?
 var private g_mm_legacy = false             // set_metal_prefill_mulmm_legacy — tests' exact-parity rail
 var private g_pf_logits_cpu = false            // set_metal_prefill_logits_cpu — the logits A/B rail
 // timing-attribution knockout (DASLLAMA_METAL_PREFILL_SKIP=attn|gemm|ew|nongemm|moe|moe_mm|
@@ -4498,6 +4496,10 @@ def public metal_prefill_shutdown {
     g_pf_pso_moe_mm_mx4 = null
     g_pf_pso_moe_mm_q51 = null
     g_pf_pso_moe_bias_rows = null
+    if (g_pf_mx4_vtab != null) {
+        metal_release(g_pf_mx4_vtab)
+        g_pf_mx4_vtab = null
+    }
     if (g_pf_e8m0_tab != null) {
         metal_release(g_pf_e8m0_tab)
         g_pf_e8m0_tab = null
@@ -4617,6 +4619,14 @@ def private metal_prefill_init : bool {
         var ep = reinterpret<uint?>(metal_buffer_contents(g_pf_e8m0_tab))
         for (ei in range(256)) {
             ep[ei] = ei < 2 ? (0x00200000u << uint(ei)) : (uint(ei - 1) << 23u)
+        }
+    }
+    g_pf_mx4_vtab = metal_new_buffer(g_pf_dev, 64ul)
+    unsafe {
+        var vp = reinterpret<float?>(metal_buffer_contents(g_pf_mx4_vtab))
+        let mags = fixed_array(0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0)
+        for (vi in range(16)) {
+            vp[vi] = vi < 8 ? mags[vi] : -mags[vi - 8]
         }
     }
     if (!ok) {
@@ -4987,6 +4997,7 @@ def private pf_enc_moe_mm_mx4(enc : MetalComputeEncoder?; t : Model; stack_off, 
     metal_set_buffer(enc, bnk, 0ul, 10)
     metal_set_buffer(enc, bgather, 0ul, 11)
     metal_set_buffer(enc, g_pf_e8m0_tab, 0ul, 12)
+    metal_set_buffer(enc, g_pf_mx4_vtab, 0ul, 13)
     metal_dispatch_threadgroups(enc, uint3(uint(tiles), uint(rows / 64l), uint(ne)), uint3(128u, 1u, 1u))
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -4057,7 +4057,8 @@ var private g_pf_upool : MetalBufferPool     // UNTRACKED pool: uniforms + rope 
 let PF_NEEDS_OK = (MetalNeed.neox | MetalNeed.qkv_bias | MetalNeed.qk_norm | MetalNeed.qd_neq_dim |
     MetalNeed.softcap | MetalNeed.sliding | MetalNeed.pre_post_norm | MetalNeed.geglu |
     MetalNeed.v_norm | MetalNeed.attn_scale | MetalNeed.out_scale |
-    MetalNeed.sinks | MetalNeed.out_bias | MetalNeed.partial_rope | MetalNeed.q_gated)
+    MetalNeed.sinks | MetalNeed.out_bias | MetalNeed.partial_rope | MetalNeed.q_gated |
+    MetalNeed.ple)
 
 var private g_min_npos = 64l
 var private g_max_npos = 2048l          // naive-attention P footprint cap: heads x npos^2 floats
@@ -4545,12 +4546,13 @@ def private prefill_decline(t : Model; s : Session; npos, start_pos : int64) : M
     if ((c.dim % 32l) != 0l || (hidden % 32l) != 0l) {
         return MetalPrefillDecline.shape
     }
-    // per-CLASS: head_size/kv_dim % 32 grid the AV kernel (QK k-slabs any size); hetero geometry and missing attn_v serve, hidden + kv_src stay pinned
+    // per-CLASS: head_size/kv_dim % 32 grid the AV kernel (QK k-slabs any size); hetero geometry and missing attn_v serve, hidden stays pinned
     for (l in range64(c.n_layers)) {
         if ((layer_head_size(c, l) % 32l) != 0l || (layer_kv_dim(c, l) % 32l) != 0l) {
             return MetalPrefillDecline.shape
         }
-        if (t.kv_src[l] != l || layer_hidden(t, l) != hidden) {
+        // E-series shared-KV layers (Q-only) serve when the source is byte-compatible — the panel aliases it
+        if ((t.kv_src[l] != l && !kv_share_ok(t, l)) || layer_hidden(t, l) != hidden) {
             return MetalPrefillDecline.layers
         }
     }
@@ -5095,10 +5097,10 @@ def private pf_enc_axpy_sig(enc : MetalComputeEncoder?; by, bx, bg, btot, bdim :
     metal_dispatch_threadgroups(enc, uint3(uint((total + 255l) / 256l), 1u, 1u), uint3(256u, 1u, 1u))
 }
 
-def private pf_enc_ew2(enc : MetalComputeEncoder?; pso : MetalComputePipeline?; ba, bb, btot : MetalBuffer?; total : int64; bascale : MetalBuffer? = null) {
+def private pf_enc_ew2(enc : MetalComputeEncoder?; pso : MetalComputePipeline?; ba, bb, btot : MetalBuffer?; total : int64; bascale : MetalBuffer? = null; boff : uint64 = 0ul) {
     metal_set_pipeline(enc, pso)
     metal_set_buffer(enc, ba, 0ul, 0)
-    metal_set_buffer(enc, bb, 0ul, 1)
+    metal_set_buffer(enc, bb, boff, 1)
     metal_set_buffer(enc, btot, 0ul, 2)
     metal_set_buffer(enc, bascale != null ? bascale : g_pf_one, 0ul, 3)   // the add's ascale slot (unused by swiglu/geglu)
     metal_dispatch_threadgroups(enc, uint3(uint((total + 63l) / 64l), 1u, 1u), uint3(64u, 1u, 1u))
@@ -5264,9 +5266,38 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             bvs |> push(no_panel)
             continue
         }
+        if (kv_shared_layer(t, l)) {   // E-series: alias the source layer's panels (same class geometry)
+            bks |> push(bks[t.kv_src[l]])
+            bvs |> push(bvs[t.kv_src[l]])
+            continue
+        }
         let bytes_kv_l = uint64(kvrows * layer_kv_dim(c, l) * 4l)   // per-layer panels: each class's width
         bks |> push(pool_acquire(g_pf_pool, g_pf_dev, bytes_kv_l))
         bvs |> push(pool_acquire(g_pf_pool, g_pf_dev, bytes_kv_l))
+    }
+    // E-series PLE: side input uploaded LAYER-major ([l][p][ple] — the flat geglu ⊙ reads layer l's
+    // block at one offset); gate outputs pad to mp rows like every GEMM panel
+    let plef = has_ple(c)
+    let ple_n = c.n_embd_per_layer
+    let bytes_ple_side = uint64(c.n_layers * npos * ple_n * 4l)
+    let bytes_ple_g = uint64(mp * ple_n * 4l)
+    var bple : MetalBuffer?
+    var bpleg : MetalBuffer?
+    if (plef) {
+        bple = pool_acquire_untracked(g_pf_upool, g_pf_dev, bytes_ple_side)
+        bpleg = pool_acquire(g_pf_pool, g_pf_dev, bytes_ple_g)
+        unsafe {
+            // transpose s.ple_inp (position-major, p*all + l*ple) into layer-major blocks
+            var dst = reinterpret<float?>(metal_buffer_contents(bple))
+            let src = addr < float const? >(s.ple_inp[0])
+            let all = c.n_layers * ple_n
+            for (l in range64(c.n_layers)) {
+                for (p in range64(npos)) {
+                    memcpy(reinterpret<void?>(dst + (l * npos + p) * ple_n),
+                        reinterpret<void const?>(src + p * all + l * ple_n), int(ple_n * 4l))
+                }
+            }
+        }
     }
     // upload the embedded rows + this prefill's rope table(s) (built for the chunk's GLOBAL
     // positions — build_rope_table takes start_pos; dual-rope: the sliding class's pair too)
@@ -5288,9 +5319,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             let runsg = addr < KVRun const? >(s.kv_runs[0])
             let sgp = (s.kv_dtype_k == KVDtype.tq4 || s.kv_dtype_v == KVDtype.tq4) ? addr < float const? >(s.kv_signs[0]) : null
             for (l in range64(c.n_layers + c.n_layer_nextn)) {
-                if (bks[l] == null) {   // recurrent layer — no rows to gather
-                    continue
-                }
+                // recurrent: no rows; shared (E-series): aliased panel — the source's gather covers it
+                continue if (bks[l] == null || kv_shared_layer(t, l))
                 var kdst = reinterpret<float?>(metal_buffer_contents(bks[l]))
                 var vdst = reinterpret<float?>(metal_buffer_contents(bvs[l]))
                 let kcp = kv_layer_kbase(s, l, c.seq_len)
@@ -5369,6 +5399,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var u_dn_qd2 = c.q_gated ? pf_uniform_u32(uint(2l * qd)) : null
     var u_qtot = c.q_gated ? pf_uniform_u32(uint(npos * qd)) : null
     var u_rot = (c.rope_dim > 0l && c.rope_dim != head_size) ? pf_uniform_u32(uint(c.rope_dim)) : null
+    // E-series PLE: gate/proj widths + the per-layer geglu ⊙ span
+    var u_ple = plef ? pf_uniform_u32(uint(ple_n)) : null
+    var u_ple_tot = plef ? pf_uniform_u32(uint(npos * ple_n)) : null
     // the SLIDING-class uniform twins (hetero models — uniform models leave these null and
     // every layer binds the base set)
     var u_qd_sw = hetero ? pf_uniform_u32(uint(qd_sw)) : null
@@ -5520,6 +5553,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 var u_npairs_k_l = het ? u_npairs_k_sw : u_npairs_k
                 let has_wv = t.wv_offs[l] >= 0l
                 let recr = layer_is_recurrent(c, l)
+                // E-series shared-KV layer: Q-only — bks[l]/bvs[l] alias the source's panels
+                let kvsh = kv_shared_layer(t, l)
                 // attention: [pending W2 residual +] norm -> [requant ->] Q/K/V -> rope ->
                 // scores+softmax -> P.V -> out-proj (fused path folds each residual add into the
                 // FOLLOWING add+rms+quant; the lcpp path feeds normed f32 rows straight to mul_mm)
@@ -5589,23 +5624,24 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             let bwqb = pf_blob_of(t, t.wq_offs[l])
                             enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l)
                         }
-                        if (fk != KqFmt.q8) {
-                            pf_enc_kq_site_mm(enc, t, fk, t.wk_offs[l], kvd_l, bxb, bks[l], u_dim, u_kvd_l, mp, koff)
-                        } else {
-                            let bwkb = pf_blob_of(t, t.wk_offs[l])
-                            enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
-                        }
-                        if (has_wv) {
-                            if (fv != KqFmt.q8) {
-                                pf_enc_kq_site_mm(enc, t, fv, t.wv_offs[l], kvd_l, bxb, bvs[l], u_dim, u_kvd_l, mp, koff)
+                        if (!kvsh) {
+                            if (fk != KqFmt.q8) {
+                                pf_enc_kq_site_mm(enc, t, fk, t.wk_offs[l], kvd_l, bxb, bks[l], u_dim, u_kvd_l, mp, koff)
                             } else {
-                                let bwvb = pf_blob_of(t, t.wv_offs[l])
-                                enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                                let bwkb = pf_blob_of(t, t.wk_offs[l])
+                                enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                            }
+                            if (has_wv) {
+                                if (fv != KqFmt.q8) {
+                                    pf_enc_kq_site_mm(enc, t, fv, t.wv_offs[l], kvd_l, bxb, bvs[l], u_dim, u_kvd_l, mp, koff)
+                                } else {
+                                    let bwvb = pf_blob_of(t, t.wv_offs[l])
+                                    enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                                }
                             }
                         }
                     } else {
                         let bwqb = pf_blob_of(t, t.wq_offs[l])
-                        let bwkb = pf_blob_of(t, t.wk_offs[l])
                         if (c.q_gated) {
                             // 2x-wide packed [q|gate] projection, deinterleaved into the q panel + gate rows
                             enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l)
@@ -5613,14 +5649,17 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         } else {
                             enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l)
                         }
-                        enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
-                        if (has_wv) {
-                            let bwvb = pf_blob_of(t, t.wv_offs[l])
-                            enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                        if (!kvsh) {   // shared layers have no K/V tensors (offs -1)
+                            let bwkb = pf_blob_of(t, t.wk_offs[l])
+                            enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                            if (has_wv) {
+                                let bwvb = pf_blob_of(t, t.wv_offs[l])
+                                enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                            }
                         }
                     }
                 }
-                if (!recr && (!has_wv || c.v_norm) && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                if (!recr && !kvsh && (!has_wv || c.v_norm) && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // gemma4 V: no-wv layers copy the PRE-norm/PRE-rope K panel rows into the V
                     // panel; v_norm then runs the weightless per-head RMS (ones plane) in place —
                     // the CPU mm_qkv order exactly, BEFORE qk_norm touches k
@@ -5653,10 +5692,12 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 if (!recr && has_qkn && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // per-head QK-norm before rope — the chunk's q panel and its new K rows
                     var bqw = pf_upload_region(addr < void? >(t.fblob[t.rms_q_offs[l]]), uint64(hs_l * 4l))
-                    var bkw = pf_upload_region(addr < void? >(t.fblob[t.rms_k_offs[l]]), uint64(hs_l * 4l))
                     enc_qk_norm_pf(enc, bq, bqw, u_nh_pf, u_qd_l, u_qd_l, u_hs_l, u_hs_l, u_eps, u_qd_l, n_heads, npos, hs_l)
-                    enc_qk_norm_pf(enc, bks[l], bkw, u_zero, u_zero, u_kvd_l, u_hs_l, u_zero, u_eps,
-                        u_zero, kvd_l / hs_l, npos, hs_l, koff)
+                    if (!kvsh) {
+                        var bkw = pf_upload_region(addr < void? >(t.fblob[t.rms_k_offs[l]]), uint64(hs_l * 4l))
+                        enc_qk_norm_pf(enc, bks[l], bkw, u_zero, u_zero, u_kvd_l, u_hs_l, u_zero, u_eps,
+                            u_zero, kvd_l / hs_l, npos, hs_l, koff)
+                    }
                 }
                 if (!recr && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // sliding layers rope with the swa row pair (dual-rope configs — gemma3/4;
@@ -5664,7 +5705,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     var bcos_l = lsl && dual_rope ? bcos_swa : bcos
                     var bsin_l = lsl && dual_rope ? bsin_swa : bsin
                     enc_rope(enc, bq, bcos_l, bsin_l, u_qd_l, u_hs_l, u_npairs_q_l, u_neox, npos * qd_l / 2l, [brot = u_rot])
-                    enc_rope(enc, bks[l], bcos_l, bsin_l, u_kvd_l, u_hs_l, u_npairs_k_l, u_neox, npos * kvd_l / 2l, koff, [brot = u_rot])
+                    if (!kvsh) {
+                        enc_rope(enc, bks[l], bcos_l, bsin_l, u_kvd_l, u_hs_l, u_npairs_k_l, u_neox, npos * kvd_l / 2l, koff, [brot = u_rot])
+                    }
                 }
                 if (!recr && g_pf_skip != "attn" && g_pf_skip != "nongemm") {
                     // sliding layers bind the span — the QK forms skip fully-below-window blocks,
@@ -5857,6 +5900,31 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         var bw_pf = pf_upload_region(addr < void? >(t.fblob[t.rms_post_ffn_off + l * dim]), uint64(dim * 4l))
                         pf_enc_rms(enc, bxb, bw_pf, bxb, u_dim, u_eps, npos)
                     }
+                }
+                if (plef) {
+                    // E-series PLE between FFN residual and out_scale (the CPU order): plain x_b +=
+                    // ffn_branch, then branch = post_norm(proj · (gelu(gate · x_b) ⊙ side[l]))
+                    if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                        pf_enc_ew2(enc, g_pf_pso_add, bx, bxb, u_total_dim, npos * dim)
+                    }
+                    if (g_pf_skip != "gemm") {
+                        let bwpg = pf_blob_of(t, t.ple_gate_off + l * dim * ple_n)
+                        enc_gemm_mm(enc, bwpg.buf, bwpg.boff, bx, bpleg, u_dim, u_ple, mp, ple_n)
+                    }
+                    if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                        pf_enc_ew2(enc, g_pf_pso_geglu, bpleg, bple, u_ple_tot, npos * ple_n,
+                            [boff = uint64(l * npos * ple_n * 4l)])
+                    }
+                    if (g_pf_skip != "gemm") {
+                        let bwpp = pf_blob_of(t, t.ple_proj_off + l * ple_n * dim)
+                        enc_gemm_mm(enc, bwpp.buf, bwpp.boff, bpleg, bxb, u_ple, u_dim, mp, dim)
+                    }
+                    if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
+                        var bw_pn = pf_upload_region(addr < void? >(t.fblob[t.ple_post_off + l * dim]), uint64(dim * 4l))
+                        pf_enc_rms(enc, bxb, bw_pn, bxb, u_dim, u_eps, npos)
+                    }
+                }
+                if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                     // gemma4 layer_out_scale multiplies the WHOLE layer output — (x + branch) * s
                     // folds into the residual add's ascale slot (a 4-byte view into the weights blob)
                     var bosc : MetalBuffer?
@@ -5933,7 +6001,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 let ts_rb = ref_time_ticks()
                 let l1 = min(int64(i + 1) * layers_per_cb, n_enc_layers)
                 for (l in range64(int64(i) * layers_per_cb, l1)) {
-                    if (bks[l] == null) {   // recurrent layer — no K/V rows to store
+                    // recurrent: no rows; shared (E-series): the source layer's store covers the alias
+                    if (bks[l] == null || kv_shared_layer(t, l)) {
                         continue
                     }
                     // the chunk's rows sit past a continuation's gathered panel head
@@ -6065,12 +6134,18 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     }
     pool_release(g_pf_upool, bsin, bytes_tab)
     for (l in range64(c.n_layers + c.n_layer_nextn)) {
-        if (bks[l] == null) {
+        if (bks[l] == null || kv_shared_layer(t, l)) {   // shared: aliased — the source releases it
             continue
         }
         let bytes_kv_l = uint64(kvrows * layer_kv_dim(c, l) * 4l)
         pool_release(g_pf_pool, bks[l], bytes_kv_l)
         pool_release(g_pf_pool, bvs[l], bytes_kv_l)
+    }
+    if (plef) {
+        pool_release(g_pf_upool, bple, bytes_ple_side)
+        pool_release(g_pf_pool, bpleg, bytes_ple_g)
+        pool_release(g_pf_upool, u_ple, 4ul)
+        pool_release(g_pf_upool, u_ple_tot, 4ul)
     }
     bks |> clear()      // non-owning handles — the pool owns them now
     bvs |> clear()

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -1084,6 +1084,71 @@ class MetalMoeGemvMx4 {
     }
 }
 
+// Expert-indexed Q5_1 GEMV — per-32 planes (a 20B quant block = 5 uints: 16 nibble bytes in the
+// k/k+16 split-half pairing + the qh u32; 4B scales = f16 d, m). value = d*q + m with
+// q = nibble | qh_bit << 4, folded as acc += d*Σ(q·x) + m*Σx per block (f32 activations).
+class MetalMoeGemvQ51 {
+    @ssbo @binding = 0 wqu : array<uint>    // quant plane, uint view (block at 5*blk; qh at +4)
+    @ssbo @binding = 1 wsh : array<float16> // scale plane (d at 2*blk, m at 2*blk+1)
+    @ssbo @binding = 2 xf : array<float4>   // activations, float4 view (xoff always % 4)
+    @ssbo @binding = 3 y : array<float>
+    @uniform @binding = 4 ndim : uint
+    @uniform @binding = 5 ddim : uint
+    @ssbo @binding = 6 sel : array<uint>    // [streams x 2k] selection rows (idx section read)
+    @uniform @binding = 7 eblk : uint       // 32-elem blocks per expert plane (ege / 32)
+    @uniform @binding = 8 xs : uint         // per-slot x stride, elements (0 = shared)
+    @uniform @binding = 9 ss : uint         // per-stream sel row stride, uints (2k; 0 single)
+    @uniform @binding = 10 bxs : uint       // per-stream x stride, elements (0 single)
+    @uniform @binding = 11 bys : uint       // per-stream y stride, elements (0 single)
+
+    [metal_kernel(name="metal_moe_gemv_q51_msl")]
+    def metal_moe_gemv_q51 {
+        let lane = gl_SubgroupInvocationID
+        let ix = lane / 8u    // 4-way block stride
+        let it = lane % 8u    // 8 threads per block, one float4 (4 elems) each
+        let nb = ndim / 32u
+        let slot = gl_WorkGroupID.y
+        let st = gl_WorkGroupID.z
+        let eb = sel[st * ss + slot] * eblk
+        let xoff = st * bxs + slot * xs
+        let y0 = st * bys + slot * ddim
+        let first_row = (gl_WorkGroupID.x * 2u + gl_SubgroupID) * 2u
+        // this thread's 4 elems: half = it/4 selects the nibble half, ku = it%4 the quant uint
+        let half = it / 4u
+        let ku = it % 4u
+        let nsh = half * 4u
+        let hb = ku * 4u + half * 16u
+        var sumf : float[2]
+        var ib = ix
+        while (ib < nb) {
+            let xv = xf[(xoff + ib * 32u) / 4u + it]
+            let sx = xv.x + xv.y + xv.z + xv.w
+            for [unroll_full] (r in range(2)) {
+                let blk = eb + (first_row + uint(r)) * nb + ib
+                let qb = blk * 5u
+                let u = wqu[qb + ku]
+                let qh = wqu[qb + 4u] >> hb
+                var qx = float((u >> nsh) & 15u) * xv.x
+                qx += float((u >> (8u + nsh)) & 15u) * xv.y
+                qx += float((u >> (16u + nsh)) & 15u) * xv.z
+                qx += float((u >> (24u + nsh)) & 15u) * xv.w
+                var hx = (qh & 1u) != 0u ? xv.x : 0.0
+                hx += (qh & 2u) != 0u ? xv.y : 0.0
+                hx += (qh & 4u) != 0u ? xv.z : 0.0
+                hx += (qh & 8u) != 0u ? xv.w : 0.0
+                sumf[r] += float(wsh[blk * 2u]) * (qx + 16.0 * hx) + float(wsh[blk * 2u + 1u]) * sx
+            }
+            ib += 4u
+        }
+        for [unroll_full] (r in range(2)) {
+            let sr = simd_sum(sumf[r])
+            if (lane == 0u && first_row + uint(r) < ddim) {
+                y[y0 + first_row + uint(r)] = sr
+            }
+        }
+    }
+}
+
 // Gathered MXFP4 mul_mm — the gathered-GEMM shape with the mx4 A stage: each thread's 16-elem
 // half IS one nibble half of the 32-block (il0 = 0 low, 1 high). Bias rides MetalMoeBiasRows.
 class MetalMoeMulMmMx4 {
@@ -1758,6 +1823,110 @@ class MetalMoeMulMmK5 {
                 for [unroll_full] (c in range(4)) {
                     let q = ((u >> (8u * uint(c) + nsh)) & 15u) | (((hu >> (8u * uint(c) + js)) & 1u) << 4u)
                     va[k * 4 + c] = float16(dsc * float(q) - dmn)
+                }
+            }
+            barrier()
+            for [unroll_full] (i in range(16)) {
+                ta[tA0 + uint(i / 8) * 512u + uint(i % 8) * 8u] = va[i]
+            }
+            tg_store_half4(tb, ibB, b0)
+            tg_store_half4(tb, ibB + 4u, b1)
+            barrier()
+            var acur = unsafe(addr(ta[aB]))
+            var bcur = unsafe(addr(tb[bB]))
+            for [unroll_full] (_ik in range(4)) {
+                for [unroll_full] (i in range(4)) {
+                    simdgroup_load(ma[i], acur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(2)) {
+                    simdgroup_load(mb[i], bcur, uint(i) * 64u, 8u)
+                }
+                for [unroll_full] (i in range(8)) {
+                    simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i])
+                }
+                acur = unsafe(acur + 512)
+                bcur = unsafe(bcur + 256)
+            }
+            xcur = unsafe(xcur + 8)
+            kb++
+        }
+        let row0 = rbase + mBase + (sg / 2u) * 16u
+        let col0 = nBase + (sg % 2u) * 32u
+        for [unroll_full] (i in range(8)) {
+            simdgroup_store(mc[i], y, (row0 + uint(i / 4) * 8u) * ndim + col0 + uint(i % 4) * 8u, ndim)
+        }
+    }
+}
+
+// Gathered Q5_1 mul_mm — the k5 skeleton with the per-32 A stage: each thread's 16-elem half is
+// one nibble half of the 32-block (il0), value = d*q + m folded into the f16 A tile.
+class MetalMoeMulMmQ51 {
+    @ssbo @binding = 0 wsh : array<float16> // scale plane (d at 2*blk, m at 2*blk+1)
+    @ssbo @binding = 1 wqu : array<uint>    // quant plane, uint view (block at 5*blk; qh at +4)
+    @ssbo @binding = 2 xf : array<float4>
+    @ssbo @binding = 3 y : array<float>
+    @uniform @binding = 4 kdim : uint
+    @uniform @binding = 5 ndim : uint
+    @ssbo @binding = 6 cnt : array<uint>
+    @ssbo @binding = 7 basep : array<uint>
+    @ssbo @binding = 8 bkt : array<uint>
+    @uniform @binding = 9 eblk : uint       // 32-elem blocks per expert plane (ege / 32)
+    @uniform @binding = 10 nk : uint
+    @uniform @binding = 11 gather : uint
+    @workgroup ta : float16[2048]
+    @workgroup tb : float16[1024]
+
+    [metal_kernel(name="metal_moe_mulmm_q51_msl")]
+    def metal_moe_mulmm_q51 {
+        let e = gl_WorkGroupID.z
+        let ce = cnt[e]
+        let mBase = gl_WorkGroupID.x * 32u
+        if (mBase >= (ce + 31u) / 32u * 32u) {
+            return
+        }
+        let rbase = basep[e]
+        let lid = gl_LocalInvocationID.x
+        let sg = gl_SubgroupID
+        let nBase = gl_WorkGroupID.y * 64u
+        var mc : simdgroup_float8x8[8]
+        var ma : simdgroup_half8x8[4]
+        var mb : simdgroup_half8x8[2]
+        var va : float16[16]
+        let kdim4 = kdim / 4u
+        let nkb = kdim / 32u
+        let lr0 = lid / 2u
+        let il0 = lid % 2u
+        let syA = lr0 / 8u
+        let lxA = lr0 % 8u
+        let tA0 = (il0 * 2u * 8u + syA) * 64u + lxA
+        let lr1 = lid / 4u
+        let iy = (lid % 4u) * 8u
+        let ibB = ((lid % 4u) * 4u + lr1 / 8u) * 64u + (lr1 % 8u) * 8u
+        let aB = (sg % 2u) * 256u
+        let bB = (sg / 2u) * 128u
+        let ewb = e * eblk + (nBase + lr0) * nkb
+        let nsh = il0 * 4u
+        let hb0 = il0 * 16u
+        var srcrow = rbase + mBase + lr1
+        if (gather != 0u) {
+            srcrow = bkt[rbase + min(mBase + lr1, ce - 1u)] / nk
+        }
+        var xcur = unsafe(addr(xf[srcrow * kdim4 + iy / 4u]))
+        var kb = 0u
+        while (kb < nkb) {
+            let blk = ewb + kb
+            let b0 = unsafe(xcur[0])
+            let b1 = unsafe(xcur[1])
+            let d = float(wsh[blk * 2u])
+            let m = float(wsh[blk * 2u + 1u])
+            let qb = blk * 5u
+            let qh = wqu[qb + 4u]
+            for [unroll_full] (k in range(4)) {
+                let u = wqu[qb + uint(k)]
+                for [unroll_full] (c in range(4)) {
+                    let el = uint(k) * 4u + uint(c)
+                    let q = ((u >> (8u * uint(c) + nsh)) & 15u) | (((qh >> (el + hb0)) & 1u) << 4u)
+                    va[k * 4 + c] = float16(d * float(q) + m)
                 }
             }
             barrier()
@@ -4115,6 +4284,7 @@ var private g_pf_pso_g4rnorm : MetalComputePipeline?   // gemma4 MoE router-inpu
 var private g_pf_pso_moe_wscale : MetalComputePipeline?
 var private g_pf_pso_swiglu_oai : MetalComputePipeline?
 var private g_pf_pso_moe_mm_mx4 : MetalComputePipeline?
+var private g_pf_pso_moe_mm_q51 : MetalComputePipeline?
 var private g_pf_pso_moe_bias_rows : MetalComputePipeline?
 var private g_pf_e8m0_tab : MetalBuffer?
 var private g_mm_legacy = false             // set_metal_prefill_mulmm_legacy — tests' exact-parity rail
@@ -4300,7 +4470,7 @@ def public metal_prefill_shutdown {
                  g_pf_pso_moe_router, g_pf_pso_moe_router_b, g_pf_pso_moe_select, g_pf_pso_moe_count, g_pf_pso_moe_prefix,
                  g_pf_pso_moe_bucket, g_pf_pso_moe_reduce, g_pf_pso_moe_mm_q8, g_pf_pso_moe_mm_k4,
                  g_pf_pso_moe_mm_k5, g_pf_pso_moe_mm_k6, g_pf_pso_g4rnorm, g_pf_pso_moe_wscale, g_pf_pso_swiglu_oai,
-                 g_pf_pso_moe_mm_mx4, g_pf_pso_moe_bias_rows]) {
+                 g_pf_pso_moe_mm_mx4, g_pf_pso_moe_mm_q51, g_pf_pso_moe_bias_rows]) {
         if (pso != null) {
             metal_release(pso)
         }
@@ -4326,6 +4496,7 @@ def public metal_prefill_shutdown {
     g_pf_pso_moe_wscale = null
     g_pf_pso_swiglu_oai = null
     g_pf_pso_moe_mm_mx4 = null
+    g_pf_pso_moe_mm_q51 = null
     g_pf_pso_moe_bias_rows = null
     if (g_pf_e8m0_tab != null) {
         metal_release(g_pf_e8m0_tab)
@@ -4430,6 +4601,7 @@ def private metal_prefill_init : bool {
     g_pf_pso_moe_wscale = pf_compile_pso(metal_moe_wscale_msl, metal_moe_wscale_msl_entry, metal_moe_wscale_msl_fastmath, ok)
     g_pf_pso_swiglu_oai = pf_compile_pso(metal_swiglu_oai_msl, metal_swiglu_oai_msl_entry, metal_swiglu_oai_msl_fastmath, ok)
     g_pf_pso_moe_mm_mx4 = pf_compile_pso(metal_moe_mulmm_mx4_msl, metal_moe_mulmm_mx4_msl_entry, metal_moe_mulmm_mx4_msl_fastmath, ok)
+    g_pf_pso_moe_mm_q51 = pf_compile_pso(metal_moe_mulmm_q51_msl, metal_moe_mulmm_q51_msl_entry, metal_moe_mulmm_q51_msl_fastmath, ok)
     g_pf_pso_moe_bias_rows = pf_compile_pso(metal_moe_bias_rows_msl, metal_moe_bias_rows_msl_entry, metal_moe_bias_rows_msl_fastmath, ok)
     g_pf_pso_dn_conv = pf_compile_pso(metal_dn_conv_msl, metal_dn_conv_msl_entry, metal_dn_conv_msl_fastmath, ok)
     g_pf_pso_dn_hist = pf_compile_pso(metal_dn_conv_hist_msl, metal_dn_conv_hist_msl_entry, metal_dn_conv_hist_msl_fastmath, ok)
@@ -4733,6 +4905,23 @@ def private pf_enc_moe_mm(enc : MetalComputeEncoder?; t : Model; fmt : KqFmt; st
         metal_set_threadgroup_memory_length(enc, metal_moe_mulmm_q8_msl_tgmem, 0)
         metal_set_buffer(enc, bw.buf, bw.boff, 0)
         metal_set_buffer(enc, bw.buf, bw.boff, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bkdim, 0ul, 4)
+        metal_set_buffer(enc, bndim, 0ul, 5)
+        metal_set_buffer(enc, bcnt, 0ul, 6)
+        metal_set_buffer(enc, bbase, 0ul, 7)
+        metal_set_buffer(enc, bbkt, 0ul, 8)
+        metal_set_buffer(enc, bes, 0ul, 9)
+        metal_set_buffer(enc, bnk, 0ul, 10)
+        metal_set_buffer(enc, bgather, 0ul, 11)
+        metal_dispatch_threadgroups(enc, uint3(uint(tiles), uint(rows / 64l), uint(ne)), uint3(128u, 1u, 1u))
+    } elif (fmt == KqFmt.q51) {
+        let qp = q51_planes_of(g_pf_dev, t, stack_off)
+        metal_set_pipeline(enc, g_pf_pso_moe_mm_q51)
+        metal_set_threadgroup_memory_length(enc, metal_moe_mulmm_q51_msl_tgmem, 0)
+        metal_set_buffer(enc, qp.sbuf, qp.soff, 0)
+        metal_set_buffer(enc, qp.qbuf, qp.qoff, 1)
         metal_set_buffer(enc, bx, 0ul, 2)
         metal_set_buffer(enc, by, 0ul, 3)
         metal_set_buffer(enc, bkdim, 0ul, 4)
@@ -5804,9 +5993,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             pf_enc_moe_bias_rows(enc, bmg2, bwb3, bmcnt, bmbase, u_moe_nfe, c.n_ff_exp, npos, c.n_expert)
                         } else {
                             pf_enc_moe_mm(enc, t, fe1, t.we1_offs[l], c.n_ff_exp, npos, g4moe ? bxb2 : bxb, bmg,
-                                u_dim, u_moe_nfe, bmcnt, bmbase, bmbkt, fe1 == KqFmt.q8 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g1)
+                                u_dim, u_moe_nfe, bmcnt, bmbase, bmbkt, fe1 == KqFmt.q8 || fe1 == KqFmt.q51 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g1)
                             pf_enc_moe_mm(enc, t, fe3, t.we3_offs[l], c.n_ff_exp, npos, g4moe ? bxb2 : bxb, bmg2,
-                                u_dim, u_moe_nfe, bmcnt, bmbase, bmbkt, fe3 == KqFmt.q8 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g1)
+                                u_dim, u_moe_nfe, bmcnt, bmbase, bmbkt, fe3 == KqFmt.q8 || fe3 == KqFmt.q51 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g1)
                         }
                         if (nsh > 0l) {
                             // shexp gate/up: dense q8 mul_mm at the wsh planes (bhb/bhb2 sized max(hidden, nsh))
@@ -5834,7 +6023,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             pf_enc_moe_bias_rows(enc, bmdn, bwb2, bmcnt, bmbase, u_dim, dim, npos, c.n_expert)
                         } else {
                             pf_enc_moe_mm(enc, t, fe2, t.we2_offs[l], dim, npos, bmg, bmdn,
-                                u_moe_nfe, u_dim, bmcnt, bmbase, bmbkt, fe2 == KqFmt.q8 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g0)
+                                u_moe_nfe, u_dim, bmcnt, bmbase, bmbkt, fe2 == KqFmt.q8 || fe2 == KqFmt.q51 ? u_moe_eblk : u_moe_esb, u_moe_nk, u_moe_g0)
                         }
                         if (nsh > 0l) {
                             // shexp down into bxb2 (free post-residual) — bxb still feeds the reduce

--- a/modules/dasLLAMA/harness/parity.das
+++ b/modules/dasLLAMA/harness/parity.das
@@ -43,6 +43,9 @@ struct Args {
     @clarg_doc = "Native K-quant planes A/B: 1 = keep Q4_K/Q5_K/Q6_K packed at load, 0 = q8-requant fallback, -1 = keep default"
     kquant_native : int = -1
 
+    @clarg_doc = "GPU layers, llama-bench spelling: 0 = CPU, anything else = the whole graph on Metal, required (default: 0)"
+    ngl : int = 0
+
     @clarg_short = "?"
     @clarg_doc = "Show this help and exit"
     help : bool
@@ -76,7 +79,13 @@ def main {
     if (cfg.kquant_native >= 0) {   // load-time layout decision, must precede load_gguf
         set_kquant_native(cfg.kquant_native != 0)
     }
+    if (cfg.ngl != 0) {   // before load_model — pins the portable backend, activates the metal overrides
+        set_metal_mode(MetalMode.required)
+    }
     var t <- load_gguf(cfg.model, cfg.quant)
+    if (cfg.ngl != 0 && !convert_model_to_metal_blob(t)) {   // the Metal drivers serve blob-form models only
+        panic("dasLLAMA parity: metal-blob transform declined — cannot serve --ngl on this load")
+    }
     // Cap the KV context: only ~(prompt + n_gen) positions are used, and native seq_len (Llama-3 /
     // Phi / gemma4: 131072) would waste multi-GB KV allocations. Same cap test_parity.das applies.
     if (t.config.seq_len > 2048l) {

--- a/modules/dasLLAMA/harness/tune_kernels.das
+++ b/modules/dasLLAMA/harness/tune_kernels.das
@@ -2010,7 +2010,7 @@ def main {
         "dot_bf16" => "vec8_u2", "add_scale_inplace" => "vec8_u2",
         "axpy_tq4kv" => "vec8_u2", "cvt_tq4kv_to_f32" => "vec8_u2",
         "dot_q8tq4kv" => "vec16", "quantize_tq4kv_row" => "plain",
-        "dot_q8q8_f16s" => "vec16"
+        "dot_q8q8_f16s" => "vec16", "dot_q51e" => "vec16"
     }
     // upsert into the app sidecar (same resolution [tuned] reads from): the loop-hint winners
     // join the "kernels" section next to the [tune] generator perms, "runtime" is replaced —

--- a/modules/dasLLAMA/performance/establish_baselines.das
+++ b/modules/dasLLAMA/performance/establish_baselines.das
@@ -59,7 +59,7 @@ def llama_bench_bin(ngl : int) : string {
 // (n_gen=0 prefill, n_prompt=0 decode) into an LlmBaseline. prefill/emission stay -1 on failure.
 def bench_one(display, path : string; threads, nprompt, ngen, ngl : int) : LlmBaseline {
     // affinity args pin the bench to distinct physical cores on the boxes that pin (see profile_common)
-    let cmd = "{llama_bench_bin(ngl)} -m {path} -ngl {ngl} -t {threads}{lcpp_affinity_args(threads)} -p {nprompt} -n {ngen} -o json"
+    let cmd = "\"{llama_bench_bin(ngl)}\" -m \"{path}\" -ngl {ngl} -t {threads}{lcpp_affinity_args(threads)} -p {nprompt} -n {ngen} -o json"
     var rows : array<LlamaBenchRow>
     if (!run_llama_bench(cmd, rows)) {
         return LlmBaseline(model = display, prefill_tok_s = -1.0lf, emission_tok_s = -1.0lf, lcpp_commit = "", n_params = 0l)

--- a/modules/dasLLAMA/performance/establish_baselines.das
+++ b/modules/dasLLAMA/performance/establish_baselines.das
@@ -55,28 +55,13 @@ def llama_bench_bin(ngl : int) : string {
                      : "/Users/borisbatkin/Work/llama.cpp-clean/build/bin/llama-bench")
 }
 
-// The subset of llama-bench's `-o json` result object we consume. sscan_json ignores the rest.
-struct LlamaBenchRow {
-    n_prompt : int
-    n_gen : int
-    avg_ts : double
-    model_n_params : int64
-    build_commit : string
-}
-
-// Run llama-bench for one model and fold its two result rows (n_gen=0 prefill, n_prompt=0 decode) into
-// an LlmBaseline. prefill/emission stay -1 on a run or parse failure.
+// Run llama-bench for one model (via profile_common's shared runner) and fold its two result rows
+// (n_gen=0 prefill, n_prompt=0 decode) into an LlmBaseline. prefill/emission stay -1 on failure.
 def bench_one(display, path : string; threads, nprompt, ngen, ngl : int) : LlmBaseline {
     // affinity args pin the bench to distinct physical cores on the boxes that pin (see profile_common)
     let cmd = "{llama_bench_bin(ngl)} -m {path} -ngl {ngl} -t {threads}{lcpp_affinity_args(threads)} -p {nprompt} -n {ngen} -o json"
-    var out = ""
-    unsafe {
-        popen(cmd) $(f) {
-            out = fread_to_eof(f)
-        }
-    }
     var rows : array<LlamaBenchRow>
-    if (!sscan_json(out, rows)) {
+    if (!run_llama_bench(cmd, rows)) {
         return LlmBaseline(model = display, prefill_tok_s = -1.0lf, emission_tok_s = -1.0lf, lcpp_commit = "", n_params = 0l)
     }
     var prefill = -1.0lf

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -217,6 +217,7 @@ def main : int {
                 cmd = cmd,
                 sha = rows[0].build_commit,
                 source = "official",
+                exec_fmt = lcpp_exec_fmt(backend),
                 hardware = hw)
             for (row in rows) {
                 let tag = row.n_gen == 0 ? "pp{row.n_prompt}" : "tg{row.n_gen}"

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -53,18 +53,19 @@ struct Args {
 }
 
 // The public catalog: community-popular GGUFs, one popular quant each — NOT the internal quant
-// matrix. Absent files skip with a warning, so one list serves every box.
+// matrix. Curated to what people run THIS year (2026 spring/summer lists: Qwen3.6 family, gemma-4
+// daily drivers, the standing staples). Absent files skip with a warning, so one list serves
+// every box.
 def private pub_catalog() : array<string> {
     return <- [
-        "SmolLM2-135M-Instruct-Q8_0.gguf",
-        "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
-        "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
-        "Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",
-        "Mistral-7B-Instruct-v0.3-Q8_0.gguf",
-        "Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-        "gemma-3-4b-it-Q8_0.gguf",
+        "Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
+        "Qwen3.6-27B-MTP-Q4_K_M.gguf",
+        "gemma-4-26B-A4B-it-Q4_K_M.gguf",
+        "gemma-4-12B-it-Q4_K_M.gguf",
+        "gemma-4-E4B-it-Q8_0.gguf",
         "gpt-oss-20b-mxfp4.gguf",
-        "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf"
+        "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
+        "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf"
     ]
 }
 

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -1,0 +1,216 @@
+options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
+
+require profile_common
+require daslib/clargs
+require daslib/fio
+require math
+
+// The official record driver (modules/dasLLAMA/PUBLIC_BENCH_PLAN.md, step 3): loops the public
+// catalog x backends, runs lcpp_bench as a CHILD per cell (one model process at a time), and
+// upserts the --json-path records into the per-box store — written after EVERY cell, so a crash
+// never costs a measured cell. Ref rows ride along: the cpu cell carries the clean-cpu ref, the
+// metal cell the stock ref (-ngl 99), and a direct stock -ngl 0 pass adds the stock CPU row.
+//   bin/daslang modules/dasLLAMA/performance/gen_bench_records.das -- [-o substr] [--backend cpu|metal|all]
+// Ref binaries come from setup_lcpp_ref: --ref-clean/--ref-stock or LLAMA_BENCH_CLEAN/LLAMA_BENCH_STOCK.
+
+[CommandLineArgs]
+struct Args {
+    @clarg_short = "o"
+    @clarg_doc = "Only catalog entries whose filename contains this substring"
+    only : string
+
+    @clarg_doc = "Backends to measure: cpu | metal | all (default: all — metal on Apple boxes only)"
+    backend : string = "all"
+
+    @clarg_name = "ref-clean"
+    @clarg_doc = "clean-cpu llama-bench binary (default: env LLAMA_BENCH_CLEAN)"
+    ref_clean : string
+
+    @clarg_name = "ref-stock"
+    @clarg_doc = "stock llama-bench binary (default: env LLAMA_BENCH_STOCK)"
+    ref_stock : string
+
+    @clarg_short = "t"
+    @clarg_doc = "Worker threads (default: the box profile)"
+    threads : int = 0
+
+    @clarg_short = "p"
+    @clarg_doc = "Prompt tokens (default: 512)"
+    plen : int = 512
+
+    @clarg_short = "n"
+    @clarg_doc = "Generated tokens (default: 128)"
+    ngen : int = 128
+
+    @clarg_short = "r"
+    @clarg_doc = "Timed repetitions per row (default: 5)"
+    reps : int = 5
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+// The public catalog: community-popular GGUFs, one popular quant each — NOT the internal quant
+// matrix. Absent files skip with a warning, so one list serves every box.
+def private pub_catalog() : array<string> {
+    return <- [
+        "SmolLM2-135M-Instruct-Q8_0.gguf",
+        "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+        "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+        "Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",
+        "Mistral-7B-Instruct-v0.3-Q8_0.gguf",
+        "Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+        "gemma-3-4b-it-Q8_0.gguf",
+        "gpt-oss-20b-mxfp4.gguf",
+        "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf"
+    ]
+}
+
+def private daslang_bin() : string {
+    let env = get_env_variable("DASLANG_BIN")
+    return empty(env) ? "bin/daslang" : env
+}
+
+def private elapsed_ms(t0 : int64) : int {
+    return get_time_usec(t0) / 1000
+}
+
+// Stamp source and upsert every run of `cell` into the store, then persist.
+def private absorb_cell(var models : array<BenchModel>; var cell : array<BenchModel>; store : string) {
+    for (c in cell) {
+        for (r in c.runs) {
+            r.source = "official"
+        }
+        upsert_bench_model(models, c)
+    }
+    write_bench_records(store, models)
+}
+
+[export]
+def main : int {
+    var r <- parse_args(type<Args>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Args>), "gen_bench_records")
+        return 1
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Args>), "gen_bench_records")
+        return 0
+    }
+    let apple = is_apple_box()
+    var backends : array<string>
+    if (cfg.backend == "cpu" || cfg.backend == "all") {
+        backends |> push("cpu")
+    }
+    if (cfg.backend == "metal" || (cfg.backend == "all" && apple)) {
+        backends |> push("metal")
+    }
+    if (empty(backends)) {
+        to_log(LOG_ERROR, "gen_bench_records: no backends selected (--backend {cfg.backend})\n")
+        return 1
+    }
+    var refClean = empty(cfg.ref_clean) ? get_env_variable("LLAMA_BENCH_CLEAN") : cfg.ref_clean
+    var refStock = empty(cfg.ref_stock) ? get_env_variable("LLAMA_BENCH_STOCK") : cfg.ref_stock
+    if (!empty(refClean) && !stat(refClean).is_valid) {
+        to_log(LOG_WARNING, "gen_bench_records: clean-cpu ref `{refClean}` not found — cpu cells run das-only\n")
+        refClean = ""
+    }
+    if (!empty(refStock) && !stat(refStock).is_valid) {
+        to_log(LOG_WARNING, "gen_bench_records: stock ref `{refStock}` not found — no stock rows\n")
+        refStock = ""
+    }
+    mkdir_rec("modules/dasLLAMA/performance/records")
+    let store = bench_records_path()
+    var models : array<BenchModel>
+    read_bench_records(store, models)
+    let hw = gather_hardware()
+    let date = format_time(get_clock(), "%Y-%m-%d")
+    let box = box_name()
+    let threads = cfg.threads > 0 ? cfg.threads : profile_threads()
+    let cellPath = "modules/dasLLAMA/performance/records/_cell_{box}.json"
+    var failed : array<string>
+    var cat <- pub_catalog()
+    for (file in cat) {
+        if (!empty(cfg.only) && find(file, cfg.only) < 0) {
+            continue
+        }
+        let path = "{models_dir()}{file}"
+        if (!stat(path).is_valid) {
+            to_log(LOG_WARNING, "gen_bench_records: SKIP {file} — not on this box\n")
+            continue
+        }
+        for (be in backends) {
+            let t0 = ref_time_ticks()
+            to_log(LOG_INFO, "gen_bench_records: START {file} {be}\n")
+            var args <- [daslang_bin(), "-jit", "modules/dasLLAMA/benchmarks/lcpp_bench.das", "--",
+                         "-m", path, "-p", "{cfg.plen}", "-n", "{cfg.ngen}", "-r", "{cfg.reps}",
+                         "-t", "{threads}", "-o", "json", "--json-path", cellPath]
+            if (be == "metal") {
+                args |> push("--ngl")
+                args |> push("99")
+            }
+            let ref = be == "metal" ? refStock : refClean
+            if (!empty(ref)) {
+                args |> push("--ref")
+                args |> push(ref)
+                args |> push("--ref-flavor")
+                args |> push(be == "metal" ? "stock" : "clean-cpu")
+            }
+            var out = ""
+            let rc = run_and_capture(args, out)
+            var cell : array<BenchModel>
+            if (rc != 0 || !read_bench_records(cellPath, cell)) {
+                let tail = slice(out, max(0, length(out) - 400))
+                to_log(LOG_ERROR, "gen_bench_records: FAILED {file} {be} rc={rc} ({elapsed_ms(t0)} ms) — tail: {tail}\n")
+                failed |> push("{file} {be}")
+                continue
+            }
+            absorb_cell(models, cell, store)
+            remove(cellPath)
+            to_log(LOG_INFO, "gen_bench_records: DONE {file} {be} ({elapsed_ms(t0)} ms)\n")
+        }
+        // the stock CPU row — llama.cpp as shipped (Accelerate on macOS), -ngl 0, direct
+        if (!empty(refStock)) {
+            let t0 = ref_time_ticks()
+            let aff = affinity_on() ? lcpp_affinity_args(threads) : ""
+            let cmd = "{refStock} -m {path} -ngl 0 -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {cfg.reps} -o json"
+            to_log(LOG_INFO, "gen_bench_records: START {file} cpu stock ref\n")
+            var rows : array<LlamaBenchRow>
+            if (!run_llama_bench(cmd, rows)) {
+                to_log(LOG_ERROR, "gen_bench_records: FAILED {file} stock cpu ref ({elapsed_ms(t0)} ms)\n")
+                failed |> push("{file} cpu stock-ref")
+                continue
+            }
+            var rr = BenchRun(
+                engine = "llama.cpp",
+                backend = "cpu",
+                flavor = "stock",
+                box = box,
+                threads = threads,
+                date = date,
+                cmd = cmd,
+                sha = rows[0].build_commit,
+                source = "official",
+                hardware = hw)
+            for (row in rows) {
+                let tag = row.n_gen == 0 ? "pp{row.n_prompt}" : "tg{row.n_gen}"
+                rr.tests |> insert(tag, BenchTest(tok_s = row.avg_ts, stddev = row.stddev_ts))
+            }
+            var bm = BenchModel(gguf = file, params_b = double(rows[0].model_n_params) / 1.0e9lf)
+            bm.runs |> emplace(rr)
+            upsert_bench_model(models, bm)
+            write_bench_records(store, models)
+            to_log(LOG_INFO, "gen_bench_records: DONE {file} cpu stock ref ({elapsed_ms(t0)} ms)\n")
+        }
+    }
+    if (!empty(failed)) {
+        let list = join(failed, ", ")
+        to_log(LOG_ERROR, "gen_bench_records: {length(failed)} FAILED cell(s): {list}\n")
+        return 1
+    }
+    return 0
+}

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -52,20 +52,27 @@ struct Args {
     help : bool
 }
 
+struct private PubEntry {
+    file : string
+    note : string   // board caveat, stamped into the model record ("" = none)
+}
+
 // The public catalog: community-popular GGUFs, one popular quant each — NOT the internal quant
 // matrix. Curated to what people run THIS year (2026 spring/summer lists: Qwen3.6 family, gemma-4
 // daily drivers, the standing staples). Absent files skip with a warning, so one list serves
 // every box.
-def private pub_catalog() : array<string> {
+def private pub_catalog() : array<PubEntry> {
     return <- [
-        "Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
-        "Qwen3.6-27B-MTP-Q4_K_M.gguf",
-        "gemma-4-26B-A4B-it-Q4_K_M.gguf",
-        "gemma-4-12B-it-Q4_K_M.gguf",
-        "gemma-4-E4B-it-Q8_0.gguf",
-        "gpt-oss-20b-mxfp4.gguf",
-        "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
-        "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf"
+        PubEntry(file = "Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf"),
+        PubEntry(file = "Qwen3.6-27B-MTP-Q4_K_M.gguf"),
+        PubEntry(file = "gemma-4-26B-A4B-it-Q8_0.gguf",
+            note = "the widespread Q4_K_M file stores its expert tensors as Q5_1, which das does not run yet — benched at Q8_0 until that lands"),
+        PubEntry(file = "gemma-4-12B-it-Q4_K_M.gguf"),
+        PubEntry(file = "gemma-4-E4B-it-Q8_0.gguf",
+            note = "das Metal decode does not serve the E-series graph yet — das rows are CPU only"),
+        PubEntry(file = "gpt-oss-20b-mxfp4.gguf"),
+        PubEntry(file = "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf"),
+        PubEntry(file = "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf")
     ]
 }
 
@@ -78,11 +85,14 @@ def private elapsed_ms(t0 : int64) : int {
     return get_time_usec(t0) / 1000
 }
 
-// Stamp source and upsert every run of `cell` into the store, then persist.
-def private absorb_cell(var models : array<BenchModel>; var cell : array<BenchModel>; store : string) {
+// Stamp source + the catalog note and upsert every run of `cell` into the store, then persist.
+def private absorb_cell(var models : array<BenchModel>; var cell : array<BenchModel>; store, note : string) {
     for (c in cell) {
         for (r in c.runs) {
             r.source = "official"
+        }
+        if (!empty(note)) {
+            c.note = note
         }
         upsert_bench_model(models, c)
     }
@@ -133,9 +143,11 @@ def main : int {
     let box = box_name()
     let threads = cfg.threads > 0 ? cfg.threads : profile_threads()
     let cellPath = "modules/dasLLAMA/performance/records/_cell_{box}.json"
+    let hasMetal = !empty(backends) && backends[length(backends) - 1] == "metal"
     var failed : array<string>
     var cat <- pub_catalog()
-    for (file in cat) {
+    for (ent in cat) {
+        let file = ent.file
         if (!empty(cfg.only) && find(file, cfg.only) < 0) {
             continue
         }
@@ -146,7 +158,7 @@ def main : int {
         }
         for (be in backends) {
             let t0 = ref_time_ticks()
-            to_log(LOG_INFO, "gen_bench_records: START {file} {be}\n")
+            to_log(LOG_INFO, "gen_bench_records: START {file} das {be}\n")
             var args <- [daslang_bin(), "-jit", "modules/dasLLAMA/benchmarks/lcpp_bench.das", "--",
                          "-m", path, "-p", "{cfg.plen}", "-n", "{cfg.ngen}", "-r", "{cfg.reps}",
                          "-t", "{threads}", "-o", "json", "--json-path", cellPath]
@@ -154,42 +166,43 @@ def main : int {
                 args |> push("--ngl")
                 args |> push("99")
             }
-            let ref = be == "metal" ? refStock : refClean
-            if (!empty(ref)) {
-                args |> push("--ref")
-                args |> push(ref)
-                args |> push("--ref-flavor")
-                args |> push(be == "metal" ? "stock" : "clean-cpu")
-            }
             var out = ""
             let rc = run_and_capture(args, out)
             var cell : array<BenchModel>
             if (rc != 0 || !read_bench_records(cellPath, cell)) {
                 let tail = slice(out, max(0, length(out) - 400))
-                to_log(LOG_ERROR, "gen_bench_records: FAILED {file} {be} rc={rc} ({elapsed_ms(t0)} ms) — tail: {tail}\n")
-                failed |> push("{file} {be}")
+                to_log(LOG_ERROR, "gen_bench_records: FAILED {file} das {be} rc={rc} ({elapsed_ms(t0)} ms) — tail: {tail}\n")
+                failed |> push("{file} das {be}")
                 continue
             }
-            absorb_cell(models, cell, store)
+            absorb_cell(models, cell, store, ent.note)
             remove(cellPath)
-            to_log(LOG_INFO, "gen_bench_records: DONE {file} {be} ({elapsed_ms(t0)} ms)\n")
+            to_log(LOG_INFO, "gen_bench_records: DONE {file} das {be} ({elapsed_ms(t0)} ms)\n")
         }
-        // the stock CPU row — llama.cpp as shipped (Accelerate on macOS), -ngl 0, direct
-        if (!empty(refStock)) {
+        // reference rows run independently of the das cells — a das capability gap must not cost
+        // the board its llama.cpp rows (or vice versa)
+        for (rp in range(3)) {
+            let bin = rp == 0 ? refClean : refStock
+            let ngl = rp == 2 ? 99 : 0
+            let flavor = rp == 0 ? "clean-cpu" : "stock"
+            if (empty(bin) || (ngl != 0 && !hasMetal)) {
+                continue
+            }
+            let backend = ngl != 0 ? "metal" : "cpu"
             let t0 = ref_time_ticks()
-            let aff = affinity_on() ? lcpp_affinity_args(threads) : ""
-            let cmd = "{refStock} -m {path} -ngl 0 -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {cfg.reps} -o json"
-            to_log(LOG_INFO, "gen_bench_records: START {file} cpu stock ref\n")
+            let aff = ngl == 0 && affinity_on() ? lcpp_affinity_args(threads) : ""
+            let cmd = "{bin} -m {path} -ngl {ngl} -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {cfg.reps} -o json"
+            to_log(LOG_INFO, "gen_bench_records: START {file} ref {flavor} {backend}\n")
             var rows : array<LlamaBenchRow>
-            if (!run_llama_bench(cmd, rows)) {
-                to_log(LOG_ERROR, "gen_bench_records: FAILED {file} stock cpu ref ({elapsed_ms(t0)} ms)\n")
-                failed |> push("{file} cpu stock-ref")
+            if (!run_llama_bench(cmd, rows) || empty(rows)) {
+                to_log(LOG_ERROR, "gen_bench_records: FAILED {file} ref {flavor} {backend} ({elapsed_ms(t0)} ms)\n")
+                failed |> push("{file} ref {flavor} {backend}")
                 continue
             }
             var rr = BenchRun(
                 engine = "llama.cpp",
-                backend = "cpu",
-                flavor = "stock",
+                backend = backend,
+                flavor = flavor,
                 box = box,
                 threads = threads,
                 date = date,
@@ -201,11 +214,11 @@ def main : int {
                 let tag = row.n_gen == 0 ? "pp{row.n_prompt}" : "tg{row.n_gen}"
                 rr.tests |> insert(tag, BenchTest(tok_s = row.avg_ts, stddev = row.stddev_ts))
             }
-            var bm = BenchModel(gguf = file, params_b = double(rows[0].model_n_params) / 1.0e9lf)
+            var bm = BenchModel(gguf = file, params_b = double(rows[0].model_n_params) / 1.0e9lf, note = ent.note)
             bm.runs |> emplace(rr)
             upsert_bench_model(models, bm)
             write_bench_records(store, models)
-            to_log(LOG_INFO, "gen_bench_records: DONE {file} cpu stock ref ({elapsed_ms(t0)} ms)\n")
+            to_log(LOG_INFO, "gen_bench_records: DONE {file} ref {flavor} {backend} ({elapsed_ms(t0)} ms)\n")
         }
     }
     if (!empty(failed)) {

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -65,8 +65,7 @@ def private pub_catalog() : array<PubEntry> {
     return <- [
         PubEntry(file = "Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf"),
         PubEntry(file = "Qwen3.6-27B-MTP-Q4_K_M.gguf"),
-        PubEntry(file = "gemma-4-26B-A4B-it-Q8_0.gguf",
-            note = "the widespread Q4_K_M file stores its expert tensors as Q5_1, which das does not run yet — benched at Q8_0 until that lands"),
+        PubEntry(file = "gemma-4-26B-A4B-it-Q4_K_M.gguf"),
         PubEntry(file = "gemma-4-12B-it-Q4_K_M.gguf"),
         PubEntry(file = "gemma-4-E4B-it-Q8_0.gguf"),
         PubEntry(file = "gpt-oss-20b-mxfp4.gguf"),

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -68,8 +68,7 @@ def private pub_catalog() : array<PubEntry> {
         PubEntry(file = "gemma-4-26B-A4B-it-Q8_0.gguf",
             note = "the widespread Q4_K_M file stores its expert tensors as Q5_1, which das does not run yet — benched at Q8_0 until that lands"),
         PubEntry(file = "gemma-4-12B-it-Q4_K_M.gguf"),
-        PubEntry(file = "gemma-4-E4B-it-Q8_0.gguf",
-            note = "das Metal decode does not serve the E-series graph yet — das rows are CPU only"),
+        PubEntry(file = "gemma-4-E4B-it-Q8_0.gguf"),
         PubEntry(file = "gpt-oss-20b-mxfp4.gguf"),
         PubEntry(file = "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf"),
         PubEntry(file = "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf")
@@ -91,12 +90,21 @@ def private absorb_cell(var models : array<BenchModel>; var cell : array<BenchMo
         for (r in c.runs) {
             r.source = "official"
         }
-        if (!empty(note)) {
-            c.note = note
-        }
         upsert_bench_model(models, c)
+        stamp_note(models, c.gguf, note)
     }
     write_bench_records(store, models)
+}
+
+// The catalog OWNS the note — stamp it verbatim after upsert (upsert's merge never clears, so a
+// resolved caveat would otherwise stick to the stored record forever).
+def private stamp_note(var models : array<BenchModel>; gguf, note : string) {
+    for (m in models) {
+        if (m.gguf == gguf) {
+            m.note = note
+            return
+        }
+    }
 }
 
 [export]
@@ -217,6 +225,7 @@ def main : int {
             var bm = BenchModel(gguf = file, params_b = double(rows[0].model_n_params) / 1.0e9lf, note = ent.note)
             bm.runs |> emplace(rr)
             upsert_bench_model(models, bm)
+            stamp_note(models, file, ent.note)
             write_bench_records(store, models)
             to_log(LOG_INFO, "gen_bench_records: DONE {file} ref {flavor} {backend} ({elapsed_ms(t0)} ms)\n")
         }

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -198,7 +198,7 @@ def main : int {
             let backend = ngl != 0 ? "metal" : "cpu"
             let t0 = ref_time_ticks()
             let aff = ngl == 0 && affinity_on() ? lcpp_affinity_args(threads) : ""
-            let cmd = "{bin} -m {path} -ngl {ngl} -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {cfg.reps} -o json"
+            let cmd = "\"{bin}\" -m \"{path}\" -ngl {ngl} -t {threads}{aff} -p {cfg.plen} -n {cfg.ngen} -r {cfg.reps} -o json"
             to_log(LOG_INFO, "gen_bench_records: START {file} ref {flavor} {backend}\n")
             var rows : array<LlamaBenchRow>
             if (!run_llama_bench(cmd, rows) || empty(rows)) {

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -120,6 +120,10 @@ def main : int {
         return 0
     }
     let apple = is_apple_box()
+    if (cfg.backend == "metal" && !apple) {   // fail fast instead of running metal cells that all decline on non-Apple boxes
+        to_log(LOG_ERROR, "gen_bench_records: --backend metal requested on a non-Apple box — Metal is macOS-only\n")
+        return 1
+    }
     var backends : array<string>
     if (cfg.backend == "cpu" || cfg.backend == "all") {
         backends |> push("cpu")

--- a/modules/dasLLAMA/performance/gen_site_records.das
+++ b/modules/dasLLAMA/performance/gen_site_records.das
@@ -1,0 +1,51 @@
+options gen2
+options stack = 65536   // dasLLAMA program-root convention (options stack does not unify up from libs)
+
+require profile_common
+require daslib/fio
+require strings
+
+// Merge every per-box record store (performance/records/<box>.json) into the one file the site
+// renders: site/files/dasllama/bench_records.json. Boxes never collide on the run key (box is part
+// of it), so the merge is a pure upsert; run after any gen_bench_records sweep, commit both.
+//   bin/daslang modules/dasLLAMA/performance/gen_site_records.das
+
+let RECORDS_DIR = "modules/dasLLAMA/performance/records"
+let SITE_PATH = "site/files/dasllama/bench_records.json"
+
+def private list_stores() : array<string> {
+    var out : array<string>
+    dir(RECORDS_DIR) $(fn) {
+        if (ends_with(fn, ".json") && !starts_with(fn, "_")) {
+            out |> push("{RECORDS_DIR}/{fn}")
+        }
+    }
+    sort(out)
+    return <- out
+}
+
+[export]
+def main : int {
+    var merged : array<BenchModel>
+    var stores <- list_stores()
+    if (empty(stores)) {
+        to_log(LOG_ERROR, "gen_site_records: no stores under {RECORDS_DIR} — run gen_bench_records first\n")
+        return 1
+    }
+    for (path in stores) {
+        var models : array<BenchModel>
+        if (!read_bench_records(path, models)) {
+            to_log(LOG_ERROR, "gen_site_records: cannot parse {path}\n")
+            return 1
+        }
+        let n = length(models)
+        to_log(LOG_INFO, "gen_site_records: {path} — {n} model(s)\n")
+        for (m in models) {
+            upsert_bench_model(merged, m)
+        }
+    }
+    write_bench_records(SITE_PATH, merged)
+    let total = length(merged)
+    to_log(LOG_INFO, "gen_site_records: wrote {SITE_PATH} — {total} model(s)\n")
+    return 0
+}

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -16,6 +16,7 @@ require daslib/strings_boost public
 require daslib/logger public              // structured, ISO-8601-timestamped ndjson event log
 require daslib/json public                // JV(...) for logger field payloads
 require dasllama/dasllama_common public   // QuantMode
+require dasllama/dasllama_math            // active_kernel_backend — the exec_fmt layout receipt
 require llvm/daslib/llvm_tune             // tune_status — stamp provenance for the platform block
 
 // ===== Box + model roots =====
@@ -190,6 +191,60 @@ def active_params_b(t : Model) : double {
         p += c.dim * c.vocab_size                          // untied classifier
     }
     return double(p) / 1.0e9lf
+}
+
+def private exec_fmt_add(var seen : table<string>; a : array<KqFmt>) {
+    if (empty(a)) {
+        seen |> insert("q8")
+        return
+    }
+    for (f in a) {
+        seen |> insert("{f}")
+    }
+}
+
+//! What this loaded das Model EXECUTES — per-site weight formats, activation/scale treatment,
+//! and the weight layout — the bench record's apples-to-apples receipt (`BenchRun.exec_fmt`).
+//! A kq entry (k4/k5/k6/q40) means the DISK format runs natively; q8 planes on a K-quant file
+//! are tensors the file itself ships as Q8_0 (norms/embeddings ride fblob, not listed).
+def model_exec_fmt(t : Model) : string {
+    if (t.quant != QuantMode.q8) {
+        return quant_str(t.quant)
+    }
+    var seen : table<string>
+    exec_fmt_add(seen, t.wq_fmt)
+    exec_fmt_add(seen, t.wk_fmt)
+    exec_fmt_add(seen, t.wv_fmt)
+    exec_fmt_add(seen, t.wo_fmt)
+    exec_fmt_add(seen, t.w1_fmt)
+    exec_fmt_add(seen, t.w2_fmt)
+    exec_fmt_add(seen, t.w3_fmt)
+    if (t.experts_mx4) {
+        seen |> insert("mxfp4")
+    } elif (t.config.moe) {
+        exec_fmt_add(seen, t.we1_fmt)
+        exec_fmt_add(seen, t.we2_fmt)
+        exec_fmt_add(seen, t.we3_fmt)
+    }
+    seen |> insert("{t.config.shared_weights ? t.emb_fmt : t.wcls_fmt}")
+    var names <- [for (k in keys(seen)); k]
+    sort(names)
+    let weights = join(names, "/")
+    let scales = t.wscale_f16 ? "f16 scales" : "f32 scales"
+    var layout = "planar {active_kernel_backend()}"
+    if (t.metal_blob) {
+        layout = "metal blob"
+    } elif (t.kq_repacked || t.mx4_repacked) {
+        layout = "planar {active_kernel_backend()} (repacked)"
+    }
+    return "weights {weights} native; q8 activations; {scales}; {layout}"
+}
+
+//! The llama.cpp sibling's execution receipt, derived from the build flavor: every gguf tensor
+//! runs in its disk format; the cpu backend additionally layout-repacks supported types at load
+//! (GGML_CPU_REPACK is ON in both pinned ref flavors).
+def lcpp_exec_fmt(backend : string) : string {
+    return backend == "cpu" ? "native gguf formats; cpu runtime layout repack" : "native gguf formats"
 }
 
 //! True when `m` is present on disk AND in the requested tier. `sz` receives the file size (0 if absent).
@@ -821,6 +876,9 @@ struct BenchRun {
     @optional sha : string      // engine commit (das: git HEAD; llama.cpp: build_commit)
     @optional version : string  // das release version
     @optional tune : string     // das gen-kernel stamp provenance — required for reproducibility
+    @optional exec_fmt : string // what this engine EXECUTES for this file (weight formats per site
+                                // class + activation/scale treatment) — the apples-to-apples receipt;
+                                // das derives it from the loaded Model, llama.cpp rows from flavor
 }
 
 //! One GGUF's identity plus every run measured against it. `gguf` (the exact filename) is the

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -833,6 +833,7 @@ struct BenchModel {
     @optional params_b : double    // total parameters, from llama-bench's model_n_params
     @optional active_b : double    // per-token active parameters (MoE-aware), from Config geometry
     @optional size_bytes : int64
+    @optional note : string        // board caveat for this model (quant substitution, capability gap)
 }
 
 //! True on a macOS box — the gate for Metal cells in the record driver.
@@ -892,6 +893,9 @@ def upsert_bench_model(var models : array<BenchModel>; var incoming : BenchModel
             }
             if (incoming.size_bytes > 0l) {
                 m.size_bytes = incoming.size_bytes
+            }
+            if (!empty(incoming.note)) {
+                m.note = incoming.note
             }
             for (i in range(length(incoming.runs))) {
                 upsert_bench_run(m.runs, incoming.runs[i])

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -327,6 +327,138 @@ def gather_platform(threads : int; llama_cpp, date, box_profile : string; parsec
         tune = tune_summary())
 }
 
+// ===== Hardware block (public bench records — see modules/dasLLAMA/PUBLIC_BENCH_PLAN.md) =====
+
+//! Auto-gathered hardware identity for a public bench record. Always probed, never typed by the
+//! submitter — community records depend on this block being trustworthy. Probes are best-effort
+//! per OS; a field the box cannot answer is omitted (`@optional`). Env overrides for boxes with
+//! no clean probe: DASLLAMA_CPU, DASLLAMA_OS, DASLLAMA_GPU_NAME, DASLLAMA_RAM_GB.
+struct HardwareInfo {
+    cpu : string
+    arch : string
+    os : string
+    @optional perf_cores : int    // performance cores (Apple asymmetric SoCs); 0 elsewhere
+    @optional total_cores : int   // physical on macOS, logical on Windows/Linux (best-effort)
+    @optional ram_gb : int
+    @optional gpu : string
+}
+
+def private is_macos() : bool {
+    return !is_windows() && run_capture("uname -s", true) == "Darwin"
+}
+
+def private platform_arch() : string {
+    if (is_windows()) {
+        return get_env_variable("PROCESSOR_ARCHITECTURE")
+    }
+    return run_capture("uname -m", true)
+}
+
+def private win_env_int(name : string) : int {
+    return to_int(get_env_variable(name))
+}
+
+def private platform_ram_gb() : int {
+    let ov = get_env_variable("DASLLAMA_RAM_GB")
+    if (!empty(ov)) {
+        return to_int(ov)
+    }
+    let gib = 1024.0 * 1024.0 * 1024.0
+    if (is_windows()) {
+        // wmic emits "TotalPhysicalMemory=68632934400"
+        let raw = run_capture("wmic ComputerSystem get TotalPhysicalMemory /value", false)
+        for (ln in split(raw, "\n")) {
+            let i = find(ln, "=")
+            if (i >= 0 && find(ln, "TotalPhysicalMemory") >= 0) {
+                return int(to_float(strip(slice(ln, i + 1))) / gib + 0.5)
+            }
+        }
+        return 0
+    }
+    if (is_macos()) {
+        return int(to_float(run_capture("sysctl -n hw.memsize", true)) / gib + 0.5)
+    }
+    // linux /proc/meminfo: "MemTotal:       131842348 kB"
+    let ln = run_capture("grep MemTotal /proc/meminfo", true)
+    let i = find(ln, ":")
+    if (i < 0) {
+        return 0
+    }
+    let toks <- split(strip(slice(ln, i + 1)), " ")
+    return empty(toks) ? 0 : int(to_float(toks[0]) / (1024.0 * 1024.0) + 0.5)
+}
+
+// after-colon tail of the first line of `raw` containing `key`; "" when absent
+def private line_value(raw, key : string) : string {
+    for (ln in split(raw, "\n")) {
+        let k = find(ln, key)
+        if (k >= 0) {
+            let c = find(ln, ":", k)
+            if (c >= 0) {
+                return strip(slice(ln, c + 1))
+            }
+        }
+    }
+    return ""
+}
+
+def private platform_gpu() : string {
+    let ov = get_env_variable("DASLLAMA_GPU_NAME")
+    if (!empty(ov)) {
+        return ov
+    }
+    if (is_windows()) {
+        let raw = run_capture("wmic path win32_VideoController get name /value", false)
+        for (ln in split(raw, "\n")) {
+            let i = find(ln, "Name=")
+            if (i >= 0) {
+                return strip(slice(ln, i + length("Name=")))
+            }
+        }
+        return ""
+    }
+    if (is_macos()) {
+        let raw = run_capture("system_profiler SPDisplaysDataType", false)
+        let chip = line_value(raw, "Chipset Model")
+        let cores = line_value(raw, "Total Number of Cores")
+        if (empty(chip)) {
+            return ""
+        }
+        return empty(cores) ? chip : "{chip} ({cores}-core)"
+    }
+    let ln = run_capture("lspci | grep -iE \"vga|3d\"", true)
+    let i = find(ln, ": ")
+    return i >= 0 ? strip(slice(ln, i + 2)) : ""
+}
+
+def private platform_cores() : tuple<perf : int; total : int> {
+    if (is_windows()) {
+        return (perf = 0, total = win_env_int("NUMBER_OF_PROCESSORS"))
+    }
+    if (is_macos()) {
+        return (
+            perf = to_int(run_capture("sysctl -n hw.perflevel0.physicalcpu", true)),
+            total = to_int(run_capture("sysctl -n hw.physicalcpu", true)))
+    }
+    return (perf = 0, total = to_int(run_capture("nproc", true)))
+}
+
+//! Probe this box's hardware identity (see `HardwareInfo`). One-shot — a handful of child
+//! processes; call once per run, not per row.
+def gather_hardware : HardwareInfo {
+    let cpu = platform_cpu()
+    let os = platform_os()
+    let cores = platform_cores()
+    return HardwareInfo(
+        cpu = empty(cpu) ? "unknown" : cpu,
+        arch = platform_arch(),
+        os = empty(os) ? "unknown" : os,
+        perf_cores = cores.perf,
+        total_cores = cores.total,
+        ram_gb = platform_ram_gb(),
+        gpu = platform_gpu())
+}
+
 // ===== Baseline TSV I/O (reference tok/s the establisher writes, the generator reads) =====
 
 //! One reference-tool baseline row for a model: llama.cpp prefill / emission tok/s (CPU), the lcpp
@@ -661,4 +793,68 @@ def upsert_asr(var tests : array<AsrRec>; var rec : AsrRec) {
         }
     }
     tests |> emplace(rec)
+}
+
+// ===== Public bench records (modules/dasLLAMA/PUBLIC_BENCH_PLAN.md) =====
+
+//! One measured test row, keyed in `BenchRun.tests` by the llama-bench test name
+//! ("pp512", "tg128", ...): mean tok/s over the timed reps ± sample stdev.
+struct BenchTest {
+    tok_s : double
+    @optional stddev : double
+}
+
+//! One engine × backend × flavor run on one box — a first-class record. das and llama.cpp runs
+//! are siblings in the same store; pairing and ratios are derived at render time, never stored.
+//! `cmd` is the reproduction receipt: the exact invocation that produced the numbers.
+struct BenchRun {
+    engine : string          // "das" | "llama.cpp"
+    backend : string         // "cpu" | "metal" | "vulkan"
+    flavor : string          // das: "tuned"; llama.cpp build flavor: "stock" | "clean-cpu"
+    box : string
+    threads : int
+    date : string            // YYYY-MM-DD
+    cmd : string
+    hardware : HardwareInfo
+    tests : table<string; BenchTest>
+    @optional source : string   // "official" | "community" — stamped by the store driver, not the tool
+    @optional sha : string      // engine commit (das: git HEAD; llama.cpp: build_commit)
+    @optional version : string  // das release version
+    @optional tune : string     // das gen-kernel stamp provenance — required for reproducibility
+}
+
+//! One GGUF's identity plus every run measured against it. `gguf` (the exact filename) is the
+//! store's primary key — it pins weights and quant.
+struct BenchModel {
+    gguf : string
+    runs : array<BenchRun>
+    @optional arch : string
+    @optional quant : string
+    @optional params_b : double    // total parameters, from llama-bench's model_n_params
+    @optional active_b : double    // per-token active parameters (MoE-aware), from Config geometry
+    @optional size_bytes : int64
+}
+
+// ===== llama-bench invocation (shared by lcpp_bench --ref and the establisher) =====
+
+//! One llama-bench `-o json` result row (prefill rows have n_gen=0, decode rows n_prompt=0).
+struct LlamaBenchRow {
+    n_prompt : int
+    n_gen : int
+    avg_ts : double
+    @optional stddev_ts : double
+    model_n_params : int64
+    build_commit : string
+}
+
+//! Run a llama-bench command line (must include `-o json`) and parse its rows. False on a run or
+//! parse failure. Stdout only — llama-bench keeps progress on stderr, so the pipe stays clean.
+def run_llama_bench(cmd : string; var rows : array<LlamaBenchRow>) : bool {
+    var out = ""
+    unsafe {
+        popen(cmd) $(f) {
+            out = fread_to_eof(f)
+        }
+    }
+    return sscan_json(out, rows)
 }

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -205,7 +205,7 @@ def private exec_fmt_add(var seen : table<string>; a : array<KqFmt>) {
 
 //! What this loaded das Model EXECUTES — per-site weight formats, activation/scale treatment,
 //! and the weight layout — the bench record's apples-to-apples receipt (`BenchRun.exec_fmt`).
-//! A kq entry (k4/k5/k6/q40) means the DISK format runs natively; q8 planes on a K-quant file
+//! A kq entry (k4/k5/k6/q40/q51) means the DISK format runs natively; q8 planes on a K-quant file
 //! are tensors the file itself ships as Q8_0 (norms/embeddings ride fblob, not listed).
 def model_exec_fmt(t : Model) : string {
     if (t.quant != QuantMode.q8) {

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -32,7 +32,12 @@ def public prof_log_name() : string {
 // Machine-local model root; override with DASLLAMA_MODELS_DIR (the x64/handoff boxes).
 def models_dir() : string {
     let env = get_env_variable("DASLLAMA_MODELS_DIR")
-    return empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+    if (empty(env)) {
+        return "/Users/borisbatkin/Work/llama.cpp/models/"
+    }
+    // callers concat "{models_dir()}{file}" — guarantee the separator so a slashless override
+    // (DASLLAMA_MODELS_DIR=/models) doesn't silently skip every catalog file
+    return ends_with(env, "/") || ends_with(env, "\\") ? env : "{env}/"
 }
 
 // Short box tag baked into the JSON/TSV filenames (profile_llm_<box>.json). Override with DASLLAMA_BOX.
@@ -344,7 +349,9 @@ def private platform_os() : string {
     if (is_windows()) {
         return run_capture("ver", true)
     }
-    return "{run_capture("sw_vers -productName", true)} {run_capture("sw_vers -productVersion", true)}"
+    // sw_vers is macOS-only; on Linux both probes return "" and the join is a lone space —
+    // strip so empty()==true and the record stores "unknown" (or set DASLLAMA_OS on those boxes)
+    return strip("{run_capture("sw_vers -productName", true)} {run_capture("sw_vers -productVersion", true)}")
 }
 
 def private tune_row_str(r : TuneStatus) : string {

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -835,6 +835,73 @@ struct BenchModel {
     @optional size_bytes : int64
 }
 
+//! True on a macOS box — the gate for Metal cells in the record driver.
+def is_apple_box : bool {
+    return !is_windows() && run_capture("uname -s", true) == "Darwin"
+}
+
+//! The official per-box record store the site build merges.
+def bench_records_path : string {
+    return "modules/dasLLAMA/performance/records/{box_name()}.json"
+}
+
+def read_bench_records(path : string; var models : array<BenchModel>) : bool {
+    if (!stat(path).is_valid) {
+        return false
+    }
+    return sscan_json(fread(path), models)
+}
+
+def write_bench_records(path : string; models : array<BenchModel>) {
+    let text = sprint_json(models, true)
+    fopen(path, "wb") $(f) {
+        if (f != null) {
+            fwrite(f, text)
+        }
+    }
+}
+
+//! Update-or-insert one run; the identity is (box, engine, backend, flavor) — a re-measure
+//! replaces its row in place (fresh date/sha), never appends a superseded copy.
+def upsert_bench_run(var runs : array<BenchRun>; var r : BenchRun) {
+    for (c in runs) {
+        if (c.box == r.box && c.engine == r.engine && c.backend == r.backend && c.flavor == r.flavor) {
+            c <- r
+            return
+        }
+    }
+    runs |> emplace(r)
+}
+
+//! Merge one incoming model (e.g. a --json-path cell from lcpp_bench) into the store: identity
+//! fields refresh when the incoming side knows them, runs upsert per (box, engine, backend, flavor).
+def upsert_bench_model(var models : array<BenchModel>; var incoming : BenchModel) {
+    for (m in models) {
+        if (m.gguf == incoming.gguf) {
+            if (!empty(incoming.arch)) {
+                m.arch = incoming.arch
+            }
+            if (!empty(incoming.quant)) {
+                m.quant = incoming.quant
+            }
+            if (incoming.params_b > 0.0lf) {
+                m.params_b = incoming.params_b
+            }
+            if (incoming.active_b > 0.0lf) {
+                m.active_b = incoming.active_b
+            }
+            if (incoming.size_bytes > 0l) {
+                m.size_bytes = incoming.size_bytes
+            }
+            for (i in range(length(incoming.runs))) {
+                upsert_bench_run(m.runs, incoming.runs[i])
+            }
+            return
+        }
+    }
+    models |> emplace(incoming)
+}
+
 // ===== llama-bench invocation (shared by lcpp_bench --ref and the establisher) =====
 
 //! One llama-bench `-o json` result row (prefill rows have n_gen=0, decode rows n_prompt=0).

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -913,10 +913,15 @@ def read_bench_records(path : string; var models : array<BenchModel>) : bool {
 
 def write_bench_records(path : string; models : array<BenchModel>) {
     let text = sprint_json(models, true)
+    var wrote = false
     fopen(path, "wb") $(f) {
         if (f != null) {
             fwrite(f, text)
+            wrote = true
         }
+    }
+    if (!wrote) {
+        to_log(LOG_ERROR, "dasLLAMA bench: could not open {path} for writing — records NOT persisted\n")
     }
 }
 

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -982,7 +982,9 @@ def run_llama_bench(cmd : string; var rows : array<LlamaBenchRow>) : bool {
     var out = ""
     unsafe {
         popen(cmd) $(f) {
-            out = fread_to_eof(f)
+            if (f != null) {   // popen can hand a null handle on spawn failure (bad binary path)
+                out = fread_to_eof(f)
+            }
         }
     }
     return sscan_json(out, rows)

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -1,1324 +1,1324 @@
 [
- {
-  "gguf": "Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 180.80838574808604,
-      "stddev": 13.35473346710205
-     },
-     "tg128": {
-      "tok_s": 34.01182021445514,
-      "stddev": 0.11796684563159943
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 153.967351,
-      "stddev": 0.67153
-     },
-     "tg128": {
-      "tok_s": 29.991538,
-      "stddev": 0.072005
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 855.1137294694505,
-      "stddev": 8.10074520111084
-     },
-     "tg128": {
-      "tok_s": 56.59940430302928,
-      "stddev": 0.20269836485385895
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 833.313344,
-      "stddev": 7.346048
-     },
-     "tg128": {
-      "tok_s": 54.105434,
-      "stddev": 0.023674
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 146.808079,
-      "stddev": 1.983984
-     },
-     "tg128": {
-      "tok_s": 30.529207,
-      "stddev": 0.333424
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   }
-  ],
-  "arch": "qwen35moe",
-  "quant": "q8",
-  "params_b": 35.505251456,
-  "active_b": 2.86261248,
-  "size_bytes": 22663387424
- },
- {
-  "gguf": "Qwen3.6-27B-MTP-Q4_K_M.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 26.800858919429174,
-      "stddev": 0.45111045241355896
-     },
-     "tg128": {
-      "tok_s": 6.004402584130001,
-      "stddev": 0.0013177604414522648
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 26.411613,
-      "stddev": 0.233075
-     },
-     "tg128": {
-      "tok_s": 6.460273,
-      "stddev": 0.006829
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 144.06797304695436,
-      "stddev": 1.917594313621521
-     },
-     "tg128": {
-      "tok_s": 14.213366025789409,
-      "stddev": 0.002345583401620388
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 127.235592,
-      "stddev": 0.741681
-     },
-     "tg128": {
-      "tok_s": 11.73591,
-      "stddev": 0.158428
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 26.562218,
-      "stddev": 0.012317
-     },
-     "tg128": {
-      "tok_s": 6.448294,
-      "stddev": 0.055931
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   }
-  ],
-  "arch": "qwen35",
-  "quant": "q8",
-  "params_b": 27.320697856,
-  "active_b": 23.84986112,
-  "size_bytes": 17106773120
- },
- {
-  "gguf": "gemma-4-12B-it-Q4_K_M.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 58.339754790484974,
-      "stddev": 0.6024041175842285
-     },
-     "tg128": {
-      "tok_s": 14.719110137582899,
-      "stddev": 0.003154399571940303
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 60.599452,
-      "stddev": 0.197576
-     },
-     "tg128": {
-      "tok_s": 14.211022,
-      "stddev": 0.113624
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 322.61801161335717,
-      "stddev": 1.3747810125350952
-     },
-     "tg128": {
-      "tok_s": 32.621352578464375,
-      "stddev": 1.4271385669708252
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 288.244973,
-      "stddev": 1.165164
-     },
-     "tg128": {
-      "tok_s": 28.803851,
-      "stddev": 0.006763
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 60.717517,
-      "stddev": 0.243022
-     },
-     "tg128": {
-      "tok_s": 14.183035,
-      "stddev": 0.061987
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   }
-  ],
-  "arch": "gemma4",
-  "quant": "q8",
-  "params_b": 11.907350576,
-  "active_b": 11.90658048,
-  "size_bytes": 7381383392
- },
- {
-  "gguf": "gemma-4-E4B-it-Q8_0.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 190.03545401192628,
-      "stddev": 2.2559540271759033
-     },
-     "tg128": {
-      "tok_s": 22.081554453555793,
-      "stddev": 0.009417129680514336
-     }
-    },
-    "source": "official",
-    "sha": "15ada7b6e",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 116.498143,
-      "stddev": 0.928353
-     },
-     "tg128": {
-      "tok_s": 20.351992,
-      "stddev": 0.02613
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 190.269425,
-      "stddev": 1.146168
-     },
-     "tg128": {
-      "tok_s": 20.282686,
-      "stddev": 0.04399
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 917.298267,
-      "stddev": 0.924628
-     },
-     "tg128": {
-      "tok_s": 52.324301,
-      "stddev": 0.147768
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 785.4658647777233,
-      "stddev": 5.344498634338379
-     },
-     "tg128": {
-      "tok_s": 50.485279926238185,
-      "stddev": 0.1642703413963318
-     }
-    },
-    "source": "official",
-    "sha": "15ada7b6e",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   }
-  ],
-  "arch": "gemma4",
-  "quant": "q8",
-  "params_b": 7.51806929,
-  "active_b": 4.58883072,
-  "size_bytes": 8031242688
- },
- {
-  "gguf": "gpt-oss-20b-mxfp4.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 198.2205438278682,
-      "stddev": 5.888680934906006
-     },
-     "tg128": {
-      "tok_s": 41.514423449506886,
-      "stddev": 0.055721234530210495
-     }
-    },
-    "source": "official",
-    "sha": "b85a5ac1d",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
-    "exec_fmt": "weights mxfp4/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 119.756605,
-      "stddev": 0.685068
-     },
-     "tg128": {
-      "tok_s": 42.409554,
-      "stddev": 0.096749
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f",
-    "exec_fmt": "native gguf formats; cpu runtime layout repack"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 842.5333840613948,
-      "stddev": 31.29744529724121
-     },
-     "tg128": {
-      "tok_s": 33.43727619509855,
-      "stddev": 0.19045644998550415
-     }
-    },
-    "source": "official",
-    "sha": "b85a5ac1d",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
-    "exec_fmt": "weights mxfp4/q8 native; q8 activations; f16 scales; metal blob"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 1030.526257,
-      "stddev": 2.853784
-     },
-     "tg128": {
-      "tok_s": 83.340371,
-      "stddev": 0.035358
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f",
-    "exec_fmt": "native gguf formats"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 119.619016,
-      "stddev": 0.193154
-     },
-     "tg128": {
-      "tok_s": 42.466951,
-      "stddev": 0.0689
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f",
-    "exec_fmt": "native gguf formats; cpu runtime layout repack"
-   }
-  ],
-  "arch": "gpt-oss",
-  "quant": "q8",
-  "params_b": 20.914757184,
-  "active_b": 4.18627584,
-  "size_bytes": 12109566560
- },
- {
-  "gguf": "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 194.55741491189448,
-      "stddev": 1.720598816871643
-     },
-     "tg128": {
-      "tok_s": 47.218791600186464,
-      "stddev": 0.0575912706553936
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 137.879655,
-      "stddev": 0.246202
-     },
-     "tg128": {
-      "tok_s": 47.127329,
-      "stddev": 0.215512
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 865.5594593137927,
-      "stddev": 2.599294662475586
-     },
-     "tg128": {
-      "tok_s": 71.4884238990187,
-      "stddev": 0.15503133833408356
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 843.357106,
-      "stddev": 4.003967
-     },
-     "tg128": {
-      "tok_s": 75.017623,
-      "stddev": 0.130823
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 133.227042,
-      "stddev": 1.094596
-     },
-     "tg128": {
-      "tok_s": 46.737828,
-      "stddev": 0.341561
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   }
-  ],
-  "arch": "qwen3moe",
-  "quant": "q8",
-  "params_b": 30.532122624,
-  "active_b": 3.35282176,
-  "size_bytes": 18556686752
- },
- {
-  "gguf": "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 27.27931073554334,
-      "stddev": 0.2012786716222763
-     },
-     "tg128": {
-      "tok_s": 8.208066997221469,
-      "stddev": 0.06084693968296051
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 30.455176,
-      "stddev": 0.303329
-     },
-     "tg128": {
-      "tok_s": 8.234437,
-      "stddev": 0.002241
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 108.99703899476303,
-      "stddev": 3.5069448947906494
-     },
-     "tg128": {
-      "tok_s": 14.750855419789758,
-      "stddev": 0.019187308847904205
-     }
-    },
-    "source": "official",
-    "sha": "dd21245c9",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 114.334859,
-      "stddev": 2.129251
-     },
-     "tg128": {
-      "tok_s": 12.41893,
-      "stddev": 0.102697
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 32.083396,
-      "stddev": 0.252617
-     },
-     "tg128": {
-      "tok_s": 8.231598,
-      "stddev": 0.003798
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f"
-   }
-  ],
-  "arch": "llama",
-  "quant": "q8",
-  "params_b": 23.5724032,
-  "active_b": 23.57198848,
-  "size_bytes": 14333910592
- },
- {
-  "gguf": "gemma-4-26B-A4B-it-Q4_K_M.gguf",
-  "runs": [
-   {
-    "engine": "das",
-    "backend": "cpu",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 147.85293629903535,
-      "stddev": 0.48709043860435486
-     },
-     "tg128": {
-      "tok_s": 26.507349722621164,
-      "stddev": 0.29626885056495667
-     }
-    },
-    "source": "official",
-    "sha": "87e926707",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
-    "exec_fmt": "weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
-   },
-   {
-    "engine": "das",
-    "backend": "metal",
-    "flavor": "tuned",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 895.5897405729733,
-      "stddev": 5.2121052742004395
-     },
-     "tg128": {
-      "tok_s": 52.20740565342571,
-      "stddev": 2.088243246078491
-     }
-    },
-    "source": "official",
-    "sha": "87e926707",
-    "version": "0.6.3",
-    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
-    "exec_fmt": "weights k4/q51/q8 native; q8 activations; f16 scales; metal blob"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "clean-cpu",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 114.417515,
-      "stddev": 1.747994
-     },
-     "tg128": {
-      "tok_s": 27.949045,
-      "stddev": 0.133598
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f",
-    "exec_fmt": "native gguf formats; cpu runtime layout repack"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "cpu",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 148.801335,
-      "stddev": 4.802642
-     },
-     "tg128": {
-      "tok_s": 26.194433,
-      "stddev": 1.906032
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f",
-    "exec_fmt": "native gguf formats; cpu runtime layout repack"
-   },
-   {
-    "engine": "llama.cpp",
-    "backend": "metal",
-    "flavor": "stock",
-    "box": "m1",
-    "threads": 8,
-    "date": "2026-07-21",
-    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-    "hardware": {
-     "cpu": "Apple M1 Max",
-     "arch": "arm64",
-     "os": "macOS 26.4.1",
-     "perf_cores": 8,
-     "total_cores": 10,
-     "ram_gb": 64,
-     "gpu": "Apple M1 Max (32-core)"
-    },
-    "tests": {
-     "pp512": {
-      "tok_s": 815.936983,
-      "stddev": 3.435514
-     },
-     "tg128": {
-      "tok_s": 60.049984,
-      "stddev": 0.13615
-     }
-    },
-    "source": "official",
-    "sha": "ebd048f",
-    "exec_fmt": "native gguf formats"
-   }
-  ],
-  "arch": "gemma4",
-  "quant": "q8",
-  "params_b": 25.233142046,
-  "active_b": 3.286564864,
-  "size_bytes": 16947541728
- }
+  {
+    "gguf":"Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":180.80838574808604,
+            "stddev":13.354733467102051
+          },
+          "tg128":{
+            "tok_s":34.011820214455142,
+            "stddev":0.11796684563159943
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":153.96735100000001,
+            "stddev":0.67152999999999996
+          },
+          "tg128":{
+            "tok_s":29.991537999999998,
+            "stddev":0.072005
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":855.1137294694505,
+            "stddev":8.1007452011108398
+          },
+          "tg128":{
+            "tok_s":56.599404303029281,
+            "stddev":0.20269836485385895
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":833.31334400000003,
+            "stddev":7.3460479999999997
+          },
+          "tg128":{
+            "tok_s":54.105434000000002,
+            "stddev":0.023674000000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":146.80807899999999,
+            "stddev":1.983984
+          },
+          "tg128":{
+            "tok_s":30.529207,
+            "stddev":0.333424
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"qwen35moe",
+    "quant":"q8",
+    "params_b":35.505251456000003,
+    "active_b":2.8626124800000001,
+    "size_bytes":22663387424
+  },
+  {
+    "gguf":"Qwen3.6-27B-MTP-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":26.800858919429174,
+            "stddev":0.45111045241355896
+          },
+          "tg128":{
+            "tok_s":6.0044025841300011,
+            "stddev":0.0013177604414522648
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":26.411612999999999,
+            "stddev":0.233075
+          },
+          "tg128":{
+            "tok_s":6.4602729999999999,
+            "stddev":0.006829
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":144.06797304695436,
+            "stddev":1.917594313621521
+          },
+          "tg128":{
+            "tok_s":14.213366025789409,
+            "stddev":0.002345583401620388
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":127.235592,
+            "stddev":0.74168100000000003
+          },
+          "tg128":{
+            "tok_s":11.735910000000001,
+            "stddev":0.15842800000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":26.562218000000001,
+            "stddev":0.012317
+          },
+          "tg128":{
+            "tok_s":6.4482939999999997,
+            "stddev":0.055931000000000002
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"qwen35",
+    "quant":"q8",
+    "params_b":27.320697855999999,
+    "active_b":23.84986112,
+    "size_bytes":17106773120
+  },
+  {
+    "gguf":"gemma-4-12B-it-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":58.339754790484974,
+            "stddev":0.60240411758422852
+          },
+          "tg128":{
+            "tok_s":14.719110137582899,
+            "stddev":0.0031543995719403028
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":60.599451999999999,
+            "stddev":0.197576
+          },
+          "tg128":{
+            "tok_s":14.211022,
+            "stddev":0.113624
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":322.61801161335717,
+            "stddev":1.3747810125350952
+          },
+          "tg128":{
+            "tok_s":32.621352578464375,
+            "stddev":1.4271385669708252
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":288.24497300000002,
+            "stddev":1.1651640000000001
+          },
+          "tg128":{
+            "tok_s":28.803851000000002,
+            "stddev":0.0067629999999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":60.717517000000001,
+            "stddev":0.24302199999999999
+          },
+          "tg128":{
+            "tok_s":14.183035,
+            "stddev":0.061987
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"gemma4",
+    "quant":"q8",
+    "params_b":11.907350576000001,
+    "active_b":11.906580480000001,
+    "size_bytes":7381383392
+  },
+  {
+    "gguf":"gemma-4-E4B-it-Q8_0.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":190.03545401192628,
+            "stddev":2.2559540271759033
+          },
+          "tg128":{
+            "tok_s":22.081554453555793,
+            "stddev":0.0094171296805143356
+          }
+        },
+        "source":"official",
+        "sha":"15ada7b6e",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":116.498143,
+            "stddev":0.92835299999999998
+          },
+          "tg128":{
+            "tok_s":20.351991999999999,
+            "stddev":0.02613
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":190.26942500000001,
+            "stddev":1.1461680000000001
+          },
+          "tg128":{
+            "tok_s":20.282686000000002,
+            "stddev":0.043990000000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":917.29826700000001,
+            "stddev":0.92462800000000001
+          },
+          "tg128":{
+            "tok_s":52.324300999999998,
+            "stddev":0.14776800000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":785.46586477772325,
+            "stddev":5.3444986343383789
+          },
+          "tg128":{
+            "tok_s":50.485279926238185,
+            "stddev":0.16427034139633179
+          }
+        },
+        "source":"official",
+        "sha":"15ada7b6e",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      }
+    ],
+    "arch":"gemma4",
+    "quant":"q8",
+    "params_b":7.5180692899999997,
+    "active_b":4.5888307199999998,
+    "size_bytes":8031242688
+  },
+  {
+    "gguf":"gpt-oss-20b-mxfp4.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":188.1157447370494,
+            "stddev":18.4388427734375
+          },
+          "tg128":{
+            "tok_s":40.553555854921797,
+            "stddev":0.34822863340377808
+          }
+        },
+        "source":"official",
+        "sha":"4a3d6c690",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":117.038847,
+            "stddev":0.90851700000000002
+          },
+          "tg128":{
+            "tok_s":42.396515000000001,
+            "stddev":0.290823
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":946.90685928332368,
+            "stddev":15.177724838256836
+          },
+          "tg128":{
+            "tok_s":77.103618825696032,
+            "stddev":0.90228211879730225
+          }
+        },
+        "source":"official",
+        "sha":"4a3d6c690",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; metal blob"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":1031.533553,
+            "stddev":2.7225839999999999
+          },
+          "tg128":{
+            "tok_s":83.471146000000005,
+            "stddev":0.053529
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":119.106099,
+            "stddev":1.2954669999999999
+          },
+          "tg128":{
+            "tok_s":42.557640999999997,
+            "stddev":0.041480999999999997
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
+      }
+    ],
+    "arch":"gpt-oss",
+    "quant":"q8",
+    "params_b":20.914757183999999,
+    "active_b":4.1862758400000004,
+    "size_bytes":12109566560
+  },
+  {
+    "gguf":"Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":194.55741491189448,
+            "stddev":1.7205988168716431
+          },
+          "tg128":{
+            "tok_s":47.218791600186464,
+            "stddev":0.0575912706553936
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":137.87965500000001,
+            "stddev":0.246202
+          },
+          "tg128":{
+            "tok_s":47.127329000000003,
+            "stddev":0.21551200000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":865.55945931379267,
+            "stddev":2.5992946624755859
+          },
+          "tg128":{
+            "tok_s":71.488423899018699,
+            "stddev":0.15503133833408356
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":843.35710600000004,
+            "stddev":4.0039670000000003
+          },
+          "tg128":{
+            "tok_s":75.017623,
+            "stddev":0.13082299999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":133.22704200000001,
+            "stddev":1.0945959999999999
+          },
+          "tg128":{
+            "tok_s":46.737828,
+            "stddev":0.341561
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"qwen3moe",
+    "quant":"q8",
+    "params_b":30.532122623999999,
+    "active_b":3.3528217599999999,
+    "size_bytes":18556686752
+  },
+  {
+    "gguf":"Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":27.279310735543341,
+            "stddev":0.20127867162227631
+          },
+          "tg128":{
+            "tok_s":8.2080669972214686,
+            "stddev":0.06084693968296051
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":30.455176000000002,
+            "stddev":0.30332900000000002
+          },
+          "tg128":{
+            "tok_s":8.2344369999999998,
+            "stddev":0.0022409999999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":108.99703899476303,
+            "stddev":3.5069448947906494
+          },
+          "tg128":{
+            "tok_s":14.750855419789758,
+            "stddev":0.019187308847904205
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":114.33485899999999,
+            "stddev":2.129251
+          },
+          "tg128":{
+            "tok_s":12.41893,
+            "stddev":0.102697
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":32.083396,
+            "stddev":0.25261699999999998
+          },
+          "tg128":{
+            "tok_s":8.231598,
+            "stddev":0.0037980000000000002
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"llama",
+    "quant":"q8",
+    "params_b":23.5724032,
+    "active_b":23.571988480000002,
+    "size_bytes":14333910592
+  },
+  {
+    "gguf":"gemma-4-26B-A4B-it-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":147.85293629903535,
+            "stddev":0.48709043860435486
+          },
+          "tg128":{
+            "tok_s":26.507349722621164,
+            "stddev":0.29626885056495667
+          }
+        },
+        "source":"official",
+        "sha":"87e926707",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":895.58974057297326,
+            "stddev":5.2121052742004395
+          },
+          "tg128":{
+            "tok_s":52.20740565342571,
+            "stddev":2.0882432460784912
+          }
+        },
+        "source":"official",
+        "sha":"87e926707",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; metal blob"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":114.41751499999999,
+            "stddev":1.747994
+          },
+          "tg128":{
+            "tok_s":27.949045000000002,
+            "stddev":0.13359799999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":148.80133499999999,
+            "stddev":4.8026419999999996
+          },
+          "tg128":{
+            "tok_s":26.194433,
+            "stddev":1.9060319999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":815.93698300000005,
+            "stddev":3.435514
+          },
+          "tg128":{
+            "tok_s":60.049984000000002,
+            "stddev":0.13614999999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats"
+      }
+    ],
+    "arch":"gemma4",
+    "quant":"q8",
+    "params_b":25.233142046000001,
+    "active_b":3.2865648639999998,
+    "size_bytes":16947541728
+  }
 ]

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -665,7 +665,7 @@
         "box":"m1",
         "threads":8,
         "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -677,18 +677,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":209.23585585213263,
-            "stddev":0.29393297433853149
+            "tok_s":198.2205438278682,
+            "stddev":5.8886809349060059
           },
           "tg128":{
-            "tok_s":41.634577298994046,
-            "stddev":0.027743775397539139
+            "tok_s":41.514423449506886,
+            "stddev":0.055721234530210495
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"b85a5ac1d",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -709,16 +710,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":119.60631600000001,
-            "stddev":2.1013760000000001
+            "tok_s":119.75660499999999,
+            "stddev":0.68506800000000001
           },
           "tg128":{
-            "tok_s":41.798597999999998,
-            "stddev":0.47513
+            "tok_s":42.409554,
+            "stddev":0.096749000000000002
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"das",
@@ -727,7 +729,7 @@
         "box":"m1",
         "threads":8,
         "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -739,18 +741,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":885.19369849039867,
-            "stddev":1.8949406147003174
+            "tok_s":842.53338406139483,
+            "stddev":31.297445297241211
           },
           "tg128":{
-            "tok_s":33.284556403692797,
-            "stddev":0.0097357295453548431
+            "tok_s":33.437276195098548,
+            "stddev":0.19045644998550415
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"b85a5ac1d",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; metal blob"
       },
       {
         "engine":"llama.cpp",
@@ -771,16 +774,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":1031.2996599999999,
-            "stddev":2.4573130000000001
+            "tok_s":1030.526257,
+            "stddev":2.8537840000000001
           },
           "tg128":{
-            "tok_s":83.367034000000004,
-            "stddev":0.065244999999999997
+            "tok_s":83.340371000000005,
+            "stddev":0.035358000000000001
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats"
       },
       {
         "engine":"llama.cpp",
@@ -801,16 +805,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":114.086674,
-            "stddev":1.89838
+            "tok_s":119.619016,
+            "stddev":0.19315399999999999
           },
           "tg128":{
-            "tok_s":42.337879999999998,
-            "stddev":0.100775
+            "tok_s":42.466951000000002,
+            "stddev":0.068900000000000003
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
     "arch":"gpt-oss",

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -1,0 +1,1284 @@
+[
+  {
+    "gguf":"Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":180.80838574808604,
+            "stddev":13.354733467102051
+          },
+          "tg128":{
+            "tok_s":34.011820214455142,
+            "stddev":0.11796684563159943
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":153.96735100000001,
+            "stddev":0.67152999999999996
+          },
+          "tg128":{
+            "tok_s":29.991537999999998,
+            "stddev":0.072005
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":855.1137294694505,
+            "stddev":8.1007452011108398
+          },
+          "tg128":{
+            "tok_s":56.599404303029281,
+            "stddev":0.20269836485385895
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":833.31334400000003,
+            "stddev":7.3460479999999997
+          },
+          "tg128":{
+            "tok_s":54.105434000000002,
+            "stddev":0.023674000000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":146.80807899999999,
+            "stddev":1.983984
+          },
+          "tg128":{
+            "tok_s":30.529207,
+            "stddev":0.333424
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"qwen35moe",
+    "quant":"q8",
+    "params_b":35.505251456000003,
+    "active_b":2.8626124800000001,
+    "size_bytes":22663387424
+  },
+  {
+    "gguf":"Qwen3.6-27B-MTP-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":26.800858919429174,
+            "stddev":0.45111045241355896
+          },
+          "tg128":{
+            "tok_s":6.0044025841300011,
+            "stddev":0.0013177604414522648
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":26.411612999999999,
+            "stddev":0.233075
+          },
+          "tg128":{
+            "tok_s":6.4602729999999999,
+            "stddev":0.006829
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":144.06797304695436,
+            "stddev":1.917594313621521
+          },
+          "tg128":{
+            "tok_s":14.213366025789409,
+            "stddev":0.002345583401620388
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":127.235592,
+            "stddev":0.74168100000000003
+          },
+          "tg128":{
+            "tok_s":11.735910000000001,
+            "stddev":0.15842800000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":26.562218000000001,
+            "stddev":0.012317
+          },
+          "tg128":{
+            "tok_s":6.4482939999999997,
+            "stddev":0.055931000000000002
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"qwen35",
+    "quant":"q8",
+    "params_b":27.320697855999999,
+    "active_b":23.84986112,
+    "size_bytes":17106773120
+  },
+  {
+    "gguf":"gemma-4-12B-it-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":58.339754790484974,
+            "stddev":0.60240411758422852
+          },
+          "tg128":{
+            "tok_s":14.719110137582899,
+            "stddev":0.0031543995719403028
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":60.599451999999999,
+            "stddev":0.197576
+          },
+          "tg128":{
+            "tok_s":14.211022,
+            "stddev":0.113624
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":322.61801161335717,
+            "stddev":1.3747810125350952
+          },
+          "tg128":{
+            "tok_s":32.621352578464375,
+            "stddev":1.4271385669708252
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":288.24497300000002,
+            "stddev":1.1651640000000001
+          },
+          "tg128":{
+            "tok_s":28.803851000000002,
+            "stddev":0.0067629999999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":60.717517000000001,
+            "stddev":0.24302199999999999
+          },
+          "tg128":{
+            "tok_s":14.183035,
+            "stddev":0.061987
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"gemma4",
+    "quant":"q8",
+    "params_b":11.907350576000001,
+    "active_b":11.906580480000001,
+    "size_bytes":7381383392
+  },
+  {
+    "gguf":"gemma-4-E4B-it-Q8_0.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":167.30516157478473,
+            "stddev":2.0537683963775635
+          },
+          "tg128":{
+            "tok_s":21.55315940749556,
+            "stddev":0.11855021119117737
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":121.73269999999999,
+            "stddev":0.17560700000000001
+          },
+          "tg128":{
+            "tok_s":19.921785,
+            "stddev":0.27912199999999998
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":181.44897,
+            "stddev":1.5306409999999999
+          },
+          "tg128":{
+            "tok_s":19.330883,
+            "stddev":0.057210999999999998
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":765.32405100000005,
+            "stddev":207.48539299999999
+          },
+          "tg128":{
+            "tok_s":40.159846999999999,
+            "stddev":1.800942
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"gemma4",
+    "quant":"q8",
+    "params_b":7.5180692899999997,
+    "active_b":4.5888307199999998,
+    "size_bytes":8031242688,
+    "note":"das Metal decode does not serve the E-series graph yet — das rows are CPU only"
+  },
+  {
+    "gguf":"gpt-oss-20b-mxfp4.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":209.23585585213263,
+            "stddev":0.29393297433853149
+          },
+          "tg128":{
+            "tok_s":41.634577298994046,
+            "stddev":0.027743775397539139
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":119.60631600000001,
+            "stddev":2.1013760000000001
+          },
+          "tg128":{
+            "tok_s":41.798597999999998,
+            "stddev":0.47513
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":885.19369849039867,
+            "stddev":1.8949406147003174
+          },
+          "tg128":{
+            "tok_s":33.284556403692797,
+            "stddev":0.0097357295453548431
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":1031.2996599999999,
+            "stddev":2.4573130000000001
+          },
+          "tg128":{
+            "tok_s":83.367034000000004,
+            "stddev":0.065244999999999997
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":114.086674,
+            "stddev":1.89838
+          },
+          "tg128":{
+            "tok_s":42.337879999999998,
+            "stddev":0.100775
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"gpt-oss",
+    "quant":"q8",
+    "params_b":20.914757183999999,
+    "active_b":4.1862758400000004,
+    "size_bytes":12109566560
+  },
+  {
+    "gguf":"Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":194.55741491189448,
+            "stddev":1.7205988168716431
+          },
+          "tg128":{
+            "tok_s":47.218791600186464,
+            "stddev":0.0575912706553936
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":137.87965500000001,
+            "stddev":0.246202
+          },
+          "tg128":{
+            "tok_s":47.127329000000003,
+            "stddev":0.21551200000000001
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":865.55945931379267,
+            "stddev":2.5992946624755859
+          },
+          "tg128":{
+            "tok_s":71.488423899018699,
+            "stddev":0.15503133833408356
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":843.35710600000004,
+            "stddev":4.0039670000000003
+          },
+          "tg128":{
+            "tok_s":75.017623,
+            "stddev":0.13082299999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":133.22704200000001,
+            "stddev":1.0945959999999999
+          },
+          "tg128":{
+            "tok_s":46.737828,
+            "stddev":0.341561
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"qwen3moe",
+    "quant":"q8",
+    "params_b":30.532122623999999,
+    "active_b":3.3528217599999999,
+    "size_bytes":18556686752
+  },
+  {
+    "gguf":"Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":27.279310735543341,
+            "stddev":0.20127867162227631
+          },
+          "tg128":{
+            "tok_s":8.2080669972214686,
+            "stddev":0.06084693968296051
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":30.455176000000002,
+            "stddev":0.30332900000000002
+          },
+          "tg128":{
+            "tok_s":8.2344369999999998,
+            "stddev":0.0022409999999999999
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":108.99703899476303,
+            "stddev":3.5069448947906494
+          },
+          "tg128":{
+            "tok_s":14.750855419789758,
+            "stddev":0.019187308847904205
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":114.33485899999999,
+            "stddev":2.129251
+          },
+          "tg128":{
+            "tok_s":12.41893,
+            "stddev":0.102697
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":32.083396,
+            "stddev":0.25261699999999998
+          },
+          "tg128":{
+            "tok_s":8.231598,
+            "stddev":0.0037980000000000002
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"llama",
+    "quant":"q8",
+    "params_b":23.5724032,
+    "active_b":23.571988480000002,
+    "size_bytes":14333910592
+  },
+  {
+    "gguf":"gemma-4-26B-A4B-it-Q8_0.gguf",
+    "runs":[
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":184.02893047578158,
+            "stddev":14.676033973693848
+          },
+          "tg128":{
+            "tok_s":25.722351335616075,
+            "stddev":0.045879118144512177
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":935.6682816830737,
+            "stddev":5.4101343154907227
+          },
+          "tg128":{
+            "tok_s":52.887731728797782,
+            "stddev":2.1626980304718018
+          }
+        },
+        "source":"official",
+        "sha":"dd21245c9",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"clean-cpu",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":161.98222000000001,
+            "stddev":1.2457929999999999
+          },
+          "tg128":{
+            "tok_s":24.159696,
+            "stddev":0.28059299999999998
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"cpu",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":154.38566599999999,
+            "stddev":3.0042059999999999
+          },
+          "tg128":{
+            "tok_s":24.988809,
+            "stddev":0.054449999999999998
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      },
+      {
+        "engine":"llama.cpp",
+        "backend":"metal",
+        "flavor":"stock",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":880.50783699999999,
+            "stddev":3.3447900000000002
+          },
+          "tg128":{
+            "tok_s":53.623131000000001,
+            "stddev":0.075286000000000006
+          }
+        },
+        "source":"official",
+        "sha":"ebd048f"
+      }
+    ],
+    "arch":"gemma4",
+    "quant":"q8",
+    "params_b":25.233142046000001,
+    "active_b":3.2865648639999998,
+    "size_bytes":26859860992,
+    "note":"the widespread Q4_K_M file stores its expert tensors as Q5_1, which das does not run yet — benched at Q8_0 until that lands"
+  }
+]

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -1,1320 +1,1324 @@
 [
-  {
-    "gguf":"Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":180.80838574808604,
-            "stddev":13.354733467102051
-          },
-          "tg128":{
-            "tok_s":34.011820214455142,
-            "stddev":0.11796684563159943
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":153.96735100000001,
-            "stddev":0.67152999999999996
-          },
-          "tg128":{
-            "tok_s":29.991537999999998,
-            "stddev":0.072005
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":855.1137294694505,
-            "stddev":8.1007452011108398
-          },
-          "tg128":{
-            "tok_s":56.599404303029281,
-            "stddev":0.20269836485385895
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":833.31334400000003,
-            "stddev":7.3460479999999997
-          },
-          "tg128":{
-            "tok_s":54.105434000000002,
-            "stddev":0.023674000000000001
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":146.80807899999999,
-            "stddev":1.983984
-          },
-          "tg128":{
-            "tok_s":30.529207,
-            "stddev":0.333424
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      }
-    ],
-    "arch":"qwen35moe",
-    "quant":"q8",
-    "params_b":35.505251456000003,
-    "active_b":2.8626124800000001,
-    "size_bytes":22663387424
-  },
-  {
-    "gguf":"Qwen3.6-27B-MTP-Q4_K_M.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":26.800858919429174,
-            "stddev":0.45111045241355896
-          },
-          "tg128":{
-            "tok_s":6.0044025841300011,
-            "stddev":0.0013177604414522648
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":26.411612999999999,
-            "stddev":0.233075
-          },
-          "tg128":{
-            "tok_s":6.4602729999999999,
-            "stddev":0.006829
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":144.06797304695436,
-            "stddev":1.917594313621521
-          },
-          "tg128":{
-            "tok_s":14.213366025789409,
-            "stddev":0.002345583401620388
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":127.235592,
-            "stddev":0.74168100000000003
-          },
-          "tg128":{
-            "tok_s":11.735910000000001,
-            "stddev":0.15842800000000001
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":26.562218000000001,
-            "stddev":0.012317
-          },
-          "tg128":{
-            "tok_s":6.4482939999999997,
-            "stddev":0.055931000000000002
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      }
-    ],
-    "arch":"qwen35",
-    "quant":"q8",
-    "params_b":27.320697855999999,
-    "active_b":23.84986112,
-    "size_bytes":17106773120
-  },
-  {
-    "gguf":"gemma-4-12B-it-Q4_K_M.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":58.339754790484974,
-            "stddev":0.60240411758422852
-          },
-          "tg128":{
-            "tok_s":14.719110137582899,
-            "stddev":0.0031543995719403028
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":60.599451999999999,
-            "stddev":0.197576
-          },
-          "tg128":{
-            "tok_s":14.211022,
-            "stddev":0.113624
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":322.61801161335717,
-            "stddev":1.3747810125350952
-          },
-          "tg128":{
-            "tok_s":32.621352578464375,
-            "stddev":1.4271385669708252
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":288.24497300000002,
-            "stddev":1.1651640000000001
-          },
-          "tg128":{
-            "tok_s":28.803851000000002,
-            "stddev":0.0067629999999999999
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":60.717517000000001,
-            "stddev":0.24302199999999999
-          },
-          "tg128":{
-            "tok_s":14.183035,
-            "stddev":0.061987
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      }
-    ],
-    "arch":"gemma4",
-    "quant":"q8",
-    "params_b":11.907350576000001,
-    "active_b":11.906580480000001,
-    "size_bytes":7381383392
-  },
-  {
-    "gguf":"gemma-4-E4B-it-Q8_0.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":190.03545401192628,
-            "stddev":2.2559540271759033
-          },
-          "tg128":{
-            "tok_s":22.081554453555793,
-            "stddev":0.0094171296805143356
-          }
-        },
-        "source":"official",
-        "sha":"15ada7b6e",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":116.498143,
-            "stddev":0.92835299999999998
-          },
-          "tg128":{
-            "tok_s":20.351991999999999,
-            "stddev":0.02613
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":190.26942500000001,
-            "stddev":1.1461680000000001
-          },
-          "tg128":{
-            "tok_s":20.282686000000002,
-            "stddev":0.043990000000000001
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":917.29826700000001,
-            "stddev":0.92462800000000001
-          },
-          "tg128":{
-            "tok_s":52.324300999999998,
-            "stddev":0.14776800000000001
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":785.46586477772325,
-            "stddev":5.3444986343383789
-          },
-          "tg128":{
-            "tok_s":50.485279926238185,
-            "stddev":0.16427034139633179
-          }
-        },
-        "source":"official",
-        "sha":"15ada7b6e",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      }
-    ],
-    "arch":"gemma4",
-    "quant":"q8",
-    "params_b":7.5180692899999997,
-    "active_b":4.5888307199999998,
-    "size_bytes":8031242688
-  },
-  {
-    "gguf":"gpt-oss-20b-mxfp4.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":198.2205438278682,
-            "stddev":5.8886809349060059
-          },
-          "tg128":{
-            "tok_s":41.514423449506886,
-            "stddev":0.055721234530210495
-          }
-        },
-        "source":"official",
-        "sha":"b85a5ac1d",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
-        "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":119.75660499999999,
-            "stddev":0.68506800000000001
-          },
-          "tg128":{
-            "tok_s":42.409554,
-            "stddev":0.096749000000000002
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f",
-        "exec_fmt":"native gguf formats; cpu runtime layout repack"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":842.53338406139483,
-            "stddev":31.297445297241211
-          },
-          "tg128":{
-            "tok_s":33.437276195098548,
-            "stddev":0.19045644998550415
-          }
-        },
-        "source":"official",
-        "sha":"b85a5ac1d",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
-        "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; metal blob"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":1030.526257,
-            "stddev":2.8537840000000001
-          },
-          "tg128":{
-            "tok_s":83.340371000000005,
-            "stddev":0.035358000000000001
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f",
-        "exec_fmt":"native gguf formats"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":119.619016,
-            "stddev":0.19315399999999999
-          },
-          "tg128":{
-            "tok_s":42.466951000000002,
-            "stddev":0.068900000000000003
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f",
-        "exec_fmt":"native gguf formats; cpu runtime layout repack"
-      }
-    ],
-    "arch":"gpt-oss",
-    "quant":"q8",
-    "params_b":20.914757183999999,
-    "active_b":4.1862758400000004,
-    "size_bytes":12109566560
-  },
-  {
-    "gguf":"Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":194.55741491189448,
-            "stddev":1.7205988168716431
-          },
-          "tg128":{
-            "tok_s":47.218791600186464,
-            "stddev":0.0575912706553936
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":137.87965500000001,
-            "stddev":0.246202
-          },
-          "tg128":{
-            "tok_s":47.127329000000003,
-            "stddev":0.21551200000000001
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":865.55945931379267,
-            "stddev":2.5992946624755859
-          },
-          "tg128":{
-            "tok_s":71.488423899018699,
-            "stddev":0.15503133833408356
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":843.35710600000004,
-            "stddev":4.0039670000000003
-          },
-          "tg128":{
-            "tok_s":75.017623,
-            "stddev":0.13082299999999999
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":133.22704200000001,
-            "stddev":1.0945959999999999
-          },
-          "tg128":{
-            "tok_s":46.737828,
-            "stddev":0.341561
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      }
-    ],
-    "arch":"qwen3moe",
-    "quant":"q8",
-    "params_b":30.532122623999999,
-    "active_b":3.3528217599999999,
-    "size_bytes":18556686752
-  },
-  {
-    "gguf":"Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":27.279310735543341,
-            "stddev":0.20127867162227631
-          },
-          "tg128":{
-            "tok_s":8.2080669972214686,
-            "stddev":0.06084693968296051
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":30.455176000000002,
-            "stddev":0.30332900000000002
-          },
-          "tg128":{
-            "tok_s":8.2344369999999998,
-            "stddev":0.0022409999999999999
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":108.99703899476303,
-            "stddev":3.5069448947906494
-          },
-          "tg128":{
-            "tok_s":14.750855419789758,
-            "stddev":0.019187308847904205
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":114.33485899999999,
-            "stddev":2.129251
-          },
-          "tg128":{
-            "tok_s":12.41893,
-            "stddev":0.102697
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":32.083396,
-            "stddev":0.25261699999999998
-          },
-          "tg128":{
-            "tok_s":8.231598,
-            "stddev":0.0037980000000000002
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      }
-    ],
-    "arch":"llama",
-    "quant":"q8",
-    "params_b":23.5724032,
-    "active_b":23.571988480000002,
-    "size_bytes":14333910592
-  },
-  {
-    "gguf":"gemma-4-26B-A4B-it-Q8_0.gguf",
-    "runs":[
-      {
-        "engine":"das",
-        "backend":"cpu",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":184.02893047578158,
-            "stddev":14.676033973693848
-          },
-          "tg128":{
-            "tok_s":25.722351335616075,
-            "stddev":0.045879118144512177
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"das",
-        "backend":"metal",
-        "flavor":"tuned",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":935.6682816830737,
-            "stddev":5.4101343154907227
-          },
-          "tg128":{
-            "tok_s":52.887731728797782,
-            "stddev":2.1626980304718018
-          }
-        },
-        "source":"official",
-        "sha":"dd21245c9",
-        "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"clean-cpu",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":161.98222000000001,
-            "stddev":1.2457929999999999
-          },
-          "tg128":{
-            "tok_s":24.159696,
-            "stddev":0.28059299999999998
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"cpu",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":154.38566599999999,
-            "stddev":3.0042059999999999
-          },
-          "tg128":{
-            "tok_s":24.988809,
-            "stddev":0.054449999999999998
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      },
-      {
-        "engine":"llama.cpp",
-        "backend":"metal",
-        "flavor":"stock",
-        "box":"m1",
-        "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
-        "hardware":{
-          "cpu":"Apple M1 Max",
-          "arch":"arm64",
-          "os":"macOS 26.4.1",
-          "perf_cores":8,
-          "total_cores":10,
-          "ram_gb":64,
-          "gpu":"Apple M1 Max (32-core)"
-        },
-        "tests":{
-          "pp512":{
-            "tok_s":880.50783699999999,
-            "stddev":3.3447900000000002
-          },
-          "tg128":{
-            "tok_s":53.623131000000001,
-            "stddev":0.075286000000000006
-          }
-        },
-        "source":"official",
-        "sha":"ebd048f"
-      }
-    ],
-    "arch":"gemma4",
-    "quant":"q8",
-    "params_b":25.233142046000001,
-    "active_b":3.2865648639999998,
-    "size_bytes":26859860992,
-    "note":"the widespread Q4_K_M file stores its expert tensors as Q5_1, which das does not run yet — benched at Q8_0 until that lands"
-  }
+ {
+  "gguf": "Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 180.80838574808604,
+      "stddev": 13.35473346710205
+     },
+     "tg128": {
+      "tok_s": 34.01182021445514,
+      "stddev": 0.11796684563159943
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 153.967351,
+      "stddev": 0.67153
+     },
+     "tg128": {
+      "tok_s": 29.991538,
+      "stddev": 0.072005
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 855.1137294694505,
+      "stddev": 8.10074520111084
+     },
+     "tg128": {
+      "tok_s": 56.59940430302928,
+      "stddev": 0.20269836485385895
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 833.313344,
+      "stddev": 7.346048
+     },
+     "tg128": {
+      "tok_s": 54.105434,
+      "stddev": 0.023674
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 146.808079,
+      "stddev": 1.983984
+     },
+     "tg128": {
+      "tok_s": 30.529207,
+      "stddev": 0.333424
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   }
+  ],
+  "arch": "qwen35moe",
+  "quant": "q8",
+  "params_b": 35.505251456,
+  "active_b": 2.86261248,
+  "size_bytes": 22663387424
+ },
+ {
+  "gguf": "Qwen3.6-27B-MTP-Q4_K_M.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 26.800858919429174,
+      "stddev": 0.45111045241355896
+     },
+     "tg128": {
+      "tok_s": 6.004402584130001,
+      "stddev": 0.0013177604414522648
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 26.411613,
+      "stddev": 0.233075
+     },
+     "tg128": {
+      "tok_s": 6.460273,
+      "stddev": 0.006829
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 144.06797304695436,
+      "stddev": 1.917594313621521
+     },
+     "tg128": {
+      "tok_s": 14.213366025789409,
+      "stddev": 0.002345583401620388
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 127.235592,
+      "stddev": 0.741681
+     },
+     "tg128": {
+      "tok_s": 11.73591,
+      "stddev": 0.158428
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 26.562218,
+      "stddev": 0.012317
+     },
+     "tg128": {
+      "tok_s": 6.448294,
+      "stddev": 0.055931
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   }
+  ],
+  "arch": "qwen35",
+  "quant": "q8",
+  "params_b": 27.320697856,
+  "active_b": 23.84986112,
+  "size_bytes": 17106773120
+ },
+ {
+  "gguf": "gemma-4-12B-it-Q4_K_M.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 58.339754790484974,
+      "stddev": 0.6024041175842285
+     },
+     "tg128": {
+      "tok_s": 14.719110137582899,
+      "stddev": 0.003154399571940303
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 60.599452,
+      "stddev": 0.197576
+     },
+     "tg128": {
+      "tok_s": 14.211022,
+      "stddev": 0.113624
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 322.61801161335717,
+      "stddev": 1.3747810125350952
+     },
+     "tg128": {
+      "tok_s": 32.621352578464375,
+      "stddev": 1.4271385669708252
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 288.244973,
+      "stddev": 1.165164
+     },
+     "tg128": {
+      "tok_s": 28.803851,
+      "stddev": 0.006763
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 60.717517,
+      "stddev": 0.243022
+     },
+     "tg128": {
+      "tok_s": 14.183035,
+      "stddev": 0.061987
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   }
+  ],
+  "arch": "gemma4",
+  "quant": "q8",
+  "params_b": 11.907350576,
+  "active_b": 11.90658048,
+  "size_bytes": 7381383392
+ },
+ {
+  "gguf": "gemma-4-E4B-it-Q8_0.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 190.03545401192628,
+      "stddev": 2.2559540271759033
+     },
+     "tg128": {
+      "tok_s": 22.081554453555793,
+      "stddev": 0.009417129680514336
+     }
+    },
+    "source": "official",
+    "sha": "15ada7b6e",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 116.498143,
+      "stddev": 0.928353
+     },
+     "tg128": {
+      "tok_s": 20.351992,
+      "stddev": 0.02613
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 190.269425,
+      "stddev": 1.146168
+     },
+     "tg128": {
+      "tok_s": 20.282686,
+      "stddev": 0.04399
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 917.298267,
+      "stddev": 0.924628
+     },
+     "tg128": {
+      "tok_s": 52.324301,
+      "stddev": 0.147768
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 785.4658647777233,
+      "stddev": 5.344498634338379
+     },
+     "tg128": {
+      "tok_s": 50.485279926238185,
+      "stddev": 0.1642703413963318
+     }
+    },
+    "source": "official",
+    "sha": "15ada7b6e",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   }
+  ],
+  "arch": "gemma4",
+  "quant": "q8",
+  "params_b": 7.51806929,
+  "active_b": 4.58883072,
+  "size_bytes": 8031242688
+ },
+ {
+  "gguf": "gpt-oss-20b-mxfp4.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 198.2205438278682,
+      "stddev": 5.888680934906006
+     },
+     "tg128": {
+      "tok_s": 41.514423449506886,
+      "stddev": 0.055721234530210495
+     }
+    },
+    "source": "official",
+    "sha": "b85a5ac1d",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+    "exec_fmt": "weights mxfp4/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 119.756605,
+      "stddev": 0.685068
+     },
+     "tg128": {
+      "tok_s": 42.409554,
+      "stddev": 0.096749
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f",
+    "exec_fmt": "native gguf formats; cpu runtime layout repack"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 842.5333840613948,
+      "stddev": 31.29744529724121
+     },
+     "tg128": {
+      "tok_s": 33.43727619509855,
+      "stddev": 0.19045644998550415
+     }
+    },
+    "source": "official",
+    "sha": "b85a5ac1d",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+    "exec_fmt": "weights mxfp4/q8 native; q8 activations; f16 scales; metal blob"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 1030.526257,
+      "stddev": 2.853784
+     },
+     "tg128": {
+      "tok_s": 83.340371,
+      "stddev": 0.035358
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f",
+    "exec_fmt": "native gguf formats"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 119.619016,
+      "stddev": 0.193154
+     },
+     "tg128": {
+      "tok_s": 42.466951,
+      "stddev": 0.0689
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f",
+    "exec_fmt": "native gguf formats; cpu runtime layout repack"
+   }
+  ],
+  "arch": "gpt-oss",
+  "quant": "q8",
+  "params_b": 20.914757184,
+  "active_b": 4.18627584,
+  "size_bytes": 12109566560
+ },
+ {
+  "gguf": "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 194.55741491189448,
+      "stddev": 1.720598816871643
+     },
+     "tg128": {
+      "tok_s": 47.218791600186464,
+      "stddev": 0.0575912706553936
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 137.879655,
+      "stddev": 0.246202
+     },
+     "tg128": {
+      "tok_s": 47.127329,
+      "stddev": 0.215512
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 865.5594593137927,
+      "stddev": 2.599294662475586
+     },
+     "tg128": {
+      "tok_s": 71.4884238990187,
+      "stddev": 0.15503133833408356
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 843.357106,
+      "stddev": 4.003967
+     },
+     "tg128": {
+      "tok_s": 75.017623,
+      "stddev": 0.130823
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 133.227042,
+      "stddev": 1.094596
+     },
+     "tg128": {
+      "tok_s": 46.737828,
+      "stddev": 0.341561
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   }
+  ],
+  "arch": "qwen3moe",
+  "quant": "q8",
+  "params_b": 30.532122624,
+  "active_b": 3.35282176,
+  "size_bytes": 18556686752
+ },
+ {
+  "gguf": "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 27.27931073554334,
+      "stddev": 0.2012786716222763
+     },
+     "tg128": {
+      "tok_s": 8.208066997221469,
+      "stddev": 0.06084693968296051
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 30.455176,
+      "stddev": 0.303329
+     },
+     "tg128": {
+      "tok_s": 8.234437,
+      "stddev": 0.002241
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99 --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench --ref-flavor stock",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 108.99703899476303,
+      "stddev": 3.5069448947906494
+     },
+     "tg128": {
+      "tok_s": 14.750855419789758,
+      "stddev": 0.019187308847904205
+     }
+    },
+    "source": "official",
+    "sha": "dd21245c9",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 114.334859,
+      "stddev": 2.129251
+     },
+     "tg128": {
+      "tok_s": 12.41893,
+      "stddev": 0.102697
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 32.083396,
+      "stddev": 0.252617
+     },
+     "tg128": {
+      "tok_s": 8.231598,
+      "stddev": 0.003798
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f"
+   }
+  ],
+  "arch": "llama",
+  "quant": "q8",
+  "params_b": 23.5724032,
+  "active_b": 23.57198848,
+  "size_bytes": 14333910592
+ },
+ {
+  "gguf": "gemma-4-26B-A4B-it-Q4_K_M.gguf",
+  "runs": [
+   {
+    "engine": "das",
+    "backend": "cpu",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 147.85293629903535,
+      "stddev": 0.48709043860435486
+     },
+     "tg128": {
+      "tok_s": 26.507349722621164,
+      "stddev": 0.29626885056495667
+     }
+    },
+    "source": "official",
+    "sha": "87e926707",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+    "exec_fmt": "weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
+   },
+   {
+    "engine": "das",
+    "backend": "metal",
+    "flavor": "tuned",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 895.5897405729733,
+      "stddev": 5.2121052742004395
+     },
+     "tg128": {
+      "tok_s": 52.20740565342571,
+      "stddev": 2.088243246078491
+     }
+    },
+    "source": "official",
+    "sha": "87e926707",
+    "version": "0.6.3",
+    "tune": "k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+    "exec_fmt": "weights k4/q51/q8 native; q8 activations; f16 scales; metal blob"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "clean-cpu",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 114.417515,
+      "stddev": 1.747994
+     },
+     "tg128": {
+      "tok_s": 27.949045,
+      "stddev": 0.133598
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f",
+    "exec_fmt": "native gguf formats; cpu runtime layout repack"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "cpu",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 148.801335,
+      "stddev": 4.802642
+     },
+     "tg128": {
+      "tok_s": 26.194433,
+      "stddev": 1.906032
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f",
+    "exec_fmt": "native gguf formats; cpu runtime layout repack"
+   },
+   {
+    "engine": "llama.cpp",
+    "backend": "metal",
+    "flavor": "stock",
+    "box": "m1",
+    "threads": 8,
+    "date": "2026-07-21",
+    "cmd": "/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 99 -t 8 -p 512 -n 128 -r 5 -o json",
+    "hardware": {
+     "cpu": "Apple M1 Max",
+     "arch": "arm64",
+     "os": "macOS 26.4.1",
+     "perf_cores": 8,
+     "total_cores": 10,
+     "ram_gb": 64,
+     "gpu": "Apple M1 Max (32-core)"
+    },
+    "tests": {
+     "pp512": {
+      "tok_s": 815.936983,
+      "stddev": 3.435514
+     },
+     "tg128": {
+      "tok_s": 60.049984,
+      "stddev": 0.13615
+     }
+    },
+    "source": "official",
+    "sha": "ebd048f",
+    "exec_fmt": "native gguf formats"
+   }
+  ],
+  "arch": "gemma4",
+  "quant": "q8",
+  "params_b": 25.233142046,
+  "active_b": 3.286564864,
+  "size_bytes": 16947541728
+ }
 ]

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -513,16 +513,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":167.30516157478473,
-            "stddev":2.0537683963775635
+            "tok_s":190.03545401192628,
+            "stddev":2.2559540271759033
           },
           "tg128":{
-            "tok_s":21.55315940749556,
-            "stddev":0.11855021119117737
+            "tok_s":22.081554453555793,
+            "stddev":0.0094171296805143356
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"15ada7b6e",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
       },
@@ -545,12 +545,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":121.73269999999999,
-            "stddev":0.17560700000000001
+            "tok_s":116.498143,
+            "stddev":0.92835299999999998
           },
           "tg128":{
-            "tok_s":19.921785,
-            "stddev":0.27912199999999998
+            "tok_s":20.351991999999999,
+            "stddev":0.02613
           }
         },
         "source":"official",
@@ -575,12 +575,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":181.44897,
-            "stddev":1.5306409999999999
+            "tok_s":190.26942500000001,
+            "stddev":1.1461680000000001
           },
           "tg128":{
-            "tok_s":19.330883,
-            "stddev":0.057210999999999998
+            "tok_s":20.282686000000002,
+            "stddev":0.043990000000000001
           }
         },
         "source":"official",
@@ -605,24 +605,55 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":765.32405100000005,
-            "stddev":207.48539299999999
+            "tok_s":917.29826700000001,
+            "stddev":0.92462800000000001
           },
           "tg128":{
-            "tok_s":40.159846999999999,
-            "stddev":1.800942
+            "tok_s":52.324300999999998,
+            "stddev":0.14776800000000001
           }
         },
         "source":"official",
         "sha":"ebd048f"
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-07-21",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.4.1",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)"
+        },
+        "tests":{
+          "pp512":{
+            "tok_s":785.46586477772325,
+            "stddev":5.3444986343383789
+          },
+          "tg128":{
+            "tok_s":50.485279926238185,
+            "stddev":0.16427034139633179
+          }
+        },
+        "source":"official",
+        "sha":"15ada7b6e",
+        "version":"0.6.3",
+        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
       }
     ],
     "arch":"gemma4",
     "quant":"q8",
     "params_b":7.5180692899999997,
     "active_b":4.5888307199999998,
-    "size_bytes":8031242688,
-    "note":"das Metal decode does not serve the E-series graph yet — das rows are CPU only"
+    "size_bytes":8031242688
   },
   {
     "gguf":"gpt-oss-20b-mxfp4.gguf",

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -105,3 +105,15 @@ Always capture COMPLETE logs (the runner does this); grep afterwards, never at c
 a capture-time filter once hid the exact proof line a verification run existed to produce.
 When a fixture claims a size/depth property ("2030 tokens", "crosses 2048"), assert the
 actual number in the test; a resize cap is not evidence.
+
+## Stale truth caches (`<model>.ref.<key>.tsv`)
+
+`cached_ids`/`cached_vals` pin a CPU trajectory into `<gguf>.ref.<key>.tsv` beside the model.
+FREEFORM-prompt caches sit on sub-noise near-ties, so any numerics-adjacent master merge can
+legitimately move the CURRENT CPU trajectory off the cached one — the parity assert then fails
+with the GPU side actually CORRECT (it matches today's CPU). Before declaring a fam-row red a
+regression: (1) stash + clean-tree rerun (same red ⇒ not your diff), (2) `mv` the cell's `.ref`
+tsv aside and rerun — a fresh-truth green means stale cache, keep the refreshed tsv. Counting
+caches are tie-proof by construction and should NOT move; a counting-cache mismatch is a real
+red. (2026-07-21: gemma4-12b/k4 `gen_free_n24` flipped at token 22 after the #3518/#3530 window
+while both counting caches held.)

--- a/modules/dasLLAMA/tests/test_kquant.das
+++ b/modules/dasLLAMA/tests/test_kquant.das
@@ -120,6 +120,35 @@ def private build_q40_block() : array<uint8> {
     return <- blkb
 }
 
+// q51 synthetic 32-block index `blk`: f16-exact d/m varied per block, elem k = q5_pat(k + blk)
+// (shifted per block so an inter-block offset bug can't cancel); disk layout [d][m][qh][qs].
+def private q51_d(blk : int) : float => float(blk % 7 + 1) * 0.0625
+def private q51_m(blk : int) : float => float(blk % 5) * 0.25 - 0.5
+
+def private build_q51_block(blk : int) : array<uint8> {
+    var b : array<uint8>
+    b |> resize(24)
+    let dbits = f32_to_f16(q51_d(blk))
+    let mbits = f32_to_f16(q51_m(blk))
+    b[0] = uint8(dbits & 0xFF)
+    b[1] = uint8(dbits >> 8u)
+    b[2] = uint8(mbits & 0xFF)
+    b[3] = uint8(mbits >> 8u)
+    var qh = 0u
+    for (k in range(32)) {   // qh bit k = the 5th bit of element k
+        if ((q5_pat(k + blk) & 16) != 0) {
+            qh |= 1u << uint(k)
+        }
+    }
+    for (i in range(4)) {
+        b[4 + i] = uint8(qh >> uint(i * 8))
+    }
+    for (j in range(16)) {   // byte j: element blk32+j low nibble, +16 high nibble
+        b[8 + j] = uint8((q5_pat(j + blk) & 15) | ((q5_pat(j + 16 + blk) & 15) << 4))
+    }
+    return <- b
+}
+
 [test]
 def test_q4k_synthetic(t : T?) {
     t |> run("Q4_K superblock unpacks the 6-bit scale/min packing") @(t : T?) {
@@ -226,6 +255,23 @@ def test_kq_transcode_planes(t : T?) {
             t |> success(dst[k] == expected, "q40 plane element must match hand-packed value exactly")
         }
     }
+    t |> run("q51 planes unpack the hand-packed Q5_1 blocks exactly") @(t : T?) {
+        for (blk in range(4)) {
+            let blkb <- build_q51_block(blk)
+            var kq : array<uint8>
+            var ks : array<uint8>
+            kq |> resize(20)
+            ks |> resize(4)
+            transcode_q51_block(blkb, 0l, kq, 0l, ks, 0l)
+            var dst : array<float>
+            dst |> resize(32)
+            dequant_q51_plane_block(kq, 0l, ks, 0l, dst, 0l)
+            for (k in range(32)) {
+                let expected = q51_d(blk) * float(q5_pat(k + blk)) + q51_m(blk)
+                t |> success(dst[k] == expected, "q51 plane element must match hand-packed value exactly")
+            }
+        }
+    }
 }
 
 // XOR the quant payload of a synthetic superblock with an LCG byte stream — every quant bit
@@ -236,6 +282,149 @@ def private perturb_quants(var blkb : array<uint8>; qoff, qlen : int) {
     for (i in range(qlen)) {
         st = st * 1664525u + 1013904223u
         blkb[qoff + i] = uint8(uint(blkb[qoff + i]) ^ (st >> 16u))
+    }
+}
+
+// ===== q51 kernel gates (per-32 planes, Q8_0-form activations — NOT the kq superblock lattice) =====
+
+// Fill `rows` q51 plane rows of n elements; row r block b packs build_q51_block(r*31 + b) so no
+// two blocks anywhere share data (offset bugs can't cancel).
+def private q51_fill_planes(var kq : array<uint8>; var ks : array<uint8>; rows, n : int64) {
+    let nb = n / 32l
+    kq |> resize(rows * nb * 20l)
+    ks |> resize(rows * nb * 4l)
+    for (r in range64(rows)) {
+        for (b in range64(nb)) {
+            let blkb <- build_q51_block(int(r * 31l + b))
+            transcode_q51_block(blkb, 0l, kq, (r * nb + b) * 20l, ks, (r * nb + b) * 4l)
+        }
+    }
+}
+
+// smooth per-row-shifted activation rows -> the Q8_0-form image (per-32 scales, no block sums)
+def private q51_fill_acts(var xq : array<int8>; var xs : array<float>; rows, n : int64) {
+    var src : array<float>
+    src |> resize(n)
+    xq |> resize(rows * n)
+    xs |> resize(rows * (n / 32l))
+    for (r in range64(rows)) {
+        for (i in range64(n)) {
+            src[i] = 1.7 * sin(float(i + r * 37l) * 0.23) + 0.3 * cos(float(i) * 0.071)
+        }
+        quantize_q8_0_into(src, n, xq, xs, r * n, r * (n / 32l))
+    }
+    delete src
+}
+
+def private q51_dot_gate(t : T?) {
+    let n = 704l   // the real 26B-A4B expert row: % 32, NOT % 256 — why the tier exists
+    let nb = n / 32l
+    var kq : array<uint8>
+    var ks : array<uint8>
+    q51_fill_planes(kq, ks, 1l, n)
+    var w : array<float>
+    w |> resize(n)
+    for (b in range64(nb)) {
+        dequant_q51_plane_block(kq, b * 20l, ks, b * 4l, w, b * 32l)
+    }
+    var xq : array<int8>
+    var xs : array<float>
+    q51_fill_acts(xq, xs, 1l, n)
+    var ref = 0.0lf
+    for (i in range64(n)) {
+        ref += double(w[i]) * double(xq[i]) * double(xs[i / 32l])
+    }
+    let got = dot_q51q8_scalar(unsafe(addr(kq[0])), unsafe(addr(ks[0])), unsafe(addr(xq[0])), unsafe(addr(xs[0])), n)
+    let denom = max(abs(float(ref)), 1.0e-6)
+    t |> success(abs(got - float(ref)) / denom < 1.0e-4, "dot_q51q8_scalar must match the fp64 plane-dequant reference")
+}
+
+def private q51_groupn_gate(t : T?) {
+    let n = 704l
+    let nb = n / 32l
+    let d = 8l
+    let nreg = 3l
+    var kq : array<uint8>
+    var ks : array<uint8>
+    q51_fill_planes(kq, ks, nreg * d, n)
+    var xq : array<int8>
+    var xs : array<float>
+    q51_fill_acts(xq, xs, nreg, n)
+    var offs : array<int64>
+    offs |> reserve(nreg * 2l)
+    for (r in range64(nreg)) {   // (weight element off, activation element off) pairs
+        offs |> push(r * d * n)
+        offs |> push(r * n)
+    }
+    var y : array<float>
+    y |> resize(nreg * d)
+    matmul_q51q8_groupn(y, kq, ks, offs, nreg, xq, xs, n, d)
+    unsafe {
+        for (r in range64(nreg)) {
+            for (row in range64(d)) {
+                let want = dot_q51q8_scalar(addr(kq[(r * d + row) * nb * 20l]), addr(ks[(r * d + row) * nb * 4l]),
+                    addr(xq[r * n]), addr(xs[r * (n / 32l)]), n)
+                t |> success(y[r * d + row] == want, "q51 groupn row must bit-match the scalar row dot")
+            }
+        }
+    }
+}
+
+def private q51_batch_gate(t : T?) {
+    let n = 704l
+    let nb = n / 32l
+    let d = 8l
+    let ntok = 5l
+    let nreg = 2l
+    var kq : array<uint8>
+    var ks : array<uint8>
+    q51_fill_planes(kq, ks, nreg * d, n)
+    var xq : array<int8>
+    var xs : array<float>
+    q51_fill_acts(xq, xs, ntok, n)
+    // batch off region 1's rows — the non-zero element woff pins the wrapper's /32*20 plane math
+    var y : array<float>
+    y |> resize(ntok * d)
+    matmul_q51q8_batch(y, kq, ks, d * n, xq, xs, n, d, ntok)
+    unsafe {
+        for (tk in range64(ntok)) {
+            for (row in range64(d)) {
+                let want = dot_q51q8_scalar(addr(kq[(d + row) * nb * 20l]), addr(ks[(d + row) * nb * 4l]),
+                    addr(xq[tk * n]), addr(xs[tk * (n / 32l)]), n)
+                t |> success(y[tk * d + row] == want, "q51 batch cell must bit-match the scalar row dot")
+            }
+        }
+    }
+    // batch groupn: (woff, row0, cnt) triples — tokens 0..2 hit region 0, 2..5 region 1
+    let offs <- [0l, 0l, 2l, d * n, 2l, 3l]
+    var yg : array<float>
+    yg |> resize(ntok * d)
+    matmul_q51q8_batch_groupn(yg, kq, ks, offs, nreg, xq, xs, n, d)
+    unsafe {
+        for (r in range64(nreg)) {
+            let row0 = offs[r * 3l + 1l]
+            let cnt = offs[r * 3l + 2l]
+            for (tk in range64(cnt)) {
+                for (row in range64(d)) {
+                    let want = dot_q51q8_scalar(addr(kq[(r * d + row) * nb * 20l]), addr(ks[(r * d + row) * nb * 4l]),
+                        addr(xq[(row0 + tk) * n]), addr(xs[(row0 + tk) * (n / 32l)]), n)
+                    t |> success(yg[(row0 + tk) * d + row] == want, "q51 batch-groupn cell must bit-match the scalar row dot")
+                }
+            }
+        }
+    }
+}
+
+[test]
+def test_q51_kernels(t : T?) {
+    t |> run("dot_q51q8_scalar matches the fp64 plane-dequant reference at n=704") @(t : T?) {
+        q51_dot_gate(t)
+    }
+    t |> run("q51 groupn bit-matches scalar row dots") @(t : T?) {
+        q51_groupn_gate(t)
+    }
+    t |> run("q51 batch + batch-groupn bit-match scalar row dots") @(t : T?) {
+        q51_batch_gate(t)
     }
 }
 

--- a/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
@@ -6,6 +6,7 @@ require dasllama/dasllama_quant  // nolint:STYLE030 — used only inside the App
 require ?das_metal dasllama/dasllama_metal_prefill  // nolint:STYLE030 — the Phase-6 prefill kernel set (Apple builds)
 require ?das_metal dasllama/dasllama_metal_kernels  // nolint:STYLE030 — the Wave C MoE routing kernel set (Apple builds)
 require ?das_metal metal/das_metal_boost  // nolint:STYLE030 — device/pipeline/buffer plumbing + the leak gate
+require llvm/daslib/f16_cvt  // f32_to_f16: the q51 gates hand-pack f16 d/m scale halfwords
 require math
 
 // The Phase-6 GPU prefill kernels vs their dasLLAMA CPU twins on synthetic data. rmsnorm /
@@ -472,6 +473,15 @@ def test_metal_prefill_kernels(t : T?) {
                 moe_gemv_gate(t, dev, queue, 64, 24, 5, 3, 3, false)   // batch streams, shared-x form
                 moe_gemv_gate(t, dev, queue, 64, 24, 5, 3, 3, true)    // batch streams, down form
                 moe_combine_gate(t, dev, queue, 200, 4)
+
+                // ===== q51 expert kernels (the 26B-A4B Q4_K_M down stacks) =====
+                // exact-arithmetic q51 planes (pow2 d, quarter m, int x) — BIT-exact both kernels;
+                // n = 96 covers 3 blocks/row, the mulmm shapes cover padded CSR tails (ce % 32)
+                moe_gemv_q51_gate(t, dev, queue, 96, 24, 5, 3, 1, false)   // gate/up site (shared x)
+                moe_gemv_q51_gate(t, dev, queue, 64, 32, 7, 4, 1, true)    // down site (per-slot x)
+                moe_gemv_q51_gate(t, dev, queue, 64, 24, 5, 3, 3, true)    // batch streams, down form
+                moe_mulmm_q51_gate(t, dev, queue, 64, 64, [32, 40, 64])    // padded tail on expert 1
+                moe_mulmm_q51_gate(t, dev, queue, 96, 128, [8, 96])        // 2 col tiles, tiny run + multi-tile
 
                 // ===== deltanet kernels (Wave D) =====
                 // the chain gates compare each stage at its seam vs a sequential CPU mirror;
@@ -948,6 +958,238 @@ def private moe_gemv_gate(t : T?; dev, queue; n, d, net, k, nst : int; perslot :
     delete wq
     delete ws
     delete sel
+    delete xv
+    delete want
+}
+
+// Build q51 plane pairs for `rows` rows of n elements: patterned 5-bit quants (position-
+// dependent), pow2 f16 d + quarter-value f16 m — every product/sum dyadic, so the CPU float
+// reference is BIT-exact under any GPU reduction order.
+def private q51_test_planes(rows, n : int; var qp : array<uint8>; var sp : array<uint8>; var wref : array<float>) {
+    let nb = n / 32
+    let dlut = fixed_array(0.25, 0.5, 1.0, 2.0)
+    let mlut = fixed_array(-1.0, 0.5, 1.25, -0.25)
+    qp |> resize(rows * nb * 20)
+    sp |> resize(rows * nb * 4)
+    wref |> resize(rows * n)
+    for (b in range(rows * nb)) {
+        let d = dlut[(b / 3) % 4]
+        let m = mlut[(b * 5 + 1) % 4]
+        let dbits = f32_to_f16(d)
+        let mbits = f32_to_f16(m)
+        sp[b * 4] = uint8(dbits & 0xFF)
+        sp[b * 4 + 1] = uint8(dbits >> 8u)
+        sp[b * 4 + 2] = uint8(mbits & 0xFF)
+        sp[b * 4 + 3] = uint8(mbits >> 8u)
+        var qh = 0u
+        for (i in range(32)) {
+            let q = (b * 11 + i * 7 + i / 3) % 32
+            wref[b * 32 + i] = d * float(q) + m
+            if ((q & 16) != 0) {
+                qh |= 1u << uint(i)
+            }
+            if (i < 16) {
+                qp[b * 20 + i] = uint8(q & 15)
+            } else {
+                qp[b * 20 + i - 16] = uint8(uint(qp[b * 20 + i - 16]) | (uint(q & 15) << 4u))
+            }
+        }
+        for (i in range(4)) {
+            qp[b * 20 + 16 + i] = uint8(qh >> uint(i * 8))
+        }
+    }
+}
+
+// The expert-indexed q51 GEMV on exact-arithmetic q51 planes — moe_gemv_gate's shapes, BIT-exact.
+def private moe_gemv_q51_gate(t : T?; dev, queue; n, d, net, k, nst : int; perslot : bool) {
+    var err : string
+    var pso = pipeline_from_source(dev, metal_moe_gemv_q51_msl, metal_moe_gemv_q51_msl_entry, metal_moe_gemv_q51_msl_fastmath, err)
+    t |> success(pso != null, "moe q51 gemv pipeline: {err}")
+    if (pso == null) {
+        return
+    }
+    let nb = n / 32
+    var qp : array<uint8>
+    var sp : array<uint8>
+    var wref : array<float>
+    q51_test_planes(net * d, n, qp, sp, wref)
+    var sel : array<uint>
+    sel |> resize(nst * 2 * k)
+    for (s in range(nst)) {
+        for (j in range(k)) {
+            sel[s * 2 * k + j] = uint((s + j * 3 + net - 1) % net)
+        }
+    }
+    let xrows = perslot ? nst * k : nst
+    var xv : array<float>
+    xv |> resize(xrows * n)
+    for (i in range(xrows * n)) {
+        xv[i] = float((i * 3) % 9 - 4)
+    }
+    var want : array<float>
+    want |> resize(nst * k * d)
+    for (s in range(nst)) {
+        for (j in range(k)) {
+            let e = int(sel[s * 2 * k + j])
+            let x0 = (perslot ? s * k + j : s) * n
+            for (r in range(d)) {
+                var acc = 0.0
+                for (c in range(n)) {
+                    acc += wref[((e * d + r) * nb) * 32 + c] * xv[x0 + c]
+                }
+                want[(s * k + j) * d + r] = acc
+            }
+        }
+    }
+    var bw = buf_upload(dev, qp)
+    var bs = buf_upload(dev, sp)
+    var bx = buf_upload(dev, xv)
+    var by = buf_fill(dev, nst * k * d, -1000.0)
+    var bn = buf_u32(dev, uint(n))
+    var bd = buf_u32(dev, uint(d))
+    var bsel = buf_upload(dev, sel)
+    var beblk = buf_u32(dev, uint(d * nb))
+    var bxs = buf_u32(dev, perslot ? uint(n) : 0u)
+    var bss = buf_u32(dev, uint(2 * k))
+    var bbxs = buf_u32(dev, uint((perslot ? k : 1) * n))
+    var bbys = buf_u32(dev, uint(k * d))
+    let ran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso)
+        metal_set_buffer(enc, bw, 0ul, 0)
+        metal_set_buffer(enc, bs, 0ul, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bn, 0ul, 4)
+        metal_set_buffer(enc, bd, 0ul, 5)
+        metal_set_buffer(enc, bsel, 0ul, 6)
+        metal_set_buffer(enc, beblk, 0ul, 7)
+        metal_set_buffer(enc, bxs, 0ul, 8)
+        metal_set_buffer(enc, bss, 0ul, 9)
+        metal_set_buffer(enc, bbxs, 0ul, 10)
+        metal_set_buffer(enc, bbys, 0ul, 11)
+        metal_dispatch_threadgroups(enc, uint3(uint((d + 3) / 4), uint(k), uint(nst)), uint3(64u, 1u, 1u))
+    }
+    t |> success(ran, "moe q51 gemv dispatch n={n} d={d} net={net} k={k} nst={nst}: {err}")
+    t |> equal(buf_mismatch_exact(by, want), 0)
+    metal_release(bw)
+    metal_release(bs)
+    metal_release(bx)
+    metal_release(by)
+    metal_release(bn)
+    metal_release(bd)
+    metal_release(bsel)
+    metal_release(beblk)
+    metal_release(bxs)
+    metal_release(bss)
+    metal_release(bbxs)
+    metal_release(bbys)
+    metal_release(pso)
+    delete qp
+    delete sp
+    delete wref
+    delete sel
+    delete xv
+    delete want
+}
+
+// The gathered q51 mul_mm: ne experts with padded-CSR row runs (gather = 0 bucket-rows mode);
+// exact-arithmetic planes (the A tile's f16(d*q + m) values are dyadic <= 63.25 — f16-exact),
+// int x rows — every simdgroup accumulate is exact, so the whole padded y compares BIT-exact.
+def private moe_mulmm_q51_gate(t : T?; dev, queue; kdim, ndim : int; counts : array<int>) {
+    var err : string
+    var pso = pipeline_from_source(dev, metal_moe_mulmm_q51_msl, metal_moe_mulmm_q51_msl_entry, metal_moe_mulmm_q51_msl_fastmath, err)
+    t |> success(pso != null, "moe q51 mulmm pipeline: {err}")
+    if (pso == null) {
+        return
+    }
+    let ne = length(counts)
+    let nb = kdim / 32
+    var qp : array<uint8>
+    var sp : array<uint8>
+    var wref : array<float>
+    q51_test_planes(ne * ndim, kdim, qp, sp, wref)
+    // padded CSR: each expert's rows start at a 32-aligned base (the route prefix contract)
+    var cnt : array<uint>
+    var basep : array<uint>
+    cnt |> reserve(ne)
+    basep |> reserve(ne)
+    var pad = 0
+    for (c in range(ne)) {
+        cnt |> push(uint(counts[c]))
+        basep |> push(uint(pad))
+        pad += (counts[c] + 31) / 32 * 32
+    }
+    var xv : array<float>
+    xv |> resize(pad * kdim)
+    for (i in range(pad * kdim)) {
+        xv[i] = float((i * 5) % 9 - 4)
+    }
+    // padded tail rows are computed from their (defined) x rows too — want covers the WHOLE buffer
+    var want : array<float>
+    want |> resize(pad * ndim)
+    for (e in range(ne)) {
+        let rows = (counts[e] + 31) / 32 * 32
+        for (r in range(rows)) {
+            let row = int(basep[e]) + r
+            for (col in range(ndim)) {
+                var acc = 0.0
+                for (c in range(kdim)) {
+                    acc += wref[(e * ndim + col) * kdim + c] * xv[row * kdim + c]
+                }
+                want[row * ndim + col] = acc
+            }
+        }
+    }
+    var bw = buf_upload(dev, qp)
+    var bs = buf_upload(dev, sp)
+    var bx = buf_upload(dev, xv)
+    var by = buf_fill(dev, pad * ndim, -1000.0)
+    var bkdim = buf_u32(dev, uint(kdim))
+    var bndim = buf_u32(dev, uint(ndim))
+    var bcnt = buf_upload(dev, cnt)
+    var bbase = buf_upload(dev, basep)
+    var bbkt = buf_u32(dev, 0u)   // gather = 0: bkt unread
+    var beblk = buf_u32(dev, uint(ndim * nb))
+    var bnk = buf_u32(dev, 1u)
+    var bgather = buf_u32(dev, 0u)
+    let tiles = (pad + 31) / 32
+    let ran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso)
+        metal_set_threadgroup_memory_length(enc, metal_moe_mulmm_q51_msl_tgmem, 0)
+        metal_set_buffer(enc, bs, 0ul, 0)
+        metal_set_buffer(enc, bw, 0ul, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bkdim, 0ul, 4)
+        metal_set_buffer(enc, bndim, 0ul, 5)
+        metal_set_buffer(enc, bcnt, 0ul, 6)
+        metal_set_buffer(enc, bbase, 0ul, 7)
+        metal_set_buffer(enc, bbkt, 0ul, 8)
+        metal_set_buffer(enc, beblk, 0ul, 9)
+        metal_set_buffer(enc, bnk, 0ul, 10)
+        metal_set_buffer(enc, bgather, 0ul, 11)
+        metal_dispatch_threadgroups(enc, uint3(uint(tiles), uint(ndim / 64), uint(ne)), uint3(128u, 1u, 1u))
+    }
+    t |> success(ran, "moe q51 mulmm dispatch kdim={kdim} ndim={ndim} ne={ne} pad={pad}: {err}")
+    t |> equal(buf_mismatch_exact(by, want), 0)
+    metal_release(bw)
+    metal_release(bs)
+    metal_release(bx)
+    metal_release(by)
+    metal_release(bkdim)
+    metal_release(bndim)
+    metal_release(bcnt)
+    metal_release(bbase)
+    metal_release(bbkt)
+    metal_release(beblk)
+    metal_release(bnk)
+    metal_release(bgather)
+    metal_release(pso)
+    delete qp
+    delete sp
+    delete wref
+    delete cnt
+    delete basep
     delete xv
     delete want
 }

--- a/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_kernels.das
@@ -483,6 +483,11 @@ def test_metal_prefill_kernels(t : T?) {
                 moe_mulmm_q51_gate(t, dev, queue, 64, 64, [32, 40, 64])    // padded tail on expert 1
                 moe_mulmm_q51_gate(t, dev, queue, 96, 128, [8, 96])        // 2 col tiles, tiny run + multi-tile
 
+                // ===== mx4 expert GEMV (reworked to the q51 shape — gpt-oss's decode kernel) =====
+                moe_gemv_mx4_gate(t, dev, queue, 96, 24, 5, 3, 1, false, false)   // gate/up (shared x)
+                moe_gemv_mx4_gate(t, dev, queue, 64, 32, 7, 4, 1, true, true)     // down site + bias rows
+                moe_gemv_mx4_gate(t, dev, queue, 64, 24, 5, 3, 3, true, true)     // batch streams, biased down
+
                 // ===== deltanet kernels (Wave D) =====
                 // the chain gates compare each stage at its seam vs a sequential CPU mirror;
                 // shapes: decode (npos 1), a batch window, npos < taps (history straddle),
@@ -1090,6 +1095,144 @@ def private moe_gemv_q51_gate(t : T?; dev, queue; n, d, net, k, nst : int; persl
     delete sel
     delete xv
     delete want
+}
+
+// The expert-indexed mx4 GEMV on exact-arithmetic planes: nibble values from the signed
+// doubled-e2m1 table, pow2 E8M0 scales, int x — BIT-exact (covers the bias arm too).
+def private moe_gemv_mx4_gate(t : T?; dev, queue; n, d, net, k, nst : int; perslot, bias : bool) {
+    var err : string
+    var pso = pipeline_from_source(dev, metal_moe_gemv_mx4_msl, metal_moe_gemv_mx4_msl_entry, metal_moe_gemv_mx4_msl_fastmath, err)
+    t |> success(pso != null, "moe mx4 gemv pipeline: {err}")
+    if (pso == null) {
+        return
+    }
+    let nb = n / 32
+    let vt = fixed_array(0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0,
+                         0.0, -1.0, -2.0, -3.0, -4.0, -6.0, -8.0, -12.0)
+    var etab : array<float>
+    etab |> resize(256)
+    for (ei in range(256)) {
+        etab[ei] = unsafe(reinterpret<float>(ei < 2 ? (0x00200000u << uint(ei)) : (uint(ei - 1) << 23u)))
+    }
+    var qp : array<uint8>
+    var sp : array<uint8>
+    var wref : array<float>
+    qp |> resize(net * d * nb * 16)
+    sp |> resize(net * d * nb)
+    wref |> resize(net * d * n)
+    for (b in range(net * d * nb)) {
+        let sc = 120 + (b * 3) % 12   // pow2 scales 2^-8 .. 2^3 — every product dyadic
+        sp[b] = uint8(sc)
+        for (i in range(16)) {
+            let nl = (b * 7 + i * 5 + 1) % 16
+            let nh = (b * 11 + i * 3 + 2) % 16
+            qp[b * 16 + i] = uint8(nl | (nh << 4))
+            wref[b * 32 + i] = vt[nl] * etab[sc]
+            wref[b * 32 + 16 + i] = vt[nh] * etab[sc]
+        }
+    }
+    var sel : array<uint>
+    sel |> resize(nst * 2 * k)
+    for (s in range(nst)) {
+        for (j in range(k)) {
+            sel[s * 2 * k + j] = uint((s + j * 3 + net - 1) % net)
+        }
+    }
+    let xrows = perslot ? nst * k : nst
+    var xv : array<float>
+    xv |> resize(xrows * n)
+    for (i in range(xrows * n)) {
+        xv[i] = float((i * 3) % 9 - 4)
+    }
+    var wb : array<float>
+    wb |> resize(net * d)
+    for (i in range(net * d)) {
+        wb[i] = bias ? float(i % 7 - 3) * 0.25 : 0.0
+    }
+    var want : array<float>
+    want |> resize(nst * k * d)
+    for (s in range(nst)) {
+        for (j in range(k)) {
+            let e = int(sel[s * 2 * k + j])
+            let x0 = (perslot ? s * k + j : s) * n
+            for (r in range(d)) {
+                var acc = 0.0
+                for (c in range(n)) {
+                    acc += wref[(e * d + r) * n + c] * xv[x0 + c]
+                }
+                want[(s * k + j) * d + r] = acc + (bias ? wb[e * d + r] : 0.0)
+            }
+        }
+    }
+    var bw = buf_upload(dev, qp)
+    var bs = buf_upload(dev, sp)
+    var bx = buf_upload(dev, xv)
+    var by = buf_fill(dev, nst * k * d, -1000.0)
+    var bn = buf_u32(dev, uint(n))
+    var bd = buf_u32(dev, uint(d))
+    var bsel = buf_upload(dev, sel)
+    var beblk = buf_u32(dev, uint(d * nb))
+    var bxs = buf_u32(dev, perslot ? uint(n) : 0u)
+    var bss = buf_u32(dev, uint(2 * k))
+    var bbxs = buf_u32(dev, uint((perslot ? k : 1) * n))
+    var bbys = buf_u32(dev, uint(k * d))
+    var bwb = buf_upload(dev, wb)
+    var bhasb = buf_u32(dev, bias ? 1u : 0u)
+    var betab = buf_upload(dev, etab)
+    var vtf : array<float>
+    vtf |> resize(16)
+    for (i in range(16)) {
+        vtf[i] = vt[i]
+    }
+    var bvt = buf_upload(dev, vtf)
+    let ran = with_compute_encoder(queue, err) $(enc : MetalComputeEncoder?) {
+        metal_set_pipeline(enc, pso)
+        metal_set_buffer(enc, bw, 0ul, 0)
+        metal_set_buffer(enc, bs, 0ul, 1)
+        metal_set_buffer(enc, bx, 0ul, 2)
+        metal_set_buffer(enc, by, 0ul, 3)
+        metal_set_buffer(enc, bn, 0ul, 4)
+        metal_set_buffer(enc, bd, 0ul, 5)
+        metal_set_buffer(enc, bsel, 0ul, 6)
+        metal_set_buffer(enc, beblk, 0ul, 7)
+        metal_set_buffer(enc, bxs, 0ul, 8)
+        metal_set_buffer(enc, bss, 0ul, 9)
+        metal_set_buffer(enc, bbxs, 0ul, 10)
+        metal_set_buffer(enc, bbys, 0ul, 11)
+        metal_set_buffer(enc, bwb, 0ul, 12)
+        metal_set_buffer(enc, bhasb, 0ul, 13)
+        metal_set_buffer(enc, betab, 0ul, 14)
+        metal_set_buffer(enc, bvt, 0ul, 15)
+        metal_dispatch_threadgroups(enc, uint3(uint((d + 3) / 4), uint(k), uint(nst)), uint3(64u, 1u, 1u))
+    }
+    t |> success(ran, "moe mx4 gemv dispatch n={n} d={d} net={net} k={k} nst={nst} bias={bias}: {err}")
+    t |> equal(buf_mismatch_exact(by, want), 0)
+    metal_release(bw)
+    metal_release(bs)
+    metal_release(bx)
+    metal_release(by)
+    metal_release(bn)
+    metal_release(bd)
+    metal_release(bsel)
+    metal_release(beblk)
+    metal_release(bxs)
+    metal_release(bss)
+    metal_release(bbxs)
+    metal_release(bbys)
+    metal_release(bwb)
+    metal_release(bhasb)
+    metal_release(betab)
+    metal_release(bvt)
+    metal_release(pso)
+    delete etab
+    delete qp
+    delete sp
+    delete wref
+    delete sel
+    delete xv
+    delete wb
+    delete want
+    delete vtf
 }
 
 // The gathered q51 mul_mm: ne experts with padded-CSR row runs (gather = 0 bucket-rows mode);

--- a/modules/dasLLAMA/tests/test_metal_support_matrix.das
+++ b/modules/dasLLAMA/tests/test_metal_support_matrix.das
@@ -858,6 +858,118 @@ def private qwen2moe_row(t : T?; path : string) {
 }
 
 [unused_argument(t, path)]   // off-Apple the gated body is empty
+def private gemma4e_row(t : T?; path : string) {
+    // gemma-4 E-series (E4B): PLE (per-layer embeddings — MetalNeed.ple) + cross-layer KV
+    // sharing (the last 18 layers are Q-only and alias layer 22/23's slab/panels). Decode +
+    // prefill ENGAGE on the blob twin; batch has NO ple arm — the decline cell runs on the
+    // PLANAR model (the blob twin's CPU batch fallback would trip the blob-only panic).
+    static_if (typeinfo builtin_module_exists(das_metal)) {
+        if (!family_on(t, "gemma4e") || !arm_on(t, "fam-gemma4e") || !model_available(t, path)) {
+            return
+        }
+        var tr <- load_model(path, QuantMode.q8)
+        tr.config.seq_len = min(tr.config.seq_len, 512l)
+        let want_bits = (MetalNeed.neox | MetalNeed.qk_norm | MetalNeed.v_norm | MetalNeed.attn_scale |
+            MetalNeed.sliding | MetalNeed.pre_post_norm | MetalNeed.out_scale | MetalNeed.geglu |
+            MetalNeed.ple | MetalNeed.qd_neq_dim)
+        let derived = metal_needs(tr)
+        t |> success((uint(derived) & uint(want_bits)) == uint(want_bits),
+            "gemma4e-e4b: metal_needs derives {want_bits} (got {derived})")
+        var nshared = 0l
+        for (l in range64(tr.config.n_layers)) {
+            if (tr.kv_src[l] != l) {
+                nshared++
+            }
+        }
+        t |> success(nshared > 0l, "gemma4e-e4b: fixture carries cross-layer KV sharing ({nshared} shared layers)")
+        var trg <- blob_twin(t, path, 512l)
+        let c = trg.config
+        let vocab = c.vocab_size
+        let pf0 = metal_prefill_stats().prefills
+        let de0 = metal_decode_stats().decodes
+        let ba0 = metal_batch_decode_stats().steps
+        var bad0 <- metal_batch_decode_declines()
+        with_job_que() {
+            setup_dasllama_jobque()
+            var sa = make_run_state(c, KVDtype.f16, KVDtype.f16)
+            let pa <- encode(trg, counting_prompt(1, 40), true, false)
+            let pb <- encode(trg, counting_prompt(5, 44), true, false)
+            t |> success(select_prefill_override("metal"), "gemma4e-e4b: prefill override registered")
+            t |> success(select_decode_override("metal"), "gemma4e-e4b: decode override registered")
+            set_metal_prefill_min_npos(1l)
+            eval_(trg, sa, pa)
+            var cura = greedy_top(sa.logits, vocab)
+            for (_i in range(2)) {
+                var one <- [cura]
+                eval_(trg, sa, one)
+                delete one
+                cura = greedy_top(sa.logits, vocab)
+            }
+            // batch decline cell on the PLANAR model: the gate records need_ple, CPU serves
+            var sc = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            var sd = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            eval_(tr, sc, pa)
+            eval_(tr, sd, pb)
+            var ws <- create_batch_workspace_(tr)
+            var sess : array<Session?>
+            unsafe {
+                sess |> push(addr(sc))
+                sess |> push(addr(sd))
+            }
+            var cur <- [greedy_top(sc.logits, vocab), greedy_top(sd.logits, vocab)]
+            eval_batch_(tr, ws, sess, cur)
+            select_decode_override("")
+            select_prefill_override("")
+            set_metal_prefill_min_npos(64l)
+            sess |> clear()   // drop the borrowed handles: delete of array<T?> cascades to the pointees
+            unsafe {
+                delete ws
+                delete sess
+            }
+            delete cur
+            delete sa
+            delete sc
+            delete sd
+        }
+        t |> success(metal_prefill_stats().prefills - pf0 > 0l, "gemma4e-e4b prefill: ENGAGES on the GPU")
+        t |> success(metal_decode_stats().decodes - de0 > 0l, "gemma4e-e4b decode: ENGAGES on the GPU")
+        var bad <- metal_batch_decode_declines()
+        t |> equal(metal_batch_decode_stats().steps - ba0, 0l)
+        t |> success((bad?["need_ple"] ?? 0l) - (bad0?["need_ple"] ?? 0l) > 0l,
+            "gemma4e-e4b batch: declines with need_ple (no PLE batch arm)")
+        delete bad0
+        delete bad
+        let prompt <- encode(tr, counting_prompt(1, 30), true, false)
+        var cpu_ids : array<int64>
+        var gpu_ids : array<int64>
+        with_job_que() {
+            setup_dasllama_jobque()
+            var s = make_run_state(tr.config, KVDtype.f16, KVDtype.f16)
+            let ids <- generate(tr, s, prompt, length(prompt) + 8)
+            cpu_ids := ids
+            delete s
+            select_decode_override("metal")
+            select_prefill_override("metal")
+            set_metal_prefill_min_npos(1l)
+            var s2 = make_run_state(trg.config, KVDtype.f16, KVDtype.f16)
+            let ids2 <- generate(trg, s2, prompt, length(prompt) + 8)
+            gpu_ids := ids2
+            delete s2
+            set_metal_prefill_min_npos(64l)
+            select_decode_override("")
+            select_prefill_override("")
+        }
+        t |> success(same(cpu_ids, gpu_ids),
+            "gemma4e-e4b: metal-overrides generate matches the CPU truth token-for-token")
+        delete cpu_ids
+        delete gpu_ids
+        cont_logits_cell(t, tr, trg, "gemma4e-e4b/q8/f16", 8.0)
+        delete trg
+        delete tr
+    }
+}
+
+[unused_argument(t, path)]   // off-Apple the gated body is empty
 def private gemma4moe_row(t : T?; path : string) {
     // gemma4-26B-A4B (Wave C stage 3): the parallel dense-shared + routed MoE graph. TOKEN
     // parity is NOT a valid instrument here (wave ruling): the CPU router's double norm is an
@@ -1430,6 +1542,10 @@ def test_metal_family_matrix(t : T?) {
             // gemma4-26B-A4B (Wave C stage 3): the parallel dense-shared + routed graph —
             // ENGAGE cells + shallow logits tolerances (see the row's ruling comment)
             gemma4moe_row(t, path_join(models_dir(), "gemma-4-26B-A4B-it-Q8_0.gguf"))
+            // gemma-4 E-series (E4B): PLE (MetalNeed.ple) + cross-layer KV sharing — decode +
+            // prefill serve, batch declines need_ple. 7.2GB — DASLLAMA_PARITY_FULL-gated.
+            // (E2B stays on the `layers` decline: per-layer FFN width, no per-layer u_hidden yet.)
+            gemma4e_row(t, path_join(models_dir(), "gemma-4-E4B-it-Q8_0.gguf"))
             // gpt-oss-20b (Wave C stage 4): mx4 experts + sinks + softmax_weight + biases
             gptoss_row(t, path_join(models_dir(), "gpt-oss-20b-mxfp4.gguf"))
             // qwen35 (Wave D): the Gated-DeltaNet hybrid — 3-in-4 recurrent layers (state

--- a/modules/dasLLAMA/tests/test_metal_support_matrix.das
+++ b/modules/dasLLAMA/tests/test_metal_support_matrix.das
@@ -969,8 +969,8 @@ def private gemma4e_row(t : T?; path : string) {
     }
 }
 
-[unused_argument(t, path)]   // off-Apple the gated body is empty
-def private gemma4moe_row(t : T?; path : string) {
+[unused_argument(t, path, tag, tol_pf, tol_step)]   // off-Apple the gated body is empty
+def private gemma4moe_row(t : T?; path : string; tag : string; tol_pf : float = 8.0; tol_step : float = 16.0) {
     // gemma4-26B-A4B (Wave C stage 3): the parallel dense-shared + routed MoE graph. TOKEN
     // parity is NOT a valid instrument here (wave ruling): the CPU router's double norm is an
     // inverse TEMPERATURE on the expert softmax and the model amplifies ANY float-class
@@ -986,11 +986,11 @@ def private gemma4moe_row(t : T?; path : string) {
         tr.config.seq_len = min(tr.config.seq_len, 512l)
         let c = tr.config
         t |> success(c.moe && c.moe_dense_shexp && c.n_expert == 128l && c.n_expert_used == 8l,
-            "gemma4moe-26b: MoE geometry loads (ne={c.n_expert} k={c.n_expert_used} nfe={c.n_ff_exp})")
+            "{tag}: MoE geometry loads (ne={c.n_expert} k={c.n_expert_used} nfe={c.n_ff_exp})")
         let derived = metal_needs(tr)
         let expected = MetalNeed.neox | MetalNeed.qk_norm | MetalNeed.sliding | MetalNeed.v_norm
         t |> success((derived & expected) == expected,
-            "gemma4moe-26b: metal_needs derives {expected} (got {derived})")
+            "{tag}: metal_needs derives {expected} (got {derived})")
         let vocab = c.vocab_size
         var prompt <- encode(tr, counting_prompt(1, 20), true, false)
         var lg0 : array<float>
@@ -1010,7 +1010,7 @@ def private gemma4moe_row(t : T?; path : string) {
         }
         delete tr
         var trg <- blob_twin(t, path, 512l)
-        matrix_cell(t, trg, KVDtype.f16, "gemma4moe-26b/q8/f16", "", "", "")
+        matrix_cell(t, trg, KVDtype.f16, "{tag}/q8/f16", "", "", "")
         var mpf = 0.0
         var m1 = 0.0
         var served = 0l
@@ -1038,10 +1038,10 @@ def private gemma4moe_row(t : T?; path : string) {
             select_decode_override("")
             delete s
         }
-        t |> success(served == 2l, "gemma4moe-26b: GPU prefill + forced step both served ({served}/2)")
-        t |> success(mpf <= 8.0, "gemma4moe-26b: post-prefill logits within 8.0 of the CPU truth (measured {mpf})")
-        t |> success(m1 <= 16.0, "gemma4moe-26b: one forced step within 16.0 of the CPU truth (measured {m1})")
-        to_log(LOG_INFO, "gemma4moe-26b tolerance cells: post-prefill maxd={mpf} (tol 8), forced step maxd={m1} (tol 16)\n")
+        t |> success(served == 2l, "{tag}: GPU prefill + forced step both served ({served}/2)")
+        t |> success(mpf <= tol_pf, "{tag}: post-prefill logits within {tol_pf} of the CPU truth (measured {mpf})")
+        t |> success(m1 <= tol_step, "{tag}: one forced step within {tol_step} of the CPU truth (measured {m1})")
+        to_log(LOG_INFO, "{tag} tolerance cells: post-prefill maxd={mpf} (tol {tol_pf}), forced step maxd={m1} (tol {tol_step})\n")
         delete lg0
         delete lg1
         delete prompt
@@ -1541,7 +1541,12 @@ def test_metal_family_matrix(t : T?) {
                 "", KVDtype.f16, 6.0)
             // gemma4-26B-A4B (Wave C stage 3): the parallel dense-shared + routed graph —
             // ENGAGE cells + shallow logits tolerances (see the row's ruling comment)
-            gemma4moe_row(t, path_join(models_dir(), "gemma-4-26B-A4B-it-Q8_0.gguf"))
+            gemma4moe_row(t, path_join(models_dir(), "gemma-4-26B-A4B-it-Q8_0.gguf"), "gemma4moe-26b")
+            // ... and the community Q4_K_M file: k4 gate_up + NATIVE q51 down expert stacks —
+            // the q51 Metal GEMV/mul_mm twins' model-level pin (15.9GB, PARITY_FULL-gated).
+            // Wider step bar: the k4/q51 f16-tile paths measure 13.8 under the same double-router
+            // amplifier (post-prefill stays 2.5-class); 24 keeps the ~2x margin discipline
+            gemma4moe_row(t, path_join(models_dir(), "gemma-4-26B-A4B-it-Q4_K_M.gguf"), "gemma4moe-26b-k", 8.0, 24.0)
             // gemma-4 E-series (E4B): PLE (MetalNeed.ple) + cross-layer KV sharing — decode +
             // prefill serve, batch declines need_ple. 7.2GB — DASLLAMA_PARITY_FULL-gated.
             // (E2B stays on the `layers` decline: per-layer FFN width, no per-layer u_hidden yet.)

--- a/site/dasllama.html
+++ b/site/dasllama.html
@@ -108,6 +108,7 @@
   .dl-bench-model__head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 6px 14px; }
   .dl-bench-model__name { font-family: var(--font-mono); font-size: 14px; font-weight: 600; color: var(--fg); overflow-wrap: anywhere; }
   .dl-bench-model__meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-faint); }
+  .dl-bench-model__note { font-family: var(--font-mono); font-size: 10.5px; color: var(--amber-dim); margin-top: 6px; }
   .dl-bench-box { margin-top: 14px; }
   .dl-bench-box__name { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); margin-bottom: 4px; }
   .dl-bench-cols, .dl-bench-row { display: grid; grid-template-columns: 210px 1fr 84px 84px 72px; gap: 12px; align-items: center; padding: 4px 8px; }

--- a/site/dasllama.html
+++ b/site/dasllama.html
@@ -103,6 +103,28 @@
   .dl-td-model { color: var(--fg); }
   .dl-plat { font-family: var(--font-mono); font-size: 11px; color: var(--fg-faint); margin-top: 14px; }
 
+  /* per-model benchmark leaderboard */
+  .dl-bench-model { border: 1px solid var(--rule); border-radius: 8px; background: var(--bg-2); margin-top: 18px; padding: 18px 20px; }
+  .dl-bench-model__head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 6px 14px; }
+  .dl-bench-model__name { font-family: var(--font-mono); font-size: 14px; font-weight: 600; color: var(--fg); overflow-wrap: anywhere; }
+  .dl-bench-model__meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-faint); }
+  .dl-bench-box { margin-top: 14px; }
+  .dl-bench-box__name { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); margin-bottom: 4px; }
+  .dl-bench-cols, .dl-bench-row { display: grid; grid-template-columns: 210px 1fr 84px 84px 72px; gap: 12px; align-items: center; padding: 4px 8px; }
+  .dl-bench-cols { font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); }
+  .dl-bench-cols span:nth-child(n+3) { text-align: right; }
+  .dl-bench-row { border-radius: 4px; cursor: pointer; }
+  .dl-bench-row:hover { background: rgba(232,161,58,0.05); }
+  .dl-bench-row__eng { font-family: var(--font-mono); font-size: 12px; color: var(--fg-dim); }
+  .dl-bench-row--das .dl-bench-row__eng { color: var(--amber); }
+  .dl-bench-row--win .dl-bench-row__eng { font-weight: 700; }
+  .dl-bench-row__tags { color: var(--fg-faint); font-size: 10px; }
+  .dl-bench-row__track { height: 13px; background: var(--bg-3); border-radius: 3px; overflow: hidden; }
+  .dl-bench-row__fill { height: 100%; border-radius: 3px; background: var(--fg-faint); }
+  .dl-bench-row--das .dl-bench-row__fill { background: var(--amber); }
+  .dl-bench-row__num, .dl-bench-row__ratio { font-family: var(--font-mono); font-size: 12px; text-align: right; color: var(--fg); }
+  .dl-bench-receipt { font-family: var(--font-mono); font-size: 10.5px; line-height: 1.6; color: var(--fg-dim); background: var(--bg-3); border-radius: 6px; padding: 10px 12px; margin: 4px 0 8px; overflow-x: auto; white-space: pre; }
+
   /* ASR */
   .dl-asr-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
   .dl-asr-model { border: 1px solid var(--rule); border-radius: 8px; padding: 20px 22px; background: var(--bg-2); }
@@ -133,6 +155,7 @@
   @media (max-width: 900px) {
     .dl-asr-grid, .dl-blowouts, .dl-caveats { grid-template-columns: 1fr; }
     .dl-bar { grid-template-columns: 110px 1fr 52px; }
+    .dl-bench-cols, .dl-bench-row { grid-template-columns: 128px 1fr 60px 60px 48px; gap: 8px; }
     .dl-axis { padding: 0 52px 0 110px; }
   }
 </style>
@@ -290,10 +313,29 @@ def main() {
         </div>
     </section>
 
-    <!-- § 02 ASR -->
-    <section class="forge-section forge-section--alt">
+    <!-- § 02 per-model benchmarks (leaderboard from bench_records.json; hidden until records exist) -->
+    <section class="forge-section forge-section--alt" id="bench" hidden>
         <div class="forge-container">
-            <div class="forge-section-label"><span class="forge-section-label__num">§ 02</span><span class="forge-section-label__rule"></span><span>speech-to-text</span></div>
+            <div class="forge-section-label"><span class="forge-section-label__num">§ 02</span><span class="forge-section-label__rule"></span><span>per-model benchmarks</span></div>
+            <h2 class="forge-h2">Every engine, every machine, one list.</h2>
+            <p class="forge-p">One group per model &times; machine, every configuration a row, sorted by measured speed. llama.cpp appears in both reference builds &mdash; <em>clean-cpu</em> (no Accelerate/BLAS, kernel-vs-kernel) and <em>stock</em> (as shipped: Accelerate on macOS, plus its Metal backend at <code>-ngl 99</code>). Click a row for its receipt: the exact command lines, commits, tune state, and auto-probed hardware. pp512 = 512-token prefill, tg128 = 128-token greedy decode, tok/s, higher is better. The ratio column compares each das row with the best llama.cpp row on the same backend.</p>
+
+            <div class="dl-toggles">
+                <span class="dl-seg__caption">sort by</span>
+                <div class="dl-seg">
+                    <button class="js-bench-sort is-active" data-sort="tg128" type="button">decode (tg128)</button>
+                    <button class="js-bench-sort" data-sort="pp512" type="button">prefill (pp512)</button>
+                </div>
+            </div>
+
+            <div id="bench-groups"></div>
+        </div>
+    </section>
+
+    <!-- § 03 ASR -->
+    <section class="forge-section">
+        <div class="forge-container">
+            <div class="forge-section-label"><span class="forge-section-label__num">§ 03</span><span class="forge-section-label__rule"></span><span>speech-to-text</span></div>
             <h2 class="forge-h2">Competitive with the dedicated engines on CPU.</h2>
             <p class="forge-p">Transcription time, CPU only, greedy decode. Bars show speed relative to the reference CLI (longer = faster); the small figure is real-time factor — seconds of audio per second of compute. Note the macOS *-cli tools do get Apple's AMX matrix unit here, so this isn't scalar-only on their side.</p>
 
@@ -313,7 +355,7 @@ def main() {
     <!-- § 03 audio-chat blowout -->
     <section class="forge-section">
         <div class="forge-container">
-            <div class="forge-section-label"><span class="forge-section-label__num">§ 03</span><span class="forge-section-label__rule"></span><span>audio-chat models</span></div>
+            <div class="forge-section-label"><span class="forge-section-label__num">§ 04</span><span class="forge-section-label__rule"></span><span>audio-chat models</span></div>
             <div class="forge-bench__grid">
                 <div>
                     <h2 class="forge-h2">Where the CPU-only gap is widest: audio chat.</h2>
@@ -328,7 +370,7 @@ def main() {
     <!-- § 04 supported model families -->
     <section class="forge-section" id="models">
         <div class="forge-container">
-            <div class="forge-section-label"><span class="forge-section-label__num">§ 04</span><span class="forge-section-label__rule"></span><span>supported model families</span></div>
+            <div class="forge-section-label"><span class="forge-section-label__num">§ 05</span><span class="forge-section-label__rule"></span><span>supported model families</span></div>
             <h2 class="forge-h2">One engine, twelve architectures.</h2>
             <p class="forge-p">Everything below loads from stock GGUF (llama2.c <code>.bin</code> for the toy), auto-detected from metadata, and is verified token-for-token against its reference engine. Weights: F32 / F16 / Q8_0 / Q4_0 / MXFP4 read directly; K-quant files (Q4_K_M / Q5_K_M / Q6_K) run on native K-quant kernels; bf16 audio towers read exactly.</p>
             <div class="dl-caveats">
@@ -348,7 +390,7 @@ def main() {
     <!-- § 05 methodology -->
     <section class="forge-section forge-section--alt" id="method">
         <div class="forge-container">
-            <div class="forge-section-label"><span class="forge-section-label__num">§ 05</span><span class="forge-section-label__rule"></span><span>methodology &amp; honest caveats</span></div>
+            <div class="forge-section-label"><span class="forge-section-label__num">§ 06</span><span class="forge-section-label__rule"></span><span>methodology &amp; honest caveats</span></div>
             <h2 class="forge-h2" style="margin-bottom:36px">The framing, in full.</h2>
             <div class="dl-caveats">
                 <div class="dl-caveat"><div class="dl-caveat__k">what das is</div><div class="dl-caveat__v">An LLM + ASR inference engine written entirely in daslang and JIT-compiled — no hand-written SIMD/assembly. The point is narrow but real: a scripting language keeping pace with hand-tuned C++ on the CPU path.</div></div>

--- a/site/files/dasllama.js
+++ b/site/files/dasllama.js
@@ -122,6 +122,89 @@
       ' · llama.cpp ' + d.platform.llama_cpp;
   }
 
+  /* ── per-model benchmark leaderboard (bench_records.json) ───── */
+  // Records are reviewed before they land, but community rows are third-party text — escape
+  // everything that reaches innerHTML.
+  function esc(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function renderBench() {
+    var recs = DATA.bench;
+    if (!recs) return;
+    var sortKey = document.querySelector('.js-bench-sort.is-active').dataset.sort;
+    function val(r, k) { return (r.tests && r.tests[k]) ? r.tests[k].tok_s : 0; }
+
+    var models = recs.slice().sort(function (a, b) { return (b.size_bytes || 0) - (a.size_bytes || 0); });
+    var html = models.map(function (m) {
+      var boxes = {};
+      (m.runs || []).forEach(function (r) { (boxes[r.box] = boxes[r.box] || []).push(r); });
+
+      var boxHTML = Object.keys(boxes).sort().map(function (bx) {
+        var runs = boxes[bx].slice().sort(function (a, b) { return val(b, sortKey) - val(a, sortKey); });
+        var maxV = runs.reduce(function (mx, r) { return Math.max(mx, val(r, sortKey)); }, 0);
+        // best llama.cpp row per backend, on the sort metric — the das ratio denominator
+        var bestRef = {};
+        runs.forEach(function (r) {
+          if (r.engine === 'llama.cpp') bestRef[r.backend] = Math.max(bestRef[r.backend] || 0, val(r, sortKey));
+        });
+        var rowsHTML = runs.map(function (r, i) {
+          var tags = [r.backend, r.flavor];
+          if (r.source === 'community') tags.push('community');
+          var v = val(r, sortKey);
+          var w = maxV > 0 && v > 0 ? Math.max(2, v / maxV * 100) : 0;
+          var ratioHTML = '';
+          if (r.engine === 'das' && v > 0 && bestRef[r.backend] > 0) {
+            var rr = v / bestRef[r.backend];
+            var cls = rr > 1.005 ? 'dl-win' : (rr < 0.995 ? 'dl-dim' : '');
+            ratioHTML = '<span class="' + cls + '">' + fmt(rr, 2) + '×</span>';
+          }
+          var hw = r.hardware || {};
+          var receipt = ['$ ' + r.cmd];
+          receipt.push([r.engine, r.sha ? '@ ' + r.sha : '', r.version || '', r.date || ''].filter(Boolean).join(' · '));
+          if (r.tune) receipt.push('tune: ' + r.tune);
+          receipt.push([hw.cpu, hw.total_cores ? hw.total_cores + ' cores' : '', hw.ram_gb ? hw.ram_gb + ' GB' : '',
+            hw.gpu, hw.os].filter(Boolean).join(' · '));
+          return '<div class="dl-bench-row dl-bench-row--' + (r.engine === 'das' ? 'das' : 'ref') +
+              (i === 0 ? ' dl-bench-row--win' : '') + '" data-bench-row>' +
+              '<div class="dl-bench-row__eng">' + esc(r.engine) +
+                ' <span class="dl-bench-row__tags">' + esc(tags.join(' · ')) + '</span></div>' +
+              '<div class="dl-bench-row__track"><div class="dl-bench-row__fill" style="width:' + w + '%"></div></div>' +
+              '<div class="dl-bench-row__num">' + tps(val(r, 'pp512')) + '</div>' +
+              '<div class="dl-bench-row__num">' + tps(val(r, 'tg128')) + '</div>' +
+              '<div class="dl-bench-row__ratio">' + ratioHTML + '</div>' +
+            '</div>' +
+            '<div class="dl-bench-receipt" hidden>' + esc(receipt.filter(Boolean).join('\n')) + '</div>';
+        }).join('');
+        var hw0 = runs[0].hardware || {};
+        var boxLabel = [hw0.cpu || bx, runs[0].threads ? runs[0].threads + ' threads' : '', hw0.os]
+          .filter(Boolean).join(' · ');
+        return '<div class="dl-bench-box"><div class="dl-bench-box__name">' + esc(boxLabel) + '</div>' +
+          '<div class="dl-bench-cols"><span>engine</span><span></span><span>pp512</span><span>tg128</span><span>vs lcpp</span></div>' +
+          rowsHTML + '</div>';
+      }).join('');
+
+      var meta = [];
+      if (m.arch) meta.push(esc(m.arch));
+      if (m.params_b) {
+        meta.push(fmt(m.params_b, 1) + 'B' +
+          (m.active_b && m.active_b < m.params_b * 0.9 ? ' (' + fmt(m.active_b, 1) + 'B active)' : ''));
+      }
+      if (m.size_bytes) meta.push(fmt(m.size_bytes / 1073741824, 1) + ' GB');
+      return '<div class="dl-bench-model"><div class="dl-bench-model__head">' +
+        '<span class="dl-bench-model__name">' + esc(m.gguf) + '</span>' +
+        '<span class="dl-bench-model__meta">' + meta.join(' · ') + '</span></div>' + boxHTML + '</div>';
+    }).join('');
+
+    document.getElementById('bench-groups').innerHTML = html;
+    document.querySelectorAll('#bench-groups [data-bench-row]').forEach(function (el) {
+      el.addEventListener('click', function () {
+        var n = el.nextElementSibling;
+        if (n) n.hidden = !n.hidden;
+      });
+    });
+  }
+
   /* ── ASR scoreboard ────────────────────────────────────────── */
   var ASR_FEATURE = {
     m1: ['Parakeet-TDT v2', 'Whisper tiny'],
@@ -260,4 +343,15 @@
     document.getElementById('llm-bars').innerHTML =
       '<div style="color:var(--red);font-family:var(--font-mono);font-size:13px">Could not load profiling data: ' + e + '</div>';
   });
+
+  // the record leaderboard loads independently — the section stays hidden until records ship
+  fetch('files/dasllama/bench_records.json')
+    .then(function (r) { if (!r.ok) throw new Error(r.status); return r.json(); })
+    .then(function (j) {
+      DATA.bench = j;
+      document.getElementById('bench').hidden = false;
+      renderBench();
+      wireToggle('.js-bench-sort', renderBench);
+    })
+    .catch(function () { /* no records yet */ });
 })();

--- a/site/files/dasllama.js
+++ b/site/files/dasllama.js
@@ -163,6 +163,7 @@
           var receipt = ['$ ' + r.cmd];
           receipt.push([r.engine, r.sha ? '@ ' + r.sha : '', r.version || '', r.date || ''].filter(Boolean).join(' · '));
           if (r.tune) receipt.push('tune: ' + r.tune);
+          if (r.exec_fmt) receipt.push('executes: ' + r.exec_fmt);
           receipt.push([hw.cpu, hw.total_cores ? hw.total_cores + ' cores' : '', hw.ram_gb ? hw.ram_gb + ' GB' : '',
             hw.gpu, hw.os].filter(Boolean).join(' · '));
           return '<div class="dl-bench-row dl-bench-row--' + (r.engine === 'das' ? 'das' : 'ref') +

--- a/site/files/dasllama.js
+++ b/site/files/dasllama.js
@@ -193,7 +193,9 @@
       if (m.size_bytes) meta.push(fmt(m.size_bytes / 1073741824, 1) + ' GB');
       return '<div class="dl-bench-model"><div class="dl-bench-model__head">' +
         '<span class="dl-bench-model__name">' + esc(m.gguf) + '</span>' +
-        '<span class="dl-bench-model__meta">' + meta.join(' · ') + '</span></div>' + boxHTML + '</div>';
+        '<span class="dl-bench-model__meta">' + meta.join(' · ') + '</span></div>' +
+        (m.note ? '<div class="dl-bench-model__note">' + esc(m.note) + '</div>' : '') +
+        boxHTML + '</div>';
     }).join('');
 
     document.getElementById('bench-groups').innerHTML = html;

--- a/utils/dasllama-server/control.html
+++ b/utils/dasllama-server/control.html
@@ -1380,6 +1380,11 @@ let benchRecord = null;
 
 function renderBench(b) {
     const log = $("bench-log");
+    if (b.state === "running" || !(b.result && b.result.record)) {
+        // never leave a prior run's record copyable — a stale copy is a wrong submission
+        benchRecord = null;
+        $("bench-record-row").style.display = "none";
+    }
     if (b.log && b.log.length) {
         log.style.display = "block";
         log.innerHTML = b.log.map(l => esc(l)).join("<br>");

--- a/utils/dasllama-server/control.html
+++ b/utils/dasllama-server/control.html
@@ -322,6 +322,10 @@ button:disabled { opacity: 0.45; cursor: default; }
             <tbody id="bench-body"></tbody>
         </table>
         <div class="cfg-file" id="bench-meta"></div>
+        <div class="controls" id="bench-record-row" style="display:none;margin-top:8px">
+            <button id="b-bench-copy" type="button">copy record</button>
+            <span class="ctl-note">the full bench record (hardware, command lines, shas) — paste into a benchmark submission</span>
+        </div>
     </div>
 
     <footer class="reveal">
@@ -1372,6 +1376,7 @@ $("b-drain").addEventListener("click", async () => {
 
 // ===== benchmark panel =====
 let benchPolling = false;
+let benchRecord = null;
 
 function renderBench(b) {
     const log = $("bench-log");
@@ -1390,6 +1395,10 @@ function renderBench(b) {
             "<td class=\"" + (r.tg_ratio >= 1 ? "hit" : "") + "\">" + r.tg_ratio.toFixed(2) + "x</td></tr>";
         $("bench-meta").textContent = (b.hardware || "") + " · " + r.threads + " threads · " +
             new Date(r.ts * 1000).toLocaleString() + " · " + r.elapsed_s + "s run";
+        if (r.record) {
+            $("bench-record-row").style.display = "flex";
+            benchRecord = r.record;
+        }
     }
     $("bench-note").textContent = b.state === "running" ? "running — both benches finish before results appear"
         : b.state === "failed" ? "failed — see the log above"
@@ -1410,6 +1419,16 @@ function renderBench(b) {
         setTimeout(tickB, 2000);
     }
 }
+
+$("b-bench-copy").addEventListener("click", async () => {
+    if (!benchRecord) return;
+    try {
+        await navigator.clipboard.writeText(JSON.stringify(benchRecord, null, 2));
+        $("bench-note").textContent = "record copied to clipboard";
+    } catch (_e) {
+        $("bench-note").textContent = "clipboard blocked — copy from the log instead";
+    }
+});
 
 $("b-bench").addEventListener("click", async () => {
     try {

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -123,9 +123,11 @@ def server_bench_running : bool {
 }
 
 // ===== benchmark button (the llama.cpp A/B) =====
-// POST /bench runs, QUIESCED ONLY, our lcpp_bench (a child daslang process — same model, same
-// thread budget, llama-bench methodology) then llama-bench itself, on a worker thread; progress
-// and results flow back over a channel the tick loop drains. GET /bench serves state/log/result.
+// POST /bench runs, QUIESCED ONLY, one lcpp_bench child (--ref runs llama-bench inside it — same
+// model, same thread budget, llama-bench methodology) on a worker thread; progress and results
+// flow back over a channel the tick loop drains. GET /bench serves state/log/result. Numbers come
+// from the child's --json-path record file (the machine rail — stdout carries engine logs), and
+// the raw record rides along in the result as `record` for the copy-record affordance.
 
 var private g_lcpp_bin = ""
 var private g_daslang_bin = ""
@@ -151,36 +153,6 @@ def private bench_emit(events : Channel?; kind : int; text : string) {
     events |> push_clone(BenchEvent(kind = kind, text = text))
 }
 
-// parse "pp512: 202.54 ± 1.23 tok/s (3 reps)" (ours) — the number after "<tag>:"
-def private parse_ours_row(out : string; tag : string) : float {
-    for (ln in split(out, "\n")) {
-        if (ln |> starts_with("{tag}:")) {
-            return to_float(strip(slice(ln, length(tag) + 1)))
-        }
-    }
-    return 0.0
-}
-
-// parse llama-bench's markdown table — the row whose test cell equals `tag`, value = next cell
-def private parse_theirs_row(out : string; tag : string) : float {
-    for (ln in split(out, "\n")) {
-        continue if (find(ln, "|") < 0)
-        var cells <- split(ln, "|")
-        var found = 0.0
-        for (i in range(length(cells) - 1)) {
-            if (strip(cells[i]) == tag) {
-                found = to_float(strip(cells[i + 1]))
-                break
-            }
-        }
-        delete cells
-        if (found > 0.0) {
-            return found
-        }
-    }
-    return 0.0
-}
-
 // argv joined into a copy-pasteable shell line (quotes only where a space demands one)
 def private cmdline(args : array<string>) : string {
     var parts <- [for (a in args); find(a, " ") >= 0 ? "\"{a}\"" : a]
@@ -198,42 +170,67 @@ def private bench_worker(daslang_bin, lcpp_bin, model_path : string; threads : i
         events |> release
     }
     let t0 = ref_time_ticks()
-    bench_emit(events, 0, "our bench: lcpp_bench pp512/tg128 x 3 reps (llama-bench methodology) — minutes-class, hold on")
-    var ours = ""
+    let record_path = path_join(get_das_root(), "logs/server_bench_record.json")
+    bench_emit(events, 0, "lcpp_bench A/B: das + llama-bench, pp512/tg128 x 3 reps (llama-bench methodology) — minutes-class, hold on")
+    var out = ""
     var args <- [daslang_bin, "-jit", path_join(get_das_root(), "modules/dasLLAMA/benchmarks/lcpp_bench.das"), "--",
-                 "-m", model_path, "-r", "3"]
+                 "-m", model_path, "-r", "3", "-t", "{threads}",
+                 "--ref", lcpp_bin, "-o", "json", "--json-path", record_path]
     bench_emit(events, 0, "$ {cmdline(args)}")
-    var rc1 = run_and_capture(args, ours, 3600.0)
-    if (rc1 == 3 && find(ours, "restart to apply") >= 0) {
+    var rc = run_and_capture(args, out, 3600.0)
+    if (rc == 3 && find(out, "restart to apply") >= 0) {
         // [tune] bootstrap: the child tuned this box's kernels and exited with the restart code
         // (the watchdog convention) — relaunch once to run with the winners
         bench_emit(events, 0, "bench child tuned this box's kernels first — relaunching with the winners")
-        ours = ""
-        rc1 = run_and_capture(args, ours, 3600.0)
+        out = ""
+        rc = run_and_capture(args, out, 3600.0)
     }
     delete args
-    let ours_pp = parse_ours_row(ours, "pp512")
-    let ours_tg = parse_ours_row(ours, "tg128")
-    if (rc1 != 0 || ours_pp <= 0.0 || ours_tg <= 0.0) {
-        bench_emit(events, 2, "our bench failed (rc={rc1}) — tail: {slice(ours, max(0, length(ours) - 300))}")
+    var record_text = ""
+    if (stat(record_path).is_valid) {
+        record_text = fread(record_path)
+    }
+    var jerr = ""
+    var js = read_json(record_text, jerr)
+    if (rc != 0 || js == null) {
+        bench_emit(events, 2, "bench failed (rc={rc}) — tail: {slice(out, max(0, length(out) - 300))}")
+        return
+    }
+    var ours_pp = 0.0lf
+    var ours_tg = 0.0lf
+    var theirs_pp = 0.0lf
+    var theirs_tg = 0.0lf
+    let runs = js?[0]?["runs"]
+    if (runs != null && runs is _array) {
+        for (rv in runs as _array) {
+            let eng : string = rv?["engine"] ?? ""
+            let pp : double = rv?["tests"]?["pp512"]?["tok_s"] ?? 0.0lf
+            let tg : double = rv?["tests"]?["tg128"]?["tok_s"] ?? 0.0lf
+            if (eng == "das") {
+                ours_pp = pp
+                ours_tg = tg
+            } elif (eng == "llama.cpp") {
+                theirs_pp = pp
+                theirs_tg = tg
+            }
+        }
+    }
+    unsafe {
+        delete js
+    }
+    if (ours_pp <= 0.0lf || ours_tg <= 0.0lf) {
+        bench_emit(events, 2, "bench produced no das rows — tail: {slice(out, max(0, length(out) - 300))}")
         return
     }
     bench_emit(events, 0, "ours: pp512 {ours_pp} tok/s · tg128 {ours_tg} tok/s")
-    var theirs = ""
-    var targs <- [lcpp_bin, "-m", model_path, "-p", "512", "-n", "128", "-r", "3", "-t", "{threads}"]
-    bench_emit(events, 0, "$ {cmdline(targs)}")
-    let rc2 = run_and_capture(targs, theirs, 3600.0)
-    delete targs
-    let theirs_pp = parse_theirs_row(theirs, "pp512")
-    let theirs_tg = parse_theirs_row(theirs, "tg128")
-    if (rc2 != 0 || theirs_pp <= 0.0 || theirs_tg <= 0.0) {
-        bench_emit(events, 2, "llama-bench failed (rc={rc2}) — tail: {slice(theirs, max(0, length(theirs) - 300))}")
+    if (theirs_pp <= 0.0lf || theirs_tg <= 0.0lf) {
+        bench_emit(events, 2, "llama-bench rows missing from the record — tail: {slice(out, max(0, length(out) - 300))}")
         return
     }
     bench_emit(events, 0, "theirs: pp512 {theirs_pp} tok/s · tg128 {theirs_tg} tok/s")
     let elapsed = int64(get_time_usec(t0)) / 1000000l
     bench_emit(events, 1,
-        "\{\"ours_pp\":{ours_pp},\"ours_tg\":{ours_tg},\"theirs_pp\":{theirs_pp},\"theirs_tg\":{theirs_tg},\"pp_ratio\":{ours_pp / theirs_pp},\"tg_ratio\":{ours_tg / theirs_tg},\"threads\":{threads},\"elapsed_s\":{elapsed},\"ts\":{created_ts()}}")
+        "\{\"ours_pp\":{ours_pp},\"ours_tg\":{ours_tg},\"theirs_pp\":{theirs_pp},\"theirs_tg\":{theirs_tg},\"pp_ratio\":{ours_pp / theirs_pp},\"tg_ratio\":{ours_tg / theirs_tg},\"threads\":{threads},\"elapsed_s\":{elapsed},\"ts\":{created_ts()},\"record\":{record_text}}")
 }
 
 def private drain_bench_events() {

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -170,7 +170,9 @@ def private bench_worker(daslang_bin, lcpp_bin, model_path : string; threads : i
         events |> release
     }
     let t0 = ref_time_ticks()
-    let record_path = path_join(get_das_root(), "logs/server_bench_record.json")
+    let logs_dir = path_join(get_das_root(), "logs")
+    mkdir_rec(logs_dir)   // the child writes its --json-path record here; a fresh checkout has no logs/
+    let record_path = path_join(logs_dir, "server_bench_record.json")
     bench_emit(events, 0, "lcpp_bench A/B: das + llama-bench, pp512/tg128 x 3 reps (llama-bench methodology) — minutes-class, hold on")
     var out = ""
     var args <- [daslang_bin, "-jit", path_join(get_das_root(), "modules/dasLLAMA/benchmarks/lcpp_bench.das"), "--",

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -189,14 +189,18 @@ def private bench_worker(daslang_bin, lcpp_bin, model_path : string; threads : i
         rc = run_and_capture(args, out, 3600.0)
     }
     delete args
+    if (rc != 0) {   // child died — check rc BEFORE parsing so js is never allocated (and leaked) on the failure path
+        bench_emit(events, 2, "bench failed (rc={rc}) — tail: {slice(out, max(0, length(out) - 300))}")
+        return
+    }
     var record_text = ""
     if (stat(record_path).is_valid) {
         record_text = fread(record_path)
     }
     var jerr = ""
     var js = read_json(record_text, jerr)
-    if (rc != 0 || js == null) {
-        bench_emit(events, 2, "bench failed (rc={rc}) — tail: {slice(out, max(0, length(out) - 300))}")
+    if (js == null) {   // rc==0 but the record didn't materialize or parse (see bench_worker's remove-before-launch)
+        bench_emit(events, 2, "bench failed (rc={rc}, no parseable record) — tail: {slice(out, max(0, length(out) - 300))}")
         return
     }
     var ours_pp = 0.0lf

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -173,6 +173,7 @@ def private bench_worker(daslang_bin, lcpp_bin, model_path : string; threads : i
     let logs_dir = path_join(get_das_root(), "logs")
     mkdir_rec(logs_dir)   // the child writes its --json-path record here; a fresh checkout has no logs/
     let record_path = path_join(logs_dir, "server_bench_record.json")
+    remove(record_path)   // drop any prior run's record — a rc=0 child that wrote nothing must not read stale
     bench_emit(events, 0, "lcpp_bench A/B: das + llama-bench, pp512/tg128 x 3 reps (llama-bench methodology) — minutes-class, hold on")
     var out = ""
     var args <- [daslang_bin, "-jit", path_join(get_das_root(), "modules/dasLLAMA/benchmarks/lcpp_bench.das"), "--",


### PR DESCRIPTION
The public-benchmarks rail end to end, plus the format/kernel work it surfaced. Records are GGUF-keyed receipts (engine, backend, flavor, hardware, sha, date, tune, exec_fmt); llama.cpp reference rows are first-class runs against pinned-sha binaries; ratios are render-derived, never stored. Publishing (the site merge) stays off — this lands the machinery and the M1 data.

### The bench rail
- `benchmarks/lcpp_bench.das` — the user-facing tool, llama-bench CLI conventions (`-p/-n/-r/-t/--ngl`, `-o txt|md|json`); `--ref &lt;llama-bench&gt;` runs the same shapes on the same GGUF; `--json-path` is the machine interface. Auto-tunes on first run.
- `benchmarks/setup_lcpp_ref.das` — the reference supply chain: worktree at a pinned sha, `clean-cpu` (no-Accelerate, kernel-fair) and `stock` (as shipped) llama-bench flavors.
- `performance/gen_bench_records.das` — the official-record driver: catalog x backends, one child per cell, store upserted after every cell, refs adjacent. `records/m1.json` carries 8 models x 5 rows (M1 Max, r=5).
- `BenchRun.exec_fmt` — the apples-to-apples receipt: what each engine actually executes per tensor (audited: every catalog tensor runs its disk format natively in das; zero transcodes).
- Site § 02 — per-model leaderboard from the merged records (hidden until records ship).

### Native Q5_1 tier (KqFmt.q51)
The 2.2M-download gemma-4-26B-A4B Q4_K_M stores its 29 `ffn_down_exps` stacks as Q5_1 — llama.cpp's quantizer fallback for rows % 32 but not % 256 (this file: 704-wide) — which the engine could not run. The tier puts them on native per-32-block planes (20B nibbles+qh / 4B f16 d+m, verbatim disk splits, never repacked) with Q8_0-form activations:
- CPU: portable kernels + an expand-to-scratch `[tuned]` MAC core (the per-element qh-bit extraction and MACs over just-stored stack bytes both defeat the vectorizer — measured 1.95 vs 8.1 GB/s/core); groupn / batch / batch-groupn forms, batch forms amortize the row expansion across tokens. Decode 17.8 → 26.3 tok/s on M1 (the exact-but-1.4x-memory requant fallback does 28.2; the Q8_0 twin 19.9).
- Metal: `MetalMoeGemvQ51` (2 rows/simdgroup off shared float4 x loads) + `MetalMoeMulMmQ51` (k5 mul_mm skeleton, per-32 f16(d*q + m) A stage). Gates (`moe_site_ok`, `moe_metal_ok`, blob offsets) take q51 clauses; the planes are already GPU-form so the blob transform passes them through.
- Dense positions demote Q5_1 → q8 at detect (expert stacks are the tier's scope); GPU-tier walks and the heat cache decline q51 via the existing fmt whitelists.
- Gates: `test_kquant` q51 arms (plane bit-map, dot vs fp64 at n=704, kernel bit-match) interp + `-jit`; Metal kernel-suite units bit-exact on exact-arithmetic planes; 26B Q4_K_M generates token-identically to its Q8_0 twin on CPU and to the CPU truth under `--ngl 99`; the `gemma4moe-26b-k` matrix row pins the Metal graph (tolerance cells 2.52 / 13.83 vs 8 / 24 bars).
- M1 cells: cpu pp 147.9 (1.29x clean / 0.99x stock), cpu tg 26.5 (0.95x / 1.01x), metal pp 895.6 (1.10x), metal tg 52.2 (0.87x — on the hit list with the shared GEMV-family work).

### gpt-oss mxfp4 Metal decode: 0.40x → 0.92x
`MetalMoeGemvMx4` had one row per simdgroup re-reading the whole activation with scalar loads (x load issues ~5:1 over the weight stream) plus a 3-csel e2m1 magnitude chain per nibble. Reworked to 2 rows/simdgroup off shared float4 x loads with a host-built [16] signed value table; the mul_mm A stage takes the same table. tg128 32.9 → 77.1 vs llama.cpp 83.5 (0.92x, was 0.40x — das GPU was below das CPU); pp512 0.82x → 0.92x. Bit-exact kernel units (bias arm included); fam-gptoss tolerance cells 0.256 / 0.260 vs 2 / 4 bars.

### gemma-4 E-series (E4B) Metal servable
PLE + cross-layer KV sharing in both drivers with zero new MSL kernels (existing PSOs): shared layers run Q-only GEMV and alias the source KV panels; the PLE epilogue chains gate GEMV → geglu → proj GEMV → rms into the existing fused add. `fam-gemma4e` matrix row (whole-GPU generate token-exact vs CPU truth). E2B stays declined (`layers` — per-layer FFN width). E4B loader change: E-series registers `ffn_is_dense = true`, which re-fingerprints its planar image.

### Notes
- decode_prof grew `--q51-native`; parity.das grew `--ngl` (blob transform + required Metal).
- The family-matrix runs currently end red on a pre-existing `metal_live_object_count` tally (51 objects on a clean master tree, stash-verified; scales with cell count — every actual cell is green). One object of that was this branch's decode PSO missing from the release list — fixed here; the rest predates the branch and is tracked for a follow-up.
- das-side record `quant` field = runtime QuantMode, not the GGUF's own label (v1 simplification; `exec_fmt` carries the precise per-tensor truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)