### PR TITLE
bundle purity gate: exempt CHANGELIST.md (history, not a reference)

### DIFF
--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -200,8 +200,10 @@ fi
 # skills content, with repo-only marker semantics this raw grep cannot honor.
 # mcp_supervisor.py is excluded: it PROBES for the in-repo das-herd behind an
 # exists-check, so the literal is functional and inert in a bundle.
+# CHANGELIST.md is excluded: release history legitimately NAMES the utils/internal
+# split; prose there is documentation, not a reference that can dangle.
 printf '  %-30s ' "no utils/internal references"
-INTERNAL_REFS="$(grep -rIl 'utils/internal' "$BUNDLE" --exclude-dir=skills --exclude=mcp_supervisor.py 2>/dev/null || true)"
+INTERNAL_REFS="$(grep -rIl 'utils/internal' "$BUNDLE" --exclude-dir=skills --exclude=mcp_supervisor.py --exclude=CHANGELIST.md 2>/dev/null || true)"
 if [[ -z "$INTERNAL_REFS" ]]; then
     echo "OK"
     PASS=$((PASS + 1))


### PR DESCRIPTION
The #3768 changelist merge is about to red master's `bundle_smoke` (already red on #3766's CI): CHANGELIST.md ships with the SDK, the 0.6.4 entry for the tool split legitimately names `utils/internal`, and the bundle purity grep has no prose exemption. Release history is documentation, not a reference that can dangle — CHANGELIST.md joins mcp_supervisor.py in the gate's named exclusions, with the reason comment beside it.

One-line fix + comment; the gate's other 30 checks unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
