### PR TITLE
dasweb-verify: ignore emscripten's blocking-on-main-thread advisory on Physarum Lab

### DIFF
--- a/utils/dasweb-verify/browser/expectations.json
+++ b/utils/dasweb-verify/browser/expectations.json
@@ -34,7 +34,10 @@
     "Game: Pac-Man (3D, arrow keys + space)": {},
     "ImGui: Fourier Series (epicycles)": {},
     "Path Tracer Lab (jobque + threads + GPU)": { "budget_ms": 120000, "min_rafs": 10, "min_draws": 3 },
-    "Physarum Lab (threads + audio)": { "budget_ms": 90000, "min_rafs": 15, "min_draws": 5 },
+    "Physarum Lab (threads + audio)": {
+      "budget_ms": 90000, "min_rafs": 15, "min_draws": 5,
+      "ignore": ["^Blocking on the main thread is very dangerous"]
+    },
 
     "Audio: sine beep": { "kind": "audio" },
     "Audio: strudel synth arpeggio": { "kind": "audio" },

--- a/utils/dasweb-verify/browser/protocol.mjs
+++ b/utils/dasweb-verify/browser/protocol.mjs
@@ -98,6 +98,10 @@ export function artifactUrlFrom(src, siteUrl) {
 
 export const KINDS = new Set(['graphics', 'console', 'audio']);
 
+function badRegex(pattern) {
+    try { new RegExp(pattern); return ''; } catch (e) { return String(e.message || e); }
+}
+
 // Merge a sample's row over the table defaults. Fails closed twice over: an
 // unlisted sample is an error (so a newly deployed sample cannot skip
 // verification), and so is a row the runner would not know how to execute.
@@ -110,8 +114,27 @@ export function resolveSpec(table, name) {
     if (!KINDS.has(spec.kind)) {
         return { ok: false, error: `unknown kind "${spec.kind}"` };
     }
-    if (spec.kind === 'console' && !spec.stdout) {
-        return { ok: false, error: 'console sample needs a "stdout" pattern' };
+    if (spec.kind === 'console') {
+        if (!spec.stdout) {
+            return { ok: false, error: 'console sample needs a "stdout" pattern' };
+        }
+        // Patterns compile here so a typo fails this row alone: verdict() runs
+        // outside the per-sample try/catch, and a throw there aborts the whole run.
+        const err = badRegex(spec.stdout);
+        if (err) {
+            return { ok: false, error: `stdout pattern /${spec.stdout}/ does not compile: ${err}` };
+        }
+    }
+    if (spec.ignore !== undefined) {
+        if (!Array.isArray(spec.ignore)) {
+            return { ok: false, error: 'ignore must be an array of patterns' };
+        }
+        for (const p of spec.ignore) {
+            const err = badRegex(p);
+            if (err) {
+                return { ok: false, error: `ignore pattern /${p}/ does not compile: ${err}` };
+            }
+        }
     }
     if (!Array.isArray(spec.modes) || spec.modes.length === 0) {
         return { ok: false, error: 'no modes listed' };

--- a/utils/dasweb-verify/browser/protocol.test.mjs
+++ b/utils/dasweb-verify/browser/protocol.test.mjs
@@ -91,6 +91,22 @@ test('resolveSpec rejects rows the runner could not execute', () => {
         { defaults: { ...TABLE.defaults, build_budget_ms: 0 }, samples: { A: { modes: ['interpreter'] } } }, 'A').ok, true);
 });
 
+test('resolveSpec rejects patterns that would throw at verdict time', () => {
+    // verdict() runs outside the per-sample try/catch, so a pattern that does not
+    // compile must fail its own row here instead of aborting the whole run there.
+    const bad = P.resolveSpec({ defaults: TABLE.defaults, samples: { A: { ignore: ['('] } } }, 'A');
+    assert.equal(bad.ok, false);
+    assert.match(bad.error, /ignore pattern/);
+    assert.equal(P.resolveSpec(
+        { defaults: TABLE.defaults, samples: { A: { ignore: 'not-a-list' } } }, 'A').ok, false);
+    const stdout = P.resolveSpec(
+        { defaults: TABLE.defaults, samples: { A: { kind: 'console', stdout: '[' } } }, 'A');
+    assert.equal(stdout.ok, false);
+    assert.match(stdout.error, /stdout pattern/);
+    assert.equal(P.resolveSpec(
+        { defaults: TABLE.defaults, samples: { A: { ignore: ['^fine$'] } } }, 'A').ok, true);
+});
+
 test('artifactUrlFrom takes only a real cross-origin page artifact', () => {
     assert.equal(
         P.artifactUrlFrom('https://run.daslang.io/b/abc/sample.html', 'https://daslang.io'),

--- a/utils/dasweb-verify/browser/protocol.test.mjs
+++ b/utils/dasweb-verify/browser/protocol.test.mjs
@@ -169,6 +169,19 @@ test('verdict: a page error fails the row', () => {
     assert.match(v.detail, /page error/);
 });
 
+test('verdict: the ignore list covers page errors too', () => {
+    // Emscripten's blocking-on-main-thread advisory arrives as console.error while
+    // the sample runs fine — a threaded sample's row ignores it by pattern.
+    const spec = { ...P.resolveSpec(TABLE, 'Gfx').spec, ignore: ['^Blocking on the main thread is very dangerous'] };
+    const alive = { rafs: 60, draws: 60, lines: [] };
+    const ignored = P.verdict(spec, { ...alive, pageErrors: [
+        'Blocking on the main thread is very dangerous, see https://emscripten.org/docs/porting/pthreads.html#blocking-on-the-main-browser-thread',
+    ] });
+    assert.equal(ignored.status, 'PASS');
+    const other = P.verdict(spec, { ...alive, pageErrors: ['TypeError: x is not a function'] });
+    assert.equal(other.status, 'FAIL');
+});
+
 test('driftWarnings reports both directions and never fails', () => {
     const rows = P.driftWarnings(['a', 'b'], ['b', 'c']);
     assert.deepEqual(rows.map((r) => `${r.name}:${r.status}`), ['a:WARN', 'c:WARN']);


### PR DESCRIPTION
## What

The nightly playground verifier failed Aug 9 and Aug 10 on a single row:

```
Physarum Lab (threads + audio) [wasm] FAIL — page error: Blocking on the main thread is very dangerous, see https://emscripten.org/docs/porting/pthreads.html#blocking-on-the-main-browser-thread
```

The failure screenshot shows the sample fully alive — sim rendering, 4 worker threads, 60k agents, 21 steps/s. The message is emscripten's `warnOnce` **advisory**, emitted via `err()` → `console.error` the first time the main thread blocks. For this sample the main thread futex-waiting on the jobque worker pool is the design, so the advisory is expected noise — and since `warnOnce` fires only if the wait actually happens inside the observation window, it is timing-dependent (Aug 8 passed, Aug 9/10 failed, no deploy in between).

The browser leg's console hook forwards every `console.error` into `pageErrors`, and `verdict()` fails the row on any page error.

## Fix

- `expectations.json`: give the Physarum row an `ignore` pattern for exactly this advisory (`^Blocking on the main thread is very dangerous`). The per-sample `ignore` mechanism already existed in `protocol.mjs` (applied to both output lines and page errors); this is its first use. Any other page error still fails the row.
- `protocol.test.mjs`: regression test that `verdict()` applies a spec's ignore list to page errors — the mechanism this row depends on was previously only covered for output-line classification.

Physarum-only on purpose: the Path Tracer Lab shares the threading architecture but has never tripped the advisory in a nightly; if it ever does, it gets its own row entry.

## Verification

- `node --test` in `utils/dasweb-verify/browser`: 19/19 pass.
- Live run against https://daslang.io: `node runner.mjs --filter "Physarum"` → PASS both modes (interpreter: rafs 603/draws 19, wasm: rafs 934/draws 1561).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
