### PR TITLE
pages: cache shared modules by glob - the enumerated list starves das2rst on cache-hit deploys

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -81,15 +81,20 @@ jobs:
       id: wasm-cache
       uses: actions/cache@v4
       with:
+        # Shared modules are globbed, not enumerated: das2rst dlopens EVERY
+        # dynamic module its doc sweep requires (stbimage via dasGLTF, pugixml,
+        # hv, unit-test, ...), and an enumerated list silently drops whichever
+        # one the sweep grows next. A hit restores only what the list names, the
+        # native build is skipped, and das2rst dies on the first missing module
+        # — reachable only on a site-only merge (anything touching src/modules/
+        # daslib misses the key), the same way the lib/ omission above stayed
+        # hidden. #3652 was the first such merge; this is the second member of
+        # that class, so the list goes.
         path: |
           bin
           lib
-          modules/dasGlfw/dasModuleGlfw.shared_module
-          modules/dasOpenGL/dasModuleOpenGL.shared_module
-          modules/dasClipboard/dasModuleClipboard.shared_module
-          modules/dasImgui/dasModuleImgui.shared_module
-          modules/dasImgui/imguiApp.shared_module
-          modules/dasImgui/imguiAppHeadless.shared_module
+          modules/**/*.shared_module
+          examples/**/*.shared_module
           web/output
           web/output64
           site/playground/samples


### PR DESCRIPTION
On a cache hit the native build is skipped and `das2rst` runs against the restored set — but the cache **enumerated six** shared modules while the doc sweep dlopens every dynamic module it requires (stbimage via dasGLTF, pugixml, hv, unit-test, …). The first missing one is fatal:

```
error[20605]: missing prerequisite 'stbimage'; file not found
```

Only reachable on a **site-only merge** — anything touching `src/modules/daslib` misses the key and rebuilds — so it stayed hidden until #3652, the first one, turned pages red deterministically (the rerun failed identically). Same class as the `lib/` omission the step comment already documents; second member of the class, so the enumeration goes: glob every shared module the build produced (`modules/**/*.shared_module`, `examples/**/*.shared_module`).

Self-recovering: `pages.yml` is part of its own cache key, so this change forces a miss → full rebuild → a save that captures the full set — and that deploy also ships the #3652 shim fix the failed run left stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
