### PR TITLE
Add multi-repository resumable agent sessions

### DIFF
--- a/modules/dasHV/dashv/dashv_boost.das
+++ b/modules/dasHV/dashv/dashv_boost.das
@@ -64,6 +64,10 @@ class HvWebSocketClient {
         //! Sends a text message to the server.
         send(client, text)
     }
+    def send_result(text : string) : int {
+        //! Sends a text message and returns the native transport result.
+        return send(client, text)
+    }
     def close : int {
         //! Closes the WebSocket connection. Returns 0 on success.
         return close(client)

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -118,6 +118,7 @@ struct public TerminalBufferSnapshot {
     scrollback : array<TerminalCell>
     scrollback_rows : int
     cursor : TerminalCursor = TerminalCursor()
+    saved_cursor : TerminalCursor = TerminalCursor()
 }
 
 struct public TerminalModes {
@@ -1184,6 +1185,7 @@ def private collect_buffer(buffer : TerminalBuffer const; columns, rows : int;
     }
     snapshot.scrollback_rows = length(buffer.history)
     snapshot.cursor = buffer.cursor
+    snapshot.saved_cursor = buffer.saved_cursor
 }
 
 def public terminal_snapshot(terminal : Terminal const; var snapshot : TerminalSnapshot) {
@@ -1365,6 +1367,175 @@ def private same_color(left, right : TerminalColor const) : bool {
         left.red == right.red && left.green == right.green && left.blue == right.blue)
 }
 
+def private checkpoint_same_style(left, right : TerminalCell const) : bool {
+    return (left.attributes == right.attributes &&
+        same_color(left.foreground, right.foreground) &&
+        same_color(left.background, right.background))
+}
+
+def private checkpoint_write_color(var writer : StringBuilderWriter;
+                                   color : TerminalColor const;
+                                   foreground : bool) {
+    let base = foreground ? 38 : 48
+    if (color.kind == TerminalColorKind.indexed) {
+        writer |> write(";{base};5;{color.index}")
+    } elif (color.kind == TerminalColorKind.rgb) {
+        writer |> write(";{base};2;{color.red};{color.green};{color.blue}")
+    }
+}
+
+def private checkpoint_write_style(var writer : StringBuilderWriter;
+                                   cell : TerminalCell const) {
+    let esc = to_char(27)
+    writer |> write("{esc}[0")
+    if ((cell.attributes & TERMINAL_ATTR_BOLD) != 0) writer |> write(";1")
+    if ((cell.attributes & TERMINAL_ATTR_FAINT) != 0) writer |> write(";2")
+    if ((cell.attributes & TERMINAL_ATTR_ITALIC) != 0) writer |> write(";3")
+    if ((cell.attributes & TERMINAL_ATTR_UNDERLINE) != 0) writer |> write(";4")
+    if ((cell.attributes & TERMINAL_ATTR_BLINK) != 0) writer |> write(";5")
+    if ((cell.attributes & TERMINAL_ATTR_INVERSE) != 0) writer |> write(";7")
+    if ((cell.attributes & TERMINAL_ATTR_HIDDEN) != 0) writer |> write(";8")
+    if ((cell.attributes & TERMINAL_ATTR_STRIKE) != 0) writer |> write(";9")
+    checkpoint_write_color(writer, cell.foreground, true)
+    checkpoint_write_color(writer, cell.background, false)
+    writer |> write("m")
+}
+
+def private checkpoint_write_hyperlink(var writer : StringBuilderWriter;
+                                       hyperlink : string) {
+    let esc = to_char(27)
+    writer |> write("{esc}]8;;{hyperlink}{esc}\\")
+}
+
+def private checkpoint_cell_visible(cell : TerminalCell const) : bool {
+    let has_text = cell.width != 0 && cell.grapheme != "" && cell.grapheme != " "
+    let has_style = (cell.attributes != 0 ||
+        cell.foreground.kind != TerminalColorKind.default_color ||
+        cell.background.kind != TerminalColorKind.default_color)
+    return has_text || has_style || !empty(cell.hyperlink)
+}
+
+def private checkpoint_write_row(var writer : StringBuilderWriter;
+                                 row : TerminalRow const;
+                                 var active_style : TerminalCell;
+                                 var active_hyperlink : string) {
+    var last_column = -1
+    for (column in range(length(row.cells))) {
+        if (checkpoint_cell_visible(row.cells[column])) {
+            last_column = column
+        }
+    }
+    for (column in range(last_column + 1)) {
+        let cell = row.cells[column]
+        if (cell.width == 0) continue
+        if (!checkpoint_same_style(active_style, cell)) {
+            checkpoint_write_style(writer, cell)
+            active_style = cell
+        }
+        if (active_hyperlink != cell.hyperlink) {
+            checkpoint_write_hyperlink(writer, cell.hyperlink)
+            active_hyperlink = cell.hyperlink
+        }
+        writer |> write(empty(cell.grapheme) ? " " : cell.grapheme)
+    }
+}
+
+def private checkpoint_write_buffer(var writer : StringBuilderWriter;
+                                    buffer : TerminalBuffer const;
+                                    include_history : bool;
+                                    var active_style : TerminalCell;
+                                    var active_hyperlink : string) {
+    var line = 0
+    let line_count = (include_history ? length(buffer.history) : 0) + length(buffer.screen)
+    if (include_history) {
+        for (row in range(length(buffer.history))) {
+            if (line > 0) writer |> write("\r\n")
+            checkpoint_write_row(writer, buffer.history[history_index(buffer, row)],
+                active_style, active_hyperlink)
+            line++
+        }
+    }
+    for (row in range(length(buffer.screen))) {
+        if (line > 0) writer |> write("\r\n")
+        checkpoint_write_row(writer, buffer.screen[screen_index(buffer, row)],
+            active_style, active_hyperlink)
+        line++
+    }
+    assert(line == line_count)
+}
+
+def private checkpoint_write_mode(var writer : StringBuilderWriter;
+                                  mode : int; enabled : bool) {
+    let esc = to_char(27)
+    let suffix = enabled ? "h" : "l"
+    writer |> write("{esc}[?{mode}{suffix}")
+}
+
+def private checkpoint_write_cursor_state(var writer : StringBuilderWriter;
+                                          cursor : TerminalCursor const) {
+    let esc = to_char(27)
+    writer |> write("{esc}[{cursor.style}q")
+    checkpoint_write_mode(writer, 25, cursor.visible)
+}
+
+def private checkpoint_restore_buffer_state(var writer : StringBuilderWriter;
+                                            buffer : TerminalBuffer const;
+                                            var active_style : TerminalCell;
+                                            var active_hyperlink : string) {
+    let esc = to_char(27)
+    writer |> write("{esc}[{buffer.scroll_top + 1};{buffer.scroll_bottom + 1}r")
+    writer |> write("{esc}[{buffer.saved_cursor.row + 1};{buffer.saved_cursor.column + 1}H")
+    checkpoint_write_cursor_state(writer, buffer.saved_cursor)
+    writer |> write("{esc}[s")
+    writer |> write("{esc}[{buffer.cursor.row + 1};{buffer.cursor.column + 1}H")
+    checkpoint_write_cursor_state(writer, buffer.cursor)
+    checkpoint_write_style(writer, buffer.pen)
+    active_style = buffer.pen
+    if (active_hyperlink != buffer.pen.hyperlink) {
+        checkpoint_write_hyperlink(writer, buffer.pen.hyperlink)
+        active_hyperlink = buffer.pen.hyperlink
+    }
+}
+
+//! Serializes authoritative terminal state so a fresh emulator can resume without replaying TUI history.
+def public terminal_checkpoint_ansi(terminal : Terminal const) : string {
+    let esc = to_char(27)
+    return build_string() $(var writer) {
+        var active_style = TerminalCell()
+        var active_hyperlink = ""
+        writer |> write("{esc}c{esc}[?7l{esc}[H")
+        checkpoint_write_buffer(writer, terminal.normal, true,
+            active_style, active_hyperlink)
+        checkpoint_restore_buffer_state(writer, terminal.normal,
+            active_style, active_hyperlink)
+        if (terminal.alternate_active) {
+            checkpoint_write_mode(writer, 1049, true)
+            active_style = TerminalCell()
+            active_hyperlink = ""
+            checkpoint_write_mode(writer, 7, false)
+            writer |> write("{esc}[H")
+            checkpoint_write_buffer(writer, terminal.alternate, false,
+                active_style, active_hyperlink)
+            checkpoint_restore_buffer_state(writer, terminal.alternate,
+                active_style, active_hyperlink)
+        }
+        checkpoint_write_mode(writer, 1, terminal.modes.application_cursor_keys)
+        checkpoint_write_mode(writer, 7, terminal.modes.auto_wrap)
+        checkpoint_write_mode(writer, 1000, terminal.modes.mouse_button_reporting)
+        checkpoint_write_mode(writer, 1002, terminal.modes.mouse_drag_reporting)
+        checkpoint_write_mode(writer, 1003, terminal.modes.mouse_any_reporting)
+        checkpoint_write_mode(writer, 1004, terminal.modes.focus_reporting)
+        checkpoint_write_mode(writer, 1006, terminal.modes.sgr_mouse_encoding)
+        checkpoint_write_mode(writer, 2004, terminal.modes.bracketed_paste)
+        let buffer & = terminal.alternate_active ? terminal.alternate : terminal.normal
+        checkpoint_write_cursor_state(writer, buffer.cursor)
+        if (!empty(terminal.title)) writer |> write("{esc}]2;{terminal.title}{esc}\\")
+        if (!empty(terminal.current_directory)) {
+            writer |> write("{esc}]7;{terminal.current_directory}{esc}\\")
+        }
+    }
+}
+
 def private batchable_ascii(cell : TerminalCell const) : bool {
     if (cell.width != 1 || cell.attributes != 0 || cell.hyperlink != "" ||
             length(cell.grapheme) != 1) return false
@@ -1541,6 +1712,7 @@ def public terminal_viewport_snapshot(terminal : Terminal const; scroll_offset :
     snapshot.text_run_projection_us = get_time_usec(runs_started)
     snapshot.buffer.scrollback_rows = history_rows
     snapshot.buffer.cursor = buffer.cursor
+    snapshot.buffer.saved_cursor = buffer.saved_cursor
 }
 
 def public terminal_viewport_snapshot_dispose(var snapshot : TerminalViewportSnapshot) {

--- a/modules/dasTerminal/src/pty.cpp
+++ b/modules/dasTerminal/src/pty.cpp
@@ -105,6 +105,7 @@ private:
     HANDLE input_write_ = nullptr;
     HANDLE output_read_ = nullptr;
     HANDLE process_ = nullptr;
+    HANDLE job_ = nullptr;
     uint32_t process_id_ = 0;
 };
 
@@ -155,11 +156,12 @@ std::string buildWindowsCommandLine(const std::vector<std::string> & arguments) 
 
 ConPtyProcess::~ConPtyProcess() {
     closePty();
+    closeHandle(job_);
     closeHandle(process_);
 }
 
 bool ConPtyProcess::launch(const PtyProcessOptions & options, std::string & error) {
-    if (pseudo_console_ || input_write_ || output_read_ || process_) {
+    if (pseudo_console_ || input_write_ || output_read_ || process_ || job_) {
         error = "ConPTY process is already launched";
         return false;
     }
@@ -248,10 +250,34 @@ bool ConPtyProcess::launch(const PtyProcessOptions & options, std::string & erro
     }
     std::vector<wchar_t> mutable_command(command.begin(), command.end());
     mutable_command.push_back(L'\0');
+
+    job_ = CreateJobObjectW(nullptr, nullptr);
+    if (!job_) {
+        error = windowsError("CreateJobObjectW");
+        DeleteProcThreadAttributeList(startup.lpAttributeList);
+        closeHandle(input_read);
+        closeHandle(output_write);
+        closePty();
+        return false;
+    }
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_limits = {};
+    job_limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    if (!SetInformationJobObject(
+            job_, JobObjectExtendedLimitInformation, &job_limits,
+            sizeof(job_limits))) {
+        error = windowsError("SetInformationJobObject");
+        DeleteProcThreadAttributeList(startup.lpAttributeList);
+        closeHandle(input_read);
+        closeHandle(output_write);
+        closePty();
+        closeHandle(job_);
+        return false;
+    }
+
     PROCESS_INFORMATION process = {};
     const BOOL created = CreateProcessW(
         nullptr, mutable_command.data(), nullptr, nullptr, FALSE,
-        EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+        EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED,
         nullptr, directory.empty() ? nullptr : directory.c_str(),
         &startup.StartupInfo, &process);
     const DWORD create_error = GetLastError();
@@ -263,8 +289,33 @@ bool ConPtyProcess::launch(const PtyProcessOptions & options, std::string & erro
     if (!created) {
         error = windowsError("CreateProcessW", create_error);
         closePty();
+        closeHandle(job_);
         return false;
     }
+
+    if (!AssignProcessToJobObject(job_, process.hProcess)) {
+        const DWORD assign_error = GetLastError();
+        TerminateProcess(process.hProcess, 1);
+        WaitForSingleObject(process.hProcess, INFINITE);
+        CloseHandle(process.hThread);
+        CloseHandle(process.hProcess);
+        closePty();
+        closeHandle(job_);
+        error = windowsError("AssignProcessToJobObject", assign_error);
+        return false;
+    }
+    if (ResumeThread(process.hThread) == static_cast<DWORD>(-1)) {
+        const DWORD resume_error = GetLastError();
+        TerminateJobObject(job_, 1);
+        WaitForSingleObject(process.hProcess, INFINITE);
+        CloseHandle(process.hThread);
+        CloseHandle(process.hProcess);
+        closePty();
+        closeHandle(job_);
+        error = windowsError("ResumeThread", resume_error);
+        return false;
+    }
+
     CloseHandle(process.hThread);
     process_ = process.hProcess;
     process_id_ = process.dwProcessId;
@@ -368,11 +419,12 @@ bool ConPtyProcess::wait(
 }
 
 bool ConPtyProcess::terminate(uint32_t exit_code, std::string & error) {
-    if (TerminateProcess(process_, exit_code)) return true;
+    if (job_ && TerminateJobObject(job_, exit_code)) return true;
+    if (!job_ && TerminateProcess(process_, exit_code)) return true;
     const DWORD code = GetLastError();
     if (code == ERROR_ACCESS_DENIED && WaitForSingleObject(process_, 0) == WAIT_OBJECT_0)
         return true;
-    error = windowsError("TerminateProcess", code);
+    error = windowsError(job_ ? "TerminateJobObject" : "TerminateProcess", code);
     return false;
 }
 

--- a/modules/dasTerminal/tests/terminal_semantics.das
+++ b/modules/dasTerminal/tests/terminal_semantics.das
@@ -41,6 +41,14 @@ def assert_cells_equal(left, right : array<TerminalCell> const) {
     }
 }
 
+def assert_cursors_equal(left, right : TerminalCursor const) {
+    assert(left.row == right.row, "cursor row")
+    assert(left.column == right.column, "cursor column")
+    assert(left.style == right.style, "cursor style")
+    assert(left.visible == right.visible, "cursor visible")
+    assert(left.blinking == right.blinking, "cursor blinking")
+}
+
 def assert_snapshots_equal(left, right : TerminalSnapshot const) {
     assert(left.columns == right.columns && left.rows == right.rows, "geometry")
     assert(left.alternate_active == right.alternate_active, "active buffer")
@@ -48,13 +56,22 @@ def assert_snapshots_equal(left, right : TerminalSnapshot const) {
     assert_cells_equal(left.normal.scrollback, right.normal.scrollback)
     assert_cells_equal(left.alternate.cells, right.alternate.cells)
     assert_cells_equal(left.alternate.scrollback, right.alternate.scrollback)
-    assert(left.normal.cursor.row == right.normal.cursor.row, "cursor row")
-    assert(left.normal.cursor.column == right.normal.cursor.column, "cursor column")
-    assert(left.normal.cursor.visible == right.normal.cursor.visible, "cursor visible")
-    assert(left.normal.cursor.blinking == right.normal.cursor.blinking, "cursor blinking")
+    assert_cursors_equal(left.normal.cursor, right.normal.cursor)
+    assert_cursors_equal(left.normal.saved_cursor, right.normal.saved_cursor)
+    assert_cursors_equal(left.alternate.cursor, right.alternate.cursor)
+    assert_cursors_equal(left.alternate.saved_cursor, right.alternate.saved_cursor)
     assert(left.modes.auto_wrap == right.modes.auto_wrap, "auto wrap")
     assert(left.modes.application_cursor_keys == right.modes.application_cursor_keys, "cursor mode")
     assert(left.modes.bracketed_paste == right.modes.bracketed_paste, "paste mode")
+    assert(left.modes.focus_reporting == right.modes.focus_reporting, "focus mode")
+    assert(left.modes.mouse_button_reporting == right.modes.mouse_button_reporting,
+        "mouse button mode")
+    assert(left.modes.mouse_drag_reporting == right.modes.mouse_drag_reporting,
+        "mouse drag mode")
+    assert(left.modes.mouse_any_reporting == right.modes.mouse_any_reporting,
+        "mouse any mode")
+    assert(left.modes.sgr_mouse_encoding == right.modes.sgr_mouse_encoding,
+        "mouse encoding")
     assert(left.title == right.title, "title")
     assert(left.current_directory == right.current_directory, "cwd")
 }
@@ -245,6 +262,50 @@ def main {
         TerminalKeyEvent(key = TerminalKey.home))
     assert(normal_home == "{esc}[H")
 
+    var inscope checkpoint_source <- terminal_create(9, 3)
+    terminal_feed(checkpoint_source,
+        "{esc}[31mred{esc}[0m\r\nplain\r\n{esc}[4;44mlink{esc}[0m\r\nlast" +
+        "{esc}]2;checkpoint title{esc}\\{esc}]7;file:///checkpoint{esc}\\" +
+        "{esc}[?1h{esc}[?1000h{esc}[?1002h{esc}[?1003h{esc}[?1004h" +
+        "{esc}[?1006h{esc}[?2004h{esc}[2;3r{esc}[2;2H" +
+        "{esc}[5q{esc}[?25l{esc}[s{esc}[2q{esc}[?25h{esc}[3;5H" +
+        "{esc}[38;2;12;34;56m")
+    let checkpoint = terminal_checkpoint_ansi(checkpoint_source)
+    var inscope checkpoint_copy <- terminal_create(9, 3)
+    terminal_feed(checkpoint_copy, checkpoint)
+    var checkpoint_source_snapshot = TerminalSnapshot()
+    var checkpoint_copy_snapshot = TerminalSnapshot()
+    terminal_snapshot(checkpoint_source, checkpoint_source_snapshot)
+    terminal_snapshot(checkpoint_copy, checkpoint_copy_snapshot)
+    assert_snapshots_equal(checkpoint_source_snapshot, checkpoint_copy_snapshot)
+    terminal_feed(checkpoint_source, "Z")
+    terminal_feed(checkpoint_copy, "Z")
+    terminal_snapshot_dispose(checkpoint_source_snapshot)
+    terminal_snapshot_dispose(checkpoint_copy_snapshot)
+    terminal_snapshot(checkpoint_source, checkpoint_source_snapshot)
+    terminal_snapshot(checkpoint_copy, checkpoint_copy_snapshot)
+    assert_snapshots_equal(checkpoint_source_snapshot, checkpoint_copy_snapshot)
+    terminal_snapshot_dispose(checkpoint_source_snapshot)
+    terminal_snapshot_dispose(checkpoint_copy_snapshot)
+
+    terminal_feed(checkpoint_source, "{esc}c")
+    terminal_resize(checkpoint_source, 10, 3)
+    terminal_feed(checkpoint_source,
+        "main{esc}[2;3H{esc}[4q{esc}[?25l{esc}[s{esc}[?1049h" +
+        "{esc}[1;35mALT{esc}[0m{esc}[3;7H{esc}[3q{esc}[?25h{esc}[s" +
+        "{esc}[6q{esc}[2;5H{esc}[?25l")
+    let alternate_checkpoint = terminal_checkpoint_ansi(checkpoint_source)
+    terminal_feed(checkpoint_copy, "{esc}c")
+    terminal_resize(checkpoint_copy, 10, 3)
+    terminal_feed(checkpoint_copy, alternate_checkpoint)
+    terminal_snapshot(checkpoint_source, checkpoint_source_snapshot)
+    terminal_snapshot(checkpoint_copy, checkpoint_copy_snapshot)
+    assert_snapshots_equal(checkpoint_source_snapshot, checkpoint_copy_snapshot)
+    terminal_snapshot_dispose(checkpoint_source_snapshot)
+    terminal_snapshot_dispose(checkpoint_copy_snapshot)
+
+    terminal_dispose(checkpoint_copy)
+    terminal_dispose(checkpoint_source)
     terminal_dispose(application_keys)
     terminal_dispose(reset)
     terminal_dispose(capped)

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -1,7 +1,7 @@
 # Agent-assisted review workflows
 
-Status: first bidirectional local Review Focus slice implemented; GitHub PR
-surface remains next
+Status: bidirectional local Review Focus and multi-repository debug-session
+foundation implemented; GitHub PR surface remains next
 
 This note records the two agreed product tracks that follow a usable local Git
 inspector. Both tracks will be implemented. The local Review Focus vertical
@@ -40,6 +40,30 @@ disjoint UTF-8 byte ranges, dimmed surrounding text, direct file navigation,
 previous/next target navigation, and a show/hide toggle. A code selection's
 right-click **Look at that** action atomically posts the exact installed
 repository/worktree/comparison/path/range to the selected session Inbox.
+
+The watcher can now create a dedicated branch/worktree in a visible Git task
+session and launch Codex there only after creation succeeds, or launch on an
+explicitly selected existing worktree. It authors a durable `context.md`, injects the watcher route,
+watcher-assigned session ID, purpose, and context path into the process, and
+retains purpose/task/origin in session state. The launch token is deliberately
+removed from persisted `session.json`.
+
+An agent may declaratively sync one logical Review Bundle spanning several
+registered repository/worktree participants. Each participant owns its own
+claimed file set and revision metadata; focus targets may override repository,
+worktree, comparison, and revision per file. A ready bundle is projected to one
+retry-safe Attention item. The Sessions UI shows the debug context, immutable
+origin, bundle status, and every participant; selecting a participant switches
+the ordinary Git surfaces to that exact repository/worktree without changing
+the session origin.
+
+The deterministic multi-repository acceptance scenario launches Codex only
+after its dedicated worktree is observed, keeps that launch worktree as the
+session origin, registers a second repository, and publishes one bundle with
+participants and exact focus in both. It also proves terminal ownership is a
+lease rather than process ownership: a second client can observe while control
+is held, explicit detach hands control over, and an ungraceful socket close
+releases it for the next client without terminating the agent.
 
 Live commands expose Attention state and explicit target opening for semantic
 verification. The next product track is the GitHub PR surface described below;
@@ -431,3 +455,12 @@ for presentation, never the correctness oracle.
   plus one corrective source-range handoff human-to-agent. Arrival is non-modal
   and never changes navigation/focus; the human navigates only by clicking its
   Attention entry.
+- 2026-07-22: Bind a debug session to a watcher-created worktree while allowing
+  the cooperating agent to declare additional repository/worktree participants
+  in one logical Review Bundle. Treat the launch origin as immutable routing
+  identity, not as a limit on the work presented for review.
+- 2026-07-22: Require a real black-box protocol test for the slice: two Git
+  repositories, dedicated worktree and agent bootstrap, explicit detach and
+  reattach, controller contention, disconnect release, declarative bundle
+  replacement, and ordered durable lifecycle logs. Preserve diagnostics only
+  on failure.

--- a/utils/dasHerd/dasherd.ps1
+++ b/utils/dasHerd/dasherd.ps1
@@ -42,17 +42,23 @@ $sessionId = Take-Option $items '--session' $env:DASHERD_SESSION_ID
 $sender = Take-Option $items '--sender' ''
 if (-not $sender -and $sessionId) { $sender = "agent_session:$sessionId" }
 
-if ($items.Count -eq 0) { throw 'command required: whoami | inbox | outbox' }
+if ($items.Count -eq 0) { throw 'command required: whoami | inbox | outbox | bundle | repository' }
 $command = $items[0]
 $items.RemoveAt(0)
 
 if ($command -eq 'whoami') {
-    Write-Json ([ordered]@{
+    $identity = [ordered]@{
         sender = $sender
         session_id = $sessionId
         url = $script:BaseUrl
         configured = [bool]($script:Token -and $sessionId)
-    })
+    }
+    if ($identity.configured) {
+        $sessions = @(Invoke-DasHerd GET '/api/v1/sessions')
+        $session = $sessions | Where-Object { $_.id -eq $sessionId } | Select-Object -First 1
+        if ($session) { $identity.session = $session }
+    }
+    Write-Json $identity
     exit 0
 }
 if (-not $script:Token) { throw 'watcher token is required (--token or DASHERD_TOKEN)' }
@@ -84,6 +90,43 @@ if ($command -eq 'inbox') {
     throw "unknown inbox subcommand: $subcommand"
 }
 
+if ($command -eq 'bundle') {
+    if ($subcommand -eq 'list') {
+        Write-JsonList (Invoke-DasHerd GET "/api/v1/bundles?session_id=$([uri]::EscapeDataString($sessionId))")
+        exit 0
+    }
+    if ($subcommand -eq 'sync') {
+        $manifestPath = Take-Option $items '--manifest' ''
+        if (-not $manifestPath) { throw 'bundle sync requires --manifest <path>' }
+        $bundle = Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        Write-Json (Invoke-DasHerd POST '/api/v1/bundles/sync' ([ordered]@{
+            session_id = $sessionId
+            bundle = $bundle
+        }))
+        exit 0
+    }
+    throw "unknown bundle subcommand: $subcommand"
+}
+
+if ($command -eq 'repository') {
+    if ($subcommand -eq 'list') {
+        Write-JsonList (Invoke-DasHerd GET '/api/v1/repositories')
+        exit 0
+    }
+    if ($subcommand -eq 'add') {
+        $path = Take-Option $items '--path' ''
+        $displayName = Take-Option $items '--name' ''
+        if (-not $path) { throw 'repository add requires --path <checkout-or-worktree>' }
+        Write-Json (Invoke-DasHerd POST '/api/v1/repositories' ([ordered]@{
+            path = [System.IO.Path]::GetFullPath($path)
+            display_name = $displayName
+            target_id = 'local'
+        }))
+        exit 0
+    }
+    throw "unknown repository subcommand: $subcommand"
+}
+
 if ($command -eq 'outbox') {
     if ($subcommand -ne 'send' -and $subcommand -ne 'reply') {
         throw "unknown outbox subcommand: $subcommand"
@@ -96,6 +139,7 @@ if ($command -eq 'outbox') {
     }
     $subject = Take-Option $items '--subject' ''
     $focusPath = Take-Option $items '--focus-json' ''
+    $bundleId = Take-Option $items '--bundle' ''
     if (-not $subject) { throw 'outbox send requires --subject' }
     $focus = [ordered]@{ repository_id = ''; worktree_path = ''; comparison = 'working'; revision = ''; summary = ''; targets = @() }
     if ($focusPath) {
@@ -108,6 +152,7 @@ if ($command -eq 'outbox') {
         kind = 'focus_set'
         subject = $subject
         reply_to = $replyTo
+        bundle_id = $bundleId
         notify = $false
         focus = $focus
     }))

--- a/utils/dasHerd/dasherder.md
+++ b/utils/dasHerd/dasherder.md
@@ -1,48 +1,139 @@
-# dasHerd session mailbox
+---
+name: dasherder
+description: Coordinate a dasHerd-managed agent session, including durable Inbox/Outbox requests, multi-repository review bundles, exact source focus, and ready-for-review handoff. Use whenever DASHERD_SESSION_ID is present or a dasHerd wake-up asks the agent to fetch a request.
+---
 
-Use this protocol when a dasHerd terminal prints a wake-up such as:
+# Coordinate with dasHerd
 
-`dasHerd review request hf_42 is ready. Use the dasHerd skill to fetch and acknowledge it.`
+Treat the launch worktree as immutable session origin. Other repositories and
+worktrees may participate, but declare them in the active review bundle. Do not
+infer ownership from dirty files and do not include unrelated pre-existing work.
 
-The watcher URL, token, and agent session id are routing context, not an
-authorization model. Configure `DASHERD_URL`, `DASHERD_TOKEN`, and
-`DASHERD_SESSION_ID`, or pass `--url`, `--token`, and `--session` to the CLI.
-
-Run the CLI from the repository root:
-
-```powershell
-powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 whoami
-powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox list
-powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox get hf_42
-powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox ack hf_42
-powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 inbox complete hf_42
-```
-
-Read the exact UTF-8 byte ranges in each message's `focus.targets[].ranges`.
-An empty range list with `whole_file: true` targets the whole file. Acknowledge
-after fetching, and complete only after handling the request.
-
-To point the human at important code, write a Focus Set JSON file outside any
-deployment directory and send it atomically:
+The watcher injects `DASHERD_URL`, `DASHERD_TOKEN`, `DASHERD_SESSION_ID`,
+`DASHERD_SESSION_KIND`, and `DASHERD_CONTEXT_PATH`. Read the context artifact
+first. Run the repository-owned CLI from any participating worktree by using its
+absolute path when necessary:
 
 ```powershell
-powershell.exe -NoProfile -File utils/dasHerd/dasherd.ps1 outbox send `
-  --subject "Ready for PR. Check it out; I've highlighted the important bits." `
-  --focus-json path/to/focus-set.json
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 whoami
 ```
 
-A Focus Set contains `repository_id`, `worktree_path`, `comparison`, optional
-`revision` and `summary`, and one or more file targets. Each target has
-`file_path`, `whole_file`, and zero or more `{start_byte,end_byte,caption}`
-ranges. `caption` is an optional short hint shown when the human hovers that
-highlight, such as `main loop` or `bug was here`. One message may target several
-files and several disjoint ranges per file. The human receives persistent,
-non-modal Attention; publishing must not assume that their current file, scroll
-position, mode, or keyboard focus changed.
+## Session checkpoints
 
-Use `outbox reply <inbox-id> --subject ... --focus-json ...` to preserve the
-conversation link. Inbox means human/system to agent; Outbox means agent to
-human. Senders are provenance strings: `agent_session:<id>`, `human:local`, or
-`system:dasHerd`. Post payloads do not choose their provenance: the watcher
-stamps it from the session and direction, and reserves `system:dasHerd` for
-watcher-generated lifecycle notices.
+Keep dasHerd informed at these semantic checkpoints; do not stream every file
+write:
+
+1. When work crosses into another repository or worktree, register it if needed
+   and add it as a bundle participant.
+2. When intended changes become clear, sync the complete participant/file set.
+3. When review points become clear, add exact focus targets and short captions.
+4. Before saying the work is ready, reconcile the manifest against Git and sync
+   the bundle with `status: ready`.
+5. After publication, sync PR state into the same participant when that schema is
+   available; do not invent a separate logical delivery.
+
+`bundle sync` is declarative and retry-safe. Always send the complete desired
+state. Reuse a stable bundle `id` chosen for the logical unit of work.
+
+```powershell
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 bundle sync `
+  --manifest path/to/bundle.json
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 bundle list
+```
+
+A bundle manifest has this shape:
+
+```json
+{
+  "id": "renderer-crash-fix",
+  "title": "Renderer crash fix",
+  "kind": "debug",
+  "status": "ready",
+  "summary": "The ownership fix spans the runtime and Vulkan adapter.",
+  "participants": [
+    {
+      "repository_id": "local:D:/Work/daScript",
+      "worktree_path": "D:/Work/daScript/.codex/worktrees/renderer-fix",
+      "role": "implementation",
+      "base_revision": "origin/master",
+      "head_revision": "abc123",
+      "state": "modified",
+      "files": [
+        {"path": "src/runtime.das", "role": "primary"}
+      ]
+    },
+    {
+      "repository_id": "local:D:/Work/dasVulkan",
+      "worktree_path": "D:/Work/dasVulkan/.codex/worktrees/renderer-fix",
+      "role": "dependency",
+      "state": "modified",
+      "files": [
+        {"path": "src/device.das", "role": "risk"}
+      ]
+    }
+  ],
+  "focus": {
+    "summary": "Important code; the remaining changes are plumbing.",
+    "targets": [
+      {
+        "repository_id": "local:D:/Work/daScript",
+        "worktree_path": "D:/Work/daScript/.codex/worktrees/renderer-fix",
+        "comparison": "working",
+        "role": "primary",
+        "file_path": "src/runtime.das",
+        "whole_file": false,
+        "ranges": [
+          {"start_byte": 120, "end_byte": 380, "caption": "main loop"}
+        ]
+      },
+      {
+        "repository_id": "local:D:/Work/dasVulkan",
+        "worktree_path": "D:/Work/dasVulkan/.codex/worktrees/renderer-fix",
+        "comparison": "working",
+        "role": "risk",
+        "file_path": "src/device.das",
+        "whole_file": false,
+        "ranges": [
+          {"start_byte": 44, "end_byte": 95, "caption": "bug was here"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Every focus target must resolve to one declared participant. UTF-8 byte offsets
+are half-open: `start_byte` is included and `end_byte` is excluded. A target with
+`whole_file: true` may have no ranges. A ready bundle automatically projects one
+non-modal Attention item; later syncs update that item.
+
+Use these commands to inspect or register repositories:
+
+```powershell
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 repository list
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 repository add --path D:/Work/dasVulkan
+```
+
+Use the exact `repository_id` and observed `worktrees[].path` returned by
+`repository list`. If a worktree is not observed yet, register/refresh it and do
+not substitute a similarly named checkout.
+
+## Human requests and replies
+
+When the terminal receives a wake-up, fetch that exact message and acknowledge
+it after reading:
+
+```powershell
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 inbox list
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 inbox get hf_42
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 inbox ack hf_42
+powershell.exe -NoProfile -File <origin>/utils/dasHerd/dasherd.ps1 inbox complete hf_42
+```
+
+Use `outbox reply <inbox-id> --subject ... --focus-json ...` for a focused reply.
+Use `outbox send --bundle <bundle-id> --subject ... --focus-json ...` for notes
+that belong to a bundle but are not its canonical ready-state projection.
+
+Inbox is human/system to agent; Outbox is agent to human. The watcher assigns
+provenance. The token prevents accidental local cross-talk; it is not a
+permission boundary.

--- a/utils/dasHerd/watcher/README.md
+++ b/utils/dasHerd/watcher/README.md
@@ -24,6 +24,14 @@ reopened from the View menu. Commands > PowerShell launches in the selected
 worktree, attaches with control, and raises the terminal. `--port=9191` is
 available on both processes when the default port is occupied.
 
+Commands > Debug with Codex opens the Session Launcher. It can create a named
+branch and dedicated worktree in a watcher-owned Git terminal, then starts
+Codex there after Git succeeds. The watcher injects the session route and
+writes a durable debug context without persisting the routing token. Sessions
+show their immutable origin and agent-declared multi-repository Review Bundles;
+clicking a participant switches the ordinary Git surfaces to that exact
+worktree.
+
 The watcher prints a token-bearing control-panel URL. Optional arguments after
 `--` are `--port=9191`, `--token=<token>`, `--log-root=<directory>`, and
 `--config=<path>`. The default global configuration is
@@ -86,9 +94,28 @@ Unicode 11 0.8.0, and web-links 0.11.0 addons under `vendor/xterm/`. It works
 offline; the corresponding MIT license files are kept beside the assets.
 
 Session logs are stored under
-`logs/dasHerd/watcher/sessions/<session-id>/`. Closing a client releases its
-controller lease but does not stop its child. Killing the watcher necessarily
-loses its live PTYs; already-flushed logs remain readable.
+`logs/dasHerd/watcher/sessions/<session-id>/`. Each `events.jsonl` record has a
+contiguous per-session sequence, wall and elapsed time, lifecycle event/detail,
+and a snapshot of state, kind, purpose, repository, worktree, PID, and current
+controller. Attach attempts, rejected controller claims, detach reasons,
+disconnect/timeout releases, agent-worktree sequencing, bundle replacement,
+and Attention projection are therefore reconstructible without correlating UI
+screenshots. Closing a client releases its controller lease but does not stop
+its child. Killing the watcher necessarily loses its live PTYs; already-flushed
+logs remain readable.
+
+Run the focused suite from the repository root with:
+
+```powershell
+bin\Release\daslang.exe dastest\dastest.das -- --test utils\dasHerd\watcher\tests
+```
+
+The Windows protocol integration test starts a real watcher and fake Codex,
+creates two temporary Git repositories plus a dedicated worktree, drives HTTP,
+WebSocket attach/detach/contention/disconnect, and syncs a two-repository bundle
+through the real CLI. Its fixtures live under `tmp/dasHerd/` and diagnostics
+under `logs/dasHerd/integration/`; successful runs remove both, while failed
+runs print and preserve their exact directories for postmortem inspection.
 
 The native terminal registers its full `ImGuiTerminalState` with the live-command
 surface. `imgui_snapshot` can therefore read terminal text, selection, geometry,

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -258,7 +258,7 @@ def private prepare_worker_main(var jobs : Channel?&;
         kind = InspectorPrepareEventKind.ready))
     var stopping = false
     while (!stopping) {
-        jobs |> pop_with_timeout_clone(250) $(first : InspectorPrepareJob#) {
+        jobs |> pop_with_timeout_clone(50) $(first : InspectorPrepareJob#) {
             var job : InspectorPrepareJob
             job := first
 

--- a/utils/dasHerd/watcher/main.das
+++ b/utils/dasHerd/watcher/main.das
@@ -27,6 +27,8 @@ var private g_log_root : string
 var private g_config_path : string
 var private g_last_memory_log_at = 0l
 var private g_last_gc_at = 0l
+var private g_started_at = 0l
+var private g_exit_after_ms = 0l
 let GC_PRESSURE_MIN_INTERVAL_SECONDS = 10l
 let GC_COMPACT_MIN_INTERVAL_SECONDS = 60l
 
@@ -57,6 +59,7 @@ def private parse_watcher_args() {
     g_log_root = option_value("--log-root=",
         path_join(get_das_root(), "logs/dasHerd/watcher/sessions"))
     g_config_path = option_value("--config=", repository_default_config_path())
+    g_exit_after_ms = max(0l, int64(to_int(option_value("--exit-after-ms=", "0"))))
 }
 
 // Log das-managed memory independently of process RSS. All formatting temporaries die before
@@ -126,6 +129,7 @@ def init() {
     watcher_reset_gc_request()
     g_last_memory_log_at = 0l
     g_last_gc_at = 0l
+    g_started_at = ref_time_ticks()
     let init_error = watcher_init(g_log_root)
     if (!empty(init_error)) {
         print("dasHerd watcher: could not initialize logs: {init_error}\n")
@@ -145,6 +149,8 @@ def init() {
 
     g_server = new DasHerdWatcherServer()
     g_server.token = g_token
+    g_server.agent_url = "http://127.0.0.1:{g_port}"
+    g_server.agent_skill_path = path_join(get_das_root(), "utils/dasHerd/dasherder.md")
     let watcher_dir = get_this_module_dir()
     let vendor_dir = path_join(watcher_dir, "vendor/xterm")
     g_server.control_html = path_join(watcher_dir, "control.html")
@@ -174,6 +180,9 @@ def init() {
     print("  logs:    {g_log_root}\n")
     print("  config:  {g_config_path}\n")
     print("  bind:    127.0.0.1:{g_port}\n")
+    if (g_exit_after_ms > 0l) {
+        print("  lifetime: {g_exit_after_ms} ms (diagnostic)\n")
+    }
 }
 
 [export]
@@ -184,6 +193,11 @@ def update() {
     }
     g_server->tick()
     log_memory_if_due()
+    if (g_exit_after_ms > 0l
+            && get_time_nsec(g_started_at) / 1000000l >= g_exit_after_ms) {
+        print("dasHerd watcher: diagnostic lifetime elapsed\n")
+        request_exit()
+    }
     sleep(2u)
 }
 

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -391,6 +391,22 @@ def public repository_build_file_diff_argv(worktree_path : string;
     return ""
 }
 
+def public repository_build_worktree_create_argv(source_worktree_path,
+                                                  new_worktree_path,
+                                                  branch, base_ref : string;
+                                                  var argv : array<string>) : string {
+    if (!valid_path(source_worktree_path)) return "source worktree path is required"
+    if (!valid_path(new_worktree_path) || !is_absolute(new_worktree_path)) {
+        return "new worktree path must be absolute"
+    }
+    if (!valid_path(branch)) return "new branch is required"
+    let resolved_base = !empty(base_ref) ? base_ref : "HEAD"
+    if (!valid_path(resolved_base)) return "base ref cannot contain CR/LF"
+    argv <- ["git", "-C", source_worktree_path, "worktree", "add", "-b",
+        branch, "--", new_worktree_path, resolved_base]
+    return ""
+}
+
 def private record_git_failure(var runtime : RepositoryRuntime?;
                                message : string) {
     runtime.snapshot.failure_session_id = runtime.snapshot.task_session_id

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -392,18 +392,24 @@ def public repository_build_file_diff_argv(worktree_path : string;
 }
 
 def public repository_build_worktree_create_argv(source_worktree_path,
-                                                  new_worktree_path,
-                                                  branch, base_ref : string;
-                                                  var argv : array<string>) : string {
-    if (!valid_path(source_worktree_path)) return "source worktree path is required"
-    if (!valid_path(new_worktree_path) || !is_absolute(new_worktree_path)) {
+                                                 new_worktree_path,
+                                                 branch, base_ref : string;
+                                                 var argv : array<string>) : string {
+    if (!valid_path(source_worktree_path) || empty(strip(source_worktree_path))) {
+        return "source worktree path is required"
+    }
+    if (!valid_path(new_worktree_path) || empty(strip(new_worktree_path))
+            || !is_absolute(new_worktree_path)) {
         return "new worktree path must be absolute"
     }
     if (!valid_path(branch)) return "new branch is required"
-    let resolved_base = !empty(base_ref) ? base_ref : "HEAD"
-    if (!valid_path(resolved_base)) return "base ref cannot contain CR/LF"
+    let normalized_branch = strip(branch)
+    if (empty(normalized_branch)) return "new branch is required"
+    if (!empty(base_ref) && !valid_path(base_ref)) return "base ref cannot contain CR/LF"
+    let normalized_base = strip(base_ref)
+    let resolved_base = !empty(normalized_base) ? normalized_base : "HEAD"
     argv <- ["git", "-C", source_worktree_path, "worktree", "add", "-b",
-        branch, "--", new_worktree_path, resolved_base]
+        normalized_branch, "--", new_worktree_path, resolved_base]
     return ""
 }
 

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -73,6 +73,13 @@ struct private WatcherMailboxMessageEnvelope {
     data : array<WatcherMailboxMessage>
 }
 
+struct private WatcherBundlesMessageEnvelope {
+    @rename = "type" _type : string
+    session_id : string
+    revision : int64
+    data : array<WatcherReviewBundle>
+}
+
 struct private WatcherMailboxPostedMessage {
     @rename = "type" _type : string
     message_id : string
@@ -284,6 +291,7 @@ var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
 var private ATTENTION_MESSAGE_ROW : table<int; ToggleState>
 var private ATTENTION_TARGET_ROW : table<int; ToggleState>
+var private BUNDLE_PARTICIPANT_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
 var private GIT_COMMIT_TITLE_TEXT : table<int; NarrativeState>
@@ -357,6 +365,7 @@ def private setup_default_layout(dock_id : uint) {
     DockBuilderDockWindow("File Inspector", inspector_id)
     DockBuilderDockWindow("Terminal", terminal_id)
     DockBuilderDockWindow("Settings", activity_id)
+    DockBuilderDockWindow("Session Launcher", activity_id)
     DockBuilderFinish(dock_id)
 }
 
@@ -572,6 +581,8 @@ class private WatcherRichClient : HvWebSocketClient {
     repositories : array<RepositorySnapshot>
     mailbox : array<WatcherMailboxMessage>
     mailbox_revision : int64
+    bundles : array<WatcherReviewBundle>
+    bundles_revision : int64
     agent_mark_revision : int64 = -1l
     agent_mark_files : table<string; bool>
     error : string
@@ -769,6 +780,15 @@ class private WatcherRichClient : HvWebSocketClient {
             } else {
                 error = "invalid mailbox message"
             }
+        } elif (envelope._type == "bundles") {
+            var incoming = WatcherBundlesMessageEnvelope()
+            if (sscan_json(body, incoming)) {
+                delete bundles
+                bundles <- incoming.data
+                bundles_revision = incoming.revision
+            } else {
+                error = "invalid bundles message"
+            }
         } elif (envelope._type == "mailbox_posted") {
             var incoming : WatcherMailboxPostedMessage
             if (sscan_json(body, incoming)) {
@@ -873,6 +893,38 @@ class private WatcherRichClient : HvWebSocketClient {
             "\"timeout_ms\":0,\"display_name\":\"PowerShell\",\"kind\":\"interactive-shell\"," +
             "\"target_id\":\"local\",\"repository_id\":{sprint_json(repository_id, false)}," +
             "\"worktree_path\":{sprint_json(worktree_path, false)}\}")
+    }
+
+    def launch_codex_debug(cwd, repository_id, task_context : string) {
+        if (!connected) {
+            error = "watcher is not connected"
+            return
+        }
+        var argv <- ["codex"]
+        send("\{\"op\":\"launch\",\"argv\":{sprint_json(argv, false)}," +
+            "\"cwd\":{sprint_json(cwd, false)},\"columns\":120,\"rows\":36," +
+            "\"timeout_ms\":0,\"display_name\":\"Codex debug\"," +
+            "\"kind\":\"agent-codex\",\"purpose\":\"debug\"," +
+            "\"task_context\":{sprint_json(task_context, false)}," +
+            "\"target_id\":\"local\",\"repository_id\":" +
+            "{sprint_json(repository_id, false)},\"worktree_path\":" +
+            "{sprint_json(cwd, false)}\}")
+    }
+
+    def create_worktree_and_launch_codex(source_worktree, repository_id,
+                                         new_worktree_path, branch, base_ref,
+                                         task_context : string) {
+        if (!connected) {
+            error = "watcher is not connected"
+            return
+        }
+        send("\{\"op\":\"launch_agent_worktree\",\"repository_id\":" +
+            "{sprint_json(repository_id, false)},\"worktree_path\":" +
+            "{sprint_json(source_worktree, false)},\"new_worktree_path\":" +
+            "{sprint_json(new_worktree_path, false)},\"branch\":" +
+            "{sprint_json(branch, false)},\"base_ref\":" +
+            "{sprint_json(base_ref, false)},\"task_context\":" +
+            "{sprint_json(task_context, false)}\}")
     }
 
     def add_repository(path : string) {
@@ -1025,8 +1077,10 @@ class private WatcherRichClient : HvWebSocketClient {
         for (message in mailbox) {
             if (message.direction != "outbox") continue
             for (target in message.focus.targets) {
-                agent_mark_files[agent_mark_key(message.focus.repository_id,
-                    message.focus.worktree_path, target.file_path)] = true
+                agent_mark_files[agent_mark_key(
+                    watcher_focus_repository(message.focus, target),
+                    watcher_focus_worktree(message.focus, target),
+                    target.file_path)] = true
             }
         }
         agent_mark_revision = mailbox_revision
@@ -1109,6 +1163,59 @@ def private selected_session_label() : string {
     return g_client.selected_id
 }
 
+def private draw_selected_session_context() {
+    if (g_client == null || empty(g_client.selected_id)) return
+    for (session in g_client.sessions) {
+        if (session.id != g_client.selected_id) continue
+        let purpose = !empty(session.purpose) ? to_upper(session.purpose) : to_upper(session.kind)
+        text("{purpose}  {session.id}")
+        text_disabled("Origin: {session.worktree_path}")
+        if (!empty(session.task_context)) {
+            text_wrapped((text = session.task_context))
+        }
+        return
+    }
+}
+
+def private select_bundle_participant(participant : WatcherBundleParticipant const) {
+    if (g_client == null) return
+    g_selected_repository_id = participant.repository_id
+    g_selected_worktree_path = participant.worktree_path
+    g_client->refresh_repository(participant.repository_id)
+    g_client->request_repository_review(participant.repository_id,
+        participant.worktree_path)
+    GIT_CHANGELIST_WIN.open = true
+    GIT_CHANGELIST_WIN.pending_raise = true
+    GIT_ACTIVITY_WIN.open = true
+}
+
+def private draw_review_bundles() {
+    text("Review bundles ({g_client != null ? length(g_client.bundles) : 0})")
+    child(REVIEW_BUNDLES_CHILD, (text = "review bundles", size = float2(0.0f, 150.0f),
+            child_flags = ImGuiChildFlags.Borders, window_flags = ImGuiWindowFlags.None)) {
+        if (g_client == null || empty(g_client.bundles)) {
+            text_disabled("The agent has not declared a review bundle yet.")
+            return
+        }
+        var row = 0
+        for (bundle in g_client.bundles) {
+            text("[{to_upper(bundle.status)}] {bundle.title}")
+            if (!empty(bundle.summary)) text_disabled((text = bundle.summary))
+            for (participant in bundle.participants) {
+                let files = length(participant.files)
+                BUNDLE_PARTICIPANT_ROW[row].value = (participant.repository_id
+                    == g_selected_repository_id && participant.worktree_path
+                    == g_selected_worktree_path)
+                if (selectable(BUNDLE_PARTICIPANT_ROW[row],
+                        (text = "  {participant.role}  {participant.worktree_path}  ({files} files)##{bundle.id}:{row}"))) {
+                    select_bundle_participant(participant)
+                }
+                row++
+            }
+        }
+    }
+}
+
 def private pending_attention_count() : int {
     var count = 0
     if (g_client != null) {
@@ -1135,6 +1242,10 @@ def private activate_focus_target(message : WatcherMailboxMessage const;
     if (g_client == null || target_index < 0
             || target_index >= length(message.focus.targets)) return
     let target & = unsafe(message.focus.targets[target_index])
+    let repository_id = watcher_focus_repository(message.focus, target)
+    let worktree_path = watcher_focus_worktree(message.focus, target)
+    let comparison = watcher_focus_comparison(message.focus, target)
+    let revision = watcher_focus_revision(message.focus, target)
     g_active_focus_message = message.id
     g_active_focus_target = target_index
     g_active_focus_range = first_focus_range(target)
@@ -1142,23 +1253,19 @@ def private activate_focus_target(message : WatcherMailboxMessage const;
     g_pending_focus_scroll = true
     g_applied_focus_identity = ""
     let selection_changed = (g_selected_repository_id
-            != message.focus.repository_id
-        || g_selected_worktree_path != message.focus.worktree_path)
-    g_selected_repository_id = message.focus.repository_id
-    g_selected_worktree_path = message.focus.worktree_path
+            != repository_id
+        || g_selected_worktree_path != worktree_path)
+    g_selected_repository_id = repository_id
+    g_selected_worktree_path = worktree_path
     if (message.status == "new") g_client->acknowledge_mailbox(message.id)
     if (selection_changed) {
-        g_client->refresh_repository(message.focus.repository_id)
-        g_client->request_repository_review(message.focus.repository_id,
-            message.focus.worktree_path)
-        g_client->request_repository_history(message.focus.repository_id,
-            message.focus.worktree_path)
-        g_client->request_repository_refs(message.focus.repository_id,
-            message.focus.worktree_path)
+        g_client->refresh_repository(repository_id)
+        g_client->request_repository_review(repository_id, worktree_path)
+        g_client->request_repository_history(repository_id, worktree_path)
+        g_client->request_repository_refs(repository_id, worktree_path)
     }
-    g_client->inspect_file(message.focus.repository_id,
-        message.focus.worktree_path, target.file_path,
-        message.focus.comparison, "full", message.focus.revision)
+    g_client->inspect_file(repository_id, worktree_path, target.file_path,
+        comparison, "full", revision)
     FILE_INSPECTOR_WIN.open = true
     FILE_INSPECTOR_WIN.pending_raise = true
 }
@@ -1194,7 +1301,8 @@ def private draw_session_list() {
         g_client->terminate_selected()
     }
     separator()
-    child(SESSIONS_CHILD, (text = "sessions", size = float2(0.0f, -260.0f),
+    draw_selected_session_context()
+    child(SESSIONS_CHILD, (text = "sessions", size = float2(0.0f, 120.0f),
             child_flags = ImGuiChildFlags.Borders, window_flags = ImGuiWindowFlags.None)) {
         var visible_sessions = 0
         if (g_client != null) {
@@ -1219,6 +1327,8 @@ def private draw_session_list() {
     }
     text_disabled("Exited sessions are retained and hidden by default.")
     separator()
+    draw_review_bundles()
+    separator()
     let attention_count = pending_attention_count()
     text("Attention ({attention_count})")
     text_disabled("Agent notes never navigate until you click them.")
@@ -1239,10 +1349,13 @@ def private draw_session_list() {
                 let selected_message = message.id == g_active_focus_message
                 for (target_index in range(length(message.focus.targets))) {
                     let target & = unsafe(message.focus.targets[target_index])
+                    let target_repository = watcher_focus_repository(message.focus, target)
+                    let repository_hint = (!empty(target.repository_id)
+                        ? "[{target_repository}] " : "")
                     ATTENTION_TARGET_ROW[target_row].value = (selected_message
                         && target_index == g_active_focus_target)
                     if (selectable(ATTENTION_TARGET_ROW[target_row],
-                            (text = "  {target.file_path}##{message.id}:{target_index}"))) {
+                            (text = "  {repository_hint}{target.file_path}##{message.id}:{target_index}"))) {
                         activate_focus_target(message, target_index)
                     }
                     target_row++
@@ -1293,8 +1406,30 @@ def private reset_layout() {
     GIT_ACTIVITY_WIN.open = true
     FILE_INSPECTOR_WIN.open = true
     TERMINAL_WIN.open = true
+    SESSION_LAUNCHER_WIN.open = false
     SETTINGS_WIN.open = false
     DOCK_ROOT.pending_reset = true
+}
+
+def private prepare_debug_launcher() {
+    let suffix = "debug-{ref_time_ticks()}"
+    AGENT_BRANCH.pending_value = "codex/{suffix}"
+    AGENT_BRANCH.has_pending = true
+    AGENT_BASE_REF.pending_value = "HEAD"
+    AGENT_BASE_REF.has_pending = true
+    var checkout = g_selected_worktree_path
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id == g_selected_repository_id) {
+                checkout = repository.record.checkout_path
+                break
+            }
+        }
+    }
+    AGENT_WORKTREE_PATH.pending_value = path_join(
+        path_join(checkout, ".codex/worktrees"), suffix)
+    AGENT_WORKTREE_PATH.has_pending = true
+    CREATE_DEDICATED_WORKTREE.value = true
 }
 
 def private draw_main_menu() {
@@ -1305,6 +1440,12 @@ def private draw_main_menu() {
             }
         }
         menu(COMMANDS_MENU, (text = "Commands", enabled = true)) {
+            if (menu_label(COMMAND_CODEX_DEBUG,
+                    (text = "Debug with Codex...", enabled = g_client != null
+                        && g_client.connected && !empty(g_selected_worktree_path)))) {
+                prepare_debug_launcher()
+                open_dock_window(SESSION_LAUNCHER_WIN)
+            }
             if (menu_label(COMMAND_POWERSHELL,
                     (text = "PowerShell", enabled = g_client != null && g_client.connected))) {
                 g_client->launch("powershell.exe -NoLogo -NoProfile", g_selected_worktree_path,
@@ -1352,6 +1493,10 @@ def private draw_main_menu() {
             if (menu_label(VIEW_TERMINAL,
                     (text = "Terminal", selected = TERMINAL_WIN.open))) {
                 open_dock_window(TERMINAL_WIN)
+            }
+            if (menu_label(VIEW_SESSION_LAUNCHER,
+                    (text = "Session Launcher", selected = SESSION_LAUNCHER_WIN.open))) {
+                open_dock_window(SESSION_LAUNCHER_WIN)
             }
             separator(VIEW_WINDOWS_SEPARATOR)
             menu_item(SHOW_EXITED, (text = "Show exited sessions"))
@@ -3145,7 +3290,10 @@ def herder_attention_state(_input : JsonValue?) : JsonValue? {
         for (message in g_client.mailbox) {
             if (message.direction != "outbox") continue
             var targets <- [for (target in message.focus.targets);
-                JV((file_path = target.file_path,
+                JV((repository_id = watcher_focus_repository(message.focus, target),
+                    worktree_path = watcher_focus_worktree(message.focus, target),
+                    comparison = watcher_focus_comparison(message.focus, target),
+                    file_path = target.file_path,
                     whole_file = target.whole_file,
                     range_count = length(target.ranges)))]
             messages |> push(JV((id = message.id, sender = message.sender,
@@ -3162,6 +3310,47 @@ def herder_attention_state(_input : JsonValue?) : JsonValue? {
         focus_visible = g_focus_visible,
         last_human_request_id = g_last_human_request,
         messages = messages))
+}
+
+[live_command(description = "Inspect selected dasHerd session origin, purpose, and multi-repository Review Bundles.")]
+def herder_session_state(_input : JsonValue?) : JsonValue? {
+    var session_id, session_state, session_kind, session_purpose : string
+    var task_context, repository_id, worktree_path, context_path : string
+    var bundles : array<JsonValue?>
+    if (g_client != null) {
+        for (session in g_client.sessions) {
+            if (session.id == g_client.selected_id) {
+                session_id = session.id
+                session_state = session.state
+                session_kind = session.kind
+                session_purpose = session.purpose
+                task_context = session.task_context
+                repository_id = session.repository_id
+                worktree_path = session.worktree_path
+                context_path = session.context_path
+                break
+            }
+        }
+        for (bundle in g_client.bundles) {
+            var participants <- [for (participant in bundle.participants);
+                JV((repository_id = participant.repository_id,
+                    worktree_path = participant.worktree_path,
+                    role = participant.role, state = participant.state,
+                    file_count = length(participant.files)))]
+            bundles |> push(JV((id = bundle.id, title = bundle.title,
+                status = bundle.status, revision = bundle.revision,
+                participant_count = length(bundle.participants),
+                focus_target_count = length(bundle.focus.targets),
+                participants = participants)))
+        }
+    }
+    return JV((ok = g_client != null, session_id = session_id,
+        session_state = session_state, session_kind = session_kind,
+        session_purpose = session_purpose, task_context = task_context,
+        repository_id = repository_id, worktree_path = worktree_path,
+        context_path = context_path,
+        bundles_revision = g_client != null ? g_client.bundles_revision : 0l,
+        bundles = bundles))
 }
 
 [live_command(description = "Open one agent Focus Set target at the user's chosen time. Args: message_id, target_index.")]
@@ -3387,7 +3576,11 @@ def private draw_active_focus_overlay(state : TextSourceViewState const;
                 || g_active_focus_target < 0
                 || g_active_focus_target >= length(message.focus.targets)) continue
         let target & = unsafe(message.focus.targets[g_active_focus_target])
-        if (target.file_path == g_inspector.installed_file_path) {
+        if (watcher_focus_repository(message.focus, target)
+                    == g_inspector.installed_repository_id
+                && watcher_focus_worktree(message.focus, target)
+                    == g_inspector.installed_worktree_path
+                && target.file_path == g_inspector.installed_file_path) {
             draw_focus_target_overlay(target, state, document, diff_mapping)
         }
         return
@@ -3409,7 +3602,11 @@ def private apply_active_focus() {
                     || g_active_focus_target < 0
                     || g_active_focus_target >= length(message.focus.targets)) continue
             let target & = unsafe(message.focus.targets[g_active_focus_target])
-            if (target.file_path != g_inspector.installed_file_path) continue
+            if (watcher_focus_repository(message.focus, target)
+                        != g_inspector.installed_repository_id
+                    || watcher_focus_worktree(message.focus, target)
+                        != g_inspector.installed_worktree_path
+                    || target.file_path != g_inspector.installed_file_path) continue
             matched_target = true
             g_inspector.focus_document_valid = true
             if (!empty(target.ranges)) {
@@ -3625,6 +3822,43 @@ def private draw_settings_window() {
     text_disabled("Repository registration and layout settings will be stored here.")
 }
 
+def private draw_session_launcher_window() {
+    text("Codex debug session")
+    text_disabled("The selected worktree becomes the immutable session origin.")
+    separator()
+    text("Repository: {g_selected_repository_id}")
+    text("Selected worktree: {g_selected_worktree_path}")
+    checkbox(CREATE_DEDICATED_WORKTREE, (text = "Create a dedicated worktree"))
+    if (CREATE_DEDICATED_WORKTREE.value) {
+        input_text_growable(AGENT_BRANCH, (text = "New branch"))
+        input_text_growable(AGENT_BASE_REF, (text = "Base ref"))
+        input_text_growable(AGENT_WORKTREE_PATH, (text = "New worktree path"))
+    }
+    text("Debug task")
+    input_text_multiline(AGENT_TASK_CONTEXT,
+        (text = "##debug-task", size = float2(-FLT_MIN, GetTextLineHeight() * 8.0f),
+         flags = ImGuiInputTextFlags.None))
+    if (button(LAUNCH_CODEX_DEBUG,
+            (text = "Launch Codex", enabled = g_client != null
+                && g_client.connected && !empty(g_selected_repository_id)
+                && !empty(g_selected_worktree_path)
+                && (!CREATE_DEDICATED_WORKTREE.value
+                    || (!empty(AGENT_BRANCH.value)
+                        && !empty(AGENT_WORKTREE_PATH.value)))
+                && !empty(AGENT_TASK_CONTEXT.value)))) {
+        if (CREATE_DEDICATED_WORKTREE.value) {
+            g_client->create_worktree_and_launch_codex(g_selected_worktree_path,
+                g_selected_repository_id, AGENT_WORKTREE_PATH.value,
+                AGENT_BRANCH.value, AGENT_BASE_REF.value,
+                AGENT_TASK_CONTEXT.value)
+        } else {
+            g_client->launch_codex_debug(g_selected_worktree_path,
+                g_selected_repository_id, AGENT_TASK_CONTEXT.value)
+        }
+        SESSION_LAUNCHER_WIN.open = false
+    }
+}
+
 def private draw_terminal_window() {
     let io & = unsafe(GetIO())
     if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
@@ -3677,6 +3911,11 @@ def init() {
     inspector_prepare_worker_start(g_prepare_worker)
     g_selected_worktree_path = get_das_root()
     SETTINGS_WIN.open = false
+    AGENT_TASK_CONTEXT.capacity = 16 * 1024
+    AGENT_BRANCH.capacity = 1024
+    AGENT_BASE_REF.capacity = 1024
+    AGENT_WORKTREE_PATH.capacity = 16 * 1024
+    CREATE_DEDICATED_WORKTREE.value = true
     let port = clamp(to_int(option_value("--port=", "9191")), 1024, 65535)
     g_token = option_value("--token=")
     g_url = "ws://127.0.0.1:{port}/ws?token={g_token}"
@@ -3737,6 +3976,10 @@ def update() {
                 flags = ImGuiWindowFlags.None)) {
             draw_settings_window()
         }
+        dock_window(SESSION_LAUNCHER_WIN, (text = "Session Launcher", closable = true,
+                flags = ImGuiWindowFlags.None)) {
+            draw_session_launcher_window()
+        }
     }
     harness_end_frame()
 }
@@ -3750,6 +3993,7 @@ def shutdown() {
         delete g_client.sessions
         delete g_client.repositories
         delete g_client.mailbox
+        delete g_client.bundles
         delete g_client.git_failure_revisions
         delete g_client.agent_mark_files
         unsafe { delete g_client }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -124,6 +124,14 @@ struct private WatcherRawResetMessage {
     offset : int64
 }
 
+struct private WatcherTerminalCheckpointMessage {
+    @rename = "type" _type : string
+    offset : int64
+    columns : int
+    rows : int
+    ansi : string
+}
+
 struct private HerderInspectorTextArgs {
     side : string = "view"
 }
@@ -254,6 +262,12 @@ struct private GitWindowStatus {
     error : bool
 }
 
+struct private AgentLaunchLocation {
+    repository_id : string
+    worktree_path : string
+    display_label : string
+}
+
 var private g_terminal = Terminal()
 var private g_terminal_view = ImGuiTerminalState()
 var private g_terminal_cache = ImGuiTerminalCache()
@@ -266,6 +280,11 @@ var private g_url : string
 var private g_token : string
 var private g_selected_worktree_path : string
 var private g_selected_repository_id : string
+var private g_agent_source_worktree_path : string
+var private g_agent_source_repository_id : string
+var private g_agent_worktree_name : string
+var private g_layout_probe_complete = false
+var private g_layout_force_default = false
 var private g_focus_terminal_pending = false
 var private g_active_focus_message = ""
 var private g_active_focus_target = -1
@@ -291,7 +310,9 @@ var private g_jobque_owned = false
 var private SESSION_ROW : table<int; ToggleState>
 var private ATTENTION_MESSAGE_ROW : table<int; ToggleState>
 var private ATTENTION_TARGET_ROW : table<int; ToggleState>
+var private BUNDLE_ROW : table<int; ToggleState>
 var private BUNDLE_PARTICIPANT_ROW : table<int; ToggleState>
+var private BUNDLE_FILE_ROW : table<int; ToggleState>
 var private WORKTREE_ROW : table<int; ToggleState>
 var private GIT_FILE_ROW : table<int; ToggleState>
 var private GIT_COMMIT_TITLE_TEXT : table<int; NarrativeState>
@@ -345,28 +366,19 @@ def private setup_default_layout(dock_id : uint) {
     var left_id : uint = 0u
     var right_id : uint = 0u
     DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.24f, left_id, right_id)
-    var upper_id : uint = 0u
-    var terminal_id : uint = 0u
-    DockBuilderSplitNode(right_id, ImGuiDir.Down, 0.34f, terminal_id, upper_id)
-    var git_id : uint = 0u
-    var inspector_id : uint = 0u
-    DockBuilderSplitNode(upper_id, ImGuiDir.Left, 0.34f, git_id, inspector_id)
-    var changelist_id : uint = 0u
-    var activity_id : uint = 0u
-    DockBuilderSplitNode(git_id, ImGuiDir.Up, 0.35f, changelist_id, activity_id)
     var repositories_id : uint = 0u
     var sessions_id : uint = 0u
     DockBuilderSplitNode(left_id, ImGuiDir.Down, 0.42f,
         sessions_id, repositories_id)
     DockBuilderDockWindow("Sessions & Activity###SessionsActivity", sessions_id)
     DockBuilderDockWindow("Repositories & Worktrees", repositories_id)
-    DockBuilderDockWindow("Git Changelist", changelist_id)
-    DockBuilderDockWindow("Git Activity", activity_id)
-    DockBuilderDockWindow("File Inspector", inspector_id)
-    DockBuilderDockWindow("Terminal", terminal_id)
-    DockBuilderDockWindow("Settings", activity_id)
-    DockBuilderDockWindow("Session Launcher", activity_id)
+    DockBuilderDockWindow("Git Changelist", right_id)
+    DockBuilderDockWindow("Git Activity", right_id)
+    DockBuilderDockWindow("File Inspector", right_id)
+    DockBuilderDockWindow("Settings", right_id)
+    DockBuilderDockWindow("Terminal", right_id)
     DockBuilderFinish(dock_id)
+    TERMINAL_WIN.pending_raise = true
 }
 
 def private option_value(prefix : string; fallback : string = "") : string {
@@ -589,6 +601,8 @@ class private WatcherRichClient : HvWebSocketClient {
     last_heartbeat : int64
     last_list : int64
     last_reconnect : int64
+    control_retry_started : int64
+    last_control_retry : int64
     sent_input_bytes : int64
     desired_columns : int
     desired_rows : int
@@ -608,6 +622,13 @@ class private WatcherRichClient : HvWebSocketClient {
     reconnect_attempt_count : int64
     message_count : int64
     repository_message_count : int64
+    heartbeat_send_count : int64
+    heartbeat_send_failure_count : int64
+    heartbeat_last_result : int
+    heartbeat_receive_count : int64
+    list_send_count : int64
+    list_send_failure_count : int64
+    list_last_result : int
 
     def override onOpen {
         connected = true
@@ -631,6 +652,8 @@ class private WatcherRichClient : HvWebSocketClient {
         attached = false
         controls = false
         attached_id = ""
+        control_retry_started = 0l
+        last_control_retry = 0l
         sent_columns = 0
         sent_rows = 0
         last_review_identity = ""
@@ -668,6 +691,8 @@ class private WatcherRichClient : HvWebSocketClient {
             if (sscan_json(body, incoming)) {
                 client_id = incoming.client_id
             }
+        } elif (envelope._type == "heartbeat") {
+            heartbeat_receive_count++
         } elif (envelope._type == "sessions") {
             var incoming : WatcherSessionsMessage
             if (sscan_json(body, incoming)) {
@@ -823,7 +848,17 @@ class private WatcherRichClient : HvWebSocketClient {
                 attached_id = incoming.session_id
                 attached = true
                 controls = incoming.controls
-                g_status = incoming.controls ? "Attached with control" : "Attached read-only"
+                if (incoming.controls) {
+                    control_retry_started = 0l
+                    last_control_retry = 0l
+                    error = ""
+                    g_status = "Attached with control"
+                } else {
+                    if (control_retry_started == 0l) {
+                        control_retry_started = ref_time_ticks()
+                    }
+                    g_status = "Attached read-only; waiting for control"
+                }
                 if (controls) {
                     if (desired_columns <= 0 || desired_rows <= 0) {
                         desired_columns = g_terminal.columns
@@ -836,8 +871,19 @@ class private WatcherRichClient : HvWebSocketClient {
             attached = false
             controls = false
             attached_id = ""
+            control_retry_started = 0l
+            last_control_retry = 0l
             sent_columns = 0
             sent_rows = 0
+        } elif (envelope._type == "terminal_checkpoint") {
+            var incoming : WatcherTerminalCheckpointMessage
+            if (sscan_json(body, incoming)) {
+                reset_terminal(max(1, incoming.columns), max(1, incoming.rows))
+                terminal_feed(g_terminal, incoming.ansi)
+                g_status = "Terminal restored at byte {incoming.offset}"
+            } else {
+                error = "invalid terminal checkpoint"
+            }
         } elif (envelope._type == "raw_reset") {
             var incoming : WatcherRawResetMessage
             if (sscan_json(body, incoming)) {
@@ -848,6 +894,26 @@ class private WatcherRichClient : HvWebSocketClient {
             var incoming : WatcherErrorMessage
             if (sscan_json(body, incoming)) {
                 error = incoming.error
+                if (incoming.error == "controller lease expired"
+                        || incoming.error == "client does not hold the controller lease"
+                        || incoming.error == "controller lease is held by another client") {
+                    controls = false
+                    sent_columns = 0
+                    sent_rows = 0
+                    if (attached && !empty(attached_id)) {
+                        control_retry_started = ref_time_ticks()
+                        last_control_retry = 0l
+                    }
+                } elif (incoming.error == "unknown operation"
+                        && attached && !controls && !empty(attached_id)) {
+                    // Compatibility with a watcher that predates
+                    // `claim_control`: reattach without raw replay or terminal
+                    // reset, then flush the latest measured PTY size when the
+                    // attached response grants control.
+                    send("\{\"op\":\"attach\",\"session_id\":" +
+                        "{sprint_json(attached_id, false)}," +
+                        "\"control\":true,\"raw\":false\}")
+                }
             }
         }
     }
@@ -864,16 +930,36 @@ class private WatcherRichClient : HvWebSocketClient {
         if (!connected || empty(session_id)) return
         var columns = 100
         var rows = 30
+        var origin_repository_id, origin_worktree_path : string
         for (session in sessions) {
             if (session.id == session_id) {
                 columns = max(20, session.columns)
                 rows = max(5, session.rows)
+                origin_repository_id = session.repository_id
+                origin_worktree_path = session.worktree_path
                 break
+            }
+        }
+        if (!empty(origin_repository_id) && !empty(origin_worktree_path)) {
+            let origin_changed = (g_selected_repository_id
+                    != origin_repository_id
+                || g_selected_worktree_path != origin_worktree_path)
+            g_selected_repository_id = origin_repository_id
+            g_selected_worktree_path = origin_worktree_path
+            if (origin_changed) {
+                request_repository_review(
+                    origin_repository_id, origin_worktree_path)
+                request_repository_history(
+                    origin_repository_id, origin_worktree_path)
+                request_repository_refs(
+                    origin_repository_id, origin_worktree_path)
             }
         }
         selected_id = session_id
         attached = false
         controls = false
+        control_retry_started = ref_time_ticks()
+        last_control_retry = 0l
         sent_columns = 0
         sent_rows = 0
         error = ""
@@ -1137,12 +1223,28 @@ class private WatcherRichClient : HvWebSocketClient {
             return
         }
         if (get_time_nsec(last_heartbeat) / 1000000l >= 1000l) {
-            send("\{\"op\":\"heartbeat\"\}")
+            heartbeat_last_result = send_result("\{\"op\":\"heartbeat\"\}")
+            heartbeat_send_count++
+            if (heartbeat_last_result < 0) heartbeat_send_failure_count++
             last_heartbeat = ref_time_ticks()
+            // libhv accepts the write here but can lose a second write issued
+            // from the same client tick. Serialize maintenance frames.
+            return
         }
         if (get_time_nsec(last_list) / 1000000l >= 1000l) {
-            refresh()
+            list_last_result = send_result("\{\"op\":\"list\"\}")
+            list_send_count++
+            if (list_last_result < 0) list_send_failure_count++
             last_list = ref_time_ticks()
+            return
+        }
+        if (attached && !controls && !empty(attached_id)
+                && control_retry_started != 0l
+                && get_time_nsec(control_retry_started) / 1000000l < 15000l
+                && (last_control_retry == 0l
+                    || get_time_nsec(last_control_retry) / 1000000l >= 500l)) {
+            send("\{\"op\":\"claim_control\"\}")
+            last_control_retry = ref_time_ticks()
         }
     }
 }
@@ -1189,6 +1291,27 @@ def private select_bundle_participant(participant : WatcherBundleParticipant con
     GIT_ACTIVITY_WIN.open = true
 }
 
+def private activate_bundle_focus(bundle : WatcherReviewBundle const;
+                                  repository_id : string = "";
+                                  worktree_path : string = "";
+                                  file_path : string = "") : bool {
+    if (g_client == null) return false
+    for (message in g_client.mailbox) {
+        if (message.direction != "outbox" || message.bundle_id != bundle.id) continue
+        for (target_index in range(length(message.focus.targets))) {
+            let target & = unsafe(message.focus.targets[target_index])
+            let target_repository = watcher_focus_repository(message.focus, target)
+            let target_worktree = watcher_focus_worktree(message.focus, target)
+            if (!empty(repository_id) && target_repository != repository_id) continue
+            if (!empty(worktree_path) && target_worktree != worktree_path) continue
+            if (!empty(file_path) && target.file_path != file_path) continue
+            activate_focus_target(message, target_index)
+            return true
+        }
+    }
+    return false
+}
+
 def private draw_review_bundles() {
     text("Review bundles ({g_client != null ? length(g_client.bundles) : 0})")
     child(REVIEW_BUNDLES_CHILD, (text = "review bundles", size = float2(0.0f, 150.0f),
@@ -1197,20 +1320,47 @@ def private draw_review_bundles() {
             text_disabled("The agent has not declared a review bundle yet.")
             return
         }
-        var row = 0
-        for (bundle in g_client.bundles) {
-            text("[{to_upper(bundle.status)}] {bundle.title}")
+        var participant_row = 0
+        var file_row = 0
+        for (bundle_index in range(length(g_client.bundles))) {
+            let bundle & = unsafe(g_client.bundles[bundle_index])
+            BUNDLE_ROW[bundle_index].value = false
+            if (selectable(BUNDLE_ROW[bundle_index],
+                    (text = "[{to_upper(bundle.status)}] {bundle.title}##{bundle.id}"))) {
+                let _ = activate_bundle_focus(bundle)
+            }
+            BUNDLE_ROW[bundle_index].value = false
             if (!empty(bundle.summary)) text_disabled((text = bundle.summary))
             for (participant in bundle.participants) {
                 let files = length(participant.files)
-                BUNDLE_PARTICIPANT_ROW[row].value = (participant.repository_id
+                BUNDLE_PARTICIPANT_ROW[participant_row].value = (participant.repository_id
                     == g_selected_repository_id && participant.worktree_path
                     == g_selected_worktree_path)
-                if (selectable(BUNDLE_PARTICIPANT_ROW[row],
-                        (text = "  {participant.role}  {participant.worktree_path}  ({files} files)##{bundle.id}:{row}"))) {
-                    select_bundle_participant(participant)
+                if (selectable(BUNDLE_PARTICIPANT_ROW[participant_row],
+                        (text = "  {participant.role}  {participant.worktree_path}  ({files} files)##{bundle.id}:{participant_row}"))) {
+                    if (!activate_bundle_focus(bundle, participant.repository_id,
+                            participant.worktree_path)) {
+                        select_bundle_participant(participant)
+                    }
                 }
-                row++
+                participant_row++
+                for (file in participant.files) {
+                    BUNDLE_FILE_ROW[file_row].value = false
+                    if (selectable(BUNDLE_FILE_ROW[file_row],
+                            (text = "      {file.role}  {file.path}##{bundle.id}:file:{file_row}"))) {
+                        if (!activate_bundle_focus(bundle, participant.repository_id,
+                                participant.worktree_path, file.path)) {
+                            select_bundle_participant(participant)
+                            g_client->inspect_file(participant.repository_id,
+                                participant.worktree_path, file.path,
+                                "working", "full", "")
+                            FILE_INSPECTOR_WIN.open = true
+                            FILE_INSPECTOR_WIN.pending_raise = true
+                        }
+                    }
+                    BUNDLE_FILE_ROW[file_row].value = false
+                    file_row++
+                }
             }
         }
     }
@@ -1406,29 +1556,80 @@ def private reset_layout() {
     GIT_ACTIVITY_WIN.open = true
     FILE_INSPECTOR_WIN.open = true
     TERMINAL_WIN.open = true
-    SESSION_LAUNCHER_WIN.open = false
     SETTINGS_WIN.open = false
+    g_layout_probe_complete = false
+    g_layout_force_default = true
     DOCK_ROOT.pending_reset = true
+}
+
+def private agent_repository_checkout(repository_id, fallback : string) : string {
+    if (g_client != null) {
+        for (repository in g_client.repositories) {
+            if (repository.record.id == repository_id) {
+                return repository.record.checkout_path
+            }
+        }
+    }
+    return fallback
+}
+
+def private suggest_agent_worktree_path() {
+    let checkout = agent_repository_checkout(
+        g_agent_source_repository_id, g_agent_source_worktree_path)
+    AGENT_WORKTREE_PATH.pending_value = path_join(
+        path_join(checkout, ".codex/worktrees"), g_agent_worktree_name)
+    AGENT_WORKTREE_PATH.has_pending = true
+}
+
+def private set_agent_launch_source(repository_id, worktree_path : string;
+                                    update_suggestion : bool = false) {
+    g_agent_source_repository_id = repository_id
+    g_agent_source_worktree_path = worktree_path
+    if (update_suggestion) suggest_agent_worktree_path()
+}
+
+def private collect_agent_launch_locations(
+                                           var locations : array<AgentLaunchLocation>&) {
+    delete locations
+    if (g_client == null) return
+    for (repository in g_client.repositories) {
+        for (worktree in repository.worktrees) {
+            let branch = (worktree.detached
+                ? "detached {slice(worktree.head, 0, min(8, length(worktree.head)))}"
+                : worktree.branch)
+            locations |> push(AgentLaunchLocation(
+                repository_id = repository.record.id,
+                worktree_path = worktree.path,
+                display_label = "{repository.record.display_name} | {branch} | {worktree.path}"))
+        }
+    }
 }
 
 def private prepare_debug_launcher() {
     let suffix = "debug-{ref_time_ticks()}"
+    g_agent_worktree_name = suffix
     AGENT_BRANCH.pending_value = "codex/{suffix}"
     AGENT_BRANCH.has_pending = true
     AGENT_BASE_REF.pending_value = "HEAD"
     AGENT_BASE_REF.has_pending = true
-    var checkout = g_selected_worktree_path
+    AGENT_TASK_CONTEXT.pending_value = ""
+    AGENT_TASK_CONTEXT.has_pending = true
+    var source_repository_id = g_selected_repository_id
+    var source_worktree_path = g_selected_worktree_path
     if (g_client != null) {
-        for (repository in g_client.repositories) {
-            if (repository.record.id == g_selected_repository_id) {
-                checkout = repository.record.checkout_path
+        for (session in g_client.sessions) {
+            if (session.id == g_client.selected_id
+                    && !empty(session.repository_id)
+                    && !empty(session.worktree_path)) {
+                source_repository_id = session.repository_id
+                source_worktree_path = session.worktree_path
                 break
             }
         }
     }
-    AGENT_WORKTREE_PATH.pending_value = path_join(
-        path_join(checkout, ".codex/worktrees"), suffix)
-    AGENT_WORKTREE_PATH.has_pending = true
+    set_agent_launch_source(source_repository_id, source_worktree_path)
+    suggest_agent_worktree_path()
+    AGENT_SOURCE_WORKTREE.value = -1
     CREATE_DEDICATED_WORKTREE.value = true
 }
 
@@ -1444,7 +1645,7 @@ def private draw_main_menu() {
                     (text = "Debug with Codex...", enabled = g_client != null
                         && g_client.connected && !empty(g_selected_worktree_path)))) {
                 prepare_debug_launcher()
-                open_dock_window(SESSION_LAUNCHER_WIN)
+                open_popup(SESSION_LAUNCHER_DIALOG)
             }
             if (menu_label(COMMAND_POWERSHELL,
                     (text = "PowerShell", enabled = g_client != null && g_client.connected))) {
@@ -1493,10 +1694,6 @@ def private draw_main_menu() {
             if (menu_label(VIEW_TERMINAL,
                     (text = "Terminal", selected = TERMINAL_WIN.open))) {
                 open_dock_window(TERMINAL_WIN)
-            }
-            if (menu_label(VIEW_SESSION_LAUNCHER,
-                    (text = "Session Launcher", selected = SESSION_LAUNCHER_WIN.open))) {
-                open_dock_window(SESSION_LAUNCHER_WIN)
             }
             separator(VIEW_WINDOWS_SEPARATOR)
             menu_item(SHOW_EXITED, (text = "Show exited sessions"))
@@ -2789,6 +2986,21 @@ def herder_client_state(_input : JsonValue?) : JsonValue? {
         reconnect_attempt_count = g_client.reconnect_attempt_count,
         message_count = g_client.message_count,
         repository_message_count = g_client.repository_message_count,
+        heartbeat_send_count = g_client.heartbeat_send_count,
+        heartbeat_send_failure_count = g_client.heartbeat_send_failure_count,
+        heartbeat_last_result = g_client.heartbeat_last_result,
+        heartbeat_receive_count = g_client.heartbeat_receive_count,
+        list_send_count = g_client.list_send_count,
+        list_send_failure_count = g_client.list_send_failure_count,
+        list_last_result = g_client.list_last_result,
+        heartbeat_age_ms = get_time_nsec(g_client.last_heartbeat) / 1000000l,
+        list_age_ms = get_time_nsec(g_client.last_list) / 1000000l,
+        attached = g_client.attached,
+        controls = g_client.controls,
+        desired_columns = g_client.desired_columns,
+        desired_rows = g_client.desired_rows,
+        sent_columns = g_client.sent_columns,
+        sent_rows = g_client.sent_rows,
         heap_bytes = int64(heap_bytes_allocated()),
         heap_total_bytes = int64(heap_total_allocated()),
         string_heap_bytes = int64(string_heap_bytes_allocated()),
@@ -3822,12 +4034,37 @@ def private draw_settings_window() {
     text_disabled("Repository registration and layout settings will be stored here.")
 }
 
-def private draw_session_launcher_window() {
+def private draw_session_launcher_dialog() {
     text("Codex debug session")
-    text_disabled("The selected worktree becomes the immutable session origin.")
+    text_disabled("The chosen worktree becomes the immutable session origin.")
     separator()
-    text("Repository: {g_selected_repository_id}")
-    text("Selected worktree: {g_selected_worktree_path}")
+    var inscope locations : array<AgentLaunchLocation>
+    collect_agent_launch_locations(locations)
+    var source_index = -1
+    for (index in range(length(locations))) {
+        if (locations[index].repository_id == g_agent_source_repository_id
+                && locations[index].worktree_path
+                    == g_agent_source_worktree_path) {
+            source_index = index
+            break
+        }
+    }
+    if (source_index < 0 && !empty(locations)) {
+        source_index = 0
+        set_agent_launch_source(locations[0].repository_id,
+            locations[0].worktree_path, true)
+    }
+    AGENT_SOURCE_WORKTREE.value = source_index
+    var source_labels <- [for (location in locations); location.display_label]
+    if (combo(AGENT_SOURCE_WORKTREE,
+            (text = "Start from", items <- source_labels,
+             popup_max_height_in_items = 12))
+            && AGENT_SOURCE_WORKTREE.value >= 0
+            && AGENT_SOURCE_WORKTREE.value < length(locations)) {
+        let selected & = unsafe(locations[AGENT_SOURCE_WORKTREE.value])
+        set_agent_launch_source(selected.repository_id,
+            selected.worktree_path, true)
+    }
     checkbox(CREATE_DEDICATED_WORKTREE, (text = "Create a dedicated worktree"))
     if (CREATE_DEDICATED_WORKTREE.value) {
         input_text_growable(AGENT_BRANCH, (text = "New branch"))
@@ -3840,22 +4077,28 @@ def private draw_session_launcher_window() {
          flags = ImGuiInputTextFlags.None))
     if (button(LAUNCH_CODEX_DEBUG,
             (text = "Launch Codex", enabled = g_client != null
-                && g_client.connected && !empty(g_selected_repository_id)
-                && !empty(g_selected_worktree_path)
+                && g_client.connected
+                && !empty(g_agent_source_repository_id)
+                && !empty(g_agent_source_worktree_path)
                 && (!CREATE_DEDICATED_WORKTREE.value
                     || (!empty(AGENT_BRANCH.value)
                         && !empty(AGENT_WORKTREE_PATH.value)))
                 && !empty(AGENT_TASK_CONTEXT.value)))) {
         if (CREATE_DEDICATED_WORKTREE.value) {
-            g_client->create_worktree_and_launch_codex(g_selected_worktree_path,
-                g_selected_repository_id, AGENT_WORKTREE_PATH.value,
+            g_client->create_worktree_and_launch_codex(
+                g_agent_source_worktree_path,
+                g_agent_source_repository_id, AGENT_WORKTREE_PATH.value,
                 AGENT_BRANCH.value, AGENT_BASE_REF.value,
                 AGENT_TASK_CONTEXT.value)
         } else {
-            g_client->launch_codex_debug(g_selected_worktree_path,
-                g_selected_repository_id, AGENT_TASK_CONTEXT.value)
+            g_client->launch_codex_debug(g_agent_source_worktree_path,
+                g_agent_source_repository_id, AGENT_TASK_CONTEXT.value)
         }
-        SESSION_LAUNCHER_WIN.open = false
+        close_current_popup(SESSION_LAUNCHER_DIALOG)
+    }
+    same_line()
+    if (button(CANCEL_CODEX_DEBUG, (text = "Cancel"))) {
+        close_current_popup(SESSION_LAUNCHER_DIALOG)
     }
 }
 
@@ -3875,6 +4118,7 @@ def private draw_terminal_window() {
     separator()
     let terminal_style = ImGuiTerminalStyle(
         external_input = true,
+        cell_backgrounds = false,
         view_height = max(GetTextLineHeight(),
             GetContentRegionAvail().y - GetFrameHeightWithSpacing()
                 - GetStyle().ItemSpacing.y))
@@ -3932,8 +4176,11 @@ def init() {
 
 [export]
 def update() {
-    if (!harness_begin_frame()) return
+    // The native frame gate returns false while the window is minimized.
+    // Keep the transport alive outside that gate so heartbeats, controller
+    // renewal, and queued PTY output continue until the window is restored.
     if (g_client != null) g_client->pump()
+    if (!harness_begin_frame()) return
     service_sha_copy()
     drain_inspector_prepare_events()
     harness_new_frame()
@@ -3941,8 +4188,25 @@ def update() {
     draw_main_menu()
     dockspace(DOCK_ROOT, (flags = ImGuiDockNodeFlags.PassthruCentralNode)) {
         if (!DOCK_ROOT.has_initial_layout && DOCK_ROOT.dock_id != 0u) {
-            setup_default_layout(DOCK_ROOT.dock_id)
-            DOCK_ROOT.has_initial_layout = true
+            if (g_layout_force_default) {
+                setup_default_layout(DOCK_ROOT.dock_id)
+                DOCK_ROOT.has_initial_layout = true
+                g_layout_probe_complete = true
+                g_layout_force_default = false
+            } elif (g_layout_probe_complete) {
+                let restored_layout = (REPOSITORIES_WIN.docked ||
+                    SESSIONS_WIN.docked || GIT_ACTIVITY_WIN.docked ||
+                    GIT_CHANGELIST_WIN.docked || FILE_INSPECTOR_WIN.docked ||
+                    TERMINAL_WIN.docked)
+                if (restored_layout) {
+                    DOCK_ROOT.has_initial_layout = true
+                } else {
+                    setup_default_layout(DOCK_ROOT.dock_id)
+                    DOCK_ROOT.has_initial_layout = true
+                }
+            } else {
+                g_layout_probe_complete = true
+            }
         }
         dock_window(REPOSITORIES_WIN, (text = "Repositories & Worktrees", closable = true,
                 flags = ImGuiWindowFlags.None)) {
@@ -3976,10 +4240,17 @@ def update() {
                 flags = ImGuiWindowFlags.None)) {
             draw_settings_window()
         }
-        dock_window(SESSION_LAUNCHER_WIN, (text = "Session Launcher", closable = true,
-                flags = ImGuiWindowFlags.None)) {
-            draw_session_launcher_window()
-        }
+    }
+    let viewport = GetMainViewport()
+    let center = float2(
+        viewport.Pos.x + viewport.Size.x * 0.5f,
+        viewport.Pos.y + viewport.Size.y * 0.5f)
+    SetNextWindowPos(center, ImGuiCond.Appearing, float2(0.5f, 0.5f))
+    SetNextWindowSize(float2(760.0f, 560.0f), ImGuiCond.Appearing)
+    popup_modal(SESSION_LAUNCHER_DIALOG,
+            (text = "Start Codex debug session", closable = true,
+             flags = ImGuiWindowFlags.None)) {
+        draw_session_launcher_dialog()
     }
     harness_end_frame()
 }
@@ -4019,8 +4290,13 @@ def shutdown() {
 def main() {
     init()
     while (!exit_requested()) {
+        let frame_started = ref_time_ticks()
         update()
         harness_maybe_collect_gc()
+        let frame_usec = int64(get_time_usec(frame_started))
+        if (frame_usec < 16000l) {
+            sleep(uint((16000l - frame_usec) / 1000l))
+        }
     }
     shutdown()
 }

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -131,6 +131,26 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(create_argv[7], "--")
         t |> equal(create_argv[8], absolute_worktree)
         t |> equal(create_argv[9], "origin/main")
+        let normalized_create_error = repository_build_worktree_create_argv(
+            "D:/Work/main", absolute_worktree, " codex/debug-fix ",
+            " origin/main ", create_argv)
+        t |> equal(normalized_create_error, "")
+        t |> equal(create_argv[6], "codex/debug-fix")
+        t |> equal(create_argv[9], "origin/main")
+        let default_base_error = repository_build_worktree_create_argv(
+            "D:/Work/main", absolute_worktree, "codex/debug-fix",
+            " \r\n ", create_argv)
+        t |> success(!empty(default_base_error),
+            "base refs containing CR/LF remain invalid after whitespace normalization")
+        let blank_base_error = repository_build_worktree_create_argv(
+            "D:/Work/main", absolute_worktree, "codex/debug-fix",
+            "   ", create_argv)
+        t |> equal(blank_base_error, "")
+        t |> equal(create_argv[9], "HEAD",
+            "a whitespace-only optional base ref keeps the default HEAD contract")
+        t |> success(!empty(repository_build_worktree_create_argv(
+            "D:/Work/main", absolute_worktree, "   ", "HEAD",
+            create_argv)), "whitespace-only worktree branches are rejected before Git")
         t |> success(!empty(repository_build_worktree_create_argv(
             "D:/Work/main", "relative/tree", "codex/debug-fix", "HEAD",
             create_argv)), "dedicated worktree creation requires an exact absolute target")

--- a/utils/dasHerd/watcher/tests/test_repository_core.das
+++ b/utils/dasHerd/watcher/tests/test_repository_core.das
@@ -116,6 +116,24 @@ def test_repository_untracked_diff_contract(t : T?) {
         t |> equal(argv[length(argv) - 2], "--file=staged.das")
         t |> equal(argv[length(argv) - 1],
             "--output=D:/Temp/staged-view.raw")
+
+        let absolute_worktree = (get_platform_name() == "windows"
+            ? "D:/Work/trees/debug" : "/tmp/work/trees/debug")
+        var create_argv : array<string>
+        let create_error = repository_build_worktree_create_argv(
+            "D:/Work/main", absolute_worktree, "codex/debug-fix",
+            "origin/main", create_argv)
+        t |> equal(create_error, "")
+        t |> equal(create_argv[0], "git")
+        t |> equal(create_argv[4], "add")
+        t |> equal(create_argv[5], "-b")
+        t |> equal(create_argv[6], "codex/debug-fix")
+        t |> equal(create_argv[7], "--")
+        t |> equal(create_argv[8], absolute_worktree)
+        t |> equal(create_argv[9], "origin/main")
+        t |> success(!empty(repository_build_worktree_create_argv(
+            "D:/Work/main", "relative/tree", "codex/debug-fix", "HEAD",
+            create_argv)), "dedicated worktree creation requires an exact absolute target")
     }
 }
 

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -135,6 +135,18 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(find(string(raw.bytes), "watcher-core-ok") >= 0, "raw PTY history can be replayed")
         let raw_tail <- watcher_output_since(quick.session_id, raw.next_offset)
         t |> equal(length(raw_tail.bytes), 0, "raw replay offset does not duplicate output")
+        let checkpoint <- watcher_terminal_checkpoint(quick.session_id)
+        t |> success(checkpoint.ok, "terminal checkpoint is available for a retained session")
+        t |> equal(checkpoint.output_offset, raw.next_offset,
+            "checkpoint starts subsequent raw delivery at the captured output offset")
+        var inscope restored <- terminal_create(checkpoint.columns, checkpoint.rows)
+        terminal_feed(restored, checkpoint.ansi)
+        var restored_viewport = TerminalViewportSnapshot()
+        terminal_viewport_snapshot(restored, 0, restored_viewport)
+        t |> success(find(restored_viewport.screen_text, "watcher-core-ok") >= 0,
+            "terminal checkpoint reconstructs the authoritative visible screen")
+        terminal_viewport_snapshot_dispose(restored_viewport)
+        terminal_dispose(restored)
         t |> success(fexist(path_join(path_join(path_join(root, "sessions"), quick.session_id), "output.raw")),
             "raw output log exists")
 
@@ -241,6 +253,20 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(first_bundle_marker >= 0 && find(updated_attention,
                 "\"bundle_id\":\"bundle-debug\"", first_bundle_marker + 1) < 0,
             "retry-safe bundle sync updates rather than duplicating Attention")
+        var draft_bundle := updated_bundle
+        draft_bundle.status = "draft"
+        let draft_result = watcher_bundle_sync(WatcherBundleSyncRequest(
+            session_id = quick.session_id, bundle := draft_bundle))
+        t |> success(draft_result.ok
+                && find(watcher_mailbox_json(quick.session_id, "outbox"),
+                    "\"status\":\"completed\"") >= 0,
+            "a draft bundle completes its projected Attention")
+        let republished_result = watcher_bundle_sync(WatcherBundleSyncRequest(
+            session_id = quick.session_id, bundle := updated_bundle))
+        t |> success(republished_result.ok
+                && find(watcher_mailbox_json(quick.session_id, "outbox"),
+                    "\"status\":\"new\"") >= 0,
+            "a draft-to-ready bundle transition reopens its projected Attention")
         let bundles_log = path_join(path_join(path_join(root, "sessions"),
             quick.session_id), "bundles.jsonl")
         t |> success(fexist(bundles_log)
@@ -255,7 +281,7 @@ def test_watcher_process_lifecycle(t : T?) {
             "argv echo script is written")
         let fake_codex_script = path_join(spaced_dir, "fake codex.ps1")
         t |> success(fwrite(fake_codex_script,
-            "[Console]::Write($env:DASHERD_SESSION_KIND + '|' + $env:DASHERD_SESSION_ID + '|' + $args.Count)"),
+            "[Console]::Write($env:DASHERD_SESSION_KIND + '|' + $env:DASHERD_SESSION_ID + '|' + $args.Count + '|' + ($args -join ' '))"),
             "fake Codex entry point is written")
         var fake_codex_argv <- ["powershell.exe", "-NoLogo", "-NoProfile",
             "-File", fake_codex_script]
@@ -272,14 +298,32 @@ def test_watcher_process_lifecycle(t : T?) {
         let agent_output = watcher_output_text(agent.session_id)
         t |> success(find(agent_output, "debug|{agent.session_id}|1") >= 0,
             "agent process receives purpose, watcher-assigned session id, and context prompt")
+        t |> success(find(agent_output, "Find the renderer crash") >= 0,
+            "agent process receives its assigned task in the initial prompt")
         let agent_dir = path_join(path_join(root, "sessions"), agent.session_id)
-        let agent_context = fread(path_join(agent_dir, "context.md"))
+        let agent_context_path = path_join(agent_dir, "context.md")
+        let agent_context = fread(agent_context_path)
         let agent_metadata = fread(path_join(agent_dir, "session.json"))
+        let agent_events = fread(path_join(agent_dir, "events.jsonl"))
         t |> success(find(agent_context, "Find the renderer crash") >= 0
                 && find(agent_context, "immutable session origin") >= 0,
             "watcher-authored agent context explains the task and cooperation contract")
+        t |> success(find(agent_events, "\"event\":\"session_created\"") >= 0
+                && find(agent_events, "; context=") >= 0
+                && find(agent_events, "context.md") >= 0
+                && fexist(agent_context_path),
+            "agent session creation advertises its durable context artifact")
         t |> success(find(agent_metadata, "secret-not-persisted") < 0,
             "session metadata never persists the watcher routing token")
+        var empty_agent_argv <- ["powershell.exe", "-NoLogo", "-NoProfile",
+            "-File", fake_codex_script]
+        let empty_agent = watcher_launch(WatcherLaunchRequest(argv <- empty_agent_argv,
+            cwd = root, display_name = "Empty Codex debug", kind = "agent-codex",
+            purpose = "debug", task_context = " \r\n ",
+            target_id = "local", repository_id = "test-repository",
+            worktree_path = root, columns = 80, rows = 20, timeout_ms = 5000l))
+        t |> success(!empty_agent.ok && empty_agent.error == "agent task is required",
+            "agent launch rejects a blank task before creating a session")
         var structured_argv <- ["powershell.exe", "-NoLogo", "-NoProfile", "-File", echo_script,
             "space value", "quote\"value", "trailing\\"]
         let structured = watcher_launch(WatcherLaunchRequest(argv <- structured_argv,
@@ -290,8 +334,13 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> success(wait_for(structured.session_id, "exited", 5000l),
             "structured argv command exits and drains")
         let structured_snapshot = watcher_snapshot_json(structured.session_id)
+        let structured_events = fread(path_join(path_join(path_join(root, "sessions"),
+            structured.session_id), "events.jsonl"))
         t |> success(find(structured_snapshot, "space value|quote\\\"value|trailing\\\\") >= 0,
             "structured argv preserves spaces, quotes, and trailing backslashes")
+        t |> success(find(structured_events, "\"event\":\"session_created\"") >= 0
+                && find(structured_events, "; context=") < 0,
+            "non-agent session creation does not claim a missing context artifact")
         t |> success(find(structured_snapshot, "\"worktree_path\":") >= 0,
             "session snapshot retains launch worktree association")
         var before_compact = WatcherSessionInfo()

--- a/utils/dasHerd/watcher/tests/test_watcher_core.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_core.das
@@ -189,12 +189,97 @@ def test_watcher_process_lifecycle(t : T?) {
                 && find(fread(mailbox_log), "acknowledged") >= 0,
             "mailbox create and state records are durable JSONL")
 
+        var first_participant = WatcherBundleParticipant(
+            repository_id = "repo-main", worktree_path = root,
+            role = "implementation", state = "modified")
+        first_participant.files |> push(WatcherBundleFile(
+            path = "src/main.das", role = "primary"))
+        var second_participant = WatcherBundleParticipant(
+            repository_id = "repo-render", worktree_path = path_join(root, "other-worktree"),
+            role = "dependency", state = "modified")
+        second_participant.files |> push(WatcherBundleFile(
+            path = "src/render.das", role = "risk"))
+        var first_bundle_target = WatcherFocusTarget(
+            repository_id = "repo-main", worktree_path = root,
+            comparison = "working", role = "primary", file_path = "src/main.das")
+        first_bundle_target.ranges |> push(WatcherFocusRange(
+            start_byte = 1, end_byte = 8, caption = "main loop"))
+        var second_bundle_target = WatcherFocusTarget(
+            repository_id = "repo-render", worktree_path = path_join(root, "other-worktree"),
+            comparison = "working", role = "risk", file_path = "src/render.das")
+        second_bundle_target.ranges |> push(WatcherFocusRange(
+            start_byte = 4, end_byte = 12, caption = "bug was here"))
+        var bundle = WatcherReviewBundle(id = "bundle-debug",
+            title = "Cross-repository debug fix", kind = "debug", status = "ready",
+            summary = "Two repositories participate in one review unit")
+        bundle.participants |> emplace(first_participant)
+        bundle.participants |> emplace(second_participant)
+        bundle.focus.targets |> emplace(first_bundle_target)
+        bundle.focus.targets |> emplace(second_bundle_target)
+        let bundle_result = watcher_bundle_sync(WatcherBundleSyncRequest(
+            session_id = quick.session_id, bundle := bundle))
+        t |> success(bundle_result.ok, bundle_result.error)
+        t |> equal(bundle_result.bundle_id, "bundle-debug")
+        let bundles_json = watcher_bundles_json(quick.session_id)
+        t |> success(find(bundles_json, "repo-main") >= 0
+                && find(bundles_json, "repo-render") >= 0
+                && find(bundles_json, "bug was here") >= 0,
+            "one durable review bundle spans repositories and exact focus ranges")
+        let bundle_attention = watcher_mailbox_json(quick.session_id, "outbox")
+        t |> success(find(bundle_attention, "\"bundle_id\":\"bundle-debug\"") >= 0
+                && find(bundle_attention, "\"kind\":\"bundle_focus\"") >= 0,
+            "a ready bundle projects one non-modal Attention message")
+        var updated_bundle := bundle
+        updated_bundle.summary = "Updated complete snapshot"
+        let updated_result = watcher_bundle_sync(WatcherBundleSyncRequest(
+            session_id = quick.session_id, bundle := updated_bundle))
+        t |> success(updated_result.ok && updated_result.revision > bundle_result.revision,
+            "bundle sync replaces the same logical bundle with a newer snapshot")
+        let updated_attention = watcher_mailbox_json(quick.session_id, "outbox")
+        let first_bundle_marker = find(updated_attention,
+            "\"bundle_id\":\"bundle-debug\"")
+        t |> success(first_bundle_marker >= 0 && find(updated_attention,
+                "\"bundle_id\":\"bundle-debug\"", first_bundle_marker + 1) < 0,
+            "retry-safe bundle sync updates rather than duplicating Attention")
+        let bundles_log = path_join(path_join(path_join(root, "sessions"),
+            quick.session_id), "bundles.jsonl")
+        t |> success(fexist(bundles_log)
+                && find(fread(bundles_log), "Updated complete snapshot") >= 0,
+            "bundle snapshots are durable JSONL")
+
         let spaced_dir = path_join(root, "argv space")
         var mkdir_error : string
         t |> success(mkdir_rec(spaced_dir, mkdir_error), mkdir_error)
         let echo_script = path_join(spaced_dir, "echo args.ps1")
         t |> success(fwrite(echo_script, "[Console]::Write(($args -join '|'))"),
             "argv echo script is written")
+        let fake_codex_script = path_join(spaced_dir, "fake codex.ps1")
+        t |> success(fwrite(fake_codex_script,
+            "[Console]::Write($env:DASHERD_SESSION_KIND + '|' + $env:DASHERD_SESSION_ID + '|' + $args.Count)"),
+            "fake Codex entry point is written")
+        var fake_codex_argv <- ["powershell.exe", "-NoLogo", "-NoProfile",
+            "-File", fake_codex_script]
+        let agent = watcher_launch(WatcherLaunchRequest(argv <- fake_codex_argv,
+            cwd = root, display_name = "Codex debug", kind = "agent-codex",
+            purpose = "debug", task_context = "Find the renderer crash",
+            agent_url = "http://127.0.0.1:9191", agent_token = "secret-not-persisted",
+            agent_skill_path = path_join(root, "dasherder.md"),
+            target_id = "local", repository_id = "test-repository",
+            worktree_path = root, columns = 80, rows = 20, timeout_ms = 5000l))
+        t |> success(agent.ok, agent.error)
+        t |> success(wait_for(agent.session_id, "exited", 5000l),
+            "agent bootstrap exits after the fake Codex process")
+        let agent_output = watcher_output_text(agent.session_id)
+        t |> success(find(agent_output, "debug|{agent.session_id}|1") >= 0,
+            "agent process receives purpose, watcher-assigned session id, and context prompt")
+        let agent_dir = path_join(path_join(root, "sessions"), agent.session_id)
+        let agent_context = fread(path_join(agent_dir, "context.md"))
+        let agent_metadata = fread(path_join(agent_dir, "session.json"))
+        t |> success(find(agent_context, "Find the renderer crash") >= 0
+                && find(agent_context, "immutable session origin") >= 0,
+            "watcher-authored agent context explains the task and cooperation contract")
+        t |> success(find(agent_metadata, "secret-not-persisted") < 0,
+            "session metadata never persists the watcher routing token")
         var structured_argv <- ["powershell.exe", "-NoLogo", "-NoProfile", "-File", echo_script,
             "space value", "quote\"value", "trailing\\"]
         let structured = watcher_launch(WatcherLaunchRequest(argv <- structured_argv,
@@ -292,6 +377,16 @@ def test_watcher_process_lifecycle(t : T?) {
         t |> equal(watcher_input(controlled.session_id, "\r", 12), "")
         let controlled_events = fread(path_join(path_join(path_join(root, "sessions"),
             controlled.session_id), "events.jsonl"))
+        t |> success(find(controlled_events, "\"sequence\":1") >= 0
+                && find(controlled_events, "\"wall_time_seconds\":") >= 0
+                && find(controlled_events, "\"state\":") >= 0
+                && find(controlled_events, "\"controller_id\":") >= 0,
+            "every event carries ordered time and reconstructible session/controller context")
+        t |> success(find(controlled_events, "\"event\":\"session_created\"") >= 0
+                && find(controlled_events, "\"event\":\"controller_claimed\"") >= 0
+                && find(controlled_events, "\"event\":\"controller_claim_rejected\"") >= 0
+                && find(controlled_events, "\"event\":\"controller_released\"") >= 0,
+            "controller contention and release are durably auditable")
         t |> success(find(controlled_events, "delivery=deferred") >= 0,
             "a deferred mailbox nudge records its eventual delivery")
         t |> success(find(controlled_events, "terminal_notification_queued") >= 0,

--- a/utils/dasHerd/watcher/tests/test_watcher_protocol.ps1
+++ b/utils/dasHerd/watcher/tests/test_watcher_protocol.ps1
@@ -182,6 +182,31 @@ function Read-SharedBytes([string]$Path) {
     }
 }
 
+function Get-ProcessTreeIds([int]$RootProcessId) {
+    $processes = @(Get-CimInstance Win32_Process)
+    $children = @{}
+    foreach ($process in $processes) {
+        $parent = [int]$process.ParentProcessId
+        if (-not $children.ContainsKey($parent)) {
+            $children[$parent] = New-Object Collections.Generic.List[int]
+        }
+        $children[$parent].Add([int]$process.ProcessId)
+    }
+    $result = New-Object Collections.Generic.List[int]
+    $pending = New-Object Collections.Generic.Queue[int]
+    $pending.Enqueue($RootProcessId)
+    while ($pending.Count -gt 0) {
+        $nextProcessId = $pending.Dequeue()
+        $result.Add($nextProcessId)
+        if ($children.ContainsKey($nextProcessId)) {
+            foreach ($childId in $children[$nextProcessId]) {
+                $pending.Enqueue($childId)
+            }
+        }
+    }
+    return @($result)
+}
+
 function Assert-OrderedEvents($Events, [string[]]$RequiredNames, [string]$Context) {
     Assert-Protocol ($Events.Count -gt 0) "$Context has no events"
     for ($index = 0; $index -lt $Events.Count; $index++) {
@@ -272,6 +297,22 @@ try {
     $ws1 = Connect-WebSocket $baseUrl $token
     Assert-Protocol ($ws1 -is [Net.WebSockets.ClientWebSocket]) `
         "websocket helper returned $($ws1.GetType().FullName)"
+    Set-TestStage 'reject-empty-agent-worktree-task'
+    $emptyTaskWorktree = "$agentWorktree-empty-task"
+    Send-WebSocketJson $ws1 @{
+        op = 'launch_agent_worktree'
+        repository_id = $observedA.record.id
+        worktree_path = $repoA
+        new_worktree_path = $emptyTaskWorktree
+        branch = "codex/$runId-empty-task"
+        base_ref = 'HEAD'
+        task_context = " `r`n "
+    }
+    $emptyTaskError = Wait-WebSocketType $ws1 'error' 5000
+    Assert-Protocol ($emptyTaskError.error -eq 'agent task is required') `
+        'blank worktree task did not return the agent-task validation error'
+    Assert-Protocol (-not (Test-Path -LiteralPath $emptyTaskWorktree)) `
+        'blank worktree task mutated Git before validation'
     Set-TestStage 'request-agent-worktree'
     Send-WebSocketJson $ws1 @{
         op = 'launch_agent_worktree'
@@ -294,10 +335,16 @@ try {
     Set-TestStage 'attach-first-controller'
     Send-WebSocketJson $ws1 @{
         op = 'attach'; session_id = $agentLaunch.session_id
-        control = $true; raw = $false
+        control = $true; raw = $true
     }
     $attached1 = Wait-WebSocketType $ws1 'attached'
     Assert-Protocol ([bool]$attached1.controls) 'first client did not receive control'
+    $checkpoint = Wait-WebSocketType $ws1 'terminal_checkpoint'
+    Assert-Protocol ([bool]$checkpoint.ansi) 'raw attach did not receive a terminal checkpoint'
+    Assert-Protocol ([int]$checkpoint.columns -gt 0 -and [int]$checkpoint.rows -gt 0) `
+        'terminal checkpoint did not retain its source geometry'
+    Assert-Protocol ([long]$checkpoint.offset -ge 0) `
+        'terminal checkpoint did not identify the subsequent raw output offset'
 
     Set-TestStage 'reject-second-controller'
     $ws2 = Connect-WebSocket $baseUrl $token
@@ -312,17 +359,14 @@ try {
     Assert-Protocol (-not [bool]$observing2.controls) `
         'second client unexpectedly received control'
 
-    Set-TestStage 'detach-and-reattach'
+    Set-TestStage 'detach-and-claim-without-replay'
     Send-WebSocketJson $ws1 @{ op = 'detach' }
     $detached1 = Wait-WebSocketType $ws1 'detached'
     Assert-Protocol ($detached1.type -eq 'detached') 'first client did not detach'
-    Send-WebSocketJson $ws2 @{
-        op = 'attach'; session_id = $agentLaunch.session_id
-        control = $true; raw = $false
-    }
+    Send-WebSocketJson $ws2 @{ op = 'claim_control' }
     $attached2 = Wait-WebSocketType $ws2 'attached'
     Assert-Protocol ([bool]$attached2.controls) `
-        'observing client could not claim control after detach'
+        'observing client could not claim control after detach without replay'
 
     Set-TestStage 'disconnect-release'
     Close-WebSocket $ws2
@@ -443,9 +487,75 @@ try {
         'bundle JSONL did not retain both declarative snapshots'
 
     Set-TestStage 'terminate-agent'
+    $launchedEvent = @($agentEvents | Where-Object {
+        $_.event -eq 'launched'
+    } | Select-Object -First 1)
+    $launchedPid = [regex]::Match(
+        [string]$launchedEvent[0].detail, '^pid=(\d+)$')
+    Assert-Protocol $launchedPid.Success 'launch event did not retain the root process id'
+    $agentProcessTree = @(Get-ProcessTreeIds ([int]$launchedPid.Groups[1].Value))
+    Assert-Protocol ($agentProcessTree.Count -gt 1) `
+        'fake Codex did not have a descendant process for termination coverage'
     Invoke-Json POST $baseUrl $token '/api/v1/terminate' @{
         session_id = $agentLaunch.session_id
     } | Out-Null
+    for ($attempt = 0; $attempt -lt 100; $attempt++) {
+        $remainingProcessTree = @($agentProcessTree | Where-Object {
+            $null -ne (Get-Process -Id $_ -ErrorAction SilentlyContinue)
+        })
+        if ($remainingProcessTree.Count -eq 0) { break }
+        Start-Sleep -Milliseconds 50
+    }
+    Assert-Protocol ($remainingProcessTree.Count -eq 0) `
+        "terminate left session process descendants running: $remainingProcessTree"
+
+    Set-TestStage 'launch-agent-in-existing-worktree'
+    Send-WebSocketJson $ws1 @{
+        op = 'launch'
+        argv = @('codex')
+        cwd = $repoB
+        columns = 120
+        rows = 36
+        timeout_ms = 0
+        display_name = 'Codex existing worktree'
+        kind = 'agent-codex'
+        purpose = 'debug'
+        task_context = 'Launch directly in the selected existing worktree.'
+        target_id = 'local'
+        repository_id = $observedB.record.id
+        worktree_path = $repoB
+    }
+    $existingLaunch = Wait-WebSocketType $ws1 'launched' 10000
+    Assert-Protocol ([bool]$existingLaunch.session_id) `
+        'existing-worktree agent session was not launched'
+    $existingDir = Join-Path $watcherSessions $existingLaunch.session_id
+    $existingMetadataPath = Join-Path $existingDir 'session.json'
+    for ($attempt = 0; $attempt -lt 100 -and
+            -not (Test-Path -LiteralPath $existingMetadataPath); $attempt++) {
+        Start-Sleep -Milliseconds 50
+    }
+    Assert-Protocol (Test-Path -LiteralPath $existingMetadataPath) `
+        'existing-worktree session metadata was not persisted'
+    $existingMetadata = Get-Content -LiteralPath $existingMetadataPath -Raw |
+        ConvertFrom-Json
+    Assert-Protocol ($existingMetadata.kind -eq 'agent-codex') `
+        'existing-worktree launch lost its agent kind'
+    Assert-Protocol ($existingMetadata.repository_id -eq $observedB.record.id) `
+        'existing-worktree launch lost its repository identity'
+    Assert-Protocol ([string]::Equals(
+            [IO.Path]::GetFullPath([string]$existingMetadata.worktree_path),
+            [IO.Path]::GetFullPath($repoB),
+            [StringComparison]::OrdinalIgnoreCase)) `
+        'existing-worktree launch lost its exact worktree origin'
+    $existingContextPath = Join-Path $existingDir 'context.md'
+    $existingContext = Get-Content -LiteralPath $existingContextPath -Raw
+    Assert-Protocol ($existingContext.Contains(
+            'Launch directly in the selected existing worktree.')) `
+        'existing-worktree launch lost its task context'
+    Invoke-Json POST $baseUrl $token '/api/v1/terminate' @{
+        session_id = $existingLaunch.session_id
+    } | Out-Null
+
     $success = $true
     Write-Output "PASS watcher protocol integration: $runId"
 } catch {

--- a/utils/dasHerd/watcher/tests/test_watcher_protocol.ps1
+++ b/utils/dasHerd/watcher/tests/test_watcher_protocol.ps1
@@ -1,0 +1,478 @@
+param(
+    [Parameter(Mandatory = $true)][string]$DaslangPath,
+    [Parameter(Mandatory = $true)][string]$Root
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2
+$script:stage = 'initializing'
+$script:harnessLog = $null
+
+function Set-TestStage([string]$Name) {
+    $script:stage = $Name
+    if ($script:harnessLog) {
+        Add-Content -LiteralPath $script:harnessLog -Encoding UTF8 `
+            -Value ("{0:o} {1}" -f [DateTimeOffset]::UtcNow, $Name)
+    }
+}
+
+function Assert-Protocol([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw "ASSERT: $Message" }
+}
+
+function Invoke-Json([string]$Method, [string]$BaseUrl, [string]$Token,
+                     [string]$Path, $Body = $null) {
+    $separator = '?'
+    if ($Path.Contains('?')) { $separator = '&' }
+    $parameters = @{
+        Method = $Method
+        Uri = "$BaseUrl$Path${separator}token=$([uri]::EscapeDataString($Token))"
+    }
+    if ($null -ne $Body) {
+        $parameters.ContentType = 'application/json; charset=utf-8'
+        $parameters.Body = $Body | ConvertTo-Json -Depth 30 -Compress
+    }
+    return Invoke-RestMethod @parameters
+}
+
+function Send-WebSocketJson([System.Net.WebSockets.ClientWebSocket]$Socket, $Value) {
+    $json = $Value | ConvertTo-Json -Depth 30 -Compress
+    $bytes = [Text.Encoding]::UTF8.GetBytes($json)
+    $segment = New-Object 'System.ArraySegment[byte]' -ArgumentList @(,$bytes)
+    $send = $Socket.SendAsync($segment, [Net.WebSockets.WebSocketMessageType]::Text,
+        $true, [Threading.CancellationToken]::None)
+    if (-not $send.Wait(5000)) {
+        $Socket.Abort()
+        throw 'timed out sending websocket message'
+    }
+    [void]($send.GetAwaiter().GetResult())
+}
+
+function Receive-WebSocketJson([System.Net.WebSockets.ClientWebSocket]$Socket,
+                               [int]$TimeoutMs = 5000) {
+    $buffer = New-Object byte[] 65536
+    $stream = New-Object IO.MemoryStream
+    try {
+        do {
+            $segment = New-Object 'System.ArraySegment[byte]' -ArgumentList @(,$buffer)
+            $receive = $Socket.ReceiveAsync($segment,
+                [Threading.CancellationToken]::None)
+            if (-not $receive.Wait($TimeoutMs)) {
+                $Socket.Abort()
+                throw "timed out receiving websocket message after ${TimeoutMs}ms"
+            }
+            $result = $receive.GetAwaiter().GetResult()
+            if ($result.MessageType -eq [Net.WebSockets.WebSocketMessageType]::Close) {
+                throw 'websocket closed while awaiting a message'
+            }
+            if ($result.Count -gt 0) { $stream.Write($buffer, 0, $result.Count) }
+        } while (-not $result.EndOfMessage)
+        Assert-Protocol ($result.MessageType -eq [Net.WebSockets.WebSocketMessageType]::Text) `
+            'unexpected binary websocket frame'
+        $text = [Text.Encoding]::UTF8.GetString($stream.ToArray())
+        return $text | ConvertFrom-Json
+    } finally {
+        $stream.Dispose()
+    }
+}
+
+function Wait-WebSocketType([System.Net.WebSockets.ClientWebSocket]$Socket,
+                            [string]$Type, [int]$TimeoutMs = 10000) {
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    while ($timer.ElapsedMilliseconds -lt $TimeoutMs) {
+        $remaining = [Math]::Max(100, $TimeoutMs - [int]$timer.ElapsedMilliseconds)
+        $message = Receive-WebSocketJson $Socket $remaining
+        if ($message.type -eq $Type) { return $message }
+    }
+    throw "timed out waiting for websocket message '$Type'"
+}
+
+function Connect-WebSocket([string]$BaseUrl, [string]$Token) {
+    $socket = New-Object Net.WebSockets.ClientWebSocket
+    $uri = [uri]($BaseUrl.Replace('http://', 'ws://') +
+        "/ws?token=$([uri]::EscapeDataString($Token))")
+    [void]($socket.ConnectAsync($uri,
+        [Threading.CancellationToken]::None).GetAwaiter().GetResult())
+    $connected = Wait-WebSocketType $socket 'connected'
+    Assert-Protocol ($connected.client_id -gt 0) 'websocket client id was not assigned'
+    return $socket
+}
+
+function Close-WebSocket([System.Net.WebSockets.ClientWebSocket]$Socket) {
+    if ($null -eq $Socket) { return }
+    try {
+        if ($Socket.State -eq [Net.WebSockets.WebSocketState]::Open) {
+            $close = $Socket.CloseOutputAsync(
+                [Net.WebSockets.WebSocketCloseStatus]::NormalClosure,
+                'test complete', [Threading.CancellationToken]::None)
+            if (-not $close.Wait(2000)) {
+                $Socket.Abort()
+            }
+        }
+    } catch {
+        $Socket.Abort()
+    } finally {
+        $Socket.Dispose()
+    }
+}
+
+function Initialize-TestRepository([string]$Path, [string]$FileName, [string]$Contents) {
+    New-Item -ItemType Directory -Force -Path $Path | Out-Null
+    & git -C $Path init --quiet
+    if ($LASTEXITCODE -ne 0) { throw "git init failed for $Path" }
+    & git -C $Path config user.email 'dasherd-test@example.invalid'
+    & git -C $Path config user.name 'dasHerd Test'
+    & git -C $Path config core.autocrlf false
+    [IO.File]::WriteAllText((Join-Path $Path $FileName), $Contents,
+        ([Text.UTF8Encoding]::new($false)))
+    & git -C $Path add -- $FileName
+    & git -C $Path commit --quiet -m initial
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed for $Path" }
+}
+
+function Wait-Repository([string]$BaseUrl, [string]$Token, [string]$CheckoutPath,
+                         [string]$RequiredWorktree = '') {
+    $wanted = [IO.Path]::GetFullPath([string]$CheckoutPath)
+    for ($attempt = 0; $attempt -lt 150; $attempt++) {
+        $repositories = Invoke-Json GET $BaseUrl $Token '/api/v1/repositories'
+        foreach ($repository in $repositories) {
+            $observedPath = [string]$repository.record.checkout_path
+            if ([string]::IsNullOrWhiteSpace($observedPath)) { continue }
+            try {
+                $observedFullPath = [IO.Path]::GetFullPath($observedPath)
+            } catch {
+                Add-Content -LiteralPath $script:harnessLog -Encoding UTF8 -Value `
+                    "ignored malformed repository checkout_path=$($observedPath | ConvertTo-Json -Compress)"
+                continue
+            }
+            if (-not [string]::Equals($observedFullPath,
+                    $wanted, [StringComparison]::OrdinalIgnoreCase)) { continue }
+            if ([bool]$repository.refreshing -or $repository.worktrees.Count -eq 0) {
+                continue
+            }
+            if (-not $RequiredWorktree) { return $repository }
+            foreach ($worktree in $repository.worktrees) {
+                $observedWorktreePath = [string]$worktree.path
+                if ([string]::IsNullOrWhiteSpace($observedWorktreePath)) { continue }
+                if ([string]::Equals([IO.Path]::GetFullPath($observedWorktreePath),
+                        [IO.Path]::GetFullPath($RequiredWorktree),
+                        [StringComparison]::OrdinalIgnoreCase)) { return $repository }
+            }
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    throw "repository/worktree was not observed: $CheckoutPath :: $RequiredWorktree"
+}
+
+function Read-JsonLines([string]$Path) {
+    return @(Get-Content -LiteralPath $Path -Encoding UTF8 |
+        Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+}
+
+function Read-SharedBytes([string]$Path) {
+    $file = [IO.File]::Open($Path, [IO.FileMode]::Open, [IO.FileAccess]::Read,
+        [IO.FileShare]::ReadWrite)
+    $memory = New-Object IO.MemoryStream
+    try {
+        $file.CopyTo($memory)
+        return $memory.ToArray()
+    } finally {
+        $memory.Dispose()
+        $file.Dispose()
+    }
+}
+
+function Assert-OrderedEvents($Events, [string[]]$RequiredNames, [string]$Context) {
+    Assert-Protocol ($Events.Count -gt 0) "$Context has no events"
+    for ($index = 0; $index -lt $Events.Count; $index++) {
+        Assert-Protocol ($Events[$index].sequence -eq $index + 1) `
+            "$Context event sequence is not contiguous"
+        Assert-Protocol ($Events[$index].wall_time_seconds -gt 0) `
+            "$Context event has no wall clock"
+        Assert-Protocol ($null -ne $Events[$index].state) "$Context event has no state"
+        Assert-Protocol ($null -ne $Events[$index].worktree_path) `
+            "$Context event has no worktree identity"
+        Assert-Protocol ($null -ne $Events[$index].controller_id) `
+            "$Context event has no controller identity"
+    }
+    $names = @($Events | ForEach-Object { $_.event })
+    foreach ($required in $RequiredNames) {
+        Assert-Protocol ($names -contains $required) "$Context is missing event '$required'"
+    }
+}
+
+$runId = "protocol-$PID-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())"
+$fixtureRoot = Join-Path $Root "tmp/dasHerd/$runId"
+$logRoot = Join-Path $Root "logs/dasHerd/integration/$runId"
+$repoA = Join-Path $fixtureRoot 'repo-a'
+$repoB = Join-Path $fixtureRoot 'repo-b'
+$agentWorktree = Join-Path $fixtureRoot 'repo-a-agent'
+$fakeBin = Join-Path $fixtureRoot 'fake-bin'
+$watcherSessions = Join-Path $logRoot 'sessions'
+$watcherStdout = Join-Path $logRoot 'watcher.stdout.log'
+$watcherStderr = Join-Path $logRoot 'watcher.stderr.log'
+$script:harnessLog = Join-Path $logRoot 'harness.log'
+$configPath = Join-Path $logRoot 'config.json'
+$manifestPath = Join-Path $fixtureRoot 'bundle.json'
+$token = "token-$runId"
+$port = 9300 + ($PID % 300)
+$baseUrl = "http://127.0.0.1:$port"
+$watcher = $null
+$ws1 = $null
+$ws2 = $null
+$ws3 = $null
+$success = $false
+$failure = $null
+$oldPath = $env:PATH
+$unicodeName = 'unicode-' + (-join ([char[]](0x041f, 0x0440, 0x0438,
+    0x0432, 0x0435, 0x0442))) + '.txt'
+
+try {
+    New-Item -ItemType Directory -Force -Path $fixtureRoot, $logRoot, $fakeBin | Out-Null
+    Set-TestStage 'create-fixtures'
+    Initialize-TestRepository $repoA 'main.txt' "alpha`n"
+    Initialize-TestRepository $repoB $unicodeName "beta`n"
+    [IO.File]::WriteAllText((Join-Path $fakeBin 'codex.cmd'),
+        "@echo off`r`necho fake-codex^|%DASHERD_SESSION_KIND%^|%DASHERD_SESSION_ID%^|%DASHERD_CONTEXT_PATH%`r`nping 127.0.0.1 -n 16 >nul`r`n",
+        [Text.Encoding]::ASCII)
+
+    Set-TestStage 'launch-watcher'
+    $env:PATH = "$fakeBin;$oldPath"
+    $watcherArgs = @('-jit', 'utils/dasHerd/watcher/main.das', '--',
+        "--port=$port", "--token=$token", "--log-root=$watcherSessions",
+        "--config=$configPath", '--exit-after-ms=60000')
+    $watcher = Start-Process -FilePath $DaslangPath -ArgumentList $watcherArgs `
+        -WorkingDirectory $Root -WindowStyle Hidden -RedirectStandardOutput $watcherStdout `
+        -RedirectStandardError $watcherStderr -PassThru
+    $env:PATH = $oldPath
+
+    Set-TestStage 'wait-health'
+    $healthy = $false
+    for ($attempt = 0; $attempt -lt 200; $attempt++) {
+        try {
+            $health = Invoke-Json GET $baseUrl $token '/api/v1/health'
+            if ($health.ok) { $healthy = $true; break }
+        } catch {
+            Start-Sleep -Milliseconds 100
+        }
+    }
+    Assert-Protocol $healthy "watcher did not start; logs: $logRoot"
+
+    Set-TestStage 'register-repositories'
+    Invoke-Json POST $baseUrl $token '/api/v1/repositories' @{
+        path = $repoA; display_name = 'Protocol A'; target_id = 'local'
+    } | Out-Null
+    Invoke-Json POST $baseUrl $token '/api/v1/repositories' @{
+        path = $repoB; display_name = 'Protocol B'; target_id = 'local'
+    } | Out-Null
+    $observedA = Wait-Repository $baseUrl $token $repoA
+    $observedB = Wait-Repository $baseUrl $token $repoB
+
+    Set-TestStage 'launch-agent-worktree'
+    $ws1 = Connect-WebSocket $baseUrl $token
+    Assert-Protocol ($ws1 -is [Net.WebSockets.ClientWebSocket]) `
+        "websocket helper returned $($ws1.GetType().FullName)"
+    Set-TestStage 'request-agent-worktree'
+    Send-WebSocketJson $ws1 @{
+        op = 'launch_agent_worktree'
+        repository_id = $observedA.record.id
+        worktree_path = $repoA
+        new_worktree_path = $agentWorktree
+        branch = "codex/$runId"
+        base_ref = 'HEAD'
+        task_context = 'Diagnose the deterministic two-repository protocol fixture.'
+    }
+    $setupLaunch = Wait-WebSocketType $ws1 'launched' 15000
+    Assert-Protocol ([bool]$setupLaunch.session_id) 'worktree task session was not launched'
+    $agentLaunch = Wait-WebSocketType $ws1 'launched' 15000
+    Assert-Protocol ([bool]$agentLaunch.session_id) 'agent session was not launched'
+    Assert-Protocol ($agentLaunch.session_id -ne $setupLaunch.session_id) `
+        'worktree task and agent reused one session identity'
+    Set-TestStage 'wait-agent-worktree-observed'
+    $observedA = Wait-Repository $baseUrl $token $repoA $agentWorktree
+
+    Set-TestStage 'attach-first-controller'
+    Send-WebSocketJson $ws1 @{
+        op = 'attach'; session_id = $agentLaunch.session_id
+        control = $true; raw = $false
+    }
+    $attached1 = Wait-WebSocketType $ws1 'attached'
+    Assert-Protocol ([bool]$attached1.controls) 'first client did not receive control'
+
+    Set-TestStage 'reject-second-controller'
+    $ws2 = Connect-WebSocket $baseUrl $token
+    Send-WebSocketJson $ws2 @{
+        op = 'attach'; session_id = $agentLaunch.session_id
+        control = $true; raw = $false
+    }
+    $contention = Wait-WebSocketType $ws2 'error'
+    Assert-Protocol ($contention.error -match 'controller lease') `
+        'second controller did not receive a lease error'
+    $observing2 = Wait-WebSocketType $ws2 'attached'
+    Assert-Protocol (-not [bool]$observing2.controls) `
+        'second client unexpectedly received control'
+
+    Set-TestStage 'detach-and-reattach'
+    Send-WebSocketJson $ws1 @{ op = 'detach' }
+    $detached1 = Wait-WebSocketType $ws1 'detached'
+    Assert-Protocol ($detached1.type -eq 'detached') 'first client did not detach'
+    Send-WebSocketJson $ws2 @{
+        op = 'attach'; session_id = $agentLaunch.session_id
+        control = $true; raw = $false
+    }
+    $attached2 = Wait-WebSocketType $ws2 'attached'
+    Assert-Protocol ([bool]$attached2.controls) `
+        'observing client could not claim control after detach'
+
+    Set-TestStage 'disconnect-release'
+    Close-WebSocket $ws2
+    $ws2 = $null
+    Start-Sleep -Milliseconds 300
+    $ws3 = Connect-WebSocket $baseUrl $token
+    Send-WebSocketJson $ws3 @{
+        op = 'attach'; session_id = $agentLaunch.session_id
+        control = $true; raw = $false
+    }
+    $attached3 = Wait-WebSocketType $ws3 'attached'
+    Assert-Protocol ([bool]$attached3.controls) `
+        'socket close did not release the controller lease'
+    Send-WebSocketJson $ws3 @{ op = 'detach' }
+    Wait-WebSocketType $ws3 'detached' | Out-Null
+
+    Set-TestStage 'sync-two-repository-bundle'
+    $manifest = [ordered]@{
+        id = 'protocol-two-repository'
+        title = 'Protocol two-repository review'
+        kind = 'debug'
+        status = 'ready'
+        summary = 'First complete snapshot'
+        participants = @(
+            [ordered]@{
+                repository_id = $observedA.record.id
+                worktree_path = $agentWorktree
+                role = 'implementation'; state = 'modified'
+                files = @([ordered]@{ path = 'main.txt'; role = 'primary' })
+            },
+            [ordered]@{
+                repository_id = $observedB.record.id
+                worktree_path = $repoB
+                role = 'dependency'; state = 'modified'
+                files = @([ordered]@{
+                    path = $unicodeName; role = 'risk'
+                })
+            }
+        )
+        focus = [ordered]@{
+            targets = @(
+                [ordered]@{
+                    repository_id = $observedA.record.id
+                    worktree_path = $agentWorktree; comparison = 'working'
+                    role = 'primary'; file_path = 'main.txt'; whole_file = $true
+                    ranges = @()
+                },
+                [ordered]@{
+                    repository_id = $observedB.record.id
+                    worktree_path = $repoB; comparison = 'working'
+                    role = 'risk'; file_path = $unicodeName
+                    whole_file = $false
+                    ranges = @([ordered]@{
+                        start_byte = 0; end_byte = 4; caption = 'cross-repository risk'
+                    })
+                }
+            )
+        }
+    }
+    [IO.File]::WriteAllText($manifestPath,
+        ($manifest | ConvertTo-Json -Depth 30), ([Text.UTF8Encoding]::new($false)))
+    $env:DASHERD_URL = $baseUrl
+    $env:DASHERD_TOKEN = $token
+    $env:DASHERD_SESSION_ID = $agentLaunch.session_id
+    $cli = Join-Path $Root 'utils/dasHerd/dasherd.ps1'
+    $syncOutput = @(& powershell.exe -NoProfile -File $cli bundle sync `
+        --manifest $manifestPath 2>&1)
+    Assert-Protocol ($LASTEXITCODE -eq 0) "bundle sync failed: $($syncOutput -join "`n")"
+    $sync = ($syncOutput -join "`n") | ConvertFrom-Json
+    Assert-Protocol ([bool]$sync.ok) 'bundle sync did not return success'
+    $manifest.summary = 'Replacement complete snapshot'
+    [IO.File]::WriteAllText($manifestPath,
+        ($manifest | ConvertTo-Json -Depth 30), ([Text.UTF8Encoding]::new($false)))
+    $syncAgain = @(& powershell.exe -NoProfile -File $cli bundle sync `
+        --manifest $manifestPath 2>&1)
+    Assert-Protocol ($LASTEXITCODE -eq 0) `
+        "replacement bundle sync failed: $($syncAgain -join "`n")"
+    Remove-Item Env:DASHERD_URL, Env:DASHERD_TOKEN, Env:DASHERD_SESSION_ID `
+        -ErrorAction SilentlyContinue
+
+    Set-TestStage 'assert-api-state'
+    $bundles = Invoke-Json GET $baseUrl $token `
+        "/api/v1/bundles?session_id=$([uri]::EscapeDataString($agentLaunch.session_id))"
+    $attention = Invoke-Json GET $baseUrl $token `
+        "/api/v1/mailbox?session_id=$([uri]::EscapeDataString($agentLaunch.session_id))&direction=outbox"
+    Assert-Protocol (@($bundles).Count -eq 1) 'bundle replacement created a duplicate bundle'
+    Assert-Protocol ($bundles[0].participants.Count -eq 2) `
+        'bundle did not retain both repository participants'
+    Assert-Protocol ($bundles[0].summary -eq 'Replacement complete snapshot') `
+        'bundle replacement did not install the complete snapshot'
+    Assert-Protocol (@($attention).Count -eq 1) 'bundle replacement duplicated Attention'
+    Assert-Protocol ($attention[0].focus.targets.Count -eq 2) `
+        'Attention did not retain both repository targets'
+
+    Set-TestStage 'assert-durable-logs'
+    $agentDir = Join-Path $watcherSessions $agentLaunch.session_id
+    $setupDir = Join-Path $watcherSessions $setupLaunch.session_id
+    $agentEvents = Read-JsonLines (Join-Path $agentDir 'events.jsonl')
+    $setupEvents = Read-JsonLines (Join-Path $setupDir 'events.jsonl')
+    Assert-OrderedEvents $setupEvents @('session_created', 'agent_worktree_queued',
+        'agent_worktree_created', 'agent_launch_started') 'worktree setup session'
+    Assert-OrderedEvents $agentEvents @('session_created', 'agent_bootstrap_prepared',
+        'client_attached', 'controller_claimed', 'controller_claim_rejected',
+        'controller_released', 'client_detached', 'bundle_synced',
+        'bundle_attention_created', 'bundle_attention_updated') 'agent session'
+    $rawOutput = [Text.Encoding]::UTF8.GetString(
+        (Read-SharedBytes (Join-Path $agentDir 'output.raw')))
+    Assert-Protocol ($rawOutput -match [regex]::Escape($agentLaunch.session_id)) `
+        'fake Codex did not receive the watcher-assigned session id'
+    Assert-Protocol ($rawOutput -match 'fake-codex\|debug\|') `
+        'fake Codex did not receive the debug purpose'
+    $metadata = [IO.File]::ReadAllText((Join-Path $agentDir 'session.json'))
+    $context = [IO.File]::ReadAllText((Join-Path $agentDir 'context.md'))
+    Assert-Protocol (-not $metadata.Contains($token)) 'routing token leaked into session metadata'
+    Assert-Protocol ($context.Contains('Diagnose the deterministic two-repository protocol fixture.')) `
+        'agent context did not retain the debug task'
+    Assert-Protocol ((Read-JsonLines (Join-Path $agentDir 'bundles.jsonl')).Count -eq 2) `
+        'bundle JSONL did not retain both declarative snapshots'
+
+    Set-TestStage 'terminate-agent'
+    Invoke-Json POST $baseUrl $token '/api/v1/terminate' @{
+        session_id = $agentLaunch.session_id
+    } | Out-Null
+    $success = $true
+    Write-Output "PASS watcher protocol integration: $runId"
+} catch {
+    $failure = "stage=$script:stage`n$($_.Exception.ToString())`n$($_.ScriptStackTrace)"
+    if ($script:harnessLog) {
+        Add-Content -LiteralPath $script:harnessLog -Encoding UTF8 -Value $failure
+    }
+    [Console]::Error.WriteLine(
+        "$failure`nPreserved diagnostics: $logRoot`nPreserved fixtures: $fixtureRoot")
+    if (Test-Path $watcherStderr) {
+        [Console]::Error.WriteLine(
+            (Get-Content -LiteralPath $watcherStderr -Raw -ErrorAction SilentlyContinue))
+    }
+} finally {
+    $env:PATH = $oldPath
+    Remove-Item Env:DASHERD_URL, Env:DASHERD_TOKEN, Env:DASHERD_SESSION_ID `
+        -ErrorAction SilentlyContinue
+    Close-WebSocket $ws1
+    Close-WebSocket $ws2
+    Close-WebSocket $ws3
+    if ($null -ne $watcher -and -not $watcher.HasExited) {
+        Stop-Process -Id $watcher.Id -Force
+        [void]$watcher.WaitForExit(5000)
+    }
+    if ($success) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+        Remove-Item -LiteralPath $logRoot -Recurse -Force
+    }
+}
+if ($null -ne $failure) { exit 1 }

--- a/utils/dasHerd/watcher/tests/test_watcher_protocol_integration.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_protocol_integration.das
@@ -13,7 +13,7 @@ def private run_protocol_test(var output : string&) : int {
     }
     let script = path_join(root,
         "utils/dasHerd/watcher/tests/test_watcher_protocol.ps1")
-    var argv <- ["powershell.exe", "-NoLogo", "-NoProfile",
+    let argv <- ["powershell.exe", "-NoLogo", "-NoProfile",
         "-ExecutionPolicy", "Bypass", "-File", script,
         "-DaslangPath", compiler, "-Root", root]
     return unsafe(popen_argv(argv, 0.0, $(file) {

--- a/utils/dasHerd/watcher/tests/test_watcher_protocol_integration.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_protocol_integration.das
@@ -1,0 +1,36 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/fio
+require strings
+
+def private run_protocol_test(var output : string&) : int {
+    let root = get_das_root()
+    var compiler = path_join(root, "bin/Release/daslang.exe")
+    if (!fexist(compiler)) {
+        let args <- get_command_line_arguments()
+        compiler = empty(args) ? "daslang.exe" : args[0]
+    }
+    let script = path_join(root,
+        "utils/dasHerd/watcher/tests/test_watcher_protocol.ps1")
+    var argv <- ["powershell.exe", "-NoLogo", "-NoProfile",
+        "-ExecutionPolicy", "Bypass", "-File", script,
+        "-DaslangPath", compiler, "-Root", root]
+    return unsafe(popen_argv(argv, 0.0, $(file) {
+        if (file != null) {
+            output = unsafe(fread_to_eof(file))
+        }
+    }))
+}
+
+[test]
+def test_watcher_protocol_integration(t : T?) {
+    if (get_platform_name() != "windows") return
+    t |> run("two-repository session survives attach, detach, and controller handoff") <| @(t : T?) {
+        var output : string
+        let exit_code = run_protocol_test(output)
+        t |> equal(exit_code, 0, output)
+        t |> success(find(output, "PASS watcher protocol integration:") >= 0,
+            "protocol harness did not report success: {output}")
+    }
+}

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -43,6 +43,11 @@ struct public WatcherLaunchRequest {
     target_id : string = "local"
     repository_id : string
     worktree_path : string
+    purpose : string
+    task_context : string
+    agent_url : string
+    agent_token : string
+    agent_skill_path : string
     columns : int = 100
     rows : int = 30
     timeout_ms : int64
@@ -74,6 +79,11 @@ struct public WatcherFocusRange {
 }
 
 struct public WatcherFocusTarget {
+    repository_id : string
+    worktree_path : string
+    comparison : string
+    revision : string
+    role : string
     file_path : string
     whole_file : bool
     ranges : array<WatcherFocusRange>
@@ -95,6 +105,7 @@ struct public WatcherMailboxPostRequest {
     kind : string = "note"
     subject : string
     reply_to : string
+    bundle_id : string
     notify : bool = true
     focus : WatcherFocusSet = WatcherFocusSet()
 }
@@ -113,6 +124,7 @@ struct public WatcherMailboxMessage {
     kind : string
     subject : string
     reply_to : string
+    bundle_id : string
     status : string = "new"
     notified : bool
     notification_error : string
@@ -129,16 +141,65 @@ struct public WatcherMailboxResult {
     error : string
 }
 
+struct public WatcherBundleFile {
+    path : string
+    role : string
+}
+
+struct public WatcherBundleParticipant {
+    repository_id : string
+    worktree_path : string
+    role : string
+    base_revision : string
+    head_revision : string
+    state : string
+    files : array<WatcherBundleFile>
+}
+
+struct public WatcherReviewBundle {
+    id : string
+    session_id : string
+    title : string
+    kind : string = "change"
+    status : string = "draft"
+    summary : string
+    revision : int64
+    updated_ms : int64
+    participants : array<WatcherBundleParticipant>
+    focus : WatcherFocusSet = WatcherFocusSet()
+}
+
+struct public WatcherBundleSyncRequest {
+    session_id : string
+    bundle : WatcherReviewBundle = WatcherReviewBundle()
+}
+
+struct public WatcherBundleResult {
+    ok : bool
+    bundle_id : string
+    revision : int64
+    error : string
+}
+
 struct private WatcherPendingNotification {
     message_id : string
     text : string
 }
 
 struct public WatcherEvent {
+    sequence : int64
+    wall_time_seconds : int64
     session_id : string
     event : string
     elapsed_ms : int64
     detail : string
+    state : string
+    kind : string
+    purpose : string
+    repository_id : string
+    worktree_path : string
+    pid : int
+    controller_id : int
 }
 
 struct public WatcherSessionInfo {
@@ -150,6 +211,9 @@ struct public WatcherSessionInfo {
     target_id : string
     repository_id : string
     worktree_path : string
+    purpose : string
+    task_context : string
+    context_path : string
     state : string
     reason : string
     pid : int = 0
@@ -161,6 +225,7 @@ struct public WatcherSessionInfo {
     rows : int
     revision : int64
     status_revision : int64
+    event_sequence : int64
     controller_id : int
     drained : bool
 }
@@ -198,10 +263,14 @@ class private WatcherSession {
     target_id : string
     repository_id : string
     worktree_path : string
+    purpose : string
+    task_context : string
+    context_path : string
     session_dir : string
     output_path : string
     events_path : string
     mailbox_path : string
+    bundles_path : string
     state : string = "starting"
     reason : string
     pid : int = 0
@@ -218,11 +287,15 @@ class private WatcherSession {
     raw_history : array<uint8>
     raw_history_start : int64
     status_revision : int64
+    event_sequence : int64
     controller_id : int
     drained : bool
     mailbox : array<WatcherMailboxMessage>
     mailbox_revision : int64
     mailbox_file : FILE const? = null
+    bundles : array<WatcherReviewBundle>
+    bundles_revision : int64
+    bundles_file : FILE const? = null
     input_line_bytes : int
     input_escape_state : int
     pending_notifications : array<WatcherPendingNotification>
@@ -242,9 +315,15 @@ class private WatcherSession {
             fclose(mailbox_file)
             mailbox_file = null
         }
+        if (bundles_file != null) {
+            fflush(bundles_file)
+            fclose(bundles_file)
+            bundles_file = null
+        }
         terminal_dispose(terminal)
         delete raw_history
         delete mailbox
+        delete bundles
         delete pending_notifications
     }
 }
@@ -268,6 +347,8 @@ var private g_log_root : string
 var private g_next_session_id = 0
 var private g_next_mailbox_id = 0
 var private g_mailbox_revision : int64
+var private g_next_bundle_id = 0
+var private g_bundle_revision : int64
 
 def private elapsed_ms(session : WatcherSession?) : int64 {
     return get_time_nsec(session.started) / 1000000l
@@ -282,12 +363,24 @@ def private write_text_file(path, body : string) : bool {
     return true
 }
 
-def private append_event(session : WatcherSession?; event, detail : string) {
+def private append_event(var session : WatcherSession?; event, detail : string) {
     if (session.events_file == null) return
-    let line = sprint_json(WatcherEvent(session_id = session.id, event = event,
-        elapsed_ms = elapsed_ms(session), detail = detail), false) + "\n"
+    session.event_sequence++
+    let line = sprint_json(WatcherEvent(sequence = session.event_sequence,
+        wall_time_seconds = int64(get_clock()), session_id = session.id,
+        event = event, elapsed_ms = elapsed_ms(session), detail = detail,
+        state = session.state, kind = session.kind, purpose = session.purpose,
+        repository_id = session.repository_id, worktree_path = session.worktree_path,
+        pid = session.pid, controller_id = session.controller_id), false) + "\n"
     fwrite(session.events_file, line)
     fflush(session.events_file)
+}
+
+def public watcher_record_event(session_id, event, detail : string) : bool {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null || empty(event)) return false
+    append_event(g_sessions[index], event, detail)
+    return true
 }
 
 def private session_info(session : WatcherSession?) : WatcherSessionInfo {
@@ -295,12 +388,15 @@ def private session_info(session : WatcherSession?) : WatcherSessionInfo {
         cwd = session.cwd, display_name = session.display_name, kind = session.kind,
         target_id = session.target_id, repository_id = session.repository_id,
         worktree_path = session.worktree_path,
+        purpose = session.purpose, task_context = session.task_context,
+        context_path = session.context_path,
         state = session.state, reason = session.reason,
         pid = session.pid, exit_code = session.exit_code,
         elapsed_ms = elapsed_ms(session), output_bytes = session.output_bytes,
         input_bytes = session.input_bytes,
         columns = session.terminal.columns, rows = session.terminal.rows,
         revision = terminal_revision(session.terminal), status_revision = session.status_revision,
+        event_sequence = session.event_sequence,
         controller_id = session.controller_id,
         drained = session.drained)
 }
@@ -361,17 +457,21 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         command_line = visible_command, cwd = request.cwd,
         display_name = request.display_name, kind = request.kind,
         target_id = request.target_id, repository_id = request.repository_id,
-        worktree_path = request.worktree_path,
+        worktree_path = request.worktree_path, purpose = request.purpose,
+        task_context = request.task_context,
         session_dir = session_dir,
         output_path = path_join(session_dir, "output.raw"),
         events_path = path_join(session_dir, "events.jsonl"),
         mailbox_path = path_join(session_dir, "mailbox.jsonl"),
+        bundles_path = path_join(session_dir, "bundles.jsonl"),
         started = ref_time_ticks(), timeout_ms = max(0l, request.timeout_ms))
+    session.context_path = path_join(session_dir, "context.md")
     session.output_file = fopen(session.output_path, "wb")
     session.events_file = fopen(session.events_path, "wb")
     session.mailbox_file = fopen(session.mailbox_path, "wb")
+    session.bundles_file = fopen(session.bundles_path, "wb")
     if (session.output_file == null || session.events_file == null
-            || session.mailbox_file == null) {
+            || session.mailbox_file == null || session.bundles_file == null) {
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not open session logs")
     }
@@ -380,12 +480,26 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
     var inscope persisted_request := request
     persisted_request.columns = columns
     persisted_request.rows = rows
+    persisted_request.agent_token = ""
     if (!write_text_file(path_join(session_dir, "session.json"), sprint_json(persisted_request, true))) {
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not write session metadata")
     }
+    append_event(session, "session_created",
+        "cwd={request.cwd}; display={visible_command}; context={session.context_path}")
 
-    if (!empty(request.argv)) {
+    if (request.kind == "agent-codex") {
+        if (!write_text_file(session.context_path,
+                agent_context_markdown(request, session_id, session.context_path))) {
+            unsafe { delete session }
+            return WatcherLaunchResult(error = "could not write agent session context")
+        }
+        append_event(session, "agent_bootstrap_prepared",
+            "context={session.context_path}; skill={request.agent_skill_path}")
+        var inscope argv <- agent_launch_argv(request, session_id, session.context_path)
+        var inscope launched <- terminal_launch_argv(argv, request.cwd, columns, rows)
+        session.terminal := launched
+    } elif (!empty(request.argv)) {
         var inscope launched <- terminal_launch_argv(request.argv, request.cwd, columns, rows)
         session.terminal := launched
     } else {
@@ -744,6 +858,55 @@ def private input_session(var session : WatcherSession?; text : string; client_i
     return ""
 }
 
+def private powershell_literal(value : string) : string {
+    return "'" + replace(value, "'", "''") + "'"
+}
+
+def private agent_context_markdown(request : WatcherLaunchRequest const;
+                                   session_id, context_path : string) : string {
+    return ("# dasHerd session\n\n" +
+        "Session: `{session_id}`\n\n" +
+        "Purpose: `{request.purpose}`\n\n" +
+        "Origin repository: `{request.repository_id}`\n\n" +
+        "Origin worktree: `{request.worktree_path}`\n\n" +
+        "## Task\n\n{request.task_context}\n\n" +
+        "## Cooperation contract\n\n" +
+        "This is a dasHerd-managed session. Keep the launch worktree as the immutable " +
+        "session origin. Use the dasHerd skill and CLI to read Inbox requests, declare " +
+        "every additional repository/worktree participating in the task, publish exact " +
+        "review focus, and sync the complete review bundle before declaring the work ready. " +
+        "Do not attribute unrelated dirty files to this session.\n\n" +
+        "Skill: `{request.agent_skill_path}`\n\n" +
+        "Context artifact: `{context_path}`\n")
+}
+
+def private agent_launch_argv(request : WatcherLaunchRequest const;
+                              session_id, context_path : string) : array<string> {
+    var command_argv := request.argv
+    if (empty(command_argv)) command_argv |> push("codex")
+    command_argv |> push("Read the dasHerd session context at {context_path} before acting. " +
+        "Use the dasHerd skill for session coordination, then help with the stated debug task.")
+    if (get_platform_name() == "windows") {
+        var command = ("$env:DASHERD_URL = {powershell_literal(request.agent_url)}; " +
+            "$env:DASHERD_TOKEN = {powershell_literal(request.agent_token)}; " +
+            "$env:DASHERD_SESSION_ID = {powershell_literal(session_id)}; " +
+            "$env:DASHERD_SESSION_KIND = {powershell_literal(request.purpose)}; " +
+            "$env:DASHERD_CONTEXT_PATH = {powershell_literal(context_path)}; & ")
+        var quoted : array<string>
+        quoted |> reserve(length(command_argv))
+        for (argument in command_argv) {
+            quoted |> push(powershell_literal(argument))
+        }
+        command += join(quoted, " ") + "; exit $LASTEXITCODE"
+        return <- ["powershell.exe", "-NoLogo", "-NoProfile", "-Command", command]
+    }
+    var result <- ["env", "DASHERD_URL={request.agent_url}",
+        "DASHERD_TOKEN={request.agent_token}", "DASHERD_SESSION_ID={session_id}",
+        "DASHERD_SESSION_KIND={request.purpose}", "DASHERD_CONTEXT_PATH={context_path}"]
+    result |> push_from(command_argv)
+    return <- result
+}
+
 def private observe_input_line(var session : WatcherSession?; text : string) {
     peek_data(text) $(bytes) {
         for (byte_u8 in bytes) {
@@ -829,6 +992,12 @@ def public watcher_notify(session_id : string; text : string;
 def private valid_focus(focus : WatcherFocusSet const) : string {
     for (target in focus.targets) {
         if (empty(target.file_path)) return "focus target file_path is required"
+        if (empty(target.repository_id) && empty(focus.repository_id)) {
+            return "focus target repository_id is required"
+        }
+        if (empty(target.worktree_path) && empty(focus.worktree_path)) {
+            return "focus target worktree_path is required"
+        }
         for (focus_range in target.ranges) {
             if (focus_range.start_byte < 0
                     || focus_range.end_byte <= focus_range.start_byte) {
@@ -837,6 +1006,26 @@ def private valid_focus(focus : WatcherFocusSet const) : string {
         }
     }
     return ""
+}
+
+def public watcher_focus_repository(focus : WatcherFocusSet const;
+                                    target : WatcherFocusTarget const) : string {
+    return !empty(target.repository_id) ? target.repository_id : focus.repository_id
+}
+
+def public watcher_focus_worktree(focus : WatcherFocusSet const;
+                                  target : WatcherFocusTarget const) : string {
+    return !empty(target.worktree_path) ? target.worktree_path : focus.worktree_path
+}
+
+def public watcher_focus_comparison(focus : WatcherFocusSet const;
+                                    target : WatcherFocusTarget const) : string {
+    return !empty(target.comparison) ? target.comparison : focus.comparison
+}
+
+def public watcher_focus_revision(focus : WatcherFocusSet const;
+                                  target : WatcherFocusTarget const) : string {
+    return !empty(target.revision) ? target.revision : focus.revision
 }
 
 def private append_mailbox_record(var session : WatcherSession?;
@@ -872,7 +1061,8 @@ def public watcher_mailbox_post(request : WatcherMailboxPostRequest) : WatcherMa
         id = "hf_{g_next_mailbox_id}", session_id = request.session_id,
         direction = request.direction, sender = sender,
         kind = request.kind, subject = request.subject,
-        reply_to = request.reply_to, created_ms = elapsed_ms(g_sessions[index]),
+        reply_to = request.reply_to, bundle_id = request.bundle_id,
+        created_ms = elapsed_ms(g_sessions[index]),
         revision = g_mailbox_revision, focus := request.focus)
     let message_id = message.id
     let message_revision = message.revision
@@ -976,6 +1166,143 @@ def public watcher_mailbox_json(session_id : string; direction : string = "";
     }
 }
 
+def private valid_bundle(bundle : WatcherReviewBundle const) : string {
+    if (empty(bundle.title)) return "bundle title is required"
+    if (bundle.status != "draft" && bundle.status != "ready"
+            && bundle.status != "published" && bundle.status != "merged"
+            && bundle.status != "complete") {
+        return "bundle status must be draft, ready, published, merged, or complete"
+    }
+    if (empty(bundle.participants)) return "bundle requires at least one participant"
+    for (participant in bundle.participants) {
+        if (empty(participant.repository_id)) return "participant repository_id is required"
+        if (empty(participant.worktree_path)) return "participant worktree_path is required"
+        for (file in participant.files) {
+            if (empty(file.path)) return "participant file path is required"
+        }
+    }
+    let focus_error = valid_focus(bundle.focus)
+    if (!empty(focus_error)) return focus_error
+    for (target in bundle.focus.targets) {
+        let repository_id = watcher_focus_repository(bundle.focus, target)
+        let worktree_path = watcher_focus_worktree(bundle.focus, target)
+        var participant_found = false
+        for (participant in bundle.participants) {
+            if (participant.repository_id == repository_id
+                    && participant.worktree_path == worktree_path) {
+                participant_found = true
+                break
+            }
+        }
+        if (!participant_found) return "focus target is not in a bundle participant"
+    }
+    return ""
+}
+
+def private append_bundle_record(var session : WatcherSession?;
+                                 bundle : WatcherReviewBundle const) {
+    if (session.bundles_file == null) return
+    fwrite(session.bundles_file, sprint_json(bundle, false) + "\n")
+    fflush(session.bundles_file)
+}
+
+def private upsert_bundle_attention(var session : WatcherSession?;
+                                    bundle : WatcherReviewBundle const;
+                                    publish : bool) {
+    for (message_index in range(length(session.mailbox))) {
+        if (session.mailbox[message_index].direction != "outbox"
+                || session.mailbox[message_index].kind != "bundle_focus"
+                || session.mailbox[message_index].bundle_id != bundle.id) continue
+        g_mailbox_revision++
+        session.mailbox[message_index].subject = bundle.title
+        session.mailbox[message_index].focus := bundle.focus
+        if (!publish) {
+            session.mailbox[message_index].status = "completed"
+        }
+        session.mailbox[message_index].revision = g_mailbox_revision
+        session.mailbox_revision = g_mailbox_revision
+        append_mailbox_record(session, session.mailbox[message_index])
+        append_event(session, publish ? "bundle_attention_updated"
+                : "bundle_attention_completed",
+            "bundle={bundle.id}; message={session.mailbox[message_index].id}; " +
+            "targets={length(bundle.focus.targets)}")
+        return
+    }
+    if (!publish || empty(bundle.focus.targets)) return
+    let sender = "agent_session:{session.id}"
+    g_next_mailbox_id++
+    g_mailbox_revision++
+    var message = WatcherMailboxMessage(
+        id = "hf_{g_next_mailbox_id}", session_id = session.id,
+        direction = "outbox", sender = sender, kind = "bundle_focus",
+        subject = bundle.title, bundle_id = bundle.id,
+        created_ms = elapsed_ms(session), revision = g_mailbox_revision,
+        focus := bundle.focus)
+    session.mailbox |> emplace(message)
+    session.mailbox_revision = g_mailbox_revision
+    append_mailbox_record(session, session.mailbox[length(session.mailbox) - 1])
+    append_event(session, "bundle_attention_created",
+        "bundle={bundle.id}; message={session.mailbox[length(session.mailbox) - 1].id}; " +
+        "targets={length(bundle.focus.targets)}")
+}
+
+def public watcher_bundle_session_revision(session_id : string) : int64 {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return -1l
+    return g_sessions[index].bundles_revision
+}
+
+def public watcher_bundle_sync(request : WatcherBundleSyncRequest) : WatcherBundleResult {
+    let index = watcher_find_session(request.session_id)
+    if (index < 0 || g_sessions[index] == null) {
+        return WatcherBundleResult(error = "unknown session")
+    }
+    let validation_error = valid_bundle(request.bundle)
+    if (!empty(validation_error)) return WatcherBundleResult(error = validation_error)
+    var bundle := request.bundle
+    if (empty(bundle.id)) {
+        g_next_bundle_id++
+        bundle.id = "rb_{g_next_bundle_id}"
+    }
+    bundle.session_id = request.session_id
+    g_bundle_revision++
+    bundle.revision = g_bundle_revision
+    bundle.updated_ms = elapsed_ms(g_sessions[index])
+    let bundle_id = bundle.id
+    var replaced = false
+    for (bundle_index in range(length(g_sessions[index].bundles))) {
+        if (g_sessions[index].bundles[bundle_index].id != bundle_id) continue
+        g_sessions[index].bundles[bundle_index] := bundle
+        replaced = true
+        break
+    }
+    if (!replaced) g_sessions[index].bundles |> emplace(bundle)
+    g_sessions[index].bundles_revision = g_bundle_revision
+    var stored_index = 0
+    for (bundle_index in range(length(g_sessions[index].bundles))) {
+        if (g_sessions[index].bundles[bundle_index].id == bundle_id) {
+            stored_index = bundle_index
+            break
+        }
+    }
+    append_bundle_record(g_sessions[index], g_sessions[index].bundles[stored_index])
+    let stored_status = g_sessions[index].bundles[stored_index].status
+    let publish_attention = (stored_status == "ready" || stored_status == "published"
+        || stored_status == "merged" || stored_status == "complete")
+    upsert_bundle_attention(g_sessions[index],
+        g_sessions[index].bundles[stored_index], publish_attention)
+    append_event(g_sessions[index], "bundle_synced",
+        "id={bundle_id}; status={stored_status}; participants={length(g_sessions[index].bundles[stored_index].participants)}")
+    return WatcherBundleResult(ok = true, bundle_id = bundle_id,
+        revision = g_bundle_revision)
+}
+
+def public watcher_bundles_json(session_id : string) : string {
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return "[]"
+    return sprint_json(g_sessions[index].bundles, false)
+}
+
 def private resize_session(var session : WatcherSession?; columns, rows, client_id : int) : string {
     if (session.controller_id != 0 && session.controller_id != client_id) return "controller lease is held by another client"
     terminal_resize(session.terminal, clamp(columns, 20, 400), clamp(rows, 5, 512))
@@ -1008,10 +1335,15 @@ def public watcher_terminate(session_id : string; detail : string = "requested")
 }
 
 def private claim_session(var session : WatcherSession?; client_id : int) : bool {
-    if (session.controller_id != 0 && session.controller_id != client_id) return false
-    if (session.controller_id == 0) append_event(session, "controller_claimed", "client={client_id}")
+    if (session.controller_id != 0 && session.controller_id != client_id) {
+        append_event(session, "controller_claim_rejected",
+            "client={client_id}; held_by={session.controller_id}")
+        return false
+    }
+    let newly_claimed = session.controller_id == 0
     session.controller_id = client_id
     session.status_revision++
+    if (newly_claimed) append_event(session, "controller_claimed", "client={client_id}")
     return true
 }
 

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -254,6 +254,14 @@ struct public WatcherOutputChunk {
     reset : bool
 }
 
+struct public WatcherTerminalCheckpoint {
+    ok : bool
+    ansi : string
+    output_offset : int64
+    columns : int
+    rows : int
+}
+
 class private WatcherSession {
     id : string
     command_line : string
@@ -425,6 +433,14 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
     if (empty(request.command_line) && empty(request.argv)) {
         return WatcherLaunchResult(error = "command_line or argv is required")
     }
+    if (request.kind == "agent-codex") {
+        if (empty(strip(request.task_context))) {
+            return WatcherLaunchResult(error = "agent task is required")
+        }
+        if (length(request.task_context) > MAX_COMMAND_BYTES / 2) {
+            return WatcherLaunchResult(error = "agent task is too large")
+        }
+    }
     if (length(request.command_line) > MAX_COMMAND_BYTES) {
         return WatcherLaunchResult(error = "command_line is too large")
     }
@@ -485,17 +501,21 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not write session metadata")
     }
-    append_event(session, "session_created",
-        "cwd={request.cwd}; display={visible_command}; context={session.context_path}")
-
+    var session_created_detail = "cwd={request.cwd}; display={visible_command}"
     if (request.kind == "agent-codex") {
         if (!write_text_file(session.context_path,
                 agent_context_markdown(request, session_id, session.context_path))) {
             unsafe { delete session }
             return WatcherLaunchResult(error = "could not write agent session context")
         }
+        session_created_detail += "; context={session.context_path}"
+    }
+    append_event(session, "session_created", session_created_detail)
+
+    if (request.kind == "agent-codex") {
         append_event(session, "agent_bootstrap_prepared",
-            "context={session.context_path}; skill={request.agent_skill_path}")
+            "context={session.context_path}; skill={request.agent_skill_path}; " +
+            "task_bytes={length(request.task_context)}")
         var inscope argv <- agent_launch_argv(request, session_id, session.context_path)
         var inscope launched <- terminal_launch_argv(argv, request.cwd, columns, rows)
         session.terminal := launched
@@ -621,6 +641,19 @@ def public watcher_output_since(session_id : string; requested_offset : int64;
         }
     }
     result.next_offset = offset + count
+    return <- result
+}
+
+def public watcher_terminal_checkpoint(session_id : string) : WatcherTerminalCheckpoint {
+    var result = WatcherTerminalCheckpoint()
+    let index = watcher_find_session(session_id)
+    if (index < 0 || g_sessions[index] == null) return <- result
+    let session = g_sessions[index]
+    result.ansi = terminal_checkpoint_ansi(session.terminal)
+    result.output_offset = session.output_bytes
+    result.columns = session.terminal.columns
+    result.rows = session.terminal.rows
+    result.ok = true
     return <- result
 }
 
@@ -884,8 +917,9 @@ def private agent_launch_argv(request : WatcherLaunchRequest const;
                               session_id, context_path : string) : array<string> {
     var command_argv := request.argv
     if (empty(command_argv)) command_argv |> push("codex")
-    command_argv |> push("Read the dasHerd session context at {context_path} before acting. " +
-        "Use the dasHerd skill for session coordination, then help with the stated debug task.")
+    command_argv |> push("Your assigned debug task is:\n\n{request.task_context}\n\n" +
+        "Read the dasHerd session context at {context_path} before acting. " +
+        "Use the dasHerd skill for session coordination, then begin the assigned task.")
     if (get_platform_name() == "windows") {
         var command = ("$env:DASHERD_URL = {powershell_literal(request.agent_url)}; " +
             "$env:DASHERD_TOKEN = {powershell_literal(request.agent_token)}; " +
@@ -1206,9 +1240,16 @@ def private append_bundle_record(var session : WatcherSession?;
     fflush(session.bundles_file)
 }
 
+def private bundle_publishes_attention(bundle : WatcherReviewBundle const) : bool {
+    if (empty(bundle.focus.targets)) return false
+    return (bundle.status == "ready" || bundle.status == "published"
+        || bundle.status == "merged" || bundle.status == "complete"
+    )
+}
+
 def private upsert_bundle_attention(var session : WatcherSession?;
                                     bundle : WatcherReviewBundle const;
-                                    publish : bool) {
+                                    publish, reopen : bool) {
     for (message_index in range(length(session.mailbox))) {
         if (session.mailbox[message_index].direction != "outbox"
                 || session.mailbox[message_index].kind != "bundle_focus"
@@ -1218,6 +1259,8 @@ def private upsert_bundle_attention(var session : WatcherSession?;
         session.mailbox[message_index].focus := bundle.focus
         if (!publish) {
             session.mailbox[message_index].status = "completed"
+        } elif (reopen) {
+            session.mailbox[message_index].status = "new"
         }
         session.mailbox[message_index].revision = g_mailbox_revision
         session.mailbox_revision = g_mailbox_revision
@@ -1270,8 +1313,11 @@ def public watcher_bundle_sync(request : WatcherBundleSyncRequest) : WatcherBund
     bundle.updated_ms = elapsed_ms(g_sessions[index])
     let bundle_id = bundle.id
     var replaced = false
+    var previously_published_attention = false
     for (bundle_index in range(length(g_sessions[index].bundles))) {
         if (g_sessions[index].bundles[bundle_index].id != bundle_id) continue
+        previously_published_attention = bundle_publishes_attention(
+            g_sessions[index].bundles[bundle_index])
         g_sessions[index].bundles[bundle_index] := bundle
         replaced = true
         break
@@ -1287,10 +1333,11 @@ def public watcher_bundle_sync(request : WatcherBundleSyncRequest) : WatcherBund
     }
     append_bundle_record(g_sessions[index], g_sessions[index].bundles[stored_index])
     let stored_status = g_sessions[index].bundles[stored_index].status
-    let publish_attention = (stored_status == "ready" || stored_status == "published"
-        || stored_status == "merged" || stored_status == "complete")
+    let publish_attention = bundle_publishes_attention(
+        g_sessions[index].bundles[stored_index])
     upsert_bundle_attention(g_sessions[index],
-        g_sessions[index].bundles[stored_index], publish_attention)
+        g_sessions[index].bundles[stored_index], publish_attention,
+        publish_attention && !previously_published_attention)
     append_event(g_sessions[index], "bundle_synced",
         "id={bundle_id}; status={stored_status}; participants={length(g_sessions[index].bundles[stored_index].participants)}")
     return WatcherBundleResult(ok = true, bundle_id = bundle_id,

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -112,6 +112,15 @@ struct public RepositoryGitFileActionMessage {
     error : string
 }
 
+struct private WatcherTerminalCheckpointMessage {
+    @rename = "type"
+    _type : string = "terminal_checkpoint"
+    offset : int64
+    columns : int
+    rows : int
+    ansi : string
+}
+
 struct private OrphanedGitFileAction {
     session_id : string
     repository_id : string
@@ -523,8 +532,7 @@ class DasHerdWatcherServer : HvWebServer {
     def send_bundles(var client : WatcherClient?; force : bool = false) {
         if (client == null || empty(client.session_id)) return
         let revision = watcher_bundle_session_revision(client.session_id)
-        if (revision < 0l) return
-        if (!force && client.bundles_revision == revision) return
+        if (revision < 0l || (!force && client.bundles_revision == revision)) return
         client.bundles_revision = revision
         send(client.channel, "\{\"type\":\"bundles\",\"session_id\":" +
             "{sprint_json(client.session_id, false)},\"revision\":{revision},\"data\":" +
@@ -731,6 +739,10 @@ class DasHerdWatcherServer : HvWebServer {
     def start_agent_worktree_launch(var client : WatcherClient?;
                                     incoming : WatcherWsMessage const) {
         if (client == null) return
+        if (empty(strip(incoming.task_context))) {
+            send_error(client.channel, "agent task is required")
+            return
+        }
         if (empty(incoming.repository_id) || empty(incoming.worktree_path)
                 || empty(incoming.new_worktree_path) || empty(incoming.branch)) {
             send_error(client.channel,
@@ -1080,6 +1092,22 @@ class DasHerdWatcherServer : HvWebServer {
         }
     }
 
+    def send_terminal_checkpoint(var client : WatcherClient?) {
+        if (client == null || !client.raw || empty(client.session_id)) return
+        let checkpoint <- watcher_terminal_checkpoint(client.session_id)
+        if (!checkpoint.ok) {
+            send_error(client.channel, "unknown session")
+            return
+        }
+        client.raw_offset = checkpoint.output_offset
+        let message = WatcherTerminalCheckpointMessage(
+            offset = checkpoint.output_offset,
+            columns = checkpoint.columns, rows = checkpoint.rows,
+            ansi = checkpoint.ansi)
+        send(client.channel, sprint_json(message, false),
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
     def detach(var client : WatcherClient?; detail : string) {
         if (client == null) return
         let session_id = client.session_id
@@ -1265,9 +1293,30 @@ class DasHerdWatcherServer : HvWebServer {
             send(channel, "\{\"type\":\"attached\",\"session_id\":{sprint_json(client.session_id, false)},\"controls\":{client.controls}\}",
                 ws_opcode.WS_OPCODE_TEXT, true)
             send_snapshot(client, true)
+            self.send_terminal_checkpoint(client)
             send_raw_output(client)
             self.send_mailbox(client, true)
             self.send_bundles(client, true)
+        } elif (incoming.op == "claim_control") {
+            if (empty(client.session_id)) {
+                send_error(channel, "client is not attached")
+                return
+            }
+            let accepts_input = watcher_accepts_input(client.session_id)
+            if (!accepts_input) {
+                send_error(channel, "session is not running; output is replay-only")
+                return
+            }
+            if (!client.controls) {
+                client.controls = watcher_claim_controller(client.session_id, client.id)
+            }
+            if (!client.controls) {
+                send_error(channel, "controller lease is held by another client")
+                return
+            }
+            send(channel, "\{\"type\":\"attached\",\"session_id\":" +
+                "{sprint_json(client.session_id, false)},\"controls\":true\}",
+                ws_opcode.WS_OPCODE_TEXT, true)
         } elif (incoming.op == "detach") {
             detach(client, "client_detached")
             send(channel, "\{\"type\":\"detached\"\}", ws_opcode.WS_OPCODE_TEXT, true)

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -48,6 +48,11 @@ struct private WatcherWsMessage {
     repository_id : string
     repository_path : string
     worktree_path : string
+    new_worktree_path : string
+    branch : string
+    base_ref : string
+    purpose : string
+    task_context : string
     file_path : string
     comparison : string
     revision : string
@@ -64,10 +69,12 @@ struct private WatcherWsMessage {
     sender : string = ""
     subject : string
     reply_to : string
+    bundle_id : string
     message_id : string
     status : string
     notify : bool = true
     focus : WatcherFocusSet = WatcherFocusSet()
+    bundle : WatcherReviewBundle = WatcherReviewBundle()
 }
 
 struct public RepositoryFileInspectionMessage {
@@ -113,6 +120,15 @@ struct private OrphanedGitFileAction {
     action : string
 }
 
+struct private PendingAgentWorktreeLaunch {
+    create_session_id : string
+    client_id : int
+    repository_id : string
+    source_worktree_path : string
+    new_worktree_path : string
+    task_context : string
+}
+
 class private WatcherClient {
     @safe_when_uninitialized
     channel : WebSocketChannel = default<WebSocketChannel>
@@ -125,6 +141,7 @@ class private WatcherClient {
     raw_offset : int64
     repository_revision : int64 = -1l
     mailbox_revision : int64 = -1l
+    bundles_revision : int64 = -1l
     inspection_request_id : int
     inspection_repository_id : string
     inspection_worktree_path : string
@@ -210,6 +227,8 @@ def private query_value(url, key : string) : string {
 
 class DasHerdWatcherServer : HvWebServer {
     token : string
+    agent_url : string
+    agent_skill_path : string
     control_html : string
     xterm_js : string
     xterm_css : string
@@ -219,6 +238,7 @@ class DasHerdWatcherServer : HvWebServer {
     clients : array<WatcherClient?>
     pending_inspection_artifacts : array<string>
     orphaned_git_actions : array<OrphanedGitFileAction>
+    pending_agent_launches : array<PendingAgentWorktreeLaunch>
     next_client_id : int
 
     def authorized(url : string) : bool {
@@ -314,6 +334,18 @@ class DasHerdWatcherServer : HvWebServer {
             return resp |> JSON(watcher_mailbox_json(session_id,
                 direction, message_id), http_status.OK)
         }
+        GET("/api/v1/bundles") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            let url = req != null ? string(req.url) : ""
+            let session_id = query_value(url, "session_id")
+            if (empty(session_id)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "session_id is required")
+            }
+            if (watcher_find_session(session_id) < 0) {
+                return self.respond_error(resp, http_status.NOT_FOUND, "unknown session")
+            }
+            return resp |> JSON(watcher_bundles_json(session_id), http_status.OK)
+        }
         POST("/api/v1/gc") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
             let coalesced = watcher_request_gc()
@@ -328,6 +360,11 @@ class DasHerdWatcherServer : HvWebServer {
             var inscope launch = WatcherLaunchRequest()
             if (!sscan_json(string(req.body), launch)) {
                 return self.respond_error(resp, http_status.BAD_REQUEST, "invalid launch JSON")
+            }
+            if (launch.kind == "agent-codex") {
+                launch.agent_url = self.agent_url
+                launch.agent_token = self.token
+                launch.agent_skill_path = self.agent_skill_path
             }
             let result = watcher_launch(launch)
             return resp |> JSON(sprint_json(result, false),
@@ -427,6 +464,19 @@ class DasHerdWatcherServer : HvWebServer {
             if (!result.ok) return self.respond_error(resp, http_status.BAD_REQUEST, result.error)
             return resp |> JSON(sprint_json(result, false), http_status.OK)
         }
+        POST("/api/v1/bundles/sync") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            if (!self.require_auth(req, resp)) return http_status.UNAUTHORIZED
+            if (req == null || length(req.body) > MAX_REQUEST_BODY_BYTES) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "request body is too large")
+            }
+            var request = WatcherBundleSyncRequest()
+            if (!sscan_json(string(req.body), request)) {
+                return self.respond_error(resp, http_status.BAD_REQUEST, "invalid bundle JSON")
+            }
+            let result = watcher_bundle_sync(request)
+            if (!result.ok) return self.respond_error(resp, http_status.BAD_REQUEST, result.error)
+            return resp |> JSON(sprint_json(result, false), http_status.OK)
+        }
     }
 
     def find_client(channel : WebSocketChannel) : int {
@@ -467,6 +517,18 @@ class DasHerdWatcherServer : HvWebServer {
         send(client.channel, "\{\"type\":\"mailbox\",\"session_id\":" +
             "{sprint_json(client.session_id, false)},\"revision\":{revision},\"data\":" +
             "{watcher_mailbox_json(client.session_id)}\}",
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def send_bundles(var client : WatcherClient?; force : bool = false) {
+        if (client == null || empty(client.session_id)) return
+        let revision = watcher_bundle_session_revision(client.session_id)
+        if (revision < 0l) return
+        if (!force && client.bundles_revision == revision) return
+        client.bundles_revision = revision
+        send(client.channel, "\{\"type\":\"bundles\",\"session_id\":" +
+            "{sprint_json(client.session_id, false)},\"revision\":{revision},\"data\":" +
+            "{watcher_bundles_json(client.session_id)}\}",
             ws_opcode.WS_OPCODE_TEXT, true)
     }
 
@@ -663,6 +725,112 @@ class DasHerdWatcherServer : HvWebServer {
             let _review_error = repository_review(
                 action.repository_id, action.worktree_path)
             orphaned_git_actions |> erase(index)
+        }
+    }
+
+    def start_agent_worktree_launch(var client : WatcherClient?;
+                                    incoming : WatcherWsMessage const) {
+        if (client == null) return
+        if (empty(incoming.repository_id) || empty(incoming.worktree_path)
+                || empty(incoming.new_worktree_path) || empty(incoming.branch)) {
+            send_error(client.channel,
+                "repository, source worktree, new worktree path, and branch are required")
+            return
+        }
+        var create_argv : array<string>
+        let command_error = repository_build_worktree_create_argv(
+            incoming.worktree_path, incoming.new_worktree_path,
+            incoming.branch, incoming.base_ref, create_argv)
+        if (!empty(command_error)) {
+            send_error(client.channel, command_error)
+            return
+        }
+        let created = watcher_launch(WatcherLaunchRequest(argv <- create_argv,
+            cwd = incoming.worktree_path, display_name = "Create {incoming.branch}",
+            kind = "worktree-create", target_id = "local",
+            repository_id = incoming.repository_id,
+            worktree_path = incoming.new_worktree_path,
+            purpose = "debug-setup", task_context = incoming.task_context,
+            columns = 120, rows = 30, timeout_ms = 0l))
+        if (!created.ok) {
+            send_error(client.channel, created.error)
+            return
+        }
+        pending_agent_launches |> push(PendingAgentWorktreeLaunch(
+            create_session_id = created.session_id, client_id = client.id,
+            repository_id = incoming.repository_id,
+            source_worktree_path = incoming.worktree_path,
+            new_worktree_path = incoming.new_worktree_path,
+            task_context = incoming.task_context))
+        let _ = watcher_record_event(created.session_id, "agent_worktree_queued",
+            "source={incoming.worktree_path}; target={incoming.new_worktree_path}; " +
+            "branch={incoming.branch}; base={incoming.base_ref}")
+        send(client.channel, "\{\"type\":\"launched\",\"session_id\":" +
+            "{sprint_json(created.session_id, false)}\}",
+            ws_opcode.WS_OPCODE_TEXT, true)
+        send_sessions(client.channel)
+    }
+
+    def poll_agent_worktree_launches() {
+        var index = length(pending_agent_launches) - 1
+        while (index >= 0) {
+            let pending = pending_agent_launches[index]
+            var info = WatcherSessionInfo()
+            if (!watcher_get_session_info(pending.create_session_id, info)
+                    || !info.drained) {
+                index--
+                continue
+            }
+            var client : WatcherClient? = null
+            for (candidate in clients) {
+                if (candidate != null && candidate.id == pending.client_id) {
+                    client = candidate
+                    break
+                }
+            }
+            if (info.exit_code != 0l) {
+                let worktree_failure_logged = watcher_record_event(pending.create_session_id,
+                    "agent_worktree_failed", "exit_code={info.exit_code}")
+                if (client != null) {
+                    send_error(client.channel,
+                        "worktree creation failed; inspect session {pending.create_session_id}")
+                }
+                pending_agent_launches |> erase(index)
+                index--
+                continue
+            }
+            let worktree_created_logged = watcher_record_event(pending.create_session_id,
+                "agent_worktree_created", "target={pending.new_worktree_path}")
+            let repository_refreshed = repository_refresh(pending.repository_id)
+            var agent_argv <- ["codex"]
+            let launched = watcher_launch(WatcherLaunchRequest(argv <- agent_argv,
+                cwd = pending.new_worktree_path, display_name = "Codex debug",
+                kind = "agent-codex", purpose = "debug",
+                task_context = pending.task_context, target_id = "local",
+                repository_id = pending.repository_id,
+                worktree_path = pending.new_worktree_path,
+                agent_url = self.agent_url, agent_token = self.token,
+                agent_skill_path = self.agent_skill_path,
+                columns = 120, rows = 36, timeout_ms = 0l))
+            if (!launched.ok) {
+                let launch_failure_logged = watcher_record_event(pending.create_session_id,
+                    "agent_launch_failed", launched.error)
+            } else {
+                let launch_started_logged = watcher_record_event(pending.create_session_id,
+                    "agent_launch_started", "session={launched.session_id}")
+            }
+            if (client != null) {
+                if (!launched.ok) {
+                    send_error(client.channel, launched.error)
+                } else {
+                    send(client.channel, "\{\"type\":\"launched\",\"session_id\":" +
+                        "{sprint_json(launched.session_id, false)}\}",
+                        ws_opcode.WS_OPCODE_TEXT, true)
+                }
+                send_sessions(client.channel)
+            }
+            pending_agent_launches |> erase(index)
+            index--
         }
     }
 
@@ -914,8 +1082,14 @@ class DasHerdWatcherServer : HvWebServer {
 
     def detach(var client : WatcherClient?; detail : string) {
         if (client == null) return
-        if (client.controls && !empty(client.session_id)) {
-            watcher_release_controller(client.session_id, client.id, detail)
+        let session_id = client.session_id
+        let had_control = client.controls
+        if (had_control && !empty(session_id)) {
+            watcher_release_controller(session_id, client.id, detail)
+        }
+        if (!empty(session_id)) {
+            let _ = watcher_record_event(session_id, "client_detached",
+                "client={client.id}; control={had_control}; reason={detail}")
         }
         client.session_id = ""
         client.controls = false
@@ -1009,6 +1183,7 @@ class DasHerdWatcherServer : HvWebServer {
                 kind = incoming.kind,
                 subject = incoming.subject,
                 reply_to = incoming.reply_to,
+                bundle_id = incoming.bundle_id,
                 notify = incoming.notify,
                 focus := incoming.focus)
             var result = watcher_mailbox_post(request)
@@ -1032,6 +1207,17 @@ class DasHerdWatcherServer : HvWebServer {
                 return
             }
             self.send_mailbox(client, true)
+        } elif (incoming.op == "bundle_sync") {
+            let result = watcher_bundle_sync(WatcherBundleSyncRequest(
+                session_id = incoming.session_id, bundle := incoming.bundle))
+            if (!result.ok) {
+                send_error(channel, result.error)
+                return
+            }
+            self.send_bundles(client, true)
+            self.send_mailbox(client, true)
+        } elif (incoming.op == "launch_agent_worktree") {
+            self.start_agent_worktree_launch(client, incoming)
         } elif (incoming.op == "launch") {
             var inscope launch = WatcherLaunchRequest(
                 command_line = incoming.command_line, cwd = incoming.cwd,
@@ -1039,9 +1225,15 @@ class DasHerdWatcherServer : HvWebServer {
                 target_id = watcher_target_id_or_local(incoming.target_id),
                 repository_id = incoming.repository_id,
                 worktree_path = incoming.worktree_path,
+                purpose = incoming.purpose, task_context = incoming.task_context,
                 columns = incoming.columns, rows = incoming.rows,
                 timeout_ms = incoming.timeout_ms)
             launch.argv := incoming.argv
+            if (launch.kind == "agent-codex") {
+                launch.agent_url = self.agent_url
+                launch.agent_token = self.token
+                launch.agent_skill_path = self.agent_skill_path
+            }
             let result = watcher_launch(launch)
             if (!result.ok) {
                 send_error(channel, result.error)
@@ -1061,6 +1253,10 @@ class DasHerdWatcherServer : HvWebServer {
             client.controls = incoming.control && accepts_input && watcher_claim_controller(incoming.session_id, client.id)
             client.raw = incoming.raw
             client.raw_offset = 0l
+            let _ = watcher_record_event(incoming.session_id, "client_attached",
+                "client={client.id}; control_requested={incoming.control}; " +
+                "control_granted={client.controls}; raw={incoming.raw}; " +
+                "accepts_input={accepts_input}")
             if (incoming.control && !accepts_input) {
                 send_error(channel, "session is not running; output is replay-only")
             } elif (incoming.control && !client.controls) {
@@ -1071,6 +1267,7 @@ class DasHerdWatcherServer : HvWebServer {
             send_snapshot(client, true)
             send_raw_output(client)
             self.send_mailbox(client, true)
+            self.send_bundles(client, true)
         } elif (incoming.op == "detach") {
             detach(client, "client_detached")
             send(channel, "\{\"type\":\"detached\"\}", ws_opcode.WS_OPCODE_TEXT, true)
@@ -1103,6 +1300,7 @@ class DasHerdWatcherServer : HvWebServer {
         repository_tick()
         self.retry_inspection_artifact_cleanup()
         self.poll_orphaned_git_actions()
+        self.poll_agent_worktree_launches()
         for (index in range(length(clients))) {
             var client = clients[index]
             if (client == null) continue
@@ -1115,6 +1313,7 @@ class DasHerdWatcherServer : HvWebServer {
             send_raw_output(client)
             send_repositories(client)
             send_mailbox(client)
+            send_bundles(client)
             self.poll_git_file_action(client)
             self.poll_file_inspection(client)
         }
@@ -1137,5 +1336,6 @@ class DasHerdWatcherServer : HvWebServer {
         self.retry_inspection_artifact_cleanup()
         delete pending_inspection_artifacts
         delete orphaned_git_actions
+        delete pending_agent_launches
     }
 }


### PR DESCRIPTION
## Summary

- add repository- and worktree-bound Codex session launches with multi-repository review bundles
- make terminal sessions resumable through authoritative VT checkpoints, durable logs, and attach/detach control handoff
- improve the rich client session dialog, docking, terminal sizing, notifications, and attention navigation
- terminate the complete Windows PTY process tree so Codex and MCP descendants cannot be orphaned

## Coordinated dependency

- depends on borisbat/dasImgui#233 for the embedded-terminal and source-view surface

## Testing

- formatter verification: 12 changed daScript files clean
- lint: 12 changed daScript files, zero findings
- small C++ suite: 78/78 passed
- dasHerd watcher suite: 58/58 passed
- protocol integration covers attach/detach, control handoff, multi-repository bundles, existing-worktree launch, checkpoints, and full process-tree termination
- full preflight: docs, interpreter, JIT, dasgen, and CI-daScript gates passed; environment-only clang, PDF, AOT, and sequence gates skipped