### PR TITLE
playground: compile the runtime wasm once per page + inline rename seams stay GLSL-legal

### DIFF
--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -559,7 +559,9 @@ class GlslExport : AstVisitor {
             funname = "{funname}_in_{fun._module.name}"
         }
         while (stnames |> key_exists(funname)) {
-            funname = "_{funname}" // nolint:PERF004 rarely iterates more than once
+            // never prepend `_` onto a `_`-spelled name: GLSL ES reserves any
+            // identifier containing `__` and WebGL enforces it
+            funname = (funname |> starts_with("_")) ? "u{funname}" : "_{funname}" // nolint:PERF004 rarely iterates more than once
         }
         return funname
     }

--- a/modules/dasGlsl/glsl/glsl_internal.das
+++ b/modules/dasGlsl/glsl/glsl_internal.das
@@ -561,7 +561,7 @@ class GlslExport : AstVisitor {
         while (stnames |> key_exists(funname)) {
             // never prepend `_` onto a `_`-spelled name: GLSL ES reserves any
             // identifier containing `__` and WebGL enforces it
-            funname = (funname |> starts_with("_")) ? "u{funname}" : "_{funname}" // nolint:PERF004 rarely iterates more than once
+            funname = (funname |> starts_with("_")) ? "u{funname}" : "_{funname}"
         }
         return funname
     }

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -10,9 +10,9 @@ files/news.json
 files/news-meta.json
 files/blog.json
 
-# Playground: vendored from web/ui/src/ for local-dev preview only.
+# Playground: vendored from web/examples/ui/src/ for local-dev preview only.
 # CI rebuilds these from source on every publish. To preview locally:
-#   cp web/ui/src/* site/playground/
+#   cp web/examples/ui/src/* site/playground/
 #   cp web/output/daslang_static.{js,wasm} site/playground/
 playground/jquery-3.6.0.min.js
 playground/main.css

--- a/site/CODEREVIEW.md
+++ b/site/CODEREVIEW.md
@@ -23,7 +23,7 @@ distinguishes is a defect. The audit procedure — including the negative contro
 - **One rule is one short paragraph.** An entry that needs more than that is describing how
   to write code, not how to review it. Split it or move it.
 - **No numbers.** These are criteria, not a spec, and numbering invites citation. Anything
-  that needs a stable reference lives in `README.md`, cited by section heading.
+  that needs a stable reference lives in `README.md`.
 - **Cite files by name; cite `README.md` by section.** Never cite an entry in this file.
 - **Name the API a rule is about; never name an example of it.** A rule governing specific
   functions or files must name them or it cannot be checked — that name is the criterion. An
@@ -42,15 +42,17 @@ does not exist yet, the page does not show the command.
 **Every code sample shown on a page compiles and runs with the current toolchain.** daslang
 samples are gen2 and compile with the current binary; no pseudo-code presented as code.
 
-**A spec under `site/tests/playground/` that needs the daslang runtime carries `@wasm` in its
-test title.** The per-PR lane stages the site without WASM artifacts and runs the suite with
-`--grep-invert '@wasm'` (`playground-e2e.yml`), so an untagged runtime-dependent spec fails
+**A test under `site/tests/playground/` that needs the daslang runtime carries `@wasm` in its
+title.** The per-PR lane stages the site without WASM artifacts and runs the suite with
+`--grep-invert '@wasm'` (`playground-e2e.yml`), so an untagged runtime-dependent test fails
 every PR.
 
-**A change under `site/playground/` ships with a stated run of the WASM-staged Playwright
-suite** (`site/tests/playground/` with the runtime artifacts present), naming the pass count
-in the PR body or commit message. The no-WASM lane cannot see a broken runtime path, and
-every sample on the page runs through it.
+**A change under `site/playground/` or `web/examples/ui/` ships with a stated run of the
+WASM-staged Playwright suite** (`site/tests/playground/`), naming the result — passes and any
+failures — in the PR body or commit message, and naming which runtime artifacts the run used
+(built from this change when the change touches the runtime, the deployed ones otherwise).
+The no-WASM lane cannot see a broken runtime path, and every sample on the page runs through
+that path.
 
 **Every number shown is either rendered from live data or copied from a checked-in
 measurement record; anything else is a placeholder and carries an HTML comment naming it as

--- a/site/CODEREVIEW.md
+++ b/site/CODEREVIEW.md
@@ -23,7 +23,7 @@ distinguishes is a defect. The audit procedure — including the negative contro
 - **One rule is one short paragraph.** An entry that needs more than that is describing how
   to write code, not how to review it. Split it or move it.
 - **No numbers.** These are criteria, not a spec, and numbering invites citation. Anything
-  that needs a stable reference lives in `README.md`, which is numbered for that purpose.
+  that needs a stable reference lives in `README.md`, cited by section heading.
 - **Cite files by name; cite `README.md` by section.** Never cite an entry in this file.
 - **Name the API a rule is about; never name an example of it.** A rule governing specific
   functions or files must name them or it cannot be checked — that name is the criterion. An
@@ -42,13 +42,23 @@ does not exist yet, the page does not show the command.
 **Every code sample shown on a page compiles and runs with the current toolchain.** daslang
 samples are gen2 and compile with the current binary; no pseudo-code presented as code.
 
+**A spec under `site/tests/playground/` that needs the daslang runtime carries `@wasm` in its
+test title.** The per-PR lane stages the site without WASM artifacts and runs the suite with
+`--grep-invert '@wasm'` (`playground-e2e.yml`), so an untagged runtime-dependent spec fails
+every PR.
+
+**A change under `site/playground/` ships with a stated run of the WASM-staged Playwright
+suite** (`site/tests/playground/` with the runtime artifacts present), naming the pass count
+in the PR body or commit message. The no-WASM lane cannot see a broken runtime path, and
+every sample on the page runs through it.
+
 **Every number shown is either rendered from live data or copied from a checked-in
 measurement record; anything else is a placeholder and carries an HTML comment naming it as
 one.** A placeholder that could be mistaken for a fact is a defect.
 
 **The `dl-*` measurement-table language's source of truth is `files/dasllama-table.css`**
-(the file dasllama.io loads). This page does not link it — it carries an inline mirror — so a
-`dl-*` change updates the source AND this page's inline copy together; changing only one is a defect.
+(the file dasllama.io loads). `dasllama.html` does not link it — it carries an inline mirror — so a
+`dl-*` change updates the source AND `dasllama.html`'s inline copy together; changing only one is a defect.
 
 **News entries state real, shipped events.** An entry in `_news/*.md` for something not yet
 true at publish time is a defect.

--- a/site/README.md
+++ b/site/README.md
@@ -63,7 +63,7 @@ generated and gitignored — see [`site/.gitignore`](.gitignore).
 | Surface | Desktop | Mobile (<768 px) |
 |---|---|---|
 | **Landing hero** | CodeMirror editor with sample picker, ▶ run, ↗ playground handoff | Static `<pre><code class="language-daslang">` block, no CM init. Hero buttons + sample tabs hidden via CSS. |
-| **/playground/** | Full multi-file IDE — tabs, splitter, share via `#z=` hash, ▶ run via WASM | "Open this on a laptop" notice. `pageInit` is overridden before WASM fetch — `daslang_static.{js,wasm}` is never requested. |
+| **/playground/** | Full multi-file IDE — tabs, splitter, share via `#z=` hash, ▶ run via WASM | "Open this on a laptop" notice (CSS overlay); the IDE and the runtime still initialize underneath it. |
 | **/blog/<slug>** | Full post + Disqus comments at the bottom (shortname `https-borisbat-github-io-dascf-blog`, identifier = slug, Auto theme picks dark via `:root { color-scheme: dark }`) | Same. Disqus is responsive. |
 | **Nav** | Inline links: docs · benchmarks · downloads · blog · community + `v0.6.4`, github ↗, install | ≡ hamburger toggles a dropdown panel with the same links. `v0.6.4` chip is hidden at <480 px. |
 
@@ -292,10 +292,11 @@ The benchmarks chart on the landing reads it directly — no rebuild needed.
 
 ## Playwright e2e suite (`site/tests/playground/`)
 
