### PR TITLE
dasLLAMA: multi-model live serving - GPU slot switching, control page, per-model config

### DIFF
--- a/examples/telegram/dictation/dictation.toml
+++ b/examples/telegram/dictation/dictation.toml
@@ -9,6 +9,11 @@
 # (asr = in the SERVER's config), or the bot exits at startup with a clear error.
 server = "http://127.0.0.1:8080"
 
+# Served model to pin chat requests to — one of the ids GET /v1/models lists (a multi-model
+# server serves several). Verified at startup; a typo fails there, not on the first voice note.
+# Empty = the server's default slot.
+model = ""
+
 # Telegram bot token from @BotFather. Leave empty to read TELEGRAM_BOT_TOKEN from the environment.
 bot_token = ""
 

--- a/examples/telegram/dictation/main.das
+++ b/examples/telegram/dictation/main.das
@@ -47,6 +47,7 @@ struct DictationArgs {
 
 struct DictationConfig {
     server : string = "http://127.0.0.1:8080"   // dasllama-server base URL (needs asr = in ITS config)
+    model : string = ""               // served model to pin requests to ("" = the server's default slot)
     bot_token : string                // Telegram bot token (TELEGRAM_BOT_TOKEN env overrides)
     prompt : string = ""              // legacy name for dictation_prompt
     dictation_prompt : string = ""    // transcript-repair prompt; \{language\} or \{lang\} is replaced
@@ -162,6 +163,7 @@ struct CadmusToolDefinition {
 }
 
 struct CadmusChatRequest {
+    @optional model : string          // routes to that server slot; omitted = the default slot
     temperature : float
     top_k : int
     top_p : float
@@ -310,6 +312,7 @@ def load_config(path : string; var err : string&) : DictationConfig {
         return cfg
     }
     cfg.server        = js?["server"] ?? cfg.server
+    cfg.model         = js?["model"] ?? cfg.model
     cfg.bot_token     = js?["bot_token"] ?? cfg.bot_token
     cfg.prompt        = js?["prompt"] ?? cfg.prompt
     cfg.dictation_prompt = js?["dictation_prompt"] ?? cfg.dictation_prompt
@@ -651,6 +654,7 @@ def private server_complete(
                             var tool_calls : array<CadmusToolCall>&
                             ) : bool {
     var request_body = CadmusChatRequest(
+        model = g_cfg.model,
         temperature = settings.temperature,
         top_k = settings.top_k,
         top_p = settings.top_p,
@@ -2095,6 +2099,8 @@ def poll_once(var offset : int64&; timeout : int) {
 
 // The server must be up AND have an ASR model loaded (asr = in ITS config) — /v1/models lists a
 // "<model>-asr" entry when it does. A clear startup error beats a 404 on the first voice note.
+// With a multi-model server, `model =` in the bot config pins requests to that slot; the pin is
+// verified against the served ids here so a typo fails at startup, not on the first voice note.
 def private check_server(var out_llm : string&; var out_asr : bool&; var err : string&) : bool {
     var ok = false
     GET("{g_cfg.server}/v1/models") $(resp) {
@@ -2108,21 +2114,38 @@ def private check_server(var out_llm : string&; var out_asr : bool&; var err : s
             if (js == null) {
                 err = "bad /v1/models JSON: {perr}"
             } else {
+                var ids : array<string>
                 let data = js?["data"]
                 if (data != null && data is _array) {
                     for (m in data as _array) {
                         let mid : string = m?["id"] ?? ""
                         if (ends_with(mid, "-asr")) {
                             out_asr = true
-                        } elif (empty(out_llm)) {
-                            out_llm = mid
+                        } else {
+                            ids |> push(mid)
                         }
                     }
                 }
-                ok = !empty(out_llm)
-                if (!ok) {
-                    err = "dasllama-server at {g_cfg.server} lists no model"
+                if (empty(g_cfg.model)) {
+                    out_llm = !empty(ids) ? ids[0] : ""
+                    ok = !empty(out_llm)
+                    if (!ok) {
+                        err = "dasllama-server at {g_cfg.server} lists no model"
+                    }
+                } else {
+                    for (mid in ids) {
+                        if (mid == g_cfg.model) {
+                            ok = true
+                        }
+                    }
+                    if (ok) {
+                        out_llm = g_cfg.model
+                    } else {
+                        err = ("model '{g_cfg.model}' is not served at {g_cfg.server} — " +
+                               "/v1/models lists: {join(ids, ", ")}")
+                    }
                 }
+                delete ids
                 unsafe {
                     delete js
                 }

--- a/examples/telegram/dictation/main.das
+++ b/examples/telegram/dictation/main.das
@@ -2115,19 +2115,25 @@ def private check_server(var out_llm : string&; var out_asr : bool&; var err : s
                 err = "bad /v1/models JSON: {perr}"
             } else {
                 var ids : array<string>
+                var asr_id = ""
                 let data = js?["data"]
                 if (data != null && data is _array) {
                     for (m in data as _array) {
                         let mid : string = m?["id"] ?? ""
                         if (ends_with(mid, "-asr")) {
                             out_asr = true
+                            asr_id = mid
                         } else {
                             ids |> push(mid)
                         }
                     }
                 }
                 if (empty(g_cfg.model)) {
-                    out_llm = !empty(ids) ? ids[0] : ""
+                    // unpinned requests route to the server's DEFAULT slot, which need not be
+                    // first in the list — but the "-asr" id is advertised for the default slot
+                    // only, so its stem names the slot unpinned chat actually lands on
+                    let def_id = !empty(asr_id) ? slice(asr_id, 0, length(asr_id) - 4) : ""
+                    out_llm = !empty(def_id) ? def_id : (!empty(ids) ? ids[0] : "")
                     ok = !empty(out_llm)
                     if (!ok) {
                         err = "dasllama-server at {g_cfg.server} lists no model"

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2027,6 +2027,29 @@ def resident_plan(t : Model; seq_cap : int64; kdt, vdt : KVDtype) : ResidentPlan
 var private g_rdec_active = false       // this loaded model runs the resident decode driver
 var private g_rdec_cnt = 0l             // cached positions in the device KV mirror (built as we decode)
 var private g_rdec_cap = 0l             // mirror context the driver armed at (<= model ctx when VRAM-capped)
+var private g_rdec_gen = 0l             // mirror ownership generation (bumped per resident prefill)
+var private g_resident_prefill_allowed = true   // multi-stream schedulers pin this off (see set_resident_prefill_allowed)
+
+//! Allow/forbid the whole-prefill resident override. A multi-stream scheduler (dasllama-server)
+//! pins it OFF: the single shared mirror + chunked prefill would leave device-only KV that a
+//! second stream's steal strands. Single-session tools keep the fast path (default on).
+def set_resident_prefill_allowed(allowed : bool) {
+    g_resident_prefill_allowed = allowed
+}
+
+// Bulk-hydrate the session's host KV from the device mirror rows [0, g_rdec_cnt) — the rail that
+// keeps host KV authoritative at rest after device-resident prefills/decodes.
+def private rdec_hydrate_host(t : Model; var s : Session) {
+    let c = t.config
+    for (l in range64(c.n_layers)) {
+        unsafe {
+            rdec_read_kv_bulk(l, reinterpret<float?>(kv_layer_kbase(s, l, c.seq_len)),
+                reinterpret<float?>(kv_layer_vbase(s, l, c.seq_len)), g_rdec_cnt)
+        }
+    }
+    s.rdec_hydrated = true
+    to_log(LOG_INFO, "dasLLAMA: resident KV hydrated to host ({g_rdec_cnt} positions x {c.n_layers} layers)\n")
+}
 let private RDEC_MIN_CTX = 4096l        // smallest ctx worth arming a capped mirror at
 
 // gather one prepared plane into device-layout bytes and place it in its format's arena; returns
@@ -2079,6 +2102,10 @@ def resident_upload(var t : Model; seq_cap : int64) : bool {
     let hs = layer_head_size(c, 0l)
     let qd = layer_qd(c, 0l)
     let kvd = layer_kv_dim(c, 0l)
+    // the prefill Q-tile attention kernel's geometry (da_attn_b: 32-dim lanes, hs-strided staging)
+    if (hs % 32l != 0l || hs > 256l) {
+        return false
+    }
     let neox = c.rope_neox
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     // reject non-uniform per-layer geometry (the recorder assumes fixed dims across layers)
@@ -2183,11 +2210,16 @@ def private vulkan_resident_decode(t : Model; var s : Session; token, pos : int6
     if (!g_rdec_active || pos > g_rdec_cnt) {
         return false
     }
-    if (pos + 1l > g_rdec_cap) {
-        // once the device path has run the mirror is the ONLY KV — capacity exhaustion fails closed
-        if (g_rdec_cnt > 0l) {
-            panic("dasLLAMA resident decode: position {pos} exceeds the device KV mirror capacity {g_rdec_cap} and host KV was never populated — reduce context or set DASLLAMA_PIN_PREFILL=cpu")
+    // ownership guard: the single mirror holds ONE session's rows (superseded => host has ours)
+    if (s.rdec_gen != g_rdec_gen) {
+        if (s.rdec_gen != 0l && !s.rdec_hydrated) {
+            panic("dasLLAMA resident decode: session's mirror rows were superseded before hydration — engine bug (the steal path must hydrate first)")
         }
+        return false
+    }
+    if (pos + 1l > g_rdec_cap) {
+        // capacity exhausted: hydrate host KV from the mirror, then the CPU rails take over
+        rdec_hydrate_host(t, s)
         return false
     }
     let c = t.config
@@ -2220,6 +2252,7 @@ def private vulkan_resident_decode(t : Model; var s : Session; token, pos : int6
     delete x
     delete cossin
     g_rdec_cnt = pos + 1l   // mirror continuity: rows [0, pos] are now live
+    s.rdec_hydrated = false   // the mirror advanced past any earlier hydration
     decode_override_logits_done()   // logits produced on device
     return true
 }
@@ -2263,23 +2296,26 @@ def resident_prefill(t : Model; var s : Session; tokens : array<int64>; npos : i
     return true
 }
 
-// The "vulkan" whole-prefill override (PrefillOverrideFn): one-submit device prefill via the resident
-// driver. KV lands in the DEVICE f32 mirror only (arming also selects the mirror-based resident
-// decode); v1 takes full prompts only — continuation chunks (start_pos != 0) decline to the CPU loop.
+// The "vulkan" whole-prefill override (PrefillOverrideFn): one-submit device prefill via the
+// resident driver. The mirror gets the rows; host KV is hydrated back on demand (continuation,
+// cap exhaustion) so the CPU rails always take over from a valid host authority.
 def private vulkan_resident_prefill(t : Model; var s : Session; npos, start_pos : int64) : bool {
-    if (!g_rdec_active) {
+    // gates: armed + embedder-allowed + the hydratable flat-f32 shape (else device would hold the only KV copy)
+    if (!g_rdec_active || !g_resident_prefill_allowed
+            || s.kv_dtype_k != KVDtype.f32 || s.kv_dtype_v != KVDtype.f32 || s.kv_pool != null) {
         return false
     }
     if (start_pos != 0l) {
-        // a continuation over device-held history has no valid CPU fallback (host KV is empty)
-        if (g_rdec_cnt > 0l) {
-            panic("dasLLAMA resident prefill: continuation at start_pos {start_pos} over device-held KV — host KV was never populated (set DASLLAMA_PIN_PREFILL=cpu for continuation flows)")
+        // continuation over OUR device-held history: hydrate host KV, then decline to the CPU loop
+        if (g_rdec_cnt > 0l && s.rdec_gen == g_rdec_gen && !s.rdec_hydrated) {
+            rdec_hydrate_host(t, s)
         }
         return false
     }
     if (npos > g_rdec_cap) {
         return false
     }
+    // a DIFFERENT session's re-prefill steals the single mirror — fine for serial flows; a stranded owner's decode fails LOUD via the ownership guard
     let c = t.config
     let hs = layer_head_size(c, 0l)
     let half = hs / 2l
@@ -2300,6 +2336,9 @@ def private vulkan_resident_prefill(t : Model; var s : Session; npos, start_pos 
     rdec_prefill(s.x_b, cb, npos, s.logits)
     delete cb
     g_rdec_cnt = npos   // the mirror now holds [0, npos) — the decode's continuity witness
+    g_rdec_gen ++
+    s.rdec_gen = g_rdec_gen
+    s.rdec_hydrated = false
     prefill_override_logits_done()
     return true
 }
@@ -4287,6 +4326,10 @@ struct Session {
     // their source layer's slab (same prefix value).
     kv_dtype_k : KVDtype      // key codec, snapshotted from the module knob in make_run_state
     kv_dtype_v : KVDtype      // value codec (independent of K by design)
+    // resident-driver mirror ownership: gen stamps which session's rows the device KV mirror
+    // holds (0 = never resident-prefilled); hydrated = host KV has been read back since
+    rdec_gen : int64
+    rdec_hydrated : bool
     kv_signs : array<float>   // tq4 rotation signs (±1, max head_size; smaller heads use a prefix)
     key_cache : array<uint8>
     value_cache : array<uint8>

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2419,6 +2419,88 @@ def resident_driver_register() {
     register_prefill_override("vulkan", @@vulkan_resident_prefill)
 }
 
+// ===== multi-model GPU slot switch (marks swap + whole-model drop/re-arm) =====
+
+//! One model's complete per-model tier state for a multi-model host: the loader-contract marks
+//! plus the resident driver's activation. Save after the model's load (or arm), restore before
+//! stepping that model — two models' offset-keyed marks must never be installed together.
+struct GpuModelMarks {
+    marks : MoeGpuMarks <- MoeGpuMarks()
+    rdec_active : bool
+    rdec_cnt : int64
+    rdec_cap : int64
+}
+
+//! Move the INSTALLED per-model tier state out into `st`; the globals read as no-model after.
+def moe_gpu_model_marks_save(var st : GpuModelMarks) {
+    moe_gpu_marks_save(st.marks)
+    st.rdec_active = g_rdec_active
+    st.rdec_cnt = g_rdec_cnt
+    st.rdec_cap = g_rdec_cap
+    g_rdec_active = false
+    g_rdec_cnt = 0l
+    g_rdec_cap = 0l
+}
+
+//! Install `st` as the per-model tier state (the save's inverse; `st` reads as no-model after).
+def moe_gpu_model_marks_restore(var st : GpuModelMarks) {
+    moe_gpu_marks_restore(st.marks)
+    g_rdec_active = st.rdec_active
+    g_rdec_cnt = st.rdec_cnt
+    g_rdec_cap = st.rdec_cap
+    st.rdec_active = false
+    st.rdec_cnt = 0l
+    st.rdec_cap = 0l
+}
+
+//! Is the resident whole-stack decode driver active for the INSTALLED model? (The arm-outcome
+//! discriminator status surfaces read: resident beats rails beats cpu.)
+def moe_gpu_resident_active() : bool => g_rdec_active
+
+//! Hydrate `s`'s host KV from the device mirror when `s` owns live mirror rows (no-op
+//! otherwise). Call over every live session of the outgoing model before ``moe_gpu_drop_model``
+//! — the drop destroys the mirror, and an unhydrated owner's rows exist nowhere else.
+def moe_gpu_hydrate_session(t : Model; var s : Session) {
+    if (g_rdec_active && g_rdec_cnt > 0l && s.rdec_gen == g_rdec_gen && !s.rdec_hydrated) {
+        rdec_hydrate_host(t, s)
+    }
+}
+
+//! Drop the INSTALLED model's whole GPU state (every model-owned device object + the routing
+//! marks); the model keeps serving on the CPU rails, and re-arm = the same three calls a load
+//! runs. Caller guarantees quiescence: no step in flight, sessions hydrated first.
+def moe_gpu_drop_model() {
+    if (!moe_gpu_tier_installed()) {
+        return
+    }
+    moe_gpu_dn_invalidate()
+    g_rdec_active = false
+    g_rdec_cnt = 0l
+    g_rdec_cap = 0l
+    // resident_upload selected the "vulkan" overrides; deselect so (a) a later re-arm's
+    // resident_upload passes its no-active-override gate (the warm re-arm decline), and (b) a
+    // dropped model's prefill/decode take the plain CPU path without consulting dead state
+    if (active_prefill_override() == "vulkan") {
+        select_prefill_override("")
+    }
+    if (active_decode_override() == "vulkan") {
+        select_decode_override("")
+    }
+    moe_gpu_drop_model_state()
+    // loader-contract reset — the same clean slate moe_gpu_upload_resident starts from
+    set_moe_gpu_layer_count(0l)
+    set_moe_gpu_from_layer(1000000l)
+    set_moe_gpu_stream_from(1000000l)
+    set_moe_gpu_total_layers(0l)
+    set_moe_gpu_cls_off(-1l)
+    reset_moe_gpu_dense_offs()
+    reset_moe_gpu_dn_layers()
+    reset_moe_gpu_attn_layers()
+    reset_moe_gpu_shexp_layers()
+    reset_moe_gpu_qkv_layers()
+    set_moe_gpu_model_support("")
+}
+
 // Upload the offloaded layers' expert stacks to the GPU tier from the PREPARED planes. Called at
 // the end of every load rail so DASLLAMA_GPU_MOE_LAYERS behaves identically however the model
 // arrived. Layers go resident from the end while the tier's VRAM budget holds.

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1810,6 +1810,96 @@ def public set_moe_gpu_qkv_route(on : bool) {
     g_moe_gpu_qkv_route = on
 }
 
+// ===== per-model mark sets + whole-model drop (multi-model hosts) =====
+// The loader-contract marks are keyed by WEIGHT ELEMENT OFFSETS and two models' offset spaces
+// overlap — a multi-model host must swap the whole set per switch or funnels read wrong planes.
+
+//! One loaded model's tier routing marks — everything the loader contract sets per load.
+//! A multi-model host saves these after each load and restores them before stepping that model.
+struct MoeGpuMarks {
+    layer_count : int64
+    from_layer : int64 = 1000000l
+    stream_from : int64 = 1000000l
+    total_layers : int64
+    cls_off : int64 = -1l
+    dense_offs : table<int64>
+    dn_layers : table<int64; int64>
+    attn_layers : table<int64>
+    shexp_layers : table<int64>
+    qkv_layers : table<int64>
+    unsupported : string
+}
+
+//! Move the installed marks out into `m`; the globals read as no-marks after (routing gates —
+//! the process-wide A/B levers — stay put).
+def public moe_gpu_marks_save(var m : MoeGpuMarks) {
+    m.layer_count = g_moe_gpu_layer_count
+    m.from_layer = g_moe_gpu_from_layer
+    m.stream_from = g_moe_gpu_stream_from
+    m.total_layers = g_moe_gpu_total_layers
+    m.cls_off = g_moe_gpu_cls_off
+    m.dense_offs <- g_moe_gpu_dense_offs
+    m.dn_layers <- g_moe_gpu_dn_layers
+    m.attn_layers <- g_moe_gpu_attn_layers
+    m.shexp_layers <- g_moe_gpu_shexp_layers
+    m.qkv_layers <- g_moe_gpu_qkv_layers
+    m.unsupported = g_moe_gpu_unsupported
+    g_moe_gpu_layer_count = 0l
+    g_moe_gpu_from_layer = 1000000l
+    g_moe_gpu_stream_from = 1000000l
+    g_moe_gpu_total_layers = 0l
+    g_moe_gpu_cls_off = -1l
+    g_moe_gpu_unsupported = ""
+}
+
+//! Does a saved mark set carry any armed state? A multi-model host uses this to attribute a
+//! load's arm outcome to the slot that captured it — the process-global VRAM counter cannot
+//! tell WHOSE planes are resident.
+def public moe_gpu_marks_armed(m : MoeGpuMarks) : bool {
+    return (!empty(m.dense_offs) || !empty(m.dn_layers) || !empty(m.attn_layers)
+        || !empty(m.shexp_layers) || !empty(m.qkv_layers) || m.cls_off >= 0l
+        || (m.total_layers > 0l && (m.from_layer < m.total_layers || m.stream_from < m.total_layers)))
+}
+
+//! Install `m` as the global marks (moves the tables in; `m` reads as no-marks after).
+def public moe_gpu_marks_restore(var m : MoeGpuMarks) {
+    g_moe_gpu_layer_count = m.layer_count
+    g_moe_gpu_from_layer = m.from_layer
+    g_moe_gpu_stream_from = m.stream_from
+    g_moe_gpu_total_layers = m.total_layers
+    g_moe_gpu_cls_off = m.cls_off
+    g_moe_gpu_dense_offs <- m.dense_offs
+    g_moe_gpu_dn_layers <- m.dn_layers
+    g_moe_gpu_attn_layers <- m.attn_layers
+    g_moe_gpu_shexp_layers <- m.shexp_layers
+    g_moe_gpu_qkv_layers <- m.qkv_layers
+    g_moe_gpu_unsupported = m.unsupported
+    m.layer_count = 0l
+    m.from_layer = 1000000l
+    m.stream_from = 1000000l
+    m.total_layers = 0l
+    m.cls_off = -1l
+    m.unsupported = ""
+}
+
+typedef MoeGpuDropModelFn = function<() : void>
+
+def private moe_gpu_noop_drop_model() {}
+
+var g_moe_gpu_drop_model = @@moe_gpu_noop_drop_model
+
+//! Tier registration of the whole-model VRAM drop (beside install_moe_gpu_tier).
+def public set_moe_gpu_drop_model_hook(f : MoeGpuDropModelFn) {
+    g_moe_gpu_drop_model = f
+}
+
+//! Destroy every model-owned device object the tier holds (stacks, arenas, the resident
+//! driver, all lazy dispatch state); device-lifetime state survives and rebuilds lazily.
+//! Callers use dasllama_common's ``moe_gpu_drop_model``, which also resets the marks.
+def public moe_gpu_drop_model_state() {
+    invoke(g_moe_gpu_drop_model)
+}
+
 //! One attention layer's q/k/v decode projections on the tier — one submit, one shared
 //! activation image (the three planes must share a quant class), results copied back per plane.
 def public matmul_gpu_qkv(var yq : array<float>; var yk : array<float>; var yv : array<float>;

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1441,6 +1441,7 @@ typedef RdecTokenFn = function<(x : array<float>; cossin : array<float>; pos : i
 typedef RdecPrefillFn = function<(x_batch : array<float>; cos_batch : array<float>; npos : int64; var logits : array<float>) : void>
 typedef RdecSyncKvFn = function<(l : int64; kp : float const?; vp : float const?; npos : int64) : void>
 typedef RdecReadKvFn = function<(l : int64; pos : int64; kp : float?; vp : float?) : void>
+typedef RdecReadKvBulkFn = function<(l : int64; kp : float?; vp : float?; npos : int64) : void>
 
 [unused_argument(fmt, cap_blocks)]
 def private rdec_unset_reserve(fmt : int; cap_blocks : int64) : bool => false
@@ -1466,6 +1467,10 @@ def private rdec_unset_prefill(x_batch : array<float>; cos_batch : array<float>;
 def private rdec_unset_sync(l : int64; kp : float const?; vp : float const?; npos : int64) {}
 [unused_argument(l, pos, kp, vp)]
 def private rdec_unset_read(l, pos : int64; kp : float?; vp : float?) {}
+[unused_argument(l, kp, vp, npos)]
+def private rdec_unset_read_bulk(l : int64; kp : float?; vp : float?; npos : int64) {
+    panic("dasLLAMA: resident KV bulk readback hit without an installed GPU driver")
+}
 
 var g_rdec_reserve = @@rdec_unset_reserve
 var g_rdec_place = @@rdec_unset_place
@@ -1477,13 +1482,15 @@ var g_rdec_token = @@rdec_unset_token
 var g_rdec_prefill = @@rdec_unset_prefill
 var g_rdec_sync_kv = @@rdec_unset_sync
 var g_rdec_read_kv = @@rdec_unset_read
+var g_rdec_read_kv_bulk = @@rdec_unset_read_bulk
 var g_rdec_installed = false
 
 //! Install the resident whole-stack decode driver (a GPU backend calls this at [init]).
 def public install_moe_gpu_resident(reserve : RdecReserveFn; place : RdecPlaceFn; prepare : RdecPrepareFn;
                                     norms : RdecNormsFn; set_layer : RdecSetLayerFn; set_cls : RdecSetClsFn;
                                     token : RdecTokenFn; prefill : RdecPrefillFn;
-                                    sync_kv : RdecSyncKvFn; read_kv : RdecReadKvFn) {
+                                    sync_kv : RdecSyncKvFn; read_kv : RdecReadKvFn;
+                                    read_kv_bulk : RdecReadKvBulkFn) {
     g_rdec_reserve = reserve
     g_rdec_place = place
     g_rdec_prepare = prepare
@@ -1494,6 +1501,7 @@ def public install_moe_gpu_resident(reserve : RdecReserveFn; place : RdecPlaceFn
     g_rdec_prefill = prefill
     g_rdec_sync_kv = sync_kv
     g_rdec_read_kv = read_kv
+    g_rdec_read_kv_bulk = read_kv_bulk
     g_rdec_installed = true
 }
 
@@ -1508,6 +1516,7 @@ def public rdec_token(x : array<float>; cossin : array<float>; pos, cnt : int64;
 def public rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int64; var logits : array<float>) { invoke(g_rdec_prefill, x_batch, cos_batch, npos, logits) }
 def public rdec_sync_kv(l : int64; kp : float const?; vp : float const?; npos : int64) { invoke(g_rdec_sync_kv, l, kp, vp, npos) }
 def public rdec_read_kv(l, pos : int64; kp : float?; vp : float?) { invoke(g_rdec_read_kv, l, pos, kp, vp) }
+def public rdec_read_kv_bulk(l : int64; kp : float?; vp : float?; npos : int64) { invoke(g_rdec_read_kv_bulk, l, kp, vp, npos) }
 
 //! Install the GPU MoE tier (a GPU backend calls this at [init] when its device probe passes).
 def public install_moe_gpu_tier(ffn : MoeGpuFfnFn; upload : MoeGpuUploadFn; cls : MoeGpuClsFn; dense : MoeGpuDenseFn; drop : MoeGpuDropFn; dn : MoeGpuDnFn; attn : MoeGpuAttnFn) {

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -2864,6 +2864,10 @@ struct private GpuState {
     ffn_pend_bytes : int64
     qkv_cmds : table<int64; QkvCmd>   // q plane offset -> the layer's decode q/k/v group
     dev_mem : table<uint64; uint64>   // device buffer -> its VkDeviceMemory (rollback destroy needs it)
+    host_mem : table<uint64; uint64>  // host-visible buffer -> memory: every make_host_buf result except
+                                      // the process-lifetime pair (staging, profiler readback) — the
+                                      // whole-model drop sweeps this
+    model_cmds : array<VkCommandBuffer>   // every alloc_cmd result — freed together at model drop
     // FFN mid-chain state (lazy — first FFN dispatch creates it)
     hq_dev : uint64          // device requantized-hidden quants (the down GEMM's activation image)
     hs_dev : uint64          // ... its scales
@@ -2994,6 +2998,7 @@ def private make_host_buf(bytes : int64; storage : bool; cached : bool = false) 
     unsafe {
         vk_check(vkMapMemory(dev_raw(), boost_value_to_vk(m), 0ul, uint64(bytes), mf, addr(mapped)), null)
     }
+    g_gpu.host_mem |> insert(b._vk, m._vk)
     return HostBuf(buf = b._vk, mem = m._vk, mapped = mapped, bytes = bytes)
 }
 
@@ -3030,6 +3035,7 @@ def private destroy_host_buf(hb : HostBuf) {   // vkFreeMemory implicitly unmaps
         vkDestroyBuffer(dev_raw(), reinterpret<VkBuffer>(hb.buf), null)
         vkFreeMemory(dev_raw(), reinterpret<VkDeviceMemory>(hb.mem), null)
     }
+    g_gpu.host_mem |> erase(hb.buf)
 }
 
 def private nonowning_buf(h : uint64) : Buffer {
@@ -3206,6 +3212,7 @@ def private vk_moe_init : bool {
     var fence <- create_fence(g_gpu.device, FenceCreateInfo())   // never finalized (process-lifetime)
     g_gpu.fence = boost_value_to_vk(fence)
     g_gpu.staging = make_host_buf(STAGING_BYTES, false)
+    g_gpu.host_mem |> erase(g_gpu.staging.buf)   // process-lifetime — exempt from the model-drop sweep
     g_init_failed = false
     to_log(LOG_INFO, "dasLLAMA vulkan tier: device ready (subgroup {int(sg)}, {g_gpu.rows_per_wg} rows/wg)\n")
     if (dasllama_noisy()) {
@@ -3377,6 +3384,79 @@ def vk_moe_drop_stacks(n : int; stream : bool) {
         destroy_device_buf(g_gpu.stacks[k].wsbuf)
         g_gpu.stacks |> resize(k)
     }
+}
+
+//! MoeGpuDropModelFn: destroy every model-owned device object — stacks, arenas, the resident
+//! driver, all lazy dispatch state, their descriptor sets and command buffers. Device-lifetime
+//! state (instance/device/pipelines/staging/fence/profiler) survives and rebuilds lazily.
+def vk_drop_model_state {
+    if (g_gpu == null) {
+        return
+    }
+    vk_check(vkQueueWaitIdle(g_gpu.queue), null)
+    assert(g_gpu.ffn_pend_s2 == -1, "dasLLAMA vulkan tier: model drop with an async FFN in flight")
+    // the resident driver's das-side shell first (its VK objects die in the sweeps below)
+    if (g_rd != null) {
+        unsafe {
+            delete g_rd
+        }
+        g_rd = null
+    }
+    // every alloc_cmd result is model-owned — one bulk free
+    if (!empty(g_gpu.model_cmds)) {
+        unsafe {
+            vkFreeCommandBuffers(dev_raw(), boost_value_to_vk(g_gpu.pool), uint(length(g_gpu.model_cmds)), addr(g_gpu.model_cmds[0]))
+        }
+        g_gpu.model_cmds |> clear()
+    }
+    // every descriptor set came from the one pool and every one is model-owned
+    let rdpf : VkDescriptorPoolResetFlags
+    vk_check(vkResetDescriptorPool(dev_raw(), boost_value_to_vk(g_gpu.desc_pool), rdpf), null)
+    // device buffers: dev_mem tracks every make_device_buf result — all model-owned
+    for (buf, mem in keys(g_gpu.dev_mem), values(g_gpu.dev_mem)) {
+        unsafe {
+            vkDestroyBuffer(dev_raw(), reinterpret<VkBuffer>(buf), null)
+            vkFreeMemory(dev_raw(), reinterpret<VkDeviceMemory>(mem), null)
+        }
+    }
+    g_gpu.dev_mem |> clear()
+    // host-visible buffers: host_mem tracks every make_host_buf result minus the exempt pair
+    for (buf, mem in keys(g_gpu.host_mem), values(g_gpu.host_mem)) {
+        unsafe {
+            vkDestroyBuffer(dev_raw(), reinterpret<VkBuffer>(buf), null)
+            vkFreeMemory(dev_raw(), reinterpret<VkDeviceMemory>(mem), null)
+        }
+    }
+    g_gpu.host_mem |> clear()
+    // das-side shells + the lazy-family latches (the ensure_* paths rebuild on next use).
+    // clear(), not delete, where values carry VK handles — nothing das-heap-owned lives inside
+    // those structs, and delete would try to finalize the handle fields
+    g_gpu.stacks |> clear()
+    delete g_gpu.stream_stacks
+    delete g_gpu.stream_slots
+    g_gpu.arenas |> clear()
+    g_gpu.ffn_cmds |> clear()
+    g_gpu.qkv_cmds |> clear()
+    g_gpu.dnd_steps |> clear()
+    delete g_gpu.heat_pools
+    g_gpu.stream_max_gu_wq = 0l
+    g_gpu.stream_max_gu_ws = 0l
+    g_gpu.stream_max_dn_wq = 0l
+    g_gpu.stream_max_dn_ws = 0l
+    g_gpu.ar_ready = false
+    g_gpu.af_ready = false
+    g_gpu.rks_ready = false
+    g_gpu.da_ready = false
+    g_gpu.ffn_ready = false
+    g_gpu.batch_ready = false
+    g_gpu.comb_ready = false
+    g_gpu.stream_ready = false
+    g_gpu.dn_ready = false
+    g_gpu.dnd_ready = false
+    g_gpu.at_ready = false
+    g_gpu.ffn_pend_s2 = -1
+    g_gpu.ffn_pend_bytes = 0l
+    g_gpu.resident_bytes = 0l
 }
 
 // ===== dispatch plumbing =====
@@ -4122,6 +4202,7 @@ def private ensure_pfq {
     g_pfq_period = lp.limits.timestampPeriod
     g_pfq_pool <- create_query_pool(g_gpu.device, QueryPoolCreateInfo(queryType = VkQueryType.TIMESTAMP, queryCount = PFQ_CAP))
     g_pfq_buf = make_host_buf(int64(PFQ_CAP) * 8l, true, [cached = true])
+    g_gpu.host_mem |> erase(g_pfq_buf.buf)   // process-lifetime — exempt from the model-drop sweep
     g_pfq_ready = true
 }
 
@@ -4723,6 +4804,7 @@ def private alloc_cmd : VkCommandBuffer {
     unsafe {
         vk_check(vkAllocateCommandBuffers(dev_raw(), ai, addr(raw)), null)
     }
+    g_gpu.model_cmds |> push(raw)   // all persistent cmds are model-owned; freed by the model drop
     return raw
 }
 
@@ -6620,5 +6702,6 @@ def dasllama_math_vulkan_register() {
     set_moe_gpu_dn_state_hooks(@@vk_dn_step_flush, @@vk_dn_step_invalidate)
     set_moe_gpu_heat_hooks(@@vk_moe_heat_query, @@vk_moe_heat_advise, @@vk_moe_ffn_begin, @@vk_moe_ffn_join)
     set_moe_gpu_qkv_hook(@@vk_moe_qkv)
+    set_moe_gpu_drop_model_hook(@@vk_drop_model_state)
     vulkan_moe_gpu_arm()
 }

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -1507,13 +1507,13 @@ def rope_kv_store {
     }
 }
 
-// decode attention (one query row): one wg/head, GQA head->kv-head, reads the f32 K/V mirror (K
-// vk_wsf, V vk_xqf). 3 phases (scores+max, exp+sum, thread c owns out dim c) dodge a per-position
-// barrier. Low-occupancy — split-K next. meta 0=cnt 2=kvd 3=hs 4=kv_mul; scale vk_xs[0].
+// decode attention (one query row): one wg/head, GQA, f32 K/V mirror (K vk_wsf, V vk_xqf).
+// Online softmax over 256-position chunks (running max/denom, alpha-rescaled V accumulators) —
+// shared use is chunk-sized, ANY cnt works. meta 0=cnt 2=kvd 3=hs 4=kv_mul; scale vk_xs[0].
 var @workgroup da_q : float[256]      // this head's query row (hs <= 256)
-var @workgroup da_sc : float[4096]    // per-position scores (DA_MAX_CNT)
+var @workgroup da_sc : float[256]     // chunk scores, then the cross-group V partial reduce
 var @workgroup da_part : float[64]    // per-subgroup partials — 64 covers subgroupSize >= 4 (was [8], OOB on subgroupSize < 32, e.g. Intel 16)
-var @workgroup da_ml : float[2]       // [0] = row max, [1] = softmax denom
+var @workgroup da_ml : float[2]       // [0] = running max, [1] = running softmax denom
 
 [compute_shader(local_size_x=256, name="da_attn_spv")]
 def da_attn {
@@ -1527,165 +1527,238 @@ def da_attn {
     let h = gl_WorkGroupID.x
     let kvh = h / kv_mul
     let tid = gl_LocalInvocationID.x
+    let npart = 256u / hs     // V-phase partial groups; thread tid = group g, output dim c
+    let g = tid / hs
+    let c = tid % hs
     var i = tid
     while (i < hs) {
         da_q[i] = vk_upf[h * hs + i]
         i += 256u
     }
-    barrier()
-    // phase 1: scores + running max (per thread over a strided set of positions)
-    var tmax = -3.0e38
-    var j = tid
-    while (j < cnt) {
-        var s = 0.0
-        var d = 0u
-        while (d < hs) {
-            s += da_q[d] * vk_wsf[kbase + j * kvd + kvh * hs + d]
-            d++
-        }
-        s *= scale
-        da_sc[j] = s
-        tmax = max(tmax, s)
-        j += 256u
-    }
-    tmax = subgroupMax(tmax)
-    if (gl_SubgroupInvocationID == 0u) {
-        da_part[gl_SubgroupID] = tmax
-    }
-    barrier()
     if (tid == 0u) {
-        var m = -3.0e38
-        var sgi = 0u
-        while (sgi < gl_NumSubgroups) {
-            m = max(m, da_part[sgi])
-            sgi++
+        da_ml[1u] = 0.0
+    }
+    barrier()
+    var acc = 0.0             // this thread's V partial (group g's slice of dim c)
+    var mrun = -3.0e38        // running max — uniform, tracked in lockstep by every thread
+    var c0 = 0u
+    while (c0 < cnt) {
+        let clen = min(256u, cnt - c0)
+        // chunk scores: thread tid owns position c0 + tid
+        var s = -3.0e38
+        if (tid < clen) {
+            var sv = 0.0
+            var d = 0u
+            while (d < hs) {
+                sv += da_q[d] * vk_wsf[kbase + (c0 + tid) * kvd + kvh * hs + d]
+                d++
+            }
+            s = sv * scale
         }
-        da_ml[0u] = m
-    }
-    barrier()
-    let m = da_ml[0u]
-    // phase 2: exp in place + running sum
-    var tsum = 0.0
-    j = tid
-    while (j < cnt) {
-        let e = exp(da_sc[j] - m)
-        da_sc[j] = e
-        tsum += e
-        j += 256u
-    }
-    tsum = subgroupAdd(tsum)
-    if (gl_SubgroupInvocationID == 0u) {
-        da_part[gl_SubgroupID] = tsum
-    }
-    barrier()
-    if (tid == 0u) {
-        var l = 0.0
-        var sgi = 0u
-        while (sgi < gl_NumSubgroups) {
-            l += da_part[sgi]
-            sgi++
+        let tmax = subgroupMax(s)
+        if (gl_SubgroupInvocationID == 0u) {
+            da_part[gl_SubgroupID] = tmax
         }
-        da_ml[1u] = l
+        barrier()
+        if (tid == 0u) {
+            var m = mrun
+            var sgi = 0u
+            while (sgi < gl_NumSubgroups) {
+                m = max(m, da_part[sgi])
+                sgi++
+            }
+            da_ml[0u] = m
+        }
+        barrier()
+        let mnew = da_ml[0u]
+        let alpha = exp(mrun - mnew)
+        mrun = mnew
+        // exp + chunk sum; denom rescale rides the same alpha
+        let e = tid < clen ? exp(s - mnew) : 0.0
+        da_sc[tid] = e
+        let tsum = subgroupAdd(e)
+        if (gl_SubgroupInvocationID == 0u) {
+            da_part[gl_SubgroupID] = tsum
+        }
+        barrier()
+        if (tid == 0u) {
+            var lsum = 0.0
+            var sgi = 0u
+            while (sgi < gl_NumSubgroups) {
+                lsum += da_part[sgi]
+                sgi++
+            }
+            da_ml[1u] = da_ml[1u] * alpha + lsum
+        }
+        // V accumulate: group g strides the chunk, rescaled by this chunk's alpha
+        acc *= alpha
+        if (tid < npart * hs) {
+            var jj = g
+            while (jj < clen) {
+                acc += da_sc[jj] * vk_xqf[vbase + (c0 + jj) * kvd + kvh * hs + c]
+                jj += npart
+            }
+        }
+        barrier()   // da_sc/da_part settle before the next chunk overwrites them
+        c0 += 256u
     }
+    // cross-group reduce (da_sc reused as the partial slab: slot tid == g * hs + c)
+    da_sc[tid] = acc
     barrier()
-    let linv = 1.0 / da_ml[1u]
-    // phase 3: thread c owns output dim c, weighted V sum over all positions
     if (tid < hs) {
-        var acc = 0.0
-        var jj = 0u
-        while (jj < cnt) {
-            acc += da_sc[jj] * vk_xqf[vbase + jj * kvd + kvh * hs + tid]
-            jj++
+        let linv = 1.0 / da_ml[1u]
+        var tot = 0.0
+        var gg = 0u
+        while (gg < npart) {
+            tot += da_sc[gg * hs + tid]
+            gg++
         }
-        vk_y[h * hs + tid] = acc * linv
+        vk_y[h * hs + tid] = tot * linv
     }
 }
 
-// batched causal decode attention (prefill): one workgroup per (query row p, head h). Query p
-// attends positions 0..p (causal). Same 3-phase online softmax as da_attn; q rows from vk_upf
-// ([npos x qd]), out to vk_y. meta 0=npos 2=kvd 3=hs 4=kv_mul 5=kbase 6=vbase; scale vk_xs[0].
+// batched causal attention (prefill), flash-style Q tile: one wg per (head, 8-query tile), // nolint:STYLE014
+// 32-position shared K/V tiles (V reuses the K staging), per-row online softmax, lane c owns dims
+// c + 32*jj. Needs hs % 32 == 0, <= 256 (resident_plan gates); reduce order differs from the row
+// kernel so the parity bar is IDS. meta 0=window rows 1=nh 2=kvd 3=hs 4=kv_mul 5=kbase 6=vbase
+// 7=w0 (window base — queries attend mirror positions [0, w0+row]); scale vk_xs[0].
 [compute_shader(local_size_x=256, name="da_attn_b_spv")]
 def da_attn_b {
+    let npos = vk_meta[0u]
+    let nh = vk_meta[1u]
     let kvd = vk_meta[2u]
     let hs = vk_meta[3u]
     let kv_mul = vk_meta[4u]
     let kbase = vk_meta[5u]
     let vbase = vk_meta[6u]
+    let w0 = vk_meta[7u]
     let scale = vk_xs[0u]
-    let nh = (vk_meta[1u])
-    let p = gl_WorkGroupID.x / nh
-    let h = gl_WorkGroupID.x % nh
-    let cnt = p + 1u          // causal: query p sees positions 0..p
-    let kvh = h / kv_mul
+    let qd = nh * hs
+    let dpl = hs / 32u
+    let qtiles = (npos + 7u) / 8u
+    let h = gl_WorkGroupID.x / qtiles
+    let q0 = (gl_WorkGroupID.x % qtiles) * 8u
     let tid = gl_LocalInvocationID.x
+    let r = tid / 32u
+    let c = tid % 32u
+    let kvh = h / kv_mul
     var i = tid
-    while (i < hs) {
-        da_q[i] = vk_upf[p * (nh * hs) + h * hs + i]
+    while (i < 8u * hs) {
+        let qr = q0 + i / hs
+        fa_q[i] = qr < npos ? vk_upf[qr * qd + h * hs + i % hs] : 0.0
         i += 256u
     }
+    if (tid < 8u) {
+        fa_m[tid] = -3.0e38
+        fa_l[tid] = 0.0
+    }
+    var o0 = 0.0
+    var o1 = 0.0
+    var o2 = 0.0
+    var o3 = 0.0
+    var o4 = 0.0
+    var o5 = 0.0
+    var o6 = 0.0
+    var o7 = 0.0
     barrier()
-    var tmax = -3.0e38
-    var j = tid
-    while (j < cnt) {
+    let gq = w0 + q0 + r
+    let kend = w0 + min(q0 + 8u, npos)   // causal bound (exclusive) of the tile's last valid row
+    var k0 = 0u
+    while (k0 < kend) {
+        i = tid
+        while (i < 32u * hs) {
+            let kr = k0 + i / hs
+            fa_kv[(i / hs) * 257u + i % hs] = kr < kend ? vk_wsf[kbase + kr * kvd + kvh * hs + i % hs] : 0.0
+            i += 256u
+        }
+        barrier()
         var s = 0.0
-        var d = 0u
-        while (d < hs) {
-            s += da_q[d] * vk_wsf[kbase + j * kvd + kvh * hs + d]
-            d++
+        var j = 0u
+        while (j < hs) {   // 4-wide manual unroll (hs % 32 == 0)
+            s += fa_q[r * hs + j] * fa_kv[c * 257u + j]
+            s += fa_q[r * hs + j + 1u] * fa_kv[c * 257u + j + 1u]
+            s += fa_q[r * hs + j + 2u] * fa_kv[c * 257u + j + 2u]
+            s += fa_q[r * hs + j + 3u] * fa_kv[c * 257u + j + 3u]
+            j += 4u
         }
-        s *= scale
-        da_sc[j] = s
-        tmax = max(tmax, s)
-        j += 256u
-    }
-    tmax = subgroupMax(tmax)
-    if (gl_SubgroupInvocationID == 0u) {
-        da_part[gl_SubgroupID] = tmax
-    }
-    barrier()
-    if (tid == 0u) {
-        var m = -3.0e38
-        var sgi = 0u
-        while (sgi < gl_NumSubgroups) {
-            m = max(m, da_part[sgi])
-            sgi++
+        let gk = k0 + c
+        fa_p[r * 32u + c] = (gk <= gq && q0 + r < npos) ? s * scale : -3.0e38
+        barrier()
+        if (tid < 8u) {   // per-row online-softmax update: max, rescale, exponentiate in place
+            var mt = fa_m[tid]
+            var j2 = 0u
+            while (j2 < 32u) {
+                mt = max(mt, fa_p[tid * 32u + j2])
+                j2++
+            }
+            let alpha = exp(fa_m[tid] - mt)
+            var lsum = 0.0
+            j2 = 0u
+            while (j2 < 32u) {
+                let e = exp(fa_p[tid * 32u + j2] - mt)
+                fa_p[tid * 32u + j2] = e
+                lsum += e
+                j2++
+            }
+            fa_l[tid] = fa_l[tid] * alpha + lsum
+            fa_m[tid] = mt
+            fa_a[tid] = alpha
         }
-        da_ml[0u] = m
-    }
-    barrier()
-    let m = da_ml[0u]
-    var tsum = 0.0
-    j = tid
-    while (j < cnt) {
-        let e = exp(da_sc[j] - m)
-        da_sc[j] = e
-        tsum += e
-        j += 256u
-    }
-    tsum = subgroupAdd(tsum)
-    if (gl_SubgroupInvocationID == 0u) {
-        da_part[gl_SubgroupID] = tsum
-    }
-    barrier()
-    if (tid == 0u) {
-        var l = 0.0
-        var sgi = 0u
-        while (sgi < gl_NumSubgroups) {
-            l += da_part[sgi]
-            sgi++
+        barrier()
+        let av = fa_a[r]
+        o0 *= av
+        if (dpl > 1u) {
+            o1 *= av
         }
-        da_ml[1u] = l
+        if (dpl > 2u) {
+            o2 *= av
+            o3 *= av
+        }
+        if (dpl > 4u) {
+            o4 *= av
+            o5 *= av
+            o6 *= av
+            o7 *= av
+        }
+        i = tid
+        while (i < 32u * hs) {   // V tile reuses the K staging (all K reads completed above)
+            let kr = k0 + i / hs
+            fa_kv[(i / hs) * 257u + i % hs] = kr < kend ? vk_xqf[vbase + kr * kvd + kvh * hs + i % hs] : 0.0
+            i += 256u
+        }
+        barrier()
+        var c2 = 0u
+        while (c2 < 32u) {
+            let pw = fa_p[r * 32u + c2]
+            let vb = c2 * 257u + c
+            o0 += pw * fa_kv[vb]
+            if (dpl > 1u) {
+                o1 += pw * fa_kv[vb + 32u]
+            }
+            if (dpl > 2u) {
+                o2 += pw * fa_kv[vb + 64u]
+                o3 += pw * fa_kv[vb + 96u]
+            }
+            if (dpl > 4u) {
+                o4 += pw * fa_kv[vb + 128u]
+                o5 += pw * fa_kv[vb + 160u]
+                o6 += pw * fa_kv[vb + 192u]
+                o7 += pw * fa_kv[vb + 224u]
+            }
+            c2++
+        }
+        barrier()
+        k0 += 32u
     }
-    barrier()
-    let linv = 1.0 / da_ml[1u]
-    if (tid < hs) {
-        var acc = 0.0
+    if (q0 + r < npos) {
+        let inv = 1.0 / fa_l[r]
+        let ob = (q0 + r) * qd + h * hs + c
         var jj = 0u
-        while (jj < cnt) {
-            acc += da_sc[jj] * vk_xqf[vbase + jj * kvd + kvh * hs + tid]
+        while (jj < dpl) {
+            vk_y[ob + jj * 32u] = (jj == 0u ? o0 : (jj == 1u ? o1 : (jj == 2u ? o2 : (jj == 3u ? o3
+                : (jj == 4u ? o4 : (jj == 5u ? o5 : (jj == 6u ? o6 : o7))))))) * inv
             jj++
         }
-        vk_y[p * (nh * hs) + h * hs + tid] = acc * linv
     }
 }
 
@@ -3604,6 +3677,7 @@ def vk_device_ready() : bool => vk_moe_init()
 let private RKS_MAX_QD = 8_192l
 let private RKS_MAX_KVD = 1_024l
 let private RKS_MAX_CTX = 4_096l   // K/V mirror rows in the standalone-kernel scratch
+let private KV_READBACK_ROWS = 256l   // bulk mirror->host hydration chunk (rows per submit)
 
 def private ensure_rks_state {
     if (g_gpu.rks_ready) {
@@ -3630,7 +3704,6 @@ def private ensure_rks_state {
     g_gpu.rks_ready = true
 }
 
-let private DA_MAX_CNT = 4_096l   // == da_sc workgroup slab
 
 def private ensure_da_state {
     if (g_gpu.da_ready) {
@@ -3659,7 +3732,7 @@ def private ensure_da_state {
 //! the device K/V mirror (the same planes vk_rope_kv_store wrote), GQA per kv_mul, into out[0..qd).
 def vk_decode_attn(var q : array<float>; var out : array<float>; cnt, qd, kv_dim, head_size, kv_mul : int64; scale : float) {
     verify(vk_moe_init())
-    assert(cnt <= DA_MAX_CNT && head_size <= 256l && qd <= RKS_MAX_QD, "dasLLAMA vulkan: decode-attn geometry over scratch")
+    assert(head_size <= 256l && qd <= RKS_MAX_QD, "dasLLAMA vulkan: decode-attn geometry over scratch")
     ensure_da_state()
     let n_heads = qd / head_size
     unsafe {
@@ -3803,7 +3876,7 @@ struct private RDec {
     pf_cmd : VkCommandBuffer
 }
 
-let private PF_MAX_NPOS = 512l
+let private PF_WINDOW = 512l   // prefill activation-buffer rows; longer prompts run as sequential windows
 
 var private g_rd : RDec?
 
@@ -3873,7 +3946,7 @@ def vk_rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab
     r.dummy = make_device_buf(256l)
     r.x_host = make_host_buf(dim * 4l, false, [cached = true])
     r.logits_host = make_host_buf(vocab * 4l, false, [cached = true])
-    r.kv_readback = make_host_buf(2l * kv_dim * 4l, false, [cached = true])
+    r.kv_readback = make_host_buf(2l * kv_dim * 4l * KV_READBACK_ROWS, false, [cached = true])
     ensure_ffn_state()   // hq_dev/hs_dev for the FFN act+requant
     r.cmd = alloc_cmd()
     return true
@@ -4203,7 +4276,7 @@ def private pf_setup {
     if (g_rd.pf_ready) {
         return
     }
-    let np = PF_MAX_NPOS
+    let np = PF_WINDOW
     g_rd.pf_np = np
     let dim = g_rd.dim
     let qd = g_rd.qd
@@ -4306,6 +4379,33 @@ def vk_rdec_sync_kv(l : int64; kp : float const?; vp : float const?; npos : int6
     }
 }
 
+//! Bulk hydration: read layer `l`'s mirror rows [0, npos) into the caller's f32 cache (kp/vp,
+//! [npos x kvd] each), one submit per KV_READBACK_ROWS rows. The host-KV-authoritative rail —
+//! makes continuations, CPU fallback, and slot switches valid after a device-resident prefill.
+def vk_rdec_read_kv_bulk(l : int64; kp : float?; vp : float?; npos : int64) {
+    assert(g_rd != null, "vk_rdec_read_kv_bulk before prepare")
+    verify(vk_moe_init())
+    let kvd = g_rd.kv_dim
+    var p0 = 0l
+    while (p0 < npos) {
+        let rows = min(KV_READBACK_ROWS, npos - p0)
+        let bytes = rows * kvd * 4l
+        let off = ((l * g_rd.seq_cap) + p0) * kvd * 4l
+        unsafe {
+            var raw = alloc_cmd()
+            let begin = VkCommandBufferBeginInfo()
+            vk_check(vkBeginCommandBuffer(raw, begin), null)
+            cmd_copy_range(raw, g_rd.k_mirror, off, g_rd.kv_readback.buf, 0l, bytes)
+            cmd_copy_range(raw, g_rd.v_mirror, off, g_rd.kv_readback.buf, bytes, bytes)
+            vk_check(vkEndCommandBuffer(raw), null)
+            submit_wait(raw)
+            memcpy(reinterpret<void?>(kp + p0 * kvd), g_rd.kv_readback.mapped, int(bytes))
+            memcpy(reinterpret<void?>(vp + p0 * kvd), reinterpret<uint8?>(g_rd.kv_readback.mapped) + bytes, int(bytes))
+        }
+        p0 += rows
+    }
+}
+
 //! Batch-decode writeback: read layer `l`'s new K/V row at `pos` from the mirror back into the
 //! caller's f32 cache row (kp/vp, kvd each). Keeps the CPU cache current after a GPU decode step.
 def vk_rdec_read_kv(l, pos : int64; kp : float?; vp : float?) {
@@ -4330,9 +4430,7 @@ def vk_rdec_read_kv(l, pos : int64; kp : float?; vp : float?) {
 //! (cos_batch, [npos x hs]) -> the last row's logits, filling the KV mirror at positions [0, npos).
 def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int64; var logits : array<float>) {
     assert(g_rd != null && g_rd.ready, "vk_rdec_prefill before prepare/set_cls")
-    assert(npos <= PF_MAX_NPOS, "vk_rdec_prefill: npos over PF_MAX_NPOS")
     pf_setup()
-    let tp0 = ref_time_ticks()
     let dim = g_rd.dim
     let qd = g_rd.qd
     let kvd = g_rd.kv_dim
@@ -4346,92 +4444,107 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
         sp[0] = g_rd.eps
         sp[1] = 1.0
         staged_upload(g_rd.ar_scal_dev, 0l, 64l)
-        upload_region_at(g_rd.pf_x, 0l, addr<uint8 const?>(x_batch[0]), npos * dim * 4l)
-        upload_region_at(g_rd.pf_cos, 0l, addr<uint8 const?>(cos_batch[0]), npos * g_rd.head_size * 4l)
-        fill_ffn_meta(hid, npos * hid / 32l, false)   // actrq over all npos rows
-        // fill metas
-        let mA = @(idx : int; n, d, blk : int64; fmt : int) {
-            fill_arena_batch_meta(g_rd.pf_meta[idx], n, d, blk, npos, fmt)
-        }
-        let mQ = @(idx : int; blocks : int64) { fill_quant_meta(g_rd.pf_meta[idx], blocks) }
-        let mR = @(idx : int; woff : int64; add : bool) { fill_addrms_meta(g_rd.pf_meta[idx], dim, woff, add) }
-        for (l in range64(g_rd.n_layers)) {
-            var L & = g_rd.layers[l]
-            let b = int(l * PF_ROLES)
-            invoke(mQ, b + 0, npos * dim / 32l)
-            invoke(mA, b + 1, dim, qd, L.bq, L.fq)
-            invoke(mA, b + 2, dim, kvd, L.bk, L.fk)
-            invoke(mA, b + 3, dim, kvd, L.bv, L.fv)
-            var mr = reinterpret<uint?>(g_rd.pf_meta[b + 4].mapped)
-            mr[0] = uint(qd); mr[1] = uint(kvd); mr[2] = uint(g_rd.head_size); mr[3] = uint(g_rd.head_size / 2l)
-            mr[4] = g_rd.neox ? 1u : 0u; mr[5] = uint(qd / 2l); mr[6] = uint(pairs)
-            mr[7] = uint(l * g_rd.seq_cap * kvd); mr[9] = uint(npos); mr[10] = 0u; mr[11] = uint(npos * kvd)
-            var ma = reinterpret<uint?>(g_rd.pf_meta[b + 5].mapped)
-            ma[1] = uint(g_rd.n_heads); ma[2] = uint(kvd); ma[3] = uint(g_rd.head_size); ma[4] = uint(g_rd.kv_mul)
-            ma[5] = uint(l * g_rd.seq_cap * kvd); ma[6] = uint(l * g_rd.seq_cap * kvd)
-            invoke(mQ, b + 6, npos * qd / 32l)
-            invoke(mA, b + 7, qd, dim, L.bo, L.fo)
-            invoke(mR, b + 8, (l * 2l + 1l) * dim, true)
-            invoke(mQ, b + 9, npos * dim / 32l)
-            invoke(mA, b + 10, dim, hid, L.b1, L.f1)
-            invoke(mA, b + 11, dim, hid, L.b3, L.f3)
-            invoke(mA, b + 13, hid, dim, L.b2, L.f2)
-            let nxt = l + 1l < g_rd.n_layers ? (l + 1l) * 2l * dim : nlfin
-            invoke(mR, b + 14, nxt, true)
-        }
-        let bp = int(g_rd.n_layers * PF_ROLES)
-        invoke(mR, bp + 0, 0l, false)   // prologue norm
-        // final quantize reads the LAST row of pf_xb
-        var mf = reinterpret<uint?>(g_rd.pf_meta[bp + 1].mapped)
-        mf[10] = uint((npos - 1l) * dim); mf[18] = uint(dim / 32l)
-        let t_prep = get_time_usec(tp0)
-        // record
-        var raw = g_rd.pf_cmd
-        let rf : VkCommandBufferResetFlags
-        vk_check(vkResetCommandBuffer(raw, rf), null)
-        let begin = VkCommandBufferBeginInfo()
-        vk_check(vkBeginCommandBuffer(raw, begin), null)
-        pfq_begin(raw)
-        pfq_ts(raw)   // q0: submit start
-        cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-        comp_barrier(raw)
-        pfq_ts(raw)   // q1: meta copy
-        let ropewg = uint((npos * pairs + int64(WG_X) - 1l) / int64(WG_X))
-        let attnwg = uint(npos * g_rd.n_heads)
-        rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(npos))   // prologue norm
-        for (l in range64(g_rd.n_layers)) {
-            let b = int(l * PF_ROLES)
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((npos * dim / 32l + 255l) / 256l))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, npos, 0))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, npos, 0))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, npos, 0))
-            cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, npos * kvd * 4l, npos * kvd * 4l)   // v into pf_kv's v half
+        // prompts over the PF_WINDOW activation buffers run as sequential windows: each window's
+        // rope/attention address the mirror at absolute positions, so window w attends everything
+        // [0, w0 + row] the earlier windows stored. Only the last window runs fin_rq + cls.
+        var w0 = 0l
+        while (w0 < npos) {
+            let tp0 = ref_time_ticks()
+            let wlen = min(g_rd.pf_np, npos - w0)
+            let last = w0 + wlen >= npos
+            upload_region_at(g_rd.pf_x, 0l, addr<uint8 const?>(x_batch[int(w0 * dim)]), wlen * dim * 4l)
+            upload_region_at(g_rd.pf_cos, 0l, addr<uint8 const?>(cos_batch[int(w0 * g_rd.head_size)]), wlen * g_rd.head_size * 4l)
+            fill_ffn_meta(hid, wlen * hid / 32l, false)   // actrq over the window's rows
+            // fill metas
+            let mA = @(idx : int; n, d, blk : int64; fmt : int) {
+                fill_arena_batch_meta(g_rd.pf_meta[idx], n, d, blk, wlen, fmt)
+            }
+            let mQ = @(idx : int; blocks : int64) { fill_quant_meta(g_rd.pf_meta[idx], blocks) }
+            let mR = @(idx : int; woff : int64; add : bool) { fill_addrms_meta(g_rd.pf_meta[idx], dim, woff, add) }
+            for (l in range64(g_rd.n_layers)) {
+                var L & = g_rd.layers[l]
+                let b = int(l * PF_ROLES)
+                invoke(mQ, b + 0, wlen * dim / 32l)
+                invoke(mA, b + 1, dim, qd, L.bq, L.fq)
+                invoke(mA, b + 2, dim, kvd, L.bk, L.fk)
+                invoke(mA, b + 3, dim, kvd, L.bv, L.fv)
+                var mr = reinterpret<uint?>(g_rd.pf_meta[b + 4].mapped)
+                mr[0] = uint(qd); mr[1] = uint(kvd); mr[2] = uint(g_rd.head_size); mr[3] = uint(g_rd.head_size / 2l)
+                mr[4] = g_rd.neox ? 1u : 0u; mr[5] = uint(qd / 2l); mr[6] = uint(pairs)
+                mr[7] = uint(l * g_rd.seq_cap * kvd); mr[9] = uint(wlen); mr[10] = uint(w0); mr[11] = uint(wlen * kvd)
+                var ma = reinterpret<uint?>(g_rd.pf_meta[b + 5].mapped)
+                ma[0] = uint(wlen); ma[1] = uint(g_rd.n_heads); ma[2] = uint(kvd); ma[3] = uint(g_rd.head_size); ma[4] = uint(g_rd.kv_mul)
+                ma[5] = uint(l * g_rd.seq_cap * kvd); ma[6] = uint(l * g_rd.seq_cap * kvd); ma[7] = uint(w0)
+                invoke(mQ, b + 6, wlen * qd / 32l)
+                invoke(mA, b + 7, qd, dim, L.bo, L.fo)
+                invoke(mR, b + 8, (l * 2l + 1l) * dim, true)
+                invoke(mQ, b + 9, wlen * dim / 32l)
+                invoke(mA, b + 10, dim, hid, L.b1, L.f1)
+                invoke(mA, b + 11, dim, hid, L.b3, L.f3)
+                invoke(mA, b + 13, hid, dim, L.b2, L.f2)
+                let nxt = l + 1l < g_rd.n_layers ? (l + 1l) * 2l * dim : nlfin
+                invoke(mR, b + 14, nxt, true)
+            }
+            let bp = int(g_rd.n_layers * PF_ROLES)
+            invoke(mR, bp + 0, 0l, false)   // prologue norm
+            if (last) {
+                // final quantize reads the LAST row of pf_xb
+                var mf = reinterpret<uint?>(g_rd.pf_meta[bp + 1].mapped)
+                mf[10] = uint((wlen - 1l) * dim); mf[18] = uint(dim / 32l)
+            }
+            let t_prep = get_time_usec(tp0)
+            // record
+            var raw = g_rd.pf_cmd
+            let rf : VkCommandBufferResetFlags
+            vk_check(vkResetCommandBuffer(raw, rf), null)
+            let begin = VkCommandBufferBeginInfo()
+            vk_check(vkBeginCommandBuffer(raw, begin), null)
+            pfq_begin(raw)
+            pfq_ts(raw)   // q0: submit start
+            cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
             comp_barrier(raw)
-            rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg)
-            rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg)
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((npos * qd / 32l + 255l) / 256l))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, npos, 0))
-            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(npos))
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((npos * dim / 32l + 255l) / 256l))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, npos, 0))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, npos, 0))
-            rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((npos * hid / 32l + 255l) / 256l))
-            rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, npos, 0))
-            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(npos))
+            pfq_ts(raw)   // q1: meta copy
+            let ropewg = uint((wlen * pairs + int64(WG_X) - 1l) / int64(WG_X))
+            let attnwg = uint(g_rd.n_heads * ((wlen + 7l) / 8l))
+            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(wlen))   // prologue norm
+            for (l in range64(g_rd.n_layers)) {
+                let b = int(l * PF_ROLES)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0))
+                cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
+                comp_barrier(raw)
+                rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg)
+                rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0))
+                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen))
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0))
+                rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l))
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0))
+                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen))
+            }
+            if (last) {
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[bp + 1], uint((dim / 32l + 255l) / 256l))
+                rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab))
+                cmd_copy_whole(raw, g_rd.logits_dev, g_rd.pf_logits_host.buf, g_rd.vocab * 4l)
+            }
+            pfq_end(raw)
+            vk_check(vkEndCommandBuffer(raw), null)
+            let t_record = get_time_usec(tp0) - t_prep
+            submit_wait(raw)
+            if (vk_prof()) {
+                to_log(LOG_INFO, "vk_rdpf w0 {w0} rows {wlen} prep {t_prep} record {t_record} submit {get_time_usec(tp0) - t_prep - t_record}\n")
+            }
+            w0 += wlen
         }
-        rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[bp + 1], uint((dim / 32l + 255l) / 256l))
-        rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab))
-        cmd_copy_whole(raw, g_rd.logits_dev, g_rd.pf_logits_host.buf, g_rd.vocab * 4l)
-        pfq_end(raw)
-        vk_check(vkEndCommandBuffer(raw), null)
-        let t_record = get_time_usec(tp0) - t_prep
-        submit_wait(raw)
         memcpy(addr<void?>(logits[0]), g_rd.pf_logits_host.mapped, int(g_rd.vocab * 4l))
-        if (vk_prof()) {
-            to_log(LOG_INFO, "vk_rdpf prep {t_prep} record {t_record} submit {get_time_usec(tp0) - t_prep - t_record}\n")
-        }
         // per-role GPU aggregation: q0 start, q1 meta, q2 prologue, then 15/layer, final rq, cls —
-        // only when every stamp landed (a >135-layer graph would overflow PFQ_CAP and truncate)
+        // only when every stamp landed (a >135-layer graph would overflow PFQ_CAP and truncate).
+        // Multi-window prompts: the stamps cover the LAST window only (the one with fin_rq + cls).
         if (vk_prof() && g_pfq_n == 5u + uint(g_rd.n_layers * 15l)) {
             var role : double[15]
             for (l in range64(g_rd.n_layers)) {
@@ -6503,7 +6616,7 @@ def dasllama_math_vulkan_register() {
     set_moe_gpu_budget_hooks(@@vk_weight_budget, @@vk_plane_bytes)
     install_moe_gpu_resident(@@vk_arena_reserve, @@vk_arena_place, @@vk_rdec_prepare,
         @@vk_rdec_upload_norms, @@vk_rdec_set_layer, @@vk_rdec_set_cls, @@vk_rdec_token, @@vk_rdec_prefill,
-        @@vk_rdec_sync_kv, @@vk_rdec_read_kv)
+        @@vk_rdec_sync_kv, @@vk_rdec_read_kv, @@vk_rdec_read_kv_bulk)
     set_moe_gpu_dn_state_hooks(@@vk_dn_step_flush, @@vk_dn_step_invalidate)
     set_moe_gpu_heat_hooks(@@vk_moe_heat_query, @@vk_moe_heat_advise, @@vk_moe_ffn_begin, @@vk_moe_ffn_join)
     set_moe_gpu_qkv_hook(@@vk_moe_qkv)

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4468,12 +4468,12 @@ def vk_rdec_read_kv_bulk(l : int64; kp : float?; vp : float?; npos : int64) {
     verify(vk_moe_init())
     let kvd = g_rd.kv_dim
     var p0 = 0l
+    var raw = alloc_transient_cmd()   // re-recorded per chunk (the pool allows reset), freed below
     while (p0 < npos) {
         let rows = min(KV_READBACK_ROWS, npos - p0)
         let bytes = rows * kvd * 4l
         let off = ((l * g_rd.seq_cap) + p0) * kvd * 4l
         unsafe {
-            var raw = alloc_cmd()
             let begin = VkCommandBufferBeginInfo()
             vk_check(vkBeginCommandBuffer(raw, begin), null)
             cmd_copy_range(raw, g_rd.k_mirror, off, g_rd.kv_readback.buf, 0l, bytes)
@@ -4485,6 +4485,7 @@ def vk_rdec_read_kv_bulk(l : int64; kp : float?; vp : float?; npos : int64) {
         }
         p0 += rows
     }
+    free_transient_cmd(raw)
 }
 
 //! Batch-decode writeback: read layer `l`'s new K/V row at `pos` from the mirror back into the
@@ -4495,7 +4496,7 @@ def vk_rdec_read_kv(l, pos : int64; kp : float?; vp : float?) {
     let off = ((l * g_rd.seq_cap) + pos) * kvd * 4l
     verify(vk_moe_init())
     unsafe {
-        var raw = alloc_cmd()
+        var raw = alloc_transient_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
         cmd_copy_range(raw, g_rd.k_mirror, off, g_rd.kv_readback.buf, 0l, kvd * 4l)
@@ -4504,6 +4505,7 @@ def vk_rdec_read_kv(l, pos : int64; kp : float?; vp : float?) {
         submit_wait(raw)
         memcpy(reinterpret<void?>(kp), g_rd.kv_readback.mapped, int(kvd * 4l))
         memcpy(reinterpret<void?>(vp), reinterpret<float?>(g_rd.kv_readback.mapped) + kvd, int(kvd * 4l))
+        free_transient_cmd(raw)
     }
 }
 
@@ -4795,7 +4797,9 @@ def vk_arena_gemv(var y : array<float>; blk : int64; n, d : int64; fmt : int; xq
     }
 }
 
-def private alloc_cmd : VkCommandBuffer {
+// One-shot command buffers (the KV readback rails) are freed by their caller — registering them
+// in model_cmds would grow it per hydration until the next model drop.
+def private alloc_transient_cmd : VkCommandBuffer {
     var ai = VkCommandBufferAllocateInfo()
     ai.commandPool = boost_value_to_vk(g_gpu.pool)
     ai.level = VkCommandBufferLevel.PRIMARY
@@ -4804,6 +4808,17 @@ def private alloc_cmd : VkCommandBuffer {
     unsafe {
         vk_check(vkAllocateCommandBuffers(dev_raw(), ai, addr(raw)), null)
     }
+    return raw
+}
+
+def private free_transient_cmd(var raw : VkCommandBuffer) {
+    unsafe {
+        vkFreeCommandBuffers(dev_raw(), boost_value_to_vk(g_gpu.pool), 1u, addr(raw))
+    }
+}
+
+def private alloc_cmd : VkCommandBuffer {
+    var raw = alloc_transient_cmd()
     g_gpu.model_cmds |> push(raw)   // all persistent cmds are model-owned; freed by the model drop
     return raw
 }

--- a/modules/dasLLAMA/tests/test_gpu_slot_swap.das
+++ b/modules/dasLLAMA/tests/test_gpu_slot_swap.das
@@ -1,0 +1,157 @@
+options gen2
+options persistent_heap   // explicit deletes below — the model frees before the test exits
+options stack = 524288
+
+require dastest/testing_boost public
+require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration
+require dasllama/dasllama_math
+require dasllama/dasllama_image   // load_model_cached — the .dlim rail
+require daslib/jobque_boost
+require daslib/fio
+require _model_tier
+
+// The multi-model switch cycle on a REAL model + the resident driver: prefill + decode on
+// device, hydrate + whole-model drop, CPU continuation over the hydrated host KV, re-arm, a
+// fresh device trajectory — every leg must stay token-for-token on the control trajectory.
+// Runs only where tinyllama + a Vulkan device are present (loud skip otherwise); the
+// synthetic model-free teardown coverage is test_vulkan_tier's drop-model cycles.
+
+def private synth_id(i : int64) : int64 => 1000l + ((i * 17l + 131l) % 5000l)
+
+def private greedy_step(tr : Model; s : Session) : int64 {
+    var best = 0l
+    var bv = s.logits[0]
+    for (v in range64(tr.config.vocab_size)) {
+        if (s.logits[v] > bv) {
+            bv = s.logits[v]
+            best = v
+        }
+    }
+    return best
+}
+
+def private run_ids(tr : Model; var s : Session; plen, ngen : int64; var ids : array<int64>) {
+    let prompt <- [for (i in range64(plen)); synth_id(i)]
+    forward_prefill(tr, s, prompt, plen, 0l)
+    ids |> reserve(int(ngen))
+    var pos = plen
+    for (_g in range64(ngen)) {
+        let best = greedy_step(tr, s)
+        ids |> push(best)
+        forward(tr, s, best, pos)
+        pos++
+    }
+}
+
+def private same_ids(a, b : array<int64>; a0, n : int) : bool {
+    for (i in range(n)) {
+        if (a[a0 + i] != b[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+struct private SwapResult {
+    armed0 : bool       // the resident driver armed at load (false = skip the rest, no device)
+    dropped_off : bool  // moe_gpu_drop_model deactivated it
+    rearm_on : bool     // re-arm re-activated it
+    a_par : bool        // hydrate + drop + CPU continuation stayed on the control trajectory
+    b_par : bool        // post-re-arm fresh trajectory matches token-for-token
+    d_par : bool        // second drop/re-arm cycle matches token-for-token
+    rearm_us : int64
+}
+
+// Kept free of T? so the whole engine chain stays JIT-served (the dastest class would pin it
+// to the interpreter stack).
+def private slot_swap_cycle(path : string) : SwapResult {
+    var r = SwapResult()
+    var want = GpuTierWant()
+    want.auto_tier = true
+    set_gpu_tier_want(want)
+    moe_gpu_tier_arm()
+    with_job_que() {
+        setup_dasllama_jobque_()
+        var tr <- load_model_cached(path, QuantMode.q8)
+        r.armed0 = moe_gpu_resident_active()
+        if (r.armed0) {
+            let plen = 64l
+            // CTRL: the truth trajectory, straight through on the resident driver
+            var sc = make_run_state(tr.config)
+            var ctrl : array<int64>
+            run_ids(tr, sc, plen, 32l, ctrl)
+            // A: 16 resident tokens, hydrate + drop, 16 more on the CPU over the hydrated KV
+            var sa = make_run_state(tr.config)
+            var a1 : array<int64>
+            run_ids(tr, sa, plen, 16l, a1)
+            moe_gpu_hydrate_session(tr, sa)
+            moe_gpu_drop_model()
+            r.dropped_off = !moe_gpu_resident_active()
+            var pos = plen + 16l
+            var a2 : array<int64>
+            for (_g in range64(16l)) {
+                let best = greedy_step(tr, sa)
+                a2 |> push(best)
+                forward(tr, sa, best, pos)
+                pos++
+            }
+            r.a_par = same_ids(ctrl, a1, 0, 16) && same_ids(ctrl, a2, 16, 16)
+            // B: re-arm (the switch-in path) + a fresh trajectory
+            let t0 = ref_time_ticks()
+            set_gpu_tier_want(want)
+            moe_gpu_tier_arm()
+            moe_gpu_upload_resident(tr)
+            r.rearm_us = int64(get_time_usec(t0))
+            r.rearm_on = moe_gpu_resident_active()
+            var sb = make_run_state(tr.config)
+            var b : array<int64>
+            run_ids(tr, sb, plen, 32l, b)
+            r.b_par = same_ids(ctrl, b, 0, 32)
+            // D: a second full drop/re-arm cycle (registry regrowth smoke)
+            moe_gpu_drop_model()
+            moe_gpu_upload_resident(tr)
+            var sd = make_run_state(tr.config)
+            var d : array<int64>
+            run_ids(tr, sd, plen, 32l, d)
+            r.d_par = same_ids(ctrl, d, 0, 32) && moe_gpu_resident_active()
+            delete sc
+            delete sa
+            delete sb
+            delete sd
+            delete ctrl
+            delete a1
+            delete a2
+            delete b
+            delete d
+        }
+        // leave the device bare + the process-global want clear for later tests in the sweep
+        moe_gpu_drop_model()
+        set_gpu_tier_want(GpuTierWant())
+        delete tr
+    }
+    return r
+}
+
+[test]
+def test_gpu_slot_swap(t : T?) {
+    t |> run("resident drop/re-arm slot swap — IDS parity across two cycles (needs tinyllama q8 + vulkan)") @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            let path = path_join(models_dir(), "tinyllama-1.1b-chat-v1.0.Q8_0.gguf")
+            if (!model_available(t, path)) {
+                return
+            }
+            let r = slot_swap_cycle(path)
+            if (!r.armed0) {
+                t |> skip("resident driver did not arm (no vulkan device, or budget refused)")
+                return
+            }
+            t |> success(r.dropped_off, "drop deactivates the resident driver")
+            t |> success(r.a_par, "hydrated CPU continuation stays on the control trajectory")
+            t |> success(r.rearm_on, "re-arm re-activates the resident driver ({r.rearm_us / 1000l}ms)")
+            t |> success(r.b_par, "post-re-arm trajectory matches token-for-token")
+            t |> success(r.d_par, "second drop/re-arm cycle matches token-for-token")
+        } else {
+            feint("dasVulkan not installed; slot swap untestable here\n")
+        }
+    }
+}

--- a/modules/dasLLAMA/tests/test_gpu_slot_swap.das
+++ b/modules/dasLLAMA/tests/test_gpu_slot_swap.das
@@ -7,7 +7,7 @@ require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires ea
 require dasllama/dasllama_math
 require dasllama/dasllama_image   // load_model_cached — the .dlim rail
 require daslib/jobque_boost
-require daslib/fio
+require daslib/fio   // nolint:STYLE030 — only used inside the builtin_module_exists(vulkan) static_if; dead on a no-vulkan lint binary
 require _model_tier
 
 // The multi-model switch cycle on a REAL model + the resident driver: prefill + decode on

--- a/modules/dasLLAMA/tests/test_vulkan_tier.das
+++ b/modules/dasLLAMA/tests/test_vulkan_tier.das
@@ -2821,3 +2821,114 @@ def test_vulkan_arena(t : T?) {
         }
     }
 }
+
+// ===== whole-model drop/re-arm (the multi-model switch primitive) =====
+
+// vk_drop_model_state (via the math-side hook) destroys EVERY model-owned object — stacks,
+// arenas, lazy dispatch families, their descriptor sets and command buffers — while the device
+// survives. Two full cycles re-upload the SAME offsets with DIFFERENT content: a stale stack
+// registry or arena would resolve the old plane and fail the cycle's own reference. Declared
+// LAST in the file on purpose: the drop nukes every stack earlier tests uploaded.
+let DMWOFF = 50000000l
+let DMROWS = 64l
+
+[test]
+def test_vulkan_drop_model(t : T?) {
+    t |> run("vulkan whole-model drop — stacks + arena rebuild and serve across two cycles") @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            install_moe_gpu_tier(@@vk_moe_ffn, @@vk_moe_upload_stack, @@vk_moe_cls, @@vk_moe_dense, @@vk_moe_drop_stacks, @@vk_moe_dn, @@vk_moe_attn)
+            let nb = int(N / 32l)
+            for (cycle in range(2)) {
+                // per-op stack rail: upload -> dense GEMV -> parity vs THIS cycle's content
+                var wq : array<int8>
+                var ws : array<float>
+                fill_stack(wq, ws, DMROWS, N, 17l + int64(cycle) * 31l, false)
+                var wqb : array<uint8>
+                var wsb : array<uint8>
+                pack_upload(wq, ws, wqb, wsb)
+                if (!moe_gpu_upload_stack(wqb, wsb, DMWOFF, N, DMROWS, 0)) {
+                    feint("no Vulkan device (or probe/budget refused the upload); skipping\n")
+                    return
+                }
+                var xq : array<int8>
+                var xs : array<float>
+                fill_acts(xq, xs, 2l)
+                var y : array<float>
+                y |> resize(int(2l * DMROWS))
+                matmul_gpu_dense(y, DMWOFF, xq, xs, N, DMROWS, 2l, 0)
+                var refy : array<float>
+                refy |> resize(int(2l * DMROWS))
+                for (r in range(2)) {
+                    for (c in range(int(DMROWS))) {
+                        var acc = 0.0lf
+                        for (b in range(nb)) {
+                            var id = 0
+                            for (k in range(32)) {
+                                id += int(xq[r * int(N) + b * 32 + k]) * int(wq[c * int(N) + b * 32 + k])
+                            }
+                            acc += double(ws[c * nb + b]) * double(xs[r * nb + b]) * double(id)
+                        }
+                        refy[r * int(DMROWS) + c] = float(acc)
+                    }
+                }
+                let cs = compare_gout(y, refy)
+                t |> success(cs.maxdiff <= float(REL_TOL) * cs.maxref,
+                    "cycle {cycle} stack serves its own content (maxdiff {cs.maxdiff} vs {float(REL_TOL) * cs.maxref} bar)")
+                // arena rail: reserve (fresh after a drop) -> place -> GEMV -> parity
+                t |> success(vk_arena_reserve(0, ARENA_BLOCKS / 2l), "cycle {cycle} arena reserve")
+                var awq : array<int8>
+                var aws : array<float>
+                fill_stack(awq, aws, DMROWS, N, 91l + int64(cycle) * 13l, false)
+                var apq : array<uint8>
+                var aps : array<uint8>
+                pack_upload(awq, aws, apq, aps)
+                let blk = vk_arena_place(apq, aps, N, DMROWS, 0)
+                t |> success(blk >= 0l, "cycle {cycle} arena placement (block {blk})")
+                var axq : array<int8>
+                var axs : array<float>
+                fill_acts(axq, axs, 1l)
+                var ay : array<float>
+                ay |> resize(int(DMROWS))
+                vk_arena_gemv(ay, blk, N, DMROWS, 0, axq, axs)
+                var aref : array<float>
+                aref |> resize(int(DMROWS))
+                for (c in range(int(DMROWS))) {
+                    var acc = 0.0lf
+                    for (b in range(nb)) {
+                        var id = 0
+                        for (k in range(32)) {
+                            id += int(axq[b * 32 + k]) * int(awq[c * int(N) + b * 32 + k])
+                        }
+                        acc += double(aws[c * nb + b]) * double(axs[b]) * double(id)
+                    }
+                    aref[c] = float(acc)
+                }
+                let ca = compare_gout(ay, aref)
+                t |> success(ca.maxdiff <= float(REL_TOL) * ca.maxref,
+                    "cycle {cycle} arena serves its own content (maxdiff {ca.maxdiff} vs {float(REL_TOL) * ca.maxref} bar)")
+                // the whole-model drop: every stack (this file's earlier tests included), the
+                // arena, and all lazy dispatch state die; cycle 1 re-runs the ladder from bare
+                moe_gpu_drop_model_state()
+                t |> equal(0l, gpu_tier_status().vram_bytes, "cycle {cycle} drop left zero resident bytes")
+                delete wq
+                delete ws
+                delete wqb
+                delete wsb
+                delete xq
+                delete xs
+                delete y
+                delete refy
+                delete awq
+                delete aws
+                delete apq
+                delete aps
+                delete axq
+                delete axs
+                delete ay
+                delete aref
+            }
+        } else {
+            feint("dasVulkan not installed; whole-model drop untestable here\n")
+        }
+    }
+}

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -58,6 +58,27 @@ team_dispatch = "hybrid" # LLM team dispatch + independent inline ASR caller thr
 asr_workers = 2    # two independent transcription requests; each worker owns an ASR model
 ```
 
+Several models serve LIVE from one process via a `[[models]]` roster instead of the flat `model`
+key — requests route on their `"model"` field (absent → the default entry). Execution is
+serialized (one scheduler steps at a time), switches are fast, and every cache level survives a
+switch: host weights stay mmap'd, each slot keeps its own KV pool + prefix cache, and ONE model's
+GPU state lives in VRAM at a time (the tier drops + re-arms on switch; `backend = "cpu"` slots
+never evict the GPU owner, so gpu↔cpu alternation is free). Blank keys inherit the flat defaults;
+`backend` is `auto | cpu | gpu` (auto = the engine's decline ladder), and per-entry `ctx`, `quant`,
+`kv_dtype`, `streams`, `chunk`, `page_rows`, `prefix`, `mtp` override per model:
+
+```toml
+[[models]]
+name = "qwen"      # route id (default: the file's basename)
+path = "D:/models/Qwen3.6-35B-A3B-Q8_0.gguf"
+default = true
+
+[[models]]
+name = "smol"
+path = "D:/models/SmolLM2-135M-Instruct-Q8_0.gguf"
+backend = "cpu"    # never touches the device — alternating with the GPU slot costs nothing
+```
+
 Chat and completion requests **batch continuously** (`llm_scheduler.das`): up to `--streams`
 generations run concurrently through one `eval_batch` decode step per tick, with long prompts
 prefilled in `--chunk`-token slices so a new arrival never stalls running streams for more than
@@ -125,17 +146,18 @@ Windows locks the DLLs.
 
 | Method | Path | Notes |
 |---|---|---|
-| `GET`  | `/` | Control page: live stats + charts, stream swimlane + live text cards, prefix-cache table, a chat panel (all sampling knobs, `<think>` inline, mic input under `--asr`), config editor with save/restart, GC + drain buttons. Serves `control.html` from beside the server sources — polls `/v1/stats` + `/v1/streams` at 1 Hz |
-| `GET`  | `/v1/models` | Lists the served model (and `--asr` if loaded) |
+| `GET`  | `/` | Control page: live stats + charts, models panel (per-slot cards with state/GPU badges, prefix hit rate, switch telemetry, activate buttons; VRAM bar + switch strip), stream swimlane + live text cards, prefix-cache table, a chat panel (all sampling knobs, `<think>` inline, mic input under `--asr`), config editor with the `[[models]]` roster table + save/restart, GC + drain buttons. Serves `control.html` from beside the server sources — polls `/v1/stats` + `/v1/streams` at 1 Hz |
+| `GET`  | `/v1/models` | Lists every served slot (and `--asr` if loaded) — requests route on these ids via their `"model"` field |
+| `POST` | `/v1/models/activate` | `{"model": name}` admin warm-switch: make `name` the stepped slot and move the GPU tier to it now (instead of waiting for the owner to drain). `409` while any work is live, `404` on an unknown name; `200` reports `switch_ms` + `backend_effective` |
 | `POST` | `/v1/chat/completions` | Chat; `stream: true` → SSE, else buffered; OpenAI function calling (`tools`) |
 | `POST` | `/v1/completions` | Raw completion; `stream: true` → SSE, else buffered |
 | `POST` | `/v1/embeddings` | Mean-pooled, L2-normalized sentence embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech→text (multipart upload; needs `--asr`). `response_format=verbose_json` adds timed segments |
 | `POST` | `/v1/audio/translations` | Speech→English text (needs `--asr`) |
 | `POST` | `/vad` | Silero speech spans over an uploaded clip (the control page's waveform overlay; in-handler, ≤120 s, needs the in-repo `silero_vad.bin`) |
-| `GET`  | `/v1/stats` | Scheduler counters (`gen_tokens`, `prefill_tokens`, TTFT last/avg, …) plus `model`/`ctx`/`uptime_s`/`draining` identity fields, memory footprint (`weights_bytes`, `kv_bytes`, das heaps), a `hardware` line (CPU · lanes · GPU), and `asr_workers`, `asr_ready`, `asr_active`, `asr_pending` |
-| `GET`  | `/v1/streams` | Per-stream poll surface: state (`queued`/`prefilling`/`decoding`/`finished`), token counts, TTFT, and capped text tails (prompt head + generated tail); finished streams linger ~10 s flagged `finished`. Plus `cache`: the prefix-cache donation chains (tokens, live pages, hits, age, preview) and `asr`: recent ASR jobs (state, audio s, wall ms, RTF) |
-| `GET`  | `/config` | Effective config with per-key source (`default`/`cli`/`toml`), model files beside the served one, active rail (gguf vs prepared `.dlim`), GPU tier status (`supported` + `reason` when the loaded model can't ride it) |
+| `GET`  | `/v1/stats` | Scheduler counters (`gen_tokens`, `prefill_tokens`, TTFT last/avg, …) plus `model`/`active_model`/`ctx`/`uptime_s`/`draining` identity fields, memory footprint (`weights_bytes`, `kv_bytes`, das heaps, `gpu_vram_bytes`/`gpu_budget_bytes`), a `hardware` line (CPU · lanes · GPU), `asr_workers`, `asr_ready`, `asr_active`, `asr_pending`, and `models[]` — one entry per slot: `is_active`, `holds_gpu`, requested `backend` vs `backend_effective` (`cpu`/`gpu:rails`/`gpu:resident`), per-slot cache counters, `last_used_s`, switch count/avg ms |
+| `GET`  | `/v1/streams` | Per-stream poll surface: `model` (the slot it runs on), state (`queued`/`prefilling`/`decoding`/`finished`), token counts, TTFT, and capped text tails (prompt head + generated tail); finished streams linger ~10 s flagged `finished`. Plus `cache`: the prefix-cache donation chains (tokens, live pages, hits, age, preview) and `asr`: recent ASR jobs (state, audio s, wall ms, RTF) |
+| `GET`  | `/config` | Effective config with per-key source (`default`/`cli`/`toml`), the `[[models]]` roster, model files beside the served one, active rail (gguf vs prepared `.dlim`), GPU tier status (`supported` + `reason` when the loaded model can't ride it) |
 | `POST` | `/config` | Validate a `{key: value}` JSON body and write it as an **authoritative** TOML (`authoritative = true`) to the config path (or `dasllama-server.toml` beside the program on a config-less start). Applies on the next restart |
 | `POST` | `/restart` | Drain like `/shutdown`, then exit with code **4** — the watchdog relaunches, picking up the saved config (3 stays the tune-restart code) |
 | `POST` | `/gc` | Schedule a validated collection at the next lifecycle safe point; concurrent requests coalesce |

--- a/utils/dasllama-server/control.html
+++ b/utils/dasllama-server/control.html
@@ -99,6 +99,40 @@ button.mini.on { border-color: var(--amber); color: var(--amber); }
 }
 .scard .txt .ph { color: var(--fg-faint); }
 
+.mcard { background: var(--bg-2); border: 1px solid var(--rule); border-radius: 6px; padding: 10px 12px; }
+.mcard.active { border-color: var(--amber-dim); }
+.mcard .head { display: flex; gap: 8px; align-items: baseline; font-family: var(--font-mono); font-size: 12px; margin-bottom: 4px; }
+.mcard .head b { font-size: 13px; color: var(--fg); }
+.mcard .def { font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--fg-faint); }
+.mcard .st { font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--fg-faint); }
+.mcard .st.active { color: var(--green); }
+.mcard .head .spacer { flex: 1; }
+.mcard .line { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); line-height: 1.7; }
+.mcard .line.dim { color: var(--fg-faint); }
+.mcard canvas { height: 26px; margin-top: 6px; cursor: default; }
+.chip { font-family: var(--font-mono); font-size: 9.5px; padding: 1px 6px; border-radius: 3px; border: 1px solid var(--amber-dim); color: var(--amber); white-space: nowrap; }
+.chip.cpu { border-color: var(--rule); color: var(--fg-dim); }
+button.xs { font-size: 10px; padding: 2px 8px; }
+.vbar { height: 14px; background: var(--bg-3); border: 1px solid var(--rule); border-radius: 4px; overflow: hidden; }
+.vbar .vfill { background: var(--amber-dim); height: 100%; width: 0%; transition: width 0.4s; }
+.swstrip { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.swchip { font-family: var(--font-mono); font-size: 10.5px; padding: 2px 8px; border-radius: 3px; border: 1px solid var(--rule); color: var(--fg-dim); white-space: nowrap; }
+.swchip:first-child { border-color: var(--amber-dim); color: var(--fg); }
+
+.roster { margin-bottom: 4px; }
+.roster input, .roster select {
+    font-family: var(--font-mono); font-size: 11.5px; color: var(--fg);
+    background: var(--bg-3); border: 1px solid var(--rule); border-radius: 4px; padding: 3px 6px; width: 100%;
+}
+.roster input:focus, .roster select:focus { outline: none; border-color: var(--amber-dim); }
+.roster td { vertical-align: middle; }
+.roster td.eff { white-space: nowrap; }
+.roster td.act { white-space: nowrap; text-align: right; }
+.roster .advrow td { padding-top: 0; border-top: none; }
+.roster .advgrid { display: flex; flex-wrap: wrap; gap: 8px 14px; padding: 4px 0 6px; }
+.roster .advgrid label { display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-faint); }
+.roster .advgrid input, .roster .advgrid select { width: 84px; }
+
 #a-wave { height: 80px; background: var(--bg-3); border: 1px solid var(--rule); border-radius: 4px; }
 .segs { margin-top: 8px; max-height: 180px; overflow-y: auto; }
 .segs .seg {
@@ -231,7 +265,16 @@ button:disabled { opacity: 0.45; cursor: default; }
         </div>
     </div>
 
-    <div class="sec"><span>§ 02</span><span class="rule"></span><span>streams</span>
+    <div class="sec"><span>§ 02</span><span class="rule"></span><span>models</span></div>
+    <div id="mcards" class="cards"></div>
+    <div class="ctl-note" id="m-note" style="margin-top:8px"></div>
+    <div class="panel" id="vram-panel" style="display:none; margin-top:12px">
+        <div class="chart-title"><span>vram · resident weights — one model's GPU state at a time</span><span class="chart-now" id="vram-now"></span></div>
+        <div class="vbar"><div class="vfill" id="vram-fill"></div></div>
+        <div class="swstrip" id="sw-strip" style="display:none"></div>
+    </div>
+
+    <div class="sec"><span>§ 03</span><span class="rule"></span><span>streams</span>
         <span class="spacer"></span>
         <button class="mini" id="b-demo" type="button" title="staged ramp 1→2→4→8 concurrent chats from this page — watch the swimlane fill and tok/s stair-step">run demo load</button>
         <button class="mini" id="b-live" type="button">live</button>
@@ -240,7 +283,7 @@ button:disabled { opacity: 0.45; cursor: default; }
     <div id="cards" class="cards"><div class="ctl-note" id="cards-empty">no active streams — POST a chat completion and watch it flow</div></div>
     <div id="history" class="cards" style="display:none"><div class="ctl-note">nothing finished yet</div></div>
 
-    <div class="sec"><span>§ 03</span><span class="rule"></span><span>prefix cache</span></div>
+    <div class="sec"><span>§ 04</span><span class="rule"></span><span>prefix cache</span></div>
     <div class="panel">
         <table class="ctable" id="ctable">
             <thead><tr><th>cached conversation</th><th>tok</th><th>pages</th><th>hits</th><th>age</th><th>idle</th></tr></thead>
@@ -248,7 +291,7 @@ button:disabled { opacity: 0.45; cursor: default; }
         </table>
     </div>
 
-    <div class="sec"><span>§ 04</span><span class="rule"></span><span>chat</span></div>
+    <div class="sec"><span>§ 05</span><span class="rule"></span><span>chat</span></div>
     <div class="panel">
         <div class="chat-log" id="chat-log"><div class="ctl-note">talk to the served model — the conversation lives in this page only</div></div>
         <div class="chat-input">
@@ -263,7 +306,7 @@ button:disabled { opacity: 0.45; cursor: default; }
     </div>
 
     <div class="asr-only" id="asr-section" style="display:none">
-        <div class="sec"><span>§ 05</span><span class="rule"></span><span>asr studio</span></div>
+        <div class="sec"><span>§ 06</span><span class="rule"></span><span>asr studio</span></div>
         <div class="panel">
             <div class="controls" style="margin-bottom:10px">
                 <button id="a-rec" type="button">● record</button>
@@ -287,12 +330,20 @@ button:disabled { opacity: 0.45; cursor: default; }
         </div>
     </div>
 
-    <div class="sec"><span>§ 06</span><span class="rule"></span><span>config</span></div>
+    <div class="sec"><span>§ 07</span><span class="rule"></span><span>config</span></div>
     <div class="panel cfg" id="cfg">…</div>
 
-    <div class="sec"><span>§ 07</span><span class="rule"></span><span>config editor</span></div>
+    <div class="sec"><span>§ 08</span><span class="rule"></span><span>config editor</span></div>
     <div class="panel">
         <div class="gpu-line" id="gpu-line" style="display:none"></div>
+        <table class="ctable roster" id="roster">
+            <thead><tr><th>name</th><th>path</th><th>backend</th><th>effective</th><th>ctx</th><th>quant</th><th>default</th><th></th></tr></thead>
+            <tbody id="roster-body"></tbody>
+        </table>
+        <div class="controls" style="margin-bottom:16px">
+            <button class="mini" id="b-addmodel" type="button">add model</button>
+            <span class="ctl-note">rows save as the [[models]] roster — blank cells inherit the flat defaults below; ⚙ opens per-model overrides</span>
+        </div>
         <form id="cfg-form" class="cfg-form"></form>
         <datalist id="model-files"></datalist>
         <div class="cfg-actions">
@@ -303,14 +354,14 @@ button:disabled { opacity: 0.45; cursor: default; }
         <div class="cfg-file" id="cfg-file"></div>
     </div>
 
-    <div class="sec"><span>§ 08</span><span class="rule"></span><span>controls</span></div>
+    <div class="sec"><span>§ 09</span><span class="rule"></span><span>controls</span></div>
     <div class="panel controls">
         <button id="b-gc" type="button">collect garbage</button>
         <button id="b-drain" class="danger" type="button">drain + shutdown</button>
         <span class="ctl-note" id="ctl-note">gc runs at the next lifecycle safe point · shutdown drains accepted work, then exits</span>
     </div>
 
-    <div class="sec"><span>§ 09</span><span class="rule"></span><span>benchmark</span></div>
+    <div class="sec"><span>§ 10</span><span class="rule"></span><span>benchmark</span></div>
     <div class="panel">
         <div class="controls" style="margin-bottom:10px">
             <button id="b-bench" type="button">run llama.cpp A/B</button>
@@ -329,7 +380,7 @@ button:disabled { opacity: 0.45; cursor: default; }
     </div>
 
     <footer class="reveal">
-        <div class="sec"><span>§ 10</span><span class="rule"></span><span>how this works</span></div>
+        <div class="sec"><span>§ 11</span><span class="rule"></span><span>how this works</span></div>
         <p>
             Everything above — the tokenizer, every matmul kernel, the continuous-batching
             scheduler, the paged KV cache, this HTTP server — is written in
@@ -421,7 +472,109 @@ function apply(s) {
     $("c-str-now").textContent = s.active + " active · " + s.queued + " queued";
     draw($("c-tps"), [{ data: tps, color: css("--amber") }]);
     draw($("c-pf"), [{ data: pf, color: css("--green") }]);
+    renderModels(s);
 }
+
+// ===== models panel: per-slot cards, VRAM bar, switch strip =====
+// Switch chips are derived client-side: a slot whose sw_count grew since the last poll just
+// received the GPU tier; its ms comes from the sw totals delta. Polls a second apart can merge
+// two switches into one chip — accepted for an admin surface.
+const slotHitHist = new Map();   // slot name -> rolling cumulative prefix-hit-rate series
+const swHist = [];               // newest first: { from, to, ms }
+let prevSlots = null;            // last poll's models[] keyed by name
+
+function renderModels(s) {
+    const slots = s.models || [];
+    if (prevSlots) {
+        for (const m of slots) {
+            const p = prevSlots.get(m.name);
+            if (p && m.sw_count > p.sw_count) {
+                const ms = m.sw_avg_ms * m.sw_count - p.sw_avg_ms * p.sw_count;
+                const from = [...prevSlots.values()].find(x => x.holds_gpu && x.name !== m.name);
+                swHist.unshift({ from: from ? from.name : "cold", to: m.name, ms: Math.max(0, Math.round(ms)) });
+                if (swHist.length > 12) swHist.pop();
+            }
+        }
+    }
+    prevSlots = new Map(slots.map(m => [m.name, m]));
+    const box = $("mcards");
+    const want = new Set();
+    for (const m of slots) {
+        const cid = "mc-" + m.name;
+        want.add(cid);
+        let el = document.getElementById(cid);
+        if (!el) {
+            el = document.createElement("div");
+            el.id = cid;
+            el.className = "mcard";
+            box.append(el);
+        }
+        el.classList.toggle("active", m.is_active);
+        const hitDen = m.cached_tokens + m.prefill_tokens;
+        const hitRate = hitDen > 0 ? m.cached_tokens / hitDen : 0;
+        let hh = slotHitHist.get(m.name);
+        if (!hh) { hh = []; slotHitHist.set(m.name, hh); }
+        push(hh, hitRate);
+        const backLine = m.backend === m.backend_effective ? m.backend : m.backend + " → " + m.backend_effective;
+        el.innerHTML =
+            '<div class="head"><b>' + esc(m.name) + '</b>' +
+            (m.is_default ? '<span class="def">default</span>' : '') +
+            '<span class="st' + (m.is_active ? ' active' : '') + '">' + (m.is_active ? 'active' : 'idle') + '</span>' +
+            (m.holds_gpu ? '<span class="chip">gpu · ' + esc(m.backend_effective) + '</span>' : '') +
+            '<span class="spacer"></span>' +
+            (!m.is_active && slots.length > 1
+                ? '<button class="mini xs" type="button" data-activate="' + esc(m.name).replace(/"/g, "&quot;") + '">activate</button>' : '') +
+            '</div>' +
+            '<div class="line">ctx ' + fmt(m.ctx) + ' · backend ' + esc(backLine) +
+                ' · ' + (m.weights_bytes / 1e9).toFixed(1) + ' GB weights · ' + (m.kv_bytes / 1e9).toFixed(2) + ' GB kv</div>' +
+            '<div class="line">streams ' + m.active + ' / queued ' + m.queued +
+                ' · prefix ' + fmt(m.cached_tokens) + ' tok cached' +
+                (hitDen > 0 ? ' (' + (100 * hitRate).toFixed(0) + '% hit)' : '') +
+                ' · ' + fmt(m.prefix_pages) + ' pages</div>' +
+            '<div class="line dim">' + (m.last_used_s < 0 ? 'never used' : 'used ' + fmtAge(m.last_used_s) + ' ago') +
+                (m.sw_count > 0 ? ' · ' + m.sw_count + ' switch-in' + (m.sw_count > 1 ? 's' : '') +
+                    ' · avg ' + m.sw_avg_ms.toFixed(0) + 'ms' : '') + '</div>' +
+            '<canvas class="mspark" height="26" title="prefix-cache hit rate"></canvas>';
+        draw(el.querySelector("canvas"), [{ data: hh, color: css("--green") }]);
+    }
+    for (const el of [...box.querySelectorAll(".mcard")]) {
+        if (!want.has(el.id)) el.remove();
+    }
+    if (s.gpu_budget_bytes > 0) {
+        $("vram-panel").style.display = "block";
+        const owner = slots.find(m => m.holds_gpu);
+        $("vram-fill").style.width = Math.min(100, 100 * s.gpu_vram_bytes / s.gpu_budget_bytes).toFixed(1) + "%";
+        $("vram-now").textContent = (owner ? owner.name + " · " : "") +
+            (s.gpu_vram_bytes / 1e9).toFixed(2) + " / " + (s.gpu_budget_bytes / 1e9).toFixed(2) + " GB" +
+            (slots.length > 1 ? " · idle slots hold no vram" : "");
+    }
+    if (swHist.length) {
+        const st = $("sw-strip");
+        st.style.display = "flex";
+        st.innerHTML = swHist.map(x =>
+            '<span class="swchip">' + esc(x.from) + '→' + esc(x.to) + ' ' + x.ms + 'ms</span>').join("");
+    }
+    refreshRosterEff();
+}
+
+$("mcards").addEventListener("click", async e => {
+    const b = e.target.closest("button[data-activate]");
+    if (!b) return;
+    b.disabled = true;
+    try {
+        const r = await fetch("/v1/models/activate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model: b.dataset.activate }),
+        });
+        const j = await r.json().catch(() => null);
+        $("m-note").textContent = r.ok
+            ? j.model + " active · switch " + j.switch_ms + "ms · " + j.backend_effective
+            : (j && j.error ? j.error.message : "activate failed: " + r.status);
+    } catch (_e) {
+        $("m-note").textContent = "activate request failed";
+    }
+});
 
 function css(v) { return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
 
@@ -1144,9 +1297,10 @@ function renderAsrJobs(rows, stats) {
 }
 
 // ===== config editor =====
+// The model paths live in the [[models]] roster table above the flat form; the flat fields are
+// the process-wide knobs plus the per-model DEFAULTS that roster rows inherit when blank.
 // field spec: k = config key, t = text|path|int|sel|bool, o = select options ("" = unset/legacy)
 const FIELDS = [
-    { k: "model", t: "path", wide: true },
     { k: "quant", t: "sel", o: ["q8", "fp32", "q4", "q8_0", "q4_0", "q4_k", "q5_k", "q6_k", "mxfp4", "f16", "bf16"] },
     { k: "kv_dtype", t: "sel", o: ["f16", "f32", "q8_0", "tq4"] },
     { k: "ctx", t: "int" }, { k: "max_tokens", t: "int" },
@@ -1214,7 +1368,6 @@ function renderForm(surface, status) {
             input = document.createElement("input");
             input.type = f.t === "int" ? "number" : "text";
             if (f.t === "int") input.step = "1";
-            if (f.t === "path" && f.k === "model") input.setAttribute("list", "model-files");
             input.value = cfg[f.k];
         }
         input.id = "f-" + f.k;
@@ -1233,10 +1386,11 @@ function renderForm(surface, status) {
             $("f-gpu_attn").checked = true;
         }
     });
-    // model picker: same-directory gguf/dlim files; picking one swaps the basename
+    // model picker: same-directory gguf/dlim files feed the roster's path inputs
     const dl = $("model-files");
     dl.textContent = "";
-    const dir = String(cfg.model).replace(/[^/\\]*$/, "");
+    const anchor = String(cfg.model || (roster[0] && roster[0].path) || "");
+    const dir = anchor.replace(/[^/\\]*$/, "");
     for (const mf of (status.model_files || [])) {
         const opt = document.createElement("option");
         opt.value = dir + mf.name;
@@ -1246,7 +1400,6 @@ function renderForm(surface, status) {
     $("cfg-file").textContent =
         "saves to " + surface.save_path + (surface.authoritative ? " · authoritative (overrides CLI flags)" : "") +
         (status.dlim_rail ? " · serving from the prepared .dlim image" : "");
-    savedSnapshot = JSON.stringify(gatherConfig());
 }
 
 function renderGpu(status) {
@@ -1269,14 +1422,228 @@ function renderGpu(status) {
     }
 }
 
+// ===== [[models]] roster editor =====
+// Each row is one served model. Blank cells = the ModelEntry inherit sentinels, OMITTED on save
+// so the TOML stays name+path per model unless something is genuinely overridden.
+const QUANT_OPTS = ["", "q8", "fp32", "q4", "q8_0", "q4_0", "q4_k", "q5_k", "q6_k", "mxfp4", "f16", "bf16"];
+const KV_OPTS = ["", "f16", "f32", "q8_0", "tq4"];
+let roster = [];         // {name, path, backend, ctx, quant, kv_dtype, streams, chunk, page_rows, prefix, mtp, def, adv}
+let gpuStatus = null;    // /config status.gpu — decline reason for the effective badge hover
+
+const routeName = r => r.name || String(r.path).split(/[/\\]/).pop();
+
+function rosterFromSurface(surface) {
+    const src = (surface.models && surface.models.length) ? surface.models
+        : [{ path: (surface.config && surface.config.model) || "", default: true }];
+    roster = src.map(e => ({
+        name: e.name || "",
+        path: e.path || "",
+        backend: e.backend || "auto",
+        ctx: e.ctx > 0 ? String(e.ctx) : "",
+        quant: e.quant || "",
+        kv_dtype: e.kv_dtype || "",
+        streams: e.streams > 0 ? String(e.streams) : "",
+        chunk: e.chunk > 0 ? String(e.chunk) : "",
+        page_rows: e.page_rows >= 0 ? String(e.page_rows) : "",
+        prefix: (e.prefix !== undefined && e.prefix !== -2) ? String(e.prefix) : "",
+        mtp: (e.mtp === 1 || e.mtp === true) ? "on" : ((e.mtp === 0 || e.mtp === false) ? "off" : ""),
+        def: !!e.default,
+        adv: false,
+    }));
+    if (roster.length && !roster.some(r => r.def)) roster[0].def = true;
+}
+
+function rosterInput(i, k, val, type, list) {
+    const inp = document.createElement("input");
+    inp.type = type || "text";
+    if (type === "number") inp.step = "1";
+    inp.value = val;
+    inp.dataset.i = i;
+    inp.dataset.k = k;
+    if (list) inp.setAttribute("list", list);
+    return inp;
+}
+
+function rosterSelect(i, k, val, opts) {
+    const sel = document.createElement("select");
+    for (const o of opts) {
+        const el = document.createElement("option");
+        el.value = o;
+        el.textContent = o === "" ? "(inherit)" : o;
+        sel.append(el);
+    }
+    sel.value = opts.includes(val) ? val : opts[0];
+    sel.dataset.i = i;
+    sel.dataset.k = k;
+    return sel;
+}
+
+function renderRoster() {
+    const body = $("roster-body");
+    body.textContent = "";
+    roster.forEach((r, i) => {
+        const tr = document.createElement("tr");
+        const tdName = document.createElement("td");
+        const nm = rosterInput(i, "name", r.name);
+        nm.placeholder = routeName(r) || "route id";
+        nm.style.width = "110px";
+        tdName.append(nm);
+        const tdPath = document.createElement("td");
+        tdPath.className = "pv";
+        tdPath.append(rosterInput(i, "path", r.path, "text", "model-files"));
+        const tdBack = document.createElement("td");
+        tdBack.append(rosterSelect(i, "backend", r.backend, ["auto", "cpu", "gpu"]));
+        const tdEff = document.createElement("td");
+        tdEff.className = "eff";
+        tdEff.id = "eff-" + i;
+        const tdCtx = document.createElement("td");
+        const cx = rosterInput(i, "ctx", r.ctx, "number");
+        cx.placeholder = "inherit";
+        cx.style.width = "84px";
+        tdCtx.append(cx);
+        const tdQuant = document.createElement("td");
+        tdQuant.append(rosterSelect(i, "quant", r.quant, QUANT_OPTS));
+        const tdDef = document.createElement("td");
+        const rb = document.createElement("input");
+        rb.type = "radio";
+        rb.name = "roster-def";
+        rb.checked = r.def;
+        rb.dataset.i = i;
+        rb.dataset.k = "def";
+        tdDef.append(rb);
+        const tdAct = document.createElement("td");
+        tdAct.className = "act";
+        const adv = document.createElement("button");
+        adv.type = "button";
+        adv.className = "mini xs" + (r.adv ? " on" : "");
+        adv.textContent = "⚙";
+        adv.title = "per-model overrides (kv_dtype / scheduler / mtp)";
+        adv.dataset.i = i;
+        adv.dataset.act = "adv";
+        const del = document.createElement("button");
+        del.type = "button";
+        del.className = "mini xs";
+        del.textContent = "✕";
+        del.title = "remove this model";
+        del.dataset.i = i;
+        del.dataset.act = "del";
+        del.disabled = roster.length <= 1;
+        tdAct.append(adv, document.createTextNode(" "), del);
+        tr.append(tdName, tdPath, tdBack, tdEff, tdCtx, tdQuant, tdDef, tdAct);
+        body.append(tr);
+        if (r.adv) {
+            const at = document.createElement("tr");
+            at.className = "advrow";
+            const td = document.createElement("td");
+            td.colSpan = 8;
+            const grid = document.createElement("div");
+            grid.className = "advgrid";
+            const wrap = (txt, el) => {
+                const l = document.createElement("label");
+                l.append(document.createTextNode(txt), el);
+                return l;
+            };
+            grid.append(
+                wrap("kv_dtype", rosterSelect(i, "kv_dtype", r.kv_dtype, KV_OPTS)),
+                wrap("streams", rosterInput(i, "streams", r.streams, "number")),
+                wrap("chunk", rosterInput(i, "chunk", r.chunk, "number")),
+                wrap("page_rows", rosterInput(i, "page_rows", r.page_rows, "number")),
+                wrap("prefix", rosterInput(i, "prefix", r.prefix, "number")),
+                wrap("mtp", rosterSelect(i, "mtp", r.mtp, ["", "off", "on"])));
+            for (const inp of grid.querySelectorAll("input")) inp.placeholder = "inherit";
+            td.append(grid);
+            at.append(td);
+            body.append(at);
+        }
+    });
+    refreshRosterEff();
+}
+
+// the effective-backend badge per row, refreshed from the stats poll (slot matched by route id)
+function refreshRosterEff() {
+    if (!last || !last.models) return;
+    roster.forEach((r, i) => {
+        const cell = document.getElementById("eff-" + i);
+        if (!cell) return;
+        const m = last.models.find(x => x.name === routeName(r));
+        if (!m) { cell.textContent = "—"; return; }
+        const degraded = r.backend !== "cpu" && m.backend_effective === "cpu" && gpuStatus && gpuStatus.reason;
+        cell.innerHTML = '<span class="chip' + (m.backend_effective === "cpu" ? " cpu" : "") + '"' +
+            (degraded ? ' title="' + esc(gpuStatus.reason).replace(/"/g, "&quot;") + '"' : "") + '>' +
+            esc(m.backend_effective) + '</span>';
+    });
+}
+
+$("roster-body").addEventListener("input", e => {
+    const t = e.target, i = Number(t.dataset.i), k = t.dataset.k;
+    if (!Number.isInteger(i) || !k || !roster[i]) return;
+    if (k === "def") {
+        if (t.checked) roster.forEach((r, j) => { r.def = j === i; });
+    } else {
+        roster[i][k] = t.value;
+    }
+});
+$("roster-body").addEventListener("click", e => {
+    const b = e.target.closest("button[data-act]");
+    if (!b) return;
+    const i = Number(b.dataset.i);
+    if (b.dataset.act === "adv") {
+        roster[i].adv = !roster[i].adv;
+    } else if (roster.length > 1) {
+        roster.splice(i, 1);
+        if (!roster.some(r => r.def)) roster[0].def = true;
+    }
+    renderRoster();
+});
+$("b-addmodel").addEventListener("click", () => {
+    roster.push({ name: "", path: "", backend: "auto", ctx: "", quant: "", kv_dtype: "",
+                  streams: "", chunk: "", page_rows: "", prefix: "", mtp: "",
+                  def: roster.length === 0, adv: false });
+    renderRoster();
+});
+
+function gatherModels() {
+    return roster.map(r => {
+        const e = { path: r.path };
+        if (r.name) e.name = r.name;
+        if (r.backend && r.backend !== "auto") e.backend = r.backend;
+        if (r.ctx !== "" && Math.trunc(+r.ctx) > 0) e.ctx = Math.trunc(+r.ctx);
+        if (r.quant) e.quant = r.quant;
+        if (r.kv_dtype) e.kv_dtype = r.kv_dtype;
+        if (r.streams !== "" && Math.trunc(+r.streams) > 0) e.streams = Math.trunc(+r.streams);
+        if (r.chunk !== "" && Math.trunc(+r.chunk) > 0) e.chunk = Math.trunc(+r.chunk);
+        if (r.page_rows !== "") e.page_rows = Math.trunc(+r.page_rows);
+        if (r.prefix !== "") e.prefix = Math.trunc(+r.prefix);
+        if (r.mtp) e.mtp = r.mtp === "on";
+        if (r.def) e.default = true;
+        return e;
+    });
+}
+
+// pre-save roster sanity — the server rejects these too, but say it before the round trip
+function rosterError() {
+    const seen = new Set();
+    for (const r of roster) {
+        if (!r.path) return "every model row needs a path";
+        const id = routeName(r);
+        if (seen.has(id)) return "duplicate model name '" + id + "'";
+        seen.add(id);
+    }
+    return "";
+}
+
 async function loadConfig() {
     try {
         const r = await fetch("/config", { cache: "no-store" });
         if (!r.ok) throw new Error(String(r.status));
         const c = await r.json();
         cfgSurface = c.surface;
+        gpuStatus = (c.status || {}).gpu || null;
+        rosterFromSurface(c.surface);
         renderForm(c.surface, c.status || {});
+        renderRoster();
         renderGpu(c.status || {});
+        savedSnapshot = JSON.stringify(gatherConfig());
     } catch (_e) {
         $("cfg-note").textContent = "could not load /config";
     }
@@ -1291,10 +1658,16 @@ function gatherConfig() {
         else if (f.t === "int" || f.t === "isel") out[f.k] = Math.trunc(Number(el.value) || 0);
         else out[f.k] = el.value;
     }
+    out.models = gatherModels();
     return out;
 }
 
 async function saveConfig() {
+    const rerr = rosterError();
+    if (rerr) {
+        $("cfg-note").textContent = "save blocked: " + rerr;
+        return false;
+    }
     const body = JSON.stringify(gatherConfig());
     try {
         const r = await fetch("/config", {

--- a/utils/dasllama-server/control.html
+++ b/utils/dasllama-server/control.html
@@ -568,7 +568,7 @@ $("mcards").addEventListener("click", async e => {
             body: JSON.stringify({ model: b.dataset.activate }),
         });
         const j = await r.json().catch(() => null);
-        $("m-note").textContent = r.ok
+        $("m-note").textContent = r.ok && j
             ? j.model + " active · switch " + j.switch_ms + "ms · " + j.backend_effective
             : (j && j.error ? j.error.message : "activate failed: " + r.status);
     } catch (_e) {

--- a/utils/dasllama-server/deploy-jit.ps1
+++ b/utils/dasllama-server/deploy-jit.ps1
@@ -44,10 +44,12 @@ foreach ($m in @("dasLLAMA","dasLLVM","dasVulkan","dasHV","dasSpirv","dasAudio",
 }
 
 # 4. server sources + control page + watchdog at the bundle root (main.das's require siblings
-#    live beside it; SERVE_FILE reads control.html from the main.das dir).
-foreach ($f in @("main.das","openai_server.das","llm_scheduler.das","ask.das","wav2txt.das","control.html","watchdog.py",".das_package")) {
+#    live beside it; SERVE_FILE reads control.html from the main.das dir). The watchdog is the
+#    shared supervisor from utils/watchdog; watchdog.json pins the deployment name.
+foreach ($f in @("main.das","openai_server.das","llm_scheduler.das","ask.das","wav2txt.das","control.html","watchdog.json",".das_package")) {
     Copy-Item (Join-Path $PSScriptRoot $f) $Dest -Force
 }
+Copy-Item (Join-Path $Repo "utils\watchdog\watchdog.py") $Dest -Force
 # ship the box tune sidecar (main.das's app sidecar) so first launch runs the tuned kernels
 # instead of re-tuning (which would exit 3 restart-loop under the watchdog).
 $tune = Join-Path $PSScriptRoot "main.tune.json"

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -577,8 +577,8 @@ def parse_args() {
         request_exit()
         return
     }
-    if (empty(g_cfg.model)) {
-        print("error: no model — pass --model or set model = in --config\n\n")
+    if (empty(g_cfg.model) && empty(g_models)) {   // a [[models]] roster needs no flat model key
+        print("error: no model — pass --model, or set model = / a [[models]] roster in --config\n\n")
         print_help(get_command_info(type<ServerArgs>), "dasllama-server")
         g_exit_code = 1
         request_exit()
@@ -743,11 +743,17 @@ def init() {
             break
         }
     }
-    // P1: exactly ONE slot owns the GPU tier — the default slot unless its backend pins cpu,
-    // else the first gpu/auto entry. Everything else serves on the CPU rails until the P2
-    // switch-on-demand lands. The want is toggled per load (the tier arms at each load tail).
+    // At load time exactly ONE slot arms the GPU tier — the default slot unless its backend pins
+    // cpu, else the first gpu/auto entry. The want is toggled per load (the tier arms at each
+    // load tail); every non-cpu slot RECORDS the want so the switch-on-demand path (P2b) can
+    // re-arm it when the tick loop or POST /v1/models/activate moves the tier.
     var gpu_idx = -1
+    var slot_want = GpuTierWant()
     if (gpu == "vulkan") {
+        slot_want = GpuTierWant(
+            moe_layers = gpu_detail_layers(g_cfg), moe_stream = gpu_detail_stream(g_cfg),
+            vram_mb = int64(g_cfg.gpu_vram_mb), dn = gpu_detail_dn(g_cfg),
+            attn = gpu_detail_attn(g_cfg), dense = g_cfg.gpu_dense, shexp = true)
         if (g_models[def_idx].backend != "cpu") {
             gpu_idx = def_idx
         } else {
@@ -768,14 +774,7 @@ def init() {
             ent.name = base_name(ent.path)
         }
         if (gpu == "vulkan") {
-            if (i == gpu_idx) {
-                set_gpu_tier_want(GpuTierWant(
-                    moe_layers = gpu_detail_layers(g_cfg), moe_stream = gpu_detail_stream(g_cfg),
-                    vram_mb = int64(g_cfg.gpu_vram_mb), dn = gpu_detail_dn(g_cfg),
-                    attn = gpu_detail_attn(g_cfg), dense = g_cfg.gpu_dense, shexp = true))
-            } else {
-                set_gpu_tier_want(GpuTierWant())   // zero want: this slot loads CPU-only
-            }
+            set_gpu_tier_want(i == gpu_idx ? slot_want : GpuTierWant())   // zero want: loads CPU-only
         }
         print("loading {ent.path} ...\n")
         var m <- load_model(ent.path, pick_quant(!empty(ent.quant) ? ent.quant : g_cfg.quant))
@@ -803,9 +802,9 @@ def init() {
             opts.kv_dtype_set = true
         }
         opts.mtp = ent.mtp
-        add_model(m, ent.name, opts)
-        if (i == gpu_idx) {
-            set_slot_backend_effective(ent.name, "gpu")   // coarse P1 badge; P2's arm path refines
+        add_model(m, ent.name, opts)   // captures this load's arm outcome + marks onto the slot
+        if (gpu == "vulkan" && ent.backend != "cpu") {
+            set_slot_gpu_want(ent.name, slot_want)   // the want switch-in re-arms with
         }
     }
     set_default_model(g_models[def_idx].name)
@@ -818,7 +817,9 @@ def init() {
     // the /config surface: a config-less start saves beside the program (the same spot the
     // auto-discovery in parse_args looks)
     let save_path = !empty(g_cfg.config) ? g_cfg.config : path_join(get_this_module_dir(), "dasllama-server.toml")
-    set_config_surface(build_config_surface(g_cfg, save_path), save_path, g_cfg.model)
+    // the served-model anchor for the page's model_files picker: the flat key, else the roster default
+    let picker_model = !empty(g_cfg.model) ? g_cfg.model : g_models[def_idx].path
+    set_config_surface(build_config_surface(g_cfg, save_path), save_path, picker_model)
     // the bench button runs OUR bench as a child daslang process (lcpp_bench.das) — a
     // standalone-exe deployment has no script runner, so the button stays disabled there
     var daslang_bin = ""

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -136,8 +136,27 @@ struct ServerArgs {
     help : bool
 }
 
+// One [[models]] config entry: a served model + its per-slot overrides. `backend` is the one
+// per-model serving knob (auto = the engine's decline ladder decides; cpu = never the device;
+// gpu = want the tier). The -1/-2/""/0 sentinels mean "inherit the global flat key".
+struct ModelEntry {
+    name : string           // route id (default: base_name(path))
+    path : string
+    backend : string = "auto"
+    ctx : int = 0
+    quant : string = ""
+    kv_dtype : string = ""
+    streams : int = -1
+    chunk : int = -1
+    page_rows : int = -1    // 0 = flat is meaningful, -1 = inherit
+    prefix : int = -2       // -1 = unbounded is meaningful, -2 = inherit
+    mtp : int = -1          // -1 inherit | 0 off | 1 on
+    is_default : bool = false
+}
+
 // Lifecycle state is global: JIT heap collection cannot see ordinary stack locals as GC roots.
 // main therefore keeps no collectable value alive across maybe_collect_gc().
+var private g_models : array<ModelEntry>
 var private g_cfg = ServerArgs()
 var private g_args_parsed = false
 var private g_args_ready = false
@@ -194,7 +213,7 @@ var private g_cfg_authoritative = false
 let CONFIG_KEYS = fixed_array("model", "port", "quant", "kv_dtype", "metal", "gpu", "gpu_layers",
     "gpu_stream", "gpu_dn", "gpu_attn", "gpu_dense", "gpu_vram_mb", "asr", "mmproj", "asr_workers",
     "ctx", "max_tokens", "streams", "threads", "team_dispatch", "affinity", "chunk", "page_rows",
-    "prefix", "flat", "mtp", "lcpp_bin")
+    "prefix", "flat", "mtp", "lcpp_bin", "models")
 
 def private from_cli(key : string) : bool
     => (g_cfg_sources?[key] ?? "") == "cli"
@@ -360,6 +379,32 @@ def apply_config(var cfg : ServerArgs) : bool {
     cfg_from_toml(root, "flat", cfg.flat, auth)
     cfg_from_toml(root, "mtp", cfg.mtp, auth)
     cfg_from_toml(root, "lcpp_bin", cfg.lcpp_bin, auth)
+    // [[models]] roster — per-model path + overrides; absent keys keep the ModelEntry sentinels
+    // (inherit the flat keys). An empty-path entry is a config mistake, skipped loudly.
+    if (toml_has(root, "models")) {
+        delete g_models
+        let mv = root?["models"]
+        if (mv != null && mv.value is _array) {
+            for (e in mv.value as _array) {
+                let has_mtp = e != null && (e.value is _object) && key_exists(e.value as _object, "mtp")
+                var ent = ModelEntry(
+                    name = e?["name"] ?? "", path = e?["path"] ?? "",
+                    backend = to_lower(e?["backend"] ?? "auto"),
+                    ctx = int(e?["ctx"] ?? 0l), quant = e?["quant"] ?? "",
+                    kv_dtype = e?["kv_dtype"] ?? "",
+                    streams = int(e?["streams"] ?? -1l), chunk = int(e?["chunk"] ?? -1l),
+                    page_rows = int(e?["page_rows"] ?? -1l), prefix = int(e?["prefix"] ?? -2l),
+                    mtp = has_mtp ? ((e?["mtp"] ?? false) ? 1 : 0) : -1,
+                    is_default = e?["default"] ?? false)
+                if (empty(ent.path)) {
+                    to_log(LOG_WARNING, "dasllama-server: [[models]] entry with no path — skipped\n")
+                } else {
+                    g_models |> push(ent)
+                }
+            }
+            g_cfg_sources["models"] = "toml"
+        }
+    }
     unsafe {
         delete root
     }
@@ -453,8 +498,23 @@ def private build_config_surface(cfg : ServerArgs; save_path : string) : string 
         mtp = cfg.mtp,
         lcpp_bin = cfg.lcpp_bin))
     var sources <- { for (k in CONFIG_KEYS); k => JV(g_cfg_sources?[k] ?? "default") }
+    // the [[models]] roster — the page's roster editor reads/writes this shape (a config-less
+    // single-model start serializes as a synthesized one-entry roster)
+    var mentries : array<JsonValue?>
+    mentries |> reserve(length(g_models))
+    for (ent in g_models) {
+        var etab <- {
+            "name" => JV(ent.name), "path" => JV(ent.path), "backend" => JV(ent.backend),
+            "ctx" => JV(int64(ent.ctx)), "quant" => JV(ent.quant), "kv_dtype" => JV(ent.kv_dtype),
+            "streams" => JV(int64(ent.streams)), "chunk" => JV(int64(ent.chunk)),
+            "page_rows" => JV(int64(ent.page_rows)), "prefix" => JV(int64(ent.prefix)),
+            "mtp" => JV(int64(ent.mtp)), "default" => JV(ent.is_default)
+        }
+        mentries |> push(JV(etab))
+    }
     var top <- {
         "config" => config,
+        "models" => JV(mentries),
         "sources" => JV(sources),
         "authoritative" => JV(g_cfg_authoritative),
         "config_path" => JV(cfg.config),
@@ -672,17 +732,83 @@ def init() {
             to_log(LOG_WARNING, "dasllama-server: gpu = vulkan requested but the tier did not arm (no vulkan device, or this build lacks the vulkan module)\n")
         }
     }
-    print("loading {g_cfg.model} ...\n")
+    // resolve the model roster: [[models]] entries, else the single legacy model key
+    if (empty(g_models)) {
+        g_models |> push(ModelEntry(path = g_cfg.model, is_default = true))
+    }
+    var def_idx = 0
+    for (i in range(length(g_models))) {
+        if (g_models[i].is_default) {
+            def_idx = i
+            break
+        }
+    }
+    // P1: exactly ONE slot owns the GPU tier — the default slot unless its backend pins cpu,
+    // else the first gpu/auto entry. Everything else serves on the CPU rails until the P2
+    // switch-on-demand lands. The want is toggled per load (the tier arms at each load tail).
+    var gpu_idx = -1
+    if (gpu == "vulkan") {
+        if (g_models[def_idx].backend != "cpu") {
+            gpu_idx = def_idx
+        } else {
+            for (i in range(length(g_models))) {
+                if (g_models[i].backend != "cpu") {
+                    gpu_idx = i
+                    break
+                }
+            }
+        }
+    }
     // A serving process prefers degrading (warn + nearest working mode) over dying on an
     // unsupported model/quant combo; API-facing tools keep the strict fail-loud default.
     set_resilient_load(true)
-    var m <- load_model(g_cfg.model, pick_quant(g_cfg.quant))
-    if (ctx > 0l) {
-        m.config.seq_len = min(m.config.seq_len, ctx)
+    for (i in range(length(g_models))) {
+        var ent & = unsafe(g_models[i])
+        if (empty(ent.name)) {
+            ent.name = base_name(ent.path)
+        }
+        if (gpu == "vulkan") {
+            if (i == gpu_idx) {
+                set_gpu_tier_want(GpuTierWant(
+                    moe_layers = gpu_detail_layers(g_cfg), moe_stream = gpu_detail_stream(g_cfg),
+                    vram_mb = int64(g_cfg.gpu_vram_mb), dn = gpu_detail_dn(g_cfg),
+                    attn = gpu_detail_attn(g_cfg), dense = g_cfg.gpu_dense, shexp = true))
+            } else {
+                set_gpu_tier_want(GpuTierWant())   // zero want: this slot loads CPU-only
+            }
+        }
+        print("loading {ent.path} ...\n")
+        var m <- load_model(ent.path, pick_quant(!empty(ent.quant) ? ent.quant : g_cfg.quant))
+        let ectx = ent.ctx > 0 ? int64(ent.ctx) : ctx
+        if (ectx > 0l) {
+            m.config.seq_len = min(m.config.seq_len, ectx)
+        }
+        let ctx_note = ectx > 0l ? "" : " (model default)"
+        to_log(LOG_INFO, "dasllama-server: {empty(ent.name) ? base_name(ent.path) : ent.name} ctx {m.config.seq_len}{ctx_note}\n")
+        var opts = SlotOpts(backend = empty(ent.backend) ? "auto" : ent.backend)
+        if (ent.streams > 0) {
+            opts.streams = int64(ent.streams)
+        }
+        if (ent.chunk > 0) {
+            opts.chunk = int64(ent.chunk)
+        }
+        if (ent.page_rows >= 0) {
+            opts.page_rows = int64(ent.page_rows)
+        }
+        if (ent.prefix != -2) {
+            opts.prefix = int64(ent.prefix)
+        }
+        if (!empty(ent.kv_dtype)) {
+            opts.kv_dtype = pick_kv_dtype(ent.kv_dtype)
+            opts.kv_dtype_set = true
+        }
+        opts.mtp = ent.mtp
+        add_model(m, ent.name, opts)
+        if (i == gpu_idx) {
+            set_slot_backend_effective(ent.name, "gpu")   // coarse P1 badge; P2's arm path refines
+        }
     }
-    let ctx_note = ctx > 0l ? "" : " (model default)"
-    to_log(LOG_INFO, "dasllama-server: ctx {m.config.seq_len}{ctx_note}\n")
-    set_model(m, base_name(g_cfg.model))
+    set_default_model(g_models[def_idx].name)
     set_default_max_tokens(g_cfg.max_tokens > 0 ? int64(g_cfg.max_tokens) : 256l)
 
     if (!empty(g_cfg.asr)) {

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -380,11 +380,13 @@ def apply_config(var cfg : ServerArgs) : bool {
     cfg_from_toml(root, "mtp", cfg.mtp, auth)
     cfg_from_toml(root, "lcpp_bin", cfg.lcpp_bin, auth)
     // [[models]] roster — per-model path + overrides; absent keys keep the ModelEntry sentinels
-    // (inherit the flat keys). An empty-path entry is a config mistake, skipped loudly.
+    // (inherit the flat keys). Hand-written TOML gets the same backend/default checks POST
+    // /config enforces, in the warn-and-degrade shape config mistakes take everywhere else here.
     if (toml_has(root, "models")) {
         delete g_models
         let mv = root?["models"]
         if (mv != null && mv.value is _array) {
+            var have_default = false
             for (e in mv.value as _array) {
                 let has_mtp = e != null && (e.value is _object) && key_exists(e.value as _object, "mtp")
                 var ent = ModelEntry(
@@ -396,6 +398,15 @@ def apply_config(var cfg : ServerArgs) : bool {
                     page_rows = int(e?["page_rows"] ?? -1l), prefix = int(e?["prefix"] ?? -2l),
                     mtp = has_mtp ? ((e?["mtp"] ?? false) ? 1 : 0) : -1,
                     is_default = e?["default"] ?? false)
+                if (ent.backend != "auto" && ent.backend != "cpu" && ent.backend != "gpu") {
+                    to_log(LOG_WARNING, "dasllama-server: [[models]] '{base_name(ent.path)}' backend '{ent.backend}' is not auto | cpu | gpu — using auto\n")
+                    ent.backend = "auto"
+                }
+                if (ent.is_default && have_default) {
+                    to_log(LOG_WARNING, "dasllama-server: more than one [[models]] entry marked default = true — keeping the first\n")
+                    ent.is_default = false
+                }
+                have_default ||= ent.is_default
                 if (empty(ent.path)) {
                     to_log(LOG_WARNING, "dasllama-server: [[models]] entry with no path — skipped\n")
                 } else {

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -387,6 +387,7 @@ def apply_config(var cfg : ServerArgs) : bool {
         let mv = root?["models"]
         if (mv != null && mv.value is _array) {
             var have_default = false
+            var seen_routes : table<string>
             for (e in mv.value as _array) {
                 let has_mtp = e != null && (e.value is _object) && key_exists(e.value as _object, "mtp")
                 var ent = ModelEntry(
@@ -410,7 +411,13 @@ def apply_config(var cfg : ServerArgs) : bool {
                 if (empty(ent.path)) {
                     to_log(LOG_WARNING, "dasllama-server: [[models]] entry with no path — skipped\n")
                 } else {
-                    g_models |> push(ent)
+                    let route = empty(ent.name) ? base_name(ent.path) : ent.name
+                    if (key_exists(seen_routes, route)) {
+                        to_log(LOG_WARNING, "dasllama-server: duplicate [[models]] name '{route}' — entry skipped (requests route on the first)\n")
+                    } else {
+                        seen_routes |> insert(route)
+                        g_models |> push(ent)
+                    }
                 }
             }
             g_cfg_sources["models"] = "toml"

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -421,6 +421,8 @@ def apply_config(var cfg : ServerArgs) : bool {
                 }
             }
             g_cfg_sources["models"] = "toml"
+        } else {
+            to_log(LOG_WARNING, "dasllama-server: 'models' in the config is not a [[models]] array-of-tables — roster ignored\n")
         }
     }
     unsafe {

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1159,7 +1159,9 @@ def private handle_models(var resp : HttpResponse?) : http_status {
     if (g_has_asr && !empty(g_slots)) {
         list.data |> push(OaiModel(id = "{g_slots[g_default_slot].name}-asr", _object = "model", created = created_ts(), owned_by = "dasllama"))
     }
-    return resp |> JSON(sprint_json(list, false), http_status.OK)
+    let body = sprint_json(list, false)
+    delete list
+    return resp |> JSON(body, http_status.OK)
 }
 
 // /v1/embeddings: mean-pooled, L2-normalized sentence embeddings over the facade `embed` verb.
@@ -1210,7 +1212,10 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
         idx ++
     }
     out.usage = OaiEmbUsage(prompt_tokens = prompt_tokens, total_tokens = prompt_tokens)
-    return resp |> JSON(sprint_json(out, false), http_status.OK)
+    let body = sprint_json(out, false)
+    delete out
+    delete inputs
+    return resp |> JSON(body, http_status.OK)
 }
 
 // POST /v1/models/activate {"model": name}: admin warm-switch — make `name` the stepped slot

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -33,10 +33,85 @@ require dasllama/dasllama_vad        // POST /vad: silero speech spans for the p
 // the small buffered holdouts (/v1/models, /v1/embeddings, /shutdown, /v1/stats) still complete
 // in-handler.
 
-// ===== Served state (set once at startup; handlers run serially on the tick thread) =====
+// ===== Served state (slots set at startup; handlers run serially on the tick thread) =====
 
-var g_model = Model()
-var g_model_name = ""
+//! Per-slot serving options (main.das resolves them from a [[models]] config entry). The -1/-2/""
+//! sentinels mean "inherit the init_server default". `backend` is a REQUEST (auto | cpu | gpu);
+//! the arm outcome lands in ModelSlot.backend_effective.
+struct SlotOpts {
+    backend : string = "auto"
+    streams : int64 = -1l
+    chunk : int64 = -1l
+    page_rows : int64 = -2l         // -2 = inherit (0 is meaningful: flat sessions)
+    prefix : int64 = -2l
+    kv_dtype : KVDtype = KVDtype.f16
+    kv_dtype_set : bool = false
+    mtp : int = -1                  // -1 inherit | 0 off | 1 on
+}
+
+//! One live served model: the loaded model, its scheduler (sessions + KV pool + prefix cache —
+//! the host caches that survive switches), and its serving options. Execution is SERIALIZED:
+//! the tick loop steps one slot's scheduler at a time (round-robin over slots with work).
+struct ModelSlot {
+    name : string
+    model : Model = Model()
+    sched : Scheduler = Scheduler()
+    opts : SlotOpts = SlotOpts()
+    backend_effective : string = "cpu"   // arm outcome: cpu | gpu:rails | gpu:resident
+    is_default : bool
+    last_used : int64
+    sw_count : int64                // P2 gpu-switch telemetry (count / total usec)
+    sw_us : int64
+}
+
+var g_slots : array<ModelSlot>
+var g_default_slot = 0
+var g_active = 0                // slot the tick loop stepped last (post-P2: the GPU owner)
+var g_cur = 0                   // slot the request being handled resolved to (handlers are serial)
+
+def private cur_model : Model& {
+    unsafe {
+        return g_slots[g_cur].model
+    }
+}
+
+def private cur_sched : Scheduler& {
+    unsafe {
+        return g_slots[g_cur].sched
+    }
+}
+
+def private cur_name : string => g_slots[g_cur].name
+
+def private total_active : int64 {
+    var n = 0l
+    for (s in g_slots) {
+        n += n_active(s.sched)
+    }
+    return n
+}
+
+def private total_queued : int64 {
+    var n = 0l
+    for (s in g_slots) {
+        n += n_queued(s.sched)
+    }
+    return n
+}
+
+// Slot index for a request's "model" field: "" -> the default slot; the exact slot name (or the
+// legacy "{name}-asr" alias) -> that slot; unknown -> -1 (the caller owns the 404).
+def private slot_index(model_field : string) : int {
+    if (empty(model_field)) {
+        return g_default_slot
+    }
+    for (i in range(length(g_slots))) {
+        if (g_slots[i].name == model_field || "{g_slots[i].name}-asr" == model_field) {
+            return i
+        }
+    }
+    return -1
+}
 var g_has_asr = false
 var g_asr_path = ""
 var g_asr_mmproj = ""
@@ -45,7 +120,6 @@ var g_asr_team_dispatch = false
 var g_shutdown_requested = false
 var g_gc_requested = false
 var g_req_counter = 0l
-var g_sched = Scheduler()       // live from run_server on; handlers submit into it
 var g_events : array<SchedEvent>
 
 // One registered request's HTTP side: where this stream id's SchedEvents go. The writer is owned by
@@ -54,6 +128,7 @@ struct private StreamWire {
     @do_not_delete writer : HttpResponseWriter?
     streaming : bool
     is_chat : bool                  // chat.completion.chunk vs text_completion framing
+    slot : int                      // the ModelSlot this stream runs on (flush sets g_cur from it)
     id : string                     // "chatcmpl-N" / "cmpl-N"
     created : int64
     reply_parts : array<string>     // non-streaming (or has_tools): pieces accumulate until the finished event
@@ -69,11 +144,50 @@ var g_default_max_new = 256l
 var private g_started_at = 0l   // ref_time_ticks at init_server; /v1/stats derives uptime_s from it
                                 // (created_ts is a per-request monotone stand-in, NOT a clock)
 
-//! Move a loaded model into the server (call once, before run_server). ``name`` is the id reported
-//! by ``/v1/models`` and echoed back in responses.
+//! Append a loaded model as a serving slot (call once per model, before ``run_server``). ``name``
+//! is the id ``/v1/models`` reports and requests route on via their ``"model"`` field. The first
+//! slot added is the default until an entry with ``opts.backend``/``default`` says otherwise.
+def add_model(var m : Model; name : string; opts : SlotOpts = SlotOpts()) {
+    var slot <- ModelSlot(name = name, is_default = empty(g_slots))
+    slot.model <- m
+    slot.opts = opts
+    g_slots |> emplace(slot)
+}
+
+//! Move a loaded model into the server as the ONLY slot (call once, before run_server). ``name``
+//! is the id reported by ``/v1/models`` and echoed back in responses. Single-model compatibility
+//! wrapper over ``add_model``; multi-model hosts call ``add_model`` per entry instead.
 def set_model(var m : Model; name : string) {
-    g_model <- m
-    g_model_name = name
+    unsafe {
+        delete g_slots
+    }
+    g_default_slot = 0
+    g_active = 0
+    g_cur = 0
+    add_model(m, name)
+}
+
+//! Record a slot's backend arm outcome for the stats/config surfaces (P1: coarse gpu/cpu; the
+//! P2 switch path refines to gpu:resident / gpu:rails). No-op on an unknown name.
+def set_slot_backend_effective(name : string; eff : string) {
+    for (s in g_slots) {
+        if (s.name == name) {
+            s.backend_effective = eff
+        }
+    }
+}
+
+//! Mark the default slot (the one serving requests with no ``"model"`` field). No-op on an
+//! unknown name.
+def set_default_model(name : string) {
+    for (i in range(length(g_slots))) {
+        if (g_slots[i].name == name) {
+            g_default_slot = i
+            g_slots[i].is_default = true
+        } elif (g_slots[i].is_default) {
+            g_slots[i].is_default = false
+        }
+    }
 }
 
 //! Default reply token budget for requests that omit ``max_tokens`` (call before run_server;
@@ -272,7 +386,7 @@ def private handle_bench_start(var resp : HttpResponse?) : http_status {
             error_body(empty(g_lcpp_bin) ? "set lcpp_bin in the config to enable benchmarking" : "benchmarking needs a source-tree daslang (standalone exe cannot spawn the bench child)", "invalid_request_error"),
             http_status.BAD_REQUEST)
     }
-    if (n_active(g_sched) > 0l || n_queued(g_sched) > 0l || g_asr_pending > 0) {
+    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0) {
         return resp |> JSON(
             error_body("streams are active — contended numbers are misleading; drain first, then bench", "invalid_request_error"),
             http_status.CONFLICT)
@@ -649,7 +763,7 @@ def private utf8_hold_bytes(s : string) : int {
 // empty delta + finish_reason for the terminating chunk.
 def private send_chat_chunk(srv : WebSocketServer; var writer : HttpResponseWriter?;
                             id : string; created : int64; role, content, finish : string) {
-    var chunk = OaiStreamChunk(id = id, _object = "chat.completion.chunk", created = created, model = g_model_name)
+    var chunk = OaiStreamChunk(id = id, _object = "chat.completion.chunk", created = created, model = cur_name())
     chunk.choices |> emplace(OaiStreamChoice(index = 0, delta <- OaiDelta(role = role, content = content),
                                              finish_reason = finish))
     sse_event(srv, writer, sprint_json(chunk, false), "")
@@ -660,7 +774,7 @@ def private send_chat_chunk(srv : WebSocketServer; var writer : HttpResponseWrit
 // OpenAI incremental framing); the caller follows with the finish_reason="tool_calls" chunk.
 def private send_chat_tool_calls_chunk(srv : WebSocketServer; var writer : HttpResponseWriter?;
                                        id : string; created : int64; calls : array<OaiToolCall>) {
-    var chunk = OaiStreamChunk(id = id, _object = "chat.completion.chunk", created = created, model = g_model_name)
+    var chunk = OaiStreamChunk(id = id, _object = "chat.completion.chunk", created = created, model = cur_name())
     var delta = OaiDelta()
     delta.tool_calls |> reserve(length(calls))
     var idx = 0
@@ -835,7 +949,7 @@ def parse_tool_calls_auto(full : string; declared_open, declared_close, id_base 
 
 def private send_compl_chunk(srv : WebSocketServer; var writer : HttpResponseWriter?;
                              id : string; created : int64; text, finish : string) {
-    var chunk = OaiComplStreamChunk(id = id, _object = "text_completion", created = created, model = g_model_name)
+    var chunk = OaiComplStreamChunk(id = id, _object = "text_completion", created = created, model = cur_name())
     chunk.choices |> push(OaiComplStreamChoice(index = 0, text = text, finish_reason = finish))
     sse_event(srv, writer, sprint_json(chunk, false), "")
     delete chunk
@@ -843,7 +957,7 @@ def private send_compl_chunk(srv : WebSocketServer; var writer : HttpResponseWri
 
 // Clamp a requested reply budget to [1, model context].
 def private clamp_max(requested : int64) : int64 {
-    return clamp(requested, 1l, g_model.config.seq_len)
+    return clamp(requested, 1l, cur_model().config.seq_len)
 }
 
 // Error on a buffered (resp-based) route — /v1/models and the audio endpoints use the response path.
@@ -940,9 +1054,12 @@ def private handle_unknown(var req : HttpRequest?; var resp : HttpResponse?) : h
 
 def private handle_models(var resp : HttpResponse?) : http_status {
     var list = OaiModelList(_object = "list")
-    list.data |> push(OaiModel(id = g_model_name, _object = "model", created = created_ts(), owned_by = "dasllama"))
-    if (g_has_asr) {
-        list.data |> push(OaiModel(id = "{g_model_name}-asr", _object = "model", created = created_ts(), owned_by = "dasllama"))
+    list.data |> reserve(length(g_slots) + 1)
+    for (s in g_slots) {
+        list.data |> push(OaiModel(id = s.name, _object = "model", created = created_ts(), owned_by = "dasllama"))
+    }
+    if (g_has_asr && !empty(g_slots)) {
+        list.data |> push(OaiModel(id = "{g_slots[g_default_slot].name}-asr", _object = "model", created = created_ts(), owned_by = "dasllama"))
     }
     return resp |> JSON(sprint_json(list, false), http_status.OK)
 }
@@ -958,6 +1075,12 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
     }
     defer() { unsafe { delete js } }
     warn_ignored_fields(js, EMB_FIELDS, "/v1/embeddings")
+    let want_model = js?["model"] ?? ""
+    let mi = slot_index(want_model)
+    if (mi < 0) {
+        return resp_error(resp, http_status.NOT_FOUND, "model '{want_model}' not found — GET /v1/models lists the served ids")
+    }
+    g_cur = mi
     let iv = js?["input"]
     if (iv == null) {
         return resp_error(resp, http_status.BAD_REQUEST, "'input' is required (a string or array of strings)")
@@ -976,19 +1099,33 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
         return resp_error(resp, http_status.BAD_REQUEST, "'input' is empty")
     }
 
-    var out = OaiEmbeddingList(_object = "list", model = g_model_name)
+    var out = OaiEmbeddingList(_object = "list", model = cur_name())
     out.data |> reserve(length(inputs))
     var prompt_tokens = 0l
     var idx = 0
     for (text in inputs) {
-        let toks <- encode(g_model, text, true, false)
+        let toks <- encode(cur_model(), text, true, false)
         prompt_tokens += int64(length(toks))
-        var vec = embed(g_model, text)
+        var vec = embed(cur_model(), text)
         out.data |> emplace(OaiEmbedding(_object = "embedding", embedding <- vec, index = idx))
         idx ++
     }
     out.usage = OaiEmbUsage(prompt_tokens = prompt_tokens, total_tokens = prompt_tokens)
     return resp |> JSON(sprint_json(out, false), http_status.OK)
+}
+
+// Resolve a streaming request's "model" field to a slot (sets g_cur). False = unknown model —
+// the 404 with OpenAI error framing is already on the wire.
+def private resolve_stream_slot(srv : WebSocketServer; var writer : HttpResponseWriter?; js : JsonValue?) : bool {
+    let want = js?["model"] ?? ""
+    let mi = slot_index(want)
+    if (mi < 0) {
+        respond(srv, writer, int(http_status.NOT_FOUND), "application/json",
+                error_body("model '{want}' not found — GET /v1/models lists the served ids", "model_not_found"))
+        return false
+    }
+    g_cur = mi
+    return true
 }
 
 // Validate the rendered prompt, submit it to the scheduler, and register the wire that routes its
@@ -1001,8 +1138,8 @@ def private register_request(srv : WebSocketServer; var writer : HttpResponseWri
                              tools_declared : bool = false; call_open : string = ""; call_close : string = "";
                              seed : int = 0) {
     let np = int64(length(prompt))
-    if (np + 1l > g_model.config.seq_len) {
-        bad_request(srv, writer, "the rendered prompt is {np} tokens; the model context is {g_model.config.seq_len} — shorten the conversation or raise --ctx")
+    if (np + 1l > cur_model().config.seq_len) {
+        bad_request(srv, writer, "the rendered prompt is {np} tokens; the model context is {cur_model().config.seq_len} — shorten the conversation or raise --ctx")
         return
     }
     let rid = next_id()
@@ -1012,17 +1149,18 @@ def private register_request(srv : WebSocketServer; var writer : HttpResponseWri
     preq.prompt <- prompt
     preq.stop_ids <- stop_ids
     preq.close_toks <- close_toks
-    if (!submit(g_model, g_sched, preq)) {
+    if (!submit(cur_model(), cur_sched(), preq)) {
         delete preq
-        to_log(LOG_WARNING, "dasllama-server: 503 queue full ({g_sched.max_queue}) — rejected {prefix} request ({np} tok)\n")
+        to_log(LOG_WARNING, "dasllama-server: 503 queue full ({cur_sched().max_queue}) — rejected {prefix} request ({np} tok)\n")
         respond(srv, writer, int(http_status.SERVICE_UNAVAILABLE), "application/json",
-                error_body("the server is at capacity ({g_sched.max_queue} requests queued) — retry shortly", "server_error"))
+                error_body("the server is at capacity ({cur_sched().max_queue} requests queued) — retry shortly", "server_error"))
         return
     }
+    g_slots[g_cur].last_used = ref_time_ticks()
     set_writer_keepalive_timeout(srv, writer, LLM_WRITER_KEEPALIVE_MS)
     to_log(LOG_INFO, "[req {rid}] {prefix}: prompt={np} tok, stream={streaming}, max_new={max_new}\n")
     var wire <- StreamWire(writer = writer, streaming = streaming, is_chat = is_chat,
-                           id = cid, created = created,
+                           slot = g_cur, id = cid, created = created,
                            has_tools = tools_declared && !empty(call_open),
                            last_keepalive_ticks = ref_time_ticks(),
                            call_open = call_open, call_close = call_close)
@@ -1041,14 +1179,14 @@ def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : arr
                                max_new : int64; start : int; thinking : bool;
                                var prompt, stop_ids, close : array<int64>&;
                                var call_open, call_close : string&) : string {
-    var chat <- create_chat_renderer(g_model, system, max_new)
+    var chat <- create_chat_renderer(cur_model(), system, max_new)
     defer() { delete chat }
     if (!thinking) {
         set_thinking(chat, false)
     }
     if (!empty(tools)) {
         if (empty(chat.tmpl.tool_call_open)) {
-            return "'tools' is not supported: the {g_model_name} chat template declares no tool-call format"
+            return "'tools' is not supported: the {cur_name()} chat template declares no tool-call format"
         }
         var render_tools <- [for (tool in tools); tool]
         set_tools(chat, render_tools)
@@ -1101,9 +1239,9 @@ def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : arr
             }
             if (pending) {
                 if (!empty(calls)) {
-                    render_assistant_calls(g_model, chat, content, calls, rendered)
+                    render_assistant_calls(cur_model(), chat, content, calls, rendered)
                 } else {
-                    render_assistant(g_model, chat, content, rendered)
+                    render_assistant(cur_model(), chat, content, rendered)
                 }
                 pending = false
             }
@@ -1122,12 +1260,12 @@ def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : arr
         delete rendered
         return "the last message must be a user or tool message"
     }
-    var turn <- render_turn(g_model, chat)
+    var turn <- render_turn(cur_model(), chat)
     rendered |> push_from(turn)
     delete turn
     prompt <- rendered
     stop_ids <- chat.stop_ids
-    close <- render_close(g_model, chat)
+    close <- render_close(cur_model(), chat)
     call_open = chat.tmpl.tool_call_open
     call_close = chat.tmpl.tool_call_close
     return ""
@@ -1159,6 +1297,9 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
     }
     defer() { unsafe { delete js } }
     warn_ignored_fields(js, CHAT_FIELDS, "/v1/chat/completions")
+    if (!resolve_stream_slot(srv, writer, js)) {
+        return
+    }
     let msgs_v = js?["messages"]
     if (msgs_v == null || !(msgs_v.value is _array)) {
         bad_request(srv, writer, "'messages' must be an array")
@@ -1249,13 +1390,13 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
             return
         }
         let required = int64(length(prompt)) + (truncation == "auto" ? max_new : 1l)
-        if (required <= g_model.config.seq_len || truncation != "auto") {
+        if (required <= cur_model().config.seq_len || truncation != "auto") {
             break
         }
         let next = next_user_start(msgs_v, start)
         if (next < 0) {
             bad_request(srv, writer,
-                        "the system prompt, tools, and latest turn need {required} tokens including the requested output; the model context is {g_model.config.seq_len} - shorten the request, lower max_tokens, or raise --ctx")
+                        "the system prompt, tools, and latest turn need {required} tokens including the requested output; the model context is {cur_model().config.seq_len} - shorten the request, lower max_tokens, or raise --ctx")
             return
         }
         to_log(LOG_INFO, "/v1/chat/completions: auto truncation dropped messages [0, {next}) to reserve {max_new} output tokens\n")
@@ -1280,6 +1421,9 @@ def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var
     }
     defer() { unsafe { delete js } }
     warn_ignored_fields(js, COMPL_FIELDS, "/v1/completions")
+    if (!resolve_stream_slot(srv, writer, js)) {
+        return
+    }
     let prompt = js?["prompt"] ?? ""
     if (empty(prompt)) {
         bad_request(srv, writer, "'prompt' must be a non-empty string")
@@ -1289,7 +1433,7 @@ def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var
     let params = parse_sampling(js)
     let seed = js?["seed"] ?? 0
     let max_new = clamp_max(js?["max_tokens"] ?? g_default_max_new)
-    var toks <- encode(g_model, prompt, true, false)
+    var toks <- encode(cur_model(), prompt, true, false)
     defer() { delete toks }
     // no stop ids and no close: raw completions run to the budget, matching bare generate()
     var none_stop : array<int64>
@@ -1304,7 +1448,7 @@ def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var
 def private reap_disconnected(srv : WebSocketServer) {
     for (id, w in keys(g_wires), values(g_wires)) {
         if (!is_writer_connected(srv, w.writer)) {
-            evict(g_sched, id, g_events)
+            evict(g_slots[w.slot].sched, id, g_events)
         }
     }
     var disconnected_asr : array<int64>
@@ -1330,6 +1474,7 @@ def private flush_tool_keepalives(srv : WebSocketServer) {
         var w = unsafe(g_wires?[id])
         if (w != null && w.streaming && w.has_tools &&
             get_time_usec(w.last_keepalive_ticks) >= 10000000) {
+            g_cur = w.slot
             send_chat_chunk(srv, w.writer, w.id, w.created, "", "", "")
             w.last_keepalive_ticks = ref_time_ticks()
         }
@@ -1346,6 +1491,7 @@ def private flush_events(srv : WebSocketServer) {
         if (w == null) {
             continue
         }
+        g_cur = w.slot   // response builders read the wire's slot (cur_name / cur_model)
         if (e.kind == SchedEventKind.piece) {
             if (!w.streaming || w.has_tools) {
                 w.reply_parts |> push(e.text)   // buffered reply, and/or the finish-time tool-call parse
@@ -1415,7 +1561,7 @@ def private flush_events(srv : WebSocketServer) {
                     finish = "tool_calls"
                 }
             }
-            var out = OaiChatResponse(id = w.id, _object = "chat.completion", created = w.created, model = g_model_name)
+            var out = OaiChatResponse(id = w.id, _object = "chat.completion", created = w.created, model = cur_name())
             out.choices |> emplace(OaiChoice(index = 0,
                                              message <- OaiMessage(role = "assistant", content = content,
                                                                    tool_calls <- calls),
@@ -1426,7 +1572,7 @@ def private flush_events(srv : WebSocketServer) {
             respond(srv, w.writer, int(http_status.OK), "application/json", sprint_json(out, false))
             delete out
         } else {
-            var out = OaiComplResponse(id = w.id, _object = "text_completion", created = w.created, model = g_model_name)
+            var out = OaiComplResponse(id = w.id, _object = "text_completion", created = w.created, model = cur_name())
             out.choices |> push(OaiComplChoice(index = 0, text = join(w.reply_parts, ""), finish_reason = e.finish))
             out.usage = OaiUsage(prompt_tokens = e.n_prompt, completion_tokens = e.n_gen,
                                  total_tokens = e.n_prompt + e.n_gen)
@@ -1443,8 +1589,34 @@ def private flush_events(srv : WebSocketServer) {
 }
 
 // /v1/stats: the scheduler's counters as JSON (buffered — cheap enough to run in-handler).
+// Top-level counters describe the ACTIVE slot (single-model deployments see the old shape
+// unchanged); `models` carries one entry per slot for the page's roster panel.
+struct private OaiSlotStats {
+    name : string
+    is_default : bool
+    is_active : bool          // the slot the tick loop is stepping (post-P2: the GPU owner)
+    backend : string          // requested: auto | cpu | gpu
+    backend_effective : string
+    ctx : int64
+    active : int64
+    queued : int64
+    admitted : int64
+    finished : int64
+    gen_tokens : int64
+    cached_tokens : int64
+    prefill_tokens : int64
+    prefix_pages : int64
+    weights_bytes : int64
+    kv_bytes : int64
+    last_used_s : float       // seconds since this slot last admitted a request (-1 = never)
+    sw_count : int64          // P2 gpu-switch telemetry
+    sw_avg_ms : float
+}
+
 struct private OaiStatsResponse {
     model : string
+    active_model : string
+    models : array<OaiSlotStats>
     ctx : int64
     uptime_s : int64
     draining : bool
@@ -1480,35 +1652,61 @@ struct private OaiStatsResponse {
 }
 
 def private handle_stats(var resp : HttpResponse?) : http_status {
-    let out = OaiStatsResponse(
-        model = g_model_name, ctx = g_model.config.seq_len,
+    var out = OaiStatsResponse(
+        model = g_slots[g_active].name, active_model = g_slots[g_active].name,
+        ctx = g_slots[g_active].model.config.seq_len,
         uptime_s = g_started_at > 0l ? get_time_nsec(g_started_at) / 1_000_000_000l : 0l,
         draining = g_shutdown_requested,
-        active = n_active(g_sched), queued = n_queued(g_sched), peak_active = g_sched.peak_active,
-        admitted = g_sched.n_admitted, finished = g_sched.n_finished, evicted = g_sched.n_evicted,
-        decode_steps = g_sched.decode_steps, gen_tokens = g_sched.gen_tokens,
-        avg_batch = float(g_sched.sum_batch) / float(max(g_sched.decode_steps, 1l)),
-        cached_tokens = g_sched.cached_tokens, prefix_pages = prefix_held_groups(g_sched.prefix),
-        max_streams = g_sched.max_streams, chunk_tokens = g_sched.chunk_tokens,
+        active = n_active(g_slots[g_active].sched), queued = n_queued(g_slots[g_active].sched),
+        peak_active = g_slots[g_active].sched.peak_active,
+        admitted = g_slots[g_active].sched.n_admitted, finished = g_slots[g_active].sched.n_finished,
+        evicted = g_slots[g_active].sched.n_evicted,
+        decode_steps = g_slots[g_active].sched.decode_steps, gen_tokens = g_slots[g_active].sched.gen_tokens,
+        avg_batch = float(g_slots[g_active].sched.sum_batch) / float(max(g_slots[g_active].sched.decode_steps, 1l)),
+        cached_tokens = g_slots[g_active].sched.cached_tokens,
+        prefix_pages = prefix_held_groups(g_slots[g_active].sched.prefix),
+        max_streams = g_slots[g_active].sched.max_streams, chunk_tokens = g_slots[g_active].sched.chunk_tokens,
         asr_workers = g_asr_worker_count, asr_ready = g_asr_ready,
         asr_active = g_asr_active, asr_pending = g_asr_pending,
-        mtp_drafted = g_sched.mtp_drafted, mtp_accepted = g_sched.mtp_accepted,
-        prefill_tokens = g_sched.prefill_tokens,
-        ttft_avg_ms = g_sched.ttft_count > 0l ? float(g_sched.ttft_sum_us / g_sched.ttft_count) / 1000.0 : 0.0,
-        ttft_last_ms = float(g_sched.last_ttft_us) / 1000.0,
-        weights_bytes = model_weights_bytes(g_model),
-        kv_bytes = kv_pool_bytes(g_sched.pool),
+        mtp_drafted = g_slots[g_active].sched.mtp_drafted, mtp_accepted = g_slots[g_active].sched.mtp_accepted,
+        prefill_tokens = g_slots[g_active].sched.prefill_tokens,
+        ttft_avg_ms = g_slots[g_active].sched.ttft_count > 0l
+            ? float(g_slots[g_active].sched.ttft_sum_us / g_slots[g_active].sched.ttft_count) / 1000.0 : 0.0,
+        ttft_last_ms = float(g_slots[g_active].sched.last_ttft_us) / 1000.0,
+        weights_bytes = model_weights_bytes(g_slots[g_active].model),
+        kv_bytes = kv_pool_bytes(g_slots[g_active].sched.pool),
         heap_bytes = int64(heap_bytes_allocated()),
         string_heap_bytes = int64(string_heap_bytes_allocated()),
         hardware = g_hardware_line,
         asr_done_jobs = g_asr_done_jobs, asr_audio_s = g_asr_audio_s)
-    return resp |> JSON(sprint_json(out, false), http_status.OK)
+    out.models |> reserve(length(g_slots))
+    for (i in range(length(g_slots))) {
+        var s & = unsafe(g_slots[i])
+        out.models |> push(OaiSlotStats(
+            name = s.name, is_default = s.is_default, is_active = i == g_active,
+            backend = s.opts.backend, backend_effective = s.backend_effective,
+            ctx = s.model.config.seq_len,
+            active = n_active(s.sched), queued = n_queued(s.sched),
+            admitted = s.sched.n_admitted, finished = s.sched.n_finished,
+            gen_tokens = s.sched.gen_tokens, cached_tokens = s.sched.cached_tokens,
+            prefill_tokens = s.sched.prefill_tokens,
+            prefix_pages = prefix_held_groups(s.sched.prefix),
+            weights_bytes = model_weights_bytes(s.model),
+            kv_bytes = kv_pool_bytes(s.sched.pool),
+            last_used_s = s.last_used > 0l ? age_seconds(s.last_used) : -1.0,
+            sw_count = s.sw_count,
+            sw_avg_ms = s.sw_count > 0l ? float(s.sw_us / s.sw_count) / 1000.0 : 0.0))
+    }
+    let body = sprint_json(out, false)
+    delete out
+    return resp |> JSON(body, http_status.OK)
 }
 
 // /v1/streams: the poll surface behind the page's swimlane + stream cards — per-stream state,
 // token counts, TTFT, and capped text tails. Finished streams linger ~10 s flagged "finished".
 struct private OaiStreamInfo {
     id : int64
+    model : string       // the slot this stream runs on
     state : string       // "queued" | "prefilling" | "decoding" | "finished"
     finish : string      // finished only: "stop" | "length" | "evicted"
     age_s : float
@@ -1524,6 +1722,7 @@ struct private OaiStreamInfo {
 
 // One prefix-cache donation chain: what a re-sent conversation would reuse.
 struct private OaiCacheEntry {
+    model : string
     tokens : int64
     pages : int64
     hits : int64
@@ -1556,41 +1755,46 @@ def private age_seconds(t : int64) : float {
 }
 
 def private handle_streams(var resp : HttpResponse?) : http_status {
-    var out = OaiStreamsResponse(max_streams = g_sched.max_streams)
-    out.streams |> reserve(length(g_sched.streams) + length(g_sched.queue) + length(g_sched.recent_done))
-    for (st in g_sched.streams) {
-        out.streams |> push(OaiStreamInfo(
-            id = st.id,
-            state = st.state == StreamState.prefilling ? "prefilling" : "decoding",
-            age_s = age_seconds(st.t_admit),
-            n_prompt = int64(length(st.prompt)), n_cached = st.n_cached,
-            n_prefilled = st.n_prefilled, n_gen = st.n_gen, max_new = st.max_new,
-            ttft_ms = float(st.ttft_us) / 1000.0,
-            prompt_head = st.prompt_head, gen_tail = utf8_trim_partial_end(string(st.gen_tail_bytes))))
+    var out = OaiStreamsResponse(max_streams = g_slots[g_active].sched.max_streams)
+    for (slot in g_slots) {
+        var sch & = unsafe(slot.sched)
+        let mname = slot.name
+        out.streams |> reserve(length(out.streams) + length(sch.streams) + length(sch.queue) + length(sch.recent_done))
+        for (st in sch.streams) {
+            out.streams |> push(OaiStreamInfo(
+                id = st.id, model = mname,
+                state = st.state == StreamState.prefilling ? "prefilling" : "decoding",
+                age_s = age_seconds(st.t_admit),
+                n_prompt = int64(length(st.prompt)), n_cached = st.n_cached,
+                n_prefilled = st.n_prefilled, n_gen = st.n_gen, max_new = st.max_new,
+                ttft_ms = float(st.ttft_us) / 1000.0,
+                prompt_head = st.prompt_head, gen_tail = utf8_trim_partial_end(string(st.gen_tail_bytes))))
+        }
+        for (q in sch.queue) {
+            out.streams |> push(OaiStreamInfo(
+                id = q.id, model = mname, state = "queued",
+                age_s = q.t_submit != 0l ? age_seconds(q.t_submit) : 0.0,
+                n_prompt = int64(length(q.prompt)), max_new = q.max_new))
+        }
+        for (d in sch.recent_done) {
+            out.streams |> push(OaiStreamInfo(
+                id = d.id, model = mname, state = "finished", finish = d.finish,
+                n_prompt = d.n_prompt, n_cached = d.n_cached, n_prefilled = d.n_prompt, n_gen = d.n_gen,
+                ttft_ms = float(d.ttft_us) / 1000.0,
+                prompt_head = d.prompt_head, gen_tail = utf8_trim_partial_end(d.gen_tail)))
+        }
+        var chains <- prefix_chain_list(sch.prefix)
+        out.cache |> reserve(length(out.cache) + length(chains))
+        for (c in chains) {
+            let age = age_seconds(c.born_at)
+            out.cache |> push(OaiCacheEntry(
+                model = mname,
+                tokens = c.n_tokens, pages = c.pages_live, hits = c.hits, age_s = age,
+                idle_s = c.last_hit_at != 0l ? age_seconds(c.last_hit_at) : age,
+                preview = c.preview))
+        }
+        delete chains
     }
-    for (q in g_sched.queue) {
-        out.streams |> push(OaiStreamInfo(
-            id = q.id, state = "queued",
-            age_s = q.t_submit != 0l ? age_seconds(q.t_submit) : 0.0,
-            n_prompt = int64(length(q.prompt)), max_new = q.max_new))
-    }
-    for (d in g_sched.recent_done) {
-        out.streams |> push(OaiStreamInfo(
-            id = d.id, state = "finished", finish = d.finish,
-            n_prompt = d.n_prompt, n_cached = d.n_cached, n_prefilled = d.n_prompt, n_gen = d.n_gen,
-            ttft_ms = float(d.ttft_us) / 1000.0,
-            prompt_head = d.prompt_head, gen_tail = utf8_trim_partial_end(d.gen_tail)))
-    }
-    var chains <- prefix_chain_list(g_sched.prefix)
-    out.cache |> reserve(length(chains))
-    for (c in chains) {
-        let age = age_seconds(c.born_at)
-        out.cache |> push(OaiCacheEntry(
-            tokens = c.n_tokens, pages = c.pages_live, hits = c.hits, age_s = age,
-            idle_s = c.last_hit_at != 0l ? age_seconds(c.last_hit_at) : age,
-            preview = c.preview))
-    }
-    delete chains
     out.asr |> reserve(length(g_asr_recent))
     for (j in g_asr_recent) {
         out.asr |> push(OaiAsrRow(
@@ -1604,13 +1808,103 @@ def private handle_streams(var resp : HttpResponse?) : http_status {
 
 // key -> expected JSON kind for POST /config bodies: "s"tring | "i"nteger | "b"ool. The one
 // schema the save endpoint validates against — mirrors ServerArgs (main.das CONFIG_KEYS).
+// "models" is the [[models]] array-of-tables; entries validate against MODEL_KEY_KINDS.
 let private CONFIG_KEY_KINDS <- {
     "model" => "s", "port" => "i", "quant" => "s", "kv_dtype" => "s", "metal" => "s",
     "gpu" => "s", "gpu_layers" => "i", "gpu_stream" => "i", "gpu_dn" => "b", "gpu_attn" => "b",
     "gpu_dense" => "b", "gpu_vram_mb" => "i", "asr" => "s", "mmproj" => "s", "asr_workers" => "i",
     "ctx" => "i", "max_tokens" => "i", "streams" => "i", "threads" => "i", "team_dispatch" => "s",
     "affinity" => "i", "chunk" => "i", "page_rows" => "i", "prefix" => "i", "flat" => "b",
-    "mtp" => "b", "lcpp_bin" => "s"
+    "mtp" => "b", "lcpp_bin" => "s", "models" => "a"
+}
+
+let private MODEL_KEY_KINDS <- {
+    "name" => "s", "path" => "s", "backend" => "s", "ctx" => "i", "quant" => "s",
+    "kv_dtype" => "s", "streams" => "i", "chunk" => "i", "page_rows" => "i", "prefix" => "i",
+    "mtp" => "b", "default" => "b"
+}
+
+// Validate + sanitize a POST /config "models" array: objects only, per-key kinds, a non-empty
+// path per entry, backend in {auto, cpu, gpu}, unique route names, at most one default = true.
+// Returns the sanitized array (JV) or null with verr set.
+def private validate_models_array(v : JsonValue?; var verr : string&) : JsonValue? {
+    if (v == null || !(v.value is _array)) {
+        verr = "'models' must be an array of model entries"
+        return null
+    }
+    var marr : array<JsonValue?>
+    var names : table<string>
+    var ndefault = 0
+    for (e in v.value as _array) {
+        if (e == null || !(e.value is _object)) {
+            verr = "'models' entries must be objects"
+            break
+        }
+        var ent : table<string; JsonValue?>
+        for (mk, mv in keys(e.value as _object), values(e.value as _object)) {
+            let kind = MODEL_KEY_KINDS?[mk] ?? ""
+            if (empty(kind)) {
+                verr = "unknown models key '{mk}'"
+                break
+            }
+            if (kind == "s" && mv != null && (mv.value is _string)) {
+                ent |> insert(mk, JV(mv.value as _string))
+            } elif (kind == "i" && mv != null && (mv.value is _longint)) {
+                ent |> insert(mk, JV(mv.value as _longint))
+            } elif (kind == "i" && mv != null && (mv.value is _number) && (mv.value as _number) == floor(mv.value as _number)) {
+                ent |> insert(mk, JV(int64(mv.value as _number)))
+            } elif (kind == "b" && mv != null && (mv.value is _bool)) {
+                ent |> insert(mk, JV(mv.value as _bool))
+            } else {
+                verr = "models key '{mk}' must be a {kind_name(kind)}"
+                break
+            }
+        }
+        if (!empty(verr)) {
+            var junk = JV(ent)
+            unsafe {
+                delete junk
+            }
+            break
+        }
+        let path = e?["path"] ?? ""
+        if (empty(path)) {
+            verr = "every models entry needs a non-empty 'path'"
+        } else {
+            let backend = e?["backend"] ?? "auto"
+            if (backend != "auto" && backend != "cpu" && backend != "gpu") {
+                verr = "models backend '{backend}' is not auto | cpu | gpu"
+            }
+        }
+        let rname = e?["name"] ?? ""
+        let route = empty(rname) ? base_name(e?["path"] ?? "") : rname
+        if (empty(verr) && key_exists(names, route)) {
+            verr = "duplicate models name '{route}'"
+        }
+        if (empty(verr) && (e?["default"] ?? false)) {
+            ndefault ++
+            if (ndefault > 1) {
+                verr = "more than one models entry marked default = true"
+            }
+        }
+        if (!empty(verr)) {
+            var junk = JV(ent)
+            unsafe {
+                delete junk
+            }
+            break
+        }
+        names |> insert(route)
+        marr |> push(JV(ent))
+    }
+    if (!empty(verr)) {
+        var junk = JV(marr)
+        unsafe {
+            delete junk
+        }
+        return null
+    }
+    return JV(marr)
 }
 
 // POST /vad: the page's waveform-overlay preview — silero speech spans over an uploaded clip.
@@ -1700,7 +1994,7 @@ def private handle_config_get(var resp : HttpResponse?) : http_status {
     var extras <- {
         "model_files" => JV(entries),
         "active_model" => JV(base_name(g_config_model_path)),
-        "dlim_rail" => JV(g_model.image_map != null),
+        "dlim_rail" => JV(g_slots[g_default_slot].model.image_map != null),
         "metal" => JV("{get_metal_mode()}"),
         "gpu" => JV((
             backend = tier.backend, supported = tier.supported, reason = tier.reason,
@@ -1746,6 +2040,12 @@ def private handle_config_save(var req : HttpRequest?; var resp : HttpResponse?)
         if (v == null) {
             verr = "config key '{k}' is null"
             break
+        }
+        if (kind == "a") {
+            var sanitized = validate_models_array(v, verr)
+            break if (!empty(verr))
+            out_tab |> insert(k, sanitized)
+            continue
         }
         if (kind == "s" && (v.value is _string)) {
             out_tab |> insert(k, JV(v.value as _string))
@@ -2122,7 +2422,7 @@ class OpenAiServer : HvWebServer {
             if (!g_shutdown_requested) {
                 to_log(
                     LOG_INFO,
-                    "dasllama-server: restart requested; draining llm_active={n_active(g_sched)}, llm_queued={n_queued(g_sched)}, asr_pending={g_asr_pending}\n")
+                    "dasllama-server: restart requested; draining llm_active={total_active()}, llm_queued={total_queued()}, asr_pending={g_asr_pending}\n")
             }
             g_shutdown_requested = true
             g_restart_requested = true
@@ -2132,7 +2432,7 @@ class OpenAiServer : HvWebServer {
             if (!g_shutdown_requested) {
                 to_log(
                     LOG_INFO,
-                    "dasllama-server: graceful shutdown requested; draining llm_active={n_active(g_sched)}, llm_queued={n_queued(g_sched)}, asr_pending={g_asr_pending}\n")
+                    "dasllama-server: graceful shutdown requested; draining llm_active={total_active()}, llm_queued={total_queued()}, asr_pending={g_asr_pending}\n")
             }
             g_shutdown_requested = true
             return resp |> JSON("\{\"ok\":true,\"draining\":true}", http_status.OK)
@@ -2194,22 +2494,41 @@ def init_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; c
     g_bench_state = "idle"
     g_bench_result_json = ""
     start_asr_worker_threads()
-    var pfx = prefix_groups
-    if (page_rows > 0l && pfx == 0l) {   // auto: retain up to one full context per stream slot
-        pfx = max_streams * ((g_model.config.seq_len + page_rows - 1l) / page_rows)
+    if (empty(g_slots)) {
+        to_log(LOG_ERROR, "dasllama-server: init_server with no model slots (call set_model/add_model first)\n")
+        return false
     }
-    if (pfx < 0l) {
-        pfx = 0l   // explicit unbounded
+    // one scheduler per slot: the init args are the defaults, SlotOpts sentinels override per slot
+    for (s in g_slots) {
+        let s_streams = s.opts.streams >= 0l ? s.opts.streams : max_streams
+        let s_chunk = s.opts.chunk >= 0l ? s.opts.chunk : chunk_tokens
+        let s_pages = s.opts.page_rows != -2l ? s.opts.page_rows : page_rows
+        var pfx = s.opts.prefix != -2l ? s.opts.prefix : prefix_groups
+        if (s_pages > 0l && pfx == 0l) {   // auto: retain up to one full context per stream slot
+            pfx = s_streams * ((s.model.config.seq_len + s_pages - 1l) / s_pages)
+        }
+        if (pfx < 0l) {
+            pfx = 0l   // explicit unbounded
+        }
+        let s_kv = s.opts.kv_dtype_set ? s.opts.kv_dtype : kv_dtype
+        var spec = s.opts.mtp >= 0 ? s.opts.mtp != 0 : mtp
+        if (spec && s.model.config.n_layer_nextn <= 0l) {
+            to_log(LOG_WARNING, "dasllama-server: mtp requested for {s.name} but the model has no NextN head — self-spec stays off\n")
+            spec = false
+        }
+        s.sched <- create_scheduler(s.model, s_streams, max_queue, s_chunk, s_pages, pfx, s_kv, spec)
     }
-    var spec = mtp
-    if (spec && g_model.config.n_layer_nextn <= 0l) {
-        to_log(LOG_WARNING, "dasllama-server: --mtp requested but the model has no NextN head — self-spec stays off\n")
-        spec = false
-    }
+    g_active = g_default_slot
+    g_cur = g_default_slot
     g_prev_mtp_spec = get_mtp_spec()
     g_mtp_spec_changed = true
-    set_mtp_spec(spec)   // engine gate: prefills maintain the draft head's KV (chunked included); restored at exit
-    g_sched <- create_scheduler(g_model, max_streams, max_queue, chunk_tokens, page_rows, pfx, kv_dtype, spec)
+    // engine gate: prefills maintain the draft head's KV (chunked included); follows the stepped
+    // slot on switch (update_server); restored at exit
+    set_mtp_spec(g_slots[g_active].sched.mtp)
+    // the single shared KV mirror + chunked multi-stream prefill don't mix: a second stream's
+    // resident prefill would strand the first's device-only KV. The batch-decode override (which
+    // resyncs host<->mirror per step) stays on; per-slot mirrors re-enable device prefill here.
+    set_resident_prefill_allowed(false)
     g_server = new OpenAiServer()
     g_server->init(port)
     let rc = g_server->start()   // 0 on success; non-zero = bind/listen failed (e.g. port in use)
@@ -2220,11 +2539,24 @@ def init_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; c
     g_server_started = true
     g_started_at = ref_time_ticks()
     compose_hardware_line()
-    let pfx_desc = pfx > 0l ? "{pfx}" : "unbounded"
-    let kv_mode = page_rows > 0l ? "{kv_dtype} paged P={page_rows}, prefix cache {pfx_desc} pages" : "{kv_dtype} flat"
-    let spec_desc = spec ? ", mtp: on" : ""
-    to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (model: {g_model_name}, streams: {max_streams}, prefill chunk: {chunk_tokens}, kv: {kv_mode}{spec_desc})\n")
+    var names <- [for (s in g_slots); s.is_default && length(g_slots) > 1 ? "{s.name}*" : s.name]
+    let kv_mode = page_rows > 0l ? "{kv_dtype} paged P={page_rows}" : "{kv_dtype} flat"
+    to_log(LOG_INFO, "dasllama-server listening on http://127.0.0.1:{port}/v1  (models: {join(names, ", ")}; streams: {max_streams}, prefill chunk: {chunk_tokens}, kv: {kv_mode})\n")
+    delete names
     return true
+}
+
+// Round-robin pick of the next slot to step, starting AFTER the last stepped one so concurrent
+// work on several slots interleaves fairly. -1 = everything idle.
+def private pick_step_slot : int {
+    let n = length(g_slots)
+    for (k in range(n)) {
+        let i = (g_active + 1 + k) % n
+        if (n_active(g_slots[i].sched) > 0l || n_queued(g_slots[i].sched) > 0l) {
+            return i
+        }
+    }
+    return -1
 }
 
 //! Drive one non-blocking server iteration. False means the graceful drain completed (or the
@@ -2237,17 +2569,27 @@ def update_server() : bool {
     drain_asr_events(g_server.server)
     drain_bench_events()
     reap_disconnected(g_server.server)
-    let t_step = ref_time_ticks()
-    let busy = scheduler_step(g_model, g_sched, g_events)
-    let step_ms = int64(get_time_usec(t_step)) / 1000l
-    if (step_ms > 3000l) {
-        // the "why does it pause" catcher: one decode step / prefill chunk should be
-        // well under a second — anything slower means contention or a stall
-        to_log(LOG_WARNING, "dasllama-server: slow scheduler step: {step_ms}ms (active={n_active(g_sched)}, queued={n_queued(g_sched)})\n")
+    // serialized multi-model stepping: ONE scheduler step per tick, slots with work interleave
+    // round-robin. Switching the stepped slot is free in P1 (P2 hangs the GPU rebind here).
+    let si = pick_step_slot()
+    var busy = false
+    if (si >= 0) {
+        if (si != g_active) {
+            g_active = si
+            set_mtp_spec(g_slots[si].sched.mtp)   // the engine prefill-warm gate follows the stepped slot
+        }
+        let t_step = ref_time_ticks()
+        busy = scheduler_step(g_slots[si].model, g_slots[si].sched, g_events)
+        let step_ms = int64(get_time_usec(t_step)) / 1000l
+        if (step_ms > 3000l) {
+            // the "why does it pause" catcher: one decode step / prefill chunk should be
+            // well under a second — anything slower means contention or a stall
+            to_log(LOG_WARNING, "dasllama-server: slow scheduler step: {step_ms}ms ({g_slots[si].name}: active={n_active(g_slots[si].sched)}, queued={n_queued(g_slots[si].sched)})\n")
+        }
     }
     flush_events(g_server.server)
     flush_tool_keepalives(g_server.server)
-    if (g_shutdown_requested && n_active(g_sched) == 0l && n_queued(g_sched) == 0l &&
+    if (g_shutdown_requested && total_active() == 0l && total_queued() == 0l &&
         g_asr_pending == 0) {
         to_log(LOG_INFO, "dasllama-server: graceful shutdown drain complete\n")
         return false
@@ -2275,9 +2617,11 @@ def shutdown_server() {
         g_server = null
     }
     unsafe {
-        delete g_sched   // live sessions + workspace go with it (writers already died with the server)
+        delete g_slots   // per slot: live sessions + workspace + the model go together (writers already died with the server)
     }
-    g_sched = Scheduler()
+    g_default_slot = 0
+    g_active = 0
+    g_cur = 0
     delete g_events
     delete g_wires
     delete g_asr_wires
@@ -2303,9 +2647,6 @@ def shutdown_server() {
         set_mtp_spec(g_prev_mtp_spec)   // a /shutdown + restart in the same context starts from a clean gate
         g_mtp_spec_changed = false
     }
-    delete g_model
-    g_model = Model()
-    g_model_name = ""
     g_has_asr = false
     g_asr_path = ""
     g_asr_mmproj = ""

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1777,12 +1777,16 @@ struct private OaiStatsResponse {
     kv_bytes : int64
     heap_bytes : int64
     string_heap_bytes : int64
+    gpu_vram_bytes : int64    // resident weight bytes on the device (0 = no tier / nothing resident)
+    gpu_budget_bytes : int64  // the tier's weight cap — the page's VRAM bar denominator
     hardware : string
     asr_done_jobs : int64
     asr_audio_s : float
 }
 
 def private handle_stats(var resp : HttpResponse?) : http_status {
+    // budget only when the tier is already live: the budget hook inits the device on first call
+    let tier = gpu_tier_status()
     var out = OaiStatsResponse(
         model = g_slots[g_active].name, active_model = g_slots[g_active].name,
         ctx = g_slots[g_active].model.config.seq_len,
@@ -1808,6 +1812,8 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
         kv_bytes = kv_pool_bytes(g_slots[g_active].sched.pool),
         heap_bytes = int64(heap_bytes_allocated()),
         string_heap_bytes = int64(string_heap_bytes_allocated()),
+        gpu_vram_bytes = tier.vram_bytes,
+        gpu_budget_bytes = (tier.supported || tier.vram_bytes > 0l) ? moe_gpu_weight_budget() : 0l,
         hardware = g_hardware_line,
         asr_done_jobs = g_asr_done_jobs, asr_audio_s = g_asr_audio_s)
     out.models |> reserve(length(g_slots))

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -60,22 +60,27 @@ struct ModelSlot {
     backend_effective : string = "cpu"   // arm outcome: cpu | gpu:rails | gpu:resident
     is_default : bool
     last_used : int64
-    sw_count : int64                // P2 gpu-switch telemetry (count / total usec)
+    sw_count : int64                // gpu-switch telemetry (count / total usec)
     sw_us : int64
+    gpu_want : GpuTierWant = GpuTierWant()   // the tier request this slot re-arms with on switch-in
+    gpu_capable : bool              // want is non-zero and backend != cpu (set_slot_gpu_want)
+    gpu_marks : GpuModelMarks <- GpuModelMarks()   // this model's tier routing marks while NOT installed
 }
 
 var g_slots : array<ModelSlot>
 var g_default_slot = 0
-var g_active = 0                // slot the tick loop stepped last (post-P2: the GPU owner)
+var g_active = 0                // slot the tick loop stepped last
 var g_cur = 0                   // slot the request being handled resolved to (handlers are serial)
+var g_gpu_owner = -1            // slot holding the GPU tier's VRAM state (-1 = none)
+var g_marks_slot = -1           // slot whose routing marks are INSTALLED in the engine globals
 
-def private cur_model : Model& {
+def private cur_model : Model & {
     unsafe {
         return g_slots[g_cur].model
     }
 }
 
-def private cur_sched : Scheduler& {
+def private cur_sched : Scheduler & {
     unsafe {
         return g_slots[g_cur].sched
     }
@@ -151,7 +156,19 @@ def add_model(var m : Model; name : string; opts : SlotOpts = SlotOpts()) {
     var slot <- ModelSlot(name = name, is_default = empty(g_slots))
     slot.model <- m
     slot.opts = opts
+    // the load's arm outcome (routing marks + resident-driver state) belongs to THIS slot:
+    // capture it, so two models' offset-keyed marks never mix. Whichever slot is stepped gets
+    // its set re-installed (install_slot_marks); an armed capture makes this slot the GPU owner.
+    // Attribution reads the CAPTURED marks, not the process-global VRAM counter — that still
+    // holds the previous load's bytes when a later CPU-only slot loads.
+    let was_resident = moe_gpu_resident_active()
+    moe_gpu_model_marks_save(slot.gpu_marks)
+    let was_gpu = was_resident || moe_gpu_marks_armed(slot.gpu_marks.marks)
+    slot.backend_effective = was_resident ? "gpu:resident" : (was_gpu ? "gpu:rails" : "cpu")
     g_slots |> emplace(slot)
+    if (was_gpu) {
+        g_gpu_owner = length(g_slots) - 1
+    }
 }
 
 //! Move a loaded model into the server as the ONLY slot (call once, before run_server). ``name``
@@ -164,7 +181,80 @@ def set_model(var m : Model; name : string) {
     g_default_slot = 0
     g_active = 0
     g_cur = 0
+    g_gpu_owner = -1
+    g_marks_slot = -1
     add_model(m, name)
+}
+
+//! Record the GPU tier want slot `name` re-arms with when the tier switches to it (main.das
+//! passes the same want it set before that slot's load). A zero want or ``backend = "cpu"``
+//! keeps the slot off the device permanently.
+def set_slot_gpu_want(name : string; want : GpuTierWant) {
+    for (s in g_slots) {
+        if (s.name == name) {
+            s.gpu_want = want
+            s.gpu_capable = (s.opts.backend != "cpu"
+                && (want.auto_tier || want.moe_layers != 0l || want.moe_stream != 0l || want.dn
+                    || want.attn || want.dense || want.dnd || want.shexp || want.qkv || want.heat > 0l))
+        }
+    }
+}
+
+// The stepped slot's marks must be the installed ones — swap on change (pure table moves, no
+// device work; this is what keeps gpu<->cpu slot alternation free).
+def private install_slot_marks(si : int) {
+    if (g_marks_slot == si) {
+        return
+    }
+    if (g_marks_slot >= 0 && g_marks_slot < length(g_slots)) {
+        moe_gpu_model_marks_save(g_slots[g_marks_slot].gpu_marks)
+    }
+    moe_gpu_model_marks_restore(g_slots[si].gpu_marks)
+    g_marks_slot = si
+}
+
+// Move the GPU tier's VRAM state to slot `si`: hydrate + drop the current owner's whole state,
+// re-arm `si` from its mmap'd image (the same walk its load ran). Serialized with stepping —
+// only called between scheduler steps.
+def private bind_gpu_slot(si : int) {
+    if (g_gpu_owner == si || !g_slots[si].gpu_capable) {
+        return
+    }
+    let t0 = ref_time_ticks()
+    let prev = g_gpu_owner
+    var prev_note = ""
+    if (prev >= 0) {
+        install_slot_marks(prev)   // the drop acts on the INSTALLED per-model state
+        for (st in g_slots[prev].sched.streams) {   // server flow keeps host KV authoritative; belt-and-braces
+            moe_gpu_hydrate_session(g_slots[prev].model, st.session)
+        }
+        moe_gpu_drop_model()
+        g_slots[prev].backend_effective = "cpu"
+        prev_note = "from {g_slots[prev].name}, "
+    }
+    install_slot_marks(si)
+    set_gpu_tier_want(g_slots[si].gpu_want)
+    moe_gpu_tier_arm()
+    moe_gpu_upload_resident(g_slots[si].model)
+    g_gpu_owner = si
+    let us = int64(get_time_usec(t0))
+    g_slots[si].sw_count ++
+    g_slots[si].sw_us += us
+    g_slots[si].backend_effective = (moe_gpu_resident_active() ? "gpu:resident"
+        : (gpu_tier_status().vram_bytes > 0l ? "gpu:rails" : "cpu"))
+    to_log(LOG_INFO, "dasllama-server: GPU tier -> {g_slots[si].name} ({prev_note}{us / 1000l}ms, {g_slots[si].backend_effective})\n")
+}
+
+// Auto-switch policy: move the tier to a gpu-wanting slot only when the current owner is idle
+// (drain, never preempt — its live streams keep their device speed). gpu<->cpu alternation
+// never lands here: cpu slots are not gpu_capable and never evict the owner.
+def private maybe_bind_gpu(si : int) {
+    if (g_gpu_owner == si || !g_slots[si].gpu_capable
+            || (g_gpu_owner >= 0
+                && (n_active(g_slots[g_gpu_owner].sched) > 0l || n_queued(g_slots[g_gpu_owner].sched) > 0l))) {
+        return
+    }
+    bind_gpu_slot(si)
 }
 
 //! Record a slot's backend arm outcome for the stats/config surfaces (P1: coarse gpu/cpu; the
@@ -1081,6 +1171,7 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
         return resp_error(resp, http_status.NOT_FOUND, "model '{want_model}' not found — GET /v1/models lists the served ids")
     }
     g_cur = mi
+    install_slot_marks(mi)   // this handler evals IN-handler — the embed forward needs ITS marks
     let iv = js?["input"]
     if (iv == null) {
         return resp_error(resp, http_status.BAD_REQUEST, "'input' is required (a string or array of strings)")
@@ -1112,6 +1203,45 @@ def private handle_embeddings(var req : HttpRequest?; var resp : HttpResponse?) 
     }
     out.usage = OaiEmbUsage(prompt_tokens = prompt_tokens, total_tokens = prompt_tokens)
     return resp |> JSON(sprint_json(out, false), http_status.OK)
+}
+
+// POST /v1/models/activate {"model": name}: admin warm-switch — make `name` the stepped slot
+// and move the GPU tier to it NOW instead of waiting for the owner to drain. 409 while any
+// work is live: the switch drops the owner's whole VRAM state.
+def private handle_activate(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    var perr = ""
+    var js = read_json(string(req.body), perr)
+    if (js == null) {
+        return resp_error(resp, http_status.BAD_REQUEST, "invalid JSON: {perr}")
+    }
+    defer() {
+        unsafe {
+            delete js
+        }
+    }
+    let want = js?["model"] ?? ""
+    let mi = slot_index(want)
+    if (mi < 0) {
+        return resp |> JSON(
+            error_body("model '{want}' not found — GET /v1/models lists the served ids", "model_not_found"),
+            http_status.NOT_FOUND)
+    }
+    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0) {
+        return resp |> JSON(
+            error_body("streams are live (active {total_active()}, queued {total_queued()}) — retry when idle", "busy"),
+            http_status.CONFLICT)
+    }
+    let t0 = ref_time_ticks()
+    g_active = mi
+    g_cur = mi
+    set_mtp_spec(g_slots[mi].sched.mtp)
+    install_slot_marks(mi)
+    bind_gpu_slot(mi)   // no-op for cpu slots and the current owner
+    g_slots[mi].last_used = ref_time_ticks()
+    let sw_ms = int64(get_time_usec(t0)) / 1000l
+    return resp |> JSON(
+        "\{\"ok\":true,\"model\":\"{g_slots[mi].name}\",\"backend_effective\":\"{g_slots[mi].backend_effective}\",\"switch_ms\":{sw_ms}}",
+        http_status.OK)
 }
 
 // Resolve a streaming request's "model" field to a slot (sets g_cur). False = unknown model —
@@ -1594,7 +1724,8 @@ def private flush_events(srv : WebSocketServer) {
 struct private OaiSlotStats {
     name : string
     is_default : bool
-    is_active : bool          // the slot the tick loop is stepping (post-P2: the GPU owner)
+    is_active : bool          // the slot the tick loop is stepping
+    holds_gpu : bool          // the slot whose VRAM state is armed (the GPU owner)
     backend : string          // requested: auto | cpu | gpu
     backend_effective : string
     ctx : int64
@@ -1684,6 +1815,7 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
         var s & = unsafe(g_slots[i])
         out.models |> push(OaiSlotStats(
             name = s.name, is_default = s.is_default, is_active = i == g_active,
+            holds_gpu = i == g_gpu_owner,
             backend = s.opts.backend, backend_effective = s.backend_effective,
             ctx = s.model.config.seq_len,
             active = n_active(s.sched), queued = n_queued(s.sched),
@@ -2393,6 +2525,9 @@ class OpenAiServer : HvWebServer {
             }
             return handle_embeddings(req, resp)
         }
+        POST("/v1/models/activate") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_activate(req, resp)
+        }
         GET("/v1/stats") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_stats(resp)
         }
@@ -2570,7 +2705,8 @@ def update_server() : bool {
     drain_bench_events()
     reap_disconnected(g_server.server)
     // serialized multi-model stepping: ONE scheduler step per tick, slots with work interleave
-    // round-robin. Switching the stepped slot is free in P1 (P2 hangs the GPU rebind here).
+    // round-robin. Every step runs under ITS model's routing marks; the GPU tier follows a
+    // gpu-wanting slot once the current owner drains.
     let si = pick_step_slot()
     var busy = false
     if (si >= 0) {
@@ -2578,6 +2714,8 @@ def update_server() : bool {
             g_active = si
             set_mtp_spec(g_slots[si].sched.mtp)   // the engine prefill-warm gate follows the stepped slot
         }
+        install_slot_marks(si)
+        maybe_bind_gpu(si)
         let t_step = ref_time_ticks()
         busy = scheduler_step(g_slots[si].model, g_slots[si].sched, g_events)
         let step_ms = int64(get_time_usec(t_step)) / 1000l
@@ -2616,6 +2754,16 @@ def shutdown_server() {
         }
         g_server = null
     }
+    // clean tier epoch: drop the owner's VRAM state and leave the engine globals bare, so a
+    // same-context restart (tests) starts from an unarmed device with no stale marks
+    if (g_gpu_owner >= 0 && g_gpu_owner < length(g_slots)) {
+        install_slot_marks(g_gpu_owner)
+        moe_gpu_drop_model()
+    } elif (g_marks_slot >= 0 && g_marks_slot < length(g_slots)) {
+        moe_gpu_model_marks_save(g_slots[g_marks_slot].gpu_marks)
+    }
+    g_gpu_owner = -1
+    g_marks_slot = -1
     unsafe {
         delete g_slots   // per slot: live sessions + workspace + the model go together (writers already died with the server)
     }

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1790,7 +1790,9 @@ struct private OaiStatsResponse {
 }
 
 def private handle_stats(var resp : HttpResponse?) : http_status {
-    // budget only when the tier is already live: the budget hook inits the device on first call
+    // budget only when the device already EXISTS (tier.device is "" until first upload creates
+    // it) — the budget hook device-inits on first call, and `supported` can read true while the
+    // tier is merely armed, so it must not gate this
     let tier = gpu_tier_status()
     var out = OaiStatsResponse(
         model = g_slots[g_active].name, active_model = g_slots[g_active].name,
@@ -1818,7 +1820,7 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
         heap_bytes = int64(heap_bytes_allocated()),
         string_heap_bytes = int64(string_heap_bytes_allocated()),
         gpu_vram_bytes = tier.vram_bytes,
-        gpu_budget_bytes = (tier.supported || tier.vram_bytes > 0l) ? moe_gpu_weight_budget() : 0l,
+        gpu_budget_bytes = !empty(tier.device) ? moe_gpu_weight_budget() : 0l,
         hardware = g_hardware_line,
         asr_done_jobs = g_asr_done_jobs, asr_audio_s = g_asr_audio_s)
     out.models |> reserve(length(g_slots))

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1248,7 +1248,7 @@ def private handle_activate(var req : HttpRequest?; var resp : HttpResponse?) : 
     g_slots[mi].last_used = ref_time_ticks()
     let sw_ms = int64(get_time_usec(t0)) / 1000l
     return resp |> JSON(
-        "\{\"ok\":true,\"model\":\"{g_slots[mi].name}\",\"backend_effective\":\"{g_slots[mi].backend_effective}\",\"switch_ms\":{sw_ms}}",
+        "\{\"ok\":true,\"model\":{json_str(g_slots[mi].name)},\"backend_effective\":{json_str(g_slots[mi].backend_effective)},\"switch_ms\":{sw_ms}}",
         http_status.OK)
 }
 

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1233,6 +1233,13 @@ def private handle_activate(var req : HttpRequest?; var resp : HttpResponse?) : 
         }
     }
     let want = js?["model"] ?? ""
+    if (empty(want)) {
+        // an admin switch has one required parameter — silently activating the default slot on
+        // a malformed body would hide the client bug behind a real VRAM-state switch
+        return resp |> JSON(
+            error_body("'model' is required — GET /v1/models lists the served ids", "invalid_request_error"),
+            http_status.BAD_REQUEST)
+    }
     let mi = slot_index(want)
     if (mi < 0) {
         return resp |> JSON(

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -104,14 +104,17 @@ def private total_queued : int64 {
     return n
 }
 
-// Slot index for a request's "model" field: "" -> the default slot; the exact slot name (or the
-// legacy "{name}-asr" alias) -> that slot; unknown -> -1 (the caller owns the 404).
+// Slot index for a request's "model" field: "" -> the default slot; the exact slot name -> that
+// slot; unknown -> -1 (the caller owns the 404). The legacy "{name}-asr" alias routes to the
+// DEFAULT slot only — that is the only "-asr" id /v1/models ever advertises, so a made-up
+// "{other}-asr" stays a 404 instead of silently serving.
 def private slot_index(model_field : string) : int {
     if (empty(model_field)) {
         return g_default_slot
     }
     for (i in range(length(g_slots))) {
-        if (g_slots[i].name == model_field || "{g_slots[i].name}-asr" == model_field) {
+        if (g_slots[i].name == model_field
+                || (i == g_default_slot && "{g_slots[i].name}-asr" == model_field)) {
             return i
         }
     }

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -151,7 +151,7 @@ var private g_started_at = 0l   // ref_time_ticks at init_server; /v1/stats deri
 
 //! Append a loaded model as a serving slot (call once per model, before ``run_server``). ``name``
 //! is the id ``/v1/models`` reports and requests route on via their ``"model"`` field. The first
-//! slot added is the default until an entry with ``opts.backend``/``default`` says otherwise.
+//! slot added is the default until ``set_default_model`` says otherwise.
 def add_model(var m : Model; name : string; opts : SlotOpts = SlotOpts()) {
     var slot <- ModelSlot(name = name, is_default = empty(g_slots))
     slot.model <- m
@@ -270,13 +270,18 @@ def set_slot_backend_effective(name : string; eff : string) {
 //! Mark the default slot (the one serving requests with no ``"model"`` field). No-op on an
 //! unknown name.
 def set_default_model(name : string) {
+    var ni = -1
     for (i in range(length(g_slots))) {
         if (g_slots[i].name == name) {
-            g_default_slot = i
-            g_slots[i].is_default = true
-        } elif (g_slots[i].is_default) {
-            g_slots[i].is_default = false
+            ni = i
         }
+    }
+    if (ni < 0) {
+        return
+    }
+    g_default_slot = ni
+    for (i in range(length(g_slots))) {
+        g_slots[i].is_default = i == ni
     }
 }
 

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -1900,7 +1900,13 @@ def private age_seconds(t : int64) : float {
 }
 
 def private handle_streams(var resp : HttpResponse?) : http_status {
-    var out = OaiStreamsResponse(max_streams = g_slots[g_active].sched.max_streams)
+    // the stream list below aggregates every slot, so the lane capacity the page sizes its
+    // swimlane from must be the cross-slot total, not the active slot's own cap
+    var total_cap = 0l
+    for (slot in g_slots) {
+        total_cap += slot.sched.max_streams
+    }
+    var out = OaiStreamsResponse(max_streams = total_cap)
     for (slot in g_slots) {
         var sch & = unsafe(slot.sched)
         let mname = slot.name

--- a/utils/dasllama-server/test_openai_server.das
+++ b/utils/dasllama-server/test_openai_server.das
@@ -660,6 +660,27 @@ def test_openai_server_multimodel(t : T?) {
                 t |> equal(int(resp.status_code), int(http_status.NOT_FOUND))
                 t |> success(find(string(resp.body), "model_not_found") >= 0, "404 carries model_not_found")
             }
+            // POST /v1/models/activate: admin warm-switch — 200 flips the active slot; 404 on an
+            // unknown id. The GPU rebind inside is a no-op on this rig (no tier armed).
+            POST("{base_url}/v1/models/activate", "\{\"model\":\"smol\"}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                t |> success(find(string(resp.body), "\"model\":\"smol\"") >= 0, "activate echoes the slot")
+            }
+            GET("{base_url}/v1/stats") $(resp) {
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null, "post-activate stats JSON parses")
+                if (js != null) {
+                    t |> equal(string(js?["active_model"] ?? ""), "smol")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            POST("{base_url}/v1/models/activate", "\{\"model\":\"nope\"}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.NOT_FOUND))
+                t |> success(find(string(resp.body), "model_not_found") >= 0, "activate 404 carries model_not_found")
+            }
             // THE directive test: slot caches survive interleaved traffic on another slot.
             // Same >1-page prompt on tiny twice, a smol request between them — the re-send must
             // hit tiny's prefix cache even though smol served in between.
@@ -698,6 +719,7 @@ def test_openai_server_multimodel(t : T?) {
                                 t |> equal(string(e?["backend"] ?? ""), "cpu")
                                 t |> equal(string(e?["backend_effective"] ?? ""), "cpu")
                                 t |> equal(e?["cached_tokens"] ?? -1l, 0l)
+                                t |> equal(e?["holds_gpu"] ?? true, false)
                             }
                         }
                     }

--- a/utils/dasllama-server/test_openai_server.das
+++ b/utils/dasllama-server/test_openai_server.das
@@ -552,3 +552,202 @@ def test_parse_tool_calls_auto(t : T?) {
         delete calls
     }
 }
+
+// ===== multi-model: two slots, "model" routing, per-slot caches surviving interleaved traffic =====
+
+let MODEL2_PATH = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+let TEST_PORT_MM = 18121
+
+// Two-slot variant of with_llama_server: tinyllama as the default slot "tiny", SmolLM2-135M as
+// "smol" (backend pinned cpu — asserts the requested-vs-effective surface). Same thread/context
+// discipline: both models load INSIDE the server thread.
+def private with_llama_server2(path_a, path_b : string; port : int; blk : block<(base_url : string) : void>) {
+    with_job_status(1) $(finished) {
+        new_thread() @() {
+            set_metal_mode(MetalMode.off)
+            var ma <- load_model(path_a, QuantMode.q8)
+            add_model(ma, "tiny")
+            var mb <- load_model(path_b, QuantMode.q8)
+            add_model(mb, "smol", SlotOpts(backend = "cpu"))
+            set_default_model("tiny")
+            set_default_max_tokens(4l)
+            var surf <- {
+                "config" => JV((port = port, model = path_a, streams = 4)),
+                "sources" => JV((port = "cli")),
+                "authoritative" => JV(false),
+                "config_path" => JV(""),
+                "save_path" => JV(TEST_SAVE_PATH)
+            }
+            var sdoc = JV(surf)
+            set_config_surface(write_json_compact(sdoc), TEST_SAVE_PATH, path_a)
+            unsafe {
+                delete sdoc
+            }
+            run_server(port)   // blocks until POST /shutdown
+            finished |> notify_and_release
+        }
+        let base_url = "http://127.0.0.1:{port}"
+        var ready = false
+        for (_attempt in range(600)) {   // up to ~60s: two loads + JIT
+            GET("{base_url}/v1/models") $(resp) {
+                if (resp != null && resp.status_code == http_status.OK) {
+                    ready = true
+                }
+            }
+            if (ready) {
+                break
+            }
+            sleep(100u)
+        }
+        if (ready) {
+            invoke(blk, base_url)
+        }
+        POST("{base_url}/shutdown", "") $(_resp) {}
+        finished |> join
+        assert(ready, "dasllama two-slot server became ready")
+    }
+}
+
+[test]
+def test_openai_server_multimodel(t : T?) {
+    t |> run("multi-model: routing + per-slot caches (needs tinyllama + SmolLM2-135M q8)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA server test is JIT-only)")
+            return
+        }
+        if (!stat(MODEL_PATH).is_valid || !stat(MODEL2_PATH).is_valid) {
+            t |> success(true, "skipped: tinyllama/SmolLM2-135M not present (set DASLLAMA_MODELS_DIR)")
+            return
+        }
+        with_llama_server2(MODEL_PATH, MODEL2_PATH, TEST_PORT_MM) $(base_url) {
+            // /v1/models lists both slots
+            GET("{base_url}/v1/models") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                let body = string(resp.body)
+                t |> success(find(body, "\"tiny\"") >= 0, "default slot listed")
+                t |> success(find(body, "\"smol\"") >= 0, "second slot listed")
+            }
+            // routed by "model": the response echoes the slot id
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"model\":\"smol\",\"messages\":[\{\"role\":\"user\",\"content\":\"Say hi.\"}],\"max_tokens\":4}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null, "routed chat JSON parses")
+                if (js != null) {
+                    t |> equal(string(js?["model"] ?? ""), "smol")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            // no "model" field -> the default slot serves and is echoed
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":\"Say hi.\"}],\"max_tokens\":4}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var err : string
+                var js = read_json(string(resp.body), err)
+                if (js != null) {
+                    t |> equal(string(js?["model"] ?? ""), "tiny")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            // unknown model -> OpenAI-shaped 404
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"model\":\"nope\",\"messages\":[\{\"role\":\"user\",\"content\":\"hi\"}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.NOT_FOUND))
+                t |> success(find(string(resp.body), "model_not_found") >= 0, "404 carries model_not_found")
+            }
+            // THE directive test: slot caches survive interleaved traffic on another slot.
+            // Same >1-page prompt on tiny twice, a smol request between them — the re-send must
+            // hit tiny's prefix cache even though smol served in between.
+            var long2 = ""
+            for (_i in range(12)) {
+                long2 += "Pack my box with five dozen liquor jugs. "
+            }
+            let body_a = "\{\"model\":\"tiny\",\"prompt\":\"{long2}\",\"max_tokens\":4}"
+            POST("{base_url}/v1/completions", body_a) $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+            }
+            POST("{base_url}/v1/completions", "\{\"model\":\"smol\",\"prompt\":\"Hello\",\"max_tokens\":2}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+            }
+            POST("{base_url}/v1/completions", body_a) $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+            }
+            // per-slot stats: roster present, default marked, smol's requested backend recorded,
+            // tiny's cache hit counted, smol's cache untouched
+            GET("{base_url}/v1/stats") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null, "stats JSON parses")
+                if (js != null) {
+                    let mv = js?["models"]
+                    t |> success(mv != null && mv.value is _array, "stats carries a models roster")
+                    if (mv != null && mv.value is _array) {
+                        t |> equal(length(mv.value as _array), 2)
+                        for (e in mv.value as _array) {
+                            let nm = string(e?["name"] ?? "")
+                            if (nm == "tiny") {
+                                t |> success(e?["is_default"] ?? false, "tiny is the default slot")
+                                t |> success((e?["cached_tokens"] ?? 0l) > 0l, "tiny's prefix cache hit across the smol interleave")
+                            } elif (nm == "smol") {
+                                t |> equal(string(e?["backend"] ?? ""), "cpu")
+                                t |> equal(string(e?["backend_effective"] ?? ""), "cpu")
+                                t |> equal(e?["cached_tokens"] ?? -1l, 0l)
+                            }
+                        }
+                    }
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            // /v1/streams entries carry the model tag
+            GET("{base_url}/v1/streams") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                t |> success(find(string(resp.body), "\"model\":\"tiny\"") >= 0, "stream cards tag their slot")
+            }
+            // POST /config with a [[models]] roster — validated, TOML round-trips as array-of-tables
+            POST("{base_url}/config",
+                 "\{\"port\":8123,\"models\":[\{\"name\":\"a\",\"path\":\"a.gguf\",\"backend\":\"cpu\",\"default\":true},\{\"name\":\"b\",\"path\":\"b.gguf\"}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+            }
+            {
+                let saved = fread(TEST_SAVE_PATH)
+                t |> success(!empty(saved), "saved roster config readable")
+                var terr : string
+                var troot = read_toml(saved, terr)
+                t |> success(troot != null, "saved roster config re-parses as TOML")
+                if (troot != null) {
+                    let mv = troot?["models"]
+                    t |> success(mv != null && mv.value is _array, "[[models]] survives the TOML round-trip")
+                    if (mv != null && mv.value is _array) {
+                        t |> equal(length(mv.value as _array), 2)
+                        t |> equal(string((mv.value as _array)[0]?["name"] ?? ""), "a")
+                        t |> equal(string((mv.value as _array)[0]?["backend"] ?? ""), "cpu")
+                    }
+                    unsafe {
+                        delete troot
+                    }
+                }
+                remove(TEST_SAVE_PATH)
+            }
+            // roster validation: duplicate names, bad backend, missing path — honest 400s
+            POST("{base_url}/config",
+                 "\{\"models\":[\{\"name\":\"x\",\"path\":\"p.gguf\"},\{\"name\":\"x\",\"path\":\"q.gguf\"}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+            }
+            POST("{base_url}/config",
+                 "\{\"models\":[\{\"name\":\"x\",\"path\":\"p.gguf\",\"backend\":\"turbo\"}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+            }
+            POST("{base_url}/config", "\{\"models\":[\{\"name\":\"x\"}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Multiple models serve LIVE from one dasllama-server process: serialized execution, fast GPU switching, every cache level preserved across switches. Six commits — engine groundwork, server slots/routing, per-model GPU state + switching, the control page, and the dictation-bot consumer.

## Engine (modules/dasLLAMA)

- **Flash-attention kernels + windowed prefill + host-KV authority** — the vulkan attention chain the resident driver and the server tier ride; host KV stays authoritative at rest (`vk_rdec_read_kv_bulk` chunked readback, hydration rails in the overrides instead of the fail-closed continuation panic).
- **Whole-model GPU drop + per-model mark sets** — `vk_drop_model_state` (dev-mem sweep + host-mem/model-cmds registries + descriptor-pool reset; device and pipelines survive) behind `moe_gpu_drop_model()`; `MoeGpuMarks`/`GpuModelMarks` save/restore swaps the offset-keyed routing marks per model — two models' offset spaces overlap, so the swap is what makes multi-model correct at all. Closes two latent holes: a later load wiping the GPU slot's marks, and stale `g_rdec_active` crossing model boundaries.

## Server (utils/dasllama-server)

- **P1 — live slots:** `ModelSlot` roster, request routing on the `model` field (unknown → OpenAI 404 body), serialized stepping (owner drains, never preempted), per-model `[[models]]` config with `backend = auto | cpu | gpu` and per-entry overrides; flat single-model configs keep working as a one-entry roster.
- **P2b — GPU slot switching:** marks installed per step (gpu↔cpu alternation stays free), `maybe_bind_gpu` traffic-driven switch + `POST /v1/models/activate` admin warm-switch (200 with `switch_ms`, 404, 409 while busy); `holds_gpu`, requested vs `backend_effective` (`cpu`/`gpu:rails`/`gpu:resident`), and switch telemetry in `/v1/stats`.
- **P3 — control page:** models panel (per-slot cards: state badge, gpu chip, prefix hit rate + sparkline, switch telemetry, activate button), VRAM bar (`gpu_vram_bytes`/`gpu_budget_bytes`, budget call gated on tier-live — the budget hook device-inits on first call), switch strip derived client-side from the sw telemetry deltas, and the config editor's flat model field replaced by a `[[models]]` roster table (backend dropdown, effective badge with decline reason, expandable per-model overrides; inherit sentinels omitted on save). `deploy-jit.ps1` ships the shared `utils/watchdog` supervisor.
- **dictation bot:** new `model` config key pins the bot to a served slot — sent on every chat completion and verified against `GET /v1/models` at startup, so a typo fails there with the served ids listed.

## Verification

- Engine gates: `test_gpu_slot_swap.das` — resident prefill/decode → hydrate + drop → CPU continuation → re-arm → second cycle, all token-identical to a no-switch control; synthetic drop-model cycles in `test_vulkan_tier.das` (34/34); 64-tok and 6000-tok prefill parity IDS-identical.
- Server suites: `test_openai_server` 19/19 (multi-model rig: routing, 404s, per-slot stats, config round-trip incl. `[[models]]` validation, activate, and the directive case — prefix cache HIT across a model interleave), stream 8/8, scheduler 12/12.
- Live 2-slot tiny+smol on vulkan: traffic-driven switches both ways + activate at 51–129 ms on the rails arm, token-coherent completions, truthful badges; control page verified against the live rig (61 ms and 113 ms switches captured as strip chips, roster save round-trips to clean TOML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
