### PR TITLE
dasHerd: add Git review views and semantic topology

### DIFF
--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -334,6 +334,10 @@ def private is_wide(value : uint) : bool {
         in_range(value, 0x20000u, 0x3fffdu))
 }
 
+def public terminal_codepoint_width(value : uint) : int {
+    return is_combining(value) ? 0 : (is_wide(value) ? 2 : 1)
+}
+
 def private indexed_color(index : int) : TerminalColor {
     return TerminalColor(kind = TerminalColorKind.indexed, index = clamp(index, 0, 255))
 }
@@ -594,9 +598,10 @@ def private put_grapheme(var terminal : Terminal; grapheme : string;
 }
 
 def private process_codepoint(var terminal : Terminal; codepoint : uint) {
-    let combining = is_combining(codepoint)
+    let width = terminal_codepoint_width(codepoint)
+    let combining = width == 0
     put_grapheme(terminal, codepoint_utf8(codepoint),
-        combining ? 0 : (is_wide(codepoint) ? 2 : 1), combining)
+        width, combining)
 }
 
 def private finish_utf8(var terminal : Terminal; valid_ : bool) {

--- a/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
+++ b/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
@@ -1,0 +1,48 @@
+# Git activity and topology plan
+
+This plan records the agreed direction for the rich client's Git review surface. Each stage is reviewed before the next one starts.
+
+## Stage 1: stable review layout
+
+- Split the current combined Git window into independently dockable `Git Changelist` and `Git Activity` windows.
+- Keep worktree identity, status, refresh state, errors, and the selected PR/commit file list in Changelist.
+- Keep only the PR, History, and Tree perspectives in Activity.
+- Use real resizable tables for commits: SHA, title, and author are separate columns and colors.
+- Show Tree with the same readable table as History until topology has a trustworthy implementation.
+
+This prevents asynchronous file-list replacement from resizing or shifting the activity view.
+
+## Stage 2: Git-owned topology stream
+
+- Treat `git log --graph --topo-order --full-history` as the topology oracle.
+- Preserve Git's physical output rows, including transition-only rows between commits.
+- Parse the graph prefix separately from commit metadata into a small headless model.
+- Add fixtures for forks, merges, octopus merges, crossings, truncation, and decorations before drawing anything.
+
+The initial scope is the current worktree plus its base. An explicit scope selector can later include more refs; loading every local and remote ref is not the default.
+
+## Stage 3: topology rendering
+
+- Extend the Tree table to four columns: SHA, title, author, topology.
+- Render the parsed graph prefix as vector lanes, nodes, and transitions in the fourth (rightmost) column.
+- Assign stable colors by active lane identity, not commit-hash randomness.
+- Keep commit metadata aligned as a table while the topology column explains ancestry.
+
+## Stage 4: selection contract
+
+- PR selects the complete outgoing range against the detected base.
+- History and Tree commit rows select one commit and populate Changelist with that commit's files.
+- A Tree ref badge selects that branch's outgoing range against its base.
+- SHA cells retain hover-copy behavior and copy the full hash.
+
+## Stage 5: robustness and scale
+
+- Add pending and failure states per window without changing dock geometry.
+- Stress-test large histories, many refs, rapid selection, and repeated async replacement.
+- Measure parsing, rendering, and selection latency before optimizing.
+
+## Research basis
+
+- Git's graph output and topological ordering are the behavioral oracle: <https://git-scm.com/docs/git-log>
+- Git's implementation documents the graph state machine and transition rows: <https://github.com/git/git/blob/master/graph.c>
+- The target information layout follows the reviewed Git GUI examples: commit metadata remains tabular while topology is a dedicated graph column.

--- a/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
+++ b/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
@@ -20,7 +20,8 @@ This prevents asynchronous file-list replacement from resizing or shifting the a
 - Parse the graph prefix separately from commit metadata into a small headless model.
 - Add fixtures for forks, merges, octopus merges, crossings, truncation, and decorations before drawing anything.
 
-The initial scope is the current worktree plus its base. An explicit scope selector can later include more refs; loading every local and remote ref is not the default.
+Tree observes all refs available to the worktree so branch topology is visible;
+History remains the focused single-branch view.
 
 ## Stage 3: topology rendering
 
@@ -41,6 +42,90 @@ The initial scope is the current worktree plus its base. An explicit scope selec
 - Add pending and failure states per window without changing dock geometry.
 - Stress-test large histories, many refs, rapid selection, and repeated async replacement.
 - Measure parsing, rendering, and selection latency before optimizing.
+
+## Endgame Tree view contract
+
+Tree is a semantic branch and PR topology view, not a decorated ASCII Git log.
+The current `git log --graph` stream remains a useful ordering oracle and test
+fallback, while the final view uses a headless commit DAG and draws continuous
+vector edges and nodes.
+
+PR remains the default perspective and the primary review answer to "what is
+going out from this worktree?" Tree is an explicit escalation surface for work
+that involves multiple branches, PRs, bases, or incoming sources. It must make
+the role of every emphasized source clear rather than presenting an undirected
+mass of refs.
+
+- An ordinary commit is a hollow circle. Every visible branch or PR head is a
+  filled circle: it represents the thing that would go out.
+- Every pushed commit has a mildly bolder circle outline. Pushed means reachable
+  from that branch's configured upstream remote head, not merely present on an
+  unrelated remote.
+- Multiple local, remote, worktree, or PR refs at one commit share one filled
+  node with multiple badges.
+- Real Git parent relationships use continuous solid edges. A branch color stays
+  continuous while its lane moves, and stable per-repository assignments survive
+  restarts. Shared history uses the base branch context rather than pretending a
+  commit belongs exclusively to one branch.
+- Selecting a branch or PR emphasizes the outgoing range
+  `merge-base(base, head)..head`, subdues parallel work, and populates Changelist
+  with that same range. For stacked PRs the declared immediate base is the
+  default; comparing against the repository base is an option.
+- `Auto` is the default cognitive-load filter: show branches with outgoing
+  changes, the current branch, necessary base context, and a small recent set of
+  merged branches. `All` adds all relevant local branches, coalesced upstream
+  refs, worktrees, and available PR heads.
+- Keep approximately the current vertical commit density. Unselected topology
+  remains visible but subdued rather than disappearing.
+- Normal merges are visible through their real Git parent edge. Squash and
+  rebase merges may have no ancestry edge back to the original PR commits; how
+  optional GitHub metadata should visualize that association remains a later,
+  explicitly labelled display decision.
+
+### Future agent-directed Tree focus
+
+A later herder skill can let an agent publish a structured Tree focus instead
+of describing topology only in terminal prose. The focus identifies exact
+refs/SHAs and assigns visible roles such as:
+
+- primary: this worktree's PR and the thing going out;
+- incoming: the branch or PR being evaluated or brought in;
+- base/context: the integration branch and any required shared ancestry.
+
+An agent-facing view can then say, in effect, "this is your PR; this is the
+other branch; this is what we are bringing in," emphasize those paths, and
+subdue unrelated topology. The focus is inspectable user-visible state, not an
+implicit filter: the user can see the selected identities, clear the focus, or
+switch back to `Auto`/`All`. This is future direction, not part of the current
+view-only PR.
+
+## Deferred operational direction -- not this PR
+
+This PR is view-only. It may select and identify commits, refs, branches, PRs,
+bases, and outgoing ranges, but it does not rewrite or synchronize Git state.
+
+Future tools can use those exact semantic selections for operations such as
+squash, rebase, cherry-pick onto another branch, fetch, pull, synchronize to a
+PR, or bring a GitHub PR into a local worktree. Potentially destructive history
+operations should carry explicit head/base/ref/SHA identity into an agent-owned
+terminal workflow. The graph must refresh from observed Git and GitHub state
+after an operation rather than optimistically inventing the result.
+
+## Immediate follow-up: stable File Inspector replacement
+
+- Keep the currently prepared document visible while a newly selected file is
+  fetched and prepared; selection must not tear down and recreate the view.
+- Track requested identity separately from displayed identity. Replace the
+  document atomically only when the newest request has a complete prepared
+  result, and discard stale worker generations.
+- Give File Inspector a permanent bottom status bar. Loading, preparation,
+  errors, and the stable file summary share that reserved area; no transient
+  status is inserted above the document.
+- Preserve dock geometry and controls throughout replacement. Apply the chosen
+  new-file scroll policy only at the atomic swap, not during pending work.
+- Expose retained-content identity, pending identity, generation, footer
+  position, and swap revision through live inspection so tests can prove that
+  selection never blanks or shifts the view.
 
 ## Research basis
 

--- a/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
+++ b/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
@@ -9,6 +9,7 @@ This plan records the agreed direction for the rich client's Git review surface.
 - Keep only the PR, History, and Tree perspectives in Activity.
 - Use real resizable tables for commits: SHA, title, and author are separate columns and colors.
 - Show Tree with the same readable table as History until topology has a trustworthy implementation.
+- Reserve a permanent bottom status bar in each Git window; loading and error text replaces the stable summary there without moving content.
 
 This prevents asynchronous file-list replacement from resizing or shifting the activity view.
 

--- a/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
+++ b/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
@@ -266,8 +266,11 @@ It publishes staged, unstaged, untracked, conflicted, ahead/behind, locked, and
 prunable state plus filenames. Selecting a worktree requests an immediate local
 refresh; no fetch is implied. ConPTY's raw bytes contain console-generated VT
 cursor operations, so this slice parses the terminal model's reconstructed
-240x100 screen and fails visibly if output reaches scrollback. An unbounded
-machine-output sidecar is a follow-up, not a reason to parse truncated state.
+240x512 capture screen and fails visibly if output reaches scrollback. Git log
+and ref records use an explicit visible field delimiter because rendered tabs
+become spaces. Observation sessions compact immediately after parsing. An
+unbounded machine-output sidecar is a follow-up, not a reason to parse replay
+bytes or truncated state.
 Completed repository-refresh observation terminals compact to 160x50, while
 file Diff/View task terminals compact to 80x25. A replacement refresh keeps only
 the newest matching emulator in memory while preserving every older raw, event,
@@ -431,6 +434,52 @@ The Git/tasks window is a terminal when a task has a terminal, not a custom
 plain-text log approximation. Structured Git observations may appear as debug
 records beside the terminal activities.
 
+### Worktree review perspectives
+
+Git inspection is scoped to the selected worktree and the agent activity that
+produced it. It is not a repository-wide staging dashboard. Three switchable
+perspectives share one file list and the existing Diff/View inspector:
+
+- **PR** answers what this worktree will send for review. Its included result
+  is the aggregate change from the worktree's recorded merge base through the
+  index: outgoing commits plus staged changes. Unstaged and untracked files
+  remain visible in a subdued Not Included section because they may be work an
+  agent forgot to stage. A path with staged and later unstaged edits appears in
+  both layers; the included row inspects the index result and the subdued row
+  inspects the remaining working delta.
+- **History** shows the selected worktree's current branch, newest-first commit
+  descriptions, and the files belonging to the selected commit. A compact
+  outgoing-commit list also appears above PR Total; selecting a commit narrows
+  the file list, while PR Total restores the aggregate payload.
+- **Tree** shows the repository commit graph and other local and remote branch
+  labels for context. Remote labels are visible by default but visually
+  secondary. Selecting a commit reuses the same file list and inspector.
+
+The review base belongs to the worktree. Worktrees created by dasHerd retain
+the base selected at creation. Externally discovered worktrees may infer an
+initial base from their upstream and then `origin/master` or `origin/main`, but
+the chosen value is visible, correctable, and never silently changed.
+
+Initial staging controls operate on whole files. Stage and Unstage execute
+immediately as watcher-hosted Git tasks, then asynchronously refresh the model;
+hunk staging may be added without changing the file model. Greyed-out files
+remain clickable. If any Git observation or mutation fails, its hosted Git session
+automatically opens and receives focus in the Terminal window so a human or an
+agent can inspect and repair the real command environment.
+
+History and graph loading are bounded and incremental. The initial target is
+200 commits with additional pages requested near the end, rather than an
+unbounded UI-thread query.
+
+The first vertical slice implements PR, History, and Tree as tabs. History and
+Tree share the same 200-commit result, selected-commit file result, and
+revision-pinned Diff/View inspector. Tree currently groups all local and remote
+branch refs; drawing parent edges and paging beyond 200 commits remain the next
+graph-specific layer. Git 2.17 cannot capture a blob with `git show --output`,
+so full staged/commit View runs a small daScript capture helper as a hosted task.
+It uses argv-based Git execution and binary pipes, preserving image bytes
+without shell redirection or quoting.
+
 ### Git file inspection workspace
 
 The useful center of Git inspection is a selected file with two instantly
@@ -452,9 +501,10 @@ Comparison scope is explicit and shares the same inspector:
 
 - **Working** compares the index with unstaged and untracked content.
 - **Staged** compares `HEAD` with the index.
-- **PR** compares the selected PR/head with its merge base. PR discovery,
-  selection, and base policy are a later slice, but this is the primary review
-  surface and must not be modeled as an alias for staged files.
+- **PR** compares the selected worktree's merge base with its index, aggregating
+  outgoing commits and staged changes rather than aliasing staged-only diff.
+- **Commit** compares one observed commit with its first parent (including root
+  and merge commits) and reads View from that exact revision.
 
 The first file list is flat, grouped by conflicts, staged, modified, and
 untracked, and shows the full repository-relative path. A tree projection may

--- a/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
+++ b/utils/dasHerd/WORKTREES_AND_TASK_TERMINALS.md
@@ -443,8 +443,9 @@ perspectives share one file list and the existing Diff/View inspector:
 - **PR** answers what this worktree will send for review. Its included result
   is the aggregate change from the worktree's recorded merge base through the
   index: outgoing commits plus staged changes. Unstaged and untracked files
-  remain visible in a subdued Not Included section because they may be work an
-  agent forgot to stage. A path with staged and later unstaged edits appears in
+  remain visible first as subdued rows because they may be work an agent forgot
+  to stage; color carries that state without a redundant Not Included label. A
+  path with staged and later unstaged edits appears in
   both layers; the included row inspects the index result and the subdued row
   inspects the remaining working delta.
 - **History** shows the selected worktree's current branch, newest-first commit
@@ -471,11 +472,17 @@ History and graph loading are bounded and incremental. The initial target is
 200 commits with additional pages requested near the end, rather than an
 unbounded UI-thread query.
 
-The first vertical slice implements PR, History, and Tree as tabs. History and
-Tree share the same 200-commit result, selected-commit file result, and
-revision-pinned Diff/View inspector. Tree currently groups all local and remote
-branch refs; drawing parent edges and paging beyond 200 commits remain the next
-graph-specific layer. Git 2.17 cannot capture a blob with `git show --output`,
+The first vertical slice implements PR, History, and Tree as tabs over a shared
+top file surface. Rows show exact added/deleted counts, style path components
+and separators separately, keep local-only changes subdued and first, and
+reveal stage/unstage controls only on hover. History and Tree share the same
+selected-commit file result and revision-pinned Diff/View inspector. Tree reads
+up to 200 commits across all refs and renders virtualized, stable-color parent
+lanes, merge connectors, commit nodes, and local/remote ref labels; paging
+beyond 200 commits remains the next graph-specific layer. Hovering a commit
+reveals a copy control for its full SHA, establishing the context-icon pattern
+that a future GitHub PR-number label will reuse. Git 2.17 cannot capture a blob
+with `git show --output`,
 so full staged/commit View runs a small daScript capture helper as a hosted task.
 It uses argv-based Git execution and binary pipes, preserving image bytes
 without shell redirection or quoting.
@@ -520,13 +527,16 @@ inspection semantic and avoids screenshot-only validation.
 The implemented working-tree path deliberately separates compact Diff from
 complete View. Git emits three context lines into the hosted terminal, while
 the resulting working file is read as exact bytes after the task succeeds.
-Large unwrapped Views virtualize visible lines; disconnected daScript hunks use
-lexical recovery for Tree-sitter gaps. The current measured stress case is a
+Large unwrapped Views virtualize visible lines. Every compact, expanded, or
+full Diff request now reconstructs the complete pre-change file from the
+complete result plus its unified patch, runs syntax preparation on both
+complete files, and projects those stable syntax roles onto the visible aligned
+rows. Context switching therefore cannot reinterpret a truncated declaration,
+comment, or scope. The current measured stress case is a
 628 KiB/12,116-line file: Diff is ready in about 0.6 seconds, synchronized
 scrolling is exact in both directions, and the prepared View renders at roughly
-50 FPS at 4K/150% zoom. Full-file syntax preparation is still a one-time
-multi-second cost and remains the next focused optimization, not a reason to
-replace Git's native diff.
+50 FPS at 4K/150% zoom. Syntax preparation remains off the UI thread and newest
+request wins; the projection pass is linear in source spans and visible rows.
 
 ### Diff vertical slice
 

--- a/utils/dasHerd/watcher/git_blob_capture.das
+++ b/utils/dasHerd/watcher/git_blob_capture.das
@@ -1,0 +1,64 @@
+options gen2
+
+require daslib/fio
+require strings
+
+def private option_value(prefix : string) : string {
+    for (argument in get_command_line_arguments()) {
+        if (starts_with(argument, prefix)) return slice(argument, length(prefix))
+    }
+    return ""
+}
+
+[export]
+def main() : int {
+    let worktree = option_value("--worktree=")
+    let revision = option_value("--revision=")
+    let file_path = option_value("--file=")
+    let output_path = option_value("--output=")
+    if (empty(worktree) || empty(revision) || empty(file_path)
+            || empty(output_path)) {
+        print("worktree, revision, file, and output are required\n")
+        return 2
+    }
+    let object_name = "{revision}:{file_path}"
+    var exit_code = -1
+    var byte_count = 0
+    var output_opened = false
+    fopen(output_path, "wb") $(output) {
+        if (output != null) {
+            output_opened = true
+            exit_code = unsafe(popen_argv_pipe([
+                "git", "--literal-pathspecs", "-C", worktree,
+                "--no-pager", "show", "--format=", object_name], $(_stdin_w, input) {
+                if (input == null) return
+                var chunk : array<uint8>
+                chunk |> resize(65536)
+                while (true) {
+                    let read_count = fread(input, chunk)
+                    if (read_count <= 0) break
+                    if (read_count < length(chunk)) chunk |> resize(read_count)
+                    let written = fwrite(output, chunk)
+                    if (written != read_count) {
+                        exit_code = 3
+                        break
+                    }
+                    byte_count += written
+                    if (read_count < 65536) chunk |> resize(65536)
+                }
+                delete chunk
+            }))
+        }
+    }
+    if (!output_opened) {
+        print("could not open captured Git blob\n")
+        return 3
+    }
+    if (exit_code != 0) {
+        let _removed = remove(output_path)
+        print("git blob capture failed ({exit_code})\n")
+        return exit_code
+    }
+    print("captured {byte_count} bytes\n")
+    return 0
+}

--- a/utils/dasHerd/watcher/git_blob_capture.das
+++ b/utils/dasHerd/watcher/git_blob_capture.das
@@ -3,6 +3,8 @@ options gen2
 require daslib/fio
 require strings
 
+let private MAX_CAPTURE_BYTES = 8 * 1024 * 1024
+
 def private option_value(prefix : string) : string {
     for (argument in get_command_line_arguments()) {
         if (starts_with(argument, prefix)) return slice(argument, length(prefix))
@@ -25,6 +27,8 @@ def main() : int {
     var exit_code = -1
     var byte_count = 0
     var output_opened = false
+    var write_failed = false
+    var capture_too_large = false
     fopen(output_path, "wb") $(output) {
         if (output != null) {
             output_opened = true
@@ -37,10 +41,14 @@ def main() : int {
                 while (true) {
                     let read_count = fread(input, chunk)
                     if (read_count <= 0) break
+                    if (byte_count + read_count > MAX_CAPTURE_BYTES) {
+                        capture_too_large = true
+                        break
+                    }
                     if (read_count < length(chunk)) chunk |> resize(read_count)
                     let written = fwrite(output, chunk)
                     if (written != read_count) {
-                        exit_code = 3
+                        write_failed = true
                         break
                     }
                     byte_count += written
@@ -52,6 +60,16 @@ def main() : int {
     }
     if (!output_opened) {
         print("could not open captured Git blob\n")
+        return 3
+    }
+    if (capture_too_large) {
+        let _removed = remove(output_path)
+        print("Git blob exceeds the 8 MiB preview limit\n")
+        return 4
+    }
+    if (write_failed) {
+        let _removed = remove(output_path)
+        print("could not write captured Git blob\n")
         return 3
     }
     if (exit_code != 0) {

--- a/utils/dasHerd/watcher/git_blob_capture.das
+++ b/utils/dasHerd/watcher/git_blob_capture.das
@@ -41,15 +41,17 @@ def main() : int {
                 while (true) {
                     let read_count = fread(input, chunk)
                     if (read_count <= 0) break
+                    if (capture_too_large || write_failed) continue
                     if (byte_count + read_count > MAX_CAPTURE_BYTES) {
                         capture_too_large = true
-                        break
+                        continue
                     }
                     if (read_count < length(chunk)) chunk |> resize(read_count)
                     let written = fwrite(output, chunk)
                     if (written != read_count) {
                         write_failed = true
-                        break
+                        if (read_count < 65536) chunk |> resize(65536)
+                        continue
                     }
                     byte_count += written
                     if (read_count < 65536) chunk |> resize(65536)

--- a/utils/dasHerd/watcher/git_graph_model.das
+++ b/utils/dasHerd/watcher/git_graph_model.das
@@ -1,0 +1,350 @@
+options gen2
+options gc
+options persistent_heap
+options indenting = 4
+
+module git_graph_model shared public
+
+require ./repository_core.das public
+require daslib/strings_boost
+require math
+require strings
+
+enum GitTreeFilter {
+    auto_
+    all
+}
+
+struct GitTreeNode {
+    commit_index : int = -1
+    hash : string
+    row : int
+    lane : int
+    color_slot : int
+    head : bool
+    pushed : bool
+    focused : bool
+    focus_head : bool
+    refs_text : string
+    primary_ref : string
+}
+
+struct GitTreeEdge {
+    child : int = -1
+    parent : int = -1
+    color_slot : int
+    focused : bool
+}
+
+struct GitTreeModel {
+    nodes : array<GitTreeNode>
+    edges : array<GitTreeEdge>
+    max_lane : int
+    included_ref_count : int
+    focus_ref : string
+    base_ref : string
+    filter : GitTreeFilter
+    def operator delete {
+        delete nodes
+        delete edges
+    }
+}
+
+def private graph_byte(value : string; index : int) : int {
+    var result = 0
+    peek_data(value) $(bytes) {
+        if (index >= 0 && index < length(value)) {
+            result = int(bytes[index])
+        }
+    }
+    return result
+}
+
+def public git_tree_color_slot(identity : string) : int {
+    var value = 2166136261u
+    for (index in range(length(identity))) {
+        value = (value ^ uint(graph_byte(identity, index))) * 16777619u
+    }
+    return int(value % 12u)
+}
+
+def private graph_lane_index(lanes : array<string> const; hash : string) : int {
+    for (index in range(length(lanes))) {
+        if (lanes[index] == hash) return index
+    }
+    return -1
+}
+
+def private graph_ref_index(repository : RepositorySnapshot const;
+                            worktree_path, name : string) : int {
+    for (index in range(length(repository.refs))) {
+        let ref = repository.refs[index]
+        if (ref.worktree_path == worktree_path
+                && (ref.name == name || ref.full_name == name)) return index
+    }
+    return -1
+}
+
+def private graph_base_ref(repository : RepositorySnapshot const;
+                           worktree : WorktreeState const) : string {
+    if (!empty(worktree.review_base_ref)
+            && graph_ref_index(repository, worktree.path,
+                worktree.review_base_ref) >= 0) return worktree.review_base_ref
+    for (candidate in ["origin/master", "origin/main", "master", "main"]) {
+        if (graph_ref_index(repository, worktree.path, candidate) >= 0) {
+            return candidate
+        }
+    }
+    return ""
+}
+
+def private graph_mark_ancestors(head : string;
+                                 commits : array<GitCommitState> const;
+                                 commit_by_hash : table<string; int> const;
+                                 var marked : table<string; bool>) {
+    if (empty(head) || !key_exists(commit_by_hash, head)) return
+    var inscope pending : array<string>
+    pending |> push(head)
+    while (!empty(pending)) {
+        let hash = pending[length(pending) - 1]
+        pending |> pop()
+        if (key_exists(marked, hash) || !key_exists(commit_by_hash, hash)) continue
+        marked[hash] = true
+        let commit = commits[commit_by_hash?[hash] ?? -1]
+        for (parent in split(commit.parents, " ")) {
+            if (!empty(parent) && key_exists(commit_by_hash, parent)
+                    && !key_exists(marked, parent)) pending |> push(parent)
+        }
+    }
+}
+
+def private graph_assign_first_parent(head, identity : string;
+                                      commits : array<GitCommitState> const;
+                                      commit_by_hash : table<string; int> const;
+                                      visible : table<string; bool> const;
+                                      var owner_slot : table<string; int>;
+                                      var owner_name : table<string; string>) {
+    var hash = head
+    let slot = git_tree_color_slot(identity)
+    while (!empty(hash) && key_exists(commit_by_hash, hash)
+            && key_exists(visible, hash) && !key_exists(owner_slot, hash)) {
+        owner_slot[hash] = slot
+        owner_name[hash] = identity
+        let parents = split(commits[commit_by_hash?[hash] ?? -1].parents, " ")
+        hash = !empty(parents) ? parents[0] : ""
+    }
+}
+
+def private graph_append_ref_label(var text : string&; name : string;
+                                   var count : int&) {
+    if (count >= 4 || empty(name) || ends_with(name, "/HEAD")) return
+    if (!empty(text)) {
+        text += " "
+    }
+    text += "[{name}]"
+    count++
+}
+
+def public git_tree_build_model(repository : RepositorySnapshot const;
+                                worktree : WorktreeState const;
+                                filter : GitTreeFilter;
+                                requested_focus_ref : string;
+                                var model : GitTreeModel) {
+    delete model.nodes
+    delete model.edges
+    model.max_lane = 0
+    model.included_ref_count = 0
+    model.filter = filter
+
+    var inscope commit_by_hash : table<string; int>
+    for (index in range(length(repository.history_commits))) {
+        let commit = repository.history_commits[index]
+        if (commit.worktree_path == worktree.path) {
+            commit_by_hash[commit.hash] = index
+        }
+    }
+
+    model.base_ref = graph_base_ref(repository, worktree)
+    let base_ref_index = graph_ref_index(repository, worktree.path, model.base_ref)
+    let base_hash = base_ref_index >= 0 ? repository.refs[base_ref_index].hash : ""
+    var inscope base_ancestors : table<string; bool>
+    graph_mark_ancestors(base_hash, repository.history_commits,
+        commit_by_hash, base_ancestors)
+
+    var inscope included_refs : table<int; bool>
+    for (index in range(length(repository.refs))) {
+        let ref = repository.refs[index]
+        if (ref.worktree_path != worktree.path || ends_with(ref.name, "/HEAD")
+                || !key_exists(commit_by_hash, ref.hash)) continue
+        var should_include = (filter == GitTreeFilter.all)
+        if (filter == GitTreeFilter.auto_) {
+            let commit_row = commit_by_hash?[ref.hash] ?? -1
+            should_include = (ref.current || ref.name == worktree.branch
+                || ref.name == model.base_ref || ref.full_name == model.base_ref
+                || (!ref.remote && (!key_exists(base_ancestors, ref.hash)
+                    || commit_row < 64)))
+        }
+        if (should_include) {
+            included_refs[index] = true
+        }
+    }
+    // Auto retains the configured upstream for every included local branch so
+    // pushed state and coalesced local/remote heads remain intelligible.
+    if (filter == GitTreeFilter.auto_) {
+        for (index in range(length(repository.refs))) {
+            if (!key_exists(included_refs, index)) continue
+            let ref = repository.refs[index]
+            if (ref.remote || empty(ref.upstream)) continue
+            let upstream_index = graph_ref_index(
+                repository, worktree.path, ref.upstream)
+            if (upstream_index >= 0) {
+                included_refs[upstream_index] = true
+            }
+        }
+    }
+    model.included_ref_count = length(included_refs)
+
+    var inscope visible : table<string; bool>
+    for (index in keys(included_refs)) {
+        graph_mark_ancestors(repository.refs[index].hash,
+            repository.history_commits, commit_by_hash, visible)
+    }
+    if (empty(visible) && key_exists(commit_by_hash, worktree.head)) {
+        graph_mark_ancestors(worktree.head, repository.history_commits,
+            commit_by_hash, visible)
+    }
+
+    var inscope pushed : table<string; bool>
+    for (index in keys(included_refs)) {
+        let ref = repository.refs[index]
+        if (ref.remote) {
+            graph_mark_ancestors(ref.hash, repository.history_commits,
+                commit_by_hash, pushed)
+        }
+    }
+
+    model.focus_ref = (empty(requested_focus_ref)
+        ? worktree.branch : requested_focus_ref)
+    var focus_ref_index = graph_ref_index(
+        repository, worktree.path, model.focus_ref)
+    if (focus_ref_index < 0) {
+        model.focus_ref = worktree.branch
+        focus_ref_index = graph_ref_index(
+            repository, worktree.path, model.focus_ref)
+    }
+    let focus_hash = (focus_ref_index >= 0
+        ? repository.refs[focus_ref_index].hash : worktree.head)
+    var inscope focus_range : table<string; bool>
+    var inscope focus_pending : array<string>
+    if (!empty(focus_hash)) focus_pending |> push(focus_hash)
+    while (!empty(focus_pending)) {
+        let hash = focus_pending[length(focus_pending) - 1]
+        focus_pending |> pop()
+        if (key_exists(focus_range, hash) || key_exists(base_ancestors, hash)
+                || !key_exists(commit_by_hash, hash)) continue
+        focus_range[hash] = true
+        let commit = repository.history_commits[commit_by_hash?[hash] ?? -1]
+        for (parent in split(commit.parents, " ")) {
+            if (!empty(parent)) focus_pending |> push(parent)
+        }
+    }
+
+    var inscope owner_slot : table<string; int>
+    var inscope owner_name : table<string; string>
+    if (base_ref_index >= 0) {
+        graph_assign_first_parent(base_hash, model.base_ref,
+            repository.history_commits, commit_by_hash, visible,
+            owner_slot, owner_name)
+    }
+    if (focus_ref_index >= 0) {
+        graph_assign_first_parent(focus_hash, model.focus_ref,
+            repository.history_commits, commit_by_hash, visible,
+            owner_slot, owner_name)
+    }
+    for (index in keys(included_refs)) {
+        let ref = repository.refs[index]
+        graph_assign_first_parent(ref.hash, ref.name,
+            repository.history_commits, commit_by_hash, visible,
+            owner_slot, owner_name)
+    }
+
+    var inscope node_by_hash : table<string; int>
+    for (commit_index in range(length(repository.history_commits))) {
+        let commit = repository.history_commits[commit_index]
+        if (commit.worktree_path != worktree.path
+                || !key_exists(visible, commit.hash)) continue
+        var refs_text : string
+        var refs_count = 0
+        var primary_ref : string
+        var head = false
+        for (ref_index in keys(included_refs)) {
+            let ref = repository.refs[ref_index]
+            if (ref.hash != commit.hash) continue
+            head = true
+            graph_append_ref_label(refs_text, ref.name, refs_count)
+            if (empty(primary_ref) || ref.current
+                    || (!ref.remote && starts_with(primary_ref, "origin/"))) {
+                primary_ref = ref.name
+            }
+        }
+        let color_slot = (key_exists(owner_slot, commit.hash)
+            ? (owner_slot?[commit.hash] ?? 0)
+            : git_tree_color_slot(commit.hash))
+        let node_index = length(model.nodes)
+        node_by_hash[commit.hash] = node_index
+        model.nodes |> push(GitTreeNode(
+            commit_index = commit_index, hash = commit.hash,
+            row = node_index, color_slot = color_slot,
+            head = head, pushed = key_exists(pushed, commit.hash),
+            focused = key_exists(focus_range, commit.hash),
+            focus_head = commit.hash == focus_hash,
+            refs_text = refs_text, primary_ref = primary_ref))
+    }
+
+    var inscope lanes : array<string>
+    for (node_index in range(length(model.nodes))) {
+        var node & = unsafe(model.nodes[node_index])
+        var lane = graph_lane_index(lanes, node.hash)
+        if (lane < 0) {
+            lanes |> push(node.hash)
+            lane = length(lanes) - 1
+        }
+        node.lane = lane
+        model.max_lane = max(model.max_lane, lane)
+        let commit = repository.history_commits[node.commit_index]
+        var inscope visible_parents : array<string>
+        for (parent in split(commit.parents, " ")) {
+            if (!empty(parent) && key_exists(node_by_hash, parent)) {
+                visible_parents |> push(parent)
+            }
+        }
+        if (empty(visible_parents)) {
+            lanes |> erase(lane)
+        } else {
+            let first_parent = visible_parents[0]
+            let existing = graph_lane_index(lanes, first_parent)
+            if (existing >= 0 && existing != lane) {
+                lanes |> erase(lane)
+            } else {
+                lanes[lane] = first_parent
+            }
+            for (parent_index in range(1, length(visible_parents))) {
+                let parent = visible_parents[parent_index]
+                if (graph_lane_index(lanes, parent) < 0) lanes |> push(parent)
+            }
+        }
+    }
+
+    for (child_index in range(length(model.nodes))) {
+        let child = model.nodes[child_index]
+        let commit = repository.history_commits[child.commit_index]
+        for (parent in split(commit.parents, " ")) {
+            if (empty(parent) || !key_exists(node_by_hash, parent)) continue
+            let parent_index = node_by_hash?[parent] ?? -1
+            model.edges |> push(GitTreeEdge(
+                child = child_index, parent = parent_index,
+                color_slot = model.nodes[parent_index].color_slot,
+                focused = child.focused))
+        }
+    }
+}

--- a/utils/dasHerd/watcher/git_graph_model.das
+++ b/utils/dasHerd/watcher/git_graph_model.das
@@ -118,6 +118,51 @@ def private graph_mark_ancestors(head : string;
     }
 }
 
+def private graph_owned_commit_key(owner, hash : string) : string {
+    return "{owner}\n{hash}"
+}
+
+def private graph_mark_owned_ancestors(owner, head : string;
+                                       commits : array<GitCommitState> const;
+                                       commit_by_hash : table<string; int> const;
+                                       var marked : table<string; bool>) {
+    if (empty(owner) || empty(head) || !key_exists(commit_by_hash, head)) return
+    var inscope pending : array<string>
+    pending |> push(head)
+    while (!empty(pending)) {
+        let hash = pending[length(pending) - 1]
+        pending |> pop()
+        let key = graph_owned_commit_key(owner, hash)
+        if (key_exists(marked, key) || !key_exists(commit_by_hash, hash)) continue
+        marked[key] = true
+        let commit = commits[commit_by_hash?[hash] ?? -1]
+        for (parent in split(commit.parents, " ")) {
+            if (!empty(parent) && key_exists(commit_by_hash, parent)) {
+                pending |> push(parent)
+            }
+        }
+    }
+}
+
+def private graph_mark_ref_pushed(identity : string; ref_index : int;
+                                  repository : RepositorySnapshot const;
+                                  worktree_path : string;
+                                  commit_by_hash : table<string; int> const;
+                                  var marked : table<string; bool>) {
+    if (ref_index < 0 || ref_index >= length(repository.refs)) return
+    let ref = repository.refs[ref_index]
+    var remote_head = ref.remote ? ref.hash : ""
+    if (!ref.remote && !empty(ref.upstream)) {
+        let upstream_index = graph_ref_index(
+            repository, worktree_path, ref.upstream)
+        if (upstream_index >= 0 && repository.refs[upstream_index].remote) {
+            remote_head = repository.refs[upstream_index].hash
+        }
+    }
+    graph_mark_owned_ancestors(identity, remote_head,
+        repository.history_commits, commit_by_hash, marked)
+}
+
 def private graph_assign_first_parent(head, identity : string;
                                       commits : array<GitCommitState> const;
                                       commit_by_hash : table<string; int> const;
@@ -205,22 +250,14 @@ def public git_tree_build_model(repository : RepositorySnapshot const;
     model.included_ref_count = length(included_refs)
 
     var inscope visible : table<string; bool>
-    for (index in keys(included_refs)) {
+    for (index in range(length(repository.refs))) {
+        if (!key_exists(included_refs, index)) continue
         graph_mark_ancestors(repository.refs[index].hash,
             repository.history_commits, commit_by_hash, visible)
     }
     if (empty(visible) && key_exists(commit_by_hash, worktree.head)) {
         graph_mark_ancestors(worktree.head, repository.history_commits,
             commit_by_hash, visible)
-    }
-
-    var inscope pushed : table<string; bool>
-    for (index in keys(included_refs)) {
-        let ref = repository.refs[index]
-        if (ref.remote) {
-            graph_mark_ancestors(ref.hash, repository.history_commits,
-                commit_by_hash, pushed)
-        }
     }
 
     model.focus_ref = (empty(requested_focus_ref)
@@ -261,11 +298,23 @@ def public git_tree_build_model(repository : RepositorySnapshot const;
             repository.history_commits, commit_by_hash, visible,
             owner_slot, owner_name)
     }
-    for (index in keys(included_refs)) {
+    for (index in range(length(repository.refs))) {
+        if (!key_exists(included_refs, index)) continue
         let ref = repository.refs[index]
         graph_assign_first_parent(ref.hash, ref.name,
             repository.history_commits, commit_by_hash, visible,
             owner_slot, owner_name)
+    }
+
+    var inscope pushed_by_owner : table<string; bool>
+    graph_mark_ref_pushed(model.base_ref, base_ref_index,
+        repository, worktree.path, commit_by_hash, pushed_by_owner)
+    graph_mark_ref_pushed(model.focus_ref, focus_ref_index,
+        repository, worktree.path, commit_by_hash, pushed_by_owner)
+    for (index in range(length(repository.refs))) {
+        if (!key_exists(included_refs, index)) continue
+        graph_mark_ref_pushed(repository.refs[index].name, index,
+            repository, worktree.path, commit_by_hash, pushed_by_owner)
     }
 
     var inscope node_by_hash : table<string; int>
@@ -276,15 +325,18 @@ def public git_tree_build_model(repository : RepositorySnapshot const;
         var refs_text : string
         var refs_count = 0
         var primary_ref : string
+        var primary_remote = true
         var head = false
-        for (ref_index in keys(included_refs)) {
+        for (ref_index in range(length(repository.refs))) {
+            if (!key_exists(included_refs, ref_index)) continue
             let ref = repository.refs[ref_index]
             if (ref.hash != commit.hash) continue
             head = true
             graph_append_ref_label(refs_text, ref.name, refs_count)
             if (empty(primary_ref) || ref.current
-                    || (!ref.remote && starts_with(primary_ref, "origin/"))) {
+                    || (!ref.remote && primary_remote)) {
                 primary_ref = ref.name
+                primary_remote = ref.remote
             }
         }
         let color_slot = (key_exists(owner_slot, commit.hash)
@@ -292,10 +344,12 @@ def public git_tree_build_model(repository : RepositorySnapshot const;
             : git_tree_color_slot(commit.hash))
         let node_index = length(model.nodes)
         node_by_hash[commit.hash] = node_index
+        let owner = key_exists(owner_name, commit.hash) ? (owner_name?[commit.hash] ?? "") : ""
         model.nodes |> push(GitTreeNode(
             commit_index = commit_index, hash = commit.hash,
             row = node_index, color_slot = color_slot,
-            head = head, pushed = key_exists(pushed, commit.hash),
+            head = head, pushed = key_exists(pushed_by_owner,
+                graph_owned_commit_key(owner, commit.hash)),
             focused = key_exists(focus_range, commit.hash),
             focus_head = commit.hash == focus_hash,
             refs_text = refs_text, primary_ref = primary_ref))

--- a/utils/dasHerd/watcher/git_graph_model.das
+++ b/utils/dasHerd/watcher/git_graph_model.das
@@ -50,20 +50,12 @@ struct GitTreeModel {
     }
 }
 
-def private graph_byte(value : string; index : int) : int {
-    var result = 0
-    peek_data(value) $(bytes) {
-        if (index >= 0 && index < length(value)) {
-            result = int(bytes[index])
-        }
-    }
-    return result
-}
-
 def public git_tree_color_slot(identity : string) : int {
     var value = 2166136261u
-    for (index in range(length(identity))) {
-        value = (value ^ uint(graph_byte(identity, index))) * 16777619u
+    peek_data(identity) $(bytes) {
+        for (index in range(length(identity))) {
+            value = (value ^ uint(bytes[index])) * 16777619u
+        }
     }
     return int(value % 12u)
 }

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -9,10 +9,12 @@ require daslib/jobque_boost
 require daslib/rtti
 require daslib/base64
 require daslib/safe_addr
+require daslib/strings_boost
 require imgui/imgui_text_tree_sitter
 require imgui/imgui_markdown_tree_sitter
 require stbimage/stbimage_boost
 require ./file_inspection.das
+require math
 
 let private MAX_BINARY_PREVIEW_PIXELS = 64l * 1024l * 1024l
 
@@ -112,6 +114,141 @@ def private prepare_changed_source_ranges(source : string;
     return <- result
 }
 
+def private source_lines(source : string) : array<string> {
+    return <- split(source, "\n")
+}
+
+def public inspector_reconstruct_old_source(new_source : string;
+                                            patch : GitParsedPatch const) : string {
+    //! Rebuild the complete pre-change file without asking Git for another
+    //! projection. Unified hunks contain every removed line and enough
+    //! coordinates to splice them back into the complete resulting file.
+    var inscope new_lines <- source_lines(new_source)
+    var inscope old_lines : array<string>
+    old_lines |> reserve(length(new_lines) + length(patch.rows))
+    var new_cursor = 0
+    for (hunk in patch.hunks) {
+        let hunk_start = max(0, hunk.new_start - 1)
+        while (new_cursor < hunk_start && new_cursor < length(new_lines)) {
+            old_lines |> push(new_lines[new_cursor])
+            new_cursor++
+        }
+        var hunk_new_end = hunk_start
+        let row_end = min(length(patch.rows), hunk.row_start + hunk.row_count)
+        for (row_index in range(hunk.row_start, row_end)) {
+            let row = patch.rows[row_index]
+            if (row.old_line > 0) {
+                old_lines |> push(row.old_text)
+            }
+            if (row.new_line > 0) {
+                hunk_new_end = max(hunk_new_end, row.new_line)
+            }
+        }
+        new_cursor = max(new_cursor, hunk_new_end)
+    }
+    while (new_cursor < length(new_lines)) {
+        old_lines |> push(new_lines[new_cursor])
+        new_cursor++
+    }
+    return join(old_lines, "\n")
+}
+
+def private line_starts(source : string) : array<int> {
+    var result : array<int>
+    result |> reserve(max(1, length(source) / 40))
+    result |> push(0)
+    peek_data(source) $(bytes) {
+        for (index in range(length(bytes))) {
+            if (int(bytes[index]) == '\n') {
+                result |> push(index + 1)
+            }
+        }
+    }
+    return <- result
+}
+
+def private inspector_byte_at(source : string; index : int) : int {
+    var result = 0
+    peek_data(source) $(bytes) {
+        result = int(bytes[index])
+    }
+    return result
+}
+
+def private line_body_end(source : string; starts : array<int> const;
+                          line_index : int) : int {
+    var result = line_index + 1 < length(starts) ? starts[line_index + 1] - 1 : length(source)
+    if (result > starts[line_index] && inspector_byte_at(source, result - 1) == '\r') {
+        result--
+    }
+    return result
+}
+
+def private append_projected_span(var document : TextSourceDocument;
+                                  start_byte, end_byte : int;
+                                  style : TextSourceSyntaxStyle) {
+    if (end_byte <= start_byte) return
+    document.spans |> push(TextSourceSpan(
+        source = TextSourceRange(start_byte = start_byte, end_byte = end_byte),
+        syntax_style = style))
+}
+
+def public inspector_project_full_syntax(full : TextSourceDocument const;
+                                         aligned_source : string;
+                                         rows : array<GitDiffRow> const;
+                                         old_side : bool;
+                                         revision : int) : TextSourceDocument {
+    //! The visible diff remains compact, but every syntax decision originates
+    //! in the complete file. This avoids truncated declarations/comments
+    //! changing Tree-sitter's interpretation when context mode changes.
+    var result = TextSourceDocument(source = aligned_source, revision = revision)
+    var inscope full_starts <- line_starts(full.source)
+    var inscope aligned_starts <- line_starts(aligned_source)
+    var full_span_index = 0
+    for (row_index in range(min(length(rows), length(aligned_starts)))) {
+        let source_number = old_side ? rows[row_index].old_line : rows[row_index].new_line
+        let destination_start = aligned_starts[row_index]
+        let destination_end = line_body_end(aligned_source, aligned_starts, row_index)
+        var covered = destination_start
+        if (source_number > 0 && source_number <= length(full_starts)) {
+            let source_start = full_starts[source_number - 1]
+            let source_end = line_body_end(full.source, full_starts, source_number - 1)
+            while (full_span_index < length(full.spans)
+                    && full.spans[full_span_index].source.end_byte <= source_start) {
+                full_span_index++
+            }
+            var scan = full_span_index
+            while (scan < length(full.spans)) {
+                let span = full.spans[scan]
+                if (span.source.start_byte >= source_end) break
+                let clipped_start = max(source_start, span.source.start_byte)
+                let clipped_end = min(source_end, span.source.end_byte)
+                let projected_start = min(destination_end,
+                    destination_start + clipped_start - source_start)
+                let projected_end = min(destination_end,
+                    destination_start + clipped_end - source_start)
+                append_projected_span(result, covered, projected_start,
+                    TextSourceSyntaxStyle.none)
+                append_projected_span(result, projected_start, projected_end,
+                    span.syntax_style)
+                covered = max(covered, projected_end)
+                scan++
+            }
+        }
+        append_projected_span(result, covered, destination_end,
+            TextSourceSyntaxStyle.none)
+        if (row_index + 1 < length(aligned_starts)) {
+            append_projected_span(result, destination_end,
+                aligned_starts[row_index + 1], TextSourceSyntaxStyle.none)
+        }
+    }
+    if (empty(result.spans) && !empty(aligned_source)) {
+        append_projected_span(result, 0, length(aligned_source),
+            TextSourceSyntaxStyle.none)
+    }
+    return <- result
+}
+
 def private prepare_worker_main(var jobs : Channel?&;
                                 var events : Channel?&) {
     this_context().name := "dasHerd_inspector_prepare"
@@ -161,12 +298,20 @@ def private prepare_worker_main(var jobs : Channel?&;
                 if (!empty(prepared_patch.error)) {
                     failure = prepared_patch.error
                 } else {
-                    var prepared_old <- tree_sitter_source_document(
-                        prepared_patch.old_aligned_text, job.language,
-                        job.generation)
-                    var prepared_new <- tree_sitter_source_document(
-                        prepared_patch.new_aligned_text, job.language,
-                        job.generation)
+                    view_source = (job.view_available || !empty(job.view_text)) ? job.view_text : prepared_patch.new_text
+                    let old_source = inspector_reconstruct_old_source(
+                        view_source, prepared_patch)
+                    var full_old <- tree_sitter_source_document(
+                        old_source, job.language, job.generation)
+                    var full_new <- tree_sitter_source_document(
+                        view_source, job.language, job.generation)
+                    var prepared_old <- inspector_project_full_syntax(
+                        full_old, prepared_patch.old_aligned_text,
+                        prepared_patch.rows, true, job.generation)
+                    var prepared_new <- inspector_project_full_syntax(
+                        full_new, prepared_patch.new_aligned_text,
+                        prepared_patch.rows, false, job.generation)
+                    text_source_document_dispose(full_old)
                     prepared_old.line_numbers |> reserve(length(prepared_patch.rows))
                     prepared_new.line_numbers |> reserve(length(prepared_patch.rows))
                     for (index in range(length(prepared_patch.rows))) {
@@ -187,17 +332,14 @@ def private prepare_worker_main(var jobs : Channel?&;
                                 kind = TextSourceLineMarkKind.added))
                         }
                     }
-                    view_source = (job.view_available || !empty(job.view_text)) ? job.view_text : prepared_patch.new_text
                     if (!prepared_patch.binary) {
-                        var prepared_view <- tree_sitter_source_document(
-                            view_source, job.language, job.generation)
-                        prepared_view.line_marks |> reserve(
+                        full_new.line_marks |> reserve(
                             length(prepared_patch.new_changed_lines))
                         for (line in prepared_patch.new_changed_lines) {
-                            prepared_view.line_marks |> push(TextSourceLineMark(
+                            full_new.line_marks |> push(TextSourceLineMark(
                                 line_index = line, kind = TextSourceLineMarkKind.added))
                         }
-                        view_document <- prepared_view
+                        view_document <- full_new
                         if (job.language == "markdown") {
                             var prepared_markdown <- md_parse(view_source)
                             if (!prepared_markdown.ok) {
@@ -214,6 +356,8 @@ def private prepare_worker_main(var jobs : Channel?&;
                                     view_source, prepared_patch.new_changed_lines)
                             }
                         }
+                    } else {
+                        text_source_document_dispose(full_new)
                     }
                     if (prepared_patch.binary) {
                         if (job.view_byte_count > MAX_FILE_PREVIEW_RAW_BYTES) {

--- a/utils/dasHerd/watcher/main.das
+++ b/utils/dasHerd/watcher/main.das
@@ -27,7 +27,8 @@ var private g_log_root : string
 var private g_config_path : string
 var private g_last_memory_log_at = 0l
 var private g_last_gc_at = 0l
-let GC_MIN_INTERVAL_SECONDS = 60l
+let GC_PRESSURE_MIN_INTERVAL_SECONDS = 10l
+let GC_COMPACT_MIN_INTERVAL_SECONDS = 60l
 
 def private option_value(prefix : string; fallback : string = "") : string {
     for (argument in get_command_line_arguments()) {
@@ -76,7 +77,6 @@ def private maybe_collect_gc() {
     let forced = watcher_take_gc_request()
     return if (is_live_mode() && !forced)
     let now = int64(get_clock())
-    if (!forced && g_last_gc_at != 0l && now - g_last_gc_at < GC_MIN_INTERVAL_SECONDS) return
     if (forced) {
         g_last_gc_at = now
         let gc_started = ref_time_ticks()
@@ -90,35 +90,26 @@ def private maybe_collect_gc() {
             "string_heap={string_heap_bytes_allocated()}/{string_heap_total_allocated()}\n")
         return
     }
-    let string_used = string_heap_bytes_allocated()
-    let string_total = string_heap_total_allocated()
-    if (string_total > 0ul && string_used * 3ul < string_total * 2ul) {
-        g_last_gc_at = now
-        let gc_started = ref_time_ticks()
-        print("dasHerd watcher: GC begin reason=string_fragmentation validate=true " +
-            "das_heap={heap_bytes_allocated()}/{heap_total_allocated()} " +
-            "string_heap={string_used}/{string_total}\n")
-        unsafe(heap_collect(true, true))
-        print("dasHerd watcher: GC end reason=string_fragmentation " +
-            "elapsed_ms={int64(get_time_usec(gc_started)) / 1000l} " +
-            "das_heap={heap_bytes_allocated()}/{heap_total_allocated()} " +
-            "string_heap={string_heap_bytes_allocated()}/{string_heap_total_allocated()}\n")
-        return
-    }
     let heap_used = heap_bytes_allocated()
     let heap_total = heap_total_allocated()
-    if (heap_total > 0ul && heap_used * 3ul < heap_total) {
-        g_last_gc_at = now
-        let gc_started = ref_time_ticks()
-        print("dasHerd watcher: GC begin reason=heap_fragmentation validate=true " +
-            "das_heap={heap_used}/{heap_total} " +
-            "string_heap={string_heap_bytes_allocated()}/{string_heap_total_allocated()}\n")
-        unsafe(heap_collect(true, true))
-        print("dasHerd watcher: GC end reason=heap_fragmentation " +
-            "elapsed_ms={int64(get_time_usec(gc_started)) / 1000l} " +
-            "das_heap={heap_bytes_allocated()}/{heap_total_allocated()} " +
-            "string_heap={string_heap_bytes_allocated()}/{string_heap_total_allocated()}\n")
-    }
+    let string_used = string_heap_bytes_allocated()
+    let string_total = string_heap_total_allocated()
+    let reason = watcher_gc_reason(string_used, string_total,
+        heap_used, heap_total)
+    if (empty(reason)) return
+    let minimum_interval = ((reason == "string_pressure" || reason == "heap_pressure")
+        ? GC_PRESSURE_MIN_INTERVAL_SECONDS : GC_COMPACT_MIN_INTERVAL_SECONDS)
+    if (g_last_gc_at != 0l && now - g_last_gc_at < minimum_interval) return
+    g_last_gc_at = now
+    let gc_started = ref_time_ticks()
+    print("dasHerd watcher: GC begin reason={reason} validate=true " +
+        "das_heap={heap_used}/{heap_total} " +
+        "string_heap={string_used}/{string_total}\n")
+    unsafe(heap_collect(true, true))
+    print("dasHerd watcher: GC end reason={reason} " +
+        "elapsed_ms={int64(get_time_usec(gc_started)) / 1000l} " +
+        "das_heap={heap_bytes_allocated()}/{heap_total_allocated()} " +
+        "string_heap={string_heap_bytes_allocated()}/{string_heap_total_allocated()}\n")
 }
 
 [export]

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1699,7 +1699,7 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
     }
     var info = WatcherSessionInfo()
     if (!watcher_get_session_info(runtime.snapshot.task_session_id, info) || !info.drained) return
-    let machine_output_truncated = false
+    var machine_output_truncated = false
     let output = watcher_machine_output_text(
         runtime.snapshot.task_session_id, machine_output_truncated)
     if (machine_output_truncated) {

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -7,6 +7,7 @@ options indenting = 4
 module repository_core shared public
 
 require ./watcher_core.das public
+require daslib/command_line
 require daslib/fio public
 require daslib/json_boost public
 require daslib/strings_boost
@@ -15,7 +16,8 @@ require strings public
 let private REPOSITORY_CONFIG_VERSION = 1
 let private GIT_TIMEOUT_MS = 15000l
 let private GIT_CAPTURE_COLUMNS = 240
-let private GIT_CAPTURE_ROWS = 100
+let private GIT_CAPTURE_ROWS = 512
+let private GIT_FIELD_SEPARATOR = "<|dasHerd-field|>"
 
 struct public RepositoryRecord {
     id : string
@@ -27,6 +29,39 @@ struct public RepositoryRecord {
 
 struct public GitFileState {
     worktree_path : string
+    code : string
+    path : string
+    old_path : string
+}
+
+struct public GitCommitState {
+    worktree_path : string
+    hash : string
+    short_hash : string
+    authored_at : int64
+    author : string
+    subject : string
+}
+
+struct public GitReviewFileState {
+    worktree_path : string
+    code : string
+    path : string
+    old_path : string
+}
+
+struct public GitRefState {
+    worktree_path : string
+    full_name : string
+    name : string
+    hash : string
+    current : bool
+    remote : bool
+}
+
+struct public GitCommitFileState {
+    worktree_path : string
+    commit_hash : string
     code : string
     path : string
     old_path : string
@@ -48,17 +83,35 @@ struct public WorktreeState {
     untracked : int
     conflicted : int
     error : string
+    review_base_ref : string
+    review_merge_base : string
+    review_loading : bool
+    review_error : string
+    history_ref : string
+    history_commit : string
+    history_loading : bool
+    history_error : string
+    refs_loading : bool
+    refs_error : string
 }
 
 struct public RepositorySnapshot {
     record : RepositoryRecord = RepositoryRecord()
     worktrees : array<WorktreeState>
     files : array<GitFileState>
+    review_commits : array<GitCommitState>
+    review_files : array<GitReviewFileState>
+    history_commits : array<GitCommitState>
+    commit_files : array<GitCommitFileState>
+    refs : array<GitRefState>
     refreshing : bool
     error : string
     revision : int64
     last_success_ms : int64
     task_session_id : string
+    failure_session_id : string
+    failure_message : string
+    failure_revision : int64
 }
 
 struct public RepositoryAddRequest {
@@ -82,9 +135,37 @@ class private RepositoryRuntime {
     worktree_index : int
     refresh_pending : bool = true
     rerun_pending : bool
+    review_pending_path : string
+    review_worktree_index : int = -1
+    review_base_ref : string
+    review_merge_base : string
+    review_tried_origin_main : bool
+    pending_review_commits : array<GitCommitState>
+    pending_review_files : array<GitReviewFileState>
+    history_pending_path : string
+    history_pending_ref : string
+    commit_pending_path : string
+    commit_pending_hash : string
+    refs_pending_path : string
+    history_worktree_index : int = -1
+    history_ref : string
+    history_commit : string
+    pending_history_commits : array<GitCommitState>
+    pending_commit_files : array<GitCommitFileState>
+    pending_refs : array<GitRefState>
     def operator delete {
         delete snapshot.worktrees
         delete snapshot.files
+        delete snapshot.review_commits
+        delete snapshot.review_files
+        delete snapshot.history_commits
+        delete snapshot.commit_files
+        delete snapshot.refs
+        delete pending_review_commits
+        delete pending_review_files
+        delete pending_history_commits
+        delete pending_commit_files
+        delete pending_refs
     }
 }
 
@@ -274,13 +355,124 @@ def public repository_build_file_diff_argv(worktree_path : string;
     return ""
 }
 
+def private record_git_failure(var runtime : RepositoryRuntime?;
+                               message : string) {
+    runtime.snapshot.failure_session_id = runtime.snapshot.task_session_id
+    runtime.snapshot.failure_message = message
+    runtime.snapshot.failure_revision++
+}
+
+def public repository_build_review_file_diff_argv(worktree_path : string;
+                                                  merge_base : string;
+                                                  file_path : string;
+                                                  var argv : array<string>&;
+                                                  diff_context : string = "compact") : string {
+    delete argv
+    if (empty(merge_base)) return "worktree review has no merge base"
+    if (!repository_valid_relative_file_path(file_path)) {
+        return "invalid worktree-relative file path"
+    }
+    var context_lines = 3
+    if (diff_context == "expanded") {
+        context_lines = 20
+    } elif (diff_context == "full") {
+        context_lines = 1000000
+    } elif (diff_context != "compact") {
+        return "diff context is not implemented"
+    }
+    var inscope command <- ["git", "--literal-pathspecs", "-C", worktree_path,
+        "--no-pager", "-c", "color.ui=false", "diff", "--cached",
+        "--no-ext-diff", "--unified={context_lines}", merge_base, "--", file_path]
+    argv := command
+    return ""
+}
+
+def public repository_build_commit_file_diff_argv(worktree_path : string;
+                                                  commit_hash : string;
+                                                  file_path : string;
+                                                  var argv : array<string>&;
+                                                  diff_context : string = "compact") : string {
+    delete argv
+    if (empty(commit_hash)) return "commit hash is required"
+    if (!repository_valid_relative_file_path(file_path)) {
+        return "invalid worktree-relative file path"
+    }
+    var context_lines = 3
+    if (diff_context == "expanded") {
+        context_lines = 20
+    } elif (diff_context == "full") {
+        context_lines = 1000000
+    } elif (diff_context != "compact") {
+        return "diff context is not implemented"
+    }
+    var inscope command <- ["git", "--literal-pathspecs", "-C", worktree_path,
+        "--no-pager", "-c", "color.ui=false", "show", "--format=",
+        "--first-parent", "--find-renames", "--no-ext-diff", "--unified={context_lines}",
+        commit_hash, "--", file_path]
+    argv := command
+    return ""
+}
+
+def public repository_build_file_action_argv(worktree_path : string;
+                                             file_path : string;
+                                             action : string;
+                                             var argv : array<string>&) : string {
+    delete argv
+    if (!repository_valid_relative_file_path(file_path)) {
+        return "invalid worktree-relative file path"
+    }
+    if (action == "stage") {
+        var inscope command <- ["git", "--literal-pathspecs", "-C", worktree_path,
+            "add", "--", file_path]
+        argv := command
+    } elif (action == "unstage") {
+        var inscope command <- ["git", "--literal-pathspecs", "-C", worktree_path,
+            "reset", "--quiet", "HEAD", "--", file_path]
+        argv := command
+    } else {
+        return "file action is not implemented"
+    }
+    return ""
+}
+
+def public repository_file_action_argv(repository_id : string;
+                                       worktree_path : string;
+                                       file_path : string;
+                                       action : string;
+                                       var argv : array<string>&) : string {
+    delete argv
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    let runtime = g_repositories[repository_index]
+    if (find_worktree(runtime, worktree_path) < 0) return "unknown worktree"
+    var file_index = -1
+    for (index in range(length(runtime.snapshot.files))) {
+        let file = runtime.snapshot.files[index]
+        if (file.worktree_path == worktree_path && file.path == file_path) {
+            file_index = index
+            break
+        }
+    }
+    if (file_index < 0) return "file is not present in the observed Git status"
+    let code = runtime.snapshot.files[file_index].code
+    let staged = code != "??" && byte_at(code, 0) != ' '
+    let working = code == "??" || byte_at(code, 1) != ' '
+    if (action == "stage" && !working) return "file has no working-tree change"
+    if (action == "unstage" && !staged) return "file has no staged change"
+    return repository_build_file_action_argv(
+        worktree_path, file_path, action, argv)
+}
+
 def public repository_file_diff_argv(repository_id : string;
                                      worktree_path : string;
                                      file_path : string;
                                      comparison : string;
                                      var argv : array<string>&;
                                      var expected_exit_code : int64&;
-                                     diff_context : string = "compact") : string {
+                                     diff_context : string = "compact";
+                                     revision : string = "") : string {
     delete argv
     expected_exit_code = 0l
     let repository_index = find_repository(repository_id)
@@ -288,14 +480,37 @@ def public repository_file_diff_argv(repository_id : string;
         return "unknown repository"
     }
     let runtime = g_repositories[repository_index]
-    var worktree_found = false
-    for (worktree in runtime.snapshot.worktrees) {
-        if (worktree.path == worktree_path) {
-            worktree_found = true
-            break
+    let worktree_index = find_worktree(runtime, worktree_path)
+    if (worktree_index < 0) return "unknown worktree"
+
+    if (comparison == "pr") {
+        var review_file_found = false
+        for (file in runtime.snapshot.review_files) {
+            if (file.worktree_path == worktree_path && file.path == file_path) {
+                review_file_found = true
+                break
+            }
         }
+        if (!review_file_found) return "file is not present in the worktree PR result"
+        return repository_build_review_file_diff_argv(
+            worktree_path,
+            runtime.snapshot.worktrees[worktree_index].review_merge_base,
+            file_path, argv, diff_context)
     }
-    if (!worktree_found) return "unknown worktree"
+
+    if (comparison == "commit") {
+        var commit_file_found = false
+        for (file in runtime.snapshot.commit_files) {
+            if (file.worktree_path == worktree_path
+                    && file.commit_hash == revision && file.path == file_path) {
+                commit_file_found = true
+                break
+            }
+        }
+        if (!commit_file_found) return "file is not present in the selected commit"
+        return repository_build_commit_file_diff_argv(
+            worktree_path, revision, file_path, argv, diff_context)
+    }
 
     var file_index = -1
     for (index in range(length(runtime.snapshot.files))) {
@@ -387,6 +602,87 @@ def public repository_working_preview_path(worktree_path : string;
     return ""
 }
 
+def private find_worktree(runtime : RepositoryRuntime?; path : string) : int {
+    for (index in range(length(runtime.snapshot.worktrees))) {
+        if (runtime.snapshot.worktrees[index].path == path) return index
+    }
+    return -1
+}
+
+def public repository_review(repository_id : string; worktree_path : string) : string {
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    var runtime = g_repositories[repository_index]
+    if (find_worktree(runtime, worktree_path) < 0) return "unknown worktree"
+    runtime.review_pending_path = worktree_path
+    changed(runtime)
+    return ""
+}
+
+def public repository_history(repository_id : string; worktree_path : string;
+                              ref_name : string = "") : string {
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    var runtime = g_repositories[repository_index]
+    let worktree_index = find_worktree(runtime, worktree_path)
+    if (worktree_index < 0) return "unknown worktree"
+    var resolved_ref = ref_name
+    if (empty(resolved_ref)) {
+        resolved_ref = runtime.snapshot.worktrees[worktree_index].branch
+    }
+    var allowed = resolved_ref == runtime.snapshot.worktrees[worktree_index].branch
+    for (ref in runtime.snapshot.refs) {
+        if (ref.worktree_path == worktree_path && ref.name == resolved_ref) {
+            allowed = true
+            break
+        }
+    }
+    if (empty(resolved_ref) || !allowed) return "unknown Git ref"
+    runtime.history_pending_path = worktree_path
+    runtime.history_pending_ref = resolved_ref
+    changed(runtime)
+    return ""
+}
+
+def public repository_commit_files(repository_id : string;
+                                   worktree_path : string;
+                                   commit_hash : string) : string {
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    var runtime = g_repositories[repository_index]
+    if (find_worktree(runtime, worktree_path) < 0) return "unknown worktree"
+    var allowed = false
+    for (commit in runtime.snapshot.history_commits) {
+        if (commit.worktree_path == worktree_path && commit.hash == commit_hash) {
+            allowed = true
+            break
+        }
+    }
+    if (!allowed) return "commit is not present in the observed history"
+    runtime.commit_pending_path = worktree_path
+    runtime.commit_pending_hash = commit_hash
+    changed(runtime)
+    return ""
+}
+
+def public repository_refs(repository_id : string; worktree_path : string) : string {
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        return "unknown repository"
+    }
+    var runtime = g_repositories[repository_index]
+    if (find_worktree(runtime, worktree_path) < 0) return "unknown worktree"
+    runtime.refs_pending_path = worktree_path
+    changed(runtime)
+    return ""
+}
+
 def public repository_working_file_text(repository_id : string;
                                         worktree_path : string;
                                         file_path : string;
@@ -453,8 +749,31 @@ def public repository_staged_file_view_argv(worktree_path : string;
         return "invalid worktree-relative file path"
     }
     if (empty(output_path)) return "staged view output path is required"
-    var inscope command <- ["git", "-C", worktree_path, "--no-pager", "show",
-        "--format=", "--output={output_path}", ":0:{file_path}"]
+    let helper = path_join(get_das_root(),
+        "utils/dasHerd/watcher/git_blob_capture.das")
+    var inscope command <- [get_das_exe(), helper, "--",
+        "--worktree={worktree_path}", "--revision=:0",
+        "--file={file_path}", "--output={output_path}"]
+    argv := command
+    return ""
+}
+
+def public repository_commit_file_view_argv(worktree_path : string;
+                                            commit_hash : string;
+                                            file_path : string;
+                                            output_path : string;
+                                            var argv : array<string>&) : string {
+    delete argv
+    if (empty(commit_hash)) return "commit hash is required"
+    if (!repository_valid_relative_file_path(file_path)) {
+        return "invalid worktree-relative file path"
+    }
+    if (empty(output_path)) return "commit view output path is required"
+    let helper = path_join(get_das_root(),
+        "utils/dasHerd/watcher/git_blob_capture.das")
+    var inscope command <- [get_das_exe(), helper, "--",
+        "--worktree={worktree_path}", "--revision={commit_hash}",
+        "--file={file_path}", "--output={output_path}"]
     argv := command
     return ""
 }
@@ -474,10 +793,14 @@ def private launch_git(var runtime : RepositoryRuntime?; argv : array<string>;
     let result = watcher_launch(request)
     runtime.snapshot.task_session_id = result.session_id
     if (!result.ok) {
-        runtime.snapshot.error = result.error
-        runtime.snapshot.refreshing = false
-        runtime.phase = 0
-        changed(runtime)
+        if (runtime.phase >= 7) {
+            fail_history(runtime, result.error)
+        } elif (runtime.phase >= 3 && runtime.review_worktree_index >= 0
+                && runtime.review_worktree_index < length(runtime.snapshot.worktrees)) {
+            fail_review(runtime, result.error)
+        } else {
+            fail_refresh(runtime, result.error)
+        }
         return false
     }
     return true
@@ -612,6 +935,282 @@ def private launch_status(var runtime : RepositoryRuntime?) : bool {
         "git-status", path)
 }
 
+def private launch_review_upstream(var runtime : RepositoryRuntime?) {
+    let index = find_worktree(runtime, runtime.review_pending_path)
+    if (index < 0) {
+        runtime.review_pending_path = ""
+        return
+    }
+    runtime.review_worktree_index = index
+    runtime.review_pending_path = ""
+    runtime.review_base_ref = ""
+    runtime.review_merge_base = ""
+    runtime.review_tried_origin_main = false
+    runtime.pending_review_commits |> clear()
+    runtime.pending_review_files |> clear()
+    runtime.snapshot.worktrees[index].review_loading = true
+    runtime.snapshot.worktrees[index].review_error = ""
+    runtime.phase = 3
+    changed(runtime)
+    let path = runtime.snapshot.worktrees[index].path
+    let branch = runtime.snapshot.worktrees[index].branch
+    let ref = empty(branch) ? "refs/heads/__detached__" : "refs/heads/{branch}"
+    let _ = launch_git(runtime, ["git", "-C", path, "for-each-ref",
+        "--format=%(upstream:short)", ref], "git-review-base", path)
+}
+
+def private launch_review_merge_base(var runtime : RepositoryRuntime?) {
+    let path = runtime.snapshot.worktrees[runtime.review_worktree_index].path
+    runtime.phase = 4
+    let _ = launch_git(runtime, ["git", "-C", path, "merge-base",
+        runtime.review_base_ref, "HEAD"], "git-review-merge-base", path)
+}
+
+def private launch_review_commits(var runtime : RepositoryRuntime?) {
+    let path = runtime.snapshot.worktrees[runtime.review_worktree_index].path
+    runtime.phase = 5
+    let revision_range = "{runtime.review_merge_base}..HEAD"
+    let _ = launch_git(runtime, ["git", "-C", path, "--no-pager", "log",
+        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s", revision_range],
+        "git-review-commits", path)
+}
+
+def private launch_review_files(var runtime : RepositoryRuntime?) {
+    let path = runtime.snapshot.worktrees[runtime.review_worktree_index].path
+    runtime.phase = 6
+    let _ = launch_git(runtime, ["git", "--literal-pathspecs", "-C", path,
+        "--no-pager", "diff", "--cached", "--name-only", "--find-renames",
+        runtime.review_merge_base, "--"], "git-review-files", path)
+}
+
+def private launch_history(var runtime : RepositoryRuntime?) {
+    let index = find_worktree(runtime, runtime.history_pending_path)
+    if (index < 0) {
+        runtime.history_pending_path = ""
+        runtime.history_pending_ref = ""
+        return
+    }
+    runtime.history_worktree_index = index
+    runtime.history_ref = runtime.history_pending_ref
+    runtime.history_pending_path = ""
+    runtime.history_pending_ref = ""
+    runtime.pending_history_commits |> clear()
+    runtime.pending_commit_files |> clear()
+    runtime.snapshot.worktrees[index].history_loading = true
+    runtime.snapshot.worktrees[index].history_error = ""
+    runtime.phase = 7
+    changed(runtime)
+    let path = runtime.snapshot.worktrees[index].path
+    let _ = launch_git(runtime, ["git", "-C", path, "--no-pager", "log",
+        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s",
+        runtime.history_ref], "git-history", path)
+}
+
+def private launch_commit_files(var runtime : RepositoryRuntime?;
+                                path : string = ""; commit_hash : string = "") {
+    var requested_path = path
+    var requested_hash = commit_hash
+    if (empty(requested_path)) {
+        requested_path = runtime.commit_pending_path
+        requested_hash = runtime.commit_pending_hash
+        runtime.commit_pending_path = ""
+        runtime.commit_pending_hash = ""
+    }
+    let index = find_worktree(runtime, requested_path)
+    if (index < 0 || empty(requested_hash)) return
+    runtime.history_worktree_index = index
+    runtime.history_commit = requested_hash
+    runtime.pending_commit_files |> clear()
+    runtime.snapshot.worktrees[index].history_loading = true
+    runtime.snapshot.worktrees[index].history_error = ""
+    runtime.phase = 8
+    changed(runtime)
+    let _ = launch_git(runtime, ["git", "--literal-pathspecs", "-C", requested_path,
+        "--no-pager", "show", "--format=", "--name-only", "--find-renames",
+        "--first-parent", requested_hash, "--"], "git-commit-files", requested_path)
+}
+
+def private launch_refs(var runtime : RepositoryRuntime?) {
+    let index = find_worktree(runtime, runtime.refs_pending_path)
+    if (index < 0) {
+        runtime.refs_pending_path = ""
+        return
+    }
+    let path = runtime.refs_pending_path
+    runtime.refs_pending_path = ""
+    runtime.history_worktree_index = index
+    runtime.pending_refs |> clear()
+    runtime.snapshot.worktrees[index].refs_loading = true
+    runtime.snapshot.worktrees[index].refs_error = ""
+    runtime.phase = 9
+    changed(runtime)
+    let _ = launch_git(runtime, ["git", "-C", path, "for-each-ref",
+        "--format=%(refname){GIT_FIELD_SEPARATOR}%(refname:short){GIT_FIELD_SEPARATOR}%(objectname){GIT_FIELD_SEPARATOR}%(HEAD){GIT_FIELD_SEPARATOR}%(symref)",
+        "refs/heads", "refs/remotes"], "git-refs", path)
+}
+
+def private erase_history_content(var runtime : RepositoryRuntime?; path : string) {
+    var index = 0
+    while (index < length(runtime.snapshot.history_commits)) {
+        if (runtime.snapshot.history_commits[index].worktree_path == path) {
+            runtime.snapshot.history_commits |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(runtime.snapshot.commit_files)) {
+        if (runtime.snapshot.commit_files[index].worktree_path == path) {
+            runtime.snapshot.commit_files |> erase(index)
+        } else {
+            index++
+        }
+    }
+}
+
+def private erase_refs(var runtime : RepositoryRuntime?; path : string) {
+    var index = 0
+    while (index < length(runtime.snapshot.refs)) {
+        if (runtime.snapshot.refs[index].worktree_path == path) {
+            runtime.snapshot.refs |> erase(index)
+        } else {
+            index++
+        }
+    }
+}
+
+def private finish_history_commits(var runtime : RepositoryRuntime?) {
+    let index = runtime.history_worktree_index
+    let path = runtime.snapshot.worktrees[index].path
+    erase_history_content(runtime, path)
+    runtime.snapshot.history_commits |> push_from(runtime.pending_history_commits)
+    runtime.pending_history_commits |> clear()
+    runtime.snapshot.worktrees[index].history_ref = runtime.history_ref
+    if (!empty(runtime.snapshot.history_commits)) {
+        var first_hash = ""
+        for (commit in runtime.snapshot.history_commits) {
+            if (commit.worktree_path == path) {
+                first_hash = commit.hash
+                break
+            }
+        }
+        if (!empty(first_hash)) {
+            launch_commit_files(runtime, path, first_hash)
+            return
+        }
+    }
+    runtime.snapshot.worktrees[index].history_commit = ""
+    runtime.snapshot.worktrees[index].history_loading = false
+    runtime.snapshot.worktrees[index].history_error = ""
+    runtime.snapshot.task_session_id = ""
+    runtime.phase = 0
+    changed(runtime)
+}
+
+def private finish_commit_files(var runtime : RepositoryRuntime?) {
+    let index = runtime.history_worktree_index
+    let path = runtime.snapshot.worktrees[index].path
+    var file_index = 0
+    while (file_index < length(runtime.snapshot.commit_files)) {
+        if (runtime.snapshot.commit_files[file_index].worktree_path == path) {
+            runtime.snapshot.commit_files |> erase(file_index)
+        } else {
+            file_index++
+        }
+    }
+    runtime.snapshot.commit_files |> push_from(runtime.pending_commit_files)
+    runtime.pending_commit_files |> clear()
+    runtime.snapshot.worktrees[index].history_commit = runtime.history_commit
+    runtime.snapshot.worktrees[index].history_loading = false
+    runtime.snapshot.worktrees[index].history_error = ""
+    runtime.snapshot.task_session_id = ""
+    runtime.phase = 0
+    changed(runtime)
+}
+
+def private finish_refs(var runtime : RepositoryRuntime?) {
+    let index = runtime.history_worktree_index
+    let path = runtime.snapshot.worktrees[index].path
+    erase_refs(runtime, path)
+    runtime.snapshot.refs |> push_from(runtime.pending_refs)
+    runtime.pending_refs |> clear()
+    runtime.snapshot.worktrees[index].refs_loading = false
+    runtime.snapshot.worktrees[index].refs_error = ""
+    runtime.snapshot.task_session_id = ""
+    runtime.phase = 0
+    changed(runtime)
+}
+
+def private erase_review_content(var runtime : RepositoryRuntime?; path : string) {
+    var index = 0
+    while (index < length(runtime.snapshot.review_commits)) {
+        if (runtime.snapshot.review_commits[index].worktree_path == path) {
+            runtime.snapshot.review_commits |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(runtime.snapshot.review_files)) {
+        if (runtime.snapshot.review_files[index].worktree_path == path) {
+            runtime.snapshot.review_files |> erase(index)
+        } else {
+            index++
+        }
+    }
+}
+
+def private finish_review(var runtime : RepositoryRuntime?) {
+    let index = runtime.review_worktree_index
+    let path = runtime.snapshot.worktrees[index].path
+    erase_review_content(runtime, path)
+    runtime.snapshot.review_commits |> push_from(runtime.pending_review_commits)
+    runtime.snapshot.review_files |> push_from(runtime.pending_review_files)
+    runtime.pending_review_commits |> clear()
+    runtime.pending_review_files |> clear()
+    runtime.snapshot.worktrees[index].review_base_ref = runtime.review_base_ref
+    runtime.snapshot.worktrees[index].review_merge_base = runtime.review_merge_base
+    runtime.snapshot.worktrees[index].review_loading = false
+    runtime.snapshot.worktrees[index].review_error = ""
+    runtime.snapshot.task_session_id = ""
+    runtime.phase = 0
+    changed(runtime)
+}
+
+def private fail_review(var runtime : RepositoryRuntime?; message : string) {
+    record_git_failure(runtime, message)
+    let index = runtime.review_worktree_index
+    if (index >= 0 && index < length(runtime.snapshot.worktrees)) {
+        runtime.snapshot.worktrees[index].review_loading = false
+        runtime.snapshot.worktrees[index].review_error = message
+    }
+    runtime.pending_review_commits |> clear()
+    runtime.pending_review_files |> clear()
+    runtime.snapshot.task_session_id = ""
+    runtime.phase = 0
+    changed(runtime)
+}
+
+def private fail_history(var runtime : RepositoryRuntime?; message : string) {
+    record_git_failure(runtime, message)
+    let index = runtime.history_worktree_index
+    if (index >= 0 && index < length(runtime.snapshot.worktrees)) {
+        if (runtime.phase == 9) {
+            runtime.snapshot.worktrees[index].refs_loading = false
+            runtime.snapshot.worktrees[index].refs_error = message
+        } else {
+            runtime.snapshot.worktrees[index].history_loading = false
+            runtime.snapshot.worktrees[index].history_error = message
+        }
+    }
+    runtime.pending_history_commits |> clear()
+    runtime.pending_commit_files |> clear()
+    runtime.pending_refs |> clear()
+    runtime.snapshot.task_session_id = ""
+    runtime.phase = 0
+    changed(runtime)
+}
+
 def private finish_refresh(var runtime : RepositoryRuntime?) {
     runtime.phase = 0
     runtime.snapshot.refreshing = false
@@ -625,9 +1224,11 @@ def private finish_refresh(var runtime : RepositoryRuntime?) {
 }
 
 def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
+    record_git_failure(runtime, message)
     runtime.phase = 0
     runtime.snapshot.refreshing = false
     runtime.snapshot.error = message
+    runtime.snapshot.task_session_id = ""
     changed(runtime)
     if (runtime.rerun_pending) {
         runtime.rerun_pending = false
@@ -635,9 +1236,126 @@ def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
     }
 }
 
+def public repository_parse_review_commits(text : string; worktree_path : string;
+                                           var commits : array<GitCommitState>) {
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (empty(line)) continue
+        let delimiter = find(line, GIT_FIELD_SEPARATOR) >= 0 ? GIT_FIELD_SEPARATOR : "\t"
+        let delimiter_length = length(delimiter)
+        let hash_end = find(line, delimiter)
+        if (hash_end < 0) continue
+        let short_end = find(line, delimiter, hash_end + delimiter_length)
+        if (short_end < 0) continue
+        let time_end = find(line, delimiter, short_end + delimiter_length)
+        if (time_end < 0) continue
+        let author_end = find(line, delimiter, time_end + delimiter_length)
+        if (author_end < 0) continue
+        commits |> push(GitCommitState(
+            worktree_path = worktree_path,
+            hash = slice(line, 0, hash_end),
+            short_hash = slice(line, hash_end + delimiter_length, short_end),
+            authored_at = to_int64(slice(line, short_end + delimiter_length, time_end)),
+            author = slice(line, time_end + delimiter_length, author_end),
+            subject = slice(line, author_end + delimiter_length)))
+    }
+}
+
+def public repository_parse_review_files(text : string; worktree_path : string;
+                                         var files : array<GitReviewFileState>) {
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (empty(line)) continue
+        let delimiter = find(line, GIT_FIELD_SEPARATOR) >= 0 ? GIT_FIELD_SEPARATOR : "\t"
+        let fields = split(line, delimiter)
+        if (length(fields) < 2) continue
+        let code = fields[0]
+        var path = fields[1]
+        var old_path : string
+        if ((starts_with(code, "R") || starts_with(code, "C"))
+                && length(fields) >= 3) {
+            old_path = path
+            path = fields[2]
+        }
+        files |> push(GitReviewFileState(
+            worktree_path = worktree_path, code = code,
+            path = path, old_path = old_path))
+    }
+}
+
+def public repository_parse_commit_files(text : string; worktree_path : string;
+                                         commit_hash : string;
+                                         var files : array<GitCommitFileState>) {
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (empty(line)) continue
+        let fields = split(line, "\t")
+        if (length(fields) < 2) continue
+        let code = fields[0]
+        var path = fields[1]
+        var old_path : string
+        if ((starts_with(code, "R") || starts_with(code, "C"))
+                && length(fields) >= 3) {
+            old_path = path
+            path = fields[2]
+        }
+        files |> push(GitCommitFileState(
+            worktree_path = worktree_path, commit_hash = commit_hash,
+            code = code, path = path, old_path = old_path))
+    }
+}
+
+def private repository_parse_review_file_names(text : string;
+                                               worktree_path : string;
+                                               var files : array<GitReviewFileState>) {
+    for (raw_line in split(text, "\n")) {
+        let path = trim_cr(raw_line)
+        if (empty(path)) continue
+        files |> push(GitReviewFileState(
+            worktree_path = worktree_path, code = "", path = path))
+    }
+}
+
+def private repository_parse_commit_file_names(text : string;
+                                               worktree_path : string;
+                                               commit_hash : string;
+                                               var files : array<GitCommitFileState>) {
+    for (raw_line in split(text, "\n")) {
+        let path = trim_cr(raw_line)
+        if (empty(path)) continue
+        files |> push(GitCommitFileState(
+            worktree_path = worktree_path, commit_hash = commit_hash,
+            code = "", path = path))
+    }
+}
+
+def public repository_parse_refs(text : string; worktree_path : string;
+                                 var refs : array<GitRefState>) {
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (empty(line)) continue
+        let delimiter = find(line, GIT_FIELD_SEPARATOR) >= 0 ? GIT_FIELD_SEPARATOR : "\t"
+        let fields = split(line, delimiter)
+        if (length(fields) < 4
+                || (length(fields) >= 5 && !empty(fields[4]))) continue
+        let full_name = fields[0]
+        refs |> push(GitRefState(
+            worktree_path = worktree_path,
+            full_name = full_name,
+            name = fields[1],
+            hash = fields[2],
+            current = strip(fields[3]) == "*",
+            remote = starts_with(full_name, "refs/remotes/")))
+    }
+}
+
 def private advance_repository(var runtime : RepositoryRuntime?) {
     if (runtime.phase == 0) {
         if (runtime.refresh_pending) launch_inventory(runtime)
+        elif (!empty(runtime.review_pending_path)) launch_review_upstream(runtime)
+        elif (!empty(runtime.refs_pending_path)) launch_refs(runtime)
+        elif (!empty(runtime.history_pending_path)) launch_history(runtime)
+        elif (!empty(runtime.commit_pending_path)) launch_commit_files(runtime)
         return
     }
     var info = WatcherSessionInfo()
@@ -646,12 +1364,26 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
     let output = watcher_terminal_text(runtime.snapshot.task_session_id, scrollback_rows)
     if (scrollback_rows > 0) {
         let _compacted_overflow = watcher_compact_session(runtime.snapshot.task_session_id)
-        fail_refresh(runtime, "Git structured output exceeded the {GIT_CAPTURE_ROWS}-row capture window; inspect session {runtime.snapshot.task_session_id}")
+        let message = "Git structured output exceeded the {GIT_CAPTURE_ROWS}-row capture window; inspect session {runtime.snapshot.task_session_id}"
+        if (runtime.phase >= 7) fail_history(runtime, message)
+        elif (runtime.phase >= 3) fail_review(runtime, message)
+        else fail_refresh(runtime, message)
         return
     }
     let _compacted = watcher_compact_session(runtime.snapshot.task_session_id)
     if (info.exit_code != 0l) {
-        fail_refresh(runtime, "git exited with {info.exit_code}: {output}")
+        if (runtime.phase == 4 && runtime.review_base_ref == "origin/master"
+                && !runtime.review_tried_origin_main) {
+            runtime.review_base_ref = "origin/main"
+            runtime.review_tried_origin_main = true
+            launch_review_merge_base(runtime)
+        } elif (runtime.phase >= 7) {
+            fail_history(runtime, "git exited with {info.exit_code}: {output}")
+        } elif (runtime.phase >= 3) {
+            fail_review(runtime, "git exited with {info.exit_code}: {output}")
+        } else {
+            fail_refresh(runtime, "git exited with {info.exit_code}: {output}")
+        }
         return
     }
     if (runtime.phase == 1) {
@@ -669,6 +1401,22 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
             fail_refresh(runtime,
                 "main checkout is already registered: {main_path}")
             return
+        }
+        for (new_worktree in worktrees) {
+            for (old_worktree in runtime.snapshot.worktrees) {
+                if (old_worktree.path != new_worktree.path) continue
+                new_worktree.review_base_ref = old_worktree.review_base_ref
+                new_worktree.review_merge_base = old_worktree.review_merge_base
+                new_worktree.review_loading = old_worktree.review_loading
+                new_worktree.review_error = old_worktree.review_error
+                new_worktree.history_ref = old_worktree.history_ref
+                new_worktree.history_commit = old_worktree.history_commit
+                new_worktree.history_loading = old_worktree.history_loading
+                new_worktree.history_error = old_worktree.history_error
+                new_worktree.refs_loading = old_worktree.refs_loading
+                new_worktree.refs_error = old_worktree.refs_error
+                break
+            }
         }
         delete runtime.snapshot.worktrees
         runtime.snapshot.worktrees <- worktrees
@@ -688,13 +1436,57 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
         changed(runtime)
         return
     }
-    repository_parse_status(output, runtime.snapshot.worktrees[runtime.worktree_index], runtime.snapshot.files)
-    runtime.worktree_index++
-    if (runtime.worktree_index < length(runtime.snapshot.worktrees)) {
-        let _next_status_started = launch_status(runtime)
-        changed(runtime)
+    if (runtime.phase == 2) {
+        repository_parse_status(output, runtime.snapshot.worktrees[runtime.worktree_index], runtime.snapshot.files)
+        runtime.worktree_index++
+        if (runtime.worktree_index < length(runtime.snapshot.worktrees)) {
+            let _next_status_started = launch_status(runtime)
+            changed(runtime)
+        } else {
+            finish_refresh(runtime)
+        }
+        return
+    }
+    if (runtime.phase == 3) {
+        runtime.review_base_ref = strip(output)
+        if (empty(runtime.review_base_ref)) {
+            if (!empty(runtime.snapshot.record.base_ref)) {
+                runtime.review_base_ref = runtime.snapshot.record.base_ref
+            } else {
+                runtime.review_base_ref = "origin/master"
+            }
+        }
+        launch_review_merge_base(runtime)
+        return
+    }
+    if (runtime.phase == 4) {
+        runtime.review_merge_base = strip(output)
+        if (empty(runtime.review_merge_base)) {
+            fail_review(runtime, "git returned no merge base for {runtime.review_base_ref}")
+        } else {
+            launch_review_commits(runtime)
+        }
+        return
+    }
+    let active_index = runtime.phase >= 7 ? runtime.history_worktree_index : runtime.review_worktree_index
+    let path = runtime.snapshot.worktrees[active_index].path
+    if (runtime.phase == 5) {
+        repository_parse_review_commits(output, path, runtime.pending_review_commits)
+        launch_review_files(runtime)
+    } elif (runtime.phase == 6) {
+        repository_parse_review_file_names(
+            output, path, runtime.pending_review_files)
+        finish_review(runtime)
+    } elif (runtime.phase == 7) {
+        repository_parse_review_commits(output, path, runtime.pending_history_commits)
+        finish_history_commits(runtime)
+    } elif (runtime.phase == 8) {
+        repository_parse_commit_file_names(
+            output, path, runtime.history_commit, runtime.pending_commit_files)
+        finish_commit_files(runtime)
     } else {
-        finish_refresh(runtime)
+        repository_parse_refs(output, path, runtime.pending_refs)
+        finish_refs(runtime)
     }
 }
 

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1572,7 +1572,6 @@ def public repository_apply_working_numstat(text : string; worktree_path : strin
     for (raw_line in split(text, "\n")) {
         var parsed = GitNumstatLine()
         if (!parse_numstat_line(trim_cr(raw_line), parsed)) continue
-        if (!key_exists(file_by_path, parsed.path)) continue
         let file_index = file_by_path?[parsed.path] ?? -1
         if (file_index < 0) continue
         files[file_index].added_lines = parsed.added_lines

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -18,6 +18,7 @@ let private GIT_TIMEOUT_MS = 15000l
 let private GIT_CAPTURE_COLUMNS = 240
 let private GIT_CAPTURE_ROWS = 512
 let private GIT_FIELD_SEPARATOR = "<|dasHerd-field|>"
+let private UNTRACKED_NUMSTAT_MAX_BYTES = 32 * 1024 * 1024
 
 struct public RepositoryRecord {
     id : string
@@ -32,6 +33,10 @@ struct public GitFileState {
     code : string
     path : string
     old_path : string
+    added_lines : int
+    deleted_lines : int
+    stats_known : bool
+    binary : bool
 }
 
 struct public GitCommitState {
@@ -41,6 +46,7 @@ struct public GitCommitState {
     authored_at : int64
     author : string
     subject : string
+    parents : string
 }
 
 struct public GitReviewFileState {
@@ -48,6 +54,10 @@ struct public GitReviewFileState {
     code : string
     path : string
     old_path : string
+    added_lines : int
+    deleted_lines : int
+    stats_known : bool
+    binary : bool
 }
 
 struct public GitRefState {
@@ -65,6 +75,10 @@ struct public GitCommitFileState {
     code : string
     path : string
     old_path : string
+    added_lines : int
+    deleted_lines : int
+    stats_known : bool
+    binary : bool
 }
 
 struct public WorktreeState {
@@ -634,7 +648,7 @@ def public repository_history(repository_id : string; worktree_path : string;
     if (empty(resolved_ref)) {
         resolved_ref = runtime.snapshot.worktrees[worktree_index].branch
     }
-    var allowed = resolved_ref == runtime.snapshot.worktrees[worktree_index].branch
+    var allowed = resolved_ref == "__all__" || resolved_ref == runtime.snapshot.worktrees[worktree_index].branch
     for (ref in runtime.snapshot.refs) {
         if (ref.worktree_path == worktree_path && ref.name == resolved_ref) {
             allowed = true
@@ -928,11 +942,20 @@ def public repository_parse_status(text : string; var worktree : WorktreeState;
 
 def private launch_status(var runtime : RepositoryRuntime?) : bool {
     if (runtime.worktree_index >= length(runtime.snapshot.worktrees)) return false
+    runtime.phase = 2
     let path = runtime.snapshot.worktrees[runtime.worktree_index].path
     runtime.snapshot.record.checkout_path = runtime.snapshot.worktrees[0].path
     return launch_git(runtime, ["git", "-C", path, "-c", "core.quotePath=false",
         "status", "--porcelain=1", "--branch", "--untracked-files=all"],
         "git-status", path)
+}
+
+def private launch_working_stats(var runtime : RepositoryRuntime?) {
+    let path = runtime.snapshot.worktrees[runtime.worktree_index].path
+    runtime.phase = 10
+    let _ = launch_git(runtime, ["git", "--literal-pathspecs", "-C", path,
+        "--no-pager", "diff", "--numstat", "--find-renames", "--"],
+        "git-working-numstat", path)
 }
 
 def private launch_review_upstream(var runtime : RepositoryRuntime?) {
@@ -971,7 +994,7 @@ def private launch_review_commits(var runtime : RepositoryRuntime?) {
     runtime.phase = 5
     let revision_range = "{runtime.review_merge_base}..HEAD"
     let _ = launch_git(runtime, ["git", "-C", path, "--no-pager", "log",
-        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s", revision_range],
+        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s{GIT_FIELD_SEPARATOR}%P", revision_range],
         "git-review-commits", path)
 }
 
@@ -979,7 +1002,7 @@ def private launch_review_files(var runtime : RepositoryRuntime?) {
     let path = runtime.snapshot.worktrees[runtime.review_worktree_index].path
     runtime.phase = 6
     let _ = launch_git(runtime, ["git", "--literal-pathspecs", "-C", path,
-        "--no-pager", "diff", "--cached", "--name-only", "--find-renames",
+        "--no-pager", "diff", "--cached", "--numstat", "--find-renames",
         runtime.review_merge_base, "--"], "git-review-files", path)
 }
 
@@ -1001,9 +1024,10 @@ def private launch_history(var runtime : RepositoryRuntime?) {
     runtime.phase = 7
     changed(runtime)
     let path = runtime.snapshot.worktrees[index].path
-    let _ = launch_git(runtime, ["git", "-C", path, "--no-pager", "log",
-        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s",
-        runtime.history_ref], "git-history", path)
+    var inscope argv <- ["git", "-C", path, "--no-pager", "log",
+        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s{GIT_FIELD_SEPARATOR}%P"]
+    argv |> push(runtime.history_ref == "__all__" ? "--all" : runtime.history_ref)
+    let _ = launch_git(runtime, argv, "git-history", path)
 }
 
 def private launch_commit_files(var runtime : RepositoryRuntime?;
@@ -1026,7 +1050,7 @@ def private launch_commit_files(var runtime : RepositoryRuntime?;
     runtime.phase = 8
     changed(runtime)
     let _ = launch_git(runtime, ["git", "--literal-pathspecs", "-C", requested_path,
-        "--no-pager", "show", "--format=", "--name-only", "--find-renames",
+        "--no-pager", "show", "--format=", "--numstat", "--find-renames",
         "--first-parent", requested_hash, "--"], "git-commit-files", requested_path)
 }
 
@@ -1251,13 +1275,139 @@ def public repository_parse_review_commits(text : string; worktree_path : string
         if (time_end < 0) continue
         let author_end = find(line, delimiter, time_end + delimiter_length)
         if (author_end < 0) continue
+        let subject_end = delimiter == GIT_FIELD_SEPARATOR ? find(line, delimiter, author_end + delimiter_length) : -1
+        var subject = slice(line, author_end + delimiter_length)
+        var parents : string
+        if (subject_end >= 0) {
+            subject = slice(line, author_end + delimiter_length, subject_end)
+            parents = slice(line, subject_end + delimiter_length)
+        }
         commits |> push(GitCommitState(
             worktree_path = worktree_path,
             hash = slice(line, 0, hash_end),
             short_hash = slice(line, hash_end + delimiter_length, short_end),
             authored_at = to_int64(slice(line, short_end + delimiter_length, time_end)),
             author = slice(line, time_end + delimiter_length, author_end),
-            subject = slice(line, author_end + delimiter_length)))
+            subject = subject,
+            parents = parents))
+    }
+}
+
+struct private GitNumstatLine {
+    path : string
+    added_lines : int
+    deleted_lines : int
+    known : bool
+    binary : bool
+}
+
+def private numstat_token_end(line : string; start : int) : int {
+    var result = start
+    let line_length = length(line)
+    while (result < line_length && !is_white_space(byte_at(line, result))) {
+        result++
+    }
+    return result
+}
+
+def private numstat_skip_space(line : string; start : int) : int {
+    var result = start
+    let line_length = length(line)
+    while (result < line_length && is_white_space(byte_at(line, result))) {
+        result++
+    }
+    return result
+}
+
+def private numstat_count_token(token : string) : bool {
+    if (token == "-") return true
+    if (empty(token)) return false
+    for (index in range(length(token))) {
+        if (!is_number(byte_at(token, index))) return false
+    }
+    return true
+}
+
+def private expanded_numstat_path(path : string) : string {
+    let arrow = find(path, " => ")
+    var tail_text : string // nolint:LINT003 daScript loses let lifetime after the early-return guard
+    var end_pos : int // nolint:LINT003 daScript loses let lifetime after the early-return guard
+    if (arrow < 0) {
+        return path
+    }
+    let brace_start = find(path, "{")
+    tail_text = slice(path, arrow + 4)
+    end_pos = find(tail_text, "}")
+    if (brace_start >= 0 && end_pos >= 0) {
+        return "{slice(path, 0, brace_start)}{slice(tail_text, 0, end_pos)}{slice(tail_text, end_pos + 1)}"
+    }
+    return slice(path, arrow + 4)
+}
+
+def private parse_numstat_line(line : string; var result : GitNumstatLine&) : bool {
+    let added_end = numstat_token_end(line, 0)
+    let deleted_start = numstat_skip_space(line, added_end)
+    let deleted_end = numstat_token_end(line, deleted_start)
+    let path_start = numstat_skip_space(line, deleted_end)
+    if (added_end == 0 || deleted_start >= deleted_end || path_start >= length(line)) return false
+    let added = slice(line, 0, added_end)
+    let deleted = slice(line, deleted_start, deleted_end)
+    if (!numstat_count_token(added) || !numstat_count_token(deleted)) return false
+    result.path = expanded_numstat_path(slice(line, path_start))
+    result.binary = added == "-" || deleted == "-"
+    result.known = !result.binary
+    result.added_lines = result.known ? to_int(added) : 0
+    result.deleted_lines = result.known ? to_int(deleted) : 0
+    return true
+}
+
+def private count_untracked_lines(worktree_path, relative_path : string;
+                                  var added_lines : int&; var binary : bool&) : bool {
+    let full_path = path_join(worktree_path, relative_path)
+    let file_status = stat(full_path)
+    if (!file_status.is_valid || !file_status.is_reg
+            || file_status.size > uint64(UNTRACKED_NUMSTAT_MAX_BYTES)) return false
+    var loaded = false
+    fopen(full_path, "rb") $(file) {
+        if (file != null) {
+            fmap(file) $(var data : array<uint8>#) {
+                added_lines = 0
+                binary = false
+                for (raw_byte in data) {
+                    let byte = int(raw_byte)
+                    if (byte == 0) {
+                        binary = true
+                        break
+                    }
+                    if (byte == '\n') added_lines++
+                }
+                if (!binary && !empty(data) && data[length(data) - 1] != uint8('\n')) added_lines++
+                loaded = true
+            }
+        }
+    }
+    return loaded
+}
+
+def public repository_apply_working_numstat(text : string; worktree_path : string;
+                                            var files : array<GitFileState>) {
+    for (raw_line in split(text, "\n")) {
+        var parsed = GitNumstatLine()
+        if (!parse_numstat_line(trim_cr(raw_line), parsed)) continue
+        for (file in files) {
+            if (file.worktree_path == worktree_path && file.path == parsed.path) {
+                file.added_lines = parsed.added_lines
+                file.deleted_lines = parsed.deleted_lines
+                file.stats_known = parsed.known
+                file.binary = parsed.binary
+                break
+            }
+        }
+    }
+    for (file in files) {
+        if (file.worktree_path != worktree_path || file.code != "??") continue
+        file.stats_known = count_untracked_lines(worktree_path, file.path,
+            file.added_lines, file.binary) && !file.binary
     }
 }
 
@@ -1266,6 +1416,15 @@ def public repository_parse_review_files(text : string; worktree_path : string;
     for (raw_line in split(text, "\n")) {
         let line = trim_cr(raw_line)
         if (empty(line)) continue
+        var numstat = GitNumstatLine()
+        if (parse_numstat_line(line, numstat)) {
+            files |> push(GitReviewFileState(
+                worktree_path = worktree_path, path = numstat.path,
+                added_lines = numstat.added_lines,
+                deleted_lines = numstat.deleted_lines,
+                stats_known = numstat.known, binary = numstat.binary))
+            continue
+        }
         let delimiter = find(line, GIT_FIELD_SEPARATOR) >= 0 ? GIT_FIELD_SEPARATOR : "\t"
         let fields = split(line, delimiter)
         if (length(fields) < 2) continue
@@ -1289,6 +1448,15 @@ def public repository_parse_commit_files(text : string; worktree_path : string;
     for (raw_line in split(text, "\n")) {
         let line = trim_cr(raw_line)
         if (empty(line)) continue
+        var numstat = GitNumstatLine()
+        if (parse_numstat_line(line, numstat)) {
+            files |> push(GitCommitFileState(
+                worktree_path = worktree_path, commit_hash = commit_hash,
+                path = numstat.path, added_lines = numstat.added_lines,
+                deleted_lines = numstat.deleted_lines,
+                stats_known = numstat.known, binary = numstat.binary))
+            continue
+        }
         let fields = split(line, "\t")
         if (length(fields) < 2) continue
         let code = fields[0]
@@ -1302,30 +1470,6 @@ def public repository_parse_commit_files(text : string; worktree_path : string;
         files |> push(GitCommitFileState(
             worktree_path = worktree_path, commit_hash = commit_hash,
             code = code, path = path, old_path = old_path))
-    }
-}
-
-def private repository_parse_review_file_names(text : string;
-                                               worktree_path : string;
-                                               var files : array<GitReviewFileState>) {
-    for (raw_line in split(text, "\n")) {
-        let path = trim_cr(raw_line)
-        if (empty(path)) continue
-        files |> push(GitReviewFileState(
-            worktree_path = worktree_path, code = "", path = path))
-    }
-}
-
-def private repository_parse_commit_file_names(text : string;
-                                               worktree_path : string;
-                                               commit_hash : string;
-                                               var files : array<GitCommitFileState>) {
-    for (raw_line in split(text, "\n")) {
-        let path = trim_cr(raw_line)
-        if (empty(path)) continue
-        files |> push(GitCommitFileState(
-            worktree_path = worktree_path, commit_hash = commit_hash,
-            code = "", path = path))
     }
 }
 
@@ -1365,7 +1509,8 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
     if (scrollback_rows > 0) {
         let _compacted_overflow = watcher_compact_session(runtime.snapshot.task_session_id)
         let message = "Git structured output exceeded the {GIT_CAPTURE_ROWS}-row capture window; inspect session {runtime.snapshot.task_session_id}"
-        if (runtime.phase >= 7) fail_history(runtime, message)
+        if (runtime.phase == 10) fail_refresh(runtime, message)
+        elif (runtime.phase >= 7) fail_history(runtime, message)
         elif (runtime.phase >= 3) fail_review(runtime, message)
         else fail_refresh(runtime, message)
         return
@@ -1377,6 +1522,8 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
             runtime.review_base_ref = "origin/main"
             runtime.review_tried_origin_main = true
             launch_review_merge_base(runtime)
+        } elif (runtime.phase == 10) {
+            fail_refresh(runtime, "git exited with {info.exit_code}: {output}")
         } elif (runtime.phase >= 7) {
             fail_history(runtime, "git exited with {info.exit_code}: {output}")
         } elif (runtime.phase >= 3) {
@@ -1438,6 +1585,12 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
     }
     if (runtime.phase == 2) {
         repository_parse_status(output, runtime.snapshot.worktrees[runtime.worktree_index], runtime.snapshot.files)
+        launch_working_stats(runtime)
+        return
+    }
+    if (runtime.phase == 10) {
+        let stats_path = runtime.snapshot.worktrees[runtime.worktree_index].path
+        repository_apply_working_numstat(output, stats_path, runtime.snapshot.files)
         runtime.worktree_index++
         if (runtime.worktree_index < length(runtime.snapshot.worktrees)) {
             let _next_status_started = launch_status(runtime)
@@ -1474,14 +1627,14 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
         repository_parse_review_commits(output, path, runtime.pending_review_commits)
         launch_review_files(runtime)
     } elif (runtime.phase == 6) {
-        repository_parse_review_file_names(
+        repository_parse_review_files(
             output, path, runtime.pending_review_files)
         finish_review(runtime)
     } elif (runtime.phase == 7) {
         repository_parse_review_commits(output, path, runtime.pending_history_commits)
         finish_history_commits(runtime)
     } elif (runtime.phase == 8) {
-        repository_parse_commit_file_names(
+        repository_parse_commit_files(
             output, path, runtime.history_commit, runtime.pending_commit_files)
         finish_commit_files(runtime)
     } else {

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -522,6 +522,9 @@ def public repository_file_diff_argv(repository_id : string;
                                      revision : string = "") : string {
     delete argv
     expected_exit_code = 0l
+    if (comparison == "commit" && empty(revision)) {
+        return "commit revision is required"
+    }
     let repository_index = find_repository(repository_id)
     if (repository_index < 0 || g_repositories[repository_index] == null) {
         return "unknown repository"

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1165,8 +1165,8 @@ def private observed_worktree_path(worktrees : array<WorktreeState> const;
 }
 
 def public repository_prune_removed_worktree_data(
-        var snapshot : RepositorySnapshot;
-        worktrees : array<WorktreeState> const) {
+                                                  var snapshot : RepositorySnapshot;
+                                                  worktrees : array<WorktreeState> const) {
     var index = 0
     while (index < length(snapshot.files)) {
         if (!observed_worktree_path(worktrees,

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -15,9 +15,13 @@ require strings public
 
 let private REPOSITORY_CONFIG_VERSION = 1
 let private GIT_TIMEOUT_MS = 15000l
-let private GIT_CAPTURE_COLUMNS = 240
+// Keep structured records on one ConPTY row. The current wire format carries
+// full hashes, author, subject, and parents; 240 columns wrapped ordinary
+// commit metadata into cursor-positioned screen fragments.
+let private GIT_CAPTURE_COLUMNS = 400
 let private GIT_CAPTURE_ROWS = 512
 let private GIT_FIELD_SEPARATOR = "<|dasHerd-field|>"
+let private GIT_COMMIT_MARKER = "<|dasHerd-commit|>"
 let private UNTRACKED_NUMSTAT_MAX_BYTES = 32 * 1024 * 1024
 
 struct public RepositoryRecord {
@@ -49,6 +53,12 @@ struct public GitCommitState {
     parents : string
 }
 
+struct public GitGraphRowState {
+    worktree_path : string
+    topology : string
+    commit_hash : string
+}
+
 struct public GitReviewFileState {
     worktree_path : string
     code : string
@@ -67,6 +77,7 @@ struct public GitRefState {
     hash : string
     current : bool
     remote : bool
+    upstream : string
 }
 
 struct public GitCommitFileState {
@@ -116,6 +127,7 @@ struct public RepositorySnapshot {
     review_commits : array<GitCommitState>
     review_files : array<GitReviewFileState>
     history_commits : array<GitCommitState>
+    graph_rows : array<GitGraphRowState>
     commit_files : array<GitCommitFileState>
     refs : array<GitRefState>
     refreshing : bool
@@ -165,6 +177,7 @@ class private RepositoryRuntime {
     history_ref : string
     history_commit : string
     pending_history_commits : array<GitCommitState>
+    pending_graph_rows : array<GitGraphRowState>
     pending_commit_files : array<GitCommitFileState>
     pending_refs : array<GitRefState>
     def operator delete {
@@ -173,11 +186,13 @@ class private RepositoryRuntime {
         delete snapshot.review_commits
         delete snapshot.review_files
         delete snapshot.history_commits
+        delete snapshot.graph_rows
         delete snapshot.commit_files
         delete snapshot.refs
         delete pending_review_commits
         delete pending_review_files
         delete pending_history_commits
+        delete pending_graph_rows
         delete pending_commit_files
         delete pending_refs
     }
@@ -1018,6 +1033,7 @@ def private launch_history(var runtime : RepositoryRuntime?) {
     runtime.history_pending_path = ""
     runtime.history_pending_ref = ""
     runtime.pending_history_commits |> clear()
+    runtime.pending_graph_rows |> clear()
     runtime.pending_commit_files |> clear()
     runtime.snapshot.worktrees[index].history_loading = true
     runtime.snapshot.worktrees[index].history_error = ""
@@ -1025,7 +1041,15 @@ def private launch_history(var runtime : RepositoryRuntime?) {
     changed(runtime)
     let path = runtime.snapshot.worktrees[index].path
     var inscope argv <- ["git", "-C", path, "--no-pager", "log",
-        "--max-count=200", "--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s{GIT_FIELD_SEPARATOR}%P"]
+        "--max-count=200"]
+    if (runtime.history_ref == "__all__") {
+        argv |> push("--graph")
+        argv |> push("--topo-order")
+        argv |> push("--full-history")
+        argv |> push("--format={GIT_COMMIT_MARKER}%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s{GIT_FIELD_SEPARATOR}%P")
+    } else {
+        argv |> push("--format=%H{GIT_FIELD_SEPARATOR}%h{GIT_FIELD_SEPARATOR}%at{GIT_FIELD_SEPARATOR}%an{GIT_FIELD_SEPARATOR}%s{GIT_FIELD_SEPARATOR}%P")
+    }
     argv |> push(runtime.history_ref == "__all__" ? "--all" : runtime.history_ref)
     let _ = launch_git(runtime, argv, "git-history", path)
 }
@@ -1069,7 +1093,7 @@ def private launch_refs(var runtime : RepositoryRuntime?) {
     runtime.phase = 9
     changed(runtime)
     let _ = launch_git(runtime, ["git", "-C", path, "for-each-ref",
-        "--format=%(refname){GIT_FIELD_SEPARATOR}%(refname:short){GIT_FIELD_SEPARATOR}%(objectname){GIT_FIELD_SEPARATOR}%(HEAD){GIT_FIELD_SEPARATOR}%(symref)",
+        "--format=%(refname){GIT_FIELD_SEPARATOR}%(refname:short){GIT_FIELD_SEPARATOR}%(objectname){GIT_FIELD_SEPARATOR}%(HEAD){GIT_FIELD_SEPARATOR}%(symref){GIT_FIELD_SEPARATOR}%(upstream:short)",
         "refs/heads", "refs/remotes"], "git-refs", path)
 }
 
@@ -1086,6 +1110,14 @@ def private erase_history_content(var runtime : RepositoryRuntime?; path : strin
     while (index < length(runtime.snapshot.commit_files)) {
         if (runtime.snapshot.commit_files[index].worktree_path == path) {
             runtime.snapshot.commit_files |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(runtime.snapshot.graph_rows)) {
+        if (runtime.snapshot.graph_rows[index].worktree_path == path) {
+            runtime.snapshot.graph_rows |> erase(index)
         } else {
             index++
         }
@@ -1109,6 +1141,8 @@ def private finish_history_commits(var runtime : RepositoryRuntime?) {
     erase_history_content(runtime, path)
     runtime.snapshot.history_commits |> push_from(runtime.pending_history_commits)
     runtime.pending_history_commits |> clear()
+    runtime.snapshot.graph_rows |> push_from(runtime.pending_graph_rows)
+    runtime.pending_graph_rows |> clear()
     runtime.snapshot.worktrees[index].history_ref = runtime.history_ref
     if (!empty(runtime.snapshot.history_commits)) {
         var first_hash = ""
@@ -1228,6 +1262,7 @@ def private fail_history(var runtime : RepositoryRuntime?; message : string) {
         }
     }
     runtime.pending_history_commits |> clear()
+    runtime.pending_graph_rows |> clear()
     runtime.pending_commit_files |> clear()
     runtime.pending_refs |> clear()
     runtime.snapshot.task_session_id = ""
@@ -1260,36 +1295,70 @@ def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
     }
 }
 
+def private repository_parse_commit_line(line, worktree_path : string;
+                                         var commit : GitCommitState&) : bool {
+    let delimiter = find(line, GIT_FIELD_SEPARATOR) >= 0 ? GIT_FIELD_SEPARATOR : "\t"
+    let delimiter_length = length(delimiter)
+    let hash_end = find(line, delimiter)
+    if (hash_end < 0) return false
+    let short_end = find(line, delimiter, hash_end + delimiter_length)
+    if (short_end < 0) return false
+    let time_end = find(line, delimiter, short_end + delimiter_length)
+    if (time_end < 0) return false
+    let author_end = find(line, delimiter, time_end + delimiter_length)
+    if (author_end < 0) return false
+    let subject_end = delimiter == GIT_FIELD_SEPARATOR ? rfind(line, delimiter) : -1
+    var subject = slice(line, author_end + delimiter_length)
+    var parents : string
+    if (subject_end >= 0) {
+        subject = slice(line, author_end + delimiter_length, subject_end)
+        parents = slice(line, subject_end + delimiter_length)
+    }
+    commit = GitCommitState(
+        worktree_path = worktree_path,
+        hash = slice(line, 0, hash_end),
+        short_hash = slice(line, hash_end + delimiter_length, short_end),
+        authored_at = to_int64(slice(line, short_end + delimiter_length, time_end)),
+        author = slice(line, time_end + delimiter_length, author_end),
+        subject = subject,
+        parents = parents)
+    return true
+}
+
 def public repository_parse_review_commits(text : string; worktree_path : string;
                                            var commits : array<GitCommitState>) {
     for (raw_line in split(text, "\n")) {
         let line = trim_cr(raw_line)
         if (empty(line)) continue
-        let delimiter = find(line, GIT_FIELD_SEPARATOR) >= 0 ? GIT_FIELD_SEPARATOR : "\t"
-        let delimiter_length = length(delimiter)
-        let hash_end = find(line, delimiter)
-        if (hash_end < 0) continue
-        let short_end = find(line, delimiter, hash_end + delimiter_length)
-        if (short_end < 0) continue
-        let time_end = find(line, delimiter, short_end + delimiter_length)
-        if (time_end < 0) continue
-        let author_end = find(line, delimiter, time_end + delimiter_length)
-        if (author_end < 0) continue
-        let subject_end = delimiter == GIT_FIELD_SEPARATOR ? rfind(line, delimiter) : -1
-        var subject = slice(line, author_end + delimiter_length)
-        var parents : string
-        if (subject_end >= 0) {
-            subject = slice(line, author_end + delimiter_length, subject_end)
-            parents = slice(line, subject_end + delimiter_length)
+        var commit = GitCommitState()
+        if (repository_parse_commit_line(line, worktree_path, commit)) {
+            commits |> push(commit)
         }
-        commits |> push(GitCommitState(
+    }
+}
+
+def public repository_parse_graph_history(text : string; worktree_path : string;
+                                          var commits : array<GitCommitState>;
+                                          var rows : array<GitGraphRowState>) {
+    for (raw_line in split(text, "\n")) {
+        let line = trim_cr(raw_line)
+        if (empty(line)) continue
+        let marker = find(line, GIT_COMMIT_MARKER)
+        var commit_hash : string
+        var topology = line
+        if (marker >= 0) {
+            topology = slice(line, 0, marker)
+            var commit = GitCommitState()
+            if (!repository_parse_commit_line(
+                    slice(line, marker + length(GIT_COMMIT_MARKER)),
+                    worktree_path, commit)) continue
+            commit_hash = commit.hash
+            commits |> push(commit)
+        }
+        rows |> push(GitGraphRowState(
             worktree_path = worktree_path,
-            hash = slice(line, 0, hash_end),
-            short_hash = slice(line, hash_end + delimiter_length, short_end),
-            authored_at = to_int64(slice(line, short_end + delimiter_length, time_end)),
-            author = slice(line, time_end + delimiter_length, author_end),
-            subject = subject,
-            parents = parents))
+            topology = topology,
+            commit_hash = commit_hash))
     }
 }
 
@@ -1489,7 +1558,8 @@ def public repository_parse_refs(text : string; worktree_path : string;
             name = fields[1],
             hash = fields[2],
             current = strip(fields[3]) == "*",
-            remote = starts_with(full_name, "refs/remotes/")))
+            remote = starts_with(full_name, "refs/remotes/"),
+            upstream = length(fields) >= 6 ? fields[5] : ""))
     }
 }
 
@@ -1504,11 +1574,12 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
     }
     var info = WatcherSessionInfo()
     if (!watcher_get_session_info(runtime.snapshot.task_session_id, info) || !info.drained) return
-    let scrollback_rows = 0
-    let output = watcher_terminal_text(runtime.snapshot.task_session_id, scrollback_rows)
-    if (scrollback_rows > 0) {
+    let machine_output_truncated = false
+    let output = watcher_machine_output_text(
+        runtime.snapshot.task_session_id, machine_output_truncated)
+    if (machine_output_truncated) {
         let _compacted_overflow = watcher_compact_session(runtime.snapshot.task_session_id)
-        let message = "Git structured output exceeded the {GIT_CAPTURE_ROWS}-row capture window; inspect session {runtime.snapshot.task_session_id}"
+        let message = "Git structured output exceeded the watcher raw-history limit; inspect session {runtime.snapshot.task_session_id}"
         if (runtime.phase == 10) fail_refresh(runtime, message)
         elif (runtime.phase >= 7) fail_history(runtime, message)
         elif (runtime.phase >= 3) fail_review(runtime, message)
@@ -1631,7 +1702,13 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
             output, path, runtime.pending_review_files)
         finish_review(runtime)
     } elif (runtime.phase == 7) {
-        repository_parse_review_commits(output, path, runtime.pending_history_commits)
+        if (runtime.history_ref == "__all__") {
+            repository_parse_graph_history(output, path,
+                runtime.pending_history_commits, runtime.pending_graph_rows)
+        } else {
+            repository_parse_review_commits(
+                output, path, runtime.pending_history_commits)
+        }
         finish_history_commits(runtime)
     } elif (runtime.phase == 8) {
         repository_parse_commit_files(

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1467,6 +1467,7 @@ def public repository_parse_graph_history(text : string; worktree_path : string;
 
 struct private GitNumstatLine {
     path : string
+    old_path : string
     added_lines : int
     deleted_lines : int
     known : bool
@@ -1507,13 +1508,27 @@ def private expanded_numstat_path(path : string) : string {
     if (arrow < 0) {
         return path
     }
-    let brace_start = find(path, "{")
+    let brace_start = find(path, "\{")
     tail_text = slice(path, arrow + 4)
-    end_pos = find(tail_text, "}")
+    end_pos = find(tail_text, "\}")
     if (brace_start >= 0 && end_pos >= 0) {
         return "{slice(path, 0, brace_start)}{slice(tail_text, 0, end_pos)}{slice(tail_text, end_pos + 1)}"
     }
     return slice(path, arrow + 4)
+}
+
+def private original_numstat_path(path : string) : string {
+    let arrow = find(path, " => ")
+    var tail_text : string // nolint:LINT003 daScript loses let lifetime after the early-return guard
+    var end_pos : int // nolint:LINT003 daScript loses let lifetime after the early-return guard
+    if (arrow < 0) return ""
+    let brace_start = find(path, "\{")
+    tail_text = slice(path, arrow + 4)
+    end_pos = find(tail_text, "\}")
+    if (brace_start >= 0 && end_pos >= 0) {
+        return "{slice(path, 0, brace_start)}{slice(path, brace_start + 1, arrow)}{slice(tail_text, end_pos + 1)}"
+    }
+    return slice(path, 0, arrow)
 }
 
 def private parse_numstat_line(line : string; var result : GitNumstatLine&) : bool {
@@ -1525,7 +1540,9 @@ def private parse_numstat_line(line : string; var result : GitNumstatLine&) : bo
     let added = slice(line, 0, added_end)
     let deleted = slice(line, deleted_start, deleted_end)
     if (!numstat_count_token(added) || !numstat_count_token(deleted)) return false
-    result.path = expanded_numstat_path(slice(line, path_start))
+    let raw_path = slice(line, path_start)
+    result.path = expanded_numstat_path(raw_path)
+    result.old_path = original_numstat_path(raw_path)
     result.binary = added == "-" || deleted == "-"
     result.known = !result.binary
     result.added_lines = result.known ? to_int(added) : 0
@@ -1595,6 +1612,7 @@ def public repository_parse_review_files(text : string; worktree_path : string;
         if (parse_numstat_line(line, numstat)) {
             files |> push(GitReviewFileState(
                 worktree_path = worktree_path, path = numstat.path,
+                old_path = numstat.old_path,
                 added_lines = numstat.added_lines,
                 deleted_lines = numstat.deleted_lines,
                 stats_known = numstat.known, binary = numstat.binary))
@@ -1627,7 +1645,8 @@ def public repository_parse_commit_files(text : string; worktree_path : string;
         if (parse_numstat_line(line, numstat)) {
             files |> push(GitCommitFileState(
                 worktree_path = worktree_path, commit_hash = commit_hash,
-                path = numstat.path, added_lines = numstat.added_lines,
+                path = numstat.path, old_path = numstat.old_path,
+                added_lines = numstat.added_lines,
                 deleted_lines = numstat.deleted_lines,
                 stats_known = numstat.known, binary = numstat.binary))
             continue

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1563,18 +1563,22 @@ def private count_untracked_lines(worktree_path, relative_path : string;
 
 def public repository_apply_working_numstat(text : string; worktree_path : string;
                                             var files : array<GitFileState>) {
+    var inscope file_by_path : table<string; int>
+    for (index in range(length(files))) {
+        if (files[index].worktree_path == worktree_path) {
+            file_by_path[files[index].path] = index
+        }
+    }
     for (raw_line in split(text, "\n")) {
         var parsed = GitNumstatLine()
         if (!parse_numstat_line(trim_cr(raw_line), parsed)) continue
-        for (file in files) {
-            if (file.worktree_path == worktree_path && file.path == parsed.path) {
-                file.added_lines = parsed.added_lines
-                file.deleted_lines = parsed.deleted_lines
-                file.stats_known = parsed.known
-                file.binary = parsed.binary
-                break
-            }
-        }
+        if (!key_exists(file_by_path, parsed.path)) continue
+        let file_index = file_by_path?[parsed.path] ?? -1
+        if (file_index < 0) continue
+        files[file_index].added_lines = parsed.added_lines
+        files[file_index].deleted_lines = parsed.deleted_lines
+        files[file_index].stats_known = parsed.known
+        files[file_index].binary = parsed.binary
     }
     for (file in files) {
         if (file.worktree_path != worktree_path || file.code != "??") continue

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -343,6 +343,12 @@ def public repository_refresh(id : string) : string {
     return ""
 }
 
+def public repository_phase_family(phase : int) : string {
+    if (phase == 10 || phase < 3) return "refresh"
+    if (phase >= 7) return "history"
+    return "review"
+}
+
 def public repository_build_file_diff_argv(worktree_path : string;
                                            file : GitFileState const;
                                            comparison : string;
@@ -389,6 +395,18 @@ def private record_git_failure(var runtime : RepositoryRuntime?;
     runtime.snapshot.failure_session_id = runtime.snapshot.task_session_id
     runtime.snapshot.failure_message = message
     runtime.snapshot.failure_revision++
+}
+
+def public repository_record_task_failure(repository_id, session_id,
+                                          message : string) : string {
+    let index = find_repository(repository_id)
+    if (index < 0 || g_repositories[index] == null) return "unknown repository"
+    var runtime = g_repositories[index]
+    runtime.snapshot.failure_session_id = session_id
+    runtime.snapshot.failure_message = message
+    runtime.snapshot.failure_revision++
+    changed(runtime)
+    return ""
 }
 
 def public repository_build_review_file_diff_argv(worktree_path : string;
@@ -822,10 +840,10 @@ def private launch_git(var runtime : RepositoryRuntime?; argv : array<string>;
     let result = watcher_launch(request)
     runtime.snapshot.task_session_id = result.session_id
     if (!result.ok) {
-        if (runtime.phase >= 7) {
+        let family = repository_phase_family(runtime.phase)
+        if (family == "history") {
             fail_history(runtime, result.error)
-        } elif (runtime.phase >= 3 && runtime.review_worktree_index >= 0
-                && runtime.review_worktree_index < length(runtime.snapshot.worktrees)) {
+        } elif (family == "review") {
             fail_review(runtime, result.error)
         } else {
             fail_refresh(runtime, result.error)
@@ -1135,6 +1153,88 @@ def private erase_refs(var runtime : RepositoryRuntime?; path : string) {
     }
 }
 
+def private observed_worktree_path(worktrees : array<WorktreeState> const;
+                                   path : string) : bool {
+    for (worktree in worktrees) {
+        if (worktree.path == path) return true
+    }
+    return false
+}
+
+def public repository_prune_removed_worktree_data(
+        var snapshot : RepositorySnapshot;
+        worktrees : array<WorktreeState> const) {
+    var index = 0
+    while (index < length(snapshot.files)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.files[index].worktree_path)) {
+            snapshot.files |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(snapshot.review_commits)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.review_commits[index].worktree_path)) {
+            snapshot.review_commits |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(snapshot.review_files)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.review_files[index].worktree_path)) {
+            snapshot.review_files |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(snapshot.history_commits)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.history_commits[index].worktree_path)) {
+            snapshot.history_commits |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(snapshot.graph_rows)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.graph_rows[index].worktree_path)) {
+            snapshot.graph_rows |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(snapshot.commit_files)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.commit_files[index].worktree_path)) {
+            snapshot.commit_files |> erase(index)
+        } else {
+            index++
+        }
+    }
+    index = 0
+    while (index < length(snapshot.refs)) {
+        if (!observed_worktree_path(worktrees,
+                snapshot.refs[index].worktree_path)) {
+            snapshot.refs |> erase(index)
+        } else {
+            index++
+        }
+    }
+}
+
+def private promote_pending_refresh(var runtime : RepositoryRuntime?) {
+    if (!runtime.rerun_pending) return
+    runtime.rerun_pending = false
+    runtime.refresh_pending = true
+}
+
 def private finish_history_commits(var runtime : RepositoryRuntime?) {
     let index = runtime.history_worktree_index
     let path = runtime.snapshot.worktrees[index].path
@@ -1162,6 +1262,7 @@ def private finish_history_commits(var runtime : RepositoryRuntime?) {
     runtime.snapshot.worktrees[index].history_error = ""
     runtime.snapshot.task_session_id = ""
     runtime.phase = 0
+    promote_pending_refresh(runtime)
     changed(runtime)
 }
 
@@ -1183,6 +1284,7 @@ def private finish_commit_files(var runtime : RepositoryRuntime?) {
     runtime.snapshot.worktrees[index].history_error = ""
     runtime.snapshot.task_session_id = ""
     runtime.phase = 0
+    promote_pending_refresh(runtime)
     changed(runtime)
 }
 
@@ -1196,6 +1298,7 @@ def private finish_refs(var runtime : RepositoryRuntime?) {
     runtime.snapshot.worktrees[index].refs_error = ""
     runtime.snapshot.task_session_id = ""
     runtime.phase = 0
+    promote_pending_refresh(runtime)
     changed(runtime)
 }
 
@@ -1232,6 +1335,7 @@ def private finish_review(var runtime : RepositoryRuntime?) {
     runtime.snapshot.worktrees[index].review_error = ""
     runtime.snapshot.task_session_id = ""
     runtime.phase = 0
+    promote_pending_refresh(runtime)
     changed(runtime)
 }
 
@@ -1246,6 +1350,7 @@ def private fail_review(var runtime : RepositoryRuntime?; message : string) {
     runtime.pending_review_files |> clear()
     runtime.snapshot.task_session_id = ""
     runtime.phase = 0
+    promote_pending_refresh(runtime)
     changed(runtime)
 }
 
@@ -1267,6 +1372,7 @@ def private fail_history(var runtime : RepositoryRuntime?; message : string) {
     runtime.pending_refs |> clear()
     runtime.snapshot.task_session_id = ""
     runtime.phase = 0
+    promote_pending_refresh(runtime)
     changed(runtime)
 }
 
@@ -1276,10 +1382,7 @@ def private finish_refresh(var runtime : RepositoryRuntime?) {
     runtime.snapshot.last_success_ms = int64(get_clock()) * 1000l
     runtime.snapshot.task_session_id = ""
     changed(runtime)
-    if (runtime.rerun_pending) {
-        runtime.rerun_pending = false
-        runtime.refresh_pending = true
-    }
+    promote_pending_refresh(runtime)
 }
 
 def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
@@ -1289,10 +1392,7 @@ def private fail_refresh(var runtime : RepositoryRuntime?; message : string) {
     runtime.snapshot.error = message
     runtime.snapshot.task_session_id = ""
     changed(runtime)
-    if (runtime.rerun_pending) {
-        runtime.rerun_pending = false
-        runtime.refresh_pending = true
-    }
+    promote_pending_refresh(runtime)
 }
 
 def private repository_parse_commit_line(line, worktree_path : string;
@@ -1636,6 +1736,7 @@ def private advance_repository(var runtime : RepositoryRuntime?) {
                 break
             }
         }
+        repository_prune_removed_worktree_data(runtime.snapshot, worktrees)
         delete runtime.snapshot.worktrees
         runtime.snapshot.worktrees <- worktrees
         runtime.snapshot.files |> clear()

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -1275,7 +1275,7 @@ def public repository_parse_review_commits(text : string; worktree_path : string
         if (time_end < 0) continue
         let author_end = find(line, delimiter, time_end + delimiter_length)
         if (author_end < 0) continue
-        let subject_end = delimiter == GIT_FIELD_SEPARATOR ? find(line, delimiter, author_end + delimiter_length) : -1
+        let subject_end = delimiter == GIT_FIELD_SEPARATOR ? rfind(line, delimiter) : -1
         var subject = slice(line, author_end + delimiter_length)
         var parents : string
         if (subject_end >= 0) {

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -205,6 +205,12 @@ struct private GitInspectorState {
     diff_scrollbar_rect : float4
 }
 
+struct private GitWindowStatus {
+    text : string
+    busy : bool
+    error : bool
+}
+
 var private g_terminal = Terminal()
 var private g_terminal_view = ImGuiTerminalState()
 var private g_terminal_cache = ImGuiTerminalCache()
@@ -244,6 +250,10 @@ var private WORKTREE_SEPARATOR : table<int; EmptyMarkerState>
 var private GIT_GROUP_SEPARATOR : table<int; EmptyMarkerState>
 var private GIT_GROUP_SPACING : table<int; EmptyMarkerState>
 var private GIT_HOVER_TOOLTIP : NarrativeState
+var private GIT_CHANGELIST_STATUS_TEXT : NarrativeState
+var private GIT_ACTIVITY_STATUS_TEXT : NarrativeState
+var private GIT_CHANGELIST_STATUS_SEPARATOR : EmptyMarkerState
+var private GIT_ACTIVITY_STATUS_SEPARATOR : EmptyMarkerState
 
 def private setup_default_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
@@ -1343,29 +1353,24 @@ def private draw_shared_pr_files(repository : RepositorySnapshot const;
     if (not_included > 0) {
         separator(GIT_GROUP_SEPARATOR[11])
     }
-    let included = draw_pr_included_files(
-        repository, worktree, file_row)
-    if (included == 0 && not_included == 0 && !worktree.review_loading
-            && empty(worktree.review_error)) {
-        text_disabled("Nothing to send or stage")
-    }
-    if (worktree.review_loading) text_disabled("Refreshing worktree PR...")
-    if (!empty(worktree.review_error)) {
-        text_colored(GIT_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = worktree.review_error))
-    }
+    draw_pr_included_files(repository, worktree, file_row)
 }
 
-def private draw_sha_copy_icon(hash, row_id : string) {
+def private draw_sha_copy_icon(hash, row_id : string;
+                               visible_sha : string = "") {
     let row_min = GetItemRectMin()
     let row_max = GetItemRectMax()
     let row_right = git_visible_row_right(row_max.x)
-    let hovered = IsItemHovered()
     let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
     let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
+    let icon_x = (empty(visible_sha)
+        ? row_right - icon_width
+        : row_min.x + GetStyle().FramePadding.x
+            + CalcTextSize(visible_sha).x + GetStyle().ItemSpacing.x)
+    let hovered = IsItemHovered() && (empty(visible_sha)
+        || GetMousePos().x <= icon_x + icon_width)
     if (icon_button_draw_at("##{row_id}:copy-sha", "duplicate",
-            float2(row_right - icon_width, row_min.y), icon_size, 1.0f,
+            float2(icon_x, row_min.y), icon_size, 1.0f,
             hovered)) {
         queue_sha_copy(hash)
     }
@@ -1376,28 +1381,9 @@ def private draw_sha_copy_icon(hash, row_id : string) {
 
 def private draw_pr_review(repository : RepositorySnapshot const;
                            worktree : WorktreeState const) {
-    var commit_count = 0
-    for (commit in repository.review_commits) {
-        if (commit.worktree_path == worktree.path) commit_count++
-    }
-    let base = ((!empty(worktree.review_base_ref))
-        ? worktree.review_base_ref : "detecting base...")
-    text(GIT_GROUP_TITLE[12],
-        (text = "OUTGOING COMMITS  {commit_count}   -> {base}"))
-    separator(GIT_GROUP_SEPARATOR[12])
-    if (worktree.review_loading) text_disabled("Reading outgoing commits...")
-    if (!empty(worktree.review_error)) {
-        text_colored(GIT_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = worktree.review_error))
-    }
-    if (commit_count == 0) {
-        if (!worktree.review_loading && empty(worktree.review_error)) {
-            text_disabled("No outgoing commits")
-        }
-        return
-    }
     var commit_row = 0
+    let sha_width = (CalcTextSize("000000000").x
+        + GetFrameHeightWithSpacing() + 8.0f)
     let table_flags = (ImGuiTableFlags.Resizable | ImGuiTableFlags.RowBg |
         ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.ScrollY |
         ImGuiTableFlags.SizingStretchProp)
@@ -1405,7 +1391,7 @@ def private draw_pr_review(repository : RepositorySnapshot const;
             flags = table_flags, outer_size = float2(0.0f, 0.0f),
             inner_width = 0.0f)) {
         table_setup_scroll_freeze(0, 1)
-        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, 112.0f)
+        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, sha_width)
         table_setup_column("Title", ImGuiTableColumnFlags.WidthStretch, 0.72f)
         table_setup_column("Author", ImGuiTableColumnFlags.WidthStretch, 0.28f)
         table_headers_row()
@@ -1419,7 +1405,8 @@ def private draw_pr_review(repository : RepositorySnapshot const;
                     flags = ImGuiSelectableFlags.SpanAllColumns |
                         ImGuiSelectableFlags.AllowOverlap))
             }
-            draw_sha_copy_icon(commit.hash, "pr-commit:{commit.hash}")
+            draw_sha_copy_icon(commit.hash, "pr-commit:{commit.hash}",
+                commit.short_hash)
             table_set_column_index(1)
             text_colored(GIT_COMMIT_TITLE_TEXT[commit_row],
                 (color = float4(0.91f, 0.93f, 0.96f, 1.0f),
@@ -1459,18 +1446,7 @@ def private draw_commit_files(repository : RepositorySnapshot const;
         g_requested_history_commit = ""
     }
     let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
-    var count = 0
-    for (file in repository.commit_files) {
-        if (file.worktree_path == worktree.path
-                && file.commit_hash == selected_commit) count++
-    }
-    text(GIT_GROUP_TITLE[21],
-        (text = "FILES IN {selected_commit}  {count}"))
-    separator(GIT_GROUP_SEPARATOR[21])
-    if (!empty(g_requested_history_commit)) {
-        text_disabled("Loading selected commit files...")
-        return
-    }
+    if (!empty(g_requested_history_commit)) return
     var row = 0
     for (file in repository.commit_files) {
         if (file.worktree_path != worktree.path
@@ -1499,15 +1475,10 @@ def private draw_commit_files(repository : RepositorySnapshot const;
         }
         row++
     }
-    if (count == 0 && !worktree.history_loading
-            && empty(worktree.history_error)) {
-        text_disabled("Select a commit to inspect its files")
-    }
 }
 
 def private draw_history_commits(repository : RepositorySnapshot const;
-                                 worktree : WorktreeState const;
-                                 heading : string) {
+                                 worktree : WorktreeState const) {
     var inscope commit_indices : array<int>
     commit_indices |> reserve(length(repository.history_commits))
     for (index in range(length(repository.history_commits))) {
@@ -1516,15 +1487,8 @@ def private draw_history_commits(repository : RepositorySnapshot const;
         }
     }
     let count = length(commit_indices)
-    text(GIT_GROUP_TITLE[20], (text = "{heading}  {count}"))
-    separator(GIT_GROUP_SEPARATOR[20])
-    if (worktree.history_loading) text_disabled("Reading Git history...")
-    if (!empty(worktree.history_error)) {
-        text_colored(GIT_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = worktree.history_error))
-    }
-    if (count == 0) return
+    let sha_width = (CalcTextSize("000000000").x
+        + GetFrameHeightWithSpacing() + 8.0f)
     let table_flags = (ImGuiTableFlags.Resizable | ImGuiTableFlags.RowBg |
         ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.ScrollY |
         ImGuiTableFlags.SizingStretchProp)
@@ -1532,7 +1496,7 @@ def private draw_history_commits(repository : RepositorySnapshot const;
             flags = table_flags, outer_size = float2(0.0f, 0.0f),
             inner_width = 0.0f)) {
         table_setup_scroll_freeze(0, 1)
-        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, 112.0f)
+        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, sha_width)
         table_setup_column("Title", ImGuiTableColumnFlags.WidthStretch, 0.72f)
         table_setup_column("Author", ImGuiTableColumnFlags.WidthStretch, 0.28f)
         table_headers_row()
@@ -1550,7 +1514,8 @@ def private draw_history_commits(repository : RepositorySnapshot const;
                         flags = ImGuiSelectableFlags.SpanAllColumns |
                             ImGuiSelectableFlags.AllowOverlap))
                 }
-                draw_sha_copy_icon(commit.hash, "history:{commit.hash}")
+                draw_sha_copy_icon(commit.hash, "history:{commit.hash}",
+                    commit.short_hash)
                 table_set_column_index(1)
                 text_colored(GIT_COMMIT_TITLE_TEXT[row],
                     (color = float4(0.91f, 0.93f, 0.96f, 1.0f),
@@ -1570,8 +1535,7 @@ def private draw_history_commits(repository : RepositorySnapshot const;
 def private draw_history_review(repository : RepositorySnapshot const;
                                 worktree : WorktreeState const) {
     ensure_history(repository, worktree, worktree.branch)
-    draw_history_commits(repository, worktree,
-        "COMMITS ON {worktree.history_ref}")
+    draw_history_commits(repository, worktree)
 }
 
 def private git_lane_index(lanes : array<string> const; hash : string) : int {
@@ -1762,87 +1726,203 @@ def private draw_tree_review(repository : RepositorySnapshot const;
             g_client->request_repository_refs(repository.record.id, worktree.path)
         }
     }
-    if (worktree.refs_loading) text_disabled("Reading local and remote branches...")
-    if (!empty(worktree.refs_error)) {
-        text_colored(GIT_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = worktree.refs_error))
-    }
     ensure_history(repository, worktree, "__all__")
-    draw_history_commits(repository, worktree, "COMMITS ACROSS WORKTREE REFS")
+    draw_history_commits(repository, worktree)
+}
+
+def private git_review_commit_count(repository : RepositorySnapshot const;
+                                    worktree : WorktreeState const) : int {
+    var count = 0
+    for (commit in repository.review_commits) {
+        if (commit.worktree_path == worktree.path) count++
+    }
+    return count
+}
+
+def private git_history_commit_count(repository : RepositorySnapshot const;
+                                     worktree : WorktreeState const) : int {
+    var count = 0
+    for (commit in repository.history_commits) {
+        if (commit.worktree_path == worktree.path) count++
+    }
+    return count
+}
+
+def private git_selected_commit_file_count(repository : RepositorySnapshot const;
+                                           worktree : WorktreeState const;
+                                           commit_hash : string) : int {
+    var count = 0
+    for (file in repository.commit_files) {
+        if (file.worktree_path == worktree.path
+                && file.commit_hash == commit_hash) count++
+    }
+    return count
+}
+
+def private git_activity_status(repository : RepositorySnapshot const;
+                                worktree : WorktreeState const) : GitWindowStatus {
+    if (GIT_TREE_TAB.selected) {
+        if (!empty(worktree.refs_error)) {
+            return GitWindowStatus(text = worktree.refs_error, error = true)
+        }
+        if (!empty(worktree.history_error)) {
+            return GitWindowStatus(text = worktree.history_error, error = true)
+        }
+        if (worktree.refs_loading) {
+            return GitWindowStatus(text = "Reading branches...", busy = true)
+        }
+        if (worktree.history_loading) {
+            return GitWindowStatus(text = "Reading Git history...", busy = true)
+        }
+        return GitWindowStatus(text = "COMMITS ACROSS WORKTREE REFS  {git_history_commit_count(repository, worktree)}")
+    }
+    if (GIT_HISTORY_TAB.selected) {
+        if (!empty(worktree.history_error)) {
+            return GitWindowStatus(text = worktree.history_error, error = true)
+        }
+        if (worktree.history_loading) {
+            return GitWindowStatus(text = "Reading Git history...", busy = true)
+        }
+        return GitWindowStatus(text = "COMMITS ON {worktree.history_ref}  {git_history_commit_count(repository, worktree)}")
+    }
+    if (!empty(worktree.review_error)) {
+        return GitWindowStatus(text = worktree.review_error, error = true)
+    }
+    if (worktree.review_loading) {
+        return GitWindowStatus(text = "Reading outgoing commits...", busy = true)
+    }
+    let base = (!empty(worktree.review_base_ref)
+        ? worktree.review_base_ref : "detecting base...")
+    return GitWindowStatus(text = "OUTGOING COMMITS  {git_review_commit_count(repository, worktree)}   -> {base}")
+}
+
+def private git_changelist_status(repository : RepositorySnapshot const;
+                                  worktree : WorktreeState const) : GitWindowStatus {
+    if (!empty(repository.error)) {
+        return GitWindowStatus(text = repository.error, error = true)
+    }
+    if (g_client != null && g_client.git_action_loading) {
+        let action = (empty(g_client.git_action_status)
+            ? "Running Git..." : g_client.git_action_status)
+        return GitWindowStatus(text = action, busy = true)
+    }
+    if (repository.refreshing) {
+        return GitWindowStatus(text = "Refreshing repository...", busy = true)
+    }
+    if (GIT_HISTORY_TAB.selected || GIT_TREE_TAB.selected) {
+        if (!empty(worktree.history_error)) {
+            return GitWindowStatus(text = worktree.history_error, error = true)
+        }
+        if (!empty(g_requested_history_commit)) {
+            return GitWindowStatus(text = "Loading selected commit files...", busy = true)
+        }
+        let commit_hash = worktree.history_commit
+        if (empty(commit_hash)) {
+            return GitWindowStatus(text = "Select a commit to inspect its files")
+        }
+        let short_hash = slice(commit_hash, 0, min(9, length(commit_hash)))
+        return GitWindowStatus(text = "FILES IN {short_hash}  {git_selected_commit_file_count(repository, worktree, commit_hash)}")
+    }
+    if (!empty(worktree.review_error)) {
+        return GitWindowStatus(text = worktree.review_error, error = true)
+    }
+    if (worktree.review_loading) {
+        return GitWindowStatus(text = "Refreshing worktree PR...", busy = true)
+    }
+    let ahead_behind = ((worktree.ahead != 0 || worktree.behind != 0)
+        ? "   ahead {worktree.ahead}   behind {worktree.behind}" : "")
+    return GitWindowStatus(text = "staged {worktree.staged}   unstaged {worktree.unstaged}   untracked {worktree.untracked}   conflicted {worktree.conflicted}{ahead_behind}")
+}
+
+def private git_status_color(status : GitWindowStatus const) : float4 {
+    return (status.error
+        ? float4(1.0f, 0.35f, 0.30f, 1.0f)
+        : (status.busy
+            ? float4(0.56f, 0.59f, 0.64f, 1.0f)
+            : float4(0.69f, 0.73f, 0.80f, 1.0f)))
 }
 
 def private draw_git_changelist_window() {
+    var status = GitWindowStatus(text = "No worktree selected")
     var found = false
-    if (g_client != null) {
-        for (repository in g_client.repositories) {
-            if (repository.record.id != g_selected_repository_id) continue
-            for (worktree in repository.worktrees) {
-                if (worktree.path != g_selected_worktree_path) continue
-                found = true
-                let title = worktree.is_main ? "MAIN - {worktree.branch}" : worktree.branch
-                text(GIT_TITLE, (text = title))
-                same_line()
-                if (small_button(REFRESH_GIT, (text = repository.refreshing ? "Refreshing..." : "Refresh",
+    child(GIT_CHANGELIST_CONTENT, (text = "changelist content",
+            size = float2(0.0f, -GetFrameHeightWithSpacing()),
+            child_flags = ImGuiChildFlags.None,
+            window_flags = ImGuiWindowFlags.None)) {
+        if (g_client != null) {
+            for (repository in g_client.repositories) {
+                if (repository.record.id != g_selected_repository_id) continue
+                for (worktree in repository.worktrees) {
+                    if (worktree.path != g_selected_worktree_path) continue
+                    found = true
+                    let title = worktree.is_main ? "MAIN - {worktree.branch}" : worktree.branch
+                    text(GIT_TITLE, (text = title))
+                    same_line()
+                    if (small_button(REFRESH_GIT, (text = "Refresh",
                         enabled = !repository.refreshing))) {
-                    g_client->refresh_repository(repository.record.id)
-                    g_client->request_repository_review(
-                        repository.record.id, worktree.path)
-                    g_client->request_repository_history(
-                        repository.record.id, worktree.path, worktree.branch)
-                    g_client->request_repository_refs(
-                        repository.record.id, worktree.path)
-                }
-                text_disabled(GIT_WORKTREE_PATH, (text = worktree.path))
-                let status_summary = "staged {worktree.staged}   unstaged {worktree.unstaged}   untracked {worktree.untracked}   conflicted {worktree.conflicted}"
-                text(GIT_STATUS_SUMMARY, (text = status_summary))
-                if (worktree.ahead != 0 || worktree.behind != 0) {
-                    text(GIT_AHEAD_BEHIND,
-                        (text = "ahead {worktree.ahead}   behind {worktree.behind}"))
-                }
-                if (!empty(repository.error)) {
-                    text_colored(GIT_ERROR, (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-                        text = repository.error))
-                }
-                separator()
-                if (GIT_HISTORY_TAB.selected || GIT_TREE_TAB.selected) {
-                    draw_commit_files(repository, worktree)
-                } else {
-                    draw_shared_pr_files(repository, worktree)
+                        g_client->refresh_repository(repository.record.id)
+                        g_client->request_repository_review(
+                            repository.record.id, worktree.path)
+                        g_client->request_repository_history(
+                            repository.record.id, worktree.path, worktree.branch)
+                        g_client->request_repository_refs(
+                            repository.record.id, worktree.path)
+                    }
+                    text_disabled(GIT_WORKTREE_PATH, (text = worktree.path))
+                    separator()
+                    if (GIT_HISTORY_TAB.selected || GIT_TREE_TAB.selected) {
+                        draw_commit_files(repository, worktree)
+                    } else {
+                        draw_shared_pr_files(repository, worktree)
+                    }
+                    status = git_changelist_status(repository, worktree)
                 }
             }
         }
+        if (!found) text_disabled("Select a worktree to inspect its changelist")
     }
-    if (!found) text_disabled("Select a worktree to inspect its changelist")
+    separator(GIT_CHANGELIST_STATUS_SEPARATOR)
+    text_colored(GIT_CHANGELIST_STATUS_TEXT,
+        (color = git_status_color(status), text = status.text))
 }
 
 def private draw_git_activity_window() {
+    var status = GitWindowStatus(text = "No worktree selected")
     var found = false
-    if (g_client != null) {
-        for (repository in g_client.repositories) {
-            if (repository.record.id != g_selected_repository_id) continue
-            for (worktree in repository.worktrees) {
-                if (worktree.path != g_selected_worktree_path) continue
-                found = true
-                tab_bar(GIT_PERSPECTIVE_TABS,
+    child(GIT_ACTIVITY_CONTENT, (text = "activity content",
+            size = float2(0.0f, -GetFrameHeightWithSpacing()),
+            child_flags = ImGuiChildFlags.None,
+            window_flags = ImGuiWindowFlags.None)) {
+        if (g_client != null) {
+            for (repository in g_client.repositories) {
+                if (repository.record.id != g_selected_repository_id) continue
+                for (worktree in repository.worktrees) {
+                    if (worktree.path != g_selected_worktree_path) continue
+                    found = true
+                    tab_bar(GIT_PERSPECTIVE_TABS,
                         (text = "Git perspectives", flags = ImGuiTabBarFlags.None)) {
-                    tab_item(GIT_PR_TAB, (text = "PR", closable = false,
+                        tab_item(GIT_PR_TAB, (text = "PR", closable = false,
                             flags = ImGuiTabItemFlags.None)) {
-                        draw_pr_review(repository, worktree)
-                    }
-                    tab_item(GIT_HISTORY_TAB, (text = "History", closable = false,
+                            draw_pr_review(repository, worktree)
+                        }
+                        tab_item(GIT_HISTORY_TAB, (text = "History", closable = false,
                             flags = ImGuiTabItemFlags.None)) {
-                        draw_history_review(repository, worktree)
-                    }
-                    tab_item(GIT_TREE_TAB, (text = "Tree", closable = false,
+                            draw_history_review(repository, worktree)
+                        }
+                        tab_item(GIT_TREE_TAB, (text = "Tree", closable = false,
                             flags = ImGuiTabItemFlags.None)) {
-                        draw_tree_review(repository, worktree)
+                            draw_tree_review(repository, worktree)
+                        }
                     }
+                    status = git_activity_status(repository, worktree)
                 }
             }
         }
+        if (!found) text_disabled("Select a worktree to inspect Git activity")
     }
-    if (!found) text_disabled("Select a worktree to inspect Git activity")
+    separator(GIT_ACTIVITY_STATUS_SEPARATOR)
+    text_colored(GIT_ACTIVITY_STATUS_TEXT,
+        (color = git_status_color(status), text = status.text))
 }
 
 def private source_view_style(diff_background : bool = false) : TextSourceViewStyle {

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -532,6 +532,8 @@ class private WatcherRichClient : HvWebSocketClient {
     def override onOpen {
         connected = true
         connect_count++
+        delete git_failure_revisions
+        git_failure_baseline_ready = false
         error = ""
         last_reconnect = ref_time_ticks()
         last_heartbeat = ref_time_ticks()
@@ -546,8 +548,24 @@ class private WatcherRichClient : HvWebSocketClient {
         disconnect_count++
         attached = false
         controls = false
+        attached_id = ""
         sent_columns = 0
         sent_rows = 0
+        last_review_identity = ""
+        last_history_identity = ""
+        last_refs_identity = ""
+        if (git_action_loading) {
+            git_action_loading = false
+            git_action_status = "interrupted"
+        }
+        if (g_inspector.loading) {
+            let disconnect_error = "watcher connection closed during file inspection"
+            g_inspector.loading = false
+            g_inspector.status = ""
+            g_inspector.error = disconnect_error
+            let _ = inspector_load_fail(g_inspector.prepare,
+                g_inspector.prepare.generation, disconnect_error)
+        }
         error = "watcher connection closed"
         last_reconnect = ref_time_ticks()
         if (was_connected) {
@@ -573,7 +591,24 @@ class private WatcherRichClient : HvWebSocketClient {
             if (sscan_json(body, incoming)) {
                 delete sessions
                 sessions <- incoming.data
-                if (empty(selected_id)) {
+                var selected_found = empty(selected_id)
+                if (!empty(selected_id)) {
+                    for (session in sessions) {
+                        if (session.id == selected_id) {
+                            selected_found = true
+                            break
+                        }
+                    }
+                }
+                if (!selected_found) {
+                    selected_id = ""
+                    attached_id = ""
+                    attached = false
+                    controls = false
+                }
+                if (!attached && !empty(selected_id)) {
+                    attach_session(selected_id)
+                } elif (empty(selected_id)) {
                     for (session in sessions) {
                         if (session.state == "running") {
                             attach_session(session.id)
@@ -597,6 +632,7 @@ class private WatcherRichClient : HvWebSocketClient {
                 delete repositories
                 repositories <- incoming.data
                 var selection_found = false
+                var selected_worktree_observed = false
                 for (repository in repositories) {
                     if (repository.record.id != g_selected_repository_id) continue
                     if (empty(repository.worktrees)) {
@@ -605,6 +641,7 @@ class private WatcherRichClient : HvWebSocketClient {
                     for (worktree in repository.worktrees) {
                         if (worktree.path == g_selected_worktree_path) {
                             selection_found = true
+                            selected_worktree_observed = true
                         }
                     }
                 }
@@ -612,12 +649,14 @@ class private WatcherRichClient : HvWebSocketClient {
                     g_selected_repository_id = repositories[0].record.id
                     if (!empty(repositories[0].worktrees)) {
                         g_selected_worktree_path = repositories[0].worktrees[0].path
+                        selected_worktree_observed = true
                     } else {
                         g_selected_worktree_path = repositories[0].record.checkout_path
                     }
                 }
                 let review_identity = "{g_selected_repository_id}\n{g_selected_worktree_path}"
-                if (!empty(g_selected_repository_id)
+                if (selected_worktree_observed
+                        && !empty(g_selected_repository_id)
                         && !empty(g_selected_worktree_path)
                         && review_identity != last_review_identity) {
                     request_repository_review(
@@ -633,7 +672,9 @@ class private WatcherRichClient : HvWebSocketClient {
                     if (repository.failure_revision <= seen) continue
                     git_failure_revisions[id] = repository.failure_revision
                     if (git_failure_baseline_ready
-                            && !empty(repository.failure_session_id)) {
+                            && !empty(repository.failure_session_id)
+                            && repository.failure_session_id != selected_id
+                            && repository.failure_session_id != attached_id) {
                         attach_session(repository.failure_session_id)
                         TERMINAL_WIN.open = true
                         TERMINAL_WIN.pending_raise = true

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -9,6 +9,7 @@ require imgui/imgui_drawlist_builtin
 require imgui/imgui_terminal
 require imgui/imgui_fonts
 require imgui/imgui_docking_builtin
+require imgui/imgui_table_builtin
 require imgui/imgui_markdown_tree_sitter
 require imgui/imgui_text_source_view
 require imgui/imgui_text_tree_sitter
@@ -229,8 +230,10 @@ var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
-var private GIT_COMMIT_TEXT : table<int; NarrativeState>
-var private GIT_HISTORY_COMMIT_ROW : table<int; ToggleState>
+var private GIT_COMMIT_TITLE_TEXT : table<int; NarrativeState>
+var private GIT_COMMIT_AUTHOR_TEXT : table<int; NarrativeState>
+var private GIT_PR_COMMIT_HOVER : table<int; EmptyMarkerState>
+var private GIT_HISTORY_COMMIT_ROW : table<int; ClickState>
 var private GIT_COMMIT_FILE_ROW : table<int; ToggleState>
 var private REPOSITORY_ERROR : table<int; NarrativeState>
 var private REPOSITORY_TITLE : table<int; NarrativeState>
@@ -256,12 +259,16 @@ def private setup_default_layout(dock_id : uint) {
     var git_id : uint = 0u
     var inspector_id : uint = 0u
     DockBuilderSplitNode(upper_id, ImGuiDir.Left, 0.34f, git_id, inspector_id)
+    var changelist_id : uint = 0u
+    var activity_id : uint = 0u
+    DockBuilderSplitNode(git_id, ImGuiDir.Up, 0.35f, changelist_id, activity_id)
     DockBuilderDockWindow("Sessions & Activity", left_id)
     DockBuilderDockWindow("Repositories & Worktrees", left_id)
-    DockBuilderDockWindow("Git Status", git_id)
+    DockBuilderDockWindow("Git Changelist", changelist_id)
+    DockBuilderDockWindow("Git Activity", activity_id)
     DockBuilderDockWindow("File Inspector", inspector_id)
     DockBuilderDockWindow("Terminal", terminal_id)
-    DockBuilderDockWindow("Settings", git_id)
+    DockBuilderDockWindow("Settings", activity_id)
     DockBuilderFinish(dock_id)
 }
 
@@ -911,7 +918,8 @@ def private open_dock_window(var state : DockWindowState) {
 def private reset_layout() {
     REPOSITORIES_WIN.open = true
     SESSIONS_WIN.open = true
-    GIT_STATUS_WIN.open = true
+    GIT_CHANGELIST_WIN.open = true
+    GIT_ACTIVITY_WIN.open = true
     FILE_INSPECTOR_WIN.open = true
     TERMINAL_WIN.open = true
     SETTINGS_WIN.open = false
@@ -956,9 +964,13 @@ def private draw_main_menu() {
                     (text = "Sessions & Activity", selected = SESSIONS_WIN.open))) {
                 open_dock_window(SESSIONS_WIN)
             }
-            if (menu_label(VIEW_GIT_STATUS,
-                    (text = "Git Status", selected = GIT_STATUS_WIN.open))) {
-                open_dock_window(GIT_STATUS_WIN)
+            if (menu_label(VIEW_GIT_CHANGELIST,
+                    (text = "Git Changelist", selected = GIT_CHANGELIST_WIN.open))) {
+                open_dock_window(GIT_CHANGELIST_WIN)
+            }
+            if (menu_label(VIEW_GIT_ACTIVITY,
+                    (text = "Git Activity", selected = GIT_ACTIVITY_WIN.open))) {
+                open_dock_window(GIT_ACTIVITY_WIN)
             }
             if (menu_label(VIEW_FILE_INSPECTOR,
                     (text = "File Inspector", selected = FILE_INSPECTOR_WIN.open))) {
@@ -1025,8 +1037,9 @@ def private draw_repositories_window() {
                     g_client->refresh_repository(repository.record.id)
                     g_client->request_repository_review(
                         repository.record.id, worktree.path)
-                    GIT_STATUS_WIN.open = true
-                    GIT_STATUS_WIN.pending_raise = true
+                    GIT_CHANGELIST_WIN.open = true
+                    GIT_CHANGELIST_WIN.pending_raise = true
+                    GIT_ACTIVITY_WIN.open = true
                 }
                 WORKTREE_ROW[row].value = (repository.record.id == g_selected_repository_id && worktree.path == g_selected_worktree_path)
                 if (worktree.is_main) separator(WORKTREE_SEPARATOR[row])
@@ -1372,19 +1385,51 @@ def private draw_pr_review(repository : RepositorySnapshot const;
     text(GIT_GROUP_TITLE[12],
         (text = "OUTGOING COMMITS  {commit_count}   -> {base}"))
     separator(GIT_GROUP_SEPARATOR[12])
-    var commit_row = 0
-    for (commit in repository.review_commits) {
-        if (commit.worktree_path != worktree.path) continue
-        with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
-            text(GIT_COMMIT_TEXT[commit_row],
-                (text = "{commit.short_hash}  {commit.subject}  - {commit.author}"))
-        }
-        draw_sha_copy_icon(commit.hash, "pr-commit:{commit.hash}")
-        commit_row++
+    if (worktree.review_loading) text_disabled("Reading outgoing commits...")
+    if (!empty(worktree.review_error)) {
+        text_colored(GIT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = worktree.review_error))
     }
-    if (commit_count == 0 && !worktree.review_loading
-            && empty(worktree.review_error)) {
-        text_disabled("No outgoing commits")
+    if (commit_count == 0) {
+        if (!worktree.review_loading && empty(worktree.review_error)) {
+            text_disabled("No outgoing commits")
+        }
+        return
+    }
+    var commit_row = 0
+    let table_flags = (ImGuiTableFlags.Resizable | ImGuiTableFlags.RowBg |
+        ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.ScrollY |
+        ImGuiTableFlags.SizingStretchProp)
+    data_table(GIT_PR_COMMIT_TABLE, (text = "##pr-commits", columns = 3,
+            flags = table_flags, outer_size = float2(0.0f, 0.0f),
+            inner_width = 0.0f)) {
+        table_setup_scroll_freeze(0, 1)
+        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, 112.0f)
+        table_setup_column("Title", ImGuiTableColumnFlags.WidthStretch, 0.72f)
+        table_setup_column("Author", ImGuiTableColumnFlags.WidthStretch, 0.28f)
+        table_headers_row()
+        for (commit in repository.review_commits) {
+            if (commit.worktree_path != worktree.path) continue
+            table_next_row()
+            table_set_column_index(0)
+            with_style((ImGuiCol.Text, float4(0.36f, 0.76f, 0.96f, 1.0f))) {
+                selectable_hover(GIT_PR_COMMIT_HOVER[commit_row],
+                    (text = "{commit.short_hash}##pr:{commit.hash}",
+                    flags = ImGuiSelectableFlags.SpanAllColumns |
+                        ImGuiSelectableFlags.AllowOverlap))
+            }
+            draw_sha_copy_icon(commit.hash, "pr-commit:{commit.hash}")
+            table_set_column_index(1)
+            text_colored(GIT_COMMIT_TITLE_TEXT[commit_row],
+                (color = float4(0.91f, 0.93f, 0.96f, 1.0f),
+                text = commit.subject))
+            table_set_column_index(2)
+            text_colored(GIT_COMMIT_AUTHOR_TEXT[commit_row],
+                (color = float4(0.64f, 0.70f, 0.80f, 1.0f),
+                text = commit.author))
+            commit_row++
+        }
     }
 }
 
@@ -1461,42 +1506,72 @@ def private draw_commit_files(repository : RepositorySnapshot const;
 }
 
 def private draw_history_commits(repository : RepositorySnapshot const;
-                                 worktree : WorktreeState const) {
-    var count = 0
-    for (commit in repository.history_commits) {
-        if (commit.worktree_path == worktree.path) count++
+                                 worktree : WorktreeState const;
+                                 heading : string) {
+    var inscope commit_indices : array<int>
+    commit_indices |> reserve(length(repository.history_commits))
+    for (index in range(length(repository.history_commits))) {
+        if (repository.history_commits[index].worktree_path == worktree.path) {
+            commit_indices |> push(index)
+        }
     }
-    text(GIT_GROUP_TITLE[20],
-        (text = "COMMITS ON {worktree.history_ref}  {count}"))
+    let count = length(commit_indices)
+    text(GIT_GROUP_TITLE[20], (text = "{heading}  {count}"))
     separator(GIT_GROUP_SEPARATOR[20])
-    var row = 0
-    for (commit in repository.history_commits) {
-        if (commit.worktree_path != worktree.path) continue
-        let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
-        GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == selected_commit
-        var selected = false
-        with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
-            selected = selectable(GIT_HISTORY_COMMIT_ROW[row],
-                (text = "{commit.short_hash}  {commit.subject}  - {commit.author}##history:{commit.hash}"))
-        }
-        if (selected && g_client != null && commit.hash != selected_commit) {
-            request_commit_files(repository, worktree, commit.hash)
-        }
-        draw_sha_copy_icon(commit.hash, "history:{commit.hash}")
-        row++
-    }
     if (worktree.history_loading) text_disabled("Reading Git history...")
     if (!empty(worktree.history_error)) {
         text_colored(GIT_ERROR,
             (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
             text = worktree.history_error))
     }
+    if (count == 0) return
+    let table_flags = (ImGuiTableFlags.Resizable | ImGuiTableFlags.RowBg |
+        ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.ScrollY |
+        ImGuiTableFlags.SizingStretchProp)
+    data_table(GIT_HISTORY_COMMIT_TABLE, (text = "##history-commits", columns = 3,
+            flags = table_flags, outer_size = float2(0.0f, 0.0f),
+            inner_width = 0.0f)) {
+        table_setup_scroll_freeze(0, 1)
+        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, 112.0f)
+        table_setup_column("Title", ImGuiTableColumnFlags.WidthStretch, 0.72f)
+        table_setup_column("Author", ImGuiTableColumnFlags.WidthStretch, 0.28f)
+        table_headers_row()
+        list_clipper(count) $(start, end_) {
+            for (row in range(start, end_)) {
+                let commit = repository.history_commits[commit_indices[row]]
+                let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
+                table_next_row()
+                table_set_column_index(0)
+                var selected = false
+                with_style((ImGuiCol.Text, float4(0.36f, 0.76f, 0.96f, 1.0f))) {
+                    selected = selectable_label(GIT_HISTORY_COMMIT_ROW[row],
+                        (text = "{commit.short_hash}##history:{commit.hash}",
+                        selected = commit.hash == selected_commit,
+                        flags = ImGuiSelectableFlags.SpanAllColumns |
+                            ImGuiSelectableFlags.AllowOverlap))
+                }
+                draw_sha_copy_icon(commit.hash, "history:{commit.hash}")
+                table_set_column_index(1)
+                text_colored(GIT_COMMIT_TITLE_TEXT[row],
+                    (color = float4(0.91f, 0.93f, 0.96f, 1.0f),
+                    text = commit.subject))
+                table_set_column_index(2)
+                text_colored(GIT_COMMIT_AUTHOR_TEXT[row],
+                    (color = float4(0.64f, 0.70f, 0.80f, 1.0f),
+                    text = commit.author))
+                if (selected && g_client != null && commit.hash != selected_commit) {
+                    request_commit_files(repository, worktree, commit.hash)
+                }
+            }
+        }
+    }
 }
 
 def private draw_history_review(repository : RepositorySnapshot const;
                                 worktree : WorktreeState const) {
     ensure_history(repository, worktree, worktree.branch)
-    draw_history_commits(repository, worktree)
+    draw_history_commits(repository, worktree,
+        "COMMITS ON {worktree.history_ref}")
 }
 
 def private git_lane_index(lanes : array<string> const; hash : string) : int {
@@ -1652,15 +1727,15 @@ def private draw_commit_graph(repository : RepositorySnapshot const;
         for (row in range(start, end_)) {
             let commit = repository.history_commits[commit_indices[row]]
             let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
-            GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == selected_commit
             let refs = git_graph_refs(repository, worktree, commit)
             let ref_text = empty(refs) ? "" : "{refs}  "
             let space_width = max(1.0f, CalcTextSize(" ").x)
             let graph_pad = repeat(" ", int(56.0f / space_width) + 1)
             var selected = false
             with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
-                selected = selectable(GIT_HISTORY_COMMIT_ROW[row],
-                    (text = "{graph_pad}{commit.short_hash}  {ref_text}{commit.subject}  - {commit.author}##graph:{commit.hash}"))
+                selected = selectable_label(GIT_HISTORY_COMMIT_ROW[row],
+                    (text = "{graph_pad}{commit.short_hash}  {ref_text}{commit.subject}  - {commit.author}##graph:{commit.hash}",
+                    selected = commit.hash == selected_commit))
             }
             draw_commit_graph_decoration(commit, observed, lanes,
                 "graph:{commit.hash}")
@@ -1694,10 +1769,10 @@ def private draw_tree_review(repository : RepositorySnapshot const;
             text = worktree.refs_error))
     }
     ensure_history(repository, worktree, "__all__")
-    draw_commit_graph(repository, worktree)
+    draw_history_commits(repository, worktree, "COMMITS ACROSS WORKTREE REFS")
 }
 
-def private draw_git_status_window() {
+def private draw_git_changelist_window() {
     var found = false
     if (g_client != null) {
         for (repository in g_client.repositories) {
@@ -1735,7 +1810,20 @@ def private draw_git_status_window() {
                 } else {
                     draw_shared_pr_files(repository, worktree)
                 }
-                separator()
+            }
+        }
+    }
+    if (!found) text_disabled("Select a worktree to inspect its changelist")
+}
+
+def private draw_git_activity_window() {
+    var found = false
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id != g_selected_repository_id) continue
+            for (worktree in repository.worktrees) {
+                if (worktree.path != g_selected_worktree_path) continue
+                found = true
                 tab_bar(GIT_PERSPECTIVE_TABS,
                         (text = "Git perspectives", flags = ImGuiTabBarFlags.None)) {
                     tab_item(GIT_PR_TAB, (text = "PR", closable = false,
@@ -1754,7 +1842,7 @@ def private draw_git_status_window() {
             }
         }
     }
-    if (!found) text_disabled("Select a worktree to inspect Git status")
+    if (!found) text_disabled("Select a worktree to inspect Git activity")
 }
 
 def private source_view_style(diff_background : bool = false) : TextSourceViewStyle {
@@ -2000,6 +2088,12 @@ def herder_client_state(_input : JsonValue?) : JsonValue? {
         selected_worktree_path = g_selected_worktree_path))
 }
 
+[live_command(description = "Restore the rich client's default dock layout.")]
+def herder_reset_layout(_input : JsonValue?) : JsonValue? {
+    reset_layout()
+    return JV((ok = true))
+}
+
 [live_command(description = "Select a worktree for Git review. Args: repository_id, worktree_path.")]
 def herder_git_select_worktree(input : JsonValue?) : JsonValue? {
     if (g_client == null || !g_client.connected) {
@@ -2020,8 +2114,9 @@ def herder_git_select_worktree(input : JsonValue?) : JsonValue? {
                 args.repository_id, args.worktree_path, worktree.branch)
             g_client->request_repository_refs(
                 args.repository_id, args.worktree_path)
-            GIT_STATUS_WIN.open = true
-            GIT_STATUS_WIN.pending_raise = true
+            GIT_CHANGELIST_WIN.open = true
+            GIT_CHANGELIST_WIN.pending_raise = true
+            GIT_ACTIVITY_WIN.open = true
             return JV((ok = true, repository_id = args.repository_id,
                 worktree_path = args.worktree_path))
         }
@@ -2207,8 +2302,9 @@ def herder_git_perspective(input : JsonValue?) : JsonValue? {
     } else {
         return JV((ok = false, error = "perspective must be pr, history, or tree"))
     }
-    GIT_STATUS_WIN.open = true
-    GIT_STATUS_WIN.pending_raise = true
+    GIT_CHANGELIST_WIN.open = true
+    GIT_ACTIVITY_WIN.open = true
+    GIT_ACTIVITY_WIN.pending_raise = true
     return JV((ok = true, perspective = perspective))
 }
 
@@ -2523,9 +2619,13 @@ def update() {
                 flags = ImGuiWindowFlags.None)) {
             draw_session_list()
         }
-        dock_window(GIT_STATUS_WIN, (text = "Git Status", closable = true,
+        dock_window(GIT_ACTIVITY_WIN, (text = "Git Activity", closable = true,
                 flags = ImGuiWindowFlags.None)) {
-            draw_git_status_window()
+            draw_git_activity_window()
+        }
+        dock_window(GIT_CHANGELIST_WIN, (text = "Git Changelist", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_git_changelist_window()
         }
         dock_window(FILE_INSPECTOR_WIN, (text = "File Inspector", closable = true,
                 flags = ImGuiWindowFlags.None)) {

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -4,6 +4,8 @@ options persistent_heap
 options no_unused_function_arguments = false
 
 require imgui/imgui_harness
+require imgui/imgui_icons
+require imgui/imgui_drawlist_builtin
 require imgui/imgui_terminal
 require imgui/imgui_fonts
 require imgui/imgui_docking_builtin
@@ -16,6 +18,7 @@ require daslib/safe_addr
 require daslib/json
 require daslib/json_boost
 require daslib/jobque_boost
+require daslib/strings_boost
 require daslib/utf8_utils
 require live/live_commands
 require ./watcher_core.das
@@ -216,13 +219,9 @@ var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
-var private GIT_ACTION_BUTTON : table<int; ClickState>
-var private GIT_ACTION_DISABLED : table<int; NarrativeState>
-var private GIT_ACTION_SAME_LINE : table<int; EmptyMarkerState>
 var private GIT_COMMIT_TEXT : table<int; NarrativeState>
 var private GIT_HISTORY_COMMIT_ROW : table<int; ToggleState>
 var private GIT_COMMIT_FILE_ROW : table<int; ToggleState>
-var private GIT_REF_ROW : table<int; ToggleState>
 var private REPOSITORY_ERROR : table<int; NarrativeState>
 var private REPOSITORY_TITLE : table<int; NarrativeState>
 var private REPOSITORY_EMPTY : table<int; NarrativeState>
@@ -231,6 +230,7 @@ var private REPOSITORY_SEPARATOR : table<int; EmptyMarkerState>
 var private WORKTREE_SEPARATOR : table<int; EmptyMarkerState>
 var private GIT_GROUP_SEPARATOR : table<int; EmptyMarkerState>
 var private GIT_GROUP_SPACING : table<int; EmptyMarkerState>
+var private GIT_HOVER_TOOLTIP : NarrativeState
 
 def private setup_default_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
@@ -1105,44 +1105,109 @@ def private git_status_file_code(repository : RepositorySnapshot const;
     return ""
 }
 
+def private git_line_stats(added_lines, deleted_lines : int;
+                           stats_known, binary : bool) : string {
+    if (binary) return "binary"
+    if (!stats_known) return "+?  -?"
+    return "+{added_lines}  -{deleted_lines}"
+}
+
+def private draw_git_path_text(path : string; p0, p1 : float2;
+                               subdued : bool) {
+    let alpha = subdued ? 0.55f : 1.0f
+    let directory_color = GetColorU32(float4(0.43f, 0.64f, 0.82f, alpha))
+    let separator_color = GetColorU32(float4(0.78f, 0.55f, 0.30f, alpha))
+    let name_color = GetColorU32(float4(0.90f, 0.91f, 0.93f, alpha))
+    var inscope components <- split(replace(path, "\\", "/"), "/")
+    var position = p0
+    with_window_drawlist() $(var dl) {
+        dl |> with_drawlist_clip_rect(p0, p1, true) {
+            for (index in range(length(components))) {
+                let component = components[index]
+                let color = index + 1 == length(components) ? name_color : directory_color
+                dl |> add_text(position, color, component)
+                position.x += CalcTextSize(component).x
+                if (index + 1 < length(components)) {
+                    dl |> add_text(position, separator_color, "/")
+                    position.x += CalcTextSize("/").x
+                }
+            }
+        }
+    }
+}
+
+def private draw_git_stats_text(position : float2; color : uint;
+                                stats : string) {
+    with_window_drawlist() $(var dl) {
+        dl |> add_text(position, color, stats)
+    }
+}
+
+def private decorate_git_file_row(row_id, path : string;
+                                  added_lines, deleted_lines : int;
+                                  stats_known, binary, subdued : bool;
+                                  action_glyph, action_tip : string;
+                                  var action_clicked : bool&) {
+    let stats = git_line_stats(added_lines, deleted_lines, stats_known, binary)
+    let row_min = GetItemRectMin()
+    let row_max = GetItemRectMax()
+    let hovered = IsItemHovered()
+    let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
+    let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
+    let action_x = row_max.x - icon_width
+    let stats_size = CalcTextSize(stats)
+    let stats_x = max(row_min.x, action_x - stats_size.x - GetStyle().ItemSpacing.x)
+    let text_y = row_min.y + max(0.0f,
+        (row_max.y - row_min.y - GetTextLineHeight()) * 0.5f)
+    draw_git_path_text(path,
+        float2(row_min.x + GetStyle().FramePadding.x, text_y),
+        float2(stats_x - GetStyle().ItemSpacing.x, row_max.y), subdued)
+    let stats_color = binary || !stats_known ? GetColorU32(ImGuiCol.TextDisabled) : GetColorU32(float4(0.61f, 0.78f, 0.52f, subdued ? 0.55f : 1.0f))
+    draw_git_stats_text(float2(stats_x, text_y), stats_color, stats)
+    action_clicked = false
+    if (!empty(action_glyph)) {
+        action_clicked = icon_button_draw_at("##{row_id}:action", action_glyph,
+            float2(action_x, row_min.y), icon_size, 1.0f, hovered)
+        if (hovered && IsItemHovered()) {
+            set_tooltip(GIT_HOVER_TOOLTIP, action_tip)
+        }
+    }
+}
+
 def private draw_pr_included_files(repository : RepositorySnapshot const;
                                    worktree : WorktreeState const;
-                                   var file_row : int&;
-                                   var action_row : int&) : int {
+                                   var file_row : int&) : int {
     var count = 0
     for (file in repository.review_files) {
         if (file.worktree_path == worktree.path) count++
     }
-    text(GIT_GROUP_TITLE[10], (text = "PR TOTAL  {count}"))
-    separator(GIT_GROUP_SEPARATOR[10])
     for (file in repository.review_files) {
         if (file.worktree_path != worktree.path) continue
         let status_code = git_status_file_code(
             repository, worktree.path, file.path)
         let staged = (!empty(status_code) && status_code != "??"
             && git_status_byte(status_code, 0) != ' ')
-        if (staged) {
-            let busy = g_client != null && g_client.git_action_loading
-            let action_label = ((busy && g_client.git_action_file_path == file.path)
-                ? "Unstaging..." : "Unstage")
-            if (busy) {
-                text_disabled(GIT_ACTION_DISABLED[action_row],
-                    (text = action_label))
-            } elif (small_button(GIT_ACTION_BUTTON[action_row],
-                    (text = "{action_label}##pr-unstage:{file.path}"))
-                    && g_client != null) {
-                g_client->git_file_action(repository.record.id,
-                    worktree.path, file.path, "unstage")
-            }
-            same_line(GIT_ACTION_SAME_LINE[action_row])
-        }
         GIT_FILE_ROW[file_row].value = (g_inspector.repository_id == repository.record.id
             && g_inspector.worktree_path == worktree.path
             && g_inspector.file_path == file.path
             && g_inspector.comparison == "pr")
-        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
-        if (selectable(GIT_FILE_ROW[file_row],
-                (text = "{file.code}  {file.path}{old_label}##pr:{file.path}"))) {
+        let busy = g_client != null && g_client.git_action_loading
+        var action_clicked = false
+        let stats = git_line_stats(file.added_lines, file.deleted_lines,
+            file.stats_known, file.binary)
+        var selected = false
+        with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
+            selected = selectable(GIT_FILE_ROW[file_row],
+                (text = "{file.path}  {stats}##pr:{file.path}"))
+        }
+        decorate_git_file_row("pr:{file.path}", file.path, file.added_lines,
+            file.deleted_lines, file.stats_known, file.binary, false,
+            staged && !busy ? "minus" : "",
+            "Remove from the staged PR result", action_clicked)
+        if (action_clicked && g_client != null) {
+            g_client->git_file_action(repository.record.id,
+                worktree.path, file.path, "unstage")
+        } elif (selected) {
             if (g_client != null) {
                 g_client->inspect_file(repository.record.id, worktree.path,
                     file.path, "pr")
@@ -1151,58 +1216,88 @@ def private draw_pr_included_files(repository : RepositorySnapshot const;
             }
         }
         file_row++
-        action_row++
     }
     return count
 }
 
 def private draw_pr_not_included_files(repository : RepositorySnapshot const;
                                        worktree : WorktreeState const;
-                                       var file_row : int&;
-                                       var action_row : int&) : int {
+                                       var file_row : int&) : int {
     var count = 0
     for (file in repository.files) {
         if (file.worktree_path != worktree.path) continue
         if (file.code == "??" || git_status_byte(file.code, 1) != ' ') count++
     }
-    text(GIT_GROUP_TITLE[11], (text = "NOT INCLUDED  {count}"))
-    separator(GIT_GROUP_SEPARATOR[11])
     for (file in repository.files) {
         if (file.worktree_path != worktree.path
                 || (file.code != "??" && git_status_byte(file.code, 1) == ' ')) continue
-        let busy = g_client != null && g_client.git_action_loading
-        let action_label = ((busy && g_client.git_action_file_path == file.path)
-            ? "Staging..." : "Stage")
-        if (busy) {
-            text_disabled(GIT_ACTION_DISABLED[action_row],
-                (text = action_label))
-        } elif (small_button(GIT_ACTION_BUTTON[action_row],
-                (text = "{action_label}##pr-stage:{file.path}"))
-                && g_client != null) {
-            g_client->git_file_action(repository.record.id,
-                worktree.path, file.path, "stage")
-        }
-        same_line(GIT_ACTION_SAME_LINE[action_row])
         GIT_FILE_ROW[file_row].value = (g_inspector.repository_id == repository.record.id
             && g_inspector.worktree_path == worktree.path
             && g_inspector.file_path == file.path
             && g_inspector.comparison == "working")
-        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
+        let busy = g_client != null && g_client.git_action_loading
+        var action_clicked = false
+        let stats = git_line_stats(file.added_lines, file.deleted_lines,
+            file.stats_known, file.binary)
         var selected = false
-        with_style((ImGuiCol.Text, GetStyleColorVec4(ImGuiCol.TextDisabled))) {
+        with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
             selected = selectable(GIT_FILE_ROW[file_row],
-                (text = "{file.code}  {file.path}{old_label}##working:{file.path}"))
+                (text = "{file.path}  {stats}##working:{file.path}"))
         }
-        if (selected && g_client != null) {
+        decorate_git_file_row("working:{file.path}", file.path, file.added_lines,
+            file.deleted_lines, file.stats_known, file.binary, true,
+            busy ? "" : "check", "Add to the staged PR result",
+            action_clicked)
+        if (action_clicked && g_client != null) {
+            g_client->git_file_action(repository.record.id,
+                worktree.path, file.path, "stage")
+        } elif (selected && g_client != null) {
             g_client->inspect_file(repository.record.id, worktree.path,
                 file.path, "working")
             FILE_INSPECTOR_WIN.open = true
             FILE_INSPECTOR_WIN.pending_raise = true
         }
         file_row++
-        action_row++
     }
     return count
+}
+
+def private draw_shared_pr_files(repository : RepositorySnapshot const;
+                                 worktree : WorktreeState const) {
+    var file_row = 0
+    let not_included = draw_pr_not_included_files(
+        repository, worktree, file_row)
+    if (not_included > 0) {
+        separator(GIT_GROUP_SEPARATOR[11])
+    }
+    let included = draw_pr_included_files(
+        repository, worktree, file_row)
+    if (included == 0 && not_included == 0 && !worktree.review_loading
+            && empty(worktree.review_error)) {
+        text_disabled("Nothing to send or stage")
+    }
+    if (worktree.review_loading) text_disabled("Refreshing worktree PR...")
+    if (!empty(worktree.review_error)) {
+        text_colored(GIT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = worktree.review_error))
+    }
+}
+
+def private draw_sha_copy_icon(hash, row_id : string) {
+    let row_min = GetItemRectMin()
+    let row_max = GetItemRectMax()
+    let hovered = IsItemHovered()
+    let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
+    let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
+    if (icon_button_draw_at("##{row_id}:copy-sha", "duplicate",
+            float2(row_max.x - icon_width, row_min.y), icon_size, 1.0f,
+            hovered)) {
+        let _ = clipboard_set_text(hash)
+    }
+    if (hovered && IsItemHovered()) {
+        set_tooltip(GIT_HOVER_TOOLTIP, "Copy full SHA")
+    }
 }
 
 def private draw_pr_review(repository : RepositorySnapshot const;
@@ -1221,31 +1316,12 @@ def private draw_pr_review(repository : RepositorySnapshot const;
         if (commit.worktree_path != worktree.path) continue
         text(GIT_COMMIT_TEXT[commit_row],
             (text = "{commit.short_hash}  {commit.subject}  - {commit.author}"))
+        draw_sha_copy_icon(commit.hash, "pr-commit:{commit.hash}")
         commit_row++
     }
     if (commit_count == 0 && !worktree.review_loading
             && empty(worktree.review_error)) {
         text_disabled("No outgoing commits")
-    }
-    if (worktree.review_loading) {
-        text_disabled("Refreshing worktree PR...")
-    }
-    if (!empty(worktree.review_error)) {
-        text_colored(GIT_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = worktree.review_error))
-    }
-    separator()
-    var file_row = 0
-    var action_row = 0
-    let included = draw_pr_included_files(
-        repository, worktree, file_row, action_row)
-    dummy(GIT_GROUP_SPACING[10], (size = float2(0.0f, GetStyle().ItemSpacing.y)))
-    let not_included = draw_pr_not_included_files(
-        repository, worktree, file_row, action_row)
-    if (included == 0 && not_included == 0 && !worktree.review_loading
-            && empty(worktree.review_error)) {
-        text_disabled("Nothing to send or stage")
     }
 }
 
@@ -1314,6 +1390,7 @@ def private draw_history_commits(repository : RepositorySnapshot const;
             g_client->request_repository_commit_files(
                 repository.record.id, worktree.path, commit.hash)
         }
+        draw_sha_copy_icon(commit.hash, "history:{commit.hash}")
         row++
     }
     if (worktree.history_loading) text_disabled("Reading Git history...")
@@ -1332,30 +1409,182 @@ def private draw_history_review(repository : RepositorySnapshot const;
     draw_history_commits(repository, worktree)
 }
 
-def private draw_ref_group(repository : RepositorySnapshot const;
-                           worktree : WorktreeState const; remote : bool;
-                           var row : int&) : int {
-    var count = 0
-    for (ref in repository.refs) {
-        if (ref.worktree_path == worktree.path && ref.remote == remote) count++
+def private git_lane_index(lanes : array<string> const; hash : string) : int {
+    for (index in range(length(lanes))) {
+        if (lanes[index] == hash) return index
     }
-    let group = remote ? 23 : 22
-    text(GIT_GROUP_TITLE[group],
-        (text = remote ? "REMOTE BRANCHES  {count}" : "LOCAL BRANCHES  {count}"))
-    separator(GIT_GROUP_SEPARATOR[group])
-    for (ref in repository.refs) {
-        if (ref.worktree_path != worktree.path || ref.remote != remote) continue
-        GIT_REF_ROW[row].value = ref.name == worktree.history_ref
-        let marker = ref.current ? "* " : "  "
-        if (selectable(GIT_REF_ROW[row],
-                (text = "{marker}{ref.name}##ref:{ref.full_name}"))
-                && g_client != null && ref.name != worktree.history_ref) {
-            g_client->request_repository_history(
-                repository.record.id, worktree.path, ref.name)
+    return -1
+}
+
+def private git_graph_color(hash : string; alpha : float = 1.0f) : uint {
+    let slot = empty(hash) ? 0 : git_status_byte(hash, 0) % 6
+    if (slot == 0) return GetColorU32(float4(0.33f, 0.72f, 0.95f, alpha))
+    if (slot == 1) return GetColorU32(float4(0.94f, 0.53f, 0.37f, alpha))
+    if (slot == 2) return GetColorU32(float4(0.53f, 0.82f, 0.43f, alpha))
+    if (slot == 3) return GetColorU32(float4(0.76f, 0.55f, 0.94f, alpha))
+    if (slot == 4) return GetColorU32(float4(0.96f, 0.76f, 0.31f, alpha))
+    return GetColorU32(float4(0.34f, 0.83f, 0.75f, alpha))
+}
+
+def private git_prepare_lanes(commit : GitCommitState const;
+                              var lanes : array<string>) : int {
+    var lane = git_lane_index(lanes, commit.hash)
+    if (lane < 0) {
+        lanes |> push(commit.hash)
+        lane = length(lanes) - 1
+    }
+    var parent_number = 0
+    for (parent in split(commit.parents, " ")) {
+        if (empty(parent)) continue
+        if (parent_number > 0 && git_lane_index(lanes, parent) < 0) {
+            lanes |> push(parent)
         }
-        row++
+        parent_number++
     }
-    return count
+    return lane
+}
+
+def private git_finish_lanes(commit : GitCommitState const; lane : int;
+                             var lanes : array<string>) {
+    var first_parent = ""
+    for (parent in split(commit.parents, " ")) {
+        if (!empty(parent)) {
+            first_parent = parent
+            break
+        }
+    }
+    if (empty(first_parent)) {
+        lanes |> erase(lane)
+    } else {
+        lanes[lane] = first_parent
+        var duplicate = length(lanes) - 1
+        while (duplicate > lane) {
+            if (lanes[duplicate] == first_parent) lanes |> erase(duplicate)
+            duplicate--
+        }
+    }
+}
+
+def private git_advance_lanes(commit : GitCommitState const;
+                              var lanes : array<string>) {
+    let lane = git_prepare_lanes(commit, lanes)
+    git_finish_lanes(commit, lane, lanes)
+}
+
+def private draw_commit_graph_decoration(repository : RepositorySnapshot const;
+                                         worktree : WorktreeState const;
+                                         commit : GitCommitState const;
+                                         var lanes : array<string>;
+                                         row_id : string) {
+    let lane = git_prepare_lanes(commit, lanes)
+    let row_min = GetItemRectMin()
+    let row_max = GetItemRectMax()
+    let center_y = (row_min.y + row_max.y) * 0.5f
+    let lane_spacing = 14.0f
+    let graph_x = row_min.x + 8.0f
+    let graph_width = 126.0f
+    var inscope parents <- split(commit.parents, " ")
+    with_window_drawlist() $(var dl) {
+        for (index in range(length(lanes))) {
+            let x = graph_x + float(index) * lane_spacing
+            dl |> add_line(float2(x, row_min.y), float2(x, row_max.y),
+                git_graph_color(lanes[index], 0.72f), 2.0f)
+        }
+        let node_x = graph_x + float(lane) * lane_spacing
+        var parent_number = 0
+        for (parent in parents) {
+            if (empty(parent)) continue
+            if (parent_number > 0) {
+                let parent_lane = git_lane_index(lanes, parent)
+                let parent_x = graph_x + float(parent_lane) * lane_spacing
+                dl |> add_line(float2(node_x, center_y),
+                    float2(parent_x, row_max.y), git_graph_color(parent, 0.85f), 2.0f)
+            }
+            parent_number++
+        }
+        dl |> add_circle_filled(float2(node_x, center_y), 4.5f,
+            git_graph_color(commit.hash), 12)
+        dl |> add_circle(float2(node_x, center_y), 5.8f,
+            GetColorU32(ImGuiCol.WindowBg), 12, 1.4f)
+
+        var text_x = row_min.x + graph_width
+        var label_count = 0
+        for (ref in repository.refs) {
+            if (ref.worktree_path != worktree.path || ref.hash != commit.hash
+                    || ends_with(ref.name, "/HEAD") || label_count >= 3) continue
+            let label_size = CalcTextSize(ref.name)
+            let label_min = float2(text_x, center_y - label_size.y * 0.5f - 2.0f)
+            let label_max = float2(text_x + label_size.x + 10.0f,
+                center_y + label_size.y * 0.5f + 2.0f)
+            dl |> add_rect_filled(label_min, label_max,
+                git_graph_color(commit.hash, ref.current ? 0.52f : 0.28f),
+                4.0f, ImDrawFlags.None)
+            dl |> add_text(float2(text_x + 5.0f,
+                center_y - label_size.y * 0.5f),
+                GetColorU32(ImGuiCol.Text), ref.name)
+            text_x = label_max.x + 6.0f
+            label_count++
+        }
+        dl |> add_text(float2(text_x, center_y - GetTextLineHeight() * 0.5f),
+            GetColorU32(ImGuiCol.Text), commit.subject)
+    }
+
+    let hovered = IsItemHovered()
+    let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
+    let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
+    if (icon_button_draw_at("##{row_id}:copy-sha", "duplicate",
+            float2(row_max.x - icon_width, row_min.y), icon_size, 1.0f,
+            hovered)) {
+        let _ = clipboard_set_text(commit.hash)
+    }
+    if (hovered && IsItemHovered()) {
+        set_tooltip(GIT_HOVER_TOOLTIP, "Copy full SHA")
+    }
+
+    git_finish_lanes(commit, lane, lanes)
+}
+
+def private draw_commit_graph(repository : RepositorySnapshot const;
+                              worktree : WorktreeState const) {
+    var inscope lanes : array<string>
+    var inscope commit_indices : array<int>
+    commit_indices |> reserve(length(repository.history_commits))
+    for (index in range(length(repository.history_commits))) {
+        if (repository.history_commits[index].worktree_path == worktree.path) {
+            commit_indices |> push(index)
+        }
+    }
+    var graph_cursor = 0
+    list_clipper(length(commit_indices)) $(start, end_) {
+        while (graph_cursor < start) {
+            git_advance_lanes(repository.history_commits[
+                commit_indices[graph_cursor]], lanes)
+            graph_cursor++
+        }
+        for (row in range(start, end_)) {
+            let commit = repository.history_commits[commit_indices[row]]
+            GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == worktree.history_commit
+            var selected = false
+            with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
+                selected = selectable(GIT_HISTORY_COMMIT_ROW[row],
+                    (text = "{commit.short_hash}  {commit.subject}##graph:{commit.hash}"))
+            }
+            draw_commit_graph_decoration(repository, worktree, commit, lanes,
+                "graph:{commit.hash}")
+            if (selected && g_client != null
+                    && commit.hash != worktree.history_commit) {
+                g_client->request_repository_commit_files(
+                    repository.record.id, worktree.path, commit.hash)
+            }
+            graph_cursor++
+        }
+    }
+    if (worktree.history_loading) text_disabled("Reading commit graph...")
+    if (!empty(worktree.history_error)) {
+        text_colored(GIT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = worktree.history_error))
+    }
 }
 
 def private draw_tree_review(repository : RepositorySnapshot const;
@@ -1366,22 +1595,16 @@ def private draw_tree_review(repository : RepositorySnapshot const;
             g_client->request_repository_refs(repository.record.id, worktree.path)
         }
     }
-    var row = 0
-    let local_count = draw_ref_group(repository, worktree, false, row)
-    dummy(GIT_GROUP_SPACING[22], (size = float2(0.0f, GetStyle().ItemSpacing.y)))
-    let remote_count = draw_ref_group(repository, worktree, true, row)
     if (worktree.refs_loading) text_disabled("Reading local and remote branches...")
     if (!empty(worktree.refs_error)) {
         text_colored(GIT_ERROR,
             (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
             text = worktree.refs_error))
     }
-    if (local_count + remote_count == 0 && !worktree.refs_loading
-            && empty(worktree.refs_error)) {
-        text_disabled("No branches found")
-    }
+    ensure_history(repository, worktree, "__all__")
+    draw_commit_graph(repository, worktree)
     separator()
-    draw_history_commits(repository, worktree)
+    draw_commit_files(repository, worktree)
 }
 
 def private draw_git_status_window() {
@@ -1416,6 +1639,8 @@ def private draw_git_status_window() {
                     text_colored(GIT_ERROR, (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
                         text = repository.error))
                 }
+                separator()
+                draw_shared_pr_files(repository, worktree)
                 separator()
                 tab_bar(GIT_PERSPECTIVE_TABS,
                         (text = "Git perspectives", flags = ImGuiTabBarFlags.None)) {
@@ -1724,7 +1949,8 @@ def herder_git_review_state(_input : JsonValue?) : JsonValue? {
                     commits |> push(JV((hash = commit.hash,
                         short_hash = commit.short_hash,
                         authored_at = commit.authored_at,
-                        author = commit.author, subject = commit.subject)))
+                        author = commit.author, subject = commit.subject,
+                        parents = commit.parents)))
                 }
                 for (file in repository.review_files) {
                     if (file.worktree_path != worktree.path) continue
@@ -1732,6 +1958,9 @@ def herder_git_review_state(_input : JsonValue?) : JsonValue? {
                         repository, worktree.path, file.path)
                     included |> push(JV((code = file.code, path = file.path,
                         old_path = file.old_path,
+                        added_lines = file.added_lines,
+                        deleted_lines = file.deleted_lines,
+                        stats_known = file.stats_known, binary = file.binary,
                         staged = (!empty(status_code) && status_code != "??"
                             && git_status_byte(status_code, 0) != ' '))))
                 }
@@ -1740,7 +1969,10 @@ def herder_git_review_state(_input : JsonValue?) : JsonValue? {
                             || (file.code != "??"
                                 && git_status_byte(file.code, 1) == ' ')) continue
                     not_included |> push(JV((code = file.code,
-                        path = file.path, old_path = file.old_path)))
+                        path = file.path, old_path = file.old_path,
+                        added_lines = file.added_lines,
+                        deleted_lines = file.deleted_lines,
+                        stats_known = file.stats_known, binary = file.binary)))
                 }
                 return JV((ok = empty(worktree.review_error),
                     repository_id = repository.record.id,
@@ -1781,14 +2013,18 @@ def herder_git_history_state(_input : JsonValue?) : JsonValue? {
                     commits |> push(JV((hash = commit.hash,
                         short_hash = commit.short_hash,
                         authored_at = commit.authored_at,
-                        author = commit.author, subject = commit.subject)))
+                        author = commit.author, subject = commit.subject,
+                        parents = commit.parents)))
                 }
                 for (file in repository.commit_files) {
                     if (file.worktree_path != worktree.path
                             || file.commit_hash != worktree.history_commit) continue
                     files |> push(JV((commit_hash = file.commit_hash,
                         code = file.code, path = file.path,
-                        old_path = file.old_path)))
+                        old_path = file.old_path,
+                        added_lines = file.added_lines,
+                        deleted_lines = file.deleted_lines,
+                        stats_known = file.stats_known, binary = file.binary)))
                 }
                 return JV((ok = empty(worktree.history_error)
                         && empty(worktree.refs_error),
@@ -1818,6 +2054,12 @@ def herder_git_perspective(input : JsonValue?) : JsonValue? {
         GIT_HISTORY_TAB.pending_select = true
     } elif (perspective == "tree") {
         GIT_TREE_TAB.pending_select = true
+        if (g_client != null && g_client.connected
+                && !empty(g_selected_repository_id)
+                && !empty(g_selected_worktree_path)) {
+            g_client->request_repository_history(g_selected_repository_id,
+                g_selected_worktree_path, "__all__")
+        }
     } else {
         return JV((ok = false, error = "perspective must be pr, history, or tree"))
     }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -135,6 +135,10 @@ struct private HerderGitFileActionArgs {
     action : string
 }
 
+struct private HerderGitShaArgs {
+    sha : string
+}
+
 enum private GitInspectorMode {
     diff
     view
@@ -213,6 +217,12 @@ var private g_token : string
 var private g_selected_worktree_path : string
 var private g_selected_repository_id : string
 var private g_focus_terminal_pending = false
+var private g_requested_history_commit : string
+var private g_pending_clipboard_sha : string
+var private g_last_copied_sha : string
+var private g_clipboard_copy_status = ClipboardStatus.no_content
+var private g_clipboard_copy_attempts = 0
+var private g_clipboard_copy_verified = false
 var private g_inspector = GitInspectorState()
 var private g_prepare_worker = InspectorPrepareWorker()
 var private g_jobque_owned = false
@@ -1112,6 +1122,32 @@ def private git_line_stats(added_lines, deleted_lines : int;
     return "+{added_lines}  -{deleted_lines}"
 }
 
+def private service_sha_copy() {
+    if (empty(g_pending_clipboard_sha)) return
+    if (g_clipboard_copy_attempts >= 8) {
+        g_pending_clipboard_sha = ""
+        return
+    }
+    g_clipboard_copy_attempts++
+    g_clipboard_copy_status = clipboard_set_text(g_pending_clipboard_sha)
+    if (g_clipboard_copy_status != ClipboardStatus.ok) return
+    var copied_text = ""
+    g_clipboard_copy_status = clipboard_get_text(copied_text)
+    if (g_clipboard_copy_status == ClipboardStatus.ok
+            && copied_text == g_pending_clipboard_sha) {
+        g_last_copied_sha = g_pending_clipboard_sha
+        g_pending_clipboard_sha = ""
+        g_clipboard_copy_verified = true
+    }
+}
+
+def private queue_sha_copy(hash : string) {
+    g_pending_clipboard_sha = hash
+    g_clipboard_copy_attempts = 0
+    g_clipboard_copy_verified = false
+    service_sha_copy()
+}
+
 def private draw_git_path_text(path : string; p0, p1 : float2;
                                subdued : bool) {
     let alpha = subdued ? 0.55f : 1.0f
@@ -1136,11 +1172,30 @@ def private draw_git_path_text(path : string; p0, p1 : float2;
     }
 }
 
-def private draw_git_stats_text(position : float2; color : uint;
-                                stats : string) {
+def private draw_git_stats_text(position : float2;
+                                added_lines, deleted_lines : int;
+                                stats_known, binary, subdued : bool) {
+    let alpha = subdued ? 0.55f : 1.0f
     with_window_drawlist() $(var dl) {
-        dl |> add_text(position, color, stats)
+        if (binary || !stats_known) {
+            let stats = binary ? "binary" : "+?  -?"
+            dl |> add_text(position, GetColorU32(ImGuiCol.TextDisabled), stats)
+        } else {
+            let added = "+{added_lines}"
+            let deleted = "-{deleted_lines}"
+            dl |> add_text(position,
+                GetColorU32(float4(0.42f, 0.82f, 0.42f, alpha)), added)
+            dl |> add_text(float2(position.x + CalcTextSize(added).x
+                    + GetStyle().ItemSpacing.x, position.y),
+                GetColorU32(float4(0.37f, 0.65f, 0.96f, alpha)), deleted)
+        }
     }
+}
+
+def private git_visible_row_right(row_right : float) : float {
+    let style & = GetStyle()
+    let window_right = GetWindowPos().x + GetWindowSize().x - style.WindowPadding.x - style.ScrollbarSize
+    return min(row_right, window_right)
 }
 
 def private decorate_git_file_row(row_id, path : string;
@@ -1151,10 +1206,11 @@ def private decorate_git_file_row(row_id, path : string;
     let stats = git_line_stats(added_lines, deleted_lines, stats_known, binary)
     let row_min = GetItemRectMin()
     let row_max = GetItemRectMax()
+    let row_right = git_visible_row_right(row_max.x)
     let hovered = IsItemHovered()
     let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
     let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
-    let action_x = row_max.x - icon_width
+    let action_x = row_right - icon_width
     let stats_size = CalcTextSize(stats)
     let stats_x = max(row_min.x, action_x - stats_size.x - GetStyle().ItemSpacing.x)
     let text_y = row_min.y + max(0.0f,
@@ -1162,8 +1218,8 @@ def private decorate_git_file_row(row_id, path : string;
     draw_git_path_text(path,
         float2(row_min.x + GetStyle().FramePadding.x, text_y),
         float2(stats_x - GetStyle().ItemSpacing.x, row_max.y), subdued)
-    let stats_color = binary || !stats_known ? GetColorU32(ImGuiCol.TextDisabled) : GetColorU32(float4(0.61f, 0.78f, 0.52f, subdued ? 0.55f : 1.0f))
-    draw_git_stats_text(float2(stats_x, text_y), stats_color, stats)
+    draw_git_stats_text(float2(stats_x, text_y), added_lines, deleted_lines,
+        stats_known, binary, subdued)
     action_clicked = false
     if (!empty(action_glyph)) {
         action_clicked = icon_button_draw_at("##{row_id}:action", action_glyph,
@@ -1196,9 +1252,11 @@ def private draw_pr_included_files(repository : RepositorySnapshot const;
         let stats = git_line_stats(file.added_lines, file.deleted_lines,
             file.stats_known, file.binary)
         var selected = false
-        with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
-            selected = selectable(GIT_FILE_ROW[file_row],
-                (text = "{file.path}  {stats}##pr:{file.path}"))
+        with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
+            with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
+                selected = selectable(GIT_FILE_ROW[file_row],
+                    (text = "{file.path}  {stats}##pr:{file.path}"))
+            }
         }
         decorate_git_file_row("pr:{file.path}", file.path, file.added_lines,
             file.deleted_lines, file.stats_known, file.binary, false,
@@ -1240,9 +1298,11 @@ def private draw_pr_not_included_files(repository : RepositorySnapshot const;
         let stats = git_line_stats(file.added_lines, file.deleted_lines,
             file.stats_known, file.binary)
         var selected = false
-        with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
-            selected = selectable(GIT_FILE_ROW[file_row],
-                (text = "{file.path}  {stats}##working:{file.path}"))
+        with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
+            with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
+                selected = selectable(GIT_FILE_ROW[file_row],
+                    (text = "{file.path}  {stats}##working:{file.path}"))
+            }
         }
         decorate_git_file_row("working:{file.path}", file.path, file.added_lines,
             file.deleted_lines, file.stats_known, file.binary, true,
@@ -1287,13 +1347,14 @@ def private draw_shared_pr_files(repository : RepositorySnapshot const;
 def private draw_sha_copy_icon(hash, row_id : string) {
     let row_min = GetItemRectMin()
     let row_max = GetItemRectMax()
+    let row_right = git_visible_row_right(row_max.x)
     let hovered = IsItemHovered()
     let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
     let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
     if (icon_button_draw_at("##{row_id}:copy-sha", "duplicate",
-            float2(row_max.x - icon_width, row_min.y), icon_size, 1.0f,
+            float2(row_right - icon_width, row_min.y), icon_size, 1.0f,
             hovered)) {
-        let _ = clipboard_set_text(hash)
+        queue_sha_copy(hash)
     }
     if (hovered && IsItemHovered()) {
         set_tooltip(GIT_HOVER_TOOLTIP, "Copy full SHA")
@@ -1314,8 +1375,10 @@ def private draw_pr_review(repository : RepositorySnapshot const;
     var commit_row = 0
     for (commit in repository.review_commits) {
         if (commit.worktree_path != worktree.path) continue
-        text(GIT_COMMIT_TEXT[commit_row],
-            (text = "{commit.short_hash}  {commit.subject}  - {commit.author}"))
+        with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
+            text(GIT_COMMIT_TEXT[commit_row],
+                (text = "{commit.short_hash}  {commit.subject}  - {commit.author}"))
+        }
         draw_sha_copy_icon(commit.hash, "pr-commit:{commit.hash}")
         commit_row++
     }
@@ -1335,29 +1398,55 @@ def private ensure_history(repository : RepositorySnapshot const;
     }
 }
 
+def private request_commit_files(repository : RepositorySnapshot const;
+                                 worktree : WorktreeState const;
+                                 commit_hash : string) {
+    if (g_client == null || empty(commit_hash)) return
+    g_requested_history_commit = commit_hash
+    g_client->request_repository_commit_files(
+        repository.record.id, worktree.path, commit_hash)
+}
+
 def private draw_commit_files(repository : RepositorySnapshot const;
                               worktree : WorktreeState const) {
+    if (!empty(g_requested_history_commit)
+            && g_requested_history_commit == worktree.history_commit) {
+        g_requested_history_commit = ""
+    }
+    let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
     var count = 0
     for (file in repository.commit_files) {
         if (file.worktree_path == worktree.path
-                && file.commit_hash == worktree.history_commit) count++
+                && file.commit_hash == selected_commit) count++
     }
     text(GIT_GROUP_TITLE[21],
-        (text = "FILES IN {worktree.history_commit}  {count}"))
+        (text = "FILES IN {selected_commit}  {count}"))
     separator(GIT_GROUP_SEPARATOR[21])
+    if (!empty(g_requested_history_commit)) {
+        text_disabled("Loading selected commit files...")
+        return
+    }
     var row = 0
     for (file in repository.commit_files) {
         if (file.worktree_path != worktree.path
-                || file.commit_hash != worktree.history_commit) continue
+                || file.commit_hash != selected_commit) continue
         GIT_COMMIT_FILE_ROW[row].value = (g_inspector.repository_id == repository.record.id
             && g_inspector.worktree_path == worktree.path
             && g_inspector.file_path == file.path
             && g_inspector.comparison == "commit"
             && g_inspector.git_revision == file.commit_hash)
-        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
-        if (selectable(GIT_COMMIT_FILE_ROW[row],
-                (text = "{file.code}  {file.path}{old_label}##commit:{file.commit_hash}:{file.path}"))
-                && g_client != null) {
+        let stats = git_line_stats(file.added_lines, file.deleted_lines,
+            file.stats_known, file.binary)
+        var selected = false
+        with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
+            selected = selectable(GIT_COMMIT_FILE_ROW[row],
+                (text = "{file.path}  {stats}##commit:{file.commit_hash}:{file.path}"))
+        }
+        var ignored_action = false
+        decorate_git_file_row("commit:{file.commit_hash}:{file.path}",
+            file.path, file.added_lines, file.deleted_lines,
+            file.stats_known, file.binary, false, "", "", ignored_action)
+        if (selected && g_client != null) {
             g_client->inspect_file(repository.record.id, worktree.path,
                 file.path, "commit", "compact", file.commit_hash)
             FILE_INSPECTOR_WIN.open = true
@@ -1383,12 +1472,15 @@ def private draw_history_commits(repository : RepositorySnapshot const;
     var row = 0
     for (commit in repository.history_commits) {
         if (commit.worktree_path != worktree.path) continue
-        GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == worktree.history_commit
-        if (selectable(GIT_HISTORY_COMMIT_ROW[row],
+        let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
+        GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == selected_commit
+        var selected = false
+        with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
+            selected = selectable(GIT_HISTORY_COMMIT_ROW[row],
                 (text = "{commit.short_hash}  {commit.subject}  - {commit.author}##history:{commit.hash}"))
-                && g_client != null && commit.hash != worktree.history_commit) {
-            g_client->request_repository_commit_files(
-                repository.record.id, worktree.path, commit.hash)
+        }
+        if (selected && g_client != null && commit.hash != selected_commit) {
+            request_commit_files(repository, worktree, commit.hash)
         }
         draw_sha_copy_icon(commit.hash, "history:{commit.hash}")
         row++
@@ -1399,8 +1491,6 @@ def private draw_history_commits(repository : RepositorySnapshot const;
             (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
             text = worktree.history_error))
     }
-    separator()
-    draw_commit_files(repository, worktree)
 }
 
 def private draw_history_review(repository : RepositorySnapshot const;
@@ -1427,6 +1517,7 @@ def private git_graph_color(hash : string; alpha : float = 1.0f) : uint {
 }
 
 def private git_prepare_lanes(commit : GitCommitState const;
+                              observed : table<string; bool> const;
                               var lanes : array<string>) : int {
     var lane = git_lane_index(lanes, commit.hash)
     if (lane < 0) {
@@ -1435,7 +1526,7 @@ def private git_prepare_lanes(commit : GitCommitState const;
     }
     var parent_number = 0
     for (parent in split(commit.parents, " ")) {
-        if (empty(parent)) continue
+        if (empty(parent) || !key_exists(observed, parent)) continue
         if (parent_number > 0 && git_lane_index(lanes, parent) < 0) {
             lanes |> push(parent)
         }
@@ -1445,10 +1536,11 @@ def private git_prepare_lanes(commit : GitCommitState const;
 }
 
 def private git_finish_lanes(commit : GitCommitState const; lane : int;
+                             observed : table<string; bool> const;
                              var lanes : array<string>) {
     var first_parent = ""
     for (parent in split(commit.parents, " ")) {
-        if (!empty(parent)) {
+        if (!empty(parent) && key_exists(observed, parent)) {
             first_parent = parent
             break
         }
@@ -1466,23 +1558,23 @@ def private git_finish_lanes(commit : GitCommitState const; lane : int;
 }
 
 def private git_advance_lanes(commit : GitCommitState const;
+                              observed : table<string; bool> const;
                               var lanes : array<string>) {
-    let lane = git_prepare_lanes(commit, lanes)
-    git_finish_lanes(commit, lane, lanes)
+    let lane = git_prepare_lanes(commit, observed, lanes)
+    git_finish_lanes(commit, lane, observed, lanes)
 }
 
-def private draw_commit_graph_decoration(repository : RepositorySnapshot const;
-                                         worktree : WorktreeState const;
-                                         commit : GitCommitState const;
+def private draw_commit_graph_decoration(commit : GitCommitState const;
+                                         observed : table<string; bool> const;
                                          var lanes : array<string>;
                                          row_id : string) {
-    let lane = git_prepare_lanes(commit, lanes)
+    let lane = git_prepare_lanes(commit, observed, lanes)
     let row_min = GetItemRectMin()
     let row_max = GetItemRectMax()
+    let row_right = git_visible_row_right(row_max.x)
     let center_y = (row_min.y + row_max.y) * 0.5f
     let lane_spacing = 14.0f
     let graph_x = row_min.x + 8.0f
-    let graph_width = 126.0f
     var inscope parents <- split(commit.parents, " ")
     with_window_drawlist() $(var dl) {
         for (index in range(length(lanes))) {
@@ -1493,7 +1585,7 @@ def private draw_commit_graph_decoration(repository : RepositorySnapshot const;
         let node_x = graph_x + float(lane) * lane_spacing
         var parent_number = 0
         for (parent in parents) {
-            if (empty(parent)) continue
+            if (empty(parent) || !key_exists(observed, parent)) continue
             if (parent_number > 0) {
                 let parent_lane = git_lane_index(lanes, parent)
                 let parent_x = graph_x + float(parent_lane) * lane_spacing
@@ -1506,75 +1598,75 @@ def private draw_commit_graph_decoration(repository : RepositorySnapshot const;
             git_graph_color(commit.hash), 12)
         dl |> add_circle(float2(node_x, center_y), 5.8f,
             GetColorU32(ImGuiCol.WindowBg), 12, 1.4f)
-
-        var text_x = row_min.x + graph_width
-        var label_count = 0
-        for (ref in repository.refs) {
-            if (ref.worktree_path != worktree.path || ref.hash != commit.hash
-                    || ends_with(ref.name, "/HEAD") || label_count >= 3) continue
-            let label_size = CalcTextSize(ref.name)
-            let label_min = float2(text_x, center_y - label_size.y * 0.5f - 2.0f)
-            let label_max = float2(text_x + label_size.x + 10.0f,
-                center_y + label_size.y * 0.5f + 2.0f)
-            dl |> add_rect_filled(label_min, label_max,
-                git_graph_color(commit.hash, ref.current ? 0.52f : 0.28f),
-                4.0f, ImDrawFlags.None)
-            dl |> add_text(float2(text_x + 5.0f,
-                center_y - label_size.y * 0.5f),
-                GetColorU32(ImGuiCol.Text), ref.name)
-            text_x = label_max.x + 6.0f
-            label_count++
-        }
-        dl |> add_text(float2(text_x, center_y - GetTextLineHeight() * 0.5f),
-            GetColorU32(ImGuiCol.Text), commit.subject)
     }
 
     let hovered = IsItemHovered()
     let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
     let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
     if (icon_button_draw_at("##{row_id}:copy-sha", "duplicate",
-            float2(row_max.x - icon_width, row_min.y), icon_size, 1.0f,
+            float2(row_right - icon_width, row_min.y), icon_size, 1.0f,
             hovered)) {
-        let _ = clipboard_set_text(commit.hash)
+        queue_sha_copy(commit.hash)
     }
     if (hovered && IsItemHovered()) {
         set_tooltip(GIT_HOVER_TOOLTIP, "Copy full SHA")
     }
 
-    git_finish_lanes(commit, lane, lanes)
+    git_finish_lanes(commit, lane, observed, lanes)
+}
+
+def private git_graph_refs(repository : RepositorySnapshot const;
+                           worktree : WorktreeState const;
+                           commit : GitCommitState const) : string {
+    var inscope names : array<string>
+    names |> reserve(3)
+    var count = 0
+    for (ref in repository.refs) {
+        if (ref.worktree_path != worktree.path || ref.hash != commit.hash
+                || ends_with(ref.name, "/HEAD") || count >= 3) continue
+        names |> push("[{ref.name}]")
+        count++
+    }
+    return join(names, " ")
 }
 
 def private draw_commit_graph(repository : RepositorySnapshot const;
                               worktree : WorktreeState const) {
     var inscope lanes : array<string>
     var inscope commit_indices : array<int>
+    var inscope observed : table<string; bool>
     commit_indices |> reserve(length(repository.history_commits))
     for (index in range(length(repository.history_commits))) {
         if (repository.history_commits[index].worktree_path == worktree.path) {
             commit_indices |> push(index)
+            observed[repository.history_commits[index].hash] = true
         }
     }
     var graph_cursor = 0
     list_clipper(length(commit_indices)) $(start, end_) {
         while (graph_cursor < start) {
             git_advance_lanes(repository.history_commits[
-                commit_indices[graph_cursor]], lanes)
+                commit_indices[graph_cursor]], observed, lanes)
             graph_cursor++
         }
         for (row in range(start, end_)) {
             let commit = repository.history_commits[commit_indices[row]]
-            GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == worktree.history_commit
+            let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
+            GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == selected_commit
+            let refs = git_graph_refs(repository, worktree, commit)
+            let ref_text = empty(refs) ? "" : "{refs}  "
+            let space_width = max(1.0f, CalcTextSize(" ").x)
+            let graph_pad = repeat(" ", int(56.0f / space_width) + 1)
             var selected = false
-            with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
+            with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
                 selected = selectable(GIT_HISTORY_COMMIT_ROW[row],
-                    (text = "{commit.short_hash}  {commit.subject}##graph:{commit.hash}"))
+                    (text = "{graph_pad}{commit.short_hash}  {ref_text}{commit.subject}  - {commit.author}##graph:{commit.hash}"))
             }
-            draw_commit_graph_decoration(repository, worktree, commit, lanes,
+            draw_commit_graph_decoration(commit, observed, lanes,
                 "graph:{commit.hash}")
             if (selected && g_client != null
-                    && commit.hash != worktree.history_commit) {
-                g_client->request_repository_commit_files(
-                    repository.record.id, worktree.path, commit.hash)
+                    && commit.hash != selected_commit) {
+                request_commit_files(repository, worktree, commit.hash)
             }
             graph_cursor++
         }
@@ -1603,8 +1695,6 @@ def private draw_tree_review(repository : RepositorySnapshot const;
     }
     ensure_history(repository, worktree, "__all__")
     draw_commit_graph(repository, worktree)
-    separator()
-    draw_commit_files(repository, worktree)
 }
 
 def private draw_git_status_window() {
@@ -1640,7 +1730,11 @@ def private draw_git_status_window() {
                         text = repository.error))
                 }
                 separator()
-                draw_shared_pr_files(repository, worktree)
+                if (GIT_HISTORY_TAB.selected || GIT_TREE_TAB.selected) {
+                    draw_commit_files(repository, worktree)
+                } else {
+                    draw_shared_pr_files(repository, worktree)
+                }
                 separator()
                 tab_bar(GIT_PERSPECTIVE_TABS,
                         (text = "Git perspectives", flags = ImGuiTabBarFlags.None)) {
@@ -1918,6 +2012,7 @@ def herder_git_select_worktree(input : JsonValue?) : JsonValue? {
             if (worktree.path != args.worktree_path) continue
             g_selected_repository_id = args.repository_id
             g_selected_worktree_path = args.worktree_path
+            g_requested_history_commit = ""
             g_client->refresh_repository(args.repository_id)
             g_client->request_repository_review(
                 args.repository_id, args.worktree_path)
@@ -2033,6 +2128,7 @@ def herder_git_history_state(_input : JsonValue?) : JsonValue? {
                     branch = worktree.branch,
                     history_ref = worktree.history_ref,
                     history_commit = worktree.history_commit,
+                    requested_history_commit = g_requested_history_commit,
                     history_loading = worktree.history_loading,
                     history_error = worktree.history_error,
                     refs_loading = worktree.refs_loading,
@@ -2042,6 +2138,54 @@ def herder_git_history_state(_input : JsonValue?) : JsonValue? {
         }
     }
     return JV((ok = false, error = "selected worktree is unavailable"))
+}
+
+[live_command(description = "Select a commit and load its changelist. Args: sha.")]
+def herder_git_select_commit(input : JsonValue?) : JsonValue? {
+    if (g_client == null || !g_client.connected) {
+        return JV((ok = false, error = "watcher is not connected"))
+    }
+    let args = from_JV(input, type<HerderGitShaArgs>)
+    for (repository in g_client.repositories) {
+        if (repository.record.id != g_selected_repository_id) continue
+        for (worktree in repository.worktrees) {
+            if (worktree.path != g_selected_worktree_path) continue
+            for (commit in repository.history_commits) {
+                if (commit.worktree_path == worktree.path
+                        && commit.hash == args.sha) {
+                    request_commit_files(repository, worktree, commit.hash)
+                    return JV((ok = true, sha = commit.hash))
+                }
+            }
+        }
+    }
+    return JV((ok = false, error = "commit is not present in the observed history"))
+}
+
+[live_command(description = "Copy a Git SHA through the same verified clipboard path used by hover controls. Args: sha.")]
+def herder_git_copy_sha(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<HerderGitShaArgs>)
+    if (empty(args.sha)) return JV((ok = false, error = "sha is empty"))
+    queue_sha_copy(args.sha)
+    return JV((ok = g_clipboard_copy_verified,
+        sha = args.sha,
+        status = int(g_clipboard_copy_status),
+        pending = !empty(g_pending_clipboard_sha)))
+}
+
+[live_command(description = "Inspect the last Git SHA clipboard write without exposing unrelated clipboard contents.")]
+def herder_git_clipboard_state(_input : JsonValue?) : JsonValue? {
+    var copied_text = ""
+    let read_status = clipboard_get_text(copied_text)
+    let expected = !empty(g_pending_clipboard_sha) ? g_pending_clipboard_sha : g_last_copied_sha
+    return JV((ok = g_clipboard_copy_verified && read_status == ClipboardStatus.ok
+            && copied_text == expected,
+        last_sha = g_last_copied_sha,
+        pending_sha = g_pending_clipboard_sha,
+        write_status = int(g_clipboard_copy_status),
+        read_status = int(read_status),
+        attempts = g_clipboard_copy_attempts,
+        matches = read_status == ClipboardStatus.ok && copied_text == expected))
 }
 
 [live_command(description = "Switch Git Status perspective. Args: perspective = pr | history | tree.")]
@@ -2361,6 +2505,7 @@ def init() {
 def update() {
     if (!harness_begin_frame()) return
     if (g_client != null) g_client->pump()
+    service_sha_copy()
     drain_inspector_prepare_events()
     harness_new_frame()
     GetStyle().FontScaleMain = float(g_zoom_percent) / 100.0f

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -157,6 +157,8 @@ let INSPECTOR_CONTEXT_VALUES : array<string> <- [
 let TREE_FILTER_LABELS : array<string> <- ["Auto", "All"]
 
 struct private GitInspectorState {
+    // Request identity changes immediately when the user picks a file. The
+    // installed identity changes only when its prepared document is ready.
     request_id : int
     repository_id : string
     worktree_path : string
@@ -164,6 +166,16 @@ struct private GitInspectorState {
     comparison : string
     git_revision : string
     diff_context : string = "compact"
+    installed_repository_id : string
+    installed_worktree_path : string
+    installed_file_path : string
+    installed_comparison : string
+    installed_git_revision : string
+    installed_diff_context : string = "compact"
+    installed_diff_context_choice : int
+    installed_syntax_choice : int
+    prepare_language : string
+    pending_select_diff : bool
     task_session_id : string
     loading : bool
     status : string
@@ -262,7 +274,8 @@ var private GIT_CHANGELIST_STATUS_TEXT : NarrativeState
 var private GIT_ACTIVITY_STATUS_TEXT : NarrativeState
 var private GIT_CHANGELIST_STATUS_SEPARATOR : EmptyMarkerState
 var private GIT_ACTIVITY_STATUS_SEPARATOR : EmptyMarkerState
-var private INSPECTOR_CONNECTION_ERROR : NarrativeState
+var private INSPECTOR_STATUS_TEXT : NarrativeState
+var private INSPECTOR_STATUS_SEPARATOR : EmptyMarkerState
 
 def private setup_default_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
@@ -359,13 +372,13 @@ def private release_inspector_content() {
 def private queue_inspector_prepare(status : string) {
     let choice = clamp(g_inspector.syntax_choice, 0,
         length(INSPECTOR_SYNTAX_VALUES) - 1)
-    g_inspector.resolved_language = inspector_language_for_path(
+    g_inspector.prepare_language = inspector_language_for_path(
         g_inspector.file_path, INSPECTOR_SYNTAX_VALUES[choice])
     let generation = inspector_load_queue(g_inspector.prepare, status)
     g_inspector.error = ""
     if (!inspector_prepare_worker_queue(g_prepare_worker, generation,
             g_inspector.source_patch, g_inspector.source_view_text,
-            g_inspector.resolved_language, g_inspector.source_view_base64,
+            g_inspector.prepare_language, g_inspector.source_view_base64,
             g_inspector.source_view_byte_count,
             g_inspector.source_view_available)) {
         let failure = "File inspection preparation worker is unavailable"
@@ -422,6 +435,22 @@ def private drain_inspector_prepare_events() {
             g_inspector.changed_source_ranges <- event.changed_source_ranges
             g_inspector.view_source = clone_string(event.view_source)
             g_inspector.view_prepared = !g_inspector.parsed.binary
+            g_inspector.installed_repository_id = g_inspector.repository_id
+            g_inspector.installed_worktree_path = g_inspector.worktree_path
+            g_inspector.installed_file_path = g_inspector.file_path
+            g_inspector.installed_comparison = g_inspector.comparison
+            g_inspector.installed_git_revision = g_inspector.git_revision
+            g_inspector.installed_diff_context = g_inspector.diff_context
+            g_inspector.installed_diff_context_choice = g_inspector.diff_context_choice
+            g_inspector.installed_syntax_choice = g_inspector.syntax_choice
+            g_inspector.resolved_language = g_inspector.prepare_language
+            DIFF_CONTEXT.value = g_inspector.installed_diff_context_choice
+            DIFF_SYNTAX.value = g_inspector.installed_syntax_choice
+            if (g_inspector.pending_select_diff) {
+                g_inspector.mode = GitInspectorMode.diff
+                INSPECTOR_DIFF_TAB.pending_select = true
+            }
+            g_inspector.pending_select_diff = false
             upload_inspector_preview(
                 unsafe(reinterpret<InspectorPrepareEvent const#>(event)))
             g_inspector.error = ""
@@ -434,7 +463,7 @@ def private begin_file_inspection(repository_id, worktree_path, file_path,
                                   comparison, diff_context : string;
                                   git_revision : string = "") {
     let same_identity = g_inspector.repository_id == repository_id && g_inspector.worktree_path == worktree_path && g_inspector.file_path == file_path && g_inspector.comparison == comparison && g_inspector.git_revision == git_revision
-    let same_content = g_inspector.prepare.has_retained_content && same_identity
+    let retained_content = g_inspector.prepare.has_retained_content
     g_inspector.request_id++
     g_inspector.repository_id = repository_id
     g_inspector.worktree_path = worktree_path
@@ -448,29 +477,23 @@ def private begin_file_inspection(repository_id, worktree_path, file_path,
     } elif (diff_context == "full") {
         g_inspector.diff_context_choice = 2
     }
-    DIFF_CONTEXT.value = g_inspector.diff_context_choice
     g_inspector.task_session_id = ""
     g_inspector.loading = true
     g_inspector.status = "Requesting diff..."
     g_inspector.error = ""
     if (!same_identity) {
-        g_inspector.source_patch = ""
-        g_inspector.source_view_text = ""
-        g_inspector.source_view_base64 = ""
-        g_inspector.source_view_byte_count = 0
-        g_inspector.source_view_available = false
         g_inspector.syntax_choice = 0
-        g_inspector.resolved_language = inspector_language_for_path(file_path)
-        DIFF_SYNTAX.value = 0
+        g_inspector.prepare_language = inspector_language_for_path(file_path)
     }
-    if (same_content) {
+    g_inspector.pending_select_diff = !same_identity
+    if (retained_content) {
         inspector_load_supersede(g_inspector.prepare, "Requesting diff...")
     } else {
         release_inspector_content()
         inspector_load_reset(g_inspector.prepare)
+        g_inspector.mode = GitInspectorMode.diff
+        INSPECTOR_DIFF_TAB.pending_select = true
     }
-    g_inspector.mode = GitInspectorMode.diff
-    INSPECTOR_DIFF_TAB.pending_select = true
 }
 
 class private WatcherRichClient : HvWebSocketClient {
@@ -2053,28 +2076,39 @@ def private draw_side_by_side_diff() {
     }
     let hunk_count = length(g_inspector.parsed.hunks)
     g_inspector.diff_current_hunk = hunk_count > 0 ? clamp(g_inspector.diff_current_hunk, 0, hunk_count - 1) : 0
-    SetNextItemWidth(150.0f)
-    combo(DIFF_CONTEXT,
-        (text = "Context", items <- INSPECTOR_CONTEXT_LABELS))
+    let replacement_busy = (g_inspector.loading
+        || g_inspector.prepare.request != InspectorRequestState.idle)
+    with_disabled(replacement_busy) {
+        SetNextItemWidth(150.0f)
+        combo(DIFF_CONTEXT,
+            (text = "Context", items <- INSPECTOR_CONTEXT_LABELS))
+        same_line()
+        SetNextItemWidth(150.0f)
+        combo(DIFF_SYNTAX, (text = "Syntax", items <- INSPECTOR_SYNTAX_LABELS))
+    }
     let selected_context = clamp(DIFF_CONTEXT.value, 0,
         length(INSPECTOR_CONTEXT_VALUES) - 1)
-    if (selected_context != g_inspector.diff_context_choice
+    if (!replacement_busy
+            && selected_context != g_inspector.installed_diff_context_choice
             && g_client != null && g_client.connected) {
-        g_client->inspect_file(g_inspector.repository_id,
-            g_inspector.worktree_path, g_inspector.file_path,
-            g_inspector.comparison, INSPECTOR_CONTEXT_VALUES[selected_context],
-            g_inspector.git_revision)
+        g_client->inspect_file(g_inspector.installed_repository_id,
+            g_inspector.installed_worktree_path, g_inspector.installed_file_path,
+            g_inspector.installed_comparison, INSPECTOR_CONTEXT_VALUES[selected_context],
+            g_inspector.installed_git_revision)
     }
-    same_line()
-    SetNextItemWidth(150.0f)
-    combo(DIFF_SYNTAX, (text = "Syntax", items <- INSPECTOR_SYNTAX_LABELS))
     let selected_syntax = clamp(DIFF_SYNTAX.value, 0,
         length(INSPECTOR_SYNTAX_VALUES) - 1)
-    if (selected_syntax != g_inspector.syntax_choice) {
+    if (!replacement_busy
+            && selected_syntax != g_inspector.installed_syntax_choice) {
+        g_inspector.repository_id = g_inspector.installed_repository_id
+        g_inspector.worktree_path = g_inspector.installed_worktree_path
+        g_inspector.file_path = g_inspector.installed_file_path
+        g_inspector.comparison = g_inspector.installed_comparison
+        g_inspector.git_revision = g_inspector.installed_git_revision
+        g_inspector.diff_context = g_inspector.installed_diff_context
+        g_inspector.diff_context_choice = g_inspector.installed_diff_context_choice
         g_inspector.syntax_choice = selected_syntax
-        g_inspector.resolved_language = inspector_language_for_path(
-            g_inspector.file_path,
-            INSPECTOR_SYNTAX_VALUES[g_inspector.syntax_choice])
+        g_inspector.pending_select_diff = false
         if (!empty(g_inspector.source_patch)) {
             queue_inspector_prepare("Applying syntax...")
         }
@@ -2520,13 +2554,20 @@ def herder_git_file_action(input : JsonValue?) : JsonValue? {
 def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
     let view_selection = text_source_view_selection(g_inspector.view)
     return JV((
-        ok = !empty(g_inspector.file_path) && !g_inspector.loading
-            && empty(g_inspector.error),
+        ok = g_inspector.prepare.has_retained_content,
         repository_id = g_inspector.repository_id,
         worktree_path = g_inspector.worktree_path,
         file_path = g_inspector.file_path,
         comparison = g_inspector.comparison,
         git_revision = g_inspector.git_revision,
+        installed_repository_id = g_inspector.installed_repository_id,
+        installed_worktree_path = g_inspector.installed_worktree_path,
+        installed_file_path = g_inspector.installed_file_path,
+        installed_comparison = g_inspector.installed_comparison,
+        installed_git_revision = g_inspector.installed_git_revision,
+        installed_diff_context = g_inspector.installed_diff_context,
+        replacement_busy = (g_inspector.loading
+            || g_inspector.prepare.request != InspectorRequestState.idle),
         zoom_percent = g_zoom_percent,
         diff_context = g_inspector.diff_context,
         diff_context_choice = g_inspector.diff_context_choice,
@@ -2554,6 +2595,7 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         diff_right_rect = g_inspector.diff_right_rect,
         diff_scrollbar_rect = g_inspector.diff_scrollbar_rect,
         syntax_choice = g_inspector.syntax_choice,
+        installed_syntax_choice = g_inspector.installed_syntax_choice,
         resolved_language = g_inspector.resolved_language,
         binary = g_inspector.parsed.binary,
         preview_texture_ready = g_inspector.preview_texture != 0u,
@@ -2672,43 +2714,51 @@ def herder_file_inspector_mode(input : JsonValue?) : JsonValue? {
     return JV((ok = true, mode = mode))
 }
 
-def private draw_file_inspector_window() {
+def private file_inspector_status() : GitWindowStatus {
+    if (g_client == null || !g_client.connected) {
+        return GitWindowStatus(text = "WATCHER DISCONNECTED - reconnecting...", error = true)
+    }
+    let retained = g_inspector.prepare.has_retained_content
+    let showing = retained ? " - showing {g_inspector.installed_file_path}" : ""
+    if (g_inspector.loading) {
+        let phase = empty(g_inspector.status) ? "Reading Git diff..." : g_inspector.status
+        return GitWindowStatus(
+            text = "LOADING {g_inspector.file_path} - {phase}{showing}", busy = true)
+    }
+    if (g_inspector.prepare.request != InspectorRequestState.idle) {
+        let phase = (empty(g_inspector.prepare.status)
+            ? "Preparing view..." : g_inspector.prepare.status)
+        return GitWindowStatus(
+            text = "PREPARING {g_inspector.file_path} - {phase}{showing}", busy = true)
+    }
+    if (!empty(g_inspector.error)) {
+        let task = (empty(g_inspector.task_session_id)
+            ? "" : "   TASK {g_inspector.task_session_id}")
+        return GitWindowStatus(
+            text = "FAILED {g_inspector.file_path} - {g_inspector.error}{showing}{task}", error = true)
+    }
+    if (retained) {
+        return GitWindowStatus(text = "{to_upper(g_inspector.installed_comparison)}  {g_inspector.installed_file_path}   HUNKS {length(g_inspector.parsed.hunks)}   PREP {g_inspector.prepare_elapsed_usec / 1000l} ms")
+    }
+    return GitWindowStatus(text = "Select a changed file")
+}
+
+def private draw_file_inspector_content() {
     let io & = unsafe(GetIO())
     if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
         if (io.MouseWheel > 0.0f) zoom_by(5)
         elif (io.MouseWheel < 0.0f) zoom_by(-5)
     }
-    if (g_client == null || !g_client.connected) {
-        text_colored(INSPECTOR_CONNECTION_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = "WATCHER DISCONNECTED - reconnecting..."))
-    }
-    if (empty(g_inspector.file_path)) {
-        text_disabled("Select a changed file")
+    if (!g_inspector.prepare.has_retained_content) {
+        if (empty(g_inspector.file_path)) {
+            text_disabled("Select a changed file")
+        }
         return
     }
-    text(INSPECTOR_PATH, (text = g_inspector.file_path))
+    text(INSPECTOR_PATH, (text = g_inspector.installed_file_path))
     same_line()
-    text_disabled(INSPECTOR_SCOPE, (text = to_upper(g_inspector.comparison)))
-    if (g_inspector.loading) {
-        text_disabled(INSPECTOR_LOADING,
-            (text = empty(g_inspector.status) ? "Loading diff..." : g_inspector.status))
-        if (!g_inspector.prepare.has_retained_content) return
-    }
-    if (!empty(g_inspector.error)) {
-        text_colored(INSPECTOR_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f), text = g_inspector.error))
-        if (!empty(g_inspector.task_session_id)) {
-            text_disabled("Task: {g_inspector.task_session_id}")
-        }
-        if (!g_inspector.prepare.has_retained_content) return
-    }
-    if (g_inspector.prepare.request != InspectorRequestState.idle) {
-        text_disabled(INSPECTOR_LOADING,
-            (text = empty(g_inspector.prepare.status)
-                ? "Preparing diff..." : g_inspector.prepare.status))
-        if (!g_inspector.prepare.has_retained_content) return
-    }
+    text_disabled(INSPECTOR_SCOPE,
+        (text = to_upper(g_inspector.installed_comparison)))
     tab_bar(INSPECTOR_MODE_TABS,
             (text = "InspectorModes", flags = ImGuiTabBarFlags.None)) {
         tab_item(INSPECTOR_DIFF_TAB, (text = "Diff", closable = false,
@@ -2722,6 +2772,19 @@ def private draw_file_inspector_window() {
             draw_file_view()
         }
     }
+}
+
+def private draw_file_inspector_window() {
+    child(FILE_INSPECTOR_CONTENT, (text = "inspector content",
+            size = float2(0.0f, -GetFrameHeightWithSpacing()),
+            child_flags = ImGuiChildFlags.None,
+            window_flags = ImGuiWindowFlags.None)) {
+        draw_file_inspector_content()
+    }
+    let status = file_inspector_status()
+    separator(INSPECTOR_STATUS_SEPARATOR)
+    text_colored(INSPECTOR_STATUS_TEXT,
+        (color = git_status_color(status), text = status.text))
 }
 
 def private draw_settings_window() {

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -68,6 +68,7 @@ struct private WatcherFileInspectionMessage {
     worktree_path : string
     file_path : string
     comparison : string
+    revision : string
     diff_context : string
     task_session_id : string
     loading : bool
@@ -76,6 +77,19 @@ struct private WatcherFileInspectionMessage {
     view_base64 : string
     view_byte_count : int
     view_available : bool
+    status : string
+    error : string
+}
+
+struct private WatcherGitFileActionMessage {
+    @rename = "type" _type : string
+    request_id : int
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    action : string
+    task_session_id : string
+    loading : bool
     status : string
     error : string
 }
@@ -94,11 +108,28 @@ struct private HerderInspectorOpenArgs {
     worktree_path : string
     file_path : string
     comparison : string = "working"
+    revision : string
     diff_context : string = "compact"
 }
 
 struct private HerderInspectorModeArgs {
     mode : string
+}
+
+struct private HerderGitWorktreeArgs {
+    repository_id : string
+    worktree_path : string
+}
+
+struct private HerderGitPerspectiveArgs {
+    perspective : string
+}
+
+struct private HerderGitFileActionArgs {
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    action : string
 }
 
 enum private GitInspectorMode {
@@ -121,6 +152,7 @@ struct private GitInspectorState {
     worktree_path : string
     file_path : string
     comparison : string
+    git_revision : string
     diff_context : string = "compact"
     task_session_id : string
     loading : bool
@@ -184,6 +216,13 @@ var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
+var private GIT_ACTION_BUTTON : table<int; ClickState>
+var private GIT_ACTION_DISABLED : table<int; NarrativeState>
+var private GIT_ACTION_SAME_LINE : table<int; EmptyMarkerState>
+var private GIT_COMMIT_TEXT : table<int; NarrativeState>
+var private GIT_HISTORY_COMMIT_ROW : table<int; ToggleState>
+var private GIT_COMMIT_FILE_ROW : table<int; ToggleState>
+var private GIT_REF_ROW : table<int; ToggleState>
 var private REPOSITORY_ERROR : table<int; NarrativeState>
 var private REPOSITORY_TITLE : table<int; NarrativeState>
 var private REPOSITORY_EMPTY : table<int; NarrativeState>
@@ -356,14 +395,16 @@ def private drain_inspector_prepare_events() {
 }
 
 def private begin_file_inspection(repository_id, worktree_path, file_path,
-                                  comparison, diff_context : string) {
-    let same_identity = g_inspector.repository_id == repository_id && g_inspector.worktree_path == worktree_path && g_inspector.file_path == file_path && g_inspector.comparison == comparison
+                                  comparison, diff_context : string;
+                                  git_revision : string = "") {
+    let same_identity = g_inspector.repository_id == repository_id && g_inspector.worktree_path == worktree_path && g_inspector.file_path == file_path && g_inspector.comparison == comparison && g_inspector.git_revision == git_revision
     let same_content = g_inspector.prepare.has_retained_content && same_identity
     g_inspector.request_id++
     g_inspector.repository_id = repository_id
     g_inspector.worktree_path = worktree_path
     g_inspector.file_path = file_path
     g_inspector.comparison = comparison
+    g_inspector.git_revision = git_revision
     g_inspector.diff_context = diff_context
     g_inspector.diff_context_choice = 0
     if (diff_context == "expanded") {
@@ -408,15 +449,26 @@ class private WatcherRichClient : HvWebSocketClient {
     error : string
     last_heartbeat : int64
     last_list : int64
+    last_reconnect : int64
     sent_input_bytes : int64
     desired_columns : int
     desired_rows : int
     sent_columns : int
     sent_rows : int
+    last_review_identity : string
+    last_history_identity : string
+    last_refs_identity : string
+    git_action_request_id : int
+    git_action_loading : bool
+    git_action_file_path : string
+    git_action_status : string
+    git_failure_revisions : table<string; int64>
+    git_failure_baseline_ready : bool
 
     def override onOpen {
         connected = true
         error = ""
+        last_reconnect = ref_time_ticks()
         last_heartbeat = ref_time_ticks()
         last_list = ref_time_ticks()
         send("\{\"op\":\"list\"\}")
@@ -429,6 +481,7 @@ class private WatcherRichClient : HvWebSocketClient {
         sent_columns = 0
         sent_rows = 0
         error = "watcher connection closed"
+        last_reconnect = ref_time_ticks()
     }
 
     def override onMessage(message : string#) {
@@ -490,11 +543,59 @@ class private WatcherRichClient : HvWebSocketClient {
                         g_selected_worktree_path = repositories[0].record.checkout_path
                     }
                 }
+                let review_identity = "{g_selected_repository_id}\n{g_selected_worktree_path}"
+                if (!empty(g_selected_repository_id)
+                        && !empty(g_selected_worktree_path)
+                        && review_identity != last_review_identity) {
+                    request_repository_review(
+                        g_selected_repository_id, g_selected_worktree_path)
+                    request_repository_history(
+                        g_selected_repository_id, g_selected_worktree_path)
+                    request_repository_refs(
+                        g_selected_repository_id, g_selected_worktree_path)
+                }
+                for (repository in repositories) {
+                    let id = repository.record.id
+                    let seen = key_exists(git_failure_revisions, id) ? git_failure_revisions[id] : 0l
+                    if (repository.failure_revision <= seen) continue
+                    git_failure_revisions[id] = repository.failure_revision
+                    if (git_failure_baseline_ready
+                            && !empty(repository.failure_session_id)) {
+                        attach_session(repository.failure_session_id)
+                        TERMINAL_WIN.open = true
+                        TERMINAL_WIN.pending_raise = true
+                        g_focus_terminal_pending = true
+                    }
+                    if (git_failure_baseline_ready) {
+                        error = repository.failure_message
+                    }
+                }
+                git_failure_baseline_ready = true
+            } else {
+                error = "invalid repository snapshot message"
             }
         } elif (envelope._type == "file_inspection") {
             var incoming : WatcherFileInspectionMessage
             if (sscan_json(body, incoming)) {
                 install_file_inspection(incoming)
+            }
+        } elif (envelope._type == "git_file_action") {
+            var incoming : WatcherGitFileActionMessage
+            if (sscan_json(body, incoming)
+                    && incoming.request_id == git_action_request_id) {
+                git_action_loading = incoming.loading
+                git_action_file_path = incoming.file_path
+                git_action_status = incoming.status
+                if (!empty(incoming.error)) {
+                    error = incoming.error
+                }
+                if (incoming.status == "failed"
+                        && !empty(incoming.task_session_id)) {
+                    attach_session(incoming.task_session_id)
+                    TERMINAL_WIN.open = true
+                    TERMINAL_WIN.pending_raise = true
+                    g_focus_terminal_pending = true
+                }
             }
         } elif (envelope._type == "attached") {
             var incoming : WatcherAttachedMessage
@@ -586,18 +687,74 @@ class private WatcherRichClient : HvWebSocketClient {
             "{sprint_json(repository_id, false)}\}")
     }
 
+    def request_repository_review(repository_id : string; worktree_path : string) {
+        if (!connected || empty(repository_id) || empty(worktree_path)) return
+        last_review_identity = "{repository_id}\n{worktree_path}"
+        send("\{\"op\":\"repository_review\"," +
+            "\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}\}")
+    }
+
+    def request_repository_history(repository_id : string;
+                                   worktree_path : string;
+                                   ref_name : string = "") {
+        if (!connected || empty(repository_id) || empty(worktree_path)) return
+        last_history_identity = "{repository_id}\n{worktree_path}\n{ref_name}"
+        send("\{\"op\":\"repository_history\"," +
+            "\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}," +
+            "\"revision\":{sprint_json(ref_name, false)}\}")
+    }
+
+    def request_repository_commit_files(repository_id : string;
+                                        worktree_path : string;
+                                        commit_hash : string) {
+        if (!connected || empty(repository_id) || empty(worktree_path)
+                || empty(commit_hash)) return
+        send("\{\"op\":\"repository_commit_files\"," +
+            "\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}," +
+            "\"revision\":{sprint_json(commit_hash, false)}\}")
+    }
+
+    def request_repository_refs(repository_id : string; worktree_path : string) {
+        if (!connected || empty(repository_id) || empty(worktree_path)) return
+        last_refs_identity = "{repository_id}\n{worktree_path}"
+        send("\{\"op\":\"repository_refs\"," +
+            "\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}\}")
+    }
+
+    def git_file_action(repository_id : string; worktree_path : string;
+                        file_path : string; action : string) {
+        if (!connected || git_action_loading || empty(repository_id)
+                || empty(worktree_path) || empty(file_path)) return
+        git_action_request_id++
+        git_action_loading = true
+        git_action_file_path = file_path
+        git_action_status = "running"
+        send("\{\"op\":\"git_file_action\"," +
+            "\"request_id\":{git_action_request_id}," +
+            "\"repository_id\":{sprint_json(repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(worktree_path, false)}," +
+            "\"file_path\":{sprint_json(file_path, false)}," +
+            "\"action\":{sprint_json(action, false)}\}")
+    }
+
     def inspect_file(repository_id, worktree_path, file_path,
                      comparison : string;
-                     diff_context : string = "compact") {
+                     diff_context : string = "compact";
+                     git_revision : string = "") {
         if (!connected || empty(repository_id) || empty(worktree_path)
                 || empty(file_path)) return
         begin_file_inspection(repository_id, worktree_path, file_path,
-            comparison, diff_context)
+            comparison, diff_context, git_revision)
         send("\{\"op\":\"file_inspect\",\"request_id\":{g_inspector.request_id}," +
             "\"repository_id\":{sprint_json(repository_id, false)}," +
             "\"worktree_path\":{sprint_json(worktree_path, false)}," +
             "\"file_path\":{sprint_json(file_path, false)}," +
             "\"comparison\":{sprint_json(comparison, false)}," +
+            "\"revision\":{sprint_json(git_revision, false)}," +
             "\"diff_context\":{sprint_json(diff_context, false)}\}")
     }
 
@@ -632,7 +789,17 @@ class private WatcherRichClient : HvWebSocketClient {
 
     def pump() {
         process_event_que()
-        if (!connected) return
+        if (!connected) {
+            if (get_time_nsec(last_reconnect) / 1000000l >= 1000l) {
+                cleanup()
+                let result = init(g_url)
+                last_reconnect = ref_time_ticks()
+                if (result != 0) {
+                    error = "watcher reconnect failed ({result})"
+                }
+            }
+            return
+        }
         if (get_time_nsec(last_heartbeat) / 1000000l >= 1000l) {
             send("\{\"op\":\"heartbeat\"\}")
             last_heartbeat = ref_time_ticks()
@@ -846,6 +1013,8 @@ def private draw_repositories_window() {
                     g_selected_repository_id = repository.record.id
                     g_selected_worktree_path = worktree.path
                     g_client->refresh_repository(repository.record.id)
+                    g_client->request_repository_review(
+                        repository.record.id, worktree.path)
                     GIT_STATUS_WIN.open = true
                     GIT_STATUS_WIN.pending_raise = true
                 }
@@ -925,6 +1094,296 @@ def private draw_git_file_group(repository : RepositorySnapshot const;
     return count
 }
 
+def private git_status_file_code(repository : RepositorySnapshot const;
+                                 worktree_path : string;
+                                 file_path : string) : string {
+    for (file in repository.files) {
+        if (file.worktree_path == worktree_path && file.path == file_path) {
+            return file.code
+        }
+    }
+    return ""
+}
+
+def private draw_pr_included_files(repository : RepositorySnapshot const;
+                                   worktree : WorktreeState const;
+                                   var file_row : int&;
+                                   var action_row : int&) : int {
+    var count = 0
+    for (file in repository.review_files) {
+        if (file.worktree_path == worktree.path) count++
+    }
+    text(GIT_GROUP_TITLE[10], (text = "PR TOTAL  {count}"))
+    separator(GIT_GROUP_SEPARATOR[10])
+    for (file in repository.review_files) {
+        if (file.worktree_path != worktree.path) continue
+        let status_code = git_status_file_code(
+            repository, worktree.path, file.path)
+        let staged = (!empty(status_code) && status_code != "??"
+            && git_status_byte(status_code, 0) != ' ')
+        if (staged) {
+            let busy = g_client != null && g_client.git_action_loading
+            let action_label = ((busy && g_client.git_action_file_path == file.path)
+                ? "Unstaging..." : "Unstage")
+            if (busy) {
+                text_disabled(GIT_ACTION_DISABLED[action_row],
+                    (text = action_label))
+            } elif (small_button(GIT_ACTION_BUTTON[action_row],
+                    (text = "{action_label}##pr-unstage:{file.path}"))
+                    && g_client != null) {
+                g_client->git_file_action(repository.record.id,
+                    worktree.path, file.path, "unstage")
+            }
+            same_line(GIT_ACTION_SAME_LINE[action_row])
+        }
+        GIT_FILE_ROW[file_row].value = (g_inspector.repository_id == repository.record.id
+            && g_inspector.worktree_path == worktree.path
+            && g_inspector.file_path == file.path
+            && g_inspector.comparison == "pr")
+        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
+        if (selectable(GIT_FILE_ROW[file_row],
+                (text = "{file.code}  {file.path}{old_label}##pr:{file.path}"))) {
+            if (g_client != null) {
+                g_client->inspect_file(repository.record.id, worktree.path,
+                    file.path, "pr")
+                FILE_INSPECTOR_WIN.open = true
+                FILE_INSPECTOR_WIN.pending_raise = true
+            }
+        }
+        file_row++
+        action_row++
+    }
+    return count
+}
+
+def private draw_pr_not_included_files(repository : RepositorySnapshot const;
+                                       worktree : WorktreeState const;
+                                       var file_row : int&;
+                                       var action_row : int&) : int {
+    var count = 0
+    for (file in repository.files) {
+        if (file.worktree_path != worktree.path) continue
+        if (file.code == "??" || git_status_byte(file.code, 1) != ' ') count++
+    }
+    text(GIT_GROUP_TITLE[11], (text = "NOT INCLUDED  {count}"))
+    separator(GIT_GROUP_SEPARATOR[11])
+    for (file in repository.files) {
+        if (file.worktree_path != worktree.path
+                || (file.code != "??" && git_status_byte(file.code, 1) == ' ')) continue
+        let busy = g_client != null && g_client.git_action_loading
+        let action_label = ((busy && g_client.git_action_file_path == file.path)
+            ? "Staging..." : "Stage")
+        if (busy) {
+            text_disabled(GIT_ACTION_DISABLED[action_row],
+                (text = action_label))
+        } elif (small_button(GIT_ACTION_BUTTON[action_row],
+                (text = "{action_label}##pr-stage:{file.path}"))
+                && g_client != null) {
+            g_client->git_file_action(repository.record.id,
+                worktree.path, file.path, "stage")
+        }
+        same_line(GIT_ACTION_SAME_LINE[action_row])
+        GIT_FILE_ROW[file_row].value = (g_inspector.repository_id == repository.record.id
+            && g_inspector.worktree_path == worktree.path
+            && g_inspector.file_path == file.path
+            && g_inspector.comparison == "working")
+        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
+        var selected = false
+        with_style((ImGuiCol.Text, GetStyleColorVec4(ImGuiCol.TextDisabled))) {
+            selected = selectable(GIT_FILE_ROW[file_row],
+                (text = "{file.code}  {file.path}{old_label}##working:{file.path}"))
+        }
+        if (selected && g_client != null) {
+            g_client->inspect_file(repository.record.id, worktree.path,
+                file.path, "working")
+            FILE_INSPECTOR_WIN.open = true
+            FILE_INSPECTOR_WIN.pending_raise = true
+        }
+        file_row++
+        action_row++
+    }
+    return count
+}
+
+def private draw_pr_review(repository : RepositorySnapshot const;
+                           worktree : WorktreeState const) {
+    var commit_count = 0
+    for (commit in repository.review_commits) {
+        if (commit.worktree_path == worktree.path) commit_count++
+    }
+    let base = ((!empty(worktree.review_base_ref))
+        ? worktree.review_base_ref : "detecting base...")
+    text(GIT_GROUP_TITLE[12],
+        (text = "OUTGOING COMMITS  {commit_count}   -> {base}"))
+    separator(GIT_GROUP_SEPARATOR[12])
+    var commit_row = 0
+    for (commit in repository.review_commits) {
+        if (commit.worktree_path != worktree.path) continue
+        text(GIT_COMMIT_TEXT[commit_row],
+            (text = "{commit.short_hash}  {commit.subject}  - {commit.author}"))
+        commit_row++
+    }
+    if (commit_count == 0 && !worktree.review_loading
+            && empty(worktree.review_error)) {
+        text_disabled("No outgoing commits")
+    }
+    if (worktree.review_loading) {
+        text_disabled("Refreshing worktree PR...")
+    }
+    if (!empty(worktree.review_error)) {
+        text_colored(GIT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = worktree.review_error))
+    }
+    separator()
+    var file_row = 0
+    var action_row = 0
+    let included = draw_pr_included_files(
+        repository, worktree, file_row, action_row)
+    dummy(GIT_GROUP_SPACING[10], (size = float2(0.0f, GetStyle().ItemSpacing.y)))
+    let not_included = draw_pr_not_included_files(
+        repository, worktree, file_row, action_row)
+    if (included == 0 && not_included == 0 && !worktree.review_loading
+            && empty(worktree.review_error)) {
+        text_disabled("Nothing to send or stage")
+    }
+}
+
+def private ensure_history(repository : RepositorySnapshot const;
+                           worktree : WorktreeState const; ref_name : string) {
+    if (g_client == null || empty(ref_name)) return
+    let identity = "{repository.record.id}\n{worktree.path}\n{ref_name}"
+    if (g_client.last_history_identity != identity) {
+        g_client->request_repository_history(
+            repository.record.id, worktree.path, ref_name)
+    }
+}
+
+def private draw_commit_files(repository : RepositorySnapshot const;
+                              worktree : WorktreeState const) {
+    var count = 0
+    for (file in repository.commit_files) {
+        if (file.worktree_path == worktree.path
+                && file.commit_hash == worktree.history_commit) count++
+    }
+    text(GIT_GROUP_TITLE[21],
+        (text = "FILES IN {worktree.history_commit}  {count}"))
+    separator(GIT_GROUP_SEPARATOR[21])
+    var row = 0
+    for (file in repository.commit_files) {
+        if (file.worktree_path != worktree.path
+                || file.commit_hash != worktree.history_commit) continue
+        GIT_COMMIT_FILE_ROW[row].value = (g_inspector.repository_id == repository.record.id
+            && g_inspector.worktree_path == worktree.path
+            && g_inspector.file_path == file.path
+            && g_inspector.comparison == "commit"
+            && g_inspector.git_revision == file.commit_hash)
+        let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
+        if (selectable(GIT_COMMIT_FILE_ROW[row],
+                (text = "{file.code}  {file.path}{old_label}##commit:{file.commit_hash}:{file.path}"))
+                && g_client != null) {
+            g_client->inspect_file(repository.record.id, worktree.path,
+                file.path, "commit", "compact", file.commit_hash)
+            FILE_INSPECTOR_WIN.open = true
+            FILE_INSPECTOR_WIN.pending_raise = true
+        }
+        row++
+    }
+    if (count == 0 && !worktree.history_loading
+            && empty(worktree.history_error)) {
+        text_disabled("Select a commit to inspect its files")
+    }
+}
+
+def private draw_history_commits(repository : RepositorySnapshot const;
+                                 worktree : WorktreeState const) {
+    var count = 0
+    for (commit in repository.history_commits) {
+        if (commit.worktree_path == worktree.path) count++
+    }
+    text(GIT_GROUP_TITLE[20],
+        (text = "COMMITS ON {worktree.history_ref}  {count}"))
+    separator(GIT_GROUP_SEPARATOR[20])
+    var row = 0
+    for (commit in repository.history_commits) {
+        if (commit.worktree_path != worktree.path) continue
+        GIT_HISTORY_COMMIT_ROW[row].value = commit.hash == worktree.history_commit
+        if (selectable(GIT_HISTORY_COMMIT_ROW[row],
+                (text = "{commit.short_hash}  {commit.subject}  - {commit.author}##history:{commit.hash}"))
+                && g_client != null && commit.hash != worktree.history_commit) {
+            g_client->request_repository_commit_files(
+                repository.record.id, worktree.path, commit.hash)
+        }
+        row++
+    }
+    if (worktree.history_loading) text_disabled("Reading Git history...")
+    if (!empty(worktree.history_error)) {
+        text_colored(GIT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = worktree.history_error))
+    }
+    separator()
+    draw_commit_files(repository, worktree)
+}
+
+def private draw_history_review(repository : RepositorySnapshot const;
+                                worktree : WorktreeState const) {
+    ensure_history(repository, worktree, worktree.branch)
+    draw_history_commits(repository, worktree)
+}
+
+def private draw_ref_group(repository : RepositorySnapshot const;
+                           worktree : WorktreeState const; remote : bool;
+                           var row : int&) : int {
+    var count = 0
+    for (ref in repository.refs) {
+        if (ref.worktree_path == worktree.path && ref.remote == remote) count++
+    }
+    let group = remote ? 23 : 22
+    text(GIT_GROUP_TITLE[group],
+        (text = remote ? "REMOTE BRANCHES  {count}" : "LOCAL BRANCHES  {count}"))
+    separator(GIT_GROUP_SEPARATOR[group])
+    for (ref in repository.refs) {
+        if (ref.worktree_path != worktree.path || ref.remote != remote) continue
+        GIT_REF_ROW[row].value = ref.name == worktree.history_ref
+        let marker = ref.current ? "* " : "  "
+        if (selectable(GIT_REF_ROW[row],
+                (text = "{marker}{ref.name}##ref:{ref.full_name}"))
+                && g_client != null && ref.name != worktree.history_ref) {
+            g_client->request_repository_history(
+                repository.record.id, worktree.path, ref.name)
+        }
+        row++
+    }
+    return count
+}
+
+def private draw_tree_review(repository : RepositorySnapshot const;
+                             worktree : WorktreeState const) {
+    if (g_client != null) {
+        let identity = "{repository.record.id}\n{worktree.path}"
+        if (g_client.last_refs_identity != identity) {
+            g_client->request_repository_refs(repository.record.id, worktree.path)
+        }
+    }
+    var row = 0
+    let local_count = draw_ref_group(repository, worktree, false, row)
+    dummy(GIT_GROUP_SPACING[22], (size = float2(0.0f, GetStyle().ItemSpacing.y)))
+    let remote_count = draw_ref_group(repository, worktree, true, row)
+    if (worktree.refs_loading) text_disabled("Reading local and remote branches...")
+    if (!empty(worktree.refs_error)) {
+        text_colored(GIT_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = worktree.refs_error))
+    }
+    if (local_count + remote_count == 0 && !worktree.refs_loading
+            && empty(worktree.refs_error)) {
+        text_disabled("No branches found")
+    }
+    separator()
+    draw_history_commits(repository, worktree)
+}
+
 def private draw_git_status_window() {
     var found = false
     if (g_client != null) {
@@ -939,6 +1398,12 @@ def private draw_git_status_window() {
                 if (small_button(REFRESH_GIT, (text = repository.refreshing ? "Refreshing..." : "Refresh",
                         enabled = !repository.refreshing))) {
                     g_client->refresh_repository(repository.record.id)
+                    g_client->request_repository_review(
+                        repository.record.id, worktree.path)
+                    g_client->request_repository_history(
+                        repository.record.id, worktree.path, worktree.branch)
+                    g_client->request_repository_refs(
+                        repository.record.id, worktree.path)
                 }
                 text_disabled(GIT_WORKTREE_PATH, (text = worktree.path))
                 let status_summary = "staged {worktree.staged}   unstaged {worktree.unstaged}   untracked {worktree.untracked}   conflicted {worktree.conflicted}"
@@ -952,13 +1417,20 @@ def private draw_git_status_window() {
                         text = repository.error))
                 }
                 separator()
-                var file_row = 0
-                let conflicts = draw_git_file_group(repository, worktree, 0, file_row)
-                let staged = draw_git_file_group(repository, worktree, 1, file_row)
-                let modified = draw_git_file_group(repository, worktree, 2, file_row)
-                let untracked = draw_git_file_group(repository, worktree, 3, file_row)
-                if (file_row == 0 && !repository.refreshing && empty(repository.error)) {
-                    text_disabled("Working tree clean")
+                tab_bar(GIT_PERSPECTIVE_TABS,
+                        (text = "Git perspectives", flags = ImGuiTabBarFlags.None)) {
+                    tab_item(GIT_PR_TAB, (text = "PR", closable = false,
+                            flags = ImGuiTabItemFlags.None)) {
+                        draw_pr_review(repository, worktree)
+                    }
+                    tab_item(GIT_HISTORY_TAB, (text = "History", closable = false,
+                            flags = ImGuiTabItemFlags.None)) {
+                        draw_history_review(repository, worktree)
+                    }
+                    tab_item(GIT_TREE_TAB, (text = "Tree", closable = false,
+                            flags = ImGuiTabItemFlags.None)) {
+                        draw_tree_review(repository, worktree)
+                    }
                 }
             }
         }
@@ -1050,7 +1522,8 @@ def private draw_side_by_side_diff() {
             && g_client != null && g_client.connected) {
         g_client->inspect_file(g_inspector.repository_id,
             g_inspector.worktree_path, g_inspector.file_path,
-            g_inspector.comparison, INSPECTOR_CONTEXT_VALUES[selected_context])
+            g_inspector.comparison, INSPECTOR_CONTEXT_VALUES[selected_context],
+            g_inspector.git_revision)
     }
     same_line()
     SetNextItemWidth(150.0f)
@@ -1196,6 +1669,181 @@ def private draw_file_view() {
     }
 }
 
+[live_command(description = "Inspect watcher connectivity and rich-client repository/session counts.")]
+def herder_client_state(_input : JsonValue?) : JsonValue? {
+    if (g_client == null) return JV((ok = false, error = "client is unavailable"))
+    return JV((ok = g_client.connected,
+        connected = g_client.connected,
+        error = g_client.error,
+        session_count = length(g_client.sessions),
+        repository_count = length(g_client.repositories),
+        selected_repository_id = g_selected_repository_id,
+        selected_worktree_path = g_selected_worktree_path))
+}
+
+[live_command(description = "Select a worktree for Git review. Args: repository_id, worktree_path.")]
+def herder_git_select_worktree(input : JsonValue?) : JsonValue? {
+    if (g_client == null || !g_client.connected) {
+        return JV((ok = false, error = "watcher is not connected"))
+    }
+    let args = from_JV(input, type<HerderGitWorktreeArgs>)
+    for (repository in g_client.repositories) {
+        if (repository.record.id != args.repository_id) continue
+        for (worktree in repository.worktrees) {
+            if (worktree.path != args.worktree_path) continue
+            g_selected_repository_id = args.repository_id
+            g_selected_worktree_path = args.worktree_path
+            g_client->refresh_repository(args.repository_id)
+            g_client->request_repository_review(
+                args.repository_id, args.worktree_path)
+            g_client->request_repository_history(
+                args.repository_id, args.worktree_path, worktree.branch)
+            g_client->request_repository_refs(
+                args.repository_id, args.worktree_path)
+            GIT_STATUS_WIN.open = true
+            GIT_STATUS_WIN.pending_raise = true
+            return JV((ok = true, repository_id = args.repository_id,
+                worktree_path = args.worktree_path))
+        }
+    }
+    return JV((ok = false, error = "unknown repository or worktree"))
+}
+
+[live_command(description = "Inspect the selected worktree PR model, including outgoing commits, included files, and not-included files.")]
+def herder_git_review_state(_input : JsonValue?) : JsonValue? {
+    var commits : array<JsonValue?>
+    var included : array<JsonValue?>
+    var not_included : array<JsonValue?>
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id != g_selected_repository_id) continue
+            for (worktree in repository.worktrees) {
+                if (worktree.path != g_selected_worktree_path) continue
+                for (commit in repository.review_commits) {
+                    if (commit.worktree_path != worktree.path) continue
+                    commits |> push(JV((hash = commit.hash,
+                        short_hash = commit.short_hash,
+                        authored_at = commit.authored_at,
+                        author = commit.author, subject = commit.subject)))
+                }
+                for (file in repository.review_files) {
+                    if (file.worktree_path != worktree.path) continue
+                    let status_code = git_status_file_code(
+                        repository, worktree.path, file.path)
+                    included |> push(JV((code = file.code, path = file.path,
+                        old_path = file.old_path,
+                        staged = (!empty(status_code) && status_code != "??"
+                            && git_status_byte(status_code, 0) != ' '))))
+                }
+                for (file in repository.files) {
+                    if (file.worktree_path != worktree.path
+                            || (file.code != "??"
+                                && git_status_byte(file.code, 1) == ' ')) continue
+                    not_included |> push(JV((code = file.code,
+                        path = file.path, old_path = file.old_path)))
+                }
+                return JV((ok = empty(worktree.review_error),
+                    repository_id = repository.record.id,
+                    worktree_path = worktree.path,
+                    branch = worktree.branch,
+                    base_ref = worktree.review_base_ref,
+                    merge_base = worktree.review_merge_base,
+                    loading = worktree.review_loading,
+                    error = worktree.review_error,
+                    commits = commits, included = included,
+                    not_included = not_included,
+                    git_action_loading = g_client.git_action_loading,
+                    git_action_file_path = g_client.git_action_file_path,
+                    git_action_status = g_client.git_action_status))
+            }
+        }
+    }
+    return JV((ok = false, error = "selected worktree is unavailable"))
+}
+
+[live_command(description = "Inspect selected worktree History and Tree data, including refs, commits, and selected-commit files.")]
+def herder_git_history_state(_input : JsonValue?) : JsonValue? {
+    var refs : array<JsonValue?>
+    var commits : array<JsonValue?>
+    var files : array<JsonValue?>
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id != g_selected_repository_id) continue
+            for (worktree in repository.worktrees) {
+                if (worktree.path != g_selected_worktree_path) continue
+                for (ref in repository.refs) {
+                    if (ref.worktree_path != worktree.path) continue
+                    refs |> push(JV((name = ref.name, full_name = ref.full_name,
+                        hash = ref.hash, current = ref.current, remote = ref.remote)))
+                }
+                for (commit in repository.history_commits) {
+                    if (commit.worktree_path != worktree.path) continue
+                    commits |> push(JV((hash = commit.hash,
+                        short_hash = commit.short_hash,
+                        authored_at = commit.authored_at,
+                        author = commit.author, subject = commit.subject)))
+                }
+                for (file in repository.commit_files) {
+                    if (file.worktree_path != worktree.path
+                            || file.commit_hash != worktree.history_commit) continue
+                    files |> push(JV((commit_hash = file.commit_hash,
+                        code = file.code, path = file.path,
+                        old_path = file.old_path)))
+                }
+                return JV((ok = empty(worktree.history_error)
+                        && empty(worktree.refs_error),
+                    repository_id = repository.record.id,
+                    worktree_path = worktree.path,
+                    branch = worktree.branch,
+                    history_ref = worktree.history_ref,
+                    history_commit = worktree.history_commit,
+                    history_loading = worktree.history_loading,
+                    history_error = worktree.history_error,
+                    refs_loading = worktree.refs_loading,
+                    refs_error = worktree.refs_error,
+                    refs = refs, commits = commits, files = files))
+            }
+        }
+    }
+    return JV((ok = false, error = "selected worktree is unavailable"))
+}
+
+[live_command(description = "Switch Git Status perspective. Args: perspective = pr | history | tree.")]
+def herder_git_perspective(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<HerderGitPerspectiveArgs>)
+    let perspective = to_lower(args.perspective)
+    if (perspective == "pr") {
+        GIT_PR_TAB.pending_select = true
+    } elif (perspective == "history") {
+        GIT_HISTORY_TAB.pending_select = true
+    } elif (perspective == "tree") {
+        GIT_TREE_TAB.pending_select = true
+    } else {
+        return JV((ok = false, error = "perspective must be pr, history, or tree"))
+    }
+    GIT_STATUS_WIN.open = true
+    GIT_STATUS_WIN.pending_raise = true
+    return JV((ok = true, perspective = perspective))
+}
+
+[live_command(description = "Stage or unstage one observed worktree file. Args: repository_id, worktree_path, file_path, action.")]
+def herder_git_file_action(input : JsonValue?) : JsonValue? {
+    if (g_client == null || !g_client.connected) {
+        return JV((ok = false, error = "watcher is not connected"))
+    }
+    let args = from_JV(input, type<HerderGitFileActionArgs>)
+    if (args.action != "stage" && args.action != "unstage") {
+        return JV((ok = false, error = "action must be stage or unstage"))
+    }
+    if (g_client.git_action_loading) {
+        return JV((ok = false, error = "another Git file action is running"))
+    }
+    g_client->git_file_action(args.repository_id, args.worktree_path,
+        args.file_path, args.action)
+    return JV((ok = true, request_id = g_client.git_action_request_id,
+        action = args.action, file_path = args.file_path))
+}
+
 [live_command(description = "Inspect the selected Git file, comparison, render mode, and changed-line telemetry.")]
 def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
     let view_selection = text_source_view_selection(g_inspector.view)
@@ -1206,6 +1854,7 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         worktree_path = g_inspector.worktree_path,
         file_path = g_inspector.file_path,
         comparison = g_inspector.comparison,
+        git_revision = g_inspector.git_revision,
         zoom_percent = g_zoom_percent,
         diff_context = g_inspector.diff_context,
         diff_context_choice = g_inspector.diff_context_choice,
@@ -1291,7 +1940,7 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         markdown_gutter_segments = g_inspector.markdown_gutter_segments))
 }
 
-[live_command(description = "Open a changed Git file immediately. Args: repository_id, worktree_path, file_path, comparison.")]
+[live_command(description = "Open a changed Git file immediately. Args: repository_id, worktree_path, file_path, comparison, optional revision for commit.")]
 def herder_file_inspector_open(input : JsonValue?) : JsonValue? {
     if (g_client == null || !g_client.connected) {
         return JV((ok = false, error = "watcher is not connected"))
@@ -1304,11 +1953,12 @@ def herder_file_inspector_open(input : JsonValue?) : JsonValue? {
     }
     let comparison = empty(args.comparison) ? "working" : args.comparison
     g_client->inspect_file(args.repository_id, args.worktree_path,
-        args.file_path, comparison, args.diff_context)
+        args.file_path, comparison, args.diff_context, args.revision)
     FILE_INSPECTOR_WIN.open = true
     FILE_INSPECTOR_WIN.pending_raise = true
     return JV((ok = true, request_id = g_inspector.request_id,
-        file_path = args.file_path, comparison = comparison))
+        file_path = args.file_path, comparison = comparison,
+        revision = args.revision))
 }
 
 [live_command(description = "Read exact inspector text. Args: side = before | after | view.")]
@@ -1514,6 +2164,7 @@ def shutdown() {
         g_client->cleanup()
         delete g_client.sessions
         delete g_client.repositories
+        delete g_client.git_failure_revisions
         unsafe { delete g_client }
         g_client = null
     }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -262,6 +262,7 @@ var private GIT_CHANGELIST_STATUS_TEXT : NarrativeState
 var private GIT_ACTIVITY_STATUS_TEXT : NarrativeState
 var private GIT_CHANGELIST_STATUS_SEPARATOR : EmptyMarkerState
 var private GIT_ACTIVITY_STATUS_SEPARATOR : EmptyMarkerState
+var private INSPECTOR_CONNECTION_ERROR : NarrativeState
 
 def private setup_default_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
@@ -499,27 +500,40 @@ class private WatcherRichClient : HvWebSocketClient {
     git_action_status : string
     git_failure_revisions : table<string; int64>
     git_failure_baseline_ready : bool
+    connect_count : int64
+    disconnect_count : int64
+    reconnect_attempt_count : int64
+    message_count : int64
+    repository_message_count : int64
 
     def override onOpen {
         connected = true
+        connect_count++
         error = ""
         last_reconnect = ref_time_ticks()
         last_heartbeat = ref_time_ticks()
         last_list = ref_time_ticks()
+        print("dasHerd client: watcher connected (generation {connect_count})\n")
         send("\{\"op\":\"list\"\}")
     }
 
     def override onClose {
+        let was_connected = connected
         connected = false
+        disconnect_count++
         attached = false
         controls = false
         sent_columns = 0
         sent_rows = 0
         error = "watcher connection closed"
         last_reconnect = ref_time_ticks()
+        if (was_connected) {
+            print("dasHerd client: watcher connection closed; reconnecting\n")
+        }
     }
 
     def override onMessage(message : string#) {
+        message_count++
         var envelope : WatcherEnvelope
         let body = string(message)
         if (!sscan_json(body, envelope)) {
@@ -554,6 +568,7 @@ class private WatcherRichClient : HvWebSocketClient {
                 g_focus_terminal_pending = true
             }
         } elif (envelope._type == "repositories") {
+            repository_message_count++
             var incoming : WatcherRepositoriesMessage
             if (sscan_json(body, incoming)) {
                 delete repositories
@@ -780,7 +795,13 @@ class private WatcherRichClient : HvWebSocketClient {
                      comparison : string;
                      diff_context : string = "compact";
                      git_revision : string = "") {
-        if (!connected || empty(repository_id) || empty(worktree_path)
+        if (!connected) {
+            error = "watcher is not connected"
+            g_inspector.loading = false
+            g_inspector.error = error
+            return
+        }
+        if (empty(repository_id) || empty(worktree_path)
                 || empty(file_path)) return
         begin_file_inspection(repository_id, worktree_path, file_path,
             comparison, diff_context, git_revision)
@@ -827,6 +848,7 @@ class private WatcherRichClient : HvWebSocketClient {
         if (!connected) {
             if (get_time_nsec(last_reconnect) / 1000000l >= 1000l) {
                 cleanup()
+                reconnect_attempt_count++
                 let result = init(g_url)
                 last_reconnect = ref_time_ticks()
                 if (result != 0) {
@@ -1441,7 +1463,7 @@ def private ensure_history(repository : RepositorySnapshot const;
 def private request_commit_files(repository : RepositorySnapshot const;
                                  worktree : WorktreeState const;
                                  commit_hash : string) {
-    if (g_client == null || empty(commit_hash)) return
+    if (g_client == null || !g_client.connected || empty(commit_hash)) return
     g_requested_history_commit = commit_hash
     g_client->request_repository_commit_files(
         repository.record.id, worktree.path, commit_hash)
@@ -1782,6 +1804,9 @@ def private git_selected_commit_file_count(repository : RepositorySnapshot const
 
 def private git_activity_status(repository : RepositorySnapshot const;
                                 worktree : WorktreeState const) : GitWindowStatus {
+    if (g_client == null || !g_client.connected) {
+        return GitWindowStatus(text = "WATCHER DISCONNECTED - reconnecting...", error = true)
+    }
     if (GIT_TREE_TAB.selected) {
         if (!empty(worktree.refs_error)) {
             return GitWindowStatus(text = worktree.refs_error, error = true)
@@ -1823,6 +1848,9 @@ def private git_activity_status(repository : RepositorySnapshot const;
 
 def private git_changelist_status(repository : RepositorySnapshot const;
                                   worktree : WorktreeState const) : GitWindowStatus {
+    if (g_client == null || !g_client.connected) {
+        return GitWindowStatus(text = "WATCHER DISCONNECTED - reconnecting...", error = true)
+    }
     if (!empty(repository.error)) {
         return GitWindowStatus(text = repository.error, error = true)
     }
@@ -2187,6 +2215,15 @@ def herder_client_state(_input : JsonValue?) : JsonValue? {
     return JV((ok = g_client.connected,
         connected = g_client.connected,
         error = g_client.error,
+        connect_count = g_client.connect_count,
+        disconnect_count = g_client.disconnect_count,
+        reconnect_attempt_count = g_client.reconnect_attempt_count,
+        message_count = g_client.message_count,
+        repository_message_count = g_client.repository_message_count,
+        heap_bytes = int64(heap_bytes_allocated()),
+        heap_total_bytes = int64(heap_total_allocated()),
+        string_heap_bytes = int64(string_heap_bytes_allocated()),
+        string_heap_total_bytes = int64(string_heap_total_allocated()),
         session_count = length(g_client.sessions),
         repository_count = length(g_client.repositories),
         selected_repository_id = g_selected_repository_id,
@@ -2640,6 +2677,11 @@ def private draw_file_inspector_window() {
     if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
         if (io.MouseWheel > 0.0f) zoom_by(5)
         elif (io.MouseWheel < 0.0f) zoom_by(-5)
+    }
+    if (g_client == null || !g_client.connected) {
+        text_colored(INSPECTOR_CONNECTION_ERROR,
+            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
+            text = "WATCHER DISCONNECTED - reconnecting..."))
     }
     if (empty(g_inspector.file_path)) {
         text_disabled("Select a changed file")

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -24,6 +24,7 @@ require daslib/utf8_utils
 require live/live_commands
 require ./watcher_core.das
 require ./repository_core.das
+require ./git_graph_model.das
 require ./file_inspection.das
 require ./inspection_worker.das
 require ./image_preview_gl.das
@@ -153,6 +154,7 @@ let INSPECTOR_CONTEXT_LABELS : array<string> <- [
     "Compact (3)", "Expanded (20)", "Full file"]
 let INSPECTOR_CONTEXT_VALUES : array<string> <- [
     "compact", "expanded", "full"]
+let TREE_FILTER_LABELS : array<string> <- ["Auto", "All"]
 
 struct private GitInspectorState {
     request_id : int
@@ -230,6 +232,9 @@ var private g_last_copied_sha : string
 var private g_clipboard_copy_status = ClipboardStatus.no_content
 var private g_clipboard_copy_attempts = 0
 var private g_clipboard_copy_verified = false
+var private g_tree_model = GitTreeModel()
+var private g_tree_model_identity : string
+var private g_tree_focus_ref : string
 var private g_inspector = GitInspectorState()
 var private g_prepare_worker = InspectorPrepareWorker()
 var private g_jobque_owned = false
@@ -238,6 +243,9 @@ var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
 var private GIT_COMMIT_TITLE_TEXT : table<int; NarrativeState>
 var private GIT_COMMIT_AUTHOR_TEXT : table<int; NarrativeState>
+var private GIT_TREE_REF_SAME_LINE : table<int; EmptyMarkerState>
+var private GIT_TREE_REF_ROW : table<int; ClickState>
+var private GIT_TREE_GRAPH_CELL : table<int; EmptyMarkerState>
 var private GIT_PR_COMMIT_HOVER : table<int; EmptyMarkerState>
 var private GIT_HISTORY_COMMIT_ROW : table<int; ClickState>
 var private GIT_COMMIT_FILE_ROW : table<int; ToggleState>
@@ -1538,183 +1546,190 @@ def private draw_history_review(repository : RepositorySnapshot const;
     draw_history_commits(repository, worktree)
 }
 
-def private git_lane_index(lanes : array<string> const; hash : string) : int {
-    for (index in range(length(lanes))) {
-        if (lanes[index] == hash) return index
-    }
-    return -1
+def private git_graph_color(slot : int; alpha : float = 1.0f) : uint {
+    let palette_slot = slot % 12
+    if (palette_slot == 0) return GetColorU32(float4(0.31f, 0.72f, 0.96f, alpha))
+    if (palette_slot == 1) return GetColorU32(float4(0.95f, 0.50f, 0.34f, alpha))
+    if (palette_slot == 2) return GetColorU32(float4(0.48f, 0.82f, 0.42f, alpha))
+    if (palette_slot == 3) return GetColorU32(float4(0.76f, 0.54f, 0.95f, alpha))
+    if (palette_slot == 4) return GetColorU32(float4(0.97f, 0.76f, 0.28f, alpha))
+    if (palette_slot == 5) return GetColorU32(float4(0.29f, 0.84f, 0.74f, alpha))
+    if (palette_slot == 6) return GetColorU32(float4(0.95f, 0.43f, 0.65f, alpha))
+    if (palette_slot == 7) return GetColorU32(float4(0.55f, 0.66f, 0.98f, alpha))
+    if (palette_slot == 8) return GetColorU32(float4(0.76f, 0.82f, 0.35f, alpha))
+    if (palette_slot == 9) return GetColorU32(float4(0.98f, 0.60f, 0.27f, alpha))
+    if (palette_slot == 10) return GetColorU32(float4(0.39f, 0.78f, 0.87f, alpha))
+    return GetColorU32(float4(0.80f, 0.48f, 0.79f, alpha))
 }
 
-def private git_graph_color(hash : string; alpha : float = 1.0f) : uint {
-    let slot = empty(hash) ? 0 : git_status_byte(hash, 0) % 6
-    if (slot == 0) return GetColorU32(float4(0.33f, 0.72f, 0.95f, alpha))
-    if (slot == 1) return GetColorU32(float4(0.94f, 0.53f, 0.37f, alpha))
-    if (slot == 2) return GetColorU32(float4(0.53f, 0.82f, 0.43f, alpha))
-    if (slot == 3) return GetColorU32(float4(0.76f, 0.55f, 0.94f, alpha))
-    if (slot == 4) return GetColorU32(float4(0.96f, 0.76f, 0.31f, alpha))
-    return GetColorU32(float4(0.34f, 0.83f, 0.75f, alpha))
+def private current_tree_filter() : GitTreeFilter {
+    if (GIT_TREE_FILTER.value == 1) return GitTreeFilter.all
+    return GitTreeFilter.auto_
 }
 
-def private git_prepare_lanes(commit : GitCommitState const;
-                              observed : table<string; bool> const;
-                              var lanes : array<string>) : int {
-    var lane = git_lane_index(lanes, commit.hash)
-    if (lane < 0) {
-        lanes |> push(commit.hash)
-        lane = length(lanes) - 1
-    }
-    var parent_number = 0
-    for (parent in split(commit.parents, " ")) {
-        if (empty(parent) || !key_exists(observed, parent)) continue
-        if (parent_number > 0 && git_lane_index(lanes, parent) < 0) {
-            lanes |> push(parent)
-        }
-        parent_number++
-    }
-    return lane
-}
-
-def private git_finish_lanes(commit : GitCommitState const; lane : int;
-                             observed : table<string; bool> const;
-                             var lanes : array<string>) {
-    var first_parent = ""
-    for (parent in split(commit.parents, " ")) {
-        if (!empty(parent) && key_exists(observed, parent)) {
-            first_parent = parent
-            break
-        }
-    }
-    if (empty(first_parent)) {
-        lanes |> erase(lane)
-    } else {
-        lanes[lane] = first_parent
-        var duplicate = length(lanes) - 1
-        while (duplicate > lane) {
-            if (lanes[duplicate] == first_parent) lanes |> erase(duplicate)
-            duplicate--
-        }
-    }
-}
-
-def private git_advance_lanes(commit : GitCommitState const;
-                              observed : table<string; bool> const;
-                              var lanes : array<string>) {
-    let lane = git_prepare_lanes(commit, observed, lanes)
-    git_finish_lanes(commit, lane, observed, lanes)
-}
-
-def private draw_commit_graph_decoration(commit : GitCommitState const;
-                                         observed : table<string; bool> const;
-                                         var lanes : array<string>;
-                                         row_id : string) {
-    let lane = git_prepare_lanes(commit, observed, lanes)
-    let row_min = GetItemRectMin()
-    let row_max = GetItemRectMax()
-    let row_right = git_visible_row_right(row_max.x)
-    let center_y = (row_min.y + row_max.y) * 0.5f
-    let lane_spacing = 14.0f
-    let graph_x = row_min.x + 8.0f
-    var inscope parents <- split(commit.parents, " ")
-    with_window_drawlist() $(var dl) {
-        for (index in range(length(lanes))) {
-            let x = graph_x + float(index) * lane_spacing
-            dl |> add_line(float2(x, row_min.y), float2(x, row_max.y),
-                git_graph_color(lanes[index], 0.72f), 2.0f)
-        }
-        let node_x = graph_x + float(lane) * lane_spacing
-        var parent_number = 0
-        for (parent in parents) {
-            if (empty(parent) || !key_exists(observed, parent)) continue
-            if (parent_number > 0) {
-                let parent_lane = git_lane_index(lanes, parent)
-                let parent_x = graph_x + float(parent_lane) * lane_spacing
-                dl |> add_line(float2(node_x, center_y),
-                    float2(parent_x, row_max.y), git_graph_color(parent, 0.85f), 2.0f)
-            }
-            parent_number++
-        }
-        dl |> add_circle_filled(float2(node_x, center_y), 4.5f,
-            git_graph_color(commit.hash), 12)
-        dl |> add_circle(float2(node_x, center_y), 5.8f,
-            GetColorU32(ImGuiCol.WindowBg), 12, 1.4f)
-    }
-
-    let hovered = IsItemHovered()
-    let icon_size = max(12.0f, GetTextLineHeight() - 3.0f)
-    let icon_width = icon_size + GetStyle().FramePadding.x * 2.0f
-    if (icon_button_draw_at("##{row_id}:copy-sha", "duplicate",
-            float2(row_right - icon_width, row_min.y), icon_size, 1.0f,
-            hovered)) {
-        queue_sha_copy(commit.hash)
-    }
-    if (hovered && IsItemHovered()) {
-        set_tooltip(GIT_HOVER_TOOLTIP, "Copy full SHA")
-    }
-
-    git_finish_lanes(commit, lane, observed, lanes)
-}
-
-def private git_graph_refs(repository : RepositorySnapshot const;
-                           worktree : WorktreeState const;
-                           commit : GitCommitState const) : string {
-    var inscope names : array<string>
-    names |> reserve(3)
-    var count = 0
-    for (ref in repository.refs) {
-        if (ref.worktree_path != worktree.path || ref.hash != commit.hash
-                || ends_with(ref.name, "/HEAD") || count >= 3) continue
-        names |> push("[{ref.name}]")
-        count++
-    }
-    return join(names, " ")
-}
-
-def private draw_commit_graph(repository : RepositorySnapshot const;
+def private ensure_tree_model(repository : RepositorySnapshot const;
                               worktree : WorktreeState const) {
-    var inscope lanes : array<string>
-    var inscope commit_indices : array<int>
-    var inscope observed : table<string; bool>
-    commit_indices |> reserve(length(repository.history_commits))
-    for (index in range(length(repository.history_commits))) {
-        if (repository.history_commits[index].worktree_path == worktree.path) {
-            commit_indices |> push(index)
-            observed[repository.history_commits[index].hash] = true
+    let filter = current_tree_filter()
+    let identity = "{repository.record.id}\n{worktree.path}\n{repository.revision}\n{int(filter)}\n{g_tree_focus_ref}"
+    if (identity == g_tree_model_identity) return
+    git_tree_build_model(repository, worktree, filter,
+        g_tree_focus_ref, g_tree_model)
+    g_tree_model_identity = identity
+}
+
+def private draw_git_tree_vectors(anchor_x, row_zero_y, row_height,
+                                  lane_spacing : float) {
+    with_window_drawlist() $(var dl) {
+        for (edge in g_tree_model.edges) {
+            if (edge.child < 0 || edge.child >= length(g_tree_model.nodes)
+                    || edge.parent < 0 || edge.parent >= length(g_tree_model.nodes)) continue
+            let child = g_tree_model.nodes[edge.child]
+            let parent = g_tree_model.nodes[edge.parent]
+            let x0 = anchor_x + float(child.lane) * lane_spacing
+            let x1 = anchor_x + float(parent.lane) * lane_spacing
+            let y0 = row_zero_y + float(child.row) * row_height
+            let y1 = row_zero_y + float(parent.row) * row_height
+            let alpha = edge.focused ? 0.98f : 0.23f
+            let thickness = edge.focused ? 2.5f : 1.45f
+            let color = git_graph_color(edge.color_slot, alpha)
+            if (abs(x1 - x0) < 0.5f) {
+                dl |> add_line(float2(x0, y0), float2(x1, y1),
+                    color, thickness)
+            } else {
+                let transition_y = min(y1,
+                    y0 + clamp((y1 - y0) * 0.45f,
+                        row_height, row_height * 1.8f))
+                let control = (transition_y - y0) * 0.62f
+                dl |> add_bezier_cubic(float2(x0, y0),
+                    float2(x0, y0 + control),
+                    float2(x1, transition_y - control),
+                    float2(x1, transition_y), color, thickness, 0)
+                if (transition_y < y1) {
+                    dl |> add_line(float2(x1, transition_y),
+                        float2(x1, y1), color, thickness)
+                }
+            }
+        }
+        for (node in g_tree_model.nodes) {
+            let x = anchor_x + float(node.lane) * lane_spacing
+            let y = row_zero_y + float(node.row) * row_height
+            let alpha = node.focused ? 1.0f : 0.34f
+            let color = git_graph_color(node.color_slot, alpha)
+            let radius = node.head ? 5.8f : 4.2f
+            if (node.head) {
+                dl |> add_circle_filled(float2(x, y), radius, color, 20)
+            } else {
+                dl |> add_circle_filled(float2(x, y), radius,
+                    GetColorU32(ImGuiCol.WindowBg), 20)
+            }
+            dl |> add_circle(float2(x, y), radius, color, 20,
+                node.pushed ? 2.8f : 1.35f)
+            if (node.focus_head) {
+                dl |> add_circle(float2(x, y), radius + 3.0f,
+                    git_graph_color(node.color_slot, 0.78f), 20, 1.25f)
+            }
         }
     }
-    var graph_cursor = 0
-    list_clipper(length(commit_indices)) $(start, end_) {
-        while (graph_cursor < start) {
-            git_advance_lanes(repository.history_commits[
-                commit_indices[graph_cursor]], observed, lanes)
-            graph_cursor++
-        }
-        for (row in range(start, end_)) {
-            let commit = repository.history_commits[commit_indices[row]]
-            let selected_commit = !empty(g_requested_history_commit) ? g_requested_history_commit : worktree.history_commit
-            let refs = git_graph_refs(repository, worktree, commit)
-            let ref_text = empty(refs) ? "" : "{refs}  "
-            let space_width = max(1.0f, CalcTextSize(" ").x)
-            let graph_pad = repeat(" ", int(56.0f / space_width) + 1)
-            var selected = false
-            with_item_flag(ImGuiItemFlags.None | ImGuiItemFlagsPrivate.AllowOverlap, true) {
-                selected = selectable_label(GIT_HISTORY_COMMIT_ROW[row],
-                    (text = "{graph_pad}{commit.short_hash}  {ref_text}{commit.subject}  - {commit.author}##graph:{commit.hash}",
-                    selected = commit.hash == selected_commit))
+}
+
+def private draw_tree_commits(repository : RepositorySnapshot const;
+                              worktree : WorktreeState const) {
+    ensure_tree_model(repository, worktree)
+    let sha_width = (CalcTextSize("000000000").x
+        + GetFrameHeightWithSpacing() + 8.0f)
+    let lane_spacing = max(15.0f, 17.0f * float(g_zoom_percent) / 100.0f)
+    let topology_width = clamp(float(g_tree_model.max_lane + 1) *
+        lane_spacing + 30.0f, 130.0f, 420.0f)
+    let table_flags = (ImGuiTableFlags.Resizable | ImGuiTableFlags.RowBg |
+        ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.ScrollY |
+        ImGuiTableFlags.SizingStretchProp)
+    let row_height = GetTextLineHeightWithSpacing()
+    var graph_anchor = false
+    var graph_anchor_x = 0.0f
+    var graph_row_zero_y = 0.0f
+    data_table(GIT_TREE_COMMIT_TABLE, (text = "##tree-commits", columns = 4,
+            flags = table_flags, outer_size = float2(0.0f, 0.0f),
+            inner_width = 0.0f)) {
+        table_setup_scroll_freeze(0, 1)
+        table_setup_column("SHA", ImGuiTableColumnFlags.WidthFixed, sha_width)
+        table_setup_column("Title", ImGuiTableColumnFlags.WidthStretch, 0.70f)
+        table_setup_column("Author", ImGuiTableColumnFlags.WidthStretch, 0.30f)
+        table_setup_column("Topology", ImGuiTableColumnFlags.WidthFixed,
+            topology_width)
+        table_headers_row()
+        list_clipper(length(g_tree_model.nodes)) $(start, end_) {
+            for (row in range(start, end_)) {
+                let node = g_tree_model.nodes[row]
+                let commit = repository.history_commits[node.commit_index]
+                let selected_commit = (!empty(g_requested_history_commit)
+                    ? g_requested_history_commit : worktree.history_commit)
+                let text_alpha = node.focused ? 1.0f : 0.42f
+                table_next_row(ImGuiTableRowFlags.None, row_height)
+                table_set_column_index(0)
+                var selected = false
+                with_style((ImGuiCol.Text,
+                        float4(0.36f, 0.76f, 0.96f, text_alpha))) {
+                    selected = selectable_label(GIT_HISTORY_COMMIT_ROW[row],
+                        (text = "{commit.short_hash}##tree:{commit.hash}",
+                        selected = commit.hash == selected_commit,
+                        flags = ImGuiSelectableFlags.SpanAllColumns |
+                            ImGuiSelectableFlags.AllowOverlap))
+                }
+                draw_sha_copy_icon(commit.hash, "tree:{commit.hash}",
+                    commit.short_hash)
+                table_set_column_index(1)
+                if (!empty(node.refs_text)) {
+                    let ref_size = float2(CalcTextSize(node.refs_text).x + 8.0f,
+                        GetTextLineHeight())
+                    var ref_clicked = false
+                    with_style(
+                            (ImGuiCol.Text,
+                                float4(0.52f, 0.82f, 0.53f, text_alpha)),
+                            (ImGuiCol.Header,
+                                float4(0.20f, 0.36f, 0.25f, 0.62f)),
+                            (ImGuiCol.HeaderHovered,
+                                float4(0.25f, 0.48f, 0.31f, 0.72f))) {
+                        ref_clicked = selectable_label(GIT_TREE_REF_ROW[row],
+                            (text = "{node.refs_text}##tree-ref:{node.hash}",
+                            selected = node.primary_ref == g_tree_model.focus_ref,
+                            flags = ImGuiSelectableFlags.AllowOverlap,
+                            size = ref_size))
+                    }
+                    if (ref_clicked && !empty(node.primary_ref)) {
+                        g_tree_focus_ref = node.primary_ref
+                        g_tree_model_identity = ""
+                    }
+                    same_line(GIT_TREE_REF_SAME_LINE[row])
+                }
+                text_colored(GIT_COMMIT_TITLE_TEXT[row],
+                    (color = float4(0.91f, 0.93f, 0.96f, text_alpha),
+                    text = commit.subject))
+                table_set_column_index(2)
+                text_colored(GIT_COMMIT_AUTHOR_TEXT[row],
+                    (color = float4(0.64f, 0.70f, 0.80f, text_alpha),
+                    text = commit.author))
+                if (selected && g_client != null
+                        && commit.hash != selected_commit) {
+                    request_commit_files(repository, worktree, commit.hash)
+                }
+                table_set_column_index(3)
+                dummy(GIT_TREE_GRAPH_CELL[row],
+                    (size = float2(0.0f, GetTextLineHeight())))
+                if (!graph_anchor) {
+                    let row_min = GetItemRectMin()
+                    let row_max = GetItemRectMax()
+                    graph_anchor = true
+                    graph_anchor_x = (row_min.x + GetStyle().CellPadding.x
+                        + lane_spacing * 0.5f)
+                    graph_row_zero_y = ((row_min.y + row_max.y) * 0.5f
+                        - float(row) * row_height)
+                }
             }
-            draw_commit_graph_decoration(commit, observed, lanes,
-                "graph:{commit.hash}")
-            if (selected && g_client != null
-                    && commit.hash != selected_commit) {
-                request_commit_files(repository, worktree, commit.hash)
-            }
-            graph_cursor++
         }
-    }
-    if (worktree.history_loading) text_disabled("Reading commit graph...")
-    if (!empty(worktree.history_error)) {
-        text_colored(GIT_ERROR,
-            (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
-            text = worktree.history_error))
+        if (graph_anchor) {
+            draw_git_tree_vectors(graph_anchor_x, graph_row_zero_y,
+                row_height, lane_spacing)
+        }
     }
 }
 
@@ -1727,7 +1742,13 @@ def private draw_tree_review(repository : RepositorySnapshot const;
         }
     }
     ensure_history(repository, worktree, "__all__")
-    draw_history_commits(repository, worktree)
+    SetNextItemWidth(130.0f)
+    combo(GIT_TREE_FILTER, (text = "Branches", items <- TREE_FILTER_LABELS))
+    same_line()
+    ensure_tree_model(repository, worktree)
+    text_disabled(GIT_TREE_FOCUS_TEXT,
+        (text = "Focus: {g_tree_model.focus_ref}   refs {g_tree_model.included_ref_count}"))
+    draw_tree_commits(repository, worktree)
 }
 
 def private git_review_commit_count(repository : RepositorySnapshot const;
@@ -1774,7 +1795,11 @@ def private git_activity_status(repository : RepositorySnapshot const;
         if (worktree.history_loading) {
             return GitWindowStatus(text = "Reading Git history...", busy = true)
         }
-        return GitWindowStatus(text = "COMMITS ACROSS WORKTREE REFS  {git_history_commit_count(repository, worktree)}")
+        var mode = "AUTO"
+        if (GIT_TREE_FILTER.value == 1) {
+            mode = "ALL"
+        }
+        return GitWindowStatus(text = "TREE {mode}   COMMITS {length(g_tree_model.nodes)}   REFS {g_tree_model.included_ref_count}")
     }
     if (GIT_HISTORY_TAB.selected) {
         if (!empty(worktree.history_error)) {
@@ -2267,6 +2292,7 @@ def herder_git_review_state(_input : JsonValue?) : JsonValue? {
 def herder_git_history_state(_input : JsonValue?) : JsonValue? {
     var refs : array<JsonValue?>
     var commits : array<JsonValue?>
+    var graph_rows : array<JsonValue?>
     var files : array<JsonValue?>
     if (g_client != null) {
         for (repository in g_client.repositories) {
@@ -2276,7 +2302,8 @@ def herder_git_history_state(_input : JsonValue?) : JsonValue? {
                 for (ref in repository.refs) {
                     if (ref.worktree_path != worktree.path) continue
                     refs |> push(JV((name = ref.name, full_name = ref.full_name,
-                        hash = ref.hash, current = ref.current, remote = ref.remote)))
+                        hash = ref.hash, current = ref.current, remote = ref.remote,
+                        upstream = ref.upstream)))
                 }
                 for (commit in repository.history_commits) {
                     if (commit.worktree_path != worktree.path) continue
@@ -2285,6 +2312,11 @@ def herder_git_history_state(_input : JsonValue?) : JsonValue? {
                         authored_at = commit.authored_at,
                         author = commit.author, subject = commit.subject,
                         parents = commit.parents)))
+                }
+                for (row in repository.graph_rows) {
+                    if (row.worktree_path != worktree.path) continue
+                    graph_rows |> push(JV((topology = row.topology,
+                        commit_hash = row.commit_hash)))
                 }
                 for (file in repository.commit_files) {
                     if (file.worktree_path != worktree.path
@@ -2308,7 +2340,48 @@ def herder_git_history_state(_input : JsonValue?) : JsonValue? {
                     history_error = worktree.history_error,
                     refs_loading = worktree.refs_loading,
                     refs_error = worktree.refs_error,
-                    refs = refs, commits = commits, files = files))
+                    refs = refs, commits = commits,
+                    graph_rows = graph_rows, files = files))
+            }
+        }
+    }
+    return JV((ok = false, error = "selected worktree is unavailable"))
+}
+
+[live_command(description = "Inspect the semantic Tree filter, focus, nodes, and edges.")]
+def herder_git_tree_state(_input : JsonValue?) : JsonValue? {
+    var nodes : array<JsonValue?>
+    var edges : array<JsonValue?>
+    nodes |> reserve(length(g_tree_model.nodes))
+    edges |> reserve(length(g_tree_model.edges))
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id != g_selected_repository_id) continue
+            for (worktree in repository.worktrees) {
+                if (worktree.path != g_selected_worktree_path) continue
+                ensure_tree_model(repository, worktree)
+                for (node in g_tree_model.nodes) {
+                    nodes |> push(JV((hash = node.hash, row = node.row,
+                        lane = node.lane, color_slot = node.color_slot,
+                        head = node.head, pushed = node.pushed,
+                        focused = node.focused, focus_head = node.focus_head,
+                        refs = node.refs_text, primary_ref = node.primary_ref)))
+                }
+                for (edge in g_tree_model.edges) {
+                    edges |> push(JV((child = edge.child, parent = edge.parent,
+                        color_slot = edge.color_slot, focused = edge.focused)))
+                }
+                var filter_name = "auto"
+                if (g_tree_model.filter == GitTreeFilter.all) {
+                    filter_name = "all"
+                }
+                return JV((ok = true,
+                    filter = filter_name,
+                    focus_ref = g_tree_model.focus_ref,
+                    base_ref = g_tree_model.base_ref,
+                    max_lane = g_tree_model.max_lane,
+                    included_ref_count = g_tree_model.included_ref_count,
+                    nodes = nodes, edges = edges))
             }
         }
     }
@@ -2653,6 +2726,7 @@ def init() {
     harness_maximize_window()
     DIFF_SYNTAX.value = 0
     DIFF_CONTEXT.value = 0
+    GIT_TREE_FILTER.value = 0
     var io & = unsafe(GetIO())
     io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
     g_fonts = load_unicode_font_roles(14.0f, g_font_sources)
@@ -2736,6 +2810,8 @@ def shutdown() {
         g_client = null
     }
     release_inspector_content()
+    delete g_tree_model.nodes
+    delete g_tree_model.edges
     text_source_view_dispose(g_inspector.old_view)
     text_source_view_dispose(g_inspector.new_view)
     text_source_view_dispose(g_inspector.view)

--- a/utils/dasHerd/watcher/tests/test_git_graph_model.das
+++ b/utils/dasHerd/watcher/tests/test_git_graph_model.das
@@ -1,0 +1,75 @@
+options gen2
+options rtti
+
+require dastest/testing_boost public
+require ../git_graph_model.das
+
+def private graph_commit(hash, parents : string; time : int64) : GitCommitState {
+    return GitCommitState(worktree_path = "D:/Work/tree", hash = hash,
+        short_hash = hash, authored_at = time, author = "Agent",
+        subject = hash, parents = parents)
+}
+
+def private graph_ref(name, hash : string; remote : bool = false;
+                      current : bool = false; upstream : string = "") : GitRefState {
+    return GitRefState(worktree_path = "D:/Work/tree",
+        full_name = remote ? "refs/remotes/{name}" : "refs/heads/{name}",
+        name = name, hash = hash, current = current,
+        remote = remote, upstream = upstream)
+}
+
+def private graph_node(model : GitTreeModel const; hash : string) : int {
+    for (index in range(length(model.nodes))) {
+        if (model.nodes[index].hash == hash) return index
+    }
+    return -1
+}
+
+[test]
+def test_git_graph_model(t : T?) {
+    t |> run("semantic Tree model retains branch, push, and focus roles") <| @(t : T?) {
+        var repository = RepositorySnapshot()
+        repository.history_commits <- [
+            graph_commit("F2", "F1", 60l),
+            graph_commit("P1", "B", 55l),
+            graph_commit("F1", "B", 50l),
+            graph_commit("B", "A", 40l),
+            graph_commit("A", "", 30l)]
+        repository.refs <- [
+            graph_ref("feature", "F2", false, true, "origin/feature"),
+            graph_ref("origin/feature", "F1", true),
+            graph_ref("parallel", "P1", false, false, "origin/parallel"),
+            graph_ref("origin/parallel", "P1", true),
+            graph_ref("origin/master", "B", true),
+            graph_ref("merged-label", "B")]
+        let worktree = WorktreeState(path = "D:/Work/tree", head = "F2",
+            branch = "feature", review_base_ref = "origin/master")
+        var model = GitTreeModel()
+        git_tree_build_model(repository, worktree,
+            GitTreeFilter.auto_, "feature", model)
+        t |> equal(length(model.nodes), 5)
+        t |> equal(length(model.edges), 4)
+        t |> success(model.included_ref_count >= 5,
+            "Auto includes outgoing locals, upstreams, base, and recent merged refs")
+        let f2 = graph_node(model, "F2")
+        let f1 = graph_node(model, "F1")
+        let p1 = graph_node(model, "P1")
+        let b = graph_node(model, "B")
+        t |> success(f2 >= 0 && f1 >= 0 && p1 >= 0 && b >= 0)
+        t |> success(model.nodes[f2].head && model.nodes[f2].focus_head)
+        t |> equal(model.nodes[f2].refs_text, "[feature]")
+        t |> equal(model.nodes[f2].primary_ref, "feature")
+        t |> success(!model.nodes[f2].pushed,
+            "local head beyond its upstream remains visibly unpushed")
+        t |> success(model.nodes[f1].head && model.nodes[f1].pushed)
+        t |> success(model.nodes[f2].focused && model.nodes[f1].focused)
+        t |> success(!model.nodes[b].focused,
+            "selected outgoing range stops at base ancestry")
+        t |> success(model.nodes[p1].head && model.nodes[p1].pushed)
+        t |> success(model.max_lane > 0,
+            "parallel history occupies a separate semantic lane")
+        delete model
+        delete repository.history_commits
+        delete repository.refs
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_git_graph_model.das
+++ b/utils/dasHerd/watcher/tests/test_git_graph_model.das
@@ -36,12 +36,13 @@ def test_git_graph_model(t : T?) {
             graph_commit("B", "A", 40l),
             graph_commit("A", "", 30l)]
         repository.refs <- [
-            graph_ref("feature", "F2", false, true, "origin/feature"),
             graph_ref("origin/feature", "F1", true),
-            graph_ref("parallel", "P1", false, false, "origin/parallel"),
+            graph_ref("feature", "F2", false, true, "origin/feature"),
             graph_ref("origin/parallel", "P1", true),
+            graph_ref("parallel", "P1", false, false, "origin/parallel"),
             graph_ref("origin/master", "B", true),
-            graph_ref("merged-label", "B")]
+            graph_ref("merged-label", "B"),
+            graph_ref("origin/unrelated", "F2", true)]
         let worktree = WorktreeState(path = "D:/Work/tree", head = "F2",
             branch = "feature", review_base_ref = "origin/master")
         var model = GitTreeModel()
@@ -66,8 +67,16 @@ def test_git_graph_model(t : T?) {
         t |> success(!model.nodes[b].focused,
             "selected outgoing range stops at base ancestry")
         t |> success(model.nodes[p1].head && model.nodes[p1].pushed)
+        t |> equal(model.nodes[p1].primary_ref, "parallel",
+            "a local branch remains the primary badge even when its remote sorts first")
         t |> success(model.max_lane > 0,
             "parallel history occupies a separate semantic lane")
+
+        git_tree_build_model(repository, worktree,
+            GitTreeFilter.all, "feature", model)
+        let all_f2 = graph_node(model, "F2")
+        t |> success(all_f2 >= 0 && !model.nodes[all_f2].pushed,
+            "a commit on an unrelated remote is not pushed for the owning branch")
         delete model
         delete repository.history_commits
         delete repository.refs

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -3,6 +3,7 @@ options gc
 options persistent_heap
 
 require dastest/testing_boost public
+require ../file_inspection.das
 require ../inspection_worker.das
 require daslib/jobque_boost
 require daslib/utf8_utils
@@ -18,6 +19,37 @@ def test_inspection_prepare_worker(t : T?) {
             "cpp", 1)
         tt |> equal(length(cpp.spans) > 1, true)
         text_source_document_dispose(cpp)
+    }
+    t |> run("compact Diff projects syntax from complete files") <| @(tt : T?) {
+        let complete_new = "options gen2\n\nstruct Sample \{\n    value : int\n\}\n\ndef answer(sample : Sample) : int \{\n    return sample.value + 1\n\}\n"
+        let compact_patch = "diff --git a/a.das b/a.das\n--- a/a.das\n+++ b/a.das\n@@ -8 +8 @@\n-    return sample.value\n+    return sample.value + 1\n"
+        var parsed <- git_parse_unified_patch(compact_patch)
+        let complete_old = inspector_reconstruct_old_source(complete_new, parsed)
+        tt |> equal(complete_old,
+            "options gen2\n\nstruct Sample \{\n    value : int\n\}\n\ndef answer(sample : Sample) : int \{\n    return sample.value\n\}\n")
+        var full_old <- tree_sitter_source_document(complete_old, "daslang", 21)
+        var full_new <- tree_sitter_source_document(complete_new, "daslang", 21)
+        var compact_old <- inspector_project_full_syntax(full_old,
+            parsed.old_aligned_text, parsed.rows, true, 21)
+        var compact_new <- inspector_project_full_syntax(full_new,
+            parsed.new_aligned_text, parsed.rows, false, 21)
+        tt |> success(length(compact_old.spans) > 1,
+            "old compact row retains complete-file syntax")
+        tt |> success(length(compact_new.spans) > 1,
+            "new compact row retains complete-file syntax")
+        var saw_keyword = false
+        for (span in compact_new.spans) {
+            if (span.syntax_style == TextSourceSyntaxStyle.keyword) {
+                saw_keyword = true
+            }
+        }
+        tt |> success(saw_keyword,
+            "the return keyword remains highlighted outside full context")
+        text_source_document_dispose(compact_old)
+        text_source_document_dispose(compact_new)
+        text_source_document_dispose(full_old)
+        text_source_document_dispose(full_new)
+        git_parsed_patch_dispose(parsed)
     }
     t |> run("worker prepares syntax off-thread and shuts down cleanly") <| @(t : T?) {
         t |> equal(is_utf8_string_valid("Καλημέρα, мир, こんにちは, 🐑"), true)

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -130,6 +130,14 @@ def test_repository_review_parsing(t : T?) {
         t |> equal(length(graph_commits), 1)
         t |> equal(graph_commits[0].subject, "Merge work")
         t |> equal(graph_commits[0].parents, "parent-one parent-two")
+        var collision_commits : array<GitCommitState>
+        repository_parse_review_commits(
+            "deadbeef<|dasHerd-field|>deadbeef<|dasHerd-field|>1721577900<|dasHerd-field|>Agent<|dasHerd-field|>Mention <|dasHerd-field|> literally<|dasHerd-field|>parent-one\n",
+            "D:/Work/tree", collision_commits)
+        t |> equal(length(collision_commits), 1)
+        t |> equal(collision_commits[0].subject,
+            "Mention <|dasHerd-field|> literally")
+        t |> equal(collision_commits[0].parents, "parent-one")
     }
     t |> run("aggregate PR files retain rename provenance") <| @(t : T?) {
         var files : array<GitReviewFileState>

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -139,6 +139,29 @@ def test_repository_review_parsing(t : T?) {
             "Mention <|dasHerd-field|> literally")
         t |> equal(collision_commits[0].parents, "parent-one")
     }
+    t |> run("Git graph history preserves commit and transition rows") <| @(t : T?) {
+        var commits : array<GitCommitState>
+        var rows : array<GitGraphRowState>
+        repository_parse_graph_history(
+            "* <|dasHerd-commit|>mergehash<|dasHerd-field|>merge<|dasHerd-field|>1721578000<|dasHerd-field|>Agent One<|dasHerd-field|>Merge topic<|dasHerd-field|>mainhash sidehash\r\n" +
+            "|\\  \r\n" +
+            "| * <|dasHerd-commit|>sidehash<|dasHerd-field|>side<|dasHerd-field|>1721577900<|dasHerd-field|>Agent Two<|dasHerd-field|>Mention <|dasHerd-field|> literally<|dasHerd-field|>mainhash\n" +
+            "|/  \n" +
+            "* <|dasHerd-commit|>mainhash<|dasHerd-field|>main<|dasHerd-field|>1721577800<|dasHerd-field|>Agent One<|dasHerd-field|>Main line<|dasHerd-field|>\n",
+            "D:/Work/tree", commits, rows)
+        t |> equal(length(commits), 3)
+        t |> equal(length(rows), 5)
+        t |> equal(rows[0].topology, "* ")
+        t |> equal(rows[0].commit_hash, "mergehash")
+        t |> equal(rows[1].topology, "|\\  ")
+        t |> equal(rows[1].commit_hash, "")
+        t |> equal(rows[2].topology, "| * ")
+        t |> equal(rows[3].topology, "|/  ")
+        t |> equal(rows[4].commit_hash, "mainhash")
+        t |> equal(commits[1].subject,
+            "Mention <|dasHerd-field|> literally")
+        t |> equal(commits[0].parents, "mainhash sidehash")
+    }
     t |> run("aggregate PR files retain rename provenance") <| @(t : T?) {
         var files : array<GitReviewFileState>
         repository_parse_review_files(
@@ -181,15 +204,25 @@ def test_repository_review_parsing(t : T?) {
         t |> equal(files[0].commit_hash, "abcdef0123456789")
         t |> equal(files[1].old_path, "old.md")
         t |> equal(files[1].path, "new.md")
+        files |> clear()
+        let esc = to_char(27)
+        repository_parse_commit_files(watcher_strip_terminal_controls(
+            "1{esc}[7C2{esc}[6Csrc/main.das\r\n"),
+            "D:/Work/tree", "abcdef0123456789", files)
+        t |> equal(length(files), 1)
+        t |> equal(files[0].added_lines, 1)
+        t |> equal(files[0].deleted_lines, 2)
+        t |> equal(files[0].path, "src/main.das")
         var refs : array<GitRefState>
         repository_parse_refs(
-            "refs/heads/main\tmain\tabcdef\t*\t\n" +
-            "refs/remotes/origin/main\torigin/main\tabcdef\t \t\n" +
+            "refs/heads/main\tmain\tabcdef\t*\t\torigin/main\n" +
+            "refs/remotes/origin/main\torigin/main\tabcdef\t \t\t\n" +
             "refs/remotes/origin/HEAD\torigin/HEAD\tabcdef\t \trefs/remotes/origin/main\n",
             "D:/Work/tree", refs)
         t |> equal(length(refs), 2)
         t |> success(refs[0].current)
         t |> success(!refs[0].remote)
+        t |> equal(refs[0].upstream, "origin/main")
         t |> success(refs[1].remote)
     }
     t |> run("working numstat updates only matching worktree files") <| @(t : T?) {

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -123,6 +123,13 @@ def test_repository_review_parsing(t : T?) {
         t |> equal(commits[0].short_hash, "01234567")
         t |> equal(commits[0].authored_at, 1721577600l)
         t |> equal(commits[1].subject, "Subject\twith tab")
+        var graph_commits : array<GitCommitState>
+        repository_parse_review_commits(
+            "feedface<|dasHerd-field|>feedface<|dasHerd-field|>1721577800<|dasHerd-field|>Agent<|dasHerd-field|>Merge work<|dasHerd-field|>parent-one parent-two\n",
+            "D:/Work/tree", graph_commits)
+        t |> equal(length(graph_commits), 1)
+        t |> equal(graph_commits[0].subject, "Merge work")
+        t |> equal(graph_commits[0].parents, "parent-one parent-two")
     }
     t |> run("aggregate PR files retain rename provenance") <| @(t : T?) {
         var files : array<GitReviewFileState>
@@ -134,6 +141,17 @@ def test_repository_review_parsing(t : T?) {
         t |> equal(files[1].path, "docs/new.md")
         t |> equal(files[2].old_path, "old name.cpp")
         t |> equal(files[2].path, "new name.cpp")
+        var stats : array<GitReviewFileState>
+        repository_parse_review_files(
+            "12  3  src/main.das\n0  0  old.cpp => src/new.cpp\n-  -  assets/image.png\n",
+            "D:/Work/tree", stats)
+        t |> equal(length(stats), 3)
+        t |> equal(stats[0].added_lines, 12)
+        t |> equal(stats[0].deleted_lines, 3)
+        t |> success(stats[0].stats_known)
+        t |> equal(stats[1].path, "src/new.cpp")
+        t |> success(stats[2].binary)
+        t |> success(!stats[2].stats_known)
     }
     t |> run("aggregate PR diffs compare the merge base with the index") <| @(t : T?) {
         var argv : array<string>
@@ -165,6 +183,19 @@ def test_repository_review_parsing(t : T?) {
         t |> success(refs[0].current)
         t |> success(!refs[0].remote)
         t |> success(refs[1].remote)
+    }
+    t |> run("working numstat updates only matching worktree files") <| @(t : T?) {
+        var files : array<GitFileState> <- [
+            GitFileState(worktree_path = "D:/Work/tree", code = " M",
+                path = "src/main.das"),
+            GitFileState(worktree_path = "D:/Work/other", code = " M",
+                path = "src/main.das")]
+        repository_apply_working_numstat(
+            "9  4  src/main.das\n", "D:/Work/tree", files)
+        t |> equal(files[0].added_lines, 9)
+        t |> equal(files[0].deleted_lines, 4)
+        t |> success(files[0].stats_known)
+        t |> success(!files[1].stats_known)
     }
     t |> run("commit inspection uses one observed revision") <| @(t : T?) {
         var argv : array<string>

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -240,6 +240,11 @@ def test_repository_review_parsing(t : T?) {
     }
     t |> run("commit inspection uses one observed revision") <| @(t : T?) {
         var argv : array<string>
+        var expected_exit_code = 0l
+        t |> equal(repository_file_diff_argv(
+            "missing", "D:/Work/tree", "src/main.das", "commit",
+            argv, expected_exit_code, "compact", ""),
+            "commit revision is required")
         t |> equal(repository_build_commit_file_diff_argv(
             "D:/Work/tree", "abcdef0123456789", "src/main.das",
             argv, "expanded"), "")

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -180,9 +180,16 @@ def test_repository_review_parsing(t : T?) {
         t |> equal(stats[0].added_lines, 12)
         t |> equal(stats[0].deleted_lines, 3)
         t |> success(stats[0].stats_known)
+        t |> equal(stats[1].old_path, "old.cpp")
         t |> equal(stats[1].path, "src/new.cpp")
         t |> success(stats[2].binary)
         t |> success(!stats[2].stats_known)
+        stats |> clear()
+        repository_parse_review_files(
+            "0  0  src/\{old => new\}.cpp\n",
+            "D:/Work/tree", stats)
+        t |> equal(stats[0].old_path, "src/old.cpp")
+        t |> equal(stats[0].path, "src/new.cpp")
     }
     t |> run("aggregate PR diffs compare the merge base with the index") <| @(t : T?) {
         var argv : array<string>
@@ -213,6 +220,12 @@ def test_repository_review_parsing(t : T?) {
         t |> equal(files[0].added_lines, 1)
         t |> equal(files[0].deleted_lines, 2)
         t |> equal(files[0].path, "src/main.das")
+        files |> clear()
+        repository_parse_commit_files(
+            "0  0  docs/\{before => after\}.md\n",
+            "D:/Work/tree", "abcdef0123456789", files)
+        t |> equal(files[0].old_path, "docs/before.md")
+        t |> equal(files[0].path, "docs/after.md")
         var refs : array<GitRefState>
         repository_parse_refs(
             "refs/heads/main\tmain\tabcdef\t*\t\torigin/main\n" +

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -99,9 +99,105 @@ def test_repository_untracked_diff_contract(t : T?) {
         let staged_view_error = repository_staged_file_view_argv(
             "D:/Work/tree", "staged.das", "D:/Temp/staged-view.raw", argv)
         t |> equal(staged_view_error, "")
-        t |> equal(argv[length(argv) - 2],
+        t |> success(ends_with(to_lower(argv[0]),
+            get_platform_name() == "windows" ? "daslang.exe" : "daslang"))
+        t |> success(ends_with(replace(argv[1], "\\", "/"),
+            "utils/dasHerd/watcher/git_blob_capture.das"))
+        t |> equal(argv[length(argv) - 3], "--revision=:0")
+        t |> equal(argv[length(argv) - 2], "--file=staged.das")
+        t |> equal(argv[length(argv) - 1],
             "--output=D:/Temp/staged-view.raw")
-        t |> equal(argv[length(argv) - 1], ":0:staged.das")
+    }
+}
+
+[test]
+def test_repository_review_parsing(t : T?) {
+    t |> run("worktree PR commits retain descriptions and identity") <| @(t : T?) {
+        var commits : array<GitCommitState>
+        repository_parse_review_commits(
+            "0123456789abcdef\t01234567\t1721577600\tAgent One\tFirst change\r\n" +
+            "abcdef0123456789\tabcdef01\t1721577700\tAgent Two\tSubject\twith tab\n",
+            "D:/Work/tree", commits)
+        t |> equal(length(commits), 2)
+        t |> equal(commits[0].worktree_path, "D:/Work/tree")
+        t |> equal(commits[0].short_hash, "01234567")
+        t |> equal(commits[0].authored_at, 1721577600l)
+        t |> equal(commits[1].subject, "Subject\twith tab")
+    }
+    t |> run("aggregate PR files retain rename provenance") <| @(t : T?) {
+        var files : array<GitReviewFileState>
+        repository_parse_review_files(
+            "M\tsrc/main.das\r\nA\tdocs/new.md\nR095\told name.cpp\tnew name.cpp\n",
+            "D:/Work/tree", files)
+        t |> equal(length(files), 3)
+        t |> equal(files[0].code, "M")
+        t |> equal(files[1].path, "docs/new.md")
+        t |> equal(files[2].old_path, "old name.cpp")
+        t |> equal(files[2].path, "new name.cpp")
+    }
+    t |> run("aggregate PR diffs compare the merge base with the index") <| @(t : T?) {
+        var argv : array<string>
+        let error = repository_build_review_file_diff_argv(
+            "D:/Work/tree", "0123456789abcdef", "src/main.das", argv, "expanded")
+        t |> equal(error, "")
+        t |> equal(argv[1], "--literal-pathspecs")
+        t |> equal(argv[8], "--cached")
+        t |> equal(argv[10], "--unified=20")
+        t |> equal(argv[11], "0123456789abcdef")
+        t |> equal(argv[length(argv) - 1], "src/main.das")
+    }
+    t |> run("commit files and refs retain review identity") <| @(t : T?) {
+        var files : array<GitCommitFileState>
+        repository_parse_commit_files(
+            "M\tsrc/main.das\r\nR090\told.md\tnew.md\n",
+            "D:/Work/tree", "abcdef0123456789", files)
+        t |> equal(length(files), 2)
+        t |> equal(files[0].commit_hash, "abcdef0123456789")
+        t |> equal(files[1].old_path, "old.md")
+        t |> equal(files[1].path, "new.md")
+        var refs : array<GitRefState>
+        repository_parse_refs(
+            "refs/heads/main\tmain\tabcdef\t*\t\n" +
+            "refs/remotes/origin/main\torigin/main\tabcdef\t \t\n" +
+            "refs/remotes/origin/HEAD\torigin/HEAD\tabcdef\t \trefs/remotes/origin/main\n",
+            "D:/Work/tree", refs)
+        t |> equal(length(refs), 2)
+        t |> success(refs[0].current)
+        t |> success(!refs[0].remote)
+        t |> success(refs[1].remote)
+    }
+    t |> run("commit inspection uses one observed revision") <| @(t : T?) {
+        var argv : array<string>
+        t |> equal(repository_build_commit_file_diff_argv(
+            "D:/Work/tree", "abcdef0123456789", "src/main.das",
+            argv, "expanded"), "")
+        t |> equal(argv[1], "--literal-pathspecs")
+        t |> equal(argv[7], "show")
+        t |> equal(argv[12], "--unified=20")
+        t |> equal(argv[13], "abcdef0123456789")
+        t |> equal(argv[length(argv) - 1], "src/main.das")
+        t |> equal(repository_commit_file_view_argv(
+            "D:/Work/tree", "abcdef0123456789", "src/main.das",
+            "D:/Temp/view.raw", argv), "")
+        t |> equal(argv[length(argv) - 3],
+            "--revision=abcdef0123456789")
+        t |> equal(argv[length(argv) - 2], "--file=src/main.das")
+        t |> equal(argv[length(argv) - 1], "--output=D:/Temp/view.raw")
+    }
+    t |> run("file staging actions use literal Git paths") <| @(t : T?) {
+        var argv : array<string>
+        t |> equal(repository_build_file_action_argv(
+            "D:/Work/tree", ":(glob)**.das", "stage", argv), "")
+        t |> equal(argv[1], "--literal-pathspecs")
+        t |> equal(argv[4], "add")
+        t |> equal(argv[length(argv) - 1], ":(glob)**.das")
+        t |> equal(repository_build_file_action_argv(
+            "D:/Work/tree", "src/main.das", "unstage", argv), "")
+        t |> equal(argv[4], "reset")
+        t |> equal(argv[5], "--quiet")
+        t |> equal(argv[6], "HEAD")
+        t |> success(!empty(repository_build_file_action_argv(
+            "D:/Work/tree", "../outside.txt", "stage", argv)))
     }
 }
 

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -289,6 +289,66 @@ def test_repository_relative_file_path_contract(t : T?) {
 }
 
 [test]
+def test_repository_async_lifecycle_contract(t : T?) {
+    t |> run("working-numstat launch failures remain refresh failures") <| @(t : T?) {
+        t |> equal(repository_phase_family(1), "refresh")
+        t |> equal(repository_phase_family(2), "refresh")
+        t |> equal(repository_phase_family(10), "refresh")
+        t |> equal(repository_phase_family(3), "review")
+        t |> equal(repository_phase_family(6), "review")
+        t |> equal(repository_phase_family(7), "history")
+        t |> equal(repository_phase_family(9), "history")
+    }
+    t |> run("inventory replacement releases removed-worktree payloads") <| @(t : T?) {
+        let kept = "D:/Work/main"
+        let removed = "D:/Work/removed"
+        var snapshot = RepositorySnapshot()
+        snapshot.files <- [
+            GitFileState(worktree_path = kept, path = "keep.txt"),
+            GitFileState(worktree_path = removed, path = "drop.txt")]
+        snapshot.review_commits <- [
+            GitCommitState(worktree_path = kept, hash = "keep"),
+            GitCommitState(worktree_path = removed, hash = "drop")]
+        snapshot.review_files <- [
+            GitReviewFileState(worktree_path = kept, path = "keep.txt"),
+            GitReviewFileState(worktree_path = removed, path = "drop.txt")]
+        snapshot.history_commits <- [
+            GitCommitState(worktree_path = kept, hash = "keep"),
+            GitCommitState(worktree_path = removed, hash = "drop")]
+        snapshot.graph_rows <- [
+            GitGraphRowState(worktree_path = kept, commit_hash = "keep"),
+            GitGraphRowState(worktree_path = removed, commit_hash = "drop")]
+        snapshot.commit_files <- [
+            GitCommitFileState(worktree_path = kept, path = "keep.txt"),
+            GitCommitFileState(worktree_path = removed, path = "drop.txt")]
+        snapshot.refs <- [
+            GitRefState(worktree_path = kept, name = "main"),
+            GitRefState(worktree_path = removed, name = "old")]
+        let observed : array<WorktreeState> <- [WorktreeState(path = kept)]
+
+        repository_prune_removed_worktree_data(snapshot, observed)
+
+        t |> equal(length(snapshot.files), 1)
+        t |> equal(length(snapshot.review_commits), 1)
+        t |> equal(length(snapshot.review_files), 1)
+        t |> equal(length(snapshot.history_commits), 1)
+        t |> equal(length(snapshot.graph_rows), 1)
+        t |> equal(length(snapshot.commit_files), 1)
+        t |> equal(length(snapshot.refs), 1)
+        t |> equal(snapshot.files[0].worktree_path, kept)
+        t |> equal(snapshot.refs[0].worktree_path, kept)
+
+        delete snapshot.files
+        delete snapshot.review_commits
+        delete snapshot.review_files
+        delete snapshot.history_commits
+        delete snapshot.graph_rows
+        delete snapshot.commit_files
+        delete snapshot.refs
+    }
+}
+
+[test]
 def test_repository_text_read_contract(t : T?) {
     t |> run("empty files remain distinct from read failures") <| @(t : T?) {
         let temp = create_temp_directory_result("dasherd_repository_text_")

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -37,6 +37,15 @@ def test_watcher_machine_output(t : T?) {
         let unicode_wrapped = "{esc}[31mΚαλημέρα, мир, こんにちは, 🐑{esc}[0m"
         t |> equal(watcher_strip_terminal_controls(unicode_wrapped),
             "Καλημέρα, мир, こんにちは, 🐑")
+        let e_acute : string = to_char(int(0xc3)) + to_char(int(0xa9))
+        t |> equal(watcher_strip_terminal_controls(e_acute + esc + "[5Gx"),
+            e_acute + "   x", "UTF-8 continuation bytes do not consume terminal columns")
+        let wide_cjk : string = to_char(int(0xe7)) + to_char(int(0x95)) + to_char(int(0x8c))
+        t |> equal(watcher_strip_terminal_controls(wide_cjk + esc + "[5Gx"),
+            wide_cjk + "  x", "wide Unicode codepoints consume two terminal columns")
+        let combining_acute : string = to_char(int(0xcc)) + to_char(int(0x81))
+        t |> equal(watcher_strip_terminal_controls("e" + combining_acute + esc + "[5Gx"),
+            "e" + combining_acute + "   x", "combining codepoints do not consume a terminal column")
     }
 }
 

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -49,6 +49,11 @@ def test_watcher_machine_output(t : T?) {
         t |> equal(watcher_strip_terminal_controls("e" + combining_acute + esc + "[5Gx"),
             "e" + combining_acute + "   x", "combining codepoints do not consume a terminal column")
     }
+    t |> run("machine output reports truncation through its out parameter") <| @(t : T?) {
+        var truncated = true
+        t |> equal(watcher_machine_output_text("missing-session", truncated), "")
+        t |> success(!truncated)
+    }
 }
 
 def private wait_for(session_id, state : string; timeout_ms : int64) : bool {

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -17,6 +17,12 @@ def test_watcher_machine_output(t : T?) {
         let bel = to_char(7)
         let wrapped = "{esc}[?9001h{esc}[2J{esc}[Hfirst\r\nsecond\tvalue{esc}]0;git.exe{bel}{esc}[?25h"
         t |> equal(watcher_strip_terminal_controls(wrapped), "first\r\nsecond\tvalue")
+        let expanded_tabs = "1{esc}[7C2{esc}[6Cutils/dasHerd/watcher_core.das"
+        t |> equal(watcher_strip_terminal_controls(expanded_tabs),
+            "1       2      utils/dasHerd/watcher_core.das")
+        let worktrees = "worktree D:/main\r\nHEAD A\r\nbranch refs/heads/main{esc}[5;1Hworktree D:/linked\r\nHEAD B\r\nbranch refs/heads/topic"
+        t |> equal(watcher_strip_terminal_controls(worktrees),
+            "worktree D:/main\r\nHEAD A\r\nbranch refs/heads/main\n\nworktree D:/linked\r\nHEAD B\r\nbranch refs/heads/topic")
         let unicode_wrapped = "{esc}[31mΚαλημέρα, мир, こんにちは, 🐑{esc}[0m"
         t |> equal(watcher_strip_terminal_controls(unicode_wrapped),
             "Καλημέρα, мир, こんにちは, 🐑")

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -31,6 +31,8 @@ def test_watcher_machine_output(t : T?) {
         let expanded_tabs = "1{esc}[7C2{esc}[6Cutils/dasHerd/watcher_core.das"
         t |> equal(watcher_strip_terminal_controls(expanded_tabs),
             "1       2      utils/dasHerd/watcher_core.das")
+        t |> equal(watcher_strip_terminal_controls("abc\n{esc}[5Gx"),
+            "abc\n    x", "normalized lone LF resets the synthesized text column")
         let worktrees = "worktree D:/main\r\nHEAD A\r\nbranch refs/heads/main{esc}[5;1Hworktree D:/linked\r\nHEAD B\r\nbranch refs/heads/topic"
         t |> equal(watcher_strip_terminal_controls(worktrees),
             "worktree D:/main\r\nHEAD A\r\nbranch refs/heads/main\n\nworktree D:/linked\r\nHEAD B\r\nbranch refs/heads/topic")

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -12,6 +12,17 @@ def test_watcher_machine_output(t : T?) {
         t |> equal(watcher_target_id_or_local(""), "local")
         t |> equal(watcher_target_id_or_local("ssh-build"), "ssh-build")
     }
+    t |> run("watcher GC reacts to allocation pressure as well as fragmentation") <| @(t : T?) {
+        t |> equal(watcher_gc_reason(64ul * 1024ul * 1024ul,
+            65ul * 1024ul * 1024ul, 1ul, 1ul), "string_pressure")
+        t |> equal(watcher_gc_reason(1ul, 1ul,
+            128ul * 1024ul * 1024ul, 129ul * 1024ul * 1024ul), "heap_pressure")
+        t |> equal(watcher_gc_reason(10ul, 100ul, 10ul, 10ul),
+            "string_fragmentation")
+        t |> equal(watcher_gc_reason(10ul, 10ul, 10ul, 100ul),
+            "heap_fragmentation")
+        t |> equal(watcher_gc_reason(10ul, 10ul, 10ul, 10ul), "")
+    }
     t |> run("ConPTY wrapper controls are removed without changing task text") <| @(t : T?) {
         let esc = to_char(27)
         let bel = to_char(7)

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -80,7 +80,7 @@ def test_watcher_process_lifecycle(t : T?) {
         let failed_metadata = fread(path_join(path_join(path_join(root, "sessions"),
             failed.session_id), "session.json"))
         t |> success(find(failed_metadata, "\"columns\":20") >= 0
-                && find(failed_metadata, "\"rows\":200") >= 0,
+                && find(failed_metadata, "\"rows\":512") >= 0,
             "session metadata retains the clamped launch dimensions")
         watcher_tick()
         t |> success(find(watcher_snapshot_json(failed.session_id), "\"state\":\"failed\"") >= 0,

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -470,6 +470,7 @@ def public watcher_strip_terminal_controls(value : string) : string {
                         utf8_remaining = 0
                     } elif (byte == '\n') {
                         cursor_row++
+                        cursor_column = 1
                         utf8_remaining = 0
                     } elif (byte < 0x80) {
                         cursor_column++

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -430,6 +430,13 @@ def public watcher_strip_terminal_controls(value : string) : string {
     var inscope output : array<uint8>
     output |> reserve(length(value))
     var state = 0 // 0=text, 1=ESC, 2=CSI, 3=OSC, 4=OSC ESC, 5=ST string, 6=ST ESC
+    var csi_first = 0
+    var csi_second = 0
+    var csi_field = 0
+    var csi_has_first = false
+    var csi_has_second = false
+    var cursor_row = 1
+    var cursor_column = 1
     peek_data(value) $(bytes) {
         for (index in range(length(value))) {
             let byte = int(bytes[index])
@@ -439,10 +446,22 @@ def public watcher_strip_terminal_controls(value : string) : string {
                 }
                 elif (byte == '\t' || byte == '\r' || byte == '\n' || byte >= 0x20) {
                     output |> push(uint8(byte))
+                    if (byte == '\r') {
+                        cursor_column = 1
+                    } elif (byte == '\n') {
+                        cursor_row++
+                    } else {
+                        cursor_column++
+                    }
                 }
             } elif (state == 1) {
                 if (byte == '[') {
                     state = 2
+                    csi_first = 0
+                    csi_second = 0
+                    csi_field = 0
+                    csi_has_first = false
+                    csi_has_second = false
                 } elif (byte == ']') {
                     state = 3
                 } elif (byte == 'P' || byte == '^' || byte == '_' || byte == 'X') {
@@ -451,7 +470,45 @@ def public watcher_strip_terminal_controls(value : string) : string {
                     state = 0
                 }
             } elif (state == 2) {
-                if (byte >= 0x40 && byte <= 0x7e) {
+                if (is_number(byte)) {
+                    if (csi_field == 0) {
+                        csi_first = min(4096, csi_first * 10 + byte - '0')
+                        csi_has_first = true
+                    } else {
+                        csi_second = min(4096, csi_second * 10 + byte - '0')
+                        csi_has_second = true
+                    }
+                } elif (byte == ';') {
+                    csi_field = 1
+                } elif (byte >= 0x40 && byte <= 0x7e) {
+                    // ConPTY expands horizontal tabs emitted by console
+                    // applications into CSI cursor commands. Preserve their
+                    // field and record-separating effect for machine consumers.
+                    if (byte == 'C') {
+                        let spaces = csi_has_first ? max(1, csi_first) : 1
+                        for (_ in range(spaces)) {
+                            output |> push(uint8(' '))
+                        }
+                        cursor_column += spaces
+                    } elif (byte == 'G') {
+                        let target_column = csi_has_first ? max(1, csi_first) : 1
+                        while (cursor_column < target_column) {
+                            output |> push(uint8(' '))
+                            cursor_column++
+                        }
+                    } elif (byte == 'H' || byte == 'f') {
+                        let target_row = csi_has_first ? max(1, csi_first) : 1
+                        let target_column = csi_has_second ? max(1, csi_second) : 1
+                        while (cursor_row < target_row) {
+                            output |> push(uint8('\n'))
+                            cursor_row++
+                            cursor_column = 1
+                        }
+                        while (cursor_column < target_column) {
+                            output |> push(uint8(' '))
+                            cursor_column++
+                        }
+                    }
                     state = 0
                 }
             } elif (state == 3) {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -583,7 +583,7 @@ def public watcher_strip_terminal_controls(value : string) : string {
 }
 
 def public watcher_machine_output_text(session_id : string;
-                                       var truncated : bool) : string {
+                                       var truncated : bool&) : string {
     truncated = false
     let index = watcher_find_session(session_id)
     if (index < 0 || g_sessions[index] == null) return ""

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -440,8 +440,9 @@ def public watcher_output_text(session_id : string) : string {
 def public watcher_strip_terminal_controls(value : string) : string {
     // Task processes launched through ConPTY are wrapped in cursor, screen,
     // title, and mode sequences even when the child itself emits plain text.
-    // Machine consumers need the original printable byte stream, not a
-    // bounded reconstructed screen.
+    // Machine consumers need the printable byte stream, not a bounded screen;
+    // cursor moves are intentionally normalized into spaces/newlines so
+    // ConPTY-expanded field and record separators remain machine-parseable.
     var inscope output : array<uint8>
     output |> reserve(length(value))
     var state = 0 // 0=text, 1=ESC, 2=CSI, 3=OSC, 4=OSC ESC, 5=ST string, 6=ST ESC
@@ -452,6 +453,9 @@ def public watcher_strip_terminal_controls(value : string) : string {
     var csi_has_second = false
     var cursor_row = 1
     var cursor_column = 1
+    var utf8_codepoint = 0u
+    var utf8_minimum = 0u
+    var utf8_remaining = 0
     peek_data(value) $(bytes) {
         for (index in range(length(value))) {
             let byte = int(bytes[index])
@@ -463,10 +467,41 @@ def public watcher_strip_terminal_controls(value : string) : string {
                     output |> push(uint8(byte))
                     if (byte == '\r') {
                         cursor_column = 1
+                        utf8_remaining = 0
                     } elif (byte == '\n') {
                         cursor_row++
-                    } else {
+                        utf8_remaining = 0
+                    } elif (byte < 0x80) {
                         cursor_column++
+                        utf8_remaining = 0
+                    } elif (utf8_remaining > 0 && (byte & 0xc0) == 0x80) {
+                        utf8_codepoint = (utf8_codepoint << 6u) | uint(byte & 0x3f)
+                        utf8_remaining--
+                        if (utf8_remaining == 0) {
+                            let valid = (utf8_codepoint >= utf8_minimum &&
+                                utf8_codepoint <= 0x10ffffu &&
+                                !(utf8_codepoint >= 0xd800u && utf8_codepoint <= 0xdfffu))
+                            cursor_column += terminal_codepoint_width(
+                                valid ? utf8_codepoint : 0xfffdu)
+                        }
+                    } else {
+                        if (utf8_remaining > 0) cursor_column++
+                        if ((byte & 0xe0) == 0xc0) {
+                            utf8_codepoint = uint(byte & 0x1f)
+                            utf8_minimum = 0x80u
+                            utf8_remaining = 1
+                        } elif ((byte & 0xf0) == 0xe0) {
+                            utf8_codepoint = uint(byte & 0x0f)
+                            utf8_minimum = 0x800u
+                            utf8_remaining = 2
+                        } elif ((byte & 0xf8) == 0xf0) {
+                            utf8_codepoint = uint(byte & 0x07)
+                            utf8_minimum = 0x10000u
+                            utf8_remaining = 3
+                        } else {
+                            cursor_column++
+                            utf8_remaining = 0
+                        }
                     }
                 }
             } elif (state == 1) {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -18,6 +18,21 @@ let private MAX_COMMAND_BYTES = 32 * 1024
 let private MAX_INPUT_BYTES = 1024 * 1024
 let private MAX_RAW_HISTORY_BYTES = 8 * 1024 * 1024
 let private RAW_HISTORY_TRIM_SLACK = 1024 * 1024
+let private WATCHER_GC_STRING_PRESSURE_BYTES = 64ul * 1024ul * 1024ul
+let private WATCHER_GC_HEAP_PRESSURE_BYTES = 128ul * 1024ul * 1024ul
+
+def public watcher_gc_reason(string_used, string_total,
+                             heap_used, heap_total : uint64) : string {
+    if (string_used >= WATCHER_GC_STRING_PRESSURE_BYTES) return "string_pressure"
+    if (heap_used >= WATCHER_GC_HEAP_PRESSURE_BYTES) return "heap_pressure"
+    if (string_total > 0ul && string_used * 3ul < string_total * 2ul) {
+        return "string_fragmentation"
+    }
+    if (heap_total > 0ul && heap_used * 3ul < heap_total) {
+        return "heap_fragmentation"
+    }
+    return ""
+}
 
 struct public WatcherLaunchRequest {
     command_line : string

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -275,7 +275,7 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         return WatcherLaunchResult(error = "could not open session logs")
     }
     let columns = clamp(request.columns, 20, 400)
-    let rows = clamp(request.rows, 5, 200)
+    let rows = clamp(request.rows, 5, 512)
     var inscope persisted_request := request
     persisted_request.columns = columns
     persisted_request.rows = rows
@@ -503,7 +503,7 @@ def public watcher_compact_session(session_id : string;
     var session = g_sessions[index]
     if (!session.drained || session.state == "running" || session.state == "terminating") return false
     let compact_columns = clamp(columns, 20, 400)
-    let compact_rows = clamp(rows, 5, 200)
+    let compact_rows = clamp(rows, 5, 512)
     if (session.terminal.transport == null && session.terminal.columns == compact_columns
             && session.terminal.rows == compact_rows) return true
     var inscope compact <- terminal_create(compact_columns, compact_rows)
@@ -559,7 +559,7 @@ def public watcher_input(session_id : string; text : string; client_id : int = 0
 
 def private resize_session(var session : WatcherSession?; columns, rows, client_id : int) : string {
     if (session.controller_id != 0 && session.controller_id != client_id) return "controller lease is held by another client"
-    terminal_resize(session.terminal, clamp(columns, 20, 400), clamp(rows, 5, 200))
+    terminal_resize(session.terminal, clamp(columns, 20, 400), clamp(rows, 5, 512))
     append_event(session, "resized", "{session.terminal.columns}x{session.terminal.rows}")
     return ""
 }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -50,6 +50,8 @@ struct private WatcherWsMessage {
     worktree_path : string
     file_path : string
     comparison : string
+    revision : string
+    action : string
     diff_context : string
     request_id : int
     text : string
@@ -68,6 +70,7 @@ struct public RepositoryFileInspectionMessage {
     worktree_path : string
     file_path : string
     comparison : string
+    revision : string
     diff_context : string
     task_session_id : string
     loading : bool
@@ -76,6 +79,20 @@ struct public RepositoryFileInspectionMessage {
     view_base64 : string
     view_byte_count : int
     view_available : bool
+    status : string
+    error : string
+}
+
+struct public RepositoryGitFileActionMessage {
+    @rename = "type"
+    _type : string = "git_file_action"
+    request_id : int
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    action : string
+    task_session_id : string
+    loading : bool
     status : string
     error : string
 }
@@ -96,6 +113,7 @@ class private WatcherClient {
     inspection_worktree_path : string
     inspection_file_path : string
     inspection_comparison : string
+    inspection_revision : string
     inspection_diff_context : string
     inspection_session_id : string
     inspection_expected_exit_code : int64
@@ -103,6 +121,13 @@ class private WatcherClient {
     inspection_phase : string
     inspection_patch : string
     inspection_artifact_path : string
+    action_request_id : int
+    action_repository_id : string
+    action_worktree_path : string
+    action_file_path : string
+    action : string
+    action_session_id : string
+    action_delivered : bool = true
 }
 
 struct private WatcherOk {
@@ -354,6 +379,7 @@ class DasHerdWatcherServer : HvWebServer {
             worktree_path = client.inspection_worktree_path,
             file_path = client.inspection_file_path,
             comparison = client.inspection_comparison,
+            revision = client.inspection_revision,
             diff_context = client.inspection_diff_context,
             task_session_id = client.inspection_session_id,
             loading = loading, patch = patch, view_text = view_text,
@@ -391,14 +417,103 @@ class DasHerdWatcherServer : HvWebServer {
         client.inspection_artifact_path = ""
     }
 
-    def start_staged_file_view(var client : WatcherClient?; patch : string) {
+    def send_git_file_action(var client : WatcherClient?; loading : bool;
+                             status : string; error : string = "") {
+        if (client == null) return
+        let message = RepositoryGitFileActionMessage(
+            request_id = client.action_request_id,
+            repository_id = client.action_repository_id,
+            worktree_path = client.action_worktree_path,
+            file_path = client.action_file_path,
+            action = client.action,
+            task_session_id = client.action_session_id,
+            loading = loading, status = status, error = error)
+        send(client.channel, sprint_json(message, false),
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def start_git_file_action(var client : WatcherClient?;
+                              incoming : WatcherWsMessage const) {
+        if (client == null) return
+        if (!client.action_delivered) {
+            self.send_git_file_action(client, false, "failed",
+                "another Git file action is still running")
+            return
+        }
+        client.action_request_id = incoming.request_id
+        client.action_repository_id = incoming.repository_id
+        client.action_worktree_path = incoming.worktree_path
+        client.action_file_path = incoming.file_path
+        client.action = incoming.action
+        client.action_session_id = ""
+        var inscope argv : array<string>
+        let command_error = repository_file_action_argv(
+            incoming.repository_id, incoming.worktree_path,
+            incoming.file_path, incoming.action, argv)
+        if (!empty(command_error)) {
+            self.send_git_file_action(client, false, "failed", command_error)
+            return
+        }
+        let kind = incoming.action == "stage" ? "git-stage" : "git-unstage"
+        let _pruned = watcher_prune_completed_sessions(
+            kind, incoming.repository_id, incoming.worktree_path)
+        var inscope request = WatcherLaunchRequest(
+            cwd = incoming.worktree_path,
+            display_name = "Git {incoming.action}: {incoming.file_path}",
+            kind = kind, target_id = "local",
+            repository_id = incoming.repository_id,
+            worktree_path = incoming.worktree_path,
+            columns = 160, rows = 50, timeout_ms = 15000l)
+        request.argv := argv
+        let result = watcher_launch(request)
+        client.action_session_id = result.session_id
+        if (!result.ok) {
+            self.send_git_file_action(client, false, "failed", result.error)
+            return
+        }
+        client.action_delivered = false
+        self.send_git_file_action(client, true, "running")
+    }
+
+    def poll_git_file_action(var client : WatcherClient?) {
+        if (client == null || client.action_delivered
+                || empty(client.action_session_id)) return
+        var info = WatcherSessionInfo()
+        if (!watcher_get_session_info(client.action_session_id, info)
+                || !info.drained) return
+        client.action_delivered = true
+        let truncated = false
+        let output = watcher_machine_output_text(client.action_session_id, truncated)
+        let _compacted = watcher_compact_session(client.action_session_id, 160, 50)
+        if (truncated) {
+            self.send_git_file_action(client, false, "failed",
+                "Git action output exceeded the retained machine-output limit")
+        } elif (info.exit_code != 0l) {
+            self.send_git_file_action(client, false, "failed",
+                "git exited with {info.exit_code}: {output}")
+        } else {
+            self.send_git_file_action(client, false, "completed")
+            let _refresh_error = repository_refresh(client.action_repository_id)
+            let _review_error = repository_review(
+                client.action_repository_id, client.action_worktree_path)
+        }
+    }
+
+    def start_indexed_file_view(var client : WatcherClient?; patch : string) {
         if (client == null) return
         let artifact_path = watcher_session_artifact_path(
-            client.inspection_session_id, "staged-view.raw")
+            client.inspection_session_id, "git-view.raw")
         var inscope argv : array<string>
-        let command_error = repository_staged_file_view_argv(
-            client.inspection_worktree_path, client.inspection_file_path,
-            artifact_path, argv)
+        var command_error = ""
+        if (client.inspection_comparison == "commit") {
+            command_error = repository_commit_file_view_argv(
+                client.inspection_worktree_path, client.inspection_revision,
+                client.inspection_file_path, artifact_path, argv)
+        } else {
+            command_error = repository_staged_file_view_argv(
+                client.inspection_worktree_path, client.inspection_file_path,
+                artifact_path, argv)
+        }
         if (!empty(command_error)) {
             client.inspection_delivered = true
             self.send_file_inspection(client, false, patch, command_error)
@@ -409,14 +524,14 @@ class DasHerdWatcherServer : HvWebServer {
             client.inspection_worktree_path)
         var inscope request = WatcherLaunchRequest(
             cwd = client.inspection_worktree_path,
-            display_name = "Git staged view: {client.inspection_file_path}",
+            display_name = "Git file view: {client.inspection_file_path}",
             kind = "git-file-view", target_id = "local",
             repository_id = client.inspection_repository_id,
             worktree_path = client.inspection_worktree_path,
             columns = 80, rows = 25, timeout_ms = 15000l)
         request.argv := argv
         let result = watcher_launch(request)
-        client.inspection_phase = "staged-view"
+        client.inspection_phase = "indexed-view"
         client.inspection_patch = clone_string(patch)
         client.inspection_artifact_path = artifact_path
         client.inspection_session_id = result.session_id
@@ -430,7 +545,7 @@ class DasHerdWatcherServer : HvWebServer {
         }
         client.inspection_delivered = false
         self.send_file_inspection(client, true, "", "", "",
-            "Reading full staged file (15 second limit)...")
+            "Reading full Git file (15 second limit)...")
     }
 
     def start_file_inspection(var client : WatcherClient?;
@@ -446,6 +561,7 @@ class DasHerdWatcherServer : HvWebServer {
         client.inspection_worktree_path = incoming.worktree_path
         client.inspection_file_path = incoming.file_path
         client.inspection_comparison = incoming.comparison
+        client.inspection_revision = incoming.revision
         client.inspection_diff_context = incoming.diff_context
         if (empty(client.inspection_diff_context)) {
             client.inspection_diff_context = "compact"
@@ -460,7 +576,8 @@ class DasHerdWatcherServer : HvWebServer {
         let command_error = repository_file_diff_argv(
             incoming.repository_id, incoming.worktree_path,
             incoming.file_path, incoming.comparison,
-            argv, expected_exit_code, client.inspection_diff_context)
+            argv, expected_exit_code, client.inspection_diff_context,
+            client.inspection_revision)
         if (!empty(command_error)) {
             self.send_file_inspection(client, false, "", command_error)
             return
@@ -496,14 +613,14 @@ class DasHerdWatcherServer : HvWebServer {
         let truncated = false
         let output = watcher_machine_output_text(client.inspection_session_id, truncated)
         let _compacted = watcher_compact_session(client.inspection_session_id, 80, 25)
-        if (client.inspection_phase == "staged-view") {
+        if (client.inspection_phase == "indexed-view") {
             client.inspection_delivered = true
             if (truncated) {
                 self.cleanup_inspection_artifact(client)
                 let patch = client.inspection_patch
                 client.inspection_patch = ""
                 self.send_file_inspection(client, false, patch,
-                    "staged file command exceeded the retained machine-output limit")
+                    "Git file command exceeded the retained machine-output limit")
                 return
             }
             if (info.exit_code != client.inspection_expected_exit_code) {
@@ -550,13 +667,15 @@ class DasHerdWatcherServer : HvWebServer {
             self.send_file_inspection(client, false, "",
                 "git diff exited with {info.exit_code}: {output}")
         } else {
-            if (client.inspection_comparison == "staged") {
+            if (client.inspection_comparison == "staged"
+                    || client.inspection_comparison == "pr"
+                    || client.inspection_comparison == "commit") {
                 if (git_patch_result_is_deleted(output)) {
                     self.send_file_inspection(client, false, output, "",
                         "", "", "", 0, true)
                     return
                 }
-                self.start_staged_file_view(client, output)
+                self.start_indexed_file_view(client, output)
                 return
             }
             var view_text = ""
@@ -692,6 +811,30 @@ class DasHerdWatcherServer : HvWebServer {
             let error = repository_refresh(incoming.repository_id)
             if (!empty(error)) send_error(channel, error)
             send_repositories(client, true)
+        } elif (incoming.op == "repository_review") {
+            let error = repository_review(
+                incoming.repository_id, incoming.worktree_path)
+            if (!empty(error)) send_error(channel, error)
+            send_repositories(client, true)
+        } elif (incoming.op == "repository_history") {
+            let error = repository_history(
+                incoming.repository_id, incoming.worktree_path,
+                incoming.revision)
+            if (!empty(error)) send_error(channel, error)
+            send_repositories(client, true)
+        } elif (incoming.op == "repository_commit_files") {
+            let error = repository_commit_files(
+                incoming.repository_id, incoming.worktree_path,
+                incoming.revision)
+            if (!empty(error)) send_error(channel, error)
+            send_repositories(client, true)
+        } elif (incoming.op == "repository_refs") {
+            let error = repository_refs(
+                incoming.repository_id, incoming.worktree_path)
+            if (!empty(error)) send_error(channel, error)
+            send_repositories(client, true)
+        } elif (incoming.op == "git_file_action") {
+            self.start_git_file_action(client, incoming)
         } elif (incoming.op == "file_inspect") {
             self.start_file_inspection(client, incoming)
         } elif (incoming.op == "launch") {
@@ -774,6 +917,7 @@ class DasHerdWatcherServer : HvWebServer {
             send_snapshot(client)
             send_raw_output(client)
             send_repositories(client)
+            self.poll_git_file_action(client)
             self.poll_file_inspection(client)
         }
     }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -97,6 +97,14 @@ struct public RepositoryGitFileActionMessage {
     error : string
 }
 
+struct private OrphanedGitFileAction {
+    session_id : string
+    repository_id : string
+    worktree_path : string
+    file_path : string
+    action : string
+}
+
 class private WatcherClient {
     @safe_when_uninitialized
     channel : WebSocketChannel = default<WebSocketChannel>
@@ -201,6 +209,7 @@ class DasHerdWatcherServer : HvWebServer {
     xterm_web_links_js : string
     clients : array<WatcherClient?>
     pending_inspection_artifacts : array<string>
+    orphaned_git_actions : array<OrphanedGitFileAction>
     next_client_id : int
 
     def authorized(url : string) : bool {
@@ -485,17 +494,80 @@ class DasHerdWatcherServer : HvWebServer {
         let truncated = false
         let output = watcher_machine_output_text(client.action_session_id, truncated)
         let _compacted = watcher_compact_session(client.action_session_id, 160, 50)
+        var failure = ""
         if (truncated) {
-            self.send_git_file_action(client, false, "failed",
-                "Git action output exceeded the retained machine-output limit")
+            failure = "Git action output exceeded the retained machine-output limit"
         } elif (info.exit_code != 0l) {
-            self.send_git_file_action(client, false, "failed",
-                "git exited with {info.exit_code}: {output}")
+            failure = "git exited with {info.exit_code}: {output}"
+        }
+        if (!empty(failure)) {
+            let _failure_error = repository_record_task_failure(
+                client.action_repository_id, client.action_session_id, failure)
+            self.send_git_file_action(client, false, "failed", failure)
         } else {
             self.send_git_file_action(client, false, "completed")
-            let _refresh_error = repository_refresh(client.action_repository_id)
+        }
+        let _refresh_error = repository_refresh(client.action_repository_id)
+        let _review_error = repository_review(
+            client.action_repository_id, client.action_worktree_path)
+    }
+
+    def remember_orphaned_git_action(var client : WatcherClient?) {
+        if (client == null || client.action_delivered
+                || empty(client.action_session_id)) return
+        orphaned_git_actions |> push(OrphanedGitFileAction(
+            session_id = client.action_session_id,
+            repository_id = client.action_repository_id,
+            worktree_path = client.action_worktree_path,
+            file_path = client.action_file_path,
+            action = client.action))
+        print("dasHerd watcher: retaining Git {client.action} task " +
+            "{client.action_session_id} for {client.action_file_path} " +
+            "after client disconnect\n")
+    }
+
+    def poll_orphaned_git_actions() {
+        var index = length(orphaned_git_actions)
+        while (index > 0) {
+            index--
+            let action = orphaned_git_actions[index]
+            var info = WatcherSessionInfo()
+            if (!watcher_get_session_info(action.session_id, info)) {
+                let failure = "orphaned Git action session disappeared before observation"
+                let _failure_error = repository_record_task_failure(
+                    action.repository_id, action.session_id, failure)
+                let _refresh_error = repository_refresh(action.repository_id)
+                let _review_error = repository_review(
+                    action.repository_id, action.worktree_path)
+                print("dasHerd watcher: Git {action.action} task " +
+                    "{action.session_id} for {action.file_path} disappeared\n")
+                orphaned_git_actions |> erase(index)
+                continue
+            }
+            if (!info.drained) continue
+            let truncated = false
+            let output = watcher_machine_output_text(action.session_id, truncated)
+            let _compacted = watcher_compact_session(
+                action.session_id, 160, 50)
+            var failure = ""
+            if (truncated) {
+                failure = "Git action output exceeded the retained machine-output limit"
+            } elif (info.exit_code != 0l) {
+                failure = "git exited with {info.exit_code}: {output}"
+            }
+            if (!empty(failure)) {
+                let _failure_error = repository_record_task_failure(
+                    action.repository_id, action.session_id, failure)
+                print("dasHerd watcher: orphaned Git {action.action} task " +
+                    "{action.session_id} for {action.file_path} failed: {failure}\n")
+            } else {
+                print("dasHerd watcher: orphaned Git {action.action} task " +
+                    "{action.session_id} for {action.file_path} completed\n")
+            }
+            let _refresh_error = repository_refresh(action.repository_id)
             let _review_error = repository_review(
-                client.action_repository_id, client.action_worktree_path)
+                action.repository_id, action.worktree_path)
+            orphaned_git_actions |> erase(index)
         }
     }
 
@@ -780,6 +852,7 @@ class DasHerdWatcherServer : HvWebServer {
         let client_id = client.id
         detach(client, "client_closed")
         self.cleanup_inspection_artifact(client)
+        self.remember_orphaned_git_action(client)
         clients |> erase(index)
         unsafe { delete client }
         print("dasHerd watcher: client {client_id} disconnected\n")
@@ -902,6 +975,7 @@ class DasHerdWatcherServer : HvWebServer {
         watcher_tick()
         repository_tick()
         self.retry_inspection_artifact_cleanup()
+        self.poll_orphaned_git_actions()
         for (index in range(length(clients))) {
             var client = clients[index]
             if (client == null) continue
@@ -934,5 +1008,6 @@ class DasHerdWatcherServer : HvWebServer {
     def cleanup_inspection_artifacts {
         self.retry_inspection_artifact_cleanup()
         delete pending_inspection_artifacts
+        delete orphaned_git_actions
     }
 }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -766,6 +766,7 @@ class DasHerdWatcherServer : HvWebServer {
         next_client_id++
         clients |> push(new WatcherClient(channel = channel, id = next_client_id,
             last_heartbeat = ref_time_ticks()))
+        print("dasHerd watcher: client {next_client_id} connected\n")
         send(channel, "\{\"type\":\"connected\",\"client_id\":{next_client_id}\}",
             ws_opcode.WS_OPCODE_TEXT, true)
         send_sessions(channel)
@@ -776,10 +777,12 @@ class DasHerdWatcherServer : HvWebServer {
         let index = find_client(channel)
         if (index < 0) return
         var client = clients[index]
+        let client_id = client.id
         detach(client, "client_closed")
         self.cleanup_inspection_artifact(client)
         clients |> erase(index)
         unsafe { delete client }
+        print("dasHerd watcher: client {client_id} disconnected\n")
     }
 
     def override onWsMessage(channel : WebSocketChannel; message : string#) {
@@ -797,7 +800,6 @@ class DasHerdWatcherServer : HvWebServer {
             send(channel, "\{\"type\":\"heartbeat\"\}", ws_opcode.WS_OPCODE_TEXT, true)
         } elif (incoming.op == "list") {
             send_sessions(channel)
-            send_repositories(client, true)
         } elif (incoming.op == "repository_add") {
             let error = repository_add(RepositoryAddRequest(path = incoming.repository_path,
                 display_name = incoming.display_name,
@@ -806,33 +808,27 @@ class DasHerdWatcherServer : HvWebServer {
                 send_error(channel, error)
                 return
             }
-            send_repositories(client, true)
         } elif (incoming.op == "repository_refresh") {
             let error = repository_refresh(incoming.repository_id)
             if (!empty(error)) send_error(channel, error)
-            send_repositories(client, true)
         } elif (incoming.op == "repository_review") {
             let error = repository_review(
                 incoming.repository_id, incoming.worktree_path)
             if (!empty(error)) send_error(channel, error)
-            send_repositories(client, true)
         } elif (incoming.op == "repository_history") {
             let error = repository_history(
                 incoming.repository_id, incoming.worktree_path,
                 incoming.revision)
             if (!empty(error)) send_error(channel, error)
-            send_repositories(client, true)
         } elif (incoming.op == "repository_commit_files") {
             let error = repository_commit_files(
                 incoming.repository_id, incoming.worktree_path,
                 incoming.revision)
             if (!empty(error)) send_error(channel, error)
-            send_repositories(client, true)
         } elif (incoming.op == "repository_refs") {
             let error = repository_refs(
                 incoming.repository_id, incoming.worktree_path)
             if (!empty(error)) send_error(channel, error)
-            send_repositories(client, true)
         } elif (incoming.op == "git_file_action") {
             self.start_git_file_action(client, incoming)
         } elif (incoming.op == "file_inspect") {

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -491,7 +491,7 @@ class DasHerdWatcherServer : HvWebServer {
         if (!watcher_get_session_info(client.action_session_id, info)
                 || !info.drained) return
         client.action_delivered = true
-        let truncated = false
+        var truncated = false
         let output = watcher_machine_output_text(client.action_session_id, truncated)
         let _compacted = watcher_compact_session(client.action_session_id, 160, 50)
         var failure = ""
@@ -545,7 +545,7 @@ class DasHerdWatcherServer : HvWebServer {
                 continue
             }
             if (!info.drained) continue
-            let truncated = false
+            var truncated = false
             let output = watcher_machine_output_text(action.session_id, truncated)
             let _compacted = watcher_compact_session(
                 action.session_id, 160, 50)
@@ -682,7 +682,7 @@ class DasHerdWatcherServer : HvWebServer {
         var info = WatcherSessionInfo()
         if (!watcher_get_session_info(client.inspection_session_id, info)
                 || !info.drained) return
-        let truncated = false
+        var truncated = false
         let output = watcher_machine_output_text(client.inspection_session_id, truncated)
         let _compacted = watcher_compact_session(client.inspection_session_id, 80, 25)
         if (client.inspection_phase == "indexed-view") {


### PR DESCRIPTION
## Summary

- add independently dockable Git Changelist, Activity, and File Inspector surfaces with PR, History, and Tree perspectives
- render a semantic commit DAG with branch focus, upstream-aware pushed state, stable colors, commit selection, SHA copy, and staged/unstaged file actions
- keep the installed diff/view interactive while replacement Git and syntax work runs asynchronously, including Markdown, JSON, Unicode, and image previews
- coalesce watcher repository delivery, add pressure-driven GC and reconnect telemetry, and retain Git actions across client disconnects
- harden Git task failure routing, refresh queuing, removed-worktree cleanup, and bounded exact-byte blob capture

## Validation

- `53 tests, 53 passed` across all `utils/dasHerd/watcher/tests`
- watcher, rich client, and blob-capture entry points compile cleanly with lint enabled
- `git diff --check` clean
- live cold-start and forced watcher-restart smoke: PR base/history repopulate without a click, reconnect succeeds, managed heaps remain flat
- maximized 4K rich-client smoke remained responsive at roughly 60-70 FPS