### PR TITLE
daslib: [template_struct_instance] — template reification (stamped struct/class instances)

### DIFF
--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -640,7 +640,7 @@ def private tsi_collect_alias_names(t : TypeDeclPtr; var names : table<string>) 
 }
 
 [macro_function]
-def private tsi_bind_aliases(st : StructurePtr; temMethods : array<FunctionPtr>; var rules : Template; var errors : das_string) : bool {
+def private tsi_bind_aliases(st : StructurePtr; temMethods : array<FunctionPtr>; var rules : Template; lateBind : bool; var errors : das_string) : bool {
     // every alias the instance carries (own typedefs + the template's, via the parser's clone) becomes a rule
     var bound : table<string>
     st |> for_each_structure_alias() $(var td) {
@@ -664,11 +664,53 @@ def private tsi_bind_aliases(st : StructurePtr; temMethods : array<FunctionPtr>;
         }
     }
     var missing <- [for (aname in keys(used)); aname; where !key_exists(bound, aname)]
-    if (!empty(missing)) {
+    if (!lateBind && !empty(missing)) { // late_bind = true: a later macro may still bind; infer reports what stays unbound
         missing |> sort()
         errors := "[template_struct_instance] {st.name} is missing 'typedef {missing[0]} = <type>'" + (
             length(missing) > 1 ? " (also: {join(missing, ", ")})" : "")
         return false
+    }
+    return true
+}
+
+[macro_function]
+def private tsi_callee_name(e : ExpressionPtr; var callee : string&; var errors : das_string) : bool {
+    if (e is ExprConstString) {
+        callee = string((e as ExprConstString).value)
+        return true
+    }
+    if (e is ExprAddr) {
+        callee = string((e as ExprAddr).target)
+        return true
+    }
+    errors := "[template_struct_instance] @template_call value must be a function address (@@name) or a string constant"
+    return false
+}
+
+[macro_function]
+def private tsi_bind_calls(var st : StructurePtr; temMethods : array<FunctionPtr>; var rules : Template; var errors : das_string) : bool {
+    var callIdx : array<int>
+    for (i in range(length(st.fields))) {
+        assume f = st.fields[i]
+        if (find_arg(f.annotation, "template_call") is nothing) continue
+        let slot = string(f.name)
+        for (func in temMethods) {
+            if (tsi_method_name(func) == slot) {
+                errors := "[template_struct_instance] @template_call '{slot}' collides with a template method name"
+                return false
+            }
+        }
+        if (f.init == null) {
+            errors := "[template_struct_instance] @template_call field '{f.name}' of {st.name} must be initialized with @@name or a string constant"
+            return false
+        }
+        var callee = ""
+        if (!tsi_callee_name(f.init, callee, errors)) return false
+        rules |> renameCall(slot, callee)
+        callIdx |> push(i)
+    }
+    for (i in range(length(callIdx))) {
+        st.fields |> erase(callIdx[length(callIdx) - 1 - i]) // reverse keeps indices valid
     }
     return true
 }
@@ -759,8 +801,8 @@ def private tsi_normalize_fields(var st : StructurePtr; var rules : Template) {
 
 [structure_macro(name = "template_struct_instance")]
 class TemplateStructInstance : AstStructureAnnotation {
-    //! Reifies a ``struct template`` / ``class template`` parent into the annotated instance at parse time: instance ``typedef``s bind the template's type parameters, ``override`` inits bind its ``@template_constant`` fields (erased from the result), template methods are cloned onto the instance (instance-authored methods win), and the template parent is cut — every later structure annotation sees a finished concrete struct or class.
-    //! Put ``[|> template_struct_instance]`` on the template itself so every instance inherits the reifier ahead of its own annotations.
+    //! Reifies a ``struct template`` / ``class template`` parent into the annotated instance at parse time: instance ``typedef``s bind the template's type parameters, ``override`` inits bind its ``@template_constant`` fields (erased from the result), ``@template_call`` fields rebind free-function callees by name (``override sdot = @@ssdot`` — calls AND ``@@`` addresses; erased too), template methods are cloned onto the instance (instance-authored methods win), and the template parent is cut — every later structure annotation sees a finished concrete struct or class.
+    //! Put ``[|> template_struct_instance]`` on the template itself so every instance inherits the reifier ahead of its own annotations. ``[|> template_struct_instance(late_bind = true)]`` skips the unbound-alias check, for templates whose type parameters another macro supplies later (e.g. from a ``[dirty_infer_macro]``).
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         if (st.flags.isTemplate) {
             return true // [|> ...] fires on the template itself: nothing to reify
@@ -791,8 +833,10 @@ class TemplateStructInstance : AstStructureAnnotation {
         var instType = new TypeDecl(at = st.at, baseType = Type.tStructure, structType = st)
         rules |> replaceStructWithTypeDecl(tem) <| clone_type(instType)
         rules |> replaceTypeWithTypeDecl(string(tem.name)) <| clone_type(instType)
-        if (!tsi_bind_aliases(st, temMethods, rules, errors)
+        let lateBind = find_arg(args, "late_bind") ?as tBool ?? false
+        if (!tsi_bind_aliases(st, temMethods, rules, lateBind, errors)
                 || !tsi_bind_constants(st, rules, errors)
+                || !tsi_bind_calls(st, temMethods, rules, errors)
                 || !tsi_stamp_methods(st, tem, temMethods, ownMethods, rules, errors)) {
             return false
         }

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -706,9 +706,8 @@ def private tsi_bind_calls(var st : StructurePtr; temMethods : array<FunctionPtr
         }
         var callee = ""
         if (!tsi_callee_name(f.init, callee, errors)) return false
-        // both spellings, same as method renames: `_::slot(...)` / `@@_::slot` must rebind too
+        // bare spelling only, by design: `_::slot` / `__::slot` keep normal `_`/`__` resolution — the pinned escape to the real function
         rules |> renameCall(slot, callee)
-        rules |> renameCall("_::{slot}", "_::{callee}")
         callIdx |> push(i)
     }
     for (i in range(length(callIdx))) {
@@ -803,7 +802,7 @@ def private tsi_normalize_fields(var st : StructurePtr; var rules : Template) {
 
 [structure_macro(name = "template_struct_instance")]
 class TemplateStructInstance : AstStructureAnnotation {
-    //! Reifies a ``struct template`` / ``class template`` parent into the annotated instance at parse time: instance ``typedef``s bind the template's type parameters, ``override`` inits bind its ``@template_constant`` fields (erased from the result), ``@template_call`` fields rebind free-function callees by name (``override sdot = @@ssdot`` — calls AND ``@@`` addresses; erased too), template methods are cloned onto the instance (instance-authored methods win), and the template parent is cut — every later structure annotation sees a finished concrete struct or class.
+    //! Reifies a ``struct template`` / ``class template`` parent into the annotated instance at parse time: instance ``typedef``s bind the template's type parameters, ``override`` inits bind its ``@template_constant`` fields (erased from the result), ``@template_call`` fields rebind free-function callees by name (``override sdot = @@ssdot`` — bare-spelled calls AND ``@@`` addresses; erased too, while ``_::sdot`` / ``__::sdot`` keep their normal resolution rules — the pinned escape to the real function), template methods are cloned onto the instance (instance-authored methods win), and the template parent is cut — every later structure annotation sees a finished concrete struct or class.
     //! Put ``[|> template_struct_instance]`` on the template itself so every instance inherits the reifier ahead of its own annotations. ``[|> template_struct_instance(late_bind = true)]`` skips the unbound-alias check, for templates whose type parameters another macro supplies later (e.g. from a ``[dirty_infer_macro]``).
     def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
         if (st.flags.isTemplate) {

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -153,7 +153,7 @@ class TypeMacroMacro : AstFunctionAnnotation {
         compiling_module() |> add_structure(cls)
         return true
     }
-    def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool {
+    def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool { // nolint:STYLE037 — pre-existing typemacro patch pass; the if/elif AST routing is one order-coupled flow
         for (ann in func.annotations) {
             if (ann.annotation.name == "typemacro_function") {
                 if (!(find_arg(ann.arguments, "patched") is nothing)) return true
@@ -389,7 +389,7 @@ class TemplateTypeMacroMacro : AstFunctionAnnotation {
         }
         return true
     }
-    def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool {
+    def override patch(var func : FunctionPtr; var group : ModuleGroup; args, progArgs : AnnotationArgumentList; var errors : das_string; var astChanged : bool&) : bool { // nolint:STYLE038 — pre-existing typemacro patch pass; sequential AST build, no free-standing seam
         for (ann in func.annotations) {
             if (ann.annotation.name == "typemacro_template_function") {
                 if (!(find_arg(ann.arguments, "patched") is nothing)) return true
@@ -531,7 +531,7 @@ class TemplateStructure : AstStructureAnnotation {
 [structure_macro(name="template_tuple")]
 class TemplateTuple : AstStructureAnnotation {
     //! Like ``[template_structure]``, but produces a typemacro that returns a named tuple instead of cloning a structure. Result is structural — no module home, no per-consumer cloning. Use for sum-type / discriminated- pair shapes (``Option``, ``Result``) where structural identity across transitive ``require ... public`` is the desired behavior (issue #2598).
-    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool { // nolint:STYLE038 — pre-existing tuple-typemacro emission; one sequential build, no free-standing seam
         if (length(args) == 0) {
             errors := "expecting at least one template argument name"
             return false

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -706,7 +706,9 @@ def private tsi_bind_calls(var st : StructurePtr; temMethods : array<FunctionPtr
         }
         var callee = ""
         if (!tsi_callee_name(f.init, callee, errors)) return false
+        // both spellings, same as method renames: `_::slot(...)` / `@@_::slot` must rebind too
         rules |> renameCall(slot, callee)
+        rules |> renameCall("_::{slot}", "_::{callee}")
         callIdx |> push(i)
     }
     for (i in range(length(callIdx))) {

--- a/daslib/typemacro_boost.das
+++ b/daslib/typemacro_boost.das
@@ -7,7 +7,9 @@ module typemacro_boost shared private
 //! Type macro and template structure support.
 //!
 //! Implements ``[template_structure]`` annotation that generates
-//! type-parameterized structs (similar to C++ templates), and provides
+//! type-parameterized structs (similar to C++ templates),
+//! ``[template_struct_instance]`` which reifies a ``struct template`` /
+//! ``class template`` parent into an inheriting instance, and provides
 //! ``int64_to_enum``, enum-to-string, and other type-manipulation
 //! helpers.
 
@@ -15,6 +17,7 @@ require daslib/ast_boost
 require daslib/macro_boost
 require daslib/templates_boost public
 require daslib/ast_boost public
+require daslib/strings_boost
 require strings
 
 def public int64_to_enum(_enu : auto(ET); value : int64) : ET {
@@ -613,6 +616,192 @@ class TemplateTuple : AstStructureAnnotation {
         if (!(compiling_module() |> add_function(typeMacroFunction))) {
             panic("can't add function {typeMacroFunctionName}")
         }
+        return true
+    }
+}
+
+[macro_function]
+def private tsi_method_name(func : FunctionPtr) : string {
+    let parts <- split(string(func.name), "`")
+    return parts[length(parts) - 1]
+}
+
+[macro_function]
+def private tsi_collect_alias_names(t : TypeDeclPtr; var names : table<string>) {
+    if (t == null) return
+    if (t.baseType == Type.alias) {
+        names |> insert(string(t.alias))
+    }
+    tsi_collect_alias_names(t.firstType, names)
+    tsi_collect_alias_names(t.secondType, names)
+    for (arg in t.argTypes) {
+        tsi_collect_alias_names(arg, names)
+    }
+}
+
+[macro_function]
+def private tsi_bind_aliases(st : StructurePtr; temMethods : array<FunctionPtr>; var rules : Template; var errors : das_string) : bool {
+    // every alias the instance carries (own typedefs + the template's, via the parser's clone) becomes a rule
+    var bound : table<string>
+    st |> for_each_structure_alias() $(var td) {
+        bound |> insert(string(td.alias))
+        rules |> replaceTypeWithTypeDecl(string(td.alias)) <| clone_type(td)
+    }
+    // module-level typedefs resolve at infer on their own — only an unbindable template parameter should error
+    program_for_each_module(compiling_program()) $(m) {
+        m |> for_each_typedef() $(tname, _td) {
+            bound |> insert(string(tname))
+        }
+    }
+    var used : table<string>
+    for (f in st.fields) {
+        tsi_collect_alias_names(f._type, used)
+    }
+    for (func in temMethods) {
+        tsi_collect_alias_names(func.result, used)
+        for (arg in func.arguments) {
+            tsi_collect_alias_names(arg._type, used)
+        }
+    }
+    var missing <- [for (aname in keys(used)); aname; where !key_exists(bound, aname)]
+    if (!empty(missing)) {
+        missing |> sort()
+        errors := "[template_struct_instance] {st.name} is missing 'typedef {missing[0]} = <type>'" + (
+            length(missing) > 1 ? " (also: {join(missing, ", ")})" : "")
+        return false
+    }
+    return true
+}
+
+[macro_function]
+def private tsi_is_const_init(e : ExpressionPtr) : bool {
+    if (is_expr_const(e)) return true
+    // a signed literal (`-1`) is still ExprOp1 over the constant this early, pre-fold
+    if (e is ExprOp1) {
+        let op1 = e as ExprOp1
+        return (op1.op == "-" || op1.op == "+") && is_expr_const(op1.subexpr)
+    }
+    return false
+}
+
+[macro_function]
+def private tsi_bind_constants(var st : StructurePtr; var rules : Template; var errors : das_string) : bool {
+    var constIdx : array<int>
+    for (i in range(length(st.fields))) {
+        assume f = st.fields[i]
+        if (find_arg(f.annotation, "template_constant") is nothing) continue
+        if (f.init == null || !tsi_is_const_init(f.init)) {
+            errors := "[template_struct_instance] @template_constant field '{f.name}' of {st.name} must be initialized with a constant literal"
+            return false
+        }
+        rules |> replaceVariable(string(f.name)) <| clone_expression(f.init)
+        constIdx |> push(i)
+    }
+    for (i in range(length(constIdx))) {
+        st.fields |> erase(constIdx[length(constIdx) - 1 - i]) // reverse keeps indices valid
+    }
+    return true
+}
+
+[macro_function]
+def private tsi_stamp_methods(var st : StructurePtr; tem : StructurePtr; temMethods : array<FunctionPtr>; ownMethods : table<string>; var rules : Template; var errors : das_string) : bool {
+    if (empty(temMethods)) return true
+    let temName = string(tem.name)
+    let instName = string(st.name)
+    var mod = compiling_module()
+    // both spellings: inherited method-pointer field inits hold module-qualified @@_::Tem`m
+    for (func in temMethods) {
+        let fn = string(func.name)
+        let mname = tsi_method_name(func)
+        rules |> renameVariable(fn, "{instName}`{mname}")
+        rules |> renameVariable("_::{fn}", "_::{instName}`{mname}")
+    }
+    for (func in temMethods) {
+        let mname = tsi_method_name(func)
+        // skip ctor + '__finalize (the instance parser already made its own); instance-authored methods win
+        if (mname == temName || func.name == "{temName}'__finalize" || key_exists(ownMethods, mname)) {
+            continue
+        }
+        var fc <- clone_function(func)
+        fc.name := "{instName}`{mname}"
+        fc.moreFlags.isTemplate = false
+        fc.classParent = st
+        fc.result = apply_template(rules, func.at, clone_type(func.result))
+        for (arg in fc.arguments) {
+            arg._type = apply_template(rules, arg.at, clone_type(arg._type))
+        }
+        fc.body = apply_template(rules, func.at, clone_expression(func.body), false)
+        if (!(mod |> add_function(fc))) {
+            errors := "[template_struct_instance] can't add method {instName}`{mname}"
+            return false
+        }
+    }
+    return true
+}
+
+[macro_function]
+def private tsi_normalize_fields(var st : StructurePtr; var rules : Template) {
+    for (f in st.fields) {
+        f._type = apply_template(rules, f.at, clone_type(f._type))
+        if (f.init != null) {
+            f.init = apply_template(rules, f.at, clone_expression(f.init))
+        }
+        // the generated derived-class __finalize (cast<auto> init + parentType) resolves only through a live parent — we cut it, so normalize to the parentless shape
+        f.flags.parentType = false
+        if (f.name == "__finalize" && f.init != null && f.init is ExprCast) {
+            let c = f.init as ExprCast
+            if (c.castType != null && c.castType.baseType == Type.autoinfer) {
+                f.init = clone_expression(c.subexpr)
+            }
+        }
+    }
+}
+
+[structure_macro(name = "template_struct_instance")]
+class TemplateStructInstance : AstStructureAnnotation {
+    //! Reifies a ``struct template`` / ``class template`` parent into the annotated instance at parse time: instance ``typedef``s bind the template's type parameters, ``override`` inits bind its ``@template_constant`` fields (erased from the result), template methods are cloned onto the instance (instance-authored methods win), and the template parent is cut — every later structure annotation sees a finished concrete struct or class.
+    //! Put ``[|> template_struct_instance]`` on the template itself so every instance inherits the reifier ahead of its own annotations.
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (st.flags.isTemplate) {
+            return true // [|> ...] fires on the template itself: nothing to reify
+        }
+        if (st.parent == null || !st.parent.flags.isTemplate) {
+            errors := "[template_struct_instance] {st.name} must derive from a struct template or a class template"
+            return false
+        }
+        var tem = st.parent
+        var mod = compiling_module()
+        var temMethods, instMethods : array<FunctionPtr>
+        for_each_function(tem._module, "") $(func) {
+            if (func.flags.isClassMethod && func.classParent == tem) {
+                temMethods |> push(func)
+            }
+        }
+        for_each_function(mod, "") $(func) {
+            if (func.flags.isClassMethod && func.classParent == st && !func.flags.generated) {
+                instMethods |> push(func)
+            }
+        }
+        var ownMethods : table<string>
+        for (func in instMethods) {
+            ownMethods |> insert(tsi_method_name(func))
+        }
+        // no inscope: implicit delete of the lambda-holding Template needs unsafe; macro contexts free wholesale (ast_match pattern)
+        var rules : Template
+        var instType = new TypeDecl(at = st.at, baseType = Type.tStructure, structType = st)
+        rules |> replaceStructWithTypeDecl(tem) <| clone_type(instType)
+        rules |> replaceTypeWithTypeDecl(string(tem.name)) <| clone_type(instType)
+        if (!tsi_bind_aliases(st, temMethods, rules, errors)
+                || !tsi_bind_constants(st, rules, errors)
+                || !tsi_stamp_methods(st, tem, temMethods, ownMethods, rules, errors)) {
+            return false
+        }
+        for (func in instMethods) {
+            // constants + aliases substitute inside instance-authored bodies too
+            func.body = apply_template(rules, func.at, func.body, false)
+        }
+        tsi_normalize_fields(st, rules)
+        st.parent = tem.parent // cut the template out of the ancestry, keep its base (if any)
         return true
     }
 }

--- a/doc/source/reference/tutorials.rst
+++ b/doc/source/reference/tutorials.rst
@@ -211,6 +211,7 @@ Run any tutorial from the project root::
    tutorials/macros/17_qmacro.rst
    tutorials/macros/18_with_boost.rst
    tutorials/macros/19_add_module_option.rst
+   tutorials/macros/20_template_struct_instance.rst
 
 .. _tutorials_dashv:
 

--- a/doc/source/reference/tutorials/macros/19_add_module_option.rst
+++ b/doc/source/reference/tutorials/macros/19_add_module_option.rst
@@ -122,6 +122,8 @@ module is unnamed, so it reports as ``<main>``, with its three functions
 
    Previous tutorial: :ref:`tutorial_macro_with_boost`
 
+   Next tutorial: :ref:`tutorial_macro_template_struct_instance`
+
    Standard library: ``daslib/validate_code.das`` registers ``shader_like``
    the same way.
 

--- a/doc/source/reference/tutorials/macros/20_template_struct_instance.rst
+++ b/doc/source/reference/tutorials/macros/20_template_struct_instance.rst
@@ -140,6 +140,11 @@ in the object and nothing blocks inlining. Compare this with the
 already spells out, while a call parameter is open — a new instance can
 route to a function the template has never heard of.
 
+Only the bare spelling rebinds. ``_::dot_i(...)`` and ``__::dot_i(...)``
+keep their normal ``_`` / ``__`` resolution rules, so a template body that
+must reach the real ``dot_i`` no matter what an instance rebinds spells the
+call qualified.
+
 
 What the reifier does
 =====================

--- a/doc/source/reference/tutorials/macros/20_template_struct_instance.rst
+++ b/doc/source/reference/tutorials/macros/20_template_struct_instance.rst
@@ -21,7 +21,8 @@ An instance is just a class that inherits from the template:
 
 - a ``typedef`` inside the instance binds a type parameter;
 - an ``override`` of a ``@template_constant`` field binds a constant;
-- an instance method with ``def override`` replaces the template's method.
+- an instance method with ``def override`` replaces the template's method;
+- an ``override`` of a ``@template_call`` field redirects a free-function call.
 
 
 The template
@@ -72,8 +73,8 @@ Three things to notice:
   stamped and concrete.
 
 
-The three instance patterns
-===========================
+The four instance patterns
+==========================
 
 Full source: :download:`20_template_struct_instance.das <../../../../../tutorials/macros/20_template_struct_instance.das>`
 
@@ -107,6 +108,38 @@ Constants also fold inside field initializers and inside methods the instance
 writes itself — a ``@template_constant`` behaves like a per-instance
 compile-time value everywhere in the class body.
 
+The fourth pattern parameterizes a **free-function call**. The template calls
+a function by name; ``@template_call`` marks that name as rebindable — the
+field name is what the body spells, the init is where the call goes:
+
+.. code-block:: das
+
+    [ |> template_struct_instance]
+    class template public MixT {
+        acc : int = 0
+        @template_call dot_i = @@dot_i
+
+        def feed(a, b : int) {
+            acc += dot_i(a, b)
+        }
+    }
+
+    class MixPlain : MixT {         // dot_i calls stay on the real dot_i
+    }
+
+    class MixLoud : MixT {
+        override dot_i = @@dot_i_scaled
+    }
+
+``MixLoud`` redirects every ``dot_i(...)`` call — and every ``@@dot_i``
+address — to ``dot_i_scaled``. The value may also be a string
+(``override dot_i = "dot_i_scaled"``). Like a constant, the field is erased:
+the stamped class makes a plain direct call, so there is no function pointer
+in the object and nothing blocks inlining. Compare this with the
+``static_if`` route: a constant switch picks between branches the template
+already spells out, while a call parameter is open — a new instance can
+route to a function the template has never heard of.
+
 
 What the reifier does
 =====================
@@ -115,16 +148,20 @@ The macro runs at parse time, when the instance class is declared. It:
 
 1. binds every template alias to the instance's ``typedef`` declarations
    (module-level aliases stay untouched — only a genuinely unbound name is
-   an error);
+   an error; ``[ |> template_struct_instance(late_bind = true)]`` waives the
+   check for templates whose parameters another macro supplies later in the
+   compile);
 2. harvests every ``@template_constant`` value, replaces its reads with the
    literal, and erases the field;
-3. clones each template method onto the instance, retyping signatures and
+3. harvests every ``@template_call`` target and renames the matching calls
+   and ``@@`` addresses, erasing the field;
+4. clones each template method onto the instance, retyping signatures and
    bodies, skipping methods the instance defines itself;
-4. cuts the template out of the instance's ancestry. If the template itself
+5. cuts the template out of the instance's ancestry. If the template itself
    derives from a concrete base class, the instance keeps that base — normal
    inheritance, upcasts, and virtual dispatch through the base still work.
 
-After step 4 the instance is an ordinary class. Anything that inspects it
+After step 5 the instance is an ordinary class. Anything that inspects it
 later — other structure annotations, RTTI, AOT — sees plain concrete code.
 
 
@@ -136,6 +173,8 @@ Output
     FloatTop:  kept 3.25 out of 3
     IntLatest: kept 7 out of 3
     IntShouty: BEST 10 OF 3!
+    MixPlain:  acc=6
+    MixLoud:   acc=600
 
 
 .. seealso::

--- a/doc/source/reference/tutorials/macros/20_template_struct_instance.rst
+++ b/doc/source/reference/tutorials/macros/20_template_struct_instance.rst
@@ -1,0 +1,154 @@
+.. _tutorial_macro_template_struct_instance:
+
+.. index::
+   single: Tutorial; Macros; template_struct_instance
+   single: Tutorial; Macros; reification
+   single: Tutorial; Macros; class template
+
+====================================================
+ Macro Tutorial 20: Template struct/class instances
+====================================================
+
+A family of similar classes — same shape, different element type, a couple of
+small behavior switches — usually ends up as copy-paste. daslang has a
+``class template`` / ``struct template`` grammar for the shared body, and
+``[template_struct_instance]`` from ``daslib/typemacro_boost`` turns that body
+into concrete classes. Each stamped copy gets its own types, its own constant
+values, and its own method set, with nothing shared at runtime — this stamping
+is called **reification**.
+
+An instance is just a class that inherits from the template:
+
+- a ``typedef`` inside the instance binds a type parameter;
+- an ``override`` of a ``@template_constant`` field binds a constant;
+- an instance method with ``def override`` replaces the template's method.
+
+
+The template
+============
+
+Full source: :download:`template_struct_instance_mod.das <../../../../../tutorials/macros/template_struct_instance_mod.das>`
+
+.. code-block:: das
+
+    [ |> template_struct_instance]
+    class template public TopKeeperT {
+        best : KT
+        n : int = 0
+        @template_constant KEEP_LATEST : bool = false
+
+        def feed(v : KT) {
+            if (n == 0) {
+                best = v
+            } else {
+                static_if (KEEP_LATEST) {
+                    best = v
+                } else {
+                    if (v > best) {
+                        best = v
+                    }
+                }
+            }
+            n++
+        }
+        def report : string {
+            return "kept {best} out of {n}"
+        }
+    }
+
+Three things to notice:
+
+- ``KT`` is not declared anywhere. An unresolved name in type position is a
+  **type parameter** — every instance must bind it with a ``typedef``, and the
+  macro reports the missing name if one forgets.
+- ``@template_constant`` marks ``KEEP_LATEST`` as a **constant parameter**.
+  Instances pick its value with ``override``; the field itself is erased from
+  every stamped class, and each use site gets the value as a literal.
+- ``[|> template_struct_instance]`` — the ``|>`` prefix marks the annotation
+  as **inherited**: the parser copies it onto every class that derives from
+  the template, ahead of that class's own annotations. Instances write no
+  macro boilerplate at all, and any annotation an instance does carry (a
+  dispatch or codegen macro, for example) runs after the class is already
+  stamped and concrete.
+
+
+The three instance patterns
+===========================
+
+Full source: :download:`20_template_struct_instance.das <../../../../../tutorials/macros/20_template_struct_instance.das>`
+
+.. code-block:: das
+
+    class FloatTop : TopKeeperT {       // 1. type parameter
+        typedef KT = float
+    }
+
+    class IntLatest : TopKeeperT {      // 2. constant parameter
+        typedef KT = int
+        override KEEP_LATEST = true
+    }
+
+    class IntShouty : TopKeeperT {      // 3. method override
+        typedef KT = int
+
+        def override report : string {
+            return "BEST {best} OF {n}!"
+        }
+    }
+
+``FloatTop`` takes everything from the template: ``KEEP_LATEST`` stays
+``false`` and ``feed`` keeps the maximum. ``IntLatest`` flips the constant —
+the ``static_if`` folds during compilation, so its stamped ``feed`` carries
+the "keep the latest value" body and no branch. ``IntShouty`` replaces
+``report``; the template's other methods call the replacement, resolved at
+stamp time with no virtual dispatch left over.
+
+Constants also fold inside field initializers and inside methods the instance
+writes itself — a ``@template_constant`` behaves like a per-instance
+compile-time value everywhere in the class body.
+
+
+What the reifier does
+=====================
+
+The macro runs at parse time, when the instance class is declared. It:
+
+1. binds every template alias to the instance's ``typedef`` declarations
+   (module-level aliases stay untouched — only a genuinely unbound name is
+   an error);
+2. harvests every ``@template_constant`` value, replaces its reads with the
+   literal, and erases the field;
+3. clones each template method onto the instance, retyping signatures and
+   bodies, skipping methods the instance defines itself;
+4. cuts the template out of the instance's ancestry. If the template itself
+   derives from a concrete base class, the instance keeps that base — normal
+   inheritance, upcasts, and virtual dispatch through the base still work.
+
+After step 4 the instance is an ordinary class. Anything that inspects it
+later — other structure annotations, RTTI, AOT — sees plain concrete code.
+
+
+Output
+======
+
+.. code-block:: text
+
+    FloatTop:  kept 3.25 out of 3
+    IntLatest: kept 7 out of 3
+    IntShouty: BEST 10 OF 3!
+
+
+.. seealso::
+
+   Full source:
+   :download:`20_template_struct_instance.das <../../../../../tutorials/macros/20_template_struct_instance.das>`,
+   :download:`template_struct_instance_mod.das <../../../../../tutorials/macros/template_struct_instance_mod.das>`
+
+   Previous tutorial: :ref:`tutorial_macro_add_module_option`
+
+   Related: :ref:`Macro Tutorial 16 <tutorial_macro_template_type_macro>` —
+   ``[template_structure]`` generates parameterized structs from type-position
+   macros; this tutorial's annotation serves the inheritance-spelled,
+   annotation-driven case.
+
+   Language reference: :ref:`Macros <macros>` — full macro system documentation

--- a/plans/template-class-instance.md
+++ b/plans/template-class-instance.md
@@ -146,6 +146,13 @@ Landed deltas vs the stage-0 spec (each probe-verified):
   pre-fold; `tsi_is_const_init` peels one unary `+`/`-`).
 - **`KT(1)`-style ctor-casts in template bodies need no rule** — infer resolves
   call-position alias names through the instance's structure aliases (probe-verified).
+- **`late_bind = true`** (decision 4) — annotation argument on the template, rides the
+  inherited copy down to every instance; test arm binds KT from a sibling structure
+  annotation that runs after the reifier.
+- **`@template_call`** (decision 5) — harvest mirrors `@template_constant`
+  (validate `@@name`/string init, `renameCall` rule, erase field, slot-vs-method-name
+  collision check); tests cover default, `@@` rebind, string rebind, and `@@` address
+  targets through a function-pointer taker; negative fixture for a non-callee init.
 
 Tests (`tests/typemacro/`, 25/25 green interp AND `-jit`; AOT emits folded bodies —
 `ToyNarrow`gated` compiles to `return x + 100`): `test_template_struct_instance.das`
@@ -197,6 +204,20 @@ before the `skills/make_pr.md` checklist:
    class-flavored name yet. When class-flavored template macros show up, we add
    `template_class_instance` alongside.
 3. Stage-1 GO given.
+4. Unbound-alias check: keep the eager named error by default;
+   `[ |> template_struct_instance(late_bind = true)]` on the template waives it for
+   macro-supplied parameters (option D). Probe round proved: natural resolution covers
+   signatures/bodies/fields on the clones (no rules needed), a `[dirty_infer_macro]`
+   can bind an alias mid-infer (NOT `[infer_macro]` — that one runs only on a clean
+   tree), and `finish`/`patch` never fire for a failed struct, so a deferred named
+   error is impossible — the opt-out knob is the only way to keep the good message.
+5. Call-parameter axis (`@template_call`, IMPLEMENTED same round): the field name is
+   what template bodies call, the init (`@@name` or string) is the default target,
+   instances redirect with `override sdot = @@ssdot`. Rides the rules engine's
+   existing `renameCall`/call2name, which rewrites calls AND `@@` address targets —
+   erased like a constant, direct call in the stamped class. Replaces the closed-set
+   `static_if` route for callee selection with an open one (a new instance can route
+   to a function the template never names).
 
 ## Stage 2 pointer (not planned here)
 

--- a/plans/template-class-instance.md
+++ b/plans/template-class-instance.md
@@ -1,0 +1,161 @@
+# `[template_class_instance]` — class-template reification (stamped instances)
+
+Boris + Claude, 2026-08-08. **Stage 0 (probes) DONE — results below.** Stage 1 = the
+daslib + C++ implementation, tests, tutorial (daslib-only, nothing metal/llama). Stage 2 =
+the dasLLAMA kernel restamp, planned separately once stage 1 lands; its worklist is the
+reification cluster table in `plans/vulkan-on-mac.md` (SqAttn 23→~6 first, then KqMv,
+MulMm/MoeMulMm with followup_general #8's A/B measurement discipline, RopeStore).
+
+## The idea
+
+A `class template` (existing grammar) is the shared body; an instance is an ordinary class
+that inherits from it. The reifier — a structure macro — flattens the template into the
+instance at parse time with substitutions, so every instance gets its OWN specialized copy
+of the methods (types baked, constants folded, no virtual hops), and every downstream
+structure annotation (`[metal_dispatch]` and friends) sees a finished concrete class.
+
+```das
+[|> template_class_instance]                  // rides down to every instance, prepended
+class template MoeMulMmT {
+    @ssbo @binding = 3 @role = "read" xf : array<float4>
+    @workgroup ta : KT[2048]                  // KT: unresolved alias = type parameter
+    @template_const WIDE : bool = true        // constant parameter, erased at reify
+    def run {
+        static_if (WIDE) { ... } else { ... } // folds per instance, in infer, for free
+        stage_a(wb, kb, il0, tA0)
+    }
+}
+
+[metal_dispatch(name = "enc_moe_mulmm_k4", pso = "g_moe_mulmm_k4_pso", tg = 64, ...)]
+class MetalMoeMulMmK4 : MoeMulMmT {
+    typedef KT = float16                      // binds the type parameter (full type grammar)
+    override WIDE = false                     // binds the constant (init replacement)
+    @ssbo @binding = 0 @role = "weight" ksh : array<float16>
+    def override stage_a(wb, kb, il0, tA0 : uint) { ... }   // instance body wins
+    [metal_kernel(name = "metal_moe_mulmm_k4_msl")]
+    def metal_moe_mulmm_k4 { run() }
+}
+```
+
+Covers the four dedup axes from the vulkan-on-mac peek with one mechanism: type axis →
+typedef; small format delta → `static_if` on a const; big delta → instance method override;
+pass axis → the already-landed `kernel=` multi-kernel. Dissolves followup_general #8's
+blockers by construction (the whole stamped body is the instance's — K6's cross-iteration
+scalars and Q8's advancing pointers live inline; Mx4's prologue is its own `run`).
+
+## Stage 0 — probe results (2026-08-08, this M1, bin/daslang @ bbatkin/profiling-rail)
+
+Everything below is witnessed, not inferred. Probe files lived in the job scratch dir
+(gone with the job); the mini-reifier probe is the stage-1 skeleton and is reproduced by
+the stage-1 implementation itself.
+
+GREEN — proven and load-bearing for the design:
+
+1. **Structure-annotation `apply` runs at parse time, in written order, sequentially**
+   (`parser_impl.cpp:492`); a later macro sees an earlier macro's mutations (added fields
+   visible). The "one macro only" restriction is for handled-type annotations, not
+   structure macros.
+2. **`[|> name]` (RPIPE prefix, `ds2_parser.ypp:1331`) marks an annotation inherited**:
+   copied to every child down the parent chain, PREPENDED before the child's own
+   annotations (`parser_impl.cpp:473-490`) — so the reifier always runs before the
+   instance's dispatch/lens annotations, and instances write zero reifier boilerplate.
+   It also fires on the template itself; `st.flags.isTemplate` is the discriminator.
+3. **`typedef NAME = <type>` inside a struct/class body is existing grammar**
+   (`ds2_parser.ypp:2601` → structure alias). Visible via `get_structure_alias` at apply
+   time; infer resolves inherited alias-typed fields against the owning struct's aliases
+   (the qmacro_template_class mechanism) — the type axis needs no field rewriting.
+4. **`override WIDE = false` parses bare** (no type respell) and replaces the inherited
+   field's init (`parser_impl.cpp:446-464` — the error message even says "use override to
+   replace initial value instead"). Constants ride the class body, per Boris's call.
+5. **Parent fields are already merged into the child at parse** (marked `inherited`,
+   `parser_impl.cpp:374`), including fields a macro added to the template earlier.
+6. **The Template rules engine does everything the reifier needs pre-infer**: bare field
+   reads inside class-method bodies are `ExprVar`s under the parser's `with(self)` wrap,
+   so `replaceVariable("WIDE", <init-clone>)` hits them; `replaceStructWithTypeDecl` +
+   `replaceTypeWithTypeDecl` retype signatures; `renameVariable` must be added in BOTH
+   spellings (`Tem`m` and `_::Tem`m`) because inherited method-pointer field inits hold
+   module-qualified `@@_::Tem`m` targets — same as `apply_qmacro_template_class:1401`.
+   Witnessed: a cloned body carrying `static_if(false)` with the substituted literal.
+7. **Method clone + rename + classParent retarget + field-init repair all work** with the
+   existing machinery (`clone_function`, `apply_template`, `add_function`); the child's
+   own `def override` methods win (skip-if-owned); the ctor and the `'`-spelled
+   `Tem'__finalize` are skipped (the child parser already generated its own).
+8. **Struct rail is FULLY GREEN end-to-end**: reify + const-field erase
+   (`st.fields |> erase(i)` works) + `parent = null` + correct runtime values. Clearing
+   parent also sidesteps the debug-info verify `!st.isTemplate`
+   (`ast_debug_info_helper.cpp:188`) that a kept template-parent trips.
+9. **`static_if` needs NO reifier folding** (Boris's position, now with evidence): MSL
+   emission runs at the `fixup` annotation stage (`msl_shader.das` → `generate_msl`) —
+   post-infer, after `visit(ExprIfThenElse)` has already folded static branches
+   (`ast_infer_type.cpp:4793`). The emitter only ever sees the taken branch. Residual
+   stage-2 note only: the metal lens derives roles pre-infer and would see BOTH branches
+   (union roles — conservative); revisit only if a real family over-declares.
+
+RED — the one genuine gap, C++-side, small and well-bounded:
+
+10. **Deriving from a `class template` always leaves the TEMPLATE's own generated
+    machinery unresolved.** `makeClassRtti`/`makeClassFinalize` run unconditionally on
+    `isClass` (`parser_impl.cpp:366`) — including templates — and infer's
+    `visitStructureField` processes template structs, so the template's
+    `__finalize : auto = cast<auto> @@Tem'__finalize` init can never resolve (the
+    finalizer body references unbound aliases) → `error[30805]` anchored at the template,
+    reported at final verify. A standalone template is inert; a derived-from one is not.
+    ⚠ Probe trap worth recording: runs where an UNRELATED error fired earlier looked
+    "green" for the class rail — compilation stopped before final verify. Two probe
+    variants differing only by the erroring line proved the masking. Never certify a
+    macro rail green while any other error is present.
+
+## Stage 1 — daslib + C++ implementation
+
+C++ (contained):
+- Make template classes inference-inert, mirroring template functions: skip
+  `visitStructureField` (and the struct's init/layout verification) for
+  `st->isTemplate`, or mark the generated finalizer/rtti template-flagged when the
+  structure is a template. Acceptance: the class-rail probe shape compiles green with the
+  das-side reifier; a standalone `class template` stays green; existing
+  `tests/typemacro/_template_structure_class_mod.das` (typemacro rail) unaffected.
+- Keep the debug-info `!st.isTemplate` verify — unreachable post-reify (parent cleared).
+
+daslib (`[template_class_instance]`, typemacro_boost family, knows nothing of metal):
+- The probe macro is the skeleton (~120 lines). Generalizations over the probe:
+  enumerate the template's unresolved alias names by walking its field/method types
+  (probe hardcoded "KT"); each must be bound by an instance typedef or `errors :=` names
+  the missing one. Constants = template fields marked `@template_const`: take the
+  instance's (possibly overridden) init, require it literal/const-foldable, add the
+  `replaceVariable` rule, erase the field. Clone loop: collect-then-add, skip ctor +
+  `'__finalize` + instance-owned names, both rename spellings, repair every field type +
+  init through the rules, then `parent = null`.
+- Struct twin: same implementation; `isClass` discriminates the (absent) rtti/finalize
+  handling. Whether it registers as a second name `[template_struct_instance]` or one
+  name serves both = Boris's naming call.
+- The typemacro rail (`[template_structure]`, `[template_tuple]`) stays untouched — it
+  serves the type-position/container use case; this serves the annotation-driven one.
+
+Tests (`tests/typemacro/`): struct rail green today — land those with the macro; class
+rail lands with the C++ fix. Negative fixtures: unbound alias → named error; parent not a
+template → error; `@template_const` init not a literal → error; instance field-name
+collision with a template field → error. Plus an override-wins arm, a two-instance arm
+(same template stamped twice in one module), and a cross-module arm (template in a
+required module).
+
+Docs: tutorial chapter under `tutorials/macros/` (the concept deserves one — Boris);
+`skills/das_macros.md` gains the `[|>` inherited-annotation fact (done, this session);
+doc-comment surface per `skills/daslib_modules.md` when the macro lands.
+
+## Decisions needed (Boris)
+
+1. `@template_const` explicit marking (recommended: greppable, and "force it's a
+   constant" has a place to hang the diagnostic) vs implicit "any overridden literal
+   field is a constant".
+2. One annotation name for both class and struct rails, or the
+   `template_class_instance` / `template_struct_instance` pair.
+3. Stage-1 go.
+
+## Stage 2 pointer (not planned here)
+
+dasLLAMA restamp per the cluster table (`plans/vulkan-on-mac.md`): SqAttn first
+(typedef-only, 23→~6), KqMv (const stamp), then MulMm/MoeMulMm — where followup_general
+#8's constraints apply verbatim: every route rewrites hot inner loops, so interleaved A/B
+per format, oracles cover correctness only; Q8/Mx4 joining renumbers cnt/basep/bkt
+6/7/8 → 7/8/9 (encoder + oracle churn accepted once). MoeGemv stays inheritance (its
+dedup is genuinely is-a). The 96 unlensed classes ride the same wave as lens adoption.

--- a/plans/template-class-instance.md
+++ b/plans/template-class-instance.md
@@ -149,6 +149,28 @@ Docs: tutorial chapter under `tutorials/macros/` (the concept deserves one — B
 `skills/das_macros.md` gains the `[|>` inherited-annotation fact (done, this session);
 doc-comment surface per `skills/daslib_modules.md` when the macro lands.
 
+## Stage-1 pre-PR rail (Boris, 2026-08-08: expect bulk lint, don't be surprised by it)
+
+The macro + tests + tutorial touch enough files that lint fires in bulk. In order,
+before the `skills/make_pr.md` checklist:
+
+1. **Fresh branch off latest master** (verify base == master; the stage-0 doc commits
+   ride along — they currently sit on the merged `bbatkin/vulkan-on-mac` branch and get
+   cherry-picked or land via master first).
+2. **Full lint sweep, both flavors**: MCP `lint` per changed file AND the CI
+   linux-flavor mirror (MCP lint ≠ CI lint) — put the whole finding set on the table
+   before any fix.
+3. **Fan out Opus agents over the findings** — one per file or rule-family, each under
+   the house discipline: fix the root cause; STYLE037/038 split only along a natural
+   seam, else `// nolint` with a tail-comment reason on the `def` line; lint TOOL bugs
+   get fixed, not worked around; no blanket suppressions. Merge, re-lint to zero.
+4. **Known pressure points from the stage-0 skeleton** (write these right at authoring
+   time, so the agents handle only residue): the single ~130-line `apply` trips
+   STYLE037/038 — factor into `[macro_function]` helpers from the start (alias
+   enumeration, const harvest, method cloning, generated-field normalization); plus
+   LINT003 let-vs-var, PERF007 das_string compares, PERF017 `empty()`, STYLE016 guard
+   merges — all already observed on the probe.
+
 ## Decisions needed (Boris)
 
 1. `@template_const` explicit marking (recommended: greppable, and "force it's a

--- a/plans/template-class-instance.md
+++ b/plans/template-class-instance.md
@@ -1,7 +1,7 @@
 # `[template_class_instance]` — class-template reification (stamped instances)
 
-Boris + Claude, 2026-08-08. **Stage 0 (probes) DONE — results below.** Stage 1 = the
-daslib + C++ implementation, tests, tutorial (daslib-only, nothing metal/llama). Stage 2 =
+Boris + Claude, 2026-08-08. **Stage 0 (probes) DONE — results below; zero C++ changes
+needed.** Stage 1 = the daslib implementation, tests, tutorial (nothing metal/llama). Stage 2 =
 the dasLLAMA kernel restamp, planned separately once stage 1 lands; its worklist is the
 reification cluster table in `plans/vulkan-on-mac.md` (SqAttn 23→~6 first, then KqMv,
 MulMm/MoeMulMm with followup_general #8's A/B measurement discipline, RopeStore).
@@ -91,40 +91,47 @@ GREEN — proven and load-bearing for the design:
    stage-2 note only: the metal lens derives roles pre-infer and would see BOTH branches
    (union roles — conservative); revisit only if a real family over-declares.
 
-RED — the one genuine gap, C++-side, small and well-bounded:
+RESOLVED — what looked like a C++ gap was the reifier's own bug (Boris's push-back on
+"small C++ change" forced the trace that found it):
 
-10. **Deriving from a `class template` always leaves the TEMPLATE's own generated
-    machinery unresolved.** `makeClassRtti`/`makeClassFinalize` run unconditionally on
-    `isClass` (`parser_impl.cpp:366`) — including templates — and infer's
-    `visitStructureField` processes template structs, so the template's
-    `__finalize : auto = cast<auto> @@Tem'__finalize` init can never resolve (the
-    finalizer body references unbound aliases) → `error[30805]` anchored at the template,
-    reported at final verify. A standalone template is inert; a derived-from one is not.
+10. **Templates are ALREADY fully inference-inert by existing design** — no C++ change
+    needed. `canVisitStructure` skips `isTemplate` structs outright
+    (`ast_infer_type.cpp:277`), `canVisitFunction` skips template functions (`:671`),
+    parsed template-class methods are auto-flagged (`ds2_parser.ypp:2635`), and
+    `makeClassFinalize` marks the template's own finalizer
+    `func->isTemplate = baseClass->isTemplate` (`ast_generate.cpp:2258`).
+    The real 30805: `makeClassFinalize` gives a DERIVED class's `__finalize` field the
+    with-parent shape — `cast<auto>(@@Cls'__finalize)` init + `parentType` flag
+    (`ast_generate.cpp:2233`) — which resolves ONLY through a live parent
+    (`visitStructureField`'s `decl.parentType && st->parent` path,
+    `ast_infer_type.cpp:331`). The reifier cut the parent and left that shape orphaned:
+    no resolution path, `cast<auto>` reported at final verify, anchored at whatever
+    LineInfo the inherited copy carried (template's or child's — which misled the first
+    diagnosis). The fix is IN THE REIFIER, ~8 lines: when clearing `parent`, normalize
+    generated fields to the parentless shape `makeClassFinalize` itself produces
+    (`ast_generate.cpp:2239`) — strip the `cast<auto>` from `__finalize`'s init to the
+    bare `@@fn`, and clear `flags.parentType` on every field. With that, the ENTIRE
+    previously-red matrix is green with exact runtime values (`plain=42 gated=142
+    doubled=840`): same-module and cross-module templates, 1 and 2 clones, override
+    arms, used and unused instances, struct and class rails.
     ⚠ Probe trap worth recording: runs where an UNRELATED error fired earlier looked
     "green" for the class rail — compilation stopped before final verify. Two probe
     variants differing only by the erroring line proved the masking. Never certify a
     macro rail green while any other error is present.
 
-## Stage 1 — daslib + C++ implementation
-
-C++ (contained):
-- Make template classes inference-inert, mirroring template functions: skip
-  `visitStructureField` (and the struct's init/layout verification) for
-  `st->isTemplate`, or mark the generated finalizer/rtti template-flagged when the
-  structure is a template. Acceptance: the class-rail probe shape compiles green with the
-  das-side reifier; a standalone `class template` stays green; existing
-  `tests/typemacro/_template_structure_class_mod.das` (typemacro rail) unaffected.
-- Keep the debug-info `!st.isTemplate` verify — unreachable post-reify (parent cleared).
+## Stage 1 — daslib implementation (no C++ changes required)
 
 daslib (`[template_class_instance]`, typemacro_boost family, knows nothing of metal):
-- The probe macro is the skeleton (~120 lines). Generalizations over the probe:
-  enumerate the template's unresolved alias names by walking its field/method types
-  (probe hardcoded "KT"); each must be bound by an instance typedef or `errors :=` names
-  the missing one. Constants = template fields marked `@template_const`: take the
-  instance's (possibly overridden) init, require it literal/const-foldable, add the
-  `replaceVariable` rule, erase the field. Clone loop: collect-then-add, skip ctor +
-  `'__finalize` + instance-owned names, both rename spellings, repair every field type +
-  init through the rules, then `parent = null`.
+- The probe macro is the skeleton (~130 lines, ran the full matrix green; appendix
+  below). Generalizations over the probe: enumerate the template's unresolved alias
+  names by walking its field/method types (probe hardcoded "KT"); each must be bound by
+  an instance typedef or `errors :=` names the missing one. Constants = template fields
+  marked `@template_const`: take the instance's (possibly overridden) init, require it
+  literal/const-foldable, add the `replaceVariable` rule, erase the field. Clone loop:
+  collect-then-add, skip ctor + `'__finalize` + instance-owned names, both rename
+  spellings (`Tem`m` and `_::Tem`m`), repair every field type + init through the rules,
+  normalize `__finalize` to the parentless shape + clear `flags.parentType` (finding 10),
+  then `parent = null`.
 - Struct twin: same implementation; `isClass` discriminates the (absent) rtti/finalize
   handling. Whether it registers as a second name `[template_struct_instance]` or one
   name serves both = Boris's naming call.
@@ -159,3 +166,105 @@ dasLLAMA restamp per the cluster table (`plans/vulkan-on-mac.md`): SqAttn first
 per format, oracles cover correctness only; Q8/Mx4 joining renumbers cnt/basep/bkt
 6/7/8 → 7/8/9 (encoder + oracle churn accepted once). MoeGemv stays inheritance (its
 dedup is genuinely is-a). The 96 unlensed classes ride the same wave as lens adoption.
+
+## Appendix — the stage-0 reifier skeleton (matrix-green verbatim, minus probe prints)
+
+Hardcodes one alias ("KT") and one const ("WIDE") — stage 1 generalizes exactly those
+two spots. Ran green: same-module + cross-module class templates, struct templates,
+override arms, multi-clone, used/unused instances.
+
+```das
+[structure_macro(name = "tci_probe")]
+class TciProbe : AstStructureAnnotation {
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (st.flags.isTemplate) return true // on the template itself: nothing to do
+        if (st.parent == null || !st.parent.flags.isTemplate) {
+            errors := "parent is not a class template"
+            return false
+        }
+        var tem = st.parent
+        let temName = string(tem.name)
+        let instName = string(st.name)
+        var mod = compiling_module()
+        var instType = new TypeDecl(at = st.at, baseType = Type.tStructure, structType = st)
+        var kt = get_structure_alias(st, "KT")               // stage 1: enumerate template aliases
+        var wideInit : ExpressionPtr                          // stage 1: fields marked @template_const
+        var wideIdx = -1
+        for (i in range(length(st.fields))) {
+            if (st.fields[i].name == "WIDE") {
+                wideInit = st.fields[i].init
+                wideIdx = i
+            }
+        }
+        var ownMethods : table<string>                        // instance-authored methods win
+        for_each_function(mod, "", $(func) {
+            if (func.flags.isClassMethod && func.classParent == st) {
+                var parts <- split(string(func.name), "`")
+                ownMethods |> insert(parts[length(parts) - 1])
+            }
+        })
+        var rules : Template
+        rules |> replaceStructWithTypeDecl(tem) <| clone_type(instType)
+        rules |> replaceTypeWithTypeDecl(temName) <| clone_type(instType)
+        rules |> replaceTypeWithTypeDecl("KT") <| clone_type(kt)
+        rules |> replaceVariable("WIDE") <| clone_expression(wideInit)
+        for_each_function(tem._module, "", $(func) {          // both rename spellings: field
+            if (func.flags.isClassMethod && func.classParent == tem) {   // inits hold @@_::Tem`m
+                let fn = string(func.name)
+                var parts <- split(fn, "`")
+                let mname = parts[length(parts) - 1]
+                rules |> renameVariable(fn, "{instName}`{mname}")
+                rules |> renameVariable("_::{fn}", "_::{instName}`{mname}")
+            }
+        })
+        var toClone : array<FunctionPtr>                      // collect THEN add
+        for_each_function(tem._module, "", $(func) {
+            if (!(func.flags.isClassMethod && func.classParent == tem)) return
+            let fn = string(func.name)
+            var parts <- split(fn, "`")
+            let mname = parts[length(parts) - 1]
+            if (mname == temName || fn == "{temName}'__finalize" || key_exists(ownMethods, mname)) {
+                return // ctor + 'finalize (quote spelling): instance has its own; overrides win
+            }
+            toClone |> push(func)
+        })
+        for (func in toClone) {
+            var parts <- split(string(func.name), "`")
+            let mname = parts[length(parts) - 1]
+            var fc <- clone_function(func)
+            fc.name := "{instName}`{mname}"
+            fc.moreFlags.isTemplate = false
+            fc.classParent = st
+            fc.result = apply_template(rules, func.at, clone_type(func.result))
+            for (arg in fc.arguments) {
+                arg._type = apply_template(rules, arg.at, clone_type(arg._type))
+            }
+            fc.body = apply_template(rules, func.at, clone_expression(func.body), false)
+            if (!(mod |> add_function(fc))) {
+                errors := "can't add {instName}`{mname}"
+            }
+        }
+        for (f in st.fields) {                                // repair fields through the rules
+            f._type = apply_template(rules, f.at, clone_type(f._type))
+            if (f.init != null) {
+                f.init = apply_template(rules, f.at, clone_expression(f.init))
+            }
+            // derived-class generated __finalize has the with-parent shape (cast<auto> init +
+            // parentType, ast_generate.cpp:2233) resolvable only through a live parent; we cut
+            // the parent, so normalize to the parentless shape (ibid:2239): bare @@fn, no flag
+            f.flags.parentType = false
+            if (f.name == "__finalize" && f.init != null && f.init is ExprCast) {
+                let c = f.init as ExprCast
+                if (c.castType != null && c.castType.baseType == Type.autoinfer) {
+                    f.init = clone_expression(c.subexpr)
+                }
+            }
+        }
+        if (wideIdx >= 0) {
+            st.fields |> erase(wideIdx)                       // consts never become fields
+        }
+        st.parent = null
+        return true
+    }
+}
+```

--- a/plans/template-class-instance.md
+++ b/plans/template-class-instance.md
@@ -1,7 +1,9 @@
-# `[template_class_instance]` — class-template reification (stamped instances)
+# `[template_struct_instance]` — template reification (stamped instances)
 
-Boris + Claude, 2026-08-08. **Stage 0 (probes) DONE — results below; zero C++ changes
-needed.** Stage 1 = the daslib implementation, tests, tutorial (nothing metal/llama). Stage 2 =
+Boris + Claude, 2026-08-07. **Stage 0 (probes) DONE — results below; zero C++ changes
+needed. Stage 1 IMPLEMENTED 2026-08-07 on `bbatkin/template-struct-instance` (macro +
+tests + tutorial, all green; landed deltas below).** Naming + const-marking ruled (see
+Decisions). Stage 2 =
 the dasLLAMA kernel restamp, planned separately once stage 1 lands; its worklist is the
 reification cluster table in `plans/vulkan-on-mac.md` (SqAttn 23→~6 first, then KqMv,
 MulMm/MoeMulMm with followup_general #8's A/B measurement discipline, RopeStore).
@@ -15,11 +17,11 @@ of the methods (types baked, constants folded, no virtual hops), and every downs
 structure annotation (`[metal_dispatch]` and friends) sees a finished concrete class.
 
 ```das
-[|> template_class_instance]                  // rides down to every instance, prepended
+[|> template_struct_instance]                 // rides down to every instance, prepended
 class template MoeMulMmT {
     @ssbo @binding = 3 @role = "read" xf : array<float4>
     @workgroup ta : KT[2048]                  // KT: unresolved alias = type parameter
-    @template_const WIDE : bool = true        // constant parameter, erased at reify
+    @template_constant WIDE : bool = true     // constant parameter, erased at reify
     def run {
         static_if (WIDE) { ... } else { ... } // folds per instance, in infer, for free
         stage_a(wb, kb, il0, tA0)
@@ -43,7 +45,7 @@ pass axis → the already-landed `kernel=` multi-kernel. Dissolves followup_gene
 blockers by construction (the whole stamped body is the instance's — K6's cross-iteration
 scalars and Q8's advancing pointers live inline; Mx4's prologue is its own `run`).
 
-## Stage 0 — probe results (2026-08-08, this M1, bin/daslang @ bbatkin/profiling-rail)
+## Stage 0 — probe results (2026-08-07, this M1, bin/daslang @ bbatkin/profiling-rail)
 
 Everything below is witnessed, not inferred. Probe files lived in the job scratch dir
 (gone with the job); the mini-reifier probe is the stage-1 skeleton and is reproduced by
@@ -119,35 +121,50 @@ RESOLVED — what looked like a C++ gap was the reifier's own bug (Boris's push-
     variants differing only by the erroring line proved the masking. Never certify a
     macro rail green while any other error is present.
 
-## Stage 1 — daslib implementation (no C++ changes required)
+## Stage 1 — daslib implementation (LANDED; no C++ changes)
 
-daslib (`[template_class_instance]`, typemacro_boost family, knows nothing of metal):
-- The probe macro is the skeleton (~130 lines, ran the full matrix green; appendix
-  below). Generalizations over the probe: enumerate the template's unresolved alias
-  names by walking its field/method types (probe hardcoded "KT"); each must be bound by
-  an instance typedef or `errors :=` names the missing one. Constants = template fields
-  marked `@template_const`: take the instance's (possibly overridden) init, require it
-  literal/const-foldable, add the `replaceVariable` rule, erase the field. Clone loop:
-  collect-then-add, skip ctor + `'__finalize` + instance-owned names, both rename
-  spellings (`Tem`m` and `_::Tem`m`), repair every field type + init through the rules,
-  normalize `__finalize` to the parentless shape + clear `flags.parentType` (finding 10),
-  then `parent = null`.
-- Struct twin: same implementation; `isClass` discriminates the (absent) rtti/finalize
-  handling. Whether it registers as a second name `[template_struct_instance]` or one
-  name serves both = Boris's naming call.
-- The typemacro rail (`[template_structure]`, `[template_tuple]`) stays untouched — it
-  serves the type-position/container use case; this serves the annotation-driven one.
+Home: `daslib/typemacro_boost.das`, beside its named siblings `[template_structure]` /
+`[template_tuple]` (the file already requires templates_boost publicly). The apply is
+factored into `[macro_function]` helpers (`tsi_bind_aliases` / `tsi_is_const_init` /
+`tsi_bind_constants` / `tsi_stamp_methods` / `tsi_normalize_fields`), per the pre-PR
+rail's STYLE037/038 pre-scoping. One name serves both rails; the typemacro rail stays
+untouched.
 
-Tests (`tests/typemacro/`): struct rail green today — land those with the macro; class
-rail lands with the C++ fix. Negative fixtures: unbound alias → named error; parent not a
-template → error; `@template_const` init not a literal → error; instance field-name
-collision with a template field → error. Plus an override-wins arm, a two-instance arm
-(same template stamped twice in one module), and a cross-module arm (template in a
-required module).
+Landed deltas vs the stage-0 spec (each probe-verified):
+- **`st.parent = tem.parent`, not `null`** — a `class template X : ConcreteBase` keeps
+  its base in the stamped instance (upcast + dispatch-through-base green); same move as
+  `apply_qmacro_template_class:1355`. The `__finalize` parentless-shape normalization
+  works under a live grandparent too.
+- **Rules also run over instance-authored method bodies** (in place, no clone) — a
+  `@template_constant` read inside a `def override` body substitutes like everywhere
+  else; constants behave as class-wide compile-time values.
+- **Unbound-alias check counts module-level typedefs as bound** (walks
+  `for_each_typedef` across the program library) — a field typed by an ordinary module
+  alias no longer false-positives; only a genuinely unbindable parameter gets the named
+  error, listing every missing name.
+- **`@template_constant` accepts signed literals** (`-1` is `ExprOp1` over the const
+  pre-fold; `tsi_is_const_init` peels one unary `+`/`-`).
+- **`KT(1)`-style ctor-casts in template bodies need no rule** — infer resolves
+  call-position alias names through the instance's structure aliases (probe-verified).
 
-Docs: tutorial chapter under `tutorials/macros/` (the concept deserves one — Boris);
-`skills/das_macros.md` gains the `[|>` inherited-annotation fact (done, this session);
-doc-comment surface per `skills/daslib_modules.md` when the macro lands.
+Tests (`tests/typemacro/`, 25/25 green interp AND `-jit`; AOT emits folded bodies —
+`ToyNarrow`gated` compiles to `return x + 100`): `test_template_struct_instance.das`
+(class rail incl. static_if fold + override-wins + const defaults arm, struct rail with
+two instances + const in field init, template-with-base arm, cross-module arm via
+`_template_struct_instance_mod.das`); negatives `failed_tsi_unbound_alias` /
+`_not_template_parent` / `_nonconst` (expect 20800) + `_field_collision` (expect 20503,
+parser-level). `tests/aot/CMakeLists.txt` typemacro glob now excludes `failed_*`.
+
+Docs: macro tutorial 20 (`tutorials/macros/20_template_struct_instance.das` +
+`template_struct_instance_mod.das`, RST under `doc/source/reference/tutorials/macros/`,
+toctree + tutorial-19 next-link updated; Sphinx -W clean). `skills/das_macros.md` carries
+the `[|>` inherited-annotation fact.
+
+Known lint interaction (report to Boris): **STYLE029 false-positives on a require whose
+only visible use is a reified template parent** — the reifier erases the parent link
+before lint runs, so the require looks redundant while being load-bearing. Nolint'd with
+reason in the tutorial usage file; a proper fix needs STYLE029 to see parse-time usage
+(or a reifier breadcrumb). Also: the formatter canonicalizes `[|>` to `[ |>`.
 
 ## Stage-1 pre-PR rail (Boris, 2026-08-08: expect bulk lint, don't be surprised by it)
 
@@ -171,14 +188,15 @@ before the `skills/make_pr.md` checklist:
    LINT003 let-vs-var, PERF007 das_string compares, PERF017 `empty()`, STYLE016 guard
    merges — all already observed on the probe.
 
-## Decisions needed (Boris)
+## Decisions (ruled, Boris 2026-08-07)
 
-1. `@template_const` explicit marking (recommended: greppable, and "force it's a
-   constant" has a place to hang the diagnostic) vs implicit "any overridden literal
-   field is a constant".
-2. One annotation name for both class and struct rails, or the
-   `template_class_instance` / `template_struct_instance` pair.
-3. Stage-1 go.
+1. `@template_constant` — EXPLICIT marking. Constants are fields the template marks;
+   unmarked overridden fields stay ordinary fields.
+2. ONE annotation, named `[template_struct_instance]` — matches the existing
+   `template_structure` family; there is no `template_class` in the family, so no
+   class-flavored name yet. When class-flavored template macros show up, we add
+   `template_class_instance` alongside.
+3. Stage-1 GO given.
 
 ## Stage 2 pointer (not planned here)
 
@@ -191,9 +209,10 @@ dedup is genuinely is-a). The 96 unlensed classes ride the same wave as lens ado
 
 ## Appendix — the stage-0 reifier skeleton (matrix-green verbatim, minus probe prints)
 
-Hardcodes one alias ("KT") and one const ("WIDE") — stage 1 generalizes exactly those
-two spots. Ran green: same-module + cross-module class templates, struct templates,
-override arms, multi-clone, used/unused instances.
+Hardcodes one alias ("KT") and one const ("WIDE") — stage 1 generalized exactly those
+two spots (plus `st.parent = tem.parent` instead of `null`; see the landed deltas). Ran
+green: same-module + cross-module class templates, struct templates, override arms,
+multi-clone, used/unused instances.
 
 ```das
 [structure_macro(name = "tci_probe")]

--- a/plans/template-class-instance.md
+++ b/plans/template-class-instance.md
@@ -218,6 +218,12 @@ before the `skills/make_pr.md` checklist:
    erased like a constant, direct call in the stamped class. Replaces the closed-set
    `static_if` route for callee selection with an open one (a new instance can route
    to a function the template never names).
+6. Rebind scope (Boris, PR round): the BARE spelling only. `_::slot` / `__::slot`
+   keep their normal `_`/`__` resolution rules — the pinned escape to the real
+   function past any rebind (probe-verified both forms; consistent with constants,
+   whose replaceVariable is bare-keyed too). This superseded the Copilot round-1
+   "rename the qualified spelling too" fix; the parser-generated `@@_::Tem`m`
+   method-pointer twins are machine references and still retarget.
 
 ## Stage 2 pointer (not planned here)
 

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -142,6 +142,22 @@ Note adapters can still *emit* code referencing the contributor's symbols by nam
 
 The trap also bites READS: module B calling A's accessor function reads **B's context copy** of A's globals — silently empty, no error (2026-07-12: llvm_exe calling llvm_tune's scope bank got `{}` while llvm_tune's own annotations saw it filled). Anything another macro module must read goes through the **AST** (annotations/stamps — `tune_scopes_status(prog)` walks `[tune_scope]` declarations instead of the bank), **files**, or **env** — never a shared macro global.
 
+## Pass macros — `[infer_macro]` needs a CLEAN tree; `[dirty_infer_macro]` runs every pass
+
+- `[infer_macro]` (AstPassMacro) fires only AFTER inference succeeds — `inferTypes` bails
+  to `failed_to_infer` before its loop, so it never sees a program with errors. Use it to
+  instrument well-typed trees (coverage, heartbeat, quote).
+- `[dirty_infer_macro]` fires after EVERY infer pass, errors present or not ("assume
+  half-way-there tree") — the hook for augmenting a not-yet-inferable program, e.g.
+  adding a structure alias mid-infer. Each pass starts by clearing `program->errors`, and
+  the loop continues only while a macro returns true (astChanged) or inference
+  progresses — a late-binder must return true when it changes the tree, or the loop stops
+  and the current errors become final. (C++ naming crossover: `[infer_macro]` registers
+  into `Module::macros`, `[dirty_infer_macro]` into `Module::inferMacros`.)
+- StructureAnnotation `finish`/`patch` do NOT run for a struct whose inference failed —
+  `apply` is the only hook guaranteed to fire, so a deferred "better error" for a failing
+  struct cannot live in `finish` (probe-verified 2026-08-07).
+
 ## Structure macros — generating types and functions
 
 - **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -145,6 +145,10 @@ The trap also bites READS: module B calling A's accessor function reads **B's co
 ## Structure macros — generating types and functions
 
 - **`[structure_macro(name=foo)]`** — annotation on a class inheriting `AstStructureAnnotation`; the `apply` method runs at compile time when a struct has `[foo]`. Use to generate companion types, operators, and functions.
+- **`apply` runs at parse time, in written order, sequentially** (repo-only: `parser_impl.cpp` `ast_structureDeclaration`) — a later annotation in the same bracket group sees every mutation the earlier one made (added fields, methods). Multiple structure macros on one struct are fine; the "only one" restriction is for handled-type annotations.
+- **`[|> foo]` marks an annotation inherited** (probe-verified 2026-08-08): it is copied to every DERIVED struct/class down the parent chain and PREPENDED before the child's own annotations, so it always applies first. It also fires on the carrying struct itself — discriminate with `st.flags.isTemplate` / other flags when the parent is a `struct template`/`class template`.
+- **`typedef NAME = <type>` inside a struct/class body is grammar** — it registers a structure alias (same slot as `add_structure_alias`), readable at apply time via `get_structure_alias(st, name)`; infer resolves alias-typed fields against the owning struct's aliases.
+- **Never certify a macro rail green while ANY other compile error is present** — final-verify errors (e.g. an unresolved `cast<auto>` from generated class machinery) are silently masked when an earlier unrelated error stops compilation first; two runs differing only by the unrelated error can flip a "green" macro red (probe-verified 2026-08-08).
 - **`clone_structure(st)`** — deep-copies a `StructurePtr` for creating modified companion types (e.g., SOA layout where every field becomes `array<FieldType>`). Pass the pointer directly — no `get_ptr` wrapping.
 - **`compiling_module() |> add_function(fn)`** — registers a concrete function in the current module
 - **`compiling_module() |> add_generic(fn)`** — registers a generic function (instanced per call site)

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -317,8 +317,8 @@ FILE(GLOB AOT_FIXED_ARRAY_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS
 list(FILTER AOT_FIXED_ARRAY_FILES EXCLUDE REGEX "failed_|/_")
 
 FILE(GLOB AOT_TYPEMACRO_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/typemacro/*.das")
-# Exclude the _-prefixed macro module (compile-time only, options no_aot)
-list(FILTER AOT_TYPEMACRO_FILES EXCLUDE REGEX "/_")
+# Exclude the _-prefixed macro modules (compile-time only, options no_aot) and failed_* expect-fixtures
+list(FILTER AOT_TYPEMACRO_FILES EXCLUDE REGEX "failed_|/_")
 
 FILE(GLOB AOT_LANGUAGE_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/language/*.das")
 # Exclude expect-error tests and no_aot files

--- a/tests/typemacro/_template_struct_instance_mod.das
+++ b/tests/typemacro/_template_struct_instance_mod.das
@@ -13,3 +13,21 @@ class template public XModKern {
         return x + BIAS
     }
 }
+
+[structure_macro(name = "tsi_test_bind_kt")]
+class TsiTestBindKt : AstStructureAnnotation {
+    def override apply(var st : StructurePtr; var group : ModuleGroup; args : AnnotationArgumentList; var errors : das_string) : bool {
+        var td = new TypeDecl(at = st.at, baseType = Type.tInt)
+        st |> add_structure_alias("KT", td)
+        return true
+    }
+}
+
+[ |> template_struct_instance(late_bind = true)]
+class template public LateKern {
+    x : KT
+
+    def take(v : KT) : KT {
+        return v + x
+    }
+}

--- a/tests/typemacro/_template_struct_instance_mod.das
+++ b/tests/typemacro/_template_struct_instance_mod.das
@@ -1,0 +1,15 @@
+options gen2
+
+module _template_struct_instance_mod shared public
+
+require daslib/typemacro_boost public
+
+[ |> template_struct_instance]
+class template public XModKern {
+    x : KT
+    @template_constant BIAS : int = 0
+
+    def value : int {
+        return x + BIAS
+    }
+}

--- a/tests/typemacro/failed_tsi_bad_call.das
+++ b/tests/typemacro/failed_tsi_bad_call.das
@@ -1,0 +1,23 @@
+options gen2
+expect 20800
+
+require daslib/typemacro_boost
+
+def pick : int {
+    return 1
+}
+
+[ |> template_struct_instance]
+struct template BT {
+    x : KT
+    @template_call op = "valid_name"
+}
+
+struct BInst : BT {
+    typedef KT = int
+    override op = pick() // neither @@name nor a string constant
+}
+
+[export]
+def main {
+}

--- a/tests/typemacro/failed_tsi_field_collision.das
+++ b/tests/typemacro/failed_tsi_field_collision.das
@@ -1,0 +1,19 @@
+options gen2
+expect 20503
+
+require daslib/typemacro_boost
+
+[ |> template_struct_instance]
+struct template FT {
+    x : KT
+    n : int = 1
+}
+
+struct FInst : FT {
+    typedef KT = int
+    n : int = 2 // redeclared without `override` — the parser rejects this before the reifier runs
+}
+
+[export]
+def main {
+}

--- a/tests/typemacro/failed_tsi_nonconst.das
+++ b/tests/typemacro/failed_tsi_nonconst.das
@@ -1,0 +1,23 @@
+options gen2
+expect 20800
+
+require daslib/typemacro_boost
+
+def side_value : int {
+    return 13
+}
+
+[ |> template_struct_instance]
+struct template CT {
+    x : KT
+    @template_constant N : int = 1
+}
+
+struct CInst : CT {
+    typedef KT = int
+    override N = side_value()
+}
+
+[export]
+def main {
+}

--- a/tests/typemacro/failed_tsi_not_template_parent.das
+++ b/tests/typemacro/failed_tsi_not_template_parent.das
@@ -1,0 +1,17 @@
+options gen2
+expect 20800
+
+require daslib/typemacro_boost
+
+struct Plain {
+    x : int
+}
+
+[template_struct_instance]
+struct Inst : Plain {
+    y : int
+}
+
+[export]
+def main {
+}

--- a/tests/typemacro/failed_tsi_unbound_alias.das
+++ b/tests/typemacro/failed_tsi_unbound_alias.das
@@ -1,0 +1,19 @@
+options gen2
+expect 20800
+
+require daslib/typemacro_boost
+
+[ |> template_struct_instance]
+struct template NT {
+    x : KT
+    y : VT
+}
+
+struct NInst : NT {
+    typedef KT = int
+    // VT deliberately unbound: the reifier must name the missing typedef
+}
+
+[export]
+def main {
+}

--- a/tests/typemacro/test_template_struct_instance.das
+++ b/tests/typemacro/test_template_struct_instance.das
@@ -1,0 +1,158 @@
+options gen2
+
+require dastest/testing_boost public
+require _template_struct_instance_mod
+
+typedef ModLevelT = float // module-level typedef: must not trip the unbound-alias check
+
+[ |> template_struct_instance]
+class template TKern {
+    x : KT
+    g : ModLevelT
+    @template_constant WIDE : bool = true
+    @template_constant OFFS : int = -3
+
+    def plain : int {
+        return x
+    }
+    def gated : int {
+        static_if (WIDE) {
+            return x + 1
+        } else {
+            return x + 100
+        }
+    }
+    def doubled : int {
+        return 2 * x
+    }
+    def offset : int {
+        return x + OFFS
+    }
+}
+
+class ToyNarrow : TKern {
+    typedef KT = int
+    override WIDE = false
+    override OFFS = -7
+
+    def override doubled : int { // instance-authored override must win over the template's
+        return 20 * x
+    }
+    def probe : int { // template constant read from an instance-authored method
+        return WIDE ? -1 : 1000 + x
+    }
+}
+
+class ToyWide : TKern { // keeps the template's constant defaults
+    typedef KT = int
+}
+
+[ |> template_struct_instance]
+struct template PairT {
+    a, b : KT
+    @template_constant SCALE : int = 1
+    sum : int = SCALE * 100
+}
+
+struct PairInt3 : PairT {
+    typedef KT = int
+    override SCALE = 3
+}
+
+struct PairInt7 : PairT {
+    typedef KT = int
+    override SCALE = 7
+    extra : KT = 5
+}
+
+class Counter {
+    hits : int = 0
+
+    def bump : void {
+        hits++
+    }
+    def abstract tag : int
+}
+
+[ |> template_struct_instance]
+class template CKern : Counter {
+    x : KT
+    @template_constant STEP : int = 1
+
+    def override tag : int {
+        return x + STEP
+    }
+}
+
+class CInt : CKern {
+    typedef KT = int
+    override STEP = 50
+}
+
+class XModInt : XModKern {
+    typedef KT = int
+    override BIAS = 1000
+}
+
+[test]
+def test_tsi_class_rail(t : T?) {
+    t |> run("stamped methods, static_if fold, override wins, constants") @(t : T?) {
+        unsafe {
+            var inscope k <- new ToyNarrow()
+            k.x = 42
+            t |> equal(k->plain(), 42)
+            t |> equal(k->gated(), 142)   // WIDE=false picks the static_if else-branch
+            t |> equal(k->doubled(), 840) // the instance override, not the template's 2*x
+            t |> equal(k->offset(), 35)   // signed-literal constant: OFFS=-7
+            t |> equal(k->probe(), 1042)  // constant substituted in an instance-authored body
+        }
+    }
+    t |> run("second instance keeps the template's constant defaults") @(t : T?) {
+        unsafe {
+            var inscope k <- new ToyWide()
+            k.x = 42
+            t |> equal(k->gated(), 43)   // WIDE=true default
+            t |> equal(k->offset(), 39)  // OFFS=-3 default
+            t |> equal(k->doubled(), 84) // the template's own doubled
+        }
+    }
+}
+
+[test]
+def test_tsi_struct_rail(t : T?) {
+    t |> run("two instances of one struct template") @(t : T?) {
+        let p = PairInt3(a = 2, b = 3)
+        let q = PairInt7(a = 10, b = 20)
+        t |> equal(p.sum, 300) // SCALE=3 folded into the field init
+        t |> equal(q.sum, 700)
+        t |> equal(q.extra, 5) // instance-own field
+        t |> equal(p.a + p.b, 5)
+        t |> equal(q.a + q.b, 30)
+    }
+}
+
+[test]
+def test_tsi_base_class(t : T?) {
+    t |> run("template's own base class survives reification") @(t : T?) {
+        unsafe {
+            var inscope k <- new CInt()
+            k.x = 7
+            k->bump()
+            k->bump()
+            var base : Counter? = k
+            t |> equal(k.hits, 2)       // inherited base method
+            t |> equal(base->tag(), 57) // dispatch through the base hits the stamped override
+        }
+    }
+}
+
+[test]
+def test_tsi_cross_module(t : T?) {
+    t |> run("template required from another module") @(t : T?) {
+        unsafe {
+            var inscope k <- new XModInt()
+            k.x = 42
+            t |> equal(k->value(), 1042)
+        }
+    }
+}

--- a/tests/typemacro/test_template_struct_instance.das
+++ b/tests/typemacro/test_template_struct_instance.das
@@ -122,6 +122,9 @@ class template DotT {
     def run_ptr(v : KT) : KT {
         return tsi_via_ptr(@@tsi_sdot, x, v) // @@ address targets rebind too
     }
+    def run_qual(v : KT) : KT {
+        return _::tsi_sdot(x, v) // module-qualified spelling rebinds too
+    }
 }
 
 class DotDefault : DotT {
@@ -227,6 +230,8 @@ def test_tsi_call_rebind(t : T?) {
             t |> equal(c->run(7), 42000)     // string-form rebind
             t |> equal(a->run_ptr(7), 42)    // @@ address target, default
             t |> equal(b->run_ptr(7), 42000) // @@ address target, rebound
+            t |> equal(a->run_qual(7), 42)   // _:: qualified spelling, default
+            t |> equal(b->run_qual(7), 42000) // _:: qualified spelling, rebound
         }
     }
 }

--- a/tests/typemacro/test_template_struct_instance.das
+++ b/tests/typemacro/test_template_struct_instance.das
@@ -123,7 +123,7 @@ class template DotT {
         return tsi_via_ptr(@@tsi_sdot, x, v) // @@ address targets rebind too
     }
     def run_qual(v : KT) : KT {
-        return _::tsi_sdot(x, v) // module-qualified spelling rebinds too
+        return _::tsi_sdot(x, v) // `_::` keeps normal resolution: pinned to the real function, past any rebind
     }
 }
 
@@ -230,8 +230,8 @@ def test_tsi_call_rebind(t : T?) {
             t |> equal(c->run(7), 42000)     // string-form rebind
             t |> equal(a->run_ptr(7), 42)    // @@ address target, default
             t |> equal(b->run_ptr(7), 42000) // @@ address target, rebound
-            t |> equal(a->run_qual(7), 42)   // _:: qualified spelling, default
-            t |> equal(b->run_qual(7), 42000) // _:: qualified spelling, rebound
+            t |> equal(a->run_qual(7), 42) // `_::` spelling pinned to the real callee...
+            t |> equal(b->run_qual(7), 42) // ...even on the rebinding instance, by design
         }
     }
 }

--- a/tests/typemacro/test_template_struct_instance.das
+++ b/tests/typemacro/test_template_struct_instance.das
@@ -94,6 +94,50 @@ class XModInt : XModKern {
     override BIAS = 1000
 }
 
+[tsi_test_bind_kt]
+class LateInt : LateKern {
+    // no typedef — [tsi_test_bind_kt] supplies KT after the reifier; late_bind waives the check
+}
+
+def tsi_sdot(a, b : int) : int {
+    return a * b
+}
+
+def tsi_ssdot(a, b : int) : int {
+    return a * b * 1000
+}
+
+def tsi_via_ptr(f : function<(a, b : int) : int>; a, b : int) : int {
+    return invoke(f, a, b)
+}
+
+[ |> template_struct_instance]
+class template DotT {
+    x : KT
+    @template_call tsi_sdot = @@tsi_sdot // the field name is what bodies call; the init is the default target
+
+    def run(v : KT) : KT {
+        return tsi_sdot(x, v)
+    }
+    def run_ptr(v : KT) : KT {
+        return tsi_via_ptr(@@tsi_sdot, x, v) // @@ address targets rebind too
+    }
+}
+
+class DotDefault : DotT {
+    typedef KT = int
+}
+
+class DotWide : DotT {
+    typedef KT = int
+    override tsi_sdot = @@tsi_ssdot
+}
+
+class DotStr : DotT {
+    typedef KT = int
+    override tsi_sdot = "tsi_ssdot"
+}
+
 [test]
 def test_tsi_class_rail(t : T?) {
     t |> run("stamped methods, static_if fold, override wins, constants") @(t : T?) {
@@ -153,6 +197,36 @@ def test_tsi_cross_module(t : T?) {
             var inscope k <- new XModInt()
             k.x = 42
             t |> equal(k->value(), 1042)
+        }
+    }
+}
+
+[test]
+def test_tsi_late_bind(t : T?) {
+    t |> run("late_bind = true defers alias binding to a later macro") @(t : T?) {
+        unsafe {
+            var inscope k <- new LateInt()
+            k.x = 40
+            t |> equal(k->take(2), 42)
+        }
+    }
+}
+
+[test]
+def test_tsi_call_rebind(t : T?) {
+    t |> run("@template_call rebinds calls and @@ addresses per instance") @(t : T?) {
+        unsafe {
+            var inscope a <- new DotDefault()
+            var inscope b <- new DotWide()
+            var inscope c <- new DotStr()
+            a.x = 6
+            b.x = 6
+            c.x = 6
+            t |> equal(a->run(7), 42)        // default: the real tsi_sdot
+            t |> equal(b->run(7), 42000)     // @@tsi_ssdot rebind
+            t |> equal(c->run(7), 42000)     // string-form rebind
+            t |> equal(a->run_ptr(7), 42)    // @@ address target, default
+            t |> equal(b->run_ptr(7), 42000) // @@ address target, rebound
         }
     }
 }

--- a/tutorials/macros/20_template_struct_instance.das
+++ b/tutorials/macros/20_template_struct_instance.das
@@ -8,10 +8,11 @@ options gen2
 // `typedef`s pick the types, its `override`s pick the constants, and its
 // own methods replace the template's.
 //
-// Three patterns are demonstrated:
+// Four patterns are demonstrated:
 //   1. Type parameter     — typedef KT = float
 //   2. Constant parameter — override KEEP_LATEST = true, folded by static_if
 //   3. Method override    — the instance's own method wins
+//   4. Call parameter     — override dot_i = @@dot_i_scaled redirects a call
 //
 // Run: daslang tutorials/macros/20_template_struct_instance.das
 
@@ -50,6 +51,19 @@ class IntShouty : TopKeeperT {
     }
 }
 
+// --- 4. Call parameter ---
+// MixT's feed() calls dot_i(). MixPlain keeps that call on the real dot_i;
+// MixLoud redirects every dot_i call — and every @@dot_i address — to
+// dot_i_scaled. The redirect happens at stamp time, so the stamped class
+// makes a plain direct call: no function pointer, nothing to inline through.
+
+class MixPlain : MixT {
+}
+
+class MixLoud : MixT {
+    override dot_i = @@dot_i_scaled
+}
+
 [export]
 def main {
     unsafe {
@@ -70,6 +84,13 @@ def main {
         shouty->feed(3)
         shouty->feed(7)
         print("IntShouty: {shouty->report()}\n")
+
+        var inscope plain <- new MixPlain()
+        var inscope loud <- new MixLoud()
+        plain->feed(2, 3)
+        loud->feed(2, 3)
+        print("MixPlain:  acc={plain.acc}\n")
+        print("MixLoud:   acc={loud.acc}\n")
     }
 }
 
@@ -77,3 +98,5 @@ def main {
 //   FloatTop:  kept 3.25 out of 3
 //   IntLatest: kept 7 out of 3
 //   IntShouty: BEST 10 OF 3!
+//   MixPlain:  acc=6
+//   MixLoud:   acc=600

--- a/tutorials/macros/20_template_struct_instance.das
+++ b/tutorials/macros/20_template_struct_instance.das
@@ -1,0 +1,79 @@
+options gen2
+
+// Tutorial 20 — Template struct/class instances (reification)
+//
+// `[template_struct_instance]` from daslib/typemacro_boost stamps a
+// `class template` (or `struct template`) into ordinary concrete classes.
+// An instance is just a class that inherits from the template: its
+// `typedef`s pick the types, its `override`s pick the constants, and its
+// own methods replace the template's.
+//
+// Three patterns are demonstrated:
+//   1. Type parameter     — typedef KT = float
+//   2. Constant parameter — override KEEP_LATEST = true, folded by static_if
+//   3. Method override    — the instance's own method wins
+//
+// Run: daslang tutorials/macros/20_template_struct_instance.das
+
+require template_struct_instance_mod // nolint:STYLE029 — TopKeeperT comes from here; the reifier erases the parent link before lint can see it
+
+// --- 1. Type parameter ---
+// `typedef KT = float` binds the template's type parameter. Everything else
+// comes from the template unchanged: KEEP_LATEST stays false, so feed()
+// keeps the maximum.
+
+class FloatTop : TopKeeperT {
+    typedef KT = float
+}
+
+// --- 2. Constant parameter ---
+// `override KEEP_LATEST = true` replaces the constant for this instance
+// only. The `static_if` inside feed() folds at compile time, so this class
+// carries no branch at runtime — just the "keep the latest value" body.
+
+class IntLatest : TopKeeperT {
+    typedef KT = int
+    override KEEP_LATEST = true
+}
+
+// --- 3. Method override ---
+// An instance may replace any template method with `def override`. The
+// template's feed() still calls the replacement, exactly like a virtual
+// call in plain class inheritance — except here it is resolved at stamp
+// time, with no virtual dispatch left in the stamped class.
+
+class IntShouty : TopKeeperT {
+    typedef KT = int
+
+    def override report : string {
+        return "BEST {best} OF {n}!"
+    }
+}
+
+[export]
+def main {
+    unsafe {
+        var inscope ftop <- new FloatTop()
+        ftop->feed(1.5)
+        ftop->feed(3.25)
+        ftop->feed(2.0)
+        print("FloatTop:  {ftop->report()}\n")
+
+        var inscope latest <- new IntLatest()
+        latest->feed(10)
+        latest->feed(3)
+        latest->feed(7)
+        print("IntLatest: {latest->report()}\n")
+
+        var inscope shouty <- new IntShouty()
+        shouty->feed(10)
+        shouty->feed(3)
+        shouty->feed(7)
+        print("IntShouty: {shouty->report()}\n")
+    }
+}
+
+// Expected output:
+//   FloatTop:  kept 3.25 out of 3
+//   IntLatest: kept 7 out of 3
+//   IntShouty: BEST 10 OF 3!

--- a/tutorials/macros/20_template_struct_instance.das
+++ b/tutorials/macros/20_template_struct_instance.das
@@ -16,7 +16,7 @@ options gen2
 //
 // Run: daslang tutorials/macros/20_template_struct_instance.das
 
-require template_struct_instance_mod // nolint:STYLE029 — TopKeeperT comes from here; the reifier erases the parent link before lint can see it
+require template_struct_instance_mod // nolint:STYLE029,LINT019 — TopKeeperT comes from here; the reifier erases the parent link before STYLE029 (MCP rail) can see it
 
 // --- 1. Type parameter ---
 // `typedef KT = float` binds the template's type parameter. Everything else

--- a/tutorials/macros/template_struct_instance_mod.das
+++ b/tutorials/macros/template_struct_instance_mod.das
@@ -34,3 +34,25 @@ class template public TopKeeperT {
         return "kept {best} out of {n}"
     }
 }
+
+def public dot_i(a, b : int) : int {
+    return a * b
+}
+
+def public dot_i_scaled(a, b : int) : int {
+    return a * b * 100
+}
+
+// A call parameter. `@template_call` names a free function the body calls:
+// the field name is what the body spells, the init is where the call goes,
+// and instances redirect it with `override`. The field is erased like a
+// constant — the stamped class makes a direct call, nothing is dispatched.
+[ |> template_struct_instance]
+class template public MixT {
+    acc : int = 0
+    @template_call dot_i = @@dot_i
+
+    def feed(a, b : int) {
+        acc += dot_i(a, b)
+    }
+}

--- a/tutorials/macros/template_struct_instance_mod.das
+++ b/tutorials/macros/template_struct_instance_mod.das
@@ -1,0 +1,36 @@
+options gen2
+
+module template_struct_instance_mod shared public
+
+require daslib/typemacro_boost public
+
+// The shared body. `class template` parses like a class but is never compiled
+// on its own — only stamped copies of it are. `KT` is not declared anywhere:
+// an unresolved name in type position is a type parameter, and every instance
+// must bind it with a `typedef`. `@template_constant` marks a field as a
+// compile-time parameter: instances pick its value with `override`, and the
+// field itself is erased from the stamped class.
+[ |> template_struct_instance]
+class template public TopKeeperT {
+    best : KT
+    n : int = 0
+    @template_constant KEEP_LATEST : bool = false
+
+    def feed(v : KT) {
+        if (n == 0) {
+            best = v
+        } else {
+            static_if (KEEP_LATEST) {
+                best = v
+            } else {
+                if (v > best) {
+                    best = v
+                }
+            }
+        }
+        n++
+    }
+    def report : string {
+        return "kept {best} out of {n}"
+    }
+}


### PR DESCRIPTION
## What

`[template_struct_instance]` in `daslib/typemacro_boost.das` stamps a `struct template` / `class template` into ordinary concrete types at parse time. An instance is just a class that inherits from the template:

```das
[ |> template_struct_instance]
class template TKern {
    x : KT                                // unresolved alias = type parameter
    @template_constant WIDE : bool = true // constant parameter, erased at stamp
    @template_call sdot = @@sdot          // call parameter: bodies call sdot(...), instances redirect

    def gated : int {
        static_if (WIDE) {                // folds per instance, in infer, for free
            return x + 1
        } else {
            return x + 100
        }
    }
    def run(v : int) : int {
        return sdot(x, v)
    }
}

class K4 : TKern {
    typedef KT = int                      // binds the type parameter
    override WIDE = false                 // binds the constant
    override sdot = @@ssdot               // redirects the callee — calls AND @@sdot addresses

    def override run(v : int) : int {     // instance-authored methods win
        return 20 * x
    }
}
```

The reifier flattens the template into the instance: aliases bound by instance typedefs, constants folded at every use (template bodies, field inits, instance-authored methods) and erased, `@template_call` callees renamed and erased, template methods cloned per instance, and the template cut from the ancestry — a concrete base class above the template survives, so upcasts and dispatch through it keep working. The `[ |> ...]` inherited-annotation spelling rides the reifier down to every instance ahead of its own annotations, so downstream structure macros always see a finished concrete class.

Everything is existing grammar plus existing machinery (the templates_boost rules engine, the parser's clone-the-parent inheritance, infer's structure-alias resolution) — zero C++ changes.

`late_bind = true` on the template's annotation waives the eager unbound-alias error for templates whose type parameters another macro supplies later in the compile (verified with a parse-time sibling annotation and with a dirty-infer-pass binder two passes in).

## Tests

`tests/typemacro/` — 30/30 green under interp and `-jit`; the full AOT sweep is green and emits fully folded bodies (the `static_if` arm compiles to a bare `return x + 100`). Positive matrix: class + struct rails, two instances of one template, override-wins, constant defaults, template-with-base, cross-module, late-bind, call-rebind (default / `@@` / string / address-target). Negative expect-fixtures: unbound alias (named error listing the missing typedef), non-template parent, non-literal constant, non-callee `@template_call` value, field collision. The typemacro AOT glob now excludes `failed_` expect-fixtures.

## Docs

Macro tutorial 20 (usage + module file, RST page, toctree, tutorial-19 next-link); Sphinx warnings-as-errors clean. `skills/das_macros.md` gains the `[|>` inherited-annotation facts plus the pass-macro facts found while probing (`[infer_macro]` runs only on a clean tree; `[dirty_infer_macro]` is the per-pass errors-tolerated hook; structure-annotation finish/patch never run for a struct whose inference failed). Design/probe record: `plans/template-class-instance.md`.

## Validation

Full preflight: interp / JIT / full-AOT sweeps, sequence smoke, imgui suite, docs gates all green. Its two failures were fixed and re-validated with targeted gates: lint (three latent STYLE037/038 in the touched `typemacro_boost.das` suppressed with reasons; a both-worlds nolint spelling in the tutorial), and one ctest (`exe_paths_module_resolve` — transient: the sqlite shared_module was rebuilt by preflight's own later build step; passes on re-run). Push used `--no-verify` per the once-per-full-preflight policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)