### PR TITLE
sweep fixes: flatten no longer drops or CSE-folds by-ref writes; hadd oracle reads its real floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,10 @@ diagnostic in any tier.
 - **`delete` on `array<T?>` frees the POINTEES**, not just the buffer. On borrowed pointers the
   interpreter reports `deleting <ptr>, which is not a chunk pointer`, while Release+JIT corrupts
   the heap silently and crashes later at an unrelated allocation. `clear()` the container first,
-  or mark the field `@do_not_delete`.
+  or mark the field `@do_not_delete`. This is about das-heap `T`: a HANDLED (C++-bound) pointee —
+  every `daslib/ast` node — is not a heap chunk, so the identical spelling frees only the buffer
+  and reads as an ownership claim the language never honors. Which one you have decides whether
+  dropping the `delete` leaks or whether keeping it corrupts.
 - **A lambda copy aliases one capture frame** — deleting a container that holds two copies of
   the same lambda is a double free.
 - **`:=` on a string copies the pointer** unless the source is a temp (`#`) string or the

--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -253,6 +253,16 @@ an entry lands here only when no name, shape, or test can carry it.
   CALL rather than an `ExprClone`, `++`/`+=` are their own nodes, and a by-reference
   argument writes with no assignment node anywhere. Hence the argument arm keys on the
   callee's parameter type (non-const and `ref` or a ref type), not on a node kind.
+- **`delete` on a container of `ExpressionPtr` frees the BUFFER, never the nodes** — the
+  house rule that `delete array<T?>` frees the pointees is about das-heap `T`, and
+  `Expression` is a handled C++ type whose instances are not heap chunks at all (the
+  measurement: an `array<S?>` of das structs returns its pointees to `heap_bytes_allocated`,
+  an `array<ExpressionPtr>` returns only the buffer and the nodes surface in the exit GC
+  report). That is why `make_float_ctor`'s const-fold early return may leave its lanes
+  un-consumed while the ctor path `emplace`s them away, why every `unsafe { delete args }`
+  after it is sound over borrowed tree nodes, and why a struct field holding a borrowed
+  node needs no `@do_not_delete`. Node lifetime belongs to the AST GC: a lane the const
+  fold drops is unreachable and collected at the enclosing `ast_gc_guard`.
 - **The whitelist admits value-returning primitives only.** `lower_stmt`'s fall-through arm
   lowers an unrecognized statement for its lifted sub-lets and drops the statement itself,
   which is correct exactly while every surviving call is pure — so `lift_expr` refuses a

--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -313,6 +313,12 @@ an entry lands here only when no name, shape, or test can carry it.
 
 - **interfaces**: the implements-marker IS the generated getter field — `is`/`as`/`?as`
   key purely on its presence; parent interfaces get their own deduped getter fields.
+  The const getter's `unsafe(addr<$t(st)? -const>(self))` is the one blessed const-strip
+  write, and it escapes the DCE trap on two counts, not on the `unsafe`: the constness sits
+  on the PARAMETER BINDING while the object behind it is an ordinary mutable allocation, and
+  the store is re-read through the same pointer two lines later while the new proxy escapes
+  into it — no tier can prove it dead. Emitted AOT C++ keeps the cast and the store verbatim.
+  Caching into anything the caller owns by const VALUE would not survive this.
 - **flat_hash_table**: `hashes[i]` is the slot state — 0 never-used (probe stops),
   1 tombstone (probe continues), above 1 live; a hash function that can return 0 or 1
   loses entries silently.

--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -246,6 +246,19 @@ an entry lands here only when no name, shape, or test can carry it.
 - **The copy-prop/CSE walks stay O(size)** — one name-to-statement index, one structural
   walk; never materialize a `string` per `ExprVar` in a visitor callback (O(n^2) persistent
   heap — the heap-overflow amplifier).
+- **`MutCollect` is the value-stability oracle, so it counts every store spelling, not the
+  one the lowering emits.** CSE treats a name outside its set as constant for the whole
+  block; a missed store is a shared subexpression across a mutation. Copies are only the
+  visible half — `<-` also zeroes its SOURCE, `:=` lowers to a `builtin`clone`(dst, src)`
+  CALL rather than an `ExprClone`, `++`/`+=` are their own nodes, and a by-reference
+  argument writes with no assignment node anywhere. Hence the argument arm keys on the
+  callee's parameter type (non-const and `ref` or a ref type), not on a node kind.
+- **The whitelist admits value-returning primitives only.** `lower_stmt`'s fall-through arm
+  lowers an unrecognized statement for its lifted sub-lets and drops the statement itself,
+  which is correct exactly while every surviving call is pure — so `lift_expr` refuses a
+  whitelisted call that writes through a by-reference argument (`sincos`) rather than let
+  the drop delete the store. Predicating such a write would need per-out-param temps the
+  lowering does not own.
 
 ## ast_verify
 

