### PR TITLE
TDD auditor: constitutional branch-test clause, shipped audit skill, per-PR auditor agent, followability dimension

### DIFF
--- a/.claude/agents/codereview-md-auditor.md
+++ b/.claude/agents/codereview-md-auditor.md
@@ -39,6 +39,11 @@ For each rule, decide one of:
 - **COMPLIANT** — the diff satisfies it, with the evidence that shows so.
 - **N/A** — nothing in the diff touches what the rule governs. Say why in a few words.
 
+One delegation: the constitutional opening clause ("New functionality ships with tests — same
+PR…") is audited branch-by-branch by the sibling `tdd-auditor` agent across the whole diff —
+mark it `N/A (owned by tdd-auditor)` rather than duplicating that work. Your checklist's own
+module-specific test rules (placement, which suite runs, platform gates) are still yours.
+
 Report VIOLATED and UNPROVEN in full. Summarize COMPLIANT and N/A by count plus a one-line list
 of rule names, so the reader can see coverage without reading a wall.
 
@@ -53,6 +58,14 @@ settle, a named API set the same change made stale, a carve-out whose descriptio
 disjoint sets. When the diff itself edits the checklist, audit the post-change text. Report
 these as **SELF-REVIEW** findings with the defective rule quoted and a concrete fix direction
 (rewrite, split, or move — never silent tolerance).
+
+Followability is part of the same dimension (`skills/codereview_md.md` carries the full
+classes): a dense multi-clause rule the reviewer must re-read; an enumeration of named cases
+standing in for the property that unites them; mechanism prose exceeding the criterion; a
+**structurally homeless rule** whose trigger is a change outside the checklist's folder (the
+step-0a walk can never surface it — it will never fire); two rules that make the reviewer
+check the same thing twice. Each of these is a SELF-REVIEW finding too — the checklist stays
+slim because every round applies this, not because someone notices.
 
 ## What counts as a real finding
 

--- a/.claude/agents/tdd-auditor.md
+++ b/.claude/agents/tdd-auditor.md
@@ -1,0 +1,49 @@
+---
+name: tdd-auditor
+description: Audits a diff against the constitutional branch-test rule — every new or changed reachable branch has a test that fails without it (procedure in skills/tdd_audit.md). Use as a dimension in any per-PR review round. Unlike the per-checklist codereview-md-auditor, ONE instance covers the whole diff, including folders no CODEREVIEW.md reaches. Runs negative controls: mutates code under test, runs the named test, restores. Note: the agent registry snapshots at session start — a freshly added or edited definition is only live in the NEXT session.
+model: opus
+tools: Bash, Read, Grep, Glob, Edit
+color: green
+---
+
+You audit ONE diff against this repo's constitutional test rule: **a new or changed reachable
+branch ships a test that fails without it; a diff that adds a branch no test distinguishes is
+a defect.** The full procedure — what counts as a branch, what "distinguishes" means, the
+negative-control ritual, the verdict vocabulary — is `skills/tdd_audit.md`. Read it first;
+this file adds only the harness rules.
+
+## Scope
+
+The prompt names the diff (a `base..head` range or a file list). Get it with `git diff` and
+enumerate branches per the skill. You own the WHOLE diff — you are not scoped to one folder
+the way the codereview-md-auditor is. Skip generated files (regenerated parsers, generated
+docs, lockfiles), prose-only changes, and branches inside test files themselves.
+
+## Negative controls — the hard rules
+
+- Mutate with Edit, run the ONE candidate test (never a whole suite per mutation), restore
+  with Edit (the exact reverse), then verify with `git diff -- <file>` that the file is back
+  to its pre-mutation state. NEVER end your run with a mutation in place — if a tool error
+  or timeout interrupts a control, restoring the tree is your first action before anything
+  else.
+- Never mutate a test file to change a verdict. The mutation goes in the code under test;
+  the test is the instrument.
+- Time-box: a negative control is one mutation plus one targeted test run. If the only
+  candidate run is heavy (a model run, a full suite, special hardware), report the branch
+  UNPROVEN with the exact settling command instead of running it.
+
+## What NOT to flag
+
+- pre-existing untested code the diff does not touch
+- branches in test files, fixtures, or generated code
+- style opinions, missing-coverage opinions beyond the rule — you audit branch distinction,
+  nothing else
+
+## Output
+
+The skill's reporting shape: per-branch `BRANCH` / `VERDICT` (`DISTINGUISHED by <test>` /
+`CONTROLLED by <test>` / `UNTESTED` / `UNPROVEN` with the settling command), then the
+summary line `N branches: X distinguished, Y controlled, Z untested, W unproven`. Report
+UNTESTED and UNPROVEN in full; summarize DISTINGUISHED and CONTROLLED by count plus a
+one-line list. Be terse — cite `file:line`, do not narrate. A clean audit that names what
+it checked is a useful result; an unexplained "looks tested" is not.

