### PR TITLE
ci: retire windows extended_checks to nightly; nightlies consume no cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,8 +278,10 @@ jobs:
     # every Windows job still missed and rebuilt openssl from source, 8.5 min a run.
     # This job is the SEEDER for both arch keys; every other Windows job in the repo
     # is restore-only, so there is exactly one writer per key and no save race.
+    # Not on the cron: nightlies consume no cache (they are not a show-stopper),
+    # so the scheduled run builds openssl from source and then re-seeds below.
     - name: "Restore vcpkg + openssl"
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         # vcpkg.exe + ports/triplets/scripts + installed/<triplet>/openssl. Build
@@ -373,12 +375,16 @@ jobs:
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
         fi
-    # Stable per-config key, one fixed slot. Restore always; on master,
-    # delete + re-save the same key after Build so the slot is overwritten
-    # with fresh objects (GHA caches are immutable — plain save under an
-    # existing key is a no-op, so we delete first). PRs read-only. Bounded
-    # footprint: N configs × one tarball, no run_id pileup.
+    # Stable per-config key, one fixed slot. On master, delete + re-save the
+    # same key after Build so the slot is overwritten with fresh objects (GHA
+    # caches are immutable — plain save under an existing key is a no-op, so we
+    # delete first). PRs read-only. Bounded footprint: N configs × one tarball,
+    # no run_id pileup. The cron does NOT restore — nightlies consume no cache
+    # and build cold by policy — but its save still lands a complete fresh
+    # object set, and that save is the seeder every PR lane warms from (master
+    # PUSH runs are usually pre_job-skipped as same-content duplicates).
     - name: "Restore sccache objects"
+      if: github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         path: ${{ runner.temp }}/sccache
@@ -616,7 +622,9 @@ jobs:
         arch: x64
 
     # Restore-only: the PR matrix job above is the single seeder for this key.
+    # Skipped on the cron: nightlies consume no cache. Dispatch still restores.
     - name: "Restore vcpkg + openssl"
+      if: github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         path: vcpkg
@@ -709,7 +717,9 @@ jobs:
         arch: x64
 
     # Restore-only: the PR matrix job above is the single seeder for this key.
+    # Skipped on the cron: nightlies consume no cache. Dispatch still restores.
     - name: "Restore vcpkg + openssl"
+      if: github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         path: vcpkg
@@ -869,10 +879,10 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: CLANG64
-        # update:false keeps the cached pkg snapshot stable+small (no per-PR full
-        # `pacman -Syu` writing a fresh ~1.65GiB cache that evicts master slots).
+        # cache:false — this job is nightly/dispatch-only and nightlies consume
+        # no cache; the msys2 pkg snapshot alone was ~1.65GiB of quota.
         update: false
-        cache: true
+        cache: false
         install: >-
           mingw-w64-clang-x86_64-toolchain
           mingw-w64-clang-x86_64-cmake
@@ -896,12 +906,8 @@ jobs:
       run: |
         echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV
         echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
-    - name: "Restore sccache objects"
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ runner.temp }}/sccache
-        key: sccache-mingw-clang64-release
-
+    # No slot restore/save: this job is nightly/dispatch-only and nightlies
+    # consume no cache. sccache stays as a per-run local-disk launcher only.
     - name: "Build: Daslang (clang-mingw64)"
       run: |
         set -eux
@@ -916,21 +922,6 @@ jobs:
           -DDAS_LLVM_DISABLED=OFF
         cmake --build ./build-mingw --parallel
         sccache --show-stats || true
-
-    # On master, overwrite the fixed cache slot with fresh objects (GHA caches
-    # are immutable, so delete then save). PRs are read-only.
-    - name: "Refresh sccache slot"
-      if: github.ref == 'refs/heads/master'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: gh cache delete "sccache-mingw-clang64-release" -R ${{ github.repository }} || true
-    - name: "Save sccache objects"
-      if: github.ref == 'refs/heads/master'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ runner.temp }}/sccache
-        key: sccache-mingw-clang64-release
 
     - name: "Test: interpreter sweep"
       run: |
