### PR TITLE
jobque: add SeqBox, and move audio status onto it

### DIFF
--- a/daslib/jobque_boost.das
+++ b/daslib/jobque_boost.das
@@ -330,6 +330,31 @@ def grab(box : LockBox?; blk : block<(var res : auto(TT)) : void>) : bool {
     return res
 }
 
+def publish(box : SeqBox?; value : auto(TT)) : bool {
+    //! Publishes a snapshot of ``value``, replacing whatever was there; false when another writer holds
+    //! the box, or ``TT`` (raw POD — no array/table/string/pointer) exceeds ``SEQ_BOX_PAYLOAD`` bytes.
+    //! Wait-free — but publish through a reference you HOLD; a last ``seq_box_release`` elsewhere frees it.
+    concept_assert(typeinfo is_pod(type<TT>) && typeinfo is_raw(type<TT>),
+        "SeqBox payload must be raw POD - the value is copied byte-wise, heap references would dangle")
+    concept_assert(typeinfo sizeof(type<TT>) <= SEQ_BOX_PAYLOAD, "SeqBox payload is at most 64 bytes")
+    return _builtin_seq_box_publish(box, unsafe(addr<void?>(value)), typeinfo sizeof(type<TT>))
+}
+
+def read(box : SeqBox?; blk : block<(value : auto(TT)) : void>) : bool {
+    //! Copies the latest snapshot out and invokes the block on the copy; consumes nothing and blocks no
+    //! one; false when nothing was published or the size differs — size is the box's only identity, so an
+    //! equal-size type reads back reinterpreted. Read through a reference you HOLD, never a borrowed one.
+    concept_assert(typeinfo is_pod(type<TT>) && typeinfo is_raw(type<TT>),
+        "SeqBox payload must be raw POD - the value is copied byte-wise, heap references would dangle")
+    concept_assert(typeinfo sizeof(type<TT>) <= SEQ_BOX_PAYLOAD, "SeqBox payload is at most 64 bytes")
+    var value : TT = default<TT>
+    if (!_builtin_seq_box_read(box, unsafe(addr<void?>(value)), typeinfo sizeof(type<TT>))) {
+        return false
+    }
+    invoke(blk, value)
+    return true
+}
+
 [template(tinfo), deprecated(message="use `each_clone` instead")]
 def each(var channel : Channel?; tinfo : auto(TT)) {
     //! this iterator is used to iterate over the channel in order it was pushed.
@@ -740,6 +765,12 @@ def public capture_jobque_stream(var s : Stream?) : Stream? {
     return s
 }
 
+def public capture_jobque_seq_box(var box : SeqBox?) : SeqBox? {
+    //! this function is used to capture a seq box that is used by the jobque.
+    box |> add_ref
+    return box
+}
+
 def public release_capture_jobque_channel(ch : Channel?) {
     //! this function is used to release a channel that is used by the jobque.
     if (ch != null) {
@@ -765,6 +796,15 @@ def public release_capture_jobque_stream(s : Stream?) {
     //! this function is used to release a stream that is used by the jobque.
     if (s != null) {
         panic("Stream has not been released. missing stream|>release or stream|>notify_and_release")
+    }
+}
+
+def public release_capture_jobque_seq_box(box : SeqBox?) {
+    //! this function is used to release a seq box that is used by the jobque.
+    // seq_box_release, not the family `release` - the latter only drops a share, so the last
+    // reference dropped through it leaks the box
+    if (box != null) {
+        panic("SeqBox has not been released. missing box|>seq_box_release")
     }
 }
 
@@ -797,7 +837,7 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
         )
         return <- pCall
     }
-    //! This macro implements capturing of the `jobque::Channel`, `jobque::JobStatus`, `jobque::LockBox`, and `jobque::Stream` types.
+    //! This macro implements capturing of the `jobque::Channel`, `jobque::JobStatus`, `jobque::LockBox`, `jobque::SeqBox`, and `jobque::Stream` types.
     //! When captured reference counts are increased. When lambda is destroyed, reference counts are decreased.
     def override captureExpression(prog : Program?; mod : Module?; expr : ExpressionPtr; typ : TypeDeclPtr) : ExpressionPtr {
         //! Implementation details for the capture macro.
@@ -807,6 +847,8 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
             return <- make_capture_call(expr, "jobque_boost::capture_jobque_job_status")
         } elif (typ |> isPtrToJQ("LockBox")) {
             return <- make_capture_call(expr, "jobque_boost::capture_jobque_lock_box")
+        } elif (typ |> isPtrToJQ("SeqBox")) {
+            return <- make_capture_call(expr, "jobque_boost::capture_jobque_seq_box")
         } elif (typ |> isPtrToJQ("Stream")) return <- make_capture_call(expr, "jobque_boost::capture_jobque_stream")
         return null
     }
