### PR TITLE
honest frames for the gc stack walk: splice stamping, static fastcall denial, walk refusals

### DIFF
--- a/doc/source/reference/language/contexts.rst
+++ b/doc/source/reference/language/contexts.rst
@@ -126,11 +126,38 @@ To collect garbage, from the inside of the context:
         heap_collect(collect_string_heap, validate_after_collect)
     }
 
+The collector finds live values by walking the interpreter call stack, so every call
+between your program's entry point and ``heap_collect`` must be a regular interpreted
+call. The compiler guarantees the common case: every function that can reach
+``heap_collect`` through direct calls keeps a real stack frame (never fastcall), so
+collect wrappers — and wrappers of wrappers — just work. One residual is not covered:
+a collect reached only through a **block, lambda, or function pointer** that a
+single-statement (fastcall) wrapper invokes; keep such wrappers to two statements or
+collect outside the callback.
+
+Chains the collector cannot walk honestly are refused with a runtime error instead
+of collecting:
+
+* an interpreted frame reached **through a compiled (AOT/JIT) frame that broke the
+  line handoff**, or entered from C++ **without line info** (see below). An
+  all-compiled chain — a standalone compiled executable — is allowed and collects
+  from globals. Note that a compiled function entered from the interpreter carries
+  an interpreter-shaped frame the collector cannot distinguish; the gc test suites
+  therefore run interpreted-only.
+
 To do the same from the C++ side:
 
 .. code-block:: cpp
 
-    context->collectHeap(dummy_line_info_ptr, collect_string_heap, validate_after_collect);
+    context->collectHeap(line_info_ptr, collect_string_heap, validate_after_collect);
+
+Passing ``nullptr`` for the line info is allowed only when no daslang frames are on the
+context's stack (for example between updates, or on a macro context). When C++ code
+re-enters daslang below live frames, use an entry point that takes a line —
+``context->callOrFastcall(fn, args, line)`` or ``das_invoke_function<...>::invoke(ctx,
+at, fn)`` — and pass a real ``at``: a collect below a null-line re-entry is refused,
+because the locals of the frames above it can no longer be attributed. (``Context::eval``
+and ``evalWithCatch`` carry no line parameter and are only safe as stack-root entries.)
 
 .. seealso::
 

--- a/doc/source/reference/language/options.rst
+++ b/doc/source/reference/language/options.rst
@@ -398,7 +398,8 @@ Debugging and Profiling
    * - ``debugger``
      - bool
      - false
-     - Enables debugger support. Disables fastcall and adds a context mutex.
+     - Enables debugger support. Disables fastcall and auto-inlining (the debugger
+       needs true frames and true lines) and adds a context mutex.
    * - ``profiler``
      - bool
      - false

--- a/doc/source/stdlib/handmade/typedef-ast-MoreFunctionFlags2.rst
+++ b/doc/source/stdlib/handmade/typedef-ast-MoreFunctionFlags2.rst
@@ -2,3 +2,4 @@ Overflow word for function flags (moreFlags is full at 32 bits).
 Function is a @@{} local function body - generated, but the block is verbatim user code.
 Result is always a fresh string allocation (or null), never a passthrough of an input, never retained by the callee.
 Executing the body may hit a temp-string queue site (a builder or a wrappable call, transitively) - a caller must not hold a parked temp across a call to this function.
+Function may reach a heap collect point (transitively over direct calls) - its caller keeps a real stack frame, so carriers are denied fastcall.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1004,6 +1004,7 @@ namespace das
                 bool    localFunction : 1;           // @@{} local function body - generated, but the block is verbatim user code
                 bool    tempStringResult : 1;        // [temp_string_result] - result is always a fresh string allocation (or null), never a passthrough of an input, never retained by the callee
                 bool    mayQueueTempString : 1;      // executing the BODY may hit a temp-string queue site (builder or wrappable call, transitively) - a caller must not hold a parked temp across a call to this
