### PR TITLE
ast_verify: skip stub functions in the post-infer verify (nightly --ast-verify sweep false positive)

### DIFF
--- a/daslib/ast_verify.das
+++ b/daslib/ast_verify.das
@@ -784,10 +784,11 @@ class private AstPostInferVerifyVisitor : AstVisitor {
         compiling_program() |> macro_error(at, "AST verify (post-infer): {msg}")
     }
 
-    // A template body is expanded per instantiation, so it carries no types; a generated
-    // body (lambda, generator) IS codegen'd, so unlike the infer-time pass it is checked.
+    // A template body is expanded per instantiation and a stub body (dasbind [extern]) is
+    // never inferred - InferTypes::canVisitFunction skips both, as does every pass this
+    // verifier guards. A generated body (lambda, generator) IS codegen'd, so it is checked.
     def override canVisitFunction(fun : Function?) : bool {
-        return !fun.moreFlags.isTemplate
+        return !fun.moreFlags.isTemplate && !fun.moreFlags.stub
     }
 
     def override preVisitFunction(var fun : FunctionPtr) : void {

--- a/utils/ast-fuzz/selftest/late_extern_stub.das
+++ b/utils/ast-fuzz/selftest/late_extern_stub.das
@@ -1,0 +1,15 @@
+options gen2
+require dasbind public
+
+// dasbind marks this function stub=true and infer never enters the body (calls are
+// retargeted to the DasBindFunction proxy), so the zero-arg int() below legitimately
+// keeps a null func - the post-infer verify must skip it, like every pass it guards.
+[extern(cdecl, late, name="NoSuchFunction", library="NoSuchLibrary")]
+def late_extern_stub() : int {
+    return int()
+}
+
+[export]
+def main {
+    print("ok\n")
+}

--- a/utils/ast-fuzz/test_ast_fuzz.das
+++ b/utils/ast-fuzz/test_ast_fuzz.das
@@ -50,6 +50,16 @@ def test_ast_verify_clean_on_valid_code(t : T?) {
 }
 
 [test]
+def test_ast_verify_skips_late_extern_stubs(t : T?) {
+    // a dasbind stub body is never inferred (InferTypes::canVisitFunction skips
+    // stub=true), so its unresolved int() must not trip the post-infer verify
+    var out : string
+    let ec = run([BIN, "--ast-verify", "utils/ast-fuzz/selftest/late_extern_stub.das"], out, 60.0)
+    t |> equal(ec, 0)
+    t |> success(find(out, "AST verify") < 0, "reported on a stub body\n{out}")
+}
+
+[test]
 def test_every_visitor_deref_has_a_repair(t : T?) {
     var out : string
     let ec = run([BIN, "utils/ast-fuzz/gen_invariants.das"], out, 180.0)


### PR DESCRIPTION
## What

Last night's **extended checks** cron failed on the `Compile tests/ with --ast-verify` sweep — its first scheduled firing since the step went nightly-only:

```
### ./tests/opengl_gpu/_lattice_gpu_parity.das
AST verify (post-infer): ExprCall 'int' has an unresolved func after inference at modules/dasOpenGL/opengl/opengl_func.das:1216:11
(+ 4 more, all int()/float() in dasOpenGL late-extern stub bodies)
```

## Root cause — verifier false positive

dasbind's `[extern(...)]` annotation marks the annotated function `stub = true` (`module_builtin_dasbind.cpp` `apply()`); calls are retargeted to the `DasBindFunction` proxy at `transformCall` time. `InferTypes::canVisitFunction` returns `false` for stubs (`ast_infer_type.cpp:668`), so a stub body is **never inferred** — the zero-arg `int()` / `float()` default-value calls in dasOpenGL's generated stubs legitimately keep `func == null`. Every pass the verifier protects (`allocate_stack`, `cse`, `dse`, `unused`, …) skips stubs the same way, so nothing ever dereferences those nulls.

The post-infer verify visitor (`daslib/ast_verify.das`) skipped only templates, walked the stub bodies, and reported the never-inferred calls.

## Fix

`AstPostInferVerifyVisitor.canVisitFunction` now also skips `moreFlags.stub` — one condition, mirroring the C++ passes. The infer-time (structural) visitor is deliberately unchanged: a stub body is normally parsed AST, and null/cycle checks on it remain valid.

New selftest `utils/ast-fuzz/selftest/late_extern_stub.das` (a `late` dasbind extern against a nonexistent library, body `return int()`) + `test_ast_verify_skips_late_extern_stubs` in `test_ast_fuzz.das`, following the existing `test_ast_verify_clean_on_valid_code` shape.

## Verification (local, rebuilt daslang)

- Pre-fix repro: `daslang --ast-verify -compile-only tests/opengl_gpu/_lattice_gpu_parity.das` reports the exact CI errors; the minimal stub file reports too.
- Post-fix: both compile clean (0 verifier lines, exit 0).
- Detection intact: the three corruption victims (`run.das`, `cycle.das`, `null_entry.das`) still report null child / cycle / null entry; `cli_victim.das` still clean under `--ast-verify`.
- Lint: 3 files, 0 issues. Format: already formatted.
- Note: the `test_ast_fuzz.das` suite can't run in the local MSVC layout (it spawns `bin/daslang`, single-config CI layout; all 7 tests fail with spawn exit −1 before this change too) — validated by direct invocation above; CI runs the suite on all three OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
