### PR TITLE
very_safe_context: per-container scratch opt-out; tuner race buffers reserve before the guard

### DIFF
--- a/daslib/archive.das
+++ b/daslib/archive.das
@@ -55,7 +55,9 @@ class public MemSerializer : Serializer {
     def override write(bytes : void? implicit; size : int) : bool {
         //! Appends bytes at the end of the data.
         let pos = length(data)
-        data |> ensure_capacity(pos + size)
+        // eager grow: no alias into `data` survives a write, and a very_safe_context would
+        // otherwise abandon every doubling generation - roughly one payload of garbage per serialize
+        unsafe(data |> scratch_ensure_capacity(pos + size))
         data |> resize_no_init(pos + size)
         unsafe {
             memcpy(addr(data[pos]), bytes, size)

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -216,6 +216,56 @@ def ensure_capacity(var Arr : array<auto(numT)>; newSize : int64) {
     }
 }
 
+//! `reserve` through the eager path: the old buffer is freed immediately even under
+//! `options very_safe_context` — the caller promises no interior alias survives the grow.
+//! Capacity is exact (reserve never rounds); a one-shot, no state left on the container.
+[unsafe_operation]
+def scratch_reserve(var Arr : array<auto(numT)>; newSize : int) {
+    unsafe(__builtin_array_scratch_reserve(Arr, newSize, typeinfo sizeof(Arr[0])))
+}
+
+//! Int64 form of `scratch_reserve`.
+[unsafe_operation]
+def scratch_reserve(var Arr : array<auto(numT)>; newSize : int64) {
+    unsafe(__builtin_array_scratch_reserve_i64(Arr, newSize, typeinfo sizeof(Arr[0])))
+}
+
+//! `ensure_capacity` through the eager path — same doubling policy, but old buffers are
+//! freed immediately even under `options very_safe_context`.
+[unsafe_operation]
+def scratch_ensure_capacity(var Arr : array<auto(numT)>; newSize : int) {
+    unsafe(scratch_ensure_capacity(Arr, int64(newSize)))
+}
+
+//! Int64 form of `scratch_ensure_capacity`.
+[unsafe_operation]
+def scratch_ensure_capacity(var Arr : array<auto(numT)>; newSize : int64) {
+    if (newSize > long_capacity(Arr)) {
+        var want = long_capacity(Arr) * 2l
+        if (newSize > want) {
+            want = newSize
+        }
+        unsafe(Arr |> scratch_reserve(want))
+    }
+}
+
+//! `resize` through the eager path: reserves the exact final size first (never pow2-rounds),
+//! so a grow frees the old buffer immediately even under `options very_safe_context`;
+//! a shrink never reallocates.
+[unsafe_operation]
+def scratch_resize(var Arr : array<auto(numT)>; newSize : int) {
+    unsafe(Arr |> scratch_resize(int64(newSize)))
+}
+
+//! Int64 form of `scratch_resize`.
+[unsafe_operation]
+def scratch_resize(var Arr : array<auto(numT)>; newSize : int64) {
+    if (newSize > long_capacity(Arr)) {
+        unsafe(Arr |> scratch_reserve(newSize))
+    }
+    Arr |> resize(newSize)
+}
+
 def pop(var Arr : array<auto(numT)>) {
     unsafe(resize(Arr, length(Arr) - 1))// resize will throw if negative
 }

--- a/daslib/debugger.das
+++ b/daslib/debugger.das
@@ -74,7 +74,7 @@ struct DapiArray {
     capacity : uint64
     lock : uint
     magic : uint
-    flags : bitfield<_shared; _hopeless>
+    flags : bitfield<_shared; _hopeless; _forego_lock_check; _tableNoHash; _borrowed; _scratch>
     _pad_after_flags : uint
 }
 

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -181,7 +181,7 @@ def document_module_builtin(_root : string) {
 find_for_edit|find_if_exists|find_index|find_index_if|has_value|key_exists|keys|values|get_key|lock|each_enum|each_ref|
 find_for_edit_if_exists|lock_forever|next|nothing|pop|push|push_from|push_clone|push_clone_from|back|sort|stable_sort|to_array|to_table|to_array_move|
 to_table_move|empty|subarray|insert|move_to_ref|copy_to_local|move_to_local|get|remove_value|erase_if|resize_and_init|
-get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_default|modify|long_length|long_capacity|long_find_index|ensure_capacity)$%%),
+get_value|insert_clone|emplace_new|insert_default|emplace_default|get_with_default|modify|long_length|long_capacity|long_find_index|ensure_capacity|set_scratch|is_scratch|scratch_reserve|scratch_ensure_capacity|scratch_resize)$%%),
         group_by_regex("Character set groups", mod, %regex~(is_alpha|is_number|is_white_space|is_char_in_set)$%%),
         group_by_regex("das::string manipulation", mod, %regex~(peek|set)$%%),
         group_by_regex("String builder", mod, %regex~(build_string|write|write_char|write_chars|write_escape_string)$%%),
@@ -1707,6 +1707,7 @@ def document_module_strudel_scheduler(_root : string) {
     var mod = find_module("strudel_scheduler")
     var groups <- array<DocGroup>(
         group_by_regex("Orbit effects", mod, %regex~(init_reverb|init_delay|get_orbit_reverb|get_orbit_delay|get_orbit_chorus)$%%),
+        group_by_regex("Scratch marking", mod, %regex~(mark_pools_scratch|mark_orbit_scratch)$%%),
         group_by_regex("Orbit levels", mod, %regex~(fade_orbit|set_orbit_gain|orbit_gain|advance_orbit_gains)$%%),
         group_by_regex("Reverb quality override", mod, %regex~(set_force_reverb_quality|set_force_reverb_stages)$%%),
         group_by_regex("Scheduler lifecycle", mod, %regex~(tick|shutdown_scheduler|finalize)$%%)

--- a/doc/source/reference/language/very_safe_context.rst
+++ b/doc/source/reference/language/very_safe_context.rst
@@ -79,6 +79,45 @@ a borrow checker, neither of which is practical for the language's performance g
 
 Some of these issues can also be caught by linting or optional runtime checks.
 
+The protection has a real cost. Every growth episode abandons its old buffers: a container that
+doubles its way to N bytes leaves about N more bytes of garbage behind, and nothing can reuse that
+memory until the next ``heap_collect``. Code that grows containers all the time — a serializer, an
+audio voice pool — pays this on every run.
+
+---------------------------------------------
+Opting out per container: ``scratch``
+---------------------------------------------
+
+A trusted container whose interior is never aliased across a grow does not need the protection.
+Two ``unsafe`` primitives turn it off for exactly that container, leaving the rest of the context
+very safe:
+
+``set_scratch(container, true)`` marks an ``array`` or a ``table`` once. From then on its growth
+frees the old buffer eagerly, exactly as in a normal context. The mark survives table rehash,
+``move``, and ``clear``; ``delete`` resets it. Use it on containers user code can never reach —
+internal pools and queues — set at the place that constructs them. ``is_scratch(container)``
+reads the mark back.
+
+.. code-block:: das
+
+    var pool : array<Voice>
+    unsafe(pool |> set_scratch(true))   // internal pool: nothing aliases its interior
+
+``scratch_reserve`` / ``scratch_ensure_capacity`` / ``scratch_resize`` grow through the eager path
+once, without marking anything. Use them at a trusted growth site when the container itself is
+later handed to user code — the handed-off array carries no special state. ``scratch_reserve``
+reserves the exact size (no power-of-two rounding); ``scratch_ensure_capacity`` doubles like
+``ensure_capacity``; ``scratch_resize`` reserves exactly and then resizes, so a shrink never
+reallocates.
+
+.. code-block:: das
+
+    unsafe(data |> scratch_ensure_capacity(pos + size))   // eager grow of a write buffer
+    data |> resize_no_init(pos + size)                    // within capacity - never grows
+
+Both primitives require ``unsafe`` on purpose: in a sandbox that withholds ``unsafe`` from user
+code, only trusted library and host code can opt a container out.
+
 ---------------------------------
 Iteration and container moves
 ---------------------------------

--- a/doc/source/stdlib/handmade/function-builtin-is_scratch-0x67a1836d59b1fd1.rst
+++ b/doc/source/stdlib/handmade/function-builtin-is_scratch-0x67a1836d59b1fd1.rst
@@ -1,0 +1,1 @@
+Reads the container's scratch mark back. A pure read; safe to call anywhere.

--- a/doc/source/stdlib/handmade/function-builtin-is_scratch-0xef26de114ad5d46.rst
+++ b/doc/source/stdlib/handmade/function-builtin-is_scratch-0xef26de114ad5d46.rst
@@ -1,0 +1,1 @@
+Reads the container's scratch mark back. A pure read; safe to call anywhere.

--- a/doc/source/stdlib/handmade/function-builtin-scratch_ensure_capacity-0x750ad533cb4c9a8e.rst
+++ b/doc/source/stdlib/handmade/function-builtin-scratch_ensure_capacity-0x750ad533cb4c9a8e.rst
@@ -1,0 +1,1 @@
+ensure_capacity through the eager path: same doubling policy, but old buffers are freed immediately even under very_safe_context. Requires unsafe.

--- a/doc/source/stdlib/handmade/function-builtin-scratch_ensure_capacity-0xac8134bbda18520e.rst
+++ b/doc/source/stdlib/handmade/function-builtin-scratch_ensure_capacity-0xac8134bbda18520e.rst
@@ -1,0 +1,1 @@
+ensure_capacity through the eager path: same doubling policy, but old buffers are freed immediately even under very_safe_context. Requires unsafe.

--- a/doc/source/stdlib/handmade/function-builtin-scratch_reserve-0x70b318095901b945.rst
+++ b/doc/source/stdlib/handmade/function-builtin-scratch_reserve-0x70b318095901b945.rst
@@ -1,0 +1,1 @@
+reserve through the eager path: the old buffer is freed immediately even under very_safe_context, and the capacity is exact (reserve never rounds). Requires unsafe.

--- a/doc/source/stdlib/handmade/function-builtin-scratch_reserve-0xbd91390cf79b6b13.rst
+++ b/doc/source/stdlib/handmade/function-builtin-scratch_reserve-0xbd91390cf79b6b13.rst
@@ -1,0 +1,1 @@
+reserve through the eager path: the old buffer is freed immediately even under very_safe_context, and the capacity is exact (reserve never rounds). Requires unsafe.

--- a/doc/source/stdlib/handmade/function-builtin-scratch_resize-0x6fb66b0b25e485ab.rst
+++ b/doc/source/stdlib/handmade/function-builtin-scratch_resize-0x6fb66b0b25e485ab.rst
@@ -1,0 +1,1 @@
+resize through the eager path: reserves the exact final size first, so a grow frees the old buffer immediately even under very_safe_context; a shrink never reallocates. Requires unsafe.

--- a/doc/source/stdlib/handmade/function-builtin-scratch_resize-0xb7a980f16399cdc7.rst
+++ b/doc/source/stdlib/handmade/function-builtin-scratch_resize-0xb7a980f16399cdc7.rst
@@ -1,0 +1,1 @@
+resize through the eager path: reserves the exact final size first, so a grow frees the old buffer immediately even under very_safe_context; a shrink never reallocates. Requires unsafe.

--- a/doc/source/stdlib/handmade/function-builtin-set_scratch-0x8a107cb621e0d654.rst
+++ b/doc/source/stdlib/handmade/function-builtin-set_scratch-0x8a107cb621e0d654.rst
@@ -1,0 +1,1 @@
+Marks the container as scratch: the owner promises no interior alias survives a grow, so growth frees the old buffer eagerly even under very_safe_context. Requires unsafe.

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -169,6 +169,7 @@ namespace das {
                 bool forego_lock_check : 1; // don't need to check if elements are locked
                 bool tableNoHash : 1;       // Table only: key type stores no per-slot hash (non-string) - see tableHashSlotBytes
                 bool borrowed : 1;          // a mark_locked view over foreign storage (fmap/temp_array) — array_forget_locked requires it, so an owned array that merely holds a lock can never be "forgotten" (leaked)
+                bool scratch : 1;           // owner promises no interior alias escapes a grow: growth frees the old buffer eagerly even in a verySafeContext
             };
             uint32_t flags;
         };
@@ -199,6 +200,7 @@ namespace das {
     DAS_API void array_lock(Context &context, Array &arr, LineInfo *at);
     DAS_API void array_unlock(Context &context, Array &arr, LineInfo *at);
     DAS_API void array_reserve(Context &context, Array &arr, uint64_t newCapacity, uint32_t stride, LineInfo *at);
+    DAS_API void array_reserve_scratch(Context &context, Array &arr, uint64_t newCapacity, uint32_t stride, LineInfo *at);  // eager even in a verySafeContext
     DAS_API void array_resize(Context &context, Array &arr, uint64_t newSize, uint32_t stride, bool zero, LineInfo *at);
     DAS_API void array_grow(Context &context, Array &arr, uint64_t newSize, uint32_t stride); // always grows
     DAS_API void array_clear(Context &context, Array &arr, LineInfo *at);

--- a/include/daScript/simulate/aot_builtin.h
+++ b/include/daScript/simulate/aot_builtin.h
@@ -112,6 +112,12 @@ namespace das {
     DAS_API void builtin_array_clear_lock ( const Array & arr, Context * );
     DAS_API void builtin_array_tag ( Array & arr, const char * name, Context * context );
     DAS_API void builtin_table_tag ( Table & tab, const char * name, Context * context );
+    DAS_API void builtin_array_set_scratch ( Array & arr, bool value, Context * );
+    DAS_API bool builtin_array_is_scratch ( const Array & arr );
+    DAS_API void builtin_array_scratch_reserve ( Array & pArray, int newSize, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_array_scratch_reserve_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at );
+    DAS_API void builtin_table_set_scratch ( Table & tab, bool value, Context * );
+    DAS_API bool builtin_table_is_scratch ( const Table & tab );
     DAS_API void builtin_temp_array ( void * data, int size, const Block & block, Context * context, LineInfoArg * lineinfo );
     DAS_API void builtin_make_temp_array ( Array & arr, void * data, int size );
     DAS_API void builtin_make_temp_array_i64 ( Array & arr, void * data, int64_t size );

--- a/include/daScript/simulate/runtime_table.h
+++ b/include/daScript/simulate/runtime_table.h
@@ -563,7 +563,7 @@ namespace das
                     }
                 }
             }
