### PR TITLE
fio: prefetch_map guard is _WIN32, not _MSC_VER (nightly mingw fix)

### DIFF
--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -2686,7 +2686,8 @@ bool das_prefetch_map ( void *, uint64_t ) { return false; }
 // Advisory: a false return means the OS declined — reads still work, just cold.
 bool das_prefetch_map ( void * base, uint64_t bytes ) {
     if ( !base || bytes==0 ) return false;
-#ifdef _MSC_VER
+#if defined(_WIN32)
+    // _WIN32, not _MSC_VER — clang-mingw is Windows too and has no madvise
     WIN32_MEMORY_RANGE_ENTRY range;
     range.VirtualAddress = base;
     range.NumberOfBytes = (SIZE_T) bytes;


### PR DESCRIPTION
The nightly build_windows_mingw broke on das_prefetch_map (#3586): the platform guard was `_MSC_VER`, so clang-mingw fell into the POSIX arm and hit undeclared `MADV_WILLNEED`. Flip to `_WIN32` — mingw-w64 declares `PrefetchVirtualMemory` (default `_WIN32_WINNT` ≥ 0x0603), and the dwrite section below already splits on `_WIN32`, which is why only prefetch broke.

Failed nightly: https://github.com/GaijinEntertainment/daScript/actions/runs/30418564199/job/90470318744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
