### PR TITLE
dasSpirv: lower a daslang enum to its underlying integer type

### DIFF
--- a/daslib/shader_block_layout.das
+++ b/daslib/shader_block_layout.das
@@ -24,6 +24,15 @@ def public matrix_info(t : TypeDecl?) : tuple<ok : bool; width : int; cols : int
     return (ok = false, width = 0, cols = 0)
 }
 
+// The base type a VALUE of this declaration carries: an enum has none of its own and lowers to the
+// OpTypeInt of its underlying integer, which the Type-keyed classifiers below cannot reach. A
+// 64-bit-based enum peels to tInt64/tUInt64, so arith_width_ok refuses it exactly like a bare one.
+def public value_base_type(t : TypeDecl?) : Type {
+    if (t == null) return Type.none
+    if (t.isEnum && t.enumType != null) return t.enumType.baseType
+    return t.baseType
+}
+
 // The whole 16/8-bit type set of the shader arc: the lattice proper (contiguous appended
 // block in the Type enum) PLUS the pre-lattice small scalars, which live in the enum's old
 // region (near tInt) and are NOT covered by the range check.

--- a/doc/source/reference/spirv.rst
+++ b/doc/source/reference/spirv.rst
@@ -245,6 +245,9 @@ Type and layout mapping
    * - ``bool``
      - ``OpTypeBool``
      - no physical interface-block layout
+   * - ``enum`` over an 8/16/32-bit int
+     - the ``OpTypeInt`` of that base type
+     - as that integer; not an interface-block member
    * - ``int2..4`` / ``float2..4`` …
      - ``OpTypeVector``
      - component-wise

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -638,7 +638,7 @@ def private tensor_object_type_of(var m : SpirvModule; t : TypeDecl?) : tuple<id
 def private is_emittable_value_type(t : TypeDecl?) : bool {
     if (t == null) return false
     if (matrix_info(t).ok) return true
-    let bt = t.baseType
+    let bt = value_base_type(t)
     if (bt == Type.tFixedArray && t.firstType != null) return is_emittable_value_type(t.firstType)
     // The 16/32-bit numerics and the 64-bit float carry a value; arith_width_ok is the one place that
     // line is drawn, so the value rail and the arithmetic rail never disagree. A 64-bit INT lowers as
@@ -2487,6 +2487,18 @@ def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : arra
     if (ci8 != null) return (ok = true, id = const_int8(m, int(ci8.value)))
     let cu8 = e ?as ExprConstUInt8
     if (cu8 != null) return (ok = true, id = const_uint8(m, uint(cu8.value)))
+    // An enum constant names its ENTRY; the integer behind it is that entry's own initializer, which
+    // already carries the enum's underlying type -- so re-entering here yields a constant of exactly
+    // the type emit_type lowered the enum to, without transcribing that width/signedness rule twice.
+    let cen = e ?as ExprConstEnumeration
+    if (cen != null) {
+        if (cen.enumType == null) return (ok = false, id = 0u)
+        for (ee in cen.enumType.list) {
+            if (ee.name == cen.value) return emit_const(m, ee.value, errors)
+        }
+        errors |> push("enum '{cen.enumType.name}' has no entry '{cen.value}'")
+        return (ok = false, id = 0u)
+    }
     // unary minus on a constant: depending on fold state `-0.6` can arrive as ExprOp1("-", const)
     // rather than a folded negative literal. Fold it here so both shapes produce the same constant.
     let neg = e ?as ExprOp1
@@ -3286,6 +3298,18 @@ class SpirvEmit : AstVisitor {
         e2id[intptr(expr)] = const_uint8(bm, uint(expr.value))
         return expr
     }
+    // An enum value is an integer constant of the enum's underlying type. The failure this reports is
+    // the 64-bit-based enum: its entry constant has no shader lowering, exactly as a bare int64 has none.
+    def override visitExprConstEnumeration(var expr : ExprConstEnumeration?) : ExpressionPtr {
+        var bm & = unsafe(*m)
+        let cr = emit_const(bm, expr, errs)
+        if (!cr.ok) {
+            errs |> push("unsupported enum constant '{expr.value}' ({expr._type.baseType})")
+            return expr
+        }
+        e2id[intptr(expr)] = cr.id
+        return expr
+    }
 
     // Folded vector constants (float2(0.5,0.5) etc. fold to ExprConstFloatN/IntN/UIntN at patch time)
     // are leaf rvalues with no scalar-style visit registration. emit_const already lowers each to an
@@ -3686,7 +3710,8 @@ class SpirvEmit : AstVisitor {
             }
             return expr
         }
-        let cls = arith_class(expr.left._type.baseType)
+        let lbt = value_base_type(expr.left._type)
+        let cls = arith_class(lbt)
         let l = value_of(expr.left)
         let r = value_of(expr.right)
         if (l == 0u || r == 0u) return expr
