### PR TITLE
dasllama-ladder: submit gate + deploy scaffolding (slice 7)

### DIFF
--- a/utils/dasllama-ladder/.das_package
+++ b/utils/dasllama-ladder/.das_package
@@ -1,0 +1,20 @@
+options gen2
+
+require daslib/daspkg
+
+[export]
+def package() {
+    package_name("dasllama-ladder")
+    package_description("dasllama.io exchange service: content-addressed sidecar + record ladder over dasHV + SQLite")
+}
+
+[export]
+def release() {
+    release_main("main.das")
+    release_name("dasllama-ladder")
+    release_include_if_missing("dasllama-ladder.toml") // initialize once; preserve deployed edits (paths, submit_open) on upgrades
+    release_include_from("utils/watchdog/watchdog.py")
+    release_include_if_missing("watchdog.json")        // carries the port + health/shutdown urls — an operator edit must survive upgrades
+    release_include("admin.das")                       // operator curation CLI; run with a daslang SDK on the box
+    release_include("caddy.snippet")                   // the public boundary, shipped beside the code so a route change reviews with it
+}

--- a/utils/dasllama-ladder/CODEREVIEW.md
+++ b/utils/dasllama-ladder/CODEREVIEW.md
@@ -53,7 +53,8 @@ creates; store tests run against `:memory:`.** A test writing into the repo tree
 Every file states what it holds. Code that belongs to a file and is written anywhere else is a
 defect, and this section is the whole test.
 
-**A new file ships with its rule here and its tests, in the same change.**
+**A new file ships with its rule here in the same change; a new `.das` source ships its tests
+too.**
 
 - `main.das` — the launcher: argv parsing into globals, logger init, the exported
   `init`/`update`/`shutdown` lifecycle, the standalone GC loop, exit-code mapping. No route,
@@ -62,9 +63,11 @@ defect, and this section is the whole test.
   per-key provenance, and the startup banner payload. No HTTP, no SQL, no filesystem beyond
   reading the config file.
 - `ladder_server.das` — the `HvWebServer` class: the route table and handlers, plus the
-  startup official-dir import. A handler validates transport-level shape, translates HTTP to
-  one store call, and formats the response. A SQL statement, a hash computation, or a policy
-  decision (size, rate, source) in this file is a defect.
+  startup official-dir import. A handler validates transport-level shape, gates the request
+  (loopback, submit-open, attempt-limit), translates HTTP to one store call, and formats the
+  response. A SQL statement, a hash computation, or a store policy decision (size caps, rate
+  ceiling, source stamping, document validation) in this file is a defect — those live in
+  `ladder_store.das`.
 - `ladder_store.das` — the store: schema structs, migrations, content hashing, and every
   policy decision (size caps, rate ceiling, source stamping, the sidecar lookup ladder). Zero
   HTTP: a require of `dashv` here is a defect.
@@ -73,6 +76,15 @@ defect, and this section is the whole test.
 - `caddy.snippet` — the authoritative copy of the public route boundary; the deployed
   Caddyfile is edited to match it, never the reverse. A route added to `ladder_server.das`
   that a public caller needs lands here in the same change.
+- `.das_package` — the daspkg release manifest: the package/release names and the
+  `release_include*` set of operator files carried onto the box. A new operator-edited file the
+  box runs from is added to `release()` here in the same change.
+- `dasllama-deploy.sh` — the box-side deploy tool (`provision`/`caddy`/`install`/`open-submit`/
+  `close-submit`/`status`), installed root-owned as the one privileged surface. A privileged
+  (root) deploy action performed anywhere else is a defect.
+- `dasllama-deploy.sudoers` — the drop-in that scopes that privilege. It grants NOPASSWD for
+  exactly `/usr/local/sbin/dasllama-deploy.sh` and nothing else; a second command, a wildcard
+  target, a bare `ALL`, or a shell is a defect.
 
 ---
 
@@ -90,6 +102,15 @@ response path that skips the log is a defect.
 
 **Every handler that consumes a request body checks `body_is_byte_faithful` before using the
 string view.** A body used without the NUL guard is a defect.
+
+**Public submissions default closed: `submit_open` is false in both `LadderArgs` and
+`LadderPolicy`, the `/api/submit/sidecar` and `/api/submit/records` handlers return 403 while it
+is false, and only the loopback `/admin/submit` route flips it.** A default of true, or an opener
+reachable from any non-loopback path, is a defect.
+
+**In `caddy.snippet` the large-body allowance appears on the `/api/submit/records` and
+`/api/submit/sidecar` matcher only; every other proxied route carries the small read cap.** A
+large cap on any other route, or a read cap on a submit route, is a defect.
 
 ---
 

