### PR TITLE
nightly relwithdebinfo: keep the immortal binding LineInfos out of the leak report

### DIFF
--- a/src/simulate/debug_info.cpp
+++ b/src/simulate/debug_info.cpp
@@ -811,8 +811,11 @@ namespace das
 
     // One FileInfo per binding name, keyed by the display name so a deserialized location maps
     // back to the same singleton. Intentionally never freed - these outlive every Program, and
-    // no FileAccess owns them.
+    // no FileAccess owns them. The tracker guard keeps these immortals out of the leak report:
+    // without it every process exit in a DAS_TRACK_ALLOC build symbolizes ~3000 of them
+    // (~5s), which starves timing-sensitive child-process tests.
     static LineInfo & cppBindingLineInfoNamed ( const string & display ) {
+        AllocTrackerInternalGuard trackerGuard;
         static das_map<string, LineInfo> * infos = new das_map<string, LineInfo>();
         static mutex * infosMutex = new mutex();
         lock_guard<mutex> guard(*infosMutex);


### PR DESCRIPTION
The nightly `build_windows_relwithdebinfo_nightly` lane (the leak-diagnostic config) has failed every night since Aug 13 on the same two tests: `tests/fio/popen_argv.das` (stdin isolation) and `tests/lint/test_parallel_equivalence.das`. Root cause: the byte-view-strings window introduced `cppBindingLineInfoNamed` — one intentionally-immortal FileInfo singleton per C++ binding name — and the alloc tracker reports all of them at every process exit: 3,051 leaks, ~5 s of symbolization, on every child process. The green Aug-12 nightly printed 9 leaks in 1.2 s. That per-exit tax starves popen's stdin-read window and drags the parallel-lint comparison past its margin.

The fix wraps the singleton factory in the tracker's own `AllocTrackerInternalGuard` — the RAII built exactly for bookkeeping allocations the report should not count; it is a no-op outside `DAS_TRACK_ALLOC` builds.

Where to look: `src/simulate/debug_info.cpp`, the one guarded function.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local RelWithDebInfo with a negative control: without the guard a bare `hello_world.das` exit prints `3,105 leaks, 1042 sites, symbolized in 2.30s`; with it, no report. Both formerly-red tests pass under the fixed RelWithDebInfo build: popen_argv 16/16, test_parallel_equivalence 6/6. Release compiles the guard as a no-op (verified build).

### Claims — stated, not tested
- The lane-level green: no per-PR CI runs this nightly config, so the settling run is the next scheduled `build_windows_relwithdebinfo_nightly` (or a manual full-workflow dispatch). It failed five consecutive nights without this change; a regression looks like the same two tests re-reddening with a large leak report in the log.

### Not done
- The two victim tests still assume child exits are cheap; if a future diagnostic config slows exits again they re-redden first. Left as-is deliberately — they are the canary that caught this.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
