### PR TITLE
fix: null dangling default-argument refs in ClearUnusedSymbols

### DIFF
--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -7936,6 +7936,12 @@ class public DisableJitVisitor : AstVisitor {
     def TypeInfoVisitor {
         disable = false
     }
+    // Default-argument inits are inlined into call sites at infer, so the copy left on the
+    // argument is a dead husk LlvmJitVisitor declines too - and ClearUnusedSymbols nulls refs
+    // inside it, so expr.func there is legitimately null.
+    def override canVisitFunctionArgumentInit(fun : Function?; arg : VariablePtr; value : ExpressionPtr) : bool {
+        return false
+    }
     // 16/8-bit lattice floor: data movement (loads/stores/moves/locals/indexing/swizzles) and the
     // vec4f wrapper ABI lower natively; what still falls back is lattice values crossing a BUILTIN CALL
     // boundary (ctors/converts/operators) — the builtin-address gates below catch those.
@@ -8010,6 +8016,10 @@ class public DisableJitVisitor : AstVisitor {
     }
 
     def disable_builtin_call(expr : ExprCallFunc?) {
+        // an unresolved call has no builtin to gate on; ResolveExternVisitor takes the same early out
+        if (expr.func == null) {
+            return
+        }
         if (expr.func.flags.builtIn && !expr.func.flags.interopFn && get_builtin_function_address(expr.func) == null) {
             if (!has_intrinsic(expr) && !is_dasbind_late(expr.func)) {
                 to_log(LOG_WARNING, "LLVM JIT: unsupported builtin `{expr.func._module.name}::{expr.func.name}` at {expr.at}, falling back to interpreter.\n")

--- a/src/ast/ast_export.cpp
+++ b/src/ast/ast_export.cpp
@@ -12,7 +12,14 @@ namespace das {
             return !fun->stub && !fun->isTemplate;    // we don't do a thing with templates
         }
         virtual bool canVisitStructureFieldInit ( Structure * ) override { return true; }
-        virtual bool canVisitArgumentInit ( Function *, const VariablePtr &, Expression * ) override { return false; }
+        // default-argument initializers are the same dangling-ref story as field inits:
+        // MarkSymbolUse never visits them (canVisitArgumentInit is false there), so a
+        // function/global whose ONLY anchor is `def f(x = helper())` is never marked used,
+        // removeUnusedSymbols frees it, and the surviving f keeps the raw pointer in
+        // arg->init - serialization then reads it (SIGSEGV in getMangledName under --ser).
+        // infer already inlined every default into its call sites, so nulling the husk here
+        // costs nothing
+        virtual bool canVisitArgumentInit ( Function *, const VariablePtr &, Expression * ) override { return true; }
         virtual void preVisit(ExprAddr * expr) override {
             Visitor::preVisit(expr);
             if ( expr->func && !expr->func->used && !expr->func->builtIn ) {

--- a/tests/language/serialize_field_init_ctor.das
+++ b/tests/language/serialize_field_init_ctor.das
@@ -43,6 +43,23 @@ struct UsesBuiltinGlobal {
     p : float = PI
 }
 
+// default-argument initializers are the same story: MarkSymbolUse skips them too
+// (canVisitArgumentInit is false there), so a helper whose only anchor is `x = arg_helper()`
+// is freed while the surviving function keeps the raw pointer in arg->init. arg_helper writes
+// a global so const folding can't erase the call, and g_arg_state rides along as the Variable
+// half of the same pin
+var private g_arg_state = 1
+
+def private arg_helper() : int {
+    g_arg_state ++
+    return g_arg_state
+}
+
+[export]
+def default_arg_anchor(x : int = arg_helper()) : int {
+    return x
+}
+
 variant PodVariant {
     i : int
     f : float


### PR DESCRIPTION
ClearUnusedSymbols had canVisitArgumentInit == false, so default-argument initializers were neither marked nor nulled. A function or global whose only anchor is `def f(x : int = helper())` is never marked used (MarkSymbolUse skips argument inits too), removeUnusedSymbols frees it, and the surviving f keeps the raw pointer in arg->init. AST serialization then reads it: SIGSEGV in Function::getMangledName via AstSerializer::writeIdentifications - the same crash d128a3dbd fixed for struct field inits, just through the other initializer that both visitors skip.

Turn the override on so the cleaner nulls those refs like it already does for field inits. Keep-alive marking is the wrong side of the fix here for the same reason d128a3dbd gave: it over-marks. Infer has inlined every default into its call sites by this point, so nulling the husk costs nothing.

Pin extended in tests/language/serialize_field_init_ctor.das. arg_helper() writes a global on purpose - with a foldable body (`return 42`) const folding rewrites the call to a literal and the dangling ref never forms, so the pin would not pin anything.

Verified both ways: with the override reverted the --ser sweep segfaults in getMangledName; with it on, tests/language ser + deser round-trip and the full tests/ suite pass.