### PR TITLE
dasLLAMA: kq/q8 tile rework — vector bsums, mr8 perms, streaming tune fixtures; DAS_JOBQUE_THREADS validation

### DIFF
--- a/modules/dasLLAMA/benchmarks/matmul/bench_gemm_iso.das
+++ b/modules/dasLLAMA/benchmarks/matmul/bench_gemm_iso.das
@@ -17,9 +17,10 @@ require strings
 // shapes at the prefill batch width (ntok = 512), THREADED, reported as GMAC/s aggregate AND per
 // core. This is the das half of the pure-GEMM ladder (harness/pure_gemm_ladder.sh) — the lcpp
 // half is `test-backend-ops perf -o MUL_MAT` with the same shapes (harness/backend_ops_shapes.patch);
-// lcpp reports GFLOPS = 2·GMAC/s. Sweep DAS_JOBQUE_THREADS=1,2,4,… to read the parallel_for
-// scaling curve: per-core GMAC/s at 1 thread is the raw kernel ceiling; how far the aggregate
-// climbs as threads grow tells us whether parallel_for or the kernel is the wall.
+// lcpp reports GFLOPS = 2·GMAC/s. Sweep DAS_JOBQUE_THREADS=2,4,8,… to read the parallel_for
+// scaling curve (values <= 1 are a fatal error — N means N total lanes incl. the computing main,
+// so there is no honest 1-lane jobque run); per-lane GMAC/s at 2 lanes is the near-kernel ceiling;
+// how far the aggregate climbs as lanes grow tells us whether parallel_for or the kernel is the wall.
 //
 //   bin/daslang -jit dastest/dastest.das -- --bench --test modules/dasLLAMA/benchmarks/matmul/bench_gemm_iso.das
 //   DASLLAMA_BENCH_MODEL=llama8b DAS_JOBQUE_THREADS=8 bin/daslang -jit dastest/dastest.das -- --bench --test .../bench_gemm_iso.das

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -111,7 +111,7 @@ def main {
         if (has_env_variable("DASLLAMA_TOKEN_BLOCK")) {   // A/B the batch-GEMM token block (weights re-stream ntok/TB times)
             let tb = to_int(get_env_variable("DASLLAMA_TOKEN_BLOCK"))
             set_q8_token_block(int64(tb))
-            print("q8_token_block override: {tb}\n")
+            print("q8_token_block override: {get_q8_token_block()}\n")   // the EFFECTIVE value (setter clamps to >= 1)
         }
         if (has_env_variable("DASLLAMA_MIN_CHUNK_ROWS_GEMV")) {
             let mgv = to_int(get_env_variable("DASLLAMA_MIN_CHUNK_ROWS_GEMV"))

--- a/modules/dasLLAMA/benchmarks/prefill_perf.das
+++ b/modules/dasLLAMA/benchmarks/prefill_perf.das
@@ -108,6 +108,11 @@ def main {
             set_matmul_min_chunk_rows(mg)
             print("min chunk rows override: {mg}\n")
         }
+        if (has_env_variable("DASLLAMA_TOKEN_BLOCK")) {   // A/B the batch-GEMM token block (weights re-stream ntok/TB times)
+            let tb = to_int(get_env_variable("DASLLAMA_TOKEN_BLOCK"))
+            set_q8_token_block(int64(tb))
+            print("q8_token_block override: {tb}\n")
+        }
         if (has_env_variable("DASLLAMA_MIN_CHUNK_ROWS_GEMV")) {
             let mgv = to_int(get_env_variable("DASLLAMA_MIN_CHUNK_ROWS_GEMV"))
             set_matmul_min_chunk_rows_gemv(mgv)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -7490,7 +7490,7 @@ def private dense_ffn_inplace(t : Model; var s : Session; l : int64) {
             quantize_q8_k_into(s.hb, hidden, s.kxq, s.kxs, s.kxbs, 0l, 0l, 0l)
         }
         mm_pre_f(s.xb, t, f2, t.w2_offs[l], s.xq, s.xs, s.kxq, s.kxs, s.kxbs, hidden, dim)
-        prof_add("mm_ffn", ts_down)
+        prof_add("mm_ffn_down", ts_down)
     } elif (t.quant == QuantMode.q8) {
         // gate+up share the activation: ONE quantize + ONE region-list dispatch into ffn_gu's halves
         quantize_q8_0_into(s.xb, dim, s.xq, s.xs, 0l, 0l)
@@ -7509,7 +7509,7 @@ def private dense_ffn_inplace(t : Model; var s : Session; l : int64) {
         let ts_down = ref_time_ticks()
         quantize_q8_0_into(s.ffn_gu, hidden, s.xq, s.xs, 0l, 0l)
         mm_at_q8_pre(s.xb, t, t.w2_offs[l], s.xq, s.xs, hidden, dim)
-        prof_add("mm_ffn", ts_down)
+        prof_add("mm_ffn_down", ts_down)
     } else {
         mm(s.hb, t, t.w1_offs[l], s.xb, s.xq, s.xs, dim, hidden)
         mm(s.hb2, t, t.w3_offs[l], s.xb, s.xq, s.xs, dim, hidden)
@@ -7519,7 +7519,7 @@ def private dense_ffn_inplace(t : Model; var s : Session; l : int64) {
         prof_add("act", ts_act)
         let ts_ffn2 = ref_time_ticks()
         mm(s.xb, t, t.w2_offs[l], s.hb, s.xq, s.xs, hidden, dim)
-        prof_add("mm_ffn", ts_ffn2)
+        prof_add("mm_ffn_down", ts_ffn2)
     }
 }
 
@@ -10740,7 +10740,7 @@ def private ffn_dense_prefill(t : Model; var s : Session; l : int64; npos : int6
     // down projection (batched) + optional post-FFN norm + residual
     let ts_ffn2 = ref_time_ticks()
     mm_b_f(s, s.xb_b, t, fmt_at(t.w2_fmt, l), t.w2_offs[l], s.hb_b, hidden, dim, npos)
-    prof_add("mm_ffn", ts_ffn2)
+    prof_add("mm_ffn_down", ts_ffn2)   // own bucket: down is long-K + often a different format (Q4_K_M keeps it q6_K)
     let ts_resid1 = ref_time_ticks()
     if (c.pre_post_norm) {  // Gemma2: post-FFN RMSNorm per position before residual
         rms_batch(s.xb_b, s.xb_b, t, t.rms_post_ffn_off + l * dim, dim, npos)

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
@@ -189,10 +189,11 @@ def private perm_declines(var gc : LlvmCodeCtx; p : TilePerm) : bool {
         return LLVMGetIntrinsicDeclaration(mod, tblId, tblTypes) == null
     }
     if (p.dotPrim == "sdot") {
-        // the NEON leg (M2 shape): 128-bit q-regs, 4-row sdot lane structure, q-reg budget checked below
+        // the NEON leg (M2 shape): 128-bit q-regs, 4-row sdot lanes; mr>=8 budgets the FUSED-acc shape (kq shares one lo+hi acc there — half the mr4 formula's int-acc bank)
         if ((!g_target_is_aarch64) || (p.width != 128)
             || (p.mr % 4 != 0)
-            || (2 * p.mr + p.nrsplit * p.mr / 4 + 2 * p.nrsplit + 2 > 32)) return true
+            || (p.mr >= 8 ? (p.mr + p.nrsplit * p.mr / 4 + 2 * p.nrsplit + 2 > 32)
+                          : (2 * p.mr + p.nrsplit * p.mr / 4 + 2 * p.nrsplit + 2 > 32))) return true
         let mod = LLVMGetGlobalParent(gc.impl)
         var v16i8 = LLVMVectorType(gc.jit.types.t_int8, 16u)
         let id = LLVMLookupIntrinsicID("llvm.aarch64.neon.sdot")
@@ -796,6 +797,23 @@ def private load_f16_vec_at(var te : TileEmit; var base, off : LLVMOpaqueValue?;
     return LLVMBuildFPExt(b, LLVMBuildBitCast(b, hv, te.vnf16, ""), te.vnf32, name)
 }
 
+// pairwise i32 fold of two bsum quads into one v4 of per-32 sums (even+odd shuffle + add —
+// the backend lowers the pair to a single addp)
+def private pairwise_add_i32(var te : TileEmit; var av, bv : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
+    let b = te.builder
+    let evens <- [0, 2, 4, 6]
+    let odds <- [1, 3, 5, 7]
+    var e = LLVMBuildShuffleVector(b, te.types, av, bv, evens, "")
+    var o = LLVMBuildShuffleVector(b, te.types, av, bv, odds, "")
+    return LLVMBuildAdd(b, e, o, name)
+}
+
+// splat one lane of a v4i32 across the accumulator width (dup .4s[lane] after lowering)
+def private splat_lane_i32(var te : TileEmit; var v : LLVMOpaqueValue?; lane : int; name : string) : LLVMOpaqueValue? {
+    let mask <- [for (_i in range(te.rv)); lane]
+    return LLVMBuildShuffleVector(te.builder, te.types, v, v, mask, name)
+}
+
 // or-in of a masked bit test as the nibble's 0x10: w |= (bytes & mask) != 0 ? 0x10 : 0
 // (pcmpeqb+pand shape after lowering — the k5 high-bit deposit)
 def private or_bit_x10(te : TileEmit; var w, bytes, maskv : LLVMOpaqueValue?; name : string) : LLVMOpaqueValue? {
@@ -848,6 +866,24 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
         iacc[i] = LLVMConstNull(te.vni32)
         bacc[i] = LLVMConstNull(te.vni32)
         facc[i] = LLVMConstNull(te.vnf32)
+    }
+    // vector bsums: sdot leg only (x64's vpbroadcastd makes scalars free; k6 needs bs0/bs1 unsummed)
+    let vecBsums = !memBcast && !k6
+    // mr>=8 fuses lo+hi into ONE acc (i32-exact — the fold adds them anyway); mr4 keeps split accs for ILP
+    let fuseAcc = !memBcast && mr >= 8 && !k6
+    var a32v8 : LLVMOpaqueValue? [8]   // [tok * 2 + blk / 4], lane blk % 4
+    if (vecBsums) {
+        var xb16 = LLVMBuildShl(b, sbi, te.types->ConstI64(4ul), "xb16")
+        for (i in range(tokCount)) {
+            let tk = tokBase + i
+            var q : LLVMOpaqueValue? [4]
+            for (q4 in range(4)) {
+                var bp = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], LLVMBuildAdd(b, xb16, te.types->ConstI64(uint64(q4 * 4)), ""), "bsp{tk}_{q4}")
+                q[q4] = LLVMBuildLoad2Aligned(b, te.vni32, bp, 4u, "bsv{tk}_{q4}")
+            }
+            a32v8[i * 2] = pairwise_add_i32(te, q[0], q[1], "a32lo{tk}")
+            a32v8[i * 2 + 1] = pairwise_add_i32(te, q[2], q[3], "a32hi{tk}")
+        }
     }
     for (blk in range(8)) {
         var xoff0 = LLVMBuildAdd(b, xb, te.types->ConstI64(uint64(blk * 32)), "")
@@ -926,8 +962,12 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
                     }
                 } else {
                     for (i in range(tokCount)) {
-                        a0[i * rq + qd] = kq_dot_lane(te, a0[i * rq + qd], wlo, xv0[i], j)
-                        a1[i * rq + qd] = kq_dot_lane(te, a1[i * rq + qd], whi, xv1[i], j)
+                        if (fuseAcc) {
+                            a0[i * rq + qd] = kq_dot_lane(te, kq_dot_lane(te, a0[i * rq + qd], wlo, xv0[i], j), whi, xv1[i], j)
+                        } else {
+                            a0[i * rq + qd] = kq_dot_lane(te, a0[i * rq + qd], wlo, xv0[i], j)
+                            a1[i * rq + qd] = kq_dot_lane(te, a1[i * rq + qd], whi, xv1[i], j)
+                        }
                     }
                 }
             }
@@ -963,9 +1003,11 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
                 mnv[qd] = LLVMBuildSExt(b, LLVMBuildLoad2Aligned(b, vri8, sc1p, 1u, ""), te.vni32, "sc{blk}_{qd}b")
             } else {
                 var scp = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(4 * mr + blk * mr + qd * te.rv)), ""), "scp{blk}_{qd}")
