### PR TITLE
dasllama-ladder: sandbox the systemd unit (provision hardening)

### DIFF
--- a/utils/dasllama-ladder/CODEREVIEW.md
+++ b/utils/dasllama-ladder/CODEREVIEW.md
@@ -86,6 +86,12 @@ too.**
   exactly `/usr/local/sbin/dasllama-deploy.sh` and nothing else; a second command, a wildcard
   target, a bare `ALL`, or a shell is a defect.
 
+**The unit `provision` writes runs the service sandboxed** (`ProtectSystem=strict`, emptied
+`CapabilityBoundingSet`, `ReadWritePaths` limited to the data dir and the release tree). A diff
+that changes where the service or watchdog writes at runtime — log path, working directory,
+database location — without a matching `ReadWritePaths` entry is a defect; so is relaxing
+`ProtectSystem` or restoring a capability with no stated reason.
+
 ---
 
 ## Transport

--- a/utils/dasllama-ladder/README.md
+++ b/utils/dasllama-ladder/README.md
@@ -99,6 +99,13 @@ sudo dasllama-deploy.sh install $SHA /tmp/dasllama-ladder-$SHA.tar.gz
 sudo dasllama-deploy.sh caddy                                      # splice /api into the dasllama.io vhost, validate, reload
 ```
 
+The unit `provision` writes is **sandboxed** (`ProtectSystem=strict`, all capabilities dropped,
+loopback-only, `ReadWritePaths` limited to the data dir + release tree) — it contains a
+hypothetical parser/runtime RCE to a process that can only write its own db and logs, while the
+host filesystem and the other `/srv` services stay read-only. It is defence-in-depth, not a
+substitute for validating what the public submit endpoints accept. `provision` is idempotent, so
+re-running it after a unit change re-applies the sandbox and restarts a running service.
+
 The board launches **read-only**: `submit_open` defaults false, so `/api/submit/*` returns 403
 until an operator opens it. Toggle for a test window over the loopback tunnel with
 `sudo dasllama-deploy.sh open-submit` / `close-submit`; the permanent open (after the security

--- a/utils/dasllama-ladder/dasllama-deploy.sh
+++ b/utils/dasllama-ladder/dasllama-deploy.sh
@@ -49,11 +49,37 @@ ExecStart=/usr/bin/python3 watchdog.py
 Restart=on-failure
 RestartSec=5
 
+# Sandbox: contain a hypothetical parser/runtime RCE to a capability-less process
+# that can only write its own db + release logs; host FS and other /srv services stay
+# read-only. Does NOT replace input-validation review. ReadWritePaths covers BOTH the
+# data dir and the release tree (the service writes libhv + watchdog logs under current/).
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=$DATA $APP/releases
+ProtectHome=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+CapabilityBoundingSet=
+AmbientCapabilities=
+SystemCallArchitectures=native
+TasksMax=64
+
 [Install]
 WantedBy=multi-user.target
 EOF
     systemctl daemon-reload
     systemctl enable dasllama-ladder >/dev/null 2>&1 || true
+    systemctl try-restart dasllama-ladder >/dev/null 2>&1 || true   # re-provision applies the unit to a running service; no-op on first provision
     # /srv is already in restic BACKUP_PATHS; add the db to SQLITE_DBS so it is snapshotted
     # with sqlite3 .backup (a plain copy of a live DB can capture a torn write).
     if [ -f "$RESTIC_ENV" ] && ! grep -q "$DATA/ladder.db" "$RESTIC_ENV"; then

--- a/utils/dasllama-ladder/dasllama-deploy.sh
+++ b/utils/dasllama-ladder/dasllama-deploy.sh
@@ -72,6 +72,9 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 CapabilityBoundingSet=
 AmbientCapabilities=
 SystemCallArchitectures=native
+# TasksMax fits because the service does no parallel work (the daslang jobque is never
+# created). If it adopts parallel_for/channels/create_job_que the pool spawns cores-1
+# threads on spawn - raise this or set DAS_JOBQUE_THREADS then.
 TasksMax=64
 
 [Install]


### PR DESCRIPTION
## What

Sandbox the `dasllama-ladder` systemd unit. Follow-up to the deploy arc (#3695, #3698) — the service is now live read-only on dasllama.io, and this hardens the unit `provision` writes ahead of opening the public submit endpoint.

The unit was bare (`User`/`ExecStart`/`Restart`). This adds a **safe-by-construction** systemd sandbox: every directive restricts something the service demonstrably does not do, so the false-positive (service-breakage) risk is near zero.

## Why

The ladder never executes uploaded content (it parses JSON, validates, stores — engine-free, no JIT), so a playground-style container is the wrong tool. The one thing process isolation genuinely buys is containing a hypothetical RCE via a memory-safety bug in the parser / dashv / sqlite C++ to a capability-less process that can only write its own db and logs, while the host filesystem and the other `/srv` services stay read-only.

This is **defence-in-depth, not a substitute** for red-teaming what the public submit endpoints accept.

## The directive set

`ProtectSystem=strict` with `ReadWritePaths` covering **both** the data dir and the release tree (the service writes `libhv.<date>.log` to its cwd and watchdog logs under `current/logs/` — strict mode with only the data dir writable would have wedged it), emptied `CapabilityBoundingSet`, `ProtectHome`/`PrivateTmp`, the `Protect*`/`Restrict*` family, `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX`, `TasksMax`.

**Deferred** (need a live-test window before trusting on the box): `SystemCallFilter`, `MemoryDenyWriteExecute`, a sized `MemoryMax`.

`provision` gains a trailing `systemctl try-restart` so re-running it re-applies the unit to a running service (no-op on first provision). README §6 + CODEREVIEW get the matching notes (`ReadWritePaths` must track the service's write paths).

## Applying to dasweb-1

The installed deploy script is root-owned, so the box picks this up when the operator re-runs the bootstrap with the updated `dasllama-deploy.sh`, then `provision` re-applies the sandbox and restarts. Verified after apply: service serves, db writes, `systemd-analyze security` score drops.

## Test

No `.das` changed — shell + markdown only. The directive set was independently checked against the service's actual runtime write paths and thread/task footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