+                bool    needCallerStackFrame : 1;    // may reach a collect point - its caller must keep a real stack frame, so carriers are denied fastcall (closure: ast_unused.cpp)
             };
             uint32_t moreFlags2 = 0;
         };

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -252,7 +252,7 @@ namespace das {
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
         static constexpr uint32_t getVersion () {
-            return 115;   // 115: generator lowering stamps genFlags.generated (serialized per-node)
+            return 116;   // 116: inline splices carry the host call-site line (gc locals-walk honesty)
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;

--- a/include/daScript/simulate/REVIEW.md
+++ b/include/daScript/simulate/REVIEW.md
@@ -1,0 +1,11 @@
+# Simulate Headers Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first — its contract binds this checklist.** Architecture doc:
+`CLAUDE.md` (repo root).
+
+- **No new work on the hot evaluation paths — call/fastcall dispatch, invoke, loop and
+  condition nodes, the per-node `eval` methods — unless correctness requires it.** The
+  interpreter's throughput is these few functions, and any added load, branch, or counter
+  there taxes every program. A correctness-required addition is FLAGGED for human review
+  in the PR description, naming the alternative that was rejected; an unflagged hot-path
+  addition is a defect.

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -454,7 +454,6 @@ namespace das
         __forceinline void restart( ) {
             DAS_ASSERTF(insideContext==0,"can't reset locked context");
             stopFlags = 0;
-            fastCallDepth = 0;
             exception = nullptr;
             last_exception = nullptr;
         }
@@ -604,16 +603,11 @@ namespace das
 
         DAS_EVAL_ABI __forceinline vec4f callOrFastcall(const SimFunction * fn, vec4f * args, LineInfo * line) {
             if ( fn->fastcall ) {
-                if ( fastCallDepth * sizeof(Prologue) > stack.free_size() ) { // this is to catch stack overflow
-                    throw_error_at(line, "stack overflow, fast call depth limit exceeded while calling %s", fn->mangledName);
-                }
-                fastCallDepth ++;
                 auto aa = abiArg;
                 abiArg = args;
                 result = fn->code->eval(*this);
                 stopFlags = 0;
                 abiArg = aa;
-                fastCallDepth --;
                 return result;
             } else {
                 // PUSH
@@ -826,7 +820,6 @@ namespace das
         char *                          globals = nullptr;
         char *                          shared = nullptr;
         StackAllocator                  stack;
-        uint32_t                        fastCallDepth = 0;
         uint32_t                        insideContext = 0;
         bool                            persistent = false;
         bool                            ownStack = false;

--- a/include/daScript/simulate/simulate_nodes.h
+++ b/include/daScript/simulate/simulate_nodes.h
@@ -1324,10 +1324,6 @@ SIM_NODE_AT_VECTOR(Float, float)
         SimNode_FastCall ( const LineInfo & at ) : SimNode_FastCallAny(at) {}
         DAS_EVAL_ABI virtual vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE
-            if ( context.fastCallDepth * sizeof(Prologue) > context.stack.free_size() ) {
-                context.throw_error_at(debugInfo, "stack overflow, fast call depth limit exceeded while calling %s", fnPtr->mangledName);
-            }
-            context.fastCallDepth ++;
             vec4f argValues[argCount ? argCount : 1];
             EvalBlock<argCount>::eval(context, arguments, argValues);
             auto aa = context.abiArg;
@@ -1335,16 +1331,11 @@ SIM_NODE_AT_VECTOR(Float, float)
             auto res = fnPtr->code->eval(context);
             context.stopFlags &= ~(EvalFlags::stopForReturn | EvalFlags::stopForBreak | EvalFlags::stopForContinue);
             context.abiArg = aa;
-            context.fastCallDepth --;
             return res;
         }
 #define EVAL_NODE(TYPE,CTYPE)\
         virtual CTYPE eval##TYPE ( Context & context ) override {                               \
                 DAS_PROFILE_NODE                                                                \
-                if ( context.fastCallDepth * sizeof(Prologue) > context.stack.free_size() ) {   \
-                    context.throw_error_at(debugInfo, "stack overflow, fast call depth limit exceeded while calling %s", fnPtr->mangledName); \
-                }                                                                               \
-                context.fastCallDepth ++;                                                       \
                 vec4f argValues[argCount ? argCount : 1];                                       \
                 EvalBlock<argCount>::eval(context, arguments, argValues);                       \
                 auto aa = context.abiArg;                                                       \
@@ -1352,7 +1343,6 @@ SIM_NODE_AT_VECTOR(Float, float)
                 auto res = EvalTT<CTYPE>::eval(context, fnPtr->code);                           \
                 context.stopFlags &= ~(EvalFlags::stopForReturn | EvalFlags::stopForBreak | EvalFlags::stopForContinue); \
                 context.abiArg = aa;                                                            \
-                context.fastCallDepth --;                                                       \
                 return res;                                                                     \
         }
         DAS_EVAL_NODE

--- a/modules/dasImgui/widgets/imgui_lint.das
+++ b/modules/dasImgui/widgets/imgui_lint.das
@@ -199,8 +199,9 @@ class ImguiLintVisitor : AstVisitor {
     }
 
     def override preVisitExprCall(var expr : ExprCall?) : void {
-        // Combined skip: null guards, macro-generated bodies, and macro-synthesized call sites (qmacro's ExprCall `at` points at the template file, not the user's — skip when fileInfo differs).
+        // skip compiler-inserted nodes: generated splices/bodies were linted at their definition, and a foreign fileInfo means a macro-synthesized call site
         if (expr.func == null || expr.func._module == null
+                || expr.genFlags.generated
                 || (current_function != null
                     && (current_function.flags.generated
                         || (current_function.at.fileInfo != null

--- a/modules/dasLiveHost/src/dasLiveHost.cpp
+++ b/modules/dasLiveHost/src/dasLiveHost.cpp
@@ -319,12 +319,16 @@ const char * live_get_watched_file(int32_t index, Context * ctx) {
 
 // --- GC ---
 
-void live_collect_gc(Context * ctx) {
-    ctx->collectHeap(nullptr, /*stringHeap*/true, /*validate*/false);
+// the call-site LineInfo is required: the collector walks caller frames and gates their
+// locals on it - a null line below live frames refuses the collect (a root-level null,
+// with no das frames on the stack, stays legal)
+void live_collect_gc(Context * ctx, LineInfoArg * at) {
+    ctx->collectHeap(at, /*stringHeap*/true, /*validate*/false);
 }
 
-void live_collect_string_gc(Context * ctx) {
-    ctx->collectHeap(nullptr, /*stringHeap*/true, /*validate*/false);
+// byte-identical to live_collect_gc - kept for live-reload API compatibility
+void live_collect_string_gc(Context * ctx, LineInfoArg * at) {
+    ctx->collectHeap(at, /*stringHeap*/true, /*validate*/false);
 }
 
 // --- Annotations ---
@@ -485,10 +489,15 @@ public:
                 ->args({"key", "value", "context"});
 
         // GC
-        addExtern<DAS_BIND_FUN(live_collect_gc)>(*this, lib, "live_collect_gc",
+        // these reach collectHeap from C++, where the closure can't see it - seed by hand
+        auto lcg = addExtern<DAS_BIND_FUN(live_collect_gc)>(*this, lib, "live_collect_gc",
             SideEffects::modifyExternal, "das::live_collect_gc");
-        addExtern<DAS_BIND_FUN(live_collect_string_gc)>(*this, lib, "live_collect_string_gc",
+        lcg->args({"context","at"});
+        lcg->needCallerStackFrame = true;
+        auto lcsg = addExtern<DAS_BIND_FUN(live_collect_string_gc)>(*this, lib, "live_collect_string_gc",
             SideEffects::modifyExternal, "das::live_collect_string_gc");
+        lcsg->args({"context","at"});
+        lcsg->needCallerStackFrame = true;
 
         // Command dispatch bridge (called from live_api agent, dispatches in main context)
         addExtern<DAS_BIND_FUN(live_dispatch_command_via_host)>(*this, lib, "dispatch_command",

--- a/modules/dasLiveHost/src/dasLiveHost.h
+++ b/modules/dasLiveHost/src/dasLiveHost.h
@@ -93,8 +93,8 @@ namespace das {
     bool live_load_bytes(const char * key, TArray<uint8_t> & data, Context * ctx);
     void live_store_string(const char * key, const char * value);
     bool live_load_string(const char * key, char * & value, Context * ctx);
-    void live_collect_gc(Context * ctx);
-    void live_collect_string_gc(Context * ctx);
+    void live_collect_gc(Context * ctx, LineInfoArg * at);
+    void live_collect_string_gc(Context * ctx, LineInfoArg * at);
     const char * live_dispatch_command_via_host(const char * cmd_json, Context * callerCtx);
 
 }

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -130,7 +130,7 @@ namespace das {
         // SimNode_MakeArrayHeap repoints abiCMRES at the heap block while constructing
         // elements, so a CMRES-aliased local read inside a heap-mode literal would resolve
         // into the (zeroed) heap buffer instead of the return slot. Track such reads and
-        // decline the elision for that variable â€” an extra move at return, always correct.
+        // decline the elision for that variable — an extra move at return, always correct.
         das_hash_set<Variable *> usedInHeapLiteral;
         int                     heapLiteralDepth = 0;
     protected:
@@ -431,7 +431,7 @@ namespace das {
             if ( expr->subexpr ) {
                 // only route a make-local return through CMRES when the function returns via
                 // CMRES; a register-returned (non-cmres) function has no result buffer, so
-                // writing the make-local through one segfaults â€” build a normal local instead.
+                // writing the make-local through one segfaults — build a normal local instead.
                 bool makeLocalCMRES = expr->returnInBlock || !func || func->copyOnReturn || func->moveOnReturn;
                 if ( expr->subexpr->rtti_isMakeLocal() && makeLocalCMRES ) {
                     uint32_t sz = sizeof(void *);
@@ -1347,10 +1347,10 @@ namespace das {
     void Program::allocateStack(TextWriter & logs, bool permanent, bool everything) {
         // temp-string sites: builder marking + [temp_string_result] wrapping (must precede AllocateStack).
         // ALWAYS wrap, regardless of heap options: this pass mutates function bodies (shared-module
-        // ASTs included), so gating it on the driving program's options makes a function's tree â€” and
-        // its AOT hash â€” depend on who compiled it first (macro-context compiles run with
+        // ASTs included), so gating it on the driving program's options makes a function's tree — and
+        // its AOT hash — depend on who compiled it first (macro-context compiles run with
         // macro_context_persistent_heap and wrapped shared daslib functions that AOT stub generation
-        // left bare â†’ error 50101 on link). The heap modes are handled at runtime instead:
+        // left bare → error 50101 on link). The heap modes are handled at runtime instead:
         // freeTempString no-ops for interned heaps and when reclaim is disabled, and linear-heap
         // frees are safe bump-retreat no-ops.
         {

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -130,7 +130,7 @@ namespace das {
         // SimNode_MakeArrayHeap repoints abiCMRES at the heap block while constructing
         // elements, so a CMRES-aliased local read inside a heap-mode literal would resolve
         // into the (zeroed) heap buffer instead of the return slot. Track such reads and
-        // decline the elision for that variable — an extra move at return, always correct.
+        // decline the elision for that variable â€” an extra move at return, always correct.
         das_hash_set<Variable *> usedInHeapLiteral;
         int                     heapLiteralDepth = 0;
     protected:
@@ -387,9 +387,10 @@ namespace das {
             auto top = popSp();
             func->totalStackSize = top.maxStack;
             DAS_ASSERT(stackTopStack.empty());
-            // detecting fastcall
+            // detecting fastcall; a needCallerStackFrame carrier (the transitive closure
+            // over every referenced callee, operators included) keeps a real frame
             func->fastCall = false;
-            if ( !program->getDebugger() && !program->getProfiler() && !noFastCall ) {
+            if ( !program->getDebugger() && !program->getProfiler() && !noFastCall && !func->needCallerStackFrame ) {
                 if ( !func->exports && !func->addr && func->totalStackSize==sizeof(Prologue) && func->arguments.size()<=32 ) {
                     if (func->body->rtti_isBlock()) {
                         auto block = static_cast<ExprBlock*>(func->body);
@@ -430,7 +431,7 @@ namespace das {
             if ( expr->subexpr ) {
                 // only route a make-local return through CMRES when the function returns via
                 // CMRES; a register-returned (non-cmres) function has no result buffer, so
-                // writing the make-local through one segfaults — build a normal local instead.
+                // writing the make-local through one segfaults â€” build a normal local instead.
                 bool makeLocalCMRES = expr->returnInBlock || !func || func->copyOnReturn || func->moveOnReturn;
                 if ( expr->subexpr->rtti_isMakeLocal() && makeLocalCMRES ) {
                     uint32_t sz = sizeof(void *);
@@ -1346,10 +1347,10 @@ namespace das {
     void Program::allocateStack(TextWriter & logs, bool permanent, bool everything) {
         // temp-string sites: builder marking + [temp_string_result] wrapping (must precede AllocateStack).
         // ALWAYS wrap, regardless of heap options: this pass mutates function bodies (shared-module
-        // ASTs included), so gating it on the driving program's options makes a function's tree — and
-        // its AOT hash — depend on who compiled it first (macro-context compiles run with
+        // ASTs included), so gating it on the driving program's options makes a function's tree â€” and
+        // its AOT hash â€” depend on who compiled it first (macro-context compiles run with
         // macro_context_persistent_heap and wrapped shared daslib functions that AOT stub generation
-        // left bare → error 50101 on link). The heap modes are handled at runtime instead:
+        // left bare â†’ error 50101 on link). The heap modes are handled at runtime instead:
         // freeTempString no-ops for interned heaps and when reclaim is disabled, and linear-heap
         // frees are safe bump-retreat no-ops.
         {

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -578,6 +578,10 @@ namespace das {
             virtual void preVisitExpression ( Expression * expr ) override {
                 Visitor::preVisitExpression(expr);
                 expr->at = expr->rtti_isBlock() ? wideAt(col) : pointAt(col);
+                // a spliced clone is compiler-inserted: the original body is linted at its
+                // definition, and at-keyed macros must not re-analyze the copy (the stamp
+                // makes it look host-authored, defeating their foreign-file heuristics)
+                expr->generated = true;
             }
             virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
                 Visitor::preVisitLet(let, var, last);

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -573,6 +573,7 @@ namespace das {
             LineInfo base;
             uint32_t col = 0;
             uint32_t cap = 0;
+            bool markGenerated = true;
         protected:
             virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
             virtual void preVisitExpression ( Expression * expr ) override {
@@ -580,8 +581,11 @@ namespace das {
                 expr->at = expr->rtti_isBlock() ? wideAt(col) : pointAt(col);
                 // a spliced clone is compiler-inserted: the original body is linted at its
                 // definition, and at-keyed macros must not re-analyze the copy (the stamp
-                // makes it look host-authored, defeating their foreign-file heuristics)
-                expr->generated = true;
+                // makes it look host-authored, defeating their foreign-file heuristics).
+                // temp INITS are exempt - they are caller-authored argument/prefix
+                // expressions merely relocated, and marking them would hide lint findings
+                // on user code; their at still joins the ladder (uninitialized-temp gating)
+                if ( markGenerated ) expr->generated = true;
             }
             virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
                 Visitor::preVisitLet(let, var, last);
@@ -2594,7 +2598,11 @@ namespace das {
                 } else {
                     tl = makeTemp(callLike->at, tname, pe, false, false, pe->type && !pe->type->canCopy());
                 }
-                if ( calleeFn ) tl->visit(stamp);
+                if ( calleeFn ) {
+                    stamp.markGenerated = false;    // caller-authored init, only relocated
+                    tl->visit(stamp);
+                    stamp.markGenerated = true;
+                }
                 splice.push_back(tl);
                 ReplaceNode rn(pe, new ExprVar(peAt, tname));
                 auto & slot = site.anchor.block->list[anchorIndex];
@@ -2607,7 +2615,9 @@ namespace das {
             InlineBodyRewriter rewriter(plan.paramSub, rename, callLike->at, calleeFn != nullptr);
             ExpressionPtr callReplacement = nullptr;
             if ( calleeFn ) {
+                stamp.markGenerated = false;    // caller-authored arg inits, only relocated
                 for ( auto & t : temps ) t->visit(stamp);   // arg temps ladder after the prefix temps
+                stamp.markGenerated = true;
             }
             if ( exprBody ) {
                 auto ret = static_cast<ExprReturn *>(in.body->list.back());

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -526,6 +526,75 @@ namespace das {
             }
         };
 
+        // stamps spliced material (manufactured temps + the cloned CALLEE subtree) with the
+        // host call-site location: the GC / stackwalk / debugger locals gate compares the
+        // parked line against local visibility ranges, and both must be host-function lines
+        // or the frame's locals silently drop out of the walk. the COLUMN LADDER restores
+        // the ordering protection line order gives user code - only already-initialized
+        // locals pass the gate. `f(a, b)` at 7:3:
+        //   let _inl0_arg_a = <a>    // subtree stamped @7:3, visible from 7:4
+        //   let _inl0_arg_b = <b>    // subtree stamped @7:4, visible from 7:5
+        //   <spliced body>           // stamped @7:5+ - sees both temps
+        // blocks get a one-line-wide range - LineInfo::inside excludes last_line, so a
+        // single-line range would hide every spliced local (infer re-derives let visibility
+        // from the enclosing scope's at); multi-var lets share one column, the joint window
+        // user-code multi-var lets have. (KNOWN RESIDUAL: the counter advances in visit
+        // order, so a let in an EARLIER conditional arm stays gate-visible at parks in a
+        // LATER sibling arm where it never initialized - and sibling scopes REUSE stack
+        // offsets, so the slot may hold an unrelated live value walked as the wrong type.
+        // inside() can't encode same-line column intervals.)
+        // one instance covers a whole site in EXECUTION order (prefix temps, arg temps,
+        // body) so the counter threads through; it runs BEFORE InlineBodyRewriter so
+        // substituted caller expressions keep their own at.
+        class SpliceAtStamp : public Visitor {
+        public:
+            // the ladder is CAPPED at the call's own last column: a host let opens its
+            // visibility at its declaration END, so an uncapped ladder could run past it
+            // and gate the host's still-uninitialized slot visible; the cap also keeps a
+            // nested round's ladder (base = an already-stamped point) from re-walking the
+            // outer round's columns
+            SpliceAtStamp ( const LineInfo & callAt ) : base(callAt), col(callAt.column) {
+                cap = callAt.last_column > callAt.column ? callAt.last_column - 1 : callAt.column;
+            }
+            LineInfo pointAt ( uint32_t c ) const {
+                LineInfo p = base;
+                p.column = c;
+                p.last_column = c;
+                p.last_line = p.line;
+                return p;
+            }
+            LineInfo wideAt ( uint32_t c ) const {
+                LineInfo w = pointAt(c);
+                w.last_line = w.line + 1;
+                w.last_column = 0;
+                return w;
+            }
+            uint32_t bump ( uint32_t c ) const { return c < cap ? c + 1 : cap; }
+            LineInfo base;
+            uint32_t col = 0;
+            uint32_t cap = 0;
+        protected:
+            virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
+            virtual void preVisitExpression ( Expression * expr ) override {
+                Visitor::preVisitExpression(expr);
+                expr->at = expr->rtti_isBlock() ? wideAt(col) : pointAt(col);
+            }
+            virtual void preVisitLet ( ExprLet * let, const VariablePtr & var, bool last ) override {
+                Visitor::preVisitLet(let, var, last);
+                let->atInit = pointAt(bump(col));    // visibility opens after the init, which parks at col
+                var->at = pointAt(col);
+            }
+            virtual ExpressionPtr visit ( ExprLet * let ) override {
+                col = bump(col);                     // later statements park past this let's visibility start
+                return Visitor::visit(let);
+            }
+            virtual void preVisit ( ExprFor * expr ) override {
+                Visitor::preVisit(expr);
+                expr->visibility = wideAt(col);     // not re-derived by infer, unlike let visibility
+                for ( auto & var : expr->iteratorVariables ) var->at = pointAt(col);
+            }
+        };
+
         // replace one specific node (by identity) inside a statement
         class ReplaceNode : public Visitor {
         public:
@@ -1123,6 +1192,7 @@ namespace das {
             var->init_via_clone = viaClone;
             auto let = new ExprLet();
             let->at = at;
+            // visibility stays closed until the init ran
             let->atInit = init ? init->at : at;
             let->variables.push_back(var);
             return let;
@@ -2244,7 +2314,12 @@ namespace das {
             auto ret = static_cast<ExprReturn *>(in.body->list.back());
             ExpressionPtr callReplacement = nullptr;
             if ( ret->subexpr ) {
-                callReplacement = ret->subexpr->clone()->visit(rewriter);
+                auto cloned = ret->subexpr->clone();
+                if ( subj.fn ) {    // callee-origin lines; a literal's body is already caller code
+                    SpliceAtStamp stamp(callLike->at);
+                    cloned = cloned->visit(stamp);
+                }
+                callReplacement = cloned->visit(rewriter);
             }
             if ( site.stmt==callLike ) {
                 auto & list = site.anchor.block->list;
@@ -2498,18 +2573,26 @@ namespace das {
                 }
             }
             vector<ExpressionPtr> splice;
+            // stamping is gated on calleeFn throughout - an invoke-block literal is
+            // caller code with honest lines already
+            SpliceAtStamp stamp(callLike->at);
             int preIdx = 0;
             for ( auto pe : prefix ) {
                 string tname = INLINE_TEMP_PREFIX + to_string(inlineId) + "_pre" + to_string(preIdx++);
+                auto peAt = pe->at;                 // the host-side read keeps the real position
+                ExprLet * tl = nullptr;
                 // non-const throughout: a const temp read would stop matching var pointer params downstream
                 if ( pe->type && pe->type->ref ) {
                     // lvalue: bind a reference - identity survives, writes land in the original place
                     pe->alwaysSafe = true;          // generated binding to real storage
-                    splice.push_back(makeTemp(pe->at, tname, pe, pe->type->constant, true, false));
+                    // callLike->at, not pe->at: the temp must be in scope at the splice's park point
+                    tl = makeTemp(callLike->at, tname, pe, pe->type->constant, true, false);
                 } else {
-                    splice.push_back(makeTemp(pe->at, tname, pe, false, false, pe->type && !pe->type->canCopy()));
+                    tl = makeTemp(callLike->at, tname, pe, false, false, pe->type && !pe->type->canCopy());
                 }
-                ReplaceNode rn(pe, new ExprVar(pe->at, tname));
+                if ( calleeFn ) tl->visit(stamp);
+                splice.push_back(tl);
+                ReplaceNode rn(pe, new ExprVar(peAt, tname));
                 auto & slot = site.anchor.block->list[anchorIndex];
                 slot = slot->visit(rn);
                 if ( !rn.done ) {
@@ -2519,14 +2602,20 @@ namespace das {
             }
             InlineBodyRewriter rewriter(plan.paramSub, rename, callLike->at, calleeFn != nullptr);
             ExpressionPtr callReplacement = nullptr;
+            if ( calleeFn ) {
+                for ( auto & t : temps ) t->visit(stamp);   // arg temps ladder after the prefix temps
+            }
             if ( exprBody ) {
                 auto ret = static_cast<ExprReturn *>(in.body->list.back());
                 if ( ret->subexpr ) {
-                    callReplacement = ret->subexpr->clone()->visit(rewriter);
+                    auto cloned = ret->subexpr->clone();
+                    if ( calleeFn ) cloned = cloned->visit(stamp);
+                    callReplacement = cloned->visit(rewriter);
                 }
                 for ( auto & t : temps ) splice.push_back(t);
             } else {
                 auto bodyClone = static_cast<ExprBlock *>(in.body->clone());
+                if ( calleeFn ) bodyClone->visit(stamp);
                 if ( site.kind==SiteKind::InvokeBlock ) {
                     // parameters became substitutions, the result becomes the result temp - a plain scope block remains
                     bodyClone->arguments.clear();
@@ -2540,7 +2629,15 @@ namespace das {
                 }
                 ReturnStoreRewrite rsr(in.result ? INLINE_TEMP_PREFIX + to_string(inlineId) + "_res" : string(),
                     INLINE_TEMP_PREFIX + to_string(inlineId) + "_ret");
-                if ( in.result ) splice.push_back(makeUninitDecl(callLike->at, rsr.resName, in.result));
+                // _res goes FIRST: a no-init decl zero-fills its slot, so the walk reads
+                // zeros until a return-store writes it - no ladder column needed. callee
+                // splices park at/after the call site, so visibility can open there; a
+                // LITERAL's body may park earlier - keep whole-function
+                if ( in.result ) {
+                    auto resLet = makeUninitDecl(callLike->at, rsr.resName, in.result);
+                    if ( calleeFn ) resLet->atInit = stamp.pointAt(callLike->at.column);
+                    splice.insert(splice.begin(), resLet);
+                }
                 rsr.apply(bodyClone);
                 if ( in.result ) {
                     callReplacement = new ExprVar(callLike->at, rsr.resName);
@@ -2560,7 +2657,8 @@ namespace das {
                         host = static_cast<ExprBlock *>(spliced);
                     } else {
                         host = new ExprBlock();
-                        host->at = callLike->at;
+                        // manufactured scope needs the same one-line-wide range spliced blocks get
+                        host->at = calleeFn ? stamp.wideAt(callLike->at.column) : callLike->at;
                         host->list.push_back(spliced);
                     }
                     auto scopeWrap = new ExprWith(callLike->at);
@@ -2571,7 +2669,8 @@ namespace das {
                 }
                 if ( !temps.empty() || rsr.flagUsed ) {
                     auto scope = new ExprBlock();
-                    scope->at = callLike->at;
+                    // same one-line-wide range as above - the arg temps live HERE
+                    scope->at = calleeFn ? stamp.wideAt(callLike->at.column) : callLike->at;
                     for ( auto & t : temps ) scope->list.push_back(t);
                     if ( rsr.flagUsed ) {
                         scope->list.push_back(makeTemp(callLike->at, rsr.flagName,
@@ -2824,7 +2923,8 @@ namespace das {
             return false;
         }
         bool mustEnabled = !options.getBoolOption("disable_inline", policies.disable_inline);
-        bool autoEnabled = getOptimize()
+        // the debugger needs true frames and true lines - same reason it disables fastcall
+        bool autoEnabled = getOptimize() && !getDebugger()
             && !options.getBoolOption("disable_auto_inline", policies.disable_auto_inline);
         // under `options no_aliasing` call-result aliasing is an ERROR; splicing calls away
         // would change which programs compile - diagnostics must not depend on a perf knob

--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -580,6 +580,19 @@ namespace das {
                 }
                 if ( mayQueue ) fnc->mayQueueTempString = true;
             }
+            // need-caller-stack-frame: bottom-up like the two rules above, same cycle
+            // under-report. invoke edges are NOT closed over: a collect reached only
+            // through a block/lambda invoked from a fastcall body is the residual
+            // documented in contexts.rst
+            if ( !fnc->needCallerStackFrame ) {
+                for ( auto & depF : fnc->useFunctions ) {
+                    if ( depF == fnc ) continue;
+                    if ( depF->needCallerStackFrame ) {
+                        fnc->needCallerStackFrame = true;
+                        break;
+                    }
+                }
+            }
             fnc->sideEffectFlags |= flags;
             return flags;
         }

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -213,7 +213,7 @@ namespace das {
         auto ft = new TypeDecl(Type::tBitfield);
         ft->alias = "MoreFunctionFlags2";
         ft->argNames = {
-            "localFunction", "tempStringResult", "mayQueueTempString"
+            "localFunction", "tempStringResult", "mayQueueTempString", "needCallerStackFrame"
         };
         return ft;
     }

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -836,15 +836,11 @@ namespace das {
             at.last_line = at.line + diff;
         }
 
-        // if ( writing ) {
-        //     DAS_ASSERTF(at.column <= 255 && at.last_column <= 255, "unexpected long line");
-        //     uint8_t column = at.column, last_column = at.last_column;
-        //     *this << column << last_column;
-        // } else {
-        //     uint8_t column, last_column;
-        //     *this << column << last_column;
-        //     at.column = column; at.last_column = last_column;
-        // }
+        // columns must round-trip: local VISIBILITY ranges gate the GC walk, and inline
+        // splices distinguish locals on one line by column alone (the SpliceAtStamp
+        // ladder) - dropping columns here made a deserialized program collect unsoundly
+        serializeAdaptiveSize32(at.column);
+        serializeAdaptiveSize32(at.last_column);
 
         return *this;
     }

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -2471,6 +2471,8 @@ namespace das
                 SideEffects::modifyExternal, "heap_collect")
                     ->args({"string_heap","validate","context","at"});
         hcol->unsafeOperation = true;
+        // the collector walks caller frames and a fastcall caller has none - this is the seed
+        hcol->needCallerStackFrame = true;
         hcol->arguments[0]->init = new ExprConstBool(true);
         hcol->arguments[1]->init = new ExprConstBool(false);
         addExtern<DAS_BIND_FUN(string_heap_report)>(*this, lib, "string_heap_report",

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -927,6 +927,33 @@ namespace das
     };
 
     void Context::collectHeap ( LineInfo * at, bool sheap, bool validate ) {
+        // refuse dishonest frames BEFORE marking - the error path must leave both heaps
+        // unmarked. a frame above a broken line handoff can't have its locals attributed:
+        // they fail the visibility gate and get swept while live. gated on persistent+gc
+        // so a direct C++ collectHeap on a non-GC context keeps its old silent no-op
+        // (the mark() bail-outs below); fastcall carriers were denied frames at compile
+        // time (needCallerStackFrame) - nothing to check for them here
+        if ( persistent && gcEnabled ) {
+            char * scanSp = stack.ap();
+            // an EMPTY line is as unattributable as a null one (a generated call node
+            // with an unset at) - normalize both to null so the refusal sees them
+            const LineInfo * scanLineAt = ( at && !at->empty() ) ? at : nullptr;
+            while ( scanSp < stack.top() ) {
+                Prologue * pp = (Prologue *) scanSp;
+                FuncInfo * info = nullptr;
+                if ( pp->info ) {
+                    intptr_t iblock = intptr_t(pp->block);
+                    info = ( iblock & 1 ) ? ((Block *)(iblock & ~1))->info : pp->info;
+                }
+                if ( info && info->locals && info->localCount && !scanLineAt ) {
+                    throw_error_at(at, "heap collection can't attribute locals of '%s' - "
+                        "the frame was entered through a compiled (AOT/JIT) frame or a "
+                        "null-line call", info->name ? info->name : "?");
+                }
+                scanLineAt = ( info && pp->line && !pp->line->empty() ) ? pp->line : nullptr;
+                scanSp += info ? info->stackSize : pp->stackSize;
+            }
+        }
         GcGuard guard(this);
         // clean up, so that all small allocations are marked as 'free'
         stringDisposeQue = nullptr;
@@ -988,6 +1015,7 @@ namespace das
                     info = pp->info;
                 }
             }
+            // dishonest frames (AOT/JIT, null-line entry) were refused by the pre-scan above
             if ( info ) {
                 for ( uint32_t i=0, is=info->count; i!=is; ++i ) {
                     walker.prepare();

--- a/tests-cpp/doctest_main.cpp
+++ b/tests-cpp/doctest_main.cpp
@@ -29,10 +29,13 @@
 
 #include <cstdio>
 
+DECLARE_MODULE(Module_GcWalkTest);  // registered in small/test_gc_walk_refusals.cpp
+
 int main(int argc, char** argv) {
     NEED_ALL_DEFAULT_MODULES;     // statement-form macro — must be inside a function body
     NEED_MODULE(Module_JobQue);   // ensure the JobQue module is linked in even if no test pulls it
     NEED_MODULE(Module_UriParser); // daslib/debug require chain (test_env_serializer) reaches uriparser
+    NEED_MODULE(Module_GcWalkTest); // test_gc_walk_refusals: das->C++->das re-entry extern
 
     das::Module::Initialize();
 

--- a/tests-cpp/small/test_gc_walk_refusals.cpp
+++ b/tests-cpp/small/test_gc_walk_refusals.cpp
@@ -1,0 +1,78 @@
+// the heap_collect refusal halves only a C++ host can exercise:
+//   - a das frame entered with at = nullptr makes the frame above it unattributable: refuse;
+//   - a null line at the stack ROOT stays legal (the macro-context collect pattern).
+
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/simulate/aot.h"
+
+#include <cstring>
+
+using namespace das;
+
+namespace {
+    // re-enters the context on a das function pointer with NO line info - the shape a
+    // C++ embedder produces with das_invoke_function<...>::invoke(ctx, nullptr, fn)
+    void reenter_null_line ( TFunc<void> fn, Context * context ) {
+        das_invoke_function<void>::invoke(context, nullptr, fn);
+    }
+}
+
+class Module_GcWalkTest : public Module {
+public:
+    Module_GcWalkTest() : Module("gc_walk_test") {
+        ModuleLibrary lib(this);
+        lib.addBuiltInModule();
+        addExtern<DAS_BIND_FUN(reenter_null_line)>(*this, lib, "reenter_null_line",
+            SideEffects::invoke, "reenter_null_line")
+                ->args({"fn","context"});
+    }
+};
+REGISTER_MODULE(Module_GcWalkTest);
+
+#define SCRIPT_PATH "/tests-cpp/small/test_gc_walk_refusals.das"
+
+TEST_CASE("heap_collect refuses frames it can't attribute") {
+    TextPrinter tout;
+    ModuleGroup dummyLibGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+    auto program = compileDaScript(getDasRoot() + SCRIPT_PATH,
+                                   fAccess, tout, dummyLibGroup);
+    if ( program->failed() ) {
+        TextWriter tw;
+        for ( auto & err : program->errors ) {
+            tw << reportError(err.at, err.what, err.extra, err.fixme, err.cerr);
+        }
+        string serr = tw.str();
+        MESSAGE(serr);
+    }
+    REQUIRE_FALSE(program->failed());
+
+    Context ctx(program->getContextStackSize());
+    REQUIRE(program->simulate(ctx, tout));
+
+    SUBCASE("collect below a null-line re-entry refuses") {
+        auto fn = ctx.findFunction("outer_reenter");
+        REQUIRE(fn);
+        bool refused = false;
+        bool ok = ctx.runWithCatchAndClear([&](){
+            vec4f r = ctx.callOrFastcall(fn, nullptr, nullptr);
+            refused = cast<bool>::to(r);
+        });
+        CHECK_MESSAGE(ok, "the refusal must be recoverable inside das, not escape the call");
+        CHECK_MESSAGE(refused, "collect under a null-line re-entry must refuse");
+    }
+
+    SUBCASE("collect with a null line at the stack ROOT stays legal") {
+        auto fn = ctx.findFunction("collect_at_root");
+        REQUIRE(fn);
+        bool collected = false;
+        bool ok = ctx.runWithCatchAndClear([&](){
+            vec4f r = ctx.callOrFastcall(fn, nullptr, nullptr);
+            collected = cast<bool>::to(r);
+        });
+        CHECK_MESSAGE(ok, "root-level collect must not throw");
+        CHECK_MESSAGE(collected, "root-level collect with a null entry line must succeed");
+    }
+}

--- a/tests-cpp/small/test_gc_walk_refusals.das
+++ b/tests-cpp/small/test_gc_walk_refusals.das
@@ -1,0 +1,38 @@
+// fixture for test_gc_walk_refusals.cpp - see the .cpp for the scenario
+options gen2
+options gc
+options persistent_heap
+
+require gc_walk_test
+
+def inner_collect() {
+    var pad = 1
+    unsafe(heap_collect(true, false))
+    pad++
+}
+
+[export]
+def outer_reenter() : bool {
+    // a live heap-string local is the point: the walk must refuse rather than sweep it
+    // (interpolated so it is a runtime allocation, not a static literal)
+    var precious = "outer_holds_{1000 + 234}"
+    var refused = false
+    try {
+        reenter_null_line(@@inner_collect)
+    } recover {
+        refused = true
+    }
+    return refused && precious == "outer_holds_1234"
+}
+
+[export]
+def collect_at_root() : bool {
+    var ok = true
+    var pad = 1
+    try {
+        unsafe(heap_collect(true, false))
+    } recover {
+        ok = false
+    }
+    return ok && pad == 1
+}

--- a/tests/.das_test
+++ b/tests/.das_test
@@ -86,15 +86,14 @@ def can_visit_folder(folder_name : string; var result : bool?) {
             }
         }
     }
-    // GC tests are interp-only under JIT: jitted frames keep locals on the native stack,
-    // so heap_collect can't see a heap pointer whose only reference is a jitted local and
-    // frees it (double-free / reuse-after-collect; Debug memory_model.h assert catches it,
-    // Release passes by luck). Lift only once the JIT spills GC roots somewhere the
-    // collector can scan.
+    // GC tests are interp-only: compiled frames (JIT, AOT) keep locals where the collector
+    // can't scan them, and one entered from the interpreter is indistinguishable from an
+    // interpreted frame, so the walk would read never-written slots. Lift once compiled
+    // frames spill GC roots somewhere scannable.
     if (folder_name == "gc") {
         let args <- get_command_line_arguments()
         for (arg in args) {
-            if (arg == "-jit") {
+            if (arg == "-jit" || arg == "--use-aot") {
                 *result = false
                 return
             }

--- a/tests/decs/test_gc.das
+++ b/tests/decs/test_gc.das
@@ -1,6 +1,9 @@
 options gen2
 options persistent_heap
 options gc
+// gc-semantics file: heap_collect refuses chains with compiled (AOT/JIT) frames,
+// so the whole file stays interpreted under both sweeps
+options no_aot
 
 require daslib/decs_boost
 require dastest/testing_boost public
@@ -71,7 +74,7 @@ def test_archive_strings(t : T?) {
     }
 }
 
-[test]
+[test, no_jit]
 def test_gc_arrays(t : T?) {
     restart()
     for (i in range(3)) {
@@ -102,7 +105,7 @@ def test_gc_arrays(t : T?) {
     }
 }
 
-[test]
+[test, no_jit]
 def test_gc_strings(t : T?) {
     restart()
     for (i in range(3)) {
@@ -156,7 +159,7 @@ def test_arrays_lifetime(t : T?) {
     t |> success(total_foo == 0)
 }
 
-[test]
+[test, no_jit]
 def test_gc_stress(t : T?) {   // nolint:STYLE037,STYLE038 - one randomized stress scenario; every phase consumes the same RNG stream and running entity count, so a split would only thread state
     var seed = random_seed(13)
     restart()

--- a/tests/decs/test_gc.das
+++ b/tests/decs/test_gc.das
@@ -1,8 +1,8 @@
 options gen2
 options persistent_heap
 options gc
-// gc-semantics file: heap_collect refuses chains with compiled (AOT/JIT) frames,
-// so the whole file stays interpreted under both sweeps
+// gc-semantics file: heap_collect refuses chains with compiled (AOT/JIT) frames -
+// no_aot covers the AOT sweep; the collect tests carry [test, no_jit] for the jit sweep
 options no_aot
 
 require daslib/decs_boost

--- a/tests/gc/_stackwalk_common.das
+++ b/tests/gc/_stackwalk_common.das
@@ -1,0 +1,71 @@
+options gen2
+options indenting = 4
+options rtti
+
+module _stackwalk_common shared public
+
+require strings
+require daslib/rtti public
+require daslib/debugger public
+
+// records every walked frame and local; tests assert on frame names and on which
+// locals report in scope. lives in its own module so each test file's own options
+// (auto_inline_functions, debugger) govern only the shapes under test.
+class CollectingWalker : DapiStackWalker {
+    frames : array<string>
+    locals : array<string>          // "frame|name|inScope"
+    curFrame : string
+    @safe_when_uninitialized walkAt : LineInfo  // empty: only the deepest frame's locals gate on it
+    def override canWalkArguments : bool => false
+    def override canWalkVariables : bool => true
+    def override canWalkOutOfScopeVariables : bool => true
+    def override onBeforeCall(pp : Prologue; sp : void?) : void {}
+    def override onCallAOT(pp : Prologue; fileName : string#) : void {
+        curFrame = "<AOT>"
+        frames |> push(curFrame)
+    }
+    def override onCallJIT(pp : Prologue; fileName : string#) : void {
+        curFrame = "<JIT>"
+        frames |> push(curFrame)
+    }
+    def override onCallAt(pp : Prologue; info : FuncInfo; at : LineInfo) : void {
+        curFrame = "{info.name}"
+        frames |> push(curFrame)
+    }
+    def override onCall(pp : Prologue; info : FuncInfo) : void {
+        curFrame = "{info.name}"
+        frames |> push(curFrame)
+    }
+    def override onAfterPrologue(pp : Prologue; sp : void?) : void {}
+    def override onArgument(info : FuncInfo; index : int; vinfo : VarInfo; arg : float4) : void {}
+    def override onBeforeVariables : void {}
+    def override onVariable(inf : FuncInfo; vinfo : LocalVariableInfo; arg : void?; inScope : bool) : void {
+        locals |> push("{curFrame}|{vinfo.name}|{inScope}")
+    }
+    def override onAfterCall(pp : Prologue) : bool => true
+    def override onCorruptStack(pp : Prologue) : void {}
+}
+
+def run_walk(var w : CollectingWalker?) {
+    make_stack_walker(w) $(adapter) {
+        adapter |> walk_stack(this_context(), w.walkAt)
+    }
+}
+
+// substring match - inlined locals carry mangled names like _inl1_l_counter
+def has_frame(w : CollectingWalker?; needle : string) : bool {
+    for (f in w.frames) {
+        return true if (find(f, needle) >= 0)
+    }
+    return false
+}
+
+// same, over the packed "frame|name|inScope" records; the local must report in scope
+def has_live_local(w : CollectingWalker?; needle : string) : bool {
+    for (l in w.locals) {
+        if (find(l, needle) >= 0 && ends_with(l, "|true")) {
+            return true
+        }
+    }
+    return false
+}

--- a/tests/gc/test_collect_frame_marking.das
+++ b/tests/gc/test_collect_frame_marking.das
@@ -1,0 +1,208 @@
+options gen2
+options indenting = 4
+options gc
+options persistent_heap
+
+require dastest/testing_boost public
+
+// pins the honest-frames marking contract: caller locals survive a collect no matter
+// where in the chain it fires - inlined callee, same frame, block/lambda/function
+// pointer indirection, argument evaluation, or an inlined callee's own for loop.
+
+def churn_strings(tag : string) : int {
+    var junk <- [for (i in range(200)); "junk/{tag}/segment_{i}/{i * 3}_tail"]
+    var total = 0
+    for (s in junk) {
+        total += length(s)
+    }
+    delete junk
+    return total
+}
+
+// tiny and inline-eligible on purpose: the collect call site gets spliced into the caller
+def collect_every(var since : int&; period : int) {
+    since++
+    if (since >= period) {
+        since = 0
+        unsafe(heap_collect(true, true))
+    }
+}
+
+[never_inline]
+def apply_block_noinline(b : block) {
+    var pad = 1
+    invoke(b)
+    pad++
+}
+
+def collect_now_regular() {
+    var pad = 1
+    unsafe(heap_collect(true, true))
+    pad++
+}
+
+def make_files(var files : array<string>) {
+    files |> reserve(60)
+    for (d in range(12)) {
+        for (i in range(5)) {
+            files |> push("root/dir_{d}/file_{i}.das")
+        }
+    }
+}
+
+def verify_files(t : T?; files : array<string>; tag : string) {
+    var idx = 0
+    for (f in files) {
+        if (f != "root/dir_{idx / 5}/file_{idx % 5}.das") {
+            t |> failure("{tag}: corrupt entry at index {idx}")
+            return
+        }
+        idx++
+    }
+    t |> success(idx == 60, "{tag}: walked all 60 entries")
+}
+
+// arg 0's initializer collects (validate on) while arg 1's temp slot is still raw
+// stack garbage - the column ladder must keep that slot invisible to the walk
+def churn_and_collect_str(seed : int) : string {
+    var junk <- [for (i in range(400)); "garbage_{seed}_{i}_padding_padding"]
+    delete junk
+    let keep = "kept_{seed}"
+    unsafe(heap_collect(true, true))
+    return keep
+}
+
+def two_args(a, b : string) : int {
+    let pad = length(a) + length(b)
+    return pad
+}
+
+// a collect while a LATER argument evaluates - the earlier temp holds the only reference.
+// the two arms below are probabilistic instruments: a regression frees the temp's string,
+// and the assert fires only when the freed block gets reused (pre-fix: 1 in 20 iterations)
+def collect_and_tail(seed : int) : string {
+    var junk <- [for (i in range(400)); "garbage2_{seed}_{i}_padding_padding"]
+    delete junk
+    unsafe(heap_collect(true, true))
+    return "tail_{seed}"
+}
+
+def pick_first(a, _b : string) : string {
+    let r = a
+    return r
+}
+
+// inline-eligible callee whose own `for` hosts the collect - pins the stamped
+// ExprFor visibility (infer does not re-derive it, unlike let visibility)
+def scan_with_collect(names : array<string>; var since : int&) : int {
+    var total = 0
+    for (nm in names) {
+        total += length(nm)
+        collect_every(since, 3)
+    }
+    return total
+}
+
+[test]
+def test_collect_frame_marking(t : T?) {  // nolint:STYLE038 - flat list of independent test arms
+    t |> run("collect in an inlined callee keeps caller locals") @(t : T?) {
+        var files : array<string>
+        make_files(files)
+        var since = 0
+        var churned = 0
+        for (f in files) {
+            churned += churn_strings(f)
+            collect_every(since, 5)
+        }
+        verify_files(t, files, "inlined callee")
+        t |> success(churned > 0)
+    }
+    t |> run("same-frame collect keeps locals") @(t : T?) {
+        var files : array<string>
+        make_files(files)
+        var since = 0
+        for (f in files) {
+            churn_strings(f)
+            since++
+            if (since >= 5) {
+                since = 0
+                unsafe(heap_collect(true, true))
+            }
+        }
+        verify_files(t, files, "same frame")
+    }
+    t |> run("collect through a real block invoke keeps caller locals") @(t : T?) {
+        var files : array<string>
+        make_files(files)
+        var since = 0
+        for (f in files) {
+            churn_strings(f)
+            since++
+            if (since >= 5) {
+                since = 0
+                apply_block_noinline() {
+                    unsafe(heap_collect(true, true))
+                }
+            }
+        }
+        verify_files(t, files, "block invoke")
+    }
+    t |> run("collect through a lambda keeps caller locals") @(t : T?) {
+        var files : array<string>
+        make_files(files)
+        let lam <- @() {
+            var pad = 1
+            unsafe(heap_collect(true, true))
+            pad++
+        }
+        var since = 0
+        for (f in files) {
+            churn_strings(f)
+            since++
+            if (since >= 5) {
+                since = 0
+                invoke(lam)
+            }
+        }
+        verify_files(t, files, "lambda")
+    }
+    t |> run("collect through a function pointer keeps caller locals") @(t : T?) {
+        var files : array<string>
+        make_files(files)
+        let fp = @@collect_now_regular
+        var since = 0
+        for (f in files) {
+            churn_strings(f)
+            since++
+            if (since >= 5) {
+                since = 0
+                invoke(fp)
+            }
+        }
+        verify_files(t, files, "function pointer")
+    }
+    t |> run("collect during argument evaluation of an inlined call") @(t : T?) {
+        for (i in range(20)) {
+            let r = two_args(churn_and_collect_str(i), "tail_{i}")
+            t |> equal(r, length("kept_{i}") + length("tail_{i}"))
+        }
+    }
+    t |> run("earlier argument temp survives a collect in a later argument") @(t : T?) {
+        for (i in range(20)) {
+            let kept = pick_first("kept_{i}", collect_and_tail(i))
+            t |> equal(kept, "kept_{i}")
+        }
+    }
+    t |> run("collect inside an inlined callee's for loop") @(t : T?) {
+        var names : array<string>
+        make_files(names)
+        var since = 0
+        var expected = 0
+        for (nm in names) {
+            expected += length(nm)
+        }
+        let total = scan_with_collect(names, since)
+        t |> equal(total, expected)
+        verify_files(t, names, "inlined for")
+    }
+}

--- a/tests/gc/test_collect_refusals.das
+++ b/tests/gc/test_collect_refusals.das
@@ -1,0 +1,72 @@
+options gen2
+options indenting = 4
+options rtti
+options gc
+options persistent_heap
+
+require dastest/testing_boost public
+require _stackwalk_common
+
+// pins the frame-presence half of the honest-frames guarantee, with a same-shape
+// non-carrier control. [never_inline] keeps every hop a real call - what is under
+// test is the flag closure, not the inliner.
+
+def walk_only(var w : CollectingWalker?) {
+    var pad = 1
+    run_walk(w)
+    pad++
+}
+
+// a collect carrier; two statements, so its own shape never depends on the flag
+def walk_and_collect(var w : CollectingWalker?) {
+    run_walk(w)
+    unsafe(heap_collect(true, false))
+}
+
+[never_inline]
+def w_plain(var w : CollectingWalker?) {    // single statement + void, NON-carrier callee: fastcall
+    walk_only(w)
+}
+
+[never_inline]
+def w_direct(var w : CollectingWalker?) {   // same shape, callee IS a carrier: real frame
+    walk_and_collect(w)
+}
+
+[never_inline]
+def w_mid(var w : CollectingWalker?) {      // carrier by transitivity, depth 2
+    w_direct(w)
+}
+
+[never_inline]
+def w_outer(var w : CollectingWalker?) {    // carrier by transitivity, depth 3
+    w_mid(w)
+}
+
+[test]
+def test_collect_chains_stay_walkable(t : T?) {
+    t |> run("the control: a same-shape non-carrier wrapper is frameless (fastcall)") @(t : T?) {
+        var w = new CollectingWalker()
+        w_plain(w)
+        t |> success(!has_frame(w, "w_plain"), "w_plain must be fastcall - proves the shape under test is frameless without the flag")
+        unsafe {
+            delete w
+        }
+    }
+    t |> run("collect carriers keep real frames at every hop and collect") @(t : T?) {
+        var w = new CollectingWalker()
+        var ok = true
+        try {
+            w_outer(w)
+        } recover {
+            ok = false
+        }
+        t |> success(ok, "the carrier chain must collect")
+        t |> success(has_frame(w, "w_direct"), "the direct collect caller keeps a real frame")
+        t |> success(has_frame(w, "w_mid"), "a depth-2 carrier keeps a real frame")
+        t |> success(has_frame(w, "w_outer"), "a depth-3 carrier keeps a real frame")
+        unsafe {
+            delete w
+        }
+    }
+}

--- a/tests/gc/test_stackwalk_debugger.das
+++ b/tests/gc/test_stackwalk_debugger.das
@@ -1,0 +1,40 @@
+options gen2
+options indenting = 4
+options rtti
+options debugger
+
+require dastest/testing_boost public
+require _stackwalk_common
+
+// `options debugger` disables auto-inlining (the debugger needs true frames and true
+// lines - same reason it disables fastcall), so the helper chain must walk as real
+// frames even though both functions are otherwise splice-eligible.
+
+def tiny_helper(var w : CollectingWalker?; tag : int) {
+    var pad = tag + 1
+    if (pad > 0) {
+        run_walk(w)
+    }
+    pad++
+}
+
+def owner_frame(var w : CollectingWalker?; seed : int) : int {
+    let counter = seed + 40
+    let precious = "PRECIOUS_{counter}"
+    tiny_helper(w, counter)
+    return length(precious) + counter
+}
+
+[test]
+def test_stackwalk_debugger_frames(t : T?) {
+    t |> run("debugger option keeps real frames") @(t : T?) {
+        var w = new CollectingWalker()
+        let r = owner_frame(w, length(w.frames) + 2)
+        t |> equal(r, length("PRECIOUS_42") + 42)
+        t |> success(has_frame(w, "tiny_helper"), "tiny_helper keeps its frame under options debugger")
+        t |> success(has_frame(w, "owner_frame"), "owner_frame keeps its frame under options debugger")
+        unsafe {
+            delete w
+        }
+    }
+}

--- a/tests/gc/test_stackwalk_inline.das
+++ b/tests/gc/test_stackwalk_inline.das
@@ -1,0 +1,42 @@
+options gen2
+options indenting = 4
+options rtti
+options gc
+
+require dastest/testing_boost public
+require _stackwalk_common
+
+// under default auto-inlining the helper chain splices into the test arm; every LIVE
+// local must still report in scope. test_stackwalk_noinline.das pins the unspliced shape.
+
+def tiny_helper(var w : CollectingWalker?; tag : int) {
+    var pad = tag + 1
+    if (pad > 0) {
+        run_walk(w)
+    }
+    pad++
+}
+
+def owner_frame(var w : CollectingWalker?; seed : int) : int {
+    let counter = seed + 40
+    let precious = "PRECIOUS_{counter}"
+    tiny_helper(w, counter)
+    return length(precious) + counter
+}
+
+[test]
+def test_stackwalk_inlined_locals(t : T?) {
+    t |> run("live locals of an inlined chain report in scope") @(t : T?) {
+        var w = new CollectingWalker()
+        let r = owner_frame(w, length(w.frames) + 2)
+        t |> equal(r, length("PRECIOUS_42") + 42)
+        t |> success(!has_frame(w, "tiny_helper"), "tiny_helper was spliced away")
+        t |> success(!has_frame(w, "owner_frame"), "owner_frame was spliced away")
+        t |> success(has_live_local(w, "counter"), "counter must be live in the walk")
+        t |> success(has_live_local(w, "precious"), "precious must be live in the walk")
+        t |> success(has_live_local(w, "pad"), "pad must be live in the walk")
+        unsafe {
+            delete w
+        }
+    }
+}

--- a/tests/gc/test_stackwalk_noinline.das
+++ b/tests/gc/test_stackwalk_noinline.das
@@ -1,0 +1,42 @@
+options gen2
+options indenting = 4
+options rtti
+options gc
+options auto_inline_functions = false
+
+require dastest/testing_boost public
+require _stackwalk_common
+
+// the unspliced control for test_stackwalk_inline.das: with the inliner off the same
+// chain walks as real frames, and every live local reports in scope under its own frame.
+
+def tiny_helper(var w : CollectingWalker?; tag : int) {
+    var pad = tag + 1
+    if (pad > 0) {
+        run_walk(w)
+    }
+    pad++
+}
+
+def owner_frame(var w : CollectingWalker?; seed : int) : int {
+    let counter = seed + 40
+    let precious = "PRECIOUS_{counter}"
+    tiny_helper(w, counter)
+    return length(precious) + counter
+}
+
+[test]
+def test_stackwalk_real_frames(t : T?) {
+    t |> run("unspliced chain walks as real frames") @(t : T?) {
+        var w = new CollectingWalker()
+        let r = owner_frame(w, length(w.frames) + 2)
+        t |> equal(r, length("PRECIOUS_42") + 42)
+        t |> success(has_frame(w, "tiny_helper"), "tiny_helper keeps its frame")
+        t |> success(has_frame(w, "owner_frame"), "owner_frame keeps its frame")
+        t |> success(has_live_local(w, "counter"), "counter must be live in the walk")
+        t |> success(has_live_local(w, "precious"), "precious must be live in the walk")
+        unsafe {
+            delete w
+        }
+    }
+}

--- a/utils/lint/main.das
+++ b/utils/lint/main.das
@@ -706,6 +706,7 @@ def main() : int {
             print("Linting {length(files)} file(s)...\n\n")
         }
         var stale_eligible : array<string>
+        var since_collect = 0
         for (file in files) {
             if (!cfg.quiet) {
                 print("checking {file}...\n")
@@ -716,7 +717,7 @@ def main() : int {
             }
             print_result(result, cfg.quiet, cfg.silent)
             tally_result(result, total_issues, total_errors, total_skipped, total_excluded)
-            // NO maybe_collect here: a collect in THIS loop corrupts live strings (worker mode collects identically and survives) - serial stays grow-only until the runtime cause is fixed
+            maybe_collect(since_collect)
         }
         if (run_paranoid && run_perf && run_style) {
             stale_scan_at_end(stale_eligible, cfg, disabled_codes, enabled_codes,

--- a/utils/lint/tests/perf030_move_assign_leak.das
+++ b/utils/lint/tests/perf030_move_assign_leak.das
@@ -14,6 +14,10 @@ options gen2
 
 expect 31208:5
 
+// the rule is source-level: without this, main()'s auto-inlined copies of the bad_*
+// bodies re-report every finding at the (stamped) call-site lines
+options auto_inline_functions = false
+
 require daslib/perf_lint
 
 struct Holder {


### PR DESCRIPTION
**Behavior changes: `heap_collect` refuses chains it cannot attribute (previously it silently mis-collected); any function that can reach `heap_collect` through direct calls is never fastcall; `Context::fastCallDepth` is deleted (C++ ABI, embedder-visible); `live_collect_gc`/`live_collect_string_gc` gain a `LineInfoArg*` (C++ signature, zero in-tree callers); the AST serializer now round-trips LineInfo columns (they were silently dropped, which made deserialized programs collect unsoundly through inline splices) and bumps to 116 (module caches re-mint once).**

The collector gates each frame's locals on the parked line vs the local's visibility range, and two mechanisms fed it foreign lines: auto-inline splices kept callee source positions, and fastcall frames do not exist at all. Either way the caller's live locals failed the gate and were swept — issue #3734's string UAF, reproduced 100% by a 70-line script. Inline splices now stamp everything they move with the host call-site position on a capped per-declaration column ladder, so at any park point exactly the already-initialized locals pass the gate; manufactured wrapper scopes get non-degenerate ranges (`LineInfo::inside` is line-exclusive at `last_line`). For fastcall, the guard is compile-time: `needCallerStackFrame` seeds on `heap_collect` and closes transitively over direct calls (same rail as `mayQueueTempString`; the fastcall gate keys on the function's own bit, so operator edges are covered too), so every collect ancestor keeps a real frame and collect wrappers of any depth just work. What remains at runtime is one pre-mark scan that refuses a locals-bearing frame whose line handoff is null or empty (compiled-frame sandwiches, null-line C++ re-entry) — refusing before marking so the error path leaves the heaps untouched.

`fastCallDepth` is deleted outright rather than extended: its overflow guard was already absent in every Release build for fused 1/2-arg fastcalls (fusion nodes never maintained the counter), so it was hot-path weight without protection. The fastcall dispatch path is now lighter than master. A new `include/daScript/simulate/REVIEW.md` makes that a standing rule: no new work on the hot evaluation paths unless correctness requires it, and then flagged. This diff's hot-path delta is a removal.

Also: `options debugger` disables auto-inlining (same reason it disables fastcall); the lint runner's serial collect rail returns (the original #3734 repro, now 5/5 + 3/3 + 3/3 clean); the gc test folder is interp-only under both compiled sweeps; docs state the real contract including the residuals.

Where to look first: `src/ast/ast_inline.cpp` (`SpliceAtStamp`, the ladder cap, the wrapper-scope ranges), `src/ast/ast_unused.cpp` (the closure), `src/simulate/simulate_gc.cpp` (the pre-scan), `src/builtin/module_builtin_ast_serialize.cpp` (LineInfo columns), `include/daScript/simulate/simulate.h` + `simulate_nodes.h` (the deletion), `tests/gc/` (the new suites).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local-only evidence CI cannot produce: the minimal UAF repro corrupted 100% pre-fix and is clean post-fix; the arg-temp probe fired 1/20 pre-fix (freed-block reuse) and is clean post-fix; `tests/gc/test_gc_coverage.das` flipped from 6 refusal errors to green across the design iterations; the lint runner's serial `daslib -j 1` collect rail (the original crash: ~80% AV) ran 5/5 + 3/3 + 3/3 clean.
- The CI ser/deser lane crash (SIGSEGV in the new arg-temp arm when run from a deserialized program) was reproduced locally and root-caused: LineInfo column serialization was commented out, so deserialized programs lost the ladder and the visibility gate walked garbage slots. With columns serialized, the isolated repro flips clean and the full local `tests/` ser+deser sweep runs 11824/11827 (3 module-gated skips).
- Full local sweeps on the final build: interp `tests/` 13546/13549, full `test_aot` 12668/12669, tests-cpp 86 cases / 1,103,794 assertions, gc suite 107/107, decs gc file 14/14 on all three tiers, JIT smoke clean, sphinx clean, doc-verify green, AST-verify clean on every changed `.das`.
- The static-denial mechanism is pinned by frame PRESENCE: a same-shape non-carrier control proves the wrapper shape is fastcall (frameless), then carrier hops at depths 1–3 assert real frames (`tests/gc/test_collect_refusals.das`).
- The inline-splice marking fixes were negative-controlled against the pre-fix binary during development; the two arg-temp arms are probabilistic instruments (stated in-file).

### Claims — stated, not tested
- 13 stamper micro-branches (ladder bump, wideAt vs pointAt selection, `_res` placement, per-path stamp gates) were audited as UNPROVEN-by-mutation: each has a named mutation + suite gate, not run (each costs a C++ rebuild). The load-bearing ones carry the pre-fix firing evidence above.
- The compiled-frame half of the refusal has no test in an enabled lane (the gc folder is skipped under `-jit`/`--use-aot` by design); a tests-cpp case constructing a compiled prologue would settle it.
- The serial lint-runner rail cannot fire under the test suite (collect every 100 files; no suite compiles 100 files in one serial process) — the local runs above are its evidence.
- An AOT-compiled program with `options gc` entered from the interpreter now refuses collect — honest and loud, previously a silent mis-walk; no in-tree consumer does this.

### Not done
- `LineInfo::inside` cannot encode same-line column intervals (its `last_column` branch is dead code), which bounds the ladder design: a let in an earlier conditional arm stays gate-visible in a later sibling arm, and ladder saturation at the cap shares one column — both documented at `SpliceAtStamp`. Resurrecting the dead branch is the structural fix and touches every visibility consumer.
- The invoke-edge residual: a collect reachable only through a block/lambda invoked from inside a single-statement fastcall wrapper is not statically closed (closing it poisons every HOF-reaching function) — documented in `contexts.rst`.
- Pre-existing and ledgered, found by the round's prover: parser statement `at`s are single-token, so the inliner's tail re-blocks (`ReturnStoreRewrite`, `ReturnCanonicalization`, the lowering arm blocks) have always produced GC-invisible scopes — a master bug family, independent of this change.
- Fused fastcall nodes never maintained the now-deleted counter — moot after the deletion, recorded for archaeology.
- `live_collect_gc`/`live_collect_string_gc` have zero in-tree callers and identical bodies; deleting them is a candidate follow-up.
- Master-wide `--ast-verify` reports (delegate.das + 15 files, unset-`at` TypeDecls in generated class fields/casts) are #3727 fallout visible since its merge, not this branch — the nightly will show them on master.
- Generated class adapters (`*_gen.inc`) pass `nullptr` lines into `das_invoke_function`, so the documented re-entry contract is unreachable for das class callbacks until `gen_bind` threads an `at`; all in-tree callback collects are stack-root and safe.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)