### PR TITLE
review triage becomes a spell; pr-babysit owns the github goo

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -438,6 +438,12 @@ jobs:
         set -eux
         $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/review-md/test_scan.das
 
+    - name: "Test pr-babysit verdict core"
+      if: matrix.target == 'linux'
+      run: |
+        set -eux
+        $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/pr-babysit/test_watch_verdict.das
+
     - name: "Test dasllama-server"
       # The model-gated server suites run --compile-only: this lane has no GGUF
       # and no -jit, so the value is the explicit compile guard — it exercises

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Task-specific instructions are split into skill files under `skills/`. You MUST 
 | `skills/abi_break_sweep.md` | Changing public C++ API, AST node layout, or daslib generic signatures that external module repos compile against — both-worlds spellings, externals-merge-first ordering, daspkg-index scope |
 | `skills/wsl_ci_repro.md` | Reproducing a Linux-only CI failure (sanitizers, POSIX divergence, headless timing) in the WSL CI-mirror distro — verbatim-CI recipe and its traps |
 | `skills/babysit.md` | Babysitting an open PR through CI failures and Copilot/human review feedback after the PR is created (the post-open loop) |
+| `skills/review_triage.md` | Triaging ANY review comment on a PR (Copilot, bot, or human) — the verdict tests, the fix-now vs ledgered disposition, what the user is asked versus told |
 | `skills/strudel_port.md` | Porting strudel.cc patterns into daslang |
 | `skills/clargs_usage.md` | Writing or editing any tool that parses command-line flags — declarative argv parsing via `daslib/clargs`, plus migration discipline for legacy `get_command_line_arguments()` callers |
 | `skills/json.md` | Reading/writing JSON in `.das` code (`sprint_json`/`sscan_json`, `JV`, manual `JsonValue?`) |

--- a/skills/babysit.md
+++ b/skills/babysit.md
@@ -100,8 +100,10 @@ An accept's reply states what changed and why; reject-reply content is
 **Resolve** is GraphQL-only — REST has no thread resolution — and the tool carries it:
 `--list-unresolved` prints each open thread's id and path,
 `--resolve <id>` (repeatable) resolves them. **Resolve every thread you replied on,
-including rejections** — the discussion is closed; the reply explains why. The end state,
-zero unresolved, is what `--watch` exit `0`/`3` already distinguishes.
+including rejections** — GitHub collapses resolved threads, so the human reviewer scrolls
+past only what still needs action; an unresolved pile of answered comments makes the PR
+unreadable. The end state, zero unresolved, is what `--watch` exit `0`/`3` already
+distinguishes.
 
 ## 6. Re-request Copilot review
 

--- a/skills/babysit.md
+++ b/skills/babysit.md
@@ -8,36 +8,36 @@ A Copilot round is complete only when all of these are true:
 
 1. Every Copilot comment in the round has an explicit accept/reject reply.
 2. Every corresponding review conversation is resolved, including rejected suggestions.
-3. A fresh query reports zero unresolved review threads. Paginate if GraphQL reports `hasNextPage`; never mistake the first page for the complete set.
+3. A fresh query reports zero unresolved review threads.
 4. Copilot's latest review `commit_id` equals the PR's current `headRefOid`.
-5. That current-tip review's comments were ALL handled — **the terminal state is a review
-   where NOTHING GOT ACCEPTED** (zero comments, or every comment rejected with evidence,
-   replied, resolved, and NO push made). **YOU DO NOT MERGE ON COPILOT RUNNING OUT — you
-   merge on a round you judged and closed without ceding anything.** Chasing a zero-comment
-   review by accepting-and-repushing is the anti-pattern this rule exists to kill.
+5. Every comment of that current-tip review was handled — the terminal state is a judged
+   round that produced no push: zero comments, or every comment rejected or ledgered per
+   `skills/review_triage.md`, replied, resolved. Merging on Copilot running out of
+   comments via accept-and-repush cycles is the anti-pattern this rule exists to kill;
+   merge on a round you judged and closed.
 
-**Any push invalidates items 4-5.** Re-request Copilot after every push without exception, including formatting, documentation, generated-file, merge-conflict, and CI-only fixes. Do not rely on `review_on_push`.
+**Any push invalidates items 4-5.** Re-request Copilot after every push without exception. Do not rely on `review_on_push`.
 
 Never merge with an unresolved thread or with Copilot's latest review targeting an older commit, even when every CI check is green.
 
 ## 1. Watching the PR — the loop
 
-**YOU babysit the build — the user does not babysit YOU.** A ready, verified fix gets
-committed and pushed **immediately**. "Batch fixes into one push" means: fix every *distinct*
-failure currently on the table, then push once — it does **NOT** mean waiting for the rest of
+**The session babysits the build; the user does not babysit the session.** A ready,
+verified fix gets committed and pushed immediately. "Batch fixes into one push" means: fix
+every *distinct* failure currently on the table, then push once — not: wait for the rest of
 the matrix to finish. Straggler lanes reproducing an already-fixed failure are zero
-information (the post-push run re-tests everything); idling on them while holding ready fixes
-is the anti-pattern. If two consecutive status updates say "still waiting", you are doing it
-wrong — act.
+information (the post-push run re-tests everything); idling on them while holding ready
+fixes is the anti-pattern. Two consecutive status updates saying "still waiting" mean the
+loop has stalled — act.
 
-**Iterate against Copilot (~5 min), not the CI matrix (~30 min).** Copilot's review is a free ruleset check that lands in ~5 minutes; the full CI matrix is free too but takes ~30. So the loop is driven by Copilot and you **never sit through a full matrix between rounds**:
+**Iterate against Copilot (~5 min), not the CI matrix (~30 min).** Copilot's review lands in ~5 minutes; the full CI matrix takes ~30. The loop is driven by Copilot — **never sit through a full matrix between rounds**:
 
 1. Compare the PR's current `headRefOid` with Copilot's latest review `commit_id`.
 2. If the tip is unreviewed and the prior round has no unresolved threads, **request Copilot review** manually.
-3. **~5 min later, act on Copilot's review:** triage each comment (Section 3) and surface your verdicts. Wait for greenlight before applying any accepted or uncertain suggestion. A round containing only clear rejections can be replied to and resolved without blocking.
+3. **~5 min later, act on Copilot's review:** triage each comment and apply its disposition per `skills/review_triage.md` (fetch mechanics in Section 3 below).
 4. If fixes changed the branch, run focused gates for the affected surface and push them.
 5. Reply to every comment and resolve every conversation from that completed round. Verify unresolved-thread count = 0.
-6. If step 4 pushed a new tip, re-request Copilot now. If the round was reject-only and produced no push, the existing review already covers the current tip.
+6. If step 4 pushed a new tip, re-request Copilot now. If the round produced no push (all rejected or ledgered), the existing review already covers the current tip.
 7. Repeat until the invariant in Section 0 holds. **Only then** wait for CI green and merge.
 
 **CI runs the whole time — watch it, but don't block on it:**
@@ -47,7 +47,7 @@ wrong — act.
 
 The two heavy Windows toolchain builds (`build_windows_mingw`, `build_windows_clangcl`) run **nightly**, not per-PR — a per-PR red is never one of those.
 
-**Manual re-request is mandatory.** `review_on_push: true` is set on the default-branch ruleset, but in testing it did NOT auto-trigger a review on any push (force-push *or* normal commit) — Copilot only auto-reviews once, on PR open. Every subsequent round needs an explicit `request_copilot_review`. (CI itself *does* auto-run on every PR commit via the `pull_request` trigger, free on standard runners, so it gates honestly without any manual nudge.)
+**Manual re-request is mandatory.** `review_on_push: true` on the default-branch ruleset fires nothing after PR open — Copilot auto-reviews exactly once, at open. Every subsequent round needs an explicit request (Section 6). CI itself *does* auto-run on every PR commit via the `pull_request` trigger, so it gates honestly without any manual nudge.
 
 **Watching is a tool call, not a polling script.** Run
 `daslang utils/pr-babysit/main.das -- --pr <N> --watch` in the background and react to its
@@ -59,97 +59,31 @@ counting); when GitHub changes, fix the tool, not this file. One gap stays manua
 detached `workflow_dispatch` run has no PR association, so the tool cannot see it — poll it
 with `gh run view <runID> --json jobs`.
 
-> **Pure-prose tail.** If a fresh review contains only prose/wording nits, reject them, reply, resolve, and let the PR proceed to merge. Do not edit, push, or start another review cycle. A small related wording cleanup may ride along when the same round already requires a substantive fix, but prose never justifies a push by itself. Factually wrong or materially misleading text is not a nit.
-
 ## 2. CI failure handling
 
 If a check goes red:
