### PR TITLE
sweep fixes: regex empty-matchable early-out, memoized recursion check, sticky ast_verify, one-form-per-local finalization, dead state out

### DIFF
--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -257,6 +257,17 @@ an entry lands here only when no name, shape, or test can carry it.
 - **Reporting is repair**: diagnostics go through `macro_sticky_error` (infer clears plain
   errors from a repaired tree); null entries in per-entry-dereferenced lists compact in
   preVisit; a self-reachable node is CUT, not reported — a cycle kills every later walk.
+  Both passes use the sticky form, post-infer included. `Program::stickyError` records the
+  error AND calls `Program::error`, so it is a strict superset of `macro_error` — the plain
+  form buys nothing. It is currently unreachable for a loss (every re-entry into
+  `inferTypes`/`inferTypesDirty` after a post-infer firing is guarded by
+  `!program->failed()`), but repair is what makes the guarantee necessary rather than
+  belt-and-suspenders: the guard that found the damage cannot fire twice, so an error
+  cleared once is gone for good.
+- **`visitExpression` is the only place an ancestor-path entry is dropped.** The C++
+  adapter's `VISIT_EXPR` macro (`aot_builtin_ast.h`) calls `visitExpression(that)` before
+  every `visitExprXXX`, so a derived visit that erased again would erase nothing — a
+  derived visit returns its node and leaves the path alone.
 - **The two passes' skip sets are complementary**: pre-infer skips `generated` (filled in
   across passes); post-infer skips only `[template]` bodies and dasbind `[extern]` stubs —
   so generated bodies ARE checked post-infer, by nothing else.
@@ -276,6 +287,16 @@ an entry lands here only when no name, shape, or test can carry it.
 - **`blacklist` entries naming back-references break reconstruction cycles — removing one
   hangs the walk** (`Function.classParent`, `ExprReturn._block`, `ExprVar.pBlock`,
   `EnumEntry.value`); the rest are post-infer bookkeeping absent from quoted trees.
+
+## templates_boost
+
+- **A `Template`'s substitution tables are freed once, by whichever mechanism the local
+  declares** — `var inscope rules` finalizes at scope exit; a plain `var rules` does not and
+  needs an explicit `delete rules`. Declaring both double-finalizes, and the double is
+  silent: a plain local leaks 224 B where inscope-only, inscope+delete and plain+delete all
+  leak 0, so nothing shows up in a heap count. Both `apply_qmacro_template_*` appliers are
+  inscope-only; the three plain-local `apply_template` overloads pair the declaration with
+  the delete. Pick one form per local and read the declaration before adding a delete.
 
 ## dupe_detect
 

--- a/daslib/apply.das
+++ b/daslib/apply.das
@@ -398,15 +398,15 @@ def private invoke_apply(var expr : ExprCallMacro?; argT : TypeDeclPtr; hasExtra
     var nfields : int
     var names : array<string>
     if (argT.baseType == Type.tStructure) {
-        callName = "apply`struct`{argT.structType.name}`{expr.at.line}"
+        callName = "apply`struct`{argT.structType.name}`{expr.at.line}`{expr.at.column}"
         nfields = argT.structType.fields |> length
         names <- generateApplyVisitStruct(expr.arguments[0]._type, callName, expr.at, hasExtraArg)  // nolint:PERF030 - target is the fresh empty decl above; the three fills are mutually exclusive branches
     } elif (argT.baseType == Type.tTuple) {
-        callName = "apply`tuple`{expr.arguments[0]._type.get_mnh}`{expr.at.line}"
+        callName = "apply`tuple`{expr.arguments[0]._type.get_mnh}`{expr.at.line}`{expr.at.column}"
         nfields = length(argT.argTypes)
         names <- generateApplyVisitTuple(expr.arguments[0]._type, callName, expr.at)  // nolint:PERF030 - target is the fresh empty decl above; the three fills are mutually exclusive branches
     } else {
-        callName = "apply`variant`{expr.arguments[0]._type.get_mnh}`{expr.at.line}"
+        callName = "apply`variant`{expr.arguments[0]._type.get_mnh}`{expr.at.line}`{expr.at.column}"
         nfields = length(argT.argTypes)
         names <- generateApplyVisitVariant(expr.arguments[0]._type, callName, expr.at)  // nolint:PERF030 - target is the fresh empty decl above; the three fills are mutually exclusive branches
     }

--- a/daslib/ast.das
+++ b/daslib/ast.das
@@ -739,9 +739,12 @@ def make_capture_macro(name : string; var someClassPtr) : CaptureMacroPtr {
     }
 }
 
