### PR TITLE
interp: block return must not ride the invokeEx code0 fast path

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -214,12 +214,12 @@ def document_module_fio(_root : string) {
     var mod = [get_module("fio_core"), find_module("fio")]
     var groups <- array<DocGroup>(
         hide_group(group_by_regex("Internal builtin functions", mod, %regex~builtin%%)),
-        group_by_regex("File manipulation", mod, %regex~(f|stat$|getchar|remove|rename|copy_file|file_size|equivalent|is_symlink|set_mtime)%%),
+        group_by_regex("File manipulation", mod, %regex~(f|long_f|stat$|getchar|remove|rename|copy_file|file_size|equivalent|is_symlink|set_mtime)%%),
         group_by_regex("Path manipulation", mod, %regex~(base_name|dir_name|get_full_file_name|extension|stem|replace_extension|path_join|normalize|to_generic_path|is_absolute|relative|relative_result|parent)$%%),
         group_by_regex("Directory manipulation", mod, %regex~(dir|dir_rec|mkdir|mkdir_rec|mkdir_result|rmdir|rmdir_rec|rmdir_rec_result|rmdir_result|chdir|getcwd)$%%),
         group_by_regex("Glob and pattern matching", mod, %regex~(match_glob|glob|glob_filtered|is_glob_pattern|expand_glob|parse_file_list)$%%),
         group_by_regex("Filesystem queries", mod, %regex~(temp_directory|temp_directory_result|create_temp_file|create_temp_file_result|create_temp_directory|create_temp_directory_result|disk_space)$%%),
-        group_by_regex("OS specific routines", mod, %regex~(sleep|exit|system|popen|popen_binary|popen_timeout|spawn_argv|popen_argv|popen_argv_pipe|popen_timed_out|run_and_capture|get_env_variable|sanitize_command_line|has_env_variable)$%%),
+        group_by_regex("OS specific routines", mod, %regex~(sleep|exit|system|popen|popen_binary|popen_timeout|spawn_argv|popen_argv|popen_argv_pipe|popen_timed_out|run_and_capture|get_env_variable|set_env_variable|sanitize_command_line|has_env_variable)$%%),
         group_by_regex("Dynamic modules", mod, %regex~(register_dynamic_module|register_native_path)$%%)
     )
     documents("File input output library", mod, "fio.rst", groups)
@@ -598,7 +598,7 @@ def document_module_jobque(_root : string) {
         group_by_regex("Channel, JobStatus, Lockbox, Stream", mod, %regex~(append|notify|join|channel_create|channel_remove|stream_create|stream_remove|add_ref|release|notify_and_release|lock_box_create|lock_box_remove|job_status_create|job_status_remove)$%%),
         group_by_regex("Queries", mod, %regex~(get_total_hw_jobs|get_total_hw_threads|get_total_hw_cores|is_job_que_shutting_down|is_job_que_available|count_jobque_leaks)$%%),
         group_by_regex("Event tracing", mod, %regex~(jobque_trace_start|jobque_trace_stop|jobque_trace_save|jobque_trace_tag|jobque_trace_category|jobque_trace_marker_name|jobque_trace_marker)$%%),
-        group_by_regex("Internal invocations", mod, %regex~(new_job_invoke|new_thread_invoke|new_debugger_thread|set_jobque_fork_pool|set_jobque_fork_skip_heap_reset|set_jobque_worker_spin|set_jobque_batch_dispatch|set_jobque_join_spin|set_jobque_team_mode|get_jobque_team_mode|set_jobque_threads_cap|set_jobque_affinity|get_jobque_affinity|set_jobque_worker_limit|get_jobque_worker_limit|set_jobque_team_rank_gate|get_jobque_team_rank_gate|set_jobque_team_prof|reset_jobque_team_prof|get_jobque_team_prof|get_jobque_team_prof_counts|get_jobque_team_prof_react|team_parallel_for_invoke|team_parallel_for_indexed_invoke|team_parallel_stages_invoke|flush_jobque_batch|jobque_try_run_one)$%%),
+        group_by_regex("Internal invocations", mod, %regex~(new_job_invoke|new_thread_invoke|new_debugger_thread|set_jobque_fork_pool|set_jobque_fork_skip_heap_reset|set_jobque_worker_spin|set_jobque_batch_dispatch|set_jobque_join_spin|set_jobque_team_mode|get_jobque_team_mode|set_jobque_thread_team_mode|get_jobque_thread_team_mode|set_current_thread_priority|set_jobque_threads_cap|set_jobque_affinity|get_jobque_affinity|set_jobque_worker_limit|get_jobque_worker_limit|set_jobque_team_rank_gate|get_jobque_team_rank_gate|set_jobque_team_prof|reset_jobque_team_prof|get_jobque_team_prof|get_jobque_team_prof_counts|get_jobque_team_prof_react|team_parallel_for_invoke|team_parallel_for_indexed_invoke|team_parallel_stages_invoke|flush_jobque_batch|jobque_try_run_one)$%%),
         group_by_regex("Construction", mod, %regex~(with_channel|with_stream|with_job_status|with_job_que|with_lock_box|create_job_que|destroy_job_que)$%%),
         group_by_regex("Atomic", mod, %regex~(atomic32_create|atomic32_remove|with_atomic32|atomic64_create|atomic64_remove|with_atomic64|get|set|inc|dec)$%%)
     )
@@ -1316,9 +1316,9 @@ def document_module_toml(_root : string) {
 def document_module_logger(_root : string) {
     var mod = find_module("logger")
     var groups <- array<DocGroup>(
-        group_by_regex("Setup", mod, %regex~.*(logger_init|logger_set_name|logger_set_path|logger_get_path|logger_get_name)$%%),
+        group_by_regex("Setup", mod, %regex~.*(logger_init|logger_init_tee|logger_set_name|logger_set_path|logger_get_path|logger_get_name)$%%),
         group_by_regex("Level filters", mod, %regex~.*(logger_set_min_level|logger_get_min_level|logger_set_category_level|logger_clear_category_levels)$%%),
-        group_by_regex("Output control", mod, %regex~.*(logger_set_stderr_fallback|logger_flush|logger_close)$%%),
+        group_by_regex("Output control", mod, %regex~.*(logger_set_stderr_fallback|logger_set_tee|logger_flush|logger_close)$%%),
         group_by_regex("Log calls", mod, %regex~.*(logger_log|logger_trace|logger_debug|logger_info|logger_warning|logger_error|logger_critical)$%%),
         group_by_regex("Stdout hook", mod, %regex~.*(logger_install_hook)$%%)
     )

--- a/doc/source/stdlib/handmade/function-fio-set_env_variable-0xf7b1b4df69de309.rst
+++ b/doc/source/stdlib/handmade/function-fio-set_env_variable-0xf7b1b4df69de309.rst
@@ -1,0 +1,1 @@
+Sets an environment variable in the current process (the `setenv`/`_putenv` family). The change is visible to subsequent `get_env_variable` calls and inherited by child processes spawned afterwards (`popen`, `spawn_argv`); it does not affect the parent shell.

--- a/doc/source/stdlib/handmade/function-jobque-get_jobque_thread_team_mode-0xadb77f2665209111.rst
+++ b/doc/source/stdlib/handmade/function-jobque-get_jobque_thread_team_mode-0xadb77f2665209111.rst
@@ -1,0 +1,1 @@
+Reads the calling OS thread's team-mode override (see `set_jobque_thread_team_mode`).

--- a/doc/source/stdlib/handmade/function-jobque-set_current_thread_priority-0x30274d0f647e878a.rst
+++ b/doc/source/stdlib/handmade/function-jobque-set_current_thread_priority-0x30274d0f647e878a.rst
@@ -1,0 +1,1 @@
+Sets the OS priority of the calling thread on the jobque `JobPriority` scale, -2 (Minimum) .. 2 (Maximum), clamped. The dispatch caller is load-bearing in team mode — only it publishes chains, so a descheduled caller idles every lane; queue creation already runs it at High (+1), and this exposes the remaining notch (and the rest of the scale) to scripts.

--- a/doc/source/stdlib/handmade/function-jobque-set_jobque_thread_team_mode-0x3ea171573d71f2e0.rst
+++ b/doc/source/stdlib/handmade/function-jobque-set_jobque_thread_team_mode-0x3ea171573d71f2e0.rst
@@ -1,0 +1,1 @@
+Per-caller team-mode override: with team mode off for this OS thread, `team_parallel_*` calls run inline on the caller while other threads keep publishing to the shared worker team. New OS threads default to enabled.

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -2221,7 +2221,10 @@ namespace das
             SimNode_Block * block;
             if ( expr->isClosure ) {
                 bool needResult = expr->type!=nullptr && expr->type->baseType!=Type::tVoid;
-                bool C0 = !needResult && simlist.size()==1 && expr->finalList.size()==0;
+                // the invokeEx code0 fast path evals list[0] bare, skipping the ClosureBlock
+                // epilogue that clears stopForReturn — a block containing a return must take
+                // the full path or the flag leaks into the invoking enumeration and its caller
+                bool C0 = !needResult && simlist.size()==1 && expr->finalList.size()==0 && !expr->hasReturn;
 #if DAS_DEBUGGER
                 if ( context.debugger ) {
                     block = context.code->makeNode<SimNodeDebug_ClosureBlock>(at, needResult, C0, expr->annotationData);

--- a/tests/ast/test_closure_block_return.das
+++ b/tests/ast/test_closure_block_return.das
@@ -1,0 +1,63 @@
+options gen2
+options indenting = 4
+options rtti
+
+require dastest/testing_boost public
+require daslib/ast
+
+//! A bare `return` inside a block exits THE BLOCK only. The interpreter's invokeEx code0 fast
+//! path handed enumerators (for_each_function et al.) the closure body's single statement WITHOUT
+//! the SimNode_ClosureBlock epilogue that clears stopForReturn — so the first firing return
+//! killed the remaining iterations AND leaked the stop flag into the calling function, silently
+//! skipping its tail (rst.das documents() lost every Uncategorized function this way). The
+//! single-statement and multi-statement closures below are semantically identical; they must
+//! count the same. JIT and AOT were always correct — this is an interpreter-only regression rail.
+
+// single-statement closure body (one IfThenElse) — rides the code0 fast path
+def private count_single(mod : rtti::Module?) : int {
+    var n = 0
+    for_each_function(mod, "") $(func) {
+        if (func.flags.generated) {
+            return
+        } else {
+            n++
+        }
+    }
+    return n
+}
+
+// multi-statement closure body — never rode the fast path, always correct
+def private count_multi(mod : rtti::Module?; var fired : int&) : int {
+    var n = 0
+    for_each_function(mod, "") $(func) {
+        if (func.flags.generated) {
+            fired++
+            return
+        }
+        n++
+    }
+    return n
+}
+
+// tail sentinel: a leaked stop flag would skip everything after the enumeration
+def private tail_runs(mod : rtti::Module?) : bool {
+    for_each_function(mod, "") $(func) {
+        if (func.flags.generated) {
+            return
+        }
+    }
+    return true
+}
+
+[test]
+def test_closure_block_return(t : T?) {
+    ast_gc_guard() {
+        var mod = get_module("$")
+        var fired = 0
+        let multi = count_multi(mod, fired)
+        t |> success(fired > 0, "the early return must actually fire (module $ has generated fns)")
+        t |> success(multi > 0, "enumeration continues past a block return")
+        t |> equal(count_single(mod), multi)
+        t |> success(tail_runs(mod), "block return must not leak past the enumeration")
+    }
+}


### PR DESCRIPTION
# interp: block return must not ride the invokeEx code0 fast path

## The bug

`Context::invokeEx` — the batch block-invocation primitive behind the ast enumerators (`for_each_function`, `for_each_generic`, …) — has a fast path: when the closure body is a void **single statement** with no finally (`code0`), it hands the enumeration lambda the bare statement instead of the `SimNode_ClosureBlock`. But the ClosureBlock's eval is what clears `stopForReturn` after the body runs. With the fast path, a **firing bare `return`** inside such a closure (return-from-block, the everyday "skip this item" idiom):

1. leaves `stopForReturn` set, so every remaining iteration of the enumeration no-ops, and
2. leaks the flag into the calling function, silently skipping everything after the enumeration call (damage stops at the next function-call boundary, which is why nothing ever crashed).

Interpreter only — JIT and AOT were always correct, and per-item `Context::invoke` (the `dir()` pattern) was safe because it evals `block.body`.

The longest-lived visible casualty: `rst.das documents()` — its "Uncategorized" loop is exactly this shape (auto-inline canonicalizes `if (cond) { return }; rest` into a single if/else statement, putting the closure on the fast path). Every function not matched by a `group_by_regex` was silently dropped from the generated docs, and the docs/uncategorized preflight gate passed *precisely because the loop was dead*.

## The fix

`ast_simulate.cpp`: `C0` additionally requires `!expr->hasReturn`. Return-bearing single-statement closures take the full ClosureBlock path; the fast path stays for the common no-return case.

## Test

`tests/ast/test_closure_block_return.das` — failing-test-first: a single-statement closure (fast path) and a multi-statement closure (never on the fast path) run the same enumeration with a firing return and must agree, plus a tail sentinel proving the flag does not leak past the enumeration. Red before the fix, green after.

Suites on the fixed binary: language 1443/1443, ast, type_lattice, spirv, metal — all green. Full preflight: the entire heavy matrix (tests-interp / tests-jit / tests-aot) passed first run.

## Doc fallout (second commit)

With the Uncategorized loop alive again, the functions it had been silently dropping surface in the generated docs. Grouped + documented so the doc gates stay green:

- `fio`: `set_env_variable` (joins the env getters; new handmade entry), `long_fread`/`long_fwrite` (join File manipulation)
- `logger`: `logger_init_tee`, `logger_set_tee` (join Setup / Output control; `//!` docs already existed)
- `jobque`: `set_jobque_thread_team_mode` / `get_jobque_thread_team_mode` / `set_current_thread_priority` — hidden with the rest of the tuning-knob family, new handmade entries

Review note: an earlier revision of this branch accidentally glob-deleted and re-derived the existing jobque handmade descriptions; Copilot's review caught the rewrites diverging from the C++ semantics. The curated files are restored verbatim from master — only the four genuinely new entries above are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
