### PR TITLE
trycatch panic path leaked the in-flight exception object — FMT_THROW now destroys it before the jump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,12 +486,12 @@ jobs:
         esac
         case "${{ matrix.target }}${{ matrix.architecture }}" in
            linux64)
-            # LSan suppressions: format_error (fmt::throw_format_error allocates
-            # std::runtime_error whose internal string is reported as leaked
-            # because the exception object isn't always destroyed); uriParseSingleUriA
-            # / uriMakeOwner (Uri handle bound to daslang without auto-finalize —
-            # tracked separately, real fix is in the binding).
-            printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
+            # LSan suppressions: uriParseSingleUriA / uriMakeOwner (Uri handle bound
+            # to daslang without auto-finalize — tracked separately, real fix is in
+            # the binding). format_error is deliberately NOT suppressed: FMT_THROW
+            # destroys the exception before the panic jump, and this lane is the
+            # regression canary for that.
+            printf 'leak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
             export TSAN_OPTIONS="suppressions=$(pwd)/.github/tsan_suppressions.txt"
             # Sanitizer matrix: only run language tests under JIT (full test
@@ -540,9 +540,9 @@ jobs:
     - name: "Small C++ Tests"
       run: |
         set -eux
-        # Suppress LSan false-positives from format_error and JIT-mode exit() paths;
-        # see "Test" step above for the same suppressions.
-        printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > build/suppressions.txt
+        # Suppress LSan false-positives from the Uri binding; see "Test" step above
+        # for the same suppressions.
+        printf 'leak:uriParseSingleUriA\nleak:uriMakeOwner\n' > build/suppressions.txt
         export LSAN_OPTIONS="suppressions=$(pwd)/build/suppressions.txt"
         cd build
         case "${{ matrix.target }}${{ matrix.architecture }}" in
@@ -571,7 +571,7 @@ jobs:
            *)
             # Same suppressions as the "Test" step — sanitizer matrix entries
             # need them here too.
-            printf 'leak:format_error\nleak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
+            printf 'leak:uriParseSingleUriA\nleak:uriMakeOwner\n' > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
             export TSAN_OPTIONS="suppressions=$(pwd)/.github/tsan_suppressions.txt"
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_aot

--- a/cmake/das_config_eastl/daScript/das_config.h
+++ b/cmake/das_config_eastl/daScript/das_config.h
@@ -92,12 +92,27 @@ using std::chrono::milliseconds;
 } // namespace das
 #define DAS_USE_EASTL 1
 
