### PR TITLE
daspkg: copy a package without reading a file whole, and without its .git

### DIFF
--- a/utils/daspkg/utils.das
+++ b/utils/daspkg/utils.das
@@ -7,6 +7,8 @@ module utils shared public
 require daslib/fio
 require strings
 
+let COPY_WINDOW_BYTES = 1024 * 1024
+
 // ── Logging ──────────────────────────────────────────────────────────
 
 var log_file_path : string
@@ -365,11 +367,51 @@ def gitignore_remove(root, pattern : string) {
     }
 }
 
+// a package is its files, not its history: copying .git costs more than the whole
+// rest of the tree and installs nothing anyone requires
+def private is_package_content(name : string) : bool {
+    return name != "." && name != ".." && name != ".git"
+}
+
+// streamed through a fixed window: sizing a buffer by the file costs that file in
+// memory, and panics outright on one past max_unreserved_size
+def private copy_file_bytes(src, dst : string) : bool {
+    var ok = true
+    fopen(src, "rb") $(fin) {
+        if (fin == null) {
+            ok = false
+            return
+        }
+        fopen(dst, "wb") $(fout) {
+            if (fout == null) {
+                ok = false
+                return
+            }
+            var buf : array<uint8>
+            buf |> resize(COPY_WINDOW_BYTES)
+            while (true) {
+                let n = fread(fin, buf)
+                break if (n <= 0)
+                if (n < length(buf)) {
+                    buf |> resize(n)
+                }
+                if (fwrite(fout, buf) != length(buf)) {
+                    ok = false
+                    break
+                }
+                break if (n < COPY_WINDOW_BYTES)
+            }
+            delete buf
+        }
+    }
+    return ok
+}
+
 def copy_dir_rec(src, dst : string) : bool {
     mkdir(dst)
     var ok = true
     dir(src) $(name) {
-        if (name == "." || name == "..") return
+        return if (!is_package_content(name))
         let src_child = "{src}/{name}"
         let dst_child = "{dst}/{name}"
         let st = stat(src_child)
@@ -378,32 +420,8 @@ def copy_dir_rec(src, dst : string) : bool {
                 ok = false
             }
         } elif (st.is_reg) {
-            fopen(src_child, "rb") $(fin) {
-                if (fin != null) {
-                    let fs = fstat(fin)
-                    let sz = int(fs.size)
-                    if (sz == 0) {
-                        // empty file — just create it
-                        fopen(dst_child, "wb") $(fout) {
-                            if (fout == null) {
-                                ok = false
-                            }
-                        }
-                    } else {
-                        var buf : array<uint8>
-                        buf |> resize(sz)
-                        fread(fin, buf)
-                        fopen(dst_child, "wb") $(fout) {
-                            if (fout != null) {
-                                fwrite(fout, buf)
-                            } else {
-                                ok = false
-                            }
-                        }
-                    }
-                } else {
-                    ok = false
-                }
+            if (!copy_file_bytes(src_child, dst_child)) {
+                ok = false
             }
         }
     }


### PR DESCRIPTION
`copy_dir_rec` is what `daspkg install` copies a package with, and it has three
problems:

1. **It recurses into `.git`.** Installing a module from a clone copies the whole
   history into `modules/<name>`. For the package that broke this for us that was
   125 MB of pack files against a few hundred KB of actual module.
2. **It reads every file whole**: `buf |> resize(sz); fread(fin, buf)`. That costs
   the file in memory, and past `max_unreserved_size` (64 MB) it does not degrade
   — it panics, and the install dies:

   ```
   EXCEPTION: array resize to 70000000 elements of 1 bytes each grows past
   max_unreserved_size (67108864 bytes)
     at daslib/builtin.das:74:8
   ```
3. **It sizes that buffer with `int(fs.size)`**, which truncates above 2 GB.

The copy now streams through a fixed 1 MB window and skips `.git`; sizing by the
file is gone, so the narrowing goes with it. Nothing else about the install
changes.

**How it surfaced.** #3724 brought the `max_unreserved_size` guard back to
`resize`, and the first sync that pulled it turned this latent bug into a hard
failure: our dasVulkan package is installed from a clone whose git pack is
125 MB, so every SDK install on both of our boxes died at the line above. The
guard is not at fault — it converted "quietly allocates 125 MB to copy a file
nobody wants" into a diagnostic, which is what a guard is for. Any package
carrying one large file reaches the same place, and a package that is a clone
gets there on its history alone.

**Verified against a tree carrying a 70 MB file and a `.git` beside it:**

| | pre-change | with this change |
|---|---|---|
| 70 MB file | the exception above | copied, byte-identical |
| 3 MB file (multi-window) | copied | copied, byte-identical |
| `.git/` | copied | skipped |

Gates: `utils/daspkg/utils.das` lints clean and passes `dasfmt --verify`.
`utils/daspkg/test_daspkg.das` is 218/219 here — identical on untouched master,
the one failure being `test_check_tool` 'detects cmake' on a box with no cmake.
