### PR TITLE
Add bidirectional dasHerd review focus

### DIFF
--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1912,7 +1912,7 @@ namespace das {
 
     bool builtin_fs_is_symlink ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) {
         error = nullptr;
-        if ( !path ) { error = empty_path_error(ctx, at); return false; }
+        if ( !path || !path[0] ) { error = empty_path_error(ctx, at); return false; }
         std::error_code ec;
 #if defined(_WIN32)
         auto widePath = utf8_file_path_to_wide(path);

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1914,7 +1914,17 @@ namespace das {
         error = nullptr;
         if ( !path ) { error = empty_path_error(ctx, at); return false; }
         std::error_code ec;
+#if defined(_WIN32)
+        auto widePath = utf8_file_path_to_wide(path);
+        if ( widePath.empty() ) {
+            static constexpr char invalidUtf8[] = "invalid UTF-8 file path";
+            error = ctx->allocateString(invalidUtf8, uint32_t(sizeof(invalidUtf8) - 1), at);
+            return false;
+        }
+        bool result = std::filesystem::is_symlink(std::filesystem::path(widePath), ec);
+#else
         bool result = std::filesystem::is_symlink(path, ec);
+#endif
         if ( ec ) { error = ec_to_string(ec, ctx, at); return false; }
         return result;
     }

--- a/tests/fs/test_fs.das
+++ b/tests/fs/test_fs.das
@@ -168,6 +168,17 @@ def test_is_symlink(t : T?) {
         t |> success(empty(error), "unexpected error: {error}")
         remove(tmp)
     }
+    t |> run("UTF-8 regular file is not symlink") @(t : T?) {
+        let root = get_das_root()
+        let tmp = root + "/_test_fs_symlink-Привет.tmp"
+        fopen(tmp, "wb") <| $(f) {
+            fwrite(f, "test")
+        }
+        var error : string
+        t |> success(!is_symlink(tmp, error))
+        t |> success(empty(error), "unexpected error: {error}")
+        remove(tmp)
+    }
     t |> run("missing path") @(t : T?) {
         var error : string
         t |> success(!is_symlink("/no/such/path", error))

--- a/tests/fs/test_fs.das
+++ b/tests/fs/test_fs.das
@@ -183,6 +183,11 @@ def test_is_symlink(t : T?) {
         var error : string
         t |> success(!is_symlink("/no/such/path", error))
     }
+    t |> run("empty path") @(t : T?) {
+        var error : string
+        t |> success(!is_symlink("", error))
+        t |> equal(error, "empty path")
+    }
 }
 
 [test]

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -1,0 +1,166 @@
+# Agent-assisted review workflows
+
+Status: product direction; ordering proposed for discussion
+
+This note records the two agreed product tracks that follow a usable local Git
+inspector. Both tracks will be implemented. The open decision is their order.
+
+1. Make local Git review useful for preparing and reviewing a PR through
+   explicit human-agent attention handoff.
+2. Add a GitHub PR surface for status, body, CI, comments, logs, and supervised
+   review operations.
+
+They are not separate interaction models. Both should use one inspectable
+`Review Focus` contract.
+
+## Shared contract: Review Focus
+
+A Review Focus is a visible, clearable set of things that a human or agent asks
+the other party to inspect. It must be structured state, not prose inferred
+from a terminal and not an invisible filter.
+
+A focus item identifies:
+
+- repository, workspace/worktree, and revision or comparison;
+- a target such as file, symbol/function, source range, ref/SHA, PR, check,
+  review thread, or log range;
+- a role such as primary, risk, question, failure, context, or plumbing;
+- a short explanation of why it matters;
+- origin (human, agent, or tool), session, and creation time;
+- acknowledgement or resolution state; and
+- enough snapshot identity to report when the target has become stale.
+
+Source targets use the existing canonical identity: workspace, worktree-
+relative path, revision/comparison, and UTF-8 byte or line range. Symbol names
+help a human read a focus item but do not replace the source range and revision.
+GitHub targets add stable repository, PR, check-run, thread/comment, and log
+identities without weakening the local source anchor.
+
+The UI may subdue unrelated material, but it always shows who supplied the
+focus, why each item is present, and how to clear it or return to the ordinary
+Auto/All view. Focus never changes Git state by itself.
+
+## Track A: local PR preparation and review
+
+### Agent to human
+
+The agent can publish a review focus equivalent to:
+
+> Look at these two files and these three functions. The remaining changes are
+> mechanical PR plumbing.
+
+The Changelist emphasizes selected files and labels supporting/plumbing files.
+Opening Diff or View emphasizes exact symbols and ranges while retaining the
+complete file. Tree applies the same idea to topology: it shows the refs, SHAs,
+and ancestry paths named by the agent, with unrelated branches subdued.
+
+This supports:
+
+- a PR-preparation summary of important implementation and risk areas;
+- a reviewer guide through semantic changes hidden among generated or
+  mechanical files;
+- questions and caveats attached to exact source ranges; and
+- an agent-directed Tree focus for primary, incoming, and base/context paths.
+
+### Human to agent
+
+A human can select files, functions, source ranges, commits, or Tree paths and
+turn that selection into either:
+
+- a generated chat prompt inserted through the normal, visible agent input
+  path; or
+- an exported Markdown review brief that the human can ask the agent to read.
+
+The Markdown artifact is the portable human-readable projection of the same
+structured focus. It lists canonical anchors, selected text only when useful,
+and the human's notes/questions. A machine-readable representation may travel
+beside or inside it, but the `.md` must remain sufficient to inspect, edit, and
+discuss without dasHerd.
+
+No prompt is sent silently. The human sees and may edit the generated request
+before sending it.
+
+## Track B: GitHub PR observation and supervised operation
+
+When a session/worktree has an open PR, dasHerd indicates that association and
+offers a PR Status surface containing:
+
+- PR identity, state, base/head, mergeability, and current review summary;
+- rendered PR body plus a locally autosaved editable Markdown draft and an
+  explicit conflict-aware publish action;
+- CI/check rows with live state, timestamps, and links;
+- review comments and threads, including replies and resolution state; and
+- failure logs that can be opened, searched, selected, and attached to a
+  Review Focus.
+
+The human can point the agent at a failing check, a red log range, or a review
+thread using the same handoff as source code: generated visible prompt or
+exported review brief. The agent can answer questions such as "why is this
+broken?" against exact observed state rather than a pasted approximation.
+
+Copilot and other automated-review interaction should use supervised
+suggestions: dasHerd presents a proposed accept, reject, reply, resolve, rerun,
+or merge operation as a ghost action with its rationale and exact target. The
+human may approve, reject, or add a comment. Read/monitor work can be automatic;
+remote mutations remain explicit and observable.
+
+The existing babysit workflow should ultimately consume this state directly:
+monitor checks and reviews, prepare proposed responses/actions, surface only
+decisions that need a human, and merge when the user's declared policy permits.
+
+## Proposed order
+
+Implement Track A first, beginning with the shared Review Focus model and its
+two-way handoff, then build Track B on that contract.
+
+Reasons:
+
+- The local Git inspector has just become usable, so this is the shortest path
+  from a viewer to a genuinely useful review tool.
+- File/symbol/range/ref anchoring is the common semantic foundation. CI lines,
+  comments, and logs can later become additional focus target kinds instead of
+  inventing a second selection and communication system.
+- The complete human-agent loop can be tested deterministically against local
+  repository state before adding authentication, API limits, changing remote
+  state, and provider-specific behavior.
+- It establishes the agent-facing publish/consume contract and the human-facing
+  prompt/Markdown export contract that GitHub babysitting will need anyway.
+- GitHub work can then concentrate on observation and supervised operations
+  rather than simultaneously discovering the underlying interaction language.
+
+The strongest argument for Track B first is immediate operational value for
+already-open PRs: status, CI, comments, and babysitting are useful before rich
+source focus exists. That remains a valid priority if remote operations are the
+near-term bottleneck. The tradeoff is a higher chance of building GitHub-
+specific selection/actions that must later be reconciled with source and Tree
+focus.
+
+## Suggested implementation sequence
+
+1. Define and persist the headless Review Focus/item schema, revision/staleness
+   rules, and live inspection surface.
+2. Render agent-to-human file, source, and Tree focus with visible provenance,
+   reasons, and clear/Auto/All controls.
+3. Capture human selections and generate an editable prompt plus Markdown
+   review brief.
+4. Add agent tools/skill flow to publish and consume focus sets during local PR
+   preparation and review.
+5. Add read-only GitHub PR association, body, checks, comments, and logs.
+6. Extend focus targets to GitHub checks, threads, and log ranges.
+7. Add supervised ghost actions and integrate the babysit/merge policy.
+
+Each stage must expose semantic state to live commands. Screenshots are useful
+for presentation, never the correctness oracle.
+
+## Discussion record
+
+- 2026-07-21: Both tracks are committed product direction; only order is open.
+- 2026-07-21: Local review should support agent-selected important files,
+  functions/ranges, and Tree branches while treating the rest as plumbing.
+- 2026-07-21: Human selections must travel back to an agent through a visible
+  generated prompt or an editable/exportable Markdown review brief.
+- 2026-07-21: GitHub review should cover PR body, CI, comments, logs, questions
+  about exact failures, Copilot review, supervised actions, and eventual
+  babysit-to-merge operation.
+- 2026-07-21: Proposed preference is local Review Focus first, GitHub second,
+  because Review Focus is the shared interaction foundation.

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -190,26 +190,36 @@ the same trusted agent could perform that operation directly through its shell.
 
 ## Next vertical slice: one scenario each way
 
-The next implementation slice is complete only when one real source-range
-handoff works in each direction against a running agent session.
+The next implementation slice is complete only when the real PR-ready focus
+scenario works agent-to-human and one corrective source-range handoff works
+human-to-agent against a running agent session.
 
 ### Agent points human at code
 
-The agent publishes one Outbox focus message containing a revision-aware source
-anchor and the human-facing instruction **Look at that**. dasHerd adds a durable
-entry to a non-modal **Attention** panel backed by the session Outbox. This may
-also add a badge to the affected file.
+The agent publishes one Outbox Focus Set with the summary:
+
+> Ready for PR. Check it out; I've highlighted the important bits.
+
+The set contains several revision-aware targets at once: whole files that are
+important as units and multiple source ranges/sections inside other files. A
+file target with no ranges means the whole file matters. A file target may
+contain several disjoint ranges. dasHerd adds one durable entry to a non-modal
+**Attention** panel backed by the session Outbox and marks every affected file
+in the Changelist.
 
 Arrival never steals the human's workflow. It does not select a repository or
 worktree, replace the inspected file, switch Diff/View, scroll, raise a window,
-or take keyboard focus. If the target document is already displayed, its range
-may be highlighted in place without moving the viewport. If it is not
-displayed, dasHerd stores the highlight but does not open the file.
+or take keyboard focus. If a targeted document is already displayed, all of its
+ranges may be highlighted in place without moving the viewport. Other targeted
+files receive Changelist/Attention markers but are not opened.
 
-At a time of the human's choosing, clicking the Attention entry navigates to
-the anchored repository/worktree/file/revision, prepares the appropriate
-Diff/View, scrolls the range into view, and applies the focus treatment. The
-entry remains inspectable and can be dismissed or resolved independently.
+At a time of the human's choosing, clicking the Attention entry activates that
+Focus Set and navigates to its first important target. The Attention panel also
+lists every file/section for direct navigation. Focus mode keeps targeted files
+and ranges ordinary/brighter while subduing unrelated PR plumbing; a toggle
+restores the normal undimmed view without discarding the set. Previous/next
+navigation walks the set's targets. The entry remains inspectable and can be
+dismissed or resolved independently.
 
 ### Human points agent at code
 
@@ -223,10 +233,12 @@ message, then can publish a reply or focus result through its Outbox.
 - Before/after live state proves agent-message arrival did not change selected
   worktree, installed file, mode, scroll position, active window/widget, or
   keyboard focus.
-- The Attention panel and mailbox expose the message, source anchor, sender,
-  lifecycle, and raw payload immediately.
-- Clicking the Attention entry is what changes navigation; the resulting exact
-  source range is visible and highlighted.
+- The test Focus Set contains multiple files and multiple disjoint ranges in at
+  least one file. The Attention panel and mailbox expose its summary, every
+  anchor, sender, lifecycle, and raw payload immediately.
+- Clicking the Attention entry is what changes navigation. All targeted files
+  are marked, all ranges for the opened file are highlighted, previous/next
+  walks the set, and the focus toggle restores the ordinary undimmed view.
 - The reverse request contains the human's exact selected source anchor; the
   Inbox records notification, fetch, and acknowledgement state.
 - The demonstration uses the real CLI, watcher, web UI mailbox, rich client,
@@ -383,6 +395,8 @@ for presentation, never the correctness oracle.
 - 2026-07-21: Herder has no agent permission or capability model. Session
   context supplies routing defaults, not authority; connection tokens are only
   transport hygiene against accidental local cross-talk.
-- 2026-07-21: Scope the next implementation slice to one source-range handoff
-  in each direction. Agent-to-human arrival is non-modal and never changes
-  navigation/focus; the human navigates only by clicking its Attention entry.
+- 2026-07-21: Scope the next implementation slice to the real PR-ready Focus
+  Set (several important files and several sections per file) agent-to-human,
+  plus one corrective source-range handoff human-to-agent. Arrival is non-modal
+  and never changes navigation/focus; the human navigates only by clicking its
+  Attention entry.

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -188,6 +188,50 @@ the same trusted agent could perform that operation directly through its shell.
   same message/focus IDs, but it does not become the authoritative mutable
   inbox record.
 
+## Next vertical slice: one scenario each way
+
+The next implementation slice is complete only when one real source-range
+handoff works in each direction against a running agent session.
+
+### Agent points human at code
+
+The agent publishes one Outbox focus message containing a revision-aware source
+anchor and the human-facing instruction **Look at that**. dasHerd adds a durable
+entry to a non-modal **Attention** panel backed by the session Outbox. This may
+also add a badge to the affected file.
+
+Arrival never steals the human's workflow. It does not select a repository or
+worktree, replace the inspected file, switch Diff/View, scroll, raise a window,
+or take keyboard focus. If the target document is already displayed, its range
+may be highlighted in place without moving the viewport. If it is not
+displayed, dasHerd stores the highlight but does not open the file.
+
+At a time of the human's choosing, clicking the Attention entry navigates to
+the anchored repository/worktree/file/revision, prepares the appropriate
+Diff/View, scrolls the range into view, and applies the focus treatment. The
+entry remains inspectable and can be dismissed or resolved independently.
+
+### Human points agent at code
+
+The human selects one source range, right-clicks, and invokes **Look at that**.
+That one action stores the exact revision/path/range in the session Inbox and
+sends the short TTY nudge. The agent uses the CLI to fetch and acknowledge the
+message, then can publish a reply or focus result through its Outbox.
+
+### Acceptance evidence
+
+- Before/after live state proves agent-message arrival did not change selected
+  worktree, installed file, mode, scroll position, active window/widget, or
+  keyboard focus.
+- The Attention panel and mailbox expose the message, source anchor, sender,
+  lifecycle, and raw payload immediately.
+- Clicking the Attention entry is what changes navigation; the resulting exact
+  source range is visible and highlighted.
+- The reverse request contains the human's exact selected source anchor; the
+  Inbox records notification, fetch, and acknowledgement state.
+- The demonstration uses the real CLI, watcher, web UI mailbox, rich client,
+  and agent TTY rather than a test-only shortcut.
+
 ## Track A: local PR preparation and review
 
 ### Agent to human
@@ -298,7 +342,8 @@ focus.
 5. Define the Review Focus payload, revision/staleness rules, and live
    inspection surface on top of the mailbox.
 6. Render agent-to-human file, source, and Tree focus, then capture human
-   selections as editable requests and Markdown review briefs.
+   selections as immediate contextual requests and optional Markdown review
+   briefs.
 7. Add read-only GitHub PR association, body, checks, comments, and logs;
    extend focus targets to GitHub state; then add supervised ghost actions and
    babysit/merge policy.
@@ -338,3 +383,6 @@ for presentation, never the correctness oracle.
 - 2026-07-21: Herder has no agent permission or capability model. Session
   context supplies routing defaults, not authority; connection tokens are only
   transport hygiene against accidental local cross-talk.
+- 2026-07-21: Scope the next implementation slice to one source-range handoff
+  in each direction. Agent-to-human arrival is non-modal and never changes
+  navigation/focus; the human navigates only by clicking its Attention entry.

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -53,32 +53,35 @@ contract.
 
 An agent-facing `dasherder.md` skill explains the available operations and how
 to discover the current session. The agent publishes structured focus sets,
-notes, acknowledgements, and results to dasHerd. MCP is the preferred ergonomic
-surface when installed; a small CLI is the portable surface; localhost HTTP is
-the underlying fallback. All three map to the same versioned protocol and
-identities.
+notes, acknowledgements, and results to dasHerd. The first supported agent
+surface is a small `dasherd` CLI. It speaks to the local watcher protocol, reads
+the current session capability automatically, and offers stable human-readable
+and JSON output. MCP is explicitly deferred until the mailbox and focus
+contract have enough real use to justify its support cost. Raw localhost HTTP
+is an implementation/debugging substrate, not the initial agent-facing
+contract.
 
 The agent should not have to synthesize UI input or emit terminal prose for
 dasHerd to scrape. A typical operation is semantically:
 
 ```text
-publish_focus(session, focus_items, summary)
+dasherd outbox send --kind focus --payload focus.json
 ```
 
 ### dasHerd to agent: durable payload plus wake-up
 
-Local HTTP/MCP state cannot wake a passive agent model. Conversely, pasting the
+Local mailbox state cannot wake a passive agent model. Conversely, pasting the
 complete request into a TTY is fragile, noisy, difficult to acknowledge, and
 unsafe for large source selections. The proposed transport therefore splits
 notification from payload:
 
 1. dasHerd stores the complete structured request in a durable per-session
    inbox and assigns a stable message ID.
-2. After the human previews and sends it, dasHerd injects one short natural-
-   language notification through the agent's normal TTY input path.
+2. The same explicit UI action immediately injects one short natural-language
+   notification through the agent's normal TTY input path.
 3. The notification tells the agent to use the dasHerd skill and fetch that
    exact message ID.
-4. The agent fetches the payload through MCP/CLI/HTTP and acknowledges it.
+4. The agent fetches the payload through the CLI and acknowledges it.
 5. dasHerd shows pending, notified, fetched, acknowledged, completed, failed,
    canceled, and stale state rather than assuming that pasted text was read.
 
@@ -90,20 +93,72 @@ For example, the visible TTY message can be:
 The nudge is intentionally sufficient for the model to choose the skill but
 does not duplicate the source payload in terminal scrollback or context.
 
-MCP resource-change notifications or a future direct agent callback may remove
-the TTY wake-up for agents that support true push. They are optimizations of
-the wake transport, not replacements for the durable inbox and acknowledgement
-model. Pure polling is not the default because an idle agent has no reason to
-take another turn.
+A future direct agent callback may remove the TTY wake-up for agents that
+support true push. It is an optimization of the wake transport, not a
+replacement for the durable inbox and acknowledgement model. Pure polling is
+not the default because an idle agent has no reason to take another turn.
+
+### Per-session Inbox and Outbox
+
+Inbox and Outbox are named relative to the agent session:
+
+- **Inbox** contains human or dasHerd-system requests addressed to that agent.
+- **Outbox** contains focus sets, replies, notes, and results published by that
+  agent for the human/dasHerd.
+
+The first implementation includes both views in the web UI for every session.
+This is not deferred until rich focus rendering. At minimum each mailbox shows
+message ID, time, sender, kind/subject, lifecycle state, reply/correlation ID,
+notification state, and a readable payload. A raw structured-payload view is
+available from the start so protocol mistakes can be diagnosed by eye. The UI
+also exposes cancel, retry-notification, and acknowledgement transitions as
+applicable.
+
+There is no required compose, preview, or confirmation stage for a contextual
+request. The baseline interaction is: select code in Diff/View, right-click,
+choose **Look at that**, and return to work. That menu action immediately
+creates the Inbox message from the selected revision/path/range and queues the
+TTY notification. Selection alone sends nothing. If notification fails, the
+durable message remains visible and retryable in the mailbox.
+
+The CLI begins with operations equivalent to:
+
+```text
+dasherd whoami
+dasherd inbox list
+dasherd inbox get <message-id>
+dasherd inbox ack <message-id>
+dasherd inbox complete <message-id> [--message <text>]
+dasherd outbox send --kind <kind> --payload <file>
+dasherd outbox reply <message-id> --kind <kind> --payload <file>
+```
+
+### Sender identity and provenance
+
+Sender is assigned by dasHerd from the authenticated transport principal; it
+is never trusted from a message field supplied by the CLI or web client.
+
+- A session-scoped CLI capability stamps the sender as
+  `agent_session:<session-id>` and restricts the destination to that session's
+  Outbox, acknowledgements, and replies.
+- The local web UI stamps the sender as `human:local` in the single-user first
+  slice and records its client/connection ID separately for diagnostics.
+- Watcher-generated lifecycle notices use `system:dasHerd`.
+
+A later multi-user or cross-agent design can add principals without changing
+message identity. Cross-session agent messaging is not part of the first
+slice: an agent can consume only its own Inbox and publish only to its own
+Outbox. Replies carry `reply_to`/correlation identity rather than copying or
+overwriting the original sender.
 
 ### Session discovery and capability scope
 
 dasHerd supplies an agent session with one capability descriptor containing the
 protocol version, localhost endpoint, session ID, and session-scoped
 credential. The launch profile exposes only the descriptor location; the
-`dasherder.md` skill describes how MCP, CLI, or HTTP consumes it. Credentials
-must not appear in generated prompts, terminal history, review briefs, or the
-repository.
+`dasherder.md` skill describes how the CLI consumes it. Credentials must not
+appear in generated prompts, terminal history, review briefs, CLI arguments,
+or the repository.
 
 The capability may read and acknowledge only its own inbox and publish focus
 for its own session/worktree. It cannot impersonate a human-origin message or
@@ -111,8 +166,8 @@ mutate Git/GitHub state through the focus protocol.
 
 ### Delivery rules
 
-- Human-to-agent delivery is explicit. The human previews the generated nudge
-  and request before sending it.
+- Human-to-agent delivery is explicit but one-step. Invoking **Look at that**
+  is the send action; there is no mandatory composer or second confirmation.
 - The TTY nudge uses the same serialized input ownership as ordinary terminal
   input; it must not interleave with a human's partial line or paste.
 - Message IDs make retries idempotent. Re-sending a nudge does not duplicate
@@ -152,8 +207,8 @@ This supports:
 A human can select files, functions, source ranges, commits, or Tree paths and
 turn that selection into either:
 
-- a generated chat prompt inserted through the normal, visible agent input
-  path; or
+- an immediate **Look at that** Inbox request plus the short visible TTY nudge;
+  or
 - an exported Markdown review brief that the human can ask the agent to read.
 
 The Markdown artifact is the portable human-readable projection of the same
@@ -162,8 +217,10 @@ and the human's notes/questions. A machine-readable representation may travel
 beside or inside it, but the `.md` must remain sufficient to inspect, edit, and
 discuss without dasHerd.
 
-No prompt is sent silently. The human sees and may edit the generated request
-before sending it.
+Selecting text never sends by itself. Invoking the named context-menu action is
+the deliberate send; the resulting request and delivery state are immediately
+visible in the session mailbox. Markdown export remains the editable path for a
+larger curated brief.
 
 ## Track B: GitHub PR observation and supervised operation
 
@@ -222,17 +279,21 @@ focus.
 
 ## Suggested implementation sequence
 
-1. Define and persist the headless Review Focus/item schema, revision/staleness
-   rules, and live inspection surface.
-2. Render agent-to-human file, source, and Tree focus with visible provenance,
-   reasons, and clear/Auto/All controls.
-3. Capture human selections and generate an editable prompt plus Markdown
-   review brief.
-4. Add agent tools/skill flow to publish and consume focus sets during local PR
-   preparation and review.
-5. Add read-only GitHub PR association, body, checks, comments, and logs.
-6. Extend focus targets to GitHub checks, threads, and log ranges.
-7. Add supervised ghost actions and integrate the babysit/merge policy.
+1. Define the generic message envelope, lifecycle/event history, authenticated
+   actor identities, and per-session Inbox/Outbox storage.
+2. Implement the session-scoped CLI capability and `dasherder.md` skill for
+   list/get/ack/complete/send/reply.
+3. Expose Inbox and Outbox in the web UI, including readable and raw payloads,
+   lifecycle state, cancel, and retry-notification controls.
+4. Add the short serialized TTY wake-up and prove store-before-notify,
+   idempotent retry, acknowledgement, and failure behavior.
+5. Define the Review Focus payload, revision/staleness rules, and live
+   inspection surface on top of the mailbox.
+6. Render agent-to-human file, source, and Tree focus, then capture human
+   selections as editable requests and Markdown review briefs.
+7. Add read-only GitHub PR association, body, checks, comments, and logs;
+   extend focus targets to GitHub state; then add supervised ghost actions and
+   babysit/merge policy.
 
 Each stage must expose semantic state to live commands. Screenshots are useful
 for presentation, never the correctness oracle.
@@ -252,5 +313,17 @@ for presentation, never the correctness oracle.
 - 2026-07-21: Adopt local Review Focus first and begin protocol design before
   UI implementation.
 - 2026-07-21: Proposed human-to-agent transport is a durable per-session inbox
-  fetched through MCP/CLI/HTTP, paired with a short visible TTY wake-up and an
+  fetched through the CLI, paired with a short visible TTY wake-up and an
   explicit acknowledgement lifecycle.
+- 2026-07-21: Make the CLI the first and only supported agent transport; defer
+  MCP until real mailbox usage justifies its support cost.
+- 2026-07-21: Ship visible per-session Inbox/Outbox views in the web UI with the
+  first protocol implementation, including raw payload inspection for manual
+  debugging.
+- 2026-07-21: Assign sender identity from scoped transport credentials:
+  `agent_session:<id>`, `human:local`, or `system:dasHerd`; never accept sender
+  identity from an untrusted message payload.
+- 2026-07-21: Human contextual delivery is one-step: select code, invoke
+  **Look at that**, and immediately create the Inbox message plus TTY nudge.
+  The visible mailbox is an audit/debug surface, not a mandatory composer or
+  confirmation step.

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -1,9 +1,11 @@
 # Agent-assisted review workflows
 
-Status: product direction; ordering proposed for discussion
+Status: product direction; local Review Focus first; communication protocol
+under discussion
 
 This note records the two agreed product tracks that follow a usable local Git
-inspector. Both tracks will be implemented. The open decision is their order.
+inspector. Both tracks will be implemented. The local Review Focus vertical
+slice comes first, followed by the GitHub PR surface.
 
 1. Make local Git review useful for preparing and reviewing a PR through
    explicit human-agent attention handoff.
@@ -39,6 +41,89 @@ identities without weakening the local source anchor.
 The UI may subdue unrelated material, but it always shows who supplied the
 focus, why each item is present, and how to clear it or return to the ordinary
 Auto/All view. Focus never changes Git state by itself.
+
+## Human-agent communication protocol
+
+The rendering is deliberately simple: focused files/ranges keep their ordinary
+or brighter treatment, unrelated material is darkened, and a toggle restores
+the unfiltered view. The protocol that delivers focus state is the harder
+contract.
+
+### Agent to dasHerd
+
+An agent-facing `dasherder.md` skill explains the available operations and how
+to discover the current session. The agent publishes structured focus sets,
+notes, acknowledgements, and results to dasHerd. MCP is the preferred ergonomic
+surface when installed; a small CLI is the portable surface; localhost HTTP is
+the underlying fallback. All three map to the same versioned protocol and
+identities.
+
+The agent should not have to synthesize UI input or emit terminal prose for
+dasHerd to scrape. A typical operation is semantically:
+
+```text
+publish_focus(session, focus_items, summary)
+```
+
+### dasHerd to agent: durable payload plus wake-up
+
+Local HTTP/MCP state cannot wake a passive agent model. Conversely, pasting the
+complete request into a TTY is fragile, noisy, difficult to acknowledge, and
+unsafe for large source selections. The proposed transport therefore splits
+notification from payload:
+
+1. dasHerd stores the complete structured request in a durable per-session
+   inbox and assigns a stable message ID.
+2. After the human previews and sends it, dasHerd injects one short natural-
+   language notification through the agent's normal TTY input path.
+3. The notification tells the agent to use the dasHerd skill and fetch that
+   exact message ID.
+4. The agent fetches the payload through MCP/CLI/HTTP and acknowledges it.
+5. dasHerd shows pending, notified, fetched, acknowledged, completed, failed,
+   canceled, and stale state rather than assuming that pasted text was read.
+
+For example, the visible TTY message can be:
+
+> dasHerd review request `hf_42` is ready (3 source anchors). Use the dasHerd
+> skill to fetch and acknowledge it.
+
+The nudge is intentionally sufficient for the model to choose the skill but
+does not duplicate the source payload in terminal scrollback or context.
+
+MCP resource-change notifications or a future direct agent callback may remove
+the TTY wake-up for agents that support true push. They are optimizations of
+the wake transport, not replacements for the durable inbox and acknowledgement
+model. Pure polling is not the default because an idle agent has no reason to
+take another turn.
+
+### Session discovery and capability scope
+
+dasHerd supplies an agent session with one capability descriptor containing the
+protocol version, localhost endpoint, session ID, and session-scoped
+credential. The launch profile exposes only the descriptor location; the
+`dasherder.md` skill describes how MCP, CLI, or HTTP consumes it. Credentials
+must not appear in generated prompts, terminal history, review briefs, or the
+repository.
+
+The capability may read and acknowledge only its own inbox and publish focus
+for its own session/worktree. It cannot impersonate a human-origin message or
+mutate Git/GitHub state through the focus protocol.
+
+### Delivery rules
+
+- Human-to-agent delivery is explicit. The human previews the generated nudge
+  and request before sending it.
+- The TTY nudge uses the same serialized input ownership as ordinary terminal
+  input; it must not interleave with a human's partial line or paste.
+- Message IDs make retries idempotent. Re-sending a nudge does not duplicate
+  the inbox payload or lose acknowledgement state.
+- The inbox is authoritative. TTY text is only a wake signal and never proof
+  that the agent received, understood, or completed the request.
+- Agent profiles may replace TTY notification with a stronger native wake
+  transport, but every profile exposes the same message lifecycle.
+- A Markdown review brief remains the portable export. It can reference the
+  same message/focus IDs, but it contains no credentials and does not become
+  the authoritative mutable inbox record.
 
 ## Track A: local PR preparation and review
 
@@ -164,3 +249,8 @@ for presentation, never the correctness oracle.
   babysit-to-merge operation.
 - 2026-07-21: Proposed preference is local Review Focus first, GitHub second,
   because Review Focus is the shared interaction foundation.
+- 2026-07-21: Adopt local Review Focus first and begin protocol design before
+  UI implementation.
+- 2026-07-21: Proposed human-to-agent transport is a durable per-session inbox
+  fetched through MCP/CLI/HTTP, paired with a short visible TTY wake-up and an
+  explicit acknowledgement lifecycle.

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -247,8 +247,10 @@ Focus Set and navigates to its first important target. The Attention panel also
 lists every file/section for direct navigation. Focus mode keeps targeted files
 and ranges ordinary/brighter while subduing unrelated PR plumbing; a toggle
 restores the normal undimmed view without discarding the set. Previous/next
-navigation walks the set's targets. The entry remains inspectable and can be
-dismissed or resolved independently.
+file navigation walks the set's targets; previous/next highlight navigation
+walks the ranges in the current file. An optional range `caption` appears as a
+hover hint explaining why that section matters. The entry remains inspectable
+and can be dismissed or resolved independently.
 
 ### Human points agent at code
 

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -1,7 +1,7 @@
 # Agent-assisted review workflows
 
-Status: product direction; local Review Focus first; communication protocol
-under discussion
+Status: first bidirectional local Review Focus slice implemented; GitHub PR
+surface remains next
 
 This note records the two agreed product tracks that follow a usable local Git
 inspector. Both tracks will be implemented. The local Review Focus vertical
@@ -14,6 +14,36 @@ slice comes first, followed by the GitHub PR surface.
 
 They are not separate interaction models. Both should use one inspectable
 `Review Focus` contract.
+
+## Implemented first slice
+
+The watcher now owns an append-only `mailbox.jsonl` in every session artifact
+directory plus authenticated localhost HTTP and WebSocket projections. Inbox
+and Outbox are visible in the web control UI with sender, lifecycle, reply
+identity, delivery/fetch state, and raw JSON. The watcher assigns provenance
+from the routed direction/session instead of trusting a payload sender string.
+
+`utils/dasHerd/dasherd.ps1` implements `whoami`, Inbox list/get/ack/complete,
+and Outbox send/reply. URL, token, and session routing come from
+`DASHERD_URL`, `DASHERD_TOKEN`, and `DASHERD_SESSION_ID`, with explicit flags
+available for diagnostics. `utils/dasHerd/dasherder.md` is the agent-facing
+protocol note. Fetching a specific Inbox item records `fetched`; the one-step
+human action stores before sending an atomic TTY wake and records notification
+success or failure.
+
+The rich client consumes Outbox messages without changing repository,
+worktree, installed file, Diff/View mode, scroll, raised window, terminal, or
+keyboard focus. Its existing Sessions window contains persistent Attention;
+agent-targeted files carry an `[AGENT]` marker in changelists. Only clicking a
+message or file target navigates. Active source focus supports multiple
+disjoint UTF-8 byte ranges, dimmed surrounding text, direct file navigation,
+previous/next target navigation, and a show/hide toggle. A code selection's
+right-click **Look at that** action atomically posts the exact installed
+repository/worktree/comparison/path/range to the selected session Inbox.
+
+Live commands expose Attention state and explicit target opening for semantic
+verification. The next product track is the GitHub PR surface described below;
+MCP remains deliberately deferred.
 
 ## Shared contract: Review Focus
 
@@ -55,8 +85,8 @@ An agent-facing `dasherder.md` skill explains the available operations and how
 to discover the current session. The agent publishes structured focus sets,
 notes, acknowledgements, and results to dasHerd. The first supported agent
 surface is a small `dasherd` CLI. It speaks to the local watcher protocol, reads
-the current session context automatically, and offers stable human-readable
-and JSON output. MCP is explicitly deferred until the mailbox and focus
+the current session context from its environment or explicit flags, and offers
+stable human-readable and JSON output. MCP is explicitly deferred until the mailbox and focus
 contract have enough real use to justify its support cost. Raw localhost HTTP
 is an implementation/debugging substrate, not the initial agent-facing
 contract.
@@ -82,8 +112,9 @@ notification from payload:
 3. The notification tells the agent to use the dasHerd skill and fetch that
    exact message ID.
 4. The agent fetches the payload through the CLI and acknowledges it.
-5. dasHerd shows pending, notified, fetched, acknowledged, completed, failed,
-   canceled, and stale state rather than assuming that pasted text was read.
+5. dasHerd shows new, notification success/failure, fetched, acknowledged, and
+   completed state rather than assuming that pasted text was read. Cancel and
+   stale transitions remain extensions of the same record.
 
 For example, the visible TTY message can be:
 
@@ -109,10 +140,8 @@ Inbox and Outbox are named relative to the agent session:
 The first implementation includes both views in the web UI for every session.
 This is not deferred until rich focus rendering. At minimum each mailbox shows
 message ID, time, sender, kind/subject, lifecycle state, reply/correlation ID,
-notification state, and a readable payload. A raw structured-payload view is
-available from the start so protocol mistakes can be diagnosed by eye. The UI
-also exposes cancel, retry-notification, and acknowledgement transitions as
-applicable.
+notification/fetch state, and a readable payload. A raw structured-payload
+view is available from the start so protocol mistakes can be diagnosed by eye.
 
 There is no required compose, preview, or confirmation stage for a contextual
 request. The baseline interaction is: select code in Diff/View, right-click,
@@ -140,7 +169,7 @@ assigned by dasHerd from the mailbox operation rather than copied from an
 arbitrary message-body field:
 
 - Posting to session `<id>`'s Outbox stamps the sender as
-  `agent_session:<id>`. The CLI defaults `<id>` from its launch context.
+  `agent_session:<id>`. The CLI defaults `<id>` from `DASHERD_SESSION_ID`.
 - The local web UI stamps the sender as `human:local` in the single-user first
   slice and records its client/connection ID separately for diagnostics.
 - Watcher-generated lifecycle notices use `system:dasHerd`.
@@ -160,10 +189,10 @@ Adding nominal Herder restrictions would not create a meaningful security
 boundary and would import support cost and permission theater from other agent
 clients.
 
-dasHerd supplies launch context containing the protocol version, localhost
-endpoint, and default session ID so the CLI can route ordinary commands without
-extra arguments. A connection token may still exist to prevent accidental
-cross-talk with unrelated local pages/processes, as the watcher already does;
+The CLI accepts launch context containing the localhost endpoint and default
+session ID through environment variables; tighter launcher injection can be
+added without changing the protocol. A connection token may still exist to
+prevent accidental cross-talk with unrelated local pages/processes, as the watcher already does;
 it is transport hygiene, not authorization or a claim that the agent lacks
 authority.
 
@@ -178,8 +207,8 @@ the same trusted agent could perform that operation directly through its shell.
   is the send action; there is no mandatory composer or second confirmation.
 - The TTY nudge uses the same serialized input ownership as ordinary terminal
   input; it must not interleave with a human's partial line or paste.
-- Message IDs make retries idempotent. Re-sending a nudge does not duplicate
-  the inbox payload or lose acknowledgement state.
+- Message IDs keep notification retries tied to the existing Inbox payload so
+  acknowledgement state is not lost when retry UI is added.
 - The inbox is authoritative. TTY text is only a wake signal and never proof
   that the agent received, understood, or completed the request.
 - Agent profiles may replace TTY notification with a stronger native wake

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -55,7 +55,7 @@ An agent-facing `dasherder.md` skill explains the available operations and how
 to discover the current session. The agent publishes structured focus sets,
 notes, acknowledgements, and results to dasHerd. The first supported agent
 surface is a small `dasherd` CLI. It speaks to the local watcher protocol, reads
-the current session capability automatically, and offers stable human-readable
+the current session context automatically, and offers stable human-readable
 and JSON output. MCP is explicitly deferred until the mailbox and focus
 contract have enough real use to justify its support cost. Raw localhost HTTP
 is an implementation/debugging substrate, not the initial agent-facing
@@ -135,34 +135,42 @@ dasherd outbox reply <message-id> --kind <kind> --payload <file>
 
 ### Sender identity and provenance
 
-Sender is assigned by dasHerd from the authenticated transport principal; it
-is never trusted from a message field supplied by the CLI or web client.
+Sender is a routing/provenance label, not an authenticated principal. It is
+assigned by dasHerd from the mailbox operation rather than copied from an
+arbitrary message-body field:
 
-- A session-scoped CLI capability stamps the sender as
-  `agent_session:<session-id>` and restricts the destination to that session's
-  Outbox, acknowledgements, and replies.
+- Posting to session `<id>`'s Outbox stamps the sender as
+  `agent_session:<id>`. The CLI defaults `<id>` from its launch context.
 - The local web UI stamps the sender as `human:local` in the single-user first
   slice and records its client/connection ID separately for diagnostics.
 - Watcher-generated lifecycle notices use `system:dasHerd`.
 
-A later multi-user or cross-agent design can add principals without changing
-message identity. Cross-session agent messaging is not part of the first
-slice: an agent can consume only its own Inbox and publish only to its own
-Outbox. Replies carry `reply_to`/correlation identity rather than copying or
-overwriting the original sender.
+A later multi-user or cross-agent design can add more provenance labels without
+changing message identity. Cross-session agent messaging is not exposed in the
+first CLI because it is outside the initial workflow, not because dasHerd
+claims to prevent it. Replies carry `reply_to`/correlation identity rather than
+copying or overwriting the original sender.
 
-### Session discovery and capability scope
+### No Herder permission model
 
-dasHerd supplies an agent session with one capability descriptor containing the
-protocol version, localhost endpoint, session ID, and session-scoped
-credential. The launch profile exposes only the descriptor location; the
-`dasherder.md` skill describes how the CLI consumes it. Credentials must not
-appear in generated prompts, terminal history, review briefs, CLI arguments,
-or the repository.
+dasHerd deliberately does not implement agent permissions, per-operation
+approval gates, or a capability sandbox. The local agent already has the
+machine/worktree authority to edit files, run Git and `gh`, and call localhost.
+Adding nominal Herder restrictions would not create a meaningful security
+boundary and would import support cost and permission theater from other agent
+clients.
 
-The capability may read and acknowledge only its own inbox and publish focus
-for its own session/worktree. It cannot impersonate a human-origin message or
-mutate Git/GitHub state through the focus protocol.
+dasHerd supplies launch context containing the protocol version, localhost
+endpoint, and default session ID so the CLI can route ordinary commands without
+extra arguments. A connection token may still exist to prevent accidental
+cross-talk with unrelated local pages/processes, as the watcher already does;
+it is transport hygiene, not authorization or a claim that the agent lacks
+authority.
+
+Sender labels, mailbox direction, and event history make behavior observable
+and debuggable. They are not security attestations. Likewise, a human clicking
+a proposed GitHub action is a product interaction, not a permission boundary:
+the same trusted agent could perform that operation directly through its shell.
 
 ### Delivery rules
 
@@ -177,8 +185,8 @@ mutate Git/GitHub state through the focus protocol.
 - Agent profiles may replace TTY notification with a stronger native wake
   transport, but every profile exposes the same message lifecycle.
 - A Markdown review brief remains the portable export. It can reference the
-  same message/focus IDs, but it contains no credentials and does not become
-  the authoritative mutable inbox record.
+  same message/focus IDs, but it does not become the authoritative mutable
+  inbox record.
 
 ## Track A: local PR preparation and review
 
@@ -279,9 +287,9 @@ focus.
 
 ## Suggested implementation sequence
 
-1. Define the generic message envelope, lifecycle/event history, authenticated
-   actor identities, and per-session Inbox/Outbox storage.
-2. Implement the session-scoped CLI capability and `dasherder.md` skill for
+1. Define the generic message envelope, lifecycle/event history, routing/
+   provenance labels, and per-session Inbox/Outbox storage.
+2. Implement the session-aware CLI context and `dasherder.md` skill for
    list/get/ack/complete/send/reply.
 3. Expose Inbox and Outbox in the web UI, including readable and raw payloads,
    lifecycle state, cancel, and retry-notification controls.
@@ -320,10 +328,13 @@ for presentation, never the correctness oracle.
 - 2026-07-21: Ship visible per-session Inbox/Outbox views in the web UI with the
   first protocol implementation, including raw payload inspection for manual
   debugging.
-- 2026-07-21: Assign sender identity from scoped transport credentials:
-  `agent_session:<id>`, `human:local`, or `system:dasHerd`; never accept sender
-  identity from an untrusted message payload.
+- 2026-07-21: Assign sender provenance from mailbox direction/session routing:
+  `agent_session:<id>`, `human:local`, or `system:dasHerd`. These are observable
+  workflow labels, not authenticated security principals.
 - 2026-07-21: Human contextual delivery is one-step: select code, invoke
   **Look at that**, and immediately create the Inbox message plus TTY nudge.
   The visible mailbox is an audit/debug surface, not a mandatory composer or
   confirmation step.
+- 2026-07-21: Herder has no agent permission or capability model. Session
+  context supplies routing defaults, not authority; connection tokens are only
+  transport hygiene against accidental local cross-talk.

--- a/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
+++ b/utils/dasHerd/GIT_TOPOLOGY_PLAN.md
@@ -97,7 +97,9 @@ other branch; this is what we are bringing in," emphasize those paths, and
 subdue unrelated topology. The focus is inspectable user-visible state, not an
 implicit filter: the user can see the selected identities, clear the focus, or
 switch back to `Auto`/`All`. This is future direction, not part of the current
-view-only PR.
+view-only PR. The shared file/source/Tree/GitHub focus and two-way human-agent
+handoff are specified in
+[`AGENT_REVIEW_WORKFLOWS.md`](AGENT_REVIEW_WORKFLOWS.md).
 
 ## Deferred operational direction -- not this PR
 

--- a/utils/dasHerd/PLAN.md
+++ b/utils/dasHerd/PLAN.md
@@ -11,6 +11,10 @@ The name is intentional: this is an agent herder, not a general-purpose IDE.
 The initial implementation may force a narrow workflow when that makes state
 unambiguous and reliable.
 
+The proposed ordering and shared interaction contract for agent-assisted local
+review and the later GitHub PR surface are recorded in
+[`AGENT_REVIEW_WORKFLOWS.md`](AGENT_REVIEW_WORKFLOWS.md).
+
 ## Product contract
 
 - One writable agent session owns one worktree.

--- a/utils/dasHerd/dasherd.ps1
+++ b/utils/dasHerd/dasherd.ps1
@@ -1,0 +1,117 @@
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+$ErrorActionPreference = 'Stop'
+
+function Take-Option([System.Collections.Generic.List[string]]$Items, [string]$Name, [string]$Default = '') {
+    $index = $Items.IndexOf($Name)
+    if ($index -lt 0) { return $Default }
+    if ($index + 1 -ge $Items.Count) { throw "$Name requires a value" }
+    $value = $Items[$index + 1]
+    $Items.RemoveAt($index + 1)
+    $Items.RemoveAt($index)
+    return $value
+}
+
+function Invoke-DasHerd([string]$Method, [string]$Path, $Body = $null) {
+    $separator = '?'
+    if ($Path.Contains('?')) { $separator = '&' }
+    $uri = "$script:BaseUrl$Path${separator}token=$([uri]::EscapeDataString($script:Token))"
+    $parameters = @{ Method = $Method; Uri = $uri }
+    if ($null -ne $Body) {
+        $parameters.ContentType = 'application/json; charset=utf-8'
+        $parameters.Body = $Body | ConvertTo-Json -Depth 20 -Compress
+    }
+    Invoke-RestMethod @parameters
+}
+
+function Write-Json($Value) {
+    ConvertTo-Json -InputObject $Value -Depth 20
+}
+
+function Write-JsonList($Value) {
+    $list = @($Value)
+    ConvertTo-Json -InputObject $list -Depth 20
+}
+
+$items = [System.Collections.Generic.List[string]]::new()
+foreach ($item in $Arguments) { $items.Add($item) }
+$script:BaseUrl = (Take-Option $items '--url' $env:DASHERD_URL).TrimEnd('/')
+if (-not $script:BaseUrl) { $script:BaseUrl = 'http://127.0.0.1:9191' }
+$script:Token = Take-Option $items '--token' $env:DASHERD_TOKEN
+$sessionId = Take-Option $items '--session' $env:DASHERD_SESSION_ID
+$sender = Take-Option $items '--sender' ''
+if (-not $sender -and $sessionId) { $sender = "agent_session:$sessionId" }
+
+if ($items.Count -eq 0) { throw 'command required: whoami | inbox | outbox' }
+$command = $items[0]
+$items.RemoveAt(0)
+
+if ($command -eq 'whoami') {
+    Write-Json ([ordered]@{
+        sender = $sender
+        session_id = $sessionId
+        url = $script:BaseUrl
+        configured = [bool]($script:Token -and $sessionId)
+    })
+    exit 0
+}
+if (-not $script:Token) { throw 'watcher token is required (--token or DASHERD_TOKEN)' }
+if (-not $sessionId) { throw 'session is required (--session or DASHERD_SESSION_ID)' }
+if ($items.Count -eq 0) { throw "$command subcommand required" }
+$subcommand = $items[0]
+$items.RemoveAt(0)
+
+if ($command -eq 'inbox') {
+    if ($subcommand -eq 'list') {
+        Write-JsonList (Invoke-DasHerd GET "/api/v1/mailbox?session_id=$([uri]::EscapeDataString($sessionId))&direction=inbox")
+        exit 0
+    }
+    if ($subcommand -eq 'get') {
+        if ($items.Count -lt 1) { throw 'inbox get requires a message id' }
+        $messageId = $items[0]
+        Write-JsonList (Invoke-DasHerd GET "/api/v1/mailbox?session_id=$([uri]::EscapeDataString($sessionId))&direction=inbox&message_id=$([uri]::EscapeDataString($messageId))")
+        exit 0
+    }
+    if ($subcommand -eq 'ack' -or $subcommand -eq 'complete') {
+        if ($items.Count -lt 1) { throw "inbox $subcommand requires a message id" }
+        $status = 'completed'
+        if ($subcommand -eq 'ack') { $status = 'acknowledged' }
+        Write-Json (Invoke-DasHerd POST '/api/v1/mailbox/state' ([ordered]@{
+            session_id = $sessionId; message_id = $items[0]; status = $status
+        }))
+        exit 0
+    }
+    throw "unknown inbox subcommand: $subcommand"
+}
+
+if ($command -eq 'outbox') {
+    if ($subcommand -ne 'send' -and $subcommand -ne 'reply') {
+        throw "unknown outbox subcommand: $subcommand"
+    }
+    $replyTo = ''
+    if ($subcommand -eq 'reply') {
+        if ($items.Count -lt 1) { throw 'outbox reply requires an inbox message id' }
+        $replyTo = $items[0]
+        $items.RemoveAt(0)
+    }
+    $subject = Take-Option $items '--subject' ''
+    $focusPath = Take-Option $items '--focus-json' ''
+    if (-not $subject) { throw 'outbox send requires --subject' }
+    $focus = [ordered]@{ repository_id = ''; worktree_path = ''; comparison = 'working'; revision = ''; summary = ''; targets = @() }
+    if ($focusPath) {
+        $focus = Get-Content -LiteralPath $focusPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
+    Write-Json (Invoke-DasHerd POST '/api/v1/mailbox' ([ordered]@{
+        session_id = $sessionId
+        direction = 'outbox'
+        sender = $sender
+        kind = 'focus_set'
+        subject = $subject
+        reply_to = $replyTo
+        notify = $false
+        focus = $focus
+    }))
+    exit 0
+}
+
+throw "unknown command: $command"

--- a/utils/dasHerd/dasherder.md
+++ b/utils/dasHerd/dasherder.md
@@ -1,0 +1,44 @@
+# dasHerd session mailbox
+
+Use this protocol when a dasHerd terminal prints a wake-up such as:
+
+`dasHerd review request hf_42 is ready. Use the dasHerd skill to fetch and acknowledge it.`
+
+The watcher URL, token, and agent session id are routing context, not an
+authorization model. Configure `DASHERD_URL`, `DASHERD_TOKEN`, and
+`DASHERD_SESSION_ID`, or pass `--url`, `--token`, and `--session` to the CLI.
+
+Run the CLI from the repository root:
+
+```powershell
+powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 whoami
+powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox list
+powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox get hf_42
+powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox ack hf_42
+powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox complete hf_42
+```
+
+Read the exact UTF-8 byte ranges in each message's `focus.targets[].ranges`.
+An empty range list with `whole_file: true` targets the whole file. Acknowledge
+after fetching, and complete only after handling the request.
+
+To point the human at important code, write a Focus Set JSON file outside any
+deployment directory and send it atomically:
+
+```powershell
+powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 outbox send `
+  --subject "Ready for PR. Check it out; I've highlighted the important bits." `
+  --focus-json path/to/focus-set.json
+```
+
+A Focus Set contains `repository_id`, `worktree_path`, `comparison`, optional
+`revision` and `summary`, and one or more file targets. Each target has
+`file_path`, `whole_file`, and zero or more `{start_byte,end_byte,caption}`
+ranges. One message may target several files and several disjoint ranges per
+file. The human receives persistent, non-modal Attention; publishing must not
+assume that their current file, scroll position, mode, or keyboard focus changed.
+
+Use `outbox reply <inbox-id> --subject ... --focus-json ...` to preserve the
+conversation link. Inbox means human/system to agent; Outbox means agent to
+human. Senders are provenance strings: `agent_session:<id>`, `human:local`, or
+`system:dasHerd`.

--- a/utils/dasHerd/dasherder.md
+++ b/utils/dasHerd/dasherder.md
@@ -34,9 +34,11 @@ powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 outbox send `
 A Focus Set contains `repository_id`, `worktree_path`, `comparison`, optional
 `revision` and `summary`, and one or more file targets. Each target has
 `file_path`, `whole_file`, and zero or more `{start_byte,end_byte,caption}`
-ranges. One message may target several files and several disjoint ranges per
-file. The human receives persistent, non-modal Attention; publishing must not
-assume that their current file, scroll position, mode, or keyboard focus changed.
+ranges. `caption` is an optional short hint shown when the human hovers that
+highlight, such as `main loop` or `bug was here`. One message may target several
+files and several disjoint ranges per file. The human receives persistent,
+non-modal Attention; publishing must not assume that their current file, scroll
+position, mode, or keyboard focus changed.
 
 Use `outbox reply <inbox-id> --subject ... --focus-json ...` to preserve the
 conversation link. Inbox means human/system to agent; Outbox means agent to

--- a/utils/dasHerd/dasherder.md
+++ b/utils/dasHerd/dasherder.md
@@ -43,4 +43,6 @@ position, mode, or keyboard focus changed.
 Use `outbox reply <inbox-id> --subject ... --focus-json ...` to preserve the
 conversation link. Inbox means human/system to agent; Outbox means agent to
 human. Senders are provenance strings: `agent_session:<id>`, `human:local`, or
-`system:dasHerd`.
+`system:dasHerd`. Post payloads do not choose their provenance: the watcher
+stamps it from the session and direction, and reserves `system:dasHerd` for
+watcher-generated lifecycle notices.

--- a/utils/dasHerd/watcher/control.html
+++ b/utils/dasHerd/watcher/control.html
@@ -28,6 +28,14 @@
     .grow { flex: 1; }
     .muted { color: #9aa8b7; }
     .error { color: #ff8e87; }
+    .mailbox { margin-top: .8rem; border-top: 1px solid #394655; padding-top: .6rem; }
+    .mailbox-tabs { display: flex; gap: .3rem; margin-bottom: .4rem; }
+    .mailbox-tabs button.active { outline: 2px solid #65a8ff; }
+    .mailbox-list { display: grid; gap: .3rem; }
+    .mail { width: 100%; text-align: left; }
+    .mail-meta { display: block; color: #9aa8b7; font-size: .82em; }
+    .mail-raw { max-height: 13rem; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere;
+      background: #080b0f; border: 1px solid #303b48; padding: .4rem; margin: .4rem 0 0; }
   </style>
 </head>
 <body>
@@ -40,6 +48,16 @@
         <button id="launch">Launch terminal</button>
       </div>
       <div id="sessions" class="sessions"></div>
+      <section class="mailbox" aria-label="Session mailbox">
+        <h1>Session mailbox</h1>
+        <div class="mailbox-tabs">
+          <button id="inboxTab" class="active">Inbox</button>
+          <button id="outboxTab">Outbox</button>
+        </div>
+        <div id="mailboxEmpty" class="muted">Select a session</div>
+        <div id="mailboxList" class="mailbox-list"></div>
+        <pre id="mailboxRaw" class="mail-raw" hidden></pre>
+      </section>
     </aside>
     <main>
       <div class="toolbar">
@@ -65,7 +83,7 @@
   <script>
     const $ = id => document.getElementById(id);
     const token = new URLSearchParams(location.search).get('token') || '';
-    const withToken = path => `${path}?token=${encodeURIComponent(token)}`;
+    const withToken = path => `${path}${path.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`;
     let sessions = [];
     let selected = '';
     let attached = '';
@@ -75,6 +93,9 @@
     let fitAddon;
     let zoom = 150;
     let resizeTimer;
+    let mailbox = [];
+    let mailboxDirection = 'inbox';
+    let mailboxSelected = '';
 
     function loadStyle(path) {
       return new Promise((resolve, reject) => {
@@ -145,9 +166,56 @@
         button.className = `session${session.id === selected ? ' selected' : ''}`;
         button.textContent = `${session.id} - ${session.state} - ${session.command_line}`;
         button.title = session.command_line;
-        button.onclick = () => { selected = session.id; renderSessions(); attach(session.state === 'running'); };
+        button.onclick = () => {
+          selected = session.id;
+          mailboxSelected = '';
+          renderSessions();
+          refreshMailbox().catch(showError);
+          attach(session.state === 'running');
+        };
         return button;
       }));
+    }
+
+    function renderMailbox() {
+      $('inboxTab').classList.toggle('active', mailboxDirection === 'inbox');
+      $('outboxTab').classList.toggle('active', mailboxDirection === 'outbox');
+      const visible = mailbox.filter(item => item.direction === mailboxDirection);
+      $('mailboxEmpty').textContent = selected
+        ? (visible.length ? '' : `No ${mailboxDirection} messages`) : 'Select a session';
+      $('mailboxList').replaceChildren(...visible.map(item => {
+        const button = document.createElement('button');
+        button.className = 'mail';
+        button.dataset.messageId = item.id;
+        const subject = document.createElement('span');
+        subject.textContent = item.subject;
+        const meta = document.createElement('span');
+        meta.className = 'mail-meta';
+        const delivery = item.direction === 'inbox'
+          ? `${item.notified ? 'notified' : (item.notification_error === 'queued' ? 'nudge queued' : (item.notification_error ? 'notify failed' : 'not notified'))} · ${item.fetched ? 'fetched' : 'not fetched'}`
+          : 'published';
+        const reply = item.reply_to ? ` · reply to ${item.reply_to}` : '';
+        meta.textContent = `${item.id} · ${item.sender} · ${item.status} · ${delivery}${reply}`;
+        button.append(subject, meta);
+        button.onclick = () => {
+          mailboxSelected = item.id;
+          $('mailboxRaw').hidden = false;
+          $('mailboxRaw').textContent = JSON.stringify(item, null, 2);
+        };
+        return button;
+      }));
+      const current = mailbox.find(item => item.id === mailboxSelected);
+      if (!current) {
+        $('mailboxRaw').hidden = true;
+        $('mailboxRaw').textContent = '';
+      }
+    }
+
+    async function refreshMailbox() {
+      mailbox = selected
+        ? await request(`/api/v1/mailbox?session_id=${encodeURIComponent(selected)}`)
+        : [];
+      renderMailbox();
     }
 
     async function refreshSessions() {
@@ -215,6 +283,10 @@
           if (index >= 0) sessions[index] = data.session; else sessions.push(data.session);
           renderSessions();
         }
+        if (message.type === 'mailbox' && message.session_id === selected) {
+          mailbox = message.data;
+          renderMailbox();
+        }
       };
     }
 
@@ -269,6 +341,8 @@
         } catch (error) { showError(error); }
       };
       $('refresh').onclick = () => refreshSessions().catch(showError);
+      $('inboxTab').onclick = () => { mailboxDirection = 'inbox'; renderMailbox(); };
+      $('outboxTab').onclick = () => { mailboxDirection = 'outbox'; renderMailbox(); };
       $('attach').onclick = () => attach(true);
       $('observe').onclick = () => attach(false);
       $('detach').onclick = () => { if (attached) sendWs({op: 'detach'}); };
@@ -282,6 +356,7 @@
       $('zoomReset').onclick = () => setZoom(150);
       setInterval(() => { if (ws?.readyState === WebSocket.OPEN) sendWs({op: 'heartbeat'}); }, 2000);
       setInterval(() => refreshSessions().catch(showError), 2000);
+      setInterval(() => refreshMailbox().catch(showError), 2000);
       connect();
     }
 

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -292,7 +292,7 @@ def private prepare_worker_main(var jobs : Channel?&;
             var changed_ranges : array<TextSourceRange>
             var view_source = ""
             var view_text_ready = false
-            var decoded_view_bytes : array<uint8>
+            var inscope decoded_view_bytes : array<uint8>
             var preview_pixels : array<uint8>
             var preview_width = 0
             var preview_height = 0

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -10,6 +10,7 @@ require daslib/rtti
 require daslib/base64
 require daslib/safe_addr
 require daslib/strings_boost
+require daslib/utf8_utils
 require imgui/imgui_text_tree_sitter
 require imgui/imgui_markdown_tree_sitter
 require stbimage/stbimage_boost
@@ -49,6 +50,7 @@ struct public InspectorPrepareEvent {
     markdown_view : MarkdownViewState = MarkdownViewState()
     changed_source_ranges : array<TextSourceRange>
     view_source : string
+    view_text_ready : bool
     preview_pixels : array<uint8>
     preview_width : int
     preview_height : int
@@ -289,16 +291,56 @@ def private prepare_worker_main(var jobs : Channel?&;
             var markdown_view = MarkdownViewState()
             var changed_ranges : array<TextSourceRange>
             var view_source = ""
+            var view_text_ready = false
+            var decoded_view_bytes : array<uint8>
             var preview_pixels : array<uint8>
             var preview_width = 0
             var preview_height = 0
             var preview_error = ""
             let failed = catch_prepare_panic(failure) {
                 var prepared_patch <- git_parse_unified_patch(job.patch)
+                if (prepared_patch.error == "diff contains no text hunks"
+                        && job.view_available) {
+                    prepared_patch.error = ""
+                }
                 if (!empty(prepared_patch.error)) {
                     failure = prepared_patch.error
                 } else {
-                    view_source = (job.view_available || !empty(job.view_text)) ? job.view_text : prepared_patch.new_text
+                    if (!prepared_patch.binary) {
+                        if (job.view_available || !empty(job.view_text)) {
+                            view_source = job.view_text
+                        } else {
+                            view_source = prepared_patch.new_text
+                        }
+                        view_text_ready = true
+                    } elif (job.view_byte_count > MAX_FILE_PREVIEW_RAW_BYTES) {
+                        preview_error = "Binary preview exceeds the 8 MiB raw-byte limit"
+                    } elif (job.view_byte_count == 0) {
+                        preview_error = "Binary preview is empty"
+                    } elif (job.view_byte_count < 0) {
+                        preview_error = "Binary transport reported an invalid byte count"
+                    } elif (empty(job.view_base64)) {
+                        preview_error = "Binary preview bytes are unavailable for this comparison"
+                    } else {
+                        let decoded = base64_decode(job.view_base64,
+                            decoded_view_bytes)
+                        if (decoded < 0 || decoded != job.view_byte_count) {
+                            preview_error = "Binary transport failed exact-byte validation"
+                        } else {
+                            var has_nul = false
+                            for (byte in decoded_view_bytes) {
+                                if (byte == uint8(0)) {
+                                    has_nul = true
+                                    break
+                                }
+                            }
+                            if (!has_nul
+                                    && is_utf8_string_valid(decoded_view_bytes)) {
+                                view_source = string(decoded_view_bytes)
+                                view_text_ready = true
+                            }
+                        }
+                    }
                     let old_source = inspector_reconstruct_old_source(
                         view_source, prepared_patch)
                     var full_old <- tree_sitter_source_document(
@@ -332,7 +374,7 @@ def private prepare_worker_main(var jobs : Channel?&;
                                 kind = TextSourceLineMarkKind.added))
                         }
                     }
-                    if (!prepared_patch.binary) {
+                    if (view_text_ready) {
                         full_new.line_marks |> reserve(
                             length(prepared_patch.new_changed_lines))
                         for (line in prepared_patch.new_changed_lines) {
@@ -359,43 +401,29 @@ def private prepare_worker_main(var jobs : Channel?&;
                     } else {
                         text_source_document_dispose(full_new)
                     }
-                    if (prepared_patch.binary) {
-                        if (job.view_byte_count > MAX_FILE_PREVIEW_RAW_BYTES) {
-                            preview_error = "Binary preview exceeds the 8 MiB raw-byte limit"
-                        } elif (job.view_byte_count == 0) {
-                            preview_error = "Binary preview is empty"
-                        } elif (job.view_byte_count < 0) {
-                            preview_error = "Binary transport reported an invalid byte count"
-                        } elif (empty(job.view_base64)) {
-                            preview_error = "Binary preview bytes are unavailable for this comparison"
+                    if (prepared_patch.binary && !view_text_ready
+                            && empty(preview_error)) {
+                        var width, height, channels : int
+                        let image_info = stbi_info_from_memory(
+                            unsafe(addr<uint8 const?>(decoded_view_bytes[0])),
+                            length(decoded_view_bytes), safe_addr(width),
+                            safe_addr(height), safe_addr(channels))
+                        if (image_info == 0) {
+                            preview_error = stbi_failure_reason()
+                        } elif (width <= 0 || height <= 0 ||
+                                int64(width) * int64(height)
+                                    > MAX_BINARY_PREVIEW_PIXELS) {
+                            preview_error = "Image dimensions exceed the 64 megapixel preview limit"
                         } else {
-                            var inscope encoded : array<uint8>
-                            let decoded = base64_decode(job.view_base64, encoded)
-                            if (decoded < 0 || decoded != job.view_byte_count) {
-                                preview_error = "Binary transport failed exact-byte validation"
+                            var image : Image
+                            let (image_ok, image_error) = image->load_from_memory(
+                                decoded_view_bytes, 4)
+                            if (image_ok) {
+                                preview_width = image.width
+                                preview_height = image.height
+                                preview_pixels <- image.bytes
                             } else {
-                                var width, height, channels : int
-                                let image_info = stbi_info_from_memory(
-                                    unsafe(addr<uint8 const?>(encoded[0])),
-                                    length(encoded), safe_addr(width),
-                                    safe_addr(height), safe_addr(channels))
-                                if (image_info == 0) {
-                                    preview_error = stbi_failure_reason()
-                                } elif (width <= 0 || height <= 0 ||
-                                        int64(width) * int64(height)
-                                            > MAX_BINARY_PREVIEW_PIXELS) {
-                                    preview_error = "Image dimensions exceed the 64 megapixel preview limit"
-                                } else {
-                                    var image : Image
-                                    let (image_ok, image_error) = image->load_from_memory(encoded, 4)
-                                    if (image_ok) {
-                                        preview_width = image.width
-                                        preview_height = image.height
-                                        preview_pixels <- image.bytes
-                                    } else {
-                                        preview_error = image_error
-                                    }
-                                }
+                                preview_error = image_error
                             }
                         }
                     }
@@ -416,6 +444,7 @@ def private prepare_worker_main(var jobs : Channel?&;
                     kind = InspectorPrepareEventKind.completed,
                     generation = job.generation,
                     view_source = view_source,
+                    view_text_ready = view_text_ready,
                     preview_width = preview_width,
                     preview_height = preview_height,
                     preview_byte_count = job.view_byte_count,

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -579,7 +579,7 @@ def public repository_file_diff_argv(repository_id : string;
         let path_error = repository_working_preview_path(
             worktree_path, file_path, absolute_path)
         if (!empty(path_error)) return path_error
-        var clean_file = GitFileState(
+        let clean_file = GitFileState(
             worktree_path = worktree_path, code = "  ", path = file_path)
         return repository_build_file_diff_argv(
             worktree_path, clean_file, comparison, argv, expected_exit_code,

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -358,11 +358,12 @@ def public repository_build_file_diff_argv(worktree_path : string;
     delete argv
     expected_exit_code = 0l
     let staged = file.code != "??" && byte_at(file.code, 0) != ' '
-    let working = file.code == "??" || byte_at(file.code, 1) != ' '
     if (comparison == "staged" && !staged) return "file has no staged change"
-    if (comparison == "working" && !working) return "file has no working-tree change"
     if (comparison != "staged" && comparison != "working") {
         return "comparison is not implemented"
+    }
+    if (!repository_valid_relative_file_path(file.path)) {
+        return "invalid worktree-relative file path"
     }
     var context_lines = 3
     if (diff_context == "expanded") {
@@ -570,7 +571,20 @@ def public repository_file_diff_argv(repository_id : string;
             break
         }
     }
-    if (file_index < 0) return "file is not present in the observed Git status"
+    if (file_index < 0) {
+        if (comparison != "working") {
+            return "file is not present in the observed Git status"
+        }
+        var absolute_path = ""
+        let path_error = repository_working_preview_path(
+            worktree_path, file_path, absolute_path)
+        if (!empty(path_error)) return path_error
+        var clean_file = GitFileState(
+            worktree_path = worktree_path, code = "  ", path = file_path)
+        return repository_build_file_diff_argv(
+            worktree_path, clean_file, comparison, argv, expected_exit_code,
+            diff_context)
+    }
     let file = runtime.snapshot.files[file_index]
     return repository_build_file_diff_argv(
         worktree_path, file, comparison, argv, expected_exit_code,
@@ -743,15 +757,7 @@ def public repository_working_file_text(repository_id : string;
         return "unknown repository"
     }
     let runtime = g_repositories[repository_index]
-    var file_found = false
-    for (file in runtime.snapshot.files) {
-        if (file.worktree_path == worktree_path && file.path == file_path
-                && (file.code == "??" || byte_at(file.code, 1) != ' ')) {
-            file_found = true
-            break
-        }
-    }
-    if (!file_found) return "file has no observed working-tree change"
+    if (find_worktree(runtime, worktree_path) < 0) return "unknown worktree"
     var absolute_path = ""
     let path_error = repository_working_preview_path(
         worktree_path, file_path, absolute_path)
@@ -772,15 +778,7 @@ def public repository_working_file_bytes(repository_id : string;
         return "unknown repository"
     }
     let runtime = g_repositories[repository_index]
-    var file_found = false
-    for (file in runtime.snapshot.files) {
-        if (file.worktree_path == worktree_path && file.path == file_path
-                && (file.code == "??" || byte_at(file.code, 1) != ' ')) {
-            file_found = true
-            break
-        }
-    }
-    if (!file_found) return "file has no observed working-tree change"
+    if (find_worktree(runtime, worktree_path) < 0) return "unknown worktree"
     var absolute_path = ""
     let path_error = repository_working_preview_path(
         worktree_path, file_path, absolute_path)

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -206,8 +206,6 @@ struct private GitInspectorState {
     old_document : TextSourceDocument = TextSourceDocument()
     new_document : TextSourceDocument = TextSourceDocument()
     view_document : TextSourceDocument = TextSourceDocument()
-    focus_new_document : TextSourceDocument = TextSourceDocument()
-    focus_view_document : TextSourceDocument = TextSourceDocument()
     focus_document_valid : bool
     focus_start_byte : int = -1
     old_view : TextSourceViewState = TextSourceViewState()
@@ -262,9 +260,11 @@ var private g_selected_repository_id : string
 var private g_focus_terminal_pending = false
 var private g_active_focus_message = ""
 var private g_active_focus_target = -1
+var private g_active_focus_range = -1
 var private g_focus_visible = true
 var private g_pending_focus_scroll = false
 var private g_focus_view_scroll_pending = false
+var private g_focus_view_scroll_y = 0.0f
 var private g_last_human_request = ""
 var private g_applied_focus_identity = ""
 var private g_requested_history_commit : string
@@ -301,12 +301,31 @@ var private WORKTREE_SEPARATOR : table<int; EmptyMarkerState>
 var private GIT_GROUP_SEPARATOR : table<int; EmptyMarkerState>
 var private GIT_GROUP_SPACING : table<int; EmptyMarkerState>
 var private GIT_HOVER_TOOLTIP : NarrativeState
+var private FOCUS_HINT_TOOLTIP : NarrativeState
 var private GIT_CHANGELIST_STATUS_TEXT : NarrativeState
 var private GIT_ACTIVITY_STATUS_TEXT : NarrativeState
 var private GIT_CHANGELIST_STATUS_SEPARATOR : EmptyMarkerState
 var private GIT_ACTIVITY_STATUS_SEPARATOR : EmptyMarkerState
 var private INSPECTOR_STATUS_TEXT : NarrativeState
 var private INSPECTOR_STATUS_SEPARATOR : EmptyMarkerState
+var private REPOSITORY_ERROR_POPUP : table<int; PopupContextItemState>
+var private REPOSITORY_ERROR_COPY : table<int; ToggleState>
+var private REPOSITORY_ERROR_SEND : table<int; ToggleState>
+var private CHANGELIST_ERROR_POPUP : PopupContextItemState
+var private CHANGELIST_ERROR_COPY : ToggleState
+var private CHANGELIST_ERROR_SEND : ToggleState
+var private ACTIVITY_ERROR_POPUP : PopupContextItemState
+var private ACTIVITY_ERROR_COPY : ToggleState
+var private ACTIVITY_ERROR_SEND : ToggleState
+var private INSPECTOR_ERROR_POPUP : PopupContextItemState
+var private INSPECTOR_ERROR_COPY : ToggleState
+var private INSPECTOR_ERROR_SEND : ToggleState
+var private CLIENT_ERROR_POPUP : PopupContextItemState
+var private CLIENT_ERROR_COPY : ToggleState
+var private CLIENT_ERROR_SEND : ToggleState
+var private PREVIEW_ERROR_POPUP : PopupContextItemState
+var private PREVIEW_ERROR_COPY : ToggleState
+var private PREVIEW_ERROR_SEND : ToggleState
 
 def private setup_default_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
@@ -325,8 +344,12 @@ def private setup_default_layout(dock_id : uint) {
     var changelist_id : uint = 0u
     var activity_id : uint = 0u
     DockBuilderSplitNode(git_id, ImGuiDir.Up, 0.35f, changelist_id, activity_id)
-    DockBuilderDockWindow("Sessions & Activity", left_id)
-    DockBuilderDockWindow("Repositories & Worktrees", left_id)
+    var repositories_id : uint = 0u
+    var sessions_id : uint = 0u
+    DockBuilderSplitNode(left_id, ImGuiDir.Down, 0.42f,
+        sessions_id, repositories_id)
+    DockBuilderDockWindow("Sessions & Activity###SessionsActivity", sessions_id)
+    DockBuilderDockWindow("Repositories & Worktrees", repositories_id)
     DockBuilderDockWindow("Git Changelist", changelist_id)
     DockBuilderDockWindow("Git Activity", activity_id)
     DockBuilderDockWindow("File Inspector", inspector_id)
@@ -382,8 +405,6 @@ def private release_inspector_content() {
     text_source_document_dispose(g_inspector.old_document)
     text_source_document_dispose(g_inspector.new_document)
     text_source_document_dispose(g_inspector.view_document)
-    text_source_document_dispose(g_inspector.focus_new_document)
-    text_source_document_dispose(g_inspector.focus_view_document)
     g_inspector.focus_document_valid = false
     g_inspector.focus_start_byte = -1
     markdown_view_dispose(g_inspector.markdown_view)
@@ -397,6 +418,7 @@ def private release_inspector_content() {
     g_inspector.preview_byte_count = 0
     g_inspector.preview_error = ""
     g_inspector.diff_scroll_y = 0.0f
+    g_focus_view_scroll_y = 0.0f
     g_inspector.diff_scroll_jump_pending = false
     g_inspector.diff_current_hunk = 0
     g_inspector.diff_left_rect = float4()
@@ -948,6 +970,37 @@ class private WatcherRichClient : HvWebSocketClient {
         send(payload)
     }
 
+    def post_error_request(context, message : string) {
+        if (!connected || empty(selected_id) || empty(message)) return
+        let subject = "{context}: {message}"
+        var focus_json = ("\"focus\":\{\"summary\":" +
+            "{sprint_json(subject, false)},\"targets\":[]\}")
+        if (!empty(g_inspector.installed_repository_id)
+                && !empty(g_inspector.installed_worktree_path)
+                && !empty(g_inspector.installed_file_path)) {
+            focus_json = ("\"focus\":\{" +
+                "\"repository_id\":{sprint_json(g_inspector.installed_repository_id, false)}," +
+                "\"worktree_path\":{sprint_json(g_inspector.installed_worktree_path, false)}," +
+                "\"comparison\":{sprint_json(g_inspector.installed_comparison, false)}," +
+                "\"revision\":{sprint_json(g_inspector.installed_git_revision, false)}," +
+                "\"summary\":{sprint_json(subject, false)},\"targets\":[\{" +
+                "\"file_path\":{sprint_json(g_inspector.installed_file_path, false)}," +
+                "\"whole_file\":true,\"ranges\":[]\}]\}")
+        }
+        send(("\{\"op\":\"mailbox_post\",\"session_id\":" +
+            "{sprint_json(selected_id, false)},\"direction\":\"inbox\"," +
+            "\"sender\":\"human:local\",\"kind\":\"error\"," +
+            "\"subject\":{sprint_json(subject, false)},\"notify\":true," +
+            "{focus_json}\}"))
+    }
+
+    def acknowledge_mailbox(message_id : string) {
+        if (!connected || empty(selected_id) || empty(message_id)) return
+        send("\{\"op\":\"mailbox_state\",\"session_id\":" +
+            "{sprint_json(selected_id, false)},\"message_id\":" +
+            "{sprint_json(message_id, false)},\"status\":\"acknowledged\"\}")
+    }
+
     def send_input(text : string) {
         if (!controls || empty(text)) return
         send("\{\"op\":\"input\",\"text\":{sprint_json(text, false)}\}")
@@ -1018,6 +1071,80 @@ def private selected_session_label() : string {
     return g_client.selected_id
 }
 
+def private pending_attention_count() : int {
+    var count = 0
+    if (g_client != null) {
+        for (message in g_client.mailbox) {
+            if (message.direction == "outbox" && message.status == "new") count++
+        }
+    }
+    return count
+}
+
+def private first_focus_range(target : WatcherFocusTarget const) : int {
+    var result = -1
+    for (index in range(length(target.ranges))) {
+        if (result < 0 || target.ranges[index].start_byte
+                < target.ranges[result].start_byte) {
+            result = index
+        }
+    }
+    return result
+}
+
+def private activate_focus_target(message : WatcherMailboxMessage const;
+                                  target_index : int) {
+    if (g_client == null || target_index < 0
+            || target_index >= length(message.focus.targets)) return
+    let target & = unsafe(message.focus.targets[target_index])
+    g_active_focus_message = message.id
+    g_active_focus_target = target_index
+    g_active_focus_range = first_focus_range(target)
+    g_focus_visible = true
+    g_pending_focus_scroll = true
+    g_applied_focus_identity = ""
+    let selection_changed = (g_selected_repository_id
+            != message.focus.repository_id
+        || g_selected_worktree_path != message.focus.worktree_path)
+    g_selected_repository_id = message.focus.repository_id
+    g_selected_worktree_path = message.focus.worktree_path
+    if (message.status == "new") g_client->acknowledge_mailbox(message.id)
+    if (selection_changed) {
+        g_client->refresh_repository(message.focus.repository_id)
+        g_client->request_repository_review(message.focus.repository_id,
+            message.focus.worktree_path)
+        g_client->request_repository_history(message.focus.repository_id,
+            message.focus.worktree_path)
+        g_client->request_repository_refs(message.focus.repository_id,
+            message.focus.worktree_path)
+    }
+    g_client->inspect_file(message.focus.repository_id,
+        message.focus.worktree_path, target.file_path,
+        message.focus.comparison, "full", message.focus.revision)
+    FILE_INSPECTOR_WIN.open = true
+    FILE_INSPECTOR_WIN.pending_raise = true
+}
+
+def private draw_error_context(var popup_state : PopupContextItemState;
+                               var copy_state : ToggleState;
+                               var send_state : ToggleState;
+                               popup_id, context, message : string) {
+    popup_context_item(popup_state,
+            (str_id = popup_id, flags = ImGuiPopupFlags.MouseButtonRight)) {
+        if (menu_item(copy_state, (text = "Copy error"))) {
+            let copied = clipboard_set_text(message)
+            g_status = (copied == ClipboardStatus.ok
+                ? "Error copied" : "Clipboard unavailable")
+        }
+        if (menu_item(send_state, (text = "Send to session agent",
+                enabled = g_client != null && g_client.connected
+                    && !empty(g_client.selected_id)))) {
+            g_client->post_error_request(context, message)
+            g_status = "Error sent to session agent"
+        }
+    }
+}
+
 def private draw_session_list() {
     let connection = g_client != null && g_client.connected ? "connected" : "disconnected"
     text("Watcher: {connection}")
@@ -1054,12 +1181,7 @@ def private draw_session_list() {
     }
     text_disabled("Exited sessions are retained and hidden by default.")
     separator()
-    var attention_count = 0
-    if (g_client != null) {
-        for (message in g_client.mailbox) {
-            if (message.direction == "outbox") attention_count++
-        }
-    }
+    let attention_count = pending_attention_count()
     text("Attention ({attention_count})")
     text_disabled("Agent notes never navigate until you click them.")
     child(ATTENTION_CHILD, (text = "attention", size = float2(0.0f, 0.0f),
@@ -1069,37 +1191,21 @@ def private draw_session_list() {
             for (message_index in range(length(g_client.mailbox))) {
                 let message & = unsafe(g_client.mailbox[message_index])
                 if (message.direction != "outbox") continue
-                let selected_message = message.id == g_active_focus_message
-                ATTENTION_MESSAGE_ROW[message_index].value = selected_message
+                ATTENTION_MESSAGE_ROW[message_index].value = false
                 if (selectable(ATTENTION_MESSAGE_ROW[message_index],
                         (text = "{message.subject}##{message.id}"))
                         && !empty(message.focus.targets)) {
-                    g_active_focus_message = message.id
-                    g_active_focus_target = 0
-                    g_focus_visible = true
-                    g_pending_focus_scroll = true
-                    let target & = unsafe(message.focus.targets[0])
-                    g_client->inspect_file(message.focus.repository_id,
-                        message.focus.worktree_path, target.file_path,
-                        message.focus.comparison, "compact", message.focus.revision)
-                    FILE_INSPECTOR_WIN.open = true
-                    FILE_INSPECTOR_WIN.pending_raise = true
+                    activate_focus_target(message, 0)
                 }
+                ATTENTION_MESSAGE_ROW[message_index].value = false
+                let selected_message = message.id == g_active_focus_message
                 for (target_index in range(length(message.focus.targets))) {
                     let target & = unsafe(message.focus.targets[target_index])
                     ATTENTION_TARGET_ROW[target_row].value = (selected_message
                         && target_index == g_active_focus_target)
                     if (selectable(ATTENTION_TARGET_ROW[target_row],
                             (text = "  {target.file_path}##{message.id}:{target_index}"))) {
-                        g_active_focus_message = message.id
-                        g_active_focus_target = target_index
-                        g_focus_visible = true
-                        g_pending_focus_scroll = true
-                        g_client->inspect_file(message.focus.repository_id,
-                            message.focus.worktree_path, target.file_path,
-                            message.focus.comparison, "compact", message.focus.revision)
-                        FILE_INSPECTOR_WIN.open = true
-                        FILE_INSPECTOR_WIN.pending_raise = true
+                        activate_focus_target(message, target_index)
                     }
                     target_row++
                 }
@@ -1188,7 +1294,9 @@ def private draw_main_menu() {
                 open_dock_window(REPOSITORIES_WIN)
             }
             if (menu_label(VIEW_SESSIONS,
-                    (text = "Sessions & Activity", selected = SESSIONS_WIN.open))) {
+                    (text = pending_attention_count() > 0
+                        ? "Sessions & Activity  [{pending_attention_count()}]"
+                        : "Sessions & Activity", selected = SESSIONS_WIN.open))) {
                 open_dock_window(SESSIONS_WIN)
             }
             if (menu_label(VIEW_GIT_CHANGELIST,
@@ -1248,6 +1356,11 @@ def private draw_repositories_window() {
             if (!empty(repository.error)) {
                 text_colored(REPOSITORY_ERROR[repository_row], (color = float4(1.0f, 0.35f, 0.30f, 1.0f),
                     text = repository.error))
+                draw_error_context(REPOSITORY_ERROR_POPUP[repository_row],
+                    REPOSITORY_ERROR_COPY[repository_row],
+                    REPOSITORY_ERROR_SEND[repository_row],
+                    "repository_error_{repository_row}", "Repository",
+                    repository.error)
             }
             for (worktree in repository.worktrees) {
                 var branch = worktree.branch
@@ -2150,6 +2263,11 @@ def private draw_git_changelist_window() {
     separator(GIT_CHANGELIST_STATUS_SEPARATOR)
     text_colored(GIT_CHANGELIST_STATUS_TEXT,
         (color = git_status_color(status), text = status.text))
+    if (status.error) {
+        draw_error_context(CHANGELIST_ERROR_POPUP, CHANGELIST_ERROR_COPY,
+            CHANGELIST_ERROR_SEND, "changelist_error", "Git Changelist",
+            status.text)
+    }
 }
 
 def private draw_git_activity_window() {
@@ -2189,6 +2307,11 @@ def private draw_git_activity_window() {
     separator(GIT_ACTIVITY_STATUS_SEPARATOR)
     text_colored(GIT_ACTIVITY_STATUS_TEXT,
         (color = git_status_color(status), text = status.text))
+    if (status.error) {
+        draw_error_context(ACTIVITY_ERROR_POPUP, ACTIVITY_ERROR_COPY,
+            ACTIVITY_ERROR_SEND, "activity_error", "Git Activity",
+            status.text)
+    }
 }
 
 def private source_view_style(diff_background : bool = false) : TextSourceViewStyle {
@@ -2238,6 +2361,11 @@ def private draw_binary_preview() {
             (text = empty(g_inspector.preview_error)
                 ? "Preview unavailable"
                 : "Preview unavailable: {g_inspector.preview_error}"))
+        if (!empty(g_inspector.preview_error)) {
+            draw_error_context(PREVIEW_ERROR_POPUP, PREVIEW_ERROR_COPY,
+                PREVIEW_ERROR_SEND, "preview_error", "File Preview",
+                g_inspector.preview_error)
+        }
         return
     }
     text_disabled(INSPECTOR_BINARY_DIMENSIONS,
@@ -2398,16 +2526,11 @@ def private draw_side_by_side_diff() {
         }
         text_disabled("AFTER")
         separator()
-        var result = TextSourceViewResult()
-        if (g_inspector.focus_document_valid) {
-            var style = focus_source_view_style(true)
-            result <- text_source_view("git diff after",
-                g_inspector.focus_new_document, g_inspector.new_view, style)
-        } else {
-            var style = source_view_style(true)
-            result <- text_source_view("git diff after", g_inspector.new_document,
-                g_inspector.new_view, style)
-        }
+        var style = source_view_style(true)
+        let result <- text_source_view("git diff after", g_inspector.new_document,
+            g_inspector.new_view, style)
+        draw_active_focus_overlay(g_inspector.new_view,
+            g_inspector.new_document, true)
         if (result.selection_context_requested) {
             open_popup(DIFF_SELECTION_POPUP)
         }
@@ -2418,8 +2541,11 @@ def private draw_side_by_side_diff() {
                     (text = "Look at that", enabled = g_client != null
                         && g_client.connected && !empty(g_client.selected_id)
                         && selection.end_byte > selection.start_byte))) {
-                g_client->post_selection_request(
-                    selection.start_byte, selection.end_byte)
+                let canonical_start = diff_byte_to_view_byte(
+                    selection.start_byte, false)
+                let canonical_end = diff_byte_to_view_byte(
+                    selection.end_byte, true)
+                g_client->post_selection_request(canonical_start, canonical_end)
                 close_current_popup(DIFF_SELECTION_POPUP)
             }
         }
@@ -2450,19 +2576,14 @@ def private draw_file_view() {
                 max(1.0f, 2.0f * float(g_zoom_percent) / 100.0f))
         } else {
             if (g_focus_view_scroll_pending) {
-                SetScrollY(max(0.0f, g_inspector.diff_scroll_y))
+                SetScrollY(max(0.0f, g_focus_view_scroll_y))
                 g_focus_view_scroll_pending = false
             }
-            var result = TextSourceViewResult()
-            if (g_inspector.focus_document_valid) {
-                var style = focus_source_view_style(false)
-                result <- text_source_view("git file view",
-                    g_inspector.focus_view_document, g_inspector.view, style)
-            } else {
-                var style = source_view_style(false)
-                result <- text_source_view("git file view",
-                    g_inspector.view_document, g_inspector.view, style)
-            }
+            var style = source_view_style(false)
+            let result <- text_source_view("git file view",
+                g_inspector.view_document, g_inspector.view, style)
+            draw_active_focus_overlay(g_inspector.view,
+                g_inspector.view_document, false)
             if (result.selection_context_requested) {
                 open_popup(INSPECTOR_SELECTION_POPUP)
             }
@@ -2857,8 +2978,8 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         new_line_number_count = length(g_inspector.new_document.line_numbers),
         view_line_mark_count = length(g_inspector.view_document.line_marks),
         focus_document_valid = g_inspector.focus_document_valid,
-        focus_new_marker_count = g_inspector.focus_new_document.marker_count,
-        focus_view_marker_count = g_inspector.focus_view_document.marker_count,
+        focus_new_marker_count = 0,
+        focus_view_marker_count = 0,
         focus_start_byte = g_inspector.focus_start_byte,
         changed_source_range_count = length(g_inspector.changed_source_ranges),
         old_syntax_span_count = length(g_inspector.old_document.spans),
@@ -2986,13 +3107,6 @@ def private file_inspector_status() : GitWindowStatus {
     return GitWindowStatus(text = "Select a changed file")
 }
 
-def private focus_source_view_style(diff_background : bool = false) : TextSourceViewStyle {
-    var style = source_view_style(diff_background)
-    style.text_color = float4(0.30f, 0.31f, 0.33f, 1.0f)
-    style.marker_color = float4(1.0f, 0.82f, 0.38f, 1.0f)
-    return style
-}
-
 [live_command(description = "Inspect persistent, non-modal agent Attention and active Focus Set state.")]
 def herder_attention_state(_input : JsonValue?) : JsonValue? {
     var messages : array<JsonValue?>
@@ -3015,6 +3129,7 @@ def herder_attention_state(_input : JsonValue?) : JsonValue? {
         mailbox_revision = g_client != null ? g_client.mailbox_revision : 0l,
         active_message_id = g_active_focus_message,
         active_target_index = g_active_focus_target,
+        active_range_index = g_active_focus_range,
         focus_visible = g_focus_visible,
         last_human_request_id = g_last_human_request,
         messages = messages))
@@ -3032,86 +3147,234 @@ def herder_attention_open(input : JsonValue?) : JsonValue? {
                 || args.target_index >= length(message.focus.targets)) {
             return JV((ok = false, error = "target_index is out of range"))
         }
-        g_active_focus_message = message.id
-        g_active_focus_target = args.target_index
-        g_focus_visible = true
-        g_pending_focus_scroll = true
-        g_applied_focus_identity = ""
         let target & = unsafe(message.focus.targets[args.target_index])
-        g_client->inspect_file(message.focus.repository_id,
-            message.focus.worktree_path, target.file_path,
-            message.focus.comparison, "compact", message.focus.revision)
-        FILE_INSPECTOR_WIN.open = true
-        FILE_INSPECTOR_WIN.pending_raise = true
+        activate_focus_target(message, args.target_index)
         return JV((ok = true, message_id = message.id,
             target_index = args.target_index, file_path = target.file_path))
     }
     return JV((ok = false, error = "unknown attention message"))
 }
 
-def private push_focus_span(var document : TextSourceDocument;
-                            start_byte, end_byte : int; marker : bool) {
-    if (end_byte <= start_byte) return
-    var styles : TextSourceStyles
-    styles.marker = marker
-    styles.bold = marker
-    document.spans |> push(TextSourceSpan(
-        source = TextSourceRange(start_byte = start_byte, end_byte = end_byte),
-        styles = styles))
-    if (marker) {
-        document.marker_count++
+def private append_line_starts(source : string;
+                               var starts : array<int>&) {
+    delete starts
+    starts |> push(0)
+    peek_data(source) $(bytes) {
+        for (index in range(length(bytes))) {
+            if (int(bytes[index]) == '\n') starts |> push(index + 1)
+        }
     }
 }
 
-def private make_focus_document(source : TextSourceDocument const;
-                                target : WatcherFocusTarget const;
-                                revision_bias : int) : TextSourceDocument {
-    var document = TextSourceDocument(
-        source = clone_string(source.source),
-        revision = source.revision + revision_bias)
-    document.line_marks := source.line_marks
-    document.line_numbers := source.line_numbers
-    let source_length = length(source.source)
-    if (target.whole_file || empty(target.ranges)) {
-        push_focus_span(document, 0, source_length, true)
-        return <- document
+def private diff_byte_to_view_byte(diff_byte : int;
+                                   end_bias : bool) : int {
+    var inscope diff_starts : array<int>
+    var inscope view_starts : array<int>
+    append_line_starts(g_inspector.new_document.source, diff_starts)
+    append_line_starts(g_inspector.view_document.source, view_starts)
+    let clamped_byte = clamp(diff_byte, 0,
+        length(g_inspector.new_document.source))
+    var display_line = 0
+    for (index in range(length(diff_starts))) {
+        if (diff_starts[index] > clamped_byte) break
+        display_line = index
     }
-    var cursor = 0
-    while (cursor < source_length) {
-        var best_start = source_length
-        var best_end = -1
-        for (focus_range in target.ranges) {
-            let range_start = clamp(focus_range.start_byte, 0, source_length)
-            let range_end = clamp(focus_range.end_byte, 0, source_length)
-            if (range_end <= cursor || range_end <= range_start) continue
-            if (range_start < best_start) {
-                best_start = range_start
-                best_end = range_end
-            } elif (range_start == best_start) {
-                best_end = max(best_end, range_end)
+    if (display_line < 0
+            || display_line >= length(g_inspector.new_document.line_numbers)) return -1
+    var source_line = g_inspector.new_document.line_numbers[display_line]
+    if (source_line <= 0 && end_bias) {
+        var scan = display_line - 1
+        while (scan >= 0) {
+            source_line = g_inspector.new_document.line_numbers[scan]
+            if (source_line > 0) break
+            scan--
+        }
+    }
+    if (source_line <= 0 || source_line > length(view_starts)) return -1
+    let column = max(0, clamped_byte - diff_starts[display_line])
+    let line_start = view_starts[source_line - 1]
+    let line_end = (source_line < length(view_starts)
+        ? max(line_start, view_starts[source_line] - 1)
+        : length(g_inspector.view_document.source))
+    return min(line_end, line_start + column)
+}
+
+def private focus_intersects(target : WatcherFocusTarget const;
+                             start_byte, end_byte : int) : bool {
+    if (target.whole_file || empty(target.ranges)) return true
+    for (focus_range in target.ranges) {
+        if (focus_range.end_byte > start_byte
+                && focus_range.start_byte < end_byte) return true
+    }
+    return false
+}
+
+def private focus_caption(target : WatcherFocusTarget const;
+                          start_byte, end_byte : int) : string {
+    for (focus_range in target.ranges) {
+        if (!empty(focus_range.caption)
+                && focus_range.end_byte > start_byte
+                && focus_range.start_byte < end_byte) {
+            return focus_range.caption
+        }
+    }
+    return ""
+}
+
+def private mouse_inside(p0, p1 : float2) : bool {
+    let mouse = GetMousePos()
+    return (mouse.x >= p0.x && mouse.x <= p1.x
+        && mouse.y >= p0.y && mouse.y <= p1.y)
+}
+
+def private draw_focus_target_overlay(target : WatcherFocusTarget const;
+                                      state : TextSourceViewState const;
+                                      document : TextSourceDocument const;
+                                      diff_mapping : bool) {
+    var inscope display_starts : array<int>
+    var inscope view_starts : array<int>
+    if (diff_mapping) {
+        append_line_starts(document.source, display_starts)
+        append_line_starts(g_inspector.view_document.source, view_starts)
+    }
+    let dim_color = GetColorU32(float4(0.015f, 0.018f, 0.024f, 0.48f))
+    let focus_fill = GetColorU32(float4(1.0f, 0.72f, 0.18f, 0.13f))
+    let focus_outline = GetColorU32(float4(1.0f, 0.76f, 0.24f, 0.92f))
+    let clip_min = GetWindowPos()
+    let clip_max = clip_min + GetWindowSize()
+    var hover_caption = ""
+    with_window_drawlist() $(var dl) {
+        dl |> with_drawlist_clip_rect(clip_min, clip_max, true) {
+            if (state.virtual_mode && !empty(state.virtual_line_starts)) {
+                let line_height = (state.screen_size.y
+                    / float(length(state.virtual_line_starts)))
+                for (line_index in range(length(state.virtual_line_starts))) {
+                    let display_start = state.virtual_line_starts[line_index]
+                    let display_end = (line_index + 1 < length(state.virtual_line_starts)
+                        ? max(display_start,
+                            state.virtual_line_starts[line_index + 1] - 1)
+                        : length(document.source))
+                    var source_start = display_start
+                    var source_end = display_end
+                    var mapped = !diff_mapping
+                    if (diff_mapping && line_index < length(document.line_numbers)) {
+                        let source_line = document.line_numbers[line_index]
+                        if (source_line > 0 && source_line <= length(view_starts)) {
+                            source_start = view_starts[source_line - 1]
+                            source_end = (source_line < length(view_starts)
+                                ? max(source_start, view_starts[source_line] - 1)
+                                : length(g_inspector.view_document.source))
+                            mapped = true
+                        }
+                    }
+                    let y0 = state.screen_origin.y + float(line_index) * line_height
+                    let p0 = float2(state.screen_origin.x, y0)
+                    let p1 = float2(state.screen_origin.x + state.screen_size.x,
+                        y0 + line_height)
+                    if (p1.y < clip_min.y || p0.y > clip_max.y) continue
+                    let focused = mapped && focus_intersects(target,
+                        source_start, max(source_start + 1, source_end))
+                    if (!focused) {
+                        dl |> add_rect_filled(p0, p1, dim_color)
+                    } else {
+                        dl |> add_rect_filled(p0, p1, focus_fill)
+                        let marker_right = state.screen_origin.x
+                            - max(2.0f, GetStyle().ItemSpacing.x * 0.35f)
+                        dl |> add_rect_filled(
+                            float2(marker_right - 3.0f, p0.y),
+                            float2(marker_right, p1.y), focus_outline)
+                        let caption = focus_caption(target,
+                            source_start, max(source_start + 1, source_end))
+                        if (empty(hover_caption) && !empty(caption)
+                                && mouse_inside(p0, p1)) {
+                            hover_caption = caption
+                        }
+                    }
+                }
+                return
+            }
+            var last_focused_line = -1
+            for (cell in state.cells) {
+                var source_start = cell.source.start_byte
+                var source_end = cell.source.end_byte
+                var mapped = !diff_mapping
+                if (diff_mapping && cell.line_index >= 0
+                        && cell.line_index < length(document.line_numbers)
+                        && cell.line_index < length(display_starts)) {
+                    let source_line = document.line_numbers[cell.line_index]
+                    if (source_line > 0 && source_line <= length(view_starts)) {
+                        let canonical_line_start = view_starts[source_line - 1]
+                        let canonical_line_end = (source_line < length(view_starts)
+                            ? max(canonical_line_start, view_starts[source_line] - 1)
+                            : length(g_inspector.view_document.source))
+                        source_start = min(canonical_line_end,
+                            canonical_line_start + max(0,
+                                cell.source.start_byte - display_starts[cell.line_index]))
+                        source_end = min(canonical_line_end,
+                            canonical_line_start + max(0,
+                                cell.source.end_byte - display_starts[cell.line_index]))
+                        mapped = true
+                    }
+                }
+                let p0 = state.screen_origin + float2(cell.rect.x, cell.rect.y)
+                let p1 = state.screen_origin + float2(cell.rect.z, cell.rect.w)
+                let focused = mapped && focus_intersects(target,
+                    source_start, max(source_start + 1, source_end))
+                if (!focused) {
+                    dl |> add_rect_filled(p0, p1, dim_color)
+                } else {
+                    dl |> add_rect_filled(p0, p1, focus_fill)
+                    if (cell.line_index != last_focused_line) {
+                        let marker_right = state.screen_origin.x
+                            - max(2.0f, GetStyle().ItemSpacing.x * 0.35f)
+                        dl |> add_rect_filled(
+                            float2(marker_right - 3.0f, p0.y),
+                            float2(marker_right, p1.y), focus_outline)
+                        last_focused_line = cell.line_index
+                    }
+                    let caption = focus_caption(target,
+                        source_start, max(source_start + 1, source_end))
+                    let hover_p0 = float2(state.screen_origin.x, p0.y)
+                    let hover_p1 = float2(state.screen_origin.x
+                        + state.screen_size.x, p1.y)
+                    if (empty(hover_caption) && !empty(caption)
+                            && mouse_inside(hover_p0, hover_p1)) {
+                        hover_caption = caption
+                    }
+                }
             }
         }
-        if (best_end < 0) {
-            push_focus_span(document, cursor, source_length, false)
-            break
-        }
-        push_focus_span(document, cursor, max(cursor, best_start), false)
-        let marked_start = max(cursor, best_start)
-        push_focus_span(document, marked_start, best_end, true)
-        cursor = best_end
     }
-    return <- document
+    if (!empty(hover_caption)) {
+        set_tooltip(FOCUS_HINT_TOOLTIP, hover_caption)
+    }
+}
+
+def private draw_active_focus_overlay(state : TextSourceViewState const;
+                                      document : TextSourceDocument const;
+                                      diff_mapping : bool) {
+    if (!g_inspector.focus_document_valid || g_client == null) return
+    for (message in g_client.mailbox) {
+        if (message.id != g_active_focus_message
+                || g_active_focus_target < 0
+                || g_active_focus_target >= length(message.focus.targets)) continue
+        let target & = unsafe(message.focus.targets[g_active_focus_target])
+        if (target.file_path == g_inspector.installed_file_path) {
+            draw_focus_target_overlay(target, state, document, diff_mapping)
+        }
+        return
+    }
 }
 
 def private apply_active_focus() {
     if (g_client == null) return
     let identity = ("{g_active_focus_message}:{g_active_focus_target}:" +
+        "{g_active_focus_range}:" +
         "{g_focus_visible}:{g_inspector.revision}:{g_inspector.installed_file_path}")
     if (identity == g_applied_focus_identity && !g_pending_focus_scroll) return
-    text_source_document_dispose(g_inspector.focus_view_document)
-    text_source_document_dispose(g_inspector.focus_new_document)
     g_inspector.focus_document_valid = false
     g_inspector.focus_start_byte = -1
+    var matched_target = false
     if (g_focus_visible && !empty(g_active_focus_message)) {
         for (message in g_client.mailbox) {
             if (message.id != g_active_focus_message
@@ -3119,13 +3382,15 @@ def private apply_active_focus() {
                     || g_active_focus_target >= length(message.focus.targets)) continue
             let target & = unsafe(message.focus.targets[g_active_focus_target])
             if (target.file_path != g_inspector.installed_file_path) continue
-            g_inspector.focus_view_document <- make_focus_document(
-                g_inspector.view_document, target, 1000001)
-            g_inspector.focus_new_document <- make_focus_document(
-                g_inspector.new_document, target, 1000002)
+            matched_target = true
             g_inspector.focus_document_valid = true
             if (!empty(target.ranges)) {
-                g_inspector.focus_start_byte = target.ranges[0].start_byte
+                if (g_active_focus_range < 0
+                        || g_active_focus_range >= length(target.ranges)) {
+                    g_active_focus_range = first_focus_range(target)
+                }
+                g_inspector.focus_start_byte = target.ranges[
+                    g_active_focus_range].start_byte
             } else {
                 g_inspector.focus_start_byte = 0
             }
@@ -3139,30 +3404,101 @@ def private apply_active_focus() {
                         }
                     }
                 }
-                g_inspector.diff_scroll_y = (float(line_index)
-                    * GetTextLineHeight())
+                var diff_row = line_index
+                for (row_index in range(length(g_inspector.parsed.rows))) {
+                    if (g_inspector.parsed.rows[row_index].new_line
+                            == line_index + 1) {
+                        diff_row = row_index
+                        break
+                    }
+                }
+                let diff_line_height = max(GetTextLineHeight(),
+                    g_inspector.new_view.key.line_height)
+                let view_line_height = max(GetTextLineHeight(),
+                    g_inspector.view.key.line_height)
+                g_inspector.diff_scroll_y = (float(max(0, diff_row - 1))
+                    * diff_line_height)
+                g_focus_view_scroll_y = (float(max(0, line_index - 1))
+                    * view_line_height)
                 g_inspector.diff_scroll_jump_pending = true
                 g_focus_view_scroll_pending = true
             }
             break
         }
     }
-    g_pending_focus_scroll = false
-    g_applied_focus_identity = identity
+    if (!g_pending_focus_scroll || matched_target) {
+        g_pending_focus_scroll = false
+        g_applied_focus_identity = identity
+    } else {
+        // Replacement inspection keeps the old document alive. Do not consume
+        // the one-shot navigation until the requested Focus target installs.
+        g_applied_focus_identity = ""
+    }
 }
 
 def private navigate_active_focus(delta : int) {
     if (g_client == null || empty(g_active_focus_message)) return
     for (message in g_client.mailbox) {
         if (message.id != g_active_focus_message || empty(message.focus.targets)) continue
-        g_active_focus_target = (g_active_focus_target + delta
+        let target_index = (g_active_focus_target + delta
             + length(message.focus.targets)) % length(message.focus.targets)
+        activate_focus_target(message, target_index)
+        return
+    }
+}
+
+def private active_focus_range_count() : int {
+    if (g_client == null || empty(g_active_focus_message)) return 0
+    for (message in g_client.mailbox) {
+        if (message.id == g_active_focus_message
+                && g_active_focus_target >= 0
+                && g_active_focus_target < length(message.focus.targets)) {
+            return length(message.focus.targets[g_active_focus_target].ranges)
+        }
+    }
+    return 0
+}
+
+def private navigate_active_focus_range(delta : int) {
+    if (g_client == null || empty(g_active_focus_message) || delta == 0) return
+    for (message in g_client.mailbox) {
+        if (message.id != g_active_focus_message
+                || g_active_focus_target < 0
+                || g_active_focus_target >= length(message.focus.targets)) continue
         let target & = unsafe(message.focus.targets[g_active_focus_target])
+        if (empty(target.ranges)) return
+        if (g_active_focus_range < 0
+                || g_active_focus_range >= length(target.ranges)) {
+            g_active_focus_range = first_focus_range(target)
+        }
+        let current_start = target.ranges[g_active_focus_range].start_byte
+        var candidate = -1
+        for (index in range(length(target.ranges))) {
+            let start_byte = target.ranges[index].start_byte
+            if (delta > 0 && start_byte > current_start
+                    && (candidate < 0 || start_byte
+                        < target.ranges[candidate].start_byte)) {
+                candidate = index
+            } elif (delta < 0 && start_byte < current_start
+                    && (candidate < 0 || start_byte
+                        > target.ranges[candidate].start_byte)) {
+                candidate = index
+            }
+        }
+        if (candidate < 0) {
+            candidate = first_focus_range(target)
+            if (delta < 0) {
+                for (index in range(length(target.ranges))) {
+                    if (target.ranges[index].start_byte
+                            > target.ranges[candidate].start_byte) {
+                        candidate = index
+                    }
+                }
+            }
+        }
+        g_active_focus_range = candidate
         g_pending_focus_scroll = true
         g_applied_focus_identity = ""
-        g_client->inspect_file(message.focus.repository_id,
-            message.focus.worktree_path, target.file_path,
-            message.focus.comparison, "compact", message.focus.revision)
         return
     }
 }
@@ -3186,16 +3522,39 @@ def private draw_file_inspector_content() {
         (text = to_upper(g_inspector.installed_comparison)))
     if (!empty(g_active_focus_message)) {
         same_line()
-        if (small_button(FOCUS_PREVIOUS, (text = "Previous"))) {
+        if (arrow_button(FOCUS_PREVIOUS,
+                (text = "##previous-focused-file", dir = ImGuiDir.Left))) {
             navigate_active_focus(-1)
         }
+        set_item_tooltip(FOCUS_PREVIOUS_TIP,
+            (text = "Previous focused file"))
         same_line()
-        if (small_button(FOCUS_NEXT, (text = "Next"))) {
+        if (arrow_button(FOCUS_NEXT,
+                (text = "##next-focused-file", dir = ImGuiDir.Right))) {
             navigate_active_focus(1)
         }
+        set_item_tooltip(FOCUS_NEXT_TIP, (text = "Next focused file"))
+        if (active_focus_range_count() > 1) {
+            same_line()
+            if (arrow_button(FOCUS_RANGE_PREVIOUS,
+                    (text = "##previous-highlight", dir = ImGuiDir.Up))) {
+                navigate_active_focus_range(-1)
+            }
+            set_item_tooltip(FOCUS_RANGE_PREVIOUS_TIP,
+                (text = "Previous highlight in file"))
+            same_line()
+            if (arrow_button(FOCUS_RANGE_NEXT,
+                    (text = "##next-highlight", dir = ImGuiDir.Down))) {
+                navigate_active_focus_range(1)
+            }
+            set_item_tooltip(FOCUS_RANGE_NEXT_TIP,
+                (text = "Next highlight in file"))
+        }
         same_line()
-        if (small_button(FOCUS_TOGGLE,
-                (text = g_focus_visible ? "Hide focus" : "Show focus"))) {
+        if (icon_button(FOCUS_TOGGLE,
+                (glyph = g_focus_visible ? "visible" : "hidden",
+                 tip = g_focus_visible ? "Hide focus" : "Show focus",
+                 size = 16.0f))) {
             g_focus_visible = !g_focus_visible
             g_applied_focus_identity = ""
         }
@@ -3226,6 +3585,11 @@ def private draw_file_inspector_window() {
     separator(INSPECTOR_STATUS_SEPARATOR)
     text_colored(INSPECTOR_STATUS_TEXT,
         (color = git_status_color(status), text = status.text))
+    if (status.error) {
+        draw_error_context(INSPECTOR_ERROR_POPUP, INSPECTOR_ERROR_COPY,
+            INSPECTOR_ERROR_SEND, "inspector_error", "File Inspector",
+            status.text)
+    }
 }
 
 def private draw_settings_window() {
@@ -3243,6 +3607,8 @@ def private draw_terminal_window() {
     if (g_client != null && !empty(g_client.error)) {
         text_colored(CLIENT_ERROR,
             (color = float4(1.0f, 0.35f, 0.30f, 1.0f), text = g_client.error))
+        draw_error_context(CLIENT_ERROR_POPUP, CLIENT_ERROR_COPY,
+            CLIENT_ERROR_SEND, "client_error", "Watcher", g_client.error)
     }
     separator()
     let terminal_style = ImGuiTerminalStyle(
@@ -3315,7 +3681,11 @@ def update() {
                 flags = ImGuiWindowFlags.None)) {
             draw_repositories_window()
         }
-        dock_window(SESSIONS_WIN, (text = "Sessions & Activity", closable = true,
+        let attention_count = pending_attention_count()
+        let sessions_title = (attention_count > 0
+            ? "Sessions & Activity  [! {attention_count}]###SessionsActivity"
+            : "Sessions & Activity###SessionsActivity")
+        dock_window(SESSIONS_WIN, (text = sessions_title, closable = true,
                 flags = ImGuiWindowFlags.None)) {
             draw_session_list()
         }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -564,6 +564,8 @@ class private WatcherRichClient : HvWebSocketClient {
     repositories : array<RepositorySnapshot>
     mailbox : array<WatcherMailboxMessage>
     mailbox_revision : int64
+    agent_mark_revision : int64 = -1l
+    agent_mark_files : table<string; bool>
     error : string
     last_heartbeat : int64
     last_list : int64
@@ -592,6 +594,8 @@ class private WatcherRichClient : HvWebSocketClient {
         connected = true
         connect_count++
         delete git_failure_revisions
+        delete agent_mark_files
+        agent_mark_revision = -1l
         git_failure_baseline_ready = false
         error = ""
         last_reconnect = ref_time_ticks()
@@ -753,6 +757,7 @@ class private WatcherRichClient : HvWebSocketClient {
                 delete mailbox
                 mailbox <- incoming.data
                 mailbox_revision = incoming.revision
+                agent_mark_revision = -1l
             } else {
                 error = "invalid mailbox message"
             }
@@ -999,6 +1004,31 @@ class private WatcherRichClient : HvWebSocketClient {
         send("\{\"op\":\"mailbox_state\",\"session_id\":" +
             "{sprint_json(selected_id, false)},\"message_id\":" +
             "{sprint_json(message_id, false)},\"status\":\"acknowledged\"\}")
+    }
+
+    def agent_mark_key(repository_id, worktree_path, file_path : string) : string {
+        return ("{length(repository_id)}:{repository_id}" +
+            "{length(worktree_path)}:{worktree_path}{file_path}")
+    }
+
+    def refresh_agent_marks() {
+        if (agent_mark_revision == mailbox_revision) return
+        delete agent_mark_files
+        for (message in mailbox) {
+            if (message.direction != "outbox") continue
+            for (target in message.focus.targets) {
+                agent_mark_files[agent_mark_key(message.focus.repository_id,
+                    message.focus.worktree_path, target.file_path)] = true
+            }
+        }
+        agent_mark_revision = mailbox_revision
+    }
+
+    def marks_file_for_agent(repository_id, worktree_path,
+                             file_path : string) : bool {
+        refresh_agent_marks()
+        return key_exists(agent_mark_files,
+            agent_mark_key(repository_id, worktree_path, file_path))
     }
 
     def send_input(text : string) {
@@ -1424,16 +1454,8 @@ def private git_group_scope(group : int) : string {
 
 def private agent_marks_file(repository_id, worktree_path,
                              file_path : string) : bool {
-    if (g_client == null) return false
-    for (message in g_client.mailbox) {
-        if (message.direction != "outbox"
-                || message.focus.repository_id != repository_id
-                || message.focus.worktree_path != worktree_path) continue
-        for (target in message.focus.targets) {
-            if (target.file_path == file_path) return true
-        }
-    }
-    return false
+    return (g_client != null
+        && g_client->marks_file_for_agent(repository_id, worktree_path, file_path))
 }
 
 def private focused_file_label(repository_id, worktree_path,
@@ -3722,6 +3744,7 @@ def shutdown() {
         delete g_client.repositories
         delete g_client.mailbox
         delete g_client.git_failure_revisions
+        delete g_client.agent_mark_files
         unsafe { delete g_client }
         g_client = null
     }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -206,6 +206,8 @@ struct private GitInspectorState {
     old_document : TextSourceDocument = TextSourceDocument()
     new_document : TextSourceDocument = TextSourceDocument()
     view_document : TextSourceDocument = TextSourceDocument()
+    new_line_starts : array<int>
+    view_line_starts : array<int>
     focus_document_valid : bool
     focus_start_byte : int = -1
     old_view : TextSourceViewState = TextSourceViewState()
@@ -405,6 +407,8 @@ def private release_inspector_content() {
     text_source_document_dispose(g_inspector.old_document)
     text_source_document_dispose(g_inspector.new_document)
     text_source_document_dispose(g_inspector.view_document)
+    delete g_inspector.new_line_starts
+    delete g_inspector.view_line_starts
     g_inspector.focus_document_valid = false
     g_inspector.focus_start_byte = -1
     markdown_view_dispose(g_inspector.markdown_view)
@@ -487,6 +491,10 @@ def private drain_inspector_prepare_events() {
             g_inspector.old_document <- event.old_document
             g_inspector.new_document <- event.new_document
             g_inspector.view_document <- event.view_document
+            append_line_starts(g_inspector.new_document.source,
+                g_inspector.new_line_starts)
+            append_line_starts(g_inspector.view_document.source,
+                g_inspector.view_line_starts)
             g_inspector.markdown_document <- event.markdown_document
             g_inspector.markdown_view <- event.markdown_view
             g_inspector.changed_source_ranges <- event.changed_source_ranges
@@ -3189,15 +3197,11 @@ def private append_line_starts(source : string;
 
 def private diff_byte_to_view_byte(diff_byte : int;
                                    end_bias : bool) : int {
-    var inscope diff_starts : array<int>
-    var inscope view_starts : array<int>
-    append_line_starts(g_inspector.new_document.source, diff_starts)
-    append_line_starts(g_inspector.view_document.source, view_starts)
     let clamped_byte = clamp(diff_byte, 0,
         length(g_inspector.new_document.source))
     var display_line = 0
-    for (index in range(length(diff_starts))) {
-        if (diff_starts[index] > clamped_byte) break
+    for (index in range(length(g_inspector.new_line_starts))) {
+        if (g_inspector.new_line_starts[index] > clamped_byte) break
         display_line = index
     }
     if (display_line < 0
@@ -3211,11 +3215,13 @@ def private diff_byte_to_view_byte(diff_byte : int;
             scan--
         }
     }
-    if (source_line <= 0 || source_line > length(view_starts)) return -1
-    let column = max(0, clamped_byte - diff_starts[display_line])
-    let line_start = view_starts[source_line - 1]
-    let line_end = (source_line < length(view_starts)
-        ? max(line_start, view_starts[source_line] - 1)
+    if (source_line <= 0
+            || source_line > length(g_inspector.view_line_starts)) return -1
+    let column = max(0,
+        clamped_byte - g_inspector.new_line_starts[display_line])
+    let line_start = g_inspector.view_line_starts[source_line - 1]
+    let line_end = (source_line < length(g_inspector.view_line_starts)
+        ? max(line_start, g_inspector.view_line_starts[source_line] - 1)
         : length(g_inspector.view_document.source))
     return min(line_end, line_start + column)
 }
@@ -3252,12 +3258,6 @@ def private draw_focus_target_overlay(target : WatcherFocusTarget const;
                                       state : TextSourceViewState const;
                                       document : TextSourceDocument const;
                                       diff_mapping : bool) {
-    var inscope display_starts : array<int>
-    var inscope view_starts : array<int>
-    if (diff_mapping) {
-        append_line_starts(document.source, display_starts)
-        append_line_starts(g_inspector.view_document.source, view_starts)
-    }
     let dim_color = GetColorU32(float4(0.015f, 0.018f, 0.024f, 0.48f))
     let focus_fill = GetColorU32(float4(1.0f, 0.72f, 0.18f, 0.13f))
     let focus_outline = GetColorU32(float4(1.0f, 0.76f, 0.24f, 0.92f))
@@ -3280,10 +3280,12 @@ def private draw_focus_target_overlay(target : WatcherFocusTarget const;
                     var mapped = !diff_mapping
                     if (diff_mapping && line_index < length(document.line_numbers)) {
                         let source_line = document.line_numbers[line_index]
-                        if (source_line > 0 && source_line <= length(view_starts)) {
-                            source_start = view_starts[source_line - 1]
-                            source_end = (source_line < length(view_starts)
-                                ? max(source_start, view_starts[source_line] - 1)
+                        if (source_line > 0
+                                && source_line <= length(g_inspector.view_line_starts)) {
+                            source_start = g_inspector.view_line_starts[source_line - 1]
+                            source_end = (source_line < length(g_inspector.view_line_starts)
+                                ? max(source_start,
+                                    g_inspector.view_line_starts[source_line] - 1)
                                 : length(g_inspector.view_document.source))
                             mapped = true
                         }
@@ -3321,19 +3323,24 @@ def private draw_focus_target_overlay(target : WatcherFocusTarget const;
                 var mapped = !diff_mapping
                 if (diff_mapping && cell.line_index >= 0
                         && cell.line_index < length(document.line_numbers)
-                        && cell.line_index < length(display_starts)) {
+                        && cell.line_index < length(g_inspector.new_line_starts)) {
                     let source_line = document.line_numbers[cell.line_index]
-                    if (source_line > 0 && source_line <= length(view_starts)) {
-                        let canonical_line_start = view_starts[source_line - 1]
-                        let canonical_line_end = (source_line < length(view_starts)
-                            ? max(canonical_line_start, view_starts[source_line] - 1)
+                    if (source_line > 0
+                            && source_line <= length(g_inspector.view_line_starts)) {
+                        let canonical_line_start = g_inspector.view_line_starts[source_line - 1]
+                        let canonical_line_end = (source_line
+                                < length(g_inspector.view_line_starts)
+                            ? max(canonical_line_start,
+                                g_inspector.view_line_starts[source_line] - 1)
                             : length(g_inspector.view_document.source))
                         source_start = min(canonical_line_end,
                             canonical_line_start + max(0,
-                                cell.source.start_byte - display_starts[cell.line_index]))
+                                cell.source.start_byte
+                                    - g_inspector.new_line_starts[cell.line_index]))
                         source_end = min(canonical_line_end,
                             canonical_line_start + max(0,
-                                cell.source.end_byte - display_starts[cell.line_index]))
+                                cell.source.end_byte
+                                    - g_inspector.new_line_starts[cell.line_index]))
                         mapped = true
                     }
                 }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -66,6 +66,19 @@ struct private WatcherRepositoriesMessage {
     data : array<RepositorySnapshot>
 }
 
+struct private WatcherMailboxMessageEnvelope {
+    @rename = "type" _type : string
+    session_id : string
+    revision : int64
+    data : array<WatcherMailboxMessage>
+}
+
+struct private WatcherMailboxPostedMessage {
+    @rename = "type" _type : string
+    message_id : string
+    revision : int64
+}
+
 struct private WatcherFileInspectionMessage {
     @rename = "type" _type : string
     request_id : int
@@ -141,6 +154,11 @@ struct private HerderGitShaArgs {
     sha : string
 }
 
+struct private HerderAttentionOpenArgs {
+    message_id : string
+    target_index : int
+}
+
 enum private GitInspectorMode {
     diff
     view
@@ -188,6 +206,10 @@ struct private GitInspectorState {
     old_document : TextSourceDocument = TextSourceDocument()
     new_document : TextSourceDocument = TextSourceDocument()
     view_document : TextSourceDocument = TextSourceDocument()
+    focus_new_document : TextSourceDocument = TextSourceDocument()
+    focus_view_document : TextSourceDocument = TextSourceDocument()
+    focus_document_valid : bool
+    focus_start_byte : int = -1
     old_view : TextSourceViewState = TextSourceViewState()
     new_view : TextSourceViewState = TextSourceViewState()
     view : TextSourceViewState = TextSourceViewState()
@@ -238,6 +260,13 @@ var private g_token : string
 var private g_selected_worktree_path : string
 var private g_selected_repository_id : string
 var private g_focus_terminal_pending = false
+var private g_active_focus_message = ""
+var private g_active_focus_target = -1
+var private g_focus_visible = true
+var private g_pending_focus_scroll = false
+var private g_focus_view_scroll_pending = false
+var private g_last_human_request = ""
+var private g_applied_focus_identity = ""
 var private g_requested_history_commit : string
 var private g_pending_clipboard_sha : string
 var private g_last_copied_sha : string
@@ -251,6 +280,8 @@ var private g_inspector = GitInspectorState()
 var private g_prepare_worker = InspectorPrepareWorker()
 var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
+var private ATTENTION_MESSAGE_ROW : table<int; ToggleState>
+var private ATTENTION_TARGET_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
 var private GIT_COMMIT_TITLE_TEXT : table<int; NarrativeState>
@@ -351,6 +382,10 @@ def private release_inspector_content() {
     text_source_document_dispose(g_inspector.old_document)
     text_source_document_dispose(g_inspector.new_document)
     text_source_document_dispose(g_inspector.view_document)
+    text_source_document_dispose(g_inspector.focus_new_document)
+    text_source_document_dispose(g_inspector.focus_view_document)
+    g_inspector.focus_document_valid = false
+    g_inspector.focus_start_byte = -1
     markdown_view_dispose(g_inspector.markdown_view)
     rich_document_dispose(g_inspector.markdown_document)
     delete g_inspector.changed_source_ranges
@@ -505,6 +540,8 @@ class private WatcherRichClient : HvWebSocketClient {
     attached_id : string
     sessions : array<WatcherSessionInfo>
     repositories : array<RepositorySnapshot>
+    mailbox : array<WatcherMailboxMessage>
+    mailbox_revision : int64
     error : string
     last_heartbeat : int64
     last_list : int64
@@ -687,6 +724,20 @@ class private WatcherRichClient : HvWebSocketClient {
                 git_failure_baseline_ready = true
             } else {
                 error = "invalid repository snapshot message"
+            }
+        } elif (envelope._type == "mailbox") {
+            var incoming = WatcherMailboxMessageEnvelope()
+            if (sscan_json(body, incoming)) {
+                delete mailbox
+                mailbox <- incoming.data
+                mailbox_revision = incoming.revision
+            } else {
+                error = "invalid mailbox message"
+            }
+        } elif (envelope._type == "mailbox_posted") {
+            var incoming : WatcherMailboxPostedMessage
+            if (sscan_json(body, incoming)) {
+                g_last_human_request = incoming.message_id
             }
         } elif (envelope._type == "file_inspection") {
             var incoming : WatcherFileInspectionMessage
@@ -878,6 +929,25 @@ class private WatcherRichClient : HvWebSocketClient {
             "\"diff_context\":{sprint_json(diff_context, false)}\}")
     }
 
+    def post_selection_request(start_byte, end_byte : int) {
+        if (!connected || empty(selected_id) || start_byte < 0
+                || end_byte <= start_byte
+                || empty(g_inspector.installed_file_path)) return
+        let payload = ("\{\"op\":\"mailbox_post\",\"session_id\":" +
+            "{sprint_json(selected_id, false)},\"direction\":\"inbox\"," +
+            "\"sender\":\"human:local\",\"kind\":\"focus_set\"," +
+            "\"subject\":\"Look at that\",\"notify\":true,\"focus\":\{" +
+            "\"repository_id\":{sprint_json(g_inspector.installed_repository_id, false)}," +
+            "\"worktree_path\":{sprint_json(g_inspector.installed_worktree_path, false)}," +
+            "\"comparison\":{sprint_json(g_inspector.installed_comparison, false)}," +
+            "\"revision\":{sprint_json(g_inspector.installed_git_revision, false)}," +
+            "\"summary\":\"Human-selected code\",\"targets\":[\{" +
+            "\"file_path\":{sprint_json(g_inspector.installed_file_path, false)}," +
+            "\"whole_file\":false,\"ranges\":[\{\"start_byte\":{start_byte}," +
+            "\"end_byte\":{end_byte},\"caption\":\"Look at that\"\}]\}]\}\}")
+        send(payload)
+    }
+
     def send_input(text : string) {
         if (!controls || empty(text)) return
         send("\{\"op\":\"input\",\"text\":{sprint_json(text, false)}\}")
@@ -959,7 +1029,7 @@ def private draw_session_list() {
         g_client->terminate_selected()
     }
     separator()
-    child(SESSIONS_CHILD, (text = "sessions", size = float2(0.0f, -150.0f),
+    child(SESSIONS_CHILD, (text = "sessions", size = float2(0.0f, -260.0f),
             child_flags = ImGuiChildFlags.Borders, window_flags = ImGuiWindowFlags.None)) {
         var visible_sessions = 0
         if (g_client != null) {
@@ -983,6 +1053,59 @@ def private draw_session_list() {
         }
     }
     text_disabled("Exited sessions are retained and hidden by default.")
+    separator()
+    var attention_count = 0
+    if (g_client != null) {
+        for (message in g_client.mailbox) {
+            if (message.direction == "outbox") attention_count++
+        }
+    }
+    text("Attention ({attention_count})")
+    text_disabled("Agent notes never navigate until you click them.")
+    child(ATTENTION_CHILD, (text = "attention", size = float2(0.0f, 0.0f),
+            child_flags = ImGuiChildFlags.Borders, window_flags = ImGuiWindowFlags.None)) {
+        if (g_client != null) {
+            var target_row = 0
+            for (message_index in range(length(g_client.mailbox))) {
+                let message & = unsafe(g_client.mailbox[message_index])
+                if (message.direction != "outbox") continue
+                let selected_message = message.id == g_active_focus_message
+                ATTENTION_MESSAGE_ROW[message_index].value = selected_message
+                if (selectable(ATTENTION_MESSAGE_ROW[message_index],
+                        (text = "{message.subject}##{message.id}"))
+                        && !empty(message.focus.targets)) {
+                    g_active_focus_message = message.id
+                    g_active_focus_target = 0
+                    g_focus_visible = true
+                    g_pending_focus_scroll = true
+                    let target & = unsafe(message.focus.targets[0])
+                    g_client->inspect_file(message.focus.repository_id,
+                        message.focus.worktree_path, target.file_path,
+                        message.focus.comparison, "compact", message.focus.revision)
+                    FILE_INSPECTOR_WIN.open = true
+                    FILE_INSPECTOR_WIN.pending_raise = true
+                }
+                for (target_index in range(length(message.focus.targets))) {
+                    let target & = unsafe(message.focus.targets[target_index])
+                    ATTENTION_TARGET_ROW[target_row].value = (selected_message
+                        && target_index == g_active_focus_target)
+                    if (selectable(ATTENTION_TARGET_ROW[target_row],
+                            (text = "  {target.file_path}##{message.id}:{target_index}"))) {
+                        g_active_focus_message = message.id
+                        g_active_focus_target = target_index
+                        g_focus_visible = true
+                        g_pending_focus_scroll = true
+                        g_client->inspect_file(message.focus.repository_id,
+                            message.focus.worktree_path, target.file_path,
+                            message.focus.comparison, "compact", message.focus.revision)
+                        FILE_INSPECTOR_WIN.open = true
+                        FILE_INSPECTOR_WIN.pending_raise = true
+                    }
+                    target_row++
+                }
+            }
+        }
+    }
 }
 
 def private draw_terminal_footer() {
@@ -1186,6 +1309,26 @@ def private git_group_scope(group : int) : string {
     return group == 1 ? "staged" : "working"
 }
 
+def private agent_marks_file(repository_id, worktree_path,
+                             file_path : string) : bool {
+    if (g_client == null) return false
+    for (message in g_client.mailbox) {
+        if (message.direction != "outbox"
+                || message.focus.repository_id != repository_id
+                || message.focus.worktree_path != worktree_path) continue
+        for (target in message.focus.targets) {
+            if (target.file_path == file_path) return true
+        }
+    }
+    return false
+}
+
+def private focused_file_label(repository_id, worktree_path,
+                               file_path : string) : string {
+    return (agent_marks_file(repository_id, worktree_path, file_path)
+        ? "[AGENT] {file_path}" : file_path)
+}
+
 def private draw_git_file_group(repository : RepositorySnapshot const;
                                 worktree : WorktreeState const;
                                 group : int; var file_row : int&) : int {
@@ -1206,8 +1349,10 @@ def private draw_git_file_group(repository : RepositorySnapshot const;
             && g_inspector.file_path == file.path
             && g_inspector.comparison == comparison)
         let old_label = !empty(file.old_path) ? "  (from {file.old_path})" : ""
+        let display_path = focused_file_label(
+            repository.record.id, worktree.path, file.path)
         if (selectable(GIT_FILE_ROW[file_row],
-                (text = "{file.code}  {file.path}{old_label}##{comparison}:{file.path}"))) {
+                (text = "{file.code}  {display_path}{old_label}##{comparison}:{file.path}"))) {
             if (g_client != null) {
                 g_client->inspect_file(repository.record.id, worktree.path,
                     file.path, comparison)
@@ -1375,7 +1520,9 @@ def private draw_pr_included_files(repository : RepositorySnapshot const;
                     (text = "{file.path}  {stats}##pr:{file.path}"))
             }
         }
-        decorate_git_file_row("pr:{file.path}", file.path, file.added_lines,
+        let display_path = focused_file_label(
+            repository.record.id, worktree.path, file.path)
+        decorate_git_file_row("pr:{file.path}", display_path, file.added_lines,
             file.deleted_lines, file.stats_known, file.binary, false,
             staged && !busy ? "minus" : "",
             "Remove from the staged PR result", action_clicked)
@@ -1421,7 +1568,9 @@ def private draw_pr_not_included_files(repository : RepositorySnapshot const;
                     (text = "{file.path}  {stats}##working:{file.path}"))
             }
         }
-        decorate_git_file_row("working:{file.path}", file.path, file.added_lines,
+        let display_path = focused_file_label(
+            repository.record.id, worktree.path, file.path)
+        decorate_git_file_row("working:{file.path}", display_path, file.added_lines,
             file.deleted_lines, file.stats_known, file.binary, true,
             busy ? "" : "check", "Add to the staged PR result",
             action_clicked)
@@ -2249,9 +2398,31 @@ def private draw_side_by_side_diff() {
         }
         text_disabled("AFTER")
         separator()
-        var style = source_view_style(true)
-        let _ = text_source_view("git diff after", g_inspector.new_document,
-            g_inspector.new_view, style)
+        var result = TextSourceViewResult()
+        if (g_inspector.focus_document_valid) {
+            var style = focus_source_view_style(true)
+            result <- text_source_view("git diff after",
+                g_inspector.focus_new_document, g_inspector.new_view, style)
+        } else {
+            var style = source_view_style(true)
+            result <- text_source_view("git diff after", g_inspector.new_document,
+                g_inspector.new_view, style)
+        }
+        if (result.selection_context_requested) {
+            open_popup(DIFF_SELECTION_POPUP)
+        }
+        popup(DIFF_SELECTION_POPUP,
+                (text = "DiffSelection", flags = ImGuiWindowFlags.None)) {
+            let selection = text_source_view_selection(g_inspector.new_view)
+            if (menu_item(DIFF_LOOK_AT_THAT,
+                    (text = "Look at that", enabled = g_client != null
+                        && g_client.connected && !empty(g_client.selected_id)
+                        && selection.end_byte > selection.start_byte))) {
+                g_client->post_selection_request(
+                    selection.start_byte, selection.end_byte)
+                close_current_popup(DIFF_SELECTION_POPUP)
+            }
+        }
     }
     g_inspector.diff_scroll_jump_pending = false
 }
@@ -2264,7 +2435,8 @@ def private draw_file_view() {
     child(FILE_VIEW_PANE, (text = "file view", size = float2(0.0f, 0.0f),
             child_flags = ImGuiChildFlags.None,
             window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
-        if (g_inspector.resolved_language == "markdown") {
+        if (g_inspector.resolved_language == "markdown"
+                && !g_inspector.focus_document_valid) {
             var style = MarkdownViewStyle(
                 fonts = g_fonts,
                 typography = MarkdownTypography(
@@ -2277,9 +2449,35 @@ def private draw_file_view() {
                 g_inspector.markdown_gutter_segments,
                 max(1.0f, 2.0f * float(g_zoom_percent) / 100.0f))
         } else {
-            var style = source_view_style(false)
-            let _ = text_source_view("git file view", g_inspector.view_document,
-                g_inspector.view, style)
+            if (g_focus_view_scroll_pending) {
+                SetScrollY(max(0.0f, g_inspector.diff_scroll_y))
+                g_focus_view_scroll_pending = false
+            }
+            var result = TextSourceViewResult()
+            if (g_inspector.focus_document_valid) {
+                var style = focus_source_view_style(false)
+                result <- text_source_view("git file view",
+                    g_inspector.focus_view_document, g_inspector.view, style)
+            } else {
+                var style = source_view_style(false)
+                result <- text_source_view("git file view",
+                    g_inspector.view_document, g_inspector.view, style)
+            }
+            if (result.selection_context_requested) {
+                open_popup(INSPECTOR_SELECTION_POPUP)
+            }
+            popup(INSPECTOR_SELECTION_POPUP,
+                    (text = "InspectorSelection", flags = ImGuiWindowFlags.None)) {
+                let selection = text_source_view_selection(g_inspector.view)
+                if (menu_item(INSPECTOR_LOOK_AT_THAT,
+                        (text = "Look at that", enabled = g_client != null
+                            && g_client.connected && !empty(g_client.selected_id)
+                            && selection.end_byte > selection.start_byte))) {
+                    g_client->post_selection_request(
+                        selection.start_byte, selection.end_byte)
+                    close_current_popup(INSPECTOR_SELECTION_POPUP)
+                }
+            }
         }
     }
 }
@@ -2658,6 +2856,10 @@ def herder_file_inspector_state(_input : JsonValue?) : JsonValue? {
         old_line_number_count = length(g_inspector.old_document.line_numbers),
         new_line_number_count = length(g_inspector.new_document.line_numbers),
         view_line_mark_count = length(g_inspector.view_document.line_marks),
+        focus_document_valid = g_inspector.focus_document_valid,
+        focus_new_marker_count = g_inspector.focus_new_document.marker_count,
+        focus_view_marker_count = g_inspector.focus_view_document.marker_count,
+        focus_start_byte = g_inspector.focus_start_byte,
         changed_source_range_count = length(g_inspector.changed_source_ranges),
         old_syntax_span_count = length(g_inspector.old_document.spans),
         new_syntax_span_count = length(g_inspector.new_document.spans),
@@ -2784,6 +2986,187 @@ def private file_inspector_status() : GitWindowStatus {
     return GitWindowStatus(text = "Select a changed file")
 }
 
+def private focus_source_view_style(diff_background : bool = false) : TextSourceViewStyle {
+    var style = source_view_style(diff_background)
+    style.text_color = float4(0.30f, 0.31f, 0.33f, 1.0f)
+    style.marker_color = float4(1.0f, 0.82f, 0.38f, 1.0f)
+    return style
+}
+
+[live_command(description = "Inspect persistent, non-modal agent Attention and active Focus Set state.")]
+def herder_attention_state(_input : JsonValue?) : JsonValue? {
+    var messages : array<JsonValue?>
+    if (g_client != null) {
+        for (message in g_client.mailbox) {
+            if (message.direction != "outbox") continue
+            var targets : array<JsonValue?>
+            for (target in message.focus.targets) {
+                targets |> push(JV((file_path = target.file_path,
+                    whole_file = target.whole_file,
+                    range_count = length(target.ranges))))
+            }
+            messages |> push(JV((id = message.id, sender = message.sender,
+                subject = message.subject, status = message.status,
+                targets = targets)))
+        }
+    }
+    return JV((ok = g_client != null,
+        session_id = g_client != null ? g_client.selected_id : "",
+        mailbox_revision = g_client != null ? g_client.mailbox_revision : 0l,
+        active_message_id = g_active_focus_message,
+        active_target_index = g_active_focus_target,
+        focus_visible = g_focus_visible,
+        last_human_request_id = g_last_human_request,
+        messages = messages))
+}
+
+[live_command(description = "Open one agent Focus Set target at the user's chosen time. Args: message_id, target_index.")]
+def herder_attention_open(input : JsonValue?) : JsonValue? {
+    if (g_client == null || !g_client.connected) {
+        return JV((ok = false, error = "watcher is not connected"))
+    }
+    let args = from_JV(input, type<HerderAttentionOpenArgs>)
+    for (message in g_client.mailbox) {
+        if (message.id != args.message_id) continue
+        if (args.target_index < 0
+                || args.target_index >= length(message.focus.targets)) {
+            return JV((ok = false, error = "target_index is out of range"))
+        }
+        g_active_focus_message = message.id
+        g_active_focus_target = args.target_index
+        g_focus_visible = true
+        g_pending_focus_scroll = true
+        g_applied_focus_identity = ""
+        let target & = unsafe(message.focus.targets[args.target_index])
+        g_client->inspect_file(message.focus.repository_id,
+            message.focus.worktree_path, target.file_path,
+            message.focus.comparison, "compact", message.focus.revision)
+        FILE_INSPECTOR_WIN.open = true
+        FILE_INSPECTOR_WIN.pending_raise = true
+        return JV((ok = true, message_id = message.id,
+            target_index = args.target_index, file_path = target.file_path))
+    }
+    return JV((ok = false, error = "unknown attention message"))
+}
+
+def private push_focus_span(var document : TextSourceDocument;
+                            start_byte, end_byte : int; marker : bool) {
+    if (end_byte <= start_byte) return
+    var styles : TextSourceStyles
+    styles.marker = marker
+    styles.bold = marker
+    document.spans |> push(TextSourceSpan(
+        source = TextSourceRange(start_byte = start_byte, end_byte = end_byte),
+        styles = styles))
+    if (marker) {
+        document.marker_count++
+    }
+}
+
+def private make_focus_document(source : TextSourceDocument const;
+                                target : WatcherFocusTarget const;
+                                revision_bias : int) : TextSourceDocument {
+    var document = TextSourceDocument(
+        source = clone_string(source.source),
+        revision = source.revision + revision_bias)
+    document.line_marks := source.line_marks
+    document.line_numbers := source.line_numbers
+    let source_length = length(source.source)
+    if (target.whole_file || empty(target.ranges)) {
+        push_focus_span(document, 0, source_length, true)
+        return <- document
+    }
+    var cursor = 0
+    while (cursor < source_length) {
+        var best_start = source_length
+        var best_end = -1
+        for (focus_range in target.ranges) {
+            let range_start = clamp(focus_range.start_byte, 0, source_length)
+            let range_end = clamp(focus_range.end_byte, 0, source_length)
+            if (range_end <= cursor || range_end <= range_start) continue
+            if (range_start < best_start) {
+                best_start = range_start
+                best_end = range_end
+            } elif (range_start == best_start) {
+                best_end = max(best_end, range_end)
+            }
+        }
+        if (best_end < 0) {
+            push_focus_span(document, cursor, source_length, false)
+            break
+        }
+        push_focus_span(document, cursor, max(cursor, best_start), false)
+        let marked_start = max(cursor, best_start)
+        push_focus_span(document, marked_start, best_end, true)
+        cursor = best_end
+    }
+    return <- document
+}
+
+def private apply_active_focus() {
+    if (g_client == null) return
+    let identity = ("{g_active_focus_message}:{g_active_focus_target}:" +
+        "{g_focus_visible}:{g_inspector.revision}:{g_inspector.installed_file_path}")
+    if (identity == g_applied_focus_identity && !g_pending_focus_scroll) return
+    text_source_document_dispose(g_inspector.focus_view_document)
+    text_source_document_dispose(g_inspector.focus_new_document)
+    g_inspector.focus_document_valid = false
+    g_inspector.focus_start_byte = -1
+    if (g_focus_visible && !empty(g_active_focus_message)) {
+        for (message in g_client.mailbox) {
+            if (message.id != g_active_focus_message
+                    || g_active_focus_target < 0
+                    || g_active_focus_target >= length(message.focus.targets)) continue
+            let target & = unsafe(message.focus.targets[g_active_focus_target])
+            if (target.file_path != g_inspector.installed_file_path) continue
+            g_inspector.focus_view_document <- make_focus_document(
+                g_inspector.view_document, target, 1000001)
+            g_inspector.focus_new_document <- make_focus_document(
+                g_inspector.new_document, target, 1000002)
+            g_inspector.focus_document_valid = true
+            if (!empty(target.ranges)) {
+                g_inspector.focus_start_byte = target.ranges[0].start_byte
+            } else {
+                g_inspector.focus_start_byte = 0
+            }
+            if (g_pending_focus_scroll) {
+                var line_index = 0
+                peek_data(g_inspector.view_document.source) $(bytes) {
+                    for (index in range(min(length(bytes),
+                            max(0, g_inspector.focus_start_byte)))) {
+                        if (int(bytes[index]) == '\n') {
+                            line_index++
+                        }
+                    }
+                }
+                g_inspector.diff_scroll_y = (float(line_index)
+                    * GetTextLineHeight())
+                g_inspector.diff_scroll_jump_pending = true
+                g_focus_view_scroll_pending = true
+            }
+            break
+        }
+    }
+    g_pending_focus_scroll = false
+    g_applied_focus_identity = identity
+}
+
+def private navigate_active_focus(delta : int) {
+    if (g_client == null || empty(g_active_focus_message)) return
+    for (message in g_client.mailbox) {
+        if (message.id != g_active_focus_message || empty(message.focus.targets)) continue
+        g_active_focus_target = (g_active_focus_target + delta
+            + length(message.focus.targets)) % length(message.focus.targets)
+        let target & = unsafe(message.focus.targets[g_active_focus_target])
+        g_pending_focus_scroll = true
+        g_applied_focus_identity = ""
+        g_client->inspect_file(message.focus.repository_id,
+            message.focus.worktree_path, target.file_path,
+            message.focus.comparison, "compact", message.focus.revision)
+        return
+    }
+}
+
 def private draw_file_inspector_content() {
     let io & = unsafe(GetIO())
     if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
@@ -2796,10 +3179,27 @@ def private draw_file_inspector_content() {
         }
         return
     }
+    apply_active_focus()
     text(INSPECTOR_PATH, (text = g_inspector.installed_file_path))
     same_line()
     text_disabled(INSPECTOR_SCOPE,
         (text = to_upper(g_inspector.installed_comparison)))
+    if (!empty(g_active_focus_message)) {
+        same_line()
+        if (small_button(FOCUS_PREVIOUS, (text = "Previous"))) {
+            navigate_active_focus(-1)
+        }
+        same_line()
+        if (small_button(FOCUS_NEXT, (text = "Next"))) {
+            navigate_active_focus(1)
+        }
+        same_line()
+        if (small_button(FOCUS_TOGGLE,
+                (text = g_focus_visible ? "Hide focus" : "Show focus"))) {
+            g_focus_visible = !g_focus_visible
+            g_applied_focus_identity = ""
+        }
+    }
     tab_bar(INSPECTOR_MODE_TABS,
             (text = "InspectorModes", flags = ImGuiTabBarFlags.None)) {
         tab_item(INSPECTOR_DIFF_TAB, (text = "Diff", closable = false,
@@ -2951,6 +3351,7 @@ def shutdown() {
         g_client->cleanup()
         delete g_client.sessions
         delete g_client.repositories
+        delete g_client.mailbox
         delete g_client.git_failure_revisions
         unsafe { delete g_client }
         g_client = null

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -3111,14 +3111,13 @@ def private file_inspector_status() : GitWindowStatus {
 def herder_attention_state(_input : JsonValue?) : JsonValue? {
     var messages : array<JsonValue?>
     if (g_client != null) {
+        messages |> reserve(length(g_client.mailbox))
         for (message in g_client.mailbox) {
             if (message.direction != "outbox") continue
-            var targets : array<JsonValue?>
-            for (target in message.focus.targets) {
-                targets |> push(JV((file_path = target.file_path,
+            var targets <- [for (target in message.focus.targets);
+                JV((file_path = target.file_path,
                     whole_file = target.whole_file,
-                    range_count = length(target.ranges))))
-            }
+                    range_count = length(target.ranges)))]
             messages |> push(JV((id = message.id, sender = message.sender,
                 subject = message.subject, status = message.status,
                 targets = targets)))
@@ -3278,8 +3277,8 @@ def private draw_focus_target_overlay(target : WatcherFocusTarget const;
                         dl |> add_rect_filled(p0, p1, dim_color)
                     } else {
                         dl |> add_rect_filled(p0, p1, focus_fill)
-                        let marker_right = state.screen_origin.x
-                            - max(2.0f, GetStyle().ItemSpacing.x * 0.35f)
+                        let marker_right = (state.screen_origin.x
+                            - max(2.0f, GetStyle().ItemSpacing.x * 0.35f))
                         dl |> add_rect_filled(
                             float2(marker_right - 3.0f, p0.y),
                             float2(marker_right, p1.y), focus_outline)
@@ -3325,8 +3324,8 @@ def private draw_focus_target_overlay(target : WatcherFocusTarget const;
                 } else {
                     dl |> add_rect_filled(p0, p1, focus_fill)
                     if (cell.line_index != last_focused_line) {
-                        let marker_right = state.screen_origin.x
-                            - max(2.0f, GetStyle().ItemSpacing.x * 0.35f)
+                        let marker_right = (state.screen_origin.x
+                            - max(2.0f, GetStyle().ItemSpacing.x * 0.35f))
                         dl |> add_rect_filled(
                             float2(marker_right - 3.0f, p0.y),
                             float2(marker_right, p1.y), focus_outline)
@@ -3397,8 +3396,8 @@ def private apply_active_focus() {
             if (g_pending_focus_scroll) {
                 var line_index = 0
                 peek_data(g_inspector.view_document.source) $(bytes) {
-                    for (index in range(min(length(bytes),
-                            max(0, g_inspector.focus_start_byte)))) {
+                    for (index in range(clamp(g_inspector.focus_start_byte,
+                            0, length(bytes)))) {
                         if (int(bytes[index]) == '\n') {
                             line_index++
                         }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -434,7 +434,7 @@ def private drain_inspector_prepare_events() {
             g_inspector.markdown_view <- event.markdown_view
             g_inspector.changed_source_ranges <- event.changed_source_ranges
             g_inspector.view_source = clone_string(event.view_source)
-            g_inspector.view_prepared = !g_inspector.parsed.binary
+            g_inspector.view_prepared = event.view_text_ready
             g_inspector.installed_repository_id = g_inspector.repository_id
             g_inspector.installed_worktree_path = g_inspector.worktree_path
             g_inspector.installed_file_path = g_inspector.file_path
@@ -2257,7 +2257,7 @@ def private draw_side_by_side_diff() {
 }
 
 def private draw_file_view() {
-    if (g_inspector.parsed.binary) {
+    if (!g_inspector.view_prepared) {
         draw_binary_preview()
         return
     }

--- a/utils/dasHerd/watcher/tests/test_inspection_worker.das
+++ b/utils/dasHerd/watcher/tests/test_inspection_worker.das
@@ -257,4 +257,61 @@ def test_inspection_prepare_worker(t : T?) {
         tt |> equal(inspector_prepare_worker_shutdown(worker), true)
         destroy_job_que()
     }
+    t |> run("no-hunk patch still prepares the selected full View") <| @(tt : T?) {
+        let source = "int generated_value = 42;\n"
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 17,
+            "warning: diff emitted no file patch\n", source,
+            "cpp", "", 0, true), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> equal(event.view_text_ready, true)
+                    tt |> equal(event.view_source, source)
+                    tt |> equal(event.view_document.source, source)
+                    tt |> equal(length(event.parsed.hunks), 0)
+                    tt |> success(length(event.view_document.spans) > 1,
+                        "zero-hunk View is syntax highlighted")
+                }
+            }
+        }
+        tt |> equal(completed, true)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
+    t |> run("Git-binary UTF-8 bytes prepare as source View") <| @(tt : T?) {
+        let source = "// generated source\nint answer = 42;\n"
+        let encoded = base64_encode(source)
+        create_job_que()
+        var worker = InspectorPrepareWorker()
+        tt |> equal(inspector_prepare_worker_start(worker), true)
+        tt |> equal(inspector_prepare_worker_queue(worker, 18,
+            "diff --git a/generated.cpp b/generated.cpp\nBinary files a/generated.cpp and b/generated.cpp differ\n",
+            "", "cpp", encoded, length(source), true), true)
+        var completed = false
+        let wait_started = ref_time_ticks()
+        while (!completed && int64(get_time_usec(wait_started)) < 5000000l) {
+            inspector_prepare_worker_try_event(worker) $(event : InspectorPrepareEvent const) {
+                if (event.kind == InspectorPrepareEventKind.completed) {
+                    completed = true
+                    tt |> equal(event.parsed.binary, true)
+                    tt |> equal(event.view_text_ready, true)
+                    tt |> equal(event.view_source, source)
+                    tt |> equal(event.view_document.source, source)
+                    tt |> equal(event.preview_error, "")
+                    tt |> equal(empty(event.preview_pixels), true)
+                    tt |> success(length(event.view_document.spans) > 1,
+                        "Git-binary source is syntax highlighted")
+                }
+            }
+        }
+        tt |> equal(completed, true)
+        tt |> equal(inspector_prepare_worker_shutdown(worker), true)
+        destroy_job_que()
+    }
 }

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -390,6 +390,13 @@ def test_repository_text_read_contract(t : T?) {
         t |> equal(repository_working_preview_path(
             root, "bytes.bin", preview_path), "")
         t |> equal(preview_path, bytes_path)
+        let unicode_name = "unicode-Привет.txt"
+        let unicode_path = path_join(root, unicode_name)
+        t |> success(fwrite(unicode_path, "hello"),
+            "UTF-8 path fixture is written")
+        t |> equal(repository_working_preview_path(
+            root, unicode_name, preview_path), "")
+        t |> equal(preview_path, unicode_path)
         t |> equal(repository_read_text_file(bytes_path, 2, text),
             "file exceeds the raw-byte View limit")
         t |> equal(text, "", "oversized mapped text is never materialized")

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -77,6 +77,15 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(argv[10], "--unified=3")
         t |> equal(argv[length(argv) - 1], "staged.das")
 
+        let clean_file = GitFileState(code = "  ", path = "clean.das")
+        let clean_error = repository_build_file_diff_argv(
+            "D:/Work/tree", clean_file, "working", argv,
+            expected_exit_code)
+        t |> equal(clean_error, "",
+            "working inspection permits files with an empty diff")
+        t |> equal(expected_exit_code, 0l)
+        t |> equal(argv[length(argv) - 1], "clean.das")
+
         let full_error = repository_build_file_diff_argv(
             "D:/Work/tree", staged_file, "staged", argv,
             expected_exit_code, "full")

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -136,6 +136,14 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(fexist(path_join(path_join(path_join(root, "sessions"), quick.session_id), "output.raw")),
             "raw output log exists")
 
+        var senderless_request = WatcherMailboxPostRequest()
+        t |> success(sscan_json("\{\"session_id\":{sprint_json(quick.session_id, false)}," +
+                "\"direction\":\"inbox\",\"subject\":\"No sender\"\}",
+                senderless_request),
+            "mailbox JSON accepts an omitted transport sender")
+        t |> equal(senderless_request.sender, "",
+            "omitted transport sender defaults to empty before server stamping")
+
         var focus_target = WatcherFocusTarget(
             file_path = "unicode-Привет.txt")
         focus_target.ranges |> push(WatcherFocusRange(
@@ -270,6 +278,13 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(find(delivered_json, "\"notified\":true") >= 0
                 && find(delivered_json, "\"notification_error\":\"\"") >= 0,
             "submitting the partial line atomically flushes its queued notification")
+        t |> equal(watcher_input(controlled.session_id, "partial", 12), "")
+        t |> equal(watcher_notify(controlled.session_id, "plain nudge\r"), "queued")
+        t |> equal(watcher_input(controlled.session_id, "\r", 12), "")
+        let controlled_events = fread(path_join(path_join(path_join(root, "sessions"),
+            controlled.session_id), "events.jsonl"))
+        t |> success(find(controlled_events, "\"detail\":\"id=; queued=true\"") < 0,
+            "a queued non-mailbox nudge does not emit an empty mailbox event")
         t |> equal(watcher_terminate(controlled.session_id, "test_complete"), "")
         t |> success(wait_for(controlled.session_id, "exited", 4000l), "terminated command exits and drains")
         watcher_shutdown(true)

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -294,6 +294,11 @@ def test_watcher_process_lifecycle(t : T?) {
             controlled.session_id), "events.jsonl"))
         t |> success(find(controlled_events, "delivery=deferred") >= 0,
             "a deferred mailbox nudge records its eventual delivery")
+        t |> success(find(controlled_events, "terminal_notification_queued") >= 0,
+            "a deferred non-mailbox nudge uses a terminal-specific queue event")
+        t |> success(find(controlled_events,
+                "\"event\":\"mailbox_notification_queued\",\"detail\":\"id=;") < 0,
+            "a deferred non-mailbox nudge does not emit an empty mailbox queue event")
         t |> success(find(controlled_events, "\"detail\":\"id=; delivery=deferred\"") < 0,
             "a deferred non-mailbox nudge does not emit an empty mailbox event")
         t |> equal(watcher_terminate(controlled.session_id, "test_complete"), "")

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -136,6 +136,49 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(fexist(path_join(path_join(path_join(root, "sessions"), quick.session_id), "output.raw")),
             "raw output log exists")
 
+        var focus_target = WatcherFocusTarget(
+            file_path = "unicode-Привет.txt")
+        focus_target.ranges |> push(WatcherFocusRange(
+            start_byte = 2, end_byte = 9, caption = "important"))
+        var mailbox_request = WatcherMailboxPostRequest(
+            session_id = quick.session_id, direction = "outbox",
+            sender = "agent_session:{quick.session_id}", kind = "focus_set",
+            subject = "Ready for PR")
+        mailbox_request.focus.repository_id = "repo"
+        mailbox_request.focus.worktree_path = root
+        mailbox_request.focus.targets |> emplace(focus_target)
+        let posted = watcher_mailbox_post(mailbox_request)
+        t |> success(posted.ok, posted.error)
+        t |> success(starts_with(posted.message_id, "hf_"),
+            "mailbox messages receive stable ids")
+        let outbox = watcher_mailbox_json(quick.session_id, "outbox")
+        t |> success(find(outbox, "unicode-Привет.txt") >= 0
+                && find(outbox, "Ready for PR") >= 0
+                && find(outbox, "agent_session:{quick.session_id}") >= 0,
+            "focus set and server-assigned provenance survive JSON serialization")
+        let notified = watcher_mailbox_set_notification(
+            quick.session_id, posted.message_id)
+        t |> success(notified.ok, notified.error)
+        let fetched = watcher_mailbox_mark_fetched(
+            quick.session_id, posted.message_id)
+        t |> success(fetched.ok, fetched.error)
+        let acknowledged = watcher_mailbox_set_state(WatcherMailboxStateRequest(
+            session_id = quick.session_id, message_id = posted.message_id,
+            status = "acknowledged"))
+        t |> success(acknowledged.ok, acknowledged.error)
+        t |> success(find(watcher_mailbox_json(quick.session_id, "", posted.message_id),
+            "\"status\":\"acknowledged\"") >= 0
+                && find(watcher_mailbox_json(quick.session_id, "", posted.message_id),
+                    "\"notified\":true") >= 0
+                && find(watcher_mailbox_json(quick.session_id, "", posted.message_id),
+                    "\"fetched\":true") >= 0,
+            "notification, fetch, and acknowledgement are observable")
+        let mailbox_log = path_join(path_join(path_join(root, "sessions"),
+            quick.session_id), "mailbox.jsonl")
+        t |> success(fexist(mailbox_log)
+                && find(fread(mailbox_log), "acknowledged") >= 0,
+            "mailbox create and state records are durable JSONL")
+
         let spaced_dir = path_join(root, "argv space")
         var mkdir_error : string
         t |> success(mkdir_rec(spaced_dir, mkdir_error), mkdir_error)
@@ -202,6 +245,25 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(!watcher_claim_controller(controlled.session_id, 12), "second controller is rejected")
         watcher_release_controller(controlled.session_id, 11, "test_detach")
         t |> success(watcher_claim_controller(controlled.session_id, 12), "released lease can be reclaimed")
+        let queued_message = watcher_mailbox_post(WatcherMailboxPostRequest(
+            session_id = controlled.session_id, direction = "inbox",
+            sender = "untrusted-payload-sender", subject = "Look at that"))
+        t |> success(queued_message.ok, queued_message.error)
+        t |> equal(watcher_input(controlled.session_id, "partial", 12), "")
+        t |> equal(watcher_notify(controlled.session_id, "nudge\r",
+            queued_message.message_id), "queued",
+            "notification waits behind a partial terminal input line")
+        let queued_json = watcher_mailbox_json(
+            controlled.session_id, "inbox", queued_message.message_id)
+        t |> success(find(queued_json, "\"sender\":\"human:local\"") >= 0
+                && find(queued_json, "\"notification_error\":\"queued\"") >= 0,
+            "queued notification and server-assigned human provenance are visible")
+        t |> equal(watcher_input(controlled.session_id, "\r", 12), "")
+        let delivered_json = watcher_mailbox_json(
+            controlled.session_id, "inbox", queued_message.message_id)
+        t |> success(find(delivered_json, "\"notified\":true") >= 0
+                && find(delivered_json, "\"notification_error\":\"\"") >= 0,
+            "submitting the partial line atomically flushes its queued notification")
         t |> equal(watcher_terminate(controlled.session_id, "test_complete"), "")
         t |> success(wait_for(controlled.session_id, "exited", 4000l), "terminated command exits and drains")
         watcher_shutdown(true)

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -283,8 +283,10 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> equal(watcher_input(controlled.session_id, "\r", 12), "")
         let controlled_events = fread(path_join(path_join(path_join(root, "sessions"),
             controlled.session_id), "events.jsonl"))
-        t |> success(find(controlled_events, "\"detail\":\"id=; queued=true\"") < 0,
-            "a queued non-mailbox nudge does not emit an empty mailbox event")
+        t |> success(find(controlled_events, "delivery=deferred") >= 0,
+            "a deferred mailbox nudge records its eventual delivery")
+        t |> success(find(controlled_events, "\"detail\":\"id=; delivery=deferred\"") < 0,
+            "a deferred non-mailbox nudge does not emit an empty mailbox event")
         t |> equal(watcher_terminate(controlled.session_id, "test_complete"), "")
         t |> success(wait_for(controlled.session_id, "exited", 4000l), "terminated command exits and drains")
         watcher_shutdown(true)

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -241,14 +241,20 @@ def test_watcher_process_lifecycle(t : T?) {
             command_line = "powershell.exe -NoProfile -Command \"Start-Sleep -Seconds 5\"",
             cwd = root, columns = 80, rows = 20, timeout_ms = 10000l))
         t |> success(controlled.ok, controlled.error)
+        let quick_mailbox_revision = watcher_mailbox_session_revision(quick.session_id)
+        t |> equal(watcher_mailbox_session_revision(controlled.session_id), 0l,
+            "a new session starts with an independent mailbox revision")
         t |> success(watcher_claim_controller(controlled.session_id, 11), "first controller claims lease")
         t |> success(!watcher_claim_controller(controlled.session_id, 12), "second controller is rejected")
         watcher_release_controller(controlled.session_id, 11, "test_detach")
         t |> success(watcher_claim_controller(controlled.session_id, 12), "released lease can be reclaimed")
         let queued_message = watcher_mailbox_post(WatcherMailboxPostRequest(
             session_id = controlled.session_id, direction = "inbox",
-            sender = "untrusted-payload-sender", subject = "Look at that"))
+            sender = "system:dasHerd", subject = "Look at that"))
         t |> success(queued_message.ok, queued_message.error)
+        t |> equal(watcher_mailbox_session_revision(quick.session_id),
+            quick_mailbox_revision,
+            "mailbox activity does not change another session's revision")
         t |> equal(watcher_input(controlled.session_id, "partial", 12), "")
         t |> equal(watcher_notify(controlled.session_id, "nudge\r",
             queued_message.message_id), "queued",
@@ -257,7 +263,7 @@ def test_watcher_process_lifecycle(t : T?) {
             controlled.session_id, "inbox", queued_message.message_id)
         t |> success(find(queued_json, "\"sender\":\"human:local\"") >= 0
                 && find(queued_json, "\"notification_error\":\"queued\"") >= 0,
-            "queued notification and server-assigned human provenance are visible")
+            "queued notification and reserved system provenance cannot be spoofed")
         t |> equal(watcher_input(controlled.session_id, "\r", 12), "")
         let delivered_json = watcher_mailbox_json(
             controlled.session_id, "inbox", queued_message.message_id)

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -123,6 +123,8 @@ def test_watcher_process_lifecycle(t : T?) {
             command_line = "powershell.exe -NoProfile -Command \"Write-Output watcher-core-ok\"",
             cwd = root, columns = 80, rows = 20, timeout_ms = 5000l))
         t |> success(quick.ok, quick.error)
+        t |> equal(watcher_mailbox_session_revision("missing-session"), -1l,
+            "unknown sessions do not expose a normal mailbox revision")
         t |> success(watcher_accepts_input(quick.session_id), "running session accepts input")
         t |> success(wait_for(quick.session_id, "exited", 5000l), "quick command exits and drains")
         t |> success(!watcher_accepts_input(quick.session_id), "exited session is replay-only")
@@ -267,6 +269,13 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> equal(watcher_notify(controlled.session_id, "nudge\r",
             queued_message.message_id), "queued",
             "notification waits behind a partial terminal input line")
+        t |> success(watcher_mailbox_session_revision(controlled.session_id)
+                > queued_message.revision,
+            "recording queued delivery advances the session mailbox revision")
+        let missing_fetch = watcher_mailbox_mark_fetched(
+            controlled.session_id, "missing-message")
+        t |> success(!missing_fetch.ok && missing_fetch.error == "unknown mailbox message",
+            "fetching an unknown mailbox message reports a routing error")
         let queued_json = watcher_mailbox_json(
             controlled.session_id, "inbox", queued_message.message_id)
         t |> success(find(queued_json, "\"sender\":\"human:local\"") >= 0

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -953,18 +953,20 @@ def public watcher_mailbox_json(session_id : string; direction : string = "";
                                 message_id : string = "") : string {
     let index = watcher_find_session(session_id)
     if (index < 0 || g_sessions[index] == null) return "[]"
-    var result = "["
-    var first = true
-    for (message in g_sessions[index].mailbox) {
-        if (!empty(direction) && message.direction != direction) continue
-        if (!empty(message_id) && message.id != message_id) continue
-        if (!first) {
-            result += ","
+    return build_string() $(var writer) {
+        writer |> write("[")
+        var first = true
+        for (message in g_sessions[index].mailbox) {
+            if ((!empty(direction) && message.direction != direction)
+                    || (!empty(message_id) && message.id != message_id)) continue
+            if (!first) {
+                writer |> write(",")
+            }
+            writer |> write(sprint_json(message, false))
+            first = false
         }
-        result += sprint_json(message, false)
-        first = false
+        writer |> write("]")
     }
-    return result + "]"
 }
 
 def private resize_session(var session : WatcherSession?; columns, rows, client_id : int) : string {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -841,8 +841,10 @@ def private append_mailbox_record(var session : WatcherSession?;
     fflush(session.mailbox_file)
 }
 
-def public watcher_mailbox_revision : int64 {
-    return g_mailbox_revision
+def public watcher_mailbox_session_revision(session_id : string) : int64 {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return -1l
+    return g_sessions[index].mailbox_revision
 }
 
 def public watcher_mailbox_post(request : WatcherMailboxPostRequest) : WatcherMailboxResult {
@@ -858,7 +860,7 @@ def public watcher_mailbox_post(request : WatcherMailboxPostRequest) : WatcherMa
     if (!empty(focus_error)) return WatcherMailboxResult(error = focus_error)
     let sender = (request.direction == "outbox"
         ? "agent_session:{request.session_id}"
-        : (request.sender == "system:dasHerd" ? request.sender : "human:local"))
+        : "human:local")
     g_next_mailbox_id++
     g_mailbox_revision++
     var message = WatcherMailboxMessage(

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -91,7 +91,7 @@ struct public WatcherFocusSet {
 struct public WatcherMailboxPostRequest {
     session_id : string
     direction : string
-    sender : string
+    sender : string = ""
     kind : string = "note"
     subject : string
     reply_to : string
@@ -776,9 +776,11 @@ def private flush_pending_notifications(var session : WatcherSession?) {
         let pending & = unsafe(session.pending_notifications[delivered])
         if (!terminal_write(session.terminal, pending.text)) break
         session.input_bytes += int64(length(pending.text))
-        let _ = watcher_mailbox_set_notification(session.id, pending.message_id)
-        append_event(session, "mailbox_notified",
-            "id={pending.message_id}; queued=true")
+        if (!empty(pending.message_id)) {
+            let _ = watcher_mailbox_set_notification(session.id, pending.message_id)
+            append_event(session, "mailbox_notified",
+                "id={pending.message_id}; queued=true")
+        }
         delivered++
     }
     if (delivered > 0) {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -814,9 +814,12 @@ def public watcher_notify(session_id : string; text : string;
         if (!empty(message_id)) {
             let _ = watcher_mailbox_set_notification(
                 session_id, message_id, "queued")
+            append_event(g_sessions[index], "mailbox_notification_queued",
+                "id={message_id}; partial_input_bytes={g_sessions[index].input_line_bytes}")
+        } else {
+            append_event(g_sessions[index], "terminal_notification_queued",
+                "partial_input_bytes={g_sessions[index].input_line_bytes}")
         }
-        append_event(g_sessions[index], "mailbox_notification_queued",
-            "id={message_id}; partial_input_bytes={g_sessions[index].input_line_bytes}")
         return "queued"
     }
     let controller_id = g_sessions[index].controller_id

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -67,6 +67,73 @@ struct public WatcherSessionRequest {
     session_id : string
 }
 
+struct public WatcherFocusRange {
+    start_byte : int = -1
+    end_byte : int = -1
+    caption : string
+}
+
+struct public WatcherFocusTarget {
+    file_path : string
+    whole_file : bool
+    ranges : array<WatcherFocusRange>
+}
+
+struct public WatcherFocusSet {
+    repository_id : string
+    worktree_path : string
+    comparison : string = "working"
+    revision : string
+    summary : string
+    targets : array<WatcherFocusTarget>
+}
+
+struct public WatcherMailboxPostRequest {
+    session_id : string
+    direction : string
+    sender : string
+    kind : string = "note"
+    subject : string
+    reply_to : string
+    notify : bool = true
+    focus : WatcherFocusSet = WatcherFocusSet()
+}
+
+struct public WatcherMailboxStateRequest {
+    session_id : string
+    message_id : string
+    status : string
+}
+
+struct public WatcherMailboxMessage {
+    id : string
+    session_id : string
+    direction : string
+    sender : string
+    kind : string
+    subject : string
+    reply_to : string
+    status : string = "new"
+    notified : bool
+    notification_error : string
+    fetched : bool
+    created_ms : int64
+    revision : int64
+    focus : WatcherFocusSet = WatcherFocusSet()
+}
+
+struct public WatcherMailboxResult {
+    ok : bool
+    message_id : string
+    revision : int64
+    error : string
+}
+
+struct private WatcherPendingNotification {
+    message_id : string
+    text : string
+}
+
 struct public WatcherEvent {
     session_id : string
     event : string
@@ -134,6 +201,7 @@ class private WatcherSession {
     session_dir : string
     output_path : string
     events_path : string
+    mailbox_path : string
     state : string = "starting"
     reason : string
     pid : int = 0
@@ -152,6 +220,12 @@ class private WatcherSession {
     status_revision : int64
     controller_id : int
     drained : bool
+    mailbox : array<WatcherMailboxMessage>
+    mailbox_revision : int64
+    mailbox_file : FILE const? = null
+    input_line_bytes : int
+    input_escape_state : int
+    pending_notifications : array<WatcherPendingNotification>
     def operator delete {
         if (output_file != null) {
             fflush(output_file)
@@ -163,8 +237,15 @@ class private WatcherSession {
             fclose(events_file)
             events_file = null
         }
+        if (mailbox_file != null) {
+            fflush(mailbox_file)
+            fclose(mailbox_file)
+            mailbox_file = null
+        }
         terminal_dispose(terminal)
         delete raw_history
+        delete mailbox
+        delete pending_notifications
     }
 }
 
@@ -185,6 +266,8 @@ def private retain_raw_output(var session : WatcherSession?; bytes : array<uint8
 var private g_sessions : array<WatcherSession?>
 var private g_log_root : string
 var private g_next_session_id = 0
+var private g_next_mailbox_id = 0
+var private g_mailbox_revision : int64
 
 def private elapsed_ms(session : WatcherSession?) : int64 {
     return get_time_nsec(session.started) / 1000000l
@@ -282,10 +365,13 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         session_dir = session_dir,
         output_path = path_join(session_dir, "output.raw"),
         events_path = path_join(session_dir, "events.jsonl"),
+        mailbox_path = path_join(session_dir, "mailbox.jsonl"),
         started = ref_time_ticks(), timeout_ms = max(0l, request.timeout_ms))
     session.output_file = fopen(session.output_path, "wb")
     session.events_file = fopen(session.events_path, "wb")
-    if (session.output_file == null || session.events_file == null) {
+    session.mailbox_file = fopen(session.mailbox_path, "wb")
+    if (session.output_file == null || session.events_file == null
+            || session.mailbox_file == null) {
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not open session logs")
     }
@@ -658,11 +744,227 @@ def private input_session(var session : WatcherSession?; text : string; client_i
     return ""
 }
 
+def private observe_input_line(var session : WatcherSession?; text : string) {
+    peek_data(text) $(bytes) {
+        for (byte_u8 in bytes) {
+            let byte = int(byte_u8)
+            if (session.input_escape_state == 1) {
+                session.input_escape_state = (byte == '[' || byte == 'O') ? 2 : 0
+            } elif (session.input_escape_state == 2) {
+                if (byte >= 0x40 && byte <= 0x7e) {
+                    session.input_escape_state = 0
+                }
+            } elif (byte == 0x1b) {
+                session.input_escape_state = 1
+            } elif (byte == '\r' || byte == '\n') {
+                session.input_line_bytes = 0
+            } elif (byte == 0x03 || byte == 0x15) {
+                session.input_line_bytes = 0
+            } elif (byte == 0x08 || byte == 0x7f) {
+                session.input_line_bytes = max(0, session.input_line_bytes - 1)
+            } elif (byte >= 0x20) {
+                session.input_line_bytes++
+            }
+        }
+    }
+}
+
+def private flush_pending_notifications(var session : WatcherSession?) {
+    if (session.input_line_bytes != 0 || empty(session.pending_notifications)) return
+    var delivered = 0
+    while (delivered < length(session.pending_notifications)) {
+        let pending & = unsafe(session.pending_notifications[delivered])
+        if (!terminal_write(session.terminal, pending.text)) break
+        session.input_bytes += int64(length(pending.text))
+        let _ = watcher_mailbox_set_notification(session.id, pending.message_id)
+        append_event(session, "mailbox_notified",
+            "id={pending.message_id}; queued=true")
+        delivered++
+    }
+    if (delivered > 0) {
+        session.pending_notifications |> erase(0, delivered)
+    }
+}
+
 def public watcher_input(session_id : string; text : string; client_id : int = 0) : string {
     let index = watcher_find_session(session_id)
     if (index < 0) return "unknown session"
     if (length(text) > MAX_INPUT_BYTES) return "input is too large"
-    return input_session(g_sessions[index], text, client_id)
+    let error = input_session(g_sessions[index], text, client_id)
+    if (!empty(error)) return error
+    observe_input_line(g_sessions[index], text)
+    flush_pending_notifications(g_sessions[index])
+    return ""
+}
+
+def public watcher_notify(session_id : string; text : string;
+                          message_id : string = "") : string {
+    //! A mailbox wake-up is one serialized terminal write. It deliberately
+    //! bypasses controller ownership: the controller is UI transport state,
+    //! not an authorization boundary for Herder's trusted local mailbox.
+    let index = watcher_find_session(session_id)
+    if (index < 0) return "unknown session"
+    if (length(text) > MAX_INPUT_BYTES) return "input is too large"
+    if (g_sessions[index].input_line_bytes != 0) {
+        var pending = WatcherPendingNotification(
+            message_id = message_id, text = text)
+        g_sessions[index].pending_notifications |> emplace(pending)
+        if (!empty(message_id)) {
+            let _ = watcher_mailbox_set_notification(
+                session_id, message_id, "queued")
+        }
+        append_event(g_sessions[index], "mailbox_notification_queued",
+            "id={message_id}; partial_input_bytes={g_sessions[index].input_line_bytes}")
+        return "queued"
+    }
+    let controller_id = g_sessions[index].controller_id
+    return input_session(g_sessions[index], text, controller_id)
+}
+
+def private valid_focus(focus : WatcherFocusSet const) : string {
+    for (target in focus.targets) {
+        if (empty(target.file_path)) return "focus target file_path is required"
+        for (focus_range in target.ranges) {
+            if (focus_range.start_byte < 0
+                    || focus_range.end_byte <= focus_range.start_byte) {
+                return "focus ranges require non-negative, increasing byte offsets"
+            }
+        }
+    }
+    return ""
+}
+
+def private append_mailbox_record(var session : WatcherSession?;
+                                  message : WatcherMailboxMessage const) {
+    if (session.mailbox_file == null) return
+    fwrite(session.mailbox_file, sprint_json(message, false) + "\n")
+    fflush(session.mailbox_file)
+}
+
+def public watcher_mailbox_revision : int64 {
+    return g_mailbox_revision
+}
+
+def public watcher_mailbox_post(request : WatcherMailboxPostRequest) : WatcherMailboxResult {
+    let index = watcher_find_session(request.session_id)
+    if (index < 0 || g_sessions[index] == null) {
+        return WatcherMailboxResult(error = "unknown session")
+    }
+    if (request.direction != "inbox" && request.direction != "outbox") {
+        return WatcherMailboxResult(error = "direction must be inbox or outbox")
+    }
+    if (empty(request.subject)) return WatcherMailboxResult(error = "subject is required")
+    let focus_error = valid_focus(request.focus)
+    if (!empty(focus_error)) return WatcherMailboxResult(error = focus_error)
+    let sender = (request.direction == "outbox"
+        ? "agent_session:{request.session_id}"
+        : (request.sender == "system:dasHerd" ? request.sender : "human:local"))
+    g_next_mailbox_id++
+    g_mailbox_revision++
+    var message = WatcherMailboxMessage(
+        id = "hf_{g_next_mailbox_id}", session_id = request.session_id,
+        direction = request.direction, sender = sender,
+        kind = request.kind, subject = request.subject,
+        reply_to = request.reply_to, created_ms = elapsed_ms(g_sessions[index]),
+        revision = g_mailbox_revision, focus := request.focus)
+    let message_id = message.id
+    let message_revision = message.revision
+    g_sessions[index].mailbox |> emplace(message)
+    g_sessions[index].mailbox_revision = g_mailbox_revision
+    append_mailbox_record(g_sessions[index],
+        g_sessions[index].mailbox[length(g_sessions[index].mailbox) - 1])
+    append_event(g_sessions[index], "mailbox_posted",
+        "id={message_id}; direction={request.direction}; sender={sender}")
+    return WatcherMailboxResult(ok = true, message_id = message_id,
+        revision = message_revision)
+}
+
+def public watcher_mailbox_set_notification(session_id, message_id : string;
+                                            error : string = "") : WatcherMailboxResult {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) {
+        return WatcherMailboxResult(error = "unknown session")
+    }
+    var session = g_sessions[index]
+    for (message_index in range(length(session.mailbox))) {
+        if (session.mailbox[message_index].id != message_id) continue
+        g_mailbox_revision++
+        session.mailbox[message_index].notified = empty(error)
+        session.mailbox[message_index].notification_error = error
+        session.mailbox[message_index].revision = g_mailbox_revision
+        session.mailbox_revision = g_mailbox_revision
+        append_mailbox_record(session, session.mailbox[message_index])
+        return WatcherMailboxResult(ok = true, message_id = message_id,
+            revision = g_mailbox_revision)
+    }
+    return WatcherMailboxResult(error = "unknown mailbox message")
+}
+
+def public watcher_mailbox_mark_fetched(session_id, message_id : string) : WatcherMailboxResult {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) {
+        return WatcherMailboxResult(error = "unknown session")
+    }
+    var session = g_sessions[index]
+    for (message_index in range(length(session.mailbox))) {
+        if (session.mailbox[message_index].id != message_id) continue
+        if (session.mailbox[message_index].fetched) {
+            return WatcherMailboxResult(ok = true, message_id = message_id,
+                revision = session.mailbox[message_index].revision)
+        }
+        g_mailbox_revision++
+        session.mailbox[message_index].fetched = true
+        session.mailbox[message_index].revision = g_mailbox_revision
+        session.mailbox_revision = g_mailbox_revision
+        append_mailbox_record(session, session.mailbox[message_index])
+        append_event(session, "mailbox_fetched", "id={message_id}")
+        return WatcherMailboxResult(ok = true, message_id = message_id,
+            revision = g_mailbox_revision)
+    }
+    return WatcherMailboxResult(error = "unknown mailbox message")
+}
+
+def public watcher_mailbox_set_state(request : WatcherMailboxStateRequest) : WatcherMailboxResult {
+    let index = watcher_find_session(request.session_id)
+    if (index < 0 || g_sessions[index] == null) {
+        return WatcherMailboxResult(error = "unknown session")
+    }
+    if (request.status != "new" && request.status != "acknowledged"
+            && request.status != "completed") {
+        return WatcherMailboxResult(error = "status must be new, acknowledged, or completed")
+    }
+    var session = g_sessions[index]
+    for (message_index in range(length(session.mailbox))) {
+        if (session.mailbox[message_index].id != request.message_id) continue
+        g_mailbox_revision++
+        session.mailbox[message_index].status = request.status
+        session.mailbox[message_index].revision = g_mailbox_revision
+        session.mailbox_revision = g_mailbox_revision
+        append_mailbox_record(session, session.mailbox[message_index])
+        append_event(session, "mailbox_state",
+            "id={request.message_id}; status={request.status}")
+        return WatcherMailboxResult(ok = true,
+            message_id = request.message_id, revision = g_mailbox_revision)
+    }
+    return WatcherMailboxResult(error = "unknown mailbox message")
+}
+
+def public watcher_mailbox_json(session_id : string; direction : string = "";
+                                message_id : string = "") : string {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return "[]"
+    var result = "["
+    var first = true
+    for (message in g_sessions[index].mailbox) {
+        if (!empty(direction) && message.direction != direction) continue
+        if (!empty(message_id) && message.id != message_id) continue
+        if (!first) {
+            result += ","
+        }
+        result += sprint_json(message, false)
+        first = false
+    }
+    return result + "]"
 }
 
 def private resize_session(var session : WatcherSession?; columns, rows, client_id : int) : string {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -779,7 +779,7 @@ def private flush_pending_notifications(var session : WatcherSession?) {
         if (!empty(pending.message_id)) {
             let _ = watcher_mailbox_set_notification(session.id, pending.message_id)
             append_event(session, "mailbox_notified",
-                "id={pending.message_id}; queued=true")
+                "id={pending.message_id}; delivery=deferred")
         }
         delivered++
     }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -60,6 +60,14 @@ struct private WatcherWsMessage {
     timeout_ms : int64
     control : bool
     raw : bool
+    direction : string
+    sender : string
+    subject : string
+    reply_to : string
+    message_id : string
+    status : string
+    notify : bool = true
+    focus : WatcherFocusSet = WatcherFocusSet()
 }
 
 struct public RepositoryFileInspectionMessage {
@@ -116,6 +124,7 @@ class private WatcherClient {
     raw : bool
     raw_offset : int64
     repository_revision : int64 = -1l
+    mailbox_revision : int64 = -1l
     inspection_request_id : int
     inspection_repository_id : string
     inspection_worktree_path : string
@@ -263,6 +272,21 @@ class DasHerdWatcherServer : HvWebServer {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
             return resp |> JSON(repository_list_json(), http_status.OK)
         }
+        GET("/api/v1/mailbox") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            let url = req != null ? string(req.url) : ""
+            let session_id = query_value(url, "session_id")
+            if (empty(session_id)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "session_id is required")
+            }
+            let direction = query_value(url, "direction")
+            let message_id = query_value(url, "message_id")
+            if (direction == "inbox" && !empty(message_id)) {
+                let _ = watcher_mailbox_mark_fetched(session_id, message_id)
+            }
+            return resp |> JSON(watcher_mailbox_json(session_id,
+                direction, message_id), http_status.OK)
+        }
         POST("/api/v1/gc") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
             let coalesced = watcher_request_gc()
@@ -347,6 +371,46 @@ class DasHerdWatcherServer : HvWebServer {
             if (!empty(error)) return self.respond_error(resp, http_status.CONFLICT, error)
             return resp |> JSON(sprint_json(WatcherOk(), false), http_status.OK)
         }
+        POST("/api/v1/mailbox") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            if (req == null || length(req.body) > MAX_REQUEST_BODY_BYTES) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "request body is too large")
+            }
+            var request = WatcherMailboxPostRequest()
+            if (!sscan_json(string(req.body), request)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "invalid mailbox JSON")
+            }
+            let result = watcher_mailbox_post(request)
+            if (!result.ok) return self.respond_error(resp, http_status.BAD_REQUEST, result.error)
+            if (request.direction == "inbox" && request.notify) {
+                let nudge_error = watcher_notify(request.session_id,
+                    "dasHerd review request {result.message_id} is ready. " +
+                    "Use the dasHerd skill to fetch and acknowledge it.\r",
+                    result.message_id)
+                if (!empty(nudge_error) && nudge_error != "queued") {
+                    print("dasHerd watcher: mailbox {result.message_id} persisted; " +
+                        "TTY nudge failed: {nudge_error}\n")
+                }
+                if (nudge_error != "queued") {
+                    let _ = watcher_mailbox_set_notification(
+                        request.session_id, result.message_id, nudge_error)
+                }
+            }
+            return resp |> JSON(sprint_json(result, false), http_status.CREATED)
+        }
+        POST("/api/v1/mailbox/state") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            if (req == null || length(req.body) > MAX_REQUEST_BODY_BYTES) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "request body is too large")
+            }
+            var request = WatcherMailboxStateRequest()
+            if (!sscan_json(string(req.body), request)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "invalid mailbox state JSON")
+            }
+            let result = watcher_mailbox_set_state(request)
+            if (!result.ok) return self.respond_error(resp, http_status.BAD_REQUEST, result.error)
+            return resp |> JSON(sprint_json(result, false), http_status.OK)
+        }
     }
 
     def find_client(channel : WebSocketChannel) : int {
@@ -372,6 +436,17 @@ class DasHerdWatcherServer : HvWebServer {
         if (!force && client.repository_revision == revision) return
         client.repository_revision = revision
         send(client.channel, "\{\"type\":\"repositories\",\"data\":{repository_list_json()}\}",
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def send_mailbox(var client : WatcherClient?; force : bool = false) {
+        if (client == null || empty(client.session_id)) return
+        let revision = watcher_mailbox_revision()
+        if (!force && client.mailbox_revision == revision) return
+        client.mailbox_revision = revision
+        send(client.channel, "\{\"type\":\"mailbox\",\"session_id\":" +
+            "{sprint_json(client.session_id, false)},\"revision\":{revision},\"data\":" +
+            "{watcher_mailbox_json(client.session_id)}\}",
             ws_opcode.WS_OPCODE_TEXT, true)
     }
 
@@ -861,7 +936,7 @@ class DasHerdWatcherServer : HvWebServer {
     def override onWsMessage(channel : WebSocketChannel; message : string#) {
         let index = find_client(channel)
         if (index < 0) return
-        var inscope incoming : WatcherWsMessage
+        var inscope incoming = WatcherWsMessage()
         if (length(message) > MAX_REQUEST_BODY_BYTES || !sscan_json(string(message), incoming)) {
             send_error(channel, "invalid WebSocket message")
             return
@@ -906,6 +981,48 @@ class DasHerdWatcherServer : HvWebServer {
             self.start_git_file_action(client, incoming)
         } elif (incoming.op == "file_inspect") {
             self.start_file_inspection(client, incoming)
+        } elif (incoming.op == "mailbox_post") {
+            var request = WatcherMailboxPostRequest(
+                session_id = incoming.session_id,
+                direction = incoming.direction,
+                sender = incoming.sender,
+                kind = incoming.kind,
+                subject = incoming.subject,
+                reply_to = incoming.reply_to,
+                notify = incoming.notify,
+                focus := incoming.focus)
+            let result = watcher_mailbox_post(request)
+            if (!result.ok) {
+                send_error(channel, result.error)
+                return
+            }
+            if (request.direction == "inbox" && request.notify) {
+                let nudge_error = watcher_notify(request.session_id,
+                    "dasHerd review request {result.message_id} is ready. " +
+                    "Use the dasHerd skill to fetch and acknowledge it.\r",
+                    result.message_id)
+                if (!empty(nudge_error) && nudge_error != "queued") {
+                    print("dasHerd watcher: mailbox {result.message_id} persisted; " +
+                        "TTY nudge failed: {nudge_error}\n")
+                }
+                if (nudge_error != "queued") {
+                    let _ = watcher_mailbox_set_notification(
+                        request.session_id, result.message_id, nudge_error)
+                }
+            }
+            send(channel, "\{\"type\":\"mailbox_posted\",\"message_id\":" +
+                "{sprint_json(result.message_id, false)},\"revision\":{result.revision}\}",
+                ws_opcode.WS_OPCODE_TEXT, true)
+            self.send_mailbox(client, true)
+        } elif (incoming.op == "mailbox_state") {
+            let result = watcher_mailbox_set_state(WatcherMailboxStateRequest(
+                session_id = incoming.session_id,
+                message_id = incoming.message_id, status = incoming.status))
+            if (!result.ok) {
+                send_error(channel, result.error)
+                return
+            }
+            self.send_mailbox(client, true)
         } elif (incoming.op == "launch") {
             var inscope launch = WatcherLaunchRequest(
                 command_line = incoming.command_line, cwd = incoming.cwd,
@@ -944,6 +1061,7 @@ class DasHerdWatcherServer : HvWebServer {
                 ws_opcode.WS_OPCODE_TEXT, true)
             send_snapshot(client, true)
             send_raw_output(client)
+            self.send_mailbox(client, true)
         } elif (incoming.op == "detach") {
             detach(client, "client_detached")
             send(channel, "\{\"type\":\"detached\"\}", ws_opcode.WS_OPCODE_TEXT, true)
@@ -987,6 +1105,7 @@ class DasHerdWatcherServer : HvWebServer {
             send_snapshot(client)
             send_raw_output(client)
             send_repositories(client)
+            send_mailbox(client)
             self.poll_git_file_action(client)
             self.poll_file_inspection(client)
         }

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -982,7 +982,7 @@ class DasHerdWatcherServer : HvWebServer {
         } elif (incoming.op == "file_inspect") {
             self.start_file_inspection(client, incoming)
         } elif (incoming.op == "mailbox_post") {
-            var request = WatcherMailboxPostRequest(
+            let request = WatcherMailboxPostRequest(
                 session_id = incoming.session_id,
                 direction = incoming.direction,
                 sender = incoming.sender,

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -296,10 +296,20 @@ class DasHerdWatcherServer : HvWebServer {
             if (empty(session_id)) {
                 return self.respond_error(resp, http_status.BAD_REQUEST, "session_id is required")
             }
+            if (watcher_find_session(session_id) < 0) {
+                return self.respond_error(resp, http_status.NOT_FOUND, "unknown session")
+            }
             let direction = query_value(url, "direction")
+            if (!empty(direction) && direction != "inbox" && direction != "outbox") {
+                return self.respond_error(resp, http_status.BAD_REQUEST,
+                    "direction must be inbox or outbox")
+            }
             let message_id = query_value(url, "message_id")
             if (direction == "inbox" && !empty(message_id)) {
-                let _ = watcher_mailbox_mark_fetched(session_id, message_id)
+                let fetched = watcher_mailbox_mark_fetched(session_id, message_id)
+                if (!fetched.ok) {
+                    return self.respond_error(resp, http_status.NOT_FOUND, fetched.error)
+                }
             }
             return resp |> JSON(watcher_mailbox_json(session_id,
                 direction, message_id), http_status.OK)
@@ -397,10 +407,11 @@ class DasHerdWatcherServer : HvWebServer {
             if (!sscan_json(string(req.body), request)) {
                 return self.respond_error(resp, http_status.BAD_REQUEST, "invalid mailbox JSON")
             }
-            let result = watcher_mailbox_post(request)
+            var result = watcher_mailbox_post(request)
             if (!result.ok) return self.respond_error(resp, http_status.BAD_REQUEST, result.error)
             self.maybe_notify_inbox_message(request.session_id,
                 request.direction, result.message_id, request.notify)
+            result.revision = watcher_mailbox_session_revision(request.session_id)
             return resp |> JSON(sprint_json(result, false), http_status.CREATED)
         }
         POST("/api/v1/mailbox/state") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
@@ -447,6 +458,10 @@ class DasHerdWatcherServer : HvWebServer {
     def send_mailbox(var client : WatcherClient?; force : bool = false) {
         if (client == null || empty(client.session_id)) return
         let revision = watcher_mailbox_session_revision(client.session_id)
+        if (revision < 0l) {
+            send_error(client.channel, "unknown session")
+            return
+        }
         if (!force && client.mailbox_revision == revision) return
         client.mailbox_revision = revision
         send(client.channel, "\{\"type\":\"mailbox\",\"session_id\":" +
@@ -996,13 +1011,14 @@ class DasHerdWatcherServer : HvWebServer {
                 reply_to = incoming.reply_to,
                 notify = incoming.notify,
                 focus := incoming.focus)
-            let result = watcher_mailbox_post(request)
+            var result = watcher_mailbox_post(request)
             if (!result.ok) {
                 send_error(channel, result.error)
                 return
             }
             self.maybe_notify_inbox_message(request.session_id,
                 request.direction, result.message_id, request.notify)
+            result.revision = watcher_mailbox_session_revision(request.session_id)
             send(channel, "\{\"type\":\"mailbox_posted\",\"message_id\":" +
                 "{sprint_json(result.message_id, false)},\"revision\":{result.revision}\}",
                 ws_opcode.WS_OPCODE_TEXT, true)

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -61,7 +61,7 @@ struct private WatcherWsMessage {
     control : bool
     raw : bool
     direction : string
-    sender : string
+    sender : string = ""
     subject : string
     reply_to : string
     message_id : string

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -235,6 +235,23 @@ class DasHerdWatcherServer : HvWebServer {
         return false
     }
 
+    def maybe_notify_inbox_message(session_id, direction, message_id : string;
+                                   notify : bool) {
+        if (direction != "inbox" || !notify) return
+        let nudge_error = watcher_notify(session_id,
+            "dasHerd review request {message_id} is ready. " +
+            "Use the dasHerd skill to fetch and acknowledge it.\r",
+            message_id)
+        if (!empty(nudge_error) && nudge_error != "queued") {
+            print("dasHerd watcher: mailbox {message_id} persisted; " +
+                "TTY nudge failed: {nudge_error}\n")
+        }
+        if (nudge_error != "queued") {
+            let _ = watcher_mailbox_set_notification(
+                session_id, message_id, nudge_error)
+        }
+    }
+
     def override onInit {
         GET("/") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
@@ -382,20 +399,8 @@ class DasHerdWatcherServer : HvWebServer {
             }
             let result = watcher_mailbox_post(request)
             if (!result.ok) return self.respond_error(resp, http_status.BAD_REQUEST, result.error)
-            if (request.direction == "inbox" && request.notify) {
-                let nudge_error = watcher_notify(request.session_id,
-                    "dasHerd review request {result.message_id} is ready. " +
-                    "Use the dasHerd skill to fetch and acknowledge it.\r",
-                    result.message_id)
-                if (!empty(nudge_error) && nudge_error != "queued") {
-                    print("dasHerd watcher: mailbox {result.message_id} persisted; " +
-                        "TTY nudge failed: {nudge_error}\n")
-                }
-                if (nudge_error != "queued") {
-                    let _ = watcher_mailbox_set_notification(
-                        request.session_id, result.message_id, nudge_error)
-                }
-            }
+            self.maybe_notify_inbox_message(request.session_id,
+                request.direction, result.message_id, request.notify)
             return resp |> JSON(sprint_json(result, false), http_status.CREATED)
         }
         POST("/api/v1/mailbox/state") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
@@ -441,7 +446,7 @@ class DasHerdWatcherServer : HvWebServer {
 
     def send_mailbox(var client : WatcherClient?; force : bool = false) {
         if (client == null || empty(client.session_id)) return
-        let revision = watcher_mailbox_revision()
+        let revision = watcher_mailbox_session_revision(client.session_id)
         if (!force && client.mailbox_revision == revision) return
         client.mailbox_revision = revision
         send(client.channel, "\{\"type\":\"mailbox\",\"session_id\":" +
@@ -996,20 +1001,8 @@ class DasHerdWatcherServer : HvWebServer {
                 send_error(channel, result.error)
                 return
             }
-            if (request.direction == "inbox" && request.notify) {
-                let nudge_error = watcher_notify(request.session_id,
-                    "dasHerd review request {result.message_id} is ready. " +
-                    "Use the dasHerd skill to fetch and acknowledge it.\r",
-                    result.message_id)
-                if (!empty(nudge_error) && nudge_error != "queued") {
-                    print("dasHerd watcher: mailbox {result.message_id} persisted; " +
-                        "TTY nudge failed: {nudge_error}\n")
-                }
-                if (nudge_error != "queued") {
-                    let _ = watcher_mailbox_set_notification(
-                        request.session_id, result.message_id, nudge_error)
-                }
-            }
+            self.maybe_notify_inbox_message(request.session_id,
+                request.direction, result.message_id, request.notify)
             send(channel, "\{\"type\":\"mailbox_posted\",\"message_id\":" +
                 "{sprint_json(result.message_id, false)},\"revision\":{result.revision}\}",
                 ws_opcode.WS_OPCODE_TEXT, true)


### PR DESCRIPTION
## Summary

- keep Git file viewing usable when a path has content but no textual diff, including UTF-8 worktree paths
- add the dasHerd session mailbox CLI/protocol and document the trusted local agent interaction model
- add bidirectional human/agent Focus Sets with exact-worktree routing, multi-file and multi-range navigation, hover captions, error handoff, and non-modal Attention UI
- preserve syntax highlighting while dimming unrelated code and expose focused ranges in both View and Diff

## Validation

- one full PR preflight run: format, dasgen, CI-only das compilation, docs, interpreter, and JIT gates passed
- environment skips: clang-cl and latexmk unavailable; AOT/sequence relink blocked by the running DLL-flavor host
- local C++ small-test binary was absent, so that gate reported Not Run; CI will build it
- post-preflight lint cleanup: 9 changed das files, 0 issues, 0 errors
- rich client compile-only check passed
- dasHerd watcher suite: 56 passed