### PR TITLE
dasweb: fix the baked-exe shared-module bug, and build graphics samples as wasm pages

### DIFF
--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -1042,11 +1042,9 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef; // noli
         )
     )
     var jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module_resolve", reg_dyn_mod_type)
-    var registered_dynamic = false
     for_each_registered_dynamic_module() $(path, mod_name, das_name) {
         if (key_exists(used_modules, das_name) || key_exists(force_dynamic_modules, das_name)) {
             has_cpp_modules = true
-            registered_dynamic = true
             to_log(LOG_INFO, "LLVM EXE: include dynamic module: `{das_name}`\n")
             let rel = compute_modules_relative_suffix(path)
             let rel_str = get_string_constant_ptr(builder, rel)
@@ -1055,14 +1053,6 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef; // noli
             LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
-    // Retry the Quiet registrations above, then fatal (naming module + dlopen error) on any
-    // still unloadable — instead of the cryptic extern-lookup death. Native only: on wasm the
-    // same modules also register via static thunks and the failed resolve is BY DESIGN.
-    if (registered_dynamic && !g_target_is_wasm) {
-        var fin_dyn = LLVMAddFunctionWithType(g_mod, "jit_finalize_dynamic_modules", das_ensure_env_type)
-        LLVMBuildCall2(builder, das_ensure_env_type, fin_dyn, array<LLVMValueRef>(), "")
-    }
-
     // -list-shared-modules <path> side-effect: dump the release-deps JSON
     // for `daspkg release` to ship dylibs + traverse dep packages.
     write_release_deps(prog)
@@ -1090,6 +1080,15 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef; // noli
         init_modules_fn = LLVMAddFunctionWithType(g_mod, "initialize_modules", init_modules_type)
     }
     LLVMBuildCall2(builder, init_modules_type, init_modules_fn, array<LLVMValueRef>(), "")
+
+    // Dynamic modules load Quiet (sibling DT_NEEDED ordering): retry after the last registration
+    // and fatal on anything still unloadable, naming the module + dlopen error. Native only — on
+    // wasm those modules also register via static thunks, so the failed resolve is BY DESIGN.
+    if (ships_dynamic && !g_target_is_wasm) {
+        let fin_dyn_type = LLVMFunctionType(types.t_void, array<LLVMTypeRef>())
+        var fin_dyn = LLVMAddFunctionWithType(g_mod, "jit_finalize_dynamic_modules", fin_dyn_type)
+        LLVMBuildCall2(builder, fin_dyn_type, fin_dyn, array<LLVMValueRef>(), "")
+    }
 
     // Init argc, argv
     let set_cmd_args_type = LLVMFunctionType(types.t_void,

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -142,7 +142,7 @@ class public CollectExternVisitor : AstVisitor {
         return ib
     }
 
-    def CollectExternVisitor(standalone_context : LLVMOpaqueValue?; _ctx : LLVMContextRef;
+    def CollectExternVisitor(standalone_context : LLVMOpaqueValue?; _ctx : LLVMContextRef; // nolint:STYLE038 — LLVM type-table setup: one cached type/fn-type per line
                              _builder : LLVMBuilderRef,
                              _mod : LLVMOpaqueModule?; var _types : PrimitiveTypes?,
                              uids : UidNodes?; register_all : bool; _jit_mod : LlvmJitMode) {
@@ -549,8 +549,8 @@ class public CollectExternVisitor : AstVisitor {
     }
 }
 
-def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVMContextRef; builder : LLVMBuilderRef,
-                               mod : LLVMOpaqueModule?; var types : PrimitiveTypes?;
+def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVMContextRef; builder : LLVMBuilderRef, // nolint:STYLE038 — flat emission walk: one registration form per function class
+                               mod : LLVMOpaqueModule ?; var types : PrimitiveTypes?;
                                var funcs : array<FunctionPtr>; var uids : UidNodes?;
                                var used_modules : table<string; bool>&;
                                dynamic_modules : table<string; bool>;
@@ -884,8 +884,8 @@ def private emit_module_registration(m : Module?; dynamic_modules : table<string
 
 // Creates main function that initializes a standalone JIT context, registers
 // all compiled functions, runs init scripts, then calls the program entry point.
-def public inject_main(program_context : Context?; ctx : LLVMContextRef;
-                       prog : Program?; entry_point : string; mod : LLVMOpaqueModule?;
+def public inject_main(program_context : Context?; ctx : LLVMContextRef; // nolint:STYLE037,STYLE038 — the standalone-exe entry emitter: one emission block per runtime feature, in startup order
+                       prog : Program ?; entry_point : string; mod : LLVMOpaqueModule?;
                        var types : PrimitiveTypes?, var uids : UidNodes?; strict : bool;
                        register_all_modules : bool = false) : tuple<fn : LLVMOpaqueValue?; link_whole_lib : bool> {
     g_exe_emitted_reg |> clear()   // per-codegen-run: one registration call per module thunk
@@ -1042,9 +1042,11 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
         )
     )
     var jit_reg_dyn_mod = LLVMAddFunctionWithType(g_mod, "jit_register_dynamic_module_resolve", reg_dyn_mod_type)
+    var registered_dynamic = false
     for_each_registered_dynamic_module() $(path, mod_name, das_name) {
         if (key_exists(used_modules, das_name) || key_exists(force_dynamic_modules, das_name)) {
             has_cpp_modules = true
+            registered_dynamic = true
             to_log(LOG_INFO, "LLVM EXE: include dynamic module: `{das_name}`\n")
             let rel = compute_modules_relative_suffix(path)
             let rel_str = get_string_constant_ptr(builder, rel)
@@ -1052,6 +1054,13 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
             let name_str = get_string_constant_ptr(builder, mod_name)
             LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
+    }
+    // The registrations above load Quiet (sibling DT_NEEDED ordering); the retry pass runs here,
+    // and anything still unloadable becomes a fatal naming the module + dlopen error instead of
+    // a later cryptic "Failed to find <fn> in module <mod>" on the first extern lookup.
+    if (registered_dynamic) {
+        var fin_dyn = LLVMAddFunctionWithType(g_mod, "jit_finalize_dynamic_modules", das_ensure_env_type)
+        LLVMBuildCall2(builder, das_ensure_env_type, fin_dyn, array<LLVMValueRef>(), "")
     }
 
     // -list-shared-modules <path> side-effect: dump the release-deps JSON
@@ -1168,6 +1177,12 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef;
     // jit_register_all_builtin_modules calls register_builtin_modules, which lives only in the
     // compiler lib — so this flag forces a whole-lib link (else "undefined reference" at link).
     if (register_all_modules) {
+        needs_whole_lib = true
+    }
+    // Every .shared_module NEEDs the FULL liblibDaScriptDyn, and dlopen resolves that only from
+    // libs already in-process or on the .so's own RUNPATH (never the exe's). A runtime-only exe
+    // fails every module dlopen silently, so shipping a dynamic module forces the full-lib link.
+    if (ships_dynamic) {
         needs_whole_lib = true
     }
 

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -1055,10 +1055,10 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef; // noli
             LLVMBuildCall2(builder, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
-    // The registrations above load Quiet (sibling DT_NEEDED ordering); the retry pass runs here,
-    // and anything still unloadable becomes a fatal naming the module + dlopen error instead of
-    // a later cryptic "Failed to find <fn> in module <mod>" on the first extern lookup.
-    if (registered_dynamic) {
+    // Retry the Quiet registrations above, then fatal (naming module + dlopen error) on any
+    // still unloadable — instead of the cryptic extern-lookup death. Native only: on wasm the
+    // same modules also register via static thunks and the failed resolve is BY DESIGN.
+    if (registered_dynamic && !g_target_is_wasm) {
         var fin_dyn = LLVMAddFunctionWithType(g_mod, "jit_finalize_dynamic_modules", das_ensure_env_type)
         LLVMBuildCall2(builder, das_ensure_env_type, fin_dyn, array<LLVMValueRef>(), "")
     }

--- a/site/playground/playground-wasm.js
+++ b/site/playground/playground-wasm.js
@@ -96,7 +96,8 @@
             if (!status.files || !status.files.length) {
                 return { ok: false, error: 'build reported done with no artifact' };
             }
-            return { ok: true, files: status.files, hash };
+            // kind: 'module' (bare wasi .wasm) or 'page' (standalone html+js+wasm)
+            return { ok: true, kind: status.kind || 'module', files: status.files, hash };
         }
         if (status.state === 'failed') {
             return { ok: false, error: status.error || 'build failed', compileError: true };

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -184,6 +184,48 @@ test('a page-kind build runs as an embedded page frame', async ({ playground }) 
     await expect(playground.locator('iframe.pg-page-frame')).toHaveCount(0, { timeout: 5_000 });
 });
 
+test('a module-kind run clears a previous page frame', async ({ playground }) => {
+    // Edit a graphics sample into a compute-only one and the next build comes
+    // back kind:'module'. Without an explicit teardown on that path the old page
+    // keeps rendering while the module run prints — a dead program's last frame
+    // on screen, which is what the run frame exists to prevent.
+    const PAGE_URL = '/api/build/artifact/abc1234/' + FAKE_HASH + '/sample.html';
+    await stubBuildInfo(playground, true);
+    await stubStore(playground);
+    await playground.route('**' + PAGE_URL, route => route.fulfill({
+        status: 200, contentType: 'text/html', body: '<html><body>stale page</body></html>',
+    }));
+    await playground.route('**' + ARTIFACT_URL, route => route.fulfill({
+        status: 200,
+        contentType: 'application/wasm',
+        body: Buffer.from([0, 0x61, 0x73, 0x6d, 1, 0, 0, 0]),
+    }));
+
+    // First build: page. Second: module. One status stub, two scripted rounds.
+    let round = 0;
+    await playground.route('**/api/build/request/**', route => {
+        round++;
+        return route.fulfill({
+            status: 200, contentType: 'application/json',
+            body: JSON.stringify(round === 1
+                ? { state: 'done', kind: 'page', toolchain: 'abc1234', files: [PAGE_URL] }
+                : { state: 'done', kind: 'module', toolchain: 'abc1234', files: [ARTIFACT_URL] }),
+        });
+    });
+    await reloadWithStubs(playground);
+
+    const memory64 = await playground.evaluate(() =>
+        WebAssembly.validate(new Uint8Array([0, 0x61, 0x73, 0x6d, 1, 0, 0, 0, 5, 3, 1, 4, 1])));
+    test.skip(!memory64, 'browser lacks wasm64/memory64');
+
+    await playground.locator(wasmSel).check();
+    await playground.locator('#run').click();
+    await expect(playground.locator('iframe.pg-page-frame')).toHaveCount(1, { timeout: 15_000 });
+
+    await playground.locator('#run').click();
+    await expect(playground.locator('iframe.pg-page-frame')).toHaveCount(0, { timeout: 15_000 });
+});
+
 test('a failed build shows the compiler error', async ({ playground }) => {
     await stubBuildInfo(playground, true);
     await stubStore(playground);

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -139,6 +139,51 @@ test('a queued build narrates its progress and then runs', async ({ playground }
     await expect.poll(() => playground.locator('#run').isDisabled(), { timeout: 15_000 }).toBe(false);
 });
 
+test('a page-kind build runs as an embedded page frame', async ({ playground }) => {
+    // Graphics/audio samples build as standalone html+js+wasm pages (kind:
+    // 'page'); the playground embeds the html artifact in an iframe instead of
+    // instantiating a bare module. Served absolute from the run origin in
+    // production — here same-origin, which the embed path treats identically.
+    const PAGE_URL = '/api/build/artifact/abc1234/' + FAKE_HASH + '/sample.html';
+    await stubBuildInfo(playground, true);
+    await stubStore(playground);
+    await stubBuild(playground, [
+        { state: 'queued', position: 1 },
+        {
+            state: 'done', kind: 'page', toolchain: 'abc1234',
+            files: [PAGE_URL,
+                '/api/build/artifact/abc1234/' + FAKE_HASH + '/sample.js',
+                '/api/build/artifact/abc1234/' + FAKE_HASH + '/sample.wasm'],
+        },
+    ]);
+    await playground.route('**' + PAGE_URL, route => route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>page artifact stands</body></html>',
+    }));
+    await reloadWithStubs(playground);
+
+    const memory64 = await playground.evaluate(() =>
+        WebAssembly.validate(new Uint8Array([0, 0x61, 0x73, 0x6d, 1, 0, 0, 0, 5, 3, 1, 4, 1])));
+    test.skip(!memory64, 'browser lacks wasm64/memory64');
+
+    await playground.locator(wasmSel).check();
+    await playground.locator('#run').click();
+
+    const frame = playground.locator('iframe.pg-page-frame');
+    await expect(frame).toHaveCount(1, { timeout: 15_000 });
+    expect(await frame.getAttribute('src')).toContain('sample.html');
+    // No sandbox attribute BY DESIGN: it would opaque the origin and break
+    // emscripten's same-origin worker spawning — the separate run origin is
+    // the isolation boundary.
+    expect(await frame.getAttribute('sandbox')).toBeNull();
+    expect(await frame.getAttribute('allow')).toContain('cross-origin-isolated');
+
+    // Switching samples clears the page frame with the canvas.
+    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
+    await expect(playground.locator('iframe.pg-page-frame')).toHaveCount(0, { timeout: 5_000 });
+});
+
 test('a failed build shows the compiler error', async ({ playground }) => {
     await stubBuildInfo(playground, true);
     await stubStore(playground);

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -1287,6 +1287,9 @@ namespace das {
         }
     }
 
+    // from module_builtin_fio.cpp — modules whose .shared_module dlopen failed (Quiet)
+    DAS_API string describe_pending_dynamic_modules();
+
     ProgramPtr reportPrerequisitesErrors (
             string fileName,
             vector<MissingRecord> & missing,
@@ -1318,6 +1321,7 @@ namespace das {
         TextWriter err;
         LineInfo at;
         bool first = true;
+        bool anyNotFound = false;
         for ( auto & mis : missing ) {
             if ( first && !mis.chain.empty() ) {
                 at.fileInfo = mis.chain.back();
@@ -1329,6 +1333,7 @@ namespace das {
             switch ( mis.hintType ) {
                 case MissingHint::FileNotFound: {
                     err << "missing prerequisite '" << mis.name << "'; file not found\n";
+                    anyNotFound = true;
                     break;
                 }
                 case MissingHint::WrongModuleName: {
@@ -1354,6 +1359,14 @@ namespace das {
                 }
             }
             reportChain(err, mis.chain);
+        }
+        // A native module whose .shared_module failed to dlopen reports as "file not found",
+        // which reads as a path typo. Name the load failures so the real cause is visible.
+        if ( anyNotFound ) {
+            auto pendingNote = describe_pending_dynamic_modules();
+            if ( !pendingNote.empty() ) {
+                err << "note: these dynamic modules failed to load — a missing module may live in one of them:\n" << pendingNote;
+            }
         }
         for ( auto & mis : circular ) {
             if ( first && !mis.chain.empty() ) {

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -284,6 +284,8 @@ namespace das {
     void * register_dynamic_module ( const char *, const char *, int, Context *, LineInfoArg * ) GENERATE_IO_STUB_RET
     void register_native_path ( const char *, const char *, const char *, Context *, LineInfoArg * ) GENERATE_IO_STUB
     DAS_API void retry_pending_dynamic_modules () GENERATE_IO_STUB
+    DAS_API string describe_pending_dynamic_modules () GENERATE_IO_STUB_RET
+    DAS_API int report_pending_dynamic_modules () GENERATE_IO_STUB_RET
 
 #undef GENERATE_IO_STUB
 #undef GENERATE_IO_STUB_RET
@@ -1908,7 +1910,7 @@ namespace das {
     // DT_NEEDED dependency (e.g. node-editor -> dasModuleImgui) not yet loaded.
     // retry_pending_dynamic_modules() re-attempts these in fixed-point passes
     // after the folder scan, so module enumeration order stops mattering.
-    static vector<tuple<string,string>> g_pending_dynamic_modules; // path, cpp_class_name
+    static vector<tuple<string,string,string>> g_pending_dynamic_modules; // path, cpp_class_name, last dlopen error
 
     // Env-gated per-attempt module-load trace (default off). Set
     // DAS_TRACE_MODULE_LOAD=1 to surface each dlopen — turns a swallowed
@@ -1956,7 +1958,7 @@ namespace das {
                 // (module .so's live in modules/<dep>/, not on RUNPATH, so a dependent
                 // enumerated before its dependency fails dlopen). Defer; the post-scan
                 // retry_pending_dynamic_modules() re-attempts once deps are loaded.
-                g_pending_dynamic_modules.emplace_back(string(path), string(mod_name));
+                g_pending_dynamic_modules.emplace_back(string(path), string(mod_name), dlErr);
             }
             return nullptr;
         }
@@ -2003,7 +2005,7 @@ namespace das {
         bool progress = true;
         while (progress && !g_pending_dynamic_modules.empty()) {
             progress = false;
-            vector<tuple<string,string>> pending;
+            vector<tuple<string,string,string>> pending;
             pending.swap(g_pending_dynamic_modules); // drain; failures re-push into the now-empty global
             for (auto & pr : pending) {
                 if (register_dynamic_module(get<0>(pr).c_str(), get<1>(pr).c_str(),
@@ -2012,6 +2014,31 @@ namespace das {
                 }
             }
         }
+    }
+
+    // One line per still-pending (dlopen-failed) module: "  dasModuleGlfw <- <path> (<dlerror>)".
+    // Empty string when nothing is pending. Compile-error paths append this to the misleading
+    // "missing prerequisite ...; file not found" so a load failure stops reading as a path typo.
+    DAS_API string describe_pending_dynamic_modules() {
+        TextWriter tw;
+        for (auto & pr : g_pending_dynamic_modules) {
+            tw << "  " << get<1>(pr) << " <- " << get<0>(pr);
+            if (!get<2>(pr).empty()) tw << " (" << get<2>(pr) << ")";
+            tw << "\n";
+        }
+        return tw.str();
+    }
+
+    // Standalone-exe epilogue to the per-module Quiet registrations: everything the exe
+    // registers is REQUIRED by its program, so a module still pending after the retry pass
+    // is a hard failure — report it loudly instead of dying later on the first extern
+    // lookup with an unrelated-looking "Failed to find <fn> in module <mod>" fatal.
+    DAS_API int report_pending_dynamic_modules() {
+        for (auto & pr : g_pending_dynamic_modules) {
+            LOG(LogLevel::error) << "dynamic module `" << get<1>(pr) << "` failed to load: " << get<0>(pr)
+                << (get<2>(pr).empty() ? string() : (" (" + get<2>(pr) + ")")) << "\n";
+        }
+        return int(g_pending_dynamic_modules.size());
     }
 
     void register_native_path(const char *mod_name, const char *src_path, const char *dst_path, Context * /*context*/, LineInfoArg * /*at*/ ) {

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -2016,7 +2016,8 @@ namespace das {
         }
     }
 
-    // One line per still-pending (dlopen-failed) module: "  dasModuleGlfw <- <path> (<dlerror>)".
+    // One line per still-pending (dlopen-failed) module: "  Module_Glfw <- <path> (<dlerror>)"
+    // — the registrator class name, which is what was looked up, not the dylib's file name.
     // Empty string when nothing is pending. Compile-error paths append this to the misleading
     // "missing prerequisite ...; file not found" so a load failure stops reading as a path typo.
     DAS_API string describe_pending_dynamic_modules() {

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -49,6 +49,8 @@ namespace das {
     void * register_dynamic_module(const char *, const char *, int, Context *, LineInfoArg *);
     void register_native_path(const char *, const char *, const char *, Context *, LineInfoArg *);
     bool builtin_fexist ( const char * path );
+    DAS_API void retry_pending_dynamic_modules();
+    DAS_API int report_pending_dynamic_modules();
 
     // JitFunction typedef lives in arraytype.h (the SimFunction::jitFunction mirror shares it)
 
@@ -419,6 +421,18 @@ extern "C" {
         static_cast<JitContext *>(ctx)->initFunctionAddr(index, globPtr);
     }
 
+    // A missing MODULE and a missing FUNCTION die on the same lookup — distinguish them,
+    // because the former is a load failure (dlopen), not a signature mismatch.
+    static bool jit_module_is_registered ( const char * moduleName ) {
+        bool exists = false;
+        Module::foreach([&](Module * module) -> bool {
+            if ( module->name != moduleName ) return true;
+            exists = true;
+            return false;
+        });
+        return exists;
+    }
+
     DAS_API void jit_init_extern_function ( const char * moduleName,
                                             const char * funcMangledName,
                                             void ** dllGlobal ) {
@@ -449,6 +463,9 @@ extern "C" {
             });
         }
         if (!found) {
+            if ( !jit_module_is_registered(moduleName) ) {
+                DAS_FATAL_ERROR("Failed to find %s: module %s is not registered (its .shared_module may have failed to load — see errors above).\n", funcMangledName, moduleName);
+            }
             DAS_FATAL_ERROR("Failed to find %s in module %s.\n", funcMangledName, moduleName);
         }
     }
@@ -462,6 +479,9 @@ extern "C" {
             return false;
         });
         if (!result) {
+            if ( !jit_module_is_registered(moduleName) ) {
+                DAS_FATAL_ERROR("Failed to find annotation %s: module %s is not registered (its .shared_module may have failed to load — see errors above).\n", annName, moduleName);
+            }
             DAS_FATAL_ERROR("Failed to find annotation %s in module %s.\n", annName, moduleName);
         }
         return result;
@@ -1722,6 +1742,18 @@ DAS_API void * jit_register_dynamic_module_resolve ( const char * rel_path,
                                                      const char * mod_name ) {
     das::string chosen = resolve_dynamic_module_path(rel_path, fallback_abs_path);
     return das::register_dynamic_module(chosen.c_str(), mod_name, 0/*Quiet*/, nullptr, nullptr);
+}
+
+// Emitted by inject_main after the per-module jit_register_dynamic_module_resolve calls.
+// Those load Quiet (sibling DT_NEEDED ordering makes a first-attempt failure normal), so
+// run the fixed-point retry, then treat anything still unloadable as fatal: every module
+// the exe registers is required by its program, and continuing only defers the death to
+// the first extern lookup, whose message no longer names the real cause.
+DAS_API void jit_finalize_dynamic_modules () {
+    das::retry_pending_dynamic_modules();
+    if ( int failed = das::report_pending_dynamic_modules() ) {
+        DAS_FATAL_ERROR("%d dynamic module(s) failed to load (see above).\n", failed);
+    }
 }
 
 DAS_API void jit_register_native_path ( const char * mod_name, const char * src_path, const char * dst_path ) {

--- a/tests-cpp/small/test_register_dynamic_module.cpp
+++ b/tests-cpp/small/test_register_dynamic_module.cpp
@@ -5,6 +5,9 @@
 namespace das {
     // forward declaration from module_builtin_fio.cpp (same as module_jit.cpp uses)
     void * register_dynamic_module(const char *, const char *, int, Context *, LineInfoArg *);
+    DAS_API void retry_pending_dynamic_modules();
+    DAS_API string describe_pending_dynamic_modules();
+    DAS_API int report_pending_dynamic_modules();
 }
 
 namespace {
@@ -50,4 +53,33 @@ TEST_CASE("register_dynamic_module — dlopen failure, nullptr context, non-Quie
     // ones with no context must report via LOG(error) and return null, not crash.
     CHECK(das::register_dynamic_module("no/such/path.no_such_ext",
         "Module_DoesNotExist", ErrorMsg, nullptr, nullptr) == nullptr);
+}
+
+// Deferred must not mean silent forever. A standalone exe that ships a dynamic
+// module used to die much later on an unrelated-looking "Failed to find <fn> in
+// module <mod>", and the compiler reported the missing module as a plain "file
+// not found" path typo. Both diagnostics now read the surface below, so a
+// still-unloadable module has to be enumerable BY NAME, with its dlerror.
+TEST_CASE("register_dynamic_module — a deferred Quiet failure stays reportable") {
+    // The pending list is process-wide and a permanently-missing entry never
+    // drains, so assert on the DELTA rather than an empty starting state.
+    das::retry_pending_dynamic_modules();
+    const int before = das::report_pending_dynamic_modules();
+
+    CHECK(das::register_dynamic_module("/nonexistent-dir-for-tests/dasModuleNoSuchThing.shared_module",
+        "Module_NoSuchThing", Quiet, nullptr, nullptr) == nullptr);
+
+    // This text is what the compiler appends to `missing prerequisite ...; file
+    // not found` — the whole point is that a load failure stops reading as a
+    // mistyped path.
+    const das::string note = das::describe_pending_dynamic_modules();
+    CHECK(note.find("Module_NoSuchThing") != das::string::npos);
+    CHECK(note.find("dasModuleNoSuchThing.shared_module") != das::string::npos);
+    CHECK(note.find('\n') != das::string::npos);   // one line per entry
+
+    // The count is what the generated standalone-exe epilogue fatals on, and a
+    // retry cannot rescue a file that is genuinely absent.
+    CHECK(das::report_pending_dynamic_modules() == before + 1);
+    das::retry_pending_dynamic_modules();
+    CHECK(das::report_pending_dynamic_modules() == before + 1);
 }

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -2695,10 +2695,12 @@ def private release_one_wasm_app(root, out_dir, app_name, main_script : string; 
     mkdir_rec(app_out_dir)
 
     let daslang = get_daslang_path()
-    let das_root = get_das_root()
+    // Intermediates live beside the output, NOT under das_root: the SDK root may be
+    // read-only (installed SDK, or the buildd sandbox's ro-mounted worktree), and
+    // app_out_dir was just created so it is always writable.
     run_cmd_counter ++
-    let obj_path = "{das_root}/_daspkg_wasm_{run_cmd_counter}.o"
-    let deps_file = "{das_root}/_daspkg_wasm_deps_{run_cmd_counter}.json"
+    let obj_path = path_join(app_out_dir, "_daspkg_wasm_{run_cmd_counter}.o")
+    let deps_file = path_join(app_out_dir, "_daspkg_wasm_deps_{run_cmd_counter}.json")
 
     // 1. Cross-compile to a wasm64 object (link skipped via --jit-emit-object),
     //    with --list-shared-modules writing the referenced-module set.

--- a/utils/daspkg/utils.das
+++ b/utils/daspkg/utils.das
@@ -54,7 +54,14 @@ def run_cmd(cmd : string; var output : string&) : int {
     output = ""
     log_debug("$ {cmd}")
     run_cmd_counter ++
-    let tmp_out = "{get_das_root()}/_daspkg_cmd_output_{run_cmd_counter}.txt"
+    // The capture file lives in the system temp dir, NOT under das_root: the SDK
+    // root may be read-only (installed SDK, the buildd sandbox's ro-mounted
+    // worktree). das_root only as a last-resort fallback.
+    var tmp_err = ""
+    var tmp_out = create_temp_file("daspkg_cmd_{run_cmd_counter}_", ".txt", tmp_err)
+    if (empty(tmp_out)) {
+        tmp_out = "{get_das_root()}/_daspkg_cmd_output_{run_cmd_counter}.txt"
+    }
     // Windows _popen invokes cmd.exe /c <our-cmd>. When <our-cmd> starts with a
     // quoted exe path AND contains `>`, cmd.exe's old-behavior rule strips the
     // first AND last `"`, mangling the inner quoting. Wrapping the whole thing

--- a/utils/dasweb-buildd/Containerfile
+++ b/utils/dasweb-buildd/Containerfile
@@ -6,10 +6,16 @@
 # host's libc++ always matches the host binary that links against it.
 #
 # The only thing that must live here is what emscripten needs from a system:
-# python3 (emcc is a python program; emsdk bundles its own node, not python).
+# python3 (emcc is a python program; emsdk bundles its own node, not python) —
+# plus the X11/GL runtime libraries below. The host daslang dlopens the tree's
+# .shared_module dylibs while COMPILING a sample (`require glfw` needs the
+# native module registered), and their DT_NEEDED X11/GL libs must resolve
+# inside the container or the dlopen fails silently and every graphics sample
+# reports "missing prerequisite". No GPU or X server is involved — the compile
+# only loads the libraries.
 #
 # Build (on the compute box, from the worktree root):
-#   podman build -t dasweb-builder:1 -f utils/dasweb-buildd/Containerfile .
+#   podman build -t dasweb-builder:2 -f utils/dasweb-buildd/Containerfile .
 #
 # Bump the tag when this file changes and update IMAGE in run_build.sh in the
 # same commit — the two are one unit.
@@ -17,6 +23,7 @@ FROM docker.io/library/debian:12-slim
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends python3 \
+      libgl1 libopengl0 libglu1-mesa libx11-6 libxi6 libxrandr2 libxcb1 \
  && rm -rf /var/lib/apt/lists/*
 
 # No USER here on purpose: run_build.sh passes --userns=keep-id, so the build

--- a/utils/dasweb-buildd/README.md
+++ b/utils/dasweb-buildd/README.md
@@ -82,7 +82,9 @@ Also applied: `--network=none`, a read-only root with a tmpfs `/tmp`, `--memory`
 `--pids-limit` / `--cpus` caps, `--cap-drop=ALL`, `--security-opt=no-new-privileges`, and
 `--userns=keep-id` so the build runs as the unprivileged account this service runs as. The
 emcc cache is mounted read-only with `EM_FROZEN_CACHE=1`, so one job cannot poison what later
-jobs link against; the toolchain-bump protocol warms it with one build outside the sandbox.
+jobs link against; the toolchain-bump protocol warms it with one build **of each mode** outside
+the sandbox — the page link is `-pthread` and needs the `-mt` system libraries a module build
+never touches.
 Podman passes no host environment through, so a token in this service's environment is not
 visible to a build. There is deliberately **no** unsandboxed fallback: no podman or no image
 means no build.

--- a/utils/dasweb-buildd/README.md
+++ b/utils/dasweb-buildd/README.md
@@ -46,8 +46,12 @@ The service refuses to start without a token and a build command.
    killed after `build_timeout_seconds`. `run_build.sh` is the recipe — see **The sandbox**
    below — and per mode it runs the exact CI command the queue replaced: `module` = host
    daslang `-exe --jit-target=wasm64-unknown-emscripten` against the `web/output64` runtime
-   archive (→ `sample.wasm`); `page` (standalone game html+js+wasm) lands with the game
-   checkpoint.
+   archive (→ `sample.wasm`); `page` = daspkg's release-wasm rail (the one the five
+   `/examples` cards use) under a `.das_package` this service generates into the scratch src
+   dir naming the app `sample` (job sources can never carry their own — bundle names must be
+   plain `.das`), flattened inside the sandbox to `sample.{html,js,wasm}`. The server decides
+   the mode at request time by scanning the source's requires; this service only obeys the
+   claimed job's mode.
 5. **Collect**: exactly the files the mode declares, by name (`expected_artifact_names`).
    The build runs the user's compile-time code and can write anything into the output
    directory, so anything else there is logged and dropped — a build cannot widen its own
@@ -102,14 +106,19 @@ A build blocks the tick thread, so `/healthz` goes dark for the build's duration
 only logs health transitions (it restarts on process exit, never on health), and
 `build_timeout_seconds` bounds the window.
 
+The image also carries the X11/GL *runtime* libraries (no X server, no GPU): the host daslang
+dlopens the tree's `.shared_module` dylibs while **compiling** a sample (`require glfw` needs
+the native module registered), and their `DT_NEEDED` X11/GL libs must resolve inside the
+container or the dlopen fails and every graphics sample reports `missing prerequisite`.
+
 The box environment (`DASWEB_WASM_WORKTREE`, pinned emsdk, the worktree's own
 `web/build_wasm_host.sh` host build, the sandbox image) is documented in `~/SETUP.md` on zen4 —
 the wasm worktree is dedicated because wasm and native builds poison each other's `bin/` and
 `lib/` (`plans/dasweb_wasm_pipeline.md` has the postmortem). Build the sandbox image once per
-`Containerfile` change:
+`Containerfile` change (bump the tag here, in `Containerfile`, and in `run_build.sh` together):
 
 ```bash
-podman build -t dasweb-builder:1 -f utils/dasweb-buildd/Containerfile .
+podman build -t dasweb-builder:2 -f utils/dasweb-buildd/Containerfile .
 ```
 
 ## Tests

--- a/utils/dasweb-buildd/buildd_core.das
+++ b/utils/dasweb-buildd/buildd_core.das
@@ -166,12 +166,38 @@ def expected_artifact_names(mode : string) : array<string> {
     //! The EXACT file set a mode may publish. Not a suffix filter: the build
     //! writes into this directory with the user's own compile-time code, so
     //! anything it drops beside the real output would otherwise be uploaded
-    //! and served publicly. Empty = the mode publishes nothing (page mode
-    //! defines its set when the page checkpoint wires it).
+    //! and served publicly. Empty = the mode publishes nothing.
     if (mode == "module") {
         return <- ["sample.wasm"]
     }
+    if (mode == "page") {
+        return <- ["sample.html", "sample.js", "sample.wasm"]
+    }
     return <- array<string>()
+}
+
+def write_page_package(src_dir : string; entry : string) : bool {
+    //! The .das_package a page build compiles under — daspkg's release-wasm rail
+    //! wants one, and a job's sources can never carry their own (bundle names
+    //! must be plain `.das`). Naming the app `sample` pins the exact artifact
+    //! set. `entry` is already validated (is_valid_source_filename), so the
+    //! interpolation cannot escape the string.
+    let body = ("options gen2\n" +
+        "require daslib/daspkg\n\n" +
+        "[export]\n" +
+        "def package() \{\n" +
+        "    package_name(\"sample\")\n" +
+        "\}\n\n" +
+        "[export]\n" +
+        "def release() \{\n" +
+        "    release_name(\"sample\")\n" +
+        "    release_main(\"{entry}\")\n" +
+        "\}\n")
+    if (!fwrite(path_join(src_dir, ".das_package"), body)) {
+        logger_error("buildd.core", "cannot write .das_package into {src_dir}")
+        return false
+    }
+    return true
 }
 
 def collect_artifacts(out_dir : string; mode : string) : array<BuiltFile> {
@@ -209,15 +235,20 @@ def collect_artifacts(out_dir : string; mode : string) : array<BuiltFile> {
             out |> clear()
             return <- out
         }
+        // All or nothing: the server refuses any set that is not exactly the
+        // mode's — uploading a partial one would only trade this clear log
+        // line for a refused upload later.
         let st = stat(full)
         if (!st.is_valid || !st.is_reg) {
             logger_error("buildd.core", "expected artifact missing", JV((name = name, mode = mode)))
-            continue
+            out |> clear()
+            return <- out
         }
         let hex = sha256_file_hex(full)
         if (empty(hex)) {
-            logger_warning("buildd.core", "skipping unreadable or empty output {name}")
-            continue
+            logger_error("buildd.core", "expected artifact unreadable or empty", JV((name = name, mode = mode)))
+            out |> clear()
+            return <- out
         }
         out |> push(BuiltFile(name = name, sha256 = hex, path = full))
     }

--- a/utils/dasweb-buildd/buildd_service.das
+++ b/utils/dasweb-buildd/buildd_service.das
@@ -149,7 +149,13 @@ def private run_one_job(job : ClaimedBuild) {
     mkdir_rec(src_dir)
     mkdir_rec(out_dir)
     logger_info("buildd", "job start", JV((hash = job.hash, mode = job.mode, toolchain = job.toolchain)))
-    let entry = unpack_sources(src_dir, job.source)
+    var entry = unpack_sources(src_dir, job.source)
+    // A page build compiles under a generated .das_package (the release-wasm
+    // rail wants one; job sources can never carry their own). Written by THIS
+    // service into a dir it owns, before the sandbox ever runs.
+    if (!empty(entry) && job.mode == "page" && !write_page_package(src_dir, entry)) {
+        entry = ""
+    }
     if (empty(entry)) {
         logger_warning("buildd", "job failed: malformed source document",
             JV((hash = job.hash, duration_ms = get_time_usec(t0) / 1000)))

--- a/utils/dasweb-buildd/buildd_service.das
+++ b/utils/dasweb-buildd/buildd_service.das
@@ -149,18 +149,18 @@ def private run_one_job(job : ClaimedBuild) {
     mkdir_rec(src_dir)
     mkdir_rec(out_dir)
     logger_info("buildd", "job start", JV((hash = job.hash, mode = job.mode, toolchain = job.toolchain)))
-    var entry = unpack_sources(src_dir, job.source)
+    let entry = unpack_sources(src_dir, job.source)
     // A page build compiles under a generated .das_package (the release-wasm
     // rail wants one; job sources can never carry their own). Written by THIS
     // service into a dir it owns, before the sandbox ever runs.
-    if (!empty(entry) && job.mode == "page" && !write_page_package(src_dir, entry)) {
-        entry = ""
-    }
-    if (empty(entry)) {
-        logger_warning("buildd", "job failed: malformed source document",
+    let packaged = empty(entry) || job.mode != "page" || write_page_package(src_dir, entry)
+    if (empty(entry) || !packaged) {
+        // Two different faults, and the user must not be told their source is
+        // malformed when the builder is what failed.
+        let why = empty(entry) ? "malformed source document" : "builder could not prepare the build directory"
+        logger_warning("buildd", "job failed: {why}",
             JV((hash = job.hash, duration_ms = get_time_usec(t0) / 1000)))
-        upload_failure(g_cfg.server_url, g_cfg.token, job.hash, job.toolchain,
-            "malformed source document")
+        upload_failure(g_cfg.server_url, g_cfg.token, job.hash, job.toolchain, why)
     } else {
         let r = run_build_command(g_cfg.build_cmd, src_dir, out_dir, job.mode, entry,
             float(g_cfg.build_timeout_seconds))

--- a/utils/dasweb-buildd/run_build.sh
+++ b/utils/dasweb-buildd/run_build.sh
@@ -56,7 +56,7 @@ ENTRY="${4:?missing entry}"
 
 WORKTREE="${DASWEB_WASM_WORKTREE:?DASWEB_WASM_WORKTREE is not set}"
 EMSDK_ROOT="${EMSDK:?EMSDK is not set (the pinned emsdk root)}"
-IMAGE="${DASWEB_BUILDER_IMAGE:-dasweb-builder:1}"
+IMAGE="${DASWEB_BUILDER_IMAGE:-dasweb-builder:2}"
 LLVM_LIB="${DASWEB_LLVM_LIB:-/usr/lib/llvm-19/lib}"
 BUILD_MEMORY="${DASWEB_BUILD_MEMORY:-8g}"
 BUILD_PIDS="${DASWEB_BUILD_PIDS:-512}"
@@ -112,8 +112,18 @@ module)
         --jit-runtime-lib="$RUNTIME_LIB"
     ;;
 page)
-    echo "page mode is not wired yet (lands with the page checkpoint)"
-    exit 13
+    # sample.{html,js,wasm}: daspkg's release-wasm rail — the same one the five
+    # /examples cards use — cross-compile + emcc link with the module archives,
+    # GL/thread flags and the canvas shell. The service wrote a .das_package
+    # naming the app `sample` into SRC_DIR before this ran, so the output set
+    # is exact. The rail nests it under <out>/sample/; flatten INSIDE the
+    # sandbox so the host never touches build-controlled paths.
+    run_sandboxed /bin/bash -c '
+        set -e
+        "$1" "$2/utils/daspkg/main.das" -- release wasm --root "$3" --out "$4"
+        mv "$4/sample/sample.html" "$4/sample/sample.js" "$4/sample/sample.wasm" "$4/"
+        rm -rf "$4/sample"
+    ' _ "$DASLANG" "$WORKTREE" "$SRC_DIR" "$OUT_DIR"
     ;;
 *)
     echo "unknown mode '$MODE'"

--- a/utils/dasweb-buildd/run_build.sh
+++ b/utils/dasweb-buildd/run_build.sh
@@ -41,10 +41,12 @@
 # mode=module: the per-sample recipe, verbatim from web/CMakeLists.txt
 # (all_wasm) — host daslang -exe with the wasm64 jit target against the
 # web/output64 runtime archive, emitting <out_dir>/sample.wasm.
-# mode=page: the standalone-page recipe (daspkg release wasm) for the five
-# /examples cards — arcanoid and pacman (games) plus furier, path_tracer_lab
-# and physarum_lab (graphics showcases). Lands with the page checkpoint of
-# plans/dasweb_wasm_pipeline.md; refused until then.
+# mode=page: the standalone-page recipe — daspkg release wasm, the same rail
+# the five /examples cards use — for any sample whose requires pull in a native
+# graphics/audio module, since GL and audio live in emscripten's JS glue that a
+# bare wasi module cannot carry. The service writes the .das_package naming the
+# app `sample` into SRC_DIR first; the rail nests its output under <out>/sample,
+# which is flattened here INSIDE the sandbox.
 
 set -u
 exec 2>&1

--- a/utils/dasweb-buildd/test_buildd_core.das
+++ b/utils/dasweb-buildd/test_buildd_core.das
@@ -144,9 +144,49 @@ def test_build_cannot_widen_its_own_output(t : T?) {
         }
     }
     t |> run("an undefined mode publishes nothing") @(tt : T?) {
-        tt |> success(empty(expected_artifact_names("page")), "page mode not wired")
         tt |> success(empty(expected_artifact_names("bogus")), "unknown mode")
         tt |> equal(length(expected_artifact_names("module")), 1)
+    }
+    t |> run("page mode publishes exactly the html+js+wasm triple") @(tt : T?) {
+        let names <- expected_artifact_names("page")
+        tt |> equal(length(names), 3)
+        tt |> equal(names[0], "sample.html")
+        tt |> equal(names[1], "sample.js")
+        tt |> equal(names[2], "sample.wasm")
+    }
+    with_temp_dir("buildd_out_") $(dir) {
+        fwrite(path_join(dir, "sample.html"), "<html></html>")
+        fwrite(path_join(dir, "sample.js"), "// glue")
+        fwrite(path_join(dir, "sample.wasm"), "wasm bytes")
+        t |> run("page mode collects its triple in order") @(tt : T?) {
+            let files <- collect_artifacts(dir, "page")
+            tt |> equal(length(files), 3)
+            tt |> equal(files[0].name, "sample.html")
+            tt |> equal(files[1].name, "sample.js")
+            tt |> equal(files[2].name, "sample.wasm")
+            tt |> equal(files[2].sha256, sha256_hex("wasm bytes"))
+        }
+    }
+    with_temp_dir("buildd_out_") $(dir) {
+        fwrite(path_join(dir, "sample.html"), "<html></html>")
+        fwrite(path_join(dir, "sample.wasm"), "wasm bytes")
+        t |> run("a partial page set yields nothing — all or nothing") @(tt : T?) {
+            let files <- collect_artifacts(dir, "page")
+            tt |> success(empty(files), "missing sample.js drops the whole set")
+        }
+    }
+}
+
+[test]
+def test_write_page_package(t : T?) {
+    with_temp_dir("buildd_pkg_") $(dir) {
+        t |> run("the generated package names the app sample and the job's entry") @(tt : T?) {
+            tt |> success(write_page_package(dir, "prog.das"), "written")
+            let body = fread(path_join(dir, ".das_package"))
+            tt |> success(find(body, "release_name(\"sample\")") >= 0, "app is sample")
+            tt |> success(find(body, "release_main(\"prog.das\")") >= 0, "entry carried")
+            tt |> success(find(body, "require daslib/daspkg") >= 0, "daspkg hook file")
+        }
     }
 }
 

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -65,12 +65,12 @@ defect, and this section is the whole test.
   hashing, and every policy decision (size cap, rate ceiling, listing). Zero HTTP: a require
   of `dashv` here is a defect.
 - `build_queue.das` — the build queue: `BuildJob`/`BuildMeta` schema, the migrations it owns,
-  the job state machine, and queue policy (claim timeout, attempt ceiling). Zero HTTP and zero
-  filesystem.
-- `build_artifacts.das` — the artifact cache: blobs layout, toolchain/hash/filename validation,
-  integrity verification, stage-then-rename placement, serving-path resolution, and every path
-  the cache assembles. The only build-side file that touches the filesystem; zero HTTP, zero
-  SQL.
+  the job state machine, mode selection from a job's source document, and queue policy (claim
+  timeout, attempt ceiling). Zero HTTP and zero filesystem.
+- `build_artifacts.das` — the artifact cache: blobs layout, toolchain/hash/filename validation
+  (including which suffixes are documents, for the origin gate), integrity verification,
+  stage-then-rename placement, serving-path resolution, and every path the cache assembles. The
+  only build-side file that touches the filesystem; zero HTTP, zero SQL.
 - `curated_import.das` — the data.json-driven curated importer: manifest parsing, sample-file
   reads, bundle assembly, calling the store. The only file besides the config loader that reads
   the filesystem; a store mutation here that bypasses `samples_store` functions is a defect.

--- a/utils/dasweb-playground/README.md
+++ b/utils/dasweb-playground/README.md
@@ -103,6 +103,26 @@ immutable headers. An upload is staged under `blobs/tmp/`, every file verified a
 manifest sha256, and the whole set renamed into place atomically — a half-written artifact is
 never served. `caddy.snippet` carries the 64MB transport cap for `/api/build/*` uploads.
 
+A build's **mode** is decided here at request time by scanning the stored source's requires
+(`detect_build_mode` in `build_queue.das`): a native graphics/audio namespace (glfw, opengl,
+audio, …) makes it a `page` build — a standalone `sample.{html,js,wasm}` emscripten page,
+because GL and audio live in emscripten's JS glue that a bare wasi module cannot carry —
+everything else stays a `module` build (one `sample.wasm` the playground runtime
+instantiates). Status responses carry `kind` so the playground knows how to run the result.
+
+**Page artifacts are user-influenced html/js and are never daslang.io content.** `page_origin`
+in the toml (production: `https://run.daslang.io`, a cookie-less grey-cloud A record to this
+box) names the only Host the service serves `.html`/`.js` artifacts on — Caddy routes that
+vhost to artifact GETs only, and the service enforces the Host itself, so a Caddyfile drift
+fails closed. Page-artifact urls in status responses go out absolute on that origin; the
+playground embeds them in an un-sandboxed iframe (`sandbox` would opaque the origin and break
+emscripten's worker spawning — the separate origin is the boundary) with
+`allow="cross-origin-isolated"`. Artifact responses carry `Cross-Origin-Resource-Policy:
+cross-origin` (embeddable under the playground's COEP) and `Cross-Origin-Embedder-Policy:
+require-corp` (the page's own agent cluster isolates, so `-pthread` programs get their
+SharedArrayBuffer; the js carries it too because a COEP'd document may only spawn workers
+whose script response itself carries an enforcing COEP).
+
 The builder's protocol on a toolchain bump: build, run the `--jit-check-abi` canary clean,
 **then** `POST /api/build/toolchain` — announcing is the go-live. Queued jobs of earlier
 toolchains are simply never claimed again; rows stay for the audit trail.

--- a/utils/dasweb-playground/build_artifacts.das
+++ b/utils/dasweb-playground/build_artifacts.das
@@ -20,6 +20,12 @@ require strings
 //! rather than caching something the pages cannot use.
 let ALLOWED_ARTIFACT_SUFFIXES = fixed_array(".wasm", ".js", ".html", ".data", ".css")
 
+//! The subset a browser renders or executes AS the origin that served it, so
+//! these may only answer on the dedicated page origin. Deliberately beside the
+//! list above: a new delivery suffix must be classified here in the same edit,
+//! or the origin gate silently would not cover it.
+let DOCUMENT_ARTIFACT_SUFFIXES = fixed_array(".html", ".js", ".css")
+
 struct ArtifactFile {
     name : string
     sha256 : string
@@ -52,13 +58,30 @@ def is_valid_artifact_hash(h : string) : bool {
     return is_lower_hex(h, 64, 64)
 }
 
-def private has_allowed_suffix(name : string) : bool {
+def private strip_br_sidecar(name : string) : string {
     // a .br sidecar is allowed only stacked on an allowed base name
-    var base = name
-    if (base |> ends_with(".br")) {
-        base = slice(base, 0, length(base) - 3)
+    if (name |> ends_with(".br")) {
+        return slice(name, 0, length(name) - 3)
     }
+    return name
+}
+
+def private has_allowed_suffix(name : string) : bool {
+    let base = strip_br_sidecar(name)
     for (suffix in ALLOWED_ARTIFACT_SUFFIXES) {
+        if (base |> ends_with(suffix)) {
+            return true
+        }
+    }
+    return false
+}
+
+def is_document_artifact(name : string) : bool {
+    //! Does serving this file put attacker-authored content INTO the serving
+    //! origin? The Host gate keys on this, so it strips a `.br` sidecar first —
+    //! `sample.html.br` is every bit as much a document as `sample.html`.
+    let base = strip_br_sidecar(name)
+    for (suffix in DOCUMENT_ARTIFACT_SUFFIXES) {
         if (base |> ends_with(suffix)) {
             return true
         }

--- a/utils/dasweb-playground/build_queue.das
+++ b/utils/dasweb-playground/build_queue.das
@@ -8,6 +8,7 @@ require sqlite/sqlite_migrate public
 require daslib/sql_linq
 require daslib/logger
 require daslib/json_boost
+require daslib/strings_boost
 require strings
 
 //! The wasm build queue: schema, migration, the job state machine, and queue
@@ -36,13 +37,63 @@ def expected_artifact_names(mode : string) : array<string> {
     //! The EXACT file set a mode may publish. The builder enforces this too,
     //! but a build runs the user's own compile-time code, so the server does
     //! not take the builder's word for what a job produced: anything the build
-    //! dropped beside its real output would be served publicly from this
-    //! origin. Empty = the mode publishes nothing (page mode defines its set
-    //! when the page checkpoint wires it).
+    //! dropped beside its real output would be served publicly. Empty = the
+    //! mode publishes nothing.
     if (mode == BUILD_MODE_MODULE) {
         return <- ["sample.wasm"]
     }
+    if (mode == BUILD_MODE_PAGE) {
+        return <- ["sample.html", "sample.js", "sample.wasm"]
+    }
     return <- array<string>()
+}
+
+// Require-path roots that force the standalone-page artifact: their native halves
+// (GL context, audio device, image decode) live in emscripten's JS glue, which a
+// bare wasi module cannot carry. strudel and live_stub are here for what they
+// require transitively (audio; a glfw window) — the scan only sees source text.
+let private PAGE_REQUIRE_ROOTS : table<string> <- {
+    "glfw", "opengl", "imgui", "audio", "minfft", "stbimage", "clipboard", "strudel", "live_stub"
+}
+
+def private text_requires_page(text : string) : bool {
+    for (line in split(text, "\n")) {
+        let t = strip(line)
+        continue if (!((t |> starts_with("require ")) || (t |> starts_with("require\t"))))
+        let rest = strip(replace(slice(t, 8), "\t", " "))
+        let sp = find(rest, " ")
+        var tok = sp >= 0 ? slice(rest, 0, sp) : rest
+        if (tok |> starts_with("?")) {
+            tok = slice(tok, 1)
+        }
+        let sl = find(tok, "/")
+        let seg = sl >= 0 ? slice(tok, 0, sl) : tok
+        if (key_exists(PAGE_REQUIRE_ROOTS, seg)) {
+            return true
+        }
+    }
+    return false
+}
+
+def detect_build_mode(source : string) : string {
+    //! module vs page, from the stored source document (raw `.das` text or the
+    //! `{files, active}` bundle): any require of a native graphics/audio
+    //! namespace, in any file, makes the artifact a standalone page.
+    var jerr = ""
+    var doc = read_json(source, jerr)
+    if (doc != null && doc.value is _object && key_exists(doc.value as _object, "files")) {
+        let files = doc?["files"]
+        if (files != null && files.value is _object) {
+            for (v in values(files.value as _object)) {
+                let text : string = v ?? ""
+                if (text_requires_page(text)) {
+                    return BUILD_MODE_PAGE
+                }
+            }
+        }
+        return BUILD_MODE_MODULE
+    }
+    return text_requires_page(source) ? BUILD_MODE_PAGE : BUILD_MODE_MODULE
 }
 
 [sql_table(name = "build_jobs")]

--- a/utils/dasweb-playground/caddy.snippet
+++ b/utils/dasweb-playground/caddy.snippet
@@ -27,7 +27,13 @@ handle /api/samples* {
 # They are bearer-gated, so the allowance is spendable only by a token holder.
 # Listed before the public block below, which would otherwise match them —
 # Caddy takes the first matching handle.
-handle /api/build/next /api/build/result /api/build/toolchain {
+#
+# The named matcher is required, not stylistic: `handle` itself takes exactly
+# ONE path token, so `handle /a /b /c { ... }` is a parse error
+# ("Wrong argument count or unexpected line ending"). Verified with
+# `caddy validate` before this was applied.
+@build_upload path /api/build/next /api/build/result /api/build/toolchain
+handle @build_upload {
 	request_body {
 		max_size 64MB
 	}

--- a/utils/dasweb-playground/caddy.snippet
+++ b/utils/dasweb-playground/caddy.snippet
@@ -56,3 +56,21 @@ handle /api/build/* {
 # /admin/* and /shutdown are deliberately absent: they are operator surfaces.
 # The service also refuses them from a non-loopback peer, so adding a route
 # here does not merely expose them — it breaks them.
+
+# ---------------------------------------------------------------------------
+# run.daslang.io — the page-artifact origin. A SEPARATE top-level vhost block
+# (site block, NOT inside daslang.io { }). Page artifacts are user-influenced
+# html/js: served from this cookie-less origin they can never act as
+# daslang.io content. Only artifact GETs are routed; the service additionally
+# refuses html/js on any other Host (page_origin in the toml), so a drift here
+# fails closed. The playground embeds these pages in an iframe; the service
+# sets the CORP/COEP headers that embedding under COEP requires.
+#
+#	run.daslang.io {
+#		handle /api/build/artifact/* {
+#			reverse_proxy 127.0.0.1:8101
+#		}
+#		handle {
+#			respond "not found" 404
+#		}
+#	}

--- a/utils/dasweb-playground/caddy.snippet
+++ b/utils/dasweb-playground/caddy.snippet
@@ -68,6 +68,13 @@ handle /api/build/* {
 #
 #	run.daslang.io {
 #		handle /api/build/artifact/* {
+#			# Same reason as every other proxied route: libhv buffers a body in
+#			# full before any handler runs, and the service only registers GET
+#			# here — so without this an unbounded POST to an artifact path grows
+#			# the process before falling through to the 404.
+#			request_body {
+#				max_size 1MB
+#			}
 #			reverse_proxy 127.0.0.1:8101
 #		}
 #		handle {

--- a/utils/dasweb-playground/dasweb-playground.toml
+++ b/utils/dasweb-playground/dasweb-playground.toml
@@ -16,9 +16,11 @@ curated_dir = ""
 # blobs path — an empty token keeps the whole build surface disabled
 build_token = ""
 blobs_dir = "blobs"
-# The separate origin page artifacts (user-influenced html/js) are served
-# from. Empty = same-origin serving with no Host gate — development only;
-# production sets https://run.daslang.io
+# The separate origin page artifacts (user-influenced html/js) are served from.
+# Empty REFUSES page builds (graphics/audio samples) rather than serving a
+# user-authored document from this origin — so leaving it unset disables the
+# feature, it does not loosen it. Production sets https://run.daslang.io; for
+# local page testing set this server's own origin, e.g. http://127.0.0.1:8101
 page_origin = ""
 build_claim_timeout_seconds = 600
 max_build_attempts = 3

--- a/utils/dasweb-playground/dasweb-playground.toml
+++ b/utils/dasweb-playground/dasweb-playground.toml
@@ -16,5 +16,9 @@ curated_dir = ""
 # blobs path — an empty token keeps the whole build surface disabled
 build_token = ""
 blobs_dir = "blobs"
+# The separate origin page artifacts (user-influenced html/js) are served
+# from. Empty = same-origin serving with no Host gate — development only;
+# production sets https://run.daslang.io
+page_origin = ""
 build_claim_timeout_seconds = 600
 max_build_attempts = 3

--- a/utils/dasweb-playground/main.das
+++ b/utils/dasweb-playground/main.das
@@ -71,6 +71,7 @@ def init {
         BuildOptions(
             token = g_cfg.build_token,
             blobs_dir = g_cfg.blobs_dir,
+            page_origin = g_cfg.page_origin,
             queue = BuildConfig(
                 claim_timeout_seconds = g_cfg.build_claim_timeout_seconds,
                 max_build_attempts = g_cfg.max_build_attempts)))

--- a/utils/dasweb-playground/playground_config.das
+++ b/utils/dasweb-playground/playground_config.das
@@ -41,6 +41,9 @@ struct ServerArgs {
     @clarg_doc = "Artifact cache root (blobs); empty disables artifact storage and serving"
     blobs_dir : string = "blobs"
 
+    @clarg_doc = "Separate origin page artifacts (user-influenced html/js) are served from, e.g. https://run.daslang.io; empty = same-origin (dev only)"
+    page_origin : string = ""
+
     @clarg_doc = "Seconds before a claimed build is considered abandoned and requeued"
     build_claim_timeout_seconds : int = 600
 
@@ -105,7 +108,7 @@ def private cfg_from_toml(root : JsonValue?; key : string; var field : int&; aut
 
 def mark_cli_sources(user_args : array<string>; var sources : table<string; string>) {
     for (key in fixed_array("port", "db", "base_url", "max_source_bytes", "max_inserts_per_ip_hour", "curated_dir",
-        "build_token", "blobs_dir", "build_claim_timeout_seconds", "max_build_attempts")) {
+        "build_token", "blobs_dir", "page_origin", "build_claim_timeout_seconds", "max_build_attempts")) {
         if (from_cli(user_args, key)) {
             sources[key] = "cli"
         }
@@ -131,6 +134,7 @@ def apply_config_text(var cfg : ServerArgs; body : string; user_args : array<str
         cfg_from_toml(root, "curated_dir", cfg.curated_dir, auth, user_args, sources, error) &&
         cfg_from_toml(root, "build_token", cfg.build_token, auth, user_args, sources, error) &&
         cfg_from_toml(root, "blobs_dir", cfg.blobs_dir, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "page_origin", cfg.page_origin, auth, user_args, sources, error) &&
         cfg_from_toml(root, "build_claim_timeout_seconds", cfg.build_claim_timeout_seconds, auth, user_args, sources, error) &&
         cfg_from_toml(root, "max_build_attempts", cfg.max_build_attempts, auth, user_args, sources, error))
     unsafe {
@@ -186,6 +190,8 @@ def config_banner(cfg : ServerArgs; sources : table<string; string>) : JsonValue
         build_token_src = sources?["build_token"] ?? "default",
         blobs_dir = cfg.blobs_dir,
         blobs_dir_src = sources?["blobs_dir"] ?? "default",
+        page_origin = cfg.page_origin,
+        page_origin_src = sources?["page_origin"] ?? "default",
         build_claim_timeout_seconds = cfg.build_claim_timeout_seconds,
         build_claim_timeout_seconds_src = sources?["build_claim_timeout_seconds"] ?? "default",
         max_build_attempts = cfg.max_build_attempts,

--- a/utils/dasweb-playground/playground_config.das
+++ b/utils/dasweb-playground/playground_config.das
@@ -143,6 +143,19 @@ def apply_config_text(var cfg : ServerArgs; body : string; user_args : array<str
     return ok
 }
 
+def normalize_origin(origin : string) : string {
+    //! An operator writing `https://run.daslang.io/` means the same origin as
+    //! one without the slash, but the two are not interchangeable downstream:
+    //! the host half would carry the `/` and then never equal a Host header, so
+    //! every page artifact 404s with nothing explaining why. Normalize once,
+    //! here, rather than teaching each consumer to tolerate both spellings.
+    var s = origin
+    while (!empty(s) && (s |> ends_with("/"))) {
+        s = slice(s, 0, length(s) - 1)
+    }
+    return s
+}
+
 def load_config(var cfg : ServerArgs; var sources : table<string; string>; var error : string&) : bool {
     //! CLI marks + config discovery (explicit --config, else dasweb-playground.toml
     //! in cwd, else beside the tool) + merge. Missing explicit config is an error;
@@ -169,6 +182,8 @@ def load_config(var cfg : ServerArgs; var sources : table<string; string>; var e
         }
     }
     delete user_args
+    // after every source has had its say, so a CLI value normalizes too
+    cfg.page_origin = normalize_origin(cfg.page_origin)
     return ok
 }
 

--- a/utils/dasweb-playground/playground_config.das
+++ b/utils/dasweb-playground/playground_config.das
@@ -41,7 +41,7 @@ struct ServerArgs {
     @clarg_doc = "Artifact cache root (blobs); empty disables artifact storage and serving"
     blobs_dir : string = "blobs"
 
-    @clarg_doc = "Separate origin page artifacts (user-influenced html/js) are served from, e.g. https://run.daslang.io; empty = same-origin (dev only)"
+    @clarg_doc = "Separate origin page artifacts (user-influenced html/js) are served from, e.g. https://run.daslang.io; empty refuses page builds outright (set it to this server's own origin for local page testing)"
     page_origin : string = ""
 
     @clarg_doc = "Seconds before a claimed build is considered abandoned and requeued"

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -36,10 +36,12 @@ struct BuildOptions {
     //! Transport-level build-surface config; queue policy nests from build_queue.
     token : string = ""       // bearer for the remote builder; "" disables the build surface
     blobs_dir : string = ""   // artifact cache root; "" disables artifact storage and serving
-    // The separate origin page artifacts (user-influenced html/js) are served from,
-    // e.g. "https://run.daslang.io". Non-empty makes html/js artifact requests
-    // answer ONLY on that Host, and page artifact urls absolute. "" (dev/tests) =
-    // same-origin serving, no Host gate.
+    // The separate origin page artifacts (user-influenced html/js) are served
+    // from, e.g. "https://run.daslang.io". Document artifacts answer ONLY on
+    // that Host, and page artifact urls go out absolute. Empty disables page
+    // mode entirely — the build is refused and no document is served, because
+    // there is nowhere safe to serve it from. A dev box that wants page builds
+    // sets this to its OWN origin.
     page_origin : string = ""
     queue : BuildConfig = BuildConfig()
 }

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -652,6 +652,11 @@ def private handle_build_artifact(var req : HttpRequest?; var resp : HttpRespons
     // so the js (and harmlessly the wasm) carry it too.
     resp |> set_header("Cross-Origin-Resource-Policy", "cross-origin")
     resp |> set_header("Cross-Origin-Embedder-Policy", "require-corp")
+    // COOP completes the isolation pair for a page opened DIRECTLY (top level):
+    // without it crossOriginIsolated stays false, SharedArrayBuffer is refused,
+    // and a -pthread program hangs forever on `loading-workers`. Ignored in a
+    // nested context, so it costs the embedded path nothing.
+    resp |> set_header("Cross-Origin-Opener-Policy", "same-origin")
     let rc = resp |> SERVE_FILE(path)
     log_request("GET", "/api/build/artifact", int(rc), ip, 0, artifact_size(path), t0)
     return rc

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -36,6 +36,11 @@ struct BuildOptions {
     //! Transport-level build-surface config; queue policy nests from build_queue.
     token : string = ""       // bearer for the remote builder; "" disables the build surface
     blobs_dir : string = ""   // artifact cache root; "" disables artifact storage and serving
+    // The separate origin page artifacts (user-influenced html/js) are served from,
+    // e.g. "https://run.daslang.io". Non-empty makes html/js artifact requests
+    // answer ONLY on that Host, and page artifact urls absolute. "" (dev/tests) =
+    // same-origin serving, no Host gate.
+    page_origin : string = ""
     queue : BuildConfig = BuildConfig()
 }
 
@@ -521,6 +526,9 @@ def private build_status_payload(hash : string; toolchain : string) : string {
         return write_json(JV((state = st.state, error = st.error)))
     }
     if (st.state == BUILD_STATE_DONE) {
+        // page artifacts live on the run origin (separate from this one), so their
+        // urls go out absolute; module artifacts stay same-origin relative
+        let base = st.mode == BUILD_MODE_PAGE ? g_build.page_origin : ""
         var urls : array<JsonValue?>
         var jerr = ""
         var names = read_json(st.artifact_files, jerr)
@@ -528,10 +536,10 @@ def private build_status_payload(hash : string; toolchain : string) : string {
             urls |> reserve(length(names.value as _array))
             for (n in names.value as _array) {
                 let name : string = n ?? ""
-                urls |> push(JV("/api/build/artifact/{toolchain}/{hash}/{name}"))
+                urls |> push(JV("{base}/api/build/artifact/{toolchain}/{hash}/{name}"))
             }
         }
-        return write_json(JV((state = st.state, toolchain = toolchain, files = JV(urls))))
+        return write_json(JV((state = st.state, kind = st.mode, toolchain = toolchain, files = JV(urls))))
     }
     return write_json(JV((state = st.state)))   // building
 }
@@ -571,7 +579,8 @@ def private handle_build_request(var req : HttpRequest?; var resp : HttpResponse
         return resp |> JSON(write_json(JV((error = "unknown sample"))), http_status.NOT_FOUND)
     }
     // no extra limiter by design: the queue plus baking time is the throttle
-    enqueue_build(g_db, hash, toolchain, BUILD_MODE_MODULE, current_unix_time())
+    let mode = detect_build_mode(get_source(g_db, hash))
+    enqueue_build(g_db, hash, toolchain, mode, current_unix_time())
     let body = build_status_payload(hash, toolchain)
     resp |> set_header("Cache-Control", "no-store")
     // the payload carries the stored compiler error, which is user-derived text
@@ -603,13 +612,30 @@ def private handle_build_status(var req : HttpRequest?; var resp : HttpResponse?
     return resp |> JSON(body, status)
 }
 
+def private page_origin_host : string {
+    //! Host half of page_origin ("https://run.daslang.io" -> "run.daslang.io").
+    let o = g_build.page_origin
+    let p = find(o, "://")
+    return p >= 0 ? slice(o, p + 3) : o
+}
+
 def private handle_build_artifact(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
+    let file = get_param(req, "file")
+    // A page artifact is user-influenced EXECUTABLE content: as a document it must
+    // never be same-origin with this site, so with a run origin configured, html/js
+    // answer only on that Host. Caddy routes accordingly; this does not trust it.
+    if (((file |> ends_with(".html")) || (file |> ends_with(".js"))) && !empty(g_build.page_origin)) {
+        if (get_header(req, "Host") != page_origin_host()) {
+            log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
+            return resp |> JSON(write_json(JV((error = "page artifacts are served from the run origin"))), http_status.NOT_FOUND)
+        }
+    }
     // resolve_artifact_file revalidates every request-derived component; a path
     // is only ever built from parts that passed
     let path = resolve_artifact_file(g_build.blobs_dir,
-        get_param(req, "toolchain"), get_param(req, "hash"), get_param(req, "file"))
+        get_param(req, "toolchain"), get_param(req, "hash"), file)
     if (empty(path)) {
         log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "unknown artifact"))), http_status.NOT_FOUND)
@@ -618,6 +644,14 @@ def private handle_build_artifact(var req : HttpRequest?; var resp : HttpRespons
     // input, so nosniff rides along like it does on stored sources
     resp |> set_header("Cache-Control", "public, max-age=31536000, immutable")
     resp |> set_header("X-Content-Type-Options", "nosniff")
+    // CORP: the COEP'd playground embeds the run-origin page (and Safari fetches
+    // module wasm cross-origin never happen — module urls stay same-origin).
+    // COEP on the artifact itself: the page document must be require-corp for its
+    // agent cluster to cross-origin-isolate (threads), and a COEP'd document may
+    // only spawn workers whose script response ITSELF carries an enforcing COEP —
+    // so the js (and harmlessly the wasm) carry it too.
+    resp |> set_header("Cross-Origin-Resource-Policy", "cross-origin")
+    resp |> set_header("Cross-Origin-Embedder-Policy", "require-corp")
     let rc = resp |> SERVE_FILE(path)
     log_request("GET", "/api/build/artifact", int(rc), ip, 0, artifact_size(path), t0)
     return rc

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -578,8 +578,23 @@ def private handle_build_request(var req : HttpRequest?; var resp : HttpResponse
         log_request("POST", "/api/build/request/:hash", 404, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "unknown sample"))), http_status.NOT_FOUND)
     }
+    // An existing job keeps its mode (enqueue is idempotent), so only a job
+    // that does not exist yet is worth scanning the source for — this route is
+    // public and deliberately unlimited, and the scan walks every line of a
+    // document up to max_source_bytes.
+    let existing = build_status(g_db, hash, toolchain)
+    let mode = existing.found ? existing.mode : detect_build_mode(get_source(g_db, hash))
+    // Fail CLOSED. A page build's artifacts are attacker-authored html/js, and
+    // the only thing that keeps them off this origin is page_origin. Unset, the
+    // old behaviour was to build anyway and serve them from here — refuse
+    // instead, so a box deployed without the key produces no page at all.
+    if (mode == BUILD_MODE_PAGE && empty(g_build.page_origin)) {
+        logger_error("playground.build", "refusing page build: no page_origin configured",
+            JV((hash = hash, toolchain = toolchain)))
+        log_request("POST", "/api/build/request/:hash", 503, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "page builds are not available on this server"))), http_status.SERVICE_UNAVAILABLE)
+    }
     // no extra limiter by design: the queue plus baking time is the throttle
-    let mode = detect_build_mode(get_source(g_db, hash))
     enqueue_build(g_db, hash, toolchain, mode, current_unix_time())
     let body = build_status_payload(hash, toolchain)
     resp |> set_header("Cache-Control", "no-store")
@@ -623,14 +638,15 @@ def private handle_build_artifact(var req : HttpRequest?; var resp : HttpRespons
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
     let file = get_param(req, "file")
-    // A page artifact is user-influenced EXECUTABLE content: as a document it must
-    // never be same-origin with this site, so with a run origin configured, html/js
-    // answer only on that Host. Caddy routes accordingly; this does not trust it.
-    if (((file |> ends_with(".html")) || (file |> ends_with(".js"))) && !empty(g_build.page_origin)) {
-        if (get_header(req, "Host") != page_origin_host()) {
-            log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
-            return resp |> JSON(write_json(JV((error = "page artifacts are served from the run origin"))), http_status.NOT_FOUND)
-        }
+    // A document artifact is attacker-authored content that becomes part of
+    // whatever origin serves it, so it answers ONLY on the dedicated page
+    // origin. Caddy routes accordingly; this does not take its word for it.
+    // With no page origin configured there is nowhere safe to serve one, so
+    // the answer is 404 rather than "then serve it from here" — same
+    // fail-closed rule the enqueue side applies.
+    if (is_document_artifact(file) && get_header(req, "Host") != page_origin_host()) {
+        log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "page artifacts are served from the run origin"))), http_status.NOT_FOUND)
     }
     // resolve_artifact_file revalidates every request-derived component; a path
     // is only ever built from parts that passed

--- a/utils/dasweb-playground/test_build_endpoints.das
+++ b/utils/dasweb-playground/test_build_endpoints.das
@@ -460,12 +460,16 @@ def test_page_build_flow(t : T?) {
                 tt |> equal(first, "http://127.0.0.1:{TEST_PORT}/api/build/artifact/{TC}/{hash}/sample.html")
             }
         }
-        t |> run("the page document serves with the embedding headers") @(tt : T?) {
+        t |> run("the page document serves with the isolation headers") @(tt : T?) {
             GET("{base_url}/api/build/artifact/{TC}/{hash}/sample.html") $(resp) {
                 tt |> equal(int(resp.status_code), 200)
                 tt |> equal(string(resp.body), "<html>page shell</html>")
                 tt |> equal(get_header(resp, "Cross-Origin-Resource-Policy"), "cross-origin")
                 tt |> equal(get_header(resp, "Cross-Origin-Embedder-Policy"), "require-corp")
+                // COOP + COEP is what makes crossOriginIsolated true for a page
+                // opened directly; without it a -pthread program never gets its
+                // SharedArrayBuffer and hangs on `loading-workers`.
+                tt |> equal(get_header(resp, "Cross-Origin-Opener-Policy"), "same-origin")
                 tt |> equal(get_header(resp, "X-Content-Type-Options"), "nosniff")
             }
         }

--- a/utils/dasweb-playground/test_build_endpoints.das
+++ b/utils/dasweb-playground/test_build_endpoints.das
@@ -19,12 +19,17 @@ let TC = "abc1234def567890abc1234def567890abc12345"
 // POST /shutdown. Strings cross into the thread as separate locals — the
 // proven capture shape — and BuildOptions is assembled inside the thread.
 def private with_build_server(token : string; blobs_dir : string; blk : block<(base_url : string) : void>) {
+    with_page_build_server(token, blobs_dir, "", blk)
+}
+
+def private with_page_build_server(token : string; blobs_dir : string; page_origin : string; blk : block<(base_url : string) : void>) {
     with_job_status(1) $(finished) {
         let token_copy = token
         let blobs_copy = blobs_dir
+        let origin_copy = page_origin
         new_thread() @() {
             run_server(TEST_PORT, ":memory:", StorePolicy(), "https://test.example", "",
-                BuildOptions(token = token_copy, blobs_dir = blobs_copy))
+                BuildOptions(token = token_copy, blobs_dir = blobs_copy, page_origin = origin_copy))
             finished |> notify_and_release
         }
         let base_url = "http://127.0.0.1:{TEST_PORT}"
@@ -387,5 +392,102 @@ def test_build_failure_paths(t : T?) { // nolint:STYLE038 — sequential refusal
         }
     }
     remove(upload_src)
+    rmdir_rec(blobs)
+}
+
+def private upload_page_triple(base_url : string; hash : string; html_src, js_src, wasm_src : string; blk : block<(resp : HttpResponse?) : void>) {
+    with_http_request() $(var req) {
+        req.method = http_method.POST
+        req.url := "{base_url}/api/build/result"
+        set_header(req, "Authorization", "Bearer {TEST_TOKEN}")
+        set_form_data(req, "hash", hash)
+        set_form_data(req, "toolchain", TC)
+        set_form_data(req, "ok", "1")
+        set_form_data(req, "manifest", ("[" +
+            "\{\"name\":\"sample.html\",\"sha256\":\"{sha256_file_hex(html_src)}\"}," +
+            "\{\"name\":\"sample.js\",\"sha256\":\"{sha256_file_hex(js_src)}\"}," +
+            "\{\"name\":\"sample.wasm\",\"sha256\":\"{sha256_file_hex(wasm_src)}\"}]"))
+        set_form_file(req, "sample.html", html_src)
+        set_form_file(req, "sample.js", js_src)
+        set_form_file(req, "sample.wasm", wasm_src)
+        request(req) $(resp) {
+            invoke(blk, resp)
+        }
+    }
+}
+
+let GL_SOURCE = "require glfw/glfw_boost\nrequire opengl/opengl_boost\n[export]\ndef main \{\n\}\n"
+
+[test]
+def test_page_build_flow(t : T?) {
+    var err = ""
+    let blobs = create_temp_directory("dasweb_ep_blobs_", err)
+    let html_src = create_temp_file("dasweb_ep_page_", ".html", err)
+    let js_src = create_temp_file("dasweb_ep_page_", ".js", err)
+    let wasm_src = create_temp_file("dasweb_ep_page_", ".bin", err)
+    fwrite(html_src, "<html>page shell</html>")
+    fwrite(js_src, "// emscripten glue")
+    fwrite(wasm_src, "fake page wasm")
+    // page_origin == this harness's own host:port, so the Host header the das
+    // client sends is exactly the run origin — the gate's ALLOW side.
+    with_page_build_server(TEST_TOKEN, blobs, "http://127.0.0.1:{TEST_PORT}") $(base_url) {
+        authed_post("{base_url}/api/build/toolchain", TC, TEST_TOKEN) $(resp) {
+            assert(int(resp.status_code) == 200, "toolchain announced")
+        }
+        let hash = posted_hash(base_url, GL_SOURCE)
+        t |> run("a graphics sample enqueues as a page build") @(tt : T?) {
+            POST("{base_url}/api/build/request/{hash}", "") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            authed_post("{base_url}/api/build/next", TC, TEST_TOKEN) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var doc = json_of(resp)
+                tt |> equal(doc?["mode"] ?? "", "page")
+                tt |> equal(doc?["source"] ?? "", GL_SOURCE)
+            }
+        }
+        t |> run("the page triple lands and status reports kind=page with absolute urls") @(tt : T?) {
+            upload_page_triple(base_url, hash, html_src, js_src, wasm_src) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            GET("{base_url}/api/build/status/{hash}") $(resp) {
+                var doc = json_of(resp)
+                tt |> equal(doc?["state"] ?? "", "done")
+                tt |> equal(doc?["kind"] ?? "", "page")
+                let files = doc?["files"]
+                tt |> success(files != null && files.value is _array, "files array present")
+                let first : string = (files.value as _array)[0] ?? ""
+                tt |> equal(first, "http://127.0.0.1:{TEST_PORT}/api/build/artifact/{TC}/{hash}/sample.html")
+            }
+        }
+        t |> run("the page document serves with the embedding headers") @(tt : T?) {
+            GET("{base_url}/api/build/artifact/{TC}/{hash}/sample.html") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(string(resp.body), "<html>page shell</html>")
+                tt |> equal(get_header(resp, "Cross-Origin-Resource-Policy"), "cross-origin")
+                tt |> equal(get_header(resp, "Cross-Origin-Embedder-Policy"), "require-corp")
+                tt |> equal(get_header(resp, "X-Content-Type-Options"), "nosniff")
+            }
+        }
+    }
+    // Same blobs, new server whose run origin is elsewhere: html/js must refuse
+    // on this Host (the gate does not trust Caddy's routing), wasm still serves.
+    with_page_build_server(TEST_TOKEN, blobs, "https://run.test.example") $(base_url) {
+        let hash = sha256_hex(GL_SOURCE)
+        t |> run("html and js artifacts answer only on the run origin's Host") @(tt : T?) {
+            GET("{base_url}/api/build/artifact/{TC}/{hash}/sample.html") $(resp) {
+                tt |> equal(int(resp.status_code), 404)
+            }
+            GET("{base_url}/api/build/artifact/{TC}/{hash}/sample.js") $(resp) {
+                tt |> equal(int(resp.status_code), 404)
+            }
+            GET("{base_url}/api/build/artifact/{TC}/{hash}/sample.wasm") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+        }
+    }
+    remove(html_src)
+    remove(js_src)
+    remove(wasm_src)
     rmdir_rec(blobs)
 }

--- a/utils/dasweb-playground/test_build_endpoints.das
+++ b/utils/dasweb-playground/test_build_endpoints.das
@@ -495,3 +495,34 @@ def test_page_build_flow(t : T?) {
     remove(wasm_src)
     rmdir_rec(blobs)
 }
+
+[test]
+def test_page_build_refused_without_page_origin(t : T?) {
+    // Fail CLOSED: page artifacts are attacker-authored html/js, and page_origin
+    // is the only thing keeping them off this origin. A server without it must
+    // refuse the build outright rather than serve the result from here.
+    var err = ""
+    let blobs = create_temp_directory("dasweb_ep_blobs_", err)
+    with_build_server(TEST_TOKEN, blobs) $(base_url) {
+        authed_post("{base_url}/api/build/toolchain", TC, TEST_TOKEN) $(resp) {
+            assert(int(resp.status_code) == 200, "toolchain announced")
+        }
+        t |> run("a graphics sample is refused when no page origin is configured") @(tt : T?) {
+            let hash = posted_hash(base_url, GL_SOURCE)
+            POST("{base_url}/api/build/request/{hash}", "") $(resp) {
+                tt |> equal(int(resp.status_code), 503)
+            }
+            // and nothing was queued for it
+            GET("{base_url}/api/build/status/{hash}") $(resp) {
+                tt |> equal(int(resp.status_code), 404)
+            }
+        }
+        t |> run("a compute sample still builds normally") @(tt : T?) {
+            let hash = posted_hash(base_url, "require math\n[export]\ndef main \{\n\}\n")
+            POST("{base_url}/api/build/request/{hash}", "") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+        }
+    }
+    rmdir_rec(blobs)
+}

--- a/utils/dasweb-playground/test_build_queue.das
+++ b/utils/dasweb-playground/test_build_queue.das
@@ -37,9 +37,47 @@ def test_expected_artifact_names(t : T?) {
         tt |> equal(length(names), 1)
         tt |> equal(names[0], "sample.wasm")
     }
+    t |> run("page publishes exactly the html+js+wasm triple") @(tt : T?) {
+        let names <- expected_artifact_names(BUILD_MODE_PAGE)
+        tt |> equal(length(names), 3)
+        tt |> equal(names[0], "sample.html")
+        tt |> equal(names[1], "sample.js")
+        tt |> equal(names[2], "sample.wasm")
+    }
     t |> run("a mode with no declared set publishes nothing") @(tt : T?) {
-        tt |> success(empty(expected_artifact_names(BUILD_MODE_PAGE)), "page not wired yet")
         tt |> success(empty(expected_artifact_names("bogus")), "unknown mode")
+    }
+}
+
+[test]
+def test_detect_build_mode(t : T?) {
+    t |> run("plain compute source is a module build") @(tt : T?) {
+        tt |> equal(detect_build_mode("require math\n[export]\ndef main \{\n    print(\"hi\")\n\}\n"), BUILD_MODE_MODULE)
+        tt |> equal(detect_build_mode("require daslib/random\nrequire strings\n"), BUILD_MODE_MODULE)
+    }
+    t |> run("a native graphics/audio require forces a page build") @(tt : T?) {
+        tt |> equal(detect_build_mode("require glfw/glfw_boost\nrequire math\n"), BUILD_MODE_PAGE)
+        tt |> equal(detect_build_mode("require opengl/opengl_boost\n"), BUILD_MODE_PAGE)
+        tt |> equal(detect_build_mode("require audio/audio_boost\n"), BUILD_MODE_PAGE)
+        tt |> equal(detect_build_mode("require stbimage\n"), BUILD_MODE_PAGE)
+        tt |> equal(detect_build_mode("require strudel/strudel_player\n"), BUILD_MODE_PAGE)
+        tt |> equal(detect_build_mode("require live_stub   // playground shim\n"), BUILD_MODE_PAGE)
+    }
+    t |> run("optional-require marker and tabs still match") @(tt : T?) {
+        tt |> equal(detect_build_mode("require ?audio\n"), BUILD_MODE_PAGE)
+        tt |> equal(detect_build_mode("require\tglfw/glfw_boost\n"), BUILD_MODE_PAGE)
+    }
+    t |> run("lookalikes stay module builds") @(tt : T?) {
+        tt |> equal(detect_build_mode("require daslib/glfw_helpers.das\n"), BUILD_MODE_MODULE)   // daslib root, not glfw
+        tt |> equal(detect_build_mode("requirements = 1\n"), BUILD_MODE_MODULE)
+        tt |> equal(detect_build_mode("// require glfw\n"), BUILD_MODE_MODULE)
+        tt |> equal(detect_build_mode("require glfwish\n"), BUILD_MODE_MODULE)
+    }
+    t |> run("bundle documents scan every file") @(tt : T?) {
+        let page_bundle = "\{\"files\":\{\"main.das\":\"require helper\\n\",\"helper.das\":\"require opengl/opengl_boost\\n\"\},\"active\":\"main.das\"\}"
+        tt |> equal(detect_build_mode(page_bundle), BUILD_MODE_PAGE)
+        let mod_bundle = "\{\"files\":\{\"main.das\":\"require math\\n\"\},\"active\":\"main.das\"\}"
+        tt |> equal(detect_build_mode(mod_bundle), BUILD_MODE_MODULE)
     }
 }
 

--- a/utils/dasweb-playground/test_playground_config.das
+++ b/utils/dasweb-playground/test_playground_config.das
@@ -97,7 +97,8 @@ def test_load_config_and_banner(t : T?) {
         let body = write_json(config_banner(cfg, sources))
         for (key in fixed_array("\"port\"", "\"port_src\" : \"cli\"", "\"db_src\" : \"default\"",
                 "\"base_url\"", "\"max_source_bytes_src\"", "\"max_inserts_per_ip_hour_src\"",
-                "\"curated_dir_src\"", "\"blobs_dir_src\"", "\"build_claim_timeout_seconds_src\"",
+                "\"curated_dir_src\"", "\"blobs_dir_src\"", "\"page_origin_src\"",
+                "\"build_claim_timeout_seconds_src\"",
                 "\"max_build_attempts_src\"", "\"build_token_src\"")) {
             t |> success(find(body, key) >= 0, "banner contains {key}")
         }
@@ -112,13 +113,29 @@ def test_build_keys_merge(t : T?) {
         var err = ""
         let args <- no_args()
         let body = ("build_token = \"s3cret\"\nblobs_dir = \"/srv/blobs\"\n" +
+            "page_origin = \"https://run.test.example\"\n" +
             "build_claim_timeout_seconds = 900\nmax_build_attempts = 5\n")
         t |> success(apply_config_text(cfg, body, args, sources, err), "toml parses")
         t |> equal(cfg.build_token, "s3cret")
         t |> equal(cfg.blobs_dir, "/srv/blobs")
+        t |> equal(cfg.page_origin, "https://run.test.example")
         t |> equal(cfg.build_claim_timeout_seconds, 900)
         t |> equal(cfg.max_build_attempts, 5)
         t |> equal(sources?["build_token"] ?? "", "toml")
+        t |> equal(sources?["page_origin"] ?? "", "toml")
+    }
+    t |> run("page_origin defaults empty, which disables page builds") @(t : T?) {
+        let cfg = ServerArgs()
+        t |> success(empty(cfg.page_origin), "no page origin unless configured")
+    }
+    t |> run("a trailing slash on the origin is normalized away") @(t : T?) {
+        // Left in, the host half would carry the '/' and never match a Host
+        // header — every page artifact 404s with nothing explaining why.
+        t |> equal(normalize_origin("https://run.daslang.io/"), "https://run.daslang.io")
+        t |> equal(normalize_origin("https://run.daslang.io///"), "https://run.daslang.io")
+        t |> equal(normalize_origin("https://run.daslang.io"), "https://run.daslang.io")
+        t |> equal(normalize_origin(""), "")
+        t |> equal(normalize_origin("/"), "")
     }
     t |> run("a wrong-typed build key is an error, not a silent zero") @(t : T?) {
         var cfg = ServerArgs()

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -646,6 +646,11 @@ async function runWasm() {
 }
 
 function runWasmArtifact(url) {
+    // Every run starts from a clean slate, page frames included: a sample edited
+    // from graphics to compute-only builds as a module, and without this the
+    // previous run's page sits there rendering while this one prints — the same
+    // "my run drew nothing" confusion the run frame was introduced to end.
+    destroyPageFrame();
     // Shim's DataView is rebuilt per-call from memRef.buffer, so we can
     // create the shim before instantiation and patch the buffer once memory
     // is exported.

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -4,6 +4,7 @@ var editorOutput;
 var samplesData;
 
 var code;
+var runHostEl;   // where run frames (interpreter) and page frames (wasm pages) stand
 
 var sampleList = {"examples":null};
 
@@ -31,6 +32,7 @@ pageInit = function () {
     runHost.className = "pg-run-host";
     if (oldCanvas) oldCanvas.parentNode.replaceChild(runHost, oldCanvas);
     else editorOutput.parentNode.insertBefore(runHost, editorOutput);
+    runHostEl = runHost;   // page-shape wasm artifacts (runWasmPage) share the canvas's place
     PlaygroundRunner.init(runHost, function (text, color) { printOutput(text, color); });
 
     sampleList["examples"] = document.getElementById("examples");
@@ -278,9 +280,45 @@ function showCanvas(show) {
     if (!show) {
         const f = document.querySelector(".pg-run-frame");
         if (f) f.style.display = "none";
+        destroyPageFrame();   // a page-shape wasm run goes with the canvas
     }
     const o = document.getElementById("output");
     if (o) o.classList.toggle("with-canvas", show);
+}
+
+// Page-shape wasm artifacts (GL/audio programs) run as their own document from
+// the run origin — a full emscripten page with its js glue and canvas. The
+// iframe is deliberately NOT sandboxed: the `sandbox` attribute makes its
+// origin opaque, which breaks emscripten's same-origin worker spawning — the
+// separate, cookie-less run origin is the isolation boundary. The allow list
+// delegates cross-origin isolation so -pthread programs get SharedArrayBuffer.
+var pageFrame = null;
+function destroyPageFrame() {
+    if (pageFrame && pageFrame.parentNode) pageFrame.parentNode.removeChild(pageFrame);
+    pageFrame = null;
+}
+function runWasmPage(files) {
+    let htmlUrl = null;
+    for (const u of files) if (/\.html$/.test(u)) htmlUrl = u;
+    if (!htmlUrl) {
+        printOutput('page build reported no html artifact', '#ff2d2d');
+        return;
+    }
+    // Same clean-slate rule as the interpreter: the previous run's canvas and
+    // page frame go before this one stands.
+    if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.reset();
+    destroyPageFrame();
+    pageFrame = document.createElement('iframe');
+    pageFrame.className = 'pg-page-frame';
+    pageFrame.setAttribute('title', 'daslang wasm program');
+    pageFrame.setAttribute('allow', 'cross-origin-isolated; autoplay; fullscreen');
+    pageFrame.style.cssText =
+        'display:block;width:100%;aspect-ratio:4/3;border:1px solid #444;' +
+        'background:#000;margin-top:20px;margin-bottom:6px;';
+    pageFrame.src = htmlUrl;
+    (runHostEl || editorOutput.parentNode).appendChild(pageFrame);
+    const o = document.getElementById('output');
+    if (o) o.classList.add('with-canvas');
 }
 
 selectSample = function(type, id) {
@@ -596,7 +634,10 @@ async function runWasm() {
             printOutput(result.error, result.compileError ? '#ff9393' : '#ff2d2d');
             return;
         }
-        runWasmArtifact(result.files[0]);
+        // The build's kind decides the delivery: a bare wasi module instantiates
+        // right here; a page-shape artifact (GL/audio) runs as its own document.
+        if (result.kind === 'page') runWasmPage(result.files);
+        else runWasmArtifact(result.files[0]);
     } catch (e) {
         printOutput('wasm build error: ' + (e && e.message ? e.message : e), '#ff2d2d');
     } finally {


### PR DESCRIPTION
Two bugs that turned out to share one shape: **a `.shared_module` dlopen failing silently, surfacing much later as an unrelated-looking error.** Plus the page-mode half of `plans/dasweb_wasm_pipeline.md`, which is what a graphics sample actually needs.

## 1. The baked-exe bug (root cause in daslang, not packaging)

`dasweb-buildd` could only run **interpreted**: its baked exe died at startup with

```
Failed to find @dashv::make_web_socket_server Ci Ci CIs CI? ... in module dashv
```

Every `.shared_module` NEEDs the **full** `liblibDaScriptDyn`, and `dlopen` resolves that dependency only from libraries already in the process or on the `.so`'s own RUNPATH — **the exe's RUNPATH is never consulted**. A runtime-only standalone exe therefore failed *every* module `dlopen`, silently, and died later on the first extern lookup. Windows escapes it via the exe-dir DLL search; Linux does not. The playground exe worked only by accident — its program trips one of the existing whole-lib conditions, so the full lib was already in-process when its modules loaded.

- `inject_main` now forces the whole-lib link when the program ships a dynamic module (`ships_dynamic` — the same signal that decides the rest of that link).
- The generated exe calls a new `jit_finalize_dynamic_modules` **after** `initialize_modules()`: it runs the deferred-load retry pass and fatals on anything still unloadable, naming the module and its `dlerror`.
- The extern/annotation lookup fatal now distinguishes "module never registered" from "function missing in module".
- `error[20605] missing prerequisite … file not found` appends the pending dynamic-module load failures when there are any — a dlopen failure no longer reads as a path typo.

Proven on zen4: a baked `dasweb-buildd` with its `dasModuleHV.shared_module` removed now says

```
dynamic module `Module_HV` failed to load: /…/dasModuleHV.shared_module
  (cannot open shared object file: No such file or directory)
1 dynamic module(s) failed to load (see above).
```

## 2. Graphics samples under the wasm engine

Trying the wasm engine on **OpenGL: rotating triangle** failed while the interpreter worked. Two causes stacked:

- Inside the podman sandbox `dasModuleGlfw.shared_module` could not resolve `libGL/libX11/libXrandr/libXi` — the host daslang dlopens the tree's shared modules while **compiling** — so `require glfw` reported `missing prerequisite 'glfw'`. The image now carries those runtime libs (no X server, no GPU involved); tag bumped to `dasweb-builder:2` in `Containerfile` + `run_build.sh` together.
- A bare wasi `.wasm` cannot carry GL or audio at all — those live in emscripten's JS glue. So **page mode** is now wired: the server picks the mode at request time by scanning the stored source's requires (`detect_build_mode`), and a graphics/audio sample builds as a standalone `sample.{html,js,wasm}` page through daspkg's release-wasm rail — the same rail the five `/examples` cards use — under a `.das_package` the builder generates into the scratch dir (job sources can never carry their own; the generated one pins the artifact set to exactly `sample.*`). The rail's output is flattened **inside** the sandbox so the host never touches build-controlled paths.

## Page artifacts get their own origin

A user-influenced `.html`/`.js` served from daslang.io would be same-origin content — the forward-looking risk flagged in #3630. `page_origin` (production `https://run.daslang.io`, a cookie-less grey-cloud A record to the same box) is now the **only** Host the service serves `.html`/`.js` artifacts on. Caddy routes that vhost to artifact GETs only, and the service enforces the Host itself, so a Caddyfile drift fails closed rather than open. The playground embeds the page in an iframe that is deliberately **not** `sandbox`ed — that would opaque the origin and break emscripten's same-origin worker spawning; the separate origin is the boundary — with `allow="cross-origin-isolated"`.

Artifacts carry `CORP: cross-origin`, `COEP: require-corp` **and** `COOP: same-origin`. The COOP part came from testing in a real browser: with COEP alone a directly-opened page never became `crossOriginIsolated`, so `SharedArrayBuffer` was refused and the `-pthread` program hung forever on `loading-workers`.

## Also fixed

`daspkg` wrote its release-wasm intermediates and its `run_cmd` capture file under `das_root`, which fails when the root is read-only — an installed SDK, or the sandbox's ro-mounted worktree. Both now go beside the output / to the system temp dir.

Artifact collection is all-or-nothing: a set missing one expected file uploads nothing, rather than trading a clear log line for a refused upload.

## Verified on the real boxes

The whole pipeline ran end to end in production while preparing this PR:

- Triangle requested → **built as a page in under 15s** → `sample.html` 1,827 B / `sample.js` 496,247 B / `sample.wasm` 16,749,680 B.
- Origin boundary proven **both ways**: `html`/`js` are `404` on daslang.io and `200` on run.daslang.io; the `.wasm` serves from both.
- Opened directly in a browser: `crossOriginIsolated: true`, canvas 640×480, and the triangle renders (black/yellow/red interpolated, mid-rotation).
- `dasweb-buildd` now runs **baked** under the watchdog on zen4 (health false→true in 5s).

The in-playground embed can't be verified in production until this merges — the site JS ships from master via `pages.yml`, so production still runs the old runner. That path is covered by the local rig.

## Gates

playground 200/200 · buildd 55/56 (56 on Linux) · playwright 42/42 · lint 0 on all changed `.das` · format clean · full preflight.

Rides along: the `caddy.snippet` named-matcher fix held back from #3630 (a one-file PR was not worth an hour of CI).
