### PR TITLE
assert: a failing bare assert names its own construct

### DIFF
--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -1385,7 +1385,7 @@ namespace das {
                         message = cast<char *>::to(resM);
                     }
                 } else {
-                    message = iscf ? "static assert failed" : "concept failed";
+                    message = iscf ? "concept assert failed" : "static assert failed";
                 }
                 if ( iscf ) {
                     LineInfo atC = expr->at;

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -1451,7 +1451,7 @@ namespace das {
                         message = iscf ? "concept assert failed" : "static assert failed";
                     }
                 } else {
-                    message = iscf ? "static assert failed" : "concept failed";
+                    message = iscf ? "concept assert failed" : "static assert failed";
                 }
                 if (iscf) {
                     LineInfo atC = expr->at;

--- a/tests/typer_errors/_bare_concept_assert.das
+++ b/tests/typer_errors/_bare_concept_assert.das
@@ -1,0 +1,14 @@
+options gen2
+expect 31400
+
+// A concept_assert with no message of its own, so the compiler has to supply the default one.
+// It sits in a generic, which is the only place concept_assert is meaningful.
+
+def private takes(x : auto(TT)) {
+    concept_assert(false)
+}
+
+[export]
+def main {
+    takes(1)
+}

--- a/tests/typer_errors/_bare_static_assert.das
+++ b/tests/typer_errors/_bare_static_assert.das
@@ -1,0 +1,9 @@
+options gen2
+expect 31403
+
+// A static_assert with no message of its own, so the compiler has to supply the default one.
+
+[export]
+def main {
+    static_assert(false)
+}

--- a/tests/typer_errors/test_assert_message.das
+++ b/tests/typer_errors/test_assert_message.das
@@ -1,0 +1,40 @@
+// The default message a failing assert supplies for itself used to name the OTHER construct:
+// a bare static_assert reported "concept failed" and a bare concept_assert reported "static assert
+// failed", while both carried the right error code. Codes are pinned by `expect` elsewhere; only a
+// compile-and-read-the-text check can pin the wording, so it lives here.
+options gen2
+options no_aot     // invokes the compiler at runtime (compile_file) — not AOT-linkable
+
+require daslib/ast
+require strings
+require dastest/testing_boost public
+
+
+def compile_issues(file_path : string) : string {
+    var issuesText = ""
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            compile_file(file_path, access, unsafe(addr(mg)), cop) $(_ok, _program, issues) {
+                issuesText := issues
+            }
+        }
+    }
+    return issuesText
+}
+
+
+[test]
+def test_bare_assert_names_its_own_construct(t : T?) {
+    t |> run("a bare static_assert reports 'static assert failed'") @(t : T?) {
+        let issues = compile_issues("{get_das_root()}/tests/typer_errors/_bare_static_assert.das")
+        t |> success(find(issues, "static assert failed") >= 0, "static_assert must name itself")
+        t |> success(find(issues, "concept") < 0, "static_assert must not mention concepts at all")
+    }
+    t |> run("a bare concept_assert reports 'concept assert failed'") @(t : T?) {
+        let issues = compile_issues("{get_das_root()}/tests/typer_errors/_bare_concept_assert.das")
+        t |> success(find(issues, "concept assert failed") >= 0, "concept_assert must name itself")
+        t |> success(find(issues, "static assert failed") < 0, "concept_assert must not claim to be a static assert")
+    }
+}


### PR DESCRIPTION
A static_assert or concept_assert with no message of its own gets a default one from the compiler, and the two were swapped - each named the OTHER construct while carrying the right error code:

    static_assert(false)   ->  error[31403]: concept failed
    concept_assert(false)  ->  error[31400]: static assert failed

31403 is static_assert_failed and 31400 is concept_failed, so only the wording was wrong, which is what made it survive: nothing keyed on the text. The same expression appears twice, in infer and in the contract fold, and the empty-message branch immediately above the infer one already had the right order - so the fix is to give both the wording that branch uses.

expect pins the CODE, so it cannot catch this. The new test compiles a fixture at runtime and reads the reported text back, the way test_alias_message.das pins the alias wording; both fixtures carry an expect directive of their own, which is also what makes lint skip them.