### PR TITLE
sweep fixes: aot emitters - ctor brace, platform-true forward decls, const-ptr emit, visitor leaks, dead offset filter

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -3936,7 +3936,7 @@ def private aotEmitStruct(ps : Structure?;
 def public dumpDependencies(program : ProgramPtr; var aotVisitor : CppAot?) {
     //! Writes forward declarations and dependent type/function definitions for AOT output.
     buildStructEnumCollisions(program);
-    let utm = new UseTypeMarker();
+    var utm = new UseTypeMarker();
     make_visitor(*utm) $(adapter) {
         visit(program, adapter);
     }
@@ -3971,7 +3971,9 @@ def public dumpDependencies(program : ProgramPtr; var aotVisitor : CppAot?) {
             }
         });
     })
-
+    unsafe {
+        delete utm
+    }
 }
 
 class ArgsConverter : AstVisitor {
@@ -4069,9 +4071,12 @@ def public collectProgramUsedFunctions(program : ProgramPtr; all_modules : bool;
 
 def registerAotCpp(var logs : StringBuilderWriter?; program : ProgramPtr; var context : Context; cross_platform; headers, all_modules : bool = false) {
     let fnn = collectProgramUsedFunctions(program, all_modules, false);
-    let visitor = new ArgsConverter(logs, cross_platform);
+    var visitor = new ArgsConverter(logs, cross_platform);
     make_visitor(*visitor) $(adapter_marker) {
         visit(program, adapter_marker);
+    }
+    unsafe {
+        delete visitor
     }
 
     var funInit = false;

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -4222,7 +4222,7 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
             write(writer, "namespace das \{\n");
             write(writer, "namespace {program.thisNamespace} \{\n");
             build_string() $(tmp_writer) {
-                let marker_vis = new NoAotMarker();
+                var marker_vis = new NoAotMarker();
                 make_visitor(*marker_vis) $(adapter_marker) {
                     visit(program, adapter_marker);
                 }
@@ -4267,6 +4267,9 @@ def public run_aot(prog : Program?; var pctx : Context?; cop : CodeOfPolicies) :
                     delete cpp_aot.helper.helper
                     delete cpp_aot.collector
                     delete cpp_aot
+                    delete flags
+                    delete pmarker
+                    delete marker_vis
                 }
                 fail_on_aot_emit_error(program)
             }
@@ -4298,7 +4301,7 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
         let (modules_str, noAotModule) = getRequiredModulesFor(program)
         if ((program._options |> find_arg("no_aot") ?as tBool ?? false) || noAotModule) return
         build_string() $(tmp_writer) {
-            let marker_vis = new NoAotMarker();
+            var marker_vis = new NoAotMarker();
             make_visitor(*marker_vis) $(adapter_marker) {
                 visit(program, adapter_marker);
             }
@@ -4344,6 +4347,9 @@ def public run_aot_function(prog : Program?; var pctx : Context?; cop : CodeOfPo
                 delete cpp_aot.helper.helper
                 delete cpp_aot.collector
                 delete cpp_aot
+                delete flags
+                delete pmarker
+                delete marker_vis
             }
             fail_on_aot_emit_error(program)
             let begin_pos = find(full_output, AOT_FUNC_BEGIN)

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -2443,8 +2443,9 @@ class public CppAot : AstVisitor {
         return c;
     }
     def override visitExprConstPtr(var c : ExprConstPtr?) : ExpressionPtr {
-        if (c.getValue != null) {
-            write(*ss, "((void *) 0x{unsafe(reinterpret<int64>(c.getValue)):x}))");
+        let pvalue = c.getValue
+        if (pvalue != null) {
+            write(*ss, "((void *) 0x{unsafe(reinterpret<int64>(pvalue)):x})");
         } else {
             write(*ss, "nullptr");
         }

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -160,8 +160,8 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
     if (initFunctions |> !empty(initFunctions)) {
         write(tw, " FillFunction(context, getGlobalAotLibrary(), id_to_funcs);\n");
         write(tw, "    context.runInitScript();\n");
-        write(tw, "\}\n");
     }
+    write(tw, "\}\n");
 }
 
 def writeStandaloneContext(var program : ProgramPtr, initFunctions : string, var header : StringBuilderWriter, var source : StringBuilderWriter; cfg : StandaloneContextCfg) {
@@ -232,7 +232,7 @@ class StandaloneContextGen : CppAot {
         for (pfun in fnn) {
             let needInline = that == pfun._module;
             if (needInline) {
-                inline_fns.push(describeCppFunc(pfun, collector, true, needInline));
+                inline_fns.push(describeCppFunc(pfun, collector, cross_platform, true, needInline));
                 used_functions.insert(aotFuncName(pfun));
             }
         }

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -346,6 +346,10 @@ def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string
     make_visitor(*flags) $(flags_adapter) {
         visit(program, flags_adapter)
     }
+    unsafe {
+        delete flags
+        delete pmarker
+    }
 
     var coll = new BlockVariableCollector();
     make_visitor(*coll) $(adapter_coll) {

--- a/daslib/cpp_gen.das
+++ b/daslib/cpp_gen.das
@@ -1111,21 +1111,19 @@ def getGenConstType(name, default_name : string) {
     return const_type_table?[name] ?? default_name
 }
 
-def searchAndGenConst(var regex_def : Regex; defTName, suffix : string; ofs : table<int; bool>; data : string; var dup : table<string; bool>; hf : FILE const?) {
+def searchAndGenConst(var regex_def : Regex; defTName, suffix : string; data : string; var dup : table<string; bool>; hf : FILE const?) {
     //! Searches for #define constants matching a regex and generates binding code.
-    regex_foreach(regex_def, data) $(r) {
-        if (!ofs |> key_exists(r.x)) {
-            let DEF = regex_group(regex_def, 1, data)
-            let VAL = regex_group(regex_def, 2, data)
-            if (!blocked_defines_table |> key_exists(DEF)) {
-                if (is_const_blocked == null || !invoke(is_const_blocked, DEF)) {
-                    let ctt = getGenConstType(DEF, defTName)
-                    if (!dup[DEF]) {
-                        fprint(hf, "addConstant<{ctt}>(*this,\"{DEF}\",{ctt}({VAL}{suffix}));\n")
-                        dup[DEF] = true
-                    } else {
-                        print("const: duplicate {DEF}\n")
-                    }
+    regex_foreach(regex_def, data) $(_r) {
+        let DEF = regex_group(regex_def, 1, data)
+        let VAL = regex_group(regex_def, 2, data)
+        if (!blocked_defines_table |> key_exists(DEF)) {
+            if (is_const_blocked == null || !invoke(is_const_blocked, DEF)) {
+                let ctt = getGenConstType(DEF, defTName)
+                if (!dup[DEF]) {
+                    fprint(hf, "addConstant<{ctt}>(*this,\"{DEF}\",{ctt}({VAL}{suffix}));\n")
+                    dup[DEF] = true
+                } else {
+                    print("const: duplicate {DEF}\n")
                 }
             }
         }
@@ -1154,15 +1152,14 @@ def genDefineConstants(fnames : array<string>; prefix : string) {
                 if (f == null) {
                     panic("can't open {fname}")
                 }
-                let ofs : table<int; bool>
                 let data = fread(f)
                 var dup : table<string; bool>
-                searchAndGenConst(reg_def_hex, "uint32_t", "u", ofs, data, dup, hf)
-                searchAndGenConst(reg_def_dec, "int32_t", "", ofs, data, dup, hf)
-                searchAndGenConst(reg_def_UINT8, const_uint8_type, "u", ofs, data, dup, hf)
-                searchAndGenConst(reg_def_UINT16, const_uint16_type, "u", ofs, data, dup, hf)
-                searchAndGenConst(reg_def_UINT32, "uint32_t", "u", ofs, data, dup, hf)
-                searchAndGenConst(reg_def_UINT64, "uint64_t", "ul", ofs, data, dup, hf)
+                searchAndGenConst(reg_def_hex, "uint32_t", "u", data, dup, hf)
+                searchAndGenConst(reg_def_dec, "int32_t", "", data, dup, hf)
+                searchAndGenConst(reg_def_UINT8, const_uint8_type, "u", data, dup, hf)
+                searchAndGenConst(reg_def_UINT16, const_uint16_type, "u", data, dup, hf)
+                searchAndGenConst(reg_def_UINT32, "uint32_t", "u", data, dup, hf)
+                searchAndGenConst(reg_def_UINT64, "uint64_t", "ul", data, dup, hf)
             }
         }
     }

--- a/tests/aot/_standalone_novars_fixture.das
+++ b/tests/aot/_standalone_novars_fixture.das
@@ -1,0 +1,3 @@
+options gen2
+
+let g_answer = 42

--- a/tests/aot/_standalone_tuple_fixture.das
+++ b/tests/aot/_standalone_tuple_fixture.das
@@ -1,0 +1,11 @@
+options gen2
+
+[never_inline]
+def sum_pair(pair : tuple<int; float>) : float {
+    return float(pair._0) + pair._1
+}
+
+[export]
+def entry() : float {
+    return sum_pair((1, 2.0))
+}

--- a/tests/aot/test_const_ptr_emit.das
+++ b/tests/aot/test_const_ptr_emit.das
@@ -1,0 +1,52 @@
+options gen2
+options no_aot
+
+require daslib/aot_cpp
+require daslib/ast
+require strings
+require dastest/testing_boost public
+
+var g_anchor = 17
+
+def private emit_const_ptr(pvalue : void?) : string {
+    var emitted = ""
+    ast_gc_guard() {
+        emitted = build_string() $(writer) {
+            var gen = new CppAot(ss = unsafe(addr(writer)))
+            var cptr = new ExprConstPtr(value = pvalue)
+            gen->visitExprConstPtr(cptr)
+            unsafe {
+                delete gen.collector
+                delete gen
+            }
+        }
+    }
+    return emitted
+}
+
+def private paren_balance(text : string) : int {
+    var balance = 0
+    peek_data(text) $(bytes) {
+        for (byte in bytes) {
+            let ch = int(byte)
+            if (ch == '(') {
+                balance ++
+            } elif (ch == ')') {
+                balance --
+            }
+        }
+    }
+    return balance
+}
+
+[test]
+def test_const_ptr_emit(t : T?) {
+    t |> run("null pointer constant emits nullptr") @(t : T?) {
+        t |> equal(emit_const_ptr(null), "nullptr")
+    }
+    t |> run("non-null pointer constant is a balanced cast expression") @(t : T?) {
+        let emitted = emit_const_ptr(unsafe(addr<void?>(g_anchor)))
+        t |> success(starts_with(emitted, "((void *) 0x"), "got {emitted}")
+        t |> equal(paren_balance(emitted), 0, "unbalanced parentheses in {emitted}")
+    }
+}

--- a/tests/aot/test_standalone_emit.das
+++ b/tests/aot/test_standalone_emit.das
@@ -1,0 +1,80 @@
+options gen2
+options no_aot
+options stack = 1_048_576
+
+require daslib/aot_standalone
+require daslib/ast_boost
+require daslib/fio
+require daslib/rtti
+require strings
+require dastest/testing_boost public
+
+def private generate_standalone(t : T?; fixture, out_dir : string) : string {
+    let input = path_join(get_das_root(), "tests/aot/{fixture}.das")
+    using() $(var cop : CodeOfPolicies) {
+        cop.threadlock_context = false
+        cop.aot = false
+        cop.aot_module = true
+        cop.aot_lib = false
+        cop.fail_on_lack_of_aot_export = true
+        cop.ignore_shared_modules = false
+        cop.version_2_syntax = true
+        cop.tune_frozen = true
+        ast_gc_guard() {
+            standalone_aot(input, out_dir, false, false, cop)
+        }
+    }
+    let generated = path_join(out_dir, "{fixture}.das.cpp")
+    var source = ""
+    fopen(generated, "rb") $(fr) {
+        if (fr != null) {
+            source = fread(fr)
+        }
+    }
+    if (empty(source)) {
+        t |> failure("standalone_aot produced no {generated}")
+    }
+    remove(generated)
+    remove(path_join(out_dir, "{fixture}.das.h"))
+    return source
+}
+
+def private brace_balance(text : string) : int {
+    var balance = 0
+    peek_data(text) $(bytes) {
+        for (byte in bytes) {
+            let ch = int(byte)
+            if (ch == '{') {
+                balance ++
+            } elif (ch == '}') {
+                balance --
+            }
+        }
+    }
+    return balance
+}
+
+[test]
+def test_standalone_emit(t : T?) {
+    var tmp_err : string
+    let out_dir = create_temp_directory("standalone_emit", tmp_err)
+    if (!empty(tmp_err)) {
+        t |> failure("cannot create temp directory: {tmp_err}")
+        return
+    }
+
+    t |> run("a context with no init functions still closes its constructor") @(t : T?) {
+        let source = generate_standalone(t, "_standalone_novars_fixture", out_dir)
+        t |> success(find(source, "Standalone::Standalone() \{") >= 0, "constructor was emitted")
+        t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
+    }
+
+    t |> run("forward declarations spell types the way the definitions do") @(t : T?) {
+        let source = generate_standalone(t, "_standalone_tuple_fixture", out_dir)
+        t |> success(find(source, "TTuple<") >= 0, "the tuple definition was emitted")
+        t |> success(find(source, "AutoTuple<") < 0, "cross-platform spelling leaked into a native emit")
+        t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
+    }
+
+    rmdir(out_dir)
+}

--- a/tests/daslib/test_cpp_gen_defines.das
+++ b/tests/daslib/test_cpp_gen_defines.das
@@ -1,0 +1,59 @@
+options gen2
+options no_aot
+
+require daslib/cpp_gen
+require daslib/fio
+require dastest/testing_boost public
+
+let HEADER_TEXT = ("#define TCG_HEX 0x10\n" +
+    "#define TCG_DEC 42\n" +
+    "#define TCG_U8 UINT8_C(0x7f)\n" +
+    "#define TCG_U16 UINT16_C(0x1234)\n" +
+    "#define TCG_U32 UINT32_C(0xdeadbeef)\n" +
+    "#define TCG_U64 UINT64_C(0x1122334455667788)\n" +
+    "#define TCG_DEC 43\n" +
+    "#define TCG_TEXT \"not a constant\"\n")
+
+def private write_header(t : T?; header : string) {
+    fopen(header, "wb") $(fw) {
+        if (fw == null) {
+            t |> failure("cannot write {header}")
+            return
+        }
+        fwrite(fw, HEADER_TEXT)
+    }
+}
+
+[test]
+def test_cpp_gen_defines(t : T?) {
+    var tmp_err : string
+    let tmp_dir = create_temp_directory("cpp_gen_defines", tmp_err)
+    if (!empty(tmp_err)) {
+        t |> failure("cannot create temp directory: {tmp_err}")
+        return
+    }
+    let header = path_join(tmp_dir, "constants.h")
+    write_header(t, header)
+
+    let prefix = path_join(tmp_dir, "constants")
+    var headers <- [ header ]
+    genDefineConstants(headers, prefix)
+    delete headers
+
+    var generated = ""
+    fopen("{prefix}.const_inc", "rb") $(fr) {
+        if (fr != null) {
+            generated = fread(fr)
+        }
+    }
+    t |> equal(generated, ("addConstant<uint32_t>(*this,\"TCG_HEX\",uint32_t(0x10u));\n" +
+        "addConstant<int32_t>(*this,\"TCG_DEC\",int32_t(42));\n" +
+        "addConstant<uint8_t>(*this,\"TCG_U8\",uint8_t(0x7fu));\n" +
+        "addConstant<uint16_t>(*this,\"TCG_U16\",uint16_t(0x1234u));\n" +
+        "addConstant<uint32_t>(*this,\"TCG_U32\",uint32_t(0xdeadbeefu));\n" +
+        "addConstant<uint64_t>(*this,\"TCG_U64\",uint64_t(0x1122334455667788ul));\n"))
+
+    remove("{prefix}.const_inc")
+    remove(header)
+    rmdir(tmp_dir)
+}


### PR DESCRIPTION
**Behavior change: the AOT emitters produce correct output in four cases that were silently wrong — the standalone constructor always closes, forward declarations follow the target platform, a non-null pointer constant emits at all (and balanced), and five leaked visitors per emit are released.**

Five emitter fixes from the comment-sweep defect hunt, each pinned by an output-shape test.

`aot_standalone`: with zero init functions the generated constructor never closed its brace — unbalanced C++. And `describeCppFunc(pfun, collector, true, needInline)` was a positional mix-up: `cross_platform` hardcoded true and `needInline` landing in the `needName` slot, so cross-platform-off builds got mismatched forward declarations (`AutoTuple` in the declaration against `TTuple` in the definition).

`aot_cpp`: the non-null pointer-constant path first threw at runtime (`reinterpret` applied directly to a bound property — reading it into a local first makes the path run) and then emitted an unbalanced `((void*)0x..))`. That throw is why the paren bug could never be observed. Five visitor objects also leaked per emit — the ruled three plus two more of the same shape, and the standalone runner's pair; retained heap per run drops 20272 → 15248 bytes with byte-identical output.

`cpp_gen`: `searchAndGenConst` carried an offset-filter table nothing ever wrote — the always-true guard and its parameter are gone, call order untouched, pinned by a characterization test over all six `#define` shapes.

Where to look: `daslib/aot_standalone.das` (`writeStandaloneCtor`, `describeCppFunc` call, `runStandaloneVisitor`), `daslib/aot_cpp.das` (`visitExprConstPtr`, the visitor deletes), `daslib/cpp_gen.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first where observable: brace balance and declaration/definition drift asserted on emitted text before and after; the visitor leaks measured under `persistent_heap` across five repeated emits.
- Regular AOT of a language test and the CI-compiled standalone context are md5-identical before and after the daslib changes.
- tests/aot 157 green (2 pre-existing missing-shared-module errors identical at base), tests/daslib 263/263; lint and format clean on every touched file.

### Claims — stated, not tested
- `reinterpret<T>` applied directly to a bound property result throws "workhorse cross-pollination" at runtime — reproduced by probe, fixed here by hoisting into a local; the compiler-side defect and a lint candidate ("hoist a property result before reinterpret") are ledgered.

### Not done
- The same dead offset-filter exists in dasClangBind's own `searchAndGenConst` copy — out of scope, ledgered.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