-                var mnp = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(12 * mr + blk * mr + qd * te.rv)), ""), "mnp{blk}_{qd}")
                 scv[qd] = LLVMBuildZExt(b, LLVMBuildLoad2Aligned(b, vri8, scp, 1u, ""), te.vni32, "sc{blk}_{qd}")
-                mnv[qd] = LLVMBuildZExt(b, LLVMBuildLoad2Aligned(b, vri8, mnp, 1u, ""), te.vni32, "mn{blk}_{qd}")
+                if (!vecBsums) {   // mins feed the inline bacc fold; the vector-bsum leg folds them in the epilogue instead
+                    var mnp = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(12 * mr + blk * mr + qd * te.rv)), ""), "mnp{blk}_{qd}")
+                    mnv[qd] = LLVMBuildZExt(b, LLVMBuildLoad2Aligned(b, vri8, mnp, 1u, ""), te.vni32, "mn{blk}_{qd}")
+                }
             }
         }
         var bIdx = LLVMBuildAdd(b, gb, te.types->ConstI64(uint64(blk)), "b{blk}")
@@ -973,15 +1015,23 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
         var bi2b = LLVMBuildAdd(b, bi2, te.types->ConstI64(1ul), "")
         for (i in range(tokCount)) {
             let tk = tokBase + i
-            var bp0 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2, "bp{tk}_{blk}a")
-            var bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{tk}_{blk}a")
-            var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2b, "bp{tk}_{blk}b")
-            var bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{tk}_{blk}b")
+            var bs0 : LLVMOpaqueValue?
+            var bs1 : LLVMOpaqueValue?
+            var a32v : LLVMOpaqueValue?
+            if (vecBsums) {
+                a32v = splat_lane_i32(te, a32v8[i * 2 + blk / 4], blk % 4, "a32v{tk}_{blk}")
+            } else {
+                var bp0 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2, "bp{tk}_{blk}a")
+                bs0 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp0, 4u, "bs{tk}_{blk}a")
+                var bp1 = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi2b, "bp{tk}_{blk}b")
+                bs1 = LLVMBuildLoad2Aligned(b, te.types.t_int32, bp1, 4u, "bs{tk}_{blk}b")
+                if (!k6) {
+                    a32v = splat_i32(te, LLVMBuildAdd(b, bs0, bs1, "a32{tk}_{blk}"), "a32v{tk}_{blk}")
+                }
+            }
             if (q40) {
-                var a32 = LLVMBuildAdd(b, bs0, bs1, "a32{tk}_{blk}")
-                var a32v = splat_i32(te, a32, "a32v{tk}_{blk}")
                 for (qd in range(rq)) {
-                    var acc = LLVMBuildAdd(b, a0[i * rq + qd], a1[i * rq + qd], "acc{tk}_{blk}_{qd}")
+                    var acc = fuseAcc ? a0[i * rq + qd] : LLVMBuildAdd(b, a0[i * rq + qd], a1[i * rq + qd], "acc{tk}_{blk}_{qd}")
                     var isub = LLVMBuildSub(b, acc, LLVMBuildMul(b, a32v, splat_i32n(te, 8), ""), "is{tk}_{blk}_{qd}")
                     facc[i * rq + qd] = fold_fma(te, LLVMBuildSIToFP(b, isub, te.vnf32, ""), dvb[qd], facc[i * rq + qd], "fa{tk}_{blk}_{qd}")
                 }
@@ -995,12 +1045,25 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
                     bacc[i * rq + qd] = LLVMBuildAdd(b, bacc[i * rq + qd], ba, "ba{tk}_{blk}_{qd}")
                 }
             } else {
-                var a32 = LLVMBuildAdd(b, bs0, bs1, "a32{tk}_{blk}")
-                var a32v = splat_i32(te, a32, "a32v{tk}_{blk}")
                 for (qd in range(rq)) {
-                    var acc = LLVMBuildAdd(b, a0[i * rq + qd], a1[i * rq + qd], "acc{tk}_{blk}_{qd}")
+                    var acc = fuseAcc ? a0[i * rq + qd] : LLVMBuildAdd(b, a0[i * rq + qd], a1[i * rq + qd], "acc{tk}_{blk}_{qd}")
                     iacc[i * rq + qd] = LLVMBuildAdd(b, iacc[i * rq + qd], LLVMBuildMul(b, scv[qd], acc, ""), "ia{tk}_{blk}_{qd}")
-                    bacc[i * rq + qd] = LLVMBuildAdd(b, bacc[i * rq + qd], LLVMBuildMul(b, mnv[qd], a32v, ""), "ba{tk}_{blk}_{qd}")
+                    if (!vecBsums) {
+                        bacc[i * rq + qd] = LLVMBuildAdd(b, bacc[i * rq + qd], LLVMBuildMul(b, mnv[qd], a32v, ""), "ba{tk}_{blk}_{qd}")
+                    }
+                }
+            }
+        }
+    }
+    // epilogue min-bias fold (k4/k5 vector-bsum leg): bit-exact i32, keeps bacc out of the block loop's register set
+    if (vecBsums && !q40) {
+        for (blk in range(8)) {
+            for (qd in range(rq)) {
+                var mnp = LLVMBuildGEP2(b, te.types.t_int8, te.sg, LLVMBuildAdd(b, sb, te.types->ConstI64(uint64(12 * mr + blk * mr + qd * te.rv)), ""), "emnp{blk}_{qd}")
+                var mnq = LLVMBuildZExt(b, LLVMBuildLoad2Aligned(b, vri8, mnp, 1u, ""), te.vni32, "emn{blk}_{qd}")
+                for (i in range(tokCount)) {
+                    var a32v = splat_lane_i32(te, a32v8[i * 2 + blk / 4], blk % 4, "ea32{tokBase + i}_{blk}")
+                    bacc[i * rq + qd] = LLVMBuildAdd(b, bacc[i * rq + qd], LLVMBuildMul(b, mnq, a32v, ""), "eba{tokBase + i}_{blk}_{qd}")
                 }
             }
         }

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -344,7 +344,7 @@ def q40q8_gemv_gen(var yp : float?; kqp : uint8 const?; ksp : uint8 const?; xqp 
 //! The K-quant TILE kernels (kq batch family): 4 tokens x mr rows per call — kqg is the group's
 //! QUANT panel (k4 the packed grp<mr> plane; k5/k6 a BYTE-EXPANDED scratch unpacked once per
 //! (group, token-block)). One call is bit-exact vs 4 per-token GEMVs over the same weights.
-[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8, nrsplit = 2),
+[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8), tune_perm(mr = 8, nrsplit = 2),
  tune_perm(dot = "maddubs", width = 256, mr = 8, requires = "avx2"), tune_perm(dot = "maddubs", width = 256, mr = 8, nrsplit = 2, requires = "avx2"),
  tune_perm(dot = "vpdpbusd", width = 256, mr = 8, requires = "avxvnni|avx512vnni"), tune_perm(dot = "vpdpbusd", width = 256, mr = 8, nrsplit = 2, requires = "avxvnni|avx512vnni"),
  tune_perm(dot = "vpdpbusd", width = 512, mr = 16, requires = "avx512vnni,avx512bw"), tune_perm(dot = "vpdpbusd", width = 512, mr = 16, nrsplit = 2, requires = "avx512vnni,avx512bw"),
@@ -364,7 +364,7 @@ def k4q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp :
     }
 }
 