--- a/utils/dasllama-ladder/README.md
+++ b/utils/dasllama-ladder/README.md
@@ -71,5 +71,40 @@ Plain dastest — the same lane `extended_checks` runs the dasweb-playground sui
 The consuming half lives with dasLLAMA: `modules/dasLLAMA/performance/exchange_client.das`
 (boot-time sidecar lookup/apply as llvm_tune's scope resolver, the privacy-stripped submit
 rails, the control-page surface), wired into `utils/dasllama-server` (the `/exchange`
-endpoints + `exchange_*` config keys) and `lcpp_bench --submit`. Deploy and the follow-up
-ledger (partial re-race, cross-box matrix, version diff) are in `plans/dasllama_io_site.md`.
+endpoints + `exchange_*` config keys) and `lcpp_bench --submit`. The follow-up ledger (partial
+re-race, cross-box matrix, version diff) is in `plans/dasllama_io_site.md`.
+
+## 6. Deploy
+
+Mirrors dasweb-playground: a `daspkg release` bundle, supervised by `systemd → watchdog.py`,
+fronted by Caddy on the `dasllama.io` vhost. `dasllama-deploy.sh` is the box-side tool, run
+through the scoped sudoers drop-in (`dasllama-deploy.sudoers`) — the one privileged surface.
+
+Build the bundle on the builder box (zen4) from the arc worktree:
+
+```
+cd ~/daScript-dasweb && git pull --ff-only origin <branch>
+bin/daslang utils/daspkg/main.das -- release --root utils/dasllama-ladder --out ~/dasllama_release
+SHA=$(git rev-parse --short HEAD)
+cd ~/dasllama_release && tar czf dasllama-ladder-$SHA.tar.gz dasllama-ladder
+# scp dasllama-ladder-$SHA.tar.gz to dasweb-1:/tmp
+```
+
+On the box, in order — `provision` before `install` before `caddy` (install needs the unit
+`provision` writes; `caddy` needs the `caddy.snippet` `install` stages):
+
+```
+sudo dasllama-deploy.sh provision                                  # user, dirs, systemd unit, restic snapshot line
+sudo dasllama-deploy.sh install $SHA /tmp/dasllama-ladder-$SHA.tar.gz
+sudo dasllama-deploy.sh caddy                                      # splice /api into the dasllama.io vhost, validate, reload
+```
+
+The board launches **read-only**: `submit_open` defaults false, so `/api/submit/*` returns 403
+until an operator opens it. Toggle for a test window over the loopback tunnel with
+`sudo dasllama-deploy.sh open-submit` / `close-submit`; the permanent open (after the security
+audit) is `submit_open = true` in the deployed toml, or the `--submit-open` boot flag.
+
+Seed the official boards (they're not in the release — the record stores live under
+`modules/dasLLAMA/performance/records/`): stage that directory on the box, point the deployed
+toml's `official_dir` at it (imported at every start), or import once over loopback with
+`admin.das`.

--- a/utils/dasllama-ladder/dasllama-deploy.sh
+++ b/utils/dasllama-ladder/dasllama-deploy.sh
@@ -8,7 +8,8 @@
 #   caddy                      splice caddy.snippet into the dasllama.io vhost, validate, reload
 #   install <sha> <tarball>    per-release: unpack, carry operator files, flip current, restart, health
 #   open-submit | close-submit flip the public-submission gate (loopback admin call)
-#   status                     service + gate state
+#   status                     systemd active-state + /api health (the gate state is not
+#                              remotely queryable; it is in the service's startup banner/log)
 #
 # The bundle comes from the builder box (zen4), from the arc worktree there:
 #   cd ~/daScript-dasweb && git pull --ff-only origin <branch>
@@ -80,6 +81,12 @@ caddy_apply() {
         }
         { print }
     ' "$CADDYFILE.bak-$ts" > "$CADDYFILE"
+    # The awk match is exact (`dasllama.io {`); if the vhost is ever reformatted (shared address,
+    # renamed) it matches nothing, validate still passes on the unchanged file, and we would
+    # wrongly report success. Confirm the proxy line actually landed before reloading.
+    if ! grep -q "reverse_proxy 127.0.0.1:$PORT" "$CADDYFILE"; then
+        echo "caddy: splice inserted nothing (dasllama.io vhost not matched) - restoring $CADDYFILE.bak-$ts"; cp "$CADDYFILE.bak-$ts" "$CADDYFILE"; exit 1
+    fi
     if ! caddy validate --config "$CADDYFILE" --adapter caddyfile >/dev/null 2>&1; then
         echo "caddy validate FAILED - restoring $CADDYFILE.bak-$ts"; cp "$CADDYFILE.bak-$ts" "$CADDYFILE"; exit 1
     fi
