### PR TITLE
examples: Boulder Dash live tribute

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,8 @@ daslang-live.exe examples/games/arcanoid/main.das
 | Directory | Description |
 |-----------|-------------|
 | `arcanoid/` | Breakout game: DECS, OpenGL, procedural audio, strudel music, 30+ live commands |
+| `pacman/` | Pac-Man: maze, ghosts, power pills, strudel music |
+| `boulder-dash/` | Boulder Dash–style caves: scan-line physics, seeded generator, grab, quota + timer |
 | `sequence/` | Sequence card board game: multi-module, bot AI, ELO tournament runner (requires `daspkg install`) |
 
 ## debugapi/ — Debug Agent Examples

--- a/examples/games/boulder-dash/CLAUDE.md
+++ b/examples/games/boulder-dash/CLAUDE.md
@@ -1,0 +1,47 @@
+# Boulder Dash — daslang-live Example
+
+Tribute clone of classic Boulder Dash cave physics. Not original First Star cave data.
+
+## Running
+
+```bash
+# Live-reload mode
+bin/Release/daslang-live.exe examples/games/boulder-dash/main.das
+
+# Standalone
+bin/Release/daslang.exe examples/games/boulder-dash/main.das
+
+# Headless smoke
+bin/Release/daslang.exe examples/games/boulder-dash/main.das -- --max-frames 3
+
+# Physics / generator tests (no GLFW)
+bin/Release/daslang.exe dastest/dastest.das -- --test examples/games/boulder-dash/test_cave.das
+bin/Release/daslang.exe dastest/dastest.das -- --test examples/games/boulder-dash/test_generate.das
+```
+
+## Controls
+
+- **Arrow keys** — one tap is one cell. Motion starts on press and lands on the next cave tick. A new direction after motion has started waits for the following cell. Hold ~0.3s to keep walking.
+- **Z** or **Ctrl** — grab: dig/collect the adjacent tile without stepping (also queued)
+- **Space** — start / resume after game over / skip cave-cleared pause
+- **Escape** — pause / unpause
+
+## Gameplay
+
+- 40×22 cave, 8 Hz scan-line physics, movers interpolated between ticks
+- Dirt, boulders, diamonds, brick, steel, fireflies, butterflies, amoeba, magic wall, expanding wall, slime
+- Collect the quota to open the exit; timer kills; 3 lives
+- Caves are generated from `(seed, cave_index)` — Liepa-style random fill plus rectangular patches
+
+## Architecture
+
+- `cave.das` — tiles, scan tick, ASCII I/O (no GLFW)
+- `cave_gen.das` — seeded generator
+- `main.das` — GLFW/OpenGL, audio, HUD, live commands
+- `test_*.das` — headless dastest
+
+ASCII legend lives next to `TILE_CH` in `cave.das`.
+
+## Live commands
+
+`cmd_game_status`, `cmd_reset_game`, `cmd_set_seed`, `cmd_next_cave`, `cmd_prev_cave`, `cmd_god_mode`, `cmd_set_time`, `cmd_set_diamonds`, `cmd_dump_cave`, `cmd_load_ascii`, `cmd_tick`, `cmd_slow_motion`, plus built-in `screenshot` / `help`.

--- a/examples/games/boulder-dash/cave.das
+++ b/examples/games/boulder-dash/cave.das
@@ -613,8 +613,22 @@ def process_player(var c : Cave; x, y : int) {
     try_step(c, x, y, nx, ny, d)
 }
 