-[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8, nrsplit = 2),
+[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8), tune_perm(mr = 8, nrsplit = 2),
  tune_perm(dot = "maddubs", width = 256, mr = 8, requires = "avx2"), tune_perm(dot = "maddubs", width = 256, mr = 8, nrsplit = 2, requires = "avx2"),
  tune_perm(dot = "vpdpbusd", width = 256, mr = 8, requires = "avxvnni|avx512vnni"), tune_perm(dot = "vpdpbusd", width = 256, mr = 8, nrsplit = 2, requires = "avxvnni|avx512vnni"),
  tune_perm(dot = "vpdpbusd", width = 512, mr = 16, requires = "avx512vnni,avx512bw"), tune_perm(dot = "vpdpbusd", width = 512, mr = 16, nrsplit = 2, requires = "avx512vnni,avx512bw"),
@@ -384,7 +384,7 @@ def k5q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp :
     }
 }
 
-[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8, nrsplit = 2),
+[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8), tune_perm(mr = 8, nrsplit = 2),
  tune_perm(dot = "maddubs", width = 256, mr = 8, requires = "avx2"), tune_perm(dot = "maddubs", width = 256, mr = 8, nrsplit = 2, requires = "avx2"),
  tune_perm(dot = "vpdpbusd", width = 256, mr = 8, requires = "avxvnni|avx512vnni"), tune_perm(dot = "vpdpbusd", width = 256, mr = 8, nrsplit = 2, requires = "avxvnni|avx512vnni"),
  tune_perm(dot = "vpdpbusd", width = 512, mr = 16, requires = "avx512vnni,avx512bw"), tune_perm(dot = "vpdpbusd", width = 512, mr = 16, nrsplit = 2, requires = "avx512vnni,avx512bw"),
