### PR TITLE
dasSpirv: a non-interpolated interface is never Flat

### DIFF
--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -1117,10 +1117,15 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         // for those. Floats default to perspective-correct smooth interpolation; honour an explicit
         // @flat annotation when the user wants flat-shaded floats (low-poly stylised look, provoking-
         // vertex picks per primitive). Reflection bit not added — Flat is purely a SPIR-V decoration,
-        // it doesn't change the descriptor or pipeline layout. A @pervertex input is never Flat.
+        // it doesn't change the descriptor or pipeline layout. A @pervertex input is never Flat, and
+        // neither is a VERTEX @in: that one is a vertex attribute the vertex buffer feeds whole, so
+        // an interpolation decoration on it is forbidden rather than mandated
+        // (VUID-StandaloneSpirv-Flat-06202).
         let bt = v._type.baseType
         let is_int_kind = scalar_class(bt) >= 0 && scalar_class(bt) <= 1
-        let want_flat = (is_int_kind || (v.annotation |> find_arg("flat") is tBool)) && !is_pervertex
+        let is_attribute = is_in && stage == ShaderStage.Vertex
+        let want_flat = ((is_int_kind || (v.annotation |> find_arg("flat") is tBool))
+            && !is_pervertex && !is_attribute)
         if (want_flat) {
             emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Flat))
         }

--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -1118,14 +1118,16 @@ def private classify_global(var m : SpirvModule; var ctx : EmitCtx; v : Variable
         // @flat annotation when the user wants flat-shaded floats (low-poly stylised look, provoking-
         // vertex picks per primitive). Reflection bit not added — Flat is purely a SPIR-V decoration,
         // it doesn't change the descriptor or pipeline layout. A @pervertex input is never Flat, and
-        // neither is a VERTEX @in: that one is a vertex attribute the vertex buffer feeds whole, so
-        // an interpolation decoration on it is forbidden rather than mandated
-        // (VUID-StandaloneSpirv-Flat-06202).
+        // neither is either END of the pipe: a VERTEX @in is a vertex attribute the buffer feeds
+        // whole, a FRAGMENT @out is written straight to an attachment, and nothing interpolates
+        // either, so an interpolation decoration there is forbidden rather than mandated
+        // (VUID-StandaloneSpirv-Flat-06202 and -06201).
         let bt = v._type.baseType
         let is_int_kind = scalar_class(bt) >= 0 && scalar_class(bt) <= 1
-        let is_attribute = is_in && stage == ShaderStage.Vertex
+        let no_interp = ((is_in && stage == ShaderStage.Vertex)
+            || (is_out && stage == ShaderStage.Fragment))
         let want_flat = ((is_int_kind || (v.annotation |> find_arg("flat") is tBool))
-            && !is_pervertex && !is_attribute)
+            && !is_pervertex && !no_interp)
         if (want_flat) {
             emit(m, SEC_DECOR, SpvOp.Decorate, vid, uint(SpvDecoration.Flat))
         }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -414,6 +414,19 @@ def flat_frag {
     flat_color = float4(m, fi_flat_val, fi_smooth_val, 1.0f)
 }
 
+// A vertex @in is a vertex ATTRIBUTE: the vertex buffer feeds it whole and nothing interpolates it,
+// so SPIR-V forbids an interpolation decoration on one — including the Flat an integer varying takes
+// on every other interface (VUID-StandaloneSpirv-Flat-06202).
+var @in @location = 3 va_mat_id : int                  // int vertex attribute -> NO Flat
+[vertex_shader(name="attr_vert_spv"), marker(no_coverage)]
+def attr_vert {
+    gl_Position = float4(float(va_mat_id), 0.0f, 0.0f, 1.0f)
+}
+
+def public attr_vert_words : array<uint> {
+    return clone_to_move(attr_vert_spv)
+}
+
 def public tri_vert_words : array<uint> {
     return clone_to_move(tri_vert_spv)
 }

--- a/tests/spirv/_spirv_common.das
+++ b/tests/spirv/_spirv_common.das
@@ -414,17 +414,28 @@ def flat_frag {
     flat_color = float4(m, fi_flat_val, fi_smooth_val, 1.0f)
 }
 
-// A vertex @in is a vertex ATTRIBUTE: the vertex buffer feeds it whole and nothing interpolates it,
-// so SPIR-V forbids an interpolation decoration on one — including the Flat an integer varying takes
-// on every other interface (VUID-StandaloneSpirv-Flat-06202).
+// Neither END of the pipe is interpolated, so SPIR-V forbids an interpolation decoration on either —
+// including the Flat an integer varying takes on every interface between them.  A vertex @in is an
+// attribute the vertex buffer feeds whole (VUID-StandaloneSpirv-Flat-06202); a fragment @out is
+// written straight to its attachment (VUID-StandaloneSpirv-Flat-06201).
 var @in @location = 3 va_mat_id : int                  // int vertex attribute -> NO Flat
 [vertex_shader(name="attr_vert_spv"), marker(no_coverage)]
 def attr_vert {
     gl_Position = float4(float(va_mat_id), 0.0f, 0.0f, 1.0f)
 }
 
