### PR TITLE
dasweb-playground: the daslang.io playground backend - share links + curated samples through a content-addressed store

### DIFF
--- a/daslib/sha_256.das
+++ b/daslib/sha_256.das
@@ -37,10 +37,10 @@ let private K = fixed_array<uint>(
 
 struct Sha256State {
     //! Streaming hash state. Create with ``sha256_init``; do not mutate directly.
-    h : uint[8]
-    buf : uint8[64]
-    bufLen : int
-    totalBytes : uint64
+    h : uint[8] //! Current hash values (eight 32-bit words).
+    buf : uint8[64] //! Pending input block.
+    bufLen : int //! Bytes buffered in the pending block.
+    totalBytes : uint64 //! Total bytes absorbed so far.
 }
 
 def sha256_init : Sha256State {

--- a/daslib/sha_256.das
+++ b/daslib/sha_256.das
@@ -1,0 +1,165 @@
+options gen2
+options indenting = 4
+
+module sha_256 shared public
+
+require strings
+
+//! FIPS 180-4 SHA-256.
+//!
+//! Content-addressing and integrity checks need a collision-resistant hash;
+//! the builtin 64-bit ``hash`` is not one (collisions are trivially
+//! computable). This module is pure daslang — it runs identically under
+//! interpreter, JIT, AOT, and wasm.
+//!
+//! One-shot: ``sha256_hex("abc")`` or ``sha256_hex(bytes)`` → 64-char
+//! lowercase hex. Streaming: ``sha256_init`` / ``sha256_update`` /
+//! ``sha256_final`` for data that arrives in pieces.
+
+let private K = fixed_array<uint>(
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+)
+
+struct Sha256State {
+    //! Streaming hash state. Create with ``sha256_init``; do not mutate directly.
+    h : uint[8]
+    buf : uint8[64]
+    bufLen : int
+    totalBytes : uint64
+}
+
+def sha256_init : Sha256State {
+    //! Fresh streaming state (FIPS 180-4 initial hash values).
+    var st : Sha256State
+    st.h = fixed_array<uint>(
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19)
+    return st
+}
+
+def private rotr(x : uint; n : uint) : uint {
+    return (x >> n) | (x << (32u - n))
+}
+
+def private compress(var st : Sha256State) {
+    var w : uint[64]
+    for (i in range(16)) {
+        w[i] = ((uint(st.buf[i * 4]) << 24u)
+            | (uint(st.buf[i * 4 + 1]) << 16u)
+            | (uint(st.buf[i * 4 + 2]) << 8u)
+            | uint(st.buf[i * 4 + 3]))
+    }
+    for (i in range(16, 64)) {
+        let s0 = rotr(w[i - 15], 7u) ^ rotr(w[i - 15], 18u) ^ (w[i - 15] >> 3u)
+        let s1 = rotr(w[i - 2], 17u) ^ rotr(w[i - 2], 19u) ^ (w[i - 2] >> 10u)
+        w[i] = w[i - 16] + s0 + w[i - 7] + s1
+    }
+    var a = st.h[0]
+    var b = st.h[1]
+    var c = st.h[2]
+    var d = st.h[3]
+    var e = st.h[4]
+    var f = st.h[5]
+    var g = st.h[6]
+    var hh = st.h[7]
+    for (i in range(64)) {
+        let s1 = rotr(e, 6u) ^ rotr(e, 11u) ^ rotr(e, 25u)
+        let ch = (e & f) ^ (~e & g)
+        let temp1 = hh + s1 + ch + K[i] + w[i]
+        let s0 = rotr(a, 2u) ^ rotr(a, 13u) ^ rotr(a, 22u)
+        let maj = (a & b) ^ (a & c) ^ (b & c)
+        let temp2 = s0 + maj
+        hh = g
+        g = f
+        f = e
+        e = d + temp1
+        d = c
+        c = b
+        b = a
+        a = temp1 + temp2
+    }
+    st.h[0] += a
+    st.h[1] += b
+    st.h[2] += c
+    st.h[3] += d
+    st.h[4] += e
+    st.h[5] += f
+    st.h[6] += g
+    st.h[7] += hh
+}
+
+def sha256_update(var st : Sha256State; b : uint8) {
+    //! Absorb one byte.
+    st.buf[st.bufLen] = b
+    st.bufLen ++
+    st.totalBytes ++
+    if (st.bufLen == 64) {
+        compress(st)
+        st.bufLen = 0
+    }
+}
+
+def sha256_update(var st : Sha256State; data : array<uint8>) {
+    //! Absorb a byte array.
+    for (b in data) {
+        sha256_update(st, b)
+    }
+}
+
+def sha256_final(var st : Sha256State) : uint[8] {
+    //! Apply FIPS 180-4 padding and return the digest as eight big-endian words.
+    //! The state is consumed — reuse requires a fresh ``sha256_init``.
+    let bitLen = st.totalBytes * 8ul
+    sha256_update(st, uint8(0x80))
+    while (st.bufLen != 56) {
+        sha256_update(st, uint8(0))
+    }
+    for (shift in fixed_array<uint64>(56ul, 48ul, 40ul, 32ul, 24ul, 16ul, 8ul, 0ul)) {
+        st.buf[st.bufLen] = uint8(bitLen >> shift)
+        st.bufLen ++
+    }
+    compress(st)
+    return st.h
+}
+
+def sha256_hex_digest(digest : uint[8]) : string {
+    //! Digest words → 64-char lowercase hex.
+    return build_string() $(writer) {
+        for (word in digest) {
+            fmt(writer, ":08x", word)
+        }
+    }
+}
+
+def sha256_hex(s : string) : string {
+    //! SHA-256 of the string's bytes (no terminator), lowercase hex.
+    var st = sha256_init()
+    peek_data(s) $(bytes) {
+        for (b in bytes) {
+            sha256_update(st, b)
+        }
+    }
+    return sha256_hex_digest(sha256_final(st))
+}
+
+def sha256_hex(data : array<uint8>) : string {
+    //! SHA-256 of a byte array, lowercase hex.
+    var st = sha256_init()
+    sha256_update(st, data)
+    return sha256_hex_digest(sha256_final(st))
+}

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -96,6 +96,7 @@ require daslib/generic_return
 // require daslib/heartbeat                     // qmacro(heartbeat()) conflicts when used in das2rst context
 require daslib/lint
 require daslib/logger
+require daslib/sha_256
 // require daslib/lint_everything               // global_lint_macro causes lint errors in other modules
 require daslib/profiler
 require daslib/profiler_boost
@@ -1340,6 +1341,15 @@ def document_module_logger(_root : string) {
     document("Structured JSON Lines logger", mod, "logger.rst", groups)
 }
 
+def document_module_sha_256(_root : string) {
+    var mod = find_module("sha_256")
+    var groups <- array<DocGroup>(
+        group_by_regex("One-shot hashing", mod, %regex~.*(sha256_hex)$%%),
+        group_by_regex("Streaming", mod, %regex~.*(sha256_init|sha256_update|sha256_final|sha256_hex_digest)$%%)
+    )
+    document("SHA-256", mod, "sha_256.rst", groups)
+}
+
 def document_module_lint_everything(_root : string) {
     var mod = find_module("lint_everything")
     var groups <- array<DocGroup>(
@@ -1915,6 +1925,7 @@ def main {  // nolint:STYLE038 — flat one-call-per-documented-module dispatch 
     document_module_lint_config(root)
     document_module_toml(root)
     document_module_logger(root)
+    document_module_sha_256(root)
     // document_module_lint_everything(root)       // global_lint_macro causes lint errors in other modules
     // document_module_live(root)                  // uses multiple_contexts
     document_module_lpipe(root)

--- a/doc/source/stdlib/handmade/module-sha_256.rst
+++ b/doc/source/stdlib/handmade/module-sha_256.rst
@@ -1,0 +1,1 @@
+FIPS 180-4 SHA-256 in pure daslang: one-shot hashing of strings and byte arrays to lowercase hex, plus a streaming init/update/final state for data that arrives in pieces. Content addressing and integrity checks need a collision-resistant hash; the builtin 64-bit hash is not one.

--- a/doc/source/stdlib/handmade/structure-sha_256-Sha256State.rst
+++ b/doc/source/stdlib/handmade/structure-sha_256-Sha256State.rst
@@ -1,5 +1,0 @@
-Streaming hash state; create with sha256_init and feed through sha256_update / sha256_final.
-Current hash values (eight 32-bit words).
-Pending input block (64 bytes).
-Bytes currently buffered in the pending block.
-Total bytes absorbed so far.

--- a/doc/source/stdlib/handmade/structure-sha_256-Sha256State.rst
+++ b/doc/source/stdlib/handmade/structure-sha_256-Sha256State.rst
@@ -1,0 +1,5 @@
+Streaming hash state; create with sha256_init and feed through sha256_update / sha256_final.
+Current hash values (eight 32-bit words).
+Pending input block (64 bytes).
+Bytes currently buffered in the pending block.
+Total bytes absorbed so far.

--- a/doc/source/stdlib/sec_algorithms.rst
+++ b/doc/source/stdlib/sec_algorithms.rst
@@ -15,3 +15,4 @@ and pattern matching.
    generated/linq_boost.rst
    generated/linq_fold.rst
    generated/match.rst
+   generated/sha_256.rst

--- a/plans/dasweb_backend.md
+++ b/plans/dasweb_backend.md
@@ -351,6 +351,20 @@ own plan doc before implementation; the contour:
 - Checkpoint 3a: curated sample builds end-to-end through the real queue from a cold cache.
   Checkpoint 3b: user-visible flow with the building indicator, on a live server.
 
+## Pre-PR gate — security-focused code review
+
+Before the arc PR (and again before any later PR that touches the service): run `/code-review`
+over the full changed set **with an explicit security focus** — input validation, SQL injection
+surface, path handling, loopback binding, secrets in logs, the Caddy route boundary. Findings
+follow the normal verify-then-fix discipline; a finding class that survives review gets a
+CODEREVIEW.md rule so it cannot recur silently.
+
+`utils/dasweb-playground/CODEREVIEW.md` exists from the get-go (same language/structure as
+`modules/dasLLAMA/CODEREVIEW.md`) and carries the binding per-diff rules: file-placement
+(one file, one rule — keeps things from going all over the place), tests-in-dir + bug⇒test,
+the security criteria, logging criteria, lifecycle rules. `skills/make_pr.md` step 0a
+discovers it automatically for every future PR touching this directory.
+
 ## Phase 4 — documentation ("for all the good stuff")
 
 Continuous minimum rides each PR anyway (CI-forced): das2rst group + doc registration for

--- a/plans/dasweb_backend.md
+++ b/plans/dasweb_backend.md
@@ -1,0 +1,368 @@
+# dasweb backend — samples store, curated unification, wasm pipeline
+
+Companion to `E:\DASWEB\plan.md` (infrastructure; boxes are live) — this doc covers the software.
+Branch: `bbatkin/dasweb-arc`, worktree `D:\Work\daScript-dasweb`.
+
+State when written (2026-08-04): daslang.io + dasllama.io serve from the web VPS (`dasweb-1`,
+89.167.63.131, Debian 13) behind Caddy; every master push mirrors the CI-built site via
+`pages.yml`; COOP/COEP headers already serve the threaded playground/examples correctly.
+Compute box (`zen4`, 65.108.238.44, Debian 12) is Boris's profiling rig for now; phase 3 claims
+it. GH Pages remains deploy-mirrored as catastrophe insurance only.
+
+Boris's phasing (agreed):
+
+1. `/s/<hash>` for user samples, live. Everything else unchanged.
+2. Curated samples through the same store; wasm ("jit") button disabled. Web box fully unified.
+3. wasm build infrastructure on the compute box; "building" UI; rename jit → wasm.
+   Split: 3a machinery first, 3b UX.
+
+Phase 0 (backups) is a parallel track, NOT a gate (Boris 2026-08-04): pre-backup, a lost
+samples.db strands only freshly-minted links — no worse than the third-party shortener chain
+it replaces, which can go stale any second. Land it when the Storage Box lands (procedural,
+Boris chasing IT); litestream bolts onto the live service with zero migration. One cheap
+honesty rule until then: the share UI says "share link", not "permanent link" — we don't
+advertise permanence before backups can honor it.
+
+---
+
+## Architecture invariants (all phases)
+
+- Caddy is the only public listener. Services bind `127.0.0.1` only, via `set_bind_host`
+  (call after `init(port)`, before `start()` — dasHerd watcher pattern, `utils/dasHerd/watcher/main.das:209`).
+- Port registry = the Caddyfile. Convention: **81xx daslang.io services, 82xx dasllama.io**.
+  `dasweb-playground` = **8101**. (`dasllama-ladder` = 8201, later, own plan.)
+- One process per service; merge only if reality forces it.
+- Every service follows the watchdog contract (below). systemd keeps the *watchdog* alive;
+  the watchdog keeps the *service* alive.
+- Sources are the archive (SQLite, litestream-replicated, precious). wasm artifacts are a cache
+  (files on disk, regenerable from source hash × toolchain, evictable — phase 3).
+
+## Service anatomy (the reusable shape — dasweb-playground is the first instance)
+
+Reference: `examples/hv/ws_chat_server.das` ("the canonical daslang server shape") +
+`utils/dasllama-server/` conventions + `examples/telegram/dictation/.das_package` (the deployed-
+service manifest template).
+
+```
+daslib/sha_256.das       real SHA-256 (bytes -> hex) — new daslib module, see Hashing
+tests/daslib/test_sha_256.das  NIST vectors
+
+utils/dasweb-playground/
+  main.das               launcher: clargs + toml config, logger, lifecycle, GC loop
+  samples_server.das     module: SamplesServer : HvWebServer — route table + handlers only
+  samples_store.das      module: SQLite + hashing + validation, ZERO HTTP (unit-testable seam,
+                         like llm_scheduler.das)
+  test_samples_store.das no network; store roundtrips, migration tests
+  test_samples_server.das end-to-end HTTP on port 19011 (19001..19010 are taken)
+  .das_package           release manifest
+  watchdog.json          { name, health_url, shutdown_url }
+  dasweb-playground.toml    starter config (shipped release_include_if_missing)
+  README.md
+```
+
+Key shape decisions, each grounded in what the repo already does:
+
+- **Options**: `options gen2`, `options gc`, `options persistent_heap`, `options stack = 262144`
+  (plain handlers are fine at 16K per skills/dashv.md, but SQL+JSON chains are not "plain";
+  262144 is cheap insurance, half of dasllama-server's).
+- **Lifecycle**: module-global state only (`var g_server : SamplesServer?` etc.) — JIT GC cannot
+  see stack locals as roots; `[export] init/update/shutdown` + standalone `main` looping
+  `update(); maybe_collect_gc()`. Stock `maybe_collect_gc` from `require live/live_gc` to start;
+  graduate to dasllama-server's rate-limited/logged variant only if GC noise shows up.
+- **Tick**: `g_server->tick()` + `sleep(2u)` idle pacer. Handlers are serialized by design
+  (single tick thread) — fine for this workload, do not assume concurrency.
+- **Route lambdas**: retained with `push` semantics (never `emplace`) — GC-visibility rule from
+  skills/dashv.md.
+- **Tests**: in-dir (hyphenated dir ⇒ bare-name sibling `require`, the dasllama-server
+  convention). `with_test_server` from `tests/dasHV/_dashv_test_common.das` does NOT fit
+  (needs per-thread DB open + `set_bind_host`) — write the local variant of the harness whose
+  thread lambda opens the store first. Server on `new_thread` = own context ⇒ all setup inside
+  the thread.
+
+### Config
+
+`[CommandLineArgs] struct ServerArgs` (clargs) + TOML merge, the dasllama-server precedence:
+defaults < toml < CLI (drop the `authoritative` flip — unneeded here). Auto-discover
+`dasweb-playground.toml` in cwd then beside the module. Keys, phase 1:
+
+```
+port = 8101
+data_dir = "/srv/dasweb-playground"       # samples.db + blobs/ (blobs used in phase 3)
+max_source_bytes = 262144              # dasHV exposes no body cap — enforced in handler
+```
+
+### Logging + watchdog integration (the "watcher" story)
+
+**Design rule (Boris): the server stores just about everything it does — any server should.**
+"If it happens, it's in the log" — the profiling/tuning sessions repeatedly went inconclusive
+for lack of checks/canaries/logs; this service does not repeat that. Concretely, ndjson lines
+for: every request (method, path, status, ms, client ip, bytes in/out); every insert / dedup-hit
+/ import / promote / reimport; every build-job state transition with timings (phase 3); every
+GC cycle; canary/ABI-check outcomes; and a startup banner dumping the full effective config
+WITH provenance (default/toml/cli — the dasllama-server pattern). Logs are cheap; archaeology
+is not.
+
+- `logger_init_tee("dasweb-playground")` in init → ndjson to `logs/dasweb-playground.log` + stdout.
+  No rotation in daslang; rotation is the watchdog's (20 MB × 5 — raise if request volume
+  makes the window too short; the request log must cover at least days, not hours).
+- Supervisor = the shared `utils/watchdog/watchdog.py` (same one dasllama-server and the
+  dictation bot ship). Contract the service honors:
+  - exit **0** = intentional shutdown (watchdog stops), **4** = config-restart request,
+    anything else = crash → notify + bounded-backoff restart + crash bundle.
+    (**3** is the tune-restart code — unused here, no `[tune]` kernels.)
+  - `GET /healthz` (cheap 200) — watchdog polls every 5 s, logs transitions only.
+  - `POST /shutdown` — graceful stop; flips the service's own context flag.
+- `watchdog.json`: `{ "name": "dasweb-playground", "health_url": "http://127.0.0.1:8101/healthz",
+  "shutdown_url": "http://127.0.0.1:8101/shutdown" }`.
+- systemd unit `dasweb-playground.service`: `ExecStart=python3 watchdog.py`, `WorkingDirectory=`
+  the release bundle, `Restart=on-failure` (guards the watchdog itself), `User=dasweb`.
+  Watchdog does the child restarts, stages, crash bundles; journald gets the watchdog's stdout.
+
+### Release + deploy (the daspkg story)
+
+This app has no `[tune]`/`[llvm_code]` kernels ⇒ it bakes to a standalone exe cleanly
+(dasllama-server is headed the same way — its baked-exe bringup exists in parallel work, not
+yet merged; the anatomy here assumes baked-exe as the normal service form). Deploy as a
+**baked `daspkg release` bundle, built on the web box** (no cross-compile exists; `-exe` needs
+dasLLVM + a `c++` driver on PATH — the published Linux SDK bundle carries dasLLVM and can run
+`daspkg release` itself):
+
+```
+# on dasweb-1, one-time: apt install g++; unzip daslang-bundle-linux-x86_64.zip to /opt/daslang
+# deploy script (checked in as utils/dasweb-playground/deploy.sh):
+git -C /srv/src/daScript fetch && git checkout <ref>
+/opt/daslang/bin/daslang utils/daspkg/main.das -- release \
+    --root utils/dasweb-playground --out /srv/apps/dasweb-playground/releases/<sha>
+ln -sfn releases/<sha> /srv/apps/dasweb-playground/current && systemctl restart dasweb-playground
+```
+
+- `.das_package`: `release_main("main.das")`, `release_name("dasweb-playground")`,
+  `release_include_if_missing("dasweb-playground.toml")` (preserve deployed edits),
+  `release_include_from("utils/watchdog/watchdog.py")`, `release_include("watchdog.json")`.
+- Bundle exe is named `dasweb-playground.exe` even on Linux (daspkg convention; CI's sequence
+  smoke test relies on the same).
+- **Launch with cwd = bundle dir** — a relocated exe's `get_das_root()` degrades to cwd
+  (`src/misc/sysos.cpp:666-693`), which is what makes `logs/`, module resolution, and
+  `get_this_module_dir()` land right. systemd `WorkingDirectory=` handles it.
+- **No top-level `let` calling Context-allocating builtins** (`get_this_module_dir()` etc.) —
+  known `-exe` ASLR bake bug; call from functions only.
+- The build costs seconds-to-a-minute on the VPS (JIT codegen + link of a small server —
+  NOT a C++ build); zen4 is not needed for deploys.
+
+CPU-target note: with no `[llvm_code]` kernels the `-exe` targets generic x86-64 ⇒ the bundle
+is portable across our boxes by construction.
+
+---
+
+## Phase 0 — backups (parallel track; lands when the Storage Box does)
+
+1. **Storage Box credentials from IT** (handover checklist item — still owed; Boris chasing.
+   Procedural — the Hetzner account is IT's; no self-serve alternative).
+2. **litestream** on dasweb-1 replicating `samples.db` continuously (SFTP target on the Storage
+   Box if litestream's SFTP replica works as documented — verify at implementation; fallback:
+   file replica to a local dir covered by restic).
+3. **restic nightly** systemd timer (`/etc`, `/home`, `/srv`) per the original IT plan — also
+   still missing on both boxes.
+4. Service user `dasweb` (no sudo), owns `/srv/dasweb-playground` + `/srv/apps/dasweb-playground`.
+5. `apt install g++ python3` on dasweb-1 (release builds + watchdog).
+6. Restore drill: prove `samples.db` restores from litestream + a blob restores from restic
+   as part of landing this phase. A backup that never restored is a rumor. (Once this phase
+   lands, the share UI may say "permanent".)
+
+## Phase 1 — user samples: `/s/<hash>` live
+
+### Storage
+
+Source text lives IN SQLite (KB-scale; one litestream stream covers everything; the `blobs/`
+dir stays empty until phase-3 wasm artifacts, which are MB-scale and stay files).
+
+```das
+[sql_table(name = "samples")]
+struct Sample {
+    @sql_primary_key Hash : string        // full lowercase hex sha256 of the source bytes
+    Source : string                       // the .das text, verbatim
+    Size : int
+    CreatedAt : int64                     // unix seconds
+    ClientIp : string                     // from X-Forwarded-For (Caddy is the only caller)
+    Listed : bool = false                 // phase 2: curated/promoted samples
+    Title : string = ""                   // phase 2
+    Origin : string = "user"              // "user" | "curated"
+}
+```
+
+Migrations via `sqlite/sqlite_migrate` from day one (`[sql_migration(version=1)]` raw-SQL body —
+frozen once shipped). Worked precedent in-tree: the dictation bot
+(`examples/telegram/dictation/cadmus_history.das`) — follow its shape, don't invent. Startup =
+`with_latest_sqlite(path)` equivalent bound to the server thread (SqlRunner is context-bound —
+open INSIDE the server thread).
+Dedup is free: same source ⇒ same hash ⇒ INSERT OR IGNORE semantics (`insert` on PK conflict —
+treat conflict as success, return the hash).
+
+### Hashing
+
+**New daslib module `daslib/sha_256`** (underscore — a require path cannot contain a hyphen).
+Why a real crypto hash and not builtin 64-bit `hash`: content-addressed PUBLIC urls need
+collision resistance — with a computable-collision hash an attacker pre-inserts a malicious
+source colliding with a commonly-shared snippet, and every honest share of the real snippet
+dedups onto the attacker's row (link poisoning). SHA-256 closes the class; KB inputs cost
+microseconds, and a pure-daslang impl also runs in wasm (client-side hashing later, if wanted).
+
+Port the compression core from the playground benchmark (`web/examples/ui/samples/examples/
+sha256.das`) + add standards padding/length. **The benchmark itself is untouched** — its
+non-conformance is deliberate (apples-to-apples with the other dasProfile language ports).
+API: `sha256_hex(data : array<uint8>) : string` + string overload. NIST vectors
+(empty, "abc", million-a's) in `tests/daslib/`. daslib addition ⇒ das2rst group + doc
+registration per `skills/make_pr.md` step 4. No OS shell-outs in the request path (the
+dasLLAMA `sha256sum` precedent is for multi-GB model files, wrong tool here).
+
+### HTTP API (dasHV, port 8101, loopback)
+
+```
+POST /api/samples          body = raw .das text (text/plain; curl-friendly)
+                           → 200 {"hash": "...", "url": "https://daslang.io/s/<hash>"}
+                           → 413 over max_source_bytes (checked in handler — dasHV has no cap)
+                           → 400 empty/non-utf8
+GET  /api/samples/<hash>   → 200 raw source, text/plain; charset=utf-8; immutable cache headers
+                           → 404 unknown
+GET  /s/<hash>             → 302 /playground/index.html?s=<hash>  (permalink humans share)
+GET  /healthz              → 200 "ok" (watchdog + Caddy probes)
+POST /shutdown             → graceful stop (never routed by Caddy — loopback only)
+```
+
+Content-addressed responses are immutable ⇒ `Cache-Control: public, max-age=31536000, immutable`
+on `GET /api/samples/<hash>`. Abuse guard, phase 1 minimal: size cap + per-IP hourly insert
+ceiling — **both toml-configurable** (`max_inserts_per_ip_hour`, one SQL count on ClientIp,
+429 over the ceiling). No auth, no captcha — samples are worthless to spam until listed.
+(Phase-3 note, Boris: build requests need no extra limiter — the queue plus baking time IS the
+natural throttle; the insert ceiling exists only because inserts are the cheap unqueued path.)
+
+### Caddy routing (adds to the daslang.io vhost)
+
+```
+handle /s/* {
+    reverse_proxy 127.0.0.1:8101
+}
+handle /api/samples/* {
+    reverse_proxy 127.0.0.1:8101
+}
+```
+
+### Playground integration (site/ change, rides the same CI deploy)
+
+- Share button: POST current editor text to `/api/samples`, put the returned `/s/<hash>` URL in
+  the clipboard/share box. Kills the zip+tinyurl third-party chain.
+- Loader: on `?s=<hash>` param, fetch `/api/samples/<hash>` into the editor.
+- Old share links keep working (loader keeps the legacy param path); we just stop MINTING them.
+
+### Definition of done (live-server test, Boris's checkpoint 1)
+
+- `curl -d @file.das https://daslang.io/api/samples` returns a URL; opening it loads the
+  playground with the code; same POST twice returns the same hash.
+- Kill -9 the service: watchdog restarts it with backoff; `/s/<hash>` works after restart;
+  static site never blinked.
+- lint/format/tests green per `skills/make_pr.md`. (Backups are phase 0, parallel — not part
+  of this checkpoint.)
+
+## Phase 2 — curated samples through the store; wasm button off
+
+- **Importer** — the "introduce existing files" process, idempotent by construction, no ETL:
+  on boot (and on a `POST /api/samples/reimport` admin nudge from loopback), scan the deployed
+  curated dir (`/srv/daslang.io/current/playground/samples/**.das` — already shipped by the
+  site deploy); each file: read → hash → INSERT-OR-IGNORE as Origin="curated", Listed=true,
+  Title from the existing samples manifest. Unchanged file ⇒ same hash ⇒ no-op; changed file
+  next deploy ⇒ new hash row and the LISTING repoints while the old row stays resolvable
+  (permalinks never break). Safe to re-run any number of times.
+- **Dropdown**: `GET /api/samples/listed` → `[{hash, title, category}]`; playground dropdown
+  consumes it instead of the static list. Dropdown stays, exactly as today, just fed by the store.
+- **Disable the "jit" button** (one flag in playground JS) — honest until phase 3 serves real
+  builds.
+- **Promotion** ("add one of theirs"): `utils/dasweb-playground/admin.das` — a tiny clargs CLI run
+  on the box over ssh (`admin.das -- promote <hash> --title "..."` → Listed=true). No public
+  admin surface, no auth added to the API.
+- Checkpoint 2 (live): dropdown loads from the store; every curated entry opens + runs
+  interpreted; user flow from phase 1 unchanged; wasm button absent.
+
+## Phase 3 — wasm pipeline (sketch; detailed plan when phase 2 ships)
+
+3a machinery first, 3b UX second. New service on the compute box (working name
+`utils/dasweb-buildd`) + queue/artifact endpoints added to dasweb-playground. This phase gets its
+own plan doc before implementation; the contour:
+
+- **Queue**: table in samples.db (hash, toolchain_id, state: queued/building/done/failed,
+  attempts, timings). dasweb-playground exposes loopback-free authed endpoints for the builder:
+  `GET /api/build/next` (claim, bearer token from toml), `POST /api/build/result` (artifact
+  upload + status). Compute box PULLS over HTTPS — nothing on the web box ever connects to it
+  (trust direction preserved; box death = queue backs up, site unaffected).
+- **Builder** (compute box): same service anatomy (watchdog, logger, clargs+toml); polls the
+  queue; each build in a throwaway sandbox (rootless podman or nsjail: no network, CPU/mem/time
+  caps, tmpfs) running `daspkg release wasm`; uploads `.wasm` (+ `.br` precompressed sidecar)
+  or the compiler error text.
+- **Toolchain = latest master, built in a dedicated worktree on the box** (Boris's call:
+  matches what the site ships). The worktree holds daslang + shared_modules + the wasm runtime
+  archives; a toolchain bump = update the worktree + rebuild, which changes `toolchain_id`
+  (= that worktree's git sha) and thereby lazily invalidates the artifact cache by construction.
+  Version skew is tolerable mid-bump: each `release wasm` artifact is self-contained (bundles
+  its runtime), so an older artifact still runs standalone.
+- **The wasm64 build config is NOT free-form — replicate CI's recipe exactly.** Authority:
+  `.github/workflows/pages.yml` "Build: Daslang host" step comments + `web/CMakeLists.txt`
+  (`web/README.md` documents only the wasm32 path). The load-bearing specifics:
+  - Cross-compile host daslang built with **libc++ + `-DDAS_ENABLE_EXCEPTIONS=1`** (clang, not
+    gcc/libstdc++): the host JIT-codegens the samples and bakes C++ handled-type layouts —
+    a libstdc++/setjmp host bakes WRONG offsets (std::string 32 vs 24 B, mutex 80 vs 40 B) ⇒
+    wasm heap corruption. Host==target stdlib/exception config is the whole trick that makes
+    the cross-compile "close". Host ptr width == target ptr width (wasm64 ⇒ 64-bit host).
+  - `web/build64` configured with `DAS_WASM_MEMORY64=ON`, `DAS_WASM_PTHREADS=ON`,
+    `-sMEMORY64=1` in C/CXX flags, `DAS_HOST_DASLANG_OVERRIDE` pointing at that host build.
+  - **emsdk pinned to the same version pages.yml pins** (5.0.7 at time of writing — the pin
+    history in pages.yml documents why: emsdk LLVM snapshots repeatedly broke ds_parser.cpp).
+  - ⇒ zen4's PROFILING daslang (`~/zen4_build.sh`, native clang-19) can never serve as the
+    wasm host; the wasm worktree gets its own host build with these flags. Deliverable: a
+    checked-in `build_wasm_host.sh` capturing the recipe (extracted from pages.yml, kept in
+    lockstep with it) + a SETUP.md section on the box; parity gate before first serve = build
+    a curated sample on zen4 and diff behavior against the CI-built artifact of the same
+    (source, toolchain) pair.
+- **ABI canary on every toolchain bump — `--jit-check-abi`** (`modules/dasLLVM/daslib/
+  llvm_exe.das:655-693`): emits a host-vs-target layout check for EVERY handled type into the
+  minted binary — bakes host size + field offsets, resolves the target's at runtime, records
+  every divergence, dumps all and aborts. Builder protocol: a new `toolchain_id` goes live
+  ONLY after a canary sample built with `--jit-check-abi` runs clean; result (including the
+  full divergence dump on failure) goes in the log. Guard the known silent path: web/
+  CMakeLists.txt WARNS-not-fails when the host compiler isn't clang ("degraded but builds") —
+  `build_wasm_host.sh` hard-requires clang so that degradation cannot happen quietly on zen4.
+  - The box environment is Boris's profiling rig first — he leaves a .md on the box documenting
+    what lives where; the wasm toolchain install (notably **emsdk**, pinned to the same version
+    pages.yml uses) must be documented alongside it and not stomp the profiling setup. Nothing
+    on zen4 gets touched until Boris signals the profiling session is done.
+- **Artifacts**: `blobs/<toolchain_id>/<hash>.wasm[.br]` on the web box, served static by the
+  samples service (or Caddy `handle_path` straight from disk); LRU eviction, curated pinned;
+  toolchain_id in the key ⇒ a release bump lazily invalidates everything, warmup job re-enqueues
+  the curated set post-deploy.
+- **UX**: "building… (queue position N)" state in the playground; rename jit → wasm everywhere
+  user-visible; failed-build shows the compiler error.
+- **CI**: keep a compile-gate job proving the curated set builds (test, publishes nothing) — a
+  broken sample reds CI, not the production queue.
+- Checkpoint 3a: curated sample builds end-to-end through the real queue from a cold cache.
+  Checkpoint 3b: user-visible flow with the building indicator, on a live server.
+
+## Open questions (decide before/during phase 1)
+
+1. ~~Name~~ **DECIDED (Boris 2026-08-04): `dasweb-playground`** (dir, binary, watchdog name,
+   systemd unit; port 8101). `dasllama-ladder` still the working name for the leaderboard.
+2. litestream SFTP → Hetzner Storage Box: verify support at implementation; fallback documented
+   in Phase 0.
+3. ~~Per-IP rate ceiling~~ DECIDED: configurable via toml (default 100/h, tune live).
+4. ~~restic mirror of samples.db~~ **DECIDED (Boris): yes, very much so.** Mechanism: a raw
+   copy of a live SQLite file is not guaranteed consistent (mid-checkpoint), so the nightly
+   timer produces a proper snapshot first — `sqlite3 samples.db ".backup <data_dir>/nightly/
+   samples.db"` (the online-backup API; consistent by construction) — and restic picks up the
+   snapshot file with the rest of `/srv`. Litestream stays the point-in-time stream; the restic
+   snapshot is the independent belt-and-braces copy.
+
+## Non-goals / deferred
+
+- dasllama-ladder (leaderboard) — separate plan, same service anatomy, port 8201.
+- Umami/analytics changes — GoatCounter stays as-is.
+- daslang.io IPv6, Cloudflare orange-cloud — infra follow-ups, unrelated.
+- Any moderation/abuse tooling beyond size+rate caps — revisit when there's traffic.
+- Touching the playground sha256 BENCHMARK — stays non-conforming on purpose (dasProfile
+  cross-language parity).

--- a/plans/dasweb_backend.md
+++ b/plans/dasweb_backend.md
@@ -73,11 +73,18 @@ Key shape decisions, each grounded in what the repo already does:
   (single tick thread) — fine for this workload, do not assume concurrency.
 - **Route lambdas**: retained with `push` semantics (never `emplace`) — GC-visibility rule from
   skills/dashv.md.
-- **Tests**: in-dir (hyphenated dir ⇒ bare-name sibling `require`, the dasllama-server
-  convention). `with_test_server` from `tests/dasHV/_dashv_test_common.das` does NOT fit
-  (needs per-thread DB open + `set_bind_host`) — write the local variant of the harness whose
-  thread lambda opens the store first. Server on `new_thread` = own context ⇒ all setup inside
-  the thread.
+- **Tests — the session rules (Boris 2026-08-04):**
+  1. **The server gets tests for ALL functionality from the get-go** — every route, every
+     store operation, every config/limit behavior has a dastest test before it's called done.
+     We have a test framework; we are not afraid to use it.
+  2. **Every bug found during the arc gets a regression test**, in the same change as the fix.
+  3. **Tests live in-dir** — `utils/dasweb-playground/test_*.das`, like other utils
+     (hyphenated dir ⇒ bare-name sibling `require`, the dasllama-server convention). NOT under
+     global `tests/`. (Exception already landed: `daslib/sha_256` is a daslib module, so its
+     tests are correctly global at `tests/daslib/test_sha_256.das`.)
+  `with_test_server` from `tests/dasHV/_dashv_test_common.das` does NOT fit (needs per-thread
+  DB open + `set_bind_host`) — write the local variant of the harness whose thread lambda
+  opens the store first. Server on `new_thread` = own context ⇒ all setup inside the thread.
 
 ### Config
 
@@ -343,6 +350,22 @@ own plan doc before implementation; the contour:
   broken sample reds CI, not the production queue.
 - Checkpoint 3a: curated sample builds end-to-end through the real queue from a cold cache.
   Checkpoint 3b: user-visible flow with the building indicator, on a live server.
+
+## Phase 4 — documentation ("for all the good stuff")
+
+Continuous minimum rides each PR anyway (CI-forced): das2rst group + doc registration for
+`daslib/sha_256` (and any later daslib addition), README per new tool dir. The dedicated
+phase at arc end covers the rest properly:
+
+- `daslib/sha_256` — stdlib reference page prose (beyond the generated stub).
+- `utils/dasweb-playground/README.md` — run/endpoints/config/supervised-deployment, the
+  dasllama-server README shape.
+- Ops runbook: box layout, Caddy routes + port registry, deploy/rollback procedure, backup
+  restore procedure, "where are the logs / what do they contain".
+- Playground user-facing bits: share-link behavior (`/s/<hash>`), wasm build states (phase 3).
+- zen4 `~/SETUP.md` wasm-toolchain section + `build_wasm_host.sh` header prose (phase 3).
+- A doc/source page only if any of this graduates to public reference material — decide then
+  (`skills/documentation_rst.md` + `skills/tutorial_prose.md` apply).
 
 ## Open questions (decide before/during phase 1)
 

--- a/plans/dasweb_backend.md
+++ b/plans/dasweb_backend.md
@@ -249,9 +249,12 @@ natural throttle; the insert ceiling exists only because inserts are the cheap u
 handle /s/* {
     reverse_proxy 127.0.0.1:8101
 }
-handle /api/samples/* {
+handle /api/samples* {
     reverse_proxy 127.0.0.1:8101
 }
+# NOTE: /api/samples* (no slash) — the slash form would not match the exact
+# path POST /api/samples that share minting uses. This matches the deployed
+# Caddyfile. /admin/* and /shutdown are deliberately NOT routed.
 ```
 
 ### Playground integration (site/ change, rides the same CI deploy)

--- a/site/playground/playground-init.js
+++ b/site/playground/playground-init.js
@@ -14,10 +14,58 @@ window.FORGE_PLAYGROUND_OPTS = {
     highlightSelectionMatches: { showToken: /\w/ },
 };
 
+// Hand a {files, active} payload to pgLoadFiles once the tab strip is mounted.
+// Stash the bundle immediately so pgInit picks it up even if it polls in
+// before we do, and flag the page as "restored from URL state" so main.js
+// skips its default `selectSample("examples", 0)` — otherwise the async
+// data.json fetch occasionally beats pgLoadFiles and the default hello.das
+// overwrites the shared payload. `active` rides along for playground-tabs.js's
+// tryInit, which otherwise falls back to main.das and loses the selected tab.
+function applySharedPayload(payload) {
+    window.__pendingSampleBundle = payload.files;
+    window.__pendingSampleActive = payload.active;
+    window.pgRestoredFromState = true;
+    const deadline = Date.now() + 5000;
+    (function tryApply() {
+        if (typeof window.pgLoadFiles === 'function') {
+            window.__pendingSampleBundle = null;
+            window.__pendingSampleActive = null;
+            window.pgLoadFiles(payload.files, payload.active);
+            return;
+        }
+        if (Date.now() < deadline) setTimeout(tryApply, 50);
+    })();
+}
+
+// `?s=<sha256>` — a stored sample on the daslang.io sample service; the body
+// is either one raw .das source or a {files, active} JSON bundle (multi-file
+// shares store the same payload the legacy #z= format compressed).
+function applySharedCodeFromServer(hash) {
+    fetch('/api/samples/' + hash)
+        .then((resp) => {
+            if (!resp.ok) throw new Error('sample fetch ' + resp.status);
+            return resp.text();
+        })
+        .then((src) => {
+            let payload = null;
+            try {
+                const obj = JSON.parse(src);
+                if (obj && obj.files) payload = obj;
+            } catch (e) { /* plain single-file source */ }
+            if (!payload) payload = { files: { 'main.das': src }, active: 'main.das' };
+            applySharedPayload(payload);
+        })
+        .catch((e) => { console.warn('shared-sample load failed:', e); });
+}
+
 // `#code=<percent-encoded-source>` — single-file share from the landing hero.
-// `#z=<lz-base64>` — multi-file share from the playground's ↗ share button.
-// Both formats hand off to pgLoadFiles once the tab strip is mounted.
+// `#z=<lz-base64>` — legacy multi-file share URLs (kept working forever).
 function applySharedCodeFromHash() {
+    const sParam = new URLSearchParams(window.location.search).get('s');
+    if (sParam && /^[0-9a-f]{64}$/.test(sParam)) {
+        applySharedCodeFromServer(sParam);
+        return;
+    }
     const hash = window.location.hash || '';
     let payload = null;
     if (hash.startsWith('#code=')) {
@@ -34,30 +82,7 @@ function applySharedCodeFromHash() {
     } else {
         return;
     }
-
-    // Stash bundle immediately so pgInit picks it up even if it polls in
-    // before we do. Also flag the page as "restored from URL state" so
-    // main.js skips its default `selectSample("examples", 0)` — otherwise
-    // the async data.json fetch occasionally beats pgLoadFiles and the
-    // default hello.das overwrites the hash payload.
-    //
-    // Stash `active` alongside the bundle: when playground-tabs.js's tryInit
-    // consumes the pending bundle before this tryApply loop resolves, it
-    // needs the active filename or it falls back to main.das and the shared
-    // URL's selected tab is silently lost.
-    window.__pendingSampleBundle = payload.files;
-    window.__pendingSampleActive = payload.active;
-    window.pgRestoredFromState = true;
-    const deadline = Date.now() + 5000;
-    (function tryApply() {
-        if (typeof window.pgLoadFiles === 'function') {
-            window.__pendingSampleBundle = null;
-            window.__pendingSampleActive = null;
-            window.pgLoadFiles(payload.files, payload.active);
-            return;
-        }
-        if (Date.now() < deadline) setTimeout(tryApply, 50);
-    })();
+    applySharedPayload(payload);
 }
 
 if (document.readyState === 'loading') {

--- a/site/playground/playground-share.js
+++ b/site/playground/playground-share.js
@@ -1,51 +1,35 @@
-// ↗ share — generate a URL containing every file in pgState, lz-compressed
-// into the hash. Click opens a small popover with the URL, a Copy button,
-// and an optional "Shorten URL" action.
+// ↗ share — store the editor state on the daslang.io sample service and hand
+// out a stable `daslang.io/s/<hash>` link. Content-addressed: the same code
+// always mints the same URL. Falls back to the legacy lz-compressed `#z=` URL
+// when the service is unreachable (e.g. the GH Pages mirror), so sharing
+// never hard-fails.
 
 (function () {
-    // Free, no-auth shorteners tried in order until one returns a URL. Each
-    // `run` performs its own fetch + parse and returns the short URL string;
-    // the chain validates the `https?://` shape. is.gd/v.gd are intentionally
-    // absent — they send no CORS headers, so a browser fetch from daslang.io is
-    // always blocked. da.gd/tinyurl (plain-text GET) and spoo.me (form POST +
-    // JSON) do send them. A longer chain survives any one service rate-limiting
-    // or dropping CORS later.
-    async function getText(url, name) {
-        const resp = await fetch(url);
-        if (!resp.ok) throw new Error(name + ' error ' + resp.status);
-        return (await resp.text()).trim();
+    function sharePayloadBody() {
+        if (!window.pgState) return null;
+        const entries = Object.entries(window.pgState.files).map(([k, doc]) => [k, doc.getValue()]);
+        if (entries.length === 1) return entries[0][1];
+        return JSON.stringify({
+            files: Object.fromEntries(entries),
+            active: window.pgState.active,
+        });
     }
 
-    const SHORTENERS = [
-        { name: 'da.gd', run: (u, name) => getText('https://da.gd/s?url=' + encodeURIComponent(u), name) },
-        { name: 'tinyurl', run: (u, name) => getText('https://tinyurl.com/api-create.php?url=' + encodeURIComponent(u), name) },
-        { name: 'spoo.me', run: async (u, name) => {
-            const resp = await fetch('https://spoo.me/', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json' },
-                body: 'url=' + encodeURIComponent(u),
-            });
-            if (!resp.ok) throw new Error(name + ' error ' + resp.status);
-            // spoo.me returns { short_url: "http://spoo.me/xxxx" } — upgrade to https.
-            return ((await resp.json()).short_url || '').replace(/^http:/, 'https:');
-        } },
-    ];
-
-    async function shortenWithFallback(longUrl) {
-        let lastErr = null;
-        for (const svc of SHORTENERS) {
-            try {
-                const short = (await svc.run(longUrl, svc.name)).trim();
-                if (!/^https?:\/\//.test(short)) throw new Error(svc.name + ' non-URL: ' + short.slice(0, 60));
-                return { short, name: svc.name };
-            } catch (e) {
-                lastErr = e;
-                console.warn('share-shorten:', e);
-            }
-        }
-        throw lastErr || new Error('no shortener available');
+    async function mintShareUrl() {
+        const body = sharePayloadBody();
+        if (body == null || body === '') throw new Error('nothing to share');
+        const resp = await fetch('/api/samples', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+            body,
+        });
+        if (!resp.ok) throw new Error('share service ' + resp.status);
+        const j = await resp.json();
+        if (!j.url) throw new Error('share service returned no url');
+        return j.url;
     }
 
+    // Legacy fallback URL — every file lz-compressed into the hash.
     function buildShareUrl() {
         if (!window.pgState || !window.LZString) return null;
         const payload = JSON.stringify({
@@ -62,7 +46,9 @@
         return window.pgState ? Object.keys(window.pgState.files).length : 0;
     }
 
-    function makePopover(url) {
+    function esc(s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+
+    function makePopover() {
         const wrap = document.createElement('div');
         wrap.className = 'pg-share';
         wrap.innerHTML = (
@@ -71,25 +57,19 @@
                 '<button class="pg-share__close" type="button" title="close">×</button>' +
             '</div>' +
             '<div class="pg-share__row">' +
-                '<input class="pg-share__url" readonly spellcheck="false" />' +
+                '<input class="pg-share__url" readonly spellcheck="false" placeholder="minting link…" />' +
                 '<button class="pg-share__copy" type="button">Copy</button>' +
             '</div>' +
             '<div class="pg-share__footer">' +
-                '<button class="pg-share__shorten" type="button">↘ Shorten URL</button>' +
                 '<span class="pg-share__meta">' + esc(fileCount() + ' file' + (fileCount() === 1 ? '' : 's')) + '</span>' +
             '</div>'
         );
-        wrap.querySelector('.pg-share__url').value = url;
         return wrap;
     }
 
-    function esc(s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
-
     function openPopover(anchor) {
         closePopover();
-        const url = buildShareUrl();
-        if (!url) return;
-        const pop = makePopover(url);
+        const pop = makePopover();
         document.body.appendChild(pop);
 
         // Position under the button.
@@ -100,11 +80,12 @@
 
         const input = pop.querySelector('.pg-share__url');
         const copyBtn = pop.querySelector('.pg-share__copy');
-        const shortenBtn = pop.querySelector('.pg-share__shorten');
         const closeBtn = pop.querySelector('.pg-share__close');
+        const meta = pop.querySelector('.pg-share__meta');
 
         input.addEventListener('focus', () => input.select());
         copyBtn.addEventListener('click', async () => {
+            if (!input.value) return;
             try {
                 await navigator.clipboard.writeText(input.value);
                 copyBtn.textContent = '✓ copied';
@@ -114,24 +95,20 @@
                 input.select();
             }
         });
-        shortenBtn.addEventListener('click', async () => {
-            shortenBtn.disabled = true;
-            shortenBtn.textContent = '…';
-            try {
-                const { short, name } = await shortenWithFallback(input.value);
-                input.value = short;
-                shortenBtn.textContent = '✓ via ' + name;
-            } catch (e) {
-                shortenBtn.textContent = 'shorten failed';
-                console.warn('share-shorten:', e);
-            } finally {
-                setTimeout(() => {
-                    shortenBtn.textContent = '↘ Shorten URL';
-                    shortenBtn.disabled = false;
-                }, 2000);
-            }
-        });
         closeBtn.addEventListener('click', closePopover);
+
+        mintShareUrl()
+            .then((url) => { input.value = url; })
+            .catch((e) => {
+                console.warn('share-mint:', e);
+                const legacy = buildShareUrl();
+                if (legacy) {
+                    input.value = legacy;
+                    meta.textContent = 'share service unavailable — long link';
+                } else {
+                    meta.textContent = 'share failed: ' + e.message;
+                }
+            });
 
         // Click-outside to close. Capture phase so we see the click before
         // the popover's own handlers (which stopPropagation).
@@ -175,4 +152,5 @@
 
     // Expose for tests.
     window.pgBuildShareUrl = buildShareUrl;
+    window.pgMintShareUrl = mintShareUrl;
 })();

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -1,18 +1,15 @@
-// The interpreter/JIT (wasm) radio in the playground toolbar. Three concerns:
-//   1. Picking a sample with a precompiled .wasm enables the JIT radio.
-//   2. Picking a sample without one disables it.
-//   3. If JIT was selected when (2) happens, the radio must also be UNCHECKED
-//      and interpreter re-checked — otherwise selectedEngine() keeps returning
-//      'jit' and runCode() 404s on the missing artifact.
+// The interpreter/JIT (wasm) radio in the playground toolbar.
 //
-// SHA-256 is in the all_wasm cross-compile list (web/CMakeLists.txt); Macros
-// is multi-file so deriveJitName returns null synchronously — clean pair for
-// "JIT becomes available → user opts in → JIT becomes unavailable".
+// Phase 2 of plans/dasweb_backend.md retires the precompiled-artifact path:
+// wasm builds move to the on-demand build service, and until phase 3 serves
+// real builds the radio is PERMANENTLY disabled (updateEngineAvailability
+// short-circuits to disableJit()). These tests pin that state — including
+// across sample switches that used to enable it — and the un-check invariant:
+// a disabled radio must never remain checked (selectedEngine() would keep
+// returning 'jit' and runCode() would 404).
 //
-// The actual .wasm artifacts are only built by `cmake --build … all_wasm`,
-// which the playground-e2e CI lane runs but local dev typically skips. So we
-// stub the HEAD probe with page.route — the test asserts the radio-state
-// machine, not the cross-compile pipeline.
+// When phase 3 lands, restore the transition tests from git history
+// (pre-phase-2 versions asserted enable-on-sha256 via a stubbed HEAD probe).
 
 const { test, expect } = require('./fixtures.js');
 
@@ -27,70 +24,32 @@ async function waitDropdownsPopulated(page) {
 const jitSel = 'input[name=engine][value=jit]';
 const interpSel = 'input[name=engine][value=interpreter]';
 
-// Deterministic HEAD-probe world: 200 for sha256.wasm only, 404 for every
-// other sample's .wasm regardless of what's actually present in the served
-// tree. A narrower `route('**/samples/examples/sha256.wasm', ...)` would let
-// the startup probe for the default Hello world sample hit a real hello.wasm
-// (if a local build has staged any), and JIT would be enabled from page
-// load — the "JIT enables on sha256 select" test would then pass even if
-// the sample-switch path stopped working.
-async function stubSha256WasmAvailable(page) {
-    await page.route('**/samples/examples/*.wasm', route => {
-        if (route.request().method() !== 'HEAD') return route.continue();
-        const ok = route.request().url().endsWith('/sha256.wasm');
-        return route.fulfill({ status: ok ? 200 : 404, body: '' });
-    });
-}
-
-test('JIT radio enables for samples with a precompiled .wasm', async ({ playground }) => {
-    await stubSha256WasmAvailable(playground);
+test('JIT radio stays disabled regardless of sample', async ({ playground }) => {
     await waitDropdownsPopulated(playground);
 
-    // The `playground` fixture's navigate-before-route ordering means the
-    // startup HEAD probe for the default sample's .wasm has already happened
-    // against the real http.server. Force a fresh probe by selecting a sample
-    // the stub returns 404 for — that establishes the "JIT disabled" baseline
-    // we need so the SHA-256 transition actually proves the sample-switch
-    // path works.
-    await playground.locator('#examples').selectOption({ label: 'Functions' });
+    expect(await playground.locator(jitSel).isDisabled()).toBe(true);
+
+    // SHA-256 used to enable it (precompiled-artifact era) — it must not now.
+    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
     await expect.poll(
         () => playground.locator(jitSel).isDisabled(),
         { timeout: 5_000 }
     ).toBe(true);
 
-    // Switching to SHA-256 must flip the radio to enabled — that transition
-    // is what the test name asserts.
-    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
-    await expect.poll(
-        () => playground.locator(jitSel).isDisabled(),
-        { timeout: 5_000 }
-    ).toBe(false);
-});
-
-test('JIT radio auto-reverts to interpreter when sample has no .wasm', async ({ playground }) => {
-    await stubSha256WasmAvailable(playground);
-    await waitDropdownsPopulated(playground);
-
-    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
-    await expect.poll(
-        () => playground.locator(jitSel).isDisabled(),
-        { timeout: 5_000 }
-    ).toBe(false);
-
-    // User opts into JIT.
-    await playground.locator(jitSel).check();
-    expect(await playground.locator(jitSel).isChecked()).toBe(true);
-
-    // Macros is multi-file — currentJitName is null, JIT disables synchronously
-    // (no HEAD fetch, so the stub above isn't consulted on this path).
     await playground.locator('#examples').selectOption({ label: 'Macros (multi-file)' });
     await expect.poll(
         () => playground.locator(jitSel).isDisabled(),
         { timeout: 5_000 }
     ).toBe(true);
+});
 
-    // The fix: disabled radio must NOT remain checked, and interpreter must
-    // be the new active selection.
+test('interpreter stays the active engine', async ({ playground }) => {
+    await waitDropdownsPopulated(playground);
+
+    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
+    await expect.poll(
+        () => playground.locator(interpSel).isChecked(),
+        { timeout: 5_000 }
+    ).toBe(true);
     expect(await playground.locator(jitSel).isChecked()).toBe(false);
-    expect(await playground.locator(interpSel).isChecked()).toBe(true);
 });

--- a/site/tests/playground/share.spec.js
+++ b/site/tests/playground/share.spec.js
@@ -1,21 +1,43 @@
-// ↗ share — compressed multi-file state in a URL hash, with an optional
-// shortener that tries da.gd, then tinyurl, then spoo.me. All three are stubbed
-// via Playwright's route() so the tests do not depend on the external services.
+// ↗ share — the popover mints a stable daslang.io/s/<hash> link from the
+// sample service (POST /api/samples), falling back to the legacy compressed
+// #z= URL when the service is unreachable (e.g. the static mirror this suite
+// serves from). The service is stubbed via Playwright's route() so the tests
+// do not depend on a live backend.
 
 const { test, expect } = require('./fixtures.js');
 
 // The "fresh context" test spawns a second browser context. Under high
-// parallelism the new-context bootstrap competes with the main suite for
-// the shared http.server and can race the polling pgInit. One retry on
-// flake is plenty.
+// parallelism the new-context bootstrap competes with the shared http.server
+// and can race the polling pgInit. One retry on flake is plenty.
 test.describe.configure({ retries: 1 });
+
+const FAKE_HASH = 'a'.repeat(64);
 
 async function waitTabsReady(page) {
     await page.waitForFunction(() => !!window.pgState, null, { timeout: 10_000 });
     await page.locator('#pg-tabs .pg-tab[data-file="main.das"]').waitFor();
 }
 
-test('share popover shows a #z= URL with all files', async ({ playground }) => {
+async function stubMintOk(page) {
+    const bodies = [];
+    await page.route('**/api/samples', route => {
+        if (route.request().method() !== 'POST') return route.continue();
+        bodies.push(route.request().postData());
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                hash: FAKE_HASH,
+                url: 'https://daslang.io/s/' + FAKE_HASH,
+                created: true,
+            }),
+        });
+    });
+    return bodies;
+}
+
+test('share popover shows the minted /s/ link and posts the file bundle', async ({ playground }) => {
+    const bodies = await stubMintOk(playground);
     await waitTabsReady(playground);
     await playground.evaluate(() => {
         window.pgSwitchFile('main.das');
@@ -27,10 +49,55 @@ test('share popover shows a #z= URL with all files', async ({ playground }) => {
     await playground.locator('#share').click();
     const popover = playground.locator('.pg-share');
     await expect(popover).toBeVisible();
-    const urlInput = popover.locator('.pg-share__url');
-    const url = await urlInput.inputValue();
-    expect(url).toContain('#z=');
+    await expect(popover.locator('.pg-share__url')).toHaveValue('https://daslang.io/s/' + FAKE_HASH);
     await expect(popover.locator('.pg-share__meta')).toHaveText(/2 files/);
+
+    // Multi-file states post the same {files, active} bundle the loader reads.
+    expect(bodies.length).toBe(1);
+    const posted = JSON.parse(bodies[0]);
+    expect(Object.keys(posted.files).sort()).toEqual(['main.das', 'utils.das']);
+    expect(posted.files['main.das']).toContain('MAIN-PAYLOAD');
+    expect(posted.files['utils.das']).toContain('UTILS-PAYLOAD');
+});
+
+test('single-file share posts the raw source, not a bundle', async ({ playground }) => {
+    const bodies = await stubMintOk(playground);
+    await waitTabsReady(playground);
+    await playground.evaluate(() => {
+        window.pgSwitchFile('main.das');
+        window.code.getDoc().setValue('// SINGLE-PAYLOAD\n');
+    });
+
+    await playground.locator('#share').click();
+    await expect(playground.locator('.pg-share__url')).toHaveValue('https://daslang.io/s/' + FAKE_HASH);
+
+    expect(bodies.length).toBe(1);
+    expect(bodies[0]).toContain('SINGLE-PAYLOAD');
+    expect(() => {
+        const o = JSON.parse(bodies[0]);
+        if (o && o.files) throw new Error('bundle-shaped');
+    }).not.toThrow('bundle-shaped');
+});
+
+test('service unavailable falls back to a legacy #z= URL that round-trips', async ({ playground }) => {
+    await playground.route('**/api/samples', route => {
+        if (route.request().method() !== 'POST') return route.continue();
+        return route.fulfill({ status: 503, body: '' });
+    });
+
+    await waitTabsReady(playground);
+    await playground.evaluate(() => {
+        window.pgSwitchFile('main.das');
+        window.code.getDoc().setValue('// MAIN-FALLBACK\n');
+        window.pgAddFile('utils.das');
+        window.code.getDoc().setValue('// UTILS-FALLBACK\n');
+    });
+
+    await playground.locator('#share').click();
+    const popover = playground.locator('.pg-share');
+    await expect(popover.locator('.pg-share__meta')).toHaveText(/share service unavailable/);
+    const url = await popover.locator('.pg-share__url').inputValue();
+    expect(url).toContain('#z=');
 
     // Decoding the hash via the same LZString library must round-trip.
     const decoded = await playground.evaluate((u) => {
@@ -38,11 +105,11 @@ test('share popover shows a #z= URL with all files', async ({ playground }) => {
         return JSON.parse(window.LZString.decompressFromEncodedURIComponent(z));
     }, url);
     expect(Object.keys(decoded.files).sort()).toEqual(['main.das', 'utils.das']);
-    expect(decoded.files['main.das']).toContain('MAIN-PAYLOAD');
-    expect(decoded.files['utils.das']).toContain('UTILS-PAYLOAD');
+    expect(decoded.files['main.das']).toContain('MAIN-FALLBACK');
+    expect(decoded.files['utils.das']).toContain('UTILS-FALLBACK');
 });
 
-test('shared URL restores state in a fresh context', async ({ playground, browser }) => {
+test('legacy #z= URL restores state in a fresh context', async ({ playground, browser }) => {
     await waitTabsReady(playground);
     await playground.evaluate(() => {
         window.pgSwitchFile('main.das');
@@ -77,74 +144,24 @@ test('shared URL restores state in a fresh context', async ({ playground, browse
     await ctx.close();
 });
 
-test('Shorten button replaces the URL with the da.gd response', async ({ playground }) => {
-    // Stub the primary shortener so the test is self-contained.
-    await playground.route('https://da.gd/s**', route => {
+test('?s= loader fetches the stored sample into the editor', async ({ playground, browser }) => {
+    const ctx = await browser.newContext();
+    const page2 = await ctx.newPage();
+    await page2.route('**/api/samples/' + FAKE_HASH, route => {
         return route.fulfill({
             status: 200,
-            contentType: 'text/plain',
-            body: 'https://da.gd/ABCxyz\n',
+            contentType: 'text/plain; charset=utf-8',
+            body: '// FROM-THE-STORE\n',
         });
     });
-
-    await waitTabsReady(playground);
-    await playground.evaluate(() => window.code.getDoc().setValue('// for shortening\n'));
-    await playground.locator('#share').click();
-    await playground.locator('.pg-share__shorten').click();
-
-    await expect(playground.locator('.pg-share__url')).toHaveValue('https://da.gd/ABCxyz');
-    await expect(playground.locator('.pg-share__shorten')).toHaveText(/via da\.gd/);
-});
-
-test('Shorten falls back to tinyurl when da.gd fails', async ({ playground }) => {
-    await playground.route('https://da.gd/s**', route => route.fulfill({ status: 502, body: '' }));
-    await playground.route('https://tinyurl.com/api-create.php**', route => {
-        return route.fulfill({
-            status: 200,
-            contentType: 'text/plain',
-            body: 'https://tinyurl.com/abc123',
-        });
-    });
-
-    await waitTabsReady(playground);
-    await playground.locator('#share').click();
-    await playground.locator('.pg-share__shorten').click();
-
-    await expect(playground.locator('.pg-share__url')).toHaveValue('https://tinyurl.com/abc123');
-    await expect(playground.locator('.pg-share__shorten')).toHaveText(/via tinyurl/);
-});
-
-test('Shorten falls back to spoo.me and upgrades http to https', async ({ playground }) => {
-    await playground.route('https://da.gd/s**', route => route.fulfill({ status: 502, body: '' }));
-    await playground.route('https://tinyurl.com/api-create.php**', route => route.fulfill({ status: 502, body: '' }));
-    // spoo.me answers with JSON and an http:// short_url; the client upgrades it.
-    await playground.route('https://spoo.me/**', route => {
-        return route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({ short_url: 'http://spoo.me/xyz789', domain: 'spoo.me' }),
-        });
-    });
-
-    await waitTabsReady(playground);
-    await playground.locator('#share').click();
-    await playground.locator('.pg-share__shorten').click();
-
-    await expect(playground.locator('.pg-share__url')).toHaveValue('https://spoo.me/xyz789');
-    await expect(playground.locator('.pg-share__shorten')).toHaveText(/via spoo\.me/);
-});
-
-test('Shorten button surfaces a failure when every service fails', async ({ playground }) => {
-    await playground.route('https://da.gd/s**', route => route.fulfill({ status: 502, body: '' }));
-    await playground.route('https://tinyurl.com/api-create.php**', route => route.fulfill({ status: 502, body: '' }));
-    await playground.route('https://spoo.me/**', route => route.fulfill({ status: 502, body: '' }));
-
-    await waitTabsReady(playground);
-    await playground.locator('#share').click();
-    const longUrl = await playground.locator('.pg-share__url').inputValue();
-    await playground.locator('.pg-share__shorten').click();
-
-    await expect(playground.locator('.pg-share__shorten')).toHaveText(/failed/);
-    // Long URL untouched so the user still has a working share.
-    await expect(playground.locator('.pg-share__url')).toHaveValue(longUrl);
+    const base = new URL(playground.url());
+    await page2.goto(base.origin + base.pathname + '?s=' + FAKE_HASH, { waitUntil: 'networkidle' });
+    await page2.locator('.CodeMirror').waitFor();
+    await page2.waitForFunction(
+        () => window.pgState && window.pgState.files['main.das'] &&
+            window.pgState.files['main.das'].getValue().includes('FROM-THE-STORE'),
+        null,
+        { timeout: 30_000 }
+    );
+    await ctx.close();
 });

--- a/tests/daslib/test_sha_256.das
+++ b/tests/daslib/test_sha_256.das
@@ -1,0 +1,62 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/sha_256
+require strings
+
+[test]
+def test_nist_vectors(t : T?) {
+    t |> run("empty string") @(t : T?) {
+        t |> equal(sha256_hex(""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+    t |> run("abc") @(t : T?) {
+        t |> equal(sha256_hex("abc"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    }
+    t |> run("two-block 448-bit message") @(t : T?) {
+        t |> equal(sha256_hex("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")
+    }
+    t |> run("four-block 896-bit message") @(t : T?) {
+        t |> equal(sha256_hex("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"),
+            "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1")
+    }
+    t |> run("one million a") @(t : T?) {
+        var st = sha256_init()
+        for (_i in range(1000000)) {
+            sha256_update(st, uint8('a'))
+        }
+        t |> equal(sha256_hex_digest(sha256_final(st)),
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0")
+    }
+}
+
+[test]
+def test_padding_boundaries(t : T?) {
+    // 55/56/63/64 bytes straddle the padding split (0x80 + length must fit or spill)
+    t |> run("55 56 63 64 byte inputs agree between overloads") @(t : T?) {
+        for (n in fixed_array(55, 56, 63, 64, 65, 119, 120)) {
+            var bytes : array<uint8>
+            var str = ""
+            for (_i in range(n)) {
+                bytes |> push(uint8('x'))
+                str += "x"
+            }
+            t |> equal(sha256_hex(bytes), sha256_hex(str))
+            delete bytes
+        }
+    }
+}
+
+[test]
+def test_streaming_equals_oneshot(t : T?) {
+    t |> run("split updates match one-shot") @(t : T?) {
+        let msg = "the quick brown fox jumps over the lazy dog"
+        var st = sha256_init()
+        peek_data(msg) $(bytes) {
+            for (b in bytes) {
+                sha256_update(st, b)
+            }
+        }
+        t |> equal(sha256_hex_digest(sha256_final(st)), sha256_hex(msg))
+    }
+}

--- a/utils/dasweb-playground/.das_package
+++ b/utils/dasweb-playground/.das_package
@@ -1,3 +1,13 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("dasweb-playground")
+    package_description("daslang.io playground backend: content-addressed sample store + share links over dasHV + SQLite")
+}
+
 [export]
 def release() {
     release_main("main.das")

--- a/utils/dasweb-playground/.das_package
+++ b/utils/dasweb-playground/.das_package
@@ -1,0 +1,8 @@
+[export]
+def release() {
+    release_main("main.das")
+    release_name("dasweb-playground")
+    release_include_if_missing("dasweb-playground.toml") // initialize once; preserve deployed edits on upgrades
+    release_include_from("utils/watchdog/watchdog.py")
+    release_include("watchdog.json")
+}

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -48,9 +48,12 @@ defect, and this section is the whole test.
 
 **A new file ships with its rule here and its tests, in the same change.**
 
-- `main.das` — the launcher: clargs + toml merge with provenance, logger init, the exported
+- `main.das` — the launcher: argv parsing into globals, logger init, the exported
   `init`/`update`/`shutdown` lifecycle, the standalone GC loop, exit-code mapping. No route,
-  no SQL, no hashing.
+  no SQL, no hashing, no merge logic.
+- `playground_config.das` — the config schema (`ServerArgs`), the defaults/toml/CLI merge with
+  per-key provenance, and the startup banner payload. No HTTP, no SQL, no filesystem beyond
+  reading the config file.
 - `playground_server.das` — the `HvWebServer` class: the route table and handlers. A handler
   validates transport-level shape, translates HTTP to one store call, and formats the response.
   A SQL statement, a hash computation, or a policy decision (size, rate, listing) in this file

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -61,7 +61,10 @@ defect, and this section is the whole test.
 - `samples_store.das` — the store: schema structs, migrations, store operations, content
   hashing, and every policy decision (size cap, rate ceiling, listing). Zero HTTP: a require
   of `dashv` here is a defect.
-- `admin.das` — the operator CLI (promotion, reimport). Talks to the store the same way the
+- `curated_import.das` — the data.json-driven curated importer: manifest parsing, sample-file
+  reads, bundle assembly, calling the store. The only file besides the config loader that reads
+  the filesystem; a store mutation here that bypasses `samples_store` functions is a defect.
+- `admin.das` — the operator CLI (listing curation). Talks to the store the same way the
   server does; a second implementation of a store operation here is a defect.
 - `.das_package`, `watchdog.json`, `dasweb-playground.toml`, `deploy.sh` — packaging and
   deployment. A behavior change hidden in these files without a README note is a defect.

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -6,8 +6,8 @@ file.
 **What stays in this document:** criteria that can be checked against a diff. Nothing else.
 A reader must be able to apply every entry below **without reading the code, without prior
 knowledge of the service, and without opening another document.** If an entry needs any of
-those, it is not a review criterion — move it to `README.md` (or, while the service is
-pre-README, `plans/dasweb_backend.md`) and leave a one-line criterion here.
+those, it is not a review criterion — move it to `README.md` and leave a one-line criterion
+here.
 
 **Form, and it is a hard limit:**
 
@@ -25,16 +25,19 @@ pre-README, `plans/dasweb_backend.md`) and leave a one-line criterion here.
 ## Tests
 
 **Every route, every store operation, and every config or limit behavior has a dastest test in
-this directory.** A behavior that ships without its test is a defect.
+this directory.** A behavior that ships without its test is a defect. Exempt: `main.das` and
+`admin.das` argv/dispatch glue — their behaviors live in the modules they call, which are the
+tested surface.
 
 **Every bug fix lands with the regression test that fails without it, in the same change.**
 
 **`[test]` files live in this directory and require siblings by bare name** — never under the
 global `tests/` tree, and never registered in any `CMakeLists.txt`.
 
-**HTTP tests go through the in-dir server harness on this directory's reserved test port; store
-tests call `samples_store` directly with no server.** A store behavior proven only through HTTP,
-or an HTTP behavior proven only against the store, is a defect.
+**HTTP tests go through `with_playground_server_at` in `test_playground_server.das`, on this
+directory's reserved test ports 19011 and 19012; store tests call `samples_store` directly with
+no server.** A store behavior proven only through HTTP, or an HTTP behavior proven only against
+the store, is a defect.
 
 **A test that touches the filesystem uses `temp_directory`-rooted paths and deletes what it
 creates.** A test writing into the repo tree is a defect.
@@ -67,7 +70,8 @@ defect, and this section is the whole test.
 - `admin.das` — the operator CLI (listing curation). Talks to the store the same way the
   server does; a second implementation of a store operation here is a defect.
 - `.das_package`, `watchdog.json`, `dasweb-playground.toml`, `deploy.sh` — packaging and
-  deployment. A behavior change hidden in these files without a README note is a defect.
+  deployment. A behavior change hidden in these files without a note in `README.md` (Run
+  section) is a defect.
 
 **Migrations are append-only.** A diff that edits a shipped `[sql_migration]` body is a defect;
 schema change means a new version.
@@ -79,19 +83,25 @@ schema change means a new version.
 **The server binds loopback only** — `set_bind_host("127.0.0.1")` between `init` and `start`.
 A diff that removes, reorders past `start`, or conditionalizes the bind is a defect.
 
-**Every SQL statement goes through the typed rail or bound parameters.** A query assembled by
-string interpolation or `format` from any request-derived value is a defect.
+**Every SQL statement goes through the `daslib/sql_linq` rail (`_sql` / `insert` /
+`_sql_update`) or bound parameters.** A query assembled by string interpolation or `format`
+from any request-derived value is a defect.
 
 **Every request body is bounds-checked against the configured cap before it is hashed or
-stored.** A handler that reads the body before checking size is a defect.
+stored.** (dasHV buffers the body before any handler runs, so the check happens in
+`put_sample` ahead of hashing — a hash or insert reachable without the size check is a defect.)
 
 **Client identity comes from `X-Forwarded-For` and is treated as data, never parsed into
 behavior beyond the rate ceiling.** Logging it is required; branching on it anywhere else is a
 defect.
 
-**No shell-out, no filesystem path derived from request data, no `unsafe` in any handler.**
-An `unsafe` in `samples_store.das` takes a same-line reason comment; an `unsafe` in
-`playground_server.das` is a defect.
+**No shell-out anywhere in the service.**
+
+**No filesystem path derived from request data.** The importer's paths come from config plus
+the deploy-tree manifest only.
+
+**No `unsafe` in any route handler.** An `unsafe` elsewhere takes a same-line reason comment;
+one without the comment is a defect.
 
 **`POST /shutdown` and every admin operation stay unrouted by Caddy.** A Caddy config change in
 this directory that forwards them, or an admin endpoint added to the public route set, is a
@@ -105,7 +115,8 @@ message.** The config banner logs key names and provenance, never values marked 
 ## Logging
 
 **Every request emits one structured line: method, path, status, duration, client ip, bytes.**
-A route without it is a defect.
+A route without it is a defect. Exempt: `GET /healthz` — the watchdog polls it every few
+seconds and logging it would bury the signal.
 
 **Every store mutation and every job/state transition emits a structured line.** A failure path
 that can trigger without leaving a log line is a defect.

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -1,0 +1,120 @@
+# dasweb-playground Code Review Checklist
+
+Run this list on every dasweb-playground change before it ships — including changes to this
+file.
+
+**What stays in this document:** criteria that can be checked against a diff. Nothing else.
+A reader must be able to apply every entry below **without reading the code, without prior
+knowledge of the service, and without opening another document.** If an entry needs any of
+those, it is not a review criterion — move it to `README.md` (or, while the service is
+pre-README, `plans/dasweb_backend.md`) and leave a one-line criterion here.
+
+**Form, and it is a hard limit:**
+
+- **One rule is one short paragraph.** An entry that needs more than that is describing how to
+  write code, not how to review it. Split it or move it.
+- **No numbers.** These are criteria, not a spec, and numbering invites citation. Anything that
+  needs a stable reference lives in `README.md`.
+- **Cite files by name; cite `README.md` by section.** Never cite an entry in this file.
+- **Name the API a rule is about; never name an example of it.**
+- **No history, no rationale, no direction of travel.** The reason lives in `README.md` or the
+  plan; planned work lives in `plans/dasweb_backend.md`.
+
+---
+
+## Tests
+
+**Every route, every store operation, and every config or limit behavior has a dastest test in
+this directory.** A behavior that ships without its test is a defect.
+
+**Every bug fix lands with the regression test that fails without it, in the same change.**
+
+**`[test]` files live in this directory and require siblings by bare name** — never under the
+global `tests/` tree, and never registered in any `CMakeLists.txt`.
+
+**HTTP tests go through the in-dir server harness on this directory's reserved test port; store
+tests call `samples_store` directly with no server.** A store behavior proven only through HTTP,
+or an HTTP behavior proven only against the store, is a defect.
+
+**A test that touches the filesystem uses `temp_directory`-rooted paths and deletes what it
+creates.** A test writing into the repo tree is a defect.
+
+---
+
+## Placement — one file, one rule
+
+Every file states what it holds. Code that belongs to a file and is written anywhere else is a
+defect, and this section is the whole test.
+
+**A new file ships with its rule here and its tests, in the same change.**
+
+- `main.das` — the launcher: clargs + toml merge with provenance, logger init, the exported
+  `init`/`update`/`shutdown` lifecycle, the standalone GC loop, exit-code mapping. No route,
+  no SQL, no hashing.
+- `playground_server.das` — the `HvWebServer` class: the route table and handlers. A handler
+  validates transport-level shape, translates HTTP to one store call, and formats the response.
+  A SQL statement, a hash computation, or a policy decision (size, rate, listing) in this file
+  is a defect.
+- `samples_store.das` — the store: schema structs, migrations, store operations, content
+  hashing, and every policy decision (size cap, rate ceiling, listing). Zero HTTP: a require
+  of `dashv` here is a defect.
+- `admin.das` — the operator CLI (promotion, reimport). Talks to the store the same way the
+  server does; a second implementation of a store operation here is a defect.
+- `.das_package`, `watchdog.json`, `dasweb-playground.toml`, `deploy.sh` — packaging and
+  deployment. A behavior change hidden in these files without a README note is a defect.
+
+**Migrations are append-only.** A diff that edits a shipped `[sql_migration]` body is a defect;
+schema change means a new version.
+
+---
+
+## Security
+
+**The server binds loopback only** — `set_bind_host("127.0.0.1")` between `init` and `start`.
+A diff that removes, reorders past `start`, or conditionalizes the bind is a defect.
+
+**Every SQL statement goes through the typed rail or bound parameters.** A query assembled by
+string interpolation or `format` from any request-derived value is a defect.
+
+**Every request body is bounds-checked against the configured cap before it is hashed or
+stored.** A handler that reads the body before checking size is a defect.
+
+**Client identity comes from `X-Forwarded-For` and is treated as data, never parsed into
+behavior beyond the rate ceiling.** Logging it is required; branching on it anywhere else is a
+defect.
+
+**No shell-out, no filesystem path derived from request data, no `unsafe` in any handler.**
+An `unsafe` in `samples_store.das` takes a same-line reason comment; an `unsafe` in
+`playground_server.das` is a defect.
+
+**`POST /shutdown` and every admin operation stay unrouted by Caddy.** A Caddy config change in
+this directory that forwards them, or an admin endpoint added to the public route set, is a
+defect.
+
+**Secrets (tokens, credentials) never appear in a log line, a response body, or an error
+message.** The config banner logs key names and provenance, never values marked secret.
+
+---
+
+## Logging
+
+**Every request emits one structured line: method, path, status, duration, client ip, bytes.**
+A route without it is a defect.
+
+**Every store mutation and every job/state transition emits a structured line.** A failure path
+that can trigger without leaving a log line is a defect.
+
+**Startup logs the full effective config with per-key provenance before the first request is
+served.**
+
+---
+
+## Lifecycle and memory
+
+**Lifecycle-owned state is module-global; no collectable value lives in a `main`-loop local
+across `maybe_collect_gc()`.**
+
+**The store opens inside the thread that serves it.** A `SqlRunner` created on one thread and
+used on another is a defect.
+
+**Route callbacks are retained with `push`, never `emplace`.**

--- a/utils/dasweb-playground/README.md
+++ b/utils/dasweb-playground/README.md
@@ -1,0 +1,49 @@
+# dasweb-playground
+
+The daslang.io playground backend: permanent share links (`daslang.io/s/<hash>`) over a
+content-addressed sample store. Phase 1 of `plans/dasweb_backend.md`; later phases add the
+curated-sample listing and the wasm build queue. Review rules: `CODEREVIEW.md` (binding).
+
+## Run
+
+```bash
+# development (interpreted or -jit)
+daslang utils/dasweb-playground/main.das -- --port 8101 --db samples.db
+
+# supervised production form (inside a daspkg release bundle)
+python3 watchdog.py
+
+# release bundle
+daslang utils/daspkg/main.das -- release --root utils/dasweb-playground --out <dir>
+```
+
+`-?` prints flag help (the daslang host eats `--help`). Config: `dasweb-playground.toml` in cwd
+or beside the tool, keys = flag names; precedence defaults < toml < explicit CLI flags, flipped
+by `authoritative = true`. The effective config is logged at startup with per-key provenance.
+
+## Endpoints (port 8101, loopback only — Caddy fronts the internet)
+
+| Route | Behavior |
+|---|---|
+| `POST /api/samples` | body = raw `.das` text → `{hash, url, created}`; 400 empty/non-utf8, 413 over size cap, 429 over per-IP ceiling |
+| `GET /api/samples/<hash>` | the stored source, `text/plain`, immutable cache headers; 400 malformed hash, 404 unknown |
+| `GET /s/<hash>` | 302 → `/playground/index.html?s=<hash>`; 404 unknown |
+| `GET /healthz` | `ok` (watchdog poll target) |
+| `POST /shutdown` | graceful stop, exit 0 (watchdog contract; never routed by Caddy) |
+
+Dedup is content-addressed: same source ⇒ same hash ⇒ same URL, first writer's metadata wins.
+
+## Files
+
+One file, one rule — the authoritative placement table is in `CODEREVIEW.md`. Data lives in
+SQLite (`samples` table, append-only `[sql_migration]` stream); every request and store
+mutation is logged as ndjson to `logs/dasweb-playground.log` (rotation is the watchdog's job).
+
+## Tests
+
+```bash
+daslang dastest/dastest.das -- --test utils/dasweb-playground/
+```
+
+In-dir per the session rules: store (no HTTP), server (real HTTP on port 19011), config
+(pure merge). Every bug fix lands with its regression test.

--- a/utils/dasweb-playground/README.md
+++ b/utils/dasweb-playground/README.md
@@ -15,6 +15,9 @@ python3 watchdog.py
 
 # release bundle
 daslang utils/daspkg/main.das -- release --root utils/dasweb-playground --out <dir>
+
+# box-side install of a shipped bundle (build recipe in the script header)
+sudo deploy.sh <short-sha> /tmp/dasweb-playground-<short-sha>.tar.gz
 ```
 
 `-?` prints flag help (the daslang host eats `--help`). Config: `dasweb-playground.toml` in cwd
@@ -53,5 +56,6 @@ mutation is logged as ndjson to `logs/dasweb-playground.log` (rotation is the wa
 daslang dastest/dastest.das -- --test utils/dasweb-playground/
 ```
 
-In-dir per the session rules: store (no HTTP), server (real HTTP on port 19011), config
-(pure merge). Every bug fix lands with its regression test.
+In-dir per the session rules: store (no HTTP), server (real HTTP on reserved ports
+19011/19012), importer (temp-dir fixtures), config (pure merge). Every bug fix lands with its
+regression test.

--- a/utils/dasweb-playground/README.md
+++ b/utils/dasweb-playground/README.md
@@ -26,10 +26,18 @@ by `authoritative = true`. The effective config is logged at startup with per-ke
 | Route | Behavior |
 |---|---|
 | `POST /api/samples` | body = raw `.das` text → `{hash, url, created}`; 400 empty/non-utf8, 413 over size cap, 429 over per-IP ceiling |
+| `GET /api/samples/listed` | the curated dropdown: `[{hash, title, category, path, slug}]`, category-then-title ordered |
 | `GET /api/samples/<hash>` | the stored source, `text/plain`, immutable cache headers; 400 malformed hash, 404 unknown |
 | `GET /s/<hash>` | 302 → `/playground/index.html?s=<hash>`; 404 unknown |
 | `GET /healthz` | `ok` (watchdog poll target) |
 | `POST /shutdown` | graceful stop, exit 0 (watchdog contract; never routed by Caddy) |
+| `POST /admin/reimport` | re-run the curated importer; 503 when `curated_dir` unset (loopback only — Caddy never routes `/admin/*`) |
+
+Curated samples: when `curated_dir` points at the deployed playground samples tree, boot (and
+`/admin/reimport`) imports every `data.json` entry through the store — single-file entries as
+raw source, multi-file as the `{files, active}` bundle user shares use. Unchanged files dedup;
+changed files repoint the listing; vanished entries demote (permalinks always survive).
+Manual curation: `admin.das` (`--op list | promote | demote`).
 
 Dedup is content-addressed: same source ⇒ same hash ⇒ same URL, first writer's metadata wins.
 

--- a/utils/dasweb-playground/admin.das
+++ b/utils/dasweb-playground/admin.das
@@ -1,0 +1,87 @@
+options gen2
+options indenting = 4
+
+require daslib/clargs
+require samples_store
+
+// Operator CLI (run on the box over ssh) — listing curation only; store
+// operations themselves live (and are tested) in samples_store.
+//
+//   daslang admin.das -- --db /srv/dasweb-playground/samples.db --op list
+//   daslang admin.das -- --db ... --op promote --hash <sha256> --title "..." --category examples
+//   daslang admin.das -- --db ... --op demote --hash <sha256>
+
+[CommandLineArgs]
+struct AdminArgs {
+    @clarg_doc = "SQLite database path"
+    db : string = "/srv/dasweb-playground/samples.db"
+
+    @clarg_doc = "list | promote | demote"
+    op : string = "list"
+
+    @clarg_doc = "Sample hash (promote/demote)"
+    hash : string = ""
+
+    @clarg_doc = "Dropdown title (promote)"
+    title : string = ""
+
+    @clarg_doc = "Dropdown category (promote)"
+    category : string = "examples"
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool = false
+}
+
+[export]
+def main : int {
+    var r <- parse_args(type<AdminArgs>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<AdminArgs>), "dasweb-playground admin")
+        return 1
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<AdminArgs>), "dasweb-playground admin")
+        return 0
+    }
+    var open_result <- try_open_sqlite(cfg.db)
+    if (open_result |> is_err) {
+        print("error: cannot open {cfg.db}: {open_result |> unwrap_err}\n")
+        return 1
+    }
+    var inscope db <- open_result._value
+    if (cfg.op == "list") {
+        let listed <- listed_samples(db)
+        for (l in listed) {
+            print("{l.hash}  [{l.category}] {l.title}\n")
+        }
+        print("{length(listed)} listed\n")
+        return 0
+    } elif (cfg.op == "promote") {
+        if (empty(cfg.hash) || empty(cfg.title)) {
+            print("error: promote needs --hash and --title\n")
+            return 1
+        }
+        if (!promote_sample(db, cfg.hash, cfg.title, cfg.category)) {
+            print("error: unknown hash {cfg.hash}\n")
+            return 1
+        }
+        print("promoted {cfg.hash} as [{cfg.category}] {cfg.title}\n")
+        return 0
+    } elif (cfg.op == "demote") {
+        if (empty(cfg.hash)) {
+            print("error: demote needs --hash\n")
+            return 1
+        }
+        if (!demote_sample(db, cfg.hash)) {
+            print("error: unknown hash {cfg.hash}\n")
+            return 1
+        }
+        print("demoted {cfg.hash} (permalink survives)\n")
+        return 0
+    }
+    print("error: unknown --op '{cfg.op}' (list | promote | demote)\n")
+    return 1
+}

--- a/utils/dasweb-playground/curated_import.das
+++ b/utils/dasweb-playground/curated_import.das
@@ -1,0 +1,93 @@
+options gen2
+options indenting = 4
+
+module curated_import public
+
+require samples_store public
+require daslib/json_boost
+require daslib/fio
+require daslib/logger
+
+//! The curated importer: reads the deployed playground manifest
+//! (`<samples_dir>/data.json`, the hand-authored schema the UI ships) and
+//! feeds every entry through the store — single-file entries as raw source,
+//! multi-file entries as the same {files, active} JSON bundle user shares
+//! use. Idempotent: unchanged files are dedup hits; changed files mint new
+//! hashes and the listing repoints; vanished entries get demoted (rows and
+//! permalinks always survive). Filesystem reads live here, not in the store.
+
+def private entry_body(samples_dir : string; entry : JsonValue?; var primary_path : string&) : string {
+    //! "" = a file was missing/unreadable (entry skipped by the caller).
+    let fv = entry?["files"]
+    if (fv == null || !(fv.value is _array)) {
+        return ""
+    }
+    var rels <- [for (fe in fv.value as _array); fe ?? ""]
+    if (empty(rels) || empty(rels[0])) {
+        return ""
+    }
+    primary_path = rels[0]
+    var texts : array<string>
+    texts |> reserve(length(rels))
+    for (rel in rels) {
+        let text = fread(path_join(samples_dir, rel))
+        if (empty(text)) {
+            logger_error("playground.import", "cannot read {rel} under {samples_dir}")
+            return ""
+        }
+        texts |> push(text)
+    }
+    if (length(texts) == 1) {
+        return texts[0]
+    }
+    var files_obj <- {for (rel, text in rels, texts); base_name(rel) => JV(text)}
+    return write_json(JV((files = JV(files_obj), active = base_name(rels[0]))))
+}
+
+def import_curated(db : SqlRunner; samples_dir : string; now : int64) : int {
+    //! Returns the listed-entry count, or -1 when the manifest is missing or
+    //! malformed (existing listings are left untouched in that case).
+    let manifest_path = path_join(samples_dir, "data.json")
+    let body = fread(manifest_path)
+    if (empty(body)) {
+        logger_error("playground.import", "cannot read manifest {manifest_path}")
+        return -1
+    }
+    var jerr = ""
+    var root = read_json(body, jerr)
+    if (root == null || !(root.value is _object)) {
+        logger_error("playground.import", "bad manifest {manifest_path}: {jerr}")
+        return -1
+    }
+    var keep : table<string>
+    var listed = 0
+    var skipped = 0
+    for (category in keys(root.value as _object)) {
+        let entries = root?[category]
+        if (entries == null || !(entries.value is _array)) {
+            continue
+        }
+        for (entry in entries.value as _array) {
+            let title : string = entry?["name"] ?? ""
+            if (empty(title)) {
+                skipped ++
+                continue
+            }
+            var primary_path = ""
+            let src = entry_body(samples_dir, entry, primary_path)
+            if (empty(src)) {
+                logger_error("playground.import", "skipping '{title}': unreadable files")
+                skipped ++
+                continue
+            }
+            let hash = upsert_curated_source(db, src, now)
+            list_curated_sample(db, hash, title, category, primary_path, entry?["slug"] ?? "")
+            keep |> insert(hash)
+            listed ++
+        }
+    }
+    let demoted = demote_stale_curated(db, keep)
+    logger_info("playground.import", "curated import: {listed} listed, {skipped} skipped, {demoted} demoted",
+        JV((listed = listed, skipped = skipped, demoted = demoted, dir = samples_dir)))
+    return listed
+}

--- a/utils/dasweb-playground/dasweb-playground.toml
+++ b/utils/dasweb-playground/dasweb-playground.toml
@@ -6,3 +6,4 @@ db = "/srv/dasweb-playground/samples.db"
 base_url = "https://daslang.io"
 max_source_bytes = 262144
 max_inserts_per_ip_hour = 100
+curated_dir = "/srv/daslang.io/current/playground/samples"

--- a/utils/dasweb-playground/dasweb-playground.toml
+++ b/utils/dasweb-playground/dasweb-playground.toml
@@ -1,0 +1,8 @@
+# dasweb-playground starter config. Deployed beside the binary; edits here
+# survive upgrades (release_include_if_missing). CLI flags override these
+# unless `authoritative = true` is set.
+port = 8101
+db = "/srv/dasweb-playground/samples.db"
+base_url = "https://daslang.io"
+max_source_bytes = 262144
+max_inserts_per_ip_hour = 100

--- a/utils/dasweb-playground/deploy.sh
+++ b/utils/dasweb-playground/deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# dasweb-playground box-side installer. Run as root on the web box:
+#
+#   deploy.sh <short-sha> /tmp/dasweb-playground-<short-sha>.tar.gz
+#
+# The bundle comes from the builder box (zen4) — from the arc worktree there:
+#
+#   cd ~/daScript-dasweb && git pull --ff-only origin <branch>
+#   bin/daslang utils/daspkg/main.das -- release --root utils/dasweb-playground --out ~/dasweb_release
+#   SHA=$(git rev-parse --short HEAD)
+#   cd ~/dasweb_release && tar czf dasweb-playground-$SHA.tar.gz dasweb-playground
+#   # scp the tarball to the web box's /tmp
+#
+# Install: unpack into /srv/apps/dasweb-playground/releases/<sha>, carry the
+# deployed (user-owned) toml forward, flip the `current` symlink atomically,
+# restart the systemd-wrapped watchdog, verify health. Rollback = point
+# `current` at the previous release dir and restart.
+set -eu
+
+SHA="${1:?usage: deploy.sh <short-sha> <tarball>}"
+TARBALL="${2:?usage: deploy.sh <short-sha> <tarball>}"
+APP=/srv/apps/dasweb-playground
+
+cd "$APP/releases"
+tar xzf "$TARBALL"
+rm -rf "$SHA"
+mv dasweb-playground "$SHA"
+if [ -f "$APP/current/dasweb-playground.toml" ]; then
+    cp "$APP/current/dasweb-playground.toml" "$SHA/dasweb-playground.toml"
+fi
+chown -R dasweb:dasweb "$SHA"
+ln -sfn "$APP/releases/$SHA" "$APP/current"
+systemctl restart dasweb-playground
+sleep 5
+systemctl is-active dasweb-playground
+curl -sf http://127.0.0.1:8101/healthz
+echo
+echo "deployed $SHA"

--- a/utils/dasweb-playground/main.das
+++ b/utils/dasweb-playground/main.das
@@ -63,7 +63,7 @@ def init {
         StorePolicy(
             max_source_bytes = g_cfg.max_source_bytes,
             max_inserts_per_ip_hour = g_cfg.max_inserts_per_ip_hour),
-        g_cfg.base_url)
+        g_cfg.base_url, g_cfg.curated_dir)
     if (!g_ready) {
         g_exit_code = 1
     }

--- a/utils/dasweb-playground/main.das
+++ b/utils/dasweb-playground/main.das
@@ -1,0 +1,96 @@
+options gen2
+options indenting = 4
+options gc
+options persistent_heap
+options stack = 262144
+
+require playground_config
+require playground_server
+require daslib/logger
+require live/live_gc
+require live_host
+
+// dasweb-playground — the daslang.io playground backend (share links + sample
+// store; plans/dasweb_backend.md). Canonical application shape: exported
+// init/update/shutdown + a standalone main with the GC boundary; hostable by
+// daslang-live, supervised by utils/watchdog in production.
+
+// Lifecycle state is global: JIT heap collection cannot see stack locals as
+// GC roots, so main keeps no collectable value alive across maybe_collect_gc().
+var private g_cfg = ServerArgs()
+var private g_sources : table<string; string>
+var private g_ready = false
+var private g_exit_code = 0
+var private g_args_parsed = false
+
+// The no-argument overload wraps clargs' parse_args(type<T>) so standalone
+// main has no collectable config local across the GC point.
+def parse_args {
+    g_args_parsed = true
+    var r <- parse_args(type<ServerArgs>)
+    if (r |> is_err) {
+        print("error: {r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<ServerArgs>), "dasweb-playground")
+        g_exit_code = 1
+        request_exit()
+        return
+    }
+    g_cfg <- r |> move_unwrap
+    if (g_cfg.help) {
+        print_help(get_command_info(type<ServerArgs>), "dasweb-playground")
+        request_exit()
+        return
+    }
+    var cfg_err = ""
+    if (!load_config(g_cfg, g_sources, cfg_err)) {
+        print("error: {cfg_err}\n")
+        g_exit_code = 1
+        request_exit()
+    }
+}
+
+[export]
+def init {
+    return if (g_exit_code != 0)
+    if (!g_args_parsed) {
+        parse_args()   // daslang-live calls init directly; standalone main parsed already
+        return if (g_exit_code != 0)
+    }
+    // tee every to_log/print to logs/dasweb-playground.log (timestamped ndjson) AND the console
+    logger_init_tee("dasweb-playground")
+    logger_info("playground", "effective config", config_banner(g_cfg, g_sources))
+    g_ready = init_server(g_cfg.port, g_cfg.db,
+        StorePolicy(
+            max_source_bytes = g_cfg.max_source_bytes,
+            max_inserts_per_ip_hour = g_cfg.max_inserts_per_ip_hour),
+        g_cfg.base_url)
+    if (!g_ready) {
+        g_exit_code = 1
+    }
+}
+
+[export]
+def update {
+    if (!g_ready || !update_server()) {
+        request_exit()
+    }
+}
+
+[export]
+def shutdown {
+    shutdown_server()
+    g_ready = false
+    logger_flush()
+}
+
+[export]
+def main : int {
+    parse_args()
+    init()
+    while (!exit_requested()) {
+        update()
+        maybe_collect_gc()
+    }
+    shutdown()
+    return g_exit_code
+}

--- a/utils/dasweb-playground/playground_config.das
+++ b/utils/dasweb-playground/playground_config.das
@@ -1,0 +1,148 @@
+options gen2
+options indenting = 4
+
+module playground_config public
+
+require daslib/clargs public
+require daslib/toml
+require daslib/json_boost
+require daslib/fio
+require daslib/module_path
+require strings
+
+//! Config schema and the defaults < toml < explicit-CLI merge (authoritative
+//! toml flips the top, the dasllama-server convention), with per-key
+//! provenance. No HTTP, no SQL — pure data, unit-testable.
+
+[CommandLineArgs]
+struct ServerArgs {
+    @clarg_short = "p"
+    @clarg_doc = "HTTP port (binds 127.0.0.1 only)"
+    port : int = 8101
+
+    @clarg_doc = "SQLite database path"
+    db : string = "samples.db"
+
+    @clarg_doc = "Public base URL minted into share links"
+    base_url : string = "https://daslang.io"
+
+    @clarg_doc = "Reject sources larger than this many bytes"
+    max_source_bytes : int = 262144
+
+    @clarg_doc = "Per-IP sample-insert ceiling per hour"
+    max_inserts_per_ip_hour : int = 100
+
+    @clarg_doc = "TOML config path (default: dasweb-playground.toml in cwd or beside the tool)"
+    config : string = ""
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit (the daslang host eats --help; use -?)"
+    help : bool = false
+}
+
+def private cli_has_flag(user_args : array<string>; flag : string) : bool {
+    let eqform = "{flag}="
+    for (a in user_args) {
+        if (a == flag || a |> starts_with(eqform)) {
+            return true
+        }
+    }
+    return false
+}
+
+def private from_cli(user_args : array<string>; key : string) : bool {
+    let flag = "--{replace(key, "_", "-")}"
+    if (cli_has_flag(user_args, flag)) {
+        return true
+    }
+    return key == "port" && cli_has_flag(user_args, "-p")
+}
+
+def private toml_has(root : JsonValue?; key : string) : bool {
+    return root != null && (root.value is _object) && key_exists(root.value as _object, key)
+}
+
+def private cfg_from_toml(root : JsonValue?; key : string; var field : string&; auth : bool; user_args : array<string>; var sources : table<string; string>) {
+    if (toml_has(root, key) && (auth || !from_cli(user_args, key))) {
+        field = root?[key] ?? ""
+        sources[key] = "toml"
+    }
+}
+
+def private cfg_from_toml(root : JsonValue?; key : string; var field : int&; auth : bool; user_args : array<string>; var sources : table<string; string>) {
+    if (toml_has(root, key) && (auth || !from_cli(user_args, key))) {
+        field = int(root?[key] ?? 0l)
+        sources[key] = "toml"
+    }
+}
+
+def mark_cli_sources(user_args : array<string>; var sources : table<string; string>) {
+    for (key in fixed_array("port", "db", "base_url", "max_source_bytes", "max_inserts_per_ip_hour")) {
+        if (from_cli(user_args, key)) {
+            sources[key] = "cli"
+        }
+    }
+}
+
+def apply_config_text(var cfg : ServerArgs; body : string; user_args : array<string>; var sources : table<string; string>; var error : string&) : bool {
+    //! Merge one TOML document into cfg per the precedence rules. `sources`
+    //! records "toml" per key it changed (on top of "cli" marks).
+    var terr = ""
+    var root = read_toml(body, terr)
+    if (root == null) {
+        error = terr
+        return false
+    }
+    let auth : bool = root?["authoritative"] ?? false
+    cfg_from_toml(root, "port", cfg.port, auth, user_args, sources)
+    cfg_from_toml(root, "db", cfg.db, auth, user_args, sources)
+    cfg_from_toml(root, "base_url", cfg.base_url, auth, user_args, sources)
+    cfg_from_toml(root, "max_source_bytes", cfg.max_source_bytes, auth, user_args, sources)
+    cfg_from_toml(root, "max_inserts_per_ip_hour", cfg.max_inserts_per_ip_hour, auth, user_args, sources)
+    unsafe {
+        delete root
+    }
+    return true
+}
+
+def load_config(var cfg : ServerArgs; var sources : table<string; string>; var error : string&) : bool {
+    //! CLI marks + config discovery (explicit --config, else dasweb-playground.toml
+    //! in cwd, else beside the tool) + merge. Missing explicit config is an error;
+    //! absent discovered config is fine.
+    var user_args <- get_user_args()
+    mark_cli_sources(user_args, sources)
+    if (empty(cfg.config)) {
+        let here = "dasweb-playground.toml"
+        let beside = path_join(get_this_module_dir(), "dasweb-playground.toml")
+        if (stat(here).is_valid) {
+            cfg.config = here
+        } elif (stat(beside).is_valid) {
+            cfg.config = beside
+        }
+    }
+    var ok = true
+    if (!empty(cfg.config)) {
+        let body = fread(cfg.config)
+        if (empty(body)) {
+            error = "cannot read config '{cfg.config}'"
+            ok = false
+        } else {
+            ok = apply_config_text(cfg, body, user_args, sources, error)
+        }
+    }
+    delete user_args
+    return ok
+}
+
+def config_banner(cfg : ServerArgs; sources : table<string; string>) : JsonValue? {
+    //! The startup banner payload: every effective key with its provenance.
+    return JV((
+        port = cfg.port, port_src = sources?["port"] ?? "default",
+        db = cfg.db, db_src = sources?["db"] ?? "default",
+        base_url = cfg.base_url, base_url_src = sources?["base_url"] ?? "default",
+        max_source_bytes = cfg.max_source_bytes,
+        max_source_bytes_src = sources?["max_source_bytes"] ?? "default",
+        max_inserts_per_ip_hour = cfg.max_inserts_per_ip_hour,
+        max_inserts_per_ip_hour_src = sources?["max_inserts_per_ip_hour"] ?? "default",
+        config = cfg.config))
+}

--- a/utils/dasweb-playground/playground_config.das
+++ b/utils/dasweb-playground/playground_config.das
@@ -32,6 +32,9 @@ struct ServerArgs {
     @clarg_doc = "Per-IP sample-insert ceiling per hour"
     max_inserts_per_ip_hour : int = 100
 
+    @clarg_doc = "Deployed curated samples dir (data.json + sources); empty = no curated import"
+    curated_dir : string = ""
+
     @clarg_doc = "TOML config path (default: dasweb-playground.toml in cwd or beside the tool)"
     config : string = ""
 
@@ -77,7 +80,7 @@ def private cfg_from_toml(root : JsonValue?; key : string; var field : int&; aut
 }
 
 def mark_cli_sources(user_args : array<string>; var sources : table<string; string>) {
-    for (key in fixed_array("port", "db", "base_url", "max_source_bytes", "max_inserts_per_ip_hour")) {
+    for (key in fixed_array("port", "db", "base_url", "max_source_bytes", "max_inserts_per_ip_hour", "curated_dir")) {
         if (from_cli(user_args, key)) {
             sources[key] = "cli"
         }
@@ -99,6 +102,7 @@ def apply_config_text(var cfg : ServerArgs; body : string; user_args : array<str
     cfg_from_toml(root, "base_url", cfg.base_url, auth, user_args, sources)
     cfg_from_toml(root, "max_source_bytes", cfg.max_source_bytes, auth, user_args, sources)
     cfg_from_toml(root, "max_inserts_per_ip_hour", cfg.max_inserts_per_ip_hour, auth, user_args, sources)
+    cfg_from_toml(root, "curated_dir", cfg.curated_dir, auth, user_args, sources)
     unsafe {
         delete root
     }
@@ -144,5 +148,7 @@ def config_banner(cfg : ServerArgs; sources : table<string; string>) : JsonValue
         max_source_bytes_src = sources?["max_source_bytes"] ?? "default",
         max_inserts_per_ip_hour = cfg.max_inserts_per_ip_hour,
         max_inserts_per_ip_hour_src = sources?["max_inserts_per_ip_hour"] ?? "default",
+        curated_dir = cfg.curated_dir,
+        curated_dir_src = sources?["curated_dir"] ?? "default",
         config = cfg.config))
 }

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -6,6 +6,7 @@ module playground_server public
 require dashv/dashv_boost public
 require daslib/json_boost
 require daslib/logger
+require daslib/fio
 require samples_store public
 require curated_import
 require strings
@@ -55,10 +56,11 @@ def is_valid_hash(h : string) : bool {
     return ok
 }
 
-def private log_request(method : string; path : string; status : int; ip : string; bytes_in : int; bytes_out : int) {
+def private log_request(method : string; path : string; status : int; ip : string; bytes_in : int; bytes_out : int; t0 : int64) {
     logger_info("playground.req", "{method} {path} {status}",
         JV((method = method, path = path, status = status, ip = ip,
-            bytes_in = bytes_in, bytes_out = bytes_out)))
+            bytes_in = bytes_in, bytes_out = bytes_out,
+            duration_ms = get_time_usec(t0) / 1000)))
 }
 
 class PlaygroundServer : HvWebServer {
@@ -84,19 +86,23 @@ class PlaygroundServer : HvWebServer {
             return handle_share_link(req, resp)
         }
         POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            let t0 = ref_time_ticks()
             logger_info("playground", "shutdown requested")
             g_stop_requested = true
+            log_request("POST", "/shutdown", 200, client_ip_of(req), 0, 3, t0)
             return resp |> TEXT_PLAIN("bye")
         }
         ANY("*") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            let t0 = ref_time_ticks()
             let body = write_json(JV((error = "not found")))
-            log_request("{req.method}", string(req.path), 404, client_ip_of(req), 0, length(body))
+            log_request("{req.method}", string(req.path), 404, client_ip_of(req), 0, length(body), t0)
             return resp |> JSON(body, http_status.NOT_FOUND)
         }
     }
 }
 
 def private handle_put(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
     let source = string(req.body)
     let ip = client_ip_of(req)
     let r = put_sample(g_db, source, ip, g_policy, current_unix_time())
@@ -114,59 +120,63 @@ def private handle_put(var req : HttpRequest?; var resp : HttpResponse?) : http_
         status = http_status.BAD_REQUEST
         body = write_json(JV((error = r.status == PutStatus.empty_source ? "empty source" : "source is not valid utf-8")))
     }
-    log_request("POST", "/api/samples", int(status), ip, length(source), length(body))
+    log_request("POST", "/api/samples", int(status), ip, length(source), length(body), t0)
     return resp |> JSON(body, status)
 }
 
 def private handle_get_source(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
     let hash = get_param(req, "hash")
     let ip = client_ip_of(req)
     if (!is_valid_hash(hash)) {
-        log_request("GET", "/api/samples/:hash", 400, ip, 0, 0)
+        log_request("GET", "/api/samples/:hash", 400, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "malformed hash"))), http_status.BAD_REQUEST)
     }
     let source = get_source(g_db, hash)
     if (empty(source)) {
-        log_request("GET", "/api/samples/:hash", 404, ip, 0, 0)
+        log_request("GET", "/api/samples/:hash", 404, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "unknown sample"))), http_status.NOT_FOUND)
     }
     // content-addressed => immutable forever
     resp |> set_header("Cache-Control", "public, max-age=31536000, immutable")
-    log_request("GET", "/api/samples/:hash", 200, ip, 0, length(source))
+    log_request("GET", "/api/samples/:hash", 200, ip, 0, length(source), t0)
     resp |> set_content_type("text/plain; charset=utf-8")
     resp.body := source
     return http_status.OK
 }
 
 def private handle_listed(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
     let listed <- listed_samples(g_db)
     var arr <- [for (l in listed); JV((hash = l.hash, title = l.title, category = l.category,
         path = l.path, slug = l.slug))]
     let body = write_json(JV(arr))
-    log_request("GET", "/api/samples/listed", 200, client_ip_of(req), 0, length(body))
+    log_request("GET", "/api/samples/listed", 200, client_ip_of(req), 0, length(body), t0)
     return resp |> JSON(body)
 }
 
 def private handle_reimport(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
     if (empty(g_curated_dir)) {
-        log_request("POST", "/admin/reimport", 503, client_ip_of(req), 0, 0)
+        log_request("POST", "/admin/reimport", 503, client_ip_of(req), 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "curated_dir not configured"))), http_status.SERVICE_UNAVAILABLE)
     }
     let listed = import_curated(g_db, g_curated_dir, current_unix_time())
     let status = listed >= 0 ? http_status.OK : http_status.INTERNAL_SERVER_ERROR
     let body = write_json(JV((listed = listed)))
-    log_request("POST", "/admin/reimport", int(status), client_ip_of(req), 0, length(body))
+    log_request("POST", "/admin/reimport", int(status), client_ip_of(req), 0, length(body), t0)
     return resp |> JSON(body, status)
 }
 
 def private handle_share_link(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
     let hash = get_param(req, "hash")
     let ip = client_ip_of(req)
     if (!is_valid_hash(hash) || !sample_exists(g_db, hash)) {
-        log_request("GET", "/s/:hash", 404, ip, 0, 0)
+        log_request("GET", "/s/:hash", 404, ip, 0, 0, t0)
         return resp |> TEXT_PLAIN("unknown sample", http_status.NOT_FOUND)
     }
-    log_request("GET", "/s/:hash", 302, ip, 0, 0)
+    log_request("GET", "/s/:hash", 302, ip, 0, 0, t0)
     return resp |> REDIRECT("/playground/index.html?s={hash}", http_status.FOUND)
 }
 
@@ -230,7 +240,7 @@ def shutdown_server {
         }
         g_server->cleanup()
         unsafe {
-            delete g_server
+            delete g_server   // class-instance delete requires unsafe; sole owner, tick loop already stopped
         }
         g_server = null
         g_server_started = false
@@ -239,6 +249,7 @@ def shutdown_server {
         delete g_db
         g_db_open = false
     }
+    logger_info("playground", "server stopped")
 }
 
 def run_server(port : int; db_path : string; policy : StorePolicy; base_url : string; curated_dir : string = "") {

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -1,0 +1,220 @@
+options gen2
+options indenting = 4
+
+module playground_server public
+
+require dashv/dashv_boost public
+require daslib/json_boost
+require daslib/logger
+require samples_store public
+require strings
+
+//! The HTTP surface: route table and handlers. A handler validates
+//! transport-level shape, translates HTTP to one samples_store call, and
+//! formats the response. Policy (size, rate, listing) lives in the store.
+
+// Lifecycle-owned state. Module-global: the server runs on its own context
+// (per-thread in tests), and JIT heap collection cannot see stack locals as
+// GC roots — handlers and the tick loop reach everything through these.
+var private g_server : PlaygroundServer?
+var private g_db = SqlRunner()
+var private g_db_open = false
+var private g_policy = StorePolicy()
+var private g_base_url = "https://daslang.io"
+var private g_stop_requested = false
+var private g_server_started = false
+
+def private client_ip_of(var req : HttpRequest?) : string {
+    //! First hop of X-Forwarded-For — Caddy is the only caller in production,
+    //! so the header is trustworthy; absent (direct loopback callers, tests)
+    //! degrades to "local".
+    let fwd = get_header(req, "X-Forwarded-For")
+    if (empty(fwd)) {
+        return "local"
+    }
+    let comma = find(fwd, ",")
+    return comma < 0 ? fwd : slice(fwd, 0, comma)
+}
+
+def is_valid_hash(h : string) : bool {
+    //! Transport-shape check: exactly 64 lowercase hex chars.
+    if (length(h) != 64) {
+        return false
+    }
+    var ok = true
+    peek_data(h) $(bytes) {
+        for (b in bytes) {
+            let c = int(b)
+            if (!(is_number(c) || (c >= 'a' && c <= 'f'))) {
+                ok = false
+            }
+        }
+    }
+    return ok
+}
+
+def private log_request(method : string; path : string; status : int; ip : string; bytes_in : int; bytes_out : int) {
+    logger_info("playground.req", "{method} {path} {status}",
+        JV((method = method, path = path, status = status, ip = ip,
+            bytes_in = bytes_in, bytes_out = bytes_out)))
+}
+
+class PlaygroundServer : HvWebServer {
+    def override onInit {  // the route table: one registration per endpoint
+        allow_cors()
+        GET("/healthz") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> TEXT_PLAIN("ok")
+        }
+        POST("/api/samples") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_put(req, resp)
+        }
+        GET("/api/samples/:hash") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_get_source(req, resp)
+        }
+        GET("/s/:hash") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_share_link(req, resp)
+        }
+        POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            logger_info("playground", "shutdown requested")
+            g_stop_requested = true
+            return resp |> TEXT_PLAIN("bye")
+        }
+        ANY("*") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            let body = write_json(JV((error = "not found")))
+            log_request("{req.method}", string(req.path), 404, client_ip_of(req), 0, length(body))
+            return resp |> JSON(body, http_status.NOT_FOUND)
+        }
+    }
+}
+
+def private handle_put(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let source = string(req.body)
+    let ip = client_ip_of(req)
+    let r = put_sample(g_db, source, ip, g_policy, current_unix_time())
+    var status = http_status.OK
+    var body = ""
+    if (r.status == PutStatus.ok) {
+        body = write_json(JV((hash = r.hash, url = "{g_base_url}/s/{r.hash}", created = r.created)))
+    } elif (r.status == PutStatus.too_large) {
+        status = http_status.PAYLOAD_TOO_LARGE
+        body = write_json(JV((error = "source too large")))
+    } elif (r.status == PutStatus.rate_limited) {
+        status = http_status.TOO_MANY_REQUESTS
+        body = write_json(JV((error = "rate limited")))
+    } else {
+        status = http_status.BAD_REQUEST
+        body = write_json(JV((error = r.status == PutStatus.empty_source ? "empty source" : "source is not valid utf-8")))
+    }
+    log_request("POST", "/api/samples", int(status), ip, length(source), length(body))
+    return resp |> JSON(body, status)
+}
+
+def private handle_get_source(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let hash = get_param(req, "hash")
+    let ip = client_ip_of(req)
+    if (!is_valid_hash(hash)) {
+        log_request("GET", "/api/samples/:hash", 400, ip, 0, 0)
+        return resp |> JSON(write_json(JV((error = "malformed hash"))), http_status.BAD_REQUEST)
+    }
+    let source = get_source(g_db, hash)
+    if (empty(source)) {
+        log_request("GET", "/api/samples/:hash", 404, ip, 0, 0)
+        return resp |> JSON(write_json(JV((error = "unknown sample"))), http_status.NOT_FOUND)
+    }
+    // content-addressed => immutable forever
+    resp |> set_header("Cache-Control", "public, max-age=31536000, immutable")
+    log_request("GET", "/api/samples/:hash", 200, ip, 0, length(source))
+    resp |> set_content_type("text/plain; charset=utf-8")
+    resp.body := source
+    return http_status.OK
+}
+
+def private handle_share_link(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let hash = get_param(req, "hash")
+    let ip = client_ip_of(req)
+    if (!is_valid_hash(hash) || !sample_exists(g_db, hash)) {
+        log_request("GET", "/s/:hash", 404, ip, 0, 0)
+        return resp |> TEXT_PLAIN("unknown sample", http_status.NOT_FOUND)
+    }
+    log_request("GET", "/s/:hash", 302, ip, 0, 0)
+    return resp |> REDIRECT("/playground/index.html?s={hash}", http_status.FOUND)
+}
+
+def init_server(port : int; db_path : string; policy : StorePolicy; base_url : string) : bool {
+    //! Open the store, migrate to latest, bind loopback, start listening.
+    //! Runs in the serving thread's context — module globals bind here.
+    g_policy = policy
+    g_base_url = base_url
+    g_stop_requested = false
+    var open_result <- try_open_sqlite(db_path)
+    if (open_result |> is_err) {
+        logger_error("playground", "could not open {db_path}: {open_result |> unwrap_err}")
+        return false
+    }
+    g_db <- open_result._value
+    g_db_open = true
+    g_db |> apply_recommended_pragmas()
+    let applied = migrate_to_latest(g_db)
+    if (applied > 0) {
+        logger_info("playground", "applied {applied} migration(s)")
+    }
+    g_server = new PlaygroundServer()
+    g_server->init(port)
+    if (!g_server->set_bind_host("127.0.0.1")) {
+        logger_error("playground", "could not bind loopback")
+        shutdown_server()
+        return false
+    }
+    let rc = g_server->start()
+    if (rc != 0) {
+        logger_error("playground", "could not start on port {port} (rc {rc}; port in use?)")
+        shutdown_server()
+        return false
+    }
+    g_server_started = true
+    logger_info("playground", "listening on http://127.0.0.1:{port}")
+    return true
+}
+
+def update_server : bool {
+    //! One tick. Returns false once shutdown was requested.
+    return false if (g_server == null)
+    g_server->tick()
+    if (g_stop_requested) {
+        return false
+    }
+    sleep(2u)
+    return true
+}
+
+def shutdown_server {
+    //! Release everything in dependency order; safe after a partially failed init.
+    if (g_server != null) {
+        if (g_server_started) {
+            g_server->stop()
+        }
+        g_server->cleanup()
+        unsafe {
+            delete g_server
+        }
+        g_server = null
+        g_server_started = false
+    }
+    if (g_db_open) {
+        delete g_db
+        g_db_open = false
+    }
+}
+
+def run_server(port : int; db_path : string; policy : StorePolicy; base_url : string) {
+    //! Blocking convenience wrapper (tests): init, tick until /shutdown, teardown.
+    if (init_server(port, db_path, policy, base_url)) {
+        while (update_server()) {
+        }
+    }
+    shutdown_server()
+}
+
+def private current_unix_time : int64 {
+    return int64(get_clock())
+}

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -7,6 +7,7 @@ require dashv/dashv_boost public
 require daslib/json_boost
 require daslib/logger
 require samples_store public
+require curated_import
 require strings
 
 //! The HTTP surface: route table and handlers. A handler validates
@@ -21,6 +22,7 @@ var private g_db = SqlRunner()
 var private g_db_open = false
 var private g_policy = StorePolicy()
 var private g_base_url = "https://daslang.io"
+var private g_curated_dir = ""
 var private g_stop_requested = false
 var private g_server_started = false
 
@@ -68,8 +70,15 @@ class PlaygroundServer : HvWebServer {
         POST("/api/samples") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_put(req, resp)
         }
+        GET("/api/samples/listed") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_listed(req, resp)
+        }
         GET("/api/samples/:hash") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_get_source(req, resp)
+        }
+        POST("/admin/reimport") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            // operator surface: reachable on loopback only — Caddy never routes /admin/*
+            return handle_reimport(req, resp)
         }
         GET("/s/:hash") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_share_link(req, resp)
@@ -129,6 +138,27 @@ def private handle_get_source(var req : HttpRequest?; var resp : HttpResponse?) 
     return http_status.OK
 }
 
+def private handle_listed(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let listed <- listed_samples(g_db)
+    var arr <- [for (l in listed); JV((hash = l.hash, title = l.title, category = l.category,
+        path = l.path, slug = l.slug))]
+    let body = write_json(JV(arr))
+    log_request("GET", "/api/samples/listed", 200, client_ip_of(req), 0, length(body))
+    return resp |> JSON(body)
+}
+
+def private handle_reimport(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    if (empty(g_curated_dir)) {
+        log_request("POST", "/admin/reimport", 503, client_ip_of(req), 0, 0)
+        return resp |> JSON(write_json(JV((error = "curated_dir not configured"))), http_status.SERVICE_UNAVAILABLE)
+    }
+    let listed = import_curated(g_db, g_curated_dir, current_unix_time())
+    let status = listed >= 0 ? http_status.OK : http_status.INTERNAL_SERVER_ERROR
+    let body = write_json(JV((listed = listed)))
+    log_request("POST", "/admin/reimport", int(status), client_ip_of(req), 0, length(body))
+    return resp |> JSON(body, status)
+}
+
 def private handle_share_link(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let hash = get_param(req, "hash")
     let ip = client_ip_of(req)
@@ -140,11 +170,13 @@ def private handle_share_link(var req : HttpRequest?; var resp : HttpResponse?) 
     return resp |> REDIRECT("/playground/index.html?s={hash}", http_status.FOUND)
 }
 
-def init_server(port : int; db_path : string; policy : StorePolicy; base_url : string) : bool {
-    //! Open the store, migrate to latest, bind loopback, start listening.
-    //! Runs in the serving thread's context — module globals bind here.
+def init_server(port : int; db_path : string; policy : StorePolicy; base_url : string; curated_dir : string = "") : bool {
+    //! Open the store, migrate to latest, import the curated set (when
+    //! configured), bind loopback, start listening. Runs in the serving
+    //! thread's context — module globals bind here.
     g_policy = policy
     g_base_url = base_url
+    g_curated_dir = curated_dir
     g_stop_requested = false
     var open_result <- try_open_sqlite(db_path)
     if (open_result |> is_err) {
@@ -157,6 +189,9 @@ def init_server(port : int; db_path : string; policy : StorePolicy; base_url : s
     let applied = migrate_to_latest(g_db)
     if (applied > 0) {
         logger_info("playground", "applied {applied} migration(s)")
+    }
+    if (!empty(g_curated_dir)) {
+        import_curated(g_db, g_curated_dir, current_unix_time())   // logs its own counts; -1 keeps prior listings
     }
     g_server = new PlaygroundServer()
     g_server->init(port)
@@ -206,9 +241,9 @@ def shutdown_server {
     }
 }
 
-def run_server(port : int; db_path : string; policy : StorePolicy; base_url : string) {
+def run_server(port : int; db_path : string; policy : StorePolicy; base_url : string; curated_dir : string = "") {
     //! Blocking convenience wrapper (tests): init, tick until /shutdown, teardown.
-    if (init_server(port, db_path, policy, base_url)) {
+    if (init_server(port, db_path, policy, base_url, curated_dir)) {
         while (update_server()) {
         }
     }

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -1,0 +1,170 @@
+﻿options gen2
+options indenting = 4
+
+module samples_store public
+
+require daslib/sql
+require sqlite/sqlite_migrate public
+require daslib/sql_linq
+require daslib/sha_256 public
+require strings
+
+//! The playground sample store: schema, migrations, store operations, and
+//! every policy decision (size cap, rate ceiling, listing). Zero HTTP --
+//! the server module translates transport to these calls and nothing else.
+
+let RATE_WINDOW_SECONDS = 3600l
+
+[sql_table(name = "samples"),
+ sql_index(fields = ("ClientIp", "CreatedAt"))]
+struct Sample {
+    @sql_primary_key Hash : string
+    Source : string
+    Size : int
+    CreatedAt : int64
+    ClientIp : string
+    Listed : bool = false
+    Title : string = ""
+    Origin : string = "user"
+}
+
+[sql_migration(version = 1, description = "create playground samples")]
+def samples_migration_001(db : SqlRunner) {
+    db |> exec(
+        "CREATE TABLE samples (" +
+        "Hash TEXT PRIMARY KEY," +
+        "Source TEXT NOT NULL," +
+        "Size INTEGER NOT NULL," +
+        "CreatedAt INTEGER NOT NULL," +
+        "ClientIp TEXT NOT NULL," +
+        "Listed INTEGER NOT NULL DEFAULT 0," +
+        "Title TEXT NOT NULL DEFAULT ''," +
+        "Origin TEXT NOT NULL DEFAULT 'user')")
+    db |> exec("CREATE INDEX idx_samples_client_created ON samples (ClientIp, CreatedAt)")
+}
+
+struct StorePolicy {
+    //! Every limit the store enforces; the launcher fills it from config.
+    max_source_bytes : int = 262144
+    max_inserts_per_ip_hour : int = 100
+}
+
+enum PutStatus {
+    ok
+    empty_source
+    too_large
+    invalid_utf8
+    rate_limited
+}
+
+struct PutResult {
+    status : PutStatus
+    hash : string       // set when status == ok
+    created : bool      // false = dedup hit (the sample already existed)
+}
+
+def is_valid_utf8(data : array<uint8> const# implicit) : bool {
+    //! Strict UTF-8 validation: rejects overlongs, surrogates, and > U+10FFFF.
+    var i = 0
+    let n = length(data)
+    while (i < n) {
+        let b0 = uint(data[i])
+        if (b0 < 0x80) {
+            i ++
+            continue
+        }
+        var need = 0
+        var lo = 0x80u
+        var hi = 0xBFu
+        if (b0 >= 0xC2 && b0 <= 0xDF) {
+            need = 1
+        } elif (b0 == 0xE0) {
+            need = 2
+            lo = 0xA0u
+        } elif (b0 >= 0xE1 && b0 <= 0xEC) {
+            need = 2
+        } elif (b0 == 0xED) {
+            need = 2
+            hi = 0x9Fu
+        } elif (b0 >= 0xEE && b0 <= 0xEF) {
+            need = 2
+        } elif (b0 == 0xF0) {
+            need = 3
+            lo = 0x90u
+        } elif (b0 >= 0xF1 && b0 <= 0xF3) {
+            need = 3
+        } elif (b0 == 0xF4) {
+            need = 3
+            hi = 0x8Fu
+        } else {
+            return false    // 0x80-0xC1 (bare continuation / overlong), 0xF5-0xFF
+        }
+        return false if (i + need >= n)
+        for (k in range(need)) {
+            let b = uint(data[i + 1 + k])
+            let bLo = k == 0 ? lo : 0x80u
+            let bHi = k == 0 ? hi : 0xBFu
+            return false if (b < bLo || b > bHi)
+        }
+        i += need + 1
+    }
+    return true
+}
+
+def is_valid_utf8(s : string) : bool {
+    var ok = true
+    peek_data(s) $(bytes) {
+        ok = is_valid_utf8(bytes)
+    }
+    return ok
+}
+
+def put_sample(db : SqlRunner; source : string; client_ip : string; policy : StorePolicy; now : int64) : PutResult {
+    //! Validate, dedup by content hash, and store. First writer wins: a dedup
+    //! hit changes nothing about the existing row.
+    if (empty(source)) {
+        return PutResult(status = PutStatus.empty_source)
+    }
+    if (length(source) > policy.max_source_bytes) {
+        return PutResult(status = PutStatus.too_large)
+    }
+    if (!is_valid_utf8(source)) {
+        return PutResult(status = PutStatus.invalid_utf8)
+    }
+    let hash = sha256_hex(source)
+    if (sample_exists(db, hash)) {
+        return PutResult(status = PutStatus.ok, hash = hash, created = false)
+    }
+    let cutoff = now - RATE_WINDOW_SECONDS
+    let recent <- _sql(db |> select_from(type<Sample>)
+        |> _where(_.ClientIp == client_ip && _.CreatedAt >= cutoff)
+        |> _select(_.Hash))
+    if (length(recent) >= policy.max_inserts_per_ip_hour) {
+        return PutResult(status = PutStatus.rate_limited)
+    }
+    db |> insert(Sample(
+        Hash = hash,
+        Source = source,
+        Size = length(source),
+        CreatedAt = now,
+        ClientIp = client_ip))
+    return PutResult(status = PutStatus.ok, hash = hash, created = true)
+}
+
+def sample_exists(db : SqlRunner; hash : string) : bool {
+    let hit <- _sql(db |> select_from(type<Sample>)
+        |> _where(_.Hash == hash)
+        |> _select(_.Hash)
+        |> take(1))
+    return !empty(hit)
+}
+
+def get_source(db : SqlRunner; hash : string) : string {
+    //! The stored source, or "" when the hash is unknown (an empty source can
+    //! never be stored, so "" is unambiguous).
+    let hit <- _sql(db |> select_from(type<Sample>)
+        |> _where(_.Hash == hash)
+        |> _select(_.Source)
+        |> take(1))
+    return !empty(hit) ? hit[0] : ""
+}

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -7,6 +7,8 @@ require daslib/sql
 require sqlite/sqlite_migrate public
 require daslib/sql_linq
 require daslib/sha_256 public
+require daslib/logger
+require daslib/json_boost
 require strings
 
 //! The playground sample store: schema, migrations, store operations, and
@@ -158,6 +160,8 @@ def put_sample(db : SqlRunner; source : string; client_ip : string; policy : Sto
         Size = length(source),
         CreatedAt = now,
         ClientIp = client_ip))
+    logger_info("playground.store", "insert user sample",
+        JV((hash = hash, size = length(source), ip = client_ip)))
     return PutResult(status = PutStatus.ok, hash = hash, created = true)
 }
 
@@ -211,6 +215,8 @@ def upsert_curated_source(db : SqlRunner; source : string; now : int64) : string
             CreatedAt = now,
             ClientIp = "importer",
             Origin = "curated"))
+        logger_info("playground.store", "insert curated sample",
+            JV((hash = hash, size = length(source))))
     }
     return hash
 }
@@ -220,6 +226,8 @@ def list_curated_sample(db : SqlRunner; hash : string; title : string; category 
         type<Sample>,
         _.Hash == hash,
         (Listed = 1, Title = title, Category = category, PrimaryPath = path, Slug = slug))
+    logger_info("playground.store", "list curated sample",
+        JV((hash = hash, title = title, category = category)))
 }
 
 def demote_stale_curated(db : SqlRunner; keep : table<string>) : int {
@@ -233,6 +241,7 @@ def demote_stale_curated(db : SqlRunner; keep : table<string>) : int {
     for (h in listed) {
         if (!key_exists(keep, h)) {
             db |> _sql_update(type<Sample>, _.Hash == h, (Listed = 0))
+            logger_info("playground.store", "demote stale curated", JV((hash = h)))
             demoted ++
         }
     }
@@ -248,6 +257,8 @@ def promote_sample(db : SqlRunner; hash : string; title : string; category : str
         type<Sample>,
         _.Hash == hash,
         (Listed = 1, Title = title, Category = category))
+    logger_info("playground.store", "promote sample",
+        JV((hash = hash, title = title, category = category)))
     return true
 }
 
@@ -260,5 +271,6 @@ def demote_sample(db : SqlRunner; hash : string) : bool {
         type<Sample>,
         _.Hash == hash,
         (Listed = 0))
+    logger_info("playground.store", "demote sample", JV((hash = hash)))
     return true
 }

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -23,9 +23,12 @@ struct Sample {
     Size : int
     CreatedAt : int64
     ClientIp : string
-    Listed : bool = false
+    Listed : int = 0   // 0/1; bool lacks a bind adapter on the predicate/update rails
     Title : string = ""
     Origin : string = "user"
+    Category : string = ""
+    PrimaryPath : string = ""   // curated: files[0] from data.json — the UI derives slug/assets from it
+    Slug : string = ""          // curated: explicit deep-link slug (?example=) when the manifest has one
 }
 
 [sql_migration(version = 1, description = "create playground samples")]
@@ -41,6 +44,13 @@ def samples_migration_001(db : SqlRunner) {
         "Title TEXT NOT NULL DEFAULT ''," +
         "Origin TEXT NOT NULL DEFAULT 'user')")
     db |> exec("CREATE INDEX idx_samples_client_created ON samples (ClientIp, CreatedAt)")
+}
+
+[sql_migration(version = 2, description = "curated listing: category, primary path, slug")]
+def samples_migration_002(db : SqlRunner) {
+    db |> exec("ALTER TABLE samples ADD COLUMN Category TEXT NOT NULL DEFAULT ''")
+    db |> exec("ALTER TABLE samples ADD COLUMN PrimaryPath TEXT NOT NULL DEFAULT ''")
+    db |> exec("ALTER TABLE samples ADD COLUMN Slug TEXT NOT NULL DEFAULT ''")
 }
 
 struct StorePolicy {
@@ -167,4 +177,88 @@ def get_source(db : SqlRunner; hash : string) : string {
         |> _select(_.Source)
         |> take(1))
     return !empty(hit) ? hit[0] : ""
+}
+
+struct ListedSample {
+    hash : string
+    title : string
+    category : string
+    path : string    // primary file path (slug/assets derivation in the UI); "" for user samples
+    slug : string    // explicit deep-link slug; "" = derive from path
+}
+
+def listed_samples(db : SqlRunner) : array<ListedSample> {
+    //! The curated dropdown, category-then-title ordered.
+    let rows <- _sql(db |> select_from(type<Sample>)
+        |> _where(_.Listed != 0)
+        |> _order_by((_.Category, _.Title))
+        |> _select((Hash = _.Hash, Title = _.Title, Category = _.Category,
+            PrimaryPath = _.PrimaryPath, Slug = _.Slug)))
+    return <- [for (r in rows); ListedSample(hash = r.Hash, title = r.Title, category = r.Category,
+        path = r.PrimaryPath, slug = r.Slug)]
+}
+
+def upsert_curated_source(db : SqlRunner; source : string; now : int64) : string {
+    //! Importer entry: store a curated body bypassing user policy (no rate
+    //! ceiling, no size cap — the deploy tree is trusted). Returns the hash;
+    //! an existing row (either origin) is left untouched.
+    let hash = sha256_hex(source)
+    if (!sample_exists(db, hash)) {
+        db |> insert(Sample(
+            Hash = hash,
+            Source = source,
+            Size = length(source),
+            CreatedAt = now,
+            ClientIp = "importer",
+            Origin = "curated"))
+    }
+    return hash
+}
+
+def list_curated_sample(db : SqlRunner; hash : string; title : string; category : string; path : string; slug : string) {
+    db |> _sql_update(
+        type<Sample>,
+        _.Hash == hash,
+        (Listed = 1, Title = title, Category = category, PrimaryPath = path, Slug = slug))
+}
+
+def demote_stale_curated(db : SqlRunner; keep : table<string>) : int {
+    //! Unlist curated rows whose hash is not in `keep` (the set the importer
+    //! just minted). User-promoted samples (Origin != "curated") are untouched;
+    //! rows and permalinks always survive. Returns the demoted count.
+    let listed <- _sql(db |> select_from(type<Sample>)
+        |> _where(_.Listed != 0 && _.Origin == "curated")
+        |> _select(_.Hash))
+    var demoted = 0
+    for (h in listed) {
+        if (!key_exists(keep, h)) {
+            db |> _sql_update(type<Sample>, _.Hash == h, (Listed = 0))
+            demoted ++
+        }
+    }
+    return demoted
+}
+
+def promote_sample(db : SqlRunner; hash : string; title : string; category : string) : bool {
+    //! List an existing sample in the dropdown. False when the hash is unknown.
+    if (!sample_exists(db, hash)) {
+        return false
+    }
+    db |> _sql_update(
+        type<Sample>,
+        _.Hash == hash,
+        (Listed = 1, Title = title, Category = category))
+    return true
+}
+
+def demote_sample(db : SqlRunner; hash : string) : bool {
+    //! Remove a sample from the dropdown; the row and its permalink stay.
+    if (!sample_exists(db, hash)) {
+        return false
+    }
+    db |> _sql_update(
+        type<Sample>,
+        _.Hash == hash,
+        (Listed = 0))
+    return true
 }

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -24,6 +24,9 @@ def private nuke(dir : string) {
         var err = ""
         remove(path_join(dir, f), err)
     }
+    var derr = ""
+    rmdir(path_join(dir, "examples"), derr)
+    rmdir(dir, derr)
 }
 
 let MANIFEST_V1 = ("\{ \"examples\": [" +

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -1,0 +1,142 @@
+options gen2
+
+require dastest/testing_boost public
+require curated_import
+require daslib/fio
+require daslib/json_boost
+
+def private fixture_dir(t : T?; tag : string) : string {
+    var err = ""
+    let root = temp_directory(err)
+    t |> success(!empty(root), "temp dir available")
+    let dir = path_join(root, "pg_import_{tag}")
+    mkdir_rec(path_join(dir, "examples"))
+    return dir
+}
+
+def private write_manifest(dir : string; body : string) {
+    fwrite(path_join(dir, "data.json"), body)
+}
+
+def private nuke(dir : string) {
+    // best-effort cleanup; temp files are per-run uniques either way
+    for (f in ["data.json", "examples/hello.das", "examples/multi_a.das", "examples/multi_b.das"]) {
+        var err = ""
+        remove(path_join(dir, f), err)
+    }
+}
+
+let MANIFEST_V1 = ("\{ \"examples\": [" +
+    "\{ \"name\": \"Hello world\", \"files\": [\"examples/hello.das\"] \}," +
+    "\{ \"name\": \"Multi (multi-file)\", \"slug\": \"multi\", \"files\": [\"examples/multi_a.das\", \"examples/multi_b.das\"] \}" +
+    "] \}")
+
+[test]
+def test_import_and_idempotency(t : T?) {
+    let dir = fixture_dir(t, "basic")
+    write_manifest(dir, MANIFEST_V1)
+    fwrite(path_join(dir, "examples/hello.das"), "print(\"hello\")")
+    fwrite(path_join(dir, "examples/multi_a.das"), "require multi_b")
+    fwrite(path_join(dir, "examples/multi_b.das"), "def helper \{ \}")
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("import lists both entries with metadata") @(tt : T?) {
+            tt |> equal(import_curated(db, dir, 1000l), 2)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 2)
+            tt |> equal(listed[0].title, "Hello world")
+            tt |> equal(listed[0].path, "examples/hello.das")
+            tt |> equal(listed[0].slug, "")
+            tt |> equal(listed[1].title, "Multi (multi-file)")
+            tt |> equal(listed[1].slug, "multi")
+        }
+        t |> run("single-file body is the raw source") @(tt : T?) {
+            let listed <- listed_samples(db)
+            tt |> equal(get_source(db, listed[0].hash), "print(\"hello\")")
+        }
+        t |> run("multi-file body is the share bundle shape") @(tt : T?) {
+            let listed <- listed_samples(db)
+            let src = get_source(db, listed[1].hash)
+            var jerr = ""
+            var doc = read_json(src, jerr)
+            tt |> success(doc != null, "bundle parses as json")
+            tt |> equal(doc?["active"] ?? "", "multi_a.das")
+            tt |> equal(doc?["files"]?["multi_a.das"] ?? "", "require multi_b")
+            tt |> equal(doc?["files"]?["multi_b.das"] ?? "", "def helper \{ \}")
+        }
+        t |> run("re-import is a no-op") @(tt : T?) {
+            let before <- listed_samples(db)
+            tt |> equal(import_curated(db, dir, 2000l), 2)
+            let after <- listed_samples(db)
+            tt |> equal(length(after), length(before))
+            tt |> equal(after[0].hash, before[0].hash)
+            tt |> equal(after[1].hash, before[1].hash)
+        }
+    }
+    nuke(dir)
+}
+
+[test]
+def test_reimport_repoints_and_demotes(t : T?) {
+    let dir = fixture_dir(t, "repoint")
+    write_manifest(dir, MANIFEST_V1)
+    fwrite(path_join(dir, "examples/hello.das"), "print(\"v1\")")
+    fwrite(path_join(dir, "examples/multi_a.das"), "require multi_b")
+    fwrite(path_join(dir, "examples/multi_b.das"), "def helper \{ \}")
+    with_latest_sqlite(":memory:") $(db) {
+        t |> equal(import_curated(db, dir, 1000l), 2)
+        var old_hash = ""
+        {
+            let listed <- listed_samples(db)
+            old_hash = listed[0].hash
+        }
+        t |> run("changed source repoints the listing, keeps the old permalink") @(tt : T?) {
+            fwrite(path_join(dir, "examples/hello.das"), "print(\"v2\")")
+            tt |> equal(import_curated(db, dir, 2000l), 2)
+            let listed <- listed_samples(db)
+            tt |> success(listed[0].hash != old_hash, "listing points at the new hash")
+            tt |> equal(get_source(db, listed[0].hash), "print(\"v2\")")
+            tt |> equal(get_source(db, old_hash), "print(\"v1\")")
+        }
+        t |> run("entry removed from the manifest gets demoted, user promotions survive") @(tt : T?) {
+            let user = put_sample(db, "let mine = 1", "10.0.0.1", StorePolicy(), 3000l)
+            tt |> success(promote_sample(db, user.hash, "Mine", "community"), "user promote")
+            write_manifest(dir, "\{ \"examples\": [ \{ \"name\": \"Hello world\", \"files\": [\"examples/hello.das\"] \} ] \}")
+            tt |> equal(import_curated(db, dir, 4000l), 1)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 2)   // hello + the user promotion
+            var titles : array<string>
+            for (l in listed) {
+                titles |> push(l.title)
+            }
+            tt |> success(find_index(titles, "Mine") >= 0, "user promotion still listed")
+            tt |> success(find_index(titles, "Multi (multi-file)") < 0, "vanished entry demoted")
+        }
+    }
+    nuke(dir)
+}
+
+[test]
+def test_import_failure_modes(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("missing manifest returns -1") @(tt : T?) {
+            tt |> equal(import_curated(db, "no/such/dir", 1000l), -1)
+        }
+        t |> run("bad json returns -1") @(tt : T?) {
+            let dir = fixture_dir(tt, "badjson")
+            write_manifest(dir, "\{ not json")
+            tt |> equal(import_curated(db, dir, 1000l), -1)
+            nuke(dir)
+        }
+        t |> run("entry with a missing file is skipped, the rest import") @(tt : T?) {
+            let dir = fixture_dir(tt, "missing")
+            write_manifest(dir, MANIFEST_V1)
+            fwrite(path_join(dir, "examples/hello.das"), "print(\"hello\")")
+            // multi_a/multi_b deliberately absent
+            tt |> equal(import_curated(db, dir, 1000l), 1)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 1)
+            tt |> equal(listed[0].title, "Hello world")
+            nuke(dir)
+        }
+    }
+}

--- a/utils/dasweb-playground/test_playground_config.das
+++ b/utils/dasweb-playground/test_playground_config.das
@@ -2,6 +2,9 @@ options gen2
 
 require dastest/testing_boost public
 require playground_config
+require daslib/fio
+require daslib/json_boost
+require strings
 
 def private no_args : array<string> {
     return <- array<string>()
@@ -39,6 +42,44 @@ def test_defaults_and_toml(t : T?) {
         let args <- no_args()
         t |> success(!apply_config_text(cfg, "port = [not toml", args, sources, err), "parse fails")
         t |> success(!empty(err), "error text set")
+    }
+}
+
+[test]
+def test_load_config_and_banner(t : T?) {
+    t |> run("explicit missing config is an error") @(t : T?) {
+        var cfg = ServerArgs()
+        cfg.config = "no/such/dasweb.toml"
+        var sources : table<string; string>
+        var err = ""
+        t |> success(!load_config(cfg, sources, err), "missing explicit config fails")
+        t |> success(!empty(err), "error text set")
+    }
+    t |> run("explicit config file loads and merges") @(t : T?) {
+        var terr = ""
+        let dir = temp_directory(terr)
+        let path = path_join(dir, "pg_cfg_test.toml")
+        fwrite(path, "port = 9210\n")
+        var cfg = ServerArgs()
+        cfg.config = path
+        var sources : table<string; string>
+        var err = ""
+        t |> success(load_config(cfg, sources, err), "config loads")
+        t |> equal(cfg.port, 9210)
+        t |> equal(sources?["port"] ?? "", "toml")
+        var rerr = ""
+        remove(path, rerr)
+    }
+    t |> run("banner carries every key with provenance") @(t : T?) {
+        let cfg = ServerArgs()
+        var sources : table<string; string>
+        sources |> insert("port", "cli")
+        let body = write_json(config_banner(cfg, sources))
+        for (key in fixed_array("\"port\"", "\"port_src\" : \"cli\"", "\"db_src\" : \"default\"",
+                "\"base_url\"", "\"max_source_bytes_src\"", "\"max_inserts_per_ip_hour_src\"",
+                "\"curated_dir_src\"")) {
+            t |> success(find(body, key) >= 0, "banner contains {key}")
+        }
     }
 }
 

--- a/utils/dasweb-playground/test_playground_config.das
+++ b/utils/dasweb-playground/test_playground_config.das
@@ -1,0 +1,90 @@
+options gen2
+
+require dastest/testing_boost public
+require playground_config
+
+def private no_args : array<string> {
+    return <- array<string>()
+}
+
+[test]
+def test_defaults_and_toml(t : T?) {
+    t |> run("defaults stand with no toml keys") @(t : T?) {
+        var cfg = ServerArgs()
+        var sources : table<string; string>
+        var err = ""
+        let args <- no_args()
+        t |> success(apply_config_text(cfg, "# empty\n", args, sources, err), "empty toml parses")
+        t |> equal(cfg.port, 8101)
+        t |> equal(cfg.base_url, "https://daslang.io")
+        t |> equal(cfg.max_source_bytes, 262144)
+    }
+    t |> run("toml overrides defaults and records provenance") @(t : T?) {
+        var cfg = ServerArgs()
+        var sources : table<string; string>
+        var err = ""
+        let args <- no_args()
+        let body = "port = 9000\ndb = \"/srv/x/samples.db\"\nmax_source_bytes = 1024\n"
+        t |> success(apply_config_text(cfg, body, args, sources, err), "toml parses")
+        t |> equal(cfg.port, 9000)
+        t |> equal(cfg.db, "/srv/x/samples.db")
+        t |> equal(cfg.max_source_bytes, 1024)
+        t |> equal(sources?["port"] ?? "", "toml")
+        t |> equal(sources?["max_inserts_per_ip_hour"] ?? "absent", "absent")
+    }
+    t |> run("bad toml reports an error") @(t : T?) {
+        var cfg = ServerArgs()
+        var sources : table<string; string>
+        var err = ""
+        let args <- no_args()
+        t |> success(!apply_config_text(cfg, "port = [not toml", args, sources, err), "parse fails")
+        t |> success(!empty(err), "error text set")
+    }
+}
+
+[test]
+def test_cli_precedence(t : T?) {
+    t |> run("explicit cli flag beats toml") @(t : T?) {
+        var cfg = ServerArgs()
+        cfg.port = 7777   // as if parsed from --port
+        var sources : table<string; string>
+        var err = ""
+        let args <- ["--port=7777"]
+        mark_cli_sources(args, sources)
+        t |> success(apply_config_text(cfg, "port = 9000\n", args, sources, err), "toml parses")
+        t |> equal(cfg.port, 7777)
+        t |> equal(sources?["port"] ?? "", "cli")
+    }
+    t |> run("short -p counts as the port flag") @(t : T?) {
+        var cfg = ServerArgs()
+        cfg.port = 7778
+        var sources : table<string; string>
+        var err = ""
+        let args <- ["-p", "7778"]
+        mark_cli_sources(args, sources)
+        t |> success(apply_config_text(cfg, "port = 9000\n", args, sources, err), "toml parses")
+        t |> equal(cfg.port, 7778)
+    }
+    t |> run("authoritative toml beats cli") @(t : T?) {
+        var cfg = ServerArgs()
+        cfg.port = 7777
+        var sources : table<string; string>
+        var err = ""
+        let args <- ["--port=7777"]
+        mark_cli_sources(args, sources)
+        t |> success(apply_config_text(cfg, "authoritative = true\nport = 9000\n", args, sources, err), "toml parses")
+        t |> equal(cfg.port, 9000)
+        t |> equal(sources?["port"] ?? "", "toml")
+    }
+    t |> run("hyphenated cli spelling maps to underscored key") @(t : T?) {
+        var cfg = ServerArgs()
+        cfg.max_source_bytes = 555
+        var sources : table<string; string>
+        var err = ""
+        let args <- ["--max-source-bytes=555"]
+        mark_cli_sources(args, sources)
+        t |> success(apply_config_text(cfg, "max_source_bytes = 9999\n", args, sources, err), "toml parses")
+        t |> equal(cfg.max_source_bytes, 555)
+        t |> equal(sources?["max_source_bytes"] ?? "", "cli")
+    }
+}

--- a/utils/dasweb-playground/test_playground_server.das
+++ b/utils/dasweb-playground/test_playground_server.das
@@ -1,0 +1,201 @@
+options gen2
+options persistent_heap
+
+require dastest/testing_boost public
+require playground_server
+require daslib/jobque_boost
+require daslib/json_boost
+require daslib/fio
+require strings
+
+let TEST_PORT = 19011   // 19001..19010 are taken by tests/dasHV
+
+// Local harness: playground_server keeps lifecycle state in module globals,
+// which are per-context — so ALL setup (store open included) happens inside
+// the server thread, and shutdown goes through POST /shutdown (which flips
+// the serving context's own flag).
+def private with_playground_server(policy : StorePolicy; blk : block<(base_url : string) : void>) {
+    with_job_status(1) $(finished) {
+        new_thread() @() {
+            run_server(TEST_PORT, ":memory:", policy, "https://test.example")
+            finished |> notify_and_release
+        }
+        let base_url = "http://127.0.0.1:{TEST_PORT}"
+        var ready = false
+        for (_attempt in range(100)) {
+            GET("{base_url}/healthz") $(resp) {
+                if (resp != null && resp.status_code == http_status.OK) {
+                    ready = true
+                }
+            }
+            if (ready) {
+                break
+            }
+            sleep(100u)
+        }
+        if (ready) {
+            invoke(blk, base_url)
+        }
+        POST("{base_url}/shutdown", "") $(_resp) {}
+        finished |> join
+        assert(ready, "playground server became ready")
+    }
+}
+
+def private default_policy : StorePolicy {
+    return StorePolicy()
+}
+
+def private tiny_policy : StorePolicy {
+    return StorePolicy(max_source_bytes = 64, max_inserts_per_ip_hour = 3)
+}
+
+def private posted_hash(base_url : string; source : string) : string {
+    var hash = ""
+    POST("{base_url}/api/samples", source) $(resp) {
+        if (resp != null && resp.status_code == http_status.OK) {
+            var jerr = ""
+            var doc = read_json(string(resp.body), jerr)
+            hash = doc?["hash"] ?? ""
+        }
+    }
+    return hash
+}
+
+[test]
+def test_health_and_unknown_routes(t : T?) {
+    with_playground_server(default_policy()) $(base_url) {
+        t |> run("healthz") @(tt : T?) {
+            GET("{base_url}/healthz") $(resp) {
+                tt |> success(resp != null, "response arrived")
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(string(resp.body), "ok")
+            }
+        }
+        t |> run("unknown route is a json 404") @(tt : T?) {
+            GET("{base_url}/no/such/route") $(resp) {
+                tt |> equal(int(resp.status_code), 404)
+                tt |> success(find(string(resp.body), "not found") >= 0, "json error body")
+            }
+        }
+    }
+}
+
+[test]
+def test_put_get_roundtrip(t : T?) {
+    with_playground_server(default_policy()) $(base_url) {
+        let source = "print(\"shared via /s/\")"
+        t |> run("post mints hash and url") @(tt : T?) {
+            POST("{base_url}/api/samples", source) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var jerr = ""
+                var doc = read_json(string(resp.body), jerr)
+                let hash : string = doc?["hash"] ?? ""
+                tt |> equal(hash, sha256_hex(source))
+                tt |> equal(doc?["url"] ?? "", "https://test.example/s/{hash}")
+                tt |> success(doc?["created"] ?? false, "first post creates")
+            }
+        }
+        t |> run("second post dedups") @(tt : T?) {
+            POST("{base_url}/api/samples", source) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var jerr = ""
+                var doc = read_json(string(resp.body), jerr)
+                tt |> success(!(doc?["created"] ?? true), "created=false on dedup")
+            }
+        }
+        t |> run("get returns the exact source") @(tt : T?) {
+            let hash = sha256_hex(source)
+            GET("{base_url}/api/samples/{hash}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(string(resp.body), source)
+                tt |> success(find(get_header(resp, "Content-Type"), "text/plain") >= 0, "text/plain")
+                tt |> success(find(get_header(resp, "Cache-Control"), "immutable") >= 0, "immutable cache header")
+            }
+        }
+    }
+}
+
+[test]
+def test_transport_rejections(t : T?) {
+    with_playground_server(tiny_policy()) $(base_url) {
+        t |> run("empty body is 400") @(tt : T?) {
+            POST("{base_url}/api/samples", "") $(resp) {
+                tt |> equal(int(resp.status_code), 400)
+            }
+        }
+        t |> run("oversized body is 413") @(tt : T?) {
+            var big = ""
+            for (_i in range(65)) {
+                big += "y"
+            }
+            POST("{base_url}/api/samples", big) $(resp) {
+                tt |> equal(int(resp.status_code), 413)
+            }
+        }
+        t |> run("malformed hash is 400") @(tt : T?) {
+            GET("{base_url}/api/samples/nothex") $(resp) {
+                tt |> equal(int(resp.status_code), 400)
+            }
+            GET("{base_url}/api/samples/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF") $(resp) {
+                tt |> equal(int(resp.status_code), 400)
+            }
+        }
+        t |> run("unknown well-formed hash is 404") @(tt : T?) {
+            GET("{base_url}/api/samples/{sha256_hex("no such sample")}") $(resp) {
+                tt |> equal(int(resp.status_code), 404)
+            }
+        }
+    }
+}
+
+[test]
+def test_rate_limiting_by_forwarded_ip(t : T?) {
+    with_playground_server(tiny_policy()) $(base_url) {
+        t |> run("fourth insert from one ip is 429; another ip passes") @(tt : T?) {
+            var headers_a : table<string; string>
+            headers_a |> insert("X-Forwarded-For", "203.0.113.7")
+            var headers_b : table<string; string>
+            headers_b |> insert("X-Forwarded-For", "203.0.113.8, 10.0.0.1")
+            for (i in range(3)) {
+                POST("{base_url}/api/samples", "sample {i}", headers_a) $(resp) {
+                    tt |> equal(int(resp.status_code), 200)
+                }
+            }
+            POST("{base_url}/api/samples", "sample 3", headers_a) $(resp) {
+                tt |> equal(int(resp.status_code), 429)
+            }
+            POST("{base_url}/api/samples", "sample 4", headers_b) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+        }
+    }
+}
+
+[test]
+def test_share_link(t : T?) {
+    with_playground_server(default_policy()) $(base_url) {
+        let source = "let shared = true"
+        let hash = posted_hash(base_url, source)
+        t |> run("known hash redirects to the playground") @(tt : T?) {
+            tt |> equal(hash, sha256_hex(source))
+            GET("{base_url}/s/{hash}") $(resp) {
+                tt |> success(resp != null, "response arrived")
+                // libhv's client may follow the 302: accept either the raw
+                // redirect or the followed-to-playground 404 on this bare API
+                // server (no static files here).
+                let sc = int(resp.status_code)
+                if (sc == 302) {
+                    tt |> success(find(get_header(resp, "Location"), hash) >= 0, "Location carries the hash")
+                } else {
+                    tt |> equal(sc, 404)
+                }
+            }
+        }
+        t |> run("unknown hash is 404") @(tt : T?) {
+            GET("{base_url}/s/{sha256_hex("never stored")}") $(resp) {
+                tt |> equal(int(resp.status_code), 404)
+            }
+        }
+    }
+}

