### PR TITLE
templates: support template_structure classes

### DIFF
--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -1366,18 +1366,24 @@ def public apply_qmacro_template_class(instance_name : string; var template_type
         if (func.classParent == template_structure) {
             // we rename methods
             let func_name = string(func.name)
-            var method_name_parts = split(func_name, "`")
-            if (method_name_parts[0] == template_name) {
-                method_name_parts[0] = instance_name
-            }
-            if (length(method_name_parts) == 2) {
-                if (method_name_parts[1] == template_name) { // ctor
-                    method_name_parts[1] = instance_name
-                } elif (method_name_parts[1] == "clone" || method_name_parts[1] == "finalize" || method_name_parts[1] == "each") {
-                    method_name_parts.erase(0)
+            var func_clone_name : string
+            if (func_name == "{template_name}'__finalize") {
+                // Keep each compiler-generated class finalizer distinct so substitution can retarget its field initializer.
+                func_clone_name = "{instance_name}'__finalize"
+            } else {
+                var method_name_parts = split(func_name, "`")
+                if (method_name_parts[0] == template_name) {
+                    method_name_parts[0] = instance_name
                 }
+                if (length(method_name_parts) == 2) {
+                    if (method_name_parts[1] == template_name) { // ctor
+                        method_name_parts[1] = instance_name
+                    } elif (method_name_parts[1] == "clone" || method_name_parts[1] == "finalize" || method_name_parts[1] == "each") {
+                        method_name_parts.erase(0)
+                    }
+                }
+                func_clone_name = join(method_name_parts, "`")
             }
-            let func_clone_name = join(method_name_parts, "`")
             method_renames.insert(func_name, func_clone_name)
         }
     })

--- a/tests/README.md
+++ b/tests/README.md
@@ -1081,6 +1081,8 @@ Coverage of per-iteration `finally` semantics across every loop form. Each cell 
 | File | Description | Expects errors |
 |---|---|---|
 | test_basic.das | All four grammar forms (`name(args)`, `$name(args)`, `name<types>(args)`, `$name<types>(args)`), const int/bool/string argument extraction, `typedecl(expr)` | |
+| test_template_structure_class.das | `[template_structure]` class specializations, inherited fields, virtual overrides, and distinct generated finalizers for multiple type arguments | |
+| _template_structure_class_mod.das | *(helper)* inherited `class template ProbeScalarCommand<T>` definition | |
 | _typemacro_mod.das | *(helper)* `tm_make` raw AstTypeMacro — resolves `tm_make(type<T>, N, wrap, tag)` to `T[N]` or `T` | |
 
 ## unsafe/

--- a/tests/typemacro/_template_structure_class_mod.das
+++ b/tests/typemacro/_template_structure_class_mod.das
@@ -1,0 +1,29 @@
+options gen2
+
+module _template_structure_class_mod shared public
+
+require daslib/typemacro_boost public
+
+class public BaseCommand {
+    executions : int = 0
+
+    def abstract redo() : void
+    def abstract undo() : void
+}
+
+[template_structure(ValueType)]
+class template public ProbeScalarCommand : BaseCommand {
+    newValue : ValueType
+
+    def override redo() : void {
+        executions++
+    }
+
+    def override undo() : void {
+        executions--
+    }
+
+    def getValue() : ValueType {
+        return newValue
+    }
+}

--- a/tests/typemacro/test_template_structure_class.das
+++ b/tests/typemacro/test_template_structure_class.das
@@ -1,0 +1,26 @@
+options gen2
+
+require dastest/testing_boost public
+require _template_structure_class_mod
+
+typedef ProbeIntCommand = $ProbeScalarCommand<int>
+typedef ProbeFloatCommand = $ProbeScalarCommand<float>
+
+[test]
+def test_template_structure_class(t : T?) {
+    unsafe {
+        var inscope intCommand <- new ProbeIntCommand()
+        intCommand.newValue = 42
+        intCommand->redo()
+        t |> equal(intCommand->getValue(), 42)
+        t |> equal(intCommand.executions, 1)
+        intCommand->undo()
+        t |> equal(intCommand.executions, 0)
+
+        var inscope floatCommand <- new ProbeFloatCommand()
+        floatCommand.newValue = 1.5
+        floatCommand->redo()
+        t |> equal(floatCommand->getValue(), 1.5)
+        t |> equal(floatCommand.executions, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- give compiler-generated class finalizers specialization-specific names during template_structure instantiation
- add cross-module regression coverage for inherited template classes and multiple type arguments
- document the new typemacro test coverage

## Validation
- formatter verification: 3 changed daScript files clean
- lint: 3 files, 0 issues, 0 errors
- tests/typemacro: 12 passed
- targeted AOT regression test: passed before the final rebase (content unchanged)

Full preflight intentionally skipped per request.