### PR TITLE
Add a make-local variable's own offset once, where the variable is simulated

### DIFF
--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -2506,28 +2506,30 @@ namespace das
         const auto &at = expr->at;
         if ( expr->block ) {
         } else if ( expr->local ) {
+            // extraLocalOffset is part of where the variable itself sits (a fake make-local var
+            // carries its slot inside the literal there), so it belongs to the variable and is
+            // added here alone - the chain of fields and indices above it never carries it
+            uint32_t varOffset = extraOffset + expr->variable->extraLocalOffset;
             if ( expr->variable->type->ref ) {
                 if ( r2vType->baseType!=Type::none ) {
                     return context.code->makeValueNode<SimNode_GetLocalRefOffR2V>(r2vType->getR2VType(), at,
-                                                    expr->variable->stackTop, extraOffset + expr->variable->extraLocalOffset);
+                                                    expr->variable->stackTop, varOffset);
                 } else {
                     return context.code->makeNode<SimNode_GetLocalRefOff>(at,
-                                                    expr->variable->stackTop, extraOffset + expr->variable->extraLocalOffset);
+                                                    expr->variable->stackTop, varOffset);
                 }
             } else if ( expr->variable->aliasCMRES ) {
-                // extraOffset already includes the var's extraLocalOffset (passed by the caller),
-                // which for fake CMRES-alias vars carries the make-struct element slot offset.
                 if ( r2vType->baseType!=Type::none ) {
-                    return context.code->makeValueNode<SimNode_GetCMResOfsR2V>(r2vType->getR2VType(), at, extraOffset);
+                    return context.code->makeValueNode<SimNode_GetCMResOfsR2V>(r2vType->getR2VType(), at, varOffset);
                 } else {
-                    return context.code->makeNode<SimNode_GetCMResOfs>(at, extraOffset);
+                    return context.code->makeNode<SimNode_GetCMResOfs>(at, varOffset);
                 }
             } else {
                 if ( r2vType->baseType!=Type::none ) {
                     return context.code->makeValueNode<SimNode_GetLocalR2V>(r2vType->getR2VType(), at,
-                                                                            expr->variable->stackTop + extraOffset);
+                                                                            expr->variable->stackTop + varOffset);
                 } else {
-                    return context.code->makeNode<SimNode_GetLocal>(at, expr->variable->stackTop + extraOffset);
+                    return context.code->makeNode<SimNode_GetLocal>(at, expr->variable->stackTop + varOffset);
                 }
             }
         } else if ( expr->argument ) {
@@ -2587,10 +2589,10 @@ namespace das
             }
         } else if ( expr->local ) {
             if ( expr->r2v ) {
-                setE(expr, sv_trySimulate(expr, expr->variable->extraLocalOffset, expr->type));
+                setE(expr, sv_trySimulate(expr, 0, expr->type));
             } else {
                 gc_local<TypeDecl> noneType = new TypeDecl(Type::none);
-                setE(expr, sv_trySimulate(expr, expr->variable->extraLocalOffset, noneType));
+                setE(expr, sv_trySimulate(expr, 0, noneType));
             }
         } else if ( expr->argument) {
             if (expr->variable->type->isRef()) {

--- a/tests/handle_types/make_local_handled_offset.das
+++ b/tests/handle_types/make_local_handled_offset.das
@@ -1,0 +1,48 @@
+options gen2
+
+require dastest/testing_boost
+require daslib/rtti
+
+// A handled sub-object of a literal is filled through a fake variable that carries its own
+// offset inside the literal.  Where the literal writes through a reference -- assignment or
+// move into an existing local, and the inline splice that lowers to one -- that offset used
+// to be added twice, so everything but a sub-object at offset zero landed past its field.
+
+struct Outer {
+    lead : int
+    @safe_when_uninitialized at : LineInfo
+    trail : int
+}
+
+
+struct Pair {
+    lead : int
+    @safe_when_uninitialized ats : LineInfo[2]
+}
+
+
+[test]
+def test_handled_sub_object_offset(t : T?) {
+    t |> run("copy into an existing local") @(t : T?) {
+        var o = Outer()
+        o = Outer(lead = 1, at = LineInfo(line = 42u), trail = 2)
+        t |> equal(1, o.lead)
+        t |> equal(42u, o.at.line)
+        t |> equal(2, o.trail)
+    }
+    t |> run("move into an existing local") @(t : T?) {
+        var o = Outer()
+        o <- Outer(lead = 1, at = LineInfo(line = 42u), trail = 2)
+        t |> equal(42u, o.at.line)
+    }
+    t |> run("initializer") @(t : T?) {
+        let o <- Outer(lead = 1, at = LineInfo(line = 42u), trail = 2)
+        t |> equal(42u, o.at.line)
+    }
+    t |> run("array element into an existing local") @(t : T?) {
+        var p = Pair()
+        p = Pair(lead = 1, ats = fixed_array(LineInfo(line = 42u), LineInfo(line = 43u)))
+        t |> equal(42u, p.ats[0].line)
+        t |> equal(43u, p.ats[1].line)
+    }
+}


### PR DESCRIPTION
A handled sub-object of a struct literal is filled through a fake local whose
`extraLocalOffset` is its slot inside the literal. That offset belongs to the
**variable**, but `ExprVar::simulate` passed it in as `sv_trySimulate`'s
`extraOffset` — the accumulator the chain of fields and indices above the
variable builds up — and `sv_trySimulate` then added `extraLocalOffset` again on
the local paths. Every leg but `aliasCMRES` therefore counted it twice, so any
sub-object at a nonzero offset was written past its field, silently: no
diagnostic, wrong bytes.

The fix puts the offset where it belongs — added once, at the variable, in
`sv_trySimulate` — and the two `ExprVar::simulate` call sites pass `0`. The
`aliasCMRES` leg loses the comment that explained the old asymmetry and now takes
the same `varOffset` as its neighbours, so all four legs read alike. No other
caller of `sv_trySimulate` passed `extraLocalOffset`.

`tests/handle_types/make_local_handled_offset.das` pins the shape the bug needs:
a literal writing **through a reference** — assignment or move into an existing
local, and the inline splice that lowers to one — with a handled sub-object at a
nonzero offset (`LineInfo` after an `int`, and a `LineInfo[2]` array element).
The initializer case, which was always correct, is in the same test so a
regression on either path is visible.

Verified: the new test passes on a build carrying this change (5/5). The C++
verdict is CI's.
