### PR TITLE
CMake: opt out of the lexer NAME-token leak dump in RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1321,10 +1321,12 @@ add_dependencies(libDaScriptDyn parser_generated)
 # (no double-override).
 target_compile_definitions(libDaScript_runtime    PUBLIC
     $<$<CONFIG:RelWithDebInfo>:DAS_TRACK_ALLOC=1>
-    $<$<CONFIG:RelWithDebInfo>:DAS_FREE_LIST=0>)
+    $<$<CONFIG:RelWithDebInfo>:DAS_FREE_LIST=0>
+    $<$<CONFIG:RelWithDebInfo>:DAS_DONT_REPORT_LEXER_LEAKS=1>)
 target_compile_definitions(libDaScriptDyn_runtime PUBLIC
     $<$<CONFIG:RelWithDebInfo>:DAS_TRACK_ALLOC=1>
-    $<$<CONFIG:RelWithDebInfo>:DAS_FREE_LIST=0>)
+    $<$<CONFIG:RelWithDebInfo>:DAS_FREE_LIST=0>
+    $<$<CONFIG:RelWithDebInfo>:DAS_DONT_REPORT_LEXER_LEAKS=1>)
 # Global new/delete override: covers STL/raw new/smart_ptr refcount blocks.
 # On Windows each module resolves operator new per-CRT, so the override TU must
 # be compiled into every binary that wants its own code covered. Uses std::malloc


### PR DESCRIPTION
RelWithDebInfo builds the two runtime targets with `DAS_TRACK_ALLOC=1` and
`DAS_FREE_LIST=0`, so every such build registers the atexit leak dump. That dump
ends with `dump_lexer_string_leaks`, whose output is the lexer's per-NAME-token
strings — a bounded compile-time retention rather than a runtime leak, as the
comment above the `#if` in `src/misc/alloc_tracker.cpp` says.

#3334 added `DAS_DONT_REPORT_LEXER_LEAKS` for exactly that, but nothing ever
defines it, so the opt-out has never taken effect. This adds it beside the two
existing RelWithDebInfo defines on `libDaScript_runtime` and
`libDaScriptDyn_runtime` — the same place the allocation tracking it gates is
switched on.

Real allocation leaks are unaffected: `dump_alloc_leaks` runs before the gate and
still drives the non-zero exit.

CMake only, so no lint/format/test gate applies to the diff; the build verdict is
CI's.
