### PR TITLE
dasLLAMA: tensor-arm twin carriers are provisioned — and their absence is a red

### DIFF
--- a/modules/dasLLAMA/performance/fetch_models.das
+++ b/modules/dasLLAMA/performance/fetch_models.das
@@ -66,18 +66,18 @@ let private REF_Q8_RECIPE = "derive: setup_asr_rig.das --refs quantizes it from 
 def models_provenance() : array<ProvEntry> {   // nolint:STYLE038 — flat provenance manifest, one entry per carrier
     return <- [
         // ===== LLM board (pub_catalog), ascending size =====
-        ProvEntry(name = "gemma-4-12B-it-Q4_K_M.gguf", root = "llm",
-            url = "{HF}/lmstudio-community/gemma-4-12B-it-GGUF/resolve/main/gemma-4-12B-it-Q4_K_M.gguf",
-            bytes = 7381382944l, sha256 = "95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8"),
         // the tensor-arm twin carriers (tests/test_metal_support_matrix.das --arm tensor): small
         // on purpose - q8 drives the mulmm/attn twins, the K-quant one the kq mulmm twins. The
         // arm FAILS (not skips) when they are absent, so every box gets them provisioned here
-        ProvEntry(name = "Llama-3.2-1B-Instruct-Q8_0.gguf", root = "llm",
-            url = "{HF}/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q8_0.gguf",
-            bytes = 1321083008l, sha256 = "432f310a77f4650a88d0fd59ecdd7cebed8d684bafea53cbff0473542964f0c3"),
         ProvEntry(name = "Llama-3.2-1B-Instruct-Q5_K_M.gguf", root = "llm",
             url = "{HF}/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf",
             bytes = 911503488l, sha256 = "4f22f95fb1679ef8e2fd6f1659d23f06cd1dbedb79ff291db7413a7ae509e2a9"),
+        ProvEntry(name = "Llama-3.2-1B-Instruct-Q8_0.gguf", root = "llm",
+            url = "{HF}/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q8_0.gguf",
+            bytes = 1321083008l, sha256 = "432f310a77f4650a88d0fd59ecdd7cebed8d684bafea53cbff0473542964f0c3"),
+        ProvEntry(name = "gemma-4-12B-it-Q4_K_M.gguf", root = "llm",
+            url = "{HF}/lmstudio-community/gemma-4-12B-it-GGUF/resolve/main/gemma-4-12B-it-Q4_K_M.gguf",
+            bytes = 7381382944l, sha256 = "95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8"),
         ProvEntry(name = "gemma-4-E4B-it-Q8_0.gguf", root = "llm",
             url = "{HF}/ggml-org/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q8_0.gguf",
             bytes = 8031242688l, sha256 = "34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a"),

--- a/modules/dasLLAMA/performance/fetch_models.das
+++ b/modules/dasLLAMA/performance/fetch_models.das
@@ -63,12 +63,21 @@ let private REF_Q8_RECIPE = "derive: setup_asr_rig.das --refs quantizes it from 
 //! the ASR carriers (`asr_catalog` names). Local name differs from the upstream one where the
 //! catalog renamed (UD/MTP stems, the E2B mmproj's lowercase -bf16); the url keeps the remote
 //! spelling. gpt-oss is revision-pinned; every unpinned repo was byte-verified 2026-07-26.
-def models_provenance() : array<ProvEntry> {
+def models_provenance() : array<ProvEntry> {   // nolint:STYLE038 — flat provenance manifest, one entry per carrier
     return <- [
         // ===== LLM board (pub_catalog), ascending size =====
         ProvEntry(name = "gemma-4-12B-it-Q4_K_M.gguf", root = "llm",
             url = "{HF}/lmstudio-community/gemma-4-12B-it-GGUF/resolve/main/gemma-4-12B-it-Q4_K_M.gguf",
             bytes = 7381382944l, sha256 = "95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8"),
+        // the tensor-arm twin carriers (tests/test_metal_support_matrix.das --arm tensor): small
+        // on purpose - q8 drives the mulmm/attn twins, the K-quant one the kq mulmm twins. The
+        // arm FAILS (not skips) when they are absent, so every box gets them provisioned here
+        ProvEntry(name = "Llama-3.2-1B-Instruct-Q8_0.gguf", root = "llm",
+            url = "{HF}/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q8_0.gguf",
+            bytes = 1321083008l, sha256 = "432f310a77f4650a88d0fd59ecdd7cebed8d684bafea53cbff0473542964f0c3"),
+        ProvEntry(name = "Llama-3.2-1B-Instruct-Q5_K_M.gguf", root = "llm",
+            url = "{HF}/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf",
+            bytes = 911503488l, sha256 = "4f22f95fb1679ef8e2fd6f1659d23f06cd1dbedb79ff291db7413a7ae509e2a9"),
         ProvEntry(name = "gemma-4-E4B-it-Q8_0.gguf", root = "llm",
             url = "{HF}/ggml-org/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q8_0.gguf",
             bytes = 8031242688l, sha256 = "34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a"),

--- a/modules/dasLLAMA/tests/test_metal_support_matrix.das
+++ b/modules/dasLLAMA/tests/test_metal_support_matrix.das
@@ -781,7 +781,13 @@ def private qwen35_row(t : T?; path, family, tag : string; expect_needs : uint; 
 [unused_argument(t, path)]   // off-Apple the gated body is empty
 def private tensor_twin_row(t : T?; path, tag : string) {   // nolint:LINT012,LINT019 — tag is read by the das_metal arm
     static_if (typeinfo builtin_module_exists(das_metal)) {
-        if (!family_on(t, "llama") || !arm_on(t, "tensor") || !model_available(t, path)) {
+        if (!family_on(t, "llama") || !arm_on(t, "tensor")) {
+            return
+        }
+        // the carriers are provisioned (fetch_models.das), so absence is a RED, never a skip -
+        // a box that skips here ships every tensor twin unexercised
+        if (!stat(path).is_valid) {
+            t |> success(false, "tensor twin carrier missing: {path} - run fetch_models.das --fetch")
             return
         }
         let CROWNED = ("attn_avmm,attn_qkmm,gemm64b_q8,gemmb_q8,gemmb_sk_q8,kq_mulmm_k4," +

--- a/modules/dasLLAMA/tests/test_metal_support_matrix.das
+++ b/modules/dasLLAMA/tests/test_metal_support_matrix.das
@@ -787,7 +787,7 @@ def private tensor_twin_row(t : T?; path, tag : string) {   // nolint:LINT012,LI
         // the carriers are provisioned (fetch_models.das), so absence is a RED, never a skip -
         // a box that skips here ships every tensor twin unexercised
         if (!stat(path).is_valid) {
-            t |> success(false, "tensor twin carrier missing: {path} - run fetch_models.das --fetch")
+            t |> success(false, "tensor twin carrier missing: {path} - bin/daslang modules/dasLLAMA/performance/fetch_models.das -- --fetch")
             return
         }
         let CROWNED = ("attn_avmm,attn_qkmm,gemm64b_q8,gemmb_q8,gemmb_sk_q8,kq_mulmm_k4," +


### PR DESCRIPTION
## What

The tensor arm's carrier models (`Llama-3.2-1B-Instruct` Q8_0 + Q5_K_M — small on purpose: q8 drives the mulmm/attn twins, the K-quant one the `kq_mulmm` twins) were in no manifest — a standard bring-up never fetched them, the twin rows loud-skipped, and `--arm tensor` read `2 passed / 2 skipped` while every Metal-4 tensor twin shipped unexercised. Bit on the m4 today: the arm's first run tested nothing until the carriers were hand-fetched.

- Both carriers join `fetch_models.das` with sha pins (provenance manifest, BRINGUP §2 rig).
- Since provisioning now covers them, `tensor_twin_row` **fails** on an absent carrier instead of skipping, and the red names the fetch command.
- Q5_K_M is pinned at **current** upstream (`4f22f95f…`) — bartowski re-uploaded it bit-different since July (same drift class as the gemma-12B re-upload; adopt-current policy). The M1's July copy was refreshed to match, so both boxes test the same bytes.

## Gate

`run.das --arm tensor --suite matrix` green on the M1 with the refreshed carrier — and notably the twins **served there** (`metal_attn_qk_mm_t`/`av` 16 dispatches each, kq k5/k6, CPU == GPU token-exact): current macOS 26.5 runs the tensor kernels on M1 Max, so the arm now exercises twins on both boxes, not only the M4. Lint 0 issues, formatter clean.

Localized dasLLAMA change — targeted gates in lieu of full preflight, pushed `--no-verify` (announced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)