-namespace das
-{
-void das_throw(const char *msg);
+// one of three identical copies - include/daScript/das_config.h, include/misc/include_fmt.h,
+// cmake/das_config_eastl/daScript/das_config.h; whichever a TU includes first must stand alone
+namespace das {
+  void das_throw(const char * msg);
 }
 #if (!defined(DAS_ENABLE_EXCEPTIONS)) || (!DAS_ENABLE_EXCEPTIONS)
-#define FMT_THROW(x) das::das_throw(((x).what()))
+#ifndef DAS_FMT_THROW_DEFINED
+#define DAS_FMT_THROW_DEFINED
+namespace das {
+  void das_stash_throw(const char * msg);
+  void das_throw_stashed();
+  // the panic longjmp never unwinds (POSIX never does; the JIT stack cannot be unwound);
+  // the temporary dies when the stash statement ends - the jump crosses nothing live
+  template <typename BuildAndStash>
+  inline void das_stash_then_throw(BuildAndStash && buildAndStash) {
+      buildAndStash();
+      das_throw_stashed();
+  }
+}
+#define FMT_THROW(x)    das::das_stash_then_throw([&]{ das::das_stash_throw(((x).what())); })
+#endif
 #endif
 
 #define DAS_GLOBAL_NEW 1

--- a/include/daScript/das_config.h
+++ b/include/daScript/das_config.h
@@ -34,11 +34,27 @@
 namespace das {using namespace std;}
 
 
+// one of three identical copies - include/daScript/das_config.h, include/misc/include_fmt.h,
+// cmake/das_config_eastl/daScript/das_config.h; whichever a TU includes first must stand alone
 namespace das {
   void das_throw(const char * msg);
 }
 #if (!defined(DAS_ENABLE_EXCEPTIONS)) || (!DAS_ENABLE_EXCEPTIONS)
-#define FMT_THROW(x)    das::das_throw(((x).what()))
+#ifndef DAS_FMT_THROW_DEFINED
+#define DAS_FMT_THROW_DEFINED
+namespace das {
+  void das_stash_throw(const char * msg);
+  void das_throw_stashed();
+  // the panic longjmp never unwinds (POSIX never does; the JIT stack cannot be unwound);
+  // the temporary dies when the stash statement ends - the jump crosses nothing live
+  template <typename BuildAndStash>
+  inline void das_stash_then_throw(BuildAndStash && buildAndStash) {
+      buildAndStash();
+      das_throw_stashed();
+  }
+}
+#define FMT_THROW(x)    das::das_stash_then_throw([&]{ das::das_stash_throw(((x).what())); })
+#endif
 #endif
 
 #if DAS_CUSTOM_HASH

--- a/include/misc/include_fmt.h
+++ b/include/misc/include_fmt.h
@@ -1,10 +1,26 @@
 #pragma once
 
+// one of three identical copies - include/daScript/das_config.h, include/misc/include_fmt.h,
+// cmake/das_config_eastl/daScript/das_config.h; whichever a TU includes first must stand alone
 namespace das {
   void das_throw(const char * msg);
 }
 #if (!defined(DAS_ENABLE_EXCEPTIONS)) || (!DAS_ENABLE_EXCEPTIONS)
-#define FMT_THROW(x)    das::das_throw(((x).what()))
+#ifndef DAS_FMT_THROW_DEFINED
+#define DAS_FMT_THROW_DEFINED
+namespace das {
+  void das_stash_throw(const char * msg);
+  void das_throw_stashed();
+  // the panic longjmp never unwinds (POSIX never does; the JIT stack cannot be unwound);
+  // the temporary dies when the stash statement ends - the jump crosses nothing live
+  template <typename BuildAndStash>
+  inline void das_stash_then_throw(BuildAndStash && buildAndStash) {
+      buildAndStash();
+      das_throw_stashed();
+  }
+}
+#define FMT_THROW(x)    das::das_stash_then_throw([&]{ das::das_stash_throw(((x).what())); })
+#endif
 #endif
 
 #include <fmt/core.h>

--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -26,29 +26,27 @@ fixes.
   problem and the fix in its own words ("this comment narrates the assignment below
   it"), never by citing this guide. The guide teaches writing; it is not an authority
   to invoke.
-- **Exceptions justify themselves.** There is no exception marker. A comment that
-  needs to be long must make the reason obvious from its content alone — an
-  injectivity argument, a wire-format contract, a miscompile it prevents. If a reader
-  who never saw this guide would ask "why is this comment so long?", that is the
-  finding.
+- **Exceptions justify themselves.** There is no exception marker; a rule's own text
+  carries the boundary for when a departure stands.
 - **The audit is not a gate.** Style review runs on every PR; findings persuade, lint
   compels. Fix or consciously decline — there is no re-run-until-clean loop.
 
 Rules marked *(lintable)* are mechanical enough for a lint to enforce; das already has
-some (noted), C++/JS lints are follow-up work.
+some (noted), C++ and JS have none — there the rule is the reviewer's.
 
 ## Comments
 
-**Short or absent.** 1–2 lines preferred, 3 the cap — das lint STYLE014 enforces it under
-`daslib/` and wherever `options _comment_hygiene = true`; everywhere else the cap is the
-reviewer's. Inside a `def private` body the cap is ONE line (STYLE015, same gating), and that cap is
-body-only: a comment *attached to* a private symbol takes the ordinary 3-line cap plus the
-bar in *Private symbols don't get public-style docs* below. The cap covers per-symbol
-and in-body comments; the file header — the block before the first declaration,
-STYLE014's boundary — is governed by the map rule below. A comment that doesn't fit is
-the signal to interrogate it: why does this need prose at all, and does the detail
-belong at the use site, in the file-header map (shared contract moves up, the symbol
-keeps what is specific to it) — or nowhere?
+**Short or absent.** 1–2 lines preferred, 3 the cap. A comment's volume is the number
+of lines its text would occupy re-wrapped at the width the file's other comments use —
+count those against the cap. das lint STYLE014 enforces the physical line count under
+`daslib/` and wherever `options _comment_hygiene = true`; everywhere else the cap is
+the reviewer's. The cap covers per-symbol and in-body comments; the file header — the
+block before the first declaration, STYLE014's boundary — is governed by the map rule
+below. Over the cap, a comment stands only when its content alone shows why — an
+injectivity argument, a wire-format contract, a miscompile it prevents; the test is
+that a cold reader never asks "why is this comment so long?". Anything else over the
+cap gets interrogated: does the detail belong at the use site, in the file-header map
+(shared contract moves up, the symbol keeps what is specific to it) — or nowhere?
 
 **No banners, no preambles.** No `// ===== name — desc =====` block above a function
 that already carries its own doc-comment, and no section-head essay restating what the
@@ -66,6 +64,11 @@ reader who already has it; if there is a genuine one-line WHY, write a plain com
 The bar for any comment on a private symbol: a maintainer reading the symbol alone
 would be surprised without it.
 
+**The body of a private function caps comments at ONE line** — a `def private`, a C++
+static or anonymous-namespace helper, a non-exported JS function (das: STYLE015, same
+gating as STYLE014). Body-only: a comment *attached to* a private symbol takes the
+ordinary cap plus the bar in *Private symbols don't get public-style docs* above.
+
 **Field comments ride the declaration line** *(lintable)*, never a line above — fewer
 lines, and the struct scans as a table. A note that cannot fit the line belongs at the use
 site; one that explains a GROUP of fields rather than any single one may sit above the
@@ -73,19 +76,20 @@ group, within the cap.
 
 **Branch hints ride the branch line.** A few words on the `if` identifying what lands
 in the branch (`// retries exhausted upstream, not here`). A WHY the line can't hold
-sits directly above the `if`, two lines at most; a hint never gets a standalone comment
-line inside the body — owned by one statement it rides that statement's line, `pass`
-included; spanning more than one it is about the branch and belongs on the `if` line or
+sits directly above the `if`, two lines at most. A hint inside the body never gets its
+own line: a note about one statement rides that statement's line (`pass` included); a
+note spanning several statements is about the branch — it belongs on the `if` line or
 in the WHY above. A self-describing predicate — a named helper, a compare against a named
 constant — gets nothing: restating `fn.neverInline` as "explicit opt-out" is
 narration. The comment must say something the identifiers don't.
 
 **No incident citations.** The banned form is a citation that can only be verified
-outside the code — a PR or issue number, a date, "proven: <module> lost <bug>". The required form is the
-failure mode named in present tense at the code that guards it: "a defaulted operand
-no call site can supply crashes simulation", not "used to crash". A mechanism note
-stays when a maintainer needs it to change the code without breaking the guard (why
-an encoding stays injective); it goes when it only argues the guard was right.
+outside the code — a PR or issue number, a date, "proven: <module> lost <bug>". The
+required form is the failure mode named in present tense at the code that guards it:
+"a defaulted operand no call site can supply crashes simulation", not "used to crash".
+A mechanism note stays when a maintainer needs it to change the code without breaking
+the guard (why an encoding stays injective); it goes when it only argues the guard was
+right.
 
 **The message is the comment.** Any site that already carries a human-readable failure
 string — a branch's error/decline/log, an assertion or panic message, a test
@@ -93,9 +97,13 @@ expectation — gets no comment restating it; put the fact the reader needs *int
 string instead. This makes good diagnostics double as documentation — one more reason
 to write them well.
 
-**Counterpart pointers earn their line.** When a condition handles one half of a split
-responsibility, a few words naming where the other half lives is a good same-line
-comment: `if (isLiteral(a)) return true;   // variables resolve in BindingScan`.
+**Counterpart pointers earn their line.** When code has a counterpart that must change
+with it — the other half of a split condition, a block duplicated in a second file — a
+few words naming where the counterpart lives are a good comment:
+`if (isLiteral(a)) return true;   // variables resolve in BindingScan`. The pointer
+rides the pointed-from line when it fits; when the pointed-from code is a whole region
+— its half of a duplicated block — or the pointer overflows the line, it sits directly
+above the pointed-from code, each copy carrying its own.
 The discriminator against the consequence-note ban below: a pointer names WHERE the other
 half lives, so a maintainer changing this line knows what else to open
 (`// consumed by control.html's chat panel`); a note describing WHAT the effect looks like

--- a/src/simulate/runtime_string.cpp
+++ b/src/simulate/runtime_string.cpp
@@ -18,9 +18,12 @@ namespace das
     DAS_THREAD_LOCAL(jmp_buf *) g_throwBuf;
     DAS_THREAD_LOCAL(string) g_throwMsg;
 
-    void das_throw(const char * msg) {
+    void das_stash_throw(const char * msg) {
+        *g_throwMsg = msg ? msg : "";
+    }
+
+    void das_throw_stashed() {
         if ( *g_throwBuf ) {
-            *g_throwMsg = msg;
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Walign-mismatch"  // mingw jmp_buf alignment
@@ -30,8 +33,13 @@ namespace das
 #pragma clang diagnostic pop
 #endif
         } else {
-            DAS_FATAL_ERROR("unhanded das_throw, %s\n", msg);
+            DAS_FATAL_ERROR("unhandled das_throw (no active das_trycatch): %s\n", g_throwMsg->c_str());
         }
+    }
+
+    void das_throw(const char * msg) {
+        das_stash_throw(msg);
+        das_throw_stashed();
     }
 
 #if defined(_MSC_VER)

--- a/tests-cpp/small/test_fmt_throw_lifetime.cpp
+++ b/tests-cpp/small/test_fmt_throw_lifetime.cpp
@@ -1,0 +1,54 @@
+// The panic longjmp does not unwind on POSIX, and can never be made to: JIT frames
+// cannot be unwound. An exception object handed to FMT_THROW leaks unless it dies first.
+
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+#include "daScript/simulate/aot.h"
+
+using namespace das;
+
+#if (!defined(DAS_ENABLE_EXCEPTIONS)) || (!DAS_ENABLE_EXCEPTIONS)
+
+namespace {
+    struct ProbeError {
+        static int destroyed;
+        ~ProbeError() { destroyed++; }
+        const char * what() const { return "probe message"; }
+    };
+    int ProbeError::destroyed = 0;
+}
+
+TEST_CASE("FMT_THROW destroys its exception before the panic jump") {
+    ProbeError::destroyed = 0;
+    int destroyedAtCatch = -1;
+    string caught;
+    das_trycatch([&]{
+        FMT_THROW(ProbeError());
+    },[&](const char * msg){
+        destroyedAtCatch = ProbeError::destroyed;
+        caught = msg;
+    });
+    CHECK_EQ(destroyedAtCatch, 1);
+    CHECK_EQ(ProbeError::destroyed, 1);
+    CHECK_EQ(caught, "probe message");
+}
+
+TEST_CASE("das_throw delivers its message to the active das_trycatch") {
+    string caught;
+    das_trycatch([&]{
+        das_throw("boom");
+    },[&](const char * msg){
+        caught = msg;
+    });
+    CHECK_EQ(caught, "boom");
+}
+
+#else
+
+TEST_CASE("FMT_THROW exception lifetime is RAII-owned when exceptions are enabled") {
+    MESSAGE("FMT_THROW is a real C++ throw here; RAII owns the object");
+    CHECK(true);
+}
+
+#endif


### PR DESCRIPTION
**The `leak:format_error` LSan suppression is removed from build.yml — the asan lane now goes red if this leak ever comes back.**

The panic longjmp never unwinds on POSIX, and can never be made to unwind anywhere — the JIT stack cannot be unwound (the same fact behind the zeroed `_JUMP_BUFFER::Frame` in `simulate_exceptions.cpp`). `FMT_THROW`'s old expansion `das_throw((x).what())` jumped out of the full-expression while the exception temporary was still alive, so the object and its message string leaked on every formatting error — the 43B/throw LSan hit from #3733, silent otherwise because the message is copied into the thread-local before the jump. The new expansion `das_stash_then_throw([&]{ das_stash_throw(((x).what())); })` keeps expression position but ends the temporary's life inside the lambda body — the stash statement is its own full-expression — so the jump crosses nothing live. The invariant is stated at the macro. `das_throw` is recomposed from the same halves and now null-guards its message like the exceptions arm always did. The config block exists in three identical copies (`das_config.h`, `include_fmt.h`, the EASTL shadow config) — all three updated and each now names the trio.

Where to look: the guarded block in `include/daScript/das_config.h`; `das_stash_throw`/`das_throw_stashed` in `src/simulate/runtime_string.cpp`; the suppression removals in `.github/workflows/build.yml` (3 sites, uri pair kept).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Negative control on the real rail (linux WSL Release, the longjmp arm — Windows dev builds are `DAS_ENABLE_EXCEPTIONS=1`, where the arm compiles out): test-only commit RED (`destroyed==0` at and after the catch, message still delivered), fix commit GREEN 3/3; after the audit round, 2 cases / 4 assertions green.
- WSL full interp suite on the longjmp arm: 12613 tests, 12604 passed, 0 failed, 9 skipped (module dirs absent in that minimal build).
- EASTL lane mirrored verbatim in WSL (`ci/build_eastl_config.sh pc`): compiles and links clean — the shadow-config copy is proven, not assumed.
- Windows (exceptions arm): full interp suite 13640/13637/0 failed, ctest -L small 92/92, preflight full 13 passed / 0 failed. tests-aot gate skipped on the known DLL-pin condition — no AOT-visible surface changed (the longjmp arm does not compile on this host; nightly AOT covers).
- cpp-syntax gate skipped (no clang on this box); the linux/mingw/clang-cl lanes compile the changed arm.

### Claims — stated, not tested
- The fatal (no-active-`das_trycatch`) arm of `das_throw_stashed` is untestable in-repo (both `DAS_FATAL_ERROR` expansions exit; no death-test facility). Behavior delta vs master: message text now says what is broken, and a null message prints empty instead of `(null)` — the null-guard in `das_stash_throw` also removes the `*g_throwMsg = nullptr` UB the recomposition would otherwise have introduced. No in-tree caller passes null.
- On MSVC x64 the `das_trycatch` longjmp still performs SEH unwinding (its jmp_buf `Frame` is not zeroed, unlike the context panic rail) — pre-fix that unwinding is likely why the leak never showed on Windows. This PR does not change that asymmetry; code between `das_trycatch`'s setjmp and a `das_throw` must neither rely on unwinding (POSIX won't) nor break under it (MSVC will).

### Not done
- `daslang_hash_map::at`'s `das_throw` sites now have their first test (the round-trip arm) but the missing-key path itself is still untested at the container level.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)