@@ -89,6 +96,15 @@ caddy_apply() {
 
 install_release() {
     SHA="${1:?install <sha> <tarball>}"; TARBALL="${2:?install <sha> <tarball>}"
+    # $SHA names a release dir under $APP/releases and drives rm -rf/mv/ln as root. Pin it to a
+    # git short-sha shape so a typo like "." or "../x" can't escape the releases tree.
+    case "$SHA" in ''|*[!0-9a-fA-F]*) echo "bad sha '$SHA' (hex only)"; exit 2;; esac
+    [ -f "$TARBALL" ] || { echo "no tarball at '$TARBALL'"; exit 2; }
+    # `tar xzf` runs as root below; reject an archive with absolute or `..` entries so a crafted
+    # or corrupt tarball can't escape the releases tree and overwrite arbitrary files.
+    if tar tzf "$TARBALL" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
+        echo "unsafe tarball: contains absolute or '..' path entries"; exit 2
+    fi
     CARRY=$(mktemp -d); trap 'rm -rf "$CARRY"' EXIT
     had_toml=0
     for f in dasllama-ladder.toml watchdog.json; do

--- a/utils/dasllama-ladder/dasllama-deploy.sh
+++ b/utils/dasllama-ladder/dasllama-deploy.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# dasllama-ladder box-side deploy tool for dasweb-1. This is the ONE privileged
+# surface: installed root-owned at /usr/local/sbin/dasllama-deploy.sh and reached
+# through a sudoers drop-in that grants NOPASSWD for exactly this script (not a
+# root shell). Verbs:
+#
+#   provision                  one-time: service user, dirs, systemd unit, restic snapshot line
+#   caddy                      splice caddy.snippet into the dasllama.io vhost, validate, reload
+#   install <sha> <tarball>    per-release: unpack, carry operator files, flip current, restart, health
+#   open-submit | close-submit flip the public-submission gate (loopback admin call)
+#   status                     service + gate state
+#
+# The bundle comes from the builder box (zen4), from the arc worktree there:
+#   cd ~/daScript-dasweb && git pull --ff-only origin <branch>
+#   bin/daslang utils/daspkg/main.das -- release --root utils/dasllama-ladder --out ~/dasllama_release
+#   SHA=$(git rev-parse --short HEAD)
+#   cd ~/dasllama_release && tar czf dasllama-ladder-$SHA.tar.gz dasllama-ladder
+#   # scp dasllama-ladder-$SHA.tar.gz to dasweb-1:/tmp, then on the box:
+#   sudo dasllama-deploy.sh install $SHA /tmp/dasllama-ladder-$SHA.tar.gz
+set -eu
+
+APP=/srv/apps/dasllama-ladder
+DATA=/srv/dasllama-ladder
+SVCUSER=dasllama
+PORT=8201
+UNIT=/etc/systemd/system/dasllama-ladder.service
+CADDYFILE=/etc/caddy/Caddyfile
+RESTIC_ENV=/etc/restic/env
+
+verb="${1:?usage: dasllama-deploy.sh provision|caddy|install <sha> <tarball>|open-submit|close-submit|status}"
+
+provision() {
+    # Dedicated service user isolates the public-upload process from the playground's dasweb.
+    id -u "$SVCUSER" >/dev/null 2>&1 || useradd --system --home-dir "$DATA" --shell /usr/sbin/nologin "$SVCUSER"
+    install -d -o "$SVCUSER" -g "$SVCUSER" "$DATA"   # db + logs, outside the release tree so a flip preserves them
+    install -d -o root -g root "$APP" "$APP/releases"
+    cat > "$UNIT" <<EOF
+[Unit]
+Description=dasllama-ladder (dasllama.io exchange service, watchdog-supervised)
+After=network.target
+
+[Service]
+Type=simple
+User=$SVCUSER
+Group=$SVCUSER
+WorkingDirectory=$APP/current
+ExecStart=/usr/bin/python3 watchdog.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable dasllama-ladder >/dev/null 2>&1 || true
+    # /srv is already in restic BACKUP_PATHS; add the db to SQLITE_DBS so it is snapshotted
+    # with sqlite3 .backup (a plain copy of a live DB can capture a torn write).
+    if [ -f "$RESTIC_ENV" ] && ! grep -q "$DATA/ladder.db" "$RESTIC_ENV"; then
+        cp "$RESTIC_ENV" "$RESTIC_ENV.bak-$(date +%Y%m%d-%H%M%S)"
+        sed -i "s#^SQLITE_DBS=\"\(.*\)\"#SQLITE_DBS=\"\1 $DATA/ladder.db\"#" "$RESTIC_ENV"
+    fi
+    echo "provisioned: user=$SVCUSER data=$DATA unit=$UNIT; restic snapshot line added"
+}
+
+caddy_apply() {
+    # Splice caddy.snippet (from the installed release) into the dasllama.io vhost, ahead of
+    # root/file_server. Idempotent, validated before reload, with a timestamped Caddyfile backup.
+    snippet="$APP/current/caddy.snippet"
+    [ -f "$snippet" ] || { echo "no $snippet - install a release first"; exit 1; }
+    if grep -q "reverse_proxy 127.0.0.1:$PORT" "$CADDYFILE"; then
+        echo "caddy: /api already spliced - nothing to do"; return 0
+    fi
+    ts=$(date +%Y%m%d-%H%M%S)
+    cp "$CADDYFILE" "$CADDYFILE.bak-$ts"
+    awk -v snip="$snippet" '
+        /^dasllama\.io \{/ && !done {
+            print
+            while ((getline line < snip) > 0) if (line !~ /^[ \t]*#/ && line !~ /^[ \t]*$/) print "\t" line
+            close(snip); done=1; next
+        }
+        { print }
+    ' "$CADDYFILE.bak-$ts" > "$CADDYFILE"
+    if ! caddy validate --config "$CADDYFILE" --adapter caddyfile >/dev/null 2>&1; then
+        echo "caddy validate FAILED - restoring $CADDYFILE.bak-$ts"; cp "$CADDYFILE.bak-$ts" "$CADDYFILE"; exit 1
+    fi
+    systemctl reload caddy
+    echo "caddy: /api spliced + reloaded (backup $CADDYFILE.bak-$ts)"
+}
+
+install_release() {
+    SHA="${1:?install <sha> <tarball>}"; TARBALL="${2:?install <sha> <tarball>}"
+    CARRY=$(mktemp -d); trap 'rm -rf "$CARRY"' EXIT
+    had_toml=0
+    for f in dasllama-ladder.toml watchdog.json; do
+        [ -f "$APP/current/$f" ] && cp "$APP/current/$f" "$CARRY/$f"
+    done
+    [ -f "$CARRY/dasllama-ladder.toml" ] && had_toml=1
+    cd "$APP/releases"
+    rm -rf dasllama-ladder
+    tar xzf "$TARBALL"
+    rm -rf "$SHA"; mv dasllama-ladder "$SHA"
+    for f in dasllama-ladder.toml watchdog.json; do
+        [ -f "$CARRY/$f" ] && cp "$CARRY/$f" "$SHA/$f"
+    done
+    # First deploy has no operator toml to carry: pin the db at the stable data dir (the release
+    # tree is wiped on every flip) and make it authoritative so the path can't drift. submit_open
+    # stays absent = closed. Later deploys carry the box's edited toml forward untouched.
+    if [ "$had_toml" -eq 0 ]; then
+        sed -i "s#^db = .*#db = \"$DATA/ladder.db\"#" "$SHA/dasllama-ladder.toml"
+        grep -q '^authoritative' "$SHA/dasllama-ladder.toml" || printf '\nauthoritative = true\n' >> "$SHA/dasllama-ladder.toml"
+    fi
+    chown -R "$SVCUSER":"$SVCUSER" "$SHA"
+    ln -sfn "$APP/releases/$SHA" "$APP/current"
+    systemctl restart dasllama-ladder
+    sleep 5
+    systemctl is-active dasllama-ladder
+    curl -sf "http://127.0.0.1:$PORT/healthz" && echo && echo "deployed $SHA"
+}
+
+submit_toggle() {
+    curl -sf -X POST "http://127.0.0.1:$PORT/admin/submit" -d "{\"open\":$1}" && echo
+}
+
+case "$verb" in
+    provision) provision ;;
+    caddy) caddy_apply ;;
+    install) shift; install_release "$@" ;;
+    open-submit) submit_toggle true ;;
+    close-submit) submit_toggle false ;;
+    status)
+        systemctl is-active dasllama-ladder || true
+        curl -sf "http://127.0.0.1:$PORT/api/versions" >/dev/null 2>&1 && echo "api: ok" || echo "api: DOWN"
+        ;;
+    *) echo "unknown verb: $verb"; exit 2 ;;
+esac

