### PR TITLE
inliner: a cast of a parameter into a writable by-ref param no longer loses the write

### DIFF
--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -1176,6 +1176,32 @@ namespace das {
             return gc_local<TypeDecl>(c);
         }
 
+        // an ExprVar on a refType parameter leaves type->ref unset (implicit ref via
+        // isRefType), and casts copy that flag - so a cast/reinterpret chain rooted in
+        // a parameter reads flag-false yet names caller storage
+        // a cast reinterprets its subexpression's storage without creating any of its own,
+        // so what the argument IS is always the thing under the casts
+        Expression * peelCasts ( Expression * e ) {
+            while ( e && e->rtti_isCast() ) e = static_cast<ExprCast *>(e)->subexpr;
+            return e;
+        }
+
+        bool rootsInVar ( Expression * e ) {
+            auto root = peelCasts(e);
+            return root && root->rtti_isVar();
+        }
+
+        // shapes that always produce a fresh value, never a view of caller storage. a
+        // ref-returning call types ref=true and binds a reference before reaching here; the
+        // ternary derives from ExprCallFunc yet SELECTS an arm, so it yields a view
+        bool isProvenRvalue ( Expression * e ) {
+            e = peelCasts(e);
+            if ( !e || e->rtti_isOp3() ) return false;
+            return e->rtti_isCallFunc() || e->rtti_isInvoke()
+                || e->rtti_isMakeStruct() || e->rtti_isMakeArray() || e->rtti_isMakeTuple()
+                || e->rtti_isMakeVariant();
+        }
+
         // a by-value temp is a local, and infer rejects a local of a type that cannot be
         // one (31020/30199) - refusing keeps the call a call, instead of erroring on a generated name
         bool tempTypeIsLocal ( Expression * init, bool ref, bool callerIsGenerator ) {
@@ -2168,10 +2194,14 @@ namespace das {
                         } else {
                             if ( !makeArgTemp(arg->clone(), false, false, true) ) return false;
                         }
-                    } else if ( arg->type && arg->type->ref ) {  // lvalue chain: bind a reference once, like the call did
+                    } else if ( arg->type && (arg->type->ref || rootsInVar(argLeaf)) ) {  // lvalue chain: bind a reference once, like the call did
                         auto init = arg->clone();
                         init->alwaysSafe = true;            // generated binding to real storage
                         if ( !makeArgTemp(init, !varParam, true, false) ) return false;
+                    } else if ( varParam && !isProvenRvalue(argLeaf) ) {
+                        siteFail(site, "can't inline " + subjName + ": argument '" + param->name
+                            + "' may alias caller storage the callee writes", callLike->at);
+                        return false;
                     } else {
                         // rvalue into a ref param: materialize. a block holder must be var -
                         // const would propagate into the invoke, rejecting the block's own var params

--- a/tests/language/optimization_auto_inline_functions.das
+++ b/tests/language/optimization_auto_inline_functions.das
@@ -384,6 +384,150 @@ def target_locked_name_dispatch(a : int) : int {
     return out
 }
 
+// ----- writable by-ref argument lvalue shapes -----
+// a cast/reinterpret of a var parameter is an lvalue the argument's type flags don't mark
+// as one - these pin that it binds a reference, never a by-value copy (rootsInVar in
+// ast_inline.cpp); the rest pin which shapes count as a fresh value (isProvenRvalue)
+
+struct WrPlain {
+    n : int = 1
+}
+
+struct WrKid : WrPlain {
+    extra : int = 0
+}
+
+struct WrTwin {
+    m : int = 5
+}
+
+struct WrBox {
+    inner : WrPlain = WrPlain()
+}
+
+struct WrOwner {
+    txt : string = "hello"
+    tbl : table<string; int>
+}
+
+struct WrPair {
+    a : int = 0
+    b : int = 0
+}
+
+variant WrEither {
+    num : int
+    plain : WrPlain
+}
+
+def poke_n(var s : WrPlain) {
+    s.n = 42
+}
+
+def poke_txt(var o : WrOwner) {
+    o.txt = "poked"
+}
+
+def poke_pair(var p : WrPair) {
+    p.a = 42
+}
+
+def poke_either(var e : WrEither) {
+    e := WrEither(num = 42)
+}
+
+def poke_dim(var d : int[3]) {
+    d[0] = 42
+}
+
+def poke_tuple(var tp : tuple<int; int>) {
+    tp._0 = 42
+}
+
+[never_inline]
+def make_wr_plain : WrPlain {
+    return WrPlain()
+}
+
+[never_inline]
+def make_wr_kid : WrKid {
+    return WrKid()
+}
+
+[export]
+def target_cast_param(var s : WrPlain) {
+    poke_n(cast<WrPlain>(s))
+}
+
+[export]
+def target_upcast_param(var k : WrKid) {
+    poke_n(cast<WrPlain>(k))
+}
+
+[export]
+def target_reinterpret_param(var w : WrTwin) {
+    unsafe {
+        poke_n(reinterpret<WrPlain>(w))
+    }
+}
+
+[export]
+def target_cast_field(var b : WrBox) {
+    // control: a field is already flagged ref, so this rides the pre-existing lvalue arm
+    poke_n(cast<WrPlain>(b.inner))
+}
+
+[export]
+def target_ternary_pick(c : bool; var a : WrPlain; var b : WrPlain) {
+    poke_n(c ? a : b)
+}
+
+[export]
+def target_cast_param_noncopyable(var o : WrOwner) {
+    // a non-copyable argument turns a by-value temp into a MOVE init: the caller's
+    // value is zeroed outright, not merely left unwritten
+    poke_txt(cast<WrOwner>(o))
+}
+
+[export]
+def target_rvalue_arg {
+    // writes land in the dying temp either way, so materializing is semantics-preserving.
+    // make_wr_plain is [never_inline] so the argument stays a call node, not a spliced var read
+    poke_n(make_wr_plain())
+}
+
+[export]
+def target_make_struct_arg {
+    poke_n(WrPlain(n = 2))
+}
+
+[export]
+def target_make_variant_arg {
+    poke_either(WrEither(num = 7))
+}
+
+[export]
+def target_make_array_arg {
+    poke_dim(fixed_array<int>(1, 2, 3))
+}
+
+[export]
+def target_make_tuple_arg {
+    poke_tuple((1, 2))
+}
+
+[export]
+def target_invoke_arg(blk : block<(x : int) : WrPair>) {
+    poke_pair(invoke(blk, 3))
+}
+
+[export]
+def target_upcast_of_rvalue {
+    // a same-type cast is elided by infer, so an UPCAST is the shape that reaches the
+    // classifier still wrapped: the fresh value is under the cast, not the cast itself
+    poke_n(cast<WrPlain>(make_wr_kid()))
+}
+
 def has(s, sub : string) : bool {
     return find(s, sub, 0) >= 0
 }
@@ -569,5 +713,111 @@ def test_auto_inline_functions_behavior(t : T?) {
         t |> equal(target_move_chain(1), 1)
         t |> equal(target_move_copyable(7), 7)
         t |> equal(target_ref_binder(10, 20, 30), 11)
+    }
+}
+
+[test]
+def test_auto_inline_writable_ref_args(t : T?) {
+    ast_gc_guard() {
+        // the binding's `&` is the load-bearing half: a by-value temp splices the call away
+        // just the same, and then drops every write the body makes into it
+        t |> run("cast of a parameter binds a reference") @(t : T?) {
+            let b = body_of(t, "target_cast_param")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+            t |> success(has(b, "WrPlain&"), "argument binds by reference: {b}")
+        }
+        t |> run("upcast of a parameter binds a reference") @(t : T?) {
+            let b = body_of(t, "target_upcast_param")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+            t |> success(has(b, "WrPlain&"), "argument binds by reference: {b}")
+        }
+        t |> run("reinterpret of a parameter binds a reference") @(t : T?) {
+            let b = body_of(t, "target_reinterpret_param")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+            t |> success(has(b, "WrPlain&"), "argument binds by reference: {b}")
+        }
+        t |> run("cast of a non-copyable parameter binds a reference") @(t : T?) {
+            let b = body_of(t, "target_cast_param_noncopyable")
+            t |> success(!has(b, "poke_txt("), "call is gone: {b}")
+            t |> success(has(b, "WrOwner&"), "argument binds by reference: {b}")
+        }
+        t |> run("cast of a field rides the pre-existing lvalue arm") @(t : T?) {
+            let b = body_of(t, "target_cast_field")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+            t |> success(has(b, "WrPlain&"), "argument binds by reference: {b}")
+        }
+        t |> run("a ternary of two lvalues into a var param stays a call") @(t : T?) {
+            let b = body_of(t, "target_ternary_pick")
+            t |> success(has(b, "poke_n("), "call stays regular: {b}")
+        }
+        t |> run("a value-returning call into a var param materializes and splices") @(t : T?) {
+            let b = body_of(t, "target_rvalue_arg")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+        }
+        t |> run("an invoke into a var param materializes and splices") @(t : T?) {
+            let b = body_of(t, "target_invoke_arg")
+            t |> success(!has(b, "poke_pair("), "call is gone: {b}")
+        }
+        t |> run("a make-struct into a var param materializes and splices") @(t : T?) {
+            let b = body_of(t, "target_make_struct_arg")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+        }
+        t |> run("a make-variant into a var param materializes and splices") @(t : T?) {
+            let b = body_of(t, "target_make_variant_arg")
+            t |> success(!has(b, "poke_either("), "call is gone: {b}")
+        }
+        t |> run("a make-array into a var param materializes and splices") @(t : T?) {
+            let b = body_of(t, "target_make_array_arg")
+            t |> success(!has(b, "poke_dim("), "call is gone: {b}")
+        }
+        t |> run("a make-tuple into a var param materializes and splices") @(t : T?) {
+            let b = body_of(t, "target_make_tuple_arg")
+            t |> success(!has(b, "poke_tuple("), "call is gone: {b}")
+        }
+        t |> run("an upcast of a value-returning call is still a proven rvalue") @(t : T?) {
+            let b = body_of(t, "target_upcast_of_rvalue")
+            t |> success(!has(b, "poke_n("), "call is gone: {b}")
+        }
+    }
+}
+
+[test]
+def test_auto_inline_writable_ref_args_behavior(t : T?) {
+    t |> run("writes through the param reach the caller") @(t : T?) {
+        var p = WrPlain()
+        target_cast_param(p)
+        t |> equal(p.n, 42, "cast of a parameter aliases")
+        var k = WrKid()
+        target_upcast_param(k)
+        t |> equal(k.n, 42, "upcast of a parameter aliases")
+        var w = WrTwin()
+        target_reinterpret_param(w)
+        t |> equal(w.m, 42, "reinterpret of a parameter aliases")
+        var bx = WrBox()
+        target_cast_field(bx)
+        t |> equal(bx.inner.n, 42, "cast of a field aliases")
+        var a = WrPlain()
+        var b = WrPlain()
+        target_ternary_pick(true, a, b)
+        t |> equal(a.n, 42, "picked arm is written")
+        t |> equal(b.n, 1, "unpicked arm is untouched")
+        target_rvalue_arg()
+        target_make_struct_arg()
+        target_make_variant_arg()
+        target_make_array_arg()
+        target_make_tuple_arg()
+        target_invoke_arg($(x : int) {
+            return WrPair(a = x, b = x)
+        })
+        target_upcast_of_rvalue()
+    }
+    t |> run("non-copyable argument is aliased, not moved out") @(t : T?) {
+        var o = WrOwner()
+        o.tbl["k"] = 7
+        target_cast_param_noncopyable(o)
+        t |> equal(o.txt, "poked", "write reaches the caller")
+        t |> equal(length(o.tbl), 1, "owned table survives the call")
+        t |> equal(o.tbl?["k"] ?? 0, 7, "table contents survive the call")
+        delete o
     }
 }

