### PR TITLE
Serializer: functions referenced only from struct field initializers dangled after symbol removal

### DIFF
--- a/src/ast/ast_export.cpp
+++ b/src/ast/ast_export.cpp
@@ -7,6 +7,7 @@ namespace das {
 
     class ClearUnusedSymbols : public Visitor {
     public:
+        ClearUnusedSymbols ( Module * tm ) : thisModule(tm) {}
         virtual bool canVisitFunction ( Function * fun ) override {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
@@ -18,6 +19,27 @@ namespace das {
                 expr->func = nullptr;
             }
         }
+        // `WithInit()` in a struct field initializer infers to ExprMakeStruct, whose
+        // constructor ref is NOT an ExprCallFunc - left unnulled, removeUnusedSymbols frees
+        // the ctor while the surviving structure's field-init expression keeps the raw
+        // pointer, and AST serialization reads a dangling Function* (nondeterministic
+        // SIGSEGV in getMangledName under --ser)
+        virtual void preVisit(ExprMakeStruct * expr) override {
+            Visitor::preVisit(expr);
+            if ( expr->constructor && !expr->constructor->used && !expr->constructor->builtIn ) {
+                expr->constructor = nullptr;
+            }
+        }
+        // same dangling-pointer story for a global referenced only from a field initializer
+        // (`s : int = g_seed`). only this module's globals get freed (RemoveUnusedSymbols
+        // runs on thisModule alone), so cross-module refs - e.g. folded builtin constants
+        // like math::PI - stay untouched and keep their valid metadata
+        virtual void preVisit(ExprVar * expr) override {
+            Visitor::preVisit(expr);
+            if ( expr->variable && expr->variable->module == thisModule && !expr->variable->used ) {
+                expr->variable = nullptr;
+            }
+        }
         virtual void preVisitExpression(Expression * expr) override {
             Visitor::preVisitExpression(expr);
             if ( expr->rtti_isCallFunc() ) {
@@ -27,6 +49,8 @@ namespace das {
                 }
             }
         }
+    protected:
+        Module * thisModule = nullptr;
     };
 
     class MarkSymbolUse : public Visitor {
@@ -114,56 +138,6 @@ namespace das {
                 if ( fn->isClassMethod && fn->classParent->macroInterface ) continue;       // methods of macro interfaces
                 propagateFunctionUse(fn);
             }
-        }
-        // structure field initializers reference functions (typically generated ctors, e.g.
-        // `w : WithInit = WithInit()`) outside any function or global body, so the expression
-        // hooks above never record them. left unmarked, removeUnusedSymbols frees the function
-        // while the surviving structure's field-init expression keeps the raw pointer — and
-        // AST serialization then reads a dangling Function* (nondeterministic SIGSEGV in
-        // getMangledName). seed every such reference into the use-propagation.
-        void markStructureFieldInitFunctions ( ModuleLibrary & lib ) {
-            struct CollectFuncRefs : Visitor {
-                MarkSymbolUse * owner = nullptr;
-                virtual void preVisit ( ExprCall * call ) override {
-                    Visitor::preVisit(call);
-                    if ( call->func ) owner->propagateFunctionUse(call->func);
-                }
-                virtual void preVisit ( ExprMakeStruct * call ) override {
-                    Visitor::preVisit(call);
-                    if ( call->constructor ) owner->propagateFunctionUse(call->constructor);
-                }
-                virtual void preVisit ( ExprAddr * addr ) override {
-                    Visitor::preVisit(addr);
-                    if ( addr->func ) owner->propagateFunctionUse(addr->func);
-                }
-                virtual void preVisit ( ExprNew * enew ) override {
-                    Visitor::preVisit(enew);
-                    if ( enew->func ) owner->propagateFunctionUse(enew->func);
-                }
-                virtual void preVisit ( ExprOp1 * op ) override {
-                    Visitor::preVisit(op);
-                    if ( op->func ) owner->propagateFunctionUse(op->func);
-                }
-                virtual void preVisit ( ExprOp2 * op ) override {
-                    Visitor::preVisit(op);
-                    if ( op->func ) owner->propagateFunctionUse(op->func);
-                }
-                virtual void preVisit ( ExprOp3 * op ) override {
-                    Visitor::preVisit(op);
-                    if ( op->func ) owner->propagateFunctionUse(op->func);
-                }
-            };
-            CollectFuncRefs cvis;
-            cvis.owner = this;
-            lib.foreach([&](Module * pm) {
-                if ( pm->builtIn ) return true;
-                for ( auto & st : pm->structures.each() ) {
-                    for ( auto & fd : st->fields ) {
-                        if ( fd.init ) fd.init = fd.init->visit(cvis);
-                    }
-                }
-                return true;
-            }, "*");
         }
         void RemoveUnusedSymbols ( Module & mod ) {
             auto functions = das::move(mod.functions);
@@ -352,7 +326,6 @@ namespace das {
         MarkSymbolUse vis(false);
         vis.tw = logs;
         visit(vis);
-        vis.markStructureFieldInitFunctions(library);
         vis.markModuleUsedFunctions(library, thisModule.get());
         vis.markModuleVarsUsed(library, thisModule.get());
     }
@@ -363,7 +336,6 @@ namespace das {
         MarkSymbolUse vis(false);
         vis.tw = logs;
         visit(vis);
-        vis.markStructureFieldInitFunctions(library);
         vis.markUsedFunctions(library, false, true, thisModule.get());
         vis.markVarsUsed(library, false);
     }
@@ -373,7 +345,6 @@ namespace das {
         MarkSymbolUse vis(false);
         vis.tw = logs;
         visit(vis);
-        vis.markStructureFieldInitFunctions(library);
         vis.markUsedFunctions(library, false, false, nullptr);
         vis.markVarsUsed(library, false);
     }
@@ -393,14 +364,13 @@ namespace das {
         MarkSymbolUse vis(builtInSym);
         vis.tw = logs;
         visit(vis);
-        vis.markStructureFieldInitFunctions(library);
         vis.markUsedFunctions(library, forceAll, initThis, macroModule);
         vis.markVarsUsed(library, forceAll);
     }
 
     void Program::removeUnusedSymbols() {
         if ( options.getBoolOption("remove_unused_symbols",true) ) {
-            ClearUnusedSymbols cvis;
+            ClearUnusedSymbols cvis(thisModule.get());
             visit(cvis);
             MarkSymbolUse vis(false);
             vis.RemoveUnusedSymbols(*thisModule);

--- a/src/ast/ast_export.cpp
+++ b/src/ast/ast_export.cpp
@@ -115,6 +115,56 @@ namespace das {
                 propagateFunctionUse(fn);
             }
         }
+        // structure field initializers reference functions (typically generated ctors, e.g.
+        // `w : WithInit = WithInit()`) outside any function or global body, so the expression
+        // hooks above never record them. left unmarked, removeUnusedSymbols frees the function
+        // while the surviving structure's field-init expression keeps the raw pointer — and
+        // AST serialization then reads a dangling Function* (nondeterministic SIGSEGV in
+        // getMangledName). seed every such reference into the use-propagation.
+        void markStructureFieldInitFunctions ( ModuleLibrary & lib ) {
+            struct CollectFuncRefs : Visitor {
+                MarkSymbolUse * owner = nullptr;
+                virtual void preVisit ( ExprCall * call ) override {
+                    Visitor::preVisit(call);
+                    if ( call->func ) owner->propagateFunctionUse(call->func);
+                }
+                virtual void preVisit ( ExprMakeStruct * call ) override {
+                    Visitor::preVisit(call);
+                    if ( call->constructor ) owner->propagateFunctionUse(call->constructor);
+                }
+                virtual void preVisit ( ExprAddr * addr ) override {
+                    Visitor::preVisit(addr);
+                    if ( addr->func ) owner->propagateFunctionUse(addr->func);
+                }
+                virtual void preVisit ( ExprNew * enew ) override {
+                    Visitor::preVisit(enew);
+                    if ( enew->func ) owner->propagateFunctionUse(enew->func);
+                }
+                virtual void preVisit ( ExprOp1 * op ) override {
+                    Visitor::preVisit(op);
+                    if ( op->func ) owner->propagateFunctionUse(op->func);
+                }
+                virtual void preVisit ( ExprOp2 * op ) override {
+                    Visitor::preVisit(op);
+                    if ( op->func ) owner->propagateFunctionUse(op->func);
+                }
+                virtual void preVisit ( ExprOp3 * op ) override {
+                    Visitor::preVisit(op);
+                    if ( op->func ) owner->propagateFunctionUse(op->func);
+                }
+            };
+            CollectFuncRefs cvis;
+            cvis.owner = this;
+            lib.foreach([&](Module * pm) {
+                if ( pm->builtIn ) return true;
+                for ( auto & st : pm->structures.each() ) {
+                    for ( auto & fd : st->fields ) {
+                        if ( fd.init ) fd.init = fd.init->visit(cvis);
+                    }
+                }
+                return true;
+            }, "*");
+        }
         void RemoveUnusedSymbols ( Module & mod ) {
             auto functions = das::move(mod.functions);
             auto globals = das::move(mod.globals);
@@ -302,6 +352,7 @@ namespace das {
         MarkSymbolUse vis(false);
         vis.tw = logs;
         visit(vis);
+        vis.markStructureFieldInitFunctions(library);
         vis.markModuleUsedFunctions(library, thisModule.get());
         vis.markModuleVarsUsed(library, thisModule.get());
     }
@@ -312,6 +363,7 @@ namespace das {
         MarkSymbolUse vis(false);
         vis.tw = logs;
         visit(vis);
+        vis.markStructureFieldInitFunctions(library);
         vis.markUsedFunctions(library, false, true, thisModule.get());
         vis.markVarsUsed(library, false);
     }
@@ -321,6 +373,7 @@ namespace das {
         MarkSymbolUse vis(false);
         vis.tw = logs;
         visit(vis);
+        vis.markStructureFieldInitFunctions(library);
         vis.markUsedFunctions(library, false, false, nullptr);
         vis.markVarsUsed(library, false);
     }
@@ -340,6 +393,7 @@ namespace das {
         MarkSymbolUse vis(builtInSym);
         vis.tw = logs;
         visit(vis);
+        vis.markStructureFieldInitFunctions(library);
         vis.markUsedFunctions(library, forceAll, initThis, macroModule);
         vis.markVarsUsed(library, forceAll);
     }

--- a/src/ast/ast_lint.cpp
+++ b/src/ast/ast_lint.cpp
@@ -1284,6 +1284,12 @@ namespace das {
         "heap_size_limit",              Type::tInt,
         "string_heap_size_limit",       Type::tInt,
         "gc",                           Type::tBool,
+        // documented in options.rst and /*option*/-tagged in ast.h, but were never registered —
+        // 'options gc_infer_collect = false' died with error 50100
+        "gc_infer_collect",             Type::tBool,
+        "gc_infer_collect_nodes",       Type::tInt,
+        "gc_infer_collect_pct",         Type::tInt,
+        "log_gc_infer_collect",         Type::tBool,
     // coverage
         "no_coverage",                  Type::tBool,
     // aot

--- a/tests/language/serialize_field_init_ctor.das
+++ b/tests/language/serialize_field_init_ctor.das
@@ -1,0 +1,47 @@
+options gen2
+require dastest/testing_boost public
+
+// Regression pin for the AST-serializer dangling-Function crash: a ctor referenced ONLY
+// from a struct field initializer (`w : WithInit = WithInit()`) was never marked used -
+// MarkSymbolUse records function refs solely under a function/global context - so
+// removeUnusedSymbols freed it while the surviving structure's field-init expression kept
+// the raw pointer, and dastest's --ser sweep read a dangling Function* in getMangledName
+// (nondeterministic SIGSEGV, all three extended_checks CI lanes). The structs below stay
+// deliberately UNUSED by any function so the ctors' only anchor is the field init; the CI
+// serialization sweep over tests/ is what exercises the pin.
+
+struct PlainPod {
+    a : int
+    b : float
+}
+
+struct WithInit {
+    x : int = 7
+}
+
+struct Nested {
+    p : PlainPod
+    w : WithInit = WithInit()
+}
+
+[safe_when_uninitialized]
+struct OptedOut {
+    x : int = 7
+}
+
+variant PodVariant {
+    i : int
+    f : float
+}
+
+variant InitVariant {
+    i : int
+    w : WithInit
+}
+
+[test]
+def test_field_init_ctor_survives_marking(t : T?) {
+    t |> run("the structs above exist and stay otherwise unused") @(t : T?) {
+        t |> success(true, "the pin is the file itself under the --ser sweep")
+    }
+}

--- a/tests/language/serialize_field_init_ctor.das
+++ b/tests/language/serialize_field_init_ctor.das
@@ -1,14 +1,15 @@
 options gen2
 require dastest/testing_boost public
+require math
 
-// Regression pin for the AST-serializer dangling-Function crash: a ctor referenced ONLY
-// from a struct field initializer (`w : WithInit = WithInit()`) was never marked used -
-// MarkSymbolUse records function refs solely under a function/global context - so
-// removeUnusedSymbols freed it while the surviving structure's field-init expression kept
-// the raw pointer, and dastest's --ser sweep read a dangling Function* in getMangledName
-// (nondeterministic SIGSEGV, all three extended_checks CI lanes). The structs below stay
-// deliberately UNUSED by any function so the ctors' only anchor is the field init; the CI
-// serialization sweep over tests/ is what exercises the pin.
+// Regression pin for the AST-serializer dangling-symbol crash: a ctor (or global) referenced
+// ONLY from a struct field initializer (`w : WithInit = WithInit()`) gets freed by
+// removeUnusedSymbols while the surviving structure's field-init expression keeps the raw
+// pointer - ClearUnusedSymbols nulls dangling refs in field inits but missed
+// ExprMakeStruct.constructor and ExprVar.variable, so dastest's --ser sweep read a dangling
+// Function*/Variable* (nondeterministic SIGSEGV, all three extended_checks CI lanes). The
+// structs below stay deliberately UNUSED by any function so the symbols' only anchor is the
+// field init; the CI serialization sweep over tests/ is what exercises the pin.
 
 struct PlainPod {
     a : int
@@ -27,6 +28,19 @@ struct Nested {
 [safe_when_uninitialized]
 struct OptedOut {
     x : int = 7
+}
+
+// mutable so const folding can't erase the ExprVar - the global's only anchor is the field init
+var g_seed = 13
+
+struct UsesGlobal {
+    s : int = g_seed
+}
+
+// builtin-module global (folded addConstant, index=-2): builtin modules are never pruned, so
+// the cleaner must LEAVE this ref alone (only thisModule's freed globals get nulled)
+struct UsesBuiltinGlobal {
+    p : float = PI
 }
 
 variant PodVariant {


### PR DESCRIPTION
Fixes a pre-existing, nondeterministic SIGSEGV in AST serialization that took down all three `extended_checks` lanes on #3602 — whose new test files were merely the first in-tree content to trip it.

## The bug

A symbol referenced ONLY from a struct field initializer dangles after `removeUnusedSymbols`:

```das
struct WithInit { x : int = 7 }
struct Nested   { w : WithInit = WithInit() }   // ctor ref lives in the field init
var g_seed = 13
struct UsesGlobal { s : int = g_seed }          // global ref lives in the field init
```

`ClearUnusedSymbols` already visits struct field initializers and nulls refs to about-to-be-freed functions — but only through the `ExprCallFunc` and `ExprAddr` hooks. `WithInit()` infers to **`ExprMakeStruct`**, whose `constructor` ref is neither, and **`ExprVar::variable`** was never nulled at all. `removeUnusedSymbols` then frees the ctor/global while the surviving structure's field-init expression keeps the raw pointer — and serialization (`dastest --ser`, the extended_checks step) reads a dangling `Function*`/`Variable*`. Whether it segfaults or silently writes garbage depends on what reuses the freed block: on pure master the four-struct repro crashes 4 of 6 runs, and runs 6 of 6 clean the moment the ctor is used anywhere else.

## The fix

Extend `ClearUnusedSymbols` with the two missing hooks:

- `ExprMakeStruct::constructor` → nulled when the ctor is unused (same `!used && !builtIn` rule as the existing function hooks)
- `ExprVar::variable` → nulled when the variable is **this module's** and unused — only `thisModule`'s globals get freed, so cross-module refs (e.g. the folded builtin constant `math::PI`, which legitimately keeps `index=-2` and no runtime slot) keep their valid metadata

The serializer already handles both nulls (`serializePointer` writes a null id; `ExprVar` has an explicit null-variable path), so serialization becomes deterministic instead of use-after-free.

An earlier revision of this PR instead marked field-init-referenced symbols as *used* (keeping them alive). That over-marks: every class's methods live in field inits as vtable pointers, so macro classes (e.g. regex_boost's reader macro) got dragged into non-rtti executable programs — `error[50503]` in the darwin `Run utils tests` step — and marking a folded builtin constant used would assign it a runtime slot, breaking the documented `index<0` const-init fallback in simulate. Nulling in the cleaner is the architecture the code already had; this just completes it.

The repro ships as `tests/language/serialize_field_init_ctor.das` — deliberately-unused structs whose ctors'/globals' only anchor is the field init, plus the builtin-constant case the cleaner must leave alone; CI's serialization sweep over `tests/` is the pin.

## Verification

- Repro: 0 crashes in 10 runs, for both the ctor and the global variant (was 4–6 in 6–10 on the same box).
- `utils/mcp` `list_module_api` on `daslib/regex_boost`: green (the darwin failure mode, reproduced and fixed locally).
- `tests/daslib/eval_single_expression_test.das` (the `PI` index=-2 fallback pin): green.
- Clean full `--ser` sweep over `tests/`; full `--deser` round-trip executing the deserialized programs.
- Full interpreter suite: 12010 passed, 0 failed.

## Rides along

Registers `gc_infer_collect` / `gc_infer_collect_nodes` / `gc_infer_collect_pct` / `log_gc_infer_collect` in the option table. They are documented in `options.rst` and read per-file with policy fallback, but `options gc_infer_collect = false` died with `error 50100: invalid option`.

#3602 rebases onto this once merged.