--- a/utils/dasllama-ladder/dasllama-deploy.sudoers
+++ b/utils/dasllama-ladder/dasllama-deploy.sudoers
@@ -9,4 +9,7 @@
 # shell. It is close to root in practice (the `install` verb unpacks a tarball as root), so
 # the real protections are: the key never gets an interactive root shell, every run is in the
 # sudo audit log, and the whole privileged surface is this one reviewed script.
+#
+# `boris` is the dasweb-1 operator account. On any other box, replace it with that box's
+# deploying user (this file is box-specific, not a drop-in-anywhere template).
 boris ALL=(root) NOPASSWD: /usr/local/sbin/dasllama-deploy.sh

--- a/utils/dasllama-ladder/dasllama-deploy.sudoers
+++ b/utils/dasllama-ladder/dasllama-deploy.sudoers
@@ -1,0 +1,12 @@
+# dasllama-ladder deploy privilege — scoped NOPASSWD for the vetted deploy script only.
+#
+# Install once, as root, with validation (never edit /etc/sudoers.d by hand):
+#   sudo install -o root -g root -m 0755 dasllama-deploy.sh /usr/local/sbin/dasllama-deploy.sh
+#   sudo install -o root -g root -m 0440 dasllama-deploy.sudoers /etc/sudoers.d/dasllama-deploy
+#   sudo visudo -cf /etc/sudoers.d/dasllama-deploy   # must print "parsed OK"
+#
+# This grants passwordless sudo for ONLY /usr/local/sbin/dasllama-deploy.sh, not a root
+# shell. It is close to root in practice (the `install` verb unpacks a tarball as root), so
+# the real protections are: the key never gets an interactive root shell, every run is in the
+# sudo audit log, and the whole privileged surface is this one reviewed script.
+boris ALL=(root) NOPASSWD: /usr/local/sbin/dasllama-deploy.sh

