### PR TITLE
Rulebook pins: mechanical triggers for the two human-only checklist gates + ruled rule-doc fixes

### DIFF
--- a/include/daScript/simulate/REVIEW.md
+++ b/include/daScript/simulate/REVIEW.md
@@ -16,5 +16,7 @@
   states a per-consumer verdict (updated / no change needed / rebuild required) for the
   rtti binding (`src/builtin/module_builtin_rtti.cpp`), the das-side readers of the
   struct (enumerate with MCP `grep_usage` on the struct name), and external-module
-  rebuilds (`skills/abi_break_sweep.md`).** A diff doing so with no such statement is a
-  defect.
+  rebuilds (`skills/abi_break_sweep.md`); such a diff with no verdict statement is a
+  defect.** The layout pin (`tests-cpp/small/test_debug_info_layout_pin.cpp`) pins the
+  size and every field offset of every `debug_info.h` struct; a diff weakening the pin
+  is a defect.

--- a/modules/dasLLVM/REVIEW.md
+++ b/modules/dasLLVM/REVIEW.md
@@ -3,45 +3,43 @@
 **Read `REVIEW_COMMON.md` (repo root) first — its contract binds this checklist.** Architecture doc:
 `ARCHITECTURE.md`. Planned work: `DEBUGGING.md` (§ Roadmap).
 
-- **A change under `modules/dasLLVM/` runs the module-owned suite** — `bin/daslang -jit
-  dastest/dastest.das -- --test modules/dasLLVM/tests` on an LLVM-enabled build. The suite is
-  outside the core `tests/` sweep, so no other lane covers it; the build gate lives in
-  `tests/README.md` here.
+- **A change under `modules/dasLLVM/` runs the module-owned suite** (command and build gate:
+  `tests/README.md` here). The suite is outside the core `tests/` sweep, so no other lane
+  covers it.
 
 - **Work added to or moved within the JIT pipeline — `run_jit`, `run_split_codegen`
-  (`llvm_jit_run.das`), or an artifact emitter (`llvm_jit_common.das`) — runs inside a timed
-  phase of the `LLVM JIT time:` breakdown** (phase inventory: `ARCHITECTURE.md` §1). Option
-  resolution before the first timer and log lines are not pipeline work.
+  (`daslib/llvm_jit_run.das`), or an artifact emitter (`daslib/llvm_jit_common.das`) —
+  runs inside a timed phase of the `LLVM JIT time:` breakdown** (phase inventory:
+  `ARCHITECTURE.md` §1). Option resolution before the first timer and log lines are not
+  pipeline work.
 
-- **A diff that breaks one timed phase into finer steps gives each step its own number in
-  the log;** a parent label may keep printing the sum only while its steps print too.
-
-- **New work inside an existing phase prints its own number when `ARCHITECTURE.md` §1 names
-  it as a step;** otherwise it rides the phase's number.
+- **Work added to or split out of a timed phase prints its own `LLVM JIT time:` number, or
+  the phase's number covers it and the phase's line still prints.**
 
 - **A change to code that EMITS machine code — IR generation, target-machine setup, an
-  `[llvm_code]` generator body, the jit call ABI — bumps `LLVM_JIT_CODEGEN_VERSION`**
-  (`llvm_jit_run.das`). A change that only SELECTS among existing generators' `[llvm_code]`
-  arguments — the `[tune]` stamping — needs no bump: stamped arguments fold into the cache
-  keys per function.
+  `[llvm_code]` generator body, the jit call ABI (the generated function signatures, name
+  scheme, prologue, and the externs the install phase binds) — bumps
+  `LLVM_JIT_CODEGEN_VERSION`** (`daslib/llvm_jit_run.das`). A change that only SELECTS
+  among existing generators' `[llvm_code]` arguments — the `[tune]` stamping — needs no
+  bump: stamped arguments fold into the cache keys per function. The emitter-edit trigger
+  is enforced by `tests-cpp/small/test_jit_emitter_pin.cpp` (repo root); weakening that
+  test is a defect.
 
 - **A new environment or config input to the cache key folds inside `jit_env_salt`
-  (`llvm_jit_run.das`), never directly into either key** — salt feeds both keys, and a config
+  (`daslib/llvm_jit_run.das`), never directly into either cache key — the DLL key or the
+  split-obj key (`ARCHITECTURE.md` §2)** — salt feeds both keys, and a config
   folded into one but not the other links stale objects. Inputs that vary per function set
   (AOT hashes) are key material, not salt.
 
 - **A change to a `[tune]`-family annotation is reviewed with `skills/tune.md`** — the
   family's reference.
 
-- **A diff that makes `llvm_tune.das`'s sidecar writers (`tune_manifest_set`,
-  `tune_sidecar_merge`, `tune_sidecar_section_merge`, `tune_provenance_note`) emit a new
-  top-level section, or a new value shape inside one, updates
+- **A diff that adds a new top-level section, or a new value shape inside one, to the tune
+  sidecar (`<app>.tune.json`, written by `daslib/llvm_tune.das`) updates
   `modules/dasLLAMA/performance/exchange_schema.das` in the same change and keeps
-  `modules/dasLLAMA/tests/test_exchange_schema.das` green.** That validator allow-lists
-  exactly `kernels` / `runtime` / `provenance` / `race`, so a section it does not know fails
-  every newly minted sidecar at submission, and the checked-in corpus the test sweeps cannot
-  show it. A new `provenance` key needs no change there — a lowercase `[a-z0-9_.-]` key with
-  a plain printable-ASCII value already validates.
+  `modules/dasLLAMA/tests/test_exchange_schema.das` green** — the validator allow-lists
+  sections, so one it does not know fails every newly minted sidecar at submission, and
+  the checked-in corpus the test sweeps cannot show it.
 
 - **A diff introducing an override knob adds it to `ARCHITECTURE.md` §3's inventory in the
   same change.** An override knob is readable from outside the code under review — an
@@ -54,19 +52,14 @@
   consumer, same change. A knob added, or given a new effect, without its announce is a
   defect.
 