@@ -1056,7 +1047,10 @@ jobs:
     # CMakeLists change) pays it; on a hit find_package(OpenSSL) finds it and the
     # from-source ExternalProject is skipped. (On Ninja CMAKE_<LANG>_COMPILER_LAUNCHER
     # now works, so sccache could be added here later; OpenSSL from-source is unchanged.)
+    # Skipped on the cron: nightlies consume no cache, so the scheduled run
+    # builds OpenSSL from source (~8 min, budgeted). Dispatch still caches.
     - name: "Cache OpenSSL (clang-cl from-source build)"
+      if: github.event_name != 'schedule'
       uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -9,7 +9,8 @@ on:
   # but the master PUSH run is usually skipped by pre_job as a concurrent duplicate
   # of the PR that just merged (4 of 15 recent merges actually ran), so seeding was
   # left to chance. A cron run is on master, has no concurrent twin, and lands the
-  # slot every night. It also hosts the checks too slow to sit on every PR.
+  # slot every night. It also hosts the checks too slow to sit on every PR,
+  # and the whole windows lane (nightly-only, uncached — see the matrix).
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
@@ -56,28 +57,18 @@ jobs:
       actions: write
     strategy:
       fail-fast: false
+      # The windows lane runs on the nightly cron and manual dispatch only —
+      # retired from the per-PR path: it re-runs the same shared das surface
+      # MSVC-slower while adding no windows-only checks (build.yml's windows
+      # cells are the per-PR MSVC gate), and it runs uncached by design (see
+      # the sccache comment below). The event ternary appears on BOTH the
+      # target axis and the include list: an include whose target is absent
+      # from the axis would be ADDED as a standalone cell, not dropped.
       matrix:
-        target: [linux, darwin15, windows]
+        target: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["linux", "darwin15", "windows"]') || fromJSON('["linux", "darwin15"]') }}
         architecture: [64, arm64]
 
-        include:
-          - target: linux
-            runner: ubuntu-latest
-            build_system: cmake
-            cmake_generator: Ninja
-
-          - target: darwin15
-            architecture: arm64
-            runner: macos-15
-            architecture_string: arm64
-            build_system: cmake
-            cmake_generator: Ninja
-
-          - target: windows
-            runner: windows-latest
-            build_system: cmake
-            cmake_generator: Ninja
-            architecture_string: x64
+        include: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('[{"target":"linux","runner":"ubuntu-latest","build_system":"cmake","cmake_generator":"Ninja"},{"target":"darwin15","architecture":"arm64","runner":"macos-15","architecture_string":"arm64","build_system":"cmake","cmake_generator":"Ninja"},{"target":"windows","runner":"windows-latest","build_system":"cmake","cmake_generator":"Ninja","architecture_string":"x64"}]') || fromJSON('[{"target":"linux","runner":"ubuntu-latest","build_system":"cmake","cmake_generator":"Ninja"},{"target":"darwin15","architecture":"arm64","runner":"macos-15","architecture_string":"arm64","build_system":"cmake","cmake_generator":"Ninja"}]') }}
 
         exclude:
           - target: linux
@@ -161,8 +152,10 @@ jobs:
     # to refs/pull/N/merge — invisible to every sibling PR. That is what actually
     # happened: 6 cache entries for 2 keys, all PR-scoped, ~836MB of quota, and
     # every Windows job still missing and rebuilding openssl (8.5 min a run).
+    # Not on the cron: nightlies consume no cache, so the scheduled windows lane
+    # builds openssl from source (~8 min, budgeted). Dispatch still restores.
     - name: "Restore vcpkg + openssl"
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         # vcpkg.exe + ports/triplets/scripts + installed/<triplet>/openssl.
@@ -184,36 +177,33 @@ jobs:
     # matrix config — mirrors build.yml. The GHA backend writes one cache item
     # per TU (quota fragmentation, frequent concurrent-write failures); local
     # disk keeps all objects in $SCCACHE_DIR persisted as a single tarball.
