### PR TITLE
Fix nightly MinGW and UBSan failures

### DIFF
--- a/modules/dasTreeSitter/languages/cpp/scanner.c
+++ b/modules/dasTreeSitter/languages/cpp/scanner.c
@@ -94,7 +94,7 @@ static bool scan_raw_string_content(Scanner *scanner, TSLexer *lexer) {
     }
 }
 
-void *tree_sitter_cpp_external_scanner_create() {
+void *tree_sitter_cpp_external_scanner_create(void) {
     Scanner *scanner = (Scanner *)ts_calloc(1, sizeof(Scanner));
     memset(scanner, 0, sizeof(Scanner));
     return scanner;

--- a/modules/dasTreeSitter/languages/markdown_inline/scanner.c
+++ b/modules/dasTreeSitter/languages/markdown_inline/scanner.c
@@ -366,7 +366,7 @@ static bool scan(Scanner *s, TSLexer *lexer, const bool *valid_symbols) {
     return false;
 }
 
-void *tree_sitter_markdown_inline_external_scanner_create() {
+void *tree_sitter_markdown_inline_external_scanner_create(void) {
     Scanner *s = (Scanner *)malloc(sizeof(Scanner));
     deserialize(s, NULL, 0);
     return s;

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1663,7 +1663,7 @@ namespace das {
     void set_env_variable ( const char * var, const char * value, Context *, LineInfoArg * ) {
         // process-wide; children spawned via popen/popen_argv inherit it
         if ( !var || !*var ) return;
-#ifdef _MSC_VER
+#ifdef _WIN32
         _putenv_s(var, value ? value : "");
 #else
         setenv(var, value ? value : "", 1);


### PR DESCRIPTION
## Summary
- use the Windows CRT environment setter for all Windows toolchains, including MinGW
- give bundled C Tree-sitter scanner constructors strict `(void)` prototypes matching the runtime callback ABI

## Context
Fixes the MinGW compile error and Linux UBSan failure from nightly build 11863:
https://github.com/GaijinEntertainment/daScript/actions/runs/30233791631

## Testing
No full preflight; relying on PR CI.