### PR TITLE
dasAudio: push_cmd frees the command payload as soon as it is archived

### DIFF
--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -1338,6 +1338,7 @@ def public batch(cb : block) {
 
 def push_cmd(var cmd : AudioCommand) {
     var bytes <- mem_archive_save(cmd)
+    delete cmd
     if (global_batch != null) {
         *global_batch |> emplace(bytes)
     } else {


### PR DESCRIPTION
mem_archive_save copies the samples into the byte archive, so the source array in the command has no reader left. Deleting it before the archive is handed to the stream keeps the PCM buffer from being live twice at the peak of the push.