### PR TITLE
bench records: the noise verdict rides the row, and the das backend cell names the armed vulkan tier

### DIFF
--- a/modules/dasLLAMA/METHODOLOGY.md
+++ b/modules/dasLLAMA/METHODOLOGY.md
@@ -126,6 +126,9 @@ touches it goes through the same schema.
   flavor (`clean-cpu`, `stock`, `metal`).
 - **`tune`** is required on das rows. Per-box tuning makes two identical machines legitimately
   differ, so a das number without its tune stamp is not reproducible and does not ship.
+- **`noise`** copies the mint's noise verdict out of the sidecar provenance (`ok` or
+  `overridden`): a row measured under a noise-overridden mint says so on the board, not only
+  inside the sidecar.
 - **`hardware`** is auto-probed on the box, never typed in — it is the block a reader has to be
   able to trust.
 - **`source`** is `official` or `community`.

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -228,7 +228,8 @@ def private asr_measure_spec(spec : AsrModelSpec; reps, threads : int; var jsonM
         workload = asr_workload(spec), box = box_name(), threads = threads,
         date = format_time(get_clock(), "%Y-%m-%d"), cmd = bench_cmd_line(), env = bench_env_line(),
         sha = run_capture("git rev-parse --short=9 HEAD", true), version = das_version(),
-        tune = tune_summary(), tune_sha = tune_manifest_sha(), hardware = gather_hardware())
+        tune = tune_summary(), tune_sha = tune_manifest_sha(), noise = tune_manifest_noise(),
+        hardware = gather_hardware())
     run.files |> emplace(file_identity(model_path, "weights"))
     if (!empty(spec.das_mmproj)) {
         run.files |> emplace(file_identity("{spec.root}{spec.das_mmproj}", "mmproj"))
@@ -866,11 +867,15 @@ def main() : int {
             delete refRows
             continue
         }
+        // the das row's backend is what OUR engine ran on — metal (--ngl protocol), the armed
+        // vulkan tier, or cpu; the reference row keeps the --ngl-derived value (llama-bench
+        // knows nothing of the vulkan tier)
         let backend = gpu ? "metal" : "cpu"
+        let das_backend = gpu ? "metal" : (moe_gpu_tier_installed() ? "vulkan" : "cpu")
         let gguf = base_name(mpath)
         if (fmt == OutFmt.md) {
             for (st in results) {
-                var row <- ["das", gguf, backend, "{cfg.ngl}", "{threads}", st.test, "{st.mean:.2f} ± {st.sd:.2f}"]
+                var row <- ["das", gguf, das_backend, "{cfg.ngl}", "{threads}", st.test, "{st.mean:.2f} ± {st.sd:.2f}"]
                 mdRows |> emplace(row)
             }
             for (rr in refRows) {
@@ -898,7 +903,7 @@ def main() : int {
     }
     var dr = BenchRun(
         engine = "das",
-        backend = backend,
+        backend = das_backend,
         flavor = flavor_stamp(cfg.accel ? "accel" : "tuned"),
         box = box,
         threads = threads,
@@ -909,6 +914,7 @@ def main() : int {
         version = das_version(),
         tune = tune_summary(),
         tune_sha = tune_manifest_sha(),
+        noise = tune_manifest_noise(),
         exec_fmt = execFmt,
         hardware = hw,
         tests <- tests_of(results))

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -909,7 +909,7 @@ def tune_manifest_noise() : string {
     }
     var err = ""
     var doc = read_json(fread(path), err)
-    let verdict = "{doc?["provenance"]?["noise"] ?? ""}"   // interpolation copies out of the doc before delete
+    let verdict = doc?["provenance"]?["noise"] ?? ""   // string-heap value; safe past delete_json (nodes only)
     delete_json(doc)
     return verdict
 }

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -16,6 +16,7 @@ require math
 require daslib/strings_boost public
 require daslib/logger public              // structured, ISO-8601-timestamped ndjson event log
 require daslib/json public                // JV(...) for logger field payloads
+require daslib/json_boost                 // ?[] / ?? navigation — the sidecar provenance reader
 require dasllama/dasllama_common public   // QuantMode
 require dasllama/dasllama_math            // active_kernel_backend — the exec_fmt layout receipt
 require llvm/daslib/llvm_tune             // tune_status — stamp provenance for the platform block
@@ -898,6 +899,21 @@ def tune_manifest_sha() : string {
     return sidecar_generation_sha(tune_manifest_path())
 }
 
+//! The mint's noise verdict from the sidecar provenance ("ok" | "overridden"; "" when the
+//! sidecar or its provenance is absent) — records copy it so a mint taken through a failing
+//! noise gate is visible on the board, not only inside the sidecar.
+def tune_manifest_noise() : string {
+    let path = tune_manifest_path()
+    if (!stat(path).is_valid) {
+        return ""
+    }
+    var err = ""
+    var doc = read_json(fread(path), err)
+    let verdict = "{doc?["provenance"]?["noise"] ?? ""}"   // interpolation copies out of the doc before delete
+    delete_json(doc)
+    return verdict
+}
+
     //! sha256 of an explicit sidecar file — the oracle's current-generation probe; "" when absent.
 def sidecar_generation_sha(path : string) : string {
     return stat(path).is_valid ? compute_sha256(path) : ""
@@ -1621,6 +1637,8 @@ struct BenchRun {
     @optional tune : string     // das gen-kernel stamp provenance — required for reproducibility
     @optional tune_sha : string // sha256 of the tune sidecar the exe shipped with — the sidecar
                                 // GENERATION; rows across generations are not comparable
+    @optional noise : string    // the mint's noise verdict from the sidecar provenance ("ok" |
+                                // "overridden") — an overridden mint shows on the board, not only in the sidecar
     @optional exec_fmt : string // what this engine EXECUTES for this file (weight formats per site
                                 // class + activation/scale treatment) — the apples-to-apples receipt;
                                 // das derives it from the loaded Model, llama.cpp rows from flavor

--- a/modules/dasLLAMA/tests/test_bench_records_schema.das
+++ b/modules/dasLLAMA/tests/test_bench_records_schema.das
@@ -19,6 +19,7 @@ def private make_asr_run(engine, workload : string) : BenchRun {
         threads = 8,
         date = "2026-07-28",
         cmd = "test-cmd",
+        noise = engine == "das" ? "ok" : "",
         versions = engine == "das" ? "" : "whisper.cpp @ abcdef123")
     r.tests |> insert("asr:jfk.wav", BenchTest(ms = 197.1lf, audio_s = 11.0lf))
     r.tests |> insert("asr:gb1.wav", BenchTest(ms = 6585.0lf, audio_s = 198.7lf))
@@ -50,6 +51,8 @@ def test_asr_round_trip(t : T?) {
         t |> equal(back[0].runs[0].files[0].role, "weights")
         t |> equal(back[0].runs[0].files[0].bytes, 77704715l)
         t |> equal(back[0].runs[1].versions, "whisper.cpp @ abcdef123")
+        t |> equal(back[0].runs[0].noise, "ok")
+        t |> equal(back[0].runs[1].noise, "")
         remove(TMP)
     }
 }


### PR DESCRIPTION
The records batch from the #3687 review discussion — pushed to that branch moments after the merge snapshot, so it rides its own PR (cherry-pick of d51d24bbe, unchanged).

Both halves are Boris-ruled:

- **Records carry the mint's noise verdict.** `BenchRun` gains `@optional noise` — `tune_manifest_noise()` reads `provenance.noise` out of the tune sidecar (`"ok"` / `"overridden"`, `""` when absent), stamped at both das record sites in `lcpp_bench` (model rows + the ASR cell). A mint taken through a failing noise gate (`DAS_TUNE_NOISE_OVERRIDE=1`) is now visible on the board, not only inside the sidecar. Documented in METHODOLOGY.md "The record"; round-tripped in `test_bench_records_schema.das`.
- **The das row's backend names the armed vulkan tier.** The schema already documented `backend : "cpu" | "metal" | "vulkan"`, but the cell was computed from `--ngl` alone — a vulkan-armed run published rows labeled `cpu`. The das row now reports `metal` (--ngl protocol) / `vulkan` (`moe_gpu_tier_installed()`) / `cpu`; the llama.cpp reference row keeps the `--ngl`-derived value (llama-bench knows nothing of the vulkan tier). The board oracle already loud-skips backend/flavor pairs no rig leg produces, so vulkan rows are skipped with a warning until a vulkan leg joins the rig.

Validation: schema test 18/18 under `-jit`, lint 0, formatted, compile-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
