### PR TITLE
dasllama-ladder: sidecar operator surface + CSRF rebinding hardening

### DIFF
--- a/plans/dasllama_io_site.md
+++ b/plans/dasllama_io_site.md
@@ -144,6 +144,46 @@ there, out of scope here.
 real server — the current mock shows an interactive `[use/tune/skip]` prompt, which this
 spec removes, so the page gets rewritten to the real output.
 
+## Slice 8 — sidecar operator surface + official seeding (Boris, 2026-08-19)
+
+The board is live read-only with 220 official records and zero sidecars. Sidecars are the
+product, and the first ones must be planted by us — but "official sidecar" has no entry
+path: community submit stamps unverified, and the only promote lever (`admin.das
+verify-sidecar`) needs a daslang interpreter the deploy box does not ship. This slice adds
+the operator surface, then seeds.
+
+**Decisions:**
+
+- Promote/plant go through the RUNNING service (loopback admin routes), never a second
+  process on the WAL db. Store logic stays in `ladder_store`.
+- Operator UI is a loopback-served `/admin/` page reached via `ssh -L` tunnel from the
+  operator's own browser — no public exposure, `/admin/*` stays out of caddy.snippet
+  (the standing transport boundary). A CLI wrapper (deploy-script verbs) covers scripting;
+  both drive the same routes.
+- Browser-facing loopback routes REQUIRE a three-layer operator gate: loopback peer +
+  loopback Host + same-origin-or-headerless. Same-origin (Origin authority == Host, or no
+  Origin at all for curl) refuses a cross-origin fetch; the loopback-Host requirement refuses
+  DNS rebinding, which an Origin==Host check alone does NOT (a rebound name owns both). The
+  openai_server CSRF lesson plus the woodpecker's rebinding catch.
+- The three seed sidecars are FRESH mints at the current `DASLLAMA_VERSION` from current
+  master on each box (m1 / m4 / zen4) — sidecar validity keys on version × box, so
+  anything from earlier profiling sessions is stale by our own rule.
+
+**Build (one PR):** store `plant_sidecar` (trusted put + Verified=1, dedup re-plant
+promotes) + admin listing; routes `GET /admin/sidecars`, `POST /admin/sidecar/verify`,
+`POST /admin/sidecar/delete`, `POST /admin/import-sidecar`, `GET /admin/` (the page; the
+no-slash `/admin` serves it too);
+same-origin hardening on `is_loopback_caller`; `admin.html`; deploy verbs
+`sidecars`/`promote`/`demote`/`plant`; tests on the in-dir harness; README + REVIEW.md.
+
+**Rollout:** rebuild bundle from master on zen4 → `install` (box catches up, picks up the
+surface) → mint v-current sidecars on m1/m4/zen4 → `plant` ×3 → verified on the site →
+brief open-submit window: the control-page exchange-card submit from m1 lands unverified,
+promote it from `/admin/` — the full user story exercised end to end.
+
+**Not this slice:** records-submission promote UI (admin.das keeps that lever); the
+dasllama-server config UX pass (gguf-only picker, simple/advanced split) — its own arc.
+
 ## Follow-up ledger (documented, deliberately not this arc)
 
 - **Partial re-race** (tune framework, dasLLVM + dasllama tuner): per-family variant-set

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -2828,12 +2828,30 @@ def private is_loopback_req(req : HttpRequest?) : bool {
     // an unknown/empty peer counts as remote (fail closed, like the ladder's is_loopback_peer):
     // this service binds every interface, so a LAN caller must not slip through on an unresolved peer
     let loopback = ip == "127.0.0.1" || ip == "::1" || ip == "::ffff:127.0.0.1"
-    return loopback && same_origin_or_headerless(req)
+    return loopback && is_loopback_host(get_header(req, "Host")) && same_origin_or_headerless(req)
+}
+
+def private authority_host(authority : string) : string {
+    // the host of an authority (host / host:port / [v6]:port), lowercased
+    if (authority |> starts_with("[")) {
+        let close = find(authority, "]")
+        return close > 0 ? to_lower(slice(authority, 1, close)) : to_lower(authority)
+    }
+    let colon = find(authority, ":")
+    return to_lower(colon >= 0 ? slice(authority, 0, colon) : authority)
+}
+
+def private is_loopback_host(authority : string) : bool {
+    let host = authority_host(authority)
+    // same set as the peer check above, incl. the IPv4-mapped IPv6 loopback
+    return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "::ffff:127.0.0.1"
 }
 
 // CSRF guard for the operator routes: allow_cors() is global and the peer is 127.0.0.1 for ANY
