### PR TITLE
Fix dasllama canonical URLs and sitemap

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -559,6 +559,7 @@ jobs:
         # copies are checked in (the preview rig serves the tree directly), but the
         # deploy regenerates anyway so a forgotten local run cannot ship stale news.
         python3 site-dasllama/build_news.py --root site-dasllama
+        python3 site-dasllama/test_metadata.py
 
         cp site-dasllama/index.html _site_dasllama/
         cp site-dasllama/ladder.html _site_dasllama/

--- a/site-dasllama/README.md
+++ b/site-dasllama/README.md
@@ -21,6 +21,11 @@ project "daslang.io Forge") on the daslang.io Forge system. Arc plan + follow-up
   preview matches production, and the deploy re-runs it anyway
 - `robots.txt` — static
 
+The public home URL is `https://dasllama.io/`. All pages link home with `/`, each page
+declares an absolute canonical URL, and `utils/dasllama-ladder/caddy.snippet` permanently
+redirects `/index.html` to `/`. The sitemap and Atom feed also use the root URL so crawlers
+never receive competing home-page identities.
+
 Shared css is NOT duplicated here: `forge.css`, `nav-dropdown.css` and
 `dasllama-table.css` live in `site/files/` (single source) and are staged into this
 site's `files/` at deploy. `dasllama-table.css` is the shared measurement-table language