--- a/utils/dasweb-playground/test_playground_server.das
+++ b/utils/dasweb-playground/test_playground_server.das
@@ -8,6 +8,8 @@ require daslib/json_boost
 require daslib/fio
 require strings
 
+let TEST_CURATED_PORT = 19012
+
 let TEST_PORT = 19011   // 19001..19010 are taken by tests/dasHV
 
 // Local harness: playground_server keeps lifecycle state in module globals,
@@ -15,12 +17,18 @@ let TEST_PORT = 19011   // 19001..19010 are taken by tests/dasHV
 // the server thread, and shutdown goes through POST /shutdown (which flips
 // the serving context's own flag).
 def private with_playground_server(policy : StorePolicy; blk : block<(base_url : string) : void>) {
+    with_playground_server_at(TEST_PORT, policy, "", blk)
+}
+
+def private with_playground_server_at(port : int; policy : StorePolicy; curated_dir : string; blk : block<(base_url : string) : void>) {
     with_job_status(1) $(finished) {
+        let port_copy = port
+        let curated_copy = curated_dir
         new_thread() @() {
-            run_server(TEST_PORT, ":memory:", policy, "https://test.example")
+            run_server(port_copy, ":memory:", policy, "https://test.example", curated_copy)
             finished |> notify_and_release
         }
-        let base_url = "http://127.0.0.1:{TEST_PORT}"
+        let base_url = "http://127.0.0.1:{port}"
         var ready = false
         for (_attempt in range(100)) {
             GET("{base_url}/healthz") $(resp) {
@@ -169,6 +177,57 @@ def test_rate_limiting_by_forwarded_ip(t : T?) {
                 tt |> equal(int(resp.status_code), 200)
             }
         }
+    }
+}
+
+[test]
+def test_listed_and_reimport(t : T?) {
+    t |> run("listed is empty without curated import; reimport 503s unconfigured") @(tt : T?) {
+        with_playground_server(default_policy()) $(base_url) {
+            GET("{base_url}/api/samples/listed") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(string(resp.body), "[]")
+            }
+            POST("{base_url}/admin/reimport", "") $(resp) {
+                tt |> equal(int(resp.status_code), 503)
+            }
+        }
+    }
+    t |> run("boot import feeds listed; reimport recounts") @(tt : T?) {
+        var terr = ""
+        let dir = path_join(temp_directory(terr), "pg_server_curated")
+        mkdir_rec(path_join(dir, "examples"))
+        fwrite(path_join(dir, "data.json"),
+            "\{ \"examples\": [ \{ \"name\": \"Hello world\", \"files\": [\"examples/hello.das\"] \} ] \}")
+        fwrite(path_join(dir, "examples/hello.das"), "print(\"curated hello\")")
+        with_playground_server_at(TEST_CURATED_PORT, default_policy(), dir) $(base_url) {
+            var hash = ""
+            GET("{base_url}/api/samples/listed") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var jerr = ""
+                var doc = read_json(string(resp.body), jerr)
+                tt |> success(doc != null && (doc.value is _array), "listed is a json array")
+                tt |> equal(length(doc.value as _array), 1)
+                let entry = (doc.value as _array)[0]
+                tt |> equal(entry?["title"] ?? "", "Hello world")
+                tt |> equal(entry?["category"] ?? "", "examples")
+                tt |> equal(entry?["path"] ?? "", "examples/hello.das")
+                hash = entry?["hash"] ?? ""
+            }
+            GET("{base_url}/api/samples/{hash}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(string(resp.body), "print(\"curated hello\")")
+            }
+            POST("{base_url}/admin/reimport", "") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var jerr = ""
+                var doc = read_json(string(resp.body), jerr)
+                tt |> equal(int(doc?["listed"] ?? 0l), 1)
+            }
+        }
+        var rerr = ""
+        remove(path_join(dir, "data.json"), rerr)
+        remove(path_join(dir, "examples/hello.das"), rerr)
     }
 }
 

