### PR TITLE
flatten example backend: accept init-less shader locals (default-value const)

### DIFF
--- a/examples/flatten/backend/shader_dsl_boost.das
+++ b/examples/flatten/backend/shader_dsl_boost.das
@@ -1,6 +1,8 @@
 options gen2
 options no_unused_block_arguments
 options no_unused_function_arguments = false
+options _cyclomatic_complexity = 0   // faithful testing copy of the engine backend — the validator is-ladders
+options _function_length = 0         // and the IR emitter mirror the engine source; keep the shapes in sync
 module shader_dsl_boost shared private
 
 require daslib/strings_boost
@@ -541,6 +543,44 @@ class ValidateShaderVisitor : AstVisitor {
         register_node(expr, node)
     }
 
+    // An init-less decl. In daslang a local without an initializer IS initialized —
+    // `var m : bool` is `var m = false`, `var v : float2` is `var v = float2(0, 0)` —
+    // the AST just carries no init node (the optimizer drops an init every path
+    // overwrites before reading). Synthesize the default-value const node and seed
+    // the variable's rail with its pin: accumulator seed (`var`) or read target (`let`).
+    def emit_default_init(v : VariablePtr&) {
+        let bt = v._type.baseType
+        let typeId = (bt == Type.tBool ? BoolConst
+                    : bt == Type.tFloat ? FloatConst
+                    : bt == Type.tFloat2 ? Float2Const
+                    : bt == Type.tFloat3 ? Float3Const
+                    : bt == Type.tFloat4 ? Float4Const
+                    : "")
+        if (empty(typeId)) {
+            errors.push(("unsupported variable type {describe(v._type)}", unsafe(addr(v.at))))
+            return
+        }
+        // constValue stays default<float4> — all zeros is exactly false / 0.0 / (0,0,…)
+        var node = IRNode(id = irNodeId, typeId = typeId, kind = ShaderNodeKind.Const)
+        if (DEBUG_AT) {
+            node.at = "default init of {v.name}"
+        }
+        var pin = new IRPin(id = irPinId, _type = pin_type_of(v._type))
+        pins[irPinId] = pin
+        irPinId++
+        node.outputs.push(pin)
+        nodes.emplace(node)
+        irNodeId++
+        add_variable(v)
+        let vid : Variable const? = v
+        if (!v._type.isConst) {
+            accumVars[vid] = true
+            accumCurPin[vid] = pin.id
+        } else {
+            variablePins[vid] = pin.id
+        }
+    }
+
     def emit_vector_ctor(expr : ExprCall?; dims : int; combineTypeId : string) {
         let argc = expr.arguments.length()
         if (argc == 1 && expr.arguments[0]._type.baseType == Type.tFloat) {
@@ -765,7 +805,7 @@ class ValidateShaderVisitor : AstVisitor {
         for (v in expr.variables) {
             // print("deep: let {v.name} = {describe(v.init)}")
             if (v.init == null) {
-                errors.push(("shader variables must be initialized with a constant expression", unsafe(addr(v.at))))
+                emit_default_init(v)
                 continue
             }
             if (v._type.isPointer) {


### PR DESCRIPTION
## What

The flatten example's shader-graph backend (a testing copy of EdenSpark's `engine.render.shader_dsl`) rejected init-less local declarations: `"shader variables must be initialized with a constant expression"`. On latest master that broke the runtime `break`/`continue` mask rail — capability checks 7 and 8 failed with `error[50503]: undefined variable __flat_loop_0 / __flat_iter_0`.

## Why

flatten's mask const-prop deliberately collapses the first mask narrow (`m = true; m = m && X` becomes `m = X`), which leaves the decl's `= true` init dead, and DSE strips it. The resulting `var __flat_loop_0 : bool` is **correct daslang** — an init-less local IS initialized (`var m : bool` is `var m = false`, `var v : float2` is `var v = float2(0, 0)`); the AST just carries no init node. Per agreement with the framework owners, the fix goes on the **backend** side (support the correct syntax) rather than the das side (no workarounds); this patch is the example they will port.

## How

New `emit_default_init(v)` in `ValidateShaderVisitor`: for an init-less decl of a supported type it synthesizes the default-value Const node (`boolConst` / `floatConst` / `float2Const` / `float3Const` / `float4Const`, `constValue` all zeros — exactly `default<T>`) and seeds the variable's existing rails with the const's pin:

- `var` (mutable accumulator) → `accumVars` + `accumCurPin` seed, same as a `var x = <const>` decl;
- `let` → `variablePins` read target.

When the first mask operation is a store (the DSE'd shape), the const node stays unlinked — a faithful "the init exists, nothing reads it"; an engine that culls unreachable nodes drops it for free. When a read precedes the first store, the const links in and supplies the correct zero/false. Unsupported types keep the existing `unsupported variable type` error.

Also adds `options _cyclomatic_complexity = 0` / `_function_length = 0` with a reason comment: the file is a faithful engine copy whose validator is-ladders and IR emitter exceed STYLE037/038 caps by design, and this PR pulls it into the changed-set lint gate.

## Verification

- Capability tier: **24/24** (checks 7 and 8 back green — `cap_loop_break` compiles to 4 selects gated by a stored bool mask, `cap_loop_continue` to 4 per-copy masks gating 4 selects).
- Regression tier: **87/87** shaders compile with identical graphs.
- Changed-file lint: 0 issues; formatter: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
