### PR TITLE
dasweb-playground: security + correctness round from the merged-arc review

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -381,6 +381,19 @@ jobs:
         set -eux
         $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasllama-server/test_openai_server.das
 
+    - name: "Test dasweb-playground"
+      # The daslang.io sample-store backend. Its suites live in-dir (a
+      # hyphenated directory requires siblings by bare name), so `--test
+      # ./tests` never reaches them — without this step the store, importer,
+      # config and HTTP tests run only by hand. The server suites bind
+      # 127.0.0.1:19011/19012 and shut themselves down.
+      if: matrix.target == 'linux'
+      run: |
+        set -eux
+        for suite in test_samples_store test_curated_import test_playground_config test_playground_server; do
+          $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasweb-playground/$suite.das
+        done
+
     # Self-binders for dasClangBind + dasLLVM bindings live on the mingw
     # worker (build.yml build_windows_mingw) — see comment on the linux
     # build step above for why dasClangBind can't be enabled here.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -550,4 +550,10 @@ jobs:
         # Atomic flip, then prune to the 5 newest releases.
         $RSH deploy@89.167.63.131 "ln -sfn /srv/daslang.io/releases/$REL /srv/daslang.io/current \
             && cd /srv/daslang.io/releases && ls -1t | tail -n +6 | xargs -r rm -rf"