--- a/site-dasllama/build_news.py
+++ b/site-dasllama/build_news.py
@@ -4,7 +4,7 @@ Build the dasllama.io news feed from _news/*.md.
 
 Rewrites index.html between the `<!-- news:begin -->` / `<!-- news:end -->` markers and
 regenerates feed.xml (Atom) and sitemap.xml next to it. Entries live ON the home page —
-there are no per-entry pages; feed entries link to the entry's anchor on index.html.
+there are no per-entry pages; feed entries link to the entry's anchor on the home page.
 
 The generated output is CHECKED IN (unlike daslang.io's blog, which builds into _site
 only): the preview rig serves the repo tree directly, and the site must preview exactly
@@ -117,7 +117,7 @@ def write_feed(root: Path, entries: list[dict], site_url: str) -> None:
     md = markdown.Markdown(extensions=['fenced_code'])
     items = []
     for e in entries:
-        link = f'{site_url}/index.html#n-{e["slug"]}'
+        link = f'{site_url}/#n-{e["slug"]}'
         body = md.convert(e['body_md']) if e['body_md'] else ''
         md.reset()
         items.append(
@@ -147,7 +147,7 @@ def write_feed(root: Path, entries: list[dict], site_url: str) -> None:
 
 def write_sitemap(root: Path, entries: list[dict], site_url: str) -> None:
     newest = entries[0]['date'] if entries else None
-    urls = [('index.html', newest), ('ladder.html', None), ('sidecars.html', None)]
+    urls = [('', newest), ('ladder.html', None), ('sidecars.html', None)]
     body = '\n'.join(
         f'<url><loc>{site_url}/{page}</loc>'
         + (f'<lastmod>{lastmod}</lastmod>' if lastmod else '')

--- a/site-dasllama/feed.xml
+++ b/site-dasllama/feed.xml
@@ -8,8 +8,8 @@
 <id>https://dasllama.io/</id>
 <entry>
 <title>dasllama.io is live — news, the full ladder, and the sidecar exchange.</title>
-<link href="https://dasllama.io/index.html#n-2026-08-10-dasllama-io-is-live"/>
-<id>https://dasllama.io/index.html#n-2026-08-10-dasllama-io-is-live</id>
+<link href="https://dasllama.io/#n-2026-08-10-dasllama-io-is-live"/>
+<id>https://dasllama.io/#n-2026-08-10-dasllama-io-is-live</id>
 <updated>2026-08-10T00:00:00Z</updated>
 <content type="html">&lt;p&gt;Everything measured now lives here, community submissions included.
 &lt;a href=&quot;https://daslang.io/dasllama.html&quot;&gt;daslang.io/dasllama.html&lt;/a&gt; stays the promotional

--- a/site-dasllama/index.html
+++ b/site-dasllama/index.html
@@ -7,6 +7,7 @@
 <meta property="og:description" content="LLM + speech-to-text inference written in daslang, JIT-compiled. News, ladder, sidecars."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://dasllama.io/"/>
+<link rel="canonical" href="https://dasllama.io/"/>
 <link rel="icon" href="files/dasllama-favicon.svg" type="image/svg+xml"/>
 <link rel="alternate" type="application/atom+xml" href="/feed.xml" title="dasllama.io news"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -24,8 +25,8 @@
 <nav class="dio-nav" id="nav"><div class="forge-container"><div class="dio-nav__inner">
 <div class="dio-nav__left">
 <button class="dio-nav__burger" onclick="document.getElementById('nav').classList.toggle('is-open')">≡</button>
-<a class="dio-mark" href="index.html"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
-<div class="dio-tabs"><a class="dio-tab is-active" href="index.html">home</a><a class="dio-tab" href="ladder.html">ladder</a><a class="dio-tab" href="sidecars.html">sidecars</a></div>
+<a class="dio-mark" href="/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
+<div class="dio-tabs"><a class="dio-tab is-active" href="/">home</a><a class="dio-tab" href="ladder.html">ladder</a><a class="dio-tab" href="sidecars.html">sidecars</a></div>
 </div>
 <div class="dio-nav__right"><a class="dio-nav__gh" href="https://github.com/GaijinEntertainment/daScript">GitHub <span data-github-star></span></a><a class="dio-nav__back" href="https://daslang.io"><b>built on</b> daslang.io ↗</a><span>v0.6.4</span><!-- hand-maintained version chip: bump with the daslang release --></div>
 </div></div></nav>
@@ -91,10 +92,10 @@ scoreboard and carries official measurements only.</p></div>
 
 <footer class="dio-footer"><div class="forge-container"><div class="dio-footer__grid">
 <div>
-<a class="dio-mark" href="index.html"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
+<a class="dio-mark" href="/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
 <p class="dio-footer__about">LLM + speech-to-text inference written in daslang.<br/>© 2018–2026 Gaijin Entertainment · BSD 3-Clause</p>
 </div>
-<div><div class="dio-footer__head">site</div><a class="dio-footer__link" href="index.html">news</a><a class="dio-footer__link" href="ladder.html">ladder</a><a class="dio-footer__link" href="sidecars.html">sidecars</a><a class="dio-footer__link" href="/feed.xml">atom feed</a></div>
+<div><div class="dio-footer__head">site</div><a class="dio-footer__link" href="/">news</a><a class="dio-footer__link" href="ladder.html">ladder</a><a class="dio-footer__link" href="sidecars.html">sidecars</a><a class="dio-footer__link" href="/feed.xml">atom feed</a></div>
 <div><div class="dio-footer__head">daslang</div><a class="dio-footer__link" href="https://daslang.io">daslang.io</a><a class="dio-footer__link" href="https://daslang.io/dasllama.html">scoreboard</a><a class="dio-footer__link" href="https://daslang.io/downloads.html">downloads</a><a class="dio-footer__link" href="https://daslang.io/playground/index.html">playground</a></div>
 <div><div class="dio-footer__head">method</div><a class="dio-footer__link" href="https://daslang.io/doc/reference/dasllama_methodology.html">methodology</a><a class="dio-footer__link" href="https://github.com/GaijinEntertainment/daScript">github</a><a class="dio-footer__link" href="https://t.me/daScript">telegram</a></div>
 </div></div></footer>

--- a/site-dasllama/ladder.html
+++ b/site-dasllama/ladder.html
@@ -7,6 +7,7 @@
 <meta property="og:description" content="Every measurement in the world — official and community — with receipts."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://dasllama.io/ladder.html"/>
+<link rel="canonical" href="https://dasllama.io/ladder.html"/>
 <link rel="icon" href="files/dasllama-favicon.svg" type="image/svg+xml"/>
 <link rel="alternate" type="application/atom+xml" href="/feed.xml" title="dasllama.io news"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -24,8 +25,8 @@
 <nav class="dio-nav" id="nav"><div class="forge-container"><div class="dio-nav__inner">
 <div class="dio-nav__left">
 <button class="dio-nav__burger" onclick="document.getElementById('nav').classList.toggle('is-open')">≡</button>
-<a class="dio-mark" href="index.html"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
-<div class="dio-tabs"><a class="dio-tab" href="index.html">home</a><a class="dio-tab is-active" href="ladder.html">ladder</a><a class="dio-tab" href="sidecars.html">sidecars</a></div>
+<a class="dio-mark" href="/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
+<div class="dio-tabs"><a class="dio-tab" href="/">home</a><a class="dio-tab is-active" href="ladder.html">ladder</a><a class="dio-tab" href="sidecars.html">sidecars</a></div>
 </div>
 <div class="dio-nav__right"><a class="dio-nav__gh" href="https://github.com/GaijinEntertainment/daScript">GitHub <span data-github-star></span></a><a class="dio-nav__back" href="https://daslang.io"><b>built on</b> daslang.io ↗</a><span>v0.6.4</span><!-- hand-maintained version chip: bump with the daslang release --></div>
 </div></div></nav>
@@ -64,10 +65,10 @@
 
 <footer class="dio-footer"><div class="forge-container"><div class="dio-footer__grid">
 <div>
-<a class="dio-mark" href="index.html"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
+<a class="dio-mark" href="/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
 <p class="dio-footer__about">LLM + speech-to-text inference written in daslang.<br/>© 2018–2026 Gaijin Entertainment · BSD 3-Clause</p>
 </div>
-<div><div class="dio-footer__head">site</div><a class="dio-footer__link" href="index.html">news</a><a class="dio-footer__link" href="ladder.html">ladder</a><a class="dio-footer__link" href="sidecars.html">sidecars</a><a class="dio-footer__link" href="/feed.xml">atom feed</a></div>
+<div><div class="dio-footer__head">site</div><a class="dio-footer__link" href="/">news</a><a class="dio-footer__link" href="ladder.html">ladder</a><a class="dio-footer__link" href="sidecars.html">sidecars</a><a class="dio-footer__link" href="/feed.xml">atom feed</a></div>
 <div><div class="dio-footer__head">daslang</div><a class="dio-footer__link" href="https://daslang.io">daslang.io</a><a class="dio-footer__link" href="https://daslang.io/dasllama.html">scoreboard</a><a class="dio-footer__link" href="https://daslang.io/downloads.html">downloads</a></div>
 <div><div class="dio-footer__head">method</div><a class="dio-footer__link" href="https://daslang.io/doc/reference/dasllama_methodology.html">methodology</a><a class="dio-footer__link" href="https://github.com/GaijinEntertainment/daScript">github</a><a class="dio-footer__link" href="https://t.me/daScript">telegram</a></div>
 </div></div></footer>

--- a/site-dasllama/sidecars.html
+++ b/site-dasllama/sidecars.html
@@ -7,6 +7,7 @@
 <meta property="og:description" content="Per-box tune manifests: kernel winners, runtime scalars, provenance. Pick one up instead of tuning."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://dasllama.io/sidecars.html"/>
+<link rel="canonical" href="https://dasllama.io/sidecars.html"/>
 <link rel="icon" href="files/dasllama-favicon.svg" type="image/svg+xml"/>
 <link rel="alternate" type="application/atom+xml" href="/feed.xml" title="dasllama.io news"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -24,8 +25,8 @@
 <nav class="dio-nav" id="nav"><div class="forge-container"><div class="dio-nav__inner">
 <div class="dio-nav__left">
 <button class="dio-nav__burger" onclick="document.getElementById('nav').classList.toggle('is-open')">≡</button>
-<a class="dio-mark" href="index.html"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
-<div class="dio-tabs"><a class="dio-tab" href="index.html">home</a><a class="dio-tab" href="ladder.html">ladder</a><a class="dio-tab is-active" href="sidecars.html">sidecars</a></div>
+<a class="dio-mark" href="/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
+<div class="dio-tabs"><a class="dio-tab" href="/">home</a><a class="dio-tab" href="ladder.html">ladder</a><a class="dio-tab is-active" href="sidecars.html">sidecars</a></div>
 </div>
 <div class="dio-nav__right"><a class="dio-nav__gh" href="https://github.com/GaijinEntertainment/daScript">GitHub <span data-github-star></span></a><a class="dio-nav__back" href="https://daslang.io"><b>built on</b> daslang.io ↗</a><span>v0.6.4</span><!-- hand-maintained version chip: bump with the daslang release --></div>
 </div></div></nav>
@@ -89,10 +90,10 @@
 
 <footer class="dio-footer" style="margin-top:0"><div class="forge-container"><div class="dio-footer__grid">
 <div>
-<a class="dio-mark" href="index.html"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
+<a class="dio-mark" href="/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dasllama"><path fill="currentColor" fill-rule="evenodd" d="M24 61 L26 40 L25 26 L21 6 L30 24 L34 24 L41 6 L40 27 L51 35 L51 42 L46 45 L38 43 L36 61 Z M29 29 L34 29 L34 34 L29 34 Z"></path></svg><span>dasllama<span class="tld">.io</span></span></a>
 <p class="dio-footer__about">LLM + speech-to-text inference written in daslang.<br/>© 2018–2026 Gaijin Entertainment · BSD 3-Clause</p>
 </div>
-<div><div class="dio-footer__head">site</div><a class="dio-footer__link" href="index.html">news</a><a class="dio-footer__link" href="ladder.html">ladder</a><a class="dio-footer__link" href="sidecars.html">sidecars</a><a class="dio-footer__link" href="/feed.xml">atom feed</a></div>
+<div><div class="dio-footer__head">site</div><a class="dio-footer__link" href="/">news</a><a class="dio-footer__link" href="ladder.html">ladder</a><a class="dio-footer__link" href="sidecars.html">sidecars</a><a class="dio-footer__link" href="/feed.xml">atom feed</a></div>
 <div><div class="dio-footer__head">daslang</div><a class="dio-footer__link" href="https://daslang.io">daslang.io</a><a class="dio-footer__link" href="https://daslang.io/dasllama.html">scoreboard</a><a class="dio-footer__link" href="https://daslang.io/downloads.html">downloads</a></div>
 <div><div class="dio-footer__head">method</div><a class="dio-footer__link" href="https://daslang.io/doc/reference/dasllama_methodology.html">methodology</a><a class="dio-footer__link" href="https://github.com/GaijinEntertainment/daScript">github</a><a class="dio-footer__link" href="https://t.me/daScript">telegram</a></div>
 </div></div></footer>

--- a/site-dasllama/sitemap.xml
+++ b/site-dasllama/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url><loc>https://dasllama.io/index.html</loc><lastmod>2026-08-10</lastmod></url>
+<url><loc>https://dasllama.io/</loc><lastmod>2026-08-10</lastmod></url>
 <url><loc>https://dasllama.io/ladder.html</loc></url>
 <url><loc>https://dasllama.io/sidecars.html</loc></url>
 </urlset>

--- a/site-dasllama/test_metadata.py
+++ b/site-dasllama/test_metadata.py
@@ -1,0 +1,65 @@
+import unittest
+import xml.etree.ElementTree as ET
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent
+
+
+class MetadataParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.canonical = None
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        if tag == "a" and "href" in values:
+            self.hrefs.append(values["href"])
+        if tag == "link" and values.get("rel") == "canonical":
+            self.canonical = values.get("href")
+
+
+class SiteMetadataTest(unittest.TestCase):
+    def test_pages_have_one_canonical_home_identity(self):
+        pages = {
+            "index.html": "https://dasllama.io/",
+            "ladder.html": "https://dasllama.io/ladder.html",
+            "sidecars.html": "https://dasllama.io/sidecars.html",
+        }
+        for filename, expected in pages.items():
+            with self.subTest(filename=filename):
+                parser = MetadataParser()
+                parser.feed((ROOT / filename).read_text(encoding="utf-8"))
+                self.assertEqual(parser.canonical, expected)
+                self.assertNotIn("index.html", parser.hrefs)
+
+    def test_sitemap_uses_the_canonical_urls(self):
+        tree = ET.parse(ROOT / "sitemap.xml")
+        namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        urls = [node.text for node in tree.findall("sm:url/sm:loc", namespace)]
+        self.assertEqual(
+            urls,
+            [
+                "https://dasllama.io/",
+                "https://dasllama.io/ladder.html",
+                "https://dasllama.io/sidecars.html",
+            ],
+        )
+
+    def test_feed_links_to_home_page_anchors(self):
+        feed = (ROOT / "feed.xml").read_text(encoding="utf-8")
+        self.assertNotIn("https://dasllama.io/index.html", feed)
+        self.assertIn("https://dasllama.io/#n-", feed)
+
+    def test_caddy_redirects_explicit_index(self):
+        snippet = (
+            REPO_ROOT / "utils" / "dasllama-ladder" / "caddy.snippet"
+        ).read_text(encoding="utf-8")
+        self.assertIn("redir /index.html / 308", snippet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/dasllama-ladder/caddy.snippet
+++ b/utils/dasllama-ladder/caddy.snippet
@@ -5,6 +5,10 @@
 #
 # Paste inside the `dasllama.io { ... }` block, ahead of `root`/`file_server`.
 
+# Keep the home page on one canonical URL. The static file remains index.html,
+# but requests that name explicitly are permanently redirected to the site root.
+redir /index.html / 308
+
 # The submit routes, and ONLY these, carry the large-body allowance: a record
 # store or tune sidecar is an MB-scale JSON document. The service enforces its
 # own (smaller) per-kind caps on top — the proxy cap exists because libhv


### PR DESCRIPTION
## Summary
- declare canonical URLs on all dasllama pages and normalize internal home links
- emit the root URL in the sitemap and Atom feed
- add the `/index.html` redirect to the authoritative Caddy snippet
- enforce the metadata contract in the deployment workflow

## Test
- `python site-dasllama/test_metadata.py`