### PR TITLE
site: canonicalize public URLs

### DIFF
--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -238,11 +238,13 @@ def make_md():
 
 # ─── Page rendering ──────────────────────────────────────────────────
 
-def render_template(tpl: str, root: str, title: str, body: str, description: str = '') -> str:
+def render_template(tpl: str, root: str, title: str, body: str,
+                    canonical: str, description: str = '') -> str:
     return (tpl
         .replace('{{root}}', root)
         .replace('{{title}}', html.escape(title))
         .replace('{{description}}', html.escape(description or title))
+        .replace('{{canonical}}', html.escape(canonical, quote=True))
         .replace('{{body}}', body))
 
 
@@ -506,6 +508,7 @@ def main():
         next_ = posts[i + 1] if i + 1 < len(posts) else None
         body = render_post(p, prev_, next_, md, posts_by_slug)
         html_out = render_template(tpl, root='../', title=p.title, body=body,
+                                   canonical=f'{args.site_url}/blog/{p.slug}.html',
                                    description=(p.excerpt_md[:160] if p.excerpt_md else p.title))
         (out / 'blog' / f'{p.slug}.html').write_text(html_out, encoding='utf-8')
 
@@ -513,6 +516,7 @@ def main():
     index_body = render_index(posts, md)
     (out / 'blog' / 'index.html').write_text(
         render_template(tpl, root='../', title='Blog', body=index_body,
+                        canonical=f'{args.site_url}/blog/',
                         description='Daslang blog — design notes, refactor stories, releases.'),
         encoding='utf-8')
 
@@ -529,6 +533,7 @@ def main():
             if n.has_body:
                 body = render_news_page(n, md)
                 html_out = render_template(tpl, root='../', title=n.title, body=body,
+                                           canonical=f'{args.site_url}/news/{n.slug}.html',
                                            description=n.title)
                 (out / 'news' / f'{n.slug}.html').write_text(html_out, encoding='utf-8')
 
@@ -537,6 +542,7 @@ def main():
     (out / 'changelist.html').write_text(
         render_template(tpl, root='', title='Change list',
                         body=changelist_body,
+                        canonical=f'{args.site_url}/changelist.html',
                         description='Releases, tooling, and ecosystem updates.'),
         encoding='utf-8')
 

--- a/site/blog/template.html
+++ b/site/blog/template.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{title}} — Daslang</title>
     <meta name="description" content="{{description}}" />
+    <link rel="canonical" href="{{canonical}}" />
     <link rel="icon" type="image/svg+xml" href="{{root}}files/daslang-favicon.svg" />
     <link rel="alternate icon" type="image/x-icon" href="{{root}}files/daslang.ico" />
     <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="{{root}}blog/feed.xml" />
@@ -34,18 +35,18 @@
     <nav class="forge-nav">
         <div class="forge-container forge-nav__inner">
             <div class="forge-nav__left">
-                <a class="forge-mark" href="{{root}}index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
                     <a href="{{root}}doc/index.html">docs</a>
-                    <a href="{{root}}playground/index.html">playground</a>
+                    <a href="/playground/">playground</a>
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="{{root}}index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                            <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                             <a href="{{root}}dasllama.html"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">CPU LLM + speech-to-text, das vs llama.cpp.</span></a>
                         </div>
                     </div>
@@ -60,8 +61,8 @@
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="{{root}}blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                            <a href="{{root}}index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                            <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                            <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                             <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                             <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                             <a href="{{root}}changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>
@@ -84,7 +85,7 @@
     <footer class="forge-footer">
         <div class="forge-container forge-footer__grid">
             <div>
-                <a class="forge-mark" href="{{root}}index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
@@ -98,11 +99,11 @@
                 <div class="forge-footer__col-head">learn</div>
                 <a class="forge-footer__link" href="{{root}}doc/index.html">introduction</a>
                 <a class="forge-footer__link" href="{{root}}doc/reference/index.html">reference</a>
-                <a class="forge-footer__link" href="{{root}}blog/index.html">blog</a>
+                <a class="forge-footer__link" href="/blog/">blog</a>
             </div>
             <div>
                 <div class="forge-footer__col-head">ecosystem</div>