+def insect_hits_blast(c : Cave; x, y : int) : bool {
+    for (d in range(4)) {
+        let n = cave_at(c, x + DIR_X[d], y + DIR_Y[d])
+        if (n == Tile.amoeba || n == Tile.boulder_fall || n == Tile.diamond_fall) {
+            return true
+        }
+    }
+    return false
+}
+
 def process_insect(var c : Cave; x, y : int) {
     let t = cave_at(c, x, y)
+    if (insect_hits_blast(c, x, y)) {
+        explode_at(c, x, y, is_butterfly(t))
+        return
+    }
     let fly = is_firefly(t)
     let heading = insect_dir(t)
     let turns = fly ? FLY_TURN : BUTTER_TURN

--- a/examples/games/boulder-dash/cave.das
+++ b/examples/games/boulder-dash/cave.das
@@ -1,0 +1,881 @@
+options gen2
+options persistent_heap
+
+module cave public
+
+require math
+require daslib/random
+require daslib/strings_boost
+
+// C64 cave size. Tests may use smaller grids.
+let CAVE_COLS = 40
+let CAVE_ROWS = 22
+let CAVE_HZ = 8.0
+let AMOEBA_MAX = 200
+let DEFAULT_MAGIC_TIME = 20.0
+let DEFAULT_AMOEBA_GROW = 0.03
+let DEFAULT_SLIME_PERM = 0.2
+
+// Legend (char ↔ Tile, enum order):
+//   . empty   : dirt     o boulder   ! boulder_fall
+//   * diamond $ diamond_fall  # brick  X steel
+//   M magic   m magic_active  = expand  ~ slime
+//   nesw firefly NESW   ABCD butterfly NESW
+//   a amoeba  R player  E exit_closed  O exit_open
+//   123 empty-explosion   456 diamond-explosion
+enum Tile : int {
+    empty = 0
+    dirt
+    boulder
+    boulder_fall
+    diamond
+    diamond_fall
+    brick
+    steel
+    magic
+    magic_active
+    expand
+    slime
+    firefly_u
+    firefly_r
+    firefly_d
+    firefly_l
+    butterfly_u
+    butterfly_r
+    butterfly_d
+    butterfly_l
+    amoeba
+    player
+    exit_closed
+    exit_open
+    explode0
+    explode1
+    explode2
+    dexplode0
+    dexplode1
+    dexplode2
+}
+
+let TILE_N = 30
+let TILE_CH = fixed_array(
+    '.', ':', 'o', '!', '*', '$', '#', 'X',
+    'M', 'm', '=', '~',
+    'n', 'e', 's', 'w',
+    'A', 'B', 'C', 'D',
+    'a', 'R', 'E', 'O',
+    '1', '2', '3', '4', '5', '6'
+)
+
+let DIR_X = fixed_array(0, 1, 0, -1)
+let DIR_Y = fixed_array(-1, 0, 1, 0)
+let FLY_TURN = fixed_array(3, 0, 1, 2)
+let BUTTER_TURN = fixed_array(1, 0, 3, 2)
+
+struct Mover {
+    from_x : int
+    from_y : int
+    to_x : int
+    to_y : int
+    tile : Tile
+}
+
+struct Cave {
+    cols : int = CAVE_COLS
+    rows : int = CAVE_ROWS
+    cells : array<Tile>
+    scanned : array<bool>
+    movers : array<Mover>
+    rockford : int2 = int2(-1, -1)
+    wish_dir : int2 = int2(0, 0)
+    grab : bool = false
+    input_locked : bool = false
+    next_dir : int2 = int2(0, 0)
+    next_grab : bool = false
+    push_held : int2 = int2(0, 0)
+    diamonds_got : int = 0
+    diamonds_need : int = 0
+    time_left : float = 9999.0
+    magic_timer : float = 0.0
+    magic_time_max : float = DEFAULT_MAGIC_TIME
+    magic_spent : bool = false
+    amoeba_grow : float = DEFAULT_AMOEBA_GROW
+    amoeba_count : int = 0
+    slime_perm : float = DEFAULT_SLIME_PERM
+    rng : int4
+    alive : bool = true
+    god : bool = false
+    cleared : bool = false
+    dug : bool = false
+    collected : int = 0
+    landed_boulder : bool = false
+    landed_diamond : bool = false
+    fell_boulder : bool = false
+    fell_diamond : bool = false
+    exploded : bool = false
+    died : bool = false
+    exit_opened : bool = false
+    timed_out : bool = false
+    pushed : bool = false
+    magic_on : bool = false
+    magic_convert : bool = false
+    amoeba_grew : bool = false
+    amoeba_gems : bool = false
+    amoeba_rocks : bool = false
+    wall_grew : bool = false
+}
+
+def tile_to_char(t : Tile) : int {
+    let i = int(t)
+    if (i < 0 || i >= TILE_N) {
+        return '?'
+    }
+    return TILE_CH[i]
+}
+
+def tile_from_int(i : int) : Tile {
+    return unsafe(reinterpret<Tile>(i))
+}
+
+def char_to_tile(ch : int) : Tile {
+    for (i in range(TILE_N)) {
+        if (TILE_CH[i] == ch) {
+            return tile_from_int(i)
+        }
+    }
+    return Tile.steel
+}
+
+def in_bounds(c : Cave; x, y : int) : bool {
+    return x >= 0 && y >= 0 && x < c.cols && y < c.rows
+}
+
+def cave_idx(c : Cave; x, y : int) : int {
+    return y * c.cols + x
+}
+
+def cave_at(c : Cave; x, y : int) : Tile {
+    if (!in_bounds(c, x, y)) {
+        return Tile.steel
+    }
+    return c.cells[cave_idx(c, x, y)]
+}
+
+def cave_set(var c : Cave; x, y : int; t : Tile) {
+    return if (!in_bounds(c, x, y))
+    c.cells[cave_idx(c, x, y)] = t
+}
+
+def cave_mark_scanned(var c : Cave; x, y : int) {
+    return if (!in_bounds(c, x, y))
+    c.scanned[cave_idx(c, x, y)] = true
+}
+
+def cave_is_scanned(c : Cave; x, y : int) : bool {
+    if (!in_bounds(c, x, y)) {
+        return true
+    }
+    return c.scanned[cave_idx(c, x, y)]
+}
+
+def is_rounded(t : Tile) : bool {
+    return t == Tile.boulder || t == Tile.boulder_fall || t == Tile.diamond || t == Tile.diamond_fall || t == Tile.brick
+}
+
+def is_fallable(t : Tile) : bool {
+    return t == Tile.boulder || t == Tile.boulder_fall || t == Tile.diamond || t == Tile.diamond_fall
+}
+
+def is_firefly(t : Tile) : bool {
+    let i = int(t)
+    return i >= int(Tile.firefly_u) && i <= int(Tile.firefly_l)
+}
+
+def is_butterfly(t : Tile) : bool {
+    let i = int(t)
+    return i >= int(Tile.butterfly_u) && i <= int(Tile.butterfly_l)
+}
+
+def is_insect(t : Tile) : bool {
+    return is_firefly(t) || is_butterfly(t)
+}
+
+def is_explode(t : Tile) : bool {
+    let i = int(t)
+    return i >= int(Tile.explode0) && i <= int(Tile.dexplode2)
+}
+
+def is_gem_tile(t : Tile) : bool {
+    return t == Tile.diamond || t == Tile.diamond_fall
+}
+
+def insect_dir(t : Tile) : int {
+    if (is_firefly(t)) {
+        return int(t) - int(Tile.firefly_u)
+    }
+    return int(t) - int(Tile.butterfly_u)
+}
+
+def insect_tile(fly : bool; dir : int) : Tile {
+    let d = ((dir % 4) + 4) % 4
+    if (fly) {
+        return tile_from_int(int(Tile.firefly_u) + d)
+    }
+    return tile_from_int(int(Tile.butterfly_u) + d)
+}
+
+def falling_variant(gem : bool) : Tile {
+    return gem ? Tile.diamond_fall : Tile.boulder_fall
+}
+
+def settled_variant(gem : bool) : Tile {
+    return gem ? Tile.diamond : Tile.boulder
+}
+
+def make_cave(cols, rows : int) : Cave {
+    var c <- Cave(cols = cols, rows = rows)
+    c.cells |> resize(cols * rows)
+    c.scanned |> resize(cols * rows)
+    c.rng = random_seed(1)
+    return <- c
+}
+
+def adopt_cave(var dst : Cave; var src : Cave) {
+    delete dst.cells
+    delete dst.scanned
+    delete dst.movers
+    dst <- src
+}
+
+def find_rockford(var c : Cave) {
+    c.rockford = int2(-1, -1)
+    for (y in range(c.rows)) {
+        for (x in range(c.cols)) {
+            if (cave_at(c, x, y) == Tile.player) {
+                c.rockford = int2(x, y)
+                return
+            }
+        }
+    }
+}
+
+def cave_from_ascii(text : string) : Cave {
+    let normalized = replace(replace(text, "\r\n", "\n"), "\r", "\n")
+    var lines <- split(normalized, "\n")
+    var rows <- [for (ln in lines); ln; where !empty(ln)]
+    let h = length(rows)
+    var w = 0
+    for (ln in rows) {
+        w = max(w, length(ln))
+    }
+    if (w < 1 || h < 1) {
+        return <- make_cave(1, 1)
+    }
+    var c <- make_cave(w, h)
+    for (y in range(h)) {
+        peek_data(rows[y]) $(d) {
+            for (x in range(w)) {
+                let ch = x < length(d) ? int(d[x]) : 'X'
+                cave_set(c, x, y, char_to_tile(ch))
+            }
+        }
+    }
+    find_rockford(c)
+    return <- c
+}
+
+def cave_to_ascii(c : Cave) : string {
+    return build_string() $(var writer) {
+        for (y in range(c.rows)) {
+            for (x in range(c.cols)) {
+                writer |> write_char(tile_to_char(cave_at(c, x, y)))
+            }
+            if (y + 1 < c.rows) {
+                writer |> write("\n")
+            }
+        }
+    }
+}
+
+def cave_count(c : Cave; t : Tile) : int {
+    var n = 0
+    for (cell in c.cells) {
+        if (cell == t) {
+            n++
+        }
+    }
+    return n
+}
+
+def cave_count_diamonds(c : Cave) : int {
+    var n = 0
+    for (cell in c.cells) {
+        if (is_gem_tile(cell)) {
+            n++
+        }
+    }
+    return n
+}
+
+def reset_tick_events(var c : Cave) {
+    c.dug = false
+    c.collected = 0
+    c.landed_boulder = false
+    c.landed_diamond = false
+    c.fell_boulder = false
+    c.fell_diamond = false
+    c.exploded = false
+    c.died = false
+    c.exit_opened = false
+    c.timed_out = false
+    c.pushed = false
+    c.magic_on = false
+    c.magic_convert = false
+    c.amoeba_grew = false
+    c.amoeba_gems = false
+    c.amoeba_rocks = false
+    c.wall_grew = false
+}
+
+def add_mover(var c : Cave; fx, fy, tx, ty : int; t : Tile) {
+    c.movers |> push <| Mover(
+        from_x = fx, from_y = fy,
+        to_x = tx, to_y = ty,
+        tile = t
+    )
+}
+
+def moved_later(fx, fy, tx, ty : int) : bool {
+    return ty > fy || (ty == fy && tx > fx)
+}
+
+def move_tile(var c : Cave; x, y, nx, ny : int; result : Tile) {
+    cave_set(c, x, y, Tile.empty)
+    cave_set(c, nx, ny, result)
+    if (moved_later(x, y, nx, ny)) {
+        cave_mark_scanned(c, nx, ny)
+    }
+    add_mover(c, x, y, nx, ny, result)
+}
+
+def kill_rockford(var c : Cave) {
+    return if (c.god || !c.alive)
+    c.alive = false
+    c.died = true
+    let p = c.rockford
+    if (in_bounds(c, p.x, p.y) && cave_at(c, p.x, p.y) == Tile.player) {
+        cave_set(c, p.x, p.y, Tile.empty)
+    }
+}
+
+def collect_diamond(var c : Cave) {
+    c.diamonds_got++
+    c.collected++
+}
+
+def explode_cell(var c : Cave; x, y : int; gems : bool) {
+    return if (!in_bounds(c, x, y))
+    let t = cave_at(c, x, y)
+    if (t == Tile.steel || t == Tile.exit_closed || t == Tile.exit_open) {
+        return
+    }
+    if (t == Tile.player) {
+        if (c.god) {
+            return
+        }
+        kill_rockford(c)
+    }
+    cave_set(c, x, y, gems ? Tile.dexplode0 : Tile.explode0)
+    cave_mark_scanned(c, x, y)
+}
+
+def explode_at(var c : Cave; cx, cy : int; gems : bool) {
+    c.exploded = true
+    for (dy in range(-1, 2)) {
+        for (dx in range(-1, 2)) {
+            explode_cell(c, cx + dx, cy + dy, gems)
+        }
+    }
+}
+
+def settle_at(var c : Cave; x, y : int; gem : bool) {
+    cave_set(c, x, y, settled_variant(gem))
+    if (gem) {
+        c.landed_diamond = true
+    } else {
+        c.landed_boulder = true
+    }
+}
+
+def note_fell(var c : Cave; gem : bool) {
+    if (gem) {
+        c.fell_diamond = true
+    } else {
+        c.fell_boulder = true
+    }
+}
+
+def try_crush(var c : Cave; x, y : int; below : Tile; falling, gem : bool) : bool {
+    if (!(falling && below == Tile.player)) {
+        return false
+    }
+    if (c.god) {
+        settle_at(c, x, y, gem)
+        return true
+    }
+    kill_rockford(c)
+    move_tile(c, x, y, x, y + 1, settled_variant(gem))
+    return true
+}
+
+def try_fall_empty(var c : Cave; x, y : int; below : Tile; gem : bool) : bool {
+    if (below != Tile.empty) {
+        return false
+    }
+    move_tile(c, x, y, x, y + 1, falling_variant(gem))
+    note_fell(c, gem)
+    return true
+}
+
+def try_magic_fall(var c : Cave; x, y : int; below : Tile; gem : bool) : bool {
+    if (below != Tile.magic && below != Tile.magic_active) {
+        return false
+    }
+    if (c.magic_spent || cave_at(c, x, y + 2) != Tile.empty) {
+        let cur = cave_at(c, x, y)
+        if (cur == Tile.boulder_fall || cur == Tile.diamond_fall) {
+            settle_at(c, x, y, gem)
+        }
+        return true
+    }
+    if (!c.magic_spent && c.magic_timer <= 0.0) {
+        c.magic_timer = c.magic_time_max
+        c.magic_on = true
+        for (i in range(length(c.cells))) {
+            if (c.cells[i] == Tile.magic) {
+                c.cells[i] = Tile.magic_active
+            }
+        }
+    }
+    move_tile(c, x, y, x, y + 2, falling_variant(!gem))
+    c.magic_convert = true
+    note_fell(c, !gem)
+    return true
+}
+
+def try_slime_fall(var c : Cave; x, y : int; below : Tile; gem : bool) : bool {
+    if (below != Tile.slime) {
+        return false
+    }
+    if (cave_at(c, x, y + 2) == Tile.empty && random_float(c.rng) < c.slime_perm) {
+        move_tile(c, x, y, x, y + 2, falling_variant(gem))
+        note_fell(c, gem)
+        return true
+    }
+    let t = cave_at(c, x, y)
+    if (t == Tile.boulder_fall || t == Tile.diamond_fall) {
+        settle_at(c, x, y, gem)
+    }
+    return true
+}
+
+def try_insect_hit(var c : Cave; x, y : int; below : Tile; falling : bool) : bool {
+    if (!(falling && is_insect(below))) {
+        return false
+    }
+    explode_at(c, x, y + 1, is_butterfly(below))
+    return true
+}
+
+def try_roll_dir(var c : Cave; x, y, dx : int; gem : bool) : bool {
+    if (cave_at(c, x + dx, y) != Tile.empty || cave_at(c, x + dx, y + 1) != Tile.empty) {
+        return false
+    }
+    move_tile(c, x, y, x + dx, y + 1, falling_variant(gem))
+    note_fell(c, gem)
+    return true
+}
+
+def try_roll(var c : Cave; x, y : int; below : Tile; gem : bool) : bool {
+    if (!is_rounded(below)) {
+        return false
+    }
+    if (try_roll_dir(c, x, y, -1, gem)) {
+        return true
+    }
+    return try_roll_dir(c, x, y, 1, gem)
+}
+
+def process_fallable(var c : Cave; x, y : int) {
+    let t = cave_at(c, x, y)
+    let falling = t == Tile.boulder_fall || t == Tile.diamond_fall
+    let gem = is_gem_tile(t)
+    let below = cave_at(c, x, y + 1)
+    if (try_crush(c, x, y, below, falling, gem) || try_fall_empty(c, x, y, below, gem) || try_magic_fall(c, x, y, below, gem) || try_slime_fall(c, x, y, below, gem) || try_insect_hit(c, x, y, below, falling) || (!falling && try_roll(c, x, y, below, gem))) {
+        return
+    }
+    if (falling) {
+        settle_at(c, x, y, gem)
+    }
+}
+
+def try_grab(var c : Cave; nx, ny : int) {
+    let dest = cave_at(c, nx, ny)
+    if (dest == Tile.dirt) {
+        cave_set(c, nx, ny, Tile.empty)
+        c.dug = true
+    } elif (is_gem_tile(dest)) {
+        cave_set(c, nx, ny, Tile.empty)
+        collect_diamond(c)
+    }
+}
+
+def player_enter(var c : Cave; x, y, nx, ny : int; dest : Tile) {
+    if (dest == Tile.dirt) {
+        c.dug = true
+    } elif (is_gem_tile(dest)) {
+        collect_diamond(c)
+    } elif (dest == Tile.exit_open) {
+        c.cleared = true
+        cave_set(c, x, y, Tile.empty)
+        c.rockford = int2(nx, ny)
+        add_mover(c, x, y, nx, ny, Tile.player)
+        return
+    }
+    move_tile(c, x, y, nx, ny, Tile.player)
+    c.rockford = int2(nx, ny)
+}
+
+def try_push(var c : Cave; x, y, nx, ny : int; d : int2; dest : Tile) : bool {
+    if (dest != Tile.boulder || d.y != 0 || d.x == 0) {
+        return false
+    }
+    let bx = nx + d.x
+    let by = ny
+    if (cave_at(c, bx, by) != Tile.empty) {
+        return false
+    }
+    if (c.push_held != d) {
+        c.push_held = d
+        return true
+    }
+    move_tile(c, nx, ny, bx, by, Tile.boulder)
+    move_tile(c, x, y, nx, ny, Tile.player)
+    c.rockford = int2(nx, ny)
+    c.push_held = d
+    c.pushed = true
+    return true
+}
+
+def try_step(var c : Cave; x, y, nx, ny : int; d : int2) {
+    let dest = cave_at(c, nx, ny)
+    if (is_insect(dest) || dest == Tile.amoeba || is_explode(dest)) {
+        if (is_insect(dest) || is_explode(dest)) {
+            kill_rockford(c)
+        }
+        c.push_held = int2(0)
+        return
+    }
+    if (try_push(c, x, y, nx, ny, d, dest)) {
+        return
+    }
+    if (dest == Tile.empty || dest == Tile.dirt || is_gem_tile(dest) || dest == Tile.exit_open) {
+        c.push_held = int2(0)
+        player_enter(c, x, y, nx, ny, dest)
+        return
+    }
+    if (dest == Tile.boulder) {
+        c.push_held = d
+        return
+    }
+    c.push_held = int2(0)
+}
+
+def process_player(var c : Cave; x, y : int) {
+    if (!c.alive || c.cleared) {
+        return
+    }
+    c.rockford = int2(x, y)
+    let d = c.wish_dir
+    if (d.x == 0 && d.y == 0) {
+        c.push_held = int2(0)
+        return
+    }
+    let nx = x + d.x
+    let ny = y + d.y
+    if (!in_bounds(c, nx, ny)) {
+        return
+    }
+    if (c.grab) {
+        try_grab(c, nx, ny)
+        c.push_held = int2(0)
+        return
+    }
+    try_step(c, x, y, nx, ny, d)
+}
+
+def process_insect(var c : Cave; x, y : int) {
+    let t = cave_at(c, x, y)
+    let fly = is_firefly(t)
+    let heading = insect_dir(t)
+    let turns = fly ? FLY_TURN : BUTTER_TURN
+    for (k in range(4)) {
+        let nd = (heading + turns[k]) % 4
+        let nx = x + DIR_X[nd]
+        let ny = y + DIR_Y[nd]
+        let dest = cave_at(c, nx, ny)
+        if (dest == Tile.player) {
+            kill_rockford(c)
+            if (c.god) {
+                return
+            }
+            move_tile(c, x, y, nx, ny, insect_tile(fly, nd))
+            return
+        }
+        if (dest == Tile.empty) {
+            move_tile(c, x, y, nx, ny, insect_tile(fly, nd))
+            return
+        }
+    }
+}
+
+def process_expand(var c : Cave; x, y : int) {
+    if (cave_at(c, x - 1, y) == Tile.empty) {
+        cave_set(c, x - 1, y, Tile.expand)
+        add_mover(c, x, y, x - 1, y, Tile.expand)
+        c.wall_grew = true
+        return
+    }
+    if (cave_at(c, x + 1, y) == Tile.empty) {
+        cave_set(c, x + 1, y, Tile.expand)
+        cave_mark_scanned(c, x + 1, y)
+        add_mover(c, x, y, x + 1, y, Tile.expand)
+        c.wall_grew = true
+    }
+}
+
+def process_explode(var c : Cave; x, y : int) {
+    let t = cave_at(c, x, y)
+    if (t == Tile.explode0) {
+        cave_set(c, x, y, Tile.explode1)
+    } elif (t == Tile.explode1) {
+        cave_set(c, x, y, Tile.explode2)
+    } elif (t == Tile.explode2) {
+        cave_set(c, x, y, Tile.empty)
+    } elif (t == Tile.dexplode0) {
+        cave_set(c, x, y, Tile.dexplode1)
+    } elif (t == Tile.dexplode1) {
+        cave_set(c, x, y, Tile.dexplode2)
+    } elif (t == Tile.dexplode2) {
+        cave_set(c, x, y, Tile.diamond)
+    }
+}
+
+def process_cell(var c : Cave; x, y : int) {
+    let t = cave_at(c, x, y)
+    if (is_fallable(t)) {
+        process_fallable(c, x, y)
+    } elif (t == Tile.player) {
+        process_player(c, x, y)
+    } elif (is_insect(t)) {
+        process_insect(c, x, y)
+    } elif (t == Tile.expand) {
+        process_expand(c, x, y)
+    } elif (is_explode(t)) {
+        process_explode(c, x, y)
+    }
+}
+
+def amoeba_can_grow_from(c : Cave; x, y : int) : bool {
+    for (d in range(4)) {
+        let t = cave_at(c, x + DIR_X[d], y + DIR_Y[d])
+        if (t == Tile.empty || t == Tile.dirt || t == Tile.player) {
+            return true
+        }
+    }
+    return false
+}
+
+def replace_all(var c : Cave; from, to : Tile) {
+    for (i in range(length(c.cells))) {
+        if (c.cells[i] == from) {
+            c.cells[i] = to
+        }
+    }
+}
+
+def grow_amoeba_at(var c : Cave; x, y : int) {
+    var n = 0
+    var ox : int[4]
+    var oy : int[4]
+    for (d in range(4)) {
+        let nx = x + DIR_X[d]
+        let ny = y + DIR_Y[d]
+        let t = cave_at(c, nx, ny)
+        if (t == Tile.empty || t == Tile.dirt || t == Tile.player) {
+            ox[n] = nx
+            oy[n] = ny
+            n++
+        }
+    }
+    return if (n == 0)
+    let k = random_int(c.rng) % n
+    let nx = ox[k]
+    let ny = oy[k]
+    if (cave_at(c, nx, ny) == Tile.player) {
+        if (c.god) {
+            return
+        }
+        kill_rockford(c)
+    }
+    cave_set(c, nx, ny, Tile.amoeba)
+}
+
+def amoeba_pass(var c : Cave) {
+    var count = 0
+    var growable = 0
+    for (y in range(c.rows)) {
+        for (x in range(c.cols)) {
+            if (cave_at(c, x, y) == Tile.amoeba) {
+                count++
+                if (amoeba_can_grow_from(c, x, y)) {
+                    growable++
+                }
+            }
+        }
+    }
+    c.amoeba_count = count
+    return if (count == 0)
+    if (count >= AMOEBA_MAX) {
+        replace_all(c, Tile.amoeba, Tile.boulder)
+        c.amoeba_rocks = true
+        return
+    }
+    if (growable == 0) {
+        replace_all(c, Tile.amoeba, Tile.diamond)
+        c.amoeba_gems = true
+        return
+    }
+    for (y in range(c.rows)) {
+        for (x in range(c.cols)) {
+            if (cave_at(c, x, y) == Tile.amoeba && amoeba_can_grow_from(c, x, y)) {
+                if (random_float(c.rng) < c.amoeba_grow) {
+                    grow_amoeba_at(c, x, y)
+                    c.amoeba_grew = true
+                }
+            }
+        }
+    }
+}
+
+def magic_pass(var c : Cave) {
+    return if (c.magic_timer <= 0.0)
+    c.magic_timer -= 1.0 / CAVE_HZ
+    if (c.magic_timer <= 0.0) {
+        c.magic_timer = 0.0
+        c.magic_spent = true
+        replace_all(c, Tile.magic_active, Tile.brick)
+        replace_all(c, Tile.magic, Tile.brick)
+    }
+}
+
+def exit_pass(var c : Cave) {
+    return if (c.diamonds_need <= 0 || c.diamonds_got < c.diamonds_need)
+    var opened = false
+    for (i in range(length(c.cells))) {
+        if (c.cells[i] == Tile.exit_closed) {
+            c.cells[i] = Tile.exit_open
+            opened = true
+        }
+    }
+    if (opened) {
+        c.exit_opened = true
+    }
+}
+
+def cave_tick(var c : Cave) {
+    reset_tick_events(c)
+    c.movers |> resize(0)
+    let n = c.cols * c.rows
+    if (length(c.scanned) != n) {
+        c.scanned |> resize(n)
+    }
+    for (i in range(n)) {
+        c.scanned[i] = false
+    }
+    for (y in range(c.rows)) {
+        for (x in range(c.cols)) {
+            if (!cave_is_scanned(c, x, y)) {
+                process_cell(c, x, y)
+            }
+        }
+    }
+    amoeba_pass(c)
+    magic_pass(c)
+    exit_pass(c)
+}
+
+def cave_apply_time(var c : Cave; dt : float) {
+    return if (!c.alive || c.cleared || c.god)
+    c.time_left -= dt
+    if (c.time_left <= 0.0) {
+        c.time_left = 0.0
+        c.timed_out = true
+        kill_rockford(c)
+    }
+}
+
+def cave_set_input(var c : Cave; dir : int2; grab : bool) {
+    c.wish_dir = dir
+    c.grab = grab
+    c.input_locked = false
+    c.next_dir = int2(0, 0)
+    c.next_grab = false
+}
+
+def cave_lock_input(var c : Cave) {
+    c.input_locked = true
+}
+
+def cave_consume_input(var c : Cave) {
+    c.input_locked = false
+    c.wish_dir = c.next_dir
+    c.grab = c.next_grab
+    c.next_dir = int2(0, 0)
+    c.next_grab = false
+}
+
+def cave_latch_input(var c : Cave; dir : int2; grab : bool) {
+    if (dir.x != 0 || dir.y != 0) {
+        if (c.input_locked) {
+            if (dir.x != c.wish_dir.x || dir.y != c.wish_dir.y) {
+                c.next_dir = dir
+            }
+        } else {
+            c.wish_dir = dir
+        }
+    }
+    if (grab) {
+        if (c.input_locked) {
+            c.next_grab = true
+        } else {
+            c.grab = true
+        }
+    }
+}
+
+def cave_peek_step(c : Cave; dir : int2) : int2 {
+    let p = c.rockford
+    if (!c.alive || (dir.x == 0 && dir.y == 0)) {
+        return p
+    }
+    let nx = p.x + dir.x
+    let ny = p.y + dir.y
+    if (!in_bounds(c, nx, ny)) {
+        return p
+    }
+    let dest = cave_at(c, nx, ny)
+    if (dest == Tile.empty || dest == Tile.dirt || is_gem_tile(dest) || dest == Tile.exit_open) {
+        return int2(nx, ny)
+    }
+    return p
+}

--- a/examples/games/boulder-dash/cave.das
+++ b/examples/games/boulder-dash/cave.das
@@ -20,7 +20,7 @@ let DEFAULT_SLIME_PERM = 0.2
 //   . empty   : dirt     o boulder   ! boulder_fall
 //   * diamond $ diamond_fall  # brick  X steel
 //   M magic   m magic_active  = expand  ~ slime
-//   nesw firefly NESW   ABCD butterfly NESW
+//   n e s w firefly (U R D L)   A B C D butterfly (U R D L)
 //   a amoeba  R player  E exit_closed  O exit_open
 //   123 empty-explosion   456 diamond-explosion
 enum Tile : int {

--- a/examples/games/boulder-dash/cave_gen.das
+++ b/examples/games/boulder-dash/cave_gen.das
@@ -87,7 +87,7 @@ def place_player_pocket(var c : Cave; var rng : int4&) {
 
 def place_insect_pocket(var c : Cave; var rng : int4&; fly : bool) {
     let x = rand_span(rng, 2, c.cols - 3)
-    let y = rand_span(rng, 2, c.rows - 3)
+    let y = rand_span(rng, 2, max(4, c.rows - 10))
     fill_rect(c, x, y, 2, 2, Tile.empty)
     let t = fly ? Tile.firefly_u : Tile.butterfly_u
     cave_set(c, x, y, t)
@@ -208,6 +208,66 @@ def paint_interior(var c : Cave; var rng : int4&; cave_index : int) {
     }
     force_diamonds(c)
     steel_border(c)
+    harden_spawn(c)
+    steel_border(c)
+}
+
+def harden_spawn(var c : Cave) {
+    find_rockford(c)
+    let p = c.rockford
+    return if (p.x < 0)
+    for (dx in range(-1, 2)) {
+        for (dy in range(-6, -1)) {
+            let x = p.x + dx
+            let y = p.y + dy
+            if (!in_bounds(c, x, y)) {
+                continue
+            }
+            let t = cave_at(c, x, y)
+            if (t == Tile.steel || t == Tile.exit_closed || t == Tile.exit_open) {
+                continue
+            }
+            if (is_fallable(t) || t == Tile.empty) {
+                cave_set(c, x, y, Tile.dirt)
+            }
+        }
+    }
+    for (dx in range(-1, 2)) {
+        for (dy in range(-1, 2)) {
+            if (dx == 0 && dy == 0) {
+                continue
+            }
+            let x = p.x + dx
+            let y = p.y + dy
+            if (!in_bounds(c, x, y)) {
+                continue
+            }
+            let t = cave_at(c, x, y)
+            if (t != Tile.steel && t != Tile.exit_closed && t != Tile.exit_open) {
+                cave_set(c, x, y, Tile.empty)
+            }
+        }
+    }
+    cave_set(c, p.x, p.y, Tile.player)
+    for (y in range(c.rows)) {
+        for (x in range(c.cols)) {
+            if (is_insect(cave_at(c, x, y)) && max(abs(x - p.x), abs(y - p.y)) <= 8) {
+                cave_set(c, x, y, Tile.empty)
+            }
+        }
+    }
+}
+
+def player_survives_idle(c0 : Cave; ticks : int) : bool {
+    var c <- cave_from_ascii(cave_to_ascii(c0))
+    find_rockford(c)
+    for (_ in range(ticks)) {
+        cave_tick(c)
+        if (!c.alive) {
+            return false
+        }
+    }
+    return true
 }
 
 def cave_is_sane(c : Cave) : bool {
@@ -215,10 +275,10 @@ def cave_is_sane(c : Cave) : bool {
         return false
     }
     let exits = cave_count(c, Tile.exit_closed) + cave_count(c, Tile.exit_open)
-    if (exits < 1) {
+    if (exits < 1 || cave_count_diamonds(c) < 1) {
         return false
     }
-    return cave_count_diamonds(c) >= 1
+    return player_survives_idle(c, 24)
 }
 
 def finish_cave(var c : Cave; rng : int4; cave_index : int) {

--- a/examples/games/boulder-dash/cave_gen.das
+++ b/examples/games/boulder-dash/cave_gen.das
@@ -1,0 +1,266 @@
+options gen2
+options persistent_heap
+
+module cave_gen public
+
+require math
+require daslib/random
+require cave
+
+def rand_span(var rng : int4&; lo, hi : int) : int {
+    if (hi <= lo) {
+        return lo
+    }
+    return lo + (random_int(rng) % (hi - lo))
+}
+
+def chance(var rng : int4&; p : float) : bool {
+    return random_float(rng) < p
+}
+
+def fill_rect(var c : Cave; x, y, w, h : int; t : Tile) {
+    let x1 = max(x, 0)
+    let y1 = max(y, 0)
+    let x2 = min(x + w, c.cols)
+    let y2 = min(y + h, c.rows)
+    for (yy in range(y1, y2)) {
+        for (xx in range(x1, x2)) {
+            cave_set(c, xx, yy, t)
+        }
+    }
+}
+
+def steel_border(var c : Cave) {
+    for (x in range(c.cols)) {
+        cave_set(c, x, 0, Tile.steel)
+        cave_set(c, x, c.rows - 1, Tile.steel)
+    }
+    for (y in range(c.rows)) {
+        cave_set(c, 0, y, Tile.steel)
+        cave_set(c, c.cols - 1, y, Tile.steel)
+    }
+}
+
+def fill_dirt(var c : Cave) {
+    for (i in range(length(c.cells))) {
+        c.cells[i] = Tile.dirt
+    }
+}
+
+def scatter_rocks(var c : Cave; var rng : int4&; p_bould, p_gem : float) {
+    for (y in range(1, c.rows - 1)) {
+        for (x in range(1, c.cols - 1)) {
+            if (chance(rng, p_bould)) {
+                cave_set(c, x, y, Tile.boulder)
+            } elif (chance(rng, p_gem)) {
+                cave_set(c, x, y, Tile.diamond)
+            }
+        }
+    }
+}
+
+def carve_room(var c : Cave; var rng : int4&) {
+    let w = rand_span(rng, 3, 8)
+    let h = rand_span(rng, 2, 5)
+    let x = rand_span(rng, 1, c.cols - w - 1)
+    let y = rand_span(rng, 1, c.rows - h - 1)
+    fill_rect(c, x, y, w, h, Tile.empty)
+}
+
+def place_exit_box(var c : Cave; var rng : int4&) {
+    let w = 5
+    let h = 4
+    let x = rand_span(rng, c.cols / 2, c.cols - w - 1)
+    let y = rand_span(rng, 1, c.rows - h - 1)
+    fill_rect(c, x, y, w, h, Tile.steel)
+    fill_rect(c, x + 1, y + 1, w - 2, h - 2, Tile.empty)
+    cave_set(c, x + 2, y + 1, Tile.exit_closed)
+    cave_set(c, x, y + h - 2, Tile.dirt)
+}
+
+def place_player_pocket(var c : Cave; var rng : int4&) {
+    let x = rand_span(rng, 2, min(12, c.cols - 4))
+    let y = rand_span(rng, c.rows - 8, c.rows - 3)
+    fill_rect(c, x - 1, y - 1, 3, 3, Tile.empty)
+    cave_set(c, x, y, Tile.player)
+}
+
+def place_insect_pocket(var c : Cave; var rng : int4&; fly : bool) {
+    let x = rand_span(rng, 2, c.cols - 3)
+    let y = rand_span(rng, 2, c.rows - 3)
+    fill_rect(c, x, y, 2, 2, Tile.empty)
+    let t = fly ? Tile.firefly_u : Tile.butterfly_u
+    cave_set(c, x, y, t)
+}
+
+def place_amoeba_blob(var c : Cave; var rng : int4&) {
+    let n = rand_span(rng, 5, 13)
+    let x0 = rand_span(rng, 3, c.cols - 5)
+    let y0 = rand_span(rng, 3, c.rows - 5)
+    for (_ in range(n)) {
+        let x = clamp(x0 + rand_span(rng, 0, 3), 1, c.cols - 2)
+        let y = clamp(y0 + rand_span(rng, 0, 3), 1, c.rows - 2)
+        cave_set(c, x, y, Tile.amoeba)
+    }
+}
+
+def place_magic_strip(var c : Cave; var rng : int4&) {
+    let w = rand_span(rng, 4, 9)
+    let x = rand_span(rng, 2, c.cols - w - 2)
+    let y = rand_span(rng, 4, c.rows - 4)
+    fill_rect(c, x, y - 1, w, 1, Tile.empty)
+    fill_rect(c, x, y, w, 1, Tile.magic)
+    fill_rect(c, x, y + 1, w, 1, Tile.empty)
+}
+
+def place_expand_seg(var c : Cave; var rng : int4&) {
+    let x = rand_span(rng, 3, c.cols - 4)
+    let y = rand_span(rng, 2, c.rows - 3)
+    cave_set(c, x, y, Tile.expand)
+    cave_set(c, x - 1, y, Tile.empty)
+    cave_set(c, x + 1, y, Tile.empty)
+}
+
+def place_slime_patch(var c : Cave; var rng : int4&) {
+    let x = rand_span(rng, 2, c.cols - 5)
+    let y = rand_span(rng, 3, c.rows - 4)
+    fill_rect(c, x, y, 3, 2, Tile.slime)
+}
+
+def gen_seed(world_seed, cave_index : int) : int4 {
+    return random_seed(world_seed * 73856093 + cave_index * 19349663 + 83492791)
+}
+
+def replace_all_player(var c : Cave) {
+    for (i in range(length(c.cells))) {
+        if (c.cells[i] == Tile.player) {
+            c.cells[i] = Tile.empty
+        }
+    }
+}
+
+def force_player(var c : Cave) {
+    replace_all_player(c)
+    let x = 3
+    let y = c.rows - 4
+    fill_rect(c, x - 1, y - 1, 3, 3, Tile.empty)
+    cave_set(c, x, y, Tile.player)
+}
+
+def force_exit(var c : Cave) {
+    let x = c.cols - 6
+    let y = 3
+    fill_rect(c, x, y, 4, 3, Tile.steel)
+    fill_rect(c, x + 1, y + 1, 2, 1, Tile.empty)
+    cave_set(c, x + 1, y + 1, Tile.exit_closed)
+    cave_set(c, x, y + 1, Tile.dirt)
+}
+
+def force_diamonds(var c : Cave) {
+    return if (cave_count_diamonds(c) >= 1)
+    cave_set(c, 5, c.rows - 4, Tile.diamond)
+    cave_set(c, 6, c.rows - 4, Tile.diamond)
+    cave_set(c, 7, c.rows - 4, Tile.diamond)
+}
+
+def paint_interior(var c : Cave; var rng : int4&; cave_index : int) {
+    var p_bould = 0.14 + float(cave_index) * 0.008
+    if (p_bould > 0.22) {
+        p_bould = 0.22
+    }
+    var p_gem = 0.05 - float(cave_index) * 0.001
+    if (p_gem < 0.025) {
+        p_gem = 0.025
+    }
+    scatter_rocks(c, rng, p_bould, p_gem)
+    let rooms = rand_span(rng, 2, 5)
+    for (_ in range(rooms)) {
+        carve_room(c, rng)
+    }
+    let flies = rand_span(rng, 2, 5 + min(cave_index, 3))
+    for (_ in range(flies)) {
+        place_insect_pocket(c, rng, true)
+    }
+    if (cave_index > 0 && chance(rng, 0.5)) {
+        place_insect_pocket(c, rng, false)
+    }
+    if (chance(rng, 0.35)) {
+        place_amoeba_blob(c, rng)
+    }
+    if (chance(rng, 0.4)) {
+        place_magic_strip(c, rng)
+    }
+    if (chance(rng, 0.25)) {
+        place_expand_seg(c, rng)
+    }
+    if (chance(rng, 0.2)) {
+        place_slime_patch(c, rng)
+    }
+    place_exit_box(c, rng)
+    place_player_pocket(c, rng)
+    steel_border(c)
+    if (cave_count(c, Tile.player) != 1) {
+        force_player(c)
+    }
+    let exits = cave_count(c, Tile.exit_closed) + cave_count(c, Tile.exit_open)
+    if (exits < 1) {
+        force_exit(c)
+    }
+    force_diamonds(c)
+    steel_border(c)
+}
+
+def cave_is_sane(c : Cave) : bool {
+    if (cave_count(c, Tile.player) != 1) {
+        return false
+    }
+    let exits = cave_count(c, Tile.exit_closed) + cave_count(c, Tile.exit_open)
+    if (exits < 1) {
+        return false
+    }
+    return cave_count_diamonds(c) >= 1
+}
+
+def finish_cave(var c : Cave; rng : int4; cave_index : int) {
+    find_rockford(c)
+    let gems = cave_count_diamonds(c)
+    var need = int(ceil(float(gems) * 0.45))
+    need = clamp(need, 1, max(gems, 1))
+    c.diamonds_need = need
+    c.diamonds_got = 0
+    c.time_left = max(150.0 - 4.0 * float(min(cave_index, 20)), 80.0)
+    c.rng = rng
+    c.alive = true
+    c.cleared = false
+}
+
+def fallback_cave() : Cave {
+    var c <- make_cave(CAVE_COLS, CAVE_ROWS)
+    fill_dirt(c)
+    steel_border(c)
+    fill_rect(c, 2, 2, 6, 4, Tile.empty)
+    cave_set(c, 3, 3, Tile.player)
+    cave_set(c, 5, 3, Tile.diamond)
+    cave_set(c, 6, 3, Tile.diamond)
+    fill_rect(c, 30, 8, 5, 4, Tile.steel)
+    fill_rect(c, 31, 9, 3, 2, Tile.empty)
+    cave_set(c, 32, 9, Tile.exit_closed)
+    cave_set(c, 30, 10, Tile.dirt)
+    let rng = random_seed(1)
+    finish_cave(c, rng, 0)
+    return <- c
+}
+
+def generate_cave(world_seed, cave_index : int) : Cave {
+    for (attempt in range(16)) {
+        var rng = gen_seed(world_seed + attempt, cave_index)
+        var c <- make_cave(CAVE_COLS, CAVE_ROWS)
+        fill_dirt(c)
+        paint_interior(c, rng, cave_index)
+        if (cave_is_sane(c)) {
+            finish_cave(c, rng, cave_index)
+            return <- c
+        }
+    }
+    return <- fallback_cave()
+}

--- a/examples/games/boulder-dash/main.das
+++ b/examples/games/boulder-dash/main.das
@@ -1,0 +1,1135 @@
+options gen2
+options persistent_heap
+options gc
+
+require glfw/glfw_boost
+require live/glfw_live
+require opengl/opengl_boost
+require opengl/opengl_gen
+require opengl/opengl_cache
+require daslib/defer
+require daslib/safe_addr
+require live/opengl_live
+require live/live_commands
+require ?dashv live/live_api
+require live/live_watch_boost
+require live/live_vars
+require live/audio_live
+require daslib/json_boost
+require daslib/math_boost
+require daslib/archive
+require opengl/opengl_ttf
+require audio/audio_boost
+require strudel/strudel
+require strudel/strudel_player
+require strudel/strudel_live
+require daslib/strings_boost
+require daslib/strings_convert
+require live_host
+require cave
+require cave_gen
+
+let CELL_SIZE = 1.0
+let LIGHT_DIR = normalize(float3(-0.28, -0.62, -1.2))
+let FILL_DIR = normalize(float3(0.55, 0.28, -0.32))
+let CAM_EYE = float3(0.0, -6.0, 26.0)
+let START_LIVES = 3
+let AUDIO_RATE = 48000
+let AUDIO_CHANNELS = 1
+
+let COL_DIRT = float3(0.45, 0.28, 0.12)
+let COL_BOULDER = float3(0.55, 0.55, 0.58)
+let COL_DIAMOND = float3(0.35, 0.95, 1.0)
+let COL_BRICK = float3(0.7, 0.25, 0.18)
+let COL_STEEL = float3(0.22, 0.28, 0.38)
+let COL_MAGIC = float3(0.85, 0.25, 0.7)
+let COL_EXPAND = float3(0.9, 0.45, 0.15)
+let COL_SLIME = float3(0.25, 0.75, 0.3)
+let COL_AMOEBA = float3(0.45, 0.95, 0.25)
+let COL_FIREFLY = float3(0.95, 0.9, 0.2)
+let COL_BUTTERFLY = float3(0.95, 0.3, 0.75)
+let COL_PLAYER = float3(1.0, 0.75, 0.35)
+let COL_EXIT = float3(0.95, 0.8, 0.2)
+let COL_FLOOR = float3(0.08, 0.07, 0.1)
+let COL_EXPLODE = float3(1.0, 0.7, 0.2)
+
+enum GameState {
+    menu
+    playing
+    paused
+    dead
+    cave_cleared
+    game_over_state
+}
+
+var @in @location = 0 v_position : float3
+var @in @location = 1 v_normal : float3
+var @in @location = 2 v_texcoord : float2
+var @uniform v_model : float4x4
+var @uniform v_view : float4x4
+var @uniform v_projection : float4x4
+var @uniform v_Time : float
+var @uniform v_Wave : float
+var @inout f_normal : float3
+var @inout f_position : float3
+var @uniform f_Color : float4
+var @uniform f_Time : float
+var @uniform f_Eye : float3
+var @uniform f_Spec : float
+var @uniform f_Gloss : float
+var @uniform f_Rim : float
+var @uniform f_Wave : float
+var @uniform f_Hash : float
+var @out f_FragColor : float4
+
+[vertex_program]
+def vs_bd {
+    let world = (v_model * float4(v_position, 1.0)).xyz
+    let nrm = normalize(float3x3(v_model) * v_normal)
+    let w1 = sin(v_Time * 3.4 + world.x * 2.4 + world.y * 1.7)
+    let w2 = sin(v_Time * 5.8 + world.x * 4.1 + world.y * 3.2)
+    let wave = v_Wave * (0.13 * w1 + 0.07 * w2)
+    f_normal = nrm
+    let tpos = float4(world + float3(0.0, 0.0, wave), 1.0)
+    f_position = tpos.xyz
+    gl_Position = v_projection * v_view * tpos
+}
+
+[fragment_program]
+def fs_bd {
+    let n = normalize(f_normal)
+    let key = saturate(-dot(LIGHT_DIR, n))
+    let fill = saturate(-dot(FILL_DIR, n))
+    let hp = f_position.xy * 3.1
+    let hr = sin(dot(floor(hp), float2(12.9898, 78.233))) * 43758.5
+    let hash = 1.0 + (hr - floor(hr) - 0.5) * f_Hash
+    var col = f_Color.xyz * (key * 0.70 + fill * 0.28 + 0.44) * hash
+    let view_dir = normalize(f_Eye - f_position)
+    let halfv = normalize(view_dir - LIGHT_DIR)
+    let spec = pow(saturate(dot(n, halfv)), max(f_Gloss, 1.0)) * f_Spec
+    let spark_ph = sin(f_Time * 6.5 + f_position.x * 14.0 + f_position.y * 9.0)
+    let spark = spec * spec * f_Spec * (0.25 + 0.75 * saturate(spark_ph))
+    col += lerp(float3(1.0), f_Color.xyz, 0.18) * (spec * 0.95 + spark * 1.6)
+    let rim = pow(1.0 - saturate(dot(n, view_dir)), 2.4) * f_Rim
+    col += f_Color.xyz * rim * 1.35
+    let w1 = sin(f_Time * 3.4 + f_position.x * 2.4 + f_position.y * 1.7)
+    let w2 = sin(f_Time * 5.8 + f_position.x * 4.1 + f_position.y * 3.2)
+    col += f_Color.xyz * (w1 * 0.42 + w2 * 0.22) * f_Wave
+    f_FragColor.xyz = col
+    f_FragColor.w = f_Color.w
+}
+
+var program : uint
+var geo_sphere : OpenGLGeometryFragment
+var geo_cube : OpenGLGeometryFragment
+var geo_plane : OpenGLGeometryFragment
+var hud_font : Font?
+var display_w = 0
+var display_h = 0
+var skip_draw : array<bool>
+
+def gen_sine_sweep(freq_start, freq_end : float; duration : float; volume : float = 0.3) : array<float> {
+    let num_samples = int(float(AUDIO_RATE) * duration)
+    var samples : array<float>
+    samples |> resize(num_samples)
+    for (i in range(num_samples)) {
+        let t = float(i) / float(AUDIO_RATE)
+        let frac = t / duration
+        let freq = freq_start + (freq_end - freq_start) * frac
+        samples[i] = sin(2.0 * PI * freq * t) * (1.0 - frac) * volume
+    }
+    return <- samples
+}
+
+def gen_noise_burst(duration : float; volume : float = 0.2) : array<float> {
+    let num_samples = int(float(AUDIO_RATE) * duration)
+    var samples : array<float>
+    samples |> resize(num_samples)
+    var seed = 12345u
+    for (i in range(num_samples)) {
+        let frac = float(i) / float(num_samples)
+        seed = seed * 1103515245u + 12345u
+        let noise = float(int(seed >> 16u) % 1000) / 500.0 - 1.0
+        samples[i] = noise * (1.0 - frac) * volume
+    }
+    return <- samples
+}
+
+def gen_tone(freq, duration, volume : float) : array<float> {
+    return <- gen_sine_sweep(freq, freq, duration, volume)
+}
+
+def overlay_at(var dst : array<float>; src : array<float>; at : int) {
+    let need = at + length(src)
+    if (length(dst) < need) {
+        dst |> resize(need)
+    }
+    for (i in range(length(src))) {
+        dst[at + i] += src[i]
+    }
+}
+
+def gen_fanfare(base : float; vol : float = 0.28) : array<float> {
+    var out : array<float>
+    let step = int(float(AUDIO_RATE) * 0.11)
+    let n1 <- gen_tone(base, 0.09, vol)
+    let n2 <- gen_tone(base * 1.25, 0.09, vol)
+    let n3 <- gen_tone(base * 1.5, 0.10, vol * 1.05)
+    let n4 <- gen_tone(base * 2.0, 0.28, vol * 1.15)
+    overlay_at(out, n1, 0)
+    overlay_at(out, n2, step)
+    overlay_at(out, n3, step * 2)
+    overlay_at(out, n4, step * 3)
+    return <- out
+}
+
+var @live snd_dig : array<float>
+var @live snd_gem : array<float>
+var @live snd_land_boulder : array<float>
+var @live snd_land_diamond : array<float>
+var @live snd_fall_boulder : array<float>
+var @live snd_fall_diamond : array<float>
+var @live snd_boom : array<float>
+var @live snd_die : array<float>
+var @live snd_timeout : array<float>
+var @live snd_exit_open : array<float>
+var @live snd_clear : array<float>
+var @live snd_push : array<float>
+var @live snd_magic : array<float>
+var @live snd_magic_convert : array<float>
+var @live snd_amoeba : array<float>
+var @live snd_amoeba_gems : array<float>
+var @live snd_amoeba_rocks : array<float>
+var @live snd_expand : array<float>
+var @live snd_time_low : array<float>
+var @live audio_initialized = false
+
+def init_audio_samples() {
+    delete snd_dig
+    delete snd_gem
+    delete snd_land_boulder
+    delete snd_land_diamond
+    delete snd_fall_boulder
+    delete snd_fall_diamond
+    delete snd_boom
+    delete snd_die
+    delete snd_timeout
+    delete snd_exit_open
+    delete snd_clear
+    delete snd_push
+    delete snd_magic
+    delete snd_magic_convert
+    delete snd_amoeba
+    delete snd_amoeba_gems
+    delete snd_amoeba_rocks
+    delete snd_expand
+    delete snd_time_low
+    snd_dig <- gen_sine_sweep(180.0, 90.0, 0.05, 0.2)
+    snd_gem <- gen_sine_sweep(980.0, 1560.0, 0.09, 0.28)
+    snd_land_boulder <- gen_sine_sweep(140.0, 55.0, 0.07, 0.24)
+    snd_land_diamond <- gen_sine_sweep(1400.0, 2100.0, 0.08, 0.26)
+    snd_fall_boulder <- gen_sine_sweep(200.0, 110.0, 0.04, 0.18)
+    snd_fall_diamond <- gen_sine_sweep(1600.0, 2200.0, 0.035, 0.22)
+    snd_boom <- gen_noise_burst(0.25, 0.28)
+    snd_die <- gen_sine_sweep(440.0, 80.0, 0.5, 0.3)
+    snd_timeout <- gen_sine_sweep(220.0, 40.0, 0.7, 0.32)
+    snd_exit_open <- gen_fanfare(392.0, 0.3)
+    snd_clear <- gen_fanfare(523.25, 0.32)
+    snd_push <- gen_sine_sweep(90.0, 70.0, 0.08, 0.22)
+    snd_magic <- gen_sine_sweep(300.0, 900.0, 0.18, 0.22)
+    snd_magic_convert <- gen_sine_sweep(700.0, 1400.0, 0.1, 0.24)
+    snd_amoeba <- gen_sine_sweep(220.0, 160.0, 0.06, 0.16)
+    snd_amoeba_gems <- gen_sine_sweep(600.0, 1600.0, 0.25, 0.26)
+    snd_amoeba_rocks <- gen_sine_sweep(160.0, 50.0, 0.3, 0.26)
+    snd_expand <- gen_sine_sweep(240.0, 180.0, 0.07, 0.18)
+    snd_time_low <- gen_sine_sweep(880.0, 440.0, 0.15, 0.22)
+}
+
+def play_sfx(samples : array<float>) {
+    return if (!audio_initialized)
+    var copy <- clone(samples)
+    play_sound_from_pcm(AUDIO_RATE, AUDIO_CHANNELS, copy)
+}
+
+var g_music_tracks : table<string; int>
+var music_initialized = false
+var music_enabled = false
+
+def strudel_music_cmd(cmd : string) {
+    let parts <- split(cmd, ":")
+    return if (length(parts) < 2)
+    let action = parts[0]
+    let name = parts[1]
+    if (action == "play" && length(parts) >= 3) {
+        let gain = length(parts) >= 4 ? float(to_double(parts[3])) : 1.0
+        if (key_exists(g_music_tracks, name)) {
+            strudel_remove_track(g_music_tracks[name])
+        }
+        g_music_tracks[name] = strudel_add_track(s(parts[2]), gain)
+    } elif (action == "note" && length(parts) >= 4) {
+        let gain = length(parts) >= 5 ? float(to_double(parts[4])) : 0.4
+        if (key_exists(g_music_tracks, name)) {
+            strudel_remove_track(g_music_tracks[name])
+        }
+        g_music_tracks[name] = strudel_add_track(note_pattern(parts[2], parts[3]), gain)
+    } elif (action == "stop") {
+        if (key_exists(g_music_tracks, name)) {
+            let fade_time = length(parts) >= 3 ? float(to_double(parts[2])) : 0.5
+            strudel_fade_track(g_music_tracks[name], 0.0, fade_time)
+        }
+    }
+}
+
+def strudel_music_main() {
+    strudel_set_bpm(110.0lf)
+    strudel_play(@@strudel_music_cmd)
+}
+
+def stop_all_music(fade : float) {
+    strudel_command("stop:drums:{fade}")
+    strudel_command("stop:hats:{fade}")
+    strudel_command("stop:bass:{fade}")
+    strudel_command("stop:lead:{fade}")
+    strudel_command("stop:arp:{fade}")
+}
+
+def start_menu_music() {
+    strudel_set_bpm(92.0lf)
+    strudel_command("play:drums:<bd ~ ~ hh?0.4> <~ sd ~ ~> <bd ~ [~ hh?0.5] ~> <~ ~ sd?0.6 cp?0.3>:0.32")
+    strudel_command("play:hats:hh(3,8):0.18")
+    strudel_command("note:bass:<[d2 ~] [a1 ~] [f1 ~] [g1 ~] [d2 ~] [c2 ~] [bb1 ~] [a1 a1?0.5]>:sine:0.22")
+    strudel_command("note:lead:<d4 ~ f4 ~ a4 ~ g4 ~> <~ f4 ~ d4 ~ a3 ~ c4> <d4 f4?0.6 ~ a4 ~ g4 f4 ~> <~ d4 ~ ~ a4?0.5 ~ ~ ~>:triangle:0.14")
+}
+
+def start_play_music() {
+    strudel_set_bpm(118.0lf)
+    strudel_command("play:drums:<bd [hh hh] sd [hh hh] bd [hh hh] sd [hh cp] bd [hh?0.75 hh] sd [hh hh] bd [hh hh] [sd?0.45 sd] [hh cp?0.35] bd [hh hh] sd [hh?0.6 hh] bd [hh cp?0.4] sd [hh hh] bd [hh hh] sd [cp?0.5 hh]>:0.48")
+    strudel_command("play:hats:hh(5,8,2):0.2")
+    strudel_command("note:bass:<[d2 d2] [d2 a1] [f2 f2] [g2 g2] [d2 d2] [c2 c2] [bb1 bb1] [a1 a1] [d2 d2] [d2 f2] [g2 g2] [a1 a1] [d2 d2] [f2?0.65 f2] [g2 g2] [a1 c2]>:square:0.24")
+    strudel_command("note:lead:<d4 ~ f4 a4 ~ g4 f4 ~ d4 ~ a4 c5 ~ g4 f4 d4 ~ f4 ~ g4 a4 ~ c5 a4 g4 ~ d4 ~ [f4 g4] a4 ~ g4?0.55 f4 d4 ~ a4 ~ f4 ~ d4 g4 ~ f4 ~>:triangle:0.16")
+    strudel_command("note:arp:<[d4 f4 a4 d5] [f4 a4 c5 f5?0.45] [d4 f4 a4 d5] [c4 e4 g4 c5?0.4] [d4 f4 a4 d5] [a3 d4 f4 a4] [d4 f4 a4 d5?0.5] [g3 bb3 d4 g4]>:triangle:0.09")
+}
+
+def start_gameover_music() {
+    strudel_set_bpm(68.0lf)
+    strudel_command("play:drums:<bd ~ ~ ~> <~ ~ bd?0.5 ~> <bd ~ hh?0.3 ~> <~ ~ ~ bd?0.35>:0.2")
+    strudel_command("note:bass:<d2 ~ bb1 ~> <a1 ~ g1 ~> <f1 ~ a1 ~> <d2 ~ ~ ~>:sine:0.26")
+    strudel_command("note:lead:<f4 ~ e4 ~> <d4 ~ c4 ~> <bb3 ~ a3 ~> <d4?0.6 ~ ~ ~>:triangle:0.16")
+}
+
+def start_music_for_state() {
+    return if (!music_enabled)
+    if (game_state == GameState.game_over_state) {
+        start_gameover_music()
+    } elif (game_state == GameState.menu) {
+        start_menu_music()
+    } else {
+        start_play_music()
+    }
+    prev_music_state = game_state
+}
+
+var @live g_cave <- Cave()
+var @live score = 0
+var @live lives = START_LIVES
+var @live game_state = GameState.menu
+var @live world_seed = 1984
+var @live cave_index = 0
+var @live tick_acc = 0.0
+var @live cave_hz = CAVE_HZ
+var @live game_speed = 1.0
+var @live god_mode = false
+var @live death_timer = 0.0
+var @live clear_timer = 0.0
+var @live prev_music_state = GameState.menu
+var space_was_pressed = false
+var esc_was_pressed = false
+var asch : AudioSystemChannels
+var time_low_armed = false
+var @live queued_dir = int2(0, 0)
+var @live queued_grab = false
+var player_slide = false
+var player_from = int2(0, 0)
+var player_to = int2(0, 0)
+var player_slide_t = 0.0
+var player_slide_dur = 0.12
+var hold_time = 0.0
+var step_this_press = false
+let REPEAT_DELAY = 0.32
+var key_left = false
+var key_right = false
+var key_up = false
+var key_down = false
+var key_grab = false
+
+def half_w() : float {
+    return float(g_cave.cols) * CELL_SIZE * 0.5
+}
+
+def half_h() : float {
+    return float(g_cave.rows) * CELL_SIZE * 0.5
+}
+
+def cell_to_world(col, row : int) : float2 {
+    return float2(
+        float(col) * CELL_SIZE - half_w() + CELL_SIZE * 0.5,
+        half_h() - float(row) * CELL_SIZE - CELL_SIZE * 0.5
+    )
+}
+
+def create_gl_objects() {
+    program = cache_shader_program(vs_bd`shader_text, fs_bd`shader_text)
+    geo_sphere <- create_geometry_fragment <| gen_sphere(12, 7, false)
+    geo_cube <- create_geometry_fragment <| gen_cube()
+    geo_plane <- create_geometry_fragment <| gen_plane(GenDirection.xy)
+    cache_ttf_objects()
+    hud_font = cache_font("{get_das_root()}/modules/dasStbImage/fonts/droidsansmono.ttf")
+}
+
+def draw_box(pos : float3; dim : float3; color : float3; alpha : float = 1.0) {
+    v_model = compose(pos, float4(0), dim * 0.5)
+    f_Color = float4(color, alpha)
+    vs_bd_bind_uniform(program)
+    fs_bd_bind_uniform(program)
+    geo_cube |> draw_geometry_fragment()
+}
+
+def draw_sphere_obj(pos : float3; radius : float; color : float3; alpha : float = 1.0) {
+    v_model = compose(pos, float4(0), float3(radius))
+    f_Color = float4(color, alpha)
+    vs_bd_bind_uniform(program)
+    fs_bd_bind_uniform(program)
+    geo_sphere |> draw_geometry_fragment()
+}
+
+def draw_text(txt : string; x, y : int; tint : float3 = float3(1.0)) {
+    return if (hud_font == null)
+    var quads <- (*hud_font) |> create_quads(txt)
+    (*hud_font) |> draw_quads_2d(quads, display_w, display_h, x, y, tint)
+    delete quads
+}
+
+def draw_text_centered(txt : string; cx, y : int; tint : float3 = float3(1.0)) {
+    return if (hud_font == null)
+    var quads <- (*hud_font) |> create_quads(txt)
+    let dim = quads_dim(quads)
+    let tw = int(dim.vmax.x - dim.vmin.x)
+    (*hud_font) |> draw_quads_2d(quads, display_w, display_h, cx - tw / 2, y, tint)
+    delete quads
+}
+
+def pulse_tint(base : float3) : float3 {
+    let pulse = 0.5 + 0.5 * sin(get_uptime() * 4.5)
+    return lerp(base * 0.86, base * 1.06, pulse)
+}
+
+def set_mat(spec, gloss, rim, wave, hash : float) {
+    f_Spec = spec
+    f_Gloss = gloss
+    f_Rim = rim
+    f_Wave = wave
+    v_Wave = wave
+    f_Hash = hash
+}
+
+def mat_for(t : Tile) {
+    if (t == Tile.dirt) {
+        set_mat(0.06, 8.0, 0.05, 0.0, 0.28)
+        return
+    }
+    if (is_gem_tile(t) || t == Tile.dexplode0 || t == Tile.dexplode1 || t == Tile.dexplode2) {
+        set_mat(1.45, 72.0, 0.62, 0.0, 0.06)
+        return
+    }
+    if (t == Tile.boulder || t == Tile.boulder_fall) {
+        set_mat(0.32, 22.0, 0.14, 0.0, 0.20)
+        return
+    }
+    if (t == Tile.brick) {
+        set_mat(0.14, 12.0, 0.10, 0.0, 0.16)
+        return
+    }
+    if (t == Tile.steel || t == Tile.exit_closed) {
+        set_mat(0.55, 36.0, 0.22, 0.0, 0.12)
+        return
+    }
+    if (t == Tile.magic || t == Tile.magic_active) {
+        let pulse = 0.5 + 0.5 * sin(get_uptime() * 5.0)
+        set_mat(0.62, 28.0, 0.35 + pulse * 0.55, 0.35, 0.10)
+        return
+    }
+    if (t == Tile.expand) {
+        set_mat(0.38, 18.0, 0.32, 1.0, 0.08)
+        return
+    }
+    if (t == Tile.slime) {
+        set_mat(0.48, 42.0, 0.22, 0.40, 0.18)
+        return
+    }
+    if (t == Tile.amoeba) {
+        let pulse = 0.5 + 0.5 * sin(get_uptime() * 4.5)
+        set_mat(0.36, 16.0, 0.40 + pulse * 0.45, 0.55, 0.14)
+        return
+    }
+    if (is_firefly(t)) {
+        set_mat(0.85, 30.0, 0.85, 0.18, 0.0)
+        return
+    }
+    if (is_butterfly(t)) {
+        set_mat(0.75, 26.0, 0.80, 0.22, 0.0)
+        return
+    }
+    if (t == Tile.player) {
+        set_mat(0.42, 24.0, 0.28, 0.0, 0.0)
+        return
+    }
+    if (t == Tile.exit_open) {
+        let pulse = 0.5 + 0.5 * sin(get_uptime() * 4.5)
+        set_mat(0.75, 34.0, 0.45 + pulse * 0.5, 0.25, 0.0)
+        return
+    }
+    if (is_explode(t)) {
+        set_mat(0.95, 10.0, 0.55, 0.15, 0.0)
+        return
+    }
+    set_mat(0.10, 12.0, 0.08, 0.0, 0.0)
+}
+
+def tile_color(t : Tile) : float3 {
+    if (t == Tile.dirt) { return COL_DIRT }
+    if (is_gem_tile(t) || t == Tile.dexplode0 || t == Tile.dexplode1 || t == Tile.dexplode2) {
+        return COL_DIAMOND
+    }
+    if (t == Tile.boulder || t == Tile.boulder_fall) { return COL_BOULDER }
+    if (t == Tile.brick) { return COL_BRICK }
+    if (t == Tile.steel || t == Tile.exit_closed) { return COL_STEEL }
+    if (t == Tile.magic || t == Tile.magic_active) { return COL_MAGIC }
+    if (t == Tile.expand) { return COL_EXPAND }
+    if (t == Tile.slime) { return COL_SLIME }
+    if (t == Tile.amoeba) { return COL_AMOEBA }
+    if (is_firefly(t)) { return COL_FIREFLY }
+    if (is_butterfly(t)) { return COL_BUTTERFLY }
+    if (t == Tile.player) { return COL_PLAYER }
+    if (t == Tile.exit_open) { return COL_EXIT }
+    if (is_explode(t)) { return COL_EXPLODE }
+    return COL_FLOOR
+}
+
+def tile_sphere(t : Tile) : bool {
+    return t == Tile.boulder || t == Tile.boulder_fall || t == Tile.amoeba || t == Tile.player || is_insect(t) || is_explode(t)
+}
+
+def draw_tile(t : Tile; pos : float3) {
+    return if (t == Tile.empty)
+    mat_for(t)
+    var col = tile_color(t)
+    if (t == Tile.magic_active || t == Tile.exit_open || t == Tile.amoeba || t == Tile.expand || is_insect(t)) {
+        col = pulse_tint(col)
+    }
+    if (t == Tile.dirt) {
+        draw_box(pos, float3(0.95, 0.95, 0.45), col)
+        return
+    }
+    if (is_gem_tile(t)) {
+        let ang = get_uptime() * 3.0
+        let q = float4(0.0, 0.0, sin(ang * 0.5), cos(ang * 0.5))
+        v_model = compose(pos + float3(0.0, 0.0, 0.22), q, float3(0.28))
+        f_Color = float4(col, 1.0)
+        vs_bd_bind_uniform(program)
+        fs_bd_bind_uniform(program)
+        geo_cube |> draw_geometry_fragment()
+        return
+    }
+    if (tile_sphere(t)) {
+        var r = 0.38
+        if (t == Tile.player) { r = 0.42 }
+        if (is_explode(t)) { r = 0.5 }
+        if (t == Tile.amoeba) { r = 0.36 + 0.06 * sin(get_uptime() * 5.0) }
+        draw_sphere_obj(pos + float3(0.0, 0.0, r), r, col)
+        return
+    }
+    var h = 0.7
+    if (t == Tile.steel || t == Tile.exit_closed) { h = 0.85 }
+    if (t == Tile.slime) {
+        draw_box(pos + float3(0.0, 0.0, 0.15), float3(0.95, 0.95, 0.35), col, 0.55)
+        return
+    }
+    if (t == Tile.exit_open) {
+        draw_box(pos + float3(0.0, 0.0, 0.4), float3(0.7, 0.7, 0.85), col)
+        return
+    }
+    draw_box(pos + float3(0.0, 0.0, h * 0.5), float3(1.0, 1.0, h), col)
+}
+
+def draw_floor() {
+    set_mat(0.05, 8.0, 0.0, 0.0, 0.12)
+    v_model = compose(float3(0.0, 0.0, -0.02), float4(0), float3(half_w() + 1.0, half_h() + 1.0, 1.0))
+    f_Color = float4(COL_FLOOR, 1.0)
+    vs_bd_bind_uniform(program)
+    fs_bd_bind_uniform(program)
+    geo_plane |> draw_geometry_fragment()
+}
+
+def mark_movers() {
+    let n = g_cave.cols * g_cave.rows
+    if (length(skip_draw) != n) {
+        skip_draw |> resize(n)
+    }
+    for (i in range(n)) {
+        skip_draw[i] = false
+    }
+    for (m in g_cave.movers) {
+        if (m.tile == Tile.player) {
+            continue
+        }
+        if (in_bounds(g_cave, m.to_x, m.to_y)) {
+            skip_draw[cave_idx(g_cave, m.to_x, m.to_y)] = true
+        }
+    }
+}
+
+def draw_static_tiles() {
+    for (y in range(g_cave.rows)) {
+        for (x in range(g_cave.cols)) {
+            if (skip_draw[cave_idx(g_cave, x, y)]) {
+                continue
+            }
+            let t = cave_at(g_cave, x, y)
+            if (t == Tile.player && player_slide) {
+                continue
+            }
+            if (player_slide && x == player_to.x && y == player_to.y) {
+                if (t == Tile.dirt || is_gem_tile(t) || t == Tile.empty) {
+                    continue
+                }
+            }
+            let w = cell_to_world(x, y)
+            draw_tile(t, float3(w.x, w.y, 0.0))
+        }
+    }
+}
+
+def draw_movers(blend : float) {
+    let u = saturate(blend)
+    let s = u * u * (3.0 - 2.0 * u)
+    for (m in g_cave.movers) {
+        if (m.tile == Tile.player) {
+            continue
+        }
+        let a = cell_to_world(m.from_x, m.from_y)
+        let b = cell_to_world(m.to_x, m.to_y)
+        let p = lerp(a, b, s)
+        draw_tile(m.tile, float3(p.x, p.y, 0.0))
+    }
+}
+
+def draw_player_slide() {
+    return if (!player_slide)
+    let u = saturate(player_slide_t)
+    let s = u * u * (3.0 - 2.0 * u)
+    let a = cell_to_world(player_from.x, player_from.y)
+    let b = cell_to_world(player_to.x, player_to.y)
+    let p = lerp(a, b, s)
+    draw_tile(Tile.player, float3(p.x, p.y, 0.0))
+}
+
+def maybe_start_player_slide(remain : float) {
+    return if (player_slide || queued_grab || !g_cave.alive)
+    let dest = cave_peek_step(g_cave, g_cave.wish_dir)
+    return if (dest.x == g_cave.rockford.x && dest.y == g_cave.rockford.y)
+    player_slide = true
+    player_from = g_cave.rockford
+    player_to = dest
+    player_slide_t = 0.0
+    player_slide_dur = max(remain, 1.0 / 120.0)
+    cave_lock_input(g_cave)
+}
+
+def draw_hud() {
+    let cx = display_w / 2
+    let cy = display_h / 2
+    if (game_state == GameState.menu) {
+        draw_text_centered("BOULDER DASH", cx, cy - 70, float3(1.0, 0.75, 0.2))
+        draw_text_centered("PRESS SPACE TO START", cx, cy + 10, pulse_tint(float3(0.7)))
+        draw_text_centered("ARROWS MOVE   Z/CTRL GRAB", cx, cy + 50, float3(0.55))
+        return
+    }
+    draw_text("SCORE {score}", 10, 32, float3(1.0))
+    draw_text("LIVES {lives}", 10, 62, float3(1.0, 0.85, 0.3))
+    draw_text("GEMS {g_cave.diamonds_got}/{g_cave.diamonds_need}", 10, 92, COL_DIAMOND)
+    var tcol = float3(1.0, 1.0, 1.0)
+    if (g_cave.time_left < 10.0) {
+        tcol = float3(1.0, 0.25, 0.2)
+    }
+    draw_text("TIME {int(g_cave.time_left)}", 10, 122, tcol)
+    draw_text("CAVE {cave_index + 1}", display_w - 160, 32, float3(0.7))
+    if (god_mode) {
+        draw_text("GOD", display_w - 80, 62, float3(1.0, 0.5, 0.0))
+    }
+    if (game_state == GameState.paused) {
+        draw_text_centered("PAUSED", cx, cy - 10, float3(0.85))
+        draw_text_centered("ESC TO RESUME", cx, cy + 30, pulse_tint(float3(0.5)))
+    } elif (game_state == GameState.game_over_state) {
+        draw_text_centered("GAME OVER", cx, cy - 20, float3(1.0, 0.25, 0.2))
+        draw_text_centered("PRESS SPACE", cx, cy + 25, pulse_tint(float3(0.7)))
+    } elif (game_state == GameState.cave_cleared) {
+        draw_text_centered("CAVE CLEARED", cx, cy - 20, float3(0.3, 1.0, 0.4))
+        draw_text_centered("PRESS SPACE", cx, cy + 25, pulse_tint(float3(0.7)))
+    } elif (game_state == GameState.dead) {
+        draw_text_centered("CRUSHED", cx, cy - 10, float3(1.0, 0.4, 0.2))
+    }
+}
+
+def play_tick_sfx() {
+    if (g_cave.dug) { play_sfx(snd_dig) }
+    if (g_cave.collected > 0) { play_sfx(snd_gem) }
+    if (g_cave.fell_boulder) { play_sfx(snd_fall_boulder) }
+    if (g_cave.fell_diamond) { play_sfx(snd_fall_diamond) }
+    if (g_cave.landed_boulder) { play_sfx(snd_land_boulder) }
+    if (g_cave.landed_diamond) { play_sfx(snd_land_diamond) }
+    if (g_cave.exploded) { play_sfx(snd_boom) }
+    if (g_cave.died) {
+        play_sfx(g_cave.timed_out ? snd_timeout : snd_die)
+    }
+    if (g_cave.exit_opened) { play_sfx(snd_exit_open) }
+    if (g_cave.cleared) { play_sfx(snd_clear) }
+    if (g_cave.pushed) { play_sfx(snd_push) }
+    if (g_cave.magic_on) { play_sfx(snd_magic) }
+    if (g_cave.magic_convert) { play_sfx(snd_magic_convert) }
+    if (g_cave.amoeba_grew) { play_sfx(snd_amoeba) }
+    if (g_cave.amoeba_gems) { play_sfx(snd_amoeba_gems) }
+    if (g_cave.amoeba_rocks) { play_sfx(snd_amoeba_rocks) }
+    if (g_cave.wall_grew) { play_sfx(snd_expand) }
+}
+
+def begin_cave() {
+    var next <- generate_cave(world_seed, cave_index)
+    adopt_cave(g_cave, next)
+    g_cave.god = god_mode
+    tick_acc = 0.0
+    time_low_armed = false
+    queued_dir = int2(0, 0)
+    queued_grab = false
+    hold_time = 0.0
+    step_this_press = false
+    player_slide = false
+}
+
+def reset_game() {
+    score = 0
+    lives = START_LIVES
+    cave_index = 0
+    begin_cave()
+    game_state = GameState.playing
+}
+
+def grabbing() : bool {
+    let z = glfwGetKey(live_window, GLFW_KEY_Z) == GLFW_PRESS
+    let ctrl = glfwGetKey(live_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS
+    let rctrl = glfwGetKey(live_window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS
+    return z || ctrl || rctrl
+}
+
+def held_dir(left, right, up, down : bool) : int2 {
+    var dx = 0
+    var dy = 0
+    if (left) { dx = -1 }
+    if (right) { dx = 1 }
+    if (up) { dy = -1 }
+    if (down) { dy = 1 }
+    if (dx != 0 && dy != 0) {
+        if (queued_dir.y != 0 && ((queued_dir.y < 0 && up) || (queued_dir.y > 0 && down))) {
+            return int2(0, queued_dir.y)
+        }
+        return int2(dx, 0)
+    }
+    return int2(dx, dy)
+}
+
+def poll_move_keys(dt : float) {
+    let left = glfwGetKey(live_window, GLFW_KEY_LEFT) == GLFW_PRESS
+    let right = glfwGetKey(live_window, GLFW_KEY_RIGHT) == GLFW_PRESS
+    let up = glfwGetKey(live_window, GLFW_KEY_UP) == GLFW_PRESS
+    let down = glfwGetKey(live_window, GLFW_KEY_DOWN) == GLFW_PRESS
+    let grab = grabbing()
+    var tapped = false
+    if (left && !key_left) { queued_dir = int2(-1, 0); tapped = true }
+    if (right && !key_right) { queued_dir = int2(1, 0); tapped = true }
+    if (up && !key_up) { queued_dir = int2(0, -1); tapped = true }
+    if (down && !key_down) { queued_dir = int2(0, 1); tapped = true }
+    if (tapped) {
+        step_this_press = false
+        hold_time = 0.0
+    }
+    if (grab && !key_grab) {
+        queued_grab = true
+    }
+    let held = held_dir(left, right, up, down)
+    if (held.x != 0 || held.y != 0) {
+        hold_time += dt
+        if (step_this_press && hold_time >= REPEAT_DELAY) {
+            queued_dir = held
+            if (grab) {
+                queued_grab = true
+            }
+        }
+    } else {
+        hold_time = 0.0
+        step_this_press = false
+    }
+    key_left = left
+    key_right = right
+    key_up = up
+    key_down = down
+    key_grab = grab
+}
+
+def consume_move_queue() {
+    cave_consume_input(g_cave)
+    queued_dir = g_cave.wish_dir
+    queued_grab = g_cave.grab
+    step_this_press = true
+}
+
+def handle_menu_keys(space_just, esc_just : bool) {
+    if (game_state == GameState.menu && space_just) {
+        reset_game()
+        return
+    }
+    if (game_state == GameState.playing && esc_just) {
+        game_state = GameState.paused
+        return
+    }
+    if (game_state == GameState.paused && (esc_just || space_just)) {
+        game_state = GameState.playing
+        return
+    }
+    if (game_state == GameState.game_over_state && space_just) {
+        reset_game()
+        return
+    }
+    if (game_state == GameState.cave_cleared && space_just) {
+        cave_index++
+        begin_cave()
+        game_state = GameState.playing
+    }
+}
+
+def after_death() {
+    lives--
+    if (lives <= 0) {
+        game_state = GameState.game_over_state
+        return
+    }
+    begin_cave()
+    game_state = GameState.playing
+}
+
+def sim_playing(dt : float) {
+    g_cave.god = god_mode
+    poll_move_keys(dt)
+    cave_latch_input(g_cave, queued_dir, queued_grab)
+    cave_apply_time(g_cave, dt)
+    let step = 1.0 / max(cave_hz * game_speed, 0.5)
+    tick_acc += dt
+    if (tick_acc >= step) {
+        tick_acc -= step
+        if (tick_acc >= step) {
+            tick_acc = 0.0
+        }
+        cave_tick(g_cave)
+        score += g_cave.collected * 10
+        play_tick_sfx()
+        consume_move_queue()
+        player_slide = false
+    } else {
+        maybe_start_player_slide(step - tick_acc)
+        if (player_slide) {
+            player_slide_t += dt / player_slide_dur
+            if (player_slide_t > 1.0) {
+                player_slide_t = 1.0
+            }
+        }
+    }
+    if (g_cave.cleared) {
+        score += int(g_cave.time_left)
+        game_state = GameState.cave_cleared
+        clear_timer = 1.4
+        return
+    }
+    if (!g_cave.alive) {
+        player_slide = false
+        game_state = GameState.dead
+        death_timer = 1.4
+    }
+    if (g_cave.time_left < 10.0 && !time_low_armed) {
+        time_low_armed = true
+        play_sfx(snd_time_low)
+    }
+}
+
+def update_music() {
+    return if (!music_enabled || prev_music_state == game_state)
+    stop_all_music(0.2)
+    start_music_for_state()
+}
+
+def setup_camera() {
+    let aspect = display_h != 0 ? float(display_w) / float(display_h) : 1.0
+    v_projection = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 200.0)
+    v_view = look_at_rh(CAM_EYE, float3(0.0, 0.0, 0.0), float3(0.0, 1.0, 0.0))
+    f_Eye = CAM_EYE
+    let t = get_uptime()
+    v_Time = t
+    f_Time = t
+}
+
+[export]
+def init() {
+    live_create_window("Boulder Dash", 1280, 720)
+    create_gl_objects()
+    music_enabled = !audio_is_single_threaded()
+    if (!audio_initialized) {
+        asch = audio_system_create()
+        audio_initialized = true
+        init_audio_samples()
+    }
+    if (music_enabled && !music_initialized) {
+        strudel_init(@@strudel_music_main)
+        strudel_set_volume(0.4, 0.0)
+        music_initialized = true
+        start_music_for_state()
+    }
+    if (!is_reload()) {
+        var next <- generate_cave(world_seed, cave_index)
+        adopt_cave(g_cave, next)
+        g_cave.god = god_mode
+    }
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) {
+        return
+    }
+    live_get_framebuffer_size(display_w, display_h)
+    glViewport(0, 0, display_w, display_h)
+    glClearColor(0.03, 0.03, 0.05, 1.0)
+    glClearDepthf(1.0)
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+    glEnable(GL_DEPTH_TEST)
+    glEnable(GL_CULL_FACE)
+    setup_camera()
+
+    let dt = min(get_dt(), 1.0 / 30.0)
+    let space_pressed = glfwGetKey(live_window, GLFW_KEY_SPACE) == GLFW_PRESS
+    let space_just = space_pressed && !space_was_pressed
+    space_was_pressed = space_pressed
+    let esc_pressed = glfwGetKey(live_window, GLFW_KEY_ESCAPE) == GLFW_PRESS
+    let esc_just = esc_pressed && !esc_was_pressed
+    esc_was_pressed = esc_pressed
+    handle_menu_keys(space_just, esc_just)
+
+    if (game_state == GameState.dead) {
+        death_timer -= dt
+        if (death_timer <= 0.0) {
+            after_death()
+        }
+    } elif (game_state == GameState.cave_cleared) {
+        clear_timer -= dt
+        if (clear_timer <= 0.0) {
+            cave_index++
+            begin_cave()
+            game_state = GameState.playing
+        }
+    } elif (game_state == GameState.playing) {
+        sim_playing(dt)
+    }
+
+    update_music()
+    glUseProgram(program)
+    draw_floor()
+    mark_movers()
+    draw_static_tiles()
+    let blend = saturate(tick_acc * max(cave_hz * game_speed, 0.5))
+    draw_movers(blend)
+    draw_player_slide()
+    glDisable(GL_CULL_FACE)
+    draw_hud()
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    if (music_enabled) {
+        strudel_shutdown()
+    }
+    if (!is_reload()) {
+        audio_system_finalize(asch.command, asch.next_sid)
+    }
+    live_destroy_window()
+}
+
+var max_frame_limit = 0
+
+def parse_args() {
+    let args <- get_command_line_arguments()
+    for (i in range(length(args) - 1)) {
+        if (args[i] == "--max-frames") {
+            max_frame_limit = try_to_int(args[i + 1]) ?? 0
+        }
+    }
+}
+
+struct GameStatusResult {
+    score : int
+    lives : int
+    cave_index : int
+    seed : int
+    diamonds_got : int
+    diamonds_need : int
+    time_left : float
+    rockford_x : int
+    rockford_y : int
+    state : string
+    god_mode : bool
+}
+
+[live_command(description="Score, lives, cave, seed, diamonds, time, Rockford")]
+def cmd_game_status(_input : JsonValue?) : JsonValue? {
+    return JV(GameStatusResult(
+        score = score,
+        lives = lives,
+        cave_index = cave_index,
+        seed = world_seed,
+        diamonds_got = g_cave.diamonds_got,
+        diamonds_need = g_cave.diamonds_need,
+        time_left = g_cave.time_left,
+        rockford_x = g_cave.rockford.x,
+        rockford_y = g_cave.rockford.y,
+        state = "{game_state}",
+        god_mode = god_mode
+    ))
+}
+
+[live_command(description="Reset game, keep seed")]
+def cmd_reset_game(_input : JsonValue?) : JsonValue? {
+    reset_game()
+    return JV(true)
+}
+
+struct CmdSeedArgs {
+    seed : int = 1984
+}
+
+[live_command(description="Set world seed and regenerate. Args: seed")]
+def cmd_set_seed(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdSeedArgs>)
+    world_seed = args.seed
+    begin_cave()
+    game_state = GameState.playing
+    return JV(args)
+}
+
+[live_command(description="Advance to next cave")]
+def cmd_next_cave(_input : JsonValue?) : JsonValue? {
+    cave_index++
+    begin_cave()
+    game_state = GameState.playing
+    return JV(cave_index)
+}
+
+[live_command(description="Go to previous cave")]
+def cmd_prev_cave(_input : JsonValue?) : JsonValue? {
+    cave_index = max(cave_index - 1, 0)
+    begin_cave()
+    game_state = GameState.playing
+    return JV(cave_index)
+}
+
+[live_command(description="Toggle god mode (no crush, insects, or timeout)")]
+def cmd_god_mode(_input : JsonValue?) : JsonValue? {
+    god_mode = !god_mode
+    g_cave.god = god_mode
+    return JV(god_mode)
+}
+
+struct CmdTimeArgs {
+    seconds : float = 150.0
+}
+
+[live_command(description="Set remaining time. Args: seconds")]
+def cmd_set_time(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdTimeArgs>)
+    g_cave.time_left = args.seconds
+    return JV(args)
+}
+
+struct CmdGemsArgs {
+    got : int = 0
+}
+
+[live_command(description="Set diamonds collected. Args: got")]
+def cmd_set_diamonds(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdGemsArgs>)
+    g_cave.diamonds_got = args.got
+    cave_tick(g_cave)
+    return JV(args)
+}
+
+[live_command(description="Dump current cave as ASCII")]
+def cmd_dump_cave(_input : JsonValue?) : JsonValue? {
+    return JV(cave_to_ascii(g_cave))
+}
+
+struct CmdAsciiArgs {
+    ascii : string = ""
+}
+
+[live_command(description="Load cave from ASCII. Args: ascii")]
+def cmd_load_ascii(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdAsciiArgs>)
+    if (empty(args.ascii)) {
+        return JV(false)
+    }
+    var loaded <- cave_from_ascii(args.ascii)
+    adopt_cave(g_cave, loaded)
+    g_cave.god = god_mode
+    game_state = GameState.playing
+    return JV(true)
+}
+
+[live_command(description="Force one cave tick")]
+def cmd_tick(_input : JsonValue?) : JsonValue? {
+    cave_tick(g_cave)
+    score += g_cave.collected * 10
+    play_tick_sfx()
+    return JV(true)
+}
+
+struct CmdSpeedArgs {
+    speed : float = 1.0
+}
+
+[live_command(description="Game speed multiplier. Args: speed")]
+def cmd_slow_motion(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<CmdSpeedArgs>)
+    game_speed = max(args.speed, 0.05)
+    return JV(args)
+}
+
+[export]
+def main() {
+    parse_args()
+    init()
+    var frame_count = 0
+    while (!exit_requested()) {
+        update()
+        maybe_collect_gc()
+        frame_count++
+        if (max_frame_limit > 0 && frame_count >= max_frame_limit) {
+            break
+        }
+    }
+    shutdown()
+}

