### PR TITLE
dasweb: script the toolchain-bump protocol; survive wasm memory growth in the wasi shim

### DIFF
--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -114,7 +114,7 @@
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
 <script type="text/javascript" src="./playground-wasm.js?v=2"></script>
-<script type="text/javascript" src="./main.js?v=4"></script>
+<script type="text/javascript" src="./main.js?v=5"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=3"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>

--- a/site/tests/playground/engine-toggle.spec.js
+++ b/site/tests/playground/engine-toggle.spec.js
@@ -139,6 +139,70 @@ test('a queued build narrates its progress and then runs', async ({ playground }
     await expect.poll(() => playground.locator('#run').isDisabled(), { timeout: 15_000 }).toBe(false);
 });
 
+// Artifacts link with -sALLOW_MEMORY_GROWTH, and growing a wasm memory DETACHES
+// its previous ArrayBuffer. The wasi shim must therefore read the buffer live
+// from the Memory object on every call — a snapshot taken at instantiation dies
+// on the first fd_write after a grow ("Cannot perform DataView constructor on a
+// detached ArrayBuffer"), which is how the f2s benchmark failed the day growth
+// was enabled. This module prints, grows, prints again.
+function growingModuleBytes() {
+    const leb = (n) => { const out = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; out.push(b); } while (n); return out; };
+    const str = (s) => [s.length, ...[...s].map(c => c.charCodeAt(0))];
+    const sec = (id, bytes) => [id, ...leb(bytes.length), ...bytes];
+    const vec = (items) => [items.length, ...items.flat()];
+
+    const type = sec(1, vec([
+        [0x60, 4, 0x7f, 0x7f, 0x7f, 0x7f, 1, 0x7f],   // (i32 i32 i32 i32) -> i32 : fd_write
+        [0x60, 0, 0],                                  // () -> ()               : _start
+    ]));
+    const imp = sec(2, vec([
+        [...str('wasi_snapshot_preview1'), ...str('fd_write'), 0x00, 0],
+    ]));
+    const func = sec(3, vec([[1]]));
+    const mem = sec(5, vec([[0x00, 1]]));              // min 1 page, NO max -> growable
+    const exp = sec(7, vec([
+        [...str('memory'), 0x02, 0],
+        [...str('_start'), 0x00, 1],                   // func 0 is the import
+    ]));
+    // iovec1 @16 -> "one\n" (0,4); iovec2 @24 -> "two\n" (4,4); nwritten @32
+    const wr = (iov) => [0x41, 1, 0x41, iov, 0x41, 1, 0x41, 32, 0x10, 0, 0x1a]; // fd_write(1,iov,1,32); drop
+    const body = [0, ...wr(16), 0x41, 1, 0x40, 0x00, 0x1a, ...wr(24), 0x0b];    // print; grow(1); print
+    const code = sec(10, vec([[...leb(body.length), ...body]]));
+    const dataBytes = [
+        ...'one\ntwo\n'.split('').map(c => c.charCodeAt(0)), 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 4, 0, 0, 0,                        // iovec1: ptr 0, len 4
+        4, 0, 0, 0, 4, 0, 0, 0,                        // iovec2: ptr 4, len 4
+    ];
+    const data = sec(11, vec([[0, 0x41, 0, 0x0b, ...leb(dataBytes.length), ...dataBytes]]));
+    return Buffer.from([0, 0x61, 0x73, 0x6d, 1, 0, 0, 0, ...type, ...imp, ...func, ...mem, ...exp, ...code, ...data]);
+}
+
+test('module-rail stdout survives a wasm memory grow', async ({ playground }) => {
+    await stubBuildInfo(playground, true);
+    await stubStore(playground);
+    await stubBuild(playground, [{ state: 'done', toolchain: 'abc1234', files: [ARTIFACT_URL] }]);
+    await playground.route('**' + ARTIFACT_URL, route => route.fulfill({
+        status: 200,
+        contentType: 'application/wasm',
+        body: growingModuleBytes(),
+    }));
+    await reloadWithStubs(playground);
+
+    const memory64 = await playground.evaluate(() =>
+        WebAssembly.validate(new Uint8Array([0, 0x61, 0x73, 0x6d, 1, 0, 0, 0, 5, 3, 1, 4, 1])));
+    test.skip(!memory64, 'browser lacks wasm64/memory64');
+
+    await playground.locator(wasmSel).check();
+    await playground.locator('#run').click();
+
+    const output = playground.locator('#output');
+    await expect(output).toContainText('one', { timeout: 15_000 });
+    // "two" is written AFTER memory.grow — a shim holding the pre-grow buffer
+    // throws here instead of printing.
+    await expect(output).toContainText('two', { timeout: 15_000 });
+    await expect(output).not.toContainText('wasm error');
+});
+
 test('a page-kind build runs as an embedded page frame', async ({ playground }) => {
     // Graphics/audio samples build as standalone html+js+wasm pages (kind:
     // 'page'); the playground embeds the html artifact in an iframe instead of

--- a/utils/dasweb-buildd/CODEREVIEW.md
+++ b/utils/dasweb-buildd/CODEREVIEW.md
@@ -69,6 +69,11 @@ defect, and this section is the whole test.
 - `run_build.sh` — the box-side build recipe and its sandbox invocation; the only place a build
   command line or a sandbox mount lives. A behavior change here without a note in `README.md`
   (The sandbox section) is a defect.
+- `roll_toolchain.sh` — the box-side toolchain-bump recipe: moving the worktree, rebuilding the
+  cross-compile host and the wasm archives, warming the emcc cache in both modes, restarting the
+  service. The only place a roll step lives. A step added or removed here without a note in
+  `README.md` (The toolchain-bump protocol section) is a defect, and a roll path that moves the
+  worktree without rebuilding both the host and the runtime archive is a defect.
 - `Containerfile` — the sandbox image. It holds only what a system must provide the toolchain;
   anything a read-only mount can supply instead belongs in `run_build.sh`. A change here
   without bumping the image tag in both files, in the same commit, is a defect.

--- a/utils/dasweb-buildd/README.md
+++ b/utils/dasweb-buildd/README.md
@@ -123,6 +123,36 @@ the wasm worktree is dedicated because wasm and native builds poison each other'
 podman build -t dasweb-builder:2 -f utils/dasweb-buildd/Containerfile .
 ```
 
+## The toolchain-bump protocol
+
+The toolchain id is the wasm worktree's HEAD sha, so moving the worktree re-keys every cached
+artifact and each sample pays a real build on its next click. Roll once, after a batch of work
+has landed — never per-merge.
+
+Moving the worktree is not by itself a roll. `run_build.sh` consumes two built things, and a
+daslang change lands in one or the other: `bin/daslang`, the cross-compile host that emits the
+emcc link line (where link flags live), and `web/output64/lib/*_runtime*.a`, the runtime archive
+linked into every artifact (where runtime behaviour lives). Pulling without rebuilding both
+announces a new id whose artifacts still carry the old code — the cache is invalidated and
+nothing is fixed. The host additionally bakes its own C++ ABI into every module it codegens, so
+it is built by `web/build_wasm_host.sh` rather than an ordinary cmake invocation; a host whose
+stdlib or exception config differs from the target corrupts the wasm heap at runtime with no
+build-time diagnostic.
+
+The emcc cache is mounted read-only into the sandbox, so a job cannot populate it: the roll
+warms it outside the sandbox with one build of **each** mode, because the page rail links
+`-pthread` and pulls `-mt` system libraries a module build never touches.
+
+`roll_toolchain.sh` performs all of it, on the box, as the box user:
+
+```bash
+./roll_toolchain.sh --dry-run     # print the plan, touch nothing
+./roll_toolchain.sh               # roll to origin/master
+```
+
+It refuses to start if the worktree has modified tracked files, and reports the old and new id.
+Verify afterwards with the browser leg of `utils/dasweb-verify`, which drives the live site.
+
 ## Tests
 
 ```bash

--- a/utils/dasweb-buildd/roll_toolchain.sh
+++ b/utils/dasweb-buildd/roll_toolchain.sh
@@ -104,8 +104,10 @@ run bash -c '. "$1/emsdk_env.sh" >/dev/null 2>&1 && cd "$2" && ./bin/daslang uti
 # builds via its own .das_package recipe — normally run by daspkg's
 # ensure_external_wasm_archives, which the SANDBOX cannot run (no cmake, and the
 # worktree is mounted read-only), so it runs here, host-side, per toolchain.
-# The build command and archive set MIRROR modules/dasImgui/.das_package —
-# a change to either without the other is a defect (see CODEREVIEW.md).
+# The build command and archives MIRROR modules/dasImgui/.das_package, minus
+# liblibDasModuleClipboard.a — that one is in daspkg's own in-tree list and is
+# staged by step 3. A change to either side without the other is a defect
+# (see CODEREVIEW.md).
 say "4/6  bake the dasImgui wasm archives"
 run bash -c '
     set -euo pipefail

--- a/utils/dasweb-buildd/roll_toolchain.sh
+++ b/utils/dasweb-buildd/roll_toolchain.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Roll the wasm toolchain to a new commit, on the build box, as the box user.
+#
+# The toolchain id is the wasm worktree's HEAD sha, so moving the worktree
+# re-keys every cached artifact — every sample pays a real build on its next
+# click. That makes this a one-shot operation to run after a batch has landed,
+# never per-merge.
+#
+# Moving the worktree alone is NOT a roll. run_build.sh consumes built things,
+# and a daslang change lands in one of them:
+#   bin/daslang                       the cross-compile host, which emits the
+#                                     emcc link line (link flags live here)
+#   web/output64/lib/*_runtime*.a     the runtime archive linked INTO artifacts
+#                                     (runtime behaviour lives here)
+#   web/output64/lib/liblib*Imgui*.a  the dasImgui family — daspkg build --wasm
+#                                     does NOT build these, and the sandbox
+#                                     cannot (no cmake, read-only worktree)
+# Pulling without rebuilding announces a new id whose artifacts still carry the
+# old code — the worst outcome, because the cache is invalidated and nothing is
+# actually fixed.
+#
+#   ./roll_toolchain.sh                 roll to origin/master
+#   ./roll_toolchain.sh --ref <sha>     roll to a specific commit
+#   ./roll_toolchain.sh --dry-run       print the plan, touch nothing
+#   ./roll_toolchain.sh --skip-restart  build and warm, leave the service alone
+#
+# Env (defaults match the systemd unit and the box):
+#   DASWEB_WASM_WORKTREE   the wasm worktree whose HEAD is the toolchain id
+#   EMSDK                  the pinned emsdk root
+#   HOST_CC / HOST_CXX     compiler for the cross-compile host. Debian 12's bare
+#                          clang is 14 and cannot build the tree; clang-19 can.
+set -euo pipefail
+
+WORKTREE="${DASWEB_WASM_WORKTREE:-/home/boris/daScript-wasm}"
+EMSDK_ROOT="${EMSDK:-/home/boris/emsdk}"
+HOST_CC="${HOST_CC:-clang-19}"
+HOST_CXX="${HOST_CXX:-clang++-19}"
+SERVICE="dasweb-buildd"
+REF="origin/master"
+DRY_RUN=0
+SKIP_RESTART=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ref)          REF="${2:?--ref needs a commit-ish}"; shift 2 ;;
+        --dry-run)      DRY_RUN=1; shift ;;
+        --skip-restart) SKIP_RESTART=1; shift ;;
+        -h|--help)      sed -n '2,31p' "$0"; exit 0 ;;
+        *)              echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+say()  { printf '\n=== %s\n' "$*"; }
+run()  { if [ "$DRY_RUN" = 1 ]; then printf '  would run: %s\n' "$*"; else "$@"; fi; }
+
+# .git is a FILE in a linked worktree (a gitdir pointer), so ask git itself.
+git -C "$WORKTREE" rev-parse --git-dir >/dev/null 2>&1 \
+    || { echo "no git worktree at $WORKTREE" >&2; exit 10; }
+[ -f "$EMSDK_ROOT/emsdk_env.sh" ] || { echo "no emsdk at $EMSDK_ROOT" >&2; exit 11; }
+
+cd "$WORKTREE"
+
+# Tracked-file changes mean someone edited the toolchain by hand; rolling would
+# silently discard or preserve them. Untracked build dirs are expected and fine.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    echo "worktree has modified tracked files — resolve before rolling:" >&2
+    git status --short --untracked-files=no >&2
+    exit 12
+fi
+
+OLD_ID="$(git rev-parse HEAD)"
+# Fetch even under --dry-run: it only moves remote-tracking refs, and without it
+# the printed plan would target whatever origin/master pointed at LAST fetch.
+git fetch origin --quiet
+NEW_ID="$(git rev-parse "$REF")"
+
+say "toolchain roll"
+printf '  worktree : %s\n  from     : %s\n  to       : %s (%s)\n' \
+    "$WORKTREE" "${OLD_ID:0:9}" "${NEW_ID:0:9}" "$REF"
+# Already-at-target is NOT an early exit: a roll that died mid-way leaves the
+# worktree moved but the rebuild/warm/restart undone, and re-running must finish
+# the job. Every later step is idempotent and cheap when already up to date.
+if [ "$OLD_ID" = "$NEW_ID" ]; then
+    echo "  worktree already at target — resuming (rebuild/warm/restart are idempotent)"
+fi
+
+say "1/6  move the worktree"
+run git checkout --quiet --detach "$NEW_ID"
+
+# The host bakes its OWN C++ ABI (struct layouts, exception model) into every
+# wasm module it codegens, so it must be built by this script — see its header.
+# emsdk must NOT be on PATH here: emsdk_env prepends its own clang, and a host
+# accidentally built by the wasm-targeting compiler is exactly the silent-heap-
+# corruption mismatch that script's header warns about.
+say "2/6  rebuild the cross-compile host (bin/daslang, $HOST_CXX)"
+run env HOST_CC="$HOST_CC" HOST_CXX="$HOST_CXX" bash web/build_wasm_host.sh
+
+# Everything from here needs emcc, so each build step sources emsdk in its own
+# subshell — nothing leaks into this shell or into the restart.
+say "3/6  restage the wasm runtime + module archives (web/output64/lib)"
+run bash -c '. "$1/emsdk_env.sh" >/dev/null 2>&1 && cd "$2" && ./bin/daslang utils/daspkg/main.das -- build --wasm' _ "$EMSDK_ROOT" "$WORKTREE"
+
+# daspkg build --wasm covers the in-tree module list only. The dasImgui family
+# builds via its own .das_package recipe — normally run by daspkg's
+# ensure_external_wasm_archives, which the SANDBOX cannot run (no cmake, and the
+# worktree is mounted read-only), so it runs here, host-side, per toolchain.
+# The build command and archive set MIRROR modules/dasImgui/.das_package —
+# a change to either without the other is a defect (see CODEREVIEW.md).
+say "4/6  bake the dasImgui wasm archives"
+run bash -c '
+    set -euo pipefail
+    . "$1/emsdk_env.sh" >/dev/null 2>&1
+    cd "$2/modules/dasImgui"
+    emcmake cmake -S . -B _wasm_build -DDASLANG_DIR="$2" -DCMAKE_BUILD_TYPE=Release -G Ninja
+    cmake --build _wasm_build --target dasModuleImgui imguiApp imguiAppHeadless
+    cp -f _wasm/liblibDasModuleImgui.a \
+          _wasm/liblibImguiApp.a \
+          _wasm/liblibImguiAppHeadless.a \
+          _wasm_build/_deps/freetype_src-build/libfreetype.a \
+          "$2/web/output64/lib/"
+' _ "$EMSDK_ROOT" "$WORKTREE"
+
+# The sandbox mounts the emcc cache READ-ONLY with EM_FROZEN_CACHE=1, so a job
+# cannot populate it. Both modes must be warmed here, outside the sandbox: the
+# page rail links -pthread and pulls the -mt system libraries a module build
+# never touches, so warming only one leaves the other failing on a cold cache.
+say "5/6  warm the emcc cache — one build of EACH mode, outside the sandbox"
+if [ "$DRY_RUN" = 1 ]; then
+    echo "  would run: a module build and a page build into a scratch dir"
+else
+    WARM="$(mktemp -d)"
+    trap 'rm -rf "$WARM"' EXIT
+    RUNTIME_LIB="$(ls "$WORKTREE"/web/output64/lib/*libDaScript_runtime*.a 2>/dev/null | head -1)"
+    [ -n "$RUNTIME_LIB" ] || { echo "no runtime archive after step 3" >&2; exit 13; }
+
+    mkdir -p "$WARM/src" "$WARM/mod" "$WARM/page"
+    printf 'options gen2\n[export]\ndef main {\n    print("warm\\n")\n}\n' > "$WARM/src/main.das"
+
+    echo "  module mode…"
+    bash -c '. "$1/emsdk_env.sh" >/dev/null 2>&1 && "$2/bin/daslang" -exe -output "$3/mod/sample" "$3/src/main.das" -- --jit-target=wasm64-unknown-emscripten --jit-runtime-lib="$4"' \
+        _ "$EMSDK_ROOT" "$WORKTREE" "$WARM" "$RUNTIME_LIB"
+
+    echo "  page mode…"
+    # The same .das_package shape write_sample_package (buildd_core.das) writes
+    # for a real page job — a change to either without the other is a defect.
+    printf 'options gen2\nrequire daslib/daspkg\n\n[export]\ndef package() {\n    package_name("sample")\n}\n\n[export]\ndef release() {\n    release_name("sample")\n    release_main("main.das")\n}\n' \
+        > "$WARM/src/.das_package"
+    bash -c '. "$1/emsdk_env.sh" >/dev/null 2>&1 && "$2/bin/daslang" "$2/utils/daspkg/main.das" -- release wasm --root "$3/src" --out "$3/page"' \
+        _ "$EMSDK_ROOT" "$WORKTREE" "$WARM"
+fi
+
+say "6/6  restart the service (announces the new toolchain id)"
+if [ "$SKIP_RESTART" = 1 ]; then
+    echo "  skipped (--skip-restart); the service still announces ${OLD_ID:0:9}"
+else
+    run sudo systemctl restart "$SERVICE"
+    run sleep 3
+    run systemctl is-active "$SERVICE"
+fi
+
+say "rolled ${OLD_ID:0:9} -> ${NEW_ID:0:9}"
+echo "Every cached artifact is now re-keyed; the first click on each sample pays a real build."
+echo "Verify with: node utils/dasweb-verify/browser/runner.mjs --mode wasm"

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -722,9 +722,13 @@ function runWasmArtifact(url) {
     // "my run drew nothing" confusion the run frame was introduced to end.
     destroyPageFrame();
     // Shim's DataView is rebuilt per-call from memRef.buffer, so we can
-    // create the shim before instantiation and patch the buffer once memory
-    // is exported.
-    const memRef = { buffer: new ArrayBuffer(0) };
+    // create the shim before instantiation and wire the buffer once memory
+    // is exported. The wire must be a LIVE getter, not a snapshot: artifacts
+    // link with -sALLOW_MEMORY_GROWTH, and the first grow detaches the old
+    // ArrayBuffer — a cached reference then throws "Cannot perform DataView
+    // constructor on a detached ArrayBuffer" on the next fd_write.
+    let wasmMemory = null;
+    const memRef = { get buffer() { return wasmMemory ? wasmMemory.buffer : new ArrayBuffer(0); } };
     const shim = makeWasiShim(memRef);
     fetch(url)
         .then(r => {
@@ -736,7 +740,7 @@ function runWasmArtifact(url) {
             env: new Proxy({}, { get: (_, name) => name === 'memory' ? undefined : () => -1 }),
         }))
         .then(({ instance }) => {
-            memRef.buffer = instance.exports.memory.buffer;
+            wasmMemory = instance.exports.memory;
             const exports = instance.exports;
             try {
                 if (typeof exports._initialize === 'function') exports._initialize();


### PR DESCRIPTION
Two commits, both fallout of rolling the wasm toolchain to pick up #3648–#3650.

## 1. `roll_toolchain.sh` — the toolchain-bump protocol, scripted

The roll was tribal knowledge spread across README prose, a memory note, and the systemd unit — and a hand-run `git pull && systemctl restart` would re-key every cached artifact while still emitting the old code, because the behaviour lives in built things, not the worktree: `bin/daslang` (the cross-compile host that emits the emcc link line) and `web/output64/lib/*_runtime*.a` (linked into every artifact).

The script does the whole protocol, fail-closed: refuse on modified tracked files → move the worktree → rebuild the host (`clang-19`, with emsdk deliberately **off** PATH — `emsdk_env` prepends its own clang, and a host built by the wasm-targeting compiler is the silent-ABI-corruption case `build_wasm_host.sh` warns about) → `daspkg build --wasm` → bake the dasImgui archive family (daspkg does not build it and the sandbox cannot: no cmake, read-only worktree; recipe mirrors `modules/dasImgui/.das_package`) → warm the emcc cache with one build of **each** mode → restart, which announces the new id. `--dry-run`, `--ref`, `--skip-restart`; already-at-target **resumes** instead of exiting, so an interrupted roll can be finished by re-running.

Validated by performing the real `7e6e8601c → 1b4b71189` roll with it. The dry-run caught two script bugs before anything ran (`.git` is a file in a linked worktree; the plan targeting a stale fetch), the live run caught two more (the warm-up package shape; resume semantics). Post-roll, at the new toolchain:

- **`ImGui: Fourier Series [wasm]` passes for the first time ever** — its build had always died on the missing imgui archives; the bake step is now part of the protocol.
- rotating triangle [wasm] passes (page rail healthy)
- module rail links fine, which leads to…

## 2. The shim fix — growth detaches the snapshot

f2s on the rolled toolchain got exactly one step past the trap #3650 fixed: the memory **grew**, which detaches the previous `ArrayBuffer` — and `runWasmArtifact` had snapshotted `instance.exports.memory.buffer` once after instantiation, so the wasi shim's next `fd_write` threw `Cannot perform DataView constructor on a detached ArrayBuffer`. The shim already rebuilds its `DataView` per call; the reference it rebuilds from is now a live getter into the `Memory` object.

The regression test hand-assembles a minimal wasm32 wasi module that prints, grows memory, and prints again — **verified failing with the exact live error** against the old shim, passing with the fix. 43/43 e2e green. `main.js` cache key bumped per the header rule.

This is a site-side fix: it reaches users on the next pages deploy, no builder roll needed. Until then f2s [wasm] on the live site fails with the detached-buffer message rather than `null function` — strictly more honest, still red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
