### PR TITLE
dasLLAMA: emitter-generated q51 GEMV family — 26B cpu tg128 red → green (0.959 → 1.054)

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -8418,7 +8418,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
                 }
             }
             s.moe_hdn |> resize(int(nhits * dim))
-            prof_add("mm_moe", ts_down)
+            prof_add("mm_moe_dn", ts_down)
             let ts_join = ref_time_ticks()
             matmul_moe_gpu_ffn_join(s.moe_hdn)
             prof_add("heat_wait", ts_join)   // GPU residue after the CPU misses — 0 = fully hidden
@@ -8509,7 +8509,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
             } else {
                 mm_at_q8_groupn(s.moe_dn, t, s.moe_offs, k, s.moe_dq, s.moe_ds, nfe, dim)
             }
-            prof_add("mm_moe", ts_down)
+            prof_add("mm_moe_dn", ts_down)
         }
         if (nhits == 0l) {   // the split arm above reduced its own hit/miss row banks
             let ts_red = ref_time_ticks()
@@ -8539,7 +8539,7 @@ def private moe_experts_apply(t : Model; var s : Session; l : int64) {
             if (c.moe_exps_bias) {  // ... and its down bias, inside the routed weight (ggml_add_id order)
                 add_bias(s.xb2, 0l, t.fblob, t.web2_off + e * dim, dim)
             }
-            prof_add("mm_moe", ts_down)
+            prof_add("mm_moe_dn", ts_down)
             let ts_red = ref_time_ticks()
             axpy(unsafe(addr(s.moe_acc[0])), unsafe(addr(s.xb2[0])), s.moe_w[j], dim)
             prof_add("moe_reduce", ts_red)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -3142,6 +3142,7 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
     let rq8 = g_repack_q8q8
     let rkq = g_repack_kq
     let rmx = g_repack_mx4
+    let rq51 = g_repack_q51
     unsafe {
         var qbp : int8? = null
         var qsp : float? = null
@@ -3155,6 +3156,8 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
         var k6sp : uint8? = null
         var q40qp : uint8? = null
         var q40sp : uint8? = null
+        var q51qp : uint8? = null
+        var q51sp : uint8? = null
         if (!empty(t.qblob)) { qbp = addr(t.qblob[0]) }
         if (!empty(t.qscales)) { qsp = addr(t.qscales[0]) }
         if (!empty(t.mxq)) { mxqp = addr(t.mxq[0]) }
@@ -3167,6 +3170,8 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
         if (!empty(t.k6s)) { k6sp = addr(t.k6s[0]) }
         if (!empty(t.q40q)) { q40qp = addr(t.q40q[0]) }
         if (!empty(t.q40s)) { q40sp = addr(t.q40s[0]) }
+        if (!empty(t.q51q)) { q51qp = addr(t.q51q[0]) }
+        if (!empty(t.q51s)) { q51sp = addr(t.q51s[0]) }
         let rp = addr<RepackReg const?>(regs[0])
         let nr = length(regs)
         let njobs = is_job_que_available() ? min(nr, 4 * (get_total_hw_jobs() + 1)) : 1
@@ -3178,6 +3183,8 @@ def private repack_regions(var t : Model; regs : array<RepackReg>) {
                         invoke(rq8, qbp + rp[i].off, qsp + rp[i].off / 32l, rp[i].n, rp[i].d)
                     } elif (f == 1) {
                         invoke(rmx, mxqp + rp[i].off / 2l, mxsp + rp[i].off / 32l, rp[i].n, rp[i].d)
+                    } elif (f == 2) {
+                        invoke(rq51, q51qp + (rp[i].off / 32l) * 20l, q51sp + (rp[i].off / 32l) * 4l, rp[i].n, rp[i].d)
                     } else {
                         let sb = rp[i].off / 256l
                         let qsb = kq_qsb(f)
@@ -3386,6 +3393,40 @@ def private repack_mx4_stacks(var t : Model) {
         }
     }
     repack_regions(t, regs)
+    delete regs
+}
+
+// q51-native expert stacks -> the active backend's grp<mr> q51 layout (per-stack: a model can
+// mix q51 downs with k4 gates, e.g. gemma-4-26B-A4B). No-op unless a stack is tagged q51.
+def private repack_q51_stacks(var t : Model) {
+    let c = t.config
+    let dim = c.dim
+    let ege = dim * c.n_ff_exp
+    var regs : array<RepackReg>
+    for (l in range64(c.n_layers)) {
+        let f1q = fmt_at(t.we1_fmt, l) == KqFmt.q51
+        let f2q = fmt_at(t.we2_fmt, l) == KqFmt.q51
+        let f3q = fmt_at(t.we3_fmt, l) == KqFmt.q51
+        if (!(f1q || f2q || f3q)) {
+            continue
+        }
+        for (e in range64(c.n_expert)) {
+            let base = e * ege
+            if (f1q) {
+                push_repack(regs, 2, t.we1_offs[l] + base, dim, c.n_ff_exp)
+            }
+            if (f2q) {
+                push_repack(regs, 2, t.we2_offs[l] + base, c.n_ff_exp, dim)
+            }
+            if (f3q) {
+                push_repack(regs, 2, t.we3_offs[l] + base, dim, c.n_ff_exp)
+            }
+        }
+    }
+    if (!empty(regs)) {
+        repack_regions(t, regs)
+        to_log(LOG_INFO, "dasLLAMA: q51 expert planes repacked to grp{active_q51_layout_mr()}\n")
+    }
     delete regs
 }
 
@@ -4261,6 +4302,9 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             repack_q8_weights(t)
             if (t.experts_mx4) {
                 repack_mx4_stacks(t)
+            }
+            if (active_q51_layout_mr() > 1l) {
+                repack_q51_stacks(t)
             }
             if (t.kquant_native && kernel_backend_has_kq()) {
                 repack_kq_weights(t)

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -8763,7 +8763,9 @@ def private gemma4_moe_ffn(t : Model; var s : Session; l : int64) {
     let ne = c.n_expert
     let k = c.n_expert_used
     // routed branch — input, custom router, select, per-expert down scale, experts, post-norm
+    let ts_norm0 = ref_time_ticks()
     rms_at(s.xb, t, t.rms_pre_ffn2_off + l * dim, s.moe_ao, dim)
+    prof_add("norm", ts_norm0)
     trace_tag(TRACE_TAG_ROUTE)   // decode router GEMV — without this it rides the stale attn tag in traces
     let ts_route = ref_time_ticks()
     gemma4_router_tmp(t, s, l)
@@ -8774,7 +8776,9 @@ def private gemma4_moe_ffn(t : Model; var s : Session; l : int64) {
     }
     prof_add("moe_route", ts_route)
     moe_experts_apply(t, s, l)
+    let ts_norm1 = ref_time_ticks()
     rms_at(s.moe_acc, t, t.rms_post_ffn2_off + l * dim, s.moe_acc, dim)
+    prof_add("norm", ts_norm1)
     // dense parallel shared expert (its own pre/post norms), into s.xb
     let ts_sh = ref_time_ticks()
     trace_tag(TRACE_TAG_SHEXP)
@@ -8783,8 +8787,12 @@ def private gemma4_moe_ffn(t : Model; var s : Session; l : int64) {
     rms_at(s.xb, t, t.rms_post_ffn1_off + l * dim, s.xb, dim)
     prof_add("mm_shexp", ts_sh)
     // combine then the shared post_ffw_norm on the sum
+    let ts_comb = ref_time_ticks()
     add_inplace(unsafe(addr(s.moe_acc[0])), unsafe(addr(s.xb[0])), dim)
+    prof_add("act_resid", ts_comb)
+    let ts_norm2 = ref_time_ticks()
     rms_at(s.moe_acc, t, t.rms_post_ffn_off + l * dim, s.moe_acc, dim)
+    prof_add("norm", ts_norm2)
 }
 
 // gemma4 FFN decode: dense (12B/31B) or the parallel dense-shared + routed MoE (26B-A4B) by expert count.
@@ -8803,7 +8811,9 @@ def private ffn_gemma4_decode(t : Model; var s : Session; l : int64) {
         return
     }
     let dim = c.dim
+    let ts_copy = ref_time_ticks()
     copy_floats(s.x, 0l, s.moe_ao, 0l, dim)
+    prof_add("act_resid", ts_copy)
     gemma4_moe_ffn(t, s, l)
     let ts_resid = ref_time_ticks()
     if (c.layer_out_scale) {
@@ -9121,8 +9131,12 @@ def forward(t : Model; var s : Session; token, pos : int64) {
     if (!stack_done) {
         blob_only_panic(t, "decode stack")
         for (l in range64(c.n_layers)) {
+            let ts_blk_attn = ref_time_ticks()
             t.blocks.attn_decode(t, s, l, pos)
+            prof_add("blk_attn", ts_blk_attn)
+            let ts_blk_ffn = ref_time_ticks()
             t.blocks.ffn_decode(t, s, l)
+            prof_add("blk_ffn", ts_blk_ffn)
         }
     }
 

--- a/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemm_gen.das
@@ -265,6 +265,8 @@ struct private TileEmit {
     xbs : LLVMOpaqueValue? [4]           // per-token bsum bases (−128·Σx i32 per block) — the tile's
                                          // bias128 correction plane; null = compute inline (gemv)
     mx4 : bool                           // block emitter: mx4 LUT-dequant instead of Q8 loads
+    q51 : bool                           // block emitter: q51 nibble+qh unpack (32-weight blocks,
+                                         // per-block f16 d/m scale pairs + xbs min-term)
     kq : int                             // 4/5/6 = K-quant superblock emitter (0 = not kq): the
                                          // block unit is a 256-weight superblock over the grp<mr>
                                          // kq planes; dots run unsigned-q (kq_dot_lane)
@@ -708,6 +710,103 @@ def private emit_block_mx4(var te : TileEmit; var bi : LLVMOpaqueValue?; var f :
     }
 }
 
+// The qh bit-plane of one 16B row-quad qh vector as 0x10-or-0 bytes for k-group j (half 0 =
+// bits 4j..4j+3 per row, half 1 = the +16 chunk): constant-shuffle byte pick + and/cmpeq/sext.
+def private qh_bits(var te : TileEmit; var qhv : LLVMOpaqueValue?; j, half : int; name : string) : LLVMOpaqueValue? {
+    let b = te.builder
+    let byteIdx = half * 2 + j / 2
+    let shufMask <- [for (lane in range(16)); (lane / 4) * 4 + byteIdx]
+    var picked = LLVMBuildShuffleVector(b, te.types, qhv, qhv, shufMask, "{name}p")
+    var bitElems <- [for (lane in range(16)); LLVMConstInt(te.types.t_int8, uint64(1 << ((j % 2) * 4 + lane % 4)), 0)]
+    var bmask = LLVMConstVector(array_data_ptr(bitElems), 16u)
+    var got = LLVMBuildAnd(b, picked, bmask, "")
+    var isSet = LLVMBuildICmp(b, LLVMIntPredicate.LLVMIntEQ, got, bmask, "")
+    var sx = LLVMBuildSExt(b, isSet, te.v16i8, "")
+    return LLVMBuildAnd(b, sx, splat_i8w(te, 16), name)
+}
+
+// One 32-k block, q51 form: per (row vector, dword-group j) one nibble load ORs its qh bits in
+// register (no scratch expand); dots ride the unsigned lattice; the per-block fold is
+// (d·isum + m·asum)·xs in q51_grp_row_dot's op order, asum off the xbs plane.
+def private emit_block_q51(var te : TileEmit; var bi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]; tokBase, tokCount : int) {
+    let b = te.builder
+    let rq = te.rq
+    var wb = LLVMBuildMul(b, bi, te.types->ConstI64(uint64(te.interleave * 20)), "wb")
+    var xb = LLVMBuildMul(b, bi, te.types->ConstI64(0x20ul), "xb")
+    var qh : LLVMOpaqueValue? [2]
+    for (qd in range(rq)) {
+        var hoff = LLVMBuildAdd(b, wb, te.types->ConstI64(uint64(16 * te.interleave + qd * 16)), "")
+        qh[qd] = load_v16i8(te, te.wg, hoff, "qh{qd}")
+    }
+    var wlo : LLVMOpaqueValue? [8]
+    var whi : LLVMOpaqueValue? [8]
+    for (j in range(4)) {
+        for (qd in range(rq)) {
+            let boff = j * 4 * te.interleave + qd * 16
+            var off = boff == 0 ? wb : LLVMBuildAdd(b, wb, te.types->ConstI64(uint64(boff)), "")
+            var nv = load_v16i8(te, te.wg, off, "nv{j * rq + qd}")
+            var lo = LLVMBuildAnd(b, nv, splat_i8w(te, 15), "")
+            var hi = LLVMBuildLShr(b, nv, splat_i8w(te, 4), "")
+            wlo[j * rq + qd] = LLVMBuildOr(b, lo, qh_bits(te, qh[qd], j, 0, "hl{j * rq + qd}"), "wlo{j * rq + qd}")
+            whi[j * rq + qd] = LLVMBuildOr(b, hi, qh_bits(te, qh[qd], j, 1, "hh{j * rq + qd}"), "whi{j * rq + qd}")
+        }
+    }
+    var xv0 : LLVMOpaqueValue? [4]
+    var xv1 : LLVMOpaqueValue? [4]
+    var xb1 = LLVMBuildAdd(b, xb, te.types->ConstI64(16ul), "")
+    for (i in range(tokCount)) {
+        xv0[i] = load_v16i8(te, te.x[tokBase + i], xb, "x{tokBase + i}lo")
+        xv1[i] = load_v16i8(te, te.x[tokBase + i], xb1, "x{tokBase + i}hi")
+    }
+    var a : LLVMOpaqueValue? [8]
+    for (i in range(tokCount * rq)) {
+        a[i] = LLVMConstNull(te.vni32)
+    }
+    for (l in range(4)) {           // chunk 0 (k 0..15): low-nibble weights
+        for (i in range(tokCount)) {
+            for (qd in range(rq)) {
+                a[i * rq + qd] = kq_dot_lane(te, a[i * rq + qd], wlo[l * rq + qd], xv0[i], l)
+            }
+        }
+    }
+    for (l in range(4)) {           // chunk 1 (k 16..31): high-nibble weights
+        for (i in range(tokCount)) {
+            for (qd in range(rq)) {
+                a[i * rq + qd] = kq_dot_lane(te, a[i * rq + qd], whi[l * rq + qd], xv1[i], l)
+            }
+        }
+    }
+    // fold: f += (d4·isum4 + m4·asum)·xs — d/m off the interleaved f16 pair plane
+    var v8i16 = LLVMVectorType(te.types.t_int16, 8u)
+    var d4 : LLVMOpaqueValue? [2]
+    var m4 : LLVMOpaqueValue? [2]
+    var sIdx0 = LLVMBuildMul(b, bi, te.types->ConstI64(uint64(4 * te.interleave)), "")
+    for (qd in range(rq)) {
+        var sIdx = qd == 0 ? sIdx0 : LLVMBuildAdd(b, sIdx0, te.types->ConstI64(uint64(qd * 16)), "")
+        var sp = LLVMBuildGEP2(b, te.types.t_int8, te.sg, sIdx, "sp{qd}")
+        var dm = LLVMBuildLoad2Aligned(b, v8i16, sp, 1u, "dm{qd}")
+        var dh = LLVMBuildShuffleVector(b, te.types, dm, dm, [0, 2, 4, 6], "")
+        var mh = LLVMBuildShuffleVector(b, te.types, dm, dm, [1, 3, 5, 7], "")
+        d4[qd] = LLVMBuildFPExt(b, LLVMBuildBitCast(b, dh, te.vnf16, ""), te.vnf32, "d4{qd}")
+        m4[qd] = LLVMBuildFPExt(b, LLVMBuildBitCast(b, mh, te.vnf16, ""), te.vnf32, "m4{qd}")
+    }
+    for (i in range(tokCount)) {
+        let tk = tokBase + i
+        var bsPtr = LLVMBuildGEP2(b, te.types.t_int32, te.xbs[tk], bi, "bsp{tk}")
+        var bsv = LLVMBuildLoad2Aligned(b, te.types.t_int32, bsPtr, 4u, "bs{tk}")
+        var asum = splat_f32(te, LLVMBuildSIToFP(b, bsv, te.types.t_float, ""), "as{tk}")
+        var qp = LLVMBuildGEP2(b, te.types.t_float, te.xs[tk], bi, "qp{tk}")
+        var q = LLVMBuildLoad2Aligned(b, te.types.t_float, qp, 4u, "q{tk}")
+        var xsv = splat_f32(te, q, "qs{tk}")
+        for (qd in range(rq)) {
+            var isumf = LLVMBuildSIToFP(b, a[i * rq + qd], te.vnf32, "af{tk}")
+            var mm = LLVMBuildFMul(b, m4[qd], asum, "")
+            var s = fold_fma(te, d4[qd], isumf, mm, "s{tk}")
+            f[i * rq + qd] = fold_fma(te, s, xsv, f[i * rq + qd], "f{tk}")
+        }
+    }
+}
+
 // One K-quant lane-dot: acc += q · (dword-group `lane` of x, splatted). Quants are UNSIGNED
 // (0..15/31/63) — they ARE the u8 side of vpdpbusd/maddubs, and fit s8 non-negatively for
 // bssd/sdot, so no |w|/sign-apply/bias plane on any leg. maddubs pair-sums stay exact (2·63·127 < 32767).
@@ -1098,6 +1197,8 @@ def private emit_block_kqv2(var te : TileEmit; var sbi : LLVMOpaqueValue?; var f
 def private emit_one_block(var te : TileEmit; var bi : LLVMOpaqueValue?; var f : LLVMOpaqueValue? [8]; tokBase, tokCount : int) {
     if (te.kq != 0) {
         emit_block_kqv2(te, bi, f, tokBase, tokCount)
+    } elif (te.q51) {
+        emit_block_q51(te, bi, f, tokBase, tokCount)
     } elif (te.mx4) {
         emit_block_mx4(te, bi, f, tokBase, tokCount)
     } elif (te.dotKind == DOT_SMMLA && tokCount >= 2) {
@@ -1259,13 +1360,13 @@ def private setup_tile_emit(var te : TileEmit; var gc : LlvmCodeCtx; p : TilePer
     te.types = gc.jit.types
     te.interleave = rt.interleave
     te.dotKind = dot_kind(p.dotPrim)
-    // mx4/kq planes are kgroup-independent — under an smmla perm they ride the plain sdot lattice
-    if ((te.mx4 || te.kq != 0) && te.dotKind == DOT_SMMLA) {
+    // mx4/kq/q51 planes are kgroup-independent — under an smmla perm they ride the plain sdot lattice
+    if ((te.mx4 || te.q51 || te.kq != 0) && te.dotKind == DOT_SMMLA) {
         te.dotKind = DOT_SDOT
     }
-    te.kgroup = (te.mx4 || te.kq != 0) ? 4 : rt.kgroup
-    // the perm's bias applies to the Q8 weight plane only — mx4/kq planes never see the biased repack
-    te.bias = (te.mx4 || te.kq != 0) ? 0 : p.bias
+    te.kgroup = (te.mx4 || te.q51 || te.kq != 0) ? 4 : rt.kgroup
+    // the perm's bias applies to the Q8 weight plane only — mx4/kq/q51 planes never see the biased repack
+    te.bias = (te.mx4 || te.q51 || te.kq != 0) ? 0 : p.bias
     te.width = (te.dotKind == DOT_SDOT || te.dotKind == DOT_SMMLA) ? 128 : p.width
     te.rv = te.width / 32
     te.rq = rt.interleave / te.rv
@@ -2244,6 +2345,70 @@ def private k5_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 5)
 def private k6_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 6)
 def private q40_gemv_gen(var gc : LlvmCodeCtx) : bool => kq_gemv_gen_impl(gc, 40)
 
+// The q51 rows-range GEMV over the grp<mr> q51 planes — kq_gemv_gen_impl's walk with the
+// 32-weight block unit (nb = n/32, row strides 20B quants / 4B scales per block). sdot leg
+// only in v1 — x64 perms decline to the portable disk-order kernels via backend wiring.
+def private q51_gemv_gen(var gc : LlvmCodeCtx) : bool {
+    if (!is_kq_gemv_signature(gc.fn)) return false
+    let p0 = parse_perm(gc)
+    if (perm_declines(gc, p0)) return false
+    let p = companion_perm(p0)
+    if (p.dotPrim != "sdot") return false
+
+    var te = TileEmit(q51 = true)
+    if (!setup_tile_emit(te, gc, p, false)) return false
+
+    let b = gc.jit.builder
+    var entry = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "entry")
+    var ghead = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "ghead")
+    var gexit = LLVMAppendBasicBlockInContext(gc.jit.ctx, gc.impl, "gexit")
+
+    LLVMPositionBuilderAtEnd(b, entry)
+    var sa = SliceArgs(gc_impl = gc.impl, ctx = gc.jit.ctx, kstep = 1)
+    sa.yp = LLVMGetParam(gc.impl, 0u)
+    let qgp = LLVMGetParam(gc.impl, 1u)
+    let sgp = LLVMGetParam(gc.impl, 2u)
+    te.x[0] = LLVMGetParam(gc.impl, 3u)
+    te.xs[0] = LLVMGetParam(gc.impl, 4u)
+    te.xbs[0] = LLVMGetParam(gc.impl, 5u)
+    let n = LLVMGetParam(gc.impl, 6u)
+    let rbv = LLVMGetParam(gc.impl, 7u)
+    let rev = LLVMGetParam(gc.impl, 8u)
+    sa.nb = LLVMBuildSDiv(b, n, te.types->ConstI64(0x20ul), "nb")
+    var qrow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(20ul), "qrow")
+    var srow = LLVMBuildMul(b, sa.nb, te.types->ConstI64(4ul), "srow")
+    sa.d = te.types->ConstI64(0ul)
+    sa.t0 = te.types->ConstI64(0ul)
+    let mrC = te.types->ConstI64(uint64(te.interleave))
+    var g0 = LLVMBuildSDiv(b, rbv, mrC, "g0")
+    var g1 = LLVMBuildSDiv(b, rev, mrC, "g1")
+    var nonempty = LLVMBuildICmp(b, LLVMIntPredicate.LLVMIntSLT, g0, g1, "any")
+    LLVMBuildCondBr(b, nonempty, ghead, gexit)
+
+    LLVMPositionBuilderAtEnd(b, ghead)
+    var gPhi = LLVMBuildPhi(b, te.types.t_int64, "g")
+    var gEntryVals <- [g0]
+    var gEntryBlocks <- [entry]
+    LLVMAddIncoming(gPhi, gEntryVals, gEntryBlocks)
+    sa.g = gPhi
+    var gRow = LLVMBuildMul(b, gPhi, mrC, "grow")
+    te.wg = LLVMBuildGEP2(b, te.types.t_int8, qgp, LLVMBuildMul(b, gRow, qrow, ""), "wg")
+    te.sg = LLVMBuildGEP2(b, te.types.t_int8, sgp, LLVMBuildMul(b, gRow, srow, ""), "sg")
+
+    var after = emit_slice(te, sa, ghead, 0, 1, "")
+    LLVMPositionBuilderAtEnd(b, after)
+    var gNext = LLVMBuildAdd(b, gPhi, te.types->ConstI64(1ul), "gnext")
+    var more = LLVMBuildICmp(b, LLVMIntPredicate.LLVMIntSLT, gNext, g1, "more")
+    LLVMBuildCondBr(b, more, ghead, gexit)
+    var gLoopVals <- [gNext]
+    var gLoopBlocks <- [after]
+    LLVMAddIncoming(gPhi, gLoopVals, gLoopBlocks)
+
+    LLVMPositionBuilderAtEnd(b, gexit)
+    LLVMBuildRetVoid(b)
+    return true
+}
+
 // The K-quant 4-token TILE (weight-stationary prefill): same 10-arg contract as the q8 tile;
 // emit_block_kqv2 unpacks each weight vector ONCE and dots it against every token, bit-exact
 // vs 4 per-token GEMVs. Declines via the SAME perm_declines — no new rails.
@@ -2317,6 +2482,7 @@ def public register_dasllama_gemm_generators {
     register_llvm_code_generator("dasllama_gemm_gen::k4_gemv", @@k4_gemv_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k5_gemv", @@k5_gemv_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k6_gemv", @@k6_gemv_gen)
+    register_llvm_code_generator("dasllama_gemm_gen::q51_gemv", @@q51_gemv_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k4_tile", @@k4_tile_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k5_tile", @@k5_tile_gen)
     register_llvm_code_generator("dasllama_gemm_gen::k6_tile", @@k6_tile_gen)

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -50,6 +50,7 @@ def image_identity(tag : string = "") : string {
     return ("v{IMAGE_VERSION}|{active_kernel_backend()}|{get_wscale_f16() ? "s16" : "s32"}"
         + "|q8 mr{active_q8_layout_mr()} b{active_q8_wbias()} g{active_q8_kgroup()}"
         + "|kq {active_kq_layout_mr(4)}/{active_kq_layout_mr(5)}/{active_kq_layout_mr(6)}/{active_kq_layout_mr(40)}"
+        + "|q51 mr{active_q51_layout_mr()}"
         + (tag != "" ? "|{tag}" : ""))
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -1212,6 +1212,9 @@ typedef MatmulMx4Q8BatchFn = function<(var yp : float?; wn : uint8 const?; we : 
 // In-place repack of one MXFP4 region [d rows x n cols] (raw plane pointers at the region start)
 // into the active backend's preferred layout. Default = no-op (row-major). n % 32 == 0.
 typedef RepackMx4Fn = function<(var np : uint8?; var ep : uint8?; n : int64; d : int64) : void>
+// In-place repack of one q51 region [d rows x n cols] (quant + scale plane pointers at the
+// region start) into the active backend's grp<mr> layout. Default = no-op (disk order).
+typedef RepackQ51Fn = function<(var qp : uint8?; var sp : uint8?; n : int64; d : int64) : void>
 // Region-list GEMV, ONE dispatch for N same-shape [d x n] projections (MoE decode fuse: all k
 // routed experts' gates/ups/downs in one fork/join). `offs` packs PAIRS [weight offset, activation
 // offset] per region; region r -> yp+r*d. bp folds a per-region bias at the store (~36us/layer saved).
@@ -1287,6 +1290,8 @@ struct KernelBackend {
     q51_batch : MatmulQ51Q8BatchFn = @@q51q8_batch_kernel
     groupn_q51 : MatmulQ51GroupNFn = @@q51q8_groupn_kernel
     q51_batch_groupn : MatmulQ51Q8BatchGroupNFn = @@q51q8_batch_groupn_kernel
+    repack_q51 : RepackQ51Fn = @@repack_q51_identity
+    q51_layout : function<() : int> = @@q51_layout_grp1
     // Optional row-range GEMV core (see MatmulQ8Q8RowsFn) — backends without one keep the panic
     // stub, and the fused multi-stage decode falls back to the per-op dispatch path.
     mm_rows : MatmulQ8Q8RowsFn = @@q8q8_unset_rows
@@ -1374,6 +1379,7 @@ var g_active_has_kq_groupn = false  // ... and the region-list kq GEMV (MoE expe
 var g_active_has_kq_batch_groupn = false   // ... and the fused batched region-list GEMM (MoE prefill)?
 var g_repack_q8q8 = @@repack_q8q8_identity   // no-op until a repack backend is selected
 var g_repack_mx4 = @@repack_mx4_identity     // no-op until a repack backend is selected
+var g_repack_q51 = @@repack_q51_identity     // no-op until a repack backend is selected
 var g_repack_kq = @@repack_kq_identity       // no-op until a kq-capable backend is selected
 
 // ===== MoE GPU tier (per-layer expert offload) =====
@@ -2306,6 +2312,7 @@ var g_active_mx4_expand_interleaved = false   // see KernelBackend.mx4_expand_in
 var g_active_mx4_native_batch = false         // see KernelBackend.mx4_native_batch
 var g_active_q8_layout_mr = 4l                // see KernelBackend.q8_layout (activation-time cache)
 var g_active_kq_layout = @@kq_layout_grp4_fmt // see KernelBackend.kq_layout (activation-time cache)
+var g_active_q51_layout_mr = 1l               // see KernelBackend.q51_layout (activation-time cache)
 var g_active_q8_wbias = 0l                    // see KernelBackend.q8_wbias (activation-time cache)
 var g_active_q8_kgroup = 4l                   // see KernelBackend.q8_kgroup (activation-time cache)
 var g_backend_pin = ""              // A/B: force this backend by name; "" = auto-select
@@ -2323,6 +2330,10 @@ def repack_mx4_identity(var np : uint8?; var ep : uint8?; n, d : int64) {}
 //! Default K-quant repack: no-op — the kq planes stay disk-order for the portable kernels.
 [unused_argument(fmt, kq, ks, n, d)]
 def repack_kq_identity(fmt : int; var kq : uint8?; var ks : uint8?; n, d : int64) {}
+
+//! Default q51 repack: no-op — the q51 planes stay disk-order for the portable kernels.
+[unused_argument(qp, sp, n, d)]
+def repack_q51_identity(var qp : uint8?; var sp : uint8?; n, d : int64) {}
 
 //! Q5_1·Q8 dot, scalar reference form — THE q51 float-order contract every q51 kernel
 //! reproduces: per 32-block isum = Σ q·a (q = nibble | qh_bit << 4, unsigned [0,31]), asum = Σ a
@@ -2404,26 +2415,73 @@ def template dot_q51e_template(qe : int8 const ?; ws : uint8 const ?; xq : int8 
 [hint(unsafe_range_check, noalias = qe, noalias = ws, noalias = xq, noalias = xs), tuned(fallback = "vec16")]
 def dot_q51e(qe : int8 const?; ws : uint8 const?; xq : int8 const?; xs : float const?; n : int64) : float {}
 
+//! expand_q51_row's grp<mr> twin: row r of one mr-row group off the interleaved plane (nibble
+//! dwords at j·4·mr + r·4, qh at the 16·mr tail section). Bit-identical expansion.
+def expand_q51_grp_row(gq : uint8 const?; r, mr : int64; var qe : int8?; nb : int64) {
+    unsafe {
+        for (bi in range64(nb)) {
+            let base = bi * 20l * mr
+            let hb = base + 16l * mr + r * 4l
+            let qh = uint(gq[hb]) | (uint(gq[hb + 1l]) << 8u) | (uint(gq[hb + 2l]) << 16u) | (uint(gq[hb + 3l]) << 24u)
+            for (j in range64(16l)) {
+                let b = int(gq[base + (j / 4l) * 4l * mr + r * 4l + j % 4l])
+                let h0 = (int(qh >> uint(j)) & 1) << 4
+                let h1 = (int(qh >> uint(j + 16l)) & 1) << 4
+                qe[bi * 32l + j] = int8((b & 15) | h0)
+                qe[bi * 32l + j + 16l] = int8((b >> 4) | h1)
+            }
+        }
+    }
+}
+
+//! One row's scale bytes gathered contiguous off the grp<mr> scale plane (dot_q51e reads a
+//! packed 4B-per-block row).
+def gather_q51_grp_scales(gs : uint8 const?; r, mr : int64; var ss : uint8?; nb : int64) {
+    unsafe {
+        for (bi in range64(nb)) {
+            let src = bi * 4l * mr + r * 4l
+            ss[bi * 4l] = gs[src]
+            ss[bi * 4l + 1l] = gs[src + 1l]
+            ss[bi * 4l + 2l] = gs[src + 2l]
+            ss[bi * 4l + 3l] = gs[src + 3l]
+        }
+    }
+}
+
 // Portable q51 batch (the KernelBackend.q51_batch default): rows-outer/tokens-inner — each row
 // expands ONCE into the worker's scratch, then ntok MAC passes (the mm_b_q51_pre core).
 def q51q8_batch_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; xqp : int8 const?; xsp : float const?; n, d, ntok : int64) {
     let nb = n / 32l
+    let mr = active_q51_layout_mr()   // grp<mr> planes on the gen backend; tail rows stay disk-order
+    let grpRows = (d / mr) * mr
     var myp = yp
     unsafe {
         maybe_parallel_for(0, int(d), matmul_chunks(int(d), get_q8_batch_chunks_per_job(), n * d * ntok)) $(rb, re) {
             var qe : array<int8>
             qe |> resize(n)
+            var sc : array<uint8>
+            sc |> resize(int(nb * 4l))
             unsafe {
                 var qep = addr(qe[0])
+                var scp = addr(sc[0])
                 for (i in range(rb, re)) {
-                    expand_q51_row(wq + int64(i) * nb * 20l, qep, nb)
-                    let srow = ws + int64(i) * nb * 4l
+                    let row = int64(i)
+                    var srow = ws + row * nb * 4l
+                    if (mr == 1l || row >= grpRows) {
+                        expand_q51_row(wq + row * nb * 20l, qep, nb)
+                    } else {
+                        let gbase = (row / mr) * mr * nb
+                        expand_q51_grp_row(wq + gbase * 20l, row % mr, mr, qep, nb)
+                        gather_q51_grp_scales(ws + gbase * 4l, row % mr, mr, scp, nb)
+                        srow = scp
+                    }
                     for (tk in range64(ntok)) {
-                        myp[tk * d + int64(i)] = dot_q51e(qep, srow, xqp + tk * n, xsp + tk * nb, n)
+                        myp[tk * d + row] = dot_q51e(qep, srow, xqp + tk * n, xsp + tk * nb, n)
                     }
                 }
             }
             delete qe
+            delete sc
         }
     }
 }
@@ -2432,24 +2490,38 @@ def q51q8_batch_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; xq
 // xoff) pairs, expand-then-MAC per (region, row). No bias form — no biased-q51 arch exists.
 def q51q8_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
+    let mr = active_q51_layout_mr()   // grp<mr> planes on the gen backend; tail rows stay disk-order
+    let grpRows = (d / mr) * mr
     var myp = yp
     unsafe {
         maybe_parallel_for(0, int(nregions * d), matmul_chunks_gemv(int(nregions * d), 1, n * d * nregions)) $(rb, re) {
             var qe : array<int8>
             qe |> resize(n)
+            var sc : array<uint8>
+            sc |> resize(int(nb * 4l))
             unsafe {
                 var qep = addr(qe[0])
+                var scp = addr(sc[0])
                 for (i in range(rb, re)) {
                     let ii = int64(i)
                     let r = ii / d
                     let row = ii % d
                     let woff = offs[r * 2l]
                     let xoff = offs[r * 2l + 1l]
-                    expand_q51_row(wq + (woff / 32l + row * nb) * 20l, qep, nb)
-                    myp[ii] = dot_q51e(qep, ws + (woff / 32l + row * nb) * 4l, xqp + xoff, xsp + xoff / 32l, n)
+                    var srow = ws + (woff / 32l + row * nb) * 4l
+                    if (mr == 1l || row >= grpRows) {
+                        expand_q51_row(wq + (woff / 32l + row * nb) * 20l, qep, nb)
+                    } else {
+                        let gbase = woff / 32l + (row / mr) * mr * nb
+                        expand_q51_grp_row(wq + gbase * 20l, row % mr, mr, qep, nb)
+                        gather_q51_grp_scales(ws + gbase * 4l, row % mr, mr, scp, nb)
+                        srow = scp
+                    }
+                    myp[ii] = dot_q51e(qep, srow, xqp + xoff, xsp + xoff / 32l, n)
                 }
             }
             delete qe
+            delete sc
         }
     }
 }
@@ -2458,13 +2530,18 @@ def q51q8_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; o
 // row0, cnt) triples; each (region, row) expands once, then cnt token MACs.
 def q51q8_batch_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
     let nb = n / 32l
+    let mr = active_q51_layout_mr()   // grp<mr> planes on the gen backend; tail rows stay disk-order
+    let grpRows = (d / mr) * mr
     var myp = yp
     unsafe {
         maybe_parallel_for(0, int(nregions * d), matmul_chunks(int(nregions * d), get_q8_batch_chunks_per_job(), n * d * nregions)) $(rb, re) {
             var qe : array<int8>
             qe |> resize(n)
+            var sc : array<uint8>
+            sc |> resize(int(nb * 4l))
             unsafe {
                 var qep = addr(qe[0])
+                var scp = addr(sc[0])
                 for (i in range(rb, re)) {
                     let ii = int64(i)
                     let r = ii / d
@@ -2472,14 +2549,22 @@ def q51q8_batch_groupn_kernel(var yp : float?; wq : uint8 const?; ws : uint8 con
                     let woff = offs[r * 3l]
                     let row0 = offs[r * 3l + 1l]
                     let cnt = offs[r * 3l + 2l]
-                    expand_q51_row(wq + (woff / 32l + row * nb) * 20l, qep, nb)
-                    let srow = ws + (woff / 32l + row * nb) * 4l
+                    var srow = ws + (woff / 32l + row * nb) * 4l
+                    if (mr == 1l || row >= grpRows) {
+                        expand_q51_row(wq + (woff / 32l + row * nb) * 20l, qep, nb)
+                    } else {
+                        let gbase = woff / 32l + (row / mr) * mr * nb
+                        expand_q51_grp_row(wq + gbase * 20l, row % mr, mr, qep, nb)
+                        gather_q51_grp_scales(ws + gbase * 4l, row % mr, mr, scp, nb)
+                        srow = scp
+                    }
                     for (tk in range64(cnt)) {
                         myp[(row0 + tk) * d + row] = dot_q51e(qep, srow, xqp + (row0 + tk) * n, xsp + (row0 + tk) * nb, n)
                     }
                 }
             }
             delete qe
+            delete sc
         }
     }
 }
@@ -2489,6 +2574,7 @@ def private no_backend() {
 }
 def private backend_always_available() : bool => true
 def private q8_layout_grp4() : int => 4
+def private q51_layout_grp1() : int => 1
 
 [unused_argument(fmt)]
 def private kq_layout_grp4_fmt(fmt : int) : int => 4
@@ -2502,6 +2588,10 @@ def active_q8_layout_mr() : int64 => g_active_q8_layout_mr
 //! The active backend's kq plane interleave for `fmt` (4/5/6) — per-format since the kq v2
 //! family split; the loader freezes these onto the Model at repack time.
 def active_kq_layout_mr(fmt : int) : int64 => int64(invoke(g_active_kq_layout, fmt))
+
+//! The active backend's q51 plane interleave — 1 (disk order) on every hand tier; the stamped
+//! mr on the arm64-gen backend (the self-anchored q51 GEMV family).
+def active_q51_layout_mr() : int64 => g_active_q51_layout_mr
 
 //! The weight-plane bias of the ACTIVE backend's Q8 layout — cached at activation from
 //! KernelBackend.q8_wbias (0 for every hand tier; 128 on a bias128 gen stamp). The mx4->Q8
@@ -2618,6 +2708,7 @@ def private activate(be : KernelBackend) {
     g_active_has_kq_batch_groupn = !(be.kq_batch_groupn == @@kq_unset_batch_groupn)
     g_repack_q8q8 = be.repack
     g_repack_mx4 = be.repack_mx4
+    g_repack_q51 = be.repack_q51
     g_repack_kq = be.repack_kq
     g_active_backend = be.name
     g_active_needs_repack = be.needs_repack
@@ -2625,6 +2716,7 @@ def private activate(be : KernelBackend) {
     g_active_mx4_native_batch = be.mx4_native_batch
     g_active_q8_layout_mr = int64(invoke(be.q8_layout))
     g_active_kq_layout = be.kq_layout
+    g_active_q51_layout_mr = int64(invoke(be.q51_layout))
     g_active_q8_wbias = int64(invoke(be.q8_wbias))
     g_active_q8_kgroup = int64(invoke(be.q8_kgroup))
     g_active_batch_backend = be.name

--- a/modules/dasLLAMA/dasllama/dasllama_math_gen.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math_gen.das
@@ -629,6 +629,167 @@ def private repack_mx4_gen(var np : uint8?; var ep : uint8?; n, d : int64) {
     repack_mx4_grp(np, ep, n, d, int64(q8q8_layout_gen()))
 }
 
+// ===== the q51 GEMV family (self-anchored — q51 does NOT ride the Q8 mr; its grid is
+// sdot-only, so x64 declines to the portable disk-order kernels via backend wiring) =====
+
+//! The q51 layout companion: the grp interleave the stamped q51 rows core reads. Reference
+//! body = 1 (grp1 IS the disk order byte-for-byte), so a declined stamp keeps the verbatim
+//! planes and the scalar walk coherent.
+def q51q8_layout_gen() : int {
+    return 1
+}
+
+//! mr-generalized q51 plane repack: per (block-group, block) at 20·mr bytes — nibbles
+//! dword-interleaved like repack_mx4_grp, then qh row-major (mr × 4B); scale plane mr × 4B
+//! f16 (d, m) per block. grp1 == disk order; tail rows (d % mr) stay disk-order.
+def repack_q51_grp(var qp : uint8?; var sp : uint8?; n, d, mr : int64) {
+    let nb = n / 32l
+    let ng = d / mr
+    var tq : array<uint8>
+    var ts : array<uint8>
+    tq |> resize(int(d * nb * 20l))
+    ts |> resize(int(d * nb * 4l))
+    unsafe {
+        var tqp = addr(tq[0])
+        var tsp = addr(ts[0])
+        for (i in range64(d * nb * 20l)) {
+            tqp[i] = qp[i]
+        }
+        for (i in range64(d * nb * 4l)) {
+            tsp[i] = sp[i]
+        }
+        for (g in range64(ng)) {
+            let gqb = g * mr * nb * 20l
+            let gsb = g * mr * nb * 4l
+            for (bi in range64(nb)) {
+                let dst = gqb + bi * 20l * mr
+                for (r in range64(mr)) {
+                    let src = ((g * mr + r) * nb + bi) * 20l
+                    for (j in range64(4l)) {   // nibble dwords, mx4 order
+                        let dj = dst + j * 4l * mr + r * 4l
+                        qp[dj + 0l] = tqp[src + j * 4l + 0l]
+                        qp[dj + 1l] = tqp[src + j * 4l + 1l]
+                        qp[dj + 2l] = tqp[src + j * 4l + 2l]
+                        qp[dj + 3l] = tqp[src + j * 4l + 3l]
+                    }
+                    let dh = dst + 16l * mr + r * 4l       // qh tail section
+                    qp[dh + 0l] = tqp[src + 16l]
+                    qp[dh + 1l] = tqp[src + 17l]
+                    qp[dh + 2l] = tqp[src + 18l]
+                    qp[dh + 3l] = tqp[src + 19l]
+                    let ds = gsb + bi * 4l * mr + r * 4l
+                    let ss = ((g * mr + r) * nb + bi) * 4l
+                    sp[ds + 0l] = tsp[ss + 0l]
+                    sp[ds + 1l] = tsp[ss + 1l]
+                    sp[ds + 2l] = tsp[ss + 2l]
+                    sp[ds + 3l] = tsp[ss + 3l]
+                }
+            }
+        }
+    }
+    delete tq
+    delete ts
+}
+
+// the backend q51 repack slot: the family's OWN layout companion decides the interleave
+def private repack_q51_gen(var qp : uint8?; var sp : uint8?; n, d : int64) {
+    repack_q51_grp(qp, sp, n, d, int64(q51q8_layout_gen()))
+}
+
+//! One row's dot off the grp<mr> q51 planes, scalar — the q51 stub's reference body and the
+//! tests' repack oracle. Exact integer sums, same per-block float fold order as
+//! dot_q51q8_scalar; asum comes from the caller's per-32 activation sums (xbsp).
+def q51_grp_row_dot(qg : uint8 const?; sg : uint8 const?; r, mr : int64; xqp : int8 const?; xsp : float const?; xbsp : int const?; n : int64) : float {
+    let nb = n / 32l
+    var f = 0.0
+    unsafe {
+        for (bi in range64(nb)) {
+            let qb = bi * 20l * mr
+            let hp = qg + qb + 16l * mr + r * 4l
+            let qh = uint(hp[0]) | (uint(hp[1]) << 8u) | (uint(hp[2]) << 16u) | (uint(hp[3]) << 24u)
+            var isum = 0
+            for (j in range64(16l)) {
+                let b = int(qg[qb + (j / 4l) * 4l * mr + r * 4l + j % 4l])
+                let h0 = (int(qh >> uint(j)) & 1) << 4
+                let h1 = (int(qh >> uint(j + 16l)) & 1) << 4
+                isum += ((b & 15) | h0) * int(xqp[bi * 32l + j]) + ((b >> 4) | h1) * int(xqp[bi * 32l + j + 16l])
+            }
+            let sb = bi * 4l * mr + r * 4l
+            let d = f16_to_f32(uint(sg[sb]) | (uint(sg[sb + 1l]) << 8u))
+            let m = f16_to_f32(uint(sg[sb + 2l]) | (uint(sg[sb + 3l]) << 8u))
+            f += (d * float(isum) + m * float(xbsp[bi])) * xsp[bi]
+        }
+    }
+    return f
+}
+
+//! The q51 GEMV kernel (the family anchor): rows [rb, re) of one plane-region pair off the
+//! grp<mr> q51 planes. xbsp = per-32 activation quant sums (the min-term's asum — the groupn
+//! driver precomputes them once per region). Reference body = the scalar grp walk above.
+[tune_perm(mr = 4), tune_perm(mr = 8),
+ tune_companion(fn = "q51q8_layout_gen", gen = "dasllama_gemm_gen::q8q8_layout"),
+ tune(gen = "dasllama_gemm_gen::q51_gemv", fallback = "mr4"),
+ hint(unsafe_range_check, noalias = qgp, noalias = sgp, noalias = xqp, noalias = xsp, noalias = xbsp)]
+def q51q8_gemv_gen(var yp : float?; qgp : uint8 const?; sgp : uint8 const?; xqp : int8 const?; xsp : float const?; xbsp : int const?; n, rb, re : int64) : void {
+    let mr = int64(q51q8_layout_gen())
+    let nb = n / 32l
+    unsafe {
+        for (i in range64(rb, re)) {
+            let g = i / mr
+            yp[i] = q51_grp_row_dot(qgp + g * mr * nb * 20l, sgp + g * mr * nb * 4l, i % mr, mr, xqp, xsp, xbsp, n)
+        }
+    }
+}
+
+// groupn_q51 slot (arm64-gen): region-contiguous rows-core spans off the grp<mr> q51 planes;
+// per-region per-32 activation sums precomputed once (shared by every row of the region), row
+// tails (d % mr) disk-order via the portable scalar dot
+def private q51q8_groupn_gen(var yp : float?; wq : uint8 const?; ws : uint8 const?; offs : int64 const?; nregions : int64; xqp : int8 const?; xsp : float const?; n, d : int64) {
+    let nb = n / 32l
+    let mr = int64(q51q8_layout_gen())
+    let ng = d / mr
+    var myp = yp
+    var bs : array<int>
+    bs |> resize(int(nregions * nb))
+    unsafe {
+        var bsp = addr(bs[0])
+        for (r in range64(nregions)) {
+            let xoff = offs[r * 2l + 1l]
+            for (bi in range64(nb)) {
+                var s = 0
+                for (j in range64(32l)) {
+                    s += int(xqp[xoff + bi * 32l + j])
+                }
+                bsp[r * nb + bi] = s
+            }
+        }
+        maybe_parallel_for(0, int(nregions * ng), matmul_chunks_gemv(int(nregions * ng * mr), get_q8_batch_chunks_per_job(), n * d * nregions)) $(gb, ge) {
+            unsafe {
+                var gg = int64(gb)
+                while (gg < int64(ge)) {
+                    let r = gg / ng
+                    let gLocal = gg % ng
+                    let gEnd = min(int64(ge) - r * ng, ng)
+                    let woff = offs[r * 2l]
+                    let xoff = offs[r * 2l + 1l]
+                    q51q8_gemv_gen(myp + r * d, wq + (woff / 32l) * 20l, ws + (woff / 32l) * 4l,
+                                   xqp + xoff, xsp + xoff / 32l, bsp + r * nb, n, gLocal * mr, gEnd * mr)
+                    gg = r * ng + gEnd
+                }
+            }
+        }
+        for (r in range64(nregions)) {   // row tails (d % mr): disk-order scalar dot per region
+            let woff = offs[r * 2l]
+            let xoff = offs[r * 2l + 1l]
+            for (i in range64(ng * mr, d)) {
+                myp[r * d + i] = dot_q51q8_scalar(wq + (woff / 32l + i * nb) * 20l, ws + (woff / 32l + i * nb) * 4l,
+                                                  xqp + xoff, xsp + xoff / 32l, n)
+            }
+        }
+    }
+    delete bs
+}
+
 // ===== K-quant grp<mr> repacks (kq stage 4): the layouts the stamped k4/k5/k6 rows cores read,
 // per superblock per mr-row group (tail rows d % mr stay disk-order, served by the portable
 // dots). Quant/high/scale byte layouts differ per format — see repack_k4/k5/k6_grp bodies. =====
@@ -1971,6 +2132,10 @@ def dasllama_math_gen_register() {
             kq_rows_k6 = @@k6q8_gemv_gen, kq_rows_q40 = @@q40q8_gemv_gen,
             kq_batch = @@kq_batch_kernel_gen,
             kq_groupn = @@kq_groupn_gen, kq_batch_groupn = @@kq_batch_groupn_gen,
+            // q51 family: self-anchored sdot GEMV (own grid/manifest entry) — arm64 only; the
+            // x64 twin below keeps the portable disk-order q51 slots
+            groupn_q51 = @@q51q8_groupn_gen, repack_q51 = @@repack_q51_gen,
+            q51_layout = @@q51q8_layout_gen,
             needs_repack = true, mx4_expand_interleaved = true, priority = 25,
             q8_layout = @@q8q8_layout_gen, kq_layout = @@kq_layout_fmt_gen, q8_wbias = @@q8q8_wbias_gen,
             q8_kgroup = @@q8q8_kgroup_gen))

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -799,6 +799,7 @@ def q51_tune_family() : string {
         if (!ok) {
             print("q51 {v._0} (mr={mr}): MISMATCH (maxdiff {maxdiff}) — aborting tune\n")
             delete sq; delete ss; delete hq; delete hs
+            delete sfx; delete hfx; delete tvs; delete y; delete yh
             return ""
         }
         var dt = 2147483647
@@ -815,6 +816,8 @@ def q51_tune_family() : string {
         }
         delete sq; delete ss; delete hq; delete hs
     }
+    delete sfx
+    delete hfx
     delete tvs
     delete y
     delete yh

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -682,6 +682,145 @@ def kq_gate_variant(suffix : string; tile : KqTileFn; gemv : KqRowsFn;
 }
 
 // one kq family's test pass: every variant of the format's OWN grid against the scalar oracle
+// ===== the q51 GEMV family (self-anchored, sdot-only grid) =====
+
+struct Q51Fixture {
+    n, d : int64
+    nb : int64
+    qq : array<uint8>       // disk-order 20B/block quant plane
+    qs : array<uint8>       // disk-order 4B/block f16 (d, m) scale plane
+    xq : array<int8>
+    xs : array<float>
+    xbs : array<int>        // per-32 activation sums (the q51 gemv contract)
+    yref : array<float>
+}
+
+def build_q51_fixture(n, d : int64) : Q51Fixture {
+    var fx = Q51Fixture(n = n, d = d, nb = n / 32l)
+    fx.qq |> resize(int(d * fx.nb * 20l))
+    fx.qs |> resize(int(d * fx.nb * 4l))
+    // valid small f16 scale bit patterns (d, m) cycled per block; quant/qh bytes an LCG walk
+    let f16s = fixed_array(0x2E66, 0x3266, 0xB18F, 0x2C00, 0x3000, 0xB266, 0x2A8F, 0x3400)
+    var seed = 0x12345
+    for (i in range64(length(fx.qq))) {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff
+        fx.qq[i] = uint8(seed >> 16)
+    }
+    for (r in range64(d)) {
+        for (bi in range64(fx.nb)) {
+            let sb = (r * fx.nb + bi) * 4l
+            let dv = f16s[int(r * 3l + bi) % 8]
+            let mv = f16s[int(r * 5l + bi * 7l + 3l) % 8]
+            fx.qs[sb] = uint8(dv & 255)
+            fx.qs[sb + 1l] = uint8(dv >> 8)
+            fx.qs[sb + 2l] = uint8(mv & 255)
+            fx.qs[sb + 3l] = uint8(mv >> 8)
+        }
+    }
+    var xrow : array<float>
+    xrow |> resize(int(n))
+    for (i in range64(n)) {
+        xrow[i] = float((i * 13l) % 37l) * 0.05 - 0.9
+    }
+    fx.xq |> resize(int(n))
+    fx.xs |> resize(int(fx.nb))
+    quantize_q8_0_into(xrow, n, fx.xq, fx.xs, 0l, 0l)
+    delete xrow
+    fx.xbs |> resize(int(fx.nb))
+    for (bi in range64(fx.nb)) {
+        var s = 0
+        for (j in range64(32l)) {
+            s += int(fx.xq[bi * 32l + j])
+        }
+        fx.xbs[bi] = s
+    }
+    fx.yref |> resize(int(d))
+    unsafe {
+        for (r in range64(d)) {
+            fx.yref[r] = dot_q51q8_scalar(addr(fx.qq[0]) + r * fx.nb * 20l, addr(fx.qs[0]) + r * fx.nb * 4l,
+                                          addr(fx.xq[0]), addr(fx.xs[0]), n)
+        }
+    }
+    return <- fx
+}
+
+def run_q51_gemv(gemv; fx : Q51Fixture; qq : array<uint8>; qs : array<uint8>; mr : int64; var y : array<float>) {
+    unsafe {
+        invoke(gemv, addr(y[0]), addr(qq[0]), addr(qs[0]), addr(fx.xq[0]), addr(fx.xs[0]), addr(fx.xbs[0]), fx.n, 0l, (fx.d / mr) * mr)
+    }
+}
+
+def close_to_q51_ref(fx : Q51Fixture; y : array<float>; mr : int64; var maxdiff : float&) : bool {
+    var mag = 0.0
+    let rows = int((fx.d / mr) * mr)
+    for (i in range(rows)) {
+        mag = max(mag, abs(fx.yref[i]))
+    }
+    let tol = max(1.0e-3, mag * 5.0e-5)
+    var ok = true
+    for (i in range(rows)) {
+        let df = abs(y[i] - fx.yref[i])
+        maxdiff = max(maxdiff, df)
+        ok = ok && df <= tol
+    }
+    return ok
+}
+
+// reference walks the layout companion's resolve (grp1/disk in the tuner process)
+def private q51_mr_of(sfx : string) : int64 => sfx == "mr8" ? 8l : (sfx == "mr4" ? 4l : int64(q51q8_layout_gen()))
+
+// The q51 family tune pass: gate every variant against the scalar disk oracle on repacked
+// planes, iso-bench the streamed decode shape, return the best suffix ("" = a gate failed).
+def q51_tune_family() : string {
+    var sfx <- build_q51_fixture(704l, 32768l)   // streamed: the 26B expert-down K at DRAM scale
+    var hfx <- build_q51_fixture(704l, 2816l)    // hot: one expert's down stack
+    var tvs <- q51q8_gemv_gen_variants()
+    var best = ""
+    var bestDt = 2147483647
+    var y : array<float>
+    y |> resize(int(sfx.d))
+    var yh : array<float>
+    yh |> resize(int(hfx.d))
+    for (v in tvs) {
+        let mr = q51_mr_of(v._0)
+        var sq := sfx.qq
+        var ss := sfx.qs
+        var hq := hfx.qq
+        var hs := hfx.qs
+        unsafe {
+            repack_q51_grp(addr(sq[0]), addr(ss[0]), sfx.n, sfx.d, mr)
+            repack_q51_grp(addr(hq[0]), addr(hs[0]), hfx.n, hfx.d, mr)
+        }
+        var maxdiff = 0.0
+        run_q51_gemv(v._1, sfx, sq, ss, mr, y)
+        var ok = close_to_q51_ref(sfx, y, mr, maxdiff)
+        run_q51_gemv(v._1, hfx, hq, hs, mr, yh)
+        ok = close_to_q51_ref(hfx, yh, mr, maxdiff) && ok
+        if (!ok) {
+            print("q51 {v._0} (mr={mr}): MISMATCH (maxdiff {maxdiff}) — aborting tune\n")
+            delete sq; delete ss; delete hq; delete hs
+            return ""
+        }
+        var dt = 2147483647
+        for (_rep in range(3)) {
+            let t0 = ref_time_ticks()
+            run_q51_gemv(v._1, sfx, sq, ss, mr, y)
+            dt = min(dt, get_time_usec(t0))
+        }
+        let gb = double(sfx.d * sfx.nb * 24l) / double(max(dt, 1)) / 1000.0lf
+        print("q51 {v._0} (mr={mr}): ok (maxdiff {maxdiff}), streamed {dt} us ({gb:0.1f} GB/s)\n")
+        if (dt < bestDt) {
+            bestDt = dt
+            best = v._0
+        }
+        delete sq; delete ss; delete hq; delete hs
+    }
+    delete tvs
+    delete y
+    delete yh
+    return best
+}
+
 def kq_test_family(fmt : int64; kfxs : array<KqFixture>) : bool {
     var tvs <- kq_tile_variants(fmt)
     var gtab <- kq_gemv_variants_by_suffix(fmt)
@@ -1392,6 +1531,16 @@ def tune_mode_run : bool {
             print("{entry} winner: {w} {wok ? "->" : "-> FAILED TO WRITE"} {tune_manifest_path()}\n")
             kok = kok && wok
         }
+    }
+    let q51_t0 = ref_time_ticks()
+    let qw = q51_tune_family()
+    print("TUNE_GEN_TIME q51_family {get_time_usec(q51_t0) / 1000} ms\n")
+    if (empty(qw)) {
+        kok = false
+    } else {
+        let qok = tune_manifest_set("q51q8_gemv_gen", qw)
+        print("q51q8_gemv_gen winner: {qw} {qok ? "->" : "-> FAILED TO WRITE"} {tune_manifest_path()}\n")
+        kok = kok && qok
     }
     let confirm_t0 = ref_time_ticks()
     let ok = confirm_and_write(vs[merged]._0) && kok

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -1422,7 +1422,7 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1435,18 +1435,18 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":145.5225534096127,
-            "stddev":3.3315732479095459
+            "tok_s":145.22715739540519,
+            "stddev":1.6870996952056885
           },
           "tg128":{
-            "tok_s":26.857309113264865,
-            "stddev":0.020655548200011253
+            "tok_s":29.650997621160815,
+            "stddev":0.0072771967388689518
           }
         },
         "source":"official",
-        "sha":"fa582726c",
+        "sha":"ba189967a",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest); q51q8_gemv_gen=mr4 (manifest)",
         "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
@@ -1488,7 +1488,7 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1501,12 +1501,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":121.574889,
-            "stddev":1.220269
+            "tok_s":120.801356,
+            "stddev":1.9510719999999999
           },
           "tg128":{
-            "tok_s":28.001379,
-            "stddev":0.165078
+            "tok_s":28.13842,
+            "stddev":0.083889000000000005
           }
         },
         "source":"official",
@@ -1519,7 +1519,7 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf\" -ngl 0 -nopo 1 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1532,12 +1532,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":117.53891299999999,
-            "stddev":0.30272300000000002
+            "tok_s":116.29980399999999,
+            "stddev":1.495479
           },
           "tg128":{
-            "tok_s":27.623059999999999,
-            "stddev":0.135772
+            "tok_s":27.924748999999998,
+            "stddev":0.114244
           }
         },
         "source":"official",
@@ -1581,7 +1581,7 @@
         "flavor":"accel",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1594,18 +1594,18 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":146.13302847294537,
-            "stddev":2.7106833457946777
+            "tok_s":141.1932187899329,
+            "stddev":2.3289098739624023
           },
           "tg128":{
-            "tok_s":26.879369133334116,
-            "stddev":0.0233466736972332
+            "tok_s":29.649276116916724,
+            "stddev":0.0063768005929887295
           }
         },
         "source":"official",