-- **An environment knob is an `[EnvConfig]` field in `llvm_env.das`, read as a `g_env_jit` /
-  `g_env_tune` field — declare knobs there, never read raw.** The load-once/arm-children
-  mechanism is `ARCHITECTURE.md` §3.
+- **An environment knob is an `[EnvConfig]` field in `daslib/llvm_env.das`, read as a `g_env_jit` /
+  `g_env_tune` field.** The load-once/arm-children mechanism is `ARCHITECTURE.md` §3.
 
 - **An ambient name — an environment variable the module reads but does not own — goes
   through `env_value_of` / `env_is_set`, with an `ambient_rows` entry backing every literal
   name; a `set_env_variable` names only a declared knob.**
 
-- **`get_env_variable` / `has_env_variable` / literal-name `env_config_*` anywhere outside
-  `llvm_env.das` in the module is a defect** — including the non-literal spelling
-  `get_env_variable(expr)`, which only review catches; `tests/llvm_env_registry.das` (run
-  per-PR by the extended checks) enforces the literal-name forms.
-
-- **`ENVIRONMENT.md` is generated (`harness/gen_env_doc.das`); hand-editing it is a defect.**
-  A change to `llvm_env.das` or the repo-root `daslib/env_registry.das` re-runs the generator
-  and commits the diff; `tests/llvm_env_registry.das` fails on drift.
+- **A computed-name env read — `get_env_variable(expr)` / `has_env_variable(expr)` outside
+  `daslib/llvm_env.das` — is a defect only review catches: spell the name as a literal
+  through the declared forms, or declare the knob, instead** (the literal-name forms are
+  scanner-enforced by `tests/llvm_env_registry.das`; weakening that test is a defect).

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -38,6 +38,10 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // makes every previously written DLL miss the cache on the next run and get GC'd.
 let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x4ful   // literal lowering: fixed-array element slots sized by recordType.sizeOf; invoke-to-cmres now skipped like call-to-cmres at let-init, copy/move and every make-* element visit (0x4e: scalar ABI coercion at calls, returns and branches)
 
+// Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
+// (normalized to LF; file list in the test)
+let LLVM_JIT_EMITTER_HASH : uint64 = 0x61996da823206333ul
+
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
 // `options fast_math` stamps every FP op with VALUE-SAFE flags (reassoc|nsz|contract) before opt —

--- a/modules/dasLLVM/tests/README.md
+++ b/modules/dasLLVM/tests/README.md
@@ -4,7 +4,8 @@ These module-owned tests cover the `llvm_tune` permutation, manifest, policy, tu
 and re-execution integration paths. They are intentionally outside the core `tests/jit_tests`
 sweep because several cases spawn nested `daslang` processes and full JIT compilations.
 