-1. Identify the failing job: `gh pr checks <PR>` shows the URL; `gh run view <runID> --log-failed` fetches the log.
-2. Apply the same fix policy as Step 2 in `skills/make_pr.md`: own change → fix it; obvious pre-existing → fix it; non-obvious pre-existing → ask the user.
-3. After the fix, reproduce the failing lane locally when practical and run focused gates for the affected surface. Do not repeat the full preflight; CI is the authoritative complete rerun for the new tip.
-   Distinguish a real red from an infra one first: a runner "shutdown signal" / "operation was canceled" with **no `error:` line** in the build log is a canceled/reclaimed runner, not your code — a fresh push's CI run supersedes it.
-4. Push the fix. CI re-runs automatically. The push invalidates Copilot-dry state, so go **back into the Copilot loop** (Section 1), re-request Copilot on the fix commit, and don't merge until Copilot is dry again and CI is green. There are no exceptions for trivial or CI-only fixes.
+1. Distinguish a real red from an infra one: a runner "shutdown signal" / "operation was canceled" with **no `error:` line** in the build log is a canceled/reclaimed runner, not your code — a fresh push's CI run supersedes it, and there is nothing to fix.
+2. Identify the failing job: `gh pr checks <PR>` shows the URL; `gh run view <runID> --log-failed` fetches the log.
+3. Apply the same fix policy as Step 2 in `skills/make_pr.md`: own change → fix it; obvious pre-existing → fix it; non-obvious pre-existing → ask the user.
+4. After the fix, reproduce the failing lane locally when practical and run focused gates for the affected surface. Do not repeat the full preflight; CI is the authoritative complete rerun for the new tip.
+5. Push the fix. CI re-runs automatically. The push invalidates Copilot-dry state, so go **back into the Copilot loop** (Section 1) and re-request per Section 0; don't merge until Copilot is dry again and CI is green.
 
-## 3. Triaging review comments — discuss BEFORE acting
+## 3. Triage review comments — `skills/review_triage.md`
 
-# ⛔ THE REVIEWER IS THE TOOL. YOU ARE THE JUDGE. ⛔
+Fetch each comment's id, path, line, and body — the GitHub MCP comment listing when
+connected, `gh api repos/<owner>/<repo>/pulls/<PR>/comments` otherwise.
 
-**CLAUDE is trusted with Copilot — Copilot is NOT trusted with Claude.** Copilot is a
-noise-generator that sometimes surfaces a real bug. Your job is to EXTRACT the signal and
-THROW AWAY the rest, not to appease the tool by fixing what it prints. This instruction has
-been given REPEATEDLY and ignored REPEATEDLY — that stops here.
-
-# THE ACCEPTANCE BAR IS EXACTLY TWO ITEMS. THERE IS NO THIRD.
-
-1. **AN ACTUAL BUG** — reachable in shipped use, at real scale, with a real consequence.
-2. **AN ACTUAL FACTUAL ERROR IN PROSE** — a doc/comment/diagnostic that states something UNTRUE.
-
-**EVERYTHING ELSE IS A REJECT. NO EXCEPTIONS. NOT ONE.**
-- ❌ NOT nits. Not "incomplete sentence", not "could be clearer", not style symmetry.
-- ❌ NOT bugs that never happen. A leak on a compile-failing error path is NOT A BUG —
-  the process is already dying. Cleanup "consistency" on a dead branch is NOT A BUG.
-- ❌ NOT guards against asteroid hits. Overflows past plausible hardware, impossible states,
-  "what if the module differs" when it provably doesn't — REJECT.
-- ❌ NOT "make it structural" tightening of something already proven correct in context.
-- ❌ NOT hygiene/determinism cosmetics — sorted diagnostics, micro-allocs beside bigger ones.
-- ❌ NOT repo-divergent "better ways".
-- ❌ NOT "cheap to fix". CHEAP IS NOT A REASON. Every accepted nit hands Copilot a fresh
-  diff and BUYS THE NEXT ROUND. The drip is self-inflicted.
-
-**AN ALL-REJECT ROUND IS THE EXPECTED, HEALTHY, NORMAL OUTCOME.** Each reject costs one
-evidence sentence. If you find yourself accepting more than the rare genuine bug per PR,
-you are being farmed by the tool.
-
-Fetch the comments:
-```bash
-gh api repos/<owner>/<repo>/pulls/<PR>/comments | jq '.[] | {id, path, line: (.line // .original_line), body}'
-```
-
-Give the user a concise per-comment verdict:
-
-| Verdict | Means | Action |
-|---|---|---|
-| 🔴 **Real bug / real issue** | reachable in supported use at realistic scale, with meaningful impact | accept — establish the path, then fix |
-| 🟡 **Factually wrong text** | a doc/comment/diagnostic states something untrue (e.g. names `_distinct()` when the public API is `distinct()`) | accept — correct it |
-| ⚪ **Theoretical / nit / over-defensive / against-convention** | no realistic execution path, wording/style, a can't-happen guard, or repo-divergent suggestion | **reject** with a one-line reason |
-
-### Reality test — require a plausible failure, not mathematical possibility
-
-Before accepting a bug claim, establish all three:
-
-1. **Reachable:** name a shipped caller and an input/state allowed by its contract.
-2. **Plausible scale:** show the threshold fits real hardware, data volume, and process lifetime.
-3. **Meaningful consequence:** identify the incorrect result, crash, corruption, security exposure, or user-visible failure.
-
-Reject when the claim exists only because an integer is technically finite or an impossible state lacks a guard. Example: a 64-bit game-entity counter wrapping only after `2^64` creations is not a real bug on plausible hardware or within the program's lifetime. Do not add saturation, warnings, assertions, or branches for it.
-
-Probability alone is not the test: a rare race, data-loss path, or attacker-controlled input can be real when the reachability chain is concrete. A reasoned proof is enough when reproduction is impractical, but speculative “could theoretically happen” is not.
-
-Real-bug verdicts deserve a probe before declaring fix direction — the obvious fix isn't always the right fix (e.g. aligning the bind-push wasn't enough for the `take(n) |> sum()` bug because the underlying SQL was degenerate; the right answer was compile-time rejection).
-
-**"Cheap to fix" is NOT a reason to accept — BE CONSERVATIVE.** The
-trap: an over-defensive/can't-happen comment arrives, the fix is 3 harmless lines, so you accept
-"for contract tightness" — and every such accept hands Copilot a fresh diff, which produces the
-next marginal comment; #3492 ran 16 rounds and rounds 12–16 were pure hygiene drip that changed
-no reachable behavior. Hold the line the table already draws:
-- **Over-defensive / can't-happen guards → reject**, even when the guard is one line. Cite why
-  the case can't occur (call-site inventory, an upstream guard, a type that makes it
-  unrepresentable). Do not add warnings/asserts for states no shipped caller can produce.
-- **Wording/comment nits → reject; don't create a prose-only changeset.** If a substantive fix
-  is already being pushed, a directly related cleanup may ride along. Otherwise resolve the
-  prose threads and land. Only standalone-fix text that is factually wrong or materially misleading.
-- Accepting a marginal comment to "keep the reviewer happy" costs a commit + a full CI matrix +
-  a new review round. Rejecting costs one evidence sentence. Reject.
-
-A rejected comment still gets a reply (one-line reason, evidence if the reviewer is wrong) + a resolved thread (Section 5). Surface the verdicts and wait for the user's greenlight before applying accepted or uncertain suggestions. If every comment is a clear rejection under the rules above, close the round without a new push and continue toward merge.
+Every comment gets a verdict, a disposition, a reply, and a resolved thread per
+`skills/review_triage.md` — the verdict tests, the fix-now vs ledgered rule, and what the
+user is asked versus told all live there.
 
 ## 4. Apply fixes + run focused gates
 
-After greenlight:
+After the verdicts, and any confirmations the triage rules required:
 1. Edit the code per the agreed verdicts.