--- a/.claude/agents/tdd-auditor.md
+++ b/.claude/agents/tdd-auditor.md
@@ -17,7 +17,18 @@ this file adds only the harness rules.
 The prompt names the diff (a `base..head` range or a file list). Get it with `git diff` and
 enumerate branches per the skill. You own the WHOLE diff — you are not scoped to one folder
 the way the codereview-md-auditor is. Skip generated files (regenerated parsers, generated
-docs, lockfiles), prose-only changes, and branches inside test files themselves.
+docs, lockfiles) and prose-only changes. Test files are exempt from branch enumeration but
+are the subject of the skill's **cheat check**: every changed expectation, weakened or
+removed assertion, deleted case, or newly added skip/exclude gets a reverse control or a
+stated reason.
+
+## Reverse controls — the cheat check mechanics
+
+Run the OLD test against the NEW code: `git checkout <base> -- <testfile>`, run the one
+test, then `git checkout <head> -- <testfile>` (verify with `git status` that the file is
+back on head). Old test green → the edit was expansion/cosmetics. Old test red with no
+stated reason in the change → verdict RETUNED. The same restore discipline as negative
+controls applies: never end the run with a checked-out base file in place.
 
 ## Negative controls — the hard rules
 
@@ -42,8 +53,10 @@ docs, lockfiles), prose-only changes, and branches inside test files themselves.
 ## Output
 
 The skill's reporting shape: per-branch `BRANCH` / `VERDICT` (`DISTINGUISHED by <test>` /