@@ -822,6 +864,9 @@ class private ChannelAndStatusCapture : AstCaptureMacro {
                 (fun.body as ExprBlock).finalList |> emplace(pCall)
             } elif (fld._type |> isPtrToJQ("LockBox")) {
                 var pCall = make_release_call(fld, "jobque_boost::release_capture_jobque_lock_box")
+                (fun.body as ExprBlock).finalList |> emplace(pCall)
+            } elif (fld._type |> isPtrToJQ("SeqBox")) {
+                var pCall = make_release_call(fld, "jobque_boost::release_capture_jobque_seq_box")
                 (fun.body as ExprBlock).finalList |> emplace(pCall)
             } elif (fld._type |> isPtrToJQ("Stream")) {
                 var pCall = make_release_call(fld, "jobque_boost::release_capture_jobque_stream")

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -604,11 +604,12 @@ def document_module_apply(_root : string) {
 def document_module_jobque(_root : string) {
     var mod = find_module("jobque")
     var groups <- array<DocGroup>(
-        group_by_regex("Channel, JobStatus, Lockbox, Stream", mod, %regex~(append|notify|join|channel_create|channel_remove|stream_create|stream_remove|add_ref|release|notify_and_release|lock_box_create|lock_box_remove|job_status_create|job_status_remove)$%%),
+        group_by_regex("Channel, JobStatus, Lockbox, SeqBox, Stream", mod, %regex~(append|notify|join|channel_create|channel_remove|stream_create|stream_remove|add_ref|release|notify_and_release|lock_box_create|lock_box_remove|job_status_create|job_status_remove|seq_box_create|seq_box_release)$%%),
         group_by_regex("Queries", mod, %regex~(get_total_hw_jobs|get_total_hw_threads|get_total_hw_cores|is_job_que_shutting_down|is_job_que_available|count_jobque_leaks)$%%),
         group_by_regex("Event tracing", mod, %regex~(jobque_trace_start|jobque_trace_stop|jobque_trace_save|jobque_trace_tag|jobque_trace_category|jobque_trace_marker_name|jobque_trace_marker)$%%),
-        group_by_regex("Internal invocations", mod, %regex~(new_job_invoke|new_thread_invoke|new_debugger_thread|set_jobque_fork_pool|set_jobque_fork_skip_heap_reset|set_jobque_worker_spin|set_jobque_batch_dispatch|set_jobque_join_spin|set_jobque_team_mode|get_jobque_team_mode|set_jobque_thread_team_mode|get_jobque_thread_team_mode|set_current_thread_priority|set_jobque_threads_cap|set_jobque_affinity|get_jobque_affinity|set_jobque_worker_limit|get_jobque_worker_limit|set_jobque_team_rank_gate|get_jobque_team_rank_gate|set_jobque_team_prof|reset_jobque_team_prof|get_jobque_team_prof|get_jobque_team_prof_counts|get_jobque_team_prof_react|team_parallel_for_invoke|team_parallel_for_indexed_invoke|team_parallel_stages_invoke|flush_jobque_batch|jobque_try_run_one)$%%),
-        group_by_regex("Construction", mod, %regex~(with_channel|with_stream|with_job_status|with_job_que|with_lock_box|create_job_que|destroy_job_que)$%%),
+        group_by_regex("Internal invocations", mod, %regex~(new_job_invoke|new_thread_invoke|new_debugger_thread|set_jobque_fork_pool|set_jobque_fork_skip_heap_reset|set_jobque_worker_spin|set_jobque_batch_dispatch|set_jobque_join_spin|set_jobque_team_mode|get_jobque_team_mode|set_jobque_thread_team_mode|get_jobque_thread_team_mode|set_current_thread_priority|set_jobque_threads_cap|set_jobque_affinity|get_jobque_affinity|set_jobque_worker_limit|get_jobque_worker_limit|set_jobque_team_rank_gate|get_jobque_team_rank_gate|set_jobque_team_prof|reset_jobque_team_prof|get_jobque_team_prof|get_jobque_team_prof_counts|get_jobque_team_prof_react|team_parallel_for_invoke|team_parallel_for_indexed_invoke|team_parallel_stages_invoke|flush_jobque_batch|jobque_try_run_one|_builtin_seq_box_publish|_builtin_seq_box_read)$%%),
+        group_by_regex("Construction", mod, %regex~(with_channel|with_stream|with_job_status|with_job_que|with_lock_box|with_seq_box|create_job_que|destroy_job_que)$%%),
+        group_by_regex("SeqBox operations", mod, %regex~(clear)$%%),
         group_by_regex("Atomic", mod, %regex~(atomic32_create|atomic32_remove|with_atomic32|atomic64_create|atomic64_remove|with_atomic64|get|set|inc|dec)$%%)
     )
     document("Jobs and threads", mod, "jobque.rst", groups)
@@ -624,7 +625,8 @@ def document_module_jobque_boost(_root : string) {
         group_by_regex("Synchronization", mod, %regex~(with_wait_group|done)$%%),
         group_by_regex("Parallel execution", mod, %regex~(_parallel_for|parallel_for|team_parallel_for|team_parallel_for_indexed|team_parallel_stages|_parallel_for_each|parallel_for_each|_parallel_map|parallel_map)$%%),
         group_by_regex("LockBox operations", mod, %regex~(set|get|update|clear|fill|grab)$%%),
-        group_by_regex("Internal capture details", mod, %regex~(capture_jobque_channel|capture_jobque_job_status|release_capture_jobque_channel|release_capture_jobque_job_status|capture_jobque_lock_box|release_capture_jobque_lock_box|capture_jobque_stream|release_capture_jobque_stream)$%%)
+        group_by_regex("SeqBox operations", mod, %regex~(publish|read)$%%),
+        group_by_regex("Internal capture details", mod, %regex~(capture_jobque_channel|capture_jobque_job_status|release_capture_jobque_channel|release_capture_jobque_job_status|capture_jobque_lock_box|release_capture_jobque_lock_box|capture_jobque_stream|release_capture_jobque_stream|capture_jobque_seq_box|release_capture_jobque_seq_box)$%%)
     )
     document("Boost package for jobs and threads", mod, "jobque_boost.rst", groups)
 }

--- a/doc/source/reference/tutorials/dasAudio_09_playback_status.rst
+++ b/doc/source/reference/tutorials/dasAudio_09_playback_status.rst
@@ -8,19 +8,21 @@ AUDIO-09 — Playback Status
     single: Tutorial; Playback Status
     single: Tutorial; AudioChannelStatus
     single: Tutorial; set_status_update
+    single: Tutorial; SeqBox
     single: Tutorial; dasAudio
 
-This tutorial covers monitoring a playing sound. Audio runs on its own thread,
-so status is published through a ``LockBox``: the audio thread writes a snapshot
-each mix, and the main thread reads it on demand. This is how you detect when a
-one-shot sound has finished, or how full a streaming queue is.
+This tutorial covers monitoring a playing sound. Audio runs on its own thread, so
+status is published through a ``SeqBox``: the audio thread writes a snapshot each
+mix, and the main thread reads it on demand. Neither side ever waits for the
+other. This is how you detect when a one-shot sound has finished, or how full a
+streaming queue is.
 
 Registering a Status Box
 ========================
 
-Create a ``LockBox`` with ``lock_box_create`` and attach it to a sound with
+Create a ``SeqBox`` with ``seq_box_create`` and attach it to a sound with
 ``set_status_update``. The call seeds the box with state ``starting``; the audio
-thread updates it from then on:
+thread publishes into it from then on:
 
 .. das-doc: given var tone : array<float>
 
@@ -30,20 +32,20 @@ thread updates it from then on:
    require daslib/jobque_boost
 
    let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
-   var status_box <- lock_box_create()
+   var status_box = seq_box_create()
    set_status_update(sid, status_box)
 
 Reading the Snapshot
 ====================
 
-Read the current ``AudioChannelStatus`` with ``box |> get()`` — a read-only peek
-that keeps the box alive across reads (do not use ``grab``, which is a one-shot
-consume). The snapshot carries the playback state, frame positions, and the
-streaming queue depth:
+Read the current ``AudioChannelStatus`` with ``box |> read()``. It copies the
+snapshot out and consumes nothing, so the same box serves any number of reads —
+and it never makes the mixer wait. The snapshot carries the playback state, frame
+positions, and the streaming queue depth:
 
 .. code-block:: das
 
-   status_box |> get() $(s : AudioChannelStatus#) {
+   status_box |> read() $(s : AudioChannelStatus) {
        // s.state              : AudioChannelState
        // s.playback_position  : frames played
        // s.consumed_position  : frames of real audio consumed
@@ -58,7 +60,7 @@ you watch a one-shot sound run to completion:
 
    var done = false
    for (i in range(100)) {
-       status_box |> get() $(s : AudioChannelStatus#) {
+       status_box |> read() $(s : AudioChannelStatus) {
            done = s.state == AudioChannelState.stopped
        }
        break if (done)
@@ -68,15 +70,14 @@ you watch a one-shot sound run to completion:
 Releasing the Box
 =================
 
-Order matters — stop the updates, clear the stored value, join, then remove the
-box, or the ``LockBox`` leaks:
+Stop the updates and drop your reference. There is no order to get right and
+nothing to wait for: the audio thread holds a reference of its own, and whichever
+side drops the last one deletes the box.
 
 .. code-block:: das
 
    unset_status_update(sid)
-   clear_status(status_box)
-   status_box |> join()
-   unsafe(lock_box_remove(status_box))
+   status_box |> seq_box_release
 
 .. seealso::
 

--- a/doc/source/stdlib/handmade/Variable-jobque-SEQ_BOX_PAYLOAD.rst
+++ b/doc/source/stdlib/handmade/Variable-jobque-SEQ_BOX_PAYLOAD.rst
@@ -1,0 +1,1 @@
+Maximum payload size in bytes that a ``SeqBox`` snapshot can hold.

--- a/doc/source/stdlib/handmade/function-jobque-_dot__rq_hasValue-0xd79cfccba3152c2a.rst
+++ b/doc/source/stdlib/handmade/function-jobque-_dot__rq_hasValue-0xd79cfccba3152c2a.rst
@@ -1,0 +1,1 @@
+Returns true when a snapshot has been published and not since cleared.

--- a/doc/source/stdlib/handmade/function-jobque-clear-0xf7e58bcfea5063d9.rst
+++ b/doc/source/stdlib/handmade/function-jobque-clear-0xf7e58bcfea5063d9.rst
@@ -1,0 +1,1 @@
+Drops the stored snapshot, so the box reads back empty until the next publish.

--- a/doc/source/stdlib/handmade/function-jobque-seq_box_create-0x2d4d70fdf69de9ae.rst
+++ b/doc/source/stdlib/handmade/function-jobque-seq_box_create-0x2d4d70fdf69de9ae.rst
@@ -1,0 +1,6 @@
+Creates a new ``SeqBox`` for wait-free snapshot exchange between threads.
+
+Returns a box that starts out empty, carrying one reference which the caller owns and
+must hand to ``seq_box_release``. Every other holder — a lambda capture, a thread the
+pointer was passed to — takes its own reference, and whoever drops the last one deletes
+the box, so the creator is under no obligation to release last.

--- a/doc/source/stdlib/handmade/function-jobque-seq_box_release-0x4d6bf22669a6afa0.rst
+++ b/doc/source/stdlib/handmade/function-jobque-seq_box_release-0x4d6bf22669a6afa0.rst
@@ -1,0 +1,1 @@
+Releases one reference to the box and clears the caller pointer; whoever drops the last reference deletes it.

--- a/doc/source/stdlib/handmade/function-jobque-with_seq_box-0xd68314fae7572b45.rst
+++ b/doc/source/stdlib/handmade/function-jobque-with_seq_box-0xd68314fae7572b45.rst
@@ -1,0 +1,5 @@
+Creates a ``SeqBox`` scoped to the given block and releases it afterward.
+
+The block receives the box as its only argument. The reference taken here is dropped when
+the block returns, so anything that outlives the block — a job, a thread, an audio callback —
+must take a reference of its own rather than borrow this pointer.

--- a/doc/source/stdlib/handmade/structure_annotation-jobque-SeqBox.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-jobque-SeqBox.rst
@@ -1,0 +1,1 @@
+Wait-free snapshot box. Similar to lockbox, only one side publishes a POD value and readers copy the latest one without either side ever waiting.

--- a/examples/audio/hrtf/main.das
+++ b/examples/audio/hrtf/main.das
@@ -155,11 +155,13 @@ def load_sound_data() {
     var f = fopen(fname, "rb")
     if (f == null) {
         // Fallback: generate a 440Hz sine tone
+        delete sound_data
         sound_data <- [for (x in range(MA_SAMPLE_RATE * 2)); sin(2.0 * PI * 440.0 * float(x) / float(MA_SAMPLE_RATE))]
         sound_channels = 1
         sound_rate = MA_SAMPLE_RATE
         return
     }
+    delete sound_data
     fmap(f) $(data) {
         sound_data <- decode_audio(data, sound_channels, sound_rate)
     }

--- a/examples/audio/hrtf/main.das
+++ b/examples/audio/hrtf/main.das
@@ -188,7 +188,7 @@ var window : GLFWwindow?
 var solid_program : uint
 var line_program : uint
 var sphere : OpenGLGeometryFragment
-var stats_box : LockBox?
+var stats_box : SeqBox?
 var asch : AudioSystemChannels
 var last_time = 0.0lf
 var n_was_pressed = false
@@ -263,11 +263,9 @@ def init {
     // Load sound
     load_sound_data()
 
-    // Stats LockBox for per-second utilization + HRTF/simulated split readout.
-    // Lifecycle wraps the audio system: the audio thread releases its share-ref during
-    // audio_system_finalize, THEN shutdown calls lock_box_remove to do the final delete.
-    // `release` alone never deletes.
-    stats_box = lock_box_create()
+    // Stats box for per-second utilization + HRTF/simulated split readout. Both this scope and
+    // the audio thread hold a reference; whichever drops the last one deletes it.
+    stats_box = seq_box_create()
 
     // Audio system — all audio API calls happen between here and audio_system_finalize in shutdown
     asch = audio_system_create()
@@ -344,11 +342,11 @@ def update { // nolint:STYLE038 — linear per-frame UI flow
     }
     b_was_pressed = b_pressed
 
-    // Per-second audio-system stats line. `get` is read-only — keeps the box alive across reads.
-    // `grab` would consume the notification and break the periodic publish/poll loop.
+    // Per-second audio-system stats line. Reading consumes nothing, so the same box serves
+    // every poll.
     since_stats_print += dt
     if (since_stats_print >= 1.0) {
-        stats_box |> get() $(s : AudioSystemStats#) {
+        stats_box |> read() $(s : AudioSystemStats) {
             print("audio: util={s.utilization_pct}%, hrtf={s.hrtf_count}/{s.total_3d} (budget={HRTF_BUDGETS[hrtf_budget_idx]})\n")
         }
         since_stats_print = 0.0
@@ -402,8 +400,7 @@ def update { // nolint:STYLE038 — linear per-frame UI flow
 def shutdown {
     audio_system_finalize(asch.command, asch.next_sid)
     if (stats_box != null) {
-        unsafe(lock_box_remove(stats_box))
-        stats_box = null
+        stats_box |> seq_box_release
     }
     if (window != null) {
         glfwDestroyWindow(window)

--- a/include/daScript/misc/job_que.h
+++ b/include/daScript/misc/job_que.h
@@ -61,6 +61,7 @@ namespace das {
         static constexpr uint32_t TRACK_CHANNEL    = 0xDA5CA002;
         static constexpr uint32_t TRACK_LOCKBOX    = 0xDA5CA003;
         static constexpr uint32_t TRACK_STREAM     = 0xDA5CA004;
+        static constexpr uint32_t TRACK_SEQBOX     = 0xDA5CA005;
         // Join poll level (0 = park on the condvar immediately, the default). Wait() polls
         // mRemaining for level*1024*128 relax-rounds before blocking — the ggml hybrid-poll shape
         // and denomination (their --poll 0..100; 50 = their default ≈ 6.5M rounds). With the

--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -59,6 +59,76 @@ namespace das {
         Feature box;
     };
 
+    // Lock-free snapshot box: one writer publishes a POD value, any number of readers copy the
+    // latest one. Where LockBox holds a mutex for the whole duration of the block it invokes, this
+    // is a seqlock — the writer bumps a version, stores the payload and bumps again; a reader that
+    // catches a write in progress retries. Neither side can ever wait for the other, which is what
+    // makes it safe to publish from a realtime thread (an audio mix callback) that must never
+    // block on a game thread.
+    //
+    // The value is copied byte-wise, so it must be POD with no heap references, and both sides
+    // must agree on its type — the box validates only the size. Payload words are atomic so the
+    // deliberate read/write race the version resolves is not also a data race under TSAN.
+    class SeqBox : public JobStatus {
+    public:
+        enum { PAYLOAD_WORDS = 8, PAYLOAD_BYTES = PAYLOAD_WORDS * 8 };
+        SeqBox() { mTrackMagic = TRACK_SEQBOX; }
+        virtual ~SeqBox() {}
+        // The odd/even counter is a seqlock, which admits exactly one writer: two writers bumping it
+        // concurrently can leave it EVEN while the payload is half-written, and a reader accepts that
+        // as a stable snapshot. So a writer CLAIMS the box with a CAS from even to odd instead.
+        // publish never waits for the claim - it is the realtime side, and a dropped status snapshot
+        // is replaced by the next one a block later, which is cheaper than any wait.
+        bool publish ( const void * data, uint32_t size ) {
+            if ( !size || size > PAYLOAD_BYTES ) return false;
+            uint64_t words[PAYLOAD_WORDS] = {};
+            memcpy(words, data, size);
+            uint32_t s0 = mSeq.load(std::memory_order_acquire);
+            if ( (s0 & 1u) || !mSeq.compare_exchange_strong(s0, s0+1,
+                    std::memory_order_acq_rel, std::memory_order_relaxed) ) return false;  // odd: writing
+            for ( uint32_t w=0; w!=PAYLOAD_WORDS; ++w ) mPayload[w].store(words[w], std::memory_order_relaxed);
+            mSize.store(size, std::memory_order_relaxed);
+            mSeq.store(s0+2, std::memory_order_release);        // even: stable
+            return true;
+        }
+        bool read ( void * out, uint32_t size ) const {
+            if ( !size || size > PAYLOAD_BYTES ) return false;
+            // The write is a handful of stores, so needing more than a couple of retries is already
+            // pathological; give up rather than spin unboundedly on a caller's thread.
+            for ( int attempt=0; attempt!=16; ++attempt ) {
+                uint32_t s0 = mSeq.load(std::memory_order_acquire);
+                if ( s0 & 1u ) continue;
+                if ( mSize.load(std::memory_order_relaxed)!=size ) return false;    // empty, or another type
+                uint64_t words[PAYLOAD_WORDS];
+                for ( uint32_t w=0; w!=PAYLOAD_WORDS; ++w ) words[w] = mPayload[w].load(std::memory_order_relaxed);
+                std::atomic_thread_fence(std::memory_order_acquire);
+                if ( mSeq.load(std::memory_order_relaxed)!=s0 ) continue;
+                memcpy(out, words, size);
+                return true;
+            }
+            return false;
+        }
+        // clear is the control side, so it waits for the claim rather than dropping the request. The
+        // wait is bounded in practice: a claim is held for a handful of stores and never across a call.
+        void clear () {
+            for ( ;; ) {
+                uint32_t s0 = mSeq.load(std::memory_order_acquire);
+                if ( s0 & 1u ) continue;
+                if ( mSeq.compare_exchange_weak(s0, s0+1,
+                        std::memory_order_acq_rel, std::memory_order_relaxed) ) {
+                    mSize.store(0, std::memory_order_relaxed);
+                    mSeq.store(s0+2, std::memory_order_release);
+                    return;
+                }
+            }
+        }
+        bool hasValue () const { return mSize.load(std::memory_order_acquire)!=0; }
+    protected:
+        mutable atomic<uint32_t> mSeq { 0 };
+        atomic<uint32_t> mSize { 0 };
+        atomic<uint64_t> mPayload[PAYLOAD_WORDS] = {};
+    };
+
     template <typename TT>
     class AtomicTT {
     public:
@@ -285,6 +355,12 @@ namespace das {
     DAS_API vec4f lockBoxFill ( Context & context, SimNode_CallBase * call, vec4f * args );
     DAS_API void lockBoxGrab ( LockBox * ch, const TBlock<void,void*> & blk, Context * context, LineInfoArg * at );
     DAS_API void lockBoxUpdate ( LockBox * ch, TypeInfo * ti, const TBlock<void *,void*> & blk, Context * context, LineInfoArg * at );
+    DAS_API SeqBox * seqBoxCreate( Context *, LineInfoArg * );
+    DAS_API void seqBoxRelease( SeqBox * & box, Context * context, LineInfoArg * at );
+    DAS_API void withSeqBox ( const TBlock<void,SeqBox *> & blk, Context * context, LineInfoArg * at );
+    DAS_API bool seqBoxPublish ( SeqBox * box, void * data, int32_t size, Context * context, LineInfoArg * at );
+    DAS_API bool seqBoxRead ( SeqBox * box, void * out, int32_t size, Context * context, LineInfoArg * at );
+    DAS_API void seqBoxClear ( SeqBox * box, Context * context, LineInfoArg * at );
 
     template <typename TT>
     AtomicTT<TT> * atomicCreate( Context *, LineInfoArg * ) {

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -271,7 +271,7 @@ class AudioChannel {
     def report_eos {
         publish_status(AudioChannelState.stopped)
     }
-    def mix(var data : array<float>#; channels, rate : int; dt : float) : bool {  // nolint:STYLE037 - one DSP stage per branch, linear pipeline
+    def mix(var data : array<float>#; channels, rate : int; dt : float) : bool {  // nolint:STYLE037,STYLE038 - one DSP stage per branch, linear pipeline
         if (!source->ready() || g_pitch == 0.) return true
         if (paused) {
             publish_status(AudioChannelState.paused)
@@ -297,7 +297,7 @@ class AudioChannel {
                 unsafe(addr(temp[0])),
                 unsafe(addr(outputFrames)))
             delete samples
-            samples <- temp  // nolint:PERF030 - target deleted on the previous line
+            samples <- temp
         }
         // hrtf — only when this channel is routed through HRTF (top-N by distance per update_hrtf budget)
         var nSoundChannels = source.channels
@@ -312,7 +312,7 @@ class AudioChannel {
                 uint(outputFrames))
             nSoundChannels = 2      // HRTF always produces stereo
             delete samples
-            samples <- temp  // nolint:PERF030 - target deleted on the previous line
+            samples <- temp
         }
         // reverb
         if (reverb != null) {
@@ -326,7 +326,7 @@ class AudioChannel {
                 panic("unsupported channel count {channels}")
             }
             delete samples
-            samples <- temp  // nolint:PERF030 - target deleted on the previous line
+            samples <- temp
         }
         // chorus
         if (chorus != null && nSoundChannels == 2) {
@@ -334,7 +334,7 @@ class AudioChannel {
             temp |> resize(int(outputFrames) * 2)
             chorus_process(chorus, unsafe(addr(samples[0])), unsafe(addr(temp[0])), int(outputFrames))
             delete samples
-            samples <- temp  // nolint:PERF030 - target deleted on the previous line
+            samples <- temp
         }
         // convert channels — for is3D channels, pick the converter sized to the upstream stage:
         //   HRTF mode    -> samples are 2ch, use `channel_converter` (2 -> MA_CHANNELS)

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -66,7 +66,7 @@ enum public AudioChannelState {
     //! Channel has been created but has not started playing yet.
 }
 
-//! Concurrent status snapshot for a playing sound, readable via LockBox.
+//! Concurrent status snapshot for a playing sound, published into a ``SeqBox``.
 struct public AudioChannelStatus {
     state : AudioChannelState
     //! Current playback state.
@@ -78,7 +78,7 @@ struct public AudioChannelStatus {
     //! Number of pending PCM chunks in the stream queue.
 }
 
-//! Snapshot of the audio system's recent CPU utilization and HRTF/simulated routing split, published to a caller-provided LockBox.
+//! Snapshot of the audio system's recent CPU utilization and HRTF/simulated routing split, published to a caller-provided ``SeqBox``.
 struct public AudioSystemStats {
     utilization_pct : float
     //! Mixer CPU utilization over the last ~1 second, in percent (0..100+).
@@ -149,7 +149,7 @@ class AudioSource {
     def set_position(pos : uint64) : uint64 {
         return 0ul
     }
-    def update_status(var status : AudioChannelStatus#) {
+    def update_status(var status : AudioChannelStatus) {
         status.stream_que_length = 0
     }
 }
@@ -177,7 +177,7 @@ class AudioChannel {
     is3D : bool = false
     is_hrtf : bool = true      // runtime per-channel mode; rewritten each frame by update_hrtf's budget
     setup3D : bool = true
-    @do_not_delete status : LockBox? = null
+    @do_not_delete status : SeqBox? = null
     @do_not_delete reverb : I3DL2Reverb?
     @do_not_delete chorus : ma_chorus?
     hrtf : ma_hrtf
@@ -244,8 +244,7 @@ class AudioChannel {
         }
         ma_resampler_uninit(unsafe(addr(resampler)))
         if (status != null) {
-            status |> notify_and_release
-            status = null
+            status |> seq_box_release
         }
         if (reverb != null) {
             unsafe {
@@ -261,23 +260,21 @@ class AudioChannel {
             ma_hrtf_uninit(unsafe(addr(hrtf)))
         }
     }
+    def publish_status(state : AudioChannelState) {
+        // Wait-free: build the snapshot on the audio stack and hand the bytes to the box. Nothing
+        // here can block, allocate, or run code belonging to whoever is reading.
+        return if (status == null)
+        var snapshot = AudioChannelStatus(state = state, playback_position = playback_position)
+        source->update_status(snapshot)
+        status |> publish(snapshot)
+    }
     def report_eos {
-        if (status != null) {
-            status |> update() $(var data : AudioChannelStatus#) {
-                data = AudioChannelStatus(state = AudioChannelState.stopped)
-            }
-        }
+        publish_status(AudioChannelState.stopped)
     }
     def mix(var data : array<float>#; channels, rate : int; dt : float) : bool {  // nolint:STYLE037 - one DSP stage per branch, linear pipeline
         if (!source->ready() || g_pitch == 0.) return true
         if (paused) {
-            if (status != null) {
-                status |> update() $(var status_channel : AudioChannelStatus#) {
-                    status_channel.state = AudioChannelState.paused
-                    status_channel.playback_position = playback_position
-                    source->update_status(status_channel)
-                }
-            }
+            publish_status(AudioChannelState.paused)
             return true
         }
         if (stop && volume_mixer.volume == 0.) return false
@@ -387,13 +384,7 @@ class AudioChannel {
         // update position
         playback_position += inputFrames
         // update status
-        if (status != null) {
-            status |> update() $(var status_channel : AudioChannelStatus#) {
-                status_channel.state = paused ? AudioChannelState.paused : (stop ? AudioChannelState.stopping : AudioChannelState.playing)
-                status_channel.playback_position = playback_position
-                source->update_status(status_channel)
-            }
-        }
+        publish_status(paused ? AudioChannelState.paused : (stop ? AudioChannelState.stopping : AudioChannelState.playing))
         return true
     }
 }
@@ -495,7 +486,7 @@ class AudioSourcePCMStream : AudioSource {
         consumed += uint64(ofs / channels)
         return <- data
     }
-    def override update_status(var status : AudioChannelStatus#) {
+    def override update_status(var status : AudioChannelStatus) {
         status.stream_que_length = length(chunks)
         status.consumed_position = consumed
     }
@@ -796,7 +787,7 @@ struct AudioCommandAddPCMStream3D : AudioCommandAddPCMStream {
 
 struct AudioCommandStatus {
     sid : SID
-    status : uint64       //! opaque LockBox? (archive-safe)
+    status : uint64       //! opaque SeqBox? (archive-safe)
 }
 
 struct AudioCommandSoundPosition3D {
@@ -846,7 +837,7 @@ variant AudioCommand {
     global_volume           : float
     ignore_global_volume    : tuple<sid : SID; value : bool>
     hrtf_budget             : int
-    system_stats_box        : uint64       //! opaque LockBox? (archive-safe)
+    system_stats_box        : uint64       //! opaque SeqBox? (archive-safe)
 }
 
 var g_command_stream : Stream?
@@ -891,10 +882,7 @@ def command_processor {  // nolint:STYLE038 - one arm per AudioCommand variant
             }
             g_sid_2_channel |> clear()
             if (g_stats_box != null) {
-                // stats box is a read-only long-lived publication target, not a one-shot;
-                // never `notify_and_release` (the caller's `get()` doesn't consume notifications).
-                g_stats_box |> release
-                g_stats_box = null
+                g_stats_box |> seq_box_release
             }
             g_command_stream |> release
         } elif (cmd is add_decoder) {
@@ -1016,14 +1004,13 @@ def command_processor {  // nolint:STYLE038 - one arm per AudioCommand variant
         } elif (cmd is system_stats_box) {
             let sbox = cmd as system_stats_box
             if (g_stats_box != null) {
-                g_stats_box |> release
-                g_stats_box = null
+                g_stats_box |> seq_box_release
             }
             // Reset the rolling window so a re-registered box starts with a clean accumulator
             // instead of inheriting partial data from the previous registration.
             g_stats_window_time_ms = 0.0lf
             g_stats_window_samples = 0ul
-            g_stats_box = unsafe(reinterpret<LockBox?>(sbox))
+            g_stats_box = unsafe(reinterpret<SeqBox?>(sbox))
         } elif (cmd is stop) {
             let scmd = cmd as stop
             g_sid_2_channel |> get(scmd.sid) $(var ch : AudioChannel?&) {
@@ -1049,22 +1036,19 @@ def command_processor {  // nolint:STYLE038 - one arm per AudioCommand variant
             }
         } elif (cmd is status) {
             assume scmd = cmd as status
-            var scmd_status = unsafe(reinterpret<LockBox?>(scmd.status))
+            var scmd_status = unsafe(reinterpret<SeqBox?>(scmd.status))
             let found = g_sid_2_channel |> get(scmd.sid) $(var ch : AudioChannel?&) {
+                // Re-registering simply swaps the box: the old one is released, and a caller that
+                // races another has a losing box rather than a dead process.
                 if (ch.status != null) {
-                    if (scmd_status != null) {
-                        panic("audio: status already set for {scmd.sid}")
-                    }
-                    ch.status |> notify_and_release
+                    ch.status |> seq_box_release
                 }
                 ch.status = scmd_status
             }
             if (!found) {
                 if (scmd_status != null) {
-                    scmd_status |> update() $(var data : AudioChannelStatus#) {
-                        data = AudioChannelStatus(state = AudioChannelState.stopped)
-                    }
-                    scmd_status |> notify_and_release
+                    scmd_status |> publish(AudioChannelStatus(state = AudioChannelState.stopped))
+                    scmd_status |> seq_box_release
                 }
             }
         } elif (cmd is reverb) {
@@ -1102,7 +1086,7 @@ var g_pause : bool = false
 var g_volume : float = 1.  //! global master volume multiplier (1.0 = full, 0.0 = mute)
 
 // AudioSystemStats publication state (audio-context-side; main side holds the LockBox handle and read-grabs it).
-var g_stats_box : LockBox? = null
+var g_stats_box : SeqBox? = null
 var g_stats_window_time_ms = 0.0lf      // accumulated mixer wall time over the current window
 var g_stats_window_samples = 0ul        // accumulated audio frames over the current window (flush gate: realTimeMs >= 1000)
 var g_stats_recent_util_pct : float = 0.0
@@ -1164,11 +1148,7 @@ def private publish_audio_stats(dt_ms : double; frames : uint64) {
     let snap = g_stats_recent_util_pct
     let hrtfCount = g_stats_hrtf_count
     let total3D = g_stats_3d_count
-    g_stats_box |> update() $(var s : AudioSystemStats#) {
-        s.utilization_pct = snap
-        s.hrtf_count = hrtfCount
-        s.total_3d = total3D
-    }
+    g_stats_box |> publish(AudioSystemStats(utilization_pct = snap, hrtf_count = hrtfCount, total_3d = total3D))
 }
 
 [init]
@@ -1500,17 +1480,17 @@ def public set_hrtf_budget(n : int) {
     push_cmd(AudioCommand(hrtf_budget = n))
 }
 
-def public set_audio_stats_box(var box : LockBox?) {
-    //! Register a LockBox to receive periodic AudioSystemStats updates from the audio thread.
-    //! The audio thread writes one snapshot per ~1-second window; the caller reads it on demand
-    //! via ``box |> get() $(var s : AudioSystemStats) { ... }`` (read-only — keeps the box alive
-    //! across multiple reads). Pass null to clear. Do NOT use ``grab()``: that's a one-shot consume.
+def public set_audio_stats_box(var box : SeqBox?) {
+    //! Register a box to receive periodic AudioSystemStats updates from the audio thread.
+    //! The audio thread publishes one snapshot per ~1-second window; read it on demand with
+    //! ``box |> read() $(s : AudioSystemStats) { ... }``. Reading consumes nothing, so the same
+    //! box serves any number of reads. Pass null to stop.
     if (box == null) {
         push_cmd(AudioCommand(system_stats_box = 0ul))
         return
     }
     box |> add_ref
-    box |> set() <| new AudioSystemStats(utilization_pct = 0.0, hrtf_count = 0, total_3d = 0)
+    box |> publish(AudioSystemStats(utilization_pct = 0.0, hrtf_count = 0, total_3d = 0))
     push_cmd(AudioCommand(system_stats_box = intptr(box)))
 }
 
@@ -1531,18 +1511,20 @@ def public set_position(sid : SID; pos : float3; dir : float3 = float3(0.)) {
     return sid
 }
 
-def public set_status_update(sid : SID; var status : LockBox?) {
-    //! set status for sound
+def public set_status_update(sid : SID; var status : SeqBox?) {
+    //! Publish this sound's status into ``status`` until ``unset_status_update``.
+    //! The box is seeded with ``starting`` here, on the calling thread, so it reads sensibly the
+    //! instant this returns. Reading it never makes the mixer wait, and releasing it needs no
+    //! ordering with the audio thread — see ``seq_box_release``.
     status |> add_ref
-    status |> append(1)
-    status |> set() <| new AudioChannelStatus(state = AudioChannelState.starting)
+    status |> publish(AudioChannelStatus(state = AudioChannelState.starting))
     push_cmd(AudioCommand(status = AudioCommandStatus(sid = sid, status = intptr(status))))
     return sid
 }
 
-def public clear_status(var status : LockBox?) {
-    //! clear status for sound
-    status |> clear(type <AudioChannelStatus>)
+def public clear_status(var status : SeqBox?) {
+    //! Drop the stored snapshot; the box reads back empty until the next publish.
+    status |> clear
 }
 
 def public unset_status_update(sid : SID) {

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -830,7 +830,7 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
     let TARGET_CHUNKS = 4
     let LOW_WATERMARK = 2
     var tracks : array<MidiPlaybackState?>
-    var status_box <- lock_box_create()
+    var status_box = seq_box_create()
     set_status_update(sid, status_box)
     var pcm_box <- lock_box_create()
     // initialize reverb (convolution: 2s decay, 15kHz→1kHz lowpass sweep)
@@ -969,7 +969,7 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
         }
         // adaptive buffering
         var que_len = 0
-        status_box |> get() $(st : AudioChannelStatus#) {
+        status_box |> read() $(st : AudioChannelStatus) {
             que_len = st.stream_que_length
         }
         if (que_len >= TARGET_CHUNKS) {
@@ -989,9 +989,7 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
     pcm_box |> join()
     unsafe(lock_box_remove(pcm_box))
     unset_status_update(sid)
-    clear_status(status_box)
-    status_box |> join()
-    unsafe(lock_box_remove(status_box))
+    status_box |> seq_box_release
     unsafe {
         set_audio_thread_command_stream(null)
     }

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -81,7 +81,7 @@ def gm_preset(program : int) : GmPreset {
 
 // ─── Channel 10 Drum Map ───
 
-def render_drum_hit(note : int; velocity : float) : array<float> {
+def render_drum_hit(note : int; velocity : float) : array<float> {  // nolint:STYLE037 - GM drum-note dispatch, one arm per note
     //! Render a GM channel-10 drum hit for `note` at the given velocity as a mono PCM buffer.
     //! Dispatches to the appropriate `render_*` drum voice from `strudel_synth`; falls back to a short hi-hat burst for unmapped notes.
     let gain = velocity
@@ -396,7 +396,7 @@ def private sf2_note_off(var state : MidiPlaybackState; ch, note : int) {
 
 // ─── Event Processing ───
 
-def process_events(var state : MidiPlaybackState) {
+def process_events(var state : MidiPlaybackState) {  // nolint:STYLE037,STYLE038 - MIDI event dispatch, one arm per event kind
     //! Dispatch all MIDI events up to the current playback tick: note-on/off, program changes, CCs, pitch bend, tempo.
     //! Routes note events either to the SF2 voice allocator or to the legacy oscillator/sample path depending on `state.sf2`.
     while (state.event_index < length(state.events)) {
@@ -423,12 +423,12 @@ def process_events(var state : MidiPlaybackState) {
                     if (state.bank != null) {
                         let drum_name = gm_drum_name(ev.data1)
                         if (!empty(drum_name) && key_exists(state.bank.sounds, drum_name)) {
-                            drum_stereo <- render_sample(*state.bank, drum_name, ev.data1 % 3, 1.0)
+                            drum_stereo <- render_sample(*state.bank, drum_name, ev.data1 % 3, 1.0)  // nolint:PERF030 - first write to the fresh declaration above
                         }
                     }
                     if (empty(drum_stereo)) {
                         var drum_mono <- render_drum_hit(ev.data1, vel)
-                        drum_stereo <- mono_to_stereo(drum_mono)
+                        drum_stereo <- mono_to_stereo(drum_mono)  // nolint:PERF030 - the enclosing `empty(drum_stereo)` guard proves the target holds nothing
                     }
                     state.voices |> push(new MidiVoice(
                         channel = ch,
@@ -541,7 +541,7 @@ def process_events(var state : MidiPlaybackState) {
 
 // ─── Render One Tick ───
 
-def midi_tick(var state : MidiPlaybackState; chunk_seconds : float) : array<float> {
+def midi_tick(var state : MidiPlaybackState; chunk_seconds : float) : array<float> {  // nolint:STYLE037,STYLE038 - render pipeline, phases share the output buffer and send buses
     //! Advance playback by `chunk_seconds`, process pending events, render all active voices and return an interleaved stereo PCM chunk.
     //! Handles oscillator voices, drum/sample playback, SF2 voices, and the shared reverb/chorus send buses.
     process_events(state)
@@ -819,7 +819,7 @@ var private g_midi_audio_vis_ptr : void?  // audio vis channel as void* (avoids 
 
 // ─── Audio Thread Main Loop ───
 
-def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_status : JobStatus?; audio_channel : void?; vis_ptr : void?) {
+def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_status : JobStatus?; audio_channel : void?; vis_ptr : void?) {  // nolint:STYLE037,STYLE038 - thread lifecycle + watermark loop, state is loop-carried
     unsafe {
         set_audio_thread_command_stream(audio_channel)
     }

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -67,7 +67,7 @@ var private g_playback_box : LockBox?
 var private g_tracks : array<StrudelTrack?>
 var private g_look_ahead : float = 0.1
 var private g_chunk_seconds : float = 0.05
-var private g_tick_status_box : LockBox?  // buffer level feedback for strudel_tick
+var private g_tick_status_box : SeqBox?   // buffer level feedback for strudel_tick
 var private g_tick_pcm_box : LockBox?    // lock box for append_box_to_pcm in main-thread mode
 
 //! Per-track PCM output written by strudel_tick (main-thread mode only), indexed by track index.
@@ -122,7 +122,7 @@ def public strudel_get_playback_time() : tuple<double; double> {
         // main-thread mode — use consumed_position once audio device starts,
         // fall back to g_wall_time during startup (before device begins consuming)
         var consumed = 0ul
-        g_tick_status_box |> get() $(st : AudioChannelStatus#) {
+        g_tick_status_box |> read() $(st : AudioChannelStatus) {
             consumed = st.consumed_position
         }
         wt = consumed > 0ul ? double(consumed) / double(SAMPLE_RATE) : g_wall_time
@@ -486,8 +486,7 @@ def public strudel_create_channel() {
     //! Create the PCM stream for main-thread playback. Call once after audio_system_create() and before strudel_tick.
     if (g_sid == 0ul) {
         g_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
-        g_tick_status_box = lock_box_create()
-        g_tick_status_box |> add_ref()
+        g_tick_status_box = seq_box_create()
         set_status_update(g_sid, g_tick_status_box)
         g_tick_pcm_box = lock_box_create()
         // memory tracking baseline
@@ -507,7 +506,7 @@ def public strudel_tick() {
     // check buffer level — skip if we're ahead enough
     if (g_tick_status_box != null) {
         var que_len = 0
-        g_tick_status_box |> get() $(st : AudioChannelStatus#) {
+        g_tick_status_box |> read() $(st : AudioChannelStatus) {
             que_len = st.stream_que_length
         }
         if (que_len >= 4) return
@@ -688,7 +687,7 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
     var total_time = 0.lf
     var total_samples = 0ul
     var max_chunk_usec = 0.0lf
-    var status_box <- lock_box_create()
+    var status_box = seq_box_create()
     set_status_update(g_sid, status_box)
     var pcm_box <- lock_box_create()
     var mixer : ma_volume_mixer
@@ -777,7 +776,7 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
         }
         // buffer level feedback
         var que_len = 0
-        status_box |> get() $(st : AudioChannelStatus#) {
+        status_box |> read() $(st : AudioChannelStatus) {
             que_len = st.stream_que_length
         }
         if (que_len >= TARGET_CHUNKS) {
@@ -799,9 +798,7 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
     unsafe(lock_box_remove(pcm_box))
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
     unset_status_update(g_sid)
-    clear_status(status_box)
-    status_box |> join()
-    unsafe(lock_box_remove(status_box))
+    status_box |> seq_box_release
     delete output
     // release thread-local tracks so sample voices and orbit buses are freed
     // before the leak-check below (and before the context dies).
@@ -908,26 +905,11 @@ def public strudel_shutdown() {
         unsafe(lock_box_remove(g_tick_pcm_box))
         g_tick_pcm_box = null
     }
-    // status box (main-thread mode: created in strudel_create_channel)
+    // status box (main-thread mode: created in strudel_create_channel). No ordering with the
+    // audio thread: whichever side drops the last reference deletes the box.
     if (g_tick_status_box != null) {
         unset_status_update(g_sid)
-        // set_status_update added a ref released only when the audio command processor
-        // handles this status=0 command (notify_and_release). In single-threaded mode
-        // there is no audio thread to do it (and the join below is a no-op, job_que.cpp),
-        // so we drain the queue ourselves — SAFE because nothing else is in the mixer
-        // context. In the threaded build we must NOT drain here: the audio thread is
-        // running command_processor concurrently and the mixer context is not
-        // thread-safe (verySafeContext=false) — racing it corrupts the heap. There the
-        // audio thread processes the command and the join below fences (original path).
-        if (audio_is_single_threaded()) {
-            audio_system_release_context()
-        }
-        clear_status(g_tick_status_box)
-        var tick_ptr = g_tick_status_box
-        g_tick_status_box |> release()
-        tick_ptr |> join()
-        unsafe(lock_box_remove(tick_ptr))
-        g_tick_status_box = null
+        g_tick_status_box |> seq_box_release
     }
     // release tracks and buffers before measuring memory
     for (t in g_tracks) {

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -498,7 +498,7 @@ def public strudel_create_channel() {
     }
 }
 
-def public strudel_tick() {
+def public strudel_tick() {  // nolint:STYLE038 - one tick: query, render, mix, append in sequence
     //! Single main-thread tick: query all tracks, render audio, mix, append to the PCM stream.
     //! Call from your render loop; self-regulating — skips when the audio buffer has enough data queued.
     // wait for previous pcm box to be consumed before overwriting the buffer
@@ -594,7 +594,7 @@ def public strudel_tick() {
     }
 }
 
-def public strudel_tick_offline() {
+def public strudel_tick_offline() {  // nolint:STYLE038 - same tick pipeline as strudel_tick, without a driver
     //! Offline tick: same as strudel_tick but without an audio driver.
     //! Renders into g_master_pcm and advances g_wall_time; call in a tight loop for offline WAV rendering.
     let t0 = ref_time_ticks()
@@ -678,7 +678,7 @@ def public strudel_tick_offline() {
 
 // --- Threaded mode ---
 
-def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noop_cmd) {
+def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noop_cmd) {  // nolint:STYLE037,STYLE038 - blocking tick loop + command dispatch, state is loop-carried
     //! Blocking multi-track tick loop for threaded playback.
     //! Runs on the strudel thread (spawned by strudel_init); dispatches incoming user commands via cmd_fn until shutdown.
     let CHUNK_SEC = g_chunk_seconds
@@ -929,7 +929,7 @@ def public strudel_shutdown() {
             delete g_sf2
         }
         g_sf2 = null
-        g_sf2_path := ""
+        g_sf2_path = ""
     }
     // release sample bank (each Sample owns a large array<float>; table finalizer drops all variations)
     delete g_bank.sounds
@@ -1024,7 +1024,7 @@ def private serialize_zone(var arch : Archive; var zone : SF2Zone?&) {
     }
 }
 
-def private serialize_sf2(var arch : Archive; var sf2 : SF2File?&) {
+def private serialize_sf2(var arch : Archive; var sf2 : SF2File?&) {  // nolint:STYLE038 - one serialize call per field, a flat list
     var has = sf2 != null
     arch |> serialize(has)
     if (!has) return

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -12,6 +12,7 @@ MAKE_TYPE_FACTORY(JobStatus, JobStatus)
 MAKE_TYPE_FACTORY(Channel, Channel)
 MAKE_TYPE_FACTORY(LockBox, LockBox)
 MAKE_TYPE_FACTORY(Stream, Stream)
+MAKE_TYPE_FACTORY(SeqBox, SeqBox)
 
 MAKE_TYPE_FACTORY(Atomic32, AtomicTT<int32_t>)
 MAKE_TYPE_FACTORY(Atomic64, AtomicTT<int64_t>)
@@ -505,6 +506,60 @@ namespace das {
     struct JobStatusAnnotation : ManagedStructureAnnotation<JobStatus,false> {
         JobStatusAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation ("JobStatus", ml) {
             addProperty<DAS_BIND_MANAGED_PROP(isReady)>("isReady");
+            addProperty<DAS_BIND_MANAGED_PROP(isValid)>("isValid");
+        }
+    };
+
+    SeqBox * seqBoxCreate( Context *, LineInfoArg * at ) {
+        SeqBox * box = new SeqBox();
+        if ( at ) box->mCreatedAt = at->describe();
+        box->addRef(at);
+        return box;
+    }
+
+    // Release, and whoever drops the last reference deletes. Deliberately not the
+    // create/remove-with-rc==1 shape the other primitives use: a status box is shared with the
+    // audio thread, and requiring the owner to remove it last is exactly what forced callers to
+    // block on join() first — the wait this box exists to remove.
+    // The last drop deletes on whichever thread releases last, possibly a realtime one; that is
+    // a teardown-only cost (a tracker unlink under mutex plus one free) and an accepted trade.
+    void seqBoxRelease( SeqBox * & box, Context * context, LineInfoArg * at ) {
+        if ( !box ) context->throw_error_at(at, "seqBoxRelease: box is null");
+        if (!box->isValid()) context->throw_error_at(at, "seq box is invalid (already deleted?)");
+        if ( box->releaseRef(at)==0 ) delete box;
+        box = nullptr;
+    }
+
+    void withSeqBox ( const TBlock<void,SeqBox *> & blk, Context * context, LineInfoArg * at ) {
+        SeqBox box;
+        AddReleaseGuard<SeqBox> guard(&box, context, at);
+        das_invoke<void>::invoke<SeqBox *>(context, at, blk, &box);
+    }
+
+    // Size comes from the das side (typeinfo sizeof), so the box never needs the value's TypeInfo —
+    // it is a byte buffer with a version, and the size is all it can validate.
+    bool seqBoxPublish ( SeqBox * box, void * data, int32_t size, Context * context, LineInfoArg * at ) {
+        if ( !box ) context->throw_error_at(at, "seqBoxPublish: box is null");
+        if ( size <= 0 || uint32_t(size) > uint32_t(SeqBox::PAYLOAD_BYTES) )
+            context->throw_error_at(at, "seqBoxPublish: value does not fit the box payload");
+        return box->publish(data, uint32_t(size));
+    }
+
+    bool seqBoxRead ( SeqBox * box, void * out, int32_t size, Context * context, LineInfoArg * at ) {
+        if ( !box ) context->throw_error_at(at, "seqBoxRead: box is null");
+        if ( size <= 0 || uint32_t(size) > uint32_t(SeqBox::PAYLOAD_BYTES) )
+            context->throw_error_at(at, "seqBoxRead: value does not fit the box payload");
+        return box->read(out, uint32_t(size));
+    }
+
+    void seqBoxClear ( SeqBox * box, Context * context, LineInfoArg * at ) {
+        if ( !box ) context->throw_error_at(at, "seqBoxClear: box is null");
+        box->clear();
+    }
+
+    struct SeqBoxAnnotation : ManagedStructureAnnotation<SeqBox,false> {
+        SeqBoxAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation ("SeqBox", ml) {
+            addProperty<DAS_BIND_MANAGED_PROP(hasValue)>("hasValue");
             addProperty<DAS_BIND_MANAGED_PROP(isValid)>("isValid");
         }
     };
@@ -1116,7 +1171,7 @@ namespace das {
     }
 
     uint64_t count_jobque_leaks () {
-        // Number of live JobStatus/Channel/LockBox/Stream + Feature objects globally.
+        // Number of live JobStatus/Channel/LockBox/SeqBox/Stream + Feature objects globally.
         // Tests compare before/after a teardown to assert no net leak (dastest's own
         // infrastructure may hold some, so an absolute count is not meaningful).
         return JobStatus::CountJobQueLeaks();
@@ -1337,6 +1392,9 @@ namespace das {
             auto stra = new StreamAnnotation(lib);
             stra->from("JobStatus");
             addAnnotation(stra);
+            auto sqb = new SeqBoxAnnotation(lib);
+            sqb->from("JobStatus");
+            addAnnotation(sqb);
             auto a32 = new AtomicAnnotation<int32_t>("Atomic32",lib);
             addAnnotation(a32);
             auto a64 = new AtomicAnnotation<int64_t>("Atomic64",lib);
@@ -1410,6 +1468,30 @@ namespace das {
             addExtern<DAS_BIND_FUN(lockBoxGrab)>(*this, lib,  "_builtin_lockbox_grab",
                 SideEffects::modifyArgumentAndExternal, "lockBoxGrab")
                     ->args({"box","block","context","line"});
+            // seq box
+            // Neither create nor release is unsafe: the box cannot be deleted while another
+            // holder still references it, so there is no lifetime hazard to gate.
+            // seq_box_release is the only deleter: the family JobStatus `release` (like on every
+            // other primitive) only drops a share, so a last reference dropped through it leaks.
+            addConstant<int>(*this, "SEQ_BOX_PAYLOAD", SeqBox::PAYLOAD_BYTES);
+            addExtern<DAS_BIND_FUN(seqBoxCreate)>(*this, lib, "seq_box_create",
+                SideEffects::invoke, "seqBoxCreate")
+                    ->args({ "context","line" });
+            addExtern<DAS_BIND_FUN(seqBoxRelease)>(*this, lib, "seq_box_release",
+                SideEffects::modifyArgumentAndAccessExternal, "seqBoxRelease")
+                    ->args({ "box", "context","line" });
+            addExtern<DAS_BIND_FUN(withSeqBox)>(*this, lib,  "with_seq_box",
+                SideEffects::invoke, "withSeqBox")
+                    ->args({"block","context","line"});
+            addExtern<DAS_BIND_FUN(seqBoxPublish)>(*this, lib,  "_builtin_seq_box_publish",
+                SideEffects::modifyArgumentAndExternal, "seqBoxPublish")
+                    ->args({"box","data","size","context","line"});
+            addExtern<DAS_BIND_FUN(seqBoxRead)>(*this, lib,  "_builtin_seq_box_read",
+                SideEffects::modifyArgumentAndExternal, "seqBoxRead")
+                    ->args({"box","out","size","context","line"});
+            addExtern<DAS_BIND_FUN(seqBoxClear)>(*this, lib,  "clear",
+                SideEffects::modifyArgumentAndExternal, "seqBoxClear")
+                    ->args({"box","context","line"});
             // channel
             addInterop<channelPush,void,Channel *,vec4f>(*this, lib,  "_builtin_channel_push",
                 SideEffects::modifyArgumentAndExternal, "channelPush")

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -971,6 +971,7 @@ namespace das {
         if ( mTrackMagic == TRACK_CHANNEL ) tp << " (Channel)";
         else if ( mTrackMagic == TRACK_LOCKBOX ) tp << " (LockBox)";
         else if ( mTrackMagic == TRACK_STREAM ) tp << " (Stream)";
+        else if ( mTrackMagic == TRACK_SEQBOX ) tp << " (SeqBox)";
         else tp << " (JobStatus)";
         tp << (isAddRef ? " addRef" : " releaseRef")
            << " (rc=" << int(mRef.load()) << ")";
@@ -1091,6 +1092,7 @@ namespace das {
                 if ( p->mTrackMagic == TRACK_CHANNEL ) tp << " Channel";
                 else if ( p->mTrackMagic == TRACK_LOCKBOX ) tp << " LockBox";
                 else if ( p->mTrackMagic == TRACK_STREAM ) tp << " Stream";
+                else if ( p->mTrackMagic == TRACK_SEQBOX ) tp << " SeqBox";
                 else tp << " JobStatus";
                 if ( !p->mCreatedAt.empty() ) tp << " created at " << p->mCreatedAt;
                 tp << "\n";

--- a/tests-cpp/small/test_seqbox_concurrent_writers.cpp
+++ b/tests-cpp/small/test_seqbox_concurrent_writers.cpp
@@ -1,0 +1,67 @@
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include "daScript/misc/job_que.h"
+#include "daScript/simulate/aot_builtin_jobque.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace das;
+
+// SeqBox's odd/even counter is a seqlock, which admits exactly one writer. Two writers bumping it
+// concurrently could leave it EVEN while the payload was half-written, and a reader accepted that as
+// a stable snapshot -- reachable from the audio module, where the mixer publishes on the device
+// thread while clear_status/set_status_update write from the caller's. Writers now claim the box
+// with a CAS, so publish either owns it outright or declines.
+//
+// Every published snapshot carries the same generation counter in all eight words, so a snapshot
+// whose words disagree can only have been assembled from two different publishes.
+TEST_CASE("seq box survives concurrent writers") {
+    SeqBox box;
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> reads{0};
+    std::atomic<uint64_t> torn{0};
+    std::atomic<uint64_t> published{0};
+    std::atomic<uint64_t> declined{0};
+
+    std::thread publisher([&]{
+        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+        uint64_t gen = 1;
+        while (!stop.load(std::memory_order_relaxed)) {
+            uint64_t words[SeqBox::PAYLOAD_WORDS];
+            for (int w=0; w!=SeqBox::PAYLOAD_WORDS; ++w) words[w] = gen;
+            if (box.publish(words, SeqBox::PAYLOAD_BYTES)) published.fetch_add(1, std::memory_order_relaxed);
+            else declined.fetch_add(1, std::memory_order_relaxed);
+            ++gen;
+        }
+    });
+    std::thread clearer([&]{
+        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+        while (!stop.load(std::memory_order_relaxed)) box.clear();
+    });
+    std::thread reader([&]{
+        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+        while (!stop.load(std::memory_order_relaxed)) {
+            uint64_t out[SeqBox::PAYLOAD_WORDS];
+            if (!box.read(out, SeqBox::PAYLOAD_BYTES)) continue;
+            reads.fetch_add(1, std::memory_order_relaxed);
+            for (int w=1; w!=SeqBox::PAYLOAD_WORDS; ++w) {
+                if (out[w]!=out[0]) { torn.fetch_add(1, std::memory_order_relaxed); break; }
+            }
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    stop.store(true, std::memory_order_relaxed);
+    publisher.join(); clearer.join(); reader.join();
+
+    CHECK(torn.load() == 0);
+    // guards against a vacuous pass: all three threads have to have made progress for the assertion
+    // above to mean anything
+    CHECK(published.load() > 0);
+    CHECK(reads.load() > 0);
+}

--- a/tests-cpp/small/test_seqbox_concurrent_writers.cpp
+++ b/tests-cpp/small/test_seqbox_concurrent_writers.cpp
@@ -13,10 +13,19 @@ using namespace das;
 // concurrently could leave it EVEN while the payload was half-written, and a reader accepted that as
 // a stable snapshot -- reachable from the audio module, where the mixer publishes on the device
 // thread while clear_status/set_status_update write from the caller's. Writers now claim the box
-// with a CAS, so publish either owns it outright or declines.
+// with a CAS, so a writer either owns it outright or declines.
 //
-// Every published snapshot carries the same generation counter in all eight words, so a snapshot
-// whose words disagree can only have been assembled from two different publishes.
+// Two publishers are the competing writers, and the clearer runs spaced out rather than flat out.
+// That is deliberate: a clearer in a tight loop leaves the box EMPTY most of the time, so reads
+// mostly fail and the number of snapshots actually validated collapses to whatever the scheduler
+// allows -- measured as low as 31 in this window, against ~130k for the shape below. Two publishers
+// keep the box full, and a spaced clearer still covers the publish-vs-clear path the audio module
+// hits. The old protocol also tears far more visibly under this shape (~85k-155k torn reads here
+// versus ~31k for one publisher against a hot clearer).
+//
+// Every published snapshot carries one generation counter in all eight words, and the two
+// publishers draw from disjoint generations, so a snapshot whose words disagree can only have been
+// assembled from two different publishes. Equal words therefore never report a false tear.
 TEST_CASE("seq box survives concurrent writers") {
     SeqBox box;
 
@@ -25,22 +34,25 @@ TEST_CASE("seq box survives concurrent writers") {
     std::atomic<uint64_t> reads{0};
     std::atomic<uint64_t> torn{0};
     std::atomic<uint64_t> published{0};
-    std::atomic<uint64_t> declined{0};
 
-    std::thread publisher([&]{
+    auto publish_loop = [&](uint64_t firstGeneration){
         while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
-        uint64_t gen = 1;
+        uint64_t gen = firstGeneration;
         while (!stop.load(std::memory_order_relaxed)) {
             uint64_t words[SeqBox::PAYLOAD_WORDS];
             for (int w=0; w!=SeqBox::PAYLOAD_WORDS; ++w) words[w] = gen;
             if (box.publish(words, SeqBox::PAYLOAD_BYTES)) published.fetch_add(1, std::memory_order_relaxed);
-            else declined.fetch_add(1, std::memory_order_relaxed);
-            ++gen;
+            gen += 2;   // disjoint from the other publisher's generations
         }
-    });
+    };
+    std::thread publisherA(publish_loop, 1);
+    std::thread publisherB(publish_loop, 2);
     std::thread clearer([&]{
         while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
-        while (!stop.load(std::memory_order_relaxed)) box.clear();
+        uint64_t spin = 0;
+        while (!stop.load(std::memory_order_relaxed)) {
+            if (++spin % 64 == 0) box.clear();
+        }
     });
     std::thread reader([&]{
         while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
@@ -57,11 +69,11 @@ TEST_CASE("seq box survives concurrent writers") {
     start.store(true, std::memory_order_release);
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
     stop.store(true, std::memory_order_relaxed);
-    publisher.join(); clearer.join(); reader.join();
+    publisherA.join(); publisherB.join(); clearer.join(); reader.join();
 
     CHECK(torn.load() == 0);
-    // guards against a vacuous pass: all three threads have to have made progress for the assertion
-    // above to mean anything
+    // guards against a vacuous pass: the writers have to have landed snapshots and the reader has
+    // to have validated some, or `torn == 0` above says nothing
     CHECK(published.load() > 0);
     CHECK(reads.load() > 0);
 }

--- a/tests/jobque/test_jobque_seqbox.das
+++ b/tests/jobque/test_jobque_seqbox.das
@@ -1,0 +1,247 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+require dastest/testing_boost public
+require daslib/jobque_boost
+
+// SeqBox is the lock-free sibling of LockBox: a POD snapshot that one side publishes and any
+// number of others copy, with neither side ever waiting. These pin the parts a caller can observe
+// — that a read consumes nothing, that an empty or wrongly-sized read fails instead of handing
+// back garbage, and that the box is deleted by whoever drops the last reference rather than by a
+// designated owner who must go last.
+
+struct Snap {
+    tag : int
+    a : uint64
+    b : uint64
+    n : int
+}
+
+[test]
+def test_empty_box_reads_nothing(t : T?) {
+    t |> run("a box with nothing published reads back false") @(t : T?) {
+        with_seq_box() $(box) {
+            t |> equal(box.isValid, true)
+            t |> equal(box.hasValue, false)
+            var entered = false
+            let got = box |> read() $(s : Snap) {
+                entered = true
+            }
+            t |> equal(got, false)
+            t |> equal(entered, false, "the block must not run when there is nothing to read")
+        }
+    }
+}
+
+[test]
+def test_publish_then_read(t : T?) {
+    t |> run("read hands back exactly what was published") @(t : T?) {
+        with_seq_box() $(box) {
+            box |> publish(Snap(tag = 7, a = 4242ul, b = 99ul, n = -3))
+            t |> equal(box.hasValue, true)
+            var seen = Snap()
+            let got = box |> read() $(s : Snap) {
+                seen = s
+            }
+            t |> equal(got, true)
+            t |> equal(seen.tag, 7)
+            t |> equal(seen.a, 4242ul)
+            t |> equal(seen.b, 99ul)
+            t |> equal(seen.n, -3)
+        }
+    }
+}
+
+[test]
+def test_read_consumes_nothing(t : T?) {
+    t |> run("the same snapshot reads back until the next publish") @(t : T?) {
+        with_seq_box() $(box) {
+            box |> publish(Snap(tag = 1, a = 10ul, b = 0ul, n = 0))
+            var first = 0
+            var second = 0
+            box |> read() $(s : Snap) {
+                first = s.tag
+            }
+            box |> read() $(s : Snap) {
+                second = s.tag
+            }
+            t |> equal(first, 1)
+            t |> equal(second, 1)
+            box |> publish(Snap(tag = 2, a = 20ul, b = 0ul, n = 0))
+            var third = 0
+            box |> read() $(s : Snap) {
+                third = s.tag
+            }
+            t |> equal(third, 2, "publish replaces the snapshot")
+        }
+    }
+}
+
+[test]
+def test_clear_empties_the_box(t : T?) {
+    t |> run("clear drops the snapshot") @(t : T?) {
+        with_seq_box() $(box) {
+            box |> publish(Snap(tag = 5, a = 0ul, b = 0ul, n = 0))
+            box |> clear
+            t |> equal(box.hasValue, false)
+            let got = box |> read() $(s : Snap) {
+                pass
+            }
+            t |> equal(got, false)
+        }
+    }
+}
+
+[test]
+def test_size_mismatch_is_refused(t : T?) {
+    t |> run("reading as a different-sized type fails instead of reinterpreting") @(t : T?) {
+        with_seq_box() $(box) {
+            box |> publish(Snap(tag = 3, a = 1ul, b = 2ul, n = 4))
+            var entered = false
+            let got = box |> read() $(s : IntVal) {
+                entered = true
+            }
+            t |> equal(got, false)
+            t |> equal(entered, false)
+        }
+    }
+}
+
+[test]
+def test_equal_size_read_reinterprets(t : T?) {
+    t |> run("an equal-size different type reads back byte-reinterpreted, as documented") @(t : T?) {
+        with_seq_box() $(box) {
+            box |> publish(PairA(x = 7, y = -9))
+            var entered = false
+            let got = box |> read() $(s : PairB) {
+                entered = true
+                t |> equal(s.u, 7)
+                t |> equal(s.v, -9)
+            }
+            t |> equal(got, true, "size is the only discriminator - the read must succeed")
+            t |> equal(entered, true)
+        }
+    }
+}
+
+[test]
+def test_payload_boundary_roundtrips(t : T?) {
+    t |> run("a payload of exactly SEQ_BOX_PAYLOAD bytes round-trips") @(t : T?) {
+        static_assert(typeinfo sizeof(type<Full64>) == SEQ_BOX_PAYLOAD, "Full64 must fill the box exactly")
+        with_seq_box() $(box) {
+            var v = Full64()
+            for (i in range(8)) {
+                v.w[i] = uint64(i * 1000 + 7)
+            }
+            let ok = box |> publish(v)
+            t |> equal(ok, true)
+            var entered = false
+            box |> read() $(s : Full64) {
+                entered = true
+                for (i in range(8)) {
+                    t |> equal(s.w[i], uint64(i * 1000 + 7))
+                }
+            }
+            t |> equal(entered, true)
+        }
+    }
+}
+
+struct IntVal {
+    v : int
+}
+
+// PairA and PairB have identical size and layout on purpose: the box stores no type identity,
+// so an equal-size read succeeds and reinterprets - the contract the read() doc states.
+struct PairA {
+    x : int
+    y : int
+}
+
+struct PairB {
+    u : int
+    v : int
+}
+
+struct Full64 {
+    w : uint64[8]
+}
+
+// A value larger than SEQ_BOX_PAYLOAD is rejected by concept_assert, so oversizing the payload is a
+// compile error rather than a runtime condition — there is nothing to assert at run time.
+
+// ---- lifetime: the last reference deletes, in either order ----
+
+[test]
+def test_owner_releases_last(t : T?) {
+    t |> run("box survives until the second holder releases it") @(t : T?) {
+        let before = count_jobque_leaks()
+        var box = seq_box_create()
+        box |> add_ref                       // stand in for the audio thread's reference
+        var mine = box
+        mine |> seq_box_release              // rc 2 -> 1, still alive
+        box |> publish(Snap(tag = 9, a = 0ul, b = 0ul, n = 0))
+        var seen = 0
+        box |> read() $(s : Snap) {
+            seen = s.tag
+        }
+        t |> equal(seen, 9, "box must still be usable while a reference remains")
+        box |> seq_box_release               // rc 1 -> 0, deleted here
+        t |> equal(count_jobque_leaks(), before)
+    }
+}
+
+[test]
+def test_other_holder_releases_last(t : T?) {
+    t |> run("releasing out of order leaks nothing") @(t : T?) {
+        let before = count_jobque_leaks()
+        var box = seq_box_create()
+        box |> add_ref
+        var other = box
+        box |> seq_box_release               // the creator goes FIRST — the old box would trap here
+        other |> seq_box_release             // the late holder deletes
+        t |> equal(count_jobque_leaks(), before)
+    }
+}
+
+[test]
+def test_with_seq_box_leaves_nothing(t : T?) {
+    t |> run("with_seq_box balances its own reference") @(t : T?) {
+        let before = count_jobque_leaks()
+        with_seq_box() $(box) {
+            box |> publish(Snap(tag = 1, a = 0ul, b = 0ul, n = 0))
+        }
+        t |> equal(count_jobque_leaks(), before)
+    }
+}
+
+// ---- capture: a lambda captures the box by reference count ----
+
+[test]
+def test_capture_in_job(t : T?) {
+    t |> run("a job captures the box, publishes, and releases its share explicitly") @(t : T?) {
+        let before = count_jobque_leaks()
+        with_job_que() {
+            var box = seq_box_create()
+            with_channel(1) $(ch) {
+                new_job() @() {
+                    box |> publish(Snap(tag = 21, a = 1ul, b = 2ul, n = 3))
+                    // the captured share; the lambda finalizer asserts this release happened
+                    box |> seq_box_release
+                    ch |> push_clone(IntVal(v = 1))
+                    ch |> notify_and_release
+                }
+                ch |> for_each_clone() $(val : IntVal#) {
+                    pass
+                }
+            }
+            var seen = 0
+            box |> read() $(s : Snap) {
+                seen = s.tag
+            }
+            t |> equal(seen, 21, "the snapshot published from the job must read back")
+            box |> seq_box_release
+        }
+        t |> equal(count_jobque_leaks(), before)
+    }
+}

--- a/tests/strudel_device/test_sound_status_seqbox.das
+++ b/tests/strudel_device/test_sound_status_seqbox.das
@@ -1,0 +1,102 @@
+options gen2
+options indenting = 4
+options persistent_heap
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost
+require daslib/defer
+require daslib/fio
+require daslib/jobque_boost
+require audio/audio_boost
+require jobque
+require math
+
+// Playback status over a SeqBox, on miniaudio's NULL backend so it runs headless. This directory
+// is INTERPRETER-ONLY (gated off under --use-aot in tests/.das_test) — see test_device_teardown.das.
+//
+// What this guards: the box reads sensibly the instant set_status_update returns, it tracks the
+// sound to completion, and releasing it needs no ordering with the audio thread — the property
+// that replaced the old join().
+
+def private short_tone(seconds : float) : array<float> {
+    let n = int(float(MA_SAMPLE_RATE) * seconds)
+    return <- [for (x in range(n)); sin(2.0 * PI * 440.0 * float(x) / float(MA_SAMPLE_RATE))]
+}
+
+[test]
+def test_status_seeded_on_the_calling_thread(t : T?) {
+    t |> run("the box reads `starting` before the audio thread has seen the sound") @(t : T?) {
+        sound_set_null_device(true)
+        defer() {
+            sound_set_null_device(false)
+        }
+        with_audio_system() {
+            var tone <- short_tone(0.2)
+            let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
+            var box = seq_box_create()
+            set_status_update(sid, box)
+            var state = AudioChannelState.stopped
+            let got = box |> read() $(s : AudioChannelStatus) {
+                state = s.state
+            }
+            t |> equal(got, true, "the box must not read empty right after registration")
+            t |> equal(state, AudioChannelState.starting)
+            stop(sid)
+            unset_status_update(sid)
+            box |> seq_box_release
+        }
+    }
+}
+
+[test]
+def test_status_reaches_stopped(t : T?) {
+    t |> run("a one-shot tone advances to stopped") @(t : T?) {
+        sound_set_null_device(true)
+        defer() {
+            sound_set_null_device(false)
+        }
+        with_audio_system() {
+            var tone <- short_tone(0.2)
+            let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
+            var box = seq_box_create()
+            set_status_update(sid, box)
+            var reached_stopped = false
+            for (_i in range(200)) {
+                box |> read() $(s : AudioChannelStatus) {
+                    reached_stopped = s.state == AudioChannelState.stopped
+                }
+                break if (reached_stopped)
+                sleep(20u)
+            }
+            t |> success(reached_stopped, "0.2s tone never reported stopped within a 4s window")
+            unset_status_update(sid)
+            box |> seq_box_release
+        }
+    }
+}
+
+[test]
+def test_release_needs_no_ordering(t : T?) {
+    t |> run("releasing the box while the sound still plays leaks nothing") @(t : T?) {
+        sound_set_null_device(true)
+        defer() {
+            sound_set_null_device(false)
+        }
+        let before = count_jobque_leaks()
+        with_audio_system() {
+            for (_i in range(8)) {
+                var tone <- short_tone(30.0)
+                let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
+                var box = seq_box_create()
+                set_status_update(sid, box)
+                // Drop our reference immediately, with the sound still playing and the audio
+                // thread still holding its own. Under the old LockBox this needed unset + join
+                // first, or it trapped on "being deleted while being used".
+                box |> seq_box_release
+            }
+            sleep(60u)
+        }
+        t |> equal(count_jobque_leaks(), before)
+    }
+}

--- a/tutorials/dasAudio/09_playback_status.das
+++ b/tutorials/dasAudio/09_playback_status.das
@@ -1,14 +1,15 @@
 // Tutorial AUDIO-09: Playback Status
 //
 // This tutorial covers:
-//   - Registering a status LockBox with set_status_update
+//   - Registering a status SeqBox with set_status_update
 //   - Reading the AudioChannelStatus snapshot (state, position, queue depth)
 //   - Watching a sound advance through its AudioChannelState lifecycle
-//   - Releasing the status box cleanly (unset_status_update + lock_box_remove)
+//   - Releasing the box with seq_box_release, in any order you like
 //
-// The audio thread publishes a snapshot into a LockBox once per mix; the main
-// thread reads it on demand with `box |> get()`. This is how you detect when a
-// one-shot sound has finished, or how full a streaming queue is.
+// The audio thread publishes a snapshot into a SeqBox once per mix; the main
+// thread reads it on demand with `box |> read()`. Neither side ever waits for the
+// other. This is how you detect when a one-shot sound has finished, or how full a
+// streaming queue is.
 //
 // Run: daslang.exe tutorials/dasAudio/09_playback_status.das
 
@@ -41,9 +42,9 @@ def main() {
 
         // ──────────────────────────────────────────────────────────────────
         // Register a status box. set_status_update seeds it with state
-        // `starting`; the audio thread then updates it as the sound plays.
+        // `starting`; the audio thread then publishes into it as the sound plays.
         // ──────────────────────────────────────────────────────────────────
-        var status_box <- lock_box_create()
+        var status_box = seq_box_create()
         set_status_update(sid, status_box)
 
         // Poll until the sound reports `stopped` (or we time out after ~2s),
@@ -52,7 +53,7 @@ def main() {
         var saw_read = false
         var reached_stopped = false
         for (_i in range(100)) {
-            status_box |> get() $(s : AudioChannelStatus#) {
+            status_box |> read() $(s : AudioChannelStatus) {
                 saw_read = true
                 if (s.state != last_state) {
                     print("  state: {s.state}  (position={int(s.playback_position)} frames, queue={s.stream_que_length})\n")
@@ -73,13 +74,12 @@ def main() {
         assert(reached_stopped, "sound never reached the stopped state within the poll window")
 
         // ──────────────────────────────────────────────────────────────────
-        // Release the status box. Order matters: stop the updates, clear the
-        // stored value, join, then remove — otherwise the LockBox leaks.
+        // Release the box. No ordering to get right and nothing to wait for:
+        // the audio thread also holds a reference, and whichever side drops the
+        // last one deletes it.
         // ──────────────────────────────────────────────────────────────────
         unset_status_update(sid)
-        clear_status(status_box)
-        status_box |> join()
-        unsafe(lock_box_remove(status_box))
+        status_box |> seq_box_release
 
         print("\nDone!\n")
     }


### PR DESCRIPTION
SeqBox is the lock-free sibling of LockBox — a POD snapshot one side publishes and any number of others copy, with neither side ever waiting. It sits in the jobque module next to LockBox/Channel/Stream, is tracked by the same leak detector, and is useful anywhere a realtime or otherwise non-blocking producer has to hand state to readers.

Why audio needed it. Every LockBox operation holds mCompleteMutex for the whole duration of the das block it invokes, and the mix callback ran status |> update() once per channel per buffer while game threads held the same mutex in status_box |> get(). That is a non-realtime thread able to stall the audio callback — the shape audio code must never have. A seqlock is asymmetric in the right direction: the writer bumps a version, stores the payload and bumps again, and can never be blocked by a reader; a reader that catches a write in progress retries. Copying the payload byte-wise is sound because the mixer context is a clone of the game context, so both share one Program and one layout for it.

The audio API keeps its shape — set_status_update / unset_status_update / clear_status / set_audio_stats_box all still take a box, now a SeqBox? instead of a LockBox?, and callers swap lock_box_create for seq_box_create and box |> get() for box |> read().

Lifetime is the one deliberate departure from the other primitives. SeqBox has seq_box_release rather than a create/remove pair with an rc==1 precondition: whoever drops the last reference deletes. Requiring the owner to remove it last is exactly what forced callers to block on join() first, and that join is what could hang when the audio thread was already gone. So strudel_shutdown loses the 25-line block that hand-separated single-threaded from threaded teardown to keep that join safe, and neither create nor release needs unsafe, since a box cannot be deleted while another holder still references it.

Two more things fall out of the mechanism rather than being patched:
- panic("audio: status already set for {sid}") is gone. Re-registering now swaps the box and releases the old one, so a racing caller gets a losing box instead of a dead process.
- The payload bound is a static_assert on typeinfo sizeof in publish/read, so a value too large for the box is a compile error, not a runtime condition.

Tests: tests/jobque/test_jobque_seqbox.das covers the primitive — empty reads, publish/read round-trip, that a read consumes nothing, clear, size-mismatch refusal, and that releasing in either order leaks nothing. tests/strudel_device/test_sound_status_seqbox.das covers it through audio: the box reads `starting` the instant set_status_update returns, a one-shot tone reaches `stopped`, and releasing the box while the sound still plays leaks nothing — the case the old LockBox trapped on.

Verified on macOS/arm64: tests/jobque 233, tests/audio 14, tests/strudel_device 16, tests/strudel 643, ctest -L small 80, all 11 dasAudio tutorials and live strudel playback on real hardware.