### PR TITLE
External-PR review follow-ups: jobque fence test, SPIR-V value pins, skill nuance

### DIFF
--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -80,9 +80,11 @@ no call site can supply crashes simulation", not "used to crash". A mechanism no
 stays when a maintainer needs it to change the code without breaking the guard (why
 an encoding stays injective); it goes when it only argues the guard was right.
 
-**The message is the comment.** A branch whose error/decline/log string already states
-the fact gets no comment on top. This makes good diagnostics double as documentation —
-one more reason to write them well.
+**The message is the comment.** Any site that already carries a human-readable failure
+string — a branch's error/decline/log, an assertion or panic message, a test
+expectation — gets no comment restating it; put the fact the reader needs *into* the
+string instead. This makes good diagnostics double as documentation — one more reason
+to write them well.
 
 **Counterpart pointers earn their line.** When a condition handles one half of a split
 responsibility, a few words naming where the other half lives is a good same-line

--- a/skills/jobque_debugging.md
+++ b/skills/jobque_debugging.md
@@ -81,7 +81,8 @@ refcounts.
 **`synch primitive deleted while being used (ref=N)` on a `with_channel` line
 is that scope closing on a worker that has not released yet** — N is the count
 it still holds, and the worker then touches a destroyed mutex, so the panic is
-followed by a fatal from libc. Taking the worker's payload is not that release:
+followed by a secondary crash — a libc mutex fatal on Linux, an access violation
+in the exit-time leak dump on Windows. Taking the worker's payload is not that release:
 a worker pushes and releases after, which wakes the consumer between the two,
 so a consumer that stops at the payload (`pop_with_timeout_clone`, `try_pop`)
 must `join()` the channel before its scope ends. A consumer that stops on the

--- a/tests/jobque/test_jobque_channels.das
+++ b/tests/jobque/test_jobque_channels.das
@@ -250,11 +250,14 @@ def test_join_fences_a_payload_consumer(t : T?) {
                 ch |> notify_and_release()
             }
             var got = false
-            while (!got) {
+            var rounds = 0
+            while (!got && rounds < 500) {
                 got = pop_with_timeout_clone(ch, 10) $(r : IntVal#) {
                     value = r.v
                 }
+                rounds++
             }
+            t |> success(got, "worker payload never arrived within the 500 x 10ms cap")
             ch |> join()
         }
         t |> equal(42, value)

--- a/tests/jobque/test_jobque_channels.das
+++ b/tests/jobque/test_jobque_channels.das
@@ -3,6 +3,7 @@ options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 require dastest/testing_boost public
 require daslib/jobque_boost
+require daslib/fio
 
 // Channel boost helpers (push_clone, for_each_clone, etc.) require struct types.
 // POD types (int, float, int2) cannot be used with `new TT` or `delete temp`.
@@ -232,6 +233,33 @@ def test_channel_push_batch_clone(t : T?) {
             t |> equal(20, results[1])
             t |> equal(30, results[2])
         }
+    }
+}
+
+// A consumer that stops at the payload (pop_with_timeout_clone, try_pop) wakes on the worker's
+// push, which happens BEFORE the worker's notify_and_release - without a join() the with_channel
+// scope can close on a channel the worker still references, which panics the process. The sleep
+// holds that window open deliberately; join() waiting the count to zero is the fence (the count
+// drops after the reference inside notify_and_release, under the same lock).
+[test]
+def test_join_fences_a_payload_consumer(t : T?) {
+    t |> run("join before scope close outlives a slow-releasing worker") @(t : T?) {
+        var got_v = 0
+        with_channel(1) $(ch) {
+            new_thread() @() {
+                ch |> push_clone(IntVal(v = 42))
+                sleep(200u)
+                ch |> notify_and_release()
+            }
+            var got = false
+            while (!got) {
+                got = pop_with_timeout_clone(ch, 10) $(r : IntVal#) {
+                    got_v = r.v
+                }
+            }
+            ch |> join()
+        }
+        t |> equal(42, got_v)
     }
 }
 

--- a/tests/jobque/test_jobque_channels.das
+++ b/tests/jobque/test_jobque_channels.das
@@ -236,15 +236,13 @@ def test_channel_push_batch_clone(t : T?) {
     }
 }
 
