### PR TITLE
playground: carry the sample assets manifest through a restored buffer

### DIFF
--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -114,7 +114,7 @@
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
 <script type="text/javascript" src="./playground-wasm.js?v=2"></script>
-<script type="text/javascript" src="./main.js?v=2"></script>
+<script type="text/javascript" src="./main.js?v=3"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=3"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -110,11 +110,11 @@
 <script type="text/javascript" src="./playground-init.js"></script>
 <!-- Owns run-frame.html (one frame per program). Must precede main.js, whose
      pageInit hands it the run host and whose run path delegates to it. -->
-<script type="text/javascript" src="./playground-runner.js?v=1"></script>
+<script type="text/javascript" src="./playground-runner.js?v=2"></script>
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
 <script type="text/javascript" src="./playground-wasm.js?v=2"></script>
-<script type="text/javascript" src="./main.js?v=1"></script>
+<script type="text/javascript" src="./main.js?v=2"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=3"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -102,15 +102,20 @@
 <script type="text/javascript" src="../files/cm/daslang-keywords.js"></script>
 <script type="text/javascript" src="../files/cm/daslang-mode.js"></script>
 <script type="text/javascript" src="../files/lz-string.min.js"></script>
+<!-- The ?v= on each script is a cache key, not decoration: BUMP IT IN THE SAME
+     COMMIT that changes the file. Nothing here is content-hashed, so an
+     unchanged URL lets a returning visitor keep running the old script against
+     a new backend — which is how a page-mode build once came back to a runner
+     that had never heard of it and tried to fetch the page as a module. -->
 <script type="text/javascript" src="./playground-init.js"></script>
 <!-- Owns run-frame.html (one frame per program). Must precede main.js, whose
      pageInit hands it the run host and whose run path delegates to it. -->
 <script type="text/javascript" src="./playground-runner.js?v=1"></script>
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
-<script type="text/javascript" src="./playground-wasm.js?v=1"></script>
-<script type="text/javascript" src="./main.js"></script>
-<script type="text/javascript" src="./playground-tabs.js?v=2"></script>
+<script type="text/javascript" src="./playground-wasm.js?v=2"></script>
+<script type="text/javascript" src="./main.js?v=1"></script>
+<script type="text/javascript" src="./playground-tabs.js?v=3"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>
 

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -55,15 +55,23 @@
     // "the render went washed out".
     var MAX_VIEWPORT_FRACTION = 0.8;
 
-    function fit(rec) {
-        if (!rec || !rec.el || rec.el.style.display === "none") return;
+    // Exposed, because the wasm engine's page frame stands in the same host and
+    // must be sized by the same rule — a second copy of this drifts, and the
+    // failure mode is silent (a frame that renders, just wrong).
+    function fitElement(el, aspect) {
+        if (!el) return;
         // Measure the column, not the host — the host sizes to its content, so
         // asking it how wide it is would just echo the frame back.
         var column = host && host.parentElement;
         var maxHeight = Math.round(window.innerHeight * MAX_VIEWPORT_FRACTION);
-        var width = Math.min(column ? column.clientWidth : 640, Math.round(maxHeight / rec.aspect));
-        rec.el.style.setProperty("width", width + "px", "important");
-        rec.el.style.setProperty("height", Math.round(width * rec.aspect) + "px", "important");
+        var width = Math.min(column ? column.clientWidth : 640, Math.round(maxHeight / aspect));
+        el.style.setProperty("width", width + "px", "important");
+        el.style.setProperty("height", Math.round(width * aspect) + "px", "important");
+    }
+
+    function fit(rec) {
+        if (!rec || !rec.el || rec.el.style.display === "none") return;
+        fitElement(rec.el, rec.aspect);
     }
 
     window.addEventListener("resize", function () { fit(current); });
@@ -142,6 +150,11 @@
         isReady: function () {
             return !!(spare && spare.ready) || !!(current && current.ready && !current.used);
         },
+
+        // Size an element the way a run frame is sized. The wasm engine's page
+        // frame lives in this same host and would otherwise have to re-derive
+        // the column-measuring rule.
+        fitElement: fitElement,
 
         // Throw away the frame that ran (if any) and promote the pre-warmed one.
         // Called before every run, and by Clear.

--- a/site/playground/playground-tabs.js
+++ b/site/playground/playground-tabs.js
@@ -39,6 +39,12 @@
                 Object.entries(pgState.files).map(([k, doc]) => [k, doc.getValue()])
             ),
             active: pgState.active,
