### PR TITLE
nightly reds: frame positions stamp sim nodes, never the AST; doc-verify spawns the running binary

### DIFF
--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -18,6 +18,7 @@ Lint Tools
 .. das-doc: given struct Session { pos : int64 }
 .. das-doc: given struct SomeStruct { value : int64 }
 .. das-doc: given struct Foo { x : int }
+.. das-doc: given struct State { mark : int; claimed : array<int> }
 .. das-doc: given def compute() : int { return 0 }
 .. das-doc: given def report(ok : bool) { }
 .. das-doc: given def process(v : int) { }

--- a/doc/source/reference/language/very_safe_context.rst
+++ b/doc/source/reference/language/very_safe_context.rst
@@ -8,6 +8,11 @@ Very safe context
 .. index::
     single: Very Safe Context
 
+.. das-doc: given struct Voice { id : int }
+.. das-doc: given var data : array<uint8>
+.. das-doc: given var pos : int
+.. das-doc: given var size : int
+
 Daslang prioritizes runtime performance and development speed over absolute safety.
 Outside of ``unsafe`` blocks the language enforces safety checks that prevent common programming errors,
 but certain fundamentally unsafe patterns cannot be eliminated without sacrificing performance.

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1528,16 +1528,15 @@ namespace das
         void appendLocalVariables ( FuncInfo * info, ExpressionPtr body );
         void appendGlobalVariables ( FuncInfo * info, const FunctionPtr & body );
         void stampFramePositions ( ExpressionPtr body, uint32_t spaceId );
-        // writes the recorded frame position of `expr` into a sim node's own LineInfo copy;
-        // no-op for unrecorded expressions or outside a stamped function's simulate. the AST's
-        // `at` is never written - it outlives simulate (macro modules, lint, LSP)
+        // no-op for unrecorded expressions or outside a stamped function's simulate.
+        // the AST's `at` is never written - it outlives simulate (macro modules, lint, LSP)
         void stampSimNode ( const Expression * expr, LineInfo & nodeAt );
         void logMemInfo ( TextWriter & tw );
     public:
         shared_ptr<DebugInfoAllocator>  debugInfo;
         das_hash_map<Variable *, FramePosInterval> varFramePos;    // filled by stampFramePositions, read by appendLocalVariables
         das_hash_map<const Expression *, uint32_t> exprFramePos;   // filled by stampFramePositions, read by stampSimNode
-        uint32_t currentTaggedSpace = 0;    // LINEINFO_FRAME_POS_TAG | spaceId of the function being simulated; 0 = stamping off
+        bool framePosStamping = false;  // on from stampFramePositions until the last function's sim nodes are built
         uint32_t currentSpaceId = 0;    // owner of the function being simulated; block frames inherit it
     public:
         das_hash_map<string,StructInfo *>        smn2s;

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1528,10 +1528,16 @@ namespace das
         void appendLocalVariables ( FuncInfo * info, ExpressionPtr body );
         void appendGlobalVariables ( FuncInfo * info, const FunctionPtr & body );
         void stampFramePositions ( ExpressionPtr body, uint32_t spaceId );
+        // writes the recorded frame position of `expr` into a sim node's own LineInfo copy;
+        // no-op for unrecorded expressions or outside a stamped function's simulate. the AST's
+        // `at` is never written - it outlives simulate (macro modules, lint, LSP)
+        void stampSimNode ( const Expression * expr, LineInfo & nodeAt );
         void logMemInfo ( TextWriter & tw );
     public:
         shared_ptr<DebugInfoAllocator>  debugInfo;
         das_hash_map<Variable *, FramePosInterval> varFramePos;    // filled by stampFramePositions, read by appendLocalVariables
+        das_hash_map<const Expression *, uint32_t> exprFramePos;   // filled by stampFramePositions, read by stampSimNode
+        uint32_t currentTaggedSpace = 0;    // LINEINFO_FRAME_POS_TAG | spaceId of the function being simulated; 0 = stamping off
         uint32_t currentSpaceId = 0;    // owner of the function being simulated; block frames inherit it
     public:
         das_hash_map<string,StructInfo *>        smn2s;

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -25,17 +25,18 @@ namespace das {
     };
 
     // numbers the FINAL tree in dense preorder; a local's interval opens after its own
