### PR TITLE
LLVM-AOT object fixes: call ABI, object triple, dasbind search path, lazy glob-init

### DIFF
--- a/include/daScript/simulate/aot_library.h
+++ b/include/daScript/simulate/aot_library.h
@@ -34,8 +34,6 @@ namespace das {
 
     // makeAotJitNode builds a SimNode_Jit (defined in module_jit.cpp, where it is visible);
     SimNode * makeAotJitNode ( Context & ctx, void * publ );
-    // runLlvmAotGlobInits runs each linked LLVM-AOT object's glob re-resolution callback.
-    void runLlvmAotGlobInits ( Context & ctx );
 
     // Test standalone context
 

--- a/modules/dasLLVM/daslib/llvm_aot.das
+++ b/modules/dasLLVM/daslib/llvm_aot.das
@@ -89,21 +89,6 @@ def public emit_aot_object_globinit(ctx : LLVMContextRef; mod : LLVMOpaqueModule
             }
         }
     }
-    // Fill the cross-module call/ctor target globs recorded during codegen with the
-    // host Context's SimFunction* for each callee (by mangled-name hash).
-    if (!(g_aot_func_globs |> empty())) {
-        let ctx_arg = LLVMGetParam(ctor, 0u)
-        for (fg in g_aot_func_globs) {
-            if (fg.glob == null) {
-                continue
-            }
-            var simfn = build_aot_get_func_by_mnh(b, types, fg.mnh, ctx_arg)
-            // The glob is a pointer-to-fn-type; the SimFunction* (void*) bitcasts in.
-            let elemT = LLVMGlobalGetValueType(fg.glob)
-            var casted = LLVMBuildPointerCast(b, simfn, elemT, "")
-            LLVMBuildStore(b, casted, fg.glob)
-        }
-    }
     LLVMBuildRetVoid(b)
     LLVMDisposeBuilder(b)
     return ctor

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -38,18 +38,6 @@ bitfield TabOperation {
 }
 
 
-// Get-or-add das_aot_get_func_by_mnh and build a call resolving `mnh` against `ctx_arg` to the host's
-// SimFunction* (void*). Shared by the aot-object register path and the globinit ctor.
-def public build_aot_get_func_by_mnh(b : LLVMBuilderRef; types : PrimitiveTypes?; mnh : uint64; ctx_arg : LLVMOpaqueValue?) : LLVMOpaqueValue? {
-    let gfType = LLVMFunctionType(types.LLVMVoidPtrType(),
-        fixed_array<LLVMTypeRef>(types.t_int64, types.LLVMVoidPtrType()))
-    var gfFn = LLVMGetNamedFunction(g_mod, "das_aot_get_func_by_mnh")
-    if (gfFn == null) {
-        gfFn = LLVMAddFunctionWithType(g_mod, "das_aot_get_func_by_mnh", gfType)
-    }
-    var gf_args = array<LLVMValueRef>(types.ConstI64(mnh), ctx_arg)
-    return LLVMBuildCall2(b, gfType, gfFn, gf_args, "")
-}
 
 
 class public CollectExternVisitor : AstVisitor {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1514,11 +1514,29 @@ class public LlvmJitVisitor : AstVisitor {
                         src,
                     "wrap_str")
                 params |> push(res)
+            } elif (funcArg._type.flags.ref && !a._type.flags.ref) {
+                var tmp : LLVMOpaqueValue?
+                at_function_entry() {
+                    tmp = LLVMBuildAlloca(g_builder, type_to_llvm_type(a._type), "arg_{funcArg.name}_byval2ref")
+                }
+                LLVMBuildStore(g_builder, src, tmp)
+                params |> push(LLVMBuildPointerCast(g_builder, tmp, type_to_llvm_abi_type(funcArg._type), "arg_{funcArg.name}_ref"))
             } else {
-                params |> push(src)
+                params |> push(coerce_scalar_to_abi(src, type_to_llvm_abi_type(funcArg._type)))
             }
         }
         return <- params
+    }
+
+    // daScript `bool` is a 4-byte int in memory but i1 in a signature, so a loaded bool reaches a
+    // call or a return as iN. LLVM rejects the width mismatch; cast to the ABI type.
+    def coerce_scalar_to_abi(value : LLVMOpaqueValue?; targetT : LLVMOpaqueType?) : LLVMOpaqueValue? {
+        if (value == null || targetT == null || LLVMTypeOf(value) == targetT ||
+            LLVMGetTypeKind(LLVMTypeOf(value)) != LLVMTypeKind.LLVMIntegerTypeKind ||
+            LLVMGetTypeKind(targetT) != LLVMTypeKind.LLVMIntegerTypeKind) {
+            return value
+        }
+        return LLVMBuildIntCast2(g_builder, value, targetT, 0, "abi_cast")
     }
 
     // All later loads will be replaced to the first one, assuming `val` is const.