+            // Which sample's assets the buffer expects. The files alone do not
+            // say where they came from, and the manifest is only ever derived
+            // when a sample is PICKED — so without carrying it here, a restored
+            // buffer runs with an empty MEMFS. Absent in older saved state,
+            // which reads back as null and behaves exactly as before.
+            assets: window.currentAssetsUrl || null,
         };
     }
 
@@ -333,6 +339,10 @@
         const saved = (!hasHash && !hasExampleParam) ? loadAutosave() : null;
         if (saved && saved.files && Object.keys(saved.files).length > 0) {
             pgLoadFiles(saved.files, saved.active);
+            // main.js owns currentAssetsUrl; hand it back the manifest that was
+            // saved beside this buffer, since the restore path never calls
+            // selectSample and so would never derive one.
+            window.pgRestoredAssetsUrl = saved.assets || null;
             window.pgRestoredFromState = true;
             return;
         }

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -201,6 +201,23 @@ test('a page-kind build runs as an embedded page frame', async ({ playground }) 
     expect(box.height / box.width).toBeGreaterThan(0.6);
     expect(box.height / box.width).toBeLessThan(0.9);
 
+    // The page reports its real drawing buffer the way run-frame.html does, and
+    // the frame reshapes to it — that report is what lets the canvas fill
+    // without letterbox bars, so a silent no-op here would look like the old
+    // "renders in the middle" bug for any program that is not 4:3.
+    await playground.evaluate(() => {
+        const f = document.querySelector('iframe.pg-page-frame');
+        window.dispatchEvent(new MessageEvent('message', {
+            source: f.contentWindow,
+            origin: new URL(f.src, location.href).origin,
+            data: { type: 'canvas-visible', width: 800, height: 200 },   // 4:1, unmistakable
+        }));
+    });
+    await expect.poll(async () => {
+        const b = await frame.boundingBox();
+        return b.height / b.width;
+    }, { timeout: 5_000 }).toBeLessThan(0.35);
+
     // Switching samples clears the page frame with the canvas.
     await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
     await expect(playground.locator('iframe.pg-page-frame')).toHaveCount(0, { timeout: 5_000 });

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -179,6 +179,28 @@ test('a page-kind build runs as an embedded page frame', async ({ playground }) 
     expect(await frame.getAttribute('sandbox')).toBeNull();
     expect(await frame.getAttribute('allow')).toContain('cross-origin-isolated');
 
+    // Sized like the interpreter's run frame — off the COLUMN, not the host.
+    // The host sizes to its CONTENT, so a percentage width is circular and
+    // collapses the frame to the CSS default iframe width (300px + border).
+    // It still renders, just far too small to use, which is why "a frame
+    // exists" is not enough to assert. Measured 302px against a 906px column
+    // on production before this was fixed — and note the collapsed width is a
+    // constant, so a loose fraction-of-column bound passes at a small viewport
+    // and misses it entirely.
+    const box = await frame.boundingBox();
+    const width = await playground.evaluate(() => {
+        const host = document.querySelector('.pg-run-host');
+        const column = host && host.parentElement ? host.parentElement.clientWidth : 0;
+        // what PlaygroundRunner.fitElement should have produced, same rule
+        const capped = Math.round(Math.round(window.innerHeight * 0.8) / (3 / 4));
+        return { column, expected: Math.min(column, capped) };
+    });
+    expect(width.column).toBeGreaterThan(320);      // else the bound below proves nothing
+    expect(box.width).toBeGreaterThan(width.expected * 0.95);
+    // 4:3 landscape, matching the run frame's starting aspect.
+    expect(box.height / box.width).toBeGreaterThan(0.6);
+    expect(box.height / box.width).toBeLessThan(0.9);
+
     // Switching samples clears the page frame with the canvas.
     await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
     await expect(playground.locator('iframe.pg-page-frame')).toHaveCount(0, { timeout: 5_000 });

--- a/site/tests/playground/persistence.spec.js
+++ b/site/tests/playground/persistence.spec.js
@@ -57,6 +57,41 @@ test('three-file state survives a reload', async ({ playground }) => {
     expect(typesText).toContain('types marker');
 });
 
+test('a restored buffer keeps the sample assets manifest', async ({ playground }) => {
+    // The buffer alone does not say which sample it came from, and the manifest
+    // is only derived when a sample is PICKED. Without carrying it through the
+    // restore, an asset-loading sample (deferred shading, skybox) runs against
+    // an empty MEMFS and panics on the first file it opens — but only on a
+    // return visit, which is what makes it read as a random failure.
+    await waitTabsReady(playground);
+    await playground.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 15_000 });
+
+    await playground.locator('#examples').selectOption({ label: 'SHA-256 (benchmark)' });
+    await expect.poll(
+        () => playground.evaluate(() => window.currentAssetsUrl),
+        { timeout: 10_000 }
+    ).toContain('.assets.json');
+    const before = await playground.evaluate(() => window.currentAssetsUrl);
+
+    // Persisted beside the buffer, not merely held in memory.
+    await expect.poll(
+        () => playground.evaluate(() => {
+            const raw = localStorage.getItem('daslang.playground.state.v1');
+            try { return JSON.parse(raw).assets; } catch (e) { return null; }
+        }),
+        { timeout: 5_000 }
+    ).toBe(before);
+
+    await playground.reload();
+    await waitTabsReady(playground);
+
+    expect(await playground.evaluate(() => window.pgRestoredFromState)).toBe(true);
+    await expect.poll(
+        () => playground.evaluate(() => window.currentAssetsUrl),
+        { timeout: 10_000 }
+    ).toBe(before);
+});
+
 test('autosave does not override URL #code hash on reload', async ({ playground }) => {
     await waitTabsReady(playground);
 

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -305,10 +305,15 @@ function showCanvas(show) {
 // delegates cross-origin isolation so -pthread programs get SharedArrayBuffer.
 var pageFrame = null;
 var pageFrameFit = null;
+var pageFrameMsg = null;
 function destroyPageFrame() {
     if (pageFrameFit) {
         window.removeEventListener('resize', pageFrameFit);
         pageFrameFit = null;
+    }
+    if (pageFrameMsg) {
+        window.removeEventListener('message', pageFrameMsg);
+        pageFrameMsg = null;
     }
     if (pageFrame && pageFrame.parentNode) pageFrame.parentNode.removeChild(pageFrame);
     pageFrame = null;
@@ -337,12 +342,24 @@ function runWasmPage(files) {
         'background:#000;margin-top:20px;margin-bottom:6px;';
     pageFrame.src = htmlUrl;
     (runHostEl || editorOutput.parentNode).appendChild(pageFrame);
-    // 3/4 is the run frame's own starting aspect. A cross-origin page cannot
-    // report its drawing buffer back the way run-frame.html does, so this stays
-    // the aspect for the whole run rather than being refined on first paint.
+    // 3/4 is the run frame's starting aspect, used until the page reports its
+    // real drawing buffer — the shell posts canvas-visible exactly as
+    // run-frame.html does, which is what lets the canvas fill without bars.
+    let pageAspect = 3 / 4;
     pageFrameFit = function () {
-        if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.fitElement(pageFrame, 3 / 4);
+        if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.fitElement(pageFrame, pageAspect);
     };
+    // Accept that report only from the frame we created, and only from the
+    // origin its artifact came from.
+    const pageOrigin = new URL(htmlUrl, location.href).origin;
+    pageFrameMsg = function (ev) {
+        if (!pageFrame || ev.source !== pageFrame.contentWindow || ev.origin !== pageOrigin) return;
+        const m = ev.data;
+        if (!m || m.type !== 'canvas-visible' || !(m.width > 0) || !(m.height > 0)) return;
+        pageAspect = m.height / m.width;
+        pageFrameFit();
+    };
+    window.addEventListener('message', pageFrameMsg);
     pageFrameFit();
     window.addEventListener('resize', pageFrameFit);
     const o = document.getElementById('output');

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -304,7 +304,12 @@ function showCanvas(show) {
 // separate, cookie-less run origin is the isolation boundary. The allow list
 // delegates cross-origin isolation so -pthread programs get SharedArrayBuffer.
 var pageFrame = null;
+var pageFrameFit = null;
 function destroyPageFrame() {
+    if (pageFrameFit) {
+        window.removeEventListener('resize', pageFrameFit);
+        pageFrameFit = null;
+    }
     if (pageFrame && pageFrame.parentNode) pageFrame.parentNode.removeChild(pageFrame);
     pageFrame = null;
 }
@@ -323,11 +328,23 @@ function runWasmPage(files) {
     pageFrame.className = 'pg-page-frame';
     pageFrame.setAttribute('title', 'daslang wasm program');
     pageFrame.setAttribute('allow', 'cross-origin-isolated; autoplay; fullscreen');
+    // Geometry is PlaygroundRunner.fitElement's job, not a percentage: this
+    // frame stands in the run host, and the host sizes to its content — so a
+    // width:100% here resolves against nothing and collapses to a tiny box.
+    // The run frame has always been sized off the COLUMN for that reason.
     pageFrame.style.cssText =
-        'display:block;width:100%;aspect-ratio:4/3;border:1px solid #444;' +
+        'display:block;border:1px solid #444;' +
         'background:#000;margin-top:20px;margin-bottom:6px;';
     pageFrame.src = htmlUrl;
     (runHostEl || editorOutput.parentNode).appendChild(pageFrame);
+    // 3/4 is the run frame's own starting aspect. A cross-origin page cannot
+    // report its drawing buffer back the way run-frame.html does, so this stays
+    // the aspect for the whole run rather than being refined on first paint.
+    pageFrameFit = function () {
+        if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.fitElement(pageFrame, 3 / 4);
+    };
+    pageFrameFit();
+    window.addEventListener('resize', pageFrameFit);
     const o = document.getElementById('output');
     if (o) o.classList.add('with-canvas');
 }

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -130,7 +130,18 @@ pageInit = function () {
          });
 
          function applyInitialSelection() {
-             if (window.pgRestoredFromState || editorHasContent()) return;
+             if (window.pgRestoredFromState || editorHasContent()) {
+                 // A restored buffer (autosave, share link, Back) never went
+                 // through selectSample, so its asset manifest was never
+                 // derived. Adopt the one saved beside the buffer — otherwise
+                 // every asset-loading sample runs against an empty MEMFS and
+                 // panics on the first file it opens, but only on a return
+                 // visit, which reads as a random failure.
+                 if (window.pgRestoredAssetsUrl) {
+                     currentAssetsUrl = window.pgRestoredAssetsUrl;
+                 }
+                 return;
+             }
              const params = new URLSearchParams(window.location.search);
              const wanted = params.get("example");
              if (wanted) {

--- a/web/templates/wasm_canvas_shell.html
+++ b/web/templates/wasm_canvas_shell.html
@@ -41,6 +41,21 @@
       var c = document.getElementById('canvas');
       // Keep focus on the canvas so keyboard input reaches the game.
       c.addEventListener('click', function () { c.focus(); });
+      // Report the drawing buffer to an embedder the moment a program asks for
+      // a GL context, so it can size its frame to the program's real aspect —
+      // the same contract run-frame.html has with the playground, which is what
+      // lets the canvas fill without letterboxing. Carries dimensions only, so
+      // the wildcard target discloses nothing; a standalone page just posts to
+      // itself and nobody listens.
+      var origGetContext = c.getContext.bind(c);
+      c.getContext = function (type) {
+        if (/webgl/i.test(String(type))) {
+          try {
+            parent.postMessage({ type: 'canvas-visible', width: c.width, height: c.height }, '*');
+          } catch (e) { /* embedder gone, or none */ }
+        }
+        return origGetContext.apply(c, arguments);
+      };
       return c;
     })(),
   };

--- a/web/templates/wasm_canvas_shell.html
+++ b/web/templates/wasm_canvas_shell.html
@@ -10,9 +10,16 @@
     display: flex; align-items: center; justify-content: center;
   }
   /* Letterbox, never stretch: the canvas keeps its intrinsic (game) aspect
-     ratio and scales to fit. Forcing width/height:100% would distort the
-     fixed-size backing store into the container shape — the "squished" look. */
-  #canvas { max-width: 100%; max-height: 100%; border: 0; outline: none; display: block; }
+     ratio and scales to fit. Forcing width/height:100% ALONE would distort the
+     fixed-size backing store into the container shape — the "squished" look;
+     object-fit is what keeps the aspect while allowing both directions.
+     max-width/max-height alone only ever scale DOWN, so a 640x480 program sat
+     at 640x480 in the middle of a larger frame — measured on a 906px-wide
+     playground frame, which is the "renders in the middle at 2/3" report. */
+  #canvas {
+    width: 100%; height: 100%; object-fit: contain;
+    border: 0; outline: none; display: block;
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
An asset-loading playground sample works when you **pick** it from the dropdown and fails when you **come back** to it.

```
EXCEPTION in init(): cat OBJ failed to load
 at main.das:433:8
```

## Why

`currentAssetsUrl` is derived in exactly one place — `selectSample()`. A page load that *restores* the buffer instead (autosave, a share link, browser Back) deliberately skips `selectSample`, because clobbering someone's work with sample zero is the bug that path exists to prevent. So the manifest is never derived, `collectAssetUrls()` returns `[]`, the run frame gets an empty MEMFS, and the program panics on the first file it opens.

It is **state-dependent, not sample-dependent**, which is exactly what makes it look random from the outside: same sample, same engine, same code — works on the visit where you picked it, panics on the next one.

## Reproduced on production

- Deferred shading picked from the dropdown → `deferred assets loaded: cat=35850 idx, env=0x1c`
- Reload so the buffer restores → identical code → `EXCEPTION in init(): cat OBJ failed to load`, with `currentAssetsUrl === null`

Same for any sample with an assets sidecar (skybox, the textured ones).

## Fix

The buffer alone cannot say where it came from, so the manifest travels with it:

- `playground-tabs.js` persists `assets` alongside the autosaved `{files, active}` and hands it back as `window.pgRestoredAssetsUrl` on restore.
- `main.js` adopts it on the branch that returns early.

Older saved state has no such key, reads back as `null`, and behaves exactly as before — no storage-version bump needed.

## Verification

Regression test in `persistence.spec.js`, checked the honest way: with the adopt-on-restore half removed it fails with `Received: null`; restored, it passes. Full playwright suite **44/44**.

## Not covered, deliberately

A `#z=` share link carries code with **no sample identity at all**, so a shared asset-loading sample still runs without assets. Fixing that means putting the manifest in the link payload, which changes the share format — out of scope here rather than smuggled in.

## CI

Site-only change (`site/**`, `web/examples/ui/**`), so this triggers the playground-e2e lane only, not the full matrix.