@@ -3706,7 +3731,7 @@ class SpirvEmit : AstVisitor {
             // component-wise compare op produces a bvecN — reduce it to the scalar with OpAll
             // (`==`: all lanes equal) / OpAny (`!=`: any lane differs), matching what glslang emits.
             // A scalar-bool-typed OpFOrdEqual on vector operands is invalid SPIR-V (drivers reject it).
-            let dn = arith_lanes(expr.left._type.baseType)
+            let dn = arith_lanes(lbt)
             if (dn > 1) {
                 let bvec = type_vector(bm, bt, dn)
                 let cmp = alloc_id(bm)
@@ -3763,7 +3788,7 @@ class SpirvEmit : AstVisitor {
             errs |> push("unsupported ternary operator '{expr.op}'")
             return expr
         }
-        let n = component_count(expr._type.baseType)
+        let n = component_count(value_base_type(expr._type))
         if (n == 0) {
             errs |> push("unsupported ternary result type {expr._type.baseType}")
             return expr
@@ -5275,7 +5300,7 @@ class SpirvEmit : AstVisitor {
         let dst = scalar_type_name_class(name)
         if (dst.cls >= 0 && length(expr.arguments) == 1) {
             let a0 = expr.arguments[0]
-            let sn = numeric_info(a0._type.baseType)
+            let sn = numeric_info(value_base_type(a0._type))
             if (!sn.ok || sn.lanes != 1) {
                 errs |> push("{name}: cannot convert from {a0._type.baseType} (numeric scalar only)")
                 return expr

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -2458,6 +2458,19 @@ def private ext_op_broadcasts_scalar(op : GLSLstd450) : bool {
         || op == GLSLstd450.Step   || op == GLSLstd450.SmoothStep)
 }
 
+// An enum constant names its ENTRY; the integer behind it is that entry's own initializer, which
+// already carries the enum's underlying type -- so re-entering emit_const yields a constant of
+// exactly the type emit_type lowered the enum to, without transcribing that width/signedness rule
+// twice.
+def private emit_const_enum(var m : SpirvModule; cen : ExprConstEnumeration?; var errors : array<string>) : tuple<ok : bool; id : uint> {
+    if (cen.enumType == null) return (ok = false, id = 0u)
+    for (ee in cen.enumType.list) {
+        if (ee.name == cen.value) return emit_const(m, ee.value, errors)
+    }
+    errors |> push("enum '{cen.enumType.name}' has no entry '{cen.value}'")
+    return (ok = false, id = 0u)
+}
+
 // ===== compile-time constants: scalars, all-const vector constructors, const arrays =====
 // Produces a deduped OpConstant / OpConstantComposite for a fully-constant expression. Used for
 // array literals (which must be constant initializers for now) and their constituents. ok=false =>
@@ -2487,18 +2500,8 @@ def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : arra
     if (ci8 != null) return (ok = true, id = const_int8(m, int(ci8.value)))
     let cu8 = e ?as ExprConstUInt8
     if (cu8 != null) return (ok = true, id = const_uint8(m, uint(cu8.value)))
-    // An enum constant names its ENTRY; the integer behind it is that entry's own initializer, which
-    // already carries the enum's underlying type -- so re-entering here yields a constant of exactly
-    // the type emit_type lowered the enum to, without transcribing that width/signedness rule twice.
     let cen = e ?as ExprConstEnumeration
-    if (cen != null) {
-        if (cen.enumType == null) return (ok = false, id = 0u)
-        for (ee in cen.enumType.list) {
-            if (ee.name == cen.value) return emit_const(m, ee.value, errors)
-        }
-        errors |> push("enum '{cen.enumType.name}' has no entry '{cen.value}'")
-        return (ok = false, id = 0u)
-    }
+    if (cen != null) return emit_const_enum(m, cen, errors)
     // unary minus on a constant: depending on fold state `-0.6` can arrive as ExprOp1("-", const)
     // rather than a folded negative literal. Fold it here so both shapes produce the same constant.
     let neg = e ?as ExprOp1

--- a/modules/dasSpirv/spirv/spirv_types.das
+++ b/modules/dasSpirv/spirv/spirv_types.das
@@ -27,7 +27,8 @@ def public emit_type(var m : SpirvModule; t : TypeDecl?) : uint {
     if (mi.ok) {
         return type_matrix(m, type_vector(m, type_float(m, 32u), mi.width), mi.cols)
     }
-    let bt = t.baseType
+    // an enum lowers as its own underlying integer, so it lands on that integer's branch below
+    let bt = value_base_type(t)
     if (bt == Type.tVoid) return type_void(m)
     if (bt == Type.tBool) return type_bool(m)
     if (bt == Type.tInt) return type_int(m, 32u, 1u)

--- a/tests/spirv/test_enum.das
+++ b/tests/spirv/test_enum.das
@@ -1,0 +1,184 @@
+options gen2
+options indenting = 4
+
+// An enum has no SPIR-V type of its own: it lowers to the OpTypeInt of the underlying integer it was
+// declared over, and every trace of the enum is gone by the time the words are written. So what this
+// pins is an ABSENCE as much as a presence -- the entry constant is an OpConstant of the plain
+// integer type carrying the entry's own VALUE (not its ordinal), the compare is a plain OpIEqual, and
+// `int(regime)` costs nothing at all, which is why the conversion opcodes are asserted to be absent
+// rather than counted.
+//
+// The uint8-based enum is here for the width/signedness half of that claim: it must land on
+// OpTypeInt 8 0, and its entry constant must be a constant OF THAT TYPE -- a 32-bit constant handed
+// to an 8-bit operand is exactly the mismatch spirv-val exists to catch.
+
+require dastest/testing_boost public
+require _spirv_common               // validate_spirv
+require spirv/spirv_shader          // [compute_shader] annotation
+require spirv/spirv_builtins public // gl_GlobalInvocationID
+require spirv/spirv_dis             // count_op, op_has_operand, op_has_operand_at
+require spirv/spirv_grammar         // SpvOp, SpvCapability
+
+// Non-contiguous values on purpose: an entry's value is what must reach the constant, and ordinals
+// would agree with it if they were 0,1,2.
+enum Regime {
+    dry = 3
+    humid = 7
+    frozen = 11
+}
+
+enum Flag : uint8 {
+    off = 0
+    on = 5
+}
+
+struct Cell {
+    regime : Regime
+    depth : int
+}
+
+var @ssbo @binding = 0 enum_data : array<int>
+
+def regime_weight(r : Regime) : int {
+    if (r == Regime.humid) return 2
+    return int(r)
+}
+
+// An enum-typed ternary is an OpSelect over the integer: the result type has to
+// peel to that integer or the lane count comes out zero and the select is refused.
+def regime_pick(hot : bool) : Regime {
+    return hot ? Regime.frozen : Regime.dry
+}
+
+// A `var` local of enum type -- a Function-storage OpVariable whose pointee is the plain integer.
+def cell_weight(c : Cell) : int {
+    var r = c.regime
+    if (r != Regime.dry) {
+        r = Regime.humid
+    }
+    return regime_weight(r) + c.depth
+}
+
+def cell_regime(c : Cell) : Regime {
+    return c.regime
+}
+
+[compute_shader(local_size_x=64, name="enum_spv"), marker(no_coverage)]
+def enum_shader {
+    let gi = gl_GlobalInvocationID.x
+    enum_data[gi] = regime_weight(regime_pick(enum_data[gi] > 0))
+}
+
+// The engine's target shape: a struct member typed by the enum itself rather than by an int.
+[compute_shader(local_size_x=64, name="enum_struct_spv"), marker(no_coverage)]
+def enum_struct_shader {
+    let gi = gl_GlobalInvocationID.x
+    let c = Cell(regime = Regime.humid, depth = enum_data[gi])
+    enum_data[gi] = cell_weight(c) + int(cell_regime(c))
+}
+
+def flag_on(f : Flag) : bool {
+    return f == Flag.on
+}
+
+[compute_shader(local_size_x=64, name="enum_u8_spv"), marker(no_coverage)]
+def enum_u8_shader {
+    let gi = gl_GlobalInvocationID.x
+    enum_data[gi] = flag_on(Flag.on) ? 1 : 0
+}
+
+// The id OpTypeInt <width> <signedness> declares (0 if absent). Operands are [result-id, width,
+// signedness], so the id sits at 0 -- which op_has_operand_pair, whose answer is a bool, cannot give.
+def private int_type_id(words : array<uint>; width, signedness : uint) : uint {
+    var id = 0u
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (opcode == uint(SpvOp.TypeInt) && n >= 3 && w[s + 1] == width && w[s + 2] == signedness) {
+            id = w[s]
+        }
+    }
+    return id
+}
+
+// Is there an OpConstant of `type_id` whose value is `value`? Operands are [result-type, result-id,
+// value], so both the type and the literal have to match on the same instruction.
+def private has_const_of_type(words : array<uint>; type_id, value : uint) : bool {
+    var found = false
+    foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+        if (opcode == uint(SpvOp.Constant) && n >= 3 && w[s] == type_id && w[s + 2] == value) {
+            found = true
+        }
+    }
+    return found
+}
+
+// No enum reaches SPIR-V as anything but its integer, so no width/class conversion may appear: these
+// fixtures index with the uint invocation id and convert nothing else, which is what makes a zero
+// count meaningful instead of merely small.
+def private check_no_converts(t : T?; words : array<uint>; what : string) {
+    t |> equal(count_op(words, SpvOp.SConvert), 0, "{what}: no OpSConvert")
+    t |> equal(count_op(words, SpvOp.UConvert), 0, "{what}: no OpUConvert")
+    t |> equal(count_op(words, SpvOp.Bitcast), 0, "{what}: no OpBitcast")
+}
+
+def private check_validates(t : T?; words : array<uint>; what : string) {
+    let r = validate_spirv(words)
+    if (r.ran) {
+        t |> success(r.ok, "{what}: spirv-val: {r.msg}")
+    } else {
+        feint("spirv-val not found locally; skipping (CI enforces)\n")
+    }
+}
+
+[test]
+def test_enum_value_rail(t : T?) {
+    t |> run("enum: lowers to its underlying int") <| @(t : T?) {
+        var words <- clone_to_move(enum_spv)
+        t |> equal(words[0], SPV_MAGIC)
+        let i32 = int_type_id(words, 32u, 1u)
+        t |> success(i32 != 0u, "declares OpTypeInt 32 1")
+        t |> success(has_const_of_type(words, i32, 11u), "Regime.frozen is the int constant 11")
+        t |> success(has_const_of_type(words, i32, 7u), "Regime.humid is the int constant 7")
+        t |> equal(count_op(words, SpvOp.IEqual), 1, "the enum compare is one OpIEqual")
+        t |> equal(count_op(words, SpvOp.Select), 1, "the enum ternary is one OpSelect")
+        check_no_converts(t, words, "enum")
+        check_validates(t, words, "enum")
+        delete words
+    }
+}
+
+[test]
+def test_enum_struct_member(t : T?) {
+    t |> run("enum: struct member, local and result") <| @(t : T?) {
+        var words <- clone_to_move(enum_struct_spv)
+        let i32 = int_type_id(words, 32u, 1u)
+        t |> success(i32 != 0u, "declares OpTypeInt 32 1")
+        // Cell is { Regime, int } — both members are the SAME int type id, so the struct carries no
+        // enum-shaped member and the host layout of an enum field is an int32's.
+        var cell_members_int = false
+        foreach_inst(words) $(opcode : uint; w : array<uint>; s, n : int) {
+            if (opcode == uint(SpvOp.TypeStruct) && n == 3 && w[s + 1] == i32 && w[s + 2] == i32) {
+                cell_members_int = true
+            }
+        }
+        t |> success(cell_members_int, "Cell lowers to OpTypeStruct \{ int, int \}")
+        t |> success(count_op(words, SpvOp.IEqual) + count_op(words, SpvOp.INotEqual) >= 2,
+            "both enum compares are integer compares")
+        check_no_converts(t, words, "enum struct")
+        check_validates(t, words, "enum struct")
+        delete words
+    }
+}
+
+[test]
+def test_enum_uint8(t : T?) {
+    t |> run("enum over uint8: lowers to OpTypeInt 8 0") <| @(t : T?) {
+        var words <- clone_to_move(enum_u8_spv)
+        t |> success(op_has_operand(words, SpvOp.Capability, uint(SpvCapability.Int8)),
+            "OpCapability Int8")
+        let u8 = int_type_id(words, 8u, 0u)
+        t |> success(u8 != 0u, "declares OpTypeInt 8 0")
+        t |> success(has_const_of_type(words, u8, 5u), "Flag.on is an 8-bit constant 5")
+        check_validates(t, words, "enum uint8")
+        delete words
+    }
+}


### PR DESCRIPTION
Lowers a daslang enum to the `OpTypeInt` of its underlying integer, so a shader
can use enum constants where it previously had to spell the raw integer.

- `emit_type` and the value/arith classifiers go through a new shared
  `value_base_type` rail (`daslib/shader_block_layout`), so an enum lands on its
  underlying integer's branch instead of falling off the `Type`-keyed switch.
- `ExprConstEnumeration` resolves to its entry's own initializer, which already
  carries the enum's underlying type — the width/signedness rule is not
  transcribed a second time.
- An enum-typed ternary lowers through `OpSelect`.
- A 64-bit-based enum fails closed, exactly as a bare `int64` does.

Tests: `tests/spirv/test_enum.das`. `tests/spirv` is 347/347.

Note on lint: `spirv_emit.das` and `spirv_types.das` already report 12 STYLE037
and 2 STYLE038 warnings on an untouched `master` checkout (STYLE037/038 landed
2026-07-29 and dasSpirv has not been swept). Nothing here adds one — the enum
lookup lives in its own helper, and the only movement is `emit_const` 76 -> 78,
the same +2 every sibling `?as` case in that dispatch costs.
