### PR TITLE
rtti: retain named-module initializer hashes

### DIFF
--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -234,8 +234,13 @@ namespace das {
         sti->init_mnh = 0;
         if ( st.module ) {
             sti->module_name = debugInfo->allocateCachedName(st.module->name);
-            if ( auto fn = st.module->findFunction(st.name) ) {
-                sti->init_mnh = fn->getMangledNameHash();
+            if ( auto it = st.module->functionsByName.find(hash64z(st.name.c_str())) ) {
+                for ( auto * fn : it->second ) {
+                    if ( fn->arguments.empty() && fn->result && fn->result->structType == &st ) {
+                        sti->init_mnh = fn->getMangledNameHash();
+                        break;
+                    }
+                }
             }
         }
         sti->annotations = makeAnnotationList(st.annotations, sti->annotation_count);

--- a/tests/README.md
+++ b/tests/README.md
@@ -769,6 +769,7 @@ JIT compilation and code-generation tests. None have `expect` directives. The sl
 | typeAlias.das | Type aliases — `Point3Array`, indexing, swizzle, array ops on aliased types | |
 | typefunction.das | `[type_function]` annotation — `type<T>` argument syntax | |
 | typeinfo.das | typeinfo sizeof, has_field, struct_get_annotation_argument | |
+| test_rtti_init_mnh.das | Named-module structure RTTI retains the generated initializer's mangled-name hash | |
 | typeinfo_annotations.das | Struct annotation queries — has_annotation, get_annotation_argument | |
 | typeinfo_traits.das | typeinfo trait queries — is_local, is_ref, is_numeric, etc. | |
 | typename.das | `typeinfo typename` for various types — generics, arrays, tables | |

--- a/tests/language/test_rtti_init_mnh.das
+++ b/tests/language/test_rtti_init_mnh.das
@@ -1,0 +1,30 @@
+options gen2
+options rtti
+
+module test_rtti_init_mnh shared public
+
+require dastest/testing_boost public
+require daslib/rtti
+
+struct public RttiInitProbe {
+    value : int = 7
+}
+
+[test]
+def test_named_module_structure_init_mnh(t : T?) {
+    let initializer = @@RttiInitProbe
+    t |> success(initializer != null)
+
+    var initializerHash : uint64
+    context_for_each_function() $(info : FuncInfo) {
+        if (info.name == "RttiInitProbe" && info.count == 0u) {
+            initializerHash = info.hash
+        }
+    }
+    t |> success(initializerHash != 0ul)
+
+    let typeInfo = typeinfo rtti_typeinfo(type<RttiInitProbe>)
+    unsafe {
+        t |> equal(typeInfo.structType.init_mnh, initializerHash)
+    }
+}


### PR DESCRIPTION
## Summary
- resolve generated structure initializers from the module's simple-name function index
- select the zero-argument function returning the exact structure before recording its mangled-name hash
- add a named-module RTTI regression that compares StructInfo.init_mnh with FuncInfo.hash

## Validation
- focused interpreter regression: 1 passed
- focused AOT regression: 1 passed
- formatter verification: clean
- linter: 0 issues, 0 errors
- full preflight: 13 passed, 0 failed (local tool/DLL-lock skips left to CI)