### PR TITLE
const folding: splat collapse only when the other operand IS the vector, and never by reordering effects (float2(x)*y miscompile)

### DIFF
--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -1190,7 +1190,9 @@ namespace das {
                     if ( isConstBoolValue(R,false) ) { reportFolding(); return L; }
                     if ( isConstBoolValue(R,true) && L->noSideEffects ) { reportFolding(); return R; }
                 }
-                // v * floatN(s) → v * s ; v / floatN(s) → v / s (splat collapse, per-lane bit-identical)
+                // v * floatN(s) → v * s ; v / floatN(s) → v / s (splat collapse, per-lane bit-identical).
+                // The OTHER operand must itself be a floatN — in `floatN(s) * t` (t scalar) the collapse
+                // would find the scalar `s * t` operator and leave a float under a floatN-typed node
                 if ( ( expr->op=="*" || expr->op=="/" ) && isFloat32Family(bt) && bt!=Type::tFloat ) {
                     auto trySplat = [&]( Expression * e ) -> Expression * {
                         if ( !e || !e->rtti_isCall() ) return nullptr;
@@ -1202,15 +1204,22 @@ namespace das {
                         if ( call->func->name!=das_to_string(bt) ) return nullptr;
                         return a0;
                     };
-                    if ( auto s = trySplat(expr->right) ) {
-                        if ( auto fn = findBuiltinOperator(expr->op.c_str(), L->type, s->type) ) {
-                            expr->right = s;
-                            expr->func = fn;
-                            reportFolding();
-                            return Visitor::visit(expr);
+                    auto isVecOfBt = [&]( Expression * e ) -> bool {
+                        return e && e->type && e->type->baseType==bt;
+                    };
+                    if ( isVecOfBt(L) ) {
+                        if ( auto s = trySplat(expr->right) ) {
+                            if ( auto fn = findBuiltinOperator(expr->op.c_str(), L->type, s->type) ) {
+                                expr->right = s;
+                                expr->func = fn;
+                                reportFolding();
+                                return Visitor::visit(expr);
+                            }
                         }
                     }
-                    if ( expr->op=="*" ) {
+                    // this arm SWAPS the operands (floatN(s) * v -> v * s), which reorders evaluation -
+                    // only when neither side can observe the other's effects
+                    if ( expr->op=="*" && isVecOfBt(R) && R->noSideEffects && L->noSideEffects ) {
                         if ( auto s = trySplat(expr->left) ) {
                             if ( auto fn = findBuiltinOperator("*", R->type, s->type) ) {
                                 expr->left = R;

--- a/tests/language/optimization_fold_shape.das
+++ b/tests/language/optimization_fold_shape.das
@@ -75,6 +75,11 @@ def target_splat(v : float3; s : float) : float3 {
 }
 
 [export]
+def target_splat_swap(v : float3; s : float) : float3 {
+    return float3(s) * v
+}
+
+[export]
 def target_div_one(f : float) : float {
     return f / 1.0
 }
@@ -253,6 +258,11 @@ def test_identity_folds_fired(t : T?) {
             let b = body_of(t, "target_splat")
             t |> success(!has(b, "float3("), "no splat ctor survives: {b}")
             t |> success(has(b, "v * s"), "vec*scalar form present: {b}")
+        }
+        t |> run("float3(s)*v collapses the splat (the swap arm, both operands pure)") @(t : T?) {
+            let b = body_of(t, "target_splat_swap")
+            t |> success(!has(b, "float3("), "no splat ctor survives: {b}")
+            t |> success(has(b, "v * s"), "swapped to vec*scalar: {b}")
         }
         t |> run("x/1.0 leaves no divide") @(t : T?) {
             let b = body_of(t, "target_div_one")

--- a/tests/language/optimization_folding.das
+++ b/tests/language/optimization_folding.das
@@ -194,6 +194,14 @@ def test_splat_collapse(t : T?) {
     t |> equal(g_v * float3(g_f), float3(1.0 * g_f, 2.0 * g_f, 4.0 * g_f))
     t |> equal(g_v / float3(g_f), float3(1.0 / g_f, 2.0 / g_f, 4.0 / g_f))
     t |> equal(float3(g_f) * g_v, float3(g_f * 1.0, g_f * 2.0, g_f * 4.0))
+    // splat against a SCALAR is not a collapse candidate: the other side must be the vector,
+    // or the fold finds the scalar operator and leaves a float under a floatN-typed node
+    t |> equal(float2(g_f) * g_f, float2(g_f * g_f, g_f * g_f))          // splat * scalar
+    t |> equal(g_f * float2(g_f), float2(g_f * g_f, g_f * g_f))          // scalar * splat
+    t |> equal(g_f / float3(g_f), float3(1.0, 1.0, 1.0))                 // scalar / splat
+    t |> equal(float3(g_f) * 2.0, float3(g_f * 2.0, g_f * 2.0, g_f * 2.0))
+    t |> equal(float4(g_f) / g_f, float4(1.0, 1.0, 1.0, 1.0))            // splat / scalar: never matched, keep it so
+    t |> equal(float2(g_f) * float2(g_f), float2(g_f * g_f, g_f * g_f))  // splat * splat: the cascade
 }
 
 [test]

--- a/tests/language/optimization_splat_order.das
+++ b/tests/language/optimization_splat_order.das
@@ -1,0 +1,60 @@
+options gen2
+options disable_auto_inline
+
+require dastest/testing_boost public
+
+// The splat-collapse fold `floatN(s) * v -> v * s` SWAPS the operands. When both carry
+// side effects that swap reorders them, so the fold must decline. Auto-inline is off
+// file-wide because the inliner would hoist a() and b() into locals before the fold and
+// hide the reorder (which is exactly how it stayed invisible in optimization_folding).
+
+var g_order = 0
+
+def a() : float {
+    g_order = g_order * 10 + 1
+    return 2.0
+}
+
+def b() : float3 {
+    g_order = g_order * 10 + 2
+    return float3(1.0, 2.0, 3.0)
+}
+
+// one-sided impurity: the swap is still observable when only ONE operand has effects,
+// because a pure operand can READ what the impure one writes - each gate clause alone
+var g_scalar = 1.0
+var g_vec3 = float3(1.0, 1.0, 1.0)
+
+def bump_scalar_ret_vec() : float3 {
+    g_scalar = 10.0
+    return float3(1.0, 1.0, 1.0)
+}
+
+def bump_vec_ret_scalar() : float {
+    g_vec3 = float3(10.0, 10.0, 10.0)
+    return 1.0
+}
+
+[test]
+def test_splat_swap_declines_when_only_right_is_impure(t : T?) {
+    g_scalar = 1.0
+    t |> equal(float3(g_scalar) * bump_scalar_ret_vec(), float3(1.0, 1.0, 1.0), "splat argument read before the right operand writes it")
+}
+
+[test]
+def test_splat_swap_declines_when_only_left_is_impure(t : T?) {
+    g_vec3 = float3(1.0, 1.0, 1.0)
+    t |> equal(float3(bump_vec_ret_scalar()) * g_vec3, float3(10.0, 10.0, 10.0), "splat argument writes before the right operand is read")
+}
+
+[test]
+def test_splat_swap_keeps_evaluation_order(t : T?) {
+    g_order = 0
+    let r = float3(a()) * b()
+    t |> equal(r, float3(2.0, 4.0, 6.0))
+    t |> equal(g_order, 12, "left operand evaluated first")
+    g_order = 0
+    let r2 = b() * float3(a())
+    t |> equal(r2, float3(2.0, 4.0, 6.0))
+    t |> equal(g_order, 21, "left operand evaluated first")
+}


### PR DESCRIPTION
**Miscompile fix, all three tiers: `float2(x) * y` (splat times a plain float) evaluated to `(x*y, 0)`.** Shipped in v0.6.4-RC1 only; RC2 carries this.

User report: `let mult = float2(ONE) * ONE` prints `1,0`. The `options log` dump shows why — the optimizer left `(ONE * ONE)` under a `float2`-typed node. The splat-collapse rule in const folding (`v * floatN(s) → v * s`, from the fast-math/identity-folding commit) assumed the non-splat operand is a `floatN`; with the splat on one side and a scalar on the other it found the scalar operator and installed it, so a scalar lands in a vector slot (x right, other lanes garbage). The cells: `float2(x)*y`, `y*float2(x)`, `y/float2(x)`, and `float2(x)*float2(x)` (cascades in through the visitor recursion). `float2(x)/y` never matched (no left-splat arm for `/`).

Fix: both arms require the other operand to be a `bt` vector. Second, related: the left-splat arm *swaps* the operands (`floatN(s) * v → v * s`), which reorders evaluation when either side has effects the other can observe — auto-inline had hidden this by hoisting impure calls before the fold. It now declines unless both operands are `noSideEffects`. The fold is AST-level, so interp/JIT/AOT are fixed together.

Where to look: `src/ast/ast_const_folding.cpp`, the splat-collapse block in `visit(ExprOp2*)`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Negative controls against the shipped RC1 binary (`D:\daslang\bin\daslang.exe`): 5 of the 6 new `test_splat_collapse` cases fail there; all three `optimization_splat_order` cases fail there (both-impure `21` vs `12`; each one-sided-impure case wrong); all pass on the fixed build. The new `optimization_fold_shape` pin (arm B still fires with pure operands) passes on both — it is the over-disable guard, and it is the only test that goes red if the whole rule is removed.
- tests/language 1658/1658 interp; the repro and its variants correct under `-jit`.
- The `!isFixedArray()` conjunct an earlier revision carried was tautological (bt is float2/3/4) — dropped.

### Claims — stated, not tested
- `test_aot_subset` (per-PR compile gate) globs `tests/language/*.das`, so the new file registers itself; plain float ops, nothing new for AOT.

### Not done
- Nothing.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
