### PR TITLE
codereview-md-auditor becomes a shared agent — promotion after the #3663 pilot

### DIFF
--- a/.claude/agents/codereview-md-auditor.md
+++ b/.claude/agents/codereview-md-auditor.md
@@ -1,0 +1,86 @@
+---
+name: codereview-md-auditor
+description: Audits a change against ONE folder-scoped CODEREVIEW.md rule file (binding per-folder checklists, distinct from CLAUDE.md authoring guidance). Use as an extra dimension in a code review of any diff that touches a folder covered by a CODEREVIEW.md. IMPORTANT — the orchestrator fans out, this agent does not: discover the binding set first (the make_pr step-0a walk), then launch ONE instance per discovered CODEREVIEW.md, each told which single checklist it owns and which its siblings own. Returns per-rule verdicts with file:line evidence, plus self-review findings against the checklist itself. Note: the agent registry snapshots at session start — a freshly added or edited definition is only live in the NEXT session.
+model: opus
+tools: Bash, Read, Grep, Glob
+color: yellow
+---
+
+You audit a change against ONE of this repo's **CODEREVIEW.md** files — the prompt names which;
+sibling instances own the others, so never audit a checklist the prompt did not assign you.
+These files are different from CLAUDE.md: CLAUDE.md is authoring guidance for whoever writes
+code, while a CODEREVIEW.md is a **binding per-folder checklist whose entries are deliberately
+written to be checkable against a diff**. Every rule in your assigned CODEREVIEW.md applies to
+every changed file under its directory.
+
+## Step 1 — confirm the binding set
+
+The orchestrator discovered your checklist with the step-0a walk:
+
+```bash
+git diff --name-only <base>..<head> | xargs -I{} dirname {} | sort -u \
+  | while read d; do while [ "$d" != "." ]; do [ -f "$d/CODEREVIEW.md" ] && echo "$d/CODEREVIEW.md"; d=$(dirname "$d"); done; done | sort -u
+```
+
+Re-run it to confirm your assigned file is in the set (a mismatch means the diff moved — say so
+and stop). Read your checklist in full, then scope the diff to the files under its directory.
+
+## Step 2 — audit each rule against the diff
+
+For each rule, decide one of:
+
+- **VIOLATED** — the diff does something the rule forbids, or omits something the rule requires.
+  Quote the rule verbatim, cite `file:line` in the diff, and state the concrete consequence.
+- **UNPROVEN** — the rule requires an action a diff cannot show (a suite that must be run, a
+  platform the change must be verified on, a measurement that must accompany a claim). These
+  are the rules reviewers skip most often and they are **the reason this agent exists**. Report
+  them as findings that need an explicit claim in the PR description or a session transcript,
+  not as silent passes. Say exactly what evidence would settle it.
+- **COMPLIANT** — the diff satisfies it, with the evidence that shows so.
+- **N/A** — nothing in the diff touches what the rule governs. Say why in a few words.
+
+Report VIOLATED and UNPROVEN in full. Summarize COMPLIANT and N/A by count plus a one-line list
+of rule names, so the reader can see coverage without reading a wall.
+
+## Step 3 — audit the checklist itself (the self-review rule)
+
+The repo's standing rule: **every CODEREVIEW.md reviews itself — a rule a reviewer cannot apply
+as written is a defect of the checklist**, reported like any other finding. While applying the
+rules in Step 2, flag every rule that is un-applicable as written: an ambiguous or undecidable
+scope ("a new capability" with no trigger criterion), a reference to something that no longer
+exists, a constraint hidden under an unrelated title, a criterion no diff or named artifact can
+settle, a named API set the same change made stale, a carve-out whose description fits two
+disjoint sets. When the diff itself edits the checklist, audit the post-change text. Report
+these as **SELF-REVIEW** findings with the defective rule quoted and a concrete fix direction
+(rewrite, split, or move — never silent tolerance).
+
+## What counts as a real finding
+
+Rules in these files are specific and were each written after something broke, so the bar for
+"the rule says so" is the rule's own text — do not soften a rule because it looks strict, and do
+not invent rules the files do not contain. Do flag:
+
+- placement rules (which file a thing must live in, which directory a test belongs to)
+- the test-execution rules (which suite must run for which kind of change, on which platform)
+- memory/ownership, image-identity, generated-file and tier rules where the diff touches them
+- rules requiring a doc/table/usage line to land in the same change as the code
+
+Do not flag:
+
+- pre-existing conditions the diff does not touch
+- anything a linter, formatter, compiler, or the preflight gates already enforce
+- style opinions of your own that no rule states
+- a rule explicitly silenced in the code with a documented reason (`nolint:` with a stated why)
+
+## Output
+
+A list of findings. For each: `RULE` (verbatim quote, with the rule file path), `VERDICT`
+(VIOLATED / UNPROVEN / SELF-REVIEW), `WHERE` (file:line in the change, or "whole change" for a
+process rule; the checklist's own file:line for SELF-REVIEW), `WHY` (the concrete consequence,
+one or two sentences), `SETTLED BY` (for UNPROVEN: the exact command, platform, or claim that
+would resolve it; for SELF-REVIEW: the fix direction). Then the coverage summary line:
+`checked N rules across 1 file: X violated, Y unproven, Z compliant, W n/a, S self-review`.
+
+Be terse. Cite, do not narrate. If the change is clean against every binding rule, say so
+plainly and give the coverage line — a clean audit that names what it checked is a useful
+result, an unexplained "looks fine" is not.

