### PR TITLE
dasLLAMA: image-chat cells join the record rig — driver-minted cards for the official vision models

### DIFF
--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -566,8 +566,9 @@ a number is self-describing rather than a bare figure in a table.
 **Regression checking inverts the same rig:** `gen_bench_records.das --oracle --legs metal`
 takes the store's das rows as the work list, re-measures each once, and gates one-sided against
 its stored mean (fail past 5%, warn past 3%, gains flagged as suspicious). llama.cpp never runs,
-the store is never written, and the timed child runs `--frozen` — a prepare pass bakes and warms
-each cell's image first (the batch starts wiped), so the cell itself never converts. A second
+the store is never written, and a text cell's timed child runs `--frozen` — a prepare pass bakes
+and warms its image first (the batch starts wiped), so the timed cell never converts; ASR and
+image-chat cells bake what they need mid-cell, like their publishing legs. A second
 harness would produce numbers that cannot be compared to any of this, which is
 why writing one is a review defect.
 

--- a/modules/dasLLAMA/BRINGUP.md
+++ b/modules/dasLLAMA/BRINGUP.md
@@ -298,11 +298,11 @@ fail bar as "suspicious — verify"). Exit is nonzero on any FAIL.
 
 - GATE 1 — llama.cpp never re-measures: no ref runs, ref binaries not even required.
 - GATE 2 — one das pass per row. The >3% cv warm-retry stays: it REPLACES a bad cold measure.
-- GATE 3 — the timed cell is frozen: the batch starts with the lifecycle wipe, a prepare pass
-  bakes each cell's image, and the timed child runs `lcpp_bench --frozen` (it never converts);
-  the store is never written.
+- GATE 3 — a timed text cell is frozen: the batch starts with the lifecycle wipe, a prepare
+  pass bakes its image, and the timed child runs `lcpp_bench --frozen` (it never converts);
+  ASR and image-chat cells bake what they need mid-cell. The store is never written.
 - Default is stop-at-first-FAIL (fail fast mid-refactor); `--oracle-keep-going` runs the full
-  board. `-o substr` narrows to one model; ASR legs are excluded (their das cells are CPU-path).
+  board. `-o substr` narrows to one model; `-w llm|asr|image` narrows the modality.
 - A FAIL auto-triggers ONE solo re-run of that cell after `--oracle-retry-settle` seconds
   (default 180 — thermal recovery takes ~3 minutes; 0 disables), and the RETRY verdict stands —
   the board shows both attempts. This

--- a/modules/dasLLAMA/PROFILE.md
+++ b/modules/dasLLAMA/PROFILE.md
@@ -102,9 +102,17 @@ DASLLAMA_BOX=<box> bin/daslang modules/dasLLAMA/performance/gen_bench_records.da
   --ref-clean <llama-bench clean-cpu build> --ref-stock <llama-bench stock build>
 ```
 
-- Reference binaries also come from `LLAMA_BENCH_CLEAN` / `LLAMA_BENCH_STOCK`.
+- Reference binaries also come from `LLAMA_BENCH_CLEAN` / `LLAMA_BENCH_STOCK`. An unset ref is
+  loud: a warning at sweep start plus a skipped-pair list in the end summary — a das-only board
+  is legal but never a surprise.
 - `--legs` takes a comma list of `cpu` (= neon + amx) / `neon` / `amx` / `metal`; there is no
-  `all`. The full Apple board is `--legs cpu,metal`. `-w llm|asr|all`, `-o <substring>` to narrow.
+  `all`. The full Apple board is `--legs cpu,metal`. `-w llm|asr|image|all`, `-o <substring>` to
+  narrow.
+- Every official model with an mmproj companion (`mmproj_companion` in `model_specs.das`) also
+  gets its image-chat cells — one `--image` child per selected leg on the pinned
+  `bench_image_fixture()` picture, das-only (llama-bench has no image mode), `--image-reps`
+  (default 3) repetitions. `-w image` runs just those cells; the oracle re-verifies the stored
+  rows the same way.
 - `-p 512 -n 128 -r 5` are the recorded shapes. Changing them makes the row incomparable to
   every other row in the store.
 - `--settle <seconds>` (default 12) idles between passes; a dead child's multi-GB map reclaims
@@ -127,6 +135,8 @@ bin/daslang modules/dasLLAMA/performance/gen_site_records.das
 ## The image cell (`--image`)
 
 The image TURN on a vision decoder — what a user actually waits on when they attach a picture.
+Rig 3 spawns these for every official model with an mmproj companion (and the oracle re-verifies
+the stored rows); the manual form below is for off-board pairs and one-off probes.
 One process, one tune-key demand, one image-identity stamp, same as the ASR cell:
 
 ```sh

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -20,8 +20,8 @@ holding a single speech model family — applies `REVIEW_AUDIO.md`. A change to
 `dasllama/dasllama_vision.das`, `dasllama/dasllama_vision_io.das`,
 `dasllama/dasllama_vision_embedder.das`, a vision family file — one
 `dasllama/dasllama_<family>.das` holding a single vision projector family — or an in-process
-path that splices a stream carrying decoded media into a prompt or schedules such a stream
-(a rig that merely spawns an image-measuring child is not one), applies
+path (one that runs inside the program under review, not a spawned child process) that
+splices a stream carrying decoded media into a prompt or schedules such a stream, applies
 `REVIEW_VISION.md`. A
 `dasllama/dasllama_tower.das` change — the shared encoder-tower home — applies
 `REVIEW_AUDIO.md` and `REVIEW_VISION.md`; a family file that only CALLS a shared rail does not
@@ -94,11 +94,11 @@ ratio across the size ladder, and superlinear is a defect.
 `tests/test_tokenizer.das` run with its cases EXECUTED, not skipped.**
 
 **An override announces itself where it changes the outcome.** An override is an environment
