### PR TITLE
dasweb-verify: nightly browser leg against the live playground

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -451,6 +451,19 @@ jobs:
           $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasweb-buildd/$suite.das
         done
 
+    - name: "Test dasweb-verify (curated sample compile check)"
+      # Tier 1 of the sample verifier: compile+simulate every sample the
+      # playground manifest ships, in process, with the binary just built.
+      # Seconds of work, and it is the only gate that catches sample rot
+      # (a require breaking, a manifest entry pointing at a moved file)
+      # before the site serves it. The browser leg against the live site is
+      # a nightly (nightly_playground.yml), not a per-PR check.
+      if: matrix.target == 'linux'
+      run: |
+        set -eux
+        $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasweb-verify/test_verify_core.das
+        $BIN/daslang ./utils/dasweb-verify/main.das
+
     # Self-binders for dasClangBind + dasLLVM bindings live on the mingw
     # worker (build.yml build_windows_mingw) — see comment on the linux
     # build step above for why dasClangBind can't be enabled here.

--- a/.github/workflows/nightly_playground.yml
+++ b/.github/workflows/nightly_playground.yml
@@ -19,11 +19,6 @@ on:
   schedule:
     # after extended_checks' 04:00 sweep, while the build boxes are idle
     - cron: '30 4 * * *'
-  # TEMPORARY — REMOVE BEFORE MERGE. A workflow_dispatch workflow is not
-  # dispatchable until it lives on the default branch, so this is the only way
-  # to exercise the full sweep on CI before this PR lands.
-  push:
-    branches: [bbatkin/dasweb-sample-verifier]
   workflow_dispatch:
     inputs:
       filter:

--- a/.github/workflows/nightly_playground.yml
+++ b/.github/workflows/nightly_playground.yml
@@ -1,0 +1,98 @@
+name: nightly playground
+
+# Drives the LIVE playground on daslang.io in headless Chromium and reports,
+# per curated sample and per engine, whether the program actually runs: boots,
+# keeps painting, issues draw calls, prints what it should, and logs no GL or
+# runtime error. Failures land as a per-sample table in the step summary and
+# turn the workflow red.
+#
+# Production is the target on purpose. The bugs this exists to catch were
+# production state no local rebuild could see — page artifacts truncated behind
+# caddy, wasm archives missing on one build box, a failed build cached under its
+# content hash. Sample sources and toolchain id are content-addressed, so a
+# night with no sample edit and no toolchain bump is mostly cache hits.
+#
+# Nothing here is cached: nightlies consume no GitHub Actions cache (that budget
+# belongs to the per-PR lanes), and there is no compile step to accelerate.
+
+on:
+  schedule:
+    # after extended_checks' 04:00 sweep, while the build boxes are idle
+    - cron: '30 4 * * *'
+  # TEMPORARY — REMOVE BEFORE MERGE. A workflow_dispatch workflow is not
+  # dispatchable until it lives on the default branch, so this is the only way
+  # to exercise the full sweep on CI before this PR lands.
+  push:
+    branches: [bbatkin/dasweb-sample-verifier]
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'only samples whose name contains this substring'
+        required: false
+        default: ''
+      mode:
+        description: 'interpreter, wasm, or both (blank = both)'
+        required: false
+        default: ''
+      base_url:
+        description: 'site to verify'
+        required: false
+        default: 'https://daslang.io'
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify_samples:
+    # The cron only runs on the canonical repo: it verifies daslang.io, which a
+    # fork neither owns nor can fix, and a red nightly emails the fork owner.
+    # workflow_dispatch still works anywhere (point --base-url at a staging box).
+    if: github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        # deliberately no `cache:` — see the header
+
+    - name: "Install runner dependencies"
+      working-directory: utils/dasweb-verify/browser
+      run: npm ci
+
+    - name: "Install Chromium"
+      working-directory: utils/dasweb-verify/browser
+      run: npx playwright install chromium --with-deps
+
+    - name: "Protocol unit tests"
+      working-directory: utils/dasweb-verify/browser
+      run: node --test
+
+    - name: "Verify curated samples on ${{ github.event.inputs.base_url || 'https://daslang.io' }}"
+      working-directory: utils/dasweb-verify/browser
+      run: |
+        set -o pipefail
+        node runner.mjs \
+          --base-url "${{ github.event.inputs.base_url || 'https://daslang.io' }}" \
+          ${{ github.event.inputs.filter && format('--filter "{0}"', github.event.inputs.filter) || '' }} \
+          ${{ github.event.inputs.mode && format('--mode {0}', github.event.inputs.mode) || '' }}
+
+    - name: "Failure screenshots"
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: sample-failures
+        path: utils/dasweb-verify/browser/artifacts
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/nightly_playground.yml
+++ b/.github/workflows/nightly_playground.yml
@@ -74,14 +74,25 @@ jobs:
       working-directory: utils/dasweb-verify/browser
       run: node --test
 
-    - name: "Verify curated samples on ${{ github.event.inputs.base_url || 'https://daslang.io' }}"
+    - name: "Verify curated samples"
       working-directory: utils/dasweb-verify/browser
+      # Dispatch inputs reach bash through env, never through ${{ }} pasted into the
+      # script body. An expression is substituted as TEXT before the shell parses the
+      # line, so a quote, $(…) or backtick in an input would break the command or run
+      # on the runner with the job's token. A quoted "$VAR" expansion cannot — the
+      # value is already a string by the time bash sees it. Sample names alone make
+      # this reachable without malice: they carry ( ) : and , characters.
+      env:
+        BASE_URL: ${{ github.event.inputs.base_url || 'https://daslang.io' }}
+        FILTER: ${{ github.event.inputs.filter }}
+        MODE: ${{ github.event.inputs.mode }}
       run: |
-        set -o pipefail
-        node runner.mjs \
-          --base-url "${{ github.event.inputs.base_url || 'https://daslang.io' }}" \
-          ${{ github.event.inputs.filter && format('--filter "{0}"', github.event.inputs.filter) || '' }} \
-          ${{ github.event.inputs.mode && format('--mode {0}', github.event.inputs.mode) || '' }}
+        set -euo pipefail
+        args=(--base-url "$BASE_URL")
+        if [ -n "${FILTER:-}" ]; then args+=(--filter "$FILTER"); fi
+        if [ -n "${MODE:-}" ]; then args+=(--mode "$MODE"); fi
+        echo "verifying ${BASE_URL}"
+        node runner.mjs "${args[@]}"
 
     - name: "Failure screenshots"
       if: failure()

--- a/modules/dasGlfw/dasglfw/glfw_live.das
+++ b/modules/dasGlfw/dasglfw/glfw_live.das
@@ -78,7 +78,12 @@ def public live_create_window(title : string; width, height : int) : GLFWwindow?
         panic("glfw_live: can't create window")
     }
     glfwMakeContextCurrent(live_window)
-    glEnable(GL_MULTISAMPLE)
+    // WebGL2/GLES3 has no GL_MULTISAMPLE capability — multisampling is decided by
+    // the context attributes there — so enabling it raises INVALID_ENUM on every
+    // window this creates under emscripten, once, before any sample code runs.
+    if (get_running_platform_name() != "emscripten") {
+        glEnable(GL_MULTISAMPLE)
+    }
     init_opengl_cache()
     return live_window
 }
