### PR TITLE
pages CI: mirror the deployed site to the daslang.io origin VPS

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -509,5 +509,45 @@ jobs:
         path: _site
 
     - name: "Deploy to GitHub Pages"
+      # master-only so a workflow_dispatch from a branch cannot touch the
+      # production Pages site. The job-level `github-pages` environment also
+      # scopes DASWEB_DEPLOY_KEY below (master-only branch policy), so testing
+      # the VPS leg from a branch needs that policy widened deliberately.
+      if: github.ref == 'refs/heads/master'
       id: deployment
       uses: actions/deploy-pages@v4
+
+    - name: "Deploy to daslang.io origin (VPS)"
+      # Mirror the exact _site snapshot onto the origin box (daslang.io is
+      # moving off GitHub Pages; both targets stay in sync until DNS flips).
+      # Release layout on the box: /srv/daslang.io/releases/<rNNN-sha>, with
+      # `current` an atomic symlink Caddy serves; --link-dest hard-links files
+      # unchanged since the previous release so a docs-only deploy costs ~MBs.
+      env:
+        DEPLOY_KEY: ${{ secrets.DASWEB_DEPLOY_KEY }}
+      run: |
+        set -euo pipefail
+        if [ -z "$DEPLOY_KEY" ]; then
+            echo "DASWEB_DEPLOY_KEY not set (fork?) - skipping VPS deploy"
+            exit 0
+        fi
+        mkdir -p ~/.ssh
+        printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/dasweb_deploy
+        chmod 600 ~/.ssh/dasweb_deploy
+        # Pinned host key - no trust-on-first-use from CI.
+        echo '89.167.63.131 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILP2wzOeEGD2r7apldQlTe2gwR1dVTCXCfrD+pJooMmY' >> ~/.ssh/known_hosts
+        RSH="ssh -i $HOME/.ssh/dasweb_deploy -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes"
+        REL="r${{ github.run_number }}-$(echo "$GITHUB_SHA" | cut -c1-8)"
+        # Hard-link against the previous release when there is one. rsync only
+        # warns on a missing --link-dest, but skipping it keeps the log honest
+        # on a fresh/rebuilt box.
+        LINK=""
+        if $RSH deploy@89.167.63.131 "test -d /srv/daslang.io/current/"; then
+            LINK="--link-dest=/srv/daslang.io/current/"
+        fi
+        rsync -az --delete $LINK \
+            -e "$RSH" _site/ "deploy@89.167.63.131:/srv/daslang.io/releases/$REL/"
+        # Atomic flip, then prune to the 5 newest releases.
+        $RSH deploy@89.167.63.131 "ln -sfn /srv/daslang.io/releases/$REL /srv/daslang.io/current \
+            && cd /srv/daslang.io/releases && ls -1t | tail -n +6 | xargs -r rm -rf"
+        echo "deployed $REL"


### PR DESCRIPTION
## What

After the GitHub Pages deploy, mirror the exact staged `_site` snapshot onto the daslang.io origin VPS (`89.167.63.131`) via rsync over SSH. First step of the daslang.io / dasllama.io self-hosting migration: both targets stay in sync on every master push, and the eventual cutover is a pure DNS change with GH Pages as instant rollback.

## How

- New step `Deploy to daslang.io origin (VPS)` after the Pages deploy:
  - releases land in `/srv/daslang.io/releases/<rNNN-shortsha>/`, `current` symlink flips atomically (Caddy serves `current`), pruned to the 5 newest releases
  - `--link-dest` against the previous release hard-links unchanged files, so a docs-only deploy transfers only deltas
  - SSH host key is pinned in the workflow (no trust-on-first-use from CI); auth via new repo secret `DASWEB_DEPLOY_KEY` (dedicated `deploy` user on the box, owns only `/srv/*`)
  - if the secret is absent (forks), the step no-ops
- The Pages deploy step is now gated `if: github.ref == 'refs/heads/master'`, so a `workflow_dispatch` from a branch exercises only the VPS leg without touching production Pages.

## Verification

Branch dispatch run [30798897364](https://github.com/GaijinEntertainment/daScript/actions/runs/30798897364) — green. 645 MB site landed as release `r1151-aa052095`; `http://89.167.63.131/` serves the full site (front page, `/doc/`, `/playground/` all 200). The temporary environment branch-policy used for that test has been removed (`github-pages` allows master only again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