-Run the suite explicitly from the repository root:
+Run the suite explicitly from the repository root, on an LLVM-enabled build
+(`-DDAS_LLVM_DISABLED=OFF`):
 
 ```text
 bin/Release/daslang.exe dastest/dastest.das -jit -- --timing-outliers 10 --test modules/dasLLVM/tests

--- a/skills/build_and_debug.md
+++ b/skills/build_and_debug.md
@@ -26,10 +26,9 @@ This skill uses `bin/Release/daslang.exe` in examples below (the dominant local-
 ## Build timing
 
 - **Builds are slow** — clean builds take **15-25 minutes**, incremental builds take **2-10 minutes** depending on what changed
-- **Always use `timeout: 0`** (no timeout) when running `cmake --build` commands. A build that hasn't finished is not stuck or broken, it's just compiling
+- **Always use `timeout: 0`** (no timeout) when running `cmake --build` commands. A build that hasn't finished is not stuck or broken, it's just compiling. A build killed mid-compile is worse than slow — it leaves truncated `.obj` files (see Build failures by symptom below)
 - **Do not assume build failure** from lack of output — MSVC and most generators are silent during compilation and only print when there are warnings/errors or when it finishes
 - For incremental builds after editing a single `.cpp` file, expect ~2-5 minutes. For changes touching headers, expect longer
-- **MSVC `C1001` / `LNK1000` during "Generating code"** (Windows) — link-time codegen (LTCG) choking on a **stale incremental database** (`.ipdb`/`.iobj`) in a long-lived `build/`, *not* a code bug. The line `"no usable IPDB/IOBJ from previous compilation … fall back to full compilation"` on a clean retry confirms it. Fix: clean-rebuild just the offending target — `cmake --build build --target <name> --clean-first` — rather than nuking `build/`. Commonly triggered when a config change (e.g. flipping a `DAS_*_DISABLED` flag) forces a recompile of an object whose stale LTCG state no longer matches.
 
 ### Shared OpenSSL cache (Windows/MSVC) — the big first-build lever
 
@@ -41,6 +40,15 @@ To build OpenSSL **once and reuse it everywhere**, point it at a shared cache (i
 
 The default (no env, no flag) stays per-build-dir, so **CI is unchanged** — its lanes use vcpkg (`vcpkg install openssl` + the vcpkg toolchain) or a cached from-source `build-clangcl/openssl` for the same effect. Linux/macOS use the system OpenSSL (brew/apt/mingw sysroot), so this is MSVC-only.
 
+## Build failures by symptom
+
+Each entry is symptom → cause → fix. Never `rm -rf build` as a first move — every one of these has a targeted repair.
+
+- **MSVC `C1001` / `LNK1000` during "Generating code"** (Windows) — link-time codegen (LTCG) choking on a **stale incremental database** (`.ipdb`/`.iobj`) in a long-lived `build/`, *not* a code bug. The line `"no usable IPDB/IOBJ from previous compilation … fall back to full compilation"` on a clean retry confirms it. Fix: clean-rebuild just the offending target — `cmake --build build --target <name> --clean-first` — rather than nuking `build/`. Commonly triggered when a config change (e.g. flipping a `DAS_*_DISABLED` flag) forces a recompile of an object whose stale LTCG state no longer matches.
+- **MSVC `LNK1103` "debugging information corrupt" / `LNK1136`** (Windows) — a build killed mid-compile (tool timeout, manual interrupt) left a **truncated `.obj`** whose fresh timestamp incremental builds trust forever. Fix: `powershell utils/build-heal/heal.ps1 [-Target <name>]` — it runs the build, deletes the `.obj` files named by corrupt-obj link errors, and retries.
+- **MSVC `LNK1104` on `libDaScriptDyn*.dll`** (Windows) — the DLL is loaded by a live process: the MCP server host, a stray `daslang`/`daslang-live`. Shut the MCP server down (`mcp__daslang__shutdown`) and kill strays **by path, never by image name** — details in `skills/make_pr.md`.
+- **daslang crashes on every script run — even after a full clean rebuild — while `tests-cpp-small` stays green**: a **stale external-module `shared_module`** (built in its own `modules/<name>/_build` against pre-change headers) is ABI-drifted; shared-module auto-discovery loads it into every compile, `tests-cpp` never scans them. Find it by mtime (`ls -lt modules/*/[a-zA-Z]*.shared_module` — the odd one out predates the header change) and rebuild that module's `_build`. Under cdb the giveaway is the `ModLoad` of the stale `.shared_module` right before the AV (see Native crash triage below).
+
 ## Debugging runtime crashes
 
 - **Always check the exit code** after running `daslang` — a crash may produce no output, looking like a silent success
@@ -50,7 +58,19 @@ The default (no env, no flag) stays per-build-dir, so **CI is unchanged** — it
 - **Don't truncate output** with `head`/`tail` — daslang stack traces and `DAS_GC_BREAK_ON_ID` traces are easily clipped. Capture full output, then `grep` if needed
 - **`options log_infer_passes`** — append at the end of a failing `.das` file to dump per-pass infer activity (which generics got reified, when finalize ran, where lookups missed). Smaller and more targeted than `options log` for template/generic reification bugs. `options log` stays the right tool when you need the final program text
 
-### JIT crash symbols and daslang stacks
+### Native crash triage (Windows)
+
+When daslang itself AVs, get the faulting instruction before theorizing:
+
+```text
+"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe" -o -c ".lines; g; .exr -1; ln @rip; kc 20; q" bin\Release\daslang.exe <args>
+```
+
+- `ln @rip` names the nearest symbol and source line; `kc` gives the call stack. Release LTCG inlines aggressively, so a thin stack (`daslang!main` only) means the attribution is useless — go to the faulting instruction instead.
+- Watch the `ModLoad` lines just before the AV — a `.shared_module` loading right before the crash points at ABI drift (see Build failures by symptom above).
+- **Heap corruption** (`RtlFreeHeap`/`RtlpHeapHandleError` in the stack — the crash site is the *victim*, not the culprit): arm full PageHeap so the corrupting WRITE faults instead — `gflags /p /enable daslang.exe /full` (elevated; gflags sits beside cdb), re-run under cdb, and **always disarm after** with `gflags /p /disable daslang.exe /full` — the IFEO entry is machine-wide, keyed by image name, and taxes every daslang run ~4× on memory until removed.
+
+### JIT crash debugging
 
 Use both debug rails for a long-running JIT repro:
 
@@ -60,20 +80,25 @@ bin/Release/daslang.exe -jit -jit-stack path/to/main.das -- --jit-debug
 
 - `-jit-stack` is a host flag placed before the script. It retains a logical daslang frame for every generated function and block so `Context::getStackWalk()` has useful JIT state.
 - `--jit-debug` is an LLVM JIT option passed after the script separator. It emits CodeView/PDB debug information, generated function names, and `.das` file/line locations. On Windows the PDB lands beside the content-addressed DLL under `.jitted_scripts/`.
-- `--jit-opt-level=0` disables the LLVM IR pass pipeline AND drives the DLL path's codegen-side target machine (fast isel) — a true end-to-end O0 for `-jit` runs, several-fold faster to build. Exe (`-exe`) and AOT-object emission still pin codegen level 3 deliberately (shipped artifacts). At level 0 the injected tune-policy default becomes `fallback` (winners are raced under O3 codegen); `DAS_TUNE_POLICY` still overrides.
 - **JIT DLL cache staleness** — the cache key folds the codegen version, per-function AOT hashes, loop hints, and fast-math, so `LLVM_JIT_CODEGEN_VERSION` bumps and tune-sidecar edits re-key automatically. Blunt fallback when behavior looks stale anyway: delete `.jitted_scripts/`. Always wipe it before declaring a JIT regression.
-- **Fast edit iteration: `--jit-split-modules=-1`** (after the `--` separator) partitions codegen per das-module — parallel emit makes the cold build several-fold faster, and the per-module obj cache (on by default under split; `--jit-obj-cache=0` disables) re-emits only from the FIRST CHANGED MODULE onward on a warm edit. **Invalidation is positional, so require order is the cache layout: place the module you are actively editing as LATE in the require chain as its dependencies allow** — a hot-edit module required early drags everything after it into every rebuild, one required last rebuilds nearly alone (canonical: the dasLLAMA umbrella requires the vulkan drivers last for exactly this reason). The cache holds ONE generation — reverting an edit re-emits from the reverted module on, same as the edit did. Dev tier only — split partitions lose cross-module inlining, so never benchmark through a split DLL.
-- **Front-end cache: `-module-cache <path>`** (host flag, before the script; also on `daslang-live`) caches the compiled AST module graph via the env-serializer rail: the first run writes the file, later runs deserialize post-infer modules instead of parsing them — measured ~12x on the dasLLAMA graph (12.2s → 1.0s compile-only). Invalidation is mtime-based with the same positional model as the obj cache: an edited module recompiles itself and everything after it, and the cache rewrites itself. A record that can never deserialize in a cold process (`llvm_func.das` — its `[dasbind]` externs register into the dasbind builtin module during compile) reparses in place (~0.03s) without cutting the stream — the run reports `deser: partial`. `-ser <path>` / `-deser <path>` are the explicit write/read halves (the round-trip test instrument; `deser: clean` vs `deser: FALLBACK` is the honest verdict). Composes with the split obj cache: a warm `-jit` edit deserializes the unchanged prefix and re-emits only the tail partitions. Dev tier only; the cache is one file you own — delete it when in doubt.
 - JIT crash bundles should preserve the matching `.dll`, `.pdb`, `.map`, and retained `.o` together. The content hash changes when debug info is toggled, so artifacts from a non-debug cache entry do not decode a debug run.
 - Windows Release C/C++ builds use `/Z7` plus linker `/DEBUG /OPT:REF /OPT:ICF`, producing side PDBs without changing optimized code. Keep the PDB that matches every shipped exe/DLL when diagnosing native runtime frames.
 
 The implementation and remaining debugger roadmap are in `modules/dasLLVM/DEBUGGING.md`.
 
+## Fast JIT iteration
+
+Dev-tier rails that cut the edit-compile-run loop; never benchmark through them.
+
+- **`--jit-opt-level=0`** (after the script separator) disables the LLVM IR pass pipeline AND drives the DLL path's codegen-side target machine (fast isel) — a true end-to-end O0 for `-jit` runs, several-fold faster to build. Exe (`-exe`) and AOT-object emission still pin codegen level 3 deliberately (shipped artifacts). At level 0 the injected tune-policy default becomes `fallback` (winners are raced under O3 codegen); `DAS_TUNE_POLICY` still overrides.
+- **`--jit-split-modules=-1`** (after the `--` separator) partitions codegen per das-module — parallel emit makes the cold build several-fold faster, and the per-module obj cache (on by default under split; `--jit-obj-cache=0` disables) re-emits only from the FIRST CHANGED MODULE onward on a warm edit. **Invalidation is positional, so require order is the cache layout: place the module you are actively editing as LATE in the require chain as its dependencies allow** — a hot-edit module required early drags everything after it into every rebuild, one required last rebuilds nearly alone (canonical: the dasLLAMA umbrella requires the vulkan drivers last for exactly this reason). The cache holds ONE generation — reverting an edit re-emits from the reverted module on, same as the edit did. Split partitions lose cross-module inlining, so never benchmark through a split DLL.
+- **Front-end cache: `-module-cache <path>`** (host flag, before the script; also on `daslang-live`) caches the compiled AST module graph via the env-serializer rail: the first run writes the file, later runs deserialize post-infer modules instead of parsing them — measured ~12x on the dasLLAMA graph (12.2s → 1.0s compile-only). Invalidation is mtime-based with the same positional model as the obj cache: an edited module recompiles itself and everything after it, and the cache rewrites itself. A record that can never deserialize in a cold process (`llvm_func.das` — its `[dasbind]` externs register into the dasbind builtin module during compile) reparses in place (~0.03s) without cutting the stream — the run reports `deser: partial`. `-ser <path>` / `-deser <path>` are the explicit write/read halves (the round-trip test instrument; `deser: clean` vs `deser: FALLBACK` is the honest verdict). Composes with the split obj cache: a warm `-jit` edit deserializes the unchanged prefix and re-emits only the tail partitions. The cache is one file you own — delete it when in doubt.
+
 ## Build configurations (module flags)
 
 Optional modules are controlled by CMake flags (`DAS_*_DISABLED`). The active configuration lives in `.vscode/settings.json` under `cmake.configureSettings` (the "WIP" block is the active one; others are commented-out presets).
 
-Key flags (defaults are MIXED — see CMakeLists.txt:28-43):
+Key flags (defaults are MIXED — see the `option(DAS_*_DISABLED …)` block near the top of CMakeLists.txt):
 - Default `OFF` (module ENABLED by default): `DAS_HV_DISABLED` (dasHV — HTTP/WebSocket via libhv), `DAS_GLFW_DISABLED` (GLFW/OpenGL windowing), `DAS_PUGIXML_DISABLED` (XML), `DAS_AUDIO_DISABLED`, `DAS_STBIMAGE_DISABLED`, `DAS_STDDLG_DISABLED`
 - Default `ON` (module DISABLED by default): `DAS_LLVM_DISABLED` (LLVM JIT), `DAS_CLANG_BIND_DISABLED` (Clang bindings), `DAS_SQLITE_DISABLED`
 - dasImgui is in-tree (`modules/dasImgui`) with `DAS_IMGUI_DISABLED` (default `OFF` = enabled). It needs dasGlfw + dasClipboard — a derived gate in `modules/dasImgui/CMakeLists.txt` drops it when either is disabled. Its still-external dependents (dasImguiImplot, dasImguiNodeEditor) are cloned into `modules/` by consumers like the wasm playground (see `.github/workflows/wasmboy.yml`)
@@ -88,4 +113,4 @@ When AOT fails with `error[50101]: AOT link failed`, the issue is a **semantic h
 
 For the full debugging workflow, see `skills/aot_hash_desync_debugging.md` (side-by-side SimNode dumps via `options log_nodes`/`log_nodes_aot_hash`, common shapes, C++ debug switches).
 
-The AOT C++ emitter lives in **`daslib/aot_cpp.das`** (the old `src/ast/ast_aot_cpp.cpp` was deleted by commit `581363ebc`). When codegen output diverges, edit `daslib/aot_cpp.das`.
+The AOT C++ emitter lives in **`daslib/aot_cpp.das`** (the old `src/ast/ast_aot_cpp.cpp` was deleted; only the header remains). When codegen output diverges, edit `daslib/aot_cpp.das`.

--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -57,8 +57,8 @@ no home in the file goes to a design doc. Terse section dividers stay.
 
 **A file header is a map, not an essay.** At or under the comment cap a header may stay
 prose; past it, it either becomes a map — one line per fact of the file's contract — or
-gets trimmed. A map may repeat per-symbol comments (a cold reader needs the shape before
-any symbol), never text the code already prints.
+gets trimmed. A header may repeat per-symbol comments (a cold reader needs the shape
+before any symbol), never text the code already prints.
 
 **Private symbols don't get public-style docs.** Doc-comment syntax (`//!` and kin) is
 for tooling-visible public API. On a private symbol a docstring restates the name to a
@@ -73,8 +73,10 @@ group, within the cap.
 
 **Branch hints ride the branch line.** A few words on the `if` identifying what lands
 in the branch (`// retries exhausted upstream, not here`). A WHY the line can't hold
-sits directly above the `if`, two lines at most; prose inside the branch body is
-never right. A self-describing predicate — a named helper, a compare against a named
+sits directly above the `if`, two lines at most; a hint never gets a standalone comment
+line inside the body — owned by one statement it rides that statement's line, `pass`
+included; spanning more than one it is about the branch and belongs on the `if` line or
+in the WHY above. A self-describing predicate — a named helper, a compare against a named
 constant — gets nothing: restating `fn.neverInline` as "explicit opt-out" is
 narration. The comment must say something the identifiers don't.
 

--- a/tests-cpp/small/test_debug_info_layout_pin.cpp
+++ b/tests-cpp/small/test_debug_info_layout_pin.cpp
@@ -1,0 +1,215 @@
+// Layout pin for the debug_info.h data structs.
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include "daScript/simulate/debug_info.h"
+#include <cstddef>
+
+using namespace das;
+
+#if INTPTR_MAX == INT64_MAX
+
+#define DAS_PIN_MSG "debug_info.h layout changed: re-pin this line in the same diff and state the per-consumer verdicts (include/daScript/simulate/REVIEW.md)"
+
+static_assert(sizeof(AnnotationArgumentInfo) == 32, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationArgumentInfo, type) == 0, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationArgumentInfo, name) == 8, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationArgumentInfo, sValue) == 16, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationArgumentInfo, iValue) == 24, DAS_PIN_MSG);
+static_assert(sizeof(AnnotationInfo) == 40, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationInfo, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationInfo, module_name) == 8, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationInfo, arguments) == 16, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationInfo, count) == 24, DAS_PIN_MSG);
+static_assert(offsetof(AnnotationInfo, resolved) == 32, DAS_PIN_MSG);
+static_assert(sizeof(LineInfo) == 24, DAS_PIN_MSG);
+static_assert(offsetof(LineInfo, fileInfo) == 0, DAS_PIN_MSG);
+static_assert(offsetof(LineInfo, column) == 8, DAS_PIN_MSG);
+static_assert(offsetof(LineInfo, line) == 12, DAS_PIN_MSG);
+static_assert(offsetof(LineInfo, last_column) == 16, DAS_PIN_MSG);
+static_assert(offsetof(LineInfo, last_line) == 20, DAS_PIN_MSG);
+static_assert(sizeof(LineInfoArg) == 24, DAS_PIN_MSG);
+static_assert(sizeof(TypeInfo) == 80, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, structType) == 0, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, firstType) == 8, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, secondType) == 16, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, argTypes) == 24, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, argNames) == 32, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, dim) == 40, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, hash) == 48, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, type) == 56, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, flags) == 60, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, size) == 64, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, argCount) == 68, DAS_PIN_MSG);
+static_assert(offsetof(TypeInfo, dimSize) == 72, DAS_PIN_MSG);
+static_assert(sizeof(VarInfo) == 128, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, value) == 80, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, sValue) == 80, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, name) == 96, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, annotation_arguments) == 104, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, annotation_argument_count) == 112, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, offset) == 116, DAS_PIN_MSG);
+static_assert(offsetof(VarInfo, nextGcField) == 120, DAS_PIN_MSG);
+static_assert(sizeof(StructInfo) == 72, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, module_name) == 8, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, fields) == 16, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, annotations) == 24, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, hash) == 32, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, init_mnh) == 40, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, flags) == 48, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, count) == 52, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, size) == 56, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, firstGcField) == 60, DAS_PIN_MSG);
+static_assert(offsetof(StructInfo, annotation_count) == 64, DAS_PIN_MSG);
+static_assert(sizeof(EnumValueInfo) == 16, DAS_PIN_MSG);
+static_assert(offsetof(EnumValueInfo, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(EnumValueInfo, value) == 8, DAS_PIN_MSG);
+static_assert(sizeof(EnumInfo) == 64, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, module_name) == 8, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, fields) == 16, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, count) == 24, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, hash) == 32, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, flags) == 40, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, annotations) == 48, DAS_PIN_MSG);
+static_assert(offsetof(EnumInfo, annotation_count) == 56, DAS_PIN_MSG);
+static_assert(sizeof(LocalVariableInfo) == 128, DAS_PIN_MSG);
+static_assert(offsetof(LocalVariableInfo, visibility) == 80, DAS_PIN_MSG);
+static_assert(offsetof(LocalVariableInfo, name) == 104, DAS_PIN_MSG);
+static_assert(offsetof(LocalVariableInfo, stackTop) == 112, DAS_PIN_MSG);
+static_assert(offsetof(LocalVariableInfo, localFlags) == 116, DAS_PIN_MSG);
+static_assert(offsetof(LocalVariableInfo, openPos) == 120, DAS_PIN_MSG);
+static_assert(offsetof(LocalVariableInfo, closePos) == 124, DAS_PIN_MSG);
+static_assert(sizeof(FramePosInterval) == 8, DAS_PIN_MSG);
+static_assert(offsetof(FramePosInterval, open) == 0, DAS_PIN_MSG);
+static_assert(offsetof(FramePosInterval, close) == 4, DAS_PIN_MSG);
+static_assert(sizeof(FuncInfo) == 96, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, cppName) == 8, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, fields) == 16, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, result) == 24, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, locals) == 32, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, globals) == 40, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, annotations) == 48, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, hash) == 56, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, flags) == 64, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, count) == 68, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, stackSize) == 72, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, localCount) == 76, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, globalCount) == 80, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, annotation_count) == 84, DAS_PIN_MSG);
+static_assert(offsetof(FuncInfo, spaceId) == 88, DAS_PIN_MSG);
+
+// STL-bearing structs: values are per-STL (and per-CRT: /MDd inflates string/vector), so pin
+// ONE ABI only — MSVC x64 Release runs on every PR, and one firing lane is enough to force
+// the re-pin into the same diff
+#if defined(_MSC_VER) && !DAS_ENABLE_PROFILER && _ITERATOR_DEBUG_LEVEL == 0
+static_assert(sizeof(FileInfo) == 80, DAS_PIN_MSG);
+static_assert(sizeof(TextFileInfo) == 96, DAS_PIN_MSG);
+static_assert(sizeof(ModuleInfo) == 136, DAS_PIN_MSG);
+static_assert(sizeof(BaseRequireRecord) == 64, DAS_PIN_MSG);
+static_assert(sizeof(RequireRecord) == 72, DAS_PIN_MSG);
+static_assert(sizeof(MissingRecord) == 136, DAS_PIN_MSG);
+static_assert(sizeof(NamelessModuleReq) == 128, DAS_PIN_MSG);
+static_assert(sizeof(NamelessMismatch) == 224, DAS_PIN_MSG);
+static_assert(sizeof(BasicAnnotation) == 112, DAS_PIN_MSG);
+// by-name offsets so a size-neutral field swap still fires
+static_assert(offsetof(ModuleInfo, moduleName) == 0, DAS_PIN_MSG);
+static_assert(offsetof(ModuleInfo, fileName) == 32, DAS_PIN_MSG);
+static_assert(offsetof(ModuleInfo, importName) == 64, DAS_PIN_MSG);
+static_assert(offsetof(ModuleInfo, extraDepModule) == 96, DAS_PIN_MSG);
+static_assert(offsetof(ModuleInfo, requireName) == 104, DAS_PIN_MSG);
+static_assert(offsetof(BaseRequireRecord, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(BaseRequireRecord, line) == 32, DAS_PIN_MSG);
+static_assert(offsetof(BaseRequireRecord, chain) == 40, DAS_PIN_MSG);
+static_assert(offsetof(RequireRecord, isPublic) == 64, DAS_PIN_MSG);
+static_assert(offsetof(MissingRecord, hintType) == 64, DAS_PIN_MSG);
+static_assert(offsetof(MissingRecord, hintName) == 72, DAS_PIN_MSG);
+static_assert(offsetof(MissingRecord, hintName2) == 104, DAS_PIN_MSG);
+static_assert(offsetof(NamelessModuleReq, name) == 0, DAS_PIN_MSG);
+static_assert(offsetof(NamelessModuleReq, moduleName) == 32, DAS_PIN_MSG);
+static_assert(offsetof(NamelessModuleReq, fileName) == 64, DAS_PIN_MSG);
+static_assert(offsetof(NamelessModuleReq, fromFile) == 96, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, chain) == 0, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, line) == 24, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, name1) == 32, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, fileName1) == 64, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, fromFile1) == 96, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, name2) == 128, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, fileName2) == 160, DAS_PIN_MSG);
+static_assert(offsetof(NamelessMismatch, fromFile2) == 192, DAS_PIN_MSG);
+
+// derived probes lift protected members into offsetof reach; they add no members, so
+// base-subobject layout is unchanged
+struct FileInfoPins : FileInfo {
+    using FileInfo::lineOffsets;
+    using FileInfo::lineIndexBuilt;
+};
+struct TextFileInfoPins : TextFileInfo {
+    using TextFileInfo::source;
+    using TextFileInfo::sourceLength;
+    using TextFileInfo::owner;
+};
+struct FileAccessPins : FileAccess {
+    using FileAccess::files;
+    using FileAccess::extraModules;
+    using FileAccess::autoRequiredModules;
+    using FileAccess::locked;
+};
+struct ModuleFileAccessPins : ModuleFileAccess {
+    using ModuleFileAccess::context;
+    using ModuleFileAccess::modGet;
+    using ModuleFileAccess::includeGet;
+    using ModuleFileAccess::moduleAllowed;
+    using ModuleFileAccess::moduleUnsafe;
+    using ModuleFileAccess::withModuleUnsafe;
+    using ModuleFileAccess::canModuleBeRequired;
+    using ModuleFileAccess::sameFileName;
+    using ModuleFileAccess::optionAllowed;
+    using ModuleFileAccess::optionBlocked;
+    using ModuleFileAccess::annotationAllowed;
+    using ModuleFileAccess::podInScopeAllowed;
+    using ModuleFileAccess::dynModulesFolderGet;
+};
+
+static_assert(sizeof(FileAccess) == 248, DAS_PIN_MSG);
+static_assert(sizeof(ModuleFileAccess) == 352, DAS_PIN_MSG);
+static_assert(offsetof(FileInfo, name) == 8, DAS_PIN_MSG);
+static_assert(offsetof(FileInfo, tabSize) == 40, DAS_PIN_MSG);
+static_assert(offsetof(FileInfoPins, lineOffsets) == 48, DAS_PIN_MSG);
+static_assert(offsetof(FileInfoPins, lineIndexBuilt) == 72, DAS_PIN_MSG);
+static_assert(offsetof(TextFileInfoPins, source) == 80, DAS_PIN_MSG);
+static_assert(offsetof(TextFileInfoPins, sourceLength) == 88, DAS_PIN_MSG);
+static_assert(offsetof(TextFileInfoPins, owner) == 92, DAS_PIN_MSG);
+static_assert(offsetof(BasicAnnotation, name) == 48, DAS_PIN_MSG);
+static_assert(offsetof(BasicAnnotation, cppName) == 80, DAS_PIN_MSG);
+static_assert(offsetof(FileAccessPins, files) == 48, DAS_PIN_MSG);
+static_assert(offsetof(FileAccessPins, extraModules) == 144, DAS_PIN_MSG);
+static_assert(offsetof(FileAccessPins, autoRequiredModules) == 168, DAS_PIN_MSG);
+static_assert(offsetof(FileAccessPins, locked) == 240, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, context) == 248, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, modGet) == 256, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, includeGet) == 264, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, moduleAllowed) == 272, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, moduleUnsafe) == 280, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, withModuleUnsafe) == 288, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, canModuleBeRequired) == 296, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, sameFileName) == 304, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, optionAllowed) == 312, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, optionBlocked) == 320, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, annotationAllowed) == 328, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, podInScopeAllowed) == 336, DAS_PIN_MSG);
+static_assert(offsetof(ModuleFileAccessPins, dynModulesFolderGet) == 344, DAS_PIN_MSG);
+#endif
+
+TEST_CASE("debug_info.h layout pins hold") {
+    CHECK(sizeof(void *) == 8);
+}
+
+#else
+
+TEST_CASE("debug_info.h layout pins skipped (64-bit only)") {
+    MESSAGE("layout pins are 64-bit only; skipped");
+}
+
+#endif

--- a/tests-cpp/small/test_jit_emitter_pin.cpp
+++ b/tests-cpp/small/test_jit_emitter_pin.cpp
@@ -1,0 +1,77 @@
+// Content pin for the LLVM JIT emitter sources. Emitted-code changes are invisible to the
+// DLL cache key (it folds the USER program's hashes, not the emitters'), so the trigger
+// has to be text-level.
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+using namespace das;
+
+// files whose text change can alter emitted machine code without changing the user
+// program's AOT hashes. llvm_tune.das stays out by design (selection only);
+// x64_avx/aarch64_neon/f16_cvt are plain das reference bodies, visible to the AOT hash;
+// llvm_aot/llvm_exe emit explicit artifacts, not silently cached DLLs.
+static const char * EMITTER_FILES[] = {
+    "llvm_jit.das",
+    "llvm_jit_common.das",
+    "llvm_boost.das",
+    "llvm_macro.das",
+    "llvm_jit_code.das",
+    "llvm_code.das",
+    "llvm_dsl.das",
+    "llvm_jit_intrin.das",
+    "llvm_targets.das",
+    "llvm_user_modules.das",
+};
+
+// normalized to LF so Windows and Linux checkouts agree
+static uint64_t fnv1a64 ( uint64_t h, const char * data, size_t size ) {
+    for ( size_t i = 0; i != size; ++i ) {
+        if ( data[i] == '\r' ) continue;
+        h ^= uint8_t(data[i]);
+        h *= 0x100000001b3ul;
+    }
+    return h;
+}
+
+static std::string readWholeFile ( const std::string & path ) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if ( !f ) return std::string();
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    std::string text;
+    text.resize(size_t(size));
+    size_t got = fread(&text[0], 1, size_t(size), f);
+    fclose(f);
+    text.resize(got);
+    return text;
+}
+
+TEST_CASE("jit emitter sources match the pinned hash") {
+    const std::string daslib = getDasRoot() + "/modules/dasLLVM/daslib/";
+    uint64_t emitterHash = 0xcbf29ce484222325ul;
+    for ( const char * name : EMITTER_FILES ) {
+        std::string text = readWholeFile(daslib + name);
+        REQUIRE_MESSAGE(!text.empty(), "can't read emitter source: " << name);
+        emitterHash = fnv1a64(emitterHash, name, strlen(name));
+        emitterHash = fnv1a64(emitterHash, "\n", 1);
+        emitterHash = fnv1a64(emitterHash, text.data(), text.size());
+    }
+    std::string runSrc = readWholeFile(daslib + "llvm_jit_run.das");
+    REQUIRE_MESSAGE(!runSrc.empty(), "can't read llvm_jit_run.das");
+    size_t pinAt = runSrc.find("let LLVM_JIT_EMITTER_HASH");
+    REQUIRE_MESSAGE(pinAt != std::string::npos, "pin constant LLVM_JIT_EMITTER_HASH missing from llvm_jit_run.das");
+    size_t hexAt = runSrc.find("0x", pinAt);
+    REQUIRE_MESSAGE(hexAt != std::string::npos, "pin constant LLVM_JIT_EMITTER_HASH has no 0x value");
+    uint64_t pinned = strtoull(runSrc.c_str() + hexAt, nullptr, 16);
+    char pinLiteral[32];
+    snprintf(pinLiteral, sizeof(pinLiteral), "0x%llxul", (unsigned long long) emitterHash);
+    INFO("emitter sources changed: set LLVM_JIT_EMITTER_HASH = " << pinLiteral
+        << " in llvm_jit_run.das, and bump LLVM_JIT_CODEGEN_VERSION beside it if emitted code changed");
+    CHECK_EQ(emitterHash, pinned);
+}

--- a/utils/build-heal/heal.ps1
+++ b/utils/build-heal/heal.ps1
@@ -1,0 +1,60 @@
+# Runs the cmake build and heals corrupt-obj link failures. An interrupted compile leaves a
+# truncated .obj with a fresh timestamp, which incremental builds trust forever: the linker
+# reports LNK1103 "debugging information corrupt" (or LNK1136), or — when the truncation hits
+# a code section — links a binary that crashes at startup. On a corrupt-obj signature this
+# deletes the named .obj files so they recompile, and retries the build.
+#
+# Usage: powershell utils/build-heal/heal.ps1 [-Target daslang[,tests-cpp-small]]
+#        [-Config Release] [-Jobs 32] [-BuildDir build] [-MaxHeals 2]
+param(
+    [string[]] $Target = @(),
+    [string] $Config = "Release",
+    [int] $Jobs = 32,
+    [int] $MaxHeals = 2,
+    [string] $BuildDir = "build"
+)
+
+$ErrorActionPreference = "Continue"
+
+for ($round = 0; $round -le $MaxHeals; $round++) {
+    $buildArgs = @("--build", $BuildDir, "--config", $Config, "-j", $Jobs)
+    if ($Target.Count -gt 0) {
+        $buildArgs += "--target"
+        $buildArgs += $Target
+    }
+    Write-Output "build round $round : cmake $($buildArgs -join ' ')"
+    $out = & cmake @buildArgs 2>&1 | ForEach-Object { $_.ToString() }
+    $rc = $LASTEXITCODE
+    $errLines = $out | Where-Object { $_ -match "fatal error|error C[0-9]|LNK[0-9]" }
+    $errLines | Select-Object -First 20 | ForEach-Object { Write-Output $_ }
+    if ($rc -eq 0 -and -not ($errLines | Where-Object { $_ -match "LNK1103|LNK1136" })) {
+        Write-Output "build OK (round $round)"
+        exit 0
+    }
+
+    # "dasHV.obj : fatal error LNK1103: debugging information corrupt; recompile module [...]"
+    $corrupt = @()
+    foreach ($line in ($out | Where-Object { $_ -match "LNK1103|LNK1136" })) {
+        if ($line -match "([\w.+-]+\.obj)") { $corrupt += $Matches[1] }
+    }
+    $corrupt = $corrupt | Sort-Object -Unique
+    if ($corrupt.Count -eq 0) {
+        Write-Output "build failed (rc=$rc) with no corrupt-obj signature - not healable here"
+        exit $rc
+    }
+    if ($round -eq $MaxHeals) { break }
+    foreach ($name in $corrupt) {
+        $found = @(Get-ChildItem -Path $BuildDir -Recurse -Filter $name -ErrorAction SilentlyContinue)
+        if ($found.Count -eq 0) {
+            Write-Output "corrupt obj $name not found under $BuildDir - clean its owning target manually"
+            continue
+        }
+        foreach ($f in $found) {
+            Write-Output "healing: deleting $($f.FullName)"
+            Remove-Item -Force $f.FullName
+        }
+    }
+}
+
+Write-Output "still failing after $MaxHeals heal rounds"
+exit 1


### PR DESCRIPTION
Two review-checklist gates relied on a human noticing the trigger; both are now forced by tests. `tests-cpp/small/test_debug_info_layout_pin.cpp` pins the size and every field offset of every `debug_info.h` struct — portable asserts for the fixed-layout structs, MSVC-x64-Release-only asserts for the STL-bearing ones (values are per-STL/per-CRT; one firing lane is enough), derived probe structs to reach protected members — so a layout change cannot build without re-pinning in the same diff, which is the simulate `REVIEW.md` rule's cue to demand the per-consumer verdicts. `tests-cpp/small/test_jit_emitter_pin.cpp` hashes the ten dasLLVM emitter sources against `LLVM_JIT_EMITTER_HASH`, checked in directly below `LLVM_JIT_CODEGEN_VERSION` — an emitter edit stays red until the re-pin lands beside the version, so the bump-or-not judgment becomes a visible two-line diff. Emitter changes are invisible to the DLL cache key (it folds the user program's hashes, not the emitters'), which is why the trigger is text-level.

Riding along: the post-#3748 rulebook walkthrough rulings (7 on `modules/dasLLVM/REVIEW.md`, 2 on `skills/comment_style_hygiene.md`), with the checklists' new pin-trigger tails; a top-to-bottom rework of `skills/build_and_debug.md` (failure modes by symptom, native crash triage via cdb/PageHeap, JIT iteration rails split out of crash debugging — including the stale-external-`shared_module` ABI-drift crash signature diagnosed on the dev box today); and `utils/build-heal/heal.ps1`, which deletes the `.obj` files named by corrupt-obj link errors and retries the build.

Per the simulate `REVIEW.md` rule this PR itself triggers: no `debug_info.h` field was added, removed, or reordered — the pin file is new — so the rtti binding, das-side readers, and external-module rebuilds all need no change.

Where to look: the two pin tests; the `LLVM_JIT_EMITTER_HASH` block in `modules/dasLLVM/daslib/llvm_jit_run.das`; the rewritten rules at `include/daScript/simulate/REVIEW.md:15-21` and `modules/dasLLVM/REVIEW.md`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full interp suite 13632 tests, 13629 passed, 0 failed, 3 skipped; dasLLVM module-owned suite green (270s); tests-cpp-small 89/89 (1.1M assertions); JIT smoke green.
- Negative controls, all executed and restored: emitter pin — appended byte to a pinned source → red with the new hash in the message; renamed the constant → red on the missing-pin `REQUIRE`. Layout pin — falsified one offset → `C2338` with the re-pin instruction; header-side control (padded `FramePosInterval`) → 3× `C2338`; falsified a probe-derived protected-member offset → `C2338`.
- Pin hash independently recomputed twice (once by a review agent, once by the TDD auditor in Python) — both matched the committed constant.
- Full preflight not run: the diff is rule docs, tests-cpp additions, one inert das constant, and a PowerShell tool; the touched gates ran individually (changed-set lint clean, format clean, mojibake clean, both suites above). No daslib/language change → AOT untouched.

### Claims — stated, not tested
- `heal.ps1` branches are untested (dev-only tooling; the not-healable arm was manually observed: empty build dir → correct message, exit 1; PS 5.1 parse-verified). A break shows as a wrong heal decision on the next corrupt-obj incident.
- STL-struct pin values are MSVC x64 Release (`/MD`, `_ITERATOR_DEBUG_LEVEL == 0`); Debug lanes compile the block out by design (measured `/MDd` values differ — the gate exists because of that).
- A new field slotted entirely into existing tail padding moves no pinned value; the rule's unconditional verdict obligation covers that residue.

### Not done
- PR-lint (changed-set relational checks) not built — both triggers landed as plain tests instead. Remaining lint-backlog candidates: pin-file-in-diff ⇒ verdict block present in PR body; `[EnvConfig]`-field ⇔ `ARCHITECTURE.md` §3 inventory drift assertion (dragon-recommended); codegen-bump adjacency check.
- One style-rulebook finding ledgered for review, not applied: "The message is the comment" is written per-site, so a comment restating a failure string printed in a *different* file escapes its letter.
- The `daslang.exe` IFEO registry key from the PageHeap session exists but is empty (inert); full removal needs an elevated shell.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