-// local browser, so a page the operator merely visits could POST to the destructive routes. Accept
-// only a same-origin request (the control page is served from here) or a header-less CLI client.
+// local browser, so a page the operator merely visits could POST to the destructive routes. A
+// same-origin request (the control page is served from here) or a header-less CLI client passes;
+// the loopback-Host requirement above defeats DNS rebinding, which Origin==Host alone would not
+// (a rebound name owns both).
 def private same_origin_or_headerless(req : HttpRequest?) : bool {
     let origin = get_header(req, "Origin")
     if (empty(origin)) {

--- a/utils/dasllama-server/test_openai_server.das
+++ b/utils/dasllama-server/test_openai_server.das
@@ -397,6 +397,26 @@ def test_openai_server(t : T?) {   // nolint:STYLE038 — one live server sessio
             POST("{base_url}/config", "\{\"port\":\"eight\"}") $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
             }
+            // operator-route CSRF gate: a cross-site Origin is refused, and a spoofed non-loopback
+            // Host is refused header-less (the DNS-rebinding defense — Origin==Host alone would pass)
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/config"
+                set_header(req, "Origin", "http://evil.example")
+                req.body := "\{\"port\":8123}"
+                request(req) $(resp) {
+                    t |> equal(int(resp.status_code), int(http_status.FORBIDDEN), "cross-site /config refused")
+                }
+            }
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/config"
+                set_header(req, "Host", "evil.example:{TEST_PORT}")
+                req.body := "\{\"port\":8123}"
+                request(req) $(resp) {
+                    t |> equal(int(resp.status_code), int(http_status.FORBIDDEN), "rebound non-loopback Host refused")
+                }
+            }
             // /v1/streams — finished chat streams linger ~10 s with counters + text tails
             GET("{base_url}/v1/streams") $(resp) {
                 t |> equal(int(resp.status_code), int(http_status.OK))

--- a/utils/internal/dasllama-ladder/.das_package
+++ b/utils/internal/dasllama-ladder/.das_package
@@ -16,5 +16,6 @@ def release() {
     release_include_from("utils/watchdog/watchdog.py")
     release_include_if_missing("watchdog.json")        // carries the port + health/shutdown urls — an operator edit must survive upgrades
     release_include("admin.das")                       // operator curation CLI; run with a daslang SDK on the box
+    release_include("admin.html")                      // the loopback /admin/ operator page, served beside the sources
     release_include("caddy.snippet")                   // the public boundary, shipped beside the code so a route change reviews with it
 }

--- a/utils/internal/dasllama-ladder/README.md
+++ b/utils/internal/dasllama-ladder/README.md
@@ -12,7 +12,10 @@ change here is `REVIEW.md`.
 - `ladder_server.das` — the HTTP surface (routes, transport shape checks, official-dir import).
 - `ladder_store.das` — schema, migrations, and every policy decision (size caps, rate
   ceiling, source stamping, the sidecar lookup ladder). Zero HTTP.
-- `admin.das` — the operator CLI (verify/delete levers, manual official import; run on the box).
+- `admin.das` — the operator CLI (verify/delete levers, manual official/sidecar imports; needs
+  a daslang on the box — the HTTP admin surface below is the interpreter-free twin).
+- `admin.html` — the loopback `/admin/` operator page (sidecar queue, promote/demote/delete,
+  plant, the submit-gate toggle), served beside the sources like the dasllama-server control page.
 - `caddy.snippet` / `watchdog.json` / `dasllama-ladder.toml` — the deploy contract.
 - `_ladder_test_common.das` + `test_ladder_*.das` — fixtures and the three dastest suites
   (store, config, server; the server suite owns reserved port 19015).
@@ -26,8 +29,16 @@ Public (proxied by `caddy.snippet`): `GET /api/versions`, `GET /api/runs[?versio
 browse listing; absent/0 version = all), `GET /api/sidecars?version=N&box=<encoded>` (the
 lookup ladder — a `box` switches modes and then version is required), `GET /api/sidecar/:sha`
 (download), `POST /api/submit/records`, `POST /api/submit/sidecar`. Loopback-only:
-`POST /admin/import-official`, `POST /shutdown`, plus `GET /healthz` for the watchdog. The
-`box` query value must be percent-encoded — box strings carry `|`, `,` and spaces.
+`GET /admin/` (the operator page) + `GET /admin/sidecars` (its listing, gate state included),
+`POST /admin/sidecar/verify` / `POST /admin/sidecar/delete`, `POST /admin/import-sidecar`
+(plant official — stored verified; re-plant promotes), `POST /admin/import-official`,
+`POST /admin/submit` (the gate flip), `POST /shutdown`, plus `GET /healthz` for the watchdog.
+Operator callers pass a three-layer gate: a loopback peer, a loopback `Host` authority, and
+same-origin-or-header-less. The `Host` and `Origin` layers together are the CSRF guard for
+the `/admin/` page over an ssh tunnel — same-origin refuses a cross-origin fetch, and the
+loopback-`Host` requirement refuses DNS rebinding (a rebound hostname would satisfy an
+Origin-equals-Host check but still send its own non-loopback `Host`). The `box` query value
+must be percent-encoded — box strings carry `|`, `,` and spaces.
 
 ## 2. Data model
 
@@ -110,6 +121,15 @@ The board launches **read-only**: `submit_open` defaults false, so `/api/submit/
 until an operator opens it. Toggle for a test window over the loopback tunnel with
 `sudo dasllama-deploy.sh open-submit` / `close-submit`; the permanent open (after the security
 audit) is `submit_open = true` in the deployed toml, or the `--submit-open` boot flag.
+
+**Sidecar curation** has two equivalent operator surfaces, both driving the loopback admin
+routes. The browser one: `ssh -L 8201:127.0.0.1:8201 dasweb-1`, then open
+`http://localhost:8201/admin/` — the queue with promote/demote/delete, a plant picker, and
+the gate toggle. The scripted one: `dasllama-deploy.sh sidecars` / `promote <sha>` /
+`demote <sha>` / `plant <sidecar.json>` (plain curl wrappers — no root needed, they live in
+the deploy script only so the operator has one tool). Planting stores the sidecar verified;
+planting content that already exists promotes the existing row, so promote-by-content and
+promote-by-sha are both available.
 
 The official boards are the record stores under `modules/dasLLAMA/performance/records/`
 (not in the release). The site deploy (`.github/workflows/pages.yml`, after the dasllama.io

--- a/utils/internal/dasllama-ladder/REVIEW.md
+++ b/utils/internal/dasllama-ladder/REVIEW.md
@@ -21,21 +21,33 @@ creates; store tests run against `:memory:`.** A test writing into the repo tree
 **Operator routes (`/admin/*`, `/shutdown`) never appear in `caddy.snippet` — or in any
 Caddyfile route reaching this service, a catch-all included.** Caddy proxies from the same box,
 so `is_loopback_peer` sees `127.0.0.1` for every proxied request — the Caddyfile is the only
-real boundary.
+real boundary. Operators reach these routes on the service port itself, over the ssh tunnel;
+no Caddyfile entry exists for them.
+
+**`is_operator_caller` requires ALL THREE of a loopback transport peer, a loopback `Host`
+authority, and same-origin-or-headerless (the request carries no `Origin` header, or its
+`Origin` names the same authority as its `Host`), and every operator route gates through it.**
+Dropping any of the three, or gating an operator route on the peer alone, is a defect. The
+`Host` and `Origin` halves together are the CSRF guard for the `/admin/` page over an ssh
+tunnel: same-origin refuses a plain cross-origin fetch, and the loopback-`Host` requirement
+refuses DNS rebinding (comparing `Origin` to `Host` alone does not — a rebound name owns both).
 
 **`caddy.snippet` is the authoritative copy of the public route boundary: the deployed
 Caddyfile is edited to match it, never the reverse, and a route a public caller needs lands in
 it in the same change as its handler.**
 
-**Every route logs one `ladder.req` line through `log_request`, including refusals.** A
-response path that skips the log is a defect.
+**Every route that serves board data, mutates the store, or refuses a caller logs one
+`ladder.req` line through `log_request`, including the refusals.** A response path on such a
+route that skips the log is a defect. (The bare liveness probe `GET /healthz` serves no data
+and is silent by design.)
 
 **Every handler that consumes a request body checks `body_is_byte_faithful` before using the
 string view.** A body used without the NUL guard is a defect.
 
-**A handler does exactly four things — validate transport shape, gate the request (loopback,
-submit-open, attempt-limit), make one store call, format the response.** SQL, hashing, and
-store policy live in `ladder_store.das`, and HTTP never does — no `dashv` require there.
+**A store-backed handler does exactly four things — validate transport shape, gate the request
+(operator gate, submit-open, attempt-limit), make one store call, format the response.** SQL,
+hashing, and store policy live in `ladder_store.das`, and HTTP never does — no `dashv` require
+there. (The `/admin/` page and `/healthz` reach no store and are not store-backed handlers.)
 
 **Public submissions default closed: `submit_open` is false in both `LadderArgs` and
 `LadderPolicy`, the `/api/submit/sidecar` and `/api/submit/records` handlers return 403 while it
@@ -51,16 +63,21 @@ only dasLLAMA module required is the engine-free `dasllama/dasllama_exchange_sch
 entry of that module's facade lint), and only `ladder_store.das` requires it** (`README.md`
 §3). Its `dasllama_lint` carrier is a compile-time macro, not engine code.
 
-**Every community document passes `validate_record_submission` / `validate_sidecar_submission`
-before any row is written; `import_official_store` validates with `validate_record_store` /
-`validate_sidecar` (shape only).** A write path that skips validation is a defect.
+**Every sidecar document — community or planted — passes `validate_sidecar_submission` before
+any row is written (a sidecar without the version stamp can never be served, so storing one is
+always an error); every community record store passes `validate_record_submission`;
+`import_official_store` validates with `validate_record_store` (shape only — official record
+history predates the release counter).** A write path that skips validation is a defect.
 
-**`Source` and `Verified` are written only from store code.** A submitter-supplied value
-reaching either column is a defect.
+**`Source` and `Verified` are written only from store code, and no value from a public
+(proxied) request reaches either column.** The loopback operator surface chooses `Verified`
+by design — through store calls, never through SQL in a handler.
 
-**A community submission is privacy-cleaned before validation, hashing, and storage — the
-cleaned text IS the document: a sidecar through `exchange_strip_private`, a record store
-through `redact_record_paths`.** Official imports (the admin lever) are trusted as-is.
+**Every sidecar — community or planted — is privacy-cleaned through `exchange_strip_private`
+before validation, hashing, and storage, and a community record store through
+`redact_record_paths`; the cleaned text IS the document.** Hashing the cleaned text on both
+sidecar paths is what makes re-plant promote instead of duplicate. `import_official_store`
+alone stores its document as-is.
 
 **After insert a document is never mutated.** Derived columns may be recomputed; the document
 itself may only be inserted, or deleted with its submission.
@@ -82,7 +99,7 @@ nothing else** — a second command, a wildcard target, a bare `ALL`, or a shell
 `CapabilityBoundingSet`, `ReadWritePaths` limited to the data dir and the release tree). A diff
 that changes where the service or watchdog writes at runtime — log path, working directory,
 database location — without a matching `ReadWritePaths` entry is a defect; so is relaxing
-`ProtectSystem` or restoring a capability with no stated reason.
+`ProtectSystem` or restoring a capability.
 
 **Placement — one file, one line: a diff keeps each file inside its line, and a new file adds
 its line here, with its tests, in the same change.**
@@ -94,22 +111,27 @@ its line here, with its tests, in the same change.**
   per-key provenance, the startup banner payload. No HTTP, no SQL, no filesystem beyond
   reading the config file.
 - `ladder_server.das` — the `HvWebServer` class: route table and handlers — transport shape,
-  request gating, HTTP-to-one-store-call translation, response formatting. No SQL, no
-  hashing, no store policy.
+  request gating, HTTP-to-one-store-call translation, response formatting — plus the server
+  lifecycle (`init`/`update`/`shutdown`, the db open and migrate at boot), the official-dir
+  boot import, and serving `admin.html`. No SQL statements, no hashing, no store policy.
 - `ladder_store.das` — the store: schema structs, migrations, content hashing, and every
   policy decision (size caps, rate ceiling, source stamping, the sidecar lookup ladder).
   Zero HTTP.
 - `admin.das` — operator CLI: argv dispatch onto `ladder_store` calls. No store mutation that
   bypasses `ladder_store` functions.
+- `admin.html` — the loopback `/admin/` operator page: renders `GET /admin/sidecars`, drives
+  the sidecar verify/delete/import routes and the gate flip. No route of its own, no direct
+  db access, nothing public-facing.
 - `caddy.snippet` — the public route boundary's authoritative copy.
 - `.das_package` — the daspkg release manifest: package/release names and the
   `release_include*` set of operator files carried onto the box.
 - `dasllama-deploy.sh` — the box-side deploy tool (`provision`/`caddy`/`install`/
-  `open-submit`/`close-submit`/`status`), installed root-owned as the one privileged surface.
+  `open-submit`/`close-submit`/`sidecars`/`promote`/`demote`/`plant`/`status`), installed
+  root-owned as the one privileged surface.
 - `dasllama-deploy.sudoers` — the drop-in that scopes that privilege.
 - `dasllama-ladder.toml` — the shipped default config: the on-box template whose keys mirror
   `LadderArgs`; operator-edited after deploy.
-- `watchdog.json` — the watchdog deploy config (port, health and shutdown URLs);
+- `watchdog.json` — the watchdog deploy config (health and shutdown URLs);
   operator-edited after deploy.
-- `_ladder_test_common.das` — shared test fixtures, required by the `[test]` files by bare
-  name (the leading `_` keeps dastest's walker away).
+- `_ladder_test_common.das` — shared test fixtures, required by bare name from the store and
+  server suites (the leading `_` keeps dastest's walker away).

--- a/utils/internal/dasllama-ladder/admin.das
+++ b/utils/internal/dasllama-ladder/admin.das
@@ -16,13 +16,14 @@ require daslib/fio
 //   daslang admin.das -- --db ... --op unverify-submission --id <id>
 //   daslang admin.das -- --db ... --op delete-submission --id <id>
 //   daslang admin.das -- --db ... --op import-official --file records/m1.json
+//   daslang admin.das -- --db ... --op plant-sidecar --file box.tune.json
 
 [CommandLineArgs]
 struct AdminArgs {
     @clarg_doc = "SQLite database path"
     db : string = "/srv/dasllama-ladder/ladder.db"
 
-    @clarg_doc = "verify-sidecar | unverify-sidecar | delete-sidecar | verify-submission | unverify-submission | delete-submission | import-official"
+    @clarg_doc = "verify-sidecar | unverify-sidecar | delete-sidecar | verify-submission | unverify-submission | delete-submission | import-official | plant-sidecar"
     op : string = ""
 
     @clarg_doc = "Sidecar content sha (the *-sidecar ops)"
@@ -31,7 +32,7 @@ struct AdminArgs {
     @clarg_doc = "Submission id (the *-submission ops)"
     id : int = 0
 
-    @clarg_doc = "Record store path (import-official)"
+    @clarg_doc = "Document path (import-official record store; plant-sidecar sidecar)"
     file : string = ""
 
     @clarg_short = "?"
@@ -40,7 +41,7 @@ struct AdminArgs {
 }
 
 [export]
-def main : int {
+def main : int {   // nolint:STYLE037 (flat operator-verb dispatch — one arm per op is the shape)
     var r <- parse_args(type<AdminArgs>)
     if (r |> is_err) {
         print("error: {r |> unwrap_err}\n\n")
@@ -95,6 +96,21 @@ def main : int {
             return 1
         }
         print("{res.runs_added} run(s) imported, {res.runs_replaced} replaced\n")
+        return 0
+    }
+    if (cfg.op == "plant-sidecar") {
+        let text = fread(cfg.file)
+        if (empty(text)) {
+            print("error: cannot read {cfg.file}\n")
+            return 1
+        }
+        let res = plant_sidecar(db, text, LadderPolicy(), int64(get_clock()))
+        if (res.status != PutStatus.ok) {
+            let why = !empty(res.error) ? res.error : "{res.status}"
+            print("error: {why}\n")
+            return 1
+        }
+        print(res.created ? "planted {res.sha}\n" : "already stored, promoted {res.sha}\n")
         return 0
     }
     print("error: unknown op '{cfg.op}'\n")

--- a/utils/internal/dasllama-ladder/admin.html
+++ b/utils/internal/dasllama-ladder/admin.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>dasllama-ladder admin</title>
+<meta name="robots" content="noindex">
+<style>
+  :root { color-scheme: dark; }
+  body { margin: 0; padding: 24px; background: #14161a; color: #d8dce2;
+         font: 14px/1.5 ui-monospace, "Cascadia Mono", Menlo, Consolas, monospace; }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  .sub { color: #8b93a1; margin: 0 0 20px; }
+  .bar { display: flex; gap: 12px; align-items: center; margin: 0 0 16px; flex-wrap: wrap; }
+  .pill { padding: 2px 10px; border-radius: 10px; font-size: 12px; }
+  .open { background: #3a2b12; color: #f0b429; }
+  .closed { background: #16321e; color: #4cbb6c; }
+  .ok { background: #16321e; color: #4cbb6c; }
+  .pending { background: #3a2b12; color: #f0b429; }
+  button { background: #232830; color: #d8dce2; border: 1px solid #3a414d;
+           border-radius: 6px; padding: 4px 10px; font: inherit; font-size: 12px; cursor: pointer; }
+  button:hover { background: #2c3340; }
+  button.danger { color: #e07070; border-color: #5a3030; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid #262b33;
+           white-space: nowrap; }
+  th { color: #8b93a1; font-weight: normal; }
+  td.box { white-space: normal; word-break: break-all; max-width: 340px; }
+  a { color: #6aa9e8; text-decoration: none; }
+  .plant { margin-top: 24px; padding: 14px; border: 1px dashed #3a414d; border-radius: 8px; }
+  .msg { margin-left: 12px; color: #8b93a1; }
+  .err { color: #e07070; }
+</style>
+</head>
+<body>
+<h1>dasllama-ladder admin</h1>
+<p class="sub">loopback-only operator surface &mdash; reach it through <code>ssh -L 8201:127.0.0.1:8201 dasweb-1</code></p>
+
+<div class="bar">
+  <span>submissions: <span id="gate" class="pill">&hellip;</span></span>
+  <button id="gate-btn" onclick="toggleGate()">&hellip;</button>
+  <button onclick="refresh()">refresh</button>
+  <span id="bar-msg" class="msg"></span>
+</div>
+
+<table>
+  <thead><tr>
+    <th>sha</th><th>v</th><th>box</th><th>noise</th><th>kernels</th>
+    <th>written</th><th>from</th><th>status</th><th>actions</th>
+  </tr></thead>
+  <tbody id="rows"><tr><td colspan="9">loading&hellip;</td></tr></tbody>
+</table>
+
+<div class="plant">
+  plant an official sidecar (stored verified):
+  <input type="file" id="plant-file" accept=".json">
+  <button onclick="plant()">plant</button>
+  <span id="plant-msg" class="msg"></span>
+</div>
+
+<script>
+"use strict";
+// wire contract: ladder_server.das - /admin/sidecars, /admin/sidecar/{verify,delete}, /admin/import-sidecar, /admin/submit
+let gateOpen = false;
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+async function post(path, body) {
+  const r = await fetch(path, { method: "POST", body: JSON.stringify(body ?? {}) });
+  const j = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(j.error || ("HTTP " + r.status));
+  return j;
+}
+
+function say(id, text, isErr) {
+  const el = document.getElementById(id);
+  el.textContent = text;
+  el.className = "msg" + (isErr ? " err" : "");
+}
+
+async function refresh() {
+  const r = await fetch("/admin/sidecars");
+  const j = await r.json();
+  gateOpen = !!j.submit_open;
+  const gate = document.getElementById("gate");
+  gate.textContent = gateOpen ? "OPEN" : "closed";
+  gate.className = "pill " + (gateOpen ? "open" : "closed");
+  document.getElementById("gate-btn").textContent = gateOpen ? "close submissions" : "open submissions";
+  const rows = document.getElementById("rows");
+  if (!j.sidecars.length) {
+    rows.innerHTML = '<tr><td colspan="9">no sidecars stored</td></tr>';
+    return;
+  }
+  rows.innerHTML = j.sidecars.map(s => {
+    const sha = esc(s.sha);
+    const when = new Date(s.created_at * 1000).toISOString().slice(0, 16).replace("T", " ");
+    return "<tr>" +
+      '<td><a href="/api/sidecar/' + sha + '" title="' + sha + '">' + sha.slice(0, 12) + "</a></td>" +
+      "<td>" + esc(s.dasllama_version) + "</td>" +
+      '<td class="box">' + esc(s.box) + "</td>" +
+      "<td>" + esc(s.noise) + "</td>" +
+      "<td>" + esc(s.kernel_count) + "</td>" +
+      "<td>" + esc(s.written) + '<br><span class="msg">' + when + "</span></td>" +
+      "<td>" + esc(s.client_ip) + "</td>" +
+      '<td><span class="pill ' + (s.verified ? "ok\">verified" : "pending\">pending") + "</span></td>" +
+      "<td>" +
+        (s.verified
+          ? '<button onclick="setVerified(\'' + sha + "', false)\">demote</button> "
+          : '<button onclick="setVerified(\'' + sha + "', true)\">promote</button> ") +
+        '<button class="danger" onclick="deleteSidecar(\'' + sha + "')\">delete</button>" +
+      "</td></tr>";
+  }).join("");
+}
+
+async function setVerified(sha, verified) {
+  try { await post("/admin/sidecar/verify", { sha, verified }); await refresh(); }
+  catch (e) { say("bar-msg", e.message, true); }
+}
+
+async function deleteSidecar(sha) {
+  if (!confirm("Delete sidecar " + sha.slice(0, 12) + "… permanently?")) return;
+  try { await post("/admin/sidecar/delete", { sha }); await refresh(); }
+  catch (e) { say("bar-msg", e.message, true); }
+}
+
+async function toggleGate() {
+  try { await post("/admin/submit", { open: !gateOpen }); await refresh(); }
+  catch (e) { say("bar-msg", e.message, true); }
+}
+
+async function plant() {
+  const f = document.getElementById("plant-file").files[0];
+  if (!f) { say("plant-msg", "pick a sidecar .json first", true); return; }
+  try {
+    const text = await f.text();
+    const r = await fetch("/admin/import-sidecar", { method: "POST", body: text });
+    const j = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(j.error || ("HTTP " + r.status));
+    say("plant-msg", (j.created ? "planted " : "already stored, promoted ") + j.sha.slice(0, 12));
+    await refresh();
+  } catch (e) { say("plant-msg", e.message, true); }
+}
+
+refresh().catch(e => say("bar-msg", e.message, true));
+</script>
+</body>
+</html>

--- a/utils/internal/dasllama-ladder/dasllama-deploy.sh
+++ b/utils/internal/dasllama-ladder/dasllama-deploy.sh
@@ -8,8 +8,13 @@
 #   caddy                      splice caddy.snippet into the dasllama.io vhost, validate, reload
 #   install <sha> <tarball>    per-release: unpack, carry operator files, flip current, restart, health
 #   open-submit | close-submit flip the public-submission gate (loopback admin call)
-#   status                     systemd active-state + /api health (the gate state is not
-#                              remotely queryable; it is in the service's startup banner/log)
+#   sidecars                   list stored sidecars + the gate state (loopback admin listing)
+#   promote <sha> | demote <sha>  flip a sidecar's verified flag
+#   plant <sidecar.json>       import an official sidecar (stored verified; re-plant promotes)
+#   status                     systemd active-state + /api health + the submit-gate state
+#
+# The curl verbs need no root — they talk to the loopback admin surface — but they live here
+# so the operator has ONE tool; the browser twin is /admin/ over `ssh -L 8201:127.0.0.1:8201`.
 #
 # The bundle comes from the builder box (zen4), from the arc worktree there:
 #   cd ~/daScript-dasweb && git pull --ff-only origin <branch>
@@ -28,7 +33,7 @@ UNIT=/etc/systemd/system/dasllama-ladder.service
 CADDYFILE=/etc/caddy/Caddyfile
 RESTIC_ENV=/etc/restic/env
 
-verb="${1:?usage: dasllama-deploy.sh provision|caddy|install <sha> <tarball>|open-submit|close-submit|status}"
+verb="${1:?usage: dasllama-deploy.sh provision|caddy|install <sha> <tarball>|open-submit|close-submit|sidecars|promote <sha>|demote <sha>|plant <file>|status}"
 
 provision() {
     # Dedicated service user isolates the public-upload process from the playground's dasweb.
@@ -166,15 +171,40 @@ submit_toggle() {
     curl -sf -X POST "http://127.0.0.1:$PORT/admin/submit" -d "{\"open\":$1}" && echo
 }
 
+set_verified() {
+    # $1 = sha, $2 = true|false. Match the server's is_valid_sha exactly (64 LOWERCASE hex) so a
+    # bad paste fails HERE with a clear message, not as a silent curl -sf 400 from the server.
+    case "$1" in *[!0-9a-f]*|"") echo "bad sha '$1' (expected 64 lowercase hex)"; exit 2;; esac
+    [ ${#1} -eq 64 ] || { echo "bad sha '$1' (expected 64 chars, got ${#1})"; exit 2; }
+    curl -sf -X POST "http://127.0.0.1:$PORT/admin/sidecar/verify" -d "{\"sha\":\"$1\",\"verified\":$2}" && echo
+}
+
 case "$verb" in
     provision) provision ;;
     caddy) caddy_apply ;;
     install) shift; install_release "$@" ;;
     open-submit) submit_toggle true ;;
     close-submit) submit_toggle false ;;
+    sidecars)
+        curl -sf "http://127.0.0.1:$PORT/admin/sidecars" && echo
+        ;;
+    promote) shift; set_verified "${1:?promote <sha>}" true ;;
+    demote) shift; set_verified "${1:?demote <sha>}" false ;;
+    plant)
+        shift; F="${1:?plant <sidecar.json>}"
+        [ -f "$F" ] || { echo "no file at '$F'"; exit 2; }
+        curl -sf -X POST "http://127.0.0.1:$PORT/admin/import-sidecar" --data-binary @"$F" && echo
+        ;;
     status)
         systemctl is-active dasllama-ladder || true
         curl -sf "http://127.0.0.1:$PORT/api/versions" >/dev/null 2>&1 && echo "api: ok" || echo "api: DOWN"
+        # advisory: parses the pretty-printed admin JSON; reads "unknown" if the format drifts
+        gate=$(curl -sf "http://127.0.0.1:$PORT/admin/sidecars" 2>/dev/null | grep -o '"submit_open" : [a-z]*' | grep -o '[a-z]*$' || true)
+        case "$gate" in
+            true) echo "submit: open" ;;
+            false) echo "submit: closed" ;;
+            *) echo "submit: unknown" ;;
+        esac
         ;;
     *) echo "unknown verb: $verb"; exit 2 ;;
 esac

--- a/utils/internal/dasllama-ladder/ladder_server.das
+++ b/utils/internal/dasllama-ladder/ladder_server.das
@@ -7,6 +7,7 @@ require dashv/dashv_boost public
 require daslib/json_boost
 require daslib/logger
 require daslib/fio
+require daslib/module_path
 require daslib/strings_boost
 require daslib/strings_convert
 require ladder_store public
@@ -46,12 +47,41 @@ def is_loopback_peer(peer : string) : bool {
     return peer == "127.0.0.1" || peer == "::1" || peer == "::ffff:127.0.0.1"
 }
 
-def private is_loopback_caller(var req : HttpRequest?) : bool {
-    //! Operator-surface gate on the TRANSPORT peer. Behind Caddy (which proxies from the same
-    //! box) that peer is always 127.0.0.1, so this passes for any internet caller — the REAL
-    //! boundary is that operator routes never appear in caddy.snippet. This is defense-in-depth
-    //! for direct-to-port access only; do not treat it as unforgeable behind the proxy.
-    return is_loopback_peer(client_ip(req))
+def private authority_host(authority : string) : string {
+    //! The host of an `authority` (`host` / `host:port` / `[v6]:port`), lowercased.
+    if (authority |> starts_with("[")) {   // bracketed IPv6: take inside the brackets
+        let close = find(authority, "]")
+        return close > 0 ? to_lower(slice(authority, 1, close)) : to_lower(authority)
+    }
+    let colon = find(authority, ":")
+    return to_lower(colon >= 0 ? slice(authority, 0, colon) : authority)
+}
+
+def private is_loopback_host(authority : string) : bool {
+    let host = authority_host(authority)
+    // same set as is_loopback_peer, incl. the IPv4-mapped IPv6 loopback
+    return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "::ffff:127.0.0.1"
+}
+
+def private is_operator_caller(var req : HttpRequest?) : bool {
+    // Three layers, all required. The peer is no boundary behind Caddy (it proxies from this
+    // box) — caddy.snippet keeping /admin/* unproxied is that one. The other two defend the
+    // ssh-tunnel case: a loopback Host defeats DNS rebinding (a rebound name still sends its own
+    // Host), and same-origin defeats a plain cross-origin fetch that happens to use a loopback
+    // Host. Comparing Origin to Host alone would NOT survive rebinding — the attacker owns both.
+    return (is_loopback_peer(client_ip(req))
+        && is_loopback_host(get_header(req, "Host"))
+        && same_origin_or_headerless(req))
+}
+
+def private same_origin_or_headerless(var req : HttpRequest?) : bool {
+    let origin = get_header(req, "Origin")
+    if (empty(origin)) {
+        return true   // CLI clients (curl) and plain navigations carry no Origin
+    }
+    let sep = find(origin, "://")
+    let authority = sep >= 0 ? slice(origin, sep + 3) : origin
+    return authority == get_header(req, "Host")
 }
 
 def is_valid_sha(h : string) : bool {
@@ -115,12 +145,30 @@ class LadderServer : HvWebServer {
         POST("/admin/import-official") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_import_official(req, resp)
         }
+        POST("/admin/import-sidecar") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_import_sidecar(req, resp)
+        }
         POST("/admin/submit") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             return handle_admin_submit(req, resp)
         }
+        GET("/admin/") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_admin_page(req, resp)
+        }
+        GET("/admin") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_admin_page(req, resp)
+        }
+        GET("/admin/sidecars") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_admin_sidecars(req, resp)
+        }
+        POST("/admin/sidecar/verify") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_admin_sidecar_verify(req, resp)
+        }
+        POST("/admin/sidecar/delete") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+            return handle_admin_sidecar_delete(req, resp)
+        }
         POST("/shutdown") <| @(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
             let t0 = ref_time_ticks()
-            if (!is_loopback_caller(req)) {
+            if (!is_operator_caller(req)) {
                 log_request("POST", "/shutdown", 403, client_ip_of(req), 0, 0, t0)
                 return resp |> TEXT_PLAIN("forbidden", http_status.FORBIDDEN)
             }
@@ -279,9 +327,16 @@ def private handle_sidecar_doc(var req : HttpRequest?; var resp : HttpResponse?)
 
 def private submit_body_of(var req : HttpRequest?; route : string; var resp : HttpResponse?;
                            var status : http_status&; t0 : int64) : string {
-    //! Shared NUL guard: returns "" and fills `status` when the body cannot be
-    //! taken at face value ("" never validates downstream, so it is safe).
+    //! Shared body gate: returns "" and fills `status` when the body cannot be
+    //! taken at face value — absent entirely, or NUL-truncated ("" never
+    //! validates downstream, so it is safe).
     let raw_bytes = length(req.body)
+    if (raw_bytes == 0) {
+        let body = write_json(JV((error = "empty document")))
+        log_request("POST", route, 400, client_ip_of(req), 0, length(body), t0)
+        status = resp |> JSON(body, http_status.BAD_REQUEST)
+        return ""
+    }
     let text = string(req.body)
     if (!body_is_byte_faithful(raw_bytes, text)) {
         let body = write_json(JV((error = "document contains NUL bytes")))
@@ -399,7 +454,7 @@ def private handle_submit_records(var req : HttpRequest?; var resp : HttpRespons
 def private handle_admin_submit(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
-    if (!is_loopback_caller(req)) {
+    if (!is_operator_caller(req)) {
         log_request("POST", "/admin/submit", 403, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
     }
@@ -419,10 +474,132 @@ def private handle_admin_submit(var req : HttpRequest?; var resp : HttpResponse?
     return resp |> JSON(body)
 }
 
+def private handle_admin_page(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
+    let ip = client_ip_of(req)
+    let path = string(req.path)   // /admin and /admin/ both land here; log the one that arrived
+    if (!is_operator_caller(req)) {
+        log_request("GET", path, 403, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
+    // the operator page ships beside the server sources; libhv sets text/html from the extension
+    let st = resp |> SERVE_FILE(path_join(get_this_module_dir(), "admin.html"))
+    log_request("GET", path, int(st), ip, 0, resp.content_length, t0)
+    return st
+}
+
+def private handle_admin_sidecars(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
+    let ip = client_ip_of(req)
+    if (!is_operator_caller(req)) {
+        log_request("GET", "/admin/sidecars", 403, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
+    let rows <- admin_list_sidecars(g_db)
+    var arr <- [for (r in rows); JV((
+        sha = r.sha, box = r.box, verified = r.verified, noise = r.noise,
+        written = r.written, kernel_count = r.kernel_count, engine_sha = r.engine_sha,
+        dasllama_version = r.dasllama_version, client_ip = r.client_ip,
+        created_at = r.created_at, url = "/api/sidecar/{r.sha}"))]
+    // admin.html's gate pill reads submit_open from this listing
+    let body = write_json(JV((submit_open = g_policy.submit_open, sidecars = JV(arr))))
+    resp |> set_header("Cache-Control", "no-store")
+    resp |> set_header("X-Content-Type-Options", "nosniff")
+    log_request("GET", "/admin/sidecars", 200, ip, 0, length(body), t0)
+    return resp |> JSON(body)
+}
+
+def private handle_admin_sidecar_verify(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
+    let ip = client_ip_of(req)
+    if (!is_operator_caller(req)) {
+        log_request("POST", "/admin/sidecar/verify", 403, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
+    var early = http_status.OK
+    let doc = submit_body_of(req, "/admin/sidecar/verify", resp, early, t0)
+    if (empty(doc)) {
+        return early
+    }
+    var jerr = ""
+    var js = read_json(doc, jerr)
+    let sha : string = js?["sha"] ?? ""
+    let want : bool = js?["verified"] ?? false   // absent/garbage → demote (never promotes by accident)
+    delete_json(js)
+    if (!is_valid_sha(sha)) {
+        let body = write_json(JV((error = "malformed sha")))
+        log_request("POST", "/admin/sidecar/verify", 400, ip, length(req.body), length(body), t0)
+        return resp |> JSON(body, http_status.BAD_REQUEST)
+    }
+    let ok = set_sidecar_verified(g_db, sha, want)
+    let status = ok ? http_status.OK : http_status.NOT_FOUND
+    let body = (ok
+        ? write_json(JV((sha = sha, verified = want)))
+        : write_json(JV((error = "unknown sidecar"))))
+    log_request("POST", "/admin/sidecar/verify", int(status), ip, length(req.body), length(body), t0)
+    return resp |> JSON(body, status)
+}
+
+def private handle_admin_sidecar_delete(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
+    let ip = client_ip_of(req)
+    if (!is_operator_caller(req)) {
+        log_request("POST", "/admin/sidecar/delete", 403, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
+    var early = http_status.OK
+    let doc = submit_body_of(req, "/admin/sidecar/delete", resp, early, t0)
+    if (empty(doc)) {
+        return early
+    }
+    var jerr = ""
+    var js = read_json(doc, jerr)
+    let sha : string = js?["sha"] ?? ""
+    delete_json(js)
+    if (!is_valid_sha(sha)) {
+        let body = write_json(JV((error = "malformed sha")))
+        log_request("POST", "/admin/sidecar/delete", 400, ip, length(req.body), length(body), t0)
+        return resp |> JSON(body, http_status.BAD_REQUEST)
+    }
+    let ok = delete_sidecar(g_db, sha)
+    let status = ok ? http_status.OK : http_status.NOT_FOUND
+    let body = (ok
+        ? write_json(JV((sha = sha, deleted = true)))
+        : write_json(JV((error = "unknown sidecar"))))
+    log_request("POST", "/admin/sidecar/delete", int(status), ip, length(req.body), length(body), t0)
+    return resp |> JSON(body, status)
+}
+
+def private handle_import_sidecar(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
+    let t0 = ref_time_ticks()
+    let ip = client_ip_of(req)
+    if (!is_operator_caller(req)) {
+        log_request("POST", "/admin/import-sidecar", 403, ip, 0, 0, t0)
+        return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
+    }
+    var early = http_status.OK
+    let doc = submit_body_of(req, "/admin/import-sidecar", resp, early, t0)
+    if (empty(doc)) {
+        return early
+    }
+    let r = plant_sidecar(g_db, doc, g_policy, current_unix_time())
+    let status = put_status_of(r.status)
+    var body = ""
+    if (r.status == PutStatus.ok) {
+        body = write_json(JV((sha = r.sha, created = r.created, url = "/api/sidecar/{r.sha}")))
+    } elif (r.status == PutStatus.invalid) {
+        body = write_json(JV((error = r.error)))
+    } else {
+        body = write_json(JV((error = "{r.status}")))
+    }
+    log_request("POST", "/admin/import-sidecar", int(status), ip, length(doc), length(body), t0)
+    return resp |> JSON(body, status)
+}
+
 def private handle_import_official(var req : HttpRequest?; var resp : HttpResponse?) : http_status {
     let t0 = ref_time_ticks()
     let ip = client_ip_of(req)
-    if (!is_loopback_caller(req)) {
+    if (!is_operator_caller(req)) {
         log_request("POST", "/admin/import-official", 403, ip, 0, 0, t0)
         return resp |> JSON(write_json(JV((error = "forbidden"))), http_status.FORBIDDEN)
     }

--- a/utils/internal/dasllama-ladder/ladder_store.das
+++ b/utils/internal/dasllama-ladder/ladder_store.das
@@ -429,6 +429,62 @@ def import_official_store(db : SqlRunner; doc : string; now : int64) : ImportRes
     return ImportResult(ok = true, runs_added = added, runs_replaced = replaced)
 }
 
+//! Plant an official sidecar (the operator lever): `put_sidecar` minus the rate limit,
+//! stored verified. Same submission-grade validation (an unstamped sidecar can never be
+//! served, so storing one is always an error) and the same privacy strip — the strip is
+//! idempotent, and hashing the same text community submits is what makes a re-plant of
+//! an existing upload promote it instead of minting a second row.
+def plant_sidecar(db : SqlRunner; var doc : string; policy : LadderPolicy; now : int64) : PutSidecarResult {
+    if (empty(doc)) {
+        return PutSidecarResult(status = PutStatus.empty_doc)
+    }
+    if (length(doc) > policy.max_sidecar_bytes) {
+        return PutSidecarResult(status = PutStatus.too_large)
+    }
+    doc = exchange_strip_private(doc)
+    if (empty(doc)) {
+        return PutSidecarResult(status = PutStatus.invalid, error = "json parse failed")
+    }
+    var errors : array<string>
+    if (!validate_sidecar_submission(doc, errors)) {
+        let first = !empty(errors) ? errors[0] : "invalid"
+        return PutSidecarResult(status = PutStatus.invalid, error = first)
+    }
+    var info : SidecarInfo
+    if (!parse_sidecar_info(doc, info)) {
+        return PutSidecarResult(status = PutStatus.invalid, error = "index fields do not parse")
+    }
+    let sha = sha256_hex(doc)
+    let existing <- _sql(db |> select_from(type<SidecarRow>)
+        |> _where(_.Sha == sha)
+        |> _select(_.Sha)
+        |> take(1))
+    if (!empty(existing)) {
+        set_sidecar_verified(db, sha, true)
+        return PutSidecarResult(status = PutStatus.ok, sha = sha, created = false)
+    }
+    add_submission(db, "sidecar", sha, doc, "importer", now)
+    db |> insert(SidecarRow(
+        Sha = sha,
+        Doc = doc,
+        DasllamaVersion = info.dasllama_version,
+        Box = info.box,
+        Platform = info.identity.platform,
+        Arch = info.identity.arch,
+        ModelId = info.identity.model_id,
+        Cpu = info.identity.cpu,
+        EngineSha = info.engine_sha,
+        Written = info.written,
+        Noise = info.noise,
+        KernelCount = info.kernel_count,
+        Verified = 1,
+        CreatedAt = now,
+        ClientIp = "importer"))
+    logger_info("ladder.store", "plant official sidecar",
+        JV((sha = sha, version = info.dasllama_version, box = info.box)))
+    return PutSidecarResult(status = PutStatus.ok, sha = sha, created = true)
+}
+
 def private tier_hits(tier : string; var seen : table<string>;
                       var out : array<SidecarHit>; rows : array<SidecarRow>) {
     // verified rows surface before unverified within a tier; rows arrive newest-first
@@ -504,6 +560,38 @@ def list_sidecars(db : SqlRunner; version : int) : array<SidecarHit> {
         |> _where(_.DasllamaVersion == version)
         |> _order_by_descending(_.CreatedAt))
     return <- listing_hits(rows)
+}
+
+//! One operator-listing row: the public hit columns plus the moderation ones
+//! (submitter ip, insert time) that never leave the loopback surface.
+struct SidecarAdminRow {
+    sha : string
+    box : string
+    verified : bool
+    noise : string
+    written : string
+    kernel_count : int
+    engine_sha : string
+    dasllama_version : int
+    client_ip : string
+    created_at : int64
+}
+
+//! Every sidecar with the moderation columns, newest first — the /admin/ page listing.
+def admin_list_sidecars(db : SqlRunner) : array<SidecarAdminRow> {
+    let rows <- _sql(db |> select_from(type<SidecarRow>)
+        |> _order_by_descending(_.CreatedAt))
+    return <- [for (r in rows); SidecarAdminRow(
+        sha = r.Sha,
+        box = r.Box,
+        verified = r.Verified != 0,
+        noise = r.Noise,
+        written = r.Written,
+        kernel_count = r.KernelCount,
+        engine_sha = r.EngineSha,
+        dasllama_version = r.DasllamaVersion,
+        client_ip = r.ClientIp,
+        created_at = r.CreatedAt)]
 }
 
 //! The stored sidecar document, or "" when the sha is unknown (an empty document can

--- a/utils/internal/dasllama-ladder/test_ladder_server.das
+++ b/utils/internal/dasllama-ladder/test_ladder_server.das
@@ -149,6 +149,9 @@ def test_sidecar_routes(t : T?) {
                 tt |> equal(int(resp.status_code), 400)
                 tt |> success(!empty(json_of(resp)?["error"] ?? ""), "error named")
             }
+            POST("{base_url}/api/submit/sidecar", "") $(resp) {
+                tt |> equal(int(resp.status_code), 400, "an empty body is a named refusal, not a bare 200")
+            }
         }
     }
 }
@@ -254,6 +257,222 @@ def test_policy_status_mapping(t : T?) {
 }
 
 [test]
+def test_admin_sidecar_curation(t : T?) {
+    // gate CLOSED throughout: the operator surface is independent of public submissions
+    with_ladder_server(LadderPolicy()) $(base_url) {
+        let doc = sidecar_doc(BOX_A, "4", "vec8_u8")
+        let sha = sha256_hex(doc)
+        t |> run("plant stores verified while the board is closed") @(tt : T?) {
+            POST("{base_url}/admin/import-sidecar", doc) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var js = json_of(resp)
+                tt |> equal(js?["sha"] ?? "", sha)
+                tt |> success(js?["created"] ?? false, "first plant creates")
+            }
+            GET("{base_url}/api/sidecars") $(resp) {
+                var js = json_of(resp)
+                tt |> equal(length(js?["sidecars"] as _array), 1)
+                tt |> success(js?["sidecars"]?[0]?["verified"] ?? false, "verified on the public listing")
+            }
+        }
+        t |> run("the admin listing carries gate state and moderation columns") @(tt : T?) {
+            GET("{base_url}/admin/sidecars") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                var js = json_of(resp)
+                tt |> success(!(js?["submit_open"] ?? true), "gate reads closed")
+                tt |> equal(length(js?["sidecars"] as _array), 1)
+                tt |> equal(js?["sidecars"]?[0]?["client_ip"] ?? "", "importer")
+            }
+        }
+        t |> run("verify demotes and promotes by sha") @(tt : T?) {
+            POST("{base_url}/admin/sidecar/verify", "\{\"sha\":\"{sha}\",\"verified\":false}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            GET("{base_url}/api/sidecars") $(resp) {
+                tt |> success(!(json_of(resp)?["sidecars"]?[0]?["verified"] ?? true), "demoted")
+            }
+            POST("{base_url}/admin/sidecar/verify", "\{\"sha\":\"{sha}\",\"verified\":true}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            GET("{base_url}/api/sidecars") $(resp) {
+                tt |> success(json_of(resp)?["sidecars"]?[0]?["verified"] ?? false, "promoted back")
+            }
+        }
+        t |> run("an absent verified key demotes (fail-safe, like the gate's open key)") @(tt : T?) {
+            POST("{base_url}/admin/sidecar/verify", "\{\"sha\":\"{sha}\"}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            GET("{base_url}/api/sidecars") $(resp) {
+                tt |> success(!(json_of(resp)?["sidecars"]?[0]?["verified"] ?? true), "no key never promotes")
+            }
+            POST("{base_url}/admin/sidecar/verify", "\{\"sha\":\"{sha}\",\"verified\":true}") $(resp) {
+                tt |> equal(int(resp.status_code), 200, "restored for the arms below")
+            }
+        }
+        t |> run("delete removes the sidecar and its receipt") @(tt : T?) {
+            POST("{base_url}/admin/sidecar/delete", "\{\"sha\":\"{sha}\"}") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            GET("{base_url}/api/sidecar/{sha}") $(resp) {
+                tt |> equal(int(resp.status_code), 404, "document gone")
+            }
+            POST("{base_url}/admin/sidecar/delete", "\{\"sha\":\"{sha}\"}") $(resp) {
+                tt |> equal(int(resp.status_code), 404, "second delete finds nothing")
+            }
+        }
+    }
+}
+
+[test]
+def test_admin_transport_rejections(t : T?) {
+    with_ladder_server(LadderPolicy()) $(base_url) {
+        t |> run("malformed, unknown, and empty inputs are named refusals") @(tt : T?) {
+            POST("{base_url}/admin/sidecar/verify", "\{\"sha\":\"nothex\",\"verified\":true}") $(resp) {
+                tt |> equal(int(resp.status_code), 400, "malformed sha")
+            }
+            POST("{base_url}/admin/sidecar/verify", "\{\"sha\":\"{sha256_hex("absent")}\",\"verified\":true}") $(resp) {
+                tt |> equal(int(resp.status_code), 404, "unknown sha")
+            }
+            POST("{base_url}/admin/sidecar/verify", "") $(resp) {
+                tt |> equal(int(resp.status_code), 400, "empty body refused, not silently accepted")
+            }
+            POST("{base_url}/admin/sidecar/delete", "\{\"sha\":\"nothex\"}") $(resp) {
+                tt |> equal(int(resp.status_code), 400, "delete rejects a malformed sha")
+            }
+            POST("{base_url}/admin/import-sidecar", "not json") $(resp) {
+                tt |> equal(int(resp.status_code), 400)
+                tt |> success(!empty(json_of(resp)?["error"] ?? ""), "plant names its error over HTTP")
+            }
+        }
+    }
+}
+
+[test]
+def test_admin_origin_gate_and_page(t : T?) {
+    with_ladder_server(LadderPolicy()) $(base_url) {
+        // 404 from the store is the pass signal - a request the gate blocks answers 403
+        let absent = sha256_hex("absent")
+        t |> run("every admin route refuses a cross-site Origin") @(tt : T?) {
+            // every operator POST, including the two my rename moved off the peer-only gate
+            // (import-official, shutdown) - a cross-origin shutdown must be REFUSED, so the
+            // server survives the arm
+            for (path in ["/admin/sidecar/verify", "/admin/sidecar/delete", "/admin/import-sidecar",
+                          "/admin/submit", "/admin/import-official", "/shutdown"]) {
+                with_http_request() $(var req) {
+                    req.method = http_method.POST
+                    req.url := "{base_url}{path}"
+                    set_header(req, "Origin", "http://evil.example")
+                    req.body := "\{\"sha\":\"{absent}\",\"verified\":true}"
+                    request(req) $(resp) {
+                        tt |> equal(int(resp.status_code), 403, "cross-site POST refused")
+                    }
+                }
+            }
+            for (path in ["/admin/", "/admin/sidecars"]) {
+                with_http_request() $(var req) {
+                    req.method = http_method.GET
+                    req.url := "{base_url}{path}"
+                    set_header(req, "Origin", "http://evil.example")
+                    request(req) $(resp) {
+                        tt |> equal(int(resp.status_code), 403, "cross-site GET refused")
+                    }
+                }
+            }
+            // Origin: null (sandboxed iframe) has no scheme separator - must still fail closed
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/admin/sidecar/verify"
+                set_header(req, "Origin", "null")
+                req.body := "\{\"sha\":\"{absent}\",\"verified\":true}"
+                request(req) $(resp) {
+                    tt |> equal(int(resp.status_code), 403, "Origin null refused")
+                }
+            }
+            // DNS rebinding: peer is loopback (the tunnel) and Origin == Host, both attacker-owned.
+            // Sent header-less so same-origin passes and ONLY the loopback-Host check can refuse it
+            // - if this 404'd the host guard would be doing nothing (and libhv would be ignoring the
+            // spoofed Host); a 403 proves the guard fires.
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/admin/sidecar/verify"
+                set_header(req, "Host", "evil.example:{TEST_PORT}")
+                req.body := "\{\"sha\":\"{absent}\",\"verified\":true}"
+                request(req) $(resp) {
+                    tt |> equal(int(resp.status_code), 403, "rebound non-loopback Host refused")
+                }
+            }
+        }
+        t |> run("a same-origin request passes the gate") @(tt : T?) {
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/admin/sidecar/verify"
+                set_header(req, "Origin", "http://127.0.0.1:{TEST_PORT}")
+                req.body := "\{\"sha\":\"{absent}\",\"verified\":true}"
+                request(req) $(resp) {
+                    tt |> equal(int(resp.status_code), 404, "reached the store")
+                    tt |> success(find(string(resp.body), "unknown sidecar") >= 0, "the store's own 404, not the catch-all's")
+                }
+            }
+        }
+        t |> run("the IPv4-mapped IPv6 loopback Host is accepted (peer/host allowlists agree)") @(tt : T?) {
+            // header-less, so only is_loopback_host decides: a 404 means it passed the gate
+            with_http_request() $(var req) {
+                req.method = http_method.POST
+                req.url := "{base_url}/admin/sidecar/verify"
+                set_header(req, "Host", "[::ffff:127.0.0.1]:{TEST_PORT}")
+                req.body := "\{\"sha\":\"{absent}\",\"verified\":true}"
+                request(req) $(resp) {
+                    tt |> equal(int(resp.status_code), 404, "mapped loopback Host reaches the store")
+                }
+            }
+        }
+    }
+}
+
+[test]
+def test_admin_page_serves(t : T?) {
+    with_ladder_server(LadderPolicy()) $(base_url) {
+        t |> run("the operator page serves on the loopback surface") @(tt : T?) {
+            GET("{base_url}/admin/") $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> success(find(string(resp.body), "dasllama-ladder admin") >= 0, "the page arrived")
+            }
+            GET("{base_url}/admin") $(resp) {
+                tt |> equal(int(resp.status_code), 200, "the no-slash spelling serves it too")
+            }
+        }
+    }
+}
+
+[test]
+def test_admin_plant_promotes_community(t : T?) {
+    // gate OPEN: a community upload is the same content a later plant promotes
+    with_ladder_server(default_policy()) $(base_url) {
+        let doc = sidecar_doc(BOX_B, "4", "vec8_u8")
+        t |> run("planting a community upload promotes it in place") @(tt : T?) {
+            POST("{base_url}/api/submit/sidecar", doc) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            GET("{base_url}/api/sidecars") $(resp) {
+                tt |> success(!(json_of(resp)?["sidecars"]?[0]?["verified"] ?? true), "community entry is unverified")
+            }
+            POST("{base_url}/admin/import-sidecar", doc) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+                tt |> success(!(json_of(resp)?["created"] ?? true), "dedup hit, not a second row")
+            }
+            GET("{base_url}/api/sidecars") $(resp) {
+                var js = json_of(resp)
+                tt |> equal(length(js?["sidecars"] as _array), 1, "still one row")
+                tt |> success(js?["sidecars"]?[0]?["verified"] ?? false, "now verified")
+            }
+            GET("{base_url}/admin/sidecars") $(resp) {
+                tt |> success(json_of(resp)?["submit_open"] ?? false, "the admin listing reads the gate open too")
+            }
+        }
+    }
+}
+
+[test]
 def test_submit_gate(t : T?) {
     // default policy = submit CLOSED: the read board serves, writes are refused until opened, and
     // the loopback admin flip is reversible (the test-window switch)
@@ -293,7 +512,7 @@ def test_submit_gate(t : T?) {
             }
             // garbage must resolve to closed: read_json -> null -> ?? false. (A non-loopback
             // caller is also refused, but every in-process peer is 127.0.0.1 so that path
-            // can't be exercised here — it is covered by is_loopback_caller's exact-match.)
+            // can't be exercised here — it is covered by is_operator_caller's exact-match.)
             POST("{base_url}/admin/submit", "not json at all") $(resp) {
                 tt |> equal(int(resp.status_code), 200)
                 var js = json_of(resp)

--- a/utils/internal/dasllama-ladder/test_ladder_store.das
+++ b/utils/internal/dasllama-ladder/test_ladder_store.das
@@ -310,6 +310,67 @@ def test_official_import(t : T?) {
 }
 
 [test]
+def test_plant_sidecar(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        t |> run("a planted sidecar stores verified with the importer stamp") @(tt : T?) {
+            let doc = sidecar_doc(BOX_A, "4", "vec8_u8")
+            let put = plant_sidecar(db, doc, test_policy(), 1000l)
+            tt |> success(put.status == PutStatus.ok, "stored")
+            tt |> success(put.created, "created")
+            tt |> equal(get_sidecar_doc(db, put.sha), doc)
+            tt |> equal(get_submission_doc(db, 1), doc, "the receipt row landed")
+            let rows <- admin_list_sidecars(db)
+            tt |> equal(length(rows), 1)
+            tt |> success(rows[0].verified, "verified from birth")
+            tt |> equal(rows[0].client_ip, "importer")
+            tt |> equal(rows[0].box, BOX_A)
+            tt |> equal(rows[0].dasllama_version, 4)
+            let hits <- find_sidecars(db, 4, ident_a())
+            tt |> equal(length(hits), 1)
+            tt |> success(hits[0].verified, "a planted row serves on the lookup ladder")
+        }
+        t |> run("re-planting an existing sha promotes it") @(tt : T?) {
+            // a community upload of the SAME content enters unverified; the re-plant flips it
+            let doc = sidecar_doc(BOX_B, "4", "vec8_u8")
+            let community = put_sidecar(db, doc, "10.0.0.9", test_policy(), 2000l)
+            tt |> success(community.status == PutStatus.ok && community.created, "community stored")
+            let put = plant_sidecar(db, doc, test_policy(), 2001l)
+            tt |> success(put.status == PutStatus.ok && !put.created, "dedup hit")
+            let rows <- admin_list_sidecars(db)
+            tt |> equal(length(rows), 2)
+            tt |> equal(rows[0].sha, put.sha, "newest first — the 2000l insert leads the 1000l plant")
+            tt |> success(rows[0].verified, "the existing row is now verified")
+        }
+        t |> run("a plant of a non-strip-invariant doc still dedups its community twin") @(tt : T?) {
+            // the community path hashes the STRIPPED text; plant must hash the same text
+            var jerr = ""
+            var jdoc = read_json(sidecar_doc(BOX_C, "4", "vec8_u8"), jerr)
+            var prov = jdoc?["provenance"]
+            update(prov, "binary", JV("/Users/someone/bin/daslang"))
+            let dirty = write_json(jdoc)
+            delete_json(jdoc)
+            let community = put_sidecar(db, dirty, "10.0.0.10", test_policy(), 2100l)
+            tt |> success(community.status == PutStatus.ok && community.created, "dirty community upload stored")
+            let put = plant_sidecar(db, dirty, test_policy(), 2101l)
+            tt |> success(put.status == PutStatus.ok && !put.created, "plant hashed the stripped text - dedup, not a second row")
+            tt |> equal(put.sha, community.sha)
+        }
+        t |> run("plant validates and bounds like any import") @(tt : T?) {
+            let none = plant_sidecar(db, "", test_policy(), 3000l)
+            tt |> success(none.status == PutStatus.empty_doc, "empty doc refused at the store gate")
+            let bad = plant_sidecar(db, "not json", test_policy(), 3001l)
+            tt |> success(bad.status == PutStatus.invalid, "garbage refused")
+            tt |> success(!empty(bad.error), "error named")
+            let stale = plant_sidecar(db, sidecar_doc(BOX_C, "0", "vec8"), test_policy(), 3002l)
+            tt |> success(stale.status == PutStatus.invalid, "unstamped sidecar refused - it could never be served")
+            let tiny = LadderPolicy(max_sidecar_bytes = 64)
+            let huge = plant_sidecar(db, sidecar_doc(BOX_C, "4", "vec8"), tiny, 3003l)
+            tt |> success(huge.status == PutStatus.too_large, "size cap holds")
+        }
+    }
+}
+
+[test]
 def test_list_versions(t : T?) {
     with_latest_sqlite(":memory:") $(db) {
         var pol = test_policy()


### PR DESCRIPTION
The dasllama.io board is live and read-only, but its point — an exchange of per-box tune sidecars — was empty and had no way to fill honestly. Sidecars are the product, yet there were zero on the board and no path to plant an official one: a community submit always stamps a sidecar unverified, and the only lever that flips it to verified is `admin.das verify-sidecar`, which runs a daslang interpreter the deploy box does not ship. This slice adds the operator surface that closes that gap.

The store grows `plant_sidecar` (a trusted import: the same submission-grade validation and privacy strip as a community submit, minus the rate limit, stored verified; re-planting content that already exists promotes its row rather than minting a second). The server grows five loopback admin routes — a `/admin/` operator page, its `/admin/sidecars` listing, and POST verify/delete/import-sidecar — and `admin.html` is the page an operator reaches over an `ssh -L` tunnel to promote, demote, delete, and plant. The deploy script and `admin.das` grow the same levers for scripting.

During review the external reviewer found a real DNS-rebinding bypass of the operator CSRF gate: with the tunnel open, an attacker who rebinds a hostname to `127.0.0.1` sends a request whose peer is loopback and whose `Origin` equals its `Host` (both attacker-owned), so an Origin-equals-Host check passes. The gate now also requires the `Host` authority itself to be loopback — a rebound name still carries its own non-loopback `Host`. The identical gate and the identical one-line fix live in `utils/dasllama-server/openai_server.das`, whose control routes carry the same pattern and which binds every interface; that fix is folded in here.

Where to look: `is_operator_caller` / `is_loopback_host` in `ladder_server.das` and the mirror in `openai_server.das`; `plant_sidecar` in `ladder_store.das`; `admin.html` for the page.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The `openai_server` rebinding arm is model-gated + JIT-only (skips CI, which has no GGUF), so the local run is the only proof it exists: `test_openai_server` **19/19 under `-jit`** with tinyllama q8 (`DASLLAMA_MODELS_DIR` set) — a cross-site `Origin` and a spoofed non-loopback `Host` are both refused on `POST /config`. Ladder suites (store 37/37, server 36/36, config 12/12) run interpreted in `extended_checks`.
- The docs gate (`sphinx -W`) is red locally on 14 pre-existing "vulkan_*.mp4 not staged" warnings, unrelated to this diff (no RST changed); CI's docs workflow triggers only on `daslib/**` / `src/builtin/**` / RST, so it does not run for this change.
- The AOT / sequence / imgui preflight gates skipped (a local DLL-host relink artifact); this diff adds no `tests/` directory and no GLFW-gated code, so none of the three apply.

### Not done
- `utils/dasllama-server` has no folder `REVIEW.md`, so the `openai_server` fix rides the repo-wide checklist only.
- `detect-dupe` flags `test_plant_sidecar` as structurally identical to `test_put_records` — symmetric store-entry tests with parallel arms; kept, since a shared helper would bury the assertions.
- The dragon audit named four rules a folder `REVIEW.das` could enforce mechanically (the caddy operator-route boundary, the engine-free require, the submit-body caps, the scoped sudoers) — ledgered, not built here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