@@ -671,7 +676,7 @@ def private mod_name_to_bit(name : string) : int {
 // event with `keycode == 0` (text-input widgets still receive it via
 // CharCallback).
 def private needs_shift_ascii(c : int) : bool {
-    if (c >= 'A' && c <= 'Z') return true   // nolint:PERF014 (uppercase-only, is_alpha would also match lowercase)
+    if (c >= 'A' && c <= 'Z') return true   // uppercase-only; is_alpha would also match lowercase
     // shifted punctuation on a US layout. Listed as char literals (not a single
     // string) so the parser doesn't treat `{` / `}` as interpolation delimiters.
     return (c == '~' || c == '!' || c == '@' || c == '#'
@@ -684,8 +689,8 @@ def private needs_shift_ascii(c : int) : bool {
 
 def private base_keycode_ascii(c : int) : int { // nolint:STYLE037 — keycode mapping ladder, splitting is noise
     // letters — distinguishing case to compute the right keycode offset
-    if (c >= 'A' && c <= 'Z') return GLFW_KEY_A + (c - 'A')   // nolint:PERF014 (need uppercase-only offset)
-    if (c >= 'a' && c <= 'z') return GLFW_KEY_A + (c - 'a')   // nolint:PERF014 (need lowercase-only offset)
+    if (c >= 'A' && c <= 'Z') return GLFW_KEY_A + (c - 'A')   // need the uppercase-only offset
+    if (c >= 'a' && c <= 'z') return GLFW_KEY_A + (c - 'a')   // need the lowercase-only offset
     // digits 0-9 → GLFW_KEY_0..9
     if (c >= '0' && c <= '9') return GLFW_KEY_0 + (c - '0')   // nolint:PERF014 (need digit-only offset)
     // shifted digit row: ! @ # $ % ^ & * ( )  → keys 1 2 3 4 5 6 7 8 9 0

--- a/plans/dasweb_sample_verifier.md
+++ b/plans/dasweb_sample_verifier.md
@@ -1,0 +1,187 @@
+# dasweb sample verifier — nightly browser leg against real daslang.io
+
+Status: IMPLEMENTED in #3649 (P1–P4 all landed). Tier 1 (compile check,
+`utils/dasweb-verify/`) shipped in #3645. This plan is the browser leg: nightly
+verification that every curated sample on the LIVE site works in both engines, with
+failures named per sample.
+
+Three things the implementation added that this plan did not anticipate, each because a
+measurement contradicted it — see #3649 for the evidence:
+
+- **The rAF counter alone is not a liveness signal.** A threaded program (path tracer)
+  leaves rAF firing at display rate while presenting under 1 frame/s. The probe also
+  counts the *program's* WebGL draw calls.
+- **The wedge deadline must be the sample's own remaining budget, not a fixed cap.** A
+  daslang program owns the main thread while it runs, so a console benchmark computing
+  for 40s is indistinguishable from a wedge until its budget is spent (the tree benchmark:
+  40.5s locally, 55.4s on a CI runner).
+- **`min_observe_ms`.** Stopping the moment thresholds are met makes the verdict depend on
+  machine speed — the same sample passed twice and failed once on an identical GL error,
+  purely on whether the loop was still watching when the line landed.
+
+## Rulings already made (do not re-litigate)
+
+- **Target is production daslang.io**, not a local rebuild. Half the samples arc's bugs were
+  production state invisible locally: libhv truncation only on the caddy path, missing wasm
+  archives per-box, cached build failures. Artifacts are content-addressed (source hash ×
+  toolchain id), so most nights hit the build cache; fresh builds only after toolchain bumps
+  or sample edits.
+- **Expectations live verifier-side** (a table in the repo), NOT in-source `// verify:` lines.
+  Budgets/regexes are properties of the check; tuning a timeout must not require redeploying
+  sample content and busting its build cache.
+- **Failure delivery = red nightly workflow** with a per-sample summary table. No auto-filed
+  issues in v1.
+- **No pixel/canvas checks in v1** (Boris dropped them — determinism). The missing-asset
+  black-canvas class dies via panic → caught by the output-pane/error checks below.
+- **Nightlies consume no cache** (#3646 policy) — the new workflow caches nothing.
+- Verify the RENDER-adjacent liveness, not exit codes; UI-presence (imgui panels) is
+  acknowledged out of scope for v1 (pathtracer's discarded-draw-list class would pass).
+
+## Components
+
+```
+utils/dasweb-verify/
+  main.das, verify_core.das, test_verify_core.das   # tier 1, shipped
+  browser/
+    runner.mjs          # orchestrator (node + playwright)
+    protocol.mjs        # pure helpers: expectations lookup, output-pane parsing,
+                        #   artifact-url extraction, verdict assembly (node:test covered)
+    expectations.json   # per-sample table (below)
+    package.json        # pinned playwright
+    protocol.test.mjs   # node:test for the pure helpers
+.github/workflows/nightly_playground.yml
+```
+
+CODEREVIEW.md + README.md gain the browser-leg rows (placement rule per file; pure helpers
+get node:test coverage; the driving loop is proven by the nightly itself — mirror the
+existing "orchestration exempt" wording).
+
+## Sample list acquisition
+
+- Deployed manifest is the truth users click: `https://daslang.io/playground/samples/data.json`
+  (confirmed live, 200, same shape as repo `web/examples/ui/samples/data.json` — `examples[]`
+  of `{name, files[], slug?}`).
+- **Drift check**: diff deployed list vs the checked-out repo copy → report-only WARN rows
+  (deploy lag is legitimate mid-merge).
+- **Fail closed on unknown samples**: a deployed sample with no expectations entry is a FAIL
+  ("add an expectations row"), so new samples can't silently skip verification.
+
+## expectations.json shape
+
+```json
+{
+  "defaults": { "kind": "graphics", "modes": ["interpreter", "wasm"],
+                "budget_ms": 30000, "min_rafs": 30 },
+  "samples": {
+    "OpenGL: rotating triangle": {},
+    "Path Tracer Lab (jobque + threads + GPU)": { "budget_ms": 120000 },
+    "Physarum Lab (threads + audio)": { "budget_ms": 60000 },
+    "Hello world": { "kind": "console", "stdout": "hello" },
+    "Tests": { "kind": "console", "stdout": "passed" },
+    "Audio: sine beep": { "kind": "audio" },
+    "Game: Arcanoid (3D, arrow keys + space)": {}
+  }
+}
+```
+
+Keyed by picker `name` (what the deployed list carries). Kinds: `graphics` (frame checks),
+`console` (stdout regex against the output pane, both engines — interpreter prints there,
+wasm module-rail wasi stdout lands there too), `audio` (boot + no-wedge only; interpreted
+audio breakup is a KNOWN parked issue, not a failure). Fill all 39 rows at implementation
+time from the tier-1 manifest.
+
+## The liveness protocol (why these exact checks)
+
+A single rAF counter is not enough — reason it through:
+- **Wedge** (jobque/strudel class): main thread hot-spins → rAF stops firing AND
+  `page.evaluate` hangs. Detect: evaluate deadline → verdict `wedge`.
+- **Crash/panic/exit** (missing asset class): emscripten loop stops but the page's own rAF
+  keeps ticking → a generic rAF counter would PASS. Detect: pageerror/console-error events +
+  output-pane text (panic/abort/build-failure markers).
+- **Alive**: injected rAF counter advances past `min_rafs` within budget AND none of the
+  error detectors fired AND no GL-watcher lines.
+
+So per graphics sample, all of: (a) evaluate stays responsive, (b) injected rAF count ≥
+min_rafs, (c) zero playwright pageerror / console.error events, (d) zero GL-error lines,
+(e) output pane free of panic/abort markers. Budgets from the table.
+
+## Per-engine flow
+
+**Interpreter**: one persistent playground tab; per sample: select the picker option
+(`select` element, dispatch change), click run, find `iframe.pg-run-frame` (SAME-origin →
+`frame.evaluate` works), inject the rAF probe, apply the protocol. The GL watcher lines
+appear in the parent `#output` pane (#3640's watcher, live on prod since #3645's pages
+deploy — verify presence during P1).
+
+**Wasm**: select the wasm radio, run. The playground POSTs the source and polls the build.
+- *Console samples* → module (wasi) rail: stdout lands in `#output`; regex it.
+- *Graphics/audio* → page rail: poll for `iframe.pg-page-frame` src (artifact URL on
+  run.daslang.io) OR failure text in `#output` (builder message becomes the FAIL detail).
+  The embedded frame is CROSS-origin (deliberate security boundary) → do NOT probe it;
+  **open the artifact URL as a top-level playwright page** (the arc's verification method —
+  full access, `crossOriginIsolated: true` confirmed live). Install the GL-error watcher via
+  `context.addInitScript` (hook canvas.getContext → wrap the returned GL context's getError /
+  poll per frame) BEFORE navigation — the page shell has no built-in watcher and adding one
+  is a toolchain bump; init-script injection avoids that entirely.
+- Build budget: fresh page builds measured 2.5–4 min (INITIAL_MEMORY asset embeds); poll
+  every 4–5 s, budget 6 min, cache hits resolve in seconds.
+- Serial, one sample at a time — don't hammer buildd.
+- A cached FAILED build for identical content+toolchain is a correct verdict, not staleness —
+  never cache-bust in the verifier.
+
+## Recovery + reporting
+
+- Wedge/timeout: screenshot → attach path in the report row → close the browser CONTEXT and
+  rebuild it (headless CI needs no renderer-kill dance) → continue with the next sample.
+- Report: one row per sample × mode (PASS/FAIL/WARN + detail + duration) appended to
+  `$GITHUB_STEP_SUMMARY`; exit 1 on any FAIL → red workflow → default GitHub notification.
+- Local runs: `node utils/dasweb-verify/browser/runner.mjs [--filter substr] [--mode m]`
+  against prod from any box; keep `--base-url` overridable for a future staging box.
+
+## nightly_playground.yml
+
+- `schedule: cron '30 4 * * *'` (after extended_checks' 04:00 — boxes idle) +
+  `workflow_dispatch` (with optional `filter` input). Canonical-repo guard on schedule like
+  the other nightlies. ubuntu-latest.
+- Steps: checkout → setup-node (NO npm cache — nightly policy) → `npm ci` in
+  `utils/dasweb-verify/browser` → `npx playwright install chromium --with-deps` → runner.
+  Use `--headless=new`; runner throttling of occluded tabs was an arc trap — CI has a single
+  focused tab, but budgets must not assume >30fps.
+- Wall clock: ~39 samples × 2 modes × 30–60 s ≈ 40–80 min on cache-hit nights. Fine.
+
+## Tier-1 wiring rides along (cheap, per-PR)
+
+`extended_checks` (linux) gains one step after the build:
+`$BIN/daslang utils/dasweb-verify/main.das` — the 39-sample compile check runs in seconds
+with the just-built binary and catches sample rot per-PR. Currently tier 1 runs nowhere in CI.
+
+## Phases (verify live before advancing)
+
+1. **P1 — interpreter leg**: runner skeleton + protocol + expectations rows for graphics
+   samples; run locally against daslang.io; confirm the GL watcher is live on prod; tune
+   budgets (pathtracer interpreted is legitimately slow — hundreds of ms per row).
+2. **P2 — wasm leg**: module-rail stdout, page-rail artifact top-page + addInitScript GL
+   watcher, build polling + failure surfacing.
+3. **P3 — completeness**: console/audio kinds, all 39 rows, unknown-sample fail-closed,
+   drift check, wedge recovery path exercised (physarum with the old source hash is a natural
+   wedge fixture if needed — or accept untested-until-it-fires).
+4. **P4 — ship**: `nightly_playground.yml`, extended_checks tier-1 step, README/CODEREVIEW
+   rows, node:test for protocol.mjs, PR (one PR — this is the samples arc's follow-up).
+
+## Traps carried from the samples arc (implementation must respect)
+
+- Occluded/headless rAF throttles to 1 Hz — `--headless=new`, single tab, generous budgets.
+- The playground tab is heavy; opening the artifact page directly (not via the iframe)
+  avoids re-running it — same recipe used to verify gl_10/gl_12.
+- `pgState`/`runCode`/engine radios (`input[name=engine]`), `#output`, `iframe.pg-run-frame`
+  / `iframe.pg-page-frame` are the established hooks (used throughout the arc).
+- Prod serves COOP/COEP on artifacts; top-level artifact pages ARE crossOriginIsolated.
+- Playground rate limits on POST /api/samples exist — serial pacing keeps under them.
+- daslang.io Host vs run.daslang.io Host: html/js artifacts 404 on the main origin BY DESIGN.
+
+## After this ships (separate, still parked)
+
+- WSL/local pre-push build leg (the emsdk mirror) — explicitly deferred.
+- Runtime bugs: jobque-on-wasm-interpreter wedge; arcanoid threaded strudel → tick port.
+- imgui-UI-presence checking (the discarded-draw-list blind spot) — needs a structured
+  snapshot rail in the web harness, not v1.

--- a/utils/dasweb-verify/CODEREVIEW.md
+++ b/utils/dasweb-verify/CODEREVIEW.md
@@ -9,6 +9,10 @@ document belongs in `README.md` with a one-line criterion here.
 **Every core behavior has a dastest test in this directory.** Exempt: `main.das` argv/exit
 glue — its pieces are the tested module.
 
+**Every pure helper in `browser/` has a `node:test` case in `browser/protocol.test.mjs`.**
+Exempt: `runner.mjs` orchestration and `probe.mjs` browser-side code — neither runs under
+node, and the nightly itself is what proves them.
+
 **Every bug fix lands with the regression test that fails without it, in the same change.**
 
 **`[test]` files live in this directory and require siblings by bare name** — never under the
@@ -22,6 +26,13 @@ creates.** A test writing into the repo tree is a defect.
 - `main.das` — the launcher: clargs parsing, per-sample reporting, exit-code mapping. No
   manifest parsing, no compilation.
 - `verify_core.das` — manifest parsing and compile execution. Zero network.
+- `browser/runner.mjs` — the driving loop: browser lifecycle, page hooks, polling, recovery.
+  No verdict rules.
+- `browser/protocol.mjs` — pure data in, pure data out: expectations lookup, output-pane
+  classification, verdicts, the report. No playwright, no network, no DOM.
+- `browser/probe.mjs` — browser-side only, installed via `addInitScript`. Self-contained (no
+  imports, no closure over module state), no node API.
+- `browser/expectations.json` — the per-sample table. Data only.
 
 **A new file ships with its rule here and its tests, in the same change.**
 
@@ -39,3 +50,25 @@ entry) is a named error and a non-zero exit, never a silent skip.
 
 **Every failure line names the sample and carries the underlying message.** A failure a reader
 cannot act on from the log alone is a defect.
+
+## Behavior — browser leg
+
+**Expectations live in `expectations.json`, never in sample sources.** A budget or pattern
+spelled as a `// verify:` line in a sample would change its content hash and throw away the
+build-cache entry the nightly depends on.
+
+**A deployed sample with no expectations row is a FAIL.** Silently skipping an unknown sample
+would let a new sample ship unverified.
+
+**Manifest drift between the deployed and repo lists is a WARN, never a FAIL.** Deploy lag
+mid-merge is legitimate.
+
+**The verifier never cache-busts a build.** A cached FAILED build for identical content and
+toolchain is a correct verdict; re-minting the hash to "get a fresh result" hides the bug.
+
+**The embedded page-shape artifact frame is never probed.** It is cross-origin by design;
+verification opens the artifact URL as a top-level page instead.
+
+**Exactly one glGetError poller per context.** `getError` clears the flag, so `probe.mjs`
+polls only where the page has no watcher of its own (artifact pages, `pollGl: true`) — never
+on the playground, where `run-frame.html` already polls.

--- a/utils/dasweb-verify/README.md
+++ b/utils/dasweb-verify/README.md
@@ -31,15 +31,70 @@ Tests run in-dir:
 daslang dastest/dastest.das -- --test utils/dasweb-verify/test_verify_core.das
 ```
 
-## Scope, and the follow-up
-
-This tier is deterministic and local — no browser, no network, no emsdk. It
+Tier 1 is deterministic and local — no browser, no network, no emsdk. It
 catches source rot (syntax/require breakage, manifest entries pointing at
-missing files) before a commit ships them to the site.
+missing files) before a commit ships them to the site. It runs per-PR in
+`extended_checks` (linux).
 
-The follow-up leg is a nightly runner against real daslang.io: drive the live
-playground in headless Chromium, run each picker sample interpreted and in wasm
-mode, and assert boot + frames advancing + a clean GL-error watcher. It targets
-production deliberately — this arc's worst bugs (artifact truncation behind
-caddy, per-box missing wasm archives) were production state no local rebuild
-can see. Artifacts are content-addressed, so most nights hit the build cache.
+## Tier 2 — the browser leg (`browser/`)
+
+A node + playwright runner that drives the LIVE playground in headless
+Chromium and reports, per sample and per engine, whether the program actually
+runs. It targets production deliberately: this arc's worst bugs (page
+artifacts truncated behind caddy, wasm archives missing on one build box, a
+failed build cached under its content hash) were production state no local
+rebuild can see. Sources and toolchain id are content-addressed, so a night
+with no sample edit and no toolchain bump is mostly cache hits.
+
+```
+cd utils/dasweb-verify/browser
+npm ci && npx playwright install chromium
+node runner.mjs                          # both engines, every sample
+node runner.mjs --mode interpreter -f gl # one engine, name substring
+node runner.mjs --list                   # the plan, no browser
+node --test                              # unit tests for the pure helpers
+```
+
+`--base-url` points it at a staging box; `--headed` shows the browser.
+Exit code 0 = every planned row passed, 1 = at least one FAIL. In CI it runs
+as `nightly_playground.yml` (04:30) and appends its table to the step summary.
+
+### What "it runs" means
+
+A single frame counter is not enough, and reasoning through the failure modes
+is what fixes the checks:
+
+- **Wedge** (the jobque class): the main thread hot-spins, so frames stop AND
+  `page.evaluate` never answers. Every call into the page is raced against a
+  deadline; a miss is a `wedge` verdict, a screenshot, and a rebuilt context.
+- **Crash / panic / missing asset**: the emscripten loop dies but the host
+  page's own frame loop keeps ticking — a bare rAF counter would call this
+  alive. So the probe also counts the *program's* WebGL draw calls, and the
+  verdict reads the output pane (`EXCEPTION`, `runtime aborted`, `error[…]`),
+  playwright's uncaught-exception events, and the GL-error watcher.
+- **Alive**: frames and draws both advance past the sample's thresholds inside
+  its budget, with none of the above firing.
+
+Console samples are checked by a stdout pattern against the output pane
+instead; audio samples only have to boot without wedging (interpreted audio
+breakup is a known parked issue, not a failure here).
+
+### expectations.json
+
+One row per sample, keyed by the picker name the deployed manifest carries,
+merged over `defaults`. Thresholds and budgets live here rather than in sample
+sources on purpose: tuning a timeout must not edit sample content and throw
+away its build-cache entry. A deployed sample with no row is a FAIL — "add an
+expectations row" — so a new sample cannot ship unverified.
+
+### Engines
+
+**Interpreter**: one persistent playground tab, the sample picked through the
+page's own `selectSample`, run in the same run frame a visitor gets.
+
+**Wasm**: the playground stores the source and polls the build. A console
+program comes back as a bare wasi module and prints into the same output pane.
+A graphics or audio program comes back as a page-shape artifact on the run
+origin, embedded cross-origin — that frame is deliberately unprobeable, so the
+runner takes its URL and opens the artifact as a top-level page, where the
+GL-error watcher is installed by init script before anything loads.

--- a/utils/dasweb-verify/browser/.gitignore
+++ b/utils/dasweb-verify/browser/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+artifacts/
+*.log

--- a/utils/dasweb-verify/browser/expectations.json
+++ b/utils/dasweb-verify/browser/expectations.json
@@ -1,0 +1,64 @@
+{
+  "_comment": [
+    "Per-sample expectations for the browser leg. Keyed by the picker name the",
+    "deployed manifest carries (playground/samples/data.json). A deployed sample",
+    "with no row here is a FAIL — new samples cannot skip verification silently.",
+    "Budgets and thresholds live here, not in sample sources: tuning a timeout",
+    "must never edit sample content and bust its content-addressed build cache."
+  ],
+  "defaults": {
+    "kind": "graphics",
+    "modes": ["interpreter", "wasm"],
+    "action": "run",
+    "budget_ms": 45000,
+    "build_budget_ms": 420000,
+    "min_observe_ms": 8000,
+    "min_rafs": 30,
+    "min_draws": 10
+  },
+  "samples": {
+    "OpenGL: rotating triangle": {},
+    "OpenGL: mandelbrot": {},
+    "OpenGL: SDF raymarcher": {},
+    "OpenGL: synthwave cube": {},
+    "OpenGL: cube swarm (instancing)": {},
+    "OpenGL: skybox + reflections (cubemap)": {},
+    "OpenGL: particle swarm (transform feedback)": {},
+    "OpenGL: shadow map (two-pass)": {},
+    "OpenGL: MSAA (multisample + blit resolve)": {},
+    "OpenGL: deferred shading (cat on brick, MRT G-buffer)": { "budget_ms": 90000 },
+    "OpenGL: HDR + bloom (float FBO)": {},
+    "OpenGL: glTF PBR capstone (deferred + HDR bloom)": { "budget_ms": 90000 },
+
+    "Game: Arcanoid (3D, arrow keys + space)": {},
+    "Game: Pac-Man (3D, arrow keys + space)": {},
+    "ImGui: Fourier Series (epicycles)": {},
+    "Path Tracer Lab (jobque + threads + GPU)": { "budget_ms": 120000, "min_rafs": 10, "min_draws": 3 },
+    "Physarum Lab (threads + audio)": { "budget_ms": 90000, "min_rafs": 15, "min_draws": 5 },
+
+    "Audio: sine beep": { "kind": "audio" },
+    "Audio: strudel synth arpeggio": { "kind": "audio" },
+
+    "Hello world": { "kind": "console", "stdout": "Hello World" },
+    "Loops": { "kind": "console", "stdout": "0123456789" },
+    "Functions": { "kind": "console", "stdout": "^hello$" },
+    "Macros (multi-file)": { "kind": "console", "stdout": "Section 3: mixed sources" },
+    "Tests": { "kind": "console", "action": "test", "modes": ["interpreter"], "stdout": "SUCCESS!" },
+
+    "Dictionary (benchmark)": { "kind": "console", "stdout": "^\"dictionary\", " },
+    "SHA-256 (benchmark)": { "kind": "console", "stdout": "^\"sha256\", " },
+    "Exp loop (benchmark)": { "kind": "console", "stdout": "^\"exp loop\", " },
+    "String→Float (benchmark)": { "kind": "console", "stdout": "^\"string2float\", " },
+    "Float→String (benchmark)": { "kind": "console", "stdout": "^\"float2string\", " },
+    "Fibonacci loop (benchmark)": { "kind": "console", "stdout": "^\"fibonacci loop\", " },
+    "Fibonacci recursive (benchmark)": { "kind": "console", "stdout": "^\"fibonacci recursive\", " },
+    "Mandelbrot (benchmark)": { "kind": "console", "stdout": "^\"mandelbrot\", " },
+    "N-bodies (benchmark)": { "kind": "console", "stdout": "^\"n-bodies\", " },
+    "Particles (benchmark)": { "kind": "console", "stdout": "^\"particles kinematics\", " },
+    "Primes loop (benchmark)": { "kind": "console", "stdout": "^\"primes loop\", " },
+    "N-Queens (benchmark)": { "kind": "console", "stdout": "^\"queen\", " },
+    "Spectral norm (benchmark)": { "kind": "console", "stdout": "^\"spectral norm\", " },
+    "Table sort (benchmark)": { "kind": "console", "stdout": "^\"sort\", " },
+    "Tree (benchmark)": { "kind": "console", "stdout": "^\"tree\", ", "budget_ms": 120000 }
+  }
+}

--- a/utils/dasweb-verify/browser/package-lock.json
+++ b/utils/dasweb-verify/browser/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "dasweb-verify-browser",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dasweb-verify-browser",
+      "version": "1.0.0",
+      "devDependencies": {
+        "playwright": "1.62.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/utils/dasweb-verify/browser/package.json
+++ b/utils/dasweb-verify/browser/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dasweb-verify-browser",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Nightly browser leg of the curated-sample verifier: drives the live daslang.io playground",
+  "scripts": {
+    "verify": "node runner.mjs",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "playwright": "1.62.1"
+  }
+}

--- a/utils/dasweb-verify/browser/probe.mjs
+++ b/utils/dasweb-verify/browser/probe.mjs
@@ -1,0 +1,96 @@
+// Browser-side probe, installed into every page and frame of a context via
+// playwright's addInitScript — before any page script runs, so nothing races
+// the program's own start-up.
+//
+// `installProbe` is serialized and evaluated in the browser: it must stay
+// self-contained (no imports, no closure over module state) and touch no node
+// API. Its only export to the runner is `window.__dwv`.
+
+export function installProbe(opts) {
+    const state = {
+        raf: 0,          // the frame's own paint loop — 0 means wedged or throttled
+        draws: 0,        // the PROGRAM's draw calls: a dead emscripten loop stops these
+        gl: false,       // a WebGL context was created
+        audio: false,    // an AudioContext was created
+        ran: false,      // this frame is the one the playground handed a program to
+        glErrors: [],    // only populated when opts.pollGl (pages with no watcher of their own)
+    };
+    window.__dwv = state;
+
+    (function tick() {
+        state.raf++;
+        requestAnimationFrame(tick);
+    })();
+
+    // The playground hands the program to one run frame and pre-warms a spare;
+    // both are run-frame.html, so the run message is what tells them apart.
+    window.addEventListener('message', function (ev) {
+        const m = ev.data;
+        if (m && typeof m === 'object' && m.type === 'run') state.ran = true;
+    });
+
+    const DRAW_METHODS = [
+        'drawArrays', 'drawElements', 'drawArraysInstanced',
+        'drawElementsInstanced', 'drawRangeElements',
+    ];
+
+    // Patch the prototypes once rather than each returned context: emscripten
+    // issues thousands of draws per frame and a per-instance wrapper chain is
+    // the more expensive of the two.
+    function patchProto(proto) {
+        if (!proto || proto.__dwvPatched) return;
+        proto.__dwvPatched = true;
+        for (const name of DRAW_METHODS) {
+            const original = proto[name];
+            if (typeof original !== 'function') continue;
+            proto[name] = function () {
+                state.draws++;
+                return original.apply(this, arguments);
+            };
+        }
+    }
+    patchProto(window.WebGLRenderingContext && window.WebGLRenderingContext.prototype);
+    patchProto(window.WebGL2RenderingContext && window.WebGL2RenderingContext.prototype);
+
+    const getContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (type) {
+        const ctx = getContext.apply(this, arguments);
+        if (ctx && /webgl/i.test(String(type))) {
+            state.gl = true;
+            // Artifact pages carry no glGetError watcher of their own, so poll
+            // one here. NEVER on the playground: run-frame.html already polls,
+            // and getError CLEARS the flag — two pollers would steal each
+            // other's errors and both would under-report.
+            if (opts && opts.pollGl) startGlPoll(ctx);
+        }
+        return ctx;
+    };
+
+    function startGlPoll(gl) {
+        const NAMES = {
+            0x0500: 'GL_INVALID_ENUM', 0x0501: 'GL_INVALID_VALUE', 0x0502: 'GL_INVALID_OPERATION',
+            0x0505: 'GL_OUT_OF_MEMORY', 0x0506: 'GL_INVALID_FRAMEBUFFER_OPERATION',
+        };
+        (function poll() {
+            try {
+                const code = gl.getError();
+                if (code) {
+                    const text = 'GL error: ' + (NAMES[code] || '0x' + code.toString(16));
+                    if (!state.glErrors.includes(text)) state.glErrors.push(text);
+                }
+            } catch (e) { /* context lost — the page's own errors will say so */ }
+            requestAnimationFrame(poll);
+        })();
+    }
+
+    for (const name of ['AudioContext', 'webkitAudioContext']) {
+        const Original = window[name];
+        if (typeof Original !== 'function') continue;
+        const Patched = function () {
+            state.audio = true;
+            return Reflect.construct(Original, arguments, this.constructor || Patched);
+        };
+        Patched.prototype = Original.prototype;
+        window[name] = Patched;
+    }
+}

--- a/utils/dasweb-verify/browser/protocol.mjs
+++ b/utils/dasweb-verify/browser/protocol.mjs
@@ -1,0 +1,241 @@
+// Pure half of the browser leg: expectations lookup, output-pane classification,
+// verdict assembly, reporting. No playwright, no network, no DOM — everything
+// here takes plain data and returns plain data, so node:test can cover it.
+//
+// The impure half (driving the live playground) lives in runner.mjs.
+
+// printOutput() in web/examples/ui/src/main.js stamps the severity as the row's
+// background colour, so the page itself tells us which lines it considered
+// failures: #ff9393 = stderr / compiler error, #ff2d2d = abort / infrastructure.
+export const ERROR_COLORS = new Set(['#ff9393', '#ff2d2d']);
+
+// run-frame.html's per-frame glGetError poll (#3640). A failed GL call neither
+// throws nor stops the program, so this line is the only in-page evidence.
+export const GL_ERROR_RE = /^GL error:/;
+
+// Lines that are failures regardless of how they were coloured. `EXCEPTION` is
+// how utils/daScript/main.cpp reports an uncaught panic; `error[NNNNN]` is a
+// compile diagnostic; the rest are the run frame's own and emscripten's.
+export const ERROR_MARKERS = [
+    /\bEXCEPTION\b/,
+    /^runtime aborted:/,
+    /\berror\[\d{5}\]/,
+    /\bassert failed\b/,
+    /\bAborted\(/,
+    /^FS error writing /,
+    /^asset .+: /,
+    /^build failed/,
+    /^build request failed/,
+    /^build status failed/,
+    /^build timed out/,
+    /^build reported done with no artifact/,
+    /^page build reported no html artifact/,
+    /^wasm build error:/,
+    /^wasm builds are not available/,
+    /^sample store returned/,
+];
+
+// The output pane reports colours back as `rgb(r, g, b)`.
+export function normalizeColor(color) {
+    if (!color) return '';
+    const m = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color);
+    if (!m) return String(color).toLowerCase();
+    const hex = (n) => Number(n).toString(16).padStart(2, '0');
+    return '#' + hex(m[1]) + hex(m[2]) + hex(m[3]);
+}
+
+function ignoreMatcher(ignore) {
+    const res = (ignore || []).map((p) => new RegExp(p));
+    return (text) => res.some((re) => re.test(text));
+}
+
+// Split the output pane into the three things a verdict cares about. GL lines
+// are pulled out before the error sweep so they report as their own class —
+// "the program ran but the driver refused a call" is a different bug from
+// "the program died".
+export function classifyOutput(lines, ignore) {
+    const ignored = ignoreMatcher(ignore);
+    const gl = [];
+    const errors = [];
+    for (const line of lines) {
+        const text = String(line.text ?? '');
+        if (ignored(text)) continue;
+        if (GL_ERROR_RE.test(text)) {
+            if (!gl.includes(text)) gl.push(text);
+            continue;
+        }
+        const color = normalizeColor(line.color);
+        if (ERROR_COLORS.has(color) || ERROR_MARKERS.some((re) => re.test(text))) {
+            errors.push(text);
+        }
+    }
+    return { gl, errors };
+}
+
+export function stdoutMatches(lines, pattern) {
+    const re = new RegExp(pattern);
+    return lines.some((line) => re.test(String(line.text ?? '')));
+}
+
+// A page-shape artifact is served from its own origin (run.daslang.io) — the
+// separate, cookie-less run origin IS the isolation boundary, so anything
+// same-origin or relative here means the page did not get a real artifact.
+export function artifactUrlFrom(src, siteUrl) {
+    if (!src) return '';
+    let url;
+    try {
+        url = new URL(src, siteUrl);
+    } catch {
+        return '';
+    }
+    if (!/^https?:$/.test(url.protocol)) return '';
+    if (!/\.html?$/.test(url.pathname)) return '';
+    return url.href;
+}
+
+export const KINDS = new Set(['graphics', 'console', 'audio']);
+
+// Merge a sample's row over the table defaults. Fails closed twice over: an
+// unlisted sample is an error (so a newly deployed sample cannot skip
+// verification), and so is a row the runner would not know how to execute.
+export function resolveSpec(table, name) {
+    const row = table.samples ? table.samples[name] : undefined;
+    if (row === undefined) {
+        return { ok: false, error: 'no expectations row — add one to expectations.json' };
+    }
+    const spec = { ...(table.defaults || {}), ...row, name };
+    if (!KINDS.has(spec.kind)) {
+        return { ok: false, error: `unknown kind "${spec.kind}"` };
+    }
+    if (spec.kind === 'console' && !spec.stdout) {
+        return { ok: false, error: 'console sample needs a "stdout" pattern' };
+    }
+    if (!Array.isArray(spec.modes) || spec.modes.length === 0) {
+        return { ok: false, error: 'no modes listed' };
+    }
+    if (!(spec.budget_ms > 0)) {
+        return { ok: false, error: 'budget_ms must be positive' };
+    }
+    // Missing would not misjudge anything, but it would silently hold every
+    // sample open for its whole budget — minutes of nightly, no signal.
+    if (!(spec.min_observe_ms > 0) || spec.min_observe_ms > spec.budget_ms) {
+        return { ok: false, error: 'min_observe_ms must be positive and within budget_ms' };
+    }
+    if (spec.modes.includes('wasm') && !(spec.build_budget_ms > 0)) {
+        return { ok: false, error: 'build_budget_ms must be positive' };
+    }
+    return { ok: true, spec };
+}
+
+// One row per sample x mode, in manifest order. An unresolvable sample yields a
+// single FAIL row rather than being dropped.
+export function planRows(samples, table, opts = {}) {
+    const wanted = opts.modes && opts.modes.length ? new Set(opts.modes) : null;
+    const filter = opts.filter ? String(opts.filter).toLowerCase() : '';
+    const rows = [];
+    for (const sample of samples) {
+        const name = sample.name;
+        if (filter && !name.toLowerCase().includes(filter)) continue;
+        const resolved = resolveSpec(table, name);
+        if (!resolved.ok) {
+            rows.push({ name, mode: '-', status: 'FAIL', detail: resolved.error, ms: 0 });
+            continue;
+        }
+        for (const mode of resolved.spec.modes) {
+            if (wanted && !wanted.has(mode)) continue;
+            rows.push({ name, mode, spec: resolved.spec, sample });
+        }
+    }
+    return rows;
+}
+
+// The liveness protocol, in one place. Order matters: a wedge hides everything
+// else, and a dead program's error line is a better report than "too few
+// frames" — which is only the symptom.
+export function verdict(spec, obs) {
+    if (obs.wedge) {
+        return { status: 'FAIL', detail: 'wedge: page stopped answering evaluate' };
+    }
+    const { gl, errors } = classifyOutput(obs.lines || [], spec.ignore);
+    if (errors.length) {
+        return { status: 'FAIL', detail: errors[0] };
+    }
+    const ignored = ignoreMatcher(spec.ignore);
+    const pageErrors = (obs.pageErrors || []).filter((e) => !ignored(e));
+    if (pageErrors.length) {
+        return { status: 'FAIL', detail: 'page error: ' + pageErrors[0] };
+    }
+    if (gl.length) {
+        return { status: 'FAIL', detail: gl.join(' | ') };
+    }
+    if (spec.kind === 'console') {
+        if (stdoutMatches(obs.lines || [], spec.stdout)) return { status: 'PASS', detail: '' };
+        return { status: 'FAIL', detail: `no output line matched /${spec.stdout}/` };
+    }
+    if (spec.kind === 'audio') {
+        if (obs.started) return { status: 'PASS', detail: '' };
+        return { status: 'FAIL', detail: 'program never started' };
+    }
+    // graphics: the page must keep painting (not wedged) AND the program's own
+    // render loop must issue draws — a crashed emscripten loop leaves the host
+    // page's rAF ticking, so the frame counter alone would call it alive.
+    const rafs = obs.rafs || 0;
+    const draws = obs.draws || 0;
+    if (rafs < spec.min_rafs || draws < spec.min_draws) {
+        return {
+            status: 'FAIL',
+            detail: `rafs ${rafs}/${spec.min_rafs}, draws ${draws}/${spec.min_draws}`,
+        };
+    }
+    return { status: 'PASS', detail: `rafs ${rafs}, draws ${draws}` };
+}
+
+// Deploy lag mid-merge is legitimate, so manifest drift is reported, never
+// failed. A sample only on the deployed side still gets verified (and fails
+// closed if it has no expectations row).
+export function driftWarnings(deployedNames, repoNames) {
+    const repo = new Set(repoNames);
+    const deployed = new Set(deployedNames);
+    const rows = [];
+    for (const name of deployedNames) {
+        if (!repo.has(name)) {
+            rows.push({ name, mode: '-', status: 'WARN', detail: 'deployed but not in the repo manifest', ms: 0 });
+        }
+    }
+    for (const name of repoNames) {
+        if (!deployed.has(name)) {
+            rows.push({ name, mode: '-', status: 'WARN', detail: 'in the repo manifest but not deployed', ms: 0 });
+        }
+    }
+    return rows;
+}
+
+function escapeCell(text) {
+    return String(text ?? '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').slice(0, 300);
+}
+
+export function formatSummary(rows, title = 'dasweb sample verifier') {
+    const counts = countStatuses(rows);
+    const out = [
+        `## ${title}`,
+        '',
+        `${counts.PASS} passed, ${counts.FAIL} failed, ${counts.WARN} warnings`,
+        '',
+        '| sample | mode | status | ms | detail |',
+        '| --- | --- | --- | ---: | --- |',
+    ];
+    for (const r of rows) {
+        out.push(`| ${escapeCell(r.name)} | ${r.mode} | ${r.status} | ${r.ms ?? 0} | ${escapeCell(r.detail)} |`);
+    }
+    return out.join('\n') + '\n';
+}
+
+export function countStatuses(rows) {
+    const counts = { PASS: 0, FAIL: 0, WARN: 0 };
+    for (const r of rows) counts[r.status] = (counts[r.status] || 0) + 1;
+    return counts;
+}
+
+export function exitCodeFor(rows) {
+    return rows.some((r) => r.status === 'FAIL') ? 1 : 0;
+}

--- a/utils/dasweb-verify/browser/protocol.mjs
+++ b/utils/dasweb-verify/browser/protocol.mjs
@@ -77,9 +77,12 @@ export function stdoutMatches(lines, pattern) {
     return lines.some((line) => re.test(String(line.text ?? '')));
 }
 
-// A page-shape artifact is served from its own origin (run.daslang.io) — the
-// separate, cookie-less run origin IS the isolation boundary, so anything
-// same-origin or relative here means the page did not get a real artifact.
+// Production serves page-shape artifacts from a separate cookie-less run origin,
+// but that is a property of the DEPLOYMENT, not a rule to hard-code here —
+// --base-url points at staging boxes that may serve them from one origin. So this
+// validates only what must always hold: an absolute http(s) URL naming an .html
+// artifact. The src can come from nowhere else — main.js sets iframe.pg-page-frame
+// from the build result alone.
 export function artifactUrlFrom(src, siteUrl) {
     if (!src) return '';
     let url;

--- a/utils/dasweb-verify/browser/protocol.test.mjs
+++ b/utils/dasweb-verify/browser/protocol.test.mjs
@@ -99,6 +99,11 @@ test('artifactUrlFrom takes only a real cross-origin page artifact', () => {
     assert.equal(P.artifactUrlFrom('about:blank', 'https://daslang.io'), '');
     // The frame src before an artifact lands, and non-page artifacts, are not URLs to open.
     assert.equal(P.artifactUrlFrom('https://run.daslang.io/b/abc/sample.wasm', 'https://daslang.io'), '');
+    // Same-origin is accepted ON PURPOSE: the separate run origin is a production
+    // deployment choice, and --base-url may point at a staging box without one.
+    assert.equal(
+        P.artifactUrlFrom('/api/build/artifact/abc/def/sample.html', 'https://daslang.io'),
+        'https://daslang.io/api/build/artifact/abc/def/sample.html');
 });
 
 test('planRows expands modes, applies the filter, and keeps unknown samples as FAIL', () => {

--- a/utils/dasweb-verify/browser/protocol.test.mjs
+++ b/utils/dasweb-verify/browser/protocol.test.mjs
@@ -1,0 +1,195 @@
+// node --test  (run from this directory)
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as P from './protocol.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+const TABLE = {
+    defaults: {
+        kind: 'graphics', modes: ['interpreter', 'wasm'], action: 'run',
+        budget_ms: 1000, build_budget_ms: 5000, min_observe_ms: 500, min_rafs: 30, min_draws: 10,
+    },
+    samples: {
+        'Gfx': {},
+        'Console': { kind: 'console', stdout: 'hello' },
+        'Audio': { kind: 'audio' },
+        'InterpOnly': { kind: 'console', stdout: 'x', modes: ['interpreter'] },
+    },
+};
+
+const line = (text, color = '#ffffff') => ({ text, color });
+
+test('normalizeColor maps the pane\'s rgb() back to hex', () => {
+    assert.equal(P.normalizeColor('rgb(255, 45, 45)'), '#ff2d2d');
+    assert.equal(P.normalizeColor('rgb(255, 147, 147)'), '#ff9393');
+    assert.equal(P.normalizeColor(''), '');
+});
+
+test('classifyOutput separates GL lines from failures and dedupes GL', () => {
+    const { gl, errors } = P.classifyOutput([
+        line('hello'),
+        line('GL error: GL_INVALID_OPERATION at frame 3', 'rgb(255, 147, 147)'),
+        line('GL error: GL_INVALID_OPERATION at frame 4', 'rgb(255, 147, 147)'),
+        line('GL error: GL_INVALID_OPERATION at frame 3', 'rgb(255, 147, 147)'),
+    ]);
+    assert.equal(errors.length, 0);
+    assert.equal(gl.length, 2);
+});
+
+test('classifyOutput trusts the pane colour for severity', () => {
+    const { errors } = P.classifyOutput([line('something went wrong', 'rgb(255, 45, 45)')]);
+    assert.deepEqual(errors, ['something went wrong']);
+});
+
+test('classifyOutput catches runtime markers that arrived uncoloured', () => {
+    const cases = [
+        'EXCEPTION: division by zero at main.das:4',
+        'runtime aborted: RuntimeError',
+        'main.das:3:1: error[30301] cannot infer type',
+        'assert failed, expected 4',
+        'Aborted(OOM)',
+        'asset /a/b.png: 404',
+    ];
+    for (const text of cases) {
+        const { errors } = P.classifyOutput([line(text)]);
+        assert.deepEqual(errors, [text], text);
+    }
+});
+
+test('classifyOutput honours a sample\'s ignore list', () => {
+    const { errors } = P.classifyOutput(
+        [line('WebGL: too many contexts', 'rgb(255, 45, 45)')], ['too many contexts']);
+    assert.deepEqual(errors, []);
+});
+
+test('resolveSpec merges defaults and fails closed on an unlisted sample', () => {
+    const ok = P.resolveSpec(TABLE, 'Gfx');
+    assert.equal(ok.ok, true);
+    assert.equal(ok.spec.min_rafs, 30);
+    assert.equal(ok.spec.kind, 'graphics');
+
+    const missing = P.resolveSpec(TABLE, 'Brand New Sample');
+    assert.equal(missing.ok, false);
+    assert.match(missing.error, /expectations/);
+});
+
+test('resolveSpec rejects rows the runner could not execute', () => {
+    assert.equal(P.resolveSpec({ defaults: {}, samples: { A: { kind: 'video' } } }, 'A').ok, false);
+    assert.equal(P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { kind: 'console' } } }, 'A').ok, false);
+    assert.equal(P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { modes: [] } } }, 'A').ok, false);
+    assert.equal(P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { budget_ms: 0 } } }, 'A').ok, false);
+    assert.equal(P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { min_observe_ms: 0 } } }, 'A').ok, false);
+    // An observation window longer than the budget could never close.
+    assert.equal(P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { min_observe_ms: 99999 } } }, 'A').ok, false);
+    // Only wasm rows pay the build; an interpreter-only row needs no build budget.
+    assert.equal(P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { build_budget_ms: 0 } } }, 'A').ok, false);
+    assert.equal(P.resolveSpec(
+        { defaults: { ...TABLE.defaults, build_budget_ms: 0 }, samples: { A: { modes: ['interpreter'] } } }, 'A').ok, true);
+});
+
+test('artifactUrlFrom takes only a real cross-origin page artifact', () => {
+    assert.equal(
+        P.artifactUrlFrom('https://run.daslang.io/b/abc/sample.html', 'https://daslang.io'),
+        'https://run.daslang.io/b/abc/sample.html');
+    assert.equal(P.artifactUrlFrom('', 'https://daslang.io'), '');
+    assert.equal(P.artifactUrlFrom('about:blank', 'https://daslang.io'), '');
+    // The frame src before an artifact lands, and non-page artifacts, are not URLs to open.
+    assert.equal(P.artifactUrlFrom('https://run.daslang.io/b/abc/sample.wasm', 'https://daslang.io'), '');
+});
+
+test('planRows expands modes, applies the filter, and keeps unknown samples as FAIL', () => {
+    const samples = [{ name: 'Gfx' }, { name: 'InterpOnly' }, { name: 'Unlisted' }];
+    const rows = P.planRows(samples, TABLE);
+    assert.deepEqual(rows.map((r) => `${r.name}/${r.mode}`),
+        ['Gfx/interpreter', 'Gfx/wasm', 'InterpOnly/interpreter', 'Unlisted/-']);
+    assert.equal(rows[3].status, 'FAIL');
+
+    const wasmOnly = P.planRows(samples, TABLE, { modes: ['wasm'] });
+    assert.deepEqual(wasmOnly.map((r) => `${r.name}/${r.mode}`), ['Gfx/wasm', 'Unlisted/-']);
+
+    const filtered = P.planRows(samples, TABLE, { filter: 'interp' });
+    assert.deepEqual(filtered.map((r) => r.name), ['InterpOnly']);
+});
+
+test('verdict: a wedge outranks everything', () => {
+    const spec = P.resolveSpec(TABLE, 'Gfx').spec;
+    const v = P.verdict(spec, { wedge: true, rafs: 999, draws: 999, lines: [] });
+    assert.equal(v.status, 'FAIL');
+    assert.match(v.detail, /wedge/);
+});
+
+test('verdict: a crashed graphics program fails even with the host page painting', () => {
+    const spec = P.resolveSpec(TABLE, 'Gfx').spec;
+    // The exact blind spot a bare rAF counter has: the frame keeps ticking after
+    // the emscripten loop dies, so only the draw counter and the error line see it.
+    const v = P.verdict(spec, { rafs: 500, draws: 0, lines: [line('runtime aborted: RuntimeError')] });
+    assert.equal(v.status, 'FAIL');
+    assert.match(v.detail, /runtime aborted/);
+
+    const silent = P.verdict(spec, { rafs: 500, draws: 0, lines: [] });
+    assert.equal(silent.status, 'FAIL');
+    assert.match(silent.detail, /draws 0\/10/);
+});
+
+test('verdict: a live graphics program passes', () => {
+    const spec = P.resolveSpec(TABLE, 'Gfx').spec;
+    assert.equal(P.verdict(spec, { rafs: 60, draws: 60, lines: [] }).status, 'PASS');
+});
+
+test('verdict: GL errors fail a sample that is otherwise alive', () => {
+    const spec = P.resolveSpec(TABLE, 'Gfx').spec;
+    const v = P.verdict(spec, { rafs: 60, draws: 60, lines: [line('GL error: GL_INVALID_OPERATION')] });
+    assert.equal(v.status, 'FAIL');
+    assert.match(v.detail, /GL_INVALID_OPERATION/);
+});
+
+test('verdict: console matches the pane, audio only needs a boot', () => {
+    const console_ = P.resolveSpec(TABLE, 'Console').spec;
+    assert.equal(P.verdict(console_, { lines: [line('hello world')] }).status, 'PASS');
+    assert.equal(P.verdict(console_, { lines: [line('goodbye')] }).status, 'FAIL');
+
+    const audio = P.resolveSpec(TABLE, 'Audio').spec;
+    assert.equal(P.verdict(audio, { started: true, lines: [] }).status, 'PASS');
+    assert.equal(P.verdict(audio, { started: false, lines: [] }).status, 'FAIL');
+});
+
+test('verdict: a page error fails the row', () => {
+    const spec = P.resolveSpec(TABLE, 'Gfx').spec;
+    const v = P.verdict(spec, { rafs: 60, draws: 60, lines: [], pageErrors: ['TypeError: x is not a function'] });
+    assert.equal(v.status, 'FAIL');
+    assert.match(v.detail, /page error/);
+});
+
+test('driftWarnings reports both directions and never fails', () => {
+    const rows = P.driftWarnings(['a', 'b'], ['b', 'c']);
+    assert.deepEqual(rows.map((r) => `${r.name}:${r.status}`), ['a:WARN', 'c:WARN']);
+});
+
+test('formatSummary escapes pipes and exitCodeFor gates on FAIL alone', () => {
+    const rows = [
+        { name: 'A|B', mode: 'interpreter', status: 'PASS', ms: 12, detail: 'rafs 60' },
+        { name: 'C', mode: 'wasm', status: 'WARN', ms: 0, detail: 'drift' },
+    ];
+    const md = P.formatSummary(rows);
+    assert.match(md, /A\\\|B/);
+    assert.match(md, /1 passed, 0 failed, 1 warnings/);
+    assert.equal(P.exitCodeFor(rows), 0);
+    assert.equal(P.exitCodeFor([...rows, { status: 'FAIL' }]), 1);
+});
+
+test('every expectations row resolves, and the shipped manifest is fully covered', async () => {
+    const table = JSON.parse(await readFile(path.join(HERE, 'expectations.json'), 'utf8'));
+    for (const name of Object.keys(table.samples)) {
+        const r = P.resolveSpec(table, name);
+        assert.equal(r.ok, true, `${name}: ${r.error}`);
+    }
+    const manifest = JSON.parse(await readFile(
+        path.join(HERE, '..', '..', '..', 'web', 'examples', 'ui', 'samples', 'data.json'), 'utf8'));
+    const rows = P.planRows(manifest.examples, table);
+    const unresolved = rows.filter((r) => r.status === 'FAIL').map((r) => r.name);
+    assert.deepEqual(unresolved, [], 'samples with no expectations row');
+});

