### PR TITLE
playground: restart the runtime per run, stop emitting GLSL-illegal temp names, sweep the projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ modules/dasLLAMA/performance/_rig/
 
 # my local box runbook (machine-specific paths; not for the shared repo)
 ZEN2.md
+
+# local playground rig scratch (web/serve_playground.py)
+web/_serve/

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -354,12 +354,22 @@ class LintVisitor : AstVisitor {
         validate_var(v, false)
     }
 
+    // `_inl<site id>_…` (`_inl0_l_text`, `_inl3_res`); the digit keeps a user's `_inline_x` in scope
+    def private is_inline_temp_name(name : string) : bool {
+        if (!(name |> starts_with("_inl")) || length(name) <= 4) return false
+        var digit = false
+        peek_data(name) $(bytes) {
+            digit = is_number(int(bytes[4]))
+        }
+        return digit
+    }
+
     def validate_var(v : VariablePtr; can_make_const : bool) {
         // marked_used: a transform consumed the reads (devirtualized block holder), or author intent
         if (v.flags.generated || v.flags.marked_used) return
         let name = string(v.name)
-        // skip system vars (`__name`) and compiler-generated names (backtick-mangled, e.g. tuple destructuring)
-        if (name |> starts_with("__") || find(name, "`") >= 0) return
+        // skip names the compiler owns rather than the author: `__system`, backtick-mangled, inliner temps
+        if (name |> starts_with("__") || find(name, "`") >= 0 || is_inline_temp_name(name)) return
         if (name |> starts_with("_")) {
             if (name |> ends_with("_")) return  // _foo_ - ignore too
             if (v.access_flags.access_ref || v.access_flags.access_pass || v.access_flags.access_get || v.access_flags.access_fold) {

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -2764,7 +2764,7 @@ def private declare_local_var(var m : SpirvModule; var ctx : EmitCtx; v : Variab
     // own: visitExprLetVariable binds it to the pointer its initializer lowered to. Declaring one
     // here would make every write through the alias land in that private copy and leave the aliased
     // element untouched. The inliner emits these whenever an inlined call's result is assigned to an
-    // lvalue (`var __inl_pre : float& = p[i]; … ; __inl_pre = __inl_res`), which is the shape a
+    // lvalue (`var _inl_pre : float& = p[i]; … ; _inl_pre = _inl_res`), which is the shape a
     // helper reached across a require arrives in.
     if (key_exists(ctx.local_vars, intptr(v)) || v._type.flags.ref) return
     let bt = v._type.baseType

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -1,4 +1,8 @@
 options gen2
+// A codegen emitter: the big functions are flat opcode dispatch (visitExprCall is 272 branches over
+// the SPIR-V instruction set), where splitting hides the mapping instead of clarifying it.
+options _cyclomatic_complexity = 0
+options _function_length = 0
 
 // daslang AST -> SPIR-V codegen via the SpirvEmit AstVisitor (modeled on llvm_jit's SSA backend).
 // SPIR-V's value/pointer model (SSA + OpAccessChain) is threaded through per-node side-maps: e2id for

--- a/plans/dasweb_wasm_pipeline.md
+++ b/plans/dasweb_wasm_pipeline.md
@@ -139,13 +139,24 @@ installed, and `/usr/bin/clang` there is clang-14 (cannot build this tree) — p
 mount path — it is `llvm/daslib/...`, not `daslib/...`; the latter fails with
 `error[20605] missing prerequisite`, which looks exactly like a missing module and is not one.
 
-One trap that run surfaced, for 3a to carry:
+**The wasm build MUST have its own worktree. This is a hard requirement, not hygiene** — it was
+demonstrated the expensive way while deploying #3625:
 
-- **The host binary lands in the tree's `bin/daslang`**, the same path an ordinary native build
-  of that tree writes. A later native build in the same worktree silently replaces the libc++
-  host with a libstdc++ one — the exact corruption this recipe exists to prevent, with no
-  signal. This is why the wasm host needs **its own worktree**, and the script now warns when
-  the resulting binary links libstdc++.
+- **Every build of this tree writes to the same tree-level `bin/` and `lib/`**, whatever build
+  directory it was configured in. So the emscripten build and the native build fight over one
+  output tree.
+- The wasm host build leaves `bin/daslang` linked against **libc++**. The web box has no libc++,
+  so a release bundle baked with that host would not run there — and nothing about the bake says
+  so. (`build_wasm_host.sh` now warns when the binary it produced links libstdc++, i.e. the
+  reverse mistake.)
+- Worse, an emscripten build **replaces static archives in `lib/` with WebAssembly ones**. After
+  one interrupted `daspkg build --wasm`, 8 of 23 archives in `lib/` held wasm objects — including
+  `liblibUriParser.a`, which links into daslang itself. The native rebuild then died on
+  `error adding symbols: file format not recognized`, and `file(1)` on the archive says
+  "current ar archive" (it reports the container, not the members), so the usual sanity check
+  looks clean. Only `ar x` + `file` on a member reveals it.
+- Recovery is `rm -f lib/*.a && rm -rf bin build web/build64` plus a full native rebuild. Budget
+  for it if the two ever share a tree again — which they should not.
 
 Still unproven end-to-end: an actual `daspkg build --wasm` run, which needs emsdk 5.0.7 (not yet
 installed). The host half is validated; the emscripten half is not.
@@ -194,9 +205,31 @@ Mapped onto the actual steps in `.github/workflows/pages.yml`:
 | 4–7. arcanoid, pacman, furier, path_tracer_lab, physarum_lab | **Fold** into the content-addressed cache rail. They change rarely, so the cache near-always hits and CI stops rebuilding them. |
 | "Verify wasm example artifacts" | Follows steps 4–7 wherever they land — it exists because those builds are non-fatal, and that property must survive the move. |
 
-**Design point the game pages force:** a game artifact is an **html + js + wasm triple**, not a
-single `.wasm`. The artifact cache must carry multi-file bundles from the start, or the games
-cannot fold in. Get that into the schema before building the single-file path, not after.
+**Design point the game pages force — and it is NOT about multi-file sources.** Two axes that
+look like one and are not:
+
+- **Input multiplicity is already solved, and is not what shapes the artifact.** A multi-file
+  sample (curated or user-authored) is stored as one `{files, active}` JSON document under one
+  hash — phase 1 does this already — and compiles to **one** wasm module. `arcanoid` is the
+  proof: its source dir holds `main.das` + `live_stub.das`, and `daspkg release wasm --root`
+  emits a single `arcanoid.wasm`. So N sources in never means N artifacts out.
+- **Output multiplicity is about delivery mode.** A playground sample is a bare `.wasm` that the
+  already-loaded `daslang_static` runtime instantiates — one file. A game is a **standalone
+  page**: its own `html` + `js` + `wasm`, staged as a triple, because the browser fetches the js
+  and the js fetches the wasm by name. That, and only that, is what forces the cache to hold
+  file sets.
+
+⇒ The cache **key** needs nothing new (the source hash already covers a bundle). The cache
+**value** needs to hold a file set only if the games fold in — which is exactly open question 1.
+If the answer is "games stay in CI", a single-`.wasm` value is sufficient and simpler.
+
+**Separate gap this exposes, worth fixing regardless:** the old per-sample wasm path skipped
+multi-file samples entirely — `deriveJitName` in `web/examples/ui/src/main.js` returns `null`
+when `files.length !== 1`, and the engine radio was disabled for those samples. Since users can
+author multi-file examples and share them, phase 3 should build them too. Nothing about the
+compiler prevents it (the games prove a multi-file root compiles); it was a UI-side shortcut
+tied to naming the artifact after a single source file. Content-addressing removes that
+constraint — the artifact is named by hash, not by basename.
 
 Keep a CI compile-gate job proving the curated set still builds (a test that publishes nothing) —
 a broken sample should red CI, not the production queue.

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -33,21 +33,15 @@
     <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" defer></script>
     <script src="../files/docsearch.js" defer></script>
 
-    <!-- Graphics canvas: force a true 4:3 box (matching the 640x480 drawing
-         buffer the shader's aspect correction assumes) so the render isn't
-         stretched and rotations trace circles, not ovals. !important beats the
-         non-important inline width/height emscripten's GLFW sets on the canvas.
-         Text output sits below it (#output), so a graphics program can both
-         draw and print(). -->
+    <!-- Graphics output: programs render inside a run frame (see
+         playground-runner.js), and the host below stands where the canvas used
+         to. The column is a flex row, so the host must not shrink — the frame
+         is sized to the program's own drawing-buffer aspect and a squeezed box
+         would stretch the render, turning rotations into ovals. Text output
+         sits beside it (#output), so a program can both draw and print(). -->
     <style>
-      #canvas {
-        display: none;
-        background: #000;
-        border: 1px solid #444;
-        margin-top: 20px;
-        margin-bottom: 6px;
-      }
-      #canvas.is-graphics { display: block; }
+      .pg-run-host { flex: 0 0 auto; align-self: flex-start; }
+      .pg-run-frame { flex: 0 0 auto; }
       #output.with-canvas { height: 40vh; }
     </style>
 </head>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -109,6 +109,9 @@
 <script type="text/javascript" src="../files/cm/daslang-mode.js"></script>
 <script type="text/javascript" src="../files/lz-string.min.js"></script>
 <script type="text/javascript" src="./playground-init.js"></script>
+<!-- Owns run-frame.html (one frame per program). Must precede main.js, whose
+     pageInit hands it the run host and whose run path delegates to it. -->
+<script type="text/javascript" src="./playground-runner.js?v=1"></script>
 <script type="text/javascript" src="./main.js"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=2"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -1,0 +1,128 @@
+// Parent half of the playground's execution sandbox. Owns run-frame.html: one
+// frame per program, thrown away afterwards.
+//
+// Why a frame at all — see the comment block in run-frame.html. Short version:
+// runs used to share one wasm instance, so a program that threw inside init()
+// left the daslang module registry un-torn-down and poisoned every later run in
+// that page ("Module 'x' already created", a fatal). Restarting makes the clean
+// slate structural instead of depending on every error path being tidy, gives a
+// kill switch for a hung program, and disposes of the canvas + WebGL context.
+//
+// Loaded BEFORE main.js, which delegates its run path here.
+
+(function () {
+    "use strict";
+
+    var FRAME_SRC = "run-frame.html";
+
+    var host = null;        // element the frames live in
+    var current = null;     // frame serving the run in flight (or the idle one)
+    var spare = null;       // pre-warmed frame, so a Run click pays ~0 startup
+    var onOutput = null;    // set by main.js: (text, color) => void
+    var onExit = null;
+
+    function makeFrame() {
+        var rec = { el: document.createElement("iframe"), ready: false, used: false };
+        rec.el.src = FRAME_SRC;
+        rec.el.className = "pg-run-frame";
+        rec.el.setAttribute("title", "daslang program output");
+        // Sized to the same 4:3 box the old #canvas used; hidden until the
+        // program asks for a WebGL context (or forever, for text programs).
+        rec.el.style.cssText =
+            "display:none;width:640px;height:480px;border:1px solid #444;" +
+            "background:#000;margin-top:20px;margin-bottom:6px;";
+        host.appendChild(rec.el);
+        return rec;
+    }
+
+    function destroy(rec) {
+        if (!rec) return;
+        // Removing the frame kills the wasm instance, its pthread pool, the
+        // AudioContext, the canvas and its GL context in one move.
+        if (rec.el && rec.el.parentNode) rec.el.parentNode.removeChild(rec.el);
+    }
+
+    function ensureSpare() {
+        if (!spare) spare = makeFrame();
+    }
+
+    // Messages carry no frame identity, so match on source window to avoid
+    // crosstalk between the outgoing frame and the pre-warmed one.
+    window.addEventListener("message", function (ev) {
+        if (ev.origin !== window.location.origin) return;
+        var msg = ev.data;
+        if (!msg || typeof msg !== "object") return;
+        var rec = null;
+        if (current && ev.source === current.el.contentWindow) rec = current;
+        else if (spare && ev.source === spare.el.contentWindow) rec = spare;
+        if (!rec) return;
+
+        switch (msg.type) {
+            case "ready":
+                rec.ready = true;
+                if (typeof window.updateButtonStates === "function") window.updateButtonStates();
+                if (rec.pending) { var p = rec.pending; rec.pending = null; send(rec, p); }
+                break;
+            case "stdout":
+                if (onOutput) onOutput(msg.text, "#ffffff");
+                break;
+            case "stderr":
+                if (onOutput) onOutput(msg.text, "#ff9393");
+                break;
+            case "aborted":
+                if (onOutput) onOutput("runtime aborted: " + msg.message, "#ff2d2d");
+                break;
+            case "canvas-visible":
+                rec.el.style.display = "block";
+                var out = document.getElementById("output");
+                if (out) out.classList.add("with-canvas");
+                break;
+            case "exit":
+                if (onExit) onExit(msg.code);
+                break;
+        }
+    });
+
+    function send(rec, payload) {
+        if (!rec.ready) { rec.pending = payload; return; }
+        rec.el.contentWindow.postMessage(payload, window.location.origin);
+    }
+
+    var PlaygroundRunner = {
+        init: function (hostEl, outputFn, exitFn) {
+            host = hostEl;
+            onOutput = outputFn;
+            onExit = exitFn || null;
+            ensureSpare();
+        },
+
+        // Ready means "a frame is standing by", which is what gates the buttons.
+        isReady: function () {
+            return !!(spare && spare.ready) || !!(current && current.ready && !current.used);
+        },
+
+        // Throw away the frame that ran (if any) and promote the pre-warmed one.
+        // Called before every run, and by Clear.
+        reset: function () {
+            if (current) { destroy(current); current = null; }
+            var out = document.getElementById("output");
+            if (out) out.classList.remove("with-canvas");
+            ensureSpare();
+        },
+
+        // files: { "main.das": "...", ... }  args: argv for callMain
+        // assets: URLs fetched into MEMFS before the program starts
+        run: function (files, args, assets) {
+            this.reset();
+            current = spare;
+            spare = null;
+            current.used = true;
+            send(current, { type: "run", files: files, args: args, assets: assets || [] });
+            // Warm the next one while this program runs, so the following Run
+            // click does not pay startup either.
+            ensureSpare();
+        },
+    };
+
+    window.PlaygroundRunner = PlaygroundRunner;
+})();

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -36,19 +36,27 @@
         return rec;
     }
 
-    // The frame IS the render surface, so it owns its geometry: a box matching
-    // the program's drawing-buffer aspect, clamped to the column. Without this
-    // the frame kept its 640x480 seed, the column squeezed the width, and the
-    // canvas — which scales to fit — left a black band below itself.
-    // !important because the column's stylesheet would otherwise stretch it.
+    // Height-led, the way the page has always actually presented the canvas:
+    // take most of the viewport height and derive width from the program's
+    // drawing-buffer aspect, giving back whatever the column cannot fit.
+    //
+    // Deliberately NOT clamped to 640. The old canvas code asked for a 640 box,
+    // but the column's stylesheet outvoted it, so every visitor has been seeing
+    // a ~1085px-wide render. A frame that honours the clamp is the first thing
+    // to shrink it, and a 1024x768 program downscaled into 640 loses exactly the
+    // thin, high-contrast detail — shadow edges, thin geometry — that reads as
+    // "the render went washed out".
+    var MAX_VIEWPORT_FRACTION = 0.8;
+
     function fit(rec) {
         if (!rec || !rec.el || rec.el.style.display === "none") return;
         // Measure the column, not the host — the host sizes to its content, so
         // asking it how wide it is would just echo the frame back.
         var column = host && host.parentElement;
-        var avail = Math.min(column ? column.clientWidth : 640, 640);
-        rec.el.style.setProperty("width", avail + "px", "important");
-        rec.el.style.setProperty("height", Math.round(avail * rec.aspect) + "px", "important");
+        var maxHeight = Math.round(window.innerHeight * MAX_VIEWPORT_FRACTION);
+        var width = Math.min(column ? column.clientWidth : 640, Math.round(maxHeight / rec.aspect));
+        rec.el.style.setProperty("width", width + "px", "important");
+        rec.el.style.setProperty("height", Math.round(width * rec.aspect) + "px", "important");
     }
 
     window.addEventListener("resize", function () { fit(current); });

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -21,6 +21,13 @@
     var onOutput = null;    // set by main.js: (text, color) => void
     var onExit = null;
 
+    // A spare that aborts never becomes ready, and readiness is what gates the Run
+    // button — so a single failed runtime fetch would leave the page dead until
+    // reload. Rebuild it instead, but bounded: if the runtime is genuinely
+    // unreachable, retrying forever just spawns frames.
+    var spareAborts = 0;
+    var MAX_SPARE_ABORTS = 3;
+
     function makeFrame() {
         var rec = { el: document.createElement("iframe"), ready: false, used: false };
         rec.el.src = FRAME_SRC;
@@ -86,6 +93,7 @@
         switch (msg.type) {
             case "ready":
                 rec.ready = true;
+                if (rec === spare) spareAborts = 0;
                 if (typeof window.updateButtonStates === "function") window.updateButtonStates();
                 if (rec.pending) { var p = rec.pending; rec.pending = null; send(rec, p); }
                 break;
@@ -97,6 +105,12 @@
                 break;
             case "aborted":
                 if (onOutput) onOutput("runtime aborted: " + msg.message, "#ff2d2d");
+                if (rec === spare) {
+                    destroy(spare);
+                    spare = null;
+                    if (++spareAborts <= MAX_SPARE_ABORTS) ensureSpare();
+                    if (typeof window.updateButtonStates === "function") window.updateButtonStates();
+                }
                 break;
             case "canvas-visible":
                 if (msg.width > 0 && msg.height > 0) rec.aspect = msg.height / msg.width;

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -26,14 +26,32 @@
         rec.el.src = FRAME_SRC;
         rec.el.className = "pg-run-frame";
         rec.el.setAttribute("title", "daslang program output");
-        // Sized to the same 4:3 box the old #canvas used; hidden until the
-        // program asks for a WebGL context (or forever, for text programs).
+        rec.aspect = 3 / 4;     // until the program reports its drawing buffer
+        // Hidden until the program asks for a WebGL context (or forever, for
+        // text programs). Geometry is fit() 's job — see below.
         rec.el.style.cssText =
             "display:none;width:640px;height:480px;border:1px solid #444;" +
             "background:#000;margin-top:20px;margin-bottom:6px;";
         host.appendChild(rec.el);
         return rec;
     }
+
+    // The frame IS the render surface, so it owns its geometry: a box matching
+    // the program's drawing-buffer aspect, clamped to the column. Without this
+    // the frame kept its 640x480 seed, the column squeezed the width, and the
+    // canvas — which scales to fit — left a black band below itself.
+    // !important because the column's stylesheet would otherwise stretch it.
+    function fit(rec) {
+        if (!rec || !rec.el || rec.el.style.display === "none") return;
+        // Measure the column, not the host — the host sizes to its content, so
+        // asking it how wide it is would just echo the frame back.
+        var column = host && host.parentElement;
+        var avail = Math.min(column ? column.clientWidth : 640, 640);
+        rec.el.style.setProperty("width", avail + "px", "important");
+        rec.el.style.setProperty("height", Math.round(avail * rec.aspect) + "px", "important");
+    }
+
+    window.addEventListener("resize", function () { fit(current); });
 
     function destroy(rec) {
         if (!rec) return;
@@ -73,7 +91,9 @@
                 if (onOutput) onOutput("runtime aborted: " + msg.message, "#ff2d2d");
                 break;
             case "canvas-visible":
+                if (msg.width > 0 && msg.height > 0) rec.aspect = msg.height / msg.width;
                 rec.el.style.display = "block";
+                fit(rec);
                 var out = document.getElementById("output");
                 if (out) out.classList.add("with-canvas");
                 break;

--- a/site/playground/run-frame.html
+++ b/site/playground/run-frame.html
@@ -24,10 +24,19 @@
   and talks to this frame only over postMessage.
 -->
 <style>
-    html, body { margin: 0; padding: 0; background: transparent; overflow: hidden; }
-    #canvas { display: block; width: 100%; height: 100%; border: 0; outline: none; }
+    html, body { margin: 0; padding: 0; height: 100%; background: transparent; overflow: hidden; }
+    /* Fill the frame exactly: the parent sizes the frame to the drawing buffer's
+       aspect, so 100%/100% scales without distorting. !important because
+       emscripten's GLFW writes an inline width/height onto the canvas. */
+    #canvas {
+        display: block;
+        width: 100% !important;
+        height: 100% !important;
+        border: 0;
+        outline: none;
+    }
 </style>
-<canvas id="canvas" tabindex="-1"></canvas>
+<canvas id="canvas" width="640" height="480" tabindex="-1"></canvas>
 <script>
 (function () {
     "use strict";
@@ -70,9 +79,14 @@
     // Reveal the canvas the instant ANY program asks it for a WebGL context. This
     // is program-driven rather than flag-driven, so pasted and edited code gets it
     // too, not just samples tagged graphics in data.json.
+    // The drawing buffer rides along so the parent can shape the frame to it
+    // instead of assuming 4:3 — a program that opens a 16:9 window then renders
+    // undistorted, and the aspect correction in its shaders stays honest.
     var origGetContext = canvas.getContext.bind(canvas);
     canvas.getContext = function (type) {
-        if (/webgl/i.test(String(type))) post({ type: "canvas-visible" });
+        if (/webgl/i.test(String(type))) {
+            post({ type: "canvas-visible", width: canvas.width, height: canvas.height });
+        }
         return origGetContext.apply(canvas, arguments);
     };
 

--- a/site/playground/run-frame.html
+++ b/site/playground/run-frame.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>daslang run frame</title>
+<!--
+  The playground's execution sandbox. One program per frame, ever.
+
+  The playground used to call Module.callMain() repeatedly inside a single wasm
+  instance, so every run inherited the previous run's world: registered daslang
+  modules, GL objects, globals. That is fine until a run FAILS — a program that
+  throws inside init() unwinds past main()'s cleanup, so Module::Shutdown() never
+  runs, and the next run trips the duplicate-module guard
+  (DAS_FATAL_ERROR "Module 'x' already created"). One bad sample poisoned the
+  whole session, and since a playground exists to run broken code, that was the
+  normal case rather than an edge case.
+
+  Restarting is what makes this structural: the parent throws the frame away and
+  builds a new one, so no error path can leak state because there is no state to
+  leak. It also gives the parent a kill switch for a hung program (previously a
+  wedged program locked the whole tab) and disposes of the canvas and its WebGL
+  context for free.
+
+  Everything the runtime touches lives in here: Module, MEMFS, the canvas, the
+  pthread pool, the AudioContext. The parent owns the editor and the output pane
+  and talks to this frame only over postMessage.
+-->
+<style>
+    html, body { margin: 0; padding: 0; background: transparent; overflow: hidden; }
+    #canvas { display: block; width: 100%; height: 100%; border: 0; outline: none; }
+</style>
+<canvas id="canvas" tabindex="-1"></canvas>
+<script>
+(function () {
+    "use strict";
+
+    var PARENT = window.parent;
+    var canvas = document.getElementById("canvas");
+
+    function post(msg) {
+        try { PARENT.postMessage(msg, window.location.origin); } catch (e) { /* parent gone */ }
+    }
+
+    // dasAudio creates an AudioContext deep inside the wasm run, after the click's
+    // synchronous frame, so browsers would leave it suspended. Wrap the constructor
+    // before daslang_static.js loads. The parent's Run click grants sticky
+    // activation, which is inherited here, so resume() is permitted.
+    (function installAudioUnlock() {
+        var OrigAC = window.AudioContext || window.webkitAudioContext;
+        if (!OrigAC) return;
+        var ctxs = new Set();
+        var Wrapped = function () {
+            var c = new OrigAC(...arguments);
+            ctxs.add(c);
+            try { c.resume(); } catch (e) {}
+            return c;
+        };
+        Wrapped.prototype = OrigAC.prototype;
+        window.AudioContext = Wrapped;
+        if (window.webkitAudioContext) window.webkitAudioContext = Wrapped;
+        var resumeAll = function () {
+            ctxs.forEach(function (c) {
+                if (c.state === "closed") ctxs.delete(c);
+                else if (c.state === "suspended") c.resume().catch(function () {});
+            });
+        };
+        ["pointerdown", "keydown", "click"].forEach(function (e) {
+            document.addEventListener(e, resumeAll, true);
+        });
+    })();
+
+    // Reveal the canvas the instant ANY program asks it for a WebGL context. This
+    // is program-driven rather than flag-driven, so pasted and edited code gets it
+    // too, not just samples tagged graphics in data.json.
+    var origGetContext = canvas.getContext.bind(canvas);
+    canvas.getContext = function (type) {
+        if (/webgl/i.test(String(type))) post({ type: "canvas-visible" });
+        return origGetContext.apply(canvas, arguments);
+    };
+
+    window.Module = {
+        canvas: canvas,
+        // Threaded build: pthread workers resolve their script from
+        // mainScriptUrlOrBlob. Name it explicitly — document.currentScript is null
+        // under some load paths, and the pool would otherwise spawn Worker(undefined).
+        mainScriptUrlOrBlob: "daslang_static.js",
+        preRun: [],
+        postRun: [],
+        print: function (text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(" ");
+            post({ type: "stdout", text: String(text) });
+        },
+        printErr: function (text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(" ");
+            post({ type: "stderr", text: String(text) });
+        },
+        onRuntimeInitialized: function () { post({ type: "ready" }); },
+        onAbort: function (err) { post({ type: "aborted", message: String(err) }); },
+    };
+
+    window.onerror = function (message) {
+        post({ type: "stderr", text: String(message) });
+    };
+
+    // --- the one program this frame will ever run ---------------------------
+
+    var didRun = false;
+
+    function writeFiles(files) {
+        var FS = window.Module.FS;
+        Object.keys(files || {}).forEach(function (name) {
+            try {
+                FS.writeFile(name, files[name]);
+            } catch (e) {
+                post({ type: "stderr", text: "FS error writing " + name + ": " + (e.message || e) });
+            }
+        });
+    }
+
+    // Assets a sample declares in its "<file>.das.assets.json" sidecar. Fetched
+    // here rather than in the parent because MEMFS lives in this frame; written at
+    // the exact cwd-relative path the program's fopen() expects.
+    async function preloadAssets(urls) {
+        if (!urls || !urls.length) return;
+        var FS = window.Module.FS;
+        for (const url of urls) {
+            try {
+                const resp = await fetch(url);
+                if (!resp.ok) throw new Error("HTTP " + resp.status);
+                const bytes = new Uint8Array(await resp.arrayBuffer());
+                const path = url.replace(/^\.?\//, "");
+                const dir = path.lastIndexOf("/") > 0 ? path.slice(0, path.lastIndexOf("/")) : "";
+                if (dir) {
+                    try { FS.mkdirTree("/" + dir); } catch (e) {}
+                }
+                FS.writeFile("/" + path, bytes);
+            } catch (e) {
+                post({ type: "stderr", text: "asset " + url + ": " + (e.message || e) });
+            }
+        }
+    }
+
+    // Emscripten's stdout/stderr TTYs line-buffer and flush only on '\n', so a
+    // final print() without a trailing newline leaves bytes pending and they
+    // never reach the panel. Synthesize a '\n' per stream that still holds
+    // bytes; the TTY flush hook turns it into a print with no spurious blank.
+    function flushStdio() {
+        var FS = window.Module.FS;
+        if (!FS || !FS.streams) return;
+        [1, 2].forEach(function (fd) {
+            var s = FS.streams[fd];
+            if (s && s.tty && s.tty.output && s.tty.output.length > 0 &&
+                s.tty.ops && typeof s.tty.ops.put_char === "function") {
+                s.tty.ops.put_char(s.tty, 10);
+            }
+        });
+    }
+
+    async function runProgram(msg) {
+        if (didRun) {
+            // A frame runs exactly one program. The parent is expected to build a
+            // new frame per run; refusing here keeps that contract honest rather
+            // than silently reintroducing the state leak this frame exists to stop.
+            post({ type: "stderr", text: "run-frame: refusing a second run in one frame" });
+            return;
+        }
+        didRun = true;
+        writeFiles(msg.files);
+        await preloadAssets(msg.assets);
+        var code = 0;
+        try {
+            window.Module.callMain(msg.args || ["main.das"]);
+            flushStdio();
+        } catch (e) {
+            flushStdio();
+            // Emscripten throws ExitStatus on a normal exit as well as on real errors.
+            if (e && typeof e.status === "number") {
+                code = e.status;
+            } else {
+                post({ type: "stderr", text: String((e && e.message) || e) });
+                code = -1;
+            }
+        }
+        post({ type: "exit", code: code });
+    }
+
+    window.addEventListener("message", function (ev) {
+        if (ev.origin !== window.location.origin) return;
+        var msg = ev.data;
+        if (!msg || typeof msg !== "object") return;
+        if (msg.type === "run") runProgram(msg);
+    });
+
+    // Load the runtime. `ready` fires from onRuntimeInitialized once wasm is live.
+    var s = document.createElement("script");
+    s.src = "daslang_static.js";
+    s.async = true;
+    s.onerror = function () {
+        post({ type: "aborted", message: "daslang_static.js failed to load" });
+    };
+    document.head.appendChild(s);
+})();
+</script>

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -6,6 +6,19 @@
 
 namespace das {
 
+    // Prefix for every local this pass manufactures. ONE leading underscore, not
+    // two: GLSL ES reserves any identifier containing `__`, and WebGL's compiler
+    // enforces it (desktop GL drivers do not), so a `__`-prefixed temp made every
+    // inlined shader helper fail to compile in the browser while working on the
+    // desktop. Emitting a name that is illegal in a target we support is the
+    // compiler's problem to avoid, not each backend's to sanitize. A single
+    // leading underscore is legal there and matches what the GLSL backend already
+    // generates for its own temps (`_for_range_vs`).
+    // nextInlineIdIn() parses ids straight back off this prefix, so generator and
+    // matcher must never drift — they share this constant and its length.
+    static const char * INLINE_TEMP_PREFIX = "_inl";
+    static const size_t INLINE_TEMP_PREFIX_LEN = 4;
+
     // ===== [inline] splicing, automatic block inlining, invoke devirtualization =====
     // Runs in the patch slot (Program::patchAnnotations -> patchInline), after infer and
     // buildAccessFlags, before lint and optimize. Splices are syntax-level: cloned callee
@@ -61,7 +74,7 @@ namespace das {
     //  (B) a pure (noSideEffects) non-leaf arg whose param is read at most once and not
     //      under a loop substitutes textually - evaluation can only become conditional
     //      (fewer evaluations of a pure expression), never repeated;
-    //  (C) everything else binds a `let/var __inl<N>_arg_<param>` temp at the statement
+    //  (C) everything else binds a `let/var _inl<N>_arg_<param>` temp at the statement
     //      anchor in call-argument order: impure args evaluate exactly once in call order,
     //      multi-read params bind once, `var` by-value params ARE the mutable local copy.
     //
@@ -429,7 +442,7 @@ namespace das {
 
         // rewrites a cloned callee subtree for splicing:
         //  * parameter reads become the planned substitution or a temp read
-        //  * local declarations and their reads get the __inl<N>_ prefix
+        //  * local declarations and their reads get the _inl<N>_ prefix
         //  * r2v flags are cleared: a callee from another module is post-optimize
         //    (ref folding turned r2v wrappers into flags), and the flag would survive
         //    re-infer inconsistently - infer re-derives value reads from scratch
@@ -1221,7 +1234,7 @@ namespace das {
         //    the last statement of every enclosing list - control after it is
         //    already function exit): stores substitute in place, zero overhead.
         //    ReturnCanonicalization manufactures these shapes ahead of candidacy.
-        //  * otherwise a generated `__inl<N>_ret : bool` guards the fallthrough:
+        //  * otherwise a generated `_inl<N>_ret : bool` guards the fallthrough:
         //    a return becomes `store; flag = true` (+ `break` under a loop), an
         //    inner loop that may have flagged gets `if (flag) break` right after it
         //    (the cascade), and at non-loop levels the statement tail wraps in
@@ -1910,13 +1923,13 @@ namespace das {
                 return privateUseCache[fn] = scan.verdict;
             }
 
-            // next free __inl counter across a subtree; names are function-scoped and
+            // next free _inl counter across a subtree; names are function-scoped and
             // later rounds keep splicing into the same function, so continue the sequence
             int nextInlineIdIn ( Expression * body ) {
                 int mx = 0;
                 auto consider = [&]( const string & name ) {
-                    if ( name.compare(0, 5, "__inl")==0 ) {
-                        int id = atoi(name.c_str()+5);
+                    if ( name.compare(0, INLINE_TEMP_PREFIX_LEN, INLINE_TEMP_PREFIX)==0 ) {
+                        int id = atoi(name.c_str()+INLINE_TEMP_PREFIX_LEN);
                         if ( id >= mx ) mx = id + 1;
                     }
                 };
@@ -2200,7 +2213,7 @@ namespace das {
                     if ( calleeFn->result && !calleeFn->result->isVoid() ) subjResult = calleeFn->result;
                     sa.ofs = 0; sa.params = &calleeFn->arguments;
                 }
-                // a callee body may itself contain manufactured __inl locals (interiors
+                // a callee body may itself contain manufactured _inl locals (interiors
                 // splice before their callers within a round, and the counter is
                 // function-scoped) - the site id must clear those too, or the rename map
                 // captures this site's synthesized names (the result store would retarget
@@ -2264,7 +2277,7 @@ namespace das {
                             argFlavorFail = true;
                             return;
                         }
-                        string tname = "__inl" + to_string(inlineId) + "_arg_" + P->name;
+                        string tname = INLINE_TEMP_PREFIX + to_string(inlineId) + "_arg_" + P->name;
                         bool viaClone = viaMove && init->type && init->type->constant;
                         temps.push_back(makeTemp(callLike->at, tname, init, cnst, ref, viaMove && !viaClone, viaClone));
                         sub.tempName = tname;
@@ -2480,7 +2493,7 @@ namespace das {
                     LocalNameCollect pnames;
                     pnames.rename = &rename;
                     pnames.canShadowArgs = &canShadowArgs;
-                    pnames.prefix = "__inl" + to_string(inlineId) + "_l_";
+                    pnames.prefix = INLINE_TEMP_PREFIX + to_string(inlineId) + "_l_";
                     body->visit(pnames);
                     // a substituted caller expression under a can_shadow block argument of the
                     // same name re-resolves to the block's variable - silently, that is what
@@ -2642,7 +2655,7 @@ namespace das {
                     }
                     auto & list = site.anchor.block->list;
                     if ( !rootVar ) {
-                        string tname = "__inl" + to_string(inlineId) + "_low";
+                        string tname = INLINE_TEMP_PREFIX + to_string(inlineId) + "_low";
                         inlineId ++;
                         // a non-const temp: a `var p = <temp>` consumer of pointer type
                         // rejects initialization from a const reference. a non-copyable
@@ -2714,7 +2727,7 @@ namespace das {
                 // ----- eager position: hoist the impure prefix, splice temps and body -----
                 // ALL declinable checks run BEFORE the prefix hoist mutates the statement: a
                 // `continue` after ReplaceNode has rewritten the statement discards the pending
-                // temp declarations but keeps the __inl<N>_pre* references, and the orphaned
+                // temp declarations but keeps the _inl<N>_pre* references, and the orphaned
                 // ExprVar later fails infer (30838) or segfaults the access-flags pass
                 vector<Expression *> prefix;
                 collectImpurePrefix(site.stmt, callLike, prefix);
@@ -2763,7 +2776,7 @@ namespace das {
                 // renamed locals live in the _l_ sub-namespace so a callee local named
                 // `res` (or `arg_x`, `pre0`, `low`) can never collide with the
                 // manufactured _res/_arg_*/_pre*/_low temps of the same site
-                names.prefix = "__inl" + to_string(inlineId) + "_l_";
+                names.prefix = INLINE_TEMP_PREFIX + to_string(inlineId) + "_l_";
                 body->visit(names);
                 bool captureRisk = false;
                 for ( auto & csn : canShadowArgs ) {
@@ -2777,7 +2790,7 @@ namespace das {
                 vector<ExpressionPtr> splice;
                 int preIdx = 0;
                 for ( auto pe : prefix ) {
-                    string tname = "__inl" + to_string(inlineId) + "_pre" + to_string(preIdx++);
+                    string tname = INLINE_TEMP_PREFIX + to_string(inlineId) + "_pre" + to_string(preIdx++);
                     // non-const temps throughout: the hoisted expression was a non-const
                     // rvalue (or keeps its lvalue constness via the reference binding), and
                     // a const temp read would no longer match var pointer params downstream
@@ -2836,9 +2849,9 @@ namespace das {
                     // (terminal shapes in place, the rest through a generated bool flag -
                     // see ReturnStoreRewrite). the standalone callee keeps its shape
                     ReturnStoreRewrite rsr;
-                    rsr.flagName = "__inl" + to_string(inlineId) + "_ret";
+                    rsr.flagName = INLINE_TEMP_PREFIX + to_string(inlineId) + "_ret";
                     if ( !isVoid ) {
-                        rsr.resName = "__inl" + to_string(inlineId) + "_res";
+                        rsr.resName = INLINE_TEMP_PREFIX + to_string(inlineId) + "_res";
                         splice.push_back(makeUninitDecl(callLike->at, rsr.resName, subjResult));
                     }
                     rsr.apply(bodyClone);

--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -216,7 +216,7 @@ namespace das {
         // initializer aliases — chase the init so the write reaches the true root (argument,
         // addr(...), another alias). without this a `let q = p; write-through-q` function is
         // judged pure and its calls are DCE'd, silently dropping the write (#3311 family);
-        // auto-inline's generated `let __inl*_arg_*` bindings are exactly this shape.
+        // auto-inline's generated `let _inl*_arg_*` bindings are exactly this shape.
         // conservative on purpose: a rebinding write (`q = null`) chases too — that only
         // over-marks, never drops. globals are excluded (covered by accessGlobal tracking).
         void propagateWriteThroughPointerAlias ( ExprVar * var ) {

--- a/web/examples/ui/samples/examples/arcanoid/main.das
+++ b/web/examples/ui/samples/examples/arcanoid/main.das
@@ -126,19 +126,19 @@ var @live audio_initialized = false
 
 def init_audio_samples() {
     // Paddle hit: chirp 440→880Hz, 50ms
-    snd_paddle_hit <- gen_sine_sweep(440.0, 880.0, 0.05, 0.3)
+    snd_paddle_hit <- gen_sine_sweep(440.0, 880.0, 0.05, 0.3)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     // Brick break: noise + sine
-    snd_brick_break <- gen_noise_burst(0.08, 0.15)
+    snd_brick_break <- gen_noise_burst(0.08, 0.15)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     let brick_tone <- gen_sine_sweep(600.0, 200.0, 0.08, 0.2)
     mix_into(snd_brick_break, brick_tone)
     // Wall bounce: short high tick
-    snd_wall_bounce <- gen_sine_sweep(1200.0, 800.0, 0.02, 0.15)
+    snd_wall_bounce <- gen_sine_sweep(1200.0, 800.0, 0.02, 0.15)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     // Ball miss: descending tone
-    snd_ball_miss <- gen_sine_sweep(440.0, 110.0, 0.3, 0.25)
+    snd_ball_miss <- gen_sine_sweep(440.0, 110.0, 0.3, 0.25)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     // Bonus pickup: bright rising chirp
-    snd_bonus_pickup <- gen_sine_sweep(600.0, 1200.0, 0.08, 0.25)
+    snd_bonus_pickup <- gen_sine_sweep(600.0, 1200.0, 0.08, 0.25)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     // Bonus bad: descending buzz
-    snd_bonus_bad <- gen_sine_sweep(400.0, 200.0, 0.1, 0.2)
+    snd_bonus_bad <- gen_sine_sweep(400.0, 200.0, 0.1, 0.2)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     // Win: ascending arpeggio
     let notes = fixed_array(523.0, 659.0, 784.0, 1047.0)  // C5 E5 G5 C6
     let note_dur = 0.12
@@ -619,11 +619,10 @@ def activate_bonus(btype : int) {
             positions |> push(b.pos)
             velocities |> push(b.vel)
         }
-        for (i in range(length(positions))) {
-            let p = positions[i]
-            let speed = length(velocities[i])
-            let vel1 = normalize(float3(velocities[i].x + sin(0.5) * speed * 0.3, 0.0, velocities[i].z)) * speed
-            let vel2 = normalize(float3(velocities[i].x + sin(-0.5) * speed * 0.3, 0.0, velocities[i].z)) * speed
+        for (p, v in positions, velocities) {
+            let speed = length(v)
+            let vel1 = normalize(float3(v.x + sin(0.5) * speed * 0.3, 0.0, v.z)) * speed
+            let vel2 = normalize(float3(v.x + sin(-0.5) * speed * 0.3, 0.0, v.z)) * speed
             create_entity() @(eid, cmp) {
                 apply_decs_template(cmp, Ball(pos = p, vel = vel1))
             }
@@ -1334,7 +1333,7 @@ def init() {
 }
 
 [export]
-def update() {
+def update() {  // nolint:STYLE037,STYLE038 -- game frame: input, sim, and render phases share mutable state
     if (!live_begin_frame()) {
         return
     }
@@ -1347,7 +1346,7 @@ def update() {
     glEnable(GL_CULL_FACE)
 
     let aspect = display_h != 0 ? float(display_w) / float(display_h) : 1.0
-    v_projection = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 100.0)
+    v_projection = perspective_rh_minus1_to_1(45.0 * PI / 180.0, aspect, 0.1, 100.0)
     v_view = look_at_rh(
         float3(0.0, 14.0, -4.0),
         float3(0.0, 0.0, 5.0),

--- a/web/examples/ui/samples/examples/gl_04_cube.das
+++ b/web/examples/ui/samples/examples/gl_04_cube.das
@@ -227,13 +227,13 @@ def update : bool {
     let aspect = float(display_w) / float(h)
 
     // camera orbits the cube; pass its world position to the fragment for the rim
-    let cam_pos = float3(cos(t * 0.5) * 4.0, 1.5, sin(t * 0.5) * 4.0)
+    let cam_pos = float3(cos(t * 0.5) * 5.0, 1.5, sin(t * 0.5) * 5.0)
     // breathing scale + tumble about a tilted axis
     let breathe = 1.0 + 0.05 * sin(t * 2.0)
     let rot = quat_from_unit_vec_ang(normalize(float3(1.0, 1.0, 0.0)), t * 0.6)
     u_model = compose(float3(0, 0, 0), rot, float3(breathe))
     u_view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 50.0)
+    u_proj = perspective_rh_minus1_to_1(45.0 * PI / 180.0, aspect, 0.1, 50.0)
     u_cam_pos = cam_pos
     u_time = t
 

--- a/web/examples/ui/samples/examples/gl_05_instancing.das
+++ b/web/examples/ui/samples/examples/gl_05_instancing.das
@@ -84,7 +84,7 @@ var window : GLFWwindow?
 var time : float = 0.0
 
 // 1000 small cubes -- comfortably visible at 640x480 with a ~6-unit swarm radius
-// and the camera orbiting at distance 14.
+// and the camera orbiting at distance 15.
 let N_INSTANCES = 1000
 
 [vertex_buffer]
@@ -215,10 +215,10 @@ def update : bool {
 
     // camera orbits the swarm with a gentle vertical sway to show depth
     let camera_angle = t * 0.3
-    let camera_r = 14.0
+    let camera_r = 15.0
     let cam_pos = float3(camera_r * cos(camera_angle), sin(camera_angle * 2.0) * 2.0, camera_r * sin(camera_angle))
     u_view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(60.0 * PI / 180.0, aspect, 0.1, 60.0)
+    u_proj = perspective_rh_minus1_to_1(60.0 * PI / 180.0, aspect, 0.1, 60.0)
     u_cam_pos = cam_pos
     u_time = t
 

--- a/web/examples/ui/samples/examples/gl_06_skybox.das
+++ b/web/examples/ui/samples/examples/gl_06_skybox.das
@@ -389,12 +389,12 @@ def update : bool {
 
     // camera orbits the sphere, slightly elevated, gently swaying
     let camera_angle = t * 0.4
-    let cam_pos = float3(cos(camera_angle) * 4.5, 2.2 + sin(camera_angle * 2.0) * 0.6, sin(camera_angle) * 4.5)
+    let cam_pos = float3(cos(camera_angle) * 5.5, 2.2 + sin(camera_angle * 2.0) * 0.6, sin(camera_angle) * 5.5)
     let target = float3(0.0, 0.9, 0.0)
     u_view_full = look_at_rh(cam_pos, target, float3(0, 1, 0))
     // rotation-only view: eye at the origin so the skybox cube stays centred on the camera
     u_view_rot = look_at_rh(float3(0, 0, 0), normalize(target - cam_pos), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(70.0 * PI / 180.0, aspect, 0.1, 50.0)
+    u_proj = perspective_rh_minus1_to_1(70.0 * PI / 180.0, aspect, 0.1, 50.0)
     u_cam_pos = cam_pos
     u_material = cycle_metal(t)
 

--- a/web/examples/ui/samples/examples/gl_07_particles.das
+++ b/web/examples/ui/samples/examples/gl_07_particles.das
@@ -233,10 +233,10 @@ def update : bool {
 
     // ===== Pass 2: render the freshly-written buffer as additive point sprites =====
     let cam_angle = t * 0.3
-    let cam_r = 3.0
+    let cam_r = 4.0
     let cam_pos = float3(cam_r * cos(cam_angle), sin(cam_angle * 2.0) * 0.5, cam_r * sin(cam_angle))
     u_view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(60.0 * PI / 180.0, aspect, 0.1, 30.0)
+    u_proj = perspective_rh_minus1_to_1(60.0 * PI / 180.0, aspect, 0.1, 30.0)
 
     glViewport(0, 0, display_w, display_h)
     glClearColor(0.02, 0.02, 0.05, 1.0)

--- a/web/examples/ui/samples/examples/gl_08_shadow.das
+++ b/web/examples/ui/samples/examples/gl_08_shadow.das
@@ -182,7 +182,7 @@ struct SceneVertex {
 }
 
 // Unit cube, 24 split vertices (one face-normal per corner) -- the same winding as
-// tutorial 04, proven correct under GL_BACK culling + perspective_rh_opengl. The
+// tutorial 04, proven correct under GL_BACK culling + perspective_rh_minus1_to_1. The
 // model matrix scales + hovers + spins it; here it spans [-1, 1] in object space.
 let cube_verts = [SceneVertex(
     pos=float3(1, 1, 1), normal=float3(0, 0, 1)), SceneVertex(
@@ -347,9 +347,9 @@ def update : bool {
 
     // Camera orbits the scene, slightly elevated.
     let cam_angle = t * 0.35
-    let cam_pos = float3(cos(cam_angle) * 5.0, 3.2, sin(cam_angle) * 5.0)
+    let cam_pos = float3(cos(cam_angle) * 6.0, 3.2, sin(cam_angle) * 6.0)
     u_view = look_at_rh(cam_pos, float3(0.0, CUBE_HOVER * 0.5, 0.0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 50.0)
+    u_proj = perspective_rh_minus1_to_1(50.0 * PI / 180.0, aspect, 0.1, 50.0)
     u_cam_pos = cam_pos
 
     // ===== Pass 1: shadow map from the light's point of view =====

--- a/web/examples/ui/samples/examples/gl_09_msaa.das
+++ b/web/examples/ui/samples/examples/gl_09_msaa.das
@@ -368,11 +368,11 @@ def update : bool {
     }
 
     // spinning ball, slowly orbiting camera -- the spin makes the 1x silhouette crawl
-    let cam_pos = float3(cos(t * 0.25) * 2.8, 0.9, sin(t * 0.25) * 2.8)
+    let cam_pos = float3(cos(t * 0.25) * 3.8, 0.9, sin(t * 0.25) * 3.8)
     let rot = quat_from_unit_vec_ang(normalize(float3(0.2, 1.0, 0.1)), t * 0.5)
     u_model = compose(float3(0, 0, 0), rot, float3(1.0))
     u_view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 50.0)
+    u_proj = perspective_rh_minus1_to_1(45.0 * PI / 180.0, aspect, 0.1, 50.0)
     u_cam_pos = cam_pos
     u_time = t
 

--- a/web/examples/ui/samples/examples/gl_10_deferred.das
+++ b/web/examples/ui/samples/examples/gl_10_deferred.das
@@ -256,7 +256,7 @@ def point_light(lp, lcol : float3; p, nrm, vdir : float3; shininess, spec_i, rng
 }
 
 [fragment_program]
-def lighting_fs {
+def lighting_fs {  // nolint:STYLE038 -- one fragment shader; its phases share registers
     // ----- bottom filmstrip: raw G-buffer (albedo / normal / world-pos) + SSAO + shadow -----
     let TH = 0.18
     let GAP = 0.012
@@ -597,7 +597,7 @@ def draw_scene_geometry {
 }
 
 [export]
-def update : bool {
+def update : bool {  // nolint:STYLE038 -- one frame: passes are FBO-bind-ordered, splitting hides the sequence
     time += 1.0 / 60.0
     let t = time
     var dw, dh : int
@@ -609,9 +609,9 @@ def update : bool {
     }
 
     let cam_angle = t * 0.3
-    let cam = float3(cos(cam_angle) * 4.6, 2.3, sin(cam_angle) * 4.6)
+    let cam = float3(cos(cam_angle) * 5.6, 2.3, sin(cam_angle) * 5.6)
     u_view = look_at_rh(cam, float3(0.0, 1.0, 0.0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(50.0 * PI / 180.0, float(w) / float(h), 0.1, 60.0)
+    u_proj = perspective_rh_minus1_to_1(50.0 * PI / 180.0, float(w) / float(h), 0.1, 60.0)
     u_cam_pos = cam
     let sun_yaw = t * 0.25
     let light_dir = normalize(float3(cos(sun_yaw) * 0.6, 1.05, sin(sun_yaw) * 0.6))

--- a/web/examples/ui/samples/examples/gl_11_hdr.das
+++ b/web/examples/ui/samples/examples/gl_11_hdr.das
@@ -408,7 +408,7 @@ def draw_fullscreen {
 }
 
 [export]
-def update : bool {
+def update : bool {  // nolint:STYLE038 -- one frame: passes are FBO-bind-ordered, splitting hides the sequence
     time += 1.0 / 60.0
     let t = time
     var display_w, display_h : int
@@ -417,10 +417,10 @@ def update : bool {
     // camera orbits the swarm with a gentle vertical sway; scene projection uses the
     // fixed HDR aspect since the scene renders into the HDR_W x HDR_H target.
     let camera_angle = t * 0.3
-    let camera_r = 14.0
+    let camera_r = 15.0
     let cam_pos = float3(camera_r * cos(camera_angle), sin(camera_angle * 2.0) * 2.0, camera_r * sin(camera_angle))
     u_view = look_at_rh(cam_pos, float3(0, 0, 0), float3(0, 1, 0))
-    u_proj = perspective_rh_opengl(60.0 * PI / 180.0, float(HDR_W) / float(HDR_H), 0.1, 60.0)
+    u_proj = perspective_rh_minus1_to_1(60.0 * PI / 180.0, float(HDR_W) / float(HDR_H), 0.1, 60.0)
     u_cam_pos = cam_pos
     u_time = t
 

--- a/web/examples/ui/samples/examples/pacman/main.das
+++ b/web/examples/ui/samples/examples/pacman/main.das
@@ -169,13 +169,13 @@ var @live snd_level_win   : array<float>
 var @live audio_initialized = false
 
 def init_audio_samples() {
-    snd_eat_pellet <- gen_sine_sweep(600.0, 400.0, 0.04, 0.15)
-    snd_eat_power <- gen_sine_sweep(300.0, 900.0, 0.12, 0.3)
-    snd_eat_ghost <- gen_sine_sweep(800.0, 1400.0, 0.1, 0.3)
-    snd_pac_die <- gen_sine_sweep(440.0, 110.0, 0.6, 0.3)
+    snd_eat_pellet <- gen_sine_sweep(600.0, 400.0, 0.04, 0.15)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
+    snd_eat_power <- gen_sine_sweep(300.0, 900.0, 0.12, 0.3)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
+    snd_eat_ghost <- gen_sine_sweep(800.0, 1400.0, 0.1, 0.3)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
+    snd_pac_die <- gen_sine_sweep(440.0, 110.0, 0.6, 0.3)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
     let extra <- gen_noise_burst(0.3, 0.1)
     mix_into(snd_pac_die, extra)
-    snd_level_win <- gen_sine_sweep(523.0, 1047.0, 0.5, 0.25)
+    snd_level_win <- gen_sine_sweep(523.0, 1047.0, 0.5, 0.25)  // nolint:PERF030 -- init_audio_samples runs once, behind the audio_initialized guard; target is still empty
 }
 
 def play_sfx(samples : array<float>) {
@@ -775,7 +775,7 @@ def update_scatter_chase(dt : float) {
 
 var @live pac_move_acc = 0.0  // sub-cell accumulator
 
-def update_pac(dt : float) {
+def update_pac(dt : float) {  // nolint:STYLE038 -- one tick of a state machine; the phases share mutable state
     if (pac_dead || game_state != GameState.playing) { return ; }
 
     // Read input → queue next direction
@@ -1111,7 +1111,7 @@ def init() {
 }
 
 [export]
-def update() {
+def update() {  // nolint:STYLE038 -- game frame: input, sim, and render phases share mutable state
     if (!live_begin_frame()) { return ; }
     live_get_framebuffer_size(display_w, display_h)
     glViewport(0, 0, display_w, display_h)
@@ -1122,7 +1122,7 @@ def update() {
     glEnable(GL_CULL_FACE)
 
     let aspect = display_h != 0 ? float(display_w) / float(display_h) : 1.0
-    v_projection = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 200.0)
+    v_projection = perspective_rh_minus1_to_1(50.0 * PI / 180.0, aspect, 0.1, 200.0)
     // Screen shake
     var shake_off = float2(0.0)
     if (shake_timer > 0.0) {

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -23,9 +23,14 @@ pageInit = function () {
     // for why (a failed run used to poison every later run in the session).
     // The frame reports its own canvas visibility, so the getContext hook and
     // the graphics/text auto-detect moved in there with it.
+    // Take the canvas's PLACE, not just its parent: the column is a flex row, so
+    // a frame merely appended lands past #output on the far right and gets
+    // shrunk. The host stands where the canvas stood and holds every frame.
     var oldCanvas = document.getElementById("canvas");
-    var runHost = oldCanvas ? oldCanvas.parentNode : editorOutput.parentNode;
-    if (oldCanvas) oldCanvas.remove();
+    var runHost = document.createElement("div");
+    runHost.className = "pg-run-host";
+    if (oldCanvas) oldCanvas.parentNode.replaceChild(runHost, oldCanvas);
+    else editorOutput.parentNode.insertBefore(runHost, editorOutput);
     PlaygroundRunner.init(runHost, function (text, color) { printOutput(text, color); });
 
     sampleList["examples"] = document.getElementById("examples");
@@ -230,32 +235,14 @@ function updateEngineAvailability(name) {
         });
 }
 
-// Force the canvas to a true 4:3 display box matching its 640x480 drawing buffer,
-// so the shader's aspect correction is right and rotations trace circles, not
-// ovals. Set inline with !important — the highest-priority source — because the
-// column's stylesheet otherwise stretches the canvas to ~80vh (portrait). Clamped
-// to the column width; re-applied on resize.
-// The run frame holds the canvas now, so sizing applies to the frame. Keep the
-// true 4:3 box the shaders' aspect correction assumes.
-function fitCanvas() {
-    const f = document.querySelector(".pg-run-frame");
-    if (!f || f.style.display === "none") return;
-    const avail = Math.min((f.parentElement ? f.parentElement.clientWidth : 640), 640);
-    f.style.setProperty("width", avail + "px", "important");
-    f.style.setProperty("height", Math.round(avail * 3 / 4) + "px", "important");
-}
-window.addEventListener("resize", fitCanvas);
-
-// Hide the run frame. Revealing it is the frame's own call — it posts
-// canvas-visible the instant a program asks for a WebGL context, which is
-// program-driven and so works for pasted code, not just samples flagged
-// graphics in data.json.
+// Hide the run frame. Revealing and sizing it is the runner's own job — the
+// frame posts canvas-visible the instant a program asks for a WebGL context,
+// which is program-driven and so works for pasted code, not just samples
+// flagged graphics in data.json.
 function showCanvas(show) {
     if (!show) {
         const f = document.querySelector(".pg-run-frame");
         if (f) f.style.display = "none";
-    } else {
-        fitCanvas();
     }
     const o = document.getElementById("output");
     if (o) o.classList.toggle("with-canvas", show);

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -8,61 +8,25 @@ var code;
 var sampleList = {"examples":null};
 
 
-// --- Audio autoplay unlock -------------------------------------------------
-// dasAudio programs (miniaudio's emscripten Web Audio / ScriptProcessor backend)
-// create an AudioContext deep inside the wasm run. The Run handler awaits
-// (preloadSampleAssets) before callMain, so the context is born after the click's
-// synchronous frame — browsers would leave it 'suspended'. We wrap AudioContext to
-// resume it on creation (the Run click gives sticky activation, so resume() is
-// allowed), and also resume on any later gesture. No-op for non-audio programs.
-// Installed at script-eval time, BEFORE pageInit loads daslang_static.js, so the
-// wasm's `new AudioContext()` sees the wrapper.
-(function installAudioUnlock() {
-    var OrigAC = window.AudioContext || window.webkitAudioContext;
-    if (!OrigAC) return;
-    var ctxs = new Set();
-    var Wrapped = function () {
-        var c = new OrigAC(...arguments);
-        ctxs.add(c);
-        try { c.resume(); } catch (e) {}
-        return c;
-    };
-    Wrapped.prototype = OrigAC.prototype;
-    window.AudioContext = Wrapped;
-    if (window.webkitAudioContext) window.webkitAudioContext = Wrapped;
-    var resumeAll = function () {
-        ctxs.forEach(function (c) {
-            if (c.state === "closed") ctxs.delete(c);          // drop dead contexts so the set can't grow across runs
-            else if (c.state === "suspended") c.resume().catch(function () {});
-        });
-    };
-    ["pointerdown", "keydown", "click"].forEach(function (e) { document.addEventListener(e, resumeAll, true); });
-})();
+// (the AudioContext autoplay unlock moved into run-frame.html — the wasm that
+// constructs the context lives there now, and the wrapper has to be installed in
+// that window before daslang_static.js loads)
 
 
 pageInit = function () {
 
-    $.getScript("daslang_static.js")
-
-
     editorCode = document.getElementById("code");
     editorOutput = document.getElementById("output");
 
-    // Bind the WebGL canvas so emscripten's GL (glfwCreateWindow → WebGL2) renders
-    // into it. AUTO-DETECT graphics vs text: hook getContext so the canvas reveals
-    // itself the instant ANY program creates a WebGL context on it — the precise,
-    // program-driven signal (works for pasted/edited code, not just flagged
-    // samples). The data.json "graphics" flag is only a pre-run hint for the
-    // sample picker. See showCanvas() / selectSample().
-    var glCanvas = document.getElementById("canvas");
-    if (glCanvas && typeof Module === "object" && Module) {
-        Module.canvas = glCanvas;
-        const origGetContext = glCanvas.getContext.bind(glCanvas);
-        glCanvas.getContext = function(type) {
-            if (/webgl/i.test(String(type))) showCanvas(true);
-            return origGetContext.apply(glCanvas, arguments);
-        };
-    }
+    // The runtime lives in run-frame.html, one frame per program — this page no
+    // longer loads daslang_static.js or owns a canvas. See playground-runner.js
+    // for why (a failed run used to poison every later run in the session).
+    // The frame reports its own canvas visibility, so the getContext hook and
+    // the graphics/text auto-detect moved in there with it.
+    var oldCanvas = document.getElementById("canvas");
+    var runHost = oldCanvas ? oldCanvas.parentNode : editorOutput.parentNode;
+    if (oldCanvas) oldCanvas.remove();
+    PlaygroundRunner.init(runHost, function (text, color) { printOutput(text, color); });
 
     sampleList["examples"] = document.getElementById("examples");
 
@@ -185,7 +149,6 @@ function deriveJitName(files) {
 // web-vs-desktop delta (desktop fopen hits real disk). Mirrors the standalone
 // gl_tutorial.html harness used to develop the rung.
 var currentAssetsUrl = null;
-var __preloadedManifests = new Set();
 
 function deriveAssetsUrl(files) {
     if (!files || files.length !== 1) return null;
@@ -195,30 +158,19 @@ function deriveAssetsUrl(files) {
 // Fetch the current sample's asset manifest (if any) and populate MEMFS. Idempotent
 // per manifest URL — MEMFS persists for the page session, so the (potentially large)
 // fetch happens once, not on every Run. Absent sidecar / a 404 is the normal case.
-async function preloadSampleAssets() {
-    if (!currentAssetsUrl || __preloadedManifests.has(currentAssetsUrl)) return;
-    if (typeof FS === 'undefined') return;
-    let assets;
+// Read the sidecar and hand the parsed list to the run frame, which does the
+// fetching — MEMFS lives in the frame now, and it is born empty with every run,
+// so the assets go in per run rather than once per page. The browser's HTTP
+// cache absorbs the repeat cost.
+async function collectAssetUrls() {
+    if (!currentAssetsUrl) return [];
     try {
         const r = await fetch(currentAssetsUrl);
-        if (!r.ok) { __preloadedManifests.add(currentAssetsUrl); return; }
-        assets = await r.json();
+        if (!r.ok) return [];   // absent sidecar is the normal case
+        const assets = await r.json();
+        return assets.map(rel => './' + rel);
     } catch (e) {
-        return; // transient network error — leave un-cached so the next Run retries
-    }
-    try {
-        for (const rel of assets) {
-            const resp = await fetch('./' + rel);
-            if (!resp.ok) throw new Error('HTTP ' + resp.status + ' fetching ' + rel);
-            const buf = new Uint8Array(await resp.arrayBuffer());
-            const path = '/' + rel;
-            try { FS.mkdirTree(path.substring(0, path.lastIndexOf('/'))); } catch (e) { /* exists */ }
-            FS.writeFile(path, buf);
-        }
-        __preloadedManifests.add(currentAssetsUrl);
-        printOutput('preloaded ' + assets.length + ' asset(s) for this sample', '#9fe');
-    } catch (e) {
-        printOutput('asset preload failed: ' + (e && e.message ? e.message : e), '#ff9393');
+        return [];  // transient network error — the next Run retries
     }
 }
 
@@ -283,24 +235,27 @@ function updateEngineAvailability(name) {
 // ovals. Set inline with !important — the highest-priority source — because the
 // column's stylesheet otherwise stretches the canvas to ~80vh (portrait). Clamped
 // to the column width; re-applied on resize.
+// The run frame holds the canvas now, so sizing applies to the frame. Keep the
+// true 4:3 box the shaders' aspect correction assumes.
 function fitCanvas() {
-    const c = document.getElementById("canvas");
-    if (!c || !c.classList.contains("is-graphics")) return;
-    const avail = Math.min((c.parentElement ? c.parentElement.clientWidth : 640), 640);
-    c.style.setProperty("width", avail + "px", "important");
-    c.style.setProperty("height", Math.round(avail * 3 / 4) + "px", "important");
+    const f = document.querySelector(".pg-run-frame");
+    if (!f || f.style.display === "none") return;
+    const avail = Math.min((f.parentElement ? f.parentElement.clientWidth : 640), 640);
+    f.style.setProperty("width", avail + "px", "important");
+    f.style.setProperty("height", Math.round(avail * 3 / 4) + "px", "important");
 }
 window.addEventListener("resize", fitCanvas);
 
-// Show/hide the WebGL canvas. Graphics programs render into it (item 0b's browser
-// loop); text programs keep it hidden. The output panel shrinks to share the
-// column so a graphics program can both draw (canvas) and print() (output below).
+// Hide the run frame. Revealing it is the frame's own call — it posts
+// canvas-visible the instant a program asks for a WebGL context, which is
+// program-driven and so works for pasted code, not just samples flagged
+// graphics in data.json.
 function showCanvas(show) {
-    const c = document.getElementById("canvas");
-    if (c) {
-        c.classList.toggle("is-graphics", show);
-        if (show) fitCanvas();
-        else { c.style.removeProperty("width"); c.style.removeProperty("height"); }
+    if (!show) {
+        const f = document.querySelector(".pg-run-frame");
+        if (f) f.style.display = "none";
+    } else {
+        fitCanvas();
     }
     const o = document.getElementById("output");
     if (o) o.classList.toggle("with-canvas", show);
@@ -374,11 +329,8 @@ loadSample = function(filesByName) {
     window.__pendingSampleBundle = bundle;
 }
 
-// Names of files we wrote to MEMFS on the previous run. Tracked so each new
-// run can unlink files the user has since deleted or renamed — otherwise
-// `require utils` would resolve stale code from the prior run, and the
-// executed program no longer matches the visible tab state.
-var __lastWrittenFiles = new Set();
+// (stale-file tracking is gone: every run gets a fresh MEMFS in a fresh frame,
+// so a deleted or renamed tab simply isn't written the next time)
 
 // Sync the URL hash with the current playground state. Run is the natural
 // "snapshot" moment — the address bar then IS the share link (no need to hunt
@@ -390,24 +342,18 @@ function syncUrlToState() {
     if (url && url !== location.href) history.pushState(null, '', url);
 }
 
-// Multi-file MEMFS sync: unlink stale, write current pgState files. Returns
-// true when both prerequisites are ready (pgState mounted AND Emscripten's
-// FS is up); false when either is still pending. Callers that fall back to
-// the single-buffer path must check WASM readiness themselves before touching
-// FS — see isWasmReady() and the runCode/runTests guards below.
-function syncMemFsFromState() {
-    if (!window.pgState || typeof FS === 'undefined') return false;
-    const current = new Set(Object.keys(window.pgState.files));
-    for (const stale of __lastWrittenFiles) {
-        if (!current.has(stale)) {
-            try { FS.unlink(stale); } catch (e) { /* ENOENT — ignore */ }
+// Snapshot the program as a {name: text} map for the run frame. Every run gets
+// a brand-new MEMFS inside a brand-new frame, so there is nothing stale to
+// unlink — deleting a tab simply means the file is absent from the next run.
+function collectProgramFiles() {
+    if (window.pgState && window.pgState.files) {
+        const out = {};
+        for (const [name, doc] of Object.entries(window.pgState.files)) {
+            out[name] = doc.getValue();
         }
+        if (Object.keys(out).length) return out;
     }
-    for (const [name, doc] of Object.entries(window.pgState.files)) {
-        FS.writeFile(name, doc.getValue());
-    }
-    __lastWrittenFiles = current;
-    return true;
+    return { 'main.das': code.getValue() };
 }
 
 // WASM readiness: callMain + FS both exposed by the Emscripten module. False
@@ -415,9 +361,7 @@ function syncMemFsFromState() {
 // or indefinitely if the load fails. Both Run and Test buttons stay disabled
 // until this flips to true (see updateButtonStates + Module.onRuntimeInitialized).
 function isWasmReady() {
-    return typeof FS !== 'undefined'
-        && typeof Module === 'object' && Module !== null
-        && typeof Module.callMain === 'function';
+    return typeof PlaygroundRunner !== 'undefined' && PlaygroundRunner.isReady();
 }
 
 // Toggle Run + Test buttons. Run requires WASM ready; Test additionally
@@ -453,33 +397,7 @@ function selectedEngine() {
     return el ? el.value : 'interpreter';
 }
 
-// Emscripten's stdout/stderr TTYs line-buffer bytes and flush only on '\n'.
-// daslang's last print() can omit the trailing newline (e.g. print("Hello")),
-// leaving those bytes pending in tty.output. They never surface in the output
-// panel — until the NEXT run writes a '\n', concatenating the prior tail with
-// the new run's first line. Fix: synthesize a '\n' through put_char per stream
-// that has pending bytes, which the TTY flush hook will turn into a print
-// without producing a spurious empty line.
-function flushStdioBuffers() {
-    if (typeof FS === 'undefined' || !FS.streams) return;
-    for (const fd of [1, 2]) {
-        const s = FS.streams[fd];
-        if (s && s.tty && s.tty.output && s.tty.output.length > 0 &&
-            s.tty.ops && typeof s.tty.ops.put_char === 'function') {
-            s.tty.ops.put_char(s.tty, 10);
-        }
-    }
-}
-
-// Module.callMain throws Emscripten's ExitStatus on normal exit AND can throw
-// user errors. Flush either way so the trailing print always lands in the panel.
-function callMainAndFlush(args) {
-    try {
-        Module.callMain(args);
-    } finally {
-        flushStdioBuffers();
-    }
-}
+// (stdout flushing moved into run-frame.html, where FS now lives)
 
 runCode = async function() {
     syncUrlToState();
@@ -491,24 +409,14 @@ runCode = async function() {
         runJit(currentJitName);
         return;
     }
-    // Interpreter path. WASM readiness gate first — both Module.callMain and
-    // the single-buffer fallback need FS up.
     if (!isWasmReady()) {
         printOutput('daslang is still loading, please wait…', '#ff9393');
         return;
     }
-    // Reset before each run: a text program leaves the canvas hidden; a graphics
-    // program re-reveals it the instant it creates a WebGL context (the
-    // getContext hook in pageInit). Detection is program-driven, not flagged.
+    // Each run gets a fresh frame, so the previous program's canvas, GL context,
+    // module registry and MEMFS are gone before this one starts.
     showCanvas(false);
-    // Populate MEMFS with any external assets this sample needs (mesh/textures)
-    // before the program's fopen() runs. No-op for samples without a manifest.
-    await preloadSampleAssets();
-    if (syncMemFsFromState()) {
-        callMainAndFlush(['main.das']);
-        return;
-    }
-    runScript(code.getValue());
+    PlaygroundRunner.run(collectProgramFiles(), ['main.das'], await collectAssetUrls());
 }
 
 // Invoke dastest against the current main.das. `[test]` functions in the file
@@ -517,16 +425,17 @@ runCode = async function() {
 // our printOutput doesn't render ANSI escapes. --timeout=0 disables dastest's
 // wall-clock thread (suite.das wraps each file in new_thread when timeout>0),
 // keeping the run single-threaded in the WASM build.
-runTests = function() {
+runTests = async function() {
     if (!isWasmReady()) {
         printOutput('daslang is still loading, please wait…', '#ff9393');
         return;
     }
-    if (!syncMemFsFromState()) {
-        FS.writeFile('main.das', code.getValue());
-    }
     syncUrlToState();
-    callMainAndFlush(['/dastest/dastest.das', '--', '--test', '/main.das', '--timeout=0']);
+    showCanvas(false);
+    PlaygroundRunner.run(
+        collectProgramFiles(),
+        ['/dastest/dastest.das', '--', '--test', '/main.das', '--timeout=0'],
+        await collectAssetUrls());
 }
 
 // Minimal wasi_snapshot_preview1 shim — daslang STANDALONE_WASM output only
@@ -682,6 +591,11 @@ clearOutput = function() {
     while (editorOutput.firstChild) {
         editorOutput.removeChild(editorOutput.lastChild);
     }
+    // Clear means clear: drop the frame so the previous program's canvas and its
+    // WebGL context go with it. Previously the canvas stuck around showing a dead
+    // program's last frame, which reads as "my run drew nothing".
+    if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.reset();
+    showCanvas(false);
 }
 
 
@@ -722,15 +636,7 @@ printOutput = function(text,color) {
 
 runScript = function(text,onComplete)
 {
-
-
-    FS.writeFile('main.das',text);
-    callMainAndFlush(['main.das']);
-
-
-
-
-    //printOutput(text,"#fff2d2");
+    PlaygroundRunner.run({ 'main.das': text }, ['main.das'], []);
 
     if (onComplete!==undefined)
         onComplete();
@@ -742,32 +648,9 @@ runScript = function(text,onComplete)
 
 
 
-var Module = {
-        // Threaded build: pthread workers load their script from Module.mainScriptUrlOrBlob, falling
-        // back to emscripten's _scriptName (= document.currentScript.src). We load daslang_static.js
-        // via $.getScript (XHR + eval), so document.currentScript is null during eval and _scriptName
-        // is undefined — the worker pool would then spawn `new Worker(undefined)`, 404 to an HTML page
-        // ("Unexpected token '<'"), and the threaded runtime would hang. Name the script explicitly.
-        mainScriptUrlOrBlob: "daslang_static.js",
-        preRun: [],
-        postRun: [],
-        print: (function() {
-
-            return function(text) {
-
-                if (arguments.length > 1)
-                    text = Array.prototype.slice.call(arguments).join(' ');
-                console.log(text);
-                printOutput(text,'#ffffff');
-            };
-        })(),
-        // Re-enable the Run / Test buttons once Emscripten has finished
-        // loading daslang_static.wasm and exposing FS + callMain. Both buttons
-        // ship disabled in index.html to avoid the early-click ReferenceError.
-        onRuntimeInitialized: function() {
-            if (typeof updateButtonStates === 'function') updateButtonStates();
-        },
-    }
+// No Module here any more: the wasm runtime, its stdout hooks and its readiness
+// signal all live in run-frame.html. playground-runner.js calls
+// updateButtonStates() when a frame reports ready.
 
 window.onerror = function(message)
 {

--- a/web/serve_playground.py
+++ b/web/serve_playground.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Local playground rig: serve the repo's playground sources over the same
+COOP/COEP headers production uses, so pthreads + SharedArrayBuffer behave.
+
+The wasm runtime itself (daslang_static.{js,wasm}) is NOT in the repo — it is a
+build artifact. Fetch it once from the live site into the serve dir:
+
+    python serve_playground.py --fetch-runtime
+
+Then just:
+
+    python serve_playground.py            # http://127.0.0.1:8791/playground/
+"""
+import argparse
+import functools
+import http.server
+import os
+import shutil
+import socketserver
+import sys
+import urllib.request
+
+REPO = os.environ.get("DASWEB_REPO", r"D:\Work\daScript-dasweb")
+SERVE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_serve")
+SITE = "https://daslang.io/"
+
+# repo path -> served path
+SOURCES = [
+    ("site/playground/index.html",            "playground/index.html"),
+    ("site/playground/run-frame.html",        "playground/run-frame.html"),
+    ("site/playground/playground-runner.js",  "playground/playground-runner.js"),
+    ("site/playground/playground-init.js",    "playground/playground-init.js"),
+    ("site/playground/playground-tabs.js",    "playground/playground-tabs.js"),
+    ("site/playground/playground-share.js",   "playground/playground-share.js"),
+    ("site/playground/playground-splitter.js","playground/playground-splitter.js"),
+    ("web/examples/ui/src/main.js",           "playground/main.js"),
+]
+
+# fetched from the live site: build artifacts + vendored libs, keyed by the path
+# the page requests them at (relative to the served root).
+RUNTIME = [
+    "playground/daslang_static.js",
+    "playground/daslang_static.wasm",
+    "playground/jquery-3.6.0.min.js",
+    "playground/samples/data.json",
+    "files/cm/codemirror.min.js",
+    "files/cm/codemirror.min.css",
+    "files/cm/simple-mode.js",
+    "files/cm/daslang-keywords.js",
+    "files/cm/daslang-mode.js",
+    "files/lz-string.min.js",
+]
+
+
+def stage():
+    for rel, dest in SOURCES:
+        src = os.path.join(REPO, rel.replace("/", os.sep))
+        dst = os.path.join(SERVE, dest.replace("/", os.sep))
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        if os.path.exists(src):
+            shutil.copy2(src, dst)
+        else:
+            print("  MISSING %s" % rel)
+    print("staged %d source file(s) from the repo" % len(SOURCES))
+
+
+def fetch_runtime():
+    for rel in RUNTIME:
+        dst = os.path.join(SERVE, rel.replace("/", os.sep))
+        if os.path.exists(dst) and os.path.getsize(dst) > 0:
+            print("  have %s" % rel)
+            continue
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        url = SITE + rel
+        print("  fetch %s" % url)
+        with urllib.request.urlopen(url) as r, open(dst, "wb") as f:
+            shutil.copyfileobj(r, f)
+    print("runtime staged")
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        # Production serves these on /playground*; pthreads need the isolation.
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def log_message(self, fmt, *args):
+        if "404" in (fmt % args):
+            sys.stderr.write("404 %s\n" % (args[0] if args else ""))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8791)
+    ap.add_argument("--fetch-runtime", action="store_true")
+    args = ap.parse_args()
+
+    os.makedirs(SERVE, exist_ok=True)
+    stage()
+    if args.fetch_runtime:
+        fetch_runtime()
+
+    os.chdir(SERVE)
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("127.0.0.1", args.port), Handler) as httpd:
+        print("serving %s at http://127.0.0.1:%d/playground/" % (SERVE, args.port))
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/web/serve_playground.py
+++ b/web/serve_playground.py
@@ -36,13 +36,21 @@ SOURCES = [
     ("web/examples/ui/src/main.js",           "playground/main.js"),
 ]
 
+# repo dir -> served dir, copied whole. The sample tree comes from the repo (not
+# the live site) so edits to a sample are testable before they ship.
+SOURCE_TREES = [
+    ("web/examples/ui/samples", "playground/samples"),
+    # what the samples' .das.assets.json sidecars fetch. The sidecar paths are
+    # relative, so they resolve against the frame's URL — under /playground/.
+    ("tutorials/_assets", "playground/tutorials/_assets"),
+]
+
 # fetched from the live site: build artifacts + vendored libs, keyed by the path
 # the page requests them at (relative to the served root).
 RUNTIME = [
     "playground/daslang_static.js",
     "playground/daslang_static.wasm",
     "playground/jquery-3.6.0.min.js",
-    "playground/samples/data.json",
     "files/cm/codemirror.min.js",
     "files/cm/codemirror.min.css",
     "files/cm/simple-mode.js",
@@ -61,7 +69,15 @@ def stage():
             shutil.copy2(src, dst)
         else:
             print("  MISSING %s" % rel)
-    print("staged %d source file(s) from the repo" % len(SOURCES))
+    for rel, dest in SOURCE_TREES:
+        src = os.path.join(REPO, rel.replace("/", os.sep))
+        dst = os.path.join(SERVE, dest.replace("/", os.sep))
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            print("  MISSING %s/" % rel)
+    print("staged %d source file(s) + %d tree(s) from the repo"
+          % (len(SOURCES), len(SOURCE_TREES)))
 
 
 def fetch_runtime():

--- a/web/serve_playground.py
+++ b/web/serve_playground.py
@@ -12,7 +12,6 @@ Then just:
     python serve_playground.py            # http://127.0.0.1:8791/playground/
 """
 import argparse
-import functools
 import http.server
 import os
 import shutil
@@ -20,8 +19,12 @@ import socketserver
 import sys
 import urllib.request
 
-REPO = os.environ.get("DASWEB_REPO", r"D:\Work\daScript-dasweb")
-SERVE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_serve")
+# Derived from this file's location, not hardcoded: the script lives in the tree it
+# serves, so a checkout or worktree other than the author's would otherwise stage the
+# WRONG tree's sources and say nothing about it. DASWEB_REPO still overrides.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.environ.get("DASWEB_REPO") or os.path.dirname(_HERE)
+SERVE = os.path.join(_HERE, "_serve")
 SITE = "https://daslang.io/"
 
 # repo path -> served path


### PR DESCRIPTION
Phase 2.5 of the dasweb arc. The report was "OpenGL examples on the playground, apart from the rotating triangle, are broken". Three bugs, none of them in the samples.

## 1. A failed run poisoned the whole session

Runs shared one wasm instance (`Module.callMain` re-entering `main()`), so every run inherited the previous run's world: registered daslang modules, GL objects, globals. Fine until a run FAILS — a program that throws inside `init()` unwinds past `main()`'s cleanup, `Module::Shutdown()` never runs, and the next run trips the duplicate-module guard (`DAS_FATAL_ERROR "Module 'x' already created"`). Repro, confirmed verbatim: run mandelbrot (fails) -> run arcanoid (fails to start) -> run arcanoid again (fatal).

Not sample-specific: **any** user program that throws in init poisoned that visitor's session until reload, and on a playground broken code is the normal case.

The runtime now lives in `run-frame.html`, one frame per program, thrown away afterwards. Restarting makes the clean slate structural instead of depending on every error path being tidy — which try/catch could not have guaranteed, since it only covers the paths we remember. Measured on the live site: **~250 ms median** to a usable runtime, and a spare frame is pre-warmed while your program runs, so the next Run pays none of it.

Two problems come free with the boundary. A hung program used to wedge the whole tab (observed: navigation itself timed out). And Clear only ever emptied the text pane, so the previous program's canvas and its live WebGL context stayed on screen, reading as "my run drew nothing".

## 2. The inliner emitted names GLSL forbids

Auto-inlining manufactured locals named `__inl<N>_*`. **GLSL ES reserves any identifier containing `__`** and WebGL's compiler enforces it, while desktop GL drivers do not — so every shader with an inlined helper compiled on the desktop and failed in the browser. `gl_02` mandelbrot died with 100+ errors.

The prefix is now `_inl<N>_*`, one underscore. Fixed in the compiler rather than sanitized in dasGlsl: emitting a name that is illegal in a target we support is the compiler's problem to avoid, not each backend's to paper over.

**This broke LINT004 repo-wide, which is also fixed here.** LINT004 flags a used variable whose name starts with an underscore, and skipped `__name` as "system" — that skip is what kept the inliner's renamed callee locals quiet. Dropping to one underscore put them in its sights: 6 hits on an untouched `daslib/strings_boost.das`, and the CI lint lane would have failed on essentially any changed-file set. Those locals cannot be marked `generated` (they ARE user variables — the inliner renames a callee's own locals into a per-site namespace), so the skip is by name alongside the existing two markers. The digit test keeps a user's `_inline_count` in scope; verified both ways by probe.

## 3. The samples now use the corrected projection

`perspective_rh_opengl` leaves `m[3][3]` at 1, so `clip.w` is `-z+1` instead of `-z`. All ten playground samples that called it now call `perspective_rh_minus1_to_1`.

The error is depth-dependent — the `+1` matters up close and fades with distance — so no fov or distance tweak reproduces the old image exactly. What DOES restore the framing exactly is **one unit of camera distance**: dividing by `d+1` is what the correct projection gives at `d+1`, and moving the eye along the view axis adds exactly 1 to every vertex's depth. So each orbiting sample's radius goes up by 1.0 and the composition is preserved rather than re-tuned by eye. The two games keep their cameras: at 17 and 30 units the shift is 6% and 3%.

## 4. Frame geometry and scale

The frame was appended after `#output` in a flex column, so it rendered at the far right, squeezed to 422px, with the canvas scaling to fit and leaving a black band. The host now takes the canvas's place in the DOM and the runner owns geometry.

Sizing is height-led and **not clamped to 640**. The old canvas code asked for a 640 box, but the column's stylesheet outvoted it, so production has always shown a ~1085px render; a frame is the first thing to actually win that argument, and a 1024x768 program resampled down to 62% loses exactly the thin high-contrast detail — shadow edges, glyph spacing — that reads as "the render is washed out". Arcanoid now lands at 1131x848 (1.10x, production 1.06x), the glTF capstone's 1280x720 at 1263x710 — no resample at all.

## Verification

Local rig, all 12 GL samples in one session: **12 draw, 0 deprecation warnings, 0 exceptions**. Lint clean on the 12 changed `.das` files; `dasfmt --verify` clean tree-wide (3820 files).

`web/serve_playground.py` is added: serves the repo's playground sources under production's COOP/COEP headers, staging the repo's own sample tree and `tutorials/_assets` so a sample edit is testable before it ships. This is what made all of the above verifiable.

## Open before merge

**A shadow-rendering difference between this branch's wasm and production's.** Arcanoid's planar shadows render correctly on the live site — measured `(33,27,44)`, exactly floor blended 50/50 with `SHADOW_COLOR` — and render as lit-geometry grey `(97,91,108)` under a wasm built from this branch. Reproduced with the *old* projection and unmodified sample source, so it is neither the sweep nor the samples; the only remaining variable is the build. Not yet root-caused. The inliner prefix change is the obvious suspect to rule in or out — running arcanoid natively against desktop GL separates "codegen broke" from "ANGLE-only" — but production's wasm is also many master commits behind, so it may not originate here.

`plans/dasweb_wasm_pipeline.md` rides along (phase-3 planning doc from earlier in the arc), flagged per the `.md` review rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