-`CONTROLLED by <test>` / `UNTESTED` / `UNPROVEN` with the settling command), then the
-summary line `N branches: X distinguished, Y controlled, Z untested, W unproven`. Report
-UNTESTED and UNPROVEN in full; summarize DISTINGUISHED and CONTROLLED by count plus a
-one-line list. Be terse — cite `file:line`, do not narrate. A clean audit that names what
-it checked is a useful result; an unexplained "looks tested" is not.
+`CONTROLLED by <test>` / `UNTESTED` / `UNPROVEN` with the settling command); per caught
+test edit `TEST EDIT` / `VERDICT` (`JUSTIFIED` / `RETUNED`); then the summary lines
+`N branches: X distinguished, Y controlled, Z untested, W unproven` and
+`M test edits: J justified, K retuned`. Report UNTESTED, UNPROVEN, and RETUNED in full;
+summarize the rest by count plus a one-line list. Be terse — cite `file:line`, do not
+narrate. A clean audit that names what it checked is a useful result; an unexplained
+"looks tested" is not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,8 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/memory_leak_detection.md` | Any leak report at exit — master index of all six leak-detection mechanisms (gc_node, `--das-profiler-leaks`, `-track-allocations`, smart_ptr tracking, jobque, HandleRegistry) and which to reach for |
 | `skills/make_pr.md` | Creating a pull request (lint, test, AOT, format checklist) |
 | `skills/review_round.md` | Running the multi-agent deep review of a branch/diff (the pre-PR round, or any "review this") — grounding → change-derived risk dimensions → parallel surfacers + CODEREVIEW auditors → falsification-gate prover → report-then-fix |
-| `skills/codereview_md.md` | Creating or editing any module `CODEREVIEW.md`, or reviewing a diff to one — the opening contract (diff-checkable criteria only, no numbers, no rationale/history), the verbatim template, `<ARCH-DOC>` selection |
+| `skills/codereview_md.md` | Creating or editing any module `CODEREVIEW.md`, or reviewing a diff to one — the opening contract (diff-checkable criteria only, no numbers, no rationale/history), the verbatim template, `<ARCH-DOC>` selection, the followability finding classes |
+| `skills/tdd_audit.md` | Auditing any diff for test coverage — the constitutional branch-test rule (a new/changed reachable branch needs a test that fails without it), the negative-control procedure, pin and expectation discipline |
 | `skills/preflight.md` | Pushing a non-trivial branch or reproducing a red CI lane — maps every PR-triggered CI lane to its exact local mirror command (or an honest "not mirrorable") |
 | `skills/abi_break_sweep.md` | Changing public C++ API, AST node layout, or daslib generic signatures that external module repos compile against — both-worlds spellings, externals-merge-first ordering, daspkg-index scope |
 | `skills/wsl_ci_repro.md` | Reproducing a Linux-only CI failure (sanitizers, POSIX divergence, headless timing) in the WSL CI-mirror distro — verbatim-CI recipe and its traps |
@@ -148,8 +149,15 @@ step-0a walk): each discovered checklist is itself audited under the self-review
 just applied. The implementer is the shared **`codereview-md-auditor` agent**
 (`.claude/agents/codereview-md-auditor.md`): one instance owns exactly one checklist, so with
 several in scope the ORCHESTRATOR launches one instance per checklist in parallel and merges
-the findings into one report. (The agent registry snapshots at session start — a freshly
-pulled or edited definition is live in the NEXT session, not the current one.)
+the findings into one report. Self-review includes **followability** — the finding classes
+(dense multi-clause rules, enumerations standing in for criteria, mechanism prose,
+structurally homeless rules, overlap) are in `skills/codereview_md.md`; checklists stay slim
+because every round applies them, not because someone notices. Beside the checklist auditors
+runs the **`tdd-auditor` agent** (`.claude/agents/tdd-auditor.md`): ONE instance for the
+whole diff, auditing the constitutional branch-test clause (`skills/tdd_audit.md`) —
+including in folders no CODEREVIEW.md covers. (The agent registry snapshots at session
+start — a freshly pulled or edited definition is live in the NEXT session, not the current
+one.)
 
 **Doc improvements at stopping points.** Propose-first applies only to what's left: restructuring, removing existing guidance, **or proposing a new skill file when you see a recurring pattern that no existing skill covers**. Doc edits direct future Claude behavior, so structural diffs still get review — but factual drift must be self-healing, not queued behind it.
 

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -74,6 +74,7 @@ Task-specific instructions are in skill files under `skills/`. Read the relevant
 | `skills/xml.md` | XML via `dasPUGIXML`/`PUGIXML_boost` (RAII, builder, XPath, struct round-trip) |
 | `skills/filesystem.md` | Any `.das` path/filename/filesystem op — must use `fio` helpers, never `rfind`/`slice` |
 | `skills/writing_tests.md` | Writing tests with the bundled `dastest` framework |
+| `skills/tdd_audit.md` | Auditing any diff for test coverage — does every new/changed branch have a test that fails without it? The negative-control procedure, pin and expectation discipline, the reporting shape |
 | `skills/memory_leak_detection.md` | Diagnosing leaks (`--das-profiler-leaks`, `--track-smart-ptr`, `GC APP LEAK`, `HandleRegistry`) |
 | `skills/jobque_debugging.md` | Channel/LockBox/JobStatus/Stream/Feature leaks |
 | `skills/detect_dupe.md` | Duplicate-function detection (corpus, MCP tools `export_corpus`/`detect_duplicates`, CLI under `utils/detect-dupe/`) |

--- a/install/skills.list
+++ b/install/skills.list
@@ -55,6 +55,7 @@ sql.md
 strings.md
 strudel_port.md
 style_lint.md
+tdd_audit.md
 tune.md
 writing_tests.md
 xml.md

--- a/modules/dasImgui/CODEREVIEW.md
+++ b/modules/dasImgui/CODEREVIEW.md
@@ -13,6 +13,11 @@ entry needs code-reading or prior knowledge, it is not a review criterion — mo
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how to
@@ -32,10 +37,6 @@ rewrite or a move, never silent tolerance) lands in the same batch as the round'
 ---
 
 ## Tests
-
-**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
-reachable branch ships a test that fails without it; a diff that adds a branch no test
-distinguishes is a defect.
 
 **Tests go under `modules/dasImgui/tests`.** No tests go under `tests/dasImgui` — that folder
 must not exist.

--- a/modules/dasLLAMA/CODEREVIEW.md
+++ b/modules/dasLLAMA/CODEREVIEW.md
@@ -13,6 +13,11 @@ and leave a one-line criterion here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how to

--- a/modules/dasLLVM/CODEREVIEW.md
+++ b/modules/dasLLVM/CODEREVIEW.md
@@ -13,6 +13,11 @@ and leave a one-line criterion here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how

--- a/modules/dasMetal/CODEREVIEW.md
+++ b/modules/dasMetal/CODEREVIEW.md
@@ -13,6 +13,11 @@ and leave a one-line criterion here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how to

--- a/modules/dasSpirv/CODEREVIEW.md
+++ b/modules/dasSpirv/CODEREVIEW.md
@@ -4,6 +4,11 @@
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 1. **Any new bit of functionality ships with test coverage for EVERY new scenario it
    introduces.** The emitter's test home is `tests/spirv/`: word-level fixtures (`_golden/`
    disassembly, equivalence gates), the opcode census, and a `_fail_closed/` fixture for

--- a/site-dasllama/CODEREVIEW.md
+++ b/site-dasllama/CODEREVIEW.md
@@ -13,6 +13,11 @@ and leave a one-line criterion here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how

--- a/site/CODEREVIEW.md
+++ b/site/CODEREVIEW.md
@@ -13,6 +13,11 @@ and leave a one-line criterion here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how

--- a/skills/codereview_md.md
+++ b/skills/codereview_md.md
@@ -7,9 +7,11 @@ master rebase — placing the file IS the registration).
 
 ## The contract
 
-The opening of every CODEREVIEW.md is this paragraph pair, verbatim except for the module
-name and the module's architecture document. It is not boilerplate — it is the mechanism that
-keeps the file short, and each file's own rules bind changes to that file too.
+The opening of every CODEREVIEW.md is this block, verbatim except for the module name and
+the module's architecture document. It is not boilerplate — it is the mechanism that keeps
+the file short, and each file's own rules bind changes to that file too. Two of its
+paragraphs are constitutional rules duplicated by design into every checklist: the
+self-review rule, and the branch-test rule (whose audit procedure is `skills/tdd_audit.md`).
 
 ```markdown
 # <Module> Code Review Checklist
