### PR TITLE
dasLLAMA: daspkg release manifest for lcpp_bench (dasllama-bench bundle)

### DIFF
--- a/modules/dasLLAMA/benchmarks/.das_package
+++ b/modules/dasLLAMA/benchmarks/.das_package
@@ -1,0 +1,15 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("dasllama-bench")
+    package_description("dasLLAMA llama-bench-protocol benchmark (lcpp_bench) as a standalone per-box exe")
+}
+
+[export]
+def release() {
+    release_main("lcpp_bench.das")
+    release_name("dasllama-bench")
+}


### PR DESCRIPTION
One additive file: `modules/dasLLAMA/benchmarks/.das_package`, making the llama-bench-protocol benchmark releasable as a self-contained bundle:

```
daspkg release --root modules/dasLLAMA/benchmarks
```

produces `dasllama-bench/` — the standalone exe, `dasModuleVulkan.shared_module`, both runtime DLLs, and the per-box tune sidecar. The recipient runs a full pp/tg row without daslang installed and without paying the per-process compiler start.

Measured on the 16GB 5060 Ti (Windows): a full pp512/tg128 5-rep row in **20.9s wall** — vs ~2 min per row under `-jit` (the ~103s compile per process) — with numbers matching the `-jit` recipe within noise (pp512 4306.32 ± 191.27 / tg128 77.94 ± 0.14 vs 4297.0 ± 130.2 / 77.77 ± 0.06) and all vulkan tier engagement lines present.

Intended first consumer: mac bench runs — build the bundle once per code change, then per-row cost is load + protocol only.

Known limitation until the vulkan-arc branch lands: a das panic inside a standalone exe exits nonzero without printing the exception (the guarded-main fix rides that branch). Dense-resident paths are validated; treat any silent nonzero exit as a panic and rerun under `-jit` for the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
