### PR TITLE
tutorial 00: ASCII math in literals, pdflatex has no U+2212 glyph

### DIFF
--- a/doc/source/reference/tutorials/dasLLAMA_00_problem_statement.rst
+++ b/doc/source/reference/tutorials/dasLLAMA_00_problem_statement.rst
@@ -328,11 +328,11 @@ score.
 Look at one pair — say floats 0 and 1. The query has an arrow there, and
 the cached key has its own arrow there; their dot product is one bracket
 of the score. Both arrows were turned by RoPE: the query sits at position
-``p``, so its arrow was turned ``p`` steps of the pair's angle ``θ``; the
+``p``, so its arrow was turned ``p`` steps of the pair's angle ``theta``; the
 key came from position ``q``, so its arrow was turned ``q`` steps. A dot
 product only cares about lengths and the angle between the arrows — and
 rotation kept the lengths. The angle between them is now exactly their
-distance apart: ``(p − q) × θ``. A key right behind the query was turned
+distance apart: ``(p - q) * theta``. A key right behind the query was turned
 almost as far — small gap between the arrows. A key from long ago lags
 far behind — big gap. The absolute positions cancel: "three tokens ago"
 means the same gap at position 10 and at position 210.

--- a/skills/documentation_rst.md
+++ b/skills/documentation_rst.md
@@ -178,6 +178,7 @@ After creating or modifying any RST files, stdlib documentation, or `daslib/*.da
    The build must introduce **no new** Sphinx errors or warnings. The final summary line should say `build succeeded.` with no warning count.
 
    Common issues:
+   - **Typographic math characters break the CI PDF build**: pdflatex's typewriter font has no glyph for `−` (U+2212), and `×`/`θ` are equally risky inside inline literals. `sphinx-build -W` (both builders) passes anyway — only CI's "Compile LaTeX document" step fails, and it has no local mirror (preflight SKIPs it without latexmk). Write ASCII math inside ``literals``: `p * theta`, `(p - q)`. Safe-in-prose (proven by green PDF builds): `π`, `≈`, em-dash, curly quotes. (Bitten 2026-07-24, tutorial 00.)
    - **Duplicate label**: Two RST files define the same `.. _label:` — rename one
    - **Unknown target**: `:ref:\`label\`` points to a nonexistent label — check spelling
    - **Malformed table**: Grid/simple table column widths don't align — see RST table rules below


### PR DESCRIPTION
The doc workflow's "Compile LaTeX document" step fails on master since #3555: the revision upgraded ASCII math to typographic characters inside inline literals, and pdflatex's typewriter font has no glyph for U+2212 (also at risk: U+00D7, U+03B8). `sphinx-build -W` passes — only the actual PDF compile catches it, and that step has no local mirror (latexmk absent; preflight reports SKIP).

Fix: back to ASCII inside literals — `p * theta`, `(p - q) * theta`. Two lines. This PR's own doc workflow run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