--- a/tests/typer_errors/_inline_alias_hazard.das
+++ b/tests/typer_errors/_inline_alias_hazard.das
@@ -1,0 +1,30 @@
+// Fixture for test_inline_errors.das — intentionally fails to compile: an
+// [inline] callee takes a writable by-ref parameter, and the argument is a
+// ternary of two lvalues. A ternary SELECTS an arm rather than producing a
+// fresh value, so binding the parameter to a by-value temp would drop the
+// callee's write; the fail-closed contract errors instead of corrupting.
+// `_`-prefix keeps dastest from auto-running it; `expect` makes lint skip it.
+expect 30100
+
+options gen2
+
+struct Plain {
+    n : int = 1;
+}
+
+[inline]
+def poke_n(var s : Plain) {
+    s.n = 42;
+}
+
+def pick(c : bool; var a : Plain; var b : Plain) {
+    poke_n(c ? a : b);
+}
+
+[export]
+def main() {
+    var a = Plain();
+    var b = Plain();
+    pick(true, a, b);
+    print("{a.n} {b.n}\n");
+}

--- a/tests/typer_errors/test_inline_errors.das
+++ b/tests/typer_errors/test_inline_errors.das
@@ -80,4 +80,8 @@ def test_inline_contract_errors(t : T?) {
         t |> expect_issue("_inline_scope_in_with.das",
             "the call site resolves inside with (module _inline_scope_dispatch_helper)")
     }