--- a/daslib/REVIEW.md
+++ b/daslib/REVIEW.md
@@ -129,6 +129,13 @@ decision silently changes output under `_flatten_no_fast_math`.
 miss path falls back to the unfused shape — the pass must never turn a shader that compiled
 into an unresolvable call on a narrower backend.
 
+**A new store spelling joins `MutCollect` in the same change.** CSE reads a name outside the
+mutable set as constant for the whole block, so an uncollected store is a silently shared
+subexpression.
+
+**A statement the lowering cannot predicate is refused, never dropped.** `lower_stmt`'s
+fall-through drop is licensed only because every call that survives lowering is pure.
+
 **`flatten_function` runs its passes in this order — dse → copy-prop → mask-const-prop →
 dse → ssa-rename — and a diff that reorders them is a defect.** Each pass produces the next
 one's input; a reorder leaves scaffolding in the generated `<name>_flat` twin, which must

--- a/daslib/REVIEW.md
+++ b/daslib/REVIEW.md
@@ -117,7 +117,9 @@ residual visitors call to prove the pass complete.
 
 **A residual oracle mirrors its arm's gate exactly and never calls the transform.** A
 narrower oracle is a false pass, a wider one a false miss; calling the transform from an
-oracle aliases the live tree.
+oracle aliases the live tree. A gate the transform takes as a parameter is threaded into the
+oracle too — re-spelling its default as a constant makes every non-default run a false pass,
+and the tests that call the oracle pass the same value.
 
 **Every new fold/fuse arm declares its float class.** Inf/NaN/rounding/association changes
 are fast-math-only; bit-exact per-lane rewrites are never gated. An arm added without that

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -230,6 +230,13 @@ def private lift_expr(var ctx : FlatCtx?; e : ExpressionPtr; structPred : Expres
         let c = e as ExprCall
         let bname = string(c.name)
         if (key_exists(ctx.whitelist, simple_name(bname))) {
+            for (ai in range(length(c.arguments))) {
+                if (writes_through_argument(c.func, ai)) {
+                    ctx.ok = false
+                    ctx.err = "flatten: '{bname}' writes through by-reference argument '{c.func.arguments[ai].name}'; a predicated twin cannot carry a store the lowering does not own - use a value-returning form"
+                    return clone_expression(e)
+                }
+            }
             var n = clone_expression(e)
             var o = n as ExprCall
             for (ai in range(length(c.arguments))) {

--- a/daslib/flatten.das
+++ b/daslib/flatten.das
@@ -718,13 +718,13 @@ def public flatten_fuse(var func : FunctionPtr; no_fast_math : bool = false; had
     return fuse_body(func, no_fast_math, hadd_min_width)
 }
 
-def public flatten_opt_residuals(var func : FunctionPtr; no_fast_math : bool = false) : array<string> {
-    //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin
-    //! has no un-extracted uniform subtree, no un-CSE'd repeat, no un-rcp'd uniform division,
-    //! no un-packed ctor lane pattern, no un-fused lane sum, no regroup-to-share miss.
+def public flatten_opt_residuals(var func : FunctionPtr; no_fast_math : bool = false;
+                                 hadd_min_width : int = 3) : array<string> {
+    //! Completeness oracle for the optimize pass (delegates to `opt_residuals`): empty ⇒ the twin has no un-extracted uniform subtree, no un-CSE'd repeat, no un-rcp'd uniform division, no un-packed ctor lane pattern, no un-fused lane sum, no regroup-to-share miss.
+    //! `hadd_min_width` MUST be the floor the `flatten_fuse` run used (`flatten_hadd_pack_pairs() ? 2 : 3`) — a floor-3 oracle over a floor-2 pass calls a unit with surviving width-2 misses complete.
     var res : array<string>
     ast_gc_guard() {
-        res <- opt_residuals(func, FLATTEN_BARRIERS, no_fast_math)
+        res <- opt_residuals(func, FLATTEN_BARRIERS, no_fast_math, hadd_min_width)
     }
     return <- res
 }

--- a/daslib/flatten_opt_common.das
+++ b/daslib/flatten_opt_common.das
@@ -615,12 +615,45 @@ def public store_base(e : Expression const?) : ExpressionPtr {
     return e is ExprVar ? unsafe(reinterpret<Expression?>(e)) : null
 }
 
+def public writes_through_argument(fn : Function const?; argIndex : int) : bool {
+    if (fn == null || argIndex >= length(fn.arguments)) return false
+    let at = fn.arguments[argIndex]._type
+    return at != null && !at.flags.constant && (at.flags.ref || at.isRefType)
+}
+
 class public MutCollect : AstVisitor {
     names : table<string>
-    def override preVisitExprCopy(expr : ExprCopy?) : void {
-        let base = store_base(expr.left)
+    def note_store(lhs : Expression const?) : void {
+        let base = store_base(lhs)
         if (base != null) {
             names |> insert("{(base as ExprVar).name}")
+        }
+    }
+    def override preVisitExprCopy(expr : ExprCopy?) : void {
+        note_store(expr.left)
+    }
+    def override preVisitExprMove(expr : ExprMove?) : void {
+        note_store(expr.left)
+        note_store(expr.right)
+    }
+    def override preVisitExprClone(expr : ExprClone?) : void {
+        note_store(expr.left)
+    }
+    def override preVisitExprOp1(expr : ExprOp1?) : void {
+        if (expr.op == "++" || expr.op == "--" || expr.op == "+++" || expr.op == "---") {
+            note_store(expr.subexpr)
+        }
+    }
+    def override preVisitExprOp2(expr : ExprOp2?) : void {
+        if (expr.op |> ends_with("=") && !(expr.op == "==" || expr.op == "!=" || expr.op == "<=" || expr.op == ">=")) {
+            note_store(expr.left)
+        }
+    }
+    def override preVisitExprCall(expr : ExprCall?) : void {
+        for (ai in range(length(expr.arguments))) {
+            if (writes_through_argument(expr.func, ai)) {
+                note_store(expr.arguments[ai])
+            }
         }
     }
 }

--- a/daslib/flatten_opt_common.das
+++ b/daslib/flatten_opt_common.das
@@ -616,7 +616,7 @@ def public store_base(e : Expression const?) : ExpressionPtr {
 }
 
 def public writes_through_argument(fn : Function const?; argIndex : int) : bool {
-    if (fn == null || argIndex >= length(fn.arguments)) return false
+    if (fn == null || argIndex < 0 || argIndex >= length(fn.arguments)) return false
     let at = fn.arguments[argIndex]._type
     return at != null && !at.flags.constant && (at.flags.ref || at.isRefType)
 }

--- a/daslib/flatten_opt_fuse.das
+++ b/daslib/flatten_opt_fuse.das
@@ -861,7 +861,7 @@ def private hadd_fold_stmt(var s : ExpressionPtr; var changed : bool&; minWidth 
     }
 }
 
-def private has_unfused_hadd(var that : ExprOp2?; dotCallable : bool) : bool {
+def private has_unfused_hadd(var that : ExprOp2?; dotCallable : bool; minWidth : int) : bool {
     if (that == null || !(that.op == "+" || that.op == "-") || expr_bt(that) != Type.tFloat) return false
     var terms : array<ReTerm>
     collect_add(that, false, terms)
@@ -880,7 +880,7 @@ def private has_unfused_hadd(var that : ExprOp2?; dotCallable : bool) : bool {
     unsafe {
         delete terms
     }
-    return n >= 3
+    return n >= minWidth
 }
 
 class public FuseResidualVisitor : AstVisitor {
@@ -888,6 +888,7 @@ class public FuseResidualVisitor : AstVisitor {
     checkLerp : bool
     checkDot : bool
     checkHadd : bool
+    haddMinWidth : int
     noFastMath : bool
     foundMad : bool
     foundLerp : bool
@@ -899,7 +900,7 @@ class public FuseResidualVisitor : AstVisitor {
         if (checkDot && has_unfused_lane_dot(expr)) {
             foundDot = true
         }
-        if (checkHadd && has_unfused_hadd(expr, checkDot)) {
+        if (checkHadd && has_unfused_hadd(expr, checkDot, haddMinWidth)) {
             foundHadd = true
         }
         if (!checkMad) {

--- a/daslib/flatten_opt_preshade.das
+++ b/daslib/flatten_opt_preshade.das
@@ -599,7 +599,8 @@ def private rcp_residual_expr(pe : PEX; barriers : table<string>; e : Expression
     return fold_children_or(e) $(c) => rcp_residual_expr(pe, barriers, c)
 }
 
-def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fast_math : bool = false) : array<string> {   // nolint:STYLE037,STYLE038 - one arm per residual peephole; the ladder IS the optimizer
+def public opt_residuals(var func : FunctionPtr; barriers : table<string>;   // nolint:STYLE037,STYLE038 - one arm per residual peephole; the ladder IS the optimizer
+                         no_fast_math : bool = false; hadd_min_width : int = 3) : array<string> {
     var res : array<string>
     if (func == null || func.body == null || !(func.body is ExprBlock)) return <- res
     var blk = func.body as ExprBlock
@@ -718,7 +719,8 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
     let cm = fuse_callable(func._module, "mad")
     var fr = new FuseResidualVisitor(checkMad = cm, checkLerp = cm && fuse_callable(func._module, "lerp"),
         checkDot = !no_fast_math && fuse_callable(func._module, "dot", 2),
-        checkHadd = !no_fast_math && fuse_callable(func._module, "hadd", 1), noFastMath = no_fast_math)
+        checkHadd = !no_fast_math && fuse_callable(func._module, "hadd", 1),
+        haddMinWidth = hadd_min_width, noFastMath = no_fast_math)
     make_visitor(*fr) $(a) {
         visit(func.body, a)
     }
@@ -738,7 +740,7 @@ def public opt_residuals(var func : FunctionPtr; barriers : table<string>; no_fa
         res |> push("an un-fused lane sum ('v.x + v.y + ...' should be dot(v, mask))")
     }
     if (fr.foundHadd) {
-        res |> push("an un-fused scalar sum ('a + b + c + d' should be hadd(float4(...)))")
+        res |> push("an un-fused scalar sum of >= {hadd_min_width} lanes (should be hadd(floatN(...)))")
     }
     unsafe {
         delete fr

--- a/doc/source/reference/flatten.rst
+++ b/doc/source/reference/flatten.rst
@@ -506,10 +506,11 @@ Public API
     value-number cache. ``[flatten]`` runs it
     automatically; the ``[pixel_shader]`` backend runs it after its fold fixpoint.
 
-``flatten_fuse(var func, no_fast_math = false) : bool``
+``flatten_fuse(var func, no_fast_math = false, hadd_min_width = 3) : bool``
     The finishing fuse pass: collapse same-vector lane sums into
-    ``dot(v, mask)`` and independent ≥4-term scalar sums into
-    ``hadd(float4(…))`` (both fast-math), re-pack ctor lane patterns
+    ``dot(v, mask)`` and independent scalar sums of ``hadd_min_width``..4 terms into
+    ``hadd(floatN(…))`` (both fast-math; the default floor of 3 keeps a bare pair
+    scalar, and ``options _flatten_hadd_pack_pairs`` lowers it to 2), re-pack ctor lane patterns
     (re-vectorization, shared-factor extraction, majority compensation),
     ``a*b ± c`` into ``mad(a, b, c)``, and the expanded lerp shape
     ``mad(b - a, t, a)`` back into ``lerp(a, b, t)``. Run it
@@ -518,7 +519,7 @@ Public API
     fold — each round strictly drops a ``+``/``-`` node, so it converges.
     ``[flatten]`` runs it automatically; the ``[pixel_shader]`` backend mirrors it.
 
-``flatten_opt_residuals(var func, no_fast_math = false) : array<string>``
+``flatten_opt_residuals(var func, no_fast_math = false, hadd_min_width = 3) : array<string>``
     The optimize-completeness oracle (sibling of ``flatten_fold_residuals``):
     walks a compiled twin and returns a description for each missed optimization —
     a maximal uniform subtree still inline in the varying body, an un-rewritten
@@ -527,6 +528,9 @@ Public API
     a pure-alias ``let`` copy left uncollapsed, a fusable mul-add left un-packed,
     a mad still carrying the lerp shape, an un-fused same-vector lane sum, or an
     un-packed ctor lane pattern.
+    Pass the same ``hadd_min_width`` the ``flatten_fuse`` run used — an oracle
+    asked for a wider floor than the pass reports a unit with surviving
+    narrow-group misses as complete.
     Empty means complete. Drives the same
     ``tests/flatten/test_flatten_fold.das`` corpus and the ``flatten-fuzz``
     strict mode.

--- a/install/CLAUDE.md
+++ b/install/CLAUDE.md
@@ -116,7 +116,10 @@ diagnostic in any tier.
 - **`delete` on `array<T?>` frees the POINTEES**, not just the buffer. On borrowed pointers the
   interpreter reports `deleting <ptr>, which is not a chunk pointer`, while Release+JIT corrupts
   the heap silently and crashes later at an unrelated allocation. `clear()` the container first,
-  or mark the field `@do_not_delete`.
+  or mark the field `@do_not_delete`. This is about das-heap `T`: a HANDLED (C++-bound) pointee —
+  every `daslib/ast` node — is not a heap chunk, so the identical spelling frees only the buffer
+  and reads as an ownership claim the language never honors. Which one you have decides whether
+  dropping the `delete` leaks or whether keeping it corrupts.
 - **A lambda copy aliases one capture frame** — deleting a container that holds two copies of
   the same lambda is a double free.
 - **`:=` on a string copies the pointer** unless the source is a temp (`#`) string or the

--- a/skills/daslang/references/memory.md
+++ b/skills/daslang/references/memory.md
@@ -159,6 +159,12 @@ unsafe { delete view }          // frees only the buffer
 Interpreted, the bad free reports `deleting <ptr>, which is not a chunk pointer` at the delete;
 optimized and JIT-ed, it corrupts the heap silently and crashes later at an unrelated allocation.
 
+The pointee-free happens only when `T` lives on the das heap. A **handled** (C++-bound) pointee —
+every `daslib/ast` node is one — is not a heap chunk, so the same `delete` frees the buffer alone
+and the pointees outlive it under their own ownership. Read the element type before trusting the
+spelling: on das-heap pointers the `delete` is load-bearing, on handled ones it claims an
+ownership the language never honors.
+
 ---
 
 ## 5. Heaps, contexts, threads

--- a/tests/flatten/_err_ref_arg.das
+++ b/tests/flatten/_err_ref_arg.das
@@ -1,0 +1,23 @@
+options gen2
+options indenting = 4
+
+require daslib/flatten
+require math
+
+//! `sincos(x, s, c)` is whitelisted and writes its results through `float&` out-parameters.
+//! The lowering owns no predicated form for a store it did not emit, so the call must be
+//! refused: dropping it silently returned the pre-call values, and the invisible store then
+//! let CSE share a subexpression straight across the mutation.
+
+[flatten]
+def withrefarg(x, y : float) : float {
+    var s = x * 2.0
+    var c = y * 3.0
+    sincos(x, s, c)
+    return s + c
+}
+
+[export]
+def main {
+    print("{withrefarg(0.7, 0.3)}\n")
+}

--- a/tests/flatten/no_aot/_mut_fixtures.das
+++ b/tests/flatten/no_aot/_mut_fixtures.das
@@ -1,0 +1,31 @@
+options gen2
+options indenting = 4
+
+require math
+
+//! Store-form corpus for `collect_mutable` (daslib/flatten_opt_common). One local per spelling a
+//! store can take — plain copy, move, clone, increment, compound assign, swizzle lane, and a write
+//! through a by-reference call argument — plus `ro`, the read-only control that must stay out of
+//! the mutable set. The `//! ` names here are the assertion keys in test_flatten_mutcollect.das.
+
+[export]
+def mut_forms(x : float) : float {
+    var cp = 0.0
+    var mv : array<int>
+    var cl : array<int>
+    var src <- [1, 2, 3]
+    var inc = 0
+    var acc = 0.0
+    var sn = 0.0
+    var cs = 0.0
+    var lane = float3(0.0)
+    let ro = x * 2.0
+    cp = x
+    mv <- src
+    cl := mv
+    inc ++
+    acc += x
+    lane.y = ro
+    sincos(x, sn, cs)
+    return cp + acc + sn + cs + lane.y + ro + float(inc + length(mv) + length(cl))
+}

--- a/tests/flatten/no_aot/_mut_fixtures.das
+++ b/tests/flatten/no_aot/_mut_fixtures.das
@@ -6,7 +6,11 @@ require math
 //! Store-form corpus for `collect_mutable` (daslib/flatten_opt_common). One local per spelling a
 //! store can take — plain copy, move, clone, increment, compound assign, swizzle lane, and a write
 //! through a by-reference call argument — plus `ro`, the read-only control that must stay out of
-//! the mutable set. The `//! ` names here are the assertion keys in test_flatten_mutcollect.das.
+//! the mutable set. The local names here are the assertion keys in test_flatten_mutcollect.das.
+//!
+//! `mut_out` is the signature side of the same corpus: one by-value parameter and one `var T&`,
+//! so `writes_through_argument` can be asked a true case, a false case, and both out-of-range
+//! ends against a real Function.
 
 [export]
 def mut_forms(x : float) : float {
@@ -28,4 +32,9 @@ def mut_forms(x : float) : float {
     lane.y = ro
     sincos(x, sn, cs)
     return cp + acc + sn + cs + lane.y + ro + float(inc + length(mv) + length(cl))
+}
+
+[export]
+def mut_out(x : float; var dst : float&) {
+    dst = x * 2.0
 }

--- a/tests/flatten/no_aot/test_flatten_ast_ownership.das
+++ b/tests/flatten/no_aot/test_flatten_ast_ownership.das
@@ -1,0 +1,67 @@
+options gen2
+options indenting = 4
+options persistent_heap
+
+require dastest/testing_boost public
+require daslib/ast
+require daslib/ast_boost
+
+//! Pins the ownership rule the flatten optimizer's `unsafe { delete <container> }` sites rest on.
+//! `ExpressionPtr` is `Expression?` — a HANDLED C++ type, so its instances never live on the das
+//! heap and the container finalizer frees only the buffer. That is what makes it safe to delete an
+//! `array<ExpressionPtr>` still holding borrowed tree nodes (the const-fold early return of
+//! `make_float_ctor` leaves its lanes un-consumed) and to keep a borrowed node in a plain struct
+//! field without `@do_not_delete`. If a release ever puts AST nodes on the das heap, those deletes
+//! become live-tree frees and this test is the tripwire — it fails here, not in a shader.
+//!
+//! The das-heap arm is the anti-vacuity control: the same measurement over `array<S?>` must show
+//! the pointees actually reclaimed, or the AST arm proves nothing.
+//!
+//! Lives in tests/flatten/no_aot/: `options persistent_heap` (exact free accounting) is a
+//! whole-program policy the AOT batch does not carry.
+
+struct private HeapNode {
+    v : int
+}
+
+struct private BorrowHolder {
+    lane : int
+    e : ExpressionPtr
+}
+
+def private borrowed_lane_survives_delete(t : T?) {
+    var owner = new ExprCall(name := "float2")
+    var a0 : ExpressionPtr = new ExprConstFloat(value = 1.0)
+    var a1 : ExpressionPtr = new ExprConstFloat(value = 2.0)
+    emplace(owner.arguments, a0)
+    emplace(owner.arguments, a1)
+    let spelling = "{describe(owner)}"
+    var borrowed <- [owner.arguments[0], owner.arguments[1]]
+    unsafe {
+        delete borrowed
+    }
+    t |> equal("{describe(owner)}", spelling, "an array delete must not reach the borrowed lanes")
+    var held <- [BorrowHolder(lane = 0, e = owner.arguments[0]), BorrowHolder(lane = 1, e = owner.arguments[1])]
+    unsafe {
+        delete held
+    }
+    t |> equal("{describe(owner)}", spelling, "a struct-field delete must not reach the borrowed lanes either")
+}
+
+[test]
+def test_flatten_ast_ownership(t : T?) {
+    t |> run("deleting an array of das-heap pointers reclaims the pointees") @(t : T?) {
+        let base = heap_bytes_allocated()
+        var arr <- [for (i in range(4)); new HeapNode(v = i)]
+        t |> success(heap_bytes_allocated() > base, "four heap nodes plus a buffer must show on the heap")
+        unsafe {
+            delete arr
+        }
+        t |> equal(heap_bytes_allocated(), base, "the pointees must come back, not just the buffer")
+    }
+    t |> run("deleting a container of AST pointers frees the buffer only") @(t : T?) {
+        ast_gc_guard() {
+            borrowed_lane_survives_delete(t)
+        }
+    }
+}

--- a/tests/flatten/no_aot/test_flatten_fold.das
+++ b/tests/flatten/no_aot/test_flatten_fold.das
@@ -68,6 +68,7 @@ def private check_unit(t : T?; proj, path : string) : int {
                 // honor the unit's own `options _flatten_no_fast_math` — gated rewrites are
                 // skipped there by design, and the oracle must mirror that (no false flags)
                 let noFastMath = program._options |> find_arg("_flatten_no_fast_math") ?as tBool ?? false
+                let haddMinWidth = (program._options |> find_arg("_flatten_hadd_pack_pairs") ?as tBool ?? false) ? 2 : 3
                 program_for_each_module(program) $(mod) {
                     for_each_function(mod, "") $(func) {
                         if (func.body == null || func.flags.builtIn || !is_flatten_output(func)) {
@@ -76,7 +77,7 @@ def private check_unit(t : T?; proj, path : string) : int {
                         checked ++
                         let r <- flatten_fold_residuals(func, noFastMath)
                         t |> equal(length(r), 0, "{base_name(path)}::{func.name}: {r}")
-                        let optr <- flatten_opt_residuals(func, noFastMath)
+                        let optr <- flatten_opt_residuals(func, noFastMath, haddMinWidth)
                         t |> equal(length(optr), 0, "{base_name(path)}::{func.name} (opt): {optr}")
                     }
                 }
@@ -84,6 +85,33 @@ def private check_unit(t : T?; proj, path : string) : int {
         }
     }
     return checked
+}
+
+def private twin_opt_residuals(t : T?; path, twin : string; haddMinWidth : int) : array<string> {
+    var res : array<string>
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.version_2_syntax = true
+            compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                if (!ok) {
+                    t |> failure("compile failed: {path}\n{iss}")
+                    return
+                }
+                program_for_each_module(program) $(mod) {
+                    for_each_function(mod, twin) $(func) {
+                        if (func.body == null || func.flags.builtIn) {
+                            return
+                        }
+                        let r <- flatten_opt_residuals(func, false, haddMinWidth)
+                        res |> push_clone_from(r)
+                    }
+                }
+            }
+        }
+    }
+    return <- res
 }
 
 // Compile `path` and return describe() of each `*_flat` twin body, keyed by twin name — the
@@ -262,6 +290,13 @@ def test_flatten_fold(t : T?) {  // nolint:STYLE038 — flat list of independent
         t |> success(p5 |> find("hadd(float3(") >= 0 && p5 |> find("hadd(float2(") >= 0,
                      "5-way must split into hadd3 + hadd2 under the option: {p5}")
         delete bodies
+    }
+    t |> run("the hadd residual oracle tracks the floor it is asked for, not a constant 3") @(t : T?) {
+        let hadd = "{root}/tests/flatten/test_flatten_hadd.das"
+        let at3 <- twin_opt_residuals(t, hadd, "h_two_flat", 3)
+        t |> equal(length(at3), 0, "h_two_flat is complete at the default floor: {at3}")
+        let at2 <- twin_opt_residuals(t, hadd, "h_two_flat", 2)
+        t |> equal(length(at2), 1, "the bare pair h_two_flat left scalar is an un-fused hadd at floor 2: {at2}")
     }
     t |> run("swizzle corpus folds clean (test_flatten_swizzle.das twins)") @(t : T?) {
         let n = check_unit(t, "", "{root}/tests/flatten/test_flatten_swizzle.das")

--- a/tests/flatten/no_aot/test_flatten_mutcollect.das
+++ b/tests/flatten/no_aot/test_flatten_mutcollect.das
@@ -46,6 +46,38 @@ def private fixture_mutables(t : T?; fnName : string) : table<string> {
     return <- res
 }
 
+def private assert_arg_guard(t : T?; fnName : string) {
+    let path = "{get_das_root()}/tests/flatten/no_aot/_mut_fixtures.das"
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.version_2_syntax = true
+            compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                if (!ok) {
+                    t |> failure("compile failed: {path}\n{iss}")
+                    return
+                }
+                var seen = false
+                program_for_each_module(program) $(mod) {
+                    for_each_function(mod, "") $(func) {
+                        if (func.body == null || func.flags.builtIn || "{func.name}" != fnName) {
+                            return
+                        }
+                        seen = true
+                        t |> equal(length(func.arguments), 2, "mut_out takes a value and a var ref")
+                        t |> success(!writes_through_argument(func, 0), "a by-value parameter is not a write target")
+                        t |> success(writes_through_argument(func, 1), "a 'var T&' parameter is a write target")
+                        t |> success(!writes_through_argument(func, -1), "a negative index answers false, never throws")
+                        t |> success(!writes_through_argument(func, 2), "an index past the last argument answers false")
+                    }
+                }
+                t |> success(seen, "{fnName} must be found")
+            }
+        }
+    }
+}
+
 [test]
 def test_flatten_mutcollect(t : T?) {
     t |> run("every store spelling reaches collect_mutable") @(t : T?) {
@@ -56,5 +88,8 @@ def test_flatten_mutcollect(t : T?) {
         }
         t |> success(!key_exists(m, "ro"), "'ro' is only read; a read must not enter the mutable set")
         delete m
+    }
+    t |> run("writes_through_argument answers false off both ends of the argument list") @(t : T?) {
+        assert_arg_guard(t, "mut_out")
     }
 }

--- a/tests/flatten/no_aot/test_flatten_mutcollect.das
+++ b/tests/flatten/no_aot/test_flatten_mutcollect.das
@@ -1,0 +1,60 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/flatten_opt_common
+require daslib/ast
+require daslib/ast_boost
+require daslib/rtti
+
+//! `collect_mutable` is what tells CSE and the preshader which names are value-stable, so every
+//! spelling a store can take has to reach it. A store form it cannot see is a name CSE believes
+//! constant: it shares a subexpression straight across the mutation and the twin computes the
+//! pre-store value twice. `_mut_fixtures.das` carries one local per spelling.
+//!
+//! Lives in tests/flatten/no_aot/ (excluded from test_aot via tests/.das_test): it compiles the
+//! fixture at runtime, which pulls macro_boost generic instantiations that don't AOT-link.
+
+def private fixture_mutables(t : T?; fnName : string) : table<string> {
+    var res : table<string>
+    let path = "{get_das_root()}/tests/flatten/no_aot/_mut_fixtures.das"
+    var inscope access <- make_file_access("")
+    using() $(var mg : ModuleGroup) {
+        using() $(var cop : CodeOfPolicies) {
+            cop.threadlock_context = true
+            cop.version_2_syntax = true
+            compile_file(path, access, unsafe(addr(mg)), cop) $(ok; program; iss) {
+                if (!ok) {
+                    t |> failure("compile failed: {path}\n{iss}")
+                    return
+                }
+                program_for_each_module(program) $(mod) {
+                    for_each_function(mod, "") $(func) {
+                        if (func.body == null || func.flags.builtIn || "{func.name}" != fnName) {
+                            return
+                        }
+                        var m <- collect_mutable(func.body as ExprBlock)
+                        for (k in keys(m)) {
+                            res |> insert(k)
+                        }
+                        delete m
+                    }
+                }
+            }
+        }
+    }
+    return <- res
+}
+
+[test]
+def test_flatten_mutcollect(t : T?) {
+    t |> run("every store spelling reaches collect_mutable") @(t : T?) {
+        var m <- fixture_mutables(t, "mut_forms")
+        t |> success(!empty(m), "mut_forms must be found and walked")
+        for (name in ["cp", "mv", "src", "cl", "inc", "acc", "lane", "sn", "cs"]) {
+            t |> success(key_exists(m, name), "'{name}' is written in mut_forms but is not in the mutable set")
+        }
+        t |> success(!key_exists(m, "ro"), "'ro' is only read; a read must not enter the mutable set")
+        delete m
+    }
+}

--- a/tests/flatten/test_flatten_errors.das
+++ b/tests/flatten/test_flatten_errors.das
@@ -50,6 +50,10 @@ def test_flatten_boundaries(t : T?) {
         let issues = compile_issues("{get_das_root()}/tests/flatten/_err_move.das")
         t |> success(find(issues, "cannot be predicated") >= 0, "expected move/clone error, got: {issues}")
     }
+    t |> run("a whitelisted builtin writing through a by-ref argument is rejected") @(t : T?) {
+        let issues = compile_issues("{get_das_root()}/tests/flatten/_err_ref_arg.das")
+        t |> success(find(issues, "writes through by-reference argument") >= 0, "expected ref-argument error, got: {issues}")
+    }
     t |> run("over-cap loop unrolling is rejected") @(t : T?) {
         let issues = compile_issues("{get_das_root()}/tests/flatten/_err_unroll.das")
         t |> success(find(issues, "exceeds max_unroll") >= 0, "expected unroll-cap error, got: {issues}")

--- a/tests/interfaces/test_const_interfaces.das
+++ b/tests/interfaces/test_const_interfaces.das
@@ -162,4 +162,13 @@ def test_const_lazy_cache(tt : T?) {
         let p2 = w as IReadable
         tt |> equal(unsafe(reinterpret<int64>(p1)), unsafe(reinterpret<int64>(p2)))
     }
+    tt |> run("the const getter's write reaches the object, in every tier") @(tt : T?) {
+        let w = new Widget(70, "store-visible")
+        tt |> equal(unsafe(reinterpret<int64>(w._interface_IReadable)), 0l, "the cache starts empty")
+        let p = w as IReadable
+        tt |> equal(unsafe(reinterpret<int64>(w._interface_IReadable)),
+                    unsafe(reinterpret<int64>(p)),
+                    "the getter's store through the const-stripped self must be visible on the object")
+        tt |> equal(p->get_value(), 70)
+    }
 }


### PR DESCRIPTION
**Behavior change: the flatten lowering no longer miscompiles code that writes through by-reference arguments — two silent-wrong-answer holes are closed, and a shape it cannot lower is now a compile error instead of a dropped statement.**

Both holes were real and probe-proven. `lower_stmt`'s fall-through arm lowered an unrecognized statement for its lifted sub-lets and then discarded the statement itself — a whitelisted `sincos(x, s, c)` call simply vanished (`mc_one_flat` returned 2.3 where the source computes 1.409). And `MutCollect`, the pass that tells CSE which names are mutable, only saw plain copies: `<-`, `:=`, `++`, compound assigns, and writes through callee by-ref parameters were invisible, so CSE folded across mutations (`3.24` where the source computes `5.29`). Every store spelling now reaches `MutCollect` (keyed on the callee's parameter type, because `:=` lowers to a `clone` call no node-kind test sees), and `lift_expr` refuses a whitelisted call that writes through a by-ref argument, naming the argument.

Also here: the hadd residual oracle reads the floor the fuse pass actually ran at instead of a hardcoded 3 (`hadd_min_width` threads through `flatten_opt_residuals`, RST updated); a pin that the swizzle path's container deletes never free borrowed AST nodes (probed: handled C++-bound pointees are not das-heap chunks — the suspected live-AST free does not exist); and the interfaces const-getter cache write blessed under interpreter, JIT and AOT with its boundary recorded in `daslib/ARCHITECTURE.md`. That probe also corrected an overstated rule in CLAUDE.md and the shipped memory reference: `delete` on a container of pointers frees pointees only for das-heap element types.

Where to look: `daslib/flatten.das` (`lower_stmt`, `MutCollect`, `lift_expr`), `daslib/flatten_opt_fuse.das:883`, `tests/flatten/no_aot/`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first end-to-end: both miscompiles reproduced numerically before the fix; a nine-store fixture shows the old visitor collecting 2 names, the new one all nine with read-only control excluded.
- tests/flatten 284/284, tests/interfaces 85/85 on the merged master; lint and format clean on every touched file.
- The interfaces pin's JIT arm ran under O3; the AOT emit was inspected (cast + store + re-read survive verbatim) and the existing identity assertion runs green under the real `test_aot` binary.

### Claims — stated, not tested
- The NEW interfaces assertion arm's runtime AOT run is pending a `test_aot` rebuild — adding it changes the enclosing lambda's semantic hash, so the prebuilt binary reports 50101; the file is already AOT-registered, so the next nightly / full preflight covers it.

### Not done
- Lint-rule candidate ledgered: a container-of-pointers `delete` whose element type is handled is a no-op that reads as ownership; its converse (a dropped `delete` on das-heap pointees) is a leak the same analysis catches.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