-                <a class="forge-footer__link" href="{{root}}playground/index.html">playground</a>
+                <a class="forge-footer__link" href="/playground/">playground</a>
                 <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
                 <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
                 <a class="forge-footer__link" href="https://github.com/imp5imp5/dasbox">dasbox · game framework</a>

--- a/site/dasllama.html
+++ b/site/dasllama.html
@@ -205,18 +205,18 @@
     <nav class="forge-nav">
         <div class="forge-container forge-nav__inner">
             <div class="forge-nav__left">
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
                     <a href="doc/index.html">docs</a>
-                    <a href="playground/index.html">playground</a>
+                    <a href="/playground/">playground</a>
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                            <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                             <a href="dasllama.html" class="is-active"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">LLM + speech-to-text, das vs llama.cpp.</span></a>
                         </div>
                     </div>
@@ -231,8 +231,8 @@
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                            <a href="index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                            <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                            <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                             <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                             <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                             <a href="changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>
@@ -424,7 +424,7 @@ def main() {
     <footer class="forge-footer">
         <div class="forge-container forge-footer__grid">
             <div>
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
@@ -436,13 +436,13 @@ def main() {
             </div>
             <div>
                 <div class="forge-footer__col-head">performance</div>
-                <a class="forge-footer__link" href="index.html#benchmarks">benchmarks</a>
+                <a class="forge-footer__link" href="/#benchmarks">benchmarks</a>
                 <a class="forge-footer__link" href="dasllama.html">dasLLAMA</a>
             </div>
             <div>
                 <div class="forge-footer__col-head">ecosystem</div>
                 <a class="forge-footer__link" href="daspkg.html">daspkg · package index</a>
-                <a class="forge-footer__link" href="playground/index.html">playground</a>
+                <a class="forge-footer__link" href="/playground/">playground</a>
                 <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
                 <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
             </div>

--- a/site/daspkg.html
+++ b/site/daspkg.html
@@ -6,6 +6,7 @@
     <title>daspkg — Daslang package manager</title>
     <meta name="description" content="The daslang package index. Bindings, bots, batteries — one daspkg install away. Rendered straight from the open daspkg-index repo." />
     <meta name="keywords" content="daslang, daspkg, package manager, daslang packages, bindings" />
+    <link rel="canonical" href="https://daslang.io/daspkg.html" />
 
     <link rel="icon" type="image/svg+xml" href="files/daslang-favicon.svg" />
     <link rel="alternate icon" type="image/x-icon" href="files/daslang.ico" />
@@ -33,18 +34,18 @@
     <nav class="forge-nav">
         <div class="forge-container forge-nav__inner">
             <div class="forge-nav__left">
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
                     <a href="doc/index.html">docs</a>
-                    <a href="playground/index.html">playground</a>
+                    <a href="/playground/">playground</a>
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                            <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                             <a href="dasllama.html"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">CPU LLM + speech-to-text, das vs llama.cpp.</span></a>
                         </div>
                     </div>
@@ -59,8 +60,8 @@
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                            <a href="index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                            <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                            <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                             <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                             <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                             <a href="changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>
@@ -147,7 +148,7 @@
     <footer class="forge-footer">
         <div class="forge-container forge-footer__grid">
             <div>
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
@@ -161,12 +162,12 @@
                 <div class="forge-footer__col-head">learn</div>
                 <a class="forge-footer__link" href="doc/index.html">introduction</a>
                 <a class="forge-footer__link" href="doc/reference/index.html">reference</a>
-                <a class="forge-footer__link" href="blog/index.html">blog</a>
+                <a class="forge-footer__link" href="/blog/">blog</a>
             </div>
             <div>
                 <div class="forge-footer__col-head">ecosystem</div>
                 <a class="forge-footer__link" href="daspkg.html">daspkg · package index</a>
-                <a class="forge-footer__link" href="playground/index.html">playground</a>
+                <a class="forge-footer__link" href="/playground/">playground</a>
                 <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
                 <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
             </div>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -6,6 +6,7 @@
     <title>Downloads — Daslang</title>
     <meta name="description" content="Daslang releases, repository, blog, and ecosystem links." />
 
+    <link rel="canonical" href="https://daslang.io/downloads.html" />
     <link rel="icon" type="image/svg+xml" href="files/daslang-favicon.svg" />
     <link rel="alternate icon" type="image/x-icon" href="files/daslang.ico" />
     <link rel="alternate" type="application/atom+xml" title="Daslang blog" href="blog/feed.xml" />
@@ -31,18 +32,18 @@
     <nav class="forge-nav">
         <div class="forge-container forge-nav__inner">
             <div class="forge-nav__left">
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
                     <a href="doc/index.html">docs</a>
-                    <a href="playground/index.html">playground</a>
+                    <a href="/playground/">playground</a>
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                            <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                             <a href="dasllama.html"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">CPU LLM + speech-to-text, das vs llama.cpp.</span></a>
                         </div>
                     </div>
@@ -57,8 +58,8 @@
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                            <a href="index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                            <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                            <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                             <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                             <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                             <a href="changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>
@@ -148,7 +149,7 @@
                     <div class="forge-feature__kicker">playground</div>
                     <div class="forge-feature__title">daslang.io/playground</div>
                     <div class="forge-feature__body">Run daslang in your browser via WebAssembly. Multi-file workspace, sample picker.
-                        <br /><a class="forge-link-amber" style="margin-top:10px" href="playground/index.html">open playground →</a>
+                        <br /><a class="forge-link-amber" style="margin-top:10px" href="/playground/">open playground →</a>
                     </div>
                 </div>
                 <div class="forge-feature">
@@ -178,7 +179,7 @@
                     <div class="forge-news__row">
                         <div class="forge-news__date">blog</div>
                         <div class="forge-news__tag">en</div>
-                        <div class="forge-news__title"><a href="blog/index.html">Boris Batkin — the daslang blog</a></div>
+                        <div class="forge-news__title"><a href="/blog/">Boris Batkin — the daslang blog</a></div>
                     </div>
                     <div class="forge-news__row">
                         <div class="forge-news__date">blog</div>
@@ -203,7 +204,7 @@
     <footer class="forge-footer">
         <div class="forge-container forge-footer__grid">
             <div>
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
@@ -217,11 +218,11 @@
                 <div class="forge-footer__col-head">learn</div>
                 <a class="forge-footer__link" href="doc/index.html">introduction</a>
                 <a class="forge-footer__link" href="doc/reference/index.html">reference</a>
-                <a class="forge-footer__link" href="blog/index.html">blog</a>
+                <a class="forge-footer__link" href="/blog/">blog</a>
             </div>
             <div>
                 <div class="forge-footer__col-head">ecosystem</div>
-                <a class="forge-footer__link" href="playground/index.html">playground</a>
+                <a class="forge-footer__link" href="/playground/">playground</a>
                 <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
                 <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
                 <a class="forge-footer__link" href="https://github.com/imp5imp5/dasbox">dasbox · game framework</a>

--- a/site/examples.html
+++ b/site/examples.html
@@ -6,6 +6,7 @@
     <title>examples — Daslang, compiled to WebAssembly</title>
     <meta name="description" content="Real daslang applications compiled to WebAssembly and running in your browser — no install, no plugin. Click a card to launch it. Every example ships its full source." />
     <meta name="keywords" content="daslang, examples, webassembly, wasm, games, arkanoid, pac-man, fourier, imgui, path tracer, ray tracing, jobque, threads, opengl, gpu, physarum, slime mold, agents, audio, strudel, demos" />
+    <link rel="canonical" href="https://daslang.io/examples.html" />
 
     <!-- Cross-origin isolation for the threaded (-pthread) wasm examples. Must run
          before anything else so the one-time reload happens up front. Self-registers
@@ -38,18 +39,18 @@
     <nav class="forge-nav">
         <div class="forge-container forge-nav__inner">
             <div class="forge-nav__left">
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
                 </a>
                 <div class="forge-nav__links">
                     <a href="doc/index.html">docs</a>
-                    <a href="playground/index.html">playground</a>
+                    <a href="/playground/">playground</a>
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                            <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                             <a href="dasllama.html"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">CPU LLM + speech-to-text, das vs llama.cpp.</span></a>
                         </div>
                     </div>
@@ -64,8 +65,8 @@
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                            <a href="index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                            <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                            <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                             <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                             <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                             <a href="changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>
@@ -109,7 +110,7 @@
     <footer class="forge-footer">
         <div class="forge-container forge-footer__grid">
             <div>
-                <a class="forge-mark" href="index.html">
+                <a class="forge-mark" href="/">
                     <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                     <span>daslang</span>
                     <span class="forge-mark__tld">.io</span>
@@ -123,12 +124,12 @@
                 <div class="forge-footer__col-head">learn</div>
                 <a class="forge-footer__link" href="doc/index.html">introduction</a>
                 <a class="forge-footer__link" href="doc/reference/index.html">reference</a>
-                <a class="forge-footer__link" href="blog/index.html">blog</a>
+                <a class="forge-footer__link" href="/blog/">blog</a>
             </div>
             <div>
                 <div class="forge-footer__col-head">ecosystem</div>
                 <a class="forge-footer__link" href="daspkg.html">daspkg · package index</a>
-                <a class="forge-footer__link" href="playground/index.html">playground</a>
+                <a class="forge-footer__link" href="/playground/">playground</a>
                 <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
                 <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
             </div>

--- a/site/files/examples.js
+++ b/site/files/examples.js
@@ -103,7 +103,7 @@
         // interpreter now hosts them in the playground. A plain (non-wasm64-only) sample
         // defaults to its id; a wasm64-only card with no slug has no playground link.
         var pgSlug = ex.playgroundSlug || (ex.wasm64Only ? null : ex.id);
-        ex.playgroundUrl = pgSlug ? ('playground/index.html?example=' + pgSlug) : null;
+        ex.playgroundUrl = pgSlug ? ('/playground/?example=' + pgSlug) : null;
     });
 
     // ─── wasm64 (memory64) feature detection ────────────────────────────

