### PR TITLE
playground: fix the broken wasm samples; add the sample verifier (tier 1)

### DIFF
--- a/examples/graphics/physarum_lab_opengl_imgui_example.das
+++ b/examples/graphics/physarum_lab_opengl_imgui_example.das
@@ -57,6 +57,7 @@ let {
     DEF_DIFFUSE = 0.10f
     DEF_EXPOSURE = 1.4f
     DEF_AGENTS = 60000
+    DEF_AGENTS_WEB_INTERP = 10000   // playground opening load — the interpreted-on-wasm runner is ~15x slower
     DEF_COL_LOW = float3(0.0, 0.0, 0.0)
     DEF_COL_MID = float3(1.0, 0.35, 0.0)
     DEF_COL_HIGH = float3(1.0, 0.96, 0.78)
@@ -135,6 +136,8 @@ var display_program : uint
 var vao, vbo, ebo : uint
 var texture : uint                    // the field uploaded here for display
 var upload_rgba : array<float4>       // RGBA staging for the upload (WebGL2 wants RGBA/FLOAT for RGBA32F)
+var g_field_dirty = true              // re-stage the texture only when the field changed (the 512^2
+                                      // staging loop is the main per-frame cost on the interpreted runner)
 
 // ----- display shader: textured fullscreen quad, tonemap + colormap -----
 var @in @location v_position : float2
@@ -327,7 +330,10 @@ def start_update_pass(n : int) {
             st |> notify_and_release   // more bands than agents — balance the wait-group, skip the thread
             continue
         }
-        new_job() <| @capture(= pagents, = pfield, = read_offset, = lo, = hi, = prm, = st) {
+        // new_thread per band (the Path Tracer pattern), NOT new_job: the persistent jobque wedges
+        // the interpreted wasm runner (playground), while per-pass threads work on every runner and
+        // map onto the same pre-spawned Web Worker pool in the compiled build.
+        new_thread() <| @capture(= pagents, = pfield, = read_offset, = lo, = hi, = prm, = st) {
             update_agents_band(pagents, pfield, read_offset, lo, hi, prm)
             st |> notify_and_release
         }
@@ -337,11 +343,12 @@ def start_update_pass(n : int) {
 // Scatter every agent's deposit into the live field (serial on the main thread — race-free).
 def deposit_agents {
     let off = read_off()
+    let dep = g_deposit          // hoisted: the interpreter re-reads a global on every iteration
     for (i in range(g_agent_count)) {
         let a = agents[i]
         let ix = wrap_i(int(floor(a.x)), TW)
         let iy = wrap_i(int(floor(a.y)), TH)
-        field[off + iy * TW + ix] += g_deposit
+        field[off + iy * TW + ix] += dep
     }
 }
 
@@ -350,6 +357,8 @@ def deposit_agents {
 def diffuse_decay {
     let so = read_off()
     let dofs = (1 - g_field_idx) * TW * TH
+    let dif = g_diffuse          // hoisted out of the 512^2 loop — see deposit_agents
+    let dec = g_decay
     for (y in range(TH)) {
         let ym = wrap_i(y - 1, TH) * TW
         let yc = y * TW
@@ -362,7 +371,7 @@ def diffuse_decay {
                 field[so + yp + xm] + field[so + yp + x] + field[so + yp + xp])
             let c = field[so + yc + x]
             let mean = sum * (1.0f / 9.0f)
-            field[dofs + yc + x] = (c + (mean - c) * g_diffuse) * g_decay
+            field[dofs + yc + x] = (c + (mean - c) * dif) * dec
         }
     }
     g_field_idx = 1 - g_field_idx
@@ -386,17 +395,20 @@ def apply_mouse_seed {
     let cy = wrap_i(int((1.0f - mp.y / ds.y) * float(TH)), TH)   // flip Y: GL origin is bottom-left
     let off = read_off()
     let R = 9
+    let r2 = float(R * R)
+    let dep8 = g_deposit * 8.0f
     for (dy in range(-R, R + 1)) {
         for (dx in range(-R, R + 1)) {
             let d2 = float(dx * dx + dy * dy)
-            if (d2 > float(R * R)) {
+            if (d2 > r2) {
                 continue
             }
             let ix = wrap_i(cx + dx, TW)
             let iy = wrap_i(cy + dy, TH)
-            field[off + iy * TW + ix] += g_deposit * 8.0f * exp(-d2 * 0.04f)
+            field[off + iy * TW + ix] += dep8 * exp(-d2 * 0.04f)
         }
     }
+    g_field_dirty = true
 }
 
 // The pass state machine, driven once per frame from update() on the main thread.
@@ -418,6 +430,7 @@ def advance_sim {
         g_prev_pass_tick = ref_time_ticks()
         deposit_agents()
         diffuse_decay()
+        g_field_dirty = true
         g_sim_frame++
     }
     // structural changes are safe here: no worker is touching agents/field
@@ -425,6 +438,7 @@ def advance_sim {
         clear_field()
         reseed_agents()
         g_reseed_pending = false
+        g_field_dirty = true
     } elif (g_target_agents != g_agent_count) {
         reseed_agents()
     }
@@ -435,6 +449,8 @@ def advance_sim {
 // ===== display + ui =====
 
 def upload_field {
+    return if (!g_field_dirty)
+    g_field_dirty = false
     let off = read_off()
     for (i in range(TW * TH)) {
         upload_rgba[i] = float4(field[off + i], 0.0f, 0.0f, 1.0f)
@@ -515,6 +531,14 @@ def drive_audio {
     }
 }
 
+// The playground runs this interpreted on wasm — every pass, the deposit and the diffuse are ~15x
+// slower than the AOT wasm64 card — so open with a lighter agent load there. The slider ceiling
+// stays the same; get_running_platform_name is the runtime (never const-folded) platform.
+def default_agents : int {
+    let web_interp = get_running_platform_name() == "emscripten" && !is_in_aot()
+    return web_interp ? DEF_AGENTS_WEB_INTERP : DEF_AGENTS
+}
+
 def reset_to_defaults {
     g_sensor_angle_deg = DEF_SENSOR_ANGLE
     g_sensor_dist = DEF_SENSOR_DIST
@@ -527,7 +551,7 @@ def reset_to_defaults {
     g_col_low = DEF_COL_LOW
     g_col_mid = DEF_COL_MID
     g_col_high = DEF_COL_HIGH
-    g_target_agents = DEF_AGENTS
+    g_target_agents = default_agents()
     g_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
 }
 
@@ -615,13 +639,11 @@ def init() {
     field |> resize(2 * TW * TH)
     upload_rgba |> resize(TW * TH)
     clear_field()
+    g_target_agents = default_agents()
     reseed_agents()
     // Open at the detected core count, floored to 4 so it never looks single-threaded on a browser
     // that clamps navigator.hardwareConcurrency, and capped at MAX_BANDS. Drag the slider up to oversubscribe.
     g_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
-    // Persistent job queue for the agent passes (start_update_pass uses new_job). Created once here so it
-    // spans the externally-driven frame loop (emscripten set_main_loop) — a with_job_que block can't.
-    create_job_que()
     if (g_audio_enabled) {
         setup_audio()
     }
@@ -670,7 +692,6 @@ def shutdown() {
             g_audio_owned = false
         }
     }
-    destroy_job_que()
     harness_shutdown()
 }
 

--- a/examples/graphics/physarum_lab_opengl_imgui_example.das
+++ b/examples/graphics/physarum_lab_opengl_imgui_example.das
@@ -531,12 +531,28 @@ def drive_audio {
     }
 }
 
-// The playground runs this interpreted on wasm — every pass, the deposit and the diffuse are ~15x
-// slower than the AOT wasm64 card — so open with a lighter agent load there. The slider ceiling
-// stays the same; get_running_platform_name is the runtime (never const-folded) platform.
+// The interpreted playground runs the sim ~30x slower than the compiled wasm64 card, so it opens
+// with a lighter agent load (the slider ceiling stays the same). MEASURED, not sniffed: the card
+// is minted by the --jit-target=wasm64 exe rail, not AOT codegen, so is_in_aot() is false on
+// BOTH wasm runtimes — a timed spin is the only signal that separates them. Web-only: desktop
+// keeps the full defaults whatever its speed.
+var g_light_defaults = false
+
+def private measure_slow_runtime : bool {
+    // pure-ALU spin, measured on daslang.io 2026-08-07: 2ms compiled wasm64, 140ms
+    // interpreted — a 70x gap the 20ms threshold splits with x7 margin on either side.
+    // (A builtin-heavy loop like sin narrows the gap enough to misread; don't.)
+    let t0 = ref_time_ticks()
+    var acc = 0u
+    for (_i in range(10000000)) {
+        acc = acc * 1664525u + 1013904223u
+    }
+    // acc feeds the result so the loop cannot fold away; the right arm is always true
+    return get_time_usec(t0) > 20000 && acc != 12345u
+}
+
 def default_agents : int {
-    let web_interp = get_running_platform_name() == "emscripten" && !is_in_aot()
-    return web_interp ? DEF_AGENTS_WEB_INTERP : DEF_AGENTS
+    return g_light_defaults ? DEF_AGENTS_WEB_INTERP : DEF_AGENTS
 }
 
 def reset_to_defaults {
@@ -639,6 +655,9 @@ def init() {
     field |> resize(2 * TW * TH)
     upload_rgba |> resize(TW * TH)
     clear_field()
+    if (get_running_platform_name() == "emscripten") {
+        g_light_defaults = measure_slow_runtime()
+    }
     g_target_agents = default_agents()
     reseed_agents()
     // Open at the detected core count, floored to 4 so it never looks single-threaded on a browser

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -903,7 +903,8 @@ http_status das_resp_file ( HttpResponse * resp, const char * filepath ) {
 }
 
 http_status das_resp_data ( HttpResponse * resp, const char * data, int32_t len, http_status status ) {
-    if ( len > 0 && (size_t)len > DAS_HV_BUFFERED_BODY_MAX ) {
+    if ( !data || len < 0 ) len = 0;
+    if ( (size_t)len > DAS_HV_BUFFERED_BODY_MAX ) {
         return das_resp_refuse_oversize(resp, "DATA", (size_t)len);
     }
     resp->content_type = APPLICATION_OCTET_STREAM;

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -706,6 +706,18 @@ static void post_writer_op ( Handle<hv::WebSocketServer> h, hv::HttpResponseWrit
     }
 }
 
+// libhv closes any connection whose queued unsent bytes exceed the channel's max write
+// bufsize (1<<24 by default): a buffered body larger than the socket drains in one write()
+// gets the connection dropped MID-BODY — a truncated response after a clean 200. Raise the
+// cap to cover the body; never lower it, so later responses on a kept-alive connection
+// inherit at least the default.
+static void cover_body_write_bufsize ( hv::HttpResponseWriter * wr, size_t body_size ) {
+    size_t want = body_size + (1u << 20);
+    if ( want < (1u << 24) ) want = (1u << 24);
+    if ( want > 0xFFFFFFFFu ) want = 0xFFFFFFFFu;
+    wr->setMaxWriteBufsize((uint32_t)want);
+}
+
 // Whole-body response through the writer (the non-streaming path): status + content-type + body, then
 // end + release. Lets one async (writer) route serve both streamed and buffered responses.
 int das_writer_respond ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w, int32_t status,
@@ -717,7 +729,42 @@ int das_writer_respond ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter *
     post_writer_op(h, w, [adapter,w,st,ct,b](hv::HttpResponseWriter* wr){
         wr->WriteStatus((http_status)st);
         wr->WriteHeader("Content-Type", ct.c_str());
+        cover_body_write_bufsize(wr, b.size());
         wr->End(b);
+        if ( adapter ) adapter->release_writer(w);
+    });
+    return 0;
+}
+
+// Set a header on a writer-rail response. Order matters only relative to the terminal op:
+// headers land on the writer's response object and serialize when `respond` / SERVE_FILE
+// writes it out, so every set_header must be issued before that call.
+int das_writer_set_header ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w,
+        const char * key, const char * value ) {
+    std::string k = key ? key : "";
+    std::string v = value ? value : "";
+    if ( k.empty() ) return -1;
+    post_writer_op(h, w, [k,v](hv::HttpResponseWriter* wr){
+        wr->WriteHeader(k.c_str(), v.c_str());
+    });
+    return 0;
+}
+
+// Whole-file response through the writer — the writer-rail twin of SERVE_FILE. The file is
+// read on the connection loop, so the bytes never pass through a das string (whose
+// `const char*` marshalling truncates binary at the first NUL). Content type follows the
+// file name; headers already set through the writer ride along; a missing file is a 404
+// with an empty body.
+int das_writer_serve_file ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter * w, const char * filepath ) {
+    auto adapter = lookup_server(h);
+    std::string path = filepath ? filepath : "";
+    post_writer_op(h, w, [adapter,w,path](hv::HttpResponseWriter* wr){
+        int st = wr->response->File(path.c_str());
+        if ( st != 200 ) wr->response->body.clear();
+        wr->response->status_code = (http_status)st;
+        cover_body_write_bufsize(wr, wr->response->body.size());
+        wr->WriteResponse(wr->response.get());
+        wr->End();
         if ( adapter ) adapter->release_writer(w);
     });
     return 0;
@@ -1607,6 +1654,12 @@ public:
         addExtern<DAS_BIND_FUN(das_writer_set_keepalive_timeout)> (*this, lib, "set_writer_keepalive_timeout",
             SideEffects::worstDefault, "das_writer_set_keepalive_timeout")
                 ->args({"server","writer","timeout_ms"});
+        addExtern<DAS_BIND_FUN(das_writer_set_header)> (*this, lib, "set_header",
+            SideEffects::worstDefault, "das_writer_set_header")
+                ->args({"server","writer","key","value"});
+        addExtern<DAS_BIND_FUN(das_writer_serve_file)> (*this, lib, "SERVE_FILE",
+            SideEffects::worstDefault, "das_writer_serve_file")
+                ->args({"server","writer","filepath"});
         addExtern<DAS_BIND_FUN(das_writer_close)> (*this, lib, "close_writer",
             SideEffects::worstDefault, "das_writer_close")
                 ->args({"server","writer"});

--- a/modules/dasHV/src/dasHV.cpp
+++ b/modules/dasHV/src/dasHV.cpp
@@ -730,7 +730,10 @@ int das_writer_respond ( Handle<hv::WebSocketServer> h, hv::HttpResponseWriter *
         wr->WriteStatus((http_status)st);
         wr->WriteHeader("Content-Type", ct.c_str());
         cover_body_write_bufsize(wr, b.size());
-        wr->End(b);
+        int rc = wr->End(b);
+        if ( rc < 0 ) {
+            hloge("dasHV: writer respond failed rc=%d body=%zu", rc, b.size());
+        }
         if ( adapter ) adapter->release_writer(w);
     });
     return 0;
@@ -763,7 +766,11 @@ int das_writer_serve_file ( Handle<hv::WebSocketServer> h, hv::HttpResponseWrite
         if ( st != 200 ) wr->response->body.clear();
         wr->response->status_code = (http_status)st;
         cover_body_write_bufsize(wr, wr->response->body.size());
-        wr->WriteResponse(wr->response.get());
+        int rc = wr->WriteResponse(wr->response.get());
+        if ( rc < 0 ) {
+            hloge("dasHV: writer SERVE_FILE failed rc=%d file=%s body=%zu",
+                rc, path.c_str(), wr->response->body.size());
+        }
         wr->End();
         if ( adapter ) adapter->release_writer(w);
     });
@@ -872,11 +879,33 @@ http_status das_resp_redirect ( HttpResponse * resp, const char * location, http
     return (http_status)resp->Redirect(location ? location : "/", status);
 }
 
+// The buffered rail cannot raise the connection's write-buf cap — the write happens after
+// the handler returns, with no channel in reach — so a body over the libhv default gets the
+// connection closed MID-SEND: a truncated response after a clean 200, logged only in libhv's
+// side log. Refuse loudly instead; a big body belongs on the writer rail, which covers it.
+static const size_t DAS_HV_BUFFERED_BODY_MAX = (1u << 24) - (1u << 20);
+
+static http_status das_resp_refuse_oversize ( HttpResponse * resp, const char * what, size_t size ) {
+    hloge("dasHV: buffered %s refused: %zu bytes exceeds the %zu write-buf budget; "
+          "serve it through a STREAM route's SERVE_FILE/respond", what, size, DAS_HV_BUFFERED_BODY_MAX);
+    resp->content_type = TEXT_PLAIN;
+    resp->body = "response too large for the buffered rail; serve it through a STREAM route";
+    return (http_status)HTTP_STATUS_INTERNAL_SERVER_ERROR;
+}
+
 http_status das_resp_file ( HttpResponse * resp, const char * filepath ) {
-    return (http_status)resp->File(filepath ? filepath : "");
+    std::string path = filepath ? filepath : "";
+    size_t fs = hv_filesize(path.c_str());
+    if ( fs > DAS_HV_BUFFERED_BODY_MAX ) {
+        return das_resp_refuse_oversize(resp, "SERVE_FILE", fs);
+    }
+    return (http_status)resp->File(path.c_str());
 }
 
 http_status das_resp_data ( HttpResponse * resp, const char * data, int32_t len, http_status status ) {
+    if ( len > 0 && (size_t)len > DAS_HV_BUFFERED_BODY_MAX ) {
+        return das_resp_refuse_oversize(resp, "DATA", (size_t)len);
+    }
     resp->content_type = APPLICATION_OCTET_STREAM;
     resp->body.assign(data, len);
     return status;

--- a/modules/dasImgui/widgets/imgui_harness.das
+++ b/modules/dasImgui/widgets/imgui_harness.das
@@ -81,6 +81,7 @@ require imgui_app_headless
 require imgui/imgui_harness_lint public
 
 require daslib/clargs
+require daslib/safe_addr
 require strings
 
 var private g_headless          : bool = false
@@ -215,11 +216,22 @@ def public harness_begin_frame() : bool {
     begin_frame()
     // (no ImGui_ImplOpenGL3_NewFrame — the das renderer builds its objects at init, nothing per-frame)
     ImGui_ImplGlfw_NewFrame()
+    var io & = unsafe(GetIO())
+    // Web: emscripten GLFW samples the canvas CSS size at creation as the "window size" — a
+    // host revealing the canvas only on first GL context (playground run-frame) samples it
+    // hidden, DisplaySize stays 0x0, every draw list is discarded. Real fb size fixes it.
+    if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f) {
+        var fbw, fbh : int
+        glfwGetFramebufferSize(live_window, safe_addr(fbw), safe_addr(fbh))
+        if (fbw > 0 && fbh > 0) {
+            io.DisplaySize = float2(float(fbw), float(fbh))
+            io.DisplayFramebufferScale = float2(1.0f, 1.0f)
+        }
+    }
     // Single clock: drive ImGui DeltaTime from the master clock (get_dt), so lockstep
     // recording uses the fixed step; normal mode get_dt()==wall dt (no-op). Guard >0.
     let mdt = get_dt()
     if (mdt > 0.0f) {
-        var io & = unsafe(GetIO())
         io.DeltaTime = mdt
     }
     advance_coroutines()

--- a/site/playground/run-frame.html
+++ b/site/playground/run-frame.html
@@ -24,7 +24,11 @@
   and talks to this frame only over postMessage.
 -->
 <style>
-    html, body { margin: 0; padding: 0; height: 100%; background: transparent; overflow: hidden; }
+    /* Opaque body, NOT transparent: under the playground's cross-origin isolation the
+       browser composites this document on an opaque white backing, so "transparent"
+       never reveals the parent's black frame — any area the canvas doesn't cover
+       renders WHITE (seen as a white L around a 512px program in a column-wide frame). */
+    html, body { margin: 0; padding: 0; height: 100%; background: #000; overflow: hidden; }
     /* Fill the frame exactly: the parent sizes the frame to the drawing buffer's
        aspect, so 100%/100% scales without distorting. !important because
        emscripten's GLFW writes an inline width/height onto the canvas. */
@@ -46,6 +50,19 @@
 
     var PARENT = window.parent;
     var canvas = document.getElementById("canvas");
+
+    // Emscripten's GLFW stamps the program's window size onto the canvas as an INLINE
+    // "width: Npx !important" at window creation — and inline !important beats the
+    // stylesheet's, so the canvas shrank to program pixels inside a frame the parent
+    // sized to the column. Undo it whenever it appears: the drawing buffer keeps the
+    // program's size, CSS keeps the fill-the-frame presentation. Self-terminating:
+    // our own rewrite re-fires the observer, sees 100%, and does nothing.
+    new MutationObserver(function () {
+        if (canvas.style.width !== "100%") {
+            canvas.style.setProperty("width", "100%", "important");
+            canvas.style.setProperty("height", "100%", "important");
+        }
+    }).observe(canvas, { attributes: true, attributeFilter: ["style"] });
 
     function post(msg) {
         try { PARENT.postMessage(msg, window.location.origin); } catch (e) { /* parent gone */ }

--- a/skills/dashv.md
+++ b/skills/dashv.md
@@ -59,10 +59,17 @@ STREAM("/events") <| @(var req : HttpRequest?; var writer : HttpResponseWriter?)
 ```
 
 - **Writer ops are handle-first** — `respond` / `sse_event` / `write_chunked` / `end_headers` /
-  `close_writer` / `release_writer` / `is_writer_connected` all take the **server handle first**,
-  then the `writer`. That is deliberate: generation runs on the tick thread, and the op posts the
-  socket write to the connection's event loop (`adapter->loop()->runInLoop`) so writes marshal to
-  the right loop.
+  `set_header` / `SERVE_FILE` / `close_writer` / `release_writer` / `is_writer_connected` all take
+  the **server handle first**, then the `writer`. That is deliberate: generation runs on the tick
+  thread, and the op posts the socket write to the connection's event loop
+  (`adapter->loop()->runInLoop`) so writes marshal to the right loop.
+- **Large or binary bodies must go through the writer rail.** The buffered `resp |> SERVE_FILE`
+  path cannot raise libhv's per-connection write-buf cap (16MB): a bigger body gets the connection
+  closed MID-BODY — a truncated response after a clean 200, logged only in `bin/libhv.*.log`.
+  `SERVE_FILE(server, writer, path)` reads the file on the connection loop (binary-safe, content
+  type from the file name) and covers the body with the cap; `respond` covers its body the same
+  way. Set extra headers first with `set_header(server, writer, k, v)` — they serialize when the
+  terminal op writes.
 - `is_writer_connected(server, writer)` — true while the writer's client connection is still open
   (false for null / unknown / released writers). The async write ops never report a dead peer, so
   a long-lived stream **polls this to evict abandoned clients** (see `openai_server.das`'s

--- a/skills/dashv.md
+++ b/skills/dashv.md
@@ -63,13 +63,16 @@ STREAM("/events") <| @(var req : HttpRequest?; var writer : HttpResponseWriter?)
   the **server handle first**, then the `writer`. That is deliberate: generation runs on the tick
   thread, and the op posts the socket write to the connection's event loop
   (`adapter->loop()->runInLoop`) so writes marshal to the right loop.
-- **Large or binary bodies must go through the writer rail.** The buffered `resp |> SERVE_FILE`
-  path cannot raise libhv's per-connection write-buf cap (16MB): a bigger body gets the connection
-  closed MID-BODY — a truncated response after a clean 200, logged only in `bin/libhv.*.log`.
+- **Large or binary bodies must go through the writer rail.** The buffered path cannot raise
+  libhv's per-connection write-buf cap (16MB) — a bigger body would get the connection closed
+  MID-BODY, a truncated response after a clean 200 — so buffered `SERVE_FILE`/`DATA` REFUSE a
+  body over ~15MB with a 500 naming the writer rail (fail closed, never truncate).
   `SERVE_FILE(server, writer, path)` reads the file on the connection loop (binary-safe, content
   type from the file name) and covers the body with the cap; `respond` covers its body the same
   way. Set extra headers first with `set_header(server, writer, k, v)` — they serialize when the
-  terminal op writes.
+  terminal op writes. Writer-rail write failures are still async: the das call cannot return
+  them; they land as `dasHV:` ERROR lines in libhv's log (`bin/libhv.*.log` by default — route
+  with `DASLIVE_HV_LOG=stderr`), and `is_writer_connected` flips false afterwards.
 - `is_writer_connected(server, writer)` — true while the writer's client connection is still open
   (false for null / unknown / released writers). The async write ops never report a dead peer, so
   a long-lived stream **polls this to evict abandoned clients** (see `openai_server.das`'s

--- a/tests/dasHV/test_server_advanced.das
+++ b/tests/dasHV/test_server_advanced.das
@@ -43,7 +43,7 @@ class AdvancedTestServer : HvWebServer {
 
         // Binary data
         GET("/binary") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
-            var payload = "BINARYDATA12"
+            let payload = "BINARYDATA12"
             return resp |> DATA(payload, 12)
         }
 
@@ -69,6 +69,12 @@ class AdvancedTestServer : HvWebServer {
         POST("/ack") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return http_status.NO_CONTENT
         }
+
+        // Oversize buffered file — the buffered rail cannot cover a body past libhv's
+        // write-buf cap, so SERVE_FILE must refuse loudly (500), never truncate a 200
+        GET("/bigfile") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return resp |> SERVE_FILE("{self.static_dir}/big.bin")
+        }
     }
 }
 
@@ -82,6 +88,8 @@ def with_advanced_test_server(port : int; blk : block<(base_url : string) : void
     mkdir_rec(static_root)
     write_test_file("{static_root}/index.html", "<h1>Test</h1>")
     write_test_file("{static_root}/data.json", "\{\"key\":\"value\"\}")
+    // 17MB — past the buffered rail's write-buf budget, for the oversize-refusal test
+    write_test_file("{static_root}/big.bin", repeat("0123456789abcdef", 17 * 1024 * 1024 / 16))
 
     with_job_status(1) $(started) {
         with_job_status(1) $(finished) {
@@ -117,6 +125,7 @@ def with_advanced_test_server(port : int; blk : block<(base_url : string) : void
     // Cleanup
     remove("{static_root}/index.html")
     remove("{static_root}/data.json")
+    remove("{static_root}/big.bin")
     remove(static_root)
 }
 
@@ -126,7 +135,7 @@ def with_advanced_test_server(port : int; blk : block<(base_url : string) : void
 
 [test]
 def test_static_file_serving(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("serves HTML file") @(t : T?) {
             GET("{base_url}/static/index.html") <| $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.OK))
@@ -149,7 +158,7 @@ def test_static_file_serving(t : T?) {
 
 [test]
 def test_cors(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("CORS headers present on response") @(t : T?) {
             with_http_request() <| $(var req) {
                 req.method = http_method.OPTIONS
@@ -167,7 +176,7 @@ def test_cors(t : T?) {
 
 [test]
 def test_redirect(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("REDIRECT returns 301 with Location header") @(t : T?) {
             with_http_request() <| $(var req) {
                 req.method = http_method.GET
@@ -191,7 +200,7 @@ def test_redirect(t : T?) {
 
 [test]
 def test_custom_headers_caching(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("custom Cache-Control and ETag headers") @(t : T?) {
             GET("{base_url}/cached") <| $(resp) {
                 let cc = get_header(resp, "Cache-Control")
@@ -207,7 +216,7 @@ def test_custom_headers_caching(t : T?) {
 
 [test]
 def test_binary_data(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("DATA returns binary with octet-stream content-type") @(t : T?) {
             GET("{base_url}/binary") <| $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.OK))
@@ -221,7 +230,7 @@ def test_binary_data(t : T?) {
 
 [test]
 def test_custom_content_type(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("HTML response with text/html content-type") @(t : T?) {
             GET("{base_url}/html") <| $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.OK))
@@ -235,7 +244,7 @@ def test_custom_content_type(t : T?) {
 
 [test]
 def test_status_404(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("404 error with JSON body") @(t : T?) {
             GET("{base_url}/not-found") <| $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.NOT_FOUND))
@@ -249,7 +258,7 @@ def test_status_404(t : T?) {
 
 [test]
 def test_status_201_created(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("201 Created with Location header") @(t : T?) {
             POST("{base_url}/items", "new item") <| $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.CREATED))
@@ -262,10 +271,22 @@ def test_status_201_created(t : T?) {
 
 [test]
 def test_status_204_no_content(t : T?) {
-    with_advanced_test_server(PORT_SERVER_ADVANCED) <| $(base_url) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
         t |> run("204 No Content") @(t : T?) {
             POST("{base_url}/ack", "done") <| $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.NO_CONTENT))
+            }
+        }
+    }
+}
+
+[test]
+def test_buffered_oversize_refused(t : T?) {
+    with_advanced_test_server(PORT_SERVER_ADVANCED) $(base_url) {
+        t |> run("a buffered SERVE_FILE past the write-buf budget answers 500, never a truncated 200") @(t : T?) {
+            GET("{base_url}/bigfile") <| $(resp) {
+                t |> equal(int(resp.status_code), 500)
+                t |> success(find(string(resp.body), "STREAM route") >= 0, "the refusal names the writer rail")
             }
         }
     }

--- a/tutorials/opengl/12_gltf/12_gltf.das
+++ b/tutorials/opengl/12_gltf/12_gltf.das
@@ -726,11 +726,11 @@ def init {
     prog_up = create_shader_program(@@post_vs, @@up_fs)
     prog_composite = create_shader_program(@@post_vs, @@composite_fs)
 
-    g_scene <- load_gltf(MODEL)
+    g_scene <- load_gltf(MODEL) // nolint:PERF030 — fresh at the one-time init
     if (empty(g_scene.meshes)) {
         panic("no meshes loaded from {MODEL}")
     }
-    g_model <- upload_gltf(g_scene)
+    g_model <- upload_gltf(g_scene) // nolint:PERF030 — fresh at the one-time init
     compute_root()
 
     glGenVertexArrays(1, safe_addr(floor_vao))

--- a/utils/dasweb-buildd/buildd_core.das
+++ b/utils/dasweb-buildd/buildd_core.das
@@ -244,12 +244,22 @@ def write_page_package(src_dir : string; entry : string; assets : array<string>;
     //! escape their string literals. Asset sources are absolute worktree paths
     //! (daspkg's path_join resolution keeps an absolute src as-is); each embeds
     //! at /<path> where the program's fopen("<path>") finds it.
+    var asset_bytes = 0l
     let embeds = build_string() $(writer) {
         for (a in assets) {
             // forward slashes regardless of host: emcc accepts them everywhere, and
             // the generated literal must never contain a backslash escape
             let src = replace(path_join(worktree, a), "\\", "/")
+            var sz_err = ""
+            asset_bytes += file_size(path_join(worktree, a), sz_err)
             writer |> write("    release_embed_file(\"{src}\", \"/{a}\")\n")
+        }
+        // Embedded files live in the wasm data segment, which must fit INITIAL_MEMORY
+        // at link (wasm-ld: "initial memory too small") — growth only helps later.
+        // Base 16MB link default + the embeds + slack, rounded to the 64KB wasm page.
+        if (asset_bytes > 0l) {
+            let initial : int64 = (asset_bytes + int64(24 * 1024 * 1024) + int64(0xFFFF)) & ~int64(0xFFFF)
+            writer |> write("    release_emcc_arg(\"-sINITIAL_MEMORY={initial}\")\n")
         }
     }
     let body = ("options gen2\n" +

--- a/utils/dasweb-buildd/buildd_core.das
+++ b/utils/dasweb-buildd/buildd_core.das
@@ -29,9 +29,8 @@ struct BuildRunResult {
     output : string   // combined stdout+stderr (the build script redirects its own stderr)
 }
 
-def private is_boring_component(name : string; suffixes) : bool {
-    let n = length(name)
-    if (n < 2 || n > 128) {
+def private is_boring_chars(name : string) : bool {
+    if (empty(name) || name |> starts_with(".") || find(name, "..") >= 0) {
         return false
     }
     var ok = true
@@ -43,7 +42,12 @@ def private is_boring_component(name : string; suffixes) : bool {
             }
         }
     }
-    if (!ok || name |> starts_with(".") || find(name, "..") >= 0) {
+    return ok
+}
+
+def private is_boring_component(name : string; suffixes) : bool {
+    let n = length(name)
+    if (n < 2 || n > 128 || !is_boring_chars(name)) {
         return false
     }
     for (suffix in suffixes) {
@@ -58,6 +62,61 @@ def is_valid_source_filename(name : string) : bool {
     //! Bundle file names are user-authored; one boring `.das` path component
     //! or the job is refused before anything touches the filesystem.
     return is_boring_component(name, fixed_array(".das"))
+}
+
+// ===== declared page assets =====
+
+let WASM_ASSETS_MARKER = "// wasm-assets:"
+let WASM_ASSETS_PREFIX = "tutorials/_assets/"
+
+def collect_declared_assets(source : string) : array<string> {
+    //! `// wasm-assets: <path>` lines in a page entry — one worktree-relative
+    //! asset path each, embedded into the artifact's MEMFS at /<path> so the
+    //! program's fopen("<path>") finds it (the same mapping the interpreted
+    //! runner's sidecar preload uses).
+    var out : array<string>
+    for (line in split(source, "\n")) {
+        let trimmed = line |> strip
+        if (trimmed |> starts_with(WASM_ASSETS_MARKER)) {
+            let p = slice(trimmed, length(WASM_ASSETS_MARKER)) |> strip
+            if (!empty(p)) {
+                out |> push(p)
+            }
+        }
+    }
+    return <- out
+}
+
+def is_valid_asset_path(path : string) : bool {
+    //! User-authored, becomes a filesystem path AND a generated .das_package
+    //! string literal: boring '/'-joined components, confined to the assets
+    //! allowlist. Anything else refuses the job before the filesystem is touched.
+    if (!(path |> starts_with(WASM_ASSETS_PREFIX)) ||
+            find(path, "\\") >= 0 || find(path, "//") >= 0 || path |> ends_with("/")) {
+        return false
+    }
+    for (part in split(path, "/")) {
+        if (!is_boring_chars(part)) {
+            return false
+        }
+    }
+    return true
+}
+
+def validate_asset_paths(assets : array<string>; worktree : string; var error : string&) : bool {
+    //! Shape first, existence second — the message is the user's own declaration
+    //! talking, so it names the exact line that refused.
+    for (a in assets) {
+        if (!is_valid_asset_path(a)) {
+            error = "invalid wasm-assets path `{a}`: one relative path under {WASM_ASSETS_PREFIX}, plain characters only"
+            return false
+        }
+        if (!fexist(path_join(worktree, a))) {
+            error = "wasm-assets path `{a}` does not exist in the build toolchain"
+            return false
+        }
+    }
+    return true
 }
 
 def private is_lower_hex(s : string; min_len : int; max_len : int) : bool {
@@ -176,12 +235,23 @@ def expected_artifact_names(mode : string) : array<string> {
     return <- array<string>()
 }
 
-def write_page_package(src_dir : string; entry : string) : bool {
+def write_page_package(src_dir : string; entry : string; assets : array<string>; worktree : string) : bool {
     //! The .das_package a page build compiles under — daspkg's release-wasm rail
     //! wants one, and a job's sources can never carry their own (bundle names
     //! must be plain `.das`). Naming the app `sample` pins the exact artifact
-    //! set. `entry` is already validated (is_valid_source_filename), so the
-    //! interpolation cannot escape the string.
+    //! set. `entry` is already validated (is_valid_source_filename) and every
+    //! asset path passed validate_asset_paths, so the interpolations cannot
+    //! escape their string literals. Asset sources are absolute worktree paths
+    //! (daspkg's path_join resolution keeps an absolute src as-is); each embeds
+    //! at /<path> where the program's fopen("<path>") finds it.
+    let embeds = build_string() $(writer) {
+        for (a in assets) {
+            // forward slashes regardless of host: emcc accepts them everywhere, and
+            // the generated literal must never contain a backslash escape
+            let src = replace(path_join(worktree, a), "\\", "/")
+            writer |> write("    release_embed_file(\"{src}\", \"/{a}\")\n")
+        }
+    }
     let body = ("options gen2\n" +
         "require daslib/daspkg\n\n" +
         "[export]\n" +
@@ -192,6 +262,7 @@ def write_page_package(src_dir : string; entry : string) : bool {
         "def release() \{\n" +
         "    release_name(\"sample\")\n" +
         "    release_main(\"{entry}\")\n" +
+        embeds +
         "\}\n")
     if (!fwrite(path_join(src_dir, ".das_package"), body)) {
         logger_error("buildd.core", "cannot write .das_package into {src_dir}")

--- a/utils/dasweb-buildd/buildd_service.das
+++ b/utils/dasweb-buildd/buildd_service.das
@@ -126,6 +126,21 @@ def private new_scratch_dir(var error : string&) : string {
     return ""
 }
 
+def private declared_page_assets(src_dir, entry, mode, worktree : string; var why : string&) : array<string> {
+    //! Assets a page entry declares (`// wasm-assets: <path>`) embed into the
+    //! artifact's MEMFS. User-authored paths: validated against the worktree
+    //! allowlist BEFORE the generated package references them; an invalid line
+    //! sets `why` (the user's own declaration talking) and yields no assets.
+    if (empty(entry) || mode != "page") {
+        return <- array<string>()
+    }
+    var out <- collect_declared_assets(fread(path_join(src_dir, entry)))
+    if (!validate_asset_paths(out, worktree, why)) {
+        out |> clear()
+    }
+    return <- out
+}
+
 def private run_one_job(job : ClaimedBuild) {
     //! One claimed job, start to finish: materialize, build, upload, clean up.
     //! Every outcome resolves the job on the server — a claim this function
@@ -150,14 +165,18 @@ def private run_one_job(job : ClaimedBuild) {
     mkdir_rec(out_dir)
     logger_info("buildd", "job start", JV((hash = job.hash, mode = job.mode, toolchain = job.toolchain)))
     let entry = unpack_sources(src_dir, job.source)
+    var asset_why = ""
+    let assets <- declared_page_assets(src_dir, entry, job.mode, g_cfg.worktree, asset_why)
     // A page build compiles under a generated .das_package (the release-wasm
     // rail wants one; job sources can never carry their own). Written by THIS
     // service into a dir it owns, before the sandbox ever runs.
-    let packaged = empty(entry) || job.mode != "page" || write_page_package(src_dir, entry)
+    let packaged = (empty(entry) || job.mode != "page" ||
+        (empty(asset_why) && write_page_package(src_dir, entry, assets, g_cfg.worktree)))
     if (empty(entry) || !packaged) {
-        // Two different faults, and the user must not be told their source is
+        // Three different faults, and the user must not be told their source is
         // malformed when the builder is what failed.
-        let why = empty(entry) ? "malformed source document" : "builder could not prepare the build directory"
+        let why = (empty(entry) ? "malformed source document"
+            : (!empty(asset_why) ? asset_why : "builder could not prepare the build directory"))
         logger_warning("buildd", "job failed: {why}",
             JV((hash = job.hash, duration_ms = get_time_usec(t0) / 1000)))
         upload_failure(g_cfg.server_url, g_cfg.token, job.hash, job.toolchain, why)

--- a/utils/dasweb-buildd/test_buildd_core.das
+++ b/utils/dasweb-buildd/test_buildd_core.das
@@ -181,11 +181,61 @@ def test_build_cannot_widen_its_own_output(t : T?) {
 def test_write_page_package(t : T?) {
     with_temp_dir("buildd_pkg_") $(dir) {
         t |> run("the generated package names the app sample and the job's entry") @(tt : T?) {
-            tt |> success(write_page_package(dir, "prog.das"), "written")
+            let no_assets : array<string>
+            tt |> success(write_page_package(dir, "prog.das", no_assets, ""), "written")
             let body = fread(path_join(dir, ".das_package"))
             tt |> success(find(body, "release_name(\"sample\")") >= 0, "app is sample")
             tt |> success(find(body, "release_main(\"prog.das\")") >= 0, "entry carried")
             tt |> success(find(body, "require daslib/daspkg") >= 0, "daspkg hook file")
+            tt |> success(find(body, "release_embed_file") < 0, "no embeds without assets")
+        }
+        t |> run("declared assets become absolute-src embeds at /<path>") @(tt : T?) {
+            let assets <- [ "tutorials/_assets/gltf/BoomBox.glb" ]
+            tt |> success(write_page_package(dir, "prog.das", assets, "/wt"), "written")
+            let body = fread(path_join(dir, ".das_package"))
+            tt |> success(
+                find(body, "release_embed_file(\"/wt/tutorials/_assets/gltf/BoomBox.glb\", \"/tutorials/_assets/gltf/BoomBox.glb\")") >= 0,
+                "embed line carries absolute src and MEMFS dst")
+        }
+    }
+}
+
+[test]
+def test_declared_assets(t : T?) {
+    t |> run("wasm-assets lines parse; everything else is ignored") @(tt : T?) {
+        let src = ("options gen2\n" +
+            "// wasm-assets: tutorials/_assets/gltf/BoomBox.glb\n" +
+            "  // wasm-assets:   tutorials/_assets/hdri/cannon_2k.hdr  \n" +
+            "// wasm-assets:\n" +
+            "// not-assets: tutorials/_assets/x.bin\n" +
+            "require math\n")
+        let got <- collect_declared_assets(src)
+        tt |> equal(length(got), 2)
+        tt |> equal(got[0], "tutorials/_assets/gltf/BoomBox.glb")
+        tt |> equal(got[1], "tutorials/_assets/hdri/cannon_2k.hdr")
+    }
+    t |> run("asset paths are shape-checked: allowlist prefix, boring components") @(tt : T?) {
+        tt |> success(is_valid_asset_path("tutorials/_assets/cat/textures/concrete_cat_statue_diff_2k.jpg"), "real shape")
+        tt |> success(!is_valid_asset_path("/etc/passwd"), "absolute")
+        tt |> success(!is_valid_asset_path("tutorials/_assets/../../secrets.txt"), "traversal")
+        tt |> success(!is_valid_asset_path("examples/hello.das"), "outside the allowlist")
+        tt |> success(!is_valid_asset_path("tutorials/_assets/a\\b.bin"), "backslash")
+        tt |> success(!is_valid_asset_path("tutorials/_assets//x.bin"), "empty component")
+        tt |> success(!is_valid_asset_path("tutorials/_assets/"), "no file")
+    }
+    t |> run("validation fails closed with the offending path in the message") @(tt : T?) {
+        with_temp_dir("buildd_assets_") $(wt) {
+            mkdir_rec(path_join(wt, "tutorials/_assets/gltf"))
+            fwrite(path_join(wt, "tutorials/_assets/gltf/BoomBox.glb"), "glb bytes")
+            let ok_assets <- [ "tutorials/_assets/gltf/BoomBox.glb" ]
+            var err = ""
+            tt |> success(validate_asset_paths(ok_assets, wt, err), "existing asset passes")
+            let missing <- [ "tutorials/_assets/gltf/NoSuch.glb" ]
+            tt |> success(!validate_asset_paths(missing, wt, err), "missing asset refuses")
+            tt |> success(find(err, "NoSuch.glb") >= 0, "message names the path")
+            let bad <- [ "tutorials/_assets/../x" ]
+            tt |> success(!validate_asset_paths(bad, wt, err), "bad shape refuses")
+            remove(path_join(wt, "tutorials/_assets/gltf/BoomBox.glb"))
         }
     }
 }

--- a/utils/dasweb-buildd/test_buildd_core.das
+++ b/utils/dasweb-buildd/test_buildd_core.das
@@ -190,12 +190,17 @@ def test_write_page_package(t : T?) {
             tt |> success(find(body, "release_embed_file") < 0, "no embeds without assets")
         }
         t |> run("declared assets become absolute-src embeds at /<path>") @(tt : T?) {
+            mkdir_rec(path_join(dir, "wt/tutorials/_assets/gltf"))
+            fwrite(path_join(dir, "wt/tutorials/_assets/gltf/BoomBox.glb"), "glb bytes")
+            let wt = replace(path_join(dir, "wt"), "\\", "/")
             let assets <- [ "tutorials/_assets/gltf/BoomBox.glb" ]
-            tt |> success(write_page_package(dir, "prog.das", assets, "/wt"), "written")
+            tt |> success(write_page_package(dir, "prog.das", assets, wt), "written")
             let body = fread(path_join(dir, ".das_package"))
             tt |> success(
-                find(body, "release_embed_file(\"/wt/tutorials/_assets/gltf/BoomBox.glb\", \"/tutorials/_assets/gltf/BoomBox.glb\")") >= 0,
+                find(body, "release_embed_file(\"{wt}/tutorials/_assets/gltf/BoomBox.glb\", \"/tutorials/_assets/gltf/BoomBox.glb\")") >= 0,
                 "embed line carries absolute src and MEMFS dst")
+            // embedded files live in the data segment: the package must widen INITIAL_MEMORY
+            tt |> success(find(body, "release_emcc_arg(\"-sINITIAL_MEMORY=") >= 0, "initial memory covers embeds")
         }
     }
 }

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -645,7 +645,7 @@ def private handle_build_artifact(srv : WebSocketServer; var req : HttpRequest?;
     // STREAM registers ANY-method matching; the artifact surface is GET-only
     // (caddy's 1MB request-body cap on this route assumes no handler reads one)
     if (req.method != http_method.GET) {
-        log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
+        log_request("{req.method}", "/api/build/artifact", 404, ip, 0, 0, t0)
         respond(srv, writer, int(http_status.NOT_FOUND), "application/json",
             write_json(JV((error = "unknown artifact"))))
         return

--- a/utils/dasweb-playground/playground_server.das
+++ b/utils/dasweb-playground/playground_server.das
@@ -185,8 +185,11 @@ class PlaygroundServer : HvWebServer {
         GET("/api/build/status/:hash") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_build_status(req, resp)
         }
-        GET("/api/build/artifact/:toolchain/:hash/:file") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
-            return handle_build_artifact(req, resp)
+        // Writer rail, not a buffered GET: artifacts run to tens of MB, and libhv drops a
+        // connection whose queued unsent body exceeds its write-buf cap — the writer-rail
+        // SERVE_FILE raises the cap over the body, the buffered path cannot.
+        STREAM("/api/build/artifact/:toolchain/:hash/:file") <| @(var req : HttpRequest?; var writer : HttpResponseWriter?) {
+            handle_build_artifact(server, req, writer)
         }
         POST("/api/build/toolchain") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_build_toolchain(req, resp)
@@ -636,9 +639,17 @@ def private page_origin_host : string {
     return p >= 0 ? slice(o, p + 3) : o
 }
 
-def private handle_build_artifact(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+def private handle_build_artifact(srv : WebSocketServer; var req : HttpRequest?; var writer : HttpResponseWriter?) {
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
+    // STREAM registers ANY-method matching; the artifact surface is GET-only
+    // (caddy's 1MB request-body cap on this route assumes no handler reads one)
+    if (req.method != http_method.GET) {
+        log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
+        respond(srv, writer, int(http_status.NOT_FOUND), "application/json",
+            write_json(JV((error = "unknown artifact"))))
+        return
+    }
     let file = get_param(req, "file")
     // A document artifact is attacker-authored content that becomes part of
     // whatever origin serves it, so it answers ONLY on the dedicated page
@@ -648,7 +659,9 @@ def private handle_build_artifact(var req : HttpRequest?; var resp : HttpRespons
     // fail-closed rule the enqueue side applies.
     if (is_document_artifact(file) && get_header(req, "Host") != page_origin_host()) {
         log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
-        return resp |> JSON(write_json(JV((error = "page artifacts are served from the run origin"))), http_status.NOT_FOUND)
+        respond(srv, writer, int(http_status.NOT_FOUND), "application/json",
+            write_json(JV((error = "page artifacts are served from the run origin"))))
+        return
     }
     // resolve_artifact_file revalidates every request-derived component; a path
     // is only ever built from parts that passed
@@ -656,28 +669,31 @@ def private handle_build_artifact(var req : HttpRequest?; var resp : HttpRespons
         get_param(req, "toolchain"), get_param(req, "hash"), file)
     if (empty(path)) {
         log_request("GET", "/api/build/artifact", 404, ip, 0, 0, t0)
-        return resp |> JSON(write_json(JV((error = "unknown artifact"))), http_status.NOT_FOUND)
+        respond(srv, writer, int(http_status.NOT_FOUND), "application/json",
+            write_json(JV((error = "unknown artifact"))))
+        return
     }
     // content-addressed => immutable forever; artifacts are derived from user
     // input, so nosniff rides along like it does on stored sources
-    resp |> set_header("Cache-Control", "public, max-age=31536000, immutable")
-    resp |> set_header("X-Content-Type-Options", "nosniff")
+    set_header(srv, writer, "Cache-Control", "public, max-age=31536000, immutable")
+    set_header(srv, writer, "X-Content-Type-Options", "nosniff")
     // CORP: the COEP'd playground embeds the run-origin page (and Safari fetches
     // module wasm cross-origin never happen — module urls stay same-origin).
     // COEP on the artifact itself: the page document must be require-corp for its
     // agent cluster to cross-origin-isolate (threads), and a COEP'd document may
     // only spawn workers whose script response ITSELF carries an enforcing COEP —
     // so the js (and harmlessly the wasm) carry it too.
-    resp |> set_header("Cross-Origin-Resource-Policy", "cross-origin")
-    resp |> set_header("Cross-Origin-Embedder-Policy", "require-corp")
+    set_header(srv, writer, "Cross-Origin-Resource-Policy", "cross-origin")
+    set_header(srv, writer, "Cross-Origin-Embedder-Policy", "require-corp")
     // COOP completes the isolation pair for a page opened DIRECTLY (top level):
     // without it crossOriginIsolated stays false, SharedArrayBuffer is refused,
     // and a -pthread program hangs forever on `loading-workers`. Ignored in a
     // nested context, so it costs the embedded path nothing.
-    resp |> set_header("Cross-Origin-Opener-Policy", "same-origin")
-    let rc = resp |> SERVE_FILE(path)
-    log_request("GET", "/api/build/artifact", int(rc), ip, 0, artifact_size(path), t0)
-    return rc
+    set_header(srv, writer, "Cross-Origin-Opener-Policy", "same-origin")
+    // writer-rail SERVE_FILE: reads the file on the connection loop and covers the
+    // body with the channel's write-buf cap — see the route registration for why
+    SERVE_FILE(srv, writer, path)
+    log_request("GET", "/api/build/artifact", 200, ip, 0, artifact_size(path), t0)
 }
 
 def init_server(port : int; db_path : string; policy : StorePolicy; base_url : string; curated_dir : string = ""; build : BuildOptions = BuildOptions()) : bool {

--- a/utils/dasweb-playground/test_build_endpoints.das
+++ b/utils/dasweb-playground/test_build_endpoints.das
@@ -526,3 +526,54 @@ def test_page_build_refused_without_page_origin(t : T?) {
     }
     rmdir_rec(blobs)
 }
+
+[test]
+def test_large_artifact_serves_whole(t : T?) {
+    // Regression: libhv closes a connection whose queued unsent body exceeds its
+    // 16MB write-buf cap, so a large artifact came back TRUNCATED after a clean
+    // 200 (deterministic through caddy's pooled connections, timing-dependent on
+    // loopback). The writer-rail SERVE_FILE covers the body with the cap; this
+    // proves a cap-sized artifact round-trips byte-exact.
+    var err = ""
+    let blobs = create_temp_directory("dasweb_ep_bigblobs_", err)
+    let upload_src = create_temp_file("dasweb_ep_bigwasm_", ".bin", err)
+    let payload = repeat("0123456789abcdef", 20 * 1024 * 1024 / 16)   // 20MB > the 16MB cap
+    fwrite(upload_src, payload)
+    let payload_sha = sha256_hex(payload)
+    with_build_server(TEST_TOKEN, blobs) $(base_url) {
+        authed_post("{base_url}/api/build/toolchain", TC, TEST_TOKEN) $(resp) {
+            assert(int(resp.status_code) == 200, "toolchain announced")
+        }
+        let hash = posted_hash(base_url, "print(\"big artifact\")")
+        POST("{base_url}/api/build/request/{hash}", "") $(resp) {
+            assert(int(resp.status_code) == 200, "build requested")
+        }
+        authed_post("{base_url}/api/build/next", TC, TEST_TOKEN) $(resp) {
+            assert(int(resp.status_code) == 200, "job claimed")
+        }
+        t |> run("a 20MB result lands") @(tt : T?) {
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/api/build/result"
+                set_header(req, "Authorization", "Bearer {TEST_TOKEN}")
+                set_form_data(req, "hash", hash)
+                set_form_data(req, "toolchain", TC)
+                set_form_data(req, "ok", "1")
+                set_form_data(req, "manifest", "[\{\"name\":\"sample.wasm\",\"sha256\":\"{payload_sha}\"}]")
+                set_form_file(req, "sample.wasm", upload_src)
+                request(req) $(resp) {
+                    tt |> equal(int(resp.status_code), 200)
+                }
+            }
+        }
+        t |> run("the 20MB artifact arrives whole, byte-exact") @(tt : T?) {
+            GET("{base_url}/api/build/artifact/{TC}/{hash}/sample.wasm") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> equal(resp.content_length, length(payload))
+                tt |> success(string(resp.body) == payload, "body matches the uploaded bytes")
+            }
+        }
+    }
+    remove(upload_src)
+    rmdir_rec(blobs)
+}

--- a/utils/dasweb-verify/CODEREVIEW.md
+++ b/utils/dasweb-verify/CODEREVIEW.md
@@ -1,0 +1,41 @@
+# dasweb-verify Code Review Checklist
+
+Run this list on every dasweb-verify change before it ships — including changes to this file.
+Entries must be checkable against a diff alone; anything needing prior knowledge or another
+document belongs in `README.md` with a one-line criterion here.
+
+## Tests
+
+**Every core behavior has a dastest test in this directory.** Exempt: `main.das` argv/exit
+glue — its pieces are the tested module.
+
+**Every bug fix lands with the regression test that fails without it, in the same change.**
+
+**`[test]` files live in this directory and require siblings by bare name** — never under the
+global `tests/` tree, and never registered in any `CMakeLists.txt`.
+
+**A test that touches the filesystem uses `temp_directory`-rooted paths and deletes what it
+creates.** A test writing into the repo tree is a defect.
+
+## Placement — one file, one rule
+
+- `main.das` — the launcher: clargs parsing, per-sample reporting, exit-code mapping. No
+  manifest parsing, no compilation.
+- `verify_core.das` — manifest parsing and compile execution. Zero network.
+
+**A new file ships with its rule here and its tests, in the same change.**
+
+## Behavior
+
+**The verifier reads the manifest the playground ships (`data.json`), never a hand-maintained
+copy.** A second sample list in this directory is a defect.
+
+**The generated-sample mapping in `verify_core.das` mirrors
+`web/stage_playground_imgui_samples.cmake`.** A change to either without the other, in the same
+change, is a defect.
+
+**Manifest handling fails closed.** A missing, unparseable, or degenerate manifest (or sample
+entry) is a named error and a non-zero exit, never a silent skip.
+
+**Every failure line names the sample and carries the underlying message.** A failure a reader
+cannot act on from the log alone is a defect.

--- a/utils/dasweb-verify/README.md
+++ b/utils/dasweb-verify/README.md
@@ -1,0 +1,45 @@
+# dasweb-verify
+
+Batch verifier for the curated playground samples. Tier 1 — the compile check —
+lives here today: it reads the manifest the playground ships
+(`web/examples/ui/samples/data.json`), and compile+simulates every sample's
+entry file with the host binary's own compiler, in process. Every listed file
+must exist; a sample that fails names itself and carries the compiler's message.
+
+The dasImgui showcase samples (fourier, path tracer, physarum) have no
+committed copies — `web/stage_playground_imgui_samples.cmake` generates them
+into the staged site tree from canonical `examples/graphics` sources. For those
+entries the verifier compiles the canonical source in its real directory
+instead, via the mapping in `verify_core.das` (kept in lockstep with the cmake
+script — see `CODEREVIEW.md`).
+
+## Run
+
+From the repo root:
+
+```
+daslang utils/dasweb-verify/main.das
+```
+
+Exit code 0 = every sample compiles; 1 = at least one failure. Flags:
+`--samples-root <dir>` (a different manifest root), `--filter <substr>`
+(subset by sample name or entry path), `-?` (help).
+
+Tests run in-dir:
+
+```
+daslang dastest/dastest.das -- --test utils/dasweb-verify/test_verify_core.das
+```
+
+## Scope, and the follow-up
+
+This tier is deterministic and local — no browser, no network, no emsdk. It
+catches source rot (syntax/require breakage, manifest entries pointing at
+missing files) before a commit ships them to the site.
+
+The follow-up leg is a nightly runner against real daslang.io: drive the live
+playground in headless Chromium, run each picker sample interpreted and in wasm
+mode, and assert boot + frames advancing + a clean GL-error watcher. It targets
+production deliberately — this arc's worst bugs (artifact truncation behind
+caddy, per-box missing wasm archives) were production state no local rebuild
+can see. Artifacts are content-addressed, so most nights hit the build cache.

--- a/utils/dasweb-verify/main.das
+++ b/utils/dasweb-verify/main.das
@@ -1,0 +1,71 @@
+options gen2
+options indenting = 4
+options rtti
+
+require verify_core
+require daslib/clargs
+require daslib/fio
+require strings
+
+//! Compile-check every curated playground sample against the shipped manifest.
+//! Run from the repo root:
+//!   daslang utils/dasweb-verify/main.das
+//! Exit code 0 = every sample compiles; 1 = at least one failure (each named).
+
+[CommandLineArgs]
+struct Config {
+    @clarg_doc = "Samples root holding data.json (default: web/examples/ui/samples)"
+    samples_root : string
+
+    @clarg_doc = "Repo root for generated samples' canonical sources (default: .)"
+    repo_root : string
+
+    @clarg_short = "f"
+    @clarg_doc = "Only check samples whose name or entry file contains this substring"
+    filter : string
+
+    @clarg_short = "?"
+    @clarg_name = "show-help"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+[export]
+def main() : int {
+    var r <- parse_args(type<Config>)
+    if (r |> is_err) {
+        to_log(LOG_ERROR, "error: {r |> unwrap_err}\n")
+        print_help(get_command_info(type<Config>), "dasweb-verify")
+        return 1
+    }
+    let cfg <- r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Config>), "dasweb-verify")
+        return 0
+    }
+    let root = empty(cfg.samples_root) ? "web/examples/ui/samples" : cfg.samples_root
+    let repo_root = empty(cfg.repo_root) ? "." : cfg.repo_root
+    var error = ""
+    let samples <- load_manifest(path_join(root, "data.json"), error)
+    if (!empty(error)) {
+        to_log(LOG_ERROR, "dasweb-verify: {error}\n")
+        return 1
+    }
+    var checked = 0
+    var failed = 0
+    for (sample in samples) {
+        if (!empty(cfg.filter) && find(sample.name, cfg.filter) < 0 && find(sample.files[0], cfg.filter) < 0) {
+            continue
+        }
+        checked++
+        let result = check_sample(root, repo_root, sample)
+        if (result.ok) {
+            to_log(LOG_INFO, "PASS {result.entry} ({result.name})\n")
+        } else {
+            failed++
+            to_log(LOG_ERROR, "FAIL {result.entry} ({result.name}): {result.message}\n")
+        }
+    }
+    to_log(failed == 0 ? LOG_INFO : LOG_ERROR, "{checked} samples checked, {checked - failed} passed, {failed} failed\n")
+    return failed == 0 ? 0 : 1
+}

--- a/utils/dasweb-verify/test_verify_core.das
+++ b/utils/dasweb-verify/test_verify_core.das
@@ -1,0 +1,122 @@
+options gen2
+
+require dastest/testing_boost public
+require verify_core
+require daslib/fio
+require strings
+
+def private with_temp_dir(prefix : string; blk : block<(dir : string) : void>) {
+    var err = ""
+    let dir = create_temp_directory(prefix, err)
+    assert(!empty(dir), "temp dir created")
+    invoke(blk, dir)
+    rmdir_rec(dir)
+}
+
+def private write_manifest(dir : string; text : string) : string {
+    let path = path_join(dir, "data.json")
+    fwrite(path, text)
+    return path
+}
+
+[test]
+def test_load_manifest(t : T?) {
+    with_temp_dir("dasweb_verify_") $(dir) {
+        t |> run("a well-formed manifest parses into entries") @(tt : T?) {
+            var m = SamplesManifest()
+            m.examples |> emplace(SampleEntry(name = "Hello", files <- ["examples/hello.das"]))
+            m.examples |> emplace(SampleEntry(name = "Game", files <- ["examples/game/main.das", "examples/game/stub.das"]))
+            let path = write_manifest(dir, sprint_json(m, true))
+            var error = ""
+            let samples <- load_manifest(path, error)
+            tt |> equal(error, "")
+            tt |> equal(length(samples), 2)
+            tt |> equal(samples[0].name, "Hello")
+            tt |> equal(samples[0].files[0], "examples/hello.das")
+            tt |> equal(length(samples[1].files), 2)
+        }
+        t |> run("unknown keys like slug are ignored, as the shipped manifest carries them") @(tt : T?) {
+            let path = write_manifest(dir,
+                "\{ \"examples\" : [ \{ \"name\" : \"Hello\", \"slug\" : \"h\", \"files\" : [\"examples/hello.das\"] \} ] \}")
+            var error = ""
+            let samples <- load_manifest(path, error)
+            tt |> equal(error, "")
+            tt |> equal(length(samples), 1)
+            tt |> equal(samples[0].files[0], "examples/hello.das")
+        }
+        t |> run("a missing manifest fails closed naming the path") @(tt : T?) {
+            var error = ""
+            let samples <- load_manifest(path_join(dir, "missing.json"), error)
+            tt |> success(empty(samples), "no entries")
+            tt |> success(find(error, "missing.json") >= 0, "error names the path")
+        }
+        t |> run("an unparseable manifest fails closed") @(tt : T?) {
+            let path = write_manifest(dir, "not json at all")
+            var error = ""
+            let samples <- load_manifest(path, error)
+            tt |> success(empty(samples), "no entries")
+            tt |> success(!empty(error), "error is set")
+        }
+        t |> run("a sample without files fails closed naming the sample") @(tt : T?) {
+            var m = SamplesManifest()
+            m.examples |> emplace(SampleEntry(name = "Broken"))
+            let path = write_manifest(dir, sprint_json(m, false))
+            var error = ""
+            let samples <- load_manifest(path, error)
+            tt |> success(empty(samples), "no entries")
+            tt |> success(find(error, "Broken") >= 0, "error names the sample")
+        }
+    }
+}
+
+[test]
+def test_check_sample(t : T?) {
+    with_temp_dir("dasweb_verify_") $(dir) {
+        t |> run("a compiling sample passes") @(tt : T?) {
+            fwrite(path_join(dir, "ok.das"), "options gen2\n[export]\ndef main() \{\n    to_log(LOG_INFO, \"ok\\n\")\n\}\n")
+            let result = check_sample(dir, dir, SampleEntry(name = "OK", files <- ["ok.das"]))
+            tt |> success(result.ok, "compiles")
+            tt |> equal(result.entry, "ok.das")
+        }
+        t |> run("a sample requiring a same-directory sibling passes") @(tt : T?) {
+            fwrite(path_join(dir, "sibling.das"), "options gen2\ndef helper() : int => 42\n")
+            fwrite(path_join(dir, "entry.das"), "options gen2\nrequire sibling\n[export]\ndef main() \{\n    to_log(LOG_INFO, \"\{helper()\}\\n\")\n\}\n")
+            let result = check_sample(dir, dir, SampleEntry(name = "Multi", files <- ["entry.das", "sibling.das"]))
+            tt |> success(result.ok, "compiles through the bare-name require")
+        }
+        t |> run("a broken sample fails with the compiler's message") @(tt : T?) {
+            fwrite(path_join(dir, "bad.das"), "options gen2\n[export]\ndef main() \{\n    let x = no_such_symbol_anywhere()\n\}\n")
+            let result = check_sample(dir, dir, SampleEntry(name = "Bad", files <- ["bad.das"]))
+            tt |> success(!result.ok, "fails")
+            tt |> success(find(result.message, "compilation failed") >= 0, "message says why")
+        }
+        t |> run("a missing listed file fails before compiling, naming the file") @(tt : T?) {
+            fwrite(path_join(dir, "present.das"), "options gen2\n[export]\ndef main() \{\n    pass\n\}\n")
+            let result = check_sample(dir, dir, SampleEntry(name = "Rot", files <- ["present.das", "gone.das"]))
+            tt |> success(!result.ok, "fails")
+            tt |> success(find(result.message, "gone.das") >= 0, "message names the file")
+        }
+    }
+}
+
+[test]
+def test_generated_samples(t : T?) {
+    with_temp_dir("dasweb_verify_") $(samples) {
+        with_temp_dir("dasweb_verify_repo_") $(repo) {
+            t |> run("a stage-time-generated sample compiles from its canonical source") @(tt : T?) {
+                var err = ""
+                mkdir_rec(path_join(repo, "examples/graphics"), err)
+                fwrite(path_join(repo, "examples/graphics/furier_opengl_imgui_example.das"),
+                    "options gen2\n[export]\ndef main() \{\n    pass\n\}\n")
+                let result = check_sample(samples, repo, SampleEntry(name = "Fourier", files <- ["examples/furier.das"]))
+                tt |> success(result.ok, "compiles via the canonical mapping")
+            }
+            t |> run("a generated sample whose canonical source is gone fails naming both paths") @(tt : T?) {
+                let result = check_sample(samples, repo, SampleEntry(name = "Phys", files <- ["examples/physarum_lab.das"]))
+                tt |> success(!result.ok, "fails")
+                tt |> success(find(result.message, "physarum_lab.das") >= 0, "names the manifest file")
+                tt |> success(find(result.message, "physarum_lab_opengl_imgui_example.das") >= 0, "names the canonical source")
+            }
+        }
+    }
+}

--- a/utils/dasweb-verify/verify_core.das
+++ b/utils/dasweb-verify/verify_core.das
@@ -1,0 +1,134 @@
+options gen2
+options indenting = 4
+options rtti
+
+module verify_core public
+
+require daslib/ast
+require daslib/rtti
+require daslib/fio
+require daslib/json_boost
+
+//! Tier 1 of the curated-sample verifier: parse the playground's shipped
+//! manifest (data.json) and compile-check every sample with the host binary's
+//! own compiler — the same in-process rail the MCP compile_check subtool uses.
+//! Zero network; the browser/nightly leg against daslang.io is a separate tool.
+
+struct SampleEntry {
+    name : string
+    files : array<string>
+}
+
+struct SamplesManifest {
+    examples : array<SampleEntry>
+}
+
+struct CheckResult {
+    name : string
+    entry : string
+    ok : bool
+    message : string
+}
+
+//! Parse the playground manifest. Fails closed: a missing/unparseable file, an
+//! empty sample list, or a sample without files yields an error naming the
+//! offender and an empty list.
+def load_manifest(path : string; var error : string&) : array<SampleEntry> {
+    error = ""
+    var empty_list : array<SampleEntry>
+    if (!stat(path).is_reg) {
+        error = "manifest not found: {path}"
+        return <- empty_list
+    }
+    var manifest = SamplesManifest()
+    if (!sscan_json(fread(path), manifest)) {
+        error = "manifest does not parse as JSON: {path}"
+        return <- empty_list
+    }
+    if (empty(manifest.examples)) {
+        error = "manifest lists no samples: {path}"
+        return <- empty_list
+    }
+    for (e in manifest.examples) {
+        if (empty(e.files)) {
+            error = "sample \"{e.name}\" lists no files"
+            return <- empty_list
+        }
+    }
+    return <- manifest.examples
+}
+
+// The dasImgui showcase samples are generated into the staged site tree by
+// web/stage_playground_imgui_samples.cmake — no committed copies under the
+// samples root. The verifier compiles their canonical sources instead (in their
+// real directories, so path_tracer_lab's cross-tree require resolves). This
+// mapping mirrors that script; a change to one without the other is a defect.
+let GENERATED_SAMPLES : table<string; string> <- {
+    "examples/furier.das" => "examples/graphics/furier_opengl_imgui_example.das",
+    "examples/path_tracer_lab/main.das" => "examples/graphics/path_tracer_lab_opengl_imgui_example.das",
+    "examples/path_tracer_lab/path_tracer.das" => "examples/pathTracer/path_tracer.das",
+    "examples/physarum_lab.das" => "examples/graphics/physarum_lab_opengl_imgui_example.das"
+}
+
+//! Resolve one manifest-listed file: committed under root, or the canonical
+//! source of a stage-time-generated sample under repo_root. Empty + error set
+//! when neither exists.
+def resolve_listed_file(root : string; repo_root : string; f : string; var error : string&) : string {
+    let committed = path_join(root, f)
+    if (stat(committed).is_reg) {
+        return committed
+    }
+    let canonical = GENERATED_SAMPLES?[f] ?? ""
+    if (empty(canonical)) {
+        error = "listed file not found: {f}"
+        return ""
+    }
+    let cpath = path_join(repo_root, canonical)
+    if (!stat(cpath).is_reg) {
+        error = "generated sample's canonical source not found: {f} -> {canonical}"
+        return ""
+    }
+    return cpath
+}
+
+//! Compile-check one sample: every listed file must resolve, and the entry
+//! (first file) must compile and simulate. Companion files are reached through
+//! the entry's own requires.
+def check_sample(root : string; repo_root : string; sample : SampleEntry) : CheckResult {
+    var result = CheckResult(name = sample.name, entry = sample.files[0])
+    var entry_path = ""
+    for (f in sample.files) {
+        let resolved = resolve_listed_file(root, repo_root, f, result.message)
+        if (empty(resolved)) {
+            return result
+        }
+        if (empty(entry_path)) {
+            entry_path = resolved
+        }
+    }
+    compile_das_file(entry_path, result)
+    return result
+}
+
+def private compile_das_file(path : string; var result : CheckResult) {
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.ignore_shared_modules = true
+            compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                if (!ok) {
+                    result.message = "compilation failed:\n{issues}"
+                } else {
+                    simulate(program) $(sok; _ctx; serrors) {
+                        if (!sok) {
+                            result.message = "simulation failed:\n{serrors}"
+                        } else {
+                            result.ok = true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/web/examples/ui/samples/examples/gl_10_deferred.das
+++ b/web/examples/ui/samples/examples/gl_10_deferred.das
@@ -1,4 +1,15 @@
 options gen2
+// The wasm page build embeds these into the artifact (fopen reads them from MEMFS);
+// the interpreted runner preloads the same set from the .assets.json sidecar.
+// wasm-assets: tutorials/_assets/cat/concrete_cat_statue.obj
+// wasm-assets: tutorials/_assets/cat/textures/concrete_cat_statue_diff_2k.jpg
+// wasm-assets: tutorials/_assets/cat/textures/concrete_cat_statue_nor_gl_2k.jpg
+// wasm-assets: tutorials/_assets/cat/textures/concrete_cat_statue_arm_2k.jpg
+// wasm-assets: tutorials/_assets/brick/Bricks031_1K-JPG_Color.jpg
+// wasm-assets: tutorials/_assets/brick/Bricks031_1K-JPG_NormalGL.jpg
+// wasm-assets: tutorials/_assets/brick/Bricks031_1K-JPG_AmbientOcclusion.jpg
+// wasm-assets: tutorials/_assets/brick/Bricks031_1K-JPG_Roughness.jpg
+// wasm-assets: tutorials/_assets/hdri/cannon_2k.hdr
 require glfw/glfw_boost
 require opengl/opengl_boost
 require geometry/geom_gen

--- a/web/examples/ui/samples/examples/gl_12_gltf.das
+++ b/web/examples/ui/samples/examples/gl_12_gltf.das
@@ -727,11 +727,11 @@ def init {
     prog_up = create_shader_program(@@post_vs, @@up_fs)
     prog_composite = create_shader_program(@@post_vs, @@composite_fs)
 
-    g_scene <- load_gltf(MODEL)
+    g_scene <- load_gltf(MODEL) // nolint:PERF030 — fresh at the one-time init
     if (empty(g_scene.meshes)) {
         panic("no meshes loaded from {MODEL}")
     }
-    g_model <- upload_gltf(g_scene)
+    g_model <- upload_gltf(g_scene) // nolint:PERF030 — fresh at the one-time init
     compute_root()
 
     glGenVertexArrays(1, safe_addr(floor_vao))
@@ -846,7 +846,7 @@ def draw_fullscreen {
 }
 
 [export]
-def update : bool {
+def update : bool { // nolint:STYLE038 — one frame of the tutorial pipeline
     time += 1.0 / 60.0
     let t = time
     var display_w, display_h : int

--- a/web/examples/ui/samples/examples/gl_12_gltf.das
+++ b/web/examples/ui/samples/examples/gl_12_gltf.das
@@ -1,4 +1,8 @@
 options gen2
+// The wasm page build embeds these into the artifact (fopen reads them from MEMFS);
+// the interpreted runner preloads the same set from the .assets.json sidecar.
+// wasm-assets: tutorials/_assets/gltf/BoomBox.glb
+// wasm-assets: tutorials/_assets/hdri/cannon_2k.hdr
 require glfw/glfw_boost
 require opengl/opengl_boost
 require gltf/gltf_boost


### PR DESCRIPTION
Fixes every broken curated sample on the daslang.io playground, across four root causes, and adds the first tier of the batch verifier that should catch this class before a human clicks.

## Fixes

**ImGui UI invisible in every harness sample, both engines** (`764713fed`): emscripten GLFW samples the canvas CSS size while the run-frame still hides it, so `glfwGetWindowSize` reads 0x0 forever and the driver discards every draw list. `imgui_harness` now falls back to `glfwGetFramebufferSize` when DisplaySize reads 0x0.

**Physarum Lab frozen at frame 0 interpreted** (`207fc580f`, `6213f1d69`): `new_job` into the persistent jobque wedges the wasm interpreter (probe-bisected); bands now dispatch via `new_thread`, the pathtracer pattern. Interpreted playground opens at 10,000 agents via a measured gate — a 10M-iteration spin distinguishes compiled (~2ms) from interpreted (~140ms) where `is_in_aot()` cannot see the `--jit-target=wasm64` exe rail — plus texture re-upload only on dirty frames and hand-hoisted loop invariants (the interpreter does not hoist). Desktop unchanged at 60,000 agents.

**Run-frame presentation** (`abaf32739`): emscripten stamps inline `width:Npx !important` on the canvas, which beats the stylesheet's fill-the-frame rule (small pathtracer, clipped physarum); a MutationObserver rewrites the stamp back to 100%. The uncovered area composited white under crossOriginIsolated; the frame body is now opaque black.

**Large page artifacts truncated — every big wasm sample dead** (`daa75ca39`, `19df74659`): libhv's buffered write path closes the connection when queued unsent bytes exceed its 16MB cap — the 26.6MB pathtracer `sample.wasm` arrived truncated with a 200. dasHV writer-rail responses now cover the body against the cap, artifact GETs moved to a `SERVE_FILE` writer route (new writer ops `SERVE_FILE` + `set_header`), and the failure is loud end-to-end: buffered `SERVE_FILE`/`DATA` refuse bodies over ~15MB with a 500 naming the writer rail, and writer-rail write failures log via `hloge`. Regression tests: a 20MB artifact round-trips byte-exact; a 17MB buffered serve gets a 500.

**Asset-loading samples black in wasm mode** (`dd18bbb50`, `59a72a38e`): a page artifact is `sample.{html,js,wasm}` and nothing else, so every `fopen` of a model/texture failed. Page entries now declare `// wasm-assets: <path>` lines; buildd validates them fail-closed (confined to `tutorials/_assets/`, boring components, must exist in the toolchain worktree — an invalid line fails the job naming the path) and emits `release_embed_file` entries into the generated package, baking the assets into MEMFS exactly where `fopen` looks. Embedded files live in the wasm data segment, which must fit `--initial-memory` at link — the package also sizes `-sINITIAL_MEMORY` to cover them. gl_10_deferred (9 assets, 22MB) and gl_12_gltf declare their sets in-source; the interp rail keeps its sidecars.

## Verified live on daslang.io

Pathtracer wasm: 13.9M rays/s (was: truncated wasm, black frame). Physarum wasm: 60,000 agents at 78.5 steps/s; interpreted: ~4.2 steps/s at 10,000 agents (was: frozen at frame 0). gl_12_gltf wasm: BoomBox renders with its emissive panel (was: black canvas). gl_10_deferred wasm: the cat-on-brick deferred scene with the G-buffer/SSAO debug strip (was: black canvas). The 26.6MB artifact serves whole through caddy 5/5.

## Verifier (tier 1)

New `utils/dasweb-verify`: compile+simulates every sample in the shipped manifest (`data.json`) in process, the same rail as the MCP compile_check subtool. Stage-time-generated samples (fourier, pathtracer, physarum) compile from their canonical `examples/graphics` sources via a mapping kept in lockstep with `stage_playground_imgui_samples.cmake` (CODEREVIEW rule). 39/39 samples pass in seconds; 14 dastest tests in-dir. The nightly browser leg against real daslang.io is the follow-up — deliberately against production, since the truncation and the per-box missing-archive failures were production state no local rebuild can see.

Rode along: pre-existing PERF030/STYLE038 suppressions in the glTF capstone twins (`12a64f944`), which joined the changed-file lint set via the asset declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