-        "sha":"fa582726c",
+        "sha":"ba189967a",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest); q51q8_gemv_gen=mr4 (manifest)",
         "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       }
     ],

--- a/modules/dasLLAMA/tests/test_kquant.das
+++ b/modules/dasLLAMA/tests/test_kquant.das
@@ -415,6 +415,70 @@ def private q51_batch_gate(t : T?) {
     }
 }
 
+// the grp<mr> q51 layout (the emitter family's plane): repack round-trip, the grp scalar walk,
+// the grp expand twins, and the untouched disk-order tail rows — all bit-exact vs disk
+def private q51_grp_gate(t : T?) {
+    let n = 704l
+    let nb = n / 32l
+    let d = 26l   // 3 grp8 (6 grp4) groups + a 2-row disk-order tail
+    var kq : array<uint8>
+    var ks : array<uint8>
+    q51_fill_planes(kq, ks, d, n)
+    var xq : array<int8>
+    var xs : array<float>
+    q51_fill_acts(xq, xs, 1l, n)
+    var xbs : array<int>
+    xbs |> resize(int(nb))
+    for (bi in range64(nb)) {
+        var s = 0
+        for (j in range64(32l)) {
+            s += int(xq[bi * 32l + j])
+        }
+        xbs[bi] = s
+    }
+    var yref : array<float>
+    yref |> resize(int(d))
+    unsafe {
+        for (r in range64(d)) {
+            yref[r] = dot_q51q8_scalar(addr(kq[0]) + r * nb * 20l, addr(ks[0]) + r * nb * 4l, addr(xq[0]), addr(xs[0]), n)
+        }
+        var qe : array<int8>
+        qe |> resize(int(n))
+        var qe2 : array<int8>
+        qe2 |> resize(int(n))
+        var sc : array<uint8>
+        sc |> resize(int(nb * 4l))
+        for (mr in fixed_array(4l, 8l)) {
+            var gq := kq
+            var gs := ks
+            repack_q51_grp(addr(gq[0]), addr(gs[0]), n, d, mr)
+            let grpRows = (d / mr) * mr
+            for (r in range64(d)) {
+                if (r < grpRows) {
+                    let gbase = (r / mr) * mr * nb
+                    let got = q51_grp_row_dot(addr(gq[0]) + gbase * 20l, addr(gs[0]) + gbase * 4l, r % mr, mr,
+                                              addr(xq[0]), addr(xs[0]), addr(xbs[0]), n)
+                    t |> success(got == yref[r], "q51_grp_row_dot must bit-match the disk scalar dot")
+                    expand_q51_grp_row(addr(gq[0]) + gbase * 20l, r % mr, mr, addr(qe[0]), nb)
+                    gather_q51_grp_scales(addr(gs[0]) + gbase * 4l, r % mr, mr, addr(sc[0]), nb)
+                    expand_q51_row(addr(kq[0]) + r * nb * 20l, addr(qe2[0]), nb)
+                    let ge = dot_q51e(addr(qe[0]), addr(sc[0]), addr(xq[0]), addr(xs[0]), n)
+                    let de = dot_q51e(addr(qe2[0]), addr(ks[0]) + r * nb * 4l, addr(xq[0]), addr(xs[0]), n)
+                    t |> success(ge == de, "q51 grp expand twins must bit-match the disk expand")
+                } else {
+                    let got = dot_q51q8_scalar(addr(gq[0]) + r * nb * 20l, addr(gs[0]) + r * nb * 4l, addr(xq[0]), addr(xs[0]), n)
+                    t |> success(got == yref[r], "q51 grp tail rows must stay disk-order")
+                }
+            }
+            delete gq
+            delete gs
+        }
+        delete qe
+        delete qe2
+        delete sc
+    }
+}
+
 [test]
 def test_q51_kernels(t : T?) {
     t |> run("dot_q51q8_scalar matches the fp64 plane-dequant reference at n=704") @(t : T?) {
@@ -422,6 +486,9 @@ def test_q51_kernels(t : T?) {
     }
     t |> run("q51 groupn bit-matches scalar row dots") @(t : T?) {
         q51_groupn_gate(t)
+    }
+    t |> run("q51 grp<mr> planes bit-match disk (repack + grp walk + expand twins + tails)") @(t : T?) {
+        q51_grp_gate(t)
     }
     t |> run("q51 batch + batch-groupn bit-match scalar row dots") @(t : T?) {
         q51_batch_gate(t)

--- a/modules/dasLLAMA/tests/test_parity.das
+++ b/modules/dasLLAMA/tests/test_parity.das
@@ -652,15 +652,15 @@ def test_parity_gemma4_26b(t : T?) {
     }
 }
 
-// gemma-4-26B-A4B-it Q4_K_M — the Q5_0 loader gate: the llama.cpp Q4_K_M MoE recipe bumps
-// ffn_down / ffn_down_exps on layers 3+ to Q5_0 (32 tensors), which load via the exact
-// Q5_0->Q8 transcode (byte-level gates in test_gguf_quant.das); the Q4_K/Q6_K rest ride the
-// native kq planes. Oracle simple_ids per-file (harness/parity.sh, 2026-07-15). Capped at 15
-// tokens — the same irreducible top-8 router near-tie as the Q8_0 arm above: at step 15 the
-// oracle derails out of the counting pattern while dasLLAMA keeps counting, so the divergence
-// sits on the oracle's own coin-flip, not a forward bug.
+// gemma-4-26B-A4B-it Q4_K_M — the q51 tier gate: this recipe's ffn_down_exps are Q5_1 on 29
+// layers (Q8_0 on one), riding the native q51 planes (the grp<mr> GEMV family since the Wave-2
+// q51 emitter); the Q4_K gate_up stacks ride the kq planes. Oracle simple_ids per-file
+// (harness/parity.sh, 2026-07-15). Capped at 12 tokens — the same irreducible top-8 router
+// near-tie as the Q8_0 arm above: at step 12 the top-2 gap is 0.4-1.5 (vs >6 at confident
+// steps; measured 2026-07-25 on both the disk-order and grp q51 paths, which land on opposite
+// sides of the flip), so the divergence sits on a router coin-flip, not a forward bug.
 let GEMMA4_26B_Q4KM_GEN <- [236743l, 236800l, 236778l, 236770l, 236764l, 236743l, 236800l, 236778l, 236778l, 236764l,
-                            236743l, 236800l, 236778l, 236800l, 236764l]
+                            236743l, 236800l]
 
 [test]
 def test_parity_gemma4_26b_q4km(t : T?) {

--- a/site/files/dasllama/bench_records.json
+++ b/site/files/dasllama/bench_records.json
@@ -85,16 +85,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":819.20553410117259,
-            "stddev":13.841548919677734
+            "tok_s":875.35419976053322,
+            "stddev":2.7784712314605713
           },
           "tg128":{
-            "tok_s":64.715896081636217,
-            "stddev":0.048071339726448059
+            "tok_s":64.72437621415898,
+            "stddev":0.040281064808368683
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights k4/k5/k6/q8 native; q8 activations; f16 scales; metal blob"
@@ -287,16 +287,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":143.51014794316262,
-            "stddev":1.8688379526138306
+            "tok_s":145.24479853842553,
+            "stddev":2.0622482299804688
           },
           "tg128":{
-            "tok_s":14.490425807153695,
-            "stddev":0.0076773958280682564
+            "tok_s":14.494149035860834,
+            "stddev":0.0089524462819099426
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights k4/k6/q8 native; q8 activations; f16 scales; metal blob"
@@ -489,16 +489,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":322.18006934471111,
-            "stddev":0.82716661691665649
+            "tok_s":327.5913902343861,
+            "stddev":0.31570258736610413
           },
           "tg128":{
-            "tok_s":33.410355402218116,
-            "stddev":1.4616864919662476
+            "tok_s":33.322471759728664,
+            "stddev":1.4384109973907471
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights k4/k6/q8 native; q8 activations; f32 scales; metal blob"
@@ -753,16 +753,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":975.31116002164924,
-            "stddev":3.4707350730895996
+            "tok_s":979.87508768904149,
+            "stddev":2.6294610500335693
           },
           "tg128":{
-            "tok_s":52.005009558973953,
-            "stddev":0.034262686967849731
+            "tok_s":52.569869735164204,
+            "stddev":0.016571598127484322
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights q8 native; q8 activations; f16 scales; metal blob"
@@ -893,16 +893,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":945.41748437426793,
-            "stddev":46.733753204345703
+            "tok_s":997.93734441589118,
+            "stddev":2.0523719787597656
           },
           "tg128":{
-            "tok_s":88.562698339367302,
-            "stddev":0.38233613967895508
+            "tok_s":88.383526781953094,
+            "stddev":0.11967682093381882
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights mxfp4/q8 native; q8 activations; f16 scales; metal blob"
@@ -1095,16 +1095,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":839.13387512511383,
-            "stddev":21.282266616821289
+            "tok_s":847.21132532574086,
+            "stddev":19.207096099853516
           },
           "tg128":{
-            "tok_s":86.164890040423458,
-            "stddev":0.10428550839424133
+            "tok_s":85.955085255674334,
+            "stddev":0.03312971442937851
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights k4/k6/q8 native; q8 activations; f32 scales; metal blob"
@@ -1297,16 +1297,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":129.39743550833799,
-            "stddev":1.3800555467605591
+            "tok_s":133.55806498041031,
+            "stddev":0.20453563332557678
           },
           "tg128":{
-            "tok_s":19.304210236321975,
-            "stddev":0.90736830234527588
+            "tok_s":20.336549004550896,
+            "stddev":0.29257255792617798
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights k4/k6 native; q8 activations; f32 scales; metal blob"
@@ -1422,7 +1422,7 @@
         "flavor":"tuned",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1435,18 +1435,18 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":145.5225534096127,
-            "stddev":3.3315732479095459
+            "tok_s":145.22715739540519,
+            "stddev":1.6870996952056885
           },
           "tg128":{
-            "tok_s":26.857309113264865,
-            "stddev":0.020655548200011253
+            "tok_s":29.650997621160815,
+            "stddev":0.0072771967388689518
           }
         },
         "source":"official",