+var private gc_root_AstTypeMacro : array<AstTypeMacro?>
+
 [macro_function]
 def make_type_macro(name : string; var someClassPtr) : TypeMacroPtr {
     static_if (typeinfo is_pointer(someClassPtr) && typeinfo is_class(*someClassPtr)) {
+        gc_root_AstTypeMacro |> push(someClassPtr)
         let classInfo = class_info(*someClassPtr)
         return make_type_macro(name, someClassPtr, classInfo)
     } else {

--- a/daslib/ast_verify.das
+++ b/daslib/ast_verify.das
@@ -318,13 +318,9 @@ class private AstVerifyVisitor : AstVisitor {
         track_type_tree(expr._type, "{expr.__rtti}.type")
     }
 
-    def leave(var expr : ExpressionPtr) : ExpressionPtr {
+    def override visitExpression(var expr : ExpressionPtr) : ExpressionPtr {
         ancestors |> erase(expr)
         return expr
-    }
-
-    def override visitExpression(var expr : ExpressionPtr) : ExpressionPtr {
-        return leave(expr)
     }
 
     def is_ancestor(slot : ExpressionPtr) : bool {
@@ -543,7 +539,7 @@ class private AstVerifyVisitor : AstVisitor {
         if (expr.blockFlags.isClosure && closure_depth > 0) {
             closure_depth--
         }
-        return leave(expr)
+        return expr
     }
 
     def override preVisitExprOp3(var expr : ExprOp3?) : void {
@@ -753,7 +749,7 @@ class private AstVerifyVisitor : AstVisitor {
             report(expr.at, "ExprVar.name '{expr.name}' disagrees with its resolved variable '{v.name}'")
             expr.name := v.name
         }
-        return leave(expr)
+        return expr
     }
 
     def override preVisitFunction(var fun : FunctionPtr) : void {
@@ -942,7 +938,7 @@ class private AstPostInferVerifyVisitor : AstVisitor {
         to_log(LOG_ERROR, empty(loc)
             ? "AST verify (post-infer): {text}\n"
             : "AST verify (post-infer): {text} at {loc}\n")
-        compiling_program() |> macro_error(anchor, "AST verify (post-infer): {text}")
+        compiling_program() |> macro_sticky_error(anchor, "AST verify (post-infer): {text}")
     }
 
     def guess_at(var expr : ExpressionPtr) : Anchor {

--- a/daslib/builtin.das
+++ b/daslib/builtin.das
@@ -321,7 +321,7 @@ def push(var Arr : array<auto(numT)>; var value : numT -# ==const) {
     }
 }
 
-[unused_argument(Arr, value)]
+[unused_argument(Arr, varr)]
 def push(var Arr : array<auto(numT)>; varr : array<numT -#> ==const) {
     static_if (typeinfo can_copy(type<numT>)) {
         static_if (typeinfo can_clone_from_const(varr[0])) {
@@ -337,7 +337,7 @@ def push(var Arr : array<auto(numT)>; varr : array<numT -#> ==const) {
     }
 }
 
-[unused_argument(Arr, value)]
+[unused_argument(Arr, varr)]
 def push(var Arr : array<auto(numT)>; var varr : array<numT -#> ==const) {
     static_if (typeinfo can_copy(type<numT>)) {
         Arr |> reserve(long_length(Arr) + long_length(varr))
@@ -349,7 +349,7 @@ def push(var Arr : array<auto(numT)>; var varr : array<numT -#> ==const) {
     }
 }
 
-[unused_argument(Arr, value)]
+[unused_argument(Arr, varr)]
 def push(var Arr : array<auto(numT)>; varr : numT[] -#) {
     static_if (typeinfo can_copy(type<numT>)) {
         Arr |> reserve(long_length(Arr) + int64(length(varr)))
@@ -455,7 +455,7 @@ def push_clone(var Arr : array<auto(numT)>; var value : numT ==const | #) {
     }
 }
 
-[unused_argument(Arr, value)]
+[unused_argument(Arr, varr)]
 def push_clone(var Arr : array<auto(numT)>; varr : numT[] ==const) {
     static_if (typeinfo can_clone(type<numT>)) {
         static_if (typeinfo can_clone_from_const(varr[0])) {
@@ -471,7 +471,7 @@ def push_clone(var Arr : array<auto(numT)>; varr : numT[] ==const) {
     }
 }
 
-[unused_argument(Arr, value)]
+[unused_argument(Arr, varr)]
 def push_clone(var Arr : array<auto(numT)>; var varr : numT[] ==const) {
     static_if (typeinfo can_clone(type<numT>)) {
         Arr |> reserve(long_length(Arr) + int64(length(varr)))

--- a/daslib/logger.das
+++ b/daslib/logger.das
@@ -55,7 +55,6 @@ require daslib/rtti
 var private log_file : FILE const? = null
 var private log_path : string
 var private log_name : string
-var private log_open_attempted = false
 var private log_open_failed = false
 var private log_min_level = LOG_INFO
 var private log_category_overrides : table<string; int>
@@ -106,7 +105,6 @@ def private ensure_dir(path : string) {
 
 def private ensure_open() {
     return if (log_file != null || log_open_failed || empty(log_path))
-    log_open_attempted = true
     ensure_dir(log_path)
     log_file = fopen(log_path, "ab")
     if (log_file == null) {
@@ -167,7 +165,6 @@ def logger_set_path(path : string) {
     }
     log_path = path
     log_name = ""
-    log_open_attempted = false
     log_open_failed = false
 }
 
@@ -259,7 +256,6 @@ def logger_close() {
         fclose(log_file)
         log_file = null
     }
-    log_open_attempted = false
     log_open_failed = false
 }
 

--- a/daslib/regex.das
+++ b/daslib/regex.das
@@ -1525,8 +1525,8 @@ def regex_compile(var re : Regex; expr : string; case_insensitive : bool = false
         re_assign_next(re)
         re_assign_groups(re)
         re_assign_match_functions(re)
-        re_early_out(re.earlyOut, re.root)
-        re.canEarlyOut = !is_set_empty(re.earlyOut)
+        let matchesEmpty = re_early_out(re.earlyOut, re.root)
+        re.canEarlyOut = !matchesEmpty && !is_set_empty(re.earlyOut)
     }
     return re.root != null
 }

--- a/daslib/sql_migrate.das
+++ b/daslib/sql_migrate.das
@@ -120,16 +120,17 @@ def private _registry_find_description(stream : string; version : int) : string 
     return ""
 }
 
-def private _verify_no_duplicate_versions(stream : string) : void {
+def private _duplicate_version_error(stream : string) : string {
     var seen : table<int; string>
     for (e in _registry) {
         if (e.stream != stream) continue
         if (key_exists(seen, e.version)) {
             let prev = seen[e.version]
-            panic("duplicate [sql_migration(version={e.version})] at runtime: '{prev}' and '{e.func_name}' (in '{e.module_name}')")
+            return "duplicate [sql_migration(version={e.version})] at runtime: '{prev}' and '{e.func_name}' (in '{e.module_name}')"
         }
         seen |> insert(e.version, "{e.func_name} (in '{e.module_name}')")
     }
+    return ""
 }
 
 let private ADOPTION_HINT = "this DB has existing tables/views/indexes but __schema_version is empty (no migration history yet). If your first migration creates tables that already exist, it will fail. To adopt migrations on an existing DB, call `db |> baseline(version = N)` before `migrate_to_latest()` to mark v1..vN as already applied. See tut 43 section \"Adopting migrations on an existing DB\"."
@@ -172,7 +173,7 @@ def private _log_warn_on_some(err : SqlError) : void {
     }
 }
 
-def private _migrate_inner(db; blocking : bool) : Result<int, string> {   // nolint:STYLE038 - one linear migration protocol; the layers share the audit-table state
+def private _migrate_inner(db; blocking : bool) : Result<int, string> {   // nolint:STYLE037,STYLE038 - one linear migration protocol; the layers share the audit-table state
     let stream = _::_migration_stream_key(db)
     let create_err = db |> _::try_exec(AUDIT_CREATE_DDL)
     if (create_err |> is_some) return err(create_err |> unwrap, type<int>)
@@ -181,7 +182,8 @@ def private _migrate_inner(db; blocking : bool) : Result<int, string> {   // nol
     if (audit_was_empty_before && max_registered > 0 && _::_migration_has_user_objects(db)) {
         to_log(LOG_WARNING, "{ADOPTION_HINT}\n")
     }
-    _verify_no_duplicate_versions(stream)
+    let dup_err = _duplicate_version_error(stream)
+    if (!empty(dup_err)) return err(dup_err, type<int>)
     let current = _scalar_int_or_zero(db, "SELECT COALESCE(MAX(version), 0) FROM __schema_version")
     if (current > max_registered) {
         let bin_max = max_registered

--- a/daslib/templates_boost.das
+++ b/daslib/templates_boost.das
@@ -1184,7 +1184,7 @@ class private AstQCallMacro : AstCallMacro {
     apply_call = "apply_qmacro" //! Default apply call, can be overridden in subclasses
     macro_call = "qmacro"       //! Default macro call, can be overridden in subclasses
     def override canVisitArgument(call : ExprCallMacro?; argIndex : int) : bool {
-        //! Only first argument is visited
+        //! No argument is visited: like quote, the call is reified exactly as written.
         return false
     }
     def override visit(prog : ProgramPtr; mod : Module?; var call : ExprCallMacro?) : Expression? {
@@ -1471,7 +1471,6 @@ def public apply_qmacro_template_class(instance_name : string; var template_type
         }
     }
     mod |> add_structure(instance_structure)
-    delete rules
     return instance_type
 }
 

--- a/daslib/validate_code.das
+++ b/daslib/validate_code.das
@@ -31,6 +31,7 @@ def check_recursive(at : LineInfo; var fun : Function?; var call_graph : array<F
         macro_error(compiling_program(), at, sb)
         return
     }
+    if (visited |> key_exists(fun)) return
     visited |> insert(fun)
     call_graph |> push(fun)
     fun |> get_use_functions() $(f) {

--- a/tests/apply/test_apply_call_site_keys.das
+++ b/tests/apply/test_apply_call_site_keys.das
@@ -1,0 +1,47 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+require daslib/apply
+
+//! An `apply` whose block uses `return` to skip a field falls back to generated per-field
+//! helpers whose names key the call site. Two applies sharing a line must each get their own
+//! instantiation and their own value; a key without a column component gives them one name.
+
+struct KeyFoo {
+    a : int
+    b : string
+}
+
+struct OtherFoo {
+    a : int
+    b : string
+    c : int
+}
+
+[test]
+def test_two_applies_on_one_line_stay_separate(t : T?) {
+    t |> run("same struct twice") @(t : T?) {
+        var left = ""
+        var right = ""
+        apply(KeyFoo(a = 1, b = "x")) $(name, field) { if (name == "b") { return }; left += "{name}={field};" }; apply(KeyFoo(a = 2, b = "y")) $(name, field) { if (name == "a") { return }; right += "{name}={field};" }
+        t |> equal(left, "a=1;")
+        t |> equal(right, "b=y;")
+    }
+    t |> run("different structs") @(t : T?) {
+        var left = ""
+        var right = ""
+        apply(KeyFoo(a = 3, b = "p")) $(name, field) { if (name == "a") { return }; left += "{name};" }; apply(OtherFoo(a = 4, b = "q", c = 5)) $(name, field) { if (name == "b") { return }; right += "{name};" }
+        t |> equal(left, "b;")
+        t |> equal(right, "a;c;")
+    }
+    t |> run("const and mutable sources") @(t : T?) {
+        let fixed = KeyFoo(a = 6, b = "r")
+        var movable = KeyFoo(a = 7, b = "s")
+        var left = ""
+        var right = ""
+        apply(fixed) $(name, field) { if (name == "b") { return }; left += "{field};" }; apply(movable) $(name, field) { if (name == "a") { return }; right += "{field};" }
+        t |> equal(left, "6;")
+        t |> equal(right, "s;")
+    }
+}

--- a/tests/daslib/_verify_completion_cycle_fixture.das
+++ b/tests/daslib/_verify_completion_cycle_fixture.das
@@ -1,0 +1,38 @@
+options gen2
+options indenting = 4
+
+require daslib/validate_code
+
+//! Companion to the fan-out fixture: the cycle here closes through `shared_tail`, which two
+//! different branches reach. A memo that swallowed an already-visited function on the current
+//! path would let the cycle through, so this fixture must still fail to compile.
+
+[never_inline]
+def shared_tail() : int {
+    return branch_top()
+}
+
+[never_inline]
+def branch_left() : int {
+    return shared_tail()
+}
+
+[never_inline]
+def branch_right() : int {
+    return shared_tail()
+}
+
+[never_inline]
+def branch_top() : int {
+    return branch_left() + branch_right()
+}
+
+[verify_completion]
+def cycle_root() : int {
+    return branch_top()
+}
+
+[export]
+def main {
+    feint("{cycle_root()}")
+}

--- a/tests/daslib/_verify_completion_fanout_fixture.das
+++ b/tests/daslib/_verify_completion_fanout_fixture.das
@@ -1,0 +1,249 @@
+options gen2
+options indenting = 4
+
+require daslib/validate_code
+
+//! Fan-out fixture for the `[verify_completion]` recursion walk: every level calls both
+//! functions of the level below, so a walk without a visited-memo explores 2^N paths
+//! while a memoized walk sees each function once. `[never_inline]` keeps the inliner
+//! from collapsing the graph before the annotation ever runs.
+
+[never_inline]
+def leaf0a() : int {
+    return 1
+}
+
+[never_inline]
+def leaf0b() : int {
+    return 2
+}
+
+[never_inline]
+def leaf1a() : int {
+    return leaf0a() + leaf0b()
+}
+
+[never_inline]
+def leaf1b() : int {
+    return leaf0a() + leaf0b()
+}
+
+[never_inline]
+def leaf2a() : int {
+    return leaf1a() + leaf1b()
+}
+
+[never_inline]
+def leaf2b() : int {
+    return leaf1a() + leaf1b()
+}
+
+[never_inline]
+def leaf3a() : int {
+    return leaf2a() + leaf2b()
+}
+
+[never_inline]
+def leaf3b() : int {
+    return leaf2a() + leaf2b()
+}
+
+[never_inline]
+def leaf4a() : int {
+    return leaf3a() + leaf3b()
+}
+
+[never_inline]
+def leaf4b() : int {
+    return leaf3a() + leaf3b()
+}
+
+[never_inline]
+def leaf5a() : int {
+    return leaf4a() + leaf4b()
+}
+
+[never_inline]
+def leaf5b() : int {
+    return leaf4a() + leaf4b()
+}
+
+[never_inline]
+def leaf6a() : int {
+    return leaf5a() + leaf5b()
+}
+
+[never_inline]
+def leaf6b() : int {
+    return leaf5a() + leaf5b()
+}
+
+[never_inline]
+def leaf7a() : int {
+    return leaf6a() + leaf6b()
+}
+
+[never_inline]
+def leaf7b() : int {
+    return leaf6a() + leaf6b()
+}
+
+[never_inline]
+def leaf8a() : int {
+    return leaf7a() + leaf7b()
+}
+
+[never_inline]
+def leaf8b() : int {
+    return leaf7a() + leaf7b()
+}
+
+[never_inline]
+def leaf9a() : int {
+    return leaf8a() + leaf8b()
+}
+
+[never_inline]
+def leaf9b() : int {
+    return leaf8a() + leaf8b()
+}
+
+[never_inline]
+def leaf10a() : int {
+    return leaf9a() + leaf9b()
+}
+
+[never_inline]
+def leaf10b() : int {
+    return leaf9a() + leaf9b()
+}
+
+[never_inline]
+def leaf11a() : int {
+    return leaf10a() + leaf10b()
+}
+
+[never_inline]
+def leaf11b() : int {
+    return leaf10a() + leaf10b()
+}
+
+[never_inline]
+def leaf12a() : int {
+    return leaf11a() + leaf11b()
+}
+
+[never_inline]
+def leaf12b() : int {
+    return leaf11a() + leaf11b()
+}
+
+[never_inline]
+def leaf13a() : int {
+    return leaf12a() + leaf12b()
+}
+
+[never_inline]
+def leaf13b() : int {
+    return leaf12a() + leaf12b()
+}
+
+[never_inline]
+def leaf14a() : int {
+    return leaf13a() + leaf13b()
+}
+
+[never_inline]
+def leaf14b() : int {
+    return leaf13a() + leaf13b()
+}
+
+[never_inline]
+def leaf15a() : int {
+    return leaf14a() + leaf14b()
+}
+
+[never_inline]
+def leaf15b() : int {
+    return leaf14a() + leaf14b()
+}
+
+[never_inline]
+def leaf16a() : int {
+    return leaf15a() + leaf15b()
+}
+
+[never_inline]
+def leaf16b() : int {
+    return leaf15a() + leaf15b()
+}
+
+[never_inline]
+def leaf17a() : int {
+    return leaf16a() + leaf16b()
+}
+
+[never_inline]
+def leaf17b() : int {
+    return leaf16a() + leaf16b()
+}
+
+[never_inline]
+def leaf18a() : int {
+    return leaf17a() + leaf17b()
+}
+
+[never_inline]
+def leaf18b() : int {
+    return leaf17a() + leaf17b()
+}
+
+[never_inline]
+def leaf19a() : int {
+    return leaf18a() + leaf18b()
+}
+
+[never_inline]
+def leaf19b() : int {
+    return leaf18a() + leaf18b()
+}
+
+[never_inline]
+def leaf20a() : int {
+    return leaf19a() + leaf19b()
+}
+
+[never_inline]
+def leaf20b() : int {
+    return leaf19a() + leaf19b()
+}
+
+[never_inline]
+def leaf21a() : int {
+    return leaf20a() + leaf20b()
+}
+
+[never_inline]
+def leaf21b() : int {
+    return leaf20a() + leaf20b()
+}
+
+[never_inline]
+def leaf22a() : int {
+    return leaf21a() + leaf21b()
+}
+
+[never_inline]
+def leaf22b() : int {
+    return leaf21a() + leaf21b()
+}
+
+[verify_completion]
+def fanout_root() : int {
+    return leaf22a() + leaf22b()
+}
+
+[export]
+def main {
+    feint("{fanout_root()}")
+}

--- a/tests/daslib/verify_completion_memo_test.das
+++ b/tests/daslib/verify_completion_memo_test.das
@@ -1,0 +1,51 @@
+options gen2
+options no_aot
+
+require dastest/testing_boost public
+require daslib/ast_boost
+require daslib/rtti
+require strings
+
+//! `[verify_completion]` walks the call graph looking for recursion. The walk memoizes the
+//! functions it has already cleared, so a wide fan-out graph costs one visit per function
+//! instead of one per path. Without the memo the fixture below takes tens of seconds.
+
+let private BUDGET_USEC = 5000000
+
+def private fixture_path(name : string) : string {
+    return "{get_das_root()}/tests/daslib/_verify_completion_{name}_fixture.das"
+}
+
+[test]
+def test_recursion_walk_visits_each_function_once(t : T?) {
+    t |> run("wide fan-out graph compiles within budget") @(t : T?) {
+        var inscope access <- make_file_access("")
+        using() $(var mg : ModuleGroup) {
+            using() $(var cop : CodeOfPolicies) {
+                cop.threadlock_context = true
+                let started = ref_time_ticks()
+                compile_file(fixture_path("fanout"), access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                    let elapsed = get_time_usec(started)
+                    t |> success(ok, "fixture must compile: {issues}")
+                    t |> success(elapsed < BUDGET_USEC, "compiled in {elapsed}us, budget {BUDGET_USEC}us")
+                }
+            }
+        }
+    }
+}
+
+[test]
+def test_recursion_through_a_shared_callee_is_still_reported(t : T?) {
+    t |> run("cycle closing through a shared function fails to compile") @(t : T?) {
+        var inscope access <- make_file_access("")
+        using() $(var mg : ModuleGroup) {
+            using() $(var cop : CodeOfPolicies) {
+                cop.threadlock_context = true
+                compile_file(fixture_path("cycle"), access, unsafe(addr(mg)), cop) $(ok; program; issues) {
+                    t |> success(!ok, "cyclic fixture must not compile")
+                    t |> success(find("{issues}", "recursive calls are not allowed") >= 0, "expected a recursion error, got: {issues}")
+                }
+            }
+        }
+    }
+}

--- a/tests/regex/test_regex_early_out.das
+++ b/tests/regex/test_regex_early_out.das
@@ -1,0 +1,81 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+require dastest/testing_boost public
+require daslib/regex
+
+def private collect_spans(var re : Regex; str : string) {
+    var spans : array<int>
+    regex_foreach(re, str) $(at) {
+        spans |> push(at.x)
+        spans |> push(at.y)
+        return true
+    }
+    return <- spans
+}
+
+def private same_as_scan(t : T?; pattern : string; str : string) {
+    var withEarlyOut <- regex_compile(pattern)
+    var fullScan <- regex_compile(pattern)
+    fullScan.canEarlyOut = false
+    var fast <- collect_spans(withEarlyOut, str)
+    var slow <- collect_spans(fullScan, str)
+    t |> equal(length(fast), length(slow), "match count for `{pattern}` on `{str}`")
+    if (length(fast) == length(slow)) {
+        for (a, b in fast, slow) {
+            t |> equal(a, b, "span bound for `{pattern}` on `{str}`")
+        }
+    }
+}
+
+[test]
+def test_empty_matchable_patterns_scan_every_position(t : T?) {
+    t |> run("star") @(t : T?) {
+        same_as_scan(t, "a*", "bab")
+        same_as_scan(t, "a*", "xyz")
+    }
+    t |> run("optional group") @(t : T?) {
+        same_as_scan(t, "(abc)?", "xabcx")
+    }
+    t |> run("repeat with zero minimum") @(t : T?) {
+        same_as_scan(t, "x\{0,3}", "aaxxa")
+    }
+    t |> run("alternation with empty branch") @(t : T?) {
+        same_as_scan(t, "a*|b", "cbc")
+    }
+}
+
+[test]
+def test_zero_length_matches_are_reported(t : T?) {
+    t |> run("a* on bab yields three matches") @(t : T?) {
+        var re <- regex_compile("a*")
+        let spans <- collect_spans(re, "bab")
+        t |> equal(length(spans), 6)
+        if (length(spans) == 6) {
+            t |> equal(spans[0], 0)
+            t |> equal(spans[1], 0)
+            t |> equal(spans[2], 1)
+            t |> equal(spans[3], 2)
+            t |> equal(spans[4], 2)
+            t |> equal(spans[5], 2)
+        }
+    }
+}
+
+[test]
+def test_early_out_survives_where_it_is_sound(t : T?) {
+    t |> run("empty-matchable patterns clear the early-out") @(t : T?) {
+        var star <- regex_compile("a*")
+        t |> success(!star.canEarlyOut, "a* must not early-out")
+        var opt <- regex_compile("(abc)?")
+        t |> success(!opt.canEarlyOut, "(abc)? must not early-out")
+    }
+    t |> run("mandatory patterns keep the early-out") @(t : T?) {
+        var lit <- regex_compile("abc")
+        t |> success(lit.canEarlyOut, "abc must early-out")
+        var plus <- regex_compile("a+")
+        t |> success(plus.canEarlyOut, "a+ must early-out")
+        var tail <- regex_compile("a*b")
+        t |> success(tail.canEarlyOut, "a*b must early-out")
+    }
+}


### PR DESCRIPTION
**Behavior changes: `regex` no longer skips legal zero-length matches for empty-matchable patterns; `validate_code`'s recursion check goes from exponential to memoized (89x on a 22-level fan-out); `sql_migrate`'s duplicate-version check honors the `try_` contract instead of panicking; `templates_boost`'s class applier stops double-finalizing its rules; `make_type_macro` gets its missing gc-root.**

Nine machinery and dead-code fixes from the comment-sweep defect hunt.

regex: `regex_compile` discarded `re_early_out`'s "this pattern can match empty" verdict, so `a*`, `(abc)?`, `x{0,3}` skipped zero-length matches the non-early-out path finds (`"bab"` matched once instead of three times). Empty-matchable patterns now clear the early-out.

ast_verify: post-infer diagnostics go through `macro_sticky_error` — a strict superset of the plain form (it records and reports), making the categorical guarantee explicit; two dead `leave()` calls fell out (the C++ `VISIT_EXPR` macro already routes every derived visit through `visitExpression`). `make_type_macro` in `ast.das` now pushes its gc-root like every sibling constructor. `sql_migrate`'s pre-transaction duplicate-version panic sat outside the `try`/`recover` its docstring promised — it returns an error now, same message, both runners keep their contract. `templates_boost`: probe showed `inscope` alone finalizes correctly and `inscope`+`delete` double-finalizes — the class applier now matches the function applier. The `apply` helper's uniqueness key gains the column, so two applies on one line stop colliding. Dead state deleted with proof: `builtin.das`'s five `[unused_argument(value)]` naming a nonexistent parameter, `validate_code`'s unread memo (now wired in), `logger`'s never-read flag.

Where to look: `daslib/regex.das`, `daslib/validate_code.das`, `daslib/ast_verify.das`, `daslib/templates_boost.das`, `daslib/sql_migrate.das`, `daslib/ARCHITECTURE.md` (the sticky-superset and one-form-per-local entries).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first where observable: the regex fixtures (6 assertions red at base), the memo timing fixture (19.98s → 0.22s) with a cycle-through-shared-callee control pinning that recursion is still reported, the apply same-line fixture.
- tests/regex 288/288, tests/daslib 266/266, tests/apply 31/31, tests/ast 14/14; full sweep's only failures are the two pre-existing box failures, verified identical on pristine master.
- All 9 touched daslib files verify clean under `force_clean_comments = true` — ready for the linq PR's flip.

### Claims — stated, not tested
- The templates_boost double-finalize and the gc-root gap are pinned by probe evidence (224B vs 0; sibling-pattern parity), not by fixtures — neither has an observable red state in a test process.
- `sql_migrate`'s runtime arm is covered by CI's dasSQLITE lane; this box validated by compile and code read (no built shared modules in the worktree).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
