### PR TITLE
jit: close four JIT-vs-AOT gaps (each(), generator range, array push, indirect dispatch)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,6 +30,12 @@ Every `.das` benchmark file in this directory tree is listed below, grouped by s
 | `test13.das` | `hash(string)` microbenchmark - short vs long keys; inlined FNV intrinsic (JIT) vs bound C++ builtin (interp) |
 | `test14.das` | Large string-keyed builtin table (open-addressed, inlined find/at) vs int reference - sizes the large-string lookup against the int reference; `_fresh`/`_same` isolate strcmp |
 
+## core/jit_aot/
+
+| File | Description |
+|---|---|
+| `primitives.das` | Per-primitive JIT-vs-AOT cost probes, grouped as `iteration` / `calls` / `compare` / `containers` / `dispatch` / `pipelines` / `interop`: `das_iterator` over range / array / fixed array / `each()` Sequence / generator, `SimPolicy_String::Equ` vs `jit_str_cmp`, and the `addInterop` builtins (`SimNode_AotInterop` vs `jit_simnode_interop`). `pipelines` prices realistic composites - `sort_block` (one comparator invoke per comparison) against `sort_default`, array clone, `finally` scope exit, string search. `dispatch` covers class-method calls (polymorphic and monomorphic receivers), table insert, `build_string`, struct clone and `try/recover` scope entry. `containers` covers table lookup by int and string key, array push growth, and float4 math. The `calls` group (`block_invoke` / `static_call` / `lambda_invoke` / `fnptr_invoke`) prices the das call boundary itself - AOT emits a native C++ signature, the JIT keeps the interpreter ABI (`vec4f(Context*, vec4f* args)`) and dispatches through `jit_call_or_fastcall`. The `generator` / `generator_while` pair guards `replaceGeneratorFor`: a range-source `for` inside a generator body must cost the same as the hand-written `while`, i.e. keep its counter in the capture frame rather than falling back to `each()` + `_builtin_iterator_first`/`next`. The AOT lane needs stubs: this dir is appended to the language suite in `tests/aot/CMakeLists.txt`, so run it as `bin/test_aot_subset dastest/dastest.das -- --bench --use-aot --test benchmarks/core/jit_aot/` against `-jit` on the same binary |
+
 ## core/gc/
 
 | File | Description |

--- a/benchmarks/core/jit_aot/primitives.das
+++ b/benchmarks/core/jit_aot/primitives.das
@@ -1,0 +1,440 @@
+options gen2
+options persistent_heap
+
+require dastest/testing_boost
+require math
+require daslib/strings_boost
+
+let N = 100000
+let M = 50000
+
+var g_sink : int64
+
+def private make_ints(n : int) {
+    var res <- [for (i in range(n)); i]
+    return <- res
+}
+
+def private make_keys(n : int; prefix : string) {
+    var res <- [for (i in range(n)); "{prefix}key_{i % 97}_padding_tail"]
+    return <- res
+}
+
+def private gen_ints(n : int) : iterator<int> {
+    return <- generator<int> {
+        for (i in range(n)) {
+            yield i
+        }
+        return false
+    }
+}
+
+def private gen_ints_while(n : int) : iterator<int> {
+    return <- generator<int> {
+        var i = 0
+        while (i < n) {
+            yield i
+            i++
+        }
+        return false
+    }
+}
+
+[benchmark]
+def iteration(b : B?) {
+    let arr <- make_ints(N)
+    var dim : int[1024]
+    for (i in range(1024)) {
+        dim[i] = i
+    }
+    b |> run("range/{N}", N) {
+        var s = 0
+        for (i in range(N)) {
+            s = (s << 1) ^ i
+        }
+        g_sink += int64(s)
+    }
+    b |> run("array/{N}", N) {
+        var s = 0
+        for (x in arr) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+    b |> run("fixed_array/1024", 1024) {
+        var s = 0
+        for (x in dim) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+    b |> run("each_iterator/{N}", N) {
+        var s = 0
+        for (x in each(arr)) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+    let small <- make_ints(8)
+    b |> run("array_setup/8", 1) {
+        var s = 0
+        for (x in small) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+    b |> run("each_iterator_setup/8", 1) {
+        var s = 0
+        for (x in each(small)) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+    b |> run("generator/{N}", N) {
+        var s = 0
+        for (x in gen_ints(N)) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+    b |> run("generator_while/{N}", N) {
+        var s = 0
+        for (x in gen_ints_while(N)) {
+            s = (s << 1) ^ x
+        }
+        g_sink += int64(s)
+    }
+}
+
+def private double_it(x : int) : int => x * 2
+
+def private rec_call(x : int) : int {
+    if (x <= 0) return 0
+    return x + rec_call(x - 1)
+}
+
+[benchmark]
+def calls(b : B?) {
+    let ia <- make_ints(M)
+    var lam <- @(x : int) : int {
+        return x * 2
+    }
+    let fp = @@double_it
+    b |> run("block_invoke", 1) {
+        g_sink++
+    }
+    b |> run("static_call/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ rec_call(ia[i] & 1)
+        }
+        g_sink += int64(s)
+    }
+    b |> run("lambda_invoke/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ invoke(lam, ia[i])
+        }
+        g_sink += int64(s)
+    }
+    b |> run("fnptr_invoke/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ invoke(fp, ia[i])
+        }
+        g_sink += int64(s)
+    }
+    unsafe {
+        delete lam
+    }
+}
+
+[benchmark]
+def compare(b : B?) {
+    let ka <- make_keys(M, "")
+    let kb <- make_keys(M, "")
+    let kd <- make_keys(M, "z")
+    let ia <- make_ints(M)
+    b |> run("int_equ/{M}", M) {
+        var c = 0
+        for (i in range(M)) {
+            if (ia[i] == i) {
+                c = (c << 1) ^ 1
+            }
+        }
+        g_sink += int64(c)
+    }
+    b |> run("string_equ_match/{M}", M) {
+        var c = 0
+        for (i in range(M)) {
+            if (ka[i] == kb[i]) {
+                c = (c << 1) ^ 1
+            }
+        }
+        g_sink += int64(c)
+    }
+    b |> run("string_equ_first_byte/{M}", M) {
+        var c = 0
+        for (i in range(M)) {
+            if (ka[i] == kd[i]) {
+                c = (c << 1) ^ 1
+            }
+        }
+        g_sink += int64(c)
+    }
+    let kp <- [for (s in ka); s]
+    b |> run("string_equ_literal/{M}", M) {
+        var c = 0
+        for (i in range(M)) {
+            if (ka[i] == "key_5_padding_tail") {
+                c = (c << 1) ^ 1
+            }
+        }
+        g_sink += int64(c)
+    }
+    b |> run("string_equ_same_ptr/{M}", M) {
+        var c = 0
+        for (i in range(M)) {
+            if (ka[i] == kp[i]) {
+                c = (c << 1) ^ 1
+            }
+        }
+        g_sink += int64(c)
+    }
+    b |> run("string_less/{M}", M) {
+        var c = 0
+        for (i in range(M)) {
+            if (ka[i] < kd[i]) {
+                c = (c << 1) ^ 1
+            }
+        }
+        g_sink += int64(c)
+    }
+}
+
+let K = 1000
+
+[benchmark]
+def containers(b : B?) {
+    let ia <- make_ints(M)
+    let ka <- make_keys(M, "")
+    var ti : table<int; int>   // nolint:STYLE027 - the insert loop is setup for the probe below
+    for (i in range(M)) {
+        ti |> insert(i, i * 2)
+    }
+    var ts : table<string; int>   // nolint:STYLE027 - the insert loop is setup for the probe below
+    for (i in range(M)) {
+        ts |> insert(ka[i], i)
+    }
+    b |> run("table_int_get/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ (ti?[i] ?? 0)
+        }
+        g_sink += int64(s)
+    }
+    b |> run("table_str_get/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ (ts?[ka[i]] ?? 0)
+        }
+        g_sink += int64(s)
+    }
+    b |> run("array_push/{K}", K) {
+        var a : array<int>   // nolint:STYLE027 - the push loop IS the measurement
+        for (i in range(K)) {
+            a |> push(i)
+        }
+        g_sink += long_length(a)
+        delete a
+    }
+    b |> run("float4_dot/{M}", M) {
+        var f = 0.
+        for (i in range(M)) {
+            let v = float4(float(ia[i]), 1., 2., 3.)
+            f = f * 0.5 + dot(v, v)
+        }
+        g_sink += int64(f)
+    }
+    delete ti
+    delete ts
+}
+
+class Shape {
+    def abstract area(k : int) : int
+}
+
+class Circle : Shape {
+    def override area(k : int) : int {
+        return k * 2
+    }
+}
+
+class Square : Shape {
+    def override area(k : int) : int {
+        return k * 3
+    }
+}
+
+struct private Bag {
+    xs : array<int>
+    name : string
+}
+
+[benchmark]
+def dispatch(b : B?) {
+    let ia <- make_ints(M)
+    var shapes : array<Shape?>
+    for (i in range(M)) {
+        if (i % 2 == 0) {
+            shapes |> push(new Circle())
+        } else {
+            shapes |> push(new Square())
+        }
+    }
+    b |> run("class_method/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ shapes[i]->area(ia[i] & 7)
+        }
+        g_sink += int64(s)
+    }
+    var circle = new Circle()
+    b |> run("class_method_mono/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            s = (s << 1) ^ circle->area(ia[i] & 7)
+        }
+        g_sink += int64(s)
+    }
+    unsafe {
+        delete circle
+    }
+    b |> run("table_insert/{M}", M) {
+        var t : table<int; int>   // nolint:STYLE027 - the insert loop IS the measurement
+        for (i in range(M)) {
+            t |> insert(i, i)
+        }
+        g_sink += long_length(t)
+        delete t
+    }
+    b |> run("build_string/{K}", K) {
+        var n = 0
+        for (i in range(K)) {
+            let s = build_string() $(var w) {
+                w |> write("ab")
+                w |> write(i)
+            }
+            n += length(s)
+        }
+        g_sink += int64(n)
+    }
+    var proto <- Bag(xs <- make_ints(8), name = "proto")
+    b |> run("struct_clone/{K}", K) {
+        var n = 0
+        for (_i in range(K)) {
+            var c := proto
+            n += length(c.xs)
+            delete c
+        }
+        g_sink += int64(n)
+    }
+    b |> run("try_recover/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            try {
+                s = (s << 1) ^ ia[i]
+            } recover {
+                s = 0
+            }
+        }
+        g_sink += int64(s)
+    }
+    delete proto
+    unsafe {
+        for (sh in shapes) {
+            delete sh
+        }
+        delete shapes
+    }
+}
+
+[benchmark]
+def pipelines(b : B?) {
+    let src <- make_ints(K)
+    let ka <- make_keys(K, "")
+    b |> run("sort_block/{K}", K) {
+        var a := src
+        a |> sort() $(x, y : int) => x > y
+        g_sink += int64(a[0])
+        delete a
+    }
+    b |> run("sort_default/{K}", K) {
+        var a := src
+        a |> sort()
+        g_sink += int64(a[0])
+        delete a
+    }
+    b |> run("array_clone/{K}", K) {
+        var a := src
+        g_sink += long_length(a)
+        delete a
+    }
+    b |> run("finally_scope/{M}", M) {
+        var s = 0
+        for (i in range(M)) {
+            {
+                s = (s << 1) ^ i
+            } finally {
+                s ^= 1
+            }
+        }
+        g_sink += int64(s)
+    }
+    b |> run("string_find/{K}", K) {
+        var n = 0
+        for (i in range(K)) {
+            n += find(ka[i], "padding")
+        }
+        g_sink += int64(n)
+    }
+}
+
+struct private Pt {
+    x, y : int
+    z : float
+}
+
+[benchmark]
+def interop(b : B?) {
+    let ia <- make_ints(M)
+    let pts <- [for (i in range(M)); Pt(x = i, y = i * 2, z = float(i))]
+    b |> run("hash_int/{M}", M) {
+        var h = 0ul
+        for (i in range(M)) {
+            h += hash(ia[i])
+        }
+        g_sink += int64(h)
+    }
+    b |> run("hash_struct/{M}", M) {
+        var h = 0ul
+        for (p in pts) {
+            h += hash(p)
+        }
+        g_sink += int64(h)
+    }
+    b |> run("interp_string/{M}", M) {
+        var n = 0
+        for (i in range(M)) {
+            n += length("v={i}")
+        }
+        g_sink += int64(n)
+    }
+    b |> run("sqrt_float/{M}", M) {
+        var f = 0.
+        for (i in range(M)) {
+            f = f * 0.5 + sqrt(float(ia[i]))
+        }
+        g_sink += int64(f)
+    }
+}