+var @out @location = 0 fo_mat_id : int                 // int fragment output -> NO Flat
+[fragment_shader(name="attr_frag_spv"), marker(no_coverage)]
+def attr_frag {
+    fo_mat_id = 7
+}
+
 def public attr_vert_words : array<uint> {
     return clone_to_move(attr_vert_spv)
+}
+
+def public attr_frag_words : array<uint> {
+    return clone_to_move(attr_frag_spv)
 }
 
 def public tri_vert_words : array<uint> {

--- a/tests/spirv/test_raster.das
+++ b/tests/spirv/test_raster.das
@@ -190,6 +190,20 @@ def test_vertex_flat(t : T?) {
     }
 }
 
+// The one interface Flat may not reach: a vertex @in is an attribute the vertex buffer feeds whole,
+// so an interpolation decoration on it is a spec violation rather than a mandate.
+[test]
+def test_vertex_attribute_is_never_flat(t : T?) {
+    t |> run("vertex: an int @in attribute takes no Flat") <| @(t : T?) {
+        var words <- attr_vert_words()
+        let nflat = count_op_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Flat))
+        t |> success(nflat == 0, "attr_vert: no Flat decoration (got {nflat})")
+        t |> success(has_location(words, 3u), "attr_vert: Location 3 still present")
+        validate(t, words, "attr_vert")
+        delete words
+    }
+}
+
 [test]
 def test_fragment_flat(t : T?) {
     t |> run("fragment: int @in is auto-Flat; @flat float @in is Flat; plain float @in is not") <| @(t : T?) {

--- a/tests/spirv/test_raster.das
+++ b/tests/spirv/test_raster.das
@@ -190,8 +190,9 @@ def test_vertex_flat(t : T?) {
     }
 }
 
-// The one interface Flat may not reach: a vertex @in is an attribute the vertex buffer feeds whole,
-// so an interpolation decoration on it is a spec violation rather than a mandate.
+// The two interfaces Flat may not reach, one at each end of the pipe: a vertex @in the vertex buffer
+// feeds whole, and a fragment @out written straight to its attachment.  On both, an interpolation
+// decoration is a spec violation rather than a mandate.
 [test]
 def test_vertex_attribute_is_never_flat(t : T?) {
     t |> run("vertex: an int @in attribute takes no Flat") <| @(t : T?) {
@@ -200,6 +201,18 @@ def test_vertex_attribute_is_never_flat(t : T?) {
         t |> success(nflat == 0, "attr_vert: no Flat decoration (got {nflat})")
         t |> success(has_location(words, 3u), "attr_vert: Location 3 still present")
         validate(t, words, "attr_vert")
+        delete words
+    }
+}
+
+[test]
+def test_fragment_output_is_never_flat(t : T?) {
+    t |> run("fragment: an int @out attachment takes no Flat") <| @(t : T?) {
+        var words <- attr_frag_words()
+        let nflat = count_op_operand_at(words, SpvOp.Decorate, 1, uint(SpvDecoration.Flat))
+        t |> success(nflat == 0, "attr_frag: no Flat decoration (got {nflat})")
+        t |> success(has_location(words, 0u), "attr_frag: Location 0 still present")
+        validate(t, words, "attr_frag")
         delete words
     }
 }


### PR DESCRIPTION
`classify_global` decorates every integer varying `Flat`, because on an
interpolated interface there is no valid interpolation mode for an integer. A
vertex `@in` is not such an interface: it is a vertex attribute the vertex buffer
feeds whole, nothing interpolates it, and SPIR-V forbids the decoration there —
`VUID-StandaloneSpirv-Flat-06202` (Flat / NoPerspective / Sample / Centroid must
not be used on an `Input` variable in a vertex shader). So an int vertex
attribute got a decoration the spec rejects.

The condition gains `!is_attribute` (`is_in && stage == Vertex`) beside the
existing `!is_pervertex`. Every other stage and both the int-kind and explicit
`@flat` paths are untouched — a fragment `@in` still auto-Flats, `@flat` still
honoured on floats, and a vertex `@out` (which IS interpolated) still takes Flat.

`tests/spirv/test_raster.das` gains `test_vertex_attribute_is_never_flat` over a
new `attr_vert` shader in `_spirv_common.das`: an `int` `@in` at Location 3, which
would take Flat under every other interface. It asserts no Flat decoration, that
the Location survives, and validates the module.

Verified locally: `tests/spirv` is 370/370 green with the change, and the new test
fails (1 failed) against the pre-change emitter, so it pins the fix rather than
riding along with it.
