### PR TITLE
wasm: let the module rail grow, and report OOM instead of trapping

### DIFF
--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1304,12 +1304,22 @@ extern "C" {
         // -sSTANDALONE_WASM: emit self-contained .wasm with wasi imports only.
         // -fwasm-exceptions + -sWASM_LEGACY_EXCEPTIONS=0: match the runtime
         // archive's modern wasm EH, avoid emcc's JS invoke_* trampolines.
-        // -sINITIAL_MEMORY=128MB: standalone wasm cannot grow memory under
-        // wasmtime (-sALLOW_MEMORY_GROWTH adds an unsatisfiable
-        // emscripten_notify_memory_growth import), so reserve up front. Cost
-        // is virtual address space only — lazy paging keeps RSS proportional
-        // to actual use. 128MB covers all current playground benchmarks; see
-        // #2805.
+        // -sINITIAL_MEMORY=128MB: reserve up front so typical programs never pay
+        // growth churn. Cost is virtual address space only — lazy paging keeps RSS
+        // proportional to actual use.
+        // -sABORTING_MALLOC=0: state the contract we rely on rather than inherit it.
+        // Every das allocation path null-checks (LinearChunkAllocator::allocate ->
+        // StringHeapAllocator::impl_allocateString -> context->throw_out_of_memory),
+        // which only works while a failed malloc RETURNS. ALLOW_MEMORY_GROWTH happens
+        // to imply this today; spelling it out keeps the guarantee if growth is ever
+        // turned back off for a host that needs a fixed memory.
+        // -sALLOW_MEMORY_GROWTH=1: 128MB is NOT enough for every program (the f2s
+        // playground benchmark retains ~130MB of string heap and died at the cap).
+        // Previously omitted because growth added an unsatisfiable
+        // emscripten_notify_memory_growth import under a bare wasi host (#2805);
+        // that is fixed upstream — verified on the pinned emsdk 5.0.7 that a
+        // STANDALONE_WASM build with growth imports NOTHING from env, so wasmtime is
+        // unaffected. Measured on that emsdk: usable heap 120MB -> 2040MB.
         const std::string runtimeArg = withRuntime ? fmt::format("\"{}\" ", runtimeLibPath) : "";
         // -sMEMORY64=1: wasm64 (memory64) target — 8-byte pointers. The object and
         // runtime archive must also be wasm64 (built with -sMEMORY64=1); the linker
@@ -1322,11 +1332,11 @@ extern "C" {
         // incorrect". Same trick create_shared_library uses (see above).
         #if defined(_WIN32) || defined(_WIN64)
         const std::string cmd = fmt::format(
-            FMT_STRING("\"\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 -sINITIAL_MEMORY=128MB{} 2>&1\""),
+            FMT_STRING("\"\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 -sINITIAL_MEMORY=128MB -sABORTING_MALLOC=0 -sALLOW_MEMORY_GROWTH=1{} 2>&1\""),
             linker.c_str(), objFilePath, runtimeArg, wasmPath, mem64Arg);
         #else
         const std::string cmd = fmt::format(
-            FMT_STRING("\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 -sINITIAL_MEMORY=128MB{} 2>&1"),
+            FMT_STRING("\"{}\" \"{}\" {}-o \"{}\" -sSTANDALONE_WASM -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0 -sINITIAL_MEMORY=128MB -sABORTING_MALLOC=0 -sALLOW_MEMORY_GROWTH=1{} 2>&1"),
             linker.c_str(), objFilePath, runtimeArg, wasmPath, mem64Arg);
         #endif
         return run_link_cmd(cmd.c_str(), wasmPath, "Wasm", context);

--- a/src/misc/memory_model.cpp
+++ b/src/misc/memory_model.cpp
@@ -192,7 +192,12 @@ namespace das {
         size = (size + alignMask) & ~alignMask;
         nsize = (nsize + alignMask) & ~alignMask;
         char * nptr = allocate(nsize);
-        DAS_VERIFYF(nptr,"out of memory?");
+        // Fail the way allocate() does — by returning null. Context::reallocate
+        // already turns that into throw_out_of_memory, so the caller gets a real
+        // daslang error naming the request size. Asserting here instead reached
+        // neither: it fired before the null could propagate, so an out-of-memory
+        // during array growth could never be reported or recovered, only aborted.
+        if ( !nptr ) return nullptr;
         memcpy ( nptr, ptr, das::min(size,nsize) );
 #if DAS_TRACK_ALLOCATIONS
         if ( trackAllocations ) {

--- a/src/runtime/context.cpp
+++ b/src/runtime/context.cpp
@@ -4,6 +4,12 @@
 
 #include <stdarg.h>
 
+#ifdef __EMSCRIPTEN__
+// write(2) + _Exit for the allocation-free out-of-memory report below.
+#include <unistd.h>
+#include <stdlib.h>
+#endif
+
 namespace das
 {
     // Context
@@ -1089,11 +1095,34 @@ namespace das
     }
 
     void Context::throw_out_of_memory ( bool isStringHeap, uint64_t size, const LineInfo * at ) {
+#ifdef __EMSCRIPTEN__
+        // Wasm-only escape: reporting an out-of-memory must not itself allocate.
+        // The normal path (throw_error_at -> throw_fatal_error) assigns
+        // exceptionMessage, a das::string — an allocation, made at the one moment
+        // allocation cannot succeed. A desktop host has swap and an OS that keeps
+        // serving small requests, so it never realistically gets here; wasm has a
+        // hard ceiling, so it does, and the failure surfaces as an opaque trap with
+        // nothing printed. Format into a stack buffer and write(2) straight to the
+        // fd instead: no heap, no stdio buffer, no C++ exception machinery. Exiting
+        // is correct — a panic is fatal in daslang, and there is nothing to unwind
+        // to that would not need the heap we just ran out of.
+        char buf[256];
+        const int n = snprintf(buf, sizeof(buf),
+            "\nout of %s memory: requested %llu bytes\n",
+            isStringHeap ? "string heap" : "heap", (unsigned long long) size);
+        if ( n > 0 ) {
+            const size_t len = size_t(n) < sizeof(buf) ? size_t(n) : sizeof(buf) - 1;
+            ssize_t ignored = write(2, buf, len); (void) ignored;
+        }
+        (void) at;
+        _Exit(1);
+#else
         if ( isStringHeap ) {
             throw_error_at(at, "out of string heap memory, requested %llu bytes, used %llu / limit %llu", (unsigned long long) size, (unsigned long long) stringHeap->bytesAllocated(), (unsigned long long) stringHeap->getLimit());
         } else {
             throw_error_at(at, "out of heap memory, requested %llu bytes, used %llu / limit %llu", (unsigned long long) size, (unsigned long long) heap->bytesAllocated(), (unsigned long long) heap->getLimit());
         }
+#endif
     }
 
     void Context::throw_error_ex ( DAS_FORMAT_STRING_PREFIX const char * message, ... ) {


### PR DESCRIPTION
The `f2s` playground benchmark died under the wasm module rail with `wasm error: null function` — an opaque V8 `call_indirect`-into-null, nothing printed. Found by the nightly verifier (#3649) on its first CI sweep.

Three separate things were wrong. Each was found by measuring; three earlier hypotheses (aborting-malloc, broken `longjmp`, the reporter's `std::string`) were disproven the same way, so nothing here is reasoned-from-plausible.

## 1. The module rail could not grow its memory at all

`module_jit.cpp` linked STANDALONE_WASM with `-sINITIAL_MEMORY=128MB` and no growth, so the memory section carried `max == initial`:

| | initial | max | grows |
|---|---|---|---|
| interpreter runtime (wasm32) | 128 MB | 2048 MB | yes |
| compiled artifact (wasm64) | 128 MB | **128 MB** | **no** |

Growth was omitted deliberately — the comment said it adds an unsatisfiable `emscripten_notify_memory_growth` import under a bare wasi host (#2805). **That is fixed upstream.** Verified on the pinned emsdk 5.0.7: a STANDALONE_WASM build with growth imports *nothing* from `env`, so wasmtime is unaffected. A C harness allocating until failure measures usable heap **120 MB → 2040 MB**.

`-sABORTING_MALLOC=0` rides along to *state* the contract every das allocation path depends on — a failed malloc must RETURN, not abort — rather than inherit it as a side effect of growth.

## 2. Array growth could not report an out-of-memory at all

`MemoryModel::reallocate` asserted its allocation with `DAS_VERIFYF` instead of returning null. `Context::reallocate` **already** turns a null into `throw_out_of_memory`, so the reporting chain was correct and simply unreachable — the assert fired first. An OOM during array growth could therefore never be reported or recovered, only aborted. That is what produced this in the repro:

```
verify failed: nptr, src/misc/memory_model.cpp:195
out of memory?
```

## 3. Reporting an out-of-memory allocated

`throw_out_of_memory` goes through `throw_fatal_error`, which assigns `exceptionMessage` (a `das::string`) — an allocation, made at the one moment allocation cannot succeed. A desktop host has swap and an OS that keeps serving small requests, so it never realistically arrives here; wasm has a hard ceiling, so it does.

Wasm now formats into a stack buffer and `write(2)`s straight to the fd — no heap, no stdio buffer, no C++ exception machinery. Desktop keeps the existing richer message with used/limit figures.

Exiting via `_Exit` also keeps this path from tripping the atexit `g_envTotal=1 at exit` check, which exists to catch an app quitting *without* shutting the environment down — which a deliberate fatal exit is not. The general case of that check is untouched.

## Verification

- full desktop `libDaScript` build
- `emcc -fsyntax-only` on the `__EMSCRIPTEN__` branches with the pinned emsdk 5.0.7 and the wasm build's real compile flags
- `try`/`recover` and uncaught `panic` both confirmed working on the compiled rail (that is how the `longjmp` theory died)

**Untested by agreement:** the OOM message itself. With growth landed the condition is no longer reachable in any practical program, so it is verified by construction and inspection rather than by a repro. It reaches users after a builder roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