@@ -404,7 +404,7 @@ def k6q8_tile_gen(var yp : float?; kqg : uint8 const?; ksg : uint8 const?; xqp :
     }
 }
 
-[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8, nrsplit = 2),
+[tune_perm(mr = 4), tune_perm(mr = 4, nrsplit = 2), tune_perm(mr = 8), tune_perm(mr = 8, nrsplit = 2),
  tune_perm(dot = "maddubs", width = 256, mr = 8, requires = "avx2"), tune_perm(dot = "maddubs", width = 256, mr = 8, nrsplit = 2, requires = "avx2"),
  tune_perm(dot = "vpdpbusd", width = 256, mr = 8, requires = "avxvnni|avx512vnni"), tune_perm(dot = "vpdpbusd", width = 256, mr = 8, nrsplit = 2, requires = "avxvnni|avx512vnni"),
  tune_perm(dot = "vpdpbusd", width = 512, mr = 16, requires = "avx512vnni,avx512bw"), tune_perm(dot = "vpdpbusd", width = 512, mr = 16, nrsplit = 2, requires = "avx512vnni,avx512bw"),

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -706,7 +706,10 @@ def kq_test_family(fmt : int64; kfxs : array<KqFixture>) : bool {
 // suffix ("" = a gate failed). The kq gemv is nrsplit-independent — same-mr rows share the
 // plane and the gemv shape — so the tile bench decides the family entry.
 def kq_tune_family(fmt : int64) : string {
-    var kbfx <- build_kq_fixture(fmt, 2048l, 512l, 64l)      // batch shape (the kv projection)
+    // batch shape: fat STREAMING ffn (weights > the L2 budget, multi-token-block walk) — the shape
+    // class that carries ~90% of prefill time. The old 2048x512x64 kv-projection probe was L2-hot
+    // and crowned hot-shape winners that lose double-digit % at model scale (mr4 vs mr8, M1).
+    var kbfx <- build_kq_fixture(fmt, 2048l, 8192l, 256l)
     var kgfx <- build_kq_fixture(fmt, 2048l, 8192l, 1l)      // streamed decode shape (DRAM-bound ffn)
     var khfx <- build_kq_fixture(fmt, 2048l, 512l, 1l)       // hot decode shape (cache-resident)
     var tvs <- kq_tile_variants(fmt)

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -1190,7 +1190,9 @@ def private confirm_and_write(winner : string) : bool {
 
 def tune_mode_run : bool {
     let tune_total_t0 = ref_time_ticks()
-    var fx <- build_fixture(2048l, 512l, 64l)      // batch shape (the kv projection)
+    // batch shape: fat STREAMING ffn like the kq fixture — the old 2048x512x64 kv-projection was
+    // L2-hot; divergent crowns still pass the e2e confirm gate before shipping
+    var fx <- build_fixture(2048l, 8192l, 256l)
     var gfx <- build_fixture(2048l, 8192l, 1l)     // streamed decode shape (DRAM-bound ffn GEMV)
     var hfx <- build_fixture(2048l, 512l, 1l)      // hot decode shape (cache-resident — the
                                                    // only regime where gemv knobs can show)

--- a/modules/dasLLAMA/harness/ggml_op_profile.patch
+++ b/modules/dasLLAMA/harness/ggml_op_profile.patch
@@ -1,8 +1,8 @@
 diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
-index 8a0e5c255..abbc5161b 100644
+index eb8341c..bcb9533 100644
 --- a/ggml/src/ggml-cpu/ggml-cpu.c
 +++ b/ggml/src/ggml-cpu/ggml-cpu.c
-@@ -3018,6 +3018,96 @@ static int ggml_cpu_try_fuse_ops(
+@@ -3015,6 +3015,97 @@ static int ggml_cpu_try_fuse_ops(
      return 0;
  }
  
@@ -16,13 +16,13 @@ index 8a0e5c255..abbc5161b 100644
 +
 +enum llm_prof_bucket {
 +    LLM_PROF_EMBED, LLM_PROF_RMSNORM, LLM_PROF_ROPE, LLM_PROF_KV_STORE, LLM_PROF_ATTN,
-+    LLM_PROF_MM_QKV, LLM_PROF_MM_WO, LLM_PROF_MM_FFN, LLM_PROF_MM_CLS, LLM_PROF_MM_OTHER,
++    LLM_PROF_MM_QKV, LLM_PROF_MM_WO, LLM_PROF_MM_FFN, LLM_PROF_MM_FFN_DOWN, LLM_PROF_MM_CLS, LLM_PROF_MM_OTHER,
 +    LLM_PROF_ACT_GATE, LLM_PROF_ADD, LLM_PROF_CPY, LLM_PROF_OTHER, LLM_PROF_COUNT
 +};
 +
 +static const char * llm_prof_bucket_names[LLM_PROF_COUNT] = {
 +    "embed", "rmsnorm", "rope", "kv_store", "attn",
-+    "mm_qkv", "mm_wo", "mm_ffn", "mm_cls", "mm_other",
++    "mm_qkv", "mm_wo", "mm_ffn", "mm_ffn_down", "mm_cls", "mm_other",
 +    "act+gate", "add", "cpy", "other"
 +};
 +
@@ -37,6 +37,7 @@ index 8a0e5c255..abbc5161b 100644
 +        case GGML_OP_MUL_MAT_ID: {
 +            if (!strncmp(n, "Qcur", 4) || !strncmp(n, "Kcur", 4) || !strncmp(n, "Vcur", 4)) return LLM_PROF_MM_QKV;
 +            if (!strncmp(n, "kqv_out", 7) || !strncmp(n, "attn_out", 8)) return LLM_PROF_MM_WO;
++            if (!strncmp(n, "ffn_down", 8) || !strncmp(n, "ffn_out", 7)) return LLM_PROF_MM_FFN_DOWN;   // long-K + q6_K in Q4_K_M — own bucket, mirrors das's mm_ffn_down. Down mm node = "ffn_out" (biasless models) or "ffn_down" (bias models)
 +            if (!strncmp(n, "ffn_", 4)) return LLM_PROF_MM_FFN;
 +            if (!strncmp(n, "result_output", 13)) return LLM_PROF_MM_CLS;
 +            if (!strncmp(n, "kq", 2)) return LLM_PROF_ATTN;   // kq + kqv (score / context GEMMs = attention, matching our attn bucket)
@@ -99,7 +100,7 @@ index 8a0e5c255..abbc5161b 100644
  static thread_ret_t ggml_graph_compute_thread(void * data) {
      struct ggml_compute_state * state = (struct ggml_compute_state *) data;
      struct ggml_threadpool    * tp    = state->threadpool;
-@@ -3046,6 +3136,8 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
+@@ -3043,6 +3134,8 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
      GGML_PRINT_DEBUG("thread #%d compute-start cplan %p last-graph %d\n", state->ith, (const void *)cplan, state->last_graph);
  #endif
  
@@ -108,7 +109,7 @@ index 8a0e5c255..abbc5161b 100644
      for (int node_n = 0; node_n < cgraph->n_nodes && atomic_load_explicit(&tp->abort, memory_order_relaxed) != node_n; node_n++) {
          struct ggml_tensor * node = cgraph->nodes[node_n];
  
-@@ -3058,6 +3150,8 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
+@@ -3055,6 +3148,8 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
              continue;
          }
  
@@ -117,7 +118,7 @@ index 8a0e5c255..abbc5161b 100644
          // TODO: move fused-op detection into ggml_graph_plan so fusion decisions are made once at planning time
          // Try fused ops, fall back to normal compute
          const int n_fused = ggml_cpu_try_fuse_ops(cgraph, node_n, &params, cplan);
-@@ -3076,6 +3170,12 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
+@@ -3073,6 +3168,12 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
          if (node_n + 1 < cgraph->n_nodes) {
              ggml_barrier(state->threadpool);
          }

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -8,8 +8,8 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "date":"2026-07-22",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -21,18 +21,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":180.80838574808604,
-            "stddev":13.354733467102051
+            "tok_s":219.03801116990559,
+            "stddev":1.6708701848983765
           },
           "tg128":{
-            "tok_s":34.011820214455142,
-            "stddev":0.11796684563159943
+            "tok_s":34.452992844421637,
+            "stddev":0.020031960681080818
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
+        "exec_fmt":"weights k4/k5/k6/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -40,8 +41,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -53,16 +54,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":153.96735100000001,
-            "stddev":0.67152999999999996
+            "tok_s":154.37838400000001,
+            "stddev":0.136466
           },
           "tg128":{
-            "tok_s":29.991537999999998,
-            "stddev":0.072005
+            "tok_s":30.592524000000001,
+            "stddev":0.25006800000000001
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"das",
@@ -132,8 +134,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-35B-A3B-MTP-UD-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -145,16 +147,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":146.80807899999999,
-            "stddev":1.983984
+            "tok_s":147.693634,
+            "stddev":0.298875
           },
           "tg128":{
-            "tok_s":30.529207,
-            "stddev":0.333424
+            "tok_s":30.025062999999999,
+            "stddev":0.31151800000000002
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"7642f1c",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
     "arch":"qwen35moe",
@@ -172,8 +175,8 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "date":"2026-07-22",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -185,18 +188,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":26.800858919429174,
-            "stddev":0.45111045241355896
+            "tok_s":30.995956074014686,
+            "stddev":0.6065516471862793
           },
           "tg128":{
-            "tok_s":6.0044025841300011,
-            "stddev":0.0013177604414522648
+            "tok_s":5.9725526532177984,
+            "stddev":0.068445555865764618
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
+        "exec_fmt":"weights k4/k6/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -204,8 +208,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -217,16 +221,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":26.411612999999999,
-            "stddev":0.233075
+            "tok_s":26.277823999999999,
+            "stddev":0.36598399999999998
           },
           "tg128":{
-            "tok_s":6.4602729999999999,
-            "stddev":0.006829
+            "tok_s":6.4219200000000001,
+            "stddev":0.094798999999999994
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"das",
@@ -296,8 +301,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Qwen3.6-27B-MTP-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -309,16 +314,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":26.562218000000001,
-            "stddev":0.012317
+            "tok_s":26.349958999999998,
+            "stddev":0.13631299999999999
           },
           "tg128":{
-            "tok_s":6.4482939999999997,
-            "stddev":0.055931000000000002
+            "tok_s":6.3638789999999998,
+            "stddev":0.080129000000000006
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"7642f1c",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
     "arch":"qwen35",
@@ -336,8 +342,8 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "date":"2026-07-22",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -349,18 +355,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":58.339754790484974,
-            "stddev":0.60240411758422852
+            "tok_s":66.006637373358728,
+            "stddev":0.47565644979476929
           },
           "tg128":{
-            "tok_s":14.719110137582899,
-            "stddev":0.0031543995719403028
+            "tok_s":14.734793513261604,
+            "stddev":0.062400501221418381
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
+        "exec_fmt":"weights k4/k6/q8 native; q8 activations; f32 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -368,8 +375,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -381,16 +388,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":60.599451999999999,
-            "stddev":0.197576
+            "tok_s":60.452703999999997,
+            "stddev":0.215444
           },
           "tg128":{
-            "tok_s":14.211022,
-            "stddev":0.113624
+            "tok_s":14.247317000000001,
+            "stddev":0.032347000000000001
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"das",
@@ -460,8 +468,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -473,16 +481,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":60.717517000000001,
-            "stddev":0.24302199999999999
+            "tok_s":60.422522999999998,
+            "stddev":0.35036299999999998
           },
           "tg128":{
-            "tok_s":14.183035,
-            "stddev":0.061987
+            "tok_s":14.078101,
+            "stddev":0.078953999999999996
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"7642f1c",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
     "arch":"gemma4",
@@ -500,7 +509,7 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
+        "date":"2026-07-22",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -513,18 +522,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":190.03545401192628,
-            "stddev":2.2559540271759033
+            "tok_s":214.93361487495326,
+            "stddev":1.5171548128128052
           },
           "tg128":{
-            "tok_s":22.081554453555793,
-            "stddev":0.0094171296805143356
+            "tok_s":21.998672444121166,
+            "stddev":0.0027258028276264668
           }
         },
         "source":"official",
-        "sha":"15ada7b6e",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
+        "exec_fmt":"weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -532,8 +542,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -545,16 +555,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":116.498143,
-            "stddev":0.92835299999999998
+            "tok_s":120.385868,
+            "stddev":0.194107
           },
           "tg128":{
-            "tok_s":20.351991999999999,
-            "stddev":0.02613
+            "tok_s":20.412303999999999,
+            "stddev":0.040924000000000002
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"llama.cpp",
@@ -562,8 +573,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -575,16 +586,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":190.26942500000001,
-            "stddev":1.1461680000000001
+            "tok_s":196.1814,
+            "stddev":1.5698909999999999
           },
           "tg128":{
-            "tok_s":20.282686000000002,
-            "stddev":0.043990000000000001
+            "tok_s":20.127203000000002,
+            "stddev":0.035373000000000002
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"7642f1c",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"llama.cpp",
@@ -664,7 +676,7 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
+        "date":"2026-07-22",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -677,18 +689,18 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":188.1157447370494,
-            "stddev":18.4388427734375
+            "tok_s":208.27883691838488,
+            "stddev":0.46420088410377502
           },
           "tg128":{
-            "tok_s":40.553555854921797,
-            "stddev":0.34822863340377808
+            "tok_s":41.32426347210297,
+            "stddev":0.063865318894386292
           }
         },
         "source":"official",
-        "sha":"4a3d6c690",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
         "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
@@ -697,8 +709,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -710,12 +722,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":117.038847,
-            "stddev":0.90851700000000002
+            "tok_s":120.847325,
+            "stddev":0.195886
           },
           "tg128":{
-            "tok_s":42.396515000000001,
-            "stddev":0.290823
+            "tok_s":42.631951999999998,
+            "stddev":0.114928
           }
         },
         "source":"official",
@@ -792,8 +804,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gpt-oss-20b-mxfp4.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -805,16 +817,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":119.106099,
-            "stddev":1.2954669999999999
+            "tok_s":120.044656,
+            "stddev":0.839314
           },
           "tg128":{
-            "tok_s":42.557640999999997,
-            "stddev":0.041480999999999997
+            "tok_s":42.193209000000003,
+            "stddev":0.098493999999999998
           }
         },
         "source":"official",
