### PR TITLE
test-release: the release-audit runner with a utils phase - every shipped tool exercised from the bundle

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -166,6 +166,7 @@ SET(DAS_UTILS_TO_TEST
     internal/hygiene
     internal/ast-fuzz
     internal/requirefix
+    internal/test-release
 )
 
 FOREACH(_das ${DAS_UTILS_TO_TEST})

--- a/utils/internal/test-release/README.md
+++ b/utils/internal/test-release/README.md
@@ -1,0 +1,39 @@
+# test-release — the release-audit batch runner
+
+Points at an EXTRACTED release bundle and proves it sane using the bundle's own binary —
+no repo files, no build tree. This is the tool tier of the release audit (tools → agents →
+people, fail-fix at every layer); agent and human testing start only on a bundle this tool
+passes.
+
+## The per-RC process
+
+1. Download the platform bundle from the release tag; extract to a CLEAN directory
+   (never over a previous install — a mixed tree tests nothing):
+   `tar -xf daslang-bundle-<os>-<arch>.zip -C <dir> --strip-components=1`
+2. From the repo root: `bin/daslang utils/internal/test-release/main.das -- --bundle <dir>`
+3. Triage the report: `UNEXPECTED` and `TIMEOUT` lines are the audit's yield — each is a
+   bundle defect, a missing payload, or a new file needing a tier ruling. `STALE-EXPECTED`
+   means the tree improved: drop the entry.
+4. Findings that are real defects get fixed in the repo (and usually a gate so the class
+   cannot return); findings that are tier classifications get an `expected_compile.txt`
+   entry with the reason.
+
+## Phases
+
+- **compile** (implemented) — the floor: every `.das` under the bundle's `examples/`,
+  `tutorials/`, and `modules/*/{examples,tutorials}` compiles with
+  `<bundle>/bin/daslang -compile-only`, per-file timeout, parallel self-spawned workers
+  (`utils/common/parallel_workers`). No execution, so windows/devices/models never engage;
+  the timeout covers the one thing that can still spin — compile-time macro work.
+- **run** (planned) — console-pure allowlist executed with timeout, rc==0 required.
+- **daspkg** (planned) — `daspkg install` for the package-requiring set (network-gated),
+  doubling as a live smoke of the shipped daspkg; then their compile tier re-runs.
+- **headless** (planned) — dasImgui apps through the harness headless arm.
+
+## expected_compile.txt
+
+`<bundle-relative-path> <reason>`, one per line, `#` comments. Discipline: an entry is a
+RULING (why this file legitimately cannot compile from a bare bundle), not a mute button —
+`SHIP-DEFECT(...)` reasons mark known defects awaiting a fix and must disappear when the
+fix lands; the stale-expected check reds the gate if an entry starts passing, so the list
+can only shrink truthfully.

--- a/utils/internal/test-release/README.md
+++ b/utils/internal/test-release/README.md
@@ -8,9 +8,11 @@ passes.
 ## The per-RC process
 
 1. Download the platform bundle from the release tag; extract to a CLEAN directory