--- a/modules/dasLLVM/.das_module
+++ b/modules/dasLLVM/.das_module
@@ -7,7 +7,7 @@ def initialize(project_path : string) {
     let daslib_paths = [
         "llvm_boost", "llvm_debug", "llvm_jit", "llvm_targets",
         "llvm_dsl",
-        "llvm_jit_intrin", "llvm_jit_common", "llvm_dll_utils",
+        "llvm_jit_intrin", "llvm_jit_common", "llvm_jit_lower", "llvm_dll_utils",
         "llvm_exe", "llvm_macro", "llvm_jit_cli", "llvm_jit_run", "llvm_aot",
         "llvm_env",     // [EnvConfig] environment-knob registry (ENVIRONMENT.md generates from it)
         "aarch64_neon", // public NEON-intrinsic header (portable fallbacks + name-based JIT recognition)

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -3797,6 +3797,16 @@ class public LlvmJitVisitor : AstVisitor {
         return is_workhorse_table_key(tabT.firstType.baseType)
     }
 
+    def inline_each_source(expr : ExpressionPtr) : ExpressionPtr {
+        if (!(expr is ExprCall)) return expr
+        var cf = expr as ExprCall
+        if (cf.func == null || length(cf.arguments) != 1
+                || !starts_with(cf.func.name, "builtin`each`")) return expr
+        assume srcT = cf.arguments[0]._type
+        if (srcT == null || !(srcT.isGoodArrayType || srcT.baseType == Type.tFixedArray)) return expr
+        return cf.arguments[0]
+    }
+
     def build_table_lock_call(tab_ptr : LLVMOpaqueValue?; at : LineInfo) {
         var params = fixed_array(
             LLVMBuildPointerCast(g_builder, tab_ptr, types.LLVMVoidPtrType(), ""),
@@ -3886,7 +3896,7 @@ class public LlvmJitVisitor : AstVisitor {
             forBodyToExpr[expr.body as ExprBlock] = expr
         }
         for (ssrc in expr.sources) {
-            if (is_count_or_ucount(ssrc) || is_table_keys_values(ssrc)) {
+            if (is_count_or_ucount(ssrc) || is_table_keys_values(ssrc) || inline_each_source(ssrc) != ssrc) {
                 skipCall |> insert(ssrc as ExprCall)
             }
         }
@@ -3923,7 +3933,14 @@ class public LlvmJitVisitor : AstVisitor {
         LOOP_START:
         */
         var lblk = loop_stack |> back()
-        for (svar, ssrc in expr.iteratorVariables, expr.sources) {
+        for (ssource in expr.sources) {
+            let ssrc = inline_each_source(ssource)
+            if (ssrc != ssource) {
+                visit(ssrc, adapter)
+            }
+        }
+        for (svar, ssource in expr.iteratorVariables, expr.sources) {
+            let ssrc = inline_each_source(ssource)
             if (ssrc._type.isRange) {// range()->first()
                 var srange = getE(ssrc)
                 var sfrom = LLVMBuildExtractElement(g_builder, srange, types.ConstI32(0ul), "range_from_{svar.name}")
@@ -3933,7 +3950,7 @@ class public LlvmJitVisitor : AstVisitor {
                 var not_okay = append_basic_block("for_{svar.name}_empty")
                 LLVMBuildCondBr(g_builder, cmp_from_to, okay, not_okay)
                 LLVMPositionBuilderAtEnd(g_builder, not_okay)
-                LLVMBuildStore(g_builder, LLVMConstInt(types.t_int1, 0ul, 0), lblk.need_loop) // need loop, no
+                LLVMBuildStore(g_builder, LLVMConstInt(types.t_int1, 0ul, 0), lblk.need_loop)
                 LLVMBuildBr(g_builder, okay)
                 LLVMPositionBuilderAtEnd(g_builder, okay)
                 range2[ssrc] = sto
@@ -3965,7 +3982,7 @@ class public LlvmJitVisitor : AstVisitor {
                 var not_okay = append_basic_block("for_{svar.name}_empty")
                 LLVMBuildCondBr(g_builder, cmp_from_to, okay, not_okay)
                 LLVMPositionBuilderAtEnd(g_builder, not_okay)
-                LLVMBuildStore(g_builder, LLVMConstInt(types.t_int1, 0ul, 0), lblk.need_loop) // need loop, no
+                LLVMBuildStore(g_builder, LLVMConstInt(types.t_int1, 0ul, 0), lblk.need_loop)
                 LLVMBuildBr(g_builder, okay)
                 LLVMPositionBuilderAtEnd(g_builder, okay)
                 build_array_lock(getE(ssrc), expr.at)
@@ -4097,7 +4114,8 @@ class public LlvmJitVisitor : AstVisitor {
             LLVMBuildBr(g_builder, lblk.loop_continue)                           // LOOP CONTINUE
         }
         LLVMPositionBuilderAtEnd(g_builder, lblk.loop_continue)
-        for (svar, ssrc in expr.iteratorVariables, expr.sources) {
+        for (svar, ssource in expr.iteratorVariables, expr.sources) {
+            let ssrc = inline_each_source(ssource)
             if (ssrc._type.isRange) {// range()->next()
                 let isRange64 = ssrc._type.baseType == Type.tRange64 || ssrc._type.baseType == Type.tURange64
                 var svar_v = LLVMBuildLoad2(g_builder, isRange64 ? types.t_int64 : types.t_int32, getV(svar), "")
@@ -4193,7 +4211,7 @@ class public LlvmJitVisitor : AstVisitor {
         for (i in range(len)) {
             let ri = len - i - 1
             let svar & = unsafe(expr.iteratorVariables[ri])
-            let ssrc & = unsafe(expr.sources[ri])
+            let ssrc = inline_each_source(expr.sources[ri])
             if (ssrc._type.isGoodArrayType) {
                 build_array_unlock(getE(ssrc), ssrc.at)
             } elif (ssrc._type.isIterator) {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -4069,27 +4069,29 @@ class public LlvmJitVisitor : AstVisitor {
                     range2[ssrc] = LLVMBuildAlloca(g_builder, LLVMPointerType(types.t_int8, 0u), "loop_iter")
                 }
                 var s_ptr = getE(ssrc)
-                // Check if it's das-optimized empty string (just nullptr).
-                var is_empty_str = LLVMBuildIsNull(g_builder, s_ptr, "null_check")
-                var not_empty_str = append_basic_block("not_empty_str")
-                LLVMBuildCondBr(g_builder, is_empty_str, lblk.loop_end, not_empty_str)
-
-                LLVMPositionBuilderAtEnd(g_builder, not_empty_str)
-
                 LLVMBuildStore(g_builder, s_ptr, range2[ssrc])
+                var is_empty_str = LLVMBuildIsNull(g_builder, s_ptr, "null_check")
+                var not_empty_str = append_basic_block("for_{svar.name}_not_empty")
+                var empty_str = append_basic_block("for_{svar.name}_empty")
+                var str_done = append_basic_block("for_{svar.name}_first_done")
+                LLVMBuildCondBr(g_builder, is_empty_str, empty_str, not_empty_str)
+                LLVMPositionBuilderAtEnd(g_builder, empty_str)
+                LLVMBuildStore(g_builder, LLVMConstInt(types.t_int1, 0ul, 0), lblk.need_loop)
+                LLVMBuildBr(g_builder, str_done)
+                LLVMPositionBuilderAtEnd(g_builder, not_empty_str)
                 var cur_chr = LLVMBuildLoad2(g_builder, types.t_int8, s_ptr, "cur_chr")
                 let zero_i8 = types.ConstI8(0 |> int8)
                 let is_null = LLVMBuildICmp(g_builder,
                     LLVMIntPredicate.LLVMIntNE, cur_chr, zero_i8, "is_null")
-                // Just in case check whether string is equal to '\0', e.g. this
-                // is native string.
-                LLVMBuildStore(g_builder, is_null, lblk.need_loop)
-
+                var need_now = LLVMBuildLoad2(g_builder, types.t_int1, lblk.need_loop, "need_loop_str")
+                LLVMBuildStore(g_builder, LLVMBuildAnd(g_builder, need_now, is_null, ""), lblk.need_loop)
                 assume svar_t = svar._type
                 assert(svar_t.baseType == Type.tInt)
                 // Cast to i32, since char is i32 in das.
-                var res = LLVMBuildSExt(g_builder, cur_chr, type_to_llvm_type(svar_t), "sext_cast")
+                var res = LLVMBuildZExt(g_builder, cur_chr, type_to_llvm_type(svar_t), "zext_cast")
                 LLVMBuildStore(g_builder, res, getV(svar))
+                LLVMBuildBr(g_builder, str_done)
+                LLVMPositionBuilderAtEnd(g_builder, str_done)
             } else {
                 failed_E(ssrc, "unsupported loop source {describe(ssrc._type)}")
             }
@@ -4184,7 +4186,7 @@ class public LlvmJitVisitor : AstVisitor {
 
                 LLVMBuildStore(g_builder, svar_i, range2[ssrc])
                 assert(svar._type.baseType == Type.tInt)
-                var res = LLVMBuildSExt(g_builder, val, type_to_llvm_type(svar._type), "sext_cast")
+                var res = LLVMBuildZExt(g_builder, val, type_to_llvm_type(svar._type), "zext_cast")
                 LLVMBuildStore(g_builder, res, getV(svar))
             } else {
                 failed_E(ssrc, "unsupported loop source {describe(ssrc._type)}")

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -1784,16 +1784,11 @@ class public LlvmJitVisitor : AstVisitor {
                         glob_fn_ptr = save_address_global(uid.get_dll_fn_name_ptr(expr.func), MNH_ADDR)
                     }
                 }
-                var params : array<LLVMOpaqueValue?>  // nolint:STYLE012 — conditional cmresEval push between fixed args
-                params |> push(glob_fn_ptr)  // mnh
-                params |> push(args)
+                var cmresPtr : LLVMOpaqueValue?
                 if (cmresEval != null) {
-                    params |> push(LLVMBuildPointerCast(g_builder, cmresEval, types.LLVMVoidPtrType(), ""))
+                    cmresPtr = LLVMBuildPointerCast(g_builder, cmresEval, types.LLVMVoidPtrType(), "")
                 }
-                params |> push(get_context_param())
-                var func = LLVMGetNamedFunction(g_mod, cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL)
-                var typ = g_fn_types[cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL]
-                var ccall = LLVMBuildCall2(g_builder, typ, func, params, "")
+                var ccall = build_call_helper(glob_fn_ptr, args, cmresPtr)
                 if (cmresEval != null) {
                     setE(expr, cmresEval)
                 } elif (expr.func.result.isVoid) {
@@ -4364,15 +4359,9 @@ class public LlvmJitVisitor : AstVisitor {
                     ctor = save_address_global(name, MNH_ADDR)
                 }
             }
-            var params <- [
-                ctor,  // mnh
-                LLVMConstPointerNull(LLVMPointerType(types.LLVMFloat4Type(), 0u)), // args
-                LLVMBuildPointerCast(g_builder, cmresEval, types.LLVMVoidPtrType(), ""),
-                get_context_param()
-            ]
-            var func = LLVMGetNamedFunction(g_mod, cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL)
-            var typ = g_fn_types[cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL]
-            var ccall = LLVMBuildCall2(g_builder, typ, func, params, "")
+            var ccall = build_call_helper(ctor,
+                LLVMConstPointerNull(LLVMPointerType(types.LLVMFloat4Type(), 0u)),
+                LLVMBuildPointerCast(g_builder, cmresEval, types.LLVMVoidPtrType(), ""))
         }
     }
 
@@ -5292,6 +5281,39 @@ class public LlvmJitVisitor : AstVisitor {
         return true
     }
 
+    def build_call_helper(simfunc, args : LLVMOpaqueValue?; cmres : LLVMOpaqueValue? = null) : LLVMOpaqueValue? {
+        if (cmres == null) {
+            return LLVMBuildCall2(g_builder, g_fn_types[FN_JIT_CALL_OR_FASTCALL],
+                LLVMGetNamedFunction(g_mod, FN_JIT_CALL_OR_FASTCALL),
+                fixed_array(simfunc, args, get_context_param()), "")
+        }
+        return LLVMBuildCall2(g_builder, g_fn_types[FN_JIT_CALL_WITH_CMRES],
+            LLVMGetNamedFunction(g_mod, FN_JIT_CALL_WITH_CMRES),
+            fixed_array(simfunc, args, cmres, get_context_param()), "")
+    }
+
+    def build_call_dispatch(simfunc, args : LLVMOpaqueValue?; cmres : LLVMOpaqueValue? = null) : LLVMOpaqueValue? {
+        var slot = LLVMBuildGEP2(g_builder, types.t_int8,
+            LLVMBuildPointerCast(g_builder, simfunc, LLVMPointerType(types.t_int8, 0u), ""),
+            types.ConstI32(uint64(SIMFUNCTION_OFFSET_OF_JIT_FUNCTION)), "simfn.jitp")
+        var jitfn = LLVMBuildLoad2(g_builder, types.LLVMVoidPtrType(), slot, "simfn.jitfn")
+        var direct = LLVMBuildIsNotNull(g_builder, jitfn, "simfn.jitted")
+        let cmresArg = cmres != null ? cmres : LLVMConstPointerNull(types.LLVMVoidPtrType())
+        var res = build_select(direct, types.LLVMFloat4Type()) {
+            var r = LLVMBuildCall2(g_builder, g_t_jit_function, jitfn,
+                fixed_array(get_context_param(), args, cmresArg), "")
+            var sfp = LLVMBuildGEP2(g_builder, types.t_int8,
+                LLVMBuildPointerCast(g_builder, get_context_param(), LLVMPointerType(types.t_int8, 0u), ""),
+                types.ConstI32(uint64(CONTEXT_OFFSET_OF_STOP_FLAGS)), "ctx.stopflagsp")
+            LLVMBuildStore(g_builder, LLVMConstInt(types.t_int32, 0ul, 0), sfp)
+            return r
+        }
+        lpipe() {
+            return build_call_helper(simfunc, args, cmres)
+        }
+        return res
+    }
+
     def override visitExprInvoke(expr : ExprInvoke?) : ExpressionPtr {
         assume blockT = expr.arguments[0]._type
         var cmresEval : LLVMOpaqueValue?
@@ -5334,16 +5356,7 @@ class public LlvmJitVisitor : AstVisitor {
             var SIMFUNCTION = LLVMBuildExtractValue(g_builder, FUNC, uint(JIT_FUNCTION.SIM_FUNCTION), "SIMFUNCTION")
             SIMFUNCTION = LLVMBuildPointerCast(g_builder, SIMFUNCTION, types.LLVMVoidPtrType(), "")
             check_ptr_zero(SIMFUNCTION, expr.at, "invoke null method")
-            var params : array<LLVMOpaqueValue?>  // nolint:STYLE012 — conditional cmresEval push between fixed args
-            params |> push(SIMFUNCTION)
-            params |> push(args)
-            if (cmresEval != null) {
-                params |> push(cmresEvalPtr)
-            }
-            params |> push(get_context_param())
-            var func = LLVMGetNamedFunction(g_mod, cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL)
-            var typ = g_fn_types[cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL]
-            var ccall = LLVMBuildCall2(g_builder, typ, func, params, "invoke")
+            var ccall = build_call_dispatch(SIMFUNCTION, args, cmresEvalPtr)
             if (cmresEval != null) {
                 setE(expr, cmresEval)
             } elif (blockT.firstType.isVoid) {
@@ -5358,16 +5371,7 @@ class public LlvmJitVisitor : AstVisitor {
             var SIMFUNCTION = LLVMBuildExtractValue(g_builder, FUNC, uint(JIT_FUNCTION.SIM_FUNCTION), "SIMFUNCTION")
             SIMFUNCTION = LLVMBuildPointerCast(g_builder, SIMFUNCTION, types.LLVMVoidPtrType(), "")
             check_ptr_zero(SIMFUNCTION, expr.at, "invoke null function")
-            var params : array<LLVMOpaqueValue?>  // nolint:STYLE012 — conditional cmresEval push between fixed args
-            params |> push(SIMFUNCTION)
-            params |> push(args)
-            if (cmresEval != null) {
-                params |> push(cmresEvalPtr)
-            }
-            params |> push(get_context_param())
-            var func = LLVMGetNamedFunction(g_mod, cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL)
-            var typ = g_fn_types[cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL]
-            var ccall = LLVMBuildCall2(g_builder, typ, func, params, "invoke")
+            var ccall = build_call_dispatch(SIMFUNCTION, args, cmresEvalPtr)
             if (cmresEval != null) {
                 setE(expr, cmresEval)
             } elif (blockT.firstType.isVoid) {
@@ -5385,16 +5389,8 @@ class public LlvmJitVisitor : AstVisitor {
             LAMBDA = LLVMBuildLoad2(g_builder, g_t_lambda, LAMBDA, "LAMBDA")
             var SIMFUNCTION = LLVMBuildExtractValue(g_builder, LAMBDA, uint(JIT_LAMBDA.EVAL), "EVAL")
             SIMFUNCTION = LLVMBuildPointerCast(g_builder, SIMFUNCTION, types.LLVMVoidPtrType(), "")
-            var params : array<LLVMOpaqueValue?>  // nolint:STYLE012 — conditional cmresEval push between fixed args
-            params |> push(SIMFUNCTION)
-            params |> push(args)
-            if (cmresEval != null) {
-                params |> push(cmresEvalPtr)
-            }
-            params |> push(get_context_param())
-            var func = LLVMGetNamedFunction(g_mod, cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL)
-            var typ = g_fn_types[cmresEval != null ? FN_JIT_CALL_WITH_CMRES : FN_JIT_CALL_OR_FASTCALL]
-            var ccall = LLVMBuildCall2(g_builder, typ, func, params, "invoke")
+            check_ptr_zero(SIMFUNCTION, expr.at, "invoke null lambda")
+            var ccall = build_call_dispatch(SIMFUNCTION, args, cmresEvalPtr)
             if (cmresEval != null) {
                 setE(expr, cmresEval)
             } elif (blockT.firstType.isVoid) {
@@ -5639,10 +5635,8 @@ class public LlvmJitVisitor : AstVisitor {
         LAMBDA = LLVMBuildLoad2(g_builder, g_t_lambda, LAMBDA, "LAMBDA")
         var SIMFUNCTION = LLVMBuildExtractValue(g_builder, LAMBDA, uint(JIT_LAMBDA.FINALIZER), "FINALIZER")
         SIMFUNCTION = LLVMBuildPointerCast(g_builder, SIMFUNCTION, types.LLVMVoidPtrType(), "")
-        var params <- [SIMFUNCTION, args, get_context_param()]
-        var func = LLVMGetNamedFunction(g_mod, FN_JIT_CALL_OR_FASTCALL)
-        var typ = g_fn_types[FN_JIT_CALL_OR_FASTCALL]
-        LLVMBuildCall2(g_builder, typ, func, params, "delete_lambda")
+        check_ptr_zero(SIMFUNCTION, at, "lambda finalizer is a null function")
+        build_call_dispatch(SIMFUNCTION, args)
         LLVMBuildBr(g_builder, end)
         LLVMPositionBuilderAtEnd(g_builder, end)
     }

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -16,6 +16,7 @@ module llvm_jit shared private
 
 require llvm/daslib/llvm_boost
 require llvm/daslib/llvm_jit_intrin
+require llvm/daslib/llvm_jit_lower
 require llvm/daslib/llvm_jit_common
 require llvm/daslib/llvm_jit_code
 require llvm/daslib/llvm_user_modules  // nolint:STYLE030,LINT019 - side-effect require: [llvm_code] generator modules must be in THIS module's closure so their [init] registration runs in the context that reads the registry; STYLE030 is policy-gated, so the keep only fires under a require-analysis run
@@ -1745,6 +1746,12 @@ class public LlvmJitVisitor : AstVisitor {
                     params |> push(cmresPtr, 0)
                     var ccall = build_interop_call(expr.func, typ, func, expr.arguments, params, true, "")
                     setE(expr, cmresEval)
+                } elif (has_interop_lowering(expr)) {
+                    var ccall = lookup_interop_lowering(g_ctx, g_builder, types, expr,
+                        [for (x in expr.arguments); getE(x)]) {
+                        return build_interop_call(expr.func, typ, func, expr.arguments, params, false, "")
+                    }
+                    setE(expr, ccall)
                 } else {
                     var ccall = build_interop_call(expr.func, typ, func, expr.arguments, params, false, "")
                     setE(expr, ccall)

--- a/modules/dasLLVM/daslib/llvm_jit_common.das
+++ b/modules/dasLLVM/daslib/llvm_jit_common.das
@@ -95,6 +95,7 @@ var public g_t_simFunction : LLVMOpaqueType?
 var public g_t_function : LLVMOpaqueType?
 var public g_t_lambda : LLVMOpaqueType?
 var public g_t_block : LLVMOpaqueType?
+var public g_t_jit_function : LLVMOpaqueType?
 var public g_t_stack_state : LLVMOpaqueType?
 var public g_t_iterator : LLVMOpaqueType?
 var public g_t_sequence : LLVMOpaqueType?
@@ -720,6 +721,7 @@ def public init_jit_state(cg_opt_level : uint; target_triple : string; host_feat
     // cold: opt sinks the failure block off the hot path; pairs with noreturn.
     jit_add_extern(FN_JIT_EXCEPTION, jit_fn_type($(text, ctx, at : void?) : void {}),
         get_jit_exception(), fixed_array(noreturn, cold), (nocapture, [0, 1]))
+    g_t_jit_function = jit_fn_type($(ctx, args, cmres : void?) : float4 {})
     jit_add_extern(FN_JIT_CALL_OR_FASTCALL, jit_fn_type($(func, args, ctx : void?) : float4 {}),
         get_jit_call_or_fastcall(), fixed_array(nounwind, willreturn), (nocapture, [0, 1, 2]))
     jit_add_extern(FN_JIT_CALL_WITH_CMRES, jit_fn_type($(func, args, cmres, ctx : void?) : float4 {}),

--- a/modules/dasLLVM/daslib/llvm_jit_lower.das
+++ b/modules/dasLLVM/daslib/llvm_jit_lower.das
@@ -1,0 +1,106 @@
+options gen2
+options indenting = 4
+
+module llvm_jit_lower shared private
+
+require llvm/daslib/llvm_boost
+require llvm/daslib/llvm_jit_common
+require llvm/daslib/llvm_jit_intrin
+require daslib/ast_boost
+require daslib/lpipe
+
+def private jit_append_bb(ctx : JitCtx; name : string) {
+    let ffunc = LLVMGetBasicBlockParent(LLVMGetInsertBlock(ctx.builder))
+    return LLVMAppendBasicBlockInContext(ctx.ctx, ffunc, name)
+}
+
+def private jit_select(ctx : JitCtx; cond : LLVMOpaqueValue?; typ : LLVMOpaqueType?;
+                       if_true, if_false : block<LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    if (LLVMIsConstant(cond) != 0) {
+        let val = LLVMConstIntGetZExtValue(cond)
+        return val != 0ul ? invoke(if_true) : invoke(if_false)
+    }
+    var check_true = jit_append_bb(ctx, "check_true")
+    var check_false = jit_append_bb(ctx, "check_false")
+    var check_end = jit_append_bb(ctx, "check_end")
+    var phi_true = jit_append_bb(ctx, "phi_true")
+    var phi_false = jit_append_bb(ctx, "phi_false")
+    LLVMBuildCondBr(ctx.builder, cond, check_true, check_false)
+    LLVMPositionBuilderAtEnd(ctx.builder, check_true)
+    var pt = invoke(if_true)
+    LLVMBuildBr(ctx.builder, phi_true)
+    LLVMPositionBuilderAtEnd(ctx.builder, phi_true)
+    LLVMBuildBr(ctx.builder, check_end)
+    LLVMPositionBuilderAtEnd(ctx.builder, check_false)
+    var pf = invoke(if_false)
+    LLVMBuildBr(ctx.builder, phi_false)
+    LLVMPositionBuilderAtEnd(ctx.builder, phi_false)
+    LLVMBuildBr(ctx.builder, check_end)
+    LLVMPositionBuilderAtEnd(ctx.builder, check_end)
+    var phi = LLVMBuildPhi(ctx.builder, typ, "select")
+    LLVMAddIncoming(phi, fixed_array(pt, pf), fixed_array(phi_true, phi_false))
+    return phi
+}
+
+def private lower_array_push_back(ctx : JitCtx; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>;
+                                  slow : block<() : LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    let arr_ptr = arguments[0]
+    let arrTy = type_to_llvm_type(expr.arguments[0]._type)
+    var hdr = LLVMBuildLoad2(ctx.builder, arrTy, arr_ptr, "push.hdr")
+    var size = LLVMBuildExtractValue(ctx.builder, hdr, uint(JIT_ARRAY.SIZE), "push.size")
+    var cap = LLVMBuildExtractValue(ctx.builder, hdr, uint(JIT_ARRAY.CAPACITY), "push.cap")
+    var lock = LLVMBuildExtractValue(ctx.builder, hdr, uint(JIT_ARRAY.LOCK), "push.lock")
+    var unlocked = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntEQ, lock,
+        LLVMConstInt(LLVMTypeOf(lock), 0ul, 0), "push.unlocked")
+    var fits = LLVMBuildICmp(ctx.builder, LLVMIntPredicate.LLVMIntULT, size, cap, "push.fits")
+    var fast = LLVMBuildAnd(ctx.builder, unlocked, fits, "push.fast")
+    var res = jit_select(ctx, fast, ctx.types.t_int64) {
+        var sizePtr = LLVMBuildStructGEP2(ctx.builder, arrTy, arr_ptr, uint(JIT_ARRAY.SIZE), "push.sizep")
+        var next = LLVMBuildAdd(ctx.builder, size, LLVMConstInt(LLVMTypeOf(size), 1ul, 0), "push.next")
+        LLVMBuildStore(ctx.builder, next, sizePtr)
+        return size
+    }
+    lpipe() {
+        return invoke(slow)
+    }
+    return res
+}
+
+def private gate_array_push_back(expr : ExprCallFunc?) : bool {
+    if (length(expr.arguments) < 2) return false
+    assume argT = expr.arguments[0]._type
+    return argT != null && argT.isGoodArrayType
+}
+
+let private g_lower_lookup <- {
+    "$::__builtin_array_push_back" => @@lower_array_push_back
+}
+
+let private g_lower_gate <- {
+    "$::__builtin_array_push_back" => @@gate_array_push_back
+}
+
+def private lowering_name(expr : ExprCallFunc?) : string {
+    if (expr.func == null) return ""
+    return "{expr.func._module.name}::{expr.func.name}"
+}
+
+def public has_interop_lowering(expr : ExprCallFunc?) : bool {
+    var result = false
+    g_lower_gate |> get(lowering_name(expr)) $(pgate) {
+        result = pgate |> invoke(expr)
+    }
+    return result
+}
+
+def public lookup_interop_lowering(var g_ctx : LLVMContextRef; var g_builder : LLVMOpaqueBuilder?;
+                                   var types : PrimitiveTypes?; expr : ExprCallFunc?; arguments : array<LLVMOpaqueValue?>;
+                                   slow : block<() : LLVMOpaqueValue?>) : LLVMOpaqueValue? {
+    var result : LLVMOpaqueValue?
+    g_lower_lookup |> get(lowering_name(expr)) $(pfun) {
+        result = pfun |> invoke(JitCtx(ctx = g_ctx, types = types, builder = g_builder), expr, arguments) {
+            return invoke(slow)
+        }
+    }
+    return result
+}

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -40,7 +40,7 @@ let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x51ul   // each(array/fixed array) for-
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0x695a9d9f12358328ul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0x54bec6b39d3ccc73ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -36,11 +36,11 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x51ul   // each(array/fixed array) for-loop sources walk inline instead of building a Sequence
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x52ul   // array push-back inlines the fits-in-capacity path (0x51: each(array/fixed array) for-loop sources walk inline)
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0x54bec6b39d3ccc73ul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0xc55144c99694597bul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -36,11 +36,11 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x50ul   // -exe native paths re-root at run time via jit_register_native_path_resolve
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x51ul   // each(array/fixed array) for-loop sources walk inline instead of building a Sequence
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0xafb153c2e58d8417ul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0x695a9d9f12358328ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -36,11 +36,11 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x52ul   // array push-back inlines the fits-in-capacity path (0x51: each(array/fixed array) for-loop sources walk inline)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x54ul   // indirect calls to jitted functions inline the dispatcher, cmres included (0x52: array push-back inlines the fits-in-capacity path)
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0xc55144c99694597bul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0x90e94d70a17cd771ul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/skills/internal/aot_testing.md
+++ b/skills/internal/aot_testing.md
@@ -79,14 +79,14 @@ tests/aot/
 # Build the test_aot binary
 cmake --build build --config Release --target test_aot
 
-# Run all AOT tests (test_aot detects its own AOT stubs via is_in_aot())
-bin/Release/test_aot.exe dastest/dastest.das -- --test tests/aot
+# Run all AOT tests - --use-aot is REQUIRED, there is no auto-detection at runtime
+bin/Release/test_aot.exe -use-aot dastest/dastest.das -- --use-aot --test tests/aot
 
 # Run with the regular daslang binary (no AOT, interpreter mode)
 bin/Release/daslang.exe dastest/dastest.das -- --test tests/aot
 ```
 
-The `-use-aot` flag enables AOT for sub-compiled test files even when the host binary has stubs. But `test_aot` auto-detects via `is_in_aot()` in `dastest/suite.das`.
+`--use-aot` (the dastest flag, after `--`) is what sets `cop.aot` + `cop.fail_on_no_aot` on each compiled test file. **Without it the stubs are simply never linked and every test silently interprets** - the run still passes, so a lane that forgets the flag measures/tests nothing. `is_in_aot()` is true only while the AOT emitter itself runs (`daslib/aot_cpp` calls `set_aot()`), never in a plain `test_aot` run, and `dastest`'s `[INTERP]`/`[JIT]` benchmark label is derived from it - so an AOT run still prints `[INTERP]`. The `run_tests_aot` / `run_tests_aot_subset` targets pass both `-use-aot` (host) and `--use-aot` (dastest); copy them.
 
 ## Adding Tests to AOT - CRITICAL
 
@@ -144,7 +144,7 @@ def test_basic(t : T?) {
 The AOT flag flows through three layers:
 
 1. **`main.cpp`**: `-use-aot` sets `useAot = true`. Does NOT set `policies.aot` on the host (dastest framework functions don't have AOT stubs in every binary).
-2. **`dastest/suite.das`**: `--use-aot` (or auto-detected via `is_in_aot()`) sets `ctx.use_aot = true`. When compiling test files, sets `cop.aot = true` and `cop.fail_on_no_aot = true`.
+2. **`dastest/suite.das`**: `--use-aot` sets `ctx.use_aot = true` (the `|| is_in_aot()` beside it never fires at run time - see above). When compiling test files, sets `cop.aot = true` and `cop.fail_on_no_aot = true`.
 3. **`dastest/dastest.das`**: In isolated mode, forwards `-use-aot` to child processes when `is_in_aot()` is true.
 
 **Critical**: The host program must NOT set `policies.aot = true` because the host compiles dastest framework scripts (like `suite.das`), which don't have AOT stubs in the host binary. Only the sub-compiled test files get `cop.aot = true`.

--- a/skills/style_lint.md
+++ b/skills/style_lint.md
@@ -14,6 +14,13 @@ Suppress one finding with `// nolint:STYLEnnn` on the line. Per-module `options`
 (STYLE037), `_function_length` (STYLE038), `_duplicate_regions` plus `_dupe_min_nodes` /
 `_dupe_min_statements` (STYLE040), and `_enable_default_off_rules` to force default-off rules on.
 
+**A file-level `options` line needs a reason the file cannot compile or run without it.** Never
+copy an options header from a neighbouring module - each knob there earns its place in *that*
+file, not in yours. `_comment_hygiene = false` is the clearest case: a new file has no comments
+to exempt, so adding it only pre-authorizes prose the comment rules would otherwise drain. When
+a knob does look necessary, try the code fix first - a const mismatch that seems to need
+`relaxed_pointer_const` is often one `var` parameter away.
+
 ## STYLE037 / STYLE038 - suppress an honest shape, never force a split
 
 Both metric rules spell their escapes the same way: `// nolint:STYLE03x` on the `def` line, or a

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -1153,9 +1153,11 @@ namespace das {
         DAS_ASSERT(capture && "generator first argument is lambda capture");
         for ( auto & var : expr->variables ) {
             auto vtd = new TypeDecl(*var->type);
+            if ( !vtd->at.fileInfo ) vtd->at = var->at;
             bool isRef = vtd->ref;
             if ( isRef ) {
                 auto pvtd = new TypeDecl(Type::tPointer);
+                pvtd->at = var->at;
                 pvtd->firstType = vtd;
                 vtd->ref = false;
                 vtd = pvtd;
@@ -1413,6 +1415,24 @@ namespace das {
         return src->rtti_isCallLikeExpr() || src->rtti_isMakeLocal();
     }
 
+    ExpressionPtr makeCounterRef ( const LineInfo & at, const string & pVarName, const TypeDeclPtr & elemType ) {
+        auto ptrT = new TypeDecl(Type::tPointer);
+        ptrT->at = at;
+        ptrT->firstType = new TypeDecl(*elemType);
+        ptrT->firstType->at = at;
+        ptrT->firstType->constant = false;
+        ptrT->firstType->explicitConst = false;
+        ptrT->firstType->ref = false;
+        auto cast = new ExprCast(at, new ExprVar(at, pVarName), ptrT);
+        cast->reinterpret = true;
+        cast->alwaysSafe = true;
+        cast->generated = true;
+        auto deref = new ExprPtr2Ref(at, cast);
+        deref->alwaysSafe = true;
+        deref->generated = true;
+        return deref;
+    }
+
     ExpressionPtr replaceGeneratorFor ( ExprFor * expr, const FunctionPtr & func ) {
         auto begin_loop_label = func->totalGenLabel ++;
         auto mid_loop_label = func->totalGenLabel ++;
@@ -1528,6 +1548,7 @@ namespace das {
             const string & srcVarName = expr->iterators[si];
             const auto & src = expr->sources[si];
             const auto & iterv = expr->iteratorVariables[si];
+            const bool plainRange = src->type->isRange();
             // if its a temp ref type, we need to create a temp variable
             ExprLet * tempLet = nullptr;
             if ( srcNeedTempVar(src, src->type) ) {
@@ -1557,8 +1578,8 @@ namespace das {
             svar->name = srcName;
             svar->type = new TypeDecl(Type::autoinfer);
             svar->type->at = svar->at;
-            svar->init_via_move = true;
-            if ( src->type->isGoodIteratorType() ) {
+            svar->init_via_move = !plainRange;
+            if ( src->type->isGoodIteratorType() || plainRange ) {
                 svar->init = src->clone();
             } else {
                 auto ceach = new ExprCall(expr->at, "each");
@@ -1627,6 +1648,15 @@ namespace das {
             vvar->init = rein;
             veqt->variables.push_back(vvar);
             blk->list.push_back(veqt);
+            if ( plainRange ) {
+                blk->list.push_back(new ExprCopy(expr->at, makeCounterRef(expr->at, pVarName, iterv->type),
+                    new ExprField(expr->at, new ExprVar(expr->at, srcName), "x")));
+                auto rlt = new ExprOp2(expr->at, "<", new ExprVar(expr->at, srcVarName),
+                    new ExprField(expr->at, new ExprVar(expr->at, srcName), "y"));
+                blk->list.push_back(new ExprCopy(expr->at, new ExprVar(expr->at, loopVar),
+                    new ExprOp2(expr->at, "&&", rlt, new ExprVar(expr->at, loopVar))));
+                continue;
+            }
             // loop = _builtin_iterator_first(it0,pvar0) && loop
             // first() on the LEFT so it runs for EVERY source even when an earlier one came up
             // empty (matches SimNode_ForWithIterator) — end_loop closes all sources, and closing
@@ -1669,6 +1699,7 @@ namespace das {
                 rblk->isCollapseable = true;
                 // close iterators before returning (mirrors normal end_loop path)
                 for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
+                    if ( expr->sources[si]->type->isRange() ) continue;
                     auto cbif = new ExprCall(expr->at, "_builtin_iterator_close");
                     cbif->generated = true;
                     cbif->arguments.push_back(new ExprVar(expr->at, srcNames[si]));
@@ -1696,6 +1727,16 @@ namespace das {
         for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
             const string & srcName = srcNames[si];
             const string & pVarName = pVarNames[si];
+            if ( expr->sources[si]->type->isRange() ) {
+                const auto & iterv = expr->iteratorVariables[si];
+                blk->list.push_back(new ExprCopy(expr->at, makeCounterRef(expr->at, pVarName, iterv->type),
+                    new ExprOp2(expr->at, "+", new ExprVar(expr->at, expr->iterators[si]),
+                        new ExprConstInt(expr->at, 1))));
+                auto rne = new ExprOp2(expr->at, "!=", new ExprVar(expr->at, expr->iterators[si]),
+                    new ExprField(expr->at, new ExprVar(expr->at, srcName), "y"));
+                blk->list.push_back(new ExprOp2(expr->at, "&&=", new ExprVar(expr->at, loopVar), rne));
+                continue;
+            }
             auto cbif = new ExprCall(expr->at, "_builtin_iterator_next");
             cbif->generated = true;
             cbif->arguments.push_back(new ExprVar(expr->at, srcName));
@@ -1711,6 +1752,7 @@ namespace das {
         blk->list.push_back(ell);
         // loop &= _builtin_iterator_close(it0,pvar0)
         for ( size_t si=0, sis=expr->sources.size(); si!=sis; ++si ) {
+            if ( expr->sources[si]->type->isRange() ) continue;
             const string & srcName = srcNames[si];
             const string & pVarName = pVarNames[si];
             auto cbif = new ExprCall(expr->at, "_builtin_iterator_close");

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -5295,7 +5295,7 @@ namespace das {
         markNoDiscard(that);
     }
     ExpressionPtr InferTypes::visitForSource(ExprFor *expr, Expression *that, bool last) {
-        if (jitEnabled() && that->type && ((that->type->isHandle() && that->type->annotation->isIterable()) || (that->type->isString()))) {
+        if (jitEnabled() && that->type && that->type->isHandle() && that->type->annotation->isIterable()) {
             auto fnc = findMatchingFunctions("*", thisModule, "each", {that->type});
             // If there's any `each` for handle type use it, otherwise
             // stay in interpreter.

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -240,13 +240,6 @@ extern "C" {
 
     DAS_API vec4f jit_call_or_fastcall ( SimFunction * fn, vec4f * args, Context * context ) {
         if ( !fn ) context->throw_error("jit_call_or_fastcall: null function (unresolved LLVM-AOT call target)");
-        if ( fn->jitFunction ) {
-            // JIT->JIT direct call: skip the stack push/prologue (JIT'd bodies push their own
-            // frame via jit_prologue when they need one) and the virtual SimNode_Jit::eval.
-            auto res = ((JitFunction) fn->jitFunction)(context, args, nullptr);
-            context->stopFlags = 0;     // mirror callOrFastcall (an invoked interpreted block may leak stopForReturn)
-            return res;
-        }
         return context->callOrFastcall(fn, args, nullptr);
     }
 
@@ -862,6 +855,7 @@ extern "C" {
     void *das_get_jit_table_lock() { return (void *)&builtin_table_lock; }
     void *das_get_jit_table_unlock() { return (void *)&builtin_table_unlock; }
     void *das_get_jit_array_resize() { return (void *)&builtin_array_resize; }
+
     void *das_get_jit_str_cmp() { return (void *)&jit_str_cmp; }
     void *das_get_jit_prologue() { return (void *)&jit_prologue; }
     void *das_get_jit_epilogue() { return (void *)&jit_epilogue; }
@@ -1689,6 +1683,8 @@ extern "C" {
             addConstant<uint32_t>(*this, "SIZE_OF_SIMNODE_INTEROP", uint32_t(sizeof(SimNode_AotInteropBase)));
             addConstant<uint32_t>(*this, "CONTEXT_OFFSET_OF_EVAL_TOP", uint32_t(uint32_t(offsetof(Context, stack) + offsetof(StackAllocator, evalTop))));
             addConstant<uint32_t>(*this, "CONTEXT_OFFSET_OF_GLOBALS", uint32_t(uint32_t(offsetof(Context, globals))));
+            addConstant<uint32_t>(*this, "CONTEXT_OFFSET_OF_STOP_FLAGS", uint32_t(uint32_t(offsetof(Context, stopFlags))));
+            addConstant<uint32_t>(*this, "SIMFUNCTION_OFFSET_OF_JIT_FUNCTION", uint32_t(uint32_t(offsetof(SimFunction, jitFunction))));
             addConstant<uint32_t>(*this, "CONTEXT_OFFSET_OF_SHARED", uint32_t(uint32_t(offsetof(Context, shared))));
             // lets make sure its all aot ready
             verifyAotReady();

--- a/tests-cpp/small/test_jit_emitter_pin.cpp
+++ b/tests-cpp/small/test_jit_emitter_pin.cpp
@@ -24,6 +24,7 @@ static const char * EMITTER_FILES[] = {
     "llvm_code.das",
     "llvm_dsl.das",
     "llvm_jit_intrin.das",
+    "llvm_jit_lower.das",
     "llvm_targets.das",
     "llvm_user_modules.das",
 };

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -328,6 +328,11 @@ list(FILTER AOT_LANGUAGE_FILES EXCLUDE REGEX "failed_|cant_|invalid_")
 # Exclude module files (they are compiled via DAS_AOT_LIB below)
 list(FILTER AOT_LANGUAGE_FILES EXCLUDE REGEX "/_")
 
+# JIT-vs-AOT primitive benchmarks ride the language suite so test_aot_subset can run
+# them with real AOT stubs (`--bench` lane); they require nothing beyond testing_boost.
+FILE(GLOB AOT_JIT_BENCH_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "benchmarks/core/jit_aot/*.das")
+list(APPEND AOT_LANGUAGE_FILES ${AOT_JIT_BENCH_FILES})
+
 # Minimal daslib closure for test_aot_subset: ONLY the daslib modules whose
 # runtime functions tests/language actually calls (50101 otherwise). This is
 # NOT the all-daslib coverage lib above — keep it minimal; a new tests/language

--- a/tests/jit_tests/array_push_fast.das
+++ b/tests/jit_tests/array_push_fast.das
@@ -1,0 +1,72 @@
+options gen2
+require dastest/testing_boost
+
+def push_range(n : int) : array<int> {
+    var res : array<int>   // nolint:STYLE027 - the push loop IS the path under test
+    for (i in range(n)) {
+        res |> push(i * 3)   // nolint:PERF006 - growing from empty is the case under test
+    }
+    return <- res
+}
+
+def push_after_reserve(n : int) : int {
+    var a : array<int>
+    a |> reserve(n)
+    for (i in range(n)) {
+        a |> push(i)
+    }
+    var s = 0
+    for (x in a) {
+        s += x
+    }
+    delete a
+    return s
+}
+
+def push_strings() : int {
+    var a : array<string>   // nolint:STYLE012 - a run of pushes IS the path under test
+    a |> push("x")
+    a |> push("yy")
+    a |> push("zzz")
+    var n = 0
+    for (s in a) {
+        n += length(s)
+    }
+    delete a
+    return n
+}
+
+def push_during_iteration(var a : array<int>) : bool {
+    var threw = false
+    try {
+        for (_x in a) {
+            a |> push(1)   // nolint:PERF006 - this push must throw, not grow
+        }
+    } recover {
+        threw = true
+    }
+    return threw
+}
+
+[test]
+def test_array_push_fast(t : T?) {
+    t |> run("grows from empty across capacity steps") @(t : T?) {
+        t |> success(!jit_enabled() || is_jit_function(@@push_range))
+        var a <- push_range(100)
+        t |> equal(length(a), 100)
+        t |> equal(a[0], 0)
+        t |> equal(a[99], 297)
+        t |> success(capacity(a) >= 100)
+        delete a
+    }
+    t |> run("reserved capacity takes the inline path") @(t : T?) {
+        t |> equal(push_after_reserve(100), 4950)
+    }
+    t |> run("non-POD elements") @(t : T?) {
+        t |> equal(push_strings(), 6)
+    }
+    t |> run("push into a locked array still throws") @(t : T?) {
+        var a <- push_range(4)
+        t |> success(push_during_iteration(a))
+    }
+}

--- a/tests/jit_tests/each_inline.das
+++ b/tests/jit_tests/each_inline.das
@@ -1,0 +1,122 @@
+options gen2
+require dastest/testing_boost
+
+def each_array_sum(a : array<int>) : int {
+    var s = 0
+    for (x in each(a)) {
+        s += x
+    }
+    return s
+}
+
+def each_dim_sum(a : int[4]) : int {
+    var s = 0
+    for (x in each(a)) {
+        s += x
+    }
+    return s
+}
+
+def each_array_bump(var a : array<int>) {   // nolint:LINT014 - writes go through the element reference
+    for (x in each(a)) {
+        x++
+    }
+}
+
+def each_break_at(a : array<int>; stop : int) : int {
+    var n = 0
+    for (_x in each(a)) {
+        n++
+        break if (n == stop)
+    }
+    return n
+}
+
+def each_return_at(a : array<int>; stop : int) : int {
+    var n = 0
+    for (x in each(a)) {
+        n++
+        return x if (n == stop)
+    }
+    return -1
+}
+
+def each_with_range(a : array<int>) : int {
+    var s = 0
+    for (x, i in each(a), range(2)) {
+        s += x * (i + 1)
+    }
+    return s
+}
+
+def each_nested(a : array<int>) : int {
+    var s = 0
+    for (x in each(a)) {
+        for (y in each(a)) {
+            s += x * y
+        }
+    }
+    return s
+}
+
+def each_table_stays_generic(t : table<int; int>) : int {
+    var s = 0
+    for (kv in each_kv(t)) {
+        s += kv.key + kv.value
+    }
+    return s
+}
+
+[test]
+def test_each_inline(t : T?) {
+    t |> run("array source walks inline") @(t : T?) {
+        t |> success(!jit_enabled() || is_jit_function(@@each_array_sum))
+        var a <- [for (i in range(5)); i]
+        t |> equal(each_array_sum(a), 10)
+        delete a
+    }
+    t |> run("fixed array source walks inline") @(t : T?) {
+        t |> success(!jit_enabled() || is_jit_function(@@each_dim_sum))
+        var d : int[4]
+        for (i in range(4)) {
+            d[i] = i * 10
+        }
+        t |> equal(each_dim_sum(d), 60)
+    }
+    t |> run("element is a writable reference") @(t : T?) {
+        var a <- [for (i in range(4)); i]
+        each_array_bump(a)
+        t |> equal(each_array_sum(a), 10)
+        delete a
+    }
+    t |> run("break unlocks the array") @(t : T?) {
+        var a <- [for (i in range(5)); i]
+        t |> equal(each_break_at(a, 3), 3)
+        a |> push(5)
+        t |> equal(length(a), 6)
+        delete a
+    }
+    t |> run("return unlocks the array") @(t : T?) {
+        var a <- [for (i in range(5)); i]
+        t |> equal(each_return_at(a, 4), 3)
+        a |> push(5)
+        t |> equal(length(a), 6)
+        delete a
+    }
+    t |> run("mixed sources stop at the shortest") @(t : T?) {
+        var a <- [for (i in range(5)); i + 1]
+        t |> equal(each_with_range(a), 5)
+        delete a
+    }
+    t |> run("nested loops over one array") @(t : T?) {
+        var a <- [for (i in range(4)); i]
+        t |> equal(each_nested(a), 36)
+        delete a
+    }
+    t |> run("table each keeps the generic path") @(t : T?) {
+        t |> success(!jit_enabled() || is_jit_function(@@each_table_stays_generic))
+        var tab <- {1 => 10, 2 => 20}
+        t |> equal(each_table_stays_generic(tab), 33)
+        delete tab
+    }
+}

--- a/tests/jit_tests/invoke_cmres.das
+++ b/tests/jit_tests/invoke_cmres.das
@@ -1,0 +1,63 @@
+options gen2
+require dastest/testing_boost
+
+struct Big {
+    a : int
+    b : int
+    c : int
+    d : int
+}
+
+def make_big(k : int) : Big {
+    return Big(a = k, b = k * 2, c = k * 3, d = k * 4)
+}
+
+def via_fn_ptr(fun : function<(k : int) : Big>; k : int) : Big {
+    return invoke(fun, k)
+}
+
+def via_lambda(fun : lambda<(k : int) : Big>; k : int) : Big {
+    return invoke(fun, k)
+}
+
+class Maker {
+    scale : int
+    def make(k : int) : Big {
+        return Big(a = k * scale, b = k * scale * 2, c = k * scale * 3, d = k * scale * 4)
+    }
+}
+
+def expect_big(t : T?; got : Big; a, b, c, d : int) {
+    t |> equal(a, got.a)
+    t |> equal(b, got.b)
+    t |> equal(c, got.c)
+    t |> equal(d, got.d)
+}
+
+[test]
+def test_cmres_invoke(t : T?) {
+    t |> run("function pointer") @(t : T?) {
+        expect_big(t, via_fn_ptr(@@make_big, 7), 7, 14, 21, 28)
+        expect_big(t, make_big(7), 7, 14, 21, 28)
+    }
+    t |> run("lambda") @(t : T?) {
+        var fn <- @(k : int) : Big => Big(a = k, b = k * 2, c = k * 3, d = k * 4)
+        expect_big(t, via_lambda(fn, 5), 5, 10, 15, 20)
+        unsafe {
+            delete fn
+        }
+    }
+    t |> run("class method") @(t : T?) {
+        var m = new Maker(scale = 3)
+        expect_big(t, m->make(2), 6, 12, 18, 24)
+        unsafe {
+            delete m
+        }
+    }
+    t |> run("result is not aliased across two invokes") @(t : T?) {
+        let first = via_fn_ptr(@@make_big, 1)
+        let second = via_fn_ptr(@@make_big, 9)
+        expect_big(t, first, 1, 2, 3, 4)
+        expect_big(t, second, 9, 18, 27, 36)
+    }
+}

--- a/tests/jit_tests/string_iter.das
+++ b/tests/jit_tests/string_iter.das
@@ -1,0 +1,140 @@
+options gen2
+require dastest/testing_boost
+
+struct Box {
+    arr : array<int>
+}
+
+def sum_chars(s : string) : int {
+    var acc = 0
+    for (c in s) {
+        acc += c
+    }
+    return acc
+}
+
+def collect(s : string) : array<int> {
+    var res : array<int>   // nolint:STYLE027 - the push loop IS the path under test
+    for (c in s) {
+        res |> push(c)   // nolint:PERF006 - growing from empty is the path under test
+    }
+    return <- res
+}
+
+[test]
+def test_string_iteration(t : T?) {
+    t |> run("empty string never enters the body") @(t : T?) {
+        var n = 0
+        for (_c in "") {
+            n++
+        }
+        t |> equal(0, n)
+        t |> equal(0, sum_chars(""))
+    }
+    t |> run("single char") @(t : T?) {
+        t |> equal(65, sum_chars("A"))
+        let v <- collect("A")
+        t |> equal(1, length(v))
+        t |> equal(65, v[0])
+    }
+    t |> run("ascii run") @(t : T?) {
+        t |> equal(104 + 105, sum_chars("hi"))
+        let v <- collect("abc")
+        t |> equal(3, length(v))
+        t |> equal(97, v[0])
+        t |> equal(98, v[1])
+        t |> equal(99, v[2])
+    }
+    t |> run("high bytes stay unsigned") @(t : T?) {
+        let v <- collect("é")
+        t |> equal(2, length(v))
+        t |> equal(195, v[0])
+        t |> equal(169, v[1])
+        t |> equal(195 + 169, sum_chars("é"))
+    }
+    t |> run("0xff byte") @(t : T?) {
+        let v <- collect("\xff")
+        t |> equal(1, length(v))
+        t |> equal(255, v[0])
+    }
+    t |> run("break stops early") @(t : T?) {
+        var n = 0
+        for (c in "abcdef") {
+            n++
+            if (c == 'c') {
+                break
+            }
+        }
+        t |> equal(3, n)
+    }
+    t |> run("continue skips") @(t : T?) {
+        var acc = 0
+        for (c in "abc") {
+            if (c == 'b') {
+                continue
+            }
+            acc += c
+        }
+        t |> equal(97 + 99, acc)
+    }
+    t |> run("variable source, not just a literal") @(t : T?) {
+        let s = "hello"
+        t |> equal(sum_chars(s), sum_chars("hello"))
+        var total = 0
+        for (c in s) {
+            total += c
+        }
+        t |> equal(sum_chars("hello"), total)
+    }
+    t |> run("nested loops over two strings") @(t : T?) {
+        var pairs = 0
+        for (_a in "ab") {
+            for (_b in "xyz") {
+                pairs++
+            }
+        }
+        t |> equal(6, pairs)
+    }
+    t |> run("loop twice over the same string") @(t : T?) {
+        let s = "abc"
+        t |> equal(sum_chars(s), sum_chars(s))
+    }
+}
+
+[test]
+def test_string_iteration_multi_source(t : T?) {
+    t |> run("multi-source stops at the shortest") @(t : T?) {
+        var arr <- [1, 2, 3, 4, 5]
+        var n = 0
+        for (x, _c in arr, "ab") {
+            n += x
+        }
+        t |> equal(1 + 2, n)
+    }
+    t |> run("empty companion source keeps the loop out") @(t : T?) {
+        var empty : array<int>
+        var n = 0
+        for (x, _c in empty, "abc") {
+            n = n * 100 + x
+        }
+        t |> equal(0, n)
+    }
+    t |> run("empty string keeps a companion array out and unlocked") @(t : T?) {
+        var arr <- [1, 2, 3]
+        var n = 0
+        for (_c, x in "", arr) {
+            n += x
+        }
+        t |> equal(0, n)
+        arr |> push(4)
+        t |> equal(4, length(arr))
+    }
+    t |> run("each() over a field beside a string source") @(t : T?) {
+        let b <- Box(arr <- [1, 2, 3])
+        var n = 0
+        for (_c, x in "ab", each(b.arr)) {
+            n += x
+        }
+        t |> equal(1 + 2, n)
+    }
+}

--- a/tests/language/cant_write_generator_for_variable.das
+++ b/tests/language/cant_write_generator_for_variable.das
@@ -1,0 +1,19 @@
+options gen2
+expect 30952
+
+def g() : iterator<int> {
+    return <- generator<int> {
+        for (i in range(3)) {
+            i = 5
+            yield i
+        }
+        return false
+    }
+}
+
+[export]
+def main() {
+    for (x in g()) {
+        print("{x}\n")
+    }
+}

--- a/tests/language/generators.das
+++ b/tests/language/generators.das
@@ -350,6 +350,42 @@ def test_for_finally_continue(t : T?) {
     checkSeq(t, gen, [99, 1, 99, 99, 3, 99, 99])
 }
 
+def test_for_range_flavors(t : T?) {
+    var gen <- generator<int> {
+        for (u in urange(3u)) {
+            yield int(u)
+        }
+        for (l in range64(3l, 7l)) {
+            yield int(l)
+        }
+        for (ul in urange64(7ul, 10ul)) {
+            yield int(ul)
+        }
+        return false
+    }
+    checkIt(t, gen)
+}
+
+def test_for_two_ranges(t : T?) {
+    var gen <- generator<int> {
+        for (a, _b in range(10), range(100, 200)) {
+            yield a
+        }
+        return false
+    }
+    checkIt(t, gen)
+}
+
+def test_for_range_and_iterator(t : T?) {
+    var gen <- generator<int> {
+        for (c, _i in "0123456789", range(10)) {
+            yield c - 48
+        }
+        return false
+    }
+    checkIt(t, gen)
+}
+
 def test_for_finally_empty(t : T?) {
     // empty iterator: body never enters, finally never runs
     var gen <- generator<int> {
@@ -385,4 +421,7 @@ def test_generators(t : T?) {
     t |> run("for finally + break in generator") @(t : T?) { test_for_finally_break(t); }
     t |> run("for finally + continue in generator") @(t : T?) { test_for_finally_continue(t); }
     t |> run("for finally empty in generator") @(t : T?) { test_for_finally_empty(t); }
+    t |> run("for over every range flavor") @(t : T?) { test_for_range_flavors(t); }
+    t |> run("for over two ranges") @(t : T?) { test_for_two_ranges(t); }
+    t |> run("for over range and iterator") @(t : T?) { test_for_range_and_iterator(t); }
 }


### PR DESCRIPTION
Four JIT codegen changes, each measured against AOT on the same binary, plus the probe suite that produced the numbers.

## Why

The JIT was slower than AOT on several everyday shapes for one structural reason: AOT gets `__forceinline` C++ templates where the JIT emits a call into the runtime. Each change below closes one of those, and each is a separate commit so it can be reverted on its own.

## What changed

**`jit: each(array/fixed array) for-loop sources walk inline`** — `for (x in each(arr))` hid an array behind a `Sequence`, paying the generic iterator protocol over a source this backend already walks natively. Unwrapped to the argument; the `each()` call is registered in `skipCall` and never evaluated, which also drops the per-loop heap iterator.

**`ast: a generator's for over a range keeps its counter in the capture frame`** — `replaceGeneratorFor` wrapped every source in `each()`, so `for (i in range(n))` inside a generator became a heap range iterator plus a virtual `first`/`next`/`close` per element **in all three lanes**. A range carries its own bound, so counter and bound live in the capture frame and `first`/`next` become the two lines `RangeIterator` would run. The counter is written through the same `void?` launder the C++ iterator used, so the loop variable stays `const` for the body — `cant_write_generator_for_variable.das` pins that (relaxing it silently turned `i = 5` into an infinite loop).

**`jit: array push-back inlines the fits-in-capacity path`** — AOT inlines `array_grow`, whose common case is a lock check, a capacity compare and a size store; only a real grow calls `array_reserve`. The JIT called `__builtin_array_push_back` on every push. The helper is kept for the grow and locked cases so growth policy and the locked-array throw stay in the runtime.

**`jit: inline the dispatcher on indirect calls to jitted functions`** — `jit_call_or_fastcall` only tests `SimFunction::jitFunction`, calls it and clears `Context::stopFlags`; that is now emitted in place, with the helper as the else-branch for interpreted/fastcall callees. **The two field offsets come from C++ accessors, not from constants in the emitter** — a hardcoded offset is a silent miscompile when the struct moves, a stale accessor is a link error.

Plus `ast: mark the generator-lowered launder nodes generated` (STYLE034 was reporting compiler-emitted IR as user source) and a correction to `skills/aot_testing.md`: `--use-aot` is required, there is no runtime auto-detection — a `test_aot` run without it silently interprets and still passes.

## Numbers

`benchmarks/core/jit_aot/primitives.das`, medians of 3, pinned core, both lanes on the same binary (ns/op):

| probe | AOT | JIT before | JIT after |
|---|---:|---:|---:|
| `each_iterator` | 1.4 | 2.3 | **0.5** |
| `each_iterator_setup/8` | 38.9 | 41.5 | **15.6** |
| `generator` (for over range) | 4.8 → **2.6** | 9.8 | **6.0** |
| `array_push` | 1.6 | 3.4 | **1.1** |

Indirect calls, interleaved same-session A/B with the emitter swapped between runs (JIT lane, medians of 3):

| probe | dispatcher | inlined |
|---|---:|---:|
| `class_method` | 3.00 | **1.60** (−47%) |
| `class_method_mono` | 2.90 | **1.60** (−45%) |
| `fnptr_invoke` | 2.80 | **1.60** (−43%) |
| `lambda_invoke` | 2.90 | **2.20** (−24%) |

Untouched probes (`static_call`, `try_recover`, `table_insert`, `build_string`) move ≤3%.

Across the 37-probe suite the JIT now wins or ties on most: `each_iterator` 0.33×, `static_call` 0.57×, `array_push` 0.69×, `table_int_get` 0.67×, `sort_default` 0.87×, `struct_clone` 0.84×, `build_string` 0.94×.

## Known remaining gaps (not addressed here)

- **Blocks** — `sort_block` (a comparator invoke per comparison) and `block_invoke` still take the generic path. Their capture base is not recoverable from a copied `Block` header; fixing it means storing the capture base inside `das::Block` (48 → 56 bytes), a real ABI change worth its own discussion.
- **`try_recover`** ~2.4× — two blocks built per `try` plus a runtime call, where AOT gets an inlined try/catch.
- **`hash_int`** ~2.1× — `_builtin_hash_int32` is `inline` in a header so AOT inlines wyhash. Matching it means reproducing wyhash bit-exactly in hand-written IR; since `hash()` feeds container hashing, a divergence between lanes would corrupt tables silently. Deliberately not attempted.
- Function-pointer/lambda/method calls still marshal arguments through a `vec4f` array where AOT passes them natively. Removing that needs either impl-symbol export (which risks the `static_call` win) or a per-module registration table.

## Testing

- `run_tests_jit` (full suite), `tests/language` under `-jit` (1606), `tests/jit_tests` (341)
- AOT lane via `test_aot_subset --use-aot` on `tests/language`
- New regression tests: `tests/jit_tests/each_inline.das` (9 arms incl. break/return unlock, mixed sources, nested loops), `tests/jit_tests/array_push_fast.das` (growth, reserved capacity, non-POD elements, locked-array throw), `tests/language/cant_write_generator_for_variable.das`, plus 3 arms in `tests/language/generators.das` covering every range flavour, two zipped ranges, and range zipped with a non-range iterator

Lint is untouched in this PR by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
