### PR TITLE
dasweb-playground followup: origin-collision demote fix + BOM strip (post-merge round for #3621)

### DIFF
--- a/plans/dasweb_backend.md
+++ b/plans/dasweb_backend.md
@@ -351,6 +351,15 @@ own plan doc before implementation; the contour:
   user-visible; failed-build shows the compiler error.
 - **CI**: keep a compile-gate job proving the curated set builds (test, publishes nothing) — a
   broken sample reds CI, not the production queue.
+- **pages.yml diet (folded in here per Boris — no separate "small PR", CI makes every PR an
+  hour):** (a) DELETE the per-sample wasm64 compute builds + staging + artifact-verify from
+  pages.yml — orphaned since phase 2 turned the radio off; the queue replaces them. (b) Fold
+  the example-game wasm64 pages (arcanoid/pacman/furier/path_tracer_lab/physarum_lab) into the
+  same content-addressed build/cache rail — they change rarely, so the store cache near-always
+  hits and CI stops rebuilding them; design point: a game artifact is an html+js+wasm TRIPLE,
+  so the artifact cache must carry multi-file bundles, not just single .wasm. (c)
+  `daslang_static` (the emcc-built interpreter runtime) explicitly STAYS in CI — it is the
+  toolchain, not a sample; not touched (Boris: "amazing it actually works").
 - Checkpoint 3a: curated sample builds end-to-end through the real queue from a cold cache.
   Checkpoint 3b: user-visible flow with the building indicator, on a live server.
 

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -1,4 +1,4 @@
-﻿options gen2
+options gen2
 options indenting = 4
 
 module samples_store public
@@ -231,11 +231,14 @@ def list_curated_sample(db : SqlRunner; hash : string; title : string; category 
 }
 
 def demote_stale_curated(db : SqlRunner; keep : table<string>) : int {
-    //! Unlist curated rows whose hash is not in `keep` (the set the importer
-    //! just minted). User-promoted samples (Origin != "curated") are untouched;
-    //! rows and permalinks always survive. Returns the demoted count.
+    //! Unlist importer-owned listings whose hash is not in `keep` (the set the
+    //! importer just minted). Importer ownership = PrimaryPath set (only
+    //! list_curated_sample sets it) — NOT Origin: a curated entry that dedups
+    //! onto a pre-existing user row keeps Origin "user" yet must still demote
+    //! when it leaves the manifest. Admin promotions (PrimaryPath "") are
+    //! untouched; rows and permalinks always survive. Returns the demoted count.
     let listed <- _sql(db |> select_from(type<Sample>)
-        |> _where(_.Listed != 0 && _.Origin == "curated")
+        |> _where(_.Listed != 0 && _.PrimaryPath != "")
         |> _select(_.Hash))
     var demoted = 0
     for (h in listed) {

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -2,6 +2,8 @@ options gen2
 
 require dastest/testing_boost public
 require curated_import
+require daslib/sql
+require daslib/sql_linq
 require daslib/fio
 require daslib/json_boost
 
@@ -101,21 +103,30 @@ def test_reimport_repoints_and_demotes(t : T?) {
             tt |> equal(get_source(db, old_hash), "print(\"v1\")")
         }
         t |> run("curated entry deduping onto a user row still demotes when dropped") @(tt : T?) {
-            // user shares content FIRST; the importer then lists the same bytes
+            // regression for the Origin-filter miss: the USER stores bytes the
+            // importer has never seen; the importer then lists that same content
             // (dedup keeps Origin "user"); dropping it from the manifest must
-            // still unlist it — regression for the Origin-filter miss.
-            let user_put = put_sample(db, "print(\"v2\")", "10.0.0.7", StorePolicy(), 2500l)
-            tt |> success(!user_put.created, "importer already stored these bytes")
+            // still unlist it.
+            let user_put = put_sample(db, "print(\"user-first\")", "10.0.0.7", StorePolicy(), 2500l)
+            tt |> success(user_put.created, "user stores these bytes first")
+            fwrite(path_join(dir, "examples/hello.das"), "print(\"user-first\")")
+            tt |> equal(import_curated(db, dir, 2600l), 2)
+            let row <- _sql(db |> select_from(type<Sample>) |> _where(_.Hash == user_put.hash))
+            tt |> equal(length(row), 1)
+            tt |> equal(row[0].Origin, "user")
+            tt |> equal(row[0].Listed, 1)   // importer listed the user-origin row
             write_manifest(dir, "\{ \"examples\": [ \{ \"name\": \"Multi (multi-file)\", \"slug\": \"multi\", \"files\": [\"examples/multi_a.das\", \"examples/multi_b.das\"] \} ] \}")
-            tt |> equal(import_curated(db, dir, 2600l), 1)
+            tt |> equal(import_curated(db, dir, 2700l), 1)
             var titles : array<string>
             for (l in listed_samples(db)) {
                 titles |> push(l.title)
             }
             tt |> success(find_index(titles, "Hello world") < 0, "user-origin curated listing demoted")
+            tt |> equal(get_source(db, user_put.hash), "print(\"user-first\")")   // permalink survives
+            // restore the fixture state the next subtest expects
             write_manifest(dir, MANIFEST_V1)
             fwrite(path_join(dir, "examples/hello.das"), "print(\"v2\")")
-            tt |> equal(import_curated(db, dir, 2700l), 2)
+            tt |> equal(import_curated(db, dir, 2800l), 2)
         }
         t |> run("entry removed from the manifest gets demoted, user promotions survive") @(tt : T?) {
             let user = put_sample(db, "let mine = 1", "10.0.0.1", StorePolicy(), 3000l)

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -100,6 +100,23 @@ def test_reimport_repoints_and_demotes(t : T?) {
             tt |> equal(get_source(db, listed[0].hash), "print(\"v2\")")
             tt |> equal(get_source(db, old_hash), "print(\"v1\")")
         }
+        t |> run("curated entry deduping onto a user row still demotes when dropped") @(tt : T?) {
+            // user shares content FIRST; the importer then lists the same bytes
+            // (dedup keeps Origin "user"); dropping it from the manifest must
+            // still unlist it — regression for the Origin-filter miss.
+            let user_put = put_sample(db, "print(\"v2\")", "10.0.0.7", StorePolicy(), 2500l)
+            tt |> success(!user_put.created, "importer already stored these bytes")
+            write_manifest(dir, "\{ \"examples\": [ \{ \"name\": \"Multi (multi-file)\", \"slug\": \"multi\", \"files\": [\"examples/multi_a.das\", \"examples/multi_b.das\"] \} ] \}")
+            tt |> equal(import_curated(db, dir, 2600l), 1)
+            var titles : array<string>
+            for (l in listed_samples(db)) {
+                titles |> push(l.title)
+            }
+            tt |> success(find_index(titles, "Hello world") < 0, "user-origin curated listing demoted")
+            write_manifest(dir, MANIFEST_V1)
+            fwrite(path_join(dir, "examples/hello.das"), "print(\"v2\")")
+            tt |> equal(import_curated(db, dir, 2700l), 2)
+        }
         t |> run("entry removed from the manifest gets demoted, user promotions survive") @(tt : T?) {
             let user = put_sample(db, "let mine = 1", "10.0.0.1", StorePolicy(), 3000l)
             tt |> success(promote_sample(db, user.hash, "Mine", "community"), "user promote")

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -2,7 +2,7 @@ options gen2
 
 require dastest/testing_boost public
 require curated_import
-require daslib/sql
+require daslib/result
 require daslib/sql_linq
 require daslib/fio
 require daslib/json_boost

--- a/utils/dasweb-playground/test_samples_store.das
+++ b/utils/dasweb-playground/test_samples_store.das
@@ -124,9 +124,9 @@ def test_curated_store_ops(t : T?) {
         }
         t |> run("demote_stale_curated demotes only curated hashes outside the keep set") @(tt : T?) {
             let ha = upsert_curated_source(db, "keep me", 1000l)
-            list_curated_sample(db, ha, "Keep", "examples", "", "")
+            list_curated_sample(db, ha, "Keep", "examples", "examples/keep.das", "")
             let hb = upsert_curated_source(db, "drop me", 1000l)
-            list_curated_sample(db, hb, "Drop", "examples", "", "")
+            list_curated_sample(db, hb, "Drop", "examples", "examples/drop.das", "")
             let user = put_sample(db, "user body", "10.0.0.1", test_policy(), 1000l)
             tt |> success(promote_sample(db, user.hash, "User", "community"), "user promote")
             var keep : table<string>


### PR DESCRIPTION
Post-merge review round for #3621, per the fold-into-followup plan:

- **Origin-collision demote fix** (Copilot catch): `demote_stale_curated` keyed stale-listing candidates on `Origin == "curated"`, but a curated entry that dedups onto a pre-existing user share keeps `Origin "user"` — it would be listed by the importer yet never demoted when dropped from the manifest. Importer ownership is now keyed on a non-empty `PrimaryPath` (only `list_curated_sample` sets it); admin promotions (empty `PrimaryPath`) remain untouchable. Regression test drives the full collision path: user share first → importer dedup-lists the same bytes → manifest drop → unlisted.
- **BOM strip**: `samples_store.das` had picked up a UTF-8 BOM from a PowerShell write (Copilot catch).

76 in-dir tests green, lint 0, formatter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
