### PR TITLE
run-tier fixes: --null-audio/--volume for every audio app, --max-frames for the last forever-loops, the audit's defect harvest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,9 @@ diagnostic in any tier.
   fresh clone per registration, not the same variable passed twice.
 - **`new WithCtor(field = v)` skips the user constructor** — it is plain field-init, so
   inherited fields stay zero. Write `new WithCtor(args)` when the constructor must run.
+- **`defer()` at the top level of a lambda body never fires per call** — it becomes the lambda's
+  finalizer (runs on `delete`), silently. `t |> run(...) @(t : T?) { defer() {...} ... }` is exactly
+  this shape. Nest the body in a bare `{ }` block, or make the cleanup the last statement.
 
 ### Code style — prefer idiomatic forms
 

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -1603,7 +1603,7 @@ def document_module_audio(_root : string) {
 def document_module_audio_boost(_root : string) {
     var mod = find_module("audio_boost")
     var groups <- array<DocGroup>(
-        group_by_regex("Audio system lifecycle", mod, %regex~(with_audio_system|audio_system_create|audio_system_finalize|audio_system_release_context)$%%),
+        group_by_regex("Audio system lifecycle", mod, %regex~(with_audio_system|audio_system_create|audio_system_finalize|audio_system_release_context|audio_user_args)$%%),
         group_by_regex("Sound playback", mod, %regex~(play_sound|play_3d_sound)%%),
         group_by_regex("Sound control", mod, %regex~(set_volume|set_pan|set_pitch|set_pause|set_global_pitch|set_global_pause|set_global_volume|set_ignore_global_volume|stop|set_playback_position)$%%),
         group_by_regex("3D audio", mod, %regex~(set_head_position|set_position)$%%),

--- a/doc/source/reference/tutorials/dasAudio_01_hello_sound.rst
+++ b/doc/source/reference/tutorials/dasAudio_01_hello_sound.rst
@@ -125,6 +125,14 @@ You will hear three tones played sequentially: a 440 Hz sine wave, middle C
 and C5, then a 440 Hz square wave.  Each tone lasts approximately one
 second.
 
+Every program that opens the audio system through ``with_audio_system`` also
+understands two flags after ``--``: ``--volume V`` scales the master volume
+(0..1), and ``--null-audio`` runs on a silent null device — for a machine with
+no sound card, or a batch run you do not want to hear::
+
+   daslang.exe tutorials/dasAudio/01_hello_sound.das -- --volume 0.2
+   daslang.exe tutorials/dasAudio/01_hello_sound.das -- --null-audio
+
 .. seealso::
 
    Full source: :download:`tutorials/dasAudio/01_hello_sound.das <../../../../tutorials/dasAudio/01_hello_sound.das>`

--- a/examples/daStrudel/README.md
+++ b/examples/daStrudel/README.md
@@ -37,13 +37,14 @@ bin/daslang examples/daStrudel/synth_demo/main.das -jit
 ### Feature snippets
 
 Each `features/*.das` file uses `play_feature_cps` from `feature_common.das`
-and supports three flags:
+and supports these flags (after `--`, which separates script args from daslang's own):
 
 ```sh
-bin/daslang examples/daStrudel/features/orbit_chorus_only.das               # play 10s
-bin/daslang examples/daStrudel/features/orbit_chorus_only.das --duration 4  # play N seconds
-bin/daslang examples/daStrudel/features/orbit_chorus_only.das --wav out.wav # render offline
-bin/daslang examples/daStrudel/features/orbit_chorus_only.das --track-memory
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das                    # play 10s
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das -- --duration 4    # play N seconds
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das -- --wav out.wav   # render offline
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das -- --volume 0.2    # quieter playback
+bin/daslang examples/daStrudel/features/orbit_chorus_only.das -- --track-memory
 ```
 
 ## See also

--- a/examples/daStrudel/features/sf2_integration_full_ambient.das
+++ b/examples/daStrudel/features/sf2_integration_full_ambient.das
@@ -70,8 +70,13 @@ def main() {
 
     let pat <- stack([layer1, layer2, layer3, layer4, layer5, layer6, layer7, layer8])
 
+    let sf2_path = find_sf2()
+    if (empty(sf2_path)) {
+        print("No SF2 found in examples/daStrudel/midi_sf2_demo — skipping\n")
+        return
+    }
     default_feature_duration = 60.0  // override default duration for this feature
     play_feature_cps(pat, 15.0lf / 60.0lf) {
-        strudel_load_sf2(find_sf2())
+        strudel_load_sf2(sf2_path)
     }
 }

--- a/examples/daStrudel/sf2_demo/render_wav.das
+++ b/examples/daStrudel/sf2_demo/render_wav.das
@@ -9,6 +9,7 @@ require strudel/strudel_sf2
 require audio/audio_wav
 require audio/audio_boost
 require daslib/fio
+require daslib/clargs
 
 def find_sf2() : string {
     let dir = "{get_das_root()}/examples/daStrudel/midi_sf2_demo"
@@ -80,7 +81,8 @@ def main() {
         wall_time += double(chunk_sec)
     }
 
-    let wav_path = "E:/sf2_demo.wav"
+    let args <- get_user_args()
+    let wav_path = !empty(args) ? args[0] : "sf2_demo.wav"
     print("Writing {wav_path} ({length(output) / 2} frames)\n")
     write_wav(wav_path, output, [sample_rate = 48000u, channels = 2])
     print("Done!\n")

--- a/examples/daStrudel/sfx_lab/export_drums.das
+++ b/examples/daStrudel/sfx_lab/export_drums.das
@@ -1,16 +1,21 @@
 options gen2
 options indenting = 4
 
-// Headless: emit a drop-in .das render function for each finished drum .sfx, concatenated into one
-// file (/tmp/drums_gen.das) for splicing into strudel_synth.das. The tom is exported parametric
-// (base_freq scales the modal pitch). Run: bin/daslang examples/daStrudel/sfx_lab/export_drums.das
+// Headless: one .das render function per finished drum .sfx, for splicing into strudel_synth.das.
+//   Output: <temp dir>/drums_gen.das
+//   Tom:    exported parametric (base_freq scales the modal pitch)
+//   Run:    bin/daslang examples/daStrudel/sfx_lab/export_drums.das
 
 require strudel/strudel_sfx
 require daslib/fio
 require strings
 
 let DIR = "{get_das_root()}/examples/daStrudel/sfx_lab/sounds/"
-let OUT = "/tmp/drums_gen.das"
+
+def out_path() : string {
+    let tmp = temp_directory_result()
+    return path_join(tmp is value ? tmp as value : ".", "drums_gen.das")
+}
 
 struct DrumExport {
     sfx : string
@@ -45,7 +50,8 @@ def main {
             to_log(LOG_INFO, "{d.func}: {length(doc.layers)} layers\n")
         }
     }
-    if (fwrite(OUT, all)) {
-        to_log(LOG_INFO, "wrote {OUT}\n")
+    let out = out_path()
+    if (fwrite(out, all)) {
+        to_log(LOG_INFO, "wrote {out}\n")
     }
 }

--- a/examples/daStrudel/sfx_lab/sfxr_presets.das
+++ b/examples/daStrudel/sfx_lab/sfxr_presets.das
@@ -1,5 +1,5 @@
 // sfxr_presets — render and audition the classic sfxr preset family.
-// Renders each generator to a WAV under ./sfxr_renders/ and plays them in sequence.
+// Renders each generator to a WAV under <temp dir>/sfxr_renders/ and plays them in sequence.
 // Run: daslang examples/daStrudel/sfx_lab/sfxr_presets.das
 options gen2
 options indenting = 4
@@ -23,10 +23,11 @@ def build_preset(idx : int; var seed : uint&) : SfxrSound {
 def main() {
     let names = fixed_array("pickup_coin", "laser_shoot", "explosion", "powerup", "hit_hurt", "jump", "blip_select")
     let seeds = fixed_array(12345u, 22222u, 33333u, 44444u, 55555u, 66666u, 77777u)
-    let outdir = "sfxr_renders"
+    let tmp = temp_directory_result()
+    let outdir = path_join(tmp is value ? tmp as value : ".", "sfxr_renders")
     mkdir_rec(outdir)
 
-    print("sfxr presets -> ./{outdir}/ (playing each as it renders)\n")
+    print("sfxr presets -> {outdir}/ (playing each as it renders)\n")
     with_audio_system() {
         for (idx in range(length(names))) {
             var seed = seeds[idx]

--- a/examples/daStrudel/strudel_visualizer/main.das
+++ b/examples/daStrudel/strudel_visualizer/main.das
@@ -192,11 +192,11 @@ def init() { // nolint:STYLE038 — linear track-setup sequence
     create_ttf_objects()
     delete font
     font <- load_ttf("{get_das_root()}/examples/opengl/droidsansmono.ttf", [pixel_height = 16.0, oversampling = 2])
-    if (!!empty(font.bitmap.bytes)) {
+    if (empty(font.bitmap.bytes)) {
         delete font
-        font <- load_ttf("{get_das_root()}/examples/opengl/media/droidsansmono.ttf", [oversampling = 2])
+        font <- load_ttf("{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf", [pixel_height = 16.0, oversampling = 2])
     }
-    if (!!empty(font.bitmap.bytes)) {
+    if (empty(font.bitmap.bytes)) {
         panic("can't load font")
     }
     upload_font_texture(font)

--- a/examples/daslive/test_api_http/main.das
+++ b/examples/daslive/test_api_http/main.das
@@ -5,15 +5,21 @@ options gc
 require dashv/dashv_boost
 require daslib/json
 require daslib/json_boost
+require daslib/jobque_boost
 require live/live_commands
 require live/live_api
 require live/live_gc
 require strings
 require live_host
 
-// Integration test for the REST API.
-// Run with: daslang-live.exe examples/daslive/test_api_http/main.das
-// Or:       daslang.exe examples/daslive/test_api_http/main.das
+// Integration test for the live-host REST API, self-driven from inside the
+// hosted program. Run with:
+//   daslang-live.exe --live-port=9090 examples/daslive/test_api_http/main.das
+//
+// The API server is serviced by the host's frame loop (the debug agent's onTick),
+// so a synchronous GET from update() would deadlock the very loop that has to
+// answer it. The client therefore runs on its own thread; update() keeps the
+// frames flowing and polls for the thread's verdict.
 
 var tests_passed : int = 0
 var tests_failed : int = 0
@@ -38,11 +44,17 @@ def ping(input : JsonValue?) : JsonValue? {
     return JV("\{\"pong\": {cmd_counter}}")
 }
 
-// --- Tests ---
+// --- Tests (run on the client thread) ---
+
+def base_url() : string {
+    return "http://127.0.0.1:{live_api_port}"
+}
 
 def test_status() {
     print("--- GET /status ---\n")
-    GET("http://localhost:{live_api_port}/status") $(resp) {
+    GET("{base_url()}/status") $(resp) {
+        check("status returns a response", resp != null)
+        if (resp == null) return
         let body = string(resp.body)
         check("status returns 200", int(resp.status_code) == int(http_status.OK))
         check("status contains fps", find(body, "fps") >= 0)
@@ -52,104 +64,123 @@ def test_status() {
     }
 }
 
-def test_reload() {
-    print("--- POST /reload ---\n")
-    POST("http://localhost:{live_api_port}/reload", "") $(resp) {
-        let body = string(resp.body)
-        check("reload returns 200", int(resp.status_code) == int(http_status.OK))
-        check("reload returns ok", find(body, "true") >= 0)
-    }
-}
-
-def test_reload_full() {
-    print("--- POST /reload/full ---\n")
-    POST("http://localhost:{live_api_port}/reload/full", "") $(resp) {
-        let body = string(resp.body)
-        check("reload/full returns 200", int(resp.status_code) == int(http_status.OK))
-        check("reload/full returns ok", find(body, "true") >= 0)
-    }
-}
-
 def test_pause_unpause() {
     print("--- POST /pause and /unpause ---\n")
-    POST("http://localhost:{live_api_port}/pause", "") $(resp) {
+    POST("{base_url()}/pause", "") $(resp) {
+        check("pause returns a response", resp != null)
+        if (resp == null) return
         check("pause returns 200", int(resp.status_code) == int(http_status.OK))
         peek(resp.body) $(body) {
             check("pause returns paused:true", find(body, "true") >= 0)
         }
     }
     // Verify via status
-    GET("http://localhost:{live_api_port}/status") $(resp) {
-        var parse_error = ""
-        var js = read_json(string(resp.body), parse_error)
-        if (js != null && js.value is _object) {
-            let tab & = unsafe(js.value as _object)
-            var pv = tab?["paused"] ?? null
-            if (pv != null && pv.value is _bool) {
-                check("status shows paused", pv.value as _bool)
-            } else {
-                check("status shows paused", false)
+    GET("{base_url()}/status") $(resp) {
+        var paused = false
+        if (resp != null) {
+            var parse_error = ""
+            var js = read_json(string(resp.body), parse_error)
+            if (js != null && js.value is _object) {
+                let tab & = unsafe(js.value as _object)
+                var pv = tab?["paused"] ?? null
+                if (pv != null && pv.value is _bool) {
+                    paused = pv.value as _bool
+                }
             }
         }
+        check("status shows paused", paused)
     }
-    // Unpause
-    POST("http://localhost:{live_api_port}/unpause", "") $(resp) {
-        check("unpause returns 200", int(resp.status_code) == int(http_status.OK))
+    POST("{base_url()}/unpause", "") $(resp) {
+        check("unpause returns 200", resp != null && int(resp.status_code) == int(http_status.OK))
     }
-    set_paused(false)
+}
+
+// The ping command returns JV("{\"pong\": N}") - a JSON STRING holding JSON - so the wire
+// body is a quoted string; parse the outer string, then the object inside it. -1 = no pong.
+def pong_of(body : string) : int {
+    var err = ""
+    var outer = read_json(body, err)
+    if (outer == null || !(outer.value is _string)) return -1
+    var inner = read_json(outer.value as _string, err)
+    if (inner == null || !(inner.value is _object)) return -1
+    let tab & = unsafe(inner.value as _object)
+    var pv = tab?["pong"] ?? null
+    return pv ?? -1   // integral JSON literals parse as _longint, not _number - let json_boost widen
 }
 
 def test_command() {
     print("--- POST /command ---\n")
-    cmd_counter = 0
-    POST("http://localhost:{live_api_port}/command", "\{\"name\": \"ping\"}") $(resp) {
+    var first = -1
+    POST("{base_url()}/command", "\{\"name\": \"ping\"}") $(resp) {
+        check("command returns a response", resp != null)
+        if (resp == null) return
         check("command returns 200", int(resp.status_code) == int(http_status.OK))
-        let body = string(resp.body)
-        check("command ping response has pong", find(body, "pong") >= 0)
+        first = pong_of(string(resp.body))
+        check("command ping response carries a pong counter", first >= 0)
     }
-    // Call again
-    POST("http://localhost:{live_api_port}/command", "\{\"name\": \"ping\"}") $(resp) {
-        let body = string(resp.body)
-        check("second ping increments counter", find(body, "2") >= 0)
+    POST("{base_url()}/command", "\{\"name\": \"ping\"}") $(resp) {
+        let second = resp != null ? pong_of(string(resp.body)) : -1
+        check("second ping increments the counter by one", first >= 0 && second == first + 1)
     }
 }
 
 def test_command_errors() {
     print("--- POST /command errors ---\n")
-    // Unknown command
-    POST("http://localhost:{live_api_port}/command", "\{\"name\": \"nonexistent\"}") $(resp) {
+    POST("{base_url()}/command", "\{\"name\": \"nonexistent\"}") $(resp) {
+        check("unknown command returns a response", resp != null)
+        if (resp == null) return
         check("unknown command returns 200", int(resp.status_code) == int(http_status.OK))
         peek(resp.body) $(body) {
-            check("unknown command has error", find(body, "error") >= 0)
+            check("unknown command names the miss", find(body, "unknown command") >= 0)
         }
     }
 }
 
 // --- Lifecycle ---
 
-var test_phase : int = 0
+let CLIENT_IDLE = 0
+let CLIENT_RUNNING = 1
+let CLIENT_DONE = 2
+
+// Written by the client thread, read by update() — hence atomic. The verdict is
+// the printed summary (the host has no exit-code channel).
+var g_client_state : Atomic32?
+
+def run_client() {
+    // pause_unpause leaves the host unpaused; the [live_command] ping runs on the
+    // host loop, so cmd_counter is host-owned — the thread only reads bodies.
+    test_status()
+    test_pause_unpause()
+    test_command()
+    test_command_errors()
+    print("\n=== Results: {tests_passed} passed, {tests_failed} failed ===\n")
+    if (tests_failed == 0) {
+        print("ALL TESTS PASSED\n")
+    }
+}
 
 [export]
 def init() {
     print("test_api_http: init\n")
-    test_phase = 0
+    g_client_state = atomic32_create()
+    if (!is_live_mode()) {
+        print("test_api_http: no live API server outside daslang-live — run under the host\n")
+        g_client_state |> set(CLIENT_DONE)
+    }
 }
 
 [export]
 def update() {
-    test_phase++
-    // Wait a couple frames for the API server to start
-    if (test_phase == 3) {
-        test_status()
-        test_reload()
-        test_reload_full()
-        test_pause_unpause()
-        test_command()
-        test_command_errors()
-        print("\n=== Results: {tests_passed} passed, {tests_failed} failed ===\n")
-        if (tests_failed == 0) {
-            print("ALL TESTS PASSED\n")
+    if (g_client_state |> get() == CLIENT_IDLE) {
+        g_client_state |> set(CLIENT_RUNNING)
+        // The thread runs in a cloned context whose globals start blank; the
+        // lambda's captured LOCALS travel, so hand the handle over that way.
+        var client_state = g_client_state
+        new_thread() @() {
+            run_client()
+            client_state |> set(CLIENT_DONE)
         }
+    } elif (g_client_state |> get() == CLIENT_DONE) {
         request_exit()
     }
 }
@@ -157,6 +188,9 @@ def update() {
 [export]
 def shutdown() {
     print("test_api_http: shutdown\n")
+    unsafe {
+        atomic32_remove(g_client_state)
+    }
 }
 
 [export]

--- a/examples/flatten/capability/check.sh
+++ b/examples/flatten/capability/check.sh
@@ -88,8 +88,22 @@
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/../../.." && pwd)"
-daslang="$root/bin/daslang"
 proj="$here/../flatten_shaders.das_project"
+
+# Binary: $DASLANG if set, else bin/daslang, bin/Release/daslang.exe, or PATH (same rule as ../run.sh).
+find_daslang() {
+    if [[ -n "${DASLANG:-}" ]]; then echo "$DASLANG"; return; fi
+    local c
+    for c in "$root/bin/daslang" "$root/bin/Release/daslang.exe" "$root/bin/Release/daslang"; do
+        if [[ -x "$c" ]]; then echo "$c"; return; fi
+    done
+    command -v daslang || command -v daslang.exe || true
+}
+daslang="$(find_daslang)"
+if [[ -z "$daslang" || ! -x "$daslang" ]]; then
+    echo "error: no daslang binary found — build daScript first or set DASLANG" >&2
+    exit 1
+fi
 
 compile() { "$daslang" -compile-only -project "$proj" "$1" 2>&1; }
 hist()    { compile "$1" | grep '^node ' | awk '{print $3}' | sort | uniq -c; }

--- a/examples/flatten/run.sh
+++ b/examples/flatten/run.sh
@@ -16,13 +16,24 @@
 #                                    #   <name|path> accepts a bare name or a .shader path,
 #                                    #   e.g. ./run.sh --das capability/cap_control.shader
 #
-# Requires bin/daslang built in the daScript root.
+# Binary: $DASLANG if set, else the first of bin/daslang (single-config layout),
+# bin/Release/daslang[.exe] (MSVC layout), or `daslang` on PATH (installed SDK).
+# The candidate list is duplicated in capability/check.sh — keep them in step.
 
 set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/../.." && pwd)"
-daslang="$root/bin/daslang"
 proj="$here/flatten_shaders.das_project"
+
+find_daslang() {
+    if [[ -n "${DASLANG:-}" ]]; then echo "$DASLANG"; return; fi
+    local c
+    for c in "$root/bin/daslang" "$root/bin/Release/daslang.exe" "$root/bin/Release/daslang"; do
+        if [[ -x "$c" ]]; then echo "$c"; return; fi
+    done
+    command -v daslang || command -v daslang.exe || true
+}
+daslang="$(find_daslang)"
 
 dump_das=0
 shaders=()
@@ -34,8 +45,8 @@ for a in "$@"; do
     fi
 done
 
-if [[ ! -x "$daslang" ]]; then
-    echo "error: $daslang not found — build daScript first (cmake --build build --config Release)" >&2
+if [[ -z "$daslang" || ! -x "$daslang" ]]; then
+    echo "error: no daslang binary found — build daScript first (cmake --build build --config Release) or set DASLANG" >&2
     exit 1
 fi
 

--- a/examples/games/arcanoid/main.das
+++ b/examples/games/arcanoid/main.das
@@ -27,6 +27,7 @@ require strudel/strudel
 require strudel/strudel_player
 require strudel/strudel_live
 require daslib/strings_boost
+require daslib/strings_convert
 require live_host
 
 // --- Constants ---
@@ -1514,7 +1515,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/games/asteroids/main.das
+++ b/examples/games/asteroids/main.das
@@ -20,6 +20,7 @@ require strudel/strudel_live
 require daslib/math_boost
 require daslib/json_boost
 require daslib/strings_boost
+require daslib/strings_convert
 require daslib/safe_addr
 require opengl/opengl_ttf
 require live_host
@@ -1080,7 +1081,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/games/pacman/main.das
+++ b/examples/games/pacman/main.das
@@ -26,6 +26,7 @@ require strudel/strudel
 require strudel/strudel_player
 require strudel/strudel_live
 require daslib/strings_boost
+require daslib/strings_convert
 require live_host
 
 // ===== Constants =====
@@ -1250,12 +1251,29 @@ def shutdown() {
     live_destroy_window()
 }
 
+var max_frame_limit = 0
+
+def parse_args() {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 [export]
 def main() {
+    parse_args()
     init()
+    var frame_count = 0
     while (!exit_requested()) {
         update()
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/examples/games/river_run/main.das
+++ b/examples/games/river_run/main.das
@@ -8,6 +8,7 @@ require river
 require gameplay
 require hud
 require hud3d
+require daslib/strings_convert
 
 // --- GL Setup ---
 
@@ -201,7 +202,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/games/sequence/main.das
+++ b/examples/games/sequence/main.das
@@ -1025,7 +1025,7 @@ def init() {
         let primary_ttf = card_mesh_ttf_path()
         ui_font <- load_ttf(primary_ttf, [pixel_height = 24.0, oversampling = 2])
         if (empty(ui_font.bitmap.bytes)) {
-            let fallback_ttf = "{get_das_root()}/modules/dasOpenGL/examples/droidsansmono.ttf"
+            let fallback_ttf = "{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf"
             ui_font <- load_ttf(fallback_ttf, [pixel_height = 24.0, oversampling = 2])
         }
         if (!empty(ui_font.bitmap.bytes)) {
@@ -1033,7 +1033,7 @@ def init() {
             // Small font for hints
             ui_font_small <- load_ttf(primary_ttf, [pixel_height = 14.0, oversampling = 2])
             if (empty(ui_font_small.bitmap.bytes)) {
-                ui_font_small <- load_ttf("{get_das_root()}/modules/dasOpenGL/examples/droidsansmono.ttf",
+                ui_font_small <- load_ttf("{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf",
                     [pixel_height = 14.0, oversampling = 2])
             }
             if (!empty(ui_font_small.bitmap.bytes)) {

--- a/examples/hv/ws_chat_client.das
+++ b/examples/hv/ws_chat_client.das
@@ -38,13 +38,28 @@ class TerminalChatClient : HvWebSocketClient {
     }
 }
 
+let CONNECT_TIMEOUT_MS = 3000
+let POLL_STEP_MS = 10
+
 [export]
-def main() {
+def main() : int {
     var client = new TerminalChatClient()
-    let rc = client->init(SERVER_URL)
-    if (rc != 0) {
-        print("Failed to connect to {SERVER_URL}\n")
-        return
+    let init_ok = client->init(SERVER_URL) == 0
+    // init() only starts the handshake — pump until connected or the window elapses;
+    // otherwise a missing server looks like a clean exit.
+    var waited = 0
+    while (init_ok && !client->is_connected() && waited < CONNECT_TIMEOUT_MS) {
+        client->process_event_que()
+        sleep(uint(POLL_STEP_MS))
+        waited += POLL_STEP_MS
+    }
+    if (!init_ok || !client->is_connected()) {
+        print("Failed to connect to {SERVER_URL} — is the server running? (daslang examples/hv/ws_chat_server.das)\n")
+        client->cleanup()
+        unsafe {
+            delete client
+        }
+        return 1
     }
     // Main loop: read stdin + pump WebSocket events
     while (client->is_connected()) {
@@ -69,4 +84,5 @@ def main() {
     unsafe {
         delete client
     }
+    return 0
 }

--- a/examples/opengl/01_hello_triangle.das
+++ b/examples/opengl/01_hello_triangle.das
@@ -3,7 +3,7 @@ options persistent_heap
 options gc
 require glfw/glfw_boost
 require opengl/opengl_boost
-require strings
+require daslib/strings_convert
 
 require daslib/safe_addr
 require live/live_gc
@@ -103,7 +103,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/02_hello_image.das
+++ b/examples/opengl/02_hello_image.das
@@ -4,7 +4,7 @@ options gc
 require glfw/glfw_boost
 require opengl/opengl_boost
 require glsl/glsl_opengl
-require strings
+require daslib/strings_convert
 
 require daslib/safe_addr
 require live/live_gc
@@ -126,7 +126,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/03_hello_cube.das
+++ b/examples/opengl/03_hello_cube.das
@@ -3,7 +3,7 @@ options persistent_heap
 options gc
 require glfw/glfw_boost
 require opengl/opengl_boost
-require strings
+require daslib/strings_convert
 
 require daslib/safe_addr
 require daslib/math_boost
@@ -170,7 +170,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/04_hello_render_to_texture.das
+++ b/examples/opengl/04_hello_render_to_texture.das
@@ -5,7 +5,7 @@ require glfw/glfw_boost
 require opengl/opengl_boost
 require glsl/glsl_opengl
 require math
-require strings
+require daslib/strings_convert
 
 require daslib/safe_addr
 require live/live_gc
@@ -177,7 +177,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/05_hello_compute.das
+++ b/examples/opengl/05_hello_compute.das
@@ -5,7 +5,7 @@ require glfw/glfw_boost
 require opengl/opengl_boost
 require glsl/glsl_opengl
 require math
-require strings
+require daslib/strings_convert
 
 require daslib/safe_addr
 require live/live_gc
@@ -182,7 +182,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/06_hello_ttf.das
+++ b/examples/opengl/06_hello_ttf.das
@@ -5,7 +5,7 @@ require glfw/glfw_boost
 require opengl/opengl_boost
 require opengl/opengl_ttf
 require math
-require strings
+require daslib/strings_convert
 require daslib/math_boost
 require live/live_gc
 
@@ -28,11 +28,11 @@ def init() {
     // create ttf internals, load font with oversampling=2 for GPU rendering
     create_ttf_objects()
     font <- load_ttf("{get_das_root()}/examples/opengl/droidsansmono.ttf", [oversampling = 2])   // nolint:PERF030 - module global, first write (init runs once)
-    if (!!empty(font.bitmap.bytes)) {
+    if (empty(font.bitmap.bytes)) {
         delete font
-        font <- load_ttf("{get_das_root()}/examples/opengl/media/droidsansmono.ttf", [oversampling = 2])
+        font <- load_ttf("{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf", [oversampling = 2])
     }
-    if (!!empty(font.bitmap.bytes)) {
+    if (empty(font.bitmap.bytes)) {
         panic("can't load droidsansmono.ttf")
     }
     upload_font_texture(font)
@@ -80,7 +80,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/07_hello_gen.das
+++ b/examples/opengl/07_hello_gen.das
@@ -5,7 +5,7 @@ require glfw/glfw_boost
 require opengl/opengl_boost
 require opengl/opengl_gen
 require math
-require strings
+require daslib/strings_convert
 require daslib/math_boost
 require live/live_gc
 
@@ -133,7 +133,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/09_hello_mesh.das
+++ b/examples/opengl/09_hello_mesh.das
@@ -5,7 +5,7 @@ require glfw/glfw_boost
 require opengl/opengl_boost
 require opengl/opengl_gen
 require math
-require strings
+require daslib/strings_convert
 require daslib/math_boost
 require live/live_gc
 
@@ -163,7 +163,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/10_hello_gltf.das
+++ b/examples/opengl/10_hello_gltf.das
@@ -9,6 +9,7 @@ require gltf/gltf_pbr
 require math
 require daslib/math_boost
 require strings
+require daslib/strings_convert
 require live/live_gc
 
 // dasGLTF — minimal static glTF viewer (OpenGL). Loads a .glb, uploads it to GL, and renders it with
@@ -132,7 +133,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/examples/opengl/11_hello_gltf_animation.das
+++ b/examples/opengl/11_hello_gltf_animation.das
@@ -9,6 +9,7 @@ require gltf/gltf_pbr
 require math
 require daslib/math_boost
 require strings
+require daslib/strings_convert
 require live/live_gc
 
 // dasGLTF — skinned glTF animation viewer (OpenGL). Loads a rigged, animated .glb, uploads it to GL, and
@@ -166,7 +167,7 @@ def parse_args() {
     let args <- get_command_line_arguments()
     for (i in range(length(args) - 1)) {
         if (args[i] == "--max-frames") {
-            max_frame_limit = to_int(args[i + 1])
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
         }
     }
 }

--- a/modules/dasAudio/audio/audio_boost.das
+++ b/modules/dasAudio/audio/audio_boost.das
@@ -21,6 +21,9 @@ module audio_boost shared private
 
 require audio public
 require math
+require strings
+require daslib/strings_convert
+require daslib/clargs
 require daslib/rtti
 
 require daslib/array_boost
@@ -1248,14 +1251,43 @@ tuple public AudioSystemChannels {
     next_sid : Atomic64 ?
 }
 
+def public audio_user_args(args : array<string>) : tuple<null_device : bool; volume : float> {
+    //! The audio knobs every app gets from its user args: `--null-audio` (run on the null backend, no
+    //! device) and `--volume V` (master volume, clamped 0..1). `volume < 0` means not given or not a number.
+    var res = (null_device = false, volume = -1.0)
+    for (i in range(length(args))) {
+        if (args[i] == "--null-audio") {
+            res.null_device = true
+        } elif (args[i] == "--volume" && i + 1 < length(args)) {
+            let parsed = try_to_float(args[i + 1])
+            if (is_ok(parsed)) {
+                res.volume = clamp(unwrap(parsed), 0.0, 1.0)
+            } else {
+                to_log(LOG_WARNING, "audio: --volume {args[i + 1]} is not a number, ignored\n")
+            }
+        }
+    }
+    return res
+}
+
 def public audio_system_create : AudioSystemChannels {
-    //! Low-level: creates the audio system. Prefer with_audio_system.
+    //! Low-level: creates the audio system. Prefer with_audio_system. Applies `audio_user_args` to the
+    //! user args (after `--` interpreted, argv[1..] as a standalone exe - `get_user_args` picks).
+    let knobs = audio_user_args(get_user_args())
+    if (knobs.null_device) {
+        sound_set_null_device(true)
+        to_log(LOG_INFO, "audio: --null-audio, using the null backend\n")
+    }
     sound_initalize(@@mixer, MA_SAMPLE_RATE, MA_CHANNELS, this_context())
     var s = unsafe(stream_create())
     s |> add_ref()
     g_command_stream = s
     g_sound_sid = atomic64_create()
     unsafe(invoke_in_context(mixer_context(), "setup_command_processor", s))
+    if (knobs.volume >= 0.0) {
+        set_global_volume(knobs.volume)
+        to_log(LOG_INFO, "audio: --volume {knobs.volume}\n")
+    }
     return (command = s, next_sid = g_sound_sid)
 }
 

--- a/modules/dasAudio/strudel/strudel_sf2.das
+++ b/modules/dasAudio/strudel/strudel_sf2.das
@@ -603,6 +603,10 @@ def private sf3_decode_samples(data : array<uint8>; smpl_offset, smpl_size : int
 
 def public sf2_load(path : string) : SF2File? {
     //! Load and parse an SF2 soundfont file from disk.
+    if (empty(path)) {           // fopen panics on an empty name
+        to_log(0, "SF2: empty path\n")
+        return null
+    }
     var data : array<uint8>
     fopen(path, "rb") $(f) {
         if (f != null) {

--- a/modules/dasImgui/CLAUDE.md
+++ b/modules/dasImgui/CLAUDE.md
@@ -48,7 +48,7 @@ Needs the dasClangBind/libclang stack — read `skills/internal/clang_bind_build
 ## Examples layout (`modules/dasImgui/examples/`)
 
 - `features/` — small focused demos, one wrapper per file (~20-80 LOC); drive `[test]` smokes in `modules/dasImgui/tests/test_<name>.das`. `harness_*` lifecycle.
-- `imgui_demo/` — daslang port of `imgui_demo.cpp`: per-scene modules consumed by `imgui_demo.das`; `main.das` is the live-reload entry; `harness_<scene>.das` for headless smokes + recordings.
+- `imgui_demo/` — daslang port of `imgui_demo.cpp`: per-scene modules consumed by `imgui_demo.das`; `main.das` is the whole-demo harness app (headless-capable); `harness_<scene>.das` for per-scene headless smokes + recordings.
 - `tutorial/` — annotated tutorials matching `doc/source/reference/tutorials/imgui/*.rst`; `live_*` lifecycle so the live-reload tutorial flow works.
 - `save_demo/` — one-shot save/load demo.
 

--- a/modules/dasImgui/examples/features/embedded_terminal.das
+++ b/modules/dasImgui/examples/features/embedded_terminal.das
@@ -3,6 +3,13 @@ options _comment_hygiene = true
 options gc
 options persistent_heap
 
+// =============================================================================
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/embedded_terminal.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/embedded_terminal.das -- --headless --headless-frames=60
+//             spawns a real PTY child (default powershell.exe) — pass --terminal-command=/bin/sh on POSIX
+// LIVE:       daslang-live modules/dasImgui/examples/features/embedded_terminal.das
+// =============================================================================
+
 require imgui/imgui_harness
 require imgui/imgui_terminal
 require imgui/imgui_fonts

--- a/modules/dasImgui/examples/features/foundation.das
+++ b/modules/dasImgui/examples/features/foundation.das
@@ -18,6 +18,7 @@ require imgui/imgui_harness
 //          curl -X POST -d '{"name":"imgui_force_set","args":{"target":"MAIN_WIN/VOLUME","value":0.5}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/foundation.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/foundation.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/foundation.das
 // =============================================================================
 

--- a/modules/dasImgui/examples/features/narrate_placement.das
+++ b/modules/dasImgui/examples/features/narrate_placement.das
@@ -16,6 +16,7 @@ require imgui/imgui_visual_aids
 //          to hide narration. Selected button is outlined by highlight(); the
 //          banner points at it via a connector line.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/narrate_placement.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/narrate_placement.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/narrate_placement.das
 // =============================================================================
 

--- a/modules/dasImgui/examples/features/snapshot_transform.das
+++ b/modules/dasImgui/examples/features/snapshot_transform.das
@@ -15,6 +15,7 @@ require imgui/imgui_boost_runtime
 //            - widgets before the push / after the pop: screen-native bbox, no canvas_bbox.
 // DRIVE:   modules/dasImgui/tests/test_snapshot_transform.das
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/snapshot_transform.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/snapshot_transform.das -- --headless --headless-frames=60
 // =============================================================================
 
 let XFORM_SCALE  = float2(2.0, 3.0)

--- a/modules/dasImgui/examples/imgui_demo/harness_app_console.das
+++ b/modules/dasImgui/examples/imgui_demo/harness_app_console.das
@@ -1,0 +1,48 @@
+options gen2
+options _comment_hygiene = true
+options gc
+
+require imgui/imgui_harness
+require app_console
+
+// =============================================================================
+// HARNESS: imgui_demo Example: Console — single-scene driver for the C++
+//          ShowExampleAppConsole port. The function opens its own window
+//          (CONSOLE_WIN).
+// SHOWS:   CONSOLE_WIN + the "Close Console" title-bar context menu; the
+//          close request is consumed here the way imgui_demo.das does it.
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_console.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_console.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_app_console.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Console", 760, 540)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    app_console::ShowExampleAppConsole()
+    if (app_console::take_close_request()) {
+        request_exit()
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+        harness_maybe_collect_gc()
+    }
+    shutdown()
+}

--- a/modules/dasImgui/examples/imgui_demo/harness_app_log.das
+++ b/modules/dasImgui/examples/imgui_demo/harness_app_log.das
@@ -1,0 +1,44 @@
+options gen2
+options _comment_hygiene = true
+options gc
+
+require imgui/imgui_harness
+require app_log
+
+// =============================================================================
+// HARNESS: imgui_demo Example: Log — single-scene driver for the C++
+//          ShowExampleAppLog port. The function opens its own window
+//          (LOG_WIN: debug add/clear buttons, filter, scrolling log region).
+// SHOWS:   LOG_WIN with the "[Debug] Add 5 entries" row inline at the top.
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_log.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_log.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_app_log.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Log", 760, 540)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    app_log::ShowExampleAppLog()
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+        harness_maybe_collect_gc()
+    }
+    shutdown()
+}

--- a/modules/dasImgui/examples/imgui_demo/harness_columns.das
+++ b/modules/dasImgui/examples/imgui_demo/harness_columns.das
@@ -1,0 +1,48 @@
+options gen2
+options _comment_hygiene = true
+options gc
+
+require imgui/imgui_harness
+require columns
+
+// =============================================================================
+// HARNESS: imgui_demo columns — single-scene driver for the C++
+//          ShowDemoWindowColumns port (the legacy Columns() API section).
+// SHOWS:   COLUMNS_OUTER tree_node inside a host MAIN_WIN window
+//          (ShowDemoWindowColumns does NOT open its own window).
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_columns.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_columns.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_columns.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Columns", 760, 640)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    SetNextWindowSize(ImVec2(720.0, 600.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "Legacy Columns", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        columns::ShowDemoWindowColumns()
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+        harness_maybe_collect_gc()
+    }
+    shutdown()
+}

--- a/modules/dasImgui/examples/imgui_demo/harness_popups.das
+++ b/modules/dasImgui/examples/imgui_demo/harness_popups.das
@@ -1,0 +1,49 @@
+options gen2
+options _comment_hygiene = true
+options gc
+
+require imgui/imgui_harness
+require popups
+
+// =============================================================================
+// HARNESS: imgui_demo popups — single-scene driver for the C++
+//          ShowDemoWindowPopups port (popups, context menus, modals,
+//          menus-in-regular-window).
+// SHOWS:   POPUPS_SECTION collapsing_header inside a host MAIN_WIN window
+//          (ShowDemoWindowPopups does NOT open its own window).
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_popups.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_popups.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_popups.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Popups", 760, 640)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    SetNextWindowSize(ImVec2(720.0, 600.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "Popups & Modal windows", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        popups::ShowDemoWindowPopups()
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+        harness_maybe_collect_gc()
+    }
+    shutdown()
+}

--- a/modules/dasImgui/examples/imgui_demo/harness_user_guide.das
+++ b/modules/dasImgui/examples/imgui_demo/harness_user_guide.das
@@ -1,0 +1,48 @@
+options gen2
+options _comment_hygiene = true
+options gc
+
+require imgui/imgui_harness
+require user_guide
+
+// =============================================================================
+// HARNESS: imgui_demo user guide — single-scene driver for the C++
+//          ShowUserGuide port (the bullet list under Help > USER GUIDE).
+// SHOWS:   the bullet_text / with_indent guide inside a host MAIN_WIN window
+//          (ShowUserGuide does NOT open its own window).
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_user_guide.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_user_guide.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_user_guide.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - User Guide", 640, 480)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    SetNextWindowSize(ImVec2(600.0, 440.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "User Guide", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        user_guide::ShowUserGuide()
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+        harness_maybe_collect_gc()
+    }
+    shutdown()
+}

--- a/modules/dasImgui/examples/imgui_demo/main.das
+++ b/modules/dasImgui/examples/imgui_demo/main.das
@@ -2,22 +2,7 @@ options gen2
 options _comment_hygiene = true
 options gc
 
-require imgui
-require imgui_app
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require daslib/clargs
-require strings
-
+require imgui/imgui_harness
 require imgui_demo
 
 // =============================================================================
@@ -25,66 +10,26 @@ require imgui_demo
 // SHOWS:   complete tour of the dasImgui boost surface as a single host file
 //          dispatching into per-section sub-modules under imgui_demo/.
 // STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/main.das
-// SMOKE:      daslang.exe modules/dasImgui/examples/imgui_demo/main.das -- --headless-frames=30
-//             (auto-exit after N frames; useful for CI smoke runs / repro)
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/main.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/main.das
 // =============================================================================
 
-// `--headless-frames=N` — exit after rendering N frames. Matches the same flag
-// name used by `imgui_harness`'s headless rail so test runners stay uniform
-// across the harness/live-host split. 0 = run until window-close.
-var private g_max_frames = 0
-var private g_frame_count = 0
-var private g_args_parsed = false
-
-def private ensure_args_parsed() {
-    return if (g_args_parsed)
-    g_args_parsed = true
-    let args <- get_user_args()
-    let raw = find_flag_raw_value(args, "--headless-frames")
-    g_max_frames = to_int(raw |> unwrap_or("0"))
-}
-
 [export]
 def init() {
-    ensure_args_parsed()
-    live_create_window("Dear ImGui Demo (daslang port)", 1280, 720)
-    live_imgui_init(live_window)
+    harness_init("Dear ImGui Demo (daslang port)", 1280, 720)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
-
+    if (!harness_begin_frame()) return
+    harness_new_frame()
     RunImGuiDemo()
-
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    live_imgui_render()
-
-    live_end_frame()
-
-    // Frame-cap exit (smoke-test path). Bump AFTER the frame so the very
-    // first iteration always renders at least one full frame.
-    g_frame_count++
-    if (g_max_frames > 0 && g_frame_count >= g_max_frames) {
-        request_exit()
-    }
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]
@@ -92,7 +37,7 @@ def main() {
     init()
     while (!exit_requested()) {
         update()
-        maybe_collect_gc()
+        harness_maybe_collect_gc()
     }
     shutdown()
 }

--- a/modules/dasImgui/examples/save_demo/main.das
+++ b/modules/dasImgui/examples/save_demo/main.das
@@ -18,7 +18,7 @@ require imgui/imgui_harness
 //          curl -X POST -d '{"name":"imgui_force_set","args":{"target":"MAIN_WIN/NAME_INPUT","value":"hello"}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/save_demo/main.das
-// HEADLESS:   daslang.exe modules/dasImgui/examples/save_demo/main.das -- --headless
+// HEADLESS:   daslang.exe modules/dasImgui/examples/save_demo/main.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/save_demo/main.das
 // =============================================================================
 

--- a/modules/dasImgui/examples/tutorial/file_dialog.das
+++ b/modules/dasImgui/examples/tutorial/file_dialog.das
@@ -25,6 +25,7 @@ require imgui/imgui_file_dialog
 // take a typed name and confirm-overwrite if it already exists.
 //
 // STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/file_dialog.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/tutorial/file_dialog.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/tutorial/file_dialog.das
 // =============================================================================
 

--- a/modules/dasImgui/examples/tutorial/wrap_tab_bar.das
+++ b/modules/dasImgui/examples/tutorial/wrap_tab_bar.das
@@ -24,6 +24,7 @@ require imgui/imgui_harness
 // The narrow window below forces the headers to wrap across rows.
 //
 // STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/wrap_tab_bar.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/tutorial/wrap_tab_bar.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/tutorial/wrap_tab_bar.das
 //
 // DRIVE (when running live) — select the "lava" tab (index 2):

--- a/modules/dasImgui/tests/test_imgui_demo_app_console.das
+++ b/modules/dasImgui/tests/test_imgui_demo_app_console.das
@@ -1,0 +1,28 @@
+options gen2
+options _comment_hygiene = true
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the imgui_demo `app_console` scene. Boots the
+//! single-scene harness driver and waits for CONSOLE_WIN + its command input.
+
+let IMGUI_DEMO_APP_CONSOLE_HARNESS = "modules/dasImgui/examples/imgui_demo/harness_app_console.das"
+
+[test]
+def test_imgui_demo_app_console_smoke(t : T?) {
+    with_imgui_app(IMGUI_DEMO_APP_CONSOLE_HARNESS) $(d) {
+        var snap0 = wait_for_widget(d, "CONSOLE_WIN", 15.0f)
+        t |> success(snap0 != null, "CONSOLE_WIN registers (console renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "CONSOLE_WIN")?["kind"] ?? "", "window",
+                   "CONSOLE_WIN.kind == 'window'")
+        var snap1 = wait_for_widget(d, "CONSOLE_WIN/CONSOLE_INPUT", 15.0f)
+        t |> success(snap1 != null, "CONSOLE_INPUT registers inside CONSOLE_WIN")
+    }
+}

--- a/modules/dasImgui/tests/test_imgui_demo_app_log.das
+++ b/modules/dasImgui/tests/test_imgui_demo_app_log.das
@@ -1,0 +1,28 @@
+options gen2
+options _comment_hygiene = true
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the imgui_demo `app_log` scene. Boots the
+//! single-scene harness driver and waits for LOG_WIN + its debug button row.
+
+let IMGUI_DEMO_APP_LOG_HARNESS = "modules/dasImgui/examples/imgui_demo/harness_app_log.das"
+
+[test]
+def test_imgui_demo_app_log_smoke(t : T?) {
+    with_imgui_app(IMGUI_DEMO_APP_LOG_HARNESS) $(d) {
+        var snap0 = wait_for_widget(d, "LOG_WIN", 15.0f)
+        t |> success(snap0 != null, "LOG_WIN registers (log renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "LOG_WIN")?["kind"] ?? "", "window",
+                   "LOG_WIN.kind == 'window'")
+        var snap1 = wait_for_widget(d, "LOG_WIN/LOG_BTN_ADD5", 15.0f)
+        t |> success(snap1 != null, "LOG_BTN_ADD5 registers inside LOG_WIN")
+    }
+}

--- a/modules/dasImgui/tests/test_imgui_demo_columns.das
+++ b/modules/dasImgui/tests/test_imgui_demo_columns.das
@@ -1,0 +1,30 @@
+options gen2
+options _comment_hygiene = true
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the imgui_demo `columns` scene. Boots the
+//! single-scene harness driver (the section is hosted in MAIN_WIN since it
+//! doesn't open its own window) and waits for the host window + the
+//! COLUMNS_OUTER tree_node inside.
+
+let IMGUI_DEMO_COLUMNS_HARNESS = "modules/dasImgui/examples/imgui_demo/harness_columns.das"
+
+[test]
+def test_imgui_demo_columns_smoke(t : T?) {
+    with_imgui_app(IMGUI_DEMO_COLUMNS_HARNESS) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN", 15.0f)
+        t |> success(snap0 != null, "MAIN_WIN registers (host window renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "MAIN_WIN")?["kind"] ?? "", "window",
+                   "MAIN_WIN.kind == 'window'")
+        var snap1 = wait_for_widget(d, "MAIN_WIN/COLUMNS_OUTER", 15.0f)
+        t |> success(snap1 != null, "COLUMNS_OUTER registers inside MAIN_WIN")
+    }
+}

--- a/modules/dasImgui/tests/test_imgui_demo_popups.das
+++ b/modules/dasImgui/tests/test_imgui_demo_popups.das
@@ -1,0 +1,30 @@
+options gen2
+options _comment_hygiene = true
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the imgui_demo `popups` scene. Boots the
+//! single-scene harness driver (the section is hosted in MAIN_WIN since it
+//! doesn't open its own window) and waits for the host window + the
+//! POPUPS_SECTION collapsing_header inside.
+
+let IMGUI_DEMO_POPUPS_HARNESS = "modules/dasImgui/examples/imgui_demo/harness_popups.das"
+
+[test]
+def test_imgui_demo_popups_smoke(t : T?) {
+    with_imgui_app(IMGUI_DEMO_POPUPS_HARNESS) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN", 15.0f)
+        t |> success(snap0 != null, "MAIN_WIN registers (host window renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "MAIN_WIN")?["kind"] ?? "", "window",
+                   "MAIN_WIN.kind == 'window'")
+        var snap1 = wait_for_widget(d, "MAIN_WIN/POPUPS_SECTION", 15.0f)
+        t |> success(snap1 != null, "POPUPS_SECTION registers inside MAIN_WIN")
+    }
+}

--- a/modules/dasImgui/tests/test_imgui_demo_user_guide.das
+++ b/modules/dasImgui/tests/test_imgui_demo_user_guide.das
@@ -1,0 +1,27 @@
+options gen2
+options _comment_hygiene = true
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the imgui_demo `user_guide` scene. Boots the
+//! single-scene harness driver (the guide is hosted in MAIN_WIN since it
+//! doesn't open its own window) and waits for the host window.
+
+let IMGUI_DEMO_USER_GUIDE_HARNESS = "modules/dasImgui/examples/imgui_demo/harness_user_guide.das"
+
+[test]
+def test_imgui_demo_user_guide_smoke(t : T?) {
+    with_imgui_app(IMGUI_DEMO_USER_GUIDE_HARNESS) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN", 15.0f)
+        t |> success(snap0 != null, "MAIN_WIN registers (host window renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "MAIN_WIN")?["kind"] ?? "", "window",
+                   "MAIN_WIN.kind == 'window'")
+    }
+}

--- a/skills/daslang/references/memory.md
+++ b/skills/daslang/references/memory.md
@@ -158,6 +158,11 @@ once, not once per iteration — wrap the body in a bare block if you need it th
 no such restriction: the loop body is its own scope, so it releases every iteration.
 (`defer_delete` is deprecated; use `var inscope`.)
 
+**A `defer()` at the top level of a lambda body never fires per call** — it lands in the lambda's
+`finally`, which is its *finalizer* (runs once, on `delete`), and nothing rejects it (probe-verified
+2026-08-18). A `$()` block body and a nested bare block `{ }` inside the lambda both fire at exit as
+expected — so wrap the lambda body in a bare block, or put the cleanup as the last statement.
+
 **Scope-exit cleanup does not run on panic.** A block's `finally` — and everything built on it — is
 skipped when the block panics, by design: a panicked program is broken and its cleanup cannot be
 trusted. Never rely on `finally`/`defer`/`inscope` for cleanup that must survive a panic.

--- a/tests/strudel/test_sf2.das
+++ b/tests/strudel/test_sf2.das
@@ -56,6 +56,17 @@ def test_centibels_to_linear(t : T?) {
 }
 
 [test]
+def test_load_empty_path(t : T?) {
+    t |> run("sf2_load(\"\") returns null instead of panicking in fopen") <| @(t : T?) {
+        // a missing-soundfont probe hands "" here; fopen("") is a panic, so the guard must catch it first
+        t |> success(sf2_load("") == null)
+    }
+    t |> run("sf2_load on a missing file returns null") <| @(t : T?) {
+        t |> success(sf2_load("{get_das_root()}/tests/strudel/fixtures/does_not_exist.sf2") == null)
+    }
+}
+
+[test]
 def test_load_sf3_compressed(t : T?) {
     // mini.sf3: a hand-built minimal SF3 holding one OGG-Vorbis sample (a 0.06s 440Hz
     // mono sine, 22050Hz). Exercises the SF3 decode path deterministically — no external asset.

--- a/tests/strudel_device/test_audio_args.das
+++ b/tests/strudel_device/test_audio_args.das
@@ -1,0 +1,68 @@
+options gen2
+options indenting = 4
+options persistent_heap
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+
+require dastest/testing_boost
+require audio/audio_boost
+require audio/audio_record
+require strings
+
+// audio_system_create reads the user args through audio_user_args (`--null-audio`,
+// `--volume V`). The parse is pure and tested directly; the null-backend EFFECT is
+// observable through capture enumeration (miniaudio's null context reports exactly
+// its one fake device), so that arm is driven for real under with_argv.
+
+def argv_with(user_args : array<string>) : array<string> {
+    var full <- ["daslang", "test_audio_args.das", "--"]
+    full |> push_from(user_args)
+    return <- full
+}
+
+def capture_device_names() : array<string> {
+    let devs <- sound_record_list_devices()
+    return <- [for (d in devs); d.name]
+}
+
+[test]
+def test_audio_user_args_parse(t : T?) {
+    t |> run("no flags = defaults") @(t : T?) {
+        let k = audio_user_args([])
+        t |> equal(k.null_device, false)
+        t |> success(k.volume < 0.0, "volume not given")
+    }
+    t |> run("--null-audio sets the flag; a near-miss spelling does not") @(t : T?) {
+        t |> equal(audio_user_args(["--null-audio"]).null_device, true)
+        t |> equal(audio_user_args(["--null-audio-not-quite"]).null_device, false)
+    }
+    t |> run("--volume V parses and clamps to 0..1") @(t : T?) {
+        t |> equal(audio_user_args(["--volume", "0.25"]).volume, 0.25)
+        t |> equal(audio_user_args(["--volume", "7"]).volume, 1.0)
+        t |> equal(audio_user_args(["--volume", "-3"]).volume, 0.0)
+    }
+    t |> run("--volume garbage or missing value = not given, never 0") @(t : T?) {
+        t |> success(audio_user_args(["--volume", "loud"]).volume < 0.0, "garbage rejected")
+        t |> success(audio_user_args(["--volume"]).volume < 0.0, "dangling flag ignored")
+    }
+    t |> run("flags compose in any order") @(t : T?) {
+        let k = audio_user_args(["--volume", "0.5", "--null-audio"])
+        t |> equal(k.null_device, true)
+        t |> equal(k.volume, 0.5)
+    }
+}
+
+[test]
+def test_null_audio_flag_effect(t : T?) {
+    t |> run("--null-audio puts audio_system_create on the null backend") @(t : T?) {
+        with_argv(argv_with(["--null-audio"])) {
+            with_audio_system() {
+                let names <- capture_device_names()
+                t |> equal(length(names), 1, "null backend exposes exactly one capture device")
+                t |> success(length(names) == 1 && find(names[0], "NULL") >= 0, "it is miniaudio's null device: {names}")
+            }
+        }
+        // sticky process-wide flag: hand the next test a clean slate
+        sound_set_null_device(false)
+    }
+}

--- a/tests/strudel_device/test_device_teardown.das
+++ b/tests/strudel_device/test_device_teardown.das
@@ -5,7 +5,6 @@ options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 
 require dastest/testing_boost
-require daslib/defer
 require strudel/strudel
 require strudel/strudel_player
 require audio/audio_boost
@@ -33,10 +32,6 @@ require jobque
 def test_device_teardown_no_leak(t : T?) {
     t |> run("strudel device create/tick/shutdown leaves no JobQue leak") @(t : T?) {
         sound_set_null_device(true)
-        // reset the global null-backend flag on exit, so a later audio test in this process isn't forced onto it
-        defer() {
-            sound_set_null_device(false)
-        }
         let before = count_jobque_leaks()
         with_audio_system() {
             strudel_create_channel()
@@ -50,6 +45,7 @@ def test_device_teardown_no_leak(t : T?) {
         }
         let after = count_jobque_leaks()
         t |> equal(after, before)
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }
 
@@ -59,10 +55,6 @@ def test_device_teardown_no_leak(t : T?) {
 def test_device_teardown_rerun(t : T?) {
     t |> run("strudel device cycle is repeatable, still no JobQue leak") @(t : T?) {
         sound_set_null_device(true)
-        // reset the global null-backend flag on exit, so a later audio test in this process isn't forced onto it
-        defer() {
-            sound_set_null_device(false)
-        }
         let before = count_jobque_leaks()
         for (_cycle in range(2)) {
             with_audio_system() {
@@ -78,5 +70,6 @@ def test_device_teardown_rerun(t : T?) {
         }
         let after = count_jobque_leaks()
         t |> equal(after, before)
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }

--- a/tests/strudel_device/test_record_capture.das
+++ b/tests/strudel_device/test_record_capture.das
@@ -5,7 +5,6 @@ options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 
 require dastest/testing_boost
-require daslib/defer
 require audio/audio_record
 require audio
 require jobque
@@ -23,10 +22,6 @@ require daslib/fio
 def test_record_capture_smoke(t : T?) {
     t |> run("null-backend capture: start, drain silent frames, clean stop") @(t : T?) {
         sound_set_null_device(true)
-        // reset the global null-backend flag on exit, so a later audio test in this process isn't forced onto it
-        defer() {
-            sound_set_null_device(false)
-        }
         let before = count_jobque_leaks()
         t |> success(sound_record_start(16000, 1, 16000, -1), "capture device should start on the null backend")
         t |> success(sound_is_recording(), "should be recording after start")
@@ -46,6 +41,7 @@ def test_record_capture_smoke(t : T?) {
         t |> equal(sound_record_available(), 0)          // device torn down -> nothing buffered
         let after = count_jobque_leaks()
         t |> equal(after, before)                        // capture allocates no jobque objects
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }
 
@@ -53,14 +49,12 @@ def test_record_capture_smoke(t : T?) {
 def test_record_device_enumeration(t : T?) {
     t |> run("null-backend capture device enumeration") @(t : T?) {
         sound_set_null_device(true)
-        defer() {
-            sound_set_null_device(false)
-        }
         let devs <- sound_record_list_devices()
         t |> equal(length(devs), sound_record_device_count())
         for (d in devs) {
             t |> success(d.index >= 0, "device index is non-negative")
         }
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }
 
@@ -68,9 +62,6 @@ def test_record_device_enumeration(t : T?) {
 def test_record_to_wav_roundtrip(t : T?) {
     t |> run("null-backend record_to_wav writes a readable WAV of exactly the requested length") @(t : T?) {
         sound_set_null_device(true)
-        defer() {
-            sound_set_null_device(false)
-        }
         let tmp = create_temp_file_result("das_record_to_wav_test", ".wav")   // unique writable path, no cwd assumptions
         if (!(tmp is value)) {
             t |> failure("could not create a temp file")
@@ -91,5 +82,6 @@ def test_record_to_wav_roundtrip(t : T?) {
         // a write failure must propagate: an unwritable output path returns false (not a silent success)
         t |> success(!record_to_wav("/nonexistent_dir_xyzzy_das/rec.wav", 0.05, rate, 1),
             "record_to_wav returns false when the WAV cannot be written")
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }

--- a/tests/strudel_device/test_sound_status_seqbox.das
+++ b/tests/strudel_device/test_sound_status_seqbox.das
@@ -5,7 +5,6 @@ options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 
 require dastest/testing_boost
-require daslib/defer
 require daslib/fio
 require daslib/jobque_boost
 require audio/audio_boost
@@ -28,9 +27,6 @@ def private short_tone(seconds : float) : array<float> {
 def test_status_seeded_on_the_calling_thread(t : T?) {
     t |> run("the box reads `starting` before the audio thread has seen the sound") @(t : T?) {
         sound_set_null_device(true)
-        defer() {
-            sound_set_null_device(false)
-        }
         with_audio_system() {
             var tone <- short_tone(0.2)
             let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
@@ -46,6 +42,7 @@ def test_status_seeded_on_the_calling_thread(t : T?) {
             unset_status_update(sid)
             box |> seq_box_release
         }
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }
 
@@ -53,9 +50,6 @@ def test_status_seeded_on_the_calling_thread(t : T?) {
 def test_status_reaches_stopped(t : T?) {
     t |> run("a one-shot tone advances to stopped") @(t : T?) {
         sound_set_null_device(true)
-        defer() {
-            sound_set_null_device(false)
-        }
         with_audio_system() {
             var tone <- short_tone(0.2)
             let sid = play_sound_from_pcm(MA_SAMPLE_RATE, 1, tone)
@@ -73,6 +67,7 @@ def test_status_reaches_stopped(t : T?) {
             unset_status_update(sid)
             box |> seq_box_release
         }
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }
 
@@ -80,9 +75,6 @@ def test_status_reaches_stopped(t : T?) {
 def test_release_needs_no_ordering(t : T?) {
     t |> run("releasing the box while the sound still plays leaks nothing") @(t : T?) {
         sound_set_null_device(true)
-        defer() {
-            sound_set_null_device(false)
-        }
         let before = count_jobque_leaks()
         with_audio_system() {
             for (_i in range(8)) {
@@ -98,5 +90,6 @@ def test_release_needs_no_ordering(t : T?) {
             sleep(60u)
         }
         t |> equal(count_jobque_leaks(), before)
+        sound_set_null_device(false)   // sticky process-wide flag: leave a clean slate
     }
 }

--- a/tutorials/dasAudio/11_recording.das
+++ b/tutorials/dasAudio/11_recording.das
@@ -129,6 +129,8 @@ def main() {
     list_devices()
     if (record_clip()) {
         verify_clip()
+        remove(OUT_FILE)
+        print("  removed {OUT_FILE} (drop the remove() to keep the clip)\n")
     }
     manual_capture()
     print("\nDone!\n")

--- a/tutorials/opengl/01_triangle/01_triangle.das
+++ b/tutorials/opengl/01_triangle/01_triangle.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/safe_addr
@@ -116,13 +117,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/02_mandelbrot/02_mandelbrot.das
+++ b/tutorials/opengl/02_mandelbrot/02_mandelbrot.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/safe_addr
@@ -206,13 +207,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/03_sdf/03_sdf.das
+++ b/tutorials/opengl/03_sdf/03_sdf.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/safe_addr
@@ -321,13 +322,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/04_cube/04_cube.das
+++ b/tutorials/opengl/04_cube/04_cube.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -279,13 +280,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/05_instancing/05_instancing.das
+++ b/tutorials/opengl/05_instancing/05_instancing.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -250,13 +251,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/06_skybox/06_skybox.das
+++ b/tutorials/opengl/06_skybox/06_skybox.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -445,13 +446,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/07_particles/07_particles.das
+++ b/tutorials/opengl/07_particles/07_particles.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -267,13 +268,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/08_shadow/08_shadow.das
+++ b/tutorials/opengl/08_shadow/08_shadow.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -408,13 +409,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/09_msaa/09_msaa.das
+++ b/tutorials/opengl/09_msaa/09_msaa.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -453,13 +454,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/10_deferred/10_deferred.das
+++ b/tutorials/opengl/10_deferred/10_deferred.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require geometry/geom_gen
 require stbimage
@@ -703,11 +704,28 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/11_hdr/11_hdr.das
+++ b/tutorials/opengl/11_hdr/11_hdr.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require math
 require daslib/math_boost
@@ -511,13 +512,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives the
 // three lifecycle functions directly and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/opengl/12_gltf/12_gltf.das
+++ b/tutorials/opengl/12_gltf/12_gltf.das
@@ -2,6 +2,7 @@ options gen2
 options gc
 options persistent_heap
 require glfw/glfw_boost
+require daslib/strings_convert
 require opengl/opengl_boost
 require gltf/gltf_boost
 require gltf/gltf_gl
@@ -1003,13 +1004,30 @@ def shutdown {
     glfwTerminate()
 }
 
+var max_frame_limit = 0
+
+def parse_args {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0   // garbage = no cap
+        }
+    }
+}
+
 // Desktop driver. On the web this is never called -- the run path drives init / update /
 // shutdown once per browser frame and persists the Context across frames.
 [export]
 def main {
+    parse_args()
     init()
+    var frame_count = 0
     while (update()) {
         maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
     }
     shutdown()
 }

--- a/tutorials/sql/02-insert_data.das
+++ b/tutorials/sql/02-insert_data.das
@@ -2,6 +2,7 @@ options gen2
 
 require daslib/sql
 require sqlite/sqlite_boost
+require daslib/fio
 
 // [sql_table] is a structure macro. At compile time it reads the field
 // metadata (@sql_primary_key etc.) and generates, attached to type Car:
@@ -48,4 +49,5 @@ def main() {
             Car(Id = 8, Name = "Volkswagen", Price = 21600)
         ])
     }
+    remove("test.db")   // reruns start clean
 }


### PR DESCRIPTION
**Behavior change: every program that opens the audio system through `with_audio_system` / `audio_system_create` now reads two user flags after `--`: `--null-audio` (miniaudio null backend, no device) and `--volume V` (master 0..1).** Nothing changes for programs that do not pass them.

The release run-tier audit walked every example and tutorial asking "can this run unattended and terminate?" and came back with two knobs that convert whole families and a defect list. This PR lands both. The two audio flags live in `audio_system_create` — the one function every audio app passes through — so all dasAudio tutorials, daStrudel features and the games get them with no per-file wiring; the parse is a pure `audio_user_args(args)` so it is unit-testable and garbage-safe (`--volume loud` warns and is ignored, never read as 0 = mute). `tutorials/opengl` 01–12 were the last forever-loop family with no off switch; they and pacman get the games-family `--max-frames N` block, and all 26 copies of that block tree-wide go `try_to_int ?? 0`.

Defects fixed: `sf2_load("")` panicked in `fopen`; `render_wav` read `argv[0]` — the daslang binary — as its output path; `test_api_http` could never run (the live API is serviced by the host's frame loop, so a synchronous GET from `update()` deadlocks the loop that has to answer — the client now runs on a thread, 18/18 under the host); `ws_chat_client` exited 0 with no output when no server was up; flatten's `run.sh`/`check.sh` hardcoded `bin/daslang` (dead on the MSVC layout and the SDK); residue files (`sql/02` `test.db`, `dasAudio/11` `recording.wav`), `/tmp` and `E:/` paths, three dead font fallbacks, the daStrudel README's missing `--`, dasImgui HEADLESS headers (save_demo's hung as written). imgui_demo: 5 scenes had no harness wrapper and zero headless coverage — each gets one plus a pairing test; `main.das` moves onto `imgui_harness` (−76 lines).

A side find worth knowing: a `defer()` at the top level of a lambda body never fires per call — it becomes the lambda's finalizer, silently. Eight `sound_set_null_device(false)` cleanups in `tests/strudel_device` were inert; replaced with explicit resets, and the trap is now in CLAUDE.md's fails-silently list.

Where to look: `modules/dasAudio/audio/audio_boost.das` (`audio_user_args` + `audio_system_create`), `tests/strudel_device/test_audio_args.das` (the `with_argv` effect test), `examples/daslive/test_api_http/main.das` (the thread/atomic shape), `modules/dasImgui/examples/imgui_demo/main.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- dasImgui suite (nightly-only in CI, no per-PR lane): local Windows run 390/390 + `test_embedded_terminal` (Windows-only) + the 5 new `test_imgui_demo_*` = every test in the folder green. The mirror command excludes `embedded_terminal` on all OSes; it was run separately here.
- Null-backend effect test is negative-controlled: with `sound_set_null_device(true)` removed and the log kept, `test_audio_args` fails 7/8; restored 8/8. `sf2_load("")` case fail-first proven against the un-guarded source.
- Run-tier probes on this box: pacman / asteroids / tutorials/opengl 01+12 / examples/opengl 01 terminate under `-- --max-frames N` rc=0; `--null-audio` + `--volume 0.05` on dasAudio/09 and a strudel feature rc=0 (also under `-jit`); test_api_http 18/18 under `daslang-live`, standalone exits 0 with the no-server message; ws_chat_client no-server rc=1, with-server chat+`/quit` rc=0; flatten `run.sh` 87/87 + `check.sh` 24/24 on the Windows layout with `DASLANG` unset; sql/02 and dasAudio/11 leave no files.
- Suites: strudel 643/643, strudel_device 24/24, audio 14/14. Sphinx html clean.

### Claims — stated, not tested
- The `--max-frames` block in the 11 opengl tutorials besides 01/12 is byte-identical to the two that were run; the fallback arms in `export_drums`/`sfxr_presets` (temp dir missing) and the repointed font fallbacks (primary font missing) are unreachable in-tree — the fallback targets were verified to exist.
- `set_global_volume` from `--volume` has no readback; the parse is tested, the effect was heard (0.05 = near-silent) not measured.
- `tests/strudel/test_sf2.das` is in the nightly `test_aot`, not the per-PR subset; the new case is a plain null-guard, nothing AOT-hostile.

### Not done
- dasLLAMA tutorial model provisioning (fetch_models has none of the tutorial-named models) — deferred by ruling until the follow-ups land.
- `imgui_demo/main.das` itself has no test driver (the 5 scene wrappers do); `harness_app_console`'s close-request arm is not driven by the smoke.
- `modules/dasImgui/REVIEW.md` self-review findings from the audit (the `.das`/`bind/`/`src/` enumeration should be the property "executable or build content"; "dasImgui test file" should be defined as "one carrying `[test]`") — a follow-up on the checklist, not this PR.
- `skills/internal/preflight.md`'s imgui mirror block hardcodes the ubuntu/macos exclude list while the gate splits per OS — doc drift, follow-up.
- `examples/games/sequence/main.das` carries 108 pre-existing lint findings only visible with `-project_root` (CI's changed-file lint skips it as a package) — a lint-sweep item.
- Lint candidates: `defer()` whose enclosing scope is a lambda body; unguarded empty-able path into `fopen`/loaders.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
