### PR TITLE
nightly lint: two both-worlds nolints

### DIFF
--- a/modules/dasLLAMA/tests/test_model_image_vulkan.das
+++ b/modules/dasLLAMA/tests/test_model_image_vulkan.das
@@ -107,7 +107,7 @@ def test_vulkan_inline_bake(tst : T?) {
             remove(img_p)
             var a = Model()
             with_job_que() {
-                a <- load_model_cached(path, QuantMode.q8)   // the move must sit inside with_job_que
+                a <- load_model_cached(path, QuantMode.q8)   // nolint:PERF030,LINT019 -- the move must sit inside with_job_que; the target is fresh-empty, so nothing drops
             }
             t |> success(a.image_map != null, "the cold cached load serves an image")
             t |> success(stat(img_v).is_valid, "the vulkan flavor was baked")

--- a/tests/language/optimization_inline.das
+++ b/tests/language/optimization_inline.das
@@ -208,7 +208,7 @@ def target_basic(x, y : int) : int {
 
 [export]
 def target_fold : float {
-    return clamp01f(2.5); // constant arg: folds through the inlined body
+    return clamp01f(2.5); // nolint:PERF015,LINT019 -- constant arg folds through the inlined body; the inliner splices clamp01f's nolinted ternary to this call site in optimized lint configs
 }
 
 [export]


### PR DESCRIPTION
The nightly whole-tree lint's findings from run 32096569410, both config-divergence re-fires the per-PR lanes cannot see: PERF015 fired on `clamp01f`'s already-nolinted ternary spliced by the inliner to its call site in `tests/language/optimization_inline.das` (a lint-rule defect candidate — rules re-firing on inliner-spliced statements at call-site locations — reported separately), and PERF030 on a fresh-empty move target that must sit inside `with_job_que` in `modules/dasLLAMA/tests/test_model_image_vulkan.das`. Both take the both-worlds nolint spelling (`…,LINT019`). Lint clean on both files; the inline suite runs 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