-knob or its programmatic setter moving a gate, policy, or threshold off its default; a CLI
-flag is out of scope — the row's `cmd` receipt already carries it.
-Where one changes an observable outcome of the run — what it measures, writes, reads, or
-mints — a printed line names it by the env spelling; set-but-inert stays silent, per-site
-repeats are fine. Adding one, or giving one a new effect, without the announce is a defect.
+knob — an env variable or its programmatic setter — that moves a gate, policy, or threshold
+off its default; a CLI flag is never an override under this rule. Where one changes an
+observable outcome of the run — what it measures, writes, reads, or mints — a printed line
+names it by the env spelling; set-but-inert stays silent, per-site repeats are fine. Adding
+one, or giving one a new effect, without the announce is a defect.
 
 **A self-measured model time entering `performance/records/<box>.json` or `PERF_LEDGER.md` comes
 from the released `lcpp_bench` exe — `benchmarks/lcpp_bench.das` built by `daspkg release`,

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -19,9 +19,11 @@ K/V-mirror change applies `REVIEW_GPU.md`. A change to `dasllama/dasllama_audio.
 holding a single speech model family — applies `REVIEW_AUDIO.md`. A change to
 `dasllama/dasllama_vision.das`, `dasllama/dasllama_vision_io.das`,
 `dasllama/dasllama_vision_embedder.das`, a vision family file — one
-`dasllama/dasllama_<family>.das` holding a single vision projector family — or a path that
-splices a stream carrying decoded media into a prompt or schedules such a stream, applies
-`REVIEW_VISION.md`. A `dasllama/dasllama_tower.das` change — the shared encoder-tower home — applies
+`dasllama/dasllama_<family>.das` holding a single vision projector family — or an in-process
+path that splices a stream carrying decoded media into a prompt or schedules such a stream
+(a rig that merely spawns an image-measuring child is not one), applies
+`REVIEW_VISION.md`. A
+`dasllama/dasllama_tower.das` change — the shared encoder-tower home — applies
 `REVIEW_AUDIO.md` and `REVIEW_VISION.md`; a family file that only CALLS a shared rail does not
 thereby pick up the other modality's checklist. A change to the tune sidecar's schema or
 emitter, wherever it lands, answers to `modules/dasLLVM/REVIEW.md`. A routed file applies BOTH
@@ -91,8 +93,9 @@ ratio across the size ladder, and superlinear is a defect.
 `dasllama/dasllama_bpe.das`, or `dasllama/dasllama_pretok.das` records a
 `tests/test_tokenizer.das` run with its cases EXECUTED, not skipped.**
 
-**An override announces itself where it changes the outcome.** An override is anything that
-moves a gate, policy, or threshold off its default — an env knob or its programmatic setter.
+**An override announces itself where it changes the outcome.** An override is an environment
+knob or its programmatic setter moving a gate, policy, or threshold off its default; a CLI
+flag is out of scope — the row's `cmd` receipt already carries it.
 Where one changes an observable outcome of the run — what it measures, writes, reads, or
 mints — a printed line names it by the env spelling; set-but-inert stays silent, per-site
 repeats are fine. Adding one, or giving one a new effect, without the announce is a defect.

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -22,9 +22,12 @@ require math
 //   amx   : das cpu --accel      vs stock -ngl 0 -nopo 1   ("cpu + accel" — -nopo keeps lcpp's
 //           Metal op-offload from serving 'CPU' rows on the GPU; nopo == nometal-build)
 //   asr   : das cpu (lcpp_bench --asr) vs each catalog reference tool, per clip
-//   bin/daslang modules/dasLLAMA/performance/gen_bench_records.das -- [-o substr] [--workload llm|asr|all]
-// --oracle inverts the rig into a regression tripwire: the stored das LLM rows re-measure once
-// each (frozen artifacts, no refs, store never written) and gate against their stored means.
+//   image : das cpu/accel/metal (lcpp_bench --image)  vs nothing ("image-chat" — llama-bench
+//           has no image mode, so the cells are das-only; the picture is the pinned fixture)
+//   bin/daslang modules/dasLLAMA/performance/gen_bench_records.das -- [-o substr] [--workload llm|asr|image|all] [--image-reps n]
+// --oracle inverts the rig into a regression tripwire: the stored das rows re-measure once
+// each (text cells frozen; ASR/image cells bake what they need; no refs, store never written)
+// and gate against their stored means.
 // Ref binaries come from setup_lcpp_ref: --ref-clean/--ref-stock or LLAMA_BENCH_CLEAN/LLAMA_BENCH_STOCK.
 // ASR references resolve via WHISPER_CPP / MTMD_BIN / ONNX_PY / NEMO_PY (profile_common).
 
@@ -619,8 +622,10 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                         threads : int; cellPath, exe : string) : int {
     let box = box_name()
     let currentSha = sidecar_generation_sha(sidecar_for(exe))
-    let doAsrOracle = cfg.workload == "asr" || cfg.workload == "all"
-    let doImageOracle = cfg.workload != "asr"   // mirrors the publishing scope: llm | image | all
+    var doLlmOracle = false
+    var doAsrOracle = false
+    var doImageOracle = false
+    workload_scope(cfg.workload, doLlmOracle, doAsrOracle, doImageOracle)   // validated at entry; the oracle shares the sweep's scope
     let asrTier = parse_tier(cfg.asr_tier)
     var board : array<string>
     var cells = 0
@@ -633,6 +638,7 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
             continue
         }
         let cellsBefore = cells
+        var imageVerified = false   // an image cell bakes the mmproj's images too - wipe them below
         for (sr in m.runs) {
             break if (stopped)
             if (sr.engine != "das" || sr.box != box) {
@@ -648,23 +654,16 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                     continue
                 }
                 var imgLeg = ""
-                var imgWant = false
-                if (sr.backend == "metal" && sr.flavor == "tuned") {
-                    imgLeg = "metal"
-                    imgWant = legMetal
-                } elif (sr.backend == "cpu" && sr.flavor == "tuned") {
-                    imgWant = legNeon
-                } elif (sr.backend == "cpu" && sr.flavor == "accel") {
-                    imgLeg = "accel"
-                    imgWant = legAmx
-                } else {
+                if (!stored_row_leg(sr.backend, sr.flavor, imgLeg)) {
                     to_log(LOG_WARNING, "gen_bench_records: ORACLE skips stored run {m.gguf} image-chat {sr.backend}/{sr.flavor} - no rig leg produces it\n")
                     continue
                 }
+                let imgWant = imgLeg == "metal" ? legMetal : (imgLeg == "accel" ? legAmx : legNeon)
                 if (!imgWant) {
                     continue
                 }
                 cells++
+                imageVerified = true
                 if (!crossgen_ok(sr, currentSha, cfg.oracle_allow_crossgen, "{m.gguf} das image", board, fails, warns)) {
                     continue
                 }
@@ -709,16 +708,8 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                     }
                     continue
                 }
-                // stored row -> the rig leg that produced it, like the LLM map below; a row no
-                // leg produces (a foreign backend, a stale flavor) is skipped loudly, not raced
                 var asrLeg = ""
-                if (sr.backend == "cpu" && sr.flavor == "tuned") {
-                    asrLeg = ""
-                } elif (sr.backend == "cpu" && sr.flavor == "accel") {
-                    asrLeg = "accel"
-                } elif (sr.backend == "metal" && sr.flavor == "tuned") {
-                    asrLeg = "metal"
-                } else {
+                if (!stored_row_leg(sr.backend, sr.flavor, asrLeg)) {
                     to_log(LOG_WARNING, "gen_bench_records: ORACLE skips stored run {m.gguf} {sr.backend}/{sr.flavor} - no rig leg produces it\n")
                     continue
                 }
@@ -746,7 +737,7 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                 }
                 continue
             }
-            if (cfg.workload == "asr" || cfg.workload == "image") {   // -w narrows the oracle exactly like the publishing rig
+            if (!doLlmOracle) {   // -w narrows the oracle exactly like the publishing rig
                 continue
             }
             var be = ""
@@ -802,6 +793,12 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
             let wm = dlim_wipe("{models_dir()}{m.gguf}")
             if (wm.removed > 0) {
                 to_log(LOG_INFO, "gen_bench_records: lifecycle - {m.gguf} profiled, {wm.removed} image(s) deleted ({wm.freed >> 20l} MB)\n")
+            }
+            if (imageVerified) {   // the image cells baked the mmproj's images too - same lifecycle
+                let wmm = dlim_wipe("{models_dir()}{mmproj_companion(spec_by_file(m.gguf))}")
+                if (wmm.removed > 0) {
+                    to_log(LOG_INFO, "gen_bench_records: lifecycle - {m.gguf} mmproj verified, {wmm.removed} image(s) deleted ({wmm.freed >> 20l} MB)\n")
+                }
             }
         }
     }
@@ -1182,10 +1179,10 @@ def main : int {
         to_log(LOG_ERROR, "gen_bench_records: --backend metal requested on a non-Apple box - Metal is macOS-only\n")
         return 1
     }
-    let doLlm = cfg.workload == "llm" || cfg.workload == "all"
-    let doAsr = cfg.workload == "asr" || cfg.workload == "all"
-    let doImage = doLlm || cfg.workload == "image"   // image cells ride the llm sweep; -w image narrows to just them
-    if (!doLlm && !doAsr && !doImage) {
+    var doLlm = false
+    var doAsr = false
+    var doImage = false
+    if (!workload_scope(cfg.workload, doLlm, doAsr, doImage)) {
         to_log(LOG_ERROR, "gen_bench_records: unknown --workload `{cfg.workload}` (expected llm | asr | image | all)\n")
         return 1
     }

--- a/modules/dasLLAMA/performance/gen_bench_records.das
+++ b/modules/dasLLAMA/performance/gen_bench_records.das
@@ -80,14 +80,18 @@ struct Args {
     asr_tier : string = "all"
 
     @clarg_short = "w"
-    @clarg_doc = "Workloads to measure: llm | asr | all (default: all — absent models/tools skip with a warning)"
+    @clarg_doc = "Workloads to measure: llm | asr | image | all (default: all — absent models/tools skip with a warning; image = only the image-chat cells of the llm sweep)"
     workload : string = "all"
 
     @clarg_name = "asr-reps"
     @clarg_doc = "Timed repetitions per ASR clip, best kept (default: 2 — clips are minutes, not seconds)"
     asr_reps : int = 2
 
-    @clarg_doc = "Verify instead of measure: re-run each stored das LLM row once and gate it against the store. The batch starts with an image wipe; a prepare pass bakes and warms each cell's image so only the timed cell is frozen, and a model's images are deleted after its last cell. No refs, no store writes. Stops at the first FAIL"
+    @clarg_name = "image-reps"
+    @clarg_doc = "Timed repetitions per image-chat cell, best kept (default: 3 — a cell is one full image turn: encode, spliced prefill, decode)"
+    image_reps : int = 3
+
+    @clarg_doc = "Verify instead of measure: re-run each stored das row (text, ASR, image-chat) once and gate it against the store. The batch starts with an image wipe; a prepare pass bakes and warms each text cell's image so only the timed cell is frozen, and a model's images are deleted after its last cell. No refs, no store writes. Stops at the first FAIL"
     oracle : bool
 
     @clarg_doc = "Oracle: run every row and report the full board instead of stopping at the first FAIL"
@@ -211,7 +215,8 @@ def private mint_check(dir, whose : string) {
 def private batch_start_wipe(workload : string) {
     // scoped to what THIS batch will re-bake: an ASR-only run must not wipe LLM images it
     // never touches again, so it wipes per ASR carrier instead of the whole models dir
-    if (workload == "llm" || workload == "all") {
+    // (image cells bake decoder + mmproj images in the llm dir, so they take the llm scope)
+    if (workload == "llm" || workload == "all" || workload == "image") {
         let w_llm = dlim_wipe(models_dir())
         if (w_llm.removed > 0) {
             to_log(LOG_INFO, "gen_bench_records: lifecycle wipe - {w_llm.removed} image(s), {w_llm.freed >> 20l} MB in {models_dir()}\n")
@@ -495,6 +500,58 @@ def private oracle_asr_cell(spec : AsrModelSpec; stored : BenchRun; leg : string
     return verdict
 }
 
+// The image twin of oracle_asr_cell: re-measure one stored image-chat row and gate it against
+// itself. Like the ASR twin the cell is not frozen — it bakes the decoder and mmproj images it
+// needs (the batch starts wiped); img:enc gates ms-mirrored, img:pp/img:tg as tok/s.
+def private oracle_image_cell(gguf, mm, pic : string; stored : BenchRun; leg : string; cfg : Args; threads : int;
+                              cellPath, exe : string; var board : array<string>) : OracleVerdict {
+    let leg_tag = empty(leg) ? "image" : "image {leg}"
+    let path = "{models_dir()}{gguf}"
+    for (p in [path, "{models_dir()}{mm}", pic]) {
+        if (!stat(p).is_valid) {
+            let miss = "FAIL {gguf} das {leg_tag} - file missing: {p}"
+            to_log(LOG_ERROR, "gen_bench_records: ORACLE {miss}\n")
+            board |> push(miss)
+            return OracleVerdict.fail
+        }
+    }
+    to_log(LOG_INFO, "gen_bench_records: ORACLE START {gguf} das {leg_tag}\n")
+    logger_info("bench.records", "oracle image cell start", JV({"model" => JV(gguf), "leg" => JV(leg_tag)}))
+    var args <- [exe, "--", "-m", path, "--image-mmproj", "{models_dir()}{mm}", "--image", pic,
+                 "-r", "{cfg.image_reps}", "-t", "{threads}", "--json-path", cellPath]
+    if (leg == "accel") {
+        args |> push("--accel")
+    } elif (leg == "metal") {
+        args |> push_from(["--ngl", "99"])
+    }
+    var out = ""
+    let rc = run_and_stream(args, out)
+    var cell : array<BenchModel>
+    if (rc != 0 || !read_bench_records(cellPath, cell)) {
+        board |> push("FAIL {gguf} das {leg_tag} - cell did not measure (rc={rc}, see the log)")
+        return OracleVerdict.fail
+    }
+    remove(cellPath)
+    var verdict = OracleVerdict.fail
+    var detail = "no das {stored.backend} image-chat run in the fresh cell records"
+    for (c in cell) {
+        for (r in c.runs) {
+            if (r.engine != "das" || r.workload != "image-chat" || r.backend != stored.backend) {
+                continue
+            }
+            var lines : array<string>
+            verdict = oracle_compare(r, stored, double(cfg.oracle_warn), double(cfg.oracle_fail), lines)
+            detail = join(lines, "; ")
+            delete lines
+        }
+    }
+    let line = "{oracle_verdict_str(verdict)} {gguf} das {leg_tag}: {detail}"
+    let level = verdict == OracleVerdict.fail ? LOG_ERROR : (verdict == OracleVerdict.warn ? LOG_WARNING : LOG_INFO)
+    to_log(level, "gen_bench_records: ORACLE {line}\n")
+    board |> push(line)
+    return verdict
+}
+
 // The freeze exists so a cell cannot silently mint a DIFFERENT image and measure a config the
 // stored row never used — but an ABSENT image (GC'd) has no identity to protect, and freezing
 // there just makes the board unrunnable. The load walk mints it (never pre-mint by hand); this
@@ -562,7 +619,8 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                         threads : int; cellPath, exe : string) : int {
     let box = box_name()
     let currentSha = sidecar_generation_sha(sidecar_for(exe))
-    let doAsrOracle = cfg.workload != "llm"
+    let doAsrOracle = cfg.workload == "asr" || cfg.workload == "all"
+    let doImageOracle = cfg.workload != "asr"   // mirrors the publishing scope: llm | image | all
     let asrTier = parse_tier(cfg.asr_tier)
     var board : array<string>
     var cells = 0
@@ -580,6 +638,57 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
             if (sr.engine != "das" || sr.box != box) {
                 continue
             }
+            if (sr.workload == "image-chat") {   // image row: its own cell, mixed ms + tok/s gate
+                if (!doImageOracle) {
+                    continue
+                }
+                let mm = mmproj_companion(spec_by_file(m.gguf))
+                if (empty(mm)) {
+                    to_log(LOG_WARNING, "gen_bench_records: ORACLE skips stored run {m.gguf} image-chat - its spec carries no mmproj companion\n")
+                    continue
+                }
+                var imgLeg = ""
+                var imgWant = false
+                if (sr.backend == "metal" && sr.flavor == "tuned") {
+                    imgLeg = "metal"
+                    imgWant = legMetal
+                } elif (sr.backend == "cpu" && sr.flavor == "tuned") {
+                    imgWant = legNeon
+                } elif (sr.backend == "cpu" && sr.flavor == "accel") {
+                    imgLeg = "accel"
+                    imgWant = legAmx
+                } else {
+                    to_log(LOG_WARNING, "gen_bench_records: ORACLE skips stored run {m.gguf} image-chat {sr.backend}/{sr.flavor} - no rig leg produces it\n")
+                    continue
+                }
+                if (!imgWant) {
+                    continue
+                }
+                cells++
+                if (!crossgen_ok(sr, currentSha, cfg.oracle_allow_crossgen, "{m.gguf} das image", board, fails, warns)) {
+                    continue
+                }
+                settle(cfg)
+                let pic = "{models_dir()}{bench_image_fixture()}"
+                var vi = oracle_image_cell(m.gguf, mm, pic, sr, imgLeg, cfg, threads, cellPath, exe, board)
+                if (vi == OracleVerdict.fail && cfg.oracle_retry_settle > 0) {
+                    // same contract as the LLM legs below: the solo re-run's verdict stands
+                    to_log(LOG_WARNING, "gen_bench_records: ORACLE FAIL {m.gguf} - auto solo re-run after {cfg.oracle_retry_settle}s settle (the retry is the verdict)\n")
+                    board |> push("  ^ suspect FAIL - the auto solo re-run below is the verdict")
+                    sleep(uint(cfg.oracle_retry_settle * 1000))
+                    vi = oracle_image_cell(m.gguf, mm, pic, sr, imgLeg, cfg, threads, cellPath, exe, board)
+                }
+                if (vi == OracleVerdict.fail) {
+                    fails++
+                    if (!cfg.oracle_keep_going) {
+                        to_log(LOG_ERROR, "gen_bench_records: ORACLE stopping at the first FAIL (--oracle-keep-going runs the full board)\n")
+                        stopped = true
+                    }
+                } elif (vi == OracleVerdict.warn) {
+                    warns++
+                }
+                continue
+            }
             if (!empty(sr.workload)) {   // audio row: its own cell, its own ms-shaped gate
                 if (!doAsrOracle) {
                     continue
@@ -593,6 +702,11 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                     }
                 }
                 if (!found) {
+                    // tier narrowing is a quiet skip; a workload string no branch owns is not —
+                    // an unknown modality's rows must never vanish from the board silently
+                    if (sr.workload != "asr" && sr.workload != "audio-chat") {
+                        to_log(LOG_WARNING, "gen_bench_records: ORACLE skips stored run {m.gguf} workload `{sr.workload}` - no oracle arm covers it\n")
+                    }
                     continue
                 }
                 // stored row -> the rig leg that produced it, like the LLM map below; a row no
@@ -632,7 +746,7 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
                 }
                 continue
             }
-            if (cfg.workload == "asr") {   // -w asr narrows the oracle exactly like the publishing rig
+            if (cfg.workload == "asr" || cfg.workload == "image") {   // -w narrows the oracle exactly like the publishing rig
                 continue
             }
             var be = ""
@@ -706,8 +820,9 @@ def private oracle_main(cfg : Args; legNeon, legAmx, legMetal : bool; models : a
 
 def private ref_pass(file, path, bin, flavor : string; ngl : int; nopo : bool; cfg : Args; threads : int;
                      hw : HardwareInfo; box, date, note, store : string;
-                     var models : array<BenchModel>; var failed : array<string>) {
+                     var models : array<BenchModel>; var failed : array<string>; var refSkipped : array<string>) {
     if (empty(bin)) {
+        refSkipped |> push("{file} ref {flavor} {ngl != 0 ? "metal" : "cpu"}")
         return
     }
     let backend = ngl != 0 ? "metal" : "cpu"
@@ -765,6 +880,47 @@ def private ref_pass(file, path, bin, flavor : string; ngl : int; nopo : bool; c
     write_bench_records(store, models)
     to_log(LOG_INFO, "gen_bench_records: DONE {file} ref {flavor} {backend} ({elapsed_ms(t0)} ms)\n")
     logger_info("bench.records", "cell done", JV({"model" => JV(file), "engine" => JV("llama.cpp"), "leg" => JV("{flavor} {backend}"), "elapsed_ms" => JV(elapsed_ms(t0))}))
+}
+
+// ===== Image legs (the image-chat cells of vision decoders — das-only: llama-bench has no image mode) =====
+
+// One lcpp_bench --image child per (vision model, leg), absorbed via the same cell protocol.
+// leg: "" = cpu (neon) | "accel" (amx) | "metal"
+def private image_das_cell(file, path, mm, pic : string; cfg : Args; threads : int; cellPath, note, store, exe : string;
+                           var models : array<BenchModel>; var failed : array<string>; leg : string = "") {
+    let t0 = ref_time_ticks()
+    let log_leg = empty(leg) ? "image" : "image {leg}"
+    for (p in [mm, pic]) {
+        if (!stat(p).is_valid) {
+            to_log(LOG_WARNING, "gen_bench_records: SKIP {file} das {log_leg} - missing companion {p}\n")
+            return
+        }
+    }
+    to_log(LOG_INFO, "gen_bench_records: START {file} das {log_leg}\n")
+    logger_info("bench.records", "cell start", JV({"model" => JV(file), "engine" => JV("das"), "leg" => JV(log_leg)}))
+    var args <- [exe, "--", "-m", path, "--image-mmproj", mm, "--image", pic,
+                 "-r", "{cfg.image_reps}", "-t", "{threads}", "-o", "json", "--json-path", cellPath]
+    if (leg == "accel") {
+        args |> push("--accel")
+    } elif (leg == "metal") {
+        args |> push_from(["--ngl", "99"])
+    }
+    mint_snapshot(models_dir())
+    var out = ""
+    let rc = run_and_stream(args, out)
+    var cell : array<BenchModel>
+    if (rc != 0 || !read_bench_records(cellPath, cell)) {
+        let tail = slice(out, max(0, length(out) - 400))
+        to_log(LOG_ERROR, "gen_bench_records: FAILED {file} das {log_leg} rc={rc} ({elapsed_ms(t0)} ms) - tail: {tail}\n")
+        logger_error("bench.records", "cell FAILED", JV({"model" => JV(file), "engine" => JV("das"), "leg" => JV(log_leg), "rc" => JV(rc)}))
+        failed |> push("{file} das {log_leg}")
+        return
+    }
+    mint_check(models_dir(), "{file} das {log_leg}")
+    absorb_cell(models, cell, store, note, failed, "ok")
+    remove(cellPath)
+    to_log(LOG_INFO, "gen_bench_records: DONE {file} das {log_leg} ({elapsed_ms(t0)} ms)\n")
+    logger_info("bench.records", "cell done", JV({"model" => JV(file), "engine" => JV("das"), "leg" => JV(log_leg), "elapsed_ms" => JV(elapsed_ms(t0))}))
 }
 
 // ===== ASR legs (the audio workloads, same adjacency discipline as the LLM legs) =====
@@ -1028,8 +1184,9 @@ def main : int {
     }
     let doLlm = cfg.workload == "llm" || cfg.workload == "all"
     let doAsr = cfg.workload == "asr" || cfg.workload == "all"
-    if (!doLlm && !doAsr) {
-        to_log(LOG_ERROR, "gen_bench_records: unknown --workload `{cfg.workload}` (expected llm | asr | all)\n")
+    let doImage = doLlm || cfg.workload == "image"   // image cells ride the llm sweep; -w image narrows to just them
+    if (!doLlm && !doAsr && !doImage) {
+        to_log(LOG_ERROR, "gen_bench_records: unknown --workload `{cfg.workload}` (expected llm | asr | image | all)\n")
         return 1
     }
     // pair legs: --legs wins outright; otherwise --backend implies its legs (amx is Apple-only —
@@ -1096,6 +1253,14 @@ def main : int {
         to_log(LOG_WARNING, "gen_bench_records: stock ref `{refStock}` not found - no stock rows\n")
         refStock = ""
     }
+    // a ref-less sweep is legal but must never be a surprise: an unset ref silently minted a
+    // whole das-only board once — say it up front, and the end summary names every skipped pair
+    if (doLlm && empty(refClean)) {
+        to_log(LOG_WARNING, "gen_bench_records: clean-cpu ref UNSET (--ref-clean / LLAMA_BENCH_CLEAN) - every neon cell mints das-only, no board ratio\n")
+    }
+    if (doLlm && empty(refStock)) {
+        to_log(LOG_WARNING, "gen_bench_records: stock ref UNSET (--ref-stock / LLAMA_BENCH_STOCK) - no stock rows, metal/amx cells mint das-only\n")
+    }
     let exe = rig_exe_checked()
     if (empty(exe)) {
         return 1
@@ -1112,13 +1277,18 @@ def main : int {
     let threads = cfg.threads > 0 ? cfg.threads : profile_threads()
     let cellPath = "modules/dasLLAMA/performance/records/_cell_{box}.json"
     var failed : array<string>
+    var refSkipped : array<string>
     var cat <- official_catalog()
     for (ent in cat) {
-        if (!doLlm) {
+        if (!doLlm && !doImage) {
             continue
         }
         let file = ent.file
         if (!empty(cfg.only) && find(file, cfg.only) < 0) {
+            continue
+        }
+        let mm = mmproj_companion(ent)
+        if (!doLlm && empty(mm)) {   // -w image visits the vision rows only
             continue
         }
         let path = "{models_dir()}{file}"
@@ -1142,33 +1312,57 @@ def main : int {
         // das-cpu heat soak while the lcpp metal ref ran minutes later on a different chip
         // state (27B: das 110.7 soaked vs 138.1 quiet — a phantom 0.91 board red). Refs still
         // run independently of das-cell failures.
-        if (legMetal) {
+        if (doLlm && legMetal) {
             settle_das(cfg)
             das_cell(file, path, "metal", exe, false, cfg, threads, cellPath, ent.note, store, models, failed)
             // the ref gets COOL-SLOT entry too: it is not insensitive on high-power parts —
             // zen2 35B read pp 81.7 twelve seconds behind a das cell vs 103.9 solo-cooled
             settle_das(cfg)
-            ref_pass(file, path, refStock, "stock", 99, false, cfg, threads, hw, box, date, ent.note, store, models, failed)
+            ref_pass(file, path, refStock, "stock", 99, false, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
         }
-        if (legNeon) {
+        if (doLlm && legNeon) {
             settle_das(cfg)
             das_cell(file, path, "cpu", exe, false, cfg, threads, cellPath, ent.note, store, models, failed)
             // the ref gets COOL-SLOT entry too: it is not insensitive on high-power parts —
             // zen2 35B read pp 81.7 twelve seconds behind a das cell vs 103.9 solo-cooled
             settle_das(cfg)
-            ref_pass(file, path, refClean, "clean-cpu", 0, false, cfg, threads, hw, box, date, ent.note, store, models, failed)
+            ref_pass(file, path, refClean, "clean-cpu", 0, false, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
         }
-        if (legAmx) {
+        if (doLlm && legAmx) {
             settle_das(cfg)
             das_cell(file, path, "cpu", exe, true, cfg, threads, cellPath, ent.note, store, models, failed)
             // the ref gets COOL-SLOT entry too: it is not insensitive on high-power parts —
             // zen2 35B read pp 81.7 twelve seconds behind a das cell vs 103.9 solo-cooled
             settle_das(cfg)
-            ref_pass(file, path, refStock, "stock", 0, true, cfg, threads, hw, box, date, ent.note, store, models, failed)
+            ref_pass(file, path, refStock, "stock", 0, true, cfg, threads, hw, box, date, ent.note, store, models, failed, refSkipped)
+        }
+        // the image-chat legs of a vision decoder (an mmproj companion), das-only — same
+        // leg order and cool-slot discipline; the picture is the one pinned fixture
+        if (doImage && !empty(mm)) {
+            let mmPath = "{models_dir()}{mm}"
+            let picPath = "{models_dir()}{bench_image_fixture()}"
+            if (legMetal) {
+                settle_das(cfg)
+                image_das_cell(file, path, mmPath, picPath, cfg, threads, cellPath, ent.note, store, exe, models, failed, "metal")
+            }
+            if (legNeon) {
+                settle_das(cfg)
+                image_das_cell(file, path, mmPath, picPath, cfg, threads, cellPath, ent.note, store, exe, models, failed)
+            }
+            if (legAmx) {
+                settle_das(cfg)
+                image_das_cell(file, path, mmPath, picPath, cfg, threads, cellPath, ent.note, store, exe, models, failed, "accel")
+            }
         }
         let wm = dlim_wipe(path)   // fully profiled - its images are done serving
         if (wm.removed > 0) {
             to_log(LOG_INFO, "gen_bench_records: lifecycle - {file} profiled, {wm.removed} image(s) deleted ({wm.freed >> 20l} MB)\n")
+        }
+        if (doImage && !empty(mm)) {   // the image legs' second carrier gets the same lifecycle
+            let wmm = dlim_wipe("{models_dir()}{mm}")
+            if (wmm.removed > 0) {
+                to_log(LOG_INFO, "gen_bench_records: lifecycle - {mm} profiled, {wmm.removed} image(s) deleted ({wmm.freed >> 20l} MB)\n")
+            }
         }
     }
     if (doAsr) {
@@ -1217,6 +1411,10 @@ def main : int {
                 to_log(LOG_INFO, "gen_bench_records: lifecycle - {spec.display} profiled, {wasr.removed} image(s) deleted ({wasr.freed >> 20l} MB)\n")
             }
         }
+    }
+    if (!empty(refSkipped)) {
+        // the loud tail of the sweep-start UNSET warning: name every pair the board is missing
+        to_log(LOG_WARNING, "gen_bench_records: {length(refSkipped)} ref cell(s) SKIPPED (refs unset - das-only rows, no board ratio): {join(refSkipped, ", ")}\n")
     }
     if (!empty(failed)) {
         let list = join(failed, ", ")

--- a/modules/dasLLAMA/performance/model_specs.das
+++ b/modules/dasLLAMA/performance/model_specs.das
@@ -553,6 +553,25 @@ def official_catalog() : array<ModelSpec> {
     return <- spec_view() $(s : ModelSpec) : bool { return s.official; }
 }
 
+//! The spec's vision mmproj companion basename ("" = no vision pairing) — the image-chat
+//! cell's second file. A row with one is a vision decoder; the driver pairs it with
+//! [[bench_image_fixture]] for the board's image cells.
+def mmproj_companion(s : ModelSpec) : string {
+    for (c in s.companions) {
+        if (c.name |> starts_with("mmproj-")) {
+            return c.name
+        }
+    }
+    return ""
+}
+
+//! The one pinned picture every image-chat cell measures (provenanced as a companion of the
+//! spec row that owns it) — cells across models and boxes stay comparable because the input
+//! never varies.
+def bench_image_fixture() : string {
+    return "coco-val2017-000000039769.jpg"
+}
+
 //! The spec row keyed `file` (empty `file` field back = no such spec) — a fresh copy off the
 //! table, so a caller (a test run-lambda, the bench parity pregate) holds no reference into an
 //! iterated table.

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -122,6 +122,37 @@ def parse_tier(s : string) : Tier {
     return Tier.small
 }
 
+//! The record rig's `-w` workload scope, shared by the publishing sweep and the oracle: which
+//! of the text (`llm`), audio (`asr`) and image-chat (`image`) cell sets a workload string
+//! selects. Image cells ride the llm sweep, so `llm`/`all` imply them and `image` narrows to
+//! just them. False = unknown workload (the caller rejects it); the out-params are then all false.
+def workload_scope(w : string; var llm, asr, image : bool&) : bool {
+    llm = w == "llm" || w == "all"
+    asr = w == "asr" || w == "all"
+    image = llm || w == "image"
+    return llm || asr || image
+}
+
+//! The rig leg that produced a stored das row, from its `(backend, flavor)` stamp:
+//! `"metal"` | `""` (the plain cpu leg — neon) | `"accel"` (amx). False = no rig leg
+//! produces that stamp (a foreign backend, a stale flavor) — the oracle skips such a row
+//! loudly instead of racing it on the wrong leg.
+def stored_row_leg(backend, flavor : string; var leg : string&) : bool {
+    leg = ""
+    if (backend == "metal" && flavor == "tuned") {
+        leg = "metal"
+        return true
+    }
+    if (backend == "cpu" && flavor == "tuned") {
+        return true
+    }
+    if (backend == "cpu" && flavor == "accel") {
+        leg = "accel"
+        return true
+    }
+    return false
+}
+
 // Full path to a catalog entry's GGUF.
 def model_path(m : ModelSpec) : string {
     return "{models_dir()}{m.file}"

--- a/modules/dasLLAMA/performance/profile_common.das
+++ b/modules/dasLLAMA/performance/profile_common.das
@@ -1662,7 +1662,7 @@ struct BenchRun {
     cmd : string
     hardware : HardwareInfo
     tests : table<string; BenchTest>
-    @optional workload : string // "" = text LLM; "asr" | "audio-chat" — selects the tests-key shape
+    @optional workload : string // "" = text LLM; "asr" | "audio-chat" | "image-chat" — selects the tests-key shape
     @optional source : string   // "official" | "community" — stamped by the store driver, not the tool
     @optional sha : string      // engine commit (das: git HEAD; llama.cpp: build_commit)
     @optional version : string  // das release version

--- a/modules/dasLLAMA/performance/records/m1.json
+++ b/modules/dasLLAMA/performance/records/m1.json
@@ -768,9 +768,198 @@
             "bytes":7381382944
           }
         ]
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-12B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":11.734999999999999
+          },
+          "img:pp":{
+            "tok_s":137.05333571126727
+          },
+          "img:tg":{
+            "tok_s":34.940600978336825,
+            "text":"Two tabby cats are lying on a pink surface, with one cat on the left and the other on the right."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4uv f32; weights k4/k6/q8 native; q8 activations; f32 scales; metal blob",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-12B-it-Q4_K_M.gguf",
+            "sha256":"95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8",
+            "bytes":7381382944
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-12B-it-BF16.gguf",
+            "sha256":"9b1edfa05b634728ca4bfd60b4e6b278e95166c078fa54ae4fa83e680112fd1d",
+            "bytes":175115616
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-12B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":53.868000000000002
+          },
+          "img:pp":{
+            "tok_s":62.325558353103055
+          },
+          "img:tg":{
+            "tok_s":14.694673436438828,
+            "text":"Two tabby cats are lying on a pink surface, with one cat on the left and the other on the right."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4uv f32; weights k4/k6/q8 native; q8 activations; f32 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-12B-it-Q4_K_M.gguf",
+            "sha256":"95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8",
+            "bytes":7381382944
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-12B-it-BF16.gguf",
+            "sha256":"9b1edfa05b634728ca4bfd60b4e6b278e95166c078fa54ae4fa83e680112fd1d",
+            "bytes":175115616
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"accel",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-12B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":16.34
+          },
+          "img:pp":{
+            "tok_s":62.393436210510657
+          },
+          "img:tg":{
+            "tok_s":14.681543964550745,
+            "text":"Two tabby cats are lying on a pink surface, with one cat on the left and one on the right."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4uv f32; weights k4/k6/q8 native; q8 activations; f32 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-12B-it-Q4_K_M.gguf",
+            "sha256":"95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8",
+            "bytes":7381382944
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-12B-it-BF16.gguf",
+            "sha256":"9b1edfa05b634728ca4bfd60b4e6b278e95166c078fa54ae4fa83e680112fd1d",
+            "bytes":175115616
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
       }
     ],
-    "arch":"gemma4",
+    "arch":"gemma4uv",
     "quant":"q8",
     "params_b":11.907350576000001,
     "active_b":11.906580480000001,
@@ -1042,9 +1231,198 @@
             "bytes":8031242688
           }
         ]
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E4B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":96.126000000000005
+          },
+          "img:pp":{
+            "tok_s":362.37186321855904
+          },
+          "img:tg":{
+            "tok_s":51.35126027225796,
+            "text":"The user wants a one-sentence description of the provided image.\nThe image contains two cats lying on a pink surface.\n\nPlan: Describe the main subjects"
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; metal blob",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E4B-it-Q8_0.gguf",
+            "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
+            "bytes":8031242688
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E4B-it-BF16.gguf",
+            "sha256":"f77995e4b6a569ab8f0d1bfdb7e8da4a0fa5b9e6f309b9bf3bdb76164d75e29f",
+            "bytes":991552256
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E4B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":419.255
+          },
+          "img:pp":{
+            "tok_s":196.65485056752573
+          },
+          "img:tg":{
+            "tok_s":21.798350273603354,
+            "text":"The user wants a one-sentence description of the provided image.\nThe image contains two cats lying on a pink surface.\n\nPlan: Describe the main subjects"
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v q8; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E4B-it-Q8_0.gguf",
+            "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
+            "bytes":8031242688
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E4B-it-BF16.gguf",
+            "sha256":"f77995e4b6a569ab8f0d1bfdb7e8da4a0fa5b9e6f309b9bf3bdb76164d75e29f",
+            "bytes":991552256
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"accel",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E4B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":480.98200000000003
+          },
+          "img:pp":{
+            "tok_s":202.40971359025528
+          },
+          "img:tg":{
+            "tok_s":21.949770693489288,
+            "text":"The user wants a one-sentence description of the provided image.\nThe image contains two cats lying on a pink surface.\n\nPlan: Describe the main subjects"
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E4B-it-Q8_0.gguf",
+            "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
+            "bytes":8031242688
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E4B-it-BF16.gguf",
+            "sha256":"f77995e4b6a569ab8f0d1bfdb7e8da4a0fa5b9e6f309b9bf3bdb76164d75e29f",
+            "bytes":991552256
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
       }
     ],
-    "arch":"gemma4",
+    "arch":"gemma4v",
     "quant":"q8",
     "params_b":7.5180692899999997,
     "active_b":4.5888307199999998,
@@ -4730,9 +5108,198 @@
             "bytes":4967497152
           }
         ]
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E2B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E2B-it-bf16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":90.968999999999994
+          },
+          "img:pp":{
+            "tok_s":682.06859161580303
+          },
+          "img:tg":{
+            "tok_s":93.042874156411273,
+            "text":": This is an image of two tabby cats lying on a pink surface."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; metal blob",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E2B-it-Q8_0.gguf",
+            "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
+            "bytes":4967497152
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E2B-it-bf16.gguf",
+            "sha256":"711e1e8f43fa0664adbac493129be1e6c25b81af4b4cdea97c7d798b25c0a3a4",
+            "bytes":986833664
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E2B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E2B-it-bf16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":422.83499999999998
+          },
+          "img:pp":{
+            "tok_s":362.82951199430636
+          },
+          "img:tg":{
+            "tok_s":42.981174245680393,
+            "text":": This is an image of two tabby cats lying on a pink surface."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v q8; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E2B-it-Q8_0.gguf",
+            "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
+            "bytes":4967497152
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E2B-it-bf16.gguf",
+            "sha256":"711e1e8f43fa0664adbac493129be1e6c25b81af4b4cdea97c7d798b25c0a3a4",
+            "bytes":986833664
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"accel",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E2B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E2B-it-bf16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":435.52100000000002
+          },
+          "img:pp":{
+            "tok_s":375.44493835242247
+          },
+          "img:tg":{
+            "tok_s":42.740035160802258,
+            "text":": This is an image of two tabby cats lying on a pink surface."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E2B-it-Q8_0.gguf",
+            "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
+            "bytes":4967497152
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E2B-it-bf16.gguf",
+            "sha256":"711e1e8f43fa0664adbac493129be1e6c25b81af4b4cdea97c7d798b25c0a3a4",
+            "bytes":986833664
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
       }
     ],
-    "arch":"gemma4",
+    "arch":"gemma4v",
     "quant":"q8",
     "params_b":4.6474501469999998,
     "active_b":2.2476226559999999,

--- a/modules/dasLLAMA/performance/records/m1.tune.5da27197acae.json
+++ b/modules/dasLLAMA/performance/records/m1.tune.5da27197acae.json
@@ -1,0 +1,2646 @@
+{
+	"kernels" : {
+		"add_inplace" : "vec8_u2",
+		"cvt_f32_to_f16" : "vec8_u2",
+		"rope_scaled_neox_tab" : "u4",
+		"q51q8_tile_gen" : "mr4",
+		"softmax" : "vec8_u2",
+		"mul_inplace" : "vec8_u2",
+		"quantize_q8_0_bs_into_ptr" : "plain",
+		"dot_q8kv" : "vec4_u2",
+		"dot_q8q8" : "vec16",
+		"quantize_q8kv_row" : "plain",
+		"axpy_f16" : "vec4_u4",
+		"q40q8_tile_gen" : "mr8",
+		"axpy_tq4kv" : "vec8_u2",
+		"cvt_tq4kv_to_f32" : "vec8_u2",
+		"axpy" : "vec8_u2",
+		"dot_q8q8kv" : "vec16",
+		"dot_mx4q8" : "u4",
+		"softmax_sink" : "vec8_u2",
+		"dot_q8q8_laneq4x4" : "u2",
+		"dot_bf16" : "vec8_u2",
+		"add_scale_inplace" : "vec8_u2",
+		"cvt_q8kv_to_f32" : "vec8_u2",
+		"axpy_q8kv" : "u2",
+		"dot_q8q8_f16s" : "vec16",
+		"q8q8_tile_gen" : "mr8_budget",
+		"quantize_q8_0_into_ptr" : "plain",
+		"k4q8_tile_gen" : "mr8",
+		"k5q8_tile_gen" : "mr8",
+		"k6q8_tile_gen" : "mr4",
+		"gemm_f32_uk_4x16" : "u2",
+		"dot_q51e" : "vec16",
+		"dot_f16" : "vec8_u2",
+		"cvt_f16_to_f32" : "vec16",
+		"dot" : "vec8_u2",
+		"dot_q8tq4kv" : "vec16",
+		"scale_inplace" : "vec8_u2",
+		"dot_q4" : "vec4_u4",
+		"quantize_tq4kv_row" : "plain",
+		"copy_floats" : "vec8_u2",
+		"rmsnorm" : "vec8"
+	},
+	"provenance" : {
+		"validation" : "ok",
+		"noise_probes" : "start cv 0.12%; mid1 cv 0.12%; mid2 cv 0.14%; end cv 0.17%",
+		"platform" : "darwin",
+		"noise_floor_cv_pct" : "0.17",
+		"engine_sha" : "fa9456675",
+		"box" : "darwin|arm64|MacBookPro18,2|25F84|Apple M1 Max",
+		"written" : "2026-08-20T19:12:02.069Z",
+		"validation_demoted" : "1",
+		"mode" : "normal",
+		"dasllama_version" : "6",
+		"noise" : "ok",
+		"binary" : "/Users/borisbatkin/Work/daScript/bin/daslang",
+		"arch" : "arm64",
+		"validation_max_drift_pct" : "12.43"
+	},
+	"race" : {
+		"cvt_q8kv_to_f32" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 524.3125,
+					"best_us" : 523.78125
+				},
+				"vec32" : {
+					"med_us" : 522.65625,
+					"best_us" : 522.25
+				},
+				"vec32_u4" : {
+					"med_us" : 523.875,
+					"best_us" : 523.65625
+				},
+				"vec32_u8" : {
+					"med_us" : 524,
+					"best_us" : 523.84375
+				},
+				"vec16_u2" : {
+					"med_us" : 521.65625,
+					"best_us" : 521.46875
+				},
+				"vec16_u4" : {
+					"med_us" : 521.625,
+					"best_us" : 521.625
+				},
+				"vec16_u8" : {
+					"med_us" : 521.71875,
+					"best_us" : 521.34375
+				},
+				"vec4" : {
+					"med_us" : 522.78125,
+					"best_us" : 522.28125
+				},
+				"vec8" : {
+					"med_us" : 522.96875,
+					"best_us" : 522.03125
+				},
+				"vec4_u4" : {
+					"med_us" : 522.375,
+					"best_us" : 522
+				},
+				"vec8_u4" : {
+					"med_us" : 523.5,
+					"best_us" : 523.375
+				},
+				"plain" : {
+					"med_us" : 522.21875,
+					"best_us" : 522.15625
+				},
+				"u2" : {
+					"med_us" : 522.96875,
+					"best_us" : 521.40625
+				},
+				"u4" : {
+					"med_us" : 522.03125,
+					"best_us" : 521.625
+				},
+				"u8" : {
+					"med_us" : 521.59375,
+					"best_us" : 521.34375
+				},
+				"vec4_u2" : {
+					"med_us" : 523.5,
+					"best_us" : 522.25
+				},
+				"vec4_u8" : {
+					"med_us" : 522.625,
+					"best_us" : 522.0625
+				},
+				"vec8_u2" : {
+					"med_us" : 523.875,
+					"best_us" : 523.125
+				},
+				"vec8_u8" : {
+					"med_us" : 523.46875,
+					"best_us" : 523.28125
+				},
+				"vec16" : {
+					"med_us" : 522.875,
+					"best_us" : 522.28125
+				}
+			}
+		},
+		"add_inplace" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 495.25,
+					"best_us" : 495.03125
+				},
+				"vec32" : {
+					"med_us" : 502.875,
+					"best_us" : 502.75
+				},
+				"vec32_u4" : {
+					"med_us" : 495,
+					"best_us" : 494.75
+				},
+				"vec32_u8" : {
+					"med_us" : 494.53125,
+					"best_us" : 494.21875
+				},
+				"vec16_u2" : {
+					"med_us" : 508.96875,
+					"best_us" : 508.8125
+				},
+				"vec16_u4" : {
+					"med_us" : 513.75,
+					"best_us" : 513.46875
+				},
+				"vec16_u8" : {
+					"med_us" : 596.25,
+					"best_us" : 595.0625
+				},
+				"vec4" : {
+					"med_us" : 500.03125,
+					"best_us" : 499.84375
+				},
+				"vec8" : {
+					"med_us" : 500.34375,
+					"best_us" : 499.71875
+				},
+				"vec4_u4" : {
+					"med_us" : 492.5625,
+					"best_us" : 491.5
+				},
+				"vec8_u4" : {
+					"med_us" : 492.34375,
+					"best_us" : 492.15625
+				},
+				"plain" : {
+					"med_us" : 499.34375,
+					"best_us" : 499
+				},
+				"u2" : {
+					"med_us" : 499.71875,
+					"best_us" : 499.625
+				},
+				"u4" : {
+					"med_us" : 500.25,
+					"best_us" : 499.78125
+				},
+				"u8" : {
+					"med_us" : 491.6875,
+					"best_us" : 491.4375
+				},
+				"vec4_u2" : {
+					"med_us" : 499.46875,
+					"best_us" : 498.90625
+				},
+				"vec4_u8" : {
+					"med_us" : 492.0625,
+					"best_us" : 491.9375
+				},
+				"vec8_u2" : {
+					"med_us" : 492.125,
+					"best_us" : 491.8125
+				},
+				"vec8_u8" : {
+					"med_us" : 491.90625,
+					"best_us" : 491.625
+				},
+				"vec16" : {
+					"med_us" : 513.5625,
+					"best_us" : 513.4375
+				}
+			}
+		},
+		"axpy_q8kv" : {
+			"winner" : "u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 14.797976468520055,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 548.4375,
+					"best_us" : 548.21875
+				},
+				"vec32" : {
+					"med_us" : 569.25,
+					"best_us" : 569.03125
+				},
+				"vec32_u4" : {
+					"med_us" : 548.53125,
+					"best_us" : 548.3125
+				},
+				"vec32_u8" : {
+					"med_us" : 548.453125,
+					"best_us" : 548.1875
+				},
+				"vec16_u2" : {
+					"med_us" : 546.921875,
+					"best_us" : 546.53125
+				},
+				"vec16_u4" : {
+					"med_us" : 547.1875,
+					"best_us" : 546.75
+				},
+				"vec16_u8" : {
+					"med_us" : 547.265625,
+					"best_us" : 546.65625
+				},
+				"vec4" : {
+					"med_us" : 569.375,
+					"best_us" : 569.21875
+				},
+				"vec8" : {
+					"med_us" : 569.25,
+					"best_us" : 569.125
+				},
+				"vec4_u4" : {
+					"med_us" : 569.53125,
+					"best_us" : 569.125
+				},
+				"vec8_u4" : {
+					"med_us" : 551.6875,
+					"best_us" : 551.0625
+				},
+				"plain" : {
+					"med_us" : 569.4375,
+					"best_us" : 569.21875
+				},
+				"u2" : {
+					"med_us" : 547.203125,
+					"best_us" : 546.5
+				},
+				"u4" : {
+					"med_us" : 547.125,
+					"best_us" : 546.6875
+				},
+				"u8" : {
+					"med_us" : 547.078125,
+					"best_us" : 546.5625
+				},
+				"vec4_u2" : {
+					"med_us" : 569.375,
+					"best_us" : 569.25
+				},
+				"vec4_u8" : {
+					"med_us" : 569.84375,
+					"best_us" : 569.125
+				},
+				"vec8_u2" : {
+					"med_us" : 642.241935483871,
+					"best_us" : 641.7741935483871
+				},
+				"vec8_u8" : {
+					"med_us" : 551.25,
+					"best_us" : 551.15625
+				},
+				"vec16" : {
+					"med_us" : 569.6875,
+					"best_us" : 569.03125
+				}
+			}
+		},
+		"cvt_f32_to_f16" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 493.53125,
+					"best_us" : 493.40625
+				},
+				"vec32" : {
+					"med_us" : 499.09375,
+					"best_us" : 498.96875
+				},
+				"vec32_u4" : {
+					"med_us" : 491.03125,
+					"best_us" : 489.78125
+				},
+				"vec32_u8" : {
+					"med_us" : 490.15625,
+					"best_us" : 490
+				},
+				"vec16_u2" : {
+					"med_us" : 501.28125,
+					"best_us" : 500.96875
+				},
+				"vec16_u4" : {
+					"med_us" : 490.625,
+					"best_us" : 490.09375
+				},
+				"vec16_u8" : {
+					"med_us" : 490.09375,
+					"best_us" : 489.90625
+				},
+				"vec4" : {
+					"med_us" : 580.78125,
+					"best_us" : 580.4375
+				},
+				"vec8" : {
+					"med_us" : 500,
+					"best_us" : 499.8125
+				},
+				"vec4_u4" : {
+					"med_us" : 572.5625,
+					"best_us" : 572.4375
+				},
+				"vec8_u4" : {
+					"med_us" : 490.59375,
+					"best_us" : 489.9375
+				},
+				"plain" : {
+					"med_us" : 499.875,
+					"best_us" : 499.6875
+				},
+				"u2" : {
+					"med_us" : 491.40625,
+					"best_us" : 491.28125
+				},
+				"u4" : {
+					"med_us" : 491.25,
+					"best_us" : 490.3125
+				},
+				"u8" : {
+					"med_us" : 490.84375,
+					"best_us" : 490.03125
+				},
+				"vec4_u2" : {
+					"med_us" : 581.75,
+					"best_us" : 581.21875
+				},
+				"vec4_u8" : {
+					"med_us" : 571.09375,
+					"best_us" : 571.0625
+				},
+				"vec8_u2" : {
+					"med_us" : 493.8125,
+					"best_us" : 493.59375
+				},
+				"vec8_u8" : {
+					"med_us" : 490.15625,
+					"best_us" : 489.875
+				},
+				"vec16" : {
+					"med_us" : 500.65625,
+					"best_us" : 500.5625
+				}
+			}
+		},
+		"rope_scaled_neox_tab" : {
+			"winner" : "u4",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.1426575623414683,
+			"margin_pct" : 3.8207174065889986,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 821.5416666666666,
+					"best_us" : 821.4583333333334
+				},
+				"vec32" : {
+					"med_us" : 750.3461538461538,
+					"best_us" : 749.9615384615385
+				},
+				"vec32_u4" : {
+					"med_us" : 799.2916666666666,
+					"best_us" : 799.2916666666666
+				},
+				"vec32_u8" : {
+					"med_us" : 797.6,
+					"best_us" : 797.48
+				},
+				"vec16_u2" : {
+					"med_us" : 652.2,
+					"best_us" : 652
+				},
+				"vec16_u4" : {
+					"med_us" : 649.7333333333333,
+					"best_us" : 649.6333333333333
+				},
+				"vec16_u8" : {
+					"med_us" : 650,
+					"best_us" : 649.6
+				},
+				"vec4" : {
+					"med_us" : 696.9310344827586,
+					"best_us" : 696.7931034482758
+				},
+				"vec8" : {
+					"med_us" : 626.7096774193549,
+					"best_us" : 626.7096774193549
+				},
+				"vec4_u4" : {
+					"med_us" : 617.453125,
+					"best_us" : 617.28125
+				},
+				"vec8_u4" : {
+					"med_us" : 617.578125,
+					"best_us" : 617.4375
+				},
+				"plain" : {
+					"med_us" : 696.8965517241379,
+					"best_us" : 696.8275862068965
+				},
+				"u2" : {
+					"med_us" : 663.6666666666666,
+					"best_us" : 663.0666666666667
+				},
+				"u4" : {
+					"med_us" : 617.46875,
+					"best_us" : 617.15625
+				},
+				"u8" : {
+					"med_us" : 744.5185185185185,
+					"best_us" : 744.3703703703703
+				},
+				"vec4_u2" : {
+					"med_us" : 664,
+					"best_us" : 663
+				},
+				"vec4_u8" : {
+					"med_us" : 744.3703703703703,
+					"best_us" : 744.2222222222222
+				},
+				"vec8_u2" : {
+					"med_us" : 642.3709677419355,
+					"best_us" : 642.1290322580645
+				},
+				"vec8_u8" : {
+					"med_us" : 709.5555555555555,
+					"best_us" : 709.5555555555555
+				},
+				"vec16" : {
+					"med_us" : 616.828125,
+					"best_us" : 616.5625
+				}
+			}
+		},
+		"q51q8_tile_gen" : {
+			"winner" : "mr4",
+			"rows" : {
+				"mr8" : {
+					"streamed_us" : 816
+				},
+				"dot_maddubs_width256_mr8" : {
+					"streamed_us" : 6064
+				},
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"streamed_us" : 6067
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"streamed_us" : 6071
+				},
+				"mr4" : {
+					"streamed_us" : 814
+				},
+				"reference" : {
+					"streamed_us" : 6213
+				},
+				"mr4_nrsplit2" : {
+					"streamed_us" : 814
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"streamed_us" : 6066
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"streamed_us" : 6066
+				},
+				"mr8_nrsplit2" : {
+					"streamed_us" : 814
+				},
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"streamed_us" : 6066
+				}
+			}
+		},
+		"softmax" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 4504.5,
+					"best_us" : 4501.75
+				},
+				"vec32" : {
+					"med_us" : 4508.25,
+					"best_us" : 4506
+				},
+				"vec32_u4" : {
+					"med_us" : 4512.75,
+					"best_us" : 4504.5
+				},
+				"vec32_u8" : {
+					"med_us" : 4509.75,
+					"best_us" : 4503
+				},
+				"vec16_u2" : {
+					"med_us" : 4498.25,
+					"best_us" : 4496
+				},
+				"vec16_u4" : {
+					"med_us" : 4502,
+					"best_us" : 4500
+				},
+				"vec16_u8" : {
+					"med_us" : 4524.25,
+					"best_us" : 4518.5
+				},
+				"vec4" : {
+					"med_us" : 4512.25,
+					"best_us" : 4508.5
+				},
+				"vec8" : {
+					"med_us" : 4516.75,
+					"best_us" : 4504
+				},
+				"vec4_u4" : {
+					"med_us" : 4529,
+					"best_us" : 4517
+				},
+				"vec8_u4" : {
+					"med_us" : 4501.5,
+					"best_us" : 4501.5
+				},
+				"plain" : {
+					"med_us" : 4513,
+					"best_us" : 4508
+				},
+				"u2" : {
+					"med_us" : 4515.25,
+					"best_us" : 4511.5
+				},
+				"u4" : {
+					"med_us" : 4515.75,
+					"best_us" : 4514.5
+				},
+				"u8" : {
+					"med_us" : 4516.5,
+					"best_us" : 4512
+				},
+				"vec4_u2" : {
+					"med_us" : 4516.5,
+					"best_us" : 4512.25
+				},
+				"vec4_u8" : {
+					"med_us" : 4524.5,
+					"best_us" : 4513
+				},
+				"vec8_u2" : {
+					"med_us" : 4501.25,
+					"best_us" : 4500.5
+				},
+				"vec8_u8" : {
+					"med_us" : 4507.75,
+					"best_us" : 4505
+				},
+				"vec16" : {
+					"med_us" : 4502,
+					"best_us" : 4499.5
+				}
+			}
+		},
+		"q8q8_tile_gen" : {
+			"winner" : "mr8_budget",
+			"rows" : {
+				"kstep1" : {
+					"tile_us" : 34666,
+					"gemv_us" : 303,
+					"hot_us" : 16.8125
+				},
+				"kstep2_nrsplit2" : {
+					"tile_us" : 35533,
+					"gemv_us" : 303,
+					"hot_us" : 16.8125
+				},
+				"kstep1_nrsplit2" : {
+					"tile_us" : 36806,
+					"gemv_us" : 303,
+					"hot_us" : 16.75
+				},
+				"reference" : {
+					"tile_us" : 50694,
+					"gemv_us" : 303,
+					"hot_us" : 16.875
+				},
+				"kstep4_nrsplit2" : {
+					"tile_us" : 35636,
+					"gemv_us" : 303,
+					"hot_us" : 16.8125
+				},
+				"kstep4_nrsplit2_mr8_gkstep2" : {
+					"tile_us" : 32873,
+					"gemv_us" : 302,
+					"hot_us" : 15.375
+				},
+				"kstep1_nrsplit2_mr8" : {
+					"tile_us" : 37429,
+					"gemv_us" : 303,
+					"hot_us" : 15.625
+				},
+				"kstep2_nrsplit2_mr8" : {
+					"tile_us" : 31860,
+					"gemv_us" : 303,
+					"hot_us" : 15.3125
+				},
+				"kstep4_nrsplit2_mr8" : {
+					"tile_us" : 32479,
+					"gemv_us" : 302,
+					"hot_us" : 15.5625
+				},
+				"kstep2_gkstep2" : {
+					"tile_us" : 34066,
+					"gemv_us" : 303,
+					"hot_us" : 16.125
+				},
+				"kstep2_gkstep4" : {
+					"tile_us" : 34024,
+					"gemv_us" : 303,
+					"hot_us" : 16.3125
+				},
+				"kstep4_nrsplit2_mr8_gkstep4" : {
+					"tile_us" : 32201,
+					"gemv_us" : 303,
+					"hot_us" : 15.375
+				},
+				"mr8_budget" : {
+					"tile_us" : 31167,
+					"gemv_us" : 302,
+					"hot_us" : 15.625
+				},
+				"kstep2" : {
+					"tile_us" : 34069,
+					"gemv_us" : 303,
+					"hot_us" : 16.5
+				},
+				"kstep4" : {
+					"tile_us" : 33484,
+					"gemv_us" : 303,
+					"hot_us" : 16.75
+				}
+			}
+		},
+		"mul_inplace" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 495.28125,
+					"best_us" : 495.03125
+				},
+				"vec32" : {
+					"med_us" : 503.71875,
+					"best_us" : 502.9375
+				},
+				"vec32_u4" : {
+					"med_us" : 494.9375,
+					"best_us" : 494.84375
+				},
+				"vec32_u8" : {
+					"med_us" : 494.4375,
+					"best_us" : 494.125
+				},
+				"vec16_u2" : {
+					"med_us" : 499.5,
+					"best_us" : 499.125
+				},
+				"vec16_u4" : {
+					"med_us" : 491.6875,
+					"best_us" : 491.46875
+				},
+				"vec16_u8" : {
+					"med_us" : 492.03125,
+					"best_us" : 491.75
+				},
+				"vec4" : {
+					"med_us" : 499.9375,
+					"best_us" : 499.71875
+				},
+				"vec8" : {
+					"med_us" : 499.8125,
+					"best_us" : 499.53125
+				},
+				"vec4_u4" : {
+					"med_us" : 491.6875,
+					"best_us" : 491.5
+				},
+				"vec8_u4" : {
+					"med_us" : 492.34375,
+					"best_us" : 492.25
+				},
+				"plain" : {
+					"med_us" : 499.4375,
+					"best_us" : 499.03125
+				},
+				"u2" : {
+					"med_us" : 499.90625,
+					"best_us" : 499.75
+				},
+				"u4" : {
+					"med_us" : 492.09375,
+					"best_us" : 491.625
+				},
+				"u8" : {
+					"med_us" : 491.84375,
+					"best_us" : 491.6875
+				},
+				"vec4_u2" : {
+					"med_us" : 499.0625,
+					"best_us" : 498.90625
+				},
+				"vec4_u8" : {
+					"med_us" : 491.5625,
+					"best_us" : 491.46875
+				},
+				"vec8_u2" : {
+					"med_us" : 492,
+					"best_us" : 491.78125
+				},
+				"vec8_u8" : {
+					"med_us" : 492.0625,
+					"best_us" : 491.84375
+				},
+				"vec16" : {
+					"med_us" : 499.75,
+					"best_us" : 499.5
+				}
+			}
+		},
+		"k4q8_tile_gen" : {
+			"winner" : "mr8",
+			"rows" : {
+				"mr8" : {
+					"tile_us" : 38330,
+					"gemv_us" : 245,
+					"hot_us" : 15
+				},
+				"dot_maddubs_width256_mr8" : {
+					"tile_us" : 748474,
+					"gemv_us" : 2977,
+					"hot_us" : 184
+				},
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"tile_us" : 748487,
+					"gemv_us" : 2954,
+					"hot_us" : 183.5625
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"tile_us" : 748591,
+					"gemv_us" : 2964,
+					"hot_us" : 183.8125
+				},
+				"mr4" : {
+					"tile_us" : 42950,
+					"gemv_us" : 257,
+					"hot_us" : 15.875
+				},
+				"reference" : {
+					"tile_us" : 757111,
+					"gemv_us" : 2957,
+					"hot_us" : 185.875
+				},
+				"mr4_nrsplit2" : {
+					"tile_us" : 51010,
+					"gemv_us" : 263,
+					"hot_us" : 16.125
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 748705,
+					"gemv_us" : 2968,
+					"hot_us" : 183.625
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 751621,
+					"gemv_us" : 2940,
+					"hot_us" : 183.625
+				},
+				"mr8_nrsplit2" : {
+					"tile_us" : 45498,
+					"gemv_us" : 240,
+					"hot_us" : 14.9375
+				},
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"tile_us" : 748957,
+					"gemv_us" : 2945,
+					"hot_us" : 184
+				}
+			}
+		},
+		"k5q8_tile_gen" : {
+			"winner" : "mr8",
+			"rows" : {
+				"mr8" : {
+					"tile_us" : 38180,
+					"gemv_us" : 593,
+					"hot_us" : 36.8125
+				},
+				"dot_maddubs_width256_mr8" : {
+					"tile_us" : 363225,
+					"gemv_us" : 3725,
+					"hot_us" : 228.5625
+				},
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"tile_us" : 361067,
+					"gemv_us" : 3683,
+					"hot_us" : 228.4375
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"tile_us" : 361283,
+					"gemv_us" : 3725,
+					"hot_us" : 228.5
+				},
+				"mr4" : {
+					"tile_us" : 40572,
+					"gemv_us" : 591,
+					"hot_us" : 36.75
+				},
+				"reference" : {
+					"tile_us" : 365924,
+					"gemv_us" : 3764,
+					"hot_us" : 232.5625
+				},
+				"mr4_nrsplit2" : {
+					"tile_us" : 44412,
+					"gemv_us" : 584,
+					"hot_us" : 36.4375
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 361273,
+					"gemv_us" : 3693,
+					"hot_us" : 228.9375
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 362458,
+					"gemv_us" : 3724,
+					"hot_us" : 228.75
+				},
+				"mr8_nrsplit2" : {
+					"tile_us" : 39792,
+					"gemv_us" : 601,
+					"hot_us" : 37.5625
+				},
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"tile_us" : 366653,
+					"gemv_us" : 3704,
+					"hot_us" : 229.375
+				}
+			}
+		},
+		"k6q8_tile_gen" : {
+			"winner" : "mr4",
+			"rows" : {
+				"mr8" : {
+					"tile_us" : 59217,
+					"gemv_us" : 513,
+					"hot_us" : 31.5625
+				},
+				"dot_maddubs_width256_mr8" : {
+					"tile_us" : 574989,
+					"gemv_us" : 13758,
+					"hot_us" : 858.875
+				},
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"tile_us" : 571529,
+					"gemv_us" : 13751,
+					"hot_us" : 858.875
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"tile_us" : 571801,
+					"gemv_us" : 13760,
+					"hot_us" : 859.75
+				},
+				"mr4" : {
+					"tile_us" : 52330,
+					"gemv_us" : 495,
+					"hot_us" : 30.625
+				},
+				"reference" : {
+					"tile_us" : 571806,
+					"gemv_us" : 13743,
+					"hot_us" : 858.9375
+				},
+				"mr4_nrsplit2" : {
+					"tile_us" : 59274,
+					"gemv_us" : 492,
+					"hot_us" : 30.6875
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 573554,
+					"gemv_us" : 13739,
+					"hot_us" : 859.125
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 571361,
+					"gemv_us" : 13789,
+					"hot_us" : 858.6875
+				},
+				"mr8_nrsplit2" : {
+					"tile_us" : 61966,
+					"gemv_us" : 511,
+					"hot_us" : 31.5625
+				},
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"tile_us" : 571489,
+					"gemv_us" : 13771,
+					"hot_us" : 858.625
+				}
+			}
+		},
+		"quantize_q8_0_into_ptr" : {
+			"winner" : "plain",
+			"fallback" : "plain",
+			"floor_pct" : 0.1426575623414683,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 3729.2,
+					"best_us" : 3725
+				},
+				"vec32" : {
+					"med_us" : 3702.8,
+					"best_us" : 3699.2
+				},
+				"vec32_u4" : {
+					"med_us" : 3725.4,
+					"best_us" : 3724.6
+				},
+				"vec32_u8" : {
+					"med_us" : 3726.8,
+					"best_us" : 3724
+				},
+				"vec16_u2" : {
+					"med_us" : 3698.8,
+					"best_us" : 3697
+				},
+				"vec16_u4" : {
+					"med_us" : 3703.8,
+					"best_us" : 3698.4
+				},
+				"vec16_u8" : {
+					"med_us" : 3698.4,
+					"best_us" : 3696.8
+				},
+				"vec4" : {
+					"med_us" : 3701.2,
+					"best_us" : 3699.2
+				},
+				"vec8" : {
+					"med_us" : 3703.4,
+					"best_us" : 3697.2
+				},
+				"vec4_u4" : {
+					"med_us" : 4712,
+					"best_us" : 4709.5
+				},
+				"vec8_u4" : {
+					"med_us" : 3929.6,
+					"best_us" : 3929.2
+				},
+				"plain" : {
+					"med_us" : 3705.6,
+					"best_us" : 3699
+				},
+				"u2" : {
+					"med_us" : 3698.6,
+					"best_us" : 3698
+				},
+				"u4" : {
+					"med_us" : 3701.4,
+					"best_us" : 3698.2
+				},
+				"u8" : {
+					"med_us" : 3704.2,
+					"best_us" : 3698.8
+				},
+				"vec4_u2" : {
+					"med_us" : 4718,
+					"best_us" : 4708.75
+				},
+				"vec4_u8" : {
+					"med_us" : 4717.25,
+					"best_us" : 4709.75
+				},
+				"vec8_u2" : {
+					"med_us" : 3928.2,
+					"best_us" : 3924.4
+				},
+				"vec8_u8" : {
+					"med_us" : 3924.8,
+					"best_us" : 3924.4
+				},
+				"vec16" : {
+					"med_us" : 3706.4,
+					"best_us" : 3703.4
+				}
+			}
+		},
+		"dot_q8kv" : {
+			"winner" : "vec4_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 24.320797557220033,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 2181.777777777778,
+					"best_us" : 2179.5555555555557
+				},
+				"vec32" : {
+					"med_us" : 4209,
+					"best_us" : 4205.75
+				},
+				"vec32_u4" : {
+					"med_us" : 2182,
+					"best_us" : 2179.777777777778
+				},
+				"vec32_u8" : {
+					"med_us" : 2180.3333333333335,
+					"best_us" : 2179.6666666666665
+				},
+				"vec16_u2" : {
+					"med_us" : 1222.3125,
+					"best_us" : 1221.3125
+				},
+				"vec16_u4" : {
+					"med_us" : 1221.5625,
+					"best_us" : 1221.3125
+				},
+				"vec16_u8" : {
+					"med_us" : 1222.1875,
+					"best_us" : 1221.125
+				},
+				"vec4" : {
+					"med_us" : 4218,
+					"best_us" : 4209
+				},
+				"vec8" : {
+					"med_us" : 4229.5,
+					"best_us" : 4215.5
+				},
+				"vec4_u4" : {
+					"med_us" : 703.2321428571429,
+					"best_us" : 689.5357142857143
+				},
+				"vec8_u4" : {
+					"med_us" : 914.952380952381,
+					"best_us" : 912.3809523809524
+				},
+				"plain" : {
+					"med_us" : 4216.5,
+					"best_us" : 4208.5
+				},
+				"u2" : {
+					"med_us" : 2067.5555555555557,
+					"best_us" : 2065.3333333333335
+				},
+				"u4" : {
+					"med_us" : 2070.1111111111113,
+					"best_us" : 2066.4444444444443
+				},
+				"u8" : {
+					"med_us" : 2066,
+					"best_us" : 2064.6666666666665
+				},
+				"vec4_u2" : {
+					"med_us" : 701.7678571428571,
+					"best_us" : 689.5357142857143
+				},
+				"vec4_u8" : {
+					"med_us" : 703.3571428571429,
+					"best_us" : 695.9285714285714
+				},
+				"vec8_u2" : {
+					"med_us" : 927.7142857142858,
+					"best_us" : 912.3809523809524
+				},
+				"vec8_u8" : {
+					"med_us" : 914.7142857142857,
+					"best_us" : 912.3809523809524
+				},
+				"vec16" : {
+					"med_us" : 4217.5,
+					"best_us" : 4216
+				}
+			}
+		},
+		"quantize_q8_0_bs_into_ptr" : {
+			"winner" : "plain",
+			"fallback" : "plain",
+			"floor_pct" : 0.1426575623414683,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 3929.75,
+					"best_us" : 3928.75
+				},
+				"vec32" : {
+					"med_us" : 3869.75,
+					"best_us" : 3867
+				},
+				"vec32_u4" : {
+					"med_us" : 3933.5,
+					"best_us" : 3927.75
+				},
+				"vec32_u8" : {
+					"med_us" : 3935.25,
+					"best_us" : 3929.5
+				},
+				"vec16_u2" : {
+					"med_us" : 3893.5,
+					"best_us" : 3883
+				},
+				"vec16_u4" : {
+					"med_us" : 3887,
+					"best_us" : 3884.8
+				},
+				"vec16_u8" : {
+					"med_us" : 3886,
+					"best_us" : 3884.25
+				},
+				"vec4" : {
+					"med_us" : 3869.25,
+					"best_us" : 3868
+				},
+				"vec8" : {
+					"med_us" : 3869,
+					"best_us" : 3868.5
+				},
+				"vec4_u4" : {
+					"med_us" : 4198,
+					"best_us" : 4193.25
+				},
+				"vec8_u4" : {
+					"med_us" : 3907.75,
+					"best_us" : 3907.25
+				},
+				"plain" : {
+					"med_us" : 3871.8,
+					"best_us" : 3869.6
+				},
+				"u2" : {
+					"med_us" : 3885.75,
+					"best_us" : 3884.75
+				},
+				"u4" : {
+					"med_us" : 3891,
+					"best_us" : 3884
+				},
+				"u8" : {
+					"med_us" : 3891.25,
+					"best_us" : 3883.25
+				},
+				"vec4_u2" : {
+					"med_us" : 4194.25,
+					"best_us" : 4192.5
+				},
+				"vec4_u8" : {
+					"med_us" : 4197.5,
+					"best_us" : 4192.25
+				},
+				"vec8_u2" : {
+					"med_us" : 3909.5,
+					"best_us" : 3907
+				},
+				"vec8_u8" : {
+					"med_us" : 3909.5,
+					"best_us" : 3906.75
+				},
+				"vec16" : {
+					"med_us" : 3869.25,
+					"best_us" : 3868.5
+				}
+			}
+		},
+		"dot_q8q8" : {
+			"winner" : "vec16",
+			"fallback" : "vec16",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 993.4,
+					"best_us" : 992.25
+				},
+				"vec32" : {
+					"med_us" : 970.15,
+					"best_us" : 969.4
+				},
+				"vec32_u4" : {
+					"med_us" : 992.45,
+					"best_us" : 991.7
+				},
+				"vec32_u8" : {
+					"med_us" : 992.421052631579,
+					"best_us" : 991.8947368421053
+				},
+				"vec16_u2" : {
+					"med_us" : 991.05,
+					"best_us" : 989.35
+				},
+				"vec16_u4" : {
+					"med_us" : 992.35,
+					"best_us" : 990.2
+				},
+				"vec16_u8" : {
+					"med_us" : 989.25,
+					"best_us" : 989.05
+				},
+				"vec4" : {
+					"med_us" : 970.7,
+					"best_us" : 969.25
+				},
+				"vec8" : {
+					"med_us" : 969.45,
+					"best_us" : 969
+				},
+				"vec4_u4" : {
+					"med_us" : 2708,
+					"best_us" : 2705.5714285714284
+				},
+				"vec8_u4" : {
+					"med_us" : 1309.2666666666667,
+					"best_us" : 1308.4
+				},
+				"plain" : {
+					"med_us" : 970.0769230769231,
+					"best_us" : 969.0769230769231
+				},
+				"u2" : {
+					"med_us" : 990,
+					"best_us" : 988.5882352941177
+				},
+				"u4" : {
+					"med_us" : 990.35,
+					"best_us" : 989.25
+				},
+				"u8" : {
+					"med_us" : 989.65,
+					"best_us" : 988.25
+				},
+				"vec4_u2" : {
+					"med_us" : 2709.714285714286,
+					"best_us" : 2709.1428571428573
+				},
+				"vec4_u8" : {
+					"med_us" : 2711.1428571428573,
+					"best_us" : 2708.714285714286
+				},
+				"vec8_u2" : {
+					"med_us" : 1309.7333333333333,
+					"best_us" : 1309.0666666666666
+				},
+				"vec8_u8" : {
+					"med_us" : 1310,
+					"best_us" : 1309.0666666666666
+				},
+				"vec16" : {
+					"med_us" : 970.35,
+					"best_us" : 969.4
+				}
+			}
+		},
+		"gemm_f32_uk_4x16" : {
+			"winner" : "u2",
+			"fallback" : "u2",
+			"floor_pct" : 0.1426575623414683,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 667.6206896551724,
+					"best_us" : 667.4827586206897
+				},
+				"vec32" : {
+					"med_us" : 826.5416666666666,
+					"best_us" : 825.6666666666666
+				},
+				"vec32_u4" : {
+					"med_us" : 701.0714285714286,
+					"best_us" : 701
+				},
+				"vec32_u8" : {
+					"med_us" : 697.3214285714286,
+					"best_us" : 697.1071428571429
+				},
+				"vec16_u2" : {
+					"med_us" : 667.7241379310345,
+					"best_us" : 667.551724137931
+				},
+				"vec16_u4" : {
+					"med_us" : 701.1071428571429,
+					"best_us" : 700.8214285714286
+				},
+				"vec16_u8" : {
+					"med_us" : 697.3214285714286,
+					"best_us" : 697.25
+				},
+				"vec4" : {
+					"med_us" : 826.25,
+					"best_us" : 825.2916666666666
+				},
+				"vec8" : {
+					"med_us" : 826.375,
+					"best_us" : 825.5416666666666
+				},
+				"vec4_u4" : {
+					"med_us" : 700.8928571428571,
+					"best_us" : 700.4285714285714
+				},
+				"vec8_u4" : {
+					"med_us" : 702.1071428571429,
+					"best_us" : 700.9642857142857
+				},
+				"plain" : {
+					"med_us" : 825.9166666666666,
+					"best_us" : 825.75
+				},
+				"u2" : {
+					"med_us" : 667.5862068965517,
+					"best_us" : 667.3103448275862
+				},
+				"u4" : {
+					"med_us" : 701.1428571428571,
+					"best_us" : 700.5714285714286
+				},
+				"u8" : {
+					"med_us" : 697.1071428571429,
+					"best_us" : 696.6785714285714
+				},
+				"vec4_u2" : {
+					"med_us" : 668.0344827586207,
+					"best_us" : 667.4137931034483
+				},
+				"vec4_u8" : {
+					"med_us" : 698.1071428571429,
+					"best_us" : 696.75
+				},
+				"vec8_u2" : {
+					"med_us" : 668.0689655172414,
+					"best_us" : 667.4827586206897
+				},
+				"vec8_u8" : {
+					"med_us" : 697.6428571428571,
+					"best_us" : 697.2857142857143
+				},
+				"vec16" : {
+					"med_us" : 825.625,
+					"best_us" : 825.4583333333334
+				}
+			}
+		},
+		"quantize_q8kv_row" : {
+			"winner" : "plain",
+			"fallback" : "plain",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 1824.1,
+					"best_us" : 1823.1
+				},
+				"vec32" : {
+					"med_us" : 1815,
+					"best_us" : 1812.6363636363637
+				},
+				"vec32_u4" : {
+					"med_us" : 1824.7,
+					"best_us" : 1822.4
+				},
+				"vec32_u8" : {
+					"med_us" : 1823.6,
+					"best_us" : 1822.9
+				},
+				"vec16_u2" : {
+					"med_us" : 1805.5454545454545,
+					"best_us" : 1802.3636363636363
+				},
+				"vec16_u4" : {
+					"med_us" : 1805.8181818181818,
+					"best_us" : 1803.2727272727273
+				},
+				"vec16_u8" : {
+					"med_us" : 1802.090909090909,
+					"best_us" : 1802
+				},
+				"vec4" : {
+					"med_us" : 1813.9,
+					"best_us" : 1813.1
+				},
+				"vec8" : {
+					"med_us" : 1813,
+					"best_us" : 1812.6363636363637
+				},
+				"vec4_u4" : {
+					"med_us" : 2311.625,
+					"best_us" : 2308.5
+				},
+				"vec8_u4" : {
+					"med_us" : 1885,
+					"best_us" : 1883.6
+				},
+				"plain" : {
+					"med_us" : 1814.1,
+					"best_us" : 1812.3
+				},
+				"u2" : {
+					"med_us" : 1805.4,
+					"best_us" : 1802.4
+				},
+				"u4" : {
+					"med_us" : 1802.6,
+					"best_us" : 1802.2
+				},
+				"u8" : {
+					"med_us" : 1802.5454545454545,
+					"best_us" : 1802.090909090909
+				},
+				"vec4_u2" : {
+					"med_us" : 2305.5,
+					"best_us" : 2305.25
+				},
+				"vec4_u8" : {
+					"med_us" : 2306.5,
+					"best_us" : 2304.75
+				},
+				"vec8_u2" : {
+					"med_us" : 1887.5,
+					"best_us" : 1884.7
+				},
+				"vec8_u8" : {
+					"med_us" : 1885.4,
+					"best_us" : 1884.8
+				},
+				"vec16" : {
+					"med_us" : 1813.5,
+					"best_us" : 1811.7
+				}
+			}
+		},
+		"dot_f16" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 381.09375,
+					"best_us" : 379.84375
+				},
+				"vec32" : {
+					"med_us" : 381.84375,
+					"best_us" : 381.5625
+				},
+				"vec32_u4" : {
+					"med_us" : 378.65625,
+					"best_us" : 378.59375
+				},
+				"vec32_u8" : {
+					"med_us" : 385.4375,
+					"best_us" : 385.09375
+				},
+				"vec16_u2" : {
+					"med_us" : 357.65625,
+					"best_us" : 357.40625
+				},
+				"vec16_u4" : {
+					"med_us" : 349.78125,
+					"best_us" : 349.75
+				},
+				"vec16_u8" : {
+					"med_us" : 357.40625,
+					"best_us" : 357.28125
+				},
+				"vec4" : {
+					"med_us" : 613.5625,
+					"best_us" : 608.90625
+				},
+				"vec8" : {
+					"med_us" : 343.84375,
+					"best_us" : 343.8125
+				},
+				"vec4_u4" : {
+					"med_us" : 619.75,
+					"best_us" : 618.75
+				},
+				"vec8_u4" : {
+					"med_us" : 335.8125,
+					"best_us" : 335.8125
+				},
+				"plain" : {
+					"med_us" : 7440,
+					"best_us" : 7421.5
+				},
+				"u2" : {
+					"med_us" : 7388.5,
+					"best_us" : 7379.5
+				},
+				"u4" : {
+					"med_us" : 7386.5,
+					"best_us" : 7379
+				},
+				"u8" : {
+					"med_us" : 7385,
+					"best_us" : 7383
+				},
+				"vec4_u2" : {
+					"med_us" : 623.15625,
+					"best_us" : 614.5625
+				},
+				"vec4_u8" : {
+					"med_us" : 619.03125,
+					"best_us" : 618.8125
+				},
+				"vec8_u2" : {
+					"med_us" : 344.25,
+					"best_us" : 344.1875
+				},
+				"vec8_u8" : {
+					"med_us" : 343.03125,
+					"best_us" : 342.3125
+				},
+				"vec16" : {
+					"med_us" : 355.46875,
+					"best_us" : 355.40625
+				}
+			}
+		},
+		"axpy_f16" : {
+			"winner" : "vec4_u4",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 6.1735391179705985,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 463.78125,
+					"best_us" : 463.6875
+				},
+				"vec32" : {
+					"med_us" : 469.3125,
+					"best_us" : 469
+				},
+				"vec32_u4" : {
+					"med_us" : 463.875,
+					"best_us" : 463.84375
+				},
+				"vec32_u8" : {
+					"med_us" : 466.1875,
+					"best_us" : 465.28125
+				},
+				"vec16_u2" : {
+					"med_us" : 463.875,
+					"best_us" : 463.03125
+				},
+				"vec16_u4" : {
+					"med_us" : 460.90625,
+					"best_us" : 460.84375
+				},
+				"vec16_u8" : {
+					"med_us" : 463.28125,
+					"best_us" : 463.125
+				},
+				"vec4" : {
+					"med_us" : 458.90625,
+					"best_us" : 458.75
+				},
+				"vec8" : {
+					"med_us" : 469.96875,
+					"best_us" : 469.5625
+				},
+				"vec4_u4" : {
+					"med_us" : 439.015625,
+					"best_us" : 438.59375
+				},
+				"vec8_u4" : {
+					"med_us" : 468.28125,
+					"best_us" : 468
+				},
+				"plain" : {
+					"med_us" : 473.0625,
+					"best_us" : 472.8125
+				},
+				"u2" : {
+					"med_us" : 468.4375,
+					"best_us" : 468.125
+				},
+				"u4" : {
+					"med_us" : 468.15625,
+					"best_us" : 467.9375
+				},
+				"u8" : {
+					"med_us" : 469.3125,
+					"best_us" : 469.1875
+				},
+				"vec4_u2" : {
+					"med_us" : 459.84375,
+					"best_us" : 459.25
+				},
+				"vec4_u8" : {
+					"med_us" : 452.109375,
+					"best_us" : 451.59375
+				},
+				"vec8_u2" : {
+					"med_us" : 468.09375,
+					"best_us" : 467.75
+				},
+				"vec8_u8" : {
+					"med_us" : 469.625,
+					"best_us" : 469.21875
+				},
+				"vec16" : {
+					"med_us" : 466.6875,
+					"best_us" : 466.53125
+				}
+			}
+		},
+		"cvt_f16_to_f32" : {
+			"winner" : "vec16",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 7.7685280683659945,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 424.71875,
+					"best_us" : 422.53125
+				},
+				"vec32" : {
+					"med_us" : 425.0625,
+					"best_us" : 424.03125
+				},
+				"vec32_u4" : {
+					"med_us" : 422.78125,
+					"best_us" : 422.65625
+				},
+				"vec32_u8" : {
+					"med_us" : 423.25,
+					"best_us" : 422.53125
+				},
+				"vec16_u2" : {
+					"med_us" : 391.5625,
+					"best_us" : 384.625
+				},
+				"vec16_u4" : {
+					"med_us" : 390.890625,
+					"best_us" : 384.34375
+				},
+				"vec16_u8" : {
+					"med_us" : 394.015625,
+					"best_us" : 387.0625
+				},
+				"vec4" : {
+					"med_us" : 422.5,
+					"best_us" : 422.25
+				},
+				"vec8" : {
+					"med_us" : 426.8125,
+					"best_us" : 424.84375
+				},
+				"vec4_u4" : {
+					"med_us" : 421.90625,
+					"best_us" : 421.15625
+				},
+				"vec8_u4" : {
+					"med_us" : 425.21875,
+					"best_us" : 423.9375
+				},
+				"plain" : {
+					"med_us" : 426.71875,
+					"best_us" : 425.78125
+				},
+				"u2" : {
+					"med_us" : 425.71875,
+					"best_us" : 424
+				},
+				"u4" : {
+					"med_us" : 426.40625,
+					"best_us" : 424.125
+				},
+				"u8" : {
+					"med_us" : 426.34375,
+					"best_us" : 424.0625
+				},
+				"vec4_u2" : {
+					"med_us" : 425.6875,
+					"best_us" : 422.59375
+				},
+				"vec4_u8" : {
+					"med_us" : 421.40625,
+					"best_us" : 421.09375
+				},
+				"vec8_u2" : {
+					"med_us" : 424.1875,
+					"best_us" : 416.6875
+				},
+				"vec8_u8" : {
+					"med_us" : 425.5,
+					"best_us" : 424.09375
+				},
+				"vec16" : {
+					"med_us" : 391.234375,
+					"best_us" : 383.53125
+				}
+			}
+		},
+		"dot" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 2603.285714285714,
+					"best_us" : 2599.4285714285716
+				},
+				"vec32" : {
+					"med_us" : 2626,
+					"best_us" : 2624.4285714285716
+				},
+				"vec32_u4" : {
+					"med_us" : 2575.4285714285716,
+					"best_us" : 2575
+				},
+				"vec32_u8" : {
+					"med_us" : 2567.4285714285716,
+					"best_us" : 2563
+				},
+				"vec16_u2" : {
+					"med_us" : 2592.8571428571427,
+					"best_us" : 2589.8571428571427
+				},
+				"vec16_u4" : {
+					"med_us" : 2571.8571428571427,
+					"best_us" : 2567.285714285714
+				},
+				"vec16_u8" : {
+					"med_us" : 2556.714285714286,
+					"best_us" : 2555.8571428571427
+				},
+				"vec4" : {
+					"med_us" : 2604.75,
+					"best_us" : 2596.75
+				},
+				"vec8" : {
+					"med_us" : 2618,
+					"best_us" : 2611.714285714286
+				},
+				"vec4_u4" : {
+					"med_us" : 2632.8571428571427,
+					"best_us" : 2629.285714285714
+				},
+				"vec8_u4" : {
+					"med_us" : 2568.5714285714284,
+					"best_us" : 2566.1428571428573
+				},
+				"plain" : {
+					"med_us" : 30529,
+					"best_us" : 30412
+				},
+				"u2" : {
+					"med_us" : 30273,
+					"best_us" : 30229
+				},
+				"u4" : {
+					"med_us" : 30249,
+					"best_us" : 30226
+				},
+				"u8" : {
+					"med_us" : 30263,
+					"best_us" : 30215
+				},
+				"vec4_u2" : {
+					"med_us" : 2633.714285714286,
+					"best_us" : 2627.285714285714
+				},
+				"vec4_u8" : {
+					"med_us" : 2633.1428571428573,
+					"best_us" : 2628.1428571428573
+				},
+				"vec8_u2" : {
+					"med_us" : 2584.4285714285716,
+					"best_us" : 2583.714285714286
+				},
+				"vec8_u8" : {
+					"med_us" : 2560.1428571428573,
+					"best_us" : 2557
+				},
+				"vec16" : {
+					"med_us" : 2620.285714285714,
+					"best_us" : 2613.285714285714
+				}
+			}
+		},
+		"q40q8_tile_gen" : {
+			"winner" : "mr8",
+			"rows" : {
+				"mr8" : {
+					"tile_us" : 40065,
+					"gemv_us" : 222,
+					"hot_us" : 13.6875
+				},
+				"dot_maddubs_width256_mr8" : {
+					"tile_us" : 459052,
+					"gemv_us" : 1823,
+					"hot_us" : 112.6875
+				},
+				"dot_vpdpbusd_width256_mr8_nrsplit2" : {
+					"tile_us" : 458971,
+					"gemv_us" : 1809,
+					"hot_us" : 112.75
+				},
+				"dot_maddubs_width256_mr8_nrsplit2" : {
+					"tile_us" : 459363,
+					"gemv_us" : 1845,
+					"hot_us" : 112.9375
+				},
+				"mr4" : {
+					"tile_us" : 45607,
+					"gemv_us" : 239,
+					"hot_us" : 14.75
+				},
+				"reference" : {
+					"tile_us" : 458494,
+					"gemv_us" : 1819,
+					"hot_us" : 112.75
+				},
+				"mr4_nrsplit2" : {
+					"tile_us" : 50141,
+					"gemv_us" : 237,
+					"hot_us" : 14.75
+				},
+				"dot_vpdpbusd_width256_mr8" : {
+					"tile_us" : 459076,
+					"gemv_us" : 1815,
+					"hot_us" : 112.6875
+				},
+				"dot_vpdpbusd_width512_mr16" : {
+					"tile_us" : 459027,
+					"gemv_us" : 1815,
+					"hot_us" : 112.75
+				},
+				"mr8_nrsplit2" : {
+					"tile_us" : 45423,
+					"gemv_us" : 220,
+					"hot_us" : 13.75
+				},
+				"dot_vpdpbusd_width512_mr16_nrsplit2" : {
+					"tile_us" : 459087,
+					"gemv_us" : 1804,
+					"hot_us" : 112.625
+				}
+			}
+		},
+		"axpy" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 492.84375,
+					"best_us" : 492.84375
+				},
+				"vec32" : {
+					"med_us" : 500.5,
+					"best_us" : 500.09375
+				},
+				"vec32_u4" : {
+					"med_us" : 493.09375,
+					"best_us" : 492.84375
+				},
+				"vec32_u8" : {
+					"med_us" : 492.59375,
+					"best_us" : 492.28125
+				},
+				"vec16_u2" : {
+					"med_us" : 505.59375,
+					"best_us" : 505.375
+				},
+				"vec16_u4" : {
+					"med_us" : 498.15625,
+					"best_us" : 498
+				},
+				"vec16_u8" : {
+					"med_us" : 498.03125,
+					"best_us" : 497.25
+				},
+				"vec4" : {
+					"med_us" : 505,
+					"best_us" : 504.6875
+				},
+				"vec8" : {
+					"med_us" : 500.46875,
+					"best_us" : 500.3125
+				},
+				"vec4_u4" : {
+					"med_us" : 498.25,
+					"best_us" : 497.96875
+				},
+				"vec8_u4" : {
+					"med_us" : 493.0625,
+					"best_us" : 492.65625
+				},
+				"plain" : {
+					"med_us" : 504.9375,
+					"best_us" : 504.8125
+				},
+				"u2" : {
+					"med_us" : 506.6875,
+					"best_us" : 506.25
+				},
+				"u4" : {
+					"med_us" : 498.53125,
+					"best_us" : 498.25
+				},
+				"u8" : {
+					"med_us" : 497.34375,
+					"best_us" : 497.125
+				},
+				"vec4_u2" : {
+					"med_us" : 504.875,
+					"best_us" : 504.625
+				},
+				"vec4_u8" : {
+					"med_us" : 497.375,
+					"best_us" : 497.09375
+				},
+				"vec8_u2" : {
+					"med_us" : 492.625,
+					"best_us" : 492.4375
+				},
+				"vec8_u8" : {
+					"med_us" : 492.71875,
+					"best_us" : 492.40625
+				},
+				"vec16" : {
+					"med_us" : 504.625,
+					"best_us" : 504.46875
+				}
+			}
+		},
+		"dot_q8q8kv" : {
+			"winner" : "vec16",
+			"fallback" : "vec16",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 239.1875,
+					"best_us" : 238.78125
+				},
+				"vec32" : {
+					"med_us" : 234.34375,
+					"best_us" : 234.03125
+				},
+				"vec32_u4" : {
+					"med_us" : 239.1875,
+					"best_us" : 238.90625
+				},
+				"vec32_u8" : {
+					"med_us" : 239.28125,
+					"best_us" : 239.03125
+				},
+				"vec16_u2" : {
+					"med_us" : 238.5625,
+					"best_us" : 238.34375
+				},
+				"vec16_u4" : {
+					"med_us" : 238.5,
+					"best_us" : 238.40625
+				},
+				"vec16_u8" : {
+					"med_us" : 238.8125,
+					"best_us" : 238.78125
+				},
+				"vec4" : {
+					"med_us" : 234.09375,
+					"best_us" : 233.9375
+				},
+				"vec8" : {
+					"med_us" : 233.9375,
+					"best_us" : 230.21875
+				},
+				"vec4_u4" : {
+					"med_us" : 680.1724137931035,
+					"best_us" : 679.9310344827586
+				},
+				"vec8_u4" : {
+					"med_us" : 326.6875,
+					"best_us" : 326.59375
+				},
+				"plain" : {
+					"med_us" : 234.1875,
+					"best_us" : 233.9375
+				},
+				"u2" : {
+					"med_us" : 238.71875,
+					"best_us" : 238.25
+				},
+				"u4" : {
+					"med_us" : 239.0625,
+					"best_us" : 238.46875
+				},
+				"u8" : {
+					"med_us" : 239.5625,
+					"best_us" : 238.9375
+				},
+				"vec4_u2" : {
+					"med_us" : 680.7,
+					"best_us" : 679.9333333333333
+				},
+				"vec4_u8" : {
+					"med_us" : 680.7666666666667,
+					"best_us" : 675.1
+				},
+				"vec8_u2" : {
+					"med_us" : 326.65625,
+					"best_us" : 325.65625
+				},
+				"vec8_u8" : {
+					"med_us" : 326.6875,
+					"best_us" : 326.5625
+				},
+				"vec16" : {
+					"med_us" : 234.125,
+					"best_us" : 233.96875
+				}
+			}
+		},
+		"dot_mx4q8" : {
+			"winner" : "u4",
+			"fallback" : "u2",
+			"floor_pct" : 0.1426575623414683,
+			"margin_pct" : 6.499012661168544,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 269.03125,
+					"best_us" : 268.9375
+				},
+				"vec32" : {
+					"med_us" : 287.9375,
+					"best_us" : 287.125
+				},
+				"vec32_u4" : {
+					"med_us" : 251.5625,
+					"best_us" : 251.5625
+				},
+				"vec32_u8" : {
+					"med_us" : 247.78125,
+					"best_us" : 247.5625
+				},
+				"vec16_u2" : {
+					"med_us" : 269.03125,
+					"best_us" : 268.9375
+				},
+				"vec16_u4" : {
+					"med_us" : 251.5625,
+					"best_us" : 251.34375
+				},
+				"vec16_u8" : {
+					"med_us" : 247.75,
+					"best_us" : 247.5625
+				},
+				"vec4" : {
+					"med_us" : 287.75,
+					"best_us" : 287.21875
+				},
+				"vec8" : {
+					"med_us" : 287.5625,
+					"best_us" : 287.125
+				},
+				"vec4_u4" : {
+					"med_us" : 251.65625,
+					"best_us" : 251.46875
+				},
+				"vec8_u4" : {
+					"med_us" : 251.515625,
+					"best_us" : 251.34375
+				},
+				"plain" : {
+					"med_us" : 287.21875,
+					"best_us" : 286.9375
+				},
+				"u2" : {
+					"med_us" : 269.03125,
+					"best_us" : 264.09375
+				},
+				"u4" : {
+					"med_us" : 251.546875,
+					"best_us" : 249.96875
+				},
+				"u8" : {
+					"med_us" : 247.75,
+					"best_us" : 247.5625
+				},
+				"vec4_u2" : {
+					"med_us" : 269.03125,
+					"best_us" : 269.03125
+				},
+				"vec4_u8" : {
+					"med_us" : 247.765625,
+					"best_us" : 247.5625
+				},
+				"vec8_u2" : {
+					"med_us" : 269.03125,
+					"best_us" : 268.8125
+				},
+				"vec8_u8" : {
+					"med_us" : 247.765625,
+					"best_us" : 247.5625
+				},
+				"vec16" : {
+					"med_us" : 287.71875,
+					"best_us" : 287.21875
+				}
+			}
+		},
+		"dot_q8q8_laneq4x4" : {
+			"winner" : "u2",
+			"fallback" : "u2",
+			"floor_pct" : 0.1426575623414683,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 1027.5263157894738,
+					"best_us" : 1027.3157894736842
+				},
+				"vec32" : {
+					"med_us" : 1034.0526315789473,
+					"best_us" : 1033.842105263158
+				},
+				"vec32_u4" : {
+					"med_us" : 1018.6842105263158,
+					"best_us" : 1018.2105263157895
+				},
+				"vec32_u8" : {
+					"med_us" : 1015.5263157894736,
+					"best_us" : 1014.578947368421
+				},
+				"vec16_u2" : {
+					"med_us" : 1027.7368421052631,
+					"best_us" : 1027.2105263157894
+				},
+				"vec16_u4" : {
+					"med_us" : 1018.5263157894736,
+					"best_us" : 1018.2105263157895
+				},
+				"vec16_u8" : {
+					"med_us" : 1015.7368421052631,
+					"best_us" : 1014.4736842105264
+				},
+				"vec4" : {
+					"med_us" : 1035,
+					"best_us" : 1034.1052631578948
+				},
+				"vec8" : {
+					"med_us" : 1034.3684210526317,
+					"best_us" : 1034.1052631578948
+				},
+				"vec4_u4" : {
+					"med_us" : 1018.421052631579,
+					"best_us" : 1018.0526315789474
+				},
+				"vec8_u4" : {
+					"med_us" : 1018.7368421052631,
+					"best_us" : 1018.0526315789474
+				},
+				"plain" : {
+					"med_us" : 1034,
+					"best_us" : 1033.421052631579
+				},
+				"u2" : {
+					"med_us" : 1027.5263157894738,
+					"best_us" : 1026.7894736842106
+				},
+				"u4" : {
+					"med_us" : 1018.5263157894736,
+					"best_us" : 1018.0526315789474
+				},
+				"u8" : {
+					"med_us" : 1015.4736842105264,
+					"best_us" : 1014.2631578947369
+				},
+				"vec4_u2" : {
+					"med_us" : 1028.157894736842,
+					"best_us" : 1027.3157894736842
+				},
+				"vec4_u8" : {
+					"med_us" : 1015.7894736842105,
+					"best_us" : 1015.578947368421
+				},
+				"vec8_u2" : {
+					"med_us" : 1028.0526315789473,
+					"best_us" : 1027.2631578947369
+				},
+				"vec8_u8" : {
+					"med_us" : 1014.7368421052631,
+					"best_us" : 1014.421052631579
+				},
+				"vec16" : {
+					"med_us" : 1034.578947368421,
+					"best_us" : 1033.8947368421052
+				}
+			}
+		},
+		"scale_inplace" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 415.375,
+					"best_us" : 415.28125
+				},
+				"vec32" : {
+					"med_us" : 415.6875,
+					"best_us" : 414.90625
+				},
+				"vec32_u4" : {
+					"med_us" : 414.53125,
+					"best_us" : 413.96875
+				},
+				"vec32_u8" : {
+					"med_us" : 413.0625,
+					"best_us" : 413
+				},
+				"vec16_u2" : {
+					"med_us" : 411.78125,
+					"best_us" : 411.625
+				},
+				"vec16_u4" : {
+					"med_us" : 410.09375,
+					"best_us" : 410
+				},
+				"vec16_u8" : {
+					"med_us" : 431.3125,
+					"best_us" : 429.71875
+				},
+				"vec4" : {
+					"med_us" : 422.5625,
+					"best_us" : 421.78125
+				},
+				"vec8" : {
+					"med_us" : 416.03125,
+					"best_us" : 415.21875
+				},
+				"vec4_u4" : {
+					"med_us" : 425.53125,
+					"best_us" : 425.40625
+				},
+				"vec8_u4" : {
+					"med_us" : 415.65625,
+					"best_us" : 414.75
+				},
+				"plain" : {
+					"med_us" : 422.8125,
+					"best_us" : 421.6875
+				},
+				"u2" : {
+					"med_us" : 425.59375,
+					"best_us" : 425.3125
+				},
+				"u4" : {
+					"med_us" : 426.0625,
+					"best_us" : 425.96875
+				},
+				"u8" : {
+					"med_us" : 424.3125,
+					"best_us" : 423.625
+				},
+				"vec4_u2" : {
+					"med_us" : 425.78125,
+					"best_us" : 425.625
+				},
+				"vec4_u8" : {
+					"med_us" : 423.5625,
+					"best_us" : 423.5
+				},
+				"vec8_u2" : {
+					"med_us" : 416.34375,
+					"best_us" : 415.625
+				},
+				"vec8_u8" : {
+					"med_us" : 414.8125,
+					"best_us" : 413.78125
+				},
+				"vec16" : {
+					"med_us" : 413.6875,
+					"best_us" : 413.40625
+				}
+			}
+		},
+		"dot_q4" : {
+			"winner" : "vec4_u4",
+			"fallback" : "vec4_u4",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 2836.8333333333335,
+					"best_us" : 2833.1666666666665
+				},
+				"vec32" : {
+					"med_us" : 3098.8333333333335,
+					"best_us" : 3097.8333333333335
+				},
+				"vec32_u4" : {
+					"med_us" : 2673,
+					"best_us" : 2671.5714285714284
+				},
+				"vec32_u8" : {
+					"med_us" : 2616.285714285714,
+					"best_us" : 2594.714285714286
+				},
+				"vec16_u2" : {
+					"med_us" : 1469.1538461538462,
+					"best_us" : 1452.7692307692307
+				},
+				"vec16_u4" : {
+					"med_us" : 1453.6923076923076,
+					"best_us" : 1452.8461538461538
+				},
+				"vec16_u8" : {
+					"med_us" : 1455.6923076923076,
+					"best_us" : 1452.5384615384614
+				},
+				"vec4" : {
+					"med_us" : 3102,
+					"best_us" : 3099
+				},
+				"vec8" : {
+					"med_us" : 3105.3333333333335,
+					"best_us" : 3099.5
+				},
+				"vec4_u4" : {
+					"med_us" : 1123.5882352941176,
+					"best_us" : 1123.2941176470588
+				},
+				"vec8_u4" : {
+					"med_us" : 1153.8235294117646,
+					"best_us" : 1152.2941176470588
+				},
+				"plain" : {
+					"med_us" : 3110.5,
+					"best_us" : 3101.5
+				},
+				"u2" : {
+					"med_us" : 1448.5384615384614,
+					"best_us" : 1448.3846153846155
+				},
+				"u4" : {
+					"med_us" : 1451.1538461538462,
+					"best_us" : 1448.6153846153845
+				},
+				"u8" : {
+					"med_us" : 1449.923076923077,
+					"best_us" : 1448.4615384615386
+				},
+				"vec4_u2" : {
+					"med_us" : 1124.3529411764705,
+					"best_us" : 1122.235294117647
+				},
+				"vec4_u8" : {
+					"med_us" : 1123.5294117647059,
+					"best_us" : 1122.2941176470588
+				},
+				"vec8_u2" : {
+					"med_us" : 1153.4705882352941,
+					"best_us" : 1151.7058823529412
+				},
+				"vec8_u8" : {
+					"med_us" : 1152.5294117647059,
+					"best_us" : 1152.0588235294117
+				},
+				"vec16" : {
+					"med_us" : 3099.3333333333335,
+					"best_us" : 3098.1666666666665
+				}
+			}
+		},
+		"copy_floats" : {
+			"winner" : "vec8_u2",
+			"fallback" : "vec8_u2",
+			"floor_pct" : 0.11867454856869712,
+			"margin_pct" : 0,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 516.375,
+					"best_us" : 477.25
+				},
+				"vec32" : {
+					"med_us" : 482.625,
+					"best_us" : 431.625
+				},
+				"vec32_u4" : {
+					"med_us" : 521.09375,
+					"best_us" : 429.53125
+				},
+				"vec32_u8" : {
+					"med_us" : 488.75,
+					"best_us" : 460.15625
+				},
+				"vec16_u2" : {
+					"med_us" : 502.703125,
+					"best_us" : 394.0625
+				},
+				"vec16_u4" : {
+					"med_us" : 499.796875,
+					"best_us" : 396.78125
+				},
+				"vec16_u8" : {
+					"med_us" : 473.40625,
+					"best_us" : 452.28125
+				},
+				"vec4" : {
+					"med_us" : 585.6875,
+					"best_us" : 405.25
+				},
+				"vec8" : {
+					"med_us" : 506.46875,
+					"best_us" : 439.5
+				},
+				"vec4_u4" : {
+					"med_us" : 511.90625,
+					"best_us" : 443.09375
+				},
+				"vec8_u4" : {
+					"med_us" : 497.6875,
+					"best_us" : 407.5
+				},
+				"plain" : {
+					"med_us" : 480.34375,
+					"best_us" : 440
+				},
+				"u2" : {
+					"med_us" : 477.59375,
+					"best_us" : 437.75
+				},
+				"u4" : {
+					"med_us" : 474.15625,
+					"best_us" : 453.25
+				},
+				"u8" : {
+					"med_us" : 466.40625,
+					"best_us" : 428.46875
+				},
+				"vec4_u2" : {
+					"med_us" : 515.34375,
+					"best_us" : 441.8125
+				},
+				"vec4_u8" : {
+					"med_us" : 508.34375,
+					"best_us" : 439.25
+				},
+				"vec8_u2" : {
+					"med_us" : 490.8125,
+					"best_us" : 397.21875
+				},
+				"vec8_u8" : {
+					"med_us" : 458.921875,
+					"best_us" : 389.96875
+				},
+				"vec16" : {
+					"med_us" : 493.859375,
+					"best_us" : 389.46875
+				}
+			},
+			"demoted" : "vec8_u8"
+		},
+		"rmsnorm" : {
+			"winner" : "vec8",
+			"fallback" : "plain",
+			"floor_pct" : 0.12186311099247496,
+			"margin_pct" : 89.29033302074366,
+			"rows" : {
+				"vec32_u2" : {
+					"med_us" : 920.3809523809524,
+					"best_us" : 920
+				},
+				"vec32" : {
+					"med_us" : 928.047619047619,
+					"best_us" : 927.4761904761905
+				},
+				"vec32_u4" : {
+					"med_us" : 929.952380952381,
+					"best_us" : 929.3809523809524
+				},
+				"vec32_u8" : {
+					"med_us" : 935.2380952380952,
+					"best_us" : 934
+				},
+				"vec16_u2" : {
+					"med_us" : 897.2272727272727,
+					"best_us" : 896.8636363636364
+				},
+				"vec16_u4" : {
+					"med_us" : 891.0227272727273,
+					"best_us" : 889.5909090909091
+				},
+				"vec16_u8" : {
+					"med_us" : 890.8181818181818,
+					"best_us" : 890.3181818181819
+				},
+				"vec4" : {
+					"med_us" : 1023.6315789473684,
+					"best_us" : 1022.2631578947369
+				},
+				"vec8" : {
+					"med_us" : 877.6304347826087,
+					"best_us" : 875.4782608695652
+				},
+				"vec4_u4" : {
+					"med_us" : 1028.7368421052631,
+					"best_us" : 1028.157894736842
+				},
+				"vec8_u4" : {
+					"med_us" : 879.8695652173913,
+					"best_us" : 879.3913043478261
+				},
+				"plain" : {
+					"med_us" : 8194.75,
+					"best_us" : 8180
+				},
+				"u2" : {
+					"med_us" : 8162,
+					"best_us" : 8150
+				},
+				"u4" : {
+					"med_us" : 8144.5,
+					"best_us" : 8142.5
+				},
+				"u8" : {
+					"med_us" : 8145,
+					"best_us" : 8138
+				},
+				"vec4_u2" : {
+					"med_us" : 1036.4736842105262,
+					"best_us" : 1019.7894736842105
+				},
+				"vec4_u8" : {
+					"med_us" : 1028.2105263157894,
+					"best_us" : 1028
+				},
+				"vec8_u2" : {
+					"med_us" : 877.7826086956521,
+					"best_us" : 875.0434782608696
+				},
+				"vec8_u8" : {
+					"med_us" : 880.4347826086956,
+					"best_us" : 880.0869565217391
+				},
+				"vec16" : {
+					"med_us" : 895.9545454545455,
+					"best_us" : 895.6818181818181
+				}
+			}
+		}
+	},
+	"runtime" : {
+		"jobque_spin_us" : 30000,
+		"target_chunk_work" : 1,
+		"norm_par_threshold" : 256000,
+		"gemv_lane_cap" : 0,
+		"matmul_min_chunk_rows" : 16,
+		"batch_grid_2d" : 0,
+		"team_rank_gate" : -1,
+		"kv_store_par_threshold" : 256000,
+		"q8_l2_budget" : 4194304,
+		"rope_par_threshold" : 100000,
+		"jobque_join_poll" : 50,
+		"q8_token_block" : 128,
+		"requant_par_threshold" : 256000,
+		"metal_tensor" : "",
+		"matmul_min_chunk_rows_gemv" : 64,
+		"attn_par_threshold" : 100000,
+		"batch_lane_cap" : 0,
+		"act_par_threshold" : 100000,
+		"threads" : 8,
+		"dispatch_worker_limit" : 0,
+		"q8_batch_chunks_per_job" : 4,
+		"q8_chunks_per_job" : 2,
+		"q4_chunks_per_job" : 4
+	}
+}

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -153,8 +153,10 @@ cells, wdec knob pinned OFF per the fixtures section). Runs under plain dastest.
 `asr_encode_bucket`) over constructed structs and parakeet's SPM detokenizer over a toy vocab.
 `test_model_specs.das` — model-free: the model-set table's shape invariants
 (`../performance/model_specs.das`: unique file/display keys, official ⇒ provenance pinned,
-parity-evidence shape) and the derived provenance view's invariants (unique names, sha-or-recipe,
-https urls).
+parity-evidence shape), the derived provenance view's invariants (unique names, sha-or-recipe,
+https urls), and the vision pairing view (`mmproj_companion` — found by name, not companion
+position; ≥ 2 official vision rows) plus the pinned image fixture's provenance
+(`bench_image_fixture`).
 `test_parity.das` — suite-less, model-gated: the frozen token-for-token parity gates. ONE
 generic loop drives every evidence-carrying spec of the model-set table through its declared
 pinned arms (evidence is DATA on `ModelSpec.parity` — ids + arms, regenerated via

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -115,8 +115,8 @@ the device-free rail unit; the serving vulkan census runs on the PC box.
 
 ## Model-free / no-arm tests
 
-A model-free file — one with at least one cell that runs, not skips, with no model present and
-with CPU prefill declared (`DASLLAMA_CPU_PREFILL=1`, which the runner sets for every child) —
+A model-free file — one with at least one cell that runs, not skips, when no model is present
+and `DASLLAMA_CPU_PREFILL=1` is set in the environment (the runner sets it for every child) —
 runs under plain dastest (still `-jit`) or as a set through `run.das -- --suite model-free`,
 the per-PR gate. The `model-free` list in `run.das` is the census of those files; this note is
 the per-file map. A file in a model suite (every suite but `model-free`) is listed in its
@@ -154,9 +154,9 @@ cells, wdec knob pinned OFF per the fixtures section). Runs under plain dastest.
 `test_model_specs.das` — model-free: the model-set table's shape invariants
 (`../performance/model_specs.das`: unique file/display keys, official ⇒ provenance pinned,
 parity-evidence shape), the derived provenance view's invariants (unique names, sha-or-recipe,
-https urls), and the vision pairing view (`mmproj_companion` — found by name, not companion
-position; ≥ 2 official vision rows) plus the pinned image fixture's provenance
-(`bench_image_fixture`).
+https urls), the mmproj pairing lookup (`mmproj_companion` — the companion found by name, not
+by position; ≥ 2 official vision rows), and the pinned image fixture's provenance
+(`bench_image_fixture` rides some spec's companion list).
 `test_parity.das` — suite-less, model-gated: the frozen token-for-token parity gates. ONE
 generic loop drives every evidence-carrying spec of the model-set table through its declared
 pinned arms (evidence is DATA on `ModelSpec.parity` — ids + arms, regenerated via

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -4,9 +4,9 @@
 doc: `CLAUDE.md`. Planned work: `../THINKING.md`.
 
 **Every PR runs `run.das -- --suite model-free`, plus every test here the change reaches — never
-the whole directory.** A change reaches a test when it alters anything the test's result depends on —
-the test file, a shared helper, engine code it exercises, or an in-tree fixture or corpus it
-reads; an identifier- or comment-only edit reaches none.
+the whole directory.** A change reaches a test when it alters anything the test's result
+depends on — the test file, a shared helper, engine code it exercises, an in-tree fixture or
+corpus it reads, or a name it asserts on; a comment-only edit reaches none.
 
 **A test file with at least one cell that RUNS (not skips) with no model file present is listed
 in `run.das`'s `model-free` suite in the same change it is added. A file whose every cell is
@@ -108,10 +108,13 @@ that leg (`set_metal_wdec(false)` / `set_metal_tower(false)`) and restores it af
 relies on the driver's runtime decline. The mechanism (why the hooks flip legs silently) is
 `CLAUDE.md`'s "Metal fixtures" section.
 
-**A test that encodes, preprocesses, or asserts on image bytes without a model builds its
-image procedurally and pins its expectations in-repo; any image a test feeds an embedder is a
-fixture the test builds, or previewable via `DASLLAMA_VISION_DUMP`** — a red never requires adding instrumentation before a human can see
-what the model saw.
+**A cell that encodes, preprocesses, or asserts on vision image bytes — pixels, not a `.dlim`
+model image — with no model loaded builds its image procedurally and pins its expectations
+in-repo.**
+
+**Any image a test feeds an embedder is a fixture the test builds, or is previewable via
+`DASLLAMA_VISION_DUMP`** — a red never requires adding instrumentation before a human can
+see what the model saw.
 
 **A tier-1 vision fixture — one an embedder-parity cell regenerates in-test and compares
 against an oracle dump — has an exact-value generator.** A generator running libm

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -4,9 +4,9 @@
 doc: `CLAUDE.md`. Planned work: `../THINKING.md`.
 
 **Every PR runs `run.das -- --suite model-free`, plus every test here the change reaches — never
-the whole directory.** A change reaches a test when it alters what code does at runtime — through
-the test file, a shared helper, or engine code the test exercises; an identifier- or
-comment-only edit reaches none.
+the whole directory.** A change reaches a test when it alters anything the test's result depends on —
+the test file, a shared helper, engine code it exercises, or an in-tree fixture or corpus it
+reads; an identifier- or comment-only edit reaches none.
 
 **A test file with at least one cell that RUNS (not skips) with no model file present is listed
 in `run.das`'s `model-free` suite in the same change it is added. A file whose every cell is
@@ -108,9 +108,9 @@ that leg (`set_metal_wdec(false)` / `set_metal_tower(false)`) and restores it af
 relies on the driver's runtime decline. The mechanism (why the hooks flip legs silently) is
 `CLAUDE.md`'s "Metal fixtures" section.
 
-**A vision test that needs no model builds its image procedurally and pins its expectations
-in-repo; any image a test feeds an embedder is a fixture the test builds, or previewable via
-`DASLLAMA_VISION_DUMP`** — a red never requires adding instrumentation before a human can see
+**A test that encodes, preprocesses, or asserts on image bytes without a model builds its
+image procedurally and pins its expectations in-repo; any image a test feeds an embedder is a
+fixture the test builds, or previewable via `DASLLAMA_VISION_DUMP`** — a red never requires adding instrumentation before a human can see
 what the model saw.
 
 **A tier-1 vision fixture — one an embedder-parity cell regenerates in-test and compares

--- a/modules/dasLLAMA/tests/test_bench_records_schema.das
+++ b/modules/dasLLAMA/tests/test_bench_records_schema.das
@@ -251,3 +251,69 @@ def test_das_run_unstamped(t : T?) {
         delete rr
     }
 }
+
+[test]
+def test_workload_scope(t : T?) {
+    t |> run("the -w scope table: llm/asr/image cells per workload, unknown rejected") @(t : T?) {
+        var llm = false
+        var asr = false
+        var image = false
+        t |> success(workload_scope("all", llm, asr, image), "all is known")
+        t |> success(llm && asr && image, "all selects every cell set")
+        t |> success(workload_scope("llm", llm, asr, image), "llm is known")
+        t |> success(llm && !asr && image, "llm selects text + image (image rides the llm sweep)")
+        t |> success(workload_scope("asr", llm, asr, image), "asr is known")
+        t |> success(!llm && asr && !image, "asr selects only the audio cells")
+        t |> success(workload_scope("image", llm, asr, image), "image is known")
+        t |> success(!llm && !asr && image, "image narrows to the image cells alone")
+        t |> success(!workload_scope("bogus", llm, asr, image), "an unknown workload is rejected")
+        t |> success(!llm && !asr && !image, "a rejection selects nothing")
+        t |> success(!workload_scope("", llm, asr, image), "the empty workload is rejected")
+    }
+}
+
+[test]
+def test_stored_row_leg(t : T?) {
+    t |> run("the stored-row -> rig-leg map: three stamps resolve, everything else refuses") @(t : T?) {
+        var leg = "poison"
+        t |> success(stored_row_leg("metal", "tuned", leg), "metal/tuned is a rig stamp")
+        t |> equal(leg, "metal")
+        t |> success(stored_row_leg("cpu", "tuned", leg), "cpu/tuned is a rig stamp")
+        t |> equal(leg, "", "the plain cpu leg is the empty leg symbol")
+        t |> success(stored_row_leg("cpu", "accel", leg), "cpu/accel is a rig stamp")
+        t |> equal(leg, "accel")
+        t |> success(!stored_row_leg("metal", "accel", leg), "accel is a CPU-tier stamp - no metal leg produces it")
+        t |> equal(leg, "", "a refusal leaves no stale leg behind")
+        t |> success(!stored_row_leg("vulkan", "tuned", leg), "a foreign backend has no rig leg")
+        t |> success(!stored_row_leg("cpu", "debug-jit", leg), "a debug flavor has no rig leg")
+    }
+}
+
+[test]
+def test_image_chat_rows_pin_the_fixture(t : T?) {
+    t |> run("every committed image-chat row's receipt names the one pinned picture") @(t : T?) {
+        // the oracle re-measures a stored image row with bench_image_fixture(); a BenchRun has
+        // no image-identity field, so the cmd receipt is where that assumption is checkable
+        var stores <- list_record_stores("modules/dasLLAMA/performance/records")
+        var rows = 0
+        for (path in stores) {
+            var models : array<BenchModel>
+            t |> success(read_bench_records(path, models), "{path} parses")
+            for (m in models) {
+                for (r in m.runs) {
+                    if (r.workload != "image-chat") {
+                        continue
+                    }
+                    rows++
+                    t |> success(find(r.cmd, bench_image_fixture()) >= 0,
+                        "{base_name(path)} {m.gguf} {r.backend}/{r.flavor}: the cmd receipt names {bench_image_fixture()}")
+                    t |> success(find(r.cmd, "--image-mmproj") >= 0,
+                        "{base_name(path)} {m.gguf} {r.backend}/{r.flavor}: the cmd receipt names its mmproj")
+                }
+            }
+            delete models
+        }
+        t |> success(rows > 0, "the sweep found image-chat rows to gate ({rows})")
+        delete stores
+    }
+}

--- a/modules/dasLLAMA/tests/test_model_specs.das
+++ b/modules/dasLLAMA/tests/test_model_specs.das
@@ -107,6 +107,15 @@ def test_model_spec_views(t : T?) {
             pinned ||= e.name == bench_image_fixture()
         }
         t |> success(pinned, "{bench_image_fixture()} rides a companion list, so every box provisions it")
+        var inscope specs <- model_specs()
+        var seen : table<string>
+        for (s in specs) {
+            for (c in s.companions) {
+                t |> success(!key_exists(seen, c.name), "a companion rides exactly one row's companions: {c.name}")
+                seen |> insert(c.name)
+            }
+        }
+        delete seen
     }
 }
 

--- a/modules/dasLLAMA/tests/test_model_specs.das
+++ b/modules/dasLLAMA/tests/test_model_specs.das
@@ -87,6 +87,11 @@ def test_model_spec_views(t : T?) {
         t |> equal(mmproj_companion(g12), "mmproj-gemma-4-12B-it-BF16.gguf")
         var inscope oss <- spec_by_file("gpt-oss-20b-mxfp4.gguf")
         t |> equal(mmproj_companion(oss), "", "a text-only row has no vision pairing")
+        var shuffled <- ModelSpec(file = "toy.gguf", companions <- [
+            ProvEntry(name = "coco-val2017-000000039769.jpg"),
+            ProvEntry(name = "mmproj-toy.gguf")])
+        t |> equal(mmproj_companion(shuffled), "mmproj-toy.gguf", "the mmproj is found by name, not by companion position")
+        delete shuffled
         // the board's image legs need real coverage: at least two official vision decoders
         var inscope off <- official_catalog()
         var vision = 0

--- a/modules/dasLLAMA/tests/test_model_specs.das
+++ b/modules/dasLLAMA/tests/test_model_specs.das
@@ -82,6 +82,27 @@ def test_model_spec_views(t : T?) {
         t |> equal(counting_prompt(3), "1, 2, 3,")
         t |> equal(counting_prompt(1), "1,")
     }
+    t |> run("mmproj_companion pairs the vision rows and only them") @(t : T?) {
+        var inscope g12 <- spec_by_file("gemma-4-12B-it-Q4_K_M.gguf")
+        t |> equal(mmproj_companion(g12), "mmproj-gemma-4-12B-it-BF16.gguf")
+        var inscope oss <- spec_by_file("gpt-oss-20b-mxfp4.gguf")
+        t |> equal(mmproj_companion(oss), "", "a text-only row has no vision pairing")
+        // the board's image legs need real coverage: at least two official vision decoders
+        var inscope off <- official_catalog()
+        var vision = 0
+        for (s in off) {
+            vision += empty(mmproj_companion(s)) ? 0 : 1
+        }
+        t |> success(vision >= 2, "the official board carries >= 2 vision rows (got {vision})")
+    }
+    t |> run("the image fixture is provenanced (some spec row owns its pin)") @(t : T?) {
+        var inscope entries <- models_provenance()
+        var pinned = false
+        for (e in entries) {
+            pinned ||= e.name == bench_image_fixture()
+        }
+        t |> success(pinned, "{bench_image_fixture()} rides a companion list, so every box provisions it")
+    }
 }
 
 [test]

--- a/site/REVIEW.md
+++ b/site/REVIEW.md
@@ -7,15 +7,16 @@
 the page shows.** A command, flag, or output line invented for illustration is a defect; if
 the implementation does not exist yet, the page does not show the command.
 
-**A receipt — the command line `files/dasllama.js` renders from
-`files/dasllama/bench_records.json` — is the exact argv the harness ran, never hand-edited.**
+**The `cmd` field of any run in `files/dasllama/bench_records.json` — the receipt a page
+renders or a reader replays — is the exact argv the harness ran, never hand-edited.**
 A receipt is per run, not per row: when one harness run produced several rows (one `cmd` +
 `date` run object in `modules/dasLLAMA/performance/records/<box>.json`), every one of those
 rows shows that run's receipt line.
 
 **`files/dasllama/bench_records.json` is generator output: `modules/dasLLAMA/performance/gen_site_records.das`
 merges every `modules/dasLLAMA/performance/records/<box>.json` and applies
-`records/annotations.json`, so re-running the generator leaves the file byte-identical.** A
+`modules/dasLLAMA/performance/records/annotations.json`, so re-running the generator leaves
+the file byte-identical.** A
 diff where it does not is a hand edit and a defect.
 
 **Every code sample shown on a page compiles and runs with the current toolchain.** daslang

--- a/site/REVIEW.md
+++ b/site/REVIEW.md
@@ -7,17 +7,15 @@
 the page shows.** A command, flag, or output line invented for illustration is a defect; if
 the implementation does not exist yet, the page does not show the command.
 
-**The `cmd` field of any run in `files/dasllama/bench_records.json` — the receipt a page
-renders or a reader replays — is the exact argv the harness ran, never hand-edited.**
-A receipt is per run, not per row: when one harness run produced several rows (one `cmd` +
-`date` run object in `modules/dasLLAMA/performance/records/<box>.json`), every one of those
-rows shows that run's receipt line.
+**The `cmd` field of any run in `files/dasllama/bench_records.json` is the exact argv the
+harness ran.** A receipt is per run — one `cmd` + `date` run object — not per rendered row:
+when one run produced several rows, `files/dasllama.js` shows that run's receipt line on
+every one of them.
 
 **`files/dasllama/bench_records.json` is generator output: `modules/dasLLAMA/performance/gen_site_records.das`
 merges every `modules/dasLLAMA/performance/records/<box>.json` and applies
 `modules/dasLLAMA/performance/records/annotations.json`, so re-running the generator leaves
-the file byte-identical.** A
-diff where it does not is a hand edit and a defect.
+the file byte-identical.** A diff where it does not is a hand edit and a defect.
 
 **Every code sample shown on a page compiles and runs with the current toolchain.** daslang
 samples are gen2 and compile with the current binary; no pseudo-code presented as code.

--- a/site/files/dasllama/bench_records.json
+++ b/site/files/dasllama/bench_records.json
@@ -1605,6 +1605,195 @@
         "engine":"das",
         "backend":"metal",
         "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-12B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":11.734999999999999
+          },
+          "img:pp":{
+            "tok_s":137.05333571126727
+          },
+          "img:tg":{
+            "tok_s":34.940600978336825,
+            "text":"Two tabby cats are lying on a pink surface, with one cat on the left and the other on the right."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4uv f32; weights k4/k6/q8 native; q8 activations; f32 scales; metal blob",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-12B-it-Q4_K_M.gguf",
+            "sha256":"95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8",
+            "bytes":7381382944
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-12B-it-BF16.gguf",
+            "sha256":"9b1edfa05b634728ca4bfd60b4e6b278e95166c078fa54ae4fa83e680112fd1d",
+            "bytes":175115616
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-12B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":53.868000000000002
+          },
+          "img:pp":{
+            "tok_s":62.325558353103055
+          },
+          "img:tg":{
+            "tok_s":14.694673436438828,
+            "text":"Two tabby cats are lying on a pink surface, with one cat on the left and the other on the right."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4uv f32; weights k4/k6/q8 native; q8 activations; f32 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-12B-it-Q4_K_M.gguf",
+            "sha256":"95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8",
+            "bytes":7381382944
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-12B-it-BF16.gguf",
+            "sha256":"9b1edfa05b634728ca4bfd60b4e6b278e95166c078fa54ae4fa83e680112fd1d",
+            "bytes":175115616
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"accel",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-12B-it-Q4_K_M.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-12B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":16.34
+          },
+          "img:pp":{
+            "tok_s":62.393436210510657
+          },
+          "img:tg":{
+            "tok_s":14.681543964550745,
+            "text":"Two tabby cats are lying on a pink surface, with one cat on the left and one on the right."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4uv f32; weights k4/k6/q8 native; q8 activations; f32 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-12B-it-Q4_K_M.gguf",
+            "sha256":"95d83ba36642b1f385fb906b5962a71763361be3bac930a709945f72d97473f8",
+            "bytes":7381382944
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-12B-it-BF16.gguf",
+            "sha256":"9b1edfa05b634728ca4bfd60b4e6b278e95166c078fa54ae4fa83e680112fd1d",
+            "bytes":175115616
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
         "box":"m3air",
         "threads":4,
         "date":"2026-07-26",
@@ -2489,6 +2678,195 @@
             "name":"gemma-4-E4B-it-Q8_0.gguf",
             "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
             "bytes":8031242688
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E4B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":96.126000000000005
+          },
+          "img:pp":{
+            "tok_s":362.37186321855904
+          },
+          "img:tg":{
+            "tok_s":51.35126027225796,
+            "text":"The user wants a one-sentence description of the provided image.\nThe image contains two cats lying on a pink surface.\n\nPlan: Describe the main subjects"
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; metal blob",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E4B-it-Q8_0.gguf",
+            "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
+            "bytes":8031242688
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E4B-it-BF16.gguf",
+            "sha256":"f77995e4b6a569ab8f0d1bfdb7e8da4a0fa5b9e6f309b9bf3bdb76164d75e29f",
+            "bytes":991552256
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E4B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":419.255
+          },
+          "img:pp":{
+            "tok_s":196.65485056752573
+          },
+          "img:tg":{
+            "tok_s":21.798350273603354,
+            "text":"The user wants a one-sentence description of the provided image.\nThe image contains two cats lying on a pink surface.\n\nPlan: Describe the main subjects"
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v q8; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E4B-it-Q8_0.gguf",
+            "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
+            "bytes":8031242688
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E4B-it-BF16.gguf",
+            "sha256":"f77995e4b6a569ab8f0d1bfdb7e8da4a0fa5b9e6f309b9bf3bdb76164d75e29f",
+            "bytes":991552256
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"accel",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E4B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E4B-it-BF16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":480.98200000000003
+          },
+          "img:pp":{
+            "tok_s":202.40971359025528
+          },
+          "img:tg":{
+            "tok_s":21.949770693489288,
+            "text":"The user wants a one-sentence description of the provided image.\nThe image contains two cats lying on a pink surface.\n\nPlan: Describe the main subjects"
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E4B-it-Q8_0.gguf",
+            "sha256":"34be82b17b4942d389b9b527170c4b058027abdd32531fda063d3d97dd8ce80a",
+            "bytes":8031242688
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E4B-it-BF16.gguf",
+            "sha256":"f77995e4b6a569ab8f0d1bfdb7e8da4a0fa5b9e6f309b9bf3bdb76164d75e29f",
+            "bytes":991552256
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
           }
         ]
       },
@@ -13250,6 +13628,195 @@
             "name":"gemma-4-E2B-it-Q8_0.gguf",
             "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
             "bytes":4967497152
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"metal",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E2B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E2B-it-bf16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --ngl 99",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":90.968999999999994
+          },
+          "img:pp":{
+            "tok_s":682.06859161580303
+          },
+          "img:tg":{
+            "tok_s":93.042874156411273,
+            "text":": This is an image of two tabby cats lying on a pink surface."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; metal blob",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E2B-it-Q8_0.gguf",
+            "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
+            "bytes":4967497152
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E2B-it-bf16.gguf",
+            "sha256":"711e1e8f43fa0664adbac493129be1e6c25b81af4b4cdea97c7d798b25c0a3a4",
+            "bytes":986833664
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"tuned",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E2B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E2B-it-bf16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":422.83499999999998
+          },
+          "img:pp":{
+            "tok_s":362.82951199430636
+          },
+          "img:tg":{
+            "tok_s":42.981174245680393,
+            "text":": This is an image of two tabby cats lying on a pink surface."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v q8; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E2B-it-Q8_0.gguf",
+            "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
+            "bytes":4967497152
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E2B-it-bf16.gguf",
+            "sha256":"711e1e8f43fa0664adbac493129be1e6c25b81af4b4cdea97c7d798b25c0a3a4",
+            "bytes":986833664
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
+          }
+        ]
+      },
+      {
+        "engine":"das",
+        "backend":"cpu",
+        "flavor":"accel",
+        "box":"m1",
+        "threads":8,
+        "date":"2026-08-20",
+        "cmd":"modules/dasLLAMA/performance/_rig/dasllama-bench.app/Contents/MacOS/dasllama-bench -- -m /Users/borisbatkin/Work/llama.cpp/models/gemma-4-E2B-it-Q8_0.gguf --image-mmproj /Users/borisbatkin/Work/llama.cpp/models/mmproj-gemma-4-E2B-it-bf16.gguf --image /Users/borisbatkin/Work/llama.cpp/models/coco-val2017-000000039769.jpg -r 3 -t 8 -o json --json-path modules/dasLLAMA/performance/records/_cell_m1.json --accel",
+        "hardware":{
+          "cpu":"Apple M1 Max",
+          "arch":"arm64",
+          "os":"macOS 26.5.2",
+          "perf_cores":8,
+          "total_cores":10,
+          "ram_gb":64,
+          "gpu":"Apple M1 Max (32-core)",
+          "model_id":"MacBookPro18,2",
+          "remote_desktop":"off"
+        },
+        "tests":{
+          "img:enc":{
+            "ms":435.52100000000002
+          },
+          "img:pp":{
+            "tok_s":375.44493835242247
+          },
+          "img:tg":{
+            "tok_s":42.740035160802258,
+            "text":": This is an image of two tabby cats lying on a pink surface."
+          }
+        },
+        "workload":"image-chat",
+        "source":"official",
+        "sha":"075ae8cd2",
+        "version":"0.6.4",
+        "dasllama_version":6,
+        "tune":"k4q8_tile_gen=mr8 (manifest); k5q8_tile_gen=mr8 (manifest); k6q8_tile_gen=mr4 (manifest); q40q8_tile_gen=mr8 (manifest); q8q8_tile_gen=mr8_budget (manifest); q51q8_tile_gen=mr4 (manifest)",
+        "tune_sha":"5da27197acae9c957f852454476bc00a4dbbaa4717d43bd7ccbe31cc105aeb6a",
+        "noise":"ok",
+        "parity":"ok",
+        "exec_fmt":"tower gemma4v f32; weights q8 native; q8 activations; f16 scales; planar arm64-gen (repacked)",
+        "env":"DASLLAMA_BOX=m1",
+        "files":[
+          {
+            "role":"weights",
+            "name":"gemma-4-E2B-it-Q8_0.gguf",
+            "sha256":"996d08777aadc6bfd3c7375ef70ba25a0f55240075860754fdb18d6d860aa63a",
+            "bytes":4967497152
+          },
+          {
+            "role":"mmproj",
+            "name":"mmproj-gemma-4-E2B-it-bf16.gguf",
+            "sha256":"711e1e8f43fa0664adbac493129be1e6c25b81af4b4cdea97c7d798b25c0a3a4",
+            "bytes":986833664
+          },
+          {
+            "role":"image",
+            "name":"coco-val2017-000000039769.jpg",
+            "sha256":"dea9e7ef97386345f7cff32f9055da4982da5471c48d575146c796ab4563b04e",
+            "bytes":173131
           }
         ]
       },


### PR DESCRIPTION
The record rig now mints image-chat cells itself. Every official model with an mmproj companion gets `lcpp_bench --image` cells on each selected leg (metal / neon / amx), paired with the one pinned picture fixture. `-w image` narrows a sweep to just those cells. llama-bench has no image mode, so the cells are das-only — and an unset text reference is now loud: a warning at sweep start plus a skipped-pair list in the end summary, so a das-only board can no longer happen silently.

The oracle re-verifies stored image-chat rows. Before this change any non-empty workload fell into the ASR branch, so a stored image row vanished from `--oracle` with no log line. Image rows now have their own oracle arm (unfrozen, like the ASR twin), and a workload string no arm owns skips loudly.

First driver-minted cards ride along: 9 m1 rows — gemma-4-12B, E2B, E4B, each on metal/neon/amx. E2B on Metal serves the whole image turn at enc 91 ms, prefill 682 tok/s, decode 93 tok/s.

Where to look: `performance/gen_bench_records.das` (the image legs, the oracle arm, the ref-unset loudness), `performance/model_specs.das` (`mmproj_companion` / `bench_image_fixture`), `performance/profile_common.das` (`workload_scope` / `stored_row_leg`, both table-tested).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local-only: a full m1 publishing sweep minted all 9 cells with zero failures; `--oracle -w image -o gemma-4-E2B --legs metal` re-verified a stored row OK end to end (−0.3% / −1.4%); the dasLLAMA model-free suite ran green at the tip, 64/64 files; empty-models-dir smokes proved `-w image` visits exactly the three official vision rows and that both ref-UNSET warnings print.
- preflight `--full`: 19 passed; its one red (`docs/sphinx-html`) was unstaged tutorial recordings on this box — fixed by the docs-assets fetch, and the gate's exact invocation re-run green in isolation.

### Claims — stated, not tested
- The `refSkipped` end summary is `doLlm`-gated and was not reached by this branch's validation (reaching it needs a model on box with refs unset, which would re-mint a store row). Reviewed, not run; a break shows as a missing "N ref cell(s) SKIPPED" line on a ref-less `-w llm` sweep.
- Every figure quoted above is a value read from the 9 `workload:"image-chat"` rows in `records/m1.json`; no cross-engine image comparison is stated anywhere (llama-bench has no image mode).
- The driver's cell/oracle orchestration functions carry the same no-unit-harness status as the `das_cell` / ASR twins they mirror; the live sweep above is their settling run.

### Not done
- The site board has no image-chat section yet — `files/dasllama.js` renders LLM/asr/audio-chat only, so the 9 rows ship as data no page shows (the earlier hand-minted gemma-3-4b image row was equally inert). The renderer arm is a follow-up.
- gemma-3-4b stays off the official catalog: its stored image row oracle-verifies, but the sweep never re-mints it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)