--- a/utils/dasllama-ladder/dasllama-ladder.toml
+++ b/utils/dasllama-ladder/dasllama-ladder.toml
@@ -11,6 +11,7 @@ db = "ladder.db"
 max_records_bytes = 4194304
 max_sidecar_bytes = 1048576
 max_submissions_per_ip_hour = 20
-# the deployed toml points this at the release's records/ copy so the official
-# boards import (and refresh) at every service start; empty = no import
+# Set on the box to a directory of official record stores (records/<box>.json) staged during
+# deploy; they import (and refresh) at every service start. Empty (the default) = no import;
+# a board is seeded by staging that dir and pointing this at it, or via loopback admin import.
 official_dir = ""

--- a/utils/dasllama-ladder/ladder_config.das
+++ b/utils/dasllama-ladder/ladder_config.das
@@ -94,9 +94,23 @@ def private cfg_from_toml(root : JsonValue?; key : string; var field : int&; aut
     return true
 }
 
+def private cfg_from_toml(root : JsonValue?; key : string; var field : bool&; auth : bool; user_args : array<string>; var sources : table<string; string>; var error : string&) : bool {
+    if (!toml_wins(root, key, auth, user_args)) {
+        return true
+    }
+    let v = root?[key]
+    if (v == null || !(v.value is _bool)) {
+        error = "config key '{key}' must be a boolean"
+        return false
+    }
+    field = v ?? false
+    sources[key] = "toml"
+    return true
+}
+
 def mark_cli_sources(user_args : array<string>; var sources : table<string; string>) {
     for (key in fixed_array("port", "db", "max_records_bytes", "max_sidecar_bytes",
-        "max_submissions_per_ip_hour", "official_dir")) {
+        "max_submissions_per_ip_hour", "submit_open", "official_dir")) {
         if (from_cli(user_args, key)) {
             sources[key] = "cli"
         }
@@ -119,6 +133,7 @@ def apply_config_text(var cfg : LadderArgs; body : string; user_args : array<str
         cfg_from_toml(root, "max_records_bytes", cfg.max_records_bytes, auth, user_args, sources, error) &&
         cfg_from_toml(root, "max_sidecar_bytes", cfg.max_sidecar_bytes, auth, user_args, sources, error) &&
         cfg_from_toml(root, "max_submissions_per_ip_hour", cfg.max_submissions_per_ip_hour, auth, user_args, sources, error) &&
+        cfg_from_toml(root, "submit_open", cfg.submit_open, auth, user_args, sources, error) &&
         cfg_from_toml(root, "official_dir", cfg.official_dir, auth, user_args, sources, error))
     unsafe {
         delete root   // read_toml minted this tree; nothing outlives this scope
@@ -167,6 +182,7 @@ def config_banner(cfg : LadderArgs; sources : table<string; string>) : JsonValue
         max_submissions_per_ip_hour = cfg.max_submissions_per_ip_hour,
         max_submissions_per_ip_hour_src = sources?["max_submissions_per_ip_hour"] ?? "default",
         submit_open = cfg.submit_open,
+        submit_open_src = sources?["submit_open"] ?? "default",
         official_dir = cfg.official_dir,
         official_dir_src = sources?["official_dir"] ?? "default",
         config = cfg.config))

--- a/utils/dasllama-ladder/ladder_config.das
+++ b/utils/dasllama-ladder/ladder_config.das
@@ -32,6 +32,10 @@ struct LadderArgs {
     @clarg_doc = "Per-IP accepted-submission ceiling per hour"
     max_submissions_per_ip_hour : int = 20
 
+    @clarg_name = "submit-open"
+    @clarg_doc = "Accept public submissions at boot (default false = read-only board); toggled at runtime via the loopback /admin/submit route"
+    submit_open : bool = false
+
     @clarg_doc = "Official record stores dir (records/<box>.json); imported at startup; empty = no import"
     official_dir : string = ""
 
@@ -162,6 +166,7 @@ def config_banner(cfg : LadderArgs; sources : table<string; string>) : JsonValue
         max_sidecar_bytes_src = sources?["max_sidecar_bytes"] ?? "default",
         max_submissions_per_ip_hour = cfg.max_submissions_per_ip_hour,
         max_submissions_per_ip_hour_src = sources?["max_submissions_per_ip_hour"] ?? "default",
+        submit_open = cfg.submit_open,
         official_dir = cfg.official_dir,
         official_dir_src = sources?["official_dir"] ?? "default",
         config = cfg.config))

--- a/utils/dasllama-ladder/ladder_server.das
+++ b/utils/dasllama-ladder/ladder_server.das
@@ -115,6 +115,9 @@ class LadderServer : HvWebServer {
         POST("/admin/import-official") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_import_official(req, resp)
         }