-            if (tab.capacity && !context->verySafeContext) {
+            if (tab.capacity && (!context->verySafeContext || tab.scratch)) {
                 uint64_t oldHashBytes = (PackedPolicy<KeyType>::storesHash && tab.capacity <= TABLE_MAX_LINEAR_CAPACITY) ? uint64_t(PackedPolicy<KeyType>::hashBytes)
                     : (PackedPolicy<KeyType>::storesHash ? uint64_t(sizeof(TableHashKey)) : uint64_t(1));
                 uint64_t oldSize = tab.capacity * (uint64_t(valueTypeSize) + uint64_t(sizeof(KeyType)) + oldHashBytes);

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -833,7 +833,7 @@ namespace das
         bool                            gcEnabled = false;
         bool                            gcLogTime = false;          // log per-phase heap GC timing
         bool                            failed = false;
-        bool                            verySafeContext = false;    // when true, array and table reserves don't free memory
+        bool                            verySafeContext = false;    // when true, array and table reserves don't free memory (unless the container's scratch flag or a scratch_* one-shot opts out)
         uint64_t                        maxUnreservedSize = 64ull<<20;  // mirrors CodeOfPolicies::max_unreserved_size (assigned in setup/simulate; this initializer covers raw contexts)
         bool                            sharedPtrContext = false;   // there is a shared ptr to this context
         bool                            skipInitShutdownScript = false; // this (cloned) context skipped global init, so skip shutdown too

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -297,6 +297,10 @@ def init_playback(var state : MidiPlaybackState; midi : MidiFile const?; name : 
     state.ticks_per_qn = midi.ticks_per_qn
     state.tempo_usec = 500000
     state.ticks_per_sec = double(state.ticks_per_qn) * 1000000.0lf / double(state.tempo_usec)
+    unsafe {   // voice pools are thread-local internals — eager grow under very_safe_context
+        state.voices |> set_scratch(true)
+        state.csf2_voices |> set_scratch(true)
+    }
     for (ch in state.channels) {
         ch = MidiChannelState()
         channel_init_cc(ch)
@@ -845,6 +849,16 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
     var pending_adds : array<MidiTrackCmd>
     let chunkSamples = int(float(CHUNK_SEC) * float(SAMPLE_RATE)) * 2
     var output : array<float>
+    unsafe {   // thread-local internals — eager grow under very_safe_context
+        g_sf2_meta |> set_scratch(true)
+        g_reverb_send_buf |> set_scratch(true)
+        g_reverb_out_buf |> set_scratch(true)
+        g_chorus_send_buf |> set_scratch(true)
+        g_chorus_out_buf |> set_scratch(true)
+        tracks |> set_scratch(true)
+        pending_adds |> set_scratch(true)
+        output |> set_scratch(true)
+    }
     output |> resize(chunkSamples)
     var running = true
     while (running) {

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -285,6 +285,7 @@ def private init_track(var track : StrudelTrack?; startTime : double) {
     track.sched.startTime = startTime
     track.sched.lastQueryEnd = (g_wall_time - startTime) * g_cps
     track.sched.sf2 = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
+    mark_pools_scratch(track.sched)
     if (g_sf2 != null) {
         init_reverb(track.sched)
     }

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -285,7 +285,7 @@ def private init_track(var track : StrudelTrack?; startTime : double) {
     track.sched.startTime = startTime
     track.sched.lastQueryEnd = (g_wall_time - startTime) * g_cps
     track.sched.sf2 = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
-    mark_pools_scratch(track.sched)
+    unsafe(mark_pools_scratch(track.sched))
     if (g_sf2 != null) {
         init_reverb(track.sched)
     }

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -176,9 +176,38 @@ struct Scheduler {
         //! Stereo output scratch (right-channel HRTF result); interleaved L/R per frame.
 }
 
+//! The scheduler's pools and buffers are player-internal - no interior alias survives a
+//! grow - so growth may free the old buffer eagerly even under `options very_safe_context`.
+def mark_pools_scratch(var sched : Scheduler) {
+    unsafe {
+        sched.voices |> set_scratch(true)
+        sched.osc_voices |> set_scratch(true)
+        sched.output |> set_scratch(true)
+        sched.sf2_voices |> set_scratch(true)
+        sched.sf2_meta |> set_scratch(true)
+        sched.orbit_buses |> set_scratch(true)
+        sched.voice_fx_buf |> set_scratch(true)
+        sched.hrtf_mono_buf |> set_scratch(true)
+        sched.hrtf_stereo_buf |> set_scratch(true)
+        sched.hrtf_stereo_buf_r |> set_scratch(true)
+    }
+}
+
 // Convert wall-clock time to cycle position.
 def private current_cycle(sched : Scheduler; wall_time : double) : double {
     return (wall_time - sched.startTime) * sched.cps
+}
+
+//! Same contract as `mark_pools_scratch`, for one orbit bus's send/return buffers.
+def mark_orbit_scratch(var bus : OrbitBus) {
+    unsafe {
+        bus.reverb_send_buf |> set_scratch(true)
+        bus.reverb_out_buf |> set_scratch(true)
+        bus.delay_send_buf |> set_scratch(true)
+        bus.delay_out_buf |> set_scratch(true)
+        bus.chorus_send_buf |> set_scratch(true)
+        bus.chorus_out_buf |> set_scratch(true)
+    }
 }
 
 // Ensure orbit bus exists at given index, creating it if needed.
@@ -187,7 +216,9 @@ def private ensure_orbit(var sched : Scheduler; orbit : int) {
         sched.orbit_buses |> push(null)
     }
     if (sched.orbit_buses[orbit] == null) {
-        sched.orbit_buses[orbit] = new OrbitBus()
+        var bus = new OrbitBus()
+        mark_orbit_scratch(*bus)
+        sched.orbit_buses[orbit] = bus
     }
 }
 

--- a/modules/dasAudio/strudel/strudel_scheduler.das
+++ b/modules/dasAudio/strudel/strudel_scheduler.das
@@ -178,6 +178,7 @@ struct Scheduler {
 
 //! The scheduler's pools and buffers are player-internal - no interior alias survives a
 //! grow - so growth may free the old buffer eagerly even under `options very_safe_context`.
+[unsafe_operation]
 def mark_pools_scratch(var sched : Scheduler) {
     unsafe {
         sched.voices |> set_scratch(true)
@@ -199,6 +200,7 @@ def private current_cycle(sched : Scheduler; wall_time : double) : double {
 }
 
 //! Same contract as `mark_pools_scratch`, for one orbit bus's send/return buffers.
+[unsafe_operation]
 def mark_orbit_scratch(var bus : OrbitBus) {
     unsafe {
         bus.reverb_send_buf |> set_scratch(true)
@@ -217,7 +219,7 @@ def private ensure_orbit(var sched : Scheduler; orbit : int) {
     }
     if (sched.orbit_buses[orbit] == null) {
         var bus = new OrbitBus()
-        mark_orbit_scratch(*bus)
+        unsafe(mark_orbit_scratch(*bus))
         sched.orbit_buses[orbit] = bus
     }
 }

--- a/modules/dasAudio/strudel/strudel_sf2.das
+++ b/modules/dasAudio/strudel/strudel_sf2.das
@@ -565,6 +565,9 @@ def private decode_ogg_block(data : array<uint8>; byte_offset, byte_len : int; v
 def private sf3_decode_samples(data : array<uint8>; smpl_offset, smpl_size : int; var sf2 : SF2File) : bool {
     if (smpl_offset < 0 || smpl_size <= 0) return false
     var pcm : array<int16>
+    // the whole decoded soundfont accumulates here (tens of MB) - eager grow under
+    // very_safe_context; the bit is cleared before the move-out below
+    unsafe(pcm |> set_scratch(true))
     for (s in sf2.samples) {
         let base = length(pcm)
         var frames = 0
@@ -591,6 +594,7 @@ def private sf3_decode_samples(data : array<uint8>; smpl_offset, smpl_size : int
         s.loop_start = uint(base + clamp(loop_lo, 0, frames))
         s.loop_end = uint(base + clamp(loop_hi, 0, frames))
     }
+    unsafe(pcm |> set_scratch(false))   // sample_data is aliased by playing voices - hand off an ordinary array
     sf2.sample_data <- pcm
     return !empty(sf2.sample_data)
 }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -3933,8 +3933,8 @@ def private mtp_verify_logits(t : Model; var s : Session; npos : int64) {
     let dim = c.dim
     let vocab = c.vocab_size
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
-    s.mtp_norm_b |> scratch_resize(npos * dim)
-    s.mtp_logits_b |> scratch_resize(npos * vocab)
+    s.mtp_norm_b |> overwrite_resize(npos * dim)
+    s.mtp_logits_b |> overwrite_resize(npos * vocab)
     rms_batch(s.mtp_norm_b, s.x_b, t, t.rms_final_off, dim, npos)
     copy_floats(s.mtp_norm_b, 0l, s.mtp_h0, 0l, dim)   // = h_pos; a reject re-seeds the draft head from it
     mm_b_f(s, s.mtp_logits_b, t, cls_fmt, t.wcls_off, s.mtp_norm_b, dim, vocab, npos)
@@ -3958,9 +3958,9 @@ def private mtp_prefill_warm(t : Model; var s : Session; tokens : array<int64>; 
     let c = t.config
     let dim = c.dim
     if (npos > 1l) {
-        s.mtp_xb_save |> scratch_resize(npos * dim)
+        s.mtp_xb_save |> overwrite_resize(npos * dim)
         copy_floats(s.x_b, 0l, s.mtp_xb_save, 0l, npos * dim)
-        s.mtp_cat_b |> scratch_resize((npos - 1l) * 2l * dim)
+        s.mtp_cat_b |> overwrite_resize((npos - 1l) * 2l * dim)
         for (p in range64(npos - 1l)) {
             embed_row(t, tokens[p + 1l], unsafe(addr(s.x[0])))
             rms_at(s.xb, t, t.mtp_enorm_off, s.x, dim)
@@ -4617,7 +4617,7 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
 // batched-prefill scratch sizing, shared by token and embedding entries. grow-only no-init:
 // contents are stage output (fully overwritten); `delete` on grow skips the realloc's old-block
 // copy + zero-fill (~5ms saved on a first 512-row prefill).
-def scratch_resize(@scratch var a : array<auto(numT)>; need : int64) {
+def overwrite_resize(@scratch var a : array<auto(numT)>; need : int64) {
     if (long_length(a) < need) {
         delete a
         a |> reserve(need)
@@ -4625,7 +4625,7 @@ def scratch_resize(@scratch var a : array<auto(numT)>; need : int64) {
     a |> resize_no_init(need)
 }
 
-// scratch_resize's zero-init twin, for scratch a consumer may read before writing. Capacity
+// overwrite_resize's zero-init twin, for scratch a consumer may read before writing. Capacity
 // precedes growth (the max_unreserved_size guard) via ensure_capacity, whose doubling keeps the
 // context-scaled att_b amortized — an exact reserve re-allocates on every chunk of a long prefill.
 def zeroed_resize(@scratch var a : array<auto(numT)>; need : int64) {
@@ -4674,16 +4674,16 @@ def forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : int64) {
     let xdim = max(dim, qd)            // xb_b holds the norm output (dim) then the attn output (qd)
     let maxn = max(xdim, hidden)
     // no-init: every array here is stage output, fully overwritten before read — zero-fill was ~5ms waste
-    s.x_b |> scratch_resize(npos * dim)
-    s.xb_b |> scratch_resize(npos * xdim)
-    s.xb2_b |> scratch_resize(npos * dim)
-    s.q_b |> scratch_resize(npos * qd)
-    s.k_b |> scratch_resize(npos * kv_dim)
-    s.v_b |> scratch_resize(npos * kv_dim)
-    s.hb_b |> scratch_resize(npos * hidden)
-    s.hb2_b |> scratch_resize(npos * hidden)
-    s.xqb |> scratch_resize(npos * maxn)
-    s.xsb |> scratch_resize(npos * maxn / 32l)
+    s.x_b |> overwrite_resize(npos * dim)
+    s.xb_b |> overwrite_resize(npos * xdim)
+    s.xb2_b |> overwrite_resize(npos * dim)
+    s.q_b |> overwrite_resize(npos * qd)
+    s.k_b |> overwrite_resize(npos * kv_dim)
+    s.v_b |> overwrite_resize(npos * kv_dim)
+    s.hb_b |> overwrite_resize(npos * hidden)
+    s.hb2_b |> overwrite_resize(npos * hidden)
+    s.xqb |> overwrite_resize(npos * maxn)
+    s.xsb |> overwrite_resize(npos * maxn / 32l)
     if (t.kquant_native) {   // kq batch tile: per-16 sums beside the batch quants
         s.xbsb |> zeroed_resize(npos * maxn / 16l)
     }

--- a/modules/dasLLAMA/harness/tune_kernels.das
+++ b/modules/dasLLAMA/harness/tune_kernels.das
@@ -513,7 +513,7 @@ def bench_dot() : string {
     var inscope w : array<float>
     var inscope x : array<float>
     var inscope o : array<float>
-    w |> resize(DOT_WALK_ROWS * N)   // 128 MB — DRAM-streaming, like a decode GEMV
+    w |> reserve_resize(DOT_WALK_ROWS * N)   // 128 MB — DRAM-streaming, like a decode GEMV
     x |> resize(N)
     o |> resize(DOT_WALK_ROWS)
     for (i in range64(DOT_WALK_ROWS * N)) {
@@ -1719,7 +1719,7 @@ def bench_quantize() : string {
     let npos = DOT_WALK_ROWS / 2l   // 4096 rows × 16 KB = 64 MB read + 17 MB written per walk
     let nb = N / 32l
     var inscope src : array<float>
-    src |> resize(npos * N)
+    src |> reserve_resize(npos * N)
     for (i in range64(npos * N)) {
         src[i] = 2.0f * sin(float(i) * 0.13f)
     }
@@ -2341,7 +2341,7 @@ def main : int { // nolint:STYLE037,STYLE038 — flat one-bench-per-kernel rail;
             }
         }
         if (!mt_ran) {
-            tune_detail("METAL_TWIN: no Metal device — tensor race skipped\n")
+            tune_detail("METAL_TWIN: no Metal device - tensor race skipped\n")
         }
         metal_crowns = join(mt_wins, ",")
         delete mt_wins

--- a/modules/dasLLAMA/performance/last_known_good_sidecar.json
+++ b/modules/dasLLAMA/performance/last_known_good_sidecar.json
@@ -1,14 +1,15 @@
 {
 	"kernels" : {
-		"add_inplace" : "vec8_u4",
+		"add_inplace" : "vec8_u8",
 		"cvt_f32_to_f16" : "u4",
 		"rope_scaled_neox_tab" : "u4",
 		"softmax" : "vec8_u2",
-		"mul_inplace" : "vec8_u4",
+		"q51q8_tile_gen" : "mr4",
+		"mul_inplace" : "vec8_u8",
 		"quantize_q8_0_bs_into_ptr" : "plain",
 		"dot_q8kv" : "vec4_u2",
 		"dot_q8q8" : "vec16",
-		"quantize_q8kv_row" : "plain",
+		"quantize_q8kv_row" : "u2",
 		"axpy_f16" : "vec4_u4",
 		"q40q8_tile_gen" : "mr8",
 		"axpy_tq4kv" : "vec8_u2",
@@ -31,131 +32,47 @@
 		"gemm_f32_uk_4x16" : "u2",
 		"dot_q51e" : "vec16",
 		"dot_f16" : "vec8_u4",
-		"cvt_f16_to_f32" : "vec16",
-		"dot" : "vec8_u8",
+		"cvt_f16_to_f32" : "vec16_u2",
+		"dot" : "vec8_u4",
 		"q51q8_gemv_gen" : "mr8",
 		"dot_q8tq4kv" : "vec16",
-		"scale_inplace" : "vec8_u2",
+		"scale_inplace" : "vec16_u2",
 		"quantize_tq4kv_row" : "plain",
 		"dot_q4" : "vec4_u4",
 		"copy_floats" : "vec8_u2",
 		"rmsnorm" : "vec8"
 	},
 	"provenance" : {
-		"noise_probes" : "start cv 0.77%; mid1 cv 0.33%; mid2 cv 0.49%; end cv 0.99%",
+		"validation" : "ok",
+		"noise_probes" : "start cv 0.24%; mid1 cv 0.52%; mid2 cv 0.33%; end cv 0.40%",
 		"platform" : "darwin",
-		"noise_floor_cv_pct" : "0.99",
-		"engine_sha" : "8a538d795",
+		"noise_floor_cv_pct" : "0.52",
+		"engine_sha" : "494a30d49",
 		"box" : "darwin|arm64|MacBookPro18,2|25F84|Apple M1 Max",
-		"written" : "2026-08-02T06:00:00.901Z",
-		"mode" : "normal",
+		"written" : "2026-08-15T12:25:55.105Z",
+		"mode" : "paranoid",
+		"dasllama_version" : "2",
 		"noise" : "ok",
 		"binary" : "/Users/borisbatkin/Work/daScript/bin/daslang",
-		"arch" : "arm64"
+		"arch" : "arm64",
+		"validation_max_drift_pct" : "0.16"
 	},
 	"race" : {
-		"cvt_q8kv_to_f32" : {
-			"winner" : "vec8_u2",
-			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 523,
-					"best_us" : 522
-				},
-				"vec32" : {
-					"med_us" : 528,
-					"best_us" : 521
-				},
-				"vec32_u4" : {
-					"med_us" : 522,
-					"best_us" : 522
-				},
-				"vec32_u8" : {
-					"med_us" : 522,
-					"best_us" : 522
-				},
-				"vec16_u2" : {
-					"med_us" : 520,
-					"best_us" : 520
-				},
-				"vec16_u4" : {
-					"med_us" : 521,
-					"best_us" : 520
-				},
-				"vec16_u8" : {
-					"med_us" : 523,
-					"best_us" : 523
-				},
-				"vec4" : {
-					"med_us" : 522,
-					"best_us" : 521
-				},
-				"vec8" : {
-					"med_us" : 522,
-					"best_us" : 522
-				},
-				"vec4_u4" : {
-					"med_us" : 521,
-					"best_us" : 521
-				},
-				"vec8_u4" : {
-					"med_us" : 523,
-					"best_us" : 522
-				},
-				"plain" : {
-					"med_us" : 522,
-					"best_us" : 521
-				},
-				"u2" : {
-					"med_us" : 522,
-					"best_us" : 520
-				},
-				"u4" : {
-					"med_us" : 520,
-					"best_us" : 520
-				},
-				"u8" : {
-					"med_us" : 520,
-					"best_us" : 520
-				},
-				"vec4_u2" : {
-					"med_us" : 523,
-					"best_us" : 521
-				},
-				"vec4_u8" : {
-					"med_us" : 522,
-					"best_us" : 521
-				},
-				"vec8_u2" : {
-					"med_us" : 523,
-					"best_us" : 522
-				},
-				"vec8_u8" : {
-					"med_us" : 523,
-					"best_us" : 522
-				},
-				"vec16" : {
-					"med_us" : 522,
-					"best_us" : 521
-				}
-			}
-		},
 		"add_inplace" : {
-			"winner" : "vec8_u4",
+			"winner" : "vec8_u8",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 498,
-					"best_us" : 497
+					"med_us" : 497,
+					"best_us" : 495
 				},
 				"vec32" : {
-					"med_us" : 500,
+					"med_us" : 499,
 					"best_us" : 499
 				},
 				"vec32_u4" : {
-					"med_us" : 492,
+					"med_us" : 493,
 					"best_us" : 492
 				},
 				"vec32_u8" : {
@@ -163,16 +80,16 @@
 					"best_us" : 492
 				},
 				"vec16_u2" : {
-					"med_us" : 509,
-					"best_us" : 506
+					"med_us" : 511,
+					"best_us" : 509
 				},
 				"vec16_u4" : {
 					"med_us" : 513,
 					"best_us" : 513
 				},
 				"vec16_u8" : {
-					"med_us" : 629,
-					"best_us" : 629
+					"med_us" : 594,
+					"best_us" : 594
 				},
 				"vec4" : {
 					"med_us" : 504,
@@ -183,16 +100,16 @@
 					"best_us" : 499
 				},
 				"vec4_u4" : {
-					"med_us" : 502,
-					"best_us" : 501
+					"med_us" : 501,
+					"best_us" : 500
 				},
 				"vec8_u4" : {
 					"med_us" : 495,
-					"best_us" : 494
+					"best_us" : 493
 				},
 				"plain" : {
 					"med_us" : 504,
-					"best_us" : 504
+					"best_us" : 503
 				},
 				"u2" : {
 					"med_us" : 505,
@@ -200,23 +117,23 @@
 				},
 				"u4" : {
 					"med_us" : 504,
-					"best_us" : 504
+					"best_us" : 502
 				},
 				"u8" : {
 					"med_us" : 498,
-					"best_us" : 498
+					"best_us" : 497
 				},
 				"vec4_u2" : {
 					"med_us" : 504,
 					"best_us" : 503
 				},
 				"vec4_u8" : {
-					"med_us" : 501,
-					"best_us" : 500
+					"med_us" : 502,
+					"best_us" : 497
 				},
 				"vec8_u2" : {
-					"med_us" : 499,
-					"best_us" : 497
+					"med_us" : 496,
+					"best_us" : 495
 				},
 				"vec8_u8" : {
 					"med_us" : 492,
@@ -228,104 +145,17 @@
 				}
 			}
 		},
-		"axpy_q8kv" : {
-			"winner" : "u2",
-			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 548,
-					"best_us" : 548
-				},
-				"vec32" : {
-					"med_us" : 570,
-					"best_us" : 569
-				},
-				"vec32_u4" : {
-					"med_us" : 549,
-					"best_us" : 547
-				},
-				"vec32_u8" : {
-					"med_us" : 549,
-					"best_us" : 548
-				},
-				"vec16_u2" : {
-					"med_us" : 547,
-					"best_us" : 546
-				},
-				"vec16_u4" : {
-					"med_us" : 547,
-					"best_us" : 546
-				},
-				"vec16_u8" : {
-					"med_us" : 547,
-					"best_us" : 546
-				},
-				"vec4" : {
-					"med_us" : 570,
-					"best_us" : 569
-				},
-				"vec8" : {
-					"med_us" : 570,
-					"best_us" : 569
-				},
-				"vec4_u4" : {
-					"med_us" : 569.5,
-					"best_us" : 568
-				},
-				"vec8_u4" : {
-					"med_us" : 551,
-					"best_us" : 551
-				},
-				"plain" : {
-					"med_us" : 570.5,
-					"best_us" : 569
-				},
-				"u2" : {
-					"med_us" : 546,
-					"best_us" : 546
-				},
-				"u4" : {
-					"med_us" : 548,
-					"best_us" : 546
-				},
-				"u8" : {
-					"med_us" : 547.5,
-					"best_us" : 546
-				},
-				"vec4_u2" : {
-					"med_us" : 570,
-					"best_us" : 568
-				},
-				"vec4_u8" : {
-					"med_us" : 569,
-					"best_us" : 568
-				},
-				"vec8_u2" : {
-					"med_us" : 640,
-					"best_us" : 640
-				},
-				"vec8_u8" : {
-					"med_us" : 552,
-					"best_us" : 551
-				},
-				"vec16" : {
-					"med_us" : 570,
-					"best_us" : 569
-				}
-			}
-		},
 		"cvt_f32_to_f16" : {
 			"winner" : "u4",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 498,
-					"best_us" : 498
+					"med_us" : 497,
+					"best_us" : 497
 				},
 				"vec32" : {
-					"med_us" : 499.5,
+					"med_us" : 498,
 					"best_us" : 498
 				},
 				"vec32_u4" : {
@@ -333,27 +163,27 @@
 					"best_us" : 490
 				},
 				"vec32_u8" : {
-					"med_us" : 490,
+					"med_us" : 489,
 					"best_us" : 489
 				},
 				"vec16_u2" : {
-					"med_us" : 503,
-					"best_us" : 500
+					"med_us" : 500,
+					"best_us" : 499
 				},
 				"vec16_u4" : {
 					"med_us" : 500,
 					"best_us" : 498
 				},
 				"vec16_u8" : {
-					"med_us" : 491,
+					"med_us" : 490,
 					"best_us" : 490
 				},
 				"vec4" : {
-					"med_us" : 581,
-					"best_us" : 581
+					"med_us" : 579,
+					"best_us" : 579
 				},
 				"vec8" : {
-					"med_us" : 500,
+					"med_us" : 499,
 					"best_us" : 499
 				},
 				"vec4_u4" : {
@@ -361,16 +191,16 @@
 					"best_us" : 578
 				},
 				"vec8_u4" : {
-					"med_us" : 491,
+					"med_us" : 490,
 					"best_us" : 490
 				},
 				"plain" : {
-					"med_us" : 499,
+					"med_us" : 498,
 					"best_us" : 498
 				},
 				"u2" : {
-					"med_us" : 500,
-					"best_us" : 498
+					"med_us" : 497,
+					"best_us" : 496
 				},
 				"u4" : {
 					"med_us" : 490,
@@ -389,15 +219,15 @@
 					"best_us" : 571
 				},
 				"vec8_u2" : {
-					"med_us" : 500,
-					"best_us" : 498
+					"med_us" : 497,
+					"best_us" : 496
 				},
 				"vec8_u8" : {
 					"med_us" : 489,
 					"best_us" : 489
 				},
 				"vec16" : {
-					"med_us" : 500,
+					"med_us" : 499,
 					"best_us" : 499
 				}
 			}
@@ -405,7 +235,7 @@
 		"rope_scaled_neox_tab" : {
 			"winner" : "u4",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.5181857443078166,
 			"rows" : {
 				"vec32_u2" : {
 					"med_us" : 816,
@@ -436,16 +266,16 @@
 					"best_us" : 649
 				},
 				"vec4" : {
-					"med_us" : 696,
-					"best_us" : 696
+					"med_us" : 686,
+					"best_us" : 686
 				},
 				"vec8" : {
-					"med_us" : 626,
+					"med_us" : 625,
 					"best_us" : 625
 				},
 				"vec4_u4" : {
-					"med_us" : 617,
-					"best_us" : 616
+					"med_us" : 616,
+					"best_us" : 606
 				},
 				"vec8_u4" : {
 					"med_us" : 617,
@@ -456,27 +286,27 @@
 					"best_us" : 696
 				},
 				"u2" : {
-					"med_us" : 662,
-					"best_us" : 662
+					"med_us" : 651,
+					"best_us" : 651
 				},
 				"u4" : {
-					"med_us" : 618,
-					"best_us" : 616
+					"med_us" : 617,
+					"best_us" : 605
 				},
 				"u8" : {
-					"med_us" : 743,
-					"best_us" : 743
+					"med_us" : 729,
+					"best_us" : 729
 				},
 				"vec4_u2" : {
-					"med_us" : 662,
-					"best_us" : 662
+					"med_us" : 649,
+					"best_us" : 649
 				},
 				"vec4_u8" : {
 					"med_us" : 743,
 					"best_us" : 743
 				},
 				"vec8_u2" : {
-					"med_us" : 643.5,
+					"med_us" : 641,
 					"best_us" : 641
 				},
 				"vec8_u8" : {
@@ -484,7 +314,7 @@
 					"best_us" : 708
 				},
 				"vec16" : {
-					"med_us" : 616,
+					"med_us" : 615,
 					"best_us" : 615
 				}
 			}
@@ -492,26 +322,26 @@
 		"softmax" : {
 			"winner" : "vec8_u2",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.5181857443078166,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 4504.5,
-					"best_us" : 4498
+					"med_us" : 4506,
+					"best_us" : 4499
 				},
 				"vec32" : {
-					"med_us" : 4506,
-					"best_us" : 4502
+					"med_us" : 4509,
+					"best_us" : 4503
 				},
 				"vec32_u4" : {
-					"med_us" : 4502,
-					"best_us" : 4498
+					"med_us" : 4505,
+					"best_us" : 4497
 				},
 				"vec32_u8" : {
-					"med_us" : 4501.5,
+					"med_us" : 4504,
 					"best_us" : 4496
 				},
 				"vec16_u2" : {
-					"med_us" : 4499,
+					"med_us" : 4502,
 					"best_us" : 4495
 				},
 				"vec16_u4" : {
@@ -519,147 +349,687 @@
 					"best_us" : 4493
 				},
 				"vec16_u8" : {
-					"med_us" : 4540,
-					"best_us" : 4533
+					"med_us" : 4525,
+					"best_us" : 4517
 				},
 				"vec4" : {
 					"med_us" : 4516,
-					"best_us" : 4509
+					"best_us" : 4510
 				},
 				"vec8" : {
-					"med_us" : 4507,
+					"med_us" : 4509,
 					"best_us" : 4502
 				},
 				"vec4_u4" : {
-					"med_us" : 4515,
-					"best_us" : 4508
+					"med_us" : 4520,
+					"best_us" : 4513
 				},
 				"vec8_u4" : {
 					"med_us" : 4505,
-					"best_us" : 4498
+					"best_us" : 4497
 				},
 				"plain" : {
-					"med_us" : 4517,
+					"med_us" : 4516,
 					"best_us" : 4509
 				},
 				"u2" : {
-					"med_us" : 4517,
-					"best_us" : 4512
+					"med_us" : 4519.5,
+					"best_us" : 4511
 				},
 				"u4" : {
-					"med_us" : 4515,
+					"med_us" : 4514,
 					"best_us" : 4507
 				},
 				"u8" : {
-					"med_us" : 4511.5,
-					"best_us" : 4506
+					"med_us" : 4513,
+					"best_us" : 4505
 				},
 				"vec4_u2" : {
-					"med_us" : 4516,
-					"best_us" : 4510
+					"med_us" : 4517,
+					"best_us" : 4511
 				},
 				"vec4_u8" : {
-					"med_us" : 4513,
+					"med_us" : 4515,
 					"best_us" : 4506
 				},
 				"vec8_u2" : {
-					"med_us" : 4505.5,
+					"med_us" : 4506,
 					"best_us" : 4499
 				},
 				"vec8_u8" : {
-					"med_us" : 4501.5,
+					"med_us" : 4504,
 					"best_us" : 4497
 				},
 				"vec16" : {
-					"med_us" : 4504,
-					"best_us" : 4497
+					"med_us" : 4505,
+					"best_us" : 4496
 				}
 			}
 		},
-		"q8q8_tile_gen" : {
-			"winner" : "mr8_budget",
+		"q51q8_tile_gen" : {
+			"winner" : "mr4",
 			"rows" : {
-				"kstep1" : {
-					"tile_us" : 34698,
-					"gemv_us" : 304,
-					"hot_us" : 16.875
+				"mr8" : {
+					"streamed_us" : 814
 				},
-				"kstep2_nrsplit2" : {
-					"tile_us" : 36030,
-					"gemv_us" : 304,
-					"hot_us" : 16.8125
+				"dot_maddubs_width256_mr8" : {
+					"streamed_us" : 6070
 				},
-				"kstep1_nrsplit2" : {
-					"tile_us" : 36750,
-					"gemv_us" : 303,
-					"hot_us" : 16.8125
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"streamed_us" : 6067
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"streamed_us" : 6070
+				},
+				"mr4" : {
+					"streamed_us" : 814
 				},
 				"reference" : {
-					"tile_us" : 50649,
-					"gemv_us" : 303,
-					"hot_us" : 16.875
+					"streamed_us" : 6212
 				},
-				"kstep4_nrsplit2" : {
-					"tile_us" : 35758,
-					"gemv_us" : 303,
-					"hot_us" : 16.8125
+				"mr4_nrsplit2" : {
+					"streamed_us" : 814
 				},
-				"kstep4_nrsplit2_mr8_gkstep2" : {
-					"tile_us" : 31758,
-					"gemv_us" : 303,
-					"hot_us" : 15.1875
+				"dot_vpdpbusd_width256_mr8" : {
+					"streamed_us" : 6068
 				},
-				"kstep1_nrsplit2_mr8" : {
-					"tile_us" : 37949,
-					"gemv_us" : 303,
-					"hot_us" : 15.625
+				"dot_vpdpbusd_width512_mr16" : {
+					"streamed_us" : 6068
 				},
-				"kstep2_nrsplit2_mr8" : {
-					"tile_us" : 32489,
-					"gemv_us" : 303,
-					"hot_us" : 15.625
+				"mr8_nrsplit2" : {
+					"streamed_us" : 814
 				},
-				"kstep4_nrsplit2_mr8" : {
-					"tile_us" : 32490,
-					"gemv_us" : 303,
-					"hot_us" : 15.5625
-				},
-				"kstep2_gkstep2" : {
-					"tile_us" : 34112,
-					"gemv_us" : 303,
-					"hot_us" : 16.0625
-				},
-				"kstep2_gkstep4" : {
-					"tile_us" : 34493,
-					"gemv_us" : 303,
-					"hot_us" : 16.375
-				},
-				"kstep4_nrsplit2_mr8_gkstep4" : {
-					"tile_us" : 32381,
-					"gemv_us" : 303,
-					"hot_us" : 15.375
-				},
-				"mr8_budget" : {
-					"tile_us" : 31069,
-					"gemv_us" : 303,
-					"hot_us" : 15.5625
-				},
-				"kstep2" : {
-					"tile_us" : 34199,
-					"gemv_us" : 303,
-					"hot_us" : 16.5625
-				},
-				"kstep4" : {
-					"tile_us" : 33865,
-					"gemv_us" : 304,
-					"hot_us" : 16.8125
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"streamed_us" : 6069
 				}
 			}
 		},
 		"mul_inplace" : {
-			"winner" : "vec8_u4",
+			"winner" : "vec8_u8",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 496,
+					"best_us" : 491
+				},
+				"vec32" : {
+					"med_us" : 499,
+					"best_us" : 490
+				},
+				"vec32_u4" : {
+					"med_us" : 497.5,
+					"best_us" : 487
+				},
+				"vec32_u8" : {
+					"med_us" : 492,
+					"best_us" : 487
+				},
+				"vec16_u2" : {
+					"med_us" : 505,
+					"best_us" : 495
+				},
+				"vec16_u4" : {
+					"med_us" : 501,
+					"best_us" : 492
+				},
+				"vec16_u8" : {
+					"med_us" : 497,
+					"best_us" : 489
+				},
+				"vec4" : {
+					"med_us" : 504,
+					"best_us" : 500
+				},
+				"vec8" : {
+					"med_us" : 499,
+					"best_us" : 499
+				},
+				"vec4_u4" : {
+					"med_us" : 501,
+					"best_us" : 492
+				},
+				"vec8_u4" : {
+					"med_us" : 497,
+					"best_us" : 484
+				},
+				"plain" : {
+					"med_us" : 504,
+					"best_us" : 498
+				},
+				"u2" : {
+					"med_us" : 505,
+					"best_us" : 495
+				},
+				"u4" : {
+					"med_us" : 503,
+					"best_us" : 495
+				},
+				"u8" : {
+					"med_us" : 497,
+					"best_us" : 491
+				},
+				"vec4_u2" : {
+					"med_us" : 504,
+					"best_us" : 503
+				},
+				"vec4_u8" : {
+					"med_us" : 498,
+					"best_us" : 497
+				},
+				"vec8_u2" : {
+					"med_us" : 496,
+					"best_us" : 489
+				},
+				"vec8_u8" : {
+					"med_us" : 492,
+					"best_us" : 486
+				},
+				"vec16" : {
+					"med_us" : 504,
+					"best_us" : 497
+				}
+			}
+		},
+		"quantize_q8_0_bs_into_ptr" : {
+			"winner" : "plain",
+			"fallback" : "plain",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 3934,
+					"best_us" : 3926
+				},
+				"vec32" : {
+					"med_us" : 3871,
+					"best_us" : 3865
+				},
+				"vec32_u4" : {
+					"med_us" : 3934,
+					"best_us" : 3927
+				},
+				"vec32_u8" : {
+					"med_us" : 3933,
+					"best_us" : 3927
+				},
+				"vec16_u2" : {
+					"med_us" : 3886.5,
+					"best_us" : 3881
+				},
+				"vec16_u4" : {
+					"med_us" : 3887.5,
+					"best_us" : 3880
+				},
+				"vec16_u8" : {
+					"med_us" : 3887,
+					"best_us" : 3880
+				},
+				"vec4" : {
+					"med_us" : 3871,
+					"best_us" : 3865
+				},
+				"vec8" : {
+					"med_us" : 3872,
+					"best_us" : 3865
+				},
+				"vec4_u4" : {
+					"med_us" : 4192,
+					"best_us" : 4192
+				},
+				"vec8_u4" : {
+					"med_us" : 3911,
+					"best_us" : 3904
+				},
+				"plain" : {
+					"med_us" : 3871,
+					"best_us" : 3865
+				},
+				"u2" : {
+					"med_us" : 3887,
+					"best_us" : 3881
+				},
+				"u4" : {
+					"med_us" : 3887,
+					"best_us" : 3880
+				},
+				"u8" : {
+					"med_us" : 3887,
+					"best_us" : 3881
+				},
+				"vec4_u2" : {
+					"med_us" : 4191,
+					"best_us" : 4191
+				},
+				"vec4_u8" : {
+					"med_us" : 4190,
+					"best_us" : 4190
+				},
+				"vec8_u2" : {
+					"med_us" : 3911,
+					"best_us" : 3904
+				},
+				"vec8_u8" : {
+					"med_us" : 3910,
+					"best_us" : 3905
+				},
+				"vec16" : {
+					"med_us" : 3870.5,
+					"best_us" : 3865
+				}
+			}
+		},
+		"dot_q8kv" : {
+			"winner" : "vec4_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 2177,
+					"best_us" : 2177
+				},
+				"vec32" : {
+					"med_us" : 4212,
+					"best_us" : 4212
+				},
+				"vec32_u4" : {
+					"med_us" : 2178,
+					"best_us" : 2178
+				},
+				"vec32_u8" : {
+					"med_us" : 2178,
+					"best_us" : 2178
+				},
+				"vec16_u2" : {
+					"med_us" : 1219,
+					"best_us" : 1219
+				},
+				"vec16_u4" : {
+					"med_us" : 1219,
+					"best_us" : 1219
+				},
+				"vec16_u8" : {
+					"med_us" : 1219,
+					"best_us" : 1219
+				},
+				"vec4" : {
+					"med_us" : 4212,
+					"best_us" : 4212
+				},
+				"vec8" : {
+					"med_us" : 4206,
+					"best_us" : 4206
+				},
+				"vec4_u4" : {
+					"med_us" : 689,
+					"best_us" : 689
+				},
+				"vec8_u4" : {
+					"med_us" : 912.5,
+					"best_us" : 911
+				},
+				"plain" : {
+					"med_us" : 4204,
+					"best_us" : 4204
+				},
+				"u2" : {
+					"med_us" : 2062,
+					"best_us" : 2062
+				},
+				"u4" : {
+					"med_us" : 2062,
+					"best_us" : 2062
+				},
+				"u8" : {
+					"med_us" : 2062,
+					"best_us" : 2062
+				},
+				"vec4_u2" : {
+					"med_us" : 691,
+					"best_us" : 689
+				},
+				"vec4_u8" : {
+					"med_us" : 689,
+					"best_us" : 689
+				},
+				"vec8_u2" : {
+					"med_us" : 912,
+					"best_us" : 911
+				},
+				"vec8_u8" : {
+					"med_us" : 911.5,
+					"best_us" : 911
+				},
+				"vec16" : {
+					"med_us" : 4206,
+					"best_us" : 4206
+				}
+			}
+		},
+		"dot_q8q8" : {
+			"winner" : "vec16",
+			"fallback" : "vec16",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 984,
+					"best_us" : 982
+				},
+				"vec32" : {
+					"med_us" : 963,
+					"best_us" : 961
+				},
+				"vec32_u4" : {
+					"med_us" : 984,
+					"best_us" : 982
+				},
+				"vec32_u8" : {
+					"med_us" : 983,
+					"best_us" : 982
+				},
+				"vec16_u2" : {
+					"med_us" : 986,
+					"best_us" : 982
+				},
+				"vec16_u4" : {
+					"med_us" : 983,
+					"best_us" : 982
+				},
+				"vec16_u8" : {
+					"med_us" : 984,
+					"best_us" : 981
+				},
+				"vec4" : {
+					"med_us" : 963,
+					"best_us" : 962
+				},
+				"vec8" : {
+					"med_us" : 965,
+					"best_us" : 961
+				},
+				"vec4_u4" : {
+					"med_us" : 2703,
+					"best_us" : 2703
+				},
+				"vec8_u4" : {
+					"med_us" : 1303,
+					"best_us" : 1303
+				},
+				"plain" : {
+					"med_us" : 963,
+					"best_us" : 961
+				},
+				"u2" : {
+					"med_us" : 986,
+					"best_us" : 982
+				},
+				"u4" : {
+					"med_us" : 984,
+					"best_us" : 982
+				},
+				"u8" : {
+					"med_us" : 987,
+					"best_us" : 982
+				},
+				"vec4_u2" : {
+					"med_us" : 2703,
+					"best_us" : 2703
+				},
+				"vec4_u8" : {
+					"med_us" : 2702,
+					"best_us" : 2702
+				},
+				"vec8_u2" : {
+					"med_us" : 1304,
+					"best_us" : 1304
+				},
+				"vec8_u8" : {
+					"med_us" : 1303,
+					"best_us" : 1303
+				},
+				"vec16" : {
+					"med_us" : 965,
+					"best_us" : 961
+				}
+			}
+		},
+		"quantize_q8kv_row" : {
+			"winner" : "u2",
+			"fallback" : "plain",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 1827,
+					"best_us" : 1824
+				},
+				"vec32" : {
+					"med_us" : 1810,
+					"best_us" : 1807
+				},
+				"vec32_u4" : {
+					"med_us" : 1827,
+					"best_us" : 1824
+				},
+				"vec32_u8" : {
+					"med_us" : 1827,
+					"best_us" : 1823
+				},
+				"vec16_u2" : {
+					"med_us" : 1800,
+					"best_us" : 1796
+				},
+				"vec16_u4" : {
+					"med_us" : 1800,
+					"best_us" : 1796
+				},
+				"vec16_u8" : {
+					"med_us" : 1799,
+					"best_us" : 1796
+				},
+				"vec4" : {
+					"med_us" : 1811,
+					"best_us" : 1807
+				},
+				"vec8" : {
+					"med_us" : 1811,
+					"best_us" : 1807
+				},
+				"vec4_u4" : {
+					"med_us" : 2305,
+					"best_us" : 2305
+				},
+				"vec8_u4" : {
+					"med_us" : 1885,
+					"best_us" : 1882
+				},
+				"plain" : {
+					"med_us" : 1810,
+					"best_us" : 1807
+				},
+				"u2" : {
+					"med_us" : 1799,
+					"best_us" : 1796
+				},
+				"u4" : {
+					"med_us" : 1800,
+					"best_us" : 1796
+				},
+				"u8" : {
+					"med_us" : 1800,
+					"best_us" : 1796
+				},
+				"vec4_u2" : {
+					"med_us" : 2304,
+					"best_us" : 2304
+				},
+				"vec4_u8" : {
+					"med_us" : 2305,
+					"best_us" : 2305
+				},
+				"vec8_u2" : {
+					"med_us" : 1885,
+					"best_us" : 1882
+				},
+				"vec8_u8" : {
+					"med_us" : 1885,
+					"best_us" : 1882
+				},
+				"vec16" : {
+					"med_us" : 1811,
+					"best_us" : 1807
+				}
+			}
+		},
+		"axpy_f16" : {
+			"winner" : "vec4_u4",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.24357032745949034,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 467,
+					"best_us" : 467
+				},
+				"vec32" : {
+					"med_us" : 471,
+					"best_us" : 471
+				},
+				"vec32_u4" : {
+					"med_us" : 465,
+					"best_us" : 465
+				},
+				"vec32_u8" : {
+					"med_us" : 466,
+					"best_us" : 466
+				},
+				"vec16_u2" : {
+					"med_us" : 466,
+					"best_us" : 466
+				},
+				"vec16_u4" : {
+					"med_us" : 464,
+					"best_us" : 464
+				},
+				"vec16_u8" : {
+					"med_us" : 466,
+					"best_us" : 466
+				},
+				"vec4" : {
+					"med_us" : 465,
+					"best_us" : 457
+				},
+				"vec8" : {
+					"med_us" : 475,
+					"best_us" : 475
+				},
+				"vec4_u4" : {
+					"med_us" : 444,
+					"best_us" : 439
+				},
+				"vec8_u4" : {
+					"med_us" : 470,
+					"best_us" : 470
+				},
+				"plain" : {
+					"med_us" : 473,
+					"best_us" : 473
+				},
+				"u2" : {
+					"med_us" : 471,
+					"best_us" : 471
+				},
+				"u4" : {
+					"med_us" : 469,
+					"best_us" : 469
+				},
+				"u8" : {
+					"med_us" : 470,
+					"best_us" : 470
+				},
+				"vec4_u2" : {
+					"med_us" : 463,
+					"best_us" : 458
+				},
+				"vec4_u8" : {
+					"med_us" : 459,
+					"best_us" : 453
+				},
+				"vec8_u2" : {
+					"med_us" : 472,
+					"best_us" : 472
+				},
+				"vec8_u8" : {
+					"med_us" : 470,
+					"best_us" : 470
+				},
+				"vec16" : {
+					"med_us" : 472,
+					"best_us" : 472
+				}
+			}
+		},
+		"q40q8_tile_gen" : {
+			"winner" : "mr8",
+			"rows" : {
+				"mr8" : {
+					"tile_us" : 39909,
+					"gemv_us" : 222,
+					"hot_us" : 13.6875
+				},
+				"dot_maddubs_width256_mr8" : {
+					"tile_us" : 458944,
+					"gemv_us" : 1806,
+					"hot_us" : 112.6875
+				},
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"tile_us" : 458896,
+					"gemv_us" : 1805,
+					"hot_us" : 112.5625
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"tile_us" : 458881,
+					"gemv_us" : 1802,
+					"hot_us" : 112.5625
+				},
+				"mr4" : {
+					"tile_us" : 45509,
+					"gemv_us" : 237,
+					"hot_us" : 14.75
+				},
+				"reference" : {
+					"tile_us" : 458220,
+					"gemv_us" : 1805,
+					"hot_us" : 112.5625
+				},
+				"mr4_nrsplit2" : {
+					"tile_us" : 50053,
+					"gemv_us" : 237,
+					"hot_us" : 14.75
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 458755,
+					"gemv_us" : 1806,
+					"hot_us" : 112.5625
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 458799,
+					"gemv_us" : 1803,
+					"hot_us" : 112.5625
+				},
+				"mr8_nrsplit2" : {
+					"tile_us" : 45388,
+					"gemv_us" : 220,
+					"hot_us" : 13.6875
+				},
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"tile_us" : 458855,
+					"gemv_us" : 1802,
+					"hot_us" : 112.5625
+				}
+			}
+		},
+		"axpy" : {
+			"winner" : "vec8_u8",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
 					"med_us" : 498,
@@ -671,75 +1041,677 @@
 				},
 				"vec32_u4" : {
 					"med_us" : 496,
-					"best_us" : 495
+					"best_us" : 496
 				},
 				"vec32_u8" : {
 					"med_us" : 492,
 					"best_us" : 492
 				},
 				"vec16_u2" : {
-					"med_us" : 505,
-					"best_us" : 505
+					"med_us" : 504,
+					"best_us" : 504
 				},
 				"vec16_u4" : {
-					"med_us" : 502,
-					"best_us" : 502
+					"med_us" : 504,
+					"best_us" : 503
 				},
 				"vec16_u8" : {
-					"med_us" : 498,
-					"best_us" : 498
+					"med_us" : 500,
+					"best_us" : 500
 				},
 				"vec4" : {
 					"med_us" : 504,
-					"best_us" : 504
+					"best_us" : 503
 				},
 				"vec8" : {
 					"med_us" : 499,
 					"best_us" : 499
 				},
 				"vec4_u4" : {
-					"med_us" : 502,
-					"best_us" : 501
+					"med_us" : 504,
+					"best_us" : 503
 				},
 				"vec8_u4" : {
-					"med_us" : 493,
-					"best_us" : 493
+					"med_us" : 495,
+					"best_us" : 494
 				},
 				"plain" : {
 					"med_us" : 504,
-					"best_us" : 504
+					"best_us" : 503
 				},
 				"u2" : {
-					"med_us" : 505,
-					"best_us" : 504
+					"med_us" : 506,
+					"best_us" : 506
 				},
 				"u4" : {
 					"med_us" : 504,
-					"best_us" : 504
+					"best_us" : 503
 				},
 				"u8" : {
-					"med_us" : 499,
-					"best_us" : 499
+					"med_us" : 497,
+					"best_us" : 497
 				},
 				"vec4_u2" : {
-					"med_us" : 503,
+					"med_us" : 504,
 					"best_us" : 503
 				},
 				"vec4_u8" : {
-					"med_us" : 501,
-					"best_us" : 500
+					"med_us" : 500,
+					"best_us" : 499
 				},
 				"vec8_u2" : {
 					"med_us" : 498,
-					"best_us" : 498
+					"best_us" : 497
 				},
 				"vec8_u8" : {
 					"med_us" : 492,
 					"best_us" : 492
 				},
 				"vec16" : {
-					"med_us" : 504,
-					"best_us" : 504
+					"med_us" : 503,
+					"best_us" : 503
+				}
+			}
+		},
+		"dot_q8q8kv" : {
+			"winner" : "vec16",
+			"fallback" : "vec16",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 238,
+					"best_us" : 233
+				},
+				"vec32" : {
+					"med_us" : 233,
+					"best_us" : 228
+				},
+				"vec32_u4" : {
+					"med_us" : 238,
+					"best_us" : 236
+				},
+				"vec32_u8" : {
+					"med_us" : 238,
+					"best_us" : 238
+				},
+				"vec16_u2" : {
+					"med_us" : 237,
+					"best_us" : 233
+				},
+				"vec16_u4" : {
+					"med_us" : 237,
+					"best_us" : 233
+				},
+				"vec16_u8" : {
+					"med_us" : 237,
+					"best_us" : 233
+				},
+				"vec4" : {
+					"med_us" : 233,
+					"best_us" : 232
+				},
+				"vec8" : {
+					"med_us" : 233,
+					"best_us" : 228
+				},
+				"vec4_u4" : {
+					"med_us" : 666,
+					"best_us" : 666
+				},
+				"vec8_u4" : {
+					"med_us" : 323,
+					"best_us" : 323
+				},
+				"plain" : {
+					"med_us" : 233,
+					"best_us" : 232
+				},
+				"u2" : {
+					"med_us" : 237,
+					"best_us" : 235
+				},
+				"u4" : {
+					"med_us" : 237,
+					"best_us" : 233
+				},
+				"u8" : {
+					"med_us" : 237,
+					"best_us" : 237
+				},
+				"vec4_u2" : {
+					"med_us" : 679,
+					"best_us" : 679
+				},
+				"vec4_u8" : {
+					"med_us" : 666,
+					"best_us" : 666
+				},
+				"vec8_u2" : {
+					"med_us" : 320,
+					"best_us" : 320
+				},
+				"vec8_u8" : {
+					"med_us" : 320,
+					"best_us" : 320
+				},
+				"vec16" : {
+					"med_us" : 233,
+					"best_us" : 228
+				}
+			}
+		},
+		"dot_mx4q8" : {
+			"winner" : "u8",
+			"fallback" : "u2",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 270,
+					"best_us" : 270
+				},
+				"vec32" : {
+					"med_us" : 282,
+					"best_us" : 282
+				},
+				"vec32_u4" : {
+					"med_us" : 247,
+					"best_us" : 246
+				},
+				"vec32_u8" : {
+					"med_us" : 242,
+					"best_us" : 242
+				},
+				"vec16_u2" : {
+					"med_us" : 270,
+					"best_us" : 270
+				},
+				"vec16_u4" : {
+					"med_us" : 247,
+					"best_us" : 246
+				},
+				"vec16_u8" : {
+					"med_us" : 242,
+					"best_us" : 242
+				},
+				"vec4" : {
+					"med_us" : 282,
+					"best_us" : 282
+				},
+				"vec8" : {
+					"med_us" : 282,
+					"best_us" : 282
+				},
+				"vec4_u4" : {
+					"med_us" : 247,
+					"best_us" : 246
+				},
+				"vec8_u4" : {
+					"med_us" : 246,
+					"best_us" : 246
+				},
+				"plain" : {
+					"med_us" : 282,
+					"best_us" : 282
+				},
+				"u2" : {
+					"med_us" : 269,
+					"best_us" : 269
+				},
+				"u4" : {
+					"med_us" : 247,
+					"best_us" : 246
+				},
+				"u8" : {
+					"med_us" : 242,
+					"best_us" : 242
+				},
+				"vec4_u2" : {
+					"med_us" : 270,
+					"best_us" : 270
+				},
+				"vec4_u8" : {
+					"med_us" : 242,
+					"best_us" : 242
+				},
+				"vec8_u2" : {
+					"med_us" : 270,
+					"best_us" : 270
+				},
+				"vec8_u8" : {
+					"med_us" : 242,
+					"best_us" : 242
+				},
+				"vec16" : {
+					"med_us" : 282,
+					"best_us" : 282
+				}
+			}
+		},
+		"dot_q8q8_laneq4x4" : {
+			"winner" : "u4",
+			"fallback" : "u2",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 1029,
+					"best_us" : 1011
+				},
+				"vec32" : {
+					"med_us" : 1035,
+					"best_us" : 1016
+				},
+				"vec32_u4" : {
+					"med_us" : 1017,
+					"best_us" : 998
+				},
+				"vec32_u8" : {
+					"med_us" : 1014,
+					"best_us" : 1000
+				},
+				"vec16_u2" : {
+					"med_us" : 1028,
+					"best_us" : 1013
+				},
+				"vec16_u4" : {
+					"med_us" : 1017,
+					"best_us" : 998
+				},
+				"vec16_u8" : {
+					"med_us" : 1014,
+					"best_us" : 995
+				},
+				"vec4" : {
+					"med_us" : 1035,
+					"best_us" : 1016
+				},
+				"vec8" : {
+					"med_us" : 1035,
+					"best_us" : 1018
+				},
+				"vec4_u4" : {
+					"med_us" : 1017,
+					"best_us" : 998
+				},
+				"vec8_u4" : {
+					"med_us" : 1017,
+					"best_us" : 998
+				},
+				"plain" : {
+					"med_us" : 1035,
+					"best_us" : 1016
+				},
+				"u2" : {
+					"med_us" : 1029,
+					"best_us" : 1010
+				},
+				"u4" : {
+					"med_us" : 1017,
+					"best_us" : 998
+				},
+				"u8" : {
+					"med_us" : 1014,
+					"best_us" : 998
+				},
+				"vec4_u2" : {
+					"med_us" : 1029,
+					"best_us" : 1010
+				},
+				"vec4_u8" : {
+					"med_us" : 1014,
+					"best_us" : 995
+				},
+				"vec8_u2" : {
+					"med_us" : 1028,
+					"best_us" : 1011
+				},
+				"vec8_u8" : {
+					"med_us" : 1014,
+					"best_us" : 995
+				},
+				"vec16" : {
+					"med_us" : 1035,
+					"best_us" : 1018
+				}
+			}
+		},
+		"cvt_q8kv_to_f32" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"vec32" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"vec32_u4" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"vec32_u8" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"vec16_u2" : {
+					"med_us" : 520,
+					"best_us" : 511
+				},
+				"vec16_u4" : {
+					"med_us" : 520,
+					"best_us" : 511
+				},
+				"vec16_u8" : {
+					"med_us" : 520,
+					"best_us" : 510
+				},
+				"vec4" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"vec8" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"vec4_u4" : {
+					"med_us" : 521,
+					"best_us" : 511
+				},
+				"vec8_u4" : {
+					"med_us" : 523,
+					"best_us" : 513
+				},
+				"plain" : {
+					"med_us" : 522,
+					"best_us" : 512
+				},
+				"u2" : {
+					"med_us" : 520,
+					"best_us" : 510
+				},
+				"u4" : {
+					"med_us" : 520,
+					"best_us" : 510
+				},
+				"u8" : {
+					"med_us" : 520,
+					"best_us" : 510
+				},
+				"vec4_u2" : {
+					"med_us" : 521,
+					"best_us" : 511
+				},
+				"vec4_u8" : {
+					"med_us" : 521,
+					"best_us" : 511
+				},
+				"vec8_u2" : {
+					"med_us" : 523,
+					"best_us" : 513
+				},
+				"vec8_u8" : {
+					"med_us" : 523,
+					"best_us" : 513
+				},
+				"vec16" : {
+					"med_us" : 522,
+					"best_us" : 512
+				}
+			}
+		},
+		"axpy_q8kv" : {
+			"winner" : "u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 548,
+					"best_us" : 548
+				},
+				"vec32" : {
+					"med_us" : 569,
+					"best_us" : 569
+				},
+				"vec32_u4" : {
+					"med_us" : 548,
+					"best_us" : 548
+				},
+				"vec32_u8" : {
+					"med_us" : 550,
+					"best_us" : 549
+				},
+				"vec16_u2" : {
+					"med_us" : 546,
+					"best_us" : 546
+				},
+				"vec16_u4" : {
+					"med_us" : 546,
+					"best_us" : 546
+				},
+				"vec16_u8" : {
+					"med_us" : 546,
+					"best_us" : 546
+				},
+				"vec4" : {
+					"med_us" : 569,
+					"best_us" : 569
+				},
+				"vec8" : {
+					"med_us" : 569,
+					"best_us" : 569
+				},
+				"vec4_u4" : {
+					"med_us" : 568,
+					"best_us" : 568
+				},
+				"vec8_u4" : {
+					"med_us" : 551,
+					"best_us" : 551
+				},
+				"plain" : {
+					"med_us" : 569,
+					"best_us" : 569
+				},
+				"u2" : {
+					"med_us" : 546,
+					"best_us" : 546
+				},
+				"u4" : {
+					"med_us" : 546,
+					"best_us" : 546
+				},
+				"u8" : {
+					"med_us" : 547,
+					"best_us" : 546
+				},
+				"vec4_u2" : {
+					"med_us" : 568,
+					"best_us" : 568
+				},
+				"vec4_u8" : {
+					"med_us" : 568,
+					"best_us" : 568
+				},
+				"vec8_u2" : {
+					"med_us" : 640,
+					"best_us" : 640
+				},
+				"vec8_u8" : {
+					"med_us" : 551,
+					"best_us" : 551
+				},
+				"vec16" : {
+					"med_us" : 569,
+					"best_us" : 569
+				}
+			}
+		},
+		"q8q8_tile_gen" : {
+			"winner" : "mr8_budget",
+			"rows" : {
+				"kstep1" : {
+					"tile_us" : 34717,
+					"gemv_us" : 303,
+					"hot_us" : 16.5
+				},
+				"kstep2_nrsplit2" : {
+					"tile_us" : 35855,
+					"gemv_us" : 303,
+					"hot_us" : 16.5
+				},
+				"kstep1_nrsplit2" : {
+					"tile_us" : 36642,
+					"gemv_us" : 303,
+					"hot_us" : 16.5625
+				},
+				"reference" : {
+					"tile_us" : 50472,
+					"gemv_us" : 303,
+					"hot_us" : 17
+				},
+				"kstep4_nrsplit2" : {
+					"tile_us" : 35546,
+					"gemv_us" : 303,
+					"hot_us" : 16.875
+				},
+				"kstep4_nrsplit2_mr8_gkstep2" : {
+					"tile_us" : 32276,
+					"gemv_us" : 303,
+					"hot_us" : 15.25
+				},
+				"kstep1_nrsplit2_mr8" : {
+					"tile_us" : 37658,
+					"gemv_us" : 303,
+					"hot_us" : 15.4375
+				},
+				"kstep2_nrsplit2_mr8" : {
+					"tile_us" : 32080,
+					"gemv_us" : 303,
+					"hot_us" : 15.375
+				},
+				"kstep4_nrsplit2_mr8" : {
+					"tile_us" : 32532,
+					"gemv_us" : 303,
+					"hot_us" : 15.375
+				},
+				"kstep2_gkstep2" : {
+					"tile_us" : 34161,
+					"gemv_us" : 303,
+					"hot_us" : 16.0625
+				},
+				"kstep2_gkstep4" : {
+					"tile_us" : 34515,
+					"gemv_us" : 303,
+					"hot_us" : 16.375
+				},
+				"kstep4_nrsplit2_mr8_gkstep4" : {
+					"tile_us" : 32055,
+					"gemv_us" : 303,
+					"hot_us" : 15.5625
+				},
+				"mr8_budget" : {
+					"tile_us" : 31131,
+					"gemv_us" : 302,
+					"hot_us" : 15.6875
+				},
+				"kstep2" : {
+					"tile_us" : 34350,
+					"gemv_us" : 303,
+					"hot_us" : 16.5625
+				},
+				"kstep4" : {
+					"tile_us" : 33979,
+					"gemv_us" : 303,
+					"hot_us" : 16.5625
+				}
+			}
+		},
+		"quantize_q8_0_into_ptr" : {
+			"winner" : "plain",
+			"fallback" : "plain",
+			"floor_pct" : 0.5181857443078166,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 3729,
+					"best_us" : 3722
+				},
+				"vec32" : {
+					"med_us" : 3705,
+					"best_us" : 3698
+				},
+				"vec32_u4" : {
+					"med_us" : 3730,
+					"best_us" : 3723
+				},
+				"vec32_u8" : {
+					"med_us" : 3730,
+					"best_us" : 3723
+				},
+				"vec16_u2" : {
+					"med_us" : 3706,
+					"best_us" : 3698
+				},
+				"vec16_u4" : {
+					"med_us" : 3705,
+					"best_us" : 3698
+				},
+				"vec16_u8" : {
+					"med_us" : 3706,
+					"best_us" : 3698
+				},
+				"vec4" : {
+					"med_us" : 3706,
+					"best_us" : 3698
+				},
+				"vec8" : {
+					"med_us" : 3706,
+					"best_us" : 3698
+				},
+				"vec4_u4" : {
+					"med_us" : 4705,
+					"best_us" : 4705
+				},
+				"vec8_u4" : {
+					"med_us" : 3923,
+					"best_us" : 3923
+				},
+				"plain" : {
+					"med_us" : 3704,
+					"best_us" : 3698
+				},
+				"u2" : {
+					"med_us" : 3707,
+					"best_us" : 3697
+				},
+				"u4" : {
+					"med_us" : 3705,
+					"best_us" : 3697
+				},
+				"u8" : {
+					"med_us" : 3705,
+					"best_us" : 3698
+				},
+				"vec4_u2" : {
+					"med_us" : 4706,
+					"best_us" : 4706
+				},
+				"vec4_u8" : {
+					"med_us" : 4704,
+					"best_us" : 4704
+				},
+				"vec8_u2" : {
+					"med_us" : 3923,
+					"best_us" : 3923
+				},
+				"vec8_u8" : {
+					"med_us" : 3923,
+					"best_us" : 3923
+				},
+				"vec16" : {
+					"med_us" : 3706,
+					"best_us" : 3698
 				}
 			}
 		},