--- a/utils/dasweb-playground/test_playground_server.das
+++ b/utils/dasweb-playground/test_playground_server.das
@@ -228,6 +228,8 @@ def test_listed_and_reimport(t : T?) {
         var rerr = ""
         remove(path_join(dir, "data.json"), rerr)
         remove(path_join(dir, "examples/hello.das"), rerr)
+        rmdir(path_join(dir, "examples"), rerr)
+        rmdir(dir, rerr)
     }
 }
 

--- a/utils/dasweb-playground/test_samples_store.das
+++ b/utils/dasweb-playground/test_samples_store.das
@@ -101,6 +101,45 @@ def test_dedup_first_writer_wins(t : T?) {
 }
 
 [test]
+def test_curated_store_ops(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("upsert_curated_source inserts once, bypassing policy") @(tt : T?) {
+            let h1 = upsert_curated_source(db, "curated body", 1000l)
+            tt |> equal(h1, sha256_hex("curated body"))
+            let h2 = upsert_curated_source(db, "curated body", 9999l)
+            tt |> equal(h2, h1)
+            let rows <- _sql(db |> select_from(type<Sample>) |> _where(_.Hash == h1))
+            tt |> equal(length(rows), 1)
+            tt |> equal(rows[0].Origin, "curated")
+            tt |> equal(rows[0].CreatedAt, 1000l)   // second upsert did not touch the row
+        }
+        t |> run("list_curated_sample sets all listing fields") @(tt : T?) {
+            let h = upsert_curated_source(db, "listed body", 1000l)
+            list_curated_sample(db, h, "The Title", "examples", "examples/x.das", "xslug")
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 1)
+            tt |> equal(listed[0].title, "The Title")
+            tt |> equal(listed[0].path, "examples/x.das")
+            tt |> equal(listed[0].slug, "xslug")
+        }
+        t |> run("demote_stale_curated demotes only curated hashes outside the keep set") @(tt : T?) {
+            let ha = upsert_curated_source(db, "keep me", 1000l)
+            list_curated_sample(db, ha, "Keep", "examples", "", "")
+            let hb = upsert_curated_source(db, "drop me", 1000l)
+            list_curated_sample(db, hb, "Drop", "examples", "", "")
+            let user = put_sample(db, "user body", "10.0.0.1", test_policy(), 1000l)
+            tt |> success(promote_sample(db, user.hash, "User", "community"), "user promote")
+            var keep : table<string>
+            keep |> insert(ha)
+            // demotes Drop AND the previous subtest's listed row (same db)
+            tt |> equal(demote_stale_curated(db, keep), 2)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 2)   // Keep + User survive
+        }
+    }
+}
+
+[test]
 def test_rejections(t : T?) {
     with_latest_sqlite(":memory:") $(db) {
         t |> run("empty source") @(tt : T?) {

--- a/utils/dasweb-playground/test_samples_store.das
+++ b/utils/dasweb-playground/test_samples_store.das
@@ -1,0 +1,143 @@
+options gen2
+
+require dastest/testing_boost public
+require samples_store
+require daslib/result
+require daslib/sql_linq
+
+def private test_policy : StorePolicy {
+    return StorePolicy(max_source_bytes = 64, max_inserts_per_ip_hour = 3)
+}
+
+[test]
+def test_migration(t : T?) {
+    t |> run("fresh db migrates to v1") @(t : T?) {
+        with_latest_sqlite(":memory:") $(db) {
+            t |> equal(current_schema_version(db), 1)
+        }
+    }
+}
+
+[test]
+def test_put_and_get(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("put stores and returns the content hash") @(tt : T?) {
+            let src = "print(\"hi\")"
+            let r = put_sample(db, src, "10.0.0.1", test_policy(), 1000l)
+            tt |> equal(r.status, PutStatus.ok)
+            tt |> success(r.created, "first put creates")
+            tt |> equal(r.hash, sha256_hex(src))
+            tt |> success(sample_exists(db, r.hash), "exists after put")
+            tt |> equal(get_source(db, r.hash), src)
+        }
+        t |> run("unknown hash reads as empty") @(tt : T?) {
+            tt |> equal(get_source(db, "deadbeef"), "")
+            tt |> success(!sample_exists(db, "deadbeef"), "absent hash does not exist")
+        }
+    }
+}
+
+[test]
+def test_dedup_first_writer_wins(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        let src = "let x = 1"
+        let first = put_sample(db, src, "10.0.0.1", test_policy(), 1000l)
+        let second = put_sample(db, src, "10.0.0.2", test_policy(), 2000l)
+        t |> run("second put dedups") @(tt : T?) {
+            tt |> equal(second.status, PutStatus.ok)
+            tt |> success(!second.created, "dedup hit does not create")
+            tt |> equal(second.hash, first.hash)
+        }
+        t |> run("original row metadata is preserved") @(tt : T?) {
+            let rows <- _sql(db |> select_from(type<Sample>)
+                |> _where(_.Hash == first.hash))
+            tt |> equal(length(rows), 1)
+            tt |> equal(rows[0].ClientIp, "10.0.0.1")
+            tt |> equal(rows[0].CreatedAt, 1000l)
+            tt |> equal(rows[0].Origin, "user")
+            tt |> success(!rows[0].Listed, "not listed by default")
+        }
+    }
+}
+
+[test]
+def test_rejections(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("empty source") @(tt : T?) {
+            tt |> equal(put_sample(db, "", "10.0.0.1", test_policy(), 1000l).status, PutStatus.empty_source)
+        }
+        t |> run("over the size cap") @(tt : T?) {
+            var big = ""
+            for (_i in range(65)) {
+                big += "x"
+            }
+            tt |> equal(put_sample(db, big, "10.0.0.1", test_policy(), 1000l).status, PutStatus.too_large)
+        }
+        t |> run("rejected puts store nothing") @(tt : T?) {
+            let rows <- _sql(db |> select_from(type<Sample>) |> _select(_.Hash))
+            tt |> equal(length(rows), 0)
+        }
+    }
+}
+
+[test]
+def test_rate_ceiling(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        let pol = test_policy()   // 3 per hour
+        t |> run("ceiling rejects the fourth insert") @(tt : T?) {
+            tt |> equal(put_sample(db, "a1", "10.0.0.1", pol, 1000l).status, PutStatus.ok)
+            tt |> equal(put_sample(db, "a2", "10.0.0.1", pol, 1010l).status, PutStatus.ok)
+            tt |> equal(put_sample(db, "a3", "10.0.0.1", pol, 1020l).status, PutStatus.ok)
+            tt |> equal(put_sample(db, "a4", "10.0.0.1", pol, 1030l).status, PutStatus.rate_limited)
+        }
+        t |> run("dedup hits bypass the ceiling") @(tt : T?) {
+            tt |> equal(put_sample(db, "a1", "10.0.0.1", pol, 1040l).status, PutStatus.ok)
+        }
+        t |> run("another ip is unaffected") @(tt : T?) {
+            tt |> equal(put_sample(db, "b1", "10.0.0.2", pol, 1050l).status, PutStatus.ok)
+        }
+        t |> run("the window expires") @(tt : T?) {
+            tt |> equal(put_sample(db, "a5", "10.0.0.1", pol, 1000l + 3601l).status, PutStatus.ok)
+        }
+    }
+}
+
+[test]
+def test_utf8_validation(t : T?) {
+    t |> run("valid sequences") @(t : T?) {
+        t |> success(is_valid_utf8("plain ascii"), "ascii")
+        t |> success(is_valid_utf8("héllo wörld"), "two-byte")
+        t |> success(is_valid_utf8("日本語"), "three-byte")
+        t |> success(is_valid_utf8("🎉"), "four-byte")
+        t |> success(is_valid_utf8(""), "empty")
+    }
+    t |> run("invalid sequences") @(t : T?) {
+        var bad : array<uint8>
+        bad |> push(uint8(0xC3))
+        bad |> push(uint8(0x28))            // 2-byte lead + non-continuation
+        t |> success(!is_valid_utf8(bad), "truncated two-byte")
+        bad |> clear()
+        bad |> push(uint8(0x80))            // bare continuation
+        t |> success(!is_valid_utf8(bad), "bare continuation")
+        bad |> clear()
+        bad |> push(uint8(0xC0))
+        bad |> push(uint8(0xAF))            // overlong '/'
+        t |> success(!is_valid_utf8(bad), "overlong")
+        bad |> clear()
+        bad |> push(uint8(0xED))
+        bad |> push(uint8(0xA0))
+        bad |> push(uint8(0x80))            // UTF-16 surrogate D800
+        t |> success(!is_valid_utf8(bad), "surrogate")
+        bad |> clear()
+        bad |> push(uint8(0xF5))
+        bad |> push(uint8(0x80))
+        bad |> push(uint8(0x80))
+        bad |> push(uint8(0x80))            // > U+10FFFF
+        t |> success(!is_valid_utf8(bad), "above U+10FFFF")
+        bad |> clear()
+        bad |> push(uint8(0xE2))
+        bad |> push(uint8(0x82))            // truncated three-byte at end
+        t |> success(!is_valid_utf8(bad), "truncated at end of input")
+        delete bad
+    }
+}

