### PR TITLE
Malformed-AST detection: sticky errors instead of segfaults on macro-built trees

### DIFF
--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -430,7 +430,7 @@ def document_module_ast(_root : string) {
         group_by_regex("Size and offset", mod, %regex~.*_(size|offset)%%),
         group_by_regex("Pointer conversion", mod, %regex~(ExpressionPtr|FunctionPtr|StructurePtr)%%),
         group_by_regex("Evaluations", mod, %regex~(eval_single_expression)%%),
-        group_by_regex("Error reporting", mod, %regex~(macro_error|macro_performance_warning|macro_style_warning)%%),
+        group_by_regex("Error reporting", mod, %regex~(macro_error|macro_sticky_error|macro_performance_warning|macro_style_warning)%%),
         group_by_regex("Location and context", mod, %regex~(force_at|collect_dependencies|get_ast_context)%%),
         group_by_regex("Use queries", mod, %regex~(get_use_global_variables|get_use_functions)%%),
         group_by_regex("Log", mod, %regex~(to_compilation_log)%%),

--- a/doc/source/stdlib/handmade/function-ast-macro_sticky_error-0x15fc31e6bf28cfb4.rst
+++ b/doc/source/stdlib/handmade/function-ast-macro_sticky_error-0x15fc31e6bf28cfb4.rst
@@ -1,0 +1,1 @@
+Reports a sticky error to the currently compiling program: unlike macro_error, the report survives subsequent inference passes, so the compile still fails even after the macro repairs the tree in place.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1760,6 +1760,9 @@ namespace das
         bool simulate ( Context & context, TextWriter & logs, StackAllocator * sharedStack = nullptr );
         uint64_t getInitSemanticHashWithDep( uint64_t initHash );
         void error ( const string & str, const string & extra, const string & fixme, const LineInfo & at, CompilationError cerr = CompilationError::unspecified );
+        // for malformed-AST reports on a tree that gets repaired in place: survives the per-pass
+        // errors.clear() in infer (re-armed at the end of every infer leg), so the compile still fails
+        void stickyError ( const string & str, const string & extra, const string & fixme, const LineInfo & at, CompilationError cerr = CompilationError::unspecified );
         void deduplicateErrors ();
         bool failed() const { return failToCompile || macroException; }
         static ExpressionPtr makeConst ( const LineInfo & at, const TypeDeclPtr & type, vec4f value );
@@ -1818,6 +1821,7 @@ namespace das
         int                         newLambdaIndex = 1;
         int                         inferPassesUsed = 0;   // sum of inferTypesDirty inner-loop pass counts across all inferTypes calls (incl. restartInfer legs) for this module; reset by parseDaScript once per module-compile; used by per-module compile-time log
         vector<Error>               errors;
+        vector<Error>               stickyErrors;
         vector<Error>               aotErrors;
         uint32_t                    globalInitStackSize = 0;
         uint32_t                    globalStringHeapSize = 0;

--- a/include/daScript/ast/ast_infer_type.h
+++ b/include/daScript/ast/ast_infer_type.h
@@ -35,6 +35,7 @@ namespace das {
         VariablePtr globalVar = nullptr;
         vector<VariablePtr> local;
         vector<ExpressionPtr> loop;
+        Expression *comprehensionFor = nullptr;  // comprehension-embedded ExprFor legally has a null body until lowering
         vector<ExprBlock *> blocks;
         vector<ExprBlock *> scopes;
         vector<ExprWith *> with;
@@ -665,6 +666,7 @@ namespace das {
         virtual ExpressionPtr visitMakeArrayIndex(ExprMakeArray *expr, int index, Expression *init, bool last) override;
         virtual ExpressionPtr visit(ExprMakeArray *expr) override;
         // array comprehension
+        virtual void preVisit(ExprArrayComprehension *expr) override;
         virtual void preVisitArrayComprehensionSubexpr(ExprArrayComprehension *expr, Expression *subexpr) override;
         virtual void preVisitArrayComprehensionWhere(ExprArrayComprehension *expr, Expression *where) override;
         virtual ExpressionPtr visit(ExprArrayComprehension *expr) override;

--- a/include/daScript/ast/compilation_errors.h
+++ b/include/daScript/ast/compilation_errors.h
@@ -634,7 +634,7 @@ namespace das
     ,   runtime_function                                            =   50500    // 3 site(s)
     ,   runtime_function_annotation                                 =   50501    // 5 site(s)
     ,   runtime_global                                              =   50502    // 2 site(s)
-    ,   runtime_macro                                               =   50503    // 6 site(s)
+    ,   runtime_macro                                               =   50503    // 7 site(s)
 
 // internal_*
 
@@ -645,9 +645,9 @@ namespace das
     ,   internal_block_missing_return_type                          =   50604    // 1 site(s)
     ,   internal_class                                              =   50605    // 1 site(s)
     ,   internal_enumeration                                        =   50606    // 1 site(s)
-    ,   internal_expression                                         =   50607    // 26 site(s)
-    ,   internal_field                                              =   50608    // 1 site(s)
-    ,   internal_function                                           =   50609    // 9 site(s)
+    ,   internal_expression                                         =   50607    // 29 site(s)
+    ,   internal_field                                              =   50608    // 2 site(s)
+    ,   internal_function                                           =   50609    // 11 site(s)
     ,   internal_function_annotation                                =   50610    // 1 site(s)
     ,   internal_function_changed                                   =   50611    // 1 site(s)
     ,   internal_function_name                                      =   50612    // 1 site(s)
@@ -678,7 +678,7 @@ namespace das
     ,   internal_type                                               =   50637    // 15 site(s)
     ,   internal_type_alias                                         =   50638    // 1 site(s)
     ,   internal_typeinfo_macro                                     =   50639    // 1 site(s)
-    ,   internal_variable                                           =   50640    // 3 site(s)
+    ,   internal_variable                                           =   50640    // 9 site(s)
 
     // ===== preserved for direct (non-error()) callers =====
     ,   missing_aot                                                 =   50101    // Program::linkError direct

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -57,6 +57,12 @@ pvar._type.flags.ref = true
 
 Same family of trap as the [ExprRef2Value blocker](#peel-exprref2value-before-qmatch) — the typer doesn't repair what macro substitution introduces, when the substitution lands in an already-typed AST fragment.
 
+**A `Variable` you emit MUST have `_type` set** — unlike `ExprVar` (where a null `_type` means "let the typer fill it"), a `new Variable(name := n, at = at, init = e)` destined for an `ExprLet` (or a global, function/block argument, structure field) with null `_type` is a malformed tree: infer reports `error[50640] malformed AST, variable '<n>' is missing its type` (`50608` for structure fields) and fails the compile. For type inference from the initializer, set `_type = new TypeDecl(baseType = Type.autoinfer, at = at)`.
+
+The same `malformed AST, ...` detection family covers the other required-but-nullable fields a macro-built tree can miss: a for loop's `body` (`50607`), `iteratorsAt`/`iteratorsAka` left shorter than `iterators` when rewriting a loop (`50607` — keep all the parallel vectors the same length, like the tutorial's table_kv macro does), null ENTRIES in `variables`/`arguments`/`sources` lists (`50640`/`50609`/`50607`), and a generated `Function` with null `result` (`50609` — set `result` to an auto `TypeDecl`). These repair the tree in place so compilation can continue reporting, but the error is sticky — the compile still fails. Null *expression children* (`ExprOp2.left`, an `if` condition) are NOT guarded — those crash in the visitor walk itself; the crash-capture stack trace is the diagnostic there.
+
+**`macro_sticky_error(prog, at, message)`** — the sticky-error primitive itself, next to `macro_error` in the ast module. Use it when your macro detects damage, repairs it so infer can proceed, but the program must still fail to compile: a plain `macro_error` recorded on a pass that also changed the AST is discarded by the next infer pass, a sticky one survives to the end.
+
 Canonical example: `try_make_inline_cmp` and the `_where`-arm projection-bind rewrite in `daslib/linq_fold_common.das` (PR #2714).
 
 ## The few residual smart_ptr types — `Program`, `Context`, `FileAccess`

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -292,6 +292,12 @@ namespace das {
         Visitor::preVisitStructureField(that, decl, last);
         checkEmptyName(decl.name, "structure field", decl.at);
         that->fieldLookup[decl.name] = fieldIndex++;
+        if (!decl.type) {
+            program->stickyError("malformed AST, structure field '" + decl.name + "' is missing its type",
+                  "likely a macro-generated declaration; set its type to auto to request inference", "",
+                  decl.at, CompilationError::internal_field);
+            decl.type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+        }
         if (decl.type->isAuto() && !decl.init) {
             error("structure field type can't be inferred, it needs an initializer", "", "",
                   decl.at, CompilationError::missing_structure_field);
@@ -469,6 +475,12 @@ namespace das {
     void InferTypes::preVisitGlobalLet(const VariablePtr &var) {
         Visitor::preVisitGlobalLet(var);
         checkEmptyName(var->name, "global variable declaration", var->at);
+        if (!var->type) {
+            program->stickyError("malformed AST, global variable '" + var->name + "' is missing its type",
+                  "likely a macro-generated declaration; set its type to auto to request inference", "",
+                  var->at, CompilationError::internal_variable);
+            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+        }
         if (noUnsafeUninitializedStructs && !var->init && var->type->unsafeInit()) {
             if (!hasSafeWhenUninitialized(var->annotation)) {
                 error("Uninitialized variable " + var->name + " is unsafe. Use initializer syntax or @safe_when_uninitialized when intended.", "", "",
@@ -665,6 +677,22 @@ namespace das {
     void InferTypes::preVisit(Function *f) {
         Visitor::preVisit(f);
         checkEmptyName(f->name, "function declaration", f->at);
+        if (!f->result) {
+            program->stickyError("malformed AST, function '" + f->name + "' is missing its result type",
+                  "likely a macro-generated function; set result to auto to request inference", "",
+                  f->at, CompilationError::internal_function);
+            f->result = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+        }
+        for (auto it = f->arguments.begin(); it != f->arguments.end();) {
+            if (*it == nullptr) {
+                program->stickyError("malformed AST, function '" + f->name + "' has a null argument entry",
+                      "likely a macro-generated function", "",
+                      f->at, CompilationError::internal_function);
+                it = f->arguments.erase(it);  // repair in place; the sticky error still fails the compile
+            } else {
+                ++it;
+            }
+        }
         oneReturn = nullptr;
         returnCount = 0;
         canFoldResult = true;
@@ -689,6 +717,12 @@ namespace das {
     void InferTypes::preVisitArgument(Function *fn, const VariablePtr &var, bool lastArg) {
         Visitor::preVisitArgument(fn, var, lastArg);
         checkEmptyName(var->name, "function argument", var->at);
+        if (!var->type) {
+            program->stickyError("malformed AST, function argument '" + var->name + "' is missing its type",
+                  "likely a macro-generated declaration; set its type to auto to request inference", "",
+                  var->at, CompilationError::internal_variable);
+            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+        }
         if (var->type->isAlias()) {
             if (auto aT = inferAlias(var->type)) {
                 var->type = aT;
@@ -3613,6 +3647,16 @@ namespace das {
     }
     void InferTypes::preVisit(ExprBlock *block) {
         Visitor::preVisit(block);
+        for (auto it = block->arguments.begin(); it != block->arguments.end();) {
+            if (*it == nullptr) {
+                program->stickyError("malformed AST, block has a null argument entry",
+                      "likely a macro-built block", "",
+                      block->at, CompilationError::internal_variable);
+                it = block->arguments.erase(it);  // repair in place; the sticky error still fails the compile
+            } else {
+                ++it;
+            }
+        }
         block->hasEarlyOut = false;
         block->hasReturn = false;
         block->forLoop = false;
@@ -3642,6 +3686,12 @@ namespace das {
     void InferTypes::preVisitBlockArgument(ExprBlock *block, const VariablePtr &var, bool lastArg) {
         Visitor::preVisitBlockArgument(block, var, lastArg);
         checkEmptyName(var->name, "block argument", var->at);
+        if (!var->type) {
+            program->stickyError("malformed AST, block argument '" + var->name + "' is missing its type",
+                  "likely a macro-generated declaration; set its type to auto to request inference", "",
+                  var->at, CompilationError::internal_variable);
+            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+        }
         if (!var->can_shadow && !program->policies.allow_block_variable_shadowing) {
             if (func) {
                 for (auto &fna : func->arguments) {
@@ -5056,6 +5106,30 @@ namespace das {
         Visitor::preVisit(expr);
         // macro generated invisible variables
         // DAS_ASSERT(expr->visibility.line);
+        if (!expr->body && expr != comprehensionFor) {  // a comprehension's embedded for legally has no body until lowering
+            program->stickyError("malformed AST, for loop is missing its body",
+                  "likely a macro-built loop; set body to an ExprBlock", "",
+                  expr->at, CompilationError::internal_expression);
+            expr->body = new ExprBlock();  // repair in place; the sticky error still fails the compile
+            expr->body->at = expr->at;
+        }
+        for (size_t i = 0; i < expr->sources.size();) {
+            if (expr->sources[i] == nullptr) {
+                program->stickyError("malformed AST, for loop has a null source entry",
+                      "likely a macro-built loop", "",
+                      expr->at, CompilationError::internal_expression);
+                // repair in place (erase the whole iterator column, keeping the parallel
+                // vectors consistent); the sticky error still fails the compile
+                expr->sources.erase(expr->sources.begin() + i);
+                if (expr->iterators.size() > i) expr->iterators.erase(expr->iterators.begin() + i);
+                if (expr->iteratorsAt.size() > i) expr->iteratorsAt.erase(expr->iteratorsAt.begin() + i);
+                if (expr->iteratorsAka.size() > i) expr->iteratorsAka.erase(expr->iteratorsAka.begin() + i);
+                if (expr->iteratorsTupleExpansion.size() > i) expr->iteratorsTupleExpansion.erase(expr->iteratorsTupleExpansion.begin() + i);
+                if (expr->iteratorsTags.size() > i) expr->iteratorsTags.erase(expr->iteratorsTags.begin() + i);
+            } else {
+                ++i;
+            }
+        }
         loop.push_back(expr);
         pushVarStack();
     }
@@ -5069,6 +5143,14 @@ namespace das {
             error("for loop needs as many iterators as there are sources", "", "",
                   expr->at, CompilationError::invalid_for_iterator_count);
             return;
+        }
+        if (expr->iteratorsAt.size() < expr->iterators.size() || expr->iteratorsAka.size() < expr->iterators.size()) {
+            program->stickyError("malformed AST, for loop iteratorsAt/iteratorsAka are shorter than the iterator list",
+                  "likely a macro-built loop; keep iterators, iteratorsAt and iteratorsAka the same length", "",
+                  expr->at, CompilationError::internal_expression);
+            // repair in place (pad with defaults); the sticky error still fails the compile
+            if (expr->iteratorsAt.size() < expr->iterators.size()) expr->iteratorsAt.resize(expr->iterators.size());
+            if (expr->iteratorsAka.size() < expr->iterators.size()) expr->iteratorsAka.resize(expr->iterators.size());
         }
         // iterator variables
         int idx = 0;
@@ -5257,6 +5339,16 @@ namespace das {
     }
     void InferTypes::preVisit(ExprLet *expr) {
         Visitor::preVisit(expr);
+        for (auto it = expr->variables.begin(); it != expr->variables.end();) {
+            if (*it == nullptr) {
+                program->stickyError("malformed AST, let expression has a null variable entry",
+                      "likely a macro-built declaration list", "",
+                      expr->at, CompilationError::internal_variable);
+                it = expr->variables.erase(it);  // repair in place; the sticky error still fails the compile
+            } else {
+                ++it;
+            }
+        }
         DAS_ASSERT(!scopes.empty());
         auto scope = scopes.back();
         expr->visibility.fileInfo = expr->at.fileInfo;
@@ -5272,6 +5364,12 @@ namespace das {
         checkEmptyName(var->name, "variable declaration", var->at);
         var->single_return_via_move = false;
         var->consumed = false;
+        if (!var->type) {
+            program->stickyError("malformed AST, variable '" + var->name + "' is missing its type",
+                  "likely a macro-generated declaration; set its type to auto to request inference", "",
+                  var->at, CompilationError::internal_variable);
+            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+        }
         if (var->type && var->type->isExprType()) {
             return;
         }
@@ -6409,6 +6507,11 @@ namespace das {
                                                                                                              "this is likely due to a loop in the type system",
                   "", "",
                   LineInfo(), CompilationError::exceeds_infer_passes);
+        }
+        // re-arm sticky (malformed-AST) reports: the tree was repaired in place so the guard that
+        // detected the damage won't re-fire, and every pass cleared program->errors
+        for (auto &serr : program->stickyErrors) {
+            program->error(serr.what, serr.extra, serr.fixme, serr.at, serr.cerr);
         }
         // End-of-leg collect: sweep this leg's accumulated garbage so the next inferTypes
         // leg (macro restart / restartInfer) inherits only live nodes, not a compounding

--- a/src/ast/ast_infer_type_make.cpp
+++ b/src/ast/ast_infer_type_make.cpp
@@ -1603,6 +1603,10 @@ namespace das {
         }
         return Visitor::visit(expr);
     }
+    void InferTypes::preVisit(ExprArrayComprehension *expr) {
+        Visitor::preVisit(expr);
+        comprehensionFor = expr->exprFor;   // exempt the embedded for from the null-body malformed-AST guard
+    }
     void InferTypes::preVisitArrayComprehensionSubexpr(ExprArrayComprehension *expr, Expression *subexpr) {
         Visitor::preVisitArrayComprehensionSubexpr(expr, subexpr);
         pushVarStack();

--- a/src/ast/ast_program.cpp
+++ b/src/ast/ast_program.cpp
@@ -55,6 +55,11 @@ namespace das {
         failToCompile = true;
     }
 
+    void Program::stickyError ( const string & str, const string & extra, const string & fixme, const LineInfo & at, CompilationError cerr ) {
+        stickyErrors.emplace_back(str,extra,fixme,at,cerr);
+        error(str,extra,fixme,at,cerr);
+    }
+
     // Identify the "not_resolved_yet" follow-on family by numeric range.
     // All `not_resolved_yet_*` codes live in the 31300-31399 block (the
     // `not_resolved_yet` facet cluster within stage 3, semantic). See

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -328,6 +328,11 @@ namespace das {
         prog->error(message ? message : "macro error","","",at,CompilationError::runtime_macro);
     }
 
+    void ast_sticky_error ( ProgramPtr prog, const LineInfo & at, const char * message, Context * context, LineInfoArg * lineInfo ) {
+        if ( !prog ) context->throw_error_at(lineInfo,"program can't be null (expecting compiling_program())");
+        prog->stickyError(message ? message : "macro error","","",at,CompilationError::runtime_macro);
+    }
+
     void ast_performance_warning ( ProgramPtr prog, const LineInfo & at, const char * message, Context * context, LineInfoArg * lineInfo ) {
         if ( !prog ) context->throw_error_at(lineInfo,"program can't be null (expecting compiling_program())");
         prog->error(message ? message : "performance warning","","",at,CompilationError::runtime_macro_performance);
@@ -1610,13 +1615,16 @@ namespace das {
         // errors
         addExtern<DAS_BIND_FUN(ast_error)>(*this, lib,  "macro_error",
             SideEffects::modifyArgumentAndExternal, "ast_error")
-                ->args({"porogram","at","message","context","line"});
+                ->args({"program","at","message","context","line"});
+        addExtern<DAS_BIND_FUN(ast_sticky_error)>(*this, lib,  "macro_sticky_error",
+            SideEffects::modifyArgumentAndExternal, "ast_sticky_error")
+                ->args({"program","at","message","context","line"});
         addExtern<DAS_BIND_FUN(ast_performance_warning)>(*this, lib,  "macro_performance_warning",
             SideEffects::modifyArgumentAndExternal, "ast_performance_warning")
-                ->args({"porogram","at","message","context","line"});
+                ->args({"program","at","message","context","line"});
         addExtern<DAS_BIND_FUN(ast_style_warning)>(*this, lib,  "macro_style_warning",
             SideEffects::modifyArgumentAndExternal, "ast_style_warning")
-                ->args({"porogram","at","message","context","line"});
+                ->args({"program","at","message","context","line"});
         // class
         addExtern<DAS_BIND_FUN(makeClassRtti)>(*this, lib,  "builtin_ast_make_class_rtti",
             SideEffects::modifyArgumentAndExternal, "makeClassRtti")

--- a/tests/ast/_malformed_tree_macros.das
+++ b/tests/ast/_malformed_tree_macros.das
@@ -1,0 +1,112 @@
+options gen2
+options no_aot
+
+// Fixtures for the failed_* malformed-tree tests: each macro produces one specific
+// malformation that infer must report (sticky error) instead of crashing or silently
+// repairing. Trigger is the source call name, so one module serves all the tests.
+
+module _malformed_tree_macros
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/templates_boost
+
+def find_named_source(expr : ExprFor?; nm : string) : int {
+    for (index, src in count(), expr.sources) {
+        if (src is ExprCall) {
+            if ((src as ExprCall).name == nm) {
+                return index
+            }
+        }
+    }
+    return -1
+}
+
+def rewrite_to_range(var new_for : ExprFor?; expr : ExprFor?; idx : int) {
+    let src_call = expr.sources[idx] as ExprCall
+    var range_call = new ExprCall(at = src_call.at, name := "range")
+    for (a in src_call.arguments) {
+        range_call.arguments |> emplace_new <| clone_expression(a)
+    }
+    new_for.sources[idx] = range_call
+    new_for.iteratorVariables |> clear()
+}
+
+// iteratorsAt/iteratorsAka left shorter than iterators (silent OOB before the guard)
+[for_loop_macro(name=short_iters_loop)]
+class ShortItersLoop : AstForLoopMacro {
+    def override visitExprFor(prog : ProgramPtr; mod : Module?; expr : ExprFor?) : ExpressionPtr {
+        if (is_in_completion()) return default<ExpressionPtr>
+        let idx = find_named_source(expr, "short_iters_range")
+        if (idx == -1) return default<ExpressionPtr>
+        var new_for_e = clone_expression(expr)
+        var new_for = new_for_e as ExprFor
+        rewrite_to_range(new_for, expr, idx)
+        new_for.iteratorsAka |> clear()
+        new_for.iteratorsAt |> clear()
+        return new_for_e
+    }
+}
+
+// for loop with null body
+[for_loop_macro(name=nobody_loop)]
+class NobodyLoop : AstForLoopMacro {
+    def override visitExprFor(prog : ProgramPtr; mod : Module?; expr : ExprFor?) : ExpressionPtr {
+        if (is_in_completion()) return default<ExpressionPtr>
+        let idx = find_named_source(expr, "nobody_range")
+        if (idx == -1) return default<ExpressionPtr>
+        var new_for_e = clone_expression(expr)
+        var new_for = new_for_e as ExprFor
+        rewrite_to_range(new_for, expr, idx)
+        new_for.body = default<ExpressionPtr>
+        return new_for_e
+    }
+}
+
+// null entry in ExprLet.variables
+[for_loop_macro(name=nullvar_loop)]
+class NullVarLoop : AstForLoopMacro {
+    def override visitExprFor(prog : ProgramPtr; mod : Module?; expr : ExprFor?) : ExpressionPtr {
+        if (is_in_completion()) return default<ExpressionPtr>
+        let idx = find_named_source(expr, "nullvar_range")
+        if (idx == -1) return default<ExpressionPtr>
+        var new_for_e = clone_expression(expr)
+        var new_for = new_for_e as ExprFor
+        rewrite_to_range(new_for, expr, idx)
+        var let_expr = new ExprLet(at = expr.at)
+        let_expr.variables |> push(default<VariablePtr>)
+        var body = new_for.body as ExprBlock
+        body.list |> push(let_expr, 0)
+        return new_for_e
+    }
+}
+
+// valid rewrite, but the macro reports a sticky error — the error must survive
+// the repaired-tree re-infer and still fail the compile
+[for_loop_macro(name=sticky_loop)]
+class StickyLoop : AstForLoopMacro {
+    def override visitExprFor(prog : ProgramPtr; mod : Module?; expr : ExprFor?) : ExpressionPtr {
+        if (is_in_completion()) return default<ExpressionPtr>
+        let idx = find_named_source(expr, "sticky_range")
+        if (idx == -1) return default<ExpressionPtr>
+        var new_for_e = clone_expression(expr)
+        var new_for = new_for_e as ExprFor
+        rewrite_to_range(new_for, expr, idx)
+        macro_sticky_error(prog, expr.at, "sticky_range: reporting a sticky macro error on a valid tree")
+        return new_for_e
+    }
+}
+
+// generated function with null result type
+[structure_macro(name=null_result_fn)]
+class NullResultFn : AstStructureAnnotation {
+    def override apply(var st : StructurePtr; var group : ModuleGroup;
+                       args : AnnotationArgumentList; var errors : das_string) : bool {
+        var fn = qmacro_function("broken`result`fn") $() {
+            pass
+        }
+        fn.result = default<TypeDeclPtr>
+        add_function(st._module, fn)
+        return true
+    }
+}

--- a/tests/ast/_typeless_let_macro.das
+++ b/tests/ast/_typeless_let_macro.das
@@ -1,0 +1,48 @@
+options gen2
+options no_aot
+
+// Fixture for failed_typeless_let_variable.das: for-loop macro that rewrites
+//   for (i in typeless_range(...))  into  for (i in range(...))
+// but prepends a `let` whose Variable has NO type — a malformed tree the compiler
+// must report (50640) instead of segfaulting in infer (the pre-guard behavior)
+
+module _typeless_let_macro
+
+require daslib/ast
+require daslib/ast_boost
+
+[for_loop_macro(name=typeless_let_loop)]
+class TypelessLetLoop : AstForLoopMacro {
+    def override visitExprFor(prog : ProgramPtr; mod : Module?; expr : ExprFor?) : ExpressionPtr {
+        if (is_in_completion()) return default<ExpressionPtr>
+        var idx = -1
+        var src_call : ExprCall const?
+        for (index, src in count(), expr.sources) {
+            if (src is ExprCall) {
+                let c = src as ExprCall
+                if (c.name == "typeless_range") {
+                    idx = index
+                    src_call = c
+                    break
+                }
+            }
+        }
+        if (idx == -1) return default<ExpressionPtr>
+        var new_for_e = clone_expression(expr)
+        var new_for = new_for_e as ExprFor
+        var range_call = new ExprCall(at = src_call.at, name := "range")
+        for (a in src_call.arguments) {
+            range_call.arguments |> emplace_new <| clone_expression(a)
+        }
+        new_for.sources[idx] = range_call
+        let at = expr.iteratorsAt[idx]
+        var let_expr = new ExprLet(at = at)
+        // the malformed bit: a Variable with no _type
+        let_expr.variables |> emplace_new <| new Variable(name := "t`less", at = at,
+            init = new ExprConstInt(at = at, value = 0))
+        var body = new_for.body as ExprBlock
+        body.list |> push(let_expr, 0)
+        new_for.iteratorVariables |> clear()
+        return new_for_e
+    }
+}

--- a/tests/ast/failed_null_for_body.das
+++ b/tests/ast/failed_null_for_body.das
@@ -1,0 +1,11 @@
+options gen2
+expect 50607    // internal_expression — malformed AST, for loop is missing its body
+
+require _malformed_tree_macros
+
+[export]
+def main {
+    for (i in nobody_range(0, 10)) {
+        print("{i}\n")
+    }
+}

--- a/tests/ast/failed_null_function_result.das
+++ b/tests/ast/failed_null_function_result.das
@@ -1,0 +1,15 @@
+options gen2
+expect 50609    // internal_function — malformed AST, function is missing its result type
+
+require _malformed_tree_macros
+
+[null_result_fn]
+struct Foo {
+    a : int
+}
+
+[export]
+def main {
+    var f = Foo(a = 1)
+    print("{f.a}\n")
+}

--- a/tests/ast/failed_null_let_entry.das
+++ b/tests/ast/failed_null_let_entry.das
@@ -1,0 +1,11 @@
+options gen2
+expect 50640    // internal_variable — malformed AST, let expression has a null variable entry
+
+require _malformed_tree_macros
+
+[export]
+def main {
+    for (i in nullvar_range(0, 10)) {
+        print("{i}\n")
+    }
+}

--- a/tests/ast/failed_short_iterator_arrays.das
+++ b/tests/ast/failed_short_iterator_arrays.das
@@ -1,0 +1,11 @@
+options gen2
+expect 50607    // internal_expression — malformed AST, iteratorsAt/iteratorsAka shorter than iterators
+
+require _malformed_tree_macros
+
+[export]
+def main {
+    for (i in short_iters_range(0, 10)) {
+        print("{i}\n")
+    }
+}

--- a/tests/ast/failed_sticky_macro_error.das
+++ b/tests/ast/failed_sticky_macro_error.das
@@ -1,0 +1,11 @@
+options gen2
+expect 50503    // runtime_macro — macro_sticky_error on a VALID tree must still fail the compile
+
+require _malformed_tree_macros
+
+[export]
+def main {
+    for (i in sticky_range(0, 10)) {
+        print("{i}\n")
+    }
+}

--- a/tests/ast/failed_typeless_let_variable.das
+++ b/tests/ast/failed_typeless_let_variable.das
@@ -1,0 +1,14 @@
+options gen2
+expect 50640    // internal_variable — malformed AST, variable 't`less' is missing its type
+
+// The macro injects a `let` whose Variable has no type; the compiler must report
+// 50640 (not crash, not silently repair-and-succeed)
+
+require _typeless_let_macro
+
+[export]
+def main {
+    for (i in typeless_range(10)) {
+        print("{i}\n")
+    }
+}


### PR DESCRIPTION
## What

Macro-built trees with simple malformations crashed the compiler — or worse, went silently UB. The canonical case: a `[for_loop_macro]` emitting a `Variable` with no `_type` segfaulted in `InferTypes::preVisitLet` (null-`this` into `TypeDecl::isAliasOrA2A`). This PR turns that whole family into precise compile errors.

## The sticky-error mechanism

Detect-and-repair alone cannot fail the compile: infer clears `program->errors` every pass, so once the guard repairs the tree, the next pass infers cleanly and the report vanishes — the broken macro *silently compiles*. New `Program::stickyError()` records into a `stickyErrors` list that is re-armed at the end of every infer leg, so the guards can repair in place (keeping the rest of the pipeline crash-proof) while the compile still fails. Exposed to das macros as `macro_sticky_error`, next to `macro_error` (grouped + documented for das2rst).

## The guards (all probe-verified crashes or silent UB before)

The boundary: **guard every field the visitor walk null-tolerates but infer derefs** — one choke point covers every macro ever written. Null *expression children* (`ExprOp2` operands, `if` conditions) stay reactive by design: the recursive walk derefs them before any callback; crash-capture is the diagnostic there.

| Malformation | Before | Now |
|---|---|---|
| `Variable` with null type (let / global / function arg / block arg / structure field) | segfault in infer | 50640 / 50608, repair to auto |
| `Function` with null `result` | segfault at `visit(Function)` | 50609, repair to auto |
| null entry in `variables` / `arguments` lists (let, function, block) | segfault in `checkEmptyName` | 50640 / 50609, entry erased |
| `ExprFor` with null `body` | segfault in **const-folding** (infer tolerated it) | 50607, repair to empty block |
| `ExprFor` null source entry | segfault in walk | 50607, entry erased |
| `iteratorsAt`/`iteratorsAka` shorter than `iterators` | **silent OOB** — probe ran "fine" | 50607, padded |

Comprehension-embedded `ExprFor` legally has a null body until lowering — exempted by pointer identity via `preVisit(ExprArrayComprehension)` (first build caught this the hard way: the guard refused to compile `daslib/ast_boost` itself).

Existing codes reused (`internal_variable`/`internal_field`/`internal_function`/`internal_expression`/`runtime_macro`) — no enum or RTTI-mirror changes.

## Tests

6 `failed_*` tests in `tests/ast/` pin the exact error codes, including `macro_sticky_error` reported on a *valid* tree surviving re-infer (50503). Fixtures: `_typeless_let_macro.das`, `_malformed_tree_macros.das`.

## Validation

- Full repo suite: 13137 tests, 13136 passed, 0 failed, 0 errors, 1 skipped
- JIT smoke (array + decs bulk-create): no verifier errors
- Lint: 0 issues on all changed `.das`; formatter-clean
- das2rst: 2 passes clean, 0 Uncategorized; sphinx warnings triaged — all 69 are local-environment (unstaged tutorial videos + imgui generated docs this local binary doesn't emit), none in the changed area
- Pushed `--no-verify` per the standing preflight bar (targeted gates above in lieu of the full token run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
