### PR TITLE
release bundle: -exe tools find the runtime lib in the installed layout

### DIFF
--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -101,9 +101,10 @@ COMPILE_TESTS=(
 # targets (platform-natural suffix); `dasexe` rows are the DAS_UTILS_SHIPPED_EXES
 # set from utils/CMakeLists.txt (always `.exe`), installed on single-config
 # generators — which is every generator the release bundles are cut on.
-# Presence-checked only — we don't run them with `--help` because daslang itself
-# intercepts `--help` and prints its own usage even after the `--` separator,
-# swallowing the script's CLI surface.
+# `cpp` rows are presence-checked; `dasexe` rows are also LAUNCHED (`--help`, exit 0)
+# from the bundle root: a `daslang -exe` binary resolves the runtime .so/.dylib
+# through its embedded rpath, and a bundle whose rpath points back at the build tree
+# is present-but-dead on every user's box.
 EXE_PRESENCE_TESTS=(
     "gen1_to_gen2|cpp"
     "daslang-live|cpp"
@@ -166,12 +167,21 @@ for entry in "${EXE_PRESENCE_TESTS[@]}"; do
     esac
     exe="$BUNDLE/bin/${name}${suffix}"
     printf '  %-30s ' "$name"
-    if [[ -f "$exe" ]]; then
-        echo "OK"
-        PASS=$((PASS + 1))
-    else
+    if [[ ! -f "$exe" ]]; then
         echo "MISSING ($exe)"
         FAIL=$((FAIL + 1))
+    elif [[ "$kind" == dasexe ]]; then
+        if "$exe" --help > "$LOG" 2>&1; then
+            echo "OK (launches)"
+            PASS=$((PASS + 1))
+        else
+            echo "FAIL (present, exit $? on --help)"
+            sed 's/^/      /' "$LOG" | head -5
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        echo "OK"
+        PASS=$((PASS + 1))
     fi
 done
 

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -101,11 +101,11 @@ COMPILE_TESTS=(
 # targets (platform-natural suffix); `dasexe` rows are the DAS_UTILS_SHIPPED_EXES
 # set from utils/CMakeLists.txt (always `.exe`), installed on single-config
 # generators — which is every generator the release bundles are cut on.
-# `cpp` rows are presence-checked; `dasexe` rows are also LAUNCHED (`--help`, exit 0)
-# from the bundle root: a `daslang -exe` binary resolves the runtime .so/.dylib
-# through its embedded rpath, and a bundle whose rpath points back at the build tree
-# is present-but-dead on every user's box.
-EXE_PRESENCE_TESTS=(
+# `cpp` rows are presence-checked; `dasexe` rows are also launched (`--help`, exit 0):
+# a `daslang -exe` binary resolves the runtime .so/.dylib through its embedded rpath,
+# and a bundle whose rpath points back at the build tree is present-but-dead on every
+# user's box.
+SHIPPED_EXE_TESTS=(
     "gen1_to_gen2|cpp"
     "daslang-live|cpp"
     "benchctl|dasexe"
@@ -125,7 +125,22 @@ EXE_PRESENCE_TESTS=(
 PASS=0
 FAIL=0
 LOG="$(mktemp)"
-trap 'rm -f "$LOG"' EXIT
+
+# The build tree's lib/ (CMAKE_LIBRARY_OUTPUT_DIRECTORY, beside ci/) is also on every
+# dasexe's rpath, so on the runner that built the bundle a build-tree rpath resolves
+# and the launch check would pass without the bundle-relative entry. Hide it for the
+# run; Windows has no rpath and locks open DLL dirs, so only POSIX.
+BUILD_LIB="$(cd "$CI_DIR/.." && pwd -P)/lib"
+HIDDEN_LIB=""
+if [[ -z "$CPP_SUFFIX" && -d "$BUILD_LIB" ]]; then
+    HIDDEN_LIB="$BUILD_LIB.smokehidden"
+    mv "$BUILD_LIB" "$HIDDEN_LIB"
+fi
+restore_and_clean() {
+    rm -f "$LOG"
+    if [[ -n "$HIDDEN_LIB" && -d "$HIDDEN_LIB" ]]; then mv "$HIDDEN_LIB" "$BUILD_LIB"; fi
+}
+trap restore_and_clean EXIT
 
 run_check() {
     local label="$1"; shift
@@ -156,8 +171,8 @@ for entry in "${COMPILE_TESTS[@]}"; do
 done
 
 echo
-echo "Prebuilt exe presence (bin/):"
-for entry in "${EXE_PRESENCE_TESTS[@]}"; do
+echo "Prebuilt exes (bin/) - presence, dasexe rows also launched:"
+for entry in "${SHIPPED_EXE_TESTS[@]}"; do
     name="${entry%%|*}"
     kind="${entry#*|}"
     case "$kind" in
@@ -166,21 +181,13 @@ for entry in "${EXE_PRESENCE_TESTS[@]}"; do
         *)      echo "ERROR: unknown kind '$kind' for $name" >&2; FAIL=$((FAIL + 1)); continue ;;
     esac
     exe="$BUNDLE/bin/${name}${suffix}"
-    printf '  %-30s ' "$name"
     if [[ ! -f "$exe" ]]; then
-        echo "MISSING ($exe)"
+        printf '  %-30s MISSING (%s)\n' "$name" "$exe"
         FAIL=$((FAIL + 1))
     elif [[ "$kind" == dasexe ]]; then
-        if "$exe" --help > "$LOG" 2>&1; then
-            echo "OK (launches)"
-            PASS=$((PASS + 1))
-        else
-            echo "FAIL (present, exit $? on --help)"
-            sed 's/^/      /' "$LOG" | head -5
-            FAIL=$((FAIL + 1))
-        fi
+        run_check "$name (launch)" "$exe" --help
     else
-        echo "OK"
+        printf '  %-30s OK\n' "$name"
         PASS=$((PASS + 1))
     fi
 done

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1279,22 +1279,24 @@ extern "C" {
             #endif
         #elif defined(__APPLE__)
             const auto linkerParam = isShared ? "-shared " : "";
-            // @executable_path first → relocated bundle finds dylibs next to the exe;
-            // build-tree path second → dev workflow keeps working without copying dylibs.
+            // @executable_path and @executable_path/../lib → a relocated bundle finds the
+            // dylibs beside the exe or in the sibling lib/ (the installed layout is bin/ + lib/);
+            // build-tree path last → dev workflow keeps working without copying dylibs.
             // The embedded `\" \"` splits the format-string's outer quotes so the linker
-            // sees two distinct -Wl,-rpath flags, not one with an embedded space.
-            const auto rpath = "-Wl,-rpath,@executable_path\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
+            // sees distinct -Wl,-rpath flags, not one with embedded spaces.
+            const auto rpath = "-Wl,-rpath,@executable_path\" \"-Wl,-rpath,@executable_path/../lib\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
             cmd = compilerLibrary.empty()
                 ? fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"), linker.c_str(), linkerParam, rpath.c_str(), libraryName, runtimeLibrary.c_str(), objFilePath, extra)
                 : fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"), linker.c_str(), linkerParam, rpath.c_str(), libraryName, runtimeLibrary.c_str(), compilerLibrary.c_str(), objFilePath, extra);
         #else
             const auto linkerParam = isShared ? "-shared" : "";
-            // $ORIGIN first → relocated bundle finds .so next to the exe;
-            // build-tree path second → dev workflow keeps working without copying.
+            // $ORIGIN and $ORIGIN/../lib → a relocated bundle finds the .so beside the exe
+            // or in the sibling lib/ (the installed layout is bin/ + lib/); build-tree path
+            // last → dev workflow keeps working without copying.
             // \$ escapes the dollar so popen's shell passes $ORIGIN to ld unexpanded.
             // The embedded `\" \"` splits the format-string's outer quotes so the linker
-            // sees two distinct -Wl,-rpath flags, not one with an embedded space.
-            const auto rpath = "-Wl,-rpath,\\$ORIGIN\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
+            // sees distinct -Wl,-rpath flags, not one with embedded spaces.
+            const auto rpath = "-Wl,-rpath,\\$ORIGIN\" \"-Wl,-rpath,\\$ORIGIN/../lib\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
             cmd = compilerLibrary.empty()
                 ? fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"),
                                         linker.c_str(), linkerParam, rpath.c_str(), libraryName, objFilePath, runtimeLibrary.c_str(), extra)

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1279,23 +1279,18 @@ extern "C" {
             #endif
         #elif defined(__APPLE__)
             const auto linkerParam = isShared ? "-shared " : "";
-            // @executable_path and @executable_path/../lib → a relocated bundle finds the
-            // dylibs beside the exe or in the sibling lib/ (the installed layout is bin/ + lib/);
-            // build-tree path last → dev workflow keeps working without copying dylibs.
-            // The embedded `\" \"` splits the format-string's outer quotes so the linker
-            // sees distinct -Wl,-rpath flags, not one with embedded spaces.
+            // installed layout is bin/ + lib/, hence the two @executable_path rpaths; the
+            // build-tree path is last so the dev workflow works without copying dylibs.
+            // The embedded `\" \"` splits the format-string's quotes into separate -Wl,-rpath args.
             const auto rpath = "-Wl,-rpath,@executable_path\" \"-Wl,-rpath,@executable_path/../lib\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
             cmd = compilerLibrary.empty()
                 ? fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"), linker.c_str(), linkerParam, rpath.c_str(), libraryName, runtimeLibrary.c_str(), objFilePath, extra)
                 : fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" \"{}\" {} 2>&1"), linker.c_str(), linkerParam, rpath.c_str(), libraryName, runtimeLibrary.c_str(), compilerLibrary.c_str(), objFilePath, extra);
         #else
             const auto linkerParam = isShared ? "-shared" : "";
-            // $ORIGIN and $ORIGIN/../lib → a relocated bundle finds the .so beside the exe
-            // or in the sibling lib/ (the installed layout is bin/ + lib/); build-tree path
-            // last → dev workflow keeps working without copying.
-            // \$ escapes the dollar so popen's shell passes $ORIGIN to ld unexpanded.
-            // The embedded `\" \"` splits the format-string's outer quotes so the linker
-            // sees distinct -Wl,-rpath flags, not one with embedded spaces.
+            // installed layout is bin/ + lib/, hence the two $ORIGIN rpaths; the build-tree
+            // path is last so the dev workflow works without copying. \$ keeps popen's shell
+            // from expanding $ORIGIN; the embedded `\" \"` yields separate -Wl,-rpath args.
             const auto rpath = "-Wl,-rpath,\\$ORIGIN\" \"-Wl,-rpath,\\$ORIGIN/../lib\" \"-Wl,-rpath," + get_prefix(runtimeLibrary);
             cmd = compilerLibrary.empty()
                 ? fmt::format(FMT_STRING("\"{}\" {} \"{}\" -o \"{}\" \"{}\" \"{}\" {} 2>&1"),


### PR DESCRIPTION
**Ship defect in every Linux/macOS 0.6.4-RC1 channel: the seven prebuilt `daslang -exe` tools (`dastest`, `lint`, `daspkg`, `das-fmt`, `dascov`, `detect-dupe`, `benchctl`) cannot start from the bundle — `error while loading shared libraries: liblibDaScriptDyn_runtime.so`.** Windows is unaffected (DLLs resolve via the exe's directory).

`daslang -exe` stamps its output with rpath `$ORIGIN` + the *build-tree* `lib/` (`/home/runner/work/daScript/daScript/lib` on CI). The bundle installs the runtime `.so`/`.dylib` into the sibling `lib/`, so neither entry resolves on a user's box; only `bin/daslang` itself (cmake-linked, `$ORIGIN/../lib`) worked. The RC1 smoke test presence-checked the tools and never launched one, so the lane stayed green.

Three changes: `module_jit.cpp` adds `$ORIGIN/../lib` (`@executable_path/../lib` on macOS) to the rpath list on both POSIX branches — beside-the-exe first, sibling `lib/` second, build tree last, so dev workflows keep working; and `ci/smoke_test_bundle.sh` now launches every `dasexe` row (`--help`, exit 0) instead of presence-checking it — the stale "daslang intercepts `--help`" comment was wrong for `-exe` binaries, all seven print their own usage and exit 0; and the script moves the build tree's `lib/` aside for the run (POSIX, restored on exit) — the tdd audit showed that on the very runner that built the bundle the build-tree rpath entry still resolves, so without the hide the launch check passed pre-fix too and proved nothing.

Where to look: `src/builtin/module_jit.cpp` (the two `rpath` lines), `ci/smoke_test_bundle.sh` (the exe loop).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The new check against the RC1 Linux bundle in WSL: 7/7 dasexe rows FAIL (exit 127, the loader error) — the check catches the shipped defect. Against the RC1 Windows bundle: 31/31.
- The masking case, WSL: a fake build tree whose `lib/` holds the runtime `.so`, tools rpath'd the pre-fix way (`$ORIGIN:<buildtree>/lib`) → the check is red (7 failures) with the tree present; fixed shape (`$ORIGIN:$ORIGIN/../lib:<buildtree>/lib`) → 31/31; the repo's `lib/` restored after each run.
- Audits: style-hygiene (applied), tdd/Opus (the masking finding above, applied), review-md on `.github/workflows/REVIEW.md` (compliant; 3 self-review findings on the checklist itself, ledgered).
- Fix value proven on a copy of the RC1 Linux bundle: `patchelf --set-rpath '$ORIGIN:$ORIGIN/../lib:<build>'` on the seven tools → 31/31, all launch. `.deb` layout (`/opt/daslang/bin` + `/opt/daslang/lib`, `/usr/bin` symlinks) resolves the same way — `$ORIGIN` follows the symlink target.
- macOS Mach-O read: `dastest.exe` carries `LC_RPATH @executable_path` + `/Users/runner/work/daScript/daScript/lib` — same shape, same fix.

### Claims — stated, not tested locally
- The emitter change compiles only on the POSIX branches (`#else` / `__APPLE__`), so it is proven by CI, not on this Windows box: `release.yml` dispatched on this branch — https://github.com/GaijinEntertainment/daScript/actions/runs/32203198363 — builds all four bundles and runs the launch check on each; the Linux/macOS smoke steps are red without the emitter change and green with it.

### Not done
- CHANGELIST.md line — post-RC1 fixes are batched into the RC2 changelist pass, same as #3773/#3775/#3776/#3778.
- The pip wheel (the reason this was found) is the next PR, stacked on this one.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