-    // init subtree and closes with its scope
+    // init subtree and closes with its scope. positions land in a side map, never in the
+    // AST's `at` - SimulateVisitor stamps them onto each expression's own sim node copy
     class FramePositionStamp : public Visitor {
     public:
-        FramePositionStamp ( das_hash_map<Variable *, FramePosInterval> & vfp, uint32_t spaceId )
-            : intervals(vfp), taggedSpace(LINEINFO_FRAME_POS_TAG | spaceId) {}
+        FramePositionStamp ( das_hash_map<Variable *, FramePosInterval> & vfp,
+                das_hash_map<const Expression *, uint32_t> & efp )
+            : intervals(vfp), positions(efp) {}
         virtual bool canVisitQuoteSubexpression ( ExprQuote * ) override { return false; }
         virtual void preVisitExpression ( Expression * expr ) override {
             Visitor::preVisitExpression(expr);
             pos ++;
-            expr->at.last_line = taggedSpace;
-            expr->at.last_column = pos;
+            positions[expr] = pos;
         }
         virtual void preVisit ( ExprBlock * block ) override {
             Visitor::preVisit(block);
@@ -75,9 +76,9 @@ namespace das {
         }
     public:
         das_hash_map<Variable *, FramePosInterval> & intervals;
+        das_hash_map<const Expression *, uint32_t> & positions;
         vector<vector<Variable *>> scopes;
         vector<Variable *> bodyVars;
-        uint32_t taggedSpace = 0;
         uint32_t pos = 0;
         bool sawLabel = false;
     };
@@ -107,7 +108,9 @@ namespace das {
         // this function's consumers (its own appendLocalVariables + per-block appends
         // during its simulate) all run before the next stamp - no need to keep the rest
         varFramePos.clear();
-        FramePositionStamp stamp(varFramePos, spaceId);
+        exprFramePos.clear();
+        currentTaggedSpace = LINEINFO_FRAME_POS_TAG | spaceId;
+        FramePositionStamp stamp(varFramePos, exprFramePos);
         body->visit(stamp);
         if ( stamp.sawLabel ) {
             // a labeled body (generator lowering) admits jumps into intervals - keep every
@@ -116,6 +119,14 @@ namespace das {
             // reach this valve - it guards future label-emitting transforms
             for ( auto v : stamp.bodyVars ) varFramePos[v] = { 0u, ~0u };
         }
+    }
+
+    void DebugInfoHelper::stampSimNode ( const Expression * expr, LineInfo & nodeAt ) {
+        if ( !currentTaggedSpace ) return;
+        auto it = exprFramePos.find(expr);
+        if ( it == exprFramePos.end() ) return;
+        nodeAt.last_line = currentTaggedSpace;
+        nodeAt.last_column = it->second;
     }
 
     void DebugInfoHelper::appendLocalVariables ( FuncInfo * info, ExpressionPtr body ) {

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -25,8 +25,7 @@ namespace das {
     };
 
     // numbers the FINAL tree in dense preorder; a local's interval opens after its own
-    // init subtree and closes with its scope. positions land in a side map, never in the
-    // AST's `at` - SimulateVisitor stamps them onto each expression's own sim node copy
+    // init subtree and closes with its scope
     class FramePositionStamp : public Visitor {
     public:
         FramePositionStamp ( das_hash_map<Variable *, FramePosInterval> & vfp,
@@ -109,7 +108,8 @@ namespace das {
         // during its simulate) all run before the next stamp - no need to keep the rest
         varFramePos.clear();
         exprFramePos.clear();
-        currentTaggedSpace = LINEINFO_FRAME_POS_TAG | spaceId;
+        framePosStamping = true;
+        currentSpaceId = spaceId;
         FramePositionStamp stamp(varFramePos, exprFramePos);
         body->visit(stamp);
         if ( stamp.sawLabel ) {
@@ -122,10 +122,10 @@ namespace das {
     }
 
     void DebugInfoHelper::stampSimNode ( const Expression * expr, LineInfo & nodeAt ) {
-        if ( !currentTaggedSpace ) return;
+        if ( !framePosStamping ) return;
         auto it = exprFramePos.find(expr);
         if ( it == exprFramePos.end() ) return;
-        nodeAt.last_line = currentTaggedSpace;
+        nodeAt.last_line = LINEINFO_FRAME_POS_TAG | currentSpaceId;
         nodeAt.last_column = it->second;
     }
 

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -145,9 +145,7 @@ namespace das
 
         void setE ( const Expression * e, SimNode * n ) {
             e2v[e] = n;
-            // under gc/debugger the node's own LineInfo copy carries the expression's
-            // frame position (the GC locals gate and LineInfoArg externs read it via
-            // &node->debugInfo); the AST's `at` stays honest
+            // the GC locals gate and LineInfoArg externs read the position via &node->debugInfo
             if ( n && context.thisHelper ) context.thisHelper->stampSimNode(e, n->debugInfo);
         }
 
@@ -1459,8 +1457,7 @@ namespace das
             }
         }
         pInvoke->debugInfo = at;
-        // same as sv_simulateCall: the keep-alive wrapper takes setE, the invoke node's
-        // own debugInfo is the handoff the invoked frame reads
+        // the invoked frame reads &pInvoke->debugInfo, not the keep-alive wrapper setE gets
         if ( context.thisHelper ) context.thisHelper->stampSimNode(expr, pInvoke->debugInfo);
         int nArg = (int) expr->arguments.size();
         if ( expr->isInvokeMethod ) nArg --;
@@ -3830,9 +3827,8 @@ namespace das
                         // number the body BEFORE building sim nodes and locals info: the
                         // positions stamp each expression's sim node as it is built (see
                         // SimulateVisitor::setE), and the intervals feed the locals gate
-                        // (see LocalVariableInfo::openPos). the AST's `at` is never written
+                        // (see LocalVariableInfo::openPos)
                         gfun.debugInfo->spaceId = frameSpaceId(pfun->index);
-                        helper.currentSpaceId = gfun.debugInfo->spaceId;
                         helper.stampFramePositions(pfun->body, gfun.debugInfo->spaceId);
                         helper.appendLocalVariables(gfun.debugInfo, pfun->body);
                         helper.appendGlobalVariables(gfun.debugInfo, pfun);
@@ -3858,10 +3854,9 @@ namespace das
                     lookupFunctionTable.push_back(pfun);
                 });
             }
-            // stamping off past the last function - global inits and annotation simulate
-            // build nodes outside any position space
+            // global inits and annotation simulate build nodes outside any position space
             helper.exprFramePos.clear();
-            helper.currentTaggedSpace = 0;
+            helper.framePosStamping = false;
         }
         if ( totalVariables ) {
             for (auto & pm : library.modules ) {

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -145,6 +145,10 @@ namespace das
 
         void setE ( const Expression * e, SimNode * n ) {
             e2v[e] = n;
+            // under gc/debugger the node's own LineInfo copy carries the expression's
+            // frame position (the GC locals gate and LineInfoArg externs read it via
+            // &node->debugInfo); the AST's `at` stays honest
+            if ( n && context.thisHelper ) context.thisHelper->stampSimNode(e, n->debugInfo);
         }
 
         SimNode * getE ( const Expression * e ) {
@@ -1455,6 +1459,9 @@ namespace das
             }
         }
         pInvoke->debugInfo = at;
+        // same as sv_simulateCall: the keep-alive wrapper takes setE, the invoke node's
+        // own debugInfo is the handoff the invoked frame reads
+        if ( context.thisHelper ) context.thisHelper->stampSimNode(expr, pInvoke->debugInfo);
         int nArg = (int) expr->arguments.size();
         if ( expr->isInvokeMethod ) nArg --;
         if ( nArg ) {
@@ -3457,6 +3464,9 @@ namespace das
                 needTypeInfo = true;
         }
         pCall->debugInfo = expr->at;
+        // stamp here as well as setE: a wrapped call (keep-alive, NewArray) hands the
+        // WRAPPER to setE, but &pCall->debugInfo is what reaches the callee's prologue
+        if ( context.thisHelper ) context.thisHelper->stampSimNode(expr, pCall->debugInfo);
         if ( func->builtIn) {
             pCall->fnPtr = nullptr;
         } else if ( func->index>=0 ) {
@@ -3817,9 +3827,10 @@ namespace das
                         gfun.debugInfo->flags &= ~ (FuncInfo::flag_init | FuncInfo::flag_shutdown);
                     }
                     if ( debuggerOrGC ) {
-                        // stamp BEFORE building sim nodes and locals info: the sim `at`
-                        // copies inherit the frame positions, and the intervals feed the
-                        // locals gate (see LocalVariableInfo::openPos)
+                        // number the body BEFORE building sim nodes and locals info: the
+                        // positions stamp each expression's sim node as it is built (see
+                        // SimulateVisitor::setE), and the intervals feed the locals gate
+                        // (see LocalVariableInfo::openPos). the AST's `at` is never written
                         gfun.debugInfo->spaceId = frameSpaceId(pfun->index);
                         helper.currentSpaceId = gfun.debugInfo->spaceId;
                         helper.stampFramePositions(pfun->body, gfun.debugInfo->spaceId);
@@ -3847,6 +3858,10 @@ namespace das
                     lookupFunctionTable.push_back(pfun);
                 });
             }