-        "sha":"ebd048f",
+        "sha":"7642f1c",
         "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
@@ -833,8 +845,8 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "date":"2026-07-22",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -846,18 +858,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":194.55741491189448,
-            "stddev":1.7205988168716431
+            "tok_s":216.96876391892638,
+            "stddev":4.3019938468933105
           },
           "tg128":{
-            "tok_s":47.218791600186464,
-            "stddev":0.0575912706553936
+            "tok_s":47.825383318584741,
+            "stddev":0.038488633930683136
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
+        "exec_fmt":"weights k4/k6/q8 native; q8 activations; f32 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -865,8 +878,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -878,16 +891,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":137.87965500000001,
-            "stddev":0.246202
+            "tok_s":137.424871,
+            "stddev":0.19991
           },
           "tg128":{
-            "tok_s":47.127329000000003,
-            "stddev":0.21551200000000001
+            "tok_s":47.623058,
+            "stddev":0.093197000000000002
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"das",
@@ -957,8 +971,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -970,16 +984,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":133.22704200000001,
-            "stddev":1.0945959999999999
+            "tok_s":134.487234,
+            "stddev":0.20582500000000001
           },
           "tg128":{
-            "tok_s":46.737828,
-            "stddev":0.341561
+            "tok_s":46.567284999999998,
+            "stddev":0.86570800000000003
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"7642f1c",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
     "arch":"qwen3moe",
@@ -997,8 +1012,8 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ref /Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench --ref-flavor clean-cpu",
+        "date":"2026-07-22",
+        "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -1010,18 +1025,19 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":27.279310735543341,
-            "stddev":0.20127867162227631
+            "tok_s":33.135724896761062,
+            "stddev":0.52679318189620972
           },
           "tg128":{
-            "tok_s":8.2080669972214686,
-            "stddev":0.06084693968296051
+            "tok_s":8.2411804882288688,
+            "stddev":0.017697233706712723
           }
         },
         "source":"official",