-2. **Watch for contradictory comments.** When fixing a bug, scan inline comments that describe the affected surface — they often need updating in the same pass. (If you forget, the next review round will flag it.)
-3. Run focused local gates that exercise the changed surface, plus `git diff --check` and any directly applicable formatter/generator check. The full preflight belongs to `skills/make_pr.md` and runs **once per PR** — before the initial push, and even when that single run fails (fix + targeted re-check, announced); never repeat it for Copilot or CI fix rounds. Let the automatically restarted CI matrix provide the complete validation of each later tip.
-4. **`//!` doc-comment changes:** re-run `bin/Release/daslang.exe -documentation doc/reflections/das2rst.das`, delete `doc/sphinx-build`, then run both Sphinx builders. Preflight's docs gate deletes that cache unconditionally so stale doctrees cannot hide warnings. Generated `doc/source/stdlib/generated/*.rst` are gitignored; Sphinx picks them up at build time.
+2. **Watch for contradictory comments.** When fixing a bug, scan inline comments that describe the affected surface — they often need updating in the same pass.
+3. Run focused local gates that exercise the changed surface, plus `git diff --check` and any directly applicable formatter/generator check — never the full preflight (Section 2's rule; it ran once per `skills/make_pr.md`).
+4. A fix round touching `//!` doc-comments re-runs the docs gates per `skills/documentation_rst.md` (das2rst regen + Sphinx).
 5. Commit the fix and push once its focused gates pass; CI remains mandatory before merge. If amending, use **`git push --force-with-lease`** (never `--force`).
 
 ## 5. Reply to each comment + resolve all threads
@@ -160,53 +94,40 @@ Replying and resolving are **separate API surfaces**. Both are required.
 ```
 mcp__github__add_reply_to_pull_request_comment(commentId=<id>, body="…")
 ```
-Reply content should:
-- For accepts: state what changed and why (e.g. "kept your suggestion but tightened the wording because the original exposed macro-author internals").
-- For accepts with sibling fixes: mention them ("also caught a sibling diagnostic on line ~996 with the same wrong example").
-- For rejects: include evidence — runtime output, file content, a probe script result. Don't just say "I disagree."
+An accept's reply states what changed and why; reject-reply content is
+`skills/review_triage.md`'s.
 
-**Resolve** uses GraphQL — REST doesn't expose `resolveReviewThread`. Two-step:
-
-```bash
-# Get thread node IDs (each thread wraps one or more comments). Inspect
-# pageInfo.hasNextPage and paginate when true.
-gh api graphql -f query='query { repository(owner:"O", name:"R") { pullRequest(number:N) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:1) { nodes { databaseId path line } } } } } } }'
-
-# Resolve each
-gh api graphql -f query="mutation { resolveReviewThread(input:{threadId:\"$thread\"}) { thread { id isResolved } } }"
-```
-
-**Resolve every thread you replied on** — including rejections (the discussion is closed; the reply explains why). Verify at the end:
-
-```bash
-gh api graphql -f query='query { repository(owner:"O", name:"R") { pullRequest(number:N) { reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved } } } } }' | jq 'if .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage then error("paginate review threads") else [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length end'
-```
-Expect `0`.
+**Resolve** is GraphQL-only — REST has no thread resolution — and the tool carries it:
+`--list-unresolved` prints each open thread's id and path,
+`--resolve <id>` (repeatable) resolves them. **Resolve every thread you replied on,
+including rejections** — the discussion is closed; the reply explains why. The end state,
+zero unresolved, is what `--watch` exit `0`/`3` already distinguishes.
 
 ## 6. Re-request Copilot review
 
 **Resolve (and reply to) every prior thread BEFORE re-requesting review.** Re-requesting while old threads are still open leaves the PR ambiguous — you can't tell a stale comment (already addressed, from a superseded commit) from one that still needs action. Resolve first, and any thread that's still open after the next review is unambiguously *new*.
 
-After all replies + resolves + any push, re-request. **Every push requires a new request; no change is too trivial to review.**
+After all replies + resolves + any push, re-request (every push requires one — Section 0).
 ```
 daslang utils/pr-babysit/main.das -- --pr <N> --request-review --watch
 ```
-This requests the review and blocks until one lands on the current tip (exit 3 or 0). The
-tool owns the request transport and its verification — REST vs GraphQL rails, the
-requested-reviewers blind spot, tip matching — and a review on an older SHA never
-satisfies the round. `mcp__github__request_copilot_review` also works when the GitHub MCP
-is connected; verify through the tool's `--watch` either way.
+This requests the review and blocks until something needs action — the same exit codes as
+Section 1, plus `1` when the request itself fails. The tool owns the request transport and
+its verification — REST vs GraphQL rails, the requested-reviewers blind spot, tip matching
+— and a review on an older SHA never satisfies the round.
+`mcp__github__request_copilot_review` also works when the GitHub MCP is connected; verify
+through the tool's `--watch` either way.
 
-If a round was reject-only and no push occurred, do not request an identical review merely because threads were resolved: Copilot already reviewed the current tip. The mandatory trigger is a changed PR tip.
+If a round produced no push, do not request an identical review merely because threads were resolved: Copilot already reviewed the current tip. The mandatory trigger is a changed PR tip.
 
 Copilot reviews the new commit's diff and may flag:
-- Same-class issues you missed elsewhere in the file (it's worth scanning the affected file for each accepted pattern before pushing — saves a round).
-- New issues introduced by the fix itself (e.g. a comment block that contradicts the new behavior — happened in chunk-4 round 2).
+- The same defect pattern elsewhere in the file — `skills/review_triage.md`'s post-accept sweep exists to catch these before the push.
+- New issues introduced by the fix itself, such as a comment block that now contradicts the new behavior.
 - **Zero new comments** = Copilot is done from its perspective. Move to human review.
 
 ## 7. Loop until both Copilot and humans are done
 
-Each fix iteration: triage → discuss → fix → gate → amend → force-push → reply → resolve → verify zero unresolved → re-request → verify reviewed tip. Convergence is normal — most PRs need 1-3 rounds. Don't get fatigued; the discipline is what keeps the review-comment vs. force-push history clean.
+Copilot dry is not the exit: the loop ends only when human reviewers are done too — a pending human review holds the merge exactly like an unreviewed tip. The Quick reference below is the per-iteration recap.
 
 ## Quick reference
 
@@ -214,11 +135,11 @@ Each fix iteration: triage → discuss → fix → gate → amend → force-push
 |---|---|---|
 | Watch PR | `daslang utils/pr-babysit/main.das -- --pr <N> --watch` | React to the exit code: 2 CI red, 3 triage review, 0 ready to merge, 5 timeout |
 | CI fail | `gh pr checks`, `gh run view --log-failed` | Fix own, fix obvious pre-existing, ask about unclear |
-| Triage comments | `gh api .../pulls/<PR>/comments` | **YOU are the judge, Copilot is the tool.** Accept ONLY actual bugs + actual factual prose errors — no nits, no never-happens bugs, no asteroid guards. All-reject rounds are the NORM |
-| Terminal state | a judged round with NOTHING accepted (zero comments, or all rejected + resolved, no push) | Never merge on "Copilot ran out" via accept-and-repush cycles |
+| Triage comments | `gh api .../pulls/<PR>/comments` | Verdict + disposition + reply per `skills/review_triage.md` |
+| Terminal state | a judged round that produced no push (zero comments, or all rejected/ledgered + resolved) | Never merge on "Copilot ran out" via accept-and-repush cycles |
 | Re-run gates | Focused tests + directly applicable format/generator/doc checks | Full preflight once before initial PR push; CI handles complete reruns after review fixes |
 | Amend/push | `git commit --amend --no-edit`, `git push --force-with-lease` | Keep squashed branch squashed |
 | Reply | `mcp__github__add_reply_to_pull_request_comment` | Every addressed comment gets a reply |
-| Resolve | `gh api graphql ... resolveReviewThread` | Every addressed thread gets resolved; paginate and verify unresolved = 0 |
-| Re-request | `daslang utils/pr-babysit/main.das -- --pr <N> --request-review --watch` | Mandatory after EVERY push, after prior threads are resolved |
+| Resolve | `daslang utils/pr-babysit/main.das -- --pr <N> --list-unresolved` / `--resolve <id>` | Every addressed thread gets resolved; end state is zero unresolved |
+| Re-request | `daslang utils/pr-babysit/main.das -- --pr <N> --request-review --watch` | Mandatory after every push, after prior threads are resolved |
 | Merge gate | Compare latest Copilot `commit_id` to PR `headRefOid` | CI green + matching reviewed tip + zero unresolved threads |

--- a/skills/babysit.md
+++ b/skills/babysit.md
@@ -49,16 +49,15 @@ The two heavy Windows toolchain builds (`build_windows_mingw`, `build_windows_cl
 
 **Manual re-request is mandatory.** `review_on_push: true` is set on the default-branch ruleset, but in testing it did NOT auto-trigger a review on any push (force-push *or* normal commit) — Copilot only auto-reviews once, on PR open. Every subsequent round needs an explicit `request_copilot_review`. (CI itself *does* auto-run on every PR commit via the `pull_request` trigger, free on standard runners, so it gates honestly without any manual nudge.)
 
-**Polling cadence (use `/loop`, dynamic mode):** ~5 min (≤270s, keeps the prompt cache warm) while iterating on Copilot; switch to ~20 min once Copilot is dry and you're only waiting on the matrix.
-
-**Status commands per tick:**
-- `gh pr checks <PR>` — CI status (pending / pass / fail), or `gh api repos/<owner>/<repo>/commits/<tip>/check-runs` filtered to `status!="completed"` (pending) and `conclusion` ∈ {`failure`, `cancelled`, `timed_out`, `action_required`} (reds — don't match only `failure`; a cancelled or timed-out lane is red too)
-- **NEVER tick on `gh run list` — it is workflow-granular and goes blind on matrix reds.** build.yml's matrix runs `fail-fast: false`, so a dead job leaves the workflow `in_progress` for the surviving siblings' full runtime — `gh run list` reports "nothing red" the entire time while the PR checks page already shows the failure. Only the two job-granular forms above see it.
-- A detached `workflow_dispatch` run is NOT in `gh pr checks` (no PR association) — job-level poll it separately: `gh run view <runID> --json jobs --jq '.jobs[] | select(.conclusion != null and .conclusion != "success" and .conclusion != "skipped") | .name + " " + .conclusion'` (empty output = no reds yet).
-- `gh api repos/<owner>/<repo>/pulls/<PR>/reviews` — Copilot's latest review; check its `commit_id` matches your tip (confirms it reviewed the latest code, not a stale commit)
-- unresolved threads via GraphQL `reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{isResolved …}}`, paginated when needed and filtered to `isResolved==false`
-
-Stop polling and surface as soon as: (a) Copilot left new comments (react), (b) a CI check went red (fix), or (c) CI green AND Copilot dry (ready to merge).
+**Watching is a tool call, not a polling script.** Run
+`daslang utils/pr-babysit/main.das -- --pr <N> --watch` in the background and react to its
+exit code: `2` = CI red (failing checks named), `3` = a review targets the tip and threads
+are unresolved — triage it, `0` = CI green + reviewed tip + zero unresolved — ready to
+merge, `5` = nothing actionable within the timeout. The tool owns the GitHub mechanics
+(job-granular check reads that see matrix reds, the bot-reviewer blind spots, thread
+counting); when GitHub changes, fix the tool, not this file. One gap stays manual: a
+detached `workflow_dispatch` run has no PR association, so the tool cannot see it — poll it
+with `gh run view <runID> --json jobs`.
 
 > **Pure-prose tail.** If a fresh review contains only prose/wording nits, reject them, reply, resolve, and let the PR proceed to merge. Do not edit, push, or start another review cycle. A small related wording cleanup may ride along when the same round already requires a substantive fix, but prose never justifies a push by itself. Factually wrong or materially misleading text is not a nit.
 
@@ -190,9 +189,13 @@ Expect `0`.
 
 After all replies + resolves + any push, re-request. **Every push requires a new request; no change is too trivial to review.**
 ```
-mcp__github__request_copilot_review(owner=…, repo=…, pullNumber=…)
+daslang utils/pr-babysit/main.das -- --pr <N> --request-review --watch
 ```
-Record the current `headRefOid` when requesting. When the review arrives, verify its `commit_id` equals that recorded tip. A review on an older SHA does not satisfy the round, even if it arrived after the latest push.
+This requests the review and blocks until one lands on the current tip (exit 3 or 0). The
+tool owns the request transport and its verification — REST vs GraphQL rails, the
+requested-reviewers blind spot, tip matching — and a review on an older SHA never
+satisfies the round. `mcp__github__request_copilot_review` also works when the GitHub MCP
+is connected; verify through the tool's `--watch` either way.
 
 If a round was reject-only and no push occurred, do not request an identical review merely because threads were resolved: Copilot already reviewed the current tip. The mandatory trigger is a changed PR tip.
 
@@ -209,7 +212,7 @@ Each fix iteration: triage → discuss → fix → gate → amend → force-push
 
 | Step | Tool/Command | Fix policy |
 |---|---|---|
-| Watch PR | `gh pr checks`, `gh api .../comments`, `gh api .../reviews` | Surface as soon as Copilot comments, CI fails, or both CI + Copilot are done |
+| Watch PR | `daslang utils/pr-babysit/main.das -- --pr <N> --watch` | React to the exit code: 2 CI red, 3 triage review, 0 ready to merge, 5 timeout |
 | CI fail | `gh pr checks`, `gh run view --log-failed` | Fix own, fix obvious pre-existing, ask about unclear |
 | Triage comments | `gh api .../pulls/<PR>/comments` | **YOU are the judge, Copilot is the tool.** Accept ONLY actual bugs + actual factual prose errors — no nits, no never-happens bugs, no asteroid guards. All-reject rounds are the NORM |
 | Terminal state | a judged round with NOTHING accepted (zero comments, or all rejected + resolved, no push) | Never merge on "Copilot ran out" via accept-and-repush cycles |
@@ -217,5 +220,5 @@ Each fix iteration: triage → discuss → fix → gate → amend → force-push
 | Amend/push | `git commit --amend --no-edit`, `git push --force-with-lease` | Keep squashed branch squashed |
 | Reply | `mcp__github__add_reply_to_pull_request_comment` | Every addressed comment gets a reply |
 | Resolve | `gh api graphql ... resolveReviewThread` | Every addressed thread gets resolved; paginate and verify unresolved = 0 |
-| Re-request | `mcp__github__request_copilot_review` | Mandatory after EVERY push, after prior threads are resolved |
+| Re-request | `daslang utils/pr-babysit/main.das -- --pr <N> --request-review --watch` | Mandatory after EVERY push, after prior threads are resolved |
 | Merge gate | Compare latest Copilot `commit_id` to PR `headRefOid` | CI green + matching reviewed tip + zero unresolved threads |

--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -55,14 +55,10 @@ that already carries its own doc-comment, and no section-head essay restating wh
 code, the doc-comments, or the file-header map already carry — architectural WHY with
 no home in the file goes to a design doc. Terse section dividers stay.
 
-**A file header is a map, not an essay.** A pass or subsystem file may open with a
-numbered overview — one line per fact — stating the whole contract: when it runs, what
-it consumes and produces, the kinds and tiers it deals in. A map legitimately repeats
-what per-symbol comments say; a reader entering cold needs the shape before any
-symbol. What stays banned is prose — paragraphs argue, maps enumerate. A map repeats
-per-symbol *comments*, not text the code already prints as a message or expectation.
-A header at or under the comment cap may stay prose; the enumeration form is
-required only past it.
+**A file header is a map, not an essay.** At or under the comment cap a header may stay
+prose; past it, it either becomes a map — one line per fact of the file's contract — or
+gets trimmed. A map may repeat per-symbol comments (a cold reader needs the shape before
+any symbol), never text the code already prints.
 
 **Private symbols don't get public-style docs.** Doc-comment syntax (`//!` and kin) is
 for tooling-visible public API. On a private symbol a docstring restates the name to a
@@ -82,8 +78,8 @@ never right. A self-describing predicate — a named helper, a compare against a
 constant — gets nothing: restating `fn.neverInline` as "explicit opt-out" is
 narration. The comment must say something the identifiers don't.
 
-**No incident citations.** The banned form is a citation only a reviewer can check —
-a PR or issue number, a date, "proven: <module> lost <bug>". The required form is the
+**No incident citations.** The banned form is a citation that can only be verified
+outside the code — a PR or issue number, a date, "proven: <module> lost <bug>". The required form is the
 failure mode named in present tense at the code that guards it: "a defaulted operand
 no call site can supply crashes simulation", not "used to crash". A mechanism note
 stays when a maintainer needs it to change the code without breaking the guard (why

--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -41,7 +41,7 @@ some (noted), C++/JS lints are follow-up work.
 
 **Short or absent.** 1–2 lines preferred, 3 the cap — das lint STYLE014 enforces it under
 `daslib/` and wherever `options _comment_hygiene = true`; everywhere else the cap is the
-reviewer's. Inside a `def private` body the cap is ONE line (STYLE015), and that cap is
+reviewer's. Inside a `def private` body the cap is ONE line (STYLE015, same gating), and that cap is
 body-only: a comment *attached to* a private symbol takes the ordinary 3-line cap plus the
 bar in *Private symbols don't get public-style docs* below. The cap covers per-symbol
 and in-body comments; the file header — the block before the first declaration,

--- a/skills/make_pr.md
+++ b/skills/make_pr.md
@@ -483,8 +483,7 @@ Creating the PR does not complete the workflow. Continue immediately with
 3. Verify the unresolved-thread count is zero after the round; replying without resolving is incomplete.
 4. After **every push** to the PR branch, re-request Copilot review. This includes formatting, documentation, CI-only, and other supposedly trivial fixes; there are no push exceptions.
 5. Treat Copilot as dry only when its latest review targets the current tip, produced no new comments, and no review threads remain unresolved.
-6. Accept bug claims only when they have a realistic shipped path, plausible scale, and meaningful impact. Reject theoretical overflow/impossible-state guards.
-7. Never create a prose-only review changeset. Reply, resolve, and let the PR land unless the text is factually wrong or materially misleading; minor prose may ride along with an already-required substantive fix.
+6. Triage every comment per `skills/review_triage.md` — the verdict tests, the fix-now vs ledgered disposition, and the prose-only round rule live there.
 
 Never merge solely because CI is green. CI green + Copilot reviewed current tip + zero unresolved conversations is the merge gate.
 
@@ -528,6 +527,6 @@ created it.
 | PR | GitHub MCP `create_pull_request` or `gh pr create` | Body follows the two-layer template (step 6): short reviewer prose + fixed-heading `<details>` ledger |
 | Copilot round | Reply to every comment, resolve every thread, verify unresolved = 0 | A review round is not complete until all three are done |
 | Push after PR creation | Re-request Copilot review | Mandatory after every push; latest review must target current tip |
-| Review acceptance | Require realistic reachability, scale, and impact | Reject theoretical defensive programming; prose-only round → resolve and land |
+| Review acceptance | `skills/review_triage.md` | Verdict tests + disposition + round outcomes |
 | Babysit | Follow `skills/babysit.md` | Merge only when CI is green and Copilot is dry on current tip |
 | Post-land sweep | `git ls-files --others --exclude-standard` | Delete session debris (`_`-prefixed probes/dumps, `__pycache__`, ad-hoc logs); keep configs/manifests/user assets |

--- a/skills/review_triage.md
+++ b/skills/review_triage.md
@@ -1,0 +1,97 @@
+# Review triage — verdict, disposition, presentation (repo-only)
+
+Read this before triaging any review comment on a PR — Copilot, another bot, or a human
+reviewer. It owns the judgment half of the review loop: what verdict a comment gets, when
+an accepted fix lands, and what the user is asked. The loop mechanics — watching, replying,
+resolving, re-requesting — stay in `skills/babysit.md`.
+
+## The verdict — three classes, tested in order
+
+Every comment gets exactly one verdict. Apply the tests in order; the first that passes
+decides.
+
+**1. Defect** — all three tests pass:
+
+- *Reachable*: a shipped caller and an input or state its contract allows lead to the
+  flagged behavior. An unguarded state no caller can produce fails — cite which of the
+  call-site inventory, an upstream guard, or the type makes it unproducible.
+- *Real scale*: the triggering threshold fits real hardware, real data, and the process's
+  lifetime. "The integer is finite" fails this test.
+- *Named consequence*: a concrete consequence — the wrong result, crash, corruption,
+  security exposure, or user-visible failure — exists, and the triager names it in the
+  verdict; a claim that chases down to none rejects. "It would be more robust" names none.
+
+A reasoned reachability chain is enough where reproduction is impractical; a rare race or
+an attacker-controlled input passes when the chain is concrete, and "could theoretically
+happen" is not a chain.
+
+**2. Falsehood** — text in the repo — a code comment, doc, diagnostic, or message — states
+something the code contradicts. The test is contradiction, not quality: text that is vague,
+incomplete, or unpolished is not a falsehood.
+
+**3. Reject** — everything else. Name the class in the reply:
+
+- *mistaken premise* — the comment's claim about what the code does is contradicted by the
+  code; the reply carries the contradicting evidence
+- *style preference* — wording, symmetry, "could be clearer"; lint owns style
+- *dead-path defect* — the flagged path already terminates the process or the compile
+- *unreachable guard* — the guarded state has no producer
+- *hardening* — a tightening of behavior with no failing input at real hardware, real
+  data, real lifetime
+- *cosmetics* — determinism or hygiene with no behavioral difference
+- *repo-divergent* — a "better way" this codebase deliberately does differently
+- *out of scope* — a change carrying no defect claim: a coverage ask, a scope expansion,
+  a question. Answer it in the reply; ledger it when worth keeping
+
+The classes are common names, not the criterion: when none fits a claim-carrying comment,
+the reply names the Defect test the claim fails.
+
+Fix cost is not an input to any test: the verdict on a comment must come out the same
+whether its fix costs one line or one week. A verdict that changed when the fix turned out
+to be cheap was not a verdict.
+
+## Disposition — a defect is always fixed; the open question is when
+
+- **Now**: the defect is in code this PR's hunks changed — a merely-touched file does not
+  count — AND the fix is bounded: no new design, no new arc, focused gates cover it. Fix
+  it in this round without asking.
+- **Ledgered**: off the PR's surface, or the fix is its own arc. Record it — the PR
+  body's `### Not done` section (`skills/make_pr.md`, step 6), an issue, or memory — and
+  reply with the entry. The entry travels in the verdict report for the user to confirm
+  or reshape; a pending confirmation blocks neither thread resolution nor round completion.
+- **In doubt, the user decides** — doubt about now-vs-ledgered, about whether the defect
+  test really passes, or about fix direction. Ask, with a recommendation.
+
+A falsehood is fixed in the round; when in doubt whether the text is actually false, or
+whether its fix belongs in this PR, ask.
+
+A reject's reply names its class plus one evidence sentence. Rejects never cause a push.
+
+An accepted defect whose fix direction is not forced gets a probe before the fix — the
+obvious fix and the right fix can differ. After any accepted fix, sweep the affected file
+for the same defect pattern before pushing; one sweep saves one round.
+
+## Presenting to the user — report decisions, ask questions
+
+Comments the rules decide arrive as a report, not a question: a per-comment verdict list —
+class, one-line evidence, and for defects the disposition.
+
+Ask exactly where a rule says ask, and ask the decision, not permission:
+
+- Never "should I fix this bug?" — a defect is being fixed; the open question is when.
+- A now-vs-ledgered question carries the magnitude: what breaks, for whom, and what the
+  bounded fix would touch — "fix now (three lines in the changed file) or ledger (touches
+  the serializer, its own arc)?"
+- A doubt question carries the evidence both ways and a recommendation.
+
+## Round outcomes
+
+- **All-reject round**: no push — proceed toward merge. This is a normal, healthy
+  outcome, not a failure to engage.
+- **Prose-only round** — every comment is a wording suggestion and none is a falsehood:
+  same as all-reject.
+- **In any round that already pushes for a substantive fix**, a directly related wording
+  cleanup may ride that push — applying it does not change its Reject verdict. Prose never
+  causes a push by itself.
+- A round is complete when every comment carries a verdict and every now-fix is pushed;
+  thread reply-and-resolve closure is `skills/babysit.md`'s Section 0 invariant.

--- a/utils/pr-babysit/main.das
+++ b/utils/pr-babysit/main.das
@@ -8,7 +8,6 @@ options gen2
 // /pulls/N/reviews with commit_id == the requested tip.
 
 require strings
-require math
 require daslib/fio
 require daslib/clargs
 require daslib/strings_boost
@@ -150,7 +149,7 @@ def private request_review_graphql(cfg : Config) : bool {
 }
 
 def private watch(cfg : Config) : int {
-    let polls = max(1, (cfg.timeout_min * 60) / max(1, cfg.interval_sec))
+    let polls = poll_budget(cfg.timeout_min, cfg.interval_sec)
     var last_state = ""
     var escalated = false
     for (poll in range(polls)) {
@@ -167,28 +166,19 @@ def private watch(cfg : Config) : int {
             to_log(LOG_WARNING, "pr-babysit: api read failed, retrying\n")
             continue
         }
-        var fails : array<string>
-        var pending = 0
-        for (c in checks) {
-            if (c |> starts_with("fail ")) {
-                fails |> push(slice(c, 5))
-            } elif (c |> starts_with("pending ")) {
-                pending++
-            }
-        }
+        let cls <- classify_checks(checks)
         let reviewed = reviews |> has_value(head)
-        let state = "tip {slice(head, 0, 9)}: {length(fails)} failed, {pending} pending, reviewed={reviewed}, unresolved={unresolved}"
+        let state = "tip {slice(head, 0, 9)}: {length(cls.fails)} failed, {cls.pending} pending, reviewed={reviewed}, unresolved={unresolved}"
         if (state != last_state) {
             to_log(LOG_INFO, "pr-babysit: {state}\n")
             last_state = state
         }
-        let verdict = watch_verdict(length(fails), pending, reviewed, unresolved)
+        let verdict = watch_verdict(length(cls.fails), cls.pending, reviewed, unresolved)
         if (verdict == WatchVerdict.ci_red) {
-            to_log(LOG_ERROR, "pr-babysit: CI red - {join(fails, ", ")}\n")
-            return 2
+            to_log(LOG_ERROR, "pr-babysit: CI red - {join(cls.fails, ", ")}\n")
         }
-        return 3 if (verdict == WatchVerdict.review_to_triage)
-        return 0 if (verdict == WatchVerdict.ready_to_merge)
+        let ec = exit_for(verdict)
+        return ec if (ec >= 0)
         // REST accepted but never re-triggered
         if (cfg.request_review && !escalated && !reviewed && poll >= polls / 2) {
             escalated = true

--- a/utils/pr-babysit/main.das
+++ b/utils/pr-babysit/main.das
@@ -1,0 +1,184 @@
+options gen2
+
+// pr-babysit - the GitHub mechanics of the babysit loop (skills/babysit.md keeps the policy).
+// --request-review asks Copilot to review the PR tip; --watch blocks until something needs
+// action. Exit codes: 0 ready to merge, 1 request/api failure, 2 CI red, 3 review to triage,
+// 5 watch timeout. Bot reviewers never appear in requested_reviewers or reviewRequests and
+// Copilot converts a request into a review within seconds, so the only trustworthy signal
+// is the review arriving in /pulls/N/reviews with commit_id == the requested tip.
+
+require strings
+require math
+require daslib/fio
+require daslib/clargs
+require daslib/strings_boost
+require daslib/strings_convert
+require watch_verdict
+
+[CommandLineArgs]
+struct Config {
+    @clarg_required
+    @clarg_doc = "Pull request number"
+    pr : int
+
+    @clarg_doc = "GitHub repository, owner/name"
+    repo : string = "GaijinEntertainment/daScript"
+
+    @clarg_doc = "Request a Copilot review of the current tip"
+    request_review : bool
+
+    @clarg_doc = "Block until action is needed: CI red (2), review to triage (3), ready to merge (0), timeout (5)"
+    watch : bool
+
+    @clarg_doc = "Watch poll interval, seconds"
+    interval : int = 30
+
+    @clarg_doc = "Watch timeout, minutes"
+    timeout_min : int = 45
+}
+
+def private gh(args : array<string>; var out : string&) : int {
+    var argv <- ["gh"]
+    argv |> push_from(args)
+    return run_and_capture(argv, out, 120.0)
+}
+
+def private gh_line(args : array<string>) : string {
+    var out : string
+    return gh(args, out) == 0 ? trim(out) : ""
+}
+
+def private head_sha(cfg : Config) : string {
+    return gh_line(["api", "repos/{cfg.repo}/pulls/{cfg.pr}", "--jq", ".head.sha"])
+}
+
+// non-empty output lines; ok=false on spawn/api failure so a caller never reads an error page as data
+def private gh_lines(args : array<string>; var ok : bool&) : array<string> {
+    var out : string
+    ok = gh(args, out) == 0
+    var lines : array<string>
+    if (ok) {
+        lines <- [for (l in split(out, "\n")); trim(l); where !empty(trim(l))]
+    }
+    return <- lines
+}
+
+// "<bucket> <name>" per check, one gh call per poll
+def private check_lines(cfg : Config; var ok : bool&) : array<string> {
+    return <- gh_lines(["pr", "checks", "{cfg.pr}", "--repo", cfg.repo,
+        "--json", "name,bucket", "--jq", ".[] | .bucket + \" \" + .name"], ok)
+}
+
+// commit_id per bot review - Copilot's REST author type is Bot
+def private bot_review_shas(cfg : Config; var ok : bool&) : array<string> {
+    return <- gh_lines(["api", "repos/{cfg.repo}/pulls/{cfg.pr}/reviews", "--paginate",
+        "--jq", ".[] | select(.user.type==\"Bot\") | .commit_id"], ok)
+}
+
+def private unresolved_count(cfg : Config) : int {
+    let slash = find(cfg.repo, "/")
+    let owner = slice(cfg.repo, 0, slash)
+    let name = slice(cfg.repo, slash + 1)
+    let query = "query \{ repository(owner: \"{owner}\", name: \"{name}\") \{ pullRequest(number: {cfg.pr}) \{ reviewThreads(first: 100) \{ nodes \{ isResolved \} \} \} \} \}"
+    let out = gh_line(["api", "graphql", "-f", "query={query}", "--jq",
+        "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length"])
+    let n = try_to_int(out)
+    return n |> is_ok ? n |> unwrap : -1
+}
+
+def private request_review(cfg : Config) : int {
+    let head = head_sha(cfg)
+    if (empty(head)) {
+        to_log(LOG_ERROR, "pr-babysit: cannot read {cfg.repo}#{cfg.pr} - is gh authenticated?\n")
+        return 1
+    }
+    var out : string
+    let rc = gh(["api", "-X", "POST", "repos/{cfg.repo}/pulls/{cfg.pr}/requested_reviewers",
+        "-f", "reviewers[]=copilot-pull-request-reviewer[bot]"], out)
+    if (rc != 0) {
+        to_log(LOG_ERROR, "pr-babysit: review request refused (rc={rc})\n{out}\n")
+        return 1
+    }
+    to_log(LOG_INFO, "pr-babysit: copilot review requested on {slice(head, 0, 9)}\n")
+    return 0
+}
+
+// re-request rail for a PR Copilot has already reviewed - REST accepts but may not re-trigger
+// there; GraphQL requestReviews(botIds, union) is the reported-reliable path
+def private request_review_graphql(cfg : Config) : bool {
+    let pr_id = gh_line(["api", "repos/{cfg.repo}/pulls/{cfg.pr}", "--jq", ".node_id"])
+    let bot_id = gh_line(["api", "repos/{cfg.repo}/pulls/{cfg.pr}/reviews",
+        "--jq", "[.[] | select(.user.type==\"Bot\") | .user.node_id] | last"])
+    return false if (empty(pr_id) || empty(bot_id) || bot_id == "null")
+    let mutation = "mutation \{ requestReviews(input: \{ pullRequestId: \"{pr_id}\", botIds: [\"{bot_id}\"], union: true \}) \{ clientMutationId \} \}"
+    var out : string
+    return gh(["api", "graphql", "-f", "query={mutation}"], out) == 0
+}
+
+def private watch(cfg : Config) : int {
+    let polls = max(1, (cfg.timeout_min * 60) / max(1, cfg.interval))
+    var last_line = ""
+    var escalated = false
+    for (poll in range(polls)) {
+        if (poll != 0) {
+            sleep(uint(cfg.interval * 1000))
+        }
+        let head = head_sha(cfg)
+        var checks_ok = false
+        var reviews_ok = false
+        let checks <- check_lines(cfg, checks_ok)
+        let reviews <- bot_review_shas(cfg, reviews_ok)
+        let unresolved = unresolved_count(cfg)
+        if (empty(head) || !checks_ok || !reviews_ok || unresolved < 0) {
+            to_log(LOG_WARNING, "pr-babysit: api read failed, retrying\n")
+            continue
+        }
+        var fails : array<string>
+        var pending = 0
+        for (c in checks) {
+            if (c |> starts_with("fail ")) {
+                fails |> push(slice(c, 5))
+            } elif (c |> starts_with("pending ")) {
+                pending++
+            }
+        }
+        let reviewed = reviews |> has_value(head)
+        let state = "tip {slice(head, 0, 9)}: {length(fails)} failed, {pending} pending, reviewed={reviewed}, unresolved={unresolved}"
+        if (state != last_line) {
+            to_log(LOG_INFO, "pr-babysit: {state}\n")
+            last_line = state
+        }
+        let v = watch_verdict(length(fails), pending, reviewed, unresolved)
+        if (v == WatchVerdict.ci_red) {
+            to_log(LOG_ERROR, "pr-babysit: CI red - {join(fails, ", ")}\n")
+            return 2
+        }
+        return 3 if (v == WatchVerdict.review_to_triage)
+        return 0 if (v == WatchVerdict.ready_to_merge)
+        // half the budget with no review on a tip we requested: REST accepted but did not
+        // re-trigger - fire the GraphQL rail once and keep watching
+        if (cfg.request_review && !escalated && !reviewed && poll >= polls / 2) {
+            escalated = true
+            let sent = request_review_graphql(cfg)
+            to_log(LOG_WARNING, "pr-babysit: no review at half timeout - GraphQL re-request {sent ? "sent" : "unavailable"}\n")
+        }
+    }
+    to_log(LOG_ERROR, "pr-babysit: nothing actionable within {cfg.timeout_min} min\n")
+    return 5
+}
+
+[export]
+def main() : int {
+    var cfg = Config()
+    let rc = parse_args_with_help(cfg, "pr-babysit")
+    return rc if (rc >= 0)
+    if (!cfg.request_review && !cfg.watch) {
+        to_log(LOG_ERROR, "pr-babysit: pick --request-review and/or --watch\n")
+        return 1
+    }
+    if (cfg.request_review) {
+        let rrc = request_review(cfg)
+        return rrc if (rrc != 0)
+    }
+    return cfg.watch ? watch(cfg) : 0
+}

--- a/utils/pr-babysit/main.das
+++ b/utils/pr-babysit/main.das
@@ -2,10 +2,12 @@ options gen2
 
 // pr-babysit - the GitHub mechanics of the babysit loop (skills/babysit.md keeps the policy).
 // --request-review asks Copilot to review the PR tip; --watch blocks until something needs
-// action. Exit codes: 0 ready to merge, 1 request/api failure, 2 CI red, 3 review to triage,
-// 5 watch timeout. Bot reviewers never appear in requested_reviewers or reviewRequests and
-// Copilot converts a request into a review within seconds, so the only trustworthy signal
-// is the review arriving in /pulls/N/reviews with commit_id == the requested tip.
+// action; --list-unresolved / --resolve <id> are the review-thread rails (resolve is
+// GraphQL-only - REST has no thread resolution). Exit codes: 0 ready to merge, 1 request/api
+// failure, 2 CI red, 3 review to triage, 5 watch timeout. Bot reviewers never appear in
+// requested_reviewers or reviewRequests and Copilot converts a request into a review within
+// seconds, so the only trustworthy signal is the review arriving in /pulls/N/reviews with
+// commit_id == the requested tip.
 
 require strings
 require math
@@ -29,6 +31,12 @@ struct Config {
 
     @clarg_doc = "Block until action is needed: CI red (2), review to triage (3), ready to merge (0), timeout (5)"
     watch : bool
+
+    @clarg_doc = "List unresolved review threads, GraphQL id and path per line"
+    list_unresolved : bool
+
+    @clarg_doc = "Resolve a review thread by GraphQL id (repeatable)"
+    resolve : array<string>
 
     @clarg_doc = "Watch poll interval, seconds"
     interval : int = 30
@@ -75,15 +83,44 @@ def private bot_review_shas(cfg : Config; var ok : bool&) : array<string> {
         "--jq", ".[] | select(.user.type==\"Bot\") | .commit_id"], ok)
 }
 
-def private unresolved_count(cfg : Config) : int {
+// "<id> <path>" per unresolved thread; paginated - an undercounted page must never read as zero
+def private unresolved_threads(cfg : Config; var ok : bool&) : array<string> {
     let slash = find(cfg.repo, "/")
     let owner = slice(cfg.repo, 0, slash)
     let name = slice(cfg.repo, slash + 1)
-    let query = "query \{ repository(owner: \"{owner}\", name: \"{name}\") \{ pullRequest(number: {cfg.pr}) \{ reviewThreads(first: 100) \{ nodes \{ isResolved \} \} \} \} \}"
-    let out = gh_line(["api", "graphql", "-f", "query={query}", "--jq",
-        "[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length"])
-    let n = try_to_int(out)
-    return n |> is_ok ? n |> unwrap : -1
+    var threads : array<string>
+    var cursor = ""
+    ok = true
+    while (true) {
+        let after = empty(cursor) ? "" : ", after: \"{cursor}\""
+        let query = "query \{ repository(owner: \"{owner}\", name: \"{name}\") \{ pullRequest(number: {cfg.pr}) \{ reviewThreads(first: 100{after}) \{ pageInfo \{ hasNextPage endCursor \} nodes \{ id isResolved path \} \} \} \} \}"
+        var page_ok = false
+        let lines <- gh_lines(["api", "graphql", "-f", "query={query}", "--jq",
+            "(.data.repository.pullRequest.reviewThreads.pageInfo | (.hasNextPage|tostring) + \" \" + (.endCursor // \"\")), (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | .id + \" \" + (.path // \"\"))"], page_ok)
+        if (!page_ok || empty(lines)) {
+            ok = page_ok && !empty(lines)
+            break
+        }
+        threads |> reserve(length(threads) + length(lines) - 1)
+        for (i in range(1, length(lines))) {
+            threads |> push(lines[i])
+        }
+        break if (!(lines[0] |> starts_with("true ")))
+        cursor = slice(lines[0], find(lines[0], " ") + 1)
+    }
+    return <- threads
+}
+
+def private unresolved_count(cfg : Config) : int {
+    var ok = false
+    let threads <- unresolved_threads(cfg, ok)
+    return ok ? length(threads) : -1
+}
+
+def private resolve_thread(thread_id : string) : bool {
+    let mutation = "mutation \{ resolveReviewThread(input: \{ threadId: \"{thread_id}\" \}) \{ thread \{ id \} \} \}"
+    var out : string
+    return gh(["api", "graphql", "-f", "query={mutation}"], out) == 0
 }
 
 def private request_review(cfg : Config) : int {
@@ -172,9 +209,28 @@ def main() : int {
     var cfg = Config()
     let rc = parse_args_with_help(cfg, "pr-babysit")
     return rc if (rc >= 0)
-    if (!cfg.request_review && !cfg.watch) {
-        to_log(LOG_ERROR, "pr-babysit: pick --request-review and/or --watch\n")
+    if (!cfg.request_review && !cfg.watch && !cfg.list_unresolved && empty(cfg.resolve)) {
+        to_log(LOG_ERROR, "pr-babysit: pick --request-review, --watch, --list-unresolved, and/or --resolve\n")
         return 1
+    }
+    for (tid in cfg.resolve) {
+        if (!resolve_thread(tid)) {
+            to_log(LOG_ERROR, "pr-babysit: failed to resolve thread {tid}\n")
+            return 1
+        }
+        to_log(LOG_INFO, "pr-babysit: resolved {tid}\n")
+    }
+    if (cfg.list_unresolved) {
+        var ok = false
+        let threads <- unresolved_threads(cfg, ok)
+        if (!ok) {
+            to_log(LOG_ERROR, "pr-babysit: cannot read review threads\n")
+            return 1
+        }
+        for (t in threads) {
+            to_log(LOG_INFO, "{t}\n")
+        }
+        to_log(LOG_INFO, "pr-babysit: {length(threads)} unresolved\n")
     }
     if (cfg.request_review) {
         let rrc = request_review(cfg)

--- a/utils/pr-babysit/main.das
+++ b/utils/pr-babysit/main.das
@@ -1,13 +1,11 @@
 options gen2
 
 // pr-babysit - the GitHub mechanics of the babysit loop (skills/babysit.md keeps the policy).
-// --request-review asks Copilot to review the PR tip; --watch blocks until something needs
-// action; --list-unresolved / --resolve <id> are the review-thread rails (resolve is
-// GraphQL-only - REST has no thread resolution). Exit codes: 0 ready to merge, 1 request/api
-// failure, 2 CI red, 3 review to triage, 5 watch timeout. Bot reviewers never appear in
-// requested_reviewers or reviewRequests and Copilot converts a request into a review within
-// seconds, so the only trustworthy signal is the review arriving in /pulls/N/reviews with
-// commit_id == the requested tip.
+// Exit codes: 0 ready to merge, 1 request/api failure, 2 CI red, 3 review to triage,
+// 5 watch timeout. Thread resolution is GraphQL-only - REST has none. Bot reviewers never
+// appear in requested_reviewers or reviewRequests and Copilot converts a request into a
+// review within seconds, so the only trustworthy signal is the review arriving in
+// /pulls/N/reviews with commit_id == the requested tip.
 
 require strings
 require math
@@ -39,7 +37,7 @@ struct Config {
     resolve : array<string>
 
     @clarg_doc = "Watch poll interval, seconds"
-    interval : int = 30
+    interval_sec : int = 30
 
     @clarg_doc = "Watch timeout, minutes"
     timeout_min : int = 45
@@ -71,13 +69,12 @@ def private gh_lines(args : array<string>; var ok : bool&) : array<string> {
     return <- lines
 }
 
-// "<bucket> <name>" per check, one gh call per poll
+// "<bucket> <name>" per check
 def private check_lines(cfg : Config; var ok : bool&) : array<string> {
     return <- gh_lines(["pr", "checks", "{cfg.pr}", "--repo", cfg.repo,
         "--json", "name,bucket", "--jq", ".[] | .bucket + \" \" + .name"], ok)
 }
 
-// commit_id per bot review - Copilot's REST author type is Bot
 def private bot_review_shas(cfg : Config; var ok : bool&) : array<string> {
     return <- gh_lines(["api", "repos/{cfg.repo}/pulls/{cfg.pr}/reviews", "--paginate",
         "--jq", ".[] | select(.user.type==\"Bot\") | .commit_id"], ok)
@@ -98,7 +95,7 @@ def private unresolved_threads(cfg : Config; var ok : bool&) : array<string> {
         let lines <- gh_lines(["api", "graphql", "-f", "query={query}", "--jq",
             "(.data.repository.pullRequest.reviewThreads.pageInfo | (.hasNextPage|tostring) + \" \" + (.endCursor // \"\")), (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | .id + \" \" + (.path // \"\"))"], page_ok)
         if (!page_ok || empty(lines)) {
-            ok = page_ok && !empty(lines)
+            ok = false
             break
         }
         threads |> reserve(length(threads) + length(lines) - 1)
@@ -153,12 +150,12 @@ def private request_review_graphql(cfg : Config) : bool {
 }
 
 def private watch(cfg : Config) : int {
-    let polls = max(1, (cfg.timeout_min * 60) / max(1, cfg.interval))
-    var last_line = ""
+    let polls = max(1, (cfg.timeout_min * 60) / max(1, cfg.interval_sec))
+    var last_state = ""
     var escalated = false
     for (poll in range(polls)) {
         if (poll != 0) {
-            sleep(uint(cfg.interval * 1000))
+            sleep(uint(cfg.interval_sec * 1000))
         }
         let head = head_sha(cfg)
         var checks_ok = false
@@ -181,19 +178,18 @@ def private watch(cfg : Config) : int {
         }
         let reviewed = reviews |> has_value(head)
         let state = "tip {slice(head, 0, 9)}: {length(fails)} failed, {pending} pending, reviewed={reviewed}, unresolved={unresolved}"
-        if (state != last_line) {
+        if (state != last_state) {
             to_log(LOG_INFO, "pr-babysit: {state}\n")
-            last_line = state
+            last_state = state
         }
-        let v = watch_verdict(length(fails), pending, reviewed, unresolved)
-        if (v == WatchVerdict.ci_red) {
+        let verdict = watch_verdict(length(fails), pending, reviewed, unresolved)
+        if (verdict == WatchVerdict.ci_red) {
             to_log(LOG_ERROR, "pr-babysit: CI red - {join(fails, ", ")}\n")
             return 2
         }
-        return 3 if (v == WatchVerdict.review_to_triage)
-        return 0 if (v == WatchVerdict.ready_to_merge)
-        // half the budget with no review on a tip we requested: REST accepted but did not
-        // re-trigger - fire the GraphQL rail once and keep watching
+        return 3 if (verdict == WatchVerdict.review_to_triage)
+        return 0 if (verdict == WatchVerdict.ready_to_merge)
+        // REST accepted but never re-triggered
         if (cfg.request_review && !escalated && !reviewed && poll >= polls / 2) {
             escalated = true
             let sent = request_review_graphql(cfg)
@@ -233,8 +229,8 @@ def main() : int {
         to_log(LOG_INFO, "pr-babysit: {length(threads)} unresolved\n")
     }
     if (cfg.request_review) {
-        let rrc = request_review(cfg)
-        return rrc if (rrc != 0)
+        let request_rc = request_review(cfg)
+        return request_rc if (request_rc != 0)
     }
     return cfg.watch ? watch(cfg) : 0
 }

--- a/utils/pr-babysit/main.das
+++ b/utils/pr-babysit/main.das
@@ -195,6 +195,10 @@ def main() : int {
     var cfg = Config()
     let rc = parse_args_with_help(cfg, "pr-babysit")
     return rc if (rc >= 0)
+    if (find(cfg.repo, "/") <= 0) {
+        to_log(LOG_ERROR, "pr-babysit: --repo must be owner/name, got '{cfg.repo}'\n")
+        return 1
+    }
     if (!cfg.request_review && !cfg.watch && !cfg.list_unresolved && empty(cfg.resolve)) {
         to_log(LOG_ERROR, "pr-babysit: pick --request-review, --watch, --list-unresolved, and/or --resolve\n")
         return 1

--- a/utils/pr-babysit/test_watch_verdict.das
+++ b/utils/pr-babysit/test_watch_verdict.das
@@ -22,4 +22,26 @@ def test_watch_verdict(t : T?) {
         t |> equal(watch_verdict(0, 0, false, 4), WatchVerdict.keep_polling)
         t |> equal(watch_verdict(0, 9, false, 0), WatchVerdict.keep_polling)
     }
+    t |> run("check lines classify by bucket; pass and skip are neither") @(t : T?) {
+        let r <- classify_checks(["fail build_linux", "pending docs", "pass lint", "skipping macos", "fail extended checks"])
+        t |> equal(length(r.fails), 2)
+        t |> equal(r.fails[0], "build_linux")
+        t |> equal(r.fails[1], "extended checks")
+        t |> equal(r.pending, 1)
+        let none <- classify_checks([])
+        t |> equal(length(none.fails), 0)
+        t |> equal(none.pending, 0)
+    }
+    t |> run("verdicts map to the documented exits; keep_polling has none") @(t : T?) {
+        t |> equal(exit_for(WatchVerdict.ci_red), 2)
+        t |> equal(exit_for(WatchVerdict.review_to_triage), 3)
+        t |> equal(exit_for(WatchVerdict.ready_to_merge), 0)
+        t |> equal(exit_for(WatchVerdict.keep_polling), -1)
+    }
+    t |> run("poll budget clamps both zeroes") @(t : T?) {
+        t |> equal(poll_budget(45, 30), 90)
+        t |> equal(poll_budget(1, 5), 12)
+        t |> equal(poll_budget(0, 30), 1)
+        t |> equal(poll_budget(1, 0), 60)
+    }
 }

--- a/utils/pr-babysit/test_watch_verdict.das
+++ b/utils/pr-babysit/test_watch_verdict.das
@@ -1,0 +1,25 @@
+options gen2
+require dastest/testing_boost public
+require watch_verdict
+
+[test]
+def test_watch_verdict(t : T?) {
+    t |> run("red CI outranks everything") @(t : T?) {
+        t |> equal(watch_verdict(1, 0, false, 0), WatchVerdict.ci_red)
+        t |> equal(watch_verdict(1, 3, true, 2), WatchVerdict.ci_red)
+        t |> equal(watch_verdict(2, 0, true, 0), WatchVerdict.ci_red)
+    }
+    t |> run("review on tip with open threads means triage, even mid-matrix") @(t : T?) {
+        t |> equal(watch_verdict(0, 5, true, 1), WatchVerdict.review_to_triage)
+        t |> equal(watch_verdict(0, 0, true, 3), WatchVerdict.review_to_triage)
+    }
+    t |> run("ready only when green, dry, and zero unresolved") @(t : T?) {
+        t |> equal(watch_verdict(0, 0, true, 0), WatchVerdict.ready_to_merge)
+        t |> equal(watch_verdict(0, 1, true, 0), WatchVerdict.keep_polling)
+        t |> equal(watch_verdict(0, 0, false, 0), WatchVerdict.keep_polling)
+    }
+    t |> run("unreviewed tip polls regardless of thread state") @(t : T?) {
+        t |> equal(watch_verdict(0, 0, false, 4), WatchVerdict.keep_polling)
+        t |> equal(watch_verdict(0, 9, false, 0), WatchVerdict.keep_polling)
+    }
+}

--- a/utils/pr-babysit/watch_verdict.das
+++ b/utils/pr-babysit/watch_verdict.das
@@ -1,0 +1,19 @@
+options gen2
+
+// pure decision core for --watch; network reads live in main.das
+
+enum public WatchVerdict {
+    keep_polling
+    ci_red
+    review_to_triage
+    ready_to_merge
+}
+
+def public watch_verdict(fail_count : int; pending_count : int; reviewed_tip : bool; unresolved : int) : WatchVerdict {
+    // a red check outranks everything - babysit fixes CI first, Copilot re-reviews the fix anyway
+    return WatchVerdict.ci_red if (fail_count > 0)
+    // triage does not wait for the matrix - the loop iterates against the review, not CI
+    return WatchVerdict.review_to_triage if (reviewed_tip && unresolved > 0)
+    return WatchVerdict.ready_to_merge if (reviewed_tip && unresolved == 0 && pending_count == 0)
+    return WatchVerdict.keep_polling
+}

--- a/utils/pr-babysit/watch_verdict.das
+++ b/utils/pr-babysit/watch_verdict.das
@@ -2,6 +2,9 @@ options gen2
 
 // pure decision core for --watch; network reads live in main.das
 
+require strings
+require math
+
 enum public WatchVerdict {
     keep_polling
     ci_red
@@ -16,4 +19,29 @@ def public watch_verdict(fail_count : int; pending_count : int; reviewed_tip : b
     return WatchVerdict.review_to_triage if (reviewed_tip && unresolved > 0)
     return WatchVerdict.ready_to_merge if (reviewed_tip && unresolved == 0 && pending_count == 0)
     return WatchVerdict.keep_polling
+}
+
+// "<bucket> <name>" check lines -> failing names + pending count; other buckets pass or skip
+def public classify_checks(checks : array<string>) : tuple<fails : array<string>; pending : int> {
+    var r : tuple<fails : array<string>; pending : int>
+    for (c in checks) {
+        if (c |> starts_with("fail ")) {
+            r.fails |> push(slice(c, 5))
+        } elif (c |> starts_with("pending ")) {
+            r.pending++
+        }
+    }
+    return <- r
+}
+
+// process exit per verdict; keep_polling has none
+def public exit_for(verdict : WatchVerdict) : int {
+    return 2 if (verdict == WatchVerdict.ci_red)
+    return 3 if (verdict == WatchVerdict.review_to_triage)
+    return 0 if (verdict == WatchVerdict.ready_to_merge)
+    return -1
+}
+
+def public poll_budget(timeout_min : int; interval_sec : int) : int {
+    return max(1, (timeout_min * 60) / max(1, interval_sec))
 }


### PR DESCRIPTION
babysit.md carried two different things: judgment rules written as exhortation, and GitHub API mechanics written as prose scripts. This PR splits both out. The judgment half is now `skills/review_triage.md` — a verdict procedure for any review comment (Copilot, bot, or human): three ordered tests (Defect: reachable + real scale + named consequence; Falsehood: the code contradicts the text; Reject: a named class or the named failed test), a disposition rule where a defect is always fixed and the only open question is *now* versus *ledgered*, and presentation rules that report decisions and ask only real questions. The mechanics half went into `utils/pr-babysit/main.das`: `--watch` blocks until something needs action (exit 2 CI red, 3 review to triage, 0 ready to merge, 5 timeout), `--request-review` requests Copilot with the REST rail plus a GraphQL escalation, `--list-unresolved` / `--resolve <id>` are the thread rails, and the requested-reviewers blind spot, tip matching, and thread pagination live in the tool — when GitHub changes, we fix the tool, not the skill.

Both documents were driven through repeated cold dragon audits until all-OK: babysit.md passed with every tool claim verified against source; review_triage.md's rounds burned down from a terminal-state contradiction (a ledgered round could never exit the loop) through reject-class coverage gaps to a line wrap, then passed clean. Two approved wording fixes to `skills/comment_style_hygiene.md` ride along (the file-header rule now states trim-or-enumerate past the cap; the incident-citation test no longer reads backwards), and `skills/make_pr.md`'s two restatements of the acceptance bar became pointers.

Where to look: `skills/review_triage.md` (the whole point), `utils/pr-babysit/main.das` (the transport — `unresolved_threads` pagination and the half-timeout GraphQL escalation are the two subtle spots), the babysit.md diff (what prose survived).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local-only: `watch_verdict` truth table 5/5 via dastest; lint and format clean on all three tool files; live runs against a real PR exercised `--watch` across pending/reviewed/green states (exits 5 and 0), `--list-unresolved` (paginated read), and `--request-review` (REST rail, review arrived on the tip).
- Dragon audits: babysit.md all-OK with tool claims source-verified; review_triage.md all-OK on the exit read, including the charter checks (decidable tests, closed reject vocabulary, clean three-way partition with babysit/make_pr).

### Claims — stated, not tested
- The `--resolve` mutation and the GraphQL re-request escalation have not fired against a live target (no unresolved thread or stale-review PR existed during development); both are single `gh api graphql` calls on the transport the verified paths use. First real babysit round exercises them.

### Not done
- The mechanical half's fuller automation (hooks around push→CI-red→fix and the copilot-address-repeat cycle) is the next discussion, deliberately not in this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