+    t |> run("writable by-ref argument that may alias caller storage") @(t : T?) {
+        t |> expect_issue("_inline_alias_hazard.das",
+            "may alias caller storage the callee writes")
+    }
 }


### PR DESCRIPTION
**Behavior change: an `[inline]` callee whose writable by-ref parameter gets an argument the inliner cannot prove is an rvalue now fails to compile, where before it silently corrupted the caller's value.**

The auto-inliner lost writes made through a cast. An `ExprVar` on a `refType` parameter leaves `type->ref` unset — parameters are the one lvalue shape that relies on the implicit `isRefType` ref instead of the flag — and `castStruct` copies that flag verbatim. So `cast<T>(param)` typed flag-false while still naming caller storage. The argument classifier keyed its "lvalue chain: bind a reference once" branch on the raw flag, missed, and fell through to "rvalue into a ref param: materialize", handing the callee a by-value temp. Every write the callee made died with that temp. When the struct was non-copyable the temp was move-initialized instead, which zeroed the caller's value outright: a `string` field came back empty and an owned `table` came back cleared. `[never_inline]` on the caller was a complete workaround, which is what pinned the bug to the inliner.

The classifier now peels cast and reinterpret chains to their root before deciding, so a cast of a parameter binds a reference exactly as the direct call did. Separately, a writable by-ref parameter whose argument is not a proven rvalue no longer materializes at all — it declines the site, or errors on an `[inline]` MUST site. That second guard caught a live second shape: `f(c ? a : b)` into a `var` parameter lost its write the same way, because a ternary derives from `ExprCallFunc` yet yields a view of an arm rather than a fresh value.