@@ -747,59 +1719,59 @@
 			"winner" : "mr8",
 			"rows" : {
 				"mr8" : {
-					"tile_us" : 38851,
-					"gemv_us" : 243,
-					"hot_us" : 15.125
+					"tile_us" : 38354,
+					"gemv_us" : 242,
+					"hot_us" : 14.9375
 				},
 				"dot_maddubs_width256_mr8" : {
-					"tile_us" : 748410,
-					"gemv_us" : 2940,
-					"hot_us" : 183.5
+					"tile_us" : 748448,
+					"gemv_us" : 2936,
+					"hot_us" : 183.3125
 				},
 				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
-					"tile_us" : 748385,
-					"gemv_us" : 2940,
+					"tile_us" : 748395,
+					"gemv_us" : 2937,
 					"hot_us" : 183.4375
 				},
 				"dot_maddubs_width256_mr8_nrsplit2" : {
-					"tile_us" : 748340,
-					"gemv_us" : 2942,
+					"tile_us" : 748246,
+					"gemv_us" : 2939,
 					"hot_us" : 183.3125
 				},
 				"mr4" : {
-					"tile_us" : 42609,
+					"tile_us" : 42530,
 					"gemv_us" : 254,
 					"hot_us" : 15.8125
 				},
 				"reference" : {
-					"tile_us" : 748430,
-					"gemv_us" : 2937,
-					"hot_us" : 183.375
-				},
-				"mr4_nrsplit2" : {
-					"tile_us" : 50821,
-					"gemv_us" : 258,
-					"hot_us" : 16.125
-				},
-				"dot_vpdpbusd_width256_mr8" : {
-					"tile_us" : 748116,
-					"gemv_us" : 2944,
+					"tile_us" : 748596,
+					"gemv_us" : 2940,
 					"hot_us" : 183.3125
 				},