@@ -26,6 +28,11 @@ and leave a one-line criterion here.
 **This file reviews itself: a rule a reviewer cannot apply as written is a defect of this
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
+
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
 
 **Form, and it is a hard limit:**
 
@@ -67,14 +74,44 @@ section for the reason.
 - A per-file placement list ("one file, one rule") is the strongest section a big module can
   carry: each line names a file and what it holds, and any code written elsewhere is a
   defect. Keep each line to the file's own contents.
+- A module's `## Tests` section adds specifics the constitutional branch-test clause can't
+  carry — where tests live, which suite runs for which change, platform gates. It may
+  sharpen the clause (a function-granular form, a bug-fix-regression form); it never
+  weakens it, and it never restates it.
 - The rule for rule-changes is the same as everywhere else in this repo: replace stale text
   outright, no dated entries, no "as of" markers.
+
+## Followability — the slimming dimension
+
+A checklist is applied under time pressure by someone holding a diff. Every audit round
+judges the file against that reader — not only each rule in isolation (the self-review
+rule), but whether the file as a whole can still be applied in one pass. These are the
+finding classes; each is reported like any other finding, and its fix lands in the same
+batch:
+
+- **Dense multi-clause rule** — one paragraph carrying several independent checks, so the
+  reviewer must re-read it to know what to verify. Split it: one rule, one check.
+- **Enumeration standing in for a criterion** — a list of named cases or carve-outs where
+  one property unites them. State the property; names go stale, the property doesn't.
+- **Mechanism prose exceeding the rule** — more words on how the code works than on what to
+  check. The mechanism moves to `<ARCH-DOC>`; the rule keeps its one sentence of WHY.
+- **Structurally homeless rule** — a rule whose trigger is a change *outside* this folder.
+  Step 0a discovers a checklist only through changed files under its own directory, so a
+  diff elsewhere can never surface the rule — it will never fire. Move it to a checklist
+  the trigger's folder walk reaches, or to the skill/CLAUDE.md that governs that code.
+- **Overlapping rules** — two entries whose criteria make the reviewer check the same thing
+  twice. Merge into the sharper one.
+
+Size is a symptom, not a criterion: a file where every rule survives these classes is as
+long as its module needs. But "a reviewer reports they can no longer follow the file" is
+itself a finding, and its fix is applying the classes above — never a table of contents.
 
 ## Reviewing a CODEREVIEW.md diff
 
 Check the change against the file's own header: is every new entry diff-checkable in
 isolation? one paragraph? unnumbered? example-free? at most one sentence of WHY, and only
 where it makes the criterion decidable? Does a moved rationale actually land in the
