### PR TITLE
dasLLAMA metal lens: derive @role's read/write axis from kernel bodies

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_kernel_access.das
+++ b/modules/dasLLAMA/dasllama/dasllama_kernel_access.das
@@ -14,14 +14,36 @@ require daslib/rtti
 // passed whole as an argument to a call it does not model — lands in `err` so the lens can fail
 // the compile instead of silently under-tracking (the strictness ratchet).
 
+let private ACCESS_DEBUG = false   // flip for macro-time access-derivation prints
+
 struct AccessResult {
     reads : table<string>
     writes : table<string>
     err : string   // non-empty = unanalyzable construct; the lens turns it into a compile error
 }
 
-// write-root of an assignment target: peel subscripts/fields/swizzles down to the base variable
-def private write_root(e : Expression?) : ExprVar? {
+// write-root of an assignment target: peel subscripts/fields/swizzles down to the base variable.
+// In field mode the peel STOPS at the first ExprField whose name is tracked (a class-field
+// buffer) and reports that name; `node` carries the claimable expression either way.
+// an ExprField that names a tracked buffer AND whose base is the kernel class itself — the
+// name check alone collides with float4 component access (`wv.y`), whose names shadow the
+// classic buffer names (x/y/w)
+// bodies are PRE-infer at lens time: buffer fields appear as bare ExprVar names, and member
+// access is a parser-level ExprField with untyped base — so an ExprField counts as a buffer
+// access only when written explicitly as self.<name> (float4 components like `wv.y` shadow the
+// classic buffer names and must NOT match)
+def private is_self_field(ef : ExprField const?; tracked : table<string>) : bool {
+    if (!key_exists(tracked, string(ef.name))) {
+        return false
+    }
+    var base = ef.value
+    if (base is ExprRef2Value) {
+        base = (base as ExprRef2Value).subexpr
+    }
+    return base is ExprVar && (base as ExprVar).name == "self"
+}
+
+def private write_root_name(e : Expression?; tracked : table<string>; fieldMode : bool; var node : Expression const?&) : string {
     var cur = e
     while (true) {
         if (cur is ExprAt) {
@@ -29,7 +51,12 @@ def private write_root(e : Expression?) : ExprVar? {
         } elif (cur is ExprSafeAt) {
             cur = (cur as ExprSafeAt).subexpr
         } elif (cur is ExprField) {
-            cur = (cur as ExprField).value
+            let ef = cur as ExprField
+            if (fieldMode && is_self_field(ef, tracked)) {
+                node = cur
+                return string(ef.name)
+            }
+            cur = ef.value
         } elif (cur is ExprSwizzle) {
             cur = (cur as ExprSwizzle).value
         } elif (cur is ExprRef2Value) {
@@ -38,7 +65,14 @@ def private write_root(e : Expression?) : ExprVar? {
             break
         }
     }
-    return cur is ExprVar ? cur as ExprVar : null
+    if (cur is ExprVar) {
+        let ev = cur as ExprVar
+        if (key_exists(tracked, string(ev.name))) {
+            node = cur
+            return string(ev.name)
+        }
+    }
+    return ""
 }
 
 def private is_setop2(op : das_string) : bool {
@@ -51,24 +85,31 @@ def private is_setop1(op : das_string) : bool => op == "++" || op == "--" || op 
 
 class private AccessVisitor : AstVisitor {
     tracked : table<string>
+    fieldMode : bool               // tracked names are class FIELDS (metal): match self.<name>
+                                   // ExprField accesses only (see is_self_field)
     reads : table<string>
     writes : table<string>
     callees : table<string>        // non-intrinsic call names, for the driver's same-module recursion
-    claimed : table<uint64>        // ExprVar nodes already classified as pure-write targets
+    claimed : table<string>        // pure-write target tokens, keyed name:line:column — infer
+                                   // CLONES subtrees during rewrites, so pointer identity misses
     err : string
 
     def is_tracked(name : das_string) : bool => key_exists(tracked, string(name))
 
     // record a write; `also_read` covers read-modify-write forms (+=, ++). A pure store claims
-    // the target node so the generic ExprVar pass does not also count it as a read.
+    // the target node so the generic read pass does not also count it as a read.
     def note_write(target : Expression?; also_read : bool) {
-        var v = write_root(target)
-        if (v == null || !is_tracked(v.name)) {
+        var node : Expression const?
+        let name = write_root_name(target, tracked, fieldMode, node)
+        if (empty(name)) {
             return
         }
-        writes |> insert(string(v.name))
+        writes |> insert(name)
         if (!also_read) {
-            claimed |> insert(intptr(v))
+            claimed |> insert("{name}:{node.at.line}:{node.at.column}")
+        }
+        if (ACCESS_DEBUG) {
+            print("[access-dbg] write {name} at={int(node.at.line)}:{int(node.at.column)} also_read={also_read}\n")
         }
     }
 
@@ -98,41 +139,70 @@ class private AccessVisitor : AstVisitor {
 
     def override preVisitExprCall(expr : ExprCall?) : void {
         let cname = string(expr.name)
-        // dasSpirv intrinsics that take a whole array and write (or only read) through it
-        if (cname == "coopmatStore") {
+        // GPU intrinsics that take a whole array and write (or only read) through it:
+        // dasSpirv coopmat pair + the dasMetal simdgroup pair store through arg 1;
+        // tg_store_float4(dst, idx, v) stores through arg 0
+        if (cname == "coopmatStore" || cname == "simdgroup_store") {
             if (length(expr.arguments) >= 2) {
                 note_write(expr.arguments[1], false)
             }
             return
         }
-        if (cname == "coopmatLoad") {
-            return   // src argument is a plain read — the generic ExprVar pass records it
+        if (cname == "tg_store_float4") {
+            if (!empty(expr.arguments)) {
+                note_write(expr.arguments[0], false)
+            }
+            return
+        }
+        if (cname == "coopmatLoad" || cname == "simdgroup_load") {
+            return   // src argument is a plain read — the generic read pass records it
         }
         callees |> insert(cname)
-        // the ratchet: a tracked global passed WHOLE to a call we do not model could be written
-        // through a var parameter — refuse to guess
+        // the ratchet: a tracked buffer passed WHOLE to a call we do not model could be written
+        // through a var parameter — refuse to guess. In field mode `self` passed whole is the
+        // same hole (a class-method helper could touch any field), and field-mode analysis does
+        // NOT recurse into free callees (bare-name matching would collide with their locals).
         for (a in expr.arguments) {
             var cur = a
             if (cur is ExprRef2Value) {
                 cur = (cur as ExprRef2Value).subexpr
             }
+            let escape = fieldMode ? "declare the @role (access_force)" : "declare [vk_access]"
             if (cur is ExprVar && is_tracked((cur as ExprVar).name)) {
-                err = "tracked global '{(cur as ExprVar).name}' passed whole to call '{cname}' — teach the intrinsic table or declare [vk_access]"
+                err = "tracked buffer '{(cur as ExprVar).name}' passed whole to call '{cname}' — teach the intrinsic table or {escape}"
+            } elif (fieldMode && cur is ExprField && is_self_field(cur as ExprField, tracked)) {
+                err = "tracked buffer '{(cur as ExprField).name}' passed whole to call '{cname}' — teach the intrinsic table or {escape}"
+            } elif (fieldMode && cur is ExprVar && (cur as ExprVar).name == "self") {
+                err = "'self' passed whole to call '{cname}' — the classifier cannot see through method helpers; use access_force with declared roles"
             }
         }
     }
 
     def override visitExprVar(var expr : ExprVar?) : ExpressionPtr {
-        if (is_tracked(expr.name) && !key_exists(claimed, intptr(expr))) {
+        if (is_tracked(expr.name) && !key_exists(claimed, "{expr.name}:{expr.at.line}:{expr.at.column}")) {
             reads |> insert(string(expr.name))
+            if (ACCESS_DEBUG) {
+                print("[access-dbg] read {expr.name} at={int(expr.at.line)}:{int(expr.at.column)}\n")
+            }
+        }
+        return expr
+    }
+
+    def override visitExprField(var expr : ExprField?) : ExpressionPtr {
+        if (fieldMode && is_self_field(expr, tracked) && !key_exists(claimed, "{expr.name}:{expr.at.line}:{expr.at.column}")) {
+            reads |> insert(string(expr.name))
+            if (ACCESS_DEBUG) {
+                print("[access-dbg] read {expr.name} at={int(expr.at.line)}:{int(expr.at.column)} (field)\n")
+            }
         }
         return expr
     }
 }
 
-def private analyze_one(fn : Function?; tracked : table<string>; var res : AccessResult; var callees : table<string>) {
+def private analyze_one(fn : Function?; tracked : table<string>; fieldMode : bool; var res : AccessResult; var callees : table<string>) {
     var astVisitor = new AccessVisitor()
     astVisitor.tracked := tracked
+    astVisitor.fieldMode = fieldMode
     make_visitor(*astVisitor) $(adapter) {
         visit(fn, adapter)
     }
@@ -153,18 +223,19 @@ def private analyze_one(fn : Function?; tracked : table<string>; var res : Acces
     }
 }
 
-//! Classify which `tracked` globals `fn` reads and writes, recursing into same-module callees
-//! (helpers access the globals directly; passing a tracked global BY ARGUMENT is refused — see
-//! AccessResult.err). Recursion is name-keyed over `mod`'s functions with a visited-set guard.
-def classify_global_access(fn : Function?; mod : Module?; tracked : table<string>) : AccessResult {
+def private classify_access(fn : Function?; mod : Module?; tracked : table<string>; fieldMode : bool) : AccessResult {
     var res : AccessResult
     var pending : table<string>
     var visited : table<string>
     var callees : table<string>
-    analyze_one(fn, tracked, res, callees)
+    analyze_one(fn, tracked, fieldMode, res, callees)
     visited |> insert(string(fn.name))
+    // field mode is intra-body only: free callees are shader intrinsics whose das shims would
+    // false-positive on bare-name matching, and self-helpers hit the ratchet instead
     for (c in keys(callees)) {
-        pending |> insert(c)
+        if (!fieldMode) {
+            pending |> insert(c)
+        }
     }
     while (!empty(pending)) {
         var name = ""
@@ -180,7 +251,7 @@ def classify_global_access(fn : Function?; mod : Module?; tracked : table<string
         var next : table<string>
         mod |> for_each_function(name) $(cfn) {
             if (cfn.name == name) {
-                analyze_one(cfn, tracked, res, next)
+                analyze_one(cfn, tracked, fieldMode, res, next)
             }
         }
         for (c in keys(next)) {
@@ -194,4 +265,18 @@ def classify_global_access(fn : Function?; mod : Module?; tracked : table<string
     delete visited
     delete callees
     return <- res
+}
+
+//! Classify which `tracked` globals `fn` reads and writes, recursing into same-module callees
+//! (helpers access the globals directly; passing a tracked global BY ARGUMENT is refused — see
+//! AccessResult.err). Recursion is name-keyed over `mod`'s functions with a visited-set guard.
+def classify_global_access(fn : Function?; mod : Module?; tracked : table<string>) : AccessResult {
+    return <- classify_access(fn, mod, tracked, false)
+}
+
+//! The field-mode twin for class-shaped kernels (metal): `tracked` names are the class's buffer
+//! FIELDS — pre-infer bodies spell them as bare names (or explicit self.<name>); member access
+//! on anything else (float4 components like wv.y) never matches.
+def classify_field_access(fn : Function?; mod : Module?; tracked : table<string>) : AccessResult {
+    return <- classify_access(fn, mod, tracked, true)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -27,10 +27,10 @@ require dasllama/dasllama_metal_lens
 // cache lines 2KB apart — measured 27us/layer at depth 24). Pass 2 softmax, pass 3 V-accumulate.
 [metal_dispatch(name = "enc_attn16_c", pso = "g_pso_attn16", tgmem = "metal_sq_attn16_msl_tgmem", tg = "head_size", grid = "nheads", params = "nheads : int64, head_size : int64")]
 class MetalSqAttnF16 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" kc : array<float16>  // this layer's K mirror slab (bound at the layer's byte offset)
-    @ssbo @binding = 1 @role = "read" @off = "voff" vc : array<float16>
-    @ssbo @binding = 2 @role = "read" q : array<float>     // [B x qd] roped queries
-    @ssbo @binding = 3 @role = "write" yo : array<float>    // [B x qd] attention out
+    @ssbo @binding = 0 @off = "koff" kc : array<float16>  // this layer's K mirror slab (bound at the layer's byte offset)
+    @ssbo @binding = 1 @off = "voff" vc : array<float16>
+    @ssbo @binding = 2 q : array<float>     // [B x qd] roped queries
+    @ssbo @binding = 3 yo : array<float>    // [B x qd] attention out
     @uniform @binding = 4 cnt : uint        // context depth (pos + 1)
     @uniform @binding = 5 kv_dim : uint
     @uniform @binding = 6 nheads : uint
@@ -199,10 +199,10 @@ class MetalSqAttnF16 {
 // f32-mirror twin (sessions created with f32 KV) — same math, f32 loads.
 [metal_dispatch(name = "enc_attn32_c", pso = "g_pso_attn32", tgmem = "metal_sq_attn32_msl_tgmem", tg = "head_size", grid = "nheads", params = "nheads : int64, head_size : int64")]
 class MetalSqAttnF32 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" kc : array<float>
-    @ssbo @binding = 1 @role = "read" @off = "voff" vc : array<float>
-    @ssbo @binding = 2 @role = "read" q : array<float>
-    @ssbo @binding = 3 @role = "write" yo : array<float>
+    @ssbo @binding = 0 @off = "koff" kc : array<float>
+    @ssbo @binding = 1 @off = "voff" vc : array<float>
+    @ssbo @binding = 2 q : array<float>
+    @ssbo @binding = 3 yo : array<float>
     @uniform @binding = 4 cnt : uint
     @uniform @binding = 5 kv_dim : uint
     @uniform @binding = 6 nheads : uint
@@ -367,12 +367,12 @@ class MetalSqAttnF32 {
 // stream. Measured 1.1-1.7x over the f16 form at d512-2048 (benchmarks/attn/bench_metal_sq_attn.das).
 [metal_dispatch(name = "enc_attn_q8_c", pso = "g_pso_attn_q8", tgmem = "metal_sq_attn_q8_msl_tgmem", tg = "head_size", grid = "nheads", params = "nheads : int64, head_size : int64")]
 class MetalSqAttnQ8 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" ksh : array<float16> // K mirror slab, HALF-SCALE view (bound at the layer's byte offset)
+    @ssbo @binding = 0 @off = "koff" ksh : array<float16> // K mirror slab, HALF-SCALE view (bound at the layer's byte offset)
     @ssbo @binding = 1 @role = "alias" @off = "koff" kqb : array<int8>    // the SAME K slab, BYTE view
-    @ssbo @binding = 2 @role = "read" @off = "voff" vsh : array<float16>
+    @ssbo @binding = 2 @off = "voff" vsh : array<float16>
     @ssbo @binding = 3 @role = "alias" @off = "voff" vqb : array<int8>
-    @ssbo @binding = 4 @role = "read" q : array<float>     // [B x qd] roped queries
-    @ssbo @binding = 5 @role = "write" yo : array<float>    // [B x qd] attention out
+    @ssbo @binding = 4 q : array<float>     // [B x qd] roped queries
+    @ssbo @binding = 5 yo : array<float>    // [B x qd] attention out
     @uniform @binding = 6 cnt : uint        // context depth (pos + 1)
     @uniform @binding = 7 nblk : uint       // blocks per row = kv_dim / 32
     @uniform @binding = 8 nheads : uint
@@ -551,12 +551,12 @@ class MetalSqAttnQ8 {
 // rotates it), so attention runs in the rotated basis and yo needs one fwht-unsign pass downstream.
 [metal_dispatch(name = "enc_attn_tq4_c", pso = "g_pso_attn_tq4", tgmem = "metal_sq_attn_tq4_msl_tgmem", tg = "head_size", grid = "nheads", params = "nheads : int64, head_size : int64")]
 class MetalSqAttnTq4 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" ksh : array<float16> // K mirror slab, HALF-SCALE view (bound at the layer's byte offset)
+    @ssbo @binding = 0 @off = "koff" ksh : array<float16> // K mirror slab, HALF-SCALE view (bound at the layer's byte offset)
     @ssbo @binding = 1 @role = "alias" @off = "koff" kqb : array<uint8>   // the SAME K slab, BYTE view
-    @ssbo @binding = 2 @role = "read" @off = "voff" vsh : array<float16>
+    @ssbo @binding = 2 @off = "voff" vsh : array<float16>
     @ssbo @binding = 3 @role = "alias" @off = "voff" vqb : array<uint8>
-    @ssbo @binding = 4 @role = "read" q : array<float>     // [B x qd] roped + rotated queries
-    @ssbo @binding = 5 @role = "write" yo : array<float>    // [B x qd] attention out (rotated basis)
+    @ssbo @binding = 4 q : array<float>     // [B x qd] roped + rotated queries
+    @ssbo @binding = 5 yo : array<float>    // [B x qd] attention out (rotated basis)
     @uniform @binding = 6 cnt : uint
     @uniform @binding = 7 nblk : uint       // blocks per row = kv_dim / 32
     @uniform @binding = 8 nheads : uint
@@ -728,10 +728,10 @@ class MetalSqAttnTq4 {
 // rescales across chunks. The single-tg form is latency-bound (measured 7.5ms/token at depth 512).
 [metal_dispatch(name = "enc_attnp16_c", pso = "g_pso_attnp16", tgmem = "metal_sq_attn_part16_msl_tgmem", tg = "head_size", grid = "ntg", params = "ntg : int64, head_size : int64")]
 class MetalSqAttnPartF16 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" kc : array<float16>
-    @ssbo @binding = 1 @role = "read" @off = "voff" vc : array<float16>
-    @ssbo @binding = 2 @role = "read" q : array<float>
-    @ssbo @binding = 3 @role = "write" part : array<float>  // [B x nheads x nchunks x (hs+2)]: acc[hs], chunk max, chunk expsum
+    @ssbo @binding = 0 @off = "koff" kc : array<float16>
+    @ssbo @binding = 1 @off = "voff" vc : array<float16>
+    @ssbo @binding = 2 q : array<float>
+    @ssbo @binding = 3 part : array<float>  // [B x nheads x nchunks x (hs+2)]: acc[hs], chunk max, chunk expsum
     @uniform @binding = 4 cnt : uint
     @uniform @binding = 5 kv_dim : uint
     @uniform @binding = 6 nheads : uint
@@ -919,10 +919,10 @@ class MetalSqAttnPartF16 {
 // f32-mirror twin — same math, f32 K/V loads.
 [metal_dispatch(name = "enc_attnp32_c", pso = "g_pso_attnp32", tgmem = "metal_sq_attn_part32_msl_tgmem", tg = "head_size", grid = "ntg", params = "ntg : int64, head_size : int64")]
 class MetalSqAttnPartF32 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" kc : array<float>
-    @ssbo @binding = 1 @role = "read" @off = "voff" vc : array<float>
-    @ssbo @binding = 2 @role = "read" q : array<float>
-    @ssbo @binding = 3 @role = "write" part : array<float>
+    @ssbo @binding = 0 @off = "koff" kc : array<float>
+    @ssbo @binding = 1 @off = "voff" vc : array<float>
+    @ssbo @binding = 2 q : array<float>
+    @ssbo @binding = 3 part : array<float>
     @uniform @binding = 4 cnt : uint
     @uniform @binding = 5 kv_dim : uint
     @uniform @binding = 6 nheads : uint
@@ -1106,12 +1106,12 @@ class MetalSqAttnPartF32 {
 // MetalSqAttnQ8); partials stay f32, so the comb below serves this form unchanged.
 [metal_dispatch(name = "enc_attnp_q8_c", pso = "g_pso_attnp_q8", tgmem = "metal_sq_attn_part_q8_msl_tgmem", tg = "head_size", grid = "ntg", params = "ntg : int64, head_size : int64")]
 class MetalSqAttnPartQ8 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" ksh : array<float16>
+    @ssbo @binding = 0 @off = "koff" ksh : array<float16>
     @ssbo @binding = 1 @role = "alias" @off = "koff" kqb : array<int8>
-    @ssbo @binding = 2 @role = "read" @off = "voff" vsh : array<float16>
+    @ssbo @binding = 2 @off = "voff" vsh : array<float16>
     @ssbo @binding = 3 @role = "alias" @off = "voff" vqb : array<int8>
-    @ssbo @binding = 4 @role = "read" q : array<float>
-    @ssbo @binding = 5 @role = "write" part : array<float>  // [B x nheads x nchunks x (hs+2)]: acc[hs], chunk max, chunk expsum
+    @ssbo @binding = 4 q : array<float>
+    @ssbo @binding = 5 part : array<float>  // [B x nheads x nchunks x (hs+2)]: acc[hs], chunk max, chunk expsum
     @uniform @binding = 6 cnt : uint
     @uniform @binding = 7 nblk : uint       // blocks per row = kv_dim / 32
     @uniform @binding = 8 nheads : uint
@@ -1310,12 +1310,12 @@ class MetalSqAttnPartQ8 {
 // below serves this form unchanged and the fwht-unsign runs after it.
 [metal_dispatch(name = "enc_attnp_tq4_c", pso = "g_pso_attnp_tq4", tgmem = "metal_sq_attn_part_tq4_msl_tgmem", tg = "head_size", grid = "ntg", params = "ntg : int64, head_size : int64")]
 class MetalSqAttnPartTq4 {
-    @ssbo @binding = 0 @role = "read" @off = "koff" ksh : array<float16>
+    @ssbo @binding = 0 @off = "koff" ksh : array<float16>
     @ssbo @binding = 1 @role = "alias" @off = "koff" kqb : array<uint8>
-    @ssbo @binding = 2 @role = "read" @off = "voff" vsh : array<float16>
+    @ssbo @binding = 2 @off = "voff" vsh : array<float16>
     @ssbo @binding = 3 @role = "alias" @off = "voff" vqb : array<uint8>
-    @ssbo @binding = 4 @role = "read" q : array<float>
-    @ssbo @binding = 5 @role = "write" part : array<float>  // [B x nheads x nchunks x (hs+2)]
+    @ssbo @binding = 4 q : array<float>
+    @ssbo @binding = 5 part : array<float>  // [B x nheads x nchunks x (hs+2)]
     @uniform @binding = 6 cnt : uint
     @uniform @binding = 7 nblk : uint
     @uniform @binding = 8 nheads : uint
@@ -1505,8 +1505,8 @@ class MetalSqAttnPartTq4 {
 // unnormalized partial to the global max, sum, normalize. Dtype-agnostic (partials are f32).
 [metal_dispatch(name = "enc_attncomb_c", pso = "g_pso_attncomb", tg = "head_size", grid = "nheads", params = "nheads : int64, head_size : int64")]
 class MetalSqAttnComb {
-    @ssbo @binding = 0 @role = "read" part : array<float>
-    @ssbo @binding = 1 @role = "write" yo : array<float>
+    @ssbo @binding = 0 part : array<float>
+    @ssbo @binding = 1 yo : array<float>
     @uniform @binding = 2 nchunks : uint
     @uniform @binding = 3 nheads : uint
     @uniform @binding = 4 hs : uint
@@ -1555,10 +1555,10 @@ class MetalQ8GemvQkvRsF16 {
     @ssbo @binding = 0 @role = "weight" @off = "wqoff" wqbq : array<int8>   // wq blob, byte view @ the q tensor's byte offset
     @ssbo @binding = 1 @role = "weight" @off = "wqoff" wshq : array<float16>   // ... half-scale view (same offset). Segments bind
                                             // separately — kind-major layout keeps q/k/v apart
-    @ssbo @binding = 2 @role = "read" x : array<float4>
-    @ssbo @binding = 3 @role = "write" qo : array<float>    // q out, roped ([0, qd) of the QKV buffer)
-    @ssbo @binding = 4 @role = "write" @off = "koff" kd : array<float16>  // mirror K row (bound at the row offset)
-    @ssbo @binding = 5 @role = "write" @off = "voff" vd : array<float16>
+    @ssbo @binding = 2 x : array<float4>
+    @ssbo @binding = 3 qo : array<float>    // q out, roped ([0, qd) of the QKV buffer)
+    @ssbo @binding = 4 @off = "koff" kd : array<float16>  // mirror K row (bound at the row offset)
+    @ssbo @binding = 5 @off = "voff" vd : array<float16>
     @ssbo @binding = 6 @role = "weight" tcos : array<float>  // [hs/2] this position's rope row
     @ssbo @binding = 7 @role = "weight" tsin : array<float>
     @uniform @binding = 8 ndim : uint
@@ -1676,10 +1676,10 @@ class MetalQ8GemvQkvRsF16 {
 class MetalQ8GemvQkvRsF32 {
     @ssbo @binding = 0 @role = "weight" @off = "wqoff" wqbq : array<int8>   // per-segment blob views — the F16 twin's scheme
     @ssbo @binding = 1 @role = "weight" @off = "wqoff" wshq : array<float16>
-    @ssbo @binding = 2 @role = "read" x : array<float4>
-    @ssbo @binding = 3 @role = "write" qo : array<float>
-    @ssbo @binding = 4 @role = "write" @off = "koff" kd : array<float>
-    @ssbo @binding = 5 @role = "write" @off = "voff" vd : array<float>
+    @ssbo @binding = 2 x : array<float4>
+    @ssbo @binding = 3 qo : array<float>
+    @ssbo @binding = 4 @off = "koff" kd : array<float>
+    @ssbo @binding = 5 @off = "voff" vd : array<float>
     @ssbo @binding = 6 @role = "weight" tcos : array<float>
     @ssbo @binding = 7 @role = "weight" tsin : array<float>
     @uniform @binding = 8 ndim : uint
@@ -1795,8 +1795,8 @@ class MetalQ8GemvQkvRsF32 {
 class MetalQ8GemvW13Sw {
     @ssbo @binding = 0 @role = "weight" @off = "w1off" wqb1 : array<int8>   // w1 blob, byte view @ its tensor offset
     @ssbo @binding = 1 @role = "weight" @off = "w1off" wsh1 : array<float16>   // ... half-scale view
-    @ssbo @binding = 2 @role = "read" x : array<float4>
-    @ssbo @binding = 3 @role = "write" @span = "hidden*4" ho : array<float>    // [hidden] silu(gate)·up
+    @ssbo @binding = 2 x : array<float4>
+    @ssbo @binding = 3 @span = "hidden*4" ho : array<float>    // [hidden] silu(gate)·up
     @uniform @binding = 4 ndim : uint
     @uniform @binding = 5 hidden : uint
     @ssbo @binding = 6 @role = "weight" @off = "w3off" wqb3 : array<int8>   // w3 blob views
@@ -1844,8 +1844,8 @@ class MetalQ8GemvW13Sw {
 // src binds at the row's byte offset; grid = ceil(n/256) x 256-tg.
 [metal_dispatch(name = "enc_copy_row", pso = "g_pso_copy_row", tg = 256, grid = "n/256", params = "n : int64")]
 class MetalCopyRow {
-    @ssbo @binding = 0 @role = "read" @off = "soff" @span = "n*4" src : array<float>
-    @ssbo @binding = 1 @role = "write" @off = "doff" @span = "n*4" dst : array<float>
+    @ssbo @binding = 0 @off = "soff" @span = "n*4" src : array<float>
+    @ssbo @binding = 1 @off = "doff" @span = "n*4" dst : array<float>
     @uniform @binding = 2 n : uint
 
     [metal_kernel(name="metal_copy_row_msl")]
@@ -1862,8 +1862,8 @@ class MetalCopyRow {
 // strict > keeps the earliest, cross-lane the (==, <) rule picks the lower index).
 [metal_dispatch(name = "enc_argmax", pso = "g_pso_argmax", tgmem = "metal_argmax_msl_tgmem", tg = 1024, grid = "1")]
 class MetalArgmax {
-    @ssbo @binding = 0 @role = "read" lg : array<float>
-    @ssbo @binding = 1 @role = "write" tok : array<uint>    // [1] winner index out
+    @ssbo @binding = 0 lg : array<float>
+    @ssbo @binding = 1 tok : array<uint>    // [1] winner index out
     @uniform @binding = 2 n : uint
     @workgroup redv : float[32]
     @workgroup redi : uint[32]
@@ -1921,8 +1921,8 @@ class MetalArgmax {
 class MetalEmbedQ8 {
     @ssbo @binding = 0 @role = "weight" @off = "eoff" q : array<int8>      // the embed blob slice, byte view (quants at 34*b + 2)
     @ssbo @binding = 1 @role = "weight" @off = "eoff" sc : array<float16>  // the same buffer, half-scale view (block b at 17*b)
-    @ssbo @binding = 2 @role = "read" tok : array<uint>
-    @ssbo @binding = 3 @role = "write" xo : array<float>    // [dim] residual input out
+    @ssbo @binding = 2 tok : array<uint>
+    @ssbo @binding = 3 xo : array<float>    // [dim] residual input out
     @uniform @binding = 4 dim : uint
     @uniform @binding = 5 @role = "weight" escale : float    // embed_scale (gemma: sqrt(dim); 1.0 elsewhere — g_one or an uploaded scalar)
 
@@ -1946,8 +1946,8 @@ class MetalEmbedK6 {
     @ssbo @binding = 0 @role = "weight" @off = "doff" kdh : array<float16> // the d plane — the scale buffer bound at byte nsb*16
     @ssbo @binding = 1 @role = "weight" @off = "soff" kscb : array<uint8>  // 16B sub-scale blocks, byte view (same buffer at 0)
     @ssbo @binding = 2 @role = "weight" @off = "qoff" kqb : array<uint8>   // k6 quant plane, byte view (ql at 192*blk, qh at +128)
-    @ssbo @binding = 3 @role = "read" tok : array<uint>
-    @ssbo @binding = 4 @role = "write" xo : array<float>    // [dim] residual input out
+    @ssbo @binding = 3 tok : array<uint>
+    @ssbo @binding = 4 xo : array<float>    // [dim] residual input out
     @uniform @binding = 5 dim : uint
     @uniform @binding = 6 @role = "weight" escale : float    // embed_scale (gemma: sqrt(dim); 1.0 elsewhere — g_one or an uploaded scalar)
 
@@ -1987,10 +1987,10 @@ class MetalEmbedK6 {
 // dim caps at the slab; wider models take the unfused pair (enc_add_rms_site).
 [metal_dispatch(name = "enc_addrms_c", pso = "g_pso_addrms", tgmem = "metal_add_rms_msl_tgmem", tg = 1024, grid = "1")]
 class MetalAddRms {
-    @ssbo @binding = 0 @role = "readwrite" x : array<float>     // [dim] residual stream, add target
-    @ssbo @binding = 1 @role = "read" a : array<float>     // [dim] addend (fully read before y is written — y may alias a)
+    @ssbo @binding = 0 x : array<float>     // [dim] residual stream, add target
+    @ssbo @binding = 1 a : array<float>     // [dim] addend (fully read before y is written — y may alias a)
     @ssbo @binding = 2 @role = "weight" w : array<float>     // [dim] norm weight
-    @ssbo @binding = 3 @role = "write" y : array<float>     // [dim] normed out
+    @ssbo @binding = 3 y : array<float>     // [dim] normed out
     @uniform @binding = 4 dim : uint
     @uniform @binding = 5 eps : float
     @uniform @binding = 6 @role = "weight" ascale : float    // (x + a) * ascale — gemma4 layer_out_scale scales
@@ -2040,11 +2040,11 @@ class MetalAddRms {
 // reductions, no inter-dispatch barrier. x is staged for the trailing norm; same slab cap as MetalAddRms.
 [metal_dispatch(name = "enc_preaddrms_c", pso = "g_pso_preaddrms", tgmem = "metal_pre_add_rms_msl_tgmem", tg = 1024, grid = "1")]
 class MetalPreAddRms {
-    @ssbo @binding = 0 @role = "readwrite" x : array<float>     // [dim] residual stream, add target + written back
-    @ssbo @binding = 1 @role = "readwrite" a : array<float>     // [dim] attn out (post-wo); normed by wpa in place before the add
+    @ssbo @binding = 0 x : array<float>     // [dim] residual stream, add target + written back
+    @ssbo @binding = 1 a : array<float>     // [dim] attn out (post-wo); wpa norm applies inline during the add
     @ssbo @binding = 2 @role = "weight" wpa : array<float>   // [dim] post-attention norm weight
     @ssbo @binding = 3 @role = "weight" wffn : array<float>  // [dim] ffn norm weight
-    @ssbo @binding = 4 @role = "write" y : array<float>     // [dim] ffn-normed out
+    @ssbo @binding = 4 y : array<float>     // [dim] ffn-normed out
     @uniform @binding = 5 dim : uint
     @uniform @binding = 6 eps : float
     @workgroup xrow : float[4096]           // == ADD_RMS_MAX_DIM — stages x for the trailing norm
@@ -2117,10 +2117,10 @@ class MetalPreAddRms {
 // Replaces the rope_qk + kv_store dispatch pair.
 [metal_dispatch(name = "enc_rpst16_c", pso = "g_pso_rpst16", tg = 64, grid = "npairs/64", params = "npairs : int64")]
 class MetalRopeStoreF16 {
-    @ssbo @binding = 0 @role = "readwrite" qk : array<float>    // q at [0, qd) roped in place, k at [qd, qd + kvd)
+    @ssbo @binding = 0 qk : array<float>    // q at [0, qd) roped in place, k at [qd, qd + kvd)
     @ssbo @binding = 1 @role = "alias" @off = "vsoff" vs : array<float>    // raw v (the QKV buffer at the v offset)
-    @ssbo @binding = 2 @role = "write" @off = "koff" kd : array<float16>  // mirror K row (bound at the (layer, pos) row offset)
-    @ssbo @binding = 3 @role = "write" @off = "voff" vd : array<float16>
+    @ssbo @binding = 2 @off = "koff" kd : array<float16>  // mirror K row (bound at the (layer, pos) row offset)
+    @ssbo @binding = 3 @off = "voff" vd : array<float16>
     @ssbo @binding = 4 @role = "weight" tcos : array<float>  // [head_size/2] this position's rope row
     @ssbo @binding = 5 @role = "weight" tsin : array<float>
     @uniform @binding = 6 qd : uint
@@ -2176,10 +2176,10 @@ class MetalRopeStoreF16 {
 // reduction. Grid: nheads q + nkvh k + nkvh v; rope pairs via the tgmem-staged POST-NORM partner.
 [metal_dispatch(name = "enc_rpst_h16_c", pso = "g_pso_rpst_h16", tgmem = "metal_rope_store_h16_msl_tgmem", tg = "head_size", grid = "ntg", params = "ntg : int64, head_size : int64")]
 class MetalRopeStoreHF16 {
-    @ssbo @binding = 0 @role = "readwrite" qk : array<float>    // q at [0, qd) roped in place, k at [qd, qd + kvd)
+    @ssbo @binding = 0 qk : array<float>    // q at [0, qd) roped in place, k at [qd, qd + kvd)
     @ssbo @binding = 1 @role = "alias" @off = "vsoff" vs : array<float>    // raw v (the QKV buffer at the v offset)
-    @ssbo @binding = 2 @role = "write" @off = "koff" kd : array<float16>  // mirror K row (bound at the (layer, pos) row offset)
-    @ssbo @binding = 3 @role = "write" @off = "voff" vd : array<float16>
+    @ssbo @binding = 2 @off = "koff" kd : array<float16>  // mirror K row (bound at the (layer, pos) row offset)
+    @ssbo @binding = 3 @off = "voff" vd : array<float16>
     @ssbo @binding = 4 @role = "weight" tcos : array<float>  // [head_size/2] this position's rope row
     @ssbo @binding = 5 @role = "weight" tsin : array<float>
     @ssbo @binding = 6 @role = "weight" w : array<float>     // [qnorm | knorm] per-head RMS weights
@@ -2251,10 +2251,10 @@ class MetalRopeStoreHF16 {
 // f32-mirror twin — straight stores, no clamp.
 [metal_dispatch(name = "enc_rpst32_c", pso = "g_pso_rpst32", tg = 64, grid = "npairs/64", params = "npairs : int64")]
 class MetalRopeStoreF32 {
-    @ssbo @binding = 0 @role = "readwrite" qk : array<float>
+    @ssbo @binding = 0 qk : array<float>
     @ssbo @binding = 1 @role = "alias" @off = "vsoff" vs : array<float>
-    @ssbo @binding = 2 @role = "write" @off = "koff" kd : array<float>
-    @ssbo @binding = 3 @role = "write" @off = "voff" vd : array<float>
+    @ssbo @binding = 2 @off = "koff" kd : array<float>
+    @ssbo @binding = 3 @off = "voff" vd : array<float>
     @ssbo @binding = 4 @role = "weight" tcos : array<float>
     @ssbo @binding = 5 @role = "weight" tsin : array<float>
     @uniform @binding = 6 qd : uint
@@ -2305,11 +2305,11 @@ class MetalRopeStoreF32 {
 // same codec. K blocks rope their 16 pairs first; V blocks copy raw.
 [metal_dispatch(name = "enc_rpst_q8_c", pso = "g_pso_rpst_q8", tg = 64, grid = "nthreads/64", params = "nthreads : int64")]
 class MetalRopeStoreQ8 {
-    @ssbo @binding = 0 @role = "readwrite" qk : array<float>    // q at [0, qd) roped in place, k at [qd, qd + kvd)
+    @ssbo @binding = 0 qk : array<float>    // q at [0, qd) roped in place, k at [qd, qd + kvd)
     @ssbo @binding = 1 @role = "alias" @off = "vsoff" vs : array<float>    // raw v (the QKV buffer at the v offset)
-    @ssbo @binding = 2 @role = "write" @off = "koff" ksh : array<float16> // mirror K row, HALF-SCALE view (bound at the (layer, pos) row offset)
+    @ssbo @binding = 2 @off = "koff" ksh : array<float16> // mirror K row, HALF-SCALE view (bound at the (layer, pos) row offset)
     @ssbo @binding = 3 @role = "alias" @off = "koff" kqb : array<int8>    // the SAME K row, BYTE view
-    @ssbo @binding = 4 @role = "write" @off = "voff" vsh : array<float16>
+    @ssbo @binding = 4 @off = "voff" vsh : array<float16>
     @ssbo @binding = 5 @role = "alias" @off = "voff" vqb : array<int8>
     @ssbo @binding = 6 @role = "weight" tcos : array<float>  // [head_size/2] this position's rope row
     @ssbo @binding = 7 @role = "weight" tsin : array<float>
@@ -2415,11 +2415,11 @@ class MetalRopeStoreQ8 {
 // row; V heads rotate + quantize, matching the CPU seam's fwht_signs_row / quantize_tq4kv_row bit-for-bit.
 [metal_dispatch(name = "enc_rpst_tq4_c", pso = "g_pso_rpst_tq4", tgmem = "metal_rope_store_tq4_msl_tgmem", tg = "head_size", grid = "ntg", params = "ntg : int64, head_size : int64")]
 class MetalRopeStoreTq4 {
-    @ssbo @binding = 0 @role = "readwrite" qk : array<float>    // q at [0, qd) ropes + rotates in place, k at [qd, qd + kvd)
+    @ssbo @binding = 0 qk : array<float>    // q at [0, qd) ropes + rotates in place, k at [qd, qd + kvd)
     @ssbo @binding = 1 @role = "alias" @off = "vsoff" vs : array<float>    // raw v (the QKV buffer at the v offset)
-    @ssbo @binding = 2 @role = "write" @off = "koff" ksh : array<float16> // mirror K row, HALF-SCALE view (bound at the (layer, pos) row offset)
+    @ssbo @binding = 2 @off = "koff" ksh : array<float16> // mirror K row, HALF-SCALE view (bound at the (layer, pos) row offset)
     @ssbo @binding = 3 @role = "alias" @off = "koff" kqb : array<uint8>   // the SAME row, BYTE view
-    @ssbo @binding = 4 @role = "write" @off = "voff" vsh : array<float16>
+    @ssbo @binding = 4 @off = "voff" vsh : array<float16>
     @ssbo @binding = 5 @role = "alias" @off = "voff" vqb : array<uint8>
     @ssbo @binding = 6 @role = "weight" tcos : array<float>  // [head_size/2] this position's rope row
     @ssbo @binding = 7 @role = "weight" tsin : array<float>
@@ -2523,7 +2523,7 @@ class MetalRopeStoreTq4 {
 // the single-stream path dispatches one row.
 [metal_dispatch(name = "enc_unsign_c", pso = "g_pso_unsign", tgmem = "metal_fwht_unsign_msl_tgmem", tg = "head_size", grid = "nheads, nrows", params = "nheads : int64, nrows : int64, head_size : int64")]
 class MetalFwhtUnsign {
-    @ssbo @binding = 0 @role = "readwrite" yo : array<float>    // [rows x qstride] attention out, un-rotated in place
+    @ssbo @binding = 0 yo : array<float>    // [rows x qstride] attention out, un-rotated in place
     @ssbo @binding = 1 @role = "weight" signs : array<float>
     @uniform @binding = 2 head_size : uint
     @uniform @binding = 3 qstride : uint

--- a/modules/dasLLAMA/dasllama/dasllama_metal_lens.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_lens.das
@@ -10,6 +10,7 @@ require daslib/rtti
 require strings
 require daslib/strings_boost   // split / strip — the grid & params micro-format tokenizers
 require das_metal   // nolint:STYLE030 — MetalBuffer/MetalComputeEncoder are referenced only inside qmacro_type(type<...>), which STYLE030 can't see; the require is load-bearing for macro-time type resolution
+require dasllama_kernel_access   // the shared body-walk classifier (field mode) — @role's read/write axis is DERIVED
 
 // The dasLLAMA Metal kernel-dispatch lens. [metal_dispatch] reads a [metal_kernel] class's
 // @ssbo/@uniform field annotations and generates the enc_* dispatch builder that the hand-
@@ -23,6 +24,10 @@ struct private BufField {
     name : string
     binding : int
     role : string
+    hzrole : string  // the direction hz staging emits — resolved role, or an alias view's OWN
+                     // derived access (the tracker keys ranges by buffer, so staging both views
+                     // unions naturally; hand-written builders encoded that union on the owner)
+    ssbo : bool      // @ssbo (vs @uniform) — only ssbo fields join the access derivation
     off : string     // @off = "<param>" — bind at a caller-passed uint64 offset ("" = 0)
     rng : string     // @span = "<a*b*4>" product over params — exact hz length ("" = whole buffer)
 }
@@ -211,9 +216,35 @@ def private param_type(tok : string; var ok : bool&) : TypeDecl? {
 
 def private role_ok(role : string) : bool {
     // alias = a second view of a buffer another field already declares (hazard lives there);
-    // weight = never written during a step (untracked by design); "" = undeclared (ratchet)
+    // weight = never written during a step (untracked by design); "" = derived from the body.
+    // read/write/readwrite stay legal as cross-checked overrides of the derivation.
     return (role == "" || role == "read" || role == "write" || role == "readwrite" ||
         role == "weight" || role == "alias")
+}
+
+// the [metal_kernel] method of a lensed class — the body the access classifier walks
+def private find_kernel_fn(st : StructurePtr; mod : Module?; var nmatch : int&) : Function? {
+    var kfn : Function?
+    mod |> for_each_function("") $(fn) {
+        if (!empty(fn.arguments) && fn.arguments[0]._type.structType == st) {
+            for (ann in fn.annotations) {
+                if (ann.annotation.name == "metal_kernel") {
+                    nmatch++
+                    if (kfn == null) {
+                        kfn = fn
+                    }
+                }
+            }
+        }
+    }
+    return kfn
+}
+
+// derived direction of one tracked field off the classifier result
+def private derived_role(res : AccessResult; name : string) : string {
+    let r = key_exists(res.reads, name)
+    let w = key_exists(res.writes, name)
+    return w ? (r ? "readwrite" : "write") : (r ? "read" : "")
 }
 
 [structure_macro(name = metal_dispatch)]
@@ -289,21 +320,101 @@ class MetalDispatch : AstStructureAnnotation {
                 return false
             }
             let role = find_arg(field.annotation, "role") ?as tString ?? ""
-            // the strictness ratchet: every @ssbo on a lensed class declares its hazard role —
-            // an undeclared buffer is a compile error, not a silently-untracked bind
-            if (is_ssbo && empty(role)) {
-                errors := "[metal_dispatch] {fn_name}: @ssbo field '{field.name}' has no @role (read/write/readwrite/weight/alias)"
-                return false
-            }
             if (!role_ok(role)) {
                 errors := "[metal_dispatch] {fn_name}: field '{field.name}' has unknown @role '{role}' (read/write/readwrite/weight/alias)"
                 return false
             }
             let off = find_arg(field.annotation, "off") ?as tString ?? ""
             let rangeStr = find_arg(field.annotation, "span") ?as tString ?? ""
-            bufs |> push(BufField(name = "{field.name}", binding = binding, role = role, off = off, rng = rangeStr))
+            bufs |> push(BufField(name = "{field.name}", binding = binding, role = role, ssbo = is_ssbo, off = off, rng = rangeStr))
         }
         sort(bufs) $(a, b) => a.binding < b.binding
+
+        // The read/write axis is DERIVED from the kernel body (shared classifier, field mode).
+        // A declared read/write/readwrite is a cross-checked assertion (mismatch = compile
+        // error); weight/alias stay declared — frame policy and hazard ownership are not kernel
+        // facts — but a body WRITE to either is refused. access_force=true restores the fully
+        // declared contract (every @ssbo must carry a @role) when a body is unanalyzable.
+        let accessForce = find_arg(args, "access_force") ?as tBool ?? false
+        for (bf in bufs) {   // default: staging follows the (declared or later-derived) role
+            bf.hzrole = bf.role
+        }
+        if (accessForce) {
+            for (bf in bufs) {
+                if (bf.ssbo && empty(bf.role)) {
+                    errors := "[metal_dispatch] {fn_name}: access_force=true — @ssbo field '{bf.name}' must declare a @role"
+                    return false
+                }
+            }
+        } else {
+            var tracked : table<string>
+            for (bf in bufs) {
+                if (bf.ssbo) {
+                    tracked |> insert(bf.name)
+                }
+            }
+            var nmatch = 0
+            let kfn = find_kernel_fn(st, compiling_module(), nmatch)
+            if (kfn == null) {
+                errors := "[metal_dispatch] {fn_name}: no [metal_kernel] method on {st.name} to derive buffer access from (access_force=true to declare instead)"
+                delete tracked
+                return false
+            }
+            if (nmatch != 1) {
+                errors := "[metal_dispatch] {fn_name}: {nmatch} [metal_kernel] methods matched {st.name} — expected exactly one"
+                delete tracked
+                return false
+            }
+            var res <- classify_field_access(kfn, compiling_module(), tracked)
+            if (!empty(res.err)) {
+                errors := "[metal_dispatch] {fn_name}: {res.err} (or access_force=true + declared roles)"
+                delete res
+                delete tracked
+                return false
+            }
+            for (bf in bufs) {
+                if (!bf.ssbo) continue
+                let dr = derived_role(res, bf.name)
+                let decl = bf.role
+                if (decl == "weight") {
+                    // a written weight is a contract violation
+                    if (key_exists(res.writes, bf.name)) {
+                        errors := "[metal_dispatch] {fn_name}: field '{bf.name}' declares @role='weight' but the kernel body writes it"
+                        delete res
+                        delete tracked
+                        return false
+                    }
+                } elif (decl == "alias") {
+                    // an alias view stages its OWN derived access: the tracker keys ranges by
+                    // buffer, so both views' staging unions into the buffer-level truth (a write
+                    // through the alias must not go unstaged just because the sibling is read-only)
+                    bf.hzrole = derived_role(res, bf.name)
+                } elif (empty(decl)) {
+                    if (empty(dr)) {
+                        errors := "[metal_dispatch] {fn_name}: @ssbo field '{bf.name}' is never accessed by the kernel body — declare @role (weight/alias) or drop the binding"
+                        delete res
+                        delete tracked
+                        return false
+                    }
+                    bf.role = dr
+                    bf.hzrole = dr
+                } elif (decl != dr) {
+                    let drName = empty(dr) ? "unused" : dr
+                    var rk <- [for (k in keys(res.reads)); k]
+                    var wk <- [for (k in keys(res.writes)); k]
+                    sort(rk)   // keys() order is unspecified — sorted for deterministic diagnostics
+                    sort(wk)
+                    errors := "[metal_dispatch] {fn_name}: field '{bf.name}' declares @role='{decl}' but the body derives '{drName}' — fix whichever is wrong (access_force=true to override) [derived reads: {join(rk, ",")} writes: {join(wk, ",")}]"
+                    delete rk
+                    delete wk
+                    delete res
+                    delete tracked
+                    return false
+                }
+            }
+            delete res
+            delete tracked
+        }
 
         // Emit the dispatch sequence, mirroring the hand-written enc_ builder exactly: binds in
         // binding order, then all hz_reads, then all hz_writes (hz staging is order-free — the
@@ -318,12 +429,12 @@ class MetalDispatch : AstStructureAnnotation {
             body |> push(mk_kn_buffer(at, "b{bf.name}", bf.binding, bf.off))
         }
         for (bf in bufs) {
-            if (bf.role == "read" || bf.role == "readwrite") {
+            if (bf.hzrole == "read" || bf.hzrole == "readwrite") {
                 body |> push(mk_hz(at, "hz_read", bf))
             }
         }
         for (bf in bufs) {
-            if (bf.role == "write" || bf.role == "readwrite") {
+            if (bf.hzrole == "write" || bf.hzrole == "readwrite") {
                 body |> push(mk_hz(at, "hz_write", bf))
             }
         }
@@ -409,6 +520,20 @@ class MetalManualDispatchCensus : AstPassMacro {
             delete v
         }
         for_each_structure(mod) $(var st) {
+            // lensed classes DERIVE the read/write axis from the kernel body ([metal_dispatch]
+            // enforces derivability there); a bare @ssbo is only an error on un-lensed classes,
+            // whose hand-written builders still consume declared intent
+            var lensed = false
+            for (ann in st.annotations) {
+                if (ann.annotation.name == "metal_dispatch") {
+                    lensed = true
+                }
+            }
+            // un-lensed classes: the declared roles are the hand-written builders' contract —
+            // cross-check them against the same body derivation the lens uses, so every
+            // declaration in the module is machine-verified, not trust-me
+            var kfn : Function?
+            var tracked : table<string>
             for (field in st.fields) {
                 var is_ssbo = false
                 for (annDecl in field.annotation) {
@@ -417,13 +542,40 @@ class MetalManualDispatchCensus : AstPassMacro {
                     }
                 }
                 continue if (!is_ssbo)
+                if (!lensed) {
+                    tracked |> insert("{field.name}")
+                }
                 let role = find_arg(field.annotation, "role") ?as tString ?? ""
                 if (empty(role)) {
-                    macro_error(prog, field.at, "@ssbo field '{field.name}' of {st.name} has no @role (read/write/readwrite/weight/alias) — the scheduling rail needs every buffer's hazard intent declared")
+                    if (!lensed) {
+                        macro_error(prog, field.at, "@ssbo field '{field.name}' of {st.name} has no @role (read/write/readwrite/weight/alias) — un-lensed classes declare their hazard intent")
+                    }
                 } elif (!role_ok(role)) {
                     macro_error(prog, field.at, "@ssbo field '{field.name}' of {st.name} has unknown @role '{role}' (read/write/readwrite/weight/alias)")
                 }
             }
+            if (!lensed && !empty(tracked)) {
+                var nmatch = 0
+                kfn = find_kernel_fn(st, mod, nmatch)
+                if (kfn != null && nmatch == 1) {
+                    var res <- classify_field_access(kfn, mod, tracked)
+                    if (empty(res.err)) {   // an unanalyzable body keeps the declared contract as-is
+                        for (field in st.fields) {
+                            let role = find_arg(field.annotation, "role") ?as tString ?? ""
+                            continue if (role != "read" && role != "write" && role != "readwrite")
+                            let r = key_exists(res.reads, "{field.name}")
+                            let w = key_exists(res.writes, "{field.name}")
+                            let dr = w ? (r ? "readwrite" : "write") : (r ? "read" : "")
+                            if (dr != role) {
+                                let drName = empty(dr) ? "unused" : dr
+                                macro_error(prog, field.at, "@ssbo field '{field.name}' of {st.name} declares @role='{role}' but the kernel body derives '{drName}' — fix the stale declaration")
+                            }
+                        }
+                    }
+                    delete res
+                }
+            }
+            delete tracked
         }
         return true
     }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -36,9 +36,9 @@ require dasllama/dasllama_metal_lens   // [metal_dispatch] — generates decode 
 // lane 0 folds partials into rsqrt(mean + eps), every thread scales its strided slice.
 [metal_dispatch(name = "enc_rms", pso = "g_pso_rms", tgmem = "metal_rmsnorm_msl_tgmem", tg = 1024, grid = "1")]
 class MetalRmsNorm {
-    @ssbo @binding = 0 @role = "read" x : array<float>     // [nrows x dim] source
+    @ssbo @binding = 0 x : array<float>     // [nrows x dim] source
     @ssbo @binding = 1 @role = "weight" w : array<float>     // [dim] weight
-    @ssbo @binding = 2 @role = "write" y : array<float>     // [nrows x dim] out (x aliasing is safe: x is fully
+    @ssbo @binding = 2 y : array<float>     // [nrows x dim] out (x aliasing is safe: x is fully
                                             // read before the barrier that precedes any write)
     @uniform @binding = 3 dim : uint
     @uniform @binding = 4 eps : float
@@ -644,8 +644,8 @@ class MetalKqMulMmK6 {
 [metal_dispatch(name = "enc_moe_router", pso = "g_pso_moe_router", tg = "g_gemv_rows*32", grid = "ne/g_gemv_rows, nst", params = "ne : int64, nst : int64")]
 class MetalMoeRouter {
     @ssbo @binding = 0 @role = "weight" w : array<float4>    // [ne x dim] router weights, float4 view
-    @ssbo @binding = 1 @role = "read" x : array<float4>    // [streams x dim] activations, float4 view
-    @ssbo @binding = 2 @role = "write" @span = "ne*nst*4" y : array<float>     // [streams x ne] logits out
+    @ssbo @binding = 1 x : array<float4>    // [streams x dim] activations, float4 view
+    @ssbo @binding = 2 @span = "ne*nst*4" y : array<float>     // [streams x ne] logits out
     @uniform @binding = 3 ndim : uint       // dim (% 32)
     @uniform @binding = 4 ddim : uint       // ne
     @uniform @binding = 5 xs : uint         // per-stream x stride, elements
@@ -726,8 +726,8 @@ class MetalMoeRouterB {
 // tie-break (lowest index), register knockout. Stream row layout: [k idx u32][k w f32].
 [metal_dispatch(name = "enc_moe_select", pso = "g_pso_moe_select", tg = 32, grid = "nst", params = "nst : int64")]
 class MetalMoeSelect {
-    @ssbo @binding = 0 @role = "read" lg : array<float>     // [streams x ne] router logits
-    @ssbo @binding = 1 @role = "write" seli : array<uint>    // selection buffer, uint view — idx of stream s at s*2k
+    @ssbo @binding = 0 lg : array<float>     // [streams x ne] router logits
+    @ssbo @binding = 1 seli : array<uint>    // selection buffer, uint view — idx of stream s at s*2k
     @ssbo @binding = 2 @role = "alias" selw : array<float>   // the same buffer, float view — w of stream s at s*2k + k
     @uniform @binding = 3 ne : uint
     @uniform @binding = 4 nk : uint
@@ -1464,9 +1464,9 @@ class MetalMoeBiasRows {
 // w2 site's write shape).
 [metal_dispatch(name = "enc_moe_combine", pso = "g_pso_moe_combine", tg = 256, grid = "dim/256, nst", params = "dim : int64, nst : int64")]
 class MetalMoeCombine {
-    @ssbo @binding = 0 @role = "read" dn : array<float>    // [streams x k x dim] per-slot down outputs
-    @ssbo @binding = 1 @role = "read" selw : array<float>  // the selection buffer's float view — w of stream s at s*2k + k
-    @ssbo @binding = 2 @role = "write" y : array<float>     // [streams x dim] combined out
+    @ssbo @binding = 0 dn : array<float>    // [streams x k x dim] per-slot down outputs
+    @ssbo @binding = 1 selw : array<float>  // the selection buffer's float view — w of stream s at s*2k + k
+    @ssbo @binding = 2 y : array<float>     // [streams x dim] combined out
     @uniform @binding = 3 dim : uint
     @uniform @binding = 4 nk : uint
 
@@ -1514,9 +1514,9 @@ class MetalSwigluOai {
 // no GPU doubles — rare tie flips ride the tolerance methodology, per the wave ruling).
 [metal_dispatch(name = "enc_g4_router_norm", pso = "g_pso_g4rnorm", tgmem = "metal_g4_router_norm_msl_tgmem", tg = 256, grid = "nst", params = "nst : int64")]
 class MetalG4RouterNorm {
-    @ssbo @binding = 0 @role = "read" x : array<float>     // [rows x dim]
+    @ssbo @binding = 0 x : array<float>     // [rows x dim]
     @ssbo @binding = 1 @role = "weight" rs : array<float>    // [dim] per-channel router scale
-    @ssbo @binding = 2 @role = "write" y : array<float>     // [rows x dim]
+    @ssbo @binding = 2 y : array<float>     // [rows x dim]
     @uniform @binding = 3 dim : uint
     @uniform @binding = 4 eps : float
     @uniform @binding = 5 invd : float      // 1/sqrt(dim)
@@ -1573,7 +1573,7 @@ class MetalG4RouterNorm {
 // folds ffn_down_exps_s into the selection weights right after select.
 [metal_dispatch(name = "enc_moe_wscale", pso = "g_pso_moe_wscale", tg = 32, grid = "nst", params = "nst : int64")]
 class MetalMoeWScale {
-    @ssbo @binding = 0 @role = "readwrite" seli : array<uint>   // selection rows, uint view (idx of row r at r*2k)
+    @ssbo @binding = 0 seli : array<uint>   // selection rows, uint view (idx of row r at r*2k)
     @ssbo @binding = 1 @role = "alias" selw : array<float>  // the same buffer, float view (w of row r at r*2k + k)
     @ssbo @binding = 2 @role = "weight" ds : array<float>    // [ne] this layer's per-expert down scales
     @uniform @binding = 3 nk : uint
@@ -2281,8 +2281,8 @@ class MetalMoeMulMmK6 {
 class MetalQ8Gemv {
     @ssbo @binding = 0 @role = "weight" @off = "boff" wsh : array<float16> // 34B-block W blob, half-scale view (block b at 17*b)
     @ssbo @binding = 1 @role = "weight" @off = "boff" wqb : array<int8>    // the same blob buffer, byte view (quants at 34*b + 2)
-    @ssbo @binding = 2 @role = "read" x : array<float4>    // [n] f32 vector, float4 view
-    @ssbo @binding = 3 @role = "write" @off = "yoff" @span = "d*4" y : array<float>     // [d] outputs
+    @ssbo @binding = 2 x : array<float4>    // [n] f32 vector, float4 view
+    @ssbo @binding = 3 @off = "yoff" @span = "d*4" y : array<float>     // [d] outputs
     @uniform @binding = 4 ndim : uint       // n (reduction dim, % 32)
     @uniform @binding = 5 ddim : uint       // d (output rows)
 
@@ -3429,7 +3429,7 @@ class MetalAddBiasRows {
 // q+k in ONE grid over the fused QKV buffer; prefill dispatches separate q/k panels per-plane.
 [metal_dispatch(name = "enc_qk_norm", pso = "g_pso_qknorm", tgmem = "metal_qk_norm_msl_tgmem", tg = "head_size", grid = "ntg, nrows", params = "ntg : int64, nrows : int64, head_size : int64")]
 class MetalQkNorm {
-    @ssbo @binding = 0 @role = "readwrite" x : array<float>     // bound at the panel offset; normalized in place
+    @ssbo @binding = 0 x : array<float>     // bound at the panel offset; normalized in place
     @ssbo @binding = 1 @role = "weight" w : array<float>
     @uniform @binding = 2 nq : uint         // q-head threadgroups before the k heads
     @uniform @binding = 3 koffe : uint      // k region's element offset within a row (the WRITE side)
@@ -4031,7 +4031,7 @@ class MetalPfCat2 {
 // forward's pin value exactly; one thread per suppressed id.
 [metal_dispatch(name = "enc_suppress_row", pso = "g_pso_suppress", tg = 64, grid = "n/64", params = "n : int64")]
 class MetalSuppressRow {
-    @ssbo @binding = 0 @role = "readwrite" @off = "xoff" x : array<float>
+    @ssbo @binding = 0 @off = "xoff" x : array<float>
     @ssbo @binding = 1 @role = "weight" ids : array<uint>
     @uniform @binding = 2 n : uint
 
@@ -4049,7 +4049,7 @@ class MetalSuppressRow {
 // (gemma2/gemma4 final_logit_softcap on the GPU classifier row).
 [metal_dispatch(name = "enc_softcap_row", pso = "g_pso_softcap", tg = 64, grid = "total/64", params = "total : int64")]
 class MetalSoftcapRow {
-    @ssbo @binding = 0 @role = "readwrite" @off = "xoff" @span = "total*4" x : array<float>
+    @ssbo @binding = 0 @off = "xoff" @span = "total*4" x : array<float>
     @uniform @binding = 1 total : uint      // grid guard
     @uniform @binding = 2 cap : float
 
@@ -4071,10 +4071,10 @@ class MetalSoftcapRow {
 // history taps (the CPU dn_conv_state layout). Never writes history — MetalDnConvHist advances.
 [metal_dispatch(name = "enc_dn_conv", pso = "g_pso_dn_conv", tg = 256, grid = "cd/256, npos", params = "cd : int64, npos : int64")]
 class MetalDnConv {
-    @ssbo @binding = 0 @role = "read" x : array<float>     // [npos x cd] fused qkv projection rows
-    @ssbo @binding = 1 @role = "read" @off = "hoff" hist : array<float>  // [cd x taps] channel-major history (layer slice)
+    @ssbo @binding = 0 x : array<float>     // [npos x cd] fused qkv projection rows
+    @ssbo @binding = 1 @off = "hoff" hist : array<float>  // [cd x taps] channel-major history (layer slice)
     @ssbo @binding = 2 @role = "weight" w : array<float>     // [cd x dconv] conv taps (raw fblob layout)
-    @ssbo @binding = 3 @role = "write" y : array<float>     // [npos x cd] conv output, silu'd
+    @ssbo @binding = 3 y : array<float>     // [npos x cd] conv output, silu'd
     @uniform @binding = 4 cd : uint
     @uniform @binding = 5 dconv : uint
     @uniform @binding = 6 npos : uint
@@ -4104,8 +4104,8 @@ class MetalDnConv {
 // land in registers before any write, so the in-place buffer update is safe per channel.
 [metal_dispatch(name = "enc_dn_conv_hist", pso = "g_pso_dn_hist", tg = 256, grid = "cd/256", params = "cd : int64")]
 class MetalDnConvHist {
-    @ssbo @binding = 0 @role = "read" x : array<float>     // [npos x cd] the window's fused qkv rows
-    @ssbo @binding = 1 @role = "readwrite" @off = "hoff" hist : array<float>  // [cd x taps] channel-major history (layer slice)
+    @ssbo @binding = 0 x : array<float>     // [npos x cd] the window's fused qkv rows
+    @ssbo @binding = 1 @off = "hoff" hist : array<float>  // [cd x taps] channel-major history (layer slice)
     @uniform @binding = 2 cd : uint
     @uniform @binding = 3 dconv : uint
     @uniform @binding = 4 npos : uint
@@ -4147,7 +4147,7 @@ class MetalDnConvHist {
 // DOUBLE — the f32 simd tree here is the deltanet drift class (same as the Vulkan tier).
 [metal_dispatch(name = "enc_dn_l2norm", pso = "g_pso_dn_l2", tg = 256, grid = "nblk/8, npos", params = "nblk : int64, npos : int64")]
 class MetalDnL2Norm {
-    @ssbo @binding = 0 @role = "readwrite" y : array<float>     // [npos x cd] conv rows: q at 0, k at kd
+    @ssbo @binding = 0 y : array<float>     // [npos x cd] conv rows: q at 0, k at kd
     @uniform @binding = 1 cd : uint
     @uniform @binding = 2 kd : uint         // key_dim = nkh * ds
     @uniform @binding = 3 ds : uint         // 128 (gated)
@@ -4183,13 +4183,13 @@ class MetalDnL2Norm {
 // zero per-token state traffic; β/σ/softplus fold into the loop (redundant per column, trivial).
 [metal_dispatch(name = "enc_dn_scan", pso = "g_pso_dn_scan", tg = 128, grid = "ds/4, nvh", params = "ds : int64, nvh : int64")]
 class MetalDnScan {
-    @ssbo @binding = 0 @role = "read" cv : array<float>    // [npos x cd] conv rows: q at 0 / k at kd / v at 2kd
-    @ssbo @binding = 1 @role = "readwrite" @off = "stoff" st : array<float>    // state layer slice [nvh x ds x ds] row-major (i·ds + j)
-    @ssbo @binding = 2 @role = "read" braw : array<float>  // [npos x nvh] raw beta projections
-    @ssbo @binding = 3 @role = "read" graw : array<float>  // [npos x nvh] raw alpha projections
+    @ssbo @binding = 0 cv : array<float>    // [npos x cd] conv rows: q at 0 / k at kd / v at 2kd
+    @ssbo @binding = 1 @off = "stoff" st : array<float>    // state layer slice [nvh x ds x ds] row-major (i·ds + j)
+    @ssbo @binding = 2 braw : array<float>  // [npos x nvh] raw beta projections
+    @ssbo @binding = 3 graw : array<float>  // [npos x nvh] raw alpha projections
     @ssbo @binding = 4 @role = "weight" aa : array<float>    // [nvh] ssm_a = -exp(A_log) (fblob row)
     @ssbo @binding = 5 @role = "weight" dtb : array<float>   // [nvh] dt_bias (fblob row)
-    @ssbo @binding = 6 @role = "write" o : array<float>     // [npos x di] delta-rule output rows
+    @ssbo @binding = 6 o : array<float>     // [npos x di] delta-rule output rows
     @uniform @binding = 7 cd : uint
     @uniform @binding = 8 kd : uint
     @uniform @binding = 9 ds : uint         // 128 (gated)
@@ -4260,8 +4260,8 @@ class MetalDnScan {
 // SHARED ssm_norm row, then ⊙ SiLU(z) — in place on o, one simdgroup per (head, position).
 [metal_dispatch(name = "enc_dn_gate", pso = "g_pso_dn_gate", tg = 256, grid = "nvh/8, npos", params = "nvh : int64, npos : int64")]
 class MetalDnGate {
-    @ssbo @binding = 0 @role = "readwrite" o : array<float>     // [npos x di] delta-rule output, gated in place
-    @ssbo @binding = 1 @role = "read" z : array<float>     // [npos x di] raw gate projections
+    @ssbo @binding = 0 o : array<float>     // [npos x di] delta-rule output, gated in place
+    @ssbo @binding = 1 z : array<float>     // [npos x di] raw gate projections
     @ssbo @binding = 2 @role = "weight" wn : array<float>    // [ds] shared norm weight (fblob row)
     @uniform @binding = 3 ds : uint         // 128 (gated)
     @uniform @binding = 4 di : uint
@@ -4296,9 +4296,9 @@ class MetalDnGate {
 // rope/attention classes untouched by the packing.
 [metal_dispatch(name = "enc_dn_deint", pso = "g_pso_dn_deint", tg = 256, grid = "qd/256, npos", params = "qd : int64, npos : int64")]
 class MetalDnDeint {
-    @ssbo @binding = 0 @role = "read" qg : array<float>    // [npos x 2qd] packed [q|gate] projection rows
-    @ssbo @binding = 1 @role = "write" q : array<float>     // qkv panel, q segment at row stride qs
-    @ssbo @binding = 2 @role = "write" gt : array<float>    // [npos x qd] sigmoid-gate rows
+    @ssbo @binding = 0 qg : array<float>    // [npos x 2qd] packed [q|gate] projection rows
+    @ssbo @binding = 1 q : array<float>     // qkv panel, q segment at row stride qs
+    @ssbo @binding = 2 gt : array<float>    // [npos x qd] sigmoid-gate rows
     @uniform @binding = 3 hs : uint
     @uniform @binding = 4 qd : uint
     @uniform @binding = 5 qs : uint         // q panel row stride, elements (qkvd; decode binds qd)
@@ -4337,9 +4337,9 @@ class MetalSigmul {
 // (decode total = dim; prefill total = npos x dim, row = the position).
 [metal_dispatch(name = "enc_axpy_sig", pso = "g_pso_axpy_sig", tg = 256, grid = "total/256", params = "total : int64")]
 class MetalAxpySig {
-    @ssbo @binding = 0 @role = "readwrite" y : array<float>
-    @ssbo @binding = 1 @role = "read" x : array<float>
-    @ssbo @binding = 2 @role = "read" g : array<float>     // per-position raw gate dots (σ applied here)
+    @ssbo @binding = 0 y : array<float>
+    @ssbo @binding = 1 x : array<float>
+    @ssbo @binding = 2 g : array<float>     // per-position raw gate dots (σ applied here)
     @uniform @binding = 3 total : uint      // grid guard
     @uniform @binding = 4 dim : uint
 

--- a/modules/dasLLAMA/kernel_access_lens_metal.md
+++ b/modules/dasLLAMA/kernel_access_lens_metal.md
@@ -1,5 +1,23 @@
 # Porting the kernel-access lens to Metal
 
+> **IMPLEMENTED** (2026-07). The lensed classes derive the
+> read/write axis from their bodies (declarations deleted); un-lensed classes keep declared
+> roles, now cross-checked against the same derivation by the census lint. The migration was
+> validated at compile time — deriving while every declaration was still present made each of
+> the 592 roles an assertion; two stale hand roles surfaced (a scatter-writer declaring
+> `readwrite`, and a `readwrite` left from an older in-place implementation the field comment
+> still described), and one hand pattern was made structural: owners of alias views used to
+> carry the buffer-level union by hand (`readwrite` on a read-only view whose alias sibling is
+> written) — alias views now derive and stage their OWN access, and the tracker's
+> buffer-identity keying unions the views naturally. Deviations from
+> the plan below, learned the hard way: bodies are PRE-infer at `[structure_macro]` time, so
+> field accesses are bare `ExprVar` names and member access is parser-level `ExprField` with
+> untyped bases — a name-only `ExprField` match collides with float4 components (`wv.y` vs a
+> buffer named `y`); the field mode therefore matches bare names + explicit `self.<name>` only,
+> does NOT recurse into free callees (intrinsic shims' locals would collide), and refuses
+> `self` passed whole. Claims are keyed by source location, not node pointer (infer clones
+> subtrees). The runtime trace-diff oracle was superseded by the compile-time cross-check.
+
 The Vulkan tier no longer hand-writes hazard masks: a compile-time lens derives each kernel's
 per-binding read/write access from its body, descriptor sets declare region bits where their
 buffers are named, and the dispatch helper composes the two. This doc is the map for doing the

--- a/skills/babysit.md
+++ b/skills/babysit.md
@@ -10,7 +10,11 @@ A Copilot round is complete only when all of these are true:
 2. Every corresponding review conversation is resolved, including rejected suggestions.
 3. A fresh query reports zero unresolved review threads. Paginate if GraphQL reports `hasNextPage`; never mistake the first page for the complete set.
 4. Copilot's latest review `commit_id` equals the PR's current `headRefOid`.
-5. That current-tip review produced no new comments.
+5. That current-tip review's comments were ALL handled — **the terminal state is a review
+   where NOTHING GOT ACCEPTED** (zero comments, or every comment rejected with evidence,
+   replied, resolved, and NO push made). **YOU DO NOT MERGE ON COPILOT RUNNING OUT — you
+   merge on a round you judged and closed without ceding anything.** Chasing a zero-comment
+   review by accepting-and-repushing is the anti-pattern this rule exists to kill.
 
 **Any push invalidates items 4-5.** Re-request Copilot after every push without exception, including formatting, documentation, generated-file, merge-conflict, and CI-only fixes. Do not rely on `review_on_push`.
 
@@ -58,21 +62,40 @@ If a check goes red:
 
 ## 3. Triaging review comments — discuss BEFORE acting
 
-When a review lands (especially Copilot — fast, often verbose), **don't auto-execute**. Pull the comments, classify each one, and surface to the user with a verdict per comment. Get user sign-off before changing code or text for an accepted/uncertain suggestion; clear rejections need no edit and may be closed immediately.
+# ⛔ THE REVIEWER IS THE TOOL. YOU ARE THE JUDGE. ⛔
+
+**CLAUDE is trusted with Copilot — Copilot is NOT trusted with Claude.** Copilot is a
+noise-generator that sometimes surfaces a real bug. Your job is to EXTRACT the signal and
+THROW AWAY the rest, not to appease the tool by fixing what it prints. This instruction has
+been given REPEATEDLY and ignored REPEATEDLY — that stops here.
+
+# THE ACCEPTANCE BAR IS EXACTLY TWO ITEMS. THERE IS NO THIRD.
+
+1. **AN ACTUAL BUG** — reachable in shipped use, at real scale, with a real consequence.
+2. **AN ACTUAL FACTUAL ERROR IN PROSE** — a doc/comment/diagnostic that states something UNTRUE.
+
+**EVERYTHING ELSE IS A REJECT. NO EXCEPTIONS. NOT ONE.**
+- ❌ NOT nits. Not "incomplete sentence", not "could be clearer", not style symmetry.
+- ❌ NOT bugs that never happen. A leak on a compile-failing error path is NOT A BUG —
+  the process is already dying. Cleanup "consistency" on a dead branch is NOT A BUG.
+- ❌ NOT guards against asteroid hits. Overflows past plausible hardware, impossible states,
+  "what if the module differs" when it provably doesn't — REJECT.
+- ❌ NOT "make it structural" tightening of something already proven correct in context.
+- ❌ NOT hygiene/determinism cosmetics — sorted diagnostics, micro-allocs beside bigger ones.
+- ❌ NOT repo-divergent "better ways".
+- ❌ NOT "cheap to fix". CHEAP IS NOT A REASON. Every accepted nit hands Copilot a fresh
+  diff and BUYS THE NEXT ROUND. The drip is self-inflicted.
+
+**AN ALL-REJECT ROUND IS THE EXPECTED, HEALTHY, NORMAL OUTCOME.** Each reject costs one
+evidence sentence. If you find yourself accepting more than the rare genuine bug per PR,
+you are being farmed by the tool.
 
 Fetch the comments:
 ```bash
 gh api repos/<owner>/<repo>/pulls/<PR>/comments | jq '.[] | {id, path, line: (.line // .original_line), body}'
 ```
 
-**Be conservative — default to reject.** Only ACCEPT a comment when it is a **real bug**, a **real issue**, or **factually incorrect** doc/comment text. REJECT everything else:
-- a failure with no realistic path in shipped use
-- an overflow/resource limit that cannot be reached within plausible hardware and process lifetime
-- an over-defensive guard (protecting a case that can't occur)
-- a suggestion that diverges from how the rest of the repo already does it
-- prose / wording nits — wording has to be **way off or factually wrong** to be worth a change
-
-Rejecting is the common case, not the exception. Give the user a concise per-comment verdict:
+Give the user a concise per-comment verdict:
 
 | Verdict | Means | Action |
 |---|---|---|
@@ -177,7 +200,8 @@ Each fix iteration: triage → discuss → fix → gate → amend → force-push
 |---|---|---|
 | Watch PR | `gh pr checks`, `gh api .../comments`, `gh api .../reviews` | Surface as soon as Copilot comments, CI fails, or both CI + Copilot are done |
 | CI fail | `gh pr checks`, `gh run view --log-failed` | Fix own, fix obvious pre-existing, ask about unclear |
-| Triage comments | `gh api .../pulls/<PR>/comments` | **Default reject**; require realistic reachability, scale, and impact. Prose-only round → resolve and land |
+| Triage comments | `gh api .../pulls/<PR>/comments` | **YOU are the judge, Copilot is the tool.** Accept ONLY actual bugs + actual factual prose errors — no nits, no never-happens bugs, no asteroid guards. All-reject rounds are the NORM |
+| Terminal state | a judged round with NOTHING accepted (zero comments, or all rejected + resolved, no push) | Never merge on "Copilot ran out" via accept-and-repush cycles |
 | Re-run gates | Focused tests + directly applicable format/generator/doc checks | Full preflight once before initial PR push; CI handles complete reruns after review fixes |
 | Amend/push | `git commit --amend --no-edit`, `git push --force-with-lease` | Keep squashed branch squashed |
 | Reply | `mcp__github__add_reply_to_pull_request_comment` | Every addressed comment gets a reply |


### PR DESCRIPTION
The Vulkan tier already derives each kernel's buffer access from its body (the shared classifier in `dasllama_kernel_access.das`); the Metal tier made authors declare `@role` on every `@ssbo` and ratcheted the declarations with a census lint. This PR ports the derivation to Metal per the in-tree design doc (`modules/dasLLAMA/kernel_access_lens_metal.md`, written with the Vulkan lens): what the body can prove is now inferred, what it cannot know stays declared.

### What changed

- **Shared classifier gains a field mode** for class-shaped Metal kernels: tracked names are the class's `@ssbo` fields, matched as bare names or explicit `self.<name>`. Three hard-won correctness rules, now documented in the doc: float4 component access (`wv.y`) must never match a buffer named `y` (`x`/`y`/`w` are simultaneously swizzle names and the house buffer names); field mode does not recurse into free callees (intrinsic shims' locals collide with bare-name matching — a `self` passed whole hits the ratchet instead); write-claims are keyed by source location, not node pointer, because infer clones subtrees (this also makes the classifier timing-agnostic — the lens runs pre-infer, the census post-infer, same results). `simdgroup_store`/`simdgroup_load` (store target = arg 1) and `tg_store_float4` (store target = arg 0) join the intrinsic table.
- **`[metal_dispatch]` derives** read/write/readwrite per `@ssbo` field from the `[metal_kernel]` body and emits `hz_read`/`hz_write` from the derivation. A declared role on that axis is a cross-checked assertion (mismatch = compile error naming both sides; `access_force=true` restores the fully declared contract for an unanalyzable body). `weight` stays declared (frame policy, body-writes refused). **Alias views derive and stage their own access** — the hazard tracker keys ranges by buffer identity, so both views' staging unions into the buffer-level truth; hand-written builders used to carry that union on the owner field by hand (review round 3 caught the gap when per-view derivation dropped it). `@off`/`@span` byte-ranges are untouched (they're what keep the Metal tracker finer than Vulkan's region bits).
- **110 read/write-axis declarations deleted** from the lensed classes. The 53 un-lensed classes (hand-written builders) keep their 258 declarations, but the census lint now **cross-checks every one against the same body derivation** — a stale declaration is a compile error, so no role anywhere in the metal modules is trust-me. (Follow-up: lens-ify those classes, then their declarations delete too.)

### Migration validation

Deriving while all 592 declarations were still present turned each into a compile-time assertion. Two stale hand roles surfaced and are fixed here, and one hand-carried pattern was made structural:

- `MetalSuppressRow.x` declared `readwrite`, body is a pure scatter-write (`x[ids[gid]] = -inf`).
- `MetalPreAddRms.a` declared `readwrite` — left over from an older in-place implementation that the field's comment still described; today the norm factor applies inline during the add. Comment corrected.
- `MetalMoeWScale.seli`'s `readwrite` was the alias-union pattern (read via `seli`, write via the `selw` view) — now expressed structurally by the alias-view staging above instead of hand-encoded on the owner.

### Gates

- All metal modules compile with derivation live; census negative-probed (flipping one declared role produces the exact mismatch error).
- Kernels suite 2/2, decode `--arm arm,batch` 3 passed/0 failed, prefill `--arm base,kq,qkv` 1 passed/0 failed — all under `DASLLAMA_METAL_HAZARD_STRICT=1` with derived hz driving every dispatch, re-run after the alias-staging change.
- Preflight `--full`: 16 passed, 0 failed, 1 skipped (cpp-syntax — no C++ changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
