### PR TITLE
ast_verify: crash guards found by fuzzing, plus three compiler bugs

### DIFF
--- a/daslib/ast.das
+++ b/daslib/ast.das
@@ -958,9 +958,9 @@ def add_new_pre_infer_macro(name : string; var someClassPtr) {
 }
 
 [macro_function]
-def add_new_pre_simulate_macro(name : string; var someClassPtr) {
+def add_new_post_infer_macro(name : string; var someClassPtr) {
     var ann = make_pass_macro(name, someClassPtr)
-    this_module() |> add_pre_simulate_macro(ann)
+    this_module() |> add_post_infer_macro(ann)
 }
 
 [macro_function]

--- a/daslib/ast_boost.das
+++ b/daslib/ast_boost.das
@@ -10,7 +10,7 @@ module ast_boost shared public
 //! macro authors: ``[macro]``, ``[reader_macro]``, ``[call_macro]``,
 //! ``[function_macro]``, ``[block_macro]``, ``[variant_macro]``,
 //! ``[tag_function]``, ``[tag_structure]``, ``[infer_macro]``,
-//! ``[optimization_macro]``, ``[pre_infer_macro]``, ``[pre_simulate_macro]``,
+//! ``[optimization_macro]``, ``[pre_infer_macro]``, ``[post_infer_macro]``,
 //! ``[lint_macro]``, ``[global_lint_macro]`` and ``[macro_function]``.
 
 require daslib/rtti
@@ -487,10 +487,10 @@ class SetupPreInferMacro : SetupAnyAnnotation {
     override annotation_function_call : string = "add_new_pre_infer_macro"
 }
 
-class SetupPreSimulateMacro : SetupAnyAnnotation {
-    //! Registers annotated structure as a pre-simulate macro: runs after inference,
-    //! before codegen, where every expression type is final.
-    override annotation_function_call : string = "add_new_pre_simulate_macro"
+class SetupPostInferMacro : SetupAnyAnnotation {
+    //! Registers annotated structure as a post-inference macro: runs once inference is
+    //! done, before lint / folding / codegen, where every expression type is final.
+    override annotation_function_call : string = "add_new_post_infer_macro"
 }
 
 class SetupLintMacro : SetupAnyAnnotation {
@@ -1150,7 +1150,7 @@ def private setup {
         add_new_structure_annotation("dirty_infer_macro", new SetupDirtyInferMacro())
         add_new_structure_annotation("optimization_macro", new SetupOptimizationMacro())
         add_new_structure_annotation("pre_infer_macro", new SetupPreInferMacro())
-        add_new_structure_annotation("pre_simulate_macro", new SetupPreSimulateMacro())
+        add_new_structure_annotation("post_infer_macro", new SetupPostInferMacro())
         add_new_structure_annotation("lint_macro", new SetupLintMacro())
         add_new_structure_annotation("global_lint_macro", new SetupGlobalLintMacro())
         add_new_variant_macro("better_rtti_in_expr", new BetterRttiVisitor())

--- a/daslib/ast_verify.das
+++ b/daslib/ast_verify.das
@@ -62,6 +62,28 @@ def private same_var_name(a, b : string) : bool {
     return unqualified(a) == unqualified(b)
 }
 
+def private compact_nulls(var list : auto(LT)) : int {
+    var removed = 0
+    var i = 0
+    while (i < length(list)) {
+        if (list[i] == null) {
+            list |> erase(i)
+            removed++
+        } else {
+            i++
+        }
+    }
+    return removed
+}
+
+// the grammar admits only these in a unary slot (ds2_parser.ypp), so any other name
+// leaves ExprOp1.func null, which SimulateVisitor::visit(ExprOp1*) dereferences
+let private UNARY_OPS <- { "-", "+", "~", "!", "++", "--", "+++", "---" }
+
+// inc / dec need an l-value, so on a literal they can never resolve; infer reports that
+// from source, but a macro-built one reaches the string-builder fold with func still null
+let private LVALUE_OPS <- { "++", "--", "+++", "---" }
+
 def private is_enum_type(bt : Type) : bool {
     return (bt == Type.tEnumeration || bt == Type.tEnumeration8
         || bt == Type.tEnumeration16 || bt == Type.tEnumeration64)
@@ -76,6 +98,10 @@ class private AstVerifyVisitor : AstVisitor {
     @do_not_delete fn_stack : array<Function?>
     seen_nodes : table<uint64; bool>
     check_unique : bool = false
+    // A node reachable from itself makes every walk — inference, codegen, ours —
+    // recurse until the stack dies, so the cycle is cut, not only reported.
+    path : table<uint64; bool>
+    tpath : table<uint64; bool>
     // `return` inside a closure block returns from the BLOCK, not the function, so
     // its null subexpr says nothing about the function's result type
     closure_depth : int = 0
@@ -103,6 +129,10 @@ class private AstVerifyVisitor : AstVisitor {
             report(at, "{what} is null (must be {want})")
             return repair_kind(want, at)
         }
+        if (is_ancestor(slot)) {
+            report(at, "{what} points at its own ancestor ({slot.__rtti}) - a cycle")
+            return repair_kind(want, at)
+        }
         if (slot.__rtti != want) {
             report(at, "{what} is {slot.__rtti}, but inference static_casts it to {want}")
             return repair_kind(want, at)
@@ -110,11 +140,21 @@ class private AstVerifyVisitor : AstVisitor {
         return slot
     }
 
+    def cut_type_cycle(var slot : TypeDeclPtr&; what : string; at : LineInfo) : void {
+        if (slot == null || !key_exists(tpath, intptr(slot))) {
+            return
+        }
+        report(at, "{what} points at its own ancestor - a cycle")
+        slot = new TypeDecl(at = at, baseType = Type.tInt)
+    }
+
     def verify_type(var typ : TypeDeclPtr; what : string;
                     at : LineInfo) : void {
         if (typ == null) {
             return
         }
+        cut_type_cycle(typ.firstType, "{what}: firstType", at)
+        cut_type_cycle(typ.secondType, "{what}: secondType", at)
         if (typ.baseType == Type.tArray || typ.baseType == Type.tFixedArray
                 || typ.baseType == Type.tIterator) {
             need_type(typ.firstType, "{what}: {typ.baseType} has no element type (firstType is null)", at)
@@ -123,6 +163,7 @@ class private AstVerifyVisitor : AstVisitor {
             need_type(typ.secondType, "{what}: table has no value type (secondType is null)", at)
         }
         for (i in range(length(typ.argTypes))) {
+            cut_type_cycle(typ.argTypes[i], "{what}: argTypes[{i}]", at)
             need_type(typ.argTypes[i], "{what}: {typ.baseType} argTypes[{i}] is null", at)
         }
         if (typ.baseType == Type.tStructure && typ.structType == null) {
@@ -131,6 +172,11 @@ class private AstVerifyVisitor : AstVisitor {
         } elif (is_enum_type(typ.baseType) && typ.enumType == null) {
             report(at, "{what}: {typ.baseType} with a null enumType")
             typ.baseType = Type.tInt
+        } elif (is_enum_type(typ.baseType) && typ.enumType._module == null) {
+            // infer looks the enumerator up through its module
+            report(at, "{what}: enumeration '{typ.enumType.name}' belongs to no module")
+            typ.baseType = Type.tInt
+            typ.enumType = null
         } elif (typ.baseType == Type.tHandle && typ.annotation == null) {
             report(at, "{what}: tHandle with a null annotation")
             typ.baseType = Type.tInt
@@ -161,15 +207,59 @@ class private AstVerifyVisitor : AstVisitor {
     }
 
     def override preVisitExpression(var expr : ExpressionPtr) : void {
-        if (!check_unique || expr == null) {
+        if (expr == null) {
             return
         }
+        // folding sets this flag only alongside a type, and acts on the flag alone
+        if (expr.flags.constexpression && expr._type == null) {
+            report(expr.at, "{expr.__rtti} is marked constexpression but has no type")
+            expr.flags.constexpression = false
+        }
         let key = intptr(expr)
+        path |> insert(key, true)
+        if (!check_unique) {
+            return
+        }
         if (key_exists(seen_nodes, key)) {
             report(expr.at, "node {expr.__rtti} is aliased - reachable from two parents (missing clone_expression)")
             return
         }
         seen_nodes |> insert(key, true)
+    }
+
+    def leave(var expr : ExpressionPtr) : ExpressionPtr {
+        path |> erase(intptr(expr))
+        return expr
+    }
+
+    def override visitExpression(var expr : ExpressionPtr) : ExpressionPtr {
+        return leave(expr)
+    }
+
+    def is_ancestor(slot : ExpressionPtr) : bool {
+        return slot != null && key_exists(path, intptr(slot))
+    }
+
+    // Variable / MakeStruct entries are dereferenced by the visitor itself before any
+    // per-entry hook runs, so a null one has to be dropped in preVisit, not reported.
+    def dropped(n : int; what : string; at : LineInfo) : void {
+        if (n > 0) {
+            report(at, "{what} holds {n} null entry(s), which the visitor dereferences")
+        }
+    }
+
+    def cycle_slot(var slot : ExpressionPtr&; what : string; at : LineInfo) : void {
+        if (!is_ancestor(slot)) {
+            return
+        }
+        report(at, "{what} points at its own ancestor ({slot.__rtti}) - a cycle")
+        slot = placeholder(at)
+    }
+
+    def cut_list_cycles(var list : dasvector`ptr`Expression; at : LineInfo; what : string) : void {
+        for (i in range(length(list))) {
+            cycle_slot(list[i], "{what}[{i}]", at)
+        }
     }
 
     // Reporting alone is not enough: the visitor descends into the slot right after
@@ -190,6 +280,7 @@ class private AstVerifyVisitor : AstVisitor {
              mk : function<(at : LineInfo) : ExpressionPtr> = @@placeholder;
              detail : string = ""; stand_in : ExpressionPtr = null) : void {
         if (slot != null) {
+            cycle_slot(slot, what, at)
             return
         }
         report(at, empty(detail) ? "{what} is null" : "{what} is null ({detail})")
@@ -204,7 +295,17 @@ class private AstVerifyVisitor : AstVisitor {
     }
 
     def override preVisitTypeDecl(var typ : TypeDeclPtr) : void {
+        if (typ != null) {
+            tpath |> insert(intptr(typ), true)
+        }
         verify_type(typ, "TypeDecl", typ != null ? typ.at : LineInfo())
+    }
+
+    def override visitTypeDecl(var typ : TypeDeclPtr) : TypeDeclPtr {
+        if (typ != null) {
+            tpath |> erase(intptr(typ))
+        }
+        return typ
     }
 
     // The visitor dispatches on the CONCRETE kind, so preVisitExprAt never fires for
@@ -256,6 +357,15 @@ class private AstVerifyVisitor : AstVisitor {
     }
 
     def override preVisitExprOp1(var expr : ExprOp1?) : void {
+        if (!key_exists(UNARY_OPS, string(expr.op))) {
+            report(expr.at, "ExprOp1 has op '{expr.op}', which is not a unary operator")
+            expr.op := "-"
+        }
+        if (key_exists(LVALUE_OPS, string(expr.op)) && expr.subexpr != null
+                && starts_with(expr.subexpr.__rtti, "ExprConst")) {
+            report(expr.at, "ExprOp1 '{expr.op}' needs an l-value, but its subexpr is {expr.subexpr.__rtti}")
+            expr.op := "+"
+        }
         need(expr.subexpr, "ExprOp1.subexpr", expr.at, detail = "op '{expr.op}'")
         value_slot(expr.subexpr, "ExprOp1.subexpr", expr.at)
     }
@@ -316,6 +426,7 @@ class private AstVerifyVisitor : AstVisitor {
 
     // finalList only: a null in `list` compiles clean, so it is not a crash shape
     def override preVisitExprBlock(var expr : ExprBlock?) : void {
+        dropped(compact_nulls(expr.arguments), "ExprBlock.arguments", expr.at)
         // ExprBlock::visit walks `arguments` only when isClosure; inference does not
         if (!expr.blockFlags.isClosure && !empty(expr.arguments)) {
             report(expr.at, "ExprBlock has arguments but is not marked isClosure")
@@ -325,13 +436,14 @@ class private AstVerifyVisitor : AstVisitor {
             closure_depth++
         }
         verify_elements(expr.finalList, expr.at, "ExprBlock.finalList")
+        cut_list_cycles(expr.list, expr.at, "ExprBlock.list")
     }
 
     def override visitExprBlock(var expr : ExprBlock?) : ExpressionPtr {
         if (expr.blockFlags.isClosure && closure_depth > 0) {
             closure_depth--
         }
-        return expr
+        return leave(expr)
     }
 
     def override preVisitExprOp3(var expr : ExprOp3?) : void {
@@ -434,7 +546,16 @@ class private AstVerifyVisitor : AstVisitor {
         }
     }
 
+    def override preVisitExprMakeVariant(var expr : ExprMakeVariant?) : void {
+        dropped(compact_nulls(expr.variants), "ExprMakeVariant.variants", expr.at)
+    }
+
+    def override preVisitExprLet(var expr : ExprLet?) : void {
+        dropped(compact_nulls(expr.variables), "ExprLet.variables", expr.at)
+    }
+
     def override preVisitExprMakeStruct(var expr : ExprMakeStruct?) : void {
+        dropped(compact_nulls(expr.structs), "ExprMakeStruct.structs", expr.at)
         if (expr._block != null) {
             expr._block = kind_slot(expr._block, "ExprMakeBlock", "ExprMakeStruct.block", expr.at)
         }
@@ -490,6 +611,28 @@ class private AstVerifyVisitor : AstVisitor {
         need(expr.values[index], "ExprMakeTuple.values[{index}]", expr.at)
     }
 
+    def payload_slot(var expr : ExpressionPtr; present : bool; what : string) : ExpressionPtr {
+        path |> erase(intptr(expr))
+        if (present) {
+            return expr
+        }
+        // infer dereferences the payload unguarded, and there is nothing to put back
+        report(expr.at, "{expr.__rtti} has a null {what}")
+        return placeholder(expr.at)
+    }
+
+    def override visitExprReader(var expr : ExprReader?) : ExpressionPtr {
+        return payload_slot(expr, expr.macro != null, "macro")
+    }
+
+    def override visitExprCallMacro(var expr : ExprCallMacro?) : ExpressionPtr {
+        return payload_slot(expr, expr.macro != null, "macro")
+    }
+
+    def override visitExprConstEnumeration(var expr : ExprConstEnumeration?) : ExpressionPtr {
+        return payload_slot(expr, expr.enumType != null, "enumType")
+    }
+
     def override visitExprVar(var expr : ExprVar?) : ExpressionPtr {
         let v = expr.variable
         // `var x aka X` gives the variable a legitimate second name
@@ -503,12 +646,13 @@ class private AstVerifyVisitor : AstVisitor {
             report(expr.at, "ExprVar.name '{expr.name}' disagrees with its resolved variable '{v.name}'")
             expr.name := v.name
         }
-        return expr
+        return leave(expr)
     }
 
     def override preVisitFunction(var fun : FunctionPtr) : void {
         fn_stack |> push(current_fn)
         current_fn = fun
+        dropped(compact_nulls(fun.arguments), "function '{fun.name}' arguments", fun.at)
         verify_type(fun.result, "function '{fun.name}' result type", fun.at)
     }
 
@@ -627,8 +771,8 @@ def public verify_program(prog : ProgramPtr) : int {
     return total
 }
 
-// ===== pre-simulate verification =====
-class private AstSimulateVerifyVisitor : AstVisitor {
+// ===== post-inference verification =====
+class private AstPostInferVerifyVisitor : AstVisitor {
     error_count : int = 0
     @do_not_delete current_fn : Function?
     closure_depth : int = 0
@@ -636,14 +780,14 @@ class private AstSimulateVerifyVisitor : AstVisitor {
 
     def report(at : LineInfo; msg : string) : void {
         error_count++
-        to_log(LOG_ERROR, "AST verify (pre-simulate): {msg} at {describe(at)}\n")
-        compiling_program() |> macro_error(at, "AST verify (pre-simulate): {msg}")
+        to_log(LOG_ERROR, "AST verify (post-infer): {msg} at {describe(at)}\n")
+        compiling_program() |> macro_error(at, "AST verify (post-infer): {msg}")
     }
 
-    // A template's own body is expanded per instantiation, never codegen'd as-is,
-    // so it legitimately carries no types.
+    // A template body is expanded per instantiation, so it carries no types; a generated
+    // body (lambda, generator) IS codegen'd, so unlike the infer-time pass it is checked.
     def override canVisitFunction(fun : Function?) : bool {
-        return !fun.moreFlags.isTemplate && !fun.flags.generated
+        return !fun.moreFlags.isTemplate
     }
 
     def override preVisitFunction(var fun : FunctionPtr) : void {
@@ -664,6 +808,85 @@ class private AstSimulateVerifyVisitor : AstVisitor {
         return expr
     }
 
+    // an `assume` alias is substituted at its use sites and never inferred, so nothing
+    // under it is typed - daslib/quote.das and typemacro_boost.das rely on that
+    def override canVisitWithAliasSubexpression(_expr : ExprAssume?) : bool {
+        return false
+    }
+
+    // a template structure's field initializers stay AST data until it is instantiated
+    def override canVisitStructureFieldInit(st : StructurePtr) : bool {
+        return !st.flags.isTemplate
+    }
+
+    // Inference is done, so an operand with no type never got one, and lint / folding /
+    // codegen all dereference it unguarded.
+    def need_typed(var slot : ExpressionPtr; what : string; at : LineInfo) : void {
+        if (slot == null || slot._type != null || slot.genFlags.generated) {
+            return
+        }
+        report(at, "{what} ({slot.__rtti}) has no type after inference")
+        slot._type = new TypeDecl(at = at, baseType = Type.tInt)
+    }
+
+    // ast_lint.cpp reports this for ExprCall; ast_unused.cpp getSideEffects segfaults
+    def need_func(fn : Function?; what : string; at : LineInfo) : void {
+        if (fn != null) {
+            return
+        }
+        report(at, "{what} has an unresolved func after inference")
+    }
+
+    def override visitExprVar(var expr : ExprVar?) : ExpressionPtr {
+        need_typed(expr, "ExprVar '{expr.name}'", expr.at)
+        return expr
+    }
+
+    def override preVisitExprCall(var expr : ExprCall?) : void {
+        need_func(expr.func, "ExprCall '{expr.name}'", expr.at)
+    }
+
+    // ast_unused.cpp reads arguments[i]->type for EVERY ExprLooksLikeCall subclass, and
+    // dispatch is on the concrete kind - hence the generic hook, not preVisitExprCall
+    def override preVisitExprLooksLikeCallArgument(var expr : ExprLooksLikeCall?; var arg : ExpressionPtr; _last : bool) : void {
+        need_typed(arg, "{expr.__rtti} '{expr.name}' argument", expr.at)
+    }
+
+    def override preVisitExprAscend(var expr : ExprAscend?) : void {
+        need_typed(expr.subexpr, "ExprAscend.subexpr", expr.at)
+    }
+
+    def override preVisitExprOp1(var expr : ExprOp1?) : void {
+        need_func(expr.func, "ExprOp1 '{expr.op}'", expr.at)
+        need_typed(expr.subexpr, "ExprOp1.subexpr", expr.at)
+    }
+
+    def override preVisitExprOp2(var expr : ExprOp2?) : void {
+        need_func(expr.func, "ExprOp2 '{expr.op}'", expr.at)
+        need_typed(expr.left, "ExprOp2.left", expr.at)
+        need_typed(expr.right, "ExprOp2.right", expr.at)
+    }
+
+    def override preVisitExprOp3(var expr : ExprOp3?) : void {
+        need_typed(expr.subexpr, "ExprOp3.subexpr", expr.at)
+        need_typed(expr.left, "ExprOp3.left", expr.at)
+        need_typed(expr.right, "ExprOp3.right", expr.at)
+    }
+
+    // ast_const_folding.cpp reads expr->type->baseType AND expr->value->type->baseType
+    def override preVisitExprSwizzle(var expr : ExprSwizzle?) : void {
+        need_typed(expr, "ExprSwizzle", expr.at)
+        need_typed(expr.value, "ExprSwizzle.value", expr.at)
+    }
+
+    def override preVisitExprStringBuilderElement(var expr : ExprStringBuilder?; var el : ExpressionPtr; _last : bool) : void {
+        need_typed(el, "ExprStringBuilder element", expr.at)
+    }
+
+    def override preVisitExprMakeArrayIndex(var expr : ExprMakeArray?; index : int; var init : ExpressionPtr; _last : bool) : void {
+        need_typed(init, "ExprMakeArray.values[{index}]", expr.at)
+    }
+
     def override preVisitExprReturn(var expr : ExprReturn?) : void {
         if (expr.subexpr != null || current_fn == null || current_fn.result == null
                 || closure_depth > 0) {
@@ -674,13 +897,26 @@ class private AstSimulateVerifyVisitor : AstVisitor {
         }
     }
 
+
 }
 
-def public verify_module_before_simulate(prog : ProgramPtr; mod : Module?) : int {
+def public verify_program_after_infer(prog : ProgramPtr; thisMod : Module?) : int {
+    //! Verifies thisMod plus every other non-builtin module - getSideEffects recurses
+    //! into CALLED functions. program_for_each_module does NOT yield thisMod itself.
+    var total = verify_module_after_infer(prog, thisMod)
+    program_for_each_module(prog) $(mod) {
+        if (!mod.moduleFlags.builtIn) {
+            total += verify_module_after_infer(prog, mod)
+        }
+    }
+    return total
+}
+
+def public verify_module_after_infer(prog : ProgramPtr; mod : Module?) : int {
     //! Verifies one module is ready for codegen, returning the violation count.
     //! Separate from [[verify_module]]: a half-inferred tree legitimately violates
     //! these, so they can only be asserted here.
-    var v = new AstSimulateVerifyVisitor()
+    var v = new AstPostInferVerifyVisitor()
     make_visitor(*v) $(adapter) {
         visit_module(prog, adapter, mod)
     }
@@ -691,13 +927,13 @@ def public verify_module_before_simulate(prog : ProgramPtr; mod : Module?) : int
     return n
 }
 
-[pre_simulate_macro]
-class AstSimulateVerifyMacro : AstPassMacro {
+[post_infer_macro]
+class AstPostInferVerifyMacro : AstPassMacro {
     def override apply(prog : ProgramPtr; mod : Module?) : bool {
         if (mod == null || mod.moduleFlags.builtIn) {
             return true
         }
-        verify_module_before_simulate(prog, mod)
+        verify_program_after_infer(prog, mod)
         return true
     }
 }

--- a/doc/source/stdlib/handmade/class-ast_boost-SetupPostInferMacro.rst
+++ b/doc/source/stdlib/handmade/class-ast_boost-SetupPostInferMacro.rst
@@ -1,0 +1,2 @@
+Base class for creating post-inference pass macros via the ``[post_infer_macro]`` structure annotation; registers an ``AstPassMacro`` that runs once inference is done, before lint / folding / codegen.
+Name of the builtin function used to register this annotation with the compiler.

--- a/doc/source/stdlib/handmade/class-ast_boost-SetupPreSimulateMacro.rst
+++ b/doc/source/stdlib/handmade/class-ast_boost-SetupPreSimulateMacro.rst
@@ -1,2 +1,0 @@
-Base class for creating pre-simulate pass macros via the ``[pre_simulate_macro]`` structure annotation; registers an ``AstPassMacro`` that runs after inference, before codegen.
-Name of the builtin function used to register this annotation with the compiler.

--- a/doc/source/stdlib/handmade/function-ast-add_post_infer_macro-0x11d5ba2eb298c567.rst
+++ b/doc/source/stdlib/handmade/function-ast-add_post_infer_macro-0x11d5ba2eb298c567.rst
@@ -1,0 +1,1 @@
+Adds an AstPassMacro adapter to the post-inference pass, which runs once inference is done, before lint, folding and code generation.

--- a/doc/source/stdlib/handmade/function-ast-add_pre_simulate_macro-0x629e331373d54ca7.rst
+++ b/doc/source/stdlib/handmade/function-ast-add_pre_simulate_macro-0x629e331373d54ca7.rst
@@ -1,1 +1,0 @@
-Adds an AstPassMacro adapter to the pre-simulate pass, which runs after inference and before code generation.

--- a/doc/source/stdlib/handmade/structure_macro-ast_boost-post_infer_macro.rst
+++ b/doc/source/stdlib/handmade/structure_macro-ast_boost-post_infer_macro.rst
@@ -1,0 +1,1 @@
+The ``[post_infer_macro]`` structure annotation — registers an ``AstPassMacro`` subclass that is invoked once inference is done, before lint / folding / codegen, where every expression type is final.

--- a/doc/source/stdlib/handmade/structure_macro-ast_boost-pre_simulate_macro.rst
+++ b/doc/source/stdlib/handmade/structure_macro-ast_boost-pre_simulate_macro.rst
@@ -1,1 +1,0 @@
-The ``[pre_simulate_macro]`` structure annotation — registers an ``AstPassMacro`` subclass that is invoked after inference and before codegen, where every expression type is final.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1258,7 +1258,7 @@ namespace das
         vector<unique_ptr<PassMacro>>               inferMacros;        // infer macros (dirty infer, assume half-way-there tree)
         vector<unique_ptr<PassMacro>>               optimizationMacros; // optimization macros
         vector<unique_ptr<PassMacro>>               preInferMacros;     // run before (re-)inference, on a possibly dirty tree
-        vector<unique_ptr<PassMacro>>               preSimulateMacros;  // run after inference, before codegen
+        vector<unique_ptr<PassMacro>>               postInferMacros;    // run once inference is done, before lint / folding / codegen
         vector<unique_ptr<PassMacro>>               lintMacros;         // lint macros (assume read-only)
         vector<unique_ptr<PassMacro>>               globalLintMacros;   // lint macros which work everywhere
         vector<unique_ptr<VariantMacro>>            variantMacros;      //  X is Y, X as Y expression handler

--- a/include/daScript/ast/ast_post_infer.h
+++ b/include/daScript/ast/ast_post_infer.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace das {
+    class Program;
+
+    // Runs every [post_infer_macro] over the program. Called once inference is done and
+    // again inside the optimizer, before the passes that read expr->type unguarded.
+    void applyPostInferMacros ( Program * program );
+}

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -801,7 +801,7 @@ namespace das {
         for (auto & m : ptm->inferMacros) target->inferMacros.push_back(std::move(m));
         for (auto & m : ptm->optimizationMacros) target->optimizationMacros.push_back(std::move(m));
         for (auto & m : ptm->preInferMacros) target->preInferMacros.push_back(std::move(m));
-        for (auto & m : ptm->preSimulateMacros) target->preSimulateMacros.push_back(std::move(m));
+        for (auto & m : ptm->postInferMacros) target->postInferMacros.push_back(std::move(m));
         for (auto & m : ptm->lintMacros) target->lintMacros.push_back(std::move(m));
         for (auto & m : ptm->globalLintMacros) target->globalLintMacros.push_back(std::move(m));
         for ( auto & rm : ptm->readMacros ) {

--- a/src/ast/ast_optimize.cpp
+++ b/src/ast/ast_optimize.cpp
@@ -1,4 +1,5 @@
 #include "daScript/misc/platform.h"
+#include "daScript/ast/ast_post_infer.h"
 
 #include "daScript/ast/ast.h"
 #include "daScript/ast/ast_expressions.h"
@@ -22,6 +23,7 @@ namespace das {
             last = program->optimizationRefFolding(optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REF FOLDING: " << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
+            applyPostInferMacros(program);                                if ( program->failed() ) break;
             last = program->optimizationUnused(logs, optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REMOVE UNUSED:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
@@ -41,6 +43,7 @@ namespace das {
             if ( log ) logs << "DEAD STORES:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
             // this is here again for a reason
+            applyPostInferMacros(program);                                if ( program->failed() ) break;
             last = program->optimizationUnused(logs, optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REMOVE UNUSED:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -59,6 +59,15 @@ DAS_CC_API das::smart_ptr<das::FileAccess> get_file_access( char * pak ) {
 
 namespace das {
 
+    void applyPostInferMacros ( Program * program ) {
+        program->library.foreach([&](Module * mod) -> bool {
+            for ( const auto & pm : mod->postInferMacros ) {
+                pm->apply(program, program->thisModule.get());
+            }
+            return true;
+        }, "*");
+    }
+
     // defined in ast_module.cpp (runtime); appends a parsed builtin module's content
     bool appendBuiltinModuleContent ( Module * target, ProgramPtr program, const string & modName );
 
@@ -975,6 +984,9 @@ namespace das {
                 *totInfer += inferLegT;
             }
             if ( !program->failed() ) {
+                // buildAccessFlags is the FIRST pass to read the finished tree, and it
+                // dereferences expr->type unguarded - so the verifier has to precede it
+                applyPostInferMacros(program.get());
                 program->buildAccessFlags(logs);    // this is used by the lint pass
                 if ( program->patchAnnotations() ) {
                     // A patchAnnotations() pass can both mutate the AST (astChanged) AND record a
@@ -1037,6 +1049,9 @@ namespace das {
             }
             if ( !program->failed() ) {
                 program->normalizeOptionTypes();
+                // lint / folding / codegen are the first consumers of the finished tree, and
+                // they dereference expr->type unguarded - so this is where a verifier can see it
+                applyPostInferMacros(program.get());
                 if (!program->failed())
                     program->lint(logs, libGroup);
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
@@ -1048,6 +1063,7 @@ namespace das {
                         callCompilationCallback(moduleName, fileName, "optimize");
                         optimizeProgram(program.get(),logs,libGroup);
                     } else {
+                        applyPostInferMacros(program.get());
                         program->buildAccessFlags(logs);
                     }
                 }

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3696,12 +3696,6 @@ namespace das
         if ( policies.keep_alive ) {
             updateKeepAliveFlags();
         }
-        library.foreach([&](Module * mod) -> bool {
-            for ( const auto & pm : mod->preSimulateMacros ) {
-                pm->apply(this, thisModule.get());
-            }
-            return true;
-        }, "*");
         isSimulating = true;
         context.failed = true;
         context.verySafeContext = options.getBoolOption("very_safe_context",policies.very_safe_context);

--- a/src/builtin/module_builtin_ast_adapters.cpp
+++ b/src/builtin/module_builtin_ast_adapters.cpp
@@ -2340,8 +2340,8 @@ namespace das {
         module->preInferMacros.push_back(unique_ptr<PassMacro>(newM));
     }
 
-    void addModulePreSimulateMacro ( Module * module, PassMacroPtr newM, Context * ) {
-        module->preSimulateMacros.push_back(unique_ptr<PassMacro>(newM));
+    void addModulePostInferMacro ( Module * module, PassMacroPtr newM, Context * ) {
+        module->postInferMacros.push_back(unique_ptr<PassMacro>(newM));
     }
 
     void addModuleLintMacro ( Module * module, PassMacroPtr newM, Context * ) {
@@ -2683,8 +2683,8 @@ namespace das {
         addExtern<DAS_BIND_FUN(addModulePreInferMacro)>(*this, lib,  "add_pre_infer_macro",
             SideEffects::modifyExternal, "addModulePreInferMacro")
                 ->args({"module","annotation","context"});
-        addExtern<DAS_BIND_FUN(addModulePreSimulateMacro)>(*this, lib,  "add_pre_simulate_macro",
-            SideEffects::modifyExternal, "addModulePreSimulateMacro")
+        addExtern<DAS_BIND_FUN(addModulePostInferMacro)>(*this, lib,  "add_post_infer_macro",
+            SideEffects::modifyExternal, "addModulePostInferMacro")
                 ->args({"module","annotation","context"});
         addExtern<DAS_BIND_FUN(addModuleLintMacro)>(*this, lib,  "add_lint_macro",
             SideEffects::modifyExternal, "addModuleLintMacro")

--- a/utils/ast-fuzz/README.md
+++ b/utils/ast-fuzz/README.md
@@ -157,7 +157,7 @@ Two compiler-side hooks, both no-ops unless the module is loaded:
   consumed in the same pass, and at the substitution site it is not yet installed
   in the module — so checking there sees the old tree. Checking per pass, with
   the tree in place, is what catches them.
-- **before codegen** (`ast_simulate.cpp`), as a `[pre_simulate_macro]`, where a
+- **once inference is done** (`ast_parse.cpp`), as a `[post_infer_macro]`, where a
   function's inferred result type is final. That is the only point at which a
   bare `return` in a non-void function is decidable: the infer-time twin has to
   skip an unresolved result type, because a function's result keeps moving until

--- a/utils/ast-fuzz/_ast_synth.das
+++ b/utils/ast-fuzz/_ast_synth.das
@@ -105,9 +105,11 @@ def private add_synth_functions(mod : Module?; seedInt : int; count : int; depth
         var g = new GenAll(seed = random_seed(seedInt + i * 6151), max_depth = depth,
             at = LineInfo())
         let nargs = abs(random_int(seed)) % 3
+        // the body is replaced with random statements below, so a non-void result is
+        // error[30310] every time and the program never reaches codegen
         var fn <- new Function(at = LineInfo(), atDecl = LineInfo(),
             name := "synth_gen_{seedInt}_{i}",
-            result = g.gen_type(depth))
+            result = new TypeDecl(at = LineInfo(), baseType = Type.tVoid))
         for (a in range(nargs)) {
             var av <- new Variable(at = LineInfo(), name := "a{a}", _type = g.gen_type(depth))
             fn.arguments |> emplace(av)

--- a/utils/ast-fuzz/gen_invariants.das
+++ b/utils/ast-fuzz/gen_invariants.das
@@ -360,8 +360,16 @@ def bind_of(kind : string) : string {
     return ""
 }
 
-def pool_for(fname : string) : string {
+def pool_for(fname : string; kind : string = "") : string {
     if (fname == "op") {
+        // the grammar admits only these in a unary / ternary slot, so a binary name
+        // there can never resolve and ExprOp1.func stays null into codegen
+        if (kind == "ExprOp1") {
+            return "UNARY_OPS"
+        }
+        if (kind == "ExprOp3") {
+            return "TERNARY_OPS"
+        }
         return "OPS"
     }
     if (fname == "mask") {
@@ -435,7 +443,8 @@ def emit_synth_all(kinds : array<string>; bases : table<string; string>; flds : 
                 } elif (f.ty == "type") {
                     ctor += ", {f.name} = gen_type(depth + 1)"
                 } elif (f.ty == "str") {
-                    ctor += ", {f.name} := {pool_for(f.name)}[rnd(length({pool_for(f.name)}))]"
+                    let pool = pool_for(f.name, k)
+                    ctor += ", {f.name} := {pool}[rnd(length({pool}))]"
                 } else {
                     vecs |> push(f)
                 }

--- a/utils/ast-fuzz/gen_prelude.das.in
+++ b/utils/ast-fuzz/gen_prelude.das.in
@@ -11,6 +11,8 @@ require math
 
 let private NAMES = fixed_array("x", "y", "z", "n", "s", "f", "_0", "_1", "i",
     "a", "b", "c", "m", "next", "red", "green", "value", "length", "__nope", "")
+let private UNARY_OPS = fixed_array("-", "+", "~", "!", "++", "--", "+++", "---")
+let private TERNARY_OPS = fixed_array("?")
 let private OPS = fixed_array("+", "-", "*", "/", "%", "==", "!=", "<", ">",
     "<=", ">=", "&&", "||", "&", "|", "^", "<<", ">>", "!", "~", "+=", "??", "")
 let private TRAITS = fixed_array("sizeof", "typename", "is_pointer", "is_array",

--- a/utils/ast-fuzz/main.das
+++ b/utils/ast-fuzz/main.das
@@ -122,8 +122,8 @@ def build_victim(cfg : Config; seed : int) : string {
         if (cfg.synth_depth > 0) {
             w |> write("options _ast_synth_depth = {cfg.synth_depth}\n")
         }
-        w |> write("options _ast_synth_funcs = {cfg.synth_funcs > 0 ? cfg.synth_funcs : 3}\n")
-        w |> write("options _ast_synth_decls = {cfg.synth_decls > 0 ? cfg.synth_decls : 3}\n")
+        w |> write("options _ast_synth_funcs = {cfg.synth_funcs > 0 ? cfg.synth_funcs : 1}\n")
+        w |> write("options _ast_synth_decls = {cfg.synth_decls > 0 ? cfg.synth_decls : 1}\n")
         if (cfg.synth_bind) {
             w |> write("options _ast_synth_bind = true\n")
         }

--- a/utils/ast-fuzz/selftest/cycle.das
+++ b/utils/ast-fuzz/selftest/cycle.das
@@ -1,0 +1,8 @@
+options gen2
+require cycle_breaker
+
+[export]
+def main {
+    var x = 1 // nolint:LINT003
+    print("{x + x}\n")
+}

--- a/utils/ast-fuzz/selftest/cycle_breaker.das
+++ b/utils/ast-fuzz/selftest/cycle_breaker.das
@@ -1,0 +1,40 @@
+options gen2
+
+module cycle_breaker shared
+
+// Self-test fixture: points an ExprOp2 at itself AFTER its own walk has passed
+// that slot, so this visitor does not recurse but every later one would. The
+// generator cannot build a cycle, so this is the only guard on that check.
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/ast_verify
+
+class Cycler : AstVisitor {
+    done : bool = false
+    def override visitExprOp2(var expr : ExprOp2?) : ExpressionPtr {
+        if (!done && expr.right != null) {
+            expr.right = expr
+            done = true
+        }
+        return expr
+    }
+}
+
+[infer_macro]
+class CycleMacro : AstPassMacro {
+    def override apply(prog : ProgramPtr; mod : Module?) : bool {
+        if (mod == null || !empty(mod.name)) {
+            return false
+        }
+        var v = new Cycler()
+        make_visitor(*v) $(adapter) {
+            visit_module(prog, adapter, mod)
+        }
+        unsafe {
+            delete v
+        }
+        verify_module(prog, mod)
+        return false
+    }
+}

--- a/utils/ast-fuzz/selftest/null_entry.das
+++ b/utils/ast-fuzz/selftest/null_entry.das
@@ -1,0 +1,9 @@
+options gen2
+require null_entry_breaker
+
+[export]
+def main {
+    // dropped by the breaker, so nothing below may reference it
+    var probe = 1
+    print("ok\n")
+}

--- a/utils/ast-fuzz/selftest/null_entry_breaker.das
+++ b/utils/ast-fuzz/selftest/null_entry_breaker.das
@@ -1,0 +1,41 @@
+options gen2
+
+module null_entry_breaker shared
+
+// Self-test fixture: nulls an entry in ExprLet.variables. ExprLet::visit
+// dereferences each entry before any per-entry hook runs, so the verifier has to
+// drop it in preVisit; the generator only ever builds real Variables, so this is
+// the only guard on that check.
+
+require daslib/ast
+require daslib/ast_boost
+require daslib/ast_verify
+
+class Nuller : AstVisitor {
+    done : bool = false
+    def override visitExprLet(var expr : ExprLet?) : ExpressionPtr {
+        if (!done && !empty(expr.variables)) {
+            expr.variables[0] = null
+            done = true
+        }
+        return expr
+    }
+}
+
+[infer_macro]
+class NullEntryMacro : AstPassMacro {
+    def override apply(prog : ProgramPtr; mod : Module?) : bool {
+        if (mod == null || !empty(mod.name)) {
+            return false
+        }
+        var v = new Nuller()
+        make_visitor(*v) $(adapter) {
+            visit_module(prog, adapter, mod)
+        }
+        unsafe {
+            delete v
+        }
+        verify_module(prog, mod)
+        return false
+    }
+}

--- a/utils/ast-fuzz/test_ast_fuzz.das
+++ b/utils/ast-fuzz/test_ast_fuzz.das
@@ -24,6 +24,24 @@ def test_verifier_reports_null_child(t : T?) {
 }
 
 [test]
+def test_verifier_cuts_a_cycle(t : T?) {
+    var out : string
+    let ec = run([BIN, "utils/ast-fuzz/selftest/cycle.das"], out, 60.0)
+    t |> success(!died(ec, out), "compile crashed (exit {ec})\n{out}")
+    t |> success(find(out, "points at its own ancestor") >= 0,
+        "did not report the cycle\n{out}")
+}
+
+[test]
+def test_verifier_drops_a_null_vector_entry(t : T?) {
+    var out : string
+    let ec = run([BIN, "utils/ast-fuzz/selftest/null_entry.das"], out, 60.0)
+    t |> success(!died(ec, out), "compile crashed (exit {ec})\n{out}")
+    t |> success(find(out, "ExprLet.variables holds 1 null entry") >= 0,
+        "did not report the null entry\n{out}")
+}
+
+[test]
 def test_ast_verify_clean_on_valid_code(t : T?) {
     var out : string
     let ec = run([BIN, "--ast-verify", "utils/ast-fuzz/selftest/cli_victim.das"], out, 60.0)


### PR DESCRIPTION
Follow-up to #3614. Everything here came out of running the fuzzers against the verifier that PR added, then fixing what they found.

## Compiler bugs (source-reachable, no macros involved)

Found by a source-level differential fuzzer — every expression is emitted twice, once with literal operands (const-folded) and once with operands laundered through a global array (folding defeated), then run under the interpreter and under `-jit`. Any mismatch is a bug in one tier; no oracle needed. A third of operands are biased to edge values, which is what made these reachable — 200 seeds of ordinary random scalars found nothing.

- **`abs(-0.0)` returned `-0.0`.** Three implementations: `SimPolicy_MathTT::Abs` (`a >= 0 ? a : -a`, true for `-0.0`), and `v_abs` for float and float vectors, which on x86 clang is `v_max(v_neg(a), a)` — `MAXPS` returns its *second* operand when both are zero. NEON's `vabsq_f32` is correct, so the interpreter also disagreed with itself per target. The JIT was right, so this was a tier divergence too, and const folding shares the policies, so the folded form was wrong under `-jit` as well.
- **The JIT dropped the `INT_MIN / -1` guard.** The interpreter throws `division overflow`; the JIT emitted a raw `sdiv`, which LLVM leaves *poison*. A program that must abort continued instead. Modulo deliberately keeps the interpreter's answer of `0` rather than throwing — guarding it would have been a *new* divergence, and the first draft of this fix made exactly that mistake.
- **Every `float`→`half` subnormal flushed to zero, and the smallest produced `-nan`.** `das_float_to_float16`'s subnormal branch double-counted the 23→10 mantissa reduction (`sh = 126 - e + 13 + 1`), so `sh` reached 38 and `1u << (sh - 1u)` was undefined behaviour. `half(x)` for any `x` under 6.104e-5 was affected.

## Crash guards (macro-built AST only)

The AST generator builds trees the parser cannot produce, so these are reachable from a macro, not from source. Each is a null check of the same species — *don't dereference what inference never resolved* — and in two cases the correct guard already existed on a sibling line (`preVisit(ExprCall)` had `expr->func ? … : 0`; simulate's make-local paths already reported `internal_*`).

- `fold`: `evalAndFold` / `evalAndFoldString` no longer simulate an expression with no type. Inference calls both mid-pass, so this alone accounted for 12 of the crashing repros.
- `unused`: four null-`Function` dereferences in `TrackFieldAndAtFlags`, including `getSideEffects` recursing over `useFunctions`, which holds a null because `markSymbolUse` records the callee of an unresolved call as one.
- `simulate`: `ExprVar` with an unresolved variable now reports `internal_variable` (50640) instead of dereferencing it.

## Verifier

- Renamed `[pre_simulate_macro]` → `[post_infer_macro]` and moved it ahead of `buildAccessFlags`, which runs right after `inferTypes` and is the first pass to read the finished tree. Also walks every non-builtin module, since `getSideEffects` recurses into called functions across module boundaries.
- New checks: AST cycles (direct, indirect, type, statement-list), null payload pointers, null entries in `Variable`/`MakeStruct`/`MakeFieldDecl` vectors, non-unary `ExprOp1` operators, inc/dec on a literal, `ExprSwizzle` types, module-less enumerations, and untyped operands after inference.
- The untyped-operand check needed two exclusions that no `Function` flag exposes: `assume` alias subexpressions and `template` struct field initializers, both of which hold AST as *data*. Measured on the 1485 compilable files under `tests/`: without them, 27201 false positives; with them, zero.

## Verification

- `tests/` 11310 passing — the 3 failures are pre-existing environment gaps here (a module not built, a spawned MCP server, a bound port), unchanged by this branch
- JIT lane: `language` 1523, `type_lattice` 478, `math` 131, `constexpr`, `bitfields` — all pass
- 1485 compilable files under `tests/` compile with `--ast-verify` and produce zero reports
- 25 kept fuzz repros: 24 no longer crash (the last is source-unreachable and left alone)
- ~30 000 AST-fuzz seeds across 11 sweeps and 8 axes; the fp16 differential sweep went from 9 divergences to 0

## Known gap

`add_pre_simulate_macro` is renamed to `add_post_infer_macro`, so its handmade doc stub needs the new signature-hash filename. das2rst cannot run in a `dashv`-disabled build, so that name has to come from the doc lane itself — expect one failure there and a single `git mv` to fix it.
