### PR TITLE
dasllama-server native audio: input_audio through the serving slot, one mmproj, no ASR copy

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -543,6 +543,7 @@ jobs:
         $BIN/daslang _dasroot_/dastest/dastest.das -- --compile-only --color --failures-only --test ./utils/dasllama-server/test_openai_server.das
         $BIN/daslang _dasroot_/dastest/dastest.das -- --compile-only --color --failures-only --test ./utils/dasllama-server/test_openai_server_think.das
         $BIN/daslang _dasroot_/dastest/dastest.das -- --compile-only --color --failures-only --test ./utils/dasllama-server/test_openai_server_vision.das
+        $BIN/daslang _dasroot_/dastest/dastest.das -- --compile-only --color --failures-only --test ./utils/dasllama-server/test_openai_server_audio.das
         $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasllama-server/test_exchange_client.das
         $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasllama-server/test_model_catalog.das
         $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/dasllama-server/test_setup_mode.das

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -327,7 +327,7 @@ def document_module_dasllama(_root : string) {
         group_by_regex("Generation", mod, %regex~(generate|generate_embd)$%%),
         group_by_regex("Embeddings", mod, %regex~(embed)$%%),
         group_by_regex("Vision", mod, %regex~(encode_image)$%%),
-        group_by_regex("Chat", mod, %regex~(create_chat|create_chat_renderer|add_user|add_user_audio|add_user_image|add_assistant|render_turn|render_turn_image|render_assistant|render_close|respond|set_thinking)$%%),
+        group_by_regex("Chat", mod, %regex~(create_chat|create_chat_renderer|add_user|add_user_audio|add_user_image|add_assistant|render_turn|render_turn_image|render_turn_audio|render_assistant|render_close|respond|set_thinking)$%%),
         group_by_regex("Tool calling", mod, %regex~(set_tools|add_tool_results|render_assistant_calls|parse_calls)$%%),
         group_by_regex("Reasoning (thinking models)", mod, %regex~(split_reasoning|make_think_stream|think_feed|think_finish|think_drain|effective_stop_ids)$%%),
         group_by_regex("Operations: prepared images and dispatch", mod, %regex~(dlim_inventory|dlim_clean|set_dispatch_worker_limit|get_dispatch_worker_limit|select_matmul_backend_for_load|kernel_backend_available)$%%),

--- a/doc/source/reference/tutorials/dasLLAMA_08_audio_chat.rst
+++ b/doc/source/reference/tutorials/dasLLAMA_08_audio_chat.rst
@@ -97,7 +97,12 @@ identity — same prompt, both roads, greedy, byte-identical output:
 
 An audio turn is this exact array with a span of rows replaced by the
 tower's soft tokens. ``add_user_audio`` builds it for you; a custom modality
-builds it by hand and hands it to ``generate_embd``.
+builds it by hand and hands it to ``generate_embd``. A scheduler serving many
+streams builds it by hand too: ``render_turn_audio`` renders the turn's tokens
+as two spans — head before the audio rows, tail after, split exactly at the
+template's audio marker (``render_turn_image``'s audio twin) — and splices the
+encoder's rows between them. Unlike an image span, audio rows stay *causal*:
+sound has a left-to-right order.
 
 .. seealso::
 

--- a/modules/dasLLAMA/dasllama/dasllama.das
+++ b/modules/dasLLAMA/dasllama/dasllama.das
@@ -315,6 +315,13 @@ def render_turn_image(model : Model; chat : ChatSession; var head : array<int64>
     render_turn_image_(model, chat, head, tail)
 }
 