-        "sha":"dd21245c9",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)"
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
+        "exec_fmt":"weights k4/k6 native; q8 activations; f32 scales; planar arm64-gen (repacked)"
       },
       {
         "engine":"llama.cpp",
@@ -1029,8 +1045,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -1042,16 +1058,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":30.455176000000002,
-            "stddev":0.30332900000000002
+            "tok_s":31.370180000000001,
+            "stddev":0.35213100000000003
           },
           "tg128":{
-            "tok_s":8.2344369999999998,
-            "stddev":0.0022409999999999999
+            "tok_s":7.9739509999999996,
+            "stddev":0.34884399999999999
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"ebd048f",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {
         "engine":"das",
@@ -1121,8 +1138,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -1134,16 +1151,17 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":32.083396,
-            "stddev":0.25261699999999998
+            "tok_s":31.328184,
+            "stddev":0.44247399999999998
           },
           "tg128":{
-            "tok_s":8.231598,
-            "stddev":0.0037980000000000002
+            "tok_s":8.202655,
+            "stddev":0.003388
           }
         },
         "source":"official",
-        "sha":"ebd048f"
+        "sha":"7642f1c",
+        "exec_fmt":"native gguf formats; cpu runtime layout repack"
       }
     ],
     "arch":"llama",
@@ -1161,7 +1179,7 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
+        "date":"2026-07-22",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1174,18 +1192,18 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":147.85293629903535,
-            "stddev":0.48709043860435486
+            "tok_s":152.9271726831129,
+            "stddev":0.93385082483291626
           },
           "tg128":{
-            "tok_s":26.507349722621164,
-            "stddev":0.29626885056495667
+            "tok_s":26.733010017144885,
+            "stddev":0.024298768490552902
           }
         },
         "source":"official",
