### PR TITLE
ci: daspkg macos nightly installs brew bison

### DIFF
--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -166,6 +166,13 @@ jobs:
     - name: "Install CMake and Ninja"
       uses: lukka/get-cmake@latest
 
+    - name: "Install bison (Homebrew)"
+      # Apple's stock /usr/bin/bison is 2.3 and can't parse the grammar
+      # (`%define api.prefix {das2_yy}` needs bison 3.x). CMake resolves the
+      # Homebrew keg via `brew --prefix bison` on Darwin, so installing it is
+      # enough — same dependency build.yml's darwin lanes install.
+      run: brew install bison
+
     - name: "Build: Daslang (Release, core only)"
       run: |
         set -eux


### PR DESCRIPTION
The `daspkg_unit_macos` job (added 2026-08-02 in e15e33011) has been red on every scheduled run since its first (Aug 4, run 30875395033) — the `index_sweep` half is green every night, so the workflow's red was easy to misread as an externals failure.

**Cause:** the job never installs bison. CMake's Darwin branch looks for the Homebrew keg via `brew --prefix bison` (CMakeLists.txt:128-138) and falls back to Apple's stock `/usr/bin/bison` 2.3, which cannot parse the grammar:

```
ds2_parser.ypp:1.9-18: syntax error, unexpected identifier, expecting string
```

(brace-style `%define api.prefix {das2_yy}` needs bison 3.x; stock flex 2.6.4 is fine — both lexers generated cleanly before the failure.)

**Fix:** `brew install bison` in the job, the same dependency build.yml's darwin lanes install (build.yml:320-327). No PATH export needed — CMake resolves the keg path directly.

Verification signal: the next scheduled `nightly daspkg index` run (02:30 UTC) — or a manual `workflow_dispatch` of the workflow from master after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
