### PR TITLE
ci: daspkg macos nightly builds with dasLLVM

### DIFF
--- a/.github/workflows/nightly_daspkg_index.yml
+++ b/.github/workflows/nightly_daspkg_index.yml
@@ -155,7 +155,10 @@ jobs:
 
   daspkg_unit_macos:
     # the platform the unit suite exists to catch: the release layout forks
-    # into an .app bundle here. Interpreted run — no LLVM, plain build.
+    # into an .app bundle here. dasLLVM is ON because the suite's
+    # test_cmd_release_* family drives `daslang -exe` (the release bundler),
+    # which needs the LLVM shared lib at runtime — core-only builds fail
+    # every release test on `can't load library LLVM.dll`.
     if: github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript'
     runs-on: macos-15
     timeout-minutes: 60
@@ -173,10 +176,12 @@ jobs:
       # enough — same dependency build.yml's darwin lanes install.
       run: brew install bison
 
-    - name: "Build: Daslang (Release, core only)"
+    - name: "Build: Daslang (Release + dasLLVM)"
+      # CMake fetches the prebuilt mac_arm64 LLVM from the repo's llvm-v*
+      # release and stages lib/LLVM.dll itself — no brew llvm needed.
       run: |
         set -eux
-        cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=Release -G Ninja
+        cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=Release -DDAS_LLVM_DISABLED=OFF -G Ninja
         cmake --build ./build --config Release --target daslang
 
     - name: "daspkg unit suite"


### PR DESCRIPTION
Follow-up to #3664. With bison in place the lane reached its unit suite and failed 5/219 — the whole `test_cmd_release_*` family (.app-bundle layout, `install_name`/`LC_RPATH` checks). All five share one upstream cause: the release rail runs `daslang -exe`, which needs the LLVM shared library at runtime, and the job built core-only:

```
release: daslang -exe failed (rc=1):
error[20800]: macro [extern] failed to apply to a function LLVMVerifyModule
can't load library LLVM.dll (dlopen(.../daScript/lib/LLVM.dll ...): no such file)
```

**Fix:** `-DDAS_LLVM_DISABLED=OFF`. dasLLVM's CMake fetches the prebuilt `mac_arm64` LLVM tarball from the repo's `llvm-v*` release and stages `lib/LLVM.dll` itself (modules/dasLLVM/CMakeLists.txt:80-122), so the enable is one flag — no brew llvm, and macos-15 runners are arm64 so the prebuilt exists.

Skipping the release tests instead was rejected: the .app-bundle fork is the reason this lane exists — skipping recreates the blind spot that let it sit red for weeks unseen.

Verification: `workflow_dispatch` of `nightly daspkg index` after merge (the same rail that confirmed #3664's build-step fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