--- a/utils/dasweb-playground/test_samples_store.das
+++ b/utils/dasweb-playground/test_samples_store.das
@@ -11,9 +11,49 @@ def private test_policy : StorePolicy {
 
 [test]
 def test_migration(t : T?) {
-    t |> run("fresh db migrates to v1") @(t : T?) {
+    t |> run("fresh db migrates to latest") @(t : T?) {
         with_latest_sqlite(":memory:") $(db) {
-            t |> equal(current_schema_version(db), 1)
+            t |> equal(current_schema_version(db), 2)
+        }
+    }
+}
+
+[test]
+def test_listing_and_promotion(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        let src = "print(\"curated\")"
+        let put = put_sample(db, src, "10.0.0.1", test_policy(), 1000l)
+        t |> run("nothing listed by default") @(tt : T?) {
+            t |> equal(length(listed_samples(db)), 0)
+        }
+        t |> run("promote lists with title and category") @(tt : T?) {
+            tt |> success(promote_sample(db, put.hash, "Curated One", "examples"), "promote known hash")
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 1)
+            tt |> equal(listed[0].hash, put.hash)
+            tt |> equal(listed[0].title, "Curated One")
+            tt |> equal(listed[0].category, "examples")
+        }
+        t |> run("promote unknown hash fails") @(tt : T?) {
+            tt |> success(!promote_sample(db, "deadbeef", "X", "examples"), "unknown hash rejected")
+        }
+        t |> run("demote unlists but keeps the permalink") @(tt : T?) {
+            tt |> success(demote_sample(db, put.hash), "demote known hash")
+            tt |> equal(length(listed_samples(db)), 0)
+            tt |> equal(get_source(db, put.hash), src)
+        }
+        t |> run("listing orders by category then title") @(tt : T?) {
+            let a = put_sample(db, "a1", "10.0.0.9", test_policy(), 9000l)
+            let b = put_sample(db, "b1", "10.0.0.9", test_policy(), 9010l)
+            let c = put_sample(db, "c1", "10.0.0.9", test_policy(), 9020l)
+            tt |> success(promote_sample(db, c.hash, "Zed", "alpha"), "promote c")
+            tt |> success(promote_sample(db, a.hash, "Mid", "beta"), "promote a")
+            tt |> success(promote_sample(db, b.hash, "Ace", "beta"), "promote b")
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 3)
+            tt |> equal(listed[0].title, "Zed")
+            tt |> equal(listed[1].title, "Ace")
+            tt |> equal(listed[2].title, "Mid")
         }
     }
 }