-architecture doc, or did it just get deleted? And apply the self-review paragraph literally —
-an entry a reviewer cannot apply as written is itself a finding. The canonical conforming
-file is `modules/dasLLAMA/CODEREVIEW.md`.
+architecture doc, or did it just get deleted? Then apply the self-review paragraph literally
+— an entry a reviewer cannot apply as written is itself a finding — and run the
+followability classes above over the touched sections. The canonical conforming file is
+`modules/dasLLAMA/CODEREVIEW.md`.

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -45,6 +45,14 @@ under the self-review rule) and merge the reports. Registry caveat: agent defini
 snapshot at session start, so a just-pulled or just-edited definition only exists in the
 next session.
 
+Alongside the checklist auditors, launch the **`tdd-auditor` agent**
+(`.claude/agents/tdd-auditor.md`) — ONE instance for the whole diff, CODEREVIEW.md folders
+or not. It audits the constitutional test rule (a new or changed reachable branch has a
+test that fails without it — procedure in `skills/tdd_audit.md`) and runs negative
+controls where reading can't settle a branch. Fix policy: an UNTESTED branch gets its test
+written in the same change, never a follow-up promise; an UNPROVEN one gets its named
+settling run executed, or the claim stated explicitly in the PR description.
+
 When the change warrants a full review round (non-trivial arcs), the round itself —
 grounding, change-derived risk dimensions, parallel surfacers, the falsification-gate
 prover — is `skills/review_round.md`; the auditor instances above run as part of its
@@ -425,6 +433,8 @@ created it.
 | Step | Tool/Command | Fix policy |
 |---|---|---|
 | Sync | `git fetch origin master && git rebase origin/master` | Always run first; verify diff vs origin/master is clean |
+| CODEREVIEW audit | step-0a walk → one `codereview-md-auditor` per discovered checklist | Binding rules; checklist defects fixed in the same batch |
+| TDD audit | one `tdd-auditor` on the whole diff (`skills/tdd_audit.md`) | UNTESTED branch → write the test in the same change; UNPROVEN → run the named gate or state the claim in the PR |
 | Lint | `utils/lint/main.das --quiet` on `git diff --name-only origin/master..HEAD -- '*.das'` | **Zero warnings.** Fix or `// nolint:CODE` every one — CI exits 2 on any warning |
 | AST verify | `<daslang> --ast-verify -compile-only <changed .das>` when the diff touches macros or `src/ast` | **Zero** `AST verify` lines. A report is a bug in the node's builder — see `skills/das_macros.md` |
 | Workaround audit | `git diff origin/master..HEAD` — read every changed file | Smell (redundant step / synthetic≠real / special-case / copied-hack) → surface fix-vs-workaround and **ask**; never ship a buried workaround |

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -48,10 +48,12 @@ next session.
 Alongside the checklist auditors, launch the **`tdd-auditor` agent**
 (`.claude/agents/tdd-auditor.md`) — ONE instance for the whole diff, CODEREVIEW.md folders
 or not. It audits the constitutional test rule (a new or changed reachable branch has a
-test that fails without it — procedure in `skills/tdd_audit.md`) and runs negative
-controls where reading can't settle a branch. Fix policy: an UNTESTED branch gets its test
-written in the same change, never a follow-up promise; an UNPROVEN one gets its named
-settling run executed, or the claim stated explicitly in the PR description.
+test that fails without it — procedure in `skills/tdd_audit.md`), runs negative
+controls where reading can't settle a branch, and runs the cheat check over the diff's own
+test edits. Fix policy: an UNTESTED branch gets its test written in the same change, never
+a follow-up promise; an UNPROVEN one gets its named settling run executed, or the claim
+stated explicitly in the PR description; a RETUNED test edit (re-tuned to pass, no stated
+reason) gets the old expectation restored or the reason stated — never shipped silent.
 
 When the change warrants a full review round (non-trivial arcs), the round itself —
 grounding, change-derived risk dimensions, parallel surfacers, the falsification-gate
