### PR TITLE
parser: piping into an operator is a compile error, not a silent discard of the piped value

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -908,7 +908,7 @@ class public AotDebugInfoHelper {
             writeDim(writer, fld, suffix);
             writeArgTypes(writer, fld, suffix);
             writeArgNames(writer, fld, suffix);
-            let prefix = (info.module_name |> !empty(info.module_name)) ? "{info.module_name}::" : "";
+            let prefix = !empty(info.module_name) ? "{info.module_name}::" : "";
             writeVarAnnotationArgs(writer, fld, "{structInfoName(info)}_field_{fi}_ann");
             let fldAnnRef = fld.annotation_argument_count > 0u ? ", {structInfoName(info)}_field_{fi}_ann, {int(fld.annotation_argument_count)}u" : ""
             let structCppName = aotSuffixNameEx(info.name, "_S",

--- a/daslib/aot_macro.das
+++ b/daslib/aot_macro.das
@@ -17,7 +17,7 @@ class AstAot : AstSimulateMacro {
         //! Runs AOT compilation of the program and writes the result to the output file specified in policies.
         return true if (is_in_completion() || is_compiling_macros() || is_folding())
         let res = run_aot(prog, ctx, prog.policies)
-        var is_ok = res |> !empty(res)
+        var is_ok = !empty(res)
         if (is_ok) {
             let fileName = "{prog.policies.aot_result}"
             print("Aot to {fileName}\n")

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -68,7 +68,7 @@ def writeStandaloneContextMethods(var prog : ProgramPtr; var logs : StringBuilde
             let args_str = (fn.arguments |> each()
                                         |> map(@(v : VariablePtr) { return coll.getVarName(v); })
                                         |> join(", "))
-            let maybe_comma = args_str |> !empty(args_str) ? ", " : "";
+            let maybe_comma = !empty(args_str) ? ", " : "";
             write(logs, " \{\n    return {aotFuncName(fn)}(this{maybe_comma}{args_str});\n\}\n\n");
         }
     }
@@ -118,7 +118,7 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
     write(tw, "    context.tabMnLookup = make_shared<das_hash_map<uint64_t,SimFunction *>>();\n");
     write(tw, "    context.tabMnLookup->clear();\n");
 
-    if (initFunctions |> !empty(initFunctions)) {
+    if (!empty(initFunctions)) {
         write(tw, "     // start totalFunctions\n");
         write(tw, "    struct FunctionStorage \{ int idx; FunctionInfo funcInfo; FuncInfo* debugInfo; \};\n");
         write(tw, "    FunctionStorage usedFunctions[] = \{\n");
@@ -157,7 +157,7 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
         write(tw, "    \}\n");
     }
 
-    if (initFunctions |> !empty(initFunctions)) {
+    if (!empty(initFunctions)) {
         write(tw, " FillFunction(context, getGlobalAotLibrary(), id_to_funcs);\n");
         write(tw, "    context.runInitScript();\n");
         write(tw, "\}\n");
@@ -357,12 +357,12 @@ def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string
     var source_content = ""
     let header_content = build_string() $(header) {
     source_content = build_string() $(source) {
-        if (mod_name |> !empty(mod_name)) {
+        if (!empty(mod_name)) {
             write(header, "// Module {mod_name}\n");
         }
         write(header, "{AOT_INCLUDES}");
 
-        if (mod_name |> !empty(mod_name)) {
+        if (!empty(mod_name)) {
             write(source, "// Module {mod_name}\n");
         }
 

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -1377,6 +1377,7 @@ namespace das {
             auto pOp = (ExprOp *) fncall;
             das_yyerror(scanner,"can't rpipe into operator '" + pOp->op + "'. the piped argument would be discarded",
                 locAt,CompilationError::cant_expression);
+            delete arg;
             return fncall;
         } else if ( fncall->rtti_isCallLikeExpr() ) {
             auto pCall = (ExprLooksLikeCall *) fncall;
@@ -1402,6 +1403,7 @@ namespace das {
             return fncall;
         } else {
             das_yyerror(scanner,"can only rpipe into a function call",locAt,CompilationError::cant_expression);
+            delete arg;
             return fncall;
         }
     }

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -1373,7 +1373,12 @@ namespace das {
     }
 
     Expression * ast_rpipe ( yyscan_t scanner, Expression * arg, Expression * fncall, const LineInfo & locAt ) {
-        if ( fncall->rtti_isCallLikeExpr() ) {
+        if ( fncall->rtti_isOp1() || fncall->rtti_isOp2() || fncall->rtti_isOp3() ) {
+            auto pOp = (ExprOp *) fncall;
+            das_yyerror(scanner,"can't rpipe into operator '" + pOp->op + "'. the piped argument would be discarded",
+                locAt,CompilationError::cant_expression);
+            return fncall;
+        } else if ( fncall->rtti_isCallLikeExpr() ) {
             auto pCall = (ExprLooksLikeCall *) fncall;
             pCall->arguments.insert(pCall->arguments.begin(),arg);
             return fncall;

--- a/tests/language/cant_rpipe_into_operator.das
+++ b/tests/language/cant_rpipe_into_operator.das
@@ -1,0 +1,16 @@
+// an operator has no argument list, so a value piped into one is silently discarded
+options gen2
+expect 30922:3
+
+def side_effect : string {
+    return "abc"
+}
+
+[export]
+def main {
+    var a = 5
+    var s = "abc"
+    debug(side_effect() |> !empty(s))
+    debug(side_effect() |> -a)
+    debug(side_effect() |> (a + a))
+}

--- a/tests/language/cant_rpipe_into_operator.das
+++ b/tests/language/cant_rpipe_into_operator.das
@@ -1,4 +1,4 @@
-// an operator has no argument list, so a value piped into one is silently discarded
+// an operator has no argument list, so piping a value into one is a compile error
 options gen2
 expect 30922:3
 

--- a/utils/aot/main.das
+++ b/utils/aot/main.das
@@ -133,7 +133,7 @@ def find_bool(args : array<string>; key : string) {
 def write_result(content : string; output_filename : string;
                  mode : string; force_overwrite : bool) {
     var result : bool = true
-    if (content |> !empty(content) && (force_overwrite || !is_content_same(content, output_filename))) {
+    if (!empty(content) && (force_overwrite || !is_content_same(content, output_filename))) {
         fopen(output_filename, "wb") $(fw) {
             if (fw != null) {
                 to_log(LOG_INFO, "{mode} to {output_filename}\n")


### PR DESCRIPTION
**Behavior change: piping into an operator — `X |> !expr`, `X |> -expr`, `X |> (a + b)` — is now compile error 30922. Before, the pipe compiled and silently discarded `X` unevaluated.**

`bump() |> !empty(x)` never called `bump()`. `ast_rpipe` routed the piped value into `ExprLooksLikeCall::arguments`; every `ExprOp` form inherits that list but reads its operands from `subexpr`/`left`/`right`, so the inserted argument was never looked at again. One guard ahead of the call-like branch in `ast_rpipe` covers both grammars and all three arities, and the error names the operator concretely. The eight accidental in-tree uses of the shape (all `X |> !empty(X)`) are rewritten to `!empty(X)`.

Where to look: `src/parser/parser_impl.cpp` (the guard), `tests/language/cant_rpipe_into_operator.das` (the fixture).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first: the fixture compiled with zero errors before the guard and reports all three shapes (unary `!`, unary `-`, parenthesized binary) after.
- A repo-wide sweep for other pipe-into-operator spellings found only the eight rewritten sites; `x |> (a ?? b)` was already rejected (`ExprNullCoalescing` is not call-like).
- Full preflight green on this branch; tests/language 1679/1679, and the whole interpreter suite ran clean at the fleet stage.
- External codex round: no findings.

### Not done
- A companion lint rule flagging the shape in external code is ledgered in `daslib/followup_comment_sweep.md`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
