### PR TITLE
daspkg: don't follow links or copy build residue on install, and harden the copy

### DIFF
--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -567,6 +567,15 @@ def is_symlink_result(path : string) : fs_result_bool {
     return fs_result_bool(value = res)
 }
 
+// a link of any flavor: symlink everywhere; on Windows also a junction / mount point
+[generic]
+def is_reparse_point_result(path : string) : fs_result_bool {
+    var error : string
+    let res = is_reparse_point(path, error)
+    if (!empty(error)) return fs_result_bool(error = error)
+    return fs_result_bool(value = res)
+}
+
 [generic]
 def copy_file_result(src : string; dst : string; overwrite : bool) : fs_result_bool {
     var error : string

--- a/daslib/fio.das
+++ b/daslib/fio.das
@@ -567,7 +567,8 @@ def is_symlink_result(path : string) : fs_result_bool {
     return fs_result_bool(value = res)
 }
 
-// a link of any flavor: symlink everywhere; on Windows also a junction / mount point
+// a symlink everywhere; on Windows any reparse point - junction, mount point, and
+// less common flavors like a cloud-file placeholder
 [generic]
 def is_reparse_point_result(path : string) : fs_result_bool {
     var error : string

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -221,7 +221,7 @@ def document_module_fio(_root : string) {
     var groups <- array<DocGroup>(
         hide_group(group_by_regex("Internal builtin functions", mod, %regex~builtin%%)),
         group_by_regex("Direct IO and mapping advice", mod, %regex~(dwrite_open|dwrite_append|dwrite_band|dwrite_commit|dwrite_stat|dwrite_close|prefetch_map)$%%),
-        group_by_regex("File manipulation", mod, %regex~(f|long_f|stat$|getchar|remove|rename|copy_file|file_size|equivalent|is_symlink|set_mtime)%%),
+        group_by_regex("File manipulation", mod, %regex~(f|long_f|stat$|getchar|remove|rename|copy_file|file_size|equivalent|is_symlink|is_reparse_point|set_mtime)%%),
         group_by_regex("Path manipulation", mod, %regex~(base_name|dir_name|get_full_file_name|extension|stem|replace_extension|path_join|normalize|to_generic_path|is_absolute|relative|relative_result|parent)$%%),
         group_by_regex("Directory manipulation", mod, %regex~(dir|dir_rec|mkdir|mkdir_rec|mkdir_result|rmdir|rmdir_rec|rmdir_rec_result|rmdir_result|chdir|getcwd)$%%),
         group_by_regex("Glob and pattern matching", mod, %regex~(match_glob|glob|glob_filtered|is_glob_pattern|expand_glob|parse_file_list)$%%),

--- a/doc/source/stdlib/handmade/function-fio-is_reparse_point-0xca55e8098100cdb6.rst
+++ b/doc/source/stdlib/handmade/function-fio-is_reparse_point-0xca55e8098100cdb6.rst
@@ -1,0 +1,1 @@
+Returns true if the path is a link of any flavor: a symbolic link on every platform, and on Windows also a junction or mount point (any reparse point). Reports errors via the error out-parameter.

--- a/doc/source/stdlib/handmade/function-fio-is_reparse_point-0xca55e8098100cdb6.rst
+++ b/doc/source/stdlib/handmade/function-fio-is_reparse_point-0xca55e8098100cdb6.rst
@@ -1,1 +1,1 @@
-Returns true if the path is a link of any flavor: a symbolic link on every platform, and on Windows also a junction or mount point (any reparse point). Reports errors via the error out-parameter.
+Returns true if the path is a symbolic link — and on Windows, any reparse point: a junction, a mount point, or a less common flavor such as a cloud-file placeholder. Reports errors via the error out-parameter.

--- a/include/daScript/simulate/aot_builtin_fio.h
+++ b/include/daScript/simulate/aot_builtin_fio.h
@@ -146,6 +146,7 @@ namespace das {
     DAS_API int64_t builtin_fs_file_size ( const char * path, char * & error, Context * context, LineInfoArg * at );
     DAS_API bool    builtin_fs_equivalent ( const char * a, const char * b, char * & error, Context * context, LineInfoArg * at );
     DAS_API bool    builtin_fs_is_symlink ( const char * path, char * & error, Context * context, LineInfoArg * at );
+    DAS_API bool    builtin_fs_is_reparse_point ( const char * path, char * & error, Context * context, LineInfoArg * at );
     // file operations
     DAS_API bool    builtin_fs_copy_file ( const char * src, const char * dst, bool overwrite, char * & error, Context * context, LineInfoArg * at );
     DAS_API bool    builtin_fs_set_mtime ( const char * path, Time time, char * & error, Context * context, LineInfoArg * at );

--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -145,8 +145,9 @@ through its caller, the collapse is a walk-abort instead: guard the callback's f
 line on the flag.
 
 **One guard style per function.** Message-setting early-outs are one-liners:
-`if (cond) { why = "..."; return false; }` — never a mix of one-liners and expanded
-blocks in the same function.
+`if (cond) { why = "..."; return false; }` — never a *gratuitous* mix of one-liners
+and expanded blocks in the same function. A guard whose message needs a local to
+build it stays expanded, and that's not a mix.
 
 **Declarations don't promise.** Declare at first use, not in an up-front batch — a
 block of aliases computed long before their consumers is a list of promises the

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -245,6 +245,7 @@ namespace das {
     int64_t builtin_fs_file_size ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
     bool builtin_fs_equivalent ( const char * a, const char * b, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
     bool builtin_fs_is_symlink ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
+    bool builtin_fs_is_reparse_point ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
     bool builtin_fs_copy_file ( const char * src, const char * dst, bool overwrite, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
     bool builtin_fs_set_mtime ( const char * path, Time time, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
     bool builtin_fs_disk_space ( const char * path, DiskSpaceInfo & info, char * & error, Context * ctx, LineInfoArg * at ) GENERATE_IO_STUB
@@ -2215,6 +2216,27 @@ namespace das {
         return result;
     }
 
+    bool builtin_fs_is_reparse_point ( const char * path, char * & error, Context * ctx, LineInfoArg * at ) {
+        error = nullptr;
+        if ( !path || !path[0] ) { error = empty_path_error(ctx, at); return false; }
+#if _WIN32
+        // is_symlink misses junctions (MSVC reports them as plain directories); the
+        // attribute catches every reparse flavor - junction, symlink, mount point
+        DWORD attrs = GetFileAttributesW(das_to_path(path).c_str());
+        if ( attrs == INVALID_FILE_ATTRIBUTES ) {
+            std::error_code ec((int)GetLastError(), std::system_category());
+            error = ec_to_string(ec, ctx, at);
+            return false;
+        }
+        return (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+#else
+        std::error_code ec;
+        bool result = std::filesystem::is_symlink(das_to_path(path), ec);
+        if ( ec ) { error = ec_to_string(ec, ctx, at); return false; }
+        return result;
+#endif
+    }
+
     // file operations
 
     bool builtin_fs_copy_file ( const char * src, const char * dst, bool overwrite, char * & error, Context * ctx, LineInfoArg * at ) {
@@ -2719,6 +2741,9 @@ namespace das {
                     ->args({"a","b","error","context","at"});
             addExtern<DAS_BIND_FUN(builtin_fs_is_symlink)>(*this, lib, "is_symlink",
                 SideEffects::modifyArgumentAndExternal, "builtin_fs_is_symlink")
+                    ->args({"path","error","context","at"});
+            addExtern<DAS_BIND_FUN(builtin_fs_is_reparse_point)>(*this, lib, "is_reparse_point",
+                SideEffects::modifyArgumentAndExternal, "builtin_fs_is_reparse_point")
                     ->args({"path","error","context","at"});
             // file operations
             addExtern<DAS_BIND_FUN(builtin_fs_copy_file)>(*this, lib, "copy_file",

--- a/utils/daspkg/REVIEW.md
+++ b/utils/daspkg/REVIEW.md
@@ -13,35 +13,36 @@ bin/daslang dastest/dastest.das -- --test utils/daspkg/test_daspkg.das
 
 Fast, no network, runs interpreted. A daspkg change without a green unit run is a defect.
 
-**Run the integration suite on any edit to `index.das`, or to any function reachable from
-`install`, `update`, `upgrade`, `introduce`, `withdraw`, or `update-index` — whichever file it
-lives in, the `utils.das` helpers those commands call included — and a behavior-preserving
-refactor of one still counts:**
+**Run the integration suite on any edit to `commands.das`, `index.das`, or `utils.das` — a
+behavior-preserving refactor still counts:**
 
 ```text
 bin/daslang dastest/dastest.das -- --test utils/daspkg/test_daspkg_git.das
 ```
 
-Needs network (the `borisbat/daspkg-test-*` fixture repos). One exception to that trigger, even
-though those commands reach them: `gitignore_add` / `gitignore_remove` in `utils.das` run no git
-command, and stay the unit suite's.
+Needs network (the `borisbat/daspkg-test-*` fixture repos). Exception: a change confined to
+functions that run no git command (checkable in the diff's own hunks) stays the unit suite's.
 
-**A release-path change is verified on macOS, or the review says it was not.** The release
-layout forks per platform (`.app` bundle vs flat directory); the only CI on these suites is
-the nightly (`nightly_daspkg_index.yml`: Linux unit+git, macOS unit), so a per-change run is
-still the review's job — a change green on one platform has shipped red on the other before.
+**A change to `cmd_release`, `cmd_release_wasm`, or a `release_*` helper is verified on macOS,
+or the review says it was not.** The release layout forks per platform (`.app` bundle vs flat
+directory), and no per-PR CI runs these suites.
 
 **A new command or flag lands with its test cell, its `print_usage` line, and its README table
 row in the same change.**
 
 ## Behavior
 
-**A release always mints the tune sidecar; `--quick` is the only inherit, and it accepts only a
-complete one.** A bundle that ships an exe without a sidecar beside it is a defect.
+**A release always mints the tune sidecar.** A bundle that ships an exe without a sidecar
+beside it is a defect.
+
+**`--quick` is the only path that inherits a prior sidecar, and it refuses an incomplete one**
+— incomplete meaning missing any scope key the exe's deps JSON reports, the same completeness
+the release build itself checks.
 
 **`release_include_if_missing` files are user-owned after initialization.** A release path that
-overwrites or deletes one, on any platform, is a defect; `.daspkg_release.manifest` is written
-on every platform.
+overwrites or deletes one, on any platform, is a defect.
+
+**`.daspkg_release.manifest` is written on every platform.**
 
 **Unit cells touch only local fixtures.** A `test_daspkg.das` cell that reaches the network is
 a defect — network coverage belongs in `test_daspkg_git.das`.

--- a/utils/daspkg/commands.das
+++ b/utils/daspkg/commands.das
@@ -356,6 +356,11 @@ def private git_clone(url, dir : string) : bool {
     return true
 }
 
+def private log_rename_locked_hint() {
+    if (get_platform_name() != "windows") return
+    to_log(LOG_ERROR, "  hint: a running process is holding the package's .shared_module - close daslang/daslang-live and retry\n")
+}
+
 def install_git(root, pkg_name, source, version : string; var lf : LockFile; is_root : bool = true; is_global : bool = false; branch : string = "") {
     var visiting : table<string; bool>
     return install_git(root, pkg_name, source, version, lf, visiting, [is_root = is_root, is_global = is_global, branch = branch])
@@ -479,6 +484,7 @@ def install_git(root, pkg_name, source, version : string; var lf : LockFile; var
     }
     if (!rename(tmp_dir, target_dir)) {
         to_log(LOG_ERROR, "Error: failed to move {tmp_dir} to {target_dir}\n")
+        log_rename_locked_hint()
         return 1
     }
 
@@ -787,6 +793,7 @@ def cmd_update(root, name : string; is_global : bool = false) { // nolint:STYLE0
         }
         if (!rename(pkg_dir, backup_dir)) {
             to_log(LOG_ERROR, "Error: failed to backup '{name}'\n")
+            log_rename_locked_hint()
             return 1
         }
     }

--- a/utils/daspkg/test_daspkg.das
+++ b/utils/daspkg/test_daspkg.das
@@ -279,6 +279,49 @@ def test_lockfile_roundtrip(t : T?) {
 }
 
 [test]
+def test_copy_dir_rec_skips_links_and_build_residue(t : T?) {
+    t |> run("junction/symlink, .git, and build dirs stay out of the copy") @(t : T?) {
+        let tmp = "{get_das_root()}/_daspkg_test_copyskip"
+        let src = "{tmp}/src"
+        mkdir(tmp)
+        mkdir(src)
+        mkdir("{src}/real")
+        fopen("{src}/real/a.txt", "wb") $(f) {
+            fprint(f, "content")
+        }
+        mkdir("{src}/_build")
+        fopen("{src}/_build/CMakeCache.txt", "wb") $(f) {
+            fprint(f, "stale")
+        }
+        mkdir("{src}/build")
+        mkdir("{src}/.git")
+        // a link pointing at src itself - copying it recurses forever unless copy_dir_rec skips links
+        let link = "{src}/loop"
+        var out : string
+        var link_cmd = "ln -s \"{src}\" \"{link}\""
+        if (get_platform_name() == "windows") {
+            link_cmd = "cmd /c mklink /J \"{replace(link, "/", "\\")}\" \"{replace(src, "/", "\\")}\""
+        }
+        let linked = run_cmd(link_cmd, out) == 0
+        let dst = "{tmp}/dst"
+        t |> success(copy_dir_rec(src, dst), "copy_dir_rec({src} -> {dst}) returned false")
+        t |> success(fexist("{dst}/real/a.txt"), "real content missing from the copy")
+        t |> success(!fexist("{dst}/_build"), "_build was copied")
+        t |> success(!fexist("{dst}/build"), "build was copied")
+        t |> success(!fexist("{dst}/.git"), ".git was copied")
+        if (linked) {
+            var link_err : string
+            t |> success(is_reparse_point(link, link_err), "is_reparse_point does not see the link")
+            t |> success(!is_reparse_point(src, link_err), "is_reparse_point flags a plain dir")
+            t |> success(!fexist("{dst}/loop"), "the link was followed into the copy")
+        } else {
+            to_log(LOG_INFO, "test_copy_dir_rec_skips_links_and_build_residue: could not create a junction/symlink here; skipping the link half\n")
+        }
+        force_rmdir(tmp)
+    }
+}
+
+[test]
 def test_in_tree_module_satisfies_install(t : T?) {
     t |> run("explicit install of an in-tree module is a no-op") @(t : T?) {
         // dasGlfw is a tracked in-tree module: present at <das_root>/modules/

--- a/utils/daspkg/utils.das
+++ b/utils/daspkg/utils.das
@@ -367,10 +367,11 @@ def gitignore_remove(root, pattern : string) {
     }
 }
 
-// a package is its files, not its history: copying .git costs more than the whole
-// rest of the tree and installs nothing anyone requires
+// a package is its files, not its history or its build residue: .git costs more than
+// the rest of the tree, and a copied build dir (_build or build) carries a CMakeCache
+// pointing at the source path, which aborts the installed package's own configure
 def private is_package_content(name : string) : bool {
-    return name != "." && name != ".." && name != ".git"
+    return name != "." && name != ".." && name != ".git" && name != "_build" && name != "build"
 }
 
 // streamed through a fixed window: sizing a buffer by the file costs that file in
@@ -401,6 +402,10 @@ def private copy_file_bytes(src, dst : string) : bool {
                 }
                 break if (n < COPY_WINDOW_BYTES)
             }
+            // a mid-file read error returns a short count exactly like EOF - feof is the tiebreaker
+            if (ok && !feof(fin)) {
+                ok = false
+            }
             delete buf
         }
     }
@@ -414,6 +419,10 @@ def copy_dir_rec(src, dst : string) : bool {
         return if (!is_package_content(name))
         let src_child = "{src}/{name}"
         let dst_child = "{dst}/{name}"
+        // never follow a junction/symlink: one into the tree recurses forever, and one
+        // out of it copies content that is not the package's
+        var link_err : string
+        return if (is_reparse_point(src_child, link_err))
         let st = stat(src_child)
         if (st.is_dir) {
             if (!copy_dir_rec(src_child, dst_child)) {

--- a/utils/daspkg/utils.das
+++ b/utils/daspkg/utils.das
@@ -432,6 +432,11 @@ def copy_dir_rec(src, dst : string) : bool {
             if (!copy_file_bytes(src_child, dst_child)) {
                 ok = false
             }
+        } else {
+            // stat failed, or the entry is neither file nor dir - a copy that silently
+            // dropped an entry must not report itself complete
+            to_log(LOG_ERROR, "Error: cannot stat {src_child} (or unsupported entry kind)\n")
+            ok = false
         }
     }
     return ok


### PR DESCRIPTION
Installing a package from a dev checkout could recurse forever (the `modules/<self>` junction layout for `-load_module`) or break the installed package's configure (a copied `_build` carries a CMakeCache pointing at the source path). `copy_dir_rec` now skips links and build dirs. The link test is a new fio builtin, `is_reparse_point` — MSVC's `std::filesystem::is_symlink` reports a junction as a plain directory (probe-verified), so the Windows arm checks `FILE_ATTRIBUTE_REPARSE_POINT` (junction, symlink, mount point alike); elsewhere it keeps `is_symlink` semantics. Additive binding — no ABI break.

Two smaller hardenings ride along: `copy_file_bytes` uses `feof` to tell a mid-file read error from EOF (a failing disk used to yield a truncated copy reported as success), and a failed module-dir rename on Windows now hints at the near-certain cause (a running process holding the package's `.shared_module`).

Where to look: the new test `test_copy_dir_rec_skips_links_and_build_residue` — a junction pointing at the tree itself, `_build`, `build`, `.git`, real content surviving, and direct `is_reparse_point` pins.

<details>
<summary>Validation, claims, checklist</summary>

### Validation
- Unit suite 221/221 (three runs across the round); network integration suite `test_daspkg_git.das` 70/70.
- Negative control: with master's `utils.das` the new test fails on both "_build was copied" and "the link was followed into the copy".
- `is_reparse_point` probe: junction → true (is_symlink says false), plain dir → false, missing path → false + error.
- Lint and format clean on all changed `.das`; style-hygiene and REVIEW.md checklist audits run, findings applied.

### Claims — stated, not tested
- The `feof` tiebreaker has no test — there is no portable mid-file read-error injection; the branch is verify-only hardening.
- The POSIX arm of `is_reparse_point` compiles and behaves as `is_symlink` by construction (verbatim body); not exercised on a POSIX box this session — CI's Linux/macOS lanes cover the compile, and the das-side test's `ln -s` arm covers behavior there.
- macOS release path untouched by this diff (release code not changed); per the checklist's escape hatch, not verified on macOS.

### Checklist self-review (lands in-batch per REVIEW_COMMON)
`utils/daspkg/REVIEW.md` reworked: the integration-suite trigger is file-shaped (was: call-graph reachability a reviewer could not decide from the diff), the gitignore exception states its property instead of enumerating names, the macOS rule names its entry functions and drops the history sentence, the tune-sidecar rule splits into its two checks with completeness defined, and the manifest check stands alone.

### Also
- `skills/comment_style_hygiene.md`: the guard-style rule gains the audit's carve-out (a guard whose message needs a local stays expanded — not a mix); the "message is the comment" broadening from #3736 is exercised here too.
- Old backlog note "update --global exits 0 on failure" no longer reproduces (probed EXIT=1) — only the hint was still missing.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