@@ -434,7 +436,7 @@ created it.
 |---|---|---|
 | Sync | `git fetch origin master && git rebase origin/master` | Always run first; verify diff vs origin/master is clean |
 | CODEREVIEW audit | step-0a walk → one `codereview-md-auditor` per discovered checklist | Binding rules; checklist defects fixed in the same batch |
-| TDD audit | one `tdd-auditor` on the whole diff (`skills/tdd_audit.md`) | UNTESTED branch → write the test in the same change; UNPROVEN → run the named gate or state the claim in the PR |
+| TDD audit | one `tdd-auditor` on the whole diff (`skills/tdd_audit.md`) | UNTESTED branch → write the test in the same change; UNPROVEN → run the named gate or state the claim in the PR; RETUNED test edit → restore the expectation or state the reason |
 | Lint | `utils/lint/main.das --quiet` on `git diff --name-only origin/master..HEAD -- '*.das'` | **Zero warnings.** Fix or `// nolint:CODE` every one — CI exits 2 on any warning |
 | AST verify | `<daslang> --ast-verify -compile-only <changed .das>` when the diff touches macros or `src/ast` | **Zero** `AST verify` lines. A report is a bug in the node's builder — see `skills/das_macros.md` |
 | Workaround audit | `git diff origin/master..HEAD` — read every changed file | Smell (redundant step / synthetic≠real / special-case / copied-hack) → surface fix-vs-workaround and **ask**; never ship a buried workaround |

--- a/skills/tdd_audit.md
+++ b/skills/tdd_audit.md
@@ -48,6 +48,24 @@ The negative control is cheap — one mutation, one targeted test run — and it
 evidence that settles the question. "The test obviously covers it" is a prediction; the
 control is a measurement.
 
