### PR TITLE
SDK payloads: dasImgui/dasVulkan das layers, examples, tutorials install

### DIFF
--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -86,6 +86,12 @@ COMPILE_TESTS=(
     "mcp-cpp|utils/mcp/cpp_main.das"
     "mcp-setup|utils/mcp/setup.das"
     "requirefix|utils/requirefix/main.das"
+    # In-tree module das layers — these catch the missing-payload class (the
+    # dasImgui merge shipped binaries + descriptor but zero .das for a while:
+    # the descriptor resolved to files the bundle did not carry).
+    "imgui-example|modules/dasImgui/examples/features/button_repeat.das"
+    "vulkan-example|modules/dasVulkan/examples/smoke.das"
+    "vulkan-tutorial|modules/dasVulkan/tutorials/01_triangle/triangle_tut.das"
 )
 
 # Tools intentionally NOT in COMPILE_TESTS:

--- a/modules/dasImgui/CMakeLists.txt
+++ b/modules/dasImgui/CMakeLists.txt
@@ -266,6 +266,21 @@ IF(COMMAND ADD_MODULE_CPP)
     # v2 glob dirs; keep in sync with .das_module.
     ADD_MODULE_DAS(imgui daslib imgui_boost)
 
+    # SDK payload: everything the .das_module mounts, the runtime font, and the
+    # examples. Without the das layer an installed SDK's `require imgui/...`
+    # resolves the descriptor to files that do not exist (the shared_module and
+    # .das_module install via the shared-twin macro, the sources do not).
+    FOREACH(_dasdir widgets text markdown commands terminal daslib)
+        FILE(GLOB _dasdir_files ${DAS_IMGUI_DIR}/${_dasdir}/*.das)
+        INSTALL(FILES ${_dasdir_files}
+            DESTINATION ${DAS_INSTALL_MODULESDIR}/dasImgui/${_dasdir})
+    ENDFOREACH()
+    INSTALL(FILES ${DAS_IMGUI_DIR}/font/JetBrainsMono-Regular.ttf
+        DESTINATION ${DAS_INSTALL_MODULESDIR}/dasImgui/font)
+    INSTALL(DIRECTORY ${DAS_IMGUI_DIR}/examples/
+        DESTINATION ${DAS_INSTALL_MODULESDIR}/dasImgui/examples
+        FILES_MATCHING PATTERN "*.das")
+
     # Static halves only — no ADD_MODULE_LIB shared twins. In a superbuild the DLL
     # flavor comes from this module's own standalone build (daspkg); the twins would
     # need the whole dllexport/dllimport matrix (IMGUI_API across the pair, glfw

--- a/modules/dasImgui/CMakeLists.txt
+++ b/modules/dasImgui/CMakeLists.txt
@@ -271,9 +271,9 @@ IF(COMMAND ADD_MODULE_CPP)
     # resolves the descriptor to files that do not exist (the shared_module and
     # .das_module install via the shared-twin macro, the sources do not).
     FOREACH(_dasdir widgets text markdown commands terminal daslib)
-        FILE(GLOB _dasdir_files ${DAS_IMGUI_DIR}/${_dasdir}/*.das)
-        INSTALL(FILES ${_dasdir_files}
-            DESTINATION ${DAS_INSTALL_MODULESDIR}/dasImgui/${_dasdir})
+        INSTALL(DIRECTORY ${DAS_IMGUI_DIR}/${_dasdir}/
+            DESTINATION ${DAS_INSTALL_MODULESDIR}/dasImgui/${_dasdir}
+            FILES_MATCHING PATTERN "*.das")
     ENDFOREACH()
     INSTALL(FILES ${DAS_IMGUI_DIR}/font/JetBrainsMono-Regular.ttf
         DESTINATION ${DAS_INSTALL_MODULESDIR}/dasImgui/font)

--- a/modules/dasVulkan/CMakeLists.txt
+++ b/modules/dasVulkan/CMakeLists.txt
@@ -126,6 +126,18 @@ IF((NOT DAS_VULKAN_INCLUDED) AND ((NOT ${DAS_VULKAN_DISABLED}) OR (NOT DEFINED D
         INSTALL(FILES ${DAS_VULKAN_DASLIB}
             DESTINATION ${DAS_INSTALL_MODULESDIR}/dasVulkan/daslib
         )
+        # SDK payload: examples and the tutorial ladder (offscreen tutorials,
+        # their shaders and oracles, the windowed viewers). The .das_test gating
+        # files ride along so folder skips (window/ needs glfw, recording/ needs
+        # audio) behave the same in an installed SDK. Assets are NOT here — the
+        # tutorials read the repo-shared tutorials/_assets, which installs with
+        # the root tutorial tree.
+        INSTALL(DIRECTORY ${DAS_VULKAN_DIR}/examples/
+            DESTINATION ${DAS_INSTALL_MODULESDIR}/dasVulkan/examples
+            FILES_MATCHING PATTERN "*.das")
+        INSTALL(DIRECTORY ${DAS_VULKAN_DIR}/tutorials/
+            DESTINATION ${DAS_INSTALL_MODULESDIR}/dasVulkan/tutorials
+            FILES_MATCHING PATTERN "*.das" PATTERN ".das_test")
     ELSE()
         # DASLANG_DIR must point to the daslang SDK root
         if(NOT DEFINED DASLANG_DIR)


### PR DESCRIPTION
The dasImgui merge shipped binaries + .das_module but ZERO .das - the
descriptor resolved to files the bundle never carried, so require imgui was
dead in every installed SDK since. dasVulkan shipped daslib but no examples
or tutorials.

- dasImgui installs the six mounted das dirs (widgets/text/markdown/commands/
  terminal/daslib), the runtime-loaded JetBrains Mono font, and examples/
- dasVulkan installs examples/ and the tutorial ladder (shaders, oracles,
  windowed viewers, the .das_test folder gates); assets stay with the
  repo-shared tutorials/_assets which already installs
- bundle_smoke gains three compile probes (imgui example, vulkan example,
  vulkan tutorial) so the missing-payload class cannot regress silently

Proof from a fresh prefix: imgui 0 -> 260 .das, vulkan 17 -> 108; all three
probes OK; the 01_triangle oracle RUNS from the installed SDK on a real GPU
(1/1, 4.9s).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
