### PR TITLE
dasHerd: detached PTY hosts, restart-surviving sessions, and the fix/goal rounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,13 +670,21 @@ ENDFOREACH()
 # the host artifacts a wasm cross-compile (daspkg release wasm) needs. A later
 # desktop configure still cleans genuinely-disabled modules.
 IF(NOT EMSCRIPTEN)
-    FILE(GLOB_RECURSE _all_shared_modules CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/modules/*.shared_module")
-    FOREACH(_sm ${_all_shared_modules})
-        GET_FILENAME_COMPONENT(_sm_name "${_sm}" NAME_WE)
-        IF(NOT TARGET ${_sm_name})
-            MESSAGE(STATUS "Removing stale ${_sm}")
-            FILE(REMOVE "${_sm}")
+    FOREACH(_module ${_modules})
+        # Standalone (daspkg / nested-repo) modules build their own .shared_module
+        # out-of-tree; those basenames are never targets here, so the stale test
+        # below would delete a perfectly live artifact on every reconfigure.
+        IF(EXISTS "${PROJECT_SOURCE_DIR}/modules/${_module}/.daspkg_standalone")
+            CONTINUE()
         ENDIF()
+        FILE(GLOB_RECURSE _mod_shared_modules "${PROJECT_SOURCE_DIR}/modules/${_module}/*.shared_module")
+        FOREACH(_sm ${_mod_shared_modules})
+            GET_FILENAME_COMPONENT(_sm_name "${_sm}" NAME_WE)
+            IF(NOT TARGET ${_sm_name})
+                MESSAGE(STATUS "Removing stale ${_sm}")
+                FILE(REMOVE "${_sm}")
+            ENDIF()
+        ENDFOREACH()
     ENDFOREACH()
 ENDIF()
 

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -300,14 +300,23 @@ namespace das {
         ~ChainDepthGuard() { --g_ChainDispatchDepth; }
     };
 
+    // Every dispatch loop below re-finds the map node each step: a listener can
+    // erase this window's chain mid-dispatch (glfwDestroyWindow, chain_clear),
+    // so no reference into g_GlfwChain may be held across a lambda call.
     void DasGlfw_ChainCursorPosDispatch ( GLFWwindow * w, double x, double y ) {
         ChainDepthGuard depth;
         if ( depth.blocked ) return;
-        auto it = g_GlfwChain.find(w);
-        if ( it == g_GlfwChain.end() ) return;
-        auto & st = it->second;
-        if ( st.prev_cursor_pos ) st.prev_cursor_pos(w, x, y);
-        for ( auto & e : st.cursor_pos_chain ) {
+        {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) return;
+            if ( it->second.prev_cursor_pos ) it->second.prev_cursor_pos(w, x, y);
+        }
+        for ( size_t i = 0; ; ++i ) {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) break;
+            auto & chain = it->second.cursor_pos_chain;
+            if ( i >= chain.size() ) break;
+            auto e = chain[i];
             if ( e.context ) {
                 das_invoke_lambda<void>::invoke<GLFWwindow *, double, double>(
                     e.context, nullptr, e.lambda, w, x, y);
@@ -318,11 +327,17 @@ namespace das {
     void DasGlfw_ChainMouseButtonDispatch ( GLFWwindow * w, int button, int action, int mods ) {
         ChainDepthGuard depth;
         if ( depth.blocked ) return;
-        auto it = g_GlfwChain.find(w);
-        if ( it == g_GlfwChain.end() ) return;
-        auto & st = it->second;
-        if ( st.prev_mouse_button ) st.prev_mouse_button(w, button, action, mods);
-        for ( auto & e : st.mouse_button_chain ) {
+        {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) return;
+            if ( it->second.prev_mouse_button ) it->second.prev_mouse_button(w, button, action, mods);
+        }
+        for ( size_t i = 0; ; ++i ) {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) break;
+            auto & chain = it->second.mouse_button_chain;
+            if ( i >= chain.size() ) break;
+            auto e = chain[i];
             if ( e.context ) {
                 das_invoke_lambda<void>::invoke<GLFWwindow *, int, int, int>(
                     e.context, nullptr, e.lambda, w, button, action, mods);
@@ -333,11 +348,17 @@ namespace das {
     void DasGlfw_ChainScrollDispatch ( GLFWwindow * w, double xoff, double yoff ) {
         ChainDepthGuard depth;
         if ( depth.blocked ) return;
-        auto it = g_GlfwChain.find(w);
-        if ( it == g_GlfwChain.end() ) return;
-        auto & st = it->second;
-        if ( st.prev_scroll ) st.prev_scroll(w, xoff, yoff);
-        for ( auto & e : st.scroll_chain ) {
+        {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) return;
+            if ( it->second.prev_scroll ) it->second.prev_scroll(w, xoff, yoff);
+        }
+        for ( size_t i = 0; ; ++i ) {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) break;
+            auto & chain = it->second.scroll_chain;
+            if ( i >= chain.size() ) break;
+            auto e = chain[i];
             if ( e.context ) {
                 das_invoke_lambda<void>::invoke<GLFWwindow *, double, double>(
                     e.context, nullptr, e.lambda, w, xoff, yoff);
@@ -348,11 +369,17 @@ namespace das {
     void DasGlfw_ChainKeyDispatch ( GLFWwindow * w, int key, int scancode, int action, int mods ) {
         ChainDepthGuard depth;
         if ( depth.blocked ) return;
-        auto it = g_GlfwChain.find(w);
-        if ( it == g_GlfwChain.end() ) return;
-        auto & st = it->second;
-        if ( st.prev_key ) st.prev_key(w, key, scancode, action, mods);
-        for ( auto & e : st.key_chain ) {
+        {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) return;
+            if ( it->second.prev_key ) it->second.prev_key(w, key, scancode, action, mods);
+        }
+        for ( size_t i = 0; ; ++i ) {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) break;
+            auto & chain = it->second.key_chain;
+            if ( i >= chain.size() ) break;
+            auto e = chain[i];
             if ( e.context ) {
                 das_invoke_lambda<void>::invoke<GLFWwindow *, int, int, int, int>(
                     e.context, nullptr, e.lambda, w, key, scancode, action, mods);
@@ -363,11 +390,17 @@ namespace das {
     void DasGlfw_ChainCharDispatch ( GLFWwindow * w, unsigned int codepoint ) {
         ChainDepthGuard depth;
         if ( depth.blocked ) return;
-        auto it = g_GlfwChain.find(w);
-        if ( it == g_GlfwChain.end() ) return;
-        auto & st = it->second;
-        if ( st.prev_char ) st.prev_char(w, codepoint);
-        for ( auto & e : st.char_chain ) {
+        {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) return;
+            if ( it->second.prev_char ) it->second.prev_char(w, codepoint);
+        }
+        for ( size_t i = 0; ; ++i ) {
+            auto it = g_GlfwChain.find(w);
+            if ( it == g_GlfwChain.end() ) break;
+            auto & chain = it->second.char_chain;
+            if ( i >= chain.size() ) break;
+            auto e = chain[i];
             if ( e.context ) {
                 das_invoke_lambda<void>::invoke<GLFWwindow *, unsigned int>(
                     e.context, nullptr, e.lambda, w, codepoint);

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -1066,11 +1066,9 @@ def public spawn_detached(arguments : array<string> const;
                           working_directory : string;
                           environment : array<string> const;
                           blk : block<(pid : int; error : string#) : void>) : int {
-    //! Spawns a plain process that OUTLIVES the caller: no console, broken out
-    //! of the caller's job object, own process group. The block receives the
-    //! pid (0 = failed) and an error text; a non-zero pid with a non-empty
-    //! error is a degraded success (job breakaway denied - the child would
-    //! still die with the caller's job).
+    //! Spawns a plain process that OUTLIVES the caller: no console, own group,
+    //! broken out of the caller's job. The block gets pid (0 = failed) + error;
+    //! non-zero pid WITH error = degraded (breakaway denied, dies with the job).
     return _spawn_detached(arguments, working_directory,
         length(working_directory), environment, blk)
 }
@@ -1360,6 +1358,31 @@ def public terminal_encode_key(terminal : Terminal const;
     var inscope bytes : array<uint8>
     terminal_encode_key_bytes(terminal, event, bytes)
     return string(bytes)
+}
+
+def public terminal_mouse_reporting_active(terminal : Terminal const) : bool {
+    //! True when the child asked for mouse events (button/drag/any-motion). A
+    //! UI host should then forward wheel/clicks instead of consuming them -
+    //! alt-screen TUIs (Claude Code, vim) scroll their own transcript with them.
+    return (terminal.modes.mouse_button_reporting
+        || terminal.modes.mouse_drag_reporting
+        || terminal.modes.mouse_any_reporting)
+}
+
+def public terminal_encode_mouse(terminal : Terminal const;
+                                 button : int; column, row : int;
+                                 down : bool) : string {
+    //! One encoded mouse event. `button`: 0/1/2 = left/middle/right, 64/65 =
+    //! wheel up/down (wheel only presses); `column`/`row` are 0-based cells.
+    //! SGR (1006) when the child selected it, else legacy X10 bytes (clamped).
+    let cx = column + 1
+    let cy = row + 1
+    if (terminal.modes.sgr_mouse_encoding) {
+        return "{to_char(27)}[<{button};{cx};{cy}{down ? "M" : "m"}"
+    }
+    // Legacy release loses button identity (3 = release); wheel sends no release.
+    let cb = (down ? button : 3) + 32
+    return "{to_char(27)}[M{to_char(cb)}{to_char(min(cx + 32, 255))}{to_char(min(cy + 32, 255))}"
 }
 
 def public terminal_encode_paste_bytes(terminal : Terminal const; text : string;

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -1049,6 +1049,32 @@ def public terminal_launch_argv(arguments : array<string> const;
     return <- terminal
 }
 
+def public terminal_launch_argv_env(arguments : array<string> const;
+                                    working_directory : string;
+                                    environment : array<string> const;
+                                    columns : int = 80; rows : int = 25) : Terminal {
+    //! Like terminal_launch_argv, with extra KEY=VALUE entries merged over the
+    //! inherited environment. Secrets belong here, never on the command line.
+    var inscope terminal <- terminal_create(columns, rows)
+    var inscope pty <- _pty_launch_argv_env(arguments,
+        working_directory, length(working_directory), environment, columns, rows)
+    move(terminal.transport) <| pty
+    return <- terminal
+}
+
+def public spawn_detached(arguments : array<string> const;
+                          working_directory : string;
+                          environment : array<string> const;
+                          blk : block<(pid : int; error : string#) : void>) : int {
+    //! Spawns a plain process that OUTLIVES the caller: no console, broken out
+    //! of the caller's job object, own process group. The block receives the
+    //! pid (0 = failed) and an error text; a non-zero pid with a non-empty
+    //! error is a degraded success (job breakaway denied - the child would
+    //! still die with the caller's job).
+    return _spawn_detached(arguments, working_directory,
+        length(working_directory), environment, blk)
+}
+
 def public terminal_feed_bytes(var terminal : Terminal; bytes : array<uint8> const) {
     if (empty(bytes)) return
     terminal.revision++

--- a/modules/dasTerminal/src/aot_builtin_terminal.h
+++ b/modules/dasTerminal/src/aot_builtin_terminal.h
@@ -25,6 +25,18 @@ das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
     const char * working_directory, int32_t directory_count,
     int32_t columns, int32_t rows, das::Context * context,
     das::LineInfoArg * at);
+das::smart_ptr<PtyHandle> builtin_pty_launch_argv_env(
+    const das::TArray<char *> & arguments,
+    const char * working_directory, int32_t directory_count,
+    const das::TArray<char *> & environment,
+    int32_t columns, int32_t rows, das::Context * context,
+    das::LineInfoArg * at);
+int32_t builtin_spawn_detached(
+    const das::TArray<char *> & arguments,
+    const char * working_directory, int32_t directory_count,
+    const das::TArray<char *> & environment,
+    const das::TBlock<void, int32_t, das::TTemporary<const char *>> & result_blk,
+    das::Context * context, das::LineInfoArg * at);
 int32_t builtin_pty_read(
     const das::smart_ptr<PtyHandle> & pty, das::TArray<uint8_t> & bytes,
     int32_t maximum_bytes, das::Context * context, das::LineInfoArg * at);

--- a/modules/dasTerminal/src/dasTerminal.cpp
+++ b/modules/dasTerminal/src/dasTerminal.cpp
@@ -79,6 +79,82 @@ das::smart_ptr<PtyHandle> builtin_pty_launch_argv(
     return pty;
 }
 
+das::smart_ptr<PtyHandle> builtin_pty_launch_argv_env(
+    const das::TArray<char *> & arguments,
+    const char * working_directory, int32_t directory_count,
+    const das::TArray<char *> & environment,
+    int32_t columns, int32_t rows, das::Context * context,
+    das::LineInfoArg * at) {
+    das::smart_ptr<PtyHandle> pty = das::make_smart<PtyHandle>();
+    if (!arguments.size) {
+        pty->error = "PTY argument array is empty";
+        return pty;
+    }
+    PtyProcessOptions options;
+    options.arguments.reserve(arguments.size);
+    for (uint32_t index = 0; index != arguments.size; ++index) {
+        const char * value = arguments[index];
+        if (!value) {
+            context->throw_error_at(at, "PTY argument %u is null", index);
+            return pty;
+        }
+        options.arguments.emplace_back(value);
+    }
+    options.environment.reserve(environment.size);
+    for (uint32_t index = 0; index != environment.size; ++index) {
+        const char * value = environment[index];
+        if (!value) {
+            context->throw_error_at(at, "PTY environment entry %u is null", index);
+            return pty;
+        }
+        options.environment.emplace_back(value);
+    }
+    if (working_directory && directory_count > 0)
+        options.working_directory.assign(
+            working_directory, static_cast<size_t>(directory_count));
+    options.columns = columns;
+    options.rows = rows;
+    pty->process = launchPtyProcess(options, pty->error);
+    return pty;
+}
+
+int32_t builtin_spawn_detached(
+    const das::TArray<char *> & arguments,
+    const char * working_directory, int32_t directory_count,
+    const das::TArray<char *> & environment,
+    const das::TBlock<void, int32_t, das::TTemporary<const char *>> & result_blk,
+    das::Context * context, das::LineInfoArg * at) {
+    std::vector<std::string> argument_list;
+    argument_list.reserve(arguments.size);
+    for (uint32_t index = 0; index != arguments.size; ++index) {
+        const char * value = arguments[index];
+        if (!value) {
+            context->throw_error_at(at, "detached spawn argument %u is null", index);
+            return 0;
+        }
+        argument_list.emplace_back(value);
+    }
+    std::vector<std::string> environment_list;
+    environment_list.reserve(environment.size);
+    for (uint32_t index = 0; index != environment.size; ++index) {
+        const char * value = environment[index];
+        if (!value) {
+            context->throw_error_at(at, "detached spawn environment entry %u is null", index);
+            return 0;
+        }
+        environment_list.emplace_back(value);
+    }
+    std::string directory;
+    if (working_directory && directory_count > 0)
+        directory.assign(working_directory, static_cast<size_t>(directory_count));
+    std::string error;
+    const uint32_t pid = spawnDetachedProcess(
+        argument_list, directory, environment_list, error);
+    das::das_invoke<void>::invoke<int32_t, const char *>(
+        context, at, result_blk, static_cast<int32_t>(pid), error.c_str());
+    return static_cast<int32_t>(pid);
+}
+
 int32_t builtin_pty_read(
     const das::smart_ptr<PtyHandle> & pty, das::TArray<uint8_t> & bytes,
     int32_t maximum_bytes, das::Context * context, das::LineInfoArg * at) {
@@ -186,6 +262,16 @@ public:
             "das_terminal::builtin_pty_launch_argv")
                 ->args({"arguments", "working_directory", "directory_count",
                     "columns", "rows", "context", "at"});
+        addExtern<DAS_BIND_FUN(das_terminal::builtin_pty_launch_argv_env)>(*this, lib,
+            "_pty_launch_argv_env", SideEffects::modifyExternal,
+            "das_terminal::builtin_pty_launch_argv_env")
+                ->args({"arguments", "working_directory", "directory_count",
+                    "environment", "columns", "rows", "context", "at"});
+        addExtern<DAS_BIND_FUN(das_terminal::builtin_spawn_detached)>(*this, lib,
+            "_spawn_detached", SideEffects::modifyExternal,
+            "das_terminal::builtin_spawn_detached")
+                ->args({"arguments", "working_directory", "directory_count",
+                    "environment", "result_blk", "context", "at"});
         addExtern<DAS_BIND_FUN(das_terminal::builtin_pty_read)>(*this, lib,
             "_pty_read", SideEffects::modifyArgumentAndExternal,
             "das_terminal::builtin_pty_read")

--- a/modules/dasTerminal/src/pty.cpp
+++ b/modules/dasTerminal/src/pty.cpp
@@ -1,6 +1,7 @@
 #include "pty.h"
 
 #include <algorithm>
+#include <cwctype>
 #include <vector>
 
 #if defined(_WIN32)
@@ -145,6 +146,58 @@ std::string escapeWindowsArgument(const std::string & argument) {
     return result;
 }
 
+// Merged environment block: every inherited entry whose KEY is not overridden,
+// then the extras, double-NUL terminated. Key comparison is case-insensitive
+// (Windows environment semantics). Returns false only on conversion failure.
+bool buildEnvironmentBlock(const std::vector<std::string> & extras,
+                           std::wstring & block, std::string & error) {
+    std::vector<std::wstring> wide_extras;
+    wide_extras.reserve(extras.size());
+    for (const auto & entry : extras) {
+        std::wstring wide = utf8ToWide(entry, error);
+        if (wide.empty()) {
+            error = "environment entry is empty or not valid UTF-8: " + entry;
+            return false;
+        }
+        if (wide.find(L'=') == std::wstring::npos || wide.front() == L'=') {
+            error = "environment entry is not KEY=VALUE: " + entry;
+            return false;
+        }
+        wide_extras.push_back(std::move(wide));
+    }
+    auto keyOf = [](const std::wstring & entry) {
+        std::wstring key = entry.substr(0, entry.find(L'='));
+        for (auto & ch : key) ch = towupper(ch);
+        return key;
+    };
+    block.clear();
+    LPWCH inherited = GetEnvironmentStringsW();
+    if (inherited) {
+        for (LPWCH cursor = inherited; *cursor;) {
+            const std::wstring entry(cursor);
+            cursor += entry.size() + 1;
+            bool overridden = false;
+            for (const auto & extra : wide_extras) {
+                if (keyOf(extra) == keyOf(entry)) {
+                    overridden = true;
+                    break;
+                }
+            }
+            if (!overridden) {
+                block.append(entry);
+                block.push_back(L'\0');
+            }
+        }
+        FreeEnvironmentStringsW(inherited);
+    }
+    for (const auto & extra : wide_extras) {
+        block.append(extra);
+        block.push_back(L'\0');
+    }
+    block.push_back(L'\0');
+    return true;
+}
+
 std::string buildWindowsCommandLine(const std::vector<std::string> & arguments) {
     std::string result;
     for (const std::string & argument : arguments) {
@@ -274,11 +327,22 @@ bool ConPtyProcess::launch(const PtyProcessOptions & options, std::string & erro
         return false;
     }
 
+    std::wstring environment_block;
+    if (!options.environment.empty()
+            && !buildEnvironmentBlock(options.environment, environment_block, error)) {
+        DeleteProcThreadAttributeList(startup.lpAttributeList);
+        closeHandle(input_read);
+        closeHandle(output_write);
+        closePty();
+        return false;
+    }
     PROCESS_INFORMATION process = {};
     const BOOL created = CreateProcessW(
         nullptr, mutable_command.data(), nullptr, nullptr, FALSE,
         EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED,
-        nullptr, directory.empty() ? nullptr : directory.c_str(),
+        environment_block.empty()
+            ? nullptr : static_cast<LPVOID>(environment_block.data()),
+        directory.empty() ? nullptr : directory.c_str(),
         &startup.StartupInfo, &process);
     const DWORD create_error = GetLastError();
     DeleteProcThreadAttributeList(startup.lpAttributeList);
@@ -439,6 +503,67 @@ std::unique_ptr<PtyProcess> launchPtyProcess(
     return std::unique_ptr<PtyProcess>(process.release());
 }
 
+uint32_t spawnDetachedProcess(
+    const std::vector<std::string> & arguments,
+    const std::string & working_directory,
+    const std::vector<std::string> & environment,
+    std::string & error) {
+    error.clear();
+    if (arguments.empty()) {
+        error = "detached spawn argument array is empty";
+        return 0;
+    }
+    const std::string command_line = buildWindowsCommandLine(arguments);
+    std::wstring command = utf8ToWide(command_line, error);
+    std::wstring directory = utf8ToWide(working_directory, error);
+    if (command.empty() || (!working_directory.empty() && directory.empty())) {
+        if (error.empty()) error = "detached spawn command conversion failed";
+        return 0;
+    }
+    std::wstring environment_block;
+    if (!environment.empty()
+            && !buildEnvironmentBlock(environment, environment_block, error)) {
+        return 0;
+    }
+    std::vector<wchar_t> mutable_command(command.begin(), command.end());
+    mutable_command.push_back(L'\0');
+    STARTUPINFOW startup = {};
+    startup.cb = sizeof(startup);
+    // CREATE_NO_WINDOW, not DETACHED_PROCESS: the child gets its own hidden
+    // console (working std handles - PowerShell and friends break without
+    // one) that it owns outright, so it still survives the caller.
+    const DWORD base_flags = CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+        | CREATE_UNICODE_ENVIRONMENT;
+    LPVOID env_ptr = environment_block.empty()
+        ? nullptr : static_cast<LPVOID>(environment_block.data());
+    PROCESS_INFORMATION process = {};
+    BOOL created = CreateProcessW(
+        nullptr, mutable_command.data(), nullptr, nullptr, FALSE,
+        base_flags | CREATE_BREAKAWAY_FROM_JOB, env_ptr,
+        directory.empty() ? nullptr : directory.c_str(), &startup, &process);
+    if (!created && GetLastError() == ERROR_ACCESS_DENIED) {
+        // The caller's job forbids breakaway. Spawn anyway so work can
+        // proceed, but say so: the child will die with that job, which
+        // defeats detachment - the caller decides whether that is fatal.
+        created = CreateProcessW(
+            nullptr, mutable_command.data(), nullptr, nullptr, FALSE,
+            base_flags, env_ptr,
+            directory.empty() ? nullptr : directory.c_str(), &startup, &process);
+        if (created) {
+            error = "job breakaway denied; the detached process remains in "
+                "the caller's job and will die with it";
+        }
+    }
+    if (!created) {
+        if (error.empty()) error = windowsError("CreateProcessW(detached)");
+        return 0;
+    }
+    const uint32_t pid = process.dwProcessId;
+    CloseHandle(process.hThread);
+    CloseHandle(process.hProcess);
+    return pid;
+}
+
 } // namespace das_terminal
 
 #else
@@ -449,6 +574,13 @@ std::unique_ptr<PtyProcess> launchPtyProcess(
     const PtyProcessOptions &, std::string & error) {
     error = "PTY transport is not implemented on this platform";
     return std::unique_ptr<PtyProcess>();
+}
+
+uint32_t spawnDetachedProcess(
+    const std::vector<std::string> &, const std::string &,
+    const std::vector<std::string> &, std::string & error) {
+    error = "detached spawn is not implemented on this platform";
+    return 0;
 }
 
 } // namespace das_terminal

--- a/modules/dasTerminal/src/pty.h
+++ b/modules/dasTerminal/src/pty.h
@@ -12,6 +12,10 @@ struct PtyProcessOptions {
     std::string command_line;
     std::vector<std::string> arguments;
     std::string working_directory;
+    // Extra KEY=VALUE entries merged over the inherited environment (same-key
+    // entries replace inherited ones). Empty = inherit unchanged. Secrets ride
+    // here instead of the command line, which any local process can read.
+    std::vector<std::string> environment;
     int columns = 80;
     int rows = 25;
 };
@@ -41,5 +45,16 @@ public:
 
 std::unique_ptr<PtyProcess> launchPtyProcess(
     const PtyProcessOptions & options, std::string & error);
+
+// Spawns a plain process that outlives the caller: detached from the caller's
+// console, broken away from its job object, in its own process group, with no
+// inherited pipe handles. The child is deliberately not tracked — discovery is
+// the caller's business (stamp files). Returns the pid, 0 on failure. A pid
+// with a non-empty error is a degraded success (e.g. job breakaway denied).
+uint32_t spawnDetachedProcess(
+    const std::vector<std::string> & arguments,
+    const std::string & working_directory,
+    const std::vector<std::string> & environment,
+    std::string & error);
 
 } // namespace das_terminal

--- a/modules/dasTerminal/tests/terminal_semantics.das
+++ b/modules/dasTerminal/tests/terminal_semantics.das
@@ -1,4 +1,7 @@
 options gen2
+// One big main holding a dozen Terminal locals: the default 16K stack
+// overflowed when the mouse-reporting block joined.
+options stack = 65536
 
 require terminal/terminal
 require strings
@@ -303,6 +306,31 @@ def main {
     assert_snapshots_equal(checkpoint_source_snapshot, checkpoint_copy_snapshot)
     terminal_snapshot_dispose(checkpoint_source_snapshot)
     terminal_snapshot_dispose(checkpoint_copy_snapshot)
+
+    // Mouse reporting: the modes gate the forwarding decision, the encoder
+    // speaks SGR when 1006 is selected and legacy X10 bytes otherwise.
+    var inscope mouse <- terminal_create(80, 24)
+    assert(!terminal_mouse_reporting_active(mouse), "mouse reporting starts off")
+    terminal_feed(mouse, "{esc}[?1003h{esc}[?1006h")
+    assert(terminal_mouse_reporting_active(mouse), "any-motion mode reports")
+    assert(terminal_encode_mouse(mouse, 64, 5, 2, true) == "{esc}[<64;6;3M",
+        "SGR wheel up")
+    assert(terminal_encode_mouse(mouse, 65, 5, 2, true) == "{esc}[<65;6;3M",
+        "SGR wheel down")
+    assert(terminal_encode_mouse(mouse, 0, 5, 2, true) == "{esc}[<0;6;3M",
+        "SGR left press")
+    assert(terminal_encode_mouse(mouse, 0, 5, 2, false) == "{esc}[<0;6;3m",
+        "SGR left release")
+    terminal_feed(mouse, "{esc}[?1006l")
+    assert(terminal_encode_mouse(mouse, 0, 0, 0, true)
+            == "{esc}[M{to_char(32)}{to_char(33)}{to_char(33)}",
+        "legacy left press")
+    assert(terminal_encode_mouse(mouse, 0, 0, 0, false)
+            == "{esc}[M{to_char(35)}{to_char(33)}{to_char(33)}",
+        "legacy release loses button identity")
+    terminal_feed(mouse, "{esc}[?1003l")
+    assert(!terminal_mouse_reporting_active(mouse), "modes reset turns reporting off")
+    terminal_dispose(mouse)
 
     terminal_dispose(checkpoint_copy)
     terminal_dispose(checkpoint_source)

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -829,12 +829,16 @@ namespace das {
             return -1;
         }
         SetHandleInformation(hReadPipe, HANDLE_FLAG_INHERIT, 0);
-        // Create job object to kill entire process tree on timeout
+        // Create job object to kill entire process tree on timeout.
+        // BREAKAWAY_OK lets a descendant that explicitly requests
+        // CREATE_BREAKAWAY_FROM_JOB (spawn_detached) opt OUT of the subtree;
+        // everything that doesn't ask still dies with the job.
         HANDLE hJob = CreateJobObjectA(NULL, NULL);
         if ( hJob ) {
             JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli;
             memset(&jeli, 0, sizeof(jeli));
-            jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            jeli.BasicLimitInformation.LimitFlags =
+                JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
             SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli));
         }
         STARTUPINFOA si;
@@ -1168,7 +1172,11 @@ namespace das {
             if ( hJob ) {
                 JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli;
                 memset(&jeli, 0, sizeof(jeli));
-                jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                // BREAKAWAY_OK: a descendant that explicitly requests
+                // CREATE_BREAKAWAY_FROM_JOB (spawn_detached) may leave the
+                // kill-on-close subtree; everything else still dies with it.
+                jeli.BasicLimitInformation.LimitFlags =
+                    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
                 SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli));
             }
         }

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -369,6 +369,32 @@ The existing babysit workflow should ultimately consume this state directly:
 monitor checks and reviews, prepare proposed responses/actions, surface only
 decisions that need a human, and merge when the user's declared policy permits.
 
+### The observer model: tool-driven, not agent-driven (decided 2026-07-26)
+
+Watching is software's job; judgment is the agent's. Agents must never poll —
+an agent context re-running `gh pr view` on a timer is the most expensive
+polling loop ever devised, and honest software does the same watch better for
+100500x less. The watcher grows a **GitHub observer**: dumb, cheap, tireless —
+it polls PRs/CI/reviews, diffs observed state, and acts only on transitions.
+
+The lifecycle is inverted — the tool drives the agent ("PR slave driver"):
+
+- **Arm**: when a PR is about to open or opens, the observer tells the
+  session's agent "we are about to do a PR, sit tight" — context delivered
+  once, no watching duties assigned.
+- **Summon**: on a meaningful transition the observer wakes the agent with a
+  delta briefing — "CI lane X went red after commit Y", "review question Z
+  arrived" — so tokens are spent on the judgment call, never on discovering
+  that nothing changed.
+
+Signal hierarchy, hard before soft: **a CI lane going red is a 100% real
+failure** and outranks every advisory signal. "Copilot says it's bad" is
+cute — an input to judgment; "test failed" is truth — an event that summons.
+Attention ranking follows deviation, not activity: changes outside the
+declared Review Bundle focus, failures appearing after a force-push, repeated
+failed fix attempts on the same lane escalate to "needs looking into, for
+reals"; everything else stays auto-trusted with a one-line receipt.
+
 ## Proposed order
 
 Implement Track A first, beginning with the shared Review Focus model and its
@@ -428,6 +454,15 @@ for presentation, never the correctness oracle.
 - 2026-07-21: GitHub review should cover PR body, CI, comments, logs, questions
   about exact failures, Copilot review, supervised actions, and eventual
   babysit-to-merge operation.
+- 2026-07-26: Track B runs on a watcher-side GitHub observer with a
+  tool-driven agent lifecycle (arm/summon); agents never poll. Hard signals
+  (CI red) outrank soft ones (Copilot verdicts); attention ranks by deviation
+  from the declared bundle, not by activity. Boris: review capacity is the
+  bottleneck — the PR-list rate resembles a medium-size startup — so the
+  next big UI after the terminal arc is the GitHub PR assistant, and key
+  views are the regular workflow (human in terminals, human directing agents
+  into terminals) plus reviewing copilot interaction with an honest
+  "this one needs looking into, for reals" escalation instead of forced trust.
 - 2026-07-21: Proposed preference is local Review Focus first, GitHub second,
   because Review Focus is the shared interaction foundation.
 - 2026-07-21: Adopt local Review Focus first and begin protocol design before

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -468,6 +468,16 @@ for presentation, never the correctness oracle.
   review turns on-demand: summoned by the observer or the human when bundle
   deviation warrants it. When the repo setting actually flips, revisit
   skills/babysit.md, which still assumes Copilot feedback arrives on every PR.
+- 2026-07-26: review-by-another-agent/tool graduates from avoided to planned.
+  What makes it safe now: the reviewer is summoned against a declared bundle
+  (reviews a claim, cheapest finding = deviation from the declaration), its
+  output lands in the attention queue as a ranked soft signal (competes for
+  trust, never demands it, never blocks), and escalation stays evidence-shaped
+  — an opinion with a reproduction (failing test) becomes a red lane and
+  summons; what can't be reproduced stays ranked advice. Reviewer sessions get
+  fresh context and the bundle only, never the author's conversation
+  (independence). Deterministic tools (lint, perf_lint, detect-dupe) join the
+  same pipeline one trust rung up: their findings reproduce by construction.
 - 2026-07-21: Proposed preference is local Review Focus first, GitHub second,
   because Review Focus is the shared interaction foundation.
 - 2026-07-21: Adopt local Review Focus first and begin protocol design before

--- a/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
+++ b/utils/dasHerd/AGENT_REVIEW_WORKFLOWS.md
@@ -463,6 +463,11 @@ for presentation, never the correctness oracle.
   views are the regular workflow (human in terminals, human directing agents
   into terminals) plus reviewing copilot interaction with an honest
   "this one needs looking into, for reals" escalation instead of forced trust.
+- 2026-07-26: consequence of the observer model — automatic Copilot review on
+  GitHub becomes a redundant firehose; Boris intends to switch it off. Advisory
+  review turns on-demand: summoned by the observer or the human when bundle
+  deviation warrants it. When the repo setting actually flips, revisit
+  skills/babysit.md, which still assumes Copilot feedback arrives on every PR.
 - 2026-07-21: Proposed preference is local Review Focus first, GitHub second,
   because Review Focus is the shared interaction foundation.
 - 2026-07-21: Adopt local Review Focus first and begin protocol design before

--- a/utils/dasHerd/BACKLOG.md
+++ b/utils/dasHerd/BACKLOG.md
@@ -5,37 +5,34 @@ HERDER_FIXROUND.md; arc designs in PTY_HOST_DESIGN.md and
 AGENT_REVIEW_WORKFLOWS.md. Rule of the round stands: bugs over everything;
 review capacity is the bottleneck the arcs exist to fix.
 
-## Phase 0 — deploy and prove (Boris at the wheel, ~one sitting)
+## Phase 0 — deploy and prove — PROVEN LIVE 2026-07-26 (accidentally)
 
-- Start the rig on the current branch (watcher + rich client). Everything
-  durable launches host-backed from the first session.
-- The proof: restart the watcher under a live agent session; watch it
-  resurrect as running. Retires the note-50 operational rule.
-- Verify the two pending-deploy items from the evening intake:
-  - 40 sessions list (alive on top, dead tinted, delete button)
-  - 41 worktree delete guards (+ resolver-session offer)
-- First dogfood session doubles as intake: file what's broken, don't fix
-  inline.
+The goal-round rig ran the current branch; the watcher died mid-flight
+(ungraceful — a closed stdout pipe) with a live shell AND a live Claude
+Code session in detached hosts. The restarted watcher logged "adopted 2
+detached PTY host session(s)"; both records resurrected running (no
+watcher_restart scar), the client reconnected on its own, and the adopted
+shell echoed input ("SURVIVED-THE-WATCHER"). Remaining for Boris: see it
+with his own eyes once, then the note-50 operational rule retires.
+40/41 are deployed with their round-time verification; dogfood confirms.
 
-## Phase 1 — dogfood bug burn-down (the open notes)
+## Phase 1 — dogfood bug burn-down — DONE 2026-07-26 (goal round)
 
-The new-session terminal cluster first — likely one root (attach-time
-resize/focus/replay), and it makes every fresh session feel broken:
+Every note fixed or verified in-build; per-note detail + proof lives in
+HERDER_FIXROUND.md:
 
-- 42 terminal in a NEW session does not scroll
-- 44 new-session terminal has no keyboard focus until clicked
-- 47 stray-letter column artifacts in a new session's terminal
-
-Then the flow lies and small frictions:
-
-- 48 Project tab "Select a worktree" while a session is selected
-  (session pick IS a worktree pick; the empty-state message lies)
-- 43 herd card click selects then unselects (selection bounce)
-- 46 Sessions & Activity opaque rows (names over ids, click-through,
-  dismiss, drop unresolvable entries)
-- 45 session-card icons need tooltips
-- 49 default layout: Git Changelist docks bottom-right
-  (boris_changelist_dock.png; update setup_layout_preset)
+- 42 FIXED — Claude runs alt-screen + mouse reporting; the widget now
+  forwards wheel/clicks to the child when reporting is active (dasTerminal
+  terminal_encode_mouse + imgui_terminal forwarding; Shift = local).
+- 44 FIXED — focus via the terminal's own model (the tabbing request fell
+  through the InvisibleButton), surviving the checkpoint reset.
+- 47 FIXED — the "stray column" was Sessions-panel text clipped at the
+  window edge; card/context/summary rows now elide to the content region.
+- 43 FIXED — herd-level selection pick; dead-card clicks stick.
+- 48/45/46/49 VERIFIED in the current build (fix-round work, was pending
+  deploy).
+- Drive-by: herder_close_session rail now rejects unknown herd ids
+  instead of ok=true.
 
 Carried remainders that slot here when touched:
 

--- a/utils/dasHerd/BACKLOG.md
+++ b/utils/dasHerd/BACKLOG.md
@@ -1,0 +1,125 @@
+# dasHerd backlog and plan
+
+Status: plan of record, 2026-07-26. History and per-note forensics live in
+HERDER_FIXROUND.md; arc designs in PTY_HOST_DESIGN.md and
+AGENT_REVIEW_WORKFLOWS.md. Rule of the round stands: bugs over everything;
+review capacity is the bottleneck the arcs exist to fix.
+
+## Phase 0 — deploy and prove (Boris at the wheel, ~one sitting)
+
+- Start the rig on the current branch (watcher + rich client). Everything
+  durable launches host-backed from the first session.
+- The proof: restart the watcher under a live agent session; watch it
+  resurrect as running. Retires the note-50 operational rule.
+- Verify the two pending-deploy items from the evening intake:
+  - 40 sessions list (alive on top, dead tinted, delete button)
+  - 41 worktree delete guards (+ resolver-session offer)
+- First dogfood session doubles as intake: file what's broken, don't fix
+  inline.
+
+## Phase 1 — dogfood bug burn-down (the open notes)
+
+The new-session terminal cluster first — likely one root (attach-time
+resize/focus/replay), and it makes every fresh session feel broken:
+
+- 42 terminal in a NEW session does not scroll
+- 44 new-session terminal has no keyboard focus until clicked
+- 47 stray-letter column artifacts in a new session's terminal
+
+Then the flow lies and small frictions:
+
+- 48 Project tab "Select a worktree" while a session is selected
+  (session pick IS a worktree pick; the empty-state message lies)
+- 43 herd card click selects then unselects (selection bounce)
+- 46 Sessions & Activity opaque rows (names over ids, click-through,
+  dismiss, drop unresolvable entries)
+- 45 session-card icons need tooltips
+- 49 default layout: Git Changelist docks bottom-right
+  (boris_changelist_dock.png; update setup_layout_preset)
+
+Carried remainders that slot here when touched:
+
+- 39 portal file in sticky Diff mode: silent empty inspector (fix shape
+  decided: force View or state "nested repository - no diff vs parent")
+- 20 token palette adoption on herd cards + repositories panel
+- 13 diff-mode search (needs text-line -> display-row map); terminal +
+  history search rides the scrollback/history work
+- dasImgui-internal QoL: combo imgui_force_set after live reload;
+  ClickState.click_count on disabled widgets
+
+## Phase 2 — external sessions arc
+
+A session whose terminal lives OUTSIDE the herder (the dev session building
+dasHerd), claimed from outside, coordination-only, outliving the watcher.
+Mechanically: a host/stamp the watcher never spawned — adoption already does
+not care who spawned a stamp. Payoff: the sessions doing the real work become
+visible, coordinated participants; "Repositories and worktrees" migrates
+right, sessions-first left (Boris, 2026-07-25).
+
+## Phase 3 — GitHub observer + PR assistant (Track B)
+
+The review-capacity payoff. Design decided (AGENT_REVIEW_WORKFLOWS.md):
+
+- Watcher-side observer polls PRs/CI/reviews; agents never poll.
+- Tool-driven lifecycle: arm ("PR about to open, sit tight") then summon
+  ("look at that" + delta briefing) on transitions.
+- Hard signals (CI red = truth) summon; soft signals (Copilot verdicts =
+  advice) rank. Attention ranks by deviation from the declared bundle.
+- Escalation policy attaches at arm time per PR/bundle.
+- With it: flip auto-Copilot-review off on GitHub; rework skills/babysit.md
+  (it assumes Copilot feedback arrives on every PR).
+- 26 "agent needs me" (blocked-at-prompt heuristics) folds into the same
+  attention machinery.
+
+## Phase 4 — reviewer agent / tool
+
+Rides Phases 2-3 with zero new machinery: a session (built), armed on
+bundle -> ready (observer), scoped by the bundle (built), reporting into
+attention (built). Disciplines: reviewer gets the bundle, never the author's
+conversation; opinions rank, reproductions escalate; deterministic tools
+(lint, perf_lint, detect-dupe) join one trust rung up.
+
+## Phase 5 — ssh / watcher-per-box
+
+Decided shape (PTY_HOST_DESIGN.md): one watcher per box, client federates
+via a watcher list; ssh = tunnel + control channel only; git stays
+watcher-local. Pull forward if a second box becomes real before Phase 3-4
+finish; nothing else depends on it.
+
+## Structural, when the scenario demands
+
+- 25 multiple terminals (or instant switching with preserved state) — the
+  several-agents-at-once scenario; pairs with 26.
+- 35 human/agent UI input lease UX ("input is leased to X - click to
+  claim") — the mute + badges landed with 38; the arbitration UX remains.
+- 37 follow-up: registered-repository synthesis for gitignored nested
+  repos; portal into its own Project view.
+- Icon-set expansion (consult Claude Design first; proposal list in
+  HERDER_FIXROUND.md).
+
+## Deferred (standing: never over real work)
+
+- Agent env via host DASHERD_CHILD_* instead of the powershell wrapper
+  (token visible in host command line today, as it was before; harden
+  later, way later).
+- WebSocketServer handle leak at rich-client exit.
+- Lease heartbeat starvation under multi-second frame stalls (no repro).
+- Diff BEFORE/AFTER one-frame scroll desync (cosmetic).
+- ImGui Install/RestoreCallbacks vs chain prev caches (latent, zero
+  in-tree callers).
+- mcp_supervisor.py ping while a tool call blocks; URL-encoding of query
+  values (watcher ids/tokens are URL-safe).
+- Watcher-ring transcript/history view for repainting TUIs (the eventual
+  answer to "scrollback" for Ink-style agents).
+
+## Decision points for Boris
+
+1. **The PR.** Sequencing settled 2026-07-25 says: whole round on this
+   branch, one PR for the record, big review on that PR. The branch now
+   carries the fix round AND the host arc (~25 unpushed commits). Cut the
+   PR after Phase 0 proves the deploy, or keep riding until Phase 1 lands?
+   Preflight budget unchanged: one full run, none used.
+2. **Phase 2 vs Phase 3 order.** External sessions makes today's work
+   visible; the observer pays down review capacity. Plan assumes external
+   first (it is smaller and Phase 3's reviewer summons benefit from it).
+3. **When ssh becomes real** — pull Phase 5 forward or leave it parked.

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -476,23 +476,58 @@ Issue intake (live rig, numbering continues):
 - 41: worktree delete from the git panel — in-use = hard block; uncommitted
   changes = block + offer to launch a resolver session briefed with the
   blocking state — IMPLEMENTED, pending deploy
-- 42: terminal in a NEW session does not scroll
+- 42: terminal in a NEW session does not scroll — FIXED (2026-07-26 goal
+  round). Root cause proven from the session journal: Claude Code runs on
+  the ALTERNATE screen (?1049h — no terminal scrollback by design) and
+  enables mouse reporting (?1000/1002/1003/1006h); in a real terminal the
+  wheel goes TO Claude, which scrolls its own transcript. Our widget only
+  did local scrollback scrolling (empty on alt screen). Fix: dasTerminal
+  grew terminal_mouse_reporting_active + terminal_encode_mouse (SGR/X10);
+  imgui_terminal forwards wheel + clicks to the child when reporting is
+  active (Shift reserves local scroll/selection; Ctrl+wheel stays zoom).
+  Live-proven: wheel over the claude session scrolled ITS transcript
+  ("Jump to bottom (ctrl+End)" indicator on screen). Shell sessions were
+  never broken (wheel 0->9 over 56 history rows on the same build).
 - 43: herd card click selects then unselects (cc-color-probe3 clicked while
-  "Towards 0.6.4 release" attached; selection bounces back)
+  "Towards 0.6.4 release" attached; selection bounces back) — FIXED
+  (2026-07-26). The dead-PTY attach guard from the fix round stopped the
+  selection yank but left the click with ZERO feedback (the highlight was
+  bound to pty==selected_id, which never changes for a dead PTY). Cards now
+  highlight through a herd-level pick (g_selected_herd_id); PTY selections
+  made outside the cards retarget it once per change. Proven both ways:
+  dead-card pick sticks, live-card pick transfers and attaches.
 - 44: after creating a new session the terminal opens but has no keyboard
-  focus — a mouse click is needed before typing
+  focus — a mouse click is needed before typing. FIXED (2026-07-26),
+  two layers: (a) SetKeyboardFocusHere's tabbing request falls through
+  the terminal's InvisibleButton onto the next tab stop (snapshot showed
+  the -5% zoom button holding focus) — focus now goes through the
+  terminal's own model (g_terminal_view.focused); (b) the attach-time
+  checkpoint restore rebuilt ImGuiTerminalState AFTER the handshake ran
+  — reset_terminal now carries focus over. Proven: real keystrokes
+  land in a fresh session with no click; snapshot focused=true
 - 45: the icons left of each session card (profile / state / conflict) have
-  no tooltips — unexplained glyphs
+  no tooltips — unexplained glyphs. VERIFIED FIXED on deploy
+  (2026-07-26): tooltips landed with the fix round; hover probe shows
+  HERD_ICON_TOOLTIP hover=true value="Agent session (profile 'claude')"
 - 46: Sessions & Activity shows opaque rows — "REGULAR s2563..." entries and
   an error list ("unknown session", "4m ago") that is not clickable, not
   scrollable, not hideable, purpose unclear. Needs names over raw ids,
   click-through, dismiss/collapse, and dropping entries whose session no
-  longer resolves
+  longer resolves. LANDED IN BUILD (2026-07-26 audit): names-over-ids in
+  the context panel and cards, attention rows show subjects and
+  click-navigate, errors are a collapsed/scrollable/clearable ring,
+  zero-count sections gone; the "unknown session" error source (dead-PTY
+  attach) fixed under 43. Boris re-test decides any residue
 - 47: visual artifacts in a NEW session's terminal — stray letters in a
   one-character column outside the text flow (Boris saw red "S"s stacked
   vertically bottom-right; captured 'e'/'w'/'s'/'n' on the pane's left
   edge). Looks like a stale/displaced grid column surviving the
-  attach-time resize, un-clipped; fades as output overwrites
+  attach-time resize, un-clipped; fades as output overwrites. FIXED
+  (2026-07-26): not the emulator — the "column" was Sessions-panel card
+  text clipped at the WINDOW edge (one character into the padding, flush
+  against the terminal border; bbox z=739 vs window edge 690 in the
+  snapshot). Card detail/context/summary rows now elide to the content
+  region (elide_to_avail). Screenshot-verified before/after
 - 51: BLOCK PIVOT (Boris, 2026-07-25): --continue resume is a crutch, not
   the answer. Next block, ahead of external sessions and everything else:
   redesign PTY hosting until a terminal session "does not depend on
@@ -527,8 +562,15 @@ Issue intake (live rig, numbering continues):
 - 49: default layout — Git Changelist docks bottom-right as its own pane
   under the Git Activity + File Inspector tab stack (per Boris's live
   arrangement, captured in boris_changelist_dock.png); update
-  setup_layout_preset so dock reset / fresh install lands there
-- 48: Project tab says "Select a worktree to browse its files" while a
+  setup_layout_preset so dock reset / fresh install lands there.
+  VERIFIED (2026-07-26): the preset already lands this shape; dock reset
+  proven live (right column: Repositories / Git Activity+Inspector /
+  Changelist bottom at y=1043)
+- 48: VERIFIED FIXED on deploy (2026-07-26): a session pick aims the git
+  surfaces (attach_herd_card), the Project tab kicks the files request on
+  entry (8490 files on direct perspective switch), and the empty state
+  distinguishes no-selection / failed / empty. Original: Project tab says
+  "Select a worktree to browse its files" while a
   session is attached and selected. Rule: selecting or creating a session
   selects its primary worktree (a session pick IS a deliberate worktree
   pick; set the explicit flag), so Project/Changelist immediately point

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -500,6 +500,14 @@ Issue intake (live rig, numbering continues):
   owns the console + child on its own, survives watcher/client/upgrade,
   reachable over a versioned IPC channel. Current UI/feature work is
   parked (committed on this branch) until that lands.
+  PROGRESS (same evening): dasTerminal grew spawn_detached (CREATE_NO_WINDOW
+  + job breakaway; DETACHED_PROCESS breaks console apps) and environment
+  blocks on both spawn paths (retires the token-on-command-line item);
+  utils/dasHerd/ptyhost/main.das v1 landed and smoke-proved the whole
+  claim live: host spawned detached, launcher died, host kept journaling;
+  a fresh client authenticated, replayed from byte 0, sent input, got the
+  child's echo with a forwarded env var. Remaining: dastest lifecycle
+  test, watcher launch-via-host + adoption, daspkg release packaging.
 - 50: HARD RULE + arc — a watcher restart must never kill hosted sessions
   ("its not ok to kill my terminal session"). Today PTYs are ConPTY
   children of the watcher and die with it; needs a per-session broker

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -508,13 +508,22 @@ Issue intake (live rig, numbering continues):
   a fresh client authenticated, replayed from byte 0, sent input, got the
   child's echo with a forwarded env var. Remaining: dastest lifecycle
   test, watcher launch-via-host + adoption, daspkg release packaging.
+  LANDED (2026-07-26): all of it — lifecycle test, release packaging, and
+  the watcher rework (launch-via-host for herd sessions, pumps proxied
+  over the host WS, adoption on startup with sessions resurrecting as
+  RUNNING, herd registry fold of dead hosts' exit stamps). Suite 71/71
+  incl. test_watcher_adoption.das proving restart survival end-to-end.
+  Decisions + the ConPTY drained-never-fires finding: PTY_HOST_DESIGN.md.
 - 50: HARD RULE + arc — a watcher restart must never kill hosted sessions
   ("its not ok to kill my terminal session"). Today PTYs are ConPTY
   children of the watcher and die with it; needs a per-session broker
   process that owns the ConPTY and outlives the watcher (tmux-server
   model), with restart = re-discover + re-attach. Operationally until
   then: the watcher only restarts when no agent session is running or
-  Boris explicitly says go
+  Boris explicitly says go. RESOLVED BY ARCHITECTURE (2026-07-26): herd
+  sessions run in detached hosts; watcher restart adopts them back as
+  running (see 51 / PTY_HOST_DESIGN.md). The operational rule stays until
+  the rework is deployed to the live rig and proven there
 - 49: default layout — Git Changelist docks bottom-right as its own pane
   under the Git Activity + File Inspector tab stack (per Boris's live
   arrangement, captured in boris_changelist_dock.png); update

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -493,6 +493,11 @@ Issue intake (live rig, numbering continues):
   vertically bottom-right; captured 'e'/'w'/'s'/'n' on the pane's left
   edge). Looks like a stale/displaced grid column surviving the
   attach-time resize, un-clipped; fades as output overwrites
+- 48: Project tab says "Select a worktree to browse its files" while a
+  session is attached and selected. Rule: selecting or creating a session
+  selects its primary worktree (a session pick IS a deliberate worktree
+  pick; set the explicit flag), so Project/Changelist immediately point
+  at the session's tree
 
 Deferred — nice-to-have, never over real work (Boris, 2026-07-25):
 - token in child command line: fix is env-block support in dasTerminal

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -449,3 +449,28 @@ the UI currently substitutes text or a wrong-shaped glyph):
 No intermediate PR — no users yet. The whole fix round (Waves 0-4)
 lands on this branch, then one PR for historical record, then the big
 review happens on that PR.
+
+## Review round (2026-07-25, post-merge of PR #3567)
+
+Full-tree review: personal pass on watcher core/server/net + 3 agent
+passes (git/inspector/files UI, sessions/launcher/terminal, C++/glue).
+9 verified defects fixed in commits 872fe420d + c6e285d74 (token
+dual-spelling auth, empty-cwd guard, worktree-row highlight, portal
+re-list, say-queue garbling, output-age table growth, glfw chain
+dispatch UAF, daslang-live is_reload, CMake stale-module sweep
+deleting standalone-module artifacts).
+
+Deferred — nice-to-have, never over real work (Boris, 2026-07-25):
+- token in child command line: fix is env-block support in dasTerminal
+  spawn (pass DASHERD_* via CreateProcess lpEnvironment instead of a
+  powershell -Command prefix). Harden later, way later.
+- lease heartbeat starvation under multi-second frame stalls (client
+  pumps ~1s, server timeout 5s) — observation, no repro.
+- diff BEFORE/AFTER one-frame scroll desync when the AFTER pane drives
+  the wheel — cosmetic, inherent child draw order.
+- ImGui Install/RestoreCallbacks vs chain prev caches can strand a das
+  glfw_chain_add_* listener after mute/unmute — latent, zero in-tree
+  callers; touching the interleave risks regressing note 38.
+- mcp_supervisor.py cannot answer ping while a tool call blocks
+  (single-threaded stdin loop); mcp_main.das query values not
+  URL-encoded (watcher-generated ids/tokens are URL-safe).

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -460,6 +460,30 @@ re-list, say-queue garbling, output-age table growth, glfw chain
 dispatch UAF, daslang-live is_reload, CMake stale-module sweep
 deleting standalone-module artifacts).
 
+## Block: external sessions (2026-07-25 evening)
+
+Goal (Boris): "external sessions" — a session whose terminal lives OUTSIDE
+the herder (like the dev session building dasHerd itself), claimed from the
+outside, attached to worktree(s), coordination-only (mailbox/bundles/claims;
+no terminal view, no lease, no input), and able to OUTLIVE the herder across
+watcher restarts. Follow-up: "Repositories and worktrees" migrates to the
+right side as "Git repositories and worktrees"; the left side is sessions,
+sessions-first.
+
+Issue intake (live rig, numbering continues):
+- 40: sessions list: alive on top, dead in a different color, delete button
+  for session + associated worktrees — IMPLEMENTED, pending deploy
+- 41: worktree delete from the git panel — in-use = hard block; uncommitted
+  changes = block + offer to launch a resolver session briefed with the
+  blocking state — IMPLEMENTED, pending deploy
+- 42: terminal in a NEW session does not scroll
+- 43: herd card click selects then unselects (cc-color-probe3 clicked while
+  "Towards 0.6.4 release" attached; selection bounces back)
+- 44: after creating a new session the terminal opens but has no keyboard
+  focus — a mouse click is needed before typing
+- 45: the icons left of each session card (profile / state / conflict) have
+  no tooltips — unexplained glyphs
+
 Deferred — nice-to-have, never over real work (Boris, 2026-07-25):
 - token in child command line: fix is env-block support in dasTerminal
   spawn (pass DASHERD_* via CreateProcess lpEnvironment instead of a

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -497,7 +497,11 @@ Issue intake (live rig, numbering continues):
   session is attached and selected. Rule: selecting or creating a session
   selects its primary worktree (a session pick IS a deliberate worktree
   pick; set the explicit flag), so Project/Changelist immediately point
-  at the session's tree
+  at the session's tree. Evidence: the header above that empty-state
+  ALREADY shows "PROJECT D:/Work/..." (the path), and visiting History or
+  Tree populates Project — so (1) the files request is not kicked on
+  Project tab entry, and (2) the empty-state message lies (state is
+  not-requested, not no-selection)
 
 Deferred — nice-to-have, never over real work (Boris, 2026-07-25):
 - token in child command line: fix is env-block support in dasTerminal

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -488,6 +488,11 @@ Issue intake (live rig, numbering continues):
   scrollable, not hideable, purpose unclear. Needs names over raw ids,
   click-through, dismiss/collapse, and dropping entries whose session no
   longer resolves
+- 47: visual artifacts in a NEW session's terminal — stray letters in a
+  one-character column outside the text flow (Boris saw red "S"s stacked
+  vertically bottom-right; captured 'e'/'w'/'s'/'n' on the pane's left
+  edge). Looks like a stale/displaced grid column surviving the
+  attach-time resize, un-clipped; fades as output overwrites
 
 Deferred — nice-to-have, never over real work (Boris, 2026-07-25):
 - token in child command line: fix is env-block support in dasTerminal

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -493,6 +493,13 @@ Issue intake (live rig, numbering continues):
   vertically bottom-right; captured 'e'/'w'/'s'/'n' on the pane's left
   edge). Looks like a stale/displaced grid column surviving the
   attach-time resize, un-clipped; fades as output overwrites
+- 51: BLOCK PIVOT (Boris, 2026-07-25): --continue resume is a crutch, not
+  the answer. Next block, ahead of external sessions and everything else:
+  redesign PTY hosting until a terminal session "does not depend on
+  anything, and yet can be communicated to" — detached ConPTY host that
+  owns the console + child on its own, survives watcher/client/upgrade,
+  reachable over a versioned IPC channel. Current UI/feature work is
+  parked (committed on this branch) until that lands.
 - 50: HARD RULE + arc — a watcher restart must never kill hosted sessions
   ("its not ok to kill my terminal session"). Today PTYs are ConPTY
   children of the watcher and die with it; needs a per-session broker

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -483,6 +483,11 @@ Issue intake (live rig, numbering continues):
   focus — a mouse click is needed before typing
 - 45: the icons left of each session card (profile / state / conflict) have
   no tooltips — unexplained glyphs
+- 46: Sessions & Activity shows opaque rows — "REGULAR s2563..." entries and
+  an error list ("unknown session", "4m ago") that is not clickable, not
+  scrollable, not hideable, purpose unclear. Needs names over raw ids,
+  click-through, dismiss/collapse, and dropping entries whose session no
+  longer resolves
 
 Deferred — nice-to-have, never over real work (Boris, 2026-07-25):
 - token in child command line: fix is env-block support in dasTerminal

--- a/utils/dasHerd/HERDER_FIXROUND.md
+++ b/utils/dasHerd/HERDER_FIXROUND.md
@@ -493,6 +493,17 @@ Issue intake (live rig, numbering continues):
   vertically bottom-right; captured 'e'/'w'/'s'/'n' on the pane's left
   edge). Looks like a stale/displaced grid column surviving the
   attach-time resize, un-clipped; fades as output overwrites
+- 50: HARD RULE + arc — a watcher restart must never kill hosted sessions
+  ("its not ok to kill my terminal session"). Today PTYs are ConPTY
+  children of the watcher and die with it; needs a per-session broker
+  process that owns the ConPTY and outlives the watcher (tmux-server
+  model), with restart = re-discover + re-attach. Operationally until
+  then: the watcher only restarts when no agent session is running or
+  Boris explicitly says go
+- 49: default layout — Git Changelist docks bottom-right as its own pane
+  under the Git Activity + File Inspector tab stack (per Boris's live
+  arrangement, captured in boris_changelist_dock.png); update
+  setup_layout_preset so dock reset / fresh install lands there
 - 48: Project tab says "Select a worktree to browse its files" while a
   session is attached and selected. Rule: selecting or creating a session
   selects its primary worktree (a session pick IS a deliberate worktree

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -32,10 +32,21 @@ exactly three things:
    / stat / terminate{reason}. Nothing else. Protocol v1 is forever — a new
    watcher must always speak old hosts.
 
-Spawned **detached**: `DETACHED_PROCESS` + breakaway from any inherited job
-(`CREATE_BREAKAWAY_FROM_JOB`; if the spawning environment forbids breakaway,
-spawn through a one-shot intermediary). No inherited console, no inherited
-job, no parent-death ties. The watcher becomes a *client* of the host.
+Spawned **detached**: `CREATE_NO_WINDOW` (NOT `DETACHED_PROCESS` — console
+apps such as PowerShell break with no console at all; a hidden conhost of
+its own keeps std handles working AND survives the caller) plus
+`CREATE_BREAKAWAY_FROM_JOB` and a new process group. No inherited console,
+no inherited job, no parent-death ties. The watcher becomes a *client* of
+the host.
+
+Two job-object facts learned live: the spawn falls back to no-breakaway
+with a reported warning when the caller's job forbids it — treat that
+warning as fatal for host spawns, the host would die with the job. And
+daslang's own `popen_argv` job needed `JOB_OBJECT_LIMIT_BREAKAWAY_OK`
+added (src/builtin/module_builtin_fio.cpp) so a popen descendant that
+explicitly requests breakaway can leave the kill-on-close subtree — that
+is what lets the lifecycle test (dastest → popen launcher → detached
+host) prove spawner-death survival.
 
 ## Discovery and adoption
 

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -1,8 +1,31 @@
 # Detached PTY host — "a terminal that depends on nothing"
 
-Status: DRAFT for review (2026-07-25). The next block per Boris: drop
-everything and make terminal sessions fully independent. `--continue`
-resume demotes to disaster recovery, never the mechanism.
+Status: CORE LANDED (2026-07-25 night). Remaining: the watcher rework
+below ("What changes where"). `--continue` resume demotes to disaster
+recovery, never the mechanism.
+
+## Resume state for the next session (written before a /clear)
+
+- DONE, committed, tests green (watcher suite 68/68; test_ptyhost 1.9s):
+  spawn_detached + env blocks in dasTerminal; utils/dasHerd/ptyhost/main.das
+  (protocol v1); daspkg release packaging; popen BREAKAWAY_OK fix in
+  src/builtin/module_builtin_fio.cpp; lifecycle test
+  utils/dasHerd/watcher/tests/test_ptyhost.das.
+- NEXT: the watcher rework only — launch-via-host, adoption on startup
+  (sessions resurrect as RUNNING), pumps proxied over the host WS. Client
+  unchanged in v1. Read this doc + utils/dasHerd/HERDER_FIXROUND.md notes
+  40-51 first.
+- Rig state: watcher and rich client are STOPPED (Boris's go). daslang.exe,
+  libDaScriptDyn_runtime.dll, dasModuleTerminal rebuilt with the fixes;
+  release bundle at logs/dasHerd/releases/dasherd-ptyhost (rebuild with
+  `daslang utils/daspkg/main.das -- release --out logs/dasHerd/releases
+  --root utils/dasHerd/ptyhost`, 7s).
+- Standing rules: file Boris's bug reports BEFORE fixing; never restart a
+  watcher with live agent sessions without his go; preflight budget for
+  this branch: at most one full run (none used); branch
+  codex/herder-view-without-diff, ~20 unpushed commits, PR later on his
+  word. Parked after this block: external sessions arc, notes 42/47
+  terminal rendering bugs, WebSocketServer handle leak at client exit.
 
 ## Problem, precisely
 

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -191,18 +191,27 @@ rich client federates.
 - Deferred consciously: cross-box sessions (satellites/bundles spanning
   boxes) — the federation seam lives in the client, later.
 
-## Next hardening block (queued, go on Boris's word)
+## Hardening block (LANDED 2026-07-26)
 
-- **Host log file** `<session>.log` beside the journal — the host currently
-  cannot log at all (spawned CREATE_NO_WINDOW; stdout evaporates into the
-  hidden conhost). Log config at start, every connect/auth/attach with
-  offsets, every op, child exit, stamp transitions, shutdown reason.
-  Everything should log like crazy; this one especially.
-- **Lock-file liveness** `<session>.lock`, held exclusively for the host's
-  lifetime: "alive = file locked; died = lock released". Race-free,
-  crash-proof, works over ssh exec; replaces the connect-timeout probe as
-  the adoption deadness test. Stamp stays the metadata record.
-- **Underlying test coverage** (UI can wait; the underlying stuff tests and
-  logs everything, because reasons): bind-retry/port-exhaustion, degraded
-  breakaway, corrupt-jsonl restore, bad-token / wrong-protocol /
-  mid-replay-disconnect adversarial cases against the host.
+- **Host log file** `<session>.log` beside the journal (the host runs
+  CREATE_NO_WINDOW — stdout evaporates; this file is the only witness).
+  Logs start config, lock acquisition, child launch/exit, every
+  connect/auth/attach with offsets, every op except the 500ms stat poll,
+  drain/linger transitions, and the exit summary. Archived with the
+  journal.
+- **Lock-file liveness** `<session>.lock`, held open for the host's
+  lifetime. Windows CRT handles carry no FILE_SHARE_DELETE, so `remove()`
+  fails while the host lives and succeeds the instant it dies — crash
+  included; removing a dead host's lock IS the cleanup. Adoption probes
+  the lock before connecting (dead-fold dropped ~2s → ~20ms); the connect
+  timeout stays as the alive-but-wedged fallback. Clean exit deletes the
+  lock; the archive sweep removes crash leftovers.
+- **Test coverage landed**: bad token / wrong protocol / pre-auth ops
+  rejected (host-side), lock held-while-alive + released-on-exit, log
+  content, corrupt-jsonl restore lines skipped, host death under a live
+  watcher fails that one session only (`host_disconnected`), bind
+  collision retries onto the next port. Suite 73/73.
+- **Not covered, documented**: port-exhaustion (impractical to occupy 200
+  ports) and degraded job breakaway (popen jobs now permit breakaway, so
+  denial cannot be simulated in-tree); both fail loudly at launch by
+  construction.

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -1,31 +1,52 @@
 # Detached PTY host — "a terminal that depends on nothing"
 
-Status: CORE LANDED (2026-07-25 night). Remaining: the watcher rework
-below ("What changes where"). `--continue` resume demotes to disaster
-recovery, never the mechanism.
+Status: LANDED (2026-07-26) — host core AND the watcher rework. Durable
+herd sessions launch via detached hosts, watcher restart adopts them back
+as RUNNING (proven by test_watcher_adoption.das). `--continue` resume is
+disaster recovery only (machine death).
 
-## Resume state for the next session (written before a /clear)
+## Rig / branch state
 
-- DONE, committed, tests green (watcher suite 68/68; test_ptyhost 1.9s):
-  spawn_detached + env blocks in dasTerminal; utils/dasHerd/ptyhost/main.das
-  (protocol v1); daspkg release packaging; popen BREAKAWAY_OK fix in
-  src/builtin/module_builtin_fio.cpp; lifecycle test
-  utils/dasHerd/watcher/tests/test_ptyhost.das.
-- NEXT: the watcher rework only — launch-via-host, adoption on startup
-  (sessions resurrect as RUNNING), pumps proxied over the host WS. Client
-  unchanged in v1. Read this doc + utils/dasHerd/HERDER_FIXROUND.md notes
-  40-51 first.
-- Rig state: watcher and rich client are STOPPED (Boris's go). daslang.exe,
-  libDaScriptDyn_runtime.dll, dasModuleTerminal rebuilt with the fixes;
-  release bundle at logs/dasHerd/releases/dasherd-ptyhost (rebuild with
+- Watcher and rich client are STOPPED (Boris's go). Release bundle at
+  logs/dasHerd/releases/dasherd-ptyhost is current (rebuild:
   `daslang utils/daspkg/main.das -- release --out logs/dasHerd/releases
   --root utils/dasHerd/ptyhost`, 7s).
 - Standing rules: file Boris's bug reports BEFORE fixing; never restart a
   watcher with live agent sessions without his go; preflight budget for
   this branch: at most one full run (none used); branch
-  codex/herder-view-without-diff, ~20 unpushed commits, PR later on his
-  word. Parked after this block: external sessions arc, notes 42/47
-  terminal rendering bugs, WebSocketServer handle leak at client exit.
+  codex/herder-view-without-diff, unpushed commits, PR on his word.
+  Parked after this block: external sessions arc, notes 42/47 terminal
+  rendering bugs, WebSocketServer handle leak at client exit.
+
+## Landed decisions (2026-07-26, the watcher rework)
+
+- **Host-backed iff `herd_session_id` is set** (and a ptyhost root is
+  configured): durable sessions get hosts; plumbing launches (git captures,
+  task terminals) stay in-process ConPTY — survival there is pointless
+  overhead.
+- **Token rides the discovery stamp** — adoption after restart must
+  authenticate, and the stamp is the discovery record. Same-user local
+  file; same trust model as the watcher token on its own stdout.
+- **Host pushes a stat on exit/drain transitions** (v1-compatible; the
+  watcher still polls at 500ms as backstop).
+- **The host journal IS the session's raw output** — host-backed sessions
+  write no watcher-side output.raw; replay offsets equal journal offsets.
+- **ConPTY never signals pipe closure while the host holds the HPCON**
+  (observed live: exited=true, drained=false for minutes). Hence: the
+  watcher folds exit via the direct path's quiet interval, and the host's
+  linger gate keys on exit alone.
+- **Host release + archive**: once the exit folds and the journal is fully
+  replicated, the watcher sends `shutdown`; when the host obliges (link
+  closes), stamp+journal move to `ptyhosts/archive/`. Stamps of hosts that
+  died with no watcher fold at the next adoption scan.
+- **Watcher-side adoption restores mailbox/bundles/events** from the
+  session-dir jsonl records (newest-per-id wins; id counters bumped past
+  restored maxima).
+- Deferred hardening (unchanged from before): agent env still rides the
+  powershell wrapper argv, so DASHERD_TOKEN is visible in the host's
+  command line exactly as it was in the ConPTY child's; the host's own
+  env also leaks DASHERD_HOST_TOKEN to the child. Move to the host's
+  DASHERD_CHILD_* env forwarding later, way later.
 
 ## Problem, precisely
 
@@ -81,15 +102,22 @@ host) prove spawner-death survival.
   registry session resurrects as **running**, not `watcher_restart`), fold
   dead hosts' exit stamps into the registry, then archive their stamps.
 
-## What changes where
+## What changed where (landed 2026-07-26)
 
-- **watcher_core launch path** — spawns a host and connects, instead of
-  calling ConPtyProcess directly. The per-session read pump becomes an IPC
-  tail. Resize/input/terminate proxy through the host connection.
-- **Raw history / replay** — served from the host journal (watcher proxies;
-  checkpoint/restore byte offsets keep working, same numbers).
-- **herd_tick observe-exit** — from host stat + exit stamps instead of
-  process handles.
+- **watcher_core launch path** — for herd sessions, spawns a host
+  (`spawn_detached`, port scan 9700+ with bind-failure retry via the
+  stamp) and connects as a WS client; the per-session read pump is an IPC
+  tail feeding a transport-less local `Terminal` screen model
+  (`terminal_feed_bytes`; parser auto-replies forwarded back as input).
+  Resize/input/terminate proxy through the host connection.
+- **Raw history / replay** — the ring is fed from the host stream;
+  checkpoint/restore byte offsets equal journal offsets, same numbers.
+- **observe-exit** — from host stat (pushed on transitions + 500ms poll);
+  drain folds on the quiet interval since ConPTY never closes the pipe
+  under a live HPCON.
+- **Adoption on startup** — `watcher_adopt_hosts()` before `herd_init()`:
+  live hosts re-attach (registry records stay **running**); dead hosts
+  fold their exit stamp into an exited, replayable session and archive.
 - **Rich client** — unchanged in v1 (still talks to the watcher). Direct
   client→host attach is a natural v2, and is also the bridge to external
   sessions (an external session is just a host the watcher never spawned).

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -60,13 +60,26 @@ job, no parent-death ties. The watcher becomes a *client* of the host.
   client→host attach is a natural v2, and is also the bridge to external
   sessions (an external session is just a host the watcher never spawned).
 
-## Operational hard lesson folded in
+## Deployment: `daspkg release` (Boris's call, 2026-07-25)
 
-Hosts must NOT run from `bin/Release` — today's builds died on LNK1104 file
-locks from live processes, and a rebuild must never collide with a running
-session. Each host launches from a **copied runtime snapshot** (version-
-stamped dir of daslang.exe + DLLs + the host script); upgrades lay down a
-new snapshot and never touch a running one.
+The host ships as a **released bundle**, not a script on the dev runtime:
+`daspkg release` produces `<bundle>/dasherd-ptyhost.exe` via `daslang -exe`
+(AOT standalone) plus only the `.shared_module` dylibs it transitively
+requires (dasTerminal, dasHV), copied into the bundle and resolved
+exe-relative. Consequences, all load-bearing:
+
+- **No dependency on `bin/Release`** — a running host locks only its own
+  bundle's files; rebuilding the tree can never LNK1104 against a live
+  session (today's failure mode, eliminated by construction).
+- **Versioned by directory** — one bundle per host protocol version; the
+  watcher spawns from the bundle matching the version it speaks; running
+  hosts keep their bundle until their session ends; upgrades lay down a new
+  bundle beside the old.
+- **AOT-clean requirement** — the host script and its requires must pass
+  the `-exe` gate (no `options no_aot` anywhere in its graph); one more
+  reason the host stays tiny and boring.
+- `.das_package` under `utils/dasHerd/ptyhost/` declares `release_main`,
+  `release_name("dasherd-ptyhost")`, and the forced shared modules.
 
 ## Failure matrix
 

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -162,3 +162,47 @@ exe-relative. Consequences, all load-bearing:
    upgrade unit owning every terminal).
 3. **Linger** after child exit (draft: 24h or until adopted+drained).
 4. Whether v1 already lets the rich client attach straight to a host.
+
+## Remote boxes: watcher-per-box (decided 2026-07-26)
+
+The ssh story is topology, not transport, and the deciding weight is GIT: a
+local watcher reaching out to remote hosts would drag every git surface
+(changelist, history, captures, inspection, worktree ops, path identity)
+through ssh. Instead we copy tmux: **one watcher per box**, its sessions,
+hosts, git layer, registry, and mailbox all box-local and unchanged; the
+rich client federates.
+
+- **The client owns a watcher list** — each entry: name, how to reach it
+  (local port, or an ssh target yielding a forwarded loopback port), token
+  source. A remote watcher behind a forwarded port is indistinguishable
+  from the local one: same protocol, same reattach.
+- **ssh has exactly two jobs**, both boring: the tunnel (no watcher port is
+  ever exposed; tokens stay loopback secrets on both ends) and the control
+  channel (deploy bundle, start/stop/upgrade the watcher, fetch its token).
+  Remote watcher restarts are safe because their sessions sit in detached
+  hosts — the terminal arc was the prerequisite.
+- **ssh drop = client reconnect with backoff**, nothing more. Sessions,
+  hosts, git, mailbox keep running remotely (tmux model: the server is
+  remote, the client is disposable).
+- **Agent MCP stays box-local**: DASHERD_URL points at that box's watcher
+  over loopback. No reverse tunnels.
+- This topology keeps watcher<->host loopback-only forever, which is what
+  makes the pump's "link closed = host died" assumption permanently valid.
+- Deferred consciously: cross-box sessions (satellites/bundles spanning
+  boxes) — the federation seam lives in the client, later.
+
+## Next hardening block (queued, go on Boris's word)
+
+- **Host log file** `<session>.log` beside the journal — the host currently
+  cannot log at all (spawned CREATE_NO_WINDOW; stdout evaporates into the
+  hidden conhost). Log config at start, every connect/auth/attach with
+  offsets, every op, child exit, stamp transitions, shutdown reason.
+  Everything should log like crazy; this one especially.
+- **Lock-file liveness** `<session>.lock`, held exclusively for the host's
+  lifetime: "alive = file locked; died = lock released". Race-free,
+  crash-proof, works over ssh exec; replaces the connect-timeout probe as
+  the adoption deadness test. Stamp stays the metadata record.
+- **Underlying test coverage** (UI can wait; the underlying stuff tests and
+  logs everything, because reasons): bind-retry/port-exhaustion, degraded
+  breakaway, corrupt-jsonl restore, bad-token / wrong-protocol /
+  mid-replay-disconnect adversarial cases against the host.

--- a/utils/dasHerd/PTY_HOST_DESIGN.md
+++ b/utils/dasHerd/PTY_HOST_DESIGN.md
@@ -1,0 +1,89 @@
+# Detached PTY host — "a terminal that depends on nothing"
+
+Status: DRAFT for review (2026-07-25). The next block per Boris: drop
+everything and make terminal sessions fully independent. `--continue`
+resume demotes to disaster recovery, never the mechanism.
+
+## Problem, precisely
+
+`ConPtyProcess::launch` (modules/dasTerminal/src/pty.cpp:163) creates the
+pipes, the pseudoconsole (HPCON), AND a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+job object **inside the watcher process**, then assigns the child to that
+job. Watcher exit therefore kills every hosted session twice over: the job
+handle closes (kill-on-close reaps the child tree) and the pseudoconsole
+tears down (console-close for anything that survived). The session's
+*record*, *journal*, and *conversation* survive; the *process* cannot.
+
+## Shape: one tiny host process per session (tmux-server model)
+
+`daslang.exe utils/dasHerd/ptyhost/main.das -- --session <id> --listen <ep>
+--journal <dir>` — a minimal, boring, rarely-changing program that does
+exactly three things:
+
+1. **Owns the terminal.** Creates the ConPTY, the kill-on-close job, and
+   the child (same dasTerminal externs the watcher uses today). The host is
+   the one honest owner; host death still reaps the child tree — that
+   guarantee moves, it does not disappear.
+2. **Journals its own output.** Raw bytes append to a per-session journal
+   on disk (ring + high-water) — replay has no gaps even while nobody is
+   attached. The journal the watcher keeps today moves into the host.
+3. **Serves a versioned IPC surface.** hello{version, session, token} /
+   attach{from_byte} → replay + live tail / input{bytes} / resize{cols,rows}
+   / stat / terminate{reason}. Nothing else. Protocol v1 is forever — a new
+   watcher must always speak old hosts.
+
+Spawned **detached**: `DETACHED_PROCESS` + breakaway from any inherited job
+(`CREATE_BREAKAWAY_FROM_JOB`; if the spawning environment forbids breakaway,
+spawn through a one-shot intermediary). No inherited console, no inherited
+job, no parent-death ties. The watcher becomes a *client* of the host.
+
+## Discovery and adoption
+
+- On start the host atomically writes `logs/dasHerd/ptyhosts/<session>.json`
+  — endpoint, token, host pid, child pid, started stamp.
+- On child exit it rewrites the stamp with exit_code + drained, lingers a
+  configurable grace for late replay attaches, then exits.
+- Watcher startup: scan stamps, connect + stat each, adopt live hosts (the
+  registry session resurrects as **running**, not `watcher_restart`), fold
+  dead hosts' exit stamps into the registry, then archive their stamps.
+
+## What changes where
+
+- **watcher_core launch path** — spawns a host and connects, instead of
+  calling ConPtyProcess directly. The per-session read pump becomes an IPC
+  tail. Resize/input/terminate proxy through the host connection.
+- **Raw history / replay** — served from the host journal (watcher proxies;
+  checkpoint/restore byte offsets keep working, same numbers).
+- **herd_tick observe-exit** — from host stat + exit stamps instead of
+  process handles.
+- **Rich client** — unchanged in v1 (still talks to the watcher). Direct
+  client→host attach is a natural v2, and is also the bridge to external
+  sessions (an external session is just a host the watcher never spawned).
+
+## Operational hard lesson folded in
+
+Hosts must NOT run from `bin/Release` — today's builds died on LNK1104 file
+locks from live processes, and a rebuild must never collide with a running
+session. Each host launches from a **copied runtime snapshot** (version-
+stamped dir of daslang.exe + DLLs + the host script); upgrades lay down a
+new snapshot and never touch a running one.
+
+## Failure matrix
+
+| dies | effect |
+|---|---|
+| watcher | nothing; hosts keep running; next watcher adopts |
+| rich client | nothing |
+| host | that one session dies (host is minimal on purpose); watcher sees the drop + stamp |
+| machine | sessions die; registry resurrect via `--continue` — the crutch's only remaining job |
+
+## Decision points for Boris
+
+1. **Transport**: dashv localhost TCP + WS framing (in-tree today, same
+   token model as the watcher) vs named pipes (more Windows-native, new
+   plumbing). Draft assumes dashv.
+2. **Granularity**: per-session host (isolation, trivial lifecycle;
+   recommended) vs one host for all sessions (fewer processes, but one
+   upgrade unit owning every terminal).
+3. **Linger** after child exit (draft: 24h or until adopted+drained).
+4. Whether v1 already lets the rich client attach straight to a host.

--- a/utils/dasHerd/ptyhost/.das_package
+++ b/utils/dasHerd/ptyhost/.das_package
@@ -1,0 +1,15 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("dasherd-ptyhost")
+    package_description("Detached PTY host: owns one ConPTY + child + journal, survives watcher/client death, serves protocol v1 on loopback")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+    release_name("dasherd-ptyhost")
+}

--- a/utils/dasHerd/ptyhost/main.das
+++ b/utils/dasHerd/ptyhost/main.das
@@ -60,6 +60,10 @@ struct HostStamp {
     version : int = PROTOCOL_VERSION
     session : string
     port : int
+    // Adoption credential: a restarted watcher discovers the host through this
+    // stamp and must authenticate. Same-user local file, same trust model as
+    // the watcher token on its own stdout.
+    token : string
     host_pid : int
     child_pid : int
     started_wall_s : int64
@@ -198,6 +202,14 @@ class PtyHostServer : HvWebServer {
         }
     }
 
+    def broadcast_stat {
+        // Pushed on child exit / drain so the watcher observes lifecycle
+        // transitions promptly instead of on its next poll.
+        for (client in clients) {
+            if (client != null && client.authorized) send_stat(client.channel)
+        }
+    }
+
     def broadcast_output(bytes : array<uint8>) {
         if (empty(bytes)) return
         for (client in clients) {
@@ -329,6 +341,7 @@ def main : int {
     }
     g_stamp.session = config.session
     g_stamp.port = config.port
+    g_stamp.token = token
     // host_pid stays 0: das has no own-pid accessor yet, and liveness is
     // decided by connecting to the port, never by pid probing.
     g_stamp.started_wall_s = int64(get_clock())
@@ -384,16 +397,21 @@ def main : int {
                 // Only pipe closure authoritatively ends the stream: the root
                 // process can exit while descendants still hold the console.
                 g_stamp.drained = true
+                save_stamp()
+                server->broadcast_stat()
             }
             if (!g_stamp.exited && _pty_process_exited(g_pty)) {
                 g_stamp.exited = true
                 g_stamp.exit_code = _pty_exit_code(g_pty)
                 g_child_exit_wall_ms = wall_ms()
                 save_stamp()
+                server->broadcast_stat()
             }
         }
-        if (g_stamp.exited && g_stamp.drained
-                && wall_ms() - g_child_exit_wall_ms > linger_ms) {
+        // Linger keys on exit alone: while this host holds the HPCON, ConPTY
+        // may never close the read pipe, so `drained` cannot gate the exit
+        // (observed live: exited=true with drained=false for minutes).
+        if (g_stamp.exited && wall_ms() - g_child_exit_wall_ms > linger_ms) {
             break
         }
         if (wall_ms() - last_stamp >= STAMP_PERIOD_MS) {

--- a/utils/dasHerd/ptyhost/main.das
+++ b/utils/dasHerd/ptyhost/main.das
@@ -79,12 +79,28 @@ var private g_stamp = HostStamp()
 var private g_stamp_path : string
 var private g_journal_path : string
 var private g_journal : file
+// Liveness primitive: held open for the host's whole life. Windows CRT
+// handles carry no FILE_SHARE_DELETE, so remove() on this path FAILS while
+// the host lives and succeeds the instant it dies - crash included. "I'm
+// alive: file locked; I died: no longer locked."
+var private g_lock_path : string
+var private g_lock : file
+// Post-mortem log. The host runs CREATE_NO_WINDOW - stdout evaporates into
+// a hidden conhost - so this file is the only place events can go.
+var private g_log : file
+var private g_log_started : int64
 var private g_shutdown_requested = false
 var private g_child_exit_wall_ms : int64
 // The one terminal this host exists for (smart_ptr; released at exit).
 var private g_pty : Pty
 
 def private wall_ms : int64 => int64(get_clock()) * 1000l
+
+def private host_log(text : string) {
+    if (g_log == null) return
+    fwrite(g_log, "[+{get_time_nsec(g_log_started) / 1000000l}ms] {text}\n")
+    fflush(g_log)
+}
 
 def private save_stamp {
     // Same durability boundary as the herd registry: write the temp fully,
@@ -126,6 +142,7 @@ class PtyHostServer : HvWebServer {
 
     def override onWsOpen(channel : WebSocketChannel; url : string#) {
         clients |> push(new HostClient(channel = channel))
+        host_log("client connected ({length(clients)} attached)")
     }
 
     def override onWsClose(channel : WebSocketChannel) {
@@ -140,6 +157,7 @@ class PtyHostServer : HvWebServer {
                 index++
             }
         }
+        host_log("client disconnected ({length(clients)} attached)")
     }
 
     def find_client(channel : WebSocketChannel) : int {
@@ -232,49 +250,61 @@ class PtyHostServer : HvWebServer {
         if (index < 0) return
         if (incoming.op == "hello") {
             if (incoming.token != token) {
+                host_log("client rejected: bad token")
                 send_error(channel, "bad token")
                 return
             }
             if (incoming.protocol != PROTOCOL_VERSION) {
+                host_log("client rejected: protocol {incoming.protocol}")
                 send_error(channel, "protocol {incoming.protocol} unsupported; host speaks {PROTOCOL_VERSION}")
                 return
             }
             clients[index].authorized = true
+            host_log("client authorized")
             send_stat(channel)
             return
         }
         if (!clients[index].authorized) {
+            host_log("client op '{incoming.op}' rejected: hello first")
             send_error(channel, "hello first")
             return
         }
         if (incoming.op == "attach") {
             clients[index].offset = max(0l, incoming.from_byte)
             clients[index].attached = true
+            host_log("client attached from_byte={clients[index].offset} journal_bytes={g_stamp.journal_bytes}")
             send(channel, "\{\"type\":\"attached\",\"from_byte\":{clients[index].offset}\}",
                 ws_opcode.WS_OPCODE_TEXT, true)
             stream_journal_from(clients[index])
         } elif (incoming.op == "input") {
             if (g_pty == null || g_stamp.exited) {
+                host_log("input rejected: child is not running")
                 send_error(channel, "child is not running")
                 return
             }
             var inscope bytes : array<uint8>
             if (base64_decode(incoming.base64, bytes) >= 0 && !empty(bytes)) {
+                host_log("input {length(bytes)} bytes")
                 let _ = _pty_write(g_pty, bytes)
             }
         } elif (incoming.op == "resize") {
             if (g_pty != null && incoming.columns > 0 && incoming.rows > 0) {
+                host_log("resize {incoming.columns}x{incoming.rows}")
                 let _ = _pty_resize(g_pty, incoming.columns, incoming.rows)
             }
         } elif (incoming.op == "stat") {
+            // Deliberately unlogged: the watcher polls stat every 500ms.
             send_stat(channel)
         } elif (incoming.op == "terminate") {
             if (g_pty != null && !g_stamp.exited) {
+                host_log("terminate requested exit_code={incoming.exit_code}")
                 let _ = _pty_terminate(g_pty, int(incoming.exit_code))
             }
         } elif (incoming.op == "shutdown") {
+            host_log("shutdown requested")
             g_shutdown_requested = true
         } else {
+            host_log("unknown operation '{incoming.op}'")
             send_error(channel, "unknown operation")
         }
     }
@@ -289,6 +319,13 @@ struct HostWsMessage {
     columns : int
     rows : int
     exit_code : int64
+}
+
+def private release_lock {
+    if (g_lock == null) return
+    fclose(g_lock)
+    g_lock = null
+    let _ = remove(g_lock_path)
 }
 
 def private append_journal(bytes : array<uint8>) {
@@ -333,9 +370,25 @@ def main : int {
     }
     g_journal_path = path_join(config.journal, "{config.session}.raw")
     g_stamp_path = path_join(config.journal, "{config.session}.host.json")
+    g_lock_path = path_join(config.journal, "{config.session}.lock")
+    g_log_started = ref_time_ticks()
+    g_log = fopen(path_join(config.journal, "{config.session}.log"), "ab")
+    host_log("start session={config.session} port={config.port} cwd={config.cwd} " +
+        "{columns}x{rows} linger_ms={linger_ms} child_tokens={length(config.child)} " +
+        "wall_s={int64(get_clock())}")
+    g_lock = fopen(g_lock_path, "wb")
+    if (g_lock == null) {
+        host_log("could not hold {g_lock_path}")
+        to_log(LOG_ERROR, "dasherd-ptyhost: could not hold {g_lock_path}\n")
+        return 3
+    }
+    fwrite(g_lock, "held by session {config.session}\n")
+    fflush(g_lock)
+    host_log("lock held {g_lock_path}")
     // Append: a relaunched host for the same session continues the stream.
     g_journal = fopen(g_journal_path, "ab")
     if (g_journal == null) {
+        host_log("could not open journal {g_journal_path}")
         to_log(LOG_ERROR, "dasherd-ptyhost: could not open {g_journal_path}\n")
         return 3
     }
@@ -362,10 +415,13 @@ def main : int {
         g_stamp.error = (empty(launch_error)
             ? "child failed to launch" : launch_error)
         save_stamp()
+        host_log("child launch failed: {g_stamp.error}")
         to_log(LOG_ERROR, "dasherd-ptyhost: launch failed: {g_stamp.error}\n")
+        release_lock()
         return 4
     }
     g_stamp.child_pid = _pty_process_id(g_pty)
+    host_log("child launched pid={g_stamp.child_pid}")
 
     var server = new PtyHostServer(token = token)
     server->init(config.port)
@@ -375,10 +431,13 @@ def main : int {
         g_stamp.exited = true
         save_stamp()
         let _ = _pty_terminate(g_pty, 1)
+        host_log("{g_stamp.error}; exiting")
         to_log(LOG_ERROR, "dasherd-ptyhost: {g_stamp.error}\n")
+        release_lock()
         return 5
     }
     save_stamp()
+    host_log("listening on 127.0.0.1:{config.port}")
     to_log(LOG_INFO, "dasherd-ptyhost: session {config.session} child {g_stamp.child_pid} on 127.0.0.1:{config.port}\n")
 
     var inscope chunk : array<uint8>
@@ -399,6 +458,7 @@ def main : int {
                 g_stamp.drained = true
                 save_stamp()
                 server->broadcast_stat()
+                host_log("output drained (pipe closed) journal_bytes={g_stamp.journal_bytes}")
             }
             if (!g_stamp.exited && _pty_process_exited(g_pty)) {
                 g_stamp.exited = true
@@ -406,12 +466,14 @@ def main : int {
                 g_child_exit_wall_ms = wall_ms()
                 save_stamp()
                 server->broadcast_stat()
+                host_log("child exited code={g_stamp.exit_code}")
             }
         }
         // Linger keys on exit alone: while this host holds the HPCON, ConPTY
         // may never close the read pipe, so `drained` cannot gate the exit
         // (observed live: exited=true with drained=false for minutes).
         if (g_stamp.exited && wall_ms() - g_child_exit_wall_ms > linger_ms) {
+            host_log("linger elapsed {linger_ms}ms after child exit")
             break
         }
         if (wall_ms() - last_stamp >= STAMP_PERIOD_MS) {
@@ -423,6 +485,7 @@ def main : int {
 
     if (!g_stamp.exited) {
         // Shutdown op with a live child: the child dies with the host's job.
+        host_log("terminating live child with the host")
         let _ = _pty_terminate(g_pty, 1)
         g_stamp.exited = true
         g_stamp.exit_code = _pty_exit_code(g_pty)
@@ -431,6 +494,8 @@ def main : int {
     // when the pipe never reported closure before the shutdown op arrived.
     g_stamp.drained = true
     save_stamp()
+    host_log("host exit: shutdown={g_shutdown_requested} exit_code={g_stamp.exit_code} " +
+        "journal_bytes={g_stamp.journal_bytes}")
     server->stop()
     server->cleanup()
     unsafe {
@@ -441,5 +506,10 @@ def main : int {
     }
     fclose(g_journal)
     g_journal = null
+    release_lock()
+    if (g_log != null) {
+        fclose(g_log)
+        g_log = null
+    }
     return 0
 }

--- a/utils/dasHerd/ptyhost/main.das
+++ b/utils/dasHerd/ptyhost/main.das
@@ -1,0 +1,425 @@
+options gen2
+options rtti
+options persistent_heap
+options gc
+options indenting = 4
+
+// dasherd-ptyhost: a terminal that depends on nothing (PTY_HOST_DESIGN.md).
+// Owns exactly one ConPTY + child + journal and serves protocol v1 over a
+// loopback WebSocket. No watcher, no client, no UI - callers are disposable.
+// This file stays boring on purpose: a crash here kills a live session.
+
+require dashv/dashv_boost
+require terminal/terminal
+require daslib/clargs
+require daslib/fio
+require daslib/json_boost
+require daslib/base64
+require daslib/strings_boost
+require strings
+require math
+
+let PROTOCOL_VERSION = 1
+let JOURNAL_CHUNK = 65536
+let STAMP_PERIOD_MS = 1000l
+
+[CommandLineArgs]
+struct HostConfig {
+    @clarg_required
+    @clarg_doc = "Session id this host serves"
+    session : string
+
+    @clarg_required
+    @clarg_doc = "Loopback port to serve protocol v1 on"
+    port : int
+
+    @clarg_required
+    @clarg_doc = "Directory for the journal and the discovery stamp"
+    journal : string
+
+    @clarg_doc = "Child working directory"
+    cwd : string
+
+    @clarg_doc = "Initial terminal columns (default 120)"
+    columns : int
+
+    @clarg_doc = "Initial terminal rows (default 36)"
+    rows : int
+
+    @clarg_doc = "How long to keep serving after the child exits, ms (default 24h)"
+    linger_ms : int
+
+    @clarg_doc = "Child argv token, repeatable and ordered"
+    child : array<string>
+
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+struct HostStamp {
+    version : int = PROTOCOL_VERSION
+    session : string
+    port : int
+    host_pid : int
+    child_pid : int
+    started_wall_s : int64
+    updated_wall_s : int64
+    journal_bytes : int64
+    exited : bool
+    exit_code : int64 = -1l
+    drained : bool
+    error : string
+}
+
+var private g_stamp = HostStamp()
+var private g_stamp_path : string
+var private g_journal_path : string
+var private g_journal : file
+var private g_shutdown_requested = false
+var private g_child_exit_wall_ms : int64
+// The one terminal this host exists for (smart_ptr; released at exit).
+var private g_pty : Pty
+
+def private wall_ms : int64 => int64(get_clock()) * 1000l
+
+def private save_stamp {
+    // Same durability boundary as the herd registry: write the temp fully,
+    // then remove + rename (Windows _wrename cannot replace in place).
+    g_stamp.updated_wall_s = int64(get_clock())
+    let temp_path = "{g_stamp_path}.tmp"
+    if (!fwrite(temp_path, sprint_json(g_stamp, true))
+            || (fexist(g_stamp_path) && !remove(g_stamp_path))) return
+    let _ = rename(temp_path, g_stamp_path)
+}
+
+struct private HostClient {
+    @safe_when_uninitialized channel : WebSocketChannel
+    authorized : bool
+    attached : bool
+    offset : int64
+}
+
+def private child_environment : array<string> {
+    //! Child env rides host env vars, never any command line: the key list in
+    //! DASHERD_CHILD_ENV_KEYS (';'-separated), each value in DASHERD_CHILD_<KEY>.
+    var pairs : array<string>
+    let keys = get_env_variable("DASHERD_CHILD_ENV_KEYS")
+    if (empty(keys)) return <- pairs
+    for (key in split(keys, ";")) {
+        let name = strip(key)
+        if (empty(name)) continue
+        pairs |> push("{name}={get_env_variable("DASHERD_CHILD_" + name)}")
+    }
+    return <- pairs
+}
+
+class PtyHostServer : HvWebServer {
+    token : string
+    clients : array<HostClient?>
+
+    def override onInit {}
+    def override onTick {}
+
+    def override onWsOpen(channel : WebSocketChannel; url : string#) {
+        clients |> push(new HostClient(channel = channel))
+    }
+
+    def override onWsClose(channel : WebSocketChannel) {
+        var index = 0
+        while (index < length(clients)) {
+            if (clients[index] != null && clients[index].channel == channel) {
+                unsafe {
+                    delete clients[index]
+                }
+                clients |> erase(index)
+            } else {
+                index++
+            }
+        }
+    }
+
+    def find_client(channel : WebSocketChannel) : int {
+        for (index in range(length(clients))) {
+            if (clients[index] != null && clients[index].channel == channel) {
+                return index
+            }
+        }
+        return -1
+    }
+
+    def send_error(channel : WebSocketChannel; text : string) {
+        send(channel, "\{\"type\":\"error\",\"error\":{sprint_json(text, false)}\}",
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def send_stat(channel : WebSocketChannel) {
+        send(channel, ("\{\"type\":\"stat\",\"protocol\":{PROTOCOL_VERSION}," +
+            "\"session\":{sprint_json(g_stamp.session, false)}," +
+            "\"child_pid\":{g_stamp.child_pid}," +
+            "\"journal_bytes\":{g_stamp.journal_bytes}," +
+            "\"exited\":{g_stamp.exited},\"exit_code\":{g_stamp.exit_code}," +
+            "\"drained\":{g_stamp.drained}\}"),
+            ws_opcode.WS_OPCODE_TEXT, true)
+    }
+
+    def stream_journal_from(var client : HostClient?) {
+        //! Catch-up: everything already journaled from the requested offset,
+        //! as binary frames. Live bytes append via broadcast_output after.
+        if (client.offset >= g_stamp.journal_bytes) {
+            client.offset = g_stamp.journal_bytes
+            return
+        }
+        fopen(g_journal_path, "rb") $(reader) {
+            if (reader == null) return
+            var skipped = 0l
+            var inscope chunk : array<uint8>
+            chunk |> resize(JOURNAL_CHUNK)
+            while (skipped < client.offset) {
+                let remaining = client.offset - skipped
+                let want = int(remaining > int64(JOURNAL_CHUNK)
+                    ? int64(JOURNAL_CHUNK) : remaining)
+                if (want < length(chunk)) chunk |> resize(want)
+                let got = fread(reader, chunk)
+                if (got <= 0) break
+                skipped += int64(got)
+                if (length(chunk) < JOURNAL_CHUNK) chunk |> resize(JOURNAL_CHUNK)
+            }
+            while (true) {
+                let got = fread(reader, chunk)
+                if (got <= 0) break
+                if (got < length(chunk)) chunk |> resize(got)
+                unsafe {
+                    send(client.channel, reinterpret<string#>(addr(chunk[0])),
+                        length(chunk), ws_opcode.WS_OPCODE_BINARY, true)
+                }
+                client.offset += int64(got)
+                if (length(chunk) < JOURNAL_CHUNK) chunk |> resize(JOURNAL_CHUNK)
+            }
+        }
+    }
+
+    def broadcast_output(bytes : array<uint8>) {
+        if (empty(bytes)) return
+        for (client in clients) {
+            if (client == null || !client.attached) continue
+            unsafe {
+                send(client.channel, reinterpret<string#>(addr(bytes[0])),
+                    length(bytes), ws_opcode.WS_OPCODE_BINARY, true)
+            }
+            client.offset = g_stamp.journal_bytes
+        }
+    }
+
+    def override onWsMessage(channel : WebSocketChannel; msg : string#) {
+        var incoming = HostWsMessage()
+        if (!sscan_json(string(msg), incoming)) {
+            send_error(channel, "invalid message")
+            return
+        }
+        let index = find_client(channel)
+        if (index < 0) return
+        if (incoming.op == "hello") {
+            if (incoming.token != token) {
+                send_error(channel, "bad token")
+                return
+            }
+            if (incoming.protocol != PROTOCOL_VERSION) {
+                send_error(channel, "protocol {incoming.protocol} unsupported; host speaks {PROTOCOL_VERSION}")
+                return
+            }
+            clients[index].authorized = true
+            send_stat(channel)
+            return
+        }
+        if (!clients[index].authorized) {
+            send_error(channel, "hello first")
+            return
+        }
+        if (incoming.op == "attach") {
+            clients[index].offset = max(0l, incoming.from_byte)
+            clients[index].attached = true
+            send(channel, "\{\"type\":\"attached\",\"from_byte\":{clients[index].offset}\}",
+                ws_opcode.WS_OPCODE_TEXT, true)
+            stream_journal_from(clients[index])
+        } elif (incoming.op == "input") {
+            if (g_pty == null || g_stamp.exited) {
+                send_error(channel, "child is not running")
+                return
+            }
+            var inscope bytes : array<uint8>
+            if (base64_decode(incoming.base64, bytes) >= 0 && !empty(bytes)) {
+                let _ = _pty_write(g_pty, bytes)
+            }
+        } elif (incoming.op == "resize") {
+            if (g_pty != null && incoming.columns > 0 && incoming.rows > 0) {
+                let _ = _pty_resize(g_pty, incoming.columns, incoming.rows)
+            }
+        } elif (incoming.op == "stat") {
+            send_stat(channel)
+        } elif (incoming.op == "terminate") {
+            if (g_pty != null && !g_stamp.exited) {
+                let _ = _pty_terminate(g_pty, int(incoming.exit_code))
+            }
+        } elif (incoming.op == "shutdown") {
+            g_shutdown_requested = true
+        } else {
+            send_error(channel, "unknown operation")
+        }
+    }
+}
+
+struct HostWsMessage {
+    op : string
+    token : string
+    protocol : int
+    from_byte : int64
+    base64 : string
+    columns : int
+    rows : int
+    exit_code : int64
+}
+
+def private append_journal(bytes : array<uint8>) {
+    if (g_journal == null || empty(bytes)) return
+    let written = fwrite(g_journal, bytes)
+    if (written > 0) {
+        g_stamp.journal_bytes += int64(written)
+        fflush(g_journal)
+    }
+}
+
+[export]
+def main : int {
+    var parsed <- parse_args(type<HostConfig>)
+    if (parsed |> is_err) {
+        to_log(LOG_ERROR, "dasherd-ptyhost: {parsed |> unwrap_err}\n")
+        print_help(get_command_info(type<HostConfig>), "dasherd-ptyhost")
+        return 2
+    }
+    let config <- parsed |> move_unwrap
+    if (config.help) {
+        print_help(get_command_info(type<HostConfig>), "dasherd-ptyhost")
+        return 0
+    }
+    if (empty(config.child)) {
+        to_log(LOG_ERROR, "dasherd-ptyhost: --child argv is required\n")
+        return 2
+    }
+    let token = get_env_variable("DASHERD_HOST_TOKEN")
+    if (empty(token)) {
+        to_log(LOG_ERROR, "dasherd-ptyhost: DASHERD_HOST_TOKEN is not set\n")
+        return 2
+    }
+    let columns = config.columns > 0 ? config.columns : 120
+    let rows = config.rows > 0 ? config.rows : 36
+    let linger_ms = int64(config.linger_ms > 0 ? config.linger_ms : 24 * 3600 * 1000)
+
+    var mkdir_error : string
+    if (!mkdir_rec(config.journal, mkdir_error)) {
+        to_log(LOG_ERROR, "dasherd-ptyhost: journal dir: {mkdir_error}\n")
+        return 3
+    }
+    g_journal_path = path_join(config.journal, "{config.session}.raw")
+    g_stamp_path = path_join(config.journal, "{config.session}.host.json")
+    // Append: a relaunched host for the same session continues the stream.
+    g_journal = fopen(g_journal_path, "ab")
+    if (g_journal == null) {
+        to_log(LOG_ERROR, "dasherd-ptyhost: could not open {g_journal_path}\n")
+        return 3
+    }
+    g_stamp.session = config.session
+    g_stamp.port = config.port
+    // host_pid stays 0: das has no own-pid accessor yet, and liveness is
+    // decided by connecting to the port, never by pid probing.
+    g_stamp.started_wall_s = int64(get_clock())
+    let journal_stat = stat(g_journal_path)
+    if (journal_stat.is_valid) {
+        g_stamp.journal_bytes = int64(journal_stat.size)
+    }
+
+    var inscope env <- child_environment()
+    unsafe {
+        g_pty <- _pty_launch_argv_env(config.child, config.cwd,
+            length(config.cwd), env, columns, rows)
+    }
+    let launch_error = _pty_error(g_pty)
+    if (_pty_process_id(g_pty) == 0) {
+        g_stamp.exited = true
+        g_stamp.drained = true
+        g_stamp.error = (empty(launch_error)
+            ? "child failed to launch" : launch_error)
+        save_stamp()
+        to_log(LOG_ERROR, "dasherd-ptyhost: launch failed: {g_stamp.error}\n")
+        return 4
+    }
+    g_stamp.child_pid = _pty_process_id(g_pty)
+
+    var server = new PtyHostServer(token = token)
+    server->init(config.port)
+    let _bind = server->set_bind_host("127.0.0.1")
+    if (server->start() != 0) {
+        g_stamp.error = "could not bind 127.0.0.1:{config.port}"
+        g_stamp.exited = true
+        save_stamp()
+        let _ = _pty_terminate(g_pty, 1)
+        to_log(LOG_ERROR, "dasherd-ptyhost: {g_stamp.error}\n")
+        return 5
+    }
+    save_stamp()
+    to_log(LOG_INFO, "dasherd-ptyhost: session {config.session} child {g_stamp.child_pid} on 127.0.0.1:{config.port}\n")
+
+    var inscope chunk : array<uint8>
+    var last_stamp = wall_ms()
+    while (!g_shutdown_requested) {
+        server->tick()
+        var pumped = false
+        if (!g_stamp.drained) {
+            let status = unsafe(reinterpret<TerminalPollStatus>(
+                _pty_read(g_pty, chunk, JOURNAL_CHUNK)))
+            if (status == TerminalPollStatus.data) {
+                pumped = true
+                append_journal(chunk)
+                server->broadcast_output(chunk)
+            } elif (status == TerminalPollStatus.closed) {
+                // Only pipe closure authoritatively ends the stream: the root
+                // process can exit while descendants still hold the console.
+                g_stamp.drained = true
+            }
+            if (!g_stamp.exited && _pty_process_exited(g_pty)) {
+                g_stamp.exited = true
+                g_stamp.exit_code = _pty_exit_code(g_pty)
+                g_child_exit_wall_ms = wall_ms()
+                save_stamp()
+            }
+        }
+        if (g_stamp.exited && g_stamp.drained
+                && wall_ms() - g_child_exit_wall_ms > linger_ms) {
+            break
+        }
+        if (wall_ms() - last_stamp >= STAMP_PERIOD_MS) {
+            last_stamp = wall_ms()
+            save_stamp()
+        }
+        if (!pumped) sleep(1u)
+    }
+
+    if (!g_stamp.exited) {
+        // Shutdown op with a live child: the child dies with the host's job.
+        let _ = _pty_terminate(g_pty, 1)
+        g_stamp.exited = true
+        g_stamp.exit_code = _pty_exit_code(g_pty)
+        g_stamp.drained = true
+    }
+    save_stamp()
+    server->stop()
+    server->cleanup()
+    unsafe {
+        delete server
+    }
+    unsafe {
+        g_pty <- default<Pty>
+    }
+    fclose(g_journal)
+    g_journal = null
+    return 0
+}

--- a/utils/dasHerd/ptyhost/main.das
+++ b/utils/dasHerd/ptyhost/main.das
@@ -408,8 +408,10 @@ def main : int {
         let _ = _pty_terminate(g_pty, 1)
         g_stamp.exited = true
         g_stamp.exit_code = _pty_exit_code(g_pty)
-        g_stamp.drained = true
     }
+    // Once the host stops serving, the journal is final by definition - even
+    // when the pipe never reported closure before the shutdown op arrived.
+    g_stamp.drained = true
     save_stamp()
     server->stop()
     server->cleanup()

--- a/utils/dasHerd/ptyhost/tests/host_launcher.das
+++ b/utils/dasHerd/ptyhost/tests/host_launcher.das
@@ -1,19 +1,37 @@
 options gen2
 
 // Test intermediary: spawns the PTY host DETACHED and exits immediately, so
-// the test can prove the host survives its spawner's death. Arguments pass
-// through to the host after "--host-args"; DASHERD_HOST_TOKEN passes via env.
+// tests can prove the host survives its spawner's death. Test-only tool: the
+// token rides argv here (loopback throwaway), which production never does.
+//   --token <t>            host API token (becomes DASHERD_HOST_TOKEN)
+//   --child-env KEY=VALUE  forwarded child env entry (repeatable)
+//   --host-args <argv...>  everything after this is the host command line
 
 require terminal/terminal
+require daslib/strings_boost
 require strings
 
 [export]
 def main : int {
     var host_args : array<string>
+    var child_pairs : array<string>
+    var token = ""
     var collecting = false
+    var expect_token = false
+    var expect_child_env = false
     for (argument in get_command_line_arguments()) {
         if (collecting) {
             host_args |> push(argument)
+        } elif (expect_token) {
+            token = argument
+            expect_token = false
+        } elif (expect_child_env) {
+            child_pairs |> push(argument)
+            expect_child_env = false
+        } elif (argument == "--token") {
+            expect_token = true
+        } elif (argument == "--child-env") {
+            expect_child_env = true
         } elif (argument == "--host-args") {
             collecting = true
         }
@@ -22,13 +40,20 @@ def main : int {
         print("host_launcher: --host-args is required\n")
         return 2
     }
+    var inscope env : array<string>
+    var inscope key_parts : array<string>
+    env |> push("DASHERD_HOST_TOKEN={token}")
+    for (pair in child_pairs) {
+        let eq = find(pair, "=")
+        if (eq <= 0) continue
+        key_parts |> push(slice(pair, 0, eq))
+        env |> push("DASHERD_CHILD_{pair}")
+    }
+    let keys = join(key_parts, ";")
+    env |> push("DASHERD_CHILD_ENV_KEYS={keys}")
     var spawned = 0
     var spawn_error = ""
-    let _ = spawn_detached(host_args, "", [
-        "DASHERD_HOST_TOKEN={get_env_variable("DASHERD_HOST_TOKEN")}",
-        "DASHERD_CHILD_ENV_KEYS={get_env_variable("DASHERD_CHILD_ENV_KEYS")}",
-        "DASHERD_CHILD_PTYHOST_TEST={get_env_variable("DASHERD_CHILD_PTYHOST_TEST")}"
-    ]) $(pid, launch_error) {
+    let _ = spawn_detached(host_args, "", env) $(pid, launch_error) {
         spawned = pid
         spawn_error := launch_error
     }

--- a/utils/dasHerd/ptyhost/tests/host_launcher.das
+++ b/utils/dasHerd/ptyhost/tests/host_launcher.das
@@ -1,0 +1,37 @@
+options gen2
+
+// Test intermediary: spawns the PTY host DETACHED and exits immediately, so
+// the test can prove the host survives its spawner's death. Arguments pass
+// through to the host after "--host-args"; DASHERD_HOST_TOKEN passes via env.
+
+require terminal/terminal
+require strings
+
+[export]
+def main : int {
+    var host_args : array<string>
+    var collecting = false
+    for (argument in get_command_line_arguments()) {
+        if (collecting) {
+            host_args |> push(argument)
+        } elif (argument == "--host-args") {
+            collecting = true
+        }
+    }
+    if (empty(host_args)) {
+        print("host_launcher: --host-args is required\n")
+        return 2
+    }
+    var spawned = 0
+    var spawn_error = ""
+    let _ = spawn_detached(host_args, "", [
+        "DASHERD_HOST_TOKEN={get_env_variable("DASHERD_HOST_TOKEN")}",
+        "DASHERD_CHILD_ENV_KEYS={get_env_variable("DASHERD_CHILD_ENV_KEYS")}",
+        "DASHERD_CHILD_PTYHOST_TEST={get_env_variable("DASHERD_CHILD_PTYHOST_TEST")}"
+    ]) $(pid, launch_error) {
+        spawned = pid
+        spawn_error := launch_error
+    }
+    print("launched pid={spawned} error='{spawn_error}'\n")
+    return spawned != 0 ? 0 : 1
+}

--- a/utils/dasHerd/watcher/herd_sessions.das
+++ b/utils/dasHerd/watcher/herd_sessions.das
@@ -473,6 +473,40 @@ def public herd_close(herd_id : string; var pty_to_terminate : string&) : string
     return save_registry()
 }
 
+def public herd_delete(herd_id : string; var removed : HerdSession) : string {
+    //! Removes the record entirely (unlike herd_close, which keeps it as
+    //! history). The caller gets the removed record so it can attempt guarded
+    //! removal of the session's worktrees. Running sessions never delete.
+    let index = herd_find(herd_id)
+    if (index < 0) return "unknown herd session"
+    if (g_herd[index].state == "running") {
+        return "session is running; close it before deleting"
+    }
+    removed := g_herd[index]
+    g_herd |> erase(index)
+    g_herd_revision++
+    return save_registry()
+}
+
+def public herd_worktree_user(worktree_path : string; exclude_herd_id : string = "") : string {
+    //! Name of a non-closed session attending this worktree (primary or
+    //! satellite), or "" when the worktree is free. Drives the hard block on
+    //! worktree deletion.
+    let canonical = herd_canonical_worktree(worktree_path)
+    for (record in g_herd) {
+        if (record.id == exclude_herd_id || record.state == "closed") continue
+        if (herd_canonical_worktree(record.worktree_path) == canonical) {
+            return record.name
+        }
+        for (entry in record.satellites) {
+            if (herd_canonical_worktree(entry.worktree_path) == canonical) {
+                return record.name
+            }
+        }
+    }
+    return ""
+}
+
 def public herd_rename(herd_id, name : string) : string {
     if (empty(strip(name))) return "session name is required"
     let index = herd_find(herd_id)

--- a/utils/dasHerd/watcher/herd_sessions.das
+++ b/utils/dasHerd/watcher/herd_sessions.das
@@ -225,15 +225,21 @@ def public herd_init(registry_path, profiles_path : string) : string {
         return "unsupported herd registry version {file.version}"
     }
     g_next_herd_id = file.next_id
-    // The watcher owns every PTY, so none of them survived the restart.
+    // In-process PTYs never survive a restart; host-backed ones do when their
+    // detached host was re-attached (watcher_adopt_hosts runs before this).
     var orphaned = 0
     var healed = 0
     for (record in file.sessions) {
         if (record.state == "running") {
-            record.state = "exited"
-            record.reason = "watcher_restart"
-            record.updated_wall_s = wall_seconds()
-            orphaned++
+            var info = WatcherSessionInfo()
+            let adopted = (watcher_get_session_info(record.pty_session_id, info)
+                && info.state == "running")
+            if (!adopted) {
+                record.state = "exited"
+                record.reason = "watcher_restart"
+                record.updated_wall_s = wall_seconds()
+                orphaned++
+            }
         }
         // Heal records saved before path spellings were canonicalized.
         let display_path = herd_display_worktree(record.worktree_path)

--- a/utils/dasHerd/watcher/inspection_worker.das
+++ b/utils/dasHerd/watcher/inspection_worker.das
@@ -282,6 +282,15 @@ def private prepare_worker_main(var jobs : Channel?&;
                 kind = InspectorPrepareEventKind.started,
                 generation = job.generation))
             let started_at = ref_time_ticks()
+            // The job is a temporary reference into channel/sender memory; the
+            // sender's context is free to GC-relocate its strings while this
+            // thread is deep in a tree-sitter parse. Clone every string the
+            // job carries into THIS context before any long work (live crash:
+            // ts_decode_utf8 read past a freed buffer mid-highlight).
+            let patch_text = clone_string(job.patch)
+            let job_view_text = clone_string(job.view_text)
+            let view_base64 = clone_string(job.view_base64)
+            let language = clone_string(job.language)
             var failure = ""
             var parsed = GitParsedPatch()
             var old_document = TextSourceDocument()
@@ -298,7 +307,7 @@ def private prepare_worker_main(var jobs : Channel?&;
             var preview_height = 0
             var preview_error = ""
             let failed = catch_prepare_panic(failure) {
-                var prepared_patch <- git_parse_unified_patch(job.patch)
+                var prepared_patch <- git_parse_unified_patch(patch_text)
                 if (prepared_patch.error == "diff contains no text hunks"
                         && job.view_available) {
                     prepared_patch.error = ""
@@ -307,8 +316,8 @@ def private prepare_worker_main(var jobs : Channel?&;
                     failure = prepared_patch.error
                 } else {
                     if (!prepared_patch.binary) {
-                        if (job.view_available || !empty(job.view_text)) {
-                            view_source = job.view_text
+                        if (job.view_available || !empty(job_view_text)) {
+                            view_source = job_view_text
                         } else {
                             view_source = prepared_patch.new_text
                         }
@@ -319,10 +328,10 @@ def private prepare_worker_main(var jobs : Channel?&;
                         preview_error = "Binary preview is empty"
                     } elif (job.view_byte_count < 0) {
                         preview_error = "Binary transport reported an invalid byte count"
-                    } elif (empty(job.view_base64)) {
+                    } elif (empty(view_base64)) {
                         preview_error = "Binary preview bytes are unavailable for this comparison"
                     } else {
-                        let decoded = base64_decode(job.view_base64,
+                        let decoded = base64_decode(view_base64,
                             decoded_view_bytes)
                         if (decoded < 0 || decoded != job.view_byte_count) {
                             preview_error = "Binary transport failed exact-byte validation"
@@ -344,9 +353,9 @@ def private prepare_worker_main(var jobs : Channel?&;
                     let old_source = inspector_reconstruct_old_source(
                         view_source, prepared_patch)
                     var full_old <- tree_sitter_source_document(
-                        old_source, job.language, job.generation)
+                        old_source, language, job.generation)
                     var full_new <- tree_sitter_source_document(
-                        view_source, job.language, job.generation)
+                        view_source, language, job.generation)
                     var prepared_old <- inspector_project_full_syntax(
                         full_old, prepared_patch.old_aligned_text,
                         prepared_patch.rows, true, job.generation)
@@ -382,7 +391,7 @@ def private prepare_worker_main(var jobs : Channel?&;
                                 line_index = line, kind = TextSourceLineMarkKind.added))
                         }
                         view_document <- full_new
-                        if (job.language == "markdown") {
+                        if (language == "markdown") {
                             var prepared_markdown <- md_parse(view_source)
                             if (!prepared_markdown.ok) {
                                 failure = (empty(prepared_markdown.error)

--- a/utils/dasHerd/watcher/main.das
+++ b/utils/dasHerd/watcher/main.das
@@ -25,6 +25,7 @@ var private g_port = 9191
 var private g_token : string
 var private g_log_root : string
 var private g_config_path : string
+var private g_ptyhost_root : string
 var private g_last_memory_log_at = 0l
 var private g_last_gc_at = 0l
 var private g_started_at = 0l
@@ -59,7 +60,24 @@ def private parse_watcher_args() {
     g_log_root = option_value("--log-root=",
         path_join(get_das_root(), "logs/dasHerd/watcher/sessions"))
     g_config_path = option_value("--config=", repository_default_config_path())
+    g_ptyhost_root = option_value("--ptyhost-root=",
+        path_join(get_das_root(), "logs/dasHerd/ptyhosts"))
     g_exit_after_ms = max(0l, int64(to_int(option_value("--exit-after-ms=", "0"))))
+}
+
+// The detached PTY host command: the released AOT bundle when present (its
+// files never collide with a tree rebuild), else the current interpreter
+// running the host script - the dev fallback.
+def private ptyhost_launcher_prefix : array<string> {
+    let bundle = path_join(get_das_root(),
+        "logs/dasHerd/releases/dasherd-ptyhost/dasherd-ptyhost.exe")
+    if (fexist(bundle)) return <- [bundle]
+    var compiler = path_join(get_das_root(), "bin/Release/daslang.exe")
+    if (!fexist(compiler)) {
+        let args <- get_command_line_arguments()
+        compiler = empty(args) ? "daslang.exe" : args[0]
+    }
+    return <- [compiler, path_join(get_das_root(), "utils/dasHerd/ptyhost/main.das"), "--"]
 }
 
 // Log das-managed memory independently of process RSS. All formatting temporaries die before
@@ -154,6 +172,17 @@ def init() {
         return
     }
     g_watcher_initialized = true
+    var inscope host_prefix <- ptyhost_launcher_prefix()
+    let ptyhost_error = watcher_configure_ptyhosts(g_ptyhost_root, host_prefix)
+    if (!empty(ptyhost_error)) {
+        print("dasHerd watcher: ptyhost root unusable ({ptyhost_error}); " +
+            "durable sessions fall back to in-process PTYs\n")
+    } else {
+        let adopted = watcher_adopt_hosts()
+        if (adopted > 0) {
+            print("dasHerd watcher: adopted {adopted} detached PTY host session(s)\n")
+        }
+    }
     let repository_error = repository_init(g_config_path, get_das_root())
     if (!empty(repository_error)) {
         print("dasHerd watcher: could not initialize repositories: {repository_error}\n")

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -719,6 +719,72 @@ def private find_worktree(runtime : RepositoryRuntime?; path : string) : int {
     return -1
 }
 
+def private git_capture(argv : array<string>; var output : string&) : int {
+    // Synchronous git for the guarded worktree-delete path only: fast plumbing
+    // calls on a user click, never the polling rails. 30s cap so a wedged git
+    // (index lock) can't hang the watcher tick forever.
+    output = ""
+    return unsafe(popen_argv(argv, 30.0, $(file) {
+        if (file != null) {
+            output = unsafe(fread_to_eof(file))
+        }
+    }))
+}
+
+def public repository_remove_worktree(repository_id, worktree_path : string;
+                                      var reason : string&;
+                                      var detail : string&) : bool {
+    //! Guarded removal. reason on failure: "unknown" | "main" | "dirty" |
+    //! "error"; for "dirty" the detail carries `git status --porcelain` so the
+    //! client can brief a resolver session.
+    reason = ""
+    detail = ""
+    let repository_index = find_repository(repository_id)
+    if (repository_index < 0 || g_repositories[repository_index] == null) {
+        reason = "unknown"
+        detail = "unknown repository"
+        return false
+    }
+    var runtime = g_repositories[repository_index]
+    let checkout = runtime.snapshot.record.checkout_path
+    if (to_lower(normalized_path(worktree_path)) == to_lower(normalized_path(checkout))) {
+        reason = "main"
+        detail = "the main checkout cannot be deleted"
+        return false
+    }
+    let worktree_index = find_worktree(runtime, worktree_path)
+    if (worktree_index >= 0 && runtime.snapshot.worktrees[worktree_index].is_main) {
+        reason = "main"
+        detail = "the main checkout cannot be deleted"
+        return false
+    }
+    var status_text : string
+    let status_exit = git_capture(["git", "-C", worktree_path,
+        "status", "--porcelain"], status_text)
+    if (status_exit != 0) {
+        reason = "error"
+        detail = "git status exited {status_exit}"
+        return false
+    }
+    if (!empty(strip(status_text))) {
+        reason = "dirty"
+        detail = (length(status_text) > 2000
+            ? slice(status_text, 0, 2000) + "\n..." : status_text)
+        return false
+    }
+    var remove_text : string
+    let remove_exit = git_capture(["git", "-C", checkout,
+        "worktree", "remove", worktree_path], remove_text)
+    if (remove_exit != 0) {
+        reason = "error"
+        detail = (empty(strip(remove_text))
+            ? "git worktree remove exited {remove_exit}" : strip(remove_text))
+        return false
+    }
+    let _ = repository_refresh(repository_id)
+    return true
+}
+
 def public repository_review(repository_id : string; worktree_path : string) : string {
     let repository_index = find_repository(repository_id)
     if (repository_index < 0 || g_repositories[repository_index] == null) {

--- a/utils/dasHerd/watcher/repository_core.das
+++ b/utils/dasHerd/watcher/repository_core.das
@@ -713,8 +713,16 @@ def public repository_working_preview_path(worktree_path : string;
 }
 
 def private find_worktree(runtime : RepositoryRuntime?; path : string) : int {
+    // Canonical compare: herd records, session origins, and git output can
+    // disagree on slash direction and drive-letter case for the same tree
+    // ("D:/work" vs "D:/Work" seen live); exact equality silently missed.
+    let wanted = (get_platform_name() == "windows"
+        ? to_lower(normalized_path(path)) : normalized_path(path))
     for (index in range(length(runtime.snapshot.worktrees))) {
-        if (runtime.snapshot.worktrees[index].path == path) return index
+        let candidate = (get_platform_name() == "windows"
+            ? to_lower(normalized_path(runtime.snapshot.worktrees[index].path))
+            : normalized_path(runtime.snapshot.worktrees[index].path))
+        if (candidate == wanted) return index
     }
     return -1
 }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -39,8 +39,10 @@ require ./rich_launcher_ui.das
 require ./rich_files_ui.das
 require ./rich_live.das
 
-// Session preset: the terminal is the spine; the inspector and Git
-// surfaces share a modest right column (HERDER_UX.md scenarios).
+// Session preset: sessions own the left (sessions-first); ALL git surfaces
+// live on the right — repositories on top, Activity/Inspector tabbed in the
+// middle, Changelist at the bottom (notes 49 and the external-sessions
+// layout call: "worktree stuff moves to the right").
 def private setup_session_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
     DockBuilderAddDockSpaceNode(dock_id, ImGuiDockNodeFlags.None)
@@ -50,23 +52,24 @@ def private setup_session_layout(dock_id : uint) {
     var center_id : uint = 0u
     var right_id : uint = 0u
     var repositories_id : uint = 0u
-    var sessions_id : uint = 0u
+    var changelist_id : uint = 0u
     DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.18f, left_id, center_id)
-    DockBuilderSplitNode(left_id, ImGuiDir.Down, 0.45f,
-        sessions_id, repositories_id)
     DockBuilderSplitNode(center_id, ImGuiDir.Right, 0.32f, right_id, center_id)
-    DockBuilderDockWindow("Repositories & Worktrees", repositories_id)
-    DockBuilderDockWindow("Sessions & Activity###SessionsActivity", sessions_id)
-    DockBuilderDockWindow("File Inspector", right_id)
-    DockBuilderDockWindow("Git Changelist", right_id)
+    DockBuilderSplitNode(right_id, ImGuiDir.Up, 0.28f, repositories_id, right_id)
+    DockBuilderSplitNode(right_id, ImGuiDir.Down, 0.45f, changelist_id, right_id)
+    DockBuilderDockWindow("Sessions & Activity###SessionsActivity", left_id)
+    DockBuilderDockWindow("Git Repositories & Worktrees###Repositories", repositories_id)
     DockBuilderDockWindow("Git Activity", right_id)
+    DockBuilderDockWindow("File Inspector", right_id)
     DockBuilderDockWindow("Settings", right_id)
+    DockBuilderDockWindow("Git Changelist", changelist_id)
     DockBuilderDockWindow("Terminal", center_id)
     DockBuilderFinish(dock_id)
     TERMINAL_WIN.pending_raise = true
 }
 
-// Review preset: terminal and inspector side by side, one Git column.
+// Review preset: terminal and inspector side by side; same sessions-left /
+// git-right shape as the session preset.
 def private setup_review_layout(dock_id : uint) {
     DockBuilderRemoveNode(dock_id)
     DockBuilderAddDockSpaceNode(dock_id, ImGuiDockNodeFlags.None)
@@ -75,20 +78,19 @@ def private setup_review_layout(dock_id : uint) {
     var left_id : uint = 0u
     var work_id : uint = 0u
     var repositories_id : uint = 0u
-    var sessions_id : uint = 0u
     var git_column_id : uint = 0u
     var activity_id : uint = 0u
     var changelist_id : uint = 0u
     var terminal_id : uint = 0u
     DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.14f, left_id, work_id)
-    DockBuilderSplitNode(left_id, ImGuiDir.Down, 0.45f,
-        sessions_id, repositories_id)
     DockBuilderSplitNode(work_id, ImGuiDir.Right, 0.24f, git_column_id, work_id)
-    DockBuilderSplitNode(git_column_id, ImGuiDir.Down, 0.55f,
+    DockBuilderSplitNode(git_column_id, ImGuiDir.Up, 0.28f,
+        repositories_id, git_column_id)
+    DockBuilderSplitNode(git_column_id, ImGuiDir.Down, 0.5f,
         changelist_id, activity_id)
     DockBuilderSplitNode(work_id, ImGuiDir.Left, 0.40f, terminal_id, work_id)
-    DockBuilderDockWindow("Repositories & Worktrees", repositories_id)
-    DockBuilderDockWindow("Sessions & Activity###SessionsActivity", sessions_id)
+    DockBuilderDockWindow("Sessions & Activity###SessionsActivity", left_id)
+    DockBuilderDockWindow("Git Repositories & Worktrees###Repositories", repositories_id)
     DockBuilderDockWindow("Git Activity", activity_id)
     DockBuilderDockWindow("Git Changelist", changelist_id)
     DockBuilderDockWindow("Terminal", terminal_id)
@@ -279,7 +281,7 @@ def private register_commands() {
     register_herd_command("session.powershell", "Session", "PowerShell here",
         command_binding("session.powershell", ImGuiKey.P, primary = true, shift = true),
         @@command_powershell)
-    register_herd_command("view.repositories", "View", "Repositories & Worktrees",
+    register_herd_command("view.repositories", "View", "Git Repositories & Worktrees",
         CommandBinding(), @@() { open_dock_window(REPOSITORIES_WIN); })
     register_herd_command("view.sessions", "View", "Sessions & Activity",
         command_binding("view.sessions", ImGuiKey.S, primary = true, shift = true),
@@ -371,7 +373,7 @@ def draw_main_menu() {
         }
         menu(VIEW_MENU, (text = "View", enabled = true)) {
             if (menu_label(VIEW_REPOSITORIES,
-                    (text = "Repositories & Worktrees", selected = REPOSITORIES_WIN.open,
+                    (text = "Git Repositories & Worktrees", selected = REPOSITORIES_WIN.open,
                         shortcut = herd_command_shortcut("view.repositories")))) {
                 let _ = run_herd_command("view.repositories")
             }

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -215,6 +215,49 @@ def private command_new_session() {
     open_launcher_modal()
 }
 
+def private draw_worktree_block_popup() {
+    if (g_worktree_delete_block.active) {
+        g_worktree_delete_block.active = false
+        open_popup(WORKTREE_BLOCK_DIALOG)
+    }
+    popup_modal(WORKTREE_BLOCK_DIALOG.PUBLIC, (text = "Cannot delete worktree",
+            closable = true, flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+        text(WORKTREE_BLOCK_PATH, (text = g_worktree_delete_block.worktree_path))
+        if (g_worktree_delete_block.reason == "in_use") {
+            text(WORKTREE_BLOCK_WHY,
+                (text = "A session is working here: {g_worktree_delete_block.detail}"))
+            text_disabled(WORKTREE_BLOCK_HINT,
+                (text = "Close or delete that session first."))
+        } elif (g_worktree_delete_block.reason == "dirty") {
+            text(WORKTREE_BLOCK_WHY, (text = "Uncommitted changes block deletion:"))
+            text_disabled(WORKTREE_BLOCK_DETAIL,
+                (text = g_worktree_delete_block.detail))
+            if (button(WORKTREE_BLOCK_LAUNCH,
+                    (text = "Launch session to resolve..."))) {
+                g_selected_repository_id = g_worktree_delete_block.repository_id
+                g_selected_worktree_path = g_worktree_delete_block.worktree_path
+                g_selection_explicit = true
+                prepare_resolver_launcher(g_worktree_delete_block.repository_id,
+                    g_worktree_delete_block.worktree_path,
+                    "The user wants to DELETE the worktree " +
+                    "{g_worktree_delete_block.worktree_path}, but it has " +
+                    "uncommitted changes:\n{g_worktree_delete_block.detail}\n" +
+                    "Review the changes and resolve them: commit (and push) " +
+                    "what should be kept, discard what should not. Do not " +
+                    "delete the worktree yourself. When the tree is clean, " +
+                    "report what you did and finish.")
+                g_launch_resolver_pending = true
+                close_current_popup(WORKTREE_BLOCK_DIALOG)
+            }
+        } else {
+            text(WORKTREE_BLOCK_WHY, (text = g_worktree_delete_block.detail))
+        }
+        if (button(WORKTREE_BLOCK_CLOSE, (text = "Close"))) {
+            close_current_popup(WORKTREE_BLOCK_DIALOG)
+        }
+    }
+}
+
 def private command_powershell() {
     return if (g_client == null || !g_client.connected)
     g_client->launch("powershell.exe -NoLogo -NoProfile", g_selected_worktree_path,
@@ -598,6 +641,10 @@ def update() {
         g_dock_reset_pending = false
         DOCK_ROOT.pending_reset = true
     }
+    if (g_launch_resolver_pending) {
+        g_launch_resolver_pending = false
+        open_launcher_modal()
+    }
     draw_main_menu()
     dockspace(DOCK_ROOT, (flags = ImGuiDockNodeFlags.PassthruCentralNode)) {
         if (!DOCK_ROOT.has_initial_layout && DOCK_ROOT.dock_id != 0u) {
@@ -631,6 +678,7 @@ def update() {
     }
     draw_herd_rename_popup()
     draw_destructive_confirm_popup()
+    draw_worktree_block_popup()
     draw_launcher_modal()
     herd_commands_drain()
     harness_end_frame()

--- a/utils/dasHerd/watcher/rich_client.das
+++ b/utils/dasHerd/watcher/rich_client.das
@@ -491,6 +491,20 @@ def update() {
                 g_session_output_seen[session.id] = session.output_bytes
             }
         }
+        // Sessions the watcher pruned leave orphaned entries behind forever
+        // otherwise (the tables only ever gain keys above).
+        if (length(g_session_output_seen) > length(g_client.sessions)) {
+            var inscope live_ids : table<string>
+            for (session in g_client.sessions) {
+                live_ids |> insert(session.id)
+            }
+            var inscope stale <- [for (id in keys(g_session_output_seen));
+                clone_string(id); where !key_exists(live_ids, id)]
+            for (id in stale) {
+                g_session_output_seen |> erase(id)
+                g_session_output_wall |> erase(id)
+            }
+        }
     }
     if (g_submit_stamp != 0l
             && get_time_nsec(g_submit_stamp) / 1000000l >= 200l) {
@@ -500,6 +514,23 @@ def update() {
         }
         g_submit_stamp = 0l
         g_submit_session = ""
+    }
+    // Feed queued says only once the pending Enter has flushed; an item for a
+    // session we no longer control is dropped (same rule as the \r above).
+    while (g_submit_stamp == 0l && !empty(g_input_queue)) {
+        let item = g_input_queue[0]
+        g_input_queue |> erase(0)
+        if (g_client == null || !g_client.controls
+                || g_client.selected_id != item.session) continue
+        if (!empty(item.text)) {
+            g_client->send_input(item.text)
+        }
+        if (item.submit) {
+            // Even a lone queued submit re-arms the paste window — its \r must
+            // stay clear of whatever text drained just before it.
+            g_submit_stamp = ref_time_ticks()
+            g_submit_session = item.session
+        }
     }
     if (!harness_begin_frame()) return
     service_sha_copy()

--- a/utils/dasHerd/watcher/rich_files_ui.das
+++ b/utils/dasHerd/watcher/rich_files_ui.das
@@ -40,6 +40,9 @@ struct private ProjectNode {
     // A nested git repository (git lists it as one "dir/" entry) — its
     // contents are invisible to this repository's file listing.
     external : bool
+    // Portal listing already ran; empty children can't stand in for this
+    // (an empty dir would re-run dir() every frame while expanded).
+    populated : bool
     stat_size : int64
     stat_mtime : int64
     children : array<int>
@@ -313,6 +316,7 @@ def private draw_project_row(var row : int&; node_index, depth : int) : bool {
 // its contents. Folder children stay external so the portal recurses; .git
 // stays out of the tree.
 def private populate_external_folder(node_index : int) {
+    g_project_nodes[node_index].populated = true
     var inscope names : array<string>
     names |> reserve(32)
     {
@@ -343,7 +347,7 @@ def private populate_external_folder(node_index : int) {
     g_project_nodes[node_index].children <- order
     // Aggregate the discovered stats up the ancestor chain and re-sort each
     // level, so Largest/Newest order the portal by its real contents. Runs
-    // once per portal level (populate only fires on empty children).
+    // once per portal level (the populated flag gates re-entry).
     var added_size = 0l
     var newest = 0l
     for (child in g_project_nodes[node_index].children) {
@@ -392,7 +396,7 @@ def private draw_project_tree() {
         }
         if (is_folder && expanded) {
             if (g_project_nodes[node_index].external
-                    && empty(g_project_nodes[node_index].children)) {
+                    && !g_project_nodes[node_index].populated) {
                 populate_external_folder(node_index)
             }
             let children & = unsafe(g_project_nodes[node_index].children)

--- a/utils/dasHerd/watcher/rich_files_ui.das
+++ b/utils/dasHerd/watcher/rich_files_ui.das
@@ -406,7 +406,15 @@ def private draw_project_tree() {
         }
     }
     if (row == 0 && !g_worktree_files_loading) {
-        text_disabled("Select a worktree to browse its files")
+        // Say what is actually missing (note 48): selection, a failed
+        // listing, and an empty tree are three different states.
+        if (empty(g_selected_worktree_path)) {
+            text_disabled("Select a worktree to browse its files")
+        } elif (!empty(g_worktree_files_error)) {
+            text_disabled("File list failed: {g_worktree_files_error}")
+        } else {
+            text_disabled("No files listed - Refresh re-reads the worktree")
+        }
     }
 }
 

--- a/utils/dasHerd/watcher/rich_git_ui.das
+++ b/utils/dasHerd/watcher/rich_git_ui.das
@@ -31,6 +31,7 @@ require ./rich_commands.das
 require ./herd_sessions.das
 require ./rich_inspector_ui.das
 require ./rich_files_ui.das
+require ./rich_sessions_ui.das
 
 var WORKTREE_ROW : table<int; ToggleState>
 
@@ -43,6 +44,8 @@ var WORKTREE_POPUP : table<int; PopupContextItemState>
 var WORKTREE_MENU_NEW_SESSION : table<int; ToggleState>
 
 var WORKTREE_MENU_OPEN_SESSION : table<int; ToggleState>
+
+var WORKTREE_MENU_DELETE : table<int; ToggleState>
 
 var REPOSITORY_FOLDER_JOIN : table<int; EmptyMarkerState>
 
@@ -255,6 +258,39 @@ def draw_repositories_window() {
                                 (text = "Open session '{g_client.herd_sessions[active_herd].name}'",
                                  shortcut = "", enabled = true))) {
                             navigate_to_herd(active_herd)
+                        }
+                    }
+                    if (menu_item(WORKTREE_MENU_DELETE[row],
+                            (text = "Delete worktree...", shortcut = "",
+                             enabled = g_client != null && g_client.connected
+                                && !worktree.is_main))) {
+                        // Client-side pre-guards give the block dialog without
+                        // a round trip; the watcher re-checks on the request.
+                        let change_count = (worktree.staged + worktree.unstaged
+                            + worktree.untracked + worktree.conflicted)
+                        if (active_herd >= 0) {
+                            g_worktree_delete_block = WorktreeDeleteBlock(
+                                active = true,
+                                repository_id = repository.record.id,
+                                worktree_path = worktree.path,
+                                reason = "in_use",
+                                detail = "in use by session " +
+                                    "'{g_client.herd_sessions[active_herd].name}'")
+                        } elif (change_count > 0) {
+                            g_worktree_delete_block = WorktreeDeleteBlock(
+                                active = true,
+                                repository_id = repository.record.id,
+                                worktree_path = worktree.path,
+                                reason = "dirty",
+                                detail = "{worktree.staged} staged, " +
+                                    "{worktree.unstaged} unstaged, " +
+                                    "{worktree.untracked} untracked, " +
+                                    "{worktree.conflicted} conflicted")
+                        } else {
+                            g_confirm_repository = repository.record.id
+                            open_destructive_confirm("worktree_delete",
+                                worktree.path,
+                                "Delete worktree {worktree.path}?")
                         }
                     }
                 }

--- a/utils/dasHerd/watcher/rich_git_ui.das
+++ b/utils/dasHerd/watcher/rich_git_ui.das
@@ -187,12 +187,22 @@ def draw_repositories_window() {
                 let dirty_label = dirty > 0 ? "  *{dirty}" : ""
                 if (g_client->herd_worktree_conflicted(worktree.path)) {
                     icon("warning", GetTextLineHeight())
+                    if (IsItemHovered()) {
+                        set_tooltip(WORKTREE_ICON_TOOLTIP,
+                            "Two or more sessions attend this worktree")
+                    }
                     same_line(WORKTREE_CONFLICT_JOIN[row])
                 }
                 let active_herd = active_herd_for_worktree(worktree.path)
                 if (active_herd >= 0) {
-                    icon(g_client.herd_sessions[active_herd].state == "running"
-                        ? "play" : "clock", GetTextLineHeight())
+                    let claim_running = (g_client.herd_sessions[active_herd].state
+                        == "running")
+                    icon(claim_running ? "play" : "clock", GetTextLineHeight())
+                    if (IsItemHovered()) {
+                        set_tooltip(WORKTREE_ICON_TOOLTIP, (claim_running
+                            ? "Session '{g_client.herd_sessions[active_herd].name}' is running here"
+                            : "Session '{g_client.herd_sessions[active_herd].name}' is attached here (not running)"))
+                    }
                     same_line(WORKTREE_ACTIVE_JOIN[row])
                 }
                 // Transparent label keeps the row id + snapshot text; the
@@ -1179,7 +1189,7 @@ def git_ui_init() {
 }
 
 def draw_repositories_dock() {
-    dock_window(REPOSITORIES_WIN.PUBLIC, (text = "Repositories & Worktrees", closable = true,
+    dock_window(REPOSITORIES_WIN.PUBLIC, (text = "Git Repositories & Worktrees###Repositories", closable = true,
             flags = ImGuiWindowFlags.None)) {
         window_zoom_scope("repositories") {
             draw_repositories_window()

--- a/utils/dasHerd/watcher/rich_git_ui.das
+++ b/utils/dasHerd/watcher/rich_git_ui.das
@@ -196,6 +196,7 @@ def draw_repositories_window() {
                 // overlay draws MAIN / slash-tinted branch / amber dirty in
                 // the shared token palette (notes 18/20).
                 let row_label = "{prefix}{branch}{dirty_label}##{repository.record.id}:{worktree.path}"
+                WORKTREE_ROW[row].value = (repository.record.id == g_selected_repository_id && worktree.path == g_selected_worktree_path)
                 var row_clicked = false
                 with_style((ImGuiCol.Text, float4(0.0f, 0.0f, 0.0f, 0.0f))) {
                     row_clicked = selectable(WORKTREE_ROW[row], (text = row_label))
@@ -212,7 +213,6 @@ def draw_repositories_window() {
                     GIT_CHANGELIST_WIN.pending_raise = true
                     GIT_ACTIVITY_WIN.open = true
                 }
-                WORKTREE_ROW[row].value = (repository.record.id == g_selected_repository_id && worktree.path == g_selected_worktree_path)
                 {
                     let row_min = GetItemRectMin()
                     let row_max = GetItemRectMax()

--- a/utils/dasHerd/watcher/rich_launcher_ui.das
+++ b/utils/dasHerd/watcher/rich_launcher_ui.das
@@ -259,6 +259,16 @@ def launcher_ui_init() {
     LAUNCHER_WORKFLOW.value = 0
 }
 
+def prepare_resolver_launcher(repository_id, worktree_path, task_brief : string) {
+    //! Launcher prefill for the blocked-worktree-delete offer: run in the
+    //! blocked worktree with the blocking state as the agent's task.
+    prepare_launcher(repository_id, worktree_path)
+    LAUNCHER_NAME.pending_value = "resolve {base_name(worktree_path)}"
+    LAUNCHER_NAME.has_pending = true
+    LAUNCHER_TASK.pending_value = task_brief
+    LAUNCHER_TASK.has_pending = true
+}
+
 // The launcher is a MODAL dialog (note 3): while it is up the rest of the UI
 // dims and ignores input — it is not a dockable pane.
 def open_launcher_modal() {

--- a/utils/dasHerd/watcher/rich_live.das
+++ b/utils/dasHerd/watcher/rich_live.das
@@ -307,6 +307,26 @@ struct HerderTerminalInputArgs {
     expect_session : string
 }
 
+// A second say inside the prior say's ~200ms Enter window would merge both
+// texts into one paste (single global submit slot). Queue it; the frame loop
+// feeds the queue only after the pending \r has flushed.
+def private queue_or_send_input(text : string; submit : bool) {
+    if (g_submit_stamp != 0l || !empty(g_input_queue)) {
+        g_input_queue |> push(PendingSay(text = clone_string(text), submit = submit,
+            session = clone_string(g_client.selected_id)))
+        return
+    }
+    if (!empty(text)) {
+        g_client->send_input(text)
+        if (submit) {
+            g_submit_stamp = ref_time_ticks()
+            g_submit_session = g_client.selected_id
+        }
+    } elif (submit) {
+        g_client->send_input("\r")
+    }
+}
+
 [live_command(description = "Type into the attached session's terminal. Args: text, submit (true appends Enter), optional expect_session (reject if another session is attached). Requires the controller lease.")]
 def herder_terminal_input(input : JsonValue?) : JsonValue? {
     if (g_client == null || !g_client.connected) {
@@ -329,15 +349,7 @@ def herder_terminal_input(input : JsonValue?) : JsonValue? {
     // The Enter must arrive OUTSIDE the text's paste window or Ink-based TUIs
     // (Claude Code) keep it as part of the paste: text now, \r deferred ~200ms
     // via the frame loop. A lone submit (empty text) sends immediately.
-    if (!empty(args.text)) {
-        g_client->send_input(args.text)
-        if (args.submit) {
-            g_submit_stamp = ref_time_ticks()
-            g_submit_session = g_client.selected_id
-        }
-    } elif (args.submit) {
-        g_client->send_input("\r")
-    }
+    queue_or_send_input(args.text, args.submit)
     return JV((ok = true, bytes = length(args.text) + (args.submit ? 1 : 0),
         session_id = g_client.selected_id))
 }
@@ -428,9 +440,7 @@ def herder_session_say(input : JsonValue?) : JsonValue? {
     delete g_say_baseline
     g_say_baseline <- split(g_terminal_view.screen_text, "\n")
     g_say_revision = g_terminal_view.content_revision
-    g_client->send_input(args.text)
-    g_submit_stamp = ref_time_ticks()
-    g_submit_session = g_client.selected_id
+    queue_or_send_input(args.text, true)
     return JV((ok = true, session_id = g_client.selected_id,
         baseline_revision = g_say_revision))
 }

--- a/utils/dasHerd/watcher/rich_live.das
+++ b/utils/dasHerd/watcher/rich_live.das
@@ -297,6 +297,17 @@ def herder_close_session(input : JsonValue?) : JsonValue? {
     }
     let args = from_JV(input, type<HerderAttachSessionArgs>)
     if (empty(args.herd_id)) return JV((ok = false, error = "herd_id is required"))
+    // Validate before queuing: the watcher's error reply lands async, so an
+    // unknown id (a stray \r from a caller's shell pipeline, say) used to
+    // report ok=true while closing nothing.
+    var known = false
+    for (record in g_client.herd_sessions) {
+        if (record.id == args.herd_id) {
+            known = true
+            break
+        }
+    }
+    if (!known) return JV((ok = false, error = "unknown herd session '{args.herd_id}'"))
     g_client->request_herd_close(args.herd_id)
     return JV((ok = true, herd_id = args.herd_id))
 }

--- a/utils/dasHerd/watcher/rich_net.das
+++ b/utils/dasHerd/watcher/rich_net.das
@@ -268,6 +268,26 @@ class WatcherRichClient : HvWebSocketClient {
                 g_open_terminal_pending = true
                 g_focus_terminal_pending = true
             }
+        } elif (envelope._type == "worktree_delete_result") {
+            var incoming = WatcherWorktreeDeleteResult()
+            if (sscan_json(body, incoming) && !incoming.ok) {
+                g_worktree_delete_block = WorktreeDeleteBlock(active = true,
+                    repository_id = clone_string(incoming.repository_id),
+                    worktree_path = clone_string(incoming.worktree_path),
+                    reason = clone_string(incoming.reason),
+                    detail = clone_string(incoming.detail))
+            }
+        } elif (envelope._type == "herd_delete_result") {
+            var incoming = WatcherHerdDeleteResult()
+            if (sscan_json(body, incoming) && !empty(incoming.kept)) {
+                // Surface the first kept worktree; the rest stay visible in
+                // the git panel with their own delete flow.
+                g_worktree_delete_block = WorktreeDeleteBlock(active = true,
+                    repository_id = clone_string(incoming.kept[0].repository_id),
+                    worktree_path = clone_string(incoming.kept[0].path),
+                    reason = clone_string(incoming.kept[0].reason),
+                    detail = clone_string(incoming.kept[0].detail))
+            }
         } elif (envelope._type == "mailbox") {
             var incoming = WatcherMailboxMessageEnvelope()
             if (sscan_json(body, incoming)) {
@@ -517,6 +537,19 @@ class WatcherRichClient : HvWebSocketClient {
         if (!connected || empty(herd_session_id)) return
         send("\{\"op\":\"herd_close\",\"herd_session_id\":" +
             "{sprint_json(herd_session_id, false)}\}")
+    }
+
+    def request_herd_delete(herd_session_id : string) {
+        if (!connected || empty(herd_session_id)) return
+        send("\{\"op\":\"herd_delete\",\"herd_session_id\":" +
+            "{sprint_json(herd_session_id, false)}\}")
+    }
+
+    def request_worktree_delete(repository_id, worktree_path : string) {
+        if (!connected || empty(worktree_path)) return
+        send("\{\"op\":\"worktree_delete\",\"repository_id\":" +
+            "{sprint_json(repository_id, false)},\"worktree_path\":" +
+            "{sprint_json(worktree_path, false)}\}")
     }
 
     def request_herd_rename(herd_session_id, name : string) {

--- a/utils/dasHerd/watcher/rich_sessions_ui.das
+++ b/utils/dasHerd/watcher/rich_sessions_ui.das
@@ -349,7 +349,15 @@ def draw_herd_cards() {
                 break
             }
         }
-        icon(profile_agent ? "bolt" : "chevron-right", line)
+        // Dead cards dim wholesale - glyphs included - so alive-vs-asleep
+        // reads at a glance instead of from the words.
+        let card_alive = record.state == "running"
+        let dead_tint = token_state_color(record.state)
+        if (card_alive) {
+            icon(profile_agent ? "bolt" : "chevron-right", line)
+        } else {
+            icon_tinted(profile_agent ? "bolt" : "chevron-right", line, dead_tint)
+        }
         if (IsItemHovered()) {
             set_tooltip(HERD_ICON_TOOLTIP, profile_agent
                 ? "Agent session (profile '{record.profile_id}')"
@@ -373,13 +381,24 @@ def draw_herd_cards() {
                 state_hint = "exited with code {record.exit_code}"
             }
         }
-        icon(state_glyph, line)
+        if (card_alive) {
+            icon(state_glyph, line)
+        } else {
+            icon_tinted(state_glyph, line, dead_tint)
+        }
         if (IsItemHovered()) {
             set_tooltip(HERD_ICON_TOOLTIP, state_hint)
         }
         same_line(HERD_STATE_JOIN[index])
         if (record.conflicted) {
-            icon("warning", line)
+            // Amber only where it is actionable: a LIVE session in a
+            // contested worktree. On dead cards the advisory dims with the
+            // rest so alive-at-a-glance survives.
+            if (card_alive) {
+                icon("warning", line)
+            } else {
+                icon_tinted("warning", line, dead_tint)
+            }
             if (IsItemHovered()) {
                 set_tooltip(HERD_ICON_TOOLTIP,
                     "Another session attends this worktree")

--- a/utils/dasHerd/watcher/rich_sessions_ui.das
+++ b/utils/dasHerd/watcher/rich_sessions_ui.das
@@ -84,9 +84,27 @@ def draw_selected_session_context() {
     if (g_client == null || empty(g_client.selected_id)) return
     for (session in g_client.sessions) {
         if (session.id != g_client.selected_id) continue
-        let purpose = !empty(session.purpose) ? to_upper(session.purpose) : to_upper(session.kind)
-        text("{purpose}  {session.id}")
-        text_disabled("Origin: {session.worktree_path}")
+        // Names over plumbing ids (note 46): prefer the herd card's name,
+        // then the display name; the raw session id lives in the tooltip.
+        var title = session.display_name
+        for (record in g_client.herd_sessions) {
+            if (record.pty_session_id == session.id) {
+                title = record.name
+                break
+            }
+        }
+        if (empty(title)) {
+            title = session.id
+        }
+        let purpose = !empty(session.purpose) ? session.purpose : session.kind
+        text("{title}")
+        if (IsItemHovered()) {
+            set_tooltip(CONTEXT_ID_TOOLTIP, "{session.id}  |  {purpose}")
+        }
+        text_disabled("{purpose} | {session.state} | {base_name(session.worktree_path)}")
+        if (IsItemHovered()) {
+            set_tooltip(CONTEXT_ORIGIN_TOOLTIP, session.worktree_path)
+        }
         if (!empty(session.task_context)) {
             text_wrapped((text = session.task_context))
         }
@@ -226,8 +244,32 @@ def private herd_age_label(updated_wall_s : int64) : string {
 }
 
 def private attach_herd_card(record : HerdSession) {
-    if (g_client == null || empty(record.pty_session_id)) return
+    if (g_client == null) return
     ui_event("herd-card-attach {record.id}")
+    // A session pick IS a worktree pick (note 48): aim the git surfaces at
+    // the card's tree whether or not a terminal can attach.
+    if (!empty(record.repository_id) && !empty(record.worktree_path)
+            && (g_selected_repository_id != record.repository_id
+                || g_selected_worktree_path != record.worktree_path)) {
+        g_selected_repository_id = record.repository_id
+        g_selected_worktree_path = record.worktree_path
+        g_selection_explicit = true
+        g_client->refresh_repository(record.repository_id)
+        g_client->request_repository_review(record.repository_id,
+            record.worktree_path)
+    }
+    // Attach only while the PTY still exists on the watcher. A stale id
+    // bounces ("unknown session") and the auto-attach yanks the selection
+    // straight back (note 43).
+    if (empty(record.pty_session_id)) return
+    var pty_exists = false
+    for (session in g_client.sessions) {
+        if (session.id == record.pty_session_id) {
+            pty_exists = true
+            break
+        }
+    }
+    if (!pty_exists) return
     g_client->attach_session(record.pty_session_id)
     g_open_terminal_pending = true
     g_focus_terminal_pending = true
@@ -262,18 +304,40 @@ def draw_herd_cards() {
             }
         }
         icon(profile_agent ? "bolt" : "chevron-right", line)
+        if (IsItemHovered()) {
+            set_tooltip(HERD_ICON_TOOLTIP, profile_agent
+                ? "Agent session (profile '{record.profile_id}')"
+                : "Shell session (profile '{record.profile_id}')")
+        }
         same_line(HERD_ICON_JOIN[index])
         var state_glyph = "clock"
+        var state_hint = "never launched"
         if (record.state == "running") {
             state_glyph = "play"
+            state_hint = "running"
         } elif (record.state == "exited") {
-            state_glyph = (record.launch_count == 0 ? "clock"
-                : (record.exit_code == 0l ? "check" : "warning"))
+            if (record.launch_count == 0) {
+                state_glyph = "clock"
+                state_hint = "created, never launched"
+            } elif (record.exit_code == 0l) {
+                state_glyph = "check"
+                state_hint = "exited cleanly"
+            } else {
+                state_glyph = "warning"
+                state_hint = "exited with code {record.exit_code}"
+            }
         }
         icon(state_glyph, line)
+        if (IsItemHovered()) {
+            set_tooltip(HERD_ICON_TOOLTIP, state_hint)
+        }
         same_line(HERD_STATE_JOIN[index])
         if (record.conflicted) {
             icon("warning", line)
+            if (IsItemHovered()) {
+                set_tooltip(HERD_ICON_TOOLTIP,
+                    "Another session attends this worktree")
+            }
             same_line(HERD_CONFLICT_JOIN[index])
         }
         let unread_hint = record.unread_outbox > 0 ? "  [{record.unread_outbox}]" : ""
@@ -509,7 +573,8 @@ def draw_session_list() {
         }
         if (visible_sessions == 0) {
             text_disabled(NO_SESSION_LABEL,
-                (text = g_show_exited ? "No sessions" : "No active sessions"))
+                (text = g_show_exited ? "No sessions"
+                    : "No running terminals (tasks and exited are hidden)"))
         }
     }
     text_disabled("Exited sessions are retained and hidden by default.")
@@ -543,21 +608,28 @@ def draw_session_list() {
             draw_attention_rows("")
         }
     }
-    // Error history (note 28): the chrome shows only the latest error; the
-    // ring keeps what was dismissed. Hidden while empty.
+    // Error history (note 28, reshaped per note 46): collapsed by default,
+    // scrollable, clearable. The ring keeps dismissed chrome errors.
     if (!empty(g_error_history)) {
         separator()
-        text("Errors ({length(g_error_history)})")
-        same_line()
-        if (small_button(ERRORS_CLEAR, (text = "clear"))) {
-            g_error_history |> clear()
-            g_error_history_wall |> clear()
-        }
-        for (error_index in range(length(g_error_history))) {
-            // Newest last in storage; show newest first.
-            let ring = length(g_error_history) - 1 - error_index
-            text_disabled(ERROR_HISTORY_ROW[error_index],
-                (text = "{herd_age_label(g_error_history_wall[ring])}  {g_error_history[ring]}"))
+        collapsing_header(ERRORS_HEADER,
+                "Errors ({length(g_error_history)})###SessionErrors",
+                false, ImGuiTreeNodeFlags.None) {
+            if (small_button(ERRORS_CLEAR, (text = "clear"))) {
+                g_error_history |> clear()
+                g_error_history_wall |> clear()
+            }
+            child(ERRORS_CHILD, (text = "errors",
+                    size = float2(0.0f, 120.0f),
+                    child_flags = ImGuiChildFlags.Borders,
+                    window_flags = ImGuiWindowFlags.None)) {
+                for (error_index in range(length(g_error_history))) {
+                    // Newest last in storage; show newest first.
+                    let ring = length(g_error_history) - 1 - error_index
+                    text_disabled(ERROR_HISTORY_ROW[error_index],
+                        (text = "{herd_age_label(g_error_history_wall[ring])}  {g_error_history[ring]}"))
+                }
+            }
         }
     }
 }

--- a/utils/dasHerd/watcher/rich_sessions_ui.das
+++ b/utils/dasHerd/watcher/rich_sessions_ui.das
@@ -101,7 +101,8 @@ def draw_selected_session_context() {
         if (IsItemHovered()) {
             set_tooltip(CONTEXT_ID_TOOLTIP, "{session.id}  |  {purpose}")
         }
-        text_disabled("{purpose} | {session.state} | {base_name(session.worktree_path)}")
+        text_disabled((text = elide_to_avail(
+            "{purpose} | {session.state} | {base_name(session.worktree_path)}")))
         if (IsItemHovered()) {
             set_tooltip(CONTEXT_ORIGIN_TOOLTIP, session.worktree_path)
         }
@@ -135,7 +136,9 @@ def private draw_bundle_rows(session_filter : string) {
             let _ = activate_bundle_focus(bundle)
         }
         BUNDLE_ROW[bundle_index].value = false
-        if (!empty(bundle.summary)) text_disabled((text = bundle.summary))
+        if (!empty(bundle.summary)) {
+            text_disabled((text = elide_to_avail(bundle.summary)))
+        }
         for (participant in bundle.participants) {
             let files = length(participant.files)
             BUNDLE_PARTICIPANT_ROW[g_bundle_participant_row].value = (participant.repository_id
@@ -246,6 +249,7 @@ def private herd_age_label(updated_wall_s : int64) : string {
 def private attach_herd_card(record : HerdSession) {
     if (g_client == null) return
     ui_event("herd-card-attach {record.id}")
+    g_selected_herd_id = record.id
     // A session pick IS a worktree pick (note 48): aim the git surfaces at
     // the card's tree whether or not a terminal can attach.
     if (!empty(record.repository_id) && !empty(record.worktree_path)
@@ -275,9 +279,51 @@ def private attach_herd_card(record : HerdSession) {
     g_focus_terminal_pending = true
 }
 
+def elide_to_avail(value : string) : string {
+    //! Truncates with an ellipsis so the text stops at the content region
+    //! instead of bleeding through the window padding into the neighbouring
+    //! pane (note 47: the "stray one-character column" on the terminal's
+    //! left edge was card text clipped at the window edge, one column past
+    //! where the layout ends).
+    let avail = GetContentRegionAvail().x
+    if (avail <= 0.0f || CalcTextSize(value).x <= avail) return value
+    var low = 0
+    var high = length(value)
+    while (low < high) {
+        let mid = (low + high + 1) / 2
+        if (CalcTextSize(slice(value, 0, mid) + "...").x <= avail) {
+            low = mid
+        } else {
+            high = mid - 1
+        }
+    }
+    // Never end the cut inside a UTF-8 sequence.
+    peek_data(value) $(bytes) {
+        while (low > 0 && low < length(value) && (int(bytes[low]) & 0xc0) == 0x80) {
+            low--
+        }
+    }
+    return low <= 0 ? "..." : slice(value, 0, low) + "..."
+}
+
 def draw_herd_cards() {
     if (g_client == null) return
     let line = GetTextLineHeight()
+    // A PTY selection made outside the cards (task rows, auto-attach)
+    // retargets the herd pick once per change; a dead-card pick survives
+    // because the live selection did not change underneath it (note 43).
+    if (g_client.selected_id != g_herd_pick_seen_selected) {
+        g_herd_pick_seen_selected = g_client.selected_id
+        var owner_id = ""
+        for (record in g_client.herd_sessions) {
+            if (!empty(record.pty_session_id)
+                    && record.pty_session_id == g_client.selected_id) {
+                owner_id = record.id
+                break
+            }
+        }
+        g_selected_herd_id = owner_id
+    }
     var visible = 0
     // Alive sessions first; registry order within each state group. Widget
     // state stays keyed by the registry index, so reordering cannot swap
@@ -341,8 +387,7 @@ def draw_herd_cards() {
             same_line(HERD_CONFLICT_JOIN[index])
         }
         let unread_hint = record.unread_outbox > 0 ? "  [{record.unread_outbox}]" : ""
-        HERD_CARD_ROW[index].value = (!empty(record.pty_session_id)
-            && record.pty_session_id == g_client.selected_id)
+        HERD_CARD_ROW[index].value = record.id == g_selected_herd_id
         // AllowOverlap or the row swallows clicks aimed at the relaunch
         // icon button drawn over its right-hand side. Dead sessions read
         // muted; alive keep the title tint.
@@ -409,9 +454,9 @@ def draw_herd_cards() {
         let output_hint = (output_wall > 0l
             ? " | output {herd_age_label(output_wall)}" : "")
         text_disabled(HERD_CARD_DETAIL[index],
-            (text = "      {record.profile_id} | {record.workflow} | " +
+            (text = elide_to_avail("      {record.profile_id} | {record.workflow} | " +
                 "{base_name(record.worktree_path)}{satellite_hint} | " +
-                "{herd_age_label(record.updated_wall_s)}{output_hint}"))
+                "{herd_age_label(record.updated_wall_s)}{output_hint}")))
         // The card's own Attention and Review Bundles as subtree children
         // (note 19); zero-count sections never render.
         let attention = session_attention_count(record.pty_session_id)

--- a/utils/dasHerd/watcher/rich_sessions_ui.das
+++ b/utils/dasHerd/watcher/rich_sessions_ui.das
@@ -30,6 +30,7 @@ require ./rich_net.das
 require ./rich_focus.das
 require ./rich_inspector_ui.das
 require ./rich_commands.das
+require ./rich_tokens.das
 
 var SESSION_ROW : table<int; ToggleState>
 
@@ -54,6 +55,8 @@ var HERD_MENU_RELAUNCH : table<int; ToggleState>
 var HERD_MENU_RENAME : table<int; ToggleState>
 
 var HERD_MENU_CLOSE : table<int; ToggleState>
+
+var HERD_MENU_DELETE : table<int; ToggleState>
 
 var HERD_RELAUNCH_BUTTON : table<int; ClickState>
 
@@ -234,7 +237,20 @@ def draw_herd_cards() {
     if (g_client == null) return
     let line = GetTextLineHeight()
     var visible = 0
-    for (index in range(length(g_client.herd_sessions))) {
+    // Alive sessions first; registry order within each state group. Widget
+    // state stays keyed by the registry index, so reordering cannot swap
+    // per-card identity when a session exits.
+    var inscope order : array<int>
+    order |> reserve(length(g_client.herd_sessions))
+    for (registry_index in range(length(g_client.herd_sessions))) {
+        order |> push(registry_index)
+    }
+    sort(order) $(a, b) {
+        let a_rank = g_client.herd_sessions[a].state == "running" ? 0 : 1
+        let b_rank = g_client.herd_sessions[b].state == "running" ? 0 : 1
+        return a_rank != b_rank ? a_rank < b_rank : a < b
+    }
+    for (index in order) {
         let record & = unsafe(g_client.herd_sessions[index])
         if (record.state == "closed") continue
         visible++
@@ -264,10 +280,16 @@ def draw_herd_cards() {
         HERD_CARD_ROW[index].value = (!empty(record.pty_session_id)
             && record.pty_session_id == g_client.selected_id)
         // AllowOverlap or the row swallows clicks aimed at the relaunch
-        // icon button drawn over its right-hand side.
-        if (selectable(HERD_CARD_ROW[index],
+        // icon button drawn over its right-hand side. Dead sessions read
+        // muted; alive keep the title tint.
+        var card_clicked = false
+        with_style((ImGuiCol.Text, record.state == "running"
+                ? token_title_color() : token_state_color(record.state))) {
+            card_clicked = selectable(HERD_CARD_ROW[index],
                 (text = "{record.name}{unread_hint}##herd:{record.id}",
-                 flags = ImGuiSelectableFlags.AllowOverlap))) {
+                 flags = ImGuiSelectableFlags.AllowOverlap))
+        }
+        if (card_clicked) {
             attach_herd_card(record)
         }
         if (IsItemHovered()) {
@@ -300,6 +322,12 @@ def draw_herd_cards() {
                     shortcut = "", enabled = true))) {
                 open_destructive_confirm("herd_close", record.id,
                     "Close session '{record.name}' and terminate its PTY?")
+            }
+            if (menu_item(HERD_MENU_DELETE[index], (text = "Delete session...",
+                    shortcut = "", enabled = record.state != "running"))) {
+                open_destructive_confirm("herd_delete", record.id,
+                    "Delete session '{record.name}' and remove its worktrees? " +
+                    "Worktrees in use or with uncommitted changes are kept.")
             }
         }
         if (record.state == "exited") {
@@ -343,6 +371,9 @@ def draw_herd_cards() {
 var g_confirm_kind : string
 var g_confirm_target : string
 var g_confirm_text : string
+// Second capture slot for kinds whose action needs a repository id beside the
+// target (worktree_delete); captured at open time like the target.
+var g_confirm_repository : string
 
 // Destructive actions (note 27) route through one confirmation modal. The
 // target is captured at open time and re-checked at confirm so a selection
@@ -366,6 +397,11 @@ def draw_destructive_confirm_popup() {
                 }
             } elif (g_confirm_kind == "herd_close") {
                 g_client->request_herd_close(g_confirm_target)
+            } elif (g_confirm_kind == "herd_delete") {
+                g_client->request_herd_delete(g_confirm_target)
+            } elif (g_confirm_kind == "worktree_delete") {
+                g_client->request_worktree_delete(g_confirm_repository,
+                    g_confirm_target)
             }
             close_current_popup(CONFIRM_DIALOG)
         }

--- a/utils/dasHerd/watcher/rich_state.das
+++ b/utils/dasHerd/watcher/rich_state.das
@@ -420,6 +420,15 @@ var g_selected_repository_id : string
 // Note-9 policy: attaches may re-aim only while the selection is not explicit.
 var g_selection_explicit : bool
 
+// The herd card the user last picked. Cards highlight through this even when
+// their PTY is gone (note 43: a dead-PTY card click used to give no feedback
+// at all, reading as select-then-unselect).
+var g_selected_herd_id = ""
+// Change detector: PTY selections made outside the cards retarget the herd
+// pick exactly once per change, so a dead-card pick is never yanked back by
+// the unchanged live selection.
+var g_herd_pick_seen_selected = ""
+
 // Cross-module window-raise request (same pattern as g_open_terminal_pending):
 // surfaces that can't see SESSIONS_WIN set this; rich_client's frame loop acts.
 var g_open_sessions_pending : bool
@@ -627,7 +636,11 @@ def reset_terminal(columns : int = 100; rows : int = 30) {
     terminal_viewport_snapshot_dispose(g_terminal_cache.snapshot)
     var inscope created <- terminal_create(columns, rows)
     g_terminal := created
+    // The checkpoint restore right after an attach lands AFTER the note-44
+    // focus handshake ran - a reset must not eat established focus.
+    let was_focused = g_terminal_view.focused
     g_terminal_view = ImGuiTerminalState()
+    g_terminal_view.focused = was_focused
     g_terminal_cache = ImGuiTerminalCache()
 }
 

--- a/utils/dasHerd/watcher/rich_state.das
+++ b/utils/dasHerd/watcher/rich_state.das
@@ -499,6 +499,16 @@ def settings_load() {
 var g_submit_stamp : int64
 var g_submit_session : string
 
+// Say requests that arrive while an Enter is still pending: sending their text
+// immediately would merge it into the prior paste and garble both commands, so
+// they wait here until the frame loop flushes the pending \r.
+struct PendingSay {
+    text : string
+    submit : bool
+    session : string
+}
+var g_input_queue : array<PendingSay>
+
 // Real-input forensics: per-frame counters of wheel/click events that reached
 // ImGui IO. With user control locked these must stay flat — a moving counter
 // is a leak through the lock (note 38).

--- a/utils/dasHerd/watcher/rich_state.das
+++ b/utils/dasHerd/watcher/rich_state.das
@@ -80,6 +80,29 @@ struct WatcherHerdLaunchedMessage {
     session_id : string
 }
 
+struct WatcherWorktreeDeleteResult {
+    @rename = "type" _type : string
+    ok : bool
+    reason : string
+    detail : string
+    repository_id : string
+    worktree_path : string
+}
+
+struct WatcherHerdDeleteKept {
+    path : string
+    repository_id : string
+    reason : string
+    detail : string
+}
+
+struct WatcherHerdDeleteResult {
+    @rename = "type" _type : string
+    herd_session_id : string
+    removed : array<string>
+    kept : array<WatcherHerdDeleteKept>
+}
+
 struct WatcherMailboxMessageEnvelope {
     @rename = "type" _type : string
     session_id : string
@@ -508,6 +531,23 @@ struct PendingSay {
     session : string
 }
 var g_input_queue : array<PendingSay>
+
+// A blocked worktree delete (in_use / dirty / main / error). The frame loop
+// opens the block modal when active; "dirty" adds the offer to launch a
+// resolver session briefed with the blocking state.
+struct WorktreeDeleteBlock {
+    active : bool
+    repository_id : string
+    worktree_path : string
+    reason : string
+    detail : string
+}
+var g_worktree_delete_block = WorktreeDeleteBlock()
+
+// Deferred launcher open for the resolver offer: open_popup from inside the
+// block modal would nest the launcher under the popup being closed, so the
+// button preps the launcher fields and the frame loop opens it at root level.
+var g_launch_resolver_pending = false
 
 // Real-input forensics: per-frame counters of wheel/click events that reached
 // ImGui IO. With user control locked these must stay flat — a moving counter

--- a/utils/dasHerd/watcher/rich_terminal_ui.das
+++ b/utils/dasHerd/watcher/rich_terminal_ui.das
@@ -106,11 +106,15 @@ def draw_terminal_window() {
                 - GetStyle().ItemSpacing.y))
     with_font(g_terminal_font) {
         if (g_focus_terminal_pending) {
-            // The window raise lands a frame after open; focusing the input
-            // while the window is still unfocused is a no-op that used to eat
-            // the request (note 44). Hold the flag until the raise arrives.
+            // The window raise lands a frame after open; focusing while the
+            // window is still unfocused is a no-op that used to eat the
+            // request (note 44). Hold the flag until the raise arrives, then
+            // set the terminal's OWN focus model: the widget is an
+            // InvisibleButton, and SetKeyboardFocusHere's tabbing request
+            // falls through it onto the next tab stop (the zoom button) -
+            // proven by snapshot, the -5% button ended up focus=true.
             if (IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows)) {
-                set_keyboard_focus_here()
+                g_terminal_view.focused = true
                 g_focus_terminal_pending = false
             }
         }

--- a/utils/dasHerd/watcher/rich_terminal_ui.das
+++ b/utils/dasHerd/watcher/rich_terminal_ui.das
@@ -106,8 +106,13 @@ def draw_terminal_window() {
                 - GetStyle().ItemSpacing.y))
     with_font(g_terminal_font) {
         if (g_focus_terminal_pending) {
-            set_keyboard_focus_here()
-            g_focus_terminal_pending = false
+            // The window raise lands a frame after open; focusing the input
+            // while the window is still unfocused is a no-op that used to eat
+            // the request (note 44). Hold the flag until the raise arrives.
+            if (IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows)) {
+                set_keyboard_focus_here()
+                g_focus_terminal_pending = false
+            }
         }
         let result <- imgui_terminal("watcher", g_terminal, g_terminal_view,
             g_terminal_cache, terminal_style)

--- a/utils/dasHerd/watcher/rich_tokens.das
+++ b/utils/dasHerd/watcher/rich_tokens.das
@@ -59,10 +59,11 @@ def token_muted_color(alpha : float = 1.0f) : float4 {
 }
 
 def token_state_color(state : string; alpha : float = 1.0f) : float4 {
-    //! Session/worktree lifecycle words: running green, exited muted,
-    //! closed dim, anything conflicted/attention amber.
+    //! Session/worktree lifecycle words: running green, exited grey and
+    //! clearly darker (alive-at-a-glance), closed dimmer still, anything
+    //! conflicted/attention amber.
     if (state == "running" || state == "interactive") return token_added_color(alpha)
-    if (state == "exited") return token_muted_color(alpha)
-    if (state == "closed") return token_muted_color(alpha * 0.7f)
+    if (state == "exited") return float4(0.47f, 0.50f, 0.56f, alpha)
+    if (state == "closed") return float4(0.38f, 0.40f, 0.45f, alpha)
     return token_warning_color(alpha)
 }

--- a/utils/dasHerd/watcher/tests/test_herd_sessions.das
+++ b/utils/dasHerd/watcher/tests/test_herd_sessions.das
@@ -155,6 +155,46 @@ def test_herd_registry(t : T?) {
             "closing the other attendees clears the advisory flag")
         herd_shutdown()
     }
+    t |> run("delete removes records under guard; worktree-user lookup respects state") <| @(t : T?) {
+        let temp = create_temp_directory_result("dasherd_herd_delete_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let root = temp as value
+        t |> equal(herd_init(path_join(root, "_registry.json"),
+            path_join(root, "profiles.json")), "")
+        var error : string
+        let herd_id = herd_create(HerdCreateRequest(name = "victim",
+            profile_id = "shell", worktree_path = root), error)
+        t |> success(!empty(herd_id), error)
+        t |> equal(herd_worktree_user(root), "victim",
+            "a non-closed session claims its worktree")
+        t |> equal(herd_worktree_user(root, herd_id), "",
+            "the exclusion id frees the lookup")
+
+        var inscope removed = HerdSession()
+        t |> success(!empty(herd_delete("nope", removed)),
+            "unknown ids are rejected")
+        t |> equal(herd_link_pty(herd_id, "pty_live"), "")
+        t |> success(!empty(herd_delete(herd_id, removed)),
+            "running sessions never delete")
+        var pty_to_terminate : string
+        t |> equal(herd_close(herd_id, pty_to_terminate), "")
+        t |> equal(herd_worktree_user(root), "",
+            "closed sessions do not hold the worktree")
+        t |> equal(herd_delete(herd_id, removed), "")
+        t |> equal(removed.name, "victim")
+        t |> equal(removed.worktree_path, herd_display_worktree(root))
+        var inscope record = HerdSession()
+        t |> success(!herd_get(herd_id, record), "deleted records are gone")
+        // Deletion is durable: a restart must not resurrect the record.
+        herd_shutdown()
+        t |> equal(herd_init(path_join(root, "_registry.json"),
+            path_join(root, "profiles.json")), "")
+        t |> success(!herd_get(herd_id, record), "deletion survives a restart")
+        herd_shutdown()
+    }
     t |> run("profile intro lines ride the initial launch request") <| @(t : T?) {
         let temp = create_temp_directory_result("dasherd_herd_intro_")
         if (!(temp is value)) {

--- a/utils/dasHerd/watcher/tests/test_ptyhost.das
+++ b/utils/dasHerd/watcher/tests/test_ptyhost.das
@@ -1,0 +1,160 @@
+options gen2
+options rtti
+
+require dastest/testing_boost public
+require dashv/dashv_boost
+require daslib/fio
+require daslib/base64
+require daslib/json_boost
+require strings
+require math
+
+let TEST_PORT = 9873
+
+var private g_hello_seen = false
+var private g_attached_seen = false
+var private g_output_text = ""
+var private g_last_stat = ""
+
+class private ProbeClient : HvWebSocketClient {
+    token : string
+    def override onOpen {
+        send("\{\"op\":\"hello\",\"token\":{sprint_json(token, false)},\"protocol\":1\}")
+    }
+    def override onClose {}
+    def override onMessage(msg : string#) {
+        if (find(msg, "\"type\":\"stat\"") >= 0) {
+            g_last_stat = string(msg)
+            if (!g_hello_seen) {
+                g_hello_seen = true
+                send("\{\"op\":\"attach\",\"from_byte\":0\}")
+            }
+        } elif (find(msg, "\"type\":\"attached\"") >= 0) {
+            g_attached_seen = true
+        }
+    }
+    def override onMessageFrame(msg : string#; byte_count : int; opcode : ws_opcode) {
+        if (opcode == ws_opcode.WS_OPCODE_BINARY) {
+            g_output_text += string(msg)
+        } else {
+            onMessage(msg)
+        }
+    }
+    def send_input(text : string) {
+        var inscope bytes : array<uint8>
+        bytes |> reserve(length(text))
+        peek_data(text) $(view) {
+            for (byte in view) {
+                bytes |> push(byte)
+            }
+        }
+        let payload = base64_encode(bytes)
+        send("\{\"op\":\"input\",\"base64\":\"{payload}\"\}")
+    }
+}
+
+def private pump_until(var client : ProbeClient?; timeout_ms : int64;
+                       blk : block<() : bool>) : bool {
+    let started = ref_time_ticks()
+    while (get_time_nsec(started) / 1000000l < timeout_ms) {
+        client->process_event_que()
+        if (invoke(blk)) return true
+        sleep(5u)
+    }
+    return false
+}
+
+[test]
+def test_ptyhost_lifecycle(t : T?) {
+    if (get_platform_name() != "windows") return
+    t |> run("host survives its spawner, replays, accepts input, terminates") <| @(t : T?) {
+        let root = get_das_root()
+        var compiler = path_join(root, "bin/Release/daslang.exe")
+        if (!fexist(compiler)) {
+            let args <- get_command_line_arguments()
+            compiler = empty(args) ? "daslang.exe" : args[0]
+        }
+        let temp = create_temp_directory_result("dasherd_ptyhost_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let journal_dir = temp as value
+
+        // Stage 1: an intermediary launcher spawns the host DETACHED and
+        // exits - the popen child's death is the spawner's death.
+        var launcher_output = ""
+        let launcher_argv <- [compiler,
+            path_join(root, "utils/dasHerd/ptyhost/tests/host_launcher.das"), "--",
+            "--token", "t1token",
+            "--child-env", "PTYHOST_TEST=from-test-env",
+            "--host-args", compiler,
+            path_join(root, "utils/dasHerd/ptyhost/main.das"), "--",
+            "--session", "t1", "--port", "{TEST_PORT}",
+            "--journal", journal_dir, "--cwd", journal_dir,
+            "--child", "cmd.exe", "--child", "/q"]
+        let launcher_exit = unsafe(popen_argv(launcher_argv, 60.0, $(file) {
+            if (file != null) {
+                launcher_output = unsafe(fread_to_eof(file))
+            }
+        }))
+        t |> equal(launcher_exit, 0, launcher_output)
+        t |> success(find(launcher_output, "launched pid=") >= 0
+                && find(launcher_output, "launched pid=0 ") < 0,
+            "launcher reported a live host pid: {launcher_output}")
+
+        // Stage 2: the stamp appears while the spawner is already gone.
+        let stamp_path = path_join(journal_dir, "t1.host.json")
+        var stamp_seen = false
+        let stamp_started = ref_time_ticks()
+        while (get_time_nsec(stamp_started) / 1000000l < 30000l) {
+            if (fexist(stamp_path)) {
+                stamp_seen = true
+                break
+            }
+            sleep(20u)
+        }
+        t |> success(stamp_seen, "host stamp appeared after spawner death")
+
+        // Stage 3: connect, authenticate, attach, drive the child.
+        g_hello_seen = false
+        g_attached_seen = false
+        g_output_text = ""
+        g_last_stat = ""
+        var client = new ProbeClient(token = "t1token")
+        t |> equal(client->init("ws://127.0.0.1:{TEST_PORT}/"), 0)
+        t |> success(pump_until(client, 15000l) $() => g_attached_seen,
+            "hello + attach handshake completed")
+        client->send_input("echo PTYHOST-OK:%PTYHOST_TEST%\r\n")
+        t |> success(pump_until(client, 15000l)
+                $() => find(g_output_text, "PTYHOST-OK:from-test-env") >= 0,
+            "child echoed input with the forwarded env var: {slice(g_output_text, max(0, length(g_output_text) - 400))}")
+
+        // Stage 4: terminate the child; the host stamps the exit.
+        client->send("\{\"op\":\"terminate\",\"exit_code\":0\}")
+        t |> success(pump_until(client, 15000l) $() {
+                client->send("\{\"op\":\"stat\"\}")
+                return find(g_last_stat, "\"exited\":true") >= 0
+            }, "host observed child exit: {g_last_stat}")
+
+        // Stage 5: shutdown; the host writes the final stamp and exits.
+        client->send("\{\"op\":\"shutdown\"\}")
+        let shutdown_started = ref_time_ticks()
+        var final_stamp = ""
+        while (get_time_nsec(shutdown_started) / 1000000l < 15000l) {
+            client->process_event_que()
+            final_stamp = fread(stamp_path)
+            if (find(final_stamp, "\"exited\":true") >= 0
+                    && find(final_stamp, "\"drained\":true") >= 0) break
+            sleep(20u)
+        }
+        t |> success(find(final_stamp, "\"exited\":true") >= 0
+                && find(final_stamp, "\"drained\":true") >= 0,
+            "final stamp records exited + drained: {final_stamp}")
+        client->close()
+        client->cleanup()
+        unsafe {
+            delete client
+        }
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_ptyhost.das
+++ b/utils/dasHerd/watcher/tests/test_ptyhost.das
@@ -18,8 +18,13 @@ var private g_last_stat = ""
 
 class private ProbeClient : HvWebSocketClient {
     token : string
+    protocol : int = 1
+    send_hello : bool = true
+    last_error : string
     def override onOpen {
-        send("\{\"op\":\"hello\",\"token\":{sprint_json(token, false)},\"protocol\":1\}")
+        if (send_hello) {
+            send("\{\"op\":\"hello\",\"token\":{sprint_json(token, false)},\"protocol\":{protocol}\}")
+        }
     }
     def override onClose {}
     def override onMessage(msg : string#) {
@@ -31,6 +36,8 @@ class private ProbeClient : HvWebSocketClient {
             }
         } elif (find(msg, "\"type\":\"attached\"") >= 0) {
             g_attached_seen = true
+        } elif (find(msg, "\"type\":\"error\"") >= 0) {
+            last_error = string(msg)
         }
     }
     def override onMessageFrame(msg : string#; byte_count : int; opcode : ws_opcode) {
@@ -130,6 +137,44 @@ def test_ptyhost_lifecycle(t : T?) {
                 $() => find(g_output_text, "PTYHOST-OK:from-test-env") >= 0,
             "child echoed input with the forwarded env var: {slice(g_output_text, max(0, length(g_output_text) - 400))}")
 
+        // Stage 3.5: liveness lock + adversarial clients. The lock is HELD -
+        // remove() must fail while the host lives; that failing remove IS the
+        // watcher's dead-or-alive probe.
+        let lock_path = path_join(journal_dir, "t1.lock")
+        t |> success(fexist(lock_path) && !remove(lock_path),
+            "host holds its liveness lock (remove fails while alive)")
+        var bad_token = new ProbeClient(token = "wrong-token")
+        t |> equal(bad_token->init("ws://127.0.0.1:{TEST_PORT}/"), 0)
+        t |> success(pump_until(bad_token, 10000l)
+                $() => find(bad_token.last_error, "bad token") >= 0,
+            "wrong token is rejected: {bad_token.last_error}")
+        bad_token->close()
+        bad_token->cleanup()
+        unsafe {
+            delete bad_token
+        }
+        var bad_protocol = new ProbeClient(token = "t1token", protocol = 99)
+        t |> equal(bad_protocol->init("ws://127.0.0.1:{TEST_PORT}/"), 0)
+        t |> success(pump_until(bad_protocol, 10000l)
+                $() => find(bad_protocol.last_error, "unsupported") >= 0,
+            "wrong protocol is rejected: {bad_protocol.last_error}")
+        bad_protocol->close()
+        bad_protocol->cleanup()
+        unsafe {
+            delete bad_protocol
+        }
+        var no_hello = new ProbeClient(token = "t1token", send_hello = false)
+        t |> equal(no_hello->init("ws://127.0.0.1:{TEST_PORT}/"), 0)
+        no_hello->send_input("dir\r\n")
+        t |> success(pump_until(no_hello, 10000l)
+                $() => find(no_hello.last_error, "hello first") >= 0,
+            "pre-auth ops are rejected: {no_hello.last_error}")
+        no_hello->close()
+        no_hello->cleanup()
+        unsafe {
+            delete no_hello
+        }
+
         // Stage 4: terminate the child; the host stamps the exit.
         client->send("\{\"op\":\"terminate\",\"exit_code\":0\}")
         t |> success(pump_until(client, 15000l) $() {
@@ -151,6 +196,25 @@ def test_ptyhost_lifecycle(t : T?) {
         t |> success(find(final_stamp, "\"exited\":true") >= 0
                 && find(final_stamp, "\"drained\":true") >= 0,
             "final stamp records exited + drained: {final_stamp}")
+
+        // Stage 6: death releases the lock, and the log tells the story.
+        var lock_released = false
+        let release_started = ref_time_ticks()
+        while (get_time_nsec(release_started) / 1000000l < 10000l) {
+            if (!fexist(lock_path)) {
+                lock_released = true
+                break
+            }
+            sleep(20u)
+        }
+        t |> success(lock_released, "clean exit removed the liveness lock")
+        let host_log_text = fread(path_join(journal_dir, "t1.log"))
+        t |> success(find(host_log_text, "child launched pid=") >= 0
+                && find(host_log_text, "client authorized") >= 0
+                && find(host_log_text, "client rejected: bad token") >= 0
+                && find(host_log_text, "shutdown requested") >= 0
+                && find(host_log_text, "host exit:") >= 0,
+            "host log recorded launch, auth, rejection, and shutdown: {host_log_text}")
         client->close()
         client->cleanup()
         unsafe {

--- a/utils/dasHerd/watcher/tests/test_watcher_adoption.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_adoption.das
@@ -1,0 +1,190 @@
+options gen2
+options rtti
+
+require dastest/testing_boost public
+require ../watcher_core.das
+require ../herd_sessions.das
+require daslib/fio
+require daslib/strings_boost
+require strings
+
+def private test_compiler : string {
+    let root = get_das_root()
+    var compiler = path_join(root, "bin/Release/daslang.exe")
+    if (!fexist(compiler)) {
+        let args <- get_command_line_arguments()
+        compiler = empty(args) ? "daslang.exe" : args[0]
+    }
+    return compiler
+}
+
+def private pump_until(timeout_ms : int64; blk : block<() : bool>) : bool {
+    let started = ref_time_ticks()
+    while (get_time_nsec(started) / 1000000l < timeout_ms) {
+        watcher_tick()
+        herd_tick()
+        if (invoke(blk)) return true
+        sleep(5u)
+    }
+    return false
+}
+
+[test]
+def test_watcher_host_adoption(t : T?) {
+    if (get_platform_name() != "windows") return
+    t |> run("host-backed session survives a watcher restart and resurrects as running") <| @(t : T?) {
+        let temp = create_temp_directory_result("dasherd_adopt_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let root = temp as value
+        let sessions_root = path_join(root, "sessions")
+        let ptyhost_root = path_join(root, "ptyhosts")
+        let registry_path = path_join(root, "_registry.json")
+        let profiles_path = path_join(root, "profiles.json")
+        var inscope host_prefix <- [test_compiler(),
+            path_join(get_das_root(), "utils/dasHerd/ptyhost/main.das"), "--"]
+
+        t |> equal(watcher_init(sessions_root), "")
+        t |> equal(watcher_configure_ptyhosts(ptyhost_root, host_prefix), "")
+        t |> equal(herd_init(registry_path, profiles_path), "")
+        var herd_error : string
+        let herd_id = herd_create(HerdCreateRequest(name = "adopt probe",
+            profile_id = "shell", worktree_path = root), herd_error)
+        t |> success(!empty(herd_id), herd_error)
+
+        var inscope request = WatcherLaunchRequest(cwd = root,
+            display_name = "adoption probe", kind = "shell",
+            herd_session_id = herd_id, columns = 100, rows = 30)
+        request.argv <- ["cmd.exe", "/q"]
+        let launched = watcher_launch(request)
+        t |> success(launched.ok, launched.error)
+        let session_id = launched.session_id
+        t |> equal(herd_link_pty(herd_id, session_id), "")
+        var info = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(session_id, info))
+        t |> equal(info.state, "running")
+        t |> success(info.pid != 0, "host reported the child pid")
+        t |> success(fexist(path_join(ptyhost_root, "{session_id}.host.json")),
+            "launch left a host discovery stamp")
+
+        t |> equal(watcher_input(session_id, "echo ADOPT-A\r\n"), "")
+        t |> success(pump_until(15000l)
+                $() => find(watcher_output_text(session_id), "ADOPT-A") >= 0,
+            "child echoed through the detached host")
+        var before_restart = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(session_id, before_restart))
+
+        // The "restart": tear the watcher-side state down WITHOUT terminating.
+        // The detached host (and cmd.exe inside it) must keep running.
+        herd_shutdown()
+        watcher_shutdown()
+        t |> equal(watcher_init(sessions_root), "")
+        t |> equal(watcher_configure_ptyhosts(ptyhost_root, host_prefix), "")
+        t |> equal(watcher_adopt_hosts(), 1)
+        t |> equal(herd_init(registry_path, profiles_path), "")
+
+        var adopted = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(session_id, adopted),
+            "adopted session keeps its identity")
+        t |> equal(adopted.state, "running")
+        var inscope record = HerdSession()
+        t |> success(herd_get(herd_id, record))
+        t |> equal(record.state, "running")
+        t |> equal(record.reason, "", "resurrected record carries no watcher_restart scar")
+
+        t |> success(pump_until(15000l)
+                $() => find(watcher_output_text(session_id), "ADOPT-A") >= 0,
+            "journal replay restored pre-restart output")
+        var replayed = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(session_id, replayed))
+        t |> success(replayed.output_bytes >= before_restart.output_bytes,
+            "byte offsets continue the journal numbering")
+        t |> equal(watcher_input(session_id, "echo ADOPT-B\r\n"), "")
+        t |> success(pump_until(15000l)
+                $() => find(watcher_output_text(session_id), "ADOPT-B") >= 0,
+            "adopted session still accepts input")
+
+        var pty_to_terminate : string
+        t |> equal(herd_close(herd_id, pty_to_terminate), "")
+        t |> equal(pty_to_terminate, session_id)
+        t |> equal(watcher_terminate(session_id, "test_cleanup"), "")
+        t |> success(pump_until(15000l) $() {
+                var closing = WatcherSessionInfo()
+                return (watcher_get_session_info(session_id, closing)
+                    && closing.state == "exited" && closing.drained)
+            }, "terminate folds back through the host")
+        t |> success(pump_until(15000l)
+                $() => fexist(path_join(path_join(ptyhost_root, "archive"),
+                    "{session_id}.host.json")),
+            "released host archived its discovery stamp")
+        watcher_shutdown()
+        herd_shutdown()
+    }
+    t |> run("a dead host's exit stamp folds into an exited, replayable session") <| @(t : T?) {
+        let temp = create_temp_directory_result("dasherd_deadfold_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let root = temp as value
+        let sessions_root = path_join(root, "sessions")
+        let ptyhost_root = path_join(root, "ptyhosts")
+        var inscope host_prefix <- [test_compiler(),
+            path_join(get_das_root(), "utils/dasHerd/ptyhost/main.das"), "--"]
+        t |> equal(watcher_init(sessions_root), "")
+        t |> equal(watcher_configure_ptyhosts(ptyhost_root, host_prefix), "")
+
+        let session_id = "s999000111_7"
+        let session_dir = path_join(sessions_root, session_id)
+        var mkdir_error : string
+        t |> success(mkdir_rec(session_dir, mkdir_error), mkdir_error)
+        var inscope persisted = WatcherLaunchRequest(cwd = root,
+            display_name = "dead probe", kind = "shell",
+            herd_session_id = "h_dead", columns = 100, rows = 30)
+        persisted.argv <- ["cmd.exe", "/q"]
+        t |> success(fwrite(path_join(session_dir, "session.json"),
+            sprint_json(persisted, true)))
+        // Mailbox history: hf_3 posted then acknowledged, hf_5 posted once.
+        let mailbox_lines = ("\{\"id\":\"hf_3\",\"session_id\":\"{session_id}\",\"direction\":\"outbox\",\"sender\":\"agent_session:{session_id}\",\"kind\":\"note\",\"subject\":\"first\",\"status\":\"new\",\"revision\":4\}\n" +
+            "\{\"id\":\"hf_3\",\"session_id\":\"{session_id}\",\"direction\":\"outbox\",\"sender\":\"agent_session:{session_id}\",\"kind\":\"note\",\"subject\":\"first\",\"status\":\"acknowledged\",\"revision\":6\}\n" +
+            "\{\"id\":\"hf_5\",\"session_id\":\"{session_id}\",\"direction\":\"inbox\",\"sender\":\"human:local\",\"kind\":\"note\",\"subject\":\"second\",\"status\":\"new\",\"revision\":7\}\n")
+        t |> success(fwrite(path_join(session_dir, "mailbox.jsonl"), mailbox_lines))
+        let journal_text = "dead-host-journal-content\r\n"
+        t |> success(fwrite(path_join(ptyhost_root, "{session_id}.raw"), journal_text))
+        let stamp_json = ("\{\"version\":1,\"session\":\"{session_id}\",\"port\":9," +
+            "\"token\":\"t\",\"child_pid\":1234,\"journal_bytes\":{length(journal_text)}," +
+            "\"exited\":true,\"exit_code\":42,\"drained\":true,\"error\":\"\"\}")
+        t |> success(fwrite(path_join(ptyhost_root, "{session_id}.host.json"), stamp_json))
+
+        t |> equal(watcher_adopt_hosts(), 1)
+        var info = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(session_id, info),
+            "dead-host session materialized")
+        t |> equal(info.state, "exited")
+        t |> equal(info.exit_code, 42l)
+        t |> success(info.drained, "folded session is drained")
+        t |> equal(info.pid, 1234)
+        t |> success(find(watcher_output_text(session_id), "dead-host-journal-content") >= 0,
+            "replay ring seeded from the journal tail")
+        t |> success(fexist(path_join(path_join(ptyhost_root, "archive"),
+                "{session_id}.host.json")),
+            "dead stamp archived after the fold")
+        t |> success(!fexist(path_join(ptyhost_root, "{session_id}.host.json")),
+            "dead stamp left the discovery directory")
+
+        let mailbox = watcher_mailbox_json(session_id)
+        t |> success(find(mailbox, "\"id\":\"hf_3\"") >= 0
+                && find(mailbox, "\"status\":\"acknowledged\"") >= 0,
+            "restored mailbox keeps the newest state per message")
+        t |> success(find(mailbox, "\"id\":\"hf_5\"") >= 0,
+            "restored mailbox keeps every message")
+        let posted = watcher_mailbox_post(WatcherMailboxPostRequest(
+            session_id = session_id, direction = "outbox", subject = "fresh"))
+        t |> success(posted.ok, posted.error)
+        t |> success(posted.message_id != "hf_3" && posted.message_id != "hf_5",
+            "restored id counters prevent duplicate mailbox ids")
+        watcher_shutdown()
+    }
+}

--- a/utils/dasHerd/watcher/tests/test_watcher_adoption.das
+++ b/utils/dasHerd/watcher/tests/test_watcher_adoption.das
@@ -4,6 +4,7 @@ options rtti
 require dastest/testing_boost public
 require ../watcher_core.das
 require ../herd_sessions.das
+require dashv/dashv_boost
 require daslib/fio
 require daslib/strings_boost
 require strings
@@ -27,6 +28,34 @@ def private pump_until(timeout_ms : int64; blk : block<() : bool>) : bool {
         sleep(5u)
     }
     return false
+}
+
+// Just enough of the host stamp to reach a host from a test.
+struct private ProbeStamp {
+    port : int
+    token : string
+}
+
+// Connects to a host with its stamp credentials and orders it to die -
+// simulating a host crash underneath a live watcher.
+class private HostKiller : HvWebSocketClient {
+    token : string
+    shutdown_sent : bool
+    def override onOpen {
+        send("\{\"op\":\"hello\",\"token\":{sprint_json(token, false)},\"protocol\":1\}")
+    }
+    def override onClose {}
+    def override onMessage(msg : string#) {
+        if (find(msg, "\"type\":\"stat\"") >= 0 && !shutdown_sent) {
+            shutdown_sent = true
+            send("\{\"op\":\"shutdown\"\}")
+        }
+    }
+}
+
+class private PortBlocker : HvWebServer {
+    def override onInit {}
+    def override onTick {}
 }
 
 [test]
@@ -73,6 +102,8 @@ def test_watcher_host_adoption(t : T?) {
         t |> success(pump_until(15000l)
                 $() => find(watcher_output_text(session_id), "ADOPT-A") >= 0,
             "child echoed through the detached host")
+        t |> success(fexist(path_join(ptyhost_root, "{session_id}.lock")),
+            "host holds its liveness lock")
         var before_restart = WatcherSessionInfo()
         t |> success(watcher_get_session_info(session_id, before_restart))
 
@@ -119,6 +150,11 @@ def test_watcher_host_adoption(t : T?) {
                 $() => fexist(path_join(path_join(ptyhost_root, "archive"),
                     "{session_id}.host.json")),
             "released host archived its discovery stamp")
+        t |> success(fexist(path_join(path_join(ptyhost_root, "archive"),
+                "{session_id}.log")),
+            "host log archived beside the journal")
+        t |> success(!fexist(path_join(ptyhost_root, "{session_id}.lock")),
+            "liveness lock left no debris")
         watcher_shutdown()
         herd_shutdown()
     }
@@ -146,9 +182,13 @@ def test_watcher_host_adoption(t : T?) {
         persisted.argv <- ["cmd.exe", "/q"]
         t |> success(fwrite(path_join(session_dir, "session.json"),
             sprint_json(persisted, true)))
-        // Mailbox history: hf_3 posted then acknowledged, hf_5 posted once.
+        // Mailbox history: hf_3 posted then acknowledged, hf_5 posted once —
+        // interleaved with a truncated-write line and plain corruption, which
+        // restore must skip without losing the valid records around them.
         let mailbox_lines = ("\{\"id\":\"hf_3\",\"session_id\":\"{session_id}\",\"direction\":\"outbox\",\"sender\":\"agent_session:{session_id}\",\"kind\":\"note\",\"subject\":\"first\",\"status\":\"new\",\"revision\":4\}\n" +
+            "\{\"id\":\"hf_4\",\"session_id\":\"{session_id}\",\"direc\n" +
             "\{\"id\":\"hf_3\",\"session_id\":\"{session_id}\",\"direction\":\"outbox\",\"sender\":\"agent_session:{session_id}\",\"kind\":\"note\",\"subject\":\"first\",\"status\":\"acknowledged\",\"revision\":6\}\n" +
+            "not json at all\n" +
             "\{\"id\":\"hf_5\",\"session_id\":\"{session_id}\",\"direction\":\"inbox\",\"sender\":\"human:local\",\"kind\":\"note\",\"subject\":\"second\",\"status\":\"new\",\"revision\":7\}\n")
         t |> success(fwrite(path_join(session_dir, "mailbox.jsonl"), mailbox_lines))
         let journal_text = "dead-host-journal-content\r\n"
@@ -185,6 +225,109 @@ def test_watcher_host_adoption(t : T?) {
         t |> success(posted.ok, posted.error)
         t |> success(posted.message_id != "hf_3" && posted.message_id != "hf_5",
             "restored id counters prevent duplicate mailbox ids")
+        watcher_shutdown()
+    }
+    t |> run("a host dying under a live watcher fails that one session only") <| @(t : T?) {
+        let temp = create_temp_directory_result("dasherd_hostdeath_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let root = temp as value
+        let ptyhost_root = path_join(root, "ptyhosts")
+        var inscope host_prefix <- [test_compiler(),
+            path_join(get_das_root(), "utils/dasHerd/ptyhost/main.das"), "--"]
+        t |> equal(watcher_init(path_join(root, "sessions")), "")
+        t |> equal(watcher_configure_ptyhosts(ptyhost_root, host_prefix), "")
+
+        var inscope request = WatcherLaunchRequest(cwd = root,
+            display_name = "doomed host", kind = "shell",
+            herd_session_id = "h_doomed", columns = 100, rows = 30)
+        request.argv <- ["cmd.exe", "/q"]
+        let launched = watcher_launch(request)
+        t |> success(launched.ok, launched.error)
+        let session_id = launched.session_id
+
+        var inscope stamp = ProbeStamp()
+        t |> success(sscan_json(fread(path_join(ptyhost_root,
+            "{session_id}.host.json")), stamp), "stamp is readable")
+        var killer = new HostKiller(token = stamp.token)
+        t |> equal(killer->init("ws://127.0.0.1:{stamp.port}/"), 0)
+        t |> success(pump_until(15000l) $() {
+                killer->process_event_que()
+                var info = WatcherSessionInfo()
+                return (watcher_get_session_info(session_id, info)
+                    && info.state == "failed" && info.drained)
+            }, "watcher marked the session failed after the host died")
+        var info = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(session_id, info))
+        t |> equal(info.reason, "host_disconnected")
+        killer->close()
+        killer->cleanup()
+        unsafe {
+            delete killer
+        }
+        watcher_shutdown()
+    }
+    t |> run("a bind collision retries onto the next port") <| @(t : T?) {
+        let temp = create_temp_directory_result("dasherd_bindretry_")
+        if (!(temp is value)) {
+            t |> failure("could not create temporary test directory")
+            return
+        }
+        let root = temp as value
+        let ptyhost_root = path_join(root, "ptyhosts")
+        var inscope host_prefix <- [test_compiler(),
+            path_join(get_das_root(), "utils/dasHerd/ptyhost/main.das"), "--"]
+        t |> equal(watcher_init(path_join(root, "sessions")), "")
+        t |> equal(watcher_configure_ptyhosts(ptyhost_root, host_prefix), "")
+
+        // Learn where the port cursor is by launching once, then squat on the
+        // NEXT port so the following launch must retry past the blocker.
+        var inscope first_request = WatcherLaunchRequest(cwd = root,
+            display_name = "cursor probe", kind = "shell",
+            herd_session_id = "h_probe", columns = 100, rows = 30)
+        first_request.argv <- ["cmd.exe", "/q"]
+        let first = watcher_launch(first_request)
+        t |> success(first.ok, first.error)
+        var inscope first_stamp = ProbeStamp()
+        t |> success(sscan_json(fread(path_join(ptyhost_root,
+            "{first.session_id}.host.json")), first_stamp))
+
+        var blocker = new PortBlocker()
+        blocker->init(first_stamp.port + 1)
+        let _bind = blocker->set_bind_host("127.0.0.1")
+        t |> equal(blocker->start(), 0, "test blocker occupies the next port")
+
+        var inscope second_request = WatcherLaunchRequest(cwd = root,
+            display_name = "collision victim", kind = "shell",
+            herd_session_id = "h_victim", columns = 100, rows = 30)
+        second_request.argv <- ["cmd.exe", "/q"]
+        let second = watcher_launch(second_request)
+        t |> success(second.ok, second.error)
+        var inscope second_stamp = ProbeStamp()
+        t |> success(sscan_json(fread(path_join(ptyhost_root,
+            "{second.session_id}.host.json")), second_stamp))
+        t |> equal(second_stamp.port, first_stamp.port + 2,
+            "launch skipped the occupied port")
+        var info = WatcherSessionInfo()
+        t |> success(watcher_get_session_info(second.session_id, info))
+        t |> equal(info.state, "running")
+
+        blocker->stop()
+        blocker->cleanup()
+        unsafe {
+            delete blocker
+        }
+        let _t1 = watcher_terminate(first.session_id, "test_cleanup")
+        let _t2 = watcher_terminate(second.session_id, "test_cleanup")
+        t |> success(pump_until(20000l) $() {
+                var first_info = WatcherSessionInfo()
+                var second_info = WatcherSessionInfo()
+                return (watcher_get_session_info(first.session_id, first_info)
+                    && watcher_get_session_info(second.session_id, second_info)
+                    && first_info.drained && second_info.drained)
+            }, "both hosts folded on terminate")
         watcher_shutdown()
     }
 }

--- a/utils/dasHerd/watcher/tests/test_watcher_protocol.ps1
+++ b/utils/dasHerd/watcher/tests/test_watcher_protocol.ps1
@@ -234,6 +234,7 @@ $repoB = Join-Path $fixtureRoot 'repo-b'
 $agentWorktree = Join-Path $fixtureRoot 'repo-a-agent'
 $fakeBin = Join-Path $fixtureRoot 'fake-bin'
 $watcherSessions = Join-Path $logRoot 'sessions'
+$ptyhostRoot = Join-Path $logRoot 'ptyhosts'
 $watcherStdout = Join-Path $logRoot 'watcher.stdout.log'
 $watcherStderr = Join-Path $logRoot 'watcher.stderr.log'
 $script:harnessLog = Join-Path $logRoot 'harness.log'
@@ -265,7 +266,8 @@ try {
     $env:PATH = "$fakeBin;$oldPath"
     $watcherArgs = @('-jit', 'utils/dasHerd/watcher/main.das', '--',
         "--port=$port", "--token=$token", "--log-root=$watcherSessions",
-        "--config=$configPath", '--exit-after-ms=60000')
+        "--config=$configPath", "--ptyhost-root=$ptyhostRoot",
+        '--exit-after-ms=60000')
     $watcher = Start-Process -FilePath $DaslangPath -ArgumentList $watcherArgs `
         -WorkingDirectory $Root -WindowStyle Hidden -RedirectStandardOutput $watcherStdout `
         -RedirectStandardError $watcherStderr -PassThru
@@ -472,8 +474,12 @@ try {
         'client_attached', 'controller_claimed', 'controller_claim_rejected',
         'controller_released', 'client_detached', 'bundle_synced',
         'bundle_attention_created', 'bundle_attention_updated') 'agent session'
-    $rawOutput = [Text.Encoding]::UTF8.GetString(
-        (Read-SharedBytes (Join-Path $agentDir 'output.raw')))
+    # Herd-managed agent sessions run in a detached PTY host: the raw stream
+    # is the host journal, not a watcher-side output.raw.
+    $agentJournal = Join-Path $ptyhostRoot "$($agentLaunch.session_id).raw"
+    Assert-Protocol (Test-Path -LiteralPath $agentJournal) `
+        'agent session has no detached-host journal'
+    $rawOutput = [Text.Encoding]::UTF8.GetString((Read-SharedBytes $agentJournal))
     Assert-Protocol ($rawOutput -match [regex]::Escape($agentLaunch.session_id)) `
         'fake Codex did not receive the watcher-assigned session id'
     Assert-Protocol ($rawOutput -match 'fake-codex\|debug\|') `
@@ -491,11 +497,18 @@ try {
         $_.event -eq 'launched'
     } | Select-Object -First 1)
     $launchedPid = [regex]::Match(
-        [string]$launchedEvent[0].detail, '^pid=(\d+)$')
-    Assert-Protocol $launchedPid.Success 'launch event did not retain the root process id'
+        [string]$launchedEvent[0].detail, '^pid=(\d+); host_port=\d+$')
+    Assert-Protocol $launchedPid.Success `
+        'launch event did not retain the root process id and host port'
     $agentProcessTree = @(Get-ProcessTreeIds ([int]$launchedPid.Groups[1].Value))
     Assert-Protocol ($agentProcessTree.Count -gt 1) `
         'fake Codex did not have a descendant process for termination coverage'
+    # Detached hosting in effect: the session has a live host discovery stamp.
+    # (ParentProcessId still chains watcher->host->agent - breakaway detaches
+    # the JOB, not parentage - so a process-tree check cannot prove this.)
+    $agentStamp = Join-Path $ptyhostRoot "$($agentLaunch.session_id).host.json"
+    Assert-Protocol (Test-Path -LiteralPath $agentStamp) `
+        'agent session has no live host discovery stamp'
     Invoke-Json POST $baseUrl $token '/api/v1/terminate' @{
         session_id = $agentLaunch.session_id
     } | Out-Null
@@ -508,6 +521,16 @@ try {
     }
     Assert-Protocol ($remainingProcessTree.Count -eq 0) `
         "terminate left session process descendants running: $remainingProcessTree"
+    # After the exit folds back, the watcher releases the host and archives
+    # its discovery stamp - lingering hosts would leak between test runs.
+    $archivedStamp = Join-Path (Join-Path $ptyhostRoot 'archive') `
+        "$($agentLaunch.session_id).host.json"
+    for ($attempt = 0; $attempt -lt 150 -and
+            -not (Test-Path -LiteralPath $archivedStamp); $attempt++) {
+        Start-Sleep -Milliseconds 100
+    }
+    Assert-Protocol (Test-Path -LiteralPath $archivedStamp) `
+        'host stamp did not archive after terminate and drain'
 
     Set-TestStage 'launch-agent-in-existing-worktree'
     Send-WebSocketJson $ws1 @{
@@ -579,6 +602,26 @@ try {
     if ($null -ne $watcher -and -not $watcher.HasExited) {
         Stop-Process -Id $watcher.Id -Force
         [void]$watcher.WaitForExit(5000)
+    }
+    # Detached hosts survive the watcher by design; on failure paths the fold
+    # never ran, so shut lingering hosts down through their own protocol.
+    if (Test-Path -LiteralPath $ptyhostRoot) {
+        foreach ($stampFile in @(Get-ChildItem -LiteralPath $ptyhostRoot `
+                -Filter '*.host.json' -ErrorAction SilentlyContinue)) {
+            try {
+                $stamp = Get-Content -LiteralPath $stampFile.FullName -Raw |
+                    ConvertFrom-Json
+                $hostSocket = New-Object Net.WebSockets.ClientWebSocket
+                [void]($hostSocket.ConnectAsync(
+                    [uri]"ws://127.0.0.1:$($stamp.port)/",
+                    [Threading.CancellationToken]::None).GetAwaiter().GetResult())
+                Send-WebSocketJson $hostSocket @{
+                    op = 'hello'; token = [string]$stamp.token; protocol = 1
+                }
+                Send-WebSocketJson $hostSocket @{ op = 'shutdown' }
+                Close-WebSocket $hostSocket
+            } catch { }
+        }
     }
     if ($success) {
         Remove-Item -LiteralPath $fixtureRoot -Recurse -Force

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -635,6 +635,19 @@ def private host_stamp_path(session_id : string) : string {
     return path_join(g_ptyhost_dir, "{session_id}.host.json")
 }
 
+def private host_lock_path(session_id : string) : string {
+    return path_join(g_ptyhost_dir, "{session_id}.lock")
+}
+
+// The host holds its .lock open for its whole life; Windows CRT handles carry
+// no FILE_SHARE_DELETE, so remove() fails while the host lives and succeeds
+// the instant it dies - crash included. Removing a dead host's lock here is
+// the cleanup, not a side effect.
+def private host_lock_held(session_id : string) : bool {
+    let lock_path = host_lock_path(session_id)
+    return fexist(lock_path) && !remove(lock_path)
+}
+
 def private archive_host_files(var session : WatcherSession?) {
     // Once the journal is replicated into the watcher (ring + registry fold),
     // the stamp and journal move aside so the next adoption scan stays clean.
@@ -655,6 +668,15 @@ def private archive_host_files(var session : WatcherSession?) {
         if (rename(journal_path, archived_journal)) {
             session.output_path = archived_journal
         }
+    }
+    let log_path = path_join(g_ptyhost_dir, "{session.id}.log")
+    if (fexist(log_path)) {
+        let _ = rename(log_path, path_join(archive_dir, "{session.id}.log"))
+    }
+    // A crashed host leaves its lock file behind unlockable; sweep it.
+    let lock_path = host_lock_path(session.id)
+    if (fexist(lock_path)) {
+        let _ = remove(lock_path)
     }
 }
 
@@ -986,12 +1008,14 @@ def private adopt_host_session(stamp : WatcherHostStamp) : bool {
         numeric_id_suffix(slice(stamp.session, find(stamp.session, "_") + 1), ""))
     var inscope model <- terminal_create(columns, rows)
     session.terminal := model
-    // A lingering-but-alive host serves the replay itself; only an unreachable
-    // one falls back to reading the journal file directly.
+    // The lock probe answers dead-or-alive instantly and race-free; only a
+    // held lock is worth the connect handshake (whose timeout stays as the
+    // fallback for a host that is alive but wedged).
     let attach_from = max(0l, stamp.journal_bytes - int64(MAX_RAW_HISTORY_BYTES))
     var link = new WatcherHostLink(token = stamp.token, attach_from = attach_from)
     var adopted_live = false
-    if (link->init("ws://127.0.0.1:{stamp.port}/") == 0) {
+    if (host_lock_held(stamp.session)
+            && link->init("ws://127.0.0.1:{stamp.port}/") == 0) {
         let handshake_started = ref_time_ticks()
         while (!link.attached && !link.closed && empty(link.last_error)
                 && get_time_nsec(handshake_started) / 1000000l < HOST_ADOPT_HANDSHAKE_TIMEOUT_MS) {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -402,6 +402,24 @@ def private append_event(var session : WatcherSession?; event, detail : string) 
     fflush(session.events_file)
 }
 
+def public watcher_running_worktree_user(worktree_path : string) : string {
+    //! Display name of a RUNNING PTY session whose cwd/worktree is this path,
+    //! or "". Exited task sessions don't hold the tree.
+    let full = get_full_file_name(worktree_path)
+    let wanted = get_platform_name() == "windows" ? to_lower(full) : full
+    for (session in g_sessions) {
+        if (session == null || session.state != "running"
+                || empty(session.worktree_path)) continue
+        let candidate = get_full_file_name(session.worktree_path)
+        let canonical = (get_platform_name() == "windows"
+            ? to_lower(candidate) : candidate)
+        if (canonical == wanted) {
+            return empty(session.display_name) ? session.id : session.display_name
+        }
+    }
+    return ""
+}
+
 def public watcher_record_event(session_id, event, detail : string) : bool {
     let index = watcher_find_session(session_id)
     if (index < 0 || g_sessions[index] == null || empty(event)) return false

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -986,6 +986,12 @@ def private ensure_git_exclude(worktree_path, pattern : string;
 // launch. A hand-written file without our marker is never touched.
 def private ensure_agent_local_instructions(request : WatcherLaunchRequest const;
                                             var detail : string&) {
+    // A launch without a cwd would resolve the drop into the WATCHER's own
+    // working directory — skip rather than litter it.
+    if (empty(request.cwd)) {
+        detail += "; local_md=skipped_no_cwd"
+        return
+    }
     let local_path = path_join(request.cwd, "CLAUDE.local.md")
     let existing = fexist(local_path) ? fread(local_path) : ""
     if (!empty(existing) && find(existing, DASHERD_LOCAL_MARKER) < 0) {

--- a/utils/dasHerd/watcher/watcher_core.das
+++ b/utils/dasHerd/watcher/watcher_core.das
@@ -7,9 +7,12 @@ options indenting = 4
 module watcher_core shared public
 
 require terminal/terminal public
+require dashv/dashv_boost
 require daslib/fio public
 require daslib/json_boost public
 require daslib/strings_boost
+require daslib/base64
+require daslib/random
 require strings public
 require math
 
@@ -25,6 +28,17 @@ let private MAX_RAW_HISTORY_BYTES = 8 * 1024 * 1024
 let private RAW_HISTORY_TRIM_SLACK = 1024 * 1024
 let private WATCHER_GC_STRING_PRESSURE_BYTES = 64ul * 1024ul * 1024ul
 let private WATCHER_GC_HEAP_PRESSURE_BYTES = 128ul * 1024ul * 1024ul
+
+// Detached PTY hosts (PTY_HOST_DESIGN.md): durable herd sessions run their
+// ConPTY inside a dasherd-ptyhost process the watcher merely talks to.
+let private HOST_PROTOCOL_VERSION = 1
+let private HOST_PORT_BASE = 9700
+let private HOST_PORT_SPAN = 200
+let private HOST_PORT_ATTEMPTS = 8
+let private HOST_STAMP_TIMEOUT_MS = 10000l
+let private HOST_HANDSHAKE_TIMEOUT_MS = 10000l
+let private HOST_ADOPT_HANDSHAKE_TIMEOUT_MS = 3000l
+let private HOST_STAT_POLL_MS = 500l
 
 def public watcher_gc_reason(string_used, string_total,
                              heap_used, heap_total : uint64) : string {
@@ -278,6 +292,115 @@ struct public WatcherTerminalCheckpoint {
     rows : int
 }
 
+// Mirror of the dasherd-ptyhost discovery stamp (ptyhost/main.das HostStamp).
+struct private WatcherHostStamp {
+    version : int
+    session : string
+    port : int
+    token : string
+    child_pid : int
+    journal_bytes : int64
+    exited : bool
+    exit_code : int64 = -1l
+    drained : bool
+    error : string
+}
+
+struct private HostStatMessage {
+    @rename = "type" _type : string
+    child_pid : int
+    journal_bytes : int64
+    exited : bool
+    exit_code : int64 = -1l
+    drained : bool
+    error : string
+}
+
+class private WatcherHostLink : HvWebSocketClient {
+    token : string
+    attach_from : int64
+    authorized : bool
+    attach_sent : bool
+    attached : bool
+    closed : bool
+    stat_seen : bool
+    stat_child_pid : int
+    stat_journal_bytes : int64
+    stat_exited : bool
+    stat_exit_code : int64 = -1l
+    stat_drained : bool
+    last_error : string
+    received : array<uint8>
+    pending_ops : array<string>
+
+    def override onOpen {
+        send("\{\"op\":\"hello\",\"token\":{sprint_json(token, false)},\"protocol\":{HOST_PROTOCOL_VERSION}\}")
+    }
+
+    def override onClose {
+        closed = true
+    }
+
+    def override onMessage(msg : string#) {
+        var incoming = HostStatMessage()
+        if (!sscan_json(string(msg), incoming)) return
+        if (incoming._type == "stat") {
+            stat_seen = true
+            stat_child_pid = incoming.child_pid
+            stat_journal_bytes = incoming.journal_bytes
+            stat_exited = incoming.exited
+            stat_exit_code = incoming.exit_code
+            stat_drained = incoming.drained
+            if (!authorized) {
+                authorized = true
+                for (op in pending_ops) {
+                    send(op)
+                }
+                pending_ops |> clear()
+            }
+            if (!attach_sent) {
+                attach_sent = true
+                send("\{\"op\":\"attach\",\"from_byte\":{attach_from}\}")
+            }
+        } elif (incoming._type == "attached") {
+            attached = true
+        } elif (incoming._type == "error") {
+            last_error = incoming.error
+        }
+    }
+
+    def override onMessageFrame(msg : string#; byte_count : int; opcode : ws_opcode) {
+        if (opcode != ws_opcode.WS_OPCODE_BINARY) {
+            onMessage(msg)
+            return
+        }
+        if (byte_count <= 0) return
+        let offset = length(received)
+        received |> resize_no_init(offset + byte_count)
+        unsafe {
+            memcpy(addr(received[offset]), reinterpret<void?>(msg), byte_count)
+        }
+    }
+
+    def queue_or_send(op : string) : bool {
+        // Ops issued between connect and the hello acknowledgement queue and
+        // flush in order; the host rejects anything before authorization.
+        if (closed) return false
+        if (!authorized) {
+            pending_ops |> push(op)
+            return true
+        }
+        send(op)
+        return true
+    }
+
+    def operator delete {
+        delete received
+        delete pending_ops
+        delete super.self
+    }
+}
+
 class private WatcherSession {
     id : string
     command_line : string
@@ -325,6 +448,13 @@ class private WatcherSession {
     input_line_bytes : int
     input_escape_state : int
     pending_notifications : array<WatcherPendingNotification>
+    // Detached-host transport (null = classic in-process ConPTY session).
+    host : WatcherHostLink?
+    host_port : int
+    host_stamp_path : string
+    host_last_stat_ms : int64
+    host_shutdown_sent : bool
+    host_archived : bool
     def operator delete {
         if (output_file != null) {
             fflush(output_file)
@@ -345,6 +475,13 @@ class private WatcherSession {
             fflush(bundles_file)
             fclose(bundles_file)
             bundles_file = null
+        }
+        if (host != null) {
+            let _closed = host->close()
+            unsafe {
+                delete host
+            }
+            host = null
         }
         terminal_dispose(terminal)
         delete raw_history
@@ -375,6 +512,9 @@ var private g_next_mailbox_id = 0
 var private g_mailbox_revision : int64
 var private g_next_bundle_id = 0
 var private g_bundle_revision : int64
+var private g_ptyhost_dir : string
+var private g_ptyhost_prefix : array<string>
+var private g_host_port_cursor = 0
 
 def private elapsed_ms(session : WatcherSession?) : int64 {
     return get_time_nsec(session.started) / 1000000l
@@ -466,6 +606,455 @@ def public watcher_accepts_input(session_id : string) : bool {
         g_sessions[index].state == "running" && !g_sessions[index].drained)
 }
 
+def public watcher_configure_ptyhosts(ptyhost_dir : string;
+                                      launcher_prefix : array<string>) : string {
+    //! Enables launch-via-host for durable (herd) sessions. ``ptyhost_dir``
+    //! holds per-session journals and discovery stamps; ``launcher_prefix`` is
+    //! the host command (release bundle exe, or interpreter + script + "--").
+    //! Never configured = every launch stays a classic in-process ConPTY.
+    g_ptyhost_dir = ""
+    delete g_ptyhost_prefix
+    if (empty(ptyhost_dir)) return ""
+    var error : string
+    if (!mkdir_rec(ptyhost_dir, error)) return error
+    g_ptyhost_dir = ptyhost_dir
+    g_ptyhost_prefix := launcher_prefix
+    return ""
+}
+
+def private read_host_stamp(path : string; var stamp : WatcherHostStamp) : bool {
+    if (!fexist(path)) return false
+    return sscan_json(fread(path), stamp)
+}
+
+def private host_journal_path(session_id : string) : string {
+    return path_join(g_ptyhost_dir, "{session_id}.raw")
+}
+
+def private host_stamp_path(session_id : string) : string {
+    return path_join(g_ptyhost_dir, "{session_id}.host.json")
+}
+
+def private archive_host_files(var session : WatcherSession?) {
+    // Once the journal is replicated into the watcher (ring + registry fold),
+    // the stamp and journal move aside so the next adoption scan stays clean.
+    // Best-effort: a file the (dying) host still holds is picked up by the
+    // next watcher start instead.
+    if (session.host_archived) return
+    session.host_archived = true
+    let archive_dir = path_join(g_ptyhost_dir, "archive")
+    var mkdir_error : string
+    if (!mkdir_rec(archive_dir, mkdir_error)) return
+    let stamp_path = host_stamp_path(session.id)
+    if (fexist(stamp_path)) {
+        let _ = rename(stamp_path, path_join(archive_dir, "{session.id}.host.json"))
+    }
+    let journal_path = host_journal_path(session.id)
+    if (fexist(journal_path)) {
+        let archived_journal = path_join(archive_dir, "{session.id}.raw")
+        if (rename(journal_path, archived_journal)) {
+            session.output_path = archived_journal
+        }
+    }
+}
+
+def private session_process_exited(session : WatcherSession?) : bool {
+    return (session.host != null ? session.host.stat_exited
+        : terminal_process_exited(session.terminal))
+}
+
+def private session_exit_code(session : WatcherSession?) : int64 {
+    return (session.host != null ? session.host.stat_exit_code
+        : terminal_exit_code(session.terminal))
+}
+
+def private session_transport_error(session : WatcherSession?) : string {
+    if (session.host == null) return terminal_transport_error(session.terminal)
+    if (!empty(session.host.last_error)) return session.host.last_error
+    return session.host.closed ? "host connection lost" : ""
+}
+
+def private session_write_bytes_host(var session : WatcherSession?;
+                                     bytes : array<uint8> const) : bool {
+    if (empty(bytes)) return true
+    return session.host->queue_or_send(
+        "\{\"op\":\"input\",\"base64\":\"{base64_encode(bytes)}\"\}")
+}
+
+def private session_write_text(var session : WatcherSession?; text : string) : bool {
+    if (session.host == null) return terminal_write(session.terminal, text)
+    var inscope bytes : array<uint8>
+    let count = length(text)
+    if (count > 0) {
+        bytes |> resize_no_init(count)
+        peek_data(text) $(view) {
+            unsafe {
+                memcpy(addr(bytes[0]), addr(view[0]), count)
+            }
+        }
+    }
+    return session_write_bytes_host(session, bytes)
+}
+
+def private launch_session_host(var session : WatcherSession?;
+                                child_argv : array<string> const;
+                                cwd : string; columns, rows : int) : string {
+    var seed = random_seed(int(ref_time_ticks()))
+    let token = "{random_uint(seed)}-{random_uint(seed)}-{random_uint(seed)}-{random_uint(seed)}"
+    session.host_stamp_path = host_stamp_path(session.id)
+    var last_error = "no free ptyhost port"
+    for (attempt in range(HOST_PORT_ATTEMPTS)) {
+        let port = HOST_PORT_BASE + ((g_host_port_cursor + attempt) % HOST_PORT_SPAN)
+        if (fexist(session.host_stamp_path)) {
+            // A previous attempt's bind-failure stamp must not satisfy the
+            // wait loop below.
+            let _ = remove(session.host_stamp_path)
+        }
+        var inscope host_argv := g_ptyhost_prefix
+        host_argv |> reserve(length(host_argv) + 12 + length(child_argv) * 2)
+        host_argv |> push_from(["--session", session.id, "--port", "{port}",
+            "--journal", g_ptyhost_dir, "--cwd", cwd,
+            "--columns", "{columns}", "--rows", "{rows}"])
+        for (argument in child_argv) {
+            host_argv |> push("--child")
+            host_argv |> push(argument)
+        }
+        var spawn_pid = 0
+        var spawn_error = ""
+        let _spawned = spawn_detached(host_argv, "", ["DASHERD_HOST_TOKEN={token}"]) $(pid, launch_error) {
+            spawn_pid = pid
+            spawn_error := launch_error
+        }
+        if (spawn_pid == 0) return "could not spawn ptyhost: {spawn_error}"
+        if (!empty(spawn_error)) {
+            // Degraded breakaway: the host would die with the watcher's job -
+            // the exact guarantee this architecture exists to provide.
+            return "ptyhost spawn degraded: {spawn_error}"
+        }
+        var stamp = WatcherHostStamp()
+        var stamp_seen = false
+        let stamp_started = ref_time_ticks()
+        while (get_time_nsec(stamp_started) / 1000000l < HOST_STAMP_TIMEOUT_MS) {
+            if (read_host_stamp(session.host_stamp_path, stamp)) {
+                stamp_seen = true
+                break
+            }
+            sleep(5u)
+        }
+        if (!stamp_seen) return "ptyhost produced no discovery stamp"
+        if (!empty(stamp.error)) {
+            last_error = stamp.error
+            continue if (find(stamp.error, "could not bind") >= 0)
+            return stamp.error
+        }
+        var link = new WatcherHostLink(token = token, attach_from = 0l)
+        if (link->init("ws://127.0.0.1:{port}/") != 0) {
+            unsafe {
+                delete link
+            }
+            last_error = "could not connect to ptyhost on port {port}"
+            continue
+        }
+        let handshake_started = ref_time_ticks()
+        while (!link.attached && !link.closed && empty(link.last_error)
+                && get_time_nsec(handshake_started) / 1000000l < HOST_HANDSHAKE_TIMEOUT_MS) {
+            link->process_event_que()
+            sleep(2u)
+        }
+        if (!link.attached) {
+            let handshake_error = (!empty(link.last_error)
+                ? link.last_error : "ptyhost handshake timeout")
+            let _closed = link->close()
+            unsafe {
+                delete link
+            }
+            return handshake_error
+        }
+        g_host_port_cursor = (port - HOST_PORT_BASE + 1) % HOST_PORT_SPAN
+        session.host = link
+        session.host_port = port
+        session.pid = link.stat_child_pid
+        return ""
+    }
+    return last_error
+}
+
+def private pump_host_session(var session : WatcherSession?; now_ms : int64) {
+    var link = session.host
+    link->process_event_que()
+    if (!empty(link.received)) {
+        session.last_data_ms = now_ms
+        session.output_bytes += int64(length(link.received))
+        retain_raw_output(session, link.received)
+        if (session.output_file != null) {
+            let _ = fwrite(session.output_file, link.received)
+            fflush(session.output_file)
+        }
+        terminal_feed_bytes(session.terminal, link.received)
+        link.received |> clear()
+        // Parser auto-replies (DA / DSR / CPR) must still reach the child.
+        var inscope replies : array<array<uint8>>
+        terminal_drain_replies_bytes(session.terminal, replies)
+        for (reply in replies) {
+            let _ = session_write_bytes_host(session, reply)
+        }
+    }
+    if (session.pid == 0 && link.stat_child_pid != 0) {
+        session.pid = link.stat_child_pid
+        session.status_revision++
+    }
+    observe_exit(session, now_ms)
+    enforce_timeout(session, now_ms)
+    if (link.closed) {
+        if (!session.drained) {
+            // The host vanished mid-stream: that one session is lost (the
+            // failure matrix's "host dies" row), never the whole herd.
+            if (session.state == "running" || session.state == "terminating") {
+                session.state = "failed"
+                session.reason = "host_disconnected"
+                session.status_revision++
+                append_event(session, "transport_error", "host_disconnected")
+            }
+            finish_drain(session, "host_disconnected")
+        }
+        if (session.host_shutdown_sent) {
+            archive_host_files(session)
+        }
+        return
+    }
+    if (!session.drained && link.stat_seen
+            && session.output_bytes >= link.stat_journal_bytes) {
+        if (link.stat_drained) {
+            finish_drain(session, "host_drained")
+        } elif (session.exit_seen_ms >= 0l) {
+            // The host never observes pipe closure while it holds the HPCON,
+            // so the exit fold reuses the direct path's quiet interval.
+            let quiet_ms = (session.drain_quiet_ms > 0l
+                ? session.drain_quiet_ms : DEFAULT_DRAIN_QUIET_MS)
+            if (now_ms - session.last_data_ms >= quiet_ms) {
+                finish_drain(session, "quiet_interval")
+            }
+        }
+    }
+    if (session.drained && session.exit_seen_ms >= 0l && !session.host_shutdown_sent) {
+        // Journal fully replicated: release the host instead of letting it
+        // linger. The stamp archives once the host acknowledges by exiting.
+        session.host_shutdown_sent = true
+        link->send("\{\"op\":\"shutdown\"\}")
+        append_event(session, "host_released", "journal_bytes={session.output_bytes}")
+    }
+    if (!session.drained && link.authorized
+            && now_ms - session.host_last_stat_ms >= HOST_STAT_POLL_MS) {
+        session.host_last_stat_ms = now_ms
+        link->send("\{\"op\":\"stat\"\}")
+    }
+}
+
+def private numeric_id_suffix(value, prefix : string) : int {
+    if (!starts_with(value, prefix)) return 0
+    return to_int(slice(value, length(prefix)))
+}
+
+// Replays the session's persisted jsonl records after adoption so mailbox and
+// bundle state (and their global id counters) survive a watcher restart.
+def private restore_session_records(var session : WatcherSession?) {
+    if (fexist(session.events_path)) {
+        for (line in split(fread(session.events_path), "\n")) {
+            continue if (empty(strip(line)))
+            var event = WatcherEvent()
+            if (sscan_json(line, event)) {
+                session.event_sequence = max(session.event_sequence, event.sequence)
+            }
+        }
+    }
+    if (fexist(session.mailbox_path)) {
+        for (line in split(fread(session.mailbox_path), "\n")) {
+            continue if (empty(strip(line)))
+            var message = WatcherMailboxMessage()
+            continue if (!sscan_json(line, message))
+            g_next_mailbox_id = max(g_next_mailbox_id, numeric_id_suffix(message.id, "hf_"))
+            g_mailbox_revision = max(g_mailbox_revision, message.revision)
+            session.mailbox_revision = max(session.mailbox_revision, message.revision)
+            var found = -1
+            for (index in range(length(session.mailbox))) {
+                if (session.mailbox[index].id == message.id) {
+                    found = index
+                    break
+                }
+            }
+            if (found >= 0) {
+                session.mailbox[found] := message
+            } else {
+                session.mailbox |> emplace(message)
+            }
+        }
+    }
+    if (fexist(session.bundles_path)) {
+        for (line in split(fread(session.bundles_path), "\n")) {
+            continue if (empty(strip(line)))
+            var bundle = WatcherReviewBundle()
+            continue if (!sscan_json(line, bundle))
+            g_next_bundle_id = max(g_next_bundle_id, numeric_id_suffix(bundle.id, "rb_"))
+            g_bundle_revision = max(g_bundle_revision, bundle.revision)
+            session.bundles_revision = max(session.bundles_revision, bundle.revision)
+            var found = -1
+            for (index in range(length(session.bundles))) {
+                if (session.bundles[index].id == bundle.id) {
+                    found = index
+                    break
+                }
+            }
+            if (found >= 0) {
+                session.bundles[found] := bundle
+            } else {
+                session.bundles |> emplace(bundle)
+            }
+        }
+    }
+}
+
+// Loads the journal tail of a dead host into the replay ring and the screen
+// model. Returns the journal's total size (the session's final output_bytes).
+def private seed_ring_from_journal(var session : WatcherSession?) : int64 {
+    let journal = host_journal_path(session.id)
+    let journal_stat = stat(journal)
+    if (!journal_stat.is_valid) return 0l
+    let total = int64(journal_stat.size)
+    let from = max(0l, total - int64(MAX_RAW_HISTORY_BYTES))
+    session.raw_history_start = from
+    fopen(journal, "rb") $(reader) {
+        if (reader == null) return
+        var inscope chunk : array<uint8>
+        chunk |> resize(64 * 1024)
+        var skipped = 0l
+        while (skipped < from) {
+            let remaining = from - skipped
+            let want = int(remaining > int64(64 * 1024) ? int64(64 * 1024) : remaining)
+            if (want < length(chunk)) chunk |> resize(want)
+            let got = fread(reader, chunk)
+            if (got <= 0) break
+            skipped += int64(got)
+            if (length(chunk) < 64 * 1024) chunk |> resize(64 * 1024)
+        }
+        while (true) {
+            let got = fread(reader, chunk)
+            if (got <= 0) break
+            if (got < length(chunk)) chunk |> resize(got)
+            retain_raw_output(session, chunk)
+            if (length(chunk) < 64 * 1024) chunk |> resize(64 * 1024)
+        }
+    }
+    session.output_bytes = session.raw_history_start + int64(length(session.raw_history))
+    terminal_feed_bytes(session.terminal, session.raw_history)
+    return total
+}
+
+def private adopt_host_session(stamp : WatcherHostStamp) : bool {
+    let session_dir = path_join(g_log_root, stamp.session)
+    let request_path = path_join(session_dir, "session.json")
+    if (!fexist(request_path)) return false
+    var inscope persisted = WatcherLaunchRequest()
+    if (!sscan_json(fread(request_path), persisted)) return false
+    var visible_command = persisted.display_name
+    if (empty(visible_command)) {
+        visible_command = (!empty(persisted.command_line)
+            ? persisted.command_line : join(persisted.argv, " "))
+    }
+    let columns = clamp(persisted.columns > 0 ? persisted.columns : 120, 20, 400)
+    let rows = clamp(persisted.rows > 0 ? persisted.rows : 36, 5, 512)
+    var session = new WatcherSession(id = stamp.session,
+        command_line = visible_command, cwd = persisted.cwd,
+        display_name = persisted.display_name, kind = persisted.kind,
+        target_id = watcher_target_id_or_local(persisted.target_id),
+        repository_id = persisted.repository_id,
+        worktree_path = persisted.worktree_path, purpose = persisted.purpose,
+        task_context = persisted.task_context,
+        herd_session_id = persisted.herd_session_id,
+        session_dir = session_dir,
+        output_path = host_journal_path(stamp.session),
+        events_path = path_join(session_dir, "events.jsonl"),
+        mailbox_path = path_join(session_dir, "mailbox.jsonl"),
+        bundles_path = path_join(session_dir, "bundles.jsonl"),
+        started = ref_time_ticks(), timeout_ms = 0l, drain_quiet_ms = 0l)
+    session.context_path = path_join(session_dir, "context.md")
+    session.host_stamp_path = host_stamp_path(stamp.session)
+    session.events_file = fopen(session.events_path, "ab")
+    session.mailbox_file = fopen(session.mailbox_path, "ab")
+    session.bundles_file = fopen(session.bundles_path, "ab")
+    restore_session_records(session)
+    g_next_session_id = max(g_next_session_id,
+        numeric_id_suffix(slice(stamp.session, find(stamp.session, "_") + 1), ""))
+    var inscope model <- terminal_create(columns, rows)
+    session.terminal := model
+    // A lingering-but-alive host serves the replay itself; only an unreachable
+    // one falls back to reading the journal file directly.
+    let attach_from = max(0l, stamp.journal_bytes - int64(MAX_RAW_HISTORY_BYTES))
+    var link = new WatcherHostLink(token = stamp.token, attach_from = attach_from)
+    var adopted_live = false
+    if (link->init("ws://127.0.0.1:{stamp.port}/") == 0) {
+        let handshake_started = ref_time_ticks()
+        while (!link.attached && !link.closed && empty(link.last_error)
+                && get_time_nsec(handshake_started) / 1000000l < HOST_ADOPT_HANDSHAKE_TIMEOUT_MS) {
+            link->process_event_que()
+            sleep(2u)
+        }
+        adopted_live = link.attached
+    }
+    if (adopted_live) {
+        session.host = link
+        session.host_port = stamp.port
+        session.pid = link.stat_child_pid
+        session.output_bytes = attach_from
+        session.raw_history_start = attach_from
+        session.state = "running"
+        session.status_revision++
+        append_event(session, "session_adopted", ("live_host; port={stamp.port}; " +
+            "journal_bytes={stamp.journal_bytes}; from_byte={attach_from}"))
+    } else {
+        let _closed = link->close()
+        unsafe {
+            delete link
+        }
+        let journal_total = seed_ring_from_journal(session)
+        session.pid = stamp.child_pid
+        session.exit_code = stamp.exited ? stamp.exit_code : -1l
+        session.state = stamp.exited ? "exited" : "failed"
+        session.reason = stamp.exited ? "process_exited" : "host_lost"
+        session.exit_seen_ms = 0l
+        session.drained = true
+        session.status_revision++
+        append_event(session, "session_adopted", ("dead_host; exited={stamp.exited}; " +
+            "exit_code={stamp.exit_code}; journal_bytes={journal_total}"))
+        archive_host_files(session)
+    }
+    g_sessions |> push(session)
+    return true
+}
+
+def public watcher_adopt_hosts : int {
+    //! Scans ptyhost discovery stamps: sessions of live hosts resurrect as
+    //! RUNNING; dead hosts fold their recorded exit into an exited session
+    //! (replay served from the journal tail) and archive their files. Runs
+    //! before herd_init so registry records keep their running state. Returns
+    //! the number of sessions adopted.
+    if (empty(g_ptyhost_dir) || empty(g_log_root)) return 0
+    var inscope stamp_files : array<string>
+    dir(g_ptyhost_dir) $(name) {
+        if (ends_with(name, ".host.json")) {
+            stamp_files |> push(clone_string(name))
+        }
+    }
+    var adopted = 0
+    for (stamp_file in stamp_files) {
+        var stamp = WatcherHostStamp()
+        continue if (!read_host_stamp(path_join(g_ptyhost_dir, stamp_file), stamp)
+            || empty(stamp.session) || stamp.version != HOST_PROTOCOL_VERSION
+            || watcher_find_session(stamp.session) >= 0)
+        if (adopt_host_session(stamp)) adopted++
+    }
+    return adopted
+}
+
 def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult {
     if (empty(request.command_line) && empty(request.argv)) {
         return WatcherLaunchResult(error = "command_line or argv is required")
@@ -523,11 +1112,21 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
         started = ref_time_ticks(), timeout_ms = max(0l, request.timeout_ms),
         drain_quiet_ms = max(0l, request.drain_quiet_ms))
     session.context_path = path_join(session_dir, "context.md")
-    session.output_file = fopen(session.output_path, "wb")
+    // Durable herd sessions run in a detached ptyhost when one is configured;
+    // ephemeral plumbing (git captures, task terminals) stays in-process.
+    let host_backed = (!empty(request.herd_session_id)
+        && !empty(g_ptyhost_dir) && !empty(g_ptyhost_prefix)
+        && (watcher_kind_is_agent(request.kind) || !empty(request.argv)))
+    if (host_backed) {
+        // The host journal IS the raw output record - no duplicate local copy.
+        session.output_path = host_journal_path(session_id)
+    } else {
+        session.output_file = fopen(session.output_path, "wb")
+    }
     session.events_file = fopen(session.events_path, "wb")
     session.mailbox_file = fopen(session.mailbox_path, "wb")
     session.bundles_file = fopen(session.bundles_path, "wb")
-    if (session.output_file == null || session.events_file == null
+    if ((!host_backed && session.output_file == null) || session.events_file == null
             || session.mailbox_file == null || session.bundles_file == null) {
         unsafe { delete session }
         return WatcherLaunchResult(error = "could not open session logs")
@@ -554,32 +1153,54 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
     }
     append_event(session, "session_created", session_created_detail)
 
+    var inscope child_argv : array<string>
     if (watcher_kind_is_agent(request.kind)) {
         append_event(session, "agent_bootstrap_prepared",
             "context={session.context_path}; skill={request.agent_skill_path}; " +
             "task_bytes={length(request.task_context)}")
-        var inscope argv <- agent_launch_argv(request, session_id, session.context_path)
-        var inscope launched <- terminal_launch_argv(argv, request.cwd, columns, rows)
-        session.terminal := launched
-    } elif (!empty(request.argv)) {
-        var inscope launched <- terminal_launch_argv(request.argv, request.cwd, columns, rows)
-        session.terminal := launched
+        child_argv <- agent_launch_argv(request, session_id, session.context_path)
     } else {
-        var inscope launched <- terminal_launch(request.command_line, request.cwd, columns, rows)
-        session.terminal := launched
+        child_argv := request.argv
     }
-    if (terminal_process_id(session.terminal) == 0) {
-        session.state = "failed"
-        session.reason = terminal_transport_error(session.terminal)
-        if (empty(session.reason)) { session.reason = "terminal launch failed" }
-        session.drained = true
-        session.status_revision++
-        append_event(session, "launch_failed", session.reason)
+    if (host_backed) {
+        // The screen model lives here; the ConPTY lives in the host process.
+        var inscope model <- terminal_create(columns, rows)
+        session.terminal := model
+        let host_error = launch_session_host(session, child_argv, request.cwd,
+            columns, rows)
+        if (!empty(host_error)) {
+            session.state = "failed"
+            session.reason = host_error
+            session.drained = true
+            session.status_revision++
+            append_event(session, "launch_failed", session.reason)
+        } else {
+            session.state = "running"
+            session.status_revision++
+            append_event(session, "launched",
+                "pid={session.pid}; host_port={session.host_port}")
+        }
     } else {
-        session.pid = terminal_process_id(session.terminal)
-        session.state = "running"
-        session.status_revision++
-        append_event(session, "launched", "pid={terminal_process_id(session.terminal)}")
+        if (!empty(child_argv)) {
+            var inscope launched <- terminal_launch_argv(child_argv, request.cwd, columns, rows)
+            session.terminal := launched
+        } else {
+            var inscope launched <- terminal_launch(request.command_line, request.cwd, columns, rows)
+            session.terminal := launched
+        }
+        if (terminal_process_id(session.terminal) == 0) {
+            session.state = "failed"
+            session.reason = terminal_transport_error(session.terminal)
+            if (empty(session.reason)) { session.reason = "terminal launch failed" }
+            session.drained = true
+            session.status_revision++
+            append_event(session, "launch_failed", session.reason)
+        } else {
+            session.pid = terminal_process_id(session.terminal)
+            session.state = "running"
+            session.status_revision++
+            append_event(session, "launched", "pid={terminal_process_id(session.terminal)}")
+        }
     }
     g_sessions |> push(session)
     if (session.state == "failed") {
@@ -589,9 +1210,9 @@ def public watcher_launch(request : WatcherLaunchRequest) : WatcherLaunchResult 
 }
 
 def private observe_exit(var session : WatcherSession?; now_ms : int64) {
-    if (session.exit_seen_ms >= 0l || !terminal_process_exited(session.terminal)) return
+    if (session.exit_seen_ms >= 0l || !session_process_exited(session)) return
     session.exit_seen_ms = now_ms
-    session.exit_code = terminal_exit_code(session.terminal)
+    session.exit_code = session_exit_code(session)
     if (session.state != "failed") {
         session.state = "exited"
     }
@@ -628,6 +1249,10 @@ def public watcher_tick(maximum_bytes_per_session : int = 64 * 1024) {
     for (session in g_sessions) {
         if (session == null) continue
         let now_ms = elapsed_ms(session)
+        if (session.host != null) {
+            pump_host_session(session, now_ms)
+            continue
+        }
         if (session.drained) {
             // Pipe closure can race slightly ahead of the process handle. Keep
             // observing lifecycle/timeout state after output is fully drained.
@@ -943,7 +1568,10 @@ def public watcher_prune_completed_sessions(kind : string;
 def private input_session(var session : WatcherSession?; text : string; client_id : int) : string {
     if (session.controller_id != 0 && session.controller_id != client_id) return "controller lease is held by another client"
     if (session.state != "running" || session.drained) return "session is not running"
-    if (!terminal_write(session.terminal, text)) return terminal_transport_error(session.terminal)
+    if (!session_write_text(session, text)) {
+        let error = session_transport_error(session)
+        return empty(error) ? "input write failed" : error
+    }
     session.input_bytes += int64(length(text))
     return ""
 }
@@ -1117,7 +1745,7 @@ def private flush_pending_notifications(var session : WatcherSession?) {
     var delivered = 0
     while (delivered < length(session.pending_notifications)) {
         let pending & = unsafe(session.pending_notifications[delivered])
-        if (!terminal_write(session.terminal, pending.text)) break
+        if (!session_write_text(session, pending.text)) break
         session.input_bytes += int64(length(pending.text))
         if (!empty(pending.message_id)) {
             let _ = watcher_mailbox_set_notification(session.id, pending.message_id)
@@ -1509,6 +2137,10 @@ def public watcher_bundles_json(session_id : string) : string {
 def private resize_session(var session : WatcherSession?; columns, rows, client_id : int) : string {
     if (session.controller_id != 0 && session.controller_id != client_id) return "controller lease is held by another client"
     terminal_resize(session.terminal, clamp(columns, 20, 400), clamp(rows, 5, 512))
+    if (session.host != null) {
+        let _ = session.host->queue_or_send(("\{\"op\":\"resize\"," +
+            "\"columns\":{session.terminal.columns},\"rows\":{session.terminal.rows}\}"))
+    }
     append_event(session, "resized", "{session.terminal.columns}x{session.terminal.rows}")
     return ""
 }
@@ -1522,11 +2154,17 @@ def public watcher_resize(session_id : string; columns : int; rows : int;
 
 def private terminate_session(var session : WatcherSession?; detail : string) : string {
     if ((session.state != "running" && session.state != "terminating")
-            || terminal_process_exited(session.terminal)) return ""
+            || session_process_exited(session)) return ""
     session.reason = detail
     session.state = "terminating"
     session.status_revision++
-    if (!terminal_terminate(session.terminal)) return terminal_transport_error(session.terminal)
+    if (session.host != null) {
+        if (!session.host->queue_or_send("\{\"op\":\"terminate\",\"exit_code\":1\}")) {
+            return "host connection lost"
+        }
+    } elif (!terminal_terminate(session.terminal)) {
+        return terminal_transport_error(session.terminal)
+    }
     append_event(session, "terminate_requested", detail)
     return ""
 }
@@ -1609,7 +2247,15 @@ def public watcher_update_key(session_id : string) : string {
 def public watcher_shutdown(terminate_running : bool = false) {
     for (session in g_sessions) {
         if (session == null) continue
-        if (terminate_running && !terminal_process_exited(session.terminal)) {
+        if (session.host != null) {
+            // Default shutdown leaves hosts (and their children) running -
+            // that survival is the entire point of the detached architecture.
+            if (terminate_running && !session.host.closed) {
+                let _t = session.host->queue_or_send("\{\"op\":\"terminate\",\"exit_code\":1\}")
+                let _s = session.host->queue_or_send("\{\"op\":\"shutdown\"\}")
+                session.host->process_event_que()
+            }
+        } elif (terminate_running && !terminal_process_exited(session.terminal)) {
             let _ = terminal_terminate(session.terminal)
         }
         if (session.output_file != null) {

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -261,6 +261,24 @@ def private query_value(url, key : string) : string {
     return ""
 }
 
+def private query_value_raw(url, key : string) : string {
+    let query = find(url, "?")
+    if (query < 0) return ""
+    let wanted = key + "="
+    let url_length = length(url)
+    var position = query + 1
+    while (position < url_length) {
+        let amp = find(url, "&", position)
+        let end = amp < 0 ? url_length : amp
+        if (starts_with(slice(url, position, end), wanted)) {
+            return slice(url, position + length(wanted), end)
+        }
+        if (amp < 0) break
+        position = amp + 1
+    }
+    return ""
+}
+
 class DasHerdWatcherServer : HvWebServer {
     token : string
     agent_url : string
@@ -278,7 +296,13 @@ class DasHerdWatcherServer : HvWebServer {
     next_client_id : int
 
     def authorized(url : string) : bool {
-        return !empty(token) && query_value(url, "token") == token
+        if (empty(token)) return false
+        // The browser panel sends the token percent-ENCODED (URLSearchParams
+        // decodes, encodeURIComponent re-encodes); the native clients and the
+        // printed control URL splice it RAW. A token containing '%' or '+'
+        // satisfies only one spelling — accept both interpretations.
+        return (query_value(url, "token") == token
+            || query_value_raw(url, "token") == token)
     }
 
     def respond_error(var resp : HttpResponse?; status : http_status; message : string) : http_status {

--- a/utils/dasHerd/watcher/watcher_server.das
+++ b/utils/dasHerd/watcher/watcher_server.das
@@ -14,6 +14,7 @@ require ./repository_core.das public
 require ./herd_sessions.das public
 require ./file_inspection.das
 require daslib/json_boost
+require daslib/strings_boost
 require daslib/base64
 require strings
 
@@ -1597,6 +1598,78 @@ class DasHerdWatcherServer : HvWebServer {
                 send_error(channel, satellite_error)
                 return
             }
+            send_herd_sessions(client, true)
+        } elif (incoming.op == "worktree_delete") {
+            var reason : string
+            var detail : string
+            var ok = false
+            let herd_user = herd_worktree_user(incoming.worktree_path)
+            let running_user = (empty(herd_user)
+                ? watcher_running_worktree_user(incoming.worktree_path) : herd_user)
+            if (!empty(running_user)) {
+                reason = "in_use"
+                detail = "in use by session '{running_user}'"
+            } else {
+                ok = repository_remove_worktree(incoming.repository_id,
+                    incoming.worktree_path, reason, detail)
+            }
+            send(channel, "\{\"type\":\"worktree_delete_result\",\"ok\":{ok}," +
+                "\"reason\":{sprint_json(reason, false)}," +
+                "\"detail\":{sprint_json(detail, false)}," +
+                "\"repository_id\":{sprint_json(incoming.repository_id, false)}," +
+                "\"worktree_path\":{sprint_json(incoming.worktree_path, false)}\}",
+                ws_opcode.WS_OPCODE_TEXT, true)
+        } elif (incoming.op == "herd_delete") {
+            var inscope removed = HerdSession()
+            let delete_error = herd_delete(incoming.herd_session_id, removed)
+            if (!empty(delete_error)) {
+                send_error(channel, delete_error)
+                return
+            }
+            // The record is gone; now try each of its worktrees under the
+            // same guards as a direct worktree delete. Blocked ones stay on
+            // disk and are reported with the reason.
+            var inscope targets : array<tuple<string; string>>
+            if (!empty(removed.worktree_path)) {
+                targets |> push(removed.repository_id => removed.worktree_path)
+            }
+            for (entry in removed.satellites) {
+                if (!empty(entry.worktree_path)) {
+                    targets |> push(entry.repository_id => entry.worktree_path)
+                }
+            }
+            var inscope removed_parts : array<string>
+            var inscope kept_parts : array<string>
+            for (target in targets) {
+                var reason : string
+                var detail : string
+                var ok = false
+                let herd_user = herd_worktree_user(target._1)
+                let running_user = (empty(herd_user)
+                    ? watcher_running_worktree_user(target._1) : herd_user)
+                if (!empty(running_user)) {
+                    reason = "in_use"
+                    detail = "in use by session '{running_user}'"
+                } else {
+                    ok = repository_remove_worktree(target._0, target._1,
+                        reason, detail)
+                }
+                if (ok) {
+                    removed_parts |> push(sprint_json(target._1, false))
+                } else {
+                    kept_parts |> push("\{\"path\":{sprint_json(target._1, false)}"
+                        + ",\"repository_id\":{sprint_json(target._0, false)}"
+                        + ",\"reason\":{sprint_json(reason, false)}"
+                        + ",\"detail\":{sprint_json(detail, false)}\}")
+                }
+            }
+            let removed_list = join(removed_parts, ",")
+            let kept_list = join(kept_parts, ",")
+            send(channel, "\{\"type\":\"herd_delete_result\"," +
+                "\"herd_session_id\":{sprint_json(incoming.herd_session_id, false)}," +
+                "\"removed\":[{removed_list}],\"kept\":[{kept_list}]\}",
+                ws_opcode.WS_OPCODE_TEXT, true)
+            send_sessions(channel)
             send_herd_sessions(client, true)
         } elif (incoming.op == "attach") {
             if (watcher_find_session(incoming.session_id) < 0) {

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -643,7 +643,10 @@ static int run_lifecycle(const string & fn) {
         }
     }
 
-    // Shutdown
+    // Shutdown — the real one, not a reload teardown. The flag stays true from
+    // the last reload otherwise, and shutdown()-time checks like glfw_live's
+    // live_destroy_window skip their final cleanup.
+    if (dll_set_is_reload) dll_set_is_reload(false);
     if (ctx && fnShutdown) {
         ctx->evalWithCatch(fnShutdown, nullptr);
         if (auto ex = ctx->getException()) {


### PR DESCRIPTION
The dasHerd fix round + the detached PTY host arc + the goal round, landed as one branch per the settled sequencing (no intermediate PRs — this is the historical record). Companion PR: borisbat/dasImgui#235 (widget layer) — **merge that one first**; the dasHerd client here calls its new `icon_tinted` and mouse-forwarding surface, and extended_checks installs dasImgui from master.

## Detached PTY hosts — "a terminal that depends on nothing"

`utils/dasHerd/ptyhost/` (protocol v1, ships as a daspkg release bundle): a tiny detached process owns the ConPTY, kill-on-close job, child, and journal; the watcher is a WebSocket client of it. Durable herd sessions launch via hosts; watcher restart adopts them back as **running** (`watcher_adopt_hosts()` before `herd_init`), dead hosts fold their exit stamps into exited, replayable sessions. Liveness is a held lock file (`remove()` fails while the host lives — crash-proof); every host writes a `<session>.log` beside its journal. Design + field findings (ConPTY never signals pipe closure under a live HPCON; alt-screen + mouse-reporting root cause of "claude doesn't scroll"): `utils/dasHerd/PTY_HOST_DESIGN.md`.

Proven live twice on the real rig: the watcher died ungracefully with a live shell **and a live Claude Code** in detached hosts; the restart adopted both as running, the client reconnected, the adopted shell echoed input.

dasTerminal grows `spawn_detached` (CREATE_NO_WINDOW + job breakaway + env blocks), `terminal_launch_argv_env`, and `terminal_mouse_reporting_active` / `terminal_encode_mouse` (SGR/X10, unit-tested). `popen_argv`'s job gains `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (src/builtin/module_builtin_fio.cpp) so an explicit-breakaway descendant can outlive the kill-on-close subtree.

## Fix round + goal round (notes 1–49, HERDER_FIXROUND.md)

All 49 play-session notes fixed or verified, per-note forensics in the doc. Highlights: env-leak scrub (NO_COLOR / CLAUDE_CODE_* markers), path canonicalization, modal launcher, command pattern + editable shortcuts, per-window zoom, project file browser, token color language, destructive-action confirms, error ring, terminal focus at session creation (tabbing request falls through an InvisibleButton — focus now rides the terminal's own model and survives the checkpoint restore), mouse forwarding to alt-screen TUIs, panel-edge text eliding, herd-level card selection, dead-card dimming (alive-at-a-glance).

## Tests

- `test_ptyhost.das` — detached host survives its spawner, replays, rejects bad token/protocol/pre-auth ops, lock held-while-alive/released-on-exit, host log content.
- `test_watcher_adoption.das` — restart survival end-to-end (resurrect as running, replay continuity, input after adoption, stamp archiving), dead-host fold with corrupt-jsonl restore, host-death-under-live-watcher isolation, bind-collision port retry.
- Watcher suite 73/73; `terminal_semantics.das` gains the mouse-encoder block; protocol integration harness updated to the host-backed world (isolated ptyhost root, journal-based raw output, lingering-host cleanup).

## Docs riding along (design records, discussed in-session)

`utils/dasHerd/PTY_HOST_DESIGN.md` (architecture + landed decisions), `HERDER_FIXROUND.md` (per-note record), `BACKLOG.md` (plan of record), `AGENT_REVIEW_WORKFLOWS.md` (observer model: tool-driven arm/summon, signal hierarchy, reviewer-agent design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
