### PR TITLE
TDD audit: WEAKENED verdict — instrument reduction needs a reason even when the old test stays green

### DIFF
--- a/.claude/agents/tdd-auditor.md
+++ b/.claude/agents/tdd-auditor.md
@@ -26,9 +26,12 @@ stated reason.
 
 Run the OLD test against the NEW code: `git checkout <base> -- <testfile>`, run the one
 test, then `git checkout <head> -- <testfile>` (verify with `git status` that the file is
-back on head). Old test green → the edit was expansion/cosmetics. Old test red with no
-stated reason in the change → verdict RETUNED. The same restore discipline as negative
-controls applies: never end the run with a checked-out base file in place.
+back on head). Old test red with no stated reason in the change → verdict RETUNED. Old
+test green but the edit reduced the instrument (weakened assertion, deleted case, added
+skip) with no stated reason → verdict WEAKENED — the reduction hid nothing, but it is
+coverage loss nothing in the diff required. Old test green and the edit only adds or
+rewords → justified. The same restore discipline as negative controls applies: never end
+the run with a checked-out base file in place.
 
 ## Negative controls — the hard rules
 
@@ -50,13 +53,17 @@ controls applies: never end the run with a checked-out base file in place.
 - style opinions, missing-coverage opinions beyond the rule — you audit branch distinction,
   nothing else
 
+One evidence rule: before claiming a symbol has "no caller" or "no test", sweep the WHOLE
+tree — `modules/`, `utils/`, `tutorials/` included. A scoped grep that missed a caller
+ships a false claim in an otherwise correct report.
+
 ## Output
 
 The skill's reporting shape: per-branch `BRANCH` / `VERDICT` (`DISTINGUISHED by <test>` /
 `CONTROLLED by <test>` / `UNTESTED` / `UNPROVEN` with the settling command); per caught