+## The cheat check — audit the diff's own test edits
+
+A diff can pass the branch audit and still cheat by adjusting the instrument. Enumerate
+every test the diff touches in one of these shapes:
+
+- an expected value changed
+- an assertion weakened — `==` to a range, exact to tolerance, a tolerance widened, an
+  assert removed
+- a test or case deleted
+- a skip, exclude, or platform gate added to a test that ran before
+- a test rewritten wholesale in the same change that rewrites the code it tests
+
+For each, run the **reverse control**: the OLD test against the NEW code. Old test passes →
+the edit was expansion or cosmetics; move on. Old test FAILS → the diff changed behavior
+AND re-tuned the test to match. That is legitimate only as a conscious flip — the change
+states why the new behavior is the right one. No stated reason means the test now pins
+whatever the code happens to do, including the bug; report it.
+
 ## Rules for the tests themselves
 
 - **A new test is shown to fail first.** Run it against the pre-change code (stash the
@@ -55,7 +73,8 @@ control is a measurement.
   green may be testing nothing.
 - **An expectation change is a conscious flip.** When a diff edits an expected value, the
   change states why the new value is the right one. Weakening an expectation until the
-  implementation passes is a defect — the test now pins the bug.
+  implementation passes is a defect — the test now pins the bug. The cheat check above is
+  how an auditor settles it.
 - **Pins assert probed behavior.** A pin test (one that freezes current behavior) records
   what the code DOES: probe first, then write the assert from the probe's output. A pin
   written from what the author hopes is documentation, not a test.
@@ -73,9 +92,14 @@ Per branch: `BRANCH` (file:line, one-line description) and `VERDICT` —
   would settle it;
 - `UNTESTED` — the mutations tried and the tests that stayed green.
 
-Then the summary line: `N branches: X distinguished, Y controlled, Z untested, W unproven`.
-An all-green audit that names its branches and tests is a real result; "tests pass" is not
-an audit.
+Per test edit the cheat check caught: `TEST EDIT` (file:case, what changed) and `VERDICT` —
+`JUSTIFIED` (the stated reason, or the reverse control passed) or `RETUNED` (the old test
+fails against the new code and the change states no reason — the test was re-tuned to
+pass).
+
+Then the summary lines: `N branches: X distinguished, Y controlled, Z untested, W unproven`
+and `M test edits: J justified, K retuned`. An all-green audit that names its branches and
+tests is a real result; "tests pass" is not an audit.
 
 ## Where this runs in the daslang repo (repo-only)
 

--- a/skills/tdd_audit.md
+++ b/skills/tdd_audit.md
@@ -1,0 +1,88 @@
+# TDD audit — every branch has a test that fails without it
+
+Read this before auditing any diff for test coverage, before claiming a change is
+adequately tested, and before writing tests for code that already exists. The procedure is
+language-agnostic; test-writing mechanics for daslang live in `skills/writing_tests.md`.
+
+## The rule
+
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect.
+
+"Distinguishes" is the load-bearing word. A test that *executes* a branch but would still
+pass with the branch broken proves nothing — coverage tools measure execution, not
+distinction. The question is never "is this line covered?" but "which test FAILS if this
+line is wrong?"
+
+## What counts as a branch
+
+Enumerate from the diff, not from the whole file:
+
+- every new `if` / `elif` / `else` arm, `match` arm, loop guard, early return
+- every new error path: a panic, a returned error, a fail-closed rejection
+- every changed condition — the old and new predicates differ on some input, and THAT
+  input is the test
+- a new function (its call is the arm; a function nothing distinguishes is untested
+  whatever runs through it)
+- a new default: a parameter default, a config fallback, an empty-input path
+
+Reachable means a public entry point can drive it. An unreachable branch is a different
+finding (dead code), not a missing test.
+
+## The audit procedure
+
+For each branch, in order of preference:
+
+1. **Name the distinguishing test** — a test in the diff, or an existing test, that fails
+   when this branch is broken. Name it specifically: file and case, not "the suite".
+2. **When reading can't settle it, run the negative control**: break the branch (invert
+   the condition, comment the body, return the wrong arm), run the one candidate test,
+   watch it FAIL, restore the code exactly, and verify the tree is back to its
+   pre-mutation state. A test that stays green under the mutation distinguishes nothing —
+   the branch is untested no matter what coverage says.
+3. **Nothing fails under mutation → the branch is untested.** The fix is a test, written
+   in the same change — not a follow-up promise.
+
+The negative control is cheap — one mutation, one targeted test run — and it is the only
+evidence that settles the question. "The test obviously covers it" is a prediction; the
+control is a measurement.
+
+## Rules for the tests themselves
+
+- **A new test is shown to fail first.** Run it against the pre-change code (stash the
+  change, or check out the base) and watch it fail for the stated reason. A test born
+  green may be testing nothing.
+- **An expectation change is a conscious flip.** When a diff edits an expected value, the
+  change states why the new value is the right one. Weakening an expectation until the
+  implementation passes is a defect — the test now pins the bug.
+- **Pins assert probed behavior.** A pin test (one that freezes current behavior) records
+  what the code DOES: probe first, then write the assert from the probe's output. A pin
+  written from what the author hopes is documentation, not a test.
+- **Never mutate a test to change a verdict.** The mutation goes in the code under test;
+  the test is the instrument.
+
+## Reporting
+
+Per branch: `BRANCH` (file:line, one-line description) and `VERDICT` —
+
+- `DISTINGUISHED by <test>` — named from reading, with the one-line reasoning;
+- `CONTROLLED by <test>` — negative control run: the mutation, the test, the observed
+  failure;
+- `UNPROVEN` — the settling run is too heavy to run here; give the exact command that
+  would settle it;
+- `UNTESTED` — the mutations tried and the tests that stayed green.
+
+Then the summary line: `N branches: X distinguished, Y controlled, Z untested, W unproven`.
+An all-green audit that names its branches and tests is a real result; "tests pass" is not
+an audit.
+
+## Where this runs in the daslang repo (repo-only)
+
+- The rule is constitutional: every `CODEREVIEW.md` carries it verbatim in its opening
+  (template: `skills/codereview_md.md`).
+- The per-PR audit is the `tdd-auditor` agent (`.claude/agents/tdd-auditor.md`), launched
+  in `skills/make_pr.md` step 0a beside the CODEREVIEW.md auditors — one instance for the
+  whole diff, so folders with no checklist (`daslib/`, `src/`, `utils/`) are covered too.
+- Repo test placement (AOT registration, the `tests/.das_test` gate) is
+  `skills/tests_in_repo.md`.

