### PR TITLE
Diagnostics through one sink

### DIFF
--- a/daslib/logger.das
+++ b/daslib/logger.das
@@ -39,9 +39,9 @@ module logger shared public
 //! What reaches the file is still the level filter's to decide, and
 //! ``print`` is a debug-level line: under the ``LOG_INFO`` default it is
 //! dropped rather than recorded. One install covers every Context including
-//! future ``new_thread`` workers. The runtime's own crash text is not
-//! ``print`` and no hook sees it: :func:`logger_capture_diagnostics` is
-//! what puts that beside the log.
+//! future ``new_thread`` workers. A leak dump or a fatal is not ``print``
+//! and no hook sees it: :func:`logger_capture_diagnostics` is what puts
+//! those beside the log.
 
 require daslib/json public
 require daslib/fio public
@@ -313,9 +313,9 @@ def logger_install_hook() {
 }
 
 def logger_capture_diagnostics() {
-    //! Send the runtime's own diagnostics — a panic report, a leak dump, a fatal — to
-    //! ``<log>.diag.log`` beside the log file, or to stderr when it cannot be opened.
-    //! Raw text, not ndjson, and no hook sees it: the runtime prints it, not ``print``.
+    //! Send the runtime's own diagnostics — a leak dump, a fatal, what it reports
+    //! about itself — as raw text to ``<log>.diag.log``, or to stderr when that
+    //! cannot open. Not a panic report: that is level-tagged, so the hook logs it.
     if (empty(log_path) ||
         !diagnostics_to_file(replace_extension(log_path, ".diag.log"))) {
         diagnostics_to_stderr()

--- a/daslib/logger.das
+++ b/daslib/logger.das
@@ -33,11 +33,15 @@ module logger shared public
 //! stays at the global :func:`logger_set_min_level`.
 //!
 //! :func:`logger_install_hook` plugs a GLOBAL debug agent into the runtime
-//! so accidental ``print()`` / ``to_log()`` calls are diverted into the
-//! log file instead of stdout/stderr — important for stdio-transport
-//! processes (MCP server, language servers) where any stdout write
-//! corrupts the wire format. One install covers every Context including
-//! future ``new_thread`` workers.
+//! so accidental ``print()`` / ``to_log()`` calls are diverted off
+//! stdout/stderr — important for stdio-transport processes (MCP server,
+//! language servers) where any stdout write corrupts the wire format.
+//! What reaches the file is still the level filter's to decide, and
+//! ``print`` is a debug-level line: under the ``LOG_INFO`` default it is
+//! dropped rather than recorded. One install covers every Context including
+//! future ``new_thread`` workers. The runtime's own crash text is not
+//! ``print`` and no hook sees it: :func:`logger_capture_diagnostics` is
+//! what puts that beside the log.
 
 require daslib/json public
 require daslib/fio public
@@ -306,6 +310,16 @@ def logger_install_hook() {
     //! Install a global debug agent that diverts ``print`` and ``to_log`` (from any Context, current or future) into the configured log file. Idempotent — safe to call from every module's [init], from MCP main, etc. Worker threads spawned via ``new_thread`` inherit the hook automatically; no per-context re-install needed.
     return if (has_debug_agent_context(LOGGER_AGENT_CATEGORY))
     install_new_debug_agent(new LogHookAgent(), LOGGER_AGENT_CATEGORY)
+}
+
+def logger_capture_diagnostics() {
+    //! Send the runtime's own diagnostics — a panic report, a leak dump, a fatal — to
+    //! ``<log>.diag.log`` beside the log file, or to stderr when it cannot be opened.
+    //! Raw text, not ndjson, and no hook sees it: the runtime prints it, not ``print``.
+    if (empty(log_path) ||
+        !diagnostics_to_file(replace_extension(log_path, ".diag.log"))) {
+        diagnostics_to_stderr()
+    }
 }
 
 def logger_init(name : string) {

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -193,7 +193,7 @@ get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_defau
         group_by_regex("Smart ptr infrastructure", mod, %regex~(add_ptr_ref|smart_ptr|get_const_ptr|move|move_new|get_ptr$)%%),
         group_by_regex("Macro infrastructure", mod, %regex~(is_folding|is_compiling|is_in_completion|is_in_lint_check|is_building_documentation|is_reporting_compilation_errors)%%),
         group_by_regex("Profiler", mod, %regex~(profile|reset_profiler|dump_profile_info|collect_profile_info)$%%),
-        group_by_regex("System infrastructure", mod, %regex~(panic|print|feint|sprint|sprint_json|sscan_json|to_log|to_compiler_log|error|terminate|breakpoint|stackwalk|get_stackwalk|get_das_root|get_das_version|is_in_aot|aot_enabled|is_intern_strings|is_safe_hash|eval_main_loop|shared_module_extension)$%%),
+        group_by_regex("System infrastructure", mod, %regex~(panic|print|feint|sprint|sprint_json|sscan_json|to_log|to_compiler_log|diagnostics_to_stderr|diagnostics_to_file|error|terminate|breakpoint|stackwalk|get_stackwalk|get_das_root|get_das_version|is_in_aot|aot_enabled|is_intern_strings|is_safe_hash|eval_main_loop|shared_module_extension)$%%),
         group_by_regex("Memory manipulation", mod, %regex~(intptr|memcmp|variant_index|set_variant_index|hash|hash_combine64|memcpy|lock_data|map_to_array|map_to_ro_array)$%%),
         group_by_regex("Binary serializer", mod, %regex~(binary_load|binary_save)$%%),
         group_by_regex("Path and command line", mod, %regex~(get_command_line_arguments|with_argv)$%%),
@@ -1356,7 +1356,7 @@ def document_module_logger(_root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Setup", mod, %regex~.*(logger_init|logger_init_tee|logger_set_name|logger_set_path|logger_get_path|logger_get_name)$%%),
         group_by_regex("Level filters", mod, %regex~.*(logger_set_min_level|logger_get_min_level|logger_set_category_level|logger_clear_category_levels)$%%),
-        group_by_regex("Output control", mod, %regex~.*(logger_set_stderr_fallback|logger_set_tee|logger_flush|logger_close)$%%),
+        group_by_regex("Output control", mod, %regex~.*(logger_set_stderr_fallback|logger_set_tee|logger_flush|logger_close|logger_capture_diagnostics)$%%),
         group_by_regex("Log calls", mod, %regex~.*(logger_log|logger_trace|logger_debug|logger_info|logger_warning|logger_error|logger_critical)$%%),
         group_by_regex("Stdout hook", mod, %regex~.*(logger_install_hook)$%%)
     )

--- a/doc/source/stdlib/handmade/function-builtin-diagnostics_to_file-0x29602e01a2fd278a.rst
+++ b/doc/source/stdlib/handmade/function-builtin-diagnostics_to_file-0x29602e01a2fd278a.rst
@@ -1,0 +1,1 @@
+Sends the runtime own diagnostics -- a panic report, a leak dump, a fatal -- to `path`, appending to it, and returns false without changing where they go when the file cannot be opened.

--- a/doc/source/stdlib/handmade/function-builtin-diagnostics_to_file-0x29602e01a2fd278a.rst
+++ b/doc/source/stdlib/handmade/function-builtin-diagnostics_to_file-0x29602e01a2fd278a.rst
@@ -1,1 +1,1 @@
-Sends the runtime own diagnostics -- a panic report, a leak dump, a fatal -- to `path`, appending to it, and returns false without changing where they go when the file cannot be opened.
+Sends the runtime's own diagnostics -- a leak dump, a fatal, what it reports about itself -- to `path`, appending to it, and returns false without changing where they go when the file cannot be opened. A panic report does not travel this way: it is level-tagged output, which the logger hook takes.

--- a/doc/source/stdlib/handmade/function-builtin-diagnostics_to_stderr-0xf5adeb65c7daf1eb.rst
+++ b/doc/source/stdlib/handmade/function-builtin-diagnostics_to_stderr-0xf5adeb65c7daf1eb.rst
@@ -1,0 +1,1 @@
+Sends the runtime own diagnostics -- a panic report, a leak dump, a fatal -- to standard error, for a program whose standard output carries a protocol rather than its own output.

--- a/doc/source/stdlib/handmade/function-builtin-diagnostics_to_stderr-0xf5adeb65c7daf1eb.rst
+++ b/doc/source/stdlib/handmade/function-builtin-diagnostics_to_stderr-0xf5adeb65c7daf1eb.rst
@@ -1,1 +1,1 @@
-Sends the runtime own diagnostics -- a panic report, a leak dump, a fatal -- to standard error, for a program whose standard output carries a protocol rather than its own output.
+Sends the runtime's own diagnostics -- a leak dump, a fatal, what it reports about itself -- to standard error, for a program whose standard output carries a protocol rather than its own output. A panic report does not travel this way: it is level-tagged output, which the logger hook takes.

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -304,8 +304,12 @@ __forceinline uint64_t rotr64_c(uint64_t a, uint64_t b) {
 void DAS_API os_debug_break();
 void DAS_API print_current_stack_trace();
 
+// Lands wherever setTextPrinterSink points, so a fatal report follows every
+// other diagnostic off a stdout that carries a protocol.
+void DAS_API das_fatal_log ( const char * format, ... );
+
 #ifndef DAS_FATAL_LOG
-#define DAS_FATAL_LOG(...)   do { printf(__VA_ARGS__); fflush(stdout); } while(0)
+#define DAS_FATAL_LOG(...)   das_fatal_log(__VA_ARGS__)
 #endif
 
 #ifndef DAS_FATAL_ERROR

--- a/include/daScript/misc/string_writer.h
+++ b/include/daScript/misc/string_writer.h
@@ -107,8 +107,8 @@ namespace das {
     // Where every TextPrinter lands, process-wide. It defaults to stdout, which
     // is what a program's own output is; a program whose stdout carries a
     // protocol instead (a stdio JSON-RPC server) points this elsewhere, so a
-    // panic report or a leak dump can never corrupt a frame. Set it before any
-    // thread can print.
+    // leak dump or a fatal can never corrupt a frame. Set it before any thread
+    // can print.
     typedef void ( * TextPrinterSink ) ( const char * text );
     DAS_API void setTextPrinterSink ( TextPrinterSink sink );
     DAS_API void textPrinterToStderr();

--- a/include/daScript/misc/string_writer.h
+++ b/include/daScript/misc/string_writer.h
@@ -104,6 +104,18 @@ namespace das {
         int32_t capacity = DAS_STRING_BUILDER_BUFFER_SIZE;
     };
 
+    // Where every TextPrinter lands, process-wide. It defaults to stdout, which
+    // is what a program's own output is; a program whose stdout carries a
+    // protocol instead (a stdio JSON-RPC server) points this elsewhere, so a
+    // panic report or a leak dump can never corrupt a frame. Set it before any
+    // thread can print.
+    typedef void ( * TextPrinterSink ) ( const char * text );
+    DAS_API void setTextPrinterSink ( TextPrinterSink sink );
+    DAS_API void textPrinterToStderr();
+    // Appends to a file instead, for a process whose launcher keeps no stderr
+    // either. False leaves the sink where it was: the file could not be opened.
+    DAS_API bool textPrinterToFile ( const char * path );
+
     class DAS_API TextPrinter : public TextWriter {
     public:
         TextPrinter() {}

--- a/skills/cpp_integration.md
+++ b/skills/cpp_integration.md
@@ -376,8 +376,14 @@ tp << "leaked " << count << " handles\n";
 
 `fprintf(stderr, ...)` has three concrete problems:
 
-- **No sink override** — `TextPrinter` can be subclassed/redirected;
-  `fprintf` writes wherever the OS `stderr` happens to point.
+- **No sink override** — every `TextPrinter` writes through one
+  process-wide sink (`setTextPrinterSink`, stdout by default), and so
+  does a fatal report (`DAS_FATAL_LOG`); `fprintf` writes wherever the
+  OS `stderr` happens to point.  A program whose stdout carries a
+  protocol calls `textPrinterToStderr()` (das: `diagnostics_to_stderr()`)
+  once, and every diagnostic follows — or `textPrinterToFile(path)` (das:
+  `diagnostics_to_file`; `logger_capture_diagnostics()` names the file
+  beside its own log) where the launcher keeps no stderr either.
 - **`stderr` is not available on consoles** (Switch, PlayStation, Xbox)
   — `TextPrinter` abstracts the output path so platform ports can route
   the text.

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1814,6 +1814,20 @@ namespace das
         context->to_out(at, level, text);
     }
 
+    void diagnosticsToStderr() {
+        // For a program whose stdout is a protocol rather than its own output:
+        // a panic report, a leak dump or a fatal landing there is read as a
+        // frame, and the reader is gone before anyone sees the text.
+        textPrinterToStderr();
+    }
+
+    bool diagnosticsToFile ( const char * path ) {
+        // The same, for a program whose stderr nobody keeps: a launcher that
+        // records neither stream leaves the death rattle nowhere at all, so it
+        // goes to a file the program names and its owner reads.
+        return path ? textPrinterToFile(path) : false;
+    }
+
     void toCompilerLog ( const char * text, Context * context, LineInfoArg * at ) {
         if ( daScriptEnvironment::getBound()->g_compilerLog ) {
             if ( text ) {
@@ -2784,6 +2798,10 @@ namespace das
         // logger
         addExtern<DAS_BIND_FUN(toLog)>(*this, lib, "to_log",
             SideEffects::modifyExternal, "toLog")->args({"level", "text", "context", "at"});
+        addExtern<DAS_BIND_FUN(diagnosticsToStderr)>(*this, lib, "diagnostics_to_stderr",
+            SideEffects::modifyExternal, "diagnosticsToStderr");
+        addExtern<DAS_BIND_FUN(diagnosticsToFile)>(*this, lib, "diagnostics_to_file",
+            SideEffects::modifyExternal, "diagnosticsToFile")->args({"path"});
         addExtern<DAS_BIND_FUN(toCompilerLog)>(*this, lib, "to_compiler_log",
             SideEffects::modifyExternal, "toCompilerLog")->args({"text","context","at"});
         // log levels

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1816,8 +1816,8 @@ namespace das
 
     void diagnosticsToStderr() {
         // For a program whose stdout is a protocol rather than its own output:
-        // a panic report, a leak dump or a fatal landing there is read as a
-        // frame, and the reader is gone before anyone sees the text.
+        // a leak dump or a fatal landing there is read as a frame, and the
+        // reader is gone before anyone sees the text.
         textPrinterToStderr();
     }
 

--- a/src/misc/string_writer.cpp
+++ b/src/misc/string_writer.cpp
@@ -205,7 +205,16 @@ namespace das {
     static TextPrinterSink g_textPrinterSink = &textPrinterToStdout;
 
     void setTextPrinterSink ( TextPrinterSink sink ) {
-        g_textPrinterSink = sink ? sink : &textPrinterToStdout;
+        auto newSink = sink ? sink : &textPrinterToStdout;
+        // the file is closed exactly when it stops BEING the sink, on the same
+        // contract the sink itself rests on: nothing prints while it is being set,
+        // which is the one moment closing it is safe.  A handle left open holds the
+        // file against deletion on Windows, where fopen does not share delete
+        if ( newSink!=&textPrinterToFileSink && g_textPrinterFile ) {
+            fclose(g_textPrinterFile);
+            g_textPrinterFile = nullptr;
+        }
+        g_textPrinterSink = newSink;
     }
 
     void textPrinterToStderr() {
@@ -217,10 +226,9 @@ namespace das {
         if ( !f ) return false;
         FILE * was = g_textPrinterFile;
         g_textPrinterFile = f;
+        // the sink does not change kind here, so setting it closes nothing: the
+        // file it replaces is closed right after, on the same being-set contract
         setTextPrinterSink(&textPrinterToFileSink);
-        // Closing the one it replaces is safe on the same contract the sink
-        // itself rests on: nothing prints while it is being set. The file is
-        // never closed after that -- a fatal fires during shutdown too.
         if ( was ) fclose(was);
         return true;
     }

--- a/src/misc/string_writer.cpp
+++ b/src/misc/string_writer.cpp
@@ -2,6 +2,8 @@
 #include "daScript/misc/string_writer.h"
 #include "misc/include_fmt.h"
 
+#include <stdarg.h>
+
 namespace das {
     DAS_API StringWriterTag HEX;
     DAS_API StringWriterTag DEC;
@@ -183,13 +185,52 @@ namespace das {
 
     // TextPrinter
 
+    static void textPrinterToStdout ( const char * text ) {
+        printf("%s", text);
+        fflush(stdout);
+    }
+
+    static void textPrinterToStderrSink ( const char * text ) {
+        fprintf(stderr, "%s", text);
+        fflush(stderr);
+    }
+
+    static FILE * g_textPrinterFile = nullptr;
+
+    static void textPrinterToFileSink ( const char * text ) {
+        fprintf(g_textPrinterFile, "%s", text);
+        fflush(g_textPrinterFile);
+    }
+
+    static TextPrinterSink g_textPrinterSink = &textPrinterToStdout;
+
+    void setTextPrinterSink ( TextPrinterSink sink ) {
+        g_textPrinterSink = sink ? sink : &textPrinterToStdout;
+    }
+
+    void textPrinterToStderr() {
+        setTextPrinterSink(&textPrinterToStderrSink);
+    }
+
+    bool textPrinterToFile ( const char * path ) {
+        FILE * f = fopen(path, "ab");
+        if ( !f ) return false;
+        FILE * was = g_textPrinterFile;
+        g_textPrinterFile = f;
+        setTextPrinterSink(&textPrinterToFileSink);
+        // Closing the one it replaces is safe on the same contract the sink
+        // itself rests on: nothing prints while it is being set. The file is
+        // never closed after that -- a fatal fires during shutdown too.
+        if ( was ) fclose(was);
+        return true;
+    }
+
     void TextPrinter::output() {
         lock_guard<mutex> guard(pmut);
         uint64_t newPos = tellp();
         if (newPos != pos) {
             string st(data() + pos, size_t(newPos - pos));
-            printf("%s", st.c_str());
-            fflush(stdout);
+            g_textPrinterSink(st.c_str());
             pos = newPos;
         }
     }
@@ -216,4 +257,18 @@ namespace das {
             pos = newPos = 0;
         }
     }
+}
+
+// The sink directly, not a TextPrinter: this fires from the allocator and the
+// smart-pointer guard, so it may not allocate, and it may not take the
+// printer's lock -- the fatal it is reporting can be a crash that already
+// holds it.
+void das_fatal_log ( const char * format, ... ) {
+    char buf[2048];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    buf[sizeof(buf) - 1] = 0;
+    das::g_textPrinterSink(buf);
 }

--- a/tests-cpp/small/test_text_printer_sink.cpp
+++ b/tests-cpp/small/test_text_printer_sink.cpp
@@ -1,0 +1,42 @@
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+
+using namespace das;
+
+namespace {
+
+    string g_sunk;
+
+    void sink_to_string ( const char * text ) {
+        g_sunk += text;
+    }
+
+    // the sink is process-wide, so a case that left it installed would send the
+    // rest of the suite's diagnostics into a dead string
+    struct SinkGuard {
+        SinkGuard() { g_sunk.clear(); setTextPrinterSink(&sink_to_string); }
+        ~SinkGuard() { setTextPrinterSink(nullptr); }
+    };
+}
+
+TEST_CASE("the text printer sink takes every diagnostic the runtime writes") {
+    SinkGuard guard;
+
+    SUBCASE("a TextPrinter writes through the sink instead of stdout") {
+        TextPrinter tp;
+        tp << "sunk " << 42 << "\n";
+        CHECK_EQ(g_sunk, "sunk 42\n");
+    }
+
+    SUBCASE("a fatal report goes the same way, formatted") {
+        das_fatal_log("fatal %s %d\n", "here", 7);
+        CHECK_EQ(g_sunk, "fatal here 7\n");
+    }
+
+    SUBCASE("an unopenable file leaves the sink where it was") {
+        CHECK_FALSE(textPrinterToFile("/no/such/directory/diagnostics.log"));
+        TextPrinter tp;
+        tp << "still sunk\n";
+        CHECK_EQ(g_sunk, "still sunk\n");
+    }
+}

--- a/tests/fio/diagnostics_sink.das
+++ b/tests/fio/diagnostics_sink.das
@@ -1,0 +1,28 @@
+options gen2
+
+require dastest/testing_boost
+require daslib/fio
+
+// `diagnostics_to_file` points the process-wide diagnostics sink at a file, so a
+// program whose stdout carries a protocol and whose launcher keeps no stderr still
+// has somewhere to leave a leak dump or a fatal. It is fail-closed: a path it
+// cannot open returns false and leaves the sink where it was.
+
+[test]
+def test_diagnostics_to_file(t : T?) {
+    t |> run("a path that cannot be opened is refused") @(t : T?) {
+        t |> success(!diagnostics_to_file("/no/such/directory/diagnostics.log"))
+    }
+    t |> run("a writable path is taken") @(t : T?) {
+        var terr = ""
+        let root = create_temp_directory("das_diag_", terr)
+        t |> success(!empty(root), "temp dir created: {terr}")
+        if (!empty(root)) {
+            t |> success(diagnostics_to_file(path_join(root, "diag.log")))
+            // the sink outlives this test and never closes the file it holds, so
+            // leave it on stderr rather than inside a directory about to go
+            diagnostics_to_stderr()
+            rmdir_rec(root)
+        }
+    }
+}

--- a/tests/fio/diagnostics_sink.das
+++ b/tests/fio/diagnostics_sink.das
@@ -19,10 +19,10 @@ def test_diagnostics_to_file(t : T?) {
         t |> success(!empty(root), "temp dir created: {terr}")
         if (!empty(root)) {
             t |> success(diagnostics_to_file(path_join(root, "diag.log")))
-            // the sink outlives this test and never closes the file it holds, so
-            // leave it on stderr rather than inside a directory about to go
+            // moving the sink off the file closes it, and a removal that succeeds
+            // is the proof: on Windows an open handle holds a file against deletion
             diagnostics_to_stderr()
-            rmdir_rec(root)
+            t |> success(rmdir_rec(root), "the sink held its file open")
         }
     }
 }

--- a/utils/mcp/mcp_core.das
+++ b/utils/mcp/mcp_core.das
@@ -545,6 +545,12 @@ def dispatch_jsonrpc(server : McpServer; reg : array<ToolDef>; body : string) : 
 // owns logger_init + ast-grep detection + registry assembly, then calls this.
 
 def serve_stdio(server : McpServer; reg : array<ToolDef>) {
+    // From here stdout carries frames and nothing else: a panic report, a leak
+    // dump or a fatal landing between them is read as a frame, and the client
+    // drops the connection mid-call rather than showing the text.  It goes to
+    // the log's own directory rather than to stderr because a client keeps no
+    // record of that stream, which leaves a death rattle nowhere.
+    logger_capture_diagnostics()
     let sin = fstdin()
     let sout = fstdout()
     while (!feof(sin)) {

--- a/utils/mcp/mcp_core.das
+++ b/utils/mcp/mcp_core.das
@@ -545,11 +545,11 @@ def dispatch_jsonrpc(server : McpServer; reg : array<ToolDef>; body : string) : 
 // owns logger_init + ast-grep detection + registry assembly, then calls this.
 
 def serve_stdio(server : McpServer; reg : array<ToolDef>) {
-    // From here stdout carries frames and nothing else: a panic report, a leak
-    // dump or a fatal landing between them is read as a frame, and the client
-    // drops the connection mid-call rather than showing the text.  It goes to
-    // the log's own directory rather than to stderr because a client keeps no
-    // record of that stream, which leaves a death rattle nowhere.
+    // From here stdout carries frames and nothing else: a leak dump or a fatal
+    // landing between them is read as a frame, and the client drops the
+    // connection mid-call rather than showing the text.  It goes to the log's
+    // own directory rather than to stderr because a client keeps no record of
+    // that stream, which leaves a death rattle nowhere.
     logger_capture_diagnostics()
     let sin = fstdin()
     let sout = fstdout()


### PR DESCRIPTION
A `TextPrinter` writes to stdout, and so does `DAS_FATAL_LOG` — by its own
`printf`. For a program whose stdout carries a protocol rather than its own
output (a stdio JSON-RPC server: the MCP server, a language server), a leak dump
or a fatal landing there is read as a frame, and the client drops the connection
before anyone sees the text. There was no one place to point that at.

**The sink.** `setTextPrinterSink` is where every `TextPrinter` lands,
process-wide, stdout by default. `textPrinterToStderr()` and
`textPrinterToFile(path)` are the two moves a protocol-carrying program wants;
the file form appends, and returns false without changing the sink when it
cannot open. `DAS_FATAL_LOG` becomes `das_fatal_log`, which writes the same sink
directly — not through a `TextPrinter`, because it fires from the allocator and
the smart-pointer guard, so it may not allocate and may not take the printer's
lock (the fatal it reports can be a crash already holding it).

**What it carries — and what it does not.** Leak dumps (jobque, JobStatus,
smart-ptr tracking), fatals, the JIT's diagnostics, the `exit(N)` notice: the
text the runtime writes *about itself*. **Not** a panic report — that goes out
through `to_err` → `Context::to_out` → the `das_to_stdout_level_prefix_text`
macro, so it never touches `TextPrinter`, and under `logger_install_hook` it
lands in the log like any other level-tagged line. Script `print()` is likewise
untouched.

**The das side.** `diagnostics_to_stderr()` / `diagnostics_to_file(path)` bind
the two sink moves, and `logger_capture_diagnostics()` in `daslib/logger` names
the file for you — `<log>.diag.log` beside the log, stderr if it cannot be
opened. Raw text, not ndjson, and no hook sees it: the runtime prints it, not
`print`. `serve_stdio` calls it before the first frame, which is the point of
the change.

`doc/reflections/das2rst.das` gains the two builtins and
`logger_capture_diagnostics` in existing groups, and both new builtins carry a
handmade description, so the doc job stays quiet.

**Tests.** `tests-cpp/small/test_text_printer_sink.cpp` installs a capturing sink
and pins three branches: `TextPrinter` routing, `das_fatal_log` formatting, and
the fail-closed `textPrinterToFile` (returns false, sink unchanged — proved by
writing again afterwards). `tests/fio/diagnostics_sink.das` pins the das binding
both ways. Default behaviour is unchanged everywhere: the sink starts at stdout,
and a program that never calls these keeps exactly the output it has now.

---

**The lint lane is red on `utils/mcp/mcp_core.das`, and this branch did not cause
it.** `extended_checks` lints every changed `.das` whole, and that file already
carries `PERF030` (the `extra_list` move) and `STYLE037` (complexity 22 on
`handle_tools_call`) at master's tip. The file was last touched 2026-07-20;
`STYLE037`'s limit dropped to 20 on 07-29 and `PERF030` landed on 08-01, so both
postdate it. This branch's own hunk there is the single
`logger_capture_diagnostics()` call and introduces neither. Say the word and I
will fix either here: `PERF030` is a one-line fold of the move into its
declaration (probed: lint-clean, behaviour identical), and `STYLE037` on that
flat argument-extraction shape is what `skills/style_lint.md` says to suppress
with a reason rather than split.
