### PR TITLE
nightly lint: enable dasSQLITE in the configure (unknown target dasModuleSQLITE)

### DIFF
--- a/.github/workflows/nightly_lint.yml
+++ b/.github/workflows/nightly_lint.yml
@@ -68,6 +68,7 @@ jobs:
             -DCMAKE_BUILD_TYPE:STRING=Release \
             -DDAS_HV_DISABLED=OFF \
             -DDAS_PUGIXML_DISABLED=OFF \
+            -DDAS_SQLITE_DISABLED=OFF \
             -DDAS_LLVM_DISABLED=ON \
             -DDAS_GLFW_DISABLED=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \


### PR DESCRIPTION
The first scheduled run of the nightly whole-tree lint (run 31862572488) failed 44 seconds in with:

```
ninja: error: unknown target 'dasModuleSQLITE'
```

The build step lists `dasModuleSQLITE`, but `DAS_SQLITE_DISABLED` defaults **ON** (the only default-disabled module in the workflow's target list), and the nightly's configure never flipped it — so the module was never configured and the target didn't exist. The configure log confirms every other listed module registered; only dasSQLITE's "module included" line is absent.

Fix: pass `-DDAS_SQLITE_DISABLED=OFF`, the same flag build.yml's Linux lanes already use.

Validation: a `workflow_dispatch` run of this workflow on this branch (the workflow file is taken from the dispatched ref, so the run exercises the fix end-to-end — build plus both whole-tree lint passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
