### PR TITLE
Add dasLLAMA problem statement tutorial

### DIFF
--- a/daslib/array_boost.das
+++ b/daslib/array_boost.das
@@ -182,3 +182,92 @@ def array_view(var bytes : array<auto(TT)> ==const; offset, length : int | int64
         }
     }
 }
+
+def array_view(bytes : array<auto(TT)>#; offset, length : int | int64; blk : block<(view : array<TT>#) : void>) {
+    //! creates a subview of an existing borrowed array, valid only within the block
+    unsafe {
+        static_if (typeinfo is_int(offset)) {
+            if (offset < 0 || length < 0 || uint(offset) + uint(length) > uint(_::length(bytes))) {
+                panic("array_view: out of range")
+            }
+            var res : array<TT>#
+            if (length > 0) {
+                _builtin_make_temp_array(res, addr(bytes[offset]), length)
+            }
+            invoke(blk, res)
+        } else {
+            if (offset < 0_l || length < 0_l || uint64(offset) + uint64(length) > uint64(_::long_length(bytes))) {
+                panic("array_view: out of range")
+            }
+            var res : array<TT>#
+            if (length > 0_l) {
+                _builtin_make_temp_array_i64(res, addr(bytes[offset]), length)
+            }
+            invoke(blk, res)
+        }
+    }
+}
+
+[template(t), unused_argument(t)]
+def array_view(
+               bytes : array<uint8> ==const;
+               byte_offset, length : int | int64;
+               t : type<auto(TT)>;
+               blk : block<(view : array<TT>#) : void>
+               ) {
+    //! creates a checked, aligned native-layout typed view over bytes; length is in TT elements
+    static_if (typeinfo is_int(byte_offset)) {
+        array_view(bytes, 0, _::length(bytes)) $(view : array<uint8>#) {
+            array_view(view, byte_offset, length, type<TT>, blk)
+        }
+    } else {
+        array_view(bytes, 0_l, _::long_length(bytes)) $(view : array<uint8>#) {
+            array_view(view, byte_offset, length, type<TT>, blk)
+        }
+    }
+}
+
+[template(t), unused_argument(t)]
+def array_view(
+               bytes : array<uint8>#;
+               byte_offset, length : int | int64;
+               t : type<auto(TT)>;
+               blk : block<(view : array<TT>#) : void>
+               ) {
+    //! creates a checked, aligned native-layout typed view over borrowed bytes; length is in TT elements
+    concept_assert(typeinfo is_pod(type<TT>), "typed array_view requires a POD element type")
+    concept_assert(typeinfo sizeof(type<TT>) > 0, "typed array_view requires a non-empty element type")
+    let element_size = typeinfo sizeof(type<TT>)
+    let element_align = typeinfo alignof(type<TT>)
+    unsafe {
+        static_if (typeinfo is_int(byte_offset)) {
+            if (byte_offset < 0 || length < 0 || byte_offset > _::length(bytes)
+                    || uint(length) > (uint(_::length(bytes)) - uint(byte_offset)) / uint(element_size)) {
+                panic("array_view: out of range")
+            }
+            var res : array<TT -const>#
+            if (length > 0) {
+                let data = addr<TT -const?>(bytes[byte_offset])
+                if (intptr(reinterpret<void? -const>(data)) % uint64(element_align) != 0_ul) {
+                    panic("array_view: unaligned typed view")
+                }
+                _builtin_make_temp_array(res, data, length)
+            }
+            invoke(blk, res)
+        } else {
+            if (byte_offset < 0_l || length < 0_l || byte_offset > _::long_length(bytes)
+                    || uint64(length) > (uint64(_::long_length(bytes)) - uint64(byte_offset)) / uint64(element_size)) {
+                panic("array_view: out of range")
+            }
+            var res : array<TT -const>#
+            if (length > 0_l) {
+                let data = addr<TT -const?>(bytes[byte_offset])
+                if (intptr(reinterpret<void? -const>(data)) % uint64(element_align) != 0_ul) {
+                    panic("array_view: unaligned typed view")
+                }
+                _builtin_make_temp_array_i64(res, data, length)
+            }
+            invoke(blk, res)
+        }
+    }
+}

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -242,22 +242,26 @@ Run any tutorial from the project root::
 dasLLAMA (CPU LLM Inference) Tutorials
 ======================================
 
-These tutorials cover the ``dasllama`` module — CPU large-language-model
-inference in pure daslang: loading GGUF models, tokenization, streaming
-generation, chat with templates, sampling, sessions and memory, performance,
-and the architecture registry. Everything is written against the public
-``dasllama/dasllama`` facade.
+Tutorial 00 states the problem with a complete, minimal Llama-2 inference
+engine over a tiny llama2.c checkpoint. The remaining tutorials cover the
+``dasllama`` module — CPU large-language-model inference in pure daslang:
+loading GGUF models, tokenization, streaming generation, chat with templates,
+sampling, sessions and memory, performance, and the architecture registry.
+Tutorial 01 onward is written against the public ``dasllama/dasllama`` facade.
 
-You'll need a GGUF model file on disk (models are not shipped with the repo) —
-a good tiny one is `SmolLM2-135M-Instruct Q8_0
+For tutorials 01 onward, you'll need a GGUF model file on disk (models are not
+shipped with the repo) — a good tiny one is `SmolLM2-135M-Instruct Q8_0
 <https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF>`_ (~145 MB).
-Run from the project root, always with ``-jit``::
+dasLLAMA's tuning framework intentionally requires the JIT; interpreted and
+AOT execution are not supported. Run those tutorials from the project root
+with ``-jit``::
 
    daslang.exe -jit tutorials/dasLLAMA/01_hello_generate.das -- path/to/model.gguf
 
 .. toctree::
    :maxdepth: 1
 
+   tutorials/dasLLAMA_00_problem_statement.rst
    tutorials/dasLLAMA_01_hello_generate.rst
    tutorials/dasLLAMA_02_chat.rst
    tutorials/dasLLAMA_03_sampling.rst

--- a/doc/source/reference/tutorials/dasLLAMA_00_problem_statement.rst
+++ b/doc/source/reference/tutorials/dasLLAMA_00_problem_statement.rst
@@ -1,0 +1,170 @@
+.. _tutorial_dasLLAMA_problem_statement:
+
+====================================
+dasLLAMA-00 — The Problem Statement
+====================================
+
+.. index::
+    single: Tutorial; dasLLAMA
+    single: Tutorial; Transformer
+    single: Tutorial; Llama 2
+
+Before using dasLLAMA, build the thing it has to become.
+
+This tutorial is a complete, deliberately tiny Llama-2 inference engine in one
+daslang file. It maps a real 15-million-parameter checkpoint, runs every layer
+of the transformer, chooses the most likely next token, and prints a story.
+There is no ``require dasllama``: only the problem, expressed directly.
+
+It tells a second story too. The first dasLLAMA commit was authored on
+2026-06-27. It began with the same naive fp32 matrix multiplication used here;
+about a day later, `PR #3297
+<https://github.com/GaijinEntertainment/daScript/pull/3297>`_ contained
+Llama-2 and Llama-3, GGUF loading, quantization, threading, batched prefill,
+tests, and chat. The path from this readable program to native machine code
+never had to leave one programming environment.
+
+Get the model
+=============
+
+Download the two files used by Karpathy's `llama2.c
+<https://github.com/karpathy/llama2.c>`_:
+
+* `stories15M.bin
+  <https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin>`_
+  — the TinyStories Llama-2 checkpoint
+* `tokenizer.bin
+  <https://raw.githubusercontent.com/karpathy/llama2.c/master/tokenizer.bin>`_
+  — its tokenizer vocabulary
+
+Put them anywhere convenient, then run from the daScript project root::
+
+   daslang.exe tutorials/dasLLAMA/00_problem_statement.das -- stories15M.bin tokenizer.bin
+
+The interpreter is intentionally usable here. On a typical development
+machine it produces several tokens per second, which makes every operation
+inspectable. Add ``-jit`` to run the exact same source as native code::
+
+   daslang.exe -jit tutorials/dasLLAMA/00_problem_statement.das -- stories15M.bin tokenizer.bin
+
+The five operations
+===================
+
+A Llama transformer needs only five numerical building blocks:
+
+``matmul``
+   Projects a vector through a matrix. Nearly all inference time is spent
+   here, and the tutorial begins with the obvious row-by-row implementation.
+
+``rmsnorm``
+   Keeps the residual stream at a useful scale.
+
+``softmax``
+   Turns attention scores into weights which sum to one.
+
+``silu``
+   Supplies the non-linearity in the feed-forward gate.
+
+``rope``
+   Rotates pairs of query and key coordinates to encode token position.
+
+They are ordinary, strongly typed daslang functions. For example, the entire
+matrix multiplication is:
+
+.. code-block:: das
+
+   def matmul(var y : array<float>; w : array<float>#; x : array<float>; n, d : int) {
+       for (row in range(d)) {
+           var sum = 0.0
+           let offset = row * n
+           for (col in range(n)) {
+               sum += w[offset + col] * x[col]
+           }
+           y[row] = sum
+       }
+   }
+
+The small loop invariants are worth naming even in reference code: they make
+the structure clearer and save repeated work in the interpreter. There is
+still an easy performance improvement left for the reader to find.
+
+The checkpoint is already an array
+==================================
+
+A llama2.c checkpoint starts with seven integers describing the model. What
+follows is one flat fp32 array containing embeddings, normalization weights,
+attention matrices, feed-forward matrices, and the classifier.
+
+``fmap`` maps the file, and scoped ``array_view`` blocks present the header as
+``array<int>#`` and the weights as ``array<float>#``. Further views select each
+matrix by element offset:
+
+.. code-block:: das
+
+   array_view(bytes, 28, (length(bytes) - 28) / 4, type<float>) $(model : array<float>#) {
+       array_view(model, offset, n * d) $(matrix : array<float>#) {
+           matmul(out, matrix, input, n, d)
+       }
+   }
+
+The views are borrowed, checked, and confined to their blocks. Loading creates
+no second 60 MB copy and the tutorial needs no ``unsafe`` code. Alignment and
+lifetimes are properties of ``array_view``, not obligations pushed onto the
+transformer.
+
+One token through the model
+===========================
+
+``forward`` is the whole transformer. For each token it:
+
+1. copies the token embedding into the residual stream;
+2. normalizes it and projects query, key, and value;
+3. applies RoPE and appends key and value to the cache;
+4. computes causal self-attention for every head;
+5. projects the attention result and adds the residual;
+6. runs the gated SiLU feed-forward network and adds its residual; and
+7. applies the final normalization and classifier to produce vocabulary
+   logits.
+
+That sequence repeats for six layers. ``most_likely`` selects the largest
+logit, making generation deterministic.
+
+Why there is no prompt
+======================
+
+Token ``1`` is both the beginning-of-sequence token and the sequence delimiter
+used by llama2.c generation. Giving it to the model is enough to begin the
+TinyStories continuation; generation ends when the model emits ``1`` again.
+The checkpoint's sequence length remains the hard safety bound.
+
+Prompting would not change the transformer. It would require the other half of
+the tokenizer—splitting input text and applying its BPE merge scores—which is
+useful code but not part of this problem statement. The tutorial therefore
+loads only the vocabulary pieces needed to turn generated token ids back into
+text. Prompt encoding arrives through the real dasLLAMA API in
+:ref:`tutorial 01 <tutorial_dasLLAMA_hello_generate>`.
+
+From seed to library
+====================
+
+This program deliberately fixes the dimensions, format, precision, execution
+strategy, tokenizer direction, and sampling policy to one tiny model. dasLLAMA
+is what happens when each of those constraints becomes an interface:
+
+* checkpoint layout becomes GGUF metadata and an architecture registry;
+* fp32 matrices become quantized tensor formats and tuned kernels;
+* serial row loops become job-queue work;
+* one-token evaluation gains batched prompt prefill;
+* greedy choice becomes a sampling pipeline;
+* a decoder vocabulary becomes full model-specific tokenization; and
+* scratch arrays become reusable sessions with managed KV caches.
+
+The important part is visible before any of that machinery: a fully functional
+transformer is small enough to read, run, interpret, JIT, and improve in one
+source file. That is the problem dasLLAMA solves at production scale.
+
+.. seealso::
+
+   Full source: :download:`tutorials/dasLLAMA/00_problem_statement.das <../../../../tutorials/dasLLAMA/00_problem_statement.das>`
+
+   Next tutorial: :ref:`tutorial_dasLLAMA_hello_generate`

--- a/doc/source/reference/tutorials/dasLLAMA_01_hello_generate.rst
+++ b/doc/source/reference/tutorials/dasLLAMA_01_hello_generate.rst
@@ -20,7 +20,8 @@ model file on disk (models are not shipped with the repo) — a good tiny one is
 `SmolLM2-135M-Instruct Q8_0
 <https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF>`_ (~145 MB).
 Pass the model path on the command line (or set ``DASLLAMA_MODEL``), and always
-run with ``-jit`` — interpreted inference is far too slow for model work::
+run with ``-jit``. The tuning framework makes the JIT part of dasLLAMA's
+execution model; interpreted and AOT execution are intentionally unsupported::
 
    daslang.exe -jit tutorials/dasLLAMA/01_hello_generate.das -- path/to/SmolLM2-135M-Instruct-Q8_0.gguf
 
@@ -110,4 +111,4 @@ Function                                        Description
 
    Full source: :download:`tutorials/dasLLAMA/01_hello_generate.das <../../../../tutorials/dasLLAMA/01_hello_generate.das>`
 
-   Next tutorial: :ref:`tutorial_dasLLAMA_chat`
+   Previous tutorial: :ref:`tutorial_dasLLAMA_problem_statement` · Next tutorial: :ref:`tutorial_dasLLAMA_chat`

--- a/doc/source/reference/tutorials/dasLLAMA_05_performance.rst
+++ b/doc/source/reference/tutorials/dasLLAMA_05_performance.rst
@@ -18,12 +18,13 @@ and the weight quantization. The tutorial measures all of them with
 Always -jit
 ===========
 
-The kernels are daslang code; the LLVM JIT compiles them to native SIMD.
-Interpreted inference is orders of magnitude slower — never benchmark it.
-``jit_enabled()`` tells you which world you're in. On top of that,
-``options _jit_fast_math = true`` lets the JIT relax FP ordering in the
-kernels (non-bit-exact, roughly +10%) — matching how llama.cpp compiles its
-own; the parity test suite stays bit-exact.
+The kernels are daslang code, and the tuning framework specializes them for
+the current box through the LLVM JIT. This is part of dasLLAMA's execution
+model, not an optional acceleration: interpreted and AOT execution are
+intentionally unsupported. ``jit_enabled()`` verifies that requirement. On
+top of that, ``options _jit_fast_math = true`` lets the JIT relax FP ordering
+in the kernels (non-bit-exact, roughly +10%) — matching how llama.cpp compiles
+its own; the parity test suite stays bit-exact.
 
 Threads: the job queue
 ======================

--- a/doc/source/stdlib/handmade/module-dasllama.rst
+++ b/doc/source/stdlib/handmade/module-dasllama.rst
@@ -15,6 +15,7 @@ K-quant files such as Q4_K_M / Q5_K_M / Q6_K run on native K-quant kernels):
 The architecture is picked from GGUF metadata at load — the same program runs any of these.
 
 Hands-on tutorials (:ref:`overview <tutorials_dasllama>`):
+:ref:`the problem statement <tutorial_dasLLAMA_problem_statement>`,
 :ref:`hello, generation <tutorial_dasLLAMA_hello_generate>`,
 :ref:`chat and templates <tutorial_dasLLAMA_chat>`,
 :ref:`sampling <tutorial_dasLLAMA_sampling>`,

--- a/tests/long_array_table/test_int64_overloads.das
+++ b/tests/long_array_table/test_int64_overloads.das
@@ -147,3 +147,58 @@ def test_array_view_int64(t : T?) {
     t |> equal(observed[1], 300)
     t |> equal(observed[2], 400)
 }
+
+[test]
+def test_array_view_borrowed_subview(t : T?) {
+    let values <- [10, 20, 30, 40]
+    array_view(values, 0, length(values)) $(whole : array<int>#) {
+        array_view(whole, 1, 2) $(middle : array<int>#) {
+            t |> equal(length(middle), 2)
+            t |> equal(middle[0], 20)
+            t |> equal(middle[1], 30)
+        }
+        array_view(whole, length(whole), 0) $(empty : array<int>#) {
+            t |> equal(length(empty), 0)
+        }
+    }
+}
+
+[test]
+def test_array_view_typed_bytes(t : T?) {
+    let bytes <- [
+        uint8(1), uint8(0), uint8(0), uint8(0),
+        uint8(0xFE), uint8(0xFF), uint8(0xFF), uint8(0xFF)
+    ]
+    array_view(bytes, 0, 2, type<int>) $(values : array<int>#) {
+        t |> equal(length(values), 2)
+        t |> equal(values[0], 1)
+        t |> equal(values[1], -2)
+    }
+    array_view(bytes, 0_l, long_length(bytes)) $(borrowed : array<uint8>#) {
+        array_view(borrowed, 4_l, 1_l, type<int>) $(tail : array<int>#) {
+            t |> equal(length(tail), 1)
+            t |> equal(tail[0], -2)
+        }
+    }
+    array_view(bytes, length(bytes), 0, type<int>) $(empty : array<int>#) {
+        t |> equal(length(empty), 0)
+    }
+
+    var unaligned_panicked = false
+    try {
+        array_view(bytes, 1, 1, type<int>) $(_ : array<int>#) {
+        }
+    } recover {
+        unaligned_panicked = true
+    }
+    t |> success(unaligned_panicked, "typed array_view rejects unaligned data")
+
+    var out_of_range_panicked = false
+    try {
+        array_view(bytes, 4, 2, type<int>) $(_ : array<int>#) {
+        }
+    } recover {
+        out_of_range_panicked = true
+    }
+    t |> success(out_of_range_panicked, "typed array_view rejects out-of-range data")
+}

--- a/tutorials/dasLLAMA/00_problem_statement.das
+++ b/tutorials/dasLLAMA/00_problem_statement.das
@@ -1,0 +1,435 @@
+options gen2
+options stack = 65536
+
+require daslib/fio
+require daslib/array_boost
+require math
+require strings
+
+// Tutorial dasLLAMA-00: Problem Statement
+//
+// This file does not use dasLLAMA. It is a complete, if deliberately tiny,
+// Llama-2 inference engine: map a real checkpoint, run the transformer, greedily
+// choose the next token, and print a story.
+//
+// It also tells another story. The first dasLLAMA commit was authored on
+// 2026-06-27. It began with the naive matmul below; about a day later PR #3297
+// contained Llama-2/3, GGUF, quantization, threading, prefill, tests, and chat.
+// That was possible because all the steps from readable script to real machine
+// code could stay in one programming environment.
+//
+// This is the seed, before it became a library.
+//
+// Get the two llama2.c files:
+//   https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
+//   https://raw.githubusercontent.com/karpathy/llama2.c/master/tokenizer.bin
+//
+// Run:
+//   daslang.exe -jit tutorials/dasLLAMA/00_problem_statement.das -- stories15M.bin tokenizer.bin
+//
+// JIT is much faster, but even the interpreter tells this story at about five
+// tokens per second. Try both: the same source runs unchanged in either tier.
+
+// -----------------------------------------------------------------------------
+// The five operations used by a Llama transformer
+// -----------------------------------------------------------------------------
+
+// y = W*x. W has d rows and n columns. Most inference time is spent here.
+def matmul(var y : array<float>; w : array<float>#; x : array<float>; n, d : int) {
+    for (row in range(d)) {
+        var sum = 0.0
+        let offset = row * n
+        for (col in range(n)) {
+            sum += w[offset + col] * x[col]
+        }
+        y[row] = sum
+    }
+}
+
+// RMSNorm keeps the residual stream at a useful scale.
+def rmsnorm(var out : array<float>; x : array<float>; weight : array<float>#; size : int) {
+    var sum = 0.0
+    for (i in range(size)) {
+        let xi = x[i]
+        sum += xi * xi
+    }
+    let scale = 1.0 / sqrt(sum / float(size) + 1e-5)
+    for (i in range(size)) {
+        out[i] = weight[i] * x[i] * scale
+    }
+}
+
+// Softmax turns attention scores into weights which sum to one.
+def softmax(var x : array<float>; size : int) {
+    var largest = x[0]
+    for (i in range(1, size)) {
+        largest = max(largest, x[i])
+    }
+    var sum = 0.0
+    for (i in range(size)) {
+        x[i] = exp(x[i] - largest)
+        sum += x[i]
+    }
+    for (i in range(size)) {
+        x[i] /= sum
+    }
+}
+
+// SiLU is the non-linearity in the feed-forward gate.
+def silu(var x : array<float>; size : int) {
+    for (i in range(size)) {
+        x[i] /= 1.0 + exp(-x[i])
+    }
+}
+
+// RoPE encodes position by rotating pairs of query/key coordinates.
+def rope(var x : array<float>; position, head_size, size : int) {
+    for (pair in range(size / 2)) {
+        let i = pair * 2
+        let frequency = 1.0 / pow(10000.0, float(i % head_size) / float(head_size))
+        let angle = float(position) * frequency
+        let a = x[i]
+        let b = x[i + 1]
+        let sin_angle = sin(angle)
+        let cos_angle = cos(angle)
+        x[i] = a * cos_angle - b * sin_angle
+        x[i + 1] = a * sin_angle + b * cos_angle
+    }
+}
+
+// -----------------------------------------------------------------------------
+// What is in a llama2.c checkpoint
+// -----------------------------------------------------------------------------
+
+struct Config {
+    dim : int
+    hidden_dim : int
+    layers : int
+    heads : int
+    kv_heads : int
+    vocab : int
+    sequence : int
+    head_size : int
+    kv_dim : int
+    shared_classifier : bool
+}
+
+// The checkpoint is one flat fp32 array. These are element offsets, not copies.
+struct Weights {
+    token_embedding : int
+    attention_norm : int
+    query : int
+    key : int
+    value : int
+    attention_output : int
+    ffn_norm : int
+    ffn_gate : int
+    ffn_down : int
+    ffn_up : int
+    final_norm : int
+    classifier : int
+    end : int
+}
+
+def take(var cursor : int&; count : int) : int {
+    let result = cursor
+    cursor += count
+    return result
+}
+
+def weight_layout(c : Config) : Weights {
+    var at = 0
+    var w = Weights(
+        token_embedding = take(at, c.vocab * c.dim),
+        attention_norm = take(at, c.layers * c.dim),
+        query = take(at, c.layers * c.dim * c.dim),
+        key = take(at, c.layers * c.dim * c.kv_dim),
+        value = take(at, c.layers * c.dim * c.kv_dim),
+        attention_output = take(at, c.layers * c.dim * c.dim),
+        ffn_norm = take(at, c.layers * c.dim),
+        ffn_gate = take(at, c.layers * c.dim * c.hidden_dim),
+        ffn_down = take(at, c.layers * c.hidden_dim * c.dim),
+        ffn_up = take(at, c.layers * c.dim * c.hidden_dim),
+        final_norm = take(at, c.dim)
+    )
+    at += c.sequence * c.head_size   // old precomputed RoPE tables; this program computes them
+    w.classifier = c.shared_classifier ? w.token_embedding : take(at, c.vocab * c.dim)
+    w.end = at
+    return w
+}
+
+// Scratch memory is allocated once and reused for every generated token.
+struct State {
+    x : array<float>
+    xb : array<float>
+    xb2 : array<float>
+    hidden : array<float>
+    gate : array<float>
+    query : array<float>
+    key : array<float>
+    value : array<float>
+    attention : array<float>
+    logits : array<float>
+    key_cache : array<float>
+    value_cache : array<float>
+}
+
+def zeros(size : int) : array<float> {
+    var result : array<float>
+    result |> resize(size)
+    return <- result
+}
+
+def make_state(c : Config) : State {
+    return <- State(
+        x <- zeros(c.dim),
+        xb <- zeros(c.dim),
+        xb2 <- zeros(c.dim),
+        hidden <- zeros(c.hidden_dim),
+        gate <- zeros(c.hidden_dim),
+        query <- zeros(c.dim),
+        key <- zeros(c.kv_dim),
+        value <- zeros(c.kv_dim),
+        attention <- zeros(c.sequence),
+        logits <- zeros(c.vocab),
+        key_cache <- zeros(c.layers * c.sequence * c.kv_dim),
+        value_cache <- zeros(c.layers * c.sequence * c.kv_dim)
+    )
+}
+
+// Present a matrix or norm vector inside the flat checkpoint as a borrowed view.
+def project(
+            var out : array<float>;
+            model : array<float>#;
+            offset : int;
+            input : array<float>;
+            n, d : int
+            ) {
+    array_view(model, offset, n * d) $(matrix : array<float>#) {
+        matmul(out, matrix, input, n, d)
+    }
+}
+
+def normalize(
+              var out : array<float>;
+              model : array<float>#;
+              offset : int;
+              input : array<float>;
+              size : int
+              ) {
+    array_view(model, offset, size) $(weight : array<float>#) {
+        rmsnorm(out, input, weight, size)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// One token through the entire transformer
+// -----------------------------------------------------------------------------
+
+def forward(
+            c : Config;
+            w : Weights;
+            model : array<float>#;
+            var s : State;
+            token, position : int
+            ) {
+    let dim = c.dim
+    let kv_multiple = c.heads / c.kv_heads
+    let attention_scale = 1.0 / sqrt(float(c.head_size))
+
+    array_view(model, w.token_embedding + token * dim, dim) $(embedding : array<float>#) {
+        for (i in range(dim)) {
+            s.x[i] = embedding[i]
+        }
+    }
+
+    for (layer in range(c.layers)) {
+        let cache_layer = layer * c.sequence * c.kv_dim
+
+        normalize(s.xb, model, w.attention_norm + layer * dim, s.x, dim)
+        project(s.query, model, w.query + layer * dim * dim, s.xb, dim, dim)
+        project(s.key, model, w.key + layer * dim * c.kv_dim, s.xb, dim, c.kv_dim)
+        project(s.value, model, w.value + layer * dim * c.kv_dim, s.xb, dim, c.kv_dim)
+
+        rope(s.query, position, c.head_size, dim)
+        rope(s.key, position, c.head_size, c.kv_dim)
+
+        let cache_row = cache_layer + position * c.kv_dim
+        for (i in range(c.kv_dim)) {
+            s.key_cache[cache_row + i] = s.key[i]
+            s.value_cache[cache_row + i] = s.value[i]
+        }
+
+        for (head in range(c.heads)) {
+            let query_row = head * c.head_size
+            let cache_head = (head / kv_multiple) * c.head_size
+
+            for (past in range(position + 1)) {
+                let key_row = cache_layer + past * c.kv_dim + cache_head
+                var score = 0.0
+                for (i in range(c.head_size)) {
+                    score += s.query[query_row + i] * s.key_cache[key_row + i]
+                }
+                s.attention[past] = score * attention_scale
+            }
+            softmax(s.attention, position + 1)
+
+            for (i in range(c.head_size)) {
+                s.xb[query_row + i] = 0.0
+            }
+            for (past in range(position + 1)) {
+                let value_row = cache_layer + past * c.kv_dim + cache_head
+                let score = s.attention[past]
+                for (i in range(c.head_size)) {
+                    s.xb[query_row + i] += score * s.value_cache[value_row + i]
+                }
+            }
+        }
+
+        project(s.xb2, model, w.attention_output + layer * dim * dim, s.xb, dim, dim)
+        for (i in range(dim)) {
+            s.x[i] += s.xb2[i]
+        }
+
+        normalize(s.xb, model, w.ffn_norm + layer * dim, s.x, dim)
+        project(s.hidden, model, w.ffn_gate + layer * dim * c.hidden_dim, s.xb, dim, c.hidden_dim)
+        project(s.gate, model, w.ffn_up + layer * dim * c.hidden_dim, s.xb, dim, c.hidden_dim)
+        silu(s.hidden, c.hidden_dim)
+        for (i in range(c.hidden_dim)) {
+            s.hidden[i] *= s.gate[i]
+        }
+        project(s.xb, model, w.ffn_down + layer * c.hidden_dim * dim, s.hidden, c.hidden_dim, dim)
+        for (i in range(dim)) {
+            s.x[i] += s.xb[i]
+        }
+    }
+
+    normalize(s.xb, model, w.final_norm, s.x, dim)
+    project(s.logits, model, w.classifier, s.xb, dim, c.vocab)
+}
+
+def most_likely(logits : array<float>) : int {
+    var best = 0
+    for (i in range(1, length(logits))) {
+        if (logits[i] > logits[best]) {
+            best = i
+        }
+    }
+    return best
+}
+
+// -----------------------------------------------------------------------------
+// Just enough tokenizer to turn generated token ids back into text
+// -----------------------------------------------------------------------------
+
+def read_i32_le(data : array<uint8>#; offset : int) : int {
+    if (offset < 0 || offset + 4 > length(data)) {
+        panic("tokenizer ends inside an int32")
+    }
+    return (
+        int(data[offset])
+        | (int(data[offset + 1]) << 8)
+        | (int(data[offset + 2]) << 16)
+        | (int(data[offset + 3]) << 24)
+    )
+}
+
+def load_pieces(path : string; count : int) : array<string> {
+    var pieces : array<string>
+    let file = fopen(path, "rb")
+    if (file == null) {
+        panic("cannot open tokenizer '{path}'")
+    }
+    fmap(file) $(var data : array<uint8>#) {
+        var cursor = 4   // max_token_length, unused by decoding
+        for (_ in range(count)) {
+            cursor += 4 // merge score, used by encoding but not decoding
+            let size = read_i32_le(data, cursor)
+            cursor += 4
+            array_view(data, cursor, size) $(piece : array<uint8>#) {
+                pieces |> push(string(piece))
+            }
+            cursor += size
+        }
+    }
+    fclose(file)
+    return <- pieces
+}
+
+def token_text(pieces : array<string>; previous, token : int) : string {
+    let text = pieces[token]
+    if (length(text) == 6 && starts_with(text, "<0x") && ends_with(text, ">")) {
+        return string([uint8(to_int(slice(text, 1, 5), true))])
+    }
+    if (previous == 1 && !empty(text) && first_character(text) == ' ') {
+        return slice(text, 1)
+    }
+    return text
+}
+
+// -----------------------------------------------------------------------------
+// Map the checkpoint and let token 1 (BOS and sequence delimiter) become a story
+// -----------------------------------------------------------------------------
+
+def tell_story(model_path, tokenizer_path : string) {
+    let file = fopen(model_path, "rb")
+    if (file == null) {
+        panic("cannot open model '{model_path}'")
+    }
+
+    fmap(file) $(var bytes : array<uint8>#) {
+        if (length(bytes) < 28) {
+            panic("checkpoint is smaller than its seven-int header")
+        }
+        array_view(bytes, 0, 7, type<int>) $(header : array<int>#) {
+            let signed_vocab = header[5]
+            let c = Config(
+                dim = header[0],
+                hidden_dim = header[1],
+                layers = header[2],
+                heads = header[3],
+                kv_heads = header[4],
+                vocab = abs(signed_vocab),
+                sequence = header[6],
+                head_size = header[0] / header[3],
+                kv_dim = header[0] * header[4] / header[3],
+                shared_classifier = signed_vocab > 0
+            )
+            let w = weight_layout(c)
+            if (length(bytes) < 28 + w.end * 4) {
+                panic("checkpoint ends before its declared weights")
+            }
+            array_view(bytes, 28, (length(bytes) - 28) / 4, type<float>) $(model : array<float>#) {
+                let pieces <- load_pieces(tokenizer_path, c.vocab)
+                var state <- make_state(c)
+
+                print("dim={c.dim}, layers={c.layers}, heads={c.heads}, parameters≈{w.end}\n\n")
+                let delimiter = 1
+                var token = delimiter
+                for (position in range(c.sequence)) {
+                    forward(c, w, model, state, token, position)
+                    let next = most_likely(state.logits)
+                    if (next == delimiter) {
+                        break
+                    }
+                    fprint(fstdout(), token_text(pieces, token, next))
+                    fflush(fstdout())
+                    token = next
+                }
+                print("\n")
+            }
+        }
+    }
+    fclose(file)
+}
+
+[export]
+def main() {
+    let args <- get_command_line_arguments()
+    let paths <- [for (arg in args); arg; where ends_with(arg, ".bin")]
+    if (length(paths) < 2) {
+        print("usage: daslang -jit tutorials/dasLLAMA/00_problem_statement.das -- stories15M.bin tokenizer.bin\n")
+        return
+    }
+    tell_story(paths[length(paths) - 2], paths[length(paths) - 1])
+}


### PR DESCRIPTION
## Summary
- add Tutorial 0: a self-contained, strongly typed Llama-2/TinyStories inference engine with no dasLLAMA dependency
- add safe scoped borrowed and typed byte `array_view` overloads, plus alignment and bounds tests
- add the companion RST and link it into the dasLLAMA tutorial and reference chain
- clarify that Tutorial 0 supports interpreter and JIT while dasLLAMA proper intentionally requires JIT

## Validation
- full repository preflight: 13 passed, 0 failed (environment/tooling skips only)
- complete TinyStories generation under `-jit -jit-no-cache`
- `14 tests, 14 passed` for `tests/long_array_table/test_int64_overloads.das`