### PR TITLE
reap the 10 stale nolints the first whole-tree nightly caught

### DIFF
--- a/modules/dasClipboard/daslib/clipboard.das
+++ b/modules/dasClipboard/daslib/clipboard.das
@@ -101,7 +101,7 @@ def public clipboard_validate_content(content : ClipboardContent const) : Clipbo
 
 def public clipboard_dispose_content(var content : ClipboardContent) {
     delete content.image.rgba8
-    content = ClipboardContent()  // nolint:PERF030 - the only owned field is deleted above; strings are borrowed, so a whole-struct delete would double-free
+    content = ClipboardContent()  // strings are borrowed - a whole-struct delete would double-free
 }
 
 def public clipboard_clone_content(content : ClipboardContent const) : ClipboardContent {

--- a/modules/dasImgui/markdown/imgui_markdown_view.das
+++ b/modules/dasImgui/markdown/imgui_markdown_view.das
@@ -296,7 +296,7 @@ def private clear_node_cache(var entry : MarkdownNodeViewCache) {
     delete entry.content.runs
     delete entry.layout.lines
     delete entry.layout.fragments
-    entry = MarkdownNodeViewCache() // nolint:PERF030 (owned fields deleted above; the move target is already empty)
+    entry = MarkdownNodeViewCache()
 }
 
 def private clear_selection(var state : MarkdownViewState) {
@@ -726,7 +726,7 @@ def public markdown_view_dispose(var state : MarkdownViewState) {
     unsafe { delete state.nodes }
     delete state.image_bindings
     markdown_view_clear_syntax(state)
-    state = MarkdownViewState() // nolint:PERF030 (owned fields deleted above; the move target is already empty)
+    state = MarkdownViewState()
 }
 
 def private retain_image_bindings(var state : MarkdownViewState;

--- a/modules/dasImgui/text/imgui_text_find.das
+++ b/modules/dasImgui/text/imgui_text_find.das
@@ -65,7 +65,7 @@ def public text_find_close(var state : TextFindState) {
 
 def public text_find_dispose(var state : TextFindState) {
     delete state.matches
-    state = TextFindState()   // nolint:PERF030 - the delete above releases the only heap-carrying field
+    state = TextFindState()
 }
 
 def public text_find_current(state : TextFindState const) : TextSourceRange {

--- a/modules/dasImgui/text/imgui_text_source_edit.das
+++ b/modules/dasImgui/text/imgui_text_source_edit.das
@@ -235,7 +235,7 @@ def public text_edit_dispose(var ed : TextEditState) {
     delete ed.list_items
     delete ed.diagnostics
     delete ed.snippet_stops
-    ed = TextEditState() // nolint:PERF030 (owned fields deleted above; the move target is already empty)
+    ed = TextEditState()
 }
 
 def public text_edit_load(var ed : TextEditState; source : string) {

--- a/modules/dasLLAMA/tests/test_model_image_vulkan.das
+++ b/modules/dasLLAMA/tests/test_model_image_vulkan.das
@@ -107,7 +107,7 @@ def test_vulkan_inline_bake(tst : T?) {
             remove(img_p)
             var a = Model()
             with_job_que() {
-                a <- load_model_cached(path, QuantMode.q8)   // nolint:PERF030 'a' is a fresh Model(); the move must sit inside with_job_que
+                a <- load_model_cached(path, QuantMode.q8)   // the move must sit inside with_job_que
             }
             t |> success(a.image_map != null, "the cold cached load serves an image")
             t |> success(stat(img_v).is_valid, "the vulkan flavor was baked")

--- a/modules/dasTerminal/daslib/terminal.das
+++ b/modules/dasTerminal/daslib/terminal.das
@@ -1232,7 +1232,7 @@ def public terminal_snapshot_dispose(var snapshot : TerminalSnapshot) {
     delete snapshot.alternate.cells
     delete snapshot.alternate.scrollback
     delete snapshot.unknown_sequences
-    snapshot = default<TerminalSnapshot>  // nolint:PERF030 - heap fields deleted above; this zeroes the shell
+    snapshot = default<TerminalSnapshot>
 }
 
 def public terminal_drain_replies_bytes(var terminal : Terminal;
@@ -1770,5 +1770,5 @@ def public terminal_viewport_snapshot_dispose(var snapshot : TerminalViewportSna
     delete snapshot.buffer.cells
     delete snapshot.buffer.scrollback
     delete snapshot.text_runs
-    snapshot = default<TerminalViewportSnapshot>  // nolint:PERF030 - heap fields deleted above; this zeroes the shell
+    snapshot = default<TerminalViewportSnapshot>
 }

--- a/tests/language/optimization_auto_inline_functions.das
+++ b/tests/language/optimization_auto_inline_functions.das
@@ -151,7 +151,7 @@ def private big_private_addr(a : int) : int {
     return t
 }
 
-def recur_inc(n : int) : int => n <= 0 ? 0 : recur_inc(n - 1) + 1  // nolint:LINT010
+def recur_inc(n : int) : int => n <= 0 ? 0 : recur_inc(n - 1) + 1
 
 def gadd(a, b : auto) => a + b  // generic: instances stay out of the heuristic tier
 

--- a/tests/language/optional_require.das
+++ b/tests/language/optional_require.das
@@ -11,7 +11,7 @@ require dastest/testing_boost public
 // expressible as a cant_ test).
 require ?math math                                  // nolint:STYLE030 — the guarded-load mechanics ARE the test: guard present (math is a core builtin) -> target loaded
 require ?no_such_guard_xyz no_such_target_also_xyz  // guard absent, target unresolvable -> skipped
-require ?no_such_guard_pkg optional_require_fixture // nolint:STYLE030 — guard absent -> SKIPPED even though the target resolves (strict plain guards); the non-load IS the test
+require ?no_such_guard_pkg optional_require_fixture // guard absent -> SKIPPED even though the target resolves (strict plain guards); the non-load IS the test
 // PATH guard (contains '/'): availability = the guard's OWN file resolves; the rail for
 // pure-das packages (nothing C++ to guard on) and cross-package dependency witnesses — the
 // target may live in an always-present package while depending on an optional one (e.g.


### PR DESCRIPTION
The first whole-tree nightly lint to get past the build step (run 31873134570, on the #3740 branch) came back: fast rule pass clean — 3530 files, 0 issues — and the `-j 1` stale-nolint pass red with exactly 10 LINT019 findings.

All 10 trace to the rule refinements in `74ced3eb5` ("PERF030 sees lowered deletes, STYLE030 knows lifecycle hooks"): the rules got smarter, so suppressions written for their old blind spots now suppress nothing. That commit's own reap missed these 8 files; the nightly caught the tail — exactly what it exists for.

- 8× `PERF030` on the delete-fields-then-reassign shape (dasClipboard, dasImgui markdown/text ×4, dasLLAMA vulkan test, dasTerminal ×2) — the rule now credits the deletes.
- 1× `LINT010` (`tests/language/optimization_auto_inline_functions.das`) and 1× `STYLE030` (`tests/language/optional_require.das`) from the same refinement.

Tags removed; load-bearing prose kept as plain comments (clipboard's borrowed-strings/double-free note, the vulkan test's with_job_que placement, the optional-require test semantics). Pure narration ("owned fields deleted above") deleted outright.

Verified: MCP lint on all 8 touched files — 0 issues, nothing resurfaces at the edited lines. Final arbiter is the nightly itself; I'll re-dispatch it on master after this merges (the queued master run was cancelled — it predated this fix and would only have reproduced the known red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