--- a/examples/games/boulder-dash/test_cave.das
+++ b/examples/games/boulder-dash/test_cave.das
@@ -1,0 +1,379 @@
+options gen2
+require dastest/testing_boost public
+require cave
+
+def ascii_eq(t : T?; c : Cave; want : string; msg : string) {
+    let got = cave_to_ascii(c)
+    t |> equal(got, want, msg)
+}
+
+def tick_n(var c : Cave; n : int) {
+    for (_ in range(n)) {
+        cave_tick(c)
+    }
+}
+
+[test]
+def test_ascii_roundtrip(t : T?) {
+    let src = "XoR*\nX:.E"
+    let c <- cave_from_ascii(src)
+    t |> equal(c.cols, 4)
+    t |> equal(c.rows, 2)
+    t |> equal(c.rockford, int2(2, 0))
+    ascii_eq(t, c, src, "roundtrip")
+}
+
+[test]
+def test_boulder_falls_into_empty(t : T?) {
+    var c <- cave_from_ascii("XoX\nX.X\nXXX")
+    cave_tick(c)
+    ascii_eq(t, c, "X.X\nX!X\nXXX", "one cell down as falling")
+    cave_tick(c)
+    ascii_eq(t, c, "X.X\nXoX\nXXX", "settles")
+}
+
+[test]
+def test_stacked_boulders_one_cell_per_tick(t : T?) {
+    var c <- cave_from_ascii("#####\n#o###\n#o###\n#.###\n#.###\n#####")
+    cave_tick(c)
+    t |> equal(cave_at(c, 1, 1), Tile.boulder, "top stays")
+    t |> equal(cave_at(c, 1, 2), Tile.empty, "middle vacated")
+    t |> equal(cave_at(c, 1, 3), Tile.boulder_fall, "lower fell one")
+    t |> equal(cave_at(c, 1, 4), Tile.empty, "scan bit blocked a double fall")
+}
+
+[test]
+def test_boulder_rests_on_dirt(t : T?) {
+    var c <- cave_from_ascii("XoX\nX:X\nXXX")
+    cave_tick(c)
+    ascii_eq(t, c, "XoX\nX:X\nXXX", "dirt is not empty")
+}
+
+[test]
+def test_boulder_rolls_left(t : T?) {
+    var c <- cave_from_ascii("#####\n#.o.#\n#.o.#\n#...#\n#####")
+    cave_tick(c)
+    t |> equal(cave_at(c, 2, 1), Tile.empty, "rolled off")
+    t |> equal(cave_at(c, 1, 2), Tile.boulder_fall, "diagonal left")
+}
+
+[test]
+def test_boulder_prefers_left_over_right(t : T?) {
+    var c <- cave_from_ascii("#####\n#.o.#\n#.o.#\n#...#\n#####")
+    cave_tick(c)
+    t |> success(cave_at(c, 3, 2) != Tile.boulder_fall, "did not roll right")
+    t |> success(cave_at(c, 1, 2) == Tile.boulder_fall, "rolled left")
+}
+
+[test]
+def test_falling_crushes_rockford(t : T?) {
+    var c <- cave_from_ascii("XoX\nXRX\nXXX")
+    cave_set(c, 1, 0, Tile.boulder_fall)
+    cave_tick(c)
+    t |> success(!c.alive, "crushed")
+    t |> success(c.died)
+    t |> success(cave_at(c, 1, 1) == Tile.boulder)
+}
+
+[test]
+def test_stationary_boulder_does_not_crush(t : T?) {
+    var c <- cave_from_ascii("XoX\nXRX\nXXX")
+    cave_tick(c)
+    t |> success(c.alive, "stationary on player is blocked, not crushing")
+    t |> equal(cave_at(c, 1, 0), Tile.boulder)
+    t |> equal(cave_at(c, 1, 1), Tile.player)
+}
+
+[test]
+def test_collect_diamond_and_grab(t : T?) {
+    t |> run("walk onto diamond") <| @(t : T?) {
+        var c <- cave_from_ascii("R*..\nXXXX")
+        cave_set_input(c, int2(1, 0), false)
+        cave_tick(c)
+        t |> equal(c.diamonds_got, 1)
+        t |> equal(c.rockford, int2(1, 0))
+        t |> equal(cave_at(c, 1, 0), Tile.player)
+    }
+    t |> run("grab dirt without moving") <| @(t : T?) {
+        var c <- cave_from_ascii("R:..\nXXXX")
+        cave_set_input(c, int2(1, 0), true)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(0, 0), "stayed")
+        t |> equal(cave_at(c, 1, 0), Tile.empty)
+        t |> success(c.dug)
+    }
+    t |> run("grab diamond without moving") <| @(t : T?) {
+        var c <- cave_from_ascii("R*..\nXXXX")
+        cave_set_input(c, int2(1, 0), true)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(0, 0))
+        t |> equal(c.diamonds_got, 1)
+        t |> equal(cave_at(c, 1, 0), Tile.empty)
+    }
+}
+
+[test]
+def test_diamond_fall_events(t : T?) {
+    var c <- cave_from_ascii("X*X\nX.X\nXXX")
+    cave_tick(c)
+    t |> success(c.fell_diamond, "diamond started falling")
+    t |> success(!c.landed_diamond)
+    cave_tick(c)
+    t |> success(c.landed_diamond, "diamond landed")
+    t |> equal(cave_at(c, 1, 1), Tile.diamond)
+}
+
+[test]
+def test_peek_step(t : T?) {
+    t |> run("walk into dirt") <| @(t : T?) {
+        let c <- cave_from_ascii("R:.\nXXX")
+        t |> equal(cave_peek_step(c, int2(1, 0)), int2(1, 0))
+    }
+    t |> run("blocked by steel") <| @(t : T?) {
+        let c <- cave_from_ascii("XR.\nXXX")
+        t |> equal(cave_peek_step(c, int2(-1, 0)), int2(1, 0))
+    }
+    t |> run("no preview into boulder") <| @(t : T?) {
+        let c <- cave_from_ascii("Ro.\nXXX")
+        t |> equal(cave_peek_step(c, int2(1, 0)), int2(0, 0))
+    }
+}
+
+[test]
+def test_input_latch(t : T?) {
+    t |> run("tap dir survives a later idle latch") <| @(t : T?) {
+        var c <- cave_from_ascii("R:..\nXXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_latch_input(c, int2(0, 0), false)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0), "queued step applied")
+    }
+    t |> run("later tap replaces earlier") <| @(t : T?) {
+        var c <- cave_from_ascii(".R.\nXXX")
+        cave_latch_input(c, int2(-1, 0), false)
+        cave_latch_input(c, int2(1, 0), false)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(2, 0), "last tap wins")
+    }
+    t |> run("lock keeps committed dir") <| @(t : T?) {
+        var c <- cave_from_ascii("R:.\n:..\nXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_lock_input(c)
+        cave_latch_input(c, int2(0, 1), false)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0), "did not cancel")
+    }
+    t |> run("lock later tap applies after consume") <| @(t : T?) {
+        var c <- cave_from_ascii("R:.\n:..\nXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_lock_input(c)
+        cave_latch_input(c, int2(0, 1), false)
+        cave_tick(c)
+        cave_consume_input(c)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 1), "pending dir next tick")
+    }
+    t |> run("same dir while locked does not queue extra step") <| @(t : T?) {
+        var c <- cave_from_ascii("R:.\nXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_lock_input(c)
+        cave_latch_input(c, int2(1, 0), false)
+        cave_tick(c)
+        cave_consume_input(c)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0), "one cell")
+    }
+    t |> run("grab while locked does not cancel walk") <| @(t : T?) {
+        var c <- cave_from_ascii("R:.\nXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_lock_input(c)
+        cave_latch_input(c, int2(1, 0), true)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0), "walked")
+        t |> equal(cave_at(c, 1, 0), Tile.player)
+    }
+    t |> run("consume without pending clears wish") <| @(t : T?) {
+        var c <- cave_from_ascii("R:.\nXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_tick(c)
+        cave_consume_input(c)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0), "stopped")
+    }
+    t |> run("set_input unlocks so a later latch applies") <| @(t : T?) {
+        var c <- cave_from_ascii("R:.\nXXX")
+        cave_latch_input(c, int2(1, 0), false)
+        cave_lock_input(c)
+        cave_set_input(c, int2(0, 0), false)
+        cave_latch_input(c, int2(1, 0), false)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0), "unlocked latch walked")
+    }
+    t |> run("grab tap survives idle latch") <| @(t : T?) {
+        var c <- cave_from_ascii("R:..\nXXXX")
+        cave_latch_input(c, int2(1, 0), true)
+        cave_latch_input(c, int2(0, 0), false)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(0, 0), "did not walk")
+        t |> success(c.dug, "grab still fired")
+        t |> equal(cave_at(c, 1, 0), Tile.empty)
+    }
+}
+
+[test]
+def test_push(t : T?) {
+    t |> run("push takes two ticks") <| @(t : T?) {
+        var c <- cave_from_ascii("Ro.\nXXX")
+        cave_set_input(c, int2(1, 0), false)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(0, 0), "wind-up")
+        t |> equal(cave_at(c, 1, 0), Tile.boulder)
+        cave_tick(c)
+        t |> equal(c.rockford, int2(1, 0))
+        t |> equal(cave_at(c, 2, 0), Tile.boulder)
+        t |> equal(cave_at(c, 1, 0), Tile.player)
+    }
+    t |> run("no push into occupied") <| @(t : T?) {
+        var c <- cave_from_ascii("Ro:\nXXX")
+        cave_set_input(c, int2(1, 0), false)
+        tick_n(c, 3)
+        t |> equal(c.rockford, int2(0, 0))
+        t |> equal(cave_at(c, 1, 0), Tile.boulder)
+    }
+    t |> run("no vertical push") <| @(t : T?) {
+        var c <- cave_from_ascii("XoX\nXRX\nXXX")
+        cave_set_input(c, int2(0, -1), false)
+        cave_tick(c)
+        t |> equal(cave_at(c, 1, 0), Tile.boulder)
+        t |> equal(c.rockford, int2(1, 1))
+    }
+}
+
+[test]
+def test_firefly_left_hand(t : T?) {
+    var c <- cave_from_ascii("XXXX\nXn.X\nX..X\nXXXX")
+    cave_tick(c)
+    t |> equal(cave_at(c, 2, 1), Tile.firefly_r, "left and up blocked, turns east")
+    t |> equal(cave_at(c, 1, 1), Tile.empty)
+}
+
+[test]
+def test_butterfly_mirror(t : T?) {
+    var c <- cave_from_ascii("XXXX\nX.AX\nX..X\nXXXX")
+    cave_tick(c)
+    t |> equal(cave_at(c, 1, 1), Tile.butterfly_l, "right-hand: from up, try right (east) blocked, stay/turn west into empty")
+}
+
+[test]
+def test_explosion_firefly_and_butterfly(t : T?) {
+    t |> run("firefly + falling boulder -> empty blast") <| @(t : T?) {
+        var c <- cave_from_ascii("XXXXX\nX...X\nX.!.X\nX.n.X\nXXXXX")
+        t |> equal(cave_at(c, 2, 2), Tile.boulder_fall, "falling boulder")
+        t |> equal(cave_at(c, 2, 3), Tile.firefly_u, "firefly")
+        cave_tick(c)
+        t |> success(c.exploded)
+        t |> equal(cave_to_ascii(c), "XXXXX\nX...X\nX111X\nX111X\nXXXXX", "3x3 empty blast")
+        t |> equal(cave_at(c, 0, 0), Tile.steel, "steel outside blast")
+        tick_n(c, 3)
+        t |> equal(cave_at(c, 2, 3), Tile.empty)
+    }
+    t |> run("butterfly + falling boulder -> diamond blast") <| @(t : T?) {
+        var c <- cave_from_ascii("XXXXX\nX...X\nX.!.X\nX.A.X\nXXXXX")
+        cave_tick(c)
+        t |> equal(cave_at(c, 2, 3), Tile.dexplode0)
+        tick_n(c, 3)
+        t |> equal(cave_at(c, 2, 3), Tile.diamond)
+        t |> equal(cave_at(c, 0, 0), Tile.steel)
+    }
+}
+
+[test]
+def test_amoeba(t : T?) {
+    t |> run("enclosed becomes diamonds") <| @(t : T?) {
+        var c <- cave_from_ascii("###\n#a#\n###")
+        cave_tick(c)
+        t |> equal(cave_at(c, 1, 1), Tile.diamond)
+    }
+    t |> run("grows into dirt when forced") <| @(t : T?) {
+        var c <- cave_from_ascii("#####\n#a:##\n#####")
+        c.amoeba_grow = 1.0
+        cave_tick(c)
+        t |> equal(cave_at(c, 1, 1), Tile.amoeba)
+        t |> equal(cave_at(c, 2, 1), Tile.amoeba)
+    }
+    t |> run("mass becomes boulders") <| @(t : T?) {
+        var c <- make_cave(20, 12)
+        for (y in range(c.rows)) {
+            for (x in range(c.cols)) {
+                cave_set(c, x, y, Tile.amoeba)
+            }
+        }
+        cave_tick(c)
+        t |> equal(cave_count(c, Tile.amoeba), 0)
+        t |> equal(cave_count(c, Tile.boulder), 20 * 12)
+    }
+}
+
+[test]
+def test_magic_wall(t : T?) {
+    var c <- cave_from_ascii("XoX\nXMX\nX.X\nXXX")
+    cave_tick(c)
+    t |> success(c.magic_timer > 0.0, "activated")
+    t |> equal(cave_at(c, 1, 1), Tile.magic_active)
+    t |> equal(cave_at(c, 1, 2), Tile.diamond_fall, "boulder became diamond below")
+    t |> equal(cave_at(c, 1, 0), Tile.empty)
+}
+
+[test]
+def test_magic_expires_to_brick(t : T?) {
+    var c <- cave_from_ascii("XoX\nXMX\nX.X\nXXX")
+    c.magic_time_max = 2.0 / CAVE_HZ
+    cave_tick(c)
+    t |> success(c.magic_timer > 0.0)
+    tick_n(c, 2)
+    t |> success(c.magic_spent)
+    t |> equal(cave_at(c, 1, 1), Tile.brick)
+}
+
+[test]
+def test_expanding_wall(t : T?) {
+    var c <- cave_from_ascii(".....\n..=..\n.....")
+    cave_tick(c)
+    t |> equal(cave_at(c, 1, 1), Tile.expand, "grows left first")
+    t |> equal(cave_at(c, 2, 1), Tile.expand, "origin stays")
+    cave_tick(c)
+    t |> equal(cave_at(c, 0, 1), Tile.expand)
+}
+
+[test]
+def test_slime_lets_boulder_through(t : T?) {
+    var c <- cave_from_ascii("XoX\nX~X\nX.X\nXXX")
+    c.slime_perm = 1.0
+    cave_tick(c)
+    t |> equal(cave_at(c, 1, 0), Tile.empty)
+    t |> equal(cave_at(c, 1, 1), Tile.slime, "slime remains")
+    t |> equal(cave_at(c, 1, 2), Tile.boulder_fall)
+}
+
+[test]
+def test_quota_exit_and_timeout(t : T?) {
+    t |> run("quota opens exit") <| @(t : T?) {
+        var c <- cave_from_ascii("R*E\nXXX")
+        c.diamonds_need = 1
+        cave_set_input(c, int2(1, 0), false)
+        cave_tick(c)
+        t |> equal(c.diamonds_got, 1)
+        t |> equal(cave_at(c, 2, 0), Tile.exit_open)
+        t |> success(c.exit_opened)
+        cave_set_input(c, int2(1, 0), false)
+        cave_tick(c)
+        t |> success(c.cleared)
+    }
+    t |> run("timeout kills") <| @(t : T?) {
+        var c <- cave_from_ascii("R.\nXX")
+        c.time_left = 0.05
+        cave_apply_time(c, 0.1)
+        t |> success(!c.alive)
+        t |> success(c.timed_out)
+    }
+}

