### PR TITLE
-exe tools: native paths re-root at run time; dastest.exe runs the interpreter

### DIFF
--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -197,6 +197,19 @@ echo "Runtime launch:"
 run_check "mcp.das (empty stdin)" bash -c \
     "'$DASLANG' utils/mcp/main.das < /dev/null"
 
+# The prebuilt tools resolve their module native paths at run time; a tool that carries
+# the build machine's paths instead launches (--help above) and then cannot compile a
+# single script. dastest pulls just_in_time -> llvm/daslib on every test, so one shipped
+# suite through bin/dastest.exe is the probe; lint over daslib must not skip a file for
+# the same reason (its SKIP line blames missing daspkg deps, which is not the cause).
+run_check "dastest.exe runs a shipped suite" bash -c \
+    "'$BUNDLE/bin/dastest${DASEXE_SUFFIX}' --test utils/common/tests | tee '$LOG.suite' \
+     && grep -Eq '^[1-9][0-9]* tests, [1-9][0-9]* passed, 0 failed, 0 errors' '$LOG.suite'"
+run_check "lint.exe lints daslib, no skips" bash -c \
+    "'$BUNDLE/bin/lint${DASEXE_SUFFIX}' daslib | tee '$LOG.lint' \
+     && grep -Eq '^[0-9]+ files, 0 issue\(s\), 0 error\(s\)\$' '$LOG.lint'"
+rm -f "$LOG.suite" "$LOG.lint"
+
 # Shipped skills must not send the reader to a path the bundle does not contain.
 # This is the same class of bug as the utils/mcp/setup.das miss: the docs promised
 # something the install rules never delivered. Here the right answer is the reverse

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -137,7 +137,7 @@ if [[ -z "$CPP_SUFFIX" && -d "$BUILD_LIB" ]]; then
     mv "$BUILD_LIB" "$HIDDEN_LIB"
 fi
 restore_and_clean() {
-    rm -f "$LOG"
+    rm -f "$LOG" "$LOG.suite" "$LOG.lint"
     if [[ -n "$HIDDEN_LIB" && -d "$HIDDEN_LIB" ]]; then mv "$HIDDEN_LIB" "$BUILD_LIB"; fi
 }
 trap restore_and_clean EXIT
@@ -197,18 +197,16 @@ echo "Runtime launch:"
 run_check "mcp.das (empty stdin)" bash -c \
     "'$DASLANG' utils/mcp/main.das < /dev/null"
 
-# The prebuilt tools resolve their module native paths at run time; a tool that carries
-# the build machine's paths instead launches (--help above) and then cannot compile a
-# single script. dastest pulls just_in_time -> llvm/daslib on every test, so one shipped
-# suite through bin/dastest.exe is the probe; lint over daslib must not skip a file for
-# the same reason (its SKIP line blames missing daspkg deps, which is not the cause).
+# Two prebuilt tools past --help. dastest.exe must compile and run a shipped suite
+# (isolated mode also spawns its own workers); lint.exe over daslib must resolve every
+# module native path - its summary line grows ", N skipped" when it cannot, so the
+# anchored grep is what rejects a skip.
 run_check "dastest.exe runs a shipped suite" bash -c \
-    "'$BUNDLE/bin/dastest${DASEXE_SUFFIX}' --test utils/common/tests | tee '$LOG.suite' \
+    "set -o pipefail; '$BUNDLE/bin/dastest${DASEXE_SUFFIX}' --test utils/common/tests --isolated-mode | tee '$LOG.suite' \
      && grep -Eq '^[1-9][0-9]* tests, [1-9][0-9]* passed, 0 failed, 0 errors' '$LOG.suite'"
 run_check "lint.exe lints daslib, no skips" bash -c \
-    "'$BUNDLE/bin/lint${DASEXE_SUFFIX}' daslib | tee '$LOG.lint' \
+    "set -o pipefail; '$BUNDLE/bin/lint${DASEXE_SUFFIX}' daslib | tee '$LOG.lint' \
      && grep -Eq '^[0-9]+ files, 0 issue\(s\), 0 error\(s\)\$' '$LOG.lint'"
-rm -f "$LOG.suite" "$LOG.lint"
 
 # Shipped skills must not send the reader to a path the bundle does not contain.
 # This is the same class of bug as the utils/mcp/setup.das miss: the docs promised

