### PR TITLE
module cache: a module abandoned mid-read must not look built-in

### DIFF
--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -874,7 +874,10 @@ namespace das {
         TextWriter * logs = nullptr;
         explicit ModuleGcFinalize ( Program * p ) : prog(p) {}
         ~ModuleGcFinalize() {
-            if ( prog ) {
+            // thisModule is legitimately null while a deserialize is in flight: Program::serialize
+            // releases it for the whole module-read loop and only restores it at the end, so an
+            // exception unwinding out of that loop reaches here with no module to collect
+            if ( prog && prog->thisModule ) {
                 auto m = prog->thisModule.get();
                 gc_root * oldRoot = m->module_gc_root.get();
                 auto fresh = make_unique<gc_root>();

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -1172,14 +1172,27 @@ namespace das {
     }
 
     AstSerializer & AstSerializer::operator << ( Module & module ) {
-        thisModule = &module;
-        module.serialize(*this, /*already_exists*/false);
-        return *this;
+        return serializeModule(module, /*already_exists*/false);
     }
 
     AstSerializer & AstSerializer::serializeModule ( Module & module, bool already_exists ) {
         thisModule = &module;
-        module.serialize(*this, already_exists);
+        if ( writing ) {
+            module.serialize(*this, already_exists);
+            return *this;
+        }
+        // reading: Module::serialize restores moduleFlags - builtIn among them - before the body
+        // is read, so a record that throws partway would leave a module flagged builtIn that was
+        // never linked into the environment's module list, where ~Module's unlink walk finds
+        // nothing and asserts. Put the flag back before the exception reaches a caller that
+        // disposes of the module; the callers that keep it re-establish builtIn via promoteToBuiltin
+        const bool wasBuiltIn = module.builtIn;
+        try {
+            module.serialize(*this, already_exists);
+        } catch ( ... ) {
+            module.builtIn = wasBuiltIn;
+            throw;
+        }
         return *this;
     }
 


### PR DESCRIPTION
Fixes the windows-Debug CI red from #3701 ([run 31576805091](https://github.com/GaijinEntertainment/daScript/actions/runs/31576805091/job/94050786390)): `tests/jit_tests/llvm_cache_selfheal.das`, `0xC0000005` in the child on **every round that reads the cache** — including round 4, where the deserialize is `clean`. Round 1 (cold, write-only) passes, so it was never about corruption handling; the plain cache-read path was crashing after the compile had already succeeded.

## Root cause

`Module::serialize` restores `moduleFlags` — `builtIn` among them — on its first line, *before* the body is read:

```cpp
ser << name << nameHash << moduleFlags;
```

A record that throws partway therefore leaves a `Module` flagged `builtIn` that was never linked into the environment's module list. `~Module` then walks that list to unlink itself, finds nothing, and trips:

```
assertion failed: 0, src\ast\ast_module.cpp:390
failed to unlink. was builtIn field assigned after the fact?
```

`DAS_ASSERTF` is Debug-only, which is exactly why every Release lane stayed green while `build (windows, 64, Debug)` went red.

Worth being precise about one thing: the flags are **not** garbage here. The record is a valid one for a module that genuinely was `builtIn`; the corruption only supplies the throw. A stomp landing on `moduleFlags` is a second way in, and it is covered by the same guard.

Three call sites already worked around this with `builtIn = false; // suppress assert`. The two `catch` handlers in `serializeProgramImpl` and the two rethrow catches in the module-read loop did not.

## Second defect on the same path

`ModuleGcFinalize::~ModuleGcFinalize` dereferenced `prog->thisModule` unguarded — but `Program::serialize` deliberately releases `thisModule` for the whole module-read loop and only restores it at the end:

```cpp
library.reset();
thisModule.release();      // null for the entire read loop
```

Any exception unwinding out of that loop — including the two catches above, which rethrow **by design** — reached the destructor with a null module and read `module_gc_root` off it. That is the observed fault address, null + `0xa18`, and it is what produced the crash exit code; the assert on its own is just an assert. Its sibling `GcCollectOnExit` already guards `prog && prog->thisModule`.

Captured stack:

```
CRASH: EXCEPTION_ACCESS_VIOLATION (0xC0000005) reading address 0xa18
  [ 1] das::ModuleGcFinalize::~ModuleGcFinalize      ast_parse.cpp:879
  [17] das::Module::~Module                          ast_module.cpp:390
  [19] AstSerializer::serializeProgramImpl catch$18  module_builtin_ast_serialize.cpp:3031
  [23] das::AstSerializer::serializeProgramImpl      module_builtin_ast_serialize.cpp:3020
  [29] das::trySerializeProgramModule                ast_parse.cpp:664
```

So the sequence is: corrupt body → throw → catch → `delete deser` → `~Module` asserts → debug break unwinds `parseDaScript` → `~ModuleGcFinalize` derefs null → AV.

## The fix

The flag is restored where it is set. `serializeModule` catches, puts `builtIn` back, and rethrows; `operator<<(Module&)` now delegates instead of duplicating the body, so **both** entry points into `Module::serialize` funnel through one guard:

```cpp
AstSerializer & AstSerializer::serializeModule ( Module & module, bool already_exists ) {
    thisModule = &module;
    if ( writing ) { module.serialize(*this, already_exists); return *this; }
    const bool wasBuiltIn = module.builtIn;
    try {
        module.serialize(*this, already_exists);
    } catch ( ... ) {
        module.builtIn = wasBuiltIn;
        throw;
    }
    return *this;
}
```

That covers the two `delete deser` handlers, the two rethrow catches, the garbage-flags case in the plain non-builtin branch, and any caller added later. The three existing `builtIn = false` lines stay — those are *success* paths, where the read completed and the flag is legitimately set.

Plus the null guard in `ModuleGcFinalize`, matching its sibling.

## Verification

Reproduced verbatim on a windows Debug build first — the child crashed before printing a single marker; it now completes `rc 0` and self-heals as designed.

| Gate | Result |
|---|---|
| `llvm_cache_selfheal` | PASS, 5.5s (was failing at 20.5s) |
| `tests/jit_tests` | 321 tests, 319 passed, 0 failed, 2 skipped |
| Full Debug sweep (`tests/`) | 13339 tests, 13330 passed, **0 failed, 0 errors**, 9 skipped |
| CODEREVIEW.md discovery (make_pr 0a) | none cover `src/ast` or `src/builtin` |
| Lint / format / dupe / AOT | N/A — C++ only, no `.das` touched |

## Not in this PR

The deeper issue stands: letting the stream apply `moduleFlags` to a live `Module` before the body is read is what makes the flag forgeable at all. This guard contains the damage rather than removing the cause. Removing it properly means never restoring linkage bits from the stream, which runs into `ModuleLibrary::reset()` freeing exactly the `!builtIn` modules, and the `catch` in `serializeProgramImpl` leaving a deleted `deser` pointer in `program->library` (harmless today only because `~ModuleLibrary` is empty). That is an ownership cleanup deserving its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
