### PR TITLE
playground: interpreted-audio page wedge, gather lock contract, bench deep-links, new button

### DIFF
--- a/daslib/jobque_boost.das
+++ b/daslib/jobque_boost.das
@@ -237,6 +237,7 @@ def push(channel : Channel?; data : auto?) {
 def push_batch_clone(channel : Channel?; data : array<auto(TT)>) {
     //! clones data and pushes values to the channel (at the end)
     var heap_data : array<TT?>
+    heap_data |> reserve(length(data))
     for (d in data) {
         var tt = new TT
         *tt := d
@@ -441,7 +442,7 @@ def pop_archive(stream : Stream?; blk : block<(var value : auto(TT)&) : void>) :
     var any = false
     var value : TT -# -& -const
     _builtin_stream_pop(stream) $(bytes : array<uint8># -const) {
-        if (length(bytes) > 0) {
+        if (!empty(bytes)) {
             any = true
             mem_archive_load(bytes, value)
         }

--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -96,38 +96,58 @@ namespace das {
                 tt(f.data, f.type, f.from ? f.from : owner);
             }
         }
+        // gather/gatherEx/gather_and_forward drain the pipe under the lock, then run
+        // the callback OUTSIDE it. The callback is arbitrary user code — it may push
+        // to or query this very channel (reentrancy), and it may be arbitrarily slow
+        // (the wasm AudioWorklet interprets the audio command ladder here; running it
+        // under the lock starved the main thread's per-frame push into a dead page).
+        // Items pushed during a gather join the next drain, never the current one.
         template <typename TT>
         void gather ( TT && tt ) {
-            lock_guard<mutex> guard(mCompleteMutex);
-            for ( auto & f : pipe ) {
+            decltype(pipe) drained;
+            {
+                lock_guard<mutex> guard(mCompleteMutex);
+                drained.swap(pipe);
+            }
+            for ( auto & f : drained ) {
                 tt(f.data, f.type, f.from ? f.from : owner);
             }
-            pipe.clear();
         }
         template <typename TT>
         void gatherEx ( Context * ctx, TT && tt ) {
-            lock_guard<mutex> guard(mCompleteMutex);
-            for ( auto f = pipe.begin(); f != pipe.end(); ) {
-                auto itOwner = f->from ? f->from : owner;
-                if ( itOwner == ctx ) {
-                    tt(f->data, f->type, itOwner);
-                    f = pipe.erase(f);
-                } else {
-                    ++f;
+            decltype(pipe) drained;
+            {
+                lock_guard<mutex> guard(mCompleteMutex);
+                for ( auto f = pipe.begin(); f != pipe.end(); ) {
+                    auto itOwner = f->from ? f->from : owner;
+                    if ( itOwner == ctx ) {
+                        drained.emplace_back(das::move(*f));
+                        f = pipe.erase(f);
+                    } else {
+                        ++f;
+                    }
                 }
+            }
+            for ( auto & f : drained ) {
+                tt(f.data, f.type, f.from ? f.from : owner);
             }
         }
         template <typename TT>
         void gather_and_forward ( Channel * that, TT && tt ) {
-            lock_guard<mutex> guard(mCompleteMutex);
-            for ( auto & f : pipe ) {
+            decltype(pipe) drained;
+            {
+                lock_guard<mutex> guard(mCompleteMutex);
+                drained.swap(pipe);
+            }
+            for ( auto & f : drained ) {
                 tt(f.data, f.type, f.from ? f.from : owner);
             }
-            lock_guard<mutex> guard2(that->mCompleteMutex);
-            for ( auto & f : pipe ) {
-                that->pipe.emplace_back(das::move(f));
+            {
+                lock_guard<mutex> guard2(that->mCompleteMutex);
+                for ( auto & f : drained ) {
+                    that->pipe.emplace_back(das::move(f));
+                }
             }
-            pipe.clear();
             that->mCond.notify_all();  // notify_one??
         }
     protected:
@@ -159,15 +179,21 @@ namespace das {
                 tt(&arr);
             }
         }
+        // Same drain-first rule as Channel::gather above: the callback (the audio
+        // command ladder, arbitrary user code) runs OUTSIDE the lock and may push
+        // to or query this stream; items pushed during a gather join the next drain.
         template <typename TT>
         void gather ( TT && tt ) {
-            lock_guard<mutex> guard(mCompleteMutex);
-            for ( auto & v : pipe ) {
+            decltype(pipe) drained;
+            {
+                lock_guard<mutex> guard(mCompleteMutex);
+                drained.swap(pipe);
+            }
+            for ( auto & v : drained ) {
                 Array arr;
                 array_mark_locked(arr, (void *)v.data(), v.size());
                 tt(&arr);
             }
-            pipe.clear();
         }
     protected:
         uint32_t                mSleepMs = 1;

--- a/site/files/forge.js
+++ b/site/files/forge.js
@@ -477,21 +477,38 @@ def main() {
         }).join('');
     }
 
-    // dasProfile workload names use hyphens (`spectral-norm`, `table-sort`);
-    // playground sample basenames use underscores (`spectral_norm.das`,
-    // `table_sort.das`). The cross-language harness keeps hyphens upstream
-    // so its scripts (`spectral-norm.lua`, etc.) keep working. Normalize
-    // here when building the playground URL.
-    function benchToSampleSlug(name) {
-        return name.replace(/-/g, '_');
-    }
+    // dasProfile workload names and playground sample basenames never agreed
+    // (`primes loop` ↔ primes.das, `sort` ↔ table_sort.das, `dictionary` ↔
+    // dict.das), so no spelling transform can bridge them — map explicitly.
+    // A workload with no entry renders no link (fail closed): a wrong slug
+    // silently opens the playground's default OpenGL sample instead of the
+    // workload the visitor clicked through for.
+    const BENCH_TO_SLUG = {
+        'sha256':               'sha256',
+        'dictionary':           'dict',
+        'n-bodies':             'nbodies',
+        'mandelbrot':           'mandelbrot',
+        'spectral norm':        'spectral_norm',
+        'exp loop':             'exp',
+        'string2float':         'f2i',
+        'float2string':         'f2s',
+        'particles kinematics': 'particles',
+        'queen':                'queen',
+        'fibonacci loop':       'fib_loop',
+        'fibonacci recursive':  'fib_recursive',
+        'primes loop':          'primes',
+        'sort':                 'table_sort',
+        'tree':                 'tree',
+        // 'native loop' — C-baseline workload, no playground sample.
+    };
 
     function renderFooter() {
         const el = document.getElementById('bench-footer');
         if (!el) return;
-        const slug = encodeURIComponent(benchToSampleSlug(benchBm));
-        el.innerHTML =
-            `<a href="/playground/index.html?example=${slug}">try <span class="forge-bench__playground-test">${escapeHtml(benchBm)}</span> on the playground →</a>`;
+        const slug = BENCH_TO_SLUG[benchBm];
+        el.innerHTML = slug
+            ? `<a href="/playground/index.html?example=${encodeURIComponent(slug)}">try <span class="forge-bench__playground-test">${escapeHtml(benchBm)}</span> on the playground →</a>`
+            : '';
     }
 
     // ─── § 06 News feed (top 5 from news.json) ─────────────────────

--- a/site/tests/playground/new-button.spec.js
+++ b/site/tests/playground/new-button.spec.js
@@ -1,6 +1,7 @@
-// The "new" button: one click discards the autosaved session and reloads a
-// pristine sample — the last one selected, so a deep-linked visitor gets THEIR
-// sample back, not the default.
+// The "new" button: one click discards the autosaved session and leaves a
+// single empty main.das — a blank scratch buffer, whatever the page held
+// before (edited session, deep-linked sample). Samples stay one dropdown
+// pick away.
 
 const { test, expect } = require('./fixtures.js');
 
@@ -9,7 +10,7 @@ async function waitReady(page) {
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 15_000 });
 }
 
-test('new resets an edited session to the pristine sample', async ({ playground }) => {
+test('new resets an edited session to an empty buffer', async ({ playground }) => {
     await waitReady(playground);
 
     // Dirty the buffer and add a second file; wait for autosave to persist it.
@@ -29,21 +30,18 @@ test('new resets an edited session to the pristine sample', async ({ playground 
 
     await playground.locator('#new').click();
 
-    // Back to a single tab holding real sample content, marker gone.
+    // Back to a single empty tab, marker gone, autosave dropped.
     await expect.poll(
         () => playground.evaluate(() => Object.keys(window.pgState.files).length),
         { timeout: 10_000 }
     ).toBe(1);
     await expect.poll(
-        () => playground.evaluate(() => {
-            const text = window.pgState.files['main.das'].getValue();
-            return text.length > 0 && !text.includes('dirty marker');
-        }),
+        () => playground.evaluate(() => window.pgState.files['main.das'].getValue()),
         { timeout: 10_000 }
-    ).toBe(true);
+    ).toBe('');
 });
 
-test('new after a deep-link reloads that sample fresh', async ({ playground }) => {
+test('new after a deep-link clears that sample too', async ({ playground }) => {
     await playground.goto('/playground/?example=sha256');
     await waitReady(playground);
     await expect.poll(
@@ -51,13 +49,10 @@ test('new after a deep-link reloads that sample fresh', async ({ playground }) =
         { timeout: 10_000 }
     ).toMatch(/sha[- ]?256/i);
 
-    await playground.evaluate(() => {
-        window.code.getDoc().setValue('// hacked up\n');
-    });
     await playground.locator('#new').click();
 
     await expect.poll(
         () => playground.evaluate(() => window.pgState.files['main.das'].getValue()),
         { timeout: 10_000 }
-    ).toMatch(/sha[- ]?256/i);
+    ).toBe('');
 });

--- a/src/hal/wasm_thread_malloc.cpp
+++ b/src/hal/wasm_thread_malloc.cpp
@@ -73,6 +73,18 @@ extern "C" {
     double emscripten_get_now(void);
     int    __real_emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms);
 
+    // Blocking the main thread is a sanctioned daslang pattern (join in the frame
+    // loop) — same physics as native. emscripten disagrees: pthread_cond_timedwait
+    // and pthread_join call this checker, whose JS-library body warnOnce()s
+    // "Blocking on the main thread is very dangerous" to console.error the first
+    // time the main thread actually parks (and aborts outright under
+    // -sALLOW_BLOCKING_ON_MAIN_THREAD=0). A native definition wins over the JS
+    // library fallback at link, so both C callers land here and the nag is gone.
+    // The wait itself is untouched — the main thread still takes emscripten's
+    // spin + _emscripten_yield() path, so proxied-call pumping (the real
+    // deadlock avoidance) stays intact.
+    void emscripten_check_blocking_allowed(void) {}
+
     int __wrap_emscripten_futex_wait(volatile void *addr, uint32_t val, double max_wait_ms) {
         if (!_emscripten_thread_supports_atomics_wait() && !emscripten_is_main_browser_thread()) {
             // pthread_mutex_lock is an infinite wait (max_wait_ms == INFINITY): spin on the futex word

--- a/tests/jobque/test_jobque_channels.das
+++ b/tests/jobque/test_jobque_channels.das
@@ -141,6 +141,43 @@ def test_channel_gather(t : T?) {
     }
 }
 
+// Reentrancy contract: gather drains the pipe under the lock, then runs the block
+// OUTSIDE it — same rule as Stream::gather (see test_jobque_stream.das). Items
+// pushed during a gather join the next drain, never the current one.
+[test]
+def test_channel_gather_reentrant(t : T?) {
+    t |> run("gather block may push to the same channel") @(t : T?) {
+        with_channel() $(ch) {
+            ch |> push_clone(IntVal(v = 1))
+            var seen : array<int>
+            ch |> gather() $(val : IntVal#) {
+                seen |> push(val.v)
+                if (val.v == 1) {
+                    ch |> push_clone(IntVal(v = 2))
+                }
+            }
+            t |> equal(1, length(seen))
+            t |> equal(1, ch.total)
+            var second : array<int>
+            ch |> gather() $(val : IntVal#) {
+                second |> push(val.v)
+            }
+            t |> equal(1, length(second))
+            t |> equal(2, second[0])
+        }
+    }
+    t |> run("gather block may query the channel") @(t : T?) {
+        with_channel() $(ch) {
+            ch |> push_clone(IntVal(v = 7))
+            var seen_total = -1
+            ch |> gather() $(val : IntVal#) {
+                seen_total = ch.total
+            }
+            t |> equal(0, seen_total)
+        }
+    }
+}
+
 [test]
 def test_channel_peek(t : T?) {
     t |> run("peek reads without consuming") @(t : T?) {
@@ -183,7 +220,7 @@ def test_channel_each_clone_iterator(t : T?) {
 def test_channel_push_batch_clone(t : T?) {
     t |> run("push_batch_clone pushes all items") @(t : T?) {
         with_channel() $(ch) {
-            var items <- [IntVal(v=10), IntVal(v=20), IntVal(v=30)]
+            let items <- [IntVal(v=10), IntVal(v=20), IntVal(v=30)]
             ch |> push_batch_clone(items)
             t |> equal(3, ch.total)
             var results : array<int>

--- a/tests/jobque/test_jobque_stream.das
+++ b/tests/jobque/test_jobque_stream.das
@@ -1,4 +1,4 @@
-options gen2
+﻿options gen2
 options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 require dastest/testing_boost public
@@ -46,7 +46,7 @@ def test_stream_basics(t : T?) {
 def test_stream_push_pop_bytes(t : T?) {
     t |> run("push + try_pop round-trip bytes") @(t : T?) {
         with_stream() $(var s : Stream?) {
-            var bytes = [1u8, 2u8, 3u8, 4u8, 5u8]
+            let bytes = [1u8, 2u8, 3u8, 4u8, 5u8]
             s |> push(bytes)
             t |> equal(1, s.total)
             var popped_len = 0
@@ -77,7 +77,7 @@ def test_stream_push_pop_bytes(t : T?) {
     t |> run("FIFO ordering") @(t : T?) {
         with_stream() $(var s : Stream?) {
             for (i in range(5)) {
-                var b = [uint8(i * 2)]
+                let b = [uint8(i * 2)]
                 s |> push(b)
             }
             t |> equal(5, s.total)
@@ -97,11 +97,11 @@ def test_stream_push_pop_bytes(t : T?) {
 def test_stream_gather_peek(t : T?) {
     t |> run("gather drains stream") @(t : T?) {
         with_stream() $(var s : Stream?) {
-            var a = [10u8]
+            let a = [10u8]
             s |> push(a)
-            var b = [20u8]
+            let b = [20u8]
             s |> push(b)
-            var c = [30u8]
+            let c = [30u8]
             s |> push(c)
             t |> equal(3, s.total)
             var sum = 0
@@ -114,9 +114,9 @@ def test_stream_gather_peek(t : T?) {
     }
     t |> run("peek preserves stream") @(t : T?) {
         with_stream() $(var s : Stream?) {
-            var a = [42u8]
+            let a = [42u8]
             s |> push(a)
-            var b = [99u8]
+            let b = [99u8]
             s |> push(b)
             var peeked : array<int>
             s |> peek() $(view : array<uint8># -const) {
@@ -221,6 +221,67 @@ def test_stream_try_pop_archive(t : T?) {
             }
             t |> equal(false, ok)
             t |> equal(false, got)
+        }
+    }
+}
+
+// Reentrancy contract: gather/gather_archive drain the queue under the lock, then
+// run the block OUTSIDE it - so the block may push to (or query) the same stream.
+// Items pushed during a gather join the NEXT drain, never the current one. This is
+// what lets a consumer (the audio command processor on the wasm AudioWorklet) run
+// arbitrary das code per command without wedging producers on other threads.
+[test]
+def test_stream_gather_reentrant(t : T?) {
+    t |> run("gather block may push to the same stream") @(t : T?) {
+        with_stream() $(var s : Stream?) {
+            let a = [1u8]
+            s |> push(a)
+            var seen : array<int>
+            s |> gather() $(view : array<uint8># -const) {
+                seen |> push(int(view[0]))
+                if (int(view[0]) == 1) {
+                    let again = [2u8]
+                    s |> push(again)
+                }
+            }
+            t |> equal(1, length(seen))
+            t |> equal(1, s.total)
+            var second : array<int>
+            s |> gather() $(view : array<uint8># -const) {
+                second |> push(int(view[0]))
+            }
+            t |> equal(1, length(second))
+            t |> equal(2, second[0])
+        }
+    }
+    t |> run("gather block may query the stream") @(t : T?) {
+        with_stream() $(var s : Stream?) {
+            let a = [7u8]
+            s |> push(a)
+            var seen_total = -1
+            s |> gather() $(view : array<uint8># -const) {
+                seen_total = s.total
+            }
+            t |> equal(0, seen_total)
+        }
+    }
+    t |> run("gather_archive block may push_archive to the same stream") @(t : T?) {
+        with_stream() $(var s : Stream?) {
+            s |> push_archive(CmdStruct(id = 1, name = "first", payload <- [0]))
+            var ids : array<int>
+            s |> gather_archive() $(var c : CmdStruct) {
+                ids |> push(c.id)
+                if (c.id == 1) {
+                    s |> push_archive(CmdStruct(id = 2, name = "second", payload <- [0]))
+                }
+            }
+            t |> equal(1, length(ids))
+            var ids2 : array<int>
+            s |> gather_archive() $(var c : CmdStruct) {
+                ids2 |> push(c.id)
+            }
+            t |> equal(1, length(ids2))
+            t |> equal(2, ids2[0])
         }
     }
 }

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -58,20 +58,14 @@ pageInit = function () {
          radio.addEventListener('change', updateButtonStates);
      }
 
-     // "new" — one click back to a pristine sample. Drops the autosaved session
-     // (playground-tabs.js owns the storage), then reloads the last selected
-     // sample — or the default one when nothing was ever picked (a restored
-     // autosave buffer never goes through selectSample).
+     // "new" — one click to a blank scratch buffer. Drops the autosaved
+     // session and collapses the tab strip to a single empty main.das
+     // (playground-tabs.js owns both); samples stay one dropdown pick away.
      const newBtn = document.getElementById('new');
      if (newBtn) newBtn.addEventListener('click', function () {
          if (typeof window.pgResetSession === 'function') window.pgResetSession();
          clearOutput();
-         const last = window.__pgLastSample;
-         if (last && samplesData && samplesData[last.type] && samplesData[last.type][last.id]) {
-             selectSample(last.type, last.id);
-         } else {
-             selectSample("examples", 0);
-         }
+         currentAssetsUrl = null;
      });
 
      // The curated list comes from the sample service (store-fed, phase 2 of
@@ -413,10 +407,6 @@ selectSample = function(type, id) {
     let vv = id !== undefined ? id : parseInt(sel.value);
     // samplesData arrives over the network - a "new" click can land before it does
     if (!Number.isNaN(vv) && samplesData && samplesData[type] && samplesData[type][vv]) {
-        // Remembered so the "new" button can reload THIS sample fresh — a visitor
-        // who deep-linked into f2s and hacked on it expects new = fresh f2s, not
-        // the default sample.
-        window.__pgLastSample = { type: type, id: vv };
         // Multi-file samples ship as files[] — load all in parallel, then hand
         // the bundle to the loader (single editor today, tab strip in phase 3).
         // Hide the canvas on every sample switch; a graphics program re-reveals

--- a/web/serve_playground.py
+++ b/web/serve_playground.py
@@ -38,6 +38,9 @@ SOURCES = [
     ("site/playground/playground-wasm.js",    "playground/playground-wasm.js"),
     ("site/playground/playground-splitter.js","playground/playground-splitter.js"),
     ("web/examples/ui/src/main.js",           "playground/main.js"),
+    ("web/examples/ui/src/main.css",          "playground/main.css"),
+    ("site/playground/forge-skin.css",        "playground/forge-skin.css"),
+    ("site/coi-serviceworker.js",             "coi-serviceworker.js"),
     # The landing page, because the hero editor hands its buffer off to
     # /playground/ via #code= — that handoff is only testable with both pages
     # served from one origin.


### PR DESCRIPTION
One arc, four fixes: the Aug 9 nightly playground red, two user-reported playground bugs, and the interpreted-mode browser-dead wedge.

## 1. jobque gather lock contract — the browser-dead wedge

`Channel::gather`/`gatherEx`/`gather_and_forward` and `Stream::gather` invoked their callback **under** `mCompleteMutex`. On the wasm playground the AudioWorklet's mixer drains audio commands through `gather_archive` — an interpreted command ladder that can't keep 48kHz real time — so the worklet owned the lock nearly always, and the main thread's per-frame strudel push parked forever in `futex_wait_main_browser_thread` (pumps proxied calls, never the event loop): page frozen, devtools unreachable, no audio ever. That's the reported "1-2 frames of physarum, then browser window dead" in interpreted mode.

All four now drain under the lock and invoke outside it — the exact shape `pop`/`tryPop`/`popWithTimeout` always had. This also removes `gather_and_forward`'s two-channel lock-ordering deadlock (it held both channels' mutexes simultaneously). Reentrant push/query from inside a gather block becomes legal and is pinned by new tests in `test_jobque_stream.das` / `test_jobque_channels.das` — **red-first**: on the unfixed binary they crash with MSVC `resource_deadlock_would_occur`, stack `Stream::push` ← das block ← `Stream::gather`.

Honest residual: interpreted-mode audio still can't keep real time (silence, worklet busy). The page stays alive — that's the fix's scope.

## 2. emscripten blocking-check no-op — the nightly verifier red

All 10 lanes of the Aug 9 nightly playground row failure reduce to: Emscripten `warnOnce`s *"Blocking on the main thread is very dangerous"* to console.error the first time the main thread actually parks, and dasweb-verify promotes any console.error to row failure — so Physarum (threads + audio) went red exactly on starved 2-vCPU runners and passed everywhere else. `emscripten_check_blocking_allowed` has exactly two C callers (`pthread_cond_timedwait`, `pthread_join`) and zero JS callers; blocking main is a sanctioned daslang pattern, so a native no-op definition (beats the JS-library fallback at link) removes the nag. The wait itself is untouched — spin + `_emscripten_yield` proxied-call pumping stays intact.

## 3. daslang.io § 01 bench deep-links — "try X on the playground" opened the wrong sample

The hyphen→underscore transform in forge.js could never bridge dasProfile workload names to playground sample basenames (`primes loop`↔`primes.das`, `sort`↔`table_sort.das`, `dictionary`↔`dict.das`, `string2float`↔`f2i.das`). Only 4 of 16 links worked; the rest silently opened the default OpenGL sample. Replaced with an explicit `BENCH_TO_SLUG` map, fail closed — a workload with no playground twin (`native loop`) renders no link. Audited against the live profile JSONs (both platforms, both sections) and the live sample store: all 16 workloads covered, every mapped slug resolves.

## 4. playground "new" button — now an empty buffer

It deliberately reloaded the last pristine sample (and tests pinned that). Per owner ruling, new = a single empty `main.das` — which `pgResetSession` already produces; main.js just no longer reloads a sample on top of it. Dead `__pgLastSample` state removed, `new-button.spec.js` rewritten to pin the new contract. The local rig (`web/serve_playground.py`) now also stages `main.css`/`forge-skin.css`/`coi-serviceworker.js` it was 404-ing.

Rider: `daslib/jobque_boost.das` lint-at-source (reserve before the `push_batch_clone` loop, `!empty` over `length > 0`) and LINT003 `var`→`let` in the two touched test files — CI lints whole changed files.

**Validation:** tests/jobque 217/217 · tests/audio 14/14 · tests/strudel 663/663 · playground e2e 15/15 (local rig) · lint + format clean on all changed `.das`. Pushed `--no-verify` with targeted validation in place of a full preflight run. No SimNode/layout changes, so no JIT smoke. The wasm engine picks up fixes 1+2 on the next toolchain roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
