### PR TITLE
sweep fixes: json surrogates/overflow/spoofable errors, jsonrpc owned request scope closes the per-request leak

### DIFF
--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -322,6 +322,18 @@ an entry lands here only when no name, shape, or test can carry it.
   `data` survives a write.
 - **json**: `is_json_white_space` is deliberately not the shared `is_white_space` —
   RFC 8259 admits exactly space/tab/CR/LF.
+- **jsonrpc**: parsing a request is a SCOPE, not a value. `ParsedRequest.params` is a
+  borrowed view into the parse tree, so the tree has to outlive the handler and cannot
+  be freed inside the parser — instead the owner is named in the result (`document` on
+  `ParsedRequest` for `parse_request`, on `ParsedBatch` for `parse_batch`, where the
+  entries borrow and own nothing) and the scope is closed by `free_request` /
+  `free_batch`; `dispatch_line` owns the whole scope and frees after the dispatcher has
+  run over every entry. Freeing is safe for the string fields because daslang never
+  finalizes a `string` field (`TypeDecl::needDelete` is false for `tString`), so
+  `method` / `id_str` / `params_json` / `error_envelope` outlive the tree — only the
+  `params` pointer dangles, which is why the free nulls it. The response side has no
+  such scope: `parse_one_response` copies everything into strings, so
+  `parse_response` / `parse_response_batch` free their own tree before returning.
 - **sql_migrate**: the audit table is provider-neutral by construction (client-side epoch
   seconds, BIGINT); duplicate versions are caught in two layers because neither sees
   everything; the `struct_convert_field` overload set is a specificity ladder — deleting

--- a/daslib/REVIEW.md
+++ b/daslib/REVIEW.md
@@ -112,6 +112,21 @@ A later pass lowers the lambda to a plain function and clears non-sticky errors.
 **UTF-8 byte-class tables are indexed through `uint(uint8(ch))`** — `for (ch in string)`
 yields a SIGNED byte under JIT; a raw index reads out of bounds for every byte >= 0x80.
 
+**A parser result that borrows a view into a tree the parser allocated names the owning
+field and ships the scope-ender that frees it.** Nothing else can free it — the tree must
+outlive the caller's read, and daslang finalizes neither a raw pointer field nor a local
+container at scope exit — so a borrowed view with no named owner leaks the whole document
+per call, invisibly until the process is long-lived.
+
+**A conversion that throws on out-of-range input is a panic on untrusted bytes.** `int64` /
+`uint64` / `double` on a string throw; a lexer or decoder reachable from a file, a socket,
+or a model reaches for the non-throwing `to_*` twin and reports through its own error
+channel.
+
+**A parser never re-derives control flow from the text of its own diagnostics.** A message
+carries user data, so `starts_with` on an error string is an input-controlled branch; the
+token that caused the failure is what the decision reads.
+
 **Every flatten_opt rewrite arm ships a read-only residual predicate** — the oracle the
 residual visitors call to prove the pass complete.
 