+            // stamping off past the last function - global inits and annotation simulate
+            // build nodes outside any position space
+            helper.exprFramePos.clear();
+            helper.currentTaggedSpace = 0;
         }
         if ( totalVariables ) {
             for (auto & pm : library.modules ) {

--- a/tests-cpp/small/test_frame_pos_unstamp.cpp
+++ b/tests-cpp/small/test_frame_pos_unstamp.cpp
@@ -1,0 +1,56 @@
+// Frame-position stamps (position-based GC liveness) must live on the sim-side
+// LineInfo copies only. The AST outlives simulate — macro modules, lint, and the
+// LSP read expression spans after a gc/debugger context is built — so a stamp
+// left on Expression::at corrupts every at-keyed consumer (STYLE038 reported
+// 2^31-line functions in daslib/debug.das).
+
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/ast/ast_visitor.h"
+#include "daScript/simulate/debug_info.h"
+
+using namespace das;
+
+#define SCRIPT_PATH "/tests-cpp/small/test_frame_pos_unstamp.das"
+
+namespace {
+    struct StampScan : Visitor {
+        uint32_t tagged = 0;
+        virtual void preVisitExpression ( Expression * expr ) override {
+            Visitor::preVisitExpression(expr);
+            if ( expr->at.last_line & LINEINFO_FRAME_POS_TAG ) tagged ++;
+        }
+    };
+}
+
+TEST_CASE("frame-position stamps live on sim nodes, not the AST") {
+    TextPrinter tout;
+    ModuleGroup dummyLibGroup;
+    auto fAccess = make_smart<FsFileAccess>();
+    auto program = compileDaScript(getDasRoot() + SCRIPT_PATH,
+                                   fAccess, tout, dummyLibGroup);
+    REQUIRE_FALSE(program->failed());
+
+    Context ctx(program->getContextStackSize());
+    REQUIRE(program->simulate(ctx, tout));
+    REQUIRE(bool(ctx.gcEnabled));   // `options gc` armed the stamping path
+
+    // sim-side copies keep the stamp: frame_position() reads the call site's
+    // runtime LineInfo, 0 means the stamp never reached the sim nodes
+    auto fn = ctx.findFunction("stamped_position");
+    REQUIRE(fn);
+    int32_t pos = cast<int32_t>::to(ctx.evalWithCatch(fn, nullptr));
+    CHECK_MESSAGE(ctx.getException() == nullptr, "stamped_position panicked");
+    CHECK_MESSAGE(pos > 0, "sim-side call site lost its frame-position stamp");
+
+    // the AST leaves simulate honest: no expression may still carry the tag
+    uint32_t tagged = 0;
+    program->thisModule->functions.foreach([&](auto pfun){
+        if ( !pfun->body ) return;
+        StampScan scan;
+        pfun->body->visit(scan);
+        tagged += scan.tagged;
+    });
+    CHECK_MESSAGE(tagged == 0, "AST expressions still stamped after simulate");
+}

--- a/tests-cpp/small/test_frame_pos_unstamp.cpp
+++ b/tests-cpp/small/test_frame_pos_unstamp.cpp
@@ -1,8 +1,6 @@
-// Frame-position stamps (position-based GC liveness) must live on the sim-side
-// LineInfo copies only. The AST outlives simulate — macro modules, lint, and the
-// LSP read expression spans after a gc/debugger context is built — so a stamp
-// left on Expression::at corrupts every at-keyed consumer (STYLE038 reported
-// 2^31-line functions in daslib/debug.das).
+// Frame-position stamps must live on the sim-side LineInfo copies only: the AST outlives
+// simulate, so a stamp left on Expression::at makes every at-keyed consumer - macro
+// modules, lint, LSP - see 2^31-line functions.
 
 #include <doctest/doctest.h>
 
@@ -36,15 +34,14 @@ TEST_CASE("frame-position stamps live on sim nodes, not the AST") {
     REQUIRE(program->simulate(ctx, tout));
     REQUIRE(bool(ctx.gcEnabled));   // `options gc` armed the stamping path
 
-    // sim-side copies keep the stamp: frame_position() reads the call site's
-    // runtime LineInfo, 0 means the stamp never reached the sim nodes
+    // frame_position() reads the call site's runtime LineInfo - 0 means the stamp
+    // never reached the sim nodes
     auto fn = ctx.findFunction("stamped_position");
     REQUIRE(fn);
     int32_t pos = cast<int32_t>::to(ctx.evalWithCatch(fn, nullptr));
     CHECK_MESSAGE(ctx.getException() == nullptr, "stamped_position panicked");
     CHECK_MESSAGE(pos > 0, "sim-side call site lost its frame-position stamp");
 
-    // the AST leaves simulate honest: no expression may still carry the tag
     uint32_t tagged = 0;
     program->thisModule->functions.foreach([&](auto pfun){
         if ( !pfun->body ) return;

--- a/tests-cpp/small/test_frame_pos_unstamp.das
+++ b/tests-cpp/small/test_frame_pos_unstamp.das
@@ -1,7 +1,8 @@
+// fixture for test_frame_pos_unstamp.cpp - see the .cpp for the scenario
 options gen2
 options gc
 
 [export]
-def stamped_position : int {
+def stamped_position() : int {
     return frame_position()
 }

--- a/tests-cpp/small/test_frame_pos_unstamp.das
+++ b/tests-cpp/small/test_frame_pos_unstamp.das
@@ -1,0 +1,7 @@
+options gen2
+options gc
+
+[export]
+def stamped_position : int {
+    return frame_position()
+}

--- a/utils/doc-verify/main.das
+++ b/utils/doc-verify/main.das
@@ -1058,6 +1058,10 @@ def compile_file_rc(cfg : Config; path : string; var output : string&) : int {
     return run_and_capture(args, output, 120.0)
 }
 
+def spawn_failure(cfg : Config) : string {
+    return "cannot spawn '{cfg.daslang}' - pass --daslang <path to the daslang binary>"
+}
+
 def first_lines(s : string; n : int) : array<string> {
     var out : array<string>
     for (l in split(s, "\n")) {
@@ -1114,7 +1118,7 @@ def check_expects(em : EmittedPage; cfg : Config; base_file : string; var rep : 
         let rc = compile_file_rc(cfg, ex_file, out)
         if (rc == -1) {
             rep.status = "red"
-            rep.errors |> push("compile spawn failed for '{cfg.daslang}' - bad --daslang path?")
+            rep.errors |> push(spawn_failure(cfg))
         } elif (rc == 0) {
             rep.status = "red"
             rep.errors |> push("expect block at :{ex.rst_line} compiled clean (expected {ex.marker_arg})")
@@ -1181,7 +1185,7 @@ def run_probes(require_lines : table<string; bool>; file_mods : table<string>; c
         var out : string
         let prc = compile_file_rc(cfg, pfile, out)
         if (prc != 0) {
-            let why = prc == -1 ? " (compile spawn failed for '{cfg.daslang}' - bad --daslang path?)" : ""
+            let why = prc == -1 ? " ({spawn_failure(cfg)})" : ""
             failures |> push((origins[idx] ? "[companion] " : "[page] ") + trim(fread(pfile)) + why)
         }
     }
@@ -1207,7 +1211,7 @@ def report_page(page_path : string; cfg : Config) : PageReport {
         if (crc != 0) {
             rep.status = "red"
             if (crc == -1) {
-                rep.errors |> push("compile spawn failed for '{cfg.daslang}' - bad --daslang path?")
+                rep.errors |> push(spawn_failure(cfg))
             } else {
                 rep.errors |> push_from(first_lines(out, 24))
             }
@@ -1232,9 +1236,8 @@ def main() : int {
     var cfg = Config()
     let rc = parse_args_with_help(cfg, "doc-verify")
     return rc if (rc >= 0)
+    // a fixed "bin/daslang" default silently spawn-fails wherever the exe lives elsewhere (bin/Release, worktrees)
     if (empty(cfg.daslang)) {
-        // the running binary - a fixed "bin/daslang" default silently spawn-fails on
-        // layouts that keep the exe elsewhere (bin/Release on MSVC, worktrees)
         cfg.daslang = get_command_line_arguments()[0]
     }
     mkdir_rec(path_join(cfg.out, "pages"))

--- a/utils/doc-verify/main.das
+++ b/utils/doc-verify/main.das
@@ -46,8 +46,8 @@ struct Config {
     @clarg_doc = "Output directory for synthetic modules and reports"
     out : string = "build/doc_verify"
 
-    @clarg_doc = "Path to the daslang binary used for compile checks"
-    daslang : string = "bin/daslang"
+    @clarg_doc = "Path to the daslang binary used for compile checks (default: the running binary)"
+    daslang : string
 
     @clarg_short = "p"
     @clarg_doc = "Only process pages whose path contains this substring"
@@ -1112,7 +1112,10 @@ def check_expects(em : EmittedPage; cfg : Config; base_file : string; var rep : 
         fwrite(ex_file, join(lines, "\n") + "\n")
         var out : string
         let rc = compile_file_rc(cfg, ex_file, out)
-        if (rc == 0) {
+        if (rc == -1) {
+            rep.status = "red"
+            rep.errors |> push("compile spawn failed for '{cfg.daslang}' - bad --daslang path?")
+        } elif (rc == 0) {
             rep.status = "red"
             rep.errors |> push("expect block at :{ex.rst_line} compiled clean (expected {ex.marker_arg})")
         } elif (!empty(ex.marker_arg) && find(out, ex.marker_arg) < 0) {
@@ -1176,8 +1179,10 @@ def run_probes(require_lines : table<string; bool>; file_mods : table<string>; c
     for (idx in range(length(origins))) {
         let pfile = path_join(probe_dir, "probe_{idx}.das")
         var out : string
-        if (compile_file_rc(cfg, pfile, out) != 0) {
-            failures |> push((origins[idx] ? "[companion] " : "[page] ") + trim(fread(pfile)))
+        let prc = compile_file_rc(cfg, pfile, out)
+        if (prc != 0) {
+            let why = prc == -1 ? " (compile spawn failed for '{cfg.daslang}' - bad --daslang path?)" : ""
+            failures |> push((origins[idx] ? "[companion] " : "[page] ") + trim(fread(pfile)) + why)
         }
     }
     return <- failures
@@ -1198,9 +1203,14 @@ def report_page(page_path : string; cfg : Config) : PageReport {
     rep.status = "green"
     for (f in em.files) {
         var out : string
-        if (compile_file_rc(cfg, f, out) != 0) {
+        let crc = compile_file_rc(cfg, f, out)
+        if (crc != 0) {
             rep.status = "red"
-            rep.errors |> push_from(first_lines(out, 24))
+            if (crc == -1) {
+                rep.errors |> push("compile spawn failed for '{cfg.daslang}' - bad --daslang path?")
+            } else {
+                rep.errors |> push_from(first_lines(out, 24))
+            }
         }
     }
     // expects append to the main page program, not an alt program
@@ -1222,6 +1232,11 @@ def main() : int {
     var cfg = Config()
     let rc = parse_args_with_help(cfg, "doc-verify")
     return rc if (rc >= 0)
+    if (empty(cfg.daslang)) {
+        // the running binary - a fixed "bin/daslang" default silently spawn-fails on
+        // layouts that keep the exe elsewhere (bin/Release on MSVC, worktrees)
+        cfg.daslang = get_command_line_arguments()[0]
+    }
     mkdir_rec(path_join(cfg.out, "pages"))
     let pages <- scan_pages(cfg)
     to_log(LOG_INFO, "doc-verify: {length(pages)} pages\n")


### PR DESCRIPTION
Both red nightlies trace to one design choice and two doc gaps. #3744 stamped frame positions into every expression's `at` at simulate time and let the sim nodes inherit the copies. The AST outlives simulate when a module compiles with the debugger on — `daslib/debug.das` installs its own agent mid-compile — so the lint pass read stamped spans and reported 124 STYLE038 findings of "2147483645-line" functions. The stamp now never touches the AST: `stampFramePositions` numbers the body into a side map (`Expression*` → preorder position), and `SimulateVisitor` stamps each expression's own sim node as it binds it — `setE` for the general case, plus the call/invoke nodes directly, because keep-alive and `NewArray` wrappers take the `setE` slot while the callee's prologue reads `&pCall->debugInfo`. Runtime carrier values are unchanged: the GC locals gate and `LineInfoArg` externs read positions through `&node->debugInfo` exactly as before, so the #3744 walk-oracle suite passes untouched.

The extended-checks reds were two pages with undeclared example types (`lint.rst`'s LINT022 `State`; `very_safe_context.rst`'s `Voice`/`data`/`pos`/`size`) — fixed with `das-doc: given` lines. Underneath them sat a doc-verify defect that had been hiding every red's cause: the hardcoded `bin/daslang` default silently spawn-fails (rc −1, page red with empty `errors[]`) on any layout that keeps the exe elsewhere (MSVC `bin/Release`, worktrees). The tool now defaults to the running binary (`argv[0]`) and a spawn failure names itself in page reports, expect checks, and rule-0 probes.

Where to look: `DebugInfoHelper::stampSimNode` + `SimulateVisitor::setE` (the mechanism), `sv_simulateCall` / `visit(ExprInvoke)` (the wrapper-hidden carriers), `tests-cpp/small/test_frame_pos_unstamp.cpp` (the invariant proven both ways: `frame_position() > 0` at runtime, tag-free AST after simulate).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local-only proof: lint on `daslib/debug.das` is 0 issues with the debug agent installing mid-compile (the nightly's exact failure); doc-verify green on both pages including the `expect error[30250]` check; `tests/gc` 136/136; full local preflight green. AOT/doc-sweep results recorded below in this PR's checks or comments.
- CI's nightly doc-verify lane passes `--daslang` explicitly, so it never takes the new default. The default and the spawn-failure arms were settled by probe: no flag → green via `argv[0]`; bogus `--daslang` → red with the explicit spawn message instead of an empty `errors[]`.

### Claims — stated, not tested
- The explicit stamps in `sv_simulateCall` / `visit(ExprInvoke)` differ from `setE`'s only when the bound node is a wrapper: `policies.keep_alive` (C++-embedder policy, no `/*option*/` marker) or `new T[N](args)` (no in-tree occurrence). A break would surface as `collectHeap` refusing frames in an embedder running keep-alive + gc.
- `check_expects` / `run_probes` spawn-failure arms are reachable (`run_and_capture` returns −1 on spawn failure) and message-only; the `report_page` arm was probed, the other two are code-identical via the shared `spawn_failure` helper.

### Not done
- `utils/doc-verify` has no test file; its new branches are probe-verified, not test-covered.
- Two rulebook findings the style audit raised against `skills/comment_style_hygiene.md` (the file-header rule's scope, and the "no incident citations" test reading backwards) are reported for review, not edited here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