+def render_turn_audio(model : Model; chat : ChatSession; var head : array<int64>; var tail : array<int64>) {
+    //! ``render_turn``'s AUDIO twin: the same two-span contract around the audio soft-token splice
+    //! (the template's audio span markers). The rows come from the family's audio encoder — for the
+    //! gemma-4 E-series, ``gemma4a_encode_all`` over the shared vision+audio mmproj.
+    render_turn_audio_(model, chat, head, tail)
+}
+
 def render_assistant(model : Model; var chat : ChatSession; text : string; var out : array<int64>) {
     //! ``add_assistant``'s render half: appends the exact token stream a known reply prefills to
     //! ``out`` WITHOUT running the model, advancing the transcript like ``add_assistant``. Use on a

--- a/modules/dasLLAMA/dasllama/dasllama_arch_gemma4.das
+++ b/modules/dasLLAMA/dasllama/dasllama_arch_gemma4.das
@@ -48,6 +48,9 @@ def register_arch_gemma4() {
     // gemma4uv vision: the image soft-token span markers, media-first before the user text
     d.chat.image_pre.parts <- [chat_special("<|image>")]
     d.chat.image_post.parts <- [chat_special("<image|>")]
+    // gemma4a audio: same media-first span shape (the E-series mmproj carries both towers)
+    d.chat.audio_pre.parts <- [chat_special("<|audio>")]
+    d.chat.audio_post.parts <- [chat_special("<audio|>")]
     d.chat.tool_mode = ToolMode.gemma4   // <|tool>declaration DSL defs, <|tool_call> DSL calls
     d.chat.think_mode = ThinkMode.asymmetric
     d.chat.think_open = "<|channel>thought"

--- a/modules/dasLLAMA/dasllama/dasllama_audio_io.das
+++ b/modules/dasLLAMA/dasllama/dasllama_audio_io.das
@@ -6,6 +6,7 @@ module dasllama_audio_io shared public
 
 require dasllama/dasllama_lint public
 require daslib/defer
+require math
 require audio   // miniaudio: decode any audio container to PCM
 
 //! Decode any format miniaudio handles (wav / mp3 / flac / ogg …) to 16 kHz mono f32 PCM —
@@ -77,15 +78,15 @@ def decode_audio_16k_mono(bytes : array<uint8> | #; max_frames : int = 0) : arra
     let chunk = 16000
     var total = 0
     while (true) {
-        if (max_frames > 0 && total >= max_frames) {
-            samples |> resize(max_frames)
-            return <- samples
+        let want = max_frames > 0 ? min(chunk, max_frames - total) : chunk
+        if (want <= 0) {
+            break
         }
-        samples |> ensure_capacity(total + chunk)
-        samples |> resize(total + chunk)   // grow by a chunk, read straight into the tail
-        let got = int(ma_decoder_read_pcm_frames(decoder, unsafe(addr(samples[total])), uint64(chunk)))
+        samples |> ensure_capacity(total + want)
+        samples |> resize(total + want)   // grow by a chunk, read straight into the tail
+        let got = int(ma_decoder_read_pcm_frames(decoder, unsafe(addr(samples[total])), uint64(want)))
         total += got
-        if (got < chunk) {
+        if (got < want) {
             break
         }
     }

--- a/modules/dasLLAMA/dasllama/dasllama_audio_io.das
+++ b/modules/dasLLAMA/dasllama/dasllama_audio_io.das
@@ -5,6 +5,7 @@ options _dasllama_internal = true
 module dasllama_audio_io shared public
 
 require dasllama/dasllama_lint public
+require daslib/defer
 require audio   // miniaudio: decode any audio container to PCM
 
 //! Decode any format miniaudio handles (wav / mp3 / flac / ogg …) to 16 kHz mono f32 PCM —
@@ -41,10 +42,10 @@ def load_audio_16k_mono(path : string) : array<float> {
     return <- samples
 }
 
-//! ``load_audio_16k_mono``'s in-memory twin: decode an audio FILE's bytes (wav / mp3 / flac /
-//! ogg …) to 16 kHz mono f32 PCM without touching disk — the shape a server holding an upload
-//! or a base64 part wants. Empty array on a decode failure (corrupt / unsupported bytes).
-def decode_audio_16k_mono(bytes : array<uint8> | #) : array<float> {
+//! ``load_audio_16k_mono``'s in-memory twin: decode an audio FILE's bytes to 16 kHz mono f32 PCM
+//! without touching disk. ``max_frames`` (> 0) hard-caps the DECODED length — compressed audio inflates
+//! hundreds-fold over its bytes, so untrusted callers MUST pass one (0 = unbounded, trusted files only).
+def decode_audio_16k_mono(bytes : array<uint8> | #; max_frames : int = 0) : array<float> {
     var samples : array<float>
     if (empty(bytes)) {
         return <- samples
@@ -61,9 +62,25 @@ def decode_audio_16k_mono(bytes : array<uint8> | #) : array<float> {
         }
         return <- samples
     }
+    defer() {
+        ma_decoder_uninit(decoder)
+        unsafe {
+            delete decoder
+        }
+    }
+    if (max_frames > 0) {
+        let declared_frames_at_16k = int64(ma_decoder_get_length_in_pcm_frames(decoder))
+        if (declared_frames_at_16k > int64(max_frames)) {
+            return <- samples
+        }
+    }
     let chunk = 16000
     var total = 0
     while (true) {
+        if (max_frames > 0 && total >= max_frames) {
+            samples |> resize(max_frames)
+            return <- samples
+        }
         samples |> ensure_capacity(total + chunk)
         samples |> resize(total + chunk)   // grow by a chunk, read straight into the tail
         let got = int(ma_decoder_read_pcm_frames(decoder, unsafe(addr(samples[total])), uint64(chunk)))
@@ -73,9 +90,5 @@ def decode_audio_16k_mono(bytes : array<uint8> | #) : array<float> {
         }
     }
     samples |> resize(total)
-    ma_decoder_uninit(decoder)
-    unsafe {
-        delete decoder
-    }
     return <- samples
 }

--- a/modules/dasLLAMA/dasllama/dasllama_audio_io.das
+++ b/modules/dasLLAMA/dasllama/dasllama_audio_io.das
@@ -40,3 +40,42 @@ def load_audio_16k_mono(path : string) : array<float> {
     }
     return <- samples
 }
+
+//! ``load_audio_16k_mono``'s in-memory twin: decode an audio FILE's bytes (wav / mp3 / flac /
+//! ogg …) to 16 kHz mono f32 PCM without touching disk — the shape a server holding an upload
+//! or a base64 part wants. Empty array on a decode failure (corrupt / unsupported bytes).
+def decode_audio_16k_mono(bytes : array<uint8> | #) : array<float> {
+    var samples : array<float>
+    if (empty(bytes)) {
+        return <- samples
+    }
+    var decoder = new ma_decoder
+    var config <- ma_decoder_config_init(ma_format.ma_format_f32, 1u, 16000u)
+    var rc = ma_result.MA_ERROR
+    unsafe {
+        rc = ma_decoder_init_memory(addr(bytes[0]), uint64(length(bytes)), addr(config), decoder)
+    }
+    if (rc != ma_result.MA_SUCCESS) {
+        unsafe {
+            delete decoder
+        }
+        return <- samples
+    }
+    let chunk = 16000
+    var total = 0
+    while (true) {
+        samples |> ensure_capacity(total + chunk)
+        samples |> resize(total + chunk)   // grow by a chunk, read straight into the tail
+        let got = int(ma_decoder_read_pcm_frames(decoder, unsafe(addr(samples[total])), uint64(chunk)))
+        total += got
+        if (got < chunk) {
+            break
+        }
+    }
+    samples |> resize(total)
+    ma_decoder_uninit(decoder)
+    unsafe {
+        delete decoder
+    }
+    return <- samples
+}

--- a/modules/dasLLAMA/dasllama/dasllama_chat.das
+++ b/modules/dasLLAMA/dasllama/dasllama_chat.das
@@ -312,6 +312,10 @@ def private gate_vocab_ok(m : Model; tmpl : ChatTemplate) : bool => parts_vocab_
 def image_vocab_ok(m : Model; tmpl : ChatTemplate) : bool => (
     parts_vocab_ok(m, tmpl.image_pre.parts) && parts_vocab_ok(m, tmpl.image_post.parts))
 
+//! ``image_vocab_ok``'s AUDIO twin: every audio span marker resolves in the vocab.
+def audio_vocab_ok(m : Model; tmpl : ChatTemplate) : bool => (
+    parts_vocab_ok(m, tmpl.audio_pre.parts) && parts_vocab_ok(m, tmpl.audio_post.parts))
+
 // The thinking gate (gemma-4's <|think|> opening the system turn) renders THIS turn: first turn,
 // thinking on, gate declared with its specials in the vocab, and a system turn to carry it.
 def private think_gate_now(c : ChatSession) : bool {
@@ -766,6 +770,13 @@ def render_turn_(m : Model; c : ChatSession) : array<int64> {
 //! Render-only: no KV, no embedder — the rows come from `encode_image` on the caller's own.
 def render_turn_image_(m : Model; c : ChatSession; var head : array<int64>; var tail : array<int64>) {
     render_prompt_image(m, c, head, tail)
+    render_think_suppress(m, c, tail)
+}
+
+//! `render_turn_`'s AUDIO twin: the same two-span contract around the audio soft-token splice
+//! (the template's audio span markers). The rows come from the family's audio encoder.
+def render_turn_audio_(m : Model; c : ChatSession; var head : array<int64>; var tail : array<int64>) {
+    render_prompt_audio(m, c, head, tail)
     render_think_suppress(m, c, tail)
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_gemma4a.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma4a.das
@@ -329,22 +329,29 @@ def load_gemma4a_encoder(path : string) : Gemma4aEncoder {
     return <- built
 }
 
-//! META-only probe of an mmproj gguf: the gemma4a audio encoder's projection width, or 0 when
-//! the file carries no gemma4a audio encoder (wrong family, vision-only, unreadable). The cheap
-//! arm-time validation — no plane bytes are read.
+//! META-only probe of an mmproj gguf: the gemma4a audio encoder's projection width, or 0 for no
+//! gemma4a audio tower (wrong family, vision-only, unreadable, a `.dlim`). Gates on the audio TENSOR
+//! and derives the width like the loader (`clip.audio.*` is written unconditionally, see REVIEW_AUDIO.md).
 def gemma4a_probe_proj_dim(path : string) : int64 {
+    if (path |> ends_with(".dlim")) {
+        return 0l
+    }
     let f = fopen(path, "rb")
     if (f == null) {
         return 0l
     }
     var dim = 0l
     fmap(f) $(var bytes : array<uint8>#) {
+        if (length(bytes) < 4 || !(int(bytes[0]) == 'G' && int(bytes[1]) == 'G' && int(bytes[2]) == 'U' && int(bytes[3]) == 'F')) {
+            return
+        }
         var inscope m <- parse_gguf_meta(bytes)
-        let proj = (gguf_has(m, "clip.audio.projector_type")
-            ? gguf_str(m, bytes, "clip.audio.projector_type")
-            : (gguf_has(m, "clip.projector_type") ? gguf_str(m, bytes, "clip.projector_type") : ""))
-        if (proj == "gemma4a" && gguf_has(m, "clip.audio.projection_dim")) {
-            dim = gguf_int(m, bytes, "clip.audio.projection_dim")
+        let out_proj = gguf_find_tensor(m, "a.pre_encode.out.weight")
+        if (out_proj >= 0 && gguf_has(m, "clip.audio.embedding_length")) {
+            let d = gguf_int(m, bytes, "clip.audio.embedding_length")
+            if (d > 0l) {
+                dim = m.tensors[out_proj].n_elem / d
+            }
         }
     }
     fclose(f)
@@ -990,9 +997,9 @@ def gemma4a_encode_all(enc : Gemma4aEncoder; var st : Gemma4aState; samples : ar
         gemma4a_log_mel(enc, samples, off, len, st)
         asr_prof_add("g4a.mel", tmel)
         let n = gemma4a_encode(enc, st)
-        rows |> reserve(int(long_length(rows) + n * enc.proj_dim))
+        rows |> ensure_capacity(int(long_length(rows) + n * enc.proj_dim))
         for (i in range64(n * enc.proj_dim)) {
-            rows |> push(st.out[i])
+            rows |> push(st.out[i])   // nolint:PERF006,LINT019 — ensure_capacity above IS the reserve; exact reserve() defeats geometric growth (O(chunks^2)); PERF006 fires at the downstream instantiation
         }
         total += n
         off += chunk

--- a/modules/dasLLAMA/dasllama/dasllama_gemma4a.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma4a.das
@@ -329,6 +329,28 @@ def load_gemma4a_encoder(path : string) : Gemma4aEncoder {
     return <- built
 }
 
+//! META-only probe of an mmproj gguf: the gemma4a audio encoder's projection width, or 0 when
+//! the file carries no gemma4a audio encoder (wrong family, vision-only, unreadable). The cheap
+//! arm-time validation — no plane bytes are read.
+def gemma4a_probe_proj_dim(path : string) : int64 {
+    let f = fopen(path, "rb")
+    if (f == null) {
+        return 0l
+    }
+    var dim = 0l
+    fmap(f) $(var bytes : array<uint8>#) {
+        var inscope m <- parse_gguf_meta(bytes)
+        let proj = (gguf_has(m, "clip.audio.projector_type")
+            ? gguf_str(m, bytes, "clip.audio.projector_type")
+            : (gguf_has(m, "clip.projector_type") ? gguf_str(m, bytes, "clip.projector_type") : ""))
+        if (proj == "gemma4a" && gguf_has(m, "clip.audio.projection_dim")) {
+            dim = gguf_int(m, bytes, "clip.audio.projection_dim")
+        }
+    }
+    fclose(f)
+    return dim
+}
+
 // GEMM read: a q8 load transcodes from the file straight into qblob/qscales (the fp32 blob
 // never holds it); an fp32 load reads it like any plain tensor
 def private g4a_read_gemm(m : GGUFMeta; b : array<uint8> | #; name : string; var st : Gemma4aStaging;

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -128,8 +128,10 @@ guard trips on a path-require resolving into modules/dasLLAMA, name prefix or no
 `test_dasllama_lint_escape.das` — model-free: `options _dasllama_internal = true` admits a
 direct engine require (the lint's escape hatch).
 `test_dasllama_lint_contracts.das` — model-free: the lint's ALLOWED set (a facade-only program
-with no escape compiles; an internal require does not) via spawned compiles, and
-`load_audio_16k_mono`'s empty-on-failure contract.
+with no escape compiles; an internal require does not) via spawned compiles,
+`load_audio_16k_mono`'s empty-on-failure contract, `decode_audio_16k_mono`'s frame cap (a
+synthetic `sampleRate=1` WAV bomb is refused before decode, an uncapped call still works), and
+`gemma4a_probe_proj_dim`'s 0-not-panic contract on `.dlim` / missing / non-GGUF inputs.
 `test_think_split.das` — the reply-side reasoning matcher, model-free: every
 thinking family's wire shape, whole-string and per-chunk down to 1 byte.
 `test_tool_formats.das` — the per-ToolMode wire codecs (dasllama_tools), model-free: defs

--- a/modules/dasLLAMA/tests/test_arch_registry.das
+++ b/modules/dasLLAMA/tests/test_arch_registry.das
@@ -56,6 +56,9 @@ def test_audio_wrap_parts(t : T?) {
         let q3 <- arch_chat("qwen3vl")
         t |> equal(q3.audio_pre.parts[0].s, "<|audio_start|>", "qwen3vl audio_pre")
         t |> equal(q3.audio_post.parts[0].s, "<|audio_end|>", "qwen3vl audio_post")
+        let g4 <- arch_chat("gemma4")
+        t |> equal(g4.audio_pre.parts[0].s, "<|audio>", "gemma4 audio_pre matches gemma4a_transcribe's hand-rolled span")
+        t |> equal(g4.audio_post.parts[0].s, "<audio|>", "gemma4 audio_post matches gemma4a_transcribe's hand-rolled span")
         let lt <- arch_chat("llama")
         t |> success(empty(lt.audio_pre.parts) && empty(lt.audio_post.parts), "llama-3: bare embeddings")
     }

--- a/modules/dasLLAMA/tests/test_dasllama_lint_contracts.das
+++ b/modules/dasLLAMA/tests/test_dasllama_lint_contracts.das
@@ -3,6 +3,7 @@ options _dasllama_internal = true   // this file spawns fixtures; its own requir
 
 require dastest/testing_boost public
 require dasllama/dasllama_audio_io
+require dasllama/dasllama_gemma4a
 require daslib/fio
 require daslib/strings_boost
 require strings
@@ -58,5 +59,66 @@ def test_load_audio_16k_mono_contract(t : T?) {
     t |> run("a missing or unreadable file decodes to an EMPTY array, never a panic") @(t : T?) {
         let samples <- load_audio_16k_mono("this-file-does-not-exist.wav")
         t |> equal(0, length(samples), "empty on a missing file")
+    }
+}
+
+def private put_le(var b : array<uint8>; off : int; v : uint; nbytes : int) {
+    for (i in range(nbytes)) {
+        b[off + i] = uint8((v >> uint(i * 8)) & 0xFFu)
+    }
+}
+
+//! A mono 8-bit PCM WAV of `data_bytes` samples at `rate` Hz. A rate of 1 is the decompression
+//! bomb — miniaudio resamples it to 16 kHz, so a tiny file inflates into hours of PCM.
+def fill_wav(var b : array<uint8>; rate : uint; data_bytes : int) {
+    b |> resize(44 + data_bytes)
+    b[0] = uint8('R'); b[1] = uint8('I'); b[2] = uint8('F'); b[3] = uint8('F')
+    put_le(b, 4, uint(36 + data_bytes), 4)
+    b[8] = uint8('W'); b[9] = uint8('A'); b[10] = uint8('V'); b[11] = uint8('E')
+    b[12] = uint8('f'); b[13] = uint8('m'); b[14] = uint8('t'); b[15] = uint8(' ')
+    put_le(b, 16, 16u, 4)
+    put_le(b, 20, 1u, 2)
+    put_le(b, 22, 1u, 2)
+    put_le(b, 24, rate, 4)
+    put_le(b, 28, rate, 4)
+    put_le(b, 32, 1u, 2)
+    put_le(b, 34, 8u, 2)
+    b[36] = uint8('d'); b[37] = uint8('a'); b[38] = uint8('t'); b[39] = uint8('a')
+    put_le(b, 40, uint(data_bytes), 4)
+}
+
+[test]
+def test_decode_audio_frame_cap(t : T?) {
+    t |> run("a well-formed clip under the cap decodes; a bomb over the cap decodes to EMPTY") @(t : T?) {
+        let cap = 16000 * 10
+        var ok : array<uint8>
+        fill_wav(ok, 8000u, 8000)
+        let good <- decode_audio_16k_mono(ok, cap)
+        t |> success(!empty(good), "a short clip decodes ({length(good)} frames)")
+        t |> success(length(good) <= cap, "the decode never exceeds the cap")
+        var bomb : array<uint8>
+        fill_wav(bomb, 1u, 4096)
+        let refused <- decode_audio_16k_mono(bomb, cap)
+        t |> equal(0, length(refused), "the length-probe refuses the bomb before decoding it")
+        let uncapped <- decode_audio_16k_mono(ok, 0)
+        t |> success(!empty(uncapped), "cap 0 is unbounded (the trusted-local-file path)")
+        delete ok
+        delete bomb
+    }
+}
+
+[test]
+def test_gemma4a_probe_rejects_non_gguf(t : T?) {
+    t |> run("the audio probe returns 0 (never panics) on a .dlim path and on non-GGUF bytes") @(t : T?) {
+        t |> equal(0l, gemma4a_probe_proj_dim("some-prepared-image.dlim"), "a .dlim is not a gguf")
+        t |> equal(0l, gemma4a_probe_proj_dim("this-file-does-not-exist.gguf"), "a missing file is 0")
+        let dir_r = create_temp_directory_result("dasllama_probe")
+        if (dir_r is value) {
+            let dir = unsafe(dir_r.value)
+            let junk = path_join(dir, "junk.gguf")
+            fwrite(junk, "not a gguf at all")
+            t |> equal(0l, gemma4a_probe_proj_dim(junk), "non-GGUF bytes are 0, not a panic")
+            rmdir_rec_result(dir)
+        }
     }
 }

--- a/tutorials/dasLLAMA/08_audio_chat.das
+++ b/tutorials/dasLLAMA/08_audio_chat.das
@@ -41,7 +41,12 @@ require math
 // IS prefilling their embedding rows. Proof by identity — same prompt, both
 // roads, greedy, byte-identical output. An audio turn is this exact array with
 // a span of rows replaced by the tower's soft tokens; add_user_audio builds it
-// for you, and a custom modality builds it by hand.
+// for you, and a custom modality builds it by hand. A scheduler serving many
+// streams builds it by hand too: render_turn_audio renders the turn's tokens
+// as two spans — head before the audio rows, tail after, split exactly at the
+// template's audio marker (render_turn_image's audio twin) — and splices the
+// encoder's rows between them. Unlike an image span, audio rows stay CAUSAL:
+// sound has a left-to-right order.
 
 def section_splice(m : Model) {
     let prompt <- encode(m, "The capital of France is")

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -417,6 +417,5 @@ and warm-vs-cold TTFT for the prefix cache.
 ## Not yet implemented
 
 The request's `stop` / `response_format` fields and the forced-function `tool_choice` object form
-— all logged when a request carries them. On the image path: more than one image per request,
-images on earlier turns of a conversation, remote `image_url` fetches, and audio content parts in
-a chat message (`/v1/audio/*` takes audio today).
+— all logged when a request carries them. On the media path: more than one media clip per request,
+media on earlier turns of a conversation, and remote `image_url` fetches.

--- a/utils/dasllama-server/README.md
+++ b/utils/dasllama-server/README.md
@@ -31,7 +31,7 @@ Run under `-jit` — interpreted inference is far too slow. Flags:
 | `--asr` | `-a` | — | ASR model (whisper/parakeet/qwen3-asr) — enables the `/v1/audio/*` routes |
 | `--asr-workers` | — | `1` | Long-lived ASR request threads; each owns a model and reusable session. Set `2` for two parallel transcriptions |
 | `--mmproj` | — | — | mmproj GGUF for the Qwen3-ASR route (paired with `--asr`) |
-| `--image-mmproj` | — | — | Vision mmproj (gemma4uv, gemma4v, or gemma3v, sniffed) for the default model — enables `image_url` parts on `/v1/chat/completions`. Per-model in a `[[models]]` roster: `image_mmproj = "..."` |
+| `--image-mmproj` | — | — | Vision mmproj (gemma4uv, gemma4v, or gemma3v, sniffed) for the default model — enables `image_url` parts on `/v1/chat/completions`. Per-model in a `[[models]]` roster: `image_mmproj = "..."`. When the file also carries a gemma4a audio encoder (the E-series mmproj carries both towers), the same flag arms **native audio**: `input_audio` parts serve through the same slot — one decoder, one mmproj, no dedicated ASR model copy |
 | `--ctx` | — | *model* | Context-length cap in tokens (default: the model's trained `context_length`; set it to bound `--flat` KV or trim RAM) |
 | `--max-tokens` | — | `256` | Default reply token budget when a request omits `max_tokens` (clamped to `--ctx` per request) |
 | `--streams` | `-s` | `4` | Max concurrent generation streams |
@@ -172,10 +172,10 @@ Windows locks the DLLs.
 
 | Method | Path | Notes |
 |---|---|---|
-| `GET`  | `/` | Control page: live stats + charts, models panel (per-slot cards with state/GPU badges, prefix hit rate, switch telemetry, activate buttons; VRAM bar + switch strip), stream swimlane + live text cards, prefix-cache table, a chat panel (all sampling knobs, `<think>` inline, mic input under `--asr`), config editor with the `[[models]]` roster table + save/restart, GC + drain buttons. Serves `control.html` from beside the server sources — polls `/v1/stats` + `/v1/streams` at 1 Hz |
+| `GET`  | `/` | Control page: live stats + charts, models panel (per-slot cards with state/GPU badges, prefix hit rate, switch telemetry, activate buttons; VRAM bar + switch strip), stream swimlane + live text cards, prefix-cache table, a chat panel (all sampling knobs, `<think>` inline, mic input — dictation under `--asr`, else the clip attaches to the next message when the slot serves native audio), config editor with the `[[models]]` roster table + save/restart, GC + drain buttons. Serves `control.html` from beside the server sources — polls `/v1/stats` + `/v1/streams` at 1 Hz |
 | `GET`  | `/v1/models` | Lists every served slot (and `--asr` if loaded) — requests route on these ids via their `"model"` field |
 | `POST` | `/v1/models/activate` | `{"model": name}` admin warm-switch: make `name` the stepped slot and move the GPU tier to it now (instead of waiting for the owner to drain). `409` while any work is live, `404` on an unknown name; `200` reports `switch_ms` + `backend_effective` |
-| `POST` | `/v1/chat/completions` | Chat; `stream: true` → SSE, else buffered; OpenAI function calling (`tools`); `image_url` content parts under `--image-mmproj` |
+| `POST` | `/v1/chat/completions` | Chat; `stream: true` → SSE, else buffered; OpenAI function calling (`tools`); `image_url` content parts under `--image-mmproj`; `input_audio` content parts when the mmproj carries the audio tower (one image OR one audio clip per request, on the final user message — the soft tokens splice into the serving slot's prefill like vision, so continuous batching covers audio too) |
 | `POST` | `/v1/completions` | Raw completion; `stream: true` → SSE, else buffered |
 | `POST` | `/v1/embeddings` | Mean-pooled, L2-normalized sentence embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech→text (multipart upload; needs `--asr`). `response_format=verbose_json` adds timed segments |

--- a/utils/dasllama-server/control.html
+++ b/utils/dasllama-server/control.html
@@ -323,6 +323,7 @@ button:disabled { opacity: 0.45; cursor: default; }
     <div class="panel">
         <div class="chat-log" id="chat-log"><div class="ctl-note">talk to the served model — the conversation lives in this page only</div></div>
         <div class="img-strip" id="img-strip" style="display:none"></div>
+        <div class="img-strip" id="aud-strip" style="display:none"></div>
         <div class="chat-input">
             <textarea id="chat-text" rows="2" placeholder="message the model — Enter sends, Shift+Enter for a newline"></textarea>
             <input id="img-file" type="file" accept="image/*" style="display:none">
@@ -529,11 +530,13 @@ function apply(s) {
         $("kn-thinking").checked = s.thinking_default;
         thinkSeeded = true;
     }
+    micNativeAudio = !!s.audio && !(s.asr_workers > 0);   // no fast-ASR workers: the clip rides the chat natively
     if (micRec === null && !micDenied) {
         const bmic = $("b-mic");
         bmic.style.display = setupMode ? "none" : "";
-        bmic.classList.toggle("off", !(s.asr_workers > 0));
-        bmic.title = s.asr_workers > 0 ? "record, click again to stop + transcribe" : ASR_OFFER;
+        bmic.classList.toggle("off", !(s.asr_workers > 0 || s.audio));
+        bmic.title = s.asr_workers > 0 ? "record, click again to stop + transcribe"
+            : (s.audio ? "record, click again to stop — the clip attaches to your next message" : ASR_OFFER);
     }
     if (s.asr_workers > 0) {
         $("tile-asr").classList.remove("hide");
@@ -1170,7 +1173,12 @@ function attachImageFile(file) {
     if (!file || !file.type.startsWith("image/")) return;
     if (file.size > IMAGE_MAX_MB * 1024 * 1024) { alert("image over the server's " + IMAGE_MAX_MB + " MB cap (" + (file.size / 1048576).toFixed(1) + " MB)"); return; }
     const fr = new FileReader();
-    fr.onload = () => { chatImage = { url: String(fr.result), name: file.name || "pasted image" }; renderImgStrip(); };
+    fr.onload = () => {
+        chatImage = { url: String(fr.result), name: file.name || "pasted image" };
+        chatAudio = null;   // the server takes ONE media clip per message
+        renderAudioStrip();
+        renderImgStrip();
+    };
     fr.readAsDataURL(file);
 }
 
@@ -1214,7 +1222,7 @@ $("chat-text").addEventListener("paste", e => {
 async function sendChat() {
     const ta = $("chat-text");
     const text = ta.value.trim();
-    if (!text || chatBusy) return;
+    if ((!text && !chatAudio) || chatBusy) return;
     chatBusy = true;
     $("b-send").disabled = true;
     ta.value = "";
@@ -1226,8 +1234,14 @@ async function sendChat() {
         shot.src = chatImage.url;
         ub.append(shot);
     }
+    if (chatAudio) {
+        const clip = document.createElement("span");
+        clip.className = "note";
+        clip.textContent = "● " + chatAudio.seconds.toFixed(1) + "s audio clip";
+        ub.append(clip);
+    }
     renderMsgContent(ub, text, "", null, true);
-    // the image goes onto the newest message only — the wire copy carries the parts array,
+    // media goes onto the newest message only — the wire copy carries the parts array,
     // chatMsgs keeps plain text so a long conversation does not resend old base64
     const wire = chatMsgs.slice();
     if (chatImage) {
@@ -1235,6 +1249,13 @@ async function sendChat() {
             { type: "image_url", image_url: { url: chatImage.url } },
             { type: "text", text: text },
         ] };
+    } else if (chatAudio) {
+        wire[wire.length - 1] = { role: "user", content: [
+            { type: "input_audio", input_audio: { data: chatAudio.b64, format: "wav" } },
+            { type: "text", text: text },
+        ] };
+        chatAudio = null;   // a clip rides ONE message; the image strip persists by design
+        renderAudioStrip();
     }
     const body = { messages: wire, stream: true };
     for (const kn of KNOBS) {
@@ -1343,6 +1364,23 @@ function encodeWav(chunks, sampleRate) {
 }
 
 let micDenied = false;   // mic permission refused — keep the button down instead of re-showing it
+let micNativeAudio = false;   // stats says: attach the clip to the chat (native audio) instead of transcribing
+let chatAudio = null;   // { b64, seconds } — rides the NEXT message as an input_audio part, then clears
+
+function renderAudioStrip() {
+    const strip = $("aud-strip");
+    strip.textContent = "";
+    if (!chatAudio) { strip.style.display = "none"; return; }
+    strip.style.display = "";
+    const note = document.createElement("span");
+    note.className = "note";
+    note.textContent = "● " + chatAudio.seconds.toFixed(1) + "s clip — rides your next message";
+    const x = document.createElement("button");
+    x.type = "button";
+    x.textContent = "remove";
+    x.addEventListener("click", () => { chatAudio = null; renderAudioStrip(); });
+    strip.append(note, x);
+}
 
 async function micToggle() {
     const btn = $("b-mic");
@@ -1360,6 +1398,21 @@ async function micToggle() {
         const rate = ctx.sampleRate;
         await ctx.close();
         if (!chunks.length) return;
+        if (micNativeAudio) {
+            // native audio: the wav attaches to the next chat message as an input_audio part —
+            // the model hears the clip itself, no transcription pass
+            const blob = encodeWav(chunks, rate);
+            const fr = new FileReader();
+            fr.onload = () => {
+                chatAudio = { b64: String(fr.result).split(",")[1] || "",
+                              seconds: chunks.reduce((n, c) => n + c.length, 0) / rate };
+                chatImage = null;   // the server takes ONE media clip per message
+                renderImgStrip();
+                renderAudioStrip();
+            };
+            fr.readAsDataURL(blob);
+            return;
+        }
         btn.disabled = true;
         try {
             const fd = new FormData();

--- a/utils/dasllama-server/main.das
+++ b/utils/dasllama-server/main.das
@@ -972,6 +972,11 @@ def init() {   // nolint:STYLE037,STYLE038 — boot sequence: the knobs are orde
                                                          : (i == def_idx ? g_cfg.image_mmproj : ""))
             if (!empty(path)) {
                 set_model_vision(g_models[i].name, path)
+                // the E-series mmproj carries BOTH towers: the same file arms native audio, so
+                // one download gives text + vision + audio off the one serving slot
+                if (gemma4a_probe_proj_dim(path) > 0l) {
+                    set_model_audio(g_models[i].name, path)
+                }
             }
         }
 

--- a/utils/dasllama-server/model_catalog.das
+++ b/utils/dasllama-server/model_catalog.das
@@ -85,6 +85,12 @@ def public catalog_env_override : string
 def public gpu_env_master_off : bool
     => is_some(g_env_gpu.gpu) && !unwrap(g_env_gpu.gpu)
 
+//! The engine noisy-diagnostics switch (`DASLLAMA_NOISY`) read the facade-only way, like
+//! [[gpu_env_master_off]]. The server gates its optional [tickprof] serving-loop profile on it,
+//! so a production server pays no clock reads and emits no profile lines unless noisy is on.
+def public env_noisy_diag : bool
+    => g_env_engine.noisy
+
 def private strip_trailing_sep(p : string) : string {
     if (!ends_with(p, "/") && !ends_with(p, "\\")) {
         return p

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -2103,7 +2103,9 @@ def private park_media_request(srv : WebSocketServer; var writer : HttpResponseW
     let rid = next_id()
     set_writer_keepalive_timeout(srv, writer, LLM_WRITER_KEEPALIVE_MS)
     g_media_wires[rid] <- MediaWire(writer = writer, js = js, slot = g_cur, is_audio = is_audio)
-    var vjob = MediaJob(id = rid, slot = g_cur, file_bytes <- file_bytes, tag = "req{rid}", is_audio = is_audio)
+    let max_audio_frames = is_audio ? audio_decode_frame_cap(g_slots[g_cur].model.config.seq_len) : 0
+    var vjob = MediaJob(id = rid, slot = g_cur, file_bytes <- file_bytes, tag = "req{rid}", is_audio = is_audio,
+                        max_audio_frames = max_audio_frames)
     g_media_jobs |> push_clone(vjob)
     delete vjob
     to_log(LOG_INFO, "[req {rid}] {is_audio ? "audio" : "image"} parked for the media worker ({length(g_media_wires)} in flight)\n")
@@ -3469,6 +3471,7 @@ struct private MediaJob {
     file_bytes : array<uint8>   // the base64-decoded media FILE (image or audio); the worker decodes + encodes
     tag : string                // DASLLAMA_VISION_DUMP artifact name (image jobs)
     is_audio : bool             // audio job: decode to 16 kHz PCM, encode via the slot's gemma4a encoder
+    max_audio_frames : int
     stop : bool
 }
 
@@ -3501,6 +3504,16 @@ struct private MediaWire {
 
 let MEDIA_QUEUE_LIMIT = 8   // parked image requests are heavy (decoded bytes ride the channel)
 
+let GEMMA4A_AUDIO_SOFT_TOKENS_PER_SEC = 25l
+let AUDIO_DECODE_SAMPLE_RATE = 16000l
+
+//! The 16 kHz decode-frame ceiling for a clip a model with `seq_len` context can hold: the clip's
+//! soft tokens must fit the context, so the longest usable clip is `seq_len / tokens-per-sec`
+//! seconds. Caps the decode of an untrusted upload before a compressed bomb reaches the encoder.
+def private audio_decode_frame_cap(seq_len : int64) : int {
+    return int(seq_len / GEMMA4A_AUDIO_SOFT_TOKENS_PER_SEC * AUDIO_DECODE_SAMPLE_RATE)
+}
+
 var private g_media_jobs : Channel?
 var private g_media_events : Channel?
 var private g_media_wires : table<int64; MediaWire>
@@ -3528,9 +3541,9 @@ def private media_encode_one(job : MediaJob; var embs : table<int; VisionEmbedde
     var failure = ""
     let failed = catch_worker_panic(failure) {
         if (job.is_audio) {
-            var inscope samples <- decode_audio_16k_mono(job.file_bytes)
+            var inscope samples <- decode_audio_16k_mono(job.file_bytes, job.max_audio_frames)
             if (empty(samples)) {
-                out.why = "the audio bytes did not decode (wav/mp3/flac/ogg are supported)"
+                out.why = "the audio did not decode, or it is longer than this model's context can hold (wav/mp3/flac/ogg, up to ~{job.max_audio_frames / int(AUDIO_DECODE_SAMPLE_RATE)}s)"
             } else {
                 let t0 = ref_time_ticks()
                 out.n_media = gemma4a_encode_all(auds[job.slot], astates[job.slot], samples, out.rows)
@@ -3987,13 +4000,7 @@ var private g_prof_reap_us = 0l
 var private g_prof_step_us = 0l
 var private g_prof_flush_us = 0l
 
-def private prof_window_report() {
-    let win_us = int64(get_time_usec(g_prof_win))
-    if (win_us < 5_000_000l || g_prof_busy == 0l) {
-        return
-    }
-    let n = g_prof_ticks
-    to_log(LOG_INFO, "dasllama-server: [tickprof] {n} ticks ({g_prof_busy} busy) in {win_us / 1000l}ms | per-tick us: pump={g_prof_pump_us / n} drain={g_prof_drain_us / n} reap={g_prof_reap_us / n} step={g_prof_step_us / n} flush={g_prof_flush_us / n} | sandwich total {(g_prof_pump_us + g_prof_drain_us + g_prof_reap_us + g_prof_flush_us) / 1000l}ms vs step {g_prof_step_us / 1000l}ms\n")
+def private prof_window_reset() {
     g_prof_win = ref_time_ticks()
     g_prof_ticks = 0l
     g_prof_busy = 0l
@@ -4002,6 +4009,18 @@ def private prof_window_report() {
     g_prof_reap_us = 0l
     g_prof_step_us = 0l
     g_prof_flush_us = 0l
+}
+
+def private prof_window_report() {
+    let win_us = int64(get_time_usec(g_prof_win))
+    if (win_us < 5_000_000l) {
+        return
+    }
+    let n = g_prof_ticks
+    if (g_prof_busy > 0l && n > 0l) {
+        to_log(LOG_INFO, "dasllama-server: [tickprof] {n} ticks ({g_prof_busy} busy) in {win_us / 1000l}ms | per-tick us: pump={g_prof_pump_us / n} drain={g_prof_drain_us / n} reap={g_prof_reap_us / n} step={g_prof_step_us / n} flush={g_prof_flush_us / n} | sandwich total {(g_prof_pump_us + g_prof_drain_us + g_prof_reap_us + g_prof_flush_us) / 1000l}ms vs step {g_prof_step_us / 1000l}ms\n")
+    }
+    prof_window_reset()
 }
 
 def update_server() : bool {

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -66,8 +66,10 @@ struct ModelSlot {
     gpu_want : GpuTierWant = GpuTierWant()   // the tier request this slot re-arms with on switch-in
     gpu_capable : bool              // want is non-zero and backend != cpu (set_slot_gpu_want)
     gpu_marks : GpuModelMarks <- gpu_model_marks_init()   // this model's tier routing marks while NOT installed
-    vision : VisionEmbedder = VisionEmbedder()   // set_model_vision; kind == none = text only (encode runs on the vision worker)
+    vision : VisionEmbedder = VisionEmbedder()   // set_model_vision; kind == none = text only (encode runs on the media worker)
     vision_path : string                             // the worker loads its own embedder from this
+    audio_armed : bool                           // set_model_audio; the media worker owns the encoder itself
+    audio_path : string                              // the mmproj the worker loads the audio encoder from
     think_default : bool   // family default when the request sends no enable_thinking (THINKING.md's table)
 }
 
@@ -329,6 +331,40 @@ def set_model_vision(name : string; path : string) {
     to_log(LOG_INFO, "dasllama-server: {name} vision arm: {base_name(path)} ({vision_family(g_slots[mi].vision)}, {vision_proj_dim(g_slots[mi].vision)}-wide, {vision_align(g_slots[mi].vision)}px per token)\n")
 }
 
+//! Give slot `name` an audio arm: the mmproj at `path` must carry a gemma4a audio encoder (the
+//! E-series mmproj carries BOTH towers, so the same file arms vision and audio). The chat route
+//! then accepts `input_audio` content parts and `/v1/audio/transcriptions` serves through THIS
+//! slot — no second decoder copy. Same call contract as ``set_model_vision``: once per slot,
+//! before ``init_server`` (the media worker snapshots the arms at init); a bad pair PANICS here.
+def set_model_audio(name : string; path : string) {
+    if (g_server_started) {
+        panic("dasllama-server: set_model_audio after init_server - the media worker snapshots the arms at init; arm the slot before starting")
+    }
+    let mi = slot_index(name)
+    if (mi < 0) {
+        panic("dasllama-server: audio mmproj names slot '{name}', which is not served")
+    }
+    if (g_slots[mi].audio_armed) {
+        panic("dasllama-server: slot '{name}' already has an audio arm ({base_name(g_slots[mi].audio_path)}) - set_model_audio is once per slot")
+    }
+    let proj_dim = gemma4a_probe_proj_dim(path)
+    if (proj_dim == 0l) {
+        panic("dasllama-server: {base_name(path)} carries no gemma4a audio encoder - it cannot arm audio for {name}")
+    }
+    if (proj_dim != g_slots[mi].model.config.dim) {
+        panic("dasllama-server: {base_name(path)}'s audio encoder projects to {proj_dim} but {name} is {g_slots[mi].model.config.dim}-wide - mismatched pair")
+    }
+    var probe <- create_chat_renderer(g_slots[mi].model, "", 1l)
+    let no_markers = empty(probe.tmpl.audio_pre.parts) || !audio_vocab_ok(g_slots[mi].model, probe.tmpl)
+    delete probe
+    if (no_markers) {
+        panic("dasllama-server: {name}'s chat template or vocab carries no audio span markers - it has no audio arm")
+    }
+    g_slots[mi].audio_armed = true
+    g_slots[mi].audio_path = path
+    to_log(LOG_INFO, "dasllama-server: {name} audio arm: {base_name(path)} (gemma4a, {proj_dim}-wide)\n")
+}
+
 //! Configure long-lived ASR worker threads. Each worker loads and owns its model in its cloned
 //! context; model/session pointers never cross context heaps. Call once before ``run_server``.
 def configure_asr_workers(path, mmproj : string; workers : int = 1) {
@@ -535,7 +571,7 @@ def private handle_bench_start(var resp : HttpResponse?) : http_status {
             error_body(empty(g_lcpp_bin) ? "set lcpp_bin in the config to enable benchmarking" : "benchmarking needs a source-tree daslang (standalone exe cannot spawn the bench child)", "invalid_request_error"),
             http_status.BAD_REQUEST)
     }
-    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0 || !empty(g_vision_wires)) {
+    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0 || !empty(g_media_wires)) {
         return resp |> JSON(
             error_body("streams are active — contended numbers are misleading; drain first, then bench", "invalid_request_error"),
             http_status.CONFLICT)
@@ -688,7 +724,7 @@ def private handle_bake_start(var req : HttpRequest?; var resp : HttpResponse?) 
             error_body("baking needs a source-tree daslang (standalone exe cannot spawn the converter child)", "invalid_request_error"),
             http_status.BAD_REQUEST)
     }
-    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0 || !empty(g_vision_wires)) {
+    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0 || !empty(g_media_wires)) {
         return resp |> JSON(
             error_body("streams are active — the converter competes for cores and RAM; drain first, then bake", "invalid_request_error"),
             http_status.CONFLICT)
@@ -1473,7 +1509,7 @@ def private warn_ignored_fields(js : JsonValue?; known : table<string>; route : 
 // A message's content: a plain string, or the OpenAI content-parts array (agents send
 // [\{type:"text", text:"..."}] even for pure text). Text parts concatenate into the return value;
 // `image_url` parts push their url into `images` for the caller to decide on; anything else logs.
-def private message_parts(mv : JsonValue?; route : string; var images : array<string>) : string {
+def private message_parts(mv : JsonValue?; route : string; var images : array<string>; var audios : array<string>) : string {
     let cv = mv?["content"]
     if (cv == null || cv.value is _null) {
         return ""
@@ -1493,6 +1529,10 @@ def private message_parts(mv : JsonValue?; route : string; var images : array<st
                 images |> push(uv != null && uv.value is _string ? (uv ?? "") : (uv?["url"] ?? ""))
             } elif (ptype == "input_image") {   // the Responses-API spelling: image_url is a string
                 images |> push(pv?["image_url"] ?? "")
+            } elif (ptype == "input_audio") {
+                // OpenAI shape: input_audio: \{data: <base64 of the audio FILE>, format: "wav"|"mp3"}
+                // — the decoder sniffs the container, so `format` is not needed here
+                audios |> push(pv?["input_audio"]?["data"] ?? "")
             } else {
                 to_log(LOG_WARNING, "{route}: skipping non-text content part '{ptype}'\n")
             }
@@ -1505,14 +1545,19 @@ def private message_parts(mv : JsonValue?; route : string; var images : array<st
     return ""
 }
 
-// `message_parts` for routes with no image path: image parts warn and drop.
+// `message_parts` for routes with no media path: image/audio parts warn and drop.
 def private message_text(mv : JsonValue?; route : string) : string {
     var images : array<string>
-    let s = message_parts(mv, route, images)
+    var audios : array<string>
+    let s = message_parts(mv, route, images, audios)
     if (!empty(images)) {
         to_log(LOG_WARNING, "{route}: skipping {length(images)} image content part(s) — no vision arm on this path\n")
     }
+    if (!empty(audios)) {
+        to_log(LOG_WARNING, "{route}: skipping {length(audios)} audio content part(s) — no audio arm on this path\n")
+    }
     delete images
+    delete audios
     return s
 }
 
@@ -1542,17 +1587,40 @@ def private decode_data_uri_bytes(url : string; var bytes : array<uint8>; var wh
     }
     var raw : array<uint8>
     defer() { delete raw }
-    peek_data(url) $(d) {
-        raw |> reserve(length(d) - payload_at)
-        for (i in range(payload_at, length(d))) {
+    strip_b64_whitespace(url, payload_at, raw)
+    if (base64_decode(raw, bytes) <= 0) {
+        why = "image_url payload is not valid base64"
+        return false
+    }
+    return true
+}
+
+// base64 wire bytes minus the whitespace GNU `base64` wraps with, from `from` to the end
+def private strip_b64_whitespace(s : string; from : int; var raw : array<uint8>) {
+    peek_data(s) $(d) {
+        raw |> reserve(length(d) - from)
+        for (i in range(from, length(d))) {
             let b = int(d[i])
             if (b != '\n' && b != '\r' && b != ' ' && b != '\t') {
                 raw |> push(d[i])
             }
         }
     }
+}
+
+// `decode_data_uri_bytes`' RAW twin for input_audio.data: bare base64 of the audio file (the
+// OpenAI shape carries no data: prefix), whitespace-tolerant, under the same size cap.
+def private decode_base64_bytes(data : string; var bytes : array<uint8>; var why : string&) : bool {
+    let max_encoded = (IMAGE_MAX_FILE_BYTES / 3) * 4 + 8
+    if (length(data) > max_encoded) {
+        why = "audio payload exceeds the {IMAGE_MAX_FILE_BYTES / (1024 * 1024)} MB cap (wrapped base64 counts its newlines)"
+        return false
+    }
+    var raw : array<uint8>
+    defer() { delete raw }
+    strip_b64_whitespace(data, 0, raw)
     if (base64_decode(raw, bytes) <= 0) {
-        why = "image_url payload is not valid base64"
+        why = "input_audio.data is not valid base64"
         return false
     }
     return true
@@ -1683,7 +1751,7 @@ def private handle_activate(var req : HttpRequest?; var resp : HttpResponse?) : 
             error_body("model '{want}' not found — GET /v1/models lists the served ids{empty(g_slots) ? " (setup mode: no model loaded yet — download one from /catalog)" : ""}", "model_not_found"),
             http_status.NOT_FOUND)
     }
-    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0 || !empty(g_vision_wires)) {
+    if (total_active() > 0l || total_queued() > 0l || g_asr_pending > 0 || !empty(g_media_wires)) {
         return resp |> JSON(
             error_body("streams are live (active {total_active()}, queued {total_queued()}) — retry when idle", "busy"),
             http_status.CONFLICT)
@@ -1725,7 +1793,8 @@ def private register_request(srv : WebSocketServer; var writer : HttpResponseWri
                              streaming, is_chat : bool; prefix : string;
                              tools_declared : bool = false; call_open : string = ""; call_close : string = "";
                              seed : int = 0; think : ThinkStream = ThinkStream();
-                             tool_mode : ToolMode = ToolMode.none; reuse_id : int64 = 0l) {
+                             tool_mode : ToolMode = ToolMode.none; reuse_id : int64 = 0l;
+                             media_is_audio : bool = false) {
     let np = long_length(prompt) + n_media
     if (np + 1l > cur_model().config.seq_len) {
         bad_request(srv, writer, "the rendered prompt is {np} tokens; the model context is {cur_model().config.seq_len} — shorten the conversation or raise --ctx")
@@ -1736,7 +1805,7 @@ def private register_request(srv : WebSocketServer; var writer : HttpResponseWri
     let created = created_ts()
     var preq <- PendingReq(id = rid, params = params, max_new = max_new, seed = seed,
                            media_at = media_at, n_media = n_media,
-                           media_non_causal = n_media > 0l)   // image rows only on this route: the gemma image span is non-causal
+                           media_non_causal = n_media > 0l && !media_is_audio)   // gemma image span rows attend in full; audio rows stay causal
     preq.prompt <- prompt
     preq.stop_ids <- stop_ids
     preq.close_toks <- close_toks
@@ -1771,7 +1840,7 @@ def private register_request(srv : WebSocketServer; var writer : HttpResponseWri
 // Render a user-led suffix of the transcript. System messages are always retained (they were
 // folded into `system`); `start` applies only to conversational messages in the original array.
 def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : array<string>;   // nolint:STYLE037,STYLE038 — one arm per message role, each accumulating into the same renderer state
-                               max_new : int64; start : int; think_set, think_val, has_image : bool;
+                               max_new : int64; start : int; think_set, think_val, has_media, media_is_audio : bool;
                                var prompt, stop_ids, close : array<int64>&;
                                var call_open, call_close : string&; var think_out : ThinkStream&;
                                var tool_mode_out : ToolMode&; var media_at : int64&) : string {
@@ -1809,6 +1878,8 @@ def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : arr
     var pending = false
     var seen_images : array<string>   // handle_chat already validated and queued these
     defer() { delete seen_images }
+    var seen_audios : array<string>   // ditto for input_audio parts
+    defer() { delete seen_audios }
     var tool_results : array<string>
     var tool_names : array<string>
     defer() {
@@ -1821,7 +1892,7 @@ def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : arr
         if (role != "system" && i < start) {
             continue
         }
-        let content = message_parts(mv, "/v1/chat/completions", seen_images)
+        let content = message_parts(mv, "/v1/chat/completions", seen_images, seen_audios)
         if (role != "tool" && !empty(tool_results)) {
             add_tool_results(chat, tool_results, tool_names)
             tool_results |> clear()
@@ -1882,12 +1953,16 @@ def private render_chat_suffix(msgs_v : JsonValue?; system : string; tools : arr
         return "the last message must be a user or tool message"
     }
     media_at = 0l
-    if (has_image) {
-        // the image turn renders as TWO token spans; the soft-token rows prefill between them, so
+    if (has_media) {
+        // the media turn renders as TWO token spans; the soft-token rows prefill between them, so
         // the scheduler gets one flat prompt plus the index the rows splice at
         var head : array<int64>
         var tail : array<int64>
-        render_turn_image(cur_model(), chat, head, tail)
+        if (media_is_audio) {
+            render_turn_audio(cur_model(), chat, head, tail)
+        } else {
+            render_turn_image(cur_model(), chat, head, tail)
+        }
         media_at = long_length(rendered) + long_length(head)
         rendered |> push_from(head, tail)
         delete head
@@ -1942,72 +2017,105 @@ def private handle_chat(srv : WebSocketServer; var req : HttpRequest?; var write
         bad_request(srv, writer, "'messages' must be an array")
         return
     }
-    // v1 vision: ONE image, on the FINAL message (a user message carrying it). Any other
-    // placement warns and drops — an earlier turn has no render seam (replays go through
-    // render_assistant, which has no splice), and a trailing tool turn must render as tools.
-    {
-        var images : array<string>
-        defer() { delete images }
-        let n_msgs = length(msgs_v.value as _array)
-        for (i in range(n_msgs)) {
-            var here : array<string>
-            message_parts((msgs_v.value as _array)[i], "/v1/chat/completions", here)
-            let is_final_user = i == n_msgs - 1 && ((msgs_v.value as _array)[i]?["role"] ?? "") == "user"
-            if (!empty(here) && !is_final_user) {
-                to_log(LOG_WARNING, "/v1/chat/completions: dropping {length(here)} image(s) on message {i} — the image is read from the FINAL user message only\n")
-            } elif (!empty(here)) {
-                images |> push_from(here)
-            }
-            delete here
-        }
-        if (!empty(images)) {
-            if (g_slots[g_cur].vision.kind == VisionKind.none) {
-                bad_request(srv, writer, "model '{cur_name()}' has no vision arm — start the server with an image mmproj for it to accept image_url parts")
-                return
-            }
-            if (length(images) > 1) {
-                bad_request(srv, writer, "one image per request — this message carries {length(images)}")
-                return
-            }
-            if (!g_vision_armed || g_vision_ready < 1) {
-                service_unavailable(srv, writer, "the vision worker is not ready")
-                return
-            }
-            if (length(g_vision_wires) >= VISION_QUEUE_LIMIT) {
-                service_unavailable(srv, writer, "the vision queue is at capacity ({VISION_QUEUE_LIMIT}) — retry shortly")
-                return
-            }
-            var file_bytes : array<uint8>
-            var why = ""
-            if (!decode_data_uri_bytes(images[0], file_bytes, why)) {
-                delete file_bytes
-                bad_request(srv, writer, why)
-                return
-            }
-            // park at the encode boundary: the worker decodes + encodes off-thread, and
-            // drain_vision_events resumes at handle_chat_tail with the rows
-            let rid = next_id()
-            set_writer_keepalive_timeout(srv, writer, LLM_WRITER_KEEPALIVE_MS)
-            g_vision_wires[rid] <- VisionWire(writer = writer, js = js, slot = g_cur)
-            var vjob = VisionJob(id = rid, slot = g_cur, file_bytes <- file_bytes, tag = "req{rid}")
-            g_vision_jobs |> push_clone(vjob)
-            delete vjob
-            to_log(LOG_INFO, "[req {rid}] image parked for the vision worker ({length(g_vision_wires)} in flight)\n")
-            js = null   // ownership parked with the wire; the defer above must not free it
-            return
-        }
+    let parked = park_media_request(srv, writer, js, msgs_v)
+    if (parked == MediaPark.parked) {
+        js = null   // ownership parked with the wire; the defer above must not free it
+        return
+    }
+    if (parked == MediaPark.answered) {
+        return   // an error already went out; the defer frees js
     }
     var no_media : array<float>
     defer() { delete no_media }
     handle_chat_tail(srv, writer, js, g_cur, no_media, 0l)
 }
 
+enum private MediaPark {
+    none       // no media parts — the caller continues as a text request
+    answered   // a validation error already went out; the caller returns (and frees js)
+    parked     // the request is parked with the media worker, which now owns js
+}
+
+// The chat route's media boundary: ONE image or ONE audio clip, on the FINAL message (a user
+// message carrying it). Any other placement warns and drops — an earlier turn has no render seam
+// (replays go through render_assistant, which has no splice), and a trailing tool turn must render
+// as tools.
+def private park_media_request(srv : WebSocketServer; var writer : HttpResponseWriter?;
+                               var js : JsonValue?; msgs_v : JsonValue?) : MediaPark {
+    var images : array<string>
+    defer() { delete images }
+    var audios : array<string>
+    defer() { delete audios }
+    let n_msgs = length(msgs_v.value as _array)
+    for (i in range(n_msgs)) {
+        var img_here : array<string>
+        var aud_here : array<string>
+        message_parts((msgs_v.value as _array)[i], "/v1/chat/completions", img_here, aud_here)
+        let is_final_user = i == n_msgs - 1 && ((msgs_v.value as _array)[i]?["role"] ?? "") == "user"
+        if ((!empty(img_here) || !empty(aud_here)) && !is_final_user) {
+            to_log(LOG_WARNING, "/v1/chat/completions: dropping {length(img_here) + length(aud_here)} media part(s) on message {i} — media is read from the FINAL user message only\n")
+        } else {
+            images |> push_from(img_here)
+            audios |> push_from(aud_here)
+        }
+        delete img_here
+        delete aud_here
+    }
+    if (empty(images) && empty(audios)) {
+        return MediaPark.none
+    }
+    if (!empty(images) && !empty(audios)) {
+        bad_request(srv, writer, "one media clip per request — this message carries an image AND audio")
+        return MediaPark.answered
+    }
+    let is_audio = !empty(audios)
+    if (is_audio && !g_slots[g_cur].audio_armed) {
+        bad_request(srv, writer, "model '{cur_name()}' has no audio arm — start the server with its (audio-carrying) mmproj for it to accept input_audio parts")
+        return MediaPark.answered
+    }
+    if (!is_audio && g_slots[g_cur].vision.kind == VisionKind.none) {
+        bad_request(srv, writer, "model '{cur_name()}' has no vision arm — start the server with an image mmproj for it to accept image_url parts")
+        return MediaPark.answered
+    }
+    if (length(images) > 1 || length(audios) > 1) {
+        bad_request(srv, writer, "one media clip per request — this message carries {length(images) + length(audios)}")
+        return MediaPark.answered
+    }
+    if (!g_media_armed || g_media_ready < 1) {
+        service_unavailable(srv, writer, "the media worker is not ready")
+        return MediaPark.answered
+    }
+    if (length(g_media_wires) >= MEDIA_QUEUE_LIMIT) {
+        service_unavailable(srv, writer, "the media queue is at capacity ({MEDIA_QUEUE_LIMIT}) — retry shortly")
+        return MediaPark.answered
+    }
+    var file_bytes : array<uint8>
+    var why = ""
+    let decoded = (is_audio ? decode_base64_bytes(audios[0], file_bytes, why)
+        : decode_data_uri_bytes(images[0], file_bytes, why))
+    if (!decoded) {
+        delete file_bytes
+        bad_request(srv, writer, why)
+        return MediaPark.answered
+    }
+    // park at the encode boundary: the worker decodes + encodes off-thread, and
+    // drain_media_events resumes at handle_chat_tail with the rows
+    let rid = next_id()
+    set_writer_keepalive_timeout(srv, writer, LLM_WRITER_KEEPALIVE_MS)
+    g_media_wires[rid] <- MediaWire(writer = writer, js = js, slot = g_cur, is_audio = is_audio)
+    var vjob = MediaJob(id = rid, slot = g_cur, file_bytes <- file_bytes, tag = "req{rid}", is_audio = is_audio)
+    g_media_jobs |> push_clone(vjob)
+    delete vjob
+    to_log(LOG_INFO, "[req {rid}] {is_audio ? "audio" : "image"} parked for the media worker ({length(g_media_wires)} in flight)\n")
+    return MediaPark.parked
+}
+
 // everything after the media boundary: re-derives the request fields from `js` (cheap), renders,
 // and registers. Runs synchronously for a text request; an image request re-enters here from
-// drain_vision_events with the worker's rows.
+// drain_media_events with the worker's rows.
 def private handle_chat_tail(srv : WebSocketServer; var writer : HttpResponseWriter?; js : JsonValue?;   // nolint:STYLE037,STYLE038 — flat request-field derivation: one guard and one client-facing message per field
                              slot : int; var media : array<float>; n_media : int64;
-                             resume_rid : int64 = 0l) {
+                             media_is_audio : bool = false; resume_rid : int64 = 0l) {
     g_cur = slot
     let msgs_v = js?["messages"]
     let streaming = js?["stream"] ?? false
@@ -2096,7 +2204,7 @@ def private handle_chat_tail(srv : WebSocketServer; var writer : HttpResponseWri
     var start = 0
     while (true) {
         let render_error = render_chat_suffix(msgs_v, system, tools, max_new, start, think_set, think_val,
-                                              n_media > 0l, prompt, stop_ids, close, call_open, call_close,
+                                              n_media > 0l, media_is_audio, prompt, stop_ids, close, call_open, call_close,
                                               think_stream, wire_tool_mode, media_at)
         if (!empty(render_error)) {
             bad_request(srv, writer, render_error)
@@ -2120,7 +2228,8 @@ def private handle_chat_tail(srv : WebSocketServer; var writer : HttpResponseWri
     }
     register_request(srv, writer, prompt, stop_ids, close, media, media_at, n_media, params, max_new,
                      streaming, true, "chatcmpl",
-                     has_tools, call_open, call_close, seed, think_stream, wire_tool_mode, resume_rid)
+                     has_tools, call_open, call_close, seed, think_stream, wire_tool_mode, resume_rid,
+                     media_is_audio)
 }
 
 def private handle_completion(srv : WebSocketServer; var req : HttpRequest?; var writer : HttpResponseWriter?) {
@@ -2180,7 +2289,7 @@ def private reap_disconnected(srv : WebSocketServer) {
     }
     delete disconnected_asr
     var disconnected_vision : array<int64>
-    for (id, w in keys(g_vision_wires), values(g_vision_wires)) {
+    for (id, w in keys(g_media_wires), values(g_media_wires)) {
         if (!is_writer_connected(srv, w.writer)) {
             release_writer(srv, w.writer)
             disconnected_vision |> push(id)
@@ -2188,11 +2297,11 @@ def private reap_disconnected(srv : WebSocketServer) {
     }
     for (id in disconnected_vision) {
         unsafe {
-            delete g_vision_wires[id].js
+            delete g_media_wires[id].js
         }
-        g_vision_wires[id].js = null
-        delete g_vision_wires[id]
-        g_vision_wires |> erase(id)
+        g_media_wires[id].js = null
+        delete g_media_wires[id]
+        g_media_wires |> erase(id)
     }
     delete disconnected_vision
 }
@@ -2416,6 +2525,7 @@ struct private OaiSlotStats {
     weights_bytes : int64
     kv_bytes : int64
     vision : bool             // a vision arm is attached: this slot's chat route takes image_url parts
+    audio : bool              // an audio arm is attached: this slot's chat route takes input_audio parts
     thinking_default : bool   // this family's own default when a request sends no enable_thinking
     last_used_s : float       // seconds since this slot last admitted a request (-1 = never)
     sw_count : int64          // P2 gpu-switch telemetry
@@ -2461,6 +2571,7 @@ struct private OaiStatsResponse {
     asr_done_jobs : int64
     asr_audio_s : float
     vision : bool             // the DEFAULT slot's vision arm — the slot a model-less page request lands on
+    audio : bool              // the DEFAULT slot's audio arm (native audio through the serving slot)
     thinking_default : bool   // the DEFAULT slot's family thinking default (the page's checkbox seed)
     vision_pending : int      // image requests parked on the vision worker (0 = idle)
     media_rows : int64        // media (image span) rows admitted to prefill since boot
@@ -2477,7 +2588,7 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
     if (empty(g_slots)) {
         // setup mode: the minimum shape control.html's apply() reads (it gates on `setup`)
         return resp |> JSON(
-            "\{\"setup\":true,\"model\":\"(no model)\",\"active_model\":\"\",\"ctx\":0,\"uptime_s\":{g_started_at > 0l ? get_time_nsec(g_started_at) / 1_000_000_000l : 0l},\"draining\":{g_shutdown_requested},\"active\":0,\"queued\":0,\"peak_active\":0,\"admitted\":0,\"finished\":0,\"evicted\":0,\"decode_steps\":0,\"gen_tokens\":0,\"avg_batch\":0,\"cached_tokens\":0,\"prefix_pages\":0,\"max_streams\":0,\"chunk_tokens\":0,\"asr_workers\":0,\"asr_ready\":0,\"asr_active\":0,\"asr_pending\":0,\"mtp_drafted\":0,\"mtp_accepted\":0,\"prefill_tokens\":0,\"ttft_avg_ms\":0,\"ttft_last_ms\":0,\"weights_bytes\":0,\"kv_bytes\":0,\"gpu_vram_bytes\":0,\"gpu_budget_bytes\":0,\"hardware\":{json_str(g_hardware_line)},\"asr_done_jobs\":0,\"asr_audio_s\":0,\"vision\":false,\"models\":[]}",
+            "\{\"setup\":true,\"model\":\"(no model)\",\"active_model\":\"\",\"ctx\":0,\"uptime_s\":{g_started_at > 0l ? get_time_nsec(g_started_at) / 1_000_000_000l : 0l},\"draining\":{g_shutdown_requested},\"active\":0,\"queued\":0,\"peak_active\":0,\"admitted\":0,\"finished\":0,\"evicted\":0,\"decode_steps\":0,\"gen_tokens\":0,\"avg_batch\":0,\"cached_tokens\":0,\"prefix_pages\":0,\"max_streams\":0,\"chunk_tokens\":0,\"asr_workers\":0,\"asr_ready\":0,\"asr_active\":0,\"asr_pending\":0,\"mtp_drafted\":0,\"mtp_accepted\":0,\"prefill_tokens\":0,\"ttft_avg_ms\":0,\"ttft_last_ms\":0,\"weights_bytes\":0,\"kv_bytes\":0,\"gpu_vram_bytes\":0,\"gpu_budget_bytes\":0,\"hardware\":{json_str(g_hardware_line)},\"asr_done_jobs\":0,\"asr_audio_s\":0,\"vision\":false,\"audio\":false,\"models\":[]}",
             http_status.OK)
     }
     let tier = gpu_tier_status()
@@ -2513,8 +2624,9 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
         // DEFAULT slot, not g_active: these two gate the page's request UI, and a page request
         // carries no model field, so it lands on the default slot - the UI must show ITS truth
         vision = g_slots[g_default_slot].vision.kind != VisionKind.none,
+        audio = g_slots[g_default_slot].audio_armed,
         thinking_default = g_slots[g_default_slot].think_default,
-        vision_pending = length(g_vision_wires), media_rows = g_media_rows)
+        vision_pending = length(g_media_wires), media_rows = g_media_rows)
     out.models |> reserve(length(g_slots))
     for (i in range(length(g_slots))) {
         var s & = unsafe(g_slots[i])
@@ -2523,6 +2635,7 @@ def private handle_stats(var resp : HttpResponse?) : http_status {
             holds_gpu = i == g_gpu_owner,
             backend = s.opts.backend, backend_effective = s.backend_effective,
             flavor = slot_flavor(s), vision = s.vision.kind != VisionKind.none,
+            audio = s.audio_armed,
             thinking_default = s.think_default,
             ctx = s.model.config.seq_len,
             active = n_active(s.sched), queued = n_queued(s.sched),
@@ -3350,22 +3463,23 @@ def private stop_asr_worker_threads() {
 // The decode + letterbox + embedder GEMMs run on ONE worker thread, so an image request never
 // stalls the tick loop's decode of every live stream.
 
-struct private VisionJob {
+struct private MediaJob {
     id : int64
     slot : int
-    file_bytes : array<uint8>   // the base64-decoded image FILE; the worker decodes + encodes
-    tag : string                // DASLLAMA_VISION_DUMP artifact name
+    file_bytes : array<uint8>   // the base64-decoded media FILE (image or audio); the worker decodes + encodes
+    tag : string                // DASLLAMA_VISION_DUMP artifact name (image jobs)
+    is_audio : bool             // audio job: decode to 16 kHz PCM, encode via the slot's gemma4a encoder
     stop : bool
 }
 
-enum private VisionEventKind {
+enum private MediaEventKind {
     completed   // one job's result (ok + why say how it went); zero value — the channel pops zeroed clones
     ready       // the worker loaded its embedders
     stopped     // the worker exited
 }
 
-struct private VisionEvent {
-    kind : VisionEventKind
+struct private MediaEvent {
+    kind : MediaEventKind
     id : int64
     ok : bool
     why : string
@@ -3373,80 +3487,124 @@ struct private VisionEvent {
     rows : array<float>
     width : int
     height : int
+    is_audio : bool
+    audio_cs : int    // decoded audio length in centiseconds (audio jobs; ints ride the channel clone)
     enc_ms : int64
 }
 
-struct private VisionWire {
+struct private MediaWire {
     @do_not_delete writer : HttpResponseWriter?
-    @do_not_delete js : JsonValue?   // the parked parsed request — drain_vision_events deletes it explicitly
+    @do_not_delete js : JsonValue?   // the parked parsed request — drain_media_events deletes it explicitly
     slot : int
+    is_audio : bool                  // picks the render span (audio vs image) and the causal splice
 }
 
-let VISION_QUEUE_LIMIT = 8   // parked image requests are heavy (decoded bytes ride the channel)
+let MEDIA_QUEUE_LIMIT = 8   // parked image requests are heavy (decoded bytes ride the channel)
 
-var private g_vision_jobs : Channel?
-var private g_vision_events : Channel?
-var private g_vision_wires : table<int64; VisionWire>
+var private g_media_jobs : Channel?
+var private g_media_events : Channel?
+var private g_media_wires : table<int64; MediaWire>
 var private g_media_rows = 0l   // media (image span) rows admitted to prefill since boot
-var private g_vision_ready = 0
-var private g_vision_armed = false
+var private g_media_ready = 0
+var private g_media_armed = false
 
-def private vision_worker_main(slot_path_lines : string; var jobs : Channel?&; var events : Channel?&) {
-    this_context().name := "dasllama_vision"
+// One media job on the worker thread: decode the file bytes (image OR audio), run the slot's
+// encoder, and return the completed event — ok + rows, or why. The one rail that chews untrusted
+// bytes: an escaping panic in a new_thread worker is a PROCESS abort, so the decode+encode runs
+// under the catch (the ASR shape).
+def private media_encode_one(job : MediaJob; var embs : table<int; VisionEmbedder>;
+                             var states : table<int; VisionState>;
+                             var auds : table<int; Gemma4aEncoder>;
+                             var astates : table<int; Gemma4aState>) : MediaEvent {
+    var out = MediaEvent(id = job.id, is_audio = job.is_audio)
+    if (job.is_audio && !key_exists(auds, job.slot)) {
+        out.why = "this slot has no audio encoder in the worker (armed after init_server, or its load failed at boot)"
+        return <- out
+    }
+    if (!job.is_audio && !key_exists(embs, job.slot)) {
+        out.why = "this slot has no vision embedder in the worker (armed after init_server, or its load failed at boot)"
+        return <- out
+    }
+    var failure = ""
+    let failed = catch_worker_panic(failure) {
+        if (job.is_audio) {
+            var inscope samples <- decode_audio_16k_mono(job.file_bytes)
+            if (empty(samples)) {
+                out.why = "the audio bytes did not decode (wav/mp3/flac/ogg are supported)"
+            } else {
+                let t0 = ref_time_ticks()
+                out.n_media = gemma4a_encode_all(auds[job.slot], astates[job.slot], samples, out.rows)
+                out.ok = true
+                out.audio_cs = int(long_length(samples) * 100l / 16000l)
+                out.enc_ms = int64(get_time_usec(t0)) / 1000l
+            }
+        } else {
+            var inscope img <- decode_image_bytes(job.file_bytes, out.why)
+            if (img.width != 0) {
+                let t0 = ref_time_ticks()
+                out.n_media = encode_image(embs[job.slot], states[job.slot], img, job.tag, out.rows)
+                out.ok = true
+                out.width = img.width
+                out.height = img.height
+                out.enc_ms = int64(get_time_usec(t0)) / 1000l
+            }
+        }
+    }
+    if (failed) {
+        to_log(LOG_ERROR, "[req {job.id}] {job.is_audio ? "audio" : "vision"} encode failed: {failure}\n")
+        out.ok = false
+        out.why = "the {job.is_audio ? "audio" : "vision"} encode failed - see the server log"
+    }
+    return <- out
+}
+
+def private media_worker_main(slot_path_lines : string; var jobs : Channel?&; var events : Channel?&) {
+    this_context().name := "dasllama_media"
     set_jobque_thread_team_mode(false)
     var embs : table<int; VisionEmbedder>
     var states : table<int; VisionState>
-    for (line in split(slot_path_lines, "\n")) {
+    var auds : table<int; Gemma4aEncoder>
+    var astates : table<int; Gemma4aState>
+    for (line in split(slot_path_lines, "\n")) {   // "<slot>\t<V|A>\t<path>" per line
         continue if (empty(line))
         let sep = find(line, "\t")
         let slot = to_int(slice(line, 0, sep))
+        let kind = slice(line, sep + 1, sep + 2)
+        let path = slice(line, sep + 3)
         var load_failure = ""
         let load_failed = catch_worker_panic(load_failure) {
-            embs[slot] <- load_vision_embedder(slice(line, sep + 1))   // own mapping; pages shared with the slot's
-            states[slot] <- VisionState()
+            if (kind == "A") {
+                auds[slot] <- load_gemma4a_encoder(path)   // own mapping; pages shared with a vision arm on the same file
+                astates[slot] <- Gemma4aState()
+            } else {
+                embs[slot] <- load_vision_embedder(path)   // own mapping; pages shared with the slot's
+                states[slot] <- VisionState()
+            }
         }
-        if (load_failed) {   // the slot's requests take the no-embedder 400; the boot must not hang on this thread
-            to_log(LOG_ERROR, "dasllama-server: vision worker could not load slot {slot}'s embedder: {load_failure}\n")
-            embs |> erase(slot)
-            states |> erase(slot)
+        if (load_failed) {   // the slot's requests take the no-encoder 400; the boot must not hang on this thread
+            to_log(LOG_ERROR, "dasllama-server: media worker could not load slot {slot}'s {kind == "A" ? "audio encoder" : "vision embedder"}: {load_failure}\n")
+            if (kind == "A") {
+                auds |> erase(slot)
+                astates |> erase(slot)
+            } else {
+                embs |> erase(slot)
+                states |> erase(slot)
+            }
         }
     }
-    var hello = VisionEvent(kind = VisionEventKind.ready)
+    var hello = MediaEvent(kind = MediaEventKind.ready)
     events |> push_clone(hello)
     delete hello
     var stopping = false
     while (!stopping) {
-        jobs |> pop_with_timeout_clone(250) $(job : VisionJob#) {
+        jobs |> pop_with_timeout_clone(250) $(job : MediaJob#) {
             if (job.stop) {
                 stopping = true
                 return
             }
-            var job_copy : VisionJob
+            var job_copy : MediaJob
             job_copy := job
-            var out = VisionEvent(id = job_copy.id)
-            if (!key_exists(embs, job_copy.slot)) {
-                out.why = "this slot has no vision embedder in the worker (armed after init_server, or its load failed at boot)"
-            } else {
-                // the one rail that chews untrusted bytes: an escaping panic in a new_thread
-                // worker is a PROCESS abort, so every job runs under the catch (the ASR shape)
-                var failure = ""
-                let failed = catch_worker_panic(failure) {
-                    var inscope img <- decode_image_bytes(job_copy.file_bytes, out.why)
-                    if (img.width != 0) {
-                        let t0 = ref_time_ticks()
-                        out.n_media = encode_image(embs[job_copy.slot], states[job_copy.slot], img, job_copy.tag, out.rows)
-                        out.ok = true
-                        out.width = img.width
-                        out.height = img.height
-                        out.enc_ms = int64(get_time_usec(t0)) / 1000l
-                    }
-                }
-                if (failed) {
-                    to_log(LOG_ERROR, "[req {job_copy.id}] vision encode failed: {failure}\n")
-                    out.ok = false
-                    out.why = "the vision encode failed - see the server log"
-                }
-            }
+            var out <- media_encode_one(job_copy, embs, states, auds, astates)
             events |> push_clone(out)
             delete out
             delete job_copy
@@ -3455,78 +3613,83 @@ def private vision_worker_main(slot_path_lines : string; var jobs : Channel?&; v
     unsafe {
         delete embs
         delete states
+        delete auds
+        delete astates
     }
-    var farewell = VisionEvent(kind = VisionEventKind.stopped)
+    var farewell = MediaEvent(kind = MediaEventKind.stopped)
     events |> push_clone(farewell)
     delete farewell
     jobs |> release       // the captured channel refs, or the thread teardown panics
     events |> release
 }
 
-def private start_vision_worker() {
-    g_vision_ready = 0
-    g_vision_armed = false
+def private start_media_worker() {
+    g_media_ready = 0
+    g_media_armed = false
     var arms : array<string>
     defer() { delete arms }
     for (i in range(length(g_slots))) {
         if (g_slots[i].vision.kind != VisionKind.none) {
-            arms |> push("{i}\t{g_slots[i].vision_path}")
+            arms |> push("{i}\tV\t{g_slots[i].vision_path}")
+        }
+        if (g_slots[i].audio_armed) {
+            arms |> push("{i}\tA\t{g_slots[i].audio_path}")
         }
     }
     if (empty(arms)) {
         return
     }
-    g_vision_armed = true
-    let arms_spec = join(arms, "\n")   // "<slot index>\t<mmproj path>" per line
-    var jobs_capture = g_vision_jobs
-    var events_capture = g_vision_events
-    to_log(LOG_INFO, "dasllama-server: starting the asynchronous vision encode worker\n")
+    g_media_armed = true
+    let arms_spec = join(arms, "\n")   // "<slot index>\t<V|A>\t<mmproj path>" per line
+    var jobs_capture = g_media_jobs
+    var events_capture = g_media_events
+    to_log(LOG_INFO, "dasllama-server: starting the asynchronous media encode worker\n")
     new_thread() <| @capture(= arms_spec, = jobs_capture, = events_capture) {
-        vision_worker_main(arms_spec, jobs_capture, events_capture)
+        media_worker_main(arms_spec, jobs_capture, events_capture)
     }
-    while (g_vision_ready < 1) {
-        g_vision_events |> pop_with_timeout_clone(1000) $(event : VisionEvent#) {
-            if (event.kind == VisionEventKind.ready) {
-                g_vision_ready++
-                to_log(LOG_INFO, "dasllama-server: vision encode worker ready\n")
+    while (g_media_ready < 1) {
+        g_media_events |> pop_with_timeout_clone(1000) $(event : MediaEvent#) {
+            if (event.kind == MediaEventKind.ready) {
+                g_media_ready++
+                to_log(LOG_INFO, "dasllama-server: media encode worker ready\n")
             }
         }
     }
 }
 
-def private stop_vision_worker() {
-    if (!g_vision_armed) {
+def private stop_media_worker() {
+    if (!g_media_armed) {
         return
     }
-    var halt = VisionJob(stop = true)
-    g_vision_jobs |> push_clone(halt)
+    var halt = MediaJob(stop = true)
+    g_media_jobs |> push_clone(halt)
     delete halt
     var stopped = false
     while (!stopped) {
-        g_vision_events |> pop_with_timeout_clone(1000) $(event : VisionEvent#) {
-            if (event.kind == VisionEventKind.stopped) {
+        g_media_events |> pop_with_timeout_clone(1000) $(event : MediaEvent#) {
+            if (event.kind == MediaEventKind.stopped) {
                 stopped = true
-            } elif (event.kind == VisionEventKind.completed) {
-                to_log(LOG_WARNING, "[req {event.id}] vision result discarded during teardown\n")
+            } elif (event.kind == MediaEventKind.completed) {
+                to_log(LOG_WARNING, "[req {event.id}] media result discarded during teardown\n")
             }
         }
     }
-    g_vision_ready = 0
-    g_vision_armed = false
+    g_media_ready = 0
+    g_media_armed = false
 }
 
-def private drain_vision_events(srv : WebSocketServer) {
+def private drain_media_events(srv : WebSocketServer) {
     var draining = true
     while (draining) {
-        draining = g_vision_events |> try_pop_clone() $(event : VisionEvent#) {
-            return if (event.kind != VisionEventKind.completed)
-            var ev : VisionEvent
+        draining = g_media_events |> try_pop_clone() $(event : MediaEvent#) {
+            return if (event.kind != MediaEventKind.completed)
+            var ev : MediaEvent
             ev := event
             defer() { delete ev }
-            // interior pointer into g_vision_wires — nothing inserts into the table between here
+            // interior pointer into g_media_wires — nothing inserts into the table between here
             // and the erase (the only insert is handle_chat's park, and handlers cannot run inside
             // this drain)
-            var wire = unsafe(g_vision_wires?[ev.id])
+            var wire = unsafe(g_media_wires?[ev.id])
             if (wire == null) {
                 return   // the client vanished while encoding; reap released the writer
             }
@@ -3537,15 +3700,19 @@ def private drain_vision_events(srv : WebSocketServer) {
             } elif (reject_deferred_while_draining(srv, wire.writer)) {
                 pass   // a clean terminal 503: the drain must not admit a new generation
             } else {
-                to_log(LOG_INFO, "[req {ev.id}] image {ev.width}x{ev.height} -> {ev.n_media} soft tokens in {ev.enc_ms}ms off-thread\n")
-                handle_chat_tail(srv, wire.writer, wire.js, wire.slot, ev.rows, ev.n_media, ev.id)
+                if (ev.is_audio) {
+                    to_log(LOG_INFO, "[req {ev.id}] audio {float(ev.audio_cs) / 100f}s -> {ev.n_media} soft tokens in {ev.enc_ms}ms off-thread\n")
+                } else {
+                    to_log(LOG_INFO, "[req {ev.id}] image {ev.width}x{ev.height} -> {ev.n_media} soft tokens in {ev.enc_ms}ms off-thread\n")
+                }
+                handle_chat_tail(srv, wire.writer, wire.js, wire.slot, ev.rows, ev.n_media, ev.is_audio, ev.id)
             }
             unsafe {
                 delete wire.js
             }
             wire.js = null
-            delete g_vision_wires[ev.id]
-            g_vision_wires |> erase(ev.id)
+            delete g_media_wires[ev.id]
+            g_media_wires |> erase(ev.id)
         }
     }
 }
@@ -3648,7 +3815,7 @@ class OpenAiServer : HvWebServer {
             if (!g_shutdown_requested) {
                 to_log(
                     LOG_INFO,
-                    "dasllama-server: restart requested; draining llm_active={total_active()}, llm_queued={total_queued()}, asr_pending={g_asr_pending}, vision_parked={length(g_vision_wires)}\n")
+                    "dasllama-server: restart requested; draining llm_active={total_active()}, llm_queued={total_queued()}, asr_pending={g_asr_pending}, vision_parked={length(g_media_wires)}\n")
             }
             g_shutdown_requested = true
             g_restart_requested = true
@@ -3659,7 +3826,7 @@ class OpenAiServer : HvWebServer {
             if (!g_shutdown_requested) {
                 to_log(
                     LOG_INFO,
-                    "dasllama-server: graceful shutdown requested; draining llm_active={total_active()}, llm_queued={total_queued()}, asr_pending={g_asr_pending}, vision_parked={length(g_vision_wires)}\n")
+                    "dasllama-server: graceful shutdown requested; draining llm_active={total_active()}, llm_queued={total_queued()}, asr_pending={g_asr_pending}, vision_parked={length(g_media_wires)}\n")
             }
             g_shutdown_requested = true
             return resp |> JSON("\{\"ok\":true,\"draining\":true}", http_status.OK)
@@ -3709,7 +3876,7 @@ def private init_worker_rails {
     g_bake_result_json = ""
     catalog_events_init()
     start_asr_worker_threads()
-    start_vision_worker()
+    start_media_worker()
 }
 
 // one scheduler per slot: the init args are the defaults, SlotOpts sentinels override per slot
@@ -3754,8 +3921,8 @@ def init_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; c
     to_log(LOG_INFO, "dasllama-server: jobque compute dispatch = {dispatch_mode}\n")
     g_asr_jobs = unsafe(channel_create())
     g_asr_events = unsafe(channel_create())
-    g_vision_jobs = unsafe(channel_create())
-    g_vision_events = unsafe(channel_create())
+    g_media_jobs = unsafe(channel_create())
+    g_media_events = unsafe(channel_create())
     init_worker_rails()
     if (empty(g_slots) && !g_setup_mode) {
         to_log(LOG_ERROR, "dasllama-server: init_server with no model slots (call set_model/add_model first)\n")
@@ -3811,17 +3978,49 @@ def private pick_step_slot : int {
 
 //! Drive one non-blocking server iteration. False means the graceful drain completed (or the
 //! server never started); an external lifecycle host should then exit and call shutdown.
+var private g_prof_win = ref_time_ticks()
+var private g_prof_ticks = 0l
+var private g_prof_busy = 0l
+var private g_prof_pump_us = 0l
+var private g_prof_drain_us = 0l
+var private g_prof_reap_us = 0l
+var private g_prof_step_us = 0l
+var private g_prof_flush_us = 0l
+
+def private prof_window_report() {
+    let win_us = int64(get_time_usec(g_prof_win))
+    if (win_us < 5_000_000l || g_prof_busy == 0l) {
+        return
+    }
+    let n = g_prof_ticks
+    to_log(LOG_INFO, "dasllama-server: [tickprof] {n} ticks ({g_prof_busy} busy) in {win_us / 1000l}ms | per-tick us: pump={g_prof_pump_us / n} drain={g_prof_drain_us / n} reap={g_prof_reap_us / n} step={g_prof_step_us / n} flush={g_prof_flush_us / n} | sandwich total {(g_prof_pump_us + g_prof_drain_us + g_prof_reap_us + g_prof_flush_us) / 1000l}ms vs step {g_prof_step_us / 1000l}ms\n")
+    g_prof_win = ref_time_ticks()
+    g_prof_ticks = 0l
+    g_prof_busy = 0l
+    g_prof_pump_us = 0l
+    g_prof_drain_us = 0l
+    g_prof_reap_us = 0l
+    g_prof_step_us = 0l
+    g_prof_flush_us = 0l
+}
+
 def update_server() : bool {
     if (!g_server_started || g_server == null) {
         return false
     }
+    let t_pump = ref_time_ticks()
     g_server->tick()   // drains queued handlers: requests parse + render + submit here
+    g_prof_pump_us += int64(get_time_usec(t_pump))
+    let t_drain = ref_time_ticks()
     drain_asr_events(g_server.server)
-    drain_vision_events(g_server.server)
+    drain_media_events(g_server.server)
     drain_bench_events()
     drain_bake_events()
     catalog_download_tick()
+    g_prof_drain_us += int64(get_time_usec(t_drain))
+    let t_reap = ref_time_ticks()
     reap_disconnected(g_server.server)
+    g_prof_reap_us += int64(get_time_usec(t_reap))
     // serialized multi-model stepping: ONE scheduler step per tick, slots with work interleave
     // round-robin. Every step runs under ITS model's routing marks; the GPU tier follows a
     // gpu-wanting slot once the current owner drains.
@@ -3836,6 +4035,7 @@ def update_server() : bool {
         maybe_bind_gpu(si)
         let t_step = ref_time_ticks()
         busy = scheduler_step(g_slots[si].model, g_slots[si].sched, g_events)
+        g_prof_step_us += int64(get_time_usec(t_step))
         let step_ms = int64(get_time_usec(t_step)) / 1000l
         if (step_ms > 3000l) {
             // the "why does it pause" catcher: one decode step / prefill chunk should be
@@ -3843,10 +4043,17 @@ def update_server() : bool {
             to_log(LOG_WARNING, "dasllama-server: slow scheduler step: {step_ms}ms ({g_slots[si].name}: active={n_active(g_slots[si].sched)}, queued={n_queued(g_slots[si].sched)})\n")
         }
     }
+    let t_flush = ref_time_ticks()
     flush_events(g_server.server)
     flush_tool_keepalives(g_server.server)
+    g_prof_flush_us += int64(get_time_usec(t_flush))
+    g_prof_ticks++
+    if (busy) {
+        g_prof_busy++
+    }
+    prof_window_report()
     if (g_shutdown_requested && total_active() == 0l && total_queued() == 0l &&
-        g_asr_pending == 0 && empty(g_vision_wires)) {
+        g_asr_pending == 0 && empty(g_media_wires)) {
         to_log(LOG_INFO, "dasllama-server: graceful shutdown drain complete\n")
         return false
     }
@@ -3865,8 +4072,8 @@ def shutdown_server() {   // nolint:STYLE038 — one ordered teardown: workers s
     if (g_asr_jobs != null && g_asr_events != null) {
         stop_asr_worker_threads()
     }
-    if (g_vision_jobs != null && g_vision_events != null) {
-        stop_vision_worker()
+    if (g_media_jobs != null && g_media_events != null) {
+        stop_media_worker()
     }
     if (g_server != null) {
         g_server->cleanup()
@@ -3894,23 +4101,23 @@ def shutdown_server() {   // nolint:STYLE038 — one ordered teardown: workers s
     delete g_events
     delete g_wires
     delete g_asr_wires
-    for (w in values(g_vision_wires)) {   // parked image requests die with the server
+    for (w in values(g_media_wires)) {   // parked image requests die with the server
         unsafe {
             delete w.js
         }
         w.js = null
     }
-    delete g_vision_wires
+    delete g_media_wires
     var asr_jobs = g_asr_jobs
     var asr_events = g_asr_events
-    var vision_jobs = g_vision_jobs
-    var vision_events = g_vision_events
+    var vision_jobs = g_media_jobs
+    var vision_events = g_media_events
     var bench_events = g_bench_events
     var bake_events = g_bake_events
     g_asr_jobs = null
     g_asr_events = null
-    g_vision_jobs = null
-    g_vision_events = null
+    g_media_jobs = null
+    g_media_events = null
     g_bench_events = null
     g_bake_events = null
     catalog_events_shutdown()

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -3511,7 +3511,7 @@ let AUDIO_DECODE_SAMPLE_RATE = 16000l
 //! soft tokens must fit the context, so the longest usable clip is `seq_len / tokens-per-sec`
 //! seconds. Caps the decode of an untrusted upload before a compressed bomb reaches the encoder.
 def private audio_decode_frame_cap(seq_len : int64) : int {
-    return int(seq_len / GEMMA4A_AUDIO_SOFT_TOKENS_PER_SEC * AUDIO_DECODE_SAMPLE_RATE)
+    return max(int(AUDIO_DECODE_SAMPLE_RATE), int(seq_len / GEMMA4A_AUDIO_SOFT_TOKENS_PER_SEC * AUDIO_DECODE_SAMPLE_RATE))
 }
 
 var private g_media_jobs : Channel?
@@ -3967,6 +3967,7 @@ def init_server(port : int; max_streams : int64 = 4l; max_queue : int64 = 32l; c
     }
     g_server_started = true
     g_started_at = ref_time_ticks()
+    g_tickprof = env_noisy_diag()
     compose_hardware_line()
     g_box_ram_gb = box_ram_gb()
     var names <- [for (s in g_slots); s.is_default && length(g_slots) > 1 ? "{s.name}*" : s.name]
@@ -3991,6 +3992,7 @@ def private pick_step_slot : int {
 
 //! Drive one non-blocking server iteration. False means the graceful drain completed (or the
 //! server never started); an external lifecycle host should then exit and call shutdown.
+var private g_tickprof = false
 var private g_prof_win = ref_time_ticks()
 var private g_prof_ticks = 0l
 var private g_prof_busy = 0l
@@ -4012,6 +4014,9 @@ def private prof_window_reset() {
 }
 
 def private prof_window_report() {
+    if (!g_tickprof) {
+        return
+    }
     let win_us = int64(get_time_usec(g_prof_win))
     if (win_us < 5_000_000l) {
         return
@@ -4029,17 +4034,23 @@ def update_server() : bool {
     }
     let t_pump = ref_time_ticks()
     g_server->tick()   // drains queued handlers: requests parse + render + submit here
-    g_prof_pump_us += int64(get_time_usec(t_pump))
+    if (g_tickprof) {
+        g_prof_pump_us += int64(get_time_usec(t_pump))
+    }
     let t_drain = ref_time_ticks()
     drain_asr_events(g_server.server)
     drain_media_events(g_server.server)
     drain_bench_events()
     drain_bake_events()
     catalog_download_tick()
-    g_prof_drain_us += int64(get_time_usec(t_drain))
     let t_reap = ref_time_ticks()
+    if (g_tickprof) {
+        g_prof_drain_us += int64(get_time_usec(t_drain))
+    }
     reap_disconnected(g_server.server)
-    g_prof_reap_us += int64(get_time_usec(t_reap))
+    if (g_tickprof) {
+        g_prof_reap_us += int64(get_time_usec(t_reap))
+    }
     // serialized multi-model stepping: ONE scheduler step per tick, slots with work interleave
     // round-robin. Every step runs under ITS model's routing marks; the GPU tier follows a
     // gpu-wanting slot once the current owner drains.
@@ -4054,8 +4065,11 @@ def update_server() : bool {
         maybe_bind_gpu(si)
         let t_step = ref_time_ticks()
         busy = scheduler_step(g_slots[si].model, g_slots[si].sched, g_events)
-        g_prof_step_us += int64(get_time_usec(t_step))
-        let step_ms = int64(get_time_usec(t_step)) / 1000l
+        let step_us = int64(get_time_usec(t_step))
+        let step_ms = step_us / 1000l
+        if (g_tickprof) {
+            g_prof_step_us += step_us
+        }
         if (step_ms > 3000l) {
             // the "why does it pause" catcher: one decode step / prefill chunk should be
             // well under a second — anything slower means contention or a stall
@@ -4065,12 +4079,14 @@ def update_server() : bool {
     let t_flush = ref_time_ticks()
     flush_events(g_server.server)
     flush_tool_keepalives(g_server.server)
-    g_prof_flush_us += int64(get_time_usec(t_flush))
-    g_prof_ticks++
-    if (busy) {
-        g_prof_busy++
+    if (g_tickprof) {
+        g_prof_flush_us += int64(get_time_usec(t_flush))
+        g_prof_ticks++
+        if (busy) {
+            g_prof_busy++
+        }
+        prof_window_report()
     }
-    prof_window_report()
     if (g_shutdown_requested && total_active() == 0l && total_queued() == 0l &&
         g_asr_pending == 0 && empty(g_media_wires)) {
         to_log(LOG_INFO, "dasllama-server: graceful shutdown drain complete\n")

--- a/utils/dasllama-server/test_openai_server.das
+++ b/utils/dasllama-server/test_openai_server.das
@@ -301,11 +301,24 @@ def test_openai_server(t : T?) {   // nolint:STYLE038 — one live server sessio
                 t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
                 t |> success(find(string(resp.body), "no vision arm") >= 0, "the missing arm outranks the image count")
             }
-            // /v1/stats declares both arms the page reads: the vision flag and the thinking default
+            // an input_audio part on a slot with NO audio arm: same named-400 contract as vision
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":[\{\"type\":\"input_audio\",\"input_audio\":\{\"data\":\"AAAA\",\"format\":\"wav\"}},\{\"type\":\"text\",\"text\":\"what is said\"}]}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+                t |> success(find(string(resp.body), "no audio arm") >= 0, "the 400 names the missing audio arm")
+            }
+            // an image AND audio in one message: refused by shape before any arm check — the
+            // scheduler takes ONE media splice per request
+            POST("{base_url}/v1/chat/completions", "\{\"messages\":[\{\"role\":\"user\",\"content\":[\{\"type\":\"image_url\",\"image_url\":\{\"url\":\"data:image/png;base64,AAAA\"}},\{\"type\":\"input_audio\",\"input_audio\":\{\"data\":\"AAAA\",\"format\":\"wav\"}}]}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+                t |> success(find(string(resp.body), "image AND audio") >= 0, "the 400 names the two-media shape")
+            }
+            // /v1/stats declares the arms the page reads: the vision/audio flags and the thinking default
             GET("{base_url}/v1/stats") $(resp) {
                 var err : string
                 var js = read_json(string(resp.body), err)
                 t |> success(js != null && !(js?["vision"] ?? true), "stats reports no vision arm for a text-only slot")
+                t |> success(js != null && !(js?["audio"] ?? true), "stats reports no audio arm for a text-only slot")
                 // the VALUE, not just presence: tinyllama neither defaults to thinking nor has the
                 // reply markers in its vocab, so a true here means the vocab gate fell off
                 t |> success(js != null && js?["thinking_default"] != null, "stats declares the family thinking default")

--- a/utils/dasllama-server/test_openai_server_audio.das
+++ b/utils/dasllama-server/test_openai_server_audio.das
@@ -1,0 +1,154 @@
+options gen2
+options persistent_heap   // the server thread loads/frees a multi-GB model once; explicit deletes below
+options stack = 524288   // every dasLLAMA program root takes this budget (options stack does not unify up from libs)
+options fast_math = true  // ggml-parity FP laxity — this is an inference tool test, not the bit-exact suite
+options _dasllama_internal = true
+
+require dastest/testing_boost public
+require openai_server                                   // set_model / set_model_audio / run_server (sibling)
+require dasllama/dasllama                               // load_model / QuantMode
+require daslib/jobque_boost                             // with_job_status (server-thread lifecycle)
+require daslib/json_boost                               // read_json
+require daslib/base64                                   // input_audio.data payload
+require daslib/fio
+require strings
+require dasllama/dasllama_env
+
+// NATIVE AUDIO through the serving slot: input_audio part -> media worker gemma4a encode -> soft
+// tokens spliced (causal) between the audio span markers -> the model transcribes/answers. ONE
+// decoder, ONE mmproj (the E-series file carries vision AND audio) — no dedicated ASR model copy.
+// Asserts: both arms on stats; a real transcription of the 4 s JFK clip with the family thinking
+// default splitting reasoning from content; the armed-slot 400 shapes; the async decode-failure 400.
+// Model-gated (E2B Q4_K_M, 2.9 GiB — inside the iteration tier) + JIT-only; skips cleanly otherwise.
+
+let TEST_PORT = 18098
+
+def private models_dir() : string {
+    return models_dir_resolved()   // the ONE resolution: DASLLAMA_MODELS_DIR, else the rig default
+}
+let DEC_PATH = path_join(models_dir(), "gemma-4-E2B-it-Q4_K_M.gguf")
+let MM_PATH = path_join(models_dir(), "mmproj-gemma-4-E2B-it-bf16.gguf")
+let JFK_PATH = "modules/dasLLAMA/models/jfk_ask_not.wav"   // in-tree, 4 s, 16 kHz mono
+
+def private with_audio_server(port : int; blk : block<(base_url : string) : void>) {
+    with_job_status(1) $(finished) {
+        new_thread() @() {
+            allow_cpu_prefill()   // planar q8 model: every prefill is CPU here, span included
+            var m <- load_model(DEC_PATH, QuantMode.q8)
+            set_model(m, "test-alm")
+            set_model_vision("test-alm", MM_PATH)   // the SAME file arms both towers — the one-download story
+            set_model_audio("test-alm", MM_PATH)
+            set_default_max_tokens(2048l)   // the default-armed thought needs room before the answer
+            run_server(port)   // blocks until POST /shutdown
+            finished |> notify_and_release
+        }
+        let base_url = "http://127.0.0.1:{port}"
+        var ready = false
+        for (_attempt in range(1200)) {   // up to ~120s: the load + both towers + JIT
+            GET("{base_url}/v1/models") $(resp) {
+                if (resp != null && resp.status_code == http_status.OK) {
+                    ready = true
+                }
+            }
+            if (ready) {
+                break
+            }
+            sleep(100u)
+        }
+        if (ready) {
+            invoke(blk, base_url)
+        }
+        POST("{base_url}/shutdown", "") $(_resp) {}
+        finished |> join
+        assert(ready, "dasllama audio server became ready")
+    }
+}
+
+// the wav's base64 (byte read: RIFF interior NULs would truncate a string read)
+def private jfk_b64() : string {
+    var inscope bytes : array<uint8>
+    fopen(JFK_PATH, "rb") $(f) {
+        if (f != null) {
+            bytes |> resize(int64(fstat(f).size))
+            fread(f, bytes)
+        }
+    }
+    return empty(bytes) ? "" : base64_encode(bytes)
+}
+
+def private audio_chat_body(b64 : string; text : string) : string {
+    return "\{\"messages\":[\{\"role\":\"user\",\"content\":[\{\"type\":\"input_audio\",\"input_audio\":\{\"data\":\"{b64}\",\"format\":\"wav\"}},\{\"type\":\"text\",\"text\":\"{text}\"}]}]}"
+}
+
+[test]
+def test_openai_server_audio(t : T?) {   // nolint:STYLE038 — one server boot, every route-proof cell against it
+    t |> run("native audio: input_audio -> gemma4a soft tokens -> a transcription (needs E2B + its mmproj)") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> success(true, "skipped: interpreted (dasLLAMA server tests are JIT-only)")
+            return
+        }
+        for (p in [DEC_PATH, MM_PATH, JFK_PATH]) {
+            if (!stat(p).is_valid) {
+                t |> success(true, "skipped: {base_name(p)} not present (set DASLLAMA_MODELS_DIR)")
+                return
+            }
+        }
+        let b64 = jfk_b64()
+        t |> success(length(b64) > 1000, "the jfk wav encoded to base64 ({length(b64)} chars)")
+        with_audio_server(TEST_PORT) $(base_url) {
+            // both arms on the stats surface — the page gates its mic/image buttons on these
+            GET("{base_url}/v1/stats") $(resp) {
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null && (js?["audio"] ?? false), "stats declares the audio arm")
+                t |> success(js != null && (js?["vision"] ?? false), "stats declares the vision arm off the same mmproj")
+                if (js != null) {
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            // the transcription, under the family thinking DEFAULT: reasoning splits into
+            // reasoning_content, and content is the clean transcript of the 4 s clip
+            POST("{base_url}/v1/chat/completions", audio_chat_body(b64, "Transcribe this audio.")) $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.OK))
+                var err : string
+                var js = read_json(string(resp.body), err)
+                t |> success(js != null, "chat JSON parses")
+                if (js != null) {
+                    let content = to_lower(js?["choices"]?[0]?["message"]?["content"] ?? "")
+                    t |> success(find(content, "fellow americans") >= 0, "the transcript hears the clip (content: {content})")
+                    let reasoning = js?["choices"]?[0]?["message"]?["reasoning_content"] ?? ""
+                    t |> success(!empty(reasoning), "the default-armed thought landed in reasoning_content, not the transcript")
+                    t |> success(int(js?["usage"]?["prompt_tokens"] ?? 0l) > 40, "the audio soft-token rows count as prompt positions")
+                    unsafe {
+                        delete js
+                    }
+                }
+            }
+            // an image AND audio on the ARMED slot: still refused by shape — one media splice per request
+            POST("{base_url}/v1/chat/completions",
+                 "\{\"messages\":[\{\"role\":\"user\",\"content\":[\{\"type\":\"image_url\",\"image_url\":\{\"url\":\"data:image/png;base64,AAAA\"}},\{\"type\":\"input_audio\",\"input_audio\":\{\"data\":\"{slice(b64, 0, 64)}\",\"format\":\"wav\"}}]}]}") $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+                t |> success(find(string(resp.body), "image AND audio") >= 0, "the 400 names the two-media shape")
+            }
+            // input_audio.data that is not base64: the synchronous 400
+            POST("{base_url}/v1/chat/completions", audio_chat_body("!!!not-base64!!!", "hi")) $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+                t |> success(find(string(resp.body), "not valid base64") >= 0, "the 400 names the base64 failure")
+            }
+            // valid base64 of NON-audio bytes: decodes in the WORKER, so the 400 proves the async
+            // error path (park -> media worker decode failure -> drain answers the parked wire)
+            var junk : array<uint8>
+            junk |> resize(64)
+            for (i in range(64)) {
+                junk[i] = uint8(i)
+            }
+            POST("{base_url}/v1/chat/completions", audio_chat_body(base64_encode(junk), "hi")) $(resp) {
+                t |> equal(int(resp.status_code), int(http_status.BAD_REQUEST))
+                t |> success(find(string(resp.body), "did not decode") >= 0, "the async decode failure reaches the client as a named 400")
+            }
+            delete junk
+        }
+    }
+}

--- a/utils/dasllama-server/tests/audio-native.spec.js
+++ b/utils/dasllama-server/tests/audio-native.spec.js
@@ -1,0 +1,73 @@
+// §10 native audio: with an audio arm and no ASR workers, the mic records a clip that rides the
+// NEXT chat message as an input_audio part — no transcription pass, no second model copy.
+// Chromium's fake media device supplies the "microphone" (a tone), so the record → stop → attach →
+// send path runs for real.
+
+const { test, expect, fx, raw, openControl, lastJson } = require('./fixtures');
+
+test.use({
+    launchOptions: { args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'] },
+    permissions: ['microphone'],
+    // localhost, not the mock hostname: mediaDevices exists only in secure contexts, and
+    // localhost is one — fixtures.js intercepts both hostnames identically
+    baseURL: 'http://localhost',
+});
+
+const chatBody = posts => lastJson(posts.filter(p => p.path === '/v1/chat/completions'));
+
+function audioStats() {
+    const s = JSON.parse(JSON.stringify(fx('stats')));
+    s.audio = true;
+    if (s.models && s.models[0]) s.models[0].audio = true;
+    return s;
+}
+
+async function recordClip(page, ms) {
+    await page.locator('#b-mic').click();
+    await expect(page.locator('#b-mic')).toHaveClass(/rec/);
+    await page.waitForTimeout(ms);
+    await page.locator('#b-mic').click();
+    await expect(page.locator('#aud-strip')).toBeVisible();
+    await expect(page.locator('#aud-strip')).toContainText('clip');
+}
+
+test('an audio arm without ASR workers flips the mic to attach mode', async ({ page }) => {
+    await openControl(page, { stats: audioStats() });
+    const mic = page.locator('#b-mic');
+    await expect(mic).toBeVisible();
+    await expect(mic).not.toHaveClass(/off/);
+    await expect(mic).toHaveAttribute('title', /attaches to your next message/);
+});
+
+test('record, stop, send: the clip rides the message as an input_audio part, once', async ({ page }) => {
+    const { posts } = await openControl(page, { stats: audioStats(), sse: raw('sse_chat') });
+    await recordClip(page, 400);
+    await page.locator('#chat-text').fill('what is being said?');
+    await page.locator('#b-send').click();
+    await expect(page.locator('#chat-log .msg.assistant').last()).toContainText(fx('sse_expected').content);
+    const body = chatBody(posts);
+    const last = body.messages[body.messages.length - 1];
+    expect(Array.isArray(last.content)).toBe(true);
+    const audio = last.content.find(p => p.type === 'input_audio');
+    expect(audio.input_audio.format).toBe('wav');
+    expect(audio.input_audio.data.length).toBeGreaterThan(100);
+    expect(last.content.find(p => p.type === 'text').text).toBe('what is being said?');
+    // the clip rode ONE message: the strip cleared, and a second send goes out as plain text
+    await expect(page.locator('#aud-strip')).toBeHidden();
+    await page.locator('#chat-text').fill('and now?');
+    await page.locator('#b-send').click();
+    await expect(page.locator('#chat-log .msg.assistant').last()).toContainText(fx('sse_expected').content);
+    expect(typeof chatBody(posts).messages.at(-1).content).toBe('string');
+});
+
+test('attaching an image drops the pending clip — the server takes one media per message', async ({ page }) => {
+    await openControl(page, { stats: audioStats() });
+    await recordClip(page, 300);
+    // a 1x1 png through the image file input, the same rail a user's picker uses
+    const png = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+        'base64');
+    await page.locator('#img-file').setInputFiles({ name: 'dot.png', mimeType: 'image/png', buffer: png });
+    await expect(page.locator('#img-strip')).toBeVisible();
+    await expect(page.locator('#aud-strip')).toBeHidden();
+});

--- a/utils/dasllama-server/tests/fixtures.js
+++ b/utils/dasllama-server/tests/fixtures.js
@@ -51,7 +51,9 @@ async function mockServer(page, opts = {}) {
     await page.route('**/*', async route => {
         const req = route.request();
         const url = new URL(req.url());
-        if (url.hostname !== 'dasllama-control.test') return route.abort();   // must match baseURL in playwright.config.js
+        // the config baseURL, plus localhost for specs that need a SECURE context (mediaDevices
+        // only exists on secure origins — audio-native.spec.js records through the fake mic)
+        if (url.hostname !== 'dasllama-control.test' && url.hostname !== 'localhost') return route.abort();
         const p = url.pathname;
 
         if (req.method() === 'GET') {


### PR DESCRIPTION
**A dasllama-server slot that serves vision from a gemma-4 E-series mmproj now also serves native audio from the same file — one decoder, one mmproj, no separate ASR model copy. `input_audio` content parts on `/v1/chat/completions` are transcribed or reasoned over through the serving slot's own scheduler, exactly like an image.**

The E-series mmproj carries both a vision and a gemma4a audio tower, so `--image-mmproj` (or a `[[models]]` roster's `image_mmproj`) arms audio too when the file has the audio encoder. An `input_audio` part decodes to 16 kHz PCM on the media worker, the gemma4a encoder turns it into soft tokens, and those splice into the prefill between the template's audio span markers — causally, unlike the non-causal image span — so continuous batching covers audio with no second model load. The control page's mic flips to attach-mode when the slot serves native audio and no dedicated ASR workers run: the clip rides the next chat message. Parakeet stays the optional fast-dictation rail.

The audio ingest path is reachable from the unauthenticated chat route, so the decode is bounded: a clip is refused before decode when its length exceeds what the model's context can hold (a compressed container can inflate hundreds of times over its file bytes). The gemma-4 audio arm probes the mmproj's audio tensors, not its metadata — the converter writes the `clip.audio.*` keys unconditionally, so a vision-only mmproj declares the whole audio block with zero audio tensors.

Where to look: `modules/dasLLAMA/dasllama/dasllama_audio_io.das` (`decode_audio_16k_mono` + its frame cap), `dasllama_gemma4a.das` (`gemma4a_probe_proj_dim` tensor gate, `gemma4a_encode_all`), `dasllama_arch_gemma4.das` (the `<|audio>`/`<audio|>` span), `dasllama_chat.das` (`render_turn_audio`), `utils/dasllama-server/openai_server.das` (the media worker, `park_media_request`, the decode cap).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full preflight ran once on the branch's superset (before the live-switch commit was split off): lint clean on all three rails, format/ast-verify/ci-das/tests-interp/tests-jit/sphinx-html all pass. The one gate that failed then, `docs/uncategorized` on `dasllama.rst`, is fixed here (the new `render_turn_audio` facade joined its das2rst group; regenerated locally to 0 uncategorized). tests-aot/sequence/imgui skipped under the DLL-pin relink block (their own targeted runs).
- The three review-round fixes were validated by targeted runs, not a second full preflight: the model-free `test_dasllama_lint_contracts` decode-cap + probe-guard cells and the `test_arch_registry` gemma-4 marker pin run in CI; the live E2B audio suite (`test_openai_server_audio.das`) transcribed the 4 s JFK clip exactly through the serving slot with the family thinking default splitting reasoning from content (`[req 1] audio 4s -> 100 soft tokens`). The audio suite is registered `--compile-only` in `extended_checks.yml` (no GGUF on the CI box), matching the existing model-gated vision-test pattern — its assertions run only on a box with `DASLLAMA_MODELS_DIR` set.
- Playwright `audio-native.spec.js` records through Chromium's fake mic on a localhost secure context.

### Claims — stated, not tested
- The decode frame cap is proven refusing a synthetic `sampleRate=1` WAV bomb in a model-free unit test; the amplification factor (~61000x on that fixture) was measured by probe, not asserted.
- The gemma-4 audio span markers are pinned model-free against the arch template, and the PR asserts they match `gemma4a_transcribe`'s hand-rolled `special_id` spellings — the two constructions of the same turn are checked equal by inspection, not by a shared source (a follow-up could render both and diff).

### Not done
- **Live model switch (`POST /v1/models/load` / `/unload`) is split out** to its own arc (branch `bbatkin/dasllama-live-switch`): the review found that route aborts the process on several request-controlled inputs (uncaught panics after the `load_model` catch), steals the GPU owner's routing marks on a `backend:"cpu"` load, reads its GPU want off a now-movable default slot, and has no runtime test coverage. It ships after that hardening.
- The gemma-4 native-audio chat turn runs the family thinking default (reasoning channel), not `gemma4a_transcribe`'s deliberately-bare no-think turn — intentional (the chat route is not the parity-pinned ASR rail), noted for expectation.
- Lint candidate: PERF006 does not accept `ensure_capacity` as satisfying "reserve before a push loop" — the one correct spelling for a dynamic accumulate — so it fires and forces a nolint. The rule should treat `ensure_capacity` like `reserve`.
- A zero-row audio encode (a sub-frame clip) degrades silently to a plain text turn (the model never hears it, the client gets 200) — ledgered.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