-28 specs covering: dropdowns, tab strip CRUD, multi-file persistence,
-share-URL round-trip, splitter drag, hero ↗ playground handoff, mobile gate
-(asserts WASM is *not* fetched at narrow viewports). 5 are tagged `@wasm`
-and only run when the WASM artifact is present.
+Specs cover: dropdowns, tab strip CRUD, multi-file persistence, share-URL
+round-trip, splitter drag, hero ↗ playground handoff, engine toggle, the
+shared runtime module, and dead-page revival. Tests that need the daslang
+runtime carry `@wasm` in their title and only run when the WASM artifacts
+are staged; the per-PR lane runs the rest with `--grep-invert '@wasm'`.
 
 ```bash
 # Start the dev server from site/ (so paths resolve like prod).
@@ -345,7 +346,8 @@ mirrors the steps above. Differences worth knowing:
 - CI fetches `profile_results.json` on each publish.
 - CI builds Sphinx with `-W` (treats warnings as errors). Local builds should
   do the same before pushing.
-- CI uploads to GitHub Pages via `actions/deploy-pages@v4`.
+- CI deploys to the VPS over rsync (`pages.yml` — a release dir + atomic
+  symlink flip; Caddy serves it directly).
 
 If something works locally but fails on CI, walk through the workflow file
 side-by-side with this README — the commands should match.

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -112,11 +112,11 @@
 <script type="text/javascript" src="./playground-init.js"></script>
 <!-- Owns run-frame.html (one frame per program). Must precede main.js, whose
      pageInit hands it the run host and whose run path delegates to it. -->
-<script type="text/javascript" src="./playground-runner.js?v=3"></script>
+<script type="text/javascript" src="./playground-runner.js?v=4"></script>
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
 <script type="text/javascript" src="./playground-wasm.js?v=2"></script>
-<script type="text/javascript" src="./main.js?v=6"></script>
+<script type="text/javascript" src="./main.js?v=7"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=4"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -112,11 +112,11 @@
 <script type="text/javascript" src="./playground-init.js"></script>
 <!-- Owns run-frame.html (one frame per program). Must precede main.js, whose
      pageInit hands it the run host and whose run path delegates to it. -->
-<script type="text/javascript" src="./playground-runner.js?v=4"></script>
+<script type="text/javascript" src="./playground-runner.js?v=5"></script>
 <!-- Compiles the editor's code on the build service for the wasm engine.
      Reads its payload from playground-share.js, so both agree on one hash. -->
 <script type="text/javascript" src="./playground-wasm.js?v=2"></script>
-<script type="text/javascript" src="./main.js?v=7"></script>
+<script type="text/javascript" src="./main.js?v=8"></script>
 <script type="text/javascript" src="./playground-tabs.js?v=4"></script>
 <script type="text/javascript" src="./playground-share.js?v=3"></script>
 <script type="text/javascript" src="./playground-splitter.js?v=3"></script>

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -13,7 +13,7 @@
 (function () {
     "use strict";
 
-    var FRAME_SRC = "run-frame.html?v=2";
+    var FRAME_SRC = "run-frame.html?v=3";
 
     var host = null;        // element the frames live in
     var current = null;     // frame serving the run in flight (or the idle one)
@@ -27,6 +27,8 @@
     // unreachable, retrying forever just spawns frames.
     var spareAborts = 0;
     var MAX_SPARE_ABORTS = 3;
+    var lastReviveAt = 0;
+    var REVIVE_COOLDOWN_MS = 8000;
 
     // ── the one compiled runtime ─────────────────────────────────────────────
     // The runtime wasm (~40MB) is compiled HERE, once per page. Every frame asks
@@ -40,9 +42,48 @@
     var WASM_URL = "daslang_static.wasm";
     var wasmModulePromise = null;
 
+    // A download that stops flowing must reject rather than hang: once a frame
+    // has been acked, this promise is the only thing it is waiting on — nothing
+    // else times out, so a silent stall would wedge the page in the exact shape
+    // this file exists to remove. Idle-based, not total-time-based, so a slow
+    // link that is still moving bytes is never cut off.
+    var STALL_MS = 30000;
+
+    function fetchRuntimeWithStallGuard() {
+        return fetch(WASM_URL).then(function (r) {
+            if (!r.ok) throw new Error("HTTP " + r.status + " fetching " + WASM_URL);
+            if (!r.body || typeof TransformStream === "undefined") return r;
+            var timer = null;
+            function arm(controller) {
+                clearTimeout(timer);
+                timer = setTimeout(function () {
+                    controller.error(new Error("runtime download stalled"));
+                }, STALL_MS);
+            }
+            var guard = new TransformStream({
+                start: function (c) { arm(c); },
+                transform: function (chunk, c) { arm(c); c.enqueue(chunk); },
+                flush: function () { clearTimeout(timer); },
+            });
+            // Headers ride along so compileStreaming still sees the wasm MIME type.
+            return new Response(r.body.pipeThrough(guard), { headers: r.headers });
+        });
+    }
+
     function compileRuntime() {
         if (!wasmModulePromise) {
-            wasmModulePromise = WebAssembly.compileStreaming(fetch(WASM_URL))
+            wasmModulePromise = fetchRuntimeWithStallGuard()
+                .then(function (r) { return WebAssembly.compileStreaming(r); })
+                .catch(function (e) {
+                    // The ladder the emscripten glue always had: streaming compile
+                    // hard-requires the application/wasm MIME type, and losing the
+                    // ArrayBuffer arm turned a warn-and-work server into a dead
+                    // page. One retry also covers a mid-stream stall.
+                    console.warn("wasm streaming compile failed, retrying as ArrayBuffer:", e);
+                    return fetchRuntimeWithStallGuard()
+                        .then(function (r) { return r.arrayBuffer(); })
+                        .then(function (bytes) { return WebAssembly.compile(bytes); });
+                })
                 .catch(function (e) {
                     // Drop the failed promise so a revive() retries the compile —
                     // an OOM here is often transient (the old page's module not
@@ -240,12 +281,14 @@
             return !!(spare && spare.ready) || !!(current && current.ready && !current.used);
         },
 
-        // Dead means the runner gave up: no frame standing by and none loading.
-        // Distinct from "loading" (a spare exists, not ready yet) — the Run
-        // button stays clickable in THIS state only, so the user has a way to
-        // trigger revive(); reporting it as "still loading" hid exactly that.
+        // Dead means the runner gave up: initialized, yet no frame standing by
+        // and none loading. Distinct from "loading" (a spare exists, not ready
+        // yet) — the Run button stays clickable in THIS state only, so the user
+        // has a way to trigger revive(); reporting it as "still loading" hid
+        // exactly that. (No `current` term: a current frame is always mid-run
+        // or finished, never standing by.)
         isDead: function () {
-            return !spare && !(current && current.ready && !current.used);
+            return !!host && !spare;
         },
 
         // A page whose spare kept aborting (MAX_SPARE_ABORTS) has no frame and,
@@ -255,9 +298,14 @@
         // reset the abort budget. Cheap — a new frame reuses the compiled
         // module, and a failed parent compile retries because compileRuntime()
         // drops its promise on rejection. Returns whether it revived anything;
-        // false means a spare is already standing (loading or ready).
+        // false means a spare is already standing (loading or ready), or a
+        // revive just ran — the cooldown keeps a click storm on a structurally
+        // dead page (no runtime to fetch at all) from stacking abort budgets.
         revive: function () {
-            if (spare) return false;
+            if (!host || spare) return false;
+            var now = Date.now();
+            if (now - lastReviveAt < REVIVE_COOLDOWN_MS) return false;
+            lastReviveAt = now;
             spareAborts = 0;
             ensureSpare();
             if (typeof window.updateButtonStates === "function") window.updateButtonStates();
@@ -279,13 +327,18 @@
         },
 
         // Throw away the frame that ran (if any) and promote the pre-warmed one.
-        // Called before every run, and by Clear.
+        // Called before every run, and by Clear. Clear on a dead page is a "try
+        // again" gesture like Run, so it grants the same fresh abort budget its
+        // new spare needs — and the buttons re-gate, since aliveness may have
+        // just flipped.
         reset: function () {
             if (current) { destroy(current); current = null; }
             var out = document.getElementById("output");
             if (out) out.classList.remove("with-canvas");
             renderBadge(null);   // the run it described is gone
+            spareAborts = 0;
             ensureSpare();
+            if (typeof window.updateButtonStates === "function") window.updateButtonStates();
         },
 
         // files: { "main.das": "...", ... }  args: argv for callMain

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -13,7 +13,7 @@
 (function () {
     "use strict";
 
-    var FRAME_SRC = "run-frame.html";
+    var FRAME_SRC = "run-frame.html?v=2";
 
     var host = null;        // element the frames live in
     var current = null;     // frame serving the run in flight (or the idle one)
@@ -27,6 +27,32 @@
     // unreachable, retrying forever just spawns frames.
     var spareAborts = 0;
     var MAX_SPARE_ABORTS = 3;
+
+    // ── the one compiled runtime ─────────────────────────────────────────────
+    // The runtime wasm (~40MB) is compiled HERE, once per page. Every frame asks
+    // for this module over postMessage and instantiates it — instances share the
+    // compiled machine code, so a Run click costs an instantiation, not a
+    // compile. Without this, every frame (one per run, plus the pre-warmed
+    // spare) compiled the whole runtime again; browsers budget compiled wasm
+    // per PROCESS and reclaim it lazily, so a session of runs walked the
+    // process to "wasm streaming compile failed: out of memory" — a wedge that
+    // survives reloads (same process) until the tab is closed.
+    var WASM_URL = "daslang_static.wasm";
+    var wasmModulePromise = null;
+
+    function compileRuntime() {
+        if (!wasmModulePromise) {
+            wasmModulePromise = WebAssembly.compileStreaming(fetch(WASM_URL))
+                .catch(function (e) {
+                    // Drop the failed promise so a revive() retries the compile —
+                    // an OOM here is often transient (the old page's module not
+                    // yet collected), and a pinned rejection would make it final.
+                    wasmModulePromise = null;
+                    throw e;
+                });
+        }
+        return wasmModulePromise;
+    }
 
     function makeFrame() {
         var rec = { el: document.createElement("iframe"), ready: false, used: false };
@@ -139,6 +165,21 @@
         if (!rec) return;
 
         switch (msg.type) {
+            case "need-wasm-module":
+                // Ack immediately: the compile can take seconds, and without an
+                // ack the frame cannot tell "parent is compiling" from "parent
+                // predates this protocol" (where it falls back to self-compile).
+                (function (target) {
+                    function deliver(payload) {
+                        try { target.postMessage(payload, window.location.origin); } catch (e) { /* frame gone */ }
+                    }
+                    deliver({ type: "wasm-module-pending" });
+                    compileRuntime().then(
+                        function (mod) { deliver({ type: "wasm-module", module: mod }); },
+                        function (e) { deliver({ type: "wasm-module", module: null, error: String((e && e.message) || e) }); }
+                    );
+                })(ev.source);
+                break;
             case "ready":
                 rec.ready = true;
                 if (rec === spare) spareAborts = 0;
@@ -188,12 +229,31 @@
             host = hostEl;
             onOutput = outputFn;
             onExit = exitFn || null;
+            // Start the one compile now — the spare is about to ask for it.
+            // Errors surface through the frame protocol, not here.
+            compileRuntime().catch(function () {});
             ensureSpare();
         },
 
         // Ready means "a frame is standing by", which is what gates the buttons.
         isReady: function () {
             return !!(spare && spare.ready) || !!(current && current.ready && !current.used);
+        },
+
+        // A page whose spare kept aborting (MAX_SPARE_ABORTS) has no frame and,
+        // without this, no way back short of a reload — which does not help when
+        // the abort was the process's wasm memory, since that outlives reloads.
+        // A Run click is the user's explicit "try again": rebuild the spare and
+        // reset the abort budget. Cheap — a new frame reuses the compiled
+        // module, and a failed parent compile retries because compileRuntime()
+        // drops its promise on rejection. Returns whether it revived anything;
+        // false means a spare is already standing (loading or ready).
+        revive: function () {
+            if (spare) return false;
+            spareAborts = 0;
+            ensureSpare();
+            if (typeof window.updateButtonStates === "function") window.updateButtonStates();
+            return true;
         },
 
         // Size an element the way a run frame is sized. The wasm engine's page

--- a/site/playground/playground-runner.js
+++ b/site/playground/playground-runner.js
@@ -240,6 +240,14 @@
             return !!(spare && spare.ready) || !!(current && current.ready && !current.used);
         },
 
+        // Dead means the runner gave up: no frame standing by and none loading.
+        // Distinct from "loading" (a spare exists, not ready yet) — the Run
+        // button stays clickable in THIS state only, so the user has a way to
+        // trigger revive(); reporting it as "still loading" hid exactly that.
+        isDead: function () {
+            return !spare && !(current && current.ready && !current.used);
+        },
+
         // A page whose spare kept aborting (MAX_SPARE_ABORTS) has no frame and,
         // without this, no way back short of a reload — which does not help when
         // the abort was the process's wasm memory, since that outlives reloads.

--- a/site/playground/run-frame.html
+++ b/site/playground/run-frame.html
@@ -186,7 +186,9 @@
         // pthread pool was already sharing it inside a frame: workers do
         // `new WebAssembly.Instance(wasmModule, …)` from the module this hook
         // hands to `done`.) A parent that predates the protocol never acks, so
-        // after a short wait the frame compiles for itself, exactly as before.
+        // after a short wait the frame compiles for itself — streaming first,
+        // then the ArrayBuffer ladder the emscripten glue carries, so a server
+        // without the wasm MIME type degrades to a warning, not a dead frame.
         instantiateWasm: function (imports, done) {
             var settled = false, acked = false;
             function fail(message) { post({ type: "aborted", message: message }); }
@@ -213,10 +215,20 @@
                 if (settled || acked) return;
                 settled = true;
                 window.removeEventListener("message", onModuleMsg);
-                WebAssembly.instantiateStreaming(fetch("daslang_static.wasm"), imports).then(
-                    function (r) { done(r.instance, r.module); },
-                    function (e) { fail("wasm compile failed: " + e); }
-                );
+                WebAssembly.instantiateStreaming(fetch("daslang_static.wasm"), imports)
+                    .catch(function (e) {
+                        post({ type: "stderr", text: "wasm streaming compile failed, retrying as ArrayBuffer: " + e + "\n" });
+                        return fetch("daslang_static.wasm")
+                            .then(function (r) {
+                                if (!r.ok) throw new Error("HTTP " + r.status + " fetching daslang_static.wasm");
+                                return r.arrayBuffer();
+                            })
+                            .then(function (bytes) { return WebAssembly.instantiate(bytes, imports); });
+                    })
+                    .then(
+                        function (r) { done(r.instance, r.module); },
+                        function (e) { fail("wasm compile failed: " + e); }
+                    );
             }, 2000);
             return {};
         },

--- a/site/playground/run-frame.html
+++ b/site/playground/run-frame.html
@@ -180,6 +180,46 @@
         // mainScriptUrlOrBlob. Name it explicitly — document.currentScript is null
         // under some load paths, and the pool would otherwise spawn Worker(undefined).
         mainScriptUrlOrBlob: "daslang_static.js",
+        // One compile per page: the parent compiles the runtime wasm once and
+        // every frame instantiates that module — instances share the machine
+        // code, so a frame costs an instantiation, not a 40MB compile. (The
+        // pthread pool was already sharing it inside a frame: workers do
+        // `new WebAssembly.Instance(wasmModule, …)` from the module this hook
+        // hands to `done`.) A parent that predates the protocol never acks, so
+        // after a short wait the frame compiles for itself, exactly as before.
+        instantiateWasm: function (imports, done) {
+            var settled = false, acked = false;
+            function fail(message) { post({ type: "aborted", message: message }); }
+            function onModuleMsg(ev) {
+                if (ev.origin !== window.location.origin) return;
+                var m = ev.data;
+                if (!m || typeof m !== "object") return;
+                if (m.type === "wasm-module-pending") { acked = true; return; }
+                if (m.type !== "wasm-module" || settled) return;
+                settled = true;
+                window.removeEventListener("message", onModuleMsg);
+                if (m.module) {
+                    WebAssembly.instantiate(m.module, imports).then(
+                        function (instance) { done(instance, m.module); },
+                        function (e) { fail("wasm instantiate failed: " + e); }
+                    );
+                } else {
+                    fail("wasm compile failed: " + (m.error || "unknown error"));
+                }
+            }
+            window.addEventListener("message", onModuleMsg);
+            post({ type: "need-wasm-module" });
+            setTimeout(function () {
+                if (settled || acked) return;
+                settled = true;
+                window.removeEventListener("message", onModuleMsg);
+                WebAssembly.instantiateStreaming(fetch("daslang_static.wasm"), imports).then(
+                    function (r) { done(r.instance, r.module); },
+                    function (e) { fail("wasm compile failed: " + e); }
+                );
+            }, 2000);
+            return {};
+        },
         preRun: [],
         postRun: [],
         print: function (text) {

--- a/site/tests/playground/runtime-revive.spec.js
+++ b/site/tests/playground/runtime-revive.spec.js
@@ -46,46 +46,85 @@ test('a dead page revives on the next Run click @wasm', async ({ page }) => {
     // Stop the sabotage: the revived spare must be allowed to come up for real.
     await page.evaluate(() => { window.__abortSpares = false; });
 
-    // Run on the dead page — the real button, not a scripted call: revive, and
-    // say so (not "still loading"). Immediately run again while the revived
-    // spare is still loading: that second call must report "still loading",
-    // not claim another revive (the spare-exists arm). Scripted, because the
-    // button is correctly disabled during the load — which is the point.
-    await page.click('#run');
-    await page.evaluate(() => runCode());
+    // Run on the dead page — the real button (a disabled button swallows even a
+    // programmatic click, so this also proves UI reachability): revive, and say
+    // so (not "still loading"). The second call runs in the same evaluate,
+    // synchronously after the click, so the revived spare provably hasn't had a
+    // frame's lifetime to become ready: it must report "still loading", not
+    // claim another revive (the spare-exists arm). Scripted, because the button
+    // is correctly disabled during the load — which is the point.
+    await page.evaluate(() => {
+        document.getElementById('run').click();
+        runCode();
+    });
     await expect(page.locator('.output_line_text', { hasText: 'failed to start — retrying' }))
-        .toBeVisible({ timeout: 5_000 });
+        .toBeVisible({ timeout: 15_000 });
     await expect(page.locator('.output_line_text', { hasText: 'still loading, please wait' }))
-        .toBeVisible({ timeout: 5_000 });
+        .toBeVisible({ timeout: 15_000 });
 
-    // The revived spare comes up for real and the next Run executes.
+    // The revived spare comes up for real, the next Run actually executes the
+    // program (the default sample prints "Hello World"), and no further abort
+    // joined the output.
     await page.waitForFunction(() => {
         const b = document.getElementById('run');
-        return b && !b.disabled;
+        return b && !b.disabled && window.PlaygroundRunner && window.PlaygroundRunner.isReady();
     }, null, { timeout: 60_000 });
-    const before = await page.evaluate(() => document.querySelectorAll('#output .output_line').length);
+    const abortsBefore = await page.evaluate(() =>
+        [...document.querySelectorAll('#output .output_line_text')]
+            .filter((e) => e.textContent.includes('runtime aborted')).length);
     await page.click('#run');
+    await expect(page.locator('.output_line_text', { hasText: 'Hello World' }))
+        .toBeVisible({ timeout: 60_000 });
+    const abortsAfter = await page.evaluate(() =>
+        [...document.querySelectorAll('#output .output_line_text')]
+            .filter((e) => e.textContent.includes('runtime aborted')).length);
+    expect(abortsAfter).toBe(abortsBefore);
+});
+
+// The compile ladder: when streaming compilation is unavailable (canonically a
+// server without the application/wasm MIME type), the ArrayBuffer arm carries
+// the page — warn-and-work, never a dead page. Streaming is stubbed dead for
+// the whole session; the page must come up and run without a single abort.
+test('streaming-compile failure falls back to ArrayBuffer and the page works @wasm', async ({ page }) => {
+    test.slow();   // a full ArrayBuffer compile + a run; parallel-suite load stretches it
+    await page.addInitScript(() => {
+        if (window.top !== window) return;   // the parent's compile is the one with the ladder
+        WebAssembly.compileStreaming = () => Promise.reject(new TypeError('induced: streaming unavailable'));
+    });
+    await page.goto('/playground/');
+    await page.locator('.CodeMirror').waitFor({ state: 'visible' });
+    await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
     await page.waitForFunction(
-        (n) => document.querySelectorAll('#output .output_line').length > n,
-        before, { timeout: 60_000 });
+        () => window.PlaygroundRunner && window.PlaygroundRunner.isReady(),
+        null, { timeout: 60_000 });
+    await page.click('#run');
+    await expect(page.locator('.output_line_text', { hasText: 'Hello World' }))
+        .toBeVisible({ timeout: 60_000 });
+    const lines = await page.evaluate(() =>
+        [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
+    expect(lines).not.toContain('runtime aborted');
 });
 
 // A failed runtime compile must surface its real reason (not hang as "still
 // loading"), and the next request must retry the compile — compileRuntime
 // drops its promise on rejection precisely so the failure is not final. The
-// stub rejects the parent's first two compileStreaming calls (the eager init
-// call absorbs one; the first spare's request eats the second and aborts), so
-// the rebuilt spare's request is the retry that succeeds.
+// stub fails BOTH rungs of the compile ladder (streaming, then the ArrayBuffer
+// retry) with a shared budget of two full ladders: the eager init call absorbs
+// one ladder, the first spare's request eats the second and aborts, so the
+// rebuilt spare's request is the retry that succeeds.
 test('a failed runtime compile reports itself and the retry recovers @wasm', async ({ page }) => {
     test.slow();   // two compile attempts + a full run; parallel-suite load stretches each
     await page.addInitScript(() => {
         if (window.top !== window) return;   // stub the parent page only
-        const orig = WebAssembly.compileStreaming.bind(WebAssembly);
-        let failures = 2;
-        WebAssembly.compileStreaming = (...a) => {
+        const origStreaming = WebAssembly.compileStreaming.bind(WebAssembly);
+        const origCompile = WebAssembly.compile.bind(WebAssembly);
+        let failures = 4;   // 2 ladders × 2 rungs
+        const failing = (orig) => (...a) => {
             if (failures > 0) { failures--; return Promise.reject(new Error('induced compile failure')); }
             return orig(...a);
         };
+        WebAssembly.compileStreaming = failing(origStreaming);
+        WebAssembly.compile = failing(origCompile);
     });
     await page.goto('/playground/');
     await page.locator('.CodeMirror').waitFor({ state: 'visible' });

--- a/site/tests/playground/runtime-revive.spec.js
+++ b/site/tests/playground/runtime-revive.spec.js
@@ -5,45 +5,57 @@
 // runner rebuilds the spare (PlaygroundRunner.revive) and says what it is
 // doing.
 //
-// Aborts are induced by posting each spare frame's own "aborted" message from
-// inside that frame — the same message a dead network or an out-of-memory
-// runtime produces. (Blocking the runtime fetch with page.route can't do it:
-// the COI service worker fetches on the frames' behalf, and routes don't see
-// service-worker fetches.)
+// Aborts are induced by an init script that makes every run-frame document
+// post its own "aborted" message the moment it is created — the same message a
+// dead network or an out-of-memory runtime produces, landed before the runtime
+// can ever come up, so a spare turning ready can never race the abort and
+// reset the budget. The top window's __abortSpares flag gates it, so the test
+// can stop the sabotage for the revive phase. (Blocking the runtime fetch with
+// page.route can't induce this: the COI service worker fetches on the frames'
+// behalf, and routes don't see service-worker fetches.)
 
 const { test, expect } = require('@playwright/test');
 
-function runFrame(page) {
-    return page.frames().find((f) => f.url().includes('run-frame.html'));
-}
-
-test('a dead page revives on the next Run click', async ({ page }) => {
+test('a dead page revives on the next Run click @wasm', async ({ page }) => {
+    test.slow();   // several full frame lifecycles; parallel-suite load stretches each
+    await page.addInitScript(() => {
+        if (window.top === window) { window.__abortSpares = true; return; }
+        try {
+            if (window.top.__abortSpares) {
+                window.parent.postMessage({ type: 'aborted', message: 'test-induced abort' }, window.location.origin);
+            }
+        } catch (e) { /* cross-origin top — not our frame */ }
+    });
     await page.goto('/playground/');
     await page.locator('.CodeMirror').waitFor({ state: 'visible' });
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
 
-    // Abort the spare; the runner rebuilds it (bounded), abort each rebuild.
-    for (let round = 1; round <= 4; round++) {
-        await page.waitForFunction(
-            () => document.querySelectorAll('iframe.pg-run-frame').length === 1,
-            null, { timeout: 15_000 });
-        const frame = runFrame(page);
-        expect(frame).toBeTruthy();
-        await frame.evaluate(() =>
-            parent.postMessage({ type: 'aborted', message: 'test-induced abort' }, location.origin));
-        await expect(page.locator('.output_line_text', { hasText: 'runtime aborted' }))
-            .toHaveCount(round, { timeout: 15_000 });
-    }
+    // The runner reported the aborts on its way down.
+    await expect(page.locator('.output_line_text', { hasText: 'runtime aborted' }).first())
+        .toBeVisible({ timeout: 30_000 });
 
-    // Dead page: the budget is spent, no frame standing by, none on the way.
+    // Dead page: the budget is spent, no frame standing by, none on the way —
+    // and the Run BUTTON is enabled, because the click is the revive trigger.
+    // (A disabled button here would make the dead state permanent from the UI.)
     await page.waitForFunction(
         () => document.querySelectorAll('iframe.pg-run-frame').length === 0
-            && window.PlaygroundRunner && !window.PlaygroundRunner.isReady(),
-        null, { timeout: 5_000 });
+            && window.PlaygroundRunner && !window.PlaygroundRunner.isReady()
+            && !document.getElementById('run').disabled,
+        null, { timeout: 15_000 });
 
-    // Run on the dead page: revive, and say so (not "still loading").
+    // Stop the sabotage: the revived spare must be allowed to come up for real.
+    await page.evaluate(() => { window.__abortSpares = false; });
+
+    // Run on the dead page — the real button, not a scripted call: revive, and
+    // say so (not "still loading"). Immediately run again while the revived
+    // spare is still loading: that second call must report "still loading",
+    // not claim another revive (the spare-exists arm). Scripted, because the
+    // button is correctly disabled during the load — which is the point.
+    await page.click('#run');
     await page.evaluate(() => runCode());
     await expect(page.locator('.output_line_text', { hasText: 'failed to start — retrying' }))
+        .toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.output_line_text', { hasText: 'still loading, please wait' }))
         .toBeVisible({ timeout: 5_000 });
 
     // The revived spare comes up for real and the next Run executes.
@@ -56,4 +68,44 @@ test('a dead page revives on the next Run click', async ({ page }) => {
     await page.waitForFunction(
         (n) => document.querySelectorAll('#output .output_line').length > n,
         before, { timeout: 60_000 });
+});
+
+// A failed runtime compile must surface its real reason (not hang as "still
+// loading"), and the next request must retry the compile — compileRuntime
+// drops its promise on rejection precisely so the failure is not final. The
+// stub rejects the parent's first two compileStreaming calls (the eager init
+// call absorbs one; the first spare's request eats the second and aborts), so
+// the rebuilt spare's request is the retry that succeeds.
+test('a failed runtime compile reports itself and the retry recovers @wasm', async ({ page }) => {
+    test.slow();   // two compile attempts + a full run; parallel-suite load stretches each
+    await page.addInitScript(() => {
+        if (window.top !== window) return;   // stub the parent page only
+        const orig = WebAssembly.compileStreaming.bind(WebAssembly);
+        let failures = 2;
+        WebAssembly.compileStreaming = (...a) => {
+            if (failures > 0) { failures--; return Promise.reject(new Error('induced compile failure')); }
+            return orig(...a);
+        };
+    });
+    await page.goto('/playground/');
+    await page.locator('.CodeMirror').waitFor({ state: 'visible' });
+    await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
+
+    // The first spare heard {module: null, error} and reported the real cause.
+    await expect(page.locator('.output_line_text', { hasText: 'wasm compile failed: induced compile failure' }))
+        .toBeVisible({ timeout: 30_000 });
+
+    // The rebuilt spare's request re-compiles for real and the page recovers.
+    await page.waitForFunction(() => {
+        const b = document.getElementById('run');
+        return b && !b.disabled && window.PlaygroundRunner && window.PlaygroundRunner.isReady();
+    }, null, { timeout: 60_000 });
+    const before = await page.evaluate(() => document.querySelectorAll('#output .output_line').length);
+    await page.click('#run');
+    await page.waitForFunction(
+        (n) => document.querySelectorAll('#output .output_line').length > n,
+        before, { timeout: 60_000 });
+    const lines = await page.evaluate(() =>
+        [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
+    expect(lines).not.toContain('runtime aborted: run-frame');
 });

--- a/site/tests/playground/runtime-revive.spec.js
+++ b/site/tests/playground/runtime-revive.spec.js
@@ -1,0 +1,59 @@
+// A page whose run frames kept aborting exhausts the runner's spare-rebuild
+// budget and used to be dead for good: Run answered "daslang is still
+// loading, please wait…" forever, and nothing short of closing the tab
+// helped. Now a Run click on a dead page is the user's "try again" — the
+// runner rebuilds the spare (PlaygroundRunner.revive) and says what it is
+// doing.
+//
+// Aborts are induced by posting each spare frame's own "aborted" message from
+// inside that frame — the same message a dead network or an out-of-memory
+// runtime produces. (Blocking the runtime fetch with page.route can't do it:
+// the COI service worker fetches on the frames' behalf, and routes don't see
+// service-worker fetches.)
+
+const { test, expect } = require('@playwright/test');
+
+function runFrame(page) {
+    return page.frames().find((f) => f.url().includes('run-frame.html'));
+}
+
+test('a dead page revives on the next Run click', async ({ page }) => {
+    await page.goto('/playground/');
+    await page.locator('.CodeMirror').waitFor({ state: 'visible' });
+    await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
+
+    // Abort the spare; the runner rebuilds it (bounded), abort each rebuild.
+    for (let round = 1; round <= 4; round++) {
+        await page.waitForFunction(
+            () => document.querySelectorAll('iframe.pg-run-frame').length === 1,
+            null, { timeout: 15_000 });
+        const frame = runFrame(page);
+        expect(frame).toBeTruthy();
+        await frame.evaluate(() =>
+            parent.postMessage({ type: 'aborted', message: 'test-induced abort' }, location.origin));
+        await expect(page.locator('.output_line_text', { hasText: 'runtime aborted' }))
+            .toHaveCount(round, { timeout: 15_000 });
+    }
+
+    // Dead page: the budget is spent, no frame standing by, none on the way.
+    await page.waitForFunction(
+        () => document.querySelectorAll('iframe.pg-run-frame').length === 0
+            && window.PlaygroundRunner && !window.PlaygroundRunner.isReady(),
+        null, { timeout: 5_000 });
+
+    // Run on the dead page: revive, and say so (not "still loading").
+    await page.evaluate(() => runCode());
+    await expect(page.locator('.output_line_text', { hasText: 'failed to start — retrying' }))
+        .toBeVisible({ timeout: 5_000 });
+
+    // The revived spare comes up for real and the next Run executes.
+    await page.waitForFunction(() => {
+        const b = document.getElementById('run');
+        return b && !b.disabled;
+    }, null, { timeout: 60_000 });
+    const before = await page.evaluate(() => document.querySelectorAll('#output .output_line').length);
+    await page.click('#run');
+    await page.waitForFunction(
+        (n) => document.querySelectorAll('#output .output_line').length > n,
+        before, { timeout: 60_000 });
+});

--- a/site/tests/playground/shared-module.spec.js
+++ b/site/tests/playground/shared-module.spec.js
@@ -27,7 +27,8 @@ async function runAndWaitForOutput(page) {
         before, { timeout: 60_000 });
 }
 
-test('a session of runs compiles the runtime once, not once per run', async ({ page }) => {
+test('a session of runs compiles the runtime once, not once per run @wasm', async ({ page }) => {
+    test.slow();   // two full runs with respawned spares; parallel-suite load stretches each
     await page.goto('/playground/');
     await page.locator('.CodeMirror').waitFor({ state: 'visible' });
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
@@ -52,4 +53,43 @@ test('a session of runs compiles the runtime once, not once per run', async ({ p
     expect(lines).not.toContain('runtime aborted');
 
     expect(lateWasmFetches).toBe(0);
+
+    // The page-level counter cannot see a frame's own fallback fetch — the COI
+    // service worker fetches on the frames' behalf and those requests don't
+    // reach page.on('request'). Ask each live run frame directly: a frame that
+    // fetched the runtime went back to compiling for itself.
+    for (const f of page.frames()) {
+        if (!f.url().includes('run-frame')) continue;
+        const frameWasmFetches = await f.evaluate(() =>
+            performance.getEntriesByType('resource')
+                .filter((e) => e.name.includes('daslang_static.wasm')).length);
+        expect(frameWasmFetches).toBe(0);
+    }
+});
+
+// Version skew: an old cached parent never answers need-wasm-module, and the
+// frame must fall back to compiling for itself (the pre-shared-module path)
+// after the ack timeout. Loading run-frame.html as its own top document IS
+// such a parent: its need-wasm-module post goes to itself and nothing answers.
+// The /playground/ visit first is what registers the COI service worker, so
+// the direct navigation is served cross-origin-isolated like production.
+test('a frame whose parent never answers compiles for itself @wasm', async ({ page }) => {
+    await page.goto('/playground/');
+    await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
+
+    await page.goto('/playground/run-frame.html');
+    // The frame posts "ready" from onRuntimeInitialized; as its own top
+    // document that post arrives on itself. (Module.callMain exists from
+    // script-eval time, long before the runtime is up — don't wait on it.)
+    await page.evaluate(() => {
+        window.__frameReady = false;
+        window.addEventListener('message', (e) => {
+            if (e.data && e.data.type === 'ready') window.__frameReady = true;
+        });
+    });
+    await page.waitForFunction(() => window.__frameReady === true, null, { timeout: 60_000 });
+    const selfFetches = await page.evaluate(() =>
+        performance.getEntriesByType('resource')
+            .filter((e) => e.name.includes('daslang_static.wasm')).length);
+    expect(selfFetches).toBe(1);
 });

--- a/site/tests/playground/shared-module.spec.js
+++ b/site/tests/playground/shared-module.spec.js
@@ -6,17 +6,21 @@
 // ("wasm streaming compile failed: InternalError: out of memory" — a state
 // reloads don't clear, because the quota is per-process, not per-page).
 //
-// The observable is network fetches of the runtime after the page is ready:
-// a run must not trigger another daslang_static.wasm fetch — a frame that
-// fetches it went back to compiling for itself.
+// The observable is fetches of the runtime after the page is ready: a run must
+// not trigger another daslang_static.wasm fetch. Counted twice — page-level
+// request events, and each run frame's own Resource Timing — because a frame
+// that fetches it went back to compiling for itself, and belt-and-braces here
+// is what keeps the spec honest if either channel's visibility changes.
 
 const { test, expect } = require('@playwright/test');
 
+// Gate on the runner's own readiness, not the Run button: the button is
+// re-gated on state *changes*, so mid-run it can briefly hold a stale enabled
+// state while isReady() is false.
 async function waitForRunReady(page) {
-    await page.waitForFunction(() => {
-        const b = document.getElementById('run');
-        return b && !b.disabled;
-    }, null, { timeout: 60_000 });
+    await page.waitForFunction(
+        () => window.PlaygroundRunner && window.PlaygroundRunner.isReady(),
+        null, { timeout: 60_000 });
 }
 
 async function runAndWaitForOutput(page) {
@@ -46,25 +50,27 @@ test('a session of runs compiles the runtime once, not once per run @wasm', asyn
     await runAndWaitForOutput(page);
     await waitForRunReady(page);
 
-    // Both runs actually executed (the count above must not pass vacuously).
+    // Both runs actually executed: the default sample prints "Hello World"
+    // once per run. (A weaker any-output check would accept a status line.)
     const lines = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
-    expect(lines.length).toBeGreaterThan(0);
+    expect((lines.match(/Hello World/g) || []).length).toBe(2);
     expect(lines).not.toContain('runtime aborted');
 
     expect(lateWasmFetches).toBe(0);
 
-    // The page-level counter cannot see a frame's own fallback fetch — the COI
-    // service worker fetches on the frames' behalf and those requests don't
-    // reach page.on('request'). Ask each live run frame directly: a frame that
-    // fetched the runtime went back to compiling for itself.
+    // Ask each live run frame directly too, and prove the loop saw frames —
+    // zero inspected frames would make this arm vacuously green.
+    let inspected = 0;
     for (const f of page.frames()) {
         if (!f.url().includes('run-frame')) continue;
+        inspected++;
         const frameWasmFetches = await f.evaluate(() =>
             performance.getEntriesByType('resource')
                 .filter((e) => e.name.includes('daslang_static.wasm')).length);
         expect(frameWasmFetches).toBe(0);
     }
+    expect(inspected).toBeGreaterThan(0);
 });
 
 // Version skew: an old cached parent never answers need-wasm-module, and the
@@ -74,6 +80,7 @@ test('a session of runs compiles the runtime once, not once per run @wasm', asyn
 // The /playground/ visit first is what registers the COI service worker, so
 // the direct navigation is served cross-origin-isolated like production.
 test('a frame whose parent never answers compiles for itself @wasm', async ({ page }) => {
+    test.slow();   // a full self-compile after the ack timeout; CI load stretches it
     await page.goto('/playground/');
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
 

--- a/site/tests/playground/shared-module.spec.js
+++ b/site/tests/playground/shared-module.spec.js
@@ -1,0 +1,55 @@
+// The daslang runtime (daslang_static.wasm, ~40MB) is compiled ONCE per page:
+// the parent compiles it and every run frame instantiates that shared module.
+// Before this, each Run click built a fresh frame that fetched and compiled
+// the whole runtime again, and a session of runs accumulated compiled-code
+// memory in the browser process until WebAssembly compilation itself failed
+// ("wasm streaming compile failed: InternalError: out of memory" — a state
+// reloads don't clear, because the quota is per-process, not per-page).
+//
+// The observable is network fetches of the runtime after the page is ready:
+// a run must not trigger another daslang_static.wasm fetch — a frame that
+// fetches it went back to compiling for itself.
+
+const { test, expect } = require('@playwright/test');
+
+async function waitForRunReady(page) {
+    await page.waitForFunction(() => {
+        const b = document.getElementById('run');
+        return b && !b.disabled;
+    }, null, { timeout: 60_000 });
+}
+
+async function runAndWaitForOutput(page) {
+    const before = await page.evaluate(() => document.querySelectorAll('#output .output_line').length);
+    await page.click('#run');
+    await page.waitForFunction(
+        (n) => document.querySelectorAll('#output .output_line').length > n,
+        before, { timeout: 60_000 });
+}
+
+test('a session of runs compiles the runtime once, not once per run', async ({ page }) => {
+    await page.goto('/playground/');
+    await page.locator('.CodeMirror').waitFor({ state: 'visible' });
+    await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
+    await waitForRunReady(page);
+
+    // The page is up and a frame is standing by — from here on, no run may
+    // cost another fetch (= another compile) of the runtime.
+    let lateWasmFetches = 0;
+    page.on('request', (r) => {
+        if (r.url().includes('daslang_static.wasm')) lateWasmFetches++;
+    });
+
+    await runAndWaitForOutput(page);
+    await waitForRunReady(page);          // the respawned spare is what would re-fetch
+    await runAndWaitForOutput(page);
+    await waitForRunReady(page);
+
+    // Both runs actually executed (the count above must not pass vacuously).
+    const lines = await page.evaluate(() =>
+        [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines).not.toContain('runtime aborted');
+
+    expect(lateWasmFetches).toBe(0);
+});

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -19,6 +19,23 @@ namespace das {
     static const char * INLINE_TEMP_PREFIX = "_inl";
     static const size_t INLINE_TEMP_PREFIX_LEN = 4;
 
+    // Joining a manufactured prefix (always '_'-terminated) straight onto a name
+    // that itself starts with '_' would spell `__` at the seam — the same GLSL ES
+    // reservation the prefix above avoids. Such names are routine here: nested
+    // inlining renames the inner site's own _inl<M>_* temps, and a callee local
+    // or parameter may be '_'-spelled by the user. Leading underscores re-encode
+    // as a 'u' run between the namespace and the stripped name
+    // (`_inl1_l_` + `_inl0_arg_a` -> `_inl1_lu_inl0_arg_a`), which stays
+    // injective: the plain arm's tail never starts with '_', so no 'u' run
+    // followed by '_' can collide across arms, and equal runs imply equal tails.
+    static string joinInlineName ( const string & prefix, const string & name ) {
+        DAS_ASSERT(!prefix.empty() && prefix.back()=='_');
+        if ( name.empty() || name[0]!='_' ) return prefix + name;
+        size_t k = 0;
+        while ( k<name.size() && name[k]=='_' ) ++k;
+        return prefix.substr(0,prefix.size()-1) + string(k,'u') + "_" + name.substr(k);
+    }
+
     // ===== [inline] splicing, automatic block inlining, invoke devirtualization =====
     // Runs in the patch slot (Program::patchAnnotations -> patchInline), after infer and
     // buildAccessFlags, before lint and optimize. Splices are syntax-level: cloned callee
@@ -412,8 +429,8 @@ namespace das {
         protected:
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
             void renameVar ( const string & name, const string & aka ) {
-                if ( rename->find(name)==rename->end() ) (*rename)[name] = prefix + name;
-                if ( !aka.empty() && rename->find(aka)==rename->end() ) (*rename)[aka] = prefix + name;
+                if ( rename->find(name)==rename->end() ) (*rename)[name] = joinInlineName(prefix, name);
+                if ( !aka.empty() && rename->find(aka)==rename->end() ) (*rename)[aka] = joinInlineName(prefix, name);
             }
             virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
                 Visitor::preVisitLet(let, var, last);
@@ -2281,7 +2298,7 @@ namespace das {
                             argFlavorFail = true;
                             return;
                         }
-                        string tname = INLINE_TEMP_PREFIX + to_string(inlineId) + "_arg_" + P->name;
+                        string tname = joinInlineName(INLINE_TEMP_PREFIX + to_string(inlineId) + "_arg_", P->name);
                         bool viaClone = viaMove && init->type && init->type->constant;
                         temps.push_back(makeTemp(callLike->at, tname, init, cnst, ref, viaMove && !viaClone, viaClone));
                         sub.tempName = tname;

--- a/tests/glsl/test_emission_basics.das
+++ b/tests/glsl/test_emission_basics.das
@@ -141,6 +141,59 @@ def nested_underscore_fragment {
     b_frag_color = float4(col, 1.0)
 }
 
+// Injectivity at the joins: `_z` vs `u_z` locals and `_a` vs `u_a` parameters
+// must stay FOUR distinct GLSL names — an escape that merely strips or
+// collapses leading underscores would silently merge them into one variable,
+// which is wrong code, worse than a reserved name.
+def private mixmul(_a, u_a : float2) : float2 {
+    return float2(_a.x * u_a.x - _a.y * u_a.y, _a.x * u_a.y + _a.y * u_a.x)
+}
+
+def private iterate_mixed(c : float2) : float2 {
+    var _z = float2(0.1, 0.1) // nolint:LINT004 the underscore spelling is the subject under test
+    var u_z = c // nolint:LINT003 must stay mutable — a const arg substitutes instead of minting the _arg_ temp
+    var n = 0
+    while (n < 8) {
+        _z = mixmul(_z, u_z) + c
+        n++
+    }
+    return float2(float(n), _z.x + u_z.x)
+}
+
+def private sample_mixed(c : float2) : float3 {
+    let nd = iterate_mixed(c)
+    if (nd.y > 4.0) {
+        return float3(nd.x * 0.1, 0.0, 0.0)
+    }
+    return float3(0.0, 0.0, 0.0)
+}
+
+[fragment_program(name="nested_mixed_fs_glsl")]
+def nested_mixed_fragment {
+    var col = float3(0.0, 0.0, 0.0)
+    for (s in range(16)) {
+        col += sample_mixed(float2(b_vcolor.x + float(s), b_vcolor.y))
+    }
+    b_frag_color = float4(col, 1.0)
+}
+
+// The emitter's own function-name uniquifier: a function colliding with a
+// struct name gets a prefix, which must never spell `__` for a `_`-spelled
+// name (it prepends `u` there instead).
+struct private _Coll {
+    v : float2
+}
+
+def private _Coll(a : float2) : float2 {
+    return a * 2.0
+}
+
+[fragment_program(name="uniquify_fs_glsl")]
+def uniquify_fragment {
+    let s = _Coll(v = float2(b_vcolor.x, b_vcolor.y))
+    b_frag_color = float4(_Coll(s.v), 0.0, 1.0)
+}
+
 def private has(hay, needle : string) : bool => find(hay, needle) >= 0
 
 [test]
@@ -192,5 +245,18 @@ def test_glsl_emission_basics(t : T?) {
         // manufactured temp itself (`_argu_a`), and the nested rename stays clean
         t |> success(has(nested_underscore_fs_glsl, "_argu_"), "a leading-underscore parameter re-encoded in its arg temp")
         t |> success(!has(nested_underscore_fs_glsl, "__"), "no reserved __ with underscore-named parameters")
+    }
+    t |> run("the underscore re-encoding is injective, not just __-free") <| @(t : T?) {
+        // `_z`/`u_z` locals and `_a`/`u_a` parameters must emit as four DISTINCT
+        // names — collapsing any pair silently merges two variables into one.
+        t |> success(has(nested_mixed_fs_glsl, "_lu_z"), "local _z re-encodes with the u mark")
+        t |> success(has(nested_mixed_fs_glsl, "_l_u_z"), "local u_z keeps the plain join")
+        t |> success(has(nested_mixed_fs_glsl, "_argu_a"), "parameter _a re-encodes in its arg temp")
+        t |> success(has(nested_mixed_fs_glsl, "_arg_u_a"), "parameter u_a keeps the plain join")
+        t |> success(!has(nested_mixed_fs_glsl, "__"), "and nothing spells the reserved __")
+    }
+    t |> run("the function-name uniquifier never spells __ on a struct collision") <| @(t : T?) {
+        t |> success(has(uniquify_fs_glsl, "u_Coll"), "the colliding _-spelled function got the u prefix")
+        t |> success(!has(uniquify_fs_glsl, "__"), "no reserved __ from the uniquifier")
     }
 }

--- a/tests/glsl/test_emission_basics.das
+++ b/tests/glsl/test_emission_basics.das
@@ -107,6 +107,40 @@ def nested_inline_fragment {
     b_frag_color = float4(col, 1.0)
 }
 
+// The other seam: a PARAMETER spelled with a leading underscore reaches the
+// manufactured `_arg_` temp name directly (`_inl<N>_arg_` + `_a`), before any
+// nesting — and then rides the rename seam too. Both joins must re-encode.
+def private mul_underscore(_a, _b : float2) : float2 {
+    return float2(_a.x * _b.x - _a.y * _b.y, _a.x * _b.y + _a.y * _b.x)
+}
+
+def private iterate_underscore(c : float2) : float2 {
+    var z = float2(0.1, 0.1)
+    var n = 0
+    while (n < 8) {
+        z = mul_underscore(z, z) + c
+        n++
+    }
+    return float2(float(n), z.x)
+}
+
+def private sample_underscore(c : float2) : float3 {
+    let nd = iterate_underscore(c)
+    if (nd.y > 4.0) {
+        return float3(nd.x * 0.1, 0.0, 0.0)
+    }
+    return float3(0.0, 0.0, 0.0)
+}
+
+[fragment_program(name="nested_underscore_fs_glsl")]
+def nested_underscore_fragment {
+    var col = float3(0.0, 0.0, 0.0)
+    for (s in range(16)) {
+        col += sample_underscore(float2(b_vcolor.x + float(s), b_vcolor.y))
+    }
+    b_frag_color = float4(col, 1.0)
+}
+
 def private has(hay, needle : string) : bool => find(hay, needle) >= 0
 
 [test]
@@ -154,5 +188,9 @@ def test_glsl_emission_basics(t : T?) {
         t |> success(has(nested_inline_fs_glsl, "_arg_"), "the inliner manufactured argument temps")
         t |> success(has(nested_inline_fs_glsl, "_lu_"), "a leading-underscore local re-encoded at the join")
         t |> success(!has(nested_inline_fs_glsl, "__"), "no reserved __ anywhere in the emitted GLSL")
+        // the _arg_ seam: a leading-underscore PARAMETER re-encodes in the
+        // manufactured temp itself (`_argu_a`), and the nested rename stays clean
+        t |> success(has(nested_underscore_fs_glsl, "_argu_"), "a leading-underscore parameter re-encoded in its arg temp")
+        t |> success(!has(nested_underscore_fs_glsl, "__"), "no reserved __ with underscore-named parameters")
     }
 }

--- a/tests/glsl/test_emission_basics.das
+++ b/tests/glsl/test_emission_basics.das
@@ -68,6 +68,45 @@ def mrt_fragment {
     mrt_g2 = float4(1.0, 0.0, 0.0, 1.0)
 }
 
+// Nested inlining must never mint a `__` identifier: GLSL ES reserves any
+// identifier containing two consecutive underscores and WebGL enforces it,
+// while desktop drivers do not — so a bad name compiles on the desktop and dies
+// only in the browser. The shape below is the mandelbrot tutorial's: a mutable
+// local passed twice into const parameters makes the inliner manufacture
+// _inl<N>_arg_* temps, and when that host function is itself inlined, those
+// temps are renamed into the outer _inl<N>_l_ namespace — a join that used to
+// spell `_inl1_l__inl0_arg_a`.
+def private cmul_nested(a, b : float2) : float2 {
+    return float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x)
+}
+
+def private iterate_nested(c : float2) : float2 {
+    var z = float2(0.0, 0.0)
+    var n = 0
+    while (n < 8) {
+        z = cmul_nested(z, z) + c
+        n++
+    }
+    return float2(float(n), z.x)
+}
+
+def private sample_nested(c : float2) : float3 {
+    let nd = iterate_nested(c)
+    if (nd.y > 4.0) {
+        return float3(nd.x * 0.1, 0.0, 0.0)
+    }
+    return float3(0.0, 0.0, 0.0)
+}
+
+[fragment_program(name="nested_inline_fs_glsl")]
+def nested_inline_fragment {
+    var col = float3(0.0, 0.0, 0.0)
+    for (s in range(16)) {
+        col += sample_nested(float2(b_vcolor.x + float(s), b_vcolor.y))
+    }
+    b_frag_color = float4(col, 1.0)
+}
+
 def private has(hay, needle : string) : bool => find(hay, needle) >= 0
 
 [test]
@@ -108,5 +147,12 @@ def test_glsl_emission_basics(t : T?) {
         t |> success(has(mrt_fs_glsl, "layout(location=2) out vec4 mrt_g2"), "MRT output 2 carries its location")
         // negative control: a single bare @out (no @location) stays unqualified
         t |> success(!has(basics_fs_glsl, "layout(location"), "single fragment output has no location qualifier")
+    }
+    t |> run("inline-manufactured temp names never contain the GLSL-reserved __") <| @(t : T?) {
+        // positive control first: the shape really did nest — the outer rename
+        // namespace and an escaped inner temp are both present in the emission.
+        t |> success(has(nested_inline_fs_glsl, "_arg_"), "the inliner manufactured argument temps")
+        t |> success(has(nested_inline_fs_glsl, "_lu_"), "a leading-underscore local re-encoded at the join")
+        t |> success(!has(nested_inline_fs_glsl, "__"), "no reserved __ anywhere in the emitted GLSL")
     }
 }

--- a/web/examples/ui/CODEREVIEW.md
+++ b/web/examples/ui/CODEREVIEW.md
@@ -1,0 +1,41 @@
+# Playground UI (web/examples/ui) Code Review Checklist
+
+Run this list on every change under this folder before it ships — including changes to this file.
+
+**What stays in this document:** criteria that can be checked against a diff. Nothing else.
+A reader must be able to apply every entry below **without reading the code and without prior
+knowledge of the module.** A rule may cite `site/README.md` for the reason behind it; it may
+not require that section to be read before the criterion can be applied. If an entry needs
+code-reading or prior knowledge, it is not a review criterion — move it to `site/README.md`
+and leave a one-line criterion here.
+
+**This file reviews itself: a rule a reviewer cannot apply as written is a defect of this
+file.** Mark it like any other finding — a checklist defect blocks nothing, but its fix (a
+rewrite or a move, never silent tolerance) lands in the same batch as the round's other fixes.
+
+**New functionality ships with tests — same PR, no follow-up promises.** A new or changed
+reachable branch ships a test that fails without it; a diff that adds a branch no test
+distinguishes is a defect. The audit procedure — including the negative control that settles
+"would it fail?" — is `skills/tdd_audit.md`.
+
+**Form, and it is a hard limit:**
+
+- **One rule is one short paragraph.** An entry that needs more than that is describing how
+  to write code, not how to review it. Split it or move it.
+- **Rules are unnumbered.** No ordinal labels and no section numbers — numbering invites
+  citation. Anything that needs a stable reference lives in `site/README.md`.
+- **Cite files by name; cite `site/README.md` by section.** Never cite an entry in this file.
+- **Name the API a rule is about; never name an example of it.** A rule governing specific
+  functions or files must name them or it cannot be checked — that name is the criterion. An
+  illustrative aside has no such excuse: nothing keeps it in sync with the code, and a stale
+  example is worse than none.
+- **One sentence of WHY is allowed where it makes the criterion decidable; anything longer
+  belongs in `site/README.md`.** No history, no PR numbers, no direction of travel; planned
+  work lives in the follow-up ledgers.
+
+---
+
+**This folder is the deployed playground's UI source — every rule of `site/CODEREVIEW.md`
+binds a change here as if the files lived under `site/playground/`.** The deploy vendors
+these files into `_site/playground/` (`pages.yml`), so `site/playground/` never shows the
+change and the walk from here is the only way that checklist fires.

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -535,8 +535,10 @@ function updateButtonStates() {
     const runnerDead = typeof PlaygroundRunner !== 'undefined'
         && PlaygroundRunner.isDead && PlaygroundRunner.isDead();
     if (runBtn) runBtn.disabled = selectedEngine() === 'wasm' ? false : !(ready || runnerDead);
-    // Test always runs interpreted, through the local runtime.
-    if (testBtn) testBtn.disabled = !ready || !hasTestAnnotation();
+    // Test always runs interpreted, through the local runtime — and on a dead
+    // page it stays clickable for the same reason Run does: the click is the
+    // revive trigger (runTests routes through the same reportNotReady).
+    if (testBtn) testBtn.disabled = !(ready || runnerDead) || !hasTestAnnotation();
 }
 // Kept under the old name so playground-tabs.js's existing autosave hook
 // still works without churn — it triggers a full refresh.

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -529,7 +529,12 @@ function updateButtonStates() {
     // instantiates the artifact itself, and its radio is only selectable once
     // the build service has answered. Gating both on the local runtime left Run
     // dead for an engine that never uses it.
-    if (runBtn) runBtn.disabled = selectedEngine() === 'wasm' ? false : !ready;
+    // A DEAD runner (gave up after repeated aborts) keeps Run clickable too:
+    // the click is what triggers the revive (see reportNotReady) — a disabled
+    // button on a dead page would make that state permanent.
+    const runnerDead = typeof PlaygroundRunner !== 'undefined'
+        && PlaygroundRunner.isDead && PlaygroundRunner.isDead();
+    if (runBtn) runBtn.disabled = selectedEngine() === 'wasm' ? false : !(ready || runnerDead);
     // Test always runs interpreted, through the local runtime.
     if (testBtn) testBtn.disabled = !ready || !hasTestAnnotation();
 }

--- a/web/examples/ui/src/main.js
+++ b/web/examples/ui/src/main.js
@@ -542,6 +542,19 @@ function selectedEngine() {
     return el ? el.value : 'interpreter';
 }
 
+// Run/Test clicked with no frame standing by. Two different truths: the frame
+// is still loading (wait), or the runtime kept aborting and the runner gave up
+// (rebuild it — PlaygroundRunner.revive — and say so). Before revive existed,
+// that second state showed the first state's message forever, on a page no
+// amount of waiting or reloading would fix.
+function reportNotReady() {
+    if (typeof PlaygroundRunner !== 'undefined' && PlaygroundRunner.revive && PlaygroundRunner.revive()) {
+        printOutput('the daslang runtime failed to start — retrying now, run again in a moment…', '#ff9393');
+    } else {
+        printOutput('daslang is still loading, please wait…', '#ff9393');
+    }
+}
+
 // (stdout flushing moved into run-frame.html, where FS now lives)
 
 runCode = async function() {
@@ -551,7 +564,7 @@ runCode = async function() {
         return;
     }
     if (!isWasmReady()) {
-        printOutput('daslang is still loading, please wait…', '#ff9393');
+        reportNotReady();
         return;
     }
     // Each run gets a fresh frame, so the previous program's canvas, GL context,
@@ -568,7 +581,7 @@ runCode = async function() {
 // keeping the run single-threaded in the WASM build.
 runTests = async function() {
     if (!isWasmReady()) {
-        printOutput('daslang is still loading, please wait…', '#ff9393');
+        reportNotReady();
         return;
     }
     syncUrlToState();


### PR DESCRIPTION
Two field failures, one arc — plus the multi-agent review round's batch (commits 4–5).

## 1. The playground OOM wedge

The reported state — `wasm streaming compile failed: InternalError: out of memory`, ArrayBuffer fallback OOM, `runtime aborted`, surviving every reload until the tab is closed — came from every run frame compiling the whole 40MB `daslang_static.wasm` for itself: one for the pre-warmed spare on load, one more per Run click, three more on the abort-retry path. Browsers budget compiled wasm machine code per PROCESS and reclaim it lazily, so a session of runs walked the process to the cliff; a reload reuses the same renderer process whose budget is still spent, so only a new tab recovered. The error spelling is SpiderMonkey's — Firefox wedges hardest (per-process wasm code ceiling).

Fix: the parent compiles the runtime ONCE and every frame instantiates that module, requested over postMessage (ack-then-deliver; a frame that never hears the ack self-compiles after a timeout, so a stale cached parent keeps working). Instances share machine code — a Run costs an instantiation with fresh memory and MEMFS, same clean-slate isolation, and the pthread pool is untouched (workers already instantiate from the module this hook hands to `receiveInstance`).

Second half: a page whose spare aborted out its budget used to be dead forever, answering "daslang is still loading, please wait…" with the Run button disabled. `PlaygroundRunner.revive()` rebuilds the spare on the next Run/Test click, `isDead()` keeps those buttons clickable in exactly that state, and the messages say what actually happened.

**The review round's batch on top** (six surfacers + adversarial prover; every fix below was negative-controlled): the ArrayBuffer compile ladder the emscripten glue always had is restored in both new paths — on a server without the wasm MIME type master warned-and-worked while the branch was a dead page; the parent's fetch takes an idle-based stall guard (30s without bytes rejects into the existing abort/revive machinery — a silent stall was a wedge the revive gate couldn't reach, on master too); aliveness has one meaning (`isDead()` ≡ initialized-and-no-spare; `reset()`/Clear grants the same fresh budget and button re-gate a revive does; revive takes a `!host` guard and an 8s cooldown so click-storming a structurally dead page can't stack 128MB-SAB × 16-worker frame bursts).

## 2. The red nightly (OpenGL mandelbrot / interpreter)

The emitted shader carried `_inl1_l__inl0_arg_a` — GLSL ES reserves any identifier containing `__` and WebGL enforces it while desktop GL does not. Trigger: the recent mutable-arg-into-const-param inliner change manufactures `_arg_` temps, and nested inlining renames them into the outer `_inl1_l_` namespace — minting `__` at the join. `joinInlineName()` (ast_inline.cpp) re-encodes leading underscores as a `u` run at both seams, injectively; `nextInlineIdIn()` still parses the outer id off the unchanged prefix.

**The round swept every other user-name seam** and found one more live `__` minter — in dasGlsl itself: the function-name uniquifier prepends bare `_` on a struct-name collision, so `struct _Coll` + `def _Coll` emitted `__Coll` (reproduced). Fixed (a `_`-spelled collision takes `u`), and the pins now cover injectivity too: `_z`/`u_z` locals and `_a`/`u_a` params must emit as FOUR distinct names — an escape that strips or collapses underscores would silently merge variables, wrong code worse than a reserved name. glslang can't gate the `__` property (warns with rc=0), so the substring pins are the right oracle.

## Tests

`tests/glsl/`: 101/101. Whole `tests/` interpreted sweep at commit 2: 13439/13442, 0 failed (3 baseline skips). Playwright suite, WASM-staged, at BOTH default and CI worker counts: **55 passed, 2 failed — the two `audio.spec.js` cells, which fail identically without this branch (negative-controlled)**. Runtime artifacts used by those runs: the deployed daslang.io build (this branch's compiler change doesn't alter the protocol surface those specs drive; the compiler leg is verified natively by `tests/glsl/` and the per-PR `wasm_build.yml` lane compiles the emscripten build). New specs, each red before its fix: shared-module (one compile per session, per-frame Resource Timing + page-level counter), version-skew self-compile, dead-page revive via the real button, compile-failure report + retry, streaming-dead → ArrayBuffer-carries-the-page. All `@wasm`-tagged; the per-PR no-WASM lane skips them.

Stated, not papered over: the multi-underscore (k greater than 1) arm of `joinInlineName` has no distinguishing test — user `__`-names are rejected by the parser (error 20116), macro-minted `__`-names never reach a GLSL context today, and outside GLSL any injective join is behaviorally equivalent. The postMessage hygiene guards are defensive and untested by choice.

## Markdown changes — flagged for review

`site/CODEREVIEW.md`: the `@wasm` tagging rule (per-test unit) and the WASM-staged-suite rule (result + artifact provenance, triggering on `web/examples/ui/` too), plus self-review fixes from its auditor. New `web/examples/ui/CODEREVIEW.md`: the standard opening + one rule delegating to `site/CODEREVIEW.md` — the deploy vendors that folder into `_site/playground/`, so the walk from there is the only way the site checklist fires for the playground UI's real source. `site/README.md` factual repairs (stale spec counts, a mobile `pageInit`-override claim nothing implements, the GH-Pages deploy line — it's VPS rsync). `site/.gitignore`'s sync instruction now points at a directory that exists.

## Deploy couplings

- The nightly's interpreter mandelbrot cell stays red until this merge rebuilds `daslang_static.wasm`.
- **The build-box toolchain roll must wait for this merge**: the current builder toolchain predates the inliner change (that is the only reason the nightly's wasm cell stayed green); rolling forward without the seam fix breaks wasm-engine shader builds too.

Preflight `--full`: 17 passed, 0 failed (commits 4–5 are the round's fix batch on top of that run; each is covered by the targeted suites above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)