+        # The curated dropdown is fed from dasweb-playground's store, which
+        # imports the tree this deploy just replaced. Without this nudge a
+        # changed or added sample stays invisible until the service restarts.
+        # Loopback-only endpoint; a non-zero here must not fail the site deploy.
+        $RSH deploy@89.167.63.131 \
+            "curl -sf -m 30 -X POST http://127.0.0.1:8101/admin/reimport || echo 'reimport nudge failed (service down?)'"
         echo "deployed $REL"

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -269,7 +269,7 @@ def document_module_dashv(_root : string) {
         group_by_regex("HTTP server configuration", mod, %regex~(STATIC|allow_cors|set_document_root|set_home_page|set_index_of|set_error_page)$%%),
         group_by_regex("HTTP response helpers", mod, %regex~(TEXT_PLAIN|JSON|REDIRECT|SERVE_FILE|DATA|set_header|set_content_type)$%%),
         group_by_regex("HTTP client requests", mod, %regex~(request|request_cb|status_message)$%%),
-        group_by_regex("Message and header access", mod, %regex~(get_header|each_header|.*content_length)$%%),
+        group_by_regex("Message and header access", mod, %regex~(get_header|each_header|client_ip|.*content_length)$%%),
         group_by_regex("Request configuration", mod, %regex~(set_basic_auth|set_bearer_token_auth|set_timeout|set_connect_timeout|allow_redirect|set_param|get_param|each_param)$%%),
         group_by_regex("Cookies", mod, %regex~(add_cookie|get_cookie|each_cookie)$%%),
         group_by_regex("Form data", mod, %regex~(set_form_data|set_form_file|get_form_data|each_form_field|save_form_file|set_url_encoded|get_url_encoded)$%%),

--- a/doc/source/stdlib/handmade/function-dashv-client_ip-0x6181f944251942ac.rst
+++ b/doc/source/stdlib/handmade/function-dashv-client_ip-0x6181f944251942ac.rst
@@ -1,0 +1,1 @@
+Peer address of the connection the request arrived on, as recorded by the server when it accepted the socket. Unlike a header such as ``X-Forwarded-For``, a client cannot set this, so it is what a service checks to tell a loopback caller from a proxied one; it is empty when the server did not record an address.

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -1044,6 +1044,15 @@ void das_req_REQUEST_CB_S ( HttpRequest * req, const TBlock<void,const char*> & 
     das_invoke<void>::invoke<HttpResponse*>(context,at,on_complete,resp.get());
 }
 
+// The peer address of the accepted connection. Unlike any header, a client
+// cannot set this — a service that must distinguish loopback callers from
+// proxied ones has to ask the transport, not X-Forwarded-For.
+char * das_httpr_client_ip ( HttpRequest * req, Context * context, LineInfoArg * at ) {
+    if ( !req ) return nullptr;
+    if ( req->client_addr.ip.empty() ) return nullptr;
+    return context->allocateString(req->client_addr.ip, at);
+}
+
 // Response/message header access
 char * das_httpm_get_header ( HttpMessage * msg, const char * key, Context * context, LineInfoArg * at ) {
     if ( !msg ) return nullptr;
@@ -1466,6 +1475,10 @@ public:
         addExtern<DAS_BIND_FUN(das_req_REQUEST)> (*this, lib, "request",
             SideEffects::worstDefault, "das_req_REQUEST")
                 ->args({"request","block","context","at"});
+        // Transport-level peer address (unforgeable, unlike any header)
+        addExtern<DAS_BIND_FUN(das_httpr_client_ip)> (*this, lib, "client_ip",
+            SideEffects::worstDefault, "das_httpr_client_ip")
+                ->args({"request","context","at"});
         // Response/message header access
         addExtern<DAS_BIND_FUN(das_httpm_get_header)> (*this, lib, "get_header",
             SideEffects::worstDefault, "das_httpm_get_header")

--- a/plans/dasweb_wasm_pipeline.md
+++ b/plans/dasweb_wasm_pipeline.md
@@ -134,18 +134,21 @@ warn-only degradation cannot happen quietly. zen4 needed `libc++-19-dev libc++ab
 installed, and `/usr/bin/clang` there is clang-14 (cannot build this tree) — pass
 `HOST_CC=clang-19 HOST_CXX=clang++-19`.
 
-Two things that run surfaced, both for 3a to settle:
+**dasLLVM is present and reachable** from that host: `require llvm/daslib/llvm_jit` and
+`require llvm/daslib/llvm_exe` (where `--jit-check-abi` lives) both resolve and run. Note the
+mount path — it is `llvm/daslib/...`, not `daslib/...`; the latter fails with
+`error[20605] missing prerequisite`, which looks exactly like a missing module and is not one.
+
+One trap that run surfaced, for 3a to carry:
 
 - **The host binary lands in the tree's `bin/daslang`**, the same path an ordinary native build
   of that tree writes. A later native build in the same worktree silently replaces the libc++
   host with a libstdc++ one — the exact corruption this recipe exists to prevent, with no
   signal. This is why the wasm host needs **its own worktree**, and the script now warns when
   the resulting binary links libstdc++.
-- **dasLLVM is configured (`DAS_LLVM_DISABLED=OFF`) but its module target is not built** by the
-  CI target list (`daslang dasModuleGlfw dasModuleOpenGL`), and `require daslib/llvm_jit` did
-  not resolve against the fresh host. CI's cross-compile works regardless, so the JIT path the
-  cross-compile uses is reached some other way — resolve this when `daspkg build --wasm` runs
-  end-to-end (which needs emsdk, not yet installed). Do not assume it is fine.
+
+Still unproven end-to-end: an actual `daspkg build --wasm` run, which needs emsdk 5.0.7 (not yet
+installed). The host half is validated; the emscripten half is not.
 
 `web/build64` is configured as CI does it:
 `DAS_WASM_MEMORY64=ON`, `DAS_WASM_PTHREADS=ON`, `-sMEMORY64=1` in C and CXX flags, and

--- a/plans/dasweb_wasm_pipeline.md
+++ b/plans/dasweb_wasm_pipeline.md
@@ -126,6 +126,27 @@ Consequences for zen4 specifically:
   in that file documents why: emsdk LLVM snapshots repeatedly broke `ds_parser.cpp`, intermittently
   enough to survive a first green run.
 
+**Validated on zen4, 2026-08-04** — `web/build_wasm_host.sh` is checked in and was run there for
+real, not just written: 381/381 targets, `bin/daslang` links `libc++.so.1` + `libc++abi.so.1`
+(the load-bearing property), runs, and the whole tree cost ~1 GB (52 GB free, unchanged). The
+non-clang gate was exercised too: `HOST_CXX=g++` is refused, so `web/CMakeLists.txt`'s
+warn-only degradation cannot happen quietly. zen4 needed `libc++-19-dev libc++abi-19-dev`
+installed, and `/usr/bin/clang` there is clang-14 (cannot build this tree) — pass
+`HOST_CC=clang-19 HOST_CXX=clang++-19`.
+
+Two things that run surfaced, both for 3a to settle:
+
+- **The host binary lands in the tree's `bin/daslang`**, the same path an ordinary native build
+  of that tree writes. A later native build in the same worktree silently replaces the libc++
+  host with a libstdc++ one — the exact corruption this recipe exists to prevent, with no
+  signal. This is why the wasm host needs **its own worktree**, and the script now warns when
+  the resulting binary links libstdc++.
+- **dasLLVM is configured (`DAS_LLVM_DISABLED=OFF`) but its module target is not built** by the
+  CI target list (`daslang dasModuleGlfw dasModuleOpenGL`), and `require daslib/llvm_jit` did
+  not resolve against the fresh host. CI's cross-compile works regardless, so the JIT path the
+  cross-compile uses is reached some other way — resolve this when `daspkg build --wasm` runs
+  end-to-end (which needs emsdk, not yet installed). Do not assume it is fine.
+
 `web/build64` is configured as CI does it:
 `DAS_WASM_MEMORY64=ON`, `DAS_WASM_PTHREADS=ON`, `-sMEMORY64=1` in C and CXX flags, and
 `DAS_HOST_DASLANG_OVERRIDE` pointing at the host build.

--- a/plans/dasweb_wasm_pipeline.md
+++ b/plans/dasweb_wasm_pipeline.md
@@ -1,0 +1,203 @@
+# dasweb phase 3 — the wasm build pipeline
+
+Detailed plan for phase 3 of `plans/dasweb_backend.md` (which carries the arc contour and the
+architecture invariants all phases obey). Written 2026-08-04, after phases 1+2 shipped and the
+security review round (#3625) landed.
+
+Split, per Boris: **3a machinery first, 3b UX second.**
+
+## State when written
+
+- `dasweb-playground` is live on daslang.io: `/s/<hash>` share links, curated dropdown fed from
+  the store, the "jit" radio permanently off since phase 2. Web box `dasweb-1`.
+- Compute box `zen4` (65.108.238.44, Debian 12, Ryzen 8700GE 8c/16t, 61 GB RAM) is released to
+  this arc. `~/SETUP.md` on the box is the contract: read first, extend, never stomp — it also
+  documents the dasLLAMA profiling rig that still lives there.
+- zen4 starting state, probed 2026-08-04: **no emsdk, no emcc, no podman/nsjail/bwrap**, and
+  **52 GB free of 437 GB (88% used)** — the model catalog owns ~300 GB. Worktree
+  `~/daScript-dasweb` exists and tracks master at `ebb422779`.
+- CI (`pages.yml`) builds every wasm artifact today. The steps this phase touches are named in
+  the diet section below.
+
+**Disk fits — measured, not estimated.** A daslang build tree on that box is **537 MB**
+(`~/daScript/build`) to **854 MB** (`~/daScript-dasweb/build`), not the many-GB I first guessed.
+So the toolchain footprint is roughly emsdk 1.5–4 GB + a second (libc++/exceptions) host build
+~1 GB + `web/build64` and the wasm64 module archives a few GB — call it **5–8 GB against 52 GB
+free**. Nothing needs pruning to start.
+
+The only unbounded part is the **artifact cache**, and it is bounded by policy, not by hope: a
+hard size cap with LRU eviction, curated entries pinned. Set the cap when the cache lands.
+
+If space is ever wanted, the obvious lever is already on the box: `~/models` is 333 GB, of which
+**171 GB is 18 `.dlim` images** — derived artifacts, regenerable from their GGUF sources by the
+conversion tool. That is Boris's call and it is not needed now; it is recorded here so the option
+is known rather than rediscovered under pressure.
+
+---
+
+## Trust model (unchanged from the arc plan, restated because everything here depends on it)
+
+Compiling user `.das` is remote code execution by design — macros run at compile time. So:
+
+- The **compute box pulls**; the web box never connects to it. Box death degrades to a backed-up
+  queue, never to a site outage.
+- Every build runs in a throwaway sandbox: no network, CPU/memory/wall-clock caps, tmpfs scratch.
+- Artifacts are content-addressed by (source hash × toolchain_id) and served as static files.
+  Sources stay precious (SQLite, litestream); artifacts stay a regenerable cache.
+
+## 3a — machinery
+
+### Queue
+
+A new table in `samples.db` (migration v4 — the migration stream is append-only):
+
+```
+BuildJob: Hash, ToolchainId, State (queued|building|done|failed), Attempts,
+          QueuedAt, StartedAt, FinishedAt, Error, ArtifactPath
+```
+
+Primary key `(Hash, ToolchainId)` — a job is a (source, toolchain) pair, so a toolchain bump
+re-enqueues lazily rather than invalidating anything eagerly.
+
+### Endpoints — and how they differ from the operator surface
+
+The builder is remote, so these **cannot** use the loopback gate that #3625 put on `/shutdown`
+and `/admin/*`. They are public routes, authenticated by a bearer token from the toml:
+
+```
+GET  /api/build/next     → claim one queued job (bearer)   → {hash, source, toolchain_id}
+POST /api/build/result   → upload artifact or error (bearer)
+```
+
+Rules that fall out of the review round and must hold here:
+
+- The token is compared in **constant time**, and never appears in a log line, a response body,
+  or an error message — the config banner logs its key name and provenance, never its value.
+- A claim mutates state, so it is a `POST`-shaped operation semantically; keep `GET` only if the
+  claim is idempotent per-worker, otherwise make it `POST`.
+- `caddy.snippet` gains these routes explicitly, with a `request_body max_size` sized for an
+  artifact upload (MB-scale, unlike the 1 MB source cap) — the service still cannot bound a body
+  it has already buffered.
+- Artifact uploads are written to a temp path and renamed into place only after the hash checks
+  out; a failed upload must never leave a half-written artifact being served.
+
+### Builder service (`utils/dasweb-buildd`, on zen4)
+
+Same service anatomy as `dasweb-playground` — clargs + toml, `logger_init_tee`, watchdog
+contract (`/healthz`, `POST /shutdown`, exit 0/4), systemd wrapping the watchdog, module-global
+lifecycle state. Its own `CODEREVIEW.md` from the get-go, same as the playground service got.
+
+It polls the queue, and for each claimed job runs one build in a sandbox. **Sandbox choice is
+open**: `bwrap` (bubblewrap) is the lightest and is a single apt package; rootless `podman` is
+heavier but gives cgroup limits and image pinning for free; `nsjail` needs building. Decide when
+implementing, on the box — the requirement is no network, a tmpfs scratch dir, a memory cap, and
+a wall-clock kill.
+
+### Toolchain — `build_wasm_host.sh` (checked in, extracted from `pages.yml`)
+
+The cross-compile host is the load-bearing part, and its recipe is **not** free-form. Verbatim
+from `pages.yml`'s "Build: Daslang host" step, which is the authority:
+
+```
+cmake --no-warn-unused-cli -B./build \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+  -DCMAKE_C_FLAGS="-DDAS_ENABLE_EXCEPTIONS=1" \
+  -DCMAKE_CXX_FLAGS="-stdlib=libc++ -DDAS_ENABLE_EXCEPTIONS=1 -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS" \
+  -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++" \
+  -DDAS_HV_DISABLED=OFF -DDAS_PUGIXML_DISABLED=OFF -DDAS_LLVM_DISABLED=OFF -DDAS_GLFW_DISABLED=OFF \
+  -G Ninja
+```
+
+Why each piece matters: the host JIT-codegens the sample and **bakes C++ handled-type layouts
+from its own ABI**. The emscripten target is libc++ with C++ exceptions, so a default
+libstdc++/setjmp host bakes wrong offsets (std::string 32 vs 24 bytes, mutex 80 vs 40) and the
+wasm heap corrupts. Host stdlib/exception config must equal target, and host pointer width must
+equal target width (wasm64 ⇒ 64-bit host).
+
+Consequences for zen4 specifically:
+
+- zen4's **profiling daslang (`~/zen4_build.sh`, native clang-19) can never serve as the wasm
+  host** — different stdlib/exception config. The wasm worktree gets its own host build. Two
+  daslang builds coexist on the box; `SETUP.md` must say which is which.
+- `web/CMakeLists.txt` **warns rather than fails** when the host compiler is not clang.
+  `build_wasm_host.sh` hard-requires clang so that degradation cannot happen quietly.
+- emsdk pins to the same version `pages.yml` pins (**5.0.7** at time of writing). The pin history
+  in that file documents why: emsdk LLVM snapshots repeatedly broke `ds_parser.cpp`, intermittently
+  enough to survive a first green run.
+
+`web/build64` is configured as CI does it:
+`DAS_WASM_MEMORY64=ON`, `DAS_WASM_PTHREADS=ON`, `-sMEMORY64=1` in C and CXX flags, and
+`DAS_HOST_DASLANG_OVERRIDE` pointing at the host build.
+
+`toolchain_id` = the wasm worktree's git sha. A bump changes the id, which lazily invalidates the
+artifact cache by construction. Version skew mid-bump is fine: each `release wasm` artifact
+bundles its own runtime and runs standalone.
+
+### ABI canary — gate on every toolchain bump
+
+`--jit-check-abi` (`modules/dasLLVM/daslib/llvm_exe.das`) bakes host size and field offsets for
+every handled type into the minted binary, resolves the target's at runtime, records divergences,
+dumps them all and aborts. Protocol: **a new `toolchain_id` goes live only after a canary sample
+built with `--jit-check-abi` runs clean**, and the result — including the full divergence dump on
+failure — goes in the log. Parity gate before first serve: build a curated sample on zen4 and
+diff behavior against the CI-built artifact of the same (source, toolchain) pair.
+
+### Artifacts
+
+`blobs/<toolchain_id>/<hash>.wasm[.br]` on the web box (the `blobs/` dir phase 1 left empty),
+served static. LRU eviction with curated entries pinned; a warmup job re-enqueues the curated set
+after a toolchain bump.
+
+## 3b — UX
+
+- "building… (queue position N)" state in the playground; a failed build shows the compiler error
+  text (it is the user's own code — showing it is the point).
+- Rename **jit → wasm** everywhere user-visible. The radio has been off since phase 2; phase 3 is
+  when it comes back meaning what it says.
+- Restore the engine-transition playwright tests that phase 2 rewrote to pin the radio off.
+
+## pages.yml diet (folded into this phase per Boris — CI makes every PR cost an hour)
+
+Mapped onto the actual steps in `.github/workflows/pages.yml`:
+
+| Step | Fate |
+|---|---|
+| "Build: Daslang host" | **Stays.** das2rst needs it, and it is the recipe `build_wasm_host.sh` mirrors. |
+| 1. wasm32 threaded `daslang_static` + playground staging | **Stays, untouched.** This is the toolchain, not a sample — the interpreter runtime the playground runs on. (Boris: "amazing it actually works".) |
+| 2. `web/build64` configure + `daspkg build --wasm` archives | **Moves** to the builder box; it exists in CI only to serve steps 3–7. |
+| 3. `cmake --build web/build64 --target all_wasm` (per-sample compute wasm64) | **DELETE.** Orphaned since phase 2 turned the radio off; the queue replaces it. |
+| 4–7. arcanoid, pacman, furier, path_tracer_lab, physarum_lab | **Fold** into the content-addressed cache rail. They change rarely, so the cache near-always hits and CI stops rebuilding them. |
+| "Verify wasm example artifacts" | Follows steps 4–7 wherever they land — it exists because those builds are non-fatal, and that property must survive the move. |
+
+**Design point the game pages force:** a game artifact is an **html + js + wasm triple**, not a
+single `.wasm`. The artifact cache must carry multi-file bundles from the start, or the games
+cannot fold in. Get that into the schema before building the single-file path, not after.
+
+Keep a CI compile-gate job proving the curated set still builds (a test that publishes nothing) —
+a broken sample should red CI, not the production queue.
+
+## Checkpoints
+
+- **3a:** a curated sample builds end-to-end through the real queue from a cold cache, on the
+  real boxes, with the canary clean.
+- **3b:** the user-visible flow with the building indicator, on the live server.
+
+## Open questions for Boris
+
+1. **Do the example games actually move off CI**, or is the fold a nice-to-have? Moving them
+   makes the queue load-bearing for the `/examples` page; leaving them in CI keeps the page
+   independent of box health at the cost of the CI time the diet was meant to reclaim. This is
+   the one question that changes the shape of 3a — the artifact cache needs multi-file bundle
+   support from day one if the answer is yes.
+2. **Sandbox**: bwrap (lightest, one apt package) vs rootless podman (best limits) — no strong
+   prior; whichever the box takes cleanly. Decidable while implementing.
+
+Disk is **not** a blocker (measured above), and no model pruning is needed.
+
+## Non-goals
+
+- Nothing touches the playground sha256 **benchmark** — it stays non-conforming on purpose
+  (dasProfile cross-language parity).
+- No new limiter on build requests: the queue plus baking time is the natural throttle. The
+  insert ceiling exists only because inserts are the cheap unqueued path.

--- a/site/playground/playground-init.js
+++ b/site/playground/playground-init.js
@@ -41,6 +41,12 @@ function applySharedPayload(payload) {
 // is either one raw .das source or a {files, active} JSON bundle (multi-file
 // shares store the same payload the legacy #z= format compressed).
 function applySharedCodeFromServer(hash) {
+    // Claim the page synchronously, before the fetch: main.js decides whether
+    // to load its default sample as soon as ITS /api/samples/listed fetch
+    // resolves, and that response is small JSON while this one can be a large
+    // source. Setting the flag inside .then() lets the default win the race and
+    // overwrite the shared code the visitor followed the link for.
+    window.pgRestoredFromState = true;
     fetch('/api/samples/' + hash)
         .then((resp) => {
             if (!resp.ok) throw new Error('sample fetch ' + resp.status);
@@ -55,7 +61,14 @@ function applySharedCodeFromServer(hash) {
             if (!payload) payload = { files: { 'main.das': src }, active: 'main.das' };
             applySharedPayload(payload);
         })
-        .catch((e) => { console.warn('shared-sample load failed:', e); });
+        .catch((e) => {
+            // Release the claim so a dead or mistyped /s/ link opens the default
+            // sample instead of leaving the editor blank. If main.js already
+            // skipped its default because of the claim, do it here.
+            console.warn('shared-sample load failed:', e);
+            window.pgRestoredFromState = false;
+            if (typeof window.selectSample === 'function') window.selectSample('examples', 0);
+        });
 }
 
 // `#code=<percent-encoded-source>` — single-file share from the landing hero.

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -286,6 +286,7 @@ SET(AOT_DASLIB_FILES
     tests/daslib/test_toml.das
     tests/daslib/test_logger.das
     tests/daslib/tty_test.das
+    tests/daslib/test_sha_256.das
 )
 
 FILE(GLOB AOT_MCP_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/mcp/*.das")

--- a/tests/daslib/test_sha_256.das
+++ b/tests/daslib/test_sha_256.das
@@ -32,16 +32,26 @@ def test_nist_vectors(t : T?) {
 
 [test]
 def test_padding_boundaries(t : T?) {
-    // 55/56/63/64 bytes straddle the padding split (0x80 + length must fit or spill)
-    t |> run("55 56 63 64 byte inputs agree between overloads") @(t : T?) {
-        for (n in fixed_array(55, 56, 63, 64, 65, 119, 120)) {
+    // These lengths straddle the padding split (0x80 + length must fit or spill
+    // into a second block). Digests come from an INDEPENDENT SHA-256: the two
+    // overloads share one per-byte path, so comparing them cannot catch this.
+    t |> run("digests at the padding boundaries match known values") @(tt : T?) {
+        for (c in fixed_array(
+                (55, "d5e285683cd4efc02d021a5c62014694958901005d6f71e89e0989fac77e4072"),
+                (56, "04c26261370ee7541549d16dee320c723e3fd14671e66a099afe0a377c16888e"),
+                (63, "75220b47218278e656f2013bb8f0c455a25eaf01e86c64924e9d48d89776d6f2"),
+                (64, "7ce100971f64e7001e8fe5a51973ecdfe1ced42befe7ee8d5fd6219506b5393c"),
+                (65, "9537c5fdf120482f7d58d25e9ed583f52c02b4e304ea814db1633ad565aed7e9"),
+                (119, "000b48d4edf0fa7bee3c6236ecd2785baa5db4eeb8bb54341b029e0d9fa5fb0c"),
+                (120, "13f05a0b594787f5ecd315edc96141bd3243203d1b7d4f0836f37308b276ba98"))) {
             var bytes : array<uint8>
             var str = ""
-            for (_i in range(n)) {
+            for (_i in range(c._0)) {
                 bytes |> push(uint8('x'))
                 str += "x"
             }
-            t |> equal(sha256_hex(bytes), sha256_hex(str))
+            tt |> equal(sha256_hex(str), c._1)
+            tt |> equal(sha256_hex(bytes), c._1)
             delete bytes
         }
     }

--- a/utils/dasweb-playground/.das_package
+++ b/utils/dasweb-playground/.das_package
@@ -14,5 +14,6 @@ def release() {
     release_name("dasweb-playground")
     release_include_if_missing("dasweb-playground.toml") // initialize once; preserve deployed edits on upgrades
     release_include_from("utils/watchdog/watchdog.py")
-    release_include("watchdog.json")
+    release_include_if_missing("watchdog.json")          // carries the port too — an operator edit must survive upgrades
+    release_include("admin.das")                         // operator curation CLI; run with a daslang SDK on the box
 }

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -69,9 +69,16 @@ defect, and this section is the whole test.
   the filesystem; a store mutation here that bypasses `samples_store` functions is a defect.
 - `admin.das` — the operator CLI (listing curation). Talks to the store the same way the
   server does; a second implementation of a store operation here is a defect.
-- `.das_package`, `watchdog.json`, `dasweb-playground.toml`, `deploy.sh` — packaging and
-  deployment. A behavior change hidden in these files without a note in `README.md` (Run
-  section) is a defect.
+- `.das_package`, `watchdog.json`, `dasweb-playground.toml`, `deploy.sh`, `caddy.snippet` —
+  packaging, deployment, and the public route boundary. A behavior change hidden in these files
+  without a note in `README.md` (Run section) is a defect.
+
+**A file an operator edits on the box is preserved across upgrades**: shipped
+`release_include_if_missing` and carried forward by `deploy.sh`. Shipping one with plain
+`release_include`, or adding one `deploy.sh` does not carry, is a defect.
+
+**Checked-in config holds development values.** The config file is discovered automatically
+beside the module, so a production path in it makes an in-repo run open the live database.
 
 **Migrations are append-only.** A diff that edits a shipped `[sql_migration]` body is a defect;
 schema change means a new version.
@@ -88,24 +95,39 @@ A diff that removes, reorders past `start`, or conditionalizes the bind is a def
 from any request-derived value is a defect.
 
 **Every request body is bounds-checked against the configured cap before it is hashed or
-stored.** (dasHV buffers the body before any handler runs, so the check happens in
-`put_sample` ahead of hashing — a hash or insert reachable without the size check is a defect.)
+stored, and the transport cap that precedes it lives in `caddy.snippet`.** The service can only
+check a body already buffered in full, so a route accepting a body without a `request_body`
+limit in front of it is a defect, as is a hash or insert reachable without the size check.
 
-**Client identity comes from `X-Forwarded-For` and is treated as data, never parsed into
-behavior beyond the rate ceiling.** Logging it is required; branching on it anywhere else is a
-defect.
+**A request body is read as bytes, and a byte count that disagrees with its string length is
+rejected.** A das string ends at the first NUL, so a body used without that guard can be stored
+truncated under a hash that does not describe it.
+
+**Client identity comes from the LAST `X-Forwarded-For` hop and is treated as data, never
+parsed into behavior beyond the rate ceiling.** A proxy appends the peer it accepted; every
+earlier hop is client-authored, so keying anything on one is a defect. Logging it is required.
+
+**Operator routes (`POST /shutdown`, `/admin/*`) verify the transport peer is loopback.** No
+header can carry that proof — a browser on any page can drive a cross-origin POST to a proxied
+route. A new operator route without the check is a defect.
+
+**No route enables CORS.** The middleware reflects the caller's `Origin` on every route at once,
+which would make stored samples and the operator surface cross-origin readable.
+
+**Responses that echo stored user input carry `X-Content-Type-Options: nosniff`.**
 
 **No shell-out anywhere in the service.**
 
-**No filesystem path derived from request data.** The importer's paths come from config plus
-the deploy-tree manifest only.
+**No filesystem path derived from request data, and a manifest-supplied path is checked to stay
+under its configured directory before it is read.** `path_join` discards the base when the right
+side is absolute, so an unchecked manifest path reads any file the service user can — and the
+importer publishes what it reads.
 
 **No `unsafe` in any route handler.** An `unsafe` elsewhere takes a same-line reason comment;
 one without the comment is a defect.
 
-**`POST /shutdown` and every admin operation stay unrouted by Caddy.** A Caddy config change in
-this directory that forwards them, or an admin endpoint added to the public route set, is a
-defect.
+**`POST /shutdown` and every admin operation stay unrouted in `caddy.snippet`.** Forwarding one
+there, or adding an admin endpoint to the public route set, is a defect.
 
 **Secrets (tokens, credentials) never appear in a log line, a response body, or an error
 message.** The config banner logs key names and provenance, never values marked secret.

--- a/utils/dasweb-playground/README.md
+++ b/utils/dasweb-playground/README.md
@@ -40,7 +40,7 @@ a body already buffered in full, so that limit cannot live in this process.
 | Route | Behavior |
 |---|---|
 | `POST /api/samples` | body = raw `.das` text → `{hash, url, created}`; 400 empty/non-utf8/embedded NUL, 413 over size cap, 429 over per-IP ceiling |
-| `GET /api/samples/listed` | the curated dropdown: `[{hash, title, category, path, slug}]`, in manifest order |
+| `GET /api/samples/listed` | the curated dropdown: `[{hash, title, category, path, slug}]`; manifest order within a category, categories alphabetical |
 | `GET /api/samples/<hash>` | the stored source, `text/plain`, `nosniff`, immutable cache headers; 400 malformed hash, 404 unknown |
 | `GET /s/<hash>` | 302 → `/playground/index.html?s=<hash>`; 404 unknown |
 | `GET /healthz` | `ok` (watchdog poll target) |
@@ -50,6 +50,10 @@ a body already buffered in full, so that limit cannot live in this process.
 Client identity for the rate ceiling is the **last** `X-Forwarded-For` hop — the one Caddy
 appends. Earlier hops are client-authored. The operator routes verify the transport peer
 instead, which no header can forge; no route enables CORS.
+
+Listing order is reproducible rather than authored: `read_json` parses the manifest object into
+a table, so the file's category key order is gone before the importer sees it. Categories are
+therefore visited sorted, and entries keep the manifest's order within their category.
 
 Curated samples: when `curated_dir` points at the deployed playground samples tree, boot (and
 `/admin/reimport`) imports every `data.json` entry through the store — single-file entries as

--- a/utils/dasweb-playground/README.md
+++ b/utils/dasweb-playground/README.md
@@ -22,25 +22,52 @@ sudo deploy.sh <short-sha> /tmp/dasweb-playground-<short-sha>.tar.gz
 
 `-?` prints flag help (the daslang host eats `--help`). Config: `dasweb-playground.toml` in cwd
 or beside the tool, keys = flag names; precedence defaults < toml < explicit CLI flags, flipped
-by `authoritative = true`. The effective config is logged at startup with per-key provenance.
+by `authoritative = true`. A key whose value has the wrong type is a startup error, not a
+silent zero. The effective config is logged at startup with per-key provenance.
+
+The checked-in toml holds development values, because it is discovered automatically beside the
+module. The deployed values on `dasweb-1` are `db = "/srv/dasweb-playground/samples.db"`,
+`base_url = "https://daslang.io"`, and
+`curated_dir = "/srv/daslang.io/current/playground/samples"`; that file and `watchdog.json` are
+operator-owned — shipped only when absent, and carried across upgrades by `deploy.sh`.
+
+The public route boundary is `caddy.snippet`, the authoritative copy of what the daslang.io
+vhost forwards here. It also carries the transport body cap: the service can only bounds-check
+a body already buffered in full, so that limit cannot live in this process.
 
 ## Endpoints (port 8101, loopback only — Caddy fronts the internet)
 
 | Route | Behavior |
 |---|---|
-| `POST /api/samples` | body = raw `.das` text → `{hash, url, created}`; 400 empty/non-utf8, 413 over size cap, 429 over per-IP ceiling |
-| `GET /api/samples/listed` | the curated dropdown: `[{hash, title, category, path, slug}]`, category-then-title ordered |
-| `GET /api/samples/<hash>` | the stored source, `text/plain`, immutable cache headers; 400 malformed hash, 404 unknown |
+| `POST /api/samples` | body = raw `.das` text → `{hash, url, created}`; 400 empty/non-utf8/embedded NUL, 413 over size cap, 429 over per-IP ceiling |
+| `GET /api/samples/listed` | the curated dropdown: `[{hash, title, category, path, slug}]`, in manifest order |
+| `GET /api/samples/<hash>` | the stored source, `text/plain`, `nosniff`, immutable cache headers; 400 malformed hash, 404 unknown |
 | `GET /s/<hash>` | 302 → `/playground/index.html?s=<hash>`; 404 unknown |
 | `GET /healthz` | `ok` (watchdog poll target) |
-| `POST /shutdown` | graceful stop, exit 0 (watchdog contract; never routed by Caddy) |
-| `POST /admin/reimport` | re-run the curated importer; 503 when `curated_dir` unset (loopback only — Caddy never routes `/admin/*`) |
+| `POST /shutdown` | graceful stop, exit 0 (watchdog contract); loopback peers only, else 403 |
+| `POST /admin/reimport` | re-run the curated importer; 503 when `curated_dir` unset; loopback peers only, else 403 |
+
+Client identity for the rate ceiling is the **last** `X-Forwarded-For` hop — the one Caddy
+appends. Earlier hops are client-authored. The operator routes verify the transport peer
+instead, which no header can forge; no route enables CORS.
 
 Curated samples: when `curated_dir` points at the deployed playground samples tree, boot (and
 `/admin/reimport`) imports every `data.json` entry through the store — single-file entries as
 raw source, multi-file as the `{files, active}` bundle user shares use. Unchanged files dedup;
-changed files repoint the listing; vanished entries demote (permalinks always survive).
-Manual curation: `admin.das` (`--op list | promote | demote`).
+changed files repoint the listing; vanished entries demote (permalinks always survive). A
+manifest path that would escape `curated_dir` is refused, and an import in which nothing was
+readable keeps the previous listings rather than emptying the dropdown. The site deploy nudges
+`/admin/reimport` so a newly shipped sample appears without a restart.
+
+Manual curation: `admin.das` (`--op list | promote | demote`), shipped in the bundle and run
+with a daslang SDK on the box (the baked exe has no interpreter):
+
+```bash
+/opt/daslang/bin/daslang admin.das -- --db /srv/dasweb-playground/samples.db --op list
+```
+
+A promoted sample is operator-owned from then on — promotion clears the importer's ownership
+marker, so a later import cannot silently demote it.
 
 Dedup is content-addressed: same source ⇒ same hash ⇒ same URL, first writer's metadata wins.
 
@@ -53,8 +80,11 @@ mutation is logged as ndjson to `logs/dasweb-playground.log` (rotation is the wa
 ## Tests
 
 ```bash
-daslang dastest/dastest.das -- --test utils/dasweb-playground/
+daslang dastest/dastest.das -- --test utils/dasweb-playground/test_samples_store.das
 ```
+
+CI runs all four suites in `extended_checks.yml` ("Test dasweb-playground") — a hyphenated
+directory means siblings are required by bare name, so `--test ./tests` never reaches them.
 
 In-dir per the session rules: store (no HTTP), server (real HTTP on reserved ports
 19011/19012), importer (temp-dir fixtures), config (pure merge). Every bug fix lands with its

--- a/utils/dasweb-playground/admin.das
+++ b/utils/dasweb-playground/admin.das
@@ -52,6 +52,12 @@ def main : int {
         return 1
     }
     var inscope db <- open_result._value
+    // sqlite3_open CREATES an empty file for a mistyped path, so "opened" does
+    // not mean "has the schema" — and every store call below would panic in
+    // prepare instead of reporting the path. Migrating first also makes the CLI
+    // usable against a database that predates a newly shipped migration.
+    db |> apply_recommended_pragmas()
+    migrate_to_latest(db)
     if (cfg.op == "list") {
         let listed <- listed_samples(db)
         for (l in listed) {

--- a/utils/dasweb-playground/caddy.snippet
+++ b/utils/dasweb-playground/caddy.snippet
@@ -1,0 +1,30 @@
+# dasweb-playground routes for the daslang.io vhost in /etc/caddy/Caddyfile.
+# This file is the authoritative copy of the service's public boundary — the
+# deployed Caddyfile is edited to match it, never the other way round, so a
+# route change is reviewable in the same diff as the code it exposes.
+#
+# Paste inside the `daslang.io { ... }` block, ahead of `root`/`file_server`.
+
+# dasweb-playground (sample store + share links) — loopback service :8101
+handle /s/* {
+	reverse_proxy 127.0.0.1:8101
+}
+handle /api/samples* {
+	# The service can only bounds-check a body it has already buffered, and
+	# libhv imposes no transport cap of its own — an unbounded chunked POST
+	# would grow the process to the size of the body before any handler runs.
+	# This is the only place that limit can exist. Keep it comfortably above
+	# max_source_bytes (262144) so the service, not the proxy, produces the
+	# 413 that the playground surfaces to the user.
+	request_body {
+		max_size 1MB
+	}
+	reverse_proxy 127.0.0.1:8101
+}
+
+# NOTE: /api/samples* is deliberately slashless — /api/samples/ would not match
+# the exact path POST /api/samples that share minting uses.
+#
+# /admin/* and /shutdown are deliberately absent: they are operator surfaces.
+# The service also refuses them from a non-loopback peer, so adding a route
+# here does not merely expose them — it breaks them.

--- a/utils/dasweb-playground/curated_import.das
+++ b/utils/dasweb-playground/curated_import.das
@@ -7,6 +7,8 @@ require samples_store public
 require daslib/json_boost
 require daslib/fio
 require daslib/logger
+require daslib/strings_boost
+require strings
 
 //! The curated importer: reads the deployed playground manifest
 //! (`<samples_dir>/data.json`, the hand-authored schema the UI ships) and
@@ -16,8 +18,28 @@ require daslib/logger
 //! hashes and the listing repoints; vanished entries get demoted (rows and
 //! permalinks always survive). Filesystem reads live here, not in the store.
 
+def private is_contained_relative_path(rel : string) : bool {
+    //! Manifest paths must stay under the samples dir. path_join is
+    //! std::filesystem's operator/=, which DISCARDS the base when the right
+    //! side is absolute, so "/etc/passwd" would read that file verbatim and
+    //! publish it as a permanent public sample; "../" would climb out the same
+    //! way. The manifest ships from the site deploy — a different trust domain
+    //! from this service — so containment is checked, not assumed.
+    // ':' rejects a drive-qualified path ("C:/..."), which is absolute too
+    if (empty(rel) || rel |> starts_with("/") || rel |> starts_with("\\") || find(rel, ":") >= 0) {
+        return false
+    }
+    for (part in split(replace(rel, "\\", "/"), "/")) {
+        if (part == "..") {
+            return false
+        }
+    }
+    return true
+}
+
 def private entry_body(samples_dir : string; entry : JsonValue?; var primary_path : string&) : string {
-    //! "" = a file was missing/unreadable (entry skipped by the caller).
+    //! "" = a file was missing, unreadable, or escaped the samples dir (entry
+    //! skipped by the caller).
     let fv = entry?["files"]
     if (fv == null || !(fv.value is _array)) {
         return ""
@@ -30,6 +52,10 @@ def private entry_body(samples_dir : string; entry : JsonValue?; var primary_pat
     var texts : array<string>
     texts |> reserve(length(rels))
     for (rel in rels) {
+        if (!is_contained_relative_path(rel)) {
+            logger_error("playground.import", "refusing path outside {samples_dir}: {rel}")
+            return ""
+        }
         let text = fread(path_join(samples_dir, rel))
         if (empty(text)) {
             logger_error("playground.import", "cannot read {rel} under {samples_dir}")
@@ -62,6 +88,7 @@ def import_curated(db : SqlRunner; samples_dir : string; now : int64) : int {
     var keep : table<string>
     var listed = 0
     var skipped = 0
+    var position = 0
     for (category in keys(root.value as _object)) {
         let entries = root?[category]
         if (entries == null || !(entries.value is _array)) {
@@ -81,10 +108,21 @@ def import_curated(db : SqlRunner; samples_dir : string; now : int64) : int {
                 continue
             }
             let hash = upsert_curated_source(db, src, now)
-            list_curated_sample(db, hash, title, category, primary_path, entry?["slug"] ?? "")
+            list_curated_sample(db, hash, title, category, primary_path, entry?["slug"] ?? "", position)
             keep |> insert(hash)
             listed ++
+            position ++
         }
+    }
+    if (listed == 0) {
+        // Nothing was readable, yet the manifest parsed: a half-written deploy
+        // tree, a `current` symlink swapped mid-import, or curated_dir pointing
+        // one directory off. Demoting against an empty keep set would unlist
+        // the whole dropdown, so treat it the same as an unreadable manifest —
+        // prior listings stand.
+        logger_error("playground.import", "manifest parsed but no entry was readable; keeping prior listings",
+            JV((skipped = skipped, dir = samples_dir)))
+        return -1
     }
     let demoted = demote_stale_curated(db, keep)
     logger_info("playground.import", "curated import: {listed} listed, {skipped} skipped, {demoted} demoted",

--- a/utils/dasweb-playground/curated_import.das
+++ b/utils/dasweb-playground/curated_import.das
@@ -89,7 +89,16 @@ def import_curated(db : SqlRunner; samples_dir : string; now : int64) : int {
     var listed = 0
     var skipped = 0
     var position = 0
-    for (category in keys(root.value as _object)) {
+    // Categories are visited in sorted order, not in table order. read_json
+    // parses a JSON object into a table, so the manifest's authored key order
+    // is already gone by here and cannot be recovered — but table iteration is
+    // hash order, which would make Position (and with it the dropdown) depend
+    // on something unspecified. Sorting makes the assignment reproducible:
+    // within a category the order IS the manifest's, and the categories
+    // themselves are alphabetical.
+    var categories <- [for (category in keys(root.value as _object)); category]
+    sort(categories)
+    for (category in categories) {
         let entries = root?[category]
         if (entries == null || !(entries.value is _array)) {
             continue

--- a/utils/dasweb-playground/dasweb-playground.toml
+++ b/utils/dasweb-playground/dasweb-playground.toml
@@ -1,9 +1,14 @@
-# dasweb-playground starter config. Deployed beside the binary; edits here
+# dasweb-playground starter config. Deployed beside the binary; edits there
 # survive upgrades (release_include_if_missing). CLI flags override these
 # unless `authoritative = true` is set.
+#
+# These are DEVELOPMENT values on purpose. The file is discovered automatically
+# beside the module, so production absolute paths here would make any in-repo
+# run open the live database. Deployed values live on the box — README.md (Run)
+# lists them.
 port = 8101
-db = "/srv/dasweb-playground/samples.db"
-base_url = "https://daslang.io"
+db = "samples.db"
+base_url = "http://127.0.0.1:8101"
 max_source_bytes = 262144
 max_inserts_per_ip_hour = 100
-curated_dir = "/srv/daslang.io/current/playground/samples"
+curated_dir = ""

--- a/utils/dasweb-playground/deploy.sh
+++ b/utils/dasweb-playground/deploy.sh
@@ -29,6 +29,10 @@ install -d -o dasweb -g dasweb /srv/dasweb-playground
 # same sha is redeployed, `current` points into the directory the rm below
 # removes, and the carry-forward would find nothing left to copy.
 CARRY=$(mktemp -d)
+# set -e means any failure below (a bad tarball, a full disk) exits before the
+# explicit cleanup, so the trap is what keeps /tmp from accumulating one
+# directory per failed deploy.
+trap 'rm -rf "$CARRY"' EXIT
 for f in dasweb-playground.toml watchdog.json; do
     if [ -f "$APP/current/$f" ]; then
         cp "$APP/current/$f" "$CARRY/$f"
@@ -45,7 +49,6 @@ for f in dasweb-playground.toml watchdog.json; do
         cp "$CARRY/$f" "$SHA/$f"
     fi
 done
-rm -rf "$CARRY"
 chown -R dasweb:dasweb "$SHA"
 ln -sfn "$APP/releases/$SHA" "$APP/current"
 systemctl restart dasweb-playground

--- a/utils/dasweb-playground/deploy.sh
+++ b/utils/dasweb-playground/deploy.sh
@@ -21,13 +21,31 @@ SHA="${1:?usage: deploy.sh <short-sha> <tarball>}"
 TARBALL="${2:?usage: deploy.sh <short-sha> <tarball>}"
 APP=/srv/apps/dasweb-playground
 
+# The service's own data dir (db + logs) lives outside the release tree so it
+# survives every flip; on a fresh box nothing has created it yet.
+install -d -o dasweb -g dasweb /srv/dasweb-playground
+
+# Snapshot the operator-owned files BEFORE touching the release tree: when this
+# same sha is redeployed, `current` points into the directory the rm below
+# removes, and the carry-forward would find nothing left to copy.
+CARRY=$(mktemp -d)
+for f in dasweb-playground.toml watchdog.json; do
+    if [ -f "$APP/current/$f" ]; then
+        cp "$APP/current/$f" "$CARRY/$f"
+    fi
+done
+
 cd "$APP/releases"
+rm -rf dasweb-playground
 tar xzf "$TARBALL"
 rm -rf "$SHA"
 mv dasweb-playground "$SHA"
-if [ -f "$APP/current/dasweb-playground.toml" ]; then
-    cp "$APP/current/dasweb-playground.toml" "$SHA/dasweb-playground.toml"
-fi
+for f in dasweb-playground.toml watchdog.json; do
+    if [ -f "$CARRY/$f" ]; then
+        cp "$CARRY/$f" "$SHA/$f"
+    fi
+done
+rm -rf "$CARRY"
 chown -R dasweb:dasweb "$SHA"
 ln -sfn "$APP/releases/$SHA" "$APP/current"
 systemctl restart dasweb-playground

--- a/utils/dasweb-playground/main.das
+++ b/utils/dasweb-playground/main.das
@@ -51,7 +51,11 @@ def parse_args {
 
 [export]
 def init {
-    return if (g_exit_code != 0)
+    // request_exit() only raises a flag — it does not abort — so -? and a
+    // config error both fall through to here. Starting up anyway would open the
+    // production database, run migrations and the curated importer, and bind
+    // the port out from under the running service.
+    return if (g_exit_code != 0 || exit_requested())
     if (!g_args_parsed) {
         parse_args()   // daslang-live calls init directly; standalone main parsed already
         return if (g_exit_code != 0)

--- a/utils/dasweb-playground/main.das
+++ b/utils/dasweb-playground/main.das
@@ -58,7 +58,7 @@ def init {
     return if (g_exit_code != 0 || exit_requested())
     if (!g_args_parsed) {
         parse_args()   // daslang-live calls init directly; standalone main parsed already
-        return if (g_exit_code != 0)
+        return if (g_exit_code != 0 || exit_requested())   // -? leaves the code 0 and only raises the flag
     }
     // tee every to_log/print to logs/dasweb-playground.log (timestamped ndjson) AND the console
     logger_init_tee("dasweb-playground")

--- a/utils/dasweb-playground/playground_config.das
+++ b/utils/dasweb-playground/playground_config.das
@@ -43,40 +43,52 @@ struct ServerArgs {
     help : bool = false
 }
 
-def private cli_has_flag(user_args : array<string>; flag : string) : bool {
-    let eqform = "{flag}="
-    for (a in user_args) {
-        if (a == flag || a |> starts_with(eqform)) {
-            return true
-        }
-    }
-    return false
-}
-
 def private from_cli(user_args : array<string>; key : string) : bool {
     let flag = "--{replace(key, "_", "-")}"
-    if (cli_has_flag(user_args, flag)) {
+    if (flag_present(user_args, flag)) {
         return true
     }
-    return key == "port" && cli_has_flag(user_args, "-p")
+    return key == "port" && flag_present(user_args, "-p")
 }
 
 def private toml_has(root : JsonValue?; key : string) : bool {
     return root != null && (root.value is _object) && key_exists(root.value as _object, key)
 }
 
-def private cfg_from_toml(root : JsonValue?; key : string; var field : string&; auth : bool; user_args : array<string>; var sources : table<string; string>) {
-    if (toml_has(root, key) && (auth || !from_cli(user_args, key))) {
-        field = root?[key] ?? ""
-        sources[key] = "toml"
-    }
+def private toml_wins(root : JsonValue?; key : string; auth : bool; user_args : array<string>) : bool {
+    return toml_has(root, key) && (auth || !from_cli(user_args, key))
 }
 
-def private cfg_from_toml(root : JsonValue?; key : string; var field : int&; auth : bool; user_args : array<string>; var sources : table<string; string>) {
-    if (toml_has(root, key) && (auth || !from_cli(user_args, key))) {
-        field = int(root?[key] ?? 0l)
-        sources[key] = "toml"
+def private cfg_from_toml(root : JsonValue?; key : string; var field : string&; auth : bool; user_args : array<string>; var sources : table<string; string>; var error : string&) : bool {
+    if (!toml_wins(root, key, auth, user_args)) {
+        return true
     }
+    let v = root?[key]
+    // A wrong-typed value coerces to ""/0 through `??`, which would start the
+    // service on a silently different config than the file states.
+    if (v == null || !(v.value is _string)) {
+        error = "config key '{key}' must be a string"
+        return false
+    }
+    field = v ?? ""
+    sources[key] = "toml"
+    return true
+}
+
+def private cfg_from_toml(root : JsonValue?; key : string; var field : int&; auth : bool; user_args : array<string>; var sources : table<string; string>; var error : string&) : bool {
+    if (!toml_wins(root, key, auth, user_args)) {
+        return true
+    }
+    let v = root?[key]
+    // TOML integers arrive as _longint, floats as _number — accept both, since
+    // `port = 8101.0` is a number the user plainly meant.
+    if (v == null || !((v.value is _longint) || (v.value is _number))) {
+        error = "config key '{key}' must be a number"
+        return false
+    }
+    field = int(v ?? 0l)
+    sources[key] = "toml"
+    return true
 }
 
 def mark_cli_sources(user_args : array<string>; var sources : table<string; string>) {
@@ -97,16 +109,17 @@ def apply_config_text(var cfg : ServerArgs; body : string; user_args : array<str
         return false
     }
     let auth : bool = root?["authoritative"] ?? false
-    cfg_from_toml(root, "port", cfg.port, auth, user_args, sources)
-    cfg_from_toml(root, "db", cfg.db, auth, user_args, sources)
-    cfg_from_toml(root, "base_url", cfg.base_url, auth, user_args, sources)
-    cfg_from_toml(root, "max_source_bytes", cfg.max_source_bytes, auth, user_args, sources)
-    cfg_from_toml(root, "max_inserts_per_ip_hour", cfg.max_inserts_per_ip_hour, auth, user_args, sources)
-    cfg_from_toml(root, "curated_dir", cfg.curated_dir, auth, user_args, sources)
+    let ok = (
+        cfg_from_toml(root, "port", cfg.port, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "db", cfg.db, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "base_url", cfg.base_url, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "max_source_bytes", cfg.max_source_bytes, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "max_inserts_per_ip_hour", cfg.max_inserts_per_ip_hour, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "curated_dir", cfg.curated_dir, auth, user_args, sources, error))
     unsafe {
-        delete root
+        delete root   // read_toml minted this tree; nothing outlives this scope
     }
-    return true
+    return ok
 }
 
 def load_config(var cfg : ServerArgs; var sources : table<string; string>; var error : string&) : bool {

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -28,15 +28,44 @@ var private g_stop_requested = false
 var private g_server_started = false
 
 def private client_ip_of(var req : HttpRequest?) : string {
-    //! First hop of X-Forwarded-For — Caddy is the only caller in production,
-    //! so the header is trustworthy; absent (direct loopback callers, tests)
-    //! degrades to "local".
+    //! RIGHTMOST X-Forwarded-For hop. A reverse proxy APPENDS the peer it
+    //! accepted, so only the last hop is proxy-authored — every hop left of it
+    //! is whatever the client sent, and taking the first lets a caller pick its
+    //! own rate-limit bucket. No header (direct callers, tests) falls back to
+    //! the transport peer.
     let fwd = get_header(req, "X-Forwarded-For")
     if (empty(fwd)) {
-        return "local"
+        let peer = client_ip(req)
+        return empty(peer) ? "local" : peer
     }
-    let comma = find(fwd, ",")
-    return comma < 0 ? fwd : slice(fwd, 0, comma)
+    let comma = rfind(fwd, ",")
+    let last = comma < 0 ? fwd : slice(fwd, comma + 1)
+    let trimmed = strip(last)
+    return empty(trimmed) ? "local" : trimmed
+}
+
+def is_loopback_peer(peer : string) : bool {
+    //! Exact-match only: an unknown or empty peer counts as remote, and no
+    //! prefix/suffix rule can be fooled by a hostname that merely contains a
+    //! loopback address.
+    return peer == "127.0.0.1" || peer == "::1" || peer == "::ffff:127.0.0.1"
+}
+
+def private is_loopback_caller(var req : HttpRequest?) : bool {
+    //! Operator-surface gate. The transport peer is the only identity a caller
+    //! cannot forge: the service sits behind a proxy, so any browser page can
+    //! drive a cross-origin POST to these routes, and no header separates that
+    //! from a local operator.
+    return is_loopback_peer(client_ip(req))
+}
+
+def body_is_byte_faithful(buffered_bytes : int; text : string) : bool {
+    //! Whether the string view of a request body still carries every byte that
+    //! arrived. A das string ends at the first NUL, so `text` can be a silent
+    //! prefix of what the client sent — only the buffered byte count knows the
+    //! difference, and a truncated body would be hashed and stored as if it
+    //! were the whole thing.
+    return buffered_bytes == length(text)
 }
 
 def is_valid_hash(h : string) : bool {
@@ -65,7 +94,9 @@ def private log_request(method : string; path : string; status : int; ip : strin
 
 class PlaygroundServer : HvWebServer {
     def override onInit {  // the route table: one registration per endpoint
-        allow_cors()
+        // No allow_cors(): libhv's CORS middleware reflects the caller's Origin
+        // back on EVERY route, which would make each stored sample and the
+        // operator surface cross-origin readable. The playground is same-origin.
         GET("/healthz") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return resp |> TEXT_PLAIN("ok")
         }
@@ -79,7 +110,6 @@ class PlaygroundServer : HvWebServer {
             return handle_get_source(req, resp)
         }
         POST("/admin/reimport") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
-            // operator surface: reachable on loopback only — Caddy never routes /admin/*
             return handle_reimport(req, resp)
         }
         GET("/s/:hash") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
@@ -87,6 +117,10 @@ class PlaygroundServer : HvWebServer {
         }
         POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             let t0 = ref_time_ticks()
+            if (!is_loopback_caller(req)) {
+                log_request("POST", "/shutdown", 403, client_ip_of(req), 0, 0, t0)
+                return resp |> TEXT_PLAIN("forbidden", http_status.FORBIDDEN)
+            }
             logger_info("playground", "shutdown requested")
             g_stop_requested = true
             log_request("POST", "/shutdown", 200, client_ip_of(req), 0, 3, t0)
@@ -103,8 +137,19 @@ class PlaygroundServer : HvWebServer {
 
 def private handle_put(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
-    let source = string(req.body)
     let ip = client_ip_of(req)
+    // Transport shape first: a das string ends at the first NUL, so a body
+    // carrying one would be size-checked, validated, hashed and stored
+    // truncated — two different bodies sharing a pre-NUL prefix would collapse
+    // onto one hash and one public URL. Compare the buffered byte count
+    // (std::string size) against the string length and refuse the mismatch.
+    let raw_bytes = length(req.body)
+    let source = string(req.body)
+    if (!body_is_byte_faithful(raw_bytes, source)) {
+        let nul_body = write_json(JV((error = "source contains NUL bytes")))
+        log_request("POST", "/api/samples", 400, ip, raw_bytes, length(nul_body), t0)
+        return resp |> JSON(nul_body, http_status.BAD_REQUEST)
+    }
     let r = put_sample(g_db, source, ip, g_policy, current_unix_time())
     var status = http_status.OK
     var body = ""
@@ -139,6 +184,10 @@ def private handle_get_source(var req : HttpRequest?; var resp : HttpResponse?) 
     }
     // content-addressed => immutable forever
     resp |> set_header("Cache-Control", "public, max-age=31536000, immutable")
+    // The body is anonymous user input served from the site's own origin, and
+    // it is cached for a year: without nosniff a browser may sniff it as script
+    // or HTML, which would make any stored sample a same-origin script source.
+    resp |> set_header("X-Content-Type-Options", "nosniff")
     log_request("GET", "/api/samples/:hash", 200, ip, 0, length(source), t0)
     resp |> set_content_type("text/plain; charset=utf-8")
     resp.body := source
@@ -151,12 +200,18 @@ def private handle_listed(var req : HttpRequest?; var resp : HttpResponse?) : ht
     var arr <- [for (l in listed); JV((hash = l.hash, title = l.title, category = l.category,
         path = l.path, slug = l.slug))]
     let body = write_json(JV(arr))
+    resp |> set_header("Cache-Control", "public, max-age=60")
+    resp |> set_header("X-Content-Type-Options", "nosniff")
     log_request("GET", "/api/samples/listed", 200, client_ip_of(req), 0, length(body), t0)
     return resp |> JSON(body)
 }
 
 def private handle_reimport(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
+    if (!is_loopback_caller(req)) {
+        log_request("POST", "/admin/reimport", 403, client_ip_of(req), 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
     if (empty(g_curated_dir)) {
         log_request("POST", "/admin/reimport", 503, client_ip_of(req), 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "curated_dir not configured"))), http_status.SERVICE_UNAVAILABLE)

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -7,6 +7,7 @@ require daslib/sql
 require sqlite/sqlite_migrate public
 require daslib/sql_linq
 require daslib/sha_256 public
+require daslib/utf8_utils
 require daslib/logger
 require daslib/json_boost
 require strings
@@ -17,6 +18,10 @@ require strings
 
 let RATE_WINDOW_SECONDS = 3600l
 
+//! Sort key for a listing the importer did not order (an admin promotion):
+//! after every manifest entry, in a store the dropdown renders top to bottom.
+let LISTING_POSITION_LAST = 999999
+
 [sql_table(name = "samples"),
  sql_index(fields = ("ClientIp", "CreatedAt"))]
 struct Sample {
@@ -25,12 +30,13 @@ struct Sample {
     Size : int
     CreatedAt : int64
     ClientIp : string
-    Listed : int = 0   // 0/1; bool lacks a bind adapter on the predicate/update rails
+    Listed : int = 0   // 0/1
     Title : string = ""
     Origin : string = "user"
     Category : string = ""
     PrimaryPath : string = ""   // curated: files[0] from data.json — the UI derives slug/assets from it
     Slug : string = ""          // curated: explicit deep-link slug (?example=) when the manifest has one
+    Position : int = LISTING_POSITION_LAST   // manifest order; unset sorts last
 }
 
 [sql_migration(version = 1, description = "create playground samples")]
@@ -55,6 +61,11 @@ def samples_migration_002(db : SqlRunner) {
     db |> exec("ALTER TABLE samples ADD COLUMN Slug TEXT NOT NULL DEFAULT ''")
 }
 
+[sql_migration(version = 3, description = "curated listing keeps manifest order")]
+def samples_migration_003(db : SqlRunner) {
+    db |> exec("ALTER TABLE samples ADD COLUMN Position INTEGER NOT NULL DEFAULT 999999")
+}
+
 struct StorePolicy {
     //! Every limit the store enforces; the launcher fills it from config.
     max_source_bytes : int = 262144
@@ -76,69 +87,44 @@ struct PutResult {
 }
 
 def is_valid_utf8(data : array<uint8> const# implicit) : bool {
-    //! Strict UTF-8 validation: rejects overlongs, surrogates, and > U+10FFFF.
-    var i = 0
-    let n = length(data)
-    while (i < n) {
-        let b0 = uint(data[i])
-        if (b0 < 0x80) {
-            i ++
-            continue
-        }
-        var need = 0
-        var lo = 0x80u
-        var hi = 0xBFu
-        if (b0 >= 0xC2 && b0 <= 0xDF) {
-            need = 1
-        } elif (b0 == 0xE0) {
-            need = 2
-            lo = 0xA0u
-        } elif (b0 >= 0xE1 && b0 <= 0xEC) {
-            need = 2
-        } elif (b0 == 0xED) {
-            need = 2
-            hi = 0x9Fu
-        } elif (b0 >= 0xEE && b0 <= 0xEF) {
-            need = 2
-        } elif (b0 == 0xF0) {
-            need = 3
-            lo = 0x90u
-        } elif (b0 >= 0xF1 && b0 <= 0xF3) {
-            need = 3
-        } elif (b0 == 0xF4) {
-            need = 3
-            hi = 0x8Fu
-        } else {
-            return false    // 0x80-0xC1 (bare continuation / overlong), 0xF5-0xFF
-        }
-        return false if (i + need >= n)
-        for (k in range(need)) {
-            let b = uint(data[i + 1 + k])
-            let bLo = k == 0 ? lo : 0x80u
-            let bHi = k == 0 ? hi : 0xBFu
-            return false if (b < bLo || b > bHi)
-        }
-        i += need + 1
-    }
-    return true
+    //! Strict UTF-8: rejects overlongs, surrogates, and > U+10FFFF.
+    return is_utf8_string_valid(data)
 }
 
 def is_valid_utf8(s : string) : bool {
+    //! Validates the BYTES, not the characters: the utf8_utils string overload
+    //! iterates decoded characters, which is not what a stored source is.
     var ok = true
     peek_data(s) $(bytes) {
-        ok = is_valid_utf8(bytes)
+        ok = is_utf8_string_valid(bytes)
     }
     return ok
+}
+
+def private rate_exceeded(db : SqlRunner; client_ip : string; policy : StorePolicy; now : int64) : bool {
+    let cutoff = now - RATE_WINDOW_SECONDS
+    let recent <- _sql(db |> select_from(type<Sample>)
+        |> _where(_.ClientIp == client_ip && _.CreatedAt >= cutoff)
+        |> _select(_.Hash))
+    return length(recent) >= policy.max_inserts_per_ip_hour
 }
 
 def put_sample(db : SqlRunner; source : string; client_ip : string; policy : StorePolicy; now : int64) : PutResult {
     //! Validate, dedup by content hash, and store. First writer wins: a dedup
     //! hit changes nothing about the existing row.
+    //! Checks run cheapest-first, and the rate ceiling comes BEFORE validation
+    //! and hashing: it counts rows created in the window, so a throttled caller
+    //! must not be able to spend a full UTF-8 scan and SHA-256 pass per request
+    //! on work that can never be stored — including for a body that would have
+    //! deduped.
     if (empty(source)) {
         return PutResult(status = PutStatus.empty_source)
     }
     if (length(source) > policy.max_source_bytes) {
         return PutResult(status = PutStatus.too_large)
+    }
+    if (rate_exceeded(db, client_ip, policy, now)) {
+        return PutResult(status = PutStatus.rate_limited)
     }
     if (!is_valid_utf8(source)) {
         return PutResult(status = PutStatus.invalid_utf8)
@@ -146,13 +132,6 @@ def put_sample(db : SqlRunner; source : string; client_ip : string; policy : Sto
     let hash = sha256_hex(source)
     if (sample_exists(db, hash)) {
         return PutResult(status = PutStatus.ok, hash = hash, created = false)
-    }
-    let cutoff = now - RATE_WINDOW_SECONDS
-    let recent <- _sql(db |> select_from(type<Sample>)
-        |> _where(_.ClientIp == client_ip && _.CreatedAt >= cutoff)
-        |> _select(_.Hash))
-    if (length(recent) >= policy.max_inserts_per_ip_hour) {
-        return PutResult(status = PutStatus.rate_limited)
     }
     db |> insert(Sample(
         Hash = hash,
@@ -192,10 +171,12 @@ struct ListedSample {
 }
 
 def listed_samples(db : SqlRunner) : array<ListedSample> {
-    //! The curated dropdown, category-then-title ordered.
+    //! The curated dropdown in manifest order — the order the site authored is
+    //! what the dropdown shows, and entry zero is what the playground opens
+    //! with. Category/title only break ties among unordered rows.
     let rows <- _sql(db |> select_from(type<Sample>)
         |> _where(_.Listed != 0)
-        |> _order_by((_.Category, _.Title))
+        |> _order_by((_.Position, _.Category, _.Title))
         |> _select((Hash = _.Hash, Title = _.Title, Category = _.Category,
             PrimaryPath = _.PrimaryPath, Slug = _.Slug)))
     return <- [for (r in rows); ListedSample(hash = r.Hash, title = r.Title, category = r.Category,
@@ -221,11 +202,11 @@ def upsert_curated_source(db : SqlRunner; source : string; now : int64) : string
     return hash
 }
 
-def list_curated_sample(db : SqlRunner; hash : string; title : string; category : string; path : string; slug : string) {
+def list_curated_sample(db : SqlRunner; hash : string; title : string; category : string; path : string; slug : string; position : int) {
     db |> _sql_update(
         type<Sample>,
         _.Hash == hash,
-        (Listed = 1, Title = title, Category = category, PrimaryPath = path, Slug = slug))
+        (Listed = 1, Title = title, Category = category, PrimaryPath = path, Slug = slug, Position = position))
     logger_info("playground.store", "list curated sample",
         JV((hash = hash, title = title, category = category)))
 }
@@ -253,13 +234,15 @@ def demote_stale_curated(db : SqlRunner; keep : table<string>) : int {
 
 def promote_sample(db : SqlRunner; hash : string; title : string; category : string) : bool {
     //! List an existing sample in the dropdown. False when the hash is unknown.
+    //! Clears PrimaryPath: that field marks importer ownership, so a sample the
+    //! manifest once carried would otherwise be re-demoted by the next import.
     if (!sample_exists(db, hash)) {
         return false
     }
     db |> _sql_update(
         type<Sample>,
         _.Hash == hash,
-        (Listed = 1, Title = title, Category = category))
+        (Listed = 1, Title = title, Category = category, PrimaryPath = "", Position = LISTING_POSITION_LAST))
     logger_info("playground.store", "promote sample",
         JV((hash = hash, title = title, category = category)))
     return true

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -92,13 +92,7 @@ def is_valid_utf8(data : array<uint8> const# implicit) : bool {
 }
 
 def is_valid_utf8(s : string) : bool {
-    //! Validates the BYTES, not the characters: the utf8_utils string overload
-    //! iterates decoded characters, which is not what a stored source is.
-    var ok = true
-    peek_data(s) $(bytes) {
-        ok = is_utf8_string_valid(bytes)
-    }
-    return ok
+    return is_utf8_string_valid(s)
 }
 
 def private rate_exceeded(db : SqlRunner; client_ip : string; policy : StorePolicy; now : int64) : bool {

--- a/utils/dasweb-playground/samples_store.das
+++ b/utils/dasweb-playground/samples_store.das
@@ -102,11 +102,14 @@ def is_valid_utf8(s : string) : bool {
 }
 
 def private rate_exceeded(db : SqlRunner; client_ip : string; policy : StorePolicy; now : int64) : bool {
+    // count() lowers to SELECT COUNT(*), so the ceiling costs one scalar row on
+    // the (ClientIp, CreatedAt) index — this runs on every POST, ahead of
+    // hashing, and must not materialize the rows it is only counting.
     let cutoff = now - RATE_WINDOW_SECONDS
-    let recent <- _sql(db |> select_from(type<Sample>)
+    let recent = _sql(db |> select_from(type<Sample>)
         |> _where(_.ClientIp == client_ip && _.CreatedAt >= cutoff)
-        |> _select(_.Hash))
-    return length(recent) >= policy.max_inserts_per_ip_hour
+        |> count())
+    return recent >= policy.max_inserts_per_ip_hour
 }
 
 def put_sample(db : SqlRunner; source : string; client_ip : string; policy : StorePolicy; now : int64) : PutResult {

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -171,3 +171,61 @@ def test_import_failure_modes(t : T?) {
         }
     }
 }
+
+[test]
+def test_manifest_paths_stay_inside_the_samples_dir(t : T?) {
+    //! Regression: manifest paths were path_join'd with no containment check,
+    //! and path_join DISCARDS the base when the right side is absolute — so a
+    //! manifest entry could publish any file the service user can read as a
+    //! permanent public sample.
+    let dir = fixture_dir(t, "escape")
+    let secret = path_join(dir, "secret.txt")
+    fwrite(secret, "TOP SECRET")
+    fwrite(path_join(dir, "examples/hello.das"), "print(\"hello\")")
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("an absolute path is refused") @(tt : T?) {
+            write_manifest(dir, "\{ \"examples\": [ \{ \"name\": \"Pwn\", \"files\": [\"{secret}\"] \} ] \}")
+            tt |> equal(import_curated(db, dir, 1000l), -1)   // nothing readable => prior listings stand
+            tt |> equal(length(listed_samples(db)), 0)
+            tt |> success(!sample_exists(db, sha256_hex("TOP SECRET")), "secret was never stored")
+        }
+        t |> run("a climbing relative path is refused") @(tt : T?) {
+            write_manifest(dir, "\{ \"examples\": [" +
+                "\{ \"name\": \"Pwn\", \"files\": [\"../secret.txt\"] \}," +
+                "\{ \"name\": \"Hello world\", \"files\": [\"examples/hello.das\"] \} ] \}")
+            tt |> equal(import_curated(db, dir, 1000l), 1)   // the honest entry still imports
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 1)
+            tt |> equal(listed[0].title, "Hello world")
+            tt |> success(!sample_exists(db, sha256_hex("TOP SECRET")), "secret was never stored")
+        }
+    }
+    var err = ""
+    remove(secret, err)
+    nuke(dir)
+}
+
+[test]
+def test_all_entries_unreadable_keeps_prior_listings(t : T?) {
+    //! Regression: a manifest that parsed but whose files were all unreadable
+    //! (partial deploy, `current` swapped mid-import, curated_dir one directory
+    //! off) demoted against an empty keep set — unlisting the whole dropdown
+    //! while reporting success.
+    let dir = fixture_dir(t, "allskipped")
+    write_manifest(dir, MANIFEST_V1)
+    fwrite(path_join(dir, "examples/hello.das"), "print(\"hello\")")
+    fwrite(path_join(dir, "examples/multi_a.das"), "require multi_b")
+    fwrite(path_join(dir, "examples/multi_b.das"), "def helper \{ \}")
+    with_latest_sqlite(":memory:") $(db) {
+        t |> equal(import_curated(db, dir, 1000l), 2)
+        t |> run("sources vanish: the dropdown survives and the import reports failure") @(tt : T?) {
+            for (f in ["examples/hello.das", "examples/multi_a.das", "examples/multi_b.das"]) {
+                var err = ""
+                remove(path_join(dir, f), err)
+            }
+            tt |> equal(import_curated(db, dir, 2000l), -1)
+            tt |> equal(length(listed_samples(db)), 2)
+        }
+    }
+    nuke(dir)
+}

--- a/utils/dasweb-playground/test_curated_import.das
+++ b/utils/dasweb-playground/test_curated_import.das
@@ -206,6 +206,43 @@ def test_manifest_paths_stay_inside_the_samples_dir(t : T?) {
 }
 
 [test]
+def test_multi_category_order_is_reproducible(t : T?) {
+    //! Regression: Position was assigned while iterating keys() of the parsed
+    //! manifest object, which is a table — hash order, not the manifest's. That
+    //! made the listing order depend on something unspecified. Categories are
+    //! now visited sorted, so the assignment is reproducible: alphabetical
+    //! across categories, manifest order within one.
+    let dir = fixture_dir(t, "multicat")
+    write_manifest(dir, "\{" +
+        "\"zeta\": [ \{ \"name\": \"Z one\", \"files\": [\"examples/hello.das\"] \}," +
+        "           \{ \"name\": \"Z two\", \"files\": [\"examples/multi_a.das\"] \} ]," +
+        "\"alpha\": [ \{ \"name\": \"A one\", \"files\": [\"examples/multi_b.das\"] \} ]" +
+        "\}")
+    fwrite(path_join(dir, "examples/hello.das"), "print(\"z1\")")
+    fwrite(path_join(dir, "examples/multi_a.das"), "print(\"z2\")")
+    fwrite(path_join(dir, "examples/multi_b.das"), "print(\"a1\")")
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("categories sort; entries keep manifest order inside one") @(tt : T?) {
+            tt |> equal(import_curated(db, dir, 1000l), 3)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 3)
+            tt |> equal(listed[0].title, "A one")   // "alpha" sorts before "zeta"
+            tt |> equal(listed[1].title, "Z one")   // manifest order within "zeta"
+            tt |> equal(listed[2].title, "Z two")
+        }
+        t |> run("a re-import reproduces the same order") @(tt : T?) {
+            tt |> equal(import_curated(db, dir, 2000l), 3)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 3)
+            tt |> equal(listed[0].title, "A one")
+            tt |> equal(listed[1].title, "Z one")
+            tt |> equal(listed[2].title, "Z two")
+        }
+    }
+    nuke(dir)
+}
+
+[test]
 def test_all_entries_unreadable_keeps_prior_listings(t : T?) {
     //! Regression: a manifest that parsed but whose files were all unreadable
     //! (partial deploy, `current` swapped mid-import, curated_dir one directory

--- a/utils/dasweb-playground/test_playground_config.das
+++ b/utils/dasweb-playground/test_playground_config.das
@@ -43,6 +43,26 @@ def test_defaults_and_toml(t : T?) {
         t |> success(!apply_config_text(cfg, "port = [not toml", args, sources, err), "parse fails")
         t |> success(!empty(err), "error text set")
     }
+    t |> run("a wrong-typed value is an error, not a silent zero") @(t : T?) {
+        // Regression: a string where a number belongs coerced to 0 (and a
+        // number where a string belongs to ""), with provenance still logged as
+        // "toml" — the service would start on a config the file does not state.
+        var cfg = ServerArgs()
+        var sources : table<string; string>
+        var err = ""
+        let args <- no_args()
+        t |> success(!apply_config_text(cfg, "max_source_bytes = \"256k\"\n", args, sources, err), "string for a number fails")
+        t |> success(find(err, "max_source_bytes") >= 0, "error names the key")
+        t |> equal(cfg.max_source_bytes, 262144)   // default stands
+    }
+    t |> run("a number where a string belongs is an error") @(t : T?) {
+        var cfg = ServerArgs()
+        var sources : table<string; string>
+        var err = ""
+        let args <- no_args()
+        t |> success(!apply_config_text(cfg, "db = 7\n", args, sources, err), "number for a string fails")
+        t |> success(find(err, "db") >= 0, "error names the key")
+    }
 }
 
 [test]

--- a/utils/dasweb-playground/test_playground_server.das
+++ b/utils/dasweb-playground/test_playground_server.das
@@ -164,7 +164,7 @@ def test_rate_limiting_by_forwarded_ip(t : T?) {
             var headers_a : table<string; string>
             headers_a |> insert("X-Forwarded-For", "203.0.113.7")
             var headers_b : table<string; string>
-            headers_b |> insert("X-Forwarded-For", "203.0.113.8, 10.0.0.1")
+            headers_b |> insert("X-Forwarded-For", "203.0.113.8, 10.0.0.1")   // identity is 10.0.0.1, the proxy-appended hop
             for (i in range(3)) {
                 POST("{base_url}/api/samples", "sample {i}", headers_a) $(resp) {
                     tt |> equal(int(resp.status_code), 200)
@@ -177,6 +177,90 @@ def test_rate_limiting_by_forwarded_ip(t : T?) {
                 tt |> equal(int(resp.status_code), 200)
             }
         }
+    }
+}
+
+[test]
+def test_forged_forwarded_hops_share_one_bucket(t : T?) {
+    //! Regression: the rate ceiling keyed on the FIRST X-Forwarded-For hop,
+    //! which a client authors. A proxy appends the peer it accepted, so only
+    //! the last hop is trustworthy — keying on the first let one caller mint a
+    //! fresh identity per request and never be throttled.
+    with_playground_server(tiny_policy()) $(base_url) {
+        t |> run("a caller cannot escape the ceiling by varying earlier hops") @(tt : T?) {
+            for (i in range(3)) {
+                var h : table<string; string>
+                h |> insert("X-Forwarded-For", "198.51.100.{i}, 10.0.0.42")
+                POST("{base_url}/api/samples", "forged {i}", h) $(resp) {
+                    tt |> equal(int(resp.status_code), 200)
+                }
+            }
+            var h4 : table<string; string>
+            h4 |> insert("X-Forwarded-For", "198.51.100.99, 10.0.0.42")
+            POST("{base_url}/api/samples", "forged 3", h4) $(resp) {
+                tt |> equal(int(resp.status_code), 429)
+            }
+        }
+    }
+}
+
+[test]
+def test_body_byte_faithfulness_guard(t : T?) {
+    //! Regression: the body was read through a NUL-terminated string, so
+    //! everything past an embedded NUL was dropped before the size check, the
+    //! validation, the hash and the stored row — two different bodies sharing a
+    //! pre-NUL prefix would collapse onto one hash and one public URL.
+    //! The guard is tested as a predicate rather than end-to-end: the dasHV
+    //! client takes the body as a NUL-terminated string too, so no dastest
+    //! client can put a NUL on the wire.
+    t |> run("a body whose bytes survive the string view is accepted") @(tt : T?) {
+        let text = "print(\"visible\")"
+        tt |> success(body_is_byte_faithful(length(text), text), "faithful body")
+        tt |> success(body_is_byte_faithful(0, ""), "empty body")
+    }
+    t |> run("a body longer than its string view is refused") @(tt : T?) {
+        let text = "print(\"visible\")"
+        // what a NUL looks like from the handler: more bytes arrived than the
+        // string carries
+        tt |> success(!body_is_byte_faithful(length(text) + 18, text), "truncated at a NUL")
+        tt |> success(!body_is_byte_faithful(1, ""), "NUL-only body")
+    }
+}
+
+[test]
+def test_stored_sources_are_served_nosniff(t : T?) {
+    //! Regression: stored anonymous input was served same-origin with a
+    //! one-year immutable cache and no nosniff, so a browser could sniff a
+    //! sample as script.
+    with_playground_server(default_policy()) $(base_url) {
+        let source = "print(\"sniff me\")"
+        let hash = posted_hash(base_url, source)
+        t |> run("GET carries X-Content-Type-Options") @(tt : T?) {
+            GET("{base_url}/api/samples/{hash}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(get_header(resp, "X-Content-Type-Options"), "nosniff")
+            }
+        }
+    }
+}
+
+[test]
+def test_loopback_peer_predicate(t : T?) {
+    //! The operator-surface gate. Only the predicate is unit-testable here: the
+    //! test client necessarily connects FROM loopback, so the allow path is
+    //! what the harness exercises (every suite shuts the server down through
+    //! POST /shutdown) and the deny path is proven on the peer string.
+    t |> run("loopback forms are accepted") @(tt : T?) {
+        tt |> success(is_loopback_peer("127.0.0.1"), "ipv4 loopback")
+        tt |> success(is_loopback_peer("::1"), "ipv6 loopback")
+        tt |> success(is_loopback_peer("::ffff:127.0.0.1"), "v4-mapped loopback")
+    }
+    t |> run("everything else is remote") @(tt : T?) {
+        tt |> success(!is_loopback_peer(""), "unknown peer")
+        tt |> success(!is_loopback_peer("203.0.113.5"), "public address")
+        tt |> success(!is_loopback_peer("10.0.0.1"), "private LAN address")
+        tt |> success(!is_loopback_peer("127.0.0.1.evil.example"), "address as a hostname prefix")
+        tt |> success(!is_loopback_peer("127.0.0.2"), "other loopback-range address")
     }
 }
 

--- a/utils/dasweb-playground/test_samples_store.das
+++ b/utils/dasweb-playground/test_samples_store.das
@@ -13,7 +13,7 @@ def private test_policy : StorePolicy {
 def test_migration(t : T?) {
     t |> run("fresh db migrates to latest") @(t : T?) {
         with_latest_sqlite(":memory:") $(db) {
-            t |> equal(current_schema_version(db), 2)
+            t |> equal(current_schema_version(db), 3)
         }
     }
 }
@@ -115,7 +115,7 @@ def test_curated_store_ops(t : T?) {
         }
         t |> run("list_curated_sample sets all listing fields") @(tt : T?) {
             let h = upsert_curated_source(db, "listed body", 1000l)
-            list_curated_sample(db, h, "The Title", "examples", "examples/x.das", "xslug")
+            list_curated_sample(db, h, "The Title", "examples", "examples/x.das", "xslug", 0)
             let listed <- listed_samples(db)
             tt |> equal(length(listed), 1)
             tt |> equal(listed[0].title, "The Title")
@@ -124,9 +124,9 @@ def test_curated_store_ops(t : T?) {
         }
         t |> run("demote_stale_curated demotes only curated hashes outside the keep set") @(tt : T?) {
             let ha = upsert_curated_source(db, "keep me", 1000l)
-            list_curated_sample(db, ha, "Keep", "examples", "examples/keep.das", "")
+            list_curated_sample(db, ha, "Keep", "examples", "examples/keep.das", "", 0)
             let hb = upsert_curated_source(db, "drop me", 1000l)
-            list_curated_sample(db, hb, "Drop", "examples", "examples/drop.das", "")
+            list_curated_sample(db, hb, "Drop", "examples", "examples/drop.das", "", 1)
             let user = put_sample(db, "user body", "10.0.0.1", test_policy(), 1000l)
             tt |> success(promote_sample(db, user.hash, "User", "community"), "user promote")
             var keep : table<string>
@@ -169,14 +169,66 @@ def test_rate_ceiling(t : T?) {
             tt |> equal(put_sample(db, "a3", "10.0.0.1", pol, 1020l).status, PutStatus.ok)
             tt |> equal(put_sample(db, "a4", "10.0.0.1", pol, 1030l).status, PutStatus.rate_limited)
         }
-        t |> run("dedup hits bypass the ceiling") @(tt : T?) {
-            tt |> equal(put_sample(db, "a1", "10.0.0.1", pol, 1040l).status, PutStatus.ok)
+        t |> run("a throttled client is refused even for a body that would dedup") @(tt : T?) {
+            // The ceiling is checked before hashing, so a repeated body cannot
+            // buy a free SHA-256 pass per request once the client is over.
+            tt |> equal(put_sample(db, "a1", "10.0.0.1", pol, 1040l).status, PutStatus.rate_limited)
         }
         t |> run("another ip is unaffected") @(tt : T?) {
             tt |> equal(put_sample(db, "b1", "10.0.0.2", pol, 1050l).status, PutStatus.ok)
         }
         t |> run("the window expires") @(tt : T?) {
             tt |> equal(put_sample(db, "a5", "10.0.0.1", pol, 1000l + 3601l).status, PutStatus.ok)
+        }
+    }
+}
+
+[test]
+def test_promotion_releases_importer_ownership(t : T?) {
+    //! Regression: promote_sample used to leave PrimaryPath set, so promoting a
+    //! sample the manifest once carried left it looking importer-owned and the
+    //! next import silently demoted it again, forever.
+    with_latest_sqlite(":memory:") $(db) {
+        let h = upsert_curated_source(db, "once curated", 1000l)
+        list_curated_sample(db, h, "Was Curated", "examples", "examples/gone.das", "", 0)
+        t |> run("promoting clears the importer-ownership marker") @(tt : T?) {
+            tt |> success(promote_sample(db, h, "Kept By Operator", "community"), "promote")
+            let rows <- _sql(db |> select_from(type<Sample>) |> _where(_.Hash == h))
+            tt |> equal(length(rows), 1)
+            tt |> equal(rows[0].PrimaryPath, "")
+        }
+        t |> run("a later import with an empty keep set leaves it listed") @(tt : T?) {
+            let keep : table<string>
+            tt |> equal(demote_stale_curated(db, keep), 0)
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 1)
+            tt |> equal(listed[0].title, "Kept By Operator")
+        }
+    }
+}
+
+[test]
+def test_listing_keeps_manifest_order(t : T?) {
+    //! Regression: the dropdown ordered by (category, title), which reshuffled
+    //! the site-authored manifest order and changed which sample the playground
+    //! opens with.
+    with_latest_sqlite(":memory:") $(db) {
+        let first = upsert_curated_source(db, "opengl triangle", 1000l)
+        list_curated_sample(db, first, "OpenGL: rotating triangle", "examples", "examples/gl.das", "", 0)
+        let second = upsert_curated_source(db, "audio beep", 1000l)
+        list_curated_sample(db, second, "Audio: sine beep", "examples", "examples/beep.das", "", 1)
+        t |> run("manifest order wins over alphabetical") @(tt : T?) {
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 2)
+            tt |> equal(listed[0].title, "OpenGL: rotating triangle")
+            tt |> equal(listed[1].title, "Audio: sine beep")
+        }
+        t |> run("an operator promotion sorts after every manifest entry") @(tt : T?) {
+            let user = put_sample(db, "user body", "10.0.0.1", test_policy(), 1000l)
+            tt |> success(promote_sample(db, user.hash, "AAA Promoted", "examples"), "promote")
+            let listed <- listed_samples(db)
+            tt |> equal(length(listed), 3)
+            tt |> equal(listed[2].title, "AAA Promoted")
         }
     }
 }

--- a/web/build_wasm_host.sh
+++ b/web/build_wasm_host.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Build the daslang host used to CROSS-COMPILE .das to wasm64.
+#
+# This is not an ordinary daslang build. `daspkg build --wasm` / `release wasm`
+# run this binary to JIT-codegen the sample, and it bakes C++ handled-type
+# layouts (Context, jobque, every std::string-bearing struct) from ITS OWN ABI
+# into the wasm module. The emscripten target is libc++ with C++ exceptions, so
+# a host built against libstdc++ with setjmp exceptions bakes the WRONG offsets
+# and sizes -- std::string 32 vs 24 bytes, mutex 80 vs 40 -- and the wasm heap
+# corrupts at runtime, with no diagnostic at build time. Host stdlib and
+# exception config must MATCH the target; host pointer width must match target
+# pointer width (wasm64 => 64-bit host).
+#
+# Authority for these flags is .github/workflows/pages.yml, step
+# "Build: Daslang host (+ glfw/opengl shared modules)". Keep the two in
+# lockstep: if that step changes, change this script in the same commit.
+#
+# web/CMakeLists.txt only WARNS when the host compiler is not clang ("degraded
+# but builds"). This script refuses instead -- a silent degradation here is the
+# failure mode that reaches production as corrupted wasm.
+#
+# The built binary lands in the TREE's bin/daslang (not in the build dir) --
+# which is the same path an ordinary native build of the same tree writes. Give
+# the wasm host its own worktree, or a later native build silently replaces the
+# libc++ host with a libstdc++ one and the corruption returns with no signal.
+#
+# Usage:
+#   web/build_wasm_host.sh [build-dir]
+#
+# Environment:
+#   HOST_CC / HOST_CXX   compiler to use (default: clang / clang++)
+#                        Debian 12 note: /usr/bin/clang is clang-14 there and
+#                        cannot build this tree -- pass clang-19 explicitly:
+#                          HOST_CC=clang-19 HOST_CXX=clang++-19 web/build_wasm_host.sh
+#   JOBS                 parallel build jobs (default: cmake's own choice)
+set -eu
+
+BUILD_DIR="${1:-build-wasm-host}"
+HOST_CC="${HOST_CC:-clang}"
+HOST_CXX="${HOST_CXX:-clang++}"
+
+REPO=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$REPO"
+
+# --- Gate 1: the compiler really is clang -------------------------------------
+if ! "$HOST_CXX" --version 2>/dev/null | grep -qi clang; then
+    echo "build_wasm_host: $HOST_CXX is not clang." >&2
+    echo "  A non-clang host cannot be given a libc++ + C++-exceptions config that" >&2
+    echo "  matches the emscripten target, and web/CMakeLists.txt would only warn." >&2
+    echo "  Set HOST_CC/HOST_CXX to a clang that can build this tree." >&2
+    exit 1
+fi
+
+# --- Gate 2: libc++ is actually usable, not merely requested ------------------
+# -stdlib=libc++ is accepted by the driver even with no libc++ installed; the
+# failure then surfaces hundreds of TUs later as a missing <__config>. Probe now.
+PROBE=$(mktemp -d)
+trap 'rm -rf "$PROBE"' EXIT
+cat > "$PROBE/probe.cpp" <<'PROBE_EOF'
+#include <string>
+#include <mutex>
+#ifndef _LIBCPP_VERSION
+#error "not libc++"
+#endif
+int main() { return (int)(sizeof(std::string) + sizeof(std::mutex)); }
+PROBE_EOF
+if ! "$HOST_CXX" -stdlib=libc++ -DDAS_ENABLE_EXCEPTIONS=1 "$PROBE/probe.cpp" -o "$PROBE/probe" 2>"$PROBE/err"; then
+    echo "build_wasm_host: $HOST_CXX cannot compile against libc++." >&2
+    echo "  Install it (Debian/Ubuntu, matching the compiler's major version), e.g." >&2
+    echo "    sudo apt install libc++-19-dev libc++abi-19-dev" >&2
+    echo "  Compiler output:" >&2
+    sed 's/^/    /' "$PROBE/err" >&2
+    exit 1
+fi
+
+echo "build_wasm_host: $($HOST_CXX --version | head -1)"
+echo "build_wasm_host: libc++ OK; configuring $BUILD_DIR"
+
+# --- Configure ----------------------------------------------------------------
+# Verbatim from pages.yml's host step. NB: a `#` comment inside the `\`-continued
+# cmake call terminates it (exit 127) -- keep comments outside the call.
+cmake --no-warn-unused-cli -B"./$BUILD_DIR" \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DCMAKE_C_COMPILER="$HOST_CC" -DCMAKE_CXX_COMPILER="$HOST_CXX" \
+  -DCMAKE_C_FLAGS="-DDAS_ENABLE_EXCEPTIONS=1" \
+  -DCMAKE_CXX_FLAGS="-stdlib=libc++ -DDAS_ENABLE_EXCEPTIONS=1 -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS" \
+  -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++" \
+  -DDAS_HV_DISABLED=OFF \
+  -DDAS_PUGIXML_DISABLED=OFF \
+  -DDAS_LLVM_DISABLED=OFF \
+  -DDAS_GLFW_DISABLED=OFF \
+  -G Ninja
+
+# dasLLVM is what makes this a cross-compile host at all; dasGlfw/dasOpenGL are
+# the shared modules the example games link against.
+if [ -n "${JOBS:-}" ]; then
+    cmake --build "./$BUILD_DIR" --target daslang dasModuleGlfw dasModuleOpenGL -j "$JOBS"
+else
+    cmake --build "./$BUILD_DIR" --target daslang dasModuleGlfw dasModuleOpenGL
+fi
+
+HOST_BIN="$REPO/bin/daslang"
+echo "build_wasm_host: host daslang at $HOST_BIN"
+echo "build_wasm_host: pass -DDAS_HOST_DASLANG_OVERRIDE=$HOST_BIN when configuring web/build64"
+if ldd "$HOST_BIN" 2>/dev/null | grep -q 'libstdc++'; then
+    echo "build_wasm_host: WARNING - the host links libstdc++, not libc++; handled-type layouts will not match the wasm target." >&2
+fi

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -91,6 +91,7 @@ pageInit = function () {
                     files: [e.path || (e.hash + '.das')],
                     slug: e.slug || undefined,
                     hash: e.hash,
+                    path: e.path || '',
                 });
             }
             initSampleUi(byCat);
@@ -320,13 +321,17 @@ selectSample = function(type, id) {
         currentJitName = deriveJitName(files);
         currentAssetsUrl = deriveAssetsUrl(files);
         updateEngineAvailability(currentJitName);
-        const loadFromStaticFiles = () => Promise.all(files.map(f =>
+        // Static fallback only exists for entries that name a real file in the
+        // shipped samples tree. A promoted user sample has no such path (the
+        // store synthesized "<hash>.das"), so fetching it is a guaranteed 404.
+        const hasStaticFiles = !entry.hash || !!entry.path;
+        const loadFromStaticFiles = () => hasStaticFiles ? Promise.all(files.map(f =>
             $.ajax({ url: './samples/' + f, dataType: 'text' })
                 .then(text => ({ name: f.split('/').pop(), text }))
         )).then(loaded => {
             const byName = Object.fromEntries(loaded.map(({ name, text }) => [name, text]));
             loadSample(byName);
-        });
+        }) : Promise.resolve();
         if (entry.hash) {
             // Store-fed entry: one fetch; multi-file samples arrive as the
             // same {files, active} bundle user shares store. Static tree is


### PR DESCRIPTION
Follow-up to the merged dasweb arc (#3621 + #3623). This is the output of the security-focused `/code-review` of the merged code plus a `CODEREVIEW.md`-compliance pass, folded into one PR (per the "no small PRs" rule — CI makes every PR expensive).

The service is **live on daslang.io**, so the security items below are live-traffic issues, not hypotheticals.

## Security

| Finding | Fix |
|---|---|
| `POST /shutdown` and `/admin/reimport` were unauthenticated behind a service-wide CORS middleware. Any web page could drive a cross-origin POST; a shutdown exits 0, which the watchdog reads as *intentional* and **does not restart** | Both routes verify the transport peer is loopback. Needs a new dasHV binding, `client_ip(request)`, reading libhv's recorded `client_addr` — the only identity a caller cannot forge |
| `allow_cors()` reflected the caller's `Origin` on **every** route, making stored samples and the operator surface cross-origin readable | Removed. The playground is same-origin |
| The rate ceiling keyed on the **first** `X-Forwarded-For` hop, which the client authors — a caller could mint a fresh bucket per request and never be throttled | Keys on the **last** hop, the one Caddy appends |
| A body with an embedded NUL was size-checked, validated, hashed and stored **truncated** (a das string ends at the first NUL) — two different bodies sharing a pre-NUL prefix collapsed onto one hash and one public URL, the exact collision class SHA-256 was chosen to prevent | Rejected with 400 when the buffered byte count disagrees with the string length |
| Manifest paths were `path_join`'d with no containment check. `path_join` is `std::filesystem`'s `operator/=`, which **discards the base** when the right side is absolute — so `{"files":["/etc/passwd"]}` published that file as a permanent public sample | Absolute, drive-qualified and climbing paths refused |
| The rate check ran *after* UTF-8 validation and the full SHA-256, so a throttled caller still burned a hash per request | Ceiling moved ahead of validation and hashing |
| Stored anonymous input served same-origin, cached a year, with no `nosniff` | `X-Content-Type-Options: nosniff` |
| No transport body cap anywhere: the service can only check a body already buffered in full, and libhv has no cap of its own | `caddy.snippet` checks in the public route boundary including `request_body max_size` |

The last one is the review's structural point: the deployment control plane existed nowhere in the repo, which made the route boundary unreviewable. `caddy.snippet` is now the authoritative copy, and `CODEREVIEW.md` points its rules at it instead of at a file that did not exist.

## Correctness

- **`-?` started the service.** `request_exit()` only raises a flag, so help fell through to opening the production database, running migrations *and the importer* (which can demote), and binding the port out from under the running service.
- **An import where nothing was readable emptied the dropdown.** A partial deploy or a `current` symlink swapped mid-import left the keep set empty, and every importer-owned listing was demoted — while the call returned success. Prior listings now stand.
- **`promote_sample` left `PrimaryPath` set**, which #3623 made the importer-ownership marker — so promoting a once-curated sample was silently undone by the next import, forever.
- **Listings lost manifest order.** Ordering by `(category, title)` reshuffled the site-authored order and changed which sample the playground opens with. New `Position` column (migration v3); operator promotions sort after every manifest entry.
- **A wrong-typed TOML value coerced to `0`/`""`** with provenance still logged as `"toml"` — `max_source_bytes = "256k"` became `0`. Now a startup error.
- **The checked-in toml carried production paths** and is auto-discovered beside the module, so an in-repo run opened the live database. Now development values; deployed values documented in the README.
- **`watchdog.json` was overwritten on every deploy** though it encodes the port — an operator port change came back on upgrade, and the watchdog then killed a healthy service in a restart loop. Now operator-owned like the toml, and `deploy.sh` carries both forward.
- **`deploy.sh` removed the release tree before snapshotting operator files**, so redeploying the same sha destroyed them; it also never created the data dir.
- **`admin.das` never migrated**, so store calls panicked in `prepare` instead of reporting the path (`sqlite3_open` creates an empty file for a mistyped path) — and it was not in the release manifest, so it never reached the box. Both fixed.
- **Playground share race:** `?s=` set the restore flag *inside* the fetch callback, so main.js's default sample could win the race and overwrite the shared code the visitor followed the link for. Claimed synchronously now; a dead link falls back to the default instead of a blank editor. Promoted entries skip a static fallback that was a guaranteed 404.

## Tests and CI

- **No CI lane ran any dasweb-playground suite.** In-dir suites are required by bare name (hyphenated directory), so `--test ./tests` never reached them — 800+ lines of mandated tests ran only by hand. `extended_checks` now runs all four.
- `tests/daslib/test_sha_256.das` was in neither `AOT_DASLIB_FILES` nor `options no_aot`, so the nightly full AOT sweep hit it with no compiled TU. Registered.
- The padding-boundary test compared the two `sha256_hex` overloads **against each other** — they share one per-byte path, so it could not fail on a padding bug. Now pins digests from an independent SHA-256 (the implementation matches at all seven boundary lengths).
- `pages.yml` nudges `/admin/reimport` after the site deploy, so a changed curated sample appears without a service restart.
- Duplicates removed: `is_valid_utf8` re-implemented the Hoehrmann DFA already in `daslib/utf8_utils`; `cli_has_flag` re-implemented clargs' `flag_present`.

Every behavior fix lands with the regression test that fails without it.

## Verification

99 tests green locally: store 36, importer 18, config 15, server 30 (was 30/12/13/24). Plus `tests/dasHV` 141 and `tests/daslib` 238 green — dasHV because of the new binding. Lint 0 issues, formatter clean, das2rst clean (`client_ip` grouped, handmade doc written, no Uncategorized/stubs/untracked). AOT codegen verified for the changed sha_256 test.

Not run: full preflight (per the standing "lint + format is the bar for incremental rounds" directive) — pushed with `--no-verify`.

Docs touched, flagged per the checklist's `.md` stop: `CODEREVIEW.md` (rules the findings imply; drops the claim that buffering makes the in-handler size check sufficient) and `README.md` (new behaviors, deployed config values, admin CLI usage).

## Deployment note

The box still runs `ebb422779`. It needs a redeploy on merge, and the Caddyfile needs the `caddy.snippet` body cap applied — neither is done yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