-				"dot_vpdpbusd_width512_mr16" : {
-					"tile_us" : 748349,
+				"mr4_nrsplit2" : {
+					"tile_us" : 50154,
+					"gemv_us" : 256,
+					"hot_us" : 15.8125
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 748176,
 					"gemv_us" : 2938,
-					"hot_us" : 183.5
+					"hot_us" : 183.4375
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 748418,
+					"gemv_us" : 2938,
+					"hot_us" : 183.3125
 				},
 				"mr8_nrsplit2" : {
-					"tile_us" : 45483,
-					"gemv_us" : 242,
-					"hot_us" : 15
+					"tile_us" : 45393,
+					"gemv_us" : 240,
+					"hot_us" : 14.9375
 				},
 				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
-					"tile_us" : 748336,
-					"gemv_us" : 2940,
-					"hot_us" : 183.5
+					"tile_us" : 748416,
+					"gemv_us" : 2937,
+					"hot_us" : 183.4375
 				}
 			}
 		},
@@ -807,59 +1779,59 @@
 			"winner" : "mr8",
 			"rows" : {
 				"mr8" : {
-					"tile_us" : 38675,
-					"gemv_us" : 593,
-					"hot_us" : 37.5625
+					"tile_us" : 38654,
+					"gemv_us" : 592,
+					"hot_us" : 36.8125
 				},
 				"dot_maddubs_width256_mr8" : {
-					"tile_us" : 363428,
-					"gemv_us" : 3752,
-					"hot_us" : 229.6875
+					"tile_us" : 359153,
+					"gemv_us" : 3659,
+					"hot_us" : 228.3125
 				},
 				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
-					"tile_us" : 363831,
-					"gemv_us" : 3730,
-					"hot_us" : 231.25
+					"tile_us" : 359288,
+					"gemv_us" : 3661,
+					"hot_us" : 228.125
 				},
 				"dot_maddubs_width256_mr8_nrsplit2" : {
-					"tile_us" : 363144,
-					"gemv_us" : 3719,
-					"hot_us" : 229.1875
+					"tile_us" : 359162,
+					"gemv_us" : 3660,
+					"hot_us" : 228.125
 				},
 				"mr4" : {
-					"tile_us" : 40456,
-					"gemv_us" : 586,
-					"hot_us" : 36.6875
+					"tile_us" : 39898,
+					"gemv_us" : 585,
+					"hot_us" : 36.4375
 				},
 				"reference" : {
-					"tile_us" : 364121,
-					"gemv_us" : 3710,
-					"hot_us" : 228.4375
+					"tile_us" : 358657,
+					"gemv_us" : 3661,
+					"hot_us" : 228.3125
 				},
 				"mr4_nrsplit2" : {
-					"tile_us" : 44451,
-					"gemv_us" : 593,
-					"hot_us" : 37.1875
+					"tile_us" : 44155,
+					"gemv_us" : 583,
+					"hot_us" : 36.4375
 				},
 				"dot_vpdpbusd_width256_mr8" : {
-					"tile_us" : 364713,
-					"gemv_us" : 3657,
+					"tile_us" : 359117,
+					"gemv_us" : 3656,
 					"hot_us" : 228.375
 				},
 				"dot_vpdpbusd_width512_mr16" : {
-					"tile_us" : 364447,
-					"gemv_us" : 3676,
-					"hot_us" : 228.625
+					"tile_us" : 359268,
+					"gemv_us" : 3661,
+					"hot_us" : 228.1875
 				},
 				"mr8_nrsplit2" : {
-					"tile_us" : 39310,
-					"gemv_us" : 594,
+					"tile_us" : 40527,
+					"gemv_us" : 591,
 					"hot_us" : 36.875
 				},
 				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
-					"tile_us" : 363257,
-					"gemv_us" : 3675,
-					"hot_us" : 228.25
+					"tile_us" : 359387,
+					"gemv_us" : 3661,
+					"hot_us" : 228.1875
 				}
 			}
 		},
@@ -867,588 +1839,153 @@
 			"winner" : "mr4",
 			"rows" : {
 				"mr8" : {
-					"tile_us" : 58704,
-					"gemv_us" : 520,
-					"hot_us" : 32.125
+					"tile_us" : 58496,
+					"gemv_us" : 510,
+					"hot_us" : 31.5
 				},
 				"dot_maddubs_width256_mr8" : {
-					"tile_us" : 571724,
-					"gemv_us" : 13746,
-					"hot_us" : 858.8125
+					"tile_us" : 571924,
+					"gemv_us" : 13744,
+					"hot_us" : 858.625
 				},
 				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
-					"tile_us" : 571443,
-					"gemv_us" : 13739,
-					"hot_us" : 858.4375
+					"tile_us" : 572233,
+					"gemv_us" : 13740,
+					"hot_us" : 858.25
 				},
 				"dot_maddubs_width256_mr8_nrsplit2" : {
-					"tile_us" : 571412,
+					"tile_us" : 572213,
 					"gemv_us" : 13735,
-					"hot_us" : 858.9375
+					"hot_us" : 858.25
 				},
 				"mr4" : {
-					"tile_us" : 52814,
-					"gemv_us" : 494,
-					"hot_us" : 30.6875
+					"tile_us" : 51998,
+					"gemv_us" : 486,
+					"hot_us" : 30.125
 				},
 				"reference" : {
-					"tile_us" : 571830,
+					"tile_us" : 572097,
+					"gemv_us" : 13739,
+					"hot_us" : 858.375
+				},
+				"mr4_nrsplit2" : {
+					"tile_us" : 58568,
+					"gemv_us" : 488,
+					"hot_us" : 30.125
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 571962,
+					"gemv_us" : 13740,
+					"hot_us" : 858.6875
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 572204,
 					"gemv_us" : 13738,
 					"hot_us" : 858.5625
 				},
-				"mr4_nrsplit2" : {
-					"tile_us" : 59387,
-					"gemv_us" : 486,
-					"hot_us" : 30.375
-				},
-				"dot_vpdpbusd_width256_mr8" : {
-					"tile_us" : 571461,
-					"gemv_us" : 13742,
-					"hot_us" : 858.5
-				},
-				"dot_vpdpbusd_width512_mr16" : {
-					"tile_us" : 571481,
-					"gemv_us" : 13748,
-					"hot_us" : 858.625
-				},
 				"mr8_nrsplit2" : {
-					"tile_us" : 62037,
-					"gemv_us" : 516,
-					"hot_us" : 32.125
+					"tile_us" : 61901,
+					"gemv_us" : 508,
+					"hot_us" : 31.5
 				},
 				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