-        "sha":"fa582726c",
+        "sha":"ba189967a",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest); q51q8_gemv_gen=mr4 (manifest)",
         "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       },
       {
@@ -1468,16 +1468,16 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":899.61722962438034,
-            "stddev":9.0033988952636719
+            "tok_s":928.10501848796173,
+            "stddev":2.8307809829711914
           },
           "tg128":{
-            "tok_s":61.190055986399486,
-            "stddev":2.7236282825469971
+            "tok_s":60.979481778717954,
+            "stddev":2.6481883525848389
           }
         },
         "source":"official",
-        "sha":"ac877ceec",
+        "sha":"96fb2ce5a",
         "version":"0.6.3",
         "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
         "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; metal blob"
@@ -1488,7 +1488,7 @@
         "flavor":"clean-cpu",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-clean-cpu/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf\" -ngl 0 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1501,12 +1501,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":121.574889,
-            "stddev":1.220269
+            "tok_s":120.801356,
+            "stddev":1.9510719999999999
           },
           "tg128":{
-            "tok_s":28.001379,
-            "stddev":0.165078
+            "tok_s":28.13842,
+            "stddev":0.083889000000000005
           }
         },
         "source":"official",
@@ -1519,7 +1519,7 @@
         "flavor":"stock",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"\"/Users/borisbatkin/Work/llama.cpp-ref-ebd048f/build-stock/bin/llama-bench\" -m \"/Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf\" -ngl 0 -nopo 1 -t 8 -p 512 -n 128 -r 5 -o json",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1532,12 +1532,12 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":117.53891299999999,