-        "sha":"87e926707",
+        "sha":"8d6fe0726",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr4 (manifest); k5q8_tile_gen=mr4 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr4 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest)",
         "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
@@ -1227,8 +1245,8 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -1240,12 +1258,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":114.41751499999999,
-            "stddev":1.747994
+            "tok_s":120.903505,
+            "stddev":0.66711600000000004
           },
           "tg128":{
-            "tok_s":27.949045000000002,
-            "stddev":0.13359799999999999
+            "tok_s":27.990476000000001,
+            "stddev":0.089593999999999993
           }
         },
         "source":"official",
@@ -1258,8 +1276,8 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-21",
-        "cmd":"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
+        "date":"2026-07-22",
+        "cmd":"\"/Users/borisbatkin/Work/llama.cpp/build/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
           "arch":"arm64",
@@ -1271,16 +1289,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":148.80133499999999,
-            "stddev":4.8026419999999996
+            "tok_s":156.67750699999999,
+            "stddev":1.3208839999999999
           },
           "tg128":{
-            "tok_s":26.194433,
-            "stddev":1.9060319999999999
+            "tok_s":27.249096999999999,
+            "stddev":0.080323000000000006
           }
         },
         "source":"official",
-        "sha":"ebd048f",
+        "sha":"7642f1c",
         "exec_fmt":"native gguf formats; cpu runtime layout repack"
       },
       {

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -34,7 +34,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x47ul   // assert message appends rather than replaces, matching interp/AOT (0x46: DIFile drops the duplicated directory)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x48ul   // kq tile: vector bsums + epilogue min-fold + fused-acc mr8 perm (0x47: assert message appends rather than replaces)
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -89,7 +89,7 @@ namespace das {
     static int jobque_thread_count(int hw) {
         static int forced = []{
             const char * e = getenv("DAS_JOBQUE_THREADS");
-            if ( !e ) return 0;
+            if ( !e || !*e ) return 0;   // exported-but-empty behaves like unset (CI environments do this)
             int v = atoi(e);
             if ( v <= 1 ) {
                 DAS_FATAL_ERROR("DAS_JOBQUE_THREADS='%s': value is TOTAL compute lanes (N-1 workers + the computing main) and must be >= 2; unset it for the default\n", e);

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -80,14 +80,23 @@ namespace das {
     // slow E-core stalls every parallel_for on its straggler chunk (measured ~1.6x slower on an
     // M-series 8P+2E prefill vs P-only) — pre-main-steal that ruled out logical cores-1 here; now
     // that the main thread computes too, the -1 is what keeps every compute thread on a P-core.
-    // DAS_JOBQUE_THREADS is an explicit override that bypasses everything (0/unset = the default).
+    // DAS_JOBQUE_THREADS is an explicit override that bypasses everything (unset = the default).
     // The value is TOTAL cores, so it follows the same cores-1 rule as the default: N-1 workers +
     // the computing main == N lanes (matches llama.cpp -t N; the old "N workers + main" oversubscribed
-    // by one core and left a ragged final wave when the split didn't divide N+1). The max(1,...)
-    // floors at one worker: a 0-worker JobQue can't run, so N==1 gives 1 worker + main = 2 lanes.
+    // by one core and left a ragged final wave when the split didn't divide N+1). Values <= 1 are a
+    // FATAL ERROR: a 0-worker JobQue can't serve new_job, and the old floor-to-1-worker silently ran
+    // "t=1" as 2 lanes — every baseline built on it was inflated 2x.
     static int jobque_thread_count(int hw) {
-        static int forced = []{ const char * e = getenv("DAS_JOBQUE_THREADS"); return e ? atoi(e) : 0; }();
-        if ( forced > 0 ) return max(1, forced - 1);
+        static int forced = []{
+            const char * e = getenv("DAS_JOBQUE_THREADS");
+            if ( !e ) return 0;
+            int v = atoi(e);
+            if ( v <= 1 ) {
+                DAS_FATAL_ERROR("DAS_JOBQUE_THREADS='%s': value is TOTAL compute lanes (N-1 workers + the computing main) and must be >= 2; unset it for the default\n", e);
+            }
+            return v;
+        }();
+        if ( forced > 0 ) return forced - 1;
         int def = 0;
 #if defined(__APPLE__)
         if ( int good = apple_perf_core_count() ) def = max(1, good - 1);


### PR DESCRIPTION
CPU prefill kernel rework driven by a per-bucket das-vs-llama.cpp profile of the Mistral-24B Q4_K_M prefill. The gap concentrated in one place: the k4 batch GEMM on fat FFN shapes delivered 0.89x of ggml's repacked `q4_K_8x4` kernel per lane, and IR-level accounting showed ~3x the loads per MAC (64 scalar bsum loads per superblock, 4-row amortization).

## Kernel changes (LLVM emitter, `dasllama_gemm_gen.das`)

- **Vector bsums + epilogue min-bias fold** (NEON sdot leg, k4/k5/q40): the superblock's 16 per-16 bsums load as 4 v4i32 with a pairwise fold instead of 16 scalar loads + 8 splats per token; the min-bias accumulation moves to a superblock epilogue so it never lives in the block loop. Bit-exact (same i32 math and order).
- **Fused lo/hi accumulator at mr >= 8** (the per-block fold adds them anyway, so fusing is i32-exact) — halves the live int-acc bank, which is what makes 8-row groups fit the NEON register file. New `mr8` perm rows on all four kq tile grids.
- **Decline-rail fix**: the sdot q-reg budget in `perm_declines` modeled the split-acc emitter and silently declined mr8/nrsplit4 to the *reference body* (~11 GMAC/s) — tests stay green on a declined perm since the reference is bit-exact, so the only tell is speed. The budget now models the fused shape at mr >= 8. This also un-blocked the pre-existing q8 `mr8_budget` perm, which then won its table and passed the e2e confirm gate (+7.5% on a Q8 model).
- **Tune fixtures re-aimed to streaming shapes** (kq and q8 batch fixtures: 2048x512x64 L2-hot kv-projection -&gt; 2048x8192x256, weights above the L2 budget): the hot probe systematically crowned perms that lose double-digit % at model scale. Divergent q8 crowns still pass the e2e confirm gate before shipping.
- `LLVM_JIT_CODEGEN_VERSION` 0x47 -&gt; 0x48 (generator emission changed for fixed args).

x64 legs are untouched: all new emission is gated behind the aarch64 sdot rail, and the new perms decline to reference on other ISAs until their own tuner re-ranks.

## Results (M1 Max, records re-sweep committed in `performance/records/m1.json`)

Every CPU pp512 cell on the 8-model board is now green vs clean-cpu llama.cpp (1.06-1.79x); the two losing cells flipped (gemma-4-12B 0.96 -&gt; 1.09, Mistral-24B 0.90 -&gt; 1.06; quiet-window Mistral pair: pp 34.22 vs 30.69 = 1.115x, tg 8.26 vs 7.87). das now beats the Accelerate/AMX stock build on 7 of 8 pp cells. No tg regressions; decode A/B gate passed (mr8 tg 7.99 vs mr4 7.86). `test_kquant` 104/104 bit-exact on the emitted kernels at both mr4 and mr8.

## Also in this PR

- **`DAS_JOBQUE_THREADS &lt;= 1` is now a fatal error** (`job_que.cpp`): the value means total compute lanes (N-1 workers + the computing main), so N==1 cannot be honored — the old floor silently ran 2 lanes and inflated every "t=1" baseline 2x. Garbage values (atoi -&gt; 0) fail loudly too.
- **`mm_ffn_down` profile bucket** (das + the lcpp `ggml_op_profile.patch` mirror): the down projection is long-K and often a different format (Q4_K_M keeps it q6_K); lumping it with gate+up hid where the deficit lived. The lcpp patch classifies `ffn_out` nodes (the biasless down mm) into the mirrored bucket.
- **`DASLLAMA_TOKEN_BLOCK` env** in `prefill_perf.das` — A/B rail for the batch-GEMM token block (used to refute the weight re-stream theory: TB=256 no change, TB=512 regresses).

Full preflight (`--full`, 17/17 gates) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)