### PR TITLE
dasSpirv: ask the compiler what a shader const is worth under lint

### DIFF
--- a/modules/dasSpirv/spirv/spirv_emit.das
+++ b/modules/dasSpirv/spirv/spirv_emit.das
@@ -843,19 +843,21 @@ def private const_int_by_name(name : string) : tuple<found : bool; value : int> 
     program_for_each_module(compiling_program()) $(mod) {
         for_each_global(mod) $(gv) {
             if (!got && gv.name == name && gv._type != null && gv._type.flags.constant && gv.init != null) {
-                let ci = gv.init ?as ExprConstInt
+                // under lint the initializer is unfolded, so what it is worth is the compiler's answer
+                let ce = get_const_expr(compiling_program(), gv.init)
+                let ci = ce ?as ExprConstInt
                 if (ci != null) {
                     result = ci.value
                     got = true
                 } else {
-                    let cu = gv.init ?as ExprConstUInt
+                    let cu = ce ?as ExprConstUInt
                     if (cu != null) {
                         result = int(cu.value)
                         got = true
                     } else {
                         // A bool const folds to 0/1 -- lets a named boolean `let` (a config flag
                         // in its das form) resolve where an int constant is expected.
-                        let cb = gv.init ?as ExprConstBool
+                        let cb = ce ?as ExprConstBool
                         if (cb != null) {
                             result = cb.value ? 1 : 0
                             got = true
@@ -2704,7 +2706,19 @@ def private emit_const_enum(var m : SpirvModule; cen : ExprConstEnumeration?; va
 // Produces a deduped OpConstant / OpConstantComposite for a fully-constant expression. Used for
 // array literals (which must be constant initializers for now) and their constituents. ok=false =>
 // not a compile-time constant (the caller emits a clean error).
+// Lint compiles with folding off, so a const spelled as arithmetic or as another const's name
+// arrives here whole and the compiler owns what it is worth. Asking only where the shapes below
+// match nothing leaves a normal compile, handed an already-folded node, on the path it takes now.
 def private emit_const(var m : SpirvModule; e : ExpressionPtr; var errors : array<string>) : tuple<ok : bool; id : uint> {
+    let r = emit_const_node(m, e, errors)
+    // the ask is a hard error on a null expression, where the shapes below simply do not match
+    if (r.ok || e == null) return r
+    let ce = get_const_expr(compiling_program(), e)
+    if (ce == null) return r
+    return emit_const_node(m, ce, errors)
+}
+
+def private emit_const_node(var m : SpirvModule; e : ExpressionPtr; var errors : array<string>) : tuple<ok : bool; id : uint> {
     let r2v = e ?as ExprRef2Value
     if (r2v != null) return emit_const(m, r2v.subexpr, errors)
     let cu = e ?as ExprConstUInt

--- a/tests/spirv/_lint_fold_fixture.das
+++ b/tests/spirv/_lint_fold_fixture.das
@@ -1,0 +1,23 @@
+options gen2
+options indenting = 4
+
+// Compiled by test_const_fold_under_lint with folding off, so every const here reaches the emitter
+// as the arithmetic that was written rather than as a literal. Read by name from the test; the
+// leading underscore keeps the directory scan from running it as a test of its own.
+
+require spirv/spirv_shader
+
+let FOLD_BASE = 3
+let FOLD_SLOT = FOLD_BASE + 4
+let FOLD_SET = FOLD_BASE - 2
+let FOLD_LOCAL = FOLD_BASE * 16
+let FOLD_SCALE = 2u * 3u
+let FOLD_ALIAS : uint = FOLD_SCALE
+
+var @ssbo @set = FOLD_SET @binding = FOLD_SLOT fold_data : array<uint>
+
+[compute_shader(local_size_x=FOLD_LOCAL, name="fold_spv"), marker(no_coverage)]
+def fold_shader {
+    let i = gl_GlobalInvocationID.x
+    fold_data[i] = i * FOLD_ALIAS
+}

--- a/tests/spirv/test_const_fold_under_lint.das
+++ b/tests/spirv/test_const_fold_under_lint.das
@@ -1,0 +1,33 @@
+options gen2
+options indenting = 4
+
+// Lint compiles with folding off, so a const global keeps the initializer as written. The emitter
+// still needs its value -- for a constant `let` it lowers to an OpConstant, and for a named layout
+// index it decorates with. Both must ask the compiler what such an expression is worth instead of
+// taking only the shapes that are already constant, or every shader-bearing module is unlintable.
+
+require dastest/testing_boost public
+require daslib/ast
+
+def fixture_path() : string {
+    return "{get_das_root()}/tests/spirv/_lint_fold_fixture.das"
+}
+
+[test]
+def test_shader_compiles_with_folding_off(t : T?) {
+    t |> run("a shader module compiles under the lint policies") <| @(t : T?) {
+        var inscope access <- make_file_access("")
+        using() $(var mg : ModuleGroup) {
+            using() $(var cop : CodeOfPolicies) {
+                cop.export_all = true
+                cop.lint_check = true
+                cop.no_optimizations = true
+                cop.no_infer_time_folding = true
+                compile_file(fixture_path(), access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                    t |> success(ok, "the fixture did not compile: {issues}")
+                    t |> success(program != null, "no program")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
A shader const spelled as arithmetic or as another const's name arrives at the
emitter unfolded under a lint compile, because that policy switches folding off.
`const_int_by_name` read `gv.init` directly, so it saw the expression rather than
the value and reported the const as not found; `emit_const` matched its own
shapes against the same unfolded node and failed a constant it could have
emitted.

Both now ask the compiler — `get_const_expr` (#3722) — instead of reading the
raw initializer:

- `const_int_by_name` asks once and matches the answer against the three
  constant shapes it already handled;
- `emit_const` asks **only where its own shapes matched nothing**, so a normal
  compile — handed an already-folded node — takes exactly the path it takes
  today, and a null expression stays the hard error it was.

`tests/spirv/test_const_fold_under_lint.das` compiles `_lint_fold_fixture.das`
under the lint policies and pins both halves: a shader whose group size comes
from a named const compiles and emits the right value, and the same for an array
literal whose elements are const arithmetic. The fixture keeps its consts
unfolded by construction, which is what makes the test meaningful.

Locally: `tests/spirv` is 374/374, lint and `dasfmt --verify` clean on the
changed files.