-   (never over a previous install — a mixed tree tests nothing):
-   `tar -xf daslang-bundle-<os>-<arch>.zip -C <dir> --strip-components=1`
-2. From the repo root: `bin/daslang utils/internal/test-release/main.das -- --bundle <dir>`
+   (never over a previous install — a mixed tree tests nothing), short on Windows
+   (`C:\dl` — deep paths hit MAX_PATH in the network rows):
+   `unzip -q daslang-bundle-<os>-<arch>.zip -d <dir>` (Windows: `Expand-Archive`); the zip
+   carries a top-level `daslang_bundle/`, which is the root the next step points at.
+2. From the repo root: `bin/daslang utils/internal/test-release/main.das -- --bundle <dir>/daslang_bundle`
    (all phases; `--phase compile|utils` for one; `--network` adds the daspkg rows, which
    install into the bundle's example dirs — a scratch extract, never the one you keep).
 3. Triage the report: `UNEXPECTED` and `TIMEOUT` lines are the audit's yield — each is a

--- a/utils/internal/test-release/README.md
+++ b/utils/internal/test-release/README.md
@@ -11,6 +11,8 @@ passes.
    (never over a previous install — a mixed tree tests nothing):
    `tar -xf daslang-bundle-<os>-<arch>.zip -C <dir> --strip-components=1`
 2. From the repo root: `bin/daslang utils/internal/test-release/main.das -- --bundle <dir>`
+   (all phases; `--phase compile|utils` for one; `--network` adds the daspkg rows, which
+   install into the bundle's example dirs — a scratch extract, never the one you keep).
 3. Triage the report: `UNEXPECTED` and `TIMEOUT` lines are the audit's yield — each is a
    bundle defect, a missing payload, or a new file needing a tier ruling. `STALE-EXPECTED`
    means the tree improved: drop the entry.
@@ -25,14 +27,26 @@ passes.
   `<bundle>/bin/daslang -compile-only`, per-file timeout, parallel self-spawned workers
   (`utils/common/parallel_workers`). No execution, so windows/devices/models never engage;
   the timeout covers the one thing that can still spin — compile-time macro work.
+- **utils** (implemented, `utils_phase.das`) — every shipped tool exercised in its
+  capacity, from the bundle alone: the shipped suites (`utils/{common,lint,dascov,find-dupe,
+  jobque-timeline}`) through the shipped runner, then `bin/dastest.exe` on one of them
+  (the exe form has to compile a test at all); `lint.exe` and `das-fmt.exe --verify` over
+  the shipped `daslib` (the tree is at zero and formatter-clean, and stays so); the analysis
+  tools on their shipped fixtures (`detect-dupe` on `utils/detect-dupe/fixture`, `dascov`
+  on its test script, `benchctl` reset/query, `aot` emitting `hello_world`); the LSP
+  subtools on the MCP fixtures; `daslang-live` on `examples/daslive/test_api`. Every row
+  is exit code plus substrings only a working run prints — `0 issue(s), 0 error(s)`,
+  `N tests, N passed, 0 failed`, `Verified!` — never rc alone. With `--network`, `daspkg`
+  installs the packages the gated examples need (sequence → das-cards, the daspkg tutorial
+  projects, telegram, the local C/C++ build example), proves the unlock by compiling or
+  running the example, and `daspkg cleanup` returns each dir to shipped state. Rows are the
+  verified command lines from the RC1 utils audit; `--only <substr>` runs a subset.
 - **run** (planned) — console-pure allowlist executed with timeout, rc==0 required.
-- **daspkg** (planned) — `daspkg install` for the package-requiring set (network-gated),
-  doubling as a live smoke of the shipped daspkg; then their compile tier re-runs.
 - **headless** (planned) — dasImgui apps through the harness headless arm.
 
-## expected_compile.txt
+## expected_compile.txt / expected_utils.txt
 
-`<bundle-relative-path> <reason>`, one per line, `#` comments. Discipline: an entry is a
+`<bundle-relative-path-or-row-name> <reason>`, one per line, `#` comments. Discipline: an entry is a
 RULING (why this file legitimately cannot compile from a bare bundle), not a mute button —
 `SHIP-DEFECT(...)` reasons mark known defects awaiting a fix and must disappear when the
 fix lands; the stale-expected check reds the gate if an entry starts passing, so the list

--- a/utils/internal/test-release/classify.das
+++ b/utils/internal/test-release/classify.das
@@ -1,0 +1,92 @@
+options gen2
+
+require strings
+require daslib/strings_boost
+require daslib/fio
+
+// The pure half of test-release: verdict-line formatting/parsing, the expected-failures
+// list, and report summarization — everything a fixture test can pin without a bundle.
+
+//! One machine-parseable verdict line for a compiled file. Child stderr/stdout is folded
+//! to one line so parallel workers can never interleave a report.
+def verdict_line(f : string; rc : int; sec, timeout : float; out : string) : string {
+    if (rc == 0) {
+        return "OK {f}"
+    }
+    if (sec >= timeout) {
+        return "TIMEOUT {f} {sec}s"
+    }
+    var head = ""
+    for (ln in split(out, "\n")) {
+        let s = strip(replace(ln, "\r", ""))
+        if (!empty(s)) {
+            head = s
+            break
+        }
+    }
+    return "FAIL {f} rc={rc} {head}"
+}
+
+//! Expected-failure entries: `path  reason`, one per line, `#` comments. Returns
+//! path → reason.
+def load_expected(path : string) : table<string; string> {
+    var out : table<string; string>
+    let text = fread(path)
+    for (raw in split(text, "\n")) {
+        let s = strip(replace(raw, "\r", ""))
+        continue if (empty(s) || s |> starts_with("#"))
+        let sp = find(s, ' ')
+        if (sp < 0) {
+            out[s] = "(no reason recorded)"
+        } else {
+            out[slice(s, 0, sp)] = strip(slice(s, sp, length(s)))
+        }
+    }
+    return <- out
+}
+
+struct Report {
+    lines : array<string>
+    ok_count : int
+    expected_count : int
+    unexpected_count : int
+    stale_count : int
+    timeout_count : int
+}
+
+//! Fold worker verdict lines against the expected list. Unexpected failures and
+//! timeouts red the gate; an expected entry that now PASSES is stale and reds too —
+//! the list must shrink when the tree improves.
+def summarize(verdicts : array<string>; expected : table<string; string>) : Report {
+    var r : Report
+    var inscope seen_expected : table<string>
+    for (v in verdicts) {
+        if (v |> starts_with("OK ")) {
+            let f = slice(v, 3, length(v))
+            if (key_exists(expected, f)) {
+                seen_expected |> insert(f)
+                r.lines |> push("STALE-EXPECTED {f} — passes now; drop it from the list")
+                r.stale_count++
+            } else {
+                r.ok_count++
+            }
+        } elif (v |> starts_with("TIMEOUT ")) {
+            r.lines |> push(v)
+            r.timeout_count++
+        } elif (v |> starts_with("FAIL ")) {
+            let rest = slice(v, 5, length(v))
+            let sp = find(rest, ' ')
+            let f = sp < 0 ? rest : slice(rest, 0, sp)
+            if (key_exists(expected, f)) {
+                seen_expected |> insert(f)
+                let reason = expected ?[f] ?? ""
+                r.lines |> push("expected-fail {f} ({reason})")
+                r.expected_count++
+            } else {
+                r.lines |> push("UNEXPECTED {v}")
+                r.unexpected_count++
+            }
+        }
+    }
+    return <- r
+}

--- a/utils/internal/test-release/classify.das
+++ b/utils/internal/test-release/classify.das
@@ -7,14 +7,15 @@ require daslib/fio
 // The pure half of test-release: verdict-line formatting/parsing, the expected-failures
 // list, and report summarization — everything a fixture test can pin without a bundle.
 
-//! One machine-parseable verdict line for a compiled file. Child stderr/stdout is folded
-//! to one line so parallel workers can never interleave a report.
-def verdict_line(f : string; rc : int; sec, timeout : float; out : string) : string {
+//! One machine-parseable verdict line per checked item (a bundle-relative path, or a utils
+//! row name). Child stderr/stdout is folded to one line so parallel workers can never
+//! interleave a report.
+def verdict_line(subject : string; rc : int; sec, timeout : float; out : string) : string {
     if (rc == 0) {
-        return "OK {f}"
+        return "OK {subject}"
     }
     if (sec >= timeout) {
-        return "TIMEOUT {f} {sec}s"
+        return "TIMEOUT {subject} {sec}s"
     }
     var head = ""
     for (ln in split(out, "\n")) {
@@ -24,7 +25,7 @@ def verdict_line(f : string; rc : int; sec, timeout : float; out : string) : str
             break
         }
     }
-    return "FAIL {f} rc={rc} {head}"
+    return "FAIL {subject} rc={rc} {head}"
 }
 
 //! Expected-failure entries: `path  reason`, one per line, `#` comments. Returns
@@ -59,12 +60,10 @@ struct Report {
 //! the list must shrink when the tree improves.
 def summarize(verdicts : array<string>; expected : table<string; string>) : Report {
     var r : Report
-    var inscope seen_expected : table<string>
     for (v in verdicts) {
         if (v |> starts_with("OK ")) {
             let f = slice(v, 3, length(v))
             if (key_exists(expected, f)) {
-                seen_expected |> insert(f)
                 r.lines |> push("STALE-EXPECTED {f} — passes now; drop it from the list")
                 r.stale_count++
             } else {
@@ -78,7 +77,6 @@ def summarize(verdicts : array<string>; expected : table<string; string>) : Repo
             let sp = find(rest, ' ')
             let f = sp < 0 ? rest : slice(rest, 0, sp)
             if (key_exists(expected, f)) {
-                seen_expected |> insert(f)
                 let reason = expected ?[f] ?? ""
                 r.lines |> push("expected-fail {f} ({reason})")
                 r.expected_count++

--- a/utils/internal/test-release/expected_compile.txt
+++ b/utils/internal/test-release/expected_compile.txt
@@ -1,0 +1,47 @@
+# test-release expected compile failures — a RULING per line, not a mute button.
+# Format: <bundle-relative-path> <reason>. SHIP-DEFECT entries must disappear when fixed.
+
+# --- ship defects awaiting repo fixes (RC2) ---
+tutorials/sql/39-schema_from.das SHIP-DEFECT: [sql_table] schema_from reads tests/dasSQLITE fixture db that never ships
+tutorials/sql/42-schema_evolution.das SHIP-DEFECT: same unshipped fixture db
+modules/dasImgui/examples/tutorial/texture_ref.das SHIP-DEFECT: rotted vs compiler policy — local ImTextureRef now requires unsafe
+
+# --- daspkg-package tier: compile only after `daspkg install` (planned daspkg phase) ---
+examples/benchmarks/sql/_common.das needs duckdb/postgres provider packages
+examples/benchmarks/sql/_sql_families.das needs duckdb/postgres provider packages
+examples/benchmarks/sql/array.das needs duckdb/postgres provider packages
+examples/benchmarks/sql/duckdb.das needs duckdb/postgres provider packages
+examples/benchmarks/sql/postgres.das needs duckdb/postgres provider packages
+examples/benchmarks/sql/sqlite.das needs duckdb/postgres provider packages
+examples/claude/daslang_helper_bot.das needs the telegram/tbot package
+examples/telegram/echo-bot/echo_bot.das needs the telegram/tbot package
+examples/crash/crash_kinds.das needs its crash package installed
+examples/crash/main.das needs its crash package installed
+examples/daStrudel/sfx_lab/main.das needs the implot package (imgui_implot_boost_v2)
+examples/daspkg/daspkg-build-example/main.das daspkg tutorial project — resolves after its own install flow
+examples/daspkg/daspkg-example/main.das daspkg tutorial project — resolves after its own install flow
+examples/daspkg/daspkg-version-1/main.das daspkg tutorial project — resolves after its own install flow
+examples/daspkg/daspkg-version-2/main.das daspkg tutorial project — resolves after its own install flow
+examples/daspkg/packages/daspkg-example-mixed/daslib/smooth.das daspkg tutorial package internals
+examples/games/sequence/main.das needs the cards package
+examples/node-editor/imgui_node_editor_basic.das needs the imgui-node-editor package
+
+# --- integration-scaffold tier: the tutorial has the user BUILD the native module ---
+tutorials/integration/c/03_binding_types.das requires the native scaffold the tutorial builds
+tutorials/integration/c/04_callbacks.das requires the native scaffold the tutorial builds
+tutorials/integration/c/05_unaligned_advanced.das requires the native scaffold the tutorial builds
+tutorials/integration/c/12_ecs.das requires the native scaffold the tutorial builds
+tutorials/integration/c/ecs_macro.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/03_binding_functions.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/04_binding_types.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/05_binding_enums.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/06_interop.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/07_callbacks.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/08_methods.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/09_operators_and_properties.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/10_custom_modules.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/11_context_variables.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/12_smart_pointers.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/15_custom_annotations.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/19_class_adapters.das requires the native scaffold the tutorial builds
+tutorials/integration/cpp/23_handle_registry.das requires the native scaffold the tutorial builds

--- a/utils/internal/test-release/expected_compile.txt
+++ b/utils/internal/test-release/expected_compile.txt
@@ -1,10 +1,6 @@
 # test-release expected compile failures — a RULING per line, not a mute button.
-# Format: <bundle-relative-path> <reason>. SHIP-DEFECT entries must disappear when fixed.
 
 # --- ship defects awaiting repo fixes (RC2) ---
-tutorials/sql/39-schema_from.das SHIP-DEFECT: [sql_table] schema_from reads tests/dasSQLITE fixture db that never ships
-tutorials/sql/42-schema_evolution.das SHIP-DEFECT: same unshipped fixture db
-modules/dasImgui/examples/tutorial/texture_ref.das SHIP-DEFECT: rotted vs compiler policy — local ImTextureRef now requires unsafe
 
 # --- daspkg-package tier: compile only after `daspkg install` (planned daspkg phase) ---
 examples/benchmarks/sql/_common.das needs duckdb/postgres provider packages
@@ -13,18 +9,15 @@ examples/benchmarks/sql/array.das needs duckdb/postgres provider packages
 examples/benchmarks/sql/duckdb.das needs duckdb/postgres provider packages
 examples/benchmarks/sql/postgres.das needs duckdb/postgres provider packages
 examples/benchmarks/sql/sqlite.das needs duckdb/postgres provider packages
-examples/claude/daslang_helper_bot.das needs the telegram/tbot package
-examples/telegram/echo-bot/echo_bot.das needs the telegram/tbot package
 examples/crash/crash_kinds.das needs its crash package installed
 examples/crash/main.das needs its crash package installed
-examples/daStrudel/sfx_lab/main.das needs the implot package (imgui_implot_boost_v2)
+examples/daStrudel/sfx_lab/main.das daspkg exercise: needs the implot package
 examples/daspkg/daspkg-build-example/main.das daspkg tutorial project — resolves after its own install flow
 examples/daspkg/daspkg-example/main.das daspkg tutorial project — resolves after its own install flow
 examples/daspkg/daspkg-version-1/main.das daspkg tutorial project — resolves after its own install flow
 examples/daspkg/daspkg-version-2/main.das daspkg tutorial project — resolves after its own install flow
 examples/daspkg/packages/daspkg-example-mixed/daslib/smooth.das daspkg tutorial package internals
 examples/games/sequence/main.das needs the cards package
-examples/node-editor/imgui_node_editor_basic.das needs the imgui-node-editor package
 
 # --- integration-scaffold tier: the tutorial has the user BUILD the native module ---
 tutorials/integration/c/03_binding_types.das requires the native scaffold the tutorial builds

--- a/utils/internal/test-release/expected_utils.txt
+++ b/utils/internal/test-release/expected_utils.txt
@@ -1,5 +1,7 @@
 # test-release expected utils failures — a RULING per line, not a mute button.
+# `<row name> <reason>`; SHIP-DEFECT(...) reasons must disappear when the fix lands.
 
-# --- ship defects awaiting repo fixes (RC2) ---
-dastest.exe/common-suite SHIP-DEFECT(#3781): -exe tools carry build-machine native paths; dastest.exe cannot compile a test
-lint.exe/daslib SHIP-DEFECT(#3781): same defect - lint.exe skips daslib/just_in_time.das
+# --- ship defects awaiting repo fixes ---
+# (none on file: RC1's -exe native-path defect is fixed on master by #3781; a bundle cut
+#  before it still fails dastest.exe/common-suite and lint.exe/daslib — that is the audit
+#  doing its job against an old bundle, not a ruling to record)

--- a/utils/internal/test-release/expected_utils.txt
+++ b/utils/internal/test-release/expected_utils.txt
@@ -1,0 +1,5 @@
+# test-release expected utils failures — a RULING per line, not a mute button.
+
+# --- ship defects awaiting repo fixes (RC2) ---
+dastest.exe/common-suite SHIP-DEFECT(#3781): -exe tools carry build-machine native paths; dastest.exe cannot compile a test
+lint.exe/daslib SHIP-DEFECT(#3781): same defect - lint.exe skips daslib/just_in_time.das

--- a/utils/internal/test-release/main.das
+++ b/utils/internal/test-release/main.das
@@ -1,16 +1,19 @@
 options gen2
 
 require strings
+require math
 require daslib/strings_boost
 require daslib/fio
 require daslib/clargs
 require ../../common/parallel_workers.das
 require classify
+require utils_phase
 
 // The release-audit batch runner: points at an EXTRACTED release bundle and proves it
 // sane with the bundle's own binary — no repo, no build tree. Phase `compile` is the
 // floor: every example/tutorial .das in the bundle compiles (-compile-only, per-file
-// timeout). The process doc is README.md here.
+// timeout). Phase `utils` exercises every shipped tool from the bundle (utils_phase.das).
+// The process doc is README.md here.
 
 [CommandLineArgs]
 struct Config {
@@ -25,6 +28,18 @@ struct Config {
 
     @clarg_doc = "Expected-failures list (default: expected_compile.txt beside the tool)"
     expected : string
+
+    @clarg_doc = "Which phases to run: compile, utils, or all"
+    phase : string = "all"
+
+    @clarg_doc = "utils phase: also run the network rows (daspkg installs; mutates the bundle's example dirs)"
+    network : bool
+
+    @clarg_doc = "utils phase: run only rows whose name contains this"
+    only : string
+
+    @clarg_doc = "utils phase expected-failures list (default: expected_utils.txt beside the tool)"
+    expected_utils : string
 
     @clarg_doc = "Internal: run as a chunk worker over this paths file"
     paths_from : string
@@ -130,12 +145,49 @@ def run_worker(cfg : Config) : int {
     return 0
 }
 
+def run_utils_phase(cfg : Config; bundle : string) : int {
+    // internal tool: runs from the repo root (README), so the default list is repo-relative
+    var inscope expected <- load_expected(!empty(cfg.expected_utils) ? cfg.expected_utils : "utils/internal/test-release/expected_utils.txt")
+    to_log(LOG_INFO, "test-release utils: {cfg.network ? "network rows on" : "network rows off"}, {length(expected)} expected failures on file\n")
+    let daslang = bundle_binary(bundle)
+    if (cfg.network && get_platform_name() == "windows" && length(bundle) > 60) {
+        to_log(LOG_WARNING, "test-release: bundle path is {length(bundle)} chars - git clones and native package builds under it can hit MAX_PATH; extract to a short path (e.g. C:/dl) for the network rows
+")
+    }
+    if (!chdir(bundle)) {
+        to_log(LOG_ERROR, "test-release: cannot chdir to {bundle}\n")
+        return 2
+    }
+    var inscope verdicts <- run_utils_checks(bundle, daslang, cfg.network, cfg.only)
+    var inscope report <- summarize(verdicts, expected)
+    for (ln in report.lines) {
+        print("{ln}\n")
+    }
+    print("test-release utils: {report.ok_count} ok, {report.expected_count} expected-fail, {report.unexpected_count} UNEXPECTED, {report.stale_count} stale-expected, {report.timeout_count} timeout\n")
+    return report.unexpected_count + report.timeout_count + report.stale_count > 0 ? 1 : 0
+}
+
 def run_parent(cfg : Config) : int {
     let bundle = get_full_file_name(cfg.bundle)
     if (empty(bundle_binary(bundle))) {
         to_log(LOG_ERROR, "test-release: no daslang binary under {cfg.bundle}/bin\n")
         return 2
     }
+    if (cfg.phase != "compile" && cfg.phase != "utils" && cfg.phase != "all") {
+        to_log(LOG_ERROR, "test-release: --phase must be compile, utils, or all\n")
+        return 2
+    }
+    var rc = 0
+    if (cfg.phase != "compile") {
+        rc = max(rc, run_utils_phase(cfg, bundle))
+    }
+    if (cfg.phase != "utils") {
+        rc = max(rc, run_compile_phase(cfg, bundle))
+    }
+    return rc
+}
+
+def run_compile_phase(cfg : Config; bundle : string) : int {
     var inscope targets <- collect_targets(bundle)
     if (empty(targets)) {
         to_log(LOG_ERROR, "test-release: no example/tutorial .das found under {bundle}\n")

--- a/utils/internal/test-release/main.das
+++ b/utils/internal/test-release/main.das
@@ -1,0 +1,180 @@
+options gen2
+
+require strings
+require daslib/strings_boost
+require daslib/fio
+require daslib/clargs
+require ../../common/parallel_workers.das
+require classify
+
+// The release-audit batch runner: points at an EXTRACTED release bundle and proves it
+// sane with the bundle's own binary — no repo, no build tree. Phase `compile` is the
+// floor: every example/tutorial .das in the bundle compiles (-compile-only, per-file
+// timeout). The process doc is README.md here.
+
+[CommandLineArgs]
+struct Config {
+    @clarg_doc = "Extracted release bundle root (contains bin/, examples/, tutorials/)"
+    bundle : string
+
+    @clarg_doc = "Seconds allowed per file"
+    timeout : float = 60.0
+
+    @clarg_doc = "Worker processes (0 = auto)"
+    jobs : int = 0
+
+    @clarg_doc = "Expected-failures list (default: expected_compile.txt beside the tool)"
+    expected : string
+
+    @clarg_doc = "Internal: run as a chunk worker over this paths file"
+    paths_from : string
+
+    @clarg_short = "?"
+    @clarg_doc = "Show this help and exit"
+    help : bool
+}
+
+def bundle_binary(bundle : string) : string {
+    for (name in ["bin/daslang.exe", "bin/daslang"]) {
+        let p = path_join(bundle, name)
+        if (fexist(p)) {
+            return get_full_file_name(p)
+        }
+    }
+    return ""
+}
+
+//! Every example/tutorial .das in the bundle, bundle-relative with forward slashes.
+def collect_targets(bundle : string) : array<string> {
+    var out : array<string>
+    var roots <- ["examples", "tutorials"]
+    dir(path_join(bundle, "modules")) $(name) {
+        return if (name == "." || name == "..")
+        for (sub in ["examples", "tutorials"]) {
+            let rel = "modules/{name}/{sub}"
+            if (stat(path_join(bundle, rel)).is_dir) {
+                roots |> push(rel)
+            }
+        }
+    }
+    for (root in roots) {
+        let base = path_join(bundle, root)
+        continue if (!stat(base).is_dir)
+        dir_rec(base) $(name, is_dir) {
+            return if (is_dir || extension(name) != ".das")
+            out |> push("{root}/{to_generic_path(name)}")
+        }
+    }
+    out |> sort
+    return <- out
+}
+
+def run_worker(cfg : Config) : int {
+    let exe = bundle_binary(cfg.bundle)
+    if (empty(exe)) {
+        to_log(LOG_ERROR, "test-release: no daslang binary under {cfg.bundle}/bin\n")
+        return 2
+    }
+    if (!chdir(cfg.bundle)) {
+        to_log(LOG_ERROR, "test-release: cannot chdir to {cfg.bundle}\n")
+        return 2
+    }
+    let listing = fread(cfg.paths_from)
+    for (raw in split(listing, "\n")) {
+        let f = strip(raw)
+        continue if (empty(f))
+        let t0 = ref_time_ticks()
+        var out : string
+        let rc = run_and_capture([exe, "-compile-only", f], out, cfg.timeout)
+        let sec = float(get_time_usec(t0)) / 1000000.0
+        print("{verdict_line(f, rc, sec, cfg.timeout, out)}\n")
+    }
+    return 0
+}
+
+def run_parent(cfg : Config) : int {
+    let bundle = get_full_file_name(cfg.bundle)
+    if (empty(bundle_binary(bundle))) {
+        to_log(LOG_ERROR, "test-release: no daslang binary under {cfg.bundle}/bin\n")
+        return 2
+    }
+    var inscope targets <- collect_targets(bundle)
+    if (empty(targets)) {
+        to_log(LOG_ERROR, "test-release: no example/tutorial .das found under {bundle}\n")
+        return 2
+    }
+    // internal tool: runs from the repo root (README), so the default list is repo-relative
+    var inscope expected <- load_expected(!empty(cfg.expected) ? cfg.expected : "utils/internal/test-release/expected_compile.txt")
+    to_log(LOG_INFO, "test-release compile: {length(targets)} targets, {length(expected)} expected failures on file\n")
+
+    let workers = compute_worker_count(length(targets), cfg.jobs)
+    var inscope chunks <- chunk_files(targets, workers)
+    var err : string
+    var argvs : array<array<string>>
+    argvs |> reserve(length(chunks))
+    var tmpfiles : array<string>
+    tmpfiles |> reserve(length(chunks))
+    for (chunk in chunks) {
+        let tmp = create_temp_file("test_release_chunk", ".txt", err)
+        let body = build_string() $(var writer) {
+            for (f in chunk) {
+                writer |> write(f)
+                writer |> write("\n")
+            }
+        }
+        fwrite(tmp, body)
+        tmpfiles |> push(tmp)
+        var argv <- spawn_argv_prefix()
+        argv |> push("--")
+        argv |> push("--bundle")
+        argv |> push(bundle)
+        argv |> push("--timeout")
+        argv |> push("{cfg.timeout}")
+        argv |> push("--paths-from")
+        argv |> push(tmp)
+        argvs |> emplace(argv)
+    }
+    var inscope results <- run_chunk_workers(argvs)
+    for (tmp in tmpfiles) {
+        remove(tmp)
+    }
+    var verdicts : array<string>
+    for (r in results) {
+        if (r.exit_code != 0) {
+            to_log(LOG_ERROR, "test-release: worker {r.index} died rc={r.exit_code}\n{r.stdout}")
+            return 2
+        }
+        for (ln in split(r.stdout, "\n")) {
+            let s = strip(replace(ln, "\r", ""))
+            if (!empty(s)) {
+                verdicts |> push(s)
+            }
+        }
+    }
+    var inscope report <- summarize(verdicts, expected)
+    for (ln in report.lines) {
+        print("{ln}\n")
+    }
+    print("test-release compile: {report.ok_count} ok, {report.expected_count} expected-fail, {report.unexpected_count} UNEXPECTED, {report.stale_count} stale-expected, {report.timeout_count} timeout\n")
+    return report.unexpected_count + report.timeout_count + report.stale_count > 0 ? 1 : 0
+}
+
+[export]
+def main() : int {
+    var args_r <- parse_args(type<Config>)
+    if (args_r |> is_err) {
+        to_log(LOG_ERROR, "error: {args_r |> unwrap_err}\n\n")
+        print_help(get_command_info(type<Config>), "test-release")
+        return 1
+    }
+    let cfg <- args_r |> move_unwrap
+    if (cfg.help) {
+        print_help(get_command_info(type<Config>), "test-release")
+        return 0
+    }
+    if (empty(cfg.bundle)) {
+        to_log(LOG_ERROR, "test-release: --bundle is required\n")
+        return 1
+    }
+    return !empty(cfg.paths_from) ? run_worker(cfg) : run_parent(cfg)
+}

--- a/utils/internal/test-release/main.das
+++ b/utils/internal/test-release/main.das
@@ -9,11 +9,12 @@ require ../../common/parallel_workers.das
 require classify
 require utils_phase
 
-// The release-audit batch runner: points at an EXTRACTED release bundle and proves it
-// sane with the bundle's own binary — no repo, no build tree. Phase `compile` is the
-// floor: every example/tutorial .das in the bundle compiles (-compile-only, per-file
-// timeout). Phase `utils` exercises every shipped tool from the bundle (utils_phase.das).
-// The process doc is README.md here.
+// Release-audit batch runner over an EXTRACTED bundle: the bundle's own binary, no repo, no build tree.
+// compile: every example/tutorial .das compiles (-compile-only, per-file timeout).
+// utils:   every shipped tool run from the bundle (utils_phase.das). Process: README.md.
+
+// the tool runs from the repo root (README), so the default lists are repo-relative
+let private EXPECTED_DIR = "utils/internal/test-release"
 
 [CommandLineArgs]
 struct Config {
@@ -26,8 +27,8 @@ struct Config {
     @clarg_doc = "Worker processes (0 = auto)"
     jobs : int = 0
 
-    @clarg_doc = "Expected-failures list (default: expected_compile.txt beside the tool)"
-    expected : string
+    @clarg_doc = "compile phase expected-failures list (default: expected_compile.txt beside the tool)"
+    expected_compile : string
 
     @clarg_doc = "Which phases to run: compile, utils, or all"
     phase : string = "all"
@@ -49,17 +50,12 @@ struct Config {
     help : bool
 }
 
-def bundle_binary(bundle : string) : string {
-    for (name in ["bin/daslang.exe", "bin/daslang"]) {
-        let p = path_join(bundle, name)
-        if (fexist(p)) {
-            return get_full_file_name(p)
-        }
-    }
-    return ""
+def bundle_daslang(bundle : string) : string {
+    let p = bundle_exe(bundle, "daslang")
+    return fexist(p) ? p : ""
 }
 
-//! Every example/tutorial .das in the bundle, bundle-relative with forward slashes.
+// every example/tutorial .das in the bundle, bundle-relative with forward slashes
 def collect_targets(bundle : string) : array<string> {
     var out : array<string>
     var roots <- ["examples", "tutorials"]
@@ -84,8 +80,7 @@ def collect_targets(bundle : string) : array<string> {
     return <- out
 }
 
-//! The nearest *.das_project at or above `f` (bundle-relative), "" when none — a file
-//! under a project dir compiles the way its README runs it: with `-project`.
+// nearest *.das_project at or above `f` (bundle-relative), "" when none
 def project_for(f : string; var cache : table<string; string>) : string {
     var d = dir_name(f)
     while (!empty(d) && d != ".") {
@@ -109,7 +104,7 @@ def project_for(f : string; var cache : table<string; string>) : string {
 }
 
 def run_worker(cfg : Config) : int {
-    let exe = bundle_binary(cfg.bundle)
+    let exe = bundle_daslang(cfg.bundle)
     if (empty(exe)) {
         to_log(LOG_ERROR, "test-release: no daslang binary under {cfg.bundle}/bin\n")
         return 2
@@ -132,9 +127,9 @@ def run_worker(cfg : Config) : int {
             // way around: sandbox-lesson projects would break bystander siblings.
             let proj = project_for(f, proj_cache)
             if (!empty(proj)) {
-                var pout : string
-                let prc = run_and_capture([exe, "-compile-only", f, "-project", proj], pout, cfg.timeout)
-                if (prc == 0) {
+                var proj_out : string
+                let proj_rc = run_and_capture([exe, "-compile-only", f, "-project", proj], proj_out, cfg.timeout)
+                if (proj_rc == 0) {
                     rc = 0
                 }
             }
@@ -146,10 +141,9 @@ def run_worker(cfg : Config) : int {
 }
 
 def run_utils_phase(cfg : Config; bundle : string) : int {
-    // internal tool: runs from the repo root (README), so the default list is repo-relative
-    var inscope expected <- load_expected(!empty(cfg.expected_utils) ? cfg.expected_utils : "utils/internal/test-release/expected_utils.txt")
+    var inscope expected <- load_expected(!empty(cfg.expected_utils) ? cfg.expected_utils : path_join(EXPECTED_DIR, "expected_utils.txt"))
     to_log(LOG_INFO, "test-release utils: {cfg.network ? "network rows on" : "network rows off"}, {length(expected)} expected failures on file\n")
-    let daslang = bundle_binary(bundle)
+    let daslang = bundle_daslang(bundle)
     if (cfg.network && get_platform_name() == "windows" && length(bundle) > 60) {
         to_log(LOG_WARNING, "test-release: bundle path is {length(bundle)} chars - git clones and native package builds under it can hit MAX_PATH; extract to a short path (e.g. C:/dl) for the network rows
 ")
@@ -169,7 +163,7 @@ def run_utils_phase(cfg : Config; bundle : string) : int {
 
 def run_parent(cfg : Config) : int {
     let bundle = get_full_file_name(cfg.bundle)
-    if (empty(bundle_binary(bundle))) {
+    if (empty(bundle_daslang(bundle))) {
         to_log(LOG_ERROR, "test-release: no daslang binary under {cfg.bundle}/bin\n")
         return 2
     }
@@ -193,19 +187,22 @@ def run_compile_phase(cfg : Config; bundle : string) : int {
         to_log(LOG_ERROR, "test-release: no example/tutorial .das found under {bundle}\n")
         return 2
     }
-    // internal tool: runs from the repo root (README), so the default list is repo-relative
-    var inscope expected <- load_expected(!empty(cfg.expected) ? cfg.expected : "utils/internal/test-release/expected_compile.txt")
+    var inscope expected <- load_expected(!empty(cfg.expected_compile) ? cfg.expected_compile : path_join(EXPECTED_DIR, "expected_compile.txt"))
     to_log(LOG_INFO, "test-release compile: {length(targets)} targets, {length(expected)} expected failures on file\n")
 
     let workers = compute_worker_count(length(targets), cfg.jobs)
     var inscope chunks <- chunk_files(targets, workers)
-    var err : string
     var argvs : array<array<string>>
     argvs |> reserve(length(chunks))
     var tmpfiles : array<string>
     tmpfiles |> reserve(length(chunks))
     for (chunk in chunks) {
+        var err : string
         let tmp = create_temp_file("test_release_chunk", ".txt", err)
+        if (empty(tmp)) {
+            to_log(LOG_ERROR, "test-release: cannot create a chunk file: {err}\n")
+            return 2
+        }
         let body = build_string() $(var writer) {
             for (f in chunk) {
                 writer |> write(f)

--- a/utils/internal/test-release/main.das
+++ b/utils/internal/test-release/main.das
@@ -171,12 +171,13 @@ def run_parent(cfg : Config) : int {
         to_log(LOG_ERROR, "test-release: --phase must be compile, utils, or all\n")
         return 2
     }
+    // compile first: the utils phase (with --network) installs into the example dirs
     var rc = 0
-    if (cfg.phase != "compile") {
-        rc = max(rc, run_utils_phase(cfg, bundle))
-    }
     if (cfg.phase != "utils") {
         rc = max(rc, run_compile_phase(cfg, bundle))
+    }
+    if (cfg.phase != "compile") {
+        rc = max(rc, run_utils_phase(cfg, bundle))
     }
     return rc
 }

--- a/utils/internal/test-release/main.das
+++ b/utils/internal/test-release/main.das
@@ -145,8 +145,7 @@ def run_utils_phase(cfg : Config; bundle : string) : int {
     to_log(LOG_INFO, "test-release utils: {cfg.network ? "network rows on" : "network rows off"}, {length(expected)} expected failures on file\n")
     let daslang = bundle_daslang(bundle)
     if (cfg.network && get_platform_name() == "windows" && length(bundle) > 60) {
-        to_log(LOG_WARNING, "test-release: bundle path is {length(bundle)} chars - git clones and native package builds under it can hit MAX_PATH; extract to a short path (e.g. C:/dl) for the network rows
-")
+        to_log(LOG_WARNING, "test-release: bundle path is {length(bundle)} chars - git clones and native package builds under it can hit MAX_PATH; extract to a short path (e.g. C:/dl) for the network rows\n")
     }
     if (!chdir(bundle)) {
         to_log(LOG_ERROR, "test-release: cannot chdir to {bundle}\n")

--- a/utils/internal/test-release/main.das
+++ b/utils/internal/test-release/main.das
@@ -69,6 +69,30 @@ def collect_targets(bundle : string) : array<string> {
     return <- out
 }
 
+//! The nearest *.das_project at or above `f` (bundle-relative), "" when none — a file
+//! under a project dir compiles the way its README runs it: with `-project`.
+def project_for(f : string; var cache : table<string; string>) : string {
+    var d = dir_name(f)
+    while (!empty(d) && d != ".") {
+        let hit = cache ?[d] ?? "?"
+        if (hit != "?") {
+            return hit
+        }
+        var found = ""
+        dir(d) $(name) {
+            if (empty(found) && extension(name) == ".das_project") {
+                found = "{d}/{name}"
+            }
+        }
+        cache[d] = found
+        if (!empty(found)) {
+            return found
+        }
+        d = dir_name(d)
+    }
+    return ""
+}
+
 def run_worker(cfg : Config) : int {
     let exe = bundle_binary(cfg.bundle)
     if (empty(exe)) {
@@ -80,12 +104,26 @@ def run_worker(cfg : Config) : int {
         return 2
     }
     let listing = fread(cfg.paths_from)
+    var inscope proj_cache : table<string; string>
     for (raw in split(listing, "\n")) {
         let f = strip(raw)
         continue if (empty(f))
         let t0 = ref_time_ticks()
         var out : string
-        let rc = run_and_capture([exe, "-compile-only", f], out, cfg.timeout)
+        var rc = run_and_capture([exe, "-compile-only", f], out, cfg.timeout)
+        if (rc != 0) {
+            // a file that fails bare may be a project-file example (engine-alias
+            // resolvers etc.) — retry the way its README runs it. Never the other
+            // way around: sandbox-lesson projects would break bystander siblings.
+            let proj = project_for(f, proj_cache)
+            if (!empty(proj)) {
+                var pout : string
+                let prc = run_and_capture([exe, "-compile-only", f, "-project", proj], pout, cfg.timeout)
+                if (prc == 0) {
+                    rc = 0
+                }
+            }
+        }
         let sec = float(get_time_usec(t0)) / 1000000.0
         print("{verdict_line(f, rc, sec, cfg.timeout, out)}\n")
     }

--- a/utils/internal/test-release/test_classify.das
+++ b/utils/internal/test-release/test_classify.das
@@ -1,0 +1,45 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/fio
+require classify
+
+[test]
+def test_verdict_lines(t : T?) {
+    t |> equal("OK a/b.das", verdict_line("a/b.das", 0, 1.0, 60.0, ""))
+    t |> equal("TIMEOUT a/b.das 61.5s", verdict_line("a/b.das", 1, 61.5, 60.0, "whatever"))
+    let failed = verdict_line("a/b.das", 1, 2.0, 60.0, "\nerror[20605]: missing prerequisite 'x'\nmore\n")
+    t |> equal("FAIL a/b.das rc=1 error[20605]: missing prerequisite 'x'", failed)
+    t |> equal("FAIL a/b.das rc=3 ", verdict_line("a/b.das", 3, 2.0, 60.0, ""), "empty output keeps the line parseable")
+}
+
+[test]
+def test_expected_list_round_trip(t : T?) {
+    let fixture_r = create_temp_file_result("test_release_expected", ".txt")
+    t |> success(fixture_r is value, "temp fixture created")
+    if (!(fixture_r is value)) return
+    let fixture = unsafe(fixture_r.value)
+    t |> success(fwrite(fixture, "# comment\n\nexamples/a.das needs the telegram package\ntutorials/b.das\n"))
+    var inscope exp <- load_expected(fixture)
+    t |> equal(2, length(exp))
+    t |> equal("needs the telegram package", exp ?["examples/a.das"] ?? "MISSING")
+    t |> equal("(no reason recorded)", exp ?["tutorials/b.das"] ?? "MISSING")
+    t |> success(remove(fixture))
+}
+
+[test]
+def test_summarize_buckets(t : T?) {
+    var inscope expected : table<string; string>
+    expected["e/known.das"] = "by design"
+    expected["e/fixed.das"] = "was broken"
+    let verdicts <- ["OK e/clean.das", "OK e/fixed.das",
+                     "FAIL e/known.das rc=1 error[20605]: x",
+                     "FAIL e/new.das rc=1 error[30000]: y",
+                     "TIMEOUT e/spin.das 60.1s"]
+    var inscope r <- summarize(verdicts, expected)
+    t |> equal(1, r.ok_count)
+    t |> equal(1, r.expected_count)
+    t |> equal(1, r.unexpected_count, "a fail off the list reds")
+    t |> equal(1, r.stale_count, "an expected entry that passes reds as stale")
+    t |> equal(1, r.timeout_count)
+}

--- a/utils/internal/test-release/test_utils_phase.das
+++ b/utils/internal/test-release/test_utils_phase.das
@@ -1,0 +1,47 @@
+options gen2
+
+require dastest/testing_boost public
+require strings
+require utils_phase
+
+[test]
+def test_substitute_tokens(t : T?) {
+    var inscope argv <- substitute(["@DASLANG@", "@OUT@/x.cpp", "plain", "--flag=@OUT@"], "/b/bin/daslang", "/b", "/tmp/o")
+    t |> equal("/b/bin/daslang", argv[0])
+    t |> equal("/tmp/o/x.cpp", argv[1])
+    t |> equal("plain", argv[2])
+    t |> equal("--flag=/tmp/o", argv[3], "@OUT@ substitutes anywhere in the token")
+}
+
+[test]
+def test_bundle_exe_missing_still_names_bin(t : T?) {
+    // a tool the bundle lacks resolves to bin/<name> so the launch fails naming the tool
+    let p = bundle_exe("/nonexistent-bundle", "nosuchtool")
+    t |> success(p |> ends_with("bin/nosuchtool") || p |> ends_with("bin\\nosuchtool"), "resolved to bin/<name>: {p}")
+}
+
+[test]
+def test_unmet_wants_and_forbids(t : T?) {
+    let row <- ToolCheck(name = "x", want <- ["0 failed, 0 errors"], forbid <- ["\n0 tests,"])
+    t |> equal("", unmet(row, "17 tests, 17 passed, 0 failed, 0 errors, 0 skipped\nSUCCESS!"))
+    t |> equal("expected `0 failed, 0 errors` in output", unmet(row, "17 tests, 16 passed, 1 failed, 0 errors"))
+    t |> equal("unexpected `0 tests,` in output", unmet(row, "0 tests, 0 passed, 0 failed, 0 errors, 0 skipped"), "the forbid anchors at line start")
+    t |> equal("", unmet(row, "10 tests, 10 passed, 0 failed, 0 errors, 0 skipped"), "'10 tests' must not trip the anchored '0 tests'")
+    let lint <- ToolCheck(name = "l", want <- ["0 issue(s), 0 error(s)"], forbid <- ["skipped"])
+    t |> equal("unexpected `skipped` in output", unmet(lint, "148 files, 0 issue(s), 0 error(s), 1 skipped"))
+    t |> equal("", unmet(lint, "148 files, 0 issue(s), 0 error(s)"))
+}
+
+[test]
+def test_rows_are_well_formed(t : T?) {
+    var inscope rows <- utils_checks()
+    t |> success(length(rows) > 20, "{length(rows)} rows")
+    var names : table<string>
+    for (r in rows) {
+        t |> success(!empty(r.name), "row has a name")
+        t |> success(!key_exists(names, r.name), "row name unique: {r.name}")
+        names |> insert(r.name)
+        t |> success(!empty(r.argv), "{r.name} has argv")
+        t |> success(r.timeout > 0.0, "{r.name} has a timeout")
+    }
+}

--- a/utils/internal/test-release/test_utils_phase.das
+++ b/utils/internal/test-release/test_utils_phase.das
@@ -2,22 +2,55 @@ options gen2
 
 require dastest/testing_boost public
 require strings
+require daslib/fio
 require utils_phase
+
+// a throwaway bundle root with bin/<names...> as files; "" when the temp dir cannot be made
+def stage_bundle(names : array<string>) : string {
+    let r = create_temp_directory_result("test_release_bundle")
+    return "" if (!(r is value))
+    let root = to_generic_path(r as value)
+    mkdir(path_join(root, "bin"))
+    for (n in names) {
+        fwrite(path_join(root, "bin/{n}"), "x")
+    }
+    return root
+}
 
 [test]
 def test_substitute_tokens(t : T?) {
-    var inscope argv <- substitute(["@DASLANG@", "@OUT@/x.cpp", "plain", "--flag=@OUT@"], "/b/bin/daslang", "/b", "/tmp/o")
+    let root = stage_bundle(["lint.exe"])
+    t |> success(!empty(root), "staged a bundle")
+    return if (empty(root))
+    var inscope argv <- substitute_tokens(["@DASLANG@", "@OUT@/x.cpp", "plain", "--flag=@OUT@", "@EXE:lint@"], "/b/bin/daslang", root, "/tmp/o")
     t |> equal("/b/bin/daslang", argv[0])
     t |> equal("/tmp/o/x.cpp", argv[1])
     t |> equal("plain", argv[2])
     t |> equal("--flag=/tmp/o", argv[3], "@OUT@ substitutes anywhere in the token")
+    t |> equal(to_generic_path(get_full_file_name(path_join(root, "bin/lint.exe"))), to_generic_path(argv[4]), "@EXE:x@ resolves through bundle_exe, trailing @ stripped")
+    rmdir_rec(root)
 }
 
 [test]
-def test_bundle_exe_missing_still_names_bin(t : T?) {
-    // a tool the bundle lacks resolves to bin/<name> so the launch fails naming the tool
-    let p = bundle_exe("/nonexistent-bundle", "nosuchtool")
-    t |> success(p |> ends_with("bin/nosuchtool") || p |> ends_with("bin\\nosuchtool"), "resolved to bin/<name>: {p}")
+def test_bundle_exe_prefers_exe_then_bare_then_names_bin(t : T?) {
+    let root = stage_bundle(["both.exe", "both", "bare"])
+    t |> success(!empty(root), "staged a bundle")
+    return if (empty(root))
+    t |> success(to_generic_path(bundle_exe(root, "both")) |> ends_with("bin/both.exe"), ".exe wins when both exist")
+    t |> success(to_generic_path(bundle_exe(root, "bare")) |> ends_with("bin/bare"), "bare name when no .exe")
+    t |> success(to_generic_path(bundle_exe(root, "nosuchtool")) |> ends_with("bin/nosuchtool"), "missing tool still names bin/<name> so the launch fails naming it")
+    rmdir_rec(root)
+}
+
+[test]
+def test_judged_rc_and_head(t : T?) {
+    let row <- ToolCheck(name = "x", want <- ["Verified!"])
+    t |> equal(0, judged_rc(row, 0, "Verified! 3 files"), "rc 0 with the oracle met stays 0")
+    t |> equal(1, judged_rc(row, 0, "Complete! 3 files"), "rc 0 with the oracle unmet becomes 1")
+    t |> equal(2, judged_rc(row, 2, "Verified! 3 files"), "a non-zero exit keeps its code even if the words appear")
+    t |> equal("expected `Verified!` in output", judged_head(row, 0, "Complete! 3 files"))
+    t |> equal("Complete! 3 files", judged_head(row, 2, "Complete! 3 files"), "a real failure shows the child's output")
+    t |> equal("Verified! 3 files", judged_head(row, 0, "Verified! 3 files"))
 }
 
 [test]

--- a/utils/internal/test-release/utils_phase.das
+++ b/utils/internal/test-release/utils_phase.das
@@ -1,0 +1,177 @@
+options gen2
+
+require strings
+require daslib/strings_boost
+require daslib/fio
+require classify
+
+// Phase `utils`: every shipped tool exercised in its capacity, from the bundle alone -
+// the shipped suites through the shipped runner, one real invocation per exe with an
+// oracle a machine can check, and (with --network) daspkg installing the packages the
+// gated examples need. Rows are the verified command lines from the RC1 utils audit.
+
+struct ToolCheck {
+    name : string           //! verdict key, e.g. "lint.exe/daslib"
+    argv : array<string>    //! @DASLANG@ = bundle daslang, @EXE:x@ = bin/x(.exe), @OUT@ = scratch dir
+    want : array<string>    //! every substring must appear in the merged output
+    forbid : array<string>  //! none may appear (checked against "\n" + output, so "\n0 tests" anchors a line)
+    timeout : float = 120.0
+    network : bool = false  //! only with --network: fetches packages, mutates the bundle's example dirs
+    copy_from : string      //! bundle-relative file copied into @OUT@ before the run (formatter round-trips)
+}
+
+let private DASTEST_OK <- ["0 failed, 0 errors, 0 skipped"]
+let private DASTEST_EMPTY <- ["\n0 tests,"]
+
+//! The bundle-relative suites the in-tree run_utils_tests target runs - through the
+//! script-form runner, which the exe-form row (dastest.exe) then has to match.
+def private suite_row(name, dir : string; extra_argv : array<string>) : ToolCheck {
+    var argv <- ["@DASLANG@"]
+    argv |> push_from(extra_argv, ["dastest/dastest.das", "--", "--test", dir])
+    return <- ToolCheck(name = name, argv <- argv, want := DASTEST_OK, forbid := DASTEST_EMPTY, timeout = 300.0)
+}
+
+def public utils_checks() : array<ToolCheck> {
+    var rows <- [
+        // --- shipped suites through the shipped runner ---------------------------------
+        <- suite_row("dastest/common-suite", "utils/common/tests", []),
+        <- suite_row("dastest/lint-suite", "utils/lint/tests", []),
+        <- suite_row("dastest/dascov-suite", "utils/dascov/tests", []),
+        <- suite_row("dastest/find-dupe-suite", "utils/find-dupe/tests", []),
+        <- suite_row("dastest/jobque-timeline-suite", "utils/jobque-timeline", ["-project_root", "utils/jobque-timeline"]),
+        // the exe form must be able to compile a test at all (RC1: frozen build-machine paths)
+        ToolCheck(name = "dastest.exe/common-suite", argv <- ["@EXE:dastest@", "--test", "utils/common/tests"],
+            want := DASTEST_OK, forbid := DASTEST_EMPTY, timeout = 300.0),
+        ToolCheck(name = "gen1_to_gen2/self-tests", argv <- ["@EXE:gen1_to_gen2@", "--tests"]),
+        ToolCheck(name = "gen1_to_gen2/convert", argv <- ["@EXE:gen1_to_gen2@", "-v2", "utils/mcp/tests/_fixture_gen1.das"],
+            want <- ["options gen2", "struct Point \{"]),
+        // --- lint / format over the shipped daslib (the tree is at zero, and stays so) -----
+        ToolCheck(name = "lint.exe/help", argv <- ["@EXE:lint@", "--help"], want <- ["Unified lint checker for daslang files."]),
+        ToolCheck(name = "lint.exe/daslib", argv <- ["@EXE:lint@", "daslib"],
+            want <- ["0 issue(s), 0 error(s)"], forbid <- ["skipped"], timeout = 300.0),
+        ToolCheck(name = "das-fmt.exe/verify-daslib", argv <- ["@EXE:das-fmt@", "--path", "daslib", "--verify"],
+            want <- ["Verified!"], forbid <- ["Verification failed"]),
+        ToolCheck(name = "das-fmt.exe/format-copy", argv <- ["@EXE:das-fmt@", "--path", "@OUT@/strings_boost.das"],
+            want <- ["Complete! 1 files"], copy_from = "daslib/strings_boost.das"),
+        // --- analysis tools on their shipped fixtures -----------------------------------
+        ToolCheck(name = "dascov.exe/report", argv <- ["@EXE:dascov@", "--", "-", "utils/dascov/tests/simple_branch.das"],
+            want <- ["simple_branch.das", "TOTAL"]),
+        ToolCheck(name = "detect-dupe.exe/fixture", argv <- ["@EXE:detect-dupe@", "-p", "utils/detect-dupe/fixture/synth.das"],
+            want <- ["functions analyzed: 9", "exact clusters    : 2", "fuzzy pairs       : 1"]),
+        ToolCheck(name = "benchctl.exe/help", argv <- ["@EXE:benchctl@", "--help"], want <- ["benchctl - benchmark database management tool"]),
+        ToolCheck(name = "benchctl.exe/reset", argv <- ["@EXE:benchctl@", "--", "reset", "--db", "@OUT@/bench.db"]),
+        ToolCheck(name = "benchctl.exe/query", argv <- ["@EXE:benchctl@", "--", "query", "--db", "@OUT@/bench.db"], want <- ["no results"]),
+        ToolCheck(name = "aot/emit", argv <- ["@DASLANG@", "utils/aot/main.das", "--", "-aot", "examples/hello_world.das", "@OUT@/hello.cpp"],
+            want <- ["Aot to "]),
+        ToolCheck(name = "fix-lint-errors/help", argv <- ["@DASLANG@", "utils/fix-lint-errors/main.das", "--", "-?"],
+            want <- ["Auto-fixer for mechanical lint rules"]),
+        // --- agent-facing tooling ---------------------------------------------------------
+        ToolCheck(name = "lsp/validate", argv <- ["@DASLANG@", "utils/lsp/subtools/validate.das", "--", "utils/mcp/tests/_fixture_error.das"],
+            want <- ["\"ok\":false", "\"code\":\"30343\""]),
+        ToolCheck(name = "lsp/nav", argv <- ["@DASLANG@", "utils/lsp/subtools/nav.das", "--", "documentSymbol", "utils/mcp/tests/_fixture_valid.das"],
+            want <- ["\"ok\":true", "\"name\":\"Point\""]),
+        ToolCheck(name = "mcp/setup-help", argv <- ["@DASLANG@", "utils/mcp/setup.das", "--", "--show-help"], want <- ["--no-build"]),
+        ToolCheck(name = "daslang-live/test_api", argv <- ["@EXE:daslang-live@", "examples/daslive/test_api/main.das", "--live-port", "19099"],
+            want <- ["PASS: 2 commands registered"], timeout = 60.0),
+        // --- daspkg: launch offline; the installs need the network and mutate example dirs --
+        ToolCheck(name = "daspkg.exe/help", argv <- ["@EXE:daspkg@", "--help"], want <- ["daslang package manager"]),
+        ToolCheck(name = "daspkg.exe/install-sequence", argv <- ["@EXE:daspkg@", "install", "--root", "examples/games/sequence", "--no-color"],
+            want <- ["Installed 'das-cards'"], network = true),
+        ToolCheck(name = "daspkg.exe/unlock-sequence", argv <- ["@DASLANG@", "-compile-only", "examples/games/sequence/main.das"], network = true),
+        ToolCheck(name = "daspkg.exe/install-daspkg-example", argv <- ["@EXE:daspkg@", "install", "--root", "examples/daspkg/daspkg-example", "--no-color"],
+            want <- ["Installed 'daspkg-test-pure'", "Installed 'daspkg-test-deps'"], network = true),
+        ToolCheck(name = "daspkg.exe/run-daspkg-example", argv <- ["@DASLANG@", "examples/daspkg/daspkg-example/main.das"],
+            want <- ["Hello, daspkg!", "2 + 3 = 5"], network = true),
+        ToolCheck(name = "daspkg.exe/install-telegram", argv <- ["@EXE:daspkg@", "install", "--root", "examples/telegram/echo-bot", "--no-color"],
+            want <- ["Installed 'dasTelegram'"], network = true),
+        ToolCheck(name = "daspkg.exe/unlock-telegram", argv <- ["@DASLANG@", "-compile-only", "examples/telegram/echo-bot/echo_bot.das"], network = true),
+        ToolCheck(name = "daspkg.exe/install-build-example", argv <- ["@EXE:daspkg@", "install", "--root", "examples/daspkg/daspkg-build-example", "--no-color"],
+            want <- ["Installed 'daspkg-example-c' (local)", "Installed 'daspkg-example-cpp' (local)"], network = true, timeout = 600.0),
+        ToolCheck(name = "daspkg.exe/run-build-example", argv <- ["@DASLANG@", "examples/daspkg/daspkg-build-example/main.das"],
+            want <- ["fast_inv_sqrt(4.0) = 0.49915358", "counter(step=5), 2x increment = 10"], network = true),
+    ]
+    // teardown - the example dirs go back to shipped state
+    rows |> reserve(length(rows) + 4)
+    for (root in ["examples/games/sequence", "examples/daspkg/daspkg-example", "examples/telegram/echo-bot", "examples/daspkg/daspkg-build-example"]) {
+        rows |> emplace(ToolCheck(name = "daspkg.exe/cleanup:{root}", argv <- ["@EXE:daspkg@", "cleanup", "--force", "--root", root, "--no-color"], network = true))
+    }
+    return <- rows
+}
+
+def public substitute(argv : array<string>; daslang, bundle, out_dir : string) : array<string> {
+    var res : array<string>
+    res |> reserve(length(argv))
+    for (a in argv) {
+        if (a == "@DASLANG@") {
+            res |> push(daslang)
+        } elif (a |> starts_with("@EXE:")) {
+            let name = slice(a, 5, length(a) - 1)
+            res |> push(bundle_exe(bundle, name))
+        } else {
+            res |> push(replace(a, "@OUT@", out_dir))
+        }
+    }
+    return <- res
+}
+
+//! bin/<name>.exe if present (every `daslang -exe` tool, and all Windows exes), else bin/<name>.
+def public bundle_exe(bundle, name : string) : string {
+    for (candidate in ["bin/{name}.exe", "bin/{name}"]) {
+        let p = path_join(bundle, candidate)
+        if (fexist(p)) {
+            return get_full_file_name(p)
+        }
+    }
+    return get_full_file_name(path_join(bundle, "bin/{name}"))   // missing: the launch fails loudly
+}
+
+//! "" when the output satisfies the row, else the first unmet expectation - the FAIL head.
+def public unmet(check : ToolCheck; out : string) : string {
+    for (e in check.want) {
+        if (find(out, e) < 0) {
+            return "expected `{e}` in output"
+        }
+    }
+    let anchored = "\n{out}"
+    for (r in check.forbid) {
+        if (find(anchored, r) >= 0) {
+            return "unexpected `{strip(r)}` in output"
+        }
+    }
+    return ""
+}
+
+//! Runs the rows in order from the bundle root; verdict lines in classify's shape.
+def public run_utils_checks(bundle, daslang : string; network : bool; only : string) : array<string> {
+    var verdicts : array<string>
+    let tmp = create_temp_directory_result("test_release_utils")
+    let out_dir = tmp is value ? to_generic_path(tmp as value) : ""
+    if (empty(out_dir)) {
+        verdicts |> push("FAIL utils/scratch rc=2 cannot create a scratch directory")
+        return <- verdicts
+    }
+    var inscope rows <- utils_checks()
+    for (check in rows) {
+        continue if ((!empty(only) && find(check.name, only) < 0) || (check.network && !network))
+        if (!empty(check.copy_from)) {
+            let src = path_join(bundle, check.copy_from)
+            fwrite(path_join(out_dir, base_name(src)), fread(src))
+        }
+        var inscope argv <- substitute(check.argv, daslang, bundle, out_dir)
+        let t0 = ref_time_ticks()
+        var out : string
+        var rc = run_and_capture(argv, out, check.timeout)
+        let sec = float(get_time_usec(t0)) / 1000000.0
+        var head = out
+        if (rc == 0) {
+            let miss = unmet(check, out)
+            if (!empty(miss)) {
+                rc = 1
+                head = miss
+            }
+        }
+        verdicts |> push(verdict_line(check.name, rc, sec, check.timeout, head))
+    }
+    rmdir_rec(out_dir)
+    return <- verdicts
+}

--- a/utils/internal/test-release/utils_phase.das
+++ b/utils/internal/test-release/utils_phase.das
@@ -5,10 +5,8 @@ require daslib/strings_boost
 require daslib/fio
 require classify
 
-// Phase `utils`: every shipped tool exercised in its capacity, from the bundle alone -
-// the shipped suites through the shipped runner, one real invocation per exe with an
-// oracle a machine can check, and (with --network) daspkg installing the packages the
-// gated examples need. Rows are the verified command lines from the RC1 utils audit.
+// Phase `utils`: every shipped tool exercised from the bundle alone.
+// Row = argv + substring oracle; --network rows fetch packages and mutate example dirs.
 
 struct ToolCheck {
     name : string           //! verdict key, e.g. "lint.exe/daslib"
@@ -23,8 +21,7 @@ struct ToolCheck {
 let private DASTEST_OK <- ["0 failed, 0 errors, 0 skipped"]
 let private DASTEST_EMPTY <- ["\n0 tests,"]
 
-//! The bundle-relative suites the in-tree run_utils_tests target runs - through the
-//! script-form runner, which the exe-form row (dastest.exe) then has to match.
+// the bundle-relative suites the in-tree run_utils_tests target runs, through the script-form runner
 def private suite_row(name, dir : string; extra_argv : array<string>) : ToolCheck {
     var argv <- ["@DASLANG@"]
     argv |> push_from(extra_argv, ["dastest/dastest.das", "--", "--test", dir])
@@ -39,7 +36,7 @@ def public utils_checks() : array<ToolCheck> {
         <- suite_row("dastest/dascov-suite", "utils/dascov/tests", []),
         <- suite_row("dastest/find-dupe-suite", "utils/find-dupe/tests", []),
         <- suite_row("dastest/jobque-timeline-suite", "utils/jobque-timeline", ["-project_root", "utils/jobque-timeline"]),
-        // the exe form must be able to compile a test at all (RC1: frozen build-machine paths)
+        // the exe form must be able to compile a test at all: an -exe tool bakes its build machine's native paths
         ToolCheck(name = "dastest.exe/common-suite", argv <- ["@EXE:dastest@", "--test", "utils/common/tests"],
             want := DASTEST_OK, forbid := DASTEST_EMPTY, timeout = 300.0),
         ToolCheck(name = "gen1_to_gen2/self-tests", argv <- ["@EXE:gen1_to_gen2@", "--tests"]),
@@ -90,7 +87,7 @@ def public utils_checks() : array<ToolCheck> {
         ToolCheck(name = "daspkg.exe/run-build-example", argv <- ["@DASLANG@", "examples/daspkg/daspkg-build-example/main.das"],
             want <- ["fast_inv_sqrt(4.0) = 0.49915358", "counter(step=5), 2x increment = 10"], network = true),
     ]
-    // teardown - the example dirs go back to shipped state
+    // rows run in order - the daspkg cleanup rows must stay last
     rows |> reserve(length(rows) + 4)
     for (root in ["examples/games/sequence", "examples/daspkg/daspkg-example", "examples/telegram/echo-bot", "examples/daspkg/daspkg-build-example"]) {
         rows |> emplace(ToolCheck(name = "daspkg.exe/cleanup:{root}", argv <- ["@EXE:daspkg@", "cleanup", "--force", "--root", root, "--no-color"], network = true))
@@ -98,7 +95,7 @@ def public utils_checks() : array<ToolCheck> {
     return <- rows
 }
 
-def public substitute(argv : array<string>; daslang, bundle, out_dir : string) : array<string> {
+def public substitute_tokens(argv : array<string>; daslang, bundle, out_dir : string) : array<string> {
     var res : array<string>
     res |> reserve(length(argv))
     for (a in argv) {
@@ -125,6 +122,20 @@ def public bundle_exe(bundle, name : string) : string {
     return get_full_file_name(path_join(bundle, "bin/{name}"))   // missing: the launch fails loudly
 }
 
+//! An exit code of 0 is only a pass when the oracle holds: 1 with the unmet expectation
+//! as the FAIL head otherwise. Non-zero exits keep their code and the child's output.
+def public judged_rc(check : ToolCheck; rc : int; out : string) : int {
+    return rc == 0 && !empty(unmet(check, out)) ? 1 : rc
+}
+
+def public judged_head(check : ToolCheck; rc : int; out : string) : string {
+    if (rc != 0) {
+        return out
+    }
+    let miss = unmet(check, out)
+    return empty(miss) ? out : miss
+}
+
 //! "" when the output satisfies the row, else the first unmet expectation - the FAIL head.
 def public unmet(check : ToolCheck; out : string) : string {
     for (e in check.want) {
@@ -142,7 +153,7 @@ def public unmet(check : ToolCheck; out : string) : string {
 }
 
 //! Runs the rows in order from the bundle root; verdict lines in classify's shape.
-def public run_utils_checks(bundle, daslang : string; network : bool; only : string) : array<string> {
+def public run_utils_checks(bundle, daslang : string; network : bool; name_filter : string) : array<string> {
     var verdicts : array<string>
     let tmp = create_temp_directory_result("test_release_utils")
     let out_dir = tmp is value ? to_generic_path(tmp as value) : ""
@@ -152,25 +163,17 @@ def public run_utils_checks(bundle, daslang : string; network : bool; only : str
     }
     var inscope rows <- utils_checks()
     for (check in rows) {
-        continue if ((!empty(only) && find(check.name, only) < 0) || (check.network && !network))
+        continue if ((!empty(name_filter) && find(check.name, name_filter) < 0) || (check.network && !network))
         if (!empty(check.copy_from)) {
             let src = path_join(bundle, check.copy_from)
             fwrite(path_join(out_dir, base_name(src)), fread(src))
         }
-        var inscope argv <- substitute(check.argv, daslang, bundle, out_dir)
+        var inscope argv <- substitute_tokens(check.argv, daslang, bundle, out_dir)
         let t0 = ref_time_ticks()
         var out : string
-        var rc = run_and_capture(argv, out, check.timeout)
+        let rc = run_and_capture(argv, out, check.timeout)
         let sec = float(get_time_usec(t0)) / 1000000.0
-        var head = out
-        if (rc == 0) {
-            let miss = unmet(check, out)
-            if (!empty(miss)) {
-                rc = 1
-                head = miss
-            }
-        }
-        verdicts |> push(verdict_line(check.name, rc, sec, check.timeout, head))
+        verdicts |> push(verdict_line(check.name, judged_rc(check, rc, out), sec, check.timeout, judged_head(check, rc, out)))
     }
     rmdir_rec(out_dir)
     return <- verdicts


### PR DESCRIPTION
**The release-audit runner (`utils/internal/test-release`), now with a `utils` phase: every shipped tool exercised from the extracted bundle alone.** Boris's ladder rung 2 ("tools awesome — each shipped tool exercised in its capacity from the bundle") — examples/tutorials were already the compile phase; nothing had ever run a shipped tool past `--help`, which is how RC1 shipped `dastest.exe` dead on all three OSes (#3781) and on Linux/mac twice over (#3779).

`utils_phase.das` carries the verified command lines from a four-agent audit of the RC1 Windows bundle (53 rows over 15 tools). Offline rows: the five shipped suites through the shipped runner (`utils/{common,lint,dascov,find-dupe,jobque-timeline}`), then `bin/dastest.exe` on one of them; `lint.exe` and `das-fmt --verify` over the shipped `daslib` (`0 issue(s), 0 error(s)` with no `skipped`, `Verified!`); `detect-dupe` on its shipped fixture (`functions analyzed: 9 / exact clusters: 2 / fuzzy pairs: 1`, pinned by its own suite), `dascov` on its test script, `benchctl` reset/query, `aot` emitting `hello_world`; the LSP subtools on the MCP fixtures; `daslang-live` on `examples/daslive/test_api`. `--network` adds `daspkg`: install → prove the unlock (compile or run the example) → `daspkg cleanup`, for sequence (das-cards), the daspkg tutorial projects (git + local C/C++ builds), telegram. Every row is exit code **plus** substrings only a working run prints — `judged_rc` turns an exit 0 with the oracle unmet into a failure — through the same expected-list machinery as the compile phase (`expected_utils.txt`: the two SHIP-DEFECT rows behind #3781, which the stale-expected check will red the moment that merges).

Also in this PR: the compile phase itself (previously only on the branch — 803 targets, project-aware retry, `expected_compile.txt` = the lesson tier), `--phase compile|utils|all`, `--only`, a MAX_PATH warning for deep bundle paths on Windows, README, and the fixture suite (`test_classify.das`, `test_utils_phase.das`) wired into `run_utils_tests`.

Where to look: `utils/internal/test-release/utils_phase.das` (the row table, `substitute_tokens`, `judged_rc`), `main.das` (phase dispatch), `README.md`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- RC1 Windows bundle, offline: **22 ok, 2 expected-fail (SHIP-DEFECT #3781), 0 unexpected**, 54 s. Same on the short-path copy after the review-round refactor.
- `--network` at a short path (`C:\dl\b`): **13/13** (four installs, four unlocks, cleanup); at the 147-char scratch path the git index clone fails with "Filename too long" — hence the MAX_PATH warning.
- Compile phase (from the branch's earlier validation): 784 ok / 33 expected / 0 unexpected / 0 stale on the fixed local bundle.
- Fixture tests 8/8 (token substitution incl. `@EXE:` through a staged bundle, `.exe`-before-bare order, anchored forbids — `10 tests` must not trip `\n0 tests`, `judged_rc`/`judged_head`, verdict lines, expected-list round trip, summarize buckets, row well-formedness); lint 0/0 on the four `.das`, `das-fmt --verify` clean.
- Audits: review-md on `utils/REVIEW.md` (compliant; found the suite unwired → fixed; 2 self-review findings on the checklist itself, ledgered), style-hygiene applied, tdd/Opus applied (see the commit).

### Claims — stated, not tested
- Linux/macOS runs of the utils phase: not run here (Windows box); the rows are OS-neutral (bundle-relative argv, `@EXE:` resolves `.exe` or bare).
- The MCP/LSP stdio round-trips (initialize → tools/call) are **not** rows: `fio` has no stdin-capable `popen`; the bundle smoke keeps the empty-stdin MCP launch. Ledgered as a follow-up (a `run_and_capture_input` in `fio`).

### Not done (ledgered — the audit's defect harvest, separate PRs)
- `utils/mcp/test_tools.das` from a bundle: 23/424 fail on repo-only paths, 279 s, rewrites a shipped fixture in place — not a row until gated/split.
- Bundle lacks `modules/dasImgui/src` + vendored `imgui/` headers → `dasImguiImplot`/`dasImguiNodeEditor` unbuildable, so `sfx_lab`/`node-editor` stay gated (ruling: ship the headers or re-tier).
- `fix-lint-errors` applies default-off STYLE005; `daspkg search` exits 0 on index failure; `dascov`/`benchctl` exe forms need an undocumented leading `--`; `[daslang atexit] FATAL: g_envTotal=1` on every non-zero `-exe` exit; MCP server logs into cwd; benchctl / jobque-timeline ship no consumable fixture; assorted README lies.
- The dasLLAMA train is its own arc.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