-// A consumer that stops at the payload (pop_with_timeout_clone, try_pop) wakes on the worker's
-// push, which happens BEFORE the worker's notify_and_release - without a join() the with_channel
-// scope can close on a channel the worker still references, which panics the process. The sleep
-// holds that window open deliberately; join() waiting the count to zero is the fence (the count
-// drops after the reference inside notify_and_release, under the same lock).
+// A payload consumer (pop_with_timeout_clone) wakes on the worker's push, which lands BEFORE the
+// worker's notify_and_release - the deliberate sleep holds that window open, and join() before the
+// with_channel scope closes is the fence (see skills/jobque_debugging.md).
 [test]
 def test_join_fences_a_payload_consumer(t : T?) {
     t |> run("join before scope close outlives a slow-releasing worker") @(t : T?) {
-        var got_v = 0
+        var value = 0
         with_channel(1) $(ch) {
             new_thread() @() {
                 ch |> push_clone(IntVal(v = 42))
@@ -254,12 +252,12 @@ def test_join_fences_a_payload_consumer(t : T?) {
             var got = false
             while (!got) {
                 got = pop_with_timeout_clone(ch, 10) $(r : IntVal#) {
-                    got_v = r.v
+                    value = r.v
                 }
             }
             ch |> join()
         }
-        t |> equal(42, got_v)
+        t |> equal(42, value)
     }
 }
 

--- a/tests/spirv/test_const_fold_under_lint.das
+++ b/tests/spirv/test_const_fold_under_lint.das
@@ -9,9 +9,38 @@ options no_aot     // invokes the compiler at runtime (compile_file) — not AOT
 
 require dastest/testing_boost public
 require daslib/ast
+require daslib/ast_boost
+require spirv/spirv_grammar
+require spirv/spirv_dis
 
 def fixture_path() : string {
     return "{get_das_root()}/tests/spirv/_lint_fold_fixture.das"
+}
+
+// The [compute_shader] macro stores the emitted blob as `name : array<uint>` whose initializer is
+// to_array_move([uint literals]) -- read the words back off the compiled program's AST.
+def shader_words(program : ProgramPtr; name : string) : array<uint> {
+    var words : array<uint>
+    for_each_global(get_this_module(program)) $(gv) {
+        if (gv.name == name && gv.init != null) {
+            var mk = gv.init ?as ExprMakeArray
+            if (mk == null) {
+                let call = gv.init ?as ExprCall
+                if (call != null && length(call.arguments) == 1) {
+                    mk = call.arguments[0] ?as ExprMakeArray
+                }
+            }
+            if (mk != null) {
+                for (v in mk.values) {
+                    let cu = v ?as ExprConstUInt
+                    if (cu != null) {
+                        words |> push(cu.value)
+                    }
+                }
+            }
+        }
+    }
+    return <- words
 }
 
 [test]
@@ -27,6 +56,26 @@ def test_shader_compiles_with_folding_off(t : T?) {
                 compile_file(fixture_path(), access, unsafe(addr(mg)), cop) $(ok; program; issues) {
                     t |> success(ok, "the fixture did not compile: {issues}")
                     t |> success(program != null, "no program")
+                    if (!ok || program == null) {
+                        return
+                    }
+                    // pin the folded VALUES, not just compiles-clean: a get_const_expr answering
+                    // the wrong number would still compile. The words are the emitted artifact.
+                    var words <- shader_words(program, "fold_spv")
+                    t |> success(length(words) > 5, "no emitted words on fold_spv")
+                    // local_size_x = FOLD_LOCAL = 3 * 16: ExecutionMode LocalSize(17) 48 1 1
+                    t |> success(op_has_operand_pair(words, SpvOp.ExecutionMode, 17u, 48u),
+                        "LocalSize x is not 48")
+                    // @binding = FOLD_SLOT = 3 + 4: Decorate ... Binding(33) 7
+                    t |> success(op_has_operand_pair(words, SpvOp.Decorate, 33u, 7u),
+                        "Binding is not 7")
+                    // @set = FOLD_SET = 3 - 2: Decorate ... DescriptorSet(34) 1
+                    t |> success(op_has_operand_pair(words, SpvOp.Decorate, 34u, 1u),
+                        "DescriptorSet is not 1")
+                    // FOLD_ALIAS = FOLD_SCALE = 2u * 3u reaches the body as OpConstant 6
+                    t |> success(op_has_operand_at(words, SpvOp.Constant, 2, 6u),
+                        "no OpConstant 6 from FOLD_ALIAS")
+                    delete words
                 }
             }
         }

--- a/tests/spirv/test_const_fold_under_lint.das
+++ b/tests/spirv/test_const_fold_under_lint.das
@@ -17,24 +17,21 @@ def fixture_path() : string {
     return "{get_das_root()}/tests/spirv/_lint_fold_fixture.das"
 }
 
-// The [compute_shader] macro stores the emitted blob as `name : array<uint>` whose initializer is
-// to_array_move([uint literals]) -- read the words back off the compiled program's AST.
+// The [compute_shader] macro stores the emitted blob as `name : array<uint>` initialized with
+// to_array_move([uint literals]) -- unwrap the call and read the words off the array literal.
 def shader_words(program : ProgramPtr; name : string) : array<uint> {
     var words : array<uint>
     for_each_global(get_this_module(program)) $(gv) {
         if (gv.name == name && gv.init != null) {
-            var mk = gv.init ?as ExprMakeArray
-            if (mk == null) {
-                let call = gv.init ?as ExprCall
-                if (call != null && length(call.arguments) == 1) {
-                    mk = call.arguments[0] ?as ExprMakeArray
-                }
-            }
-            if (mk != null) {
-                for (v in mk.values) {
-                    let cu = v ?as ExprConstUInt
-                    if (cu != null) {
-                        words |> push(cu.value)
+            let call = gv.init ?as ExprCall
+            if (call != null && length(call.arguments) == 1) {
+                let mk = call.arguments[0] ?as ExprMakeArray
+                if (mk != null) {
+                    for (v in mk.values) {
+                        let cu = v ?as ExprConstUInt
+                        if (cu != null) {
+                            words |> push(cu.value)
+                        }
                     }
                 }
             }
@@ -56,25 +53,19 @@ def test_shader_compiles_with_folding_off(t : T?) {
                 compile_file(fixture_path(), access, unsafe(addr(mg)), cop) $(ok; program; issues) {
                     t |> success(ok, "the fixture did not compile: {issues}")
                     t |> success(program != null, "no program")
-                    if (!ok || program == null) {
-                        return
-                    }
+                    if (!ok || program == null) return
                     // pin the folded VALUES, not just compiles-clean: a get_const_expr answering
-                    // the wrong number would still compile. The words are the emitted artifact.
+                    // the wrong number would still compile.
                     var words <- shader_words(program, "fold_spv")
-                    t |> success(length(words) > 5, "no emitted words on fold_spv")
-                    // local_size_x = FOLD_LOCAL = 3 * 16: ExecutionMode LocalSize(17) 48 1 1
-                    t |> success(op_has_operand_pair(words, SpvOp.ExecutionMode, 17u, 48u),
-                        "LocalSize x is not 48")
-                    // @binding = FOLD_SLOT = 3 + 4: Decorate ... Binding(33) 7
-                    t |> success(op_has_operand_pair(words, SpvOp.Decorate, 33u, 7u),
-                        "Binding is not 7")
-                    // @set = FOLD_SET = 3 - 2: Decorate ... DescriptorSet(34) 1
-                    t |> success(op_has_operand_pair(words, SpvOp.Decorate, 34u, 1u),
-                        "DescriptorSet is not 1")
-                    // FOLD_ALIAS = FOLD_SCALE = 2u * 3u reaches the body as OpConstant 6
+                    t |> success(length(words) > 5, "fold_spv has no instructions past the 5-word header")
+                    t |> success(op_has_operand_pair(words, SpvOp.ExecutionMode, uint(SpvExecutionMode.LocalSize), 48u),
+                        "LocalSize x is not 48 (FOLD_LOCAL = 3 * 16)")
+                    t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.Binding), 7u),
+                        "Binding is not 7 (FOLD_SLOT = 3 + 4)")
+                    t |> success(op_has_operand_pair(words, SpvOp.Decorate, uint(SpvDecoration.DescriptorSet), 1u),
+                        "DescriptorSet is not 1 (FOLD_SET = 3 - 2)")
                     t |> success(op_has_operand_at(words, SpvOp.Constant, 2, 6u),
-                        "no OpConstant 6 from FOLD_ALIAS")
+                        "no OpConstant 6 (FOLD_ALIAS = FOLD_SCALE = 2u * 3u)")
                     delete words
                 }
             }


### PR DESCRIPTION
Three follow-ups from the #3729/#3730 review ledger. The jobque channels suite gains the join-fence contract test: a worker that sleeps between `push_clone` and `notify_and_release` holds the race window open, and `join()` before the `with_channel` scope closes is the fence — this is the exact shape #3729 fixed in `mcp_core.das`, pinned at the primitive level. The spirv lint-fold test now pins the folded values off the emitted words (LocalSize 48, Binding 7, DescriptorSet 1, OpConstant 6) instead of compiles-clean only, so a `get_const_expr` answering the wrong number fails the test. And `skills/jobque_debugging.md` names the Windows flavor of the secondary crash beside the Linux libc one.

Where to look: the negative controls — both new tests were verified to bite (join removed → the run dies with the AV; a pin flipped to 49 → the test fails on that message).

<details>
<summary>Validation, claims</summary>

### Validation
- `tests/jobque/test_jobque_channels.das`: 24/24; with the `join()` line removed the run crashes (`EXCEPTION_ACCESS_VIOLATION`) — the fence test bites.
- `tests/spirv/test_const_fold_under_lint.das`: 2/2 with all four pins; LocalSize pin flipped 48→49 fails with its own message — the extraction and pins bite.
- Lint and format clean on both test files; the skill edit is one sentence, SDK-safe.

### Claims — stated, not tested
- The new jobque test enters the nightly AOT glob with its siblings; it uses the same runtime surface (`new_thread`, channel ops, `sleep`) as tests already in that suite.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
