### PR TITLE
Nightly fixes: macOS chord double swap + AOT fixture registration

### DIFF
--- a/examples/text/main.das
+++ b/examples/text/main.das
@@ -925,8 +925,8 @@ def private handle_document_shortcuts(doc : TextViewerDocument const) {
     let io & = unsafe(GetIO())
     command_poll_scope(g_commands, CommandScope.document, "{doc.id}")
     command_poll_scope(g_commands, CommandScope.component, "{doc.id}")
-    let command_down = io.ConfigMacOSXBehaviors ? io.KeySuper : io.KeyCtrl
-    if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && command_down) {
+    // io.KeyCtrl is logical — ImGui maps Cmd onto it under ConfigMacOSXBehaviors.
+    if (IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) && io.KeyCtrl) {
         if (io.MouseWheel > 0.0f) {
             let _ = command_invoke(g_commands, CMD_VIEW_ZOOM_IN,
                                    CommandSource.programmatic, "{doc.id}")

--- a/modules/dasImgui/commands/imgui_commands.das
+++ b/modules/dasImgui/commands/imgui_commands.das
@@ -189,24 +189,13 @@ def public command_take(var registry : CommandRegistry;
     return true
 }
 
-def private command_uses_macos_behaviors() : bool {
-    if (GetCurrentContext() != null) {
-        return GetIO().ConfigMacOSXBehaviors
-    }
-    return get_platform_name() == "darwin"
-}
-
 def private make_chord(key : int; primary, shift, alt, secondary : bool) : int {
+    // Chords are LOGICAL (primary = Ctrl bit, secondary = Super bit): ImGui's ConfigMacOSXBehaviors swap in AddKeyEvent already maps Cmd onto logical Ctrl — swapping here too double-swaps and no primary chord ever fires on macOS.
     var chord = key
-    let macos = command_uses_macos_behaviors()
-    if (primary) {
-        chord = chord | (macos ? COMMAND_MOD_SUPER : COMMAND_MOD_CTRL)
-    }
+    if (primary) { chord = chord | COMMAND_MOD_CTRL }
     if (shift) { chord = chord | COMMAND_MOD_SHIFT }
     if (alt) { chord = chord | COMMAND_MOD_ALT }
-    if (secondary) {
-        chord = chord | (macos ? COMMAND_MOD_CTRL : COMMAND_MOD_SUPER)
-    }
+    if (secondary) { chord = chord | COMMAND_MOD_SUPER }
     return chord
 }
 
@@ -505,8 +494,10 @@ def public command_capture_tick(var registry : CommandRegistry) {
         if (empty(name) || name == "None" || name == "Unknown"
                 || starts_with(name, "Mod") || starts_with(name, "Mouse")
                 || starts_with(name, "Gamepad") || !IsKeyPressed(key, false)) continue
-        let primary_down = io.ConfigMacOSXBehaviors ? io.KeySuper : io.KeyCtrl
-        let secondary_down = io.ConfigMacOSXBehaviors ? io.KeyCtrl : io.KeySuper
+        // io.KeyCtrl/io.KeySuper are already logical (ImGui swaps Cmd onto
+        // KeyCtrl under ConfigMacOSXBehaviors), matching make_chord's bits.
+        let primary_down = io.KeyCtrl
+        let secondary_down = io.KeySuper
         let id = registry.capture_command_id
         let scope = registry.definitions[definition].scope
         let alt_capture = registry.capture_alt

--- a/modules/dasImgui/commands/imgui_commands.das
+++ b/modules/dasImgui/commands/imgui_commands.das
@@ -599,9 +599,6 @@ def public command_bindings_editor(var registry : CommandRegistry;
 }
 
 def public command_registry_dispose(var registry : CommandRegistry) {
-    delete registry.definitions
-    delete registry.default_bindings
-    delete registry.bindings
-    delete registry.invocations
-    registry = CommandRegistry()
+    // delete finalizes every container and zeroes the value - exactly default<CommandRegistry>
+    delete registry
 }

--- a/modules/dasImgui/examples/features/macos_chords.das
+++ b/modules/dasImgui/examples/features/macos_chords.das
@@ -1,0 +1,117 @@
+options gen2
+options _comment_hygiene = true
+options gc
+
+require imgui/imgui_harness
+require imgui/imgui_commands
+require daslib/json public
+require daslib/json_boost public
+require live/live_commands
+
+// =============================================================================
+// FEATURE: macos_chords — the command registry under the macOS input model.
+// SHOWS:   io.ConfigMacOSXBehaviors forced ON so every platform exercises the
+//          Mac path: ImGui swaps Ctrl<->Super inside AddKeyEvent, bindings stay
+//          declared in logical Ctrl-speak, and Shortcut() matching still fires.
+// DRIVE:   curl -X POST -d '{"name":"imgui_key_chord","args":{"mods":["Ctrl"],"key":"K"}}' \
+//              localhost:9090/command
+//          curl -X POST -d '{"name":"macos_chords_state"}' localhost:9090/command
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/macos_chords.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/macos_chords.das -- --headless --headless-frames=60
+// =============================================================================
+
+var private g_commands = CommandRegistry()
+var private g_primary_fired = 0
+var private g_secondary_fired = 0
+
+[export]
+def init() {
+    harness_init("macos chords probe", 720, 320)
+    // Force the macOS input model regardless of host OS: ImGui swaps
+    // Ctrl<->Super inside AddKeyEvent when this is on, same as a real Mac.
+    var io & = unsafe(GetIO())
+    io.ConfigMacOSXBehaviors = true
+    command_define(g_commands, CommandDefinition(
+        id = "probe.primary", title = "Primary chord probe", category = "Probe"),
+        command_binding("probe.primary", ImGuiKey.K, primary = true))
+    command_define(g_commands, CommandDefinition(
+        id = "probe.secondary", title = "Secondary chord probe", category = "Probe"),
+        command_binding("probe.secondary", ImGuiKey.J, secondary = true))
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    command_begin_frame(g_commands)
+    SetNextWindowPos(ImVec2(40.0, 40.0), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(640.0, 240.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "macOS chord probe", closable = false,
+                      flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove)) {
+        command_poll_scope(g_commands, CommandScope.application)
+        command_capture_tick(g_commands)
+        var invocation = CommandInvocation()
+        while (command_take(g_commands, invocation)) {
+            if (invocation.command_id == "probe.primary") {
+                g_primary_fired++
+            } elif (invocation.command_id == "probe.secondary") {
+                g_secondary_fired++
+            }
+        }
+        text("Cmd+K fires the primary probe, Ctrl+J the secondary one.")
+        text("primary fired: {g_primary_fired}")
+        text("secondary fired: {g_secondary_fired}")
+    }
+    harness_end_frame()
+}
+
+def private binding_of(id : string) : CommandBinding {
+    for (binding in g_commands.bindings) {
+        if (binding.command_id == id) return binding
+    }
+    return CommandBinding()
+}
+
+[live_command(description = "Chord ints, fire counters, io modifiers and the probe.primary binding under forced macOS behaviors.")]
+def macos_chords_state(_input : JsonValue?) : JsonValue? {
+    let io & = unsafe(GetIO())
+    let primary = binding_of("probe.primary")
+    let secondary = binding_of("probe.secondary")
+    return JV((
+        ok = true,
+        macos_behaviors = io.ConfigMacOSXBehaviors,
+        key_ctrl = io.KeyCtrl,
+        key_super = io.KeySuper,
+        primary_fired = g_primary_fired,
+        secondary_fired = g_secondary_fired,
+        primary_chord = command_binding_chord(primary),
+        secondary_chord = command_binding_chord(secondary),
+        primary_text = command_binding_text(primary),
+        primary_key = primary.key,
+        primary_is_primary = primary.primary,
+        primary_is_secondary = primary.secondary,
+        capture_armed = !empty(g_commands.capture_command_id)))
+}
+
+[live_command(description = "Arm binding capture on probe.primary — the next non-modifier key press rebinds it.")]
+def macos_chords_arm_capture(_input : JsonValue?) : JsonValue? {
+    g_commands.capture_command_id = "probe.primary"
+    g_commands.capture_alt = false
+    return JV((ok = true))
+}
+
+[export]
+def shutdown() {
+    command_registry_dispose(g_commands)
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+        harness_maybe_collect_gc()
+    }
+    shutdown()
+}

--- a/modules/dasImgui/examples/features/markdown_viewer.das
+++ b/modules/dasImgui/examples/features/markdown_viewer.das
@@ -102,7 +102,8 @@ def private bind_demo_image(width, height : float;
 def markdown_probe_state(_input : JsonValue?) : JsonValue? { // nolint:STYLE038
     let s = g_last_selection
     let io & = unsafe(GetIO())
-    let copy_modifier_down = io.ConfigMacOSXBehaviors ? io.KeySuper : io.KeyCtrl
+    // io.KeyCtrl is logical — ImGui maps Cmd onto it under ConfigMacOSXBehaviors.
+    let copy_modifier_down = io.KeyCtrl
     return JV((
         ok = g_doc.ok,
         render_revision = g_view.render_revision,

--- a/modules/dasImgui/examples/features/markdown_viewer.das
+++ b/modules/dasImgui/examples/features/markdown_viewer.das
@@ -413,7 +413,8 @@ print("{greeting}\n")
 
 Entities decode for display while retaining source bytes: &amp; &copy; &#x1f680;.
 %%
-    g_doc <- md_parse(source)
+    delete g_doc
+    g_doc <- md_parse(source)  // nolint:PERF030 - target deleted on the previous line; the lint mirrors the compiler rewrite, not statement context
     if (!g_doc.ok) {
         g_status = g_doc.error
     }

--- a/modules/dasImgui/tests/test_commands.das
+++ b/modules/dasImgui/tests/test_commands.das
@@ -27,8 +27,10 @@ def test_command_invocation_is_input_source_agnostic(t : T?) {
 }
 
 [test]
-def test_command_primary_modifier_follows_platform_policy(t : T?) {
-    let macos = get_platform_name() == "darwin"
+def test_command_chords_speak_logical_ctrl(t : T?) {
+    // Chords are logical on every platform: primary is the Ctrl bit, secondary
+    // the Super bit. ImGui's ConfigMacOSXBehaviors swap inside AddKeyEvent owns
+    // the Cmd mapping — a registry-side swap would double-swap on macOS.
     let key = int(ImGuiKey.C)
     let ctrl = 1 << 12
     let shift = 1 << 13
@@ -40,11 +42,11 @@ def test_command_primary_modifier_follows_platform_policy(t : T?) {
                                     secondary = true)
 
     t |> equal(command_binding_chord(primary),
-               key | (macos ? super : ctrl) | shift | alt,
-               "primary follows the current platform modifier policy")
+               key | ctrl | shift | alt,
+               "primary is the logical Ctrl bit on every platform")
     t |> equal(command_binding_chord(secondary),
-               key | (macos ? ctrl : super),
-               "secondary uses the complementary platform modifier")
+               key | super,
+               "secondary is the logical Super bit on every platform")
 }
 
 [test]

--- a/modules/dasImgui/tests/test_imgui_synth_ctrl_shortcuts.das
+++ b/modules/dasImgui/tests/test_imgui_synth_ctrl_shortcuts.das
@@ -63,20 +63,18 @@ def test_imgui_synth_ctrl_shortcuts(t : T?) { // nolint:STYLE038
             t |> success(snap0 != null, "NAME_INPUT renders")
             if (snap0 == null) return
 
-            // ImGui swaps Cmd<>Ctrl inside AddKeyEvent when ConfigMacOSXBehaviors is on
-            // (default on macOS), so a synth LeftCtrl surfaces as the Super modifier there.
-            let macos = snap0?["io"]?["config_macos_behaviors"] ?? false
-            let mod_field = macos ? "key_super" : "key_ctrl"
-
+            // Synth keys are logical: the synth layer pre-swaps Ctrl<->Super
+            // under ConfigMacOSXBehaviors to cancel ImGui's AddKeyEvent swap,
+            // so a synth LeftCtrl reads back as io.KeyCtrl on every platform.
             let ctrl_key = int(ImGuiKey.LeftCtrl)
             post_command(d, "imgui_key_press", JV((key = ctrl_key)))
             let saw_ctrl = wait_until(d, 240) $(var snap) {
-                return snap?["io"]?[mod_field] ?? false
+                return snap?["io"]?["key_ctrl"] ?? false
             }
             t |> success(saw_ctrl != null, "synth Ctrl held shows up in the io modifier state")
             post_command(d, "imgui_key_release", JV((key = ctrl_key)))
             let cleared = wait_until(d, 240) $(var snap) {
-                return !(snap?["io"]?[mod_field] ?? true)
+                return !(snap?["io"]?["key_ctrl"] ?? true)
             }
             t |> success(cleared != null, "io modifier clears after release")
         }
@@ -84,15 +82,11 @@ def test_imgui_synth_ctrl_shortcuts(t : T?) { // nolint:STYLE038
 
         // Canary for the click-then-Ctrl+A bug: synth-click NAME_INPUT, type text, select-all →
         // Backspace, expect an empty buffer (legacy glfw_live left Shortcut() routing broken, so
-        // Ctrl+A no-opped and the buffer ended "ab"). macOS uses Cmd not Ctrl (config_macos_behaviors).
+        // Ctrl+A no-opped). Chords are logical: synth Ctrl is the primary mod on every platform.
         t |> run("click_then_ctrl_a_clears_input") <| @(t : T?) {
             var snap0 = wait_for_render(d, "MAIN_WIN/NAME_INPUT", 15.0f)
             t |> success(snap0 != null, "NAME_INPUT renders")
             if (snap0 == null) return
-
-            // Determine platform shortcut modifier from the io snapshot.
-            let macos = snap0?["io"]?["config_macos_behaviors"] ?? false
-            let select_all_mod = macos ? "Super" : "Ctrl"
 
             // Locate NAME_INPUT center for the synth click.
             let b = snap0?["globals"]?["MAIN_WIN/NAME_INPUT"]?["bbox"]
@@ -124,13 +118,8 @@ def test_imgui_synth_ctrl_shortcuts(t : T?) { // nolint:STYLE038
             // idle before the chord so the chord events don't interleave its tail.
             t |> success(wait_for_key_idle(d, 4.0f), "key_type timeline idle before chord")
 
-            // Select-all chord: Cmd+A on macOS, Ctrl+A everywhere else.
-            if (macos) {
-                post_command(d, "imgui_key_chord", JV((mods = ["Super"], key = "A")))
-            } else {
-                post_command(d, "imgui_key_chord", JV((mods = ["Ctrl"], key = "A")))
-            }
-            t |> success(wait_for_key_idle(d, 4.0f), "{select_all_mod}+A chord completes")
+            post_command(d, "imgui_key_chord", JV((mods = ["Ctrl"], key = "A")))
+            t |> success(wait_for_key_idle(d, 4.0f), "Ctrl+A chord completes")
 
             // Backspace once → if selection is active, buffer empties.
             let bksp = int(ImGuiKey.Backspace)
@@ -141,7 +130,7 @@ def test_imgui_synth_ctrl_shortcuts(t : T?) { // nolint:STYLE038
                 let v = snap?["globals"]?["MAIN_WIN/NAME_INPUT"]?["payload"]?["value"] ?? "still-has-content"
                 return v == ""
             }
-            t |> success(emptied != null, "NAME_INPUT.value == \"\" after {select_all_mod}+A then Backspace")
+            t |> success(emptied != null, "NAME_INPUT.value == \"\" after Ctrl+A then Backspace")
         }
     }
 }

--- a/modules/dasImgui/tests/test_macos_chords.das
+++ b/modules/dasImgui/tests/test_macos_chords.das
@@ -29,7 +29,7 @@ def private probe(app : ImguiApp) : JsonValue? {
 }
 
 [test]
-def test_macos_chords(t : T?) { // nolint:STYLE038 — one forced-macOS scenario; the sub-cases share app state
+def test_macos_chords(t : T?) {
     with_imgui_app(FEATURE) $(d) {
         t |> run("bindings declare logical Ctrl chords") <| @(t : T?) {
             var snap0 = wait_for_render(d, "MAIN_WIN", GUARD_SEC)

--- a/modules/dasImgui/tests/test_macos_chords.das
+++ b/modules/dasImgui/tests/test_macos_chords.das
@@ -1,0 +1,105 @@
+options gen2
+options _comment_hygiene = true
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui public
+require imgui/imgui_commands public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! The command registry under the macOS input model, on every platform.
+//!
+//! The feature app forces io.ConfigMacOSXBehaviors = true, so ImGui swaps
+//! Ctrl<->Super inside AddKeyEvent exactly like a real Mac. The contract
+//! proven here: bindings and synth chords both speak LOGICAL Ctrl-speak —
+//! ImGui's input swap alone maps a physical Cmd onto them. Regression
+//! coverage for the nightly macOS double swap (registry declared Super
+//! chords while ImGui had already turned Cmd into logical Ctrl, so no
+//! primary chord could ever fire on macOS).
+
+let FEATURE = "modules/dasImgui/examples/features/macos_chords.das"
+let GUARD_SEC = 15.0f
+
+def private probe(app : ImguiApp) : JsonValue? {
+    return post_command(app, "macos_chords_state", null)
+}
+
+[test]
+def test_macos_chords(t : T?) { // nolint:STYLE038 — one forced-macOS scenario; the sub-cases share app state
+    with_imgui_app(FEATURE) $(d) {
+        t |> run("bindings declare logical Ctrl chords") <| @(t : T?) {
+            var snap0 = wait_for_render(d, "MAIN_WIN", GUARD_SEC)
+            t |> success(snap0 != null, "MAIN_WIN renders")
+            if (snap0 == null) return
+            var state = probe(d)
+            t |> success(state?["macos_behaviors"] ?? false,
+                         "feature app runs with ConfigMacOSXBehaviors forced on")
+            t |> equal(state?["primary_chord"] ?? 0,
+                       int(ImGuiKey.K) | COMMAND_MOD_CTRL,
+                       "primary binding matches on the logical Ctrl bit — ImGui's input swap owns the Cmd mapping")
+            t |> equal(state?["secondary_chord"] ?? 0,
+                       int(ImGuiKey.J) | COMMAND_MOD_SUPER,
+                       "secondary binding matches on the logical Super bit")
+            t |> equal(state?["primary_text"] ?? "", "Cmd+K",
+                       "display text still speaks the platform key name")
+        }
+
+        t |> run("synth Ctrl surfaces as logical Ctrl") <| @(t : T?) {
+            let ctrl_key = int(ImGuiKey.LeftCtrl)
+            post_command(d, "imgui_key_press", JV((key = ctrl_key)))
+            let saw_ctrl = wait_until(d, 240) $(var snap) {
+                return ((snap?["io"]?["key_ctrl"] ?? false)
+                    && !(snap?["io"]?["key_super"] ?? true))
+            }
+            t |> success(saw_ctrl != null,
+                         "synth Ctrl held reads back as io.KeyCtrl under macOS behaviors")
+            post_command(d, "imgui_key_release", JV((key = ctrl_key)))
+            let cleared = wait_until(d, 240) $(var snap) {
+                return !(snap?["io"]?["key_ctrl"] ?? true)
+            }
+            t |> success(cleared != null, "io modifier clears after release")
+        }
+
+        t |> run("primary chord fires end-to-end") <| @(t : T?) {
+            let before = probe(d)?["primary_fired"] ?? 0
+            post_command(d, "imgui_key_chord", JV((mods = ["Ctrl"], key = "K")))
+            t |> success(wait_for_key_idle(d, 4.0f), "Ctrl+K chord completes")
+            let fired = wait_cond(d, GUARD_SEC) $() : bool {
+                return (probe(d)?["primary_fired"] ?? 0) > before
+            }
+            t |> success(fired, "logical Ctrl+K fires the primary-bound command")
+        }
+
+        t |> run("secondary chord fires end-to-end") <| @(t : T?) {
+            let before = probe(d)?["secondary_fired"] ?? 0
+            post_command(d, "imgui_key_chord", JV((mods = ["Super"], key = "J")))
+            t |> success(wait_for_key_idle(d, 4.0f), "Super+J chord completes")
+            let fired = wait_cond(d, GUARD_SEC) $() : bool {
+                return (probe(d)?["secondary_fired"] ?? 0) > before
+            }
+            t |> success(fired, "logical Super+J fires the secondary-bound command")
+        }
+
+        t |> run("capture stores the logical primary modifier") <| @(t : T?) {
+            let armed = post_command(d, "macos_chords_arm_capture", null)
+            t |> success(armed?["ok"] ?? false, "capture arms on probe.primary")
+            post_command(d, "imgui_key_chord", JV((mods = ["Ctrl"], key = "M")))
+            t |> success(wait_for_key_idle(d, 4.0f), "Ctrl+M chord completes")
+            let captured = wait_cond(d, GUARD_SEC) $() : bool {
+                return !(probe(d)?["capture_armed"] ?? true)
+            }
+            t |> success(captured, "capture consumes the chord")
+            var state = probe(d)
+            t |> equal(state?["primary_key"] ?? 0, int(ImGuiKey.M),
+                       "captured binding lands on the tapped key")
+            t |> success(state?["primary_is_primary"] ?? false,
+                         "held logical Ctrl captures as the PRIMARY modifier")
+            t |> success(!(state?["primary_is_secondary"] ?? true),
+                         "held logical Ctrl does not misfile as secondary")
+        }
+    }
+}

--- a/modules/dasImgui/tests/test_markdown_view_interaction.das
+++ b/modules/dasImgui/tests/test_markdown_view_interaction.das
@@ -399,19 +399,15 @@ def test_markdown_view_event_driven_interactions(t : T?) { // nolint:STYLE038
         // system writes, so regular dastest never mutates the desktop clipboard.
         let selected_text = committed_state?["selection"]?["display_text"] ?? ""
         let copy_before = committed_state?["selection"]?["copy_revision"] ?? -1
-        var input_state = markdown_state(app)
-        let macos = input_state?["input"]?["macos_behaviors"] ?? false
-        // ImGui remaps synthetic LeftCtrl to Super when macOS behaviors are
-        // enabled, matching the viewer's platform shortcut choice.
+        // Synth keys are logical: LeftCtrl reads back as io.KeyCtrl on every
+        // platform (the synth layer cancels ImGui's macOS Ctrl<->Super swap).
         let copy_modifier_key = int(ImGuiKey.LeftCtrl)
         post_command(app, "imgui_key_press", JV((key = copy_modifier_key)))
         let modifier_down = wait_cond(app, DEADLOCK_GUARD_SEC) $() : bool {
             var state = markdown_state(app)
             return state?["input"]?["copy_modifier_down"] ?? false
         }
-        t |> success(modifier_down,
-                     macos ? "synthetic Cmd modifier is observed"
-                           : "synthetic Ctrl modifier is observed")
+        t |> success(modifier_down, "synthetic primary modifier is observed")
 
         post_command(app, "imgui_key_press", JV((key = int(ImGuiKey.C))))
         let copied = wait_cond(app, DEADLOCK_GUARD_SEC) $() : bool {

--- a/modules/dasImgui/tests/test_text_viewer.das
+++ b/modules/dasImgui/tests/test_text_viewer.das
@@ -123,10 +123,10 @@ def test_text_viewer_open_modes_and_zoom(t : T?) { // nolint:STYLE038 — one ev
         }
         t |> success(release_observed, "source selection release is acknowledged")
 
-        let input_snapshot = post_command(app, "imgui_snapshot", null)
-        let input_primary = (input_snapshot?["io"]?["config_macos_behaviors"] ?? false) ? "Super" : "Ctrl"
+        // Synth chords are logical: "Ctrl" is the primary modifier on every
+        // platform (the synth layer maps it onto Cmd under macOS behaviors).
         let copy_before = viewer_state(app)?["source_selection_copy_revision"] ?? 0
-        post_command(app, "imgui_key_chord", JV((mods = [input_primary], key = "C")))
+        post_command(app, "imgui_key_chord", JV((mods = ["Ctrl"], key = "C")))
         t |> success(wait_for_key_idle(app, 4.0f), "platform-primary copy chord completes")
         let copy_observed = wait_cond(app, DEADLOCK_GUARD_SEC) $() : bool {
             var state = viewer_state(app)
@@ -136,7 +136,7 @@ def test_text_viewer_open_modes_and_zoom(t : T?) { // nolint:STYLE038 — one ev
         t |> success(copy_observed,
                      "copy binding routes through a semantic command into the source view")
 
-        post_command(app, "imgui_key_chord", JV((mods = [input_primary], key = "A")))
+        post_command(app, "imgui_key_chord", JV((mods = ["Ctrl"], key = "A")))
         t |> success(wait_for_key_idle(app, 4.0f),
                      "platform-primary select-all chord completes")
         let select_all_observed = wait_cond(app, DEADLOCK_GUARD_SEC) $() : bool {
@@ -158,9 +158,7 @@ def test_text_viewer_open_modes_and_zoom(t : T?) { // nolint:STYLE038 — one ev
 
         var before_reset = viewer_state(app)
         let command_before = before_reset?["command_revision"] ?? 0
-        let zoom_snapshot = post_command(app, "imgui_snapshot", null)
-        let primary_mod = (zoom_snapshot?["io"]?["config_macos_behaviors"] ?? false) ? "Super" : "Ctrl"
-        post_command(app, "imgui_key_chord", JV((mods = [primary_mod], key = "0")))
+        post_command(app, "imgui_key_chord", JV((mods = ["Ctrl"], key = "0")))
         t |> success(wait_for_key_idle(app, 4.0f),
                      "platform-primary reset chord completes")
         let reset_observed = wait_cond(app, DEADLOCK_GUARD_SEC) $() : bool {

--- a/modules/dasImgui/tests/test_text_viewer.das
+++ b/modules/dasImgui/tests/test_text_viewer.das
@@ -525,7 +525,7 @@ def test_text_viewer_find_scrolls_to_match(t : T?) { // nolint:STYLE038 — one 
 }
 
 [test]
-def test_text_viewer_find_icons_and_reopen(t : T?) { // nolint:STYLE038 — one event-gated scenario; splitting breaks the wait-chain
+def test_text_viewer_find_icons_and_reopen(t : T?) {
     with_imgui_app(FEATURE) $(app) {
         let ready = wait_cond(app, DEADLOCK_GUARD_SEC) $() : bool {
             var state = viewer_state(app)
@@ -881,7 +881,7 @@ def test_text_viewer_fold_clicks_and_no_reflow(t : T?) { // nolint:STYLE038 — 
 }
 
 [test]
-def test_text_viewer_single_scroller(t : T?) { // nolint:STYLE038 — one event-gated scenario; splitting breaks the wait-chain
+def test_text_viewer_single_scroller(t : T?) {
     //! The content child is the only scroller: the dock window must never grow
     //! its own scrollbar, and the right-aligned zoom cluster must fit at any
     //! zoom value (both regressed together as "two scrollbars + clipped 100%").

--- a/modules/dasImgui/widgets/imgui_boost_runtime.das
+++ b/modules/dasImgui/widgets/imgui_boost_runtime.das
@@ -1576,14 +1576,26 @@ def private mod_alias_for_side_key(key : int) : int {
     return 0
 }
 
+def private wire_key(key : int) : int {
+    // Synth keys are LOGICAL — pre-swap Ctrl<->Super under ConfigMacOSXBehaviors to cancel ImGui's AddKeyEvent swap, so a synth Ctrl lands as io.KeyCtrl on every platform and chords never need a per-OS mods dance.
+    if (!GetIO().ConfigMacOSXBehaviors) return key
+    if (key == int(ImGuiKey.LeftCtrl)) return int(ImGuiKey.LeftSuper)
+    if (key == int(ImGuiKey.RightCtrl)) return int(ImGuiKey.RightSuper)
+    if (key == int(ImGuiKey.LeftSuper)) return int(ImGuiKey.LeftCtrl)
+    if (key == int(ImGuiKey.RightSuper)) return int(ImGuiKey.RightCtrl)
+    if (key == int(ImGuiKey.ImGuiMod_Ctrl)) return int(ImGuiKey.ImGuiMod_Super)
+    if (key == int(ImGuiKey.ImGuiMod_Super)) return int(ImGuiKey.ImGuiMod_Ctrl)
+    return key
+}
+
 def public synth_key_press(key : int) {
-    //! Press synth ``key`` (ImGuiKey int); auto-pairs the ``ImGuiMod_*`` alias for side-mod keys so ``Shortcut()`` routing sees the chord.
+    //! Press synth ``key`` (a LOGICAL ImGuiKey int — Ctrl means io.KeyCtrl even under macOS behaviors); auto-pairs the ``ImGuiMod_*`` alias for side-mod keys so ``Shortcut()`` routing sees the chord.
     var io & = unsafe(GetIO())
-    io |> AddKeyEvent(as_imgui_key(key), true)
+    io |> AddKeyEvent(as_imgui_key(wire_key(key)), true)
     synth_held_keys |> insert(key)
     let mod_alias = mod_alias_for_side_key(key)
     if (mod_alias != 0) {
-        io |> AddKeyEvent(as_imgui_key(mod_alias), true)
+        io |> AddKeyEvent(as_imgui_key(wire_key(mod_alias)), true)
         synth_held_keys |> insert(mod_alias)
     }
     synth_last_keycode   = key
@@ -1593,11 +1605,11 @@ def public synth_key_press(key : int) {
 def public synth_key_release(key : int) {
     //! Release synth ``key`` (and its mod alias).
     var io & = unsafe(GetIO())
-    io |> AddKeyEvent(as_imgui_key(key), false)
+    io |> AddKeyEvent(as_imgui_key(wire_key(key)), false)
     synth_held_keys |> erase(key)
     let mod_alias = mod_alias_for_side_key(key)
     if (mod_alias != 0) {
-        io |> AddKeyEvent(as_imgui_key(mod_alias), false)
+        io |> AddKeyEvent(as_imgui_key(wire_key(mod_alias)), false)
         synth_held_keys |> erase(mod_alias)
     }
 }
@@ -1713,7 +1725,7 @@ def public imgui_synth_tick() {
         }
     }
     for (k in keys(synth_held_keys)) {
-        io |> AddKeyEvent(as_imgui_key(k), true)
+        io |> AddKeyEvent(as_imgui_key(wire_key(k)), true)
     }
 }
 

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -353,6 +353,7 @@ SET(AOT_LANGUAGE_MODULE_FILES
     tests/language/_distinct_fixture.das
     tests/language/_glob.das
     tests/language/_helper_foo.das
+    tests/language/_inline_constant_expression_helper.das
     tests/language/_inline_generic_helper.das
     tests/language/_inline_scope_helper.das
     tests/language/_inline_unsafe_helper.das

--- a/utils/dasHerd/watcher/rich_inspector_ui.das
+++ b/utils/dasHerd/watcher/rich_inspector_ui.das
@@ -1092,8 +1092,8 @@ def draw_file_inspector_content() { // nolint:STYLE038
 def draw_file_inspector_window() {
     if (IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows)) {
         let io & = unsafe(GetIO())
-        let command_down = io.ConfigMacOSXBehaviors ? io.KeySuper : io.KeyCtrl
-        if (command_down && IsKeyPressed(ImGuiKey.F, false)) {
+        // io.KeyCtrl is logical — ImGui maps Cmd onto it under ConfigMacOSXBehaviors.
+        if (io.KeyCtrl && IsKeyPressed(ImGuiKey.F, false)) {
             text_find_open(g_inspector.find)
         }
     }


### PR DESCRIPTION
Fixes both red nightlies (Aug 1 + Aug 2).

## 1. nightly dasImgui integration — macOS lane: the Ctrl/Super double swap

ImGui swaps Ctrl<->Super inside `AddKeyEvent` when `ConfigMacOSXBehaviors` is on, so a physical Cmd already arrives as **logical Ctrl**. The command registry swapped again — `make_chord` declared `Super+X` chords on macOS — so no primary chord could ever fire there, for synthetic tests or real users. That is exactly what killed `test_text_viewer_open_modes_and_zoom` (copy / select-all / zoom-reset chords) and `test_text_edit_find_replace` (the find bar's raw `io.KeyCtrl && io.KeyAlt` check saw the synth Ctrl swapped to Super and fell into single-replace: `zzdone zzdone zzfind`). Neither test had ever run on macOS CI before Aug 1 — `test_viewer.das` lived in `examples/text/tests` (no CI lane), and `test_text_edit.das` is new from the editor E1–E4 arc.

The contract is now **logical everywhere**:

- `imgui_commands.das`: primary = Ctrl bit, secondary = Super bit, no platform ternary (ImGui's input swap owns the Cmd mapping); the capture flow reads `io.KeyCtrl`/`io.KeySuper` directly. Display names still say Cmd/Ctrl per platform.
- `imgui_boost_runtime.das`: synth keys are logical — `wire_key()` pre-swaps Ctrl<->Super under macOS behaviors to cancel ImGui's swap, so a synth Ctrl lands as `io.KeyCtrl` on every platform. Chords in tests never need a per-OS mods dance.
- Same one-liner at the remaining raw-read sites: markdown viewer probe, text viewer wheel-zoom, dasHerd inspector Ctrl+F.
- Tests updated to the logical contract (`test_text_viewer`, `test_imgui_synth_ctrl_shortcuts`, `test_commands`, `test_markdown_view_interaction`).

**Regression coverage that runs on every platform:** new `examples/features/macos_chords.das` forces `ConfigMacOSXBehaviors = true`, and `tests/test_macos_chords.das` asserts the chord ints (`Ctrl|K` = 4652, not `Super|K` = 33324), the io modifier readback, both end-to-end chords, and binding capture. The chord-int and modifier-readback cases were proven failing pre-fix on Windows — the macOS breakage reproduced locally.

Verification: macos_chords 6/6 (2 failing pre-fix), full dasImgui suite 315/315 headless (isolated-mode, CODEREVIEW.md excludes), lint + formatter clean on all touched `.das`.

## 2. nightly build — all lanes: `error[50101]` in the full test_aot sweep

e7a464438 added `tests/language/_inline_constant_expression_helper.das` but not its `AOT_LANGUAGE_MODULE_FILES` entry in `tests/aot/CMakeLists.txt`. Its `with_picked` is concrete (not generic), so the missing stub failed the nightly sweep on every lane. One-line registration; verified with a rebuilt `test_aot_subset`: the failing file is 34/34 and the full tests/language sweep is **1523/1523** under `-use-aot`.

## Notes

- Pushed with `--no-verify` per the standing preflight bar (lint + format of changed `.das`, both clean); targeted gates above stand in for the full run.
- One loose end to watch on the next nightly: mid-test on macOS the viewer app stopped answering (`daslang-live timed out (>120s)`) right after a chord. It most likely disappears now that chords route; if it recurs, it is a separate crash to hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
