### PR TITLE
dasLLAMA vulkan: resident qwen3, coopmat GEMM + flash attention, derived hazard scheduling — pp512 2465 t/s, past llama.cpp

### DIFF
--- a/modules/dasLLAMA/.das_module
+++ b/modules/dasLLAMA/.das_module
@@ -4,7 +4,7 @@ require daslib/fio
 [export]
 def initialize(project_path : string) {
     let dasllama_paths = [
-        "dasllama_par", "dasllama_parity", "dasllama_tune", "dasllama_math", "dasllama_math_default", "dasllama_math_aarch64_neon", "dasllama_math_gen", "dasllama_math_metal", "dasllama_math_vulkan", "dasllama_math_accelerate", "dasllama_metal_lens", "dasllama_metal_common", "dasllama_metal_kernels", "dasllama_metal_prefill", "dasllama_metal_llama", "dasllama_gemm_gen", "dasllama_gemm_register", "dasllama_gemm_schema", "dasllama_quant", "dasllama_gguf",
+        "dasllama_par", "dasllama_parity", "dasllama_tune", "dasllama_math", "dasllama_math_default", "dasllama_math_aarch64_neon", "dasllama_math_gen", "dasllama_math_metal", "dasllama_math_vulkan", "dasllama_math_accelerate", "dasllama_kernel_access", "dasllama_vulkan_lens", "dasllama_metal_lens", "dasllama_metal_common", "dasllama_metal_kernels", "dasllama_metal_prefill", "dasllama_metal_llama", "dasllama_gemm_gen", "dasllama_gemm_register", "dasllama_gemm_schema", "dasllama_quant", "dasllama_gguf",
         "dasllama_unicode", "dasllama_tokenizer", "dasllama_bpe", "dasllama_common", "dasllama_prefix", "dasllama_audio", "dasllama_audio_io", "dasllama_whisper", "dasllama_qwen3a", "dasllama_parakeet", "dasllama_canary", "dasllama_gemma4a", "dasllama_vad", "dasllama_asr",
         "dasllama_arch_llama", "dasllama_arch_qwen2", "dasllama_arch_qwen3", "dasllama_arch_phi3", "dasllama_arch_gemma2", "dasllama_arch_gemma3", "dasllama_arch_gemma4", "dasllama_arch_qwen2moe", "dasllama_arch_qwen3moe", "dasllama_arch_qwen35", "dasllama_arch_gptoss", "dasllama_arch_mistral3", "dasllama_arch_glm4moe", "dasllama_image",
         "dasllama_transformer", "dasllama_chat", "dasllama"

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -2110,10 +2110,11 @@ def resident_upload(var t : Model; seq_cap : int64) : bool {
         return false
     }
     let c = t.config
-    // only the plain llama std shape for now — no bias, no sinks, no qk-norm (qwen3), no shared-KV,
-    // no softcap (gemma), no partial rotary. These decline cleanly and fall back to the CPU loop.
+    // the plain llama std shape + qk-norm (qwen3) — no bias, sinks, gated attention (its wq is
+    // 2x qd rows, and it rode the old qk_norm decline), shared-KV, softcap, or partial rotary.
+    // These decline cleanly and fall back to the CPU loop.
     if (c.attn_qkv_bias || c.attn_out_bias || c.v_norm || c.attn_sinks || c.moe_dense_shexp
-            || c.n_layer_nextn > 0l || c.qk_norm || c.attn_logit_softcap != 0.0
+            || c.n_layer_nextn > 0l || c.q_gated || c.attn_logit_softcap != 0.0
             || c.final_logit_softcap != 0.0 || c.pre_post_norm
             || (c.rope_dim > 0l && c.rope_dim != c.head_size)) {
         return false
@@ -2172,7 +2173,7 @@ def resident_upload(var t : Model; seq_cap : int64) : bool {
     let kg = repacked ? active_q8_kgroup() : 4l
     let wb = repacked ? active_q8_wbias() : 0l
     if (!rdec_prepare(c.n_layers, dim, qd, kvd, hs, c.n_heads, hid0, c.vocab_size, seq_cap, neox,
-                      c.norm_eps, c.attn_scale > 0.0 ? c.attn_scale : 1.0 / sqrt(float(hs)))) {
+                      c.norm_eps, c.attn_scale > 0.0 ? c.attn_scale : 1.0 / sqrt(float(hs)), c.qk_norm)) {
         return false
     }
     // place every plane, wire each layer
@@ -2199,9 +2200,10 @@ def resident_upload(var t : Model; seq_cap : int64) : bool {
         return false
     }
     rdec_set_cls(bcls, int(cls_fmt))
-    // upload the norm rows: [rms_att[l], rms_ffn[l]] x L, then rms_final
+    // upload the norm rows: [rms_att[l], rms_ffn[l]] x L, then rms_final; qk_norm appends the
+    // per-head [rms_q[l], rms_k[l]] x L rows (hs floats each) past the fixed layout
     var norms : array<float>
-    norms |> resize(int(c.n_layers * 2l * dim + dim))
+    norms |> resize(int(c.n_layers * 2l * dim + dim + (c.qk_norm ? c.n_layers * 2l * hs : 0l)))
     for (l in range64(c.n_layers)) {
         for (i in range64(dim)) {
             norms[int(l * 2l * dim + i)] = t.fblob[t.rms_att_off + l * dim + i]
@@ -2210,6 +2212,15 @@ def resident_upload(var t : Model; seq_cap : int64) : bool {
     }
     for (i in range64(dim)) {
         norms[int(c.n_layers * 2l * dim + i)] = t.fblob[t.rms_final_off + i]
+    }
+    if (c.qk_norm) {
+        let qkw = c.n_layers * 2l * dim + dim
+        for (l in range64(c.n_layers)) {
+            for (i in range64(hs)) {
+                norms[int(qkw + l * 2l * hs + i)] = t.fblob[t.rms_q_offs[l] + i]
+                norms[int(qkw + (l * 2l + 1l) * hs + i)] = t.fblob[t.rms_k_offs[l] + i]
+            }
+        }
     }
     rdec_upload_norms(norms)
     delete norms

--- a/modules/dasLLAMA/dasllama/dasllama_kernel_access.das
+++ b/modules/dasLLAMA/dasllama/dasllama_kernel_access.das
@@ -1,0 +1,197 @@
+options gen2
+options indenting = 4
+
+module dasllama_kernel_access shared public
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/rtti
+
+// Interprocedural read/write classifier over a declared set of tracked module globals — the
+// shared analysis half of the GPU dispatch lenses (vulkan today, metal's @role next). Given a
+// kernel function, it walks the body (recursing into same-module helpers) and reports which
+// tracked globals are read and which are written. Anything it cannot prove — a tracked global
+// passed whole as an argument to a call it does not model — lands in `err` so the lens can fail
+// the compile instead of silently under-tracking (the strictness ratchet).
+
+struct AccessResult {
+    reads : table<string>
+    writes : table<string>
+    err : string   // non-empty = unanalyzable construct; the lens turns it into a compile error
+}
+
+// write-root of an assignment target: peel subscripts/fields/swizzles down to the base variable
+def private write_root(e : Expression?) : ExprVar? {
+    var cur = e
+    while (true) {
+        if (cur is ExprAt) {
+            cur = (cur as ExprAt).subexpr
+        } elif (cur is ExprSafeAt) {
+            cur = (cur as ExprSafeAt).subexpr
+        } elif (cur is ExprField) {
+            cur = (cur as ExprField).value
+        } elif (cur is ExprSwizzle) {
+            cur = (cur as ExprSwizzle).value
+        } elif (cur is ExprRef2Value) {
+            cur = (cur as ExprRef2Value).subexpr
+        } else {
+            break
+        }
+    }
+    return cur is ExprVar ? cur as ExprVar : null
+}
+
+def private is_setop2(op : das_string) : bool {
+    return (op == "+=" || op == "-=" || op == "*=" || op == "/=" || op == "%="
+        || op == "&=" || op == "|=" || op == "^=" || op == "<<=" || op == ">>="
+        || op == "&&=" || op == "||=" || op == "^^=")
+}
+
+def private is_setop1(op : das_string) : bool => op == "++" || op == "--" || op == "+++" || op == "---"
+
+class private AccessVisitor : AstVisitor {
+    tracked : table<string>
+    reads : table<string>
+    writes : table<string>
+    callees : table<string>        // non-intrinsic call names, for the driver's same-module recursion
+    claimed : table<uint64>        // ExprVar nodes already classified as pure-write targets
+    err : string
+
+    def is_tracked(name : das_string) : bool => key_exists(tracked, string(name))
+
+    // record a write; `also_read` covers read-modify-write forms (+=, ++). A pure store claims
+    // the target node so the generic ExprVar pass does not also count it as a read.
+    def note_write(target : Expression?; also_read : bool) {
+        var v = write_root(target)
+        if (v == null || !is_tracked(v.name)) {
+            return
+        }
+        writes |> insert(string(v.name))
+        if (!also_read) {
+            claimed |> insert(intptr(v))
+        }
+    }
+
+    def override preVisitExprCopy(expr : ExprCopy?) : void {
+        note_write(expr.left, false)
+    }
+
+    def override preVisitExprMove(expr : ExprMove?) : void {
+        note_write(expr.left, false)
+    }
+
+    def override preVisitExprClone(expr : ExprClone?) : void {
+        note_write(expr.left, false)
+    }
+
+    def override preVisitExprOp2(expr : ExprOp2?) : void {
+        if (is_setop2(expr.op)) {
+            note_write(expr.left, true)
+        }
+    }
+
+    def override preVisitExprOp1(expr : ExprOp1?) : void {
+        if (is_setop1(expr.op)) {
+            note_write(expr.subexpr, true)
+        }
+    }
+
+    def override preVisitExprCall(expr : ExprCall?) : void {
+        let cname = string(expr.name)
+        // dasSpirv intrinsics that take a whole array and write (or only read) through it
+        if (cname == "coopmatStore") {
+            if (length(expr.arguments) >= 2) {
+                note_write(expr.arguments[1], false)
+            }
+            return
+        }
+        if (cname == "coopmatLoad") {
+            return   // src argument is a plain read — the generic ExprVar pass records it
+        }
+        callees |> insert(cname)
+        // the ratchet: a tracked global passed WHOLE to a call we do not model could be written
+        // through a var parameter — refuse to guess
+        for (a in expr.arguments) {
+            var cur = a
+            if (cur is ExprRef2Value) {
+                cur = (cur as ExprRef2Value).subexpr
+            }
+            if (cur is ExprVar && is_tracked((cur as ExprVar).name)) {
+                err = "tracked global '{(cur as ExprVar).name}' passed whole to call '{cname}' — teach the intrinsic table or declare [vk_access]"
+            }
+        }
+    }
+
+    def override visitExprVar(var expr : ExprVar?) : ExpressionPtr {
+        if (is_tracked(expr.name) && !key_exists(claimed, intptr(expr))) {
+            reads |> insert(string(expr.name))
+        }
+        return expr
+    }
+}
+
+def private analyze_one(fn : Function?; tracked : table<string>; var res : AccessResult; var callees : table<string>) {
+    var astVisitor = new AccessVisitor()
+    astVisitor.tracked := tracked
+    make_visitor(*astVisitor) $(adapter) {
+        visit(fn, adapter)
+    }
+    for (r in keys(astVisitor.reads)) {
+        res.reads |> insert(r)
+    }
+    for (w in keys(astVisitor.writes)) {
+        res.writes |> insert(w)
+    }
+    for (c in keys(astVisitor.callees)) {
+        callees |> insert(c)
+    }
+    if (!empty(astVisitor.err) && empty(res.err)) {
+        res.err = "{fn.name}: {astVisitor.err}"
+    }
+    unsafe {
+        delete astVisitor
+    }
+}
+
+//! Classify which `tracked` globals `fn` reads and writes, recursing into same-module callees
+//! (helpers access the globals directly; passing a tracked global BY ARGUMENT is refused — see
+//! AccessResult.err). Recursion is name-keyed over `mod`'s functions with a visited-set guard.
+def classify_global_access(fn : Function?; mod : Module?; tracked : table<string>) : AccessResult {
+    var res : AccessResult
+    var pending : table<string>
+    var visited : table<string>
+    var callees : table<string>
+    analyze_one(fn, tracked, res, callees)
+    visited |> insert(string(fn.name))
+    for (c in keys(callees)) {
+        pending |> insert(c)
+    }
+    while (!empty(pending)) {
+        var name = ""
+        for (p in keys(pending)) {
+            name = p
+            break
+        }
+        pending |> erase(name)
+        if (key_exists(visited, name)) {
+            continue
+        }
+        visited |> insert(name)
+        var next : table<string>
+        mod |> for_each_function(name) $(cfn) {
+            if (cfn.name == name) {
+                analyze_one(cfn, tracked, res, next)
+            }
+        }
+        for (c in keys(next)) {
+            if (!key_exists(visited, c)) {
+                pending |> insert(c)
+            }
+        }
+        delete next
+    }
+    delete pending
+    delete visited
+    delete callees
+    return <- res
+}

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1476,7 +1476,7 @@ var g_moe_gpu_attn_route = true        // runtime routing gate over the attentio
 // symbol. reserve/place fill the arenas; prepare/norms/set_layer/set_cls build it; token runs one forward.
 typedef RdecReserveFn = function<(fmt : int; cap_blocks : int64) : bool>
 typedef RdecPlaceFn = function<(wq : array<uint8>; ws : array<uint8>; n : int64; rows : int64; fmt : int) : int64>
-typedef RdecPrepareFn = function<(n_layers : int64; dim : int64; qd : int64; kv_dim : int64; head_size : int64; n_heads : int64; hidden : int64; vocab : int64; seq_cap : int64; neox : bool; eps : float; scale : float) : bool>
+typedef RdecPrepareFn = function<(n_layers : int64; dim : int64; qd : int64; kv_dim : int64; head_size : int64; n_heads : int64; hidden : int64; vocab : int64; seq_cap : int64; neox : bool; eps : float; scale : float; qk_norm : bool) : bool>
 typedef RdecNormsFn = function<(norms : array<float>) : void>
 typedef RdecSetLayerFn = function<(l : int64; bq : int64; bk : int64; bv : int64; bo : int64; b1 : int64; b3 : int64; b2 : int64; fq : int; fk : int; fv : int; fo : int; f1 : int; f3 : int; f2 : int) : void>
 typedef RdecSetClsFn = function<(cls_block : int64; cls_fmt : int) : void>
@@ -1490,8 +1490,8 @@ typedef RdecReadKvBulkFn = function<(l : int64; kp : float?; vp : float?; npos :
 def private rdec_unset_reserve(fmt : int; cap_blocks : int64) : bool => false
 [unused_argument(wq, ws, n, rows, fmt)]
 def private rdec_unset_place(wq : array<uint8>; ws : array<uint8>; n, rows : int64; fmt : int) : int64 => -1l
-[unused_argument(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap, neox, eps, scale)]
-def private rdec_unset_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap : int64; neox : bool; eps, scale : float) : bool => false
+[unused_argument(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap, neox, eps, scale, qk_norm)]
+def private rdec_unset_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap : int64; neox : bool; eps, scale : float; qk_norm : bool) : bool => false
 [unused_argument(norms)]
 def private rdec_unset_norms(norms : array<float>) {}
 [unused_argument(l, bq, bk, bv, bo, b1, b3, b2, fq, fk, fv, fo, f1, f3, f2)]
@@ -1551,7 +1551,7 @@ def public install_moe_gpu_resident(reserve : RdecReserveFn; place : RdecPlaceFn
 def public moe_gpu_resident_installed() : bool => g_rdec_installed
 def public rdec_reserve(fmt : int; cap_blocks : int64) : bool => invoke(g_rdec_reserve, fmt, cap_blocks)
 def public rdec_place(wq : array<uint8>; ws : array<uint8>; n, rows : int64; fmt : int) : int64 => invoke(g_rdec_place, wq, ws, n, rows, fmt)
-def public rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap : int64; neox : bool; eps, scale : float) : bool => invoke(g_rdec_prepare, n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap, neox, eps, scale)
+def public rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap : int64; neox : bool; eps, scale : float; qk_norm : bool) : bool => invoke(g_rdec_prepare, n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap, neox, eps, scale, qk_norm)
 def public rdec_upload_norms(norms : array<float>) { invoke(g_rdec_norms, norms) }
 def public rdec_set_layer(l, bq, bk, bv, bo, b1, b3, b2 : int64; fq, fk, fv, fo, f1, f3, f2 : int) { invoke(g_rdec_set_layer, l, bq, bk, bv, bo, b1, b3, b2, fq, fk, fv, fo, f1, f3, f2) }
 def public rdec_set_cls(cls_block : int64; cls_fmt : int) { invoke(g_rdec_set_cls, cls_block, cls_fmt) }

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -2288,6 +2288,197 @@ def da_attn_b {
     }
 }
 
+// hs=128 flash-attention twin of da_attn_b (coopmat devices): QK^T on f16 MMAs (hoisted q frags),
+// shuffle-reduced online softmax, register-tiled PV over the f16 V tile. Same meta contract;
+// parity bar is IDS (f16 staging + different reduce order). Measured 5.0x da_attn_b (3060 Ti).
+
+var @workgroup fb_q : uint[2048]
+var @workgroup fb_kv : uint[2048]
+var @workgroup fb_p : float[1024]
+var @workgroup fb_m : float[32]
+var @workgroup fb_l : float[32]
+var @workgroup fb_a : float[32]
+
+[compute_shader(local_size_x=128, name="da_attn_b_h128_spv")]
+def da_attn_b_h128 {
+    let npos = vk_meta[0u]
+    let nh = vk_meta[1u]
+    let kvd = vk_meta[2u]
+    let kv_mul = vk_meta[4u]
+    let kbase = vk_meta[5u]
+    let vbase = vk_meta[6u]
+    let w0 = vk_meta[7u]
+    let scale = vk_xs[0u]
+    let qd = nh * 128u
+    let qtiles = (npos + 31u) / 32u
+    let h = gl_WorkGroupID.x / qtiles
+    let q0 = (gl_WorkGroupID.x % qtiles) * 32u
+    let tid = gl_LocalInvocationID.x
+    let warp = tid / 32u
+    let kvh = h / kv_mul
+    var i = tid
+    while (i < 2048u) {   // stage the 32-row q tile once, f32 -> f16 pairs
+        let qr = q0 + i / 64u
+        let jp = (i % 64u) * 2u
+        if (qr < npos) {
+            let src = qr * qd + h * 128u + jp
+            fb_q[i] = packHalf2x16(float2(vk_upf[src], vk_upf[src + 1u]))
+        } else {
+            fb_q[i] = 0u
+        }
+        i += 128u
+    }
+    if (tid < 32u) {
+        fb_m[tid] = -3.0e38
+        fb_l[tid] = 0.0
+    }
+    var o : float[32]   // 2 rows x 16 cols per thread
+    for (z in range(32)) {
+        o[z] = 0.0
+    }
+    let orow0 = (tid / 8u) * 2u
+    let oe = (tid % 8u) * 16u
+    let srow = tid / 4u
+    let cb = (tid % 4u) * 8u
+    let lane4 = tid % 4u
+    barrier()
+    // my S block's q fragments — invariant across the whole K loop
+    let br = warp / 2u
+    let bc = warp % 2u
+    var qa0 : coopmatA_f16_16x16
+    var qa1 : coopmatA_f16_16x16
+    var qa2 : coopmatA_f16_16x16
+    var qa3 : coopmatA_f16_16x16
+    var qa4 : coopmatA_f16_16x16
+    var qa5 : coopmatA_f16_16x16
+    var qa6 : coopmatA_f16_16x16
+    var qa7 : coopmatA_f16_16x16
+    coopmatLoad(qa0, fb_q, int(br * 16u) * 64, 64, 0)
+    coopmatLoad(qa1, fb_q, int(br * 16u) * 64 + 8, 64, 0)
+    coopmatLoad(qa2, fb_q, int(br * 16u) * 64 + 16, 64, 0)
+    coopmatLoad(qa3, fb_q, int(br * 16u) * 64 + 24, 64, 0)
+    coopmatLoad(qa4, fb_q, int(br * 16u) * 64 + 32, 64, 0)
+    coopmatLoad(qa5, fb_q, int(br * 16u) * 64 + 40, 64, 0)
+    coopmatLoad(qa6, fb_q, int(br * 16u) * 64 + 48, 64, 0)
+    coopmatLoad(qa7, fb_q, int(br * 16u) * 64 + 56, 64, 0)
+    let kend = w0 + min(q0 + 32u, npos)
+    var k0 = 0u
+    while (k0 < kend) {
+        i = tid
+        while (i < 2048u) {   // K tile, f16 pairs
+            let kr = k0 + i / 64u
+            let jp = (i % 64u) * 2u
+            if (kr < kend) {
+                let src = kbase + kr * kvd + kvh * 128u + jp
+                fb_kv[i] = packHalf2x16(float2(vk_wsf[src], vk_wsf[src + 1u]))
+            } else {
+                fb_kv[i] = 0u
+            }
+            i += 128u
+        }
+        barrier()
+        var acc : coopmatAcc_f32_16x16
+        var kb : coopmatB_f16_16x16
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64, 64, 1)
+        acc = coopmatMulAdd(qa0, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 8, 64, 1)
+        acc = coopmatMulAdd(qa1, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 16, 64, 1)
+        acc = coopmatMulAdd(qa2, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 24, 64, 1)
+        acc = coopmatMulAdd(qa3, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 32, 64, 1)
+        acc = coopmatMulAdd(qa4, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 40, 64, 1)
+        acc = coopmatMulAdd(qa5, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 48, 64, 1)
+        acc = coopmatMulAdd(qa6, kb, acc)
+        coopmatLoad(kb, fb_kv, int(bc * 16u) * 64 + 56, 64, 1)
+        acc = coopmatMulAdd(qa7, kb, acc)
+        coopmatStore(acc, fb_p, int(br * 16u) * 32 + int(bc * 16u), 32, 0)
+        barrier()
+        // online softmax: 4 threads/row (8 cols each), shuffle-reduced within the aligned quad
+        let gq = w0 + q0 + srow
+        let m_old = fb_m[srow]
+        var mloc = -3.0e38
+        for [unroll] (j in range(8)) {
+            let idx = srow * 32u + cb + uint(j)
+            let gk = k0 + cb + uint(j)
+            let s = (gk <= gq && q0 + srow < npos && gk < kend) ? fb_p[idx] * scale : -3.0e38
+            fb_p[idx] = s
+            mloc = max(mloc, s)
+        }
+        mloc = max(mloc, subgroupShuffleXor(mloc, 1u))
+        mloc = max(mloc, subgroupShuffleXor(mloc, 2u))
+        let mt = max(m_old, mloc)
+        var lloc = 0.0
+        for [unroll] (j in range(8)) {
+            let idx = srow * 32u + cb + uint(j)
+            let e = exp(fb_p[idx] - mt)
+            fb_p[idx] = e
+            lloc += e
+        }
+        lloc += subgroupShuffleXor(lloc, 1u)
+        lloc += subgroupShuffleXor(lloc, 2u)
+        if (lane4 == 0u) {
+            let alpha = exp(m_old - mt)
+            fb_l[srow] = fb_l[srow] * alpha + lloc
+            fb_m[srow] = mt
+            fb_a[srow] = alpha
+        }
+        barrier()
+        i = tid
+        while (i < 2048u) {   // V tile reuses the K staging
+            let kr = k0 + i / 64u
+            let jp = (i % 64u) * 2u
+            if (kr < kend) {
+                let src = vbase + kr * kvd + kvh * 128u + jp
+                fb_kv[i] = packHalf2x16(float2(vk_xqf[src], vk_xqf[src + 1u]))
+            } else {
+                fb_kv[i] = 0u
+            }
+            i += 128u
+        }
+        barrier()
+        let av0 = fb_a[orow0]
+        let av1 = fb_a[orow0 + 1u]
+        for (z in range(16)) {
+            o[z] *= av0
+            o[16 + z] *= av1
+        }
+        var c2 = 0u
+        while (c2 < 32u) {
+            let pw0 = fb_p[orow0 * 32u + c2]
+            let pw1 = fb_p[(orow0 + 1u) * 32u + c2]
+            let vb = c2 * 64u + oe / 2u
+            for [unroll] (zp in range(8)) {
+                let pair = unpackHalf2x16(fb_kv[vb + uint(zp)])
+                o[zp * 2] += pw0 * pair.x
+                o[zp * 2 + 1] += pw0 * pair.y
+                o[16 + zp * 2] += pw1 * pair.x
+                o[16 + zp * 2 + 1] += pw1 * pair.y
+            }
+            c2++
+        }
+        barrier()
+        k0 += 32u
+    }
+    if (q0 + orow0 < npos) {
+        let inv0 = 1.0 / fb_l[orow0]
+        let ob0 = (q0 + orow0) * qd + h * 128u + oe
+        for (z in range(16)) {
+            vk_y[ob0 + uint(z)] = o[z] * inv0
+        }
+    }
+    if (q0 + orow0 + 1u < npos) {
+        let inv1 = 1.0 / fb_l[orow0 + 1u]
+        let ob1 = (q0 + orow0 + 1u) * qd + h * 128u + oe
+        for (z in range(16)) {
+            vk_y[ob1 + uint(z)] = o[16 + z] * inv1
+        }
+    }
+}
+
 // batched rope + KV-store (prefill, npos positions). q roped in place (vk_upf); k/v ride vk_y (k at
 // 0, v at voff); roped k -> vk_wsf, raw v -> vk_xqf at absolute pos. cos/sin per pos in vk_xs.
 // meta 0=qd 1=kvd 2=hs 3=half 4=neox 5=kpair0 6=pairs/pos 7=layerbase 9=npos 10=pos0 11=voff
@@ -3367,7 +3558,8 @@ struct private GpuState {
     da_pipeline : Pipeline          // resident driver: decode attention over the f32 KV mirror
     ar_pipeline_b : Pipeline        // prefill: batched add+rmsnorm
     rks_b_pipeline : Pipeline       // prefill: batched rope + KV-store
-    da_b_pipeline : Pipeline        // prefill: batched causal attention
+    da_b_pipeline : Pipeline        // prefill: batched causal attention (generic hs)
+    da_b128_pipeline : Pipeline     // prefill: the hs=128 coopmat flash-attention twin (coopmat devices)
     qkn_pipeline : Pipeline         // resident driver: per-head q/k rmsnorm (qk_norm models), decode + prefill
     staging : HostBuf
     fence : VkFence          // the one reusable submit fence (reset after every wait)
@@ -3643,7 +3835,7 @@ def private vk_moe_init : bool {
         return false
     }
     g_gpu.fam = select_graphics_queue_family(g_gpu.phys)
-    // coopmat device features are only requested when a DASLLAMA_COOPMAT mode is actually selected
+    // coopmat requested whenever supported — the fa twin needs it even in sdot4 GEMM mode
     g_gpu.has_coopmat = cooperative_matrix_supported(g_gpu.phys)
     g_gpu.coopmat_mode = 0
     if (g_gpu.has_coopmat) {
@@ -3656,10 +3848,12 @@ def private vk_moe_init : bool {
             g_gpu.coopmat_mode = 3
         }
     }
-    if (g_gpu.coopmat_mode != 0) {
+    if (g_gpu.has_coopmat) {
         g_gpu.device <- create_device_storage_8_16_int_dot_coopmat(g_gpu.phys, g_gpu.fam)
-        let cm_name = g_gpu.coopmat_mode == 1 ? "f16" : (g_gpu.coopmat_mode == 2 ? "int8" : "mul_mm L-tile")
-        to_log(LOG_INFO, "dasLLAMA vulkan tier: Q8_0 prefill on {cm_name} cooperative-matrix tiles\n")
+        if (g_gpu.coopmat_mode != 0) {
+            let cm_name = g_gpu.coopmat_mode == 1 ? "f16" : (g_gpu.coopmat_mode == 2 ? "int8" : "mul_mm L-tile")
+            to_log(LOG_INFO, "dasLLAMA vulkan tier: Q8_0 prefill on {cm_name} cooperative-matrix tiles\n")
+        }
     } else {
         g_gpu.device <- create_device_storage_8_16_int_dot(g_gpu.phys, g_gpu.fam)
     }
@@ -3767,6 +3961,9 @@ def private vk_moe_init : bool {
     g_gpu.ar_pipeline_b <- make_kernel_pipe("ar_add_rms_b", ar_add_rms_b_spv)
     g_gpu.rks_b_pipeline <- make_kernel_pipe("rope_kv_store_b", rope_kv_store_b_spv)
     g_gpu.da_b_pipeline <- make_kernel_pipe("da_attn_b", da_attn_b_spv)
+    if (g_gpu.has_coopmat) {
+        g_gpu.da_b128_pipeline <- make_kernel_pipe("da_attn_b_h128", da_attn_b_h128_spv)
+    }
     g_gpu.qkn_pipeline <- make_kernel_pipe("qk_rms", qk_rms_spv)
 
     var fence <- create_fence(g_gpu.device, FenceCreateInfo())   // never finalized (process-lifetime)
@@ -5047,6 +5244,15 @@ def private vhz_trace : bool {
     return g_vhz_trace != 0
 }
 
+var private g_vk_fa = -1   // DASLLAMA_VK_FA=0 pins the generic da_attn_b (flash-attn bisect hatch)
+
+def private vk_fa_on : bool {
+    if (g_vk_fa < 0) {
+        g_vk_fa = get_env_variable("DASLLAMA_VK_FA") == "0" ? 0 : 1
+    }
+    return g_vk_fa != 0
+}
+
 // the per-node gate: barrier iff this node's declared masks conflict with the pending set
 def private vhz_dep(raw : VkCommandBuffer; var h : VkHaz; rmask, wmask : uint; transfer : bool = false) {
     h.disp++
@@ -5503,7 +5709,8 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
             pfq_ts(raw)   // q1: meta copy
             let ropewg = uint((wlen * pairs + int64(WG_X) - 1l) / int64(WG_X))
-            let attnwg = uint(g_rd.n_heads * ((wlen + 7l) / 8l))
+            let fa128 = g_gpu.has_coopmat && g_rd.head_size == 128l && vk_fa_on()
+            let attnwg = uint(fa128 ? g_rd.n_heads * ((wlen + 31l) / 32l) : g_rd.n_heads * ((wlen + 7l) / 8l))
             rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(wlen), h)   // prologue norm
             for (l in range64(g_rd.n_layers)) {
                 let b = int(l * PF_ROLES)
@@ -5518,7 +5725,7 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
                         uint(wlen * (g_rd.n_heads + kvd / g_rd.head_size)), h)
                 }
                 rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg, h)
-                rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg, h)
+                rd_dispatch(raw, weak_copy(fa128 ? g_gpu.da_b128_pipeline : g_gpu.da_b_pipeline), g_rd.pf_sets[b + 5], attnwg, h)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l), h)
                 rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h)
                 rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen), h)

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4489,8 +4489,8 @@ def private fill_addrms_meta(hb : HostBuf; dim, woff : int64; add : bool) {
 def private rd_gemv_wg(rows : int64) : uint => uint((rows + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg)
 
 // ===== GPU per-dispatch profiler (DASLLAMA_GPU_PROF=1) =====
-// BOTTOM_OF_PIPE timestamp after each profiled dispatch (every one ends on a full barrier, so
-// deltas are per-role GPU wall time); results ride a copy in the same submit, no extra fence
+// BOTTOM_OF_PIPE stamps; results ride a same-submit copy, no extra fence. Overlapped hazard
+// levels put the whole level's cost on the LAST member's delta (earlier members read near-zero)
 let private PFQ_CAP = 2048u
 var private g_pfq_pool : QueryPool
 var private g_pfq_buf : HostBuf
@@ -4550,23 +4550,101 @@ def private pfq_us(i : uint) : double {
     }
 }
 
-// bar = false joins the NEXT dispatch into one barrier level — the caller owns the disjointness proof
-def private rd_dispatch(raw : VkCommandBuffer; pipe : Pipeline; var set : VkDescriptorSet; groups : uint; bar : bool = true) {
+// ===== the hazard-mask rail (the dasLLAMA-metal bar_dep port: declared masks, derived barriers) =====
+// Nodes declare role-bit (region, not VkBuffer) r/w masks; barrier only on RAW/WAW/WAR vs pending, then reset.
+// Barrier dst is always full-stage (the wholesale reset relies on it); src narrows to the pending stages.
+
+let private VHZ_X = 0x1u          // residual x
+let private VHZ_XB = 0x2u         // normed panel xb
+let private VHZ_XQ = 0x4u         // quantized activations xq+xs
+let private VHZ_Q = 0x8u          // q rows
+let private VHZ_KVK = 0x10u       // kv panel, k half
+let private VHZ_KVV = 0x20u       // kv panel, v half
+let private VHZ_VST = 0x40u       // prefill v-GEMM staging (pf_v)
+let private VHZ_MIR = 0x80u       // k/v mirrors
+let private VHZ_ATT = 0x100u      // attention out
+let private VHZ_AQ = 0x200u       // quantized attention out aq+as
+let private VHZ_XB2 = 0x400u      // wo out
+let private VHZ_GATE = 0x800u     // ffn gate plane
+let private VHZ_UP = 0x1000u      // ffn up plane
+let private VHZ_HQ = 0x2000u      // requantized hidden hq+hs
+let private VHZ_FFO = 0x4000u     // ffn down out
+let private VHZ_META = 0x8000u    // ffn_meta_dev
+let private VHZ_LOG = 0x10000u    // logits
+let private VHZ_COS = 0x20000u    // rope cos/sin rows
+
+struct private VkHaz {
+    w : uint            // bits with a pending (unbarriered) write
+    r : uint            // bits with a pending read
+    pend_compute : bool // stages present in the pending set — the next barrier's src side
+    pend_transfer : bool
+    barriers : int
+    disp : int
+}
+
+var private g_vhz_paranoid = -1   // DASLLAMA_VK_HAZARD_PARANOID: barrier before every node
+
+def private vhz_paranoid : bool {
+    if (g_vhz_paranoid < 0) {
+        g_vhz_paranoid = get_env_variable("DASLLAMA_VK_HAZARD_PARANOID") == "1" ? 1 : 0
+    }
+    return g_vhz_paranoid != 0
+}
+
+// the per-node gate: barrier iff this node's declared masks conflict with the pending set
+def private vhz_dep(raw : VkCommandBuffer; var h : VkHaz; rmask, wmask : uint; transfer : bool = false) {
+    h.disp++
+    var bar = (rmask & h.w) != 0u || (wmask & h.w) != 0u || (wmask & h.r) != 0u
+    if (vhz_paranoid() && (h.w != 0u || h.r != 0u)) {
+        bar = true
+    }
+    if (bar) {
+        var mb : MemoryBarrier
+        mb.srcAccessMask.shader_write = h.pend_compute
+        mb.srcAccessMask.transfer_write = h.pend_transfer
+        mb.dstAccessMask.shader_read = true
+        mb.dstAccessMask.shader_write = true
+        mb.dstAccessMask.transfer_read = true
+        mb.dstAccessMask.transfer_write = true
+        var mbs : array<MemoryBarrier>
+        mbs |> emplace(mb)
+        var sstage : VkPipelineStageFlags
+        sstage.compute_shader = h.pend_compute
+        sstage.transfer = h.pend_transfer
+        var dstage : VkPipelineStageFlags
+        dstage.compute_shader = true
+        dstage.transfer = true
+        let dflags : VkDependencyFlags
+        let no_bufb : array<BufferMemoryBarrier>
+        let no_imgb : array<ImageMemoryBarrier>
+        cmd_pipeline_barrier(vk_value_to_boost(raw), sstage, dstage, dflags, mbs, no_bufb, no_imgb)
+        h.w = 0u
+        h.r = 0u
+        h.pend_compute = false
+        h.pend_transfer = false
+        h.barriers++
+    }
+    h.r |= rmask
+    h.w |= wmask
+    if (transfer) {
+        h.pend_transfer = true
+    } else {
+        h.pend_compute = true
+    }
+}
+
+def private rd_dispatch(raw : VkCommandBuffer; pipe : Pipeline; var set : VkDescriptorSet; groups : uint; var h : VkHaz; rmask, wmask : uint) {
+    vhz_dep(raw, h, rmask, wmask)
     cmd_bind_pipeline(vk_value_to_boost(raw), pipe, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, set, groups)
-    if (bar) {
-        comp_barrier(raw)
-    }
     pfq_ts(raw)
 }
 
 // GEMV dispatch — the per-format kernel selected off the plane format
-def private rd_dispatch_gemv(raw : VkCommandBuffer; fmt : int; var set : VkDescriptorSet; groups : uint; bar : bool = true) {
+def private rd_dispatch_gemv(raw : VkCommandBuffer; fmt : int; var set : VkDescriptorSet; groups : uint; var h : VkHaz; rmask, wmask : uint) {
+    vhz_dep(raw, h, rmask, wmask)
     bind_gemv_pipe(raw, fmt)
     cmd_bind_dispatch(raw, set, groups)
-    if (bar) {
-        comp_barrier(raw)
-    }
     pfq_ts(raw)
 }
 
@@ -4631,37 +4709,41 @@ def private rd_record_token {
         vk_check(vkResetCommandBuffer(raw, rf), null)
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHZ_X, true)
         cmd_copy_whole(raw, g_rd.x_host.buf, g_rd.x_dev, dim * 4l)
+        vhz_dep(raw, h, 0u, VHZ_COS, true)
         cmd_copy_whole(raw, g_rd.cos_host.buf, g_rd.cos_dev, g_rd.head_size * 4l)
+        vhz_dep(raw, h, 0u, VHZ_META, true)
         cmd_copy_whole(raw, g_rd.ffn_meta_h.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-        batch_barrier(raw, true)   // transfer -> compute (a compute-only barrier under-orders these copies)
-        rd_dispatch(raw, g_gpu.ar_pipeline, g_rd.s_prologue, 1u)   // xb = rms_att[0](x)
+        rd_dispatch(raw, g_gpu.ar_pipeline, g_rd.s_prologue, 1u, h, VHZ_X, VHZ_XB)   // xb = rms_att[0](x)
         for (l in range64(g_rd.n_layers)) {
             var L & = g_rd.layers[l]
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb, uint((dim / 32l + 255l) / 256l))
-            // q|k|v: one level — all read xq/xs; q writes q_dev, k/v disjoint kv_dev ranges
-            rd_dispatch_gemv(raw, L.fq, L.s_q, rd_gemv_wg(qd), [bar = false])
-            rd_dispatch_gemv(raw, L.fk, L.s_k, rd_gemv_wg(kvd), [bar = false])
-            rd_dispatch_gemv(raw, L.fv, L.s_v, rd_gemv_wg(kvd))
+            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb, uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
+            rd_dispatch_gemv(raw, L.fq, L.s_q, rd_gemv_wg(qd), h, VHZ_XQ, VHZ_Q)
+            rd_dispatch_gemv(raw, L.fk, L.s_k, rd_gemv_wg(kvd), h, VHZ_XQ, VHZ_KVK)
+            rd_dispatch_gemv(raw, L.fv, L.s_v, rd_gemv_wg(kvd), h, VHZ_XQ, VHZ_KVV)
             if (g_rd.qk_norm) {
-                rd_dispatch(raw, g_gpu.qkn_pipeline, L.s_qkn, uint(g_rd.n_heads + kvd / g_rd.head_size))
+                rd_dispatch(raw, g_gpu.qkn_pipeline, L.s_qkn, uint(g_rd.n_heads + kvd / g_rd.head_size),
+                    h, VHZ_Q | VHZ_KVK, VHZ_Q | VHZ_KVK)
             }
-            rd_dispatch(raw, g_gpu.rks_pipeline, L.s_rope, uint((qd / 2l + kvd / 2l + int64(WG_X) - 1l) / int64(WG_X)))
-            rd_dispatch(raw, g_gpu.da_pipeline, L.s_attn, uint(g_rd.n_heads))
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_at, uint((qd / 32l + 255l) / 256l))
-            rd_dispatch_gemv(raw, L.fo, L.s_wo, rd_gemv_wg(dim))
-            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_ffn, 1u)
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb2, uint((dim / 32l + 255l) / 256l))
-            // gate|up: one level — both read xq/xs, write gate_dev / up_dev
-            rd_dispatch_gemv(raw, L.f1, L.s_gate, rd_gemv_wg(hid), [bar = false])
-            rd_dispatch_gemv(raw, L.f3, L.s_up, rd_gemv_wg(hid))
-            rd_dispatch(raw, g_gpu.actrq_pipeline, L.s_actrq, uint((hid / 32l + 255l) / 256l))
-            rd_dispatch_gemv(raw, L.f2, L.s_down, rd_gemv_wg(dim))
-            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_next, 1u)
+            rd_dispatch(raw, g_gpu.rks_pipeline, L.s_rope, uint((qd / 2l + kvd / 2l + int64(WG_X) - 1l) / int64(WG_X)),
+                h, VHZ_Q | VHZ_KVK | VHZ_KVV | VHZ_COS, VHZ_Q | VHZ_KVK | VHZ_MIR)
+            rd_dispatch(raw, g_gpu.da_pipeline, L.s_attn, uint(g_rd.n_heads), h, VHZ_Q | VHZ_MIR, VHZ_ATT)
+            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_at, uint((qd / 32l + 255l) / 256l), h, VHZ_ATT, VHZ_AQ)
+            rd_dispatch_gemv(raw, L.fo, L.s_wo, rd_gemv_wg(dim), h, VHZ_AQ, VHZ_XB2)
+            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_ffn, 1u, h, VHZ_X | VHZ_XB2, VHZ_X | VHZ_XB)
+            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb2, uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
+            rd_dispatch_gemv(raw, L.f1, L.s_gate, rd_gemv_wg(hid), h, VHZ_XQ, VHZ_GATE)
+            rd_dispatch_gemv(raw, L.f3, L.s_up, rd_gemv_wg(hid), h, VHZ_XQ, VHZ_UP)
+            rd_dispatch(raw, g_gpu.actrq_pipeline, L.s_actrq, uint((hid / 32l + 255l) / 256l),
+                h, VHZ_GATE | VHZ_UP | VHZ_META, VHZ_HQ)
+            rd_dispatch_gemv(raw, L.f2, L.s_down, rd_gemv_wg(dim), h, VHZ_HQ, VHZ_FFO)
+            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_next, 1u, h, VHZ_X | VHZ_FFO, VHZ_X | VHZ_XB)
         }
-        rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.s_quant_final, uint((dim / 32l + 255l) / 256l))
-        rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab))
-        batch_barrier(raw, false)   // compute -> transfer for the logits DMA
+        rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.s_quant_final, uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
+        rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab), h, VHZ_XQ, VHZ_LOG)
+        vhz_dep(raw, h, VHZ_LOG, 0u, true)   // compute -> transfer for the logits DMA
         cmd_copy_whole(raw, g_rd.logits_dev, g_rd.logits_host.buf, g_rd.vocab * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
     }
@@ -4947,40 +5029,47 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             vk_check(vkBeginCommandBuffer(raw, begin), null)
             pfq_begin(raw)
             pfq_ts(raw)   // q0: submit start
+            var h : VkHaz
+            vhz_dep(raw, h, 0u, VHZ_META, true)
             cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-            comp_barrier(raw)
             pfq_ts(raw)   // q1: meta copy
             let ropewg = uint((wlen * pairs + int64(WG_X) - 1l) / int64(WG_X))
             let attnwg = uint(g_rd.n_heads * ((wlen + 7l) / 8l))
-            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(wlen))   // prologue norm
+            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(wlen), h, VHZ_X, VHZ_XB)   // prologue norm
             for (l in range64(g_rd.n_layers)) {
                 let b = int(l * PF_ROLES)
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0))
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h, VHZ_XQ, VHZ_Q)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h, VHZ_XQ, VHZ_KVK)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h, VHZ_XQ, VHZ_VST)
+                vhz_dep(raw, h, VHZ_VST, VHZ_KVV, true)
                 cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
-                comp_barrier(raw)
                 if (g_rd.qk_norm) {
                     rd_dispatch(raw, g_gpu.qkn_pipeline, g_rd.pf_sets[b + 15],
-                        uint(wlen * (g_rd.n_heads + kvd / g_rd.head_size)))
+                        uint(wlen * (g_rd.n_heads + kvd / g_rd.head_size)), h, VHZ_Q | VHZ_KVK, VHZ_Q | VHZ_KVK)
                 }
-                rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg)
-                rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg)
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0))
-                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen))
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0))
-                rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l))
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0))
-                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen))
+                rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg,
+                    h, VHZ_Q | VHZ_KVK | VHZ_KVV | VHZ_COS, VHZ_Q | VHZ_KVK | VHZ_MIR)
+                rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg, h, VHZ_Q | VHZ_MIR, VHZ_ATT)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l), h, VHZ_ATT, VHZ_AQ)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h, VHZ_AQ, VHZ_XB2)
+                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen), h, VHZ_X | VHZ_XB2, VHZ_X | VHZ_XB)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h, VHZ_XQ, VHZ_GATE)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h, VHZ_XQ, VHZ_UP)
+                rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l),
+                    h, VHZ_GATE | VHZ_UP | VHZ_META, VHZ_HQ)
+                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h, VHZ_HQ, VHZ_FFO)
+                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen), h, VHZ_X | VHZ_FFO, VHZ_X | VHZ_XB)
             }
             if (last) {
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[bp + 1], uint((dim / 32l + 255l) / 256l))
-                rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab))
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[bp + 1], uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
+                rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab), h, VHZ_XQ, VHZ_LOG)
+                vhz_dep(raw, h, VHZ_LOG, 0u, true)
                 cmd_copy_whole(raw, g_rd.logits_dev, g_rd.pf_logits_host.buf, g_rd.vocab * 4l)
+            }
+            if (vk_prof()) {
+                to_log(LOG_INFO, "vk_rdpf hz: {h.disp} nodes, {h.barriers} barriers\n")
             }
             pfq_end(raw)
             vk_check(vkEndCommandBuffer(raw), null)
@@ -4992,9 +5081,9 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             w0 += wlen
         }
         memcpy(addr<void?>(logits[0]), g_rd.pf_logits_host.mapped, int(g_rd.vocab * 4l))
-        // per-role GPU aggregation: q0 start, q1 meta, q2 prologue, then rpl/layer, final rq, cls —
-        // only when every stamp landed (a very deep graph would overflow PFQ_CAP and truncate).
-        // Multi-window prompts: the stamps cover the LAST window only (the one with fin_rq + cls).
+        // per-role GPU aggregation (q0 start, q1 meta, q2 prologue, rpl/layer, final rq, cls), only when
+        // every stamp landed (deep graphs overflow PFQ_CAP). Multi-window prompts: LAST window only.
+        // Overlapped levels (q|k|v, gate|up) put the whole level's cost on the LAST member's delta.
         let rpl = g_rd.qk_norm ? 16l : 15l
         if (vk_prof() && g_pfq_n == 5u + uint(g_rd.n_layers * rpl)) {
             var role : double[16]

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -5,11 +5,14 @@ module dasllama_math_vulkan shared public
 
 require dasllama/dasllama_math
 require dasllama/dasllama_par
+require dasllama/dasllama_vulkan_lens
 require vulkan
 require vulkan/vulkan_boost
 require spirv/spirv_shader
 require spirv/spirv_builtins public
 require math
+require strings
+require daslib/strings_boost
 require daslib/fio
 
 // dasLLAMA Vulkan GPU tier — per-layer MoE expert-stack offload. The loader gathers offloaded
@@ -3722,83 +3725,49 @@ def private vk_moe_init : bool {
     dpci.pPoolSizes |> push(psize)
     g_gpu.desc_pool <- create_descriptor_pool(g_gpu.device, dpci)
 
-    var shader <- create_shader_module(g_gpu.device, q8_moe_groupn_spv)   // never finalized (kept via pipeline)
     var plci : PipelineLayoutCreateInfo
     plci.pSetLayouts <- [weak_copy(g_gpu.set_layout)]
     g_gpu.pipe_layout <- create_pipeline_layout(g_gpu.device, plci)
-    g_gpu.pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, shader)
-    var bshader <- create_shader_module(g_gpu.device, q8_moe_batch_spv)   // same 6-binding layout
-    g_gpu.batch_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bshader)
+    g_pipe_access |> clear()
+    g_gpu.pipeline <- make_kernel_pipe("q8_moe_groupn", q8_moe_groupn_spv)
+    g_gpu.batch_pipeline <- make_kernel_pipe("q8_moe_batch", q8_moe_batch_spv)   // same 6-binding layout
     if (g_gpu.coopmat_mode == 1) {   // f16 tensor-core prefill GEMMs (coopmat device only)
-        var cmf16shader <- create_shader_module(g_gpu.device, q8_moe_batch_cmf16_spv)
-        g_gpu.batch_coopmat_f16 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmf16shader)
-        var cmq40shader <- create_shader_module(g_gpu.device, kq_moe_batch_q40_cmf16_spv)
-        g_gpu.batch_coopmat_q40 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmq40shader)
+        g_gpu.batch_coopmat_f16 <- make_kernel_pipe("q8_moe_batch_cmf16", q8_moe_batch_cmf16_spv)
+        g_gpu.batch_coopmat_q40 <- make_kernel_pipe("kq_moe_batch_q40_cmf16", kq_moe_batch_q40_cmf16_spv)
     } elif (g_gpu.coopmat_mode == 2) {   // native-s8 tensor-core prefill GEMM
-        var cmi8shader <- create_shader_module(g_gpu.device, q8_moe_batch_cmi8_spv)
-        g_gpu.batch_coopmat_i8 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmi8shader)
+        g_gpu.batch_coopmat_i8 <- make_kernel_pipe("q8_moe_batch_cmi8", q8_moe_batch_cmi8_spv)
     } elif (g_gpu.coopmat_mode == 3) {   // the mul_mm L/M-tile prefill GEMMs (routed per dispatch)
-        var cmmmshader <- create_shader_module(g_gpu.device, q8_moe_batch_mm_spv)
-        g_gpu.batch_coopmat_mm <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader)
-        var cmmmshader_m <- create_shader_module(g_gpu.device, q8_moe_batch_mm_m_spv)
-        g_gpu.batch_coopmat_mm_m <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader_m)
-        var cmmmshader_a <- create_shader_module(g_gpu.device, q8_moe_batch_mm_a_spv)
-        g_gpu.batch_coopmat_mm_a <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader_a)
+        g_gpu.batch_coopmat_mm <- make_kernel_pipe("q8_moe_batch_mm", q8_moe_batch_mm_spv)
+        g_gpu.batch_coopmat_mm_m <- make_kernel_pipe("q8_moe_batch_mm_m", q8_moe_batch_mm_m_spv)
+        g_gpu.batch_coopmat_mm_a <- make_kernel_pipe("q8_moe_batch_mm_a", q8_moe_batch_mm_a_spv)
     }
-    var ashader <- create_shader_module(g_gpu.device, q8_moe_actrq_spv)
-    g_gpu.actrq_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, ashader)
-    var k4shader <- create_shader_module(g_gpu.device, kq_moe_gemv_k4_spv)
-    g_gpu.gemv_k4 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, k4shader)
-    var k5shader <- create_shader_module(g_gpu.device, kq_moe_gemv_k5_spv)
-    g_gpu.gemv_k5 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, k5shader)
-    var k6shader <- create_shader_module(g_gpu.device, kq_moe_gemv_k6_spv)
-    g_gpu.gemv_k6 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, k6shader)
-    var q40shader <- create_shader_module(g_gpu.device, kq_moe_gemv_q40_spv)
-    g_gpu.gemv_q40 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, q40shader)
-    var rkshader <- create_shader_module(g_gpu.device, q8k_moe_actrq_spv)
-    g_gpu.actrq_k_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, rkshader)
-    var bk4shader <- create_shader_module(g_gpu.device, kq_moe_batch_k4_spv)
-    g_gpu.batch_k4 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bk4shader)
-    var bk5shader <- create_shader_module(g_gpu.device, kq_moe_batch_k5_spv)
-    g_gpu.batch_k5 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bk5shader)
-    var bk6shader <- create_shader_module(g_gpu.device, kq_moe_batch_k6_spv)
-    g_gpu.batch_k6 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bk6shader)
-    var bq40shader <- create_shader_module(g_gpu.device, kq_moe_batch_q40_spv)
-    g_gpu.batch_q40 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, bq40shader)
-    var cshader <- create_shader_module(g_gpu.device, moe_combine_spv)
-    g_gpu.comb_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cshader)
-    var dcshader <- create_shader_module(g_gpu.device, dn_conv_spv)
-    g_gpu.dn_conv_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, dcshader)
-    var dfshader <- create_shader_module(g_gpu.device, dn_step_fused_spv)
-    g_gpu.dnd_fused_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, dfshader)
-    var ds1shader <- create_shader_module(g_gpu.device, dn_scan_p1_spv)
-    g_gpu.dn_scan_p1_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, ds1shader)
-    var ds2shader <- create_shader_module(g_gpu.device, dn_scan_p2_spv)
-    g_gpu.dn_scan_p2_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, ds2shader)
-    var drshader <- create_shader_module(g_gpu.device, dn_requant_spv)
-    g_gpu.dn_rq_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, drshader)
-    var apqshader <- create_shader_module(g_gpu.device, at_prep_q_spv)
-    g_gpu.at_prep_q_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, apqshader)
-    var apkshader <- create_shader_module(g_gpu.device, at_prep_k_spv)
-    g_gpu.at_prep_k_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, apkshader)
-    var atshader <- create_shader_module(g_gpu.device, at_attn_spv)
-    g_gpu.at_attn_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, atshader)
-    var qkrshader <- create_shader_module(g_gpu.device, q8k_requant_spv)
-    g_gpu.q8k_rq_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, qkrshader)
-    var arshader <- create_shader_module(g_gpu.device, ar_add_rms_spv)
-    g_gpu.ar_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, arshader)
-    var rksshader <- create_shader_module(g_gpu.device, rope_kv_store_spv)
-    g_gpu.rks_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, rksshader)
-    var dashader <- create_shader_module(g_gpu.device, da_attn_spv)
-    g_gpu.da_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, dashader)
-    var arbshader <- create_shader_module(g_gpu.device, ar_add_rms_b_spv)
-    g_gpu.ar_pipeline_b <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, arbshader)
-    var rksbshader <- create_shader_module(g_gpu.device, rope_kv_store_b_spv)
-    g_gpu.rks_b_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, rksbshader)
-    var dabshader <- create_shader_module(g_gpu.device, da_attn_b_spv)
-    g_gpu.da_b_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, dabshader)
-    var qknshader <- create_shader_module(g_gpu.device, qk_rms_spv)
-    g_gpu.qkn_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, qknshader)
+    g_gpu.actrq_pipeline <- make_kernel_pipe("q8_moe_actrq", q8_moe_actrq_spv)
+    g_gpu.gemv_k4 <- make_kernel_pipe("kq_moe_gemv_k4", kq_moe_gemv_k4_spv)
+    g_gpu.gemv_k5 <- make_kernel_pipe("kq_moe_gemv_k5", kq_moe_gemv_k5_spv)
+    g_gpu.gemv_k6 <- make_kernel_pipe("kq_moe_gemv_k6", kq_moe_gemv_k6_spv)
+    g_gpu.gemv_q40 <- make_kernel_pipe("kq_moe_gemv_q40", kq_moe_gemv_q40_spv)
+    g_gpu.actrq_k_pipeline <- make_kernel_pipe("q8k_moe_actrq", q8k_moe_actrq_spv)
+    g_gpu.batch_k4 <- make_kernel_pipe("kq_moe_batch_k4", kq_moe_batch_k4_spv)
+    g_gpu.batch_k5 <- make_kernel_pipe("kq_moe_batch_k5", kq_moe_batch_k5_spv)
+    g_gpu.batch_k6 <- make_kernel_pipe("kq_moe_batch_k6", kq_moe_batch_k6_spv)
+    g_gpu.batch_q40 <- make_kernel_pipe("kq_moe_batch_q40", kq_moe_batch_q40_spv)
+    g_gpu.comb_pipeline <- make_kernel_pipe("moe_combine", moe_combine_spv)
+    g_gpu.dn_conv_pipeline <- make_kernel_pipe("dn_conv", dn_conv_spv)
+    g_gpu.dnd_fused_pipeline <- make_kernel_pipe("dn_step_fused", dn_step_fused_spv)
+    g_gpu.dn_scan_p1_pipeline <- make_kernel_pipe("dn_scan_p1", dn_scan_p1_spv)
+    g_gpu.dn_scan_p2_pipeline <- make_kernel_pipe("dn_scan_p2", dn_scan_p2_spv)
+    g_gpu.dn_rq_pipeline <- make_kernel_pipe("dn_requant", dn_requant_spv)
+    g_gpu.at_prep_q_pipeline <- make_kernel_pipe("at_prep_q", at_prep_q_spv)
+    g_gpu.at_prep_k_pipeline <- make_kernel_pipe("at_prep_k", at_prep_k_spv)
+    g_gpu.at_attn_pipeline <- make_kernel_pipe("at_attn", at_attn_spv)
+    g_gpu.q8k_rq_pipeline <- make_kernel_pipe("q8k_requant", q8k_requant_spv)
+    g_gpu.ar_pipeline <- make_kernel_pipe("ar_add_rms", ar_add_rms_spv)
+    g_gpu.rks_pipeline <- make_kernel_pipe("rope_kv_store", rope_kv_store_spv)
+    g_gpu.da_pipeline <- make_kernel_pipe("da_attn", da_attn_spv)
+    g_gpu.ar_pipeline_b <- make_kernel_pipe("ar_add_rms_b", ar_add_rms_b_spv)
+    g_gpu.rks_b_pipeline <- make_kernel_pipe("rope_kv_store_b", rope_kv_store_b_spv)
+    g_gpu.da_b_pipeline <- make_kernel_pipe("da_attn_b", da_attn_b_spv)
+    g_gpu.qkn_pipeline <- make_kernel_pipe("qk_rms", qk_rms_spv)
 
     var fence <- create_fence(g_gpu.device, FenceCreateInfo())   // never finalized (process-lifetime)
     g_gpu.fence = boost_value_to_vk(fence)
@@ -3904,6 +3873,8 @@ def private ensure_gemv_scratch(si : int) {
     write_buf_desc(writes, g_gpu.stacks[si].raw_set, 5u, g_gpu.stacks[si].y_dev, Y_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    // default y role; role-fluid chains (gate/up pair, qkv group, dn step) re-declare before recording
+    hz_set_bits(g_gpu.stacks[si].raw_set, 0u, 0u, 0u, 0u, 0u, VHG_Y1)
     g_gpu.stacks[si].gemv_made = true
 }
 
@@ -4004,6 +3975,7 @@ def vk_drop_model_state {
     // every descriptor set came from the one pool and every one is model-owned
     let rdpf : VkDescriptorPoolResetFlags
     vk_check(vkResetDescriptorPool(dev_raw(), boost_value_to_vk(g_gpu.desc_pool), rdpf), null)
+    g_set_bits |> clear()   // pool reset recycles set handles — stale region bits must not survive
     // device buffers: dev_mem tracks every make_device_buf result — all model-owned
     for (buf, mem in keys(g_gpu.dev_mem), values(g_gpu.dev_mem)) {
         unsafe {
@@ -4205,6 +4177,7 @@ def private arena_ensure_scratch(fmt : int) {
         write_buf_desc(writes, a.raw_set, 5u, a.y_dev, Y_BYTES)
         let no_copies : array<CopyDescriptorSet>
         update_descriptor_sets(g_gpu.device, writes, no_copies)
+        hz_set_bits(a.raw_set, 0u, 0u, 0u, 0u, 0u, VHG_YO)
         a.ready = true
     }
 }
@@ -4232,6 +4205,7 @@ def private ensure_ar_state {
     write_buf_desc(writes, g_gpu.ar_set, 5u, g_gpu.ar_y_dev, bytes)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.ar_set, VHG_X, 0u, 0u, 0u, 0u, VHG_YO)   // a/w/meta/scal fill pre-cmd
     g_gpu.ar_ready = true
 }
 
@@ -4260,9 +4234,7 @@ def vk_add_rms(var x : array<float>; a : array<float>; w : array<float>; var y :
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
         var h : VkHaz
-        vhz_dep(raw, h, 0u, VHG_X | VHG_YO)
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.ar_pipeline, VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, g_gpu.ar_set, 1u)   // one workgroup owns the whole row (it reduces)
+        hz_dispatch(raw, h, weak_copy(g_gpu.ar_pipeline), g_gpu.ar_set, 1u)   // one workgroup owns the whole row (it reduces)
         vhz_dep(raw, h, VHG_YO, 0u, true)   // x reads back post-fence in the second cmd
         cmd_copy_whole(raw, g_gpu.ar_y_dev, g_gpu.ar_host.buf, bytes)
         vk_check(vkEndCommandBuffer(raw), null)
@@ -4332,6 +4304,10 @@ def private ensure_af_state(f1, f3, f2 : int) {
     write_buf_desc(writes, g_gpu.af_down_set, 5u, g_gpu.af_yo_dev, Y_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.af_gate_set, 0u, 0u, 0u, 0u, 0u, VHG_Y1)
+    hz_set_bits(g_gpu.af_up_set, 0u, 0u, 0u, 0u, 0u, VHG_Y2)
+    hz_set_bits(g_gpu.af_actrq_set, VHG_Y2, 0u, VHG_META, VHG_HQ, VHG_HQ, VHG_Y1)
+    hz_set_bits(g_gpu.af_down_set, 0u, 0u, 0u, VHG_HQ, VHG_HQ, VHG_YO)
     g_gpu.af_ready = true
 }
 
@@ -4378,6 +4354,7 @@ def private ensure_rks_state {
     write_buf_desc(writes, g_gpu.rks_set, 5u, g_gpu.rks_q_dev, RKS_MAX_QD * 4l)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.rks_set, 0u, VHG_Y2, 0u, VHG_Y3, 0u, VHG_Y1)   // K mirror / V mirror / roped q
     g_gpu.rks_ready = true
 }
 
@@ -4402,6 +4379,7 @@ def private ensure_da_state {
     write_buf_desc(writes, g_gpu.da_set, 5u, g_gpu.da_out_dev, RKS_MAX_QD * 4l)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.da_set, 0u, 0u, 0u, 0u, 0u, VHG_YO)   // q/mirrors fill pre-cmd (fence-ordered)
     g_gpu.da_ready = true
 }
 
@@ -4428,9 +4406,7 @@ def vk_decode_attn(var q : array<float>; var out : array<float>; cnt, qd, kv_dim
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
         var h : VkHaz
-        vhz_dep(raw, h, 0u, VHG_YO)
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.da_pipeline, VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, g_gpu.da_set, uint(n_heads))
+        hz_dispatch(raw, h, weak_copy(g_gpu.da_pipeline), g_gpu.da_set, uint(n_heads))
         vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.da_out_dev, g_gpu.da_out_host.buf, qd * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
@@ -4469,9 +4445,7 @@ def vk_rope_kv_store(var qkv : array<float>; var qout : array<float>; var krow :
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
         var h : VkHaz
-        vhz_dep(raw, h, 0u, VHG_Y1 | VHG_Y2 | VHG_Y3)
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.rks_pipeline, VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, g_gpu.rks_set, uint((npairs + int64(WG_X) - 1l) / int64(WG_X)))
+        hz_dispatch(raw, h, weak_copy(g_gpu.rks_pipeline), g_gpu.rks_set, uint((npairs + int64(WG_X) - 1l) / int64(WG_X)))
         vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_Y3, 0u, true)   // one declaration for the q/k/v readback group
         cmd_copy_whole(raw, g_gpu.rks_q_dev, g_gpu.rks_q_host.buf, qd * 4l)
         cmd_copy_range(raw, g_gpu.rks_k_dev, pos * kv_dim * 4l, g_gpu.rks_kv_host.buf, 0l, kv_dim * 4l)
@@ -4567,7 +4541,7 @@ let private PF_WINDOW = 512l   // prefill activation-buffer rows; longer prompts
 
 var private g_rd : RDec?
 
-def private rd_set6(b0, b1, b2, b3, b4, b5 : uint64; s0, s1, s2, s3, s4, s5 : int64) : VkDescriptorSet {
+def private rd_set6(b0, b1, b2, b3, b4, b5 : uint64; s0, s1, s2, s3, s4, s5 : int64; gbits : uint[6]) : VkDescriptorSet {
     var set = alloc_desc_set()
     var writes : array<WriteDescriptorSet>
     write_buf_desc(writes, set, 0u, b0, s0)
@@ -4578,6 +4552,7 @@ def private rd_set6(b0, b1, b2, b3, b4, b5 : uint64; s0, s1, s2, s3, s4, s5 : in
     write_buf_desc(writes, set, 5u, b5, s5)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(set, gbits)
     return set
 }
 
@@ -4683,53 +4658,69 @@ def vk_rdec_set_layer(l : int64; bq, bk, bv, bo, b1, b3, b2 : int64; fq, fk, fv,
         L.m_actrq = rd_meta(); L.m_down = rd_meta(); L.m_addr_next = rd_meta()
         // quantize xb -> xq/xs (dn_requant: in vk_upf@0, meta@2, xq@3, xs@4)
         L.s_quant_xb = rd_set6(g_rd.xb_dev, g_rd.dummy, L.m_quant_xb.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.dummy,
-            dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l)
+            dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l,
+            fixed_array(VHZ_XB, 0u, 0u, VHZ_XQ, VHZ_XQ, 0u))
         // q/k/v GEMV: arena[f] planes @0/1, meta@2, xq@3, xs@4, out@5
         L.s_q = rd_set6(pq.wq, pq.ws, L.m_q.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.q_dev,
-            pq.wqb, pq.wsb, META_BYTES, dim, (dim / 32l) * 4l, qd * 4l)
+            pq.wqb, pq.wsb, META_BYTES, dim, (dim / 32l) * 4l, qd * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_Q))
         L.s_k = rd_set6(pk.wq, pk.ws, L.m_k.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.kv_dev,
-            pk.wqb, pk.wsb, META_BYTES, dim, (dim / 32l) * 4l, (qd + 2l * kvd) * 4l)
+            pk.wqb, pk.wsb, META_BYTES, dim, (dim / 32l) * 4l, (qd + 2l * kvd) * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_KVK))
         L.s_v = rd_set6(pv.wq, pv.ws, L.m_v.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.kv_dev,
-            pv.wqb, pv.wsb, META_BYTES, dim, (dim / 32l) * 4l, (qd + 2l * kvd) * 4l)
+            pv.wqb, pv.wsb, META_BYTES, dim, (dim / 32l) * 4l, (qd + 2l * kvd) * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_KVV))
         // qk rmsnorm (qk_norm models): q@0 (q_dev), meta@2, norm rows@3, eps@4, k@5 (kv_dev, k at qd)
         if (g_rd.qk_norm) {
             L.m_qkn = rd_meta()
             L.s_qkn = rd_set6(g_rd.q_dev, g_rd.dummy, L.m_qkn.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.kv_dev,
-                qd * 4l, 256l, META_BYTES, g_rd.norms_bytes, 64l, (qd + 2l * kvd) * 4l)
+                qd * 4l, 256l, META_BYTES, g_rd.norms_bytes, 64l, (qd + 2l * kvd) * 4l,
+                fixed_array(VHZ_Q, 0u, 0u, 0u, 0u, VHZ_KVK))
         }
         // rope+store: kv@0, Kmirror@1, meta@2, Vmirror@3, cossin@4, q@5
         let mirbytes = g_rd.n_layers * g_rd.seq_cap * kvd * 4l
         L.s_rope = rd_set6(g_rd.kv_dev, g_rd.k_mirror, L.m_rope.buf, g_rd.v_mirror, g_rd.cos_dev, g_rd.q_dev,
-            (qd + 2l * kvd) * 4l, mirbytes, META_BYTES, mirbytes, g_rd.head_size * 4l, qd * 4l)
+            (qd + 2l * kvd) * 4l, mirbytes, META_BYTES, mirbytes, g_rd.head_size * 4l, qd * 4l,
+            fixed_array(VHZ_KVK | VHZ_KVV, VHZ_MIR, 0u, VHZ_MIR, VHZ_COS, VHZ_Q))
         // attn: q@0, Kmirror@1, meta@2, Vmirror@3, scale@4, out@5
         L.s_attn = rd_set6(g_rd.q_dev, g_rd.k_mirror, L.m_attn.buf, g_rd.v_mirror, g_rd.scal_dev, g_rd.attn_dev,
-            qd * 4l, mirbytes, META_BYTES, mirbytes, 64l, qd * 4l)
+            qd * 4l, mirbytes, META_BYTES, mirbytes, 64l, qd * 4l,
+            fixed_array(VHZ_Q, VHZ_MIR, 0u, VHZ_MIR, 0u, VHZ_ATT))
         // quantize attn -> aq/as
         L.s_quant_at = rd_set6(g_rd.attn_dev, g_rd.dummy, L.m_quant_at.buf, g_rd.aq_dev, g_rd.as_dev, g_rd.dummy,
-            qd * 4l, 256l, META_BYTES, qd, (qd / 32l) * 4l, 256l)
+            qd * 4l, 256l, META_BYTES, qd, (qd / 32l) * 4l, 256l,
+            fixed_array(VHZ_ATT, 0u, 0u, VHZ_AQ, VHZ_AQ, 0u))
         // wo GEMV -> xb2
         L.s_wo = rd_set6(po.wq, po.ws, L.m_wo.buf, g_rd.aq_dev, g_rd.as_dev, g_rd.xb2_dev,
-            po.wqb, po.wsb, META_BYTES, qd, (qd / 32l) * 4l, dim * 4l)
+            po.wqb, po.wsb, META_BYTES, qd, (qd / 32l) * 4l, dim * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_AQ, VHZ_AQ, VHZ_XB2))
         // addrms: x@0 += xb2@1, meta@2, norms@3, scalars@4, xb@5
         L.s_addr_ffn = rd_set6(g_rd.x_dev, g_rd.xb2_dev, L.m_addr_ffn.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.xb_dev,
-            dim * 4l, dim * 4l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l)
+            dim * 4l, dim * 4l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l,
+            fixed_array(VHZ_X, VHZ_XB2, 0u, 0u, 0u, VHZ_XB))
         // quantize xb (post-ffn-norm) -> xq/xs
         L.s_quant_xb2 = rd_set6(g_rd.xb_dev, g_rd.dummy, L.m_quant_xb2.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.dummy,
-            dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l)
+            dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l,
+            fixed_array(VHZ_XB, 0u, 0u, VHZ_XQ, VHZ_XQ, 0u))
         // gate/up GEMV
         L.s_gate = rd_set6(p1.wq, p1.ws, L.m_gate.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.gate_dev,
-            p1.wqb, p1.wsb, META_BYTES, dim, (dim / 32l) * 4l, hid * 4l)
+            p1.wqb, p1.wsb, META_BYTES, dim, (dim / 32l) * 4l, hid * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_GATE))
         L.s_up = rd_set6(p3.wq, p3.ws, L.m_up.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.up_dev,
-            p3.wqb, p3.wsb, META_BYTES, dim, (dim / 32l) * 4l, hid * 4l)
+            p3.wqb, p3.wsb, META_BYTES, dim, (dim / 32l) * 4l, hid * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_UP))
         // act+requant: up@0, filler@1, ffn_meta@2, hq@3, hs@4, gate@5
         L.s_actrq = rd_set6(g_rd.up_dev, g_rd.dummy, g_gpu.ffn_meta_dev, g_gpu.hq_dev, g_gpu.hs_dev, g_rd.gate_dev,
-            hid * 4l, 256l, FFN_META_BYTES, BATCH_HQ_BYTES, BATCH_HS_BYTES, hid * 4l)
+            hid * 4l, 256l, FFN_META_BYTES, BATCH_HQ_BYTES, BATCH_HS_BYTES, hid * 4l,
+            fixed_array(VHZ_UP, 0u, VHZ_META, VHZ_HQ, VHZ_HQ, VHZ_GATE))
         // down GEMV -> ffnout
         L.s_down = rd_set6(p2.wq, p2.ws, L.m_down.buf, g_gpu.hq_dev, g_gpu.hs_dev, g_rd.ffnout_dev,
-            p2.wqb, p2.wsb, META_BYTES, hid, (hid / 32l) * 4l, dim * 4l)
+            p2.wqb, p2.wsb, META_BYTES, hid, (hid / 32l) * 4l, dim * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_HQ, VHZ_HQ, VHZ_FFO))
         // addrms next: x@0 += ffnout@1, norms@3, xb@5
         L.s_addr_next = rd_set6(g_rd.x_dev, g_rd.ffnout_dev, L.m_addr_next.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.xb_dev,
-            dim * 4l, dim * 4l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l)
+            dim * 4l, dim * 4l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l,
+            fixed_array(VHZ_X, VHZ_FFO, 0u, 0u, 0u, VHZ_XB))
         L.made = true
     }
     g_rd.tok_recorded = false   // the recorded chain references the replaced sets
@@ -4748,14 +4739,17 @@ def vk_rdec_set_cls(cls_block : int64; cls_fmt : int) {
         g_rd.cls_meta_dev = make_device_buf(CLS_META_BYTES)
         // prologue: xb = rms_att[0](x), add off
         g_rd.s_prologue = rd_set6(g_rd.x_dev, g_rd.dummy, g_rd.m_prologue.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.xb_dev,
-            dim * 4l, 256l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l)
+            dim * 4l, 256l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l,
+            fixed_array(VHZ_X, 0u, 0u, 0u, 0u, VHZ_XB))
         // quantize final xb
         g_rd.s_quant_final = rd_set6(g_rd.xb_dev, g_rd.dummy, g_rd.m_quant_final.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.dummy,
-            dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l)
+            dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l,
+            fixed_array(VHZ_XB, 0u, 0u, VHZ_XQ, VHZ_XQ, 0u))
         // cls GEMV: arena[fmt]@0/1, device meta@2, xq@3, xs@4, logits@5
         let pc = arena_planes(cls_fmt)
         g_rd.cls_set = rd_set6(pc.wq, pc.ws, g_rd.cls_meta_dev, g_rd.xq_dev, g_rd.xs_dev, g_rd.logits_dev,
-            pc.wqb, pc.wsb, CLS_META_BYTES, dim, (dim / 32l) * 4l, vocab * 4l)
+            pc.wqb, pc.wsb, CLS_META_BYTES, dim, (dim / 32l) * 4l, vocab * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_LOG))
         // cls meta is constant (block base, n=dim, d=vocab) — device-filled once
         var mp = reinterpret<uint?>(g_gpu.staging.mapped)
         mp[0] = uint(dim)
@@ -4928,7 +4922,115 @@ struct private VkHaz {
     disp : int
 }
 
+// ===== the derived-dispatch registry (the vulkan lens) =====
+// Pipelines register lens-derived binding access masks at creation, descriptor sets declare
+// per-binding region bits at build — hz_dispatch composes the two into vhz_dep masks.
+
+var private g_kernel_access : table<string; uint2>   // kernel name -> (read-bindings, write-bindings)
+var private g_pipe_access : table<uint64; uint2>     // VkPipeline -> (read-bindings, write-bindings)
+var private g_set_bits : table<uint64; SetBits>      // VkDescriptorSet -> per-binding region-bit masks
+
+struct private SetBits {
+    b : uint[6]
+}
+
+def private ensure_kernel_access {
+    if (!empty(g_kernel_access)) {
+        return
+    }
+    for (ent in split(vk_kernel_access_spec(), ";")) {
+        if (ent == "") {
+            continue
+        }
+        let nv <- split(ent, "=")
+        let rw <- split(nv[1], ",")
+        g_kernel_access |> insert(nv[0], uint2(uint(to_int(rw[0])), uint(to_int(rw[1]))))
+    }
+}
+
+//! Debug: log the lens-derived per-kernel binding access masks (bindings 0-5, hex bit masks).
+def vk_dump_kernel_access {
+    ensure_kernel_access()
+    for (k, v in keys(g_kernel_access), values(g_kernel_access)) {
+        to_log(LOG_INFO, "vk_access {k} r={v.x} w={v.y}\n")
+    }
+}
+
+// declare the region bits sitting at each of a set's 6 bindings (0 = untracked); a set must be
+// declared before hz_dispatch can serve it — the strict rail panics on an undeclared set
+def private hz_set_bits(set_ : VkDescriptorSet; b0, b1, b2, b3, b4, b5 : uint) {
+    var sb : SetBits
+    sb.b[0] = b0
+    sb.b[1] = b1
+    sb.b[2] = b2
+    sb.b[3] = b3
+    sb.b[4] = b4
+    sb.b[5] = b5
+    g_set_bits[intptr(set_)] = sb
+}
+
+def private hz_set_bits(set_ : VkDescriptorSet; gbits : uint[6]) {
+    var sb : SetBits
+    for (i in range(6)) {
+        sb.b[i] = gbits[i]
+    }
+    g_set_bits[intptr(set_)] = sb
+}
+
+def private hz_pipe_register(pipe : Pipeline; kernel : string) {
+    ensure_kernel_access()
+    if (!key_exists(g_kernel_access, kernel)) {
+        panic("dasLLAMA vulkan lens: no derived access for kernel {kernel}")
+    }
+    g_pipe_access[intptr(boost_value_to_vk(pipe))] = g_kernel_access[kernel]
+}
+
+// create a kernel's pipeline and register its lens-derived access masks (the shader-module local
+// is deliberately never finalized — same lifetime the hand-written creation block had)
+def private make_kernel_pipe(kernel : string; var spv : array<uint>) : Pipeline {
+    var shader <- create_shader_module(g_gpu.device, spv)
+    var pipe <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, shader)
+    hz_pipe_register(pipe, kernel)
+    return <- pipe
+}
+
+// derive this dispatch's hazard masks: the set's region bits distributed over the kernel's
+// read/write bindings. Undeclared pipeline or set = a programming error, not a fallback.
+def private hz_masks(pipe : Pipeline; var set_ : VkDescriptorSet) : tuple<r : uint; w : uint> {
+    let pk = intptr(boost_value_to_vk(pipe))
+    if (!key_exists(g_pipe_access, pk)) {
+        panic("dasLLAMA vulkan lens: dispatch through an unregistered pipeline")
+    }
+    let sk = intptr(set_)
+    if (!key_exists(g_set_bits, sk)) {
+        panic("dasLLAMA vulkan lens: dispatch against a set with no declared region bits")
+    }
+    let acc = g_pipe_access[pk]
+    let sb = g_set_bits[sk]
+    var r = 0u
+    var w = 0u
+    for (i in range(6)) {
+        let bit = 1u << uint(i)
+        if ((acc.x & bit) != 0u) {
+            r |= sb.b[i]
+        }
+        if ((acc.y & bit) != 0u) {
+            w |= sb.b[i]
+        }
+    }
+    return (r, w)
+}
+
+// the derived-mask dispatch node: declare via the composed masks, bind, dispatch
+def private hz_dispatch(raw : VkCommandBuffer; var h : VkHaz; pipe : Pipeline; var set_ : VkDescriptorSet; groups : uint) {
+    let m = hz_masks(pipe, set_)
+    vhz_dep(raw, h, m.r, m.w)
+    cmd_bind_pipeline(vk_value_to_boost(raw), pipe, VkPipelineBindPoint.COMPUTE)
+    cmd_bind_dispatch(raw, set_, groups)
+}
+
 var private g_vhz_paranoid = -1   // DASLLAMA_VK_HAZARD_PARANOID: barrier before every node
+var private g_vhz_trace = -1      // DASLLAMA_VK_HAZARD_TRACE: log every declared node (schedule oracle)
 var private g_mm_m_logged = false   // one-time mul_mm M-tile engagement log
 
 def private vhz_paranoid : bool {
@@ -4938,9 +5040,19 @@ def private vhz_paranoid : bool {
     return g_vhz_paranoid != 0
 }
 
+def private vhz_trace : bool {
+    if (g_vhz_trace < 0) {
+        g_vhz_trace = get_env_variable("DASLLAMA_VK_HAZARD_TRACE") == "1" ? 1 : 0
+    }
+    return g_vhz_trace != 0
+}
+
 // the per-node gate: barrier iff this node's declared masks conflict with the pending set
 def private vhz_dep(raw : VkCommandBuffer; var h : VkHaz; rmask, wmask : uint; transfer : bool = false) {
     h.disp++
+    if (vhz_trace()) {
+        to_log(LOG_INFO, "vhz {h.disp} r={rmask} w={wmask} t={transfer ? 1 : 0}\n")
+    }
     var bar = (rmask & h.w) != 0u || (wmask & h.w) != 0u || (wmask & h.r) != 0u
     if (vhz_paranoid() && (h.w != 0u || h.r != 0u)) {
         bar = true
@@ -4980,19 +5092,14 @@ def private vhz_dep(raw : VkCommandBuffer; var h : VkHaz; rmask, wmask : uint; t
     }
 }
 
-def private rd_dispatch(raw : VkCommandBuffer; pipe : Pipeline; var set : VkDescriptorSet; groups : uint; var h : VkHaz; rmask, wmask : uint) {
-    vhz_dep(raw, h, rmask, wmask)
-    cmd_bind_pipeline(vk_value_to_boost(raw), pipe, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, set, groups)
+def private rd_dispatch(raw : VkCommandBuffer; pipe : Pipeline; var set : VkDescriptorSet; groups : uint; var h : VkHaz) {
+    hz_dispatch(raw, h, pipe, set, groups)
     pfq_ts(raw)
 }
 
 // GEMV dispatch — the per-format kernel selected off the plane format
-def private rd_dispatch_gemv(raw : VkCommandBuffer; fmt : int; var set : VkDescriptorSet; groups : uint; var h : VkHaz; rmask, wmask : uint) {
-    vhz_dep(raw, h, rmask, wmask)
-    bind_gemv_pipe(raw, fmt)
-    cmd_bind_dispatch(raw, set, groups)
-    pfq_ts(raw)
+def private rd_dispatch_gemv(raw : VkCommandBuffer; fmt : int; var set : VkDescriptorSet; groups : uint; var h : VkHaz) {
+    rd_dispatch(raw, gemv_pipe(fmt), set, groups, h)
 }
 
 // Record the whole-token cmd ONCE per set_layer/set_cls epoch: constant metas + scalars fill here;
@@ -5063,33 +5170,30 @@ def private rd_record_token {
         cmd_copy_whole(raw, g_rd.cos_host.buf, g_rd.cos_dev, g_rd.head_size * 4l)
         vhz_dep(raw, h, 0u, VHZ_META, true)
         cmd_copy_whole(raw, g_rd.ffn_meta_h.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-        rd_dispatch(raw, g_gpu.ar_pipeline, g_rd.s_prologue, 1u, h, VHZ_X, VHZ_XB)   // xb = rms_att[0](x)
+        rd_dispatch(raw, g_gpu.ar_pipeline, g_rd.s_prologue, 1u, h)   // xb = rms_att[0](x)
         for (l in range64(g_rd.n_layers)) {
             var L & = g_rd.layers[l]
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb, uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-            rd_dispatch_gemv(raw, L.fq, L.s_q, rd_gemv_wg(qd), h, VHZ_XQ, VHZ_Q)
-            rd_dispatch_gemv(raw, L.fk, L.s_k, rd_gemv_wg(kvd), h, VHZ_XQ, VHZ_KVK)
-            rd_dispatch_gemv(raw, L.fv, L.s_v, rd_gemv_wg(kvd), h, VHZ_XQ, VHZ_KVV)
+            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb, uint((dim / 32l + 255l) / 256l), h)
+            rd_dispatch_gemv(raw, L.fq, L.s_q, rd_gemv_wg(qd), h)
+            rd_dispatch_gemv(raw, L.fk, L.s_k, rd_gemv_wg(kvd), h)
+            rd_dispatch_gemv(raw, L.fv, L.s_v, rd_gemv_wg(kvd), h)
             if (g_rd.qk_norm) {
-                rd_dispatch(raw, g_gpu.qkn_pipeline, L.s_qkn, uint(g_rd.n_heads + kvd / g_rd.head_size),
-                    h, VHZ_Q | VHZ_KVK, VHZ_Q | VHZ_KVK)
+                rd_dispatch(raw, g_gpu.qkn_pipeline, L.s_qkn, uint(g_rd.n_heads + kvd / g_rd.head_size), h)
             }
-            rd_dispatch(raw, g_gpu.rks_pipeline, L.s_rope, uint((qd / 2l + kvd / 2l + int64(WG_X) - 1l) / int64(WG_X)),
-                h, VHZ_Q | VHZ_KVK | VHZ_KVV | VHZ_COS, VHZ_Q | VHZ_KVK | VHZ_MIR)
-            rd_dispatch(raw, g_gpu.da_pipeline, L.s_attn, uint(g_rd.n_heads), h, VHZ_Q | VHZ_MIR, VHZ_ATT)
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_at, uint((qd / 32l + 255l) / 256l), h, VHZ_ATT, VHZ_AQ)
-            rd_dispatch_gemv(raw, L.fo, L.s_wo, rd_gemv_wg(dim), h, VHZ_AQ, VHZ_XB2)
-            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_ffn, 1u, h, VHZ_X | VHZ_XB2, VHZ_X | VHZ_XB)
-            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb2, uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-            rd_dispatch_gemv(raw, L.f1, L.s_gate, rd_gemv_wg(hid), h, VHZ_XQ, VHZ_GATE)
-            rd_dispatch_gemv(raw, L.f3, L.s_up, rd_gemv_wg(hid), h, VHZ_XQ, VHZ_UP)
-            rd_dispatch(raw, g_gpu.actrq_pipeline, L.s_actrq, uint((hid / 32l + 255l) / 256l),
-                h, VHZ_GATE | VHZ_UP | VHZ_META, VHZ_HQ)
-            rd_dispatch_gemv(raw, L.f2, L.s_down, rd_gemv_wg(dim), h, VHZ_HQ, VHZ_FFO)
-            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_next, 1u, h, VHZ_X | VHZ_FFO, VHZ_X | VHZ_XB)
+            rd_dispatch(raw, g_gpu.rks_pipeline, L.s_rope, uint((qd / 2l + kvd / 2l + int64(WG_X) - 1l) / int64(WG_X)), h)
+            rd_dispatch(raw, g_gpu.da_pipeline, L.s_attn, uint(g_rd.n_heads), h)
+            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_at, uint((qd / 32l + 255l) / 256l), h)
+            rd_dispatch_gemv(raw, L.fo, L.s_wo, rd_gemv_wg(dim), h)
+            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_ffn, 1u, h)
+            rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_xb2, uint((dim / 32l + 255l) / 256l), h)
+            rd_dispatch_gemv(raw, L.f1, L.s_gate, rd_gemv_wg(hid), h)
+            rd_dispatch_gemv(raw, L.f3, L.s_up, rd_gemv_wg(hid), h)
+            rd_dispatch(raw, g_gpu.actrq_pipeline, L.s_actrq, uint((hid / 32l + 255l) / 256l), h)
+            rd_dispatch_gemv(raw, L.f2, L.s_down, rd_gemv_wg(dim), h)
+            rd_dispatch(raw, g_gpu.ar_pipeline, L.s_addr_next, 1u, h)
         }
-        rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.s_quant_final, uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-        rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab), h, VHZ_XQ, VHZ_LOG)
+        rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.s_quant_final, uint((dim / 32l + 255l) / 256l), h)
+        rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab), h)
         vhz_dep(raw, h, VHZ_LOG, 0u, true)   // compute -> transfer for the logits DMA
         cmd_copy_whole(raw, g_rd.logits_dev, g_rd.logits_host.buf, g_rd.vocab * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
@@ -5128,8 +5232,8 @@ def vk_rdec_token(x : array<float>; cossin : array<float>; pos, cnt : int64; var
 
 let private PF_ROLES = 16l   // quant_xb q k v rope attn quant_at wo addr_ffn quant_xb2 gate up actrq down addr_next qkn
 
-def private pf_bind(idx : int; b0, b1, b2, b3, b4, b5 : uint64; s0, s1, s2, s3, s4, s5 : int64) {
-    g_rd.pf_sets[idx] = rd_set6(b0, b1, b2, b3, b4, b5, s0, s1, s2, s3, s4, s5)
+def private pf_bind(idx : int; b0, b1, b2, b3, b4, b5 : uint64; s0, s1, s2, s3, s4, s5 : int64; gbits : uint[6]) {
+    g_rd.pf_sets[idx] = rd_set6(b0, b1, b2, b3, b4, b5, s0, s1, s2, s3, s4, s5, gbits)
 }
 
 def private pf_setup {
@@ -5176,59 +5280,77 @@ def private pf_setup {
         let po = arena_planes(L.fo); let p1 = arena_planes(L.f1); let p3 = arena_planes(L.f3); let p2 = arena_planes(L.f2)
         // 0 quant_xb: pf_xb -> pf_xq/pf_xs
         pf_bind(b + 0, g_rd.pf_xb, g_rd.dummy, g_rd.pf_meta[b + 0].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.dummy,
-            np * dim * 4l, 256l, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, 256l)
+            np * dim * 4l, 256l, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, 256l,
+            fixed_array(VHZ_XB, 0u, 0u, VHZ_XQ, VHZ_XQ, 0u))
         // 1/2/3 q/k/v batch GEMM: arena planes, pf_xq/pf_xs act, -> pf_q / pf_kv(k@0) / pf_kv(v@np*kvd)
         pf_bind(b + 1, pq.wq, pq.ws, g_rd.pf_meta[b + 1].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.pf_q,
-            pq.wqb, pq.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * qd * 4l)
+            pq.wqb, pq.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * qd * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_Q))
         pf_bind(b + 2, pk.wq, pk.ws, g_rd.pf_meta[b + 2].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.pf_kv,
-            pk.wqb, pk.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * 2l * kvd * 4l)
+            pk.wqb, pk.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * 2l * kvd * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_KVK))
         pf_bind(b + 3, pv.wq, pv.ws, g_rd.pf_meta[b + 3].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.pf_v,
-            pv.wqb, pv.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * kvd * 4l)
+            pv.wqb, pv.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * kvd * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_VST))
         // 4 rope+store: q@0 in place, Kmir@1, Vmir@3, cos@4, kv@5
         pf_bind(b + 4, g_rd.pf_q, g_rd.k_mirror, g_rd.pf_meta[b + 4].buf, g_rd.v_mirror, g_rd.pf_cos, g_rd.pf_kv,
-            np * qd * 4l, mirbytes, BATCH_META_BYTES, mirbytes, np * g_rd.head_size * 4l, np * 2l * kvd * 4l)
+            np * qd * 4l, mirbytes, BATCH_META_BYTES, mirbytes, np * g_rd.head_size * 4l, np * 2l * kvd * 4l,
+            fixed_array(VHZ_Q, VHZ_MIR, 0u, VHZ_MIR, VHZ_COS, VHZ_KVK | VHZ_KVV))
         // 5 attn: q@0, Kmir@1, Vmir@3, scale@4, out@5
         pf_bind(b + 5, g_rd.pf_q, g_rd.k_mirror, g_rd.pf_meta[b + 5].buf, g_rd.v_mirror, g_rd.scal_dev, g_rd.pf_attn,
-            np * qd * 4l, mirbytes, BATCH_META_BYTES, mirbytes, 64l, np * qd * 4l)
+            np * qd * 4l, mirbytes, BATCH_META_BYTES, mirbytes, 64l, np * qd * 4l,
+            fixed_array(VHZ_Q, VHZ_MIR, 0u, VHZ_MIR, 0u, VHZ_ATT))
         // 6 quant_at: pf_attn -> pf_aq/pf_as
         pf_bind(b + 6, g_rd.pf_attn, g_rd.dummy, g_rd.pf_meta[b + 6].buf, g_rd.pf_aq, g_rd.pf_as, g_rd.dummy,
-            np * qd * 4l, 256l, BATCH_META_BYTES, np * qd, np * (qd / 32l) * 4l, 256l)
+            np * qd * 4l, 256l, BATCH_META_BYTES, np * qd, np * (qd / 32l) * 4l, 256l,
+            fixed_array(VHZ_ATT, 0u, 0u, VHZ_AQ, VHZ_AQ, 0u))
         // 7 wo GEMM -> pf_xb2
         pf_bind(b + 7, po.wq, po.ws, g_rd.pf_meta[b + 7].buf, g_rd.pf_aq, g_rd.pf_as, g_rd.pf_xb2,
-            po.wqb, po.wsb, BATCH_META_BYTES, np * qd, np * (qd / 32l) * 4l, np * dim * 4l)
+            po.wqb, po.wsb, BATCH_META_BYTES, np * qd, np * (qd / 32l) * 4l, np * dim * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_AQ, VHZ_AQ, VHZ_XB2))
         // 8 addr_ffn: x += xb2, xb = rms_ffn
         pf_bind(b + 8, g_rd.pf_x, g_rd.pf_xb2, g_rd.pf_meta[b + 8].buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.pf_xb,
-            np * dim * 4l, np * dim * 4l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l)
+            np * dim * 4l, np * dim * 4l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l,
+            fixed_array(VHZ_X, VHZ_XB2, 0u, 0u, 0u, VHZ_XB))
         // 9 quant_xb2: pf_xb -> pf_xq
         pf_bind(b + 9, g_rd.pf_xb, g_rd.dummy, g_rd.pf_meta[b + 9].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.dummy,
-            np * dim * 4l, 256l, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, 256l)
+            np * dim * 4l, 256l, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, 256l,
+            fixed_array(VHZ_XB, 0u, 0u, VHZ_XQ, VHZ_XQ, 0u))
         // 10/11 gate/up GEMM
         pf_bind(b + 10, p1.wq, p1.ws, g_rd.pf_meta[b + 10].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.pf_gate,
-            p1.wqb, p1.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * hid * 4l)
+            p1.wqb, p1.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * hid * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_GATE))
         pf_bind(b + 11, p3.wq, p3.ws, g_rd.pf_meta[b + 11].buf, g_rd.pf_xq, g_rd.pf_xs, g_rd.pf_up,
-            p3.wqb, p3.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * hid * 4l)
+            p3.wqb, p3.wsb, BATCH_META_BYTES, np * dim, np * (dim / 32l) * 4l, np * hid * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_XQ, VHZ_XQ, VHZ_UP))
         // 12 actrq: up@0, ffn_meta@2, hq@3, hs@4, gate@5
         pf_bind(b + 12, g_rd.pf_up, g_rd.dummy, g_gpu.ffn_meta_dev, g_gpu.hq_dev, g_gpu.hs_dev, g_rd.pf_gate,
-            np * hid * 4l, 256l, FFN_META_BYTES, BATCH_HQ_BYTES, BATCH_HS_BYTES, np * hid * 4l)
+            np * hid * 4l, 256l, FFN_META_BYTES, BATCH_HQ_BYTES, BATCH_HS_BYTES, np * hid * 4l,
+            fixed_array(VHZ_UP, 0u, VHZ_META, VHZ_HQ, VHZ_HQ, VHZ_GATE))
         // 13 down GEMM: hq/hs act -> pf_ffnout
         pf_bind(b + 13, p2.wq, p2.ws, g_rd.pf_meta[b + 13].buf, g_gpu.hq_dev, g_gpu.hs_dev, g_rd.pf_ffnout,
-            p2.wqb, p2.wsb, BATCH_META_BYTES, np * hid, np * (hid / 32l) * 4l, np * dim * 4l)
+            p2.wqb, p2.wsb, BATCH_META_BYTES, np * hid, np * (hid / 32l) * 4l, np * dim * 4l,
+            fixed_array(0u, 0u, 0u, VHZ_HQ, VHZ_HQ, VHZ_FFO))
         // 14 addr_next: x += ffnout, xb = rms_att[l+1]|final
         pf_bind(b + 14, g_rd.pf_x, g_rd.pf_ffnout, g_rd.pf_meta[b + 14].buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.pf_xb,
-            np * dim * 4l, np * dim * 4l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l)
+            np * dim * 4l, np * dim * 4l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l,
+            fixed_array(VHZ_X, VHZ_FFO, 0u, 0u, 0u, VHZ_XB))
         // 15 qk rmsnorm (qk_norm models): q@0 (pf_q), norm rows@3, eps@4, k@5 (pf_kv, k at 0)
         if (g_rd.qk_norm) {
             pf_bind(b + 15, g_rd.pf_q, g_rd.dummy, g_rd.pf_meta[b + 15].buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.pf_kv,
-                np * qd * 4l, 256l, BATCH_META_BYTES, normbytes, 64l, np * 2l * kvd * 4l)
+                np * qd * 4l, 256l, BATCH_META_BYTES, normbytes, 64l, np * 2l * kvd * 4l,
+                fixed_array(VHZ_Q, 0u, 0u, 0u, 0u, VHZ_KVK))
         }
     }
     let bp = int(g_rd.n_layers * PF_ROLES)
     // prologue: xb = rms_att[0](x), add off
     pf_bind(bp + 0, g_rd.pf_x, g_rd.dummy, g_rd.pf_meta[bp + 0].buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.pf_xb,
-        np * dim * 4l, 256l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l)
+        np * dim * 4l, 256l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l,
+        fixed_array(VHZ_X, 0u, 0u, 0u, 0u, VHZ_XB))
     // final quantize of the LAST row (into the decode driver's xq_dev/xs_dev) for the cls GEMV
     pf_bind(bp + 1, g_rd.pf_xb, g_rd.dummy, g_rd.pf_meta[bp + 1].buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.dummy,
-        np * dim * 4l, 256l, BATCH_META_BYTES, dim, (dim / 32l) * 4l, 256l)
+        np * dim * 4l, 256l, BATCH_META_BYTES, dim, (dim / 32l) * 4l, 256l,
+        fixed_array(VHZ_XB, 0u, 0u, VHZ_XQ, VHZ_XQ, 0u))
     g_rd.pf_ready = true
 }
 
@@ -5382,36 +5504,34 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             pfq_ts(raw)   // q1: meta copy
             let ropewg = uint((wlen * pairs + int64(WG_X) - 1l) / int64(WG_X))
             let attnwg = uint(g_rd.n_heads * ((wlen + 7l) / 8l))
-            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(wlen), h, VHZ_X, VHZ_XB)   // prologue norm
+            rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[bp + 0], uint(wlen), h)   // prologue norm
             for (l in range64(g_rd.n_layers)) {
                 let b = int(l * PF_ROLES)
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch(raw, q8_batch_pipe_for(qd, wlen), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h, VHZ_XQ, VHZ_Q)
-                rd_dispatch(raw, q8_batch_pipe_for(kvd, wlen), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h, VHZ_XQ, VHZ_KVK)
-                rd_dispatch(raw, q8_batch_pipe_for(kvd, wlen), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h, VHZ_XQ, VHZ_VST)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l), h)
+                rd_dispatch(raw, q8_batch_pipe_for(qd, wlen), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h)
+                rd_dispatch(raw, q8_batch_pipe_for(kvd, wlen), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h)
+                rd_dispatch(raw, q8_batch_pipe_for(kvd, wlen), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h)
                 vhz_dep(raw, h, VHZ_VST, VHZ_KVV, true)
                 cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
                 if (g_rd.qk_norm) {
                     rd_dispatch(raw, g_gpu.qkn_pipeline, g_rd.pf_sets[b + 15],
-                        uint(wlen * (g_rd.n_heads + kvd / g_rd.head_size)), h, VHZ_Q | VHZ_KVK, VHZ_Q | VHZ_KVK)
+                        uint(wlen * (g_rd.n_heads + kvd / g_rd.head_size)), h)
                 }
-                rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg,
-                    h, VHZ_Q | VHZ_KVK | VHZ_KVV | VHZ_COS, VHZ_Q | VHZ_KVK | VHZ_MIR)
-                rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg, h, VHZ_Q | VHZ_MIR, VHZ_ATT)
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l), h, VHZ_ATT, VHZ_AQ)
-                rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h, VHZ_AQ, VHZ_XB2)
-                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen), h, VHZ_X | VHZ_XB2, VHZ_X | VHZ_XB)
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch(raw, q8_batch_pipe_for(hid, wlen), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h, VHZ_XQ, VHZ_GATE)
-                rd_dispatch(raw, q8_batch_pipe_for(hid, wlen), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h, VHZ_XQ, VHZ_UP)
-                rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l),
-                    h, VHZ_GATE | VHZ_UP | VHZ_META, VHZ_HQ)
-                rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h, VHZ_HQ, VHZ_FFO)
-                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen), h, VHZ_X | VHZ_FFO, VHZ_X | VHZ_XB)
+                rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg, h)
+                rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg, h)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l), h)
+                rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h)
+                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen), h)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l), h)
+                rd_dispatch(raw, q8_batch_pipe_for(hid, wlen), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h)
+                rd_dispatch(raw, q8_batch_pipe_for(hid, wlen), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h)
+                rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l), h)
+                rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h)
+                rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen), h)
             }
             if (last) {
-                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[bp + 1], uint((dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab), h, VHZ_XQ, VHZ_LOG)
+                rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[bp + 1], uint((dim / 32l + 255l) / 256l), h)
+                rd_dispatch_gemv(raw, g_rd.cls_fmt_marker, g_rd.cls_set, rd_gemv_wg(g_rd.vocab), h)
                 vhz_dep(raw, h, VHZ_LOG, 0u, true)
                 cmd_copy_whole(raw, g_rd.logits_dev, g_rd.pf_logits_host.buf, g_rd.vocab * 4l)
             }
@@ -5480,21 +5600,12 @@ def vk_arena_ffn(var y : array<float>; blk1, blk3, blk2 : int64; n, nfe : int64;
         vhz_dep(raw, h, 0u, VHG_META, true)
         cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
         let gwg = uint((nfe + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg)
-        vhz_dep(raw, h, 0u, VHG_Y1)
-        bind_gemv_pipe(raw, f1)
-        cmd_bind_dispatch(raw, g_gpu.af_gate_set, gwg)
-        vhz_dep(raw, h, 0u, VHG_Y2)
-        if (f3 != f1) {
-            bind_gemv_pipe(raw, f3)
-        }
-        cmd_bind_dispatch(raw, g_gpu.af_up_set, gwg)
+        hz_dispatch(raw, h, gemv_pipe(f1), g_gpu.af_gate_set, gwg)
+        hz_dispatch(raw, h, gemv_pipe(f3), g_gpu.af_up_set, gwg)
         // the requant form follows the DOWN plane — its GEMV consumes hq/hs
-        vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_META, VHG_HQ)
-        cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, g_gpu.af_actrq_set, uint((nfe / (dkq ? 256l : 32l) + 255l) / 256l))
-        vhz_dep(raw, h, VHG_HQ, VHG_YO)
-        bind_gemv_pipe(raw, f2)
-        cmd_bind_dispatch(raw, g_gpu.af_down_set, uint((n + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+        hz_dispatch(raw, h, weak_copy(dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline),
+            g_gpu.af_actrq_set, uint((nfe / (dkq ? 256l : 32l) + 255l) / 256l))
+        hz_dispatch(raw, h, gemv_pipe(f2), g_gpu.af_down_set, uint((n + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
         vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.af_yo_dev, g_gpu.af_yo_host.buf, n * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
@@ -5545,6 +5656,7 @@ def private arena_ensure_batch(fmt : int) {
         write_buf_desc(writes, a.batch_set, 5u, g_gpu.batch_y1_dev, BATCH_Y_BYTES)
         let no_copies : array<CopyDescriptorSet>
         update_descriptor_sets(g_gpu.device, writes, no_copies)
+        hz_set_bits(a.batch_set, 0u, 0u, 0u, 0u, 0u, VHG_YO)   // meta/acts fill pre-cmd
         a.batch_ready = true
     }
 }
@@ -5564,9 +5676,7 @@ def vk_arena_gemm(var y : array<float>; blk : int64; n, d, npos : int64; fmt : i
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
         var h : VkHaz
-        vhz_dep(raw, h, 0u, VHG_YO)
-        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe_for(d, npos), VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, g_gpu.arenas[fmt].batch_set, groups)
+        hz_dispatch(raw, h, q8_batch_pipe_for(d, npos), g_gpu.arenas[fmt].batch_set, groups)
         vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, npos * d * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
@@ -5602,9 +5712,7 @@ def vk_arena_gemv(var y : array<float>; blk : int64; n, d : int64; fmt : int; xq
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
         var h : VkHaz
-        vhz_dep(raw, h, 0u, VHG_YO)
-        bind_gemv_pipe(raw, fmt)
-        cmd_bind_dispatch(raw, a.raw_set, uint((d + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+        hz_dispatch(raw, h, gemv_pipe(fmt), a.raw_set, uint((d + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
         vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, a.y_dev, a.y.buf, d * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
@@ -5647,21 +5755,21 @@ def private cmd_bind_dispatch(raw : VkCommandBuffer; var set_ : VkDescriptorSet;
     vkCmdDispatch(raw, groups, 1u, 1u)
 }
 
-// bind the GEMV pipeline for a stack's format (0 = the q8 kernel, 1/2/3/4 = kq_moe_gemv_k4/5/6/q40)
-def private bind_gemv_pipe(raw : VkCommandBuffer; fmt : int) {
+// the GEMV pipeline for a stack's format (0 = the q8 kernel, 1/2/3/4 = kq_moe_gemv_k4/5/6/q40)
+def private gemv_pipe(fmt : int) : Pipeline {
     if (fmt == 0) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.pipeline, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.pipeline)
     } elif (fmt == 1) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_k4, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.gemv_k4)
     } elif (fmt == 2) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_k5, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.gemv_k5)
     } elif (fmt == 3) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_k6, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.gemv_k6)
     } elif (fmt == 4) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.gemv_q40, VkPipelineBindPoint.COMPUTE)
-    } else {
-        panic("dasLLAMA vulkan tier: no GEMV kernel for stack format {fmt}")
+        return weak_copy(g_gpu.gemv_q40)
     }
+    panic("dasLLAMA vulkan tier: no GEMV kernel for stack format {fmt}")
+    return weak_copy(g_gpu.pipeline)
 }
 
 // The Q8_0 prefill batch pipeline, switched to the tensor-core coopmat variant when DASLLAMA_COOPMAT
@@ -5687,30 +5795,21 @@ def private q8_batch_pipe(tile : int64; aligned : bool = false) : Pipeline {
     return weak_copy(g_gpu.batch_pipeline)
 }
 
-// two stacks share one bound pipeline only when the whole choice agrees (fmt + tile + aligned)
-def private same_batch_pipe(a, b : int) : bool
-    => (g_gpu.stacks[a].fmt == g_gpu.stacks[b].fmt && g_gpu.stacks[a].batch_tile == g_gpu.stacks[b].batch_tile
-        && g_gpu.stacks[a].batch_aligned == g_gpu.stacks[b].batch_aligned)
-
-def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int; tile : int64; aligned : bool = false) {
+def private batch_pipe(fmt : int; tile : int64; aligned : bool = false) : Pipeline {
     if (fmt == 0) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(tile, aligned), VkPipelineBindPoint.COMPUTE)
+        return q8_batch_pipe(tile, aligned)
     } elif (fmt == 1) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k4, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.batch_k4)
     } elif (fmt == 2) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k5, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.batch_k5)
     } elif (fmt == 3) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k6, VkPipelineBindPoint.COMPUTE)
+        return weak_copy(g_gpu.batch_k6)
     } elif (fmt == 4) {
         // Q4_0 rides the f16 coopmat arm too (no s8-native for nibbles — mode 2 falls back to sdot4)
-        if (g_gpu.coopmat_mode == 1) {
-            cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_coopmat_q40, VkPipelineBindPoint.COMPUTE)
-        } else {
-            cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_q40, VkPipelineBindPoint.COMPUTE)
-        }
-    } else {
-        panic("dasLLAMA vulkan tier: no batch tile for stack format {fmt}")
+        return weak_copy(g_gpu.coopmat_mode == 1 ? g_gpu.batch_coopmat_q40 : g_gpu.batch_q40)
     }
+    panic("dasLLAMA vulkan tier: no batch tile for stack format {fmt}")
+    return weak_copy(g_gpu.batch_pipeline)
 }
 
 def private submit_nowait(var raw : VkCommandBuffer) {
@@ -5823,6 +5922,7 @@ def private ensure_batch_state {
     write_buf_desc(writes, g_gpu.batch_actrq_set, 5u, g_gpu.batch_y1_dev, BATCH_Y_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.batch_actrq_set, VHB_Y2, 0u, VHB_META, VHB_HQ, VHB_HQ, VHB_Y1)
     g_gpu.resident_bytes += BATCH_XQ_BYTES + BATCH_XS_BYTES
     g_gpu.batch_ready = true
     to_log(LOG_INFO, "dasLLAMA vulkan tier: prefill batch tier engaged\n")
@@ -5848,6 +5948,7 @@ def private ensure_comb_state {
     write_buf_desc(writes, g_gpu.comb_set, 5u, g_gpu.batch_y1_dev, BATCH_Y_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.comb_set, VHB_CY, VHB_COMB, VHB_META, VHB_COMB, VHB_COMB, VHB_Y1)
     g_gpu.comb_ready = true
     to_log(LOG_INFO, "dasLLAMA vulkan tier: device-side moe combine engaged\n")
 }
@@ -5855,7 +5956,7 @@ def private ensure_comb_state {
 // batch bindings differ from decode's: meta is the stack's BATCH table, activations point at a
 // role-fixed image (gate/up: the gathered x scratch; down: the requantized hidden planes), y one
 // of the two shared device planes (gate/down write y1_dev, up y2_dev)
-def private ensure_batch_set(si : int; ybuf, xqbuf, xsbuf : uint64; xqbytes, xsbytes : int64; ybytes : int64 = BATCH_Y_BYTES) {
+def private ensure_batch_set(si : int; ybuf, xqbuf, xsbuf : uint64; xqbytes, xsbytes : int64; xbit, ybit : uint; ybytes : int64 = BATCH_Y_BYTES) {
     if (g_gpu.stacks[si].batch_made && g_gpu.stacks[si].batch_y == ybuf && g_gpu.stacks[si].batch_xq == xqbuf) {
         return
     }
@@ -5874,6 +5975,7 @@ def private ensure_batch_set(si : int; ybuf, xqbuf, xsbuf : uint64; xqbytes, xsb
     write_buf_desc(writes, g_gpu.stacks[si].batch_set, 5u, ybuf, ybytes)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.stacks[si].batch_set, 0u, 0u, VHB_META, xbit, xbit, ybit)
     g_gpu.stacks[si].batch_y = ybuf
     g_gpu.stacks[si].batch_xq = xqbuf
 }
@@ -6037,26 +6139,18 @@ def private record_ffn_batch_cmd(s1, s3, s2 : int; nwg_gu, nwg_dn : uint; rows, 
         cmd_copy_whole(raw, g_gpu.comb_stage.buf, g_gpu.comb_w_dev, comb_wi_bytes)
         cmd_copy_at(raw, g_gpu.comb_stage.buf, COMB_WI_BYTES, g_gpu.comb_inv_dev, comb_wi_bytes)
     }
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, g_gpu.stacks[s1].fmt, g_gpu.stacks[s1].batch_tile, g_gpu.stacks[s1].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s1].batch_set, nwg_gu)
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y2)
-    if (!same_batch_pipe(s3, s1)) {
-        bind_batch_pipe(raw, g_gpu.stacks[s3].fmt, g_gpu.stacks[s3].batch_tile, g_gpu.stacks[s3].batch_aligned)
-    }
-    cmd_bind_dispatch(raw, g_gpu.stacks[s3].batch_set, nwg_gu)
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s1].fmt, g_gpu.stacks[s1].batch_tile, g_gpu.stacks[s1].batch_aligned),
+        g_gpu.stacks[s1].batch_set, nwg_gu)
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s3].fmt, g_gpu.stacks[s3].batch_tile, g_gpu.stacks[s3].batch_aligned),
+        g_gpu.stacks[s3].batch_set, nwg_gu)
     // the requant form follows the DOWN stack — its GEMM is the consumer of hq/hs
     let dkq = g_gpu.stacks[s2].fmt != 0
-    vhz_dep(raw, h, VHB_Y1 | VHB_Y2 | VHB_META, VHB_HQ)
-    cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.batch_actrq_set, uint((rows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
-    vhz_dep(raw, h, VHB_HQ | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, g_gpu.stacks[s2].fmt, g_gpu.stacks[s2].batch_tile, g_gpu.stacks[s2].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s2].batch_set, nwg_dn)
+    hz_dispatch(raw, h, weak_copy(dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline),
+        g_gpu.batch_actrq_set, uint((rows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s2].fmt, g_gpu.stacks[s2].batch_tile, g_gpu.stacks[s2].batch_aligned),
+        g_gpu.stacks[s2].batch_set, nwg_dn)
     if (comb_npos > 0u) {
-        vhz_dep(raw, h, VHB_Y1 | VHB_COMB | VHB_CY | VHB_META, VHB_CY)
-        cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.comb_pipeline, VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, g_gpu.comb_set, comb_npos)
+        hz_dispatch(raw, h, weak_copy(g_gpu.comb_pipeline), g_gpu.comb_set, comb_npos)
         if (comb_last) {
             vhz_dep(raw, h, VHB_CY, 0u, true)
             cmd_copy_whole(raw, g_gpu.comb_y_dev, g_gpu.comb_y.buf, comb_y_bytes)
@@ -6084,9 +6178,9 @@ def private vk_moe_ffn_batch(var goutp : float?; offs1 : int64 const?; offs3 : i
     let xunit_in = kq_in ? 256l : 32l
     let xunit_mid = f2 != 0 ? 256l : 32l
     ensure_batch_state()
-    ensure_batch_set(s1, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
-    ensure_batch_set(s3, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
-    ensure_batch_set(s2, g_gpu.batch_y1_dev, g_gpu.hq_dev, g_gpu.hs_dev, BATCH_HQ_BYTES, BATCH_HS_BYTES)
+    ensure_batch_set(s1, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y1)
+    ensure_batch_set(s3, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y2)
+    ensure_batch_set(s2, g_gpu.batch_y1_dev, g_gpu.hq_dev, g_gpu.hs_dev, BATCH_HQ_BYTES, BATCH_HS_BYTES, VHB_HQ, VHB_Y1)
     let comb = npos > 0l
     var comb_k = 0l
     if (comb) {
@@ -6151,9 +6245,8 @@ def private record_dense_cmd(si : int; nwg : uint; y_bytes : int64; axq_bytes, a
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
     vhz_dep(raw, h, 0u, VHB_META, true)
     cmd_copy_batch_meta(raw, si)
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, g_gpu.stacks[si].fmt, g_gpu.stacks[si].batch_tile, g_gpu.stacks[si].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[si].batch_set, nwg)
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[si].fmt, g_gpu.stacks[si].batch_tile, g_gpu.stacks[si].batch_aligned),
+        g_gpu.stacks[si].batch_set, nwg)
     vhz_dep(raw, h, VHB_Y1, 0u, true)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, y_bytes)
     vk_check(vkEndCommandBuffer(raw), null)
@@ -6166,7 +6259,7 @@ def vk_moe_dense(var yp : float?; woff : int64; xqp : int8 const?; xsp : float c
     let si = find_stack(woff, fmt)
     let xunit = fmt != 0 ? 256l : 32l
     ensure_batch_state()
-    ensure_batch_set(si, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
+    ensure_batch_set(si, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y1)
     var chunk = min(BATCH_XQ_BYTES / n, BATCH_XS_BYTES / ((n / xunit) * 4l))
     chunk = min(chunk, BATCH_Y_BYTES / (d * 4l))
     chunk = min(chunk, BATCH_CHUNK_ROWS) / BATCH_TILE * BATCH_TILE
@@ -6246,6 +6339,9 @@ def private ensure_dn_state {
     write_buf_desc(writes, g_gpu.dn_rq_set, 5u, g_gpu.dn_meta_dev, DN_META_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.dn_conv_set, VHB_HQ, 0u, VHB_META, 0u, VHB_SM, VHB_Y1)   // 1/3 = untouched fillers
+    hz_set_bits(g_gpu.dn_scan_set, VHB_HQ, VHB_ST, VHB_META, VHB_WS, VHB_SM, VHB_Y2)
+    hz_set_bits(g_gpu.dn_rq_set, VHB_WS, 0u, VHB_META, VHB_HQ, VHB_HQ, 0u)     // 1/5 = untouched fillers
     g_gpu.dn_ready = true
     to_log(LOG_INFO, "dasLLAMA vulkan tier: deltanet chain engaged\n")
 }
@@ -6305,26 +6401,16 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
         cmd_copy_whole(raw, g_gpu.dn_state_stage.buf, g_gpu.dn_state_dev, nvh * ds * ds * 4l)
     }
     pfq_ts(raw)   // q1: uploads
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, 0, g_gpu.stacks[s_qkv].batch_tile, g_gpu.stacks[s_qkv].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_qkv].batch_set, nwg_qkv)
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y2)
-    if (!same_batch_pipe(s_z, s_qkv)) {
-        bind_batch_pipe(raw, 0, g_gpu.stacks[s_z].batch_tile, g_gpu.stacks[s_z].batch_aligned)
-    }
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_z].batch_set, nwg_z)
+    hz_dispatch(raw, h, batch_pipe(0, g_gpu.stacks[s_qkv].batch_tile, g_gpu.stacks[s_qkv].batch_aligned),
+        g_gpu.stacks[s_qkv].batch_set, nwg_qkv)
+    hz_dispatch(raw, h, batch_pipe(0, g_gpu.stacks[s_z].batch_tile, g_gpu.stacks[s_z].batch_aligned),
+        g_gpu.stacks[s_z].batch_set, nwg_z)
     pfq_ts(raw)   // q2: qkv+z GEMMs
-    vhz_dep(raw, h, VHB_Y1 | VHB_SM | VHB_META, VHB_HQ)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_conv_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.dn_conv_set, uint(rows))
+    hz_dispatch(raw, h, weak_copy(g_gpu.dn_conv_pipeline), g_gpu.dn_conv_set, uint(rows))
     pfq_ts(raw)   // q3: conv
-    vhz_dep(raw, h, VHB_HQ | VHB_Y2 | VHB_SM | VHB_ST | VHB_META, VHB_ST | VHB_WS)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_scan_p1_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.dn_scan_set, uint(nvh * ((rows + DN_CS - 1l) / DN_CS)))
+    hz_dispatch(raw, h, weak_copy(g_gpu.dn_scan_p1_pipeline), g_gpu.dn_scan_set, uint(nvh * ((rows + DN_CS - 1l) / DN_CS)))
     pfq_ts(raw)   // q4: scan phase 1
-    vhz_dep(raw, h, VHB_HQ | VHB_Y2 | VHB_SM | VHB_ST | VHB_WS | VHB_META, VHB_ST | VHB_WS)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_scan_p2_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.dn_scan_set, uint(nvh))
+    hz_dispatch(raw, h, weak_copy(g_gpu.dn_scan_p2_pipeline), g_gpu.dn_scan_set, uint(nvh))
     pfq_ts(raw)   // q5: scan phase 2
     // conv-tail extraction: last `taps` RAW qkv rows out of y1 before out-proj reuses it
     if (!last) {
@@ -6337,13 +6423,10 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
         cmd_copy_whole(raw, g_gpu.dn_state_dev, g_gpu.dn_state_host.buf, nvh * ds * ds * 4l)
     }
     pfq_ts(raw)   // q6: tail copies
-    vhz_dep(raw, h, VHB_WS | VHB_META, VHB_HQ)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_rq_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.dn_rq_set, uint((rows * di / 32l + 255l) / 256l))
+    hz_dispatch(raw, h, weak_copy(g_gpu.dn_rq_pipeline), g_gpu.dn_rq_set, uint((rows * di / 32l + 255l) / 256l))
     pfq_ts(raw)   // q7: o requant
-    vhz_dep(raw, h, VHB_HQ | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, 0, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_out)
+    hz_dispatch(raw, h, batch_pipe(0, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned),
+        g_gpu.stacks[s_o].batch_set, nwg_out)
     pfq_ts(raw)   // q8: out GEMM
     vhz_dep(raw, h, VHB_Y1, 0u, true)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, rows * dim * 4l)
@@ -6376,9 +6459,9 @@ def vk_moe_dn(var yp : float?; woq, woz, woo : int64;
         "dasLLAMA vulkan tier: deltanet geometry outside chain capacity")
     ensure_batch_state()
     ensure_dn_state()
-    ensure_batch_set(s_qkv, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
-    ensure_batch_set(s_z, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
-    ensure_batch_set(s_o, g_gpu.batch_y1_dev, g_gpu.hq_dev, g_gpu.hs_dev, BATCH_HQ_BYTES, BATCH_HS_BYTES)
+    ensure_batch_set(s_qkv, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y1)
+    ensure_batch_set(s_z, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y2)
+    ensure_batch_set(s_o, g_gpu.batch_y1_dev, g_gpu.hq_dev, g_gpu.hs_dev, BATCH_HQ_BYTES, BATCH_HS_BYTES, VHB_HQ, VHB_Y1)
     unsafe {
         var sp = reinterpret<float?>(g_gpu.dn_smalls.mapped)
         sp[0] = eps
@@ -6524,6 +6607,11 @@ def private dnd_step_make(s_qkv, s_z, s_o : int; woq, woz, woo : int64;
     write_buf_desc(writes, st.out_set, 5u, g_gpu.stacks[s_o].y_dev, Y_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    // the qkv stack's raw_set plays Y1 in this chain (role-fluid sets re-declare per record)
+    hz_set_bits(g_gpu.stacks[s_qkv].raw_set, 0u, 0u, 0u, 0u, 0u, VHG_Y1)
+    hz_set_bits(st.z_set, 0u, 0u, 0u, 0u, 0u, VHG_Y2)
+    hz_set_bits(st.fused_set, VHG_WS, VHG_ST, VHG_META, VHG_WS, VHG_SM, VHG_Y1 | VHG_Y2)
+    hz_set_bits(st.out_set, 0u, 0u, 0u, VHG_WS, VHG_WS, VHG_YO)
     let raw = st.cmd
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
@@ -6534,17 +6622,10 @@ def private dnd_step_make(s_qkv, s_z, s_o : int; woq, woz, woo : int64;
     cmd_copy_range(raw, g_gpu.dnd_bg.buf, 2l * nvh * 4l, st.smalls_dev, 8l, 4l)   // the ring parity word
     vhz_dep(raw, h, 0u, VHG_META, true)
     cmd_copy_whole(raw, g_gpu.dnd_meta.buf, g_gpu.dn_meta_dev, DN_META_BYTES)
-    vhz_dep(raw, h, 0u, VHG_Y1)
-    bind_gemv_pipe(raw, 0)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_qkv].raw_set, uint((cd + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    vhz_dep(raw, h, 0u, VHG_Y2)
-    cmd_bind_dispatch(raw, st.z_set, uint((di + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_SM | VHG_META | VHG_ST, VHG_ST | VHG_WS | VHG_SM)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dnd_fused_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, st.fused_set, uint(nvh))
-    vhz_dep(raw, h, VHG_WS, VHG_YO)
-    bind_gemv_pipe(raw, 0)
-    cmd_bind_dispatch(raw, st.out_set, uint((dim + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, gemv_pipe(0), g_gpu.stacks[s_qkv].raw_set, uint((cd + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, gemv_pipe(0), st.z_set, uint((di + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, weak_copy(g_gpu.dnd_fused_pipeline), st.fused_set, uint(nvh))
+    hz_dispatch(raw, h, gemv_pipe(0), st.out_set, uint((dim + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
     vhz_dep(raw, h, VHG_YO, 0u, true)
     cmd_copy_whole(raw, g_gpu.stacks[s_o].y_dev, g_gpu.stacks[s_o].y.buf, dim * 4l)
     if (vk_prof()) {
@@ -6720,6 +6801,10 @@ def private ensure_at_state {
     write_buf_desc(writes, g_gpu.at_rq_set, 5u, g_gpu.at_meta_dev, AT_META_BYTES)
     let no_copies : array<CopyDescriptorSet>
     update_descriptor_sets(g_gpu.device, writes, no_copies)
+    hz_set_bits(g_gpu.at_prep_q_set, VHB_ATQ, 0u, VHB_META, VHB_ATG, VHB_SM, VHB_Y1)
+    hz_set_bits(g_gpu.at_prep_k_set, VHB_ATK, 0u, VHB_META, 0u, VHB_SM, VHB_Y2)   // 3 = the never-fired gate view
+    hz_set_bits(g_gpu.at_attn_set, VHB_ATQ, VHB_ATK, VHB_META, VHB_ATG, VHB_SM, VHB_ATV)
+    hz_set_bits(g_gpu.at_rq_set, VHB_ATG, 0u, VHB_META, VHB_HQ, VHB_HQ, 0u)
     g_gpu.at_ready = true
     to_log(LOG_INFO, "dasLLAMA vulkan tier: attention chain engaged\n")
 }
@@ -6771,25 +6856,14 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     cmd_copy_whole(raw, g_gpu.at_meta.buf, g_gpu.at_meta_dev, AT_META_BYTES)
     vhz_dep(raw, h, 0u, VHB_SM, true)
     cmd_copy_range(raw, g_gpu.at_smalls.buf, 0l, g_gpu.at_smalls_dev, 0l, sm_bytes)
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, g_gpu.stacks[s_q].fmt, g_gpu.stacks[s_q].batch_tile, g_gpu.stacks[s_q].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_q].batch_set, nwg_q)
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y2)
-    if (!same_batch_pipe(s_k, s_q)) {
-        bind_batch_pipe(raw, g_gpu.stacks[s_k].fmt, g_gpu.stacks[s_k].batch_tile, g_gpu.stacks[s_k].batch_aligned)
-    }
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_k].batch_set, nwg_k)
-    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_VRAW)
-    if (!same_batch_pipe(s_v, s_k)) {
-        bind_batch_pipe(raw, g_gpu.stacks[s_v].fmt, g_gpu.stacks[s_v].batch_tile, g_gpu.stacks[s_v].batch_aligned)
-    }
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_v].batch_set, nwg_v)
-    vhz_dep(raw, h, VHB_Y1 | VHB_SM | VHB_META, VHB_ATQ | VHB_ATG)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.at_prep_q_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.at_prep_q_set, uint(rows))
-    vhz_dep(raw, h, VHB_Y2 | VHB_SM | VHB_META, VHB_ATK)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.at_prep_k_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.at_prep_k_set, uint(rows))
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s_q].fmt, g_gpu.stacks[s_q].batch_tile, g_gpu.stacks[s_q].batch_aligned),
+        g_gpu.stacks[s_q].batch_set, nwg_q)
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s_k].fmt, g_gpu.stacks[s_k].batch_tile, g_gpu.stacks[s_k].batch_aligned),
+        g_gpu.stacks[s_k].batch_set, nwg_k)
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s_v].fmt, g_gpu.stacks[s_v].batch_tile, g_gpu.stacks[s_v].batch_aligned),
+        g_gpu.stacks[s_v].batch_set, nwg_v)
+    hz_dispatch(raw, h, weak_copy(g_gpu.at_prep_q_pipeline), g_gpu.at_prep_q_set, uint(rows))
+    hz_dispatch(raw, h, weak_copy(g_gpu.at_prep_k_pipeline), g_gpu.at_prep_k_set, uint(rows))
     // transfer window: append raw v at absolute positions, DMA roped k/raw v to host
     vhz_dep(raw, h, VHB_VRAW, VHB_ATV, true)
     cmd_copy_range(raw, g_gpu.at_vraw_dev, 0l, g_gpu.at_v_dev, w0 * kv_dim * 4l, rows * kv_dim * 4l)
@@ -6797,15 +6871,11 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     cmd_copy_range(raw, g_gpu.at_k_dev, w0 * kv_dim * 4l, g_gpu.at_kv_host.buf, 0l, rows * kv_dim * 4l)
     vhz_dep(raw, h, VHB_VRAW, 0u, true)
     cmd_copy_range(raw, g_gpu.at_vraw_dev, 0l, g_gpu.at_kv_host.buf, AT_WINDOW * AT_MAX_KV * 4l, rows * kv_dim * 4l)
-    vhz_dep(raw, h, VHB_ATQ | VHB_ATK | VHB_ATV | VHB_ATG | VHB_SM | VHB_META, VHB_ATG)
-    cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.at_attn_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.at_attn_set, uint(n_heads * ((rows + 7l) / 8l)))
-    vhz_dep(raw, h, VHB_ATG | VHB_META, VHB_HQ)
-    cmd_bind_pipeline(vk_value_to_boost(raw), o_kq ? g_gpu.q8k_rq_pipeline : g_gpu.dn_rq_pipeline, VkPipelineBindPoint.COMPUTE)
-    cmd_bind_dispatch(raw, g_gpu.at_rq_set, uint((rows * qd / (o_kq ? 256l : 32l) + 255l) / 256l))
-    vhz_dep(raw, h, VHB_HQ | VHB_META, VHB_Y1)
-    bind_batch_pipe(raw, g_gpu.stacks[s_o].fmt, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned)
-    cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_o)
+    hz_dispatch(raw, h, weak_copy(g_gpu.at_attn_pipeline), g_gpu.at_attn_set, uint(n_heads * ((rows + 7l) / 8l)))
+    hz_dispatch(raw, h, weak_copy(o_kq ? g_gpu.q8k_rq_pipeline : g_gpu.dn_rq_pipeline),
+        g_gpu.at_rq_set, uint((rows * qd / (o_kq ? 256l : 32l) + 255l) / 256l))
+    hz_dispatch(raw, h, batch_pipe(g_gpu.stacks[s_o].fmt, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned),
+        g_gpu.stacks[s_o].batch_set, nwg_o)
     vhz_dep(raw, h, VHB_Y1, 0u, true)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, rows * dim * 4l)
     if (vk_prof()) {
@@ -6846,11 +6916,11 @@ def vk_moe_attn(var yp : float?; var kp : float?; var vp : float?;
     let xunit = kq ? 256l : 32l
     ensure_batch_state()
     ensure_at_state()
-    ensure_batch_set(s_q, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
-    ensure_batch_set(s_k, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES)
+    ensure_batch_set(s_q, g_gpu.batch_y1_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y1)
+    ensure_batch_set(s_k, g_gpu.batch_y2_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES, VHB_ACT, VHB_Y2)
     ensure_batch_set(s_v, g_gpu.at_vraw_dev, g_gpu.batch_xq_dev, g_gpu.batch_xs_dev, BATCH_XQ_BYTES, BATCH_XS_BYTES,
-        [ybytes = AT_WINDOW * AT_MAX_KV * 4l])
-    ensure_batch_set(s_o, g_gpu.batch_y1_dev, g_gpu.hq_dev, g_gpu.hs_dev, BATCH_HQ_BYTES, BATCH_HS_BYTES)
+        VHB_ACT, VHB_VRAW, [ybytes = AT_WINDOW * AT_MAX_KV * 4l])
+    ensure_batch_set(s_o, g_gpu.batch_y1_dev, g_gpu.hq_dev, g_gpu.hs_dev, BATCH_HQ_BYTES, BATCH_HS_BYTES, VHB_HQ, VHB_Y1)
     unsafe {
         var sp = reinterpret<float?>(g_gpu.at_smalls.mapped)
         sp[0] = eps
@@ -6951,26 +7021,22 @@ def private ffn_cmd_for(s1, s3, s2 : int; nrows, n, nfe : int64) : VkCommandBuff
         let raw = fc.cmd
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        // gate/up roles on the two stacks' raw_sets, this chain's view (re-declared per record)
+        hz_set_bits(g_gpu.stacks[s1].raw_set, 0u, 0u, 0u, 0u, 0u, VHG_Y1)
+        hz_set_bits(g_gpu.stacks[s3].raw_set, 0u, 0u, 0u, 0u, 0u, VHG_Y2)
+        hz_set_bits(fc.actrq_set, VHG_Y2, 0u, VHG_META, VHG_HQ, VHG_HQ, VHG_Y1)
+        hz_set_bits(fc.down_set, 0u, 0u, 0u, VHG_HQ, VHG_HQ, VHG_YO)
         var h : VkHaz
         vhz_dep(raw, h, 0u, VHG_META, true)
         cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-        vhz_dep(raw, h, 0u, VHG_Y1)
-        bind_gemv_pipe(raw, g_gpu.stacks[s1].fmt)
         let ggu = uint((nrows * nfe + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg)
-        cmd_bind_dispatch(raw, g_gpu.stacks[s1].raw_set, ggu)
-        vhz_dep(raw, h, 0u, VHG_Y2)
-        if (g_gpu.stacks[s3].fmt != g_gpu.stacks[s1].fmt) {
-            bind_gemv_pipe(raw, g_gpu.stacks[s3].fmt)
-        }
-        cmd_bind_dispatch(raw, g_gpu.stacks[s3].raw_set, ggu)
+        hz_dispatch(raw, h, gemv_pipe(g_gpu.stacks[s1].fmt), g_gpu.stacks[s1].raw_set, ggu)
+        hz_dispatch(raw, h, gemv_pipe(g_gpu.stacks[s3].fmt), g_gpu.stacks[s3].raw_set, ggu)
         // the requant form follows the DOWN stack — its GEMV is the consumer of hq/hs
         let dkq = g_gpu.stacks[s2].fmt != 0
-        vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_META, VHG_HQ)
-        cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
-        cmd_bind_dispatch(raw, fc.actrq_set, uint((nrows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
-        vhz_dep(raw, h, VHG_HQ, VHG_YO)
-        bind_gemv_pipe(raw, g_gpu.stacks[s2].fmt)
-        cmd_bind_dispatch(raw, fc.down_set, uint((nrows * n + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+        hz_dispatch(raw, h, weak_copy(dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline),
+            fc.actrq_set, uint((nrows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
+        hz_dispatch(raw, h, gemv_pipe(g_gpu.stacks[s2].fmt), fc.down_set, uint((nrows * n + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
         vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.stacks[s2].y_dev, g_gpu.stacks[s2].y.buf, nrows * n * 4l)
         if (vk_prof()) {
@@ -7078,20 +7144,14 @@ def private qkv_cmd_make(sq, sk, sv : int; woq, wok, wov : int64; n, dq, dk, dv 
     let fq = g_gpu.stacks[sq].fmt
     let fk = g_gpu.stacks[sk].fmt
     let fv = g_gpu.stacks[sv].fmt
+    // three disjoint row levels on the shared y — the q stack's raw_set plays Y1 in this chain
+    hz_set_bits(g_gpu.stacks[sq].raw_set, 0u, 0u, 0u, 0u, 0u, VHG_Y1)
+    hz_set_bits(qc.k_set, 0u, 0u, 0u, 0u, 0u, VHG_Y2)
+    hz_set_bits(qc.v_set, 0u, 0u, 0u, 0u, 0u, VHG_Y3)
     var h : VkHaz
-    vhz_dep(raw, h, 0u, VHG_Y1)
-    bind_gemv_pipe(raw, fq)
-    cmd_bind_dispatch(raw, g_gpu.stacks[sq].raw_set, uint((dq + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    vhz_dep(raw, h, 0u, VHG_Y2)
-    if (fk != fq) {
-        bind_gemv_pipe(raw, fk)
-    }
-    cmd_bind_dispatch(raw, qc.k_set, uint((dk + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    vhz_dep(raw, h, 0u, VHG_Y3)
-    if (fv != fk) {
-        bind_gemv_pipe(raw, fv)
-    }
-    cmd_bind_dispatch(raw, qc.v_set, uint((dv + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, gemv_pipe(fq), g_gpu.stacks[sq].raw_set, uint((dq + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, gemv_pipe(fk), qc.k_set, uint((dk + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, gemv_pipe(fv), qc.v_set, uint((dv + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
     vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_Y3, 0u, true)
     cmd_copy_whole(raw, g_gpu.stacks[sq].y_dev, g_gpu.stacks[sq].y.buf, qc.ybytes)
     vk_check(vkEndCommandBuffer(raw), null)
@@ -7426,10 +7486,10 @@ def private ensure_cls(si : int; woff, n, d : int64) {
     var raw = alloc_cmd()
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    hz_set_bits(g_gpu.stacks[si].cls_set, 0u, 0u, 0u, 0u, 0u, VHG_YO)
     var h : VkHaz
-    vhz_dep(raw, h, 0u, VHG_YO)
-    bind_gemv_pipe(raw, g_gpu.stacks[si].fmt)
-    cmd_bind_dispatch(raw, g_gpu.stacks[si].cls_set, uint((d + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    hz_dispatch(raw, h, gemv_pipe(g_gpu.stacks[si].fmt), g_gpu.stacks[si].cls_set,
+        uint((d + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
     vhz_dep(raw, h, VHG_YO, 0u, true)
     cmd_copy_whole(raw, g_gpu.stacks[si].y_dev, g_gpu.stacks[si].y.buf, d * 4l)
     vk_check(vkEndCommandBuffer(raw), null)

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4259,9 +4259,11 @@ def vk_add_rms(var x : array<float>; a : array<float>; w : array<float>; var y :
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_X | VHG_YO)
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.ar_pipeline, VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.ar_set, 1u)   // one workgroup owns the whole row (it reduces)
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHG_YO, 0u, true)   // x reads back post-fence in the second cmd
         cmd_copy_whole(raw, g_gpu.ar_y_dev, g_gpu.ar_host.buf, bytes)
         vk_check(vkEndCommandBuffer(raw), null)
         submit_wait(raw)
@@ -4425,9 +4427,11 @@ def vk_decode_attn(var q : array<float>; var out : array<float>; cnt, qd, kv_dim
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_YO)
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.da_pipeline, VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.da_set, uint(n_heads))
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.da_out_dev, g_gpu.da_out_host.buf, qd * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
         submit_wait(raw)
@@ -4464,9 +4468,11 @@ def vk_rope_kv_store(var qkv : array<float>; var qout : array<float>; var krow :
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_Y1 | VHG_Y2 | VHG_Y3)
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.rks_pipeline, VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.rks_set, uint((npairs + int64(WG_X) - 1l) / int64(WG_X)))
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_Y3, 0u, true)   // one declaration for the q/k/v readback group
         cmd_copy_whole(raw, g_gpu.rks_q_dev, g_gpu.rks_q_host.buf, qd * 4l)
         cmd_copy_range(raw, g_gpu.rks_k_dev, pos * kv_dim * 4l, g_gpu.rks_kv_host.buf, 0l, kv_dim * 4l)
         cmd_copy_range(raw, g_gpu.rks_v_dev, pos * kv_dim * 4l, g_gpu.rks_kv_host.buf, kv_dim * 4l, kv_dim * 4l)
@@ -4900,6 +4906,18 @@ let private VHB_ATG = 0x800u      // at gate/o rows
 let private VHB_ATK = 0x1000u     // at roped-k panel
 let private VHB_ATV = 0x2000u     // at v panel (absolute positions)
 let private VHB_VRAW = 0x4000u    // at raw-v window
+
+// serial-seam region bits (decode GEMV preps, arena + standalone seams) — third namespace, same rail
+let private VHG_META = 0x1u       // ffn/dn params staged to device
+let private VHG_SM = 0x2u         // dn smalls image (β/γ + parity ring)
+let private VHG_Y1 = 0x4u         // gate / qkv / q out
+let private VHG_Y2 = 0x8u         // up / z / k out
+let private VHG_Y3 = 0x10u        // v out (qkv group, rope v mirror)
+let private VHG_HQ = 0x20u        // hq+hs requant image
+let private VHG_ST = 0x40u        // dn recurrent state (in place)
+let private VHG_WS = 0x80u        // dn o scratch (oq+os)
+let private VHG_X = 0x100u        // add_rms residual x (in place)
+let private VHG_YO = 0x200u       // the host-bound result plane (the DMA source)
 
 struct private VkHaz {
     w : uint            // bits with a pending (unbarriered) write
@@ -5458,23 +5476,26 @@ def vk_arena_ffn(var y : array<float>; blk1, blk3, blk2 : int64; n, nfe : int64;
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_META, true)
         cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-        batch_barrier(raw, true)
         let gwg = uint((nfe + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg)
+        vhz_dep(raw, h, 0u, VHG_Y1)
         bind_gemv_pipe(raw, f1)
         cmd_bind_dispatch(raw, g_gpu.af_gate_set, gwg)
+        vhz_dep(raw, h, 0u, VHG_Y2)
         if (f3 != f1) {
             bind_gemv_pipe(raw, f3)
         }
         cmd_bind_dispatch(raw, g_gpu.af_up_set, gwg)
-        comp_barrier(raw)
         // the requant form follows the DOWN plane — its GEMV consumes hq/hs
+        vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_META, VHG_HQ)
         cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.af_actrq_set, uint((nfe / (dkq ? 256l : 32l) + 255l) / 256l))
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHG_HQ, VHG_YO)
         bind_gemv_pipe(raw, f2)
         cmd_bind_dispatch(raw, g_gpu.af_down_set, uint((n + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-        batch_barrier(raw, false)
+        vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.af_yo_dev, g_gpu.af_yo_host.buf, n * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
         submit_wait(raw)
@@ -5542,9 +5563,11 @@ def vk_arena_gemm(var y : array<float>; blk : int64; n, d, npos : int64; fmt : i
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_YO)
         cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe_for(d, npos), VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.arenas[fmt].batch_set, groups)
-        batch_barrier(raw, false)
+        vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, npos * d * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
         submit_wait(raw)
@@ -5578,9 +5601,11 @@ def vk_arena_gemv(var y : array<float>; blk : int64; n, d : int64; fmt : int; xq
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_YO)
         bind_gemv_pipe(raw, fmt)
         cmd_bind_dispatch(raw, a.raw_set, uint((d + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, a.y_dev, a.y.buf, d * 4l)
         vk_check(vkEndCommandBuffer(raw), null)
         submit_wait(raw)
@@ -5771,26 +5796,6 @@ def private fill_ffn_meta(elems, nblocks : int64; is_gelu : bool; comb_n : int64
         mp[6] = uint(comb_r0)
         mp[7] = uint(comb_r1)
     }
-}
-
-// compute -> compute barrier between the chain's kernels (RAW on the y/hidden planes; the
-// write-after-read hazard between requant and the down overwrite of y rides the same
-// execution dependency)
-def private comp_barrier(raw : VkCommandBuffer) {
-    var mb : MemoryBarrier
-    mb.srcAccessMask.shader_write = true
-    mb.dstAccessMask.shader_read = true
-    mb.dstAccessMask.shader_write = true
-    var mbs : array<MemoryBarrier>
-    mbs |> emplace(mb)
-    var sstage : VkPipelineStageFlags
-    sstage.compute_shader = true
-    var dstage : VkPipelineStageFlags
-    dstage.compute_shader = true
-    let dflags : VkDependencyFlags
-    let no_bufb : array<BufferMemoryBarrier>
-    let no_imgb : array<ImageMemoryBarrier>
-    cmd_pipeline_barrier(vk_value_to_boost(raw), sstage, dstage, dflags, mbs, no_bufb, no_imgb)
 }
 
 // ===== prefill batch dispatch (the FFN's batched-GEMM arm) =====
@@ -5993,26 +5998,6 @@ def private cmd_copy_batch_meta(raw : VkCommandBuffer; si : int) {
     regions |> push(BufferCopy(srcOffset = 0ul, dstOffset = 0ul, size = uint64(BATCH_META_BYTES)))
     cmd_copy_buffer(vk_value_to_boost(raw), nonowning_buf(g_gpu.stacks[si].batch_meta.buf),
                     nonowning_buf(g_gpu.stacks[si].batch_meta_dev), regions)
-}
-
-def private batch_barrier(raw : VkCommandBuffer; src_transfer : bool) {
-    var mb : MemoryBarrier
-    mb.srcAccessMask.transfer_write = src_transfer
-    mb.srcAccessMask.shader_write = !src_transfer
-    mb.dstAccessMask.shader_read = src_transfer
-    mb.dstAccessMask.transfer_read = !src_transfer
-    var mbs : array<MemoryBarrier>
-    mbs |> emplace(mb)
-    var sstage : VkPipelineStageFlags
-    sstage.transfer = src_transfer
-    sstage.compute_shader = !src_transfer
-    var dstage : VkPipelineStageFlags
-    dstage.compute_shader = src_transfer
-    dstage.transfer = !src_transfer
-    let dflags : VkDependencyFlags
-    let no_bufb : array<BufferMemoryBarrier>
-    let no_imgb : array<ImageMemoryBarrier>
-    cmd_pipeline_barrier(vk_value_to_boost(raw), sstage, dstage, dflags, mbs, no_bufb, no_imgb)
 }
 
 def private cmd_copy_whole(raw : VkCommandBuffer; src, dst : uint64; bytes : int64) {
@@ -6542,22 +6527,29 @@ def private dnd_step_make(s_qkv, s_z, s_o : int; woq, woz, woo : int64;
     let raw = st.cmd
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    var h : VkHaz
+    vhz_dep(raw, h, 0u, VHG_SM, true)   // one declaration for the smalls copy group
     cmd_copy_range(raw, g_gpu.dnd_bg.buf, 0l, st.smalls_dev, DN_SM_BETA * 4l, nvh * 4l)
     cmd_copy_range(raw, g_gpu.dnd_bg.buf, nvh * 4l, st.smalls_dev, DN_SM_G * 4l, nvh * 4l)
     cmd_copy_range(raw, g_gpu.dnd_bg.buf, 2l * nvh * 4l, st.smalls_dev, 8l, 4l)   // the ring parity word
+    vhz_dep(raw, h, 0u, VHG_META, true)
     cmd_copy_whole(raw, g_gpu.dnd_meta.buf, g_gpu.dn_meta_dev, DN_META_BYTES)
-    batch_barrier(raw, true)
+    vhz_dep(raw, h, 0u, VHG_Y1)
     bind_gemv_pipe(raw, 0)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_qkv].raw_set, uint((cd + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    vhz_dep(raw, h, 0u, VHG_Y2)
     cmd_bind_dispatch(raw, st.z_set, uint((di + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    comp_barrier(raw)
+    vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_SM | VHG_META | VHG_ST, VHG_ST | VHG_WS | VHG_SM)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dnd_fused_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, st.fused_set, uint(nvh))
-    comp_barrier(raw)
+    vhz_dep(raw, h, VHG_WS, VHG_YO)
     bind_gemv_pipe(raw, 0)
     cmd_bind_dispatch(raw, st.out_set, uint((dim + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    batch_barrier(raw, false)
+    vhz_dep(raw, h, VHG_YO, 0u, true)
     cmd_copy_whole(raw, g_gpu.stacks[s_o].y_dev, g_gpu.stacks[s_o].y.buf, dim * 4l)
+    if (vk_prof()) {
+        to_log(LOG_INFO, "vk_dnd hz: {h.disp} nodes, {h.barriers} barriers\n")
+    }
     vk_check(vkEndCommandBuffer(raw), null)
     g_gpu.dnd_steps |> insert(woq, st)
 }
@@ -6959,25 +6951,31 @@ def private ffn_cmd_for(s1, s3, s2 : int; nrows, n, nfe : int64) : VkCommandBuff
         let raw = fc.cmd
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
+        var h : VkHaz
+        vhz_dep(raw, h, 0u, VHG_META, true)
         cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
-        batch_barrier(raw, true)
+        vhz_dep(raw, h, 0u, VHG_Y1)
         bind_gemv_pipe(raw, g_gpu.stacks[s1].fmt)
         let ggu = uint((nrows * nfe + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg)
         cmd_bind_dispatch(raw, g_gpu.stacks[s1].raw_set, ggu)
+        vhz_dep(raw, h, 0u, VHG_Y2)
         if (g_gpu.stacks[s3].fmt != g_gpu.stacks[s1].fmt) {
             bind_gemv_pipe(raw, g_gpu.stacks[s3].fmt)
         }
         cmd_bind_dispatch(raw, g_gpu.stacks[s3].raw_set, ggu)
-        comp_barrier(raw)
         // the requant form follows the DOWN stack — its GEMV is the consumer of hq/hs
         let dkq = g_gpu.stacks[s2].fmt != 0
+        vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_META, VHG_HQ)
         cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, fc.actrq_set, uint((nrows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHG_HQ, VHG_YO)
         bind_gemv_pipe(raw, g_gpu.stacks[s2].fmt)
         cmd_bind_dispatch(raw, fc.down_set, uint((nrows * n + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-        batch_barrier(raw, false)
+        vhz_dep(raw, h, VHG_YO, 0u, true)
         cmd_copy_whole(raw, g_gpu.stacks[s2].y_dev, g_gpu.stacks[s2].y.buf, nrows * n * 4l)
+        if (vk_prof()) {
+            to_log(LOG_INFO, "vk_ffng hz: {h.disp} nodes, {h.barriers} barriers\n")
+        }
         vk_check(vkEndCommandBuffer(raw), null)
         g_gpu.ffn_cmds[key] = FfnCmd(cmd = fc.cmd, actrq_set = fc.actrq_set,
             down_set = fc.down_set, nrows = nrows)
@@ -7080,17 +7078,21 @@ def private qkv_cmd_make(sq, sk, sv : int; woq, wok, wov : int64; n, dq, dk, dv 
     let fq = g_gpu.stacks[sq].fmt
     let fk = g_gpu.stacks[sk].fmt
     let fv = g_gpu.stacks[sv].fmt
+    var h : VkHaz
+    vhz_dep(raw, h, 0u, VHG_Y1)
     bind_gemv_pipe(raw, fq)
     cmd_bind_dispatch(raw, g_gpu.stacks[sq].raw_set, uint((dq + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    vhz_dep(raw, h, 0u, VHG_Y2)
     if (fk != fq) {
         bind_gemv_pipe(raw, fk)
     }
     cmd_bind_dispatch(raw, qc.k_set, uint((dk + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
+    vhz_dep(raw, h, 0u, VHG_Y3)
     if (fv != fk) {
         bind_gemv_pipe(raw, fv)
     }
     cmd_bind_dispatch(raw, qc.v_set, uint((dv + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    batch_barrier(raw, false)
+    vhz_dep(raw, h, VHG_Y1 | VHG_Y2 | VHG_Y3, 0u, true)
     cmd_copy_whole(raw, g_gpu.stacks[sq].y_dev, g_gpu.stacks[sq].y.buf, qc.ybytes)
     vk_check(vkEndCommandBuffer(raw), null)
     g_gpu.qkv_cmds |> insert(woq, qc)
@@ -7424,9 +7426,11 @@ def private ensure_cls(si : int; woff, n, d : int64) {
     var raw = alloc_cmd()
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    var h : VkHaz
+    vhz_dep(raw, h, 0u, VHG_YO)
     bind_gemv_pipe(raw, g_gpu.stacks[si].fmt)
     cmd_bind_dispatch(raw, g_gpu.stacks[si].cls_set, uint((d + g_gpu.rows_per_wg - 1l) / g_gpu.rows_per_wg))
-    batch_barrier(raw, false)
+    vhz_dep(raw, h, VHG_YO, 0u, true)
     cmd_copy_whole(raw, g_gpu.stacks[si].y_dev, g_gpu.stacks[si].y.buf, d * 4l)
     vk_check(vkEndCommandBuffer(raw), null)
     g_gpu.stacks[si].cls_cmd = raw

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -383,6 +383,218 @@ def q8_moe_batch_cmi8 {
     }
 }
 
+// The mul_mm L-tile variant (DASLLAMA_COOPMAT=mm): llama.cpp's aligned-L geometry — BM=BN=128
+// BK=32, 4 warps 2x2 with 16 f16acc fragments each — 108-129% of lcpp's own mul_mm in isolation
+// (modules/dasVulkan/_coopmat_mulmm_port.das). Edge tiles bounce stores via cml_o; subgroupSize 32.
+
+let private CML_SST = 20u   // shared row stride in uints (16 f16-pair data + 4 pad — bank spread)
+
+var @workgroup cml_a : uint[2560]     // A tile: 128 weight rows x one block (32 K) as f16 pairs
+var @workgroup cml_b : uint[2560]     // B tile: 128 token rows x one block
+var @workgroup cml_o : float16[1024]  // 4 warps x 16x16 f16-acc store bounce (edge tiles only) —
+                                      // 2KB keeps total shared at 22528B = 2 wg/SM (f32 tipped to 1)
+
+[compute_shader(local_size_x=128, name="q8_moe_batch_mm_spv")]
+def q8_moe_batch_mm {
+    let n = vk_meta[0u]
+    let d = vk_meta[1u]
+    let rid = vk_meta[vk_meta[3u] + gl_WorkGroupID.x]
+    let rb = 4u + rid * 4u
+    let wblk0 = vk_meta[rb]
+    let row0 = vk_meta[rb + 1u]
+    let cnt = vk_meta[rb + 2u]
+    let tix = gl_WorkGroupID.x - vk_meta[rb + 3u]
+    let wtiles = (d + 127u) / 128u
+    let xt = tix / wtiles             // token (B) tile
+    let wt = tix % wtiles             // weight (A) tile
+    let gm0 = wt * 128u
+    let gn0 = xt * 128u
+    let nbb = n / 32u
+    let tid = gl_LocalInvocationID.x
+    let warp_r = gl_SubgroupID % 2u   // which 64-row half of the A tile
+    let warp_c = gl_SubgroupID / 2u   // which 64-col half of the B tile
+    let lw = tid % 8u                 // which packed word (4 qs) of the staged row's block
+    let lr0 = tid / 8u                // staging row base 0..15
+    var acc00 : coopmatAcc_f16_16x16
+    var acc01 : coopmatAcc_f16_16x16
+    var acc02 : coopmatAcc_f16_16x16
+    var acc03 : coopmatAcc_f16_16x16
+    var acc10 : coopmatAcc_f16_16x16
+    var acc11 : coopmatAcc_f16_16x16
+    var acc12 : coopmatAcc_f16_16x16
+    var acc13 : coopmatAcc_f16_16x16
+    var acc20 : coopmatAcc_f16_16x16
+    var acc21 : coopmatAcc_f16_16x16
+    var acc22 : coopmatAcc_f16_16x16
+    var acc23 : coopmatAcc_f16_16x16
+    var acc30 : coopmatAcc_f16_16x16
+    var acc31 : coopmatAcc_f16_16x16
+    var acc32 : coopmatAcc_f16_16x16
+    var acc33 : coopmatAcc_f16_16x16
+    var kb = 0u
+    while (kb < nbb) {
+        for [unroll] (p in range(8)) {   // stage A: 128 weight rows x 1 block; OOR rows -> 0
+            let row = lr0 + uint(p) * 16u
+            let wrow = gm0 + row
+            var v = float4(0.0)
+            if (wrow < d) {
+                let ib = wblk0 + wrow * nbb + kb
+                v = float4(int4(unpack8(int(vk_wq[ib * 8u + lw])))) * float(vk_ws[ib])
+            }
+            let o = row * CML_SST + lw * 2u
+            cml_a[o] = packHalf2x16(v.xy)
+            cml_a[o + 1u] = packHalf2x16(v.zw)
+        }
+        for [unroll] (p in range(8)) {   // stage B: 128 token rows x 1 block; OOR rows -> 0
+            let row = lr0 + uint(p) * 16u
+            var v = float4(0.0)
+            if (gn0 + row < cnt) {
+                let ib = (row0 + gn0 + row) * nbb + kb
+                v = float4(int4(unpack8(int(vk_xq[ib * 8u + lw])))) * vk_xs[ib]
+            }
+            let o = row * CML_SST + lw * 2u
+            cml_b[o] = packHalf2x16(v.xy)
+            cml_b[o + 1u] = packHalf2x16(v.zw)
+        }
+        barrier()
+        for [unroll] (ks in range(2)) {   // 2 K-subtiles x (4 A rows x 4 B cols), their MMA order
+            let k8 = uint(ks) * 8u
+            var ca : coopmatA_f16_16x16
+            var cb : coopmatB_f16_16x16
+            coopmatLoad(ca, cml_a, int((warp_r * 64u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc00 = coopmatMulAdd(ca, cb, acc00)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc01 = coopmatMulAdd(ca, cb, acc01)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc02 = coopmatMulAdd(ca, cb, acc02)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc03 = coopmatMulAdd(ca, cb, acc03)
+            coopmatLoad(ca, cml_a, int((warp_r * 64u + 16u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc10 = coopmatMulAdd(ca, cb, acc10)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc11 = coopmatMulAdd(ca, cb, acc11)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc12 = coopmatMulAdd(ca, cb, acc12)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc13 = coopmatMulAdd(ca, cb, acc13)
+            coopmatLoad(ca, cml_a, int((warp_r * 64u + 32u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc20 = coopmatMulAdd(ca, cb, acc20)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc21 = coopmatMulAdd(ca, cb, acc21)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc22 = coopmatMulAdd(ca, cb, acc22)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc23 = coopmatMulAdd(ca, cb, acc23)
+            coopmatLoad(ca, cml_a, int((warp_r * 64u + 48u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc30 = coopmatMulAdd(ca, cb, acc30)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc31 = coopmatMulAdd(ca, cb, acc31)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc32 = coopmatMulAdd(ca, cb, acc32)
+            coopmatLoad(cb, cml_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc33 = coopmatMulAdd(ca, cb, acc33)
+        }
+        barrier()
+        kb++
+    }
+    // stores: y[(row0 + token) * d + wrow] — fragment weight-dim contiguous = column-major, stride d
+    let dr = gm0 + warp_r * 64u
+    let dc = gn0 + warp_c * 64u
+    if (gm0 + 128u <= d && gn0 + 128u <= cnt) {
+        var accw : coopmatAcc_f32_16x16
+        let yb = (row0 + dc) * d + dr
+        coopmatConvert(accw, acc00)
+        coopmatStore(accw, vk_y, int(yb), int(d), 1)
+        coopmatConvert(accw, acc01)
+        coopmatStore(accw, vk_y, int(yb + 16u * d), int(d), 1)
+        coopmatConvert(accw, acc02)
+        coopmatStore(accw, vk_y, int(yb + 32u * d), int(d), 1)
+        coopmatConvert(accw, acc03)
+        coopmatStore(accw, vk_y, int(yb + 48u * d), int(d), 1)
+        coopmatConvert(accw, acc10)
+        coopmatStore(accw, vk_y, int(yb + 16u), int(d), 1)
+        coopmatConvert(accw, acc11)
+        coopmatStore(accw, vk_y, int(yb + 16u * d + 16u), int(d), 1)
+        coopmatConvert(accw, acc12)
+        coopmatStore(accw, vk_y, int(yb + 32u * d + 16u), int(d), 1)
+        coopmatConvert(accw, acc13)
+        coopmatStore(accw, vk_y, int(yb + 48u * d + 16u), int(d), 1)
+        coopmatConvert(accw, acc20)
+        coopmatStore(accw, vk_y, int(yb + 32u), int(d), 1)
+        coopmatConvert(accw, acc21)
+        coopmatStore(accw, vk_y, int(yb + 16u * d + 32u), int(d), 1)
+        coopmatConvert(accw, acc22)
+        coopmatStore(accw, vk_y, int(yb + 32u * d + 32u), int(d), 1)
+        coopmatConvert(accw, acc23)
+        coopmatStore(accw, vk_y, int(yb + 48u * d + 32u), int(d), 1)
+        coopmatConvert(accw, acc30)
+        coopmatStore(accw, vk_y, int(yb + 48u), int(d), 1)
+        coopmatConvert(accw, acc31)
+        coopmatStore(accw, vk_y, int(yb + 16u * d + 48u), int(d), 1)
+        coopmatConvert(accw, acc32)
+        coopmatStore(accw, vk_y, int(yb + 32u * d + 48u), int(d), 1)
+        coopmatConvert(accw, acc33)
+        coopmatStore(accw, vk_y, int(yb + 48u * d + 48u), int(d), 1)
+    } else {
+        // edge tile: every fragment bounces its f16 acc through this warp's cml_o slab (rowmajor,
+        // row = weight dim), then 32 lanes widen + write 8 elements each under bounds checks.
+        // Value-identical to the direct arm (coopmatConvert only widens). Uniform across the wg.
+        let lane = gl_SubgroupInvocationID
+        let ob = gl_SubgroupID * 256u
+        for (fi in range(16)) {
+            let fr = uint(fi) / 4u       // fragment row: weight offset fr*16
+            let fc = uint(fi) % 4u       // fragment col: token offset fc*16
+            if (fi == 0) {
+                coopmatStore(acc00, cml_o, int(ob), 16, 0)
+            } elif (fi == 1) {
+                coopmatStore(acc01, cml_o, int(ob), 16, 0)
+            } elif (fi == 2) {
+                coopmatStore(acc02, cml_o, int(ob), 16, 0)
+            } elif (fi == 3) {
+                coopmatStore(acc03, cml_o, int(ob), 16, 0)
+            } elif (fi == 4) {
+                coopmatStore(acc10, cml_o, int(ob), 16, 0)
+            } elif (fi == 5) {
+                coopmatStore(acc11, cml_o, int(ob), 16, 0)
+            } elif (fi == 6) {
+                coopmatStore(acc12, cml_o, int(ob), 16, 0)
+            } elif (fi == 7) {
+                coopmatStore(acc13, cml_o, int(ob), 16, 0)
+            } elif (fi == 8) {
+                coopmatStore(acc20, cml_o, int(ob), 16, 0)
+            } elif (fi == 9) {
+                coopmatStore(acc21, cml_o, int(ob), 16, 0)
+            } elif (fi == 10) {
+                coopmatStore(acc22, cml_o, int(ob), 16, 0)
+            } elif (fi == 11) {
+                coopmatStore(acc23, cml_o, int(ob), 16, 0)
+            } elif (fi == 12) {
+                coopmatStore(acc30, cml_o, int(ob), 16, 0)
+            } elif (fi == 13) {
+                coopmatStore(acc31, cml_o, int(ob), 16, 0)
+            } elif (fi == 14) {
+                coopmatStore(acc32, cml_o, int(ob), 16, 0)
+            } else {
+                coopmatStore(acc33, cml_o, int(ob), 16, 0)
+            }
+            barrier()
+            for (e in range(8)) {
+                let idx = lane * 8u + uint(e)
+                let wr = dr + fr * 16u + idx / 16u
+                let tc = dc + fc * 16u + idx % 16u
+                if (wr < d && tc < cnt) {
+                    vk_y[(row0 + tc) * d + wr] = float(cml_o[ob + idx])
+                }
+            }
+            barrier()
+        }
+    }
+}
+
 // Q4_0 coopmat f16 variant (fmt=4 stacks): kq_moe_batch_q40 math baked into f16 dequant — w =
 // (nib-8)*d_b, a = aq*xs (per-256 Q8_K) — then the same 4-subgroup MMA as q8_moe_batch_cmf16.
 // No int8-native arm: nibbles would need dequant-to-s8 shared staging (byte stores, NV-slow).
@@ -2619,6 +2831,10 @@ let private BATCH_XS_BYTES = 8_388_608l    // ... its scale plane
 let private BATCH_Y_BYTES = 67_108_864l    // one output plane (two exist: gate/single + up)
 let private BATCH_META_BYTES = 262_144l    // per-stack batch params + regions + workgroup map
 let private BATCH_TILE = 32l               // kernel tile edge (rows and cols)
+
+// the Q8_0 batch kernel's tile edge — 128 for the mul_mm L-tile kernel (mode 3), 32 otherwise.
+// Meta builders MUST use the same edge the bound kernel derives (wtiles = ceil(d / edge)).
+def private q8_batch_tile : int64 => g_gpu.coopmat_mode == 3 ? 128l : BATCH_TILE
 let private BATCH_CHUNK_ROWS = 8_192l      // dispatch row-window cap (bounds y and the wg map)
 let private BATCH_HQ_BYTES = 33_554_432l   // device requantized-hidden quants (the down GEMM's activations)
 let private BATCH_HS_BYTES = 8_388_608l    // ... its scale plane
@@ -2821,6 +3037,7 @@ struct private GpuState {
     batch_coopmat_f16 : Pipeline  // prefill Q8_0 GEMM on tensor cores, f16-dequant (DASLLAMA_COOPMAT=f16)
     batch_coopmat_i8 : Pipeline   // prefill Q8_0 GEMM on tensor cores, native s8 (DASLLAMA_COOPMAT=int8)
     batch_coopmat_q40 : Pipeline  // prefill Q4_0 GEMM on tensor cores, f16-dequant (COOPMAT=f16, fmt 4)
+    batch_coopmat_mm : Pipeline   // prefill Q8_0 GEMM, the mul_mm 128x128 L-tile (DASLLAMA_COOPMAT=mm)
     actrq_pipeline : Pipeline   // fused act(g)*u + q8_0 requant of the hidden rows
     gemv_k4 : Pipeline          // native K-quant GEMVs (per-format decode kernels)
     gemv_k5 : Pipeline
@@ -2852,7 +3069,7 @@ struct private GpuState {
     fence : VkFence          // the one reusable submit fence (reset after every wait)
     rows_per_wg : int64      // subgroups per workgroup = output rows per workgroup
     has_coopmat : bool       // device supports VK_KHR_cooperative_matrix (the f16/int8 tensor tiles)
-    coopmat_mode : int       // Q8_0 prefill GEMM: 0 = sdot4 (default), 1 = f16 coopmat, 2 = int8 coopmat
+    coopmat_mode : int       // Q8_0 prefill GEMM: 0 = sdot4 (default), 1 = f16 coopmat, 2 = int8 coopmat, 3 = mul_mm L-tile
     weight_budget : int64    // resident-weight cap — queried heap budget minus reserve, or VRAM_BUDGET
     @do_not_delete stacks : array<VkStack>
     // the resident driver's weight arenas, one per format present (see the arena section). Separate
@@ -3131,11 +3348,14 @@ def private vk_moe_init : bool {
             g_gpu.coopmat_mode = 1
         } elif (mode == "int8") {
             g_gpu.coopmat_mode = 2
+        } elif (mode == "mm") {
+            g_gpu.coopmat_mode = 3
         }
     }
     if (g_gpu.coopmat_mode != 0) {
         g_gpu.device <- create_device_storage_8_16_int_dot_coopmat(g_gpu.phys, g_gpu.fam)
-        to_log(LOG_INFO, "dasLLAMA vulkan tier: Q8_0 prefill on {g_gpu.coopmat_mode == 1 ? "f16" : "int8"} cooperative-matrix tiles\n")
+        let cm_name = g_gpu.coopmat_mode == 1 ? "f16" : (g_gpu.coopmat_mode == 2 ? "int8" : "mul_mm L-tile")
+        to_log(LOG_INFO, "dasLLAMA vulkan tier: Q8_0 prefill on {cm_name} cooperative-matrix tiles\n")
     } else {
         g_gpu.device <- create_device_storage_8_16_int_dot(g_gpu.phys, g_gpu.fam)
     }
@@ -3211,6 +3431,9 @@ def private vk_moe_init : bool {
     } elif (g_gpu.coopmat_mode == 2) {   // native-s8 tensor-core prefill GEMM
         var cmi8shader <- create_shader_module(g_gpu.device, q8_moe_batch_cmi8_spv)
         g_gpu.batch_coopmat_i8 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmi8shader)
+    } elif (g_gpu.coopmat_mode == 3) {   // the mul_mm 128x128 L-tile prefill GEMM
+        var cmmmshader <- create_shader_module(g_gpu.device, q8_moe_batch_mm_spv)
+        g_gpu.batch_coopmat_mm <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader)
     }
     var ashader <- create_shader_module(g_gpu.device, q8_moe_actrq_spv)
     g_gpu.actrq_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, ashader)
@@ -4843,10 +5066,10 @@ def vk_arena_ffn(var y : array<float>; blk1, blk3, blk2 : int64; n, nfe : int64;
 
 // single-region batch-GEMM meta over an arena block: all tiles map to region 0. Returns the
 // dispatch workgroup count. Mirrors fill_batch_meta for one region [0, npos).
-[unused_argument(fmt)]
 def private fill_arena_batch_meta(hb : HostBuf; n, d, blk, npos : int64; fmt : int) : uint {
-    let wtiles = (d + BATCH_TILE - 1l) / BATCH_TILE
-    let rtiles = (npos + BATCH_TILE - 1l) / BATCH_TILE
+    let tile = fmt == 0 ? q8_batch_tile() : BATCH_TILE
+    let wtiles = (d + tile - 1l) / tile
+    let rtiles = (npos + tile - 1l) / tile
     let total = rtiles * wtiles
     unsafe {
         var mp = reinterpret<uint?>(hb.mapped)
@@ -5006,6 +5229,8 @@ def private q8_batch_pipe : Pipeline {
         return weak_copy(g_gpu.batch_coopmat_f16)
     } elif (g_gpu.coopmat_mode == 2) {
         return weak_copy(g_gpu.batch_coopmat_i8)
+    } elif (g_gpu.coopmat_mode == 3) {
+        return weak_copy(g_gpu.batch_coopmat_mm)
     }
     return weak_copy(g_gpu.batch_pipeline)
 }
@@ -5278,7 +5503,8 @@ def private cmd_copy_batch_acts(raw : VkCommandBuffer; xq_bytes, xs_bytes : int6
 // window), then the per-workgroup region map. Weight offsets follow the stack's format units —
 // 32-weight blocks for q8, superblocks for kq. Returns the workgroup count.
 def private fill_batch_meta(si : int; offs : int64 const?; nregions : int64; n, d : int64; r0, r1 : int64) : uint {
-    let wtiles = (d + BATCH_TILE - 1l) / BATCH_TILE
+    let tile = g_gpu.stacks[si].fmt == 0 ? q8_batch_tile() : BATCH_TILE
+    let wtiles = (d + tile - 1l) / tile
     let unit = g_gpu.stacks[si].fmt != 0 ? 256l : 32l
     unsafe {
         var mp = reinterpret<uint?>(g_gpu.stacks[si].batch_meta.mapped)
@@ -5290,7 +5516,7 @@ def private fill_batch_meta(si : int; offs : int64 const?; nregions : int64; n, 
                 nrc++
             }
         }
-        let wg_bound = ((r1 - r0 + BATCH_TILE - 1l) / BATCH_TILE + nrc) * wtiles
+        let wg_bound = ((r1 - r0 + tile - 1l) / tile + nrc) * wtiles
         assert((4l + nrc * 4l + wg_bound) * 4l <= BATCH_META_BYTES, "dasLLAMA vulkan tier: batch meta exceeds capacity")
         let map_off = 4l + nrc * 4l
         mp[0] = uint(n)
@@ -5312,7 +5538,7 @@ def private fill_batch_meta(si : int; offs : int64 const?; nregions : int64; n, 
             mp[mb + 1l] = uint(rb0 - r0)
             mp[mb + 2l] = uint(rb1 - rb0)
             mp[mb + 3l] = uint(wg)
-            let rwg = ((rb1 - rb0 + BATCH_TILE - 1l) / BATCH_TILE) * wtiles
+            let rwg = ((rb1 - rb0 + tile - 1l) / tile) * wtiles
             for (g in range64(rwg)) {
                 mp[map_off + wg + g] = uint(ri)
             }

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -1465,6 +1465,52 @@ def ar_add_rms_b {
     }
 }
 
+// per-head RMSNorm on q/k between the projections and rope (qk_norm models), one wg per head-row,
+// in place: q rows in vk_upf, k rows in vk_y; weight rows in vk_xqf; eps = vk_xs[0]. meta 0=hs
+// 1=nh 2=nkvh 3=qstride 4=kstride 5=kbase 6=qwoff 7=kwoff; dispatch rows*(nh+nkvh) wgs.
+[compute_shader(local_size_x=256, name="qk_rms_spv")]
+def qk_rms {
+    let hs = vk_meta[0u]
+    let nh = vk_meta[1u]
+    let per = nh + vk_meta[2u]
+    let wid = gl_WorkGroupID.x
+    let r = wid / per
+    let hh = wid % per
+    let is_q = hh < nh
+    let base = is_q ? r * vk_meta[3u] + hh * hs : vk_meta[5u] + r * vk_meta[4u] + (hh - nh) * hs
+    let wbase = is_q ? vk_meta[6u] : vk_meta[7u]
+    let tid = gl_LocalInvocationID.x
+    var ss = 0.0
+    if (tid < hs) {
+        let v = is_q ? vk_upf[base + tid] : vk_y[base + tid]
+        ss = v * v
+    }
+    ss = subgroupAdd(ss)
+    if (gl_SubgroupInvocationID == 0u) {
+        ar_part[gl_SubgroupID] = ss
+    }
+    barrier()
+    if (tid == 0u) {
+        var tot = 0.0
+        var sgi = 0u
+        while (sgi < gl_NumSubgroups) {
+            tot += ar_part[sgi]
+            sgi++
+        }
+        ar_inv[0u] = 1.0 / sqrt(tot / float(hs) + vk_xs[0u])
+    }
+    barrier()
+    if (tid < hs) {
+        let inv = ar_inv[0u]
+        let w = vk_xqf[wbase + tid]
+        if (is_q) {
+            vk_upf[base + tid] = w * (vk_upf[base + tid] * inv)
+        } else {
+            vk_y[base + tid] = w * (vk_y[base + tid] * inv)
+        }
+    }
+}
+
 // fused rope + KV-row store (decode, one token), f32 mirror. One thread per rotation pair; each
 // owns 2 distinct K + 2 V slots (no packing, no hazard). q roped in vk_y, k roped into vk_wsf, v raw
 // into vk_xqf at absolute pos. meta 0=qd 1=kvd 2=hs 3=half 4=neox 5=kpair0 6=npairs 7=krow_f 8=vrow_f.
@@ -2801,6 +2847,7 @@ struct private GpuState {
     ar_pipeline_b : Pipeline        // prefill: batched add+rmsnorm
     rks_b_pipeline : Pipeline       // prefill: batched rope + KV-store
     da_b_pipeline : Pipeline        // prefill: batched causal attention
+    qkn_pipeline : Pipeline         // resident driver: per-head q/k rmsnorm (qk_norm models), decode + prefill
     staging : HostBuf
     fence : VkFence          // the one reusable submit fence (reset after every wait)
     rows_per_wg : int64      // subgroups per workgroup = output rows per workgroup
@@ -3217,6 +3264,8 @@ def private vk_moe_init : bool {
     g_gpu.rks_b_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, rksbshader)
     var dabshader <- create_shader_module(g_gpu.device, da_attn_b_spv)
     g_gpu.da_b_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, dabshader)
+    var qknshader <- create_shader_module(g_gpu.device, qk_rms_spv)
+    g_gpu.qkn_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, qknshader)
 
     var fence <- create_fence(g_gpu.device, FenceCreateInfo())   // never finalized (process-lifetime)
     g_gpu.fence = boost_value_to_vk(fence)
@@ -3907,6 +3956,7 @@ struct private RLayer {
     // the layer's descriptor sets (built once, referenced every token)
     s_quant_xb : VkDescriptorSet    // dn_requant of the attn-norm activation
     s_q, s_k, s_v : VkDescriptorSet  // q/k/v GEMV
+    s_qkn : VkDescriptorSet         // per-head q/k rmsnorm (qk_norm models only)
     s_rope : VkDescriptorSet
     s_attn : VkDescriptorSet
     s_quant_at : VkDescriptorSet
@@ -3918,7 +3968,7 @@ struct private RLayer {
     s_down : VkDescriptorSet
     s_addr_next : VkDescriptorSet
     // per-dispatch metas (host-visible; contents rewritten per token)
-    m_quant_xb, m_q, m_k, m_v, m_rope, m_attn, m_quant_at, m_wo, m_addr_ffn : HostBuf
+    m_quant_xb, m_q, m_k, m_v, m_qkn, m_rope, m_attn, m_quant_at, m_wo, m_addr_ffn : HostBuf
     m_quant_xb2, m_gate, m_up, m_actrq, m_down, m_addr_next : HostBuf
     next_norm_off : int64   // rms_ffn is w_off for addr_ffn; addr_next uses rms_att[l+1] or final
     made : bool
@@ -3928,6 +3978,8 @@ struct private RDec {
     ready : bool
     n_layers, dim, qd, kv_dim, head_size, n_heads, kv_mul, hidden, vocab, seq_cap : int64
     neox : bool
+    qk_norm : bool                // per-head q/k rmsnorm role armed (norms buffer carries the rows)
+    norms_bytes : int64           // full norms buffer size (grows past the fixed layout under qk_norm)
     eps, scale : float
     // per-token device buffers
     x_dev, xb_dev : uint64        // residual, normed activation
@@ -4004,7 +4056,7 @@ def private arena_planes(fmt : int) : tuple<wq : uint64; ws : uint64; wqb : int6
 //! Resident-driver prepare: allocate all per-token + session buffers for a model's geometry. One
 //! resident model at a time (the arbiter guarantees it). Call before set_layer / token.
 def vk_rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab, seq_cap : int64;
-                    neox : bool; eps, scale : float) : bool {
+                    neox : bool; eps, scale : float; qk_norm : bool) : bool {
     if (!vk_moe_init()) {
         return false
     }
@@ -4016,7 +4068,8 @@ def vk_rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab
     }
     g_rd = new RDec(ready = false, n_layers = n_layers, dim = dim, qd = qd, kv_dim = kv_dim,
                  head_size = head_size, n_heads = n_heads, kv_mul = n_heads / (kv_dim / head_size),
-                 hidden = hidden, vocab = vocab, seq_cap = seq_cap, neox = neox, eps = eps, scale = scale)
+                 hidden = hidden, vocab = vocab, seq_cap = seq_cap, neox = neox, eps = eps, scale = scale,
+                 qk_norm = qk_norm)
     var r & = unsafe(*g_rd)
     let wide = max(max(qd, hidden), dim)
     r.x_dev = make_device_buf(dim * 4l)
@@ -4034,7 +4087,10 @@ def vk_rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab
     r.xb2_dev = make_device_buf(dim * 4l)
     r.k_mirror = make_device_buf(n_layers * seq_cap * kv_dim * 4l)
     r.v_mirror = make_device_buf(n_layers * seq_cap * kv_dim * 4l)
-    r.norms_dev = make_device_buf((n_layers * 2l * dim + dim) * 4l)
+    // norms layout: [rms_att[l], rms_ffn[l]] x L + rms_final (dim each), then under qk_norm the
+    // per-head rows [rms_q[l], rms_k[l]] x L (head_size each) appended past the fixed layout
+    r.norms_bytes = (n_layers * 2l * dim + dim + (qk_norm ? n_layers * 2l * head_size : 0l)) * 4l
+    r.norms_dev = make_device_buf(r.norms_bytes)
     r.cos_dev = make_device_buf(head_size * 4l)
     r.scal_dev = make_device_buf(64l)
     r.ar_scal_dev = make_device_buf(64l)
@@ -4051,7 +4107,8 @@ def vk_rdec_prepare(n_layers, dim, qd, kv_dim, head_size, n_heads, hidden, vocab
 }
 
 //! Upload the norm-weight rows once: [rms_att[0], rms_ffn[0], ..., rms_att[L-1], rms_ffn[L-1],
-//! rms_final], dim floats each, exactly the layout the layer w_offs index.
+//! rms_final], dim floats each, exactly the layout the layer w_offs index. Under qk_norm the
+//! per-head [rms_q[l], rms_k[l]] x L rows (head_size floats each) follow.
 def vk_rdec_upload_norms(norms : array<float>) {
     assert(g_rd != null, "vk_rdec_upload_norms before prepare")
     upload_region_at(g_rd.norms_dev, 0l, unsafe(addr<uint8 const?>(norms[0])), int64(length(norms)) * 4l)
@@ -4095,6 +4152,12 @@ def vk_rdec_set_layer(l : int64; bq, bk, bv, bo, b1, b3, b2 : int64; fq, fk, fv,
             pk.wqb, pk.wsb, META_BYTES, dim, (dim / 32l) * 4l, (qd + 2l * kvd) * 4l)
         L.s_v = rd_set6(pv.wq, pv.ws, L.m_v.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.kv_dev,
             pv.wqb, pv.wsb, META_BYTES, dim, (dim / 32l) * 4l, (qd + 2l * kvd) * 4l)
+        // qk rmsnorm (qk_norm models): q@0 (q_dev), meta@2, norm rows@3, eps@4, k@5 (kv_dev, k at qd)
+        if (g_rd.qk_norm) {
+            L.m_qkn = rd_meta()
+            L.s_qkn = rd_set6(g_rd.q_dev, g_rd.dummy, L.m_qkn.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.kv_dev,
+                qd * 4l, 256l, META_BYTES, g_rd.norms_bytes, 64l, (qd + 2l * kvd) * 4l)
+        }
         // rope+store: kv@0, Kmirror@1, meta@2, Vmirror@3, cossin@4, q@5
         let mirbytes = g_rd.n_layers * g_rd.seq_cap * kvd * 4l
         L.s_rope = rd_set6(g_rd.kv_dev, g_rd.k_mirror, L.m_rope.buf, g_rd.v_mirror, g_rd.cos_dev, g_rd.q_dev,
@@ -4110,7 +4173,7 @@ def vk_rdec_set_layer(l : int64; bq, bk, bv, bo, b1, b3, b2 : int64; fq, fk, fv,
             po.wqb, po.wsb, META_BYTES, qd, (qd / 32l) * 4l, dim * 4l)
         // addrms: x@0 += xb2@1, meta@2, norms@3, scalars@4, xb@5
         L.s_addr_ffn = rd_set6(g_rd.x_dev, g_rd.xb2_dev, L.m_addr_ffn.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.xb_dev,
-            dim * 4l, dim * 4l, META_BYTES, (g_rd.n_layers * 2l * dim + dim) * 4l, 64l, dim * 4l)
+            dim * 4l, dim * 4l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l)
         // quantize xb (post-ffn-norm) -> xq/xs
         L.s_quant_xb2 = rd_set6(g_rd.xb_dev, g_rd.dummy, L.m_quant_xb2.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.dummy,
             dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l)
@@ -4127,7 +4190,7 @@ def vk_rdec_set_layer(l : int64; bq, bk, bv, bo, b1, b3, b2 : int64; fq, fk, fv,
             p2.wqb, p2.wsb, META_BYTES, hid, (hid / 32l) * 4l, dim * 4l)
         // addrms next: x@0 += ffnout@1, norms@3, xb@5
         L.s_addr_next = rd_set6(g_rd.x_dev, g_rd.ffnout_dev, L.m_addr_next.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.xb_dev,
-            dim * 4l, dim * 4l, META_BYTES, (g_rd.n_layers * 2l * dim + dim) * 4l, 64l, dim * 4l)
+            dim * 4l, dim * 4l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l)
         L.made = true
     }
     g_rd.tok_recorded = false   // the recorded chain references the replaced sets
@@ -4146,7 +4209,7 @@ def vk_rdec_set_cls(cls_block : int64; cls_fmt : int) {
         g_rd.cls_meta_dev = make_device_buf(CLS_META_BYTES)
         // prologue: xb = rms_att[0](x), add off
         g_rd.s_prologue = rd_set6(g_rd.x_dev, g_rd.dummy, g_rd.m_prologue.buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.xb_dev,
-            dim * 4l, 256l, META_BYTES, (g_rd.n_layers * 2l * dim + dim) * 4l, 64l, dim * 4l)
+            dim * 4l, 256l, META_BYTES, g_rd.norms_bytes, 64l, dim * 4l)
         // quantize final xb
         g_rd.s_quant_final = rd_set6(g_rd.xb_dev, g_rd.dummy, g_rd.m_quant_final.buf, g_rd.xq_dev, g_rd.xs_dev, g_rd.dummy,
             dim * 4l, 256l, META_BYTES, dim, (dim / 32l) * 4l, 256l)
@@ -4315,6 +4378,14 @@ def private rd_record_token {
             fill_gemv_meta(L.m_q, dim, qd, 0l, L.bq)
             fill_gemv_meta(L.m_k, dim, kvd, qd, L.bk)             // k at ybase qd in kv_dev
             fill_gemv_meta(L.m_v, dim, kvd, qd + kvd, L.bv)       // v at ybase qd+kvd
+            if (g_rd.qk_norm) {
+                let hs = g_rd.head_size
+                var mn = reinterpret<uint?>(L.m_qkn.mapped)
+                mn[0] = uint(hs); mn[1] = uint(g_rd.n_heads); mn[2] = uint(kvd / hs)
+                mn[3] = uint(qd); mn[4] = 0u; mn[5] = uint(qd)   // one row: k lives at qd in kv_dev
+                mn[6] = uint(nlfin + dim + l * 2l * hs)          // rms_q[l] past the fixed norms layout
+                mn[7] = uint(nlfin + dim + (l * 2l + 1l) * hs)   // rms_k[l]
+            }
             var mr = reinterpret<uint?>(L.m_rope.mapped)
             mr[0] = uint(qd); mr[1] = uint(kvd); mr[2] = uint(g_rd.head_size); mr[3] = uint(g_rd.head_size / 2l)
             mr[4] = g_rd.neox ? 1u : 0u; mr[5] = uint(qd / 2l); mr[6] = uint(qd / 2l + kvd / 2l)
@@ -4349,6 +4420,9 @@ def private rd_record_token {
             rd_dispatch_gemv(raw, L.fq, L.s_q, rd_gemv_wg(qd), [bar = false])
             rd_dispatch_gemv(raw, L.fk, L.s_k, rd_gemv_wg(kvd), [bar = false])
             rd_dispatch_gemv(raw, L.fv, L.s_v, rd_gemv_wg(kvd))
+            if (g_rd.qk_norm) {
+                rd_dispatch(raw, g_gpu.qkn_pipeline, L.s_qkn, uint(g_rd.n_heads + kvd / g_rd.head_size))
+            }
             rd_dispatch(raw, g_gpu.rks_pipeline, L.s_rope, uint((qd / 2l + kvd / 2l + int64(WG_X) - 1l) / int64(WG_X)))
             rd_dispatch(raw, g_gpu.da_pipeline, L.s_attn, uint(g_rd.n_heads))
             rd_dispatch(raw, g_gpu.dn_rq_pipeline, L.s_quant_at, uint((qd / 32l + 255l) / 256l))
@@ -4398,9 +4472,9 @@ def vk_rdec_token(x : array<float>; cossin : array<float>; pos, cnt : int64; var
 
 // ===== the resident prefill driver (batched, npos rows, one submit) =====
 // Batch-kernel twin of vk_rdec_token; only the LAST row's logits are produced (reuses the decode
-// tail). 15 prefill sets/layer + the buffers are built once; metas fill per call (npos varies).
+// tail). PF_ROLES prefill sets/layer + the buffers are built once; metas fill per call (npos varies).
 
-let private PF_ROLES = 15l   // quant_xb q k v rope attn quant_at wo addr_ffn quant_xb2 gate up actrq down addr_next
+let private PF_ROLES = 16l   // quant_xb q k v rope attn quant_at wo addr_ffn quant_xb2 gate up actrq down addr_next qkn
 
 def private pf_bind(idx : int; b0, b1, b2, b3, b4, b5 : uint64; s0, s1, s2, s3, s4, s5 : int64) {
     g_rd.pf_sets[idx] = rd_set6(b0, b1, b2, b3, b4, b5, s0, s1, s2, s3, s4, s5)
@@ -4442,7 +4516,7 @@ def private pf_setup {
         g_rd.pf_meta[mi] = make_host_buf(BATCH_META_BYTES, true)
     }
     let mirbytes = g_rd.n_layers * g_rd.seq_cap * kvd * 4l
-    let normbytes = (g_rd.n_layers * 2l * dim + dim) * 4l
+    let normbytes = g_rd.norms_bytes
     for (l in range64(g_rd.n_layers)) {
         var L & = unsafe(g_rd.layers[l])
         let b = int(l * PF_ROLES)
@@ -4490,6 +4564,11 @@ def private pf_setup {
         // 14 addr_next: x += ffnout, xb = rms_att[l+1]|final
         pf_bind(b + 14, g_rd.pf_x, g_rd.pf_ffnout, g_rd.pf_meta[b + 14].buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.pf_xb,
             np * dim * 4l, np * dim * 4l, BATCH_META_BYTES, normbytes, 64l, np * dim * 4l)
+        // 15 qk rmsnorm (qk_norm models): q@0 (pf_q), norm rows@3, eps@4, k@5 (pf_kv, k at 0)
+        if (g_rd.qk_norm) {
+            pf_bind(b + 15, g_rd.pf_q, g_rd.dummy, g_rd.pf_meta[b + 15].buf, g_rd.norms_dev, g_rd.ar_scal_dev, g_rd.pf_kv,
+                np * qd * 4l, 256l, BATCH_META_BYTES, normbytes, 64l, np * 2l * kvd * 4l)
+        }
     }
     let bp = int(g_rd.n_layers * PF_ROLES)
     // prologue: xb = rms_att[0](x), add off
@@ -4604,6 +4683,14 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
                 invoke(mA, b + 1, dim, qd, L.bq, L.fq)
                 invoke(mA, b + 2, dim, kvd, L.bk, L.fk)
                 invoke(mA, b + 3, dim, kvd, L.bv, L.fv)
+                if (g_rd.qk_norm) {
+                    let hs = g_rd.head_size
+                    var mn = reinterpret<uint?>(g_rd.pf_meta[b + 15].mapped)
+                    mn[0] = uint(hs); mn[1] = uint(g_rd.n_heads); mn[2] = uint(kvd / hs)
+                    mn[3] = uint(qd); mn[4] = uint(kvd); mn[5] = 0u   // k rows at 0 in pf_kv, kvd stride
+                    mn[6] = uint(nlfin + dim + l * 2l * hs)
+                    mn[7] = uint(nlfin + dim + (l * 2l + 1l) * hs)
+                }
                 var mr = reinterpret<uint?>(g_rd.pf_meta[b + 4].mapped)
                 mr[0] = uint(qd); mr[1] = uint(kvd); mr[2] = uint(g_rd.head_size); mr[3] = uint(g_rd.head_size / 2l)
                 mr[4] = g_rd.neox ? 1u : 0u; mr[5] = uint(qd / 2l); mr[6] = uint(pairs)
@@ -4651,6 +4738,10 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
                 rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0))
                 cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
                 comp_barrier(raw)
+                if (g_rd.qk_norm) {
+                    rd_dispatch(raw, g_gpu.qkn_pipeline, g_rd.pf_sets[b + 15],
+                        uint(wlen * (g_rd.n_heads + kvd / g_rd.head_size)))
+                }
                 rd_dispatch(raw, g_gpu.rks_b_pipeline, g_rd.pf_sets[b + 4], ropewg)
                 rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l))
@@ -4678,23 +4769,29 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             w0 += wlen
         }
         memcpy(addr<void?>(logits[0]), g_rd.pf_logits_host.mapped, int(g_rd.vocab * 4l))
-        // per-role GPU aggregation: q0 start, q1 meta, q2 prologue, then 15/layer, final rq, cls —
-        // only when every stamp landed (a >135-layer graph would overflow PFQ_CAP and truncate).
+        // per-role GPU aggregation: q0 start, q1 meta, q2 prologue, then rpl/layer, final rq, cls —
+        // only when every stamp landed (a very deep graph would overflow PFQ_CAP and truncate).
         // Multi-window prompts: the stamps cover the LAST window only (the one with fin_rq + cls).
-        if (vk_prof() && g_pfq_n == 5u + uint(g_rd.n_layers * 15l)) {
-            var role : double[15]
+        let rpl = g_rd.qk_norm ? 16l : 15l
+        if (vk_prof() && g_pfq_n == 5u + uint(g_rd.n_layers * rpl)) {
+            var role : double[16]
             for (l in range64(g_rd.n_layers)) {
-                for (s in range(15)) {
-                    role[s] += pfq_us(uint(3l + l * 15l) + uint(s))
+                for (s in range(int(rpl))) {
+                    role[s] += pfq_us(uint(3l + l * rpl) + uint(s))
                 }
             }
-            let nq = 3u + uint(g_rd.n_layers * 15l)
+            let nq = 3u + uint(g_rd.n_layers * rpl)
             var tot = 0.0lf
-            for (s in range(15)) {
+            for (s in range(int(rpl))) {
                 tot += role[s]
             }
             tot += pfq_us(2u) + pfq_us(nq) + pfq_us(nq + 1u)
-            to_log(LOG_INFO, "vk_rdpf gpu prologue {int(pfq_us(2u))} rq_x {int(role[0])} q {int(role[1])} k {int(role[2])} v {int(role[3])} rope_kv {int(role[4])} attn {int(role[5])} rq_a {int(role[6])} wo {int(role[7])} ar1 {int(role[8])} rq_f {int(role[9])} gate {int(role[10])} up {int(role[11])} act {int(role[12])} down {int(role[13])} ar2 {int(role[14])} fin_rq {int(pfq_us(nq))} cls {int(pfq_us(nq + 1u))} total {int(tot)}\n")
+            // the qkn dispatch stamps between v and rope_kv, shifting every later role by one
+            if (g_rd.qk_norm) {
+                to_log(LOG_INFO, "vk_rdpf gpu prologue {int(pfq_us(2u))} rq_x {int(role[0])} q {int(role[1])} k {int(role[2])} v {int(role[3])} qkn {int(role[4])} rope_kv {int(role[5])} attn {int(role[6])} rq_a {int(role[7])} wo {int(role[8])} ar1 {int(role[9])} rq_f {int(role[10])} gate {int(role[11])} up {int(role[12])} act {int(role[13])} down {int(role[14])} ar2 {int(role[15])} fin_rq {int(pfq_us(nq))} cls {int(pfq_us(nq + 1u))} total {int(tot)}\n")
+            } else {
+                to_log(LOG_INFO, "vk_rdpf gpu prologue {int(pfq_us(2u))} rq_x {int(role[0])} q {int(role[1])} k {int(role[2])} v {int(role[3])} rope_kv {int(role[4])} attn {int(role[5])} rq_a {int(role[6])} wo {int(role[7])} ar1 {int(role[8])} rq_f {int(role[9])} gate {int(role[10])} up {int(role[11])} act {int(role[12])} down {int(role[13])} ar2 {int(role[14])} fin_rq {int(pfq_us(nq))} cls {int(pfq_us(nq + 1u))} total {int(tot)}\n")
+            }
         }
     }
 }

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -4883,6 +4883,24 @@ let private VHZ_META = 0x8000u    // ffn_meta_dev
 let private VHZ_LOG = 0x10000u    // logits
 let private VHZ_COS = 0x20000u    // rope cos/sin rows
 
+// batch/hybrid-tier region bits — a separate namespace over the same rail (each recorder's VkHaz
+// is private to its cmd buffer, so the two families never meet in one pending set)
+let private VHB_ACT = 0x1u        // batch_xq/batch_xs activation staging
+let private VHB_META = 0x2u       // stack batch metas + the chain's params (ffn/dn/at meta)
+let private VHB_Y1 = 0x4u         // batch_y1 (gate / qkv / q|gate / down / wo out)
+let private VHB_Y2 = 0x8u         // batch_y2 (up / z / k out)
+let private VHB_HQ = 0x10u        // hq+hs requant image
+let private VHB_COMB = 0x20u      // combine weight/bucket planes
+let private VHB_CY = 0x40u        // combine accumulator
+let private VHB_SM = 0x80u        // smalls image (dn/at)
+let private VHB_ST = 0x100u       // dn recurrent state
+let private VHB_WS = 0x200u       // dn slabs/o scratch
+let private VHB_ATQ = 0x400u      // at deinterleaved q rows
+let private VHB_ATG = 0x800u      // at gate/o rows
+let private VHB_ATK = 0x1000u     // at roped-k panel
+let private VHB_ATV = 0x2000u     // at v panel (absolute positions)
+let private VHB_VRAW = 0x4000u    // at raw-v window
+
 struct private VkHaz {
     w : uint            // bits with a pending (unbarriered) write
     r : uint            // bits with a pending read
@@ -6020,41 +6038,50 @@ def private record_ffn_batch_cmd(s1, s3, s2 : int; nwg_gu, nwg_dn : uint; rows, 
     vk_check(vkResetCommandBuffer(raw, rf), null)
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    var h : VkHaz
+    // one declaration per same-region copy GROUP — per-copy would fake WAW on the shared bit
+    vhz_dep(raw, h, 0u, VHB_ACT, true)
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
+    vhz_dep(raw, h, 0u, VHB_META, true)
     cmd_copy_batch_meta(raw, s1)
     cmd_copy_batch_meta(raw, s3)
     cmd_copy_batch_meta(raw, s2)
     cmd_copy_whole(raw, g_gpu.ffn_meta.buf, g_gpu.ffn_meta_dev, FFN_META_BYTES)
     if (comb_npos > 0u && comb_first) {
+        vhz_dep(raw, h, 0u, VHB_COMB, true)
         cmd_copy_whole(raw, g_gpu.comb_stage.buf, g_gpu.comb_w_dev, comb_wi_bytes)
         cmd_copy_at(raw, g_gpu.comb_stage.buf, COMB_WI_BYTES, g_gpu.comb_inv_dev, comb_wi_bytes)
     }
-    batch_barrier(raw, true)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, g_gpu.stacks[s1].fmt, g_gpu.stacks[s1].batch_tile, g_gpu.stacks[s1].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s1].batch_set, nwg_gu)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y2)
     if (!same_batch_pipe(s3, s1)) {
         bind_batch_pipe(raw, g_gpu.stacks[s3].fmt, g_gpu.stacks[s3].batch_tile, g_gpu.stacks[s3].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s3].batch_set, nwg_gu)
-    comp_barrier(raw)
     // the requant form follows the DOWN stack — its GEMM is the consumer of hq/hs
     let dkq = g_gpu.stacks[s2].fmt != 0
+    vhz_dep(raw, h, VHB_Y1 | VHB_Y2 | VHB_META, VHB_HQ)
     cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.batch_actrq_set, uint((rows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
-    comp_barrier(raw)
+    vhz_dep(raw, h, VHB_HQ | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, g_gpu.stacks[s2].fmt, g_gpu.stacks[s2].batch_tile, g_gpu.stacks[s2].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s2].batch_set, nwg_dn)
     if (comb_npos > 0u) {
-        comp_barrier(raw)
+        vhz_dep(raw, h, VHB_Y1 | VHB_COMB | VHB_CY | VHB_META, VHB_CY)
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.comb_pipeline, VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.comb_set, comb_npos)
         if (comb_last) {
-            batch_barrier(raw, false)
+            vhz_dep(raw, h, VHB_CY, 0u, true)
             cmd_copy_whole(raw, g_gpu.comb_y_dev, g_gpu.comb_y.buf, comb_y_bytes)
         }
     } else {
-        batch_barrier(raw, false)
+        vhz_dep(raw, h, VHB_Y1, 0u, true)
         cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, gout_bytes)
+    }
+    if (vk_prof()) {
+        to_log(LOG_INFO, "vk_ffnb hz: {h.disp} nodes, {h.barriers} barriers\n")
     }
     vk_check(vkEndCommandBuffer(raw), null)
 }
@@ -6134,12 +6161,15 @@ def private record_dense_cmd(si : int; nwg : uint; y_bytes : int64; axq_bytes, a
     vk_check(vkResetCommandBuffer(raw, rf), null)
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    var h : VkHaz
+    vhz_dep(raw, h, 0u, VHB_ACT, true)
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
+    vhz_dep(raw, h, 0u, VHB_META, true)
     cmd_copy_batch_meta(raw, si)
-    batch_barrier(raw, true)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, g_gpu.stacks[si].fmt, g_gpu.stacks[si].batch_tile, g_gpu.stacks[si].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[si].batch_set, nwg)
-    batch_barrier(raw, false)
+    vhz_dep(raw, h, VHB_Y1, 0u, true)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, y_bytes)
     vk_check(vkEndCommandBuffer(raw), null)
 }
@@ -6271,61 +6301,71 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
     vk_check(vkResetCommandBuffer(raw, rf), null)
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    var h : VkHaz
     pfq_begin(raw)
     pfq_ts(raw)   // q0: submit start
+    vhz_dep(raw, h, 0u, VHB_ACT, true)
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
+    vhz_dep(raw, h, 0u, VHB_META, true)
     cmd_copy_batch_meta(raw, s_qkv)
     cmd_copy_batch_meta(raw, s_z)
     cmd_copy_batch_meta(raw, s_o)
     cmd_copy_whole(raw, g_gpu.dn_meta.buf, g_gpu.dn_meta_dev, DN_META_BYTES)
     // stops SHORT of the hist region — later windows read the device-copied tail rows there
+    vhz_dep(raw, h, 0u, VHB_SM, true)
     cmd_copy_range(raw, g_gpu.dn_smalls.buf, 0l, g_gpu.dn_smalls_dev, 0l, DN_SM_HIST * 4l)
     if (first) {
         cmd_copy_range(raw, g_gpu.dn_smalls.buf, DN_SM_HIST * 4l, g_gpu.dn_smalls_dev, DN_SM_HIST * 4l, cd * taps * 4l)
+        vhz_dep(raw, h, 0u, VHB_ST, true)
         cmd_copy_whole(raw, g_gpu.dn_state_stage.buf, g_gpu.dn_state_dev, nvh * ds * ds * 4l)
     }
-    batch_barrier(raw, true)
     pfq_ts(raw)   // q1: uploads
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, 0, g_gpu.stacks[s_qkv].batch_tile, g_gpu.stacks[s_qkv].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_qkv].batch_set, nwg_qkv)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y2)
     if (!same_batch_pipe(s_z, s_qkv)) {
         bind_batch_pipe(raw, 0, g_gpu.stacks[s_z].batch_tile, g_gpu.stacks[s_z].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_z].batch_set, nwg_z)
-    comp_barrier(raw)
     pfq_ts(raw)   // q2: qkv+z GEMMs
+    vhz_dep(raw, h, VHB_Y1 | VHB_SM | VHB_META, VHB_HQ)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_conv_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.dn_conv_set, uint(rows))
-    comp_barrier(raw)
     pfq_ts(raw)   // q3: conv
+    vhz_dep(raw, h, VHB_HQ | VHB_Y2 | VHB_SM | VHB_ST | VHB_META, VHB_ST | VHB_WS)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_scan_p1_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.dn_scan_set, uint(nvh * ((rows + DN_CS - 1l) / DN_CS)))
-    comp_barrier(raw)
     pfq_ts(raw)   // q4: scan phase 1
+    vhz_dep(raw, h, VHB_HQ | VHB_Y2 | VHB_SM | VHB_ST | VHB_WS | VHB_META, VHB_ST | VHB_WS)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_scan_p2_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.dn_scan_set, uint(nvh))
-    comp_barrier(raw)
     pfq_ts(raw)   // q5: scan phase 2
     // conv-tail extraction: last `taps` RAW qkv rows out of y1 before out-proj reuses it
-    batch_barrier(raw, false)
     if (!last) {
+        vhz_dep(raw, h, VHB_Y1, VHB_SM, true)
         cmd_copy_range(raw, g_gpu.batch_y1_dev, (rows - taps) * cd * 4l, g_gpu.dn_smalls_dev, DN_SM_HIST * 4l, taps * cd * 4l)
     } else {
+        vhz_dep(raw, h, VHB_Y1, 0u, true)
         cmd_copy_range(raw, g_gpu.batch_y1_dev, (rows - taps) * cd * 4l, g_gpu.dn_tail_host.buf, 0l, taps * cd * 4l)
+        vhz_dep(raw, h, VHB_ST, 0u, true)
         cmd_copy_whole(raw, g_gpu.dn_state_dev, g_gpu.dn_state_host.buf, nvh * ds * ds * 4l)
     }
-    batch_barrier(raw, true)
     pfq_ts(raw)   // q6: tail copies
+    vhz_dep(raw, h, VHB_WS | VHB_META, VHB_HQ)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.dn_rq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.dn_rq_set, uint((rows * di / 32l + 255l) / 256l))
-    comp_barrier(raw)
     pfq_ts(raw)   // q7: o requant
+    vhz_dep(raw, h, VHB_HQ | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, 0, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_out)
-    batch_barrier(raw, false)
     pfq_ts(raw)   // q8: out GEMM
+    vhz_dep(raw, h, VHB_Y1, 0u, true)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, rows * dim * 4l)
     pfq_end(raw)
+    if (vk_prof()) {
+        to_log(LOG_INFO, "vk_dn hz: {h.disp} nodes, {h.barriers} barriers\n")
+    }
     vk_check(vkEndCommandBuffer(raw), null)
 }
 
@@ -6728,45 +6768,57 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     vk_check(vkResetCommandBuffer(raw, rf), null)
     let begin = VkCommandBufferBeginInfo()
     vk_check(vkBeginCommandBuffer(raw, begin), null)
+    var h : VkHaz
+    vhz_dep(raw, h, 0u, VHB_ACT, true)
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
+    vhz_dep(raw, h, 0u, VHB_META, true)
     cmd_copy_batch_meta(raw, s_q)
     cmd_copy_batch_meta(raw, s_k)
     cmd_copy_batch_meta(raw, s_v)
     cmd_copy_batch_meta(raw, s_o)
     cmd_copy_whole(raw, g_gpu.at_meta.buf, g_gpu.at_meta_dev, AT_META_BYTES)
+    vhz_dep(raw, h, 0u, VHB_SM, true)
     cmd_copy_range(raw, g_gpu.at_smalls.buf, 0l, g_gpu.at_smalls_dev, 0l, sm_bytes)
-    batch_barrier(raw, true)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, g_gpu.stacks[s_q].fmt, g_gpu.stacks[s_q].batch_tile, g_gpu.stacks[s_q].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_q].batch_set, nwg_q)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_Y2)
     if (!same_batch_pipe(s_k, s_q)) {
         bind_batch_pipe(raw, g_gpu.stacks[s_k].fmt, g_gpu.stacks[s_k].batch_tile, g_gpu.stacks[s_k].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_k].batch_set, nwg_k)
+    vhz_dep(raw, h, VHB_ACT | VHB_META, VHB_VRAW)
     if (!same_batch_pipe(s_v, s_k)) {
         bind_batch_pipe(raw, g_gpu.stacks[s_v].fmt, g_gpu.stacks[s_v].batch_tile, g_gpu.stacks[s_v].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_v].batch_set, nwg_v)
-    comp_barrier(raw)
+    vhz_dep(raw, h, VHB_Y1 | VHB_SM | VHB_META, VHB_ATQ | VHB_ATG)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.at_prep_q_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.at_prep_q_set, uint(rows))
+    vhz_dep(raw, h, VHB_Y2 | VHB_SM | VHB_META, VHB_ATK)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.at_prep_k_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.at_prep_k_set, uint(rows))
     // transfer window: append raw v at absolute positions, DMA roped k/raw v to host
-    batch_barrier(raw, false)
+    vhz_dep(raw, h, VHB_VRAW, VHB_ATV, true)
     cmd_copy_range(raw, g_gpu.at_vraw_dev, 0l, g_gpu.at_v_dev, w0 * kv_dim * 4l, rows * kv_dim * 4l)
+    vhz_dep(raw, h, VHB_ATK, 0u, true)
     cmd_copy_range(raw, g_gpu.at_k_dev, w0 * kv_dim * 4l, g_gpu.at_kv_host.buf, 0l, rows * kv_dim * 4l)
+    vhz_dep(raw, h, VHB_VRAW, 0u, true)
     cmd_copy_range(raw, g_gpu.at_vraw_dev, 0l, g_gpu.at_kv_host.buf, AT_WINDOW * AT_MAX_KV * 4l, rows * kv_dim * 4l)
-    batch_barrier(raw, true)
+    vhz_dep(raw, h, VHB_ATQ | VHB_ATK | VHB_ATV | VHB_ATG | VHB_SM | VHB_META, VHB_ATG)
     cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.at_attn_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.at_attn_set, uint(n_heads * ((rows + 7l) / 8l)))
-    comp_barrier(raw)
+    vhz_dep(raw, h, VHB_ATG | VHB_META, VHB_HQ)
     cmd_bind_pipeline(vk_value_to_boost(raw), o_kq ? g_gpu.q8k_rq_pipeline : g_gpu.dn_rq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.at_rq_set, uint((rows * qd / (o_kq ? 256l : 32l) + 255l) / 256l))
-    comp_barrier(raw)
+    vhz_dep(raw, h, VHB_HQ | VHB_META, VHB_Y1)
     bind_batch_pipe(raw, g_gpu.stacks[s_o].fmt, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_o)
-    batch_barrier(raw, false)
+    vhz_dep(raw, h, VHB_Y1, 0u, true)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, rows * dim * 4l)
+    if (vk_prof()) {
+        to_log(LOG_INFO, "vk_attn hz: {h.disp} nodes, {h.barriers} barriers\n")
+    }
     vk_check(vkEndCommandBuffer(raw), null)
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -595,6 +595,126 @@ def q8_moe_batch_mm {
     }
 }
 
+// The mul_mm M-tile twin (64x64, lcpp's cm1 m-warptile): the L scheme at half edge — 4 warps 2x2
+// over the tile, 2x2 fragments each, 12.3KB shared. Routed in by q8_batch_tile_for when cnt or d
+// <= 64: the L tile pads every such dispatch to 128 B-columns (MoE regions run ~32 rows).
+
+var @workgroup cmm_a : uint[1280]     // A tile: 64 weight rows x one block (32 K) as f16 pairs
+var @workgroup cmm_b : uint[1280]     // B tile: 64 token rows x one block
+
+[compute_shader(local_size_x=128, name="q8_moe_batch_mm_m_spv")]
+def q8_moe_batch_mm_m {
+    let n = vk_meta[0u]
+    let d = vk_meta[1u]
+    let rid = vk_meta[vk_meta[3u] + gl_WorkGroupID.x]
+    let rb = 4u + rid * 4u
+    let wblk0 = vk_meta[rb]
+    let row0 = vk_meta[rb + 1u]
+    let cnt = vk_meta[rb + 2u]
+    let tix = gl_WorkGroupID.x - vk_meta[rb + 3u]
+    let wtiles = (d + 63u) / 64u
+    let xt = tix / wtiles             // token (B) tile
+    let wt = tix % wtiles             // weight (A) tile
+    let gm0 = wt * 64u
+    let gn0 = xt * 64u
+    let nbb = n / 32u
+    let tid = gl_LocalInvocationID.x
+    let warp_r = gl_SubgroupID % 2u   // which 32-row half of the A tile
+    let warp_c = gl_SubgroupID / 2u   // which 32-col half of the B tile
+    let lw = tid % 8u                 // which packed word (4 qs) of the staged row's block
+    let lr0 = tid / 8u                // staging row base 0..15
+    var acc00 : coopmatAcc_f16_16x16
+    var acc01 : coopmatAcc_f16_16x16
+    var acc10 : coopmatAcc_f16_16x16
+    var acc11 : coopmatAcc_f16_16x16
+    var kb = 0u
+    while (kb < nbb) {
+        for [unroll] (p in range(4)) {   // stage A: 64 weight rows x 1 block; OOR rows -> 0
+            let row = lr0 + uint(p) * 16u
+            let wrow = gm0 + row
+            var v = float4(0.0)
+            if (wrow < d) {
+                let ib = wblk0 + wrow * nbb + kb
+                v = float4(int4(unpack8(int(vk_wq[ib * 8u + lw])))) * float(vk_ws[ib])
+            }
+            let o = row * CML_SST + lw * 2u
+            cmm_a[o] = packHalf2x16(v.xy)
+            cmm_a[o + 1u] = packHalf2x16(v.zw)
+        }
+        for [unroll] (p in range(4)) {   // stage B: 64 token rows x 1 block; OOR rows -> 0
+            let row = lr0 + uint(p) * 16u
+            var v = float4(0.0)
+            if (gn0 + row < cnt) {
+                let ib = (row0 + gn0 + row) * nbb + kb
+                v = float4(int4(unpack8(int(vk_xq[ib * 8u + lw])))) * vk_xs[ib]
+            }
+            let o = row * CML_SST + lw * 2u
+            cmm_b[o] = packHalf2x16(v.xy)
+            cmm_b[o + 1u] = packHalf2x16(v.zw)
+        }
+        barrier()
+        for [unroll] (ks in range(2)) {   // 2 K-subtiles x (2 A rows x 2 B cols), the L MMA order
+            let k8 = uint(ks) * 8u
+            var ca : coopmatA_f16_16x16
+            var cb : coopmatB_f16_16x16
+            coopmatLoad(ca, cmm_a, int((warp_r * 32u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cmm_b, int((warp_c * 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc00 = coopmatMulAdd(ca, cb, acc00)
+            coopmatLoad(cb, cmm_b, int((warp_c * 32u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc01 = coopmatMulAdd(ca, cb, acc01)
+            coopmatLoad(ca, cmm_a, int((warp_r * 32u + 16u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cmm_b, int((warp_c * 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc10 = coopmatMulAdd(ca, cb, acc10)
+            coopmatLoad(cb, cmm_b, int((warp_c * 32u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc11 = coopmatMulAdd(ca, cb, acc11)
+        }
+        barrier()
+        kb++
+    }
+    // stores: y[(row0 + token) * d + wrow] — same column-major layout as the L tile
+    let dr = gm0 + warp_r * 32u
+    let dc = gn0 + warp_c * 32u
+    if (gm0 + 64u <= d && gn0 + 64u <= cnt) {
+        var accw : coopmatAcc_f32_16x16
+        let yb = (row0 + dc) * d + dr
+        coopmatConvert(accw, acc00)
+        coopmatStore(accw, vk_y, int(yb), int(d), 1)
+        coopmatConvert(accw, acc01)
+        coopmatStore(accw, vk_y, int(yb + 16u * d), int(d), 1)
+        coopmatConvert(accw, acc10)
+        coopmatStore(accw, vk_y, int(yb + 16u), int(d), 1)
+        coopmatConvert(accw, acc11)
+        coopmatStore(accw, vk_y, int(yb + 16u * d + 16u), int(d), 1)
+    } else {
+        // edge tile: bounce each f16 acc through this warp's cml_o slab, bounds-checked write-out
+        let lane = gl_SubgroupInvocationID
+        let ob = gl_SubgroupID * 256u
+        for (fi in range(4)) {
+            let fr = uint(fi) / 2u       // fragment row: weight offset fr*16
+            let fc = uint(fi) % 2u       // fragment col: token offset fc*16
+            if (fi == 0) {
+                coopmatStore(acc00, cml_o, int(ob), 16, 0)
+            } elif (fi == 1) {
+                coopmatStore(acc01, cml_o, int(ob), 16, 0)
+            } elif (fi == 2) {
+                coopmatStore(acc10, cml_o, int(ob), 16, 0)
+            } else {
+                coopmatStore(acc11, cml_o, int(ob), 16, 0)
+            }
+            barrier()
+            for (e in range(8)) {
+                let idx = lane * 8u + uint(e)
+                let wr = dr + fr * 16u + idx / 16u
+                let tc = dc + fc * 16u + idx % 16u
+                if (wr < d && tc < cnt) {
+                    vk_y[(row0 + tc) * d + wr] = float(cml_o[ob + idx])
+                }
+            }
+            barrier()
+        }
+    }
+}
+
 // Q4_0 coopmat f16 variant (fmt=4 stacks): kq_moe_batch_q40 math baked into f16 dequant — w =
 // (nib-8)*d_b, a = aq*xs (per-256 Q8_K) — then the same 4-subgroup MMA as q8_moe_batch_cmf16.
 // No int8-native arm: nibbles would need dequant-to-s8 shared staging (byte stores, NV-slow).
@@ -2835,6 +2955,30 @@ let private BATCH_TILE = 32l               // kernel tile edge (rows and cols)
 // the Q8_0 batch kernel's tile edge — 128 for the mul_mm L-tile kernel (mode 3), 32 otherwise.
 // Meta builders MUST use the same edge the bound kernel derives (wtiles = ceil(d / edge)).
 def private q8_batch_tile : int64 => g_gpu.coopmat_mode == 3 ? 128l : BATCH_TILE
+
+let private MM_SMALL_CNT = 192l   // measured crossover (qwen3-4B pp: sdot4 +42% at 128, L +2.5% at 192)
+
+// mode-3 small-batch tier: 32 = sdot4 (default — beats BOTH coopmat tiles below the crossover:
+// pp64 887 sdot4 / 677 M / 426 L), 64 = the coopmat M tile (the experiment arm), 128 = always-L
+var private g_mm_small = -1l
+
+def private mm_small_tile : int64 {
+    if (g_mm_small < 0l) {
+        let e = get_env_variable("DASLLAMA_MM_SMALL")
+        g_mm_small = e == "64" ? 64l : (e == "128" ? 128l : BATCH_TILE)   // else fails closed to sdot4
+    }
+    return g_mm_small
+}
+
+// per-dispatch tile router (the lcpp l/m ladder, ours resolved by measurement): in mm mode a
+// small-cnt or small-d dispatch drops to the small tier — the L tile starves the grid and pads
+// its B panel there. Pure in (d, cnt, mode), so pipe pick and meta fill can never disagree.
+def private q8_batch_tile_for(d, cnt : int64) : int64 {
+    if (g_gpu.coopmat_mode != 3) {
+        return q8_batch_tile()
+    }
+    return d <= 64l || cnt < MM_SMALL_CNT ? mm_small_tile() : 128l
+}
 let private BATCH_CHUNK_ROWS = 8_192l      // dispatch row-window cap (bounds y and the wg map)
 let private BATCH_HQ_BYTES = 33_554_432l   // device requantized-hidden quants (the down GEMM's activations)
 let private BATCH_HS_BYTES = 8_388_608l    // ... its scale plane
@@ -2940,6 +3084,7 @@ struct private VkStack {
     batch_set : VkDescriptorSet   // batch bindings: stack planes + act-image scratch + a y plane
     batch_y : uint64         // which shared y plane batch_set binds (role-fixed per stack)
     batch_xq : uint64        // which activation-quant plane it binds (gate/up: gathered x; down: hq)
+    batch_tile : int64       // the tile edge the last fill_batch_meta routed — the bind must match
     batch_made : bool
     // classifier dispatch state (lazy — set up on the first cls GEMV against this stack)
     cls_set : VkDescriptorSet
@@ -3038,6 +3183,7 @@ struct private GpuState {
     batch_coopmat_i8 : Pipeline   // prefill Q8_0 GEMM on tensor cores, native s8 (DASLLAMA_COOPMAT=int8)
     batch_coopmat_q40 : Pipeline  // prefill Q4_0 GEMM on tensor cores, f16-dequant (COOPMAT=f16, fmt 4)
     batch_coopmat_mm : Pipeline   // prefill Q8_0 GEMM, the mul_mm 128x128 L-tile (DASLLAMA_COOPMAT=mm)
+    batch_coopmat_mm_m : Pipeline // ... its 64x64 M-tile twin, routed in for small-cnt dispatches
     actrq_pipeline : Pipeline   // fused act(g)*u + q8_0 requant of the hidden rows
     gemv_k4 : Pipeline          // native K-quant GEMVs (per-format decode kernels)
     gemv_k5 : Pipeline
@@ -3436,9 +3582,11 @@ def private vk_moe_init : bool {
     } elif (g_gpu.coopmat_mode == 2) {   // native-s8 tensor-core prefill GEMM
         var cmi8shader <- create_shader_module(g_gpu.device, q8_moe_batch_cmi8_spv)
         g_gpu.batch_coopmat_i8 <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmi8shader)
-    } elif (g_gpu.coopmat_mode == 3) {   // the mul_mm 128x128 L-tile prefill GEMM
+    } elif (g_gpu.coopmat_mode == 3) {   // the mul_mm L/M-tile prefill GEMMs (routed per dispatch)
         var cmmmshader <- create_shader_module(g_gpu.device, q8_moe_batch_mm_spv)
         g_gpu.batch_coopmat_mm <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader)
+        var cmmmshader_m <- create_shader_module(g_gpu.device, q8_moe_batch_mm_m_spv)
+        g_gpu.batch_coopmat_mm_m <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader_m)
     }
     var ashader <- create_shader_module(g_gpu.device, q8_moe_actrq_spv)
     g_gpu.actrq_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, ashader)
@@ -4588,6 +4736,7 @@ struct private VkHaz {
 }
 
 var private g_vhz_paranoid = -1   // DASLLAMA_VK_HAZARD_PARANOID: barrier before every node
+var private g_mm_m_logged = false   // one-time mul_mm M-tile engagement log
 
 def private vhz_paranoid : bool {
     if (g_vhz_paranoid < 0) {
@@ -5044,9 +5193,9 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             for (l in range64(g_rd.n_layers)) {
                 let b = int(l * PF_ROLES)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h, VHZ_XQ, VHZ_Q)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h, VHZ_XQ, VHZ_KVK)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h, VHZ_XQ, VHZ_VST)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(qd, wlen)), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h, VHZ_XQ, VHZ_Q)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(kvd, wlen)), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h, VHZ_XQ, VHZ_KVK)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(kvd, wlen)), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h, VHZ_XQ, VHZ_VST)
                 vhz_dep(raw, h, VHZ_VST, VHZ_KVV, true)
                 cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
                 if (g_rd.qk_norm) {
@@ -5057,14 +5206,14 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
                     h, VHZ_Q | VHZ_KVK | VHZ_KVV | VHZ_COS, VHZ_Q | VHZ_KVK | VHZ_MIR)
                 rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg, h, VHZ_Q | VHZ_MIR, VHZ_ATT)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l), h, VHZ_ATT, VHZ_AQ)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h, VHZ_AQ, VHZ_XB2)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(dim, wlen)), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h, VHZ_AQ, VHZ_XB2)
                 rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen), h, VHZ_X | VHZ_XB2, VHZ_X | VHZ_XB)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h, VHZ_XQ, VHZ_GATE)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h, VHZ_XQ, VHZ_UP)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(hid, wlen)), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h, VHZ_XQ, VHZ_GATE)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(hid, wlen)), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h, VHZ_XQ, VHZ_UP)
                 rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l),
                     h, VHZ_GATE | VHZ_UP | VHZ_META, VHZ_HQ)
-                rd_dispatch(raw, q8_batch_pipe(), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h, VHZ_HQ, VHZ_FFO)
+                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(dim, wlen)), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h, VHZ_HQ, VHZ_FFO)
                 rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen), h, VHZ_X | VHZ_FFO, VHZ_X | VHZ_XB)
             }
             if (last) {
@@ -5161,7 +5310,7 @@ def vk_arena_ffn(var y : array<float>; blk1, blk3, blk2 : int64; n, nfe : int64;
 // single-region batch-GEMM meta over an arena block: all tiles map to region 0. Returns the
 // dispatch workgroup count. Mirrors fill_batch_meta for one region [0, npos).
 def private fill_arena_batch_meta(hb : HostBuf; n, d, blk, npos : int64; fmt : int) : uint {
-    let tile = fmt == 0 ? q8_batch_tile() : BATCH_TILE
+    let tile = fmt == 0 ? q8_batch_tile_for(d, npos) : BATCH_TILE
     let wtiles = (d + tile - 1l) / tile
     let rtiles = (npos + tile - 1l) / tile
     let total = rtiles * wtiles
@@ -5218,7 +5367,7 @@ def vk_arena_gemm(var y : array<float>; blk : int64; n, d, npos : int64; fmt : i
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
-        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(), VkPipelineBindPoint.COMPUTE)
+        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(q8_batch_tile_for(d, npos)), VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.arenas[fmt].batch_set, groups)
         batch_barrier(raw, false)
         cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, npos * d * 4l)
@@ -5315,23 +5464,32 @@ def private bind_gemv_pipe(raw : VkCommandBuffer; fmt : int) {
     }
 }
 
-// ... and the batch-tile twin (0 = q8_moe_batch, 1/2/3/4 = kq_moe_batch_k4/5/6/q40)
 // The Q8_0 prefill batch pipeline, switched to the tensor-core coopmat variant when DASLLAMA_COOPMAT
-// selected one (weak — a non-owning alias; g_gpu keeps ownership). Q8_0 stacks only (fmt 0).
-def private q8_batch_pipe : Pipeline {
+// selected one (weak alias — g_gpu owns). `tile` = the edge the caller's meta used; picks L vs M in mm mode.
+def private q8_batch_pipe(tile : int64) : Pipeline {
     if (g_gpu.coopmat_mode == 1) {
         return weak_copy(g_gpu.batch_coopmat_f16)
     } elif (g_gpu.coopmat_mode == 2) {
         return weak_copy(g_gpu.batch_coopmat_i8)
     } elif (g_gpu.coopmat_mode == 3) {
+        if (tile == BATCH_TILE) {   // the small tier IS the sdot4 kernel — measured, not a fallback
+            return weak_copy(g_gpu.batch_pipeline)
+        }
+        if (tile == 64l) {
+            if (!g_mm_m_logged) {
+                g_mm_m_logged = true
+                to_log(LOG_INFO, "dasLLAMA vulkan tier: mul_mm M-tile engaged\n")
+            }
+            return weak_copy(g_gpu.batch_coopmat_mm_m)
+        }
         return weak_copy(g_gpu.batch_coopmat_mm)
     }
     return weak_copy(g_gpu.batch_pipeline)
 }
 
-def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int) {
+def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int; tile : int64) {
     if (fmt == 0) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(), VkPipelineBindPoint.COMPUTE)
+        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(tile), VkPipelineBindPoint.COMPUTE)
     } elif (fmt == 1) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k4, VkPipelineBindPoint.COMPUTE)
     } elif (fmt == 2) {
@@ -5597,19 +5755,23 @@ def private cmd_copy_batch_acts(raw : VkCommandBuffer; xq_bytes, xs_bytes : int6
 // window), then the per-workgroup region map. Weight offsets follow the stack's format units —
 // 32-weight blocks for q8, superblocks for kq. Returns the workgroup count.
 def private fill_batch_meta(si : int; offs : int64 const?; nregions : int64; n, d : int64; r0, r1 : int64) : uint {
-    let tile = g_gpu.stacks[si].fmt == 0 ? q8_batch_tile() : BATCH_TILE
-    let wtiles = (d + tile - 1l) / tile
     let unit = g_gpu.stacks[si].fmt != 0 ? 256l : 32l
     unsafe {
         var mp = reinterpret<uint?>(g_gpu.stacks[si].batch_meta.mapped)
         var nrc = 0l
+        var nrows = 0l
         for (r in range64(nregions)) {
             let b0 = max(offs[r * 3l + 1l], r0)
             let b1 = min(offs[r * 3l + 1l] + offs[r * 3l + 2l], r1)
             if (b1 > b0) {
                 nrc++
+                nrows += b1 - b0
             }
         }
+        // route the tile on the AVERAGE rows per active region — one pipeline serves the dispatch
+        let tile = g_gpu.stacks[si].fmt == 0 ? q8_batch_tile_for(d, nrc > 0l ? nrows / nrc : r1 - r0) : BATCH_TILE
+        g_gpu.stacks[si].batch_tile = tile
+        let wtiles = (d + tile - 1l) / tile
         let wg_bound = ((r1 - r0 + tile - 1l) / tile + nrc) * wtiles
         assert((4l + nrc * 4l + wg_bound) * 4l <= BATCH_META_BYTES, "dasLLAMA vulkan tier: batch meta exceeds capacity")
         let map_off = 4l + nrc * 4l
@@ -5703,10 +5865,10 @@ def private record_ffn_batch_cmd(s1, s3, s2 : int; nwg_gu, nwg_dn : uint; rows, 
         cmd_copy_at(raw, g_gpu.comb_stage.buf, COMB_WI_BYTES, g_gpu.comb_inv_dev, comb_wi_bytes)
     }
     batch_barrier(raw, true)
-    bind_batch_pipe(raw, g_gpu.stacks[s1].fmt)
+    bind_batch_pipe(raw, g_gpu.stacks[s1].fmt, g_gpu.stacks[s1].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[s1].batch_set, nwg_gu)
     if (g_gpu.stacks[s3].fmt != g_gpu.stacks[s1].fmt) {
-        bind_batch_pipe(raw, g_gpu.stacks[s3].fmt)
+        bind_batch_pipe(raw, g_gpu.stacks[s3].fmt, g_gpu.stacks[s3].batch_tile)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s3].batch_set, nwg_gu)
     comp_barrier(raw)
@@ -5715,7 +5877,7 @@ def private record_ffn_batch_cmd(s1, s3, s2 : int; nwg_gu, nwg_dn : uint; rows, 
     cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.batch_actrq_set, uint((rows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
     comp_barrier(raw)
-    bind_batch_pipe(raw, g_gpu.stacks[s2].fmt)
+    bind_batch_pipe(raw, g_gpu.stacks[s2].fmt, g_gpu.stacks[s2].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[s2].batch_set, nwg_dn)
     if (comb_npos > 0u) {
         comp_barrier(raw)
@@ -5810,7 +5972,7 @@ def private record_dense_cmd(si : int; nwg : uint; y_bytes : int64; axq_bytes, a
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
     cmd_copy_batch_meta(raw, si)
     batch_barrier(raw, true)
-    bind_batch_pipe(raw, g_gpu.stacks[si].fmt)
+    bind_batch_pipe(raw, g_gpu.stacks[si].fmt, g_gpu.stacks[si].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[si].batch_set, nwg)
     batch_barrier(raw, false)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, y_bytes)
@@ -5959,7 +6121,7 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
     }
     batch_barrier(raw, true)
     pfq_ts(raw)   // q1: uploads
-    bind_batch_pipe(raw, 0)
+    bind_batch_pipe(raw, 0, g_gpu.stacks[s_qkv].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_qkv].batch_set, nwg_qkv)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_z].batch_set, nwg_z)
     comp_barrier(raw)
@@ -5990,7 +6152,7 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
     cmd_bind_dispatch(raw, g_gpu.dn_rq_set, uint((rows * di / 32l + 255l) / 256l))
     comp_barrier(raw)
     pfq_ts(raw)   // q7: o requant
-    bind_batch_pipe(raw, 0)
+    bind_batch_pipe(raw, 0, g_gpu.stacks[s_o].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_out)
     batch_barrier(raw, false)
     pfq_ts(raw)   // q8: out GEMM
@@ -6406,14 +6568,14 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     cmd_copy_whole(raw, g_gpu.at_meta.buf, g_gpu.at_meta_dev, AT_META_BYTES)
     cmd_copy_range(raw, g_gpu.at_smalls.buf, 0l, g_gpu.at_smalls_dev, 0l, sm_bytes)
     batch_barrier(raw, true)
-    bind_batch_pipe(raw, g_gpu.stacks[s_q].fmt)
+    bind_batch_pipe(raw, g_gpu.stacks[s_q].fmt, g_gpu.stacks[s_q].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_q].batch_set, nwg_q)
     if (g_gpu.stacks[s_k].fmt != g_gpu.stacks[s_q].fmt) {
-        bind_batch_pipe(raw, g_gpu.stacks[s_k].fmt)
+        bind_batch_pipe(raw, g_gpu.stacks[s_k].fmt, g_gpu.stacks[s_k].batch_tile)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_k].batch_set, nwg_k)
     if (g_gpu.stacks[s_v].fmt != g_gpu.stacks[s_k].fmt) {
-        bind_batch_pipe(raw, g_gpu.stacks[s_v].fmt)
+        bind_batch_pipe(raw, g_gpu.stacks[s_v].fmt, g_gpu.stacks[s_v].batch_tile)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_v].batch_set, nwg_v)
     comp_barrier(raw)
@@ -6433,7 +6595,7 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     cmd_bind_pipeline(vk_value_to_boost(raw), o_kq ? g_gpu.q8k_rq_pipeline : g_gpu.dn_rq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.at_rq_set, uint((rows * qd / (o_kq ? 256l : 32l) + 255l) / 256l))
     comp_barrier(raw)
-    bind_batch_pipe(raw, g_gpu.stacks[s_o].fmt)
+    bind_batch_pipe(raw, g_gpu.stacks[s_o].fmt, g_gpu.stacks[s_o].batch_tile)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_o)
     batch_barrier(raw, false)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, rows * dim * 4l)

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -2810,9 +2810,9 @@ def kq_moe_batch_k6 {
 
 // ===== device state (process-lifetime; never finalized by design) =====
 
-let private WEIGHT_CAP = 4_200_000_000l    // conservative default: WDDM commit cliff hit at ~6.5GiB
-                                           // of 8GB (measured); other processes are invisible to the
-                                           // Vulkan budget query — DASLLAMA_GPU_VRAM_MB overrides for bigger cards
+let private WEIGHT_CAP = 4_200_000_000l    // default ceiling — NV/WDDM heapBudget IGNORES other
+                                           // processes (reported 7608 of 8192MB under a 1.7GB desktop);
+                                           // over-commit = silent SysMem demotion, act role 35x slower
 let private VRAM_RESERVE = 805_306_368l    // headroom below the queried heap budget when it clamps
                                            // the cap down: the tier's own scratch (~210MB batch
                                            // planes) + eviction slack
@@ -3363,7 +3363,7 @@ def private vk_moe_init : bool {
     g_gpu.queue = get_device_queue(g_gpu.device, g_gpu.fam, 0u)
     let sg = subgroup_properties(g_gpu.phys).subgroupSize
     g_gpu.rows_per_wg = int64((WG_X + sg - 1u) / sg)   // = gl_NumSubgroups for our 1D workgroup
-    // DASLLAMA_GPU_VRAM_MB / gpu_vram_mb wins outright; env PRESENCE alone skips the budget clamp (=0 pins WEIGHT_CAP — the misreporting-driver escape hatch)
+    // env wins outright (=0 pins WEIGHT_CAP — the misreporting-driver hatch); else live budget - reserve
     g_gpu.weight_budget = WEIGHT_CAP
     let vram_mb = gpu_want_vram_mb()
     let vram_override = vram_mb > 0l || has_env_variable("DASLLAMA_GPU_VRAM_MB")
@@ -3385,8 +3385,13 @@ def private vk_moe_init : bool {
             }
         }
         if (best >= 0 && mb.heapBudget[best] > 0ul) {
+            let safe_cap = max(int64(mb.heapBudget[best]) - VRAM_RESERVE, 0l)
+            // the honest cliff leaves 2GB of the raw heap for the desktop (6000MB healthy, 6803 demoted)
+            let cliff = min(safe_cap, int64(mp2.memoryProperties.memoryHeaps[best].size) - 2_147_483_648l)
             if (!vram_override) {
-                g_gpu.weight_budget = clamp(int64(mb.heapBudget[best]) - VRAM_RESERVE, 0l, g_gpu.weight_budget)
+                g_gpu.weight_budget = min(safe_cap, g_gpu.weight_budget)
+            } elif (g_gpu.weight_budget > cliff) {
+                to_log(LOG_WARNING, "dasLLAMA vulkan tier: DASLLAMA_GPU_VRAM_MB {g_gpu.weight_budget / 1000000l} MB is above the demotion cliff — WDDM will silently demote buffers to SysMem (act-role collapse); lower it to <= {cliff / 1000000l} MB\n")
             }
             to_log(LOG_INFO, "dasLLAMA vulkan tier: device heap budget {int64(mb.heapBudget[best]) / 1000000l} MB (used {int64(mb.heapUsage[best]) / 1000000l}), weight cap {g_gpu.weight_budget / 1000000l} MB\n")
         }

--- a/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_vulkan.das
@@ -595,6 +595,151 @@ def q8_moe_batch_mm {
     }
 }
 
+// The aligned L twin: staging guards + edge branch removed — the guards serialize the unrolled
+// staging loads (14.5 -> 31.2 TF on the gate shape), and even a never-taken guarded path costs
+// ~20%, so like lcpp's _aligned pipelines this is its own pipeline (d + every cnt 128-multiples).
+
+var @workgroup cma_a : uint[2560]     // A tile: 128 weight rows x one block (32 K) as f16 pairs
+var @workgroup cma_b : uint[2560]     // B tile: 128 token rows x one block
+
+[compute_shader(local_size_x=128, name="q8_moe_batch_mm_a_spv")]
+def q8_moe_batch_mm_a {
+    let n = vk_meta[0u]
+    let d = vk_meta[1u]
+    let rid = vk_meta[vk_meta[3u] + gl_WorkGroupID.x]
+    let rb = 4u + rid * 4u
+    let wblk0 = vk_meta[rb]
+    let row0 = vk_meta[rb + 1u]
+    let tix = gl_WorkGroupID.x - vk_meta[rb + 3u]
+    let wtiles = (d + 127u) / 128u
+    let xt = tix / wtiles             // token (B) tile
+    let wt = tix % wtiles             // weight (A) tile
+    let gm0 = wt * 128u
+    let gn0 = xt * 128u
+    let nbb = n / 32u
+    let tid = gl_LocalInvocationID.x
+    let warp_r = gl_SubgroupID % 2u   // which 64-row half of the A tile
+    let warp_c = gl_SubgroupID / 2u   // which 64-col half of the B tile
+    let lw = tid % 8u                 // which packed word (4 qs) of the staged row's block
+    let lr0 = tid / 8u                // staging row base 0..15
+    var acc00 : coopmatAcc_f16_16x16
+    var acc01 : coopmatAcc_f16_16x16
+    var acc02 : coopmatAcc_f16_16x16
+    var acc03 : coopmatAcc_f16_16x16
+    var acc10 : coopmatAcc_f16_16x16
+    var acc11 : coopmatAcc_f16_16x16
+    var acc12 : coopmatAcc_f16_16x16
+    var acc13 : coopmatAcc_f16_16x16
+    var acc20 : coopmatAcc_f16_16x16
+    var acc21 : coopmatAcc_f16_16x16
+    var acc22 : coopmatAcc_f16_16x16
+    var acc23 : coopmatAcc_f16_16x16
+    var acc30 : coopmatAcc_f16_16x16
+    var acc31 : coopmatAcc_f16_16x16
+    var acc32 : coopmatAcc_f16_16x16
+    var acc33 : coopmatAcc_f16_16x16
+    var kb = 0u
+    while (kb < nbb) {
+        for [unroll] (p in range(8)) {   // stage A: 128 weight rows x 1 block, unguarded
+            let row = lr0 + uint(p) * 16u
+            let ib = wblk0 + (gm0 + row) * nbb + kb
+            let v = float4(int4(unpack8(int(vk_wq[ib * 8u + lw])))) * float(vk_ws[ib])
+            let o = row * CML_SST + lw * 2u
+            cma_a[o] = packHalf2x16(v.xy)
+            cma_a[o + 1u] = packHalf2x16(v.zw)
+        }
+        for [unroll] (p in range(8)) {   // stage B: 128 token rows x 1 block, unguarded
+            let row = lr0 + uint(p) * 16u
+            let ib = (row0 + gn0 + row) * nbb + kb
+            let v = float4(int4(unpack8(int(vk_xq[ib * 8u + lw])))) * vk_xs[ib]
+            let o = row * CML_SST + lw * 2u
+            cma_b[o] = packHalf2x16(v.xy)
+            cma_b[o + 1u] = packHalf2x16(v.zw)
+        }
+        barrier()
+        for [unroll] (ks in range(2)) {   // 2 K-subtiles x (4 A rows x 4 B cols), their MMA order
+            let k8 = uint(ks) * 8u
+            var ca : coopmatA_f16_16x16
+            var cb : coopmatB_f16_16x16
+            coopmatLoad(ca, cma_a, int((warp_r * 64u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc00 = coopmatMulAdd(ca, cb, acc00)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc01 = coopmatMulAdd(ca, cb, acc01)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc02 = coopmatMulAdd(ca, cb, acc02)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc03 = coopmatMulAdd(ca, cb, acc03)
+            coopmatLoad(ca, cma_a, int((warp_r * 64u + 16u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc10 = coopmatMulAdd(ca, cb, acc10)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc11 = coopmatMulAdd(ca, cb, acc11)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc12 = coopmatMulAdd(ca, cb, acc12)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc13 = coopmatMulAdd(ca, cb, acc13)
+            coopmatLoad(ca, cma_a, int((warp_r * 64u + 32u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc20 = coopmatMulAdd(ca, cb, acc20)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc21 = coopmatMulAdd(ca, cb, acc21)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc22 = coopmatMulAdd(ca, cb, acc22)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc23 = coopmatMulAdd(ca, cb, acc23)
+            coopmatLoad(ca, cma_a, int((warp_r * 64u + 48u) * CML_SST + k8), int(CML_SST), 0)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u) * CML_SST + k8), int(CML_SST), 1)
+            acc30 = coopmatMulAdd(ca, cb, acc30)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 16u) * CML_SST + k8), int(CML_SST), 1)
+            acc31 = coopmatMulAdd(ca, cb, acc31)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 32u) * CML_SST + k8), int(CML_SST), 1)
+            acc32 = coopmatMulAdd(ca, cb, acc32)
+            coopmatLoad(cb, cma_b, int((warp_c * 64u + 48u) * CML_SST + k8), int(CML_SST), 1)
+            acc33 = coopmatMulAdd(ca, cb, acc33)
+        }
+        barrier()
+        kb++
+    }
+    // stores: y[(row0 + token) * d + wrow] — fragment weight-dim contiguous = column-major, stride d
+    let dr = gm0 + warp_r * 64u
+    let dc = gn0 + warp_c * 64u
+    var accw : coopmatAcc_f32_16x16
+    let yb = (row0 + dc) * d + dr
+    coopmatConvert(accw, acc00)
+    coopmatStore(accw, vk_y, int(yb), int(d), 1)
+    coopmatConvert(accw, acc01)
+    coopmatStore(accw, vk_y, int(yb + 16u * d), int(d), 1)
+    coopmatConvert(accw, acc02)
+    coopmatStore(accw, vk_y, int(yb + 32u * d), int(d), 1)
+    coopmatConvert(accw, acc03)
+    coopmatStore(accw, vk_y, int(yb + 48u * d), int(d), 1)
+    coopmatConvert(accw, acc10)
+    coopmatStore(accw, vk_y, int(yb + 16u), int(d), 1)
+    coopmatConvert(accw, acc11)
+    coopmatStore(accw, vk_y, int(yb + 16u * d + 16u), int(d), 1)
+    coopmatConvert(accw, acc12)
+    coopmatStore(accw, vk_y, int(yb + 32u * d + 16u), int(d), 1)
+    coopmatConvert(accw, acc13)
+    coopmatStore(accw, vk_y, int(yb + 48u * d + 16u), int(d), 1)
+    coopmatConvert(accw, acc20)
+    coopmatStore(accw, vk_y, int(yb + 32u), int(d), 1)
+    coopmatConvert(accw, acc21)
+    coopmatStore(accw, vk_y, int(yb + 16u * d + 32u), int(d), 1)
+    coopmatConvert(accw, acc22)
+    coopmatStore(accw, vk_y, int(yb + 32u * d + 32u), int(d), 1)
+    coopmatConvert(accw, acc23)
+    coopmatStore(accw, vk_y, int(yb + 48u * d + 32u), int(d), 1)
+    coopmatConvert(accw, acc30)
+    coopmatStore(accw, vk_y, int(yb + 48u), int(d), 1)
+    coopmatConvert(accw, acc31)
+    coopmatStore(accw, vk_y, int(yb + 16u * d + 48u), int(d), 1)
+    coopmatConvert(accw, acc32)
+    coopmatStore(accw, vk_y, int(yb + 32u * d + 48u), int(d), 1)
+    coopmatConvert(accw, acc33)
+    coopmatStore(accw, vk_y, int(yb + 48u * d + 48u), int(d), 1)
+}
+
 // The mul_mm M-tile twin (64x64, lcpp's cm1 m-warptile): the L scheme at half edge — 4 warps 2x2
 // over the tile, 2x2 fragments each, 12.3KB shared. Routed in by q8_batch_tile_for when cnt or d
 // <= 64: the L tile pads every such dispatch to 128 B-columns (MoE regions run ~32 rows).
@@ -2979,6 +3124,14 @@ def private q8_batch_tile_for(d, cnt : int64) : int64 {
     }
     return d <= 64l || cnt < MM_SMALL_CNT ? mm_small_tile() : 128l
 }
+
+// aligned-L eligibility: every tile interior (d and cnt both 128-multiples) — the guard-free
+// pipeline. Pure in (d, cnt, mode) like the tile router, so pipe pick and meta fill agree.
+def private q8_batch_aligned(d, cnt : int64) : bool
+    => d % 128l == 0l && cnt % 128l == 0l && q8_batch_tile_for(d, cnt) == 128l
+
+def private q8_batch_pipe_for(d, cnt : int64) : Pipeline
+    => q8_batch_pipe(q8_batch_tile_for(d, cnt), q8_batch_aligned(d, cnt))
 let private BATCH_CHUNK_ROWS = 8_192l      // dispatch row-window cap (bounds y and the wg map)
 let private BATCH_HQ_BYTES = 33_554_432l   // device requantized-hidden quants (the down GEMM's activations)
 let private BATCH_HS_BYTES = 8_388_608l    // ... its scale plane
@@ -3085,6 +3238,7 @@ struct private VkStack {
     batch_y : uint64         // which shared y plane batch_set binds (role-fixed per stack)
     batch_xq : uint64        // which activation-quant plane it binds (gate/up: gathered x; down: hq)
     batch_tile : int64       // the tile edge the last fill_batch_meta routed — the bind must match
+    batch_aligned : bool     // ... and whether that fill qualified for the guard-free aligned-L pipe
     batch_made : bool
     // classifier dispatch state (lazy — set up on the first cls GEMV against this stack)
     cls_set : VkDescriptorSet
@@ -3184,6 +3338,7 @@ struct private GpuState {
     batch_coopmat_q40 : Pipeline  // prefill Q4_0 GEMM on tensor cores, f16-dequant (COOPMAT=f16, fmt 4)
     batch_coopmat_mm : Pipeline   // prefill Q8_0 GEMM, the mul_mm 128x128 L-tile (DASLLAMA_COOPMAT=mm)
     batch_coopmat_mm_m : Pipeline // ... its 64x64 M-tile twin, routed in for small-cnt dispatches
+    batch_coopmat_mm_a : Pipeline // ... the aligned-L twin (no staging guards/edge path — 2.2x the L rate)
     actrq_pipeline : Pipeline   // fused act(g)*u + q8_0 requant of the hidden rows
     gemv_k4 : Pipeline          // native K-quant GEMVs (per-format decode kernels)
     gemv_k5 : Pipeline
@@ -3587,6 +3742,8 @@ def private vk_moe_init : bool {
         g_gpu.batch_coopmat_mm <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader)
         var cmmmshader_m <- create_shader_module(g_gpu.device, q8_moe_batch_mm_m_spv)
         g_gpu.batch_coopmat_mm_m <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader_m)
+        var cmmmshader_a <- create_shader_module(g_gpu.device, q8_moe_batch_mm_a_spv)
+        g_gpu.batch_coopmat_mm_a <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, cmmmshader_a)
     }
     var ashader <- create_shader_module(g_gpu.device, q8_moe_actrq_spv)
     g_gpu.actrq_pipeline <- create_compute_pipeline(g_gpu.device, g_gpu.pipe_layout, ashader)
@@ -5193,9 +5350,9 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
             for (l in range64(g_rd.n_layers)) {
                 let b = int(l * PF_ROLES)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 0], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(qd, wlen)), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h, VHZ_XQ, VHZ_Q)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(kvd, wlen)), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h, VHZ_XQ, VHZ_KVK)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(kvd, wlen)), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h, VHZ_XQ, VHZ_VST)
+                rd_dispatch(raw, q8_batch_pipe_for(qd, wlen), g_rd.pf_sets[b + 1], fill_arena_batch_meta(g_rd.pf_meta[b + 1], dim, qd, g_rd.layers[l].bq, wlen, 0), h, VHZ_XQ, VHZ_Q)
+                rd_dispatch(raw, q8_batch_pipe_for(kvd, wlen), g_rd.pf_sets[b + 2], fill_arena_batch_meta(g_rd.pf_meta[b + 2], dim, kvd, g_rd.layers[l].bk, wlen, 0), h, VHZ_XQ, VHZ_KVK)
+                rd_dispatch(raw, q8_batch_pipe_for(kvd, wlen), g_rd.pf_sets[b + 3], fill_arena_batch_meta(g_rd.pf_meta[b + 3], dim, kvd, g_rd.layers[l].bv, wlen, 0), h, VHZ_XQ, VHZ_VST)
                 vhz_dep(raw, h, VHZ_VST, VHZ_KVV, true)
                 cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
                 if (g_rd.qk_norm) {
@@ -5206,14 +5363,14 @@ def vk_rdec_prefill(x_batch : array<float>; cos_batch : array<float>; npos : int
                     h, VHZ_Q | VHZ_KVK | VHZ_KVV | VHZ_COS, VHZ_Q | VHZ_KVK | VHZ_MIR)
                 rd_dispatch(raw, g_gpu.da_b_pipeline, g_rd.pf_sets[b + 5], attnwg, h, VHZ_Q | VHZ_MIR, VHZ_ATT)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 6], uint((wlen * qd / 32l + 255l) / 256l), h, VHZ_ATT, VHZ_AQ)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(dim, wlen)), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h, VHZ_AQ, VHZ_XB2)
+                rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 7], fill_arena_batch_meta(g_rd.pf_meta[b + 7], qd, dim, g_rd.layers[l].bo, wlen, 0), h, VHZ_AQ, VHZ_XB2)
                 rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 8], uint(wlen), h, VHZ_X | VHZ_XB2, VHZ_X | VHZ_XB)
                 rd_dispatch(raw, g_gpu.dn_rq_pipeline, g_rd.pf_sets[b + 9], uint((wlen * dim / 32l + 255l) / 256l), h, VHZ_XB, VHZ_XQ)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(hid, wlen)), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h, VHZ_XQ, VHZ_GATE)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(hid, wlen)), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h, VHZ_XQ, VHZ_UP)
+                rd_dispatch(raw, q8_batch_pipe_for(hid, wlen), g_rd.pf_sets[b + 10], fill_arena_batch_meta(g_rd.pf_meta[b + 10], dim, hid, g_rd.layers[l].b1, wlen, 0), h, VHZ_XQ, VHZ_GATE)
+                rd_dispatch(raw, q8_batch_pipe_for(hid, wlen), g_rd.pf_sets[b + 11], fill_arena_batch_meta(g_rd.pf_meta[b + 11], dim, hid, g_rd.layers[l].b3, wlen, 0), h, VHZ_XQ, VHZ_UP)
                 rd_dispatch(raw, g_gpu.actrq_pipeline, g_rd.pf_sets[b + 12], uint((wlen * hid / 32l + 255l) / 256l),
                     h, VHZ_GATE | VHZ_UP | VHZ_META, VHZ_HQ)
-                rd_dispatch(raw, q8_batch_pipe(q8_batch_tile_for(dim, wlen)), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h, VHZ_HQ, VHZ_FFO)
+                rd_dispatch(raw, q8_batch_pipe_for(dim, wlen), g_rd.pf_sets[b + 13], fill_arena_batch_meta(g_rd.pf_meta[b + 13], hid, dim, g_rd.layers[l].b2, wlen, 0), h, VHZ_HQ, VHZ_FFO)
                 rd_dispatch(raw, g_gpu.ar_pipeline_b, g_rd.pf_sets[b + 14], uint(wlen), h, VHZ_X | VHZ_FFO, VHZ_X | VHZ_XB)
             }
             if (last) {
@@ -5367,7 +5524,7 @@ def vk_arena_gemm(var y : array<float>; blk : int64; n, d, npos : int64; fmt : i
         var raw = alloc_cmd()
         let begin = VkCommandBufferBeginInfo()
         vk_check(vkBeginCommandBuffer(raw, begin), null)
-        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(q8_batch_tile_for(d, npos)), VkPipelineBindPoint.COMPUTE)
+        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe_for(d, npos), VkPipelineBindPoint.COMPUTE)
         cmd_bind_dispatch(raw, g_gpu.arenas[fmt].batch_set, groups)
         batch_barrier(raw, false)
         cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, npos * d * 4l)
@@ -5466,7 +5623,7 @@ def private bind_gemv_pipe(raw : VkCommandBuffer; fmt : int) {
 
 // The Q8_0 prefill batch pipeline, switched to the tensor-core coopmat variant when DASLLAMA_COOPMAT
 // selected one (weak alias — g_gpu owns). `tile` = the edge the caller's meta used; picks L vs M in mm mode.
-def private q8_batch_pipe(tile : int64) : Pipeline {
+def private q8_batch_pipe(tile : int64; aligned : bool = false) : Pipeline {
     if (g_gpu.coopmat_mode == 1) {
         return weak_copy(g_gpu.batch_coopmat_f16)
     } elif (g_gpu.coopmat_mode == 2) {
@@ -5482,14 +5639,19 @@ def private q8_batch_pipe(tile : int64) : Pipeline {
             }
             return weak_copy(g_gpu.batch_coopmat_mm_m)
         }
-        return weak_copy(g_gpu.batch_coopmat_mm)
+        return weak_copy(aligned ? g_gpu.batch_coopmat_mm_a : g_gpu.batch_coopmat_mm)
     }
     return weak_copy(g_gpu.batch_pipeline)
 }
 
-def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int; tile : int64) {
+// two stacks share one bound pipeline only when the whole choice agrees (fmt + tile + aligned)
+def private same_batch_pipe(a, b : int) : bool
+    => (g_gpu.stacks[a].fmt == g_gpu.stacks[b].fmt && g_gpu.stacks[a].batch_tile == g_gpu.stacks[b].batch_tile
+        && g_gpu.stacks[a].batch_aligned == g_gpu.stacks[b].batch_aligned)
+
+def private bind_batch_pipe(raw : VkCommandBuffer; fmt : int; tile : int64; aligned : bool = false) {
     if (fmt == 0) {
-        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(tile), VkPipelineBindPoint.COMPUTE)
+        cmd_bind_pipeline(vk_value_to_boost(raw), q8_batch_pipe(tile, aligned), VkPipelineBindPoint.COMPUTE)
     } elif (fmt == 1) {
         cmd_bind_pipeline(vk_value_to_boost(raw), g_gpu.batch_k4, VkPipelineBindPoint.COMPUTE)
     } elif (fmt == 2) {
@@ -5760,17 +5922,20 @@ def private fill_batch_meta(si : int; offs : int64 const?; nregions : int64; n, 
         var mp = reinterpret<uint?>(g_gpu.stacks[si].batch_meta.mapped)
         var nrc = 0l
         var nrows = 0l
+        var all128 = true   // every active region's cnt a 128-multiple -> aligned-L eligible
         for (r in range64(nregions)) {
             let b0 = max(offs[r * 3l + 1l], r0)
             let b1 = min(offs[r * 3l + 1l] + offs[r * 3l + 2l], r1)
             if (b1 > b0) {
                 nrc++
                 nrows += b1 - b0
+                all128 = all128 && (b1 - b0) % 128l == 0l
             }
         }
         // route the tile on the AVERAGE rows per active region — one pipeline serves the dispatch
         let tile = g_gpu.stacks[si].fmt == 0 ? q8_batch_tile_for(d, nrc > 0l ? nrows / nrc : r1 - r0) : BATCH_TILE
         g_gpu.stacks[si].batch_tile = tile
+        g_gpu.stacks[si].batch_aligned = g_gpu.stacks[si].fmt == 0 && tile == 128l && d % 128l == 0l && all128
         let wtiles = (d + tile - 1l) / tile
         let wg_bound = ((r1 - r0 + tile - 1l) / tile + nrc) * wtiles
         assert((4l + nrc * 4l + wg_bound) * 4l <= BATCH_META_BYTES, "dasLLAMA vulkan tier: batch meta exceeds capacity")
@@ -5865,10 +6030,10 @@ def private record_ffn_batch_cmd(s1, s3, s2 : int; nwg_gu, nwg_dn : uint; rows, 
         cmd_copy_at(raw, g_gpu.comb_stage.buf, COMB_WI_BYTES, g_gpu.comb_inv_dev, comb_wi_bytes)
     }
     batch_barrier(raw, true)
-    bind_batch_pipe(raw, g_gpu.stacks[s1].fmt, g_gpu.stacks[s1].batch_tile)
+    bind_batch_pipe(raw, g_gpu.stacks[s1].fmt, g_gpu.stacks[s1].batch_tile, g_gpu.stacks[s1].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s1].batch_set, nwg_gu)
-    if (g_gpu.stacks[s3].fmt != g_gpu.stacks[s1].fmt) {
-        bind_batch_pipe(raw, g_gpu.stacks[s3].fmt, g_gpu.stacks[s3].batch_tile)
+    if (!same_batch_pipe(s3, s1)) {
+        bind_batch_pipe(raw, g_gpu.stacks[s3].fmt, g_gpu.stacks[s3].batch_tile, g_gpu.stacks[s3].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s3].batch_set, nwg_gu)
     comp_barrier(raw)
@@ -5877,7 +6042,7 @@ def private record_ffn_batch_cmd(s1, s3, s2 : int; nwg_gu, nwg_dn : uint; rows, 
     cmd_bind_pipeline(vk_value_to_boost(raw), dkq ? g_gpu.actrq_k_pipeline : g_gpu.actrq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.batch_actrq_set, uint((rows * nfe / (dkq ? 256l : 32l) + 255l) / 256l))
     comp_barrier(raw)
-    bind_batch_pipe(raw, g_gpu.stacks[s2].fmt, g_gpu.stacks[s2].batch_tile)
+    bind_batch_pipe(raw, g_gpu.stacks[s2].fmt, g_gpu.stacks[s2].batch_tile, g_gpu.stacks[s2].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s2].batch_set, nwg_dn)
     if (comb_npos > 0u) {
         comp_barrier(raw)
@@ -5972,7 +6137,7 @@ def private record_dense_cmd(si : int; nwg : uint; y_bytes : int64; axq_bytes, a
     cmd_copy_batch_acts(raw, axq_bytes, axs_bytes)
     cmd_copy_batch_meta(raw, si)
     batch_barrier(raw, true)
-    bind_batch_pipe(raw, g_gpu.stacks[si].fmt, g_gpu.stacks[si].batch_tile)
+    bind_batch_pipe(raw, g_gpu.stacks[si].fmt, g_gpu.stacks[si].batch_tile, g_gpu.stacks[si].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[si].batch_set, nwg)
     batch_barrier(raw, false)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, y_bytes)
@@ -6121,8 +6286,11 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
     }
     batch_barrier(raw, true)
     pfq_ts(raw)   // q1: uploads
-    bind_batch_pipe(raw, 0, g_gpu.stacks[s_qkv].batch_tile)
+    bind_batch_pipe(raw, 0, g_gpu.stacks[s_qkv].batch_tile, g_gpu.stacks[s_qkv].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_qkv].batch_set, nwg_qkv)
+    if (!same_batch_pipe(s_z, s_qkv)) {
+        bind_batch_pipe(raw, 0, g_gpu.stacks[s_z].batch_tile, g_gpu.stacks[s_z].batch_aligned)
+    }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_z].batch_set, nwg_z)
     comp_barrier(raw)
     pfq_ts(raw)   // q2: qkv+z GEMMs
@@ -6152,7 +6320,7 @@ def private record_dn_cmd(s_qkv, s_z, s_o : int; nwg_qkv, nwg_z, nwg_out : uint;
     cmd_bind_dispatch(raw, g_gpu.dn_rq_set, uint((rows * di / 32l + 255l) / 256l))
     comp_barrier(raw)
     pfq_ts(raw)   // q7: o requant
-    bind_batch_pipe(raw, 0, g_gpu.stacks[s_o].batch_tile)
+    bind_batch_pipe(raw, 0, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_out)
     batch_barrier(raw, false)
     pfq_ts(raw)   // q8: out GEMM
@@ -6568,14 +6736,14 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     cmd_copy_whole(raw, g_gpu.at_meta.buf, g_gpu.at_meta_dev, AT_META_BYTES)
     cmd_copy_range(raw, g_gpu.at_smalls.buf, 0l, g_gpu.at_smalls_dev, 0l, sm_bytes)
     batch_barrier(raw, true)
-    bind_batch_pipe(raw, g_gpu.stacks[s_q].fmt, g_gpu.stacks[s_q].batch_tile)
+    bind_batch_pipe(raw, g_gpu.stacks[s_q].fmt, g_gpu.stacks[s_q].batch_tile, g_gpu.stacks[s_q].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_q].batch_set, nwg_q)
-    if (g_gpu.stacks[s_k].fmt != g_gpu.stacks[s_q].fmt) {
-        bind_batch_pipe(raw, g_gpu.stacks[s_k].fmt, g_gpu.stacks[s_k].batch_tile)
+    if (!same_batch_pipe(s_k, s_q)) {
+        bind_batch_pipe(raw, g_gpu.stacks[s_k].fmt, g_gpu.stacks[s_k].batch_tile, g_gpu.stacks[s_k].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_k].batch_set, nwg_k)
-    if (g_gpu.stacks[s_v].fmt != g_gpu.stacks[s_k].fmt) {
-        bind_batch_pipe(raw, g_gpu.stacks[s_v].fmt, g_gpu.stacks[s_v].batch_tile)
+    if (!same_batch_pipe(s_v, s_k)) {
+        bind_batch_pipe(raw, g_gpu.stacks[s_v].fmt, g_gpu.stacks[s_v].batch_tile, g_gpu.stacks[s_v].batch_aligned)
     }
     cmd_bind_dispatch(raw, g_gpu.stacks[s_v].batch_set, nwg_v)
     comp_barrier(raw)
@@ -6595,7 +6763,7 @@ def private record_at_cmd(s_q, s_k, s_v, s_o : int; nwg_q, nwg_k, nwg_v, nwg_o :
     cmd_bind_pipeline(vk_value_to_boost(raw), o_kq ? g_gpu.q8k_rq_pipeline : g_gpu.dn_rq_pipeline, VkPipelineBindPoint.COMPUTE)
     cmd_bind_dispatch(raw, g_gpu.at_rq_set, uint((rows * qd / (o_kq ? 256l : 32l) + 255l) / 256l))
     comp_barrier(raw)
-    bind_batch_pipe(raw, g_gpu.stacks[s_o].fmt, g_gpu.stacks[s_o].batch_tile)
+    bind_batch_pipe(raw, g_gpu.stacks[s_o].fmt, g_gpu.stacks[s_o].batch_tile, g_gpu.stacks[s_o].batch_aligned)
     cmd_bind_dispatch(raw, g_gpu.stacks[s_o].batch_set, nwg_o)
     batch_barrier(raw, false)
     cmd_copy_whole(raw, g_gpu.batch_y1_dev, g_gpu.batch_y1.buf, rows * dim * 4l)

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_lens.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_lens.das
@@ -1,0 +1,139 @@
+options gen2
+options indenting = 4
+
+module dasllama_vulkan_lens shared private
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/macro_boost
+require daslib/rtti
+require strings
+require daslib/strings_boost
+require dasllama/dasllama_kernel_access
+
+// The dasLLAMA Vulkan kernel-access lens ([[dasllama_metal_lens]]'s sibling). At compile time it
+// walks every [compute_shader] kernel in the requiring module, derives which SSBO BINDINGS the
+// body reads and writes (via dasllama_kernel_access over the @ssbo globals, aliased views
+// unioned per @binding), and splices the result into the module as a spec string:
+//     "kernel=readmask,writemask;..."   (decimal, 6-bit binding masks, name-sorted)
+// The runtime pairs those masks with per-descriptor-set region bits to derive each dispatch's
+// hazard masks — see dasllama_math_vulkan's hz_dispatch.
+//
+// Escape hatch: [vk_access(reads="vk_a,vk_b", writes="vk_y")] on a kernel overrides derivation.
+// Without force=true the override must MATCH the derived masks (a drift guard); force=true makes
+// the deliberate lie win — including when the body is unanalyzable (the ratchet error).
+
+[function_macro(name = vk_access)]
+class VkAccessAnnotation : AstFunctionAnnotation {
+    def override apply(var func : FunctionPtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        return true   // marker — vk_kernel_access_spec reads the arguments during its module scan
+    }
+}
+
+def private names_to_mask(spec : string; bindings : table<string; int>; var bad : string&) : uint {
+    var mask = 0u
+    for (tok in split(spec, ",")) {
+        let t = strip(tok)
+        if (t == "") {
+            continue
+        }
+        if (key_exists(bindings, t)) {
+            mask |= 1u << uint(bindings?[t] ?? 0)
+        } else {
+            bad = t
+        }
+    }
+    return mask
+}
+
+def private set_to_mask(names : table<string>; bindings : table<string; int>) : uint {
+    var mask = 0u
+    for (n in keys(names)) {
+        if (key_exists(bindings, n)) {
+            mask |= 1u << uint(bindings?[n] ?? 0)
+        }
+    }
+    return mask
+}
+
+[call_macro(name = "vk_kernel_access_spec")]
+class VkKernelAccessSpec : AstCallMacro {
+    def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : ExpressionPtr {
+        macro_verify(empty(call.arguments), prog, call.at, "vk_kernel_access_spec takes no arguments")
+        // the tracked set: every @ssbo global with a @binding (aliased views union onto one bit)
+        var bindings : table<string; int>
+        mod |> for_each_global() $(v) {
+            if (v.annotation |> find_arg("ssbo") is tBool) {
+                let b = v.annotation |> find_arg("binding") ?as tInt ?? -1
+                if (b >= 0) {
+                    bindings |> insert(string(v.name), b)
+                }
+            }
+        }
+        macro_verify(!empty(bindings), prog, call.at, "vk_kernel_access_spec: no @ssbo @binding globals in this module")
+        var tracked : table<string>
+        for (n in keys(bindings)) {
+            tracked |> insert(n)
+        }
+        var names : array<string>
+        var rmasks : table<string; uint>
+        var wmasks : table<string; uint>
+        var fail = ""
+        mod |> for_each_function("") $(fn) {
+            var is_kernel = false
+            var ovr_reads = ""
+            var ovr_writes = ""
+            var has_ovr = false
+            var ovr_force = false
+            for (ann in fn.annotations) {
+                if (ann != null && ann.annotation.name == "compute_shader") {
+                    is_kernel = true
+                } elif (ann != null && ann.annotation.name == "vk_access") {
+                    has_ovr = true
+                    ovr_reads = ann.arguments |> find_arg("reads") ?as tString ?? ""
+                    ovr_writes = ann.arguments |> find_arg("writes") ?as tString ?? ""
+                    ovr_force = ann.arguments |> find_arg("force") ?as tBool ?? false
+                }
+            }
+            if (is_kernel) {
+                let name = string(fn.name)
+                var res <- classify_global_access(fn, mod, tracked)
+                var r = set_to_mask(res.reads, bindings)
+                var w = set_to_mask(res.writes, bindings)
+                if (has_ovr) {
+                    var bad = ""
+                    let or_ = names_to_mask(ovr_reads, bindings, bad)
+                    let ow = names_to_mask(ovr_writes, bindings, bad)
+                    if (bad != "" && fail == "") {
+                        fail = "{name}: [vk_access] names unknown global '{bad}'"
+                    }
+                    if (!ovr_force) {
+                        if (!empty(res.err) && fail == "") {
+                            fail = "{name}: body unanalyzable ({res.err}) — [vk_access] needs force=true"
+                        }
+                        if ((or_ != r || ow != w) && fail == "") {
+                            fail = "{name}: [vk_access] (r={int(or_)},w={int(ow)}) does not match derived (r={int(r)},w={int(w)}) — fix it or add force=true"
+                        }
+                    }
+                    r = or_
+                    w = ow
+                } elif (!empty(res.err) && fail == "") {
+                    fail = res.err
+                }
+                delete res
+                names |> push(name)
+                rmasks |> insert(name, r)
+                wmasks |> insert(name, w)
+            }
+        }
+        macro_verify(fail == "", prog, call.at, "vk_kernel_access_spec: {fail}")
+        macro_verify(!empty(names), prog, call.at, "vk_kernel_access_spec: no [compute_shader] kernels in this module")
+        sort(names)
+        let spec = build_string() $(writer) {
+            for (n in names) {
+                writer |> write(n) |> write("=") |> write(int(rmasks[n])) |> write(",") |> write(int(wmasks[n])) |> write(";")
+            }
+        }
+        return new ExprConstString(at = call.at, value := spec)
+    }
+}

--- a/modules/dasLLAMA/kernel_access_lens_metal.md
+++ b/modules/dasLLAMA/kernel_access_lens_metal.md
@@ -1,0 +1,109 @@
+# Porting the kernel-access lens to Metal
+
+The Vulkan tier no longer hand-writes hazard masks: a compile-time lens derives each kernel's
+per-binding read/write access from its body, descriptor sets declare region bits where their
+buffers are named, and the dispatch helper composes the two. This doc is the map for doing the
+same under the Metal lens. The Vulkan implementation (commit `a9d2e8933`) is the worked example.
+
+## What already exists (reuse, don't rewrite)
+
+**`dasllama/dasllama_kernel_access.das`** — the shared analyzer, deliberately kept
+backend-agnostic:
+
+```das
+def classify_global_access(fn : Function?; mod : Module?; tracked : table<string>) : AccessResult
+struct AccessResult { reads, writes : table<string>; err : string }
+```
+
+Given a function and a set of tracked global names, it walks the body and reports which tracked
+globals are read and which are written. Mechanics:
+
+- write detection: `ExprCopy`/`ExprMove`/`ExprClone` left sides, compound assigns (`+=` family
+  on `ExprOp2`), `++`/`--` (`ExprOp1`); the write-root peels `ExprAt`/`ExprSafeAt`/`ExprField`/
+  `ExprSwizzle`/`ExprRef2Value` down to the base `ExprVar`
+- a pure store claims its target node so the generic `ExprVar` pass doesn't double-count it as a
+  read; read-modify-write forms count as both
+- intrinsic table: `coopmatStore` writes its arg 1, `coopmatLoad` only reads — extend here for
+  any Metal builtin that takes a whole array and writes through it
+- interprocedural: same-module callees are analyzed recursively (memoized, cycle-guarded);
+  helpers that access the globals directly Just Work
+- **the ratchet**: a tracked global passed WHOLE as an argument to a call the analyzer does not
+  model sets `err` — the lens turns that into a compile error instead of silently under-tracking
+
+**`dasllama/dasllama_vulkan_lens.das`** — the consumer shape to copy:
+
+- a `[call_macro]` (`vk_kernel_access_spec()`) that fires during infer of the requiring module —
+  the whole module is parsed by then, so it can scan every kernel with zero per-kernel markup
+  and no add-function timing games
+- it splices the result as a **spec string constant** (`"kernel=readmask,writemask;..."`,
+  decimal, name-sorted for determinism) that the runtime parses once — this dodges every
+  AST-literal-construction subtlety; keep that trick
+- `[vk_access(reads = "...", writes = "...", force = false)]` — the override annotation.
+  Without `force` it must MATCH the derived masks (drift guard, compile error naming the diff);
+  `force = true` is the deliberate lie, and the only way through when the body is unanalyzable
+
+## The Metal mapping
+
+Metal's `[metal_dispatch]` lens today requires `@role` on every `@ssbo` field. The port makes
+`@role`'s read/write/readwrite axis **derived**, keeps everything the body cannot know
+**declared**:
+
+| today | after the port |
+|---|---|
+| `@role = "read" / "write" / "readwrite"` | derived from the kernel body; `@role` stays legal as an override, cross-checked like `[vk_access]` (mismatch = compile error unless forced) |
+| `@role = "weight"` (never written in a step, untracked by design) | stays declared — frame-level policy, not a kernel fact |
+| `@role = "alias"` (hazard lives on another field) | stays declared |
+| `@off` / `@span` (exact byte ranges over runtime params) | stays declared — the ranges are what make the decode tracker finer than region bits; a body walk cannot produce symbolic spans |
+
+So in `MetalDispatch.apply` (dasllama_metal_lens.das): instead of erroring on a missing
+`@role`, run the analyzer on the kernel and use the derived direction; when `@role` IS present,
+compare and enforce the `force` contract. The `hz_read`/`hz_write` emission and everything else
+in the builder is unchanged — only where the direction COMES FROM changes.
+
+## The one analyzer extension the port needs
+
+Metal kernels are **classes**; their buffers are **fields**, not module globals. The analyzer
+tracks `ExprVar` by name, and its write-root peel goes THROUGH `ExprField` to the base variable
+— so `self.bx[i] = v` currently resolves to a write of `self`, not `bx`.
+
+Extend `dasllama_kernel_access` with a field-tracking mode (second entry point or a flag):
+
+- tracked set = the class's `@ssbo`/`@uniform` field names
+- the write-root peel STOPS at the first `ExprField` whose name is in the tracked set (and
+  records that name) instead of peeling to the base var; same for the read pass — visit
+  `ExprField` nodes, match `name`, honor the claimed-node set
+- interprocedural: methods of the same class calling each other resolve like same-module
+  functions; a field passed whole to an unmodeled call hits the same ratchet
+
+Everything else (setops, claims, intrinsic table, memoization, `err`) reuses as-is. Keep the
+extension in the shared module — the point of the split is one analyzer, two lenses.
+
+## The migration oracle (do not skip this)
+
+The Vulkan port was proven with a trace diff, and it caught three stale hand masks that had
+survived review (a write bit on a buffer the kernel never writes, two over-declared reads).
+Same discipline on Metal:
+
+1. add a trace env that logs every declared node's masks in order (Vulkan:
+   `DASLLAMA_VK_HAZARD_TRACE=1` in `vhz_dep`; Metal wants the same one line in `bar_dep` and/or
+   the `hz_gate` staging dump)
+2. capture BEFORE traces on the current hand-annotated build — one run per arm that covers each
+   recorder (the metal suites' decode + prefill + matrix arms; `run.das --arm ...`)
+3. switch to derived, capture AFTER, `diff` the ordered streams **grouped by distinct
+   (r, w) pattern** — every group must be either identical or adjudicated as "derivation more
+   accurate than hand" (you will find stale annotations; that's the lens paying for itself)
+4. then the usual gates: bit-identity on the parity arms, `DASLLAMA_METAL_HAZARD_PARANOID=1`
+   == elided, STRICT run clean
+
+## Gotchas from the Vulkan round
+
+- new `.das` files must be listed in `modules/dasLLAMA/.das_module` or `require` fails with
+  20605
+- a module declared `shared private` hides ALL its symbols from direct requirers — the shared
+  analyzer must stay `shared public`
+- `var out : string` parameters are by-VALUE (workhorse type) — an out-param must be
+  `var out : string&` (this was a real bug lint caught in the Vulkan lens)
+- indexing a `const` table param is a compile error — use `t?[k] ?? d` under a `key_exists`
+  guard
+- aliased views of one buffer (Vulkan: `vk_wq8` over `vk_wq`) union onto one tracked slot; the
+  Metal analog is two fields bound to the same buffer — that's what `alias` still declares

--- a/modules/dasLLAMA/performance/coopmat_mulmm_port.das
+++ b/modules/dasLLAMA/performance/coopmat_mulmm_port.das
@@ -1,0 +1,561 @@
+options gen2
+options indenting = 4
+
+// scratch probe: OUR dasSpirv port of llama.cpp's matmul_q8_0_f32_f16acc_aligned_l config vs THEIR
+// compiled spv, same device buffers, one shape (the 24-TF headline: m=9728 k=2560 n=512).
+// Their exact geometry: BM=128 BN=128 BK=32, 4 warps in 2x2, each warp 64x64 = 4x4 f16acc fragments
+// (16 MMAs per TK step, A frag cached per row, B frag loaded per MMA), shared f16 pairs SST=BK/2+4.
+// A is the gguf block_q8_0 byte stream (d f16 + 32 qs = 17 uint16s), dequantized during staging;
+// B is f32, converted to f16 during staging. Success = matching their TFLOPS on the same harness.
+
+require vulkan public
+require vulkan/vulkan_boost public
+require spirv/spirv_shader
+require spirv/spirv_builtins public
+require daslib/fio
+require math
+
+let SPV_PATH = "D:/Work/llama.cpp/build-vulkan/ggml/src/ggml-vulkan/vulkan-shaders.spv/matmul_q8_0_f32_f16acc_cm1.spv"
+
+let N = 512              // tokens (all in-graph prefill GEMMs run n=512)
+let DISPATCHES = 32
+
+let SST = 20             // shared row stride in uints (f16 pairs): BK/2/2 uints data (8) ... 16 f16 + 4 pad v2 = 20 v2 units == 20 uints? (v2=2 f16=1 uint)
+
+// their l_warptile_mmq spec for the reference pipeline
+let SPEC = fixed_array<uint>(128u, 128u, 128u, 32u, 64u, 64u, 2u, 16u, 16u, 16u, 32u, 1u)
+
+// ===== OUR kernel =====
+// bindings: 0 = A as uint16 view of gguf q8_0 blocks (17 u16/block), 1 = B f32, 2 = D f32 (ours),
+// 3 = meta [0]=M [1]=K [2]=NBK (runtime shape — the integration-realistic form)
+var @ssbo @binding = 0 vk_aq : array<uint16>
+var @ssbo @binding = 1 vk_bf : array<float>
+var @ssbo @binding = 2 vk_y : array<float>
+var @ssbo @binding = 3 vk_meta : array<uint>
+
+var @workgroup buf_a : uint[2560]   // 128 rows x SST uints (f16 pairs, K contiguous)
+var @workgroup buf_b : uint[2560]   // 128 cols x SST
+
+[compute_shader(local_size_x=128, name="ourmm_spv")]
+def ourmm_kernel {
+    let mm = int(vk_meta[0])
+    let kk = int(vk_meta[1])
+    let nbk = int(vk_meta[2])
+    let ir = int(gl_WorkGroupID.x)            // M tile
+    let ic = int(gl_WorkGroupID.y)            // N tile
+    let gm0 = ir * 128
+    let gn0 = ic * 128
+    let tid = int(gl_LocalInvocationID.x)
+    let warp_i = int(gl_SubgroupID)
+    let warp_r = warp_i % 2                   // BM/WM = 2
+    let warp_c = warp_i / 2
+    // staging map: 8 uint-pair slots per 32-K block row; 16 rows per pass
+    let lw = tid % 8                          // which pair-of-u16 (4 qs) in the row's block
+    let lr0 = tid / 8                         // row base 0..15
+    var acc00 : coopmatAcc_f16_16x16
+    var acc01 : coopmatAcc_f16_16x16
+    var acc02 : coopmatAcc_f16_16x16
+    var acc03 : coopmatAcc_f16_16x16
+    var acc10 : coopmatAcc_f16_16x16
+    var acc11 : coopmatAcc_f16_16x16
+    var acc12 : coopmatAcc_f16_16x16
+    var acc13 : coopmatAcc_f16_16x16
+    var acc20 : coopmatAcc_f16_16x16
+    var acc21 : coopmatAcc_f16_16x16
+    var acc22 : coopmatAcc_f16_16x16
+    var acc23 : coopmatAcc_f16_16x16
+    var acc30 : coopmatAcc_f16_16x16
+    var acc31 : coopmatAcc_f16_16x16
+    var acc32 : coopmatAcc_f16_16x16
+    var acc33 : coopmatAcc_f16_16x16
+    var kb = 0
+    while (kb < nbk) {
+        // stage A: 128 rows x one q8_0 block each — d = u16[ib*17], qs pairs at u16[ib*17+1..16]
+        for [unroll] (p in range(8)) {
+            let row = lr0 + p * 16
+            let ib = (gm0 + row) * nbk + kb
+            let d = unpackHalf2x16(uint(vk_aq[ib * 17])).x
+            let q0 = uint(vk_aq[ib * 17 + 1 + lw * 2])
+            let q1 = uint(vk_aq[ib * 17 + 2 + lw * 2])
+            let v = float4(int4(unpack8(int(q0 | (q1 << 16u))))) * d
+            let o = row * SST + lw * 2
+            buf_a[o] = packHalf2x16(v.xy)
+            buf_a[o + 1] = packHalf2x16(v.zw)
+        }
+        // stage B: 128 cols x 32 K f32 -> f16 pairs
+        for [unroll] (p in range(8)) {
+            let col = lr0 + p * 16
+            let base = (gn0 + col) * kk + kb * 32 + lw * 4
+            let v = float4(vk_bf[base], vk_bf[base + 1], vk_bf[base + 2], vk_bf[base + 3])
+            let o = col * SST + lw * 2
+            buf_b[o] = packHalf2x16(v.xy)
+            buf_b[o + 1] = packHalf2x16(v.zw)
+        }
+        barrier()
+        // 2 TK steps x (4 A rows x 4 B cols): A cached per row, B loaded per MMA — their order
+        for [unroll] (ks in range(2)) {
+            var ca : coopmatA_f16_16x16
+            var cb : coopmatB_f16_16x16
+            coopmatLoad(ca, buf_a, (warp_r * 64) * SST + ks * 8, SST, 0)
+            coopmatLoad(cb, buf_b, (warp_c * 64) * SST + ks * 8, SST, 1)
+            acc00 = coopmatMulAdd(ca, cb, acc00)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 16) * SST + ks * 8, SST, 1)
+            acc01 = coopmatMulAdd(ca, cb, acc01)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 32) * SST + ks * 8, SST, 1)
+            acc02 = coopmatMulAdd(ca, cb, acc02)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 48) * SST + ks * 8, SST, 1)
+            acc03 = coopmatMulAdd(ca, cb, acc03)
+            coopmatLoad(ca, buf_a, (warp_r * 64 + 16) * SST + ks * 8, SST, 0)
+            coopmatLoad(cb, buf_b, (warp_c * 64) * SST + ks * 8, SST, 1)
+            acc10 = coopmatMulAdd(ca, cb, acc10)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 16) * SST + ks * 8, SST, 1)
+            acc11 = coopmatMulAdd(ca, cb, acc11)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 32) * SST + ks * 8, SST, 1)
+            acc12 = coopmatMulAdd(ca, cb, acc12)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 48) * SST + ks * 8, SST, 1)
+            acc13 = coopmatMulAdd(ca, cb, acc13)
+            coopmatLoad(ca, buf_a, (warp_r * 64 + 32) * SST + ks * 8, SST, 0)
+            coopmatLoad(cb, buf_b, (warp_c * 64) * SST + ks * 8, SST, 1)
+            acc20 = coopmatMulAdd(ca, cb, acc20)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 16) * SST + ks * 8, SST, 1)
+            acc21 = coopmatMulAdd(ca, cb, acc21)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 32) * SST + ks * 8, SST, 1)
+            acc22 = coopmatMulAdd(ca, cb, acc22)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 48) * SST + ks * 8, SST, 1)
+            acc23 = coopmatMulAdd(ca, cb, acc23)
+            coopmatLoad(ca, buf_a, (warp_r * 64 + 48) * SST + ks * 8, SST, 0)
+            coopmatLoad(cb, buf_b, (warp_c * 64) * SST + ks * 8, SST, 1)
+            acc30 = coopmatMulAdd(ca, cb, acc30)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 16) * SST + ks * 8, SST, 1)
+            acc31 = coopmatMulAdd(ca, cb, acc31)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 32) * SST + ks * 8, SST, 1)
+            acc32 = coopmatMulAdd(ca, cb, acc32)
+            coopmatLoad(cb, buf_b, (warp_c * 64 + 48) * SST + ks * 8, SST, 1)
+            acc33 = coopmatMulAdd(ca, cb, acc33)
+        }
+        barrier()
+        kb++
+    }
+    // stores: D[n][m] (stride M), fragment M-dim contiguous = column-major
+    let dr = gm0 + warp_r * 64
+    let dc = gn0 + warp_c * 64
+    var accw : coopmatAcc_f32_16x16
+    coopmatConvert(accw, acc00)
+    coopmatStore(accw, vk_y, dc * mm + dr, mm, 1)
+    coopmatConvert(accw, acc01)
+    coopmatStore(accw, vk_y, (dc + 16) * mm + dr, mm, 1)
+    coopmatConvert(accw, acc02)
+    coopmatStore(accw, vk_y, (dc + 32) * mm + dr, mm, 1)
+    coopmatConvert(accw, acc03)
+    coopmatStore(accw, vk_y, (dc + 48) * mm + dr, mm, 1)
+    coopmatConvert(accw, acc10)
+    coopmatStore(accw, vk_y, dc * mm + dr + 16, mm, 1)
+    coopmatConvert(accw, acc11)
+    coopmatStore(accw, vk_y, (dc + 16) * mm + dr + 16, mm, 1)
+    coopmatConvert(accw, acc12)
+    coopmatStore(accw, vk_y, (dc + 32) * mm + dr + 16, mm, 1)
+    coopmatConvert(accw, acc13)
+    coopmatStore(accw, vk_y, (dc + 48) * mm + dr + 16, mm, 1)
+    coopmatConvert(accw, acc20)
+    coopmatStore(accw, vk_y, dc * mm + dr + 32, mm, 1)
+    coopmatConvert(accw, acc21)
+    coopmatStore(accw, vk_y, (dc + 16) * mm + dr + 32, mm, 1)
+    coopmatConvert(accw, acc22)
+    coopmatStore(accw, vk_y, (dc + 32) * mm + dr + 32, mm, 1)
+    coopmatConvert(accw, acc23)
+    coopmatStore(accw, vk_y, (dc + 48) * mm + dr + 32, mm, 1)
+    coopmatConvert(accw, acc30)
+    coopmatStore(accw, vk_y, dc * mm + dr + 48, mm, 1)
+    coopmatConvert(accw, acc31)
+    coopmatStore(accw, vk_y, (dc + 16) * mm + dr + 48, mm, 1)
+    coopmatConvert(accw, acc32)
+    coopmatStore(accw, vk_y, (dc + 32) * mm + dr + 48, mm, 1)
+    coopmatConvert(accw, acc33)
+    coopmatStore(accw, vk_y, (dc + 48) * mm + dr + 48, mm, 1)
+}
+
+// ===== harness =====
+
+def private s8b(v : int) : uint8 => uint8(v & 0xFF)
+
+def private f32_of(buf : array<uint8>; i : int) : float {
+    let w = uint(buf[i * 4]) | (uint(buf[i * 4 + 1]) << 8u) | (uint(buf[i * 4 + 2]) << 16u) | (uint(buf[i * 4 + 3]) << 24u)
+    return unsafe(reinterpret<float>(w))
+}
+
+def private put_f32(var buf : array<uint8>; i : int; v : float) {
+    let w = unsafe(reinterpret<uint>(v))
+    buf[i * 4] = uint8(w & 0xFFu)
+    buf[i * 4 + 1] = uint8((w >> 8u) & 0xFFu)
+    buf[i * 4 + 2] = uint8((w >> 16u) & 0xFFu)
+    buf[i * 4 + 3] = uint8((w >> 24u) & 0xFFu)
+}
+
+def private put_half_at(var buf : array<uint8>; byte_off : int; v : float) {
+    let bits = packHalf2x16(float2(v, 0.0)) & 0xFFFFu
+    buf[byte_off] = uint8(bits & 0xFFu)
+    buf[byte_off + 1] = uint8((bits >> 8u) & 0xFFu)
+}
+
+struct DevBuf {
+    buf : Buffer
+    mem : DeviceMemory
+    bytes : int
+}
+
+def private make_dev_buf(var device : Device; phys : VkPhysicalDevice; bytes : int) : DevBuf {
+    var r : DevBuf
+    r.bytes = bytes
+    var bci : BufferCreateInfo
+    bci.size = uint64(bytes)
+    bci.usage.storage_buffer = true
+    bci.usage.transfer_dst = true
+    bci.usage.transfer_src = true
+    r.buf <- create_buffer(device, bci)
+    var req : VkMemoryRequirements
+    vkGetBufferMemoryRequirements(boost_value_to_vk(device), boost_value_to_vk(r.buf), req)
+    var want : VkMemoryPropertyFlags
+    want.device_local = true
+    let mai = MemoryAllocateInfo(allocationSize = req.size, memoryTypeIndex = find_memory_type(phys, req.memoryTypeBits, want))
+    r.mem <- allocate_memory(device, mai)
+    vk_check(vkBindBufferMemory(boost_value_to_vk(device), boost_value_to_vk(r.buf), boost_value_to_vk(r.mem), 0ul), null)
+    return <- r
+}
+
+def private staging_roundtrip(var device : Device; phys : VkPhysicalDevice; var pool : CommandPool;
+                              queue : VkQueue; var db : DevBuf; var host : array<uint8>; upload : bool) {
+    var bci : BufferCreateInfo
+    bci.size = uint64(db.bytes)
+    bci.usage.transfer_src = true
+    bci.usage.transfer_dst = true
+    var inscope stage <- create_buffer(device, bci)
+    var req : VkMemoryRequirements
+    vkGetBufferMemoryRequirements(boost_value_to_vk(device), boost_value_to_vk(stage), req)
+    var want : VkMemoryPropertyFlags
+    want.host_visible = true
+    want.host_coherent = true
+    let mai = MemoryAllocateInfo(allocationSize = req.size, memoryTypeIndex = find_memory_type(phys, req.memoryTypeBits, want))
+    var inscope smem <- allocate_memory(device, mai)
+    vk_check(vkBindBufferMemory(boost_value_to_vk(device), boost_value_to_vk(stage), boost_value_to_vk(smem), 0ul), null)
+    var mapped : void? = null
+    let mf : VkMemoryMapFlags
+    if (upload) {
+        unsafe {
+            vk_check(vkMapMemory(boost_value_to_vk(device), boost_value_to_vk(smem), 0ul, uint64(db.bytes), mf, addr(mapped)), null)
+            memcpy(mapped, addr<void?>(host[0]), db.bytes)
+        }
+        vkUnmapMemory(boost_value_to_vk(device), boost_value_to_vk(smem))
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            var region : VkBufferCopy
+            region.size = uint64(db.bytes)
+            unsafe {
+                vkCmdCopyBuffer(boost_value_to_vk(cmd), boost_value_to_vk(stage), boost_value_to_vk(db.buf), 1u, addr(region))
+            }
+        }
+    } else {
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            var region : VkBufferCopy
+            region.size = uint64(db.bytes)
+            unsafe {
+                vkCmdCopyBuffer(boost_value_to_vk(cmd), boost_value_to_vk(db.buf), boost_value_to_vk(stage), 1u, addr(region))
+            }
+        }
+        unsafe {
+            vk_check(vkMapMemory(boost_value_to_vk(device), boost_value_to_vk(smem), 0ul, uint64(db.bytes), mf, addr(mapped)), null)
+            memcpy(addr<void?>(host[0]), mapped, db.bytes)
+        }
+        vkUnmapMemory(boost_value_to_vk(device), boost_value_to_vk(smem))
+    }
+}
+
+def private record_chain(rawcmd : VkCommandBuffer; rpipe : VkPipeline; rlayout : VkPipelineLayout;
+                         var rset : VkDescriptorSet; pc : uint[17]; use_pc : bool; gx, gy : uint; count : int) {
+    var flags : VkShaderStageFlags
+    flags.compute = true
+    var mbar = VkMemoryBarrier()
+    mbar.srcAccessMask.shader_write = true
+    mbar.dstAccessMask.shader_read = true
+    mbar.dstAccessMask.shader_write = true
+    var stg : VkPipelineStageFlags
+    stg.compute_shader = true
+    var pcl = pc
+    unsafe {
+        vkCmdBindPipeline(rawcmd, VkPipelineBindPoint.COMPUTE, rpipe)
+        vkCmdBindDescriptorSets(rawcmd, VkPipelineBindPoint.COMPUTE, rlayout, 0u, 1u, addr(rset), 0u, null)
+        if (use_pc) {
+            vkCmdPushConstants(rawcmd, rlayout, flags, 0u, 68u, addr<void?>(pcl[0]))
+        }
+        for (i in range(count)) {
+            vkCmdDispatch(rawcmd, gx, gy, 1u)
+            if (i + 1 < count) {
+                let df : VkDependencyFlags
+                vkCmdPipelineBarrier(rawcmd, stg, stg, df, 1u, addr(mbar), 0u, null, 0u, null)
+            }
+        }
+    }
+}
+
+def private write_set4(var device : Device; set_ : VkDescriptorSet; b0, b1, b2, b3 : DevBuf) {
+    var writes : array<WriteDescriptorSet>
+    var w0 = WriteDescriptorSet(dstSet = vk_value_to_boost(set_), dstBinding = 0u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+    w0.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(b0.buf), range_ = uint64(b0.bytes)))
+    writes |> emplace(w0)
+    var w1 = WriteDescriptorSet(dstSet = vk_value_to_boost(set_), dstBinding = 1u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+    w1.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(b1.buf), range_ = uint64(b1.bytes)))
+    writes |> emplace(w1)
+    var w2 = WriteDescriptorSet(dstSet = vk_value_to_boost(set_), dstBinding = 2u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+    w2.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(b2.buf), range_ = uint64(b2.bytes)))
+    writes |> emplace(w2)
+    var w3 = WriteDescriptorSet(dstSet = vk_value_to_boost(set_), dstBinding = 3u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+    w3.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(b3.buf), range_ = uint64(b3.bytes)))
+    writes |> emplace(w3)
+    let no_copies : array<CopyDescriptorSet>
+    update_descriptor_sets(device, writes, no_copies)
+}
+
+// one warmup then DISPATCHES-chain reps; returns best us/dispatch
+def private bench_pipe(var device : Device; var pool : CommandPool; queue : VkQueue;
+                       rpipe : VkPipeline; rlayout : VkPipelineLayout; var set_ : VkDescriptorSet;
+                       pc : uint[17]; use_pc : bool; gx, gy : uint) : double {
+    run_cmd_sync(device, pool, queue) $(cmd) {
+        record_chain(boost_value_to_vk(cmd), rpipe, rlayout, set_, pc, use_pc, gx, gy, 1)
+    }
+    var best_us = 1.0e30lf
+    for (_rep in range(5)) {
+        let t0 = ref_time_ticks()
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            record_chain(boost_value_to_vk(cmd), rpipe, rlayout, set_, pc, use_pc, gx, gy, DISPATCHES)
+        }
+        let us = double(get_time_usec(t0)) / double(DISPATCHES)
+        if (us < best_us) { best_us = us }
+    }
+    return best_us
+}
+
+def private make_raw_pipeline(dev : VkDevice; shader_words : array<uint>; var rlayout : VkPipelineLayout;
+                              use_spec : bool) : VkPipeline {
+    var words := shader_words
+    var smci = VkShaderModuleCreateInfo()
+    smci.codeSize = uint64(length(words) * 4)
+    var raw_shader : VkShaderModule
+    var entries : VkSpecializationMapEntry[12]
+    for (i in range(12)) {
+        entries[i].constantID = uint(i)
+        entries[i].offset = uint(i * 4)
+        entries[i].size = uint64(4)
+    }
+    var spec_vals = SPEC
+    var spec_info : VkSpecializationInfo
+    spec_info.mapEntryCount = 12u
+    spec_info.dataSize = uint64(48)
+    var stage = VkPipelineShaderStageCreateInfo()
+    stage.stage.compute = true
+    stage.flags.require_full_subgroups = true
+    stage.pName = "main"
+    var cp = VkComputePipelineCreateInfo()
+    cp.layout = rlayout
+    cp.flags.capture_statistics_khr = true
+    var raw_pipe : VkPipeline
+    unsafe {
+        smci.pCode = addr(words[0])
+        vk_check(vkCreateShaderModule(dev, smci, null, raw_shader), null)
+        stage.module_ = raw_shader
+        if (use_spec) {
+            spec_info.pMapEntries = addr(entries[0])
+            spec_info.pData = addr<void?>(spec_vals[0])
+            stage.pSpecializationInfo = addr(spec_info)
+        }
+        cp.stage = stage
+        vk_check(vkCreateComputePipelines(dev, null, 1u, addr(cp), null, addr(raw_pipe)), null)
+    }
+    delete words
+    return raw_pipe
+}
+
+[export]
+def main {
+    if (volkInitialize() != 0) {
+        to_log(LOG_ERROR, "no Vulkan loader\n")
+        return
+    }
+    var their_words : array<uint>
+    var spv_bytes : array<uint8>
+    fopen(SPV_PATH, "rb") $(f) {
+        if (f != null) {
+            fmap(f) $(data) {
+                spv_bytes |> resize(length(data))
+                unsafe {
+                    memcpy(addr<void?>(spv_bytes[0]), addr<void? const?>(data[0]), length(data))
+                }
+            }
+        }
+    }
+    if (empty(spv_bytes)) {
+        print("FAILED to read {SPV_PATH}\n")
+        return
+    }
+    their_words |> resize(length(spv_bytes) / 4)
+    for (i in range(length(their_words))) {
+        their_words[i] = uint(spv_bytes[i * 4]) | (uint(spv_bytes[i * 4 + 1]) << 8u) | (uint(spv_bytes[i * 4 + 2]) << 16u) | (uint(spv_bytes[i * 4 + 3]) << 24u)
+    }
+
+    var inscope instance <- create_instance("coopmat mulmm port", make_api_version(1u, 3u, 0u))
+    volkLoadInstance(boost_value_to_vk(instance))
+    let phys = select_physical_device(instance)
+    if (!cooperative_matrix_supported(phys)) {
+        to_log(LOG_WARNING, "device lacks VK_KHR_cooperative_matrix; skipping\n")
+        return
+    }
+    let gfx = select_graphics_queue_family(phys)
+    var inscope device <- create_device_coopmat_full_subgroups(phys, gfx)
+    volkLoadDevice(boost_value_to_vk(device))
+    let dev = boost_value_to_vk(device)
+    let queue = get_device_queue(device, gfx, 0u)
+    var cpci : CommandPoolCreateInfo
+    cpci.queueFamilyIndex = gfx
+    var inscope pool <- create_command_pool(device, cpci)
+
+    // shared descriptor layout: 4 storage buffers (theirs uses 0-2, ours also binds meta at 3)
+    var dslci : DescriptorSetLayoutCreateInfo
+    dslci.pBindings |> reserve(4)
+    for (bi in range(4)) {
+        var b0 = DescriptorSetLayoutBinding(binding = uint(bi), descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+        b0.stageFlags.compute = true
+        dslci.pBindings |> emplace(b0)
+    }
+    var inscope set_layout <- create_descriptor_set_layout(device, dslci)
+    var dpci : DescriptorPoolCreateInfo
+    dpci.maxSets = 32u
+    dpci.pPoolSizes |> push(DescriptorPoolSize(type_ = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 128u))
+    var inscope desc_pool <- create_descriptor_pool(device, dpci)
+
+    // pipeline layouts: theirs (push constants), ours (none)
+    var plci_t : PipelineLayoutCreateInfo
+    plci_t.pSetLayouts <- [weak_copy(set_layout)]
+    var pcr : PushConstantRange
+    pcr.stageFlags.compute = true
+    pcr.size = 17u * 4u
+    plci_t.pPushConstantRanges |> push(pcr)
+    var inscope layout_t <- create_pipeline_layout(device, plci_t)
+    var plci_o : PipelineLayoutCreateInfo
+    plci_o.pSetLayouts <- [weak_copy(set_layout)]
+    var inscope layout_o <- create_pipeline_layout(device, plci_o)
+
+    let pipe_theirs = make_raw_pipeline(dev, their_words, boost_value_to_vk(layout_t), true)
+    var our_words <- clone_to_move(ourmm_spv)
+    let pipe_ours = make_raw_pipeline(dev, our_words, boost_value_to_vk(layout_o), false)
+
+    // stats for ours (theirs already dumped by _lcpp_mulmm_isolated)
+    var inscope pw <- vk_value_to_boost(pipe_ours)
+    pw._needs_delete = true
+    pw._device = unsafe(reinterpret<uint64>(dev))
+    if (device_extension_available(phys, "VK_KHR_pipeline_executable_properties")) {
+        let report = dump_pipeline_executables(device, pw)
+        fwrite("D:/Work/daScript/_ourmm_stats.txt", report)
+    }
+
+    var ms : array<int> <- [1024, 4096, 9728, 2560, 3072, 4096]
+    var ks : array<int> <- [2560, 2560, 2560, 9728, 3072, 14336]
+    for (m, k in ms, ks) {
+        let nbk = k / 32
+        // data: biased (non-cancelling) synthetic, f16-exact values
+        var a_bytes : array<uint8>
+        a_bytes |> resize(m * nbk * 34)
+        for (r in range(m)) {
+            for (b in range(nbk)) {
+                let off = (r * nbk + b) * 34
+                put_half_at(a_bytes, off, float((r + b) % 4 + 1) * 0.03125)
+                for (j in range(32)) {
+                    a_bytes[off + 2 + j] = s8b((r + b * 32 + j) % 5 - 1)
+                }
+            }
+        }
+        var b_bytes : array<uint8>
+        b_bytes |> resize(N * k * 4)
+        for (r in range(N)) {
+            for (j in range(k)) {
+                put_f32(b_bytes, r * k + j, float((r * 2 + j) % 7 - 2) * 0.03125)
+            }
+        }
+        var meta_bytes : array<uint8>
+        meta_bytes |> resize(16)
+        unsafe {
+            var mp = addr<uint?>(meta_bytes[0])
+            mp[0] = uint(m); mp[1] = uint(k); mp[2] = uint(nbk); mp[3] = 0u
+        }
+        var d_theirs : array<uint8>
+        d_theirs |> resize(m * N * 4)
+        var d_ours : array<uint8>
+        d_ours |> resize(m * N * 4)
+
+        var da <- make_dev_buf(device, phys, length(a_bytes))
+        var db <- make_dev_buf(device, phys, length(b_bytes))
+        var dmeta <- make_dev_buf(device, phys, length(meta_bytes))
+        var dt <- make_dev_buf(device, phys, length(d_theirs))
+        var douts <- make_dev_buf(device, phys, length(d_ours))
+        staging_roundtrip(device, phys, pool, queue, da, a_bytes, true)
+        staging_roundtrip(device, phys, pool, queue, db, b_bytes, true)
+        staging_roundtrip(device, phys, pool, queue, dmeta, meta_bytes, true)
+
+        var set_theirs : VkDescriptorSet
+        var set_ours : VkDescriptorSet
+        var dsai = VkDescriptorSetAllocateInfo()
+        dsai.descriptorPool = boost_value_to_vk(desc_pool)
+        dsai.descriptorSetCount = 1u
+        var rsl = boost_value_to_vk(set_layout)
+        unsafe {
+            dsai.pSetLayouts = addr(rsl)
+            vk_check(vkAllocateDescriptorSets(dev, dsai, addr(set_theirs)), null)
+            vk_check(vkAllocateDescriptorSets(dev, dsai, addr(set_ours)), null)
+        }
+        write_set4(device, set_theirs, da, db, dt, dmeta)
+        write_set4(device, set_ours, da, db, douts, dmeta)
+
+        var pc : uint[17]
+        pc[0] = uint(m); pc[1] = uint(N); pc[2] = uint(k)
+        pc[3] = uint(k); pc[4] = uint(k); pc[5] = uint(m)
+        pc[6] = uint(k * m); pc[7] = uint(k * N); pc[8] = uint(m * N)
+        pc[9] = 0u; pc[10] = 1u
+        pc[11] = uint(k)
+        pc[12] = 1u; pc[13] = 1u; pc[14] = 1u; pc[15] = 1u
+        pc[16] = uint(N)
+        let gx = uint(m / 128)
+        let gy = uint(N / 128)
+        let us_theirs = bench_pipe(device, pool, queue, pipe_theirs, boost_value_to_vk(layout_t), set_theirs, pc, true, gx, gy)
+        let us_ours = bench_pipe(device, pool, queue, pipe_ours, boost_value_to_vk(layout_o), set_ours, pc, false, gx, gy)
+        let ops = 2.0lf * double(m) * double(N) * double(k)
+        let tf_theirs = float(ops / (us_theirs * 1.0e6lf))
+        let tf_ours = float(ops / (us_ours * 1.0e6lf))
+
+        // outputs: D[n][m] stride m both — direct elementwise diff
+        staging_roundtrip(device, phys, pool, queue, dt, d_theirs, false)
+        staging_roundtrip(device, phys, pool, queue, douts, d_ours, false)
+        var bad = 0
+        var maxrel = 0.0
+        for (s in range(4096)) {
+            let i = (s * 121639) % (m * N)
+            let a = f32_of(d_theirs, i)
+            let b = f32_of(d_ours, i)
+            let rel = abs(a - b) / max(max(abs(a), abs(b)), 0.5)
+            if (rel > maxrel) { maxrel = rel }
+            if (rel > 0.02) { bad++ }
+        }
+        let verdict = bad == 0 ? "PASS" : "FAIL({bad}/4096, maxrel {maxrel})"
+        print("m={m} k={k} n={N}: theirs {us_theirs:.0f} us = {tf_theirs:.2f} TF | OURS {us_ours:.0f} us = {tf_ours:.2f} TF ({100.0 * tf_ours / tf_theirs:.1f}%) | diff {verdict}\n")
+
+        delete a_bytes
+        delete b_bytes
+        delete meta_bytes
+        delete d_theirs
+        delete d_ours
+        delete da
+        delete db
+        delete dmeta
+        delete dt
+        delete douts
+    }
+    delete ms
+    delete ks
+    delete their_words
+    delete spv_bytes
+}

--- a/modules/dasLLAMA/performance/coopmat_mulmm_reference.das
+++ b/modules/dasLLAMA/performance/coopmat_mulmm_reference.das
@@ -1,0 +1,419 @@
+options gen2
+options indenting = 4
+
+// scratch probe: run llama.cpp's OWN matmul_q8_0_f32_f16acc_aligned_l pipeline (the cm1/KHR-coopmat
+// mul_mm that clocks 13-27 TFLOPS in-graph) in OUR harness, on the exact in-graph shapes, isolated.
+// SPV straight from their build dir; spec constants = l_warptile_mmq + ALIGNED; push constants =
+// vk_mat_mat_push_constants exactly as the GGML_VULKAN_DEBUG dispatch lines showed. The question this
+// answers: does 17 TFLOPS exist OUTSIDE their graph, or is their own test-backend-ops' 1.78 the truth?
+
+require vulkan public
+require vulkan/vulkan_boost public
+require spirv/spirv_shader
+require spirv/spirv_builtins public
+require daslib/fio
+require math
+
+let SPV_PATH = "D:/Work/llama.cpp/build-vulkan/ggml/src/ggml-vulkan/vulkan-shaders.spv/matmul_q8_0_f32_f16acc_cm1.spv"
+let N_TOK = 512          // n (batch/tokens) — all in-graph prefill GEMMs run n=512
+let DISPATCHES = 32      // per timed submit, compute-barrier separated (the in-graph pattern)
+
+// l_warptile_mmq on this device (subgroup 32, KHR coopmat 16x16x16) + ALIGNED=1 at id 11:
+// BLOCK_SIZE BM BN BK WM WN WMITER TM TN TK WARP ALIGNED
+let SPEC = fixed_array<uint>(128u, 128u, 128u, 32u, 64u, 64u, 2u, 16u, 16u, 16u, 32u, 1u)
+
+struct Shape {
+    m : int      // output features (weight rows)
+    k : int      // contraction
+    graph_tf : float   // what the perf logger showed in-graph (qwen3-4B/llama-3B runs)
+    tbo_tf : float     // what their test-backend-ops showed for the same shape
+}
+
+def private s8b(v : int) : uint8 => uint8(v & 0xFF)
+
+def private s8_ref(v : uint8) : int {
+    var x = int(v)
+    if (x > 127) { x -= 256 }
+    return x
+}
+
+def private put_half_at(var buf : array<uint8>; byte_off : int; v : float) {
+    let bits = packHalf2x16(float2(v, 0.0)) & 0xFFFFu
+    buf[byte_off] = uint8(bits & 0xFFu)
+    buf[byte_off + 1] = uint8((bits >> 8u) & 0xFFu)
+}
+
+def private f32_of(buf : array<uint8>; i : int) : float {
+    let w = uint(buf[i * 4]) | (uint(buf[i * 4 + 1]) << 8u) | (uint(buf[i * 4 + 2]) << 16u) | (uint(buf[i * 4 + 3]) << 24u)
+    return unsafe(reinterpret<float>(w))
+}
+
+def private put_f32(var buf : array<uint8>; i : int; v : float) {
+    let w = unsafe(reinterpret<uint>(v))
+    buf[i * 4] = uint8(w & 0xFFu)
+    buf[i * 4 + 1] = uint8((w >> 8u) & 0xFFu)
+    buf[i * 4 + 2] = uint8((w >> 16u) & 0xFFu)
+    buf[i * 4 + 3] = uint8((w >> 24u) & 0xFFu)
+}
+
+// device-local buffer + staged upload (matches the graph: A/B/D live in DEVICE_LOCAL memory)
+struct DevBuf {
+    buf : Buffer
+    mem : DeviceMemory
+    bytes : int
+}
+
+def private make_dev_buf(var device : Device; phys : VkPhysicalDevice; bytes : int) : DevBuf {
+    var r : DevBuf
+    r.bytes = bytes
+    var bci : BufferCreateInfo
+    bci.size = uint64(bytes)
+    bci.usage.storage_buffer = true
+    bci.usage.transfer_dst = true
+    bci.usage.transfer_src = true
+    r.buf <- create_buffer(device, bci)
+    var req : VkMemoryRequirements
+    vkGetBufferMemoryRequirements(boost_value_to_vk(device), boost_value_to_vk(r.buf), req)
+    var want : VkMemoryPropertyFlags
+    want.device_local = true
+    let mai = MemoryAllocateInfo(allocationSize = req.size, memoryTypeIndex = find_memory_type(phys, req.memoryTypeBits, want))
+    r.mem <- allocate_memory(device, mai)
+    vk_check(vkBindBufferMemory(boost_value_to_vk(device), boost_value_to_vk(r.buf), boost_value_to_vk(r.mem), 0ul), null)
+    return <- r
+}
+
+def private staging_roundtrip(var device : Device; phys : VkPhysicalDevice; var pool : CommandPool;
+                              queue : VkQueue; var db : DevBuf; var host : array<uint8>; upload : bool) {
+    var bci : BufferCreateInfo
+    bci.size = uint64(db.bytes)
+    bci.usage.transfer_src = true
+    bci.usage.transfer_dst = true
+    var inscope stage <- create_buffer(device, bci)
+    var req : VkMemoryRequirements
+    vkGetBufferMemoryRequirements(boost_value_to_vk(device), boost_value_to_vk(stage), req)
+    var want : VkMemoryPropertyFlags
+    want.host_visible = true
+    want.host_coherent = true
+    let mai = MemoryAllocateInfo(allocationSize = req.size, memoryTypeIndex = find_memory_type(phys, req.memoryTypeBits, want))
+    var inscope smem <- allocate_memory(device, mai)
+    vk_check(vkBindBufferMemory(boost_value_to_vk(device), boost_value_to_vk(stage), boost_value_to_vk(smem), 0ul), null)
+    var mapped : void? = null
+    let mf : VkMemoryMapFlags
+    if (upload) {
+        unsafe {
+            vk_check(vkMapMemory(boost_value_to_vk(device), boost_value_to_vk(smem), 0ul, uint64(db.bytes), mf, addr(mapped)), null)
+            memcpy(mapped, addr<void?>(host[0]), db.bytes)
+        }
+        vkUnmapMemory(boost_value_to_vk(device), boost_value_to_vk(smem))
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            var region : VkBufferCopy
+            region.size = uint64(db.bytes)
+            unsafe {
+                vkCmdCopyBuffer(boost_value_to_vk(cmd), boost_value_to_vk(stage), boost_value_to_vk(db.buf), 1u, addr(region))
+            }
+        }
+    } else {
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            var region : VkBufferCopy
+            region.size = uint64(db.bytes)
+            unsafe {
+                vkCmdCopyBuffer(boost_value_to_vk(cmd), boost_value_to_vk(db.buf), boost_value_to_vk(stage), 1u, addr(region))
+            }
+        }
+        unsafe {
+            vk_check(vkMapMemory(boost_value_to_vk(device), boost_value_to_vk(smem), 0ul, uint64(db.bytes), mf, addr(mapped)), null)
+            memcpy(addr<void?>(host[0]), mapped, db.bytes)
+        }
+        vkUnmapMemory(boost_value_to_vk(device), boost_value_to_vk(smem))
+    }
+}
+
+// all-raw recording (no boost-wrapper captures): bind, push constants, count dispatches with
+// compute-compute barriers between (the in-graph dependent-chain pattern)
+def private record_gemm(rawcmd : VkCommandBuffer; rpipe : VkPipeline; rlayout : VkPipelineLayout;
+                        var rset : VkDescriptorSet; pc : uint[17]; gx, gy : uint; count : int) {
+    var flags : VkShaderStageFlags
+    flags.compute = true
+    var mbar = VkMemoryBarrier()
+    mbar.srcAccessMask.shader_write = true
+    mbar.dstAccessMask.shader_read = true
+    mbar.dstAccessMask.shader_write = true
+    var stg : VkPipelineStageFlags
+    stg.compute_shader = true
+    var pcl = pc
+    unsafe {
+        vkCmdBindPipeline(rawcmd, VkPipelineBindPoint.COMPUTE, rpipe)
+        vkCmdBindDescriptorSets(rawcmd, VkPipelineBindPoint.COMPUTE, rlayout, 0u, 1u, addr(rset), 0u, null)
+        vkCmdPushConstants(rawcmd, rlayout, flags, 0u, 68u, addr<void?>(pcl[0]))
+        for (i in range(count)) {
+            vkCmdDispatch(rawcmd, gx, gy, 1u)
+            if (i + 1 < count) {
+                let df : VkDependencyFlags
+                vkCmdPipelineBarrier(rawcmd, stg, stg, df, 1u, addr(mbar), 0u, null, 0u, null)
+            }
+        }
+    }
+}
+
+[export]
+def main {
+    if (volkInitialize() != 0) {
+        to_log(LOG_ERROR, "no Vulkan loader\n")
+        return
+    }
+    var spv_bytes : array<uint8>
+    fopen(SPV_PATH, "rb") $(f) {
+        if (f != null) {
+            fmap(f) $(data) {
+                spv_bytes |> resize(length(data))
+                unsafe {
+                    memcpy(addr<void?>(spv_bytes[0]), addr<void? const?>(data[0]), length(data))
+                }
+            }
+        }
+    }
+    if (empty(spv_bytes)) {
+        print("FAILED to read {SPV_PATH}\n")
+        return
+    }
+    var words : array<uint>
+    words |> resize(length(spv_bytes) / 4)
+    for (i in range(length(words))) {
+        words[i] = uint(spv_bytes[i * 4]) | (uint(spv_bytes[i * 4 + 1]) << 8u) | (uint(spv_bytes[i * 4 + 2]) << 16u) | (uint(spv_bytes[i * 4 + 3]) << 24u)
+    }
+    print("loaded {SPV_PATH}: {length(spv_bytes)} bytes\n")
+
+    var inscope instance <- create_instance("lcpp mulmm isolated", make_api_version(1u, 3u, 0u))
+    volkLoadInstance(boost_value_to_vk(instance))
+    let phys = select_physical_device(instance)
+    if (!cooperative_matrix_supported(phys)) {
+        to_log(LOG_WARNING, "device lacks VK_KHR_cooperative_matrix; skipping\n")
+        return
+    }
+    let gfx = select_graphics_queue_family(phys)
+    var inscope device <- create_device_coopmat_full_subgroups(phys, gfx)
+    volkLoadDevice(boost_value_to_vk(device))
+    let dev = boost_value_to_vk(device)
+    let queue = get_device_queue(device, gfx, 0u)
+
+    // descriptor layout: 3 storage buffers (A q8_0 blocks, B f32, D f32) — their binding order
+    var dslci : DescriptorSetLayoutCreateInfo
+    dslci.pBindings |> reserve(3)
+    for (bi in range(3)) {
+        var b0 = DescriptorSetLayoutBinding(binding = uint(bi), descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+        b0.stageFlags.compute = true
+        dslci.pBindings |> emplace(b0)
+    }
+    var inscope set_layout <- create_descriptor_set_layout(device, dslci)
+    var dpci : DescriptorPoolCreateInfo
+    dpci.maxSets = 8u
+    dpci.pPoolSizes |> push(DescriptorPoolSize(type_ = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 24u))
+    var inscope desc_pool <- create_descriptor_pool(device, dpci)
+
+    // pipeline layout: set 0 + the 17-word vk_mat_mat_push_constants block
+    var plci : PipelineLayoutCreateInfo
+    plci.pSetLayouts <- [weak_copy(set_layout)]
+    var pcr : PushConstantRange
+    pcr.stageFlags.compute = true
+    pcr.size = 17u * 4u
+    plci.pPushConstantRanges |> push(pcr)
+    var inscope pipe_layout <- create_pipeline_layout(device, plci)
+
+    // pipeline: their spv + their spec constants; require_full_subgroups like ggml_vk_create_pipeline
+    var inscope shader <- create_shader_module(device, words)
+    var entries : VkSpecializationMapEntry[12]
+    for (i in range(12)) {
+        entries[i].constantID = uint(i)
+        entries[i].offset = uint(i * 4)
+        entries[i].size = uint64(4)
+    }
+    var spec_vals = SPEC
+    var spec_info : VkSpecializationInfo
+    spec_info.mapEntryCount = 12u
+    spec_info.dataSize = uint64(48)
+    var stage = VkPipelineShaderStageCreateInfo()
+    stage.stage.compute = true
+    stage.flags.require_full_subgroups = true
+    stage.module_ = boost_value_to_vk(shader)
+    stage.pName = "main"
+    var cp = VkComputePipelineCreateInfo()
+    cp.layout = boost_value_to_vk(pipe_layout)
+    cp.flags.capture_statistics_khr = true
+    var raw_pipe : VkPipeline
+    unsafe {
+        spec_info.pMapEntries = addr(entries[0])
+        spec_info.pData = addr<void?>(spec_vals[0])
+        stage.pSpecializationInfo = addr(spec_info)
+        cp.stage = stage
+        vk_check(vkCreateComputePipelines(dev, null, 1u, addr(cp), null, addr(raw_pipe)), null)
+    }
+    var inscope pipeline <- vk_value_to_boost(raw_pipe)
+    pipeline._needs_delete = true
+    pipeline._device = unsafe(reinterpret<uint64>(dev))
+    if (device_extension_available(phys, "VK_KHR_pipeline_executable_properties")) {
+        let report = dump_pipeline_executables(device, pipeline)
+        if (fwrite("D:/Work/daScript/_lcpp_mulmm_stats.txt", report)) {
+            print("their pipeline stats -> D:/Work/daScript/_lcpp_mulmm_stats.txt\n")
+        }
+    }
+
+    var cpci : CommandPoolCreateInfo
+    cpci.queueFamilyIndex = gfx
+    var inscope pool <- create_command_pool(device, cpci)
+
+    // the shapes: in-graph rate vs their-test rate, from the perf-logger and test-backend-ops sessions
+    var shapes <- [
+        Shape(m = 1024, k = 2560, graph_tf = 13.2, tbo_tf = 1.66),
+        Shape(m = 4096, k = 2560, graph_tf = 15.1, tbo_tf = 1.70),
+        Shape(m = 9728, k = 2560, graph_tf = 17.2, tbo_tf = 1.38),
+        Shape(m = 2560, k = 9728, graph_tf = 18.0, tbo_tf = 3.70),
+        Shape(m = 3072, k = 3072, graph_tf = 23.9, tbo_tf = 1.97),
+        Shape(m = 4096, k = 14336, graph_tf = 0.0, tbo_tf = 1.78)]
+
+    for (sh in shapes) {
+        let m = sh.m
+        let k = sh.k
+        let n = N_TOK
+        let nbk = k / 32
+        // A: gguf block_q8_0 rows — d(f16) + 32 qs, 34B/block; crib's exact-in-f16 synthetic pattern
+        var a_bytes : array<uint8>
+        a_bytes |> resize(m * nbk * 34)
+        for (r in range(m)) {
+            for (b in range(nbk)) {
+                let off = (r * nbk + b) * 34
+                put_half_at(a_bytes, off, float((r + b) % 4 + 1) * 0.03125)
+                for (j in range(32)) {
+                    a_bytes[off + 2 + j] = s8b((r + b * 32 + j) % 5 - 1)   // mean +0.2: sums must NOT cancel (vacuous-validation guard)
+                }
+            }
+        }
+        // B: n rows x k f32, values exact in f16 (ints/32)
+        var b_bytes : array<uint8>
+        b_bytes |> resize(n * k * 4)
+        for (r in range(n)) {
+            for (j in range(k)) {
+                put_f32(b_bytes, r * k + j, float((r * 2 + j) % 7 - 2) * 0.03125)   // mean +0.14, same guard
+            }
+        }
+        var d_bytes : array<uint8>
+        d_bytes |> resize(m * n * 4)
+
+        var da <- make_dev_buf(device, phys, length(a_bytes))
+        var db <- make_dev_buf(device, phys, length(b_bytes))
+        var dd <- make_dev_buf(device, phys, length(d_bytes))
+        staging_roundtrip(device, phys, pool, queue, da, a_bytes, true)
+        staging_roundtrip(device, phys, pool, queue, db, b_bytes, true)
+
+        var dsai = VkDescriptorSetAllocateInfo()
+        dsai.descriptorPool = boost_value_to_vk(desc_pool)
+        dsai.descriptorSetCount = 1u
+        var raw_set_layout = boost_value_to_vk(set_layout)
+        var raw_set : VkDescriptorSet
+        unsafe {
+            dsai.pSetLayouts = addr(raw_set_layout)
+            vk_check(vkAllocateDescriptorSets(dev, dsai, addr(raw_set)), null)
+        }
+        var writes : array<WriteDescriptorSet>
+        var w0 = WriteDescriptorSet(dstSet = vk_value_to_boost(raw_set), dstBinding = 0u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+        w0.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(da.buf), range_ = uint64(da.bytes)))
+        writes |> emplace(w0)
+        var w1 = WriteDescriptorSet(dstSet = vk_value_to_boost(raw_set), dstBinding = 1u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+        w1.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(db.buf), range_ = uint64(db.bytes)))
+        writes |> emplace(w1)
+        var w2 = WriteDescriptorSet(dstSet = vk_value_to_boost(raw_set), dstBinding = 2u, descriptorType = VkDescriptorType.STORAGE_BUFFER, descriptorCount = 1u)
+        w2.pBufferInfo |> push(DescriptorBufferInfo(buffer = weak_copy(dd.buf), range_ = uint64(dd.bytes)))
+        writes |> emplace(w2)
+        let no_copies : array<CopyDescriptorSet>
+        update_descriptor_sets(device, writes, no_copies)
+
+        // push constants exactly as the in-graph debug line: strides in elements, k_split 1, padded_N = n
+        var pc : uint[17]
+        pc[0] = uint(m); pc[1] = uint(n); pc[2] = uint(k)
+        pc[3] = uint(k); pc[4] = uint(k); pc[5] = uint(m)
+        pc[6] = uint(k * m); pc[7] = uint(k * n); pc[8] = uint(m * n)
+        pc[9] = 0u; pc[10] = 1u
+        pc[11] = uint(k)   // k_split is the per-partition K SIZE — full K when unsplit (ggml_vk_matmul:8280)
+        pc[12] = 1u; pc[13] = 1u; pc[14] = 1u; pc[15] = 1u
+        pc[16] = uint(n)
+        let gx = uint((m + 127) / 128)
+        let gy = uint((n + 127) / 128)
+
+        // warmup (also produces D for validation)
+        run_cmd_sync(device, pool, queue) $(cmd) {
+            record_gemm(boost_value_to_vk(cmd), raw_pipe, boost_value_to_vk(pipe_layout), raw_set, pc, gx, gy, 1)
+        }
+        // did the kernel actually write? nonzero count over D after ONE dispatch
+        staging_roundtrip(device, phys, pool, queue, dd, d_bytes, false)
+        var nonzero = 0
+        for (i in range(m * n)) {
+            if (f32_of(d_bytes, i) != 0.0) { nonzero++ }
+        }
+        var one_us = 0.0lf
+        for (rep in range(3)) {
+            let t1 = ref_time_ticks()
+            run_cmd_sync(device, pool, queue) $(cmd) {
+                record_gemm(boost_value_to_vk(cmd), raw_pipe, boost_value_to_vk(pipe_layout), raw_set, pc, gx, gy, 1)
+            }
+            let us1 = double(get_time_usec(t1))
+            if (rep == 0 || us1 < one_us) { one_us = us1 }
+        }
+        var best_us = 1.0e30lf
+        for (_rep in range(5)) {
+            let t0 = ref_time_ticks()
+            run_cmd_sync(device, pool, queue) $(cmd) {
+                record_gemm(boost_value_to_vk(cmd), raw_pipe, boost_value_to_vk(pipe_layout), raw_set, pc, gx, gy, DISPATCHES)
+            }
+            let us = double(get_time_usec(t0)) / double(DISPATCHES)
+            if (us < best_us) { best_us = us }
+        }
+        print("  [nonzero {nonzero}/{m * n} after 1 dispatch; single-dispatch wall {one_us:.0f} us]\n")
+        let ops = 2.0lf * double(m) * double(n) * double(k)
+        let tflops = float(ops / (best_us * 1.0e6lf))
+
+        // validate a sample vs the f16-dequant reference (their math: A,B -> f16, f16acc MMA)
+        staging_roundtrip(device, phys, pool, queue, dd, d_bytes, false)
+        var bad = 0
+        var maxrel = 0.0
+        for (s in range(64)) {
+            let rm = (s * 37) % m
+            let rn = (s * 101) % n
+            // f16acc semantics: 16-wide chunks accumulate in higher precision inside one MMA, the
+            // running total is f16 between MMAs
+            var running = 0.0
+            var chunk = 0.0
+            var cn = 0
+            for (b in range(nbk)) {
+                let off = (rm * nbk + b) * 34
+                let d = unpackHalf2x16(uint(a_bytes[off]) | (uint(a_bytes[off + 1]) << 8u)).x
+                for (j in range(32)) {
+                    let aq = s8_ref(a_bytes[off + 2 + j])
+                    let bv = float((rn * 2 + (b * 32 + j)) % 7 - 2) * 0.03125
+                    chunk += float(float16(float(aq) * d)) * float(float16(bv))
+                    cn++
+                    if (cn == 16) {
+                        running = float(float16(running + chunk))
+                        chunk = 0.0
+                        cn = 0
+                    }
+                }
+            }
+            let ref = running
+            let got = f32_of(d_bytes, rn * m + rm)
+            let rel = abs(got - ref) / max(abs(ref), 0.5)
+            if (rel > maxrel) { maxrel = rel }
+            if (rel > 0.03) { bad++ }
+        }
+        let verdict = bad == 0 ? "PASS" : "FAIL({bad}/64, maxrel {maxrel})"
+        print("m={m} k={k} n={n}: {best_us:.0f} us/dispatch -> {tflops:.2f} TFLOPS  (in-graph {sh.graph_tf}, their-test {sh.tbo_tf})  {verdict}\n")
+
+        delete a_bytes
+        delete b_bytes
+        delete d_bytes
+        delete da
+        delete db
+        delete dd
+    }
+    delete shapes
+    delete words
+    delete spv_bytes
+}


### PR DESCRIPTION
Qwen3-4B on the resident Vulkan driver, start to finish of the stretch: **pp512 202 → 2465 t/s, tg16 11.5 → ~46 t/s — past llama.cpp Vulkan (2252 / 24.7) on the same gguf, same 3060 Ti.** Twelve commits, three threads.

## 1. The model family (what made qwen3 resident at all)

- **qk_norm role** — per-head q/k RMS between the projections and rope (`qk_rms` kernel, decode slot + prefill slot 16); `rdec_prepare` grew `qk_norm`, `resident_upload` lifts it and declines `q_gated` explicitly. Qwen3-4B arms resident with IDS == exact-CPU.

## 2. The kernels (the throughput)

- **mul_mm L-tile coopmat GEMM** (`DASLLAMA_COOPMAT=mm`) — llama.cpp's l_warptile config ported into our dasSpirv emitter: BM=BN=128 BK=32, 4 warps 2×2, 16 f16-acc fragments per warp. The isolated port beats their compiled kernel 108–129% on every model shape (their test-backend-ops "1.79 TF" datum was an artifact; in-graph they run 13–27 TF).
- **Per-dispatch tile router** — measurement inverted the l/m/s ladder: below cnt≈192 the fastest "small tile" is the sdot4 kernel, not a smaller coopmat tile. Router: `cnt<192 || d<=64 → sdot4, else L`; mm mode wins or ties at every prefill size and is bit-exact to sdot4 on MoE.
- **Aligned-L twin** — the in-graph-vs-isolated gap (12 vs 30 TF) was the staging bounds-guards (2.2×): a guarded path *merely present* costs ~20%, so aligned shapes (d%128==0 && cnt%128==0) get a guard-free twin with direct stores, picked by a pure predicate shared between pipe pick and meta fill. GEMM roles at isolated rate in-graph (gate/down 31 TF, q 33, wo 30).
- **Flash-attention twin** (`da_attn_b_h128`, hs=128, coopmat devices; generic kernel stays for other head sizes, `DASLLAMA_VK_FA=0` pins it) — the attn role was 37% of prefill at 0.69 TF: all-scalar operands from shared, softmax on 8/256 threads, 41KB shared = 1 wg/SM. The twin: 32-query tiles, QK^T on 16×16 f16 MMAs with f32 acc and the q fragments hoisted, online softmax on 4 threads/row with subgroup-shuffle reduces, PV register-tiled over the f16 V tile (~21KB shared, 2 wg/SM). The register-O shape sidesteps the per-row-alpha-rescale-of-coopmat-accumulators snag. 5.0× on the probe ladder; attn 112.8 → 25.5 ms in-graph.

## 3. The scheduling (uniform, declarative, then derived)

- **Hazard-mask rail** (`VkHaz` + `vhz_dep`) — the Metal bar_dep model: nodes declare region-bit read/write masks, a barrier is emitted only on RAW/WAW/WAR against the pending set, dst side always full-stage so the wholesale reset stays sound. Copies are declared transfer nodes — which closed six real compute-barrier-before-transfer-copy spec holes across the tier (NV-tolerated, still holes).
- **Unification parts 1–3** — every recorder and seam moved onto the rail (batch/hybrid recorders, decode GEMV preps, arena + standalone seams, cls); `comp_barrier`/`batch_barrier` deleted. Derived schedules come out tighter than hand where overlap is legal (ffn decode chain 3 vs 4 barriers, dn step 3 vs 4, dn window 7 vs 9, attn window 6 vs 7).
- **The kernel-access lens** — hazard masks are now *derived*, not written: a compile-time macro (`dasllama_vulkan_lens` + the shared `dasllama_kernel_access` analyzer) walks every `[compute_shader]` body interprocedurally and splices per-kernel binding read/write masks into the module; pipelines register them at creation, descriptor sets declare per-binding region bits where their buffers are named, `hz_dispatch` composes the two. Escape hatches: `[vk_access(reads/writes/force)]` override cross-checked against the body, explicit `vhz_dep` stays, unregistered pipeline/set panics. The migration trace-oracle (`DASLLAMA_VK_HAZARD_TRACE=1`, kept) caught three stale hand masks that had survived review. The flash-attention kernel above was the first new kernel after the lens: zero hand-written hazard bits.
- **Metal port guide** — `modules/dasLLAMA/kernel_access_lens_metal.md`: reuse map, `@role` → derived-with-override, the class-field analyzer extension the port needs, the oracle recipe.

## Ops

- **Demotion-cliff warning** — `DASLLAMA_GPU_VRAM_MB` above `min(heapBudget−reserve, heapSize−2GB)` logs the safe number: WDDM silently demotes host-visible-adjacent buffers under oversubscription and the act role goes 1 → 37 ms/layer over PCIe with no error anywhere (NV heapBudget ignores other processes, so it cannot be the cap itself).

## Gates

Bit-identity before/after (PFHASH/DECHASH/IDS + per-token gaps) at each step on Qwen1.5-MoE 8-layer (batch + combine + decode chains), Qwen3.5-0.8B (dn + at + dense), tinyllama (resident regression), Qwen3-4B (resident + qk_norm + mm + FA); FA vs generic IDS identical at plen 512 and 600 (multi-window); paranoid == elided bit-identical throughout; the lens migration trace-diffed against the hand masks node-for-node; test_vulkan_tier 34/34; spirv-val on new shaders; lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
