### PR TITLE
exchange: the privacy strip no longer eats a box identity that carries a slash

### DIFF
--- a/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
+++ b/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
@@ -694,11 +694,12 @@ def private validate_sidecar_doc(doc : JsonValue const?; submission : bool; var 
     return empty(errors)
 }
 
-// Any backslash, or a slash glued to what follows (`/home/x`, `bin/daslang`, `C:/x`, a
-// trailing `/`). A slash followed by a space is prose, not a path: AMD APU brand strings read
-// `... 8700GE w/ Radeon 780M Graphics`, and that string is the box identity itself.
+// Any backslash, a leading `/` or `~` (an absolute path — the username-carrying shape), or a
+// slash glued to what follows (`bin/daslang`, `C:/x`, a trailing `/`). A slash followed by a
+// space inside prose is not a path: AMD APU brand strings read `... 8700GE w/ Radeon 780M
+// Graphics`, and that string is the box identity itself.
 def private path_shaped(s : string) : bool {
-    var shaped = false
+    var shaped = s |> starts_with("/") || s |> starts_with("~")
     peek_data(s) $(arr) {
         let n = length(arr)
         for (i in range(n)) {

--- a/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
+++ b/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
@@ -694,10 +694,8 @@ def private validate_sidecar_doc(doc : JsonValue const?; submission : bool; var 
     return empty(errors)
 }
 
-// Any backslash, a leading `/` or `~` (an absolute path — the username-carrying shape), or a
-// slash glued to what follows (`bin/daslang`, `C:/x`, a trailing `/`). A slash followed by a
-// space inside prose is not a path: AMD APU brand strings read `... 8700GE w/ Radeon 780M
-// Graphics`, and that string is the box identity itself.
+// A slash followed by a space is prose, not a path: AMD APU brand strings read
+// `... 8700GE w/ Radeon 780M Graphics`, and that string is the box identity itself.
 def private path_shaped(s : string) : bool {
     var shaped = s |> starts_with("/") || s |> starts_with("~")
     peek_data(s) $(arr) {
@@ -706,6 +704,7 @@ def private path_shaped(s : string) : bool {
             let c = int(arr[i])
             if (c == '\\' || (c == '/' && (i + 1 >= n || int(arr[i + 1]) != ' '))) {
                 shaped = true
+                break
             }
         }
     }
@@ -727,8 +726,8 @@ def exchange_strip_private(text : string) : string {
         var pt & = unsafe(prov.value as _object)
         var drop : array<string>
         for (k, v in keys(pt), values(pt)) {
-            let shaped = v != null && v.value is _string && path_shaped(v.value as _string)
-            if (k == "binary" || shaped) {
+            let is_path = v != null && v.value is _string && path_shaped(v.value as _string)
+            if (k == "binary" || is_path) {
                 drop |> push("{k}")   // clone — k aliases the key the erase below frees
             }
         }

--- a/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
+++ b/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
@@ -694,12 +694,27 @@ def private validate_sidecar_doc(doc : JsonValue const?; submission : bool; var 
     return empty(errors)
 }
 
+// Any backslash, or a slash glued to what follows (`/home/x`, `bin/daslang`, `C:/x`, a
+// trailing `/`). A slash followed by a space is prose, not a path: AMD APU brand strings read
+// `... 8700GE w/ Radeon 780M Graphics`, and that string is the box identity itself.
+def private path_shaped(s : string) : bool {
+    var shaped = false
+    peek_data(s) $(arr) {
+        let n = length(arr)
+        for (i in range(n)) {
+            let c = int(arr[i])
+            if (c == '\\' || (c == '/' && (i + 1 >= n || int(arr[i + 1]) != ' '))) {
+                shaped = true
+            }
+        }
+    }
+    return shaped
+}
+
 //! Strip what must never leave (or reach) a public store: `provenance.binary` (a full local
-//! path with the username in it) and any other path-shaped provenance value. The box identity
-//! keys are exempt — a cpu brand string can carry a slash (`... 8700GE w/ Radeon 780M`), and
-//! a document stripped of its box is not a sidecar at all. Returns the stripped document, ""
-//! when the input does not parse. The submitting client AND the ladder service both run this
-//! — defense in depth against a client that skipped it.
+//! path with the username in it) and any other path-shaped provenance value. Returns the
+//! stripped document, "" when the input does not parse. The submitting client AND the ladder
+//! service both run this — defense in depth against a client that skipped it.
 def exchange_strip_private(text : string) : string {
     var jerr = ""
     var doc = read_json(text, jerr)
@@ -711,12 +726,8 @@ def exchange_strip_private(text : string) : string {
         var pt & = unsafe(prov.value as _object)
         var drop : array<string>
         for (k, v in keys(pt), values(pt)) {
-            var path_shaped = false
-            if (v != null && v.value is _string && k != "box" && k != "applied_box") {
-                let s = v.value as _string
-                path_shaped = find(s, "/") >= 0 || find(s, "\\") >= 0
-            }
-            if (k == "binary" || path_shaped) {
+            let shaped = v != null && v.value is _string && path_shaped(v.value as _string)
+            if (k == "binary" || shaped) {
                 drop |> push("{k}")   // clone — k aliases the key the erase below frees
             }
         }

--- a/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
+++ b/modules/dasLLAMA/dasllama/dasllama_exchange_schema.das
@@ -695,9 +695,11 @@ def private validate_sidecar_doc(doc : JsonValue const?; submission : bool; var 
 }
 
 //! Strip what must never leave (or reach) a public store: `provenance.binary` (a full local
-//! path with the username in it) and any other path-shaped provenance value. Returns the
-//! stripped document, "" when the input does not parse. The submitting client AND the ladder
-//! service both run this — defense in depth against a client that skipped it.
+//! path with the username in it) and any other path-shaped provenance value. The box identity
+//! keys are exempt — a cpu brand string can carry a slash (`... 8700GE w/ Radeon 780M`), and
+//! a document stripped of its box is not a sidecar at all. Returns the stripped document, ""
+//! when the input does not parse. The submitting client AND the ladder service both run this
+//! — defense in depth against a client that skipped it.
 def exchange_strip_private(text : string) : string {
     var jerr = ""
     var doc = read_json(text, jerr)
@@ -710,7 +712,7 @@ def exchange_strip_private(text : string) : string {
         var drop : array<string>
         for (k, v in keys(pt), values(pt)) {
             var path_shaped = false
-            if (v != null && v.value is _string) {
+            if (v != null && v.value is _string && k != "box" && k != "applied_box") {
                 let s = v.value as _string
                 path_shaped = find(s, "/") >= 0 || find(s, "\\") >= 0
             }

--- a/skills/comment_style_hygiene.md
+++ b/skills/comment_style_hygiene.md
@@ -180,7 +180,8 @@ the implementation.
 
 ## Shape
 
-**A flag set-then-returned is a return in disguise** *(lintable — STYLE041)*.
+**A flag set-then-returned is a return in disguise** *(partly lintable — STYLE041; a set
+that keeps looping and the walk-abort-in-callback form stay the reviewer's)*.
 A bool initialized false, set on failure paths, then immediately
 consumed by a single `if (flag) return/error` — collapse to a direct return at each
 set site. The flag form often keeps looping after the answer is known and reports

--- a/utils/dasllama-server/test_exchange_client.das
+++ b/utils/dasllama-server/test_exchange_client.das
@@ -326,38 +326,39 @@ def test_privacy_strip(t : T?) {
         tt |> equal(exchange_strip_private("not json at all"), "")
     }
     t |> run("a slash in the box identity is not a path") @(tt : T?) {
-        // AMD APU brand strings read "... w/ Radeon ..."; stripping the box leaves no sidecar
-        let apu = "linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
-        let stripped = exchange_strip_private(fixture_sidecar(apu, DASLLAMA_VERSION, "vec16"))
-        tt |> success(find(stripped, apu) >= 0, "box survives")
+        let apu_box = "linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
+        let stripped = exchange_strip_private(fixture_sidecar(apu_box, DASLLAMA_VERSION, "vec16"))
+        tt |> success(find(stripped, apu_box) >= 0, "box survives")
         var errs : array<string>
-        tt |> success(validate_sidecar_submission(stripped, errs), "still submission-grade")
+        tt |> success(validate_sidecar_submission(stripped, errs), "box intact, so the doc is still submission-grade")
         delete errs
     }
     t |> run("a path smuggled into the identity keys is still stripped") @(tt : T?) {
-        // the identity keys are not exempt - a five-field box ending in a path, or an
-        // applied_box (never structurally validated), must not reach the public store
         let smuggled = exchange_strip_private(fixture_sidecar("linux|x86_64||6.1|/home/alice/tool", DASLLAMA_VERSION, "vec16"))
         tt |> success(find(smuggled, "alice") < 0, "path-shaped box is gone")
         var errs : array<string>
         tt |> success(!validate_sidecar_submission(smuggled, errs), "and the document is refused")
         delete errs
+        // applied_box is never structurally validated - a path there must still not reach the public store
         var doc = JV((
             kernels = (dot = "vec16"),
             provenance = (
                 box = tune_box_identity(),
                 applied_box = "darwin|arm64|Mac|25F84|C:\\Users\\bob",
+                trailing = "Graphics/",
                 dasllama_version = "{DASLLAMA_VERSION}")))
         let text = write_json(doc)
         delete_json(doc)
-        tt |> success(find(exchange_strip_private(text), "bob") < 0, "path-shaped applied_box is gone")
+        let cleaned = exchange_strip_private(text)
+        tt |> success(find(cleaned, "bob") < 0, "path-shaped applied_box is gone")
+        tt |> success(find(cleaned, "trailing") < 0, "a trailing slash is a path")
         // an absolute path is a path even when every component starts with a space
-        var abs = JV((
+        var abs_doc = JV((
             kernels = (dot = "vec16"),
             provenance = (box = tune_box_identity(), leak = "/ Users/ alice", home = "~/ alice",
                 dasllama_version = "{DASLLAMA_VERSION}")))
-        let abs_text = write_json(abs)
-        delete_json(abs)
+        let abs_text = write_json(abs_doc)
+        delete_json(abs_doc)
         tt |> success(find(exchange_strip_private(abs_text), "alice") < 0, "leading-slash and tilde values are gone")
     }
 }

--- a/utils/dasllama-server/test_exchange_client.das
+++ b/utils/dasllama-server/test_exchange_client.das
@@ -334,6 +334,24 @@ def test_privacy_strip(t : T?) {
         tt |> success(validate_sidecar_submission(stripped, errs), "still submission-grade")
         delete errs
     }
+    t |> run("a path smuggled into the identity keys is still stripped") @(tt : T?) {
+        // the identity keys are not exempt - a five-field box ending in a path, or an
+        // applied_box (never structurally validated), must not reach the public store
+        let smuggled = exchange_strip_private(fixture_sidecar("linux|x86_64||6.1|/home/alice/tool", DASLLAMA_VERSION, "vec16"))
+        tt |> success(find(smuggled, "alice") < 0, "path-shaped box is gone")
+        var errs : array<string>
+        tt |> success(!validate_sidecar_submission(smuggled, errs), "and the document is refused")
+        delete errs
+        var doc = JV((
+            kernels = (dot = "vec16"),
+            provenance = (
+                box = tune_box_identity(),
+                applied_box = "darwin|arm64|Mac|25F84|C:\\Users\\bob",
+                dasllama_version = "{DASLLAMA_VERSION}")))
+        let text = write_json(doc)
+        delete_json(doc)
+        tt |> success(find(exchange_strip_private(text), "bob") < 0, "path-shaped applied_box is gone")
+    }
 }
 
 [test]

--- a/utils/dasllama-server/test_exchange_client.das
+++ b/utils/dasllama-server/test_exchange_client.das
@@ -351,6 +351,14 @@ def test_privacy_strip(t : T?) {
         let text = write_json(doc)
         delete_json(doc)
         tt |> success(find(exchange_strip_private(text), "bob") < 0, "path-shaped applied_box is gone")
+        // an absolute path is a path even when every component starts with a space
+        var abs = JV((
+            kernels = (dot = "vec16"),
+            provenance = (box = tune_box_identity(), leak = "/ Users/ alice", home = "~/ alice",
+                dasllama_version = "{DASLLAMA_VERSION}")))
+        let abs_text = write_json(abs)
+        delete_json(abs)
+        tt |> success(find(exchange_strip_private(abs_text), "alice") < 0, "leading-slash and tilde values are gone")
     }
 }
 

--- a/utils/dasllama-server/test_exchange_client.das
+++ b/utils/dasllama-server/test_exchange_client.das
@@ -325,6 +325,15 @@ def test_privacy_strip(t : T?) {
     t |> run("garbage never leaves the box") @(tt : T?) {
         tt |> equal(exchange_strip_private("not json at all"), "")
     }
+    t |> run("a slash in the box identity is not a path") @(tt : T?) {
+        // AMD APU brand strings read "... w/ Radeon ..."; stripping the box leaves no sidecar
+        let apu = "linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
+        let stripped = exchange_strip_private(fixture_sidecar(apu, DASLLAMA_VERSION, "vec16"))
+        tt |> success(find(stripped, apu) >= 0, "box survives")
+        var errs : array<string>
+        tt |> success(validate_sidecar_submission(stripped, errs), "still submission-grade")
+        delete errs
+    }
 }
 
 [test]

--- a/utils/internal/dasllama-ladder/REVIEW.md
+++ b/utils/internal/dasllama-ladder/REVIEW.md
@@ -135,3 +135,6 @@ its line here, with its tests, in the same change.**
   operator-edited after deploy.
 - `_ladder_test_common.das` — shared test fixtures, required by bare name from the store and
   server suites (the leading `_` keeps dastest's walker away).
+- `test_ladder_store.das` — the store suite: `ladder_store` calls against `:memory:`, no server.
+- `test_ladder_server.das` — the HTTP suite: routes through `with_ladder_server` on port 19015.
+- `test_ladder_config.das` — the config suite: the defaults/toml/CLI merge and its provenance.

--- a/utils/internal/dasllama-ladder/test_ladder_store.das
+++ b/utils/internal/dasllama-ladder/test_ladder_store.das
@@ -58,6 +58,19 @@ def test_put_sidecar(t : T?) {
             tt |> success(find(stored, "\"noise\"") >= 0, "plain provenance survives")
             tt |> equal(sha256_hex(stored), put.sha, "the sha is of the stripped text")
         }
+        t |> run("a slash in the cpu brand string does not strip the box") @(tt : T?) {
+            // zen4's identity - the strip once ate it as path-shaped and the plant 400'd
+            let apu = "linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
+            let put = plant_sidecar(db, sidecar_doc(apu, "4", "vec16"), test_policy(), 3100l)
+            tt |> success(put.status == PutStatus.ok, "planted: {put.error}")
+            tt |> success(find(get_sidecar_doc(db, put.sha), "w/ Radeon") >= 0, "box survived the strip")
+            var ident : BoxIdentity
+            parse_box_string(apu, ident)
+            var hits <- find_sidecars(db, 4, ident)
+            tt |> equal(length(hits), 1, "indexed under its own box")
+            tt |> success(hits[0].verified && hits[0].tier == "exact", "verified, exact tier")
+            delete hits
+        }
         t |> run("an unversioned sidecar is refused") @(tt : T?) {
             var bad = %json~
             {

--- a/utils/internal/dasllama-ladder/test_ladder_store.das
+++ b/utils/internal/dasllama-ladder/test_ladder_store.das
@@ -65,7 +65,7 @@ def test_put_sidecar(t : T?) {
             tt |> success(put.status == PutStatus.ok, "planted: {put.error}")
             tt |> success(find(get_sidecar_doc(db, put.sha), "w/ Radeon") >= 0, "box survived the strip")
             var ident : BoxIdentity
-            parse_box_string(apu_box, ident)
+            tt |> success(parse_box_string(apu_box, ident), "the box string parses")
             var hits <- find_sidecars(db, 4, ident)
             tt |> equal(length(hits), 1, "indexed under its own box")
             tt |> success(hits[0].verified && hits[0].tier == "exact", "verified, exact tier")

--- a/utils/internal/dasllama-ladder/test_ladder_store.das
+++ b/utils/internal/dasllama-ladder/test_ladder_store.das
@@ -59,13 +59,13 @@ def test_put_sidecar(t : T?) {
             tt |> equal(sha256_hex(stored), put.sha, "the sha is of the stripped text")
         }
         t |> run("a slash in the cpu brand string does not strip the box") @(tt : T?) {
-            // zen4's identity - the strip once ate it as path-shaped and the plant 400'd
-            let apu = "linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
-            let put = plant_sidecar(db, sidecar_doc(apu, "4", "vec16"), test_policy(), 3100l)
+            // zen4's box: read "w/ Radeon" as a path and the identity is stripped away, so the plant refuses with 400
+            let apu_box = "linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
+            let put = plant_sidecar(db, sidecar_doc(apu_box, "4", "vec16"), test_policy(), 3100l)
             tt |> success(put.status == PutStatus.ok, "planted: {put.error}")
             tt |> success(find(get_sidecar_doc(db, put.sha), "w/ Radeon") >= 0, "box survived the strip")
             var ident : BoxIdentity
-            parse_box_string(apu, ident)
+            parse_box_string(apu_box, ident)
             var hits <- find_sidecars(db, 4, ident)
             tt |> equal(length(hits), 1, "indexed under its own box")
             tt |> success(hits[0].verified && hits[0].tier == "exact", "verified, exact tier")


### PR DESCRIPTION
**Behavior change: the exchange privacy strip keeps a provenance value whose only slash is followed by a space — the deployed ladder runs this tip since 2026-08-19 (`current -> fcc582828`, then re-installed at the final sha).**

Planting the first official v4 zen4 sidecar failed with `provenance.box: required string missing`. The cause was `exchange_strip_private`: any provenance value containing `/` counted as path-shaped and was dropped, and zen4's box identity reads `linux|x86_64||6.1.0-49-amd64|AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics`. Every AMD APU box was locked out of the exchange on both sides of the wire — the client strips before submit, the ladder strips before plant/put.

The fix makes "path-shaped" precise instead of exempting keys: a backslash, a leading `/` or `~` (the username-carrying shape), or a slash glued to what follows (`bin/daslang`, `C:/x`, a trailing `/`). A slash followed by a space is prose. No key is exempt — an earlier cut exempted `box`/`applied_box`, and the external review showed that lets a crafted path reach the public store (`applied_box` is never structurally validated). Regression tests pin both directions in the client suite and the ladder store suite (plant + lookup ladder on the zen4 identity).

Two rule-doc edits ride along from the checklist audits: the ladder placement block now lists its three test suites (a diff to one had no line to stay inside), and the hygiene skill's STYLE041 marker says what the lint actually covers.

Where to look: `path_shaped` in `modules/dasLLAMA/dasllama/dasllama_exchange_schema.das`; the new arms in `test_privacy_strip` (client) and `test_put_sidecar` (store).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Live: ladder redeployed from this branch on dasweb-1; the zen4 v4 sidecar planted (sha `452895f3…`, verified, exact-tier hit for its box), a re-plant after each later tip dedups (`created: false`) — the strip output is hash-stable for the one stored sidecar.
- `modules/dasLLAMA/tests/test_exchange_schema.das` 21/21 and `run.das -- --suite model-free` on zen4 (Linux): every suite green except `test_vulkan_kernels` (2 errors) / `test_vulkan_tier` (SIGSEGV) — `ERROR_INCOMPATIBLE_DRIVER`, zen4 has the Vulkan loader but no ICD; box environment, not this diff (the two suites do not skip cleanly on a driver-less box — worth its own fix). Locally one pre-existing red in the corpus test from an autocrlf CRLF checkout, unrelated.
- Targeted gates only (lint, format, the three suites); no full preflight — a 3-file change.

### Claims — stated, not tested
- `redact_bare` (records rail) keeps the old broad slash test; it only sees space-split `cmd`/`env` tokens and `files[].name`, never a cpu string, so it is unaffected. Out of scope here.

### Not done
- The external reviewer's round-2 example `private/ Documents` (a relative path whose every component starts with a space) still passes the strip — a deliberate self-leak outside the rail's threat model (the strip guards a client's own accidental path stamps; every other provenance string already publishes arbitrary printable text). Recorded, not fixed.
- Checklist self-review findings ledgered for a grooming pass, not this PR: `modules/dasLLAMA/REVIEW.md` routing paragraph is six routings in one (the step-0a walk cannot surface KIND-routed checklists — `tests/` and `performance/` REVIEW.md were audited by hand here); "tool wire text" undefined; `utils/REVIEW.md` tool-directory definition vs its gate's exclusions, fused mechanism sentence, unnamed settling artifact for the `DAS_UTILS_SHIPPED_EXES` record; the strip-output-stability obligation has no home (belongs beside the strip rule in `modules/dasLLAMA/performance/REVIEW.md`); the ladder `REVIEW.md` itself carries a dragon sweep's worth of pre-existing simplify/split/dedupe findings (the test-rule tail that exempts `main.das`/`admin.das`, the `is_operator_caller` rule as two checks, the store-backed-handler second sentence, three rules mechanical enough for a `REVIEW.das` gate) — a grooming PR, not this one.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