--- a/site/files/forge.js
+++ b/site/files/forge.js
@@ -174,7 +174,7 @@ def main() {
         btn.addEventListener('click', () => {
             const code = heroEditor ? heroEditor.getValue() : '';
             const url = '/playground/#code=' + encodeURIComponent(code);
-            window.open(url, '_blank');
+            window.open(url, '_blank', 'noopener');
         });
     }
 

--- a/site/files/forge.js
+++ b/site/files/forge.js
@@ -173,7 +173,7 @@ def main() {
         if (!btn) return;
         btn.addEventListener('click', () => {
             const code = heroEditor ? heroEditor.getValue() : '';
-            const url = 'playground/index.html#code=' + encodeURIComponent(code);
+            const url = '/playground/#code=' + encodeURIComponent(code);
             window.open(url, '_blank');
         });
     }
@@ -507,7 +507,7 @@ def main() {
         if (!el) return;
         const slug = BENCH_TO_SLUG[benchBm];
         el.innerHTML = slug
-            ? `<a href="/playground/index.html?example=${encodeURIComponent(slug)}">try <span class="forge-bench__playground-test">${escapeHtml(benchBm)}</span> on the playground →</a>`
+            ? `<a href="/playground/?example=${encodeURIComponent(slug)}">try <span class="forge-bench__playground-test">${escapeHtml(benchBm)}</span> on the playground →</a>`
             : '';
     }
 

