### PR TITLE
tests/spirv: no_aot on the lint-fold test, per the dir convention for compile_file tests

### DIFF
--- a/tests/spirv/test_const_fold_under_lint.das
+++ b/tests/spirv/test_const_fold_under_lint.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options no_aot     // invokes the compiler at runtime (compile_file) — not AOT-linkable
 
 // Lint compiles with folding off, so a const global keeps the initializer as written. The emitter
 // still needs its value -- for a constant `let` it lowers to an OpConstant, and for a named layout


### PR DESCRIPTION
Follow-up from #3730's review: `test_const_fold_under_lint.das` invokes the compiler at runtime (`compile_file`), and this directory marks that shape `options no_aot` (`test_conf_rejects.das`, `test_fail_closed.das` — "not AOT-linkable"). The new test was missing the line, and the nightly `test_aot` glob picks up every non-underscore `tests/spirv` file; per-PR CI cannot see it because the PR gate only AOT-compiles `tests/language`.

<details>
<summary>Validation, claims</summary>

### Validation
- Test still passes with the line: 2/2.
- Lint clean on the changed file.

### Claims — stated, not tested
- Nightly `test_aot` not built locally (nightly-scale target); the sibling precedent comments are the evidence the emission must be skipped.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
