### PR TITLE
Preview caret: collapsed selection + focus-line tint, not a one-byte span

### DIFF
--- a/examples/text/main.das
+++ b/examples/text/main.das
@@ -1091,16 +1091,18 @@ def private apply_preview_caret(var doc : TextViewerDocument) {
     return if (doc.preview_revision != doc.edit.revision)
     if (doc.preview_caret_applied != doc.edit.follow_revision) {
         doc.preview_caret_applied = doc.edit.follow_revision
-        // one byte wide (a zero-width selection maps but yields no focus
-        // screen Y), walked back to the nearest RENDERED byte - the caret can
-        // sit on blank lines or fence syntax the preview never draws
+        // ZERO-width: a one-byte selection paints random spans when the caret
+        // sits on unrendered markdown syntax (anchor and focus each fall
+        // forward to different rendered runs). Collapsed resolves the position
+        // invisibly; the focus-line tint below is the visible indication. The
+        // walk covers end-of-document, where nothing is left to fall forward to
         let caret = text_edit_byte_of_position(doc.edit,
             doc.edit.cursor_line, doc.edit.cursor_column)
         var anchor = caret
         var tries = 0
         while (tries < 64) {
             let _sel = markdown_view_select_source_range(
-                doc.preview_view, anchor, anchor + 1)
+                doc.preview_view, anchor, anchor)
             break if (markdown_view_selection_focus_screen_y(
                 doc.preview_view).valid || anchor == 0)
             anchor--
@@ -1156,6 +1158,10 @@ def private draw_document_editor(var doc : TextViewerDocument) {
                 doc.status = "Preview checkboxes are read-only - edit the source."
             }
             apply_preview_caret(doc)
+            if (doc.preview_revision == doc.edit.revision) {
+                markdown_view_focus_line_tint(doc.preview_view,
+                    TextSourceViewStyle().current_line_color)
+            }
         }
     }
 }
@@ -1445,6 +1451,10 @@ def text_viewer_state(_input : JsonValue?) : JsonValue? { // nolint:STYLE038 —
             doc.preview_view).valid,
         preview_focus_y = markdown_view_selection_focus_screen_y(
             doc.preview_view).y,
+        preview_selection_start = md_text_selection_range(
+            doc.preview_view.selection_anchor, doc.preview_view.selection_focus).start_byte,
+        preview_selection_end = md_text_selection_range(
+            doc.preview_view.selection_anchor, doc.preview_view.selection_focus).end_byte,
         has_utf8_bom = doc.source.has_utf8_bom,
         checkbox_count = length(doc.projection.controls),
         control_activation_revision = doc.markdown_view.control_activation_revision,

--- a/modules/dasImgui/markdown/imgui_markdown_view.das
+++ b/modules/dasImgui/markdown/imgui_markdown_view.das
@@ -292,7 +292,7 @@ def private clear_node_cache(var entry : MarkdownNodeViewCache) {
     delete entry.content.runs
     delete entry.layout.lines
     delete entry.layout.fragments
-    entry = MarkdownNodeViewCache()
+    entry = MarkdownNodeViewCache() // nolint:PERF030 (owned fields deleted above; the move target is already empty)
 }
 
 def private clear_selection(var state : MarkdownViewState) {
@@ -408,6 +408,35 @@ def public markdown_view_selection_focus_screen_y(
         return (valid = true, y = state.selection_screen_bounds.y)
     }
     return (valid = false, y = 0.0f)
+}
+
+def public markdown_view_focus_line_tint(state : MarkdownViewState const;
+                                         color : float4) {
+    //! Tint the selection-focus LINE across the current window — caret-follow
+    //! indication for live previews; pairs with a ZERO-width selection (a
+    //! one-byte one paints random spans on unrendered markdown syntax).
+    let focus = state.selection_focus
+    return if (!focus.valid || focus.inline_node < 0
+        || focus.inline_node >= length(state.nodes))
+    let entry & = unsafe(state.nodes[focus.inline_node])
+    return if (!entry.layout_valid)
+    var line_y = entry.screen_origin.y
+    var line_height = GetTextLineHeight()
+    for (line in entry.layout.lines) {
+        if (focus.display_byte >= line.source.start_byte
+                && focus.display_byte <= line.source.end_byte) {
+            line_y = entry.screen_origin.y + line.y
+            line_height = max(line.height, 1.0f)
+            break
+        }
+    }
+    let window_pos = GetWindowPos()
+    let window_size = GetWindowSize()
+    return if (line_y + line_height < window_pos.y || line_y > window_pos.y + window_size.y)
+    var dl = GetWindowDrawList()
+    *dl |> AddRectFilled(float2(window_pos.x, line_y),
+        float2(window_pos.x + window_size.x, line_y + line_height),
+        GetColorU32(color))
 }
 
 def public markdown_view_expand_for_byte(var state : MarkdownViewState;
@@ -677,7 +706,7 @@ def public markdown_view_dispose(var state : MarkdownViewState) {
     unsafe { delete state.nodes }
     delete state.image_bindings
     markdown_view_clear_syntax(state)
-    state = MarkdownViewState()
+    state = MarkdownViewState() // nolint:PERF030 (owned fields deleted above; the move target is already empty)
 }
 
 def private retain_image_bindings(var state : MarkdownViewState;

--- a/modules/dasImgui/tests/test_text_viewer.das
+++ b/modules/dasImgui/tests/test_text_viewer.das
@@ -1102,6 +1102,10 @@ def test_text_viewer_edit_preview_and_watch(t : T?) { // nolint:STYLE038 — one
             return (state?["preview_focus_valid"] ?? false)
         }
         t |> success(followed, "the preview maps the caret to a rendered position")
+        var caret_state = viewer_state(app)
+        t |> equal(caret_state?["preview_selection_end"] ?? -1,
+            caret_state?["preview_selection_start"] ?? -2,
+            "the caret mark is collapsed - no text selection paints in the preview")
 
         // external change: detect and warn, never auto-reload a dirty buffer
         let before_lines = edit_text_state(app)?["text"] ?? ""


### PR DESCRIPTION
## Preview caret: collapsed selection + focus-line tint

Live-play catch on E5 (#3607): typing in side-by-side markdown randomly selected whole sections in the preview.

**Root cause**: the caret-follow mark was a **one-byte selection** (`select_source_range(caret, caret + 1)`). When the caret sits on unrendered markdown source — blank lines, emphasis markers, list bullets, i.e. constantly while typing — `source_byte_position` falls forward to the next *rendered* run for each end independently, so anchor and focus land in different runs and the painted selection spans the gap: whole "sections" light up.

**Fix**:
- The caret maps as a **zero-width** selection — position resolution only, nothing paints; the end-of-document back-walk keeps its collapsed form.
- New view helper `markdown_view_focus_line_tint(state, color)` tints the focus **line** across the pane (current-line style, drawn by the view where the layout lives) — the visible cursor indication ruling (e) asked for, without any text selection.
- `text_viewer_state` gains `preview_selection_start/end`; the watch scenario pins the selection staying collapsed after caret moves.
- Two pre-existing PERF030 hits on the view's dispose idiom (reset-after-field-deletes) carry the same reasoned nolints `text_edit_dispose` got in #3607.

Verified: viewer suite 10/10 headless (clean port), lint 0, formatted; driven live — the tint tracks the caret through blank lines and syntax without selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