--- a/tree-sitter-daslang/CODEREVIEW.md
+++ b/tree-sitter-daslang/CODEREVIEW.md
@@ -14,6 +14,11 @@ and leave a one-line criterion here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how

--- a/utils/dasllama-ladder/CODEREVIEW.md
+++ b/utils/dasllama-ladder/CODEREVIEW.md
@@ -13,6 +13,11 @@ here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how to

--- a/utils/daspkg/CODEREVIEW.md
+++ b/utils/daspkg/CODEREVIEW.md
@@ -6,6 +6,11 @@ Run this list on every daspkg change before it ships. Every entry is checkable a
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 ## Tests
 
 **Run the unit suite on every change:**

--- a/utils/dasweb-buildd/CODEREVIEW.md
+++ b/utils/dasweb-buildd/CODEREVIEW.md
@@ -12,6 +12,11 @@ here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how to

--- a/utils/dasweb-playground/CODEREVIEW.md
+++ b/utils/dasweb-playground/CODEREVIEW.md
@@ -13,6 +13,11 @@ here.
 file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
 rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 **Form, and it is a hard limit:**
 
 - **One rule is one short paragraph.** An entry that needs more than that is describing how to

--- a/utils/dasweb-verify/CODEREVIEW.md
+++ b/utils/dasweb-verify/CODEREVIEW.md
@@ -4,6 +4,11 @@ Run this list on every dasweb-verify change before it ships — including change
 Entries must be checkable against a diff alone; anything needing prior knowledge or another
 document belongs in `README.md` with a one-line criterion here.
 
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
 ## Tests
 
 **Every core behavior has a dastest test in this directory.** Exempt: `main.das` argv/exit


### PR DESCRIPTION
Docs/process only — no code changes, no CI-gated paths.

## What this is

The branch-distinguishing-test rule becomes constitutional, with the machinery to enforce it every PR:

**The rule** — *New functionality ships with tests — same PR, no follow-up promises. A new or changed reachable branch ships a test that fails without it; a diff that adds a branch no test distinguishes is a defect.*

- **Template clause** (`skills/codereview_md.md`): the rule joins the verbatim CODEREVIEW.md opening, same constitutional status as the self-review rule. All **13** existing checklists updated in one pass (dasImgui's copy moved from its Tests section into the opening; module-specific test rules — placement, suites, bug-fix-regression forms — stay as sharpeners).
- **Shipped skill** (`skills/tdd_audit.md`, SDK-shipped): the audit procedure — branch enumeration from the diff, "distinguishes vs executes", the **negative control** (break the branch, watch the named test fail, restore), the **cheat check** with its **reverse control** (run the OLD test against the NEW code; red with no stated reason = the test was re-tuned to pass, verdict RETUNED), new-tests-fail-first, conscious expectation flips, pins-from-probes, and the reporting shape.
- **Auditor agent** (`.claude/agents/tdd-auditor.md`, opus): thin harness over the skill — ONE instance per diff, covering folders no CODEREVIEW.md reaches; Edit-capable for negative/reverse controls with hard restore discipline.
- **Wiring**: `skills/make_pr.md` step 0a launches it beside the CODEREVIEW.md auditors, with fix policy per verdict (UNTESTED → write the test same change; UNPROVEN → run the named gate or state the claim; RETUNED → restore the expectation or state the reason).
- **Followability** becomes an explicit self-review dimension (`skills/codereview_md.md` + the codereview-md-auditor): dense multi-clause rules, enumerations standing in for criteria, mechanism prose exceeding the rule, structurally homeless rules the step-0a walk can never surface, overlapping rules. Checklists stay slim because every round applies the classes — not because someone notices.

Follow-up (separate PR, after these rules settle): the all-checklist cleanup sweep applying the followability classes; known targets include dasSpirv (numbered entries, no opening contract) and the abbreviated openings in daspkg / dasweb-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)