### PR TITLE
SDK packaging: release checksums, a .deb, and the manifest templates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,8 +305,27 @@ jobs:
         if: matrix.cmake_preset == 'Release'
         shell: bash
         run: bash ci/smoke_test_bundle.sh ./daslang_bundle
-      - name: "Upload release asset"
+      - name: "Checksum"
+        # every package-manager manifest reads its sha256 from this sibling asset
+        if: matrix.cmake_preset == 'Release'
+        shell: bash
+        run: |
+          set -eux
+          cd artifacts
+          f=daslang-bundle-${{ matrix.release_target }}-${{ matrix.release_arch }}.zip
+          (sha256sum "$f" 2>/dev/null || shasum -a 256 "$f") > "$f.sha256"
+          cat "$f.sha256"
+      - name: "Build .deb"
+        # the apt-installable form of the linux bundle (ci/packaging/README.md)
+        if: matrix.cmake_preset == 'Release' && matrix.release_target == 'linux' && matrix.release_arch == 'x86_64'
+        shell: bash
+        run: |
+          set -eux
+          bash ci/packaging/deb_build.sh ./daslang_bundle "${{ github.event.release.tag_name || '0.0.0-dev' }}" ./artifacts
+          d=$(ls artifacts/*.deb)
+          (sha256sum "$d" 2>/dev/null || shasum -a 256 "$d") > "$d.sha256"
+      - name: "Upload release assets"
         if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased') && matrix.cmake_preset == 'Release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/daslang-bundle-${{ matrix.release_target }}-${{ matrix.release_arch }}.zip --clobber
+        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,8 +322,10 @@ jobs:
         run: |
           set -eux
           bash ci/packaging/deb_build.sh ./daslang_bundle "${{ github.event.release.tag_name || '0.0.0-dev' }}" ./artifacts
-          d=$(ls artifacts/*.deb)
-          (sha256sum "$d" 2>/dev/null || shasum -a 256 "$d") > "$d.sha256"
+          cd artifacts
+          for d in *.deb; do
+            (sha256sum "$d" 2>/dev/null || shasum -a 256 "$d") > "$d.sha256"
+          done
       - name: "Upload release assets"
         if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased') && matrix.cmake_preset == 'Release'
         env:

--- a/ci/packaging/README.md
+++ b/ci/packaging/README.md
@@ -1,0 +1,28 @@
+# Packaging — release artifacts and package-manager manifests
+
+The canonical distribution source is the GitHub release: four stable-named bundles
+(`daslang-bundle-{linux-x86_64,linux-arm64,darwin26-arm64,windows-x86_64}.zip`, unix
+modes preserved), each with a sibling `.zip.sha256`, plus a `.deb` for Debian/Ubuntu —
+all produced by `release.yml` at prerelease-cut time. Every package manager below is a
+pointer at those assets.
+
+## The per-release ritual
+
+1. Cut the prerelease tag; `release.yml` uploads bundles + `.sha256` files + the `.deb`.
+2. **Homebrew tap** (repo `homebrew-daslang`, formula `Formula/daslang.rb` from
+   `homebrew-daslang.rb.template`): fill `@TAG@`/`@VERSION@` and the three `@SHA_*@`
+   values from the `.sha256` assets, push to the tap.
+   Users: `brew install <org>/daslang/daslang`.
+3. **Scoop bucket** (repo `scoop-daslang`, `bucket/daslang.json` from
+   `scoop-daslang.json.template`): fill version/tag/hash, push.
+   Users: `scoop bucket add daslang <repo-url>; scoop install daslang`.
+4. **winget** (real releases ONLY, never an RC): render the manifest trio from
+   `winget-daslang.yaml.template` and PR it to microsoft/winget-pkgs.
+5. **apt**: the `.deb` on the release page installs with
+   `sudo apt install ./daslang_<version>_amd64.deb` (binaries land in `/opt/daslang`,
+   `daslang`/`daslang-live`/`gen1_to_gen2` symlinked into `/usr/bin`). A hosted apt
+   repo is a later tier.
+
+RC dry-runs point the tap and bucket at the RC tag to validate install paths end to
+end; retargeting to the real tag is a hash+tag bump. Templates here are the copies of
+record — edit them first, then propagate to the tap/bucket repos.

--- a/ci/packaging/deb_build.sh
+++ b/ci/packaging/deb_build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build a .deb from an installed daslang bundle directory.
+# Usage: deb_build.sh <bundle_dir> <tag_or_version> <out_dir>
+# The tag is normalized to a dpkg version: leading v stripped, -RCn -> ~rcn
+# (tilde sorts BEFORE the release, so 0.6.4~rc1 upgrades cleanly to 0.6.4).
+set -euo pipefail
+
+BUNDLE="$1"
+RAW_VERSION="${2:-0.0.0-dev}"
+OUT="$3"
+
+VERSION="${RAW_VERSION#v}"
+VERSION="$(echo "$VERSION" | sed -E 's/-[Rr][Cc]([0-9]+)/~rc\1/')"
+ARCH="$(dpkg --print-architecture)"
+
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+PKG="$ROOT/daslang_${VERSION}_${ARCH}"
+
+mkdir -p "$PKG/opt/daslang" "$PKG/usr/bin" "$PKG/DEBIAN"
+cp -a "$BUNDLE"/. "$PKG/opt/daslang/"
+
+# the user-facing binaries; everything else is reached relative to /opt/daslang
+for exe in daslang daslang-live gen1_to_gen2; do
+    if [ -x "$PKG/opt/daslang/bin/$exe" ]; then
+        ln -s "/opt/daslang/bin/$exe" "$PKG/usr/bin/$exe"
+    fi
+done
+
+INSTALLED_SIZE=$(du -sk "$PKG/opt" | cut -f1)
+cat > "$PKG/DEBIAN/control" << EOF
+Package: daslang
+Version: $VERSION
+Section: devel
+Priority: optional
+Architecture: $ARCH
+Installed-Size: $INSTALLED_SIZE
+Maintainer: daslang maintainers <team@daslang.io>
+Homepage: https://daslang.io
+Description: daslang programming language SDK
+ High-performance statically-typed scripting language for games and
+ real-time applications: compiler, JIT, standard library, test framework,
+ tools, and modules. Installed under /opt/daslang.
+EOF
+
+dpkg-deb --build --root-owner-group "$PKG" "$OUT/daslang_${VERSION}_${ARCH}.deb"
+echo "built: $OUT/daslang_${VERSION}_${ARCH}.deb"

--- a/ci/packaging/deb_build.sh
+++ b/ci/packaging/deb_build.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 BUNDLE="$1"
 RAW_VERSION="${2:-0.0.0-dev}"
 OUT="$3"
+mkdir -p "$OUT"
 
 VERSION="${RAW_VERSION#v}"
 VERSION="$(echo "$VERSION" | sed -E 's/-[Rr][Cc]([0-9]+)/~rc\1/')"

--- a/ci/packaging/homebrew-daslang.rb.template
+++ b/ci/packaging/homebrew-daslang.rb.template
@@ -1,0 +1,45 @@
+# Homebrew formula template for the daslang tap.
+# Lives in the tap repo as Formula/daslang.rb; this copy is the template of record.
+# Update per release: url tags + sha256 values (from the .sha256 assets).
+class Daslang < Formula
+  desc "High-performance statically-typed scripting language for games and real-time applications"
+  homepage "https://daslang.io"
+  version "@VERSION@"
+  license "BSD-3-Clause"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/GaijinEntertainment/daScript/releases/download/@TAG@/daslang-bundle-darwin26-arm64.zip"
+      sha256 "@SHA_DARWIN_ARM64@"
+    end
+  end
+  on_linux do
+    on_intel do
+      url "https://github.com/GaijinEntertainment/daScript/releases/download/@TAG@/daslang-bundle-linux-x86_64.zip"
+      sha256 "@SHA_LINUX_X86_64@"
+    end
+    on_arm do
+      url "https://github.com/GaijinEntertainment/daScript/releases/download/@TAG@/daslang-bundle-linux-arm64.zip"
+      sha256 "@SHA_LINUX_ARM64@"
+    end
+  end
+
+  def install
+    # the bundle is a self-contained SDK tree; daslang derives its module root
+    # from the executable location, so the tree must stay together
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"bin/daslang"
+    bin.install_symlink libexec/"bin/daslang-live"
+    bin.install_symlink libexec/"bin/gen1_to_gen2"
+  end
+
+  test do
+    (testpath/"hello.das").write <<~EOS
+      [export]
+      def main() {
+          print("hello daslang\\n")
+      }
+    EOS
+    assert_match "hello daslang", shell_output("#{bin}/daslang #{testpath}/hello.das")
+  end
+end

--- a/ci/packaging/homebrew-daslang.rb.template
+++ b/ci/packaging/homebrew-daslang.rb.template
@@ -26,8 +26,11 @@ class Daslang < Formula
 
   def install
     # the bundle is a self-contained SDK tree; daslang derives its module root
-    # from the executable location, so the tree must stay together
-    libexec.install Dir["*"]
+    # from the executable location, so the tree must stay together. The zip
+    # carries a top-level daslang_bundle/ dir; brew strips a sole top dir on
+    # unpack, but stage from it explicitly in case that ever changes.
+    root = File.directory?("daslang_bundle") ? "daslang_bundle" : "."
+    libexec.install Dir["#{root}/*"]
     bin.install_symlink libexec/"bin/daslang"
     bin.install_symlink libexec/"bin/daslang-live"
     bin.install_symlink libexec/"bin/gen1_to_gen2"

--- a/ci/packaging/scoop-daslang.json.template
+++ b/ci/packaging/scoop-daslang.json.template
@@ -1,0 +1,27 @@
+{
+    "version": "@VERSION@",
+    "description": "High-performance statically-typed scripting language for games and real-time applications",
+    "homepage": "https://daslang.io",
+    "license": "BSD-3-Clause",
+    "url": "https://github.com/GaijinEntertainment/daScript/releases/download/@TAG@/daslang-bundle-windows-x86_64.zip",
+    "hash": "@SHA_WINDOWS_X86_64@",
+    "extract_dir": "daslang_bundle",
+    "bin": [
+        "bin\\daslang.exe",
+        "bin\\daslang-live.exe",
+        "bin\\gen1_to_gen2.exe",
+        "bin\\lint.exe",
+        "bin\\daspkg.exe",
+        "bin\\dascov.exe",
+        "bin\\detect-dupe.exe",
+        "bin\\benchctl.exe",
+        "bin\\dastest.exe",
+        "bin\\das-fmt.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/GaijinEntertainment/daScript"
+    },
+    "autoupdate": {
+        "url": "https://github.com/GaijinEntertainment/daScript/releases/download/v$version/daslang-bundle-windows-x86_64.zip"
+    }
+}

--- a/ci/packaging/winget-daslang.yaml.template
+++ b/ci/packaging/winget-daslang.yaml.template
@@ -1,0 +1,39 @@
+# winget manifest trio template (submitted to microsoft/winget-pkgs under
+# manifests/g/GaijinEntertainment/daslang/@VERSION@/ as three files; the
+# split points are marked). First submission happens at the REAL release tag,
+# never an RC — the catalog is public and each version is a reviewed PR.
+
+# --- GaijinEntertainment.daslang.yaml (version manifest) ---
+PackageIdentifier: GaijinEntertainment.daslang
+PackageVersion: "@VERSION@"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+
+# --- GaijinEntertainment.daslang.installer.yaml ---
+# PackageIdentifier / PackageVersion as above
+# Installers:
+#   - Architecture: x64
+#     InstallerType: zip
+#     InstallerUrl: https://github.com/GaijinEntertainment/daScript/releases/download/@TAG@/daslang-bundle-windows-x86_64.zip
+#     InstallerSha256: "@SHA_WINDOWS_X86_64@"
+#     NestedInstallerType: portable
+#     NestedInstallerFiles:
+#       - RelativeFilePath: daslang_bundle\bin\daslang.exe
+#         PortableCommandAlias: daslang
+#       - RelativeFilePath: daslang_bundle\bin\daslang-live.exe
+#         PortableCommandAlias: daslang-live
+#       - RelativeFilePath: daslang_bundle\bin\dastest.exe
+#         PortableCommandAlias: dastest
+#       - RelativeFilePath: daslang_bundle\bin\daspkg.exe
+#         PortableCommandAlias: daspkg
+# ManifestType: installer
+
+# --- GaijinEntertainment.daslang.locale.en-US.yaml ---
+# PackageIdentifier / PackageVersion as above
+# Publisher: Gaijin Entertainment
+# PackageName: daslang
+# License: BSD-3-Clause
+# ShortDescription: High-performance statically-typed scripting language for games and real-time applications
+# PackageUrl: https://daslang.io
+# ManifestType: defaultLocale


### PR DESCRIPTION
The packaging lane of the 0.6.4 pilot (brew tap / winget / scoop / .deb — all ruled): every manager is a pointer at the GitHub release, so `release.yml` grows what pointers need — a sibling `.zip.sha256` per bundle (each build cell), and a `.deb` of the linux x86_64 bundle (`/opt/daslang` tree + `/usr/bin` symlinks for daslang / daslang-live / gen1_to_gen2, dpkg-correct `~rcN` version normalization so RCs upgrade cleanly to the release). The upload step widens to `artifacts/*`. Artifact names and the zip format stay exactly as-is — verified against the published 0.6.3-RC3 linux bundle that the 7z zips preserve unix exec bits (bins at 0755), so nothing downstream churns.

`ci/packaging/` carries the copies of record: the Homebrew formula template (three-platform, `libexec` install so the SDK tree stays whole), the Scoop manifest (all ten shipped exes on `bin`, autoupdate wired), the winget manifest-trio template (real releases only, never an RC), and the per-release ritual in its README.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- `deb_build.sh` dry-run in WSL against a fixture bundle: builds `daslang_0.6.4~rc1_amd64.deb`, correct control fields, root-owned entries, working `/usr/bin/daslang` symlink; version normalization probed for `v0.6.4-RC1` / `v0.6.4` / `0.7.0-rc2` / dispatch-fallback.
- bash syntax-checked; the checksum step uses `sha256sum || shasum -a 256` so all three runner OSes produce the file.

### Claims — stated, not tested
- The full `release.yml` run with these steps: validate with a `workflow_dispatch` run (uploads nothing by design), or the RC2 cut — the ruled plan points the tap/scoop dry-run at RC2.

### Asks / next
- The tap and bucket need repos (`homebrew-daslang`, `scoop-daslang`) under whichever org owns them — an owner decision, not in this PR.
- Site follow-up (daslang.io / dasllama.io install sections) lands after the packages exist, per the arc ledger.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