-            "stddev":0.30272300000000002
+            "tok_s":116.29980399999999,
+            "stddev":1.495479
           },
           "tg128":{
-            "tok_s":27.623059999999999,
-            "stddev":0.135772
+            "tok_s":27.924748999999998,
+            "stddev":0.114244
           }
         },
         "source":"official",
@@ -1581,7 +1581,7 @@
         "flavor":"accel",
         "box":"m1",
         "threads":8,
-        "date":"2026-07-24",
+        "date":"2026-07-25",
         "cmd":"bin/daslang -jit modules/dasLLAMA/benchmarks/lcpp_bench.das -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-26B-A4B-it-Q4_K_M.gguf -p 512 -n 128 -r 5 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
         "hardware":{
           "cpu":"Apple M1 Max",
@@ -1594,18 +1594,18 @@
         },
         "tests":{
           "pp512":{
-            "tok_s":146.13302847294537,
-            "stddev":2.7106833457946777
+            "tok_s":141.1932187899329,
+            "stddev":2.3289098739624023
           },
           "tg128":{
-            "tok_s":26.879369133334116,
-            "stddev":0.0233466736972332
+            "tok_s":29.649276116916724,
+            "stddev":0.0063768005929887295
           }
         },
         "source":"official",
-        "sha":"fa582726c",
+        "sha":"ba189967a",
         "version":"0.6.3",