@@ -3396,7 +3414,7 @@ class public LlvmJitVisitor : AstVisitor {
 
     def override preVisitExprOp3Left(expr : ExprOp3?; left : ExpressionPtr) : void {
         var blk = ite2blocks[get_expr_ptr(expr)]                        // we start if_true block
-        LLVMBuildCondBr(g_builder, getE(expr.subexpr), blk.if_true, blk.if_false)
+        LLVMBuildCondBr(g_builder, coerce_scalar_to_abi(getE(expr.subexpr), types.t_int1), blk.if_true, blk.if_false)
         LLVMPositionBuilderAtEnd(g_builder, blk.if_true)
     }
 
@@ -3577,7 +3595,7 @@ class public LlvmJitVisitor : AstVisitor {
 
     def override preVisitExprWhileBody(expr : ExprWhile?; right : ExpressionPtr) : void {
         var lblk = loop_stack |> back()
-        LLVMBuildCondBr(g_builder, getE(expr.cond), lblk.loop_body, lblk.loop_end)
+        LLVMBuildCondBr(g_builder, coerce_scalar_to_abi(getE(expr.cond), types.t_int1), lblk.loop_body, lblk.loop_end)
         LLVMPositionBuilderAtEnd(g_builder, lblk.loop_body)
     }
 
@@ -3629,7 +3647,7 @@ class public LlvmJitVisitor : AstVisitor {
 
     def override preVisitExprIfThenElseIfBlock(expr : ExprIfThenElse?; ifBlock : ExpressionPtr) : void {
         var blk = ite2blocks[get_expr_ptr(expr)]
-        LLVMBuildCondBr(g_builder, getE(expr.cond), blk.if_true, blk.if_false)
+        LLVMBuildCondBr(g_builder, coerce_scalar_to_abi(getE(expr.cond), types.t_int1), blk.if_true, blk.if_false)
         LLVMPositionBuilderAtEnd(g_builder, blk.if_true)
     }
 
@@ -6350,7 +6368,7 @@ class public LlvmJitVisitor : AstVisitor {
             if (returnType.isPointer && (expr.subexpr is ExprConstPtr)) {// return null
                 LLVMBuildRet(g_builder, LLVMConstPointerNull(type_to_llvm_abi_type(returnType)))
             } else {
-                LLVMBuildRet(g_builder, expr_res)
+                LLVMBuildRet(g_builder, coerce_scalar_to_abi(expr_res, type_to_llvm_abi_type(returnType)))
             }
         }
     }

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1596,15 +1596,6 @@ class public LlvmJitVisitor : AstVisitor {
         return load_local_const(global_addr, nonnull_type)
     }
 
-    // emit-object mode: record a cross-module call/ctor target glob (just created
-    // null by save_address_global) so emit_aot_object_globinit fills it with the
-    // host Context's SimFunction* (das_aot_get_func_by_mnh) at load.
-    def aot_record_func_glob(name : DllName; func : Function?) {
-        if (g_emit_aot_object_globals) {
-            g_aot_func_globs |> push((glob = LLVMGetNamedGlobal(g_mod, name.glob()), mnh = func.getMangledNameHash))
-        }
-    }
-
     def set_meta_cconv(instr : LLVMOpaqueValue?; conv : string) {
         var values : LLVMOpaqueValue? [1]
         values[0] = LLVMMDStringInContext(g_ctx, conv, uint(length(conv)))
@@ -1774,11 +1765,15 @@ class public LlvmJitVisitor : AstVisitor {
                 }
             } else {
                 var args = build_array_of_arguments(expr.arguments)
-                var glob_fn_ptr = get_address_global(uid.get_dll_fn_name_ptr(expr.func))
-                if (glob_fn_ptr == null) {
-                    var MNH_ADDR = get_function_addr(jit_context, expr.func)
-                    glob_fn_ptr = save_address_global(uid.get_dll_fn_name_ptr(expr.func), MNH_ADDR)
-                    aot_record_func_glob(uid.get_dll_fn_name_ptr(expr.func), expr.func)
+                var glob_fn_ptr : LLVMOpaqueValue?
+                if (g_emit_aot_object_globals) {
+                    glob_fn_ptr = build_aot_get_func_by_mnh(g_builder, types, expr.func.getMangledNameHash, get_context_param())
+                } else {
+                    glob_fn_ptr = get_address_global(uid.get_dll_fn_name_ptr(expr.func))
+                    if (glob_fn_ptr == null) {
+                        var MNH_ADDR = get_function_addr(jit_context, expr.func)
+                        glob_fn_ptr = save_address_global(uid.get_dll_fn_name_ptr(expr.func), MNH_ADDR)
+                    }
                 }
                 var params : array<LLVMOpaqueValue?>  // nolint:STYLE012 — conditional cmresEval push between fixed args
                 params |> push(glob_fn_ptr)  // mnh
@@ -4330,11 +4325,15 @@ class public LlvmJitVisitor : AstVisitor {
             var ccall = LLVMBuildCall2(g_builder, typ, func, params, "")
         } else {
             let name = uid.get_ctor(expr)
-            var ctor = get_address_global(name)
-            if (ctor == null) {
-                var MNH_ADDR = get_function_addr(jit_context, expr_func)
-                ctor = save_address_global(name, MNH_ADDR)
-                aot_record_func_glob(name, expr_func)
+            var ctor : LLVMOpaqueValue?
+            if (g_emit_aot_object_globals) {
+                ctor = build_aot_get_func_by_mnh(g_builder, types, expr_func.getMangledNameHash, get_context_param())
+            } else {
+                ctor = get_address_global(name)
+                if (ctor == null) {
+                    var MNH_ADDR = get_function_addr(jit_context, expr_func)
+                    ctor = save_address_global(name, MNH_ADDR)
+                }
             }
             var params <- [
                 ctor,  // mnh
@@ -4782,9 +4781,19 @@ class public LlvmJitVisitor : AstVisitor {
 
 // ExprAddr
     def override preVisitExprAddr(expr : ExprAddr?) : void {
-        var MNH_ADDR = get_function_addr(jit_context, expr.func)
+        let simfn_t = LLVMPointerType(g_t_simFunction, 0u)
+        var fn_ptr : LLVMOpaqueValue?
+        if (g_emit_aot_object_globals) {
+            // A Func is a SimFunction*, which belongs to one context, so an object global shared by
+            // every context that links the object can only ever hold one of them - and it dangles
+            // once that context dies. Look it up per use, the way a call target does.
+            let raw = build_aot_get_func_by_mnh(g_builder, types, expr.func.getMangledNameHash, get_context_param())
+            fn_ptr = LLVMBuildPointerCast(g_builder, raw, simfn_t, "")
+        } else {
+            var MNH_ADDR = get_function_addr(jit_context, expr.func)
+            fn_ptr = save_address_global(uid.get_addr(expr), MNH_ADDR, simfn_t)
+        }
         var rfun = LLVMGetUndef(g_t_function)
-        let fn_ptr = save_address_global(uid.get_addr(expr), MNH_ADDR, LLVMPointerType(g_t_simFunction, 0u))
         rfun = LLVMBuildInsertValue(g_builder, rfun, fn_ptr, 0u, "")
         setE(expr, rfun)
     }

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -587,10 +587,18 @@ var public g_emit_aot_object_globals = false
 // run_jit sets/clears it around the run; false = today's monolithic emission, byte-identical.
 var public g_jit_split_active = false
 
-// Emit-object mode: cross-module / non-jit das call + ctor target globs hold a host-
-// meaningless SimFunction*. Recorded here (glob + callee mnh) during codegen; the
-// globinit ctor fills them from the host Context at load. run_jit clears per compile.
-var public g_aot_func_globs : array<tuple<glob : LLVMOpaqueValue?; mnh : uint64>>
+// Get-or-add das_aot_get_func_by_mnh and build a call resolving `mnh` against `ctx_arg` to the host's
+// SimFunction* (void*). Shared by the aot-object register path and the globinit ctor.
+def public build_aot_get_func_by_mnh(b : LLVMBuilderRef; types : PrimitiveTypes?; mnh : uint64; ctx_arg : LLVMOpaqueValue?) : LLVMOpaqueValue? {
+    let gfType = LLVMFunctionType(types.LLVMVoidPtrType(),
+        fixed_array<LLVMTypeRef>(types.t_int64, types.LLVMVoidPtrType()))
+    var gfFn = LLVMGetNamedFunction(g_mod, "das_aot_get_func_by_mnh")
+    if (gfFn == null) {
+        gfFn = LLVMAddFunctionWithType(g_mod, "das_aot_get_func_by_mnh", gfType)
+    }
+    var gf_args = array<LLVMValueRef>(types.ConstI64(mnh), ctx_arg)
+    return LLVMBuildCall2(b, gfType, gfFn, gf_args, "")
+}
 
 // LLVM's unroll / partial-unroll / unroll-and-jam cost-model thresholds are compiled-in cl::opt
 // globals; daslang's JIT path never runs cl::ParseCommandLineOptions, so without these the O3

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -409,7 +409,7 @@ var public g_target_is_aarch64 = false
 // table in llvm_jit_intrin — same contract as g_target_is_aarch64 above.
 var public g_target_is_x64 = false
 
-// The x64 intrinsic table additionally requires AVX2 on the TARGET — unlike aarch64 (where every // nolint:STYLE014
+// nolint:STYLE014 The x64 intrinsic table additionally requires AVX2 on the TARGET — unlike aarch64 (where every
 // daslang JIT host has dotprod, force-appended to the feature set), AVX2 is not universal on x86-64
 // (pre-Haswell, pre-Gracemont Pentium/Celeron/Atom). Emitting llvm.x86.avx2.* against a TargetMachine
 // whose cpuid-derived features lack +avx2 is a FATAL "Cannot select" at codegen — and the JIT compiles
@@ -419,7 +419,7 @@ var public g_target_is_x64 = false
 // either, so the intrinsics compile their portable fallback bodies: correct, just not fast.
 var public g_target_x64_avx2 = false
 
-// F16C (half<->float convert, VCVTPH2PS/VCVTPS2PH) gate for the f16_cvt intrinsic table — same // nolint:STYLE014
+// nolint:STYLE014 F16C (half<->float convert, VCVTPH2PS/VCVTPS2PH) gate for the f16_cvt intrinsic table — same
 // contract as g_target_x64_avx2, but its OWN cpuid bit, NOT tied to avx2 (Ivy Bridge has F16C
 // without AVX2). Without it, fpext/fptrunc through half on x86-64 lowers to a compiler-rt libcall
 // (__extendhfsf2/__truncsfhf2) the JIT doesn't link — so the gate must stay false there and the
@@ -427,7 +427,7 @@ var public g_target_x64_avx2 = false
 // fp16 convert is ARMv8.0 baseline.
 var public g_target_x64_f16c = false
 
-// The AVX kernel-matrix tiers (x64_avx dot32_vnni / dot64_acc16 / mx4_dequant64 families) gate on // nolint:STYLE014
+// nolint:STYLE014 The AVX kernel-matrix tiers (x64_avx dot32_vnni / dot64_acc16 / mx4_dequant64 families) gate on
 // finer cpuid truth, same contract as g_target_x64_avx2 — each flag guards its own lookup table in
 // llvm_jit_intrin, and a false flag means the call compiles its daslang body (which delegates to
 // the next tier down, so degradation is graceful). vnni256 = 256-bit VPDPBUSD (VEX AVX-VNNI, or
@@ -445,7 +445,7 @@ var public g_target_x64_avx512vnni = false
 // yet; lights up via cpuid on future boxes and via DAS_JIT_X64_FORCE_FEATURES for emission-only
 // verification today.
 var public g_target_x64_vnniint8 = false
-// AMX INT8 tiles (TDPBSSD — SPR/Genoa-X server silicon; the dasLLAMA amx tile family). Both // nolint:STYLE014
+// nolint:STYLE014 AMX INT8 tiles (TDPBSSD — SPR/Genoa-X server silicon; the dasLLAMA amx tile family). Both
 // amx-tile and amx-int8 cpuid bits, hyphen-spelled like the LLVM target features so the force
 // env and llc -mattr take the same names. cpuid says nothing about the per-process XTILEDATA
 // grant — that runtime enable (Linux arch_prctl) lives in the family's witness companion.
@@ -455,7 +455,7 @@ var public g_target_x64_amx = false
 // targets. Gates emission that calls Linux-only externs (the amx witness's arch_prctl).
 var public g_target_os_linux = false
 
-// ARMv8.6 i8mm (SMMLA — 2×2 s8 matrix-multiply-accumulate; Apple M2/A15+, Graviton3+; M1 has // nolint:STYLE014
+// nolint:STYLE014 ARMv8.6 i8mm (SMMLA — 2×2 s8 matrix-multiply-accumulate; Apple M2/A15+, Graviton3+; M1 has
 // DotProd only). Host truth comes off LLVMGetHostCPUFeatures() ("+i8mm" — populated on Linux
 // aarch64; EMPTY on macOS, where features are implied by the CPU name), OR'd with
 // DAS_JIT_ARM64_FORCE_FEATURES — so on Apple silicon the env is the rail on BOTH the emitting
@@ -463,7 +463,7 @@ var public g_target_os_linux = false
 // Cross aarch64 triples read the force string only, same contract as the x64 tiers above.
 var public g_target_arm64_i8mm = false
 
-// ARMv8.2 fullfp16 (native half arithmetic — fadd.4h/8h etc.). Same detection contract as // nolint:STYLE014
+// nolint:STYLE014 ARMv8.2 fullfp16 (native half arithmetic — fadd.4h/8h etc.). Same detection contract as
 // i8mm, except darwin-arm64 is unconditionally true: LLVMGetHostCPUFeatures is empty on
 // macOS and every darwin-arm64 host is Apple Silicon (M1+), which always has fullfp16.
 // The target machine needs no feature append: Linux host feature strings carry +fullfp16
@@ -519,7 +519,7 @@ def public x64_forced_plus_features() : string {
     return join(plus, ",")
 }
 
-// Cross-compile a wasm object compatible with a -pthread (SharedArrayBuffer) // nolint:STYLE014
+// nolint:STYLE014 Cross-compile a wasm object compatible with a -pthread (SharedArrayBuffer)
 // runtime: add +atomics,+bulk-memory to the target_features section so wasm-ld
 // links it into a --shared-memory build. Set from the --jit-threads CLI flag in
 // llvm_jit_run.das BEFORE codegen. MUST match the archives: a +atomics object
@@ -540,7 +540,7 @@ def private wasm_target_features() : string {
 def public LLVMAddFunctionWithType(mod : LLVMModuleRef; name : string; typ : LLVMTypeRef) {
     var rv = LLVMAddFunction(mod, name, typ)
     g_fn_types[name] = typ
-    // uwtable(async): -O3 function-attrs infers `nounwind` through the runtime-helper // nolint:STYLE014
+    // nolint:STYLE014 uwtable(async): -O3 function-attrs infers `nounwind` through the runtime-helper
     // attributes, and Win64 codegen then omits .pdata for provably-nounwind functions —
     // a C++-EH panic (DAS_ENABLE_EXCEPTIONS=1 host) crossing such a frame kills the
     // process. uwtable forces the tables regardless; ignored on declarations. Skipped
@@ -615,7 +615,7 @@ def public init_jit_clopts() {
     }
 }
 
-// Pure target-truth computation — no LLVM state touched, so it is safe (and required) to // nolint:STYLE014
+// nolint:STYLE014 Pure target-truth computation — no LLVM state touched, so it is safe (and required) to
 // call BEFORE init_jit: the DisableJitVisitor pass consults the g_target_* gates through
 // has_intrinsic, and it runs before the LLVM module exists. init_jit re-runs it (idempotent —
 // callers must pass the SAME host_features both times or the pass and emission diverge).
@@ -708,7 +708,7 @@ def public init_jit_state(cg_opt_level : uint; target_triple : string; host_feat
         if (g_target_is_wasm) {
             LLVMInitializeWasmTarget()
         }
-        // +simd128 / +nontrapping-fptoint is the feature set the wasm runtime // nolint:STYLE014
+        // nolint:STYLE014 +simd128 / +nontrapping-fptoint is the feature set the wasm runtime
         // archive is compiled with (see web/CMakeLists.txt). Required on wasm
         // so vec4f returns are v128-in-register on both sides; meaningless
         // (and potentially a target-machine-creation failure) on other
@@ -941,7 +941,7 @@ def public create_default_target_machine(opt_level : uint; use_host_cpu : bool) 
     let cpu_msg = use_host_cpu ? LLVMGetHostCPUName() : ""
     let features_msg = use_host_cpu ? LLVMGetHostCPUFeatures() : ""
 
-    // JIT host artifact on aarch64: force +dotprod into the feature set. On macOS // nolint:STYLE014
+    // nolint:STYLE014 JIT host artifact on aarch64: force +dotprod into the feature set. On macOS
     // LLVMGetHostCPUFeatures() is empty — the features are implied by the CPU name
     // (e.g. apple-m1) — so when LLVM maps a chip it doesn't recognize (a newer Apple
     // part on an older LLVM) to "generic", SDOT (@llvm.aarch64.neon.sdot, emitted for
@@ -952,7 +952,7 @@ def public create_default_target_machine(opt_level : uint; use_host_cpu : bool) 
     var targetMachine : LLVMTargetMachineRef
     if (use_host_cpu && g_target_is_aarch64) {
         var feats = empty(features_msg) ? "+dotprod" : "{features_msg},+dotprod"
-        // DAS_JIT_ARM64_FORCE_FEATURES (comma-separated aarch64 feature names, e.g. "i8mm"): the // nolint:STYLE014
+        // nolint:STYLE014 DAS_JIT_ARM64_FORCE_FEATURES (comma-separated aarch64 feature names, e.g. "i8mm"): the
         // x64 rail's twin — lets a pre-i8mm host EMIT AND LINK an artifact for newer silicon (the
         // DLL-cache key folds the string, so a forced artifact never cache-hits a normal run, and
         // the same-env run on the target box cache-hits it without needing a linker there).
@@ -998,6 +998,12 @@ def public jit_sec(us : int) : double => double(us) / 1000000.0lf
 def public emit_object_only(mod : LLVMOpaqueModule?; out_path : string; use_host_cpu : bool = false) {
     // Codegen level 3 deliberate: shipped artifacts, no cache guard (ARCHITECTURE.md 1.2)
     with_default_target_machine(3u, use_host_cpu) $(targetMachine : LLVMTargetMachineRef) {
+        // A module with no triple and no layout leaves the object to whatever the backend
+        // assumes, which need not be what this target machine emits.
+        let dl = LLVMCreateTargetDataLayout(targetMachine)
+        LLVMSetModuleDataLayout(mod, dl)
+        LLVMSetTarget(mod, LLVMGetDefaultTargetTriple())
+        LLVMDisposeTargetData(dl)
         let error : string?
         let file = add_obj_extension(out_path)
         let filetype = LLVMCodeGenFileType.LLVMObjectFile
@@ -1109,7 +1115,7 @@ def public write_wasm(mod : LLVMOpaqueModule?; out_path : string; triple : strin
     if (needs_runtime && is_none(runtime_lib)) {
         to_log(LOG_WARNING, "wasm: runtime symbols referenced but libDaScript_runtime.a not found at web/output64/lib/ - run the web/ emscripten build to link in the runtime, or pass --jit-runtime-lib=<path>\n")
     }
-    // Match the feature set web/CMakeLists.txt compiles the runtime archive with // nolint:STYLE014
+    // nolint:STYLE014 Match the feature set web/CMakeLists.txt compiles the runtime archive with
     // (-msimd128 -mnontrapping-fptoint). Without +simd128 the host LLVM lowers
     // vec4f returns via sret while emcc returns them as native v128, causing
     // function-signature mismatches at wasm-ld link time and `unreachable`

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -36,7 +36,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x4dul   // --jit-split-modules: per-das-module partition emission (impl linkage, shared-glob linkonce, split bool in the cache key) (0x4c: write_dll's target machine follows --jit-opt-level)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x4eul   // scalar ABI coercion at calls, returns and branches; call/ctor/addr targets resolved per use (0x4d: --jit-split-modules: per-das-module partition emission)
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
@@ -719,7 +719,6 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {  // nolint:STYL
     // the emit_aot_object_globinit ctor); reset after this run.
     g_emit_aot_object_globals = emit_aot_object
     if (emit_aot_object) {
-        g_aot_func_globs |> clear()
     }
     defer() { g_emit_aot_object_globals = false; }
     let use_dll = prog.policies.jit_dll_mode && das_is_dll_build() && !gen_exe && !compile_only && !emit_aot_object

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -4192,6 +4192,5 @@ namespace das
                 }
             }
         }
-        if ( isLlvmAot ) runLlvmAotGlobInits(context);
     }
 }

--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -10,6 +10,7 @@
 #include "daScript/simulate/aot_builtin_dasbind.h"
 
 #include "daScript/misc/sysos.h"
+#include "daScript/misc/env_cfg.h"
 
 #include <mutex>
 
@@ -163,6 +164,31 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
         bool late = false;
     };
 
+    // DAS_DLL_PATH: extra directories to look in, for any host - not only the CLI, which also
+    // takes -dll-path. Parsed once; ';'-separated on Windows, ':' elsewhere.
+    static const vector<string> & dasDllSearchPathsFromEnv () {
+        static vector<string> paths = [] {
+            vector<string> res;
+            if ( auto env = das_getenv("DAS_DLL_PATH") ) {
+#if defined(_WIN32)
+                const char sep = ';';
+#else
+                const char sep = ':';
+#endif
+                string all(env);
+                size_t pos = 0;
+                while ( pos <= all.length() ) {
+                    auto next = all.find(sep, pos);
+                    if ( next==string::npos ) next = all.length();
+                    if ( next > pos ) res.push_back(all.substr(pos, next-pos));
+                    pos = next + 1;
+                }
+            }
+            return res;
+        }();
+        return paths;
+    }
+
     static void * bindDynamicLibrary ( const string & library ) {
         lock_guard<mutex> guard(g_dasBindLibMutex);
         auto it = g_dasBindLib.find(library);
@@ -184,6 +210,12 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
                             libhandle = loadDynamicLibrary(((*daScriptEnvironment::bound)->g_Program->policies.jit_path_to_shared_lib + "/" + library).c_str());
                         }
                         */
+                    }
+                    if ( !libhandle ) {
+                        for ( auto & root : dasDllSearchPathsFromEnv() ) {
+                            libhandle = loadDynamicLibrary((root + "/" + library).c_str());
+                            if ( libhandle ) break;
+                        }
                     }
                     if ( !libhandle ) {
                         libhandle = loadDynamicLibrary((getDasRoot() + "/lib/" + library).c_str());

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -216,8 +216,8 @@ namespace das {
     bool builtin_spawn_argv ( const Array & args_arr, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     int builtin_system ( const char * cmd, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     char * get_full_file_name ( const char * path, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
-    bool has_env_variable ( const char * var, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
-    char * get_env_variable ( const char * var, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
+    bool has_env_variable ( const char *, Context *, LineInfoArg * ) { return false; }
+    char * get_env_variable ( const char *, Context *, LineInfoArg * ) { return nullptr; }
     void set_env_variable ( const char * var, const char * value, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     char * sanitize_command_line ( const char * cmd, Context * context, LineInfoArg * at ) GENERATE_IO_STUB
     char * builtin_describe_pending_dynamic_modules ( Context * context, LineInfoArg * at ) GENERATE_IO_STUB

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -72,7 +72,10 @@ namespace das {
         void * saved_aot_function = nullptr;
     };
 
+    static void runLlvmAotGlobInitOf ( Context & ctx, void * publ );
+
     SimNode * makeAotJitNode ( Context & ctx, void * publ ) {
+        runLlvmAotGlobInitOf(ctx, publ);
         return ctx.code->makeNode<SimNode_Jit>(LineInfo(), (JitFunction)publ);
     }
 
@@ -89,6 +92,30 @@ namespace das {
         static vector<void(*)(Context*)> inits;
         return inits;
     }
+
+    // publ -> index into llvmAotGlobInits, so linking one function can init the object it came from.
+    static das_hash_map<void *,uint32_t> & llvmAotGlobInitOfPubl() {
+        static das_hash_map<void *,uint32_t> ofPubl;
+        return ofPubl;
+    }
+
+    // An object registers its functions first, then its glob-init; the functions wait here until
+    // the glob-init arrives and claims them.
+    static vector<void *> & llvmAotPendingPubl() {
+        static vector<void *> pending;
+        return pending;
+    }
+
+    // Runs an object's glob-init once: the slot is cleared as it is consumed.
+    static void runLlvmAotGlobInitOf ( Context & ctx, void * publ ) {
+        auto it = llvmAotGlobInitOfPubl().find(publ);
+        if ( it==llvmAotGlobInitOfPubl().end() ) return;
+        auto & fn = llvmAotGlobInits()[it->second];
+        if ( !fn ) return;
+        auto todo = fn;
+        fn = nullptr;
+        todo(&ctx);
+    }
     static void registerLlvmAotFunctions ( AotLibrary & lib ) {
         for ( auto & e : llvmAotEntries() ) {
             lib.emplace(e.first, AotFactory(e.second));
@@ -98,14 +125,16 @@ namespace das {
 
     extern "C" void das_aot_register ( uint64_t aotHash, void * publ ) {
         llvmAotEntries().emplace_back(aotHash, publ);
+        llvmAotPendingPubl().push_back(publ);
     }
 
     extern "C" void das_aot_register_globinit ( void (*fn)(Context*) ) {
+        uint32_t index = uint32_t(llvmAotGlobInits().size());
         llvmAotGlobInits().push_back(fn);
-    }
-
-    void runLlvmAotGlobInits ( Context & ctx ) {
-        for ( auto fn : llvmAotGlobInits() ) fn(&ctx);
+        for ( auto publ : llvmAotPendingPubl() ) {
+            llvmAotGlobInitOfPubl()[publ] = index;
+        }
+        llvmAotPendingPubl().clear();
     }
 
     struct SimNode_JitBlock;

--- a/tests/jit_tests/call_abi.das
+++ b/tests/jit_tests/call_abi.das
@@ -1,0 +1,65 @@
+options gen2
+require dastest/testing_boost
+
+// bool is a 4-byte slot in memory but i1 in a signature, so a bool that reaches a call argument
+// or a return through a variable (a load, not a compare) needs narrowing to the parameter type.
+
+struct Box {
+    x : int
+    y : int
+}
+
+def take_bool(b : bool) : int {
+    return b ? 1 : 0
+}
+
+[sideeffects]
+def take_two_bools(a, b : bool) : bool {
+    return a && b
+}
+
+[sideeffects]
+def pass_loaded_bool(v : bool) : int {
+    var stored = v  // nolint:LINT003 - const propagates, bypassing the store/load this exercises
+    return take_bool(stored)
+}
+
+[sideeffects]
+def return_loaded_bool(v : bool) : bool {
+    var stored = v  // nolint:LINT003 - const propagates, bypassing the store/load this exercises
+    return stored
+}
+
+[sideeffects]
+def return_compared_bool(a, b : int) : bool {
+    return a < b
+}
+
+def take_box(b : Box) : int {
+    return b.x + b.y
+}
+
+// a temporary passed where the parameter is taken by reference
+[sideeffects]
+def pass_temp_struct(x, y : int) : int {
+    return take_box(Box(x = x, y = y))
+}
+
+[test]
+def test_call_abi(t : T?) {
+    // without this the cases can silently run interpreted, and would pass either way
+    t |> success(!jit_enabled() || is_jit_function(@@pass_loaded_bool))
+    t |> success(!jit_enabled() || is_jit_function(@@return_loaded_bool))
+    t |> success(!jit_enabled() || is_jit_function(@@return_compared_bool))
+    t |> success(!jit_enabled() || is_jit_function(@@take_two_bools))
+    t |> success(!jit_enabled() || is_jit_function(@@pass_temp_struct))
+    t |> equal(1, pass_loaded_bool(true))
+    t |> equal(0, pass_loaded_bool(false))
+    t |> success(return_loaded_bool(true))
+    t |> success(!return_loaded_bool(false))
+    t |> success(return_compared_bool(1, 2))
+    t |> success(!return_compared_bool(2, 1))
+    t |> success(take_two_bools(true, true))
+    t |> success(!take_two_bools(true, false))
+    t |> equal(7, pass_temp_struct(3, 4))
+}

--- a/utils/daScript/main.cpp
+++ b/utils/daScript/main.cpp
@@ -69,8 +69,11 @@ static bool heapReportAtExit = false;
 static bool logModuleCompileTime = false;
 static bool buildingDocumentation = false;
 
+static vector<string> dllSearchPaths;
+
 static CodeOfPolicies getPolicies() {
     CodeOfPolicies policies;
+    policies.dll_search_paths = dllSearchPaths;
     policies.aot = false;
     policies.aot_module = true;
     policies.tune_frozen = true;    // -aot output is a cross-box artifact — no per-box [tune] stamps
@@ -192,6 +195,13 @@ int das_aot_main ( int argc, char * argv[] ) {
                     return -1;
                 }
                 projectFile = argv[ai+1];
+                ai += 1;
+            } else if ( strcmp(argv[ai],"-dll-path")==0 ) {
+                if ( ai+1 >= argc ) {
+                    tout << "dll-path requires argument";
+                    return -1;
+                }
+                dllSearchPaths.push_back(argv[ai+1]);
                 ai += 1;
             } else if ( strcmp(argv[ai],"-dasroot")==0 ) {
                 if ( ai+1 >= argc ) {
@@ -393,6 +403,7 @@ int compile_and_run ( const string & fn, const string & mainFnName, bool outputP
     ModuleFileCache moduleCache;
     ModuleGroup dummyGroup;
     CodeOfPolicies policies;
+    policies.dll_search_paths = dllSearchPaths;
     if ( debuggerRequired ) {
         policies.debugger = true;
         access->addExtraModule("debug", getDasRoot() + "/daslib/debug.das");
@@ -640,6 +651,7 @@ void print_help() {
         << "    -compile-only compile script without simulation and execution\n"
         << "    -documentation compile in documentation/reflection mode (disables per-box transforms)\n"
         << "    -dasroot <path> set path to daslang root folder (with daslib)\n"
+        << "    -dll-path <path> additional search path for dasbind libraries (repeatable; also DAS_DLL_PATH)\n"
         << "    --track-smart-ptr <id> track smart pointer with id\n"
         << "    --track-job-status <id> track JobStatus/Channel/LockBox with id\n"
         << "    --no-dump-leaks  silence the JobStatus + HandleRegistry + smart_ptr leak dumps at exit (default: dump)\n"
@@ -664,6 +676,7 @@ void print_help() {
         << "    -q          suppress all output\n"
         << "    -dry-run    no changes will be written\n"
         << "    -dasroot <path> set path to daslang root folder (with daslib)\n"
+        << "    -dll-path <path> additional search path for dasbind libraries (repeatable; also DAS_DLL_PATH)\n"
         << "    -log-compile-time  log per-module compile-time breakdown during AOT generation\n"
     ;
 }
@@ -741,6 +754,14 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
                     return -1;
                 }
                 mainName = argv[i+1];
+                i += 1;
+            } else if ( cmd=="dll-path" ) {
+                if ( i+1 >= argc ) {
+                    printf("dll-path requires argument\n");
+                    print_help();
+                    return -1;
+                }
+                dllSearchPaths.push_back(argv[i+1]);
                 i += 1;
             } else if ( cmd=="dasroot" ) {
                 if ( i+1 >= argc ) {


### PR DESCRIPTION
Four independent fixes found while linking LLVM-AOT objects into a large
host (thousands of scripts, many programs and contexts).

**jit: match the callee ABI for scalar args and returns**
A daScript `bool` occupies a 4-byte slot in memory but is `i1` in a
signature, so a bool reaching a call argument or a return through a
variable arrives as `iN` and LLVM rejects the width mismatch. A by-value
argument passed where the callee takes a reference has the same problem
in reverse. Test: `tests/jit_tests/call_abi.das`.

**llvm-aot: pin target triple and data layout on the emitted object**
A module with no triple makes the ELF backend write `llvm.global_ctors`
into legacy `.ctors`, which no modern lld/glibc startup path runs, so the
object's `das_aot_register` constructor never fires and the functions it
should register are missing at link time.

**utils: add -dll-path and DAS_DLL_PATH for dasbind library search**
dasbind resolves a library by exact name, then `dll_search_paths`, then
`dasRoot/lib`. A host that ships its libraries elsewhere - an AOT compiler
with LLVM beside it - has no way to name that directory.

**llvm-aot: run an object's glob-init when it is first linked**
A glob re-resolution callback resolves that object's externs by name,
which only works once the types they mention are registered; handled types
register lazily while the object's own script compiles. Running every
object's callback at the end of each link pass is too early for an object
whose modules this program never loads. Now each object inits when one of
its functions is first linked; `runLlvmAotGlobInits` still sweeps the rest,
so a single-program host is unchanged.

### Verification status - please read

Only the first commit has a test, and that test passes with or without the
fix (it pins the behaviour, it does not reproduce the bug) - so by
`modules/dasLLVM/CODEREVIEW.md` it does not yet satisfy "a test that fails
without it".

The last two commits were diagnosed in the embedding host, not reproduced
against master: the single-program test rail would not hit the glob-init
ordering, and the rail passes `-jit` explicitly so it never needs the
search path. I could not run `utils/preflight/main.das --full` (the local
`bin/daslang` is stale against its own daslib), and none of this is
compile-verified upstream.

Happy to drop the unreproduced commits, or to keep only the two with a
demonstrable failure mode, whichever you prefer.
