### PR TITLE
site-dasllama: fix the caddy.snippet path the tool split moved (deploy red)

### DIFF
--- a/site-dasllama/test_metadata.py
+++ b/site-dasllama/test_metadata.py
@@ -56,7 +56,7 @@ class SiteMetadataTest(unittest.TestCase):
 
     def test_caddy_redirects_explicit_index(self):
         snippet = (
-            REPO_ROOT / "utils" / "dasllama-ladder" / "caddy.snippet"
+            REPO_ROOT / "utils" / "internal" / "dasllama-ladder" / "caddy.snippet"
         ).read_text(encoding="utf-8")
         self.assertIn("redir /index.html / 308", snippet)
 


### PR DESCRIPTION
Master's `Deploy daslang.io` run has been red since #3762 merged: `site-dasllama/test_metadata.py` reads `caddy.snippet` via a component-form path (`REPO_ROOT / "utils" / "dasllama-ladder" / ...`) that the tool-split's regex sweep could not see — the same trap already fixed once in `mcp_supervisor.py:361`. The stage step dies on FileNotFoundError and both daslang.io and dasllama.io deploys skip. One-line path fix; `python site-dasllama/test_metadata.py` runs 4/4 OK locally. Settling run: the next master push's deploy workflow (or a manual dispatch).

These two files were the only component-form `"utils"` path builders in the tree (swept `.py/.js/.mjs/.ts`); a resolves-in-tree gate for such references is ledgered with the REVIEW.das arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