@@ -55,7 +95,7 @@ def test_dedup_first_writer_wins(t : T?) {
             tt |> equal(rows[0].ClientIp, "10.0.0.1")
             tt |> equal(rows[0].CreatedAt, 1000l)
             tt |> equal(rows[0].Origin, "user")
-            tt |> success(!rows[0].Listed, "not listed by default")
+            tt |> equal(rows[0].Listed, 0)
         }
     }
 }

--- a/utils/dasweb-playground/watchdog.json
+++ b/utils/dasweb-playground/watchdog.json
@@ -1,0 +1,5 @@
+{
+    "name": "dasweb-playground",
+    "health_url": "http://127.0.0.1:8101/healthz",
+    "shutdown_url": "http://127.0.0.1:8101/shutdown"
+}

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -76,7 +76,28 @@ pageInit = function () {
     });
 
 
-     $.getJSON( "./samples/data.json", function(res) {
+     // The curated list comes from the sample service (store-fed, phase 2 of
+     // plans/dasweb_backend.md); the committed data.json remains the fallback
+     // for the GH Pages mirror / an empty store on first boot.
+     fetch('/api/samples/listed')
+        .then(function(r) { if (!r.ok) throw new Error('listed ' + r.status); return r.json(); })
+        .then(function(listed) {
+            if (!Array.isArray(listed) || !listed.length) throw new Error('listed empty');
+            const byCat = {};
+            for (const e of listed) {
+                const cat = e.category || 'examples';
+                (byCat[cat] = byCat[cat] || []).push({
+                    name: e.title,
+                    files: [e.path || (e.hash + '.das')],
+                    slug: e.slug || undefined,
+                    hash: e.hash,
+                });
+            }
+            initSampleUi(byCat);
+        })
+        .catch(function() { $.getJSON('./samples/data.json', initSampleUi); });
+
+     function initSampleUi(res) {
         samplesData = res;
 
 
@@ -124,7 +145,7 @@ pageInit = function () {
              selectSample("examples", 0);
          }
 
-    });
+    }
 
 
 }