--- a/examples/games/boulder-dash/test_cave.das
+++ b/examples/games/boulder-dash/test_cave.das
@@ -285,6 +285,20 @@ def test_explosion_firefly_and_butterfly(t : T?) {
         t |> equal(cave_at(c, 2, 3), Tile.diamond)
         t |> equal(cave_at(c, 0, 0), Tile.steel)
     }
+    t |> run("butterfly walks into falling boulder -> diamonds") <| @(t : T?) {
+        var c <- cave_from_ascii("XXXXX\nXA!#X\nXXXXX")
+        cave_tick(c)
+        t |> success(c.exploded, "walk-in blast")
+        tick_n(c, 3)
+        t |> success(cave_count_diamonds(c) >= 1, "left diamonds")
+    }
+    t |> run("amoeba touching butterfly -> diamonds") <| @(t : T?) {
+        var c <- cave_from_ascii("XXXXX\nX...X\nX.AaX\nX...X\nXXXXX")
+        cave_tick(c)
+        t |> success(c.exploded)
+        tick_n(c, 3)
+        t |> success(cave_count_diamonds(c) >= 1)
+    }
 }
 
 [test]

--- a/examples/games/boulder-dash/test_generate.das
+++ b/examples/games/boulder-dash/test_generate.das
@@ -1,0 +1,69 @@
+options gen2
+require dastest/testing_boost public
+require cave
+require cave_gen
+
+def border_is_steel(c : Cave) : bool {
+    for (x in range(c.cols)) {
+        if (cave_at(c, x, 0) != Tile.steel || cave_at(c, x, c.rows - 1) != Tile.steel) {
+            return false
+        }
+    }
+    for (y in range(c.rows)) {
+        if (cave_at(c, 0, y) != Tile.steel || cave_at(c, c.cols - 1, y) != Tile.steel) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def test_generated_cave_invariants(t : T?) {
+    let c <- generate_cave(1984, 0)
+    t |> equal(c.cols, CAVE_COLS)
+    t |> equal(c.rows, CAVE_ROWS)
+    t |> success(border_is_steel(c), "steel border")
+    t |> equal(cave_count(c, Tile.player), 1, "one Rockford")
+    let exits = cave_count(c, Tile.exit_closed) + cave_count(c, Tile.exit_open)
+    t |> success(exits >= 1, "has exit")
+    let gems = cave_count_diamonds(c)
+    t |> success(gems >= 1, "has diamonds")
+    t |> success(c.diamonds_need >= 1 && c.diamonds_need <= gems, "quota in range")
+    t |> success(c.time_left >= 80.0)
+    t |> success(c.rockford.x > 0)
+    t |> success(cave_count(c, Tile.boulder) > 20, "scattered boulders")
+}
+
+[test]
+def test_same_seed_identical(t : T?) {
+    let a <- generate_cave(42, 3)
+    let b <- generate_cave(42, 3)
+    t |> equal(cave_to_ascii(a), cave_to_ascii(b), "deterministic")
+    t |> equal(a.diamonds_need, b.diamonds_need)
+}
+
+[test]
+def test_different_seeds_differ(t : T?) {
+    let a <- generate_cave(1984, 0)
+    let b <- generate_cave(2026, 0)
+    let d <- generate_cave(1984, 1)
+    t |> success(cave_to_ascii(a) != cave_to_ascii(b), "world seed changes layout")
+    t |> success(cave_to_ascii(a) != cave_to_ascii(d), "cave index changes layout")
+}
+
+[test]
+def test_fallback_playable(t : T?) {
+    let c <- fallback_cave()
+    t |> success(cave_is_sane(c))
+    t |> success(border_is_steel(c))
+    t |> equal(cave_count(c, Tile.player), 1)
+}
+
+[test]
+def test_many_seeds_sane(t : T?) {
+    for (s in range(20)) {
+        let c <- generate_cave(1000 + s, s % 5)
+        t |> success(cave_is_sane(c), "seed {s}")
+        t |> success(c.diamonds_need <= cave_count_diamonds(c))
+    }
+}

--- a/examples/games/boulder-dash/test_generate.das
+++ b/examples/games/boulder-dash/test_generate.das
@@ -67,3 +67,31 @@ def test_many_seeds_sane(t : T?) {
         t |> success(c.diamonds_need <= cave_count_diamonds(c))
     }
 }
+
+def survives_idle(c0 : Cave; ticks : int) : bool {
+    var c <- cave_from_ascii(cave_to_ascii(c0))
+    find_rockford(c)
+    for (_ in range(ticks)) {
+        cave_tick(c)
+        if (!c.alive) {
+            return false
+        }
+    }
+    return true
+}
+
+[test]
+def test_spawn_not_sucker(t : T?) {
+    t |> run("seed 1984 cave 3 survives idle") <| @(t : T?) {
+        let c <- generate_cave(1984, 2)
+        t |> success(survives_idle(c, 24), "no crush/chase in first 3s")
+    }
+    t |> run("early caves across seeds") <| @(t : T?) {
+        for (s in range(12)) {
+            for (idx in range(5)) {
+                let c <- generate_cave(2000 + s * 17, idx)
+                t |> success(survives_idle(c, 24), "seed {s} cave {idx + 1}")
+            }
+        }
+    }
+}

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -914,6 +914,7 @@ def public strudel_shutdown() {
     if (g_tick_status_box != null) {
         unset_status_update(g_sid)
         g_tick_status_box |> seq_box_release
+        g_tick_status_box = null
     }
     // release tracks and buffers before measuring memory
     for (t in g_tracks) {

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -849,6 +849,7 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
     g_done_status |> append(1)
     // create PCM stream on main thread (audio globals are initialized here)
     let thread_sid = play_sound_from_pcm_stream(MA_SAMPLE_RATE, MA_CHANNELS)
+    g_sid = thread_sid   // main-thread copy: shutdown/save_state run here, not on the worker
     // capture shared resources from main thread
     var bank_ptr = unsafe(addr(g_bank))
     var sf2_ptr = g_sf2 != null ? unsafe(reinterpret<SF2File const?>(g_sf2)) : null
@@ -896,6 +897,8 @@ def public strudel_shutdown() {
         // refcount was 2 after init; worker's release made it 1; *_remove decrements to 0 and deletes
         unsafe(stream_remove(g_cmd_stream))
         unsafe(job_status_remove(g_done_status))
+        g_cmd_stream = null
+        g_done_status = null
         // player box
         unsafe(lock_box_remove(g_playback_box))
         g_playback_box = null
@@ -923,7 +926,10 @@ def public strudel_shutdown() {
     unsafe {
         delete g_tracks
     }
-    g_sid = 0ul
+    if (g_sid != 0ul) {
+        stop(g_sid, 0.0)   // mixer voice outlives the worker unless stopped
+        g_sid = 0ul
+    }
     // release SF2 soundfont (finalizer recursively frees instruments/presets/zones)
     if (g_sf2 != null) {
         unsafe {
@@ -1133,7 +1139,7 @@ def public strudel_restore_sf2_state(data : array<uint8>) {
 
 def public strudel_save_state() : array<uint8> {
     //! Serialize playback state (wall time, CPS, sample bank) into a byte array; shuts down playback first.
-    if (g_sid == 0ul) {
+    if (g_sid == 0ul && g_cmd_stream == null) {
         var empty : array<uint8>
         return <- empty
     }


### PR DESCRIPTION
Adds a Boulder Dash–style live example under `examples/games/boulder-dash`: 40×22 scan-line caves, a seeded generator, grab, quota plus timer, three lives. Play with `daslang-live examples/games/boulder-dash/main.das`.

A tap starts the Rockford slide immediately and lands on the next 8 Hz tick. Once that slide has started, the cell is committed — a different direction before the tick queues for the following cell instead of cancelling. Hold ~0.3s to keep walking. Phong tiles, river-style waves on expanding walls, and a tight glint on diamonds.

`strudel_shutdown` now stops the mixer voice and clears the command stream so a live reload does not leave two music beds playing.

Where to look: `cave.das` (`cave_lock_input` / `cave_latch_input` / `cave_consume_input`), `main.das` (`maybe_start_player_slide`, `poll_move_keys`, shaders + `mat_for`), `cave_gen.das`, `test_cave.das` input-latch cases, `strudel_player.das` shutdown.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local preflight `--full`: 17 passed, 0 failed. Skipped `tests-aot`, `sequence`, and `imgui` because the live/MCP host had `libDaScriptDyn*.dll` loaded (no relink). `cpp-syntax` skipped (no C++ in the diff). Boulder Dash dastest: 51 passed. Live play on seed 1984 cave 1 confirmed shaders and tick.
- Woodpecker (Codex review) skipped by request.

### Claims — stated, not tested
- Host slide lock is wired by calling `cave_lock_input` when the preview starts; the lock/consume policy is distinguished in `test_cave.das`. GLFW-frame retarget-not-allowed has no headless host test. A break looks like: start walking, tap another arrow before the tick, Rockford turns mid-slide.
- `strudel_shutdown` mixer-stop was verified by live reload (one bed after reload). A break is two overlapping music beds after `live_reload`.

### Not done
- Style-hygiene rename sweep (`gem`/`diamond`, `FLY_TURN`, `cmd_slow_motion`, etc.) declined: vocabulary churn on a new example, not a defect of the physics or shaders.
- ASCII legend still writes `NESW` next to firefly chars that are actually `n e s w`.

</details>
