### PR TITLE
sweep fixes: upper_bound heterogeneous comparator, join over iterators, faker week_day, ast_print keywords, rst hooks and stubs

### DIFF
--- a/daslib/algorithm.das
+++ b/daslib/algorithm.das
@@ -159,7 +159,7 @@ def upper_bound(a : array<auto(TT)>; val : TT const -&) {
     return upper_bound(a, 0, length(a), val)
 }
 
-def upper_bound(a : array<auto(TT)>; f, l : int; value : auto(QQ); less : block<(a : TT const -&, b : QQ) : bool>) {
+def upper_bound(a : array<auto(TT)>; f, l : int; value : auto(QQ); less : block<(a : QQ, b : TT const -&) : bool>) {
     //! Returns the index of the first element in the range [f, l) for which less(val, element) returns true, or l if no such element is found.
     assert(f >= 0 && f <= l, "upper bound first out of range")
     assert(l >= f && l <= length(a), "upper bound last out of range")
@@ -178,7 +178,7 @@ def upper_bound(a : array<auto(TT)>; f, l : int; value : auto(QQ); less : block<
     return first
 }
 
-def upper_bound(a : array<auto(TT)>; value : auto(QQ); less : block<(a : TT const -&, b : QQ) : bool>) {
+def upper_bound(a : array<auto(TT)>; value : auto(QQ); less : block<(a : QQ, b : TT const -&) : bool>) {
     //! Returns the index of the first element in the array for which less(val, element) returns true, or length(a) if no such element is found.
     return upper_bound(a, 0, length(a), value, less)
 }

--- a/daslib/ast_print.das
+++ b/daslib/ast_print.das
@@ -198,7 +198,7 @@ class PrintVisitor : AstVisitor {
                     if (arg.annotation |> length != 0) {
                         write(*writer, "[{describe(arg.annotation)}] ");
                     }
-                    if (arg._type.flags.constant) {
+                    if (!arg._type.flags.constant) {
                         write(*writer, "var ");
                     }
                     write(*writer, "{arg.name} : {describe([decl=arg._type,extra=extraTypeInfo])}");
@@ -256,7 +256,7 @@ class PrintVisitor : AstVisitor {
         //! Prints the let or var keyword for a variable declaration.
         var isLet = true;
         for (pv in expr.variables) {
-            if (pv._type != null && pv._type.flags.constant) {
+            if (pv._type != null && !pv._type.flags.constant) {
                 isLet = false;
                 break;
             }

--- a/daslib/ast_print.das
+++ b/daslib/ast_print.das
@@ -173,10 +173,7 @@ class PrintVisitor : AstVisitor {
         if (!arg._type.flags.constant) {
             write(*writer, "var ");
         }
-        if (arg.isAccessUnused) {
-            write(*writer, " /*unsued*/ ");
-        }
-        write(*writer, "{arg.name} : {describe([decl=arg._type,extra=extraTypeInfo])}");
+        write_variable_decl(arg);
     }
     def override visitFunctionArgument(fun : FunctionPtr; arg : VariablePtr; last : bool) {
         //! Prints the separator between function arguments.

--- a/daslib/faker.das
+++ b/daslib/faker.das
@@ -347,12 +347,12 @@ def public is_leap_year(year : uint) {
 }
 
 def public week_day(year, month, day : uint) {
-    //! Returns week day for given date.
+    //! Returns week day for given date. `month` and `day` are 1-based; the result counts from 0 = Sunday.
     return week_day(int(year), int(month), int(day))
 }
 
 def public week_day(year, month, day : int) {
-    //! Returns week day for given date.
+    //! Returns week day for given date. `month` and `day` are 1-based; the result counts from 0 = Sunday.
     static_let() {
         let offset <- [ 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
     }
@@ -364,7 +364,7 @@ def public week_day(year, month, day : int) {
     var dayOfWeek  = 5
     dayOfWeek += (aux + afterFeb) * 365
     dayOfWeek += aux / 4 - aux / 100 + (aux + 100) / 400
-    dayOfWeek += offset[month] + (day - 1)
+    dayOfWeek += offset[month - 1] + (day - 1)
     dayOfWeek %= 7
     return dayOfWeek
 }
@@ -384,6 +384,6 @@ def public date(var faker : Faker) {
         max_days = 29u
     }
     day = 1u + (day % max_days)
-    let dow = week_day(year, month, day)
+    let dow = week_day(year, month + 1u, day)
     return "{g_days[dow]}, {g_months[month].name} {int(day)}, {int(year)}"
 }

--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -1974,54 +1974,59 @@ def private generate_topic_stub(var tab : table<string>; doc_file : file; topic 
     }
 }
 
-def private generate_substitute_stub(mod : Module?; substname : string) {
-    var _st : FStat
+def private generate_module_stubs(var tab : table<string>; stub_file : file; mod : Module?) {
+    for_each_typedef(mod) $(name, _value) {
+        generate_topic_stub(tab, stub_file, topic("typedef", mod, name))
+    }
+    for_each_enumeration(mod) $(value) {
+        generate_topic_stub(tab, stub_file, topic("enumeration", mod, string(value.name)))
+    }
+    for_each_structure(mod) $(value) {
+        if (value.flags.isClass) {
+            generate_topic_stub(tab, stub_file, topic("class", mod, string(value.name)))
+            for (fld in value.fields) {
+                if (is_class_method(value, fld) && !(fld.flags.generated) && !fld.flags.privateField && !(fld.flags.parentType) && (fld.flags.implemented) && fld.init != null) {
+                    generate_topic_stub(tab, stub_file, topic("function", mod, "{value.name}-{function_label_file(fld.name, fld.init._type, 1)}"))
+                }
+            }
+        } elif (!value.flags.generated) {
+            generate_topic_stub(tab, stub_file, topic("structure", mod, string(value.name)))
+        }
+    }
+    for_each_function(mod, "") $(func) {
+        if (function_needs_documenting(func)) {
+            generate_topic_stub(tab, stub_file, topic("function", mod, function_label_file(func)))
+        }
+    }
+    for_each_generic(mod) $(func) {
+        if (function_needs_documenting(func)) {
+            generate_topic_stub(tab, stub_file, topic("function", mod, function_label_file(func)))
+        }
+    }
+    module_for_each_annotation(mod) $(value) {
+        if (value.isBasicStructureAnnotation) {
+            generate_topic_stub(tab, stub_file, topic("structure_annotation", mod, string(value.name)))
+        } elif (value.isTypeAnnotation) {
+            generate_topic_stub(tab, stub_file, topic("annotation", mod, string(value.name)))
+        }
+    }
+    for_each_global(mod) $(value) {
+        if (is_global_constant(value)) {
+            generate_topic_stub(tab, stub_file, topic("Variable", mod, string(value.name)))
+        }
+    }
+}
+
+def private generate_substitute_stub(mods : array<Module?>; substname : string) {
     mkdir_rec(dir_name(substname))
     fopen(substname, "wb") $(stub_file) {
-        if (stub_file != null) {
-            var tab : table<string>
-            for_each_typedef(mod) $(name, _value) {
-                generate_topic_stub(tab, stub_file, topic("typedef", mod, name))
-            }
-            for_each_enumeration(mod) $(value) {
-                generate_topic_stub(tab, stub_file, topic("enumeration", mod, string(value.name)))
-            }
-            for_each_structure(mod) $(value) {
-                if (value.flags.isClass) {
-                    generate_topic_stub(tab, stub_file, topic("class", mod, string(value.name)))
-                    for (fld in value.fields) {
-                        if (is_class_method(value, fld) && !(fld.flags.generated) && !(fld.flags.parentType) && (fld.flags.implemented)) {
-                            generate_topic_stub(tab, stub_file, topic("method", mod, "{value.name}.{fld.name}"))
-                        }
-                    }
-                } elif (!value.flags.generated) {
-                    generate_topic_stub(tab, stub_file, topic("structure", mod, string(value.name)))
-                }
-            }
-            for_each_function(mod, "") $(func) {
-                if (function_needs_documenting(func)) {
-                    generate_topic_stub(tab, stub_file, topic("function", mod, "{func.name}"))
-                }
-            }
-            for_each_generic(mod) $(func) {
-                if (function_needs_documenting(func)) {
-                    generate_topic_stub(tab, stub_file, topic("function", mod, "{func.name}"))
-                }
-            }
-            module_for_each_annotation(mod) $(value) {
-                if (value.isBasicStructureAnnotation) {
-                    generate_topic_stub(tab, stub_file, topic("structure_annotation", mod, string(value.name)))
-                } elif (value.isTypeAnnotation) {
-                    generate_topic_stub(tab, stub_file, topic("any_annotation", mod, string(value.name)))
-                }
-            }
-            for_each_global(mod) $(value) {
-                if (is_global_constant(value)) {
-                    generate_topic_stub(tab, stub_file, topic("variable", mod, string(value.name)))
-                }
-            }
-        } else {
+        if (stub_file == null) {
             PANIC("can't generate stub at {substname}\n")
+            return
+        }
+        var tab : table<string>
+        for (mod in mods) {
+            generate_module_stubs(tab, stub_file, mod)
         }
     }
 }
@@ -2084,9 +2089,7 @@ def public documents(name : string; mods : array<Module?>; fname : string; var g
     }
     fwrite(doc_file, make_header(name, mod_name))
     fwrite(doc_file, ".. das:module:: {mod_name}\n\n")
-    for (mod in mods) {
-        generate_substitute_stub(mod, "{topic_root}/detail/{fname}")
-    }
+    generate_substitute_stub(mods, "{topic_root}/detail/{fname}")
     for (mod in mods) {
         document_topic(doc_file, topic(mod), "Module {mod.name}")
         break

--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -1518,7 +1518,7 @@ def document_enumeration_annotations(doc_file : file; mods : array<Module?>; hoo
     for (mod in mods) {
         if (any) break
         module_for_each_annotation(mod) $(value) {
-            if (!value.isEnumerationAnnotation) return
+            if (any || !value.isEnumerationAnnotation || (hook.annotationFilter != null && !hook.annotationFilter |> invoke(value))) return
             any = true
         }
     }
@@ -1526,7 +1526,7 @@ def document_enumeration_annotations(doc_file : file; mods : array<Module?>; hoo
     fwrite(doc_file, make_group("Handled enumerations"))
     for (mod in mods) {
         module_for_each_annotation(mod) $(value) {
-            if (!value.isEnumerationAnnotation) return
+            if (!value.isEnumerationAnnotation || (hook.annotationFilter != null && !hook.annotationFilter |> invoke(value))) return
             document_enumeration_annotation(doc_file, mod, value)
         }
     }

--- a/daslib/strings_boost.das
+++ b/daslib/strings_boost.das
@@ -64,11 +64,7 @@ def join(var it : iterator<auto(TT)>; separator : string implicit) {
             } else {
                 write(writer, separator)
             }
-            static_if (typeinfo is_numeric(type<TT>)) {
-                write_char(writer, elem)
-            } else {
-                write(writer, elem)
-            }
+            write(writer, elem)
         }
     }
     return st

--- a/tests/algorithm/test_algorithm_new.das
+++ b/tests/algorithm/test_algorithm_new.das
@@ -4,6 +4,10 @@ options no_unused_block_arguments = false
 require daslib/algorithm
 require dastest/testing_boost public
 
+struct KeyedItem {
+    key : int
+}
+
 // ---- upper_bound ----
 
 [test]
@@ -49,6 +53,17 @@ def test_upper_bound(t : T?) {
         let a <- [1, 2, 2, 2, 3]
         t |> equal(lower_bound(a, 2), 1)
         t |> equal(upper_bound(a, 2), 4)
+    }
+    t |> run("key comparator of a type the elements are not") @(t : T?) {
+        let a <- [KeyedItem(key = 1), KeyedItem(key = 3), KeyedItem(key = 3), KeyedItem(key = 7)]
+        let lo = lower_bound(a, 3) $(e : KeyedItem const -&; k : int) {
+            return e.key < k
+        }
+        let hi = upper_bound(a, 3) $(k : int; e : KeyedItem const -&) {
+            return k < e.key
+        }
+        t |> equal(lo, 1)
+        t |> equal(hi, 3)
     }
 }
 

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -288,6 +288,7 @@ SET(AOT_DASLIB_FILES
     tests/daslib/test_logger.das
     tests/daslib/tty_test.das
     tests/daslib/test_sha_256.das
+    tests/daslib/test_faker.das
 )
 
 FILE(GLOB AOT_MCP_FILES RELATIVE ${PROJECT_SOURCE_DIR} CONFIGURE_DEPENDS "tests/mcp/*.das")

--- a/tests/daslib/_rst_probe.das
+++ b/tests/daslib/_rst_probe.das
@@ -1,0 +1,42 @@
+options gen2
+options rtti
+options no_aot
+
+module _rst_probe shared private
+
+require dastest/testing_boost public
+require daslib/fio
+require daslib/rtti
+require daslib/rst public
+
+struct public DocRun {
+    root : string
+    page : string
+    stubs : string
+}
+
+def public document_into_temp(t : T?; mods : array<Module?>; hook : DocsHook) : DocRun {
+    //! Runs the RST generator over `mods` into a throwaway tree and returns the page
+    //! plus its substitution-stub file. Call `drop_run` on the result.
+    var err : string
+    let root = create_temp_directory("das_rst_probe", err)
+    t |> success(empty(err), "temp directory: {err}")
+    let saved_topic = topic_root
+    let saved_handmade = handmade_root
+    topic_root = "{root}/generated"
+    handmade_root = "{root}/handmade"
+    var groups : array<DocGroup>
+    documents("Probe", mods, "probe.rst", groups, hook)
+    let made = DocRun(root = root,
+        page = fread("{topic_root}/probe.rst"),
+        stubs = fread("{topic_root}/detail/probe.rst"))
+    topic_root = saved_topic
+    handmade_root = saved_handmade
+    return made
+}
+
+def public drop_run(made : DocRun) {
+    //! Removes the throwaway tree a `document_into_temp` run left behind.
+    var err : string
+    rmdir_rec(made.root, err)
+}

--- a/tests/daslib/_rst_stub_mod_a.das
+++ b/tests/daslib/_rst_stub_mod_a.das
@@ -1,0 +1,14 @@
+options gen2
+options no_aot
+
+module _rst_stub_mod_a
+
+def public rst_stub_alpha(x : int) : int {
+    //! First fixture function of the A module.
+    return x + 1
+}
+
+def public rst_stub_alpha_two(x : int) : int {
+    //! Second fixture function of the A module.
+    return x + 2
+}

--- a/tests/daslib/_rst_stub_mod_b.das
+++ b/tests/daslib/_rst_stub_mod_b.das
@@ -1,0 +1,14 @@
+options gen2
+options no_aot
+
+module _rst_stub_mod_b
+
+def public rst_stub_beta(x : int) : int {
+    //! First fixture function of the B module.
+    return x + 3
+}
+
+def public rst_stub_beta_two(x : int) : int {
+    //! Second fixture function of the B module.
+    return x + 4
+}

--- a/tests/daslib/test_ast_print.das
+++ b/tests/daslib/test_ast_print.das
@@ -1,0 +1,76 @@
+options gen2
+options rtti
+options no_aot
+options no_coverage
+
+require dastest/testing_boost public
+require daslib/ast
+require daslib/rtti
+require daslib/ast_boost
+require daslib/ast_print
+require strings
+require daslib/strings_boost
+
+var g_seed = 1
+
+[never_inline]
+def apply_ro(v : int; blk : block<(x : int) : int>) : int {
+    return invoke(blk, v)
+}
+
+[never_inline]
+def apply_rw(v : int; blk : block<(var y : int) : int>) : int {
+    return invoke(blk, v)
+}
+
+[never_inline]
+def fixture_shape() : int {
+    let a = g_seed + 1
+    var b = a * 2
+    b += apply_ro(b) $(x : int) : int {
+        return x + 1
+    }
+    b += apply_rw(b) $(var y : int) : int {
+        y ++
+        return y
+    }
+    return b
+}
+
+def printed_fixture(t : T?) : string {
+    var txt = ""
+    compiling_module() |> for_each_function("fixture_shape") $(var func) {
+        if (empty(txt)) {
+            txt = build_string() $(var w) {
+                printFunc(func, unsafe(addr(w)))
+            }
+        }
+    }
+    t |> success(!empty(txt), "fixture_shape not found in the compiling module")
+    return txt
+}
+
+[test]
+def test_ast_print_let_var(t : T?) {
+    g_seed = 1
+    t |> equal(fixture_shape(), 19)
+    let golden = join(fixed_array<string>(
+        "[never_inline]",
+        "def fixture_shape : int const \{",
+        "    let a : int const = (g_seed + 1)",
+        "    var b : int = (a * 2)",
+        "    (b += apply_ro(b,$(x : int const):int \{",
+        "        return (x + 1)",
+        "    \}))",
+        "    (b += apply_rw(b,$(var y : int -const):int \{",
+        "        ++(y)",
+        "        return y",
+        "    \}))",
+        "    return b",
+        "\}",
+        "",
+        ""), "\n")
+    t |> run("locals and closure arguments print their own mutability") @(t : T?) {
+        t |> equal(printed_fixture(t), golden)
+    }
+}

--- a/tests/daslib/test_ast_print.das
+++ b/tests/daslib/test_ast_print.das
@@ -2,6 +2,7 @@ options gen2
 options rtti
 options no_aot
 options no_coverage
+options no_unused_function_arguments = false
 
 require dastest/testing_boost public
 require daslib/ast
@@ -37,16 +38,22 @@ def fixture_shape() : int {
     return b
 }
 
-def printed_fixture(t : T?) : string {
+[never_inline]
+def fixture_args(var out : int; spare : int) : int { // nolint:LINT012 - spare is unused on purpose: it is the fixture for the printer's unused-argument marker
+    out ++
+    return out
+}
+
+def printed_fixture(t : T?; name : string) : string {
     var txt = ""
-    compiling_module() |> for_each_function("fixture_shape") $(var func) {
+    compiling_module() |> for_each_function(name) $(var func) {
         if (empty(txt)) {
             txt = build_string() $(var w) {
                 printFunc(func, unsafe(addr(w)))
             }
         }
     }
-    t |> success(!empty(txt), "fixture_shape not found in the compiling module")
+    t |> success(!empty(txt), "{name} not found in the compiling module")
     return txt
 }
 
@@ -71,6 +78,23 @@ def test_ast_print_let_var(t : T?) {
         "",
         ""), "\n")
     t |> run("locals and closure arguments print their own mutability") @(t : T?) {
-        t |> equal(printed_fixture(t), golden)
+        t |> equal(printed_fixture(t, "fixture_shape"), golden)
+    }
+}
+
+[test]
+def test_ast_print_function_arguments(t : T?) {
+    g_seed = 1
+    t |> equal(fixture_args(g_seed, 0), 2)
+    let golden = join(fixed_array<string>(
+        "[never_inline]",
+        "def fixture_args ( var out : int -const;  /*unused*/ spare : int const )  : int const \{",
+        "    ++(out)",
+        "    return out",
+        "\}",
+        "",
+        ""), "\n")
+    t |> run("function arguments print their mutability and the unused marker") @(t : T?) {
+        t |> equal(printed_fixture(t, "fixture_args"), golden)
     }
 }

--- a/tests/daslib/test_faker.das
+++ b/tests/daslib/test_faker.das
@@ -1,0 +1,100 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/faker
+require strings
+require daslib/strings_boost
+
+let REF_MONTH_SHIFT = fixed_array<int>(0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4)
+
+let MONTH_NAMES = fixed_array<string>("January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December")
+
+let DAY_NAMES = fixed_array<string>("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+
+def private reference_week_day(year, month, day : int) : int {
+    var y = year
+    if (month < 3) {
+        y --
+    }
+    return (y + y / 4 - y / 100 + y / 400 + REF_MONTH_SHIFT[month - 1] + day) % 7
+}
+
+def private month_index(name : string) : int {
+    for (mn, idx in MONTH_NAMES, count(0)) {
+        if (mn == name) return idx
+    }
+    return -1
+}
+
+[test]
+def test_week_day_known_dates(t : T?) {
+    t |> run("dates the algorithm is anchored on") @(t : T?) {
+        t |> equal(week_day(1700, 1, 1), 5)
+        t |> equal(week_day(2028, 3, 1), 3)
+        t |> equal(week_day(2028, 2, 29), 2)
+        t |> equal(week_day(2000, 1, 1), 6)
+        t |> equal(week_day(1900, 3, 1), 4)
+        t |> equal(week_day(2024, 12, 31), 2)
+    }
+    t |> run("the uint overload agrees with the int one") @(t : T?) {
+        t |> equal(week_day(2028u, 3u, 1u), 3)
+        t |> equal(week_day(2024u, 12u, 31u), 2)
+    }
+}
+
+[test]
+def test_week_day_matches_reference(t : T?) {
+    t |> run("every month of every year from 1700 to 2100") @(t : T?) {
+        var mismatch = ""
+        for (year in range(1700, 2101)) {
+            for (month in range(1, 13)) {
+                for (day in fixed_array<int>(1, 15, 28)) {
+                    let got = week_day(year, month, day)
+                    let want = reference_week_day(year, month, day)
+                    if (got != want && empty(mismatch)) {
+                        mismatch = "{year}-{month}-{day}: got {got}, want {want}"
+                    }
+                }
+            }
+        }
+        t |> success(empty(mismatch), "first mismatch at {mismatch}")
+    }
+    t |> run("the leap-day boundary") @(t : T?) {
+        var mismatch = ""
+        for (year in range(1700, 2101)) {
+            continue if (!is_leap_year(uint(year)))
+            for (date in fixed_array<int2>(int2(2, 29), int2(3, 1))) {
+                let got = week_day(year, date.x, date.y)
+                let want = reference_week_day(year, date.x, date.y)
+                if (got != want && empty(mismatch)) {
+                    mismatch = "{year}-{date.x}-{date.y}: got {got}, want {want}"
+                }
+            }
+        }
+        t |> success(empty(mismatch), "first mismatch at {mismatch}")
+    }
+}
+
+[test]
+def test_faker_date_names_the_right_week_day(t : T?) {
+    t |> run("generated dates carry the week day they fall on") @(t : T?) {
+        var fake <- Faker()
+        var mismatch = ""
+        for (_i in range(200)) {
+            let text = fake |> date
+            let parts <- split(text, ", ")
+            t |> equal(length(parts), 3)
+            let monthDay <- split(parts[1], " ")
+            t |> equal(length(monthDay), 2)
+            let month = month_index(monthDay[0]) + 1
+            let day = to_int(monthDay[1])
+            let year = to_int(parts[2])
+            let want = DAY_NAMES[reference_week_day(year, month, day)]
+            if (parts[0] != want && empty(mismatch)) {
+                mismatch = "{text}: named {parts[0]}, falls on {want}"
+            }
+        }
+        t |> success(empty(mismatch), "{mismatch}")
+    }
+}

--- a/tests/daslib/test_rst_hooks.das
+++ b/tests/daslib/test_rst_hooks.das
@@ -1,0 +1,29 @@
+options gen2
+options rtti
+options no_aot
+options no_coverage
+
+require dastest/testing_boost public
+require daslib/rtti
+require daslib/ast
+require daslib/rst
+require daslib/enum_trait
+require strings
+require _rst_probe
+
+[test]
+def test_rst_enumeration_annotation_hook(t : T?) {
+    let mods : array<Module?> = [find_module("enum_trait")]
+    let unfiltered <- document_into_temp(t, mods, DocsHook())
+    t |> success(find(unfiltered.page, "Handled enumerations") >= 0, "fixture module has no enumeration annotation")
+    drop_run(unfiltered)
+    var hook = DocsHook()
+    hook.annotationFilter <- @(ann : rtti::Annotation const) : bool {
+        return false
+    }
+    let filtered <- document_into_temp(t, mods, hook)
+    t |> run("annotationFilter reaches the enumeration annotations too") @(t : T?) {
+        t |> success(find(filtered.page, "Handled enumerations") < 0, "filtered-out annotations still documented")
+    }
+    drop_run(filtered)
+}

--- a/tests/daslib/test_rst_stubs.das
+++ b/tests/daslib/test_rst_stubs.das
@@ -1,0 +1,30 @@
+options gen2
+options rtti
+options no_aot
+options no_coverage
+
+require dastest/testing_boost public
+require daslib/rtti
+require daslib/ast
+require daslib/rst
+require strings
+require _rst_probe
+require _rst_stub_mod_a
+require _rst_stub_mod_b
+
+[test]
+def test_rst_substitution_stubs_span_every_module(t : T?) {
+    let mods : array<Module?> = [find_module("_rst_stub_mod_a"), find_module("_rst_stub_mod_b")]
+    let docs <- document_into_temp(t, mods, DocsHook())
+    t |> run("the stub file keeps the first module's symbols too") @(t : T?) {
+        t |> success(find(docs.stubs, "rst_stub_beta") >= 0, "last module missing: {docs.stubs}")
+        t |> success(find(docs.stubs, "rst_stub_alpha") >= 0, "first module missing: {docs.stubs}")
+    }
+    t |> run("stub topic names are the ones the page reads back") @(t : T?) {
+        for (name in fixed_array<string>("rst_stub_alpha", "rst_stub_alpha_two", "rst_stub_beta", "rst_stub_beta_two")) {
+            let needle = "{name}-0x"
+            t |> success(find(docs.stubs, needle) >= 0, "{name} stub carries no argument hash: {docs.stubs}")
+        }
+    }
+    drop_run(docs)
+}

--- a/tests/strings/strings_boost_split_and_join.das
+++ b/tests/strings/strings_boost_split_and_join.das
@@ -101,6 +101,24 @@ def test_join_block_forms(t : T?) {
     }
 }
 
+[test]
+def test_join_iterator_elements(t : T?) {
+    t |> run("numeric elements join as numbers, exactly as the array form does") @@(t : T?) {
+        let ints <- [ 1, 2, 3 ]
+        t |> equal(join(ints, ","), "1,2,3")
+        t |> equal(join(unsafe(each(ints)), ","), "1,2,3")
+        let floats <- [ 1.5, 2.5 ]
+        t |> equal(join(unsafe(each(floats)), ","), "1.5,2.5")
+    }
+    t |> run("string elements survive the iterator overload") @@(t : T?) {
+        let words <- [ "a", "b" ]
+        t |> equal(join(unsafe(each(words)), "-"), "a-b")
+    }
+    t |> run("a string is still joined character by character") @@(t : T?) {
+        t |> equal(join("abc", "-"), "a-b-c")
+    }
+}
+
 
 [test]
 def tricky_test_split_and_join(t : T?) {


### PR DESCRIPTION
**Behavior changes: `algorithm::upper_bound`'s heterogeneous-comparator overload now compiles (its declaration matches the order it always called with); `strings_boost::join` over an iterator of numbers writes numbers, not character codes; `faker::week_day` is coherently 1-based and no longer reads past its offset table; `ast_print` prints the right let/var keywords for locals and closure arguments.**

Six tooling and API fixes from the comment-sweep defect hunt, each red-first.

`ast_print` printed `var` for const locals and `let` for mutable ones (the globals path was correct all along), and inverted closure-argument constness — it had never had a test; it now has two golden fixtures. Fixing the adjacent `/*unsued*/` typo exposed a genuine duplication the misspelling had been hiding, so the argument path now routes through `write_variable_decl` like the variable path.

`rst`: `document_enumeration_annotations` ignored its hook's annotation filter where its three siblings honour it; and the substitution-stub file was opened `"wb"` per module, so a multi-module doc run kept only the last module's stubs, under topic names the reading side never used. One pass now spans every module under the names the page reads.

`upper_bound` invoked its comparator as `(value, element)` while the declaration said `(element, value)` — heterogeneous key/element comparators were a hard compile error. The declaration now follows the call (the `std::upper_bound` convention); swapping the call instead would have broken `upper_bound` semantics, proven by the pre-existing greater-comparator test.

`join` over an iterator routed numeric elements through `write_char`. `week_day` mixed a 1-based leap test with a 0-based table (March 1st of a leap year was off by one) and a 1-based December read `offset[12]` of a 12-entry table; it is now 1-based throughout, cross-checked against Sakamoto's algorithm for every month of 1700-2100.

Where to look: `daslib/ast_print.das`, `daslib/rst.das`, `daslib/algorithm.das`, `daslib/strings_boost.das`, `daslib/faker.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first fixtures for every fix; ast_print's are its first coverage ever.
- tests/algorithm 163/163, tests/strings 445/445, tests/daslib 279/279 on the merged master; lint and format clean on all 15 touched files.

### Not done
- Open ruling: the substitution-stub file is now correct, but nothing appears to read it any more (`conf.py` excludes `stdlib/generated/detail`, and topics inline their content) — keep or delete is a maintainer call.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
