### PR TITLE
utils/jobque-timeline: the per-lane jobque trace viewer, and its story

### DIFF
--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -115,6 +115,7 @@ namespace das {
     DAS_API bool builtin_rmdir_rec ( const char * path );
     DAS_API bool has_env_variable ( const char * var, Context * context, LineInfoArg * at );
     DAS_API char * get_env_variable ( const char * var, Context * context, LineInfoArg * at );
+    DAS_API void set_env_variable ( const char * var, const char * value, Context * context, LineInfoArg * at );
     DAS_API char * sanitize_command_line ( const char * cmd, Context * context, LineInfoArg * at );
     // filesystem operations (C++17 <filesystem>)
     struct DiskSpaceInfo {

--- a/site/blog/_posts/stories.md
+++ b/site/blog/_posts/stories.md
@@ -1,0 +1,61 @@
+---
+title: Tell me a story.
+date: 2026-07-23 13:28:46
+tags:
+    - daslang
+    - dasllama
+---
+
+All those scars upon my back tell me a story.
+
+<!-- more -->
+
+Once upon a time "it just predicted the next word". Thats about sums it up. At least on July-23rd it did for me.
+
+I was always curious as to how it really works. Here is the sad reality. U don't know unless u write one.
+I mean glancing through a tutorial or even really reading one is cute.
+The topic is small. ~500 lines, if u ask ME. By all means, read it. Tell yourself a story. Call it good.
+
+Or, maybe, do The Ritual. Have someone else tell u a story. Really teach it. Draw some pictures. Graphs.
+Answer questions. Write the code, explain the missing bits. Quiz, and quiz again. Then, maybe, turn it into something real.
+I dunno, big ask. Go to that crazy 25-hour painkiller-fed rave (don't leave your bed not that u can).
+Come out changed. EZ. Its your life (hi Danny).
+
+How's [mine](https://daslang.io/doc/reference/tutorials/dasLLAMA_00_problem_statement.html) different?
+I best take things in certain manner. Having one open with the code already written is an extra crutch,
+and boy do I need them. Peek at the answer - see the destination from the get go, see the journey.
+Many parallel views, few parallel realities. Copenhagen interpretation of attention. Minkowski? Never fear.
+Saves you "ok, but where is this whole thing going" kind of question. So there, saved one for u.
+
+Sometimes u get more than what u bargained for. U get to see a lot of what I got in the days to come.
+Dasllama is, already, something else. Embed it, or use dasllama-server - all good stuff, all in good time.
+Don't read it yet. It will shrink. Has to explode first, grow organically.
+
+I have to say something here. llama.cpp is awesome. Wanna learn something real? Read it, like I did.
+Its full of stories. They inspire. Give back, too. I filed a few bugs.
+Maybe I'll submit a few C++ lines, if I force myself to that hell hole ever again.
+Sometimes it causes the best form of flattery, only for u to then throw it all away. And do better.
+Tell your own stories. I'll tell mine.
+
+Here is the fun part. I'm not a doctor, Carl. I'm in the business of making programming language. Just one too (hi Andrei).
+Nothing tests programming languages like scientific research on frontier performance critical applications in heterogenic environment, a mouthful.
+Its a gift that keeps on giving, and gave it did.
+
+[tune] framework, which will get its own story, is something else. No, Boris, u can't hand optimize 392 loops (roughly).
+Don't even try. Nevermind their permutations. U are not 'the community', nor 'the collective'. Did u know I worked for The Collective?
+So I did something better - and now u can tune your own loops a new fashion way. They tend to come out better, for the box they are tuned for.
+Which is every box.
+
+I'm doing the same with Metal kernel scheduling at the moment. By the time u reading this, u can actually read the code (shocking).
+No, Boris, u can't hand tune the order and dependencies on 38 kernel families. Don't even try. U only have M1. U just bought M5, its not even here.
+That M3 u secretly ssh to ... just don't.
+
+I might look into expanding this for Vulkan. I wanted to stick to CPU, but that hybrid kernel for the MOE model kept running circles around CPU.
+On a 35B model. On an 8gb 3060. U know, the useless kind. Ah, the irony.
+
+Then there was a jobque. Did u know that jobque bites? I thought I had it good. I fixed it. I thought I had it decent. I fixed it. I thought it might do. I had to add team mode, spin-to-win, limits. It hardly holds now. I might have a few more rounds in me. There is now a tool - u can see what went in when - PS2 A-Probe style, GPAD style, beyond debugging... nah, that last one is too awkward unless u were on ice during the PS3 launch. Same flashback. Same bar graphs. Same job manager struggles. Way better latency way back then.
+
+Of cause, there is also first part of this story. Which I skipped. For now...(strudel, evil chords, empire strikes back). Not today, really, not today.
+
+So many stories, each deserves at least a blog post. I've been neglecting blog. "Stories" pulled me in. They tell me a story.
+

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1651,6 +1651,16 @@ namespace das {
         return context->allocateString(res, at);
     }
 
+    void set_env_variable ( const char * var, const char * value, Context *, LineInfoArg * ) {
+        // process-wide; children spawned via popen/popen_argv inherit it
+        if ( !var || !*var ) return;
+#ifdef _MSC_VER
+        _putenv_s(var, value ? value : "");
+#else
+        setenv(var, value ? value : "", 1);
+#endif
+    }
+
     enum class RegisterOnError {
         Quiet = 0,      // missing/unloadable .shared_module is silent (deferred for retry); broken artifacts still report
         ErrorMsg,       // error message is displayed

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -192,6 +192,7 @@ namespace das {
     char * get_full_file_name ( const char * path, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     bool has_env_variable ( const char * var, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     char * get_env_variable ( const char * var, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
+    void set_env_variable ( const char * var, const char * value, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     char * sanitize_command_line ( const char * cmd, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     // filesystem stubs
     char * builtin_fs_extension ( const char * path, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
@@ -2354,6 +2355,9 @@ namespace das {
             addExtern<DAS_BIND_FUN(get_env_variable)>(*this, lib, "get_env_variable",
                 SideEffects::accessExternal, "get_env_variable")
                     ->args({"var","context","at"});
+            addExtern<DAS_BIND_FUN(set_env_variable)>(*this, lib, "set_env_variable",
+                SideEffects::modifyExternal, "set_env_variable")
+                    ->args({"var","value","context","at"});
             addExtern<DAS_BIND_FUN(has_env_variable)>(*this, lib, "has_env_variable",
                 SideEffects::accessExternal, "has_env_variable")
                     ->args({"var","context","at"});

--- a/utils/jobque-timeline/.das_package
+++ b/utils/jobque-timeline/.das_package
@@ -1,0 +1,19 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("jobque-timeline")
+    package_description("Per-lane jobque trace timeline viewer — docking multi-file compare, unit navigation, live commands")
+}
+
+[export]
+def dependencies(version : string) {
+    require_package("github.com/borisbat/dasImgui")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+}

--- a/utils/jobque-timeline/README.md
+++ b/utils/jobque-timeline/README.md
@@ -1,0 +1,60 @@
+# jobque-timeline
+
+Per-lane jobque trace viewer — the in-repo successor to the hand-spliced lane-timeline
+browser artifact. Opens `jobque_trace_save` / `daslib/jobque_profile` JSON files (perfetto-
+compatible) in dockable ImGui windows: one row per lane, events colored by category with
+per-stage shading, unit markers (`token` / `layer` / `step`), computed stats (idle %,
+parallelism, busy by category), multi-file compare with shared zoom/timer, and a launch
+rail that reruns your trace-producing app and auto-refreshes on save.
+
+## Setup
+
+The viewer needs dasImgui (external package), installed into this tool's root:
+
+```
+bin/Release/daslang.exe utils/daspkg/main.das -- install --root utils/jobque-timeline
+```
+
+## Run
+
+```
+bin/Release/daslang.exe -project_root utils/jobque-timeline utils/jobque-timeline/main.das -- a.trace.json b.trace.json
+```
+
+Or live (hot reload + remote commands):
+
+```
+daslang-live -project_root utils/jobque-timeline utils/jobque-timeline/main.das
+```
+
+## Interaction
+
+- wheel = zoom at cursor, drag = pan, double-click = full span, drag the overview strip = scrub
+- shift+drag = time-range selection (stats line appears above the canvas; Esc clears)
+- hover = event tooltip (kind, category, stage, chunk, chain, t, dur)
+- Controls panel: share zoom / share timer (on by default), auto refresh, per-file reload,
+  and the launch rail (browse for an app, args, launch, exit code + output tail)
+
+## Live commands (`daslang-live`, port 9090)
+
+`timeline_files`, `timeline_open {path}`, `timeline_get_view {file}`,
+`timeline_set_view {file,t0,t1}`, `timeline_focus_unit {file,kind,index}`,
+`timeline_get_selection {file}` / `timeline_set_selection {file,t0,t1}`,
+`timeline_range_stats {file,t0,t1}` (pure query), `timeline_describe`,
+`timeline_launch {app,args}`, `timeline_launch_status`, `timeline_refresh {file}`,
+`timeline_set_autorefresh {on}`.
+
+All times are µs, file-relative. `timeline_range_stats` and `timeline_describe` are the
+screenshot-free rail: selections and views come back as structured JSON (events, busy µs
+by category, idle %, parallelism, publish count).
+
+## Files
+
+`main.das` (app + dock layout + live commands), `tl_model.das` (trace model), `tl_loader.das`
+(fast rigid-format parser), `tl_lod.das` (per-lane bucket mipmaps), `tl_view.das` (canvas +
+cached draw runs), `tl_stats.das` (range statistics), `tl_launch.das` (subprocess launch +
+file watch). Tests are co-located (`test_tl_*.das`):
+
+```
+bin/Release/daslang.exe dastest/dastest.das -- --test utils/jobque-timeline
+```

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -122,16 +122,17 @@ def sync_views(from_idx : int) {
             ui.t1 = span
             ui.inited = true
         }
-        let nw = SHARE_ZOOM.value ? clamp(w, 8.0lf, span) : (ui.t1 - ui.t0)
+        let nw = SHARE_ZOOM.value ? max(w, 8.0lf) : (ui.t1 - ui.t0)
         var nt0 = ui.t0
         if (SHARE_TIMER.value) {
             nt0 = src.t0
         } elif (SHARE_ZOOM.value) {
             nt0 = (ui.t0 + ui.t1) * 0.5lf - nw * 0.5lf
         }
+        // NO clamp on adoption — shared timer means the same absolute clock even when this
+        // file's data has run out (it draws empty); direct interaction on this view clamps
         ui.t0 = nt0
         ui.t1 = nt0 + nw
-        clamp_view(ui, span)
     }
 }
 

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -28,7 +28,7 @@ var g_render : array<RenderCache>      // per-doc cached draw runs
 var g_view_stats : array<StatsCache>   // per-doc, keyed on the visible range
 var g_sel_stats : array<StatsCache>    // per-doc, keyed on the selection range
 var g_pending : array<string>   // files handed on the command line, loaded in init
-var g_launch : LaunchRail
+var g_launch = LaunchRail()
 var g_watch : array<FileWatch>  // per-doc auto-refresh watchers
 var g_poll_frame = 0
 var g_dlg_purpose = 0           // the singleton file dialog's pending consumer: 1 = launch app, 2 = open traces
@@ -208,6 +208,7 @@ def init() {
     SHARE_ZOOM.value = true    // both sync modes ON by default
     SHARE_TIMER.value = true
     AUTO_REFRESH.value = true
+    AFFINITY_CB.value = true   // bench discipline: launched runs pin by default
     for (path in g_pending) {
         open_file(path)
     }
@@ -222,6 +223,14 @@ def update() {
     harness_new_frame()
     if (launch_pump(g_launch)) {
         to_log(LOG_INFO, "jobque-timeline: launch finished rc={g_launch.exit_code}\n")
+        if (g_launch.exit_code == 0) {
+            for (line in g_launch.tail) {   // auto-open every trace the run reported saving
+                let jp = extract_json_path(line)
+                if (!empty(jp)) {
+                    open_or_reload(jp)
+                }
+            }
+        }
     }
     g_poll_frame++
     if (AUTO_REFRESH.value && g_poll_frame % 30 == 0) {
@@ -278,6 +287,7 @@ def update() {
             }
             same_line()
             text(ARGS_LABEL, (text = empty(g_launch.args) ? "<no args>" : g_launch.args))
+            checkbox(AFFINITY_CB, (text = "affinity"))
             popup_modal(ARGS_MODAL, (text = "Launch arguments", closable = true, flags = ImGuiWindowFlags.None)) {
                 text("whitespace-separated; newlines are fine (one argument per line avoids quoting)")
                 input_text_multiline(ARGS_MULTI, (text = "##args", size = float2(640.0f, 240.0f)))
@@ -294,6 +304,7 @@ def update() {
                 text("running...")
             } else {
                 if (icon_button(LAUNCH_BTN, (glyph = "play", tip = "launch"))) {
+                    g_launch.affinity = AFFINITY_CB.value
                     if (!launch_start(g_launch)) {
                         to_log(LOG_ERROR, "jobque-timeline: launch failed to start\n")
                     }
@@ -533,6 +544,7 @@ def timeline_launch(input : JsonValue?) : JsonValue? {
         g_launch.app = a.app
     }
     g_launch.args = a.args
+    g_launch.affinity = AFFINITY_CB.value
     if (!a.start) {
         return JV((running = false, app = g_launch.app, args = g_launch.args))
     }

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -41,6 +41,10 @@ var private RELOAD_BTN : table<int; ClickState>       // per-file manual refresh
 var private CLOSE_BTN : table<int; ClickState>        // per-file close
 var private FILE_SL_A : table<int; EmptyMarkerState>  // per-file row same_line markers
 var private FILE_SL_B : table<int; EmptyMarkerState>
+var private TAIL_OPEN : table<int; ClickState>        // output lines naming a .json: open it
+var private TAIL_COPY : table<int; ClickState>        // ... or copy its path
+var private TAIL_SL_A : table<int; EmptyMarkerState>
+var private TAIL_SL_B : table<int; EmptyMarkerState>
 var private TAIL_LINE : table<int; NarrativeState>    // launch output tail
 var g_close_req = -1            // deferred close (icon or window X) — applied after the frame's windows
 
@@ -92,6 +96,18 @@ def close_file(i : int) {
     TRACE2.open = true
     TRACE3.open = true
     TL_ROOT.has_initial_layout = false
+}
+
+def open_or_reload(path : string) {
+    for (i in range(length(g_docs))) {
+        if (g_docs[i].path == path) {
+            reload_file(i)
+            return
+        }
+    }
+    if (open_file(path)) {
+        TL_ROOT.has_initial_layout = false
+    }
 }
 
 def reload_file(i : int) {
@@ -289,6 +305,19 @@ def update() {
             }
             separator()
             for (i in range(length(g_launch.tail))) {
+                let jpath = extract_json_path(g_launch.tail[i])
+                if (!empty(jpath)) {
+                    if (icon_button(TAIL_OPEN[i], (glyph = "folder", tip = "open this trace", size = 14.0f))) {
+                        open_or_reload(jpath)
+                    }
+                    same_line(TAIL_SL_A[i])
+                    if (icon_button(TAIL_COPY[i], (glyph = "duplicate", tip = "copy path to clipboard", size = 14.0f))) {
+                        log_to_clipboard()
+                        log_text(jpath)
+                        log_finish()
+                    }
+                    same_line(TAIL_SL_B[i])
+                }
                 text(TAIL_LINE[i], (text = g_launch.tail[i]))
             }
         }
@@ -333,7 +362,7 @@ def update() {
         } elif (g_dlg_purpose == 2) {
             var sel <- file_dialog_selection()
             for (p in sel) {
-                open_file(p)
+                open_or_reload(p)   // re-picking an open file reloads it instead of duplicating
             }
             delete sel
             TL_ROOT.has_initial_layout = false   // reseed the stacked layout with the new windows

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -209,6 +209,9 @@ def init() {
     SHARE_TIMER.value = true
     AUTO_REFRESH.value = true
     AFFINITY_CB.value = true   // bench discipline: launched runs pin by default
+    if (has_env_variable("DAS_JOBQUE_THREADS")) {   // seed from the tool's own env (box config)
+        THREADS_INPUT.value = to_int(get_env_variable("DAS_JOBQUE_THREADS"))
+    }
     for (path in g_pending) {
         open_file(path)
     }
@@ -288,6 +291,7 @@ def update() {
             same_line()
             text(ARGS_LABEL, (text = empty(g_launch.args) ? "<no args>" : g_launch.args))
             checkbox(AFFINITY_CB, (text = "affinity"))
+            input_int(THREADS_INPUT, (text = "threads (0 = inherit)"))
             popup_modal(ARGS_MODAL, (text = "Launch arguments", closable = true, flags = ImGuiWindowFlags.None)) {
                 text("whitespace-separated; newlines are fine (one argument per line avoids quoting)")
                 input_text_multiline(ARGS_MULTI, (text = "##args", size = float2(640.0f, 240.0f)))
@@ -305,6 +309,7 @@ def update() {
             } else {
                 if (icon_button(LAUNCH_BTN, (glyph = "play", tip = "launch"))) {
                     g_launch.affinity = AFFINITY_CB.value
+                    g_launch.threads = THREADS_INPUT.value
                     if (!launch_start(g_launch)) {
                         to_log(LOG_ERROR, "jobque-timeline: launch failed to start\n")
                     }
@@ -545,6 +550,7 @@ def timeline_launch(input : JsonValue?) : JsonValue? {
     }
     g_launch.args = a.args
     g_launch.affinity = AFFINITY_CB.value
+    g_launch.threads = THREADS_INPUT.value
     if (!a.start) {
         return JV((running = false, app = g_launch.app, args = g_launch.args))
     }

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -1,0 +1,488 @@
+options gen2
+options stack = 65536
+
+require imgui/imgui_harness
+require daslib/jobque_boost
+require daslib/clargs
+require daslib/json_boost
+require strings
+require math
+require stddlg
+require tl_model
+require tl_loader
+require tl_view
+require tl_stats
+require tl_launch
+
+// jobque timeline viewer — first light: N trace files in dockable windows (stacked),
+// shared zoom/timer ON by default, unit markers, hover tooltips, timeline_* live commands.
+//   daslang -project_root utils/jobque-timeline utils/jobque-timeline/main.das -- a.trace.json b.trace.json
+//   daslang-live -project_root utils/jobque-timeline utils/jobque-timeline/main.das
+
+let MAX_DOCS = 4   // static dock_window slots (TRACE0..TRACE3) — dynamic idents later
+
+var g_docs : array<TraceDoc>
+var g_ui : array<ViewUI>
+var g_render : array<RenderCache>      // per-doc cached draw runs
+var g_view_stats : array<StatsCache>   // per-doc, keyed on the visible range
+var g_sel_stats : array<StatsCache>    // per-doc, keyed on the selection range
+var g_pending : array<string>   // files handed on the command line, loaded in init
+var g_launch : LaunchRail
+var g_watch : array<FileWatch>  // per-doc auto-refresh watchers
+var g_poll_frame = 0
+
+var private DOC_STATS : table<int; NarrativeState>    // per-window header line widgets
+var private DOC_CHIPS : table<int; NarrativeState>    // per-window computed stats (idle/par/cats)
+var private DOC_SEL : table<int; NarrativeState>      // per-window selection stats
+var private FILE_LABEL : table<int; NarrativeState>   // controls-panel file list
+var private RELOAD_BTN : table<int; ClickState>       // per-file manual refresh
+var private TAIL_LINE : table<int; NarrativeState>    // launch output tail
+
+def open_file(path : string) : bool {
+    if (length(g_docs) >= MAX_DOCS) {
+        to_log(LOG_ERROR, "jobque-timeline: MAX_DOCS={MAX_DOCS} windows in v0\n")
+        return false
+    }
+    var doc : TraceDoc
+    if (!load_trace(path, doc)) {
+        to_log(LOG_ERROR, "jobque-timeline: failed to load {path}\n")
+        return false
+    }
+    doc.title = "{length(g_docs)}: {doc.title}"
+    g_docs |> emplace(doc)
+    var ui = ViewUI()
+    g_ui |> push(ui)
+    var rc = RenderCache()
+    g_render |> emplace(rc)
+    var vc = StatsCache()
+    g_view_stats |> emplace(vc)
+    var sc = StatsCache()
+    g_sel_stats |> emplace(sc)
+    var fw = FileWatch()
+    watch_prime(fw, path)
+    g_watch |> push(fw)
+    return true
+}
+
+def reload_file(i : int) {
+    var doc : TraceDoc
+    if (!load_trace(g_docs[i].path, doc)) {
+        to_log(LOG_ERROR, "jobque-timeline: reload failed for {g_docs[i].path}\n")
+        return
+    }
+    doc.title = g_docs[i].title
+    doc.generation = g_docs[i].generation + 1   // keep caches strictly invalidating
+    g_docs[i] <- doc
+    clamp_view(g_ui[i], max(g_docs[i].span, 8.0lf))
+}
+
+// ---- view sync: one-way intent from the interacted view; clamping display-local ----
+
+def sync_views(from_idx : int) {
+    let src & = unsafe(g_ui[from_idx])
+    let w = src.t1 - src.t0
+    for (i in range(length(g_ui))) {
+        if (i == from_idx) {
+            continue
+        }
+        var ui & = unsafe(g_ui[i])
+        let span = max(g_docs[i].span, 8.0lf)
+        if (!ui.inited) {   // sync must land on fresh views too, not be overwritten by view_full
+            ui.t0 = 0.0lf
+            ui.t1 = span
+            ui.inited = true
+        }
+        let nw = SHARE_ZOOM.value ? clamp(w, 8.0lf, span) : (ui.t1 - ui.t0)
+        var nt0 = ui.t0
+        if (SHARE_TIMER.value) {
+            nt0 = src.t0
+        } elif (SHARE_ZOOM.value) {
+            nt0 = (ui.t0 + ui.t1) * 0.5lf - nw * 0.5lf
+        }
+        ui.t0 = nt0
+        ui.t1 = nt0 + nw
+        clamp_view(ui, span)
+    }
+}
+
+def setup_layout(dock_id : uint) {
+    // controls left column, trace windows stacked vertically on the right
+    DockBuilderRemoveNode(dock_id)
+    DockBuilderAddDockSpaceNode(dock_id, ImGuiDockNodeFlags.None)
+    let vp = GetMainViewport()
+    DockBuilderSetNodeSize(dock_id, ImVec2(vp.Size.x, vp.Size.y))
+    var left_id : uint = 0u
+    var main_id : uint = 0u
+    DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.16f, left_id, main_id)
+    DockBuilderDockWindow("Controls", left_id)
+    let n = length(g_docs)
+    var cur = main_id
+    for (i in range(n)) {
+        if (i == n - 1) {
+            DockBuilderDockWindow(g_docs[i].title, cur)
+        } else {
+            var top_id : uint = 0u
+            var bot_id : uint = 0u
+            DockBuilderSplitNode(cur, ImGuiDir.Up, 1.0f / float(n - i), top_id, bot_id)
+            DockBuilderDockWindow(g_docs[i].title, top_id)
+            cur = bot_id
+        }
+    }
+    DockBuilderFinish(dock_id)
+}
+
+def draw_doc_window(i : int) {
+    let header = "{g_docs[i].total_events} events  {length(g_docs[i].lanes)} lanes  span {fmt_us(g_docs[i].span)}  view {fmt_us(g_ui[i].t1 - g_ui[i].t0)}"
+    text(DOC_STATS[i], (text = header))
+    if (g_ui[i].inited) {
+        cached_stats(g_view_stats[i], g_docs[i], g_ui[i].t0, g_ui[i].t1)
+        text(DOC_CHIPS[i], (text = stats_line(g_view_stats[i].stats)))
+        if (g_ui[i].sel_active) {
+            cached_stats(g_sel_stats[i], g_docs[i], g_ui[i].sel_t0, g_ui[i].sel_t1)
+            text(DOC_SEL[i], (text = "sel {fmt_us(g_ui[i].sel_t1 - g_ui[i].sel_t0)}:  " + stats_line(g_sel_stats[i].stats)))
+        }
+    }
+    draw_timeline(g_docs[i], g_ui[i], g_render[i], "tl_canvas_{i}")
+    if (g_ui[i].interacted) {
+        sync_views(i)
+    }
+}
+
+[export]
+def init() {
+    harness_init("jobque timeline", 1500, 950)
+    create_job_que()   // the launch rail runs subprocesses in background jobs
+    var io & = unsafe(GetIO())
+    io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
+    SHARE_ZOOM.value = true    // both sync modes ON by default
+    SHARE_TIMER.value = true
+    AUTO_REFRESH.value = true
+    for (path in g_pending) {
+        open_file(path)
+    }
+    delete g_pending
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) {
+        return
+    }
+    harness_new_frame()
+    if (launch_pump(g_launch)) {
+        to_log(LOG_INFO, "jobque-timeline: launch finished rc={g_launch.exit_code}\n")
+    }
+    g_poll_frame++
+    if (AUTO_REFRESH.value && g_poll_frame % 30 == 0) {
+        for (i in range(length(g_docs))) {
+            if (watch_poll(g_watch[i], g_docs[i].path)) {
+                reload_file(i)
+            }
+        }
+    }
+    dockspace(TL_ROOT, (flags = ImGuiDockNodeFlags.PassthruCentralNode)) {
+        if (!TL_ROOT.has_initial_layout && TL_ROOT.dock_id != 0u) {
+            setup_layout(TL_ROOT.dock_id)
+            TL_ROOT.has_initial_layout = true
+        }
+        dock_window(CONTROLS, (text = "Controls", closable = false, flags = ImGuiWindowFlags.None)) {
+            checkbox(SHARE_ZOOM, (text = "share zoom"))
+            checkbox(SHARE_TIMER, (text = "share timer"))
+            checkbox(AUTO_REFRESH, (text = "auto refresh"))
+            for (i in range(length(g_docs))) {
+                text(FILE_LABEL[i], (text = g_docs[i].title))
+                if (button(RELOAD_BTN[i], (text = "reload##{i}"))) {
+                    reload_file(i)
+                }
+            }
+            text("-- launch --")
+            text(APP_LABEL, (text = empty(g_launch.app) ? "<no app>" : g_launch.app))
+            if (button(BROWSE_BTN, (text = "browse..."))) {
+                let picked = get_dlg_open_file("", "")
+                if (!empty(picked)) {
+                    g_launch.app = picked
+                }
+            }
+            input_text(ARGS_INPUT, (text = "args"))
+            if (g_launch.running) {
+                text("running...")
+            } else {
+                if (button(LAUNCH_BTN, (text = "launch"))) {
+                    g_launch.args = ARGS_INPUT.value
+                    if (!launch_start(g_launch)) {
+                        to_log(LOG_ERROR, "jobque-timeline: launch failed to start\n")
+                    }
+                }
+                if (g_launch.has_run) {
+                    text(RC_LABEL, (text = "exit code {g_launch.exit_code}"))
+                }
+            }
+            for (i in range(length(g_launch.tail))) {
+                text(TAIL_LINE[i], (text = g_launch.tail[i]))
+            }
+        }
+        let flags = ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse
+        if (!empty(g_docs)) {
+            dock_window(TRACE0, (text = g_docs[0].title, closable = false, flags = flags)) {
+                draw_doc_window(0)
+            }
+        }
+        if (length(g_docs) > 1) {
+            dock_window(TRACE1, (text = g_docs[1].title, closable = false, flags = flags)) {
+                draw_doc_window(1)
+            }
+        }
+        if (length(g_docs) > 2) {
+            dock_window(TRACE2, (text = g_docs[2].title, closable = false, flags = flags)) {
+                draw_doc_window(2)
+            }
+        }
+        if (length(g_docs) > 3) {
+            dock_window(TRACE3, (text = g_docs[3].title, closable = false, flags = flags)) {
+                draw_doc_window(3)
+            }
+        }
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    destroy_job_que()
+    harness_shutdown()
+}
+
+// ---- live commands (timeline_ prefix): structured state for screenshot-free queries ----
+
+struct TLFileArg {
+    file : int
+}
+
+struct TLSetViewArg {
+    file : int
+    t0 : double
+    t1 : double
+}
+
+struct TLUnitArg {
+    file : int
+    kind : string
+    index : int
+}
+
+struct TLOpenArg {
+    path : string
+}
+
+def doc_entry(i : int) : JsonValue? {
+    var mks <- [for (mk in g_docs[i].marker_kinds); "{mk.name}:{length(mk.ts)}"]
+    return JV((index = i, title = g_docs[i].title, path = g_docs[i].path,
+        lanes = length(g_docs[i].lanes), events = int(g_docs[i].total_events),
+        span_us = g_docs[i].span, view_t0 = g_ui[i].t0, view_t1 = g_ui[i].t1,
+        markers <- mks))
+}
+
+[live_command(description = "list open trace files with spans, views, and marker kinds"), unused_argument(input)]
+def timeline_files(input : JsonValue?) : JsonValue? {
+    var files <- [for (i in range(length(g_docs))); doc_entry(i)]
+    return JV((files <- files, share_zoom = SHARE_ZOOM.value, share_timer = SHARE_TIMER.value))
+}
+
+[live_command(description = "open a trace file: args \{path\}")]
+def timeline_open(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLOpenArg>)
+    if (!open_file(args.path)) {
+        return JV("failed to open {args.path}")
+    }
+    TL_ROOT.has_initial_layout = false   // reseed the stacked layout with the new window
+    return doc_entry(length(g_docs) - 1)
+}
+
+[live_command(description = "get a file visible time window: args \{file\}")]
+def timeline_get_view(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLFileArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    return JV((t0 = g_ui[args.file].t0, t1 = g_ui[args.file].t1, span_us = g_docs[args.file].span))
+}
+
+[live_command(description = "set a file's visible window (drives sync like a user interaction): args \{file,t0,t1\}")]
+def timeline_set_view(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLSetViewArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    var ui & = unsafe(g_ui[args.file])
+    ui.t0 = args.t0
+    ui.t1 = args.t1
+    ui.inited = true
+    clamp_view(ui, max(g_docs[args.file].span, 8.0lf))
+    sync_views(args.file)
+    var views <- [for (i in range(length(g_ui))); JV((index = i, t0 = g_ui[i].t0, t1 = g_ui[i].t1))]
+    return JV((views <- views))
+}
+
+[live_command(description = "zoom a file to one unit: args \{file,kind,index\}")]
+def timeline_focus_unit(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLUnitArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    let doc & = unsafe(g_docs[args.file])
+    for (mk in doc.marker_kinds) {
+        if (mk.name == args.kind) {
+            if (args.index < 0 || args.index >= length(mk.ts)) {
+                return JV("unit index {args.index} out of range 0..{length(mk.ts) - 1}")
+            }
+            let u0 = mk.ts[args.index]
+            let u1 = args.index + 1 < length(mk.ts) ? mk.ts[args.index + 1] : doc.span
+            var ui & = unsafe(g_ui[args.file])
+            ui.t0 = u0
+            ui.t1 = max(u1, u0 + 8.0lf)
+            ui.inited = true
+            clamp_view(ui, max(doc.span, 8.0lf))
+            sync_views(args.file)
+            return JV((t0 = ui.t0, t1 = ui.t1, arg = mk.args[args.index]))
+        }
+    }
+    return JV("no marker kind '{args.kind}'")
+}
+
+[live_command(description = "computed stats for an arbitrary range, no UI change: args \{file,t0,t1\}")]
+def timeline_range_stats(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLSetViewArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    var st <- compute_range_stats(g_docs[args.file], args.t0, args.t1)
+    return JV(st)
+}
+
+[live_command(description = "the current selection + its computed stats: args \{file\}")]
+def timeline_get_selection(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLFileArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    if (!g_ui[args.file].sel_active) {
+        return JV((active = false))
+    }
+    // local compute — a tuple field would MOVE (zero) the cache's stats, not copy them
+    var st <- compute_range_stats(g_docs[args.file], g_ui[args.file].sel_t0, g_ui[args.file].sel_t1)
+    return JV((active = true, t0 = g_ui[args.file].sel_t0, t1 = g_ui[args.file].sel_t1, stats = st))
+}
+
+[live_command(description = "set the selection range (shown in the UI, stats computed): args \{file,t0,t1\}")]
+def timeline_set_selection(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLSetViewArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    var ui & = unsafe(g_ui[args.file])
+    ui.sel_active = true
+    ui.sel_t0 = min(args.t0, args.t1)
+    ui.sel_t1 = max(args.t0, args.t1)
+    // local compute — a tuple field would MOVE (zero) the cache's stats, not copy them
+    var st <- compute_range_stats(g_docs[args.file], ui.sel_t0, ui.sel_t1)
+    return JV((active = true, t0 = ui.sel_t0, t1 = ui.sel_t1, stats = st))
+}
+
+struct TLLaunchArg {
+    app : string
+    args : string
+}
+
+struct TLAutoArg {
+    on : bool
+}
+
+[live_command(description = "launch a trace-producing app in the background: args \{app,args\}")]
+def timeline_launch(input : JsonValue?) : JsonValue? {
+    let a = from_JV(input, type<TLLaunchArg>)
+    if (!empty(a.app)) {
+        g_launch.app = a.app
+    }
+    g_launch.args = a.args
+    if (!launch_start(g_launch)) {
+        return JV("launch failed (already running, or no app set)")
+    }
+    return JV((running = true, app = g_launch.app, args = g_launch.args))
+}
+
+[live_command(description = "launch status: running flag, exit code, output tail"), unused_argument(input)]
+def timeline_launch_status(input : JsonValue?) : JsonValue? {
+    return JV((running = g_launch.running, has_run = g_launch.has_run,
+        exit_code = g_launch.exit_code, tail := g_launch.tail))
+}
+
+[live_command(description = "re-parse an open trace file from disk: args \{file\}")]
+def timeline_refresh(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<TLFileArg>)
+    if (args.file < 0 || args.file >= length(g_docs)) {
+        return JV("no such file index {args.file}")
+    }
+    reload_file(args.file)
+    watch_prime(g_watch[args.file], g_docs[args.file].path)
+    return doc_entry(args.file)
+}
+
+[live_command(description = "toggle mtime-watch auto refresh: args \{on\}")]
+def timeline_set_autorefresh(input : JsonValue?) : JsonValue? {
+    let a = from_JV(input, type<TLAutoArg>)
+    AUTO_REFRESH.value = a.on
+    return JV((auto_refresh = AUTO_REFRESH.value))
+}
+
+[live_command(description = "what am I looking at: per-file view, visible events, busy-by-category per open file"), unused_argument(input)]
+def timeline_describe(input : JsonValue?) : JsonValue? {
+    var files : array<JsonValue?>
+    files |> reserve(length(g_docs))
+    for (i in range(length(g_docs))) {
+        let doc & = unsafe(g_docs[i])
+        let ui & = unsafe(g_ui[i])
+        var visible = 0
+        var cat_busy : array<double>
+        cat_busy |> resize(length(doc.cats))
+        for (lane in doc.lanes) {
+            var j = lane_lower_bound(lane, ui.t0 - lane.max_dur)
+            while (j < length(lane.ev)) {
+                let e & = unsafe(lane.ev[j])
+                if (e.t0 > ui.t1) {
+                    break
+                }
+                j++
+                let te = e.t0 + double(e.dur)
+                if (te < ui.t0) {
+                    continue
+                }
+                visible++
+                let kind = ev_kind(e.meta)
+                if (kind == EV_CHUNK || kind == EV_FIFO) {
+                    cat_busy[ev_cat(e.meta)] += min(te, ui.t1) - max(e.t0, ui.t0)
+                }
+            }
+        }
+        var cats <- [for (c in range(length(doc.cats)));
+            JV((name = doc.cats[c].name, busy_us = cat_busy[c]));
+            where cat_busy[c] > 0.0lf]
+        files |> push(JV((index = i, title = doc.title, view_t0 = ui.t0, view_t1 = ui.t1,
+            visible_events = visible, busy_by_category <- cats)))
+        delete cat_busy
+    }
+    return JV((files <- files, share_zoom = SHARE_ZOOM.value, share_timer = SHARE_TIMER.value))
+}
+
+[export]
+def main() {
+    for (arg in get_cli_arguments()) {
+        if (ends_with(arg, ".json")) {
+            g_pending |> push(arg)
+        }
+    }
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -246,20 +246,38 @@ def update() {
             }
         }
         dock_window(LAUNCH_WIN, (text = "Launch", closable = false, flags = ImGuiWindowFlags.None)) {
-            if (icon_button(BROWSE_BTN, (glyph = "folder", tip = "select the app to run"))) {
+            if (icon_button(BROWSE_BTN, (glyph = "folder", tip = "select the app to run (.das runs via daslang -jit)"))) {
                 file_dialog_open(FileDialogConfig(title = "Select App", start_dir = "",
-                    filters <- file_filters("Programs (*.exe)|exe|All files|"),
+                    filters <- file_filters("Apps (*.das *.exe)|das;exe|All files|"),
                     mode = FileDialogMode.open, max_selection = 1))
                 g_dlg_purpose = 1
             }
             same_line()
             text(APP_LABEL, (text = empty(g_launch.app) ? "<no app>" : base_name(g_launch.app)))
-            input_text(ARGS_INPUT, (text = "args"))
+            if (icon_button(ARGS_EDIT_BTN, (glyph = "sliders", tip = "edit arguments (multi-line)"))) {
+                ARGS_MULTI.capacity = 4096
+                ARGS_MULTI.pending_value = g_launch.args
+                ARGS_MULTI.has_pending = true
+                ARGS_MODAL.pending_open = true
+            }
+            same_line()
+            text(ARGS_LABEL, (text = empty(g_launch.args) ? "<no args>" : g_launch.args))
+            popup_modal(ARGS_MODAL, (text = "Launch arguments", closable = true, flags = ImGuiWindowFlags.None)) {
+                text("whitespace-separated; newlines are fine (one argument per line avoids quoting)")
+                input_text_multiline(ARGS_MULTI, (text = "##args", size = float2(640.0f, 240.0f)))
+                if (button(ARGS_OK, (text = "OK"))) {
+                    g_launch.args = ARGS_MULTI.value
+                    ARGS_MODAL.pending_close = true
+                }
+                same_line()
+                if (button(ARGS_CANCEL, (text = "Cancel"))) {
+                    ARGS_MODAL.pending_close = true
+                }
+            }
             if (g_launch.running) {
                 text("running...")
             } else {
                 if (icon_button(LAUNCH_BTN, (glyph = "play", tip = "launch"))) {
-                    g_launch.args = ARGS_INPUT.value
                     if (!launch_start(g_launch)) {
                         to_log(LOG_ERROR, "jobque-timeline: launch failed to start\n")
                     }
@@ -472,19 +490,23 @@ def timeline_set_selection(input : JsonValue?) : JsonValue? {
 struct TLLaunchArg {
     app : string
     args : string
+    start : bool = true   // false = just pre-fill the launch panel
 }
 
 struct TLAutoArg {
     on : bool
 }
 
-[live_command(description = "launch a trace-producing app in the background: args \{app,args\}")]
+[live_command(description = "launch a trace-producing app in the background: args \{app,args,start?\} (start=false pre-fills only)")]
 def timeline_launch(input : JsonValue?) : JsonValue? {
     let a = from_JV(input, type<TLLaunchArg>)
     if (!empty(a.app)) {
         g_launch.app = a.app
     }
     g_launch.args = a.args
+    if (!a.start) {
+        return JV((running = false, app = g_launch.app, args = g_launch.args))
+    }
     if (!launch_start(g_launch)) {
         return JV("launch failed (already running, or no app set)")
     }

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -7,7 +7,7 @@ require daslib/clargs
 require daslib/json_boost
 require strings
 require math
-require stddlg
+require imgui/imgui_file_dialog
 require tl_model
 require tl_loader
 require tl_view
@@ -30,6 +30,7 @@ var g_pending : array<string>   // files handed on the command line, loaded in i
 var g_launch : LaunchRail
 var g_watch : array<FileWatch>  // per-doc auto-refresh watchers
 var g_poll_frame = 0
+var g_dlg_purpose = 0           // the singleton file dialog's pending consumer: 1 = launch app, 2 = open traces
 
 var private DOC_STATS : table<int; NarrativeState>    // per-window header line widgets
 var private DOC_CHIPS : table<int; NarrativeState>    // per-window computed stats (idle/par/cats)
@@ -189,6 +190,12 @@ def update() {
             checkbox(SHARE_ZOOM, (text = "share zoom"))
             checkbox(SHARE_TIMER, (text = "share timer"))
             checkbox(AUTO_REFRESH, (text = "auto refresh"))
+            if (button(OPEN_TRACE_BTN, (text = "open trace..."))) {
+                file_dialog_open(FileDialogConfig(title = "Open Trace", start_dir = "",
+                    filters <- file_filters("Traces (*.json)|json|All files|"),
+                    mode = FileDialogMode.open, max_selection = MAX_DOCS))
+                g_dlg_purpose = 2
+            }
             for (i in range(length(g_docs))) {
                 text(FILE_LABEL[i], (text = g_docs[i].title))
                 if (button(RELOAD_BTN[i], (text = "reload##{i}"))) {
@@ -198,10 +205,10 @@ def update() {
             text("-- launch --")
             text(APP_LABEL, (text = empty(g_launch.app) ? "<no app>" : g_launch.app))
             if (button(BROWSE_BTN, (text = "browse..."))) {
-                let picked = get_dlg_open_file("", "")
-                if (!empty(picked)) {
-                    g_launch.app = picked
-                }
+                file_dialog_open(FileDialogConfig(title = "Select App", start_dir = "",
+                    filters <- file_filters("Programs (*.exe)|exe|All files|"),
+                    mode = FileDialogMode.open, max_selection = 1))
+                g_dlg_purpose = 1
             }
             input_text(ARGS_INPUT, (text = "args"))
             if (g_launch.running) {
@@ -242,6 +249,24 @@ def update() {
                 draw_doc_window(3)
             }
         }
+    }
+    // the file dialog renders at top level (clean FILEDLG/... registry path); one modal
+    // serves both consumers, dispatched by g_dlg_purpose
+    let fd = file_dialog_draw()
+    if (fd == FileDialogResult.confirmed) {
+        if (g_dlg_purpose == 1) {
+            g_launch.app = file_dialog_selected_path()
+        } elif (g_dlg_purpose == 2) {
+            var sel <- file_dialog_selection()
+            for (p in sel) {
+                open_file(p)
+            }
+            delete sel
+            TL_ROOT.has_initial_layout = false   // reseed the stacked layout with the new windows
+        }
+        g_dlg_purpose = 0
+    } elif (fd == FileDialogResult.cancelled) {
+        g_dlg_purpose = 0
     }
     harness_end_frame()
 }

--- a/utils/jobque-timeline/main.das
+++ b/utils/jobque-timeline/main.das
@@ -4,6 +4,7 @@ options stack = 65536
 require imgui/imgui_harness
 require daslib/jobque_boost
 require daslib/clargs
+require daslib/fio
 require daslib/json_boost
 require strings
 require math
@@ -37,7 +38,11 @@ var private DOC_CHIPS : table<int; NarrativeState>    // per-window computed sta
 var private DOC_SEL : table<int; NarrativeState>      // per-window selection stats
 var private FILE_LABEL : table<int; NarrativeState>   // controls-panel file list
 var private RELOAD_BTN : table<int; ClickState>       // per-file manual refresh
+var private CLOSE_BTN : table<int; ClickState>        // per-file close
+var private FILE_SL_A : table<int; EmptyMarkerState>  // per-file row same_line markers
+var private FILE_SL_B : table<int; EmptyMarkerState>
 var private TAIL_LINE : table<int; NarrativeState>    // launch output tail
+var g_close_req = -1            // deferred close (icon or window X) — applied after the frame's windows
 
 def open_file(path : string) : bool {
     if (length(g_docs) >= MAX_DOCS) {
@@ -63,6 +68,30 @@ def open_file(path : string) : bool {
     watch_prime(fw, path)
     g_watch |> push(fw)
     return true
+}
+
+def trace_window_open(i : int) : bool {
+    if (i == 0) return TRACE0.open
+    if (i == 1) return TRACE1.open
+    if (i == 2) return TRACE2.open
+    return TRACE3.open
+}
+
+def close_file(i : int) {
+    g_docs |> erase(i)
+    g_ui |> erase(i)
+    g_render |> erase(i)
+    g_view_stats |> erase(i)
+    g_sel_stats |> erase(i)
+    g_watch |> erase(i)
+    for (j in range(length(g_docs))) {
+        g_docs[j].title = "{j}: {base_name(g_docs[j].path)}"
+    }
+    TRACE0.open = true   // dock slots are positional — reset and reseed
+    TRACE1.open = true
+    TRACE2.open = true
+    TRACE3.open = true
+    TL_ROOT.has_initial_layout = false
 }
 
 def reload_file(i : int) {
@@ -115,7 +144,11 @@ def setup_layout(dock_id : uint) {
     var left_id : uint = 0u
     var main_id : uint = 0u
     DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.16f, left_id, main_id)
-    DockBuilderDockWindow("Controls", left_id)
+    var launch_id : uint = 0u
+    var ctrl_id : uint = 0u
+    DockBuilderSplitNode(left_id, ImGuiDir.Down, 0.34f, launch_id, ctrl_id)
+    DockBuilderDockWindow("Controls", ctrl_id)
+    DockBuilderDockWindow("Launch", launch_id)
     let n = length(g_docs)
     var cur = main_id
     for (i in range(n)) {
@@ -190,66 +223,88 @@ def update() {
             checkbox(SHARE_ZOOM, (text = "share zoom"))
             checkbox(SHARE_TIMER, (text = "share timer"))
             checkbox(AUTO_REFRESH, (text = "auto refresh"))
-            if (button(OPEN_TRACE_BTN, (text = "open trace..."))) {
+            separator()
+            if (icon_button(OPEN_TRACE_BTN, (glyph = "folder", tip = "open trace file(s) — multi-select with ctrl/shift"))) {
                 file_dialog_open(FileDialogConfig(title = "Open Trace", start_dir = "",
                     filters <- file_filters("Traces (*.json)|json|All files|"),
                     mode = FileDialogMode.open, max_selection = MAX_DOCS))
                 g_dlg_purpose = 2
             }
+            same_line()
+            text("open trace...")
             for (i in range(length(g_docs))) {
-                text(FILE_LABEL[i], (text = g_docs[i].title))
-                if (button(RELOAD_BTN[i], (text = "reload##{i}"))) {
+                if (icon_button(RELOAD_BTN[i], (glyph = "refresh", tip = "reload from disk"))) {
                     reload_file(i)
                 }
+                same_line(FILE_SL_A[i])
+                if (icon_button(CLOSE_BTN[i], (glyph = "close", tip = "close"))) {
+                    g_close_req = i
+                }
+                same_line(FILE_SL_B[i])
+                text(FILE_LABEL[i], (text = g_docs[i].title))
             }
-            text("-- launch --")
-            text(APP_LABEL, (text = empty(g_launch.app) ? "<no app>" : g_launch.app))
-            if (button(BROWSE_BTN, (text = "browse..."))) {
+        }
+        dock_window(LAUNCH_WIN, (text = "Launch", closable = false, flags = ImGuiWindowFlags.None)) {
+            if (icon_button(BROWSE_BTN, (glyph = "folder", tip = "select the app to run"))) {
                 file_dialog_open(FileDialogConfig(title = "Select App", start_dir = "",
                     filters <- file_filters("Programs (*.exe)|exe|All files|"),
                     mode = FileDialogMode.open, max_selection = 1))
                 g_dlg_purpose = 1
             }
+            same_line()
+            text(APP_LABEL, (text = empty(g_launch.app) ? "<no app>" : base_name(g_launch.app)))
             input_text(ARGS_INPUT, (text = "args"))
             if (g_launch.running) {
                 text("running...")
             } else {
-                if (button(LAUNCH_BTN, (text = "launch"))) {
+                if (icon_button(LAUNCH_BTN, (glyph = "play", tip = "launch"))) {
                     g_launch.args = ARGS_INPUT.value
                     if (!launch_start(g_launch)) {
                         to_log(LOG_ERROR, "jobque-timeline: launch failed to start\n")
                     }
                 }
                 if (g_launch.has_run) {
+                    same_line()
                     text(RC_LABEL, (text = "exit code {g_launch.exit_code}"))
                 }
             }
+            separator()
             for (i in range(length(g_launch.tail))) {
                 text(TAIL_LINE[i], (text = g_launch.tail[i]))
             }
         }
         let flags = ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse
         if (!empty(g_docs)) {
-            dock_window(TRACE0, (text = g_docs[0].title, closable = false, flags = flags)) {
+            dock_window(TRACE0, (text = g_docs[0].title, closable = true, flags = flags)) {
                 draw_doc_window(0)
             }
         }
         if (length(g_docs) > 1) {
-            dock_window(TRACE1, (text = g_docs[1].title, closable = false, flags = flags)) {
+            dock_window(TRACE1, (text = g_docs[1].title, closable = true, flags = flags)) {
                 draw_doc_window(1)
             }
         }
         if (length(g_docs) > 2) {
-            dock_window(TRACE2, (text = g_docs[2].title, closable = false, flags = flags)) {
+            dock_window(TRACE2, (text = g_docs[2].title, closable = true, flags = flags)) {
                 draw_doc_window(2)
             }
         }
         if (length(g_docs) > 3) {
-            dock_window(TRACE3, (text = g_docs[3].title, closable = false, flags = flags)) {
+            dock_window(TRACE3, (text = g_docs[3].title, closable = true, flags = flags)) {
                 draw_doc_window(3)
             }
         }
     }
+    // apply deferred closes (close icon or a trace window's X)
+    for (i in range(length(g_docs))) {
+        if (!trace_window_open(i)) {
+            g_close_req = i
+        }
+    }
+    if (g_close_req >= 0 && g_close_req < length(g_docs)) {
+        close_file(g_close_req)
+    }
+    g_close_req = -1
     // the file dialog renders at top level (clean FILEDLG/... registry path); one modal
     // serves both consumers, dispatched by g_dlg_purpose
     let fd = file_dialog_draw()

--- a/utils/jobque-timeline/test_tl_launch.das
+++ b/utils/jobque-timeline/test_tl_launch.das
@@ -1,0 +1,48 @@
+options gen2
+require dastest/testing_boost public
+require daslib/fio
+require tl_launch
+
+// Launch-rail helpers that run without a subprocess: quote-aware argv split and the
+// mtime/size debounced file watcher.
+
+[test]
+def test_split_args(t : T?) {
+    t |> run("quote-aware argv split") @(t : T?) {
+        let a <- split_args("-m \"a b.gguf\" -p  512")
+        t |> equal(4, length(a))
+        t |> equal("-m", a[0])
+        t |> equal("a b.gguf", a[1])
+        t |> equal("-p", a[2])
+        t |> equal("512", a[3])
+        let b <- split_args("")
+        t |> equal(0, length(b))
+        let c <- split_args("single")
+        t |> equal(1, length(c))
+    }
+}
+
+[test]
+def test_file_watch(t : T?) {
+    t |> run("watch fires on change only after a stable poll") @(t : T?) {
+        var terr = ""
+        let dir = temp_directory(terr)
+        let path = "{dir}/tl_watch_probe.txt"
+        fopen(path, "wb") $(f) {
+            if (f != null) {
+                f |> fwrite("one")
+            }
+        }
+        var w = FileWatch()
+        watch_prime(w, path)
+        t |> success(!watch_poll(w, path), "no change -> no fire")
+        fopen(path, "wb") $(f) {
+            if (f != null) {
+                f |> fwrite("two-longer")
+            }
+        }
+        t |> success(!watch_poll(w, path), "first poll after change arms the debounce")
+        t |> success(watch_poll(w, path), "second (stable) poll fires")
+        t |> success(!watch_poll(w, path), "and it rearms quietly")
+    }
+}

--- a/utils/jobque-timeline/test_tl_launch.das
+++ b/utils/jobque-timeline/test_tl_launch.das
@@ -23,6 +23,15 @@ def test_split_args(t : T?) {
 }
 
 [test]
+def test_extract_json_path(t : T?) {
+    t |> run("finds the .json token in an output line") @(t : T?) {
+        t |> equal("C:/tmp/a.trace.json", extract_json_path("jobque trace saved: C:/tmp/a.trace.json"))
+        t |> equal("", extract_json_path("decode: 8 tokens in 118494us"))
+        t |> equal("b.json", extract_json_path("wrote b.json ok"))
+    }
+}
+
+[test]
 def test_file_watch(t : T?) {
     t |> run("watch fires on change only after a stable poll") @(t : T?) {
         var terr = ""

--- a/utils/jobque-timeline/test_tl_loader.das
+++ b/utils/jobque-timeline/test_tl_loader.das
@@ -1,0 +1,113 @@
+options gen2
+require dastest/testing_boost public
+require daslib/fio
+require tl_model
+require tl_loader
+
+// Loader round-trip on synthetic traceSave text: new-format (jobqueProfile + markers),
+// old-format fallback (legacy palette, no markers), sorting, chain resolution.
+
+def write_temp(t : T?; name, text : string) : string {
+    var terr = ""
+    let dir = temp_directory(terr)
+    t |> success(terr == "", "temp_directory resolves")
+    let path = "{dir}/{name}"
+    fopen(path, "wb") $(f) {
+        if (f != null) {
+            f |> fwrite(text)
+        }
+    }
+    return path
+}
+
+def new_format_trace() : string {
+    // one worker + caller; a 2-stage tagged chain, a wake recorded AFTER later events
+    // (ring order is completion order — the loader must sort), a marker, a header
+    var s = "\{\"traceEvents\":[\n"
+    s += "\{\"ph\":\"M\",\"pid\":0,\"tid\":0,\"name\":\"thread_name\",\"args\":\{\"name\":\"worker 0\"\}\},\n"
+    s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":10.000,\"dur\":5.000,\"name\":\"chunk\",\"args\":\{\"stage\":0,\"arg\":0,\"chain\":7\}\},\n"
+    s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":16.000,\"dur\":4.000,\"name\":\"chunk\",\"args\":\{\"stage\":1,\"arg\":1,\"chain\":7\}\},\n"
+    s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":2.500,\"dur\":30.000,\"name\":\"wake\",\"args\":\{\"stage\":0,\"arg\":1,\"chain\":0\}\},\n"
+    s += "\{\"ph\":\"M\",\"pid\":0,\"tid\":1,\"name\":\"thread_name\",\"args\":\{\"name\":\"caller 1\"\}\},\n"
+    s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":1,\"ts\":9.000,\"dur\":1.500,\"name\":\"publish\",\"args\":\{\"stage\":1794,\"arg\":4,\"chain\":7\}\},\n"
+    s += "\{\"ph\":\"i\",\"s\":\"g\",\"pid\":0,\"tid\":1,\"ts\":8.000,\"name\":\"token\",\"args\":\{\"arg\":41\}\},\n"
+    s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":1,\"ts\":20.000,\"dur\":2.000,\"name\":\"stage_wait\",\"args\":\{\"stage\":1,\"arg\":0,\"chain\":7\}\}\n"
+    s += "],\"jobqueProfile\":\{\"version\":1,\"lanes\":2,"
+    s += "\"categories\":[\{\"id\":7,\"name\":\"my op\",\"color\":\"#112233\"\}],"
+    s += "\"markers\":[\{\"id\":0,\"name\":\"token\"\}]\}\}\n"
+    return s
+}
+
+[test]
+def test_loader_new_format(t : T?) {
+    t |> run("new-format trace loads with header, markers, chains") @(t : T?) {
+        let path = write_temp(t, "tl_test_new.json", new_format_trace())
+        var doc : TraceDoc
+        t |> success(load_trace(path, doc), "load_trace succeeds")
+        t |> equal(2, length(doc.lanes))
+        t |> equal(5, int(doc.total_events))
+        t |> success(doc.has_profile, "jobqueProfile parsed")
+        t |> equal("worker 0", doc.lanes[0].name)
+        t |> equal("caller 1", doc.lanes[1].name)
+        // header category "my op" (tag 7) appended after the 4 base classes
+        t |> equal(5, length(doc.cats))
+        t |> equal("my op", doc.cats[4].name)
+        t |> equal(0x112233u, doc.cats[4].col)
+        // markers
+        t |> equal(1, length(doc.marker_kinds))
+        t |> equal("token", doc.marker_kinds[0].name)
+        t |> equal(41, doc.marker_kinds[0].args[0])
+        t |> equal(8.0lf, doc.marker_kinds[0].ts[0])
+        // wake recorded out of t0 order must sort first on lane 0
+        t |> equal(EV_WAKE, ev_kind(doc.lanes[0].ev[0].meta))
+        t |> equal(2.5lf, doc.lanes[0].ev[0].t0)
+        t |> equal(30.0lf, doc.lanes[0].max_dur)
+        // chain resolution: packed 1794 = nstages 2 | tag 7<<8 -> both chunks tagged "my op"
+        let c0 = doc.lanes[0].ev[1]
+        t |> equal(EV_CHUNK, ev_kind(c0.meta))
+        t |> equal(2, ev_nstages(c0.meta))
+        t |> equal(4, ev_cat(c0.meta))
+        // publish stage field unpacked to the low byte (sorted first on the caller lane)
+        let pub = doc.lanes[1].ev[0]
+        t |> equal(EV_PUBLISH, ev_kind(pub.meta))
+        t |> equal(2, ev_stage(pub.meta))
+        // span covers the longest event end
+        t |> equal(32.5lf, doc.span)
+        // mips built (level 0 at least)
+        t |> success(length(doc.lanes[0].mips) >= 1, "mips built")
+    }
+}
+
+[test]
+def test_loader_old_format(t : T?) {
+    t |> run("headerless trace falls back to the legacy palette") @(t : T?) {
+        var s = "\{\"traceEvents\":[\n"
+        s += "\{\"ph\":\"M\",\"pid\":0,\"tid\":0,\"name\":\"thread_name\",\"args\":\{\"name\":\"caller 0\"\}\},\n"
+        s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":0.000,\"dur\":3.000,\"name\":\"publish\",\"args\":\{\"stage\":1281,\"arg\":2,\"chain\":3\}\},\n"
+        s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":4.000,\"dur\":6.000,\"name\":\"chunk\",\"args\":\{\"stage\":0,\"arg\":0,\"chain\":3\}\}\n"
+        s += "]\}\n"
+        let path = write_temp(t, "tl_test_old.json", s)
+        var doc : TraceDoc
+        t |> success(load_trace(path, doc), "load_trace succeeds")
+        t |> success(!doc.has_profile, "no header")
+        t |> equal(0, length(doc.marker_kinds))
+        // packed 1281 = nstages 1 | tag 5<<8 -> legacy tag 5 = classifier appended
+        let c = doc.lanes[0].ev[1]
+        t |> equal(1, ev_nstages(c.meta))
+        t |> equal("classifier", doc.cats[ev_cat(c.meta)].name)
+    }
+}
+
+[test]
+def test_loader_untagged_heuristic(t : T?) {
+    t |> run("untagged chains classify by stage count") @(t : T?) {
+        var s = "\{\"traceEvents\":[\n"
+        s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":0.000,\"dur\":1.000,\"name\":\"publish\",\"args\":\{\"stage\":2,\"arg\":2,\"chain\":9\}\},\n"
+        s += "\{\"ph\":\"X\",\"pid\":0,\"tid\":0,\"ts\":2.000,\"dur\":1.000,\"name\":\"chunk\",\"args\":\{\"stage\":0,\"arg\":0,\"chain\":9\}\}\n"
+        s += "]\}\n"
+        let path = write_temp(t, "tl_test_untagged.json", s)
+        var doc : TraceDoc
+        t |> success(load_trace(path, doc), "load_trace succeeds")
+        t |> equal(CAT_FFN, ev_cat(doc.lanes[0].ev[1].meta))
+    }
+}

--- a/utils/jobque-timeline/test_tl_stats.das
+++ b/utils/jobque-timeline/test_tl_stats.das
@@ -1,0 +1,76 @@
+options gen2
+require dastest/testing_boost public
+require math
+require tl_model
+require tl_stats
+
+// RangeStats on a hand-built doc: clipping at range edges, idle/parallelism math,
+// per-category shares, cache freshness.
+
+def make_doc() : TraceDoc {
+    var doc = TraceDoc(cats <- base_categories(), span = 100.0lf)
+    doc.lanes |> resize(2)
+    // lane 0: one 10µs attn chunk [10,20], one publish [5,6]
+    doc.lanes[0].ev <- [
+        Ev(t0 = 5.0lf, dur = 1.0f, meta = ev_meta(EV_PUBLISH, 2, 2, CAT_ATTN), arg = 0u, chain = 1u),
+        Ev(t0 = 10.0lf, dur = 10.0f, meta = ev_meta(EV_CHUNK, 0, 2, CAT_ATTN), arg = 0u, chain = 1u)
+    ]
+    doc.lanes[0].max_dur = 10.0lf
+    // lane 1: a 20µs ffn chunk [15,35] (clips at range edge), a 5µs stage_wait [40,45]
+    doc.lanes[1].ev <- [
+        Ev(t0 = 15.0lf, dur = 20.0f, meta = ev_meta(EV_CHUNK, 1, 2, CAT_FFN), arg = 1u, chain = 1u),
+        Ev(t0 = 40.0lf, dur = 5.0f, meta = ev_meta(EV_STAGE_WAIT, 1, 2, CAT_FFN), arg = 0u, chain = 1u)
+    ]
+    doc.lanes[1].max_dur = 20.0lf
+    doc.generation = 1
+    return <- doc
+}
+
+[test]
+def test_range_stats(t : T?) {
+    t |> run("busy/idle/parallelism with edge clipping") @(t : T?) {
+        var doc <- make_doc()
+        // range [10,25]: lane0 chunk fully in (10), lane1 chunk clipped to [15,25] (10);
+        // publish [5,6] outside; wait outside
+        let st <- compute_range_stats(doc, 10.0lf, 25.0lf)
+        t |> equal(2, st.events)
+        t |> equal(20.0lf, st.busy_us)
+        t |> equal(0.0lf, st.wait_us)
+        t |> equal(0, st.publish_count)
+        // idle = 1 - 20/(15*2) = 33.33%
+        t |> success(abs(st.idle_pct - 33.333f) < 0.1f, "idle pct: {st.idle_pct}")
+        t |> success(abs(st.parallelism - 20.0f / 15.0f) < 0.01f, "parallelism: {st.parallelism}")
+        t |> equal(2, length(st.cat))
+        t |> equal(st.cat[0].busy_us, st.cat[1].busy_us)   // 10 attn + 10 ffn
+    }
+}
+
+[test]
+def test_range_stats_full(t : T?) {
+    t |> run("full span counts publish and wait") @(t : T?) {
+        var doc <- make_doc()
+        let st <- compute_range_stats(doc, 0.0lf, 100.0lf)
+        t |> equal(4, st.events)
+        t |> equal(1, st.publish_count)
+        t |> equal(31.0lf, st.busy_us)   // 10 + 20 + 1 (publish counts as work)
+        t |> equal(5.0lf, st.wait_us)
+    }
+}
+
+[test]
+def test_stats_cache(t : T?) {
+    t |> run("cache recomputes only on key change") @(t : T?) {
+        var doc <- make_doc()
+        var cache = StatsCache()
+        cached_stats(cache, doc, 10.0lf, 25.0lf)
+        t |> equal(2, cache.stats.events)
+        // same key -> stays; poke the stats to detect a recompute
+        cache.stats.events = 999
+        cached_stats(cache, doc, 10.0lf, 25.0lf)
+        t |> equal(999, cache.stats.events)
+        // generation bump -> recompute
+        doc.generation++
+        cached_stats(cache, doc, 10.0lf, 25.0lf)
+        t |> equal(2, cache.stats.events)
+    }
+}

--- a/utils/jobque-timeline/tl_launch.das
+++ b/utils/jobque-timeline/tl_launch.das
@@ -5,6 +5,7 @@ module tl_launch
 
 require daslib/jobque_boost
 require daslib/strings_boost
+require daslib/command_line
 require daslib/fio
 require math
 require strings
@@ -39,7 +40,7 @@ def public split_args(s : string) : array<string> {
             let c = data[i]
             if (c == uint8('"')) {
                 in_quote = !in_quote
-            } elif (!in_quote && (c == uint8(' ') || c == uint8('\t'))) {
+            } elif (!in_quote && (c == uint8(' ') || c == uint8('\t') || c == uint8('\n') || c == uint8('\r'))) {
                 if (!empty(cur)) {
                     unsafe {
                         out |> push(string(cur))
@@ -74,11 +75,19 @@ def public launch_start(var L : LaunchRail) : bool {
     var ch = L.ch
     let app := L.app
     let args := L.args
+    let das_exe := get_das_exe()   // .das apps run as `daslang -jit <script> -- <args>`
     new_job <| @ {
         var outp = ""
         var argv <- split_args(args)
         var full : array<string>
-        full |> push(app)
+        if (ends_with(app, ".das")) {
+            full |> push(das_exe)
+            full |> push("-jit")
+            full |> push(app)
+            full |> push("--")
+        } else {
+            full |> push(app)
+        }
         full |> push_from(argv)
         let rc = unsafe(popen_argv(full, 0.0, $(f) {
             if (f != null) {

--- a/utils/jobque-timeline/tl_launch.das
+++ b/utils/jobque-timeline/tl_launch.das
@@ -39,10 +39,10 @@ def public split_args(s : string) : array<string> {
     var in_quote = false
     peek_data(s) $(data) {
         for (i in range(length(data))) {
-            let c = data[i]
-            if (c == uint8('"')) {
+            let c = int(data[i])
+            if (c == '"') {
                 in_quote = !in_quote
-            } elif (!in_quote && (c == uint8(' ') || c == uint8('\t') || c == uint8('\n') || c == uint8('\r'))) {
+            } elif (!in_quote && (c == ' ' || c == '\t' || c == '\n' || c == '\r')) {
                 if (!empty(cur)) {
                     unsafe {
                         out |> push(string(cur))
@@ -50,7 +50,7 @@ def public split_args(s : string) : array<string> {
                     cur |> clear()
                 }
             } else {
-                cur |> push(c)
+                cur |> push(uint8(c))
             }
         }
     }
@@ -70,7 +70,7 @@ def public extract_json_path(line : string) : string {
     var toks <- split_args(line)
     for (tk in toks) {
         if (ends_with(tk, ".json")) {
-            found := tk
+            found = tk
             break
         }
     }
@@ -104,9 +104,9 @@ def public launch_start(var L : LaunchRail) : bool {
     }
     L.ch = unsafe(channel_create())
     var ch = L.ch
-    let app := L.app
-    let args := L.args
-    let das_exe := get_das_exe()   // .das apps run as `daslang -jit <script> -- <args>`
+    let app = clone_string(L.app)          // cloned: the job below runs in another context
+    let args = clone_string(L.args)
+    let das_exe = clone_string(get_das_exe())   // .das apps run as `daslang -jit <script> -- <args>`
     new_job <| @ {
         var outp = ""
         var argv <- split_args(args)

--- a/utils/jobque-timeline/tl_launch.das
+++ b/utils/jobque-timeline/tl_launch.das
@@ -1,0 +1,182 @@
+options gen2
+options indenting = 4
+
+module tl_launch
+
+require daslib/jobque_boost
+require daslib/strings_boost
+require daslib/fio
+require math
+require strings
+
+// Launch rail: run a trace-producing app (argv-direct popen_argv — no shell quoting traps)
+// in a background job, stream its result back over a channel, and watch trace files for
+// changes (auto-refresh). The job captures plain strings; argv is rebuilt job-side.
+
+struct public LaunchMsg {
+    kind : int      // 0 = output line, 1 = done
+    text : string
+    rc : int
+}
+
+struct public LaunchRail {
+    app : string
+    args : string
+    running : bool
+    has_run : bool
+    exit_code : int
+    tail : array<string>     // last lines of the finished run's output
+    ch : Channel?
+}
+
+//! Quote-aware argv split: `-m "a b.gguf" -p 512` -> ["-m", "a b.gguf", "-p", "512"]
+def public split_args(s : string) : array<string> {
+    var out : array<string>
+    var cur : array<uint8>
+    var in_quote = false
+    peek_data(s) $(data) {
+        for (i in range(length(data))) {
+            let c = data[i]
+            if (c == uint8('"')) {
+                in_quote = !in_quote
+            } elif (!in_quote && (c == uint8(' ') || c == uint8('\t'))) {
+                if (!empty(cur)) {
+                    unsafe {
+                        out |> push(string(cur))
+                    }
+                    cur |> clear()
+                }
+            } else {
+                cur |> push(c)
+            }
+        }
+    }
+    if (!empty(cur)) {
+        unsafe {
+            out |> push(string(cur))
+        }
+    }
+    delete cur
+    return <- out
+}
+
+//! Start `app args` in a background job. Output (last lines) and the exit code arrive
+//! via launch_pump. False when already running or no app set.
+def public launch_start(var L : LaunchRail) : bool {
+    if (L.running || empty(L.app)) {
+        return false
+    }
+    L.running = true
+    L.has_run = false
+    L.exit_code = -9999
+    delete L.tail
+    L.ch = unsafe(channel_create())
+    var ch = L.ch
+    let app := L.app
+    let args := L.args
+    new_job <| @ {
+        var outp = ""
+        var argv <- split_args(args)
+        var full : array<string>
+        full |> push(app)
+        full |> push_from(argv)
+        let rc = unsafe(popen_argv(full, 0.0, $(f) {
+            if (f != null) {
+                outp = unsafe(fread_to_eof(f))
+            }
+        }))
+        var lines <- split(outp, "\n")
+        let first = max(0, length(lines) - 30)
+        for (i in range(first, length(lines))) {
+            ch |> push_clone(LaunchMsg(kind = 0, text = lines[i], rc = 0))
+        }
+        ch |> push_clone(LaunchMsg(kind = 1, text = "", rc = rc))
+        ch |> release()
+        delete lines
+        delete full
+        delete argv
+    }
+    return true
+}
+
+//! Drain the launch channel (call once per frame). Returns true the frame the run finishes.
+def public launch_pump(var L : LaunchRail) : bool {
+    if (L.ch == null) {
+        return false
+    }
+    var finished = false
+    var more = true
+    while (more) {
+        more = L.ch |> try_pop_clone() $(m : LaunchMsg#) {
+            if (m.kind == 1) {
+                L.exit_code = m.rc
+                L.running = false
+                L.has_run = true
+                finished = true
+            } else {
+                var line = ""
+                unsafe {
+                    line = clone_string(m.text)
+                }
+                L.tail |> push(line)
+                if (length(L.tail) > 30) {
+                    L.tail |> erase(0)
+                }
+            }
+        }
+    }
+    if (finished) {
+        unsafe {
+            channel_remove(L.ch)
+        }
+        L.ch = null
+    }
+    return finished
+}
+
+// ---- file watching (auto-refresh): mtime change + size stable across two polls ----
+
+struct public FileWatch {
+    mtime : int64
+    size : uint64
+    pending_mtime : int64
+    pending_size : uint64
+    pending : bool
+}
+
+def public watch_prime(var w : FileWatch; path : string) {
+    let st = stat(path)
+    if (st.is_valid) {
+        w.mtime = int64(st.mtime)
+        w.size = st.size
+    }
+    w.pending = false
+}
+
+//! Poll a file (call every ~0.5s). True when it changed AND stayed stable for one poll —
+//! the debounce against catching traceSave mid-write.
+def public watch_poll(var w : FileWatch; path : string) : bool {
+    let st = stat(path)
+    if (!st.is_valid) {
+        return false
+    }
+    let mt = int64(st.mtime)
+    let sz = st.size
+    if (!w.pending) {
+        if (mt != w.mtime || sz != w.size) {
+            w.pending = true
+            w.pending_mtime = mt
+            w.pending_size = sz
+        }
+        return false
+    }
+    if (mt == w.pending_mtime && sz == w.pending_size) {
+        w.mtime = mt
+        w.size = sz
+        w.pending = false
+        return true
+    }
+    w.pending_mtime = mt
+    w.pending_size = sz
+    return false
+}

--- a/utils/jobque-timeline/tl_launch.das
+++ b/utils/jobque-timeline/tl_launch.das
@@ -61,6 +61,21 @@ def public split_args(s : string) : array<string> {
     return <- out
 }
 
+//! First whitespace-separated token ending in ".json" — how output lines like
+//! "jobque trace saved: <path>" surface a clickable trace. "" when none.
+def public extract_json_path(line : string) : string {
+    var found = ""
+    var toks <- split_args(line)
+    for (tk in toks) {
+        if (ends_with(tk, ".json")) {
+            found := tk
+            break
+        }
+    }
+    delete toks
+    return found
+}
+
 //! Start `app args` in a background job. Output (last lines) and the exit code arrive
 //! via launch_pump. False when already running or no app set.
 def public launch_start(var L : LaunchRail) : bool {

--- a/utils/jobque-timeline/tl_launch.das
+++ b/utils/jobque-timeline/tl_launch.das
@@ -24,6 +24,7 @@ struct public LaunchRail {
     app : string
     args : string
     affinity : bool = true   // DAS_JOBQUE_AFFINITY for the child
+    threads : int = 0        // DAS_JOBQUE_THREADS for the child; 0 = inherit
     running : bool
     has_run : bool
     exit_code : int
@@ -98,6 +99,9 @@ def public launch_start(var L : LaunchRail) : bool {
         set_env_variable("DASLLAMA_BATCH_TRACE", "{tdir}/launch_batch.trace.json")
     }
     set_env_variable("DAS_JOBQUE_AFFINITY", L.affinity ? "1" : "0")
+    if (L.threads > 0) {
+        set_env_variable("DAS_JOBQUE_THREADS", "{L.threads}")
+    }
     L.ch = unsafe(channel_create())
     var ch = L.ch
     let app := L.app

--- a/utils/jobque-timeline/tl_launch.das
+++ b/utils/jobque-timeline/tl_launch.das
@@ -23,6 +23,7 @@ struct public LaunchMsg {
 struct public LaunchRail {
     app : string
     args : string
+    affinity : bool = true   // DAS_JOBQUE_AFFINITY for the child
     running : bool
     has_run : bool
     exit_code : int
@@ -86,6 +87,17 @@ def public launch_start(var L : LaunchRail) : bool {
     L.has_run = false
     L.exit_code = -9999
     delete L.tail
+    // the child inherits these: dasLLAMA's env-armed trace rails point at tool-owned
+    // paths (the "jobque trace saved:" output line + auto-open pick the file up), and
+    // the affinity pin follows the checkbox
+    var terr = ""
+    let tdir = "{temp_directory(terr)}/jobque-timeline"
+    if (empty(terr)) {
+        mkdir(tdir)
+        set_env_variable("DASLLAMA_PREFILL_TRACE", "{tdir}/launch_prefill.trace.json")
+        set_env_variable("DASLLAMA_BATCH_TRACE", "{tdir}/launch_batch.trace.json")
+    }
+    set_env_variable("DAS_JOBQUE_AFFINITY", L.affinity ? "1" : "0")
     L.ch = unsafe(channel_create())
     var ch = L.ch
     let app := L.app
@@ -110,7 +122,7 @@ def public launch_start(var L : LaunchRail) : bool {
             }
         }))
         var lines <- split(outp, "\n")
-        let first = max(0, length(lines) - 30)
+        let first = max(0, length(lines) - 60)
         for (i in range(first, length(lines))) {
             ch |> push_clone(LaunchMsg(kind = 0, text = lines[i], rc = 0))
         }
@@ -143,7 +155,7 @@ def public launch_pump(var L : LaunchRail) : bool {
                     line = clone_string(m.text)
                 }
                 L.tail |> push(line)
-                if (length(L.tail) > 30) {
+                if (length(L.tail) > 60) {
                     L.tail |> erase(0)
                 }
             }

--- a/utils/jobque-timeline/tl_loader.das
+++ b/utils/jobque-timeline/tl_loader.das
@@ -1,0 +1,321 @@
+options gen2
+options indenting = 4
+
+module tl_loader shared
+
+require tl_model
+require tl_lod
+require strings
+require daslib/fio
+require daslib/json_boost
+
+// Rigid-format fast path over traceSave output (job_que.cpp): one event per line, fixed key
+// order, kind names unique by first letter. No JSON DOM for events — only the small
+// jobqueProfile trailer goes through the generic parser. Old files (no header, no markers)
+// load with the legacy palette.
+
+def private parse_uint(data : array<uint8> const#; var pos : int&) : uint64 {
+    var v = 0ul
+    while (pos < length(data)) {
+        let c = uint(data[pos])
+        if (c < uint('0') || c > uint('9')) {
+            break
+        }
+        v = v * 10ul + uint64(c - uint('0'))
+        pos++
+    }
+    return v
+}
+
+// "%.3f" µs field parsed as exact integer nanoseconds
+def private parse_us3(data : array<uint8> const#; var pos : int&) : double {
+    var ns = parse_uint(data, pos) * 1000ul
+    if (pos < length(data) && data[pos] == uint8('.')) {
+        pos++
+        var mul = 100ul
+        while (pos < length(data) && uint(data[pos]) >= uint('0') && uint(data[pos]) <= uint('9')) {
+            ns += uint64(uint(data[pos]) - uint('0')) * mul
+            mul /= 10ul
+            pos++
+        }
+    }
+    return double(ns) / 1000.0lf
+}
+
+// advance past `key` (e.g. "\"tid\":") scanning from pos, up to line_end; -1 if absent
+def private seek_past(data : array<uint8> const#; pos, line_end : int; key : string) : int {
+    var at = pos
+    var hit = -1
+    peek_data(key) $(kb) {
+        let kn = length(kb)
+        while (at + kn <= line_end) {
+            var m = 0
+            while (m < kn && data[at + m] == kb[m]) {
+                m++
+            }
+            if (m == kn) {
+                hit = at + kn
+                break
+            }
+            at++
+        }
+    }
+    return hit
+}
+
+def private read_json_string(data : array<uint8> const#; var pos : int&; line_end : int) : string {
+    var sb : array<uint8>
+    while (pos < line_end && data[pos] != uint8('"')) {
+        if (data[pos] == uint8('\\') && pos + 1 < line_end) {
+            pos++   // minimal unescape: \" and \\ (our writer escapes nothing else in names)
+        }
+        sb |> push(data[pos])
+        pos++
+    }
+    var out : string
+    unsafe {
+        out = string(sb)
+    }
+    delete sb
+    return out
+}
+
+struct private LineEv {
+    tid : int
+    ts : double
+    dur : double
+    kind : int
+    stage : uint
+    arg : uint
+    chain : uint
+}
+
+// parse one `{"ph":"X"...}` line; false when malformed
+def private parse_x_line(data : array<uint8> const#; pos, line_end : int; var e : LineEv&) : bool {
+    var at = seek_past(data, pos, line_end, "\"tid\":")
+    if (at < 0) return false
+    e.tid = int(parse_uint(data, at))
+    at = seek_past(data, at, line_end, "\"ts\":")
+    if (at < 0) return false
+    e.ts = parse_us3(data, at)
+    at = seek_past(data, at, line_end, "\"dur\":")
+    if (at < 0) return false
+    e.dur = parse_us3(data, at)
+    at = seek_past(data, at, line_end, "\"name\":\"")
+    if (at < 0) return false
+    let c = data[at]
+    if (c == uint8('p')) {
+        e.kind = EV_PUBLISH
+    } elif (c == uint8('c')) {
+        e.kind = EV_CHUNK
+    } elif (c == uint8('s')) {
+        e.kind = EV_STAGE_WAIT
+    } elif (c == uint8('w')) {
+        e.kind = EV_WAKE
+    } else {
+        e.kind = EV_FIFO
+    }
+    at = seek_past(data, at, line_end, "\"stage\":")
+    if (at < 0) return false
+    e.stage = uint(parse_uint(data, at))
+    at = seek_past(data, at, line_end, "\"arg\":")
+    if (at < 0) return false
+    e.arg = uint(parse_uint(data, at))
+    at = seek_past(data, at, line_end, "\"chain\":")
+    if (at < 0) return false
+    e.chain = uint(parse_uint(data, at))
+    return true
+}
+
+def private cat_for_tag(var doc : TraceDoc; var tag2cat : table<int; int>; tag : int) : int {
+    let known = tag2cat?[tag] ?? -1
+    if (known >= 0) return known
+    doc.cats |> push(legacy_tag_category(tag))
+    let idx = length(doc.cats) - 1
+    tag2cat[tag] = idx
+    return idx
+}
+
+def private marker_kind_index(var doc : TraceDoc; name : string) : int {
+    for (i in range(length(doc.marker_kinds))) {
+        if (doc.marker_kinds[i].name == name) return i
+    }
+    var mk : MarkerKind
+    mk.name = name
+    doc.marker_kinds |> emplace(mk)
+    return length(doc.marker_kinds) - 1
+}
+
+//! Load a traceSave JSON file into a TraceDoc. Synchronous (phases run back to back);
+//! returns false on read/parse failure. Old-format files (no jobqueProfile) get the
+//! legacy palette and an empty marker table.
+def public load_trace(path : string; var doc : TraceDoc) : bool {
+    var text = ""
+    fopen(path, "rb") $(f) {
+        if (f != null) {
+            text = fread(f)
+        }
+    }
+    if (empty(text)) return false
+    doc.path = path
+    doc.title = base_name(path)
+    doc.cats <- base_categories()
+    var tag2cat : table<int; int>
+    var chains : table<uint; uint>   // chain -> packed nstages|tag<<8 (from its publish)
+    var ok = true
+    peek_data(text) $(data) {
+        let n = length(data)
+        // pass A: count events per tid, find max tid, register header categories
+        var counts : array<int>
+        var pos = 0
+        while (pos < n) {
+            var line_end = pos
+            while (line_end < n && data[line_end] != uint8('\n')) {
+                line_end++
+            }
+            if (pos + 8 < n && data[pos] == uint8('{') && data[pos + 2] == uint8('p') && data[pos + 4] == uint8('"')) {
+                let ph = data[pos + 7]
+                if (ph == uint8('X') || ph == uint8('i')) {
+                    var at = seek_past(data, pos, line_end, "\"tid\":")
+                    if (at >= 0) {
+                        let tid = int(parse_uint(data, at))
+                        while (length(counts) <= tid) {
+                            counts |> push(0)
+                        }
+                        if (ph == uint8('X')) {
+                            counts[tid]++
+                        }
+                    }
+                }
+            } elif (data[pos] == uint8(']')) {
+                // trailer: parse the jobqueProfile object with the generic JSON parser
+                let at = seek_past(data, pos, line_end, "\"jobqueProfile\":")
+                if (at >= 0) {
+                    var jtxt = slice(text, at, line_end)
+                    if (ends_with(jtxt, "}}")) {
+                        jtxt = slice(jtxt, 0, length(jtxt) - 1)
+                    }
+                    var jerr = ""
+                    let prof = read_json(jtxt, jerr)
+                    if (prof != null) {
+                        doc.has_profile = true
+                        if (prof?["categories"] != null) {
+                            for (cat in prof?["categories"] as _array) {
+                                let tag = cat?["id"] ?? 0
+                                var col = 0xC39536u
+                                let hexs = cat?["color"] ?? ""
+                                if (length(hexs) == 7) {
+                                    col = to_uint("0x" + slice(hexs, 1), true)
+                                }
+                                doc.cats |> push(Category(tag = tag, name = cat?["name"] ?? "", col = col))
+                                tag2cat[tag] = length(doc.cats) - 1
+                            }
+                        }
+                    }
+                }
+            }
+            pos = line_end + 1
+        }
+        if (empty(counts)) {
+            ok = false
+            return
+        }
+        doc.lanes |> resize(length(counts))
+        for (i in range(length(counts))) {
+            doc.lanes[i].ev |> reserve(counts[i])
+            doc.lanes[i].name = "lane {i}"
+        }
+        // pass B: fill events, lane names, markers; collect chain->packed off publishes
+        pos = 0
+        while (pos < n) {
+            var line_end = pos
+            while (line_end < n && data[line_end] != uint8('\n')) {
+                line_end++
+            }
+            if (pos + 8 < n && data[pos] == uint8('{') && data[pos + 2] == uint8('p') && data[pos + 4] == uint8('"')) {
+                let ph = data[pos + 7]
+                if (ph == uint8('X')) {
+                    var le : LineEv
+                    if (parse_x_line(data, pos, line_end, le) && le.tid < length(doc.lanes)) {
+                        var stage = le.stage
+                        if (le.kind == EV_PUBLISH) {
+                            chains[le.chain] = le.stage   // packed nstages|tag<<8
+                            stage = le.stage & 0xFFu      // trace_window.py semantics
+                        }
+                        doc.lanes[le.tid].ev |> push(Ev(
+                            t0 = le.ts, dur = float(le.dur),
+                            meta = ev_meta(le.kind, int(stage), 0, 0),
+                            arg = le.arg, chain = le.chain))
+                        doc.total_events++
+                        let tend = le.ts + le.dur
+                        if (tend > doc.span) {
+                            doc.span = tend
+                        }
+                    }
+                } elif (ph == uint8('i')) {
+                    var at = seek_past(data, pos, line_end, "\"tid\":")
+                    if (at >= 0) {
+                        let tid = int(parse_uint(data, at))
+                        at = seek_past(data, at, line_end, "\"ts\":")
+                        if (at >= 0) {
+                            let ts = parse_us3(data, at)
+                            at = seek_past(data, at, line_end, "\"name\":\"")
+                            if (at >= 0) {
+                                let mname = read_json_string(data, at, line_end)
+                                var aat = seek_past(data, at, line_end, "\"arg\":")
+                                let arg = aat >= 0 ? int(parse_uint(data, aat)) : 0
+                                let mi = marker_kind_index(doc, mname)
+                                doc.marker_kinds[mi].ts |> push(ts)
+                                doc.marker_kinds[mi].args |> push(arg)
+                                doc.marker_kinds[mi].lane |> push(int8(tid))
+                                if (ts > doc.span) {
+                                    doc.span = ts
+                                }
+                            }
+                        }
+                    }
+                } elif (ph == uint8('M')) {
+                    var at = seek_past(data, pos, line_end, "\"tid\":")
+                    if (at >= 0) {
+                        let tid = int(parse_uint(data, at))
+                        at = seek_past(data, at, line_end, "\"args\":\{\"name\":\"")
+                        if (at >= 0 && tid < length(doc.lanes)) {
+                            doc.lanes[tid].name = read_json_string(data, at, line_end)
+                        }
+                    }
+                }
+            }
+            pos = line_end + 1
+        }
+    }
+    if (!ok) return false
+    // resolve: stamp nstages/cat from each event's chain, sort lanes, compute max_dur
+    for (li in range(length(doc.lanes))) {
+        var lane & = unsafe(doc.lanes[li])
+        for (i in range(length(lane.ev))) {
+            var e & = unsafe(lane.ev[i])
+            let kind = ev_kind(e.meta)
+            let packed = chains?[e.chain] ?? 0u
+            let nstages = int(packed & 0xFFu)
+            let tag = int(packed >> 8u)
+            var cat = CAT_STD
+            if (kind == EV_PUBLISH || kind == EV_CHUNK || kind == EV_STAGE_WAIT) {
+                cat = tag != 0 ? cat_for_tag(doc, tag2cat, tag) : heuristic_cat(nstages)
+            }
+            e.meta = ev_meta(kind, ev_stage(e.meta), nstages, cat)
+        }
+        lane.ev |> sort() $(a, b : Ev) {
+            return a.t0 < b.t0
+        }
+        var mx = 0.0lf
+        for (e in lane.ev) {
+            if (double(e.dur) > mx) {
+                mx = double(e.dur)
+            }
+        }
+        lane.max_dur = mx
+    }
+    build_mips(doc)
+    doc.generation++
+    return true
+}

--- a/utils/jobque-timeline/tl_loader.das
+++ b/utils/jobque-timeline/tl_loader.das
@@ -17,11 +17,11 @@ require daslib/json_boost
 def private parse_uint(data : array<uint8> const#; var pos : int&) : uint64 {
     var v = 0ul
     while (pos < length(data)) {
-        let c = uint(data[pos])
-        if (c < uint('0') || c > uint('9')) {
+        let c = int(data[pos])
+        if (!is_number(c)) {
             break
         }
-        v = v * 10ul + uint64(c - uint('0'))
+        v = v * 10ul + uint64(c - '0')
         pos++
     }
     return v
@@ -103,14 +103,14 @@ def private parse_x_line(data : array<uint8> const#; pos, line_end : int; var e 
     e.dur = parse_us3(data, at)
     at = seek_past(data, at, line_end, "\"name\":\"")
     if (at < 0) return false
-    let c = data[at]
-    if (c == uint8('p')) {
+    let c = int(data[at])
+    if (c == 'p') {
         e.kind = EV_PUBLISH
-    } elif (c == uint8('c')) {
+    } elif (c == 'c') {
         e.kind = EV_CHUNK
-    } elif (c == uint8('s')) {
+    } elif (c == 's') {
         e.kind = EV_STAGE_WAIT
-    } elif (c == uint8('w')) {
+    } elif (c == 'w') {
         e.kind = EV_WAKE
     } else {
         e.kind = EV_FIFO
@@ -174,15 +174,15 @@ def public load_trace(path : string; var doc : TraceDoc) : bool {
                 line_end++
             }
             if (pos + 8 < n && data[pos] == uint8('{') && data[pos + 2] == uint8('p') && data[pos + 4] == uint8('"')) {
-                let ph = data[pos + 7]
-                if (ph == uint8('X') || ph == uint8('i')) {
+                let ph = int(data[pos + 7])
+                if (ph == 'X' || ph == 'i') {
                     var at = seek_past(data, pos, line_end, "\"tid\":")
                     if (at >= 0) {
                         let tid = int(parse_uint(data, at))
                         while (length(counts) <= tid) {
                             counts |> push(0)
                         }
-                        if (ph == uint8('X')) {
+                        if (ph == 'X') {
                             counts[tid]++
                         }
                     }
@@ -233,8 +233,8 @@ def public load_trace(path : string; var doc : TraceDoc) : bool {
                 line_end++
             }
             if (pos + 8 < n && data[pos] == uint8('{') && data[pos + 2] == uint8('p') && data[pos + 4] == uint8('"')) {
-                let ph = data[pos + 7]
-                if (ph == uint8('X')) {
+                let ph = int(data[pos + 7])
+                if (ph == 'X') {
                     var le : LineEv
                     if (parse_x_line(data, pos, line_end, le) && le.tid < length(doc.lanes)) {
                         var stage = le.stage
@@ -252,7 +252,7 @@ def public load_trace(path : string; var doc : TraceDoc) : bool {
                             doc.span = tend
                         }
                     }
-                } elif (ph == uint8('i')) {
+                } elif (ph == 'i') {
                     var at = seek_past(data, pos, line_end, "\"tid\":")
                     if (at >= 0) {
                         let tid = int(parse_uint(data, at))
@@ -274,7 +274,7 @@ def public load_trace(path : string; var doc : TraceDoc) : bool {
                             }
                         }
                     }
-                } elif (ph == uint8('M')) {
+                } elif (ph == 'M') {
                     var at = seek_past(data, pos, line_end, "\"tid\":")
                     if (at >= 0) {
                         let tid = int(parse_uint(data, at))

--- a/utils/jobque-timeline/tl_lod.das
+++ b/utils/jobque-timeline/tl_lod.das
@@ -1,0 +1,96 @@
+options gen2
+options indenting = 4
+
+module tl_lod shared
+
+require tl_model
+require math
+
+// Per-lane time-bucket mipmaps + level choice. Two cost levers in the viewer:
+//  - bucket path: when a view holds too many events, walk fixed buckets instead
+//  - run merge: adjacent same-color buckets collapse into one draw run
+// The viewer additionally replays cached runs until the view changes, so
+// steady-state frames never re-walk events at all.
+
+let public MIP_BASE = 2048            // level-0 bucket count (also the overview source)
+let public EVENT_PATH_MAX = 8000      // visible events above this -> bucket path
+
+def private build_level(lane : Lane; span : double; nb : int; ncats : int) : MipLevel {
+    var lvl = MipLevel(nb = nb)
+    lvl.b |> resize(nb)
+    var cat_acc : array<float>       // nb x ncats dominant-category accumulator
+    cat_acc |> resize(nb * ncats)
+    let bw = span / double(nb)
+    for (e in lane.ev) {
+        let kind = ev_kind(e.meta)
+        let t0 = e.t0
+        let t1 = e.t0 + double(e.dur)
+        var b0 = int(t0 / bw)
+        var b1 = int(t1 / bw)
+        b0 = clamp(b0, 0, nb - 1)
+        b1 = clamp(b1, 0, nb - 1)
+        for (bi in range(b0, b1 + 1)) {
+            var bk & = unsafe(lvl.b[bi])
+            let ov = float((min(t1, double(bi + 1) * bw) - max(t0, double(bi) * bw)) / bw)
+            if (ov <= 0.0f) {
+                continue
+            }
+            if (kind == EV_CHUNK || kind == EV_FIFO || kind == EV_PUBLISH) {
+                bk.busy += ov
+                cat_acc[bi * ncats + ev_cat(e.meta)] += ov
+            } elif (kind == EV_STAGE_WAIT) {
+                bk.wait += ov
+            }
+            bk.count++
+        }
+    }
+    for (bi in range(nb)) {
+        var bk & = unsafe(lvl.b[bi])
+        bk.busy = min(bk.busy, 1.0f)
+        bk.wait = min(bk.wait, 1.0f)
+        var best = -1
+        var bestv = 0.0f
+        for (c in range(ncats)) {
+            let v = cat_acc[bi * ncats + c]
+            if (v > bestv) {
+                bestv = v
+                best = c
+            }
+        }
+        bk.dom = best
+    }
+    delete cat_acc
+    return <- lvl
+}
+
+//! Build mip levels for every lane: level 0 always (the overview source), finer levels
+//! while the lane has enough events to need them.
+def public build_mips(var doc : TraceDoc) {
+    let span = max(doc.span, 8.0lf)
+    let ncats = length(doc.cats)
+    for (li in range(length(doc.lanes))) {
+        var lane & = unsafe(doc.lanes[li])
+        delete lane.mips
+        lane.mips |> reserve(4)
+        var nb = MIP_BASE
+        while (true) {
+            lane.mips |> emplace(build_level(lane, span, nb, ncats))
+            if (nb * 2 >= length(lane.ev) || nb >= 131072) {
+                break
+            }
+            nb *= 4
+        }
+    }
+}
+
+//! Deepest built level whose bucket is at least `min_px` pixels wide at the current zoom.
+def public pick_level(lane : Lane; span : double; px_per_us : double; min_px : double) : int {
+    var best = 0
+    for (li in range(length(lane.mips))) {
+        let bw_px = (span / double(lane.mips[li].nb)) * px_per_us
+        if (bw_px >= min_px) {
+            best = li
+        }
+    }
+    return best
+}

--- a/utils/jobque-timeline/tl_model.das
+++ b/utils/jobque-timeline/tl_model.das
@@ -1,0 +1,127 @@
+options gen2
+options indenting = 4
+
+module tl_model shared
+
+// Event kinds — traceSave's tagName[] order (job_que.cpp), same ints trace_window.py uses
+let public EV_PUBLISH = 0
+let public EV_CHUNK = 1
+let public EV_STAGE_WAIT = 2
+let public EV_WAKE = 3
+let public EV_FIFO = 4
+
+// meta packing: kind(3b) | stage(6b) | nstages(6b) | cat(8b)
+def public ev_meta(kind, stage, nstages, cat : int) : uint {
+    return uint(kind & 7) | (uint(stage & 63) << 3u) | (uint(nstages & 63) << 9u) | (uint(cat & 255) << 15u)
+}
+
+def public ev_kind(meta : uint) : int => int(meta & 7u)
+def public ev_stage(meta : uint) : int => int((meta >> 3u) & 63u)
+def public ev_nstages(meta : uint) : int => int((meta >> 9u) & 63u)
+def public ev_cat(meta : uint) : int => int((meta >> 15u) & 255u)
+
+struct public Ev {
+    t0 : double      // µs from file start (parsed as integer ns — exact)
+    dur : float      // µs
+    meta : uint
+    arg : uint
+    chain : uint
+}
+
+struct public Bucket {
+    busy : float             // work fraction 0..1 (chunk+fifo+publish)
+    wait : float             // stage_wait fraction
+    dom : int                // dominant category by busy time; -1 = empty
+    count : int              // events touching the bucket
+}
+
+struct public MipLevel {
+    nb : int
+    b : array<Bucket>
+}
+
+struct public Lane {
+    name : string            // "worker N" / "caller N" from the thread_name metadata
+    ev : array<Ev>           // sorted by t0 at load (ring order is completion order)
+    max_dur : double         // widens visible-range binary search for overlapping events
+    mips : array<MipLevel>   // [0] = coarsest (overview source), 4x finer while useful
+}
+
+struct public Category {
+    tag : int                // the raw trace tag this category labels (0 = untagged/heuristic)
+    name : string
+    col : uint               // 0xRRGGBB
+}
+
+struct public MarkerKind {
+    name : string            // e.g. "token", "layer"
+    ts : array<double>       // sorted µs; unit i spans [ts[i], ts[i+1])
+    args : array<int>
+    lane : array<int8>
+}
+
+struct public TraceDoc {
+    path : string
+    title : string
+    span : double            // µs
+    lanes : array<Lane>
+    cats : array<Category>   // index == ev_cat(meta); [0..3] are the heuristic base classes
+    marker_kinds : array<MarkerKind>
+    has_profile : bool       // jobqueProfile header present
+    total_events : int64
+    generation : int
+}
+
+// base classes for untagged chains (stage-count heuristic, same as the HTML viewer):
+// 0 std/amber, 1 attn/blue, 2 ffn/green, 3 cls/purple — registered tags append after these
+let public CAT_STD = 0
+let public CAT_ATTN = 1
+let public CAT_FFN = 2
+let public CAT_CLS = 3
+
+def public base_categories() : array<Category> {
+    return <- [
+        Category(tag = 0, name = "std kernel", col = 0xC39536u),
+        Category(tag = 0, name = "attn chain", col = 0x5E96DEu),
+        Category(tag = 0, name = "ffn chain", col = 0x43B08Au),
+        Category(tag = 0, name = "classifier", col = 0xAC82E4u)
+    ]
+}
+
+// legacy palette for tag-carrying traces saved without a jobqueProfile header (tags 1..11)
+def public legacy_tag_category(tag : int) : Category {
+    if (tag == 1) return Category(tag = tag, name = "attn chain", col = 0x5E96DEu)
+    if (tag == 2) return Category(tag = tag, name = "attn std", col = 0x5E96DEu)
+    if (tag == 3) return Category(tag = tag, name = "ffn chain", col = 0x43B08Au)
+    if (tag == 4) return Category(tag = tag, name = "ffn per-op", col = 0x43B08Au)
+    if (tag == 5) return Category(tag = tag, name = "classifier", col = 0xAC82E4u)
+    if (tag == 6) return Category(tag = tag, name = "moe experts", col = 0xE08563u)
+    if (tag == 7) return Category(tag = tag, name = "shexp", col = 0xC39536u)
+    if (tag == 8) return Category(tag = tag, name = "ple", col = 0xC39536u)
+    if (tag == 9) return Category(tag = tag, name = "router", col = 0x4FC3D0u)
+    if (tag == 10) return Category(tag = tag, name = "park/reduce", col = 0xD678B4u)
+    if (tag == 11) return Category(tag = tag, name = "deltanet", col = 0x8385E8u)
+    return Category(tag = tag, name = "tag {tag}", col = 0xC39536u)
+}
+
+def public lane_lower_bound(lane : Lane; t : double) : int {
+    var lo = 0
+    var hi = length(lane.ev)
+    while (lo < hi) {
+        let mid = (lo + hi) / 2
+        if (lane.ev[mid].t0 < t) {
+            lo = mid + 1
+        } else {
+            hi = mid
+        }
+    }
+    return lo
+}
+
+// heuristic class for an untagged chain — nstages>=3 attn, 2 ffn, 1 cls, else std
+def public heuristic_cat(nstages : int) : int {
+    if (nstages >= 3) return CAT_ATTN
+    if (nstages == 2) return CAT_FFN
+    if (nstages == 1) return CAT_CLS
+    return CAT_STD
+}

--- a/utils/jobque-timeline/tl_stats.das
+++ b/utils/jobque-timeline/tl_stats.das
@@ -1,0 +1,106 @@
+options gen2
+options indenting = 4
+
+module tl_stats shared
+
+require tl_model
+require math
+
+// Computed statistics for a time range of a TraceDoc — the chips the HTML artifact
+// hand-wrote. Cached per (range, generation); recomputed only when the key changes.
+
+struct public CatStat {
+    name : string
+    busy_us : double
+    pct : float            // share of total busy
+}
+
+struct public RangeStats {
+    t0, t1 : double
+    events : int
+    busy_us : double       // chunk + fifo + publish work, clipped to the range, all lanes
+    wait_us : double       // stage_wait clipped
+    idle_pct : float       // 1 - busy/(range × lanes)
+    parallelism : float    // busy/range = average busy lanes
+    publish_count : int
+    cat : array<CatStat>   // busy>0 categories, descending
+}
+
+def public compute_range_stats(doc : TraceDoc; t0, t1 : double) : RangeStats {
+    var st = RangeStats(t0 = t0, t1 = t1)
+    let range_us = max(t1 - t0, 1.0e-9lf)
+    var cat_busy : array<double>
+    cat_busy |> resize(length(doc.cats))
+    for (lane in doc.lanes) {
+        var j = lane_lower_bound(lane, t0 - lane.max_dur)
+        while (j < length(lane.ev)) {
+            let e & = unsafe(lane.ev[j])
+            if (e.t0 > t1) {
+                break
+            }
+            j++
+            let te = e.t0 + double(e.dur)
+            if (te < t0) {
+                continue
+            }
+            st.events++
+            let clipped = min(te, t1) - max(e.t0, t0)
+            let kind = ev_kind(e.meta)
+            if (kind == EV_CHUNK || kind == EV_FIFO || kind == EV_PUBLISH) {
+                st.busy_us += clipped
+                cat_busy[ev_cat(e.meta)] += clipped
+                if (kind == EV_PUBLISH) {
+                    st.publish_count++
+                }
+            } elif (kind == EV_STAGE_WAIT) {
+                st.wait_us += clipped
+            }
+        }
+    }
+    let nlanes = max(length(doc.lanes), 1)
+    st.idle_pct = float(1.0lf - st.busy_us / (range_us * double(nlanes))) * 100.0f
+    st.parallelism = float(st.busy_us / range_us)
+    for (c in range(length(doc.cats))) {
+        if (cat_busy[c] > 0.0lf) {
+            st.cat |> push(CatStat(name = doc.cats[c].name, busy_us = cat_busy[c],
+                pct = float(cat_busy[c] / max(st.busy_us, 1.0e-9lf)) * 100.0f))
+        }
+    }
+    st.cat |> sort() $(a, b : CatStat) {
+        return a.busy_us > b.busy_us
+    }
+    delete cat_busy
+    return <- st
+}
+
+struct public StatsCache {
+    t0, t1 : double
+    generation : int = -1
+    stats : RangeStats
+}
+
+//! Freshen a stats cache: recompute only when the range or the doc generation changed.
+//! Read the result from `cache.stats`.
+def public cached_stats(var cache : StatsCache; doc : TraceDoc; t0, t1 : double) {
+    if (cache.generation != doc.generation || cache.t0 != t0 || cache.t1 != t1) {
+        cache.stats <- compute_range_stats(doc, t0, t1)
+        cache.t0 = t0
+        cache.t1 = t1
+        cache.generation = doc.generation
+    }
+}
+
+//! One-line chip text: "idle 23%  par 12.4x  pubs 321  |  ffn per-op 61%  attn std 34%"
+def public stats_line(stats : RangeStats) : string {
+    let deci = int(stats.parallelism * 10.0f + 0.5f)
+    var line = "idle {int(stats.idle_pct + 0.5f)}%  par {deci / 10}.{deci % 10}x  pubs {stats.publish_count}"
+    var shown = 0
+    for (c in stats.cat) {
+        if (shown >= 4) {
+            break
+        }
+        line += "  |  {c.name} {int(c.pct + 0.5f)}%"   // nolint:PERF001 — at most 4 chips
+        shown++
+    }
+    return line
+}

--- a/utils/jobque-timeline/tl_view.das
+++ b/utils/jobque-timeline/tl_view.das
@@ -1,0 +1,508 @@
+options gen2
+options indenting = 4
+
+module tl_view shared
+
+require tl_model
+require tl_lod
+require imgui/imgui_harness
+require math
+
+// Canvas port of the lane-timeline HTML viewer: one row per lane, events colored by
+// category with per-stage shading, gray barrier waits, ink publish ticks, marker row,
+// overview strip with a viewport indicator. Custom item via the sanctioned internal rail
+// (ItemSize + ItemAdd + ButtonBehavior); all drawing through the v2 drawlist scope.
+// Draw runs are CACHED per (view, width, generation) — steady-state frames replay them
+// without touching events; dense views build from the mip buckets with run merging.
+
+let GUT = 74.0            // lane-label gutter px
+let OV_H = 26.0           // overview strip height
+let GRID_H = 14.0         // time-label row height
+let UN_H = 14.0           // units (marker) row height — own band, below the time labels
+let HDR_H = OV_H + GRID_H + UN_H
+let SURFACE = 0x14171Bu   // canvas background 0xRRGGBB
+
+struct public ViewUI {
+    t0, t1 : double        // visible window, µs
+    inited : bool
+    hover_lane : int = -1
+    hover_idx : int = -1
+    interacted : bool      // this frame — drives view sync in main
+    sel_active : bool      // shift+drag time-range selection (per-view)
+    sel_dragging : bool
+    sel_anchor : double
+    sel_t0, sel_t1 : double
+}
+
+// one cached rectangle; x in px relative to the plot origin (overview: normalized 0..1)
+struct public DrawRun {
+    x0, x1 : float
+    lane : int16
+    kind : int8            // 0 row rect, 1 slim wait bar, 2 publish tick, 3 wake inset
+    col : uint             // final 0xRRGGBB (alpha applied at replay)
+}
+
+struct public RenderCache {
+    t0, t1 : double
+    plot_w : float
+    generation : int = -1
+    bucket_mode : bool     // what the last rebuild used (exposed for describe/tests)
+    runs : array<DrawRun>
+    ov_generation : int = -1
+    ov_rows : int = 1      // lanes fold into <= 22 overview rows
+    ov_runs : array<DrawRun>
+}
+
+def public col32(rgb : uint; a : int) : uint {
+    return rgba(int((rgb >> 16u) & 255u), int((rgb >> 8u) & 255u), int(rgb & 255u), a)
+}
+
+def private blend_rgb(a, b : uint; k : float) : uint {
+    let ar = float((a >> 16u) & 255u)
+    let ag = float((a >> 8u) & 255u)
+    let ab = float(a & 255u)
+    let br = float((b >> 16u) & 255u)
+    let bg = float((b >> 8u) & 255u)
+    let bb = float(b & 255u)
+    return (uint(ar + (br - ar) * k) << 16u) | (uint(ag + (bg - ag) * k) << 8u) | uint(ab + (bb - ab) * k)
+}
+
+// earlier pipeline stages lighter, final stage full hue (HTML: k = 0.38*(1 - s/(n-1)))
+def private stage_color(base : uint; stage, nstages : int) : uint {
+    if (nstages <= 1) return base
+    let k = 0.38 * (1.0 - float(stage) / float(nstages - 1))
+    return blend_rgb(base, SURFACE, k)
+}
+
+def public fmt_us(v : double) : string {
+    if (v >= 10000.0lf) return "{int(v / 1000.0lf)}ms"
+    if (v >= 1000.0lf) return "{float(v) / 1000.0f}ms"
+    return "{int(v)}us"
+}
+
+def public clamp_view(var ui : ViewUI; span : double) {
+    var w = ui.t1 - ui.t0
+    w = clamp(w, 8.0lf, max(span, 8.0lf))
+    ui.t0 = clamp(ui.t0, 0.0lf, max(0.0lf, span - w))
+    ui.t1 = ui.t0 + w
+}
+
+def public view_full(var ui : ViewUI; doc : TraceDoc) {
+    ui.t0 = 0.0lf
+    ui.t1 = max(doc.span, 8.0lf)
+    ui.inited = true
+}
+
+def private kind_name(kind : int) : string {
+    if (kind == EV_PUBLISH) return "publish"
+    if (kind == EV_CHUNK) return "chunk"
+    if (kind == EV_STAGE_WAIT) return "stage wait"
+    if (kind == EV_WAKE) return "wake"
+    return "fifo job"
+}
+
+def private count_visible(doc : TraceDoc; t0, t1 : double) : int {
+    var n = 0
+    for (lane in doc.lanes) {
+        n += lane_lower_bound(lane, t1) - lane_lower_bound(lane, t0 - lane.max_dur)
+    }
+    return n
+}
+
+def private rebuild_event_runs(doc : TraceDoc; var cache : RenderCache; px_per_us : double) {
+    let vis_t0 = cache.t0
+    let vis_t1 = cache.t1
+    for (li in range(length(doc.lanes))) {
+        let lane & = unsafe(doc.lanes[li])
+        var i = lane_lower_bound(lane, vis_t0 - lane.max_dur)
+        while (i < length(lane.ev)) {
+            let e & = unsafe(lane.ev[i])
+            if (e.t0 > vis_t1) {
+                break
+            }
+            i++
+            let te = e.t0 + double(e.dur)
+            if (te < vis_t0) {
+                continue
+            }
+            let x0 = max(float((e.t0 - vis_t0) * px_per_us), 0.0f)
+            let kind = ev_kind(e.meta)
+            if (kind == EV_CHUNK) {
+                let x1 = max(x0 + 0.6f, float((te - vis_t0) * px_per_us))
+                let cat & = unsafe(doc.cats[ev_cat(e.meta)])
+                cache.runs |> push(DrawRun(x0 = x0, x1 = x1, lane = int16(li), kind = int8(0),
+                    col = stage_color(cat.col, ev_stage(e.meta), ev_nstages(e.meta))))
+            } elif (kind == EV_STAGE_WAIT) {
+                let x1 = max(x0 + 0.6f, float((te - vis_t0) * px_per_us))
+                cache.runs |> push(DrawRun(x0 = x0, x1 = x1, lane = int16(li), kind = int8(1), col = 0x3A3F46u))
+            } elif (kind == EV_PUBLISH) {
+                let x1 = max(x0 + 1.4f, float((te - vis_t0) * px_per_us))
+                cache.runs |> push(DrawRun(x0 = x0, x1 = x1, lane = int16(li), kind = int8(2), col = 0xE8EAEDu))
+            } elif (kind == EV_WAKE) {
+                let x1 = max(x0 + 0.6f, float((te - vis_t0) * px_per_us))
+                cache.runs |> push(DrawRun(x0 = x0, x1 = x1, lane = int16(li), kind = int8(3), col = 0xC39536u))
+            } else {
+                let x1 = max(x0 + 0.6f, float((te - vis_t0) * px_per_us))
+                cache.runs |> push(DrawRun(x0 = x0, x1 = x1, lane = int16(li), kind = int8(0), col = 0x7A9AAEu))
+            }
+        }
+    }
+}
+
+// quantized bucket color: dominant category blended toward surface by busy fraction.
+// COARSE bands (4) — merge-friendliness beats gradient fidelity: adjacent noisy buckets
+// must collapse into few runs or the replay cost eats the LOD win
+def private bucket_col(doc : TraceDoc; dom : int; busy_q, wait_q : int) : uint {
+    if (busy_q <= 0) {
+        return wait_q > 0 ? 0x2C3138u : 0u   // 0 = skip
+    }
+    let base = dom >= 0 ? doc.cats[dom].col : 0xC39536u
+    return blend_rgb(SURFACE, base, float(busy_q) / 3.0f)
+}
+
+def private rebuild_bucket_runs(doc : TraceDoc; var cache : RenderCache; span, px_per_us : double) {
+    for (li in range(length(doc.lanes))) {
+        let lane & = unsafe(doc.lanes[li])
+        if (empty(lane.mips)) {
+            continue
+        }
+        let lvl_i = pick_level(lane, span, px_per_us, 1.0lf)
+        let lvl & = unsafe(lane.mips[lvl_i])
+        let bw = span / double(lvl.nb)
+        let b0 = clamp(int(cache.t0 / bw), 0, lvl.nb - 1)
+        let b1 = clamp(int(cache.t1 / bw) + 1, 0, lvl.nb - 1)
+        var run_col = 0u
+        var run_x0 = 0.0f
+        var run_x1 = 0.0f
+        for (bi in range(b0, b1 + 1)) {
+            let bk & = unsafe(lvl.b[bi])
+            let busy_q = min(int(bk.busy * 4.0f), 3)
+            let wait_q = bk.wait > 0.25f ? 1 : 0
+            let col = bk.count == 0 ? 0u : bucket_col(doc, bk.dom, busy_q, wait_q)
+            let x0 = max(float((double(bi) * bw - cache.t0) * px_per_us), 0.0f)
+            let x1 = float((double(bi + 1) * bw - cache.t0) * px_per_us)
+            if (col == run_col && run_col != 0u && x0 <= run_x1 + 0.01f) {
+                run_x1 = x1   // extend the current run
+                continue
+            }
+            if (run_col != 0u) {
+                cache.runs |> push(DrawRun(x0 = run_x0, x1 = run_x1, lane = int16(li), kind = int8(0), col = run_col))
+            }
+            run_col = col
+            run_x0 = x0
+            run_x1 = x1
+        }
+        if (run_col != 0u) {
+            cache.runs |> push(DrawRun(x0 = run_x0, x1 = run_x1, lane = int16(li), kind = int8(0), col = run_col))
+        }
+    }
+}
+
+def private rebuild_overview(doc : TraceDoc; var cache : RenderCache) {
+    // lanes fold into at most OV_ROWS visual rows (the strip is ~22px tall) — per (row,
+    // bucket) the busiest lane's bucket wins, THEN runs merge per row. Bounds replay cost
+    // by rows, not lanes.
+    delete cache.ov_runs
+    let nlanes = length(doc.lanes)
+    let rows = clamp(nlanes, 1, 22)
+    cache.ov_rows = rows
+    let nb = MIP_BASE
+    var row_busy : array<float>
+    var row_dom : array<int>
+    row_busy |> resize(rows * nb)
+    row_dom |> resize(rows * nb)
+    for (li in range(nlanes)) {
+        let lane & = unsafe(doc.lanes[li])
+        if (empty(lane.mips)) {
+            continue
+        }
+        let row = li * rows / nlanes
+        let lvl & = unsafe(lane.mips[0])
+        for (bi in range(nb)) {
+            let bk & = unsafe(lvl.b[bi])
+            if (bk.count != 0 && bk.busy > row_busy[row * nb + bi]) {
+                row_busy[row * nb + bi] = bk.busy
+                row_dom[row * nb + bi] = bk.dom
+            }
+        }
+    }
+    for (row in range(rows)) {
+        var run_col = 0u
+        var run_x0 = 0.0f
+        var run_x1 = 0.0f
+        for (bi in range(nb)) {
+            let busy = row_busy[row * nb + bi]
+            let busy_q = min(int(busy * 4.0f), 3)
+            let col = busy <= 0.0f ? 0u : bucket_col(doc, row_dom[row * nb + bi], max(busy_q, 1), 0)
+            let x0 = float(bi) / float(nb)
+            let x1 = float(bi + 1) / float(nb)
+            if (col == run_col && run_col != 0u) {
+                run_x1 = x1
+                continue
+            }
+            if (run_col != 0u) {
+                cache.ov_runs |> push(DrawRun(x0 = run_x0, x1 = run_x1, lane = int16(row), kind = int8(0), col = run_col))
+            }
+            run_col = col
+            run_x0 = x0
+            run_x1 = x1
+        }
+        if (run_col != 0u) {
+            cache.ov_runs |> push(DrawRun(x0 = run_x0, x1 = run_x1, lane = int16(row), kind = int8(0), col = run_col))
+        }
+    }
+    delete row_busy
+    delete row_dom
+    cache.ov_generation = doc.generation
+}
+
+//! Draw one file's timeline canvas filling the current window's remaining space.
+//! Handles wheel zoom-at-cursor, drag pan, shift+drag selection, double-click reset,
+//! overview scrub, hover pick. Replays cached draw runs when the view is unchanged.
+def public draw_timeline(doc : TraceDoc; var ui : ViewUI; var cache : RenderCache; id : string) {
+    if (!ui.inited) {
+        view_full(ui, doc)
+    }
+    ui.interacted = false
+    let avail = GetContentRegionAvail()
+    let w = max(avail.x, 120.0f)
+    let h = max(avail.y, 120.0f)
+    let p = GetCursorScreenPos()
+    let bb = float4(p.x, p.y, p.x + w, p.y + h)
+    ItemSize(bb)
+    if (!ItemAdd(bb, GetID(id))) {
+        return
+    }
+    var hovered = false
+    var held = false
+    ButtonBehavior(bb, GetID(id), hovered, held, ImGuiButtonFlags.MouseButtonLeft)
+
+    let span = max(doc.span, 8.0lf)
+    let nlanes = max(length(doc.lanes), 1)
+    let lanes_y0 = p.y + HDR_H
+    let row_h = max((h - HDR_H) / float(nlanes), 3.0f)
+    let plot_x0 = p.x + GUT
+    let plot_w = max(w - GUT, 10.0f)
+    var px_per_us = double(plot_w) / (ui.t1 - ui.t0)
+
+    // ---- input ----
+    let io & = unsafe(GetIO())
+    let mx = io.MousePos.x
+    let my = io.MousePos.y
+    let m_t = ui.t0 + double(mx - plot_x0) / px_per_us
+    if (hovered && io.MouseWheel != 0.0f) {
+        let factor = exp(-io.MouseWheel * 0.16f)
+        var nw = (ui.t1 - ui.t0) * double(factor)
+        nw = clamp(nw, 8.0lf, span)
+        let frac = clamp(double(mx - plot_x0) / double(plot_w), 0.0lf, 1.0lf)
+        ui.t0 = m_t - nw * frac
+        ui.t1 = ui.t0 + nw
+        clamp_view(ui, span)
+        ui.interacted = true
+    }
+    // shift+drag = range selection; plain drag = pan
+    if (hovered && io.KeyShift && IsMouseClicked(ImGuiMouseButton.Left) && my >= lanes_y0) {
+        ui.sel_dragging = true
+        ui.sel_active = true
+        ui.sel_anchor = m_t
+        ui.sel_t0 = m_t
+        ui.sel_t1 = m_t
+    }
+    if (ui.sel_dragging) {
+        if (held) {
+            ui.sel_t0 = min(ui.sel_anchor, m_t)
+            ui.sel_t1 = max(ui.sel_anchor, m_t)
+        } else {
+            ui.sel_dragging = false
+        }
+    } elif (held && io.MouseDelta.x != 0.0f && !io.KeyShift) {
+        if (my >= lanes_y0) {
+            let dt = double(io.MouseDelta.x) / px_per_us
+            ui.t0 -= dt
+            ui.t1 -= dt
+        }
+        clamp_view(ui, span)
+        ui.interacted = true
+    }
+    if (held && my < p.y + OV_H) {
+        // overview scrub: center the view at the clicked time
+        let frac = clamp(double(mx - plot_x0) / double(plot_w), 0.0lf, 1.0lf)
+        let c = span * frac
+        let vw = ui.t1 - ui.t0
+        ui.t0 = c - vw * 0.5lf
+        ui.t1 = ui.t0 + vw
+        clamp_view(ui, span)
+        ui.interacted = true
+    }
+    if (hovered && IsMouseDoubleClicked(ImGuiMouseButton.Left)) {
+        view_full(ui, doc)
+        ui.interacted = true
+    }
+    if (hovered && IsKeyPressed(ImGuiKey.Escape)) {
+        ui.sel_active = false
+        ui.sel_dragging = false
+    }
+    px_per_us = double(plot_w) / (ui.t1 - ui.t0)
+
+    // ---- hover pick (chunk-preferred) ----
+    ui.hover_lane = -1
+    ui.hover_idx = -1
+    if (hovered && my >= lanes_y0) {
+        let hl = int((my - lanes_y0) / row_h)
+        if (hl >= 0 && hl < nlanes) {
+            let tol = 4.0lf / px_per_us
+            var best = -1
+            var bestChunk = false
+            let lane & = unsafe(doc.lanes[hl])
+            var i = lane_lower_bound(lane, m_t - max(lane.max_dur, tol))
+            while (i < length(lane.ev)) {
+                let e & = unsafe(lane.ev[i])
+                if (e.t0 > m_t + tol) {
+                    break
+                }
+                if (m_t >= e.t0 - tol && m_t <= e.t0 + max(double(e.dur), tol)) {
+                    let isChunk = ev_kind(e.meta) == EV_CHUNK
+                    if (best < 0 || (isChunk && !bestChunk)) {
+                        best = i
+                        bestChunk = isChunk
+                    }
+                }
+                i++
+            }
+            ui.hover_lane = hl
+            ui.hover_idx = best
+        }
+    }
+
+    // ---- run caches ----
+    if (cache.generation != doc.generation || cache.t0 != ui.t0 || cache.t1 != ui.t1 || cache.plot_w != plot_w) {
+        delete cache.runs
+        cache.t0 = ui.t0
+        cache.t1 = ui.t1
+        cache.plot_w = plot_w
+        cache.generation = doc.generation
+        cache.bucket_mode = count_visible(doc, ui.t0, ui.t1) > EVENT_PATH_MAX
+        if (cache.bucket_mode) {
+            rebuild_bucket_runs(doc, cache, span, px_per_us)
+        } else {
+            rebuild_event_runs(doc, cache, px_per_us)
+        }
+    }
+    if (cache.ov_generation != doc.generation) {
+        rebuild_overview(doc, cache)
+    }
+
+    // ---- draw ----
+    with_window_drawlist() $(var dl) {
+        dl |> add_rect_filled(float2(bb.x, bb.y), float2(bb.z, bb.w), col32(SURFACE, 255))
+        with_drawlist_clip_rect(dl, float2(bb.x, bb.y), float2(bb.z, bb.w), true) $ {
+            // overview strip (cached normalized runs, lane-folded rows) + viewport rect
+            let ov_y0 = p.y + 2.0f
+            let ov_y1 = p.y + OV_H - 2.0f
+            let ov_row = (ov_y1 - ov_y0) / float(max(cache.ov_rows, 1))
+            for (r in cache.ov_runs) {
+                let oy0 = ov_y0 + float(int(r.lane)) * ov_row
+                dl |> add_rect_filled(float2(plot_x0 + r.x0 * plot_w, oy0),
+                    float2(max(plot_x0 + r.x1 * plot_w, plot_x0 + r.x0 * plot_w + 0.5f), oy0 + ov_row),
+                    col32(r.col, 150))
+            }
+            let vx0 = plot_x0 + float(ui.t0 / span) * plot_w
+            let vx1 = plot_x0 + float(ui.t1 / span) * plot_w
+            dl |> add_rect_filled(float2(vx0, ov_y0), float2(max(vx1, vx0 + 2.0f), ov_y1), col32(0xE8EAEDu, 36))
+            dl |> add_line(float2(vx0, ov_y0), float2(vx0, ov_y1), col32(0xE8EAEDu, 160), 1.0)
+            dl |> add_line(float2(vx1, ov_y0), float2(vx1, ov_y1), col32(0xE8EAEDu, 160), 1.0)
+
+            // time grid: 1-2-5 ladder targeting ~90px
+            let target_us = 90.0lf / px_per_us
+            var step = 1.0lf
+            while (step < target_us) {
+                if (step * 2.0lf >= target_us) {
+                    step *= 2.0lf
+                    break
+                }
+                if (step * 5.0lf >= target_us) {
+                    step *= 5.0lf
+                    break
+                }
+                step *= 10.0lf
+            }
+            var gt = floor(ui.t0 / step) * step
+            while (gt <= ui.t1) {
+                let gx = plot_x0 + float((gt - ui.t0) * px_per_us)
+                if (gx >= plot_x0) {
+                    dl |> add_line(float2(gx, lanes_y0), float2(gx, bb.w), col32(0x2A2F36u, 255), 1.0)
+                    dl |> add_text(float2(gx + 3.0f, p.y + OV_H), col32(0x8A9099u, 255), fmt_us(gt))
+                }
+                gt += step
+            }
+
+            // marker (unit) row — its own band below the time labels
+            let un_y = p.y + OV_H + GRID_H
+            for (mk in doc.marker_kinds) {
+                for (i in range(length(mk.ts))) {
+                    let t = mk.ts[i]
+                    if (t < ui.t0 || t > ui.t1) {
+                        continue
+                    }
+                    let x = plot_x0 + float((t - ui.t0) * px_per_us)
+                    dl |> add_line(float2(x, un_y), float2(x, bb.w), col32(0xE8EAEDu, 70), 1.0)
+                    dl |> add_text(float2(x + 2.0f, un_y), col32(0xC9CDD2u, 255), "{mk.name} {mk.args[i]}")
+                }
+            }
+
+            // lane separators + labels
+            for (li in range(nlanes)) {
+                let y0 = lanes_y0 + float(li) * row_h
+                dl |> add_line(float2(p.x, y0), float2(bb.z, y0), col32(0x20242Au, 255), 1.0)
+                if (row_h >= 9.0f) {
+                    dl |> add_text(float2(p.x + 4.0f, y0 + max((row_h - 14.0f) * 0.5f, 0.0f)), col32(0x8A9099u, 255), doc.lanes[li].name)
+                }
+            }
+
+            // cached event/bucket runs
+            for (r in cache.runs) {
+                let y0 = lanes_y0 + float(int(r.lane)) * row_h
+                let y1 = y0 + row_h - 1.0f
+                let rx0 = plot_x0 + r.x0
+                let rx1 = plot_x0 + r.x1
+                if (int(r.kind) == 1) {
+                    let cy = (y0 + y1) * 0.5f
+                    dl |> add_rect_filled(float2(rx0, cy - row_h * 0.16f), float2(rx1, cy + row_h * 0.16f), col32(r.col, 255))
+                } elif (int(r.kind) == 3) {
+                    dl |> add_rect_filled(float2(rx0, y0 + row_h * 0.3f), float2(rx1, y1 - row_h * 0.3f), col32(r.col, 120))
+                } else {
+                    dl |> add_rect_filled(float2(rx0, y0 + 1.0f), float2(rx1, y1), col32(r.col, 255))
+                }
+            }
+
+            // selection overlay
+            if (ui.sel_active) {
+                let sx0 = plot_x0 + float((ui.sel_t0 - ui.t0) * px_per_us)
+                let sx1 = plot_x0 + float((ui.sel_t1 - ui.t0) * px_per_us)
+                dl |> add_rect_filled(float2(sx0, lanes_y0), float2(max(sx1, sx0 + 1.0f), bb.w), col32(0xE8EAEDu, 22))
+                dl |> add_line(float2(sx0, lanes_y0), float2(sx0, bb.w), col32(0xE8EAEDu, 180), 1.0)
+                dl |> add_line(float2(sx1, lanes_y0), float2(sx1, bb.w), col32(0xE8EAEDu, 180), 1.0)
+            }
+
+            // hover outline
+            if (ui.hover_lane >= 0 && ui.hover_idx >= 0) {
+                let e & = unsafe(doc.lanes[ui.hover_lane].ev[ui.hover_idx])
+                let y0 = lanes_y0 + float(ui.hover_lane) * row_h
+                let x0 = plot_x0 + float((e.t0 - ui.t0) * px_per_us)
+                let x1 = max(x0 + 1.0f, plot_x0 + float((e.t0 + double(e.dur) - ui.t0) * px_per_us))
+                dl |> add_rect(float2(x0 - 1.0f, y0), float2(x1 + 1.0f, y0 + row_h - 1.0f), col32(0xE8EAEDu, 255), 0.0, ImDrawFlags.None, 1.0)
+            }
+        }
+    }
+
+    // hover tooltip
+    if (ui.hover_lane >= 0 && ui.hover_idx >= 0) {
+        let e & = unsafe(doc.lanes[ui.hover_lane].ev[ui.hover_idx])
+        let cat & = unsafe(doc.cats[ev_cat(e.meta)])
+        tooltip(TL_TIP) {
+            text("{kind_name(ev_kind(e.meta))} — {cat.name}")
+            text("stage {ev_stage(e.meta)}/{ev_nstages(e.meta)}  chunk {e.arg}  chain {e.chain}")
+            text("t {fmt_us(e.t0)}  dur {fmt_us(double(e.dur))}")
+        }
+    }
+}

--- a/utils/jobque-timeline/tl_view.das
+++ b/utils/jobque-timeline/tl_view.das
@@ -75,15 +75,18 @@ def private stage_color(base : uint; stage, nstages : int) : uint {
 }
 
 def public fmt_us(v : double) : string {
+    if (v < 0.0lf) return "-" + fmt_us(-v)
     if (v >= 10000.0lf) return "{int(v / 1000.0lf)}ms"
     if (v >= 1000.0lf) return "{float(v) / 1000.0f}ms"
     return "{int(v)}us"
 }
 
 def public clamp_view(var ui : ViewUI; span : double) {
-    var w = ui.t1 - ui.t0
-    w = clamp(w, 8.0lf, max(span, 8.0lf))
-    ui.t0 = clamp(ui.t0, 0.0lf, max(0.0lf, span - w))
+    // perfetto-style: the window may pan up to one full window past either end of the
+    // data — so share-timer keeps absolute alignment across files with unequal spans
+    // (the shorter file's content just runs off-screen) instead of pinning at its edge
+    let w = max(ui.t1 - ui.t0, 8.0lf)
+    ui.t0 = clamp(ui.t0, -w, span)
     ui.t1 = ui.t0 + w
 }
 
@@ -293,7 +296,7 @@ def public draw_timeline(doc : TraceDoc; var ui : ViewUI; var cache : RenderCach
     if (hovered && io.MouseWheel != 0.0f) {
         let factor = exp(-io.MouseWheel * 0.16f)
         var nw = (ui.t1 - ui.t0) * double(factor)
-        nw = clamp(nw, 8.0lf, span)
+        nw = clamp(nw, 8.0lf, span * 2.0lf)
         let frac = clamp(double(mx - plot_x0) / double(plot_w), 0.0lf, 1.0lf)
         ui.t0 = m_t - nw * frac
         ui.t1 = ui.t0 + nw
@@ -406,8 +409,8 @@ def public draw_timeline(doc : TraceDoc; var ui : ViewUI; var cache : RenderCach
                     float2(max(plot_x0 + r.x1 * plot_w, plot_x0 + r.x0 * plot_w + 0.5f), oy0 + ov_row),
                     col32(r.col, 150))
             }
-            let vx0 = plot_x0 + float(ui.t0 / span) * plot_w
-            let vx1 = plot_x0 + float(ui.t1 / span) * plot_w
+            let vx0 = clamp(plot_x0 + float(ui.t0 / span) * plot_w, plot_x0, plot_x0 + plot_w)
+            let vx1 = clamp(plot_x0 + float(ui.t1 / span) * plot_w, plot_x0, plot_x0 + plot_w)
             dl |> add_rect_filled(float2(vx0, ov_y0), float2(max(vx1, vx0 + 2.0f), ov_y1), col32(0xE8EAEDu, 36))
             dl |> add_line(float2(vx0, ov_y0), float2(vx0, ov_y1), col32(0xE8EAEDu, 160), 1.0)
             dl |> add_line(float2(vx1, ov_y0), float2(vx1, ov_y1), col32(0xE8EAEDu, 160), 1.0)


### PR DESCRIPTION
The jobque lane-timeline viewer as an in-repo ImGui tool, plus the blog post that announces it.

### utils/jobque-timeline
Per-lane jobque trace viewer — the in-repo successor to the hand-spliced lane-timeline browser artifact. Opens `jobque_trace_save` / `daslib/jobque_profile` JSON (perfetto-compatible) in dockable ImGui windows: one row per lane, events colored by category with per-stage shading, unit markers (`token`/`layer`/`step`), computed stats (idle %, parallelism, busy-by-category), multi-file compare with shared zoom/timer, and a launch rail that reruns the trace-producing app and auto-refreshes on save. Needs dasImgui via `daspkg install --root utils/jobque-timeline`; runs standalone or under `daslang-live`.

Small runtime addition: one fio builtin (+15 lines) the launch rail uses.

### Blog
`site/blog/_posts/stories.md` — "Tell me a story." Lands with the tool per the post's own claim ("There is now a tool - u can see what went in when").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