-					"tile_us" : 571685,
-					"gemv_us" : 13740,
-					"hot_us" : 858.875
-				}
-			}
-		},
-		"quantize_q8_0_into_ptr" : {
-			"winner" : "plain",
-			"fallback" : "plain",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 1793,
-					"best_us" : 1790
-				},
-				"vec32" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec32_u4" : {
-					"med_us" : 1793,
-					"best_us" : 1790
-				},
-				"vec32_u8" : {
-					"med_us" : 1793,
-					"best_us" : 1790
-				},
-				"vec16_u2" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec16_u4" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec16_u8" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec4" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec8" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec4_u4" : {
-					"med_us" : 2273,
-					"best_us" : 2273
-				},
-				"vec8_u4" : {
-					"med_us" : 1891,
-					"best_us" : 1891
-				},
-				"plain" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"u2" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"u4" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"u8" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				},
-				"vec4_u2" : {
-					"med_us" : 2273,
-					"best_us" : 2273
-				},
-				"vec4_u8" : {
-					"med_us" : 2273,
-					"best_us" : 2273
-				},
-				"vec8_u2" : {
-					"med_us" : 1891,
-					"best_us" : 1891
-				},
-				"vec8_u8" : {
-					"med_us" : 1891,
-					"best_us" : 1891
-				},
-				"vec16" : {
-					"med_us" : 1780,
-					"best_us" : 1777
-				}
-			}
-		},
-		"dot_q8kv" : {
-			"winner" : "vec4_u2",
-			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 2180,
-					"best_us" : 2180
-				},
-				"vec32" : {
-					"med_us" : 4210,
-					"best_us" : 4210
-				},
-				"vec32_u4" : {
-					"med_us" : 2178,
-					"best_us" : 2178
-				},
-				"vec32_u8" : {
-					"med_us" : 2180,
-					"best_us" : 2180
-				},
-				"vec16_u2" : {
-					"med_us" : 1220,
-					"best_us" : 1220
-				},
-				"vec16_u4" : {
-					"med_us" : 1220,
-					"best_us" : 1220
-				},
-				"vec16_u8" : {
-					"med_us" : 1220,
-					"best_us" : 1220
-				},
-				"vec4" : {
-					"med_us" : 4210,
-					"best_us" : 4210
-				},
-				"vec8" : {
-					"med_us" : 4212,
-					"best_us" : 4212
-				},
-				"vec4_u4" : {
-					"med_us" : 702,
-					"best_us" : 689
-				},
-				"vec8_u4" : {
-					"med_us" : 931,
-					"best_us" : 911
-				},
-				"plain" : {
-					"med_us" : 4209,
-					"best_us" : 4209
-				},
-				"u2" : {
-					"med_us" : 2062,
-					"best_us" : 2062
-				},
-				"u4" : {
-					"med_us" : 2063,
-					"best_us" : 2063
-				},
-				"u8" : {
-					"med_us" : 2062,
-					"best_us" : 2062
-				},
-				"vec4_u2" : {
-					"med_us" : 703,
-					"best_us" : 689
-				},
-				"vec4_u8" : {
-					"med_us" : 705,
-					"best_us" : 689
-				},
-				"vec8_u2" : {
-					"med_us" : 929.5,
-					"best_us" : 911
-				},
-				"vec8_u8" : {
-					"med_us" : 930,
-					"best_us" : 911
-				},
-				"vec16" : {
-					"med_us" : 4208,
-					"best_us" : 4208
-				}
-			}
-		},
-		"quantize_q8_0_bs_into_ptr" : {
-			"winner" : "plain",
-			"fallback" : "plain",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 3940,
-					"best_us" : 3934
-				},
-				"vec32" : {
-					"med_us" : 3870.5,
-					"best_us" : 3865
-				},
-				"vec32_u4" : {
-					"med_us" : 3940.5,
-					"best_us" : 3934
-				},
-				"vec32_u8" : {
-					"med_us" : 3939,
-					"best_us" : 3935
-				},
-				"vec16_u2" : {
-					"med_us" : 3890,
-					"best_us" : 3884
-				},
-				"vec16_u4" : {
-					"med_us" : 3889,
-					"best_us" : 3884
-				},
-				"vec16_u8" : {
-					"med_us" : 3889,
-					"best_us" : 3883
-				},
-				"vec4" : {
-					"med_us" : 3870,
-					"best_us" : 3865
-				},
-				"vec8" : {
-					"med_us" : 3870,
-					"best_us" : 3865
-				},
-				"vec4_u4" : {
-					"med_us" : 4197,
-					"best_us" : 4197
-				},
-				"vec8_u4" : {
-					"med_us" : 3908.5,
-					"best_us" : 3904
-				},
-				"plain" : {
-					"med_us" : 3871,
-					"best_us" : 3865
-				},
-				"u2" : {
-					"med_us" : 3889.5,
-					"best_us" : 3884
-				},
-				"u4" : {
-					"med_us" : 3889,
-					"best_us" : 3884
-				},
-				"u8" : {
-					"med_us" : 3889,
-					"best_us" : 3884
-				},
-				"vec4_u2" : {
-					"med_us" : 4196,
-					"best_us" : 4196
-				},
-				"vec4_u8" : {
-					"med_us" : 4198,
-					"best_us" : 4198
-				},
-				"vec8_u2" : {
-					"med_us" : 3909,
-					"best_us" : 3904
-				},
-				"vec8_u8" : {
-					"med_us" : 3909,
-					"best_us" : 3904
-				},
-				"vec16" : {
-					"med_us" : 3870,
-					"best_us" : 3865
-				}
-			}
-		},
-		"dot_q8q8" : {
-			"winner" : "vec16",
-			"fallback" : "vec16",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 235,
-					"best_us" : 235
-				},
-				"vec32" : {
-					"med_us" : 229,
-					"best_us" : 229
-				},
-				"vec32_u4" : {
-					"med_us" : 235,
-					"best_us" : 235
-				},
-				"vec32_u8" : {
-					"med_us" : 235,
-					"best_us" : 235
-				},
-				"vec16_u2" : {
-					"med_us" : 234,
-					"best_us" : 234
-				},
-				"vec16_u4" : {
-					"med_us" : 234,
-					"best_us" : 234
-				},
-				"vec16_u8" : {
-					"med_us" : 234,
-					"best_us" : 234
-				},
-				"vec4" : {
-					"med_us" : 229,
-					"best_us" : 229
-				},
-				"vec8" : {
-					"med_us" : 229,
-					"best_us" : 229
-				},
-				"vec4_u4" : {
-					"med_us" : 658,
-					"best_us" : 658
-				},
-				"vec8_u4" : {
-					"med_us" : 317,
-					"best_us" : 317
-				},
-				"plain" : {
-					"med_us" : 229,
-					"best_us" : 229
-				},
-				"u2" : {
-					"med_us" : 234,
-					"best_us" : 234
-				},
-				"u4" : {
-					"med_us" : 234,
-					"best_us" : 234
-				},
-				"u8" : {
-					"med_us" : 234,
-					"best_us" : 234
-				},
-				"vec4_u2" : {
-					"med_us" : 658,
-					"best_us" : 658
-				},
-				"vec4_u8" : {
-					"med_us" : 658,
-					"best_us" : 658
-				},
-				"vec8_u2" : {
-					"med_us" : 317,
-					"best_us" : 317
-				},
-				"vec8_u8" : {
-					"med_us" : 317,
-					"best_us" : 317
-				},
-				"vec16" : {
-					"med_us" : 229,
-					"best_us" : 229
+					"tile_us" : 571775,
+					"gemv_us" : 13737,
+					"hot_us" : 858.375
 				}
 			}
 		},
 		"gemm_f32_uk_4x16" : {
 			"winner" : "u2",
 			"fallback" : "u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.5181857443078166,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 670,
-					"best_us" : 667
+					"med_us" : 669,
+					"best_us" : 656
 				},
 				"vec32" : {
 					"med_us" : 825,
 					"best_us" : 825
 				},
 				"vec32_u4" : {
-					"med_us" : 707,
-					"best_us" : 707
+					"med_us" : 705,
+					"best_us" : 705
 				},
 				"vec32_u8" : {
-					"med_us" : 698.5,
+					"med_us" : 696,
 					"best_us" : 696
 				},
 				"vec16_u2" : {
-					"med_us" : 667,
-					"best_us" : 667
+					"med_us" : 669,
+					"best_us" : 656
 				},
 				"vec16_u4" : {
-					"med_us" : 707,
-					"best_us" : 707
+					"med_us" : 706,
+					"best_us" : 706
 				},
 				"vec16_u8" : {
-					"med_us" : 697,
+					"med_us" : 696,
 					"best_us" : 696
 				},
 				"vec4" : {
-					"med_us" : 824,
-					"best_us" : 824
+					"med_us" : 825,
+					"best_us" : 825
 				},
 				"vec8" : {
 					"med_us" : 825,
 					"best_us" : 825
 				},
 				"vec4_u4" : {
-					"med_us" : 706,
-					"best_us" : 706
+					"med_us" : 705,
+					"best_us" : 705
 				},
 				"vec8_u4" : {
-					"med_us" : 707,
-					"best_us" : 707
+					"med_us" : 706,
+					"best_us" : 706
 				},
 				"plain" : {
 					"med_us" : 825,
 					"best_us" : 825
 				},
 				"u2" : {
-					"med_us" : 667,
-					"best_us" : 667
+					"med_us" : 669,
+					"best_us" : 656
 				},
 				"u4" : {
-					"med_us" : 708,
-					"best_us" : 708
+					"med_us" : 707,
+					"best_us" : 707
 				},
 				"u8" : {
-					"med_us" : 697,
-					"best_us" : 696
+					"med_us" : 696,
+					"best_us" : 683
 				},
 				"vec4_u2" : {
-					"med_us" : 667,
-					"best_us" : 667
+					"med_us" : 668,
+					"best_us" : 655
 				},
 				"vec4_u8" : {
-					"med_us" : 697,
+					"med_us" : 696,
 					"best_us" : 696
 				},
 				"vec8_u2" : {
 					"med_us" : 669,
-					"best_us" : 667
+					"best_us" : 656
 				},
 				"vec8_u8" : {
-					"med_us" : 697,
+					"med_us" : 696,
 					"best_us" : 696
 				},
 				"vec16" : {
 					"med_us" : 825,
 					"best_us" : 825
-				}
-			}
-		},
-		"quantize_q8kv_row" : {
-			"winner" : "plain",
-			"fallback" : "plain",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 1827,
-					"best_us" : 1824
-				},
-				"vec32" : {
-					"med_us" : 1811,
-					"best_us" : 1808
-				},
-				"vec32_u4" : {
-					"med_us" : 1827,
-					"best_us" : 1824
-				},
-				"vec32_u8" : {
-					"med_us" : 1827,
-					"best_us" : 1824
-				},
-				"vec16_u2" : {
-					"med_us" : 1800,
-					"best_us" : 1797
-				},
-				"vec16_u4" : {
-					"med_us" : 1800,
-					"best_us" : 1797
-				},
-				"vec16_u8" : {
-					"med_us" : 1800,
-					"best_us" : 1797
-				},
-				"vec4" : {
-					"med_us" : 1811,
-					"best_us" : 1808
-				},
-				"vec8" : {
-					"med_us" : 1811,
-					"best_us" : 1808
-				},
-				"vec4_u4" : {
-					"med_us" : 2305,
-					"best_us" : 2305
-				},
-				"vec8_u4" : {
-					"med_us" : 1885,
-					"best_us" : 1882
-				},
-				"plain" : {
-					"med_us" : 1811,
-					"best_us" : 1808
-				},
-				"u2" : {
-					"med_us" : 1800,
-					"best_us" : 1797
-				},
-				"u4" : {
-					"med_us" : 1800,
-					"best_us" : 1797
-				},
-				"u8" : {
-					"med_us" : 1800,
-					"best_us" : 1797
-				},
-				"vec4_u2" : {
-					"med_us" : 2305,
-					"best_us" : 2305
-				},
-				"vec4_u8" : {
-					"med_us" : 2308,
-					"best_us" : 2308
-				},
-				"vec8_u2" : {
-					"med_us" : 1885,
-					"best_us" : 1882
-				},
-				"vec8_u8" : {
-					"med_us" : 1885,
-					"best_us" : 1882
-				},
-				"vec16" : {
-					"med_us" : 1811,
-					"best_us" : 1808
 				}
 			}
 		},
 		"dot_f16" : {
 			"winner" : "vec8_u4",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
 					"med_us" : 372,
@@ -1472,43 +2009,43 @@
 				},
 				"vec16_u4" : {
 					"med_us" : 349,
-					"best_us" : 342
+					"best_us" : 343
 				},
 				"vec16_u8" : {
 					"med_us" : 348,
 					"best_us" : 348
 				},
 				"vec4" : {
-					"med_us" : 609,
-					"best_us" : 609
+					"med_us" : 610,
+					"best_us" : 610
 				},
 				"vec8" : {
-					"med_us" : 344,
-					"best_us" : 337
+					"med_us" : 343,
+					"best_us" : 336
 				},
 				"vec4_u4" : {
-					"med_us" : 608,
-					"best_us" : 608
+					"med_us" : 610,
+					"best_us" : 610
 				},
 				"vec8_u4" : {
 					"med_us" : 335,
 					"best_us" : 329
 				},
 				"plain" : {
-					"med_us" : 7386,
-					"best_us" : 7386
+					"med_us" : 7374,
+					"best_us" : 7374
 				},
 				"u2" : {
-					"med_us" : 7383,
-					"best_us" : 7383
+					"med_us" : 7374,
+					"best_us" : 7374
 				},
 				"u4" : {
-					"med_us" : 7382,
-					"best_us" : 7382
+					"med_us" : 7374,
+					"best_us" : 7374
 				},
 				"u8" : {
-					"med_us" : 7385,
-					"best_us" : 7385
+					"med_us" : 7375,
+					"best_us" : 7375
 				},
 				"vec4_u2" : {
 					"med_us" : 609,
@@ -1519,7 +2056,7 @@
 					"best_us" : 606
 				},
 				"vec8_u2" : {
-					"med_us" : 347.5,
+					"med_us" : 347,
 					"best_us" : 341
 				},
 				"vec8_u8" : {
@@ -1532,411 +2069,177 @@
 				}
 			}
 		},
-		"axpy_f16" : {
-			"winner" : "vec4_u4",
-			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 465,
-					"best_us" : 465
-				},
-				"vec32" : {
-					"med_us" : 471,
-					"best_us" : 471
-				},
-				"vec32_u4" : {
-					"med_us" : 466,
-					"best_us" : 466
-				},
-				"vec32_u8" : {
-					"med_us" : 464,
-					"best_us" : 464
-				},
-				"vec16_u2" : {
-					"med_us" : 462,
-					"best_us" : 462
-				},
-				"vec16_u4" : {
-					"med_us" : 462,
-					"best_us" : 460
-				},
-				"vec16_u8" : {
-					"med_us" : 463,
-					"best_us" : 463
-				},
-				"vec4" : {
-					"med_us" : 458,
-					"best_us" : 457
-				},
-				"vec8" : {
-					"med_us" : 471,
-					"best_us" : 471
-				},
-				"vec4_u4" : {
-					"med_us" : 439,
-					"best_us" : 439
-				},
-				"vec8_u4" : {
-					"med_us" : 468,
-					"best_us" : 468
-				},
-				"plain" : {
-					"med_us" : 470,
-					"best_us" : 470
-				},
-				"u2" : {
-					"med_us" : 469,
-					"best_us" : 469
-				},
-				"u4" : {
-					"med_us" : 467,
-					"best_us" : 467
-				},
-				"u8" : {
-					"med_us" : 468,
-					"best_us" : 468
-				},
-				"vec4_u2" : {
-					"med_us" : 458,
-					"best_us" : 458
-				},
-				"vec4_u8" : {
-					"med_us" : 452,
-					"best_us" : 451
-				},
-				"vec8_u2" : {
-					"med_us" : 468,
-					"best_us" : 468
-				},
-				"vec8_u8" : {
-					"med_us" : 468,
-					"best_us" : 468
-				},
-				"vec16" : {
-					"med_us" : 469,
-					"best_us" : 469
-				}
-			}
-		},
 		"cvt_f16_to_f32" : {
-			"winner" : "vec16",
+			"winner" : "vec16_u2",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 414,
+					"best_us" : 414
 				},
 				"vec32" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 417,
+					"best_us" : 417
 				},
 				"vec32_u4" : {
-					"med_us" : 422,
-					"best_us" : 422
+					"med_us" : 414,
+					"best_us" : 414
 				},
 				"vec32_u8" : {
-					"med_us" : 422,
-					"best_us" : 422
+					"med_us" : 414,
+					"best_us" : 414
 				},
 				"vec16_u2" : {
-					"med_us" : 390,
-					"best_us" : 390
+					"med_us" : 383,
+					"best_us" : 382
 				},
 				"vec16_u4" : {
-					"med_us" : 391,
-					"best_us" : 390
+					"med_us" : 383,
+					"best_us" : 383
 				},
 				"vec16_u8" : {
-					"med_us" : 393,
-					"best_us" : 393
+					"med_us" : 386,
+					"best_us" : 385
 				},
 				"vec4" : {
-					"med_us" : 421,
-					"best_us" : 421
+					"med_us" : 413,
+					"best_us" : 413
 				},
 				"vec8" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 415,
+					"best_us" : 415
 				},
 				"vec4_u4" : {
-					"med_us" : 421,
-					"best_us" : 421
+					"med_us" : 413,
+					"best_us" : 413
 				},
 				"vec8_u4" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 415,
+					"best_us" : 415
 				},
 				"plain" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 416,
+					"best_us" : 416
 				},
 				"u2" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 415,
+					"best_us" : 415
 				},
 				"u4" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 415,
+					"best_us" : 415
 				},
 				"u8" : {
-					"med_us" : 426,
-					"best_us" : 426
+					"med_us" : 415,
+					"best_us" : 415
 				},
 				"vec4_u2" : {
-					"med_us" : 421,
-					"best_us" : 421
+					"med_us" : 414,
+					"best_us" : 414
 				},
 				"vec4_u8" : {
-					"med_us" : 421,
-					"best_us" : 421
+					"med_us" : 413,
+					"best_us" : 413
 				},
 				"vec8_u2" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 416,
+					"best_us" : 416
 				},
 				"vec8_u8" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 416,
+					"best_us" : 416
 				},
 				"vec16" : {
-					"med_us" : 391,
-					"best_us" : 390
+					"med_us" : 385,
+					"best_us" : 382
 				}
 			}
 		},
 		"dot" : {
-			"winner" : "vec8_u8",
+			"winner" : "vec8_u4",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 460,
-					"best_us" : 460
+					"med_us" : 2601,
+					"best_us" : 2550
 				},
 				"vec32" : {
-					"med_us" : 465,
-					"best_us" : 465
+					"med_us" : 2629,
+					"best_us" : 2578
 				},
 				"vec32_u4" : {
-					"med_us" : 466,
-					"best_us" : 457
+					"med_us" : 2579,
+					"best_us" : 2531
 				},
 				"vec32_u8" : {
-					"med_us" : 464,
-					"best_us" : 455
+					"med_us" : 2568,
+					"best_us" : 2521
 				},
 				"vec16_u2" : {
-					"med_us" : 457,
-					"best_us" : 448
+					"med_us" : 2592,
+					"best_us" : 2541
 				},
 				"vec16_u4" : {
-					"med_us" : 447,
-					"best_us" : 438
+					"med_us" : 2572,
+					"best_us" : 2522
 				},
 				"vec16_u8" : {
-					"med_us" : 444,
-					"best_us" : 436
+					"med_us" : 2563,
+					"best_us" : 2514
 				},
 				"vec4" : {
-					"med_us" : 586,
-					"best_us" : 586
+					"med_us" : 2635,
+					"best_us" : 2576
 				},
 				"vec8" : {
-					"med_us" : 462,
-					"best_us" : 452
+					"med_us" : 2616,
+					"best_us" : 2560
 				},
 				"vec4_u4" : {
-					"med_us" : 587,
-					"best_us" : 587
+					"med_us" : 2630,
+					"best_us" : 2576
 				},
 				"vec8_u4" : {
-					"med_us" : 448,
-					"best_us" : 438
+					"med_us" : 2570,
+					"best_us" : 2520
 				},
 				"plain" : {
-					"med_us" : 7376,
-					"best_us" : 7376
+					"med_us" : 30268,
+					"best_us" : 30268
 				},
 				"u2" : {
-					"med_us" : 7374,
-					"best_us" : 7374
+					"med_us" : 30223,
+					"best_us" : 30223
 				},
 				"u4" : {
-					"med_us" : 7370,
-					"best_us" : 7370
+					"med_us" : 30225,
+					"best_us" : 30225
 				},
 				"u8" : {
-					"med_us" : 7375,
-					"best_us" : 7375
+					"med_us" : 30220,
+					"best_us" : 30220
 				},
 				"vec4_u2" : {
-					"med_us" : 587,
-					"best_us" : 587
+					"med_us" : 2633,
+					"best_us" : 2575
 				},
 				"vec4_u8" : {
-					"med_us" : 584,
-					"best_us" : 584
+					"med_us" : 2632,
+					"best_us" : 2574
 				},
 				"vec8_u2" : {
-					"med_us" : 458,
-					"best_us" : 449
+					"med_us" : 2587,
+					"best_us" : 2535
 				},
 				"vec8_u8" : {
-					"med_us" : 446.5,
-					"best_us" : 436
+					"med_us" : 2563,
+					"best_us" : 2511
 				},
 				"vec16" : {
-					"med_us" : 462,
-					"best_us" : 453
-				}
-			}
-		},
-		"q40q8_tile_gen" : {
-			"winner" : "mr8",
-			"rows" : {
-				"mr8" : {
-					"tile_us" : 40062,
-					"gemv_us" : 226,
-					"hot_us" : 13.75
-				},
-				"dot_maddubs_width256_mr8" : {
-					"tile_us" : 459336,
-					"gemv_us" : 1807,
-					"hot_us" : 112.75
-				},
-				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
-					"tile_us" : 459050,
-					"gemv_us" : 1806,
-					"hot_us" : 112.75
-				},
-				"dot_maddubs_width256_mr8_nrsplit2" : {
-					"tile_us" : 459514,
-					"gemv_us" : 1810,
-					"hot_us" : 112.8125
-				},
-				"mr4" : {
-					"tile_us" : 45622,
-					"gemv_us" : 237,
-					"hot_us" : 14.75
-				},
-				"reference" : {
-					"tile_us" : 458276,
-					"gemv_us" : 1807,
-					"hot_us" : 112.625
-				},
-				"mr4_nrsplit2" : {
-					"tile_us" : 50114,
-					"gemv_us" : 236,
-					"hot_us" : 14.75
-				},
-				"dot_vpdpbusd_width256_mr8" : {
-					"tile_us" : 459130,
-					"gemv_us" : 1803,
-					"hot_us" : 112.8125
-				},
-				"dot_vpdpbusd_width512_mr16" : {
-					"tile_us" : 459343,
-					"gemv_us" : 1809,
-					"hot_us" : 112.625
-				},
-				"mr8_nrsplit2" : {
-					"tile_us" : 45482,
-					"gemv_us" : 220,
-					"hot_us" : 13.75
-				},
-				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
-					"tile_us" : 459262,
-					"gemv_us" : 1805,
-					"hot_us" : 112.75
-				}
-			}
-		},
-		"axpy" : {
-			"winner" : "vec8_u8",
-			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 499,
-					"best_us" : 498
-				},
-				"vec32" : {
-					"med_us" : 499,
-					"best_us" : 499
-				},
-				"vec32_u4" : {
-					"med_us" : 500,
-					"best_us" : 498
-				},
-				"vec32_u8" : {
-					"med_us" : 492,
-					"best_us" : 492
-				},
-				"vec16_u2" : {
-					"med_us" : 504.5,
-					"best_us" : 504
-				},
-				"vec16_u4" : {
-					"med_us" : 505,
-					"best_us" : 504
-				},
-				"vec16_u8" : {
-					"med_us" : 503,
-					"best_us" : 500
-				},
-				"vec4" : {
-					"med_us" : 505,
-					"best_us" : 503
-				},
-				"vec8" : {
-					"med_us" : 499,
-					"best_us" : 499
-				},
-				"vec4_u4" : {
-					"med_us" : 506,
-					"best_us" : 505
-				},
-				"vec8_u4" : {
-					"med_us" : 500,
-					"best_us" : 499
-				},
-				"plain" : {
-					"med_us" : 505,
-					"best_us" : 504
-				},
-				"u2" : {
-					"med_us" : 507,
-					"best_us" : 506
-				},
-				"u4" : {
-					"med_us" : 505.5,
-					"best_us" : 505
-				},
-				"u8" : {
-					"med_us" : 502.5,
-					"best_us" : 501
-				},
-				"vec4_u2" : {
-					"med_us" : 504,
-					"best_us" : 503
-				},
-				"vec4_u8" : {
-					"med_us" : 504,
-					"best_us" : 504
-				},
-				"vec8_u2" : {
-					"med_us" : 499.5,
-					"best_us" : 499
-				},
-				"vec8_u8" : {
-					"med_us" : 493,
-					"best_us" : 492
-				},
-				"vec16" : {
-					"med_us" : 504,
-					"best_us" : 503
+					"med_us" : 2617,
+					"best_us" : 2564
 				}
 			}
 		},
