### PR TITLE
ci: deploy installs libglfw3 runtime for the cache-hit path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,7 +47,13 @@ jobs:
         sudo apt-get update
         # libc++ so the wasm cross-compile host can be built with the SAME C++
         # stdlib as the emscripten target (see the host build step below).
-        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev xorg-dev libc++-dev libc++abi-dev
+        # libglfw3 is the RUNTIME .so for imgui2rst below: on a wasm-cache hit
+        # the host build is skipped, so the superbuild's libglfw.so.3 (found
+        # via build-tree rpath on full builds) doesn't exist — the cached
+        # imguiApp/dasGlfw shared modules then fail to dlopen and imgui2rst
+        # dies on `missing prerequisite 'imgui_app'`. The system soname
+        # satisfies the same lookup on both paths.
+        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev xorg-dev libc++-dev libc++abi-dev libglfw3
 
     - name: Setup Emscripten
       uses: emscripten-core/setup-emsdk@v11


### PR DESCRIPTION
`Deploy daslang.io` fails at ~1m50s on cache-hit pushes — #3665's merge push (run 31303637222), #3658's (31252895117), and the Aug 7 pair — while full builds (30-45 min) always pass. That split is the diagnosis:

- On a **wasm-cache hit** (workflow-only / doc-only push), the host build step is skipped and `imgui2rst` runs against the cached `bin/` + shared modules.
- `libglfw.so.3` only ever existed via the *skipped* build tree (superbuild product, found by rpath on full builds), so `imguiApp.shared_module` / `dasGlfw` fail to dlopen:

```
error[20605]: missing prerequisite 'imgui_app'; file not found
  Module_imgui_app <- .../imguiApp.shared_module (libglfw.so.3: cannot open shared object file)
```

**Fix:** install the `libglfw3` runtime package in the unconditional apt step. Its soname satisfies the same lookup on both paths; imgui2rst is headless RST generation, so the system 3.3.x runtime vs superbuild 3.4 makes no difference at load time.

Verification: after merge, any doc-only or workflow-only push to master exercises the cache-hit path (that's exactly the shape that fails today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