--- a/dastest/dastest.das
+++ b/dastest/dastest.das
@@ -379,7 +379,7 @@ def serialize_path(ctx : SuiteCtx, files : array<string>, out_file : string) {
                     cop.aot = ctx.use_aot
                     cop.fail_on_no_aot = ctx.use_aot
                     cop.threadlock_context = true
-                    cop.jit_enabled = jit_enabled()
+                    cop.jit_enabled = tests_jit_enabled()
                     compile_file(file, access, unsafe(addr(mg)), cop) $(ok, program, output) {
                         if (!ok) {
                             log::error("Failed to compile {file}\n{output}")
@@ -610,7 +610,7 @@ def main() : int {  // nolint:STYLE037,STYLE038 - CLI dispatch, one arm per mode
         let totalFiles = length(files)
         var totalThreads = test_args.isolated_mode_threads
         if (totalThreads == 0) {
-            totalThreads = (jit_enabled()
+            totalThreads = (tests_jit_enabled()
                 ? default_jit_isolated_threads(get_total_hw_threads())
                 : max(1, get_total_hw_threads() * 2))
         }
@@ -641,7 +641,7 @@ def main() : int {  // nolint:STYLE037,STYLE038 - CLI dispatch, one arm per mode
                 if (needs_quote) w |> write("\"")
             }
         }
-        let jitstr = jit_enabled() ? "-jit" : ""
+        let jitstr = tests_jit_enabled() ? "-jit" : ""
         let aotstr = is_in_aot() ? "-use-aot" : ""
         let benchstr = ctx.bench_enabled ? "--bench" : ""
         // Forward --stack-on-exception to each worker: the flag sets the test

--- a/dastest/suite.das
+++ b/dastest/suite.das
@@ -18,6 +18,13 @@ require log
 require testing
 require suite_result public
 
+//! JIT the tests only when the HOST was launched with -jit. Inside a standalone exe
+//! jit_enabled() is always true (the exe is a JIT product), but the exe carries none of
+//! the llvm/dasbind machinery a JIT compile needs - dastest.exe runs the interpreter.
+def public tests_jit_enabled() : bool {
+    return jit_enabled() && !is_standalone_exe()
+}
+
 var test_results : array<SuiteTestResult>
 var bench_messages : array<string>
 
@@ -177,7 +184,7 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
                 cop.stack = 1024u * 1024u
             }
             cop.threadlock_context = true
-            cop.jit_enabled = jit_enabled()
+            cop.jit_enabled = tests_jit_enabled()
             cop.debugger = ctx.debugger
             cop.keep_alive = ctx.keep_alive
             cop.disable_cse = ctx.disable_cse
@@ -185,7 +192,7 @@ def test_file(file_name : string; var ctx : SuiteCtx; var file_ctx : FileCtx) : 
             cop.disable_temp_string_reclaim = ctx.disable_temp_string_reclaim
             cop.disable_inline = ctx.disable_inline
             cop.disable_auto_inline = ctx.disable_auto_inline
-            if (jit_enabled()) {
+            if (tests_jit_enabled()) {
                 access |> add_extra_module("just_in_time", "{get_das_root()}/daslib/just_in_time.das")
             }
             if (!ctx.cov_path |> empty()) {

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -593,7 +593,7 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
             LLVMBuildCall2(ib, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
-    // native paths re-root at run time like dynamic modules (exe_dir, das_root, baked absolute)
+    // native paths re-root at run time like dynamic modules; counterpart emission site: inject_main
     let reg_native_path_type = LLVMFunctionType(t.t_void,
         fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
     )
@@ -1047,9 +1047,8 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef; // noli
     // for `daspkg release` to ship dylibs + traverse dep packages.
     write_release_deps(prog)
 
-    // Register native paths (das include paths) that were loaded during compilation. The
-    // destination re-roots at run time like dynamic modules: <exe_dir>/<rel>, <das_root>/<rel>,
-    // then the baked absolute - a bundle built on another machine finds its own modules/.
+    // Register native paths (das include paths) loaded during compilation; jit_register_native_path_resolve
+    // (module_jit.cpp) re-roots the destination at run time. Counterpart emission site: collect_external_functions.
     let reg_native_path_type = LLVMFunctionType(types.t_void,
         fixed_array<LLVMTypeRef>(
             types.LLVMVoidPtrType(), // const char * mod_name

--- a/modules/dasLLVM/daslib/llvm_exe.das
+++ b/modules/dasLLVM/daslib/llvm_exe.das
@@ -593,18 +593,20 @@ def collect_external_functions(standalone_context : LLVMOpaqueValue?; ctx : LLVM
             LLVMBuildCall2(ib, reg_dyn_mod_type, jit_reg_dyn_mod, fixed_array(rel_str, abs_str, name_str), "")
         }
     }
+    // native paths re-root at run time like dynamic modules (exe_dir, das_root, baked absolute)
     let reg_native_path_type = LLVMFunctionType(t.t_void,
-        fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
+        fixed_array<LLVMTypeRef>(t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType(), t.LLVMVoidPtrType())
     )
-    var jit_reg_native_path = LLVMGetNamedFunction(g_mod, "jit_register_native_path")
+    var jit_reg_native_path = LLVMGetNamedFunction(g_mod, "jit_register_native_path_resolve")
     if (jit_reg_native_path == null) {
-        jit_reg_native_path = LLVMAddFunctionWithType(g_mod, "jit_register_native_path", reg_native_path_type)
+        jit_reg_native_path = LLVMAddFunctionWithType(g_mod, "jit_register_native_path_resolve", reg_native_path_type)
     }
     for_each_registered_native_path() $(mod_name, src_path, dst_path) {
         let mod_str = get_string_constant_ptr(ib, mod_name)
         let src_str = get_string_constant_ptr(ib, src_path)
+        let rel_str = get_string_constant_ptr(ib, compute_modules_relative_suffix(dst_path))
         let dst_str = get_string_constant_ptr(ib, dst_path)
-        LLVMBuildCall2(ib, reg_native_path_type, jit_reg_native_path, fixed_array(mod_str, src_str, dst_str), "")
+        LLVMBuildCall2(ib, reg_native_path_type, jit_reg_native_path, fixed_array(mod_str, src_str, rel_str, dst_str), "")
     }
     if (!empty(extern_resolver.registered_modules) || !empty(used_modules)) {
         let init_done_type = LLVMFunctionType(t.t_void, array<LLVMTypeRef>())
@@ -1045,20 +1047,24 @@ def public inject_main(program_context : Context?; ctx : LLVMContextRef; // noli
     // for `daspkg release` to ship dylibs + traverse dep packages.
     write_release_deps(prog)
 
-    // Register native paths (das include paths) that were loaded during compilation
+    // Register native paths (das include paths) that were loaded during compilation. The
+    // destination re-roots at run time like dynamic modules: <exe_dir>/<rel>, <das_root>/<rel>,
+    // then the baked absolute - a bundle built on another machine finds its own modules/.
     let reg_native_path_type = LLVMFunctionType(types.t_void,
         fixed_array<LLVMTypeRef>(
             types.LLVMVoidPtrType(), // const char * mod_name
             types.LLVMVoidPtrType(), // const char * src_path
-            types.LLVMVoidPtrType()  // const char * dst_path
+            types.LLVMVoidPtrType(), // const char * rel_dst ("" = no /modules/ segment)
+            types.LLVMVoidPtrType()  // const char * fallback_abs_dst
         )
     )
-    var jit_reg_native_path = LLVMAddFunctionWithType(g_mod, "jit_register_native_path", reg_native_path_type)
+    var jit_reg_native_path = LLVMAddFunctionWithType(g_mod, "jit_register_native_path_resolve", reg_native_path_type)
     for_each_registered_native_path() $(mod_name, src_path, dst_path) {
         let mod_str = get_string_constant_ptr(builder, mod_name)
         let src_str = get_string_constant_ptr(builder, src_path)
+        let rel_str = get_string_constant_ptr(builder, compute_modules_relative_suffix(dst_path))
         let dst_str = get_string_constant_ptr(builder, dst_path)
-        LLVMBuildCall2(builder, reg_native_path_type, jit_reg_native_path, fixed_array(mod_str, src_str, dst_str), "")
+        LLVMBuildCall2(builder, reg_native_path_type, jit_reg_native_path, fixed_array(mod_str, src_str, rel_str, dst_str), "")
     }
 
     // Call initialize_modules() — built by CollectExternVisitor during collect_external_functions

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -36,7 +36,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x50ul   // -exe native paths re-root at run time via jit_register_native_path_resolve (0x4f: literal lowering: fixed-array element slots sized by recordType.sizeOf; invoke-to-cmres now skipped like call-to-cmres at let-init, copy/move and every make-* element visit (0x4e: scalar ABI coercion at calls, returns and branches))
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x50ul   // -exe native paths re-root at run time via jit_register_native_path_resolve
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -36,7 +36,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x4ful   // literal lowering: fixed-array element slots sized by recordType.sizeOf; invoke-to-cmres now skipped like call-to-cmres at let-init, copy/move and every make-* element visit (0x4e: scalar ABI coercion at calls, returns and branches)
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x50ul   // -exe native paths re-root at run time via jit_register_native_path_resolve (0x4f: literal lowering: fixed-array element slots sized by recordType.sizeOf; invoke-to-cmres now skipped like call-to-cmres at let-init, copy/move and every make-* element visit (0x4e: scalar ABI coercion at calls, returns and branches))
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1974,6 +1974,12 @@ DAS_API void jit_finalize_dynamic_modules () {
     }
 }
 
+// ABI shim: -exe binaries emitted before the resolving form link this runtime dynamically
+// and still import the 3-argument name.
+DAS_API void jit_register_native_path ( const char * mod_name, const char * src_path, const char * dst_path ) {
+    das::register_native_path(mod_name, src_path, dst_path, nullptr, nullptr);
+}
+
 // Emitted by inject_main (llvm_exe.das) for every native path the program compiled
 // against: the destination is re-rooted onto <exe_dir> / <das_root> at run time, so a
 // bundle built elsewhere finds its own modules/ instead of the build machine's.

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1742,13 +1742,6 @@ static das::string pick_at_dir ( const std::filesystem::path & dir, const char *
     return "";
 }
 
-// Pure resolution: pick the path to load, in priority order:
-//   1. <exe_dir>/<rel_path>   — daspkg release bundle layout (modules sit next to the exe)
-//   2. <das_root>/<rel_path>  — SDK install layout AND local dev build
-//   3. <fallback_abs_path>    — baked-at-codegen absolute path (legacy / paths without /modules/ segment)
-//
-// Tiers 1+2 are skipped when rel_path is empty/null. Returns the chosen path;
-// tier 3 is unconditional, so the result is never empty when fallback is set.
 static das::string jit_exe_file () {
     if ( g_jit_exe_file_for_test ) {
         const char * s = g_jit_exe_file_for_test();
@@ -1757,6 +1750,13 @@ static das::string jit_exe_file () {
     return das::getExecutableFileName();
 }
 
+// Pure resolution: pick the path to load, in priority order:
+//   1. <exe_dir>/<rel_path>   — daspkg release bundle layout (modules sit next to the exe)
+//   2. <das_root>/<rel_path>  — SDK install layout AND local dev build
+//   3. <fallback_abs_path>    — baked-at-codegen absolute path (legacy / paths without /modules/ segment)
+//
+// Tiers 1+2 are skipped when rel_path is empty/null. Returns the chosen path;
+// tier 3 is unconditional, so the result is never empty when fallback is set.
 static das::string resolve_dynamic_module_path ( const char * rel_path, const char * fallback_abs_path ) {
     namespace fs = std::filesystem;
     // tier 1 — exe_dir (parent_path correctly preserves filesystem root: "/myapp" → "/", "C:\myapp.exe" → "C:\")
@@ -1776,17 +1776,17 @@ static das::string resolve_dynamic_module_path ( const char * rel_path, const ch
     return fallback_abs_path ? fallback_abs_path : "";
 }
 
-// Same three tiers for a native-path template's destination. It is a PATTERN
-// ("modules/dasLLVM/daslib/{path}.das"), so the probe is its directory prefix — up to
-// the last separator before the first '{' — and the winner is that base with the whole
-// pattern re-rooted onto it. Empty rel_pattern (no /modules/ segment at codegen) → tier 3.
+// Same three tiers for a native-path template's destination. It may be a PATTERN
+// ("modules/dasLLVM/daslib/{path}.das"), so the probe is its directory prefix and the
+// winner is that base with the whole pattern re-rooted onto it. Empty rel_pattern (no
+// /modules/ segment at codegen) → tier 3.
 static das::string resolve_native_path_dst ( const char * rel_pattern, const char * fallback_abs ) {
     namespace fs = std::filesystem;
     if ( rel_pattern && *rel_pattern ) {
         std::string rel = rel_pattern;
-        size_t brace = rel.find('{');
-        size_t cut = rel.rfind('/', brace == std::string::npos ? std::string::npos : brace);
-        std::string dirRel = cut == std::string::npos ? "" : rel.substr(0, cut);
+        size_t firstBrace = rel.find('{');       // npos → rfind searches the whole string
+        size_t dirEnd = rel.rfind('/', firstBrace);
+        std::string dirRel = dirEnd == std::string::npos ? "" : rel.substr(0, dirEnd);
         das::vector<fs::path> bases;
         das::string exeFile = jit_exe_file();
         if ( !exeFile.empty() ) {
@@ -1972,10 +1972,6 @@ DAS_API void jit_finalize_dynamic_modules () {
     if ( int failed = das::report_pending_dynamic_modules() ) {
         DAS_FATAL_ERROR("%d dynamic module(s) failed to load (see above).\n", failed);
     }
-}
-
-DAS_API void jit_register_native_path ( const char * mod_name, const char * src_path, const char * dst_path ) {
-    das::register_native_path(mod_name, src_path, dst_path, nullptr, nullptr);
 }
 
 // Emitted by inject_main (llvm_exe.das) for every native path the program compiled

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1811,8 +1811,11 @@ static das::string resolve_native_path_dst ( const char * rel_pattern, const cha
 static das::string resolve_dynamic_module_path ( const char *, const char * ) {
     std::abort();
 }
-static das::string resolve_native_path_dst ( const char *, const char * ) {
-    std::abort();
+// Unlike a dynamic module, a native-path entry is an inert string-table registration
+// (register_native_path is a stubbed no-op under DAS_NO_FILEIO), so a standalone exe
+// that registered one must keep starting - hand back the baked path, never abort.
+static das::string resolve_native_path_dst ( const char *, const char * fallback_abs ) {
+    return fallback_abs ? fallback_abs : "";
 }
 #endif
 

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1749,16 +1749,18 @@ static das::string pick_at_dir ( const std::filesystem::path & dir, const char *
 //
 // Tiers 1+2 are skipped when rel_path is empty/null. Returns the chosen path;
 // tier 3 is unconditional, so the result is never empty when fallback is set.
+static das::string jit_exe_file () {
+    if ( g_jit_exe_file_for_test ) {
+        const char * s = g_jit_exe_file_for_test();
+        return s ? das::string(s) : das::string();
+    }
+    return das::getExecutableFileName();
+}
+
 static das::string resolve_dynamic_module_path ( const char * rel_path, const char * fallback_abs_path ) {
     namespace fs = std::filesystem;
     // tier 1 — exe_dir (parent_path correctly preserves filesystem root: "/myapp" → "/", "C:\myapp.exe" → "C:\")
-    das::string exeFile;
-    if ( g_jit_exe_file_for_test ) {
-        const char * s = g_jit_exe_file_for_test();
-        if ( s ) exeFile = s;
-    } else {
-        exeFile = das::getExecutableFileName();
-    }
+    das::string exeFile = jit_exe_file();
     if ( !exeFile.empty() ) {
         fs::path exeDir = fs::path(exeFile.c_str()).parent_path();
         if ( exeDir.empty() ) exeDir = ".";  // exe is a bare filename relative to cwd
@@ -1773,11 +1775,43 @@ static das::string resolve_dynamic_module_path ( const char * rel_path, const ch
     // tier 3 — baked absolute (legacy fallback)
     return fallback_abs_path ? fallback_abs_path : "";
 }
+
+// Same three tiers for a native-path template's destination. It is a PATTERN
+// ("modules/dasLLVM/daslib/{path}.das"), so the probe is its directory prefix — up to
+// the last separator before the first '{' — and the winner is that base with the whole
+// pattern re-rooted onto it. Empty rel_pattern (no /modules/ segment at codegen) → tier 3.
+static das::string resolve_native_path_dst ( const char * rel_pattern, const char * fallback_abs ) {
+    namespace fs = std::filesystem;
+    if ( rel_pattern && *rel_pattern ) {
+        std::string rel = rel_pattern;
+        size_t brace = rel.find('{');
+        size_t cut = rel.rfind('/', brace == std::string::npos ? std::string::npos : brace);
+        std::string dirRel = cut == std::string::npos ? "" : rel.substr(0, cut);
+        das::vector<fs::path> bases;
+        das::string exeFile = jit_exe_file();
+        if ( !exeFile.empty() ) {
+            fs::path exeDir = fs::path(exeFile.c_str()).parent_path();
+            bases.push_back(exeDir.empty() ? fs::path(".") : exeDir);
+        }
+        das::string dasRoot = das::getDasRoot();
+        if ( !dasRoot.empty() ) bases.push_back(fs::path(dasRoot.c_str()));
+        for ( auto & base : bases ) {
+            fs::path dir = dirRel.empty() ? base : base / dirRel;
+            if ( jit_path_exists(dir.string().c_str()) ) {
+                return das::string((base / rel).string().c_str());
+            }
+        }
+    }
+    return fallback_abs ? fallback_abs : "";
+}
 #else
 // No file IO (DAS_NO_FILEIO): there is no filesystem to resolve a dynamic
 // module against, and a build with no fio can't dlopen one anyway. Calling
 // this is a logic error on such a platform, so abort loudly.
 static das::string resolve_dynamic_module_path ( const char *, const char * ) {
+    std::abort();
+}
+static das::string resolve_native_path_dst ( const char *, const char * ) {
     std::abort();
 }
 #endif
@@ -1909,6 +1943,16 @@ DAS_API bool jit_resolve_dynamic_module_path_for_test_ ( const char * rel_path,
     return true;
 }
 
+DAS_API bool jit_resolve_native_path_dst_for_test_ ( const char * rel_pattern,
+                                                    const char * fallback_abs,
+                                                    char * out_buf,
+                                                    size_t buf_size ) {
+    das::string r = resolve_native_path_dst(rel_pattern, fallback_abs);
+    if ( r.size() + 1 > buf_size ) return false;
+    memcpy(out_buf, r.c_str(), r.size() + 1);
+    return true;
+}
+
 // Resolve and load a dynamic module. Used by standalone exes (emitted by
 // inject_main in llvm_exe.das).
 DAS_API void * jit_register_dynamic_module_resolve ( const char * rel_path,
@@ -1932,5 +1976,14 @@ DAS_API void jit_finalize_dynamic_modules () {
 
 DAS_API void jit_register_native_path ( const char * mod_name, const char * src_path, const char * dst_path ) {
     das::register_native_path(mod_name, src_path, dst_path, nullptr, nullptr);
+}
+
+// Emitted by inject_main (llvm_exe.das) for every native path the program compiled
+// against: the destination is re-rooted onto <exe_dir> / <das_root> at run time, so a
+// bundle built elsewhere finds its own modules/ instead of the build machine's.
+DAS_API void jit_register_native_path_resolve ( const char * mod_name, const char * src_path,
+                                                const char * rel_dst, const char * fallback_abs_dst ) {
+    das::string chosen = resolve_native_path_dst(rel_dst, fallback_abs_dst);
+    das::register_native_path(mod_name, src_path, chosen.c_str(), nullptr, nullptr);
 }
 }

--- a/tests-cpp/small/test_jit_module_resolve.cpp
+++ b/tests-cpp/small/test_jit_module_resolve.cpp
@@ -220,16 +220,37 @@ TEST_CASE("jit native path resolve — baked absolute when nothing resolves") {
 TEST_CASE("jit native path resolve — empty rel pattern goes straight to the absolute") {
     TestSeams seams;
     g_exe_file = "/bundle/bin/dastest.exe";
-    g_existing.insert("/bundle/bin/modules");
+    // both bases exist as directories: without the guard the resolver would hand back the exe dir
+    g_existing.insert("/bundle/bin");
+    g_existing.insert(das::getDasRoot());
     auto chosen = resolve_native("", "/baked/abs/{path}.das");
     CHECK(chosen == "/baked/abs/{path}.das");
+}
+
+TEST_CASE("jit native path resolve — exe-relative wins over das_root when both exist") {
+    TestSeams seams;
+    g_exe_file = "/bundle/bin/dastest.exe";
+    g_existing.insert("/bundle/bin/modules/dasLLVM/daslib");
+    g_existing.insert(das::getDasRoot() + "/modules/dasLLVM/daslib");
+    auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
+                                 "/build/abs/modules/dasLLVM/daslib/{path}.das");
+    CHECK(chosen == "/bundle/bin/modules/dasLLVM/daslib/{path}.das");
+}
+
+TEST_CASE("jit native path resolve — empty exe_file still tries das_root") {
+    TestSeams seams;
+    g_exe_file = "";
+    auto dasRoot = das::getDasRoot();
+    g_existing.insert(dasRoot + "/modules/dasLLVM/daslib");
+    auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
+                                 "/build/abs/modules/dasLLVM/daslib/{path}.das");
+    CHECK(chosen == dasRoot + "/modules/dasLLVM/daslib/{path}.das");
 }
 
 TEST_CASE("jit native path resolve — the probe is the directory, not the file pattern") {
     TestSeams seams;
     g_exe_file = "/bundle/bin/dastest.exe";
-    // only the exact (unexpanded) pattern path is marked existing - a naive file probe would
-    // accept it; the directory prefix is absent, so the resolver must fall through
+    // the unexpanded pattern exists, its directory does not - a naive file probe would take it
     g_existing.insert("/bundle/bin/modules/dasLLVM/daslib/{path}.das");
     auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
                                  "/build/abs/modules/dasLLVM/daslib/{path}.das");

--- a/tests-cpp/small/test_jit_module_resolve.cpp
+++ b/tests-cpp/small/test_jit_module_resolve.cpp
@@ -16,6 +16,11 @@ extern "C" {
         const char * fallback_abs_path,
         char * out_buf,
         size_t buf_size );
+    DAS_API bool jit_resolve_native_path_dst_for_test_(
+        const char * rel_pattern,
+        const char * fallback_abs,
+        char * out_buf,
+        size_t buf_size );
 }
 
 namespace {
@@ -56,6 +61,12 @@ static std::string resolve(const char * rel, const char * abs) {
     char buf[4096] = {0};
     REQUIRE(jit_resolve_dynamic_module_path_for_test_(rel, abs, buf, sizeof(buf)));
     // Normalize to forward-slash form so CHECK comparisons are host-agnostic.
+    return std::filesystem::path(buf).generic_string();
+}
+
+static std::string resolve_native(const char * rel_pattern, const char * abs) {
+    char buf[4096] = {0};
+    REQUIRE(jit_resolve_native_path_dst_for_test_(rel_pattern, abs, buf, sizeof(buf)));
     return std::filesystem::path(buf).generic_string();
 }
 
@@ -176,3 +187,51 @@ TEST_CASE("jit module resolve — Windows drive-root exe path is handled") {
     CHECK(chosen == "C:/modules/dasFoo/dasFoo.shared_module");
 }
 #endif
+
+// ---- native-path templates: the destination is a PATTERN, so the probe is its directory ----
+
+TEST_CASE("jit native path resolve — exe-relative module dir wins when present") {
+    TestSeams seams;
+    g_exe_file = "/bundle/bin/dastest.exe";
+    g_existing.insert("/bundle/bin/modules/dasLLVM/daslib");
+    auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
+                                 "/build/abs/modules/dasLLVM/daslib/{path}.das");
+    CHECK(chosen == "/bundle/bin/modules/dasLLVM/daslib/{path}.das");
+}
+
+TEST_CASE("jit native path resolve — das_root when the exe dir has no modules/") {
+    TestSeams seams;
+    g_exe_file = "/bundle/bin/dastest.exe";
+    auto dasRoot = das::getDasRoot();
+    g_existing.insert(dasRoot + "/modules/dasLLVM/daslib");
+    auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
+                                 "/build/abs/modules/dasLLVM/daslib/{path}.das");
+    CHECK(chosen == dasRoot + "/modules/dasLLVM/daslib/{path}.das");
+}
+
+TEST_CASE("jit native path resolve — baked absolute when nothing resolves") {
+    TestSeams seams;
+    g_exe_file = "/somewhere/dastest.exe";
+    auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
+                                 "/build/abs/modules/dasLLVM/daslib/{path}.das");
+    CHECK(chosen == "/build/abs/modules/dasLLVM/daslib/{path}.das");
+}
+
+TEST_CASE("jit native path resolve — empty rel pattern goes straight to the absolute") {
+    TestSeams seams;
+    g_exe_file = "/bundle/bin/dastest.exe";
+    g_existing.insert("/bundle/bin/modules");
+    auto chosen = resolve_native("", "/baked/abs/{path}.das");
+    CHECK(chosen == "/baked/abs/{path}.das");
+}
+
+TEST_CASE("jit native path resolve — the probe is the directory, not the file pattern") {
+    TestSeams seams;
+    g_exe_file = "/bundle/bin/dastest.exe";
+    // only the exact (unexpanded) pattern path is marked existing - a naive file probe would
+    // accept it; the directory prefix is absent, so the resolver must fall through
+    g_existing.insert("/bundle/bin/modules/dasLLVM/daslib/{path}.das");
+    auto chosen = resolve_native("modules/dasLLVM/daslib/{path}.das",
+                                 "/build/abs/modules/dasLLVM/daslib/{path}.das");
+    CHECK(chosen == "/build/abs/modules/dasLLVM/daslib/{path}.das");
+}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -110,13 +110,14 @@ foreach(util_path ${DAS_UTILS})
 endforeach()
 
 SET(TEST_MAIN ${PROJECT_SOURCE_DIR}/dastest/dastest.das)
+file(GLOB DASTEST_SOURCES ${PROJECT_SOURCE_DIR}/dastest/*.das)
 
 add_custom_command(
     OUTPUT  ${UTIL_BIN_DIR}/dastest.exe
     COMMAND daslang -exe -output ${UTIL_BIN_DIR}/dastest ${TEST_MAIN}
             $<$<BOOL:${DAS_JIT_LINKER_STRING}>:-->
             ${DAS_JIT_LINKER_STRING}
-    DEPENDS ${TEST_MAIN} daslang ${DASLIB_SOURCES} ${DASLLVM_DASLIB_SOURCES}
+    DEPENDS ${TEST_MAIN} ${DASTEST_SOURCES} daslang ${DASLIB_SOURCES} ${DASLLVM_DASLIB_SOURCES}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMENT "Building dastest executable (daslang -exe)"
 )


### PR DESCRIPTION
**Second RC1 ship defect in the `-exe` toolchain, this one on all three OSes: `bin/dastest.exe` cannot compile a single test from any bundle, and `bin/lint.exe` silently skips `daslib/just_in_time.das`.** Found by the shipped-utils audit (four Opus agents over the RC1 Windows bundle); the RC1 smoke never launched a tool past `--help`.

Two layers. (1) Every `daslang -exe` binary carries the **build machine's absolute paths** for the module native-path table (`register_native_path` from `.das_module`): `strings bin/dastest.exe | grep D:/a/daScript` → `modules/dasLLVM/daslib/...` (`bin/daslang.exe`: 0 hits). A tool that pulls a module by alias — dastest → `just_in_time` → `llvm/daslib/llvm_macro` — resolves to `D:/a/daScript/daScript/modules/dasLLVM/daslib/llvm_macro.das - FILE NOT FOUND` while the file sits at `<bundle>/modules/dasLLVM/daslib/`. `llvm_exe.das` already relocates *dynamic modules* at run time; the native-path table was emitted as baked absolutes only. Now both emission sites record the `modules/…` suffix beside the baked path and call `jit_register_native_path_resolve`, whose resolver (`resolve_native_path_dst`) probes the entry's directory in the same three tiers — `<exe_dir>/<rel>`, `<das_root>/<rel>`, baked absolute. (2) With the path fixed, `dastest.exe` still died **in-tree**: `jit_enabled()` is always true inside a JIT-built exe, so dastest tried to JIT every test — with an exe that links none of the `llvm`/`dasbind` C++ modules. `tests_jit_enabled() = jit_enabled() && !is_standalone_exe()`: the exe runs the interpreter (the only thing it can do), the `-jit` host still JITs (CI convention untouched).

Bundle smoke gains two launches that go **red on the RC1 bundle** (2 failures / 31 passes) and green on a bundle from this tree: `dastest.exe` runs `utils/common/tests` (`[1-9]+ tests, … 0 failed, 0 errors`), `lint.exe daslib` ends `0 issue(s), 0 error(s)` with no `skipped` suffix. `LLVM_JIT_CODEGEN_VERSION` → 0x50.

Where to look: `src/builtin/module_jit.cpp` (`resolve_native_path_dst`, `jit_register_native_path_resolve`, test seam), `modules/dasLLVM/daslib/llvm_exe.das` (both `reg_native_path` sites), `dastest/suite.das` (`tests_jit_enabled`), `ci/smoke_test_bundle.sh`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Unit: `tests-cpp-small -tc="*jit*resolve*"` → 14/14 (9 existing dyn-module cases + 5 native-path cases: exe-relative wins, das_root fallback, baked fallback, empty rel, "the probe is the directory not the pattern").
- Relocation proof, Windows: `cmake --install` bundle from this tree + the rebuilt `dastest.exe`/`lint.exe`, with the repo's `modules/dasLLVM` **renamed away** so the baked absolute could not rescue it → `dastest.exe --test utils/common/tests` = **17 tests, 17 passed**; `lint.exe daslib` = `148 files, 0 issue(s), 0 error(s)` (RC1's exe: `1 skipped`). Restored after.
- Mode matrix in-tree: `dastest.exe` → 17/17 interpreter; `daslang dastest.das` → 17/17; `daslang -jit dastest.das` → still `[I] LLVM JIT: 82 functions`, 17/17.
- Negative control: the two new smoke checks on the RC1 Windows bundle → both FAIL with the exact `FILE NOT FOUND` / `1 skipped` evidence; `bash -n` clean.
- Emitted binary carries `jit_register_native_path_resolve` and the `modules/...` entries; the baked absolutes remain as tier 3.

### Claims — stated, not tested locally
- Linux/macOS: proven by the per-PR `bundle_smoke` lane (Linux, with the #3779 lib-hide) and the release dispatch — the same emitter code, no platform arms.
- The five other `-exe` tools (daspkg, dascov, detect-dupe, benchctl, das-fmt) worked from RC1 only because their programs never pull an aliased module; they now carry re-rootable tables too.

### Not done (ledgered from the same audit, separate PRs)
- `dastest`: `--help`/no-args/unknown flags print `0 tests … SUCCESS!` rc 0; a `--test` dir with zero tests is "SUCCESS" (`utils/mcp/tests` is fixtures-only — the suite is `utils/mcp/test_tools.das`, 23/424 failing from a bundle on repo-only paths, 279 s, rewrites a shipped fixture in place).
- `exit()` in a `-exe` tool skips Shutdown → `[daslang atexit] FATAL: g_envTotal=1` on every non-zero exit (das-fmt, MCP shutdown).
- CHANGELIST line: RC2 batch.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
