### PR TITLE
jobque: join the capture worker before its channel scope closes

### DIFF
--- a/skills/jobque_debugging.md
+++ b/skills/jobque_debugging.md
@@ -73,6 +73,22 @@ total 1 leaked Feature objects
 - **created at** — daScript source location
 - **owner=#4** — Feature is inside JobStatus #4
 
+**A dump that follows an `EXCEPTION:` line is a consequence, not the leak.**
+A panic is fatal to the process, so every reference live at that moment is
+reported as leaked whatever the panic was. Chase the exception, not the
+refcounts.
+
+**`synch primitive deleted while being used (ref=N)` on a `with_channel` line
+is that scope closing on a worker that has not released yet** — N is the count
+it still holds, and the worker then touches a destroyed mutex, so the panic is
+followed by a fatal from libc. Taking the worker's payload is not that release:
+a worker pushes and releases after, which wakes the consumer between the two,
+so a consumer that stops at the payload (`pop_with_timeout_clone`, `try_pop`)
+must `join()` the channel before its scope ends. A consumer that stops on the
+count instead — `for_each_clone`, whose final `pop` blocks until the count
+reaches zero — is already fenced, as is a worker that releases the channel
+before signalling a separate wait group.
+
 ## Step 2: Trace a Specific Object
 
 Once you know the leaking ID, use `--track-job-status` to get every addRef/releaseRef with source locations:

--- a/utils/mcp/mcp_core.das
+++ b/utils/mcp/mcp_core.das
@@ -376,9 +376,7 @@ def emit_progress_from_file() {
 // Run an external command, streaming progress when the current call set one up.
 // A worker runs the blocking capture; the main thread polls the progress file
 // every PROGRESS_POLL_MS, emitting a tick each interval, then takes the worker's
-// result. Popping that single result is the whole teardown — the worker's
-// notify_and_release already balanced its channel ref, so an extra release here
-// would under-count and abort the run.
+// result and joins it before the channel scope closes.
 def run_with_progress(argv : array<string>; timeout_sec : float; var output : string&) : int {
     if (empty(current_progress_file) || empty(current_progress_token)) {
         return run_and_capture(argv, output, timeout_sec)
@@ -408,6 +406,10 @@ def run_with_progress(argv : array<string>; timeout_sec : float; var output : st
                 emit_progress_from_file()
             }
         }
+        // The worker releases its channel reference after the push, so the pop
+        // that takes the result can return while that reference is still out —
+        // and a scope closing on a channel in use panics the process mid-call.
+        ch |> join()
     }
     output = captured
     remove(current_progress_file, err)


### PR DESCRIPTION
`run_with_progress` runs the blocking capture on a worker and polls the progress
file on the main thread, taking the worker's result with
`pop_with_timeout_clone`. That pop is not a fence: the worker pushes and
*then* releases its channel reference, and the push is what wakes the consumer —
so the pop can return while the worker's reference is still out. The
`with_channel` scope then closes on a channel still in use, which panics
(`synch primitive deleted while being used`) and takes the process down mid-call,
followed by a fatal from libc when the worker touches the destroyed mutex.

`ch |> join()` before the scope ends is the fence: it waits for the count to
reach zero, which is exactly what the pop does not do.

The old comment said the pop was the whole teardown because
`notify_and_release` had already balanced the worker's reference. That is true of
the *count*, and beside the point: the release happens after the push, so the two
are not ordered against the consumer.

`skills/jobque_debugging.md` gains what that failure looks like from the dump —
a leak report following an `EXCEPTION:` line is a consequence rather than the
leak, and `ref=N` on a `with_channel` line is the scope closing on a worker that
has not released. It also names which consumers are already fenced
(`for_each_clone`, whose final `pop` blocks on the count) so the rule reads as a
distinction rather than "always join".

Locally: `mcp_core.das` lints clean and passes `dasfmt --verify`.
`utils/mcp/test_tools.das` reports 423 tests / 397 passed / 26 failed on this
box — and **the same 26 fail on untouched master**, so the run carries no delta
from this branch; the failures are environmental here (the tool suite drives
external binaries this box lacks).
