### PR TITLE
web: reconcile the canvas size in one place, and show the frame rate

### DIFF
--- a/modules/dasGlfw/bind/bind_glfw.das
+++ b/modules/dasGlfw/bind/bind_glfw.das
@@ -27,7 +27,11 @@ class GlfwGen : CppGenBind {
     }
     def init_skip_func {
         glfw_skip_func <- {
-            "glfwDestroyWindow" => true
+            "glfwDestroyWindow" => true,
+            // Hand-bound so the web build can reconcile the canvas size first — see
+            // DasGlfw_PollEvents in dasGLFW.main.cpp. Every GLFW app polls once a
+            // frame, which is what makes that the one place the fix has to live.
+            "glfwPollEvents" => true
         }
         // No emscripten_skip_function override: the 11 GLFW functions emcc's JS GLFW
         // (library_glfw.js) does not provide are implemented as honest C stubs in

--- a/modules/dasGlfw/src/dasGLFW.func_3.cpp
+++ b/modules/dasGlfw/src/dasGLFW.func_3.cpp
@@ -76,9 +76,6 @@ void Module_dasGLFW::initFunctions_3() {
 	makeExtern< void * (*)(GLFWwindow *) , glfwGetWindowUserPointer , SimNode_ExtFuncCall >(lib,"glfwGetWindowUserPointer","glfwGetWindowUserPointer")
 		->args({"window"})
 		->addToModule(*this, SideEffects::worstDefault);
-// from GLFW/glfw3.h:4534:14
-	makeExtern< void (*)() , glfwPollEvents , SimNode_ExtFuncCall >(lib,"glfwPollEvents","glfwPollEvents")
-		->addToModule(*this, SideEffects::worstDefault);
 // from GLFW/glfw3.h:4579:14
 	makeExtern< void (*)() , glfwWaitEvents , SimNode_ExtFuncCall >(lib,"glfwWaitEvents","glfwWaitEvents")
 		->addToModule(*this, SideEffects::worstDefault);

--- a/modules/dasGlfw/src/dasGLFW.main.cpp
+++ b/modules/dasGlfw/src/dasGLFW.main.cpp
@@ -575,6 +575,41 @@ namespace das {
         DasGlfw_ChainCharDispatch(w, codepoint);
     }
 
+    // THE canvas-size reconcile. On the web a "window" is faked out of two numbers that
+    // nothing keeps in sync: the canvas CSS box (what the user sees, and the space the
+    // browser delivers mouse events in) and the canvas backing store (what GL renders
+    // into). A host page restyling the canvas — a playground frame, a fullscreened
+    // example card — moves the first and never tells GLFW, so the app goes on believing
+    // a size that no longer exists: ImGui lays out in stale units while clicks arrive in
+    // real ones, and "fullscreen" only magnifies the old render.
+    //
+    // The CSS box is the only externally-true size, so make GLFW agree with it. One
+    // glfwSetWindowSize moves the GLFW window size AND the backing store together, and
+    // everything downstream (glfwGetFramebufferSize, ImGui's DisplaySize via its own GLFW
+    // backend) then follows exactly as it does on desktop.
+    //
+    // It lives on glfwPollEvents because that is the one call every GLFW app makes every
+    // frame, whichever way it created its window — glfw_live (games), the imgui harness,
+    // or a raw glfwCreateWindow sample. Before poll, so the size is already true when the
+    // app reads it this frame. Desktop keeps the plain glfwPollEvents: a real OS window
+    // needs no reconciling, and DAS_glfwCanvasCssWidth returns 0 there anyway.
+    void DasGlfw_PollEvents () {
+#ifdef __EMSCRIPTEN__
+        if ( GLFWwindow * window = glfwGetCurrentContext() ) {
+            int cw = DAS_glfwCanvasCssWidth();
+            int ch = DAS_glfwCanvasCssHeight();
+            if ( cw > 0 && ch > 0 ) {
+                int ww = 0, wh = 0;
+                glfwGetWindowSize(window, &ww, &wh);
+                if ( ww != cw || wh != ch ) {
+                    glfwSetWindowSize(window, cw, ch);
+                }
+            }
+        }
+#endif
+        glfwPollEvents();
+    }
+
     void DasGlfw_DestroyWindow ( GLFWwindow * window ) {
         auto it = Module_dasGLFW::g_Callbacks.find(window);
         if ( it!=Module_dasGLFW::g_Callbacks.end() ) Module_dasGLFW::g_Callbacks.erase(it);
@@ -606,6 +641,8 @@ namespace das {
             SideEffects::worstDefault,"DasGlfw_SetScrollCallback");
         addExtern<DAS_BIND_FUN(DasGlfw_DestroyWindow)>(*this,lib,"glfwDestroyWindow",
             SideEffects::worstDefault,"DasGlfw_DestroyWindow");
+        addExtern<DAS_BIND_FUN(DasGlfw_PollEvents)>(*this,lib,"glfwPollEvents",
+            SideEffects::worstDefault,"DasGlfw_PollEvents");
         // chain + synthetic event API
         addExtern<DAS_BIND_FUN(DasGlfw_ChainAddCursorPos)>(*this,lib,"glfw_chain_add_cursor_pos",
             SideEffects::worstDefault,"DasGlfw_ChainAddCursorPos");

--- a/modules/dasImgui/widgets/imgui_harness.das
+++ b/modules/dasImgui/widgets/imgui_harness.das
@@ -148,9 +148,9 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
     }
     var w = width
     var h = height
-    // On web, size the window at creation to the largest card-aspect box fitting the on-page viewport so
-    // the UI fills the card at native scale. Done ONCE: a mid-run canvas resize invalidates the WebGL
-    // context and aborts the wasm. Desktop: glfw_canvas_css_* return 0, so the requested size is used as-is.
+    // On web, size the window at creation to the card-aspect box fitting the viewport, so the first frame
+    // is already right rather than corrected by the glfwPollEvents reconcile. Desktop: glfw_canvas_css_*
+    // return 0, so the requested size is used as-is.
     let vw = glfw_canvas_css_width()
     let vh = glfw_canvas_css_height()
     if (vw > 0 && vh > 0 && width > 0 && height > 0) {
@@ -217,9 +217,9 @@ def public harness_begin_frame() : bool {
     // (no ImGui_ImplOpenGL3_NewFrame — the das renderer builds its objects at init, nothing per-frame)
     ImGui_ImplGlfw_NewFrame()
     var io & = unsafe(GetIO())
-    // Web: emscripten GLFW samples the canvas CSS size at creation as the "window size" — a
-    // host revealing the canvas only on first GL context (playground run-frame) samples it
-    // hidden, DisplaySize stays 0x0, every draw list is discarded. Real fb size fixes it.
+    // Last-resort guard, not the mechanism: glfwPollEvents reconciles window size to the canvas CSS box
+    // every frame. This only catches a host reporting no CSS box at all, where 0x0 would discard every
+    // draw list — framebuffer units are the wrong space for mouse input, but they beat rendering nothing.
     if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f) {
         var fbw, fbh : int
         glfwGetFramebufferSize(live_window, safe_addr(fbw), safe_addr(fbh))

--- a/site/files/examples.js
+++ b/site/files/examples.js
@@ -199,11 +199,17 @@
         if (e.key === 'Escape') closePlayer();
     }
 
-    // The "⤢ fullscreen" button fullscreens the parent viewport element, which
-    // (a) leaves keyboard focus on the parent so a game — whose input listener
-    // lives inside the iframe — goes deaf, and (b) doesn't resize the iframe's
-    // fixed-backing-store canvas. Reaching into the same-origin game frame fixes
-    // both: refocus it, and let a game canvas fill the box letterboxed.
+    // The "⤢ fullscreen" button fullscreens the parent viewport element, which leaves
+    // keyboard focus on the parent — a game whose input listener lives inside the iframe
+    // goes deaf. Refocusing the frame is all this has to do now.
+    //
+    // It used to also CSS-stretch the frame's canvas to fill the screen, because the
+    // backing store stayed at its original size and nothing resized it: a magnified
+    // render, not a bigger one. That stretch is what desynced emscripten's cursor
+    // mapping (clicks landing away from the UI), which is why it had to skip imgui
+    // cards. dasGlfw's glfwPollEvents now reconciles the GLFW window size to the canvas
+    // CSS box every frame, so entering fullscreen grows the box and the next frame
+    // re-renders at the new size for real, at native resolution, for every card.
     function onFsChange() {
         var frame = document.getElementById('ex-frame');
         var vp = document.getElementById('ex-viewport');
@@ -212,33 +218,7 @@
         try {
             var idoc = frame.contentDocument;
             var canvas = idoc && idoc.getElementById('canvas');
-            if (canvas) {
-                if (entering) {
-                    // Fill ONLY a fixed-backing (game) canvas — object-fit:contain scales
-                    // it up preserving aspect (no squish). A canvas whose size emscripten
-                    // manages itself (GLFW_SCALE_TO_MONITOR imgui cards set an inline
-                    // width/height + a HiDPI backing store) must be left alone: overriding
-                    // it desyncs emscripten's device-pixel cursor mapping, so on a HiDPI
-                    // display clicks land in the wrong place. Those cards fill via their
-                    // own in-app F11 (which routes through emscripten's real fullscreen).
-                    if (!canvas.style.width && !canvas.style.height) {
-                        canvas.style.width = '100%';
-                        canvas.style.height = '100%';
-                        canvas.style.objectFit = 'contain';
-                    }
-                    if (canvas.focus) canvas.focus();
-                } else if (canvas.style.width === '100%' && canvas.style.objectFit === 'contain') {
-                    // Revert only the fill WE applied, matched by its exact inline signature
-                    // (100% + contain — a value we alone set; games start with no inline size,
-                    // imgui cards carry emscripten's px). Stateless, so a cross-session
-                    // fullscreenchange race (exitFullscreen is async; opening another card
-                    // re-attaches this listener before the pending event lands) can never
-                    // clear a different card's inline sizing.
-                    canvas.style.width = '';
-                    canvas.style.height = '';
-                    canvas.style.objectFit = '';
-                }
-            }
+            if (entering && canvas && canvas.focus) canvas.focus();
         } catch (e) {}
         if (entering && frame.contentWindow) { try { frame.contentWindow.focus(); } catch (e) {} }
     }

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -110,11 +110,11 @@
 <script type="text/javascript" src="./playground-init.js"></script>
 <!-- Owns run-frame.html (one frame per program). Must precede main.js, whose
      pageInit hands it the run host and whose run path delegates to it. -->
-<script type="text/javascript" src="./playground-runner.js?v=2"></script>
+<script type="text/javascript" src="./playground-runner.js?v=3"></script>
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
 <script type="text/javascript" src="./playground-wasm.js?v=2"></script>
-<script type="text/javascript" src="./main.js?v=3"></script>
+<script type="text/javascript" src="./main.js?v=4"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=3"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>
@@ -143,6 +143,7 @@
             </div>
         </div>
         <div class="main_header_right">
+            <label class="engine-toggle" title="show the program's frame rate over the canvas"><input type="checkbox" id="show-fps" checked> fps</label>
             <button id="clear" class="button_header button_header--ghost" onclick="clearOutput()">clear</button>
         </div>
     </div>

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -87,6 +87,46 @@
         if (!spare) spare = makeFrame();
     }
 
+    // ── fps badge ────────────────────────────────────────────────────────────
+    // One badge for both engines. The number is measured inside whichever frame is
+    // running (run-frame.html interpreted, the artifact shell in wasm mode) and
+    // posted here, because only the frame can see the program's draw calls — the
+    // wasm artifact is cross-origin and cannot be inspected from this side at all.
+    // It stands over the run host so it reads as part of the picture.
+    var badge = null;
+    var badgeVisible = true;
+    var badgeHideTimer = null;
+
+    function ensureBadge() {
+        if (badge || !host) return;
+        if (getComputedStyle(host).position === "static") host.style.position = "relative";
+        badge = document.createElement("div");
+        badge.className = "pg-fps";
+        badge.style.cssText =
+            "position:absolute;top:26px;right:6px;z-index:5;pointer-events:none;" +
+            "padding:2px 6px;border-radius:3px;background:rgba(0,0,0,.62);" +
+            "color:#e8dcc0;font:600 11px/1.4 'JetBrains Mono',monospace;" +
+            "letter-spacing:.02em;display:none;";
+        host.appendChild(badge);
+    }
+
+    function renderBadge(text) {
+        ensureBadge();
+        if (!badge) return;
+        if (text === null) { badge.style.display = "none"; return; }
+        badge.textContent = text;
+        badge.style.display = badgeVisible ? "block" : "none";
+    }
+
+    // A program that stops presenting (finished, wedged, torn down) must not leave a
+    // stale number on screen implying it is still running.
+    function noteFps(value) {
+        if (!(value >= 0)) return;
+        renderBadge(value >= 10 ? Math.round(value) + " fps" : value.toFixed(1) + " fps");
+        if (badgeHideTimer) clearTimeout(badgeHideTimer);
+        badgeHideTimer = setTimeout(function () { renderBadge(null); }, 2000);
+    }
+
     // Messages carry no frame identity, so match on source window to avoid
     // crosstalk between the outgoing frame and the pre-warmed one.
     window.addEventListener("message", function (ev) {
@@ -127,6 +167,11 @@
                 var out = document.getElementById("output");
                 if (out) out.classList.add("with-canvas");
                 break;
+            case "fps":
+                // Only the frame actually running a program may drive the badge; the
+                // pre-warmed spare also ticks rAF and would otherwise report 0.
+                if (rec === current) noteFps(msg.value);
+                break;
             case "exit":
                 if (onExit) onExit(msg.code);
                 break;
@@ -156,12 +201,22 @@
         // the column-measuring rule.
         fitElement: fitElement,
 
+        // The wasm engine's page frame posts its own fps (cross-origin, so main.js
+        // receives it there and forwards); the badge itself stays owned here.
+        noteFps: noteFps,
+
+        setFpsVisible: function (on) {
+            badgeVisible = !!on;
+            if (badge && !badgeVisible) badge.style.display = "none";
+        },
+
         // Throw away the frame that ran (if any) and promote the pre-warmed one.
         // Called before every run, and by Clear.
         reset: function () {
             if (current) { destroy(current); current = null; }
             var out = document.getElementById("output");
             if (out) out.classList.remove("with-canvas");
+            renderBadge(null);   // the run it described is gone
             ensureSpare();
         },
 

--- a/site/playground/run-frame.html
+++ b/site/playground/run-frame.html
@@ -51,22 +51,43 @@
     var PARENT = window.parent;
     var canvas = document.getElementById("canvas");
 
-    // Emscripten's GLFW stamps the program's window size onto the canvas as an INLINE
-    // "width: Npx !important" at window creation — and inline !important beats the
-    // stylesheet's, so the canvas shrank to program pixels inside a frame the parent
-    // sized to the column. Undo it whenever it appears: the drawing buffer keeps the
-    // program's size, CSS keeps the fill-the-frame presentation. Self-terminating:
-    // our own rewrite re-fires the observer, sees 100%, and does nothing.
-    new MutationObserver(function () {
-        if (canvas.style.width !== "100%") {
-            canvas.style.setProperty("width", "100%", "important");
-            canvas.style.setProperty("height", "100%", "important");
-        }
-    }).observe(canvas, { attributes: true, attributeFilter: ["style"] });
+    // (The canvas is NOT restyled here on purpose. Emscripten's GLFW stamps the program's
+    // window size onto it as an inline "width: Npx !important", and fighting that stamp is
+    // what made the CSS box disagree with the drawing buffer — the program then rendered at
+    // one size while the browser delivered mouse events in another. dasGlfw's glfwPollEvents
+    // now reconciles the window size to this frame's box every frame, so the stamp already
+    // IS the frame's size and there is nothing to undo.)
 
     function post(msg) {
         try { PARENT.postMessage(msg, window.location.origin); } catch (e) { /* parent gone */ }
     }
+
+    // Feed for the parent's fps badge. Counts animation frames in which the PROGRAM
+    // drew, not raw rAF ticks: a threaded program (the path tracer) leaves rAF firing
+    // at display rate while presenting well under one frame a second, and reporting
+    // 60 there would hide exactly the interpreter-vs-wasm gap the badge exists to show.
+    (function installFpsMeter() {
+        var drew = false, frames = 0, last = performance.now();
+        var DRAWS = ["drawArrays", "drawElements", "drawArraysInstanced", "drawElementsInstanced", "drawRangeElements"];
+        [window.WebGLRenderingContext, window.WebGL2RenderingContext].forEach(function (ctor) {
+            if (!ctor || !ctor.prototype) return;
+            DRAWS.forEach(function (name) {
+                var original = ctor.prototype[name];
+                if (typeof original !== "function") return;
+                ctor.prototype[name] = function () { drew = true; return original.apply(this, arguments); };
+            });
+        });
+        (function tick() {
+            if (drew) { frames++; drew = false; }
+            var now = performance.now();
+            if (now - last >= 500) {
+                post({ type: "fps", value: frames * 1000 / (now - last) });
+                frames = 0;
+                last = now;
+            }
+            requestAnimationFrame(tick);
+        })();
+    })();
 
     // dasAudio creates an AudioContext deep inside the wasm run, after the click's
     // synchronous frame, so browsers would leave it suspended. Wrap the constructor

--- a/site/tests/playground/fps-badge.spec.js
+++ b/site/tests/playground/fps-badge.spec.js
@@ -1,0 +1,80 @@
+// The fps checkbox and the badge it controls.
+//
+// The number itself is measured inside the run frame (interpreted) or the
+// artifact shell (wasm) and posted to the parent, because only the frame can see
+// the program's draw calls — the wasm artifact is cross-origin and cannot be
+// inspected from this side at all. These specs drive that message directly, so
+// they cover the parent half without needing a WASM runtime.
+
+const { test, expect } = require('./fixtures.js');
+
+const BOX = '#show-fps';
+const BADGE = '.pg-fps';
+
+// The runner only trusts fps from the frame currently running a program (the
+// pre-warmed spare ticks too), so feed the badge through its own entry point —
+// the same one main.js uses to forward the cross-origin page frame's reports.
+async function feedFps(page, value) {
+    await page.evaluate(v => window.PlaygroundRunner.noteFps(v), value);
+}
+
+test('the toggle sits in the header, left of clear, and is on by default', async ({ playground: page }) => {
+    const box = page.locator(BOX);
+    await expect(box).toBeChecked();
+
+    const order = await page.evaluate(() => {
+        const right = document.querySelector('.main_header_right');
+        const kids = Array.from(right.children);
+        return {
+            fpsIndex: kids.findIndex(k => k.querySelector('#show-fps')),
+            clearIndex: kids.findIndex(k => k.id === 'clear'),
+        };
+    });
+    expect(order.fpsIndex).toBeGreaterThanOrEqual(0);
+    expect(order.clearIndex).toBeGreaterThan(order.fpsIndex);
+});
+
+test('a reported frame rate shows over the canvas', async ({ playground: page }) => {
+    await feedFps(page, 58.4);
+    await expect(page.locator(BADGE)).toBeVisible();
+    await expect(page.locator(BADGE)).toHaveText('58 fps');
+});
+
+// The badge exists to make the interpreter/wasm gap obvious, and an interpreted
+// program can sit well under 1 fps — rounding those all to "0 fps" would erase
+// the very comparison it is for.
+test('sub-10 rates keep a decimal', async ({ playground: page }) => {
+    await feedFps(page, 0.4);
+    await expect(page.locator(BADGE)).toHaveText('0.4 fps');
+});
+
+test('unchecking hides it, and the choice survives a reload', async ({ playground: page }) => {
+    await feedFps(page, 60);
+    await expect(page.locator(BADGE)).toBeVisible();
+
+    await page.locator(BOX).uncheck();
+    await expect(page.locator(BADGE)).toBeHidden();
+
+    await page.reload();
+    await page.locator('.CodeMirror').waitFor({ state: 'visible' });
+    await expect(page.locator(BOX)).not.toBeChecked();
+    await feedFps(page, 60);
+    await expect(page.locator(BADGE)).toBeHidden();
+
+    await page.locator(BOX).check();
+    await feedFps(page, 60);
+    await expect(page.locator(BADGE)).toBeVisible();
+});
+
+// A program that stops presenting must not leave a stale number implying it is
+// still running.
+test('the badge clears when reports stop, and on reset', async ({ playground: page }) => {
+    await feedFps(page, 60);
+    await expect(page.locator(BADGE)).toBeVisible();
+    await expect(page.locator(BADGE)).toBeHidden({ timeout: 5_000 });
+
+    await feedFps(page, 60);
+    await expect(page.locator(BADGE)).toBeVisible();
+    await page.evaluate(() => window.PlaygroundRunner.reset());
+    await expect(page.locator(BADGE)).toBeHidden();
+});

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -34,6 +34,7 @@ pageInit = function () {
     else editorOutput.parentNode.insertBefore(runHost, editorOutput);
     runHostEl = runHost;   // page-shape wasm artifacts (runWasmPage) share the canvas's place
     PlaygroundRunner.init(runHost, function (text, color) { printOutput(text, color); });
+    initFpsToggle();
 
     sampleList["examples"] = document.getElementById("examples");
 
@@ -283,6 +284,23 @@ function updateEngineAvailability() {
         .catch(() => disableWasm());
 }
 
+// The fps badge is on by default: comparing the two engines is the reason it exists,
+// and a counter you have to go and enable is one nobody turns on. A visitor who opts
+// out keeps that across visits — a preference, not per-run state.
+const FPS_PREF_KEY = 'pg-show-fps';
+function initFpsToggle() {
+    const box = document.getElementById('show-fps');
+    if (!box) return;
+    let on = true;
+    try { on = localStorage.getItem(FPS_PREF_KEY) !== '0'; } catch (e) { /* storage blocked */ }
+    box.checked = on;
+    if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.setFpsVisible(on);
+    box.addEventListener('change', function () {
+        if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.setFpsVisible(box.checked);
+        try { localStorage.setItem(FPS_PREF_KEY, box.checked ? '1' : '0'); } catch (e) { /* storage blocked */ }
+    });
+}
+
 // Hide the run frame. Revealing and sizing it is the runner's own job — the
 // frame posts canvas-visible the instant a program asks for a WebGL context,
 // which is program-driven and so works for pasted code, not just samples
@@ -355,7 +373,14 @@ function runWasmPage(files) {
     pageFrameMsg = function (ev) {
         if (!pageFrame || ev.source !== pageFrame.contentWindow || ev.origin !== pageOrigin) return;
         const m = ev.data;
-        if (!m || m.type !== 'canvas-visible' || !(m.width > 0) || !(m.height > 0)) return;
+        if (!m) return;
+        // The artifact is cross-origin by design, so its own fps meter reporting in is
+        // the only way this side can know the frame rate. The badge lives in the runner.
+        if (m.type === 'fps') {
+            if (typeof PlaygroundRunner !== 'undefined') PlaygroundRunner.noteFps(m.value);
+            return;
+        }
+        if (m.type !== 'canvas-visible' || !(m.width > 0) || !(m.height > 0)) return;
         pageAspect = m.height / m.width;
         pageFrameFit();
     };

--- a/web/templates/wasm_canvas_shell.html
+++ b/web/templates/wasm_canvas_shell.html
@@ -59,6 +59,34 @@
       return c;
     })(),
   };
+
+  // Feed for an embedder's fps badge (the playground's, today). Counts animation
+  // frames in which the program DREW rather than raw rAF ticks — a threaded program
+  // keeps rAF at display rate while presenting far fewer frames, and the whole point
+  // of the badge is to show the real rate. Wildcard target like canvas-visible above:
+  // it carries one number, and a standalone page just posts to itself.
+  (function installFpsMeter() {
+    var drew = false, frames = 0, last = performance.now();
+    var DRAWS = ['drawArrays', 'drawElements', 'drawArraysInstanced', 'drawElementsInstanced', 'drawRangeElements'];
+    [window.WebGLRenderingContext, window.WebGL2RenderingContext].forEach(function (ctor) {
+      if (!ctor || !ctor.prototype) return;
+      DRAWS.forEach(function (name) {
+        var original = ctor.prototype[name];
+        if (typeof original !== 'function') return;
+        ctor.prototype[name] = function () { drew = true; return original.apply(this, arguments); };
+      });
+    });
+    (function tick() {
+      if (drew) { frames++; drew = false; }
+      var now = performance.now();
+      if (now - last >= 500) {
+        try { parent.postMessage({ type: 'fps', value: frames * 1000 / (now - last) }, '*'); } catch (e) { /* no embedder */ }
+        frames = 0;
+        last = now;
+      }
+      requestAnimationFrame(tick);
+    })();
+  })();
 </script>
 {{{ SCRIPT }}}
 </body>


### PR DESCRIPTION
On the web a GLFW "window" is faked out of two numbers that nothing keeps in sync: the canvas **CSS box** (what the user sees, and the space the browser delivers mouse events in) and the canvas **backing store** (what GL renders into). A host page restyling the canvas moves the first and never tells GLFW, so the app goes on believing a size that no longer exists.

Every symptom we have chased in this area is that one desync wearing a different hat:

- path tracer / fourier / physarum **clicks landing away from the widget** — ImGui laid out in framebuffer units (1024) while clicks arrived in CSS units (682)
- **"fullscreen doesn't really resize"** — the box grew, the backing store did not, so the browser magnified the old render
- the playground's **blank imgui UI** (#3645) — window size stuck at 0x0, so every draw list was discarded

## The measurement

Fourier interpreted, versus the same sample as a wasm artifact, both live:

| | `glfwGetWindowSize` | framebuffer | canvas CSS box | `io.DisplaySize` | mouse @ css 512 |
|---|---|---|---|---|---|
| interpreter | **0x0** | 1024x1024 | 680x680 | **1024x1024** | 511 |
| wasm artifact | 682x682 | 682x682 | 682x682 | 682x682 | 512 |

The wasm artifact escapes it for exactly one reason: its canvas is laid out before the program starts, so `glfwCreateWindow` samples a real size. Nothing else differs. Note the mouse was never wrong — `DisplaySize` was the liar.

## The fix

`DasGlfw_PollEvents` reconciles the GLFW window size to the canvas CSS box each frame. One `glfwSetWindowSize` moves the window size **and** the backing store together, and everything downstream (`glfwGetFramebufferSize`, ImGui's `DisplaySize` via its own GLFW backend) then follows exactly as it does on desktop.

It rides `glfwPollEvents` because that is the one call every GLFW app makes every frame whichever way it created its window — `glfw_live` (games), the imgui harness, or a raw `glfwCreateWindow` sample — and `glfw_live.das:121` calls it at the *start* of the frame, so the size is already true before anything reads it. Hand-bound through the binder's skip list, the same way `glfwDestroyWindow` already is, so a regen keeps it.

Proven before it was written: the same reconcile, expressed in das inside a patched sample against the **deployed** binary, collapsed all four numbers to 680 on frame 1 and never fired again — including healing the 0x0 creation race.

## Retired, rather than patched around

Each existed only because the two numbers drifted:

- `run-frame.html`'s MutationObserver, which forced the canvas to 100% and was itself what made the CSS box disagree with the drawing buffer
- `examples.js`'s fullscreen CSS-magnify, and the HiDPI carve-out it needed because stretching an emscripten-managed canvas desynced cursor mapping. **The button now grows the box and the next frame re-renders at the new size, at native resolution, for every card** — including arcanoid and pac-man
- the harness's `DisplaySize` fallback is demoted to a last-resort guard

## A correction

`imgui_harness.das` claimed a mid-run canvas resize invalidates the WebGL context and aborts the wasm. That arrived with the flat dasImgui import and is false for how we build (no `OFFSCREENCANVAS_SUPPORT`, no `PROXY_TO_PTHREAD`). Resizing a running artifact 682→900 kept it drawing (11,030 → 22,566 draw calls), zero `webglcontextlost`, no abort. What actually broke was the size going **stale**, not the resize.

## Frame-rate badge

Requested feature, and it only reads honestly once the sync above lands. On by default, checkbox left of `clear`, remembered in `localStorage`. Both frame hosts measure and post; the parent owns one badge over the canvas — the wasm artifact is cross-origin, so its own report is the only way this side can know.

It counts **animation frames in which the program drew**, not raw rAF ticks: a threaded program leaves rAF at display rate while presenting under one frame a second, and reporting 60 there would hide exactly the interpreter-vs-wasm gap the badge exists to show. Rates under 10 keep a decimal for the same reason.

## Verification

- **42/42** playground e2e green locally (37 existing + 5 new `fps-badge.spec.js`), staged and served the way `playground-e2e.yml` does
- lint 0 issues and formatter clean on both changed `.das` files
- `libDasModuleGlfw` builds

**Not verified locally, flagged honestly:** the `#ifdef __EMSCRIPTEN__` body only compiles under emcc, so CI's wasm lane is its first real check. It reaches users in two steps — the interpreter rail on the next pages deploy, the wasm rail only after a builder roll (currently `7e6e8601c`, already two PRs stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