@@ -1954,366 +2257,105 @@
 				}
 			}
 		},
-		"dot_q8q8kv" : {
-			"winner" : "vec16",
-			"fallback" : "vec16",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 243,
-					"best_us" : 242
-				},
-				"vec32" : {
-					"med_us" : 238,
-					"best_us" : 237
-				},
-				"vec32_u4" : {
-					"med_us" : 243,
-					"best_us" : 242
-				},
-				"vec32_u8" : {
-					"med_us" : 243,
-					"best_us" : 242
-				},
-				"vec16_u2" : {
-					"med_us" : 245,
-					"best_us" : 245
-				},
-				"vec16_u4" : {
-					"med_us" : 245,
-					"best_us" : 245
-				},
-				"vec16_u8" : {
-					"med_us" : 245,
-					"best_us" : 245
-				},
-				"vec4" : {
-					"med_us" : 238,
-					"best_us" : 237
-				},
-				"vec8" : {
-					"med_us" : 238,
-					"best_us" : 237
-				},
-				"vec4_u4" : {
-					"med_us" : 683,
-					"best_us" : 683
-				},
-				"vec8_u4" : {
-					"med_us" : 331,
-					"best_us" : 331
-				},
-				"plain" : {
-					"med_us" : 238,
-					"best_us" : 237
-				},
-				"u2" : {
-					"med_us" : 258,
-					"best_us" : 258
-				},
-				"u4" : {
-					"med_us" : 245,
-					"best_us" : 245
-				},
-				"u8" : {
-					"med_us" : 245,
-					"best_us" : 245
-				},
-				"vec4_u2" : {
-					"med_us" : 683,
-					"best_us" : 683
-				},
-				"vec4_u8" : {
-					"med_us" : 683,
-					"best_us" : 683
-				},
-				"vec8_u2" : {
-					"med_us" : 331,
-					"best_us" : 331
-				},
-				"vec8_u8" : {
-					"med_us" : 331,
-					"best_us" : 331
-				},
-				"vec16" : {
-					"med_us" : 238,
-					"best_us" : 237
-				}
-			}
-		},
-		"dot_mx4q8" : {
-			"winner" : "u8",
-			"fallback" : "u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 270,
-					"best_us" : 270
-				},
-				"vec32" : {
-					"med_us" : 282,
-					"best_us" : 282
-				},
-				"vec32_u4" : {
-					"med_us" : 254,
-					"best_us" : 252
-				},
-				"vec32_u8" : {
-					"med_us" : 247,
-					"best_us" : 245
-				},
-				"vec16_u2" : {
-					"med_us" : 271,
-					"best_us" : 271
-				},
-				"vec16_u4" : {
-					"med_us" : 253,
-					"best_us" : 249
-				},
-				"vec16_u8" : {
-					"med_us" : 247,
-					"best_us" : 245
-				},
-				"vec4" : {
-					"med_us" : 282,
-					"best_us" : 282
-				},
-				"vec8" : {
-					"med_us" : 282,
-					"best_us" : 282
-				},
-				"vec4_u4" : {
-					"med_us" : 253,
-					"best_us" : 248
-				},
-				"vec8_u4" : {
-					"med_us" : 252,
-					"best_us" : 247
-				},
-				"plain" : {
-					"med_us" : 282,
-					"best_us" : 282
-				},
-				"u2" : {
-					"med_us" : 274,
-					"best_us" : 274
-				},
-				"u4" : {
-					"med_us" : 253,
-					"best_us" : 248
-				},
-				"u8" : {
-					"med_us" : 247,
-					"best_us" : 242
-				},
-				"vec4_u2" : {
-					"med_us" : 270,
-					"best_us" : 270
-				},
-				"vec4_u8" : {
-					"med_us" : 247,
-					"best_us" : 242
-				},
-				"vec8_u2" : {
-					"med_us" : 270,
-					"best_us" : 270
-				},
-				"vec8_u8" : {
-					"med_us" : 247,
-					"best_us" : 242
-				},
-				"vec16" : {
-					"med_us" : 282,
-					"best_us" : 282
-				}
-			}
-		},
-		"dot_q8q8_laneq4x4" : {
-			"winner" : "u4",
-			"fallback" : "u2",
-			"floor_pct" : 0.767086915754956,
-			"rows" : {
-				"vec32_u2" : {
-					"med_us" : 1032,
-					"best_us" : 1028
-				},
-				"vec32" : {
-					"med_us" : 1038,
-					"best_us" : 1034
-				},
-				"vec32_u4" : {
-					"med_us" : 1020,
-					"best_us" : 1017
-				},
-				"vec32_u8" : {
-					"med_us" : 1017,
-					"best_us" : 1014
-				},
-				"vec16_u2" : {
-					"med_us" : 1032,
-					"best_us" : 1028
-				},
-				"vec16_u4" : {
-					"med_us" : 1020,
-					"best_us" : 1017
-				},
-				"vec16_u8" : {
-					"med_us" : 1017,
-					"best_us" : 1014
-				},
-				"vec4" : {
-					"med_us" : 1038,
-					"best_us" : 1035
-				},
-				"vec8" : {
-					"med_us" : 1038,
-					"best_us" : 1035
-				},
-				"vec4_u4" : {
-					"med_us" : 1020,
-					"best_us" : 1017
-				},
-				"vec8_u4" : {
-					"med_us" : 1020,
-					"best_us" : 1017
-				},
-				"plain" : {
-					"med_us" : 1037,
-					"best_us" : 1034
-				},
-				"u2" : {
-					"med_us" : 1032,
-					"best_us" : 1028
-				},
-				"u4" : {
-					"med_us" : 1020,
-					"best_us" : 1017
-				},
-				"u8" : {
-					"med_us" : 1017,
-					"best_us" : 1014
-				},
-				"vec4_u2" : {
-					"med_us" : 1032,
-					"best_us" : 1028
-				},
-				"vec4_u8" : {
-					"med_us" : 1017,
-					"best_us" : 1014
-				},
-				"vec8_u2" : {
-					"med_us" : 1031,
-					"best_us" : 1028
-				},
-				"vec8_u8" : {
-					"med_us" : 1017,
-					"best_us" : 1014
-				},
-				"vec16" : {
-					"med_us" : 1038,
-					"best_us" : 1034
-				}
-			}
-		},
 		"scale_inplace" : {
-			"winner" : "vec8_u2",
+			"winner" : "vec16_u2",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
 					"med_us" : 416,
-					"best_us" : 415
+					"best_us" : 407
 				},
 				"vec32" : {
 					"med_us" : 415,
-					"best_us" : 415
+					"best_us" : 407
 				},
 				"vec32_u4" : {
 					"med_us" : 414,
-					"best_us" : 413
+					"best_us" : 406
 				},
 				"vec32_u8" : {
-					"med_us" : 413,
-					"best_us" : 412
+					"med_us" : 415,
+					"best_us" : 405
 				},
 				"vec16_u2" : {
-					"med_us" : 411,
-					"best_us" : 411
+					"med_us" : 412,
+					"best_us" : 404
 				},
 				"vec16_u4" : {
-					"med_us" : 411,
-					"best_us" : 410
+					"med_us" : 410,
+					"best_us" : 402
 				},
 				"vec16_u8" : {
-					"med_us" : 442,
-					"best_us" : 442
+					"med_us" : 431,
+					"best_us" : 421
 				},
 				"vec4" : {
 					"med_us" : 423,
-					"best_us" : 421
+					"best_us" : 413
 				},
 				"vec8" : {
-					"med_us" : 415,
-					"best_us" : 415
+					"med_us" : 414,
+					"best_us" : 407
 				},
 				"vec4_u4" : {
 					"med_us" : 425,
-					"best_us" : 425
+					"best_us" : 417
 				},
 				"vec8_u4" : {
-					"med_us" : 414,
-					"best_us" : 414
+					"med_us" : 415.5,
+					"best_us" : 406
 				},
 				"plain" : {
 					"med_us" : 422,
-					"best_us" : 421
+					"best_us" : 413
 				},
 				"u2" : {
 					"med_us" : 425,
-					"best_us" : 425
+					"best_us" : 416
 				},
 				"u4" : {
-					"med_us" : 425,
-					"best_us" : 425
+					"med_us" : 428,
+					"best_us" : 417
 				},
 				"u8" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 424,