--- a/site/index.html
+++ b/site/index.html
@@ -9,6 +9,7 @@
     <title>Daslang — High-performance code that stands alone.</title>
     <meta name="description" content="Daslang is a strong, statically-typed programming language with three execution tiers — interpreter, AOT to C++, JIT via LLVM. Embed it in your C++ engine, or build a standalone application end-to-end." />
     <meta name="keywords" content="daslang, daScript, programming language, game development, JIT, AOT, C++ scripting" />
+    <link rel="canonical" href="https://daslang.io/" />
 
     <!-- Algolia Crawler domain verification (DocSearch) -->
     <meta name="algolia-site-verification" content="5E2859D3649D63BC" />
@@ -51,7 +52,7 @@
                 </a>
                 <div class="forge-nav__links">
                     <a href="doc/index.html">docs</a>
-                    <a href="playground/index.html">playground</a>
+                    <a href="/playground/">playground</a>
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
@@ -70,7 +71,7 @@
                     <div class="forge-nav__group">
                         <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                         <div class="forge-nav__menu">
-                            <a href="blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                            <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
                             <a href="#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                             <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                             <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
@@ -453,11 +454,11 @@ def main() {
                 <a class="forge-footer__link" href="doc/index.html">introduction</a>
                 <a class="forge-footer__link" href="doc/reference/index.html">reference</a>
                 <a class="forge-footer__link" href="doc/reference/design_philosophy.html">design philosophy</a>
-                <a class="forge-footer__link" href="blog/index.html">blog</a>
+                <a class="forge-footer__link" href="/blog/">blog</a>
             </div>
             <div>
                 <div class="forge-footer__col-head">ecosystem</div>
-                <a class="forge-footer__link" href="playground/index.html">playground</a>
+                <a class="forge-footer__link" href="/playground/">playground</a>
                 <a class="forge-footer__link" href="https://edenspark.io">edenspark · games on daslang</a>
                 <a class="forge-footer__link" href="https://github.com/profelis/daScript-plugin">vs code extension</a>
                 <a class="forge-footer__link" href="https://github.com/imp5imp5/dasbox">dasbox · game framework</a>

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -9,6 +9,8 @@
     <!-- Cross-origin isolation so threaded (-pthread) wasm can run here. Must run
          before anything else so the one-time reload happens up front. Self-registers
          only on memory64 engines; scoped to /examples* + /playground* (see the file). -->
+    <link rel="canonical" href="https://daslang.io/playground/" />
+
     <script src="/coi-serviceworker.js"></script>
 
     <link rel="icon" type="image/svg+xml" href="../files/daslang-favicon.svg" />
@@ -52,18 +54,18 @@
 <nav class="forge-nav">
     <div class="forge-container forge-nav__inner">
         <div class="forge-nav__left">
-            <a class="forge-mark" href="../index.html">
+            <a class="forge-mark" href="/">
                 <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                 <span>daslang</span>
                 <span class="forge-mark__tld">.io</span>
             </a>
             <div class="forge-nav__links">
                 <a href="../doc/index.html">docs</a>
-                <a href="../playground/index.html" class="is-active">playground</a>
+                <a href="/playground/" class="is-active">playground</a>
                 <div class="forge-nav__group">
                     <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                     <div class="forge-nav__menu">
-                    <a href="../index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                    <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                     <a href="../dasllama.html"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">CPU LLM + speech-to-text, das vs llama.cpp.</span></a>
                     </div>
                 </div>
@@ -78,8 +80,8 @@
                 <div class="forge-nav__group">
                     <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                     <div class="forge-nav__menu">
-                    <a href="../blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                    <a href="../index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                    <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                    <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                     <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                     <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                     <a href="../changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>

--- a/site/playground/placeholder.html
+++ b/site/playground/placeholder.html
@@ -20,18 +20,18 @@
 <nav class="forge-nav">
     <div class="forge-container forge-nav__inner">
         <div class="forge-nav__left">
-            <a class="forge-mark" href="../index.html">
+            <a class="forge-mark" href="/">
                 <span class="forge-mark__glyph" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M 19,2 C 6.848484,12.699956 12.591844,7.4593088 6.8243462,13.056243 16.852307,10.274014 6.8079126,19.737584 5,22 L 17.120536,11.596175 C 6.7139271,14.121239 17.627482,3.775356 19,2 Z m -7,1 c -5,0 -9,4 -9,9 0,2.5 0.9875,4.80625 2.6875,6.40625 L 7.09375,17 C 5.79375,15.8 5,14 5,12 5,8.1 8.1,5 12,5 12.4,5 12.69375,4.99375 13.09375,5.09375 L 14.8125,3.40625 C 13.9125,3.20625 13,3 12,3 Z M 18.3125,5.59375 16.90625,7 C 18.20625,8.2 19,10 19,12 c 0,3.9 -3.1,7 -7,7 -0.4,0 -0.69375,0.0063 -1.09375,-0.09375 L 9.1875,20.59375 C 10.0875,20.79375 11,21 12,21 c 5,0 9,-4 9,-9 0,-2.5 -0.9875,-4.80625 -2.6875,-6.40625 z"/></svg></span>
                 <span>daslang</span>
                 <span class="forge-mark__tld">.io</span>
             </a>
             <div class="forge-nav__links">
                 <a href="../doc/index.html">docs</a>
-                <a href="../playground/index.html" class="is-active">playground</a>
+                <a href="/playground/" class="is-active">playground</a>
                 <div class="forge-nav__group">
                     <button class="forge-nav__trigger" type="button">performance <span class="forge-nav__chev">▾</span></button>
                     <div class="forge-nav__menu">
-                    <a href="../index.html#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
+                    <a href="/#benchmarks"><span class="forge-nav__menu-label">benchmarks</span><span class="forge-nav__menu-desc">Cross-language CPU speed — interpreter &amp; JIT.</span></a>
                     <a href="../dasllama.html"><span class="forge-nav__menu-label">dasLLAMA <span class="forge-nav__menu-new">NEW</span></span><span class="forge-nav__menu-desc">CPU LLM + speech-to-text, das vs llama.cpp.</span></a>
                     </div>
                 </div>
@@ -46,8 +46,8 @@
                 <div class="forge-nav__group">
                     <button class="forge-nav__trigger" type="button">community <span class="forge-nav__chev">▾</span></button>
                     <div class="forge-nav__menu">
-                    <a href="../blog/index.html"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
-                    <a href="../index.html#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
+                    <a href="/blog/"><span class="forge-nav__menu-label">blog</span><span class="forge-nav__menu-desc">Release notes &amp; deep dives.</span></a>
+                    <a href="/#news"><span class="forge-nav__menu-label">news</span><span class="forge-nav__menu-desc">Latest releases &amp; ecosystem activity.</span></a>
                     <a href="https://t.me/daScript"><span class="forge-nav__menu-label">telegram</span><span class="forge-nav__menu-desc">Chat with the daslang team.</span></a>
                     <a href="https://github.com/GaijinEntertainment/daScript"><span class="forge-nav__menu-label">github</span><span class="forge-nav__menu-desc">Source, issues &amp; releases.</span></a>
                     <a href="../changelist.html"><span class="forge-nav__menu-label">change list</span><span class="forge-nav__menu-desc">Every release, version by version.</span></a>
@@ -79,7 +79,7 @@
         master kicks off a fresh build — usually a few minutes.
     </p>
     <div class="pg-mobile-notice__ctas">
-        <a class="pg-mobile-notice__btn" href="../index.html">← back to daslang.io</a>
+        <a class="pg-mobile-notice__btn" href="/">← back to daslang.io</a>
         <a class="pg-mobile-notice__btn pg-mobile-notice__btn--ghost" href="../downloads.html">downloads</a>
     </div>
 </div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -8,4 +8,6 @@
     <url><loc>https://daslang.io/downloads.html</loc></url>
     <url><loc>https://daslang.io/examples.html</loc></url>
     <url><loc>https://daslang.io/changelist.html</loc></url>
+    <url><loc>https://daslang.io/blog/</loc></url>
+    <url><loc>https://daslang.io/playground/</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add explicit canonical URLs to the primary static pages
- emit canonical metadata for generated blog, news, and changelist pages
- link internally to clean `/`, `/blog/`, and `/playground/` URL forms
- include the blog and playground canonical URLs in the root sitemap

## Why
Google Search Console correctly treats `www.daslang.io` as a redirecting alias, but the canonical site still exposed duplicate `index.html` URL forms without consistent user-selected canonicals. This gives Google avoidable duplicate URLs to consolidate and inflates indexing noise.

This change does not alter the existing `www` redirect or Caddy configuration. The normal `master` deployment publishes the metadata and link changes automatically.

## Verification
- generated 43 blog posts and 42 news entries successfully
- verified all 45 generated HTML pages contain exactly one absolute `https://daslang.io/` canonical
- `node --check site/files/forge.js`
- `node --check site/files/examples.js`
- `git diff --check origin/master...HEAD`