--- a/utils/dasweb-verify/browser/runner.mjs
+++ b/utils/dasweb-verify/browser/runner.mjs
@@ -1,0 +1,569 @@
+#!/usr/bin/env node
+// Browser leg of the curated-sample verifier: drive the LIVE playground in
+// headless Chromium and report, per sample and per engine, whether the program
+// actually runs.
+//
+// It targets production on purpose. This arc's worst bugs were production state
+// no local rebuild could see — artifacts truncated behind caddy, wasm archives
+// missing on one box, a build failure cached under its content hash. Artifacts
+// are content-addressed (source hash x toolchain id), so a night with no
+// toolchain bump and no sample edit is mostly cache hits.
+//
+//   node runner.mjs [--mode interpreter|wasm] [--filter substr] [--base-url URL]
+//
+// Exit code 0 = every planned row passed; 1 = at least one FAIL (each named).
+
+import { chromium } from 'playwright';
+import { readFile, writeFile, mkdir, appendFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as P from './protocol.mjs';
+import { installProbe } from './probe.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_MANIFEST = path.join(HERE, '..', '..', '..', 'web', 'examples', 'ui', 'samples', 'data.json');
+
+const POLL_MS = 500;
+// Build polling is deliberately slow: the queue is one shared compute box and
+// a fresh page build runs for minutes. Serial pacing also keeps the verifier
+// under the playground's POST rate limits.
+const BUILD_POLL_MS = 4500;
+// Cap for a single page.evaluate outside a sample's own budget (page setup,
+// sample selection). Inside the run loop the cap is whatever is LEFT of the
+// budget instead: a daslang program owns the main thread while it runs, so a
+// console benchmark computing for 40s looks exactly like a wedge until its
+// budget is actually spent. Declaring one sooner is a false alarm — it bit the
+// tree benchmark on the first live sweep.
+const EVALUATE_MS = 20000;
+// Floor under that derived cap, so the last poll of a budget still gets a fair
+// chance to answer instead of reporting a wedge a millisecond before the end.
+const EVALUATE_FLOOR_MS = 5000;
+// The playground tab itself must come up well inside this or the run is moot.
+const PAGE_READY_MS = 90000;
+
+function parseArgs(argv) {
+    const cfg = {
+        baseUrl: 'https://daslang.io',
+        modes: [],
+        filter: '',
+        summary: process.env.GITHUB_STEP_SUMMARY || '',
+        artifacts: path.join(HERE, 'artifacts'),
+        headed: false,
+        list: false,
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        const next = () => argv[++i];
+        if (a === '--base-url') cfg.baseUrl = next().replace(/\/+$/, '');
+        else if (a === '--filter' || a === '-f') cfg.filter = next();
+        else if (a === '--mode' || a === '-m') cfg.modes.push(...next().split(',').map((s) => s.trim()).filter(Boolean));
+        else if (a === '--summary') cfg.summary = next();
+        else if (a === '--artifacts') cfg.artifacts = next();
+        else if (a === '--headed') cfg.headed = true;
+        else if (a === '--console') cfg.console = true;
+        else if (a === '--list') cfg.list = true;
+        else if (a === '--help' || a === '-?') cfg.help = true;
+        else throw new Error(`unknown argument: ${a}`);
+    }
+    return cfg;
+}
+
+const HELP = `dasweb-verify browser leg
+
+  --base-url URL     site to verify (default https://daslang.io)
+  --mode M[,M]       interpreter | wasm (default: whatever each sample lists)
+  --filter SUBSTR    only samples whose name contains SUBSTR
+  --summary PATH     append the markdown report here (default $GITHUB_STEP_SUMMARY)
+  --artifacts DIR    where failure screenshots go
+  --headed           run with a visible browser
+  --list             print the plan and exit, no browser
+`;
+
+async function fetchJson(url) {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`GET ${url} -> ${resp.status}`);
+    return resp.json();
+}
+
+// Every call into the page is raced: a wedged renderer never answers, and a
+// verifier that waits forever reports nothing at all.
+async function withDeadline(promise, ms, label) {
+    let timer;
+    const guard = new Promise((resolve) => {
+        timer = setTimeout(() => resolve({ wedge: true, label }), ms);
+    });
+    try {
+        const value = await Promise.race([promise.then((v) => ({ value: v })), guard]);
+        return value;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+async function evaluateIn(target, fn, arg, ms = EVALUATE_MS) {
+    const r = await withDeadline(target.evaluate(fn, arg), ms, 'evaluate');
+    if (r.wedge) throw new WedgeError();
+    return r.value;
+}
+
+class WedgeError extends Error {
+    constructor() {
+        super('page stopped answering evaluate');
+        this.wedge = true;
+    }
+}
+
+// ── the playground tab ────────────────────────────────────────────────────
+
+class Playground {
+    constructor(browser, cfg) {
+        this.browser = browser;
+        this.cfg = cfg;
+        this.context = null;
+        this.page = null;
+        this.pageErrors = [];
+    }
+
+    async open() {
+        this.context = await this.browser.newContext({ viewport: { width: 1440, height: 1000 } });
+        // Before any page script: the probe must not race the program's start.
+        await this.context.addInitScript(installProbe, { pollGl: false });
+        this.page = await this.context.newPage();
+        this.page.on('pageerror', (e) => this.pageErrors.push(String(e && e.message ? e.message : e)));
+        this.page.on('console', (msg) => {
+            // Chrome writes the WHY of a rejected GL call to its own console
+            // ("WebGL: INVALID_ENUM: <api>: <reason>") and nothing else can read
+            // it — including the page. --console is how a failing sample gets
+            // diagnosed without reproducing it by hand.
+            if (this.cfg.console) process.stderr.write(`  [${msg.type()}] ${msg.text()}\n`);
+            // A failed request is NOT a program failure here: the playground
+            // probes `<sample>.das.assets.json` for every sample and only two
+            // have one, so a 404 per run is the designed normal case. Assets
+            // that fail once a run frame does want them surface as an
+            // `asset <url>: …` line in the output pane, which the verdict reads.
+            if (msg.type() === 'error' && !/^Failed to load resource:/.test(msg.text())) {
+                this.pageErrors.push(msg.text());
+            }
+        });
+        await this.page.goto(`${this.cfg.baseUrl}/playground/index.html`, { waitUntil: 'load', timeout: PAGE_READY_MS });
+        // The interpreter engine gates Run on the local runtime finishing its
+        // load; the wasm radio unlocks only once the build service answers.
+        await this.page.waitForFunction(
+            () => { const b = document.getElementById('run'); return b && !b.disabled; },
+            null, { timeout: PAGE_READY_MS });
+    }
+
+    async close() {
+        // A wedged renderer can refuse to tear down; the browser outlives it.
+        await withDeadline(this.context.close(), 15000, 'close');
+        this.context = null;
+        this.page = null;
+    }
+
+    async restart() {
+        try { await this.close(); } catch { /* the point of restarting */ }
+        await this.open();
+    }
+
+    async selectMode(mode) {
+        if (mode === 'wasm') {
+            await this.page.waitForFunction(
+                () => { const r = document.querySelector('input[name=engine][value=wasm]'); return r && !r.disabled; },
+                null, { timeout: PAGE_READY_MS });
+        }
+        await evaluateIn(this.page, (m) => {
+            const radio = document.querySelector(`input[name=engine][value=${m}]`);
+            if (!radio) throw new Error('no engine radio ' + m);
+            radio.checked = true;
+            radio.dispatchEvent(new Event('change', { bubbles: true }));
+        }, mode);
+    }
+
+    // Load a sample by its index in the deployed manifest — that is exactly the
+    // picker's own indexing, so this clicks what a visitor clicks.
+    //
+    // Readiness is "the editor holds THIS sample's bytes", compared against the
+    // source fetched straight from the site. "The text changed" would be the
+    // obvious check and is wrong: the page preloads the first sample, so
+    // verifying it would wait forever for a change that already happened.
+    async selectSample(index, sample) {
+        const entryUrl = `${this.cfg.baseUrl}/playground/samples/${sample.files[0]}`;
+        const resp = await fetch(entryUrl);
+        if (!resp.ok) throw new Error(`entry file ${entryUrl} -> ${resp.status}`);
+        const expected = (await resp.text()).replace(/\r\n/g, '\n').trimEnd();
+
+        await evaluateIn(this.page, (i) => window.selectSample('examples', i), index);
+        const loaded = await withDeadline(this.page.waitForFunction(({ want, count }) => {
+            const st = window.pgState;
+            if (!st || !st.files) return false;
+            const names = Object.keys(st.files);
+            if (names.length !== count) return false;
+            const doc = st.files['main.das'] || st.files[names[0]];
+            const text = doc ? doc.getValue() : '';
+            return text.replace(/\r\n/g, '\n').trimEnd() === want;
+        }, { want: expected, count: sample.files.length }, { timeout: 30000, polling: 200 }), 35000, 'sample-load');
+        if (loaded.wedge) throw new WedgeError();
+    }
+
+    async clearAndRun(action, mode) {
+        // The interpreter runs in a pre-warmed frame, and the frame that
+        // replaces a torn-down one needs a moment to report itself ready. Run
+        // before that and the page answers "daslang is still loading" instead
+        // of running the sample — a verifier failure with no bug behind it.
+        if (mode !== 'wasm') {
+            const ready = await withDeadline(this.page.waitForFunction(
+                () => window.PlaygroundRunner && window.PlaygroundRunner.isReady(),
+                null, { timeout: 60000, polling: 200 }), 65000, 'frame-ready');
+            if (ready.wedge) throw new WedgeError();
+        }
+        await evaluateIn(this.page, () => {
+            if (typeof window.clearOutput === 'function') window.clearOutput();
+        });
+        this.pageErrors.length = 0;
+        // Deliberately not awaited inside the page: runCode resolves only after
+        // the whole wasm build round-trip, and a graphics program never stops.
+        await evaluateIn(this.page, (a) => {
+            const fn = a === 'test' ? window.runTests : window.runCode;
+            Promise.resolve(fn()).catch((e) => {
+                const out = document.getElementById('output');
+                if (out) out.appendChild(Object.assign(document.createElement('div'), {
+                    className: 'output_line', innerText: 'runner: run threw ' + e,
+                }));
+            });
+        }, action);
+    }
+
+    async readOutput(ms) {
+        return evaluateIn(this.page, () => {
+            const rows = document.querySelectorAll('#output .output_line');
+            return Array.from(rows, (row) => {
+                const p = row.querySelector('.output_line_text');
+                return { text: p ? p.innerText : row.innerText, color: row.style.backgroundColor };
+            });
+        }, null, ms);
+    }
+
+    // The playground keeps a pre-warmed spare frame, so identity matters: the
+    // one that was handed a program is the one that saw the run message.
+    async readRunFrameProbe(ms) {
+        for (const frame of this.page.frames()) {
+            if (!/run-frame\.html/.test(frame.url())) continue;
+            let probe = null;
+            try {
+                probe = await evaluateIn(frame, () => (window.__dwv ? { ...window.__dwv } : null), null, ms);
+            } catch (e) {
+                if (e.wedge) throw e;
+                continue;   // frame was swapped out mid-read
+            }
+            if (probe && probe.ran) return probe;
+        }
+        return null;
+    }
+
+    async reset() {
+        await evaluateIn(this.page, () => {
+            if (window.PlaygroundRunner) window.PlaygroundRunner.reset();
+        });
+    }
+
+    // The wasm page rail embeds the artifact cross-origin — a deliberate
+    // security boundary, so the frame cannot be probed. Its src is the whole
+    // point: the artifact opens as a top-level page instead.
+    async readArtifactUrl() {
+        const src = await evaluateIn(this.page, () => {
+            const frame = document.querySelector('iframe.pg-page-frame');
+            return frame ? frame.src : '';
+        });
+        return P.artifactUrlFrom(src, this.cfg.baseUrl);
+    }
+
+    // Stop the embedded copy before the top-level one starts: two instances of
+    // a threaded GL program fighting for the same box makes both look slow.
+    async dropArtifactFrame() {
+        await evaluateIn(this.page, () => {
+            if (typeof window.showCanvas === 'function') window.showCanvas(false);
+            const frame = document.querySelector('iframe.pg-page-frame');
+            if (frame && frame.parentNode) frame.parentNode.removeChild(frame);
+        });
+    }
+}
+
+// A page-shape artifact runs in its own context so the GL-error poll can be
+// installed there and only there: run-frame.html already polls glGetError on
+// the playground side, and getError CLEARS the flag, so a second poller would
+// steal half the errors.
+class Artifacts {
+    constructor(browser, cfg) {
+        this.browser = browser;
+        this.cfg = cfg;
+        this.context = null;
+        this.page = null;
+        this.pageErrors = [];
+    }
+
+    async open() {
+        this.context = await this.browser.newContext({ viewport: { width: 1280, height: 900 } });
+        await this.context.addInitScript(installProbe, { pollGl: true });
+        this.page = await this.context.newPage();
+        this.page.on('pageerror', (e) => this.pageErrors.push(String(e && e.message ? e.message : e)));
+        this.page.on('console', (msg) => {
+            // Chrome writes the WHY of a rejected GL call to its own console
+            // ("WebGL: INVALID_ENUM: <api>: <reason>") and nothing else can read
+            // it — including the page. --console is how a failing sample gets
+            // diagnosed without reproducing it by hand.
+            if (this.cfg.console) process.stderr.write(`  [${msg.type()}] ${msg.text()}\n`);
+            if (msg.type() === 'error' && !/^Failed to load resource:/.test(msg.text())) {
+                this.pageErrors.push(msg.text());
+            }
+        });
+    }
+
+    async close() {
+        if (this.context) await withDeadline(this.context.close(), 15000, 'close');
+        this.context = null;
+        this.page = null;
+    }
+
+    async restart() {
+        try { await this.close(); } catch { /* the point of restarting */ }
+        await this.open();
+    }
+
+    async load(url) {
+        if (!this.page) await this.open();
+        this.pageErrors.length = 0;
+        const nav = await withDeadline(
+            this.page.goto(url, { waitUntil: 'commit', timeout: 120000 }), 130000, 'artifact-goto');
+        if (nav.wedge) throw new WedgeError();
+    }
+
+    async readProbe(ms) {
+        return evaluateIn(this.page, () => (window.__dwv ? { ...window.__dwv } : null), null, ms);
+    }
+
+    // Leave nothing running between samples: an artifact page keeps its render
+    // loop (and its worker pool) alive for as long as the tab exists.
+    async blank() {
+        if (this.page) await withDeadline(this.page.goto('about:blank'), 15000, 'blank');
+    }
+}
+
+// ── one sample, one engine ────────────────────────────────────────────────
+
+function satisfied(spec, obs) {
+    if (spec.kind === 'console') return P.stdoutMatches(obs.lines, spec.stdout);
+    if (spec.kind === 'audio') return obs.started;
+    return obs.rafs >= spec.min_rafs && obs.draws >= spec.min_draws;
+}
+
+// Stopping the moment the thresholds are met makes the whole verdict depend on
+// machine speed: an error line that lands a beat later is simply never read, so
+// the same sample passes on a fast box and fails on a slow one. The contract is
+// "runs cleanly for this long", so the window is held open for min_observe_ms
+// regardless of how quickly the thresholds fell.
+function done(spec, obs, startedAt) {
+    return satisfied(spec, obs) && Date.now() - startedAt >= spec.min_observe_ms;
+}
+
+async function verifyInterpreter(pg, row, index) {
+    const spec = row.spec;
+    const obs = { wedge: false, rafs: 0, draws: 0, started: false, lines: [], pageErrors: [] };
+    await pg.selectMode('interpreter');
+    await pg.selectSample(index, row.sample);
+    await pg.clearAndRun(spec.action, 'interpreter');
+
+    const startedAt = Date.now();
+    const deadline = startedAt + spec.budget_ms;
+    const left = () => Math.max(EVALUATE_FLOOR_MS, deadline - Date.now());
+    while (Date.now() < deadline) {
+        obs.lines = await pg.readOutput(left());
+        const probe = await pg.readRunFrameProbe(left());
+        if (probe) {
+            obs.rafs = probe.raf;
+            obs.draws = probe.draws;
+            obs.started = probe.gl || probe.audio || obs.lines.length > 0;
+        }
+        obs.pageErrors = [...pg.pageErrors];
+        const { errors, gl } = P.classifyOutput(obs.lines, spec.ignore);
+        if (errors.length || gl.length) break;      // fail fast; the detail is already captured
+        if (done(spec, obs, startedAt)) break;
+        await new Promise((r) => setTimeout(r, POLL_MS));
+    }
+    return obs;
+}
+
+// Wasm mode has two deliveries, decided by the build: a console program comes
+// back as a bare wasi module and prints into the same output pane; a graphics or
+// audio program comes back as a page-shape artifact on the run origin.
+async function verifyWasm(pg, artifacts, row, index) {
+    const spec = row.spec;
+    const obs = { wedge: false, rafs: 0, draws: 0, started: false, lines: [], pageErrors: [] };
+    await pg.selectMode('wasm');
+    await pg.selectSample(index, row.sample);
+    await pg.clearAndRun('run', 'wasm');
+
+    // A fresh build takes minutes (the toolchain embeds declared assets and
+    // relinks); an unchanged source is a cache hit and resolves in seconds.
+    // Both are correct outcomes — a cached FAILED build is a correct verdict
+    // too, so the verifier never cache-busts.
+    let artifactUrl = '';
+    const buildDeadline = Date.now() + spec.build_budget_ms;
+    while (Date.now() < buildDeadline) {
+        obs.lines = await pg.readOutput(Math.max(EVALUATE_FLOOR_MS, buildDeadline - Date.now()));
+        obs.pageErrors = [...pg.pageErrors];
+        if (P.classifyOutput(obs.lines, spec.ignore).errors.length) return obs;
+        if (spec.kind === 'console' && P.stdoutMatches(obs.lines, spec.stdout)) return obs;
+        artifactUrl = await pg.readArtifactUrl();
+        if (artifactUrl) break;
+        await new Promise((r) => setTimeout(r, BUILD_POLL_MS));
+    }
+    if (!artifactUrl) {
+        obs.lines.push({ text: `build did not deliver an artifact within ${spec.build_budget_ms}ms`, color: '#ff2d2d' });
+        return obs;
+    }
+
+    await pg.dropArtifactFrame();
+    await artifacts.load(artifactUrl);
+    const startedAt = Date.now();
+    const deadline = startedAt + spec.budget_ms;
+    while (Date.now() < deadline) {
+        const probe = await artifacts.readProbe(Math.max(EVALUATE_FLOOR_MS, deadline - Date.now()));
+        if (probe) {
+            obs.rafs = probe.raf;
+            obs.draws = probe.draws;
+            obs.started = probe.gl || probe.audio;
+            // The artifact page has no output pane, so its GL-error poll feeds
+            // the same line list the verdict already reads.
+            for (const text of probe.glErrors) {
+                if (!obs.lines.some((l) => l.text === text)) obs.lines.push({ text, color: '' });
+            }
+        }
+        obs.pageErrors = [...pg.pageErrors, ...artifacts.pageErrors];
+        if (P.classifyOutput(obs.lines, spec.ignore).errors.length) break;
+        if (done(spec, obs, startedAt)) break;
+        await new Promise((r) => setTimeout(r, POLL_MS));
+    }
+    obs.artifactUrl = artifactUrl;
+    return obs;
+}
+
+async function verifySample(pg, artifacts, row, index, cfg) {
+    const started = Date.now();
+    let obs;
+    try {
+        if (row.mode === 'interpreter') obs = await verifyInterpreter(pg, row, index);
+        else if (row.mode === 'wasm') obs = await verifyWasm(pg, artifacts, row, index);
+        else throw new Error(`unknown mode "${row.mode}"`);
+    } catch (e) {
+        if (e instanceof WedgeError || e.wedge) {
+            const shot = await screenshot(shotPage(pg, artifacts, row), row, cfg);
+            await pg.restart();
+            await artifacts.restart();
+            return { ...row, status: 'FAIL', ms: Date.now() - started, detail: `wedge${shot ? ' — ' + shot : ''}` };
+        }
+        return { ...row, status: 'FAIL', ms: Date.now() - started, detail: String(e.message || e) };
+    }
+    const v = P.verdict(row.spec, obs);
+    const out = { ...row, status: v.status, ms: Date.now() - started, detail: v.detail };
+    if (v.status === 'FAIL') {
+        const shot = await screenshot(shotPage(pg, artifacts, row), row, cfg);
+        if (shot) out.detail = `${out.detail} — ${shot}`;
+    }
+    try {
+        await pg.reset();
+        await artifacts.blank();
+    } catch {
+        await pg.restart();
+        await artifacts.restart();
+    }
+    return out;
+}
+
+// A page-rail failure is a picture of the ARTIFACT (the black canvas), not of
+// the playground tab that merely embedded it.
+function shotPage(pg, artifacts, row) {
+    if (row.mode === 'wasm' && artifacts.page && !/^about:/.test(artifacts.page.url())) return artifacts.page;
+    return pg.page;
+}
+
+function slug(text) {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 60);
+}
+
+async function screenshot(page, row, cfg) {
+    if (!page) return '';
+    const file = path.join(cfg.artifacts, `${slug(row.name)}-${row.mode}.png`);
+    try {
+        await mkdir(cfg.artifacts, { recursive: true });
+        // A wedged renderer cannot paint, so this is best-effort by design.
+        const shot = await withDeadline(page.screenshot({ path: file, timeout: 10000 }), 15000, 'screenshot');
+        if (shot.wedge) return '';
+        return path.relative(process.cwd(), file);
+    } catch {
+        return '';
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+    const cfg = parseArgs(process.argv.slice(2));
+    if (cfg.help) { process.stdout.write(HELP); return 0; }
+
+    const table = JSON.parse(await readFile(path.join(HERE, 'expectations.json'), 'utf8'));
+    const deployed = await fetchJson(`${cfg.baseUrl}/playground/samples/data.json`);
+    if (!deployed.examples || !deployed.examples.length) {
+        throw new Error('deployed manifest lists no samples');
+    }
+
+    const rows = [];
+    try {
+        const repo = JSON.parse(await readFile(REPO_MANIFEST, 'utf8'));
+        rows.push(...P.driftWarnings(deployed.examples.map((e) => e.name), repo.examples.map((e) => e.name)));
+    } catch (e) {
+        rows.push({ name: '(drift check)', mode: '-', status: 'WARN', ms: 0, detail: String(e.message || e) });
+    }
+
+    const plan = P.planRows(deployed.examples, table, { modes: cfg.modes, filter: cfg.filter });
+    const indexOf = new Map(deployed.examples.map((e, i) => [e.name, i]));
+
+    if (cfg.list) {
+        for (const row of plan) {
+            process.stdout.write(`${row.status || 'plan'}\t${row.mode}\t${row.name}\n`);
+        }
+        return 0;
+    }
+
+    const browser = await chromium.launch({
+        headless: !cfg.headed,
+        channel: 'chromium',    // the new headless mode — the old one throttles rAF harder
+        args: ['--autoplay-policy=no-user-gesture-required'],
+    });
+    const pg = new Playground(browser, cfg);
+    const artifacts = new Artifacts(browser, cfg);
+    try {
+        await pg.open();
+        await artifacts.open();
+        for (const row of plan) {
+            if (row.status) { rows.push(row); continue; }   // already decided (no expectations row)
+            process.stderr.write(`… ${row.mode}\t${row.name}\n`);
+            const result = await verifySample(pg, artifacts, row, indexOf.get(row.name), cfg);
+            process.stderr.write(`${result.status}\t${result.ms}ms\t${result.name} [${result.mode}] ${result.detail}\n`);
+            rows.push(result);
+        }
+    } finally {
+        await browser.close();
+    }
+
+    const report = P.formatSummary(rows.map((r) => ({ ...r, detail: r.detail || '' })));
+    process.stdout.write(report);
+    if (cfg.summary) await appendFile(cfg.summary, report);
+    const counts = P.countStatuses(rows);
+    process.stderr.write(`\n${counts.PASS} passed, ${counts.FAIL} failed, ${counts.WARN} warnings\n`);
+    return P.exitCodeFor(rows);
+}
+
+main().then((code) => process.exit(code), (e) => {
+    process.stderr.write(`dasweb-verify: ${e && e.stack ? e.stack : e}\n`);
+    process.exit(1);
+});

--- a/utils/dasweb-verify/browser/runner.mjs
+++ b/utils/dasweb-verify/browser/runner.mjs
@@ -76,6 +76,8 @@ const HELP = `dasweb-verify browser leg
   --summary PATH     append the markdown report here (default $GITHUB_STEP_SUMMARY)
   --artifacts DIR    where failure screenshots go
   --headed           run with a visible browser
+  --console          echo every browser console message (the only way to read the
+                     WHY behind a GL error — the browser logs it where no page can)
   --list             print the plan and exit, no browser
 `;
 


### PR DESCRIPTION
Tier 2 of the curated-sample verifier: a node + playwright runner that drives the **live** playground in headless Chromium and reports, per sample and per engine, whether the program actually runs. Follow-up to #3645, per `plans/dasweb_sample_verifier.md`.

Production is the target on purpose — the bugs this exists to catch (artifacts truncated behind caddy, wasm archives missing on one build box, a failed build cached under its content hash) were production state no local rebuild can see. Sources and toolchain id are content-addressed, so a night with no sample edit and no toolchain bump is mostly cache hits.

## What the first full CI sweep found

All 77 rows (39 samples × 2 engines, minus `Tests` which is interpreter-only): **70 PASS / 7 FAIL**, three distinct real classes, **no false positives**.

- **`GL_INVALID_ENUM` × 5** — fourier / path tracer / physarum, on *both* rails. `glfw_live.das` called `glEnable(GL_MULTISAMPLE)` after window creation; WebGL2/GLES3 has no such capability (multisampling is a context attribute there), so every imgui-harness sample raised it once at start-up. Fixed in this PR, guarded to non-emscripten so desktop MSAA is unchanged.
- **Fourier [wasm] — build failure**: `release wasm: building wasm archives for external module at .../modules/dasImgui`. The missing-dasImgui-archives class, still live for that one sample.
- **Float→String (benchmark) [wasm] — `wasm error: null function`.** A genuine runtime bug in `f2s.das` under the wasm module rail. New, never reported.

## The liveness protocol

A frame counter alone is not enough, and reasoning through the failure modes is what fixes the checks:

- **wedge** — the main thread hot-spins, so frames stop *and* `page.evaluate` never answers. Every call into the page is raced against the sample's own remaining budget rather than a fixed cap: a daslang program owns the main thread while it runs, so a console benchmark computing for 40s is indistinguishable from a wedge until its budget is actually spent. (This bit the tree benchmark on the first live sweep — 40.5s here, 55.4s on the CI runner.)
- **crash / panic / missing asset** — the emscripten loop dies but the host page keeps painting, so a bare rAF counter calls it alive. The probe also counts the *program's* WebGL draw calls, and the verdict reads the output pane (`EXCEPTION`, `runtime aborted`, `error[…]`), playwright's uncaught-exception events, and the GL-error watcher.
- **alive** — frames and draws both past threshold, held open for `min_observe_ms` so a late error line cannot be outrun by a fast box. Without that the same sample passed twice and failed once on an identical GL error, purely on timing.

## Design rulings held

- **Expectations live verifier-side** (`expectations.json`), never in sample sources — tuning a budget must not edit sample content and throw away its build-cache entry.
- **A deployed sample with no row is a FAIL**, so a new sample cannot ship unverified. Manifest drift against the repo copy is a WARN (deploy lag mid-merge is legitimate).
- **Never cache-bust.** A cached failed build for identical content and toolchain is a correct verdict.
- **The embedded page artifact is never probed** — cross-origin by design; the runner takes its URL and opens it top-level, where the `glGetError` poll is installed by init script before anything loads. Exactly one poller per context, since `getError` clears the flag and `run-frame.html` already polls on the playground side.

## Also here

Tier 1 (the in-process compile check from #3645) now runs per-PR in `extended_checks` on linux — it ran **nowhere** until now, and it is the only gate that catches sample rot before the site serves it.

## Verification

- 18 `node:test` cases over the pure helpers, including one asserting every shipped manifest sample has an expectations row
- 36/39 interpreter samples pass locally against daslang.io; both wasm rails proven (Hello world 14.4s module rail, rotating triangle 23.0s page rail)
- the full 77-row sweep above, run on a free ubuntu runner
- lint 0 issues, formatter clean on the changed `.das` file

Three stale `nolint:PERF014` markers in `glfw_live.das` go with it — single-case alpha ranges never trigger that rule (only the both-case compound and digit ranges do, and the digit marker beside them is live), and they would have red-lined the lint lane the moment that file was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