Where to look: `classifyArguments` in `src/ast/ast_inline.cpp` — the `byRefParam` branch chain, and the two helpers above `tempTypeIsLocal`. The whitelist in `isProvenRvalue` is the risky spot: a shape wrongly listed there reintroduces the lost write, while a shape wrongly missing it only costs an inline.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Negative-controlled per shape. With `src/ast/ast_inline.cpp` reverted to master and rebuilt, the four `binds a reference` arms go red on the binding shape, the ternary arm goes red on the decline, both behavioral arms go red on the corrupted values, and the new `[inline]` error arm goes red. Restored and rebuilt before the run below.
- The `cast of a field` arm is a control, not a bug test: a field already types `ref==true`, so it rides the pre-existing lvalue arm and stays green on both sides. It is named as a control so a later reader does not mistake it for coverage of the new path.
- Full local `preflight --full` green: 19 passed, 0 failed, 2 skipped (both skips are `dasVulkan` not built in this tree — `docs/vulkan2rst` and the `docs/sphinx-html` that depends on its generated pages).

### Claims — stated, not tested
- `rtti_isConstant()` and `rtti_isNullCoalescing()` were dropped from `isProvenRvalue` as dead rather than kept untested. `rtti_isConstant` is unreachable at this site: the branch is guarded by a non-const by-ref parameter, and infer rejects a constant argument at 30341 before the inline pass runs (0 `ExprConst` arrivals across 1423 traced ones in the full suite). `rtti_isNullCoalescing` was inert: `ExprNullCoalescing` does not derive from `ExprCallFunc` or any `Make*`, so the return expression already yielded false for it — `??` still reaches the site and still declines, byte-identically. Both removals fail safe: if either shape did arrive, the result is a declined inline, never a lost write.

### Not done
- `tests/language/generators.das` and `tests/language/typeAlias.das` each report `error[50503]` (`TypeDecl ... has no source location`) under a tree-wide `--ast-verify-batch` sweep. Both reproduce byte-identically on master (`872a1ab2a`), so they are pre-existing and unrelated to this change — the gaps are in lambda/generic-alias TypeDecl construction. Not fixed here; the per-PR gate scopes to changed files and passes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
