### PR TITLE
generator lowering: a for source runs once — the iterator temp var double-evaluated it

### DIFF
--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -1407,6 +1407,9 @@ namespace das {
 
     bool srcNeedTempVar ( Expression * src, TypeDecl * type ) {
         if ( !type->isRef() ) return false;
+        // an iterator source is consumed directly by the source variable's move-init;
+        // a temp would evaluate the source expression a second time
+        if ( type->isGoodIteratorType() ) return false;
         return src->rtti_isCallLikeExpr() || src->rtti_isMakeLocal();
     }
 
@@ -1537,7 +1540,6 @@ namespace das {
                 svar->at = expr->at;
                 svar->name = srcName + "_temp_var";
                 svar->type = new TypeDecl(Type::autoinfer);
-            svar->type->at = svar->at;
                 svar->type->at = svar->at;
                 svar->init_via_move = true;
                 svar->init = src->clone();

--- a/tests/language/generator_source_eval_once.das
+++ b/tests/language/generator_source_eval_once.das
@@ -1,0 +1,142 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require daslib/coroutines
+
+// Pins the contract that a `for` source expression is evaluated exactly once.
+// Shapes the double-eval bug hit: a yielding for-loop in a generator body, and the
+// co_await/yeild_from macros that inline a call as a for source. Shapes that must not
+// regress: array-returning call source, yieldless coroutine for-loop, comprehension.
+
+var g_iter_count : int = 0
+var g_arr_count : int = 0
+var g_bump_count : int = 0
+
+def noisy_iter() : iterator<int> {
+    g_iter_count ++
+    return <- generator<int> {
+        yield 1
+        yield 2
+        yield 3
+        return false
+    }
+}
+
+def noisy_arr() : array<int> {
+    g_arr_count ++
+    return <- [10, 20, 30]
+}
+
+def bump(n : int) : int {
+    g_bump_count ++
+    return n
+}
+
+[coroutine]
+def sub_task(_n : int) {
+    co_continue()
+}
+
+[coroutine]
+def awaiting_task() {
+    co_await <| sub_task(bump(7))
+}
+
+[coroutine]
+def delegating_gen() : int {
+    yeild_from <| noisy_iter()
+    return false
+}
+
+[coroutine]
+def yieldless_for_sum() : int {
+    var total = 0
+    for (x in noisy_iter()) {
+        total += x
+    }
+    yield total
+    return false
+}
+
+[test]
+def test_generator_for_source_eval_once(t : T?) {
+    t |> run("iterator call in a yielding for-loop runs once") @(t : T?) {
+        g_iter_count = 0
+        var total = 0
+        var gen <- generator<int> {
+            for (x in noisy_iter()) {
+                yield x
+            }
+            return false
+        }
+        for (v in gen) {
+            total += v
+        }
+        t |> equal(g_iter_count, 1)
+        t |> equal(total, 6)
+    }
+    t |> run("zip sources each run once") @(t : T?) {
+        g_iter_count = 0
+        g_arr_count = 0
+        var total = 0
+        var gen <- generator<int> {
+            for (a, b in noisy_iter(), noisy_arr()) {
+                yield a + b
+            }
+            return false
+        }
+        for (v in gen) {
+            total += v
+        }
+        t |> equal(g_iter_count, 1)
+        t |> equal(g_arr_count, 1)
+        t |> equal(total, 66)
+    }
+    t |> run("co_await argument runs once") @(t : T?) {
+        g_bump_count = 0
+        var c <- awaiting_task()
+        cr_run(c)
+        t |> equal(g_bump_count, 1)
+    }
+    t |> run("yeild_from source runs once") @(t : T?) {
+        g_iter_count = 0
+        var total = 0
+        for (v in delegating_gen()) {
+            total += v
+        }
+        t |> equal(g_iter_count, 1)
+        t |> equal(total, 6)
+    }
+    t |> run("array-returning call runs once") @(t : T?) {
+        g_arr_count = 0
+        var total = 0
+        var gen <- generator<int> {
+            for (x in noisy_arr()) {
+                yield x
+            }
+            return false
+        }
+        for (v in gen) {
+            total += v
+        }
+        t |> equal(g_arr_count, 1)
+        t |> equal(total, 60)
+    }
+    t |> run("for-loop in a yieldless coroutine runs the source once") @(t : T?) {
+        g_iter_count = 0
+        var res = 0
+        for (v in yieldless_for_sum()) {
+            res = v
+        }
+        t |> equal(g_iter_count, 1)
+        t |> equal(res, 6)
+    }
+    t |> run("comprehension source runs once") @(t : T?) {
+        g_iter_count = 0
+        let vals <- [for (x in noisy_iter()); x]
+        t |> equal(g_iter_count, 1)
+        t |> equal(length(vals), 3)
+    }
+}


### PR DESCRIPTION
**Behavior change: a `for` source call inside a generator now runs once, not twice — code that (unknowingly) relied on the extra side effect will observe one fewer call.**

Every `for x in f()` whose loop body yields called `f()` twice. `srcNeedTempVar` counts `tIterator` as a ref type, so an iterator-returning call got a temp variable holding one clone of the call — and then the `isGoodIteratorType` branch cloned the call again for the direct move-init, never reading the temp. The loop consumed the second iterator; the first was only closed by the finalizer, so pure factories survived and the bug hid for months. `co_await`, `yeild_from`, and async `await` all splice their argument into exactly this shape, so every await double-evaluated its expression. The fix skips the temp for good iterator sources — the direct move-init consumes the call; the each()/temp path for non-iterator ref sources is untouched. A duplicated line in the temp-var block rides along.

Where to look: `srcNeedTempVar` in `src/ast/ast_generate.cpp` (the new early-return), and the source-init region of `replaceGeneratorFor` just below it (unchanged, but where both inits are emitted). Test: `tests/language/generator_source_eval_once.das` — four arms negative-controlled red pre-fix, three arms pin the previously-correct paths.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full AOT sweep run locally (nightly-only lane; the only pre-push AOT check outside tests/language): 12733 tests, 12732 passed, 0 failed, 1 skipped, with all `_aot_generated` stubs wiped first. Preflight's tests-aot gate itself skipped on the known DLL-pin condition; this manual run is the gate's content.
- AST-verify sweep over daslib + tests: zero new reports; the only hits are the pre-existing #3727 unset-at TypeDecl reports (`daslib/delegate.das`, aot template fixture), already ledgered master-wide.
- cpp-syntax (clang-cl frontend) gate skipped — no clang on this box; the C++ change is a 3-line guard + a deleted duplicate line, and the nightly clang lanes cover it.
- Sequence smoke skipped locally — its `daspkg install` step fails on this box before compiling anything (env, not the diff); CI's extended_checks runs the lane per-PR. Imgui gate (nightly-only lane) skipped — the lowering change is validated by the full interp/JIT/AOT suites; the imgui nightly re-proves within 24h.

### Claims — stated, not tested
- The array-source control arm ("array-returning call runs once") is not proven to catch an over-broad fix (one that skipped the temp for non-iterator ref sources too): a probe of the un-temped shape suggests it would leak the array rather than corrupt it, leaving values and count green. The arm still pins the call count; the temp-still-needed behavior itself is otherwise unguarded in-tree. Settling it needs a mutation build (`return false` for all ref sources) — not run.

### Not done
- `daslib/coroutines.das` (`co_await`/`yeild_from`) and async `await` could hoist their argument into a capture instead of splicing it into the for source (the comprehension lowering already does this). Root fix makes it unnecessary; noted only as design context.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)