@@ -232,6 +253,12 @@ function updateEngineAvailability(name) {
             if (interpRadio) interpRadio.checked = true;
         }
     };
+    // Phase 2 (plans/dasweb_backend.md): the precompiled-artifact path is
+    // retired — wasm builds move to the on-demand build service. The radio
+    // stays off until phase 3 serves real builds; the gates below stay
+    // dormant for that return.
+    disableJit();
+    return;
     // Gate 1: no memory64 → wasm64 artifacts can't run here at all.
     if (!WASM64_SUPPORTED) { disableJit(); return; }
     // Gate 2: no precompiled .wasm for this sample (multi-file or absent).
@@ -288,17 +315,33 @@ selectSample = function(type, id) {
         // Hide the canvas on every sample switch; a graphics program re-reveals
         // it on Run when it creates a WebGL context (the getContext hook).
         showCanvas(false);
-        const files = samplesData[type][vv].files;
+        const entry = samplesData[type][vv];
+        const files = entry.files;
         currentJitName = deriveJitName(files);
         currentAssetsUrl = deriveAssetsUrl(files);
         updateEngineAvailability(currentJitName);
-        Promise.all(files.map(f =>
+        const loadFromStaticFiles = () => Promise.all(files.map(f =>
             $.ajax({ url: './samples/' + f, dataType: 'text' })
                 .then(text => ({ name: f.split('/').pop(), text }))
         )).then(loaded => {
             const byName = Object.fromEntries(loaded.map(({ name, text }) => [name, text]));
             loadSample(byName);
         });
+        if (entry.hash) {
+            // Store-fed entry: one fetch; multi-file samples arrive as the
+            // same {files, active} bundle user shares store. Static tree is
+            // the fallback (mirror / store hiccup).
+            fetch('/api/samples/' + entry.hash)
+                .then(r => { if (!r.ok) throw new Error('sample ' + r.status); return r.text(); })
+                .then(text => {
+                    let bundle = null;
+                    try { const o = JSON.parse(text); if (o && o.files) bundle = o.files; } catch (e) { /* single file */ }
+                    loadSample(bundle || { 'main.das': text });
+                })
+                .catch(loadFromStaticFiles);
+        } else {
+            loadFromStaticFiles();
+        }
     }
     if (sel) sel.value = "init";
 }


### PR DESCRIPTION
## What

The daslang.io playground backend (`utils/dasweb-playground`) — phases 1+2 of `plans/dasweb_backend.md`:

- **Phase 1 — user share links.** `POST /api/samples` stores playground code content-addressed (new `daslib/sha_256`); `daslang.io/s/<hash>` is a permanent share link. Kills the zip+tinyurl third-party shortener chain. Share button + `?s=` loader in the playground JS (legacy `#code=`/`#z=` links keep working forever).
- **Phase 2 — curated samples through the same store.** A `data.json`-driven idempotent importer runs at boot (and on loopback `POST /admin/reimport`): single-file entries stored as raw source, multi-file as the same `{files, active}` bundle user shares use. The dropdown is fed by `GET /api/samples/listed` (committed `data.json` remains the mirror/empty-store fallback). Changed sources repoint listings, vanished entries demote, permalinks always survive. `admin.das` = operator promote/demote CLI. The "JIT (wasm)" radio is disabled until phase 3 serves real on-demand builds.

## Service shape

Canonical app skeleton (`examples/hv/ws_chat_server.das` + dasllama-server conventions): dasHV on loopback `127.0.0.1:8101` behind Caddy, module-global lifecycle + GC boundary, clargs+toml config with per-key provenance, ndjson request/mutation logging (`daslib/logger` tee), `utils/watchdog` contract (exit 0/4, `/healthz`, `POST /shutdown`), `daspkg release` baked-exe deployment. Binding per-diff rules in `utils/dasweb-playground/CODEREVIEW.md` (placement / security / logging / lifecycle), written before the first line of code.

## Already live (deployed from this branch during development)

- Service running on the daslang.io origin (systemd → watchdog → baked exe, built via `daspkg release` on the zen4 worktree); Caddy routes `/s/*` + `/api/samples*`.
- Live-verified over public TLS: share mint + fetch + 302, immutable cache headers, curated import of the real deployed tree (39 listed / 0 skipped), single- and multi-file curated fetch, kill -9 → watchdog recovery in 5 s.
- The playground JS in this PR is what makes `/s/` links load in the editor and the dropdown store-fed — it goes live when this merges and the site redeploys.

## Verification

- 77 dastest cases green (67 in-dir: store/importer/server-over-HTTP/config; 10 `tests/daslib/test_sha_256.das`: NIST vectors incl. million-a, padding boundaries, streaming parity). Lint 0 across every changed `.das`. Formatter clean. JIT smoke clean. Scoped detect-dupe: 0 matches.
- das2rst registration for `daslib/sha_256` (+ handmade docs); Uncategorized = 0.
- Playground e2e: `engine-toggle.spec.js` rewritten to pin the permanently-disabled radio (the enable-transition tests it replaces come back with phase 3, per comment).

## Notes for review

- `Sample.Listed` is `int` 0/1, not `bool`: bool has no `sql_bind` adapter on the sql_linq predicate/update rails (struct-field extraction works; expression rail doesn't). Commented at the field; a daslib-side bool adapter would let this revert.
- `POST /admin/reimport` is deliberately outside `/api/samples*` so Caddy never routes it (CODEREVIEW rule: admin surface stays loopback-only).
- `.md` files in this PR: `plans/dasweb_backend.md` (the reviewed plan), `utils/dasweb-playground/CODEREVIEW.md` + `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