--- a/daslib/json.das
+++ b/daslib/json.das
@@ -50,6 +50,93 @@ struct TokenAt {
 let private {
     Token_string = typeinfo variant_index<_string>(type<Token>) //! index of the
     Token_symbol = typeinfo variant_index<_symbol>(type<Token>)
+    HIGH_SURROGATE_FIRST = 0xD800u
+    HIGH_SURROGATE_LAST = 0xDBFFu
+    LOW_SURROGATE_FIRST = 0xDC00u
+    LOW_SURROGATE_LAST = 0xDFFFu
+    SUPPLEMENTARY_FIRST = 0x10000u
+    REPLACEMENT_CODEPOINT = 0xFFFDu
+    INT64_MAX_DIGITS = 19
+}
+
+def private is_high_surrogate(codepoint : uint) : bool => codepoint >= HIGH_SURROGATE_FIRST && codepoint <= HIGH_SURROGATE_LAST
+
+def private is_low_surrogate(codepoint : uint) : bool => codepoint >= LOW_SURROGATE_FIRST && codepoint <= LOW_SURROGATE_LAST
+
+def private push_utf8_continuation(var str : array<uint8>; codepoint : uint; shift : uint) {
+    //! appends one UTF-8 continuation byte carrying the six `codepoint` bits above `shift`.
+    push(str, uint8(0x80u | ((codepoint >> shift) & 0x3Fu)))
+}
+
+def private push_utf8(var str : array<uint8>; codepoint : uint) {
+    //! appends the UTF-8 encoding of `codepoint` to `str`.
+    if (codepoint <= 0x7Fu) {
+        push(str, uint8(codepoint))
+    } elif (codepoint <= 0x7FFu) {
+        push(str, uint8(0xC0u | (codepoint >> 6u)))
+        push_utf8_continuation(str, codepoint, 0u)
+    } elif (codepoint <= 0xFFFFu) {
+        push(str, uint8(0xE0u | (codepoint >> 12u)))
+        push_utf8_continuation(str, codepoint, 6u)
+        push_utf8_continuation(str, codepoint, 0u)
+    } else {
+        push(str, uint8(0xF0u | (codepoint >> 18u)))
+        push_utf8_continuation(str, codepoint, 12u)
+        push_utf8_continuation(str, codepoint, 6u)
+        push_utf8_continuation(str, codepoint, 0u)
+    }
+}
+
+def private flush_unpaired_surrogate(var str : array<uint8>; var pending : uint&) {
+    //! emits U+FFFD for a high surrogate that never got its low half, and clears `pending`.
+    if (!is_high_surrogate(pending)) return
+    pending = 0u
+    push_utf8(str, REPLACEMENT_CODEPOINT)
+}
+
+def private hex4_codepoint(hex_str : array<uint8>) : uint {
+    //! folds four hex digits into a code point.
+    var codepoint = 0u
+    for (hb in hex_str) {
+        codepoint = codepoint << 4u
+        let c = int(hb)
+        if (is_number(c)) {
+            codepoint += uint(c - '0')
+        } elif (c >= 'a' && c <= 'f') {
+            codepoint += uint(c - 'a' + 10)
+        } elif (c >= 'A' && c <= 'F') {
+            codepoint += uint(c - 'A' + 10)
+        }
+    }
+    return codepoint
+}
+
+def private fits_int64(num : string) : bool {
+    //! true when the `[+-]?digits` literal `num` is representable as int64.
+    var fits = true
+    peek_data(num) $(digits) {
+        let n = length(digits)
+        var i = 0
+        var negative = false
+        if (i < n && (digits[i] == '+'u8 || digits[i] == '-'u8)) {
+            negative = digits[i] == '-'u8
+            i ++
+        }
+        while (i < n && digits[i] == '0'u8) {
+            i ++
+        }
+        if (n - i > INT64_MAX_DIGITS) {
+            fits = false
+        } else {
+            var value = 0ul
+            while (i < n) {
+                value = value * 10ul + uint64(int(digits[i]) - '0')
+                i ++
+            }
+            fits = value <= (negative ? 9223372036854775808ul : 9223372036854775807ul)
+        }
+    }
+    return fits
 }
 
 def JVNull {
@@ -194,6 +281,7 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
         }
         var ahead : int = ' '
         var str : array<uint8>
+        var pending_high = 0u
         var line : int = 1
         var row : int = 0
         while (!empty(tin)) {
@@ -208,19 +296,7 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                 while (next(tin, ahead, line, row) && ahead != '"') {
                     if (ahead == '\\') {
                         if (next(tin, ahead, line, row)) {
-                            if (ahead == 'b') {
-                                ahead = '\b'
-                            } elif (ahead == 'f') {
-                                ahead = '\f'
-                            } elif (ahead == 'n') {
-                                ahead = '\n'
-                            } elif (ahead == 'r') {
-                                ahead = '\r'
-                            } elif (ahead == 't') {
-                                ahead = '\t'
-                            } elif (ahead == '/') {
-                                ahead = '/'
-                            } elif (ahead == 'u') {
+                            if (ahead == 'u') {
                                 var hex_str : array<uint8>
                                 var valid_hex = true
                                 for (_ in range(4)) {
@@ -235,29 +311,21 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                                     push(hex_str, uint8(ahead))
                                 }
                                 if (valid_hex && length(hex_str) == 4) {
-                                    var codepoint = uint(0)
-                                    for (hb in hex_str) {
-                                        codepoint = codepoint << uint(4)
-                                        let c = int(hb)
-                                        if (is_number(c)) {
-                                            codepoint += uint(c - '0')
-                                        } elif (c >= 'a' && c <= 'f') {
-                                            codepoint += uint(c - 'a' + 10)
-                                        } elif (c >= 'A' && c <= 'F') {
-                                            codepoint += uint(c - 'A' + 10)
-                                        }
-                                    }
-                                    if (codepoint <= 0x7F) {
-                                        push(str, uint8(codepoint))
-                                    } elif (codepoint <= 0x7FF) {
-                                        push(str, uint8(0xC0 | (codepoint >> uint(6)))) // nolint:STYLE012 UTF-8 continuation bytes append to the accumulating token buffer
-                                        push(str, uint8(0x80 | (codepoint & 0x3F)))
-                                    } elif (codepoint <= 0xFFFF) {
-                                        push(str, uint8(0xE0 | (codepoint >> uint(12)))) // nolint:STYLE012 UTF-8 continuation bytes append to the accumulating token buffer
-                                        push(str, uint8(0x80 | ((codepoint >> uint(6)) & 0x3F)))
-                                        push(str, uint8(0x80 | (codepoint & 0x3F)))
+                                    let codepoint = hex4_codepoint(hex_str)
+                                    if (is_high_surrogate(codepoint)) {
+                                        flush_unpaired_surrogate(str, pending_high)
+                                        pending_high = codepoint
+                                    } elif (is_low_surrogate(codepoint) && is_high_surrogate(pending_high)) {
+                                        push_utf8(str, SUPPLEMENTARY_FIRST + ((pending_high - HIGH_SURROGATE_FIRST) << 10u) + (codepoint - LOW_SURROGATE_FIRST))
+                                        pending_high = 0u
+                                    } elif (is_low_surrogate(codepoint)) {
+                                        push_utf8(str, REPLACEMENT_CODEPOINT)
+                                    } else {
+                                        flush_unpaired_surrogate(str, pending_high)
+                                        push_utf8(str, codepoint)
                                     }
                                 } else {
+                                    flush_unpaired_surrogate(str, pending_high)
                                     push(str, uint8('\\')) // nolint:STYLE012 the unparsed escape appends to the accumulating token buffer
                                     push(str, uint8('u'))
                                     str |> push_from(hex_str) // nolint:PERF006,LINT019 hex_str is 4 bytes max; PERF006 fires only in downstream compiles
@@ -267,12 +335,27 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                                 }
                                 continue
                             }
+                            flush_unpaired_surrogate(str, pending_high)
+                            if (ahead == 'b') {
+                                ahead = '\b'
+                            } elif (ahead == 'f') {
+                                ahead = '\f'
+                            } elif (ahead == 'n') {
+                                ahead = '\n'
+                            } elif (ahead == 'r') {
+                                ahead = '\r'
+                            } elif (ahead == 't') {
+                                ahead = '\t'
+                            } elif (ahead == '/') {
+                                ahead = '/'
+                            }
                             push(str, uint8(ahead))
                         } else {
                             yield TokenAt(value = Token(_error = "string escape sequence exceeds text"), line = line, row = row)
                             return false
                         }
                     } else {
+                        flush_unpaired_surrogate(str, pending_high)
                         push(str, uint8(ahead))
                     }
                 }
@@ -280,11 +363,11 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                     yield TokenAt(value = Token(_error = "string exceeds text"), line = line, row = row)
                     return false
                 }
+                flush_unpaired_surrogate(str, pending_high)
                 yield TokenAt(value = Token(_string = string(str)), line = line, row = row)
                 clear(str)
                 next(tin, ahead)
             } elif (ahead == '+' || ahead == '-' || is_number(ahead)) {
-                var is_negative = (ahead == '-')
                 push(str, uint8(ahead))
                 var anyNumbers = is_number(ahead)
                 while (next(tin, ahead, line, row) && is_number(ahead)) {
@@ -317,9 +400,15 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                     yield TokenAt(value = Token(_error = "invalid number {num}"), line = line, row = row)
                     return false
                 }
-                if (is_integer) {
-                    var ival = is_negative ? int64(num) : int64(uint64(num))
-                    yield TokenAt(value = Token(_longint = ival), line = line, row = row)
+                if (is_integer && fits_int64(num)) {
+                    yield TokenAt(value = Token(_longint = int64(num)), line = line, row = row)
+                } elif (is_integer) {
+                    let wide = to_double(num)
+                    if (wide == 0.0lf) {
+                        yield TokenAt(value = Token(_error = "number {num} is out of range"), line = line, row = row)
+                        return false
+                    }
+                    yield TokenAt(value = Token(_number = wide), line = line, row = row)
                 } else {
                     yield TokenAt(value = Token(_number = double(num)), line = line, row = row)
                 }
@@ -389,10 +478,15 @@ def private expect_symbol(var itv : iterator<TokenAt>; var ahead : TokenAt; sym 
     }
 }
 
-def private parse_value(var itv : iterator<TokenAt>; var error : string&) : JsonValue? {  // nolint:STYLE037,STYLE038 - recursive descent, one arm per json production
+def private parse_value(var itv : iterator<TokenAt>; var error : string&) : JsonValue? {
     //! parses a JSON value from the token iterator `itv`.
     var ahead : TokenAt
     if (!next(itv, ahead)) return null
+    return parse_value(itv, ahead, error)
+}
+
+def private parse_value(var itv : iterator<TokenAt>; var ahead : TokenAt; var error : string&) : JsonValue? {  // nolint:STYLE037 - recursive descent, one arm per json production
+    //! parses a JSON value whose first token `ahead` has already been read.
     if (ahead.value is _symbol) {
         let sym = ahead.value as _symbol
         if (sym == ']') {
@@ -401,30 +495,22 @@ def private parse_value(var itv : iterator<TokenAt>; var error : string&) : Json
         }
         if (sym == '[') {
             var arr : array<JsonValue?>
-            while (!empty(itv)) {
-                var value = parse_value(itv, error)
-                if (value == null) {
-                    if (error |> starts_with("unexpected ]") && empty(arr)) {
-                        error = ""
-                        return JV(arr)
-                    }
-                    return null
-                }
+            var element : TokenAt
+            while (next(itv, element)) {
+                if (empty(arr) && (element.value is _symbol) && (element.value as _symbol) == ']') return JV(arr)
+                var value = parse_value(itv, element, error)
+                if (value == null) return null
                 push(arr, value)
                 if (!expect_token(itv, ahead, Token_symbol, error)) return null
                 let sepsym = ahead.value as _symbol
-                if (sepsym == ']') {
-                    break;
-                } elif (sepsym != ',') {
+                if (sepsym == ']') return JV(arr)
+                if (sepsym != ',') {
                     error = "unexpected array separator symbol `{to_char(sepsym)}` aka ASCII {sepsym} at {ahead.line}:{ahead.row}";
                     return null;
                 }
             }
-            if (empty(itv)) {
-                error = "unexpected eos";
-                return null;
-            }
-            return JV(arr);
+            error = "unexpected eos";
+            return null;
         } elif (sym == '{') {
             var tab : table<string; JsonValue?>;
             while (!empty(itv)) {
@@ -712,7 +798,7 @@ def try_fixing_broken_json(var bad : string) {  // nolint:STYLE038 - one linear 
                             continue;
                         }
                     }
-                    if (str[i] == '\\'u8 && str[i + 1] == 'u'u8) {
+                    if (str[i] == '\\'u8 && i + 1 < lstr && str[i + 1] == 'u'u8) {
                         i += 2;
                         while (i < lstr && is_hex(int(str[i]))) {
                             i ++;

--- a/daslib/json_boost.das
+++ b/daslib/json_boost.das
@@ -520,8 +520,7 @@ def JV(value : auto(TT)) : JsonValue? { // nolint:STYLE038 — flat static_if di
             arr |> push(JV(t))
         }
         return _::JV(arr)
-    }
-    static_if (typeinfo typename(value) == "json::JsonValue?" || typeinfo typename(value) == "json::JsonValue? const") {
+    } static_elif (typeinfo typename(value) == "json::JsonValue?" || typeinfo typename(value) == "json::JsonValue? const") {
         unsafe {
             return reinterpret<JsonValue?>(value)
         }
@@ -638,8 +637,6 @@ def JV(value : auto(TT)) : JsonValue? { // nolint:STYLE038 — flat static_if di
         var arr : array<JsonValue?>
         static_if (typeinfo is_array(value)) {
             arr |> reserve(long_length(value))
-        } static_elif (typeinfo is_dim(value)) {
-            arr |> reserve(typeinfo dim(value))
         }
         for (x in value) {
             arr |> push <| _::JV(x)

--- a/daslib/jsonrpc.das
+++ b/daslib/jsonrpc.das
@@ -23,6 +23,11 @@ module jsonrpc shared public
 //! Pass ``strict=true`` to ``parse_request`` / ``parse_batch`` /
 //! ``dispatch_line`` for full §4 compliance (missing or non-"2.0" yields
 //! INVALID_REQUEST).
+//!
+//! Request parsing is request-scoped: ``parse_request`` / ``parse_batch`` hand
+//! back the parsed document in the ``document`` field, and the caller MUST end
+//! the scope with ``free_request`` / ``free_batch`` — nothing else frees it.
+//! ``dispatch_line`` owns the whole scope and needs no free from its caller.
 
 require daslib/json
 require daslib/json_boost
@@ -42,15 +47,17 @@ struct public ParsedRequest {
     id_str          : string       //!< Serialized id ("null" / "7" / "\"abc\"") — embed verbatim into responses.
     method          : string       //!< Method name. Empty when the request was malformed.
     params_json     : string       //!< Raw serialized ``params`` value (e.g. ``"null"``, ``"[1,2]"``, ``"{\"x\":1}"``).
-    params          : JsonValue?   //!< Pre-parsed ``params`` JsonValue; null when absent. Saves callers a second ``read_json``.
+    params          : JsonValue?   //!< Pre-parsed ``params`` JsonValue; null when absent. Saves callers a second ``read_json``. A view into ``document`` — dangling once the request is freed.
     is_notification : bool         //!< True when the request omits ``id`` (spec §4.1 — MUST NOT send a response).
     error_envelope  : string       //!< Pre-built error response for malformed input. Empty when the request was well-formed.
+    document        : JsonValue?   //!< Parse tree this request owns; free it with ``free_request``. Null in a batch entry — ``ParsedBatch`` owns the batch document.
 }
 
 struct public ParsedBatch {
     is_batch        : bool                   //!< True when the wire body was a JSON array.
     requests        : array<ParsedRequest>   //!< One entry per array element (or one for a single request).
     framing_error   : string                 //!< Top-level error envelope to send as-is (parse failure, empty array). Mutually exclusive with ``requests``.
+    document        : JsonValue?             //!< Parse tree every entry's ``params`` points into; free it with ``free_batch``.
 }
 
 
@@ -77,16 +84,23 @@ def public response(id_str : string; result_json : string) : string {
     return "\{\"jsonrpc\":\"2.0\",\"id\":{id_str},\"result\":{result_json}}"
 }
 
+def private quoted(s : string) : string {
+    var jsv = JV(s)
+    let text = write_json(jsv)
+    delete_json(jsv)
+    return text
+}
+
 def public error(id_str : string; code : int; message : string) : string {
     //! Wrap ``code`` + ``message`` in a JSON-RPC 2.0 error response envelope.
-    let msg_json = write_json(JV(message))
+    let msg_json = quoted(message)
     return "\{\"jsonrpc\":\"2.0\",\"id\":{id_str},\"error\":\{\"code\":{code},\"message\":{msg_json}}}"
 }
 
 def public error_with_data(id_str : string; code : int; message, data_json : string) : string {
     //! Like ``error``, but also includes the optional ``data`` field (spec §5.1).
     //! ``data_json`` is embedded verbatim — must be valid JSON.
-    let msg_json = write_json(JV(message))
+    let msg_json = quoted(message)
     return "\{\"jsonrpc\":\"2.0\",\"id\":{id_str},\"error\":\{\"code\":{code},\"message\":{msg_json},\"data\":{data_json}}}"
 }
 
@@ -100,20 +114,20 @@ def public serialize_id(id_val : JsonValue?) : string {
 def public make_request(method : string; params_json : string; id : int) : string {
     //! Build a JSON-RPC 2.0 request with an integer id.
     //! ``params_json`` is the pre-serialized params value (``"null"``, ``"[1,2]"``, ``"{\"x\":1}"``).
-    let method_str = write_json(JV(method))
+    let method_str = quoted(method)
     return "\{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":{method_str},\"params\":{params_json}}"
 }
 
 def public make_request(method : string; params_json : string; id : string) : string {
     //! Build a JSON-RPC 2.0 request with a string id.
-    let method_str = write_json(JV(method))
-    let id_str = write_json(JV(id))
+    let method_str = quoted(method)
+    let id_str = quoted(id)
     return "\{\"jsonrpc\":\"2.0\",\"id\":{id_str},\"method\":{method_str},\"params\":{params_json}}"
 }
 
 def public make_notification(method : string; params_json : string) : string {
     //! Build a JSON-RPC 2.0 notification (no id — server MUST NOT respond).
-    let method_str = write_json(JV(method))
+    let method_str = quoted(method)
     return "\{\"jsonrpc\":\"2.0\",\"method\":{method_str},\"params\":{params_json}}"
 }
 
@@ -171,6 +185,7 @@ def private parse_one_request(body_value : JsonValue?; strict : bool) : ParsedRe
 
 def public parse_request(line : string; strict : bool = false) : ParsedRequest {
     //! Parse a single JSON-RPC 2.0 request line. Pure function — testable in isolation.
+    //! The result owns its parse tree: end the request scope with ``free_request``.
     var result = ParsedRequest(id_str = "null")
     var parse_error_msg = ""
     var parsed = read_json(line, parse_error_msg)
@@ -178,11 +193,24 @@ def public parse_request(line : string; strict : bool = false) : ParsedRequest {
         result.error_envelope = error("null", PARSE_ERROR, "parse error: {parse_error_msg}")
         return result
     }
-    return parse_one_request(parsed, strict)
+    result = parse_one_request(parsed, strict)
+    result.document = parsed
+    return result
+}
+
+def public free_request(var req : ParsedRequest) {
+    //! End a ``parse_request`` scope: free the owned document and clear the ``params`` view.
+    //! The ``id_str`` / ``method`` / ``params_json`` / ``error_envelope`` strings outlive it.
+    //! No-op on a batch entry — ``free_batch`` owns those.
+    req.params = null
+    delete_json(req.document)
+    req.document = null
 }
 
 def public parse_batch(line : string; strict : bool = false) : ParsedBatch {
     //! Parse a JSON-RPC 2.0 wire body that may be a single request or a §6 batch array.
+    //! The result owns the parse tree every entry's ``params`` points into: end the
+    //! request scope with ``free_batch``.
     var result : ParsedBatch
     var parse_error_msg = ""
     var parsed = read_json(line, parse_error_msg)
@@ -190,6 +218,7 @@ def public parse_batch(line : string; strict : bool = false) : ParsedBatch {
         result.framing_error = error("null", PARSE_ERROR, "parse error: {parse_error_msg}")
         return <- result
     }
+    result.document = parsed
     if (parsed.value is _array) {
         result.is_batch = true
         let arr & = unsafe(parsed.value as _array)
@@ -207,6 +236,20 @@ def public parse_batch(line : string; strict : bool = false) : ParsedBatch {
     result.is_batch = false
     result.requests |> push(parse_one_request(parsed, strict))
     return <- result
+}
+
+def public free_batch(var pb : ParsedBatch) {
+    //! End a ``parse_batch`` scope: free the owned document and release the entry array.
+    //! Read every entry before calling this; afterwards ``requests`` is empty. The
+    //! ``framing_error`` string outlives it.
+    for (req in pb.requests) {
+        req.params = null
+    }
+    delete_json(pb.document)
+    pb.document = null
+    unsafe {
+        delete pb.requests
+    }
 }
 
 
@@ -249,7 +292,8 @@ def private parse_one_response(body_value : JsonValue?) : ParsedResponse {
 }
 
 def public parse_response(line : string) : ParsedResponse {
-    //! Parse a single JSON-RPC 2.0 response line.
+    //! Parse a single JSON-RPC 2.0 response line. Every field is a fresh string, so
+    //! the parse tree is freed before returning — the caller owns nothing.
     var result = ParsedResponse(id_str = "null", is_success = false)
     var parse_error_msg = ""
     var parsed = read_json(line, parse_error_msg)
@@ -257,11 +301,14 @@ def public parse_response(line : string) : ParsedResponse {
         result.parse_error = "parse error: {parse_error_msg}"
         return result
     }
-    return parse_one_response(parsed)
+    result = parse_one_response(parsed)
+    delete_json(parsed)
+    return result
 }
 
 def public parse_response_batch(line : string) : ParsedResponseBatch {
     //! Parse a JSON-RPC 2.0 response wire body that may be a single response or a §6 batch array.
+    //! Like ``parse_response``, the parse tree is freed before returning.
     var result : ParsedResponseBatch
     var parse_error_msg = ""
     var parsed = read_json(line, parse_error_msg)
@@ -277,10 +324,11 @@ def public parse_response_batch(line : string) : ParsedResponseBatch {
             let ev = unsafe(reinterpret<JsonValue?>(entry))
             result.responses |> push(parse_one_response(ev))
         }
-        return <- result
+    } else {
+        result.is_batch = false
+        result.responses |> push(parse_one_response(parsed))
     }
-    result.is_batch = false
-    result.responses |> push(parse_one_response(parsed))
+    delete_json(parsed)
     return <- result
 }
 
@@ -317,17 +365,15 @@ def public compact_json_whitespace(s : string) : string {
 
 
 def private dispatch_one(req : ParsedRequest; dispatcher : block<(method : string; params_json : string) : string>) : string {
-    if (!empty(req.error_envelope)) return req.is_notification ? "" : req.error_envelope
+    if (!empty(req.error_envelope)) return req.error_envelope
     let result_json = invoke(dispatcher, req.method, req.params_json)
     return req.is_notification ? "" : response(req.id_str, result_json)
 }
 
-def public dispatch_line(line : string; strict : bool; dispatcher : block<(method : string; params_json : string) : string>) : string {
-    //! Dispatch a JSON-RPC 2.0 wire line (single or §6 batch) through ``dispatcher``, returning the response string ready for the wire (or ``""`` for all-notifications).
-    let pb = parse_batch(line, strict)
+def private dispatch_parsed(pb : ParsedBatch; dispatcher : block<(method : string; params_json : string) : string>) : string {
     if (!empty(pb.framing_error)) return pb.framing_error
     if (!pb.is_batch) return dispatch_one(pb.requests[0], dispatcher)
-    var parts : array<string>
+    var inscope parts : array<string>
     for (req in pb.requests) {
         let r = dispatch_one(req, dispatcher)
         if (!empty(r)) parts |> push(r)
@@ -343,4 +389,13 @@ def public dispatch_line(line : string; strict : bool; dispatcher : block<(metho
         }
         write_char(w, ']')
     }
+}
+
+def public dispatch_line(line : string; strict : bool; dispatcher : block<(method : string; params_json : string) : string>) : string {
+    //! Dispatch a JSON-RPC 2.0 wire line (single or §6 batch) through ``dispatcher``, returning the response string ready for the wire (or ``""`` for all-notifications).
+    //! Owns the whole request scope: the parse tree is freed once ``dispatcher`` has run over every entry, so the caller frees nothing.
+    var pb <- parse_batch(line, strict)
+    let wire = dispatch_parsed(pb, dispatcher)
+    free_batch(pb)
+    return wire
 }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -579,6 +579,7 @@ def document_module_jsonrpc(_root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Envelope builders", mod, %regex~(response|error|error_with_data|serialize_id)$%%),
         group_by_regex("Server-side parsers", mod, %regex~(parse_request|parse_batch)$%%),
+        group_by_regex("Request scope", mod, %regex~(free_request|free_batch)$%%),
         group_by_regex("Outgoing request builders", mod, %regex~(make_request|make_notification|make_batch)$%%),
         group_by_regex("Response parsers", mod, %regex~(parse_response|parse_response_batch)$%%),
         group_by_regex("Framing helper", mod, %regex~(compact_json_whitespace)$%%),

--- a/doc/source/reference/tutorials/jsonrpc_02_dispatch_line.rst
+++ b/doc/source/reference/tutorials/jsonrpc_02_dispatch_line.rst
@@ -75,13 +75,24 @@ When you need to emit specific error codes per method
 .. code-block:: das
 
    def handle(line : string) : string {
-       let req = parse_request(line)
-       if (!empty(req.error_envelope)) return req.is_notification ? "" : req.error_envelope
-       if (req.method != "ping" && req.method != "echo") {
-           return error(req.id_str, METHOD_NOT_FOUND, "no such method: {req.method}")
+       var req = parse_request(line)
+       var wire = ""
+       if (!empty(req.error_envelope)) {
+           wire = req.error_envelope
+       } elif (req.method != "ping" && req.method != "echo") {
+           wire = error(req.id_str, METHOD_NOT_FOUND, "no such method: {req.method}")
+       } else {
+           wire = response(req.id_str, dispatch(req.method, req.params_json))
        }
-       return response(req.id_str, dispatch(req.method, req.params_json))
+       free_request(req)
+       return wire
    }
+
+``parse_request`` hands back the parse tree it built in ``req.document``, because
+``req.params`` is a view into it. Close the request scope with ``free_request``
+once you are done reading; the strings on ``ParsedRequest`` outlive the tree, so
+the assembled response is still valid afterwards. ``dispatch_line`` owns that
+scope itself, which is why the high-level path above frees nothing.
 
 Running the tutorial
 ====================

--- a/doc/source/reference/tutorials/jsonrpc_03_batch.rst
+++ b/doc/source/reference/tutorials/jsonrpc_03_batch.rst
@@ -86,8 +86,8 @@ directly:
 .. code-block:: das
 
    def handle_batch(wire : string) : string {
-       let pb = parse_batch(wire)
-       return pb.framing_error if (!empty(pb.framing_error))
+       var pb <- parse_batch(wire)
+       var out = pb.framing_error
        for (req in pb.requests) {
            if (!empty(req.error_envelope)) {
                // per-entry error — req.error_envelope is ready to go on the wire
@@ -95,8 +95,16 @@ directly:
                // req.method, req.id_str, req.params, req.params_json available
            }
        }
-       return ""   // assemble the response array from the per-entry results
+       // assemble the response array from the per-entry results into `out`
+       free_batch(pb)
+       return out
    }
+
+One parse tree backs the whole batch (``pb.document``), and every entry's
+``params`` is a view into it — an entry never owns a document of its own. Read
+the entries, then close the scope with ``free_batch``: it releases the tree and
+the entry array together, so ``pb.requests`` is empty afterwards. The per-entry
+strings outlive it. ``dispatch_line`` owns that scope itself.
 
 Running the tutorial
 ====================

--- a/skills/daslang/references/json.md
+++ b/skills/daslang/references/json.md
@@ -84,10 +84,15 @@ key write `js?["value"]`.
 Cases: `_object` (`table<string; JsonValue?>`), `_array` (`array<JsonValue?>`), `_string`
 (`string`), `_number` (`double`), `_longint` (`int64`), `_bool` (`bool`), `_null` (`void?`).
 
+An integer literal is `_longint` only while it fits `int64`; past that it parses as `_number`,
+and past `double` it is a parse error. So a wire format carrying `uint64` ids above
+`INT64_MAX` loses precision — send those as strings.
+
 ## Parsing, writing, embedding
 
 - `read_json(text, var error)` takes a `string` or an `array<uint8>`; `write_json(js)` serializes,
-  a null pointer as `"null"`.
+  a null pointer as `"null"`. `\uXXXX` escapes decode to UTF-8, a surrogate pair folding into one
+  code point; an unpaired surrogate becomes U+FFFD.
 - `try_fixing_broken_json(text)` repairs model-generated output before `read_json` — concatenation
   (`"a" + "b"`), trailing commas, double-quoted nesting.
 - Writer settings return the previous value (save and restore for a scoped change):

--- a/tests/json/test_json_edge.das
+++ b/tests/json/test_json_edge.das
@@ -288,6 +288,22 @@ def test_parse_errors(t : T?) {
     t |> run("trailing comma in array rejected") @(t : T?) {
         parse_expect_fail("[1, 2, ]", t)
     }
+    t |> run("a string that looks like a close bracket does not open an empty array") @(t : T?) {
+        parse_expect_fail("[[1 \"]\"]", t)
+        parse_expect_fail("[[1 \"] fake\"]]", t)
+        parse_expect_fail("[\{\"a\":1 \"] fake\"}]", t)
+    }
+    t |> run("a value after an open bracket is still required") @(t : T?) {
+        parse_expect_fail("[\{]", t)
+        parse_expect_fail("[[\{]]", t)
+    }
+    t |> run("empty array nests and mixes") @(t : T?) {
+        var js = parse("[[], \{\}, []]", t)
+        t |> equal(length(js as _array), 3)
+        t |> equal((js as _array)[0] is _array, true)
+        t |> equal(length((js as _array)[0] as _array), 0)
+        t |> equal((js as _array)[1] is _object, true)
+    }
     t |> run("duplicate keys rejected by default") @(t : T?) {
         let input = "\{ \"a\": 1, \"a\": 2 \}"
         parse_expect_fail(input, t)
@@ -783,6 +799,16 @@ def test_fix_broken_json(t : T?) {
         var error : string
         var js = read_json(fixed, error)
         t |> success(js != null)
+    }
+    t |> run("input ending in a backslash outside a string") @(t : T?) {
+        let backslash = "\\"
+        t |> equal(try_fixing_broken_json(backslash), backslash)
+        t |> equal(try_fixing_broken_json("[1,2]" + backslash), "[1,2]" + backslash)
+        t |> equal(try_fixing_broken_json("\{\}" + backslash), "\{\}" + backslash)
+    }
+    t |> run("a unicode escape outside a string is still skipped") @(t : T?) {
+        let backslash = "\\"
+        t |> equal(try_fixing_broken_json("[1," + backslash + "u0020 2]"), "[1, 2]")
     }
 }
 

--- a/tests/json/test_json_numbers.das
+++ b/tests/json/test_json_numbers.das
@@ -1,0 +1,100 @@
+options gen2
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+require dastest/testing_boost public
+require daslib/json_boost
+require strings
+
+def parse(t : T?; text : string) : JsonValue? {
+    var error : string
+    var js = read_json(text, error)
+    t |> success(js != null, "parsed {text}")
+    t |> equal(error, "")
+    return js
+}
+
+def repeat_digit(digit : int; count : int) : string {
+    return build_string() $(var w) {
+        for (_ in range(count)) {
+            write_char(w, digit)
+        }
+    }
+}
+
+[test]
+def test_integers_within_range(t : T?) {
+    t |> run("int64 max") @(t : T?) {
+        var js = parse(t, "9223372036854775807")
+        t |> equal(js is _longint, true)
+        t |> equal(js as _longint, 9223372036854775807l)
+    }
+    t |> run("int64 min") @(t : T?) {
+        var js = parse(t, "-9223372036854775808")
+        t |> equal(js is _longint, true)
+        t |> equal(js as _longint, -9223372036854775807l - 1l)
+    }
+    t |> run("nineteen digits below the limit") @(t : T?) {
+        var js = parse(t, "9223372036854775806")
+        t |> equal(js is _longint, true)
+        t |> equal(js as _longint, 9223372036854775806l)
+    }
+    t |> run("leading zeros do not push past the limit") @(t : T?) {
+        var js = parse(t, "000000000000000000000042")
+        t |> equal(js is _longint, true)
+        t |> equal(js as _longint, 42l)
+    }
+    t |> run("zero") @(t : T?) {
+        var js = parse(t, "0")
+        t |> equal(js is _longint, true)
+        t |> equal(js as _longint, 0l)
+    }
+    t |> run("negative zero") @(t : T?) {
+        var js = parse(t, "-0")
+        t |> equal(js is _longint, true)
+        t |> equal(js as _longint, 0l)
+    }
+}
+
+[test]
+def test_integers_out_of_range_become_numbers(t : T?) {
+    t |> run("int64 max plus one") @(t : T?) {
+        var js = parse(t, "9223372036854775808")
+        t |> equal(js is _number, true)
+        t |> success(js as _number > 9.223e18lf, "magnitude and sign are preserved")
+    }
+    t |> run("uint64 max") @(t : T?) {
+        var js = parse(t, "18446744073709551615")
+        t |> equal(js is _number, true)
+        t |> success(js as _number > 1.8e19lf, "magnitude and sign are preserved")
+    }
+    t |> run("int64 min minus one") @(t : T?) {
+        var js = parse(t, "-9223372036854775809")
+        t |> equal(js is _number, true)
+        t |> success(js as _number < -9.223e18lf, "magnitude and sign are preserved")
+    }
+    t |> run("far past uint64") @(t : T?) {
+        var js = parse(t, "99999999999999999999999999")
+        t |> equal(js is _number, true)
+        t |> success(js as _number > 9.9e25lf, "magnitude and sign are preserved")
+    }
+    t |> run("out of range inside a document") @(t : T?) {
+        var js = parse(t, "\{ \"id\" : 18446744073709551615 \}")
+        t |> equal(js?["id"] is _number, true)
+    }
+}
+
+[test]
+def test_integers_past_double_range_error(t : T?) {
+    t |> run("four hundred digits is a parse error, not a panic") @(t : T?) {
+        var error : string
+        var js = read_json(repeat_digit('9', 400), error)
+        t |> equal(js == null, true)
+        t |> success(!empty(error), "the lexer reports the out-of-range number")
+    }
+    t |> run("negative four hundred digits") @(t : T?) {
+        var error : string
+        var js = read_json("-" + repeat_digit('9', 400), error)
+        t |> equal(js == null, true)
+        t |> success(!empty(error), "the lexer reports the out-of-range number")
+    }
+}

--- a/tests/json/test_json_unicode.das
+++ b/tests/json/test_json_unicode.das
@@ -1,0 +1,118 @@
+options gen2
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+require dastest/testing_boost public
+require daslib/json_boost
+require strings
+
+def utf8_bytes(s : string) : string {
+    return build_string() $(var w) {
+        peek_data(s) $(raw) {
+            var first = true
+            for (b in raw) {
+                if (!first) {
+                    write_char(w, ' ')
+                }
+                first = false
+                write(w, int(b))
+            }
+        }
+    }
+}
+
+def decode(t : T?; text : string) : string {
+    var error : string
+    var js = read_json(text, error)
+    t |> success(js != null, "parsed {text}")
+    if (js == null) {
+        t |> failure("{text}: {error}")
+        return ""
+    }
+    t |> success(js is _string, "decoded a string")
+    return js as _string
+}
+
+[test]
+def test_surrogate_pairs(t : T?) {
+    t |> run("emoji pair decodes to one 4-byte code point") @(t : T?) {
+        let s = decode(t, "\"\\ud83d\\ude00\"")
+        t |> equal(utf8_bytes(s), "240 159 152 128")
+        t |> equal(length(s), 4)
+    }
+    t |> run("musical symbol pair") @(t : T?) {
+        let s = decode(t, "\"\\ud834\\udd1e\"")
+        t |> equal(utf8_bytes(s), "240 157 132 158")
+    }
+    t |> run("last code point") @(t : T?) {
+        let s = decode(t, "\"\\udbff\\udfff\"")
+        t |> equal(utf8_bytes(s), "244 143 191 191")
+    }
+    t |> run("pair surrounded by ASCII") @(t : T?) {
+        let s = decode(t, "\"a\\ud83d\\ude00b\"")
+        t |> equal(utf8_bytes(s), "97 240 159 152 128 98")
+    }
+    t |> run("two pairs in a row") @(t : T?) {
+        let s = decode(t, "\"\\ud83d\\ude00\\ud83d\\ude00\"")
+        t |> equal(utf8_bytes(s), "240 159 152 128 240 159 152 128")
+    }
+}
+
+[test]
+def test_lone_surrogates(t : T?) {
+    t |> run("lone high surrogate becomes U+FFFD") @(t : T?) {
+        let s = decode(t, "\"\\ud83d\"")
+        t |> equal(utf8_bytes(s), "239 191 189")
+    }
+    t |> run("lone low surrogate becomes U+FFFD") @(t : T?) {
+        let s = decode(t, "\"\\ude00\"")
+        t |> equal(utf8_bytes(s), "239 191 189")
+    }
+    t |> run("high surrogate followed by a literal char") @(t : T?) {
+        let s = decode(t, "\"\\ud83dx\"")
+        t |> equal(utf8_bytes(s), "239 191 189 120")
+    }
+    t |> run("high surrogate followed by a non-u escape") @(t : T?) {
+        let s = decode(t, "\"\\ud83d\\n\"")
+        t |> equal(utf8_bytes(s), "239 191 189 10")
+    }
+    t |> run("high surrogate followed by a BMP escape") @(t : T?) {
+        let s = decode(t, "\"\\ud83d\\u0041\"")
+        t |> equal(utf8_bytes(s), "239 191 189 65")
+    }
+    t |> run("two high surrogates then a low one") @(t : T?) {
+        let s = decode(t, "\"\\ud83d\\ud83d\\ude00\"")
+        t |> equal(utf8_bytes(s), "239 191 189 240 159 152 128")
+    }
+    t |> run("pair split by a literal char") @(t : T?) {
+        let s = decode(t, "\"\\ud83dx\\ude00\"")
+        t |> equal(utf8_bytes(s), "239 191 189 120 239 191 189")
+    }
+}
+
+[test]
+def test_bmp_escapes_unchanged(t : T?) {
+    t |> run("ASCII") @(t : T?) {
+        let s = decode(t, "\"\\u0041\"")
+        t |> equal(utf8_bytes(s), "65")
+    }
+    t |> run("two-byte") @(t : T?) {
+        let s = decode(t, "\"\\u00e9\"")
+        t |> equal(utf8_bytes(s), "195 169")
+    }
+    t |> run("three-byte") @(t : T?) {
+        let s = decode(t, "\"\\u20ac\"")
+        t |> equal(utf8_bytes(s), "226 130 172")
+    }
+    t |> run("just below the surrogate block") @(t : T?) {
+        let s = decode(t, "\"\\ud7ff\"")
+        t |> equal(utf8_bytes(s), "237 159 191")
+    }
+    t |> run("just above the surrogate block") @(t : T?) {
+        let s = decode(t, "\"\\ue000\"")
+        t |> equal(utf8_bytes(s), "238 128 128")
+    }
+    t |> run("malformed escape is preserved verbatim") @(t : T?) {
+        let s = decode(t, "\"\\u12zz\"")
+        t |> equal(s, "\\u12zz")
+    }
+}

--- a/tests/jsonrpc/test_dispatch_line.das
+++ b/tests/jsonrpc/test_dispatch_line.das
@@ -80,6 +80,20 @@ def test_dispatch_batch_per_entry_errors(t : T?) {
 }
 
 [test]
+def test_dispatch_malformed_without_id_still_answers(t : T?) {
+    let r = dispatch_line("\{\"params\":[1,2]}", false) $(_method, _params_json) {
+        return "\"ok\""
+    }
+    t |> success(!empty(r), "a malformed idless request still gets a response")
+    t |> success(find(r, "\"id\":null") >= 0, "id is null")
+    t |> success(find(r, "-32600") >= 0, "INVALID_REQUEST code")
+    let rb = dispatch_line("[\{\"params\":[1,2]}]", false) $(_method, _params_json) {
+        return "\"ok\""
+    }
+    t |> success(find(rb, "-32600") >= 0, "same inside a batch")
+}
+
+[test]
 def test_dispatch_strict_mode_propagates(t : T?) {
     let r = dispatch_line("\{\"id\":1,\"method\":\"x\"}", true) $(_method, _params_json) {
         return "\"ok\""

--- a/tests/jsonrpc/test_request_ownership.das
+++ b/tests/jsonrpc/test_request_ownership.das
@@ -5,14 +5,13 @@ options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 require dastest/testing_boost public
 require daslib/jsonrpc
-require daslib/json
 
 let SINGLE = "\{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"echo\",\"params\":\{\"a\":[1,2,3],\"b\":\"text\"}}"
 let BATCH = "[\{\"id\":1,\"method\":\"a\",\"params\":[1,2]},\{\"method\":\"n\"},\{\"id\":3,\"method\":\"b\"}]"
 let MALFORMED = "\{\"id\":1,\"method\":42,\"params\":[1,2]}"
 
 def echo_dispatch(line : string) : string {
-    return dispatch_line(line, false) $(method, params_json) {
+    return dispatch_line(line, false) $(method, _params_json) {
         return "\{\"m\":\"{method}\"}"
     }
 }
@@ -85,7 +84,7 @@ def test_free_request_ends_the_scope(t : T?) {
         free_request(req)
         t |> equal(req.method, "echo")
         t |> equal(req.id_str, "1")
-        t |> equal(req.params_json |> length > 0, true)
+        t |> equal(!empty(req.params_json), true)
     }
     t |> run("a failed parse owns nothing") @(t : T?) {
         let before = heap_bytes_allocated()

--- a/tests/jsonrpc/test_request_ownership.das
+++ b/tests/jsonrpc/test_request_ownership.das
@@ -1,0 +1,73 @@
+options gen2
+options persistent_heap
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+require dastest/testing_boost public
+require daslib/jsonrpc
+require daslib/json
+
+let SINGLE = "\{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"echo\",\"params\":\{\"a\":[1,2,3],\"b\":\"text\"}}"
+let BATCH = "[\{\"id\":1,\"method\":\"a\",\"params\":[1,2]},\{\"method\":\"n\"},\{\"id\":3,\"method\":\"b\"}]"
+let MALFORMED = "\{\"id\":1,\"method\":42,\"params\":[1,2]}"
+
+def echo_dispatch(line : string) : string {
+    return dispatch_line(line, false) $(method, params_json) {
+        return "\{\"m\":\"{method}\"}"
+    }
+}
+
+[test]
+def test_dispatch_line_owns_the_document(t : T?) {
+    t |> run("a dispatched single request leaves nothing on the heap") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            let r = echo_dispatch(SINGLE)
+            t |> success(!empty(r), "the request produced a response")
+        }
+        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+    }
+    t |> run("a dispatched batch leaves nothing on the heap") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            let r = echo_dispatch(BATCH)
+            t |> success(!empty(r), "the batch produced a response")
+        }
+        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+    }
+    t |> run("a malformed request leaves nothing on the heap") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            let r = echo_dispatch(MALFORMED)
+            t |> success(!empty(r), "the error envelope came back")
+        }
+        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+    }
+    t |> run("unparseable input leaves nothing on the heap") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            let r = echo_dispatch("not json at all")
+            t |> success(!empty(r), "the framing error came back")
+        }
+        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+    }
+}
+
+[test]
+def test_response_parsers_own_their_document(t : T?) {
+    t |> run("parse_response leaves nothing on the heap") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            let r = parse_response("\{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\{\"x\":[1,2,3]}}")
+            t |> equal(r.is_success, true)
+        }
+        t |> equal(heap_bytes_allocated(), before, "no parse tree survives parse_response")
+    }
+    t |> run("parse_response_batch leaves nothing on the heap") @(t : T?) {
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            let rb = parse_response_batch("[\{\"id\":1,\"result\":1},\{\"id\":2,\"result\":[1,2]}]")
+            t |> equal(length(rb.responses), 2)
+        }
+        t |> equal(heap_bytes_allocated(), before, "no parse tree survives parse_response_batch")
+    }
+}

--- a/tests/jsonrpc/test_request_ownership.das
+++ b/tests/jsonrpc/test_request_ownership.das
@@ -1,5 +1,6 @@
 options gen2
 options persistent_heap
+options force_inscope_pod
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 require dastest/testing_boost public
@@ -16,39 +17,30 @@ def echo_dispatch(line : string) : string {
     }
 }
 
+def dispatch_residue(t : T?; line : string) : uint64 {
+    let warm = echo_dispatch(line)
+    t |> success(!empty(warm), "the line produced a response")
+    let before = heap_bytes_allocated()
+    for (_ in range(8)) {
+        let r = echo_dispatch(line)
+        t |> success(!empty(r), "the line produced a response")
+    }
+    return heap_bytes_allocated() - before
+}
+
 [test]
 def test_dispatch_line_owns_the_document(t : T?) {
     t |> run("a dispatched single request leaves nothing on the heap") @(t : T?) {
-        let before = heap_bytes_allocated()
-        for (_ in range(8)) {
-            let r = echo_dispatch(SINGLE)
-            t |> success(!empty(r), "the request produced a response")
-        }
-        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+        t |> equal(dispatch_residue(t, SINGLE), 0ul, "no parse tree survives dispatch")
     }
     t |> run("a dispatched batch leaves nothing on the heap") @(t : T?) {
-        let before = heap_bytes_allocated()
-        for (_ in range(8)) {
-            let r = echo_dispatch(BATCH)
-            t |> success(!empty(r), "the batch produced a response")
-        }
-        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+        t |> equal(dispatch_residue(t, BATCH), 0ul, "no parse tree survives dispatch")
     }
     t |> run("a malformed request leaves nothing on the heap") @(t : T?) {
-        let before = heap_bytes_allocated()
-        for (_ in range(8)) {
-            let r = echo_dispatch(MALFORMED)
-            t |> success(!empty(r), "the error envelope came back")
-        }
-        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+        t |> equal(dispatch_residue(t, MALFORMED), 0ul, "no parse tree survives dispatch")
     }
     t |> run("unparseable input leaves nothing on the heap") @(t : T?) {
-        let before = heap_bytes_allocated()
-        for (_ in range(8)) {
-            let r = echo_dispatch("not json at all")
-            t |> success(!empty(r), "the framing error came back")
-        }
-        t |> equal(heap_bytes_allocated(), before, "no parse tree survives dispatch")
+        t |> equal(dispatch_residue(t, "not json at all"), 0ul, "no parse tree survives dispatch")
     }
 }
 
@@ -65,9 +57,86 @@ def test_response_parsers_own_their_document(t : T?) {
     t |> run("parse_response_batch leaves nothing on the heap") @(t : T?) {
         let before = heap_bytes_allocated()
         for (_ in range(8)) {
-            let rb = parse_response_batch("[\{\"id\":1,\"result\":1},\{\"id\":2,\"result\":[1,2]}]")
+            var rb <- parse_response_batch("[\{\"id\":1,\"result\":1},\{\"id\":2,\"result\":[1,2]}]")
             t |> equal(length(rb.responses), 2)
+            unsafe {
+                delete rb.responses
+            }
         }
         t |> equal(heap_bytes_allocated(), before, "no parse tree survives parse_response_batch")
+    }
+}
+
+[test]
+def test_free_request_ends_the_scope(t : T?) {
+    t |> run("parse_request hands back an owned document") @(t : T?) {
+        let before = heap_bytes_allocated()
+        var req = parse_request(SINGLE)
+        t |> success(req.document != null, "the request owns its parse tree")
+        t |> success(req.params != null, "params is a view into it")
+        t |> success(heap_bytes_allocated() > before, "the tree is on the heap")
+        free_request(req)
+        t |> success(req.document == null, "free_request clears the document")
+        t |> success(req.params == null, "free_request clears the params view")
+        t |> equal(heap_bytes_allocated(), before, "free_request releases the tree")
+    }
+    t |> run("the request strings outlive the document") @(t : T?) {
+        var req = parse_request(SINGLE)
+        free_request(req)
+        t |> equal(req.method, "echo")
+        t |> equal(req.id_str, "1")
+        t |> equal(req.params_json |> length > 0, true)
+    }
+    t |> run("a failed parse owns nothing") @(t : T?) {
+        let before = heap_bytes_allocated()
+        var req = parse_request("not json at all")
+        t |> success(req.document == null, "there is no document to own")
+        t |> success(!empty(req.error_envelope), "the error envelope came back")
+        free_request(req)
+        t |> equal(heap_bytes_allocated(), before, "free_request on a failed parse is a no-op")
+    }
+    t |> run("repeated parse and free does not accumulate") @(t : T?) {
+        var warm = parse_request(SINGLE)
+        free_request(warm)
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            var req = parse_request(SINGLE)
+            free_request(req)
+        }
+        t |> equal(heap_bytes_allocated(), before, "the scope closes every time")
+    }
+}
+
+[test]
+def test_free_batch_ends_the_scope(t : T?) {
+    t |> run("parse_batch hands back one owned document for the whole batch") @(t : T?) {
+        let before = heap_bytes_allocated()
+        var pb <- parse_batch(BATCH)
+        t |> success(pb.document != null, "the batch owns the parse tree")
+        t |> equal(length(pb.requests), 3)
+        for (req in pb.requests) {
+            t |> success(req.document == null, "an entry never owns the document")
+        }
+        t |> success(pb.requests[0].params != null, "the first entry has a params view")
+        free_batch(pb)
+        t |> success(pb.document == null, "free_batch clears the document")
+        t |> equal(heap_bytes_allocated(), before, "free_batch releases the tree and the entry array")
+    }
+    t |> run("repeated parse and free does not accumulate") @(t : T?) {
+        var warm <- parse_batch(BATCH)
+        free_batch(warm)
+        let before = heap_bytes_allocated()
+        for (_ in range(8)) {
+            var pb <- parse_batch(BATCH)
+            free_batch(pb)
+        }
+        t |> equal(heap_bytes_allocated(), before, "the scope closes every time")
+    }
+    t |> run("a framing error owns its document too") @(t : T?) {
+        let before = heap_bytes_allocated()
+        var pb <- parse_batch("[]")
+        t |> success(!empty(pb.framing_error), "the empty batch was rejected")
+        free_batch(pb)
+        t |> equal(heap_bytes_allocated(), before, "free_batch releases the tree")
     }
 }

--- a/tutorials/jsonrpc/02_dispatch_line.das
+++ b/tutorials/jsonrpc/02_dispatch_line.das
@@ -111,16 +111,21 @@ def main() {   // nolint:STYLE038 - tutorial walkthrough, the sequence IS the le
 
     print("\n=== Section 5: Lower-level (parse_request + envelopes) ===\n")
 
+    // `parse_request` hands back the parse tree it built (`parsed.document`), because
+    // `parsed.params` is a view into it. Close the request scope with `free_request`
+    // once you are done reading — the strings on `ParsedRequest` outlive the tree.
+
     let custom_req = "\{\"id\":42,\"method\":\"unknown\"}"
-    let parsed = parse_request(custom_req)
+    var parsed = parse_request(custom_req)
     var custom_resp = ""
     if (!empty(parsed.error_envelope)) {
-        custom_resp = parsed.is_notification ? "" : parsed.error_envelope
+        custom_resp = parsed.error_envelope
     } elif (parsed.method != "ping" && parsed.method != "echo") {
         custom_resp = error(parsed.id_str, METHOD_NOT_FOUND, "no such method: {parsed.method}")
     } else {
         custom_resp = response(parsed.id_str, dispatch_method(parsed.method, parsed.params_json))
     }
+    free_request(parsed)
     print("custom dispatch with -32601: {custom_resp}\n")
 
     print("\nDone.\n")

--- a/tutorials/jsonrpc/03_batch.das
+++ b/tutorials/jsonrpc/03_batch.das
@@ -112,7 +112,11 @@ def main() {   // nolint:STYLE038 - tutorial walkthrough, the sequence IS the le
 
     print("\n=== Section 5: Manual batch via parse_batch ===\n")
 
-    let pb = parse_batch(wire)
+    // One parse tree backs the whole batch (`pb.document`), and every entry's
+    // `params` is a view into it. Read the entries, then close the scope with
+    // `free_batch` — it releases the tree and the entry array together.
+
+    var pb <- parse_batch(wire)
     print("is_batch: {pb.is_batch}, requests: {length(pb.requests)}, framing_error: '{pb.framing_error}'\n")
     for (req in pb.requests) {
         if (!empty(req.error_envelope)) {
@@ -122,6 +126,7 @@ def main() {   // nolint:STYLE038 - tutorial walkthrough, the sequence IS the le
             print("  {kind}: method={req.method}, id={req.id_str}, params={req.params_json}\n")
         }
     }
+    free_batch(pb)
 
     print("\nDone.\n")
 }

--- a/utils/mcp/mcp_core.das
+++ b/utils/mcp/mcp_core.das
@@ -482,10 +482,9 @@ def handle_tools_call(server : McpServer; reg : array<ToolDef>; id_json : string
 // ── JSON-RPC dispatcher ──────────────────────────────────────────────
 
 def dispatch_one(server : McpServer; reg : array<ToolDef>; req : jsonrpc::ParsedRequest; body : string) : string {
-    // Malformed entry — parser already built the envelope. Notifications skip the wire.
     if (!empty(req.error_envelope)) {
-        if (!req.is_notification) log_error(req.error_envelope)
-        return req.is_notification ? "" : req.error_envelope
+        log_error(req.error_envelope)
+        return req.error_envelope
     }
     let id_json = req.id_str
     let method = req.method

--- a/utils/mcp/mcp_core.das
+++ b/utils/mcp/mcp_core.das
@@ -510,15 +510,14 @@ def dispatch_one(server : McpServer; reg : array<ToolDef>; req : jsonrpc::Parsed
     return req.is_notification ? "" : result
 }
 
-def dispatch_jsonrpc(server : McpServer; reg : array<ToolDef>; body : string) : string {
-    let pb = jsonrpc::parse_batch(body)
+def dispatch_parsed(server : McpServer; reg : array<ToolDef>; pb : jsonrpc::ParsedBatch; body : string) : string {
     if (!empty(pb.framing_error)) {
         log_error(pb.framing_error)
         return pb.framing_error
     }
     if (!pb.is_batch) return dispatch_one(server, reg, pb.requests[0], body)
     // §6 batch: collect non-empty per-entry responses, wrap as JSON array; "" if all-notifications.
-    var parts : array<string>
+    var inscope parts : array<string>
     parts |> reserve(length(pb.requests))
     for (req in pb.requests) {
         let r = dispatch_one(server, reg, req, body)
@@ -535,6 +534,13 @@ def dispatch_jsonrpc(server : McpServer; reg : array<ToolDef>; body : string) : 
         }
         write_char(w, ']')
     }
+}
+
+def dispatch_jsonrpc(server : McpServer; reg : array<ToolDef>; body : string) : string {
+    var pb <- jsonrpc::parse_batch(body)
+    let wire = dispatch_parsed(server, reg, pb, body)
+    jsonrpc::free_batch(pb)
+    return wire
 }
 
 // ── stdio server loop ────────────────────────────────────────────────


### PR DESCRIPTION
**Behavior changes: `read_json` decodes `\uXXXX` surrogate pairs to real UTF-8 (lone surrogates become U+FFFD), parses integers past int64 as doubles instead of wrapping negative or throwing out of the process, and rejects malformed input it used to silently accept; `jsonrpc` request parsing becomes an owned scope with `free_request`/`free_batch`, closing a per-request leak of the whole JSON tree.**

json: surrogate pairs were emitted as CESU-8; `9223372036854775808` parsed as its negative twin and `-9223372036854775809` **threw an uncaught exception out of the lexer** — a process kill on untrusted bytes; `try_fixing_broken_json` read one byte past a trailing backslash; and `parse_value` detected an empty array by string-matching its own error message, which user data could spoof — `read_json("[[1 \"]\"]")` returned `[]` with no error. All four are structural now, pinned by 42 new test arms.

jsonrpc: `parse_one_request` borrowed `params` into a document nobody freed — a long-running server leaked every request's parse tree. `ParsedRequest`/`ParsedBatch` now own their documents, dispatch frees after the handler, and the request-scoped lifetime is explicit API (`free_request`/`free_batch`, RST-grouped, tutorials updated). Measured: single request, batch, malformed request and unparseable line each settle at 0 bytes retained. The dead notification branch fell out of `jsonrpc` and its copy in `utils/mcp/mcp_core.das`.

json_boost: `JV`'s dim arm joined the dispatch chain as `static_elif` — the standalone `static_if` made the arm below it dead at runtime but still elaborated at compile time, so plain deletion would have regressed.

Where to look: `daslib/json.das` (lexer number path, escape decoding), `daslib/jsonrpc.das` (ownership), `tests/json/`, `tests/jsonrpc/`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first throughout: 12 unicode failures, 8 number panics/failures, and 6 leak assertions red at base, green after.
- tests/json 384/384, tests/jsonrpc 138/138, three jsonrpc tutorials run clean; lint and format clean on all 9 touched `.das`.
- `mcp_core` compile-proven against the new daslib; the shared code path is covered by tests/jsonrpc.

### Claims — stated, not tested
- Chosen contracts: lone surrogates → U+FFFD (WHATWG rule); integers beyond int64 → double, beyond double → parse error.

### Not done
- `tests/mcp/test_mcp_jsonrpc.das` spawns its server subprocess without `-dasroot`, silently pairing the main tree's daslib with the tested `utils/mcp/` in any worktree — the forwarding fix plus a build-state precondition (or an in-process `dispatch_jsonrpc` test) is its own arc, ledgered.
- Pre-existing json error-path leak (an abandoned partial array on parse error) and the `1e400` / leading-`+` float-path panics are ledgered, not touched.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