-test edit `TEST EDIT` / `VERDICT` (`JUSTIFIED` / `RETUNED`); then the summary lines
-`N branches: X distinguished, Y controlled, Z untested, W unproven` and
-`M test edits: J justified, K retuned`. Report UNTESTED, UNPROVEN, and RETUNED in full;
-summarize the rest by count plus a one-line list. Be terse — cite `file:line`, do not
-narrate. A clean audit that names what it checked is a useful result; an unexplained
-"looks tested" is not.
+test edit `TEST EDIT` / `VERDICT` (`JUSTIFIED` / `RETUNED` / `WEAKENED`); then the summary
+lines `N branches: X distinguished, Y controlled, Z untested, W unproven` and
+`M test edits: J justified, K retuned, L weakened`. Report UNTESTED, UNPROVEN, RETUNED,
+and WEAKENED in full; summarize the rest by count plus a one-line list. Be terse — cite
+`file:line`, do not narrate. A clean audit that names what it checked is a useful result;
+an unexplained "looks tested" is not.

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -53,7 +53,9 @@ controls where reading can't settle a branch, and runs the cheat check over the 
 test edits. Fix policy: an UNTESTED branch gets its test written in the same change, never
 a follow-up promise; an UNPROVEN one gets its named settling run executed, or the claim
 stated explicitly in the PR description; a RETUNED test edit (re-tuned to pass, no stated
-reason) gets the old expectation restored or the reason stated — never shipped silent.
+reason) gets the old expectation restored or the reason stated; a WEAKENED one (assertion
+weakened, case deleted, skip added — coverage loss the diff didn't require) gets the
+instrument restored or the reason stated — never shipped silent.
 
 When the change warrants a full review round (non-trivial arcs), the round itself —
 grounding, change-derived risk dimensions, parallel surfacers, the falsification-gate
@@ -436,7 +438,7 @@ created it.
 |---|---|---|
 | Sync | `git fetch origin master && git rebase origin/master` | Always run first; verify diff vs origin/master is clean |
 | CODEREVIEW audit | step-0a walk → one `codereview-md-auditor` per discovered checklist | Binding rules; checklist defects fixed in the same batch |
-| TDD audit | one `tdd-auditor` on the whole diff (`skills/tdd_audit.md`) | UNTESTED branch → write the test in the same change; UNPROVEN → run the named gate or state the claim in the PR; RETUNED test edit → restore the expectation or state the reason |
+| TDD audit | one `tdd-auditor` on the whole diff (`skills/tdd_audit.md`) | UNTESTED branch → write the test in the same change; UNPROVEN → run the named gate or state the claim in the PR; RETUNED/WEAKENED test edit → restore the expectation/instrument or state the reason |
 | Lint | `utils/lint/main.das --quiet` on `git diff --name-only origin/master..HEAD -- '*.das'` | **Zero warnings.** Fix or `// nolint:CODE` every one — CI exits 2 on any warning |
 | AST verify | `<daslang> --ast-verify -compile-only <changed .das>` when the diff touches macros or `src/ast` | **Zero** `AST verify` lines. A report is a bug in the node's builder — see `skills/das_macros.md` |
 | Workaround audit | `git diff origin/master..HEAD` — read every changed file | Smell (redundant step / synthetic≠real / special-case / copied-hack) → surface fix-vs-workaround and **ask**; never ship a buried workaround |

--- a/skills/tdd_audit.md
+++ b/skills/tdd_audit.md
@@ -60,11 +60,18 @@ every test the diff touches in one of these shapes:
 - a skip, exclude, or platform gate added to a test that ran before
 - a test rewritten wholesale in the same change that rewrites the code it tests
 
-For each, run the **reverse control**: the OLD test against the NEW code. Old test passes →
-the edit was expansion or cosmetics; move on. Old test FAILS → the diff changed behavior
-AND re-tuned the test to match. That is legitimate only as a conscious flip — the change
-states why the new behavior is the right one. No stated reason means the test now pins
-whatever the code happens to do, including the bug; report it.
+For each, run the **reverse control**: the OLD test against the NEW code.
+
+- Old test FAILS → the diff changed behavior AND re-tuned the test to match. Legitimate
+  only as a conscious flip — the change states why the new behavior is the right one. No
+  stated reason means the test now pins whatever the code happens to do, including the
+  bug: verdict RETUNED.
+- Old test passes and the edit only ADDS to the instrument (new cases, tighter asserts) —
+  expansion; move on.
+- Old test passes but the edit REDUCES the instrument — a weakened assertion, a deleted
+  case, an added skip — then the reduction hid nothing, but it is coverage loss all the
+  same, and nothing in the diff required it. It needs a stated reason too: verdict
+  WEAKENED.
 
 ## Rules for the tests themselves
 
@@ -93,13 +100,14 @@ Per branch: `BRANCH` (file:line, one-line description) and `VERDICT` —
 - `UNTESTED` — the mutations tried and the tests that stayed green.
 
 Per test edit the cheat check caught: `TEST EDIT` (file:case, what changed) and `VERDICT` —
-`JUSTIFIED` (the stated reason, or the reverse control passed) or `RETUNED` (the old test
-fails against the new code and the change states no reason — the test was re-tuned to
-pass).
+`JUSTIFIED` (the stated reason, or the reverse control passed and the edit only adds),
+`RETUNED` (the old test fails against the new code and the change states no reason — the
+test was re-tuned to pass), or `WEAKENED` (the old test still passes but the edit reduced
+the instrument with no stated reason).
 
 Then the summary lines: `N branches: X distinguished, Y controlled, Z untested, W unproven`
-and `M test edits: J justified, K retuned`. An all-green audit that names its branches and
-tests is a real result; "tests pass" is not an audit.
+and `M test edits: J justified, K retuned, L weakened`. An all-green audit that names its
+branches and tests is a real result; "tests pass" is not an audit.
 
 ## Where this runs in the daslang repo (repo-only)
 


### PR DESCRIPTION
Docs/process only. Follow-up to #3711, produced by testing the setup against a honeypot diff.

The honeypot planted six cheat shapes; the audit caught all six and cleared both camouflage features — but two baits passed only on the auditor's own judgment, not the spec: a gratuitously weakened assertion (`equal(..., 12)` → `success(... > 0)`) and a gratuitously deleted test case both slid through the reverse control's old-test-green path, which read "expansion or cosmetics; move on".

The fix is a three-outcome rule for the cheat check:

- old test **red**, no stated reason → **RETUNED** (the test was re-tuned to hide a behavior change)
- old test green, edit only **adds** to the instrument → justified
- old test green, edit **reduces** the instrument (weakened assertion, deleted case, added skip) → **WEAKENED** — the reduction hid nothing, but it is coverage loss nothing in the diff required; it needs a stated reason like any other reduction

Applied to `skills/tdd_audit.md`, the `tdd-auditor` agent (verdicts, reporting, make_pr fix policy: restore the instrument or state the reason). Also from the same run: the agent now must sweep the whole tree (`modules/` included) before claiming a symbol has no caller — the run's one factual miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)