-    # Windows MSVC compiles are cacheable because daslang builds /Z7
-    # (CMakeCommon.txt) — debug info embedded in the .obj; sccache refuses /Zi.
+    # Linux + darwin only: the windows lane is nightly-only and nightlies run
+    # UNCACHED by policy (they are not a show-stopper; a windows /Z7 object
+    # slot alone would be ~5-6GB of quota serving one un-waited-on run a day).
     - uses: mozilla-actions/sccache-action@v0.0.10
-    - run: |
+      if: matrix.target != 'windows'
+    - if: matrix.target != 'windows'
+      run: |
         echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV
         echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
-        # Non-Windows: export the launcher via env (also wraps the GLFW/libhv
-        # ExternalProject sub-builds — harmless on gcc/clang). Windows must NOT
-        # export it: the env leaks into the sub-cmakes where sccache + MSVC /Zi
-        # (those sub-builds keep /Zi) + parallel Ninja collide on the shared
-        # glfw.pdb (C1041). Windows passes the launcher as -D on the main
-        # configure only (Build step), scoping sccache to daslang's /Z7 TUs.
+        # The launcher exported via env also wraps the GLFW/libhv
+        # ExternalProject sub-builds — harmless on gcc/clang.
         # SCCACHE_CACHE_SIZE bounds the slot: the default is 10G, so an unbounded
         # slot grows until it evicts other caches in the repository. 500M holds a
         # full linux/macOS object set with room — build.yml's linux Release slot
-        # sits at ~94MB. Windows needs far more because /Z7 embeds debug info in
-        # every .obj: build.yml's Windows Release slot measures 5.1GB for ~920 TUs.
-        if [ "$RUNNER_OS" != "Windows" ]; then
-          echo "SCCACHE_CACHE_SIZE=500M" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-        else
-          echo "SCCACHE_CACHE_SIZE=6G" >> $GITHUB_ENV
-        fi
+        # sits at ~94MB.
+        echo "SCCACHE_CACHE_SIZE=500M" >> $GITHUB_ENV
+        echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+        echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
     # Stable per-config key in its own `sccache-extended-*` namespace so it never
-    # clobbers build.yml's slots. Restore always; save only on master (delete
-    # first — GHA caches are immutable, so a plain save under an existing key is
-    # a no-op). PRs read-only. The nightly cron is what makes the save reliable:
-    # the master PUSH run is usually skipped as a concurrent duplicate.
+    # clobbers build.yml's slots. PRs restore read-only; save only on master
+    # (delete first — GHA caches are immutable, so a plain save under an existing
+    # key is a no-op). The nightly cron is what makes the save reliable (the
+    # master PUSH run is usually skipped as a concurrent duplicate), and it does
+    # NOT restore — nightlies consume no cache; a cold build still saves a
+    # complete fresh object set for the PR lanes to warm from.
     - name: "Restore sccache objects"
+      if: matrix.target != 'windows' && github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         path: ${{ runner.temp }}/sccache
@@ -230,10 +220,8 @@ jobs:
             # vcpkg so dasHV skips its perl+nmake source build.
             echo "BIN=./bin" >> $GITHUB_ENV
             export PATH="/c/Strawberry/perl/bin:$PATH"
-            # Launcher passed as -D here (not env) so it scopes to daslang's own
-            # /Z7 targets and does NOT leak into the GLFW/libhv /Zi sub-builds.
+            # No sccache launcher: this lane is nightly-only and runs uncached.
             cmake --no-warn-unused-cli -B./build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE:STRING=Release \
-              -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
               $ACTIVE_MODULES -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
             cmake --build ./build --config Release --target daslang das-fmt daslang_static --parallel
             ;;
@@ -265,22 +253,14 @@ jobs:
             ;;
         esac
 
