### PR TITLE
ast_verify: guess a location for a node whose `at` is unset

### DIFF
--- a/daslib/ast_verify.das
+++ b/daslib/ast_verify.das
@@ -182,7 +182,9 @@ class private AstVerifyVisitor : AstVisitor {
 
     def report(at : LineInfo; msg : string) : void {
         error_count++
-        to_log(LOG_ERROR, "AST verify: {msg} at {describe(at)}\n")
+        // a detached synthetic tree has no location in it at all - do not trail an empty " at "
+        let loc = describe(at)
+        to_log(LOG_ERROR, empty(loc) ? "AST verify: {msg}\n" : "AST verify: {msg} at {loc}\n")
         compiling_program() |> macro_error(at, "AST verify: {msg}")
     }
 
@@ -911,17 +913,90 @@ def public verify_program(prog : ProgramPtr) : int {
     return total
 }
 
+// `node` set means it carries its own `at` and names itself, so the walk stores one pointer per
+// node; otherwise `at` and `phrase` are it. Not an Option<T> - LineInfo is no tuple element.
+struct private Anchor {
+    @do_not_delete node : Expression?
+    @safe_when_uninitialized at : LineInfo
+    phrase : string
+}
+
+// Runs for every node the walk touches - keep it a null test; `usable` does the rest, rarely.
+def private located(e : Expression?) : bool {
+    return e != null && e.at.fileInfo != null
+}
+
+def private usable(e : Expression?) : bool {
+    return located(e) && !is_cpp_binding_at(e.at)
+}
+
+// Runs only for a node that turns out to have no `at`, so a well formed tree pays nothing. The two
+// gates match AstPostInferVerifyVisitor: a location from a region that walk refuses to enter belongs
+// to a spelling that is not part of this instantiation, and need_at stamps what it is given.
+class private FirstLocatedVisitor : AstVisitor {
+    @do_not_delete found : Expression?
+    def override preVisitExpression(var expr : ExpressionPtr) : void {
+        if (found == null && usable(expr)) {
+            found = expr
+        }
+    }
+    def override canVisitWithAliasSubexpression(_expr : ExprAssume?) : bool {
+        return false
+    }
+    def override canVisitStructureFieldInit(st : StructurePtr) : bool {
+        return !st.flags.isTemplate
+    }
+}
+
+def private first_located_inside(var expr : ExpressionPtr) : Expression? {
+    var v = new FirstLocatedVisitor()
+    make_visitor(*v) $(adapter) {
+        visit(expr, adapter)
+    }
+    var found = v.found
+    unsafe {
+        delete v
+    }
+    return found
+}
+
 // ===== post-inference verification =====
 class private AstPostInferVerifyVisitor : AstVisitor {
     error_count : int = 0
     @do_not_delete current_fn : Function?
     closure_depth : int = 0
+    // the last located thing the walk passed - a node, or a site with no expression around it
+    @safe_when_uninitialized last_passed : Anchor
 
 
     def report(at : LineInfo; msg : string) : void {
         error_count++
-        to_log(LOG_ERROR, "AST verify (post-infer): {msg} at {describe(at)}\n")
-        compiling_program() |> macro_error(at, "AST verify (post-infer): {msg}")
+        var text = msg
+        var anchor = at
+        if (at.fileInfo == null) {
+            let guess = guess_at(null)
+            anchor = guess.at
+            if (!empty(guess.phrase)) {
+                text = "{msg}; {guess.phrase}"
+            }
+        }
+        let loc = describe(anchor)
+        to_log(LOG_ERROR, empty(loc)
+            ? "AST verify (post-infer): {text}\n"
+            : "AST verify (post-infer): {text} at {loc}\n")
+        compiling_program() |> macro_error(anchor, "AST verify (post-infer): {text}")
+    }
+
+    // Subtree first: a node begins where its subtree begins, which is the exact line for 91% of
+    // nodes against 8% for the function head. What the walk passed last covers a synthetic subtree.
+    def guess_at(var expr : ExpressionPtr) : Anchor {
+        var inside = expr != null ? first_located_inside(expr) : null
+        if (inside != null) {
+            return Anchor(at = inside.at, phrase = "first located node inside it is {inside.__rtti}")
+        }
+        let passed = usable(last_passed.node) ? last_passed.node : null
+        return Anchor(at = passed != null ? passed.at : last_passed.at,
+            phrase = passed != null ? "preceded by {passed.__rtti}" : last_passed.phrase)
     }
 
     // A template body is expanded per instantiation and a stub body (dasbind [extern]) is
@@ -933,6 +1008,8 @@ class private AstPostInferVerifyVisitor : AstVisitor {
 
     def override preVisitFunction(var fun : FunctionPtr) : void {
         current_fn = fun
+        // walk state from the previously walked function is no vicinity for this one
+        last_passed = Anchor()
         need_at(fun.at, "function '{fun.name}'")
         need_slot(fun.result, "function '{fun.name}' result type", fun.at)
         if (fun.body == null) {
@@ -959,14 +1036,15 @@ class private AstPostInferVerifyVisitor : AstVisitor {
         return !st.flags.isTemplate
     }
 
-    // Inference is done, so an operand with no type never got one, and lint / folding /
-    // codegen all dereference it unguarded.
+    // Inference is done, so an operand with no type never got one, and lint / folding / codegen all
+    // dereference it unguarded. An empty `what` names it after the node, only if it reports.
     def need_typed(var slot : ExpressionPtr; what : string; at : LineInfo) : void {
         // a statement is not a value - inference never gives it a type
         if (slot == null || slot._type != null || slot.genFlags.generated || is_stmt_node(slot)) {
             return
         }
-        report(at, "{what} ({slot.__rtti}) has no type after inference")
+        let named = empty(what) ? "{slot.__rtti}" : what
+        report(at, "{named} ({slot.__rtti}) has no type after inference")
         slot._type = new TypeDecl(at = at, baseType = Type.tInt)
     }
 
@@ -978,33 +1056,43 @@ class private AstPostInferVerifyVisitor : AstVisitor {
         report(at, "{what} has an unresolved func after inference")
     }
 
-    // A node with no location makes every later diagnostic over it point at nothing. No
-    // kind is exempt: a value from a C++ binding gets the call site stamped by infer.
-    def need_at(var at : LineInfo&; what : string) : void {
+    // A node with no location makes every later diagnostic over it point at nothing. No kind is
+    // exempt: a value from a C++ binding gets the call site stamped by infer. The guess is stamped
+    // in, so the passes after this one have a place too.
+    def need_at(var at : LineInfo&; what : string; var expr : ExpressionPtr = null; track : bool = true) : void {
         if (at.fileInfo != null) {
+            if (track && !is_cpp_binding_at(at)) {
+                // a site has no node to name it, and clears the one the walk last stored
+                last_passed = Anchor(at = at, phrase = "closest location the walk passed is {what}")
+            }
             return
         }
-        // the node has no location, so the report is anchored to the enclosing function
         let ctx = current_fn != null ? " in '{current_fn.name}'" : ""
-        let anchor = current_fn != null && current_fn.at.fileInfo != null ? current_fn.at : at
-        report(anchor, "{what} has no source location (at is unset){ctx}")
-        if (current_fn != null && current_fn.at.fileInfo != null) {
-            at = current_fn.at
+        let guess = guess_at(expr)
+        let tail = empty(guess.phrase) ? guess.phrase : "; {guess.phrase}"
+        report(guess.at, "{what} has no source location (at is unset){ctx}{tail}")
+        if (guess.at.fileInfo != null) {
+            at = guess.at
         }
     }
 
-    // TypeDecl::visit preVisits firstType / secondType / argTypes, so one hook covers the tree
+    // TypeDecl::visit preVisits firstType / secondType / argTypes, so one hook covers the tree. Not
+    // tracked: a type's `at` is its declaration site, often another module, not this use.
     def need_type_at(var typ : TypeDeclPtr; what : string) : void {
         if (typ != null) {
-            need_at(typ.at, "{what} {describe(typ)}")
+            need_at(typ.at, "{what} {describe(typ)}", track = false)
         }
     }
 
+    // `expr` is never null - Expression::visit hands its own `this` to every hook. Stamping the
+    // guess is also what keeps ExprConst, pre-visited twice for one node, from reporting twice.
     def override preVisitExpression(var expr : ExpressionPtr) : void {
-        if (expr != null) {
-            need_at(expr.at, "{expr.__rtti}")
-            need_typed(expr, "{expr.__rtti}", expr.at)
+        if (located(expr)) {
+            last_passed.node = expr
+        } else {
+            need_at(expr.at, "{expr.__rtti}", expr)
         }
+        need_typed(expr, "", expr.at)
     }
 
     // Inference is done, so a null in a slot codegen dereferences is never filled in later.

--- a/utils/ast-fuzz/selftest/at_unset.das
+++ b/utils/ast-fuzz/selftest/at_unset.das
@@ -1,0 +1,38 @@
+options gen2
+require at_unset_breaker
+
+// One function per guess the verify has to make for a node with no `at`; at_unset_breaker.das clears
+// the locations. Operands are arguments so `a + b` survives folding - the breaker needs a live op.
+
+// the subtree still has locations: the guess comes from inside it
+def lost_one(a, b : int) : int {
+    return a + b
+}
+
+// nothing located inside, and in pre-order the enclosing return is the node passed last
+def deep_add(a, b : int) : int {
+    return a + b
+}
+
+// nothing located in the body at all: what is left is the argument the walk came in through
+def all_gone(a : int) : int {
+    return a
+}
+
+// and with no argument either, the function itself
+def no_args : int {
+    return 5
+}
+
+// an `assume` alias is substituted at its use sites and never inferred, so the verify refuses to
+// walk into it - and so must the search for a location, or it anchors at a spelling nobody ran
+def with_assume(a : int) : int {
+    assume alias = a + 111
+    return alias * 2
+}
+
+[export]
+def main {
+    var x = 2 // nolint:LINT003
+    print("{lost_one(x, 3)} {deep_add(x, 3)} {all_gone(x)} {no_args()} {with_assume(x)}\n")
+}

--- a/utils/ast-fuzz/selftest/at_unset_breaker.das
+++ b/utils/ast-fuzz/selftest/at_unset_breaker.das
@@ -1,0 +1,85 @@
+options gen2
+
+module at_unset_breaker shared
+
+// Self-test fixture: a deliberately buggy pass macro that clears `at`, the invariant every node is
+// supposed to carry, so the post-infer verify has to guess a location. One mode per shape.
+
+require daslib/ast
+require daslib/ast_boost
+
+enum private Mode {
+    off
+    one_node   // a single ExprOp2 loses its `at`, its operands keep theirs
+    subtree    // the whole `a + b` subtree loses its `at`
+    whole_body // nothing in the body keeps a location
+    assume_in  // the body block and the ExprAssume lose theirs, the alias expression keeps its
+}
+
+class Breaker : AstVisitor {
+    mode : Mode = Mode.off
+    strip : bool = false
+
+    def override preVisitFunction(var fun : FunctionPtr) : void {
+        mode = Mode.off
+        if (fun.name == "lost_one") {
+            mode = Mode.one_node
+        } elif (fun.name == "deep_add") {
+            mode = Mode.subtree
+        } elif (fun.name == "all_gone" || fun.name == "no_args") {
+            mode = Mode.whole_body
+        } elif (fun.name == "with_assume") {
+            mode = Mode.assume_in
+        }
+        strip = false
+    }
+
+    def override preVisitExpression(var expr : ExpressionPtr) : void {
+        if (mode == Mode.whole_body || (mode == Mode.subtree && strip)) {
+            expr.at = LineInfo()
+        }
+    }
+
+    def override preVisitExprBlock(var expr : ExprBlock?) : void {
+        if (mode == Mode.assume_in && !expr.blockFlags.isClosure) {
+            expr.at = LineInfo()
+        }
+    }
+
+    def override preVisitExprAssume(var expr : ExprAssume?) : void {
+        if (mode == Mode.assume_in) {
+            expr.at = LineInfo()
+        }
+    }
+
+    def override preVisitExprOp2(var _expr : ExprOp2?) : void {
+        if (mode == Mode.subtree) {
+            strip = true
+        }
+    }
+
+    def override visitExprOp2(var expr : ExprOp2?) : ExpressionPtr {
+        if (mode == Mode.one_node || (mode == Mode.subtree && strip)) {
+            expr.at = LineInfo()
+            strip = false
+        }
+        return expr
+    }
+}
+
+[infer_macro]
+class BreakMacro : AstPassMacro {
+    def override apply(prog : ProgramPtr; mod : Module?) : bool {
+        if (mod == null || !empty(mod.name)) {
+            return false
+        }
+        var v = new Breaker()
+        make_visitor(*v) $(adapter) {
+            visit_module(prog, adapter, mod)
+        }
+        unsafe {
+            delete v
+        }
+        return false
+    }
+}

--- a/utils/ast-fuzz/test_ast_fuzz.das
+++ b/utils/ast-fuzz/test_ast_fuzz.das
@@ -59,6 +59,34 @@ def test_verifier_reports_an_aliased_expression_type(t : T?) {
     t |> success(!died(ec, out), "compile crashed (exit {ec})\n{out}")
     t |> success(find(out, "TypeDecl int (ExprConstInt.type) is aliased") >= 0,
         "did not report the aliased expression type\n{out}")
+    // nothing in a detached synthetic tree is located, so the report carries no location - and
+    // must not trail an empty " at " either
+    t |> success(find(out, "(missing clone) at") < 0, "trailing empty location\n{out}")
+}
+
+// A node with no `at` is anchored by the verify itself, tier by tier: its own subtree first, then
+// the node the walk passed last (in pre-order the enclosing one, for a first child), then the last
+// located non-expression site. One function per tier in at_unset.das.
+[test]
+def test_ast_verify_guesses_a_location_for_an_unset_at(t : T?) {
+    var out : string
+    let f = "utils/ast-fuzz/selftest/at_unset.das"
+    let ec = run([BIN, "--ast-verify", f], out, 60.0)
+    t |> success(!died(ec, out), "compile crashed (exit {ec})\n{out}")
+    t |> success(find(out, "ExprOp2 has no source location (at is unset) in 'lost_one'") >= 0,
+        "did not report the unset at\n{out}")
+    t |> success(find(out, "in 'lost_one'; first located node inside it is ExprRef2Value at {f}:9:11") >= 0,
+        "did not anchor inside the subtree, on the operand\n{out}")
+    t |> success(find(out, "in 'deep_add'; preceded by ExprReturn at {f}:14:4") >= 0,
+        "an unlocated subtree did not anchor to the node enclosing it\n{out}")
+    t |> success(find(out, "in 'all_gone'; closest location the walk passed is function 'all_gone' argument 'a' at {f}:18:") >= 0,
+        "a fully unlocated body did not fall back to the argument\n{out}")
+    t |> success(find(out, "in 'no_args'; closest location the walk passed is function 'no_args' at {f}:23:") >= 0,
+        "a fully unlocated body with no argument did not fall back to the function\n{out}")
+    // the alias expression on line 30 is located, but it is never inferred and never runs, so the
+    // search has to skip it exactly as the verify walk does
+    t |> success(find(out, "in 'with_assume'; first located node inside it is ExprReturn at {f}:31:4") >= 0,
+        "the search walked into an assume alias it should not see\n{out}")
 }
 
 [test]


### PR DESCRIPTION
## Problem

`--ast-verify` reports a node whose `at` is unset — the invariant every macro-built node is supposed to carry. The report itself had nowhere to point:

- with an enclosing function, it anchored to the function's **head**, so the caret sat on `def foo`, not on the offending construct;
- with no enclosing function (a global initializer, a struct field type, a TypeDecl in a signature) it printed **no file and no line at all**, plus a dangling `" at "` in the log line.

You got a node kind and nothing to navigate to.

## What changed

The location is now guessed from the tree around the offender, in three tiers, each naming itself in the message:

1. the first located node **inside its own subtree**
2. the last located node the walk **passed**
3. the last located **non-expression site** (argument, field, global, function)

Tier 1 runs on demand: when a node turns out to have no `at`, a throwaway visitor scans its subtree for the first node that has one, so a well formed tree pays nothing. Tier 2 needs no ancestor chain — pre-order means the node the walk passed last *is* the enclosing node whenever the offender is a first child, which is why adding an explicit "enclosing" tier measured *worse* (see the table). Tier 3 covers a TypeDecl verified outside any function or expression, where the first two have nothing.

The guess is stamped into the node, which is also what keeps `ExprConst` — pre-visited twice for one node, base then derived — from reporting itself twice.

The infer-time verifier gets the same predecessor fallback, and neither verifier prints a dangling `" at "` when nothing can be found.

Same fixture, three generations:

```
def lost_one(a, b : int) : int {   <- before: function head
    return a + b                   <- interim: last located node, on `return`
           ^                       <- now: 10:11, caret on the operand
```

```
AST verify (post-infer): ExprOp2 has no source location (at is unset) in 'lost_one';
    first located node inside it is ExprRef2Value at at_unset.das:10:11
```

## Why this order — measured, not guessed

Temporary instrumentation in the post-infer verifier: for every node that *has* an `at`, record its true location plus what each candidate predictor would have said at that moment, then score `|predicted_line - true_line|`. A predictor that produces nothing is charged a 60-line penalty; a cross-file answer counts as nothing. Corpus: 43 files (`tests/language` sample + `dastest`, `utils/detect-dupe`, and `daslib` pulled in through requires) — **80,374 located expressions, 16,132 TypeDecls** after dedupe.

| anchor | mean lines off | exact line | exact caret | no location |
|---|---|---|---|---|
| **first located node inside subtree -> predecessor** *(shipped)* | **2.18** | **91.3%** | **46.8%** | 0.2% |
| descendant -> enclosing -> predecessor -> fn | 2.46 | 91.2% | 46.9% | 0.1% |
| enclosing (parent) -> descendant | 4.98 | 80.1% | 30.0% | 0.4% |
| last located node only | 5.78 | 78.4% | 26.1% | 3.9% |
| enclosing only | 6.99 | 78.1% | 28.5% | 4.4% |
| function head *(previous behaviour)* | 28.28 | 7.7% | 3.9% | 1.9% |
| *per-node oracle (upper bound)* | *1.46* | *94.9%* | - | - |
| *per-kind optimal table, 76 kinds* | *1.42* | - | - | - |

Reading the table:

- **descendant beats predecessor and parent** because a node begins where its subtree begins. `ExprBlock` is the extreme case: 1.02 mean vs 25.60 for last-located.
- **an explicit enclosing tier is not worth having**: the shipped two-node chain scores better than the four-tier one, because in pre-order the predecessor already *is* the enclosing node for a first child. The last row of the table is what the shipped chain leaves on the table against a per-node oracle: ~0.7 lines. Tier 3 removes the residual 0.2% that produce no location at all.
- **a per-kind table is not worth it** — 76 hardcoded entries buy 1 line of mean error over the plain chain, and rot on every new node kind. The chain already sits within ~1 line of the per-node oracle.
- **TypeDecls are different, and the proxy misleads there**: a type's own `at` is its *declaration* site, often in another module, while the actionable place is the use site. Confirmed against the population of nodes that genuinely lack `at` today: the descendant (`firstType`) is essentially never located, enclosing/predecessor ~40%, function/argument always. Types therefore get no descendant tier.


## Cost — cheaper than master on real work

`at` is nearly always there, so the per-node path has to do nothing when it is: a null test, one pointer store, and a `need_typed` whose label is built only if it reports. Master interpolated `"{expr.__rtti}"` **twice per node** and threw both away for every node that was fine. The subtree search runs only for a node that turns out to have no `at`.

Measured with callgrind against a pinned binary (wall clock and CPU time were unusable — a concurrent build kept relinking the binary mid-run):

| input | branch | master | delta |
|---|---|---|---|
| `utils/ast-fuzz/selftest/cli_victim.das` (trivial file) | 1901M | 1842M | +58.1M (+3.16%) |
| `utils/detect-dupe/main.das` (large program) | 43484M | 44581M | **−1096.8M (−2.46%)** |

The extra is **fixed, not per-node**: compiling a bigger `ast_verify` module (the `Anchor` struct, the helpers, the `FirstLocatedVisitor` class), paid once per run and only when the verifier is loaded at all. On a real program that same +58M is swallowed by the ~1.15G the walk saves.

For the record, the first version of this PR kept a per-expression frame stack and a `visitExpression` hook to reach ancestors: **13% over master** in wall clock, for 0.28 lines of *worse* mean error. It is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
