### PR TITLE
pages: cache lib/ with bin/, or a cache hit restores a daslang that cannot start

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,12 +65,19 @@ jobs:
     # cached binaries/archives are reused, so docs redeploy without rebuilding
     # the runtime, games, or compute samples. Any source change to the runtime,
     # modules, daslib, daspkg, or the example sources misses the key → full rebuild.
+    # `lib` is cached with `bin` and must stay that way: bin/daslang links
+    # against lib/liblibDaScriptDyn*.so, and a hit SKIPS the host build below,
+    # so restoring the exe alone yields a binary that cannot start at all
+    # ("error while loading shared libraries"). That combination only occurs on
+    # a site-only merge — anything touching src/modules/daslib misses the key
+    # and rebuilds — which is why it stayed hidden until the first one landed.
     - name: "Cache wasm build artifacts"
       id: wasm-cache
       uses: actions/cache@v4
       with:
         path: |
           bin
+          lib
           modules/dasGlfw/dasModuleGlfw.shared_module
           modules/dasOpenGL/dasModuleOpenGL.shared_module
           modules/dasClipboard/dasModuleClipboard.shared_module


### PR DESCRIPTION
The Pages deploy of #3635 failed, and the site is not updating until this lands.

```
./bin/daslang: error while loading shared libraries: liblibDaScriptDyn.so: cannot open shared object file
```

## Cause

`bin/daslang` links against `lib/liblibDaScriptDyn*.so`. The cache saved `bin` **without** `lib`, and a cache **hit skips the host build entirely** (`if: steps.wasm-cache.outputs.cache-hit != 'true'`) — so the restored binary had no library and nothing left to build one. It cannot start at all; every step downstream of it dies.

## Why now, after months of working

The key hashes `src/**`, `include/**`, `modules/**`, `daslib/**`, `utils/daspkg/**`, `examples/**`, `tutorials/**`, `dastest/**`. Every merge that touches the compiler **misses** the key and rebuilds the host, which quietly papered over the gap.

**#3635 was the first site-only merge** — `site/**`, `web/examples/ui/src/**`, `web/templates/**`, none of them in the hash — so it produced the same key as the merge before it. First cache hit, first failure. The bug has been latent since the cache was introduced; it just needed a change shaped like this one to reach it.

## Fix

Add `lib` to the cached paths.

This also repairs the already-poisoned entry rather than inheriting it: the key hashes **this workflow file**, so editing it misses once, rebuilds from scratch, and stores an entry containing both halves. Without that property the change would be inert — the old `bin`-only entry would keep being restored.

## Verification

YAML re-parsed to confirm `lib` lands as its own path entry and not as text: comments cannot go inside `path: |`, since a literal block scalar would treat `#` lines as paths, so the explanation sits above the step.

The real proof is this workflow's own next run: it must miss the key, rebuild the host, and get past `Run das2rst` — the step that just failed.
