### PR TITLE
pages.yml: publish the record stores to the live ladder on every site deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -643,4 +643,21 @@ jobs:
             -e "$RSH" _site_dasllama/ "deploy@89.167.63.131:/srv/dasllama.io/releases/$REL/"
         $RSH deploy@89.167.63.131 "ln -sfn /srv/dasllama.io/releases/$REL /srv/dasllama.io/current \
             && cd /srv/dasllama.io/releases && ls -1t | tail -n +6 | xargs -r rm -rf"
+        # The ladder renders from the exchange service's DB, not from the pages just shipped;
+        # its official boards are the record stores in the repo, so a merged store refresh
+        # must reach the service or the live board silently stays at its last hand-seed.
+        # Same shape as the playground nudge: loopback-only endpoint, upsert-on-identity
+        # (re-imports are idempotent), a miss must not fail the site deploy. Store filter
+        # mirrors the service's own official_dir import: records/<box>.json single-dot names
+        # only - tune sidecars, annotations.json and _scratch are not stores.
+        for store in modules/dasLLAMA/performance/records/*.json; do
+            name=$(basename "$store")
+            case "$name" in
+                *.*.*|annotations.json|_*) continue ;;
+            esac
+            $RSH deploy@89.167.63.131 \
+                "curl -sf -m 60 -X POST -H 'Content-Type: application/json' --data-binary @- http://127.0.0.1:8201/admin/import-official" \
+                < "$store" && echo "imported $name" \
+                || echo "ladder import of $name failed (service down?)"
+        done
         echo "deployed $REL"

--- a/utils/internal/dasllama-ladder/README.md
+++ b/utils/internal/dasllama-ladder/README.md
@@ -111,7 +111,10 @@ until an operator opens it. Toggle for a test window over the loopback tunnel wi
 `sudo dasllama-deploy.sh open-submit` / `close-submit`; the permanent open (after the security
 audit) is `submit_open = true` in the deployed toml, or the `--submit-open` boot flag.
 
-Seed the official boards (they're not in the release — the record stores live under
-`modules/dasLLAMA/performance/records/`): stage that directory on the box, point the deployed
-toml's `official_dir` at it (imported at every start), or import once over loopback with
-`admin.das`.
+The official boards are the record stores under `modules/dasLLAMA/performance/records/`
+(not in the release). The site deploy (`.github/workflows/pages.yml`, after the dasllama.io
+flip) POSTs every `records/<box>.json` to `/admin/import-official` over loopback, so a merged
+store refresh publishes itself — the same commit-is-publish contract the news has. Manual
+paths for a box without a deploy: the deployed toml's `official_dir` (imported at every
+start), or on the box
+`daslang admin.das -- --db /srv/dasllama-ladder/ladder.db --op import-official --file records/<box>.json`.


### PR DESCRIPTION
**Deploy behavior change: every site deploy now POSTs the five `records/<box>.json` stores to the live ladder over loopback.** After this merges, one `workflow_dispatch` of `pages.yml` lands the missing Qwen3.8-27B M1/M4 and Qwen3-ASR rows — no box login needed.

The ladder page renders from the exchange service's DB, not from the pages the deploy ships. Its official boards are seeded only two ways — the deployed toml's `official_dir` (ships as `""`) or a loopback `POST /admin/import-official` — and the deploy did neither, so every merged record refresh silently missed the live board; the ladder still shows the last hand-seed. This adds one loop to the deploy step, right after the dasllama.io flip: stream each single-dot `records/<box>.json` (the service's own `official_dir` filter — no tune sidecars, no `annotations.json`, no `_scratch`) into a loopback `curl` on the box. Upsert-on-identity makes re-imports idempotent; a miss echoes instead of failing the site deploy — the same shape as the playground `/admin/reimport` nudge beside it. The ladder README now says the deploy owns seeding; by-hand stays the fallback for a box without one.

Where to look: `.github/workflows/pages.yml`, the loop after the dasllama.io `ln -sfn`; `utils/internal/dasllama-ladder/README.md` § Deploy.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- YAML parses; the extracted `run` block passes `bash -n`; the store filter dry-run selects exactly m1/m3air/m4/zen2/zen4 (largest 360 KB against the service's 4 MB `max_records_bytes`).
- The endpoint contract (raw store JSON body, loopback-only, upsert) read from `ladder_server.das` `handle_import_official` / `import_official_store` and `admin.das`.

### Claims — stated, not tested
- The live run itself: only the first master deploy proves it end to end (the box, the key, port 8201 up). Watch the deploy log for `imported <box>.json` ×5; a `ladder import ... failed` line means the service was down, and the next deploy retries.

### Not done
- No `official_dir` in the deployed toml — the DB persists across restarts, so loopback import alone is complete.
- The deploy key stays a CI-only secret; no dev box gets deploy access.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