+        POST("/admin/submit") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_admin_submit(req, resp)
+        }
         POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             let t0 = ref_time_ticks()
             if (!is_loopback_caller(req)) {
@@ -329,6 +332,11 @@ def private put_status_of(status : PutStatus) : http_status {
 def private handle_submit_sidecar(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
+    if (!g_policy.submit_open) {
+        let body = write_json(JV((error = "submissions are not open yet")))
+        log_request("POST", "/api/submit/sidecar", 403, ip, length(req.body), length(body), t0)
+        return resp |> JSON(body, http_status.FORBIDDEN)
+    }
     if (attempt_exceeded(ip, current_unix_time())) {
         let body = write_json(JV((error = "too many requests")))
         log_request("POST", "/api/submit/sidecar", 429, ip, length(req.body), length(body), t0)
@@ -356,6 +364,11 @@ def private handle_submit_sidecar(var req : HttpRequest?; var resp : HttpRespons
 def private handle_submit_records(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
+    if (!g_policy.submit_open) {
+        let body = write_json(JV((error = "submissions are not open yet")))
+        log_request("POST", "/api/submit/records", 403, ip, length(req.body), length(body), t0)
+        return resp |> JSON(body, http_status.FORBIDDEN)
+    }
     if (attempt_exceeded(ip, current_unix_time())) {
         let body = write_json(JV((error = "too many requests")))
         log_request("POST", "/api/submit/records", 429, ip, length(req.body), length(body), t0)
@@ -378,6 +391,29 @@ def private handle_submit_records(var req : HttpRequest?; var resp : HttpRespons
     }
     log_request("POST", "/api/submit/records", int(status), ip, length(doc), length(body), t0)
     return resp |> JSON(body, status)
+}
+
+// Flip the public-submission gate at runtime (loopback-only): POST {"open":true|false}. In-memory
+// only — a restart re-reads the config, so closed stays the fail-safe resting state. This is the
+// test-window switch; the permanent open state is the --submit-open boot flag.
+def private handle_admin_submit(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
+    let ip = client_ip_of(req)
+    if (!is_loopback_caller(req)) {
+        log_request("POST", "/admin/submit", 403, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
+    var jerr = ""
+    var js = read_json(string(req.body), jerr)
+    let want : bool = js?["open"] ?? false   // absent/garbage body → closed (fail-safe)
+    unsafe {
+        delete js   // read_json minted this tree; the bool is already copied out
+    }
+    g_policy.submit_open = want
+    logger_info("ladder", want ? "submissions OPENED via loopback admin" : "submissions CLOSED via loopback admin")
+    let body = write_json(JV((submit_open = g_policy.submit_open)))
+    log_request("POST", "/admin/submit", 200, ip, length(req.body), length(body), t0)
+    return resp |> JSON(body)
 }
 
 def private handle_import_official(var req : HttpRequest?; var resp : HttpResponse?) : http_status {

--- a/utils/dasllama-ladder/ladder_server.das
+++ b/utils/dasllama-ladder/ladder_server.das
@@ -403,12 +403,15 @@ def private handle_admin_submit(var req : HttpRequest?; var resp : HttpResponse?
         log_request("POST", "/admin/submit", 403, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
     }
-    var jerr = ""
-    var js = read_json(string(req.body), jerr)
-    let want : bool = js?["open"] ?? false   // absent/garbage body → closed (fail-safe)
-    unsafe {
-        delete js   // read_json minted this tree; the bool is already copied out
+    var early = http_status.OK
+    let doc = submit_body_of(req, "/admin/submit", resp, early, t0)
+    if (empty(doc)) {
+        return early
     }
+    var jerr = ""
+    var js = read_json(doc, jerr)
+    let want : bool = js?["open"] ?? false   // absent/garbage body → closed (fail-safe)
+    delete_json(js)                          // no-ops on null; the bool is already copied out
     g_policy.submit_open = want
     logger_info("ladder", want ? "submissions OPENED via loopback admin" : "submissions CLOSED via loopback admin")
     let body = write_json(JV((submit_open = g_policy.submit_open)))

--- a/utils/dasllama-ladder/ladder_store.das
+++ b/utils/dasllama-ladder/ladder_store.das
@@ -159,6 +159,10 @@ struct LadderPolicy {
     // that caps parse/validate work on the single tick thread; the accepted ceiling above
     // counts only stored rows, so it never throttles a flood of invalid documents
     max_attempts_per_ip_hour : int = 120
+    // public submissions accepted only when true; default closed = read-only board. The server
+    // flips this at runtime via the loopback /admin/submit route (no restart), and a restart
+    // re-reads the config, so closed is the fail-safe resting state
+    submit_open : bool = false
 }
 
 enum PutStatus {

--- a/utils/dasllama-ladder/main.das
+++ b/utils/dasllama-ladder/main.das
@@ -65,7 +65,8 @@ def init {
         LadderPolicy(
             max_records_bytes = g_cfg.max_records_bytes,
             max_sidecar_bytes = g_cfg.max_sidecar_bytes,
-            max_submissions_per_ip_hour = g_cfg.max_submissions_per_ip_hour),
+            max_submissions_per_ip_hour = g_cfg.max_submissions_per_ip_hour,
+            submit_open = g_cfg.submit_open),
         g_cfg.official_dir)
     if (!g_ready) {
         g_exit_code = 1

--- a/utils/dasllama-ladder/test_ladder_config.das
+++ b/utils/dasllama-ladder/test_ladder_config.das
@@ -14,6 +14,7 @@ def test_defaults(t : T?) {
         t |> equal(cfg.port, 8201)
         t |> equal(cfg.db, "ladder.db")
         t |> equal(cfg.max_submissions_per_ip_hour, 20)
+        t |> equal(cfg.submit_open, false, "public submissions closed by default")
         t |> equal(cfg.official_dir, "")
     }
 }
@@ -74,5 +75,38 @@ def test_toml_merge(t : T?) {
         let banner = write_json(config_banner(cfg, sources))
         t |> success(find(banner, "9301") >= 0, "value present")
         t |> success(find(banner, "toml") >= 0, "provenance present")
+    }
+}
+
+[test]
+def test_submit_open_config(t : T?) {
+    t |> run("submit_open flips via toml, with provenance") @(t : T?) {
+        var cfg = LadderArgs()
+        var sources : table<string; string>
+        var err = ""
+        let no_args : array<string>
+        t |> equal(cfg.submit_open, false, "closed by default")
+        t |> success(apply_config_text(cfg, "submit_open = true\n", no_args, sources, err), "merge ok ({err})")
+        t |> success(cfg.submit_open, "toml opened it")
+        t |> equal(sources?["submit_open"] ?? "", "toml")
+    }
+    t |> run("explicit --submit-open beats a non-authoritative toml") @(t : T?) {
+        var cfg = LadderArgs()
+        cfg.submit_open = true   // as if clargs parsed --submit-open
+        var sources : table<string; string>
+        var err = ""
+        let args <- ["--submit-open"]
+        mark_cli_sources(args, sources)
+        t |> success(apply_config_text(cfg, "submit_open = false\n", args, sources, err), "merge ok")
+        t |> success(cfg.submit_open, "cli open wins over a non-authoritative toml false")
+        t |> equal(sources?["submit_open"] ?? "", "cli")
+    }
+    t |> run("a wrong-typed submit_open is refused, never coerced") @(t : T?) {
+        var cfg = LadderArgs()
+        var sources : table<string; string>
+        var err = ""
+        let no_args : array<string>
+        t |> success(!apply_config_text(cfg, "submit_open = \"yes\"\n", no_args, sources, err), "string submit_open refused")
+        t |> success(find(err, "submit_open") >= 0, "error names the key")
     }
 }

--- a/utils/dasllama-ladder/test_ladder_server.das
+++ b/utils/dasllama-ladder/test_ladder_server.das
@@ -48,7 +48,7 @@ def private with_ladder_server(policy : LadderPolicy; blk : block<(base_url : st
 }
 
 def private default_policy : LadderPolicy {
-    return LadderPolicy()
+    return LadderPolicy(submit_open = true)   // the submit-path tests need an open board; the gate itself has its own test
 }
 
 def private json_of(var resp : HttpResponse?) : JsonValue? {
@@ -222,7 +222,7 @@ def test_records_routes(t : T?) {
 
 [test]
 def test_policy_status_mapping(t : T?) {
-    with_ladder_server(LadderPolicy(max_sidecar_bytes = 64, max_submissions_per_ip_hour = 1)) $(base_url) {
+    with_ladder_server(LadderPolicy(max_sidecar_bytes = 64, max_submissions_per_ip_hour = 1, submit_open = true)) $(base_url) {
         t |> run("oversize is 413, throttle is 429") @(tt : T?) {
             POST("{base_url}/api/submit/sidecar", sidecar_doc(BOX_A, "3", "vec8")) $(resp) {
                 tt |> equal(int(resp.status_code), 413, "the tiny cap rejects the real fixture")
@@ -236,7 +236,7 @@ def test_policy_status_mapping(t : T?) {
         }
     }
     // the attempt limiter caps REJECTED traffic too — the accepted ceiling never fires on it
-    with_ladder_server(LadderPolicy(max_attempts_per_ip_hour = 2)) $(base_url) {
+    with_ladder_server(LadderPolicy(max_attempts_per_ip_hour = 2, submit_open = true)) $(base_url) {
         t |> run("invalid submissions are attempt-limited before parse") @(tt : T?) {
             // two malformed bodies (400, never stored, so the accepted ceiling is untouched)
             POST("{base_url}/api/submit/sidecar", "not json") $(resp) {
@@ -248,6 +248,43 @@ def test_policy_status_mapping(t : T?) {
             // the third attempt trips the transport-layer limiter regardless of validity
             POST("{base_url}/api/submit/sidecar", sidecar_doc(BOX_A, "3", "vec8")) $(resp) {
                 tt |> equal(int(resp.status_code), 429, "attempt ceiling reached on rejected traffic")
+            }
+        }
+    }
+}
+
+[test]
+def test_submit_gate(t : T?) {
+    // default policy = submit CLOSED: the read board serves, writes are refused until opened, and
+    // the loopback admin flip is reversible (the test-window switch)
+    with_ladder_server(LadderPolicy()) $(base_url) {
+        let doc = sidecar_doc(BOX_A, "3", "vec8_u8")
+        t |> run("a closed board refuses submissions with 403") @(tt : T?) {
+            POST("{base_url}/api/submit/sidecar", doc) $(resp) {
+                tt |> equal(int(resp.status_code), 403, "sidecar refused")
+            }
+            POST("{base_url}/api/submit/records", records_doc()) $(resp) {
+                tt |> equal(int(resp.status_code), 403, "records refused")
+            }
+        }
+        t |> run("the loopback admin toggle opens submissions") @(tt : T?) {
+            POST("{base_url}/admin/submit", "\{\"open\":true}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var js = json_of(resp)
+                tt |> success(js?["submit_open"] ?? false, "reports open")
+            }
+            POST("{base_url}/api/submit/sidecar", doc) $(resp) {
+                tt |> equal(int(resp.status_code), 200, "sidecar now accepted")
+            }
+        }
+        t |> run("the toggle closes them again") @(tt : T?) {
+            POST("{base_url}/admin/submit", "\{\"open\":false}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var js = json_of(resp)
+                tt |> success(!(js?["submit_open"] ?? true), "reports closed")
+            }
+            POST("{base_url}/api/submit/records", records_doc()) $(resp) {
+                tt |> equal(int(resp.status_code), 403, "records refused again")
             }
         }
     }

--- a/utils/dasllama-ladder/test_ladder_server.das
+++ b/utils/dasllama-ladder/test_ladder_server.das
@@ -287,5 +287,21 @@ def test_submit_gate(t : T?) {
                 tt |> equal(int(resp.status_code), 403, "records refused again")
             }
         }
+        t |> run("a malformed admin body cannot leave the gate open (fail-safe)") @(tt : T?) {
+            POST("{base_url}/admin/submit", "\{\"open\":true}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            // garbage must resolve to closed: read_json -> null -> ?? false. (A non-loopback
+            // caller is also refused, but every in-process peer is 127.0.0.1 so that path
+            // can't be exercised here — it is covered by is_loopback_caller's exact-match.)
+            POST("{base_url}/admin/submit", "not json at all") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var js = json_of(resp)
+                tt |> success(!(js?["submit_open"] ?? true), "garbage body closed the gate")
+            }
+            POST("{base_url}/api/submit/sidecar", doc) $(resp) {
+                tt |> equal(int(resp.status_code), 403, "submit refused after the garbage close")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Slice 7 — the ladder's submit gate + deploy machinery

Follows the merged dasllama.io arc (#3695). This is the **code** half of the deploy: it makes
the public board launch **read-only** by default and adds the machinery to release + install the
ladder service on dasweb-1, mirroring the `dasweb-playground` pattern. No box changes here — the
actual deploy runs from this once merged.

### Submit gate (closed by default)

The public exchange launches read-only until it's been security-audited:
- `LadderPolicy.submit_open` defaults `false`. The two `/api/submit/*` handlers return
  `403 "submissions are not open yet"` before any rate-limit or parse work.
- A loopback-only `POST /admin/submit {"open":bool}` flips it at runtime (in-memory) — the
  test-window switch. A restart re-reads the config, so **closed is the fail-safe resting
  state**. `/admin/*` is excluded from the Caddy boundary (`caddy.snippet`), so this is never
  internet-reachable.
- The permanent open (post-audit) is the `--submit-open` boot flag. `submit_open` shows in the
  startup banner for ops visibility.
- `test_submit_gate` covers closed→403 / flip-open→200 / flip-closed→403.

### Deploy scaffolding (mirrors dasweb-playground)

- **`.das_package`** — the `daspkg release` manifest: `-exe`-compile + bundle the runtime,
  modules, config, `watchdog.py`, `watchdog.json`, `admin.das`, `caddy.snippet`.
  `release_include_if_missing` on the toml + `watchdog.json` so operator edits survive upgrades.
- **`dasllama-deploy.sh`** — the one privileged surface (root-owned, sudoers-scoped). Verbs:
  `provision` (service user + dirs + systemd unit + restic snapshot line), `caddy` (splice the
  snippet into the `dasllama.io` vhost, validate, reload), `install <sha> <tarball>` (atomic
  release flip + health, carrying operator files forward), `open-submit`/`close-submit`, `status`.
- **`dasllama-deploy.sudoers`** — NOPASSWD scoped to that one script, not a root shell.

### Testing

`test_ladder_server` 21/21 (incl. the new gate test), `test_ladder_config` 8/8, lint + format
clean. The deploy scripts are not exercised by CI — they run against the box post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