+					"best_us" : 415
 				},
 				"vec4_u2" : {
-					"med_us" : 425,
-					"best_us" : 424
+					"med_us" : 426,
+					"best_us" : 416
 				},
 				"vec4_u8" : {
-					"med_us" : 423,
-					"best_us" : 423
+					"med_us" : 424,
+					"best_us" : 416
 				},
 				"vec8_u2" : {
 					"med_us" : 416,
-					"best_us" : 415
+					"best_us" : 408
 				},
 				"vec8_u8" : {
-					"med_us" : 414,
-					"best_us" : 414
+					"med_us" : 413,
+					"best_us" : 405
 				},
 				"vec16" : {
-					"med_us" : 414,
-					"best_us" : 413
+					"med_us" : 414.5,
+					"best_us" : 405
 				}
 			}
 		},
 		"dot_q4" : {
 			"winner" : "vec4_u4",
 			"fallback" : "vec4_u4",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.5181857443078166,
 			"rows" : {
 				"vec32_u2" : {
 					"med_us" : 2828,
 					"best_us" : 2828
 				},
 				"vec32" : {
-					"med_us" : 3098,
-					"best_us" : 3098
+					"med_us" : 3095,
+					"best_us" : 3095
 				},
 				"vec32_u4" : {
 					"med_us" : 2670,
@@ -2328,8 +2370,8 @@
 					"best_us" : 1452
 				},
 				"vec16_u4" : {
-					"med_us" : 1453,
-					"best_us" : 1453
+					"med_us" : 1452,
+					"best_us" : 1452
 				},
 				"vec16_u8" : {
 					"med_us" : 1452,
@@ -2344,177 +2386,177 @@
 					"best_us" : 3095
 				},
 				"vec4_u4" : {
-					"med_us" : 1142,
+					"med_us" : 1121,
 					"best_us" : 1120
 				},
 				"vec8_u4" : {
-					"med_us" : 1172,
-					"best_us" : 1150
+					"med_us" : 1150,
+					"best_us" : 1149
 				},
 				"plain" : {
-					"med_us" : 3098,
-					"best_us" : 3098
+					"med_us" : 3095,
+					"best_us" : 3095
 				},
 				"u2" : {
 					"med_us" : 1446,
 					"best_us" : 1446
 				},
 				"u4" : {
-					"med_us" : 1446,
-					"best_us" : 1446
+					"med_us" : 1445,
+					"best_us" : 1445
 				},
 				"u8" : {
 					"med_us" : 1446,
 					"best_us" : 1446
 				},
 				"vec4_u2" : {
-					"med_us" : 1145.5,
-					"best_us" : 1123
+					"med_us" : 1123,
+					"best_us" : 1120
 				},
 				"vec4_u8" : {
-					"med_us" : 1142,
+					"med_us" : 1120,
 					"best_us" : 1120
 				},
 				"vec8_u2" : {
-					"med_us" : 1172,
-					"best_us" : 1149
+					"med_us" : 1150,
+					"best_us" : 1150
 				},
 				"vec8_u8" : {
-					"med_us" : 1172,
+					"med_us" : 1150,
 					"best_us" : 1150
 				},
 				"vec16" : {
-					"med_us" : 3096,
-					"best_us" : 3096
+					"med_us" : 3095,
+					"best_us" : 3095
 				}
 			}
 		},
 		"copy_floats" : {
 			"winner" : "vec8_u2",
 			"fallback" : "vec8_u2",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.24357032745949034,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 692.5,
-					"best_us" : 422
+					"med_us" : 416,
+					"best_us" : 382
 				},
 				"vec32" : {
-					"med_us" : 693.5,
-					"best_us" : 422
+					"med_us" : 453,
+					"best_us" : 433
 				},
 				"vec32_u4" : {
-					"med_us" : 693,
-					"best_us" : 424
+					"med_us" : 450,
+					"best_us" : 431
 				},
 				"vec32_u8" : {
-					"med_us" : 695,
-					"best_us" : 425
+					"med_us" : 455.5,
+					"best_us" : 436
 				},
 				"vec16_u2" : {
-					"med_us" : 692,
-					"best_us" : 424
+					"med_us" : 419,
+					"best_us" : 381
 				},
 				"vec16_u4" : {
-					"med_us" : 692,
-					"best_us" : 422
+					"med_us" : 448.5,
+					"best_us" : 429
 				},
 				"vec16_u8" : {
-					"med_us" : 689.5,
-					"best_us" : 422
+					"med_us" : 417,
+					"best_us" : 386
 				},
 				"vec4" : {
-					"med_us" : 695,
-					"best_us" : 427
+					"med_us" : 458,
+					"best_us" : 433
 				},
 				"vec8" : {
-					"med_us" : 693,
-					"best_us" : 427
+					"med_us" : 418,
+					"best_us" : 383
 				},
 				"vec4_u4" : {
-					"med_us" : 692.5,
-					"best_us" : 422
+					"med_us" : 417,
+					"best_us" : 382
 				},
 				"vec8_u4" : {
-					"med_us" : 690,
-					"best_us" : 426
+					"med_us" : 417,
+					"best_us" : 383
 				},
 				"plain" : {
-					"med_us" : 693,
-					"best_us" : 417
+					"med_us" : 448.5,
+					"best_us" : 431
 				},
 				"u2" : {
-					"med_us" : 694,
-					"best_us" : 417
+					"med_us" : 415,
+					"best_us" : 379
 				},
 				"u4" : {
-					"med_us" : 695,
-					"best_us" : 424
+					"med_us" : 447,
+					"best_us" : 427
 				},
 				"u8" : {
-					"med_us" : 693.5,
-					"best_us" : 419
+					"med_us" : 444.5,
+					"best_us" : 428
 				},
 				"vec4_u2" : {
-					"med_us" : 692.5,
-					"best_us" : 422
+					"med_us" : 415.5,
+					"best_us" : 383
 				},
 				"vec4_u8" : {
-					"med_us" : 693.5,
-					"best_us" : 417
+					"med_us" : 451,
+					"best_us" : 431
 				},
 				"vec8_u2" : {
-					"med_us" : 691.5,
-					"best_us" : 422
+					"med_us" : 417,
+					"best_us" : 385
 				},
 				"vec8_u8" : {
-					"med_us" : 692,
-					"best_us" : 424
+					"med_us" : 417,
+					"best_us" : 382
 				},
 				"vec16" : {
-					"med_us" : 692,
-					"best_us" : 422
+					"med_us" : 449,
+					"best_us" : 431
 				}
 			}
 		},
 		"rmsnorm" : {
 			"winner" : "vec8",
 			"fallback" : "plain",
-			"floor_pct" : 0.767086915754956,
+			"floor_pct" : 0.5181857443078166,
 			"rows" : {
 				"vec32_u2" : {
-					"med_us" : 906,
-					"best_us" : 906
+					"med_us" : 920,
+					"best_us" : 903
 				},
 				"vec32" : {
-					"med_us" : 914,
-					"best_us" : 914
+					"med_us" : 911,
+					"best_us" : 911
 				},
 				"vec32_u4" : {
-					"med_us" : 929,
-					"best_us" : 929
+					"med_us" : 912,
+					"best_us" : 912
 				},
 				"vec32_u8" : {
-					"med_us" : 933,
-					"best_us" : 933
+					"med_us" : 916,
+					"best_us" : 916
 				},
 				"vec16_u2" : {
-					"med_us" : 900,
-					"best_us" : 882
+					"med_us" : 897,
+					"best_us" : 880
 				},
 				"vec16_u4" : {
-					"med_us" : 898,
-					"best_us" : 881
+					"med_us" : 894,
+					"best_us" : 879
 				},
 				"vec16_u8" : {
-					"med_us" : 893,
+					"med_us" : 891.5,
 					"best_us" : 874
 				},
 				"vec4" : {
-					"med_us" : 1013,
-					"best_us" : 1013
+					"med_us" : 1014,
+					"best_us" : 1014
 				},
 				"vec8" : {
-					"med_us" : 881,
+					"med_us" : 880,
 					"best_us" : 863
 				},
 				"vec4_u4" : {
@@ -2522,24 +2564,24 @@
 					"best_us" : 1008
 				},
 				"vec8_u4" : {
-					"med_us" : 882,
+					"med_us" : 880,
 					"best_us" : 863
 				},
 				"plain" : {
-					"med_us" : 8175,
-					"best_us" : 8175
+					"med_us" : 8141,
+					"best_us" : 8141
 				},
 				"u2" : {
-					"med_us" : 8142,
-					"best_us" : 8142
+					"med_us" : 8143,
+					"best_us" : 8143
 				},
 				"u4" : {
-					"med_us" : 8136,
-					"best_us" : 8136
+					"med_us" : 8137,
+					"best_us" : 8137
 				},
 				"u8" : {
-					"med_us" : 8139,
-					"best_us" : 8139
+					"med_us" : 8137,
+					"best_us" : 8137
 				},
 				"vec4_u2" : {
 					"med_us" : 1014,
@@ -2550,11 +2592,11 @@
 					"best_us" : 1008
 				},
 				"vec8_u2" : {
-					"med_us" : 881,
-					"best_us" : 862
+					"med_us" : 886,
+					"best_us" : 870
 				},
 				"vec8_u8" : {
-					"med_us" : 886,
+					"med_us" : 884,
 					"best_us" : 867
 				},
 				"vec16" : {
@@ -2583,7 +2625,7 @@
 		"attn_par_threshold" : 100000,
 		"batch_lane_cap" : 0,
 		"act_par_threshold" : 100000,
-		"threads" : 7,
+		"threads" : 8,
 		"dispatch_worker_limit" : 0,
 		"q8_batch_chunks_per_job" : 4,
 		"q8_chunks_per_job" : 2,

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -122,7 +122,7 @@ synthetic log files from a per-process temp dir. Requires `run` by bare same-dir
 `test_tok_seed.das` — model-free: `lcpp_bench.das`'s `tok_read_seed` corpus-header walk, required
 by relative path (`../benchmarks/lcpp_bench.das`), so it pays the bench's full engine compile.
 `test_sizing_helpers.das` — model-free: the sizing helpers (`reserve_resize` exact capacity,
-`grow_resize` geometric reuse, `scratch_resize` grow-only no-init) fed directly, including
+`grow_resize` geometric reuse, `overwrite_resize` grow-only no-init) fed directly, including
 grows past the `max_unreserved_size` guard that must not panic.
 `test_vision.das` — model-free: the vision preprocessing rail (geometry, letterbox, normalize)
 bit-exact against pinned mtmd oracle hashes (dumps + mint.sh in the models dir's

--- a/modules/dasLLAMA/tests/test_exchange_schema.das
+++ b/modules/dasLLAMA/tests/test_exchange_schema.das
@@ -67,11 +67,15 @@ def test_corpus_sidecars(t : T?) {
                     report(t, name, validate_sidecar(text, errors), errors)
                     delete errors
                     t |> success(info.kernel_count > 0, "{name} has kernels")
-                    t |> equal(info.dasllama_version, 0, "{name} predates the release counter")
                     t |> success(!empty(info.identity.platform) && !empty(info.identity.cpu), "{name} box identity parses")
-                    // pre-counter sidecars are shape-valid history, but the exchange must refuse them
+                    // the release counter decides submission grade: pre-counter sidecars are
+                    // shape-valid history the exchange must refuse; stamped ones must clear it
                     var serrors : array<string>
-                    t |> success(!validate_sidecar_submission(text, serrors), "{name} is not submission-grade")
+                    if (info.dasllama_version == 0) {
+                        t |> success(!validate_sidecar_submission(text, serrors), "{name} is not submission-grade")
+                    } else {
+                        report(t, "{name} submission-grade", validate_sidecar_submission(text, serrors), serrors)
+                    }
                     delete serrors
                 }
             }

--- a/modules/dasLLAMA/tests/test_sizing_helpers.das
+++ b/modules/dasLLAMA/tests/test_sizing_helpers.das
@@ -5,7 +5,7 @@ require dasllama/dasllama_common
 
 // The sizing helpers' own contract, fed directly: reserve_resize is exact at any element
 // width, grow_resize keeps a reused buffer amortized across shrink-then-grow, and
-// scratch_resize is grow-only no-init — and all three stay panic-free past the
+// overwrite_resize is grow-only no-init — and all three stay panic-free past the
 // max_unreserved_size guard (64 MB default), which is the reason they exist.
 
 [test]
@@ -42,16 +42,16 @@ def test_grow_resize(t : T?) {
 }
 
 [test]
-def test_scratch_resize(t : T?) {
+def test_overwrite_resize(t : T?) {
     t |> run("grow-only no-init scratch") @(t : T?) {
         var s : array<float>
-        scratch_resize(s, 1000l)
+        overwrite_resize(s, 1000l)
         t |> equal(long_length(s), 1000l)
         let cap0 = long_capacity(s)
-        scratch_resize(s, 10l)           // need below length: shrink, capacity kept
+        overwrite_resize(s, 10l)           // need below length: shrink, capacity kept
         t |> equal(long_length(s), 10l)
         t |> equal(long_capacity(s), cap0)
-        scratch_resize(s, 20000000l)     // 80 MB grow: exact reserve inside, no panic
+        overwrite_resize(s, 20000000l)     // 80 MB grow: exact reserve inside, no panic
         t |> equal(long_length(s), 20000000l)
         t |> equal(long_capacity(s), 20000000l)
     }

--- a/modules/dasMetal/MASTERPLAN.md
+++ b/modules/dasMetal/MASTERPLAN.md
@@ -921,7 +921,7 @@ gates green. Attribution rail: g_skip modes keep logits OFF so knockout deltas s
 "alloc 5ms" was forward_prefill_alloc's batched-scratch GROWTH cost on the first prefill at a
 new npos (~70 MB across 10 arrays at 512 rows): das `resize` zero-fills the grown span AND the
 realloc copies the old block. Both are pure waste here — the scratch is stage output, fully
-written before any read. Fix = `scratch_resize` (dasllama_common): grow-only, contents-
+written before any read. Fix = `overwrite_resize` (dasllama_common): grow-only, contents-
 DISCARDING (`delete` on grow skips the realloc's old-block copy), `resize_no_init` (skips the
 zero-fill). Measured (3B pp512, per-bucket profile): alloc 4969us -> 55us; embed +0.2ms
 (absorbs the first-touch page faults); framing TOTAL 5728 -> 1075us. A new `alloc` prof bucket

--- a/skills/perf_lint.md
+++ b/skills/perf_lint.md
@@ -223,7 +223,7 @@ struct Session {
 
 // a helper that sizes a caller's buffer marks the PARAMETER — the call site cannot see
 // which field arrived, because the destination comes in by reference
-def scratch_resize(@scratch var a : array<numT>; need : int64) { ... }
+def overwrite_resize(@scratch var a : array<numT>; need : int64) { ... }
 ```
 
 A sizing call whose destination reaches a `@scratch` declaration is not descended into — a
@@ -240,7 +240,7 @@ tells the linter "this buffer is reused". The same statement is exactly the prec
   up-size becomes a no-op instead of a realloc.
 - **Skip the zero-fill.** `resize` init-fills new elements; a scratch buffer is fully rewritten by
   the step that sizes it, so `@scratch` licenses `resize_no_init` implicitly. dasLLAMA already
-  hand-rolls exactly this in `scratch_resize` (delete-on-grow, exact `reserve`, then
+  hand-rolls exactly this in `overwrite_resize` (delete-on-grow, exact `reserve`, then
   `resize_no_init`) — the annotation could make that the default rather than a hand-written idiom.
 - **Hoist the sizing.** With the reuse promise, a `resize(n)` whose `n` is loop-invariant can be
   lifted out of the step loop entirely.

--- a/src/builtin/module_builtin_array.cpp
+++ b/src/builtin/module_builtin_array.cpp
@@ -149,6 +149,24 @@ namespace das {
         if ( arr.data && name ) context->heap->mark_comment(arr.data, name);
     }
 
+    void builtin_array_set_scratch ( Array & arr, bool value, Context * ) {
+        arr.scratch = value;
+    }
+
+    bool builtin_array_is_scratch ( const Array & arr ) {
+        return arr.scratch;
+    }
+
+    void builtin_array_scratch_reserve ( Array & pArray, int newSize, int stride, Context * context, LineInfoArg * at ) {
+        if ( newSize<0 ) return; // no point of displaying errors, if reserve fails
+        array_reserve_scratch( *context, pArray, newSize, stride, at );
+    }
+
+    void builtin_array_scratch_reserve_i64 ( Array & pArray, int64_t newSize, int stride, Context * context, LineInfoArg * at ) {
+        if ( newSize<0 ) return; // no point of displaying errors, if reserve fails
+        array_reserve_scratch( *context, pArray, uint64_t(newSize), stride, at );
+    }
+
     void Module_BuiltIn::addArrayTypes(ModuleLibrary & lib) {
         // array functions
         // the public 'clear' is a builtin.das generic (finalize banner); this is its raw half
@@ -235,5 +253,19 @@ namespace das {
         addExtern<DAS_BIND_FUN(builtin_array_tag)>(*this, lib, "tag_array",
             SideEffects::modifyExternal, "builtin_array_tag")
                 ->args({"array","name","context"});
+        // scratch: the owner promises no interior alias escapes a grow, so growth may free
+        // the old buffer eagerly even in a verySafeContext (set once on internal containers)
+        addExtern<DAS_BIND_FUN(builtin_array_set_scratch)>(*this, lib, "set_scratch",
+            SideEffects::modifyArgument, "builtin_array_set_scratch")
+                ->args({"array","value","context"})->unsafeOperation = true;
+        addExtern<DAS_BIND_FUN(builtin_array_is_scratch)>(*this, lib, "is_scratch",
+            SideEffects::none, "builtin_array_is_scratch")
+                ->arg("array");
+        addExtern<DAS_BIND_FUN(builtin_array_scratch_reserve)>(*this, lib, "__builtin_array_scratch_reserve",
+            SideEffects::modifyArgument, "builtin_array_scratch_reserve")
+                ->args({"array","newSize","stride","context","at"})->unsafeOperation = true;
+        addExtern<DAS_BIND_FUN(builtin_array_scratch_reserve_i64)>(*this, lib, "__builtin_array_scratch_reserve_i64",
+            SideEffects::modifyArgument, "builtin_array_scratch_reserve_i64")
+                ->args({"array","newSize","stride","context","at"})->unsafeOperation = true;
     }
 }

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1438,6 +1438,10 @@ namespace das
             } else {
                 memset ( &dim, 0, sizeof(Array) );
             }
+        } else {
+            // no backing store to free, but delete still resets the scratch mark - the one
+            // flag settable on a dataless container; lock state must survive untouched
+            dim.scratch = false;
         }
     }
 
@@ -1455,6 +1459,8 @@ namespace das
             } else {
                 memset ( &tab, 0, sizeof(Table) );
             }
+        } else {
+            tab.scratch = false;
         }
     }
 

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1182,6 +1182,14 @@ namespace das
         const_cast<Table&>(arr).hopeless = 0;
     }
 
+    void builtin_table_set_scratch ( Table & tab, bool value, Context * ) {
+        tab.scratch = value;
+    }
+
+    bool builtin_table_is_scratch ( const Table & tab ) {
+        return tab.scratch;
+    }
+
     void builtin_table_tag ( Table & tab, const char * name, Context * context ) {
         // Debug helper: tag the table's current heap block with `name` so it shows
         // up in heap reports under that name. Requires `options track_allocations`
@@ -2555,6 +2563,13 @@ namespace das
         addExtern<DAS_BIND_FUN(builtin_table_tag)>(*this, lib, "tag_table",
             SideEffects::modifyExternal, "builtin_table_tag")
                 ->args({"table","name","context"});
+        // scratch: same contract as the array flag; the bit lives in the shared Array flags word
+        addExtern<DAS_BIND_FUN(builtin_table_set_scratch)>(*this, lib, "set_scratch",
+            SideEffects::modifyArgument, "builtin_table_set_scratch")
+                ->args({"table","value","context"})->unsafeOperation = true;
+        addExtern<DAS_BIND_FUN(builtin_table_is_scratch)>(*this, lib, "is_scratch",
+            SideEffects::none, "builtin_table_is_scratch")
+                ->arg("table");
         addExtern<DAS_BIND_FUN(builtin_table_keys)>(*this, lib, "__builtin_table_keys",
             SideEffects::modifyArgumentAndExternal, "builtin_table_keys")
                 ->args({"iterator","table","stride","context","at"});

--- a/src/simulate/runtime_array.cpp
+++ b/src/simulate/runtime_array.cpp
@@ -75,7 +75,7 @@ namespace das
         }
     }
 
-    void array_reserve(Context & context, Array & arr, uint64_t newCapacity, uint32_t stride, LineInfo * at) {
+    static void array_reserve_impl(Context & context, Array & arr, uint64_t newCapacity, uint32_t stride, bool eager, LineInfo * at) {
         if ( arr.isLocked() ) context.throw_error_at(at, "can't change capacity of a locked array");
         if ( arr.capacity >= newCapacity ) return;
         // Explicit mul_overflow guard: stride is uint32, newCapacity is uint64.
@@ -89,7 +89,8 @@ namespace das
         uint64_t memSize64 = newCapacity * uint64_t(stride);
         const char * prev_comment = arr.data ? context.heap->get_comment(arr.data) : nullptr;
         char * newData = nullptr;
-        if ( context.verySafeContext ) {
+        // deferred arm: abandon the old buffer to GC so stale interior aliases stay readable
+        if ( context.verySafeContext && !arr.scratch && !eager ) {
             newData = (char *)context.allocate(memSize64, at);
             if ( newData && arr.data ) {
                 memcpy(newData, arr.data, arr.size*stride);
@@ -103,6 +104,14 @@ namespace das
             arr.data = newData;
         }
         arr.capacity = newCapacity;
+    }
+
+    void array_reserve(Context & context, Array & arr, uint64_t newCapacity, uint32_t stride, LineInfo * at) {
+        array_reserve_impl(context, arr, newCapacity, stride, false, at);
+    }
+
+    void array_reserve_scratch(Context & context, Array & arr, uint64_t newCapacity, uint32_t stride, LineInfo * at) {
+        array_reserve_impl(context, arr, newCapacity, stride, true, at);
     }
 
     void array_resize ( Context & context, Array & arr, uint64_t newSize, uint32_t stride, bool zero, LineInfo * at ) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,6 +54,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | File | Description | Expects errors |
 |---|---|---|
 | test_archive.das | mem_archive_save/load for variants, tables, arrays, structs | |
+| test_archive_scratch_churn.das | MemSerializer eager-grow opt-in under very_safe_context — round-trip + churn bound | |
 
 ## assert_once/
 
@@ -586,6 +587,7 @@ JIT compilation and code-generation tests. None have `expect` directives. The sl
 | cant_have_local_variable.das | Non-local type as local variable (uses `ast::TypeDecl`) | **expect** `30108:4` `30101:2` `31300:3` |
 | cant_index.das | Invalid index operations | **expect** `30502:2` |
 | cant_override_sealed.das | Sealed method override errors | **expect** `30115:2` |
+| cant_scratch_outside_unsafe.das | Every scratch container primitive requires `unsafe` | **expect** `31013:6` |
 | cant_write_to_constant_value.das | Const value write violations | **expect** `30504:3` |
 | capture_as_ref.das | Class lambda capturing `self` as ref | |
 | capture_string.das | String capture in lambdas and string builder (module) | |
@@ -733,6 +735,9 @@ JIT compilation and code-generation tests. None have `expect` directives. The sl
 | safe_index.das | Safe index `?[]` on arrays, tables, vectors, strings | |
 | safe_ptr_at.das | Safe index `?[]` on pointer types — null safety, struct pointer arrays | |
 | safe_operators.das | Custom `operator []`, `?[]`, `.`, `?.` on user struct | |
+| scratch_containers.das | scratch one-shot semantics (exact reserve/resize/ensure_capacity) + inert-outside-very-safe control | |
+| scratch_very_safe_array.das | Array scratch bit under very_safe_context — eager vs deferred heap deltas, move/delete/clear lifecycle | |
+| scratch_very_safe_table.das | Table scratch bit under very_safe_context — rehash free, bit rides rehash (self-calibrating) | |
 | serialization.das | Archive serialization — structs, custom serialize, arrays, tables | |
 | set_table.das | `table<int>` as set — insert, erase, keys iteration, clone, literal | |
 | setand_and_setor_bool.das | Short-circuit `\|\|=` and `&&=` operators | |

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -126,6 +126,7 @@ IF(NOT DAS_AUDIO_DISABLED)
         tests/strudel/test_orbit_gain.das
         tests/strudel/test_reverb.das
         tests/strudel/test_scales.das
+        tests/strudel/test_scratch_pools.das
         tests/strudel/test_setters.das
         tests/strudel/test_signals.das
         tests/strudel/test_synthesis.das

--- a/tests/archive/test_archive_scratch_churn.das
+++ b/tests/archive/test_archive_scratch_churn.das
@@ -1,0 +1,57 @@
+options gen2
+options persistent_heap = true
+options very_safe_context
+
+// scope: the archive writer's eager-grow opt-in (MemSerializer.write -> scratch_ensure_capacity)
+// eager expectation: a serialize leaves ~1x the payload live (the final buffer)
+// deferred would leave: ~2x (the abandoned doubling ladder too) - the 1.5x bound splits them
+// payload: element-wise records (struct fields, per-element strings) so the buffer walks the
+//          ladder; a bulk workhorse array would memcpy in one write and prove nothing
+// behavior-unchanged instrument: test_archive.das, deliberately untouched
+
+require dastest/testing_boost public
+require daslib/archive
+
+struct Rec {
+    id : int
+    name : string
+}
+
+var g_recs : array<Rec>
+var g_bytes : array<uint8>
+
+[test]
+def test_archive_scratch_churn(t : T?) {
+    t |> run("round-trip is field-identical through the eager path") @(t : T?) {
+        g_recs |> resize(2000)
+        for (i in range(2000)) {
+            g_recs[i].id = i
+            g_recs[i].name = "record number {i} with some padding to stretch the stream"
+        }
+        g_bytes <- mem_archive_save(g_recs)   // nolint:PERF030 — the target global is fresh-empty
+        var loaded : array<Rec>
+        t |> success(mem_archive_load(g_bytes, loaded), "load must succeed")
+        t |> equal(length(loaded), 2000)
+        var mismatches = 0
+        for (i in range(2000)) {
+            if (loaded[i].id != g_recs[i].id || loaded[i].name != g_recs[i].name) {
+                mismatches++
+            }
+        }
+        t |> equal(mismatches, 0)
+        delete loaded
+    }
+    t |> run("churn stays ~1x the payload under very_safe") @(t : T?) {
+        // the payload and the previous arm's allocations are all outside this window
+        let before = heap_bytes_allocated()
+        var bytes <- mem_archive_save(g_recs)
+        let grew = heap_bytes_allocated() - before
+        let cap = uint64(long_capacity(bytes))
+        // eager: the live survivor is the final buffer (the serializer shell nets to zero);
+        // deferred would leave the doubling ladder too, ~2x - the 1.5x bound splits them
+        t |> success(grew <= cap * 3ul / 2ul, "abandoned generations must not survive the save")
+        t |> success(grew >= cap, "the final buffer itself is in the window")
+        t |> success(long_capacity(bytes) >= long_length(bytes), "sanity: resize stayed within the ensured capacity")
+        delete bytes
+    }
+}

--- a/tests/language/cant_scratch_outside_unsafe.das
+++ b/tests/language/cant_scratch_outside_unsafe.das
@@ -1,0 +1,35 @@
+options gen2
+expect 31013 : 6    // unsafe_function_call - every scratch primitive is gated; one site per def below
+
+var a : array<int>
+var tb : table<int; int>
+
+[export]
+def cant_set_scratch_array {
+    a |> set_scratch(true)
+}
+
+[export]
+def cant_set_scratch_table {
+    tb |> set_scratch(true)
+}
+
+[export]
+def cant_scratch_reserve {
+    a |> scratch_reserve(10)
+}
+
+[export]
+def cant_scratch_ensure_capacity {
+    a |> scratch_ensure_capacity(10)
+}
+
+[export]
+def cant_scratch_resize {
+    a |> scratch_resize(10)
+}
+
+[export]
+def cant_raw_builtin {
+    __builtin_array_scratch_reserve(a, 10, 4)
+}

--- a/tests/language/scratch_containers.das
+++ b/tests/language/scratch_containers.das
@@ -1,0 +1,113 @@
+options gen2
+options persistent_heap = true
+
+// The scratch one-shot family's capacity/length semantics, plus the inert-outside-very-safe
+// control: this file deliberately does NOT set very_safe_context, so the scratch bit must
+// change nothing here. The very-safe halves live in scratch_very_safe_array/table.das.
+
+require dastest/testing_boost public
+
+// globals: a stack-promoted local never reaches array_reserve, and the heap delta in the
+// control arm below would read zero against a broken predicate
+var g_marked : array<int>
+var g_plain : array<int>
+
+[test]
+def test_scratch_reserve(t : T?) {
+    t |> run("scratch_reserve is exact - reserve never rounds") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_reserve(300))
+        t |> equal(capacity(a), 300)
+        t |> equal(length(a), 0)
+    }
+    t |> run("int64 overload") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_reserve(300l))
+        t |> equal(long_capacity(a), 300l)
+    }
+}
+
+[test]
+def test_scratch_ensure_capacity(t : T?) {
+    t |> run("no-op at or below capacity") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_reserve(64))
+        unsafe(a |> scratch_ensure_capacity(32))
+        t |> equal(capacity(a), 64)
+        t |> equal(length(a), 0)
+    }
+    t |> run("doubling wins when it covers the ask") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_reserve(64))
+        unsafe(a |> scratch_ensure_capacity(100))
+        t |> equal(capacity(a), 128)
+    }
+    t |> run("exact ask wins past the double") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_reserve(64))
+        unsafe(a |> scratch_ensure_capacity(500))
+        t |> equal(capacity(a), 500)
+    }
+    t |> run("int overload forwards, doubling-from-zero edge") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_ensure_capacity(10))
+        t |> equal(capacity(a), 10)
+    }
+}
+
+[test]
+def test_scratch_resize(t : T?) {
+    t |> run("grow reserves the exact size - plain resize pow2-rounds") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_resize(300))
+        t |> equal(length(a), 300)
+        t |> equal(capacity(a), 300)
+        var inscope b : array<int>
+        b |> resize(300)   // the contrast: same size through the plain path
+        t |> equal(capacity(b), 512)
+    }
+    t |> run("shrink keeps capacity") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_resize(300))
+        unsafe(a |> scratch_resize(10))
+        t |> equal(length(a), 10)
+        t |> equal(capacity(a), 300)
+    }
+    t |> run("zero size") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_resize(300))
+        unsafe(a |> scratch_resize(0))
+        t |> equal(length(a), 0)
+        t |> equal(capacity(a), 300)
+    }
+    t |> run("negative size is a no-op, both widths") @(t : T?) {
+        var inscope a : array<int>
+        unsafe(a |> scratch_reserve(64))
+        unsafe(a |> scratch_reserve(-1))
+        t |> equal(capacity(a), 64)
+        unsafe(a |> scratch_reserve(-1l))
+        t |> equal(capacity(a), 64)
+    }
+}
+
+[test]
+def test_scratch_inert_outside_very_safe(t : T?) {
+    t |> run("a normal context grows identically with and without the bit") @(t : T?) {
+        let before = heap_bytes_allocated()
+        unsafe(g_marked |> set_scratch(true))
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_marked |> reserve(c)
+        }
+        let grewMarked = heap_bytes_allocated() - before
+        let b2 = heap_bytes_allocated()
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_plain |> reserve(c)
+        }
+        let grewPlain = heap_bytes_allocated() - b2
+        // eager both ways: only the final generation stays live
+        t |> equal(grewMarked, uint64(long_capacity(g_marked)) * 4ul)
+        t |> equal(grewPlain, uint64(long_capacity(g_plain)) * 4ul)
+        t |> equal(is_scratch(g_marked), true)
+        t |> equal(is_scratch(g_plain), false)
+    }
+}

--- a/tests/language/scratch_very_safe_array.das
+++ b/tests/language/scratch_very_safe_array.das
@@ -93,10 +93,12 @@ def test_scratch_lifecycle(t : T?) {
         let grew = heap_bytes_allocated() - before
         t |> equal(grew, uint64(long_capacity(g_dst)) * 4ul)   // eager: the bit moved with the buffer
     }
-    t |> run("delete clears the bit") @(t : T?) {
+    t |> run("delete clears the bit - grown and never-grown alike") @(t : T?) {
+        // never-grown: no backing store to free, but delete still resets the mark
         unsafe(g_deleted |> set_scratch(true))
-        // reserve before delete is load-bearing: builtin_array_free's memset sits under
-        // `if (dim.data)`, so deleting a never-grown array leaves the flags word untouched
+        delete g_deleted
+        t |> equal(is_scratch(g_deleted), false)
+        unsafe(g_deleted |> set_scratch(true))
         g_deleted |> reserve(16l)
         delete g_deleted
         t |> equal(is_scratch(g_deleted), false)

--- a/tests/language/scratch_very_safe_array.das
+++ b/tests/language/scratch_very_safe_array.das
@@ -1,0 +1,123 @@
+options gen2
+options persistent_heap = true
+options very_safe_context
+
+// scope: the array half of the scratch flag under very_safe_context
+// heap: persistent, 16-byte accounting, no pow2 bucketing - array asserts are exact
+// ladder: reserve 16..4096 of array<int> - every generation a 16-multiple
+// eager expectation: cap*4 (only the final generation lives)
+// deferred expectation: cap*8 - 64 (the whole ladder lives)
+// windows: `before` is the arm's first statement, at capacity 0; ladders are fixed_array (stack)
+
+require dastest/testing_boost public
+
+// one global per arm: a stack-promoted local never reaches array_reserve at all,
+// and the arm would read green against a broken predicate
+var g_eager : array<int>
+var g_deferred : array<int>
+var g_oneshot_unmarked : array<int>
+var g_oneshot_marked : array<int>
+var g_src : array<int>
+var g_dst : array<int>
+var g_deleted : array<int>
+var g_cleared : array<int>
+var g_unmarked : array<int>
+
+[test]
+def test_scratch_eager_vs_deferred(t : T?) {
+    t |> run("very_safe + scratch takes the eager realloc/free arm") @(t : T?) {
+        let before = heap_bytes_allocated()
+        unsafe(g_eager |> set_scratch(true))
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_eager |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(long_capacity(g_eager), 4096l)
+        t |> equal(grew, uint64(long_capacity(g_eager)) * 4ul)   // 16384
+    }
+    t |> run("no scratch defers - every generation stays live") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_deferred |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(long_capacity(g_deferred), 4096l)
+        t |> equal(grew, uint64(long_capacity(g_deferred)) * 8ul - 64ul)   // 32704
+    }
+    t |> run("set_scratch(false) re-arms the deferral") @(t : T?) {
+        let before = heap_bytes_allocated()
+        unsafe(g_unmarked |> set_scratch(true))
+        unsafe(g_unmarked |> set_scratch(false))
+        t |> equal(is_scratch(g_unmarked), false)
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_unmarked |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_unmarked)) * 8ul - 64ul)   // deferred: the clear took
+    }
+}
+
+[test]
+def test_scratch_reserve_forces_eager(t : T?) {
+    t |> run("scratch_reserve is eager with the bit unset") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            unsafe(g_oneshot_unmarked |> scratch_reserve(c))
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_oneshot_unmarked)) * 4ul)
+        t |> equal(is_scratch(g_oneshot_unmarked), false)   // the one-shot leaves no state behind
+    }
+    t |> run("scratch_reserve is eager with the bit set too") @(t : T?) {
+        let before = heap_bytes_allocated()
+        unsafe(g_oneshot_marked |> set_scratch(true))
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            unsafe(g_oneshot_marked |> scratch_reserve(c))
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_oneshot_marked)) * 4ul)
+    }
+}
+
+[test]
+def test_scratch_lifecycle(t : T?) {
+    t |> run("the bit survives a move") @(t : T?) {
+        let before = heap_bytes_allocated()
+        unsafe(g_src |> set_scratch(true))
+        g_src |> reserve(16l)
+        g_dst <- g_src   // nolint:PERF030 — the target global is fresh-empty; struct copied wholesale, source zeroed
+        t |> equal(long_capacity(g_src), 0l)
+        for (c in fixed_array(32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_dst |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_dst)) * 4ul)   // eager: the bit moved with the buffer
+    }
+    t |> run("delete clears the bit") @(t : T?) {
+        unsafe(g_deleted |> set_scratch(true))
+        // reserve before delete is load-bearing: builtin_array_free's memset sits under
+        // `if (dim.data)`, so deleting a never-grown array leaves the flags word untouched
+        g_deleted |> reserve(16l)
+        delete g_deleted
+        t |> equal(is_scratch(g_deleted), false)
+        let before = heap_bytes_allocated()
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_deleted |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_deleted)) * 8ul - 64ul)   // deferred again
+    }
+    t |> run("clear keeps the bit - the recycled-queue pattern") @(t : T?) {
+        let before = heap_bytes_allocated()
+        unsafe(g_cleared |> set_scratch(true))
+        g_cleared |> reserve(16l)
+        g_cleared |> resize(16l)
+        g_cleared |> clear()   // size=0 only; capacity and flags untouched
+        t |> equal(is_scratch(g_cleared), true)
+        for (c in fixed_array(32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_cleared |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_cleared)) * 4ul)   // still eager
+    }
+}

--- a/tests/language/scratch_very_safe_array.das
+++ b/tests/language/scratch_very_safe_array.das
@@ -7,7 +7,9 @@ options very_safe_context
 // ladder: reserve 16..4096 of array<int> - every generation a 16-multiple
 // eager expectation: cap*4 (only the final generation lives)
 // deferred expectation: cap*8 - 64 (the whole ladder lives)
-// windows: `before` is the arm's first statement, at capacity 0; ladders are fixed_array (stack)
+// windows: a window holds only set_scratch (allocates nothing) and reserves - any
+// resize/clear stays OUTSIDE, since first-in-context they can lazily allocate
+// instrument state under the CI Coverage rig; ladders are fixed_array (stack)
 
 require dastest/testing_boost public
 
@@ -110,16 +112,20 @@ def test_scratch_lifecycle(t : T?) {
         t |> equal(grew, uint64(long_capacity(g_deleted)) * 8ul - 64ul)   // deferred again
     }
     t |> run("clear keeps the bit - the recycled-queue pattern") @(t : T?) {
-        let before = heap_bytes_allocated()
+        // setup stays OUTSIDE the window: under the CI Coverage rig, first-in-context
+        // resize/clear can lazily allocate instrument state (+144 bytes each, linux
+        // directory sweep) - the window holds only the ladder, the actual instrument
         unsafe(g_cleared |> set_scratch(true))
         g_cleared |> reserve(16l)
         g_cleared |> resize(16l)
         g_cleared |> clear()   // size=0 only; capacity and flags untouched
         t |> equal(is_scratch(g_cleared), true)
+        let before = heap_bytes_allocated()
         for (c in fixed_array(32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
             g_cleared |> reserve(c)
         }
         let grew = heap_bytes_allocated() - before
-        t |> equal(grew, uint64(long_capacity(g_cleared)) * 4ul)   // still eager
+        // still eager; -64 = the pre-window 16-cap buffer, freed at the first regrow
+        t |> equal(grew, uint64(long_capacity(g_cleared)) * 4ul - 64ul)
     }
 }

--- a/tests/language/scratch_very_safe_table.das
+++ b/tests/language/scratch_very_safe_table.das
@@ -1,0 +1,60 @@
+options gen2
+options persistent_heap = true
+options very_safe_context
+
+// scope: the table half of the scratch flag under very_safe_context
+// growth: insert-driven only - table reserve jumps to the final pow2 in one allocation
+// layout: perSlot is internal policy, so no byte count is pinned - ratios + self-calibration
+// rehash-survival: an isolated grow's eager delta equals the old block, measured by this test
+
+require dastest/testing_boost public
+
+var g_eager : table<int; int>
+var g_deferred : table<int; int>
+var g_unmarked : table<int; int>
+
+[test]
+def test_scratch_table(t : T?) {
+    t |> run("eager free on rehash, deferred without, bit rides every rehash") @(t : T?) {
+        // eager: 500 inserts drive growth 8 -> 1024; old blocks freed at each rehash
+        let b0 = heap_bytes_allocated()
+        unsafe(g_eager |> set_scratch(true))
+        for (i in range(500)) {
+            g_eager[i] = i
+        }
+        let grewEager = heap_bytes_allocated() - b0
+        t |> equal(long_capacity(g_eager), 1024l)
+        t |> equal(is_scratch(g_eager), true)
+        // deferred: the identical insert run leaves every generation live
+        t |> equal(is_scratch(g_deferred), false)
+        let b1 = heap_bytes_allocated()
+        for (i in range(500)) {
+            g_deferred[i] = i
+        }
+        let grewDeferred = heap_bytes_allocated() - b1
+        t |> equal(long_capacity(g_deferred), 1024l)
+        t |> success(grewEager < grewDeferred, "deferred must retain more than eager")
+        t |> success(grewDeferred >= grewEager * 3ul / 2ul, "deferred ~2x eager: the generation ladder stays live")
+        // set_scratch(false) re-arms the deferral: same shape as the deferred run, so the
+        // deltas must be exactly equal
+        let b2 = heap_bytes_allocated()
+        unsafe(g_unmarked |> set_scratch(true))
+        unsafe(g_unmarked |> set_scratch(false))
+        t |> equal(is_scratch(g_unmarked), false)
+        for (i in range(500)) {
+            g_unmarked[i] = i
+        }
+        let grewUnmarked = heap_bytes_allocated() - b2
+        t |> equal(grewUnmarked, grewDeferred)
+        // the bit survives every newTab.flags copy + swap of those rehashes: one more
+        // isolated grow 1024 -> 2048. Eager delta = new(2x) - freed old(1x) = old block,
+        // which is exactly what grewEager measured; a lost bit would read 2x that.
+        let b3 = heap_bytes_allocated()
+        for (i in range(500, 700)) {
+            g_eager[i] = i
+        }
+        let lateDelta = heap_bytes_allocated() - b3
+        t |> equal(long_capacity(g_eager), 2048l)
+        t |> equal(lateDelta, grewEager)
+    }
+}

--- a/tests/language/scratch_very_safe_table.das
+++ b/tests/language/scratch_very_safe_table.das
@@ -12,6 +12,7 @@ require dastest/testing_boost public
 var g_eager : table<int; int>
 var g_deferred : table<int; int>
 var g_unmarked : table<int; int>
+var g_deleted : table<int; int>
 
 [test]
 def test_scratch_table(t : T?) {
@@ -56,5 +57,15 @@ def test_scratch_table(t : T?) {
         let lateDelta = heap_bytes_allocated() - b3
         t |> equal(long_capacity(g_eager), 2048l)
         t |> equal(lateDelta, grewEager)
+    }
+    t |> run("delete clears the bit - grown and never-grown alike") @(t : T?) {
+        // never-grown: no backing store to free, but delete still resets the mark
+        unsafe(g_deleted |> set_scratch(true))
+        delete g_deleted
+        t |> equal(is_scratch(g_deleted), false)
+        unsafe(g_deleted |> set_scratch(true))
+        g_deleted[1] = 1
+        delete g_deleted
+        t |> equal(is_scratch(g_deleted), false)
     }
 }

--- a/tests/strudel/test_midi_player.das
+++ b/tests/strudel/test_midi_player.das
@@ -116,6 +116,8 @@ def test_playback(tt : T?) {
         var midi <- parse_midi(d)
         var state = MidiPlaybackState()
         init_playback(state, unsafe(addr(midi)), "test", 1.0, false)
+        tt |> success(is_scratch(state.voices), "voice pool marked scratch at init")
+        tt |> success(is_scratch(state.csf2_voices), "sf2 voice pool marked scratch at init")
         var has_sound = false
         for (_ in range(20)) {
             var chunk <- midi_tick(state, 0.05)

--- a/tests/strudel/test_scratch_pools.das
+++ b/tests/strudel/test_scratch_pools.das
@@ -1,0 +1,61 @@
+options gen2
+options indenting = 4
+options persistent_heap = true
+options very_safe_context
+
+// scope: the audio opt-in half of the scratch flag
+// marks: scheduler pools/buffers + each orbit bus's send/return buffers, set at construction
+// seams: mark_pools_scratch / mark_orbit_scratch run directly (the player's instances are
+//        private); fade_orbit is the public path through ensure_orbit
+// proof: one eager-math arm on a marked field (only the final generation lives)
+
+require dastest/testing_boost public
+require strudel/strudel_scheduler
+
+var g_sched : Scheduler
+var g_orbit_sched : Scheduler
+
+[test]
+def test_scheduler_pools_marked(t : T?) {
+    t |> run("mark_pools_scratch marks every pool and buffer") @(t : T?) {
+        mark_pools_scratch(g_sched)
+        t |> success(is_scratch(g_sched.voices), "voices")
+        t |> success(is_scratch(g_sched.osc_voices), "osc_voices")
+        t |> success(is_scratch(g_sched.output), "output")
+        t |> success(is_scratch(g_sched.sf2_voices), "sf2_voices")
+        t |> success(is_scratch(g_sched.sf2_meta), "sf2_meta")
+        t |> success(is_scratch(g_sched.orbit_buses), "orbit_buses")
+        t |> success(is_scratch(g_sched.voice_fx_buf), "voice_fx_buf")
+        t |> success(is_scratch(g_sched.hrtf_mono_buf), "hrtf_mono_buf")
+        t |> success(is_scratch(g_sched.hrtf_stereo_buf), "hrtf_stereo_buf")
+        t |> success(is_scratch(g_sched.hrtf_stereo_buf_r), "hrtf_stereo_buf_r")
+    }
+    t |> run("a marked pool grows eagerly under very_safe") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (c in fixed_array(16l, 32l, 64l, 128l, 256l, 512l, 1024l, 2048l, 4096l)) {
+            g_sched.output |> reserve(c)
+        }
+        let grew = heap_bytes_allocated() - before
+        t |> equal(grew, uint64(long_capacity(g_sched.output)) * 4ul)   // only the final generation lives
+    }
+}
+
+[test]
+def test_orbit_bus_marked(t : T?) {
+    t |> run("mark_orbit_scratch marks the six send/return buffers") @(t : T?) {
+        var bus : OrbitBus   // no inscope: nothing here allocates, and finalizing the raw FX pointers needs unsafe
+        mark_orbit_scratch(bus)
+        t |> success(is_scratch(bus.reverb_send_buf), "reverb_send_buf")
+        t |> success(is_scratch(bus.reverb_out_buf), "reverb_out_buf")
+        t |> success(is_scratch(bus.delay_send_buf), "delay_send_buf")
+        t |> success(is_scratch(bus.delay_out_buf), "delay_out_buf")
+        t |> success(is_scratch(bus.chorus_send_buf), "chorus_send_buf")
+        t |> success(is_scratch(bus.chorus_out_buf), "chorus_out_buf")
+    }
+    t |> run("a bus built through ensure_orbit arrives marked") @(t : T?) {
+        fade_orbit(g_orbit_sched, 0, 1.0, 0.0)   // public path: creates orbit 0 on demand
+        t |> success(g_orbit_sched.orbit_buses[0] != null, "bus exists")
+        t |> success(is_scratch(g_orbit_sched.orbit_buses[0].reverb_send_buf), "reverb_send_buf")
+        t |> success(is_scratch(g_orbit_sched.orbit_buses[0].chorus_out_buf), "chorus_out_buf")
+    }
+}

--- a/tests/strudel/test_scratch_pools.das
+++ b/tests/strudel/test_scratch_pools.das
@@ -18,7 +18,7 @@ var g_orbit_sched : Scheduler
 [test]
 def test_scheduler_pools_marked(t : T?) {
     t |> run("mark_pools_scratch marks every pool and buffer") @(t : T?) {
-        mark_pools_scratch(g_sched)
+        unsafe(mark_pools_scratch(g_sched))
         t |> success(is_scratch(g_sched.voices), "voices")
         t |> success(is_scratch(g_sched.osc_voices), "osc_voices")
         t |> success(is_scratch(g_sched.output), "output")
@@ -44,7 +44,7 @@ def test_scheduler_pools_marked(t : T?) {
 def test_orbit_bus_marked(t : T?) {
     t |> run("mark_orbit_scratch marks the six send/return buffers") @(t : T?) {
         var bus : OrbitBus   // no inscope: nothing here allocates, and finalizing the raw FX pointers needs unsafe
-        mark_orbit_scratch(bus)
+        unsafe(mark_orbit_scratch(bus))
         t |> success(is_scratch(bus.reverb_send_buf), "reverb_send_buf")
         t |> success(is_scratch(bus.reverb_out_buf), "reverb_out_buf")
         t |> success(is_scratch(bus.delay_send_buf), "delay_send_buf")


### PR DESCRIPTION
**Behavior change for `options very_safe_context` programs: the archive writer, the strudel scheduler/MIDI pools, and the SF3 decode accumulator now free old buffers eagerly on growth. Also fixes the paranoid tune mint, broken on every box since the `max_unreserved_size` guard landed.**

The tuner half: `bench_dot`'s DRAM-streaming walk resized to 128 MB from empty, so the kernel scope of every mint died on the guard 27 seconds in. Both oversized race buffers now `reserve_resize`. The refreshed `last_known_good_sidecar.json` is the first complete post-pin mint (paranoid, `dasllama_version 2`).

A rider defuses a fixture landmine the version pin armed: `test_exchange_schema.das` pinned `dasllama_version == 0` for every current-format sidecar in `records/`, so the first fixture refresh after the pin would red through no fault of the refresher. Each sidecar now takes the claim its own counter earns — unstamped refused at submission grade, stamped must clear it. All 11 corpus sidecars are unstamped today, so behavior is unchanged until a stamped fixture lands.

The feature half: `very_safe_context` defers container-growth frees to GC so stale interior aliases stay readable. The cost is churn — every grow episode abandons a doubling ladder that sums to roughly one payload, and nothing reuses it until `heap_collect`. Trusted internal buffers that never leak an interior reference pay this for nothing. Two `unsafe` primitives carve the exception per container: a `scratch` bit (`set_scratch`/`is_scratch`) set once on containers user code can never reach, and one-shot eager grows (`scratch_reserve`/`scratch_ensure_capacity`/`scratch_resize`) for trusted growth sites on containers later handed out — no state left behind. Growth funnels through exactly two allocation sites in every execution tier, so the flag consults live in those two predicates. `array_reserve` keeps its public signature; `array_reserve_scratch` is additive. The sandbox withholds `unsafe` from user code, so the escape stays in trusted hands.

The added condition sits on the amortized grow slow path — not the per-node eval hot path — and short-circuits behind `verySafeContext` (default off). The rejected alternative was a per-context option, which cannot exempt one container. dasLLAMA's unrelated no-init sizing helper renames to `overwrite_resize` to clear the name.

Where to look: the two predicates (`src/simulate/runtime_array.cpp` `array_reserve_impl`, `include/daScript/simulate/runtime_table.h:566`), the `daslib/builtin.das` scratch generics, `daslib/archive.das` `MemSerializer.write`, and the strudel construction seats (`mark_pools_scratch`/`mark_orbit_scratch` in `strudel_scheduler.das`).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full preflight ran once: 16/18 gates green. The two red lanes were diagnosed and fixed with targeted validation, not a re-run: tests-jit failed on stale `.jitted_scripts` DLLs from the pre-feature binary (cache wiped; the cold full-root `-jit` sweep then passed 13,484/13,484), and tests-aot failed because `tests/strudel` is a hand-enumerated AOT list, not a glob — the new test file is now registered, `test_aot` rebuilt, and the previously failing form plus the full strudel and archive AOT slices pass.
- The tuner `reserve_resize` swaps are settled by a complete paranoid mint on the M1 — the run this PR's `last_known_good_sidecar.json` is the output of. There is no in-suite test for the tuner's own benches; the mint is the only proof, and CI cannot produce it.
- Sidecar figures (crown moves, noise floors) are rig-internal tuner margins carrying their own provenance in the sidecar (`engine_sha`, `dasllama_version`, box, mode, validation re-race); no serving-level timing claims are made.
- Six negative controls ran locally (Release): reverting the archive opt-in, rerouting `scratch_reserve` to the plain builtin, dropping one `unsafe` gate, dropping one pool mark, dropping `!arr.scratch` from the array predicate, and reverting the table rehash condition — each turned exactly its named test red, then was restored and re-verified green.
- dasLLAMA model-free test set ran under `-jit` (its checklist's required tier), all green, including `test_sizing_helpers` over the renamed helper.
- The exchange-test rider was controlled both ways under `-jit`: a temporary stamped sidecar dropped into `records/` passes through the new submission-grade arm, and the same probe against the old assert reds at exactly the pinned line.
- AST-verify sweep over daslib+tests: the only reports are pre-existing fixture warts (typemacro/delegate/distinct), reproduced with master's daslib as the control; none touch this diff.

### Claims — stated, not tested
- The `overwrite_resize` rename is identifier-only: bodies byte-identical to master's, verified by diff inspection; a rename miss could not be silent — the reverse control (old test against new code) fails with `31013` compile errors because the new same-named builtin is unsafe-gated with different semantics.
- Three scratch-mark call sites have no test observable: `init_track` (private, its `mark_pools_scratch` callee is fully asserted), `midi_thread_main`'s thread-local marks (no test drives the thread entry), and the SF3 decode mark/unmark pair (needs an OGG-compressed SF3 fixture that does not exist; the `set_scratch(false)` primitive it relies on is unit-distinguished both ways). A break would show as very-safe churn regressing in those paths, not as wrong audio.

### Not done
- No sanctioned-carve-out edits to the four REVIEW.md checklists this diff is bound by; their self-review findings from this round are reported separately.
- `tests/strudel` has no README index section (the directory is not indexed); the new test follows the folder convention.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)