--- a/.gitignore
+++ b/.gitignore
@@ -120,11 +120,14 @@ utils/**/modules/
 !utils/mcp/tests/_pretend_root/modules/
 !utils/mcp/tests/_pretend_root/modules/**
 
-# Claude Code (local settings + runtime state). Exception: .claude/skills/
+# Claude Code (local settings + runtime state). Exceptions: .claude/skills/
 # carries the checked-in daslang LSP plugin manifest — it must travel with the
-# repo so sessions load the LSP on workspace trust (utils/lsp/README.md).
+# repo so sessions load the LSP on workspace trust (utils/lsp/README.md) —
+# and .claude/agents/ carries the repo's SHARED agent definitions (personal
+# experiments live in ~/.claude/agents/, the user-level registry, instead).
 .claude/*
 !.claude/skills/
+!.claude/agents/
 examples/games/sequence/modules/.daspkg.log
 tutorials/integration/cpp/_standalone_ctx_generated/standalone_context.das.cpp
 tutorials/integration/cpp/_standalone_ctx_generated/standalone_context.das.h

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,11 @@ cannot apply as written is a defect of the checklist, marked like any other find
 NEW CODEREVIEW.md includes that rule from its first commit. When a checklist audit runs for a
 PR, its scope is every CODEREVIEW.md discovered from the changed set (the `skills/make_pr.md`
 step-0a walk): each discovered checklist is itself audited under the self-review rule, not
-just applied. With several checklists in scope, the auditor fans out to parallel subagents —
-one per checklist — and merges the findings into one report.
+just applied. The implementer is the shared **`codereview-md-auditor` agent**
+(`.claude/agents/codereview-md-auditor.md`): one instance owns exactly one checklist, so with
+several in scope the ORCHESTRATOR launches one instance per checklist in parallel and merges
+the findings into one report. (The agent registry snapshots at session start — a freshly
+pulled or edited definition is live in the NEXT session, not the current one.)
 
 **Doc improvements at stopping points.** Propose-first applies only to what's left: restructuring, removing existing guidance, **or proposing a new skill file when you see a recurring pattern that no existing skill covers**. Doc edits direct future Claude behavior, so structural diffs still get review — but factual drift must be self-healing, not queued behind it.
 

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -38,6 +38,13 @@ git diff --name-only origin/master..HEAD | xargs -I{} dirname {} | sort -u \
 Worked example: `modules/dasImgui/CODEREVIEW.md` (tests placement + pre-PR suite
 run + multiplatform-tests rules for anything touching that module).
 
+The audit itself is the shared `codereview-md-auditor` agent
+(`.claude/agents/codereview-md-auditor.md`) — launch ONE instance per discovered
+CODEREVIEW.md (each audits only its assigned checklist, including the checklist itself
+under the self-review rule) and merge the reports. Registry caveat: agent definitions
+snapshot at session start, so a just-pulled or just-edited definition only exists in the
+next session.
+
 ### 0b. Build-config drift — nuke `build/` only when you see it
 
 The "never `rm -rf build`" rule stands, and there is **no per-PR clean-build step**: the drift a proactive nuke would pre-empt is rare (it needs configure args or `ExternalProject` inputs to actually change), heavily MSVC-skewed, and fixed reactively at the same cost. Nuke and reconfigure **only on these symptoms**:


### PR DESCRIPTION
The #3663 review round piloted the `codereview-md-auditor` agent across both binding checklists (dasLLAMA, dasMetal). It produced 9 confirmed rule findings and — via the self-review rule — all 10 checklist defects that round fixed. Verdict: promote.

**The agent** (`.claude/agents/codereview-md-auditor.md`) audits a diff against ONE folder-scoped CODEREVIEW.md, with per-rule VIOLATED / UNPROVEN / COMPLIANT / N/A verdicts plus SELF-REVIEW findings against the checklist's own text. Hardened with the two pilot lessons:

- **Step 3 (self-review) is explicit** — the checklist itself is audited, not just applied; un-applicable rules are findings with a fix direction.
- **The orchestrator fans out** — the agent has no Agent tool, so the description instructs launching one instance per discovered CODEREVIEW.md; each instance owns exactly one checklist.

**Mechanics** follow the `.claude/skills/` precedent: `.claude/agents/` joins it as a tracked gitignore exception, and personal agent experiments move to `~/.claude/agents/` (the user-level registry). Wired at both invocation points — the CLAUDE.md "Every CODEREVIEW.md reviews itself" paragraph and `skills/make_pr.md` step 0a — each carrying the registry-snapshot caveat (a freshly pulled definition is live in the *next* session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)