-        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest)",
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=kstep2 (manifest); q51q8_gemv_gen=mr4 (manifest)",
         "exec_fmt":"weights k4/q51/q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)"
       }
     ],


### PR DESCRIPTION
The gemma-4-26B-A4B cpu decode cell was the board's worst standing loss. Per-bucket attribution (new `blk_attn`/`blk_ffn` outer profiler spans + an `mm_moe` gate/up-vs-down split, both in this PR) pinned it to one kernel: the **q51 (Q5_1) expert-down GEMV**, running expand-then-MAC over disk-order planes at ~43 GB/s achieved vs llama.cpp's 61 (das 6854 vs 4900 us/token on the down projection alone — the cell needed 1500 back).

### The fix: q51 joins the emitter-kernel family pattern

q51 was the one weight format without an LLVM-emitter family (k4/k5/k6/q40/q8/mx4 all have one). This PR gives it the full treatment:

- **Self-anchored `[tune]` family** on `q51q8_gemv_gen` — mr4/mr8 sdot grid, its own manifest entry, layout companion riding the shared `q8q8_layout` generator. The grid is aarch64-only by construction; x64 declines through the fallback chain to the untouched portable path (zen2 numbers unchanged).
- **grp-interleaved planes repacked at load** (`repack_q51_grp`): per 32-weight block, nibbles dword-interleaved across the mr rows exactly like the mx4 repack, qh appended row-major (one 16B load spans four rows' qh at mr4), f16 (d, m) scale pairs interleaved per block. grp1 reproduces disk order byte-for-byte, tail rows (d % mr) stay disk-order, and the dlim image identity folds the q51 mr so images self-invalidate.
- **Register-fused block emitter** (`emit_block_q51`): nibble loads + in-register qh bit-spread (constant-shuffle byte pick + cmp/sext lattice — no scratch expand round-trip), unsigned sdot lane-dots, and the per-block `(d*isum + m*asum)*xs` fold in the scalar reference's op order, with the min-term's activation block-sums precomputed once per region by the das-level groupn driver.
- **All three portable q51 kernels are grp-aware** (`expand_q51_grp_row` / `gather_q51_grp_scales` twins), so prefill/batch stay correct over repacked planes on every backend; mr==1 and tail rows keep the SWAR fast path.
- **Tuner integration**: `gen_tune_probe` gains a q51 family section (correctness gates against the scalar disk oracle on repacked planes, streamed + hot fixtures at the real 26B shapes, crowns the manifest entry).

### Results (M1 Max, official records rail, adjacent warm pairs)

| cell | before | after | ratio |
|---|---|---|---|
| 26B cpu tg128 vs clean-cpu | 26.86 vs 28.0 = **0.959** | 29.65 ± 0.007 vs 28.14 | **1.054** |
| 26B cpu+accel tg128 vs stock -nopo | 26.88 vs 27.62 = 0.973 | 29.65 vs 27.92 | **1.062** |
| 26B cpu pp512 | 145.5 | 145.2 | no regression |

`mm_moe_dn` 6854 → 3477 us/token (the down GEMV halved); iso-bench 21.3 GB/s/lane vs the scalar reference's 2.8. records/m1.json + the site bench_records re-paired in-PR.

### Correctness

- Probe family gates: grp reference bit-exact (maxdiff 0) vs the disk scalar oracle; emitted mr4/mr8 maxdiff 1.1e-05 (fast-math fold-order class).
- `test_kquant` 106/106 including a new grp gate: repack round-trip, the grp scalar walk, the expand twins, and untouched disk-order tails — all bit-exact. `test_groupn` 6/6.
- 26B Q4_K_M token parity through the grp prefill AND decode paths.
- **One test-expectation change, following in-tree precedent**: the 26B Q4_K_M parity pin is capped 15 → 12 tokens. Step 12 is a top-8-of-128 router near-tie — measured top-2 logit gap 0.37 (new path) / 1.49 (old path) vs >6 at oracle-confident steps, with the two paths landing on opposite sides of the flip (old path forced via a manifest pinning the family to `reference` passes 15/15 on the same binary). This is the same documented irreducible class that capped the Q8_0 arm at 11 tokens; the comment also fixes a stale format claim (the file's exps are Q5_1 on native q51 planes, not the older Q5_0-transcode description).

### Also in this PR

- Decode profiler: permanent `blk_attn`/`blk_ffn` per-layer outer spans (wall now fully decomposable, cost unmeasurable) + the `mm_moe`/`mm_moe_dn` split + gemma4 moe-ffn glue buckets.
- `gen_tune_probe`: the family's "reference" variants row maps to the layout companion's resolve (grp1 in the tuner process), not a hardcoded mr.

Preflight --full: 16 passed, 0 failed, 1 skipped (cpp-syntax — no C++ changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