-    # Windows is by far the most expensive slot — ~5GB of objects against ~250MB
-    # for linux and macOS together, because /Z7 embeds debug info in every .obj —
-    # and it is also where the payoff is: this job's Windows build takes ~29 min
-    # cold, where build.yml's warm one takes ~14. It only fits because the repo
-    # cache limit is raised to 20GB; at GitHub's 10GB default, saving it evicted
-    # build.yml's slots and left every lane colder. That budget is also why the
-    # nightly Windows jobs stay uncached — a slot each would put the repo over.
-    # If the limit ever drops back, this is the first slot to stop persisting.
     - name: "Refresh sccache slot"
-      if: github.ref == 'refs/heads/master'
+      if: matrix.target != 'windows' && github.ref == 'refs/heads/master'
       env:
         GH_TOKEN: ${{ github.token }}
         SCKEY: sccache-extended-${{ matrix.target }}-${{ matrix.architecture }}
       run: gh cache delete "$SCKEY" -R ${{ github.repository }} || true
     - name: "Save sccache objects"
-      if: github.ref == 'refs/heads/master'
+      if: matrix.target != 'windows' && github.ref == 'refs/heads/master'
       uses: actions/cache/save@v4
       with:
         path: ${{ runner.temp }}/sccache

--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -75,7 +75,9 @@ jobs:
 
     # sccache with local-disk backend, RESTORE-ONLY from extended_checks'
     # master-seeded slot — this workflow never saves, so it cannot clobber
-    # the per-PR cache slots. A cold slot just means a slower build.
+    # the per-PR cache slots. The restore is skipped on the cron (nightlies
+    # consume no cache and build cold by policy); a manual dispatch — the
+    # on-demand ABI sweep someone is waiting on — still restores warm.
     - uses: mozilla-actions/sccache-action@v0.0.10
     - run: |
         echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV
@@ -83,6 +85,7 @@ jobs:
         echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
         echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
     - name: "Restore sccache objects (read-only)"
+      if: github.event_name != 'schedule'
       uses: actions/cache/restore@v4
       with:
         path: ${{ runner.temp }}/sccache


### PR DESCRIPTION
Follow-up to the CI diet (#3637/#3638/#3642), per two rulings: the windows extended_checks lane leaves the per-PR path, and nightly builds consume no cache.

## Windows extended_checks → nightly

The lane re-ran the same shared das surface MSVC-slower while adding no windows-only checks — its only unique steps were Defender exclusion, MSVC/nasm setup, and vcpkg OpenSSL; build.yml's windows cells remain the per-PR MSVC gate, and linux keeps all the exclusive checks (lint, MCP/LSP/dasweb tests, coverage). It now runs on the 04:00 cron and manual dispatch only, uncached — so the ~5-6GB /Z7 object slot it was about to start persisting never exists.

Matrix note: the event ternary appears on **both** the `target` axis and the `include` list, because an `include` whose target is absent from the axis gets **added as a standalone cell** rather than dropped.

## Nightlies consume no cache; master saves stay

The crons are the only reliable writers of the caches every PR lane warms from — master push runs are pre_job-skipped as same-content duplicates of the PR that just merged — so the saves survive, and only the restores go:

- build.yml's cron builds cold and re-seeds its sccache slots + vcpkg (a cold build still saves a complete fresh object set).
- extended_checks' cron: same, for the linux/darwin extended slots.
- The nightly-only jobs lose caching outright: relwithdebinfo + release-llvm vcpkg restores skip on schedule; mingw drops its (never-seeded) sccache slot and the ~1.65GiB msys2 pkg cache; clang-cl's OpenSSL cache skips on schedule.
- nightly_daspkg_index skips its read-only restore on schedule; manual dispatch — the on-demand ABI sweep someone actually waits on — still restores warm everywhere.

## Expected numbers

Per-PR extended_checks becomes linux (~37 min) + darwin (~21); the PR wall clock pole is build.yml at ~42 min once its windows slot is warm (first seeded by tonight's cron). Steady-state cache stays around 12GB of the 20GB limit instead of brushing against it, with the mingw/msys2/nightly windows entries gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
