### PR TITLE
sweep copilot round: base64url alphabet, panic-free json floats, syntax errors through short-circuit

### DIFF
--- a/daslib/base64.das
+++ b/daslib/base64.das
@@ -8,6 +8,10 @@ module base64 shared private
 //! Provides ``base64_encode`` and ``base64_decode`` for converting between
 //! binary data (strings or ``array<uint8>``) and Base64 text representation.
 //! Inspired by the libhv implementation.
+//!
+//! Decoding accepts the standard (``+`` ``/``) and URL-safe (``-`` ``_``)
+//! alphabets alike, with or without ``=`` padding, and rejects a length that
+//! leaves one orphan character. Encoding always emits the standard padded form.
 
 require daslib/strings
 
@@ -27,13 +31,13 @@ let base64en <- fixed_array<int>(
 );
 
 let base64de <- fixed_array<int>(
-        62,  -1,  -1,  -1,  63,  52,  53,  54,
+        62,  -1,  62,  -1,  63,  52,  53,  54,
         55,  56,  57,  58,  59,  60,  61,  -1,
         -1,  -1,  -1,  -1,  -1,  -1,   0,   1,
          2,   3,   4,   5,   6,   7,   8,   9,
         10,  11,  12,  13,  14,  15,  16,  17,
         18,  19,  20,  21,  22,  23,  24,  25,
-        -1,  -1,  -1,  -1,  -1,  -1,  26,  27,
+        -1,  -1,  -1,  -1,  63,  -1,  26,  27,
         28,  29,  30,  31,  32,  33,  34,  35,
         36,  37,  38,  39,  40,  41,  42,  43,
         44,  45,  46,  47,  48,  49,  50,  51
@@ -75,6 +79,7 @@ def public base64_decode(inp : array<uint8> | #; var out : array<uint8>) : int {
     let inlen = inp |> length
     var j = 0
     out |> clear()
+    if ((inlen % 4) == 1) return -1
     out |> ensure_capacity(BASE64_DECODE_OUT_SIZE(inlen))
     out |> resize(BASE64_DECODE_OUT_SIZE(inlen))
     for (i in range(inp |> length)) {

--- a/daslib/debug_eval.das
+++ b/daslib/debug_eval.das
@@ -90,7 +90,7 @@ struct TokenStream {
     stream : array<Token> //! Buffered array of tokens.
     errors : array<string> //! Accumulated parsing errors.
     names  : table<string; Result> //! Named variable lookup table for expression evaluation.
-    shortCircuited : bool //! True while parsing an operand a logical operator already decided without.
+    shortCircuited : bool //! True while an operand is being parsed whose value a logical operator has already decided without it; such an operand reports syntax errors but not evaluation errors.
 }
 
 def TokenStream(st : string) {
@@ -134,8 +134,13 @@ def InvalidResult {
     return self
 }
 
-def error(var st : TokenStream; error : string) {
-    if (!st.shortCircuited) st.errors |> push(error)
+def syntax_error(var st : TokenStream; message : string) {
+    st.errors |> push(message)
+    return InvalidResult()
+}
+
+def eval_error(var st : TokenStream; message : string) {
+    if (!st.shortCircuited) st.errors |> push(message)
     return InvalidResult()
 }
 
@@ -170,13 +175,13 @@ def getPD(var st : TokenStream; result : Result; offset : int = 0) : void? {
 
 def getI(var st : TokenStream; result : Result) : int64 {
     if (result.tinfo.dimSize != 0u) {
-        st |> error("can't get value of [{result.tinfo.dimSize}]")
+        st |> eval_error("can't get value of [{result.tinfo.dimSize}]")
         return INVALID_VALUE
     }
     let bt = result.tinfo.basicType
     let data = st |> getPD(result)
     if (data == null) {
-        st |> error("null pointer dereference for {result.tinfo.basicType}")
+        st |> eval_error("null pointer dereference for {result.tinfo.basicType}")
         return INVALID_VALUE
     }
     return loadI(data, type<int64>) if (bt == Type.tInt64 || bt == Type.tUInt64)
@@ -184,7 +189,7 @@ def getI(var st : TokenStream; result : Result) : int64 {
     return int64(loadI(data, type<int16>)) if (bt == Type.tInt16 || bt == Type.tUInt16)
     return int64(loadI(data, type<int8>)) if (bt == Type.tInt8 || bt == Type.tUInt8)
     return (loadI(data, type<bool>) ? 1l : 0l) if (bt == Type.tBool)
-    st |> error("can't get value of {result.tinfo.basicType}")
+    st |> eval_error("can't get value of {result.tinfo.basicType}")
     return INVALID_VALUE
 }
 
@@ -217,22 +222,22 @@ def func_call_length(var st : TokenStream; result : Result) : Result {
             return <- Result(int64(ptab.size))
         }
     }
-    return st |> error("unsupported length for type {result.tinfo.basicType}")
+    return st |> eval_error("unsupported length for type {result.tinfo.basicType}")
 }
 
 def func_call(var st : TokenStream; name : string; arg : Result) : Result {
     return func_call_length(st, arg) if (name == "length")
-    return st |> error("unknown function {name}")
+    return st |> eval_error("unknown function {name}")
 }
 
 def expr_value(var st : TokenStream) : Result {
     let token = token(st)
     match (token) {
         if (Token(invalid = _)) {
-            return st |> error("invalid token {token}, expecting number or (")
+            return st |> syntax_error("invalid token {token}, expecting number or (")
         }
         if (Token(eos = _)) {
-            return st |> error("unexpected end of stream")
+            return st |> syntax_error("unexpected end of stream")
         }
         if (Token(number = $v(value))) {
             return <- Result(value)
@@ -242,7 +247,7 @@ def expr_value(var st : TokenStream) : Result {
             if (ntoken ?as punkt ?? 0 == '(') {
                 let arg = expr(st);
                 ntoken = token(st);
-                if (ntoken ?as punkt ?? 0 != ')') return st |> error("expecting )")
+                if (ntoken ?as punkt ?? 0 != ')') return st |> syntax_error("expecting )")
                 return func_call(st, name, arg)
             }
             unput(st, ntoken)
@@ -250,16 +255,16 @@ def expr_value(var st : TokenStream) : Result {
                 return <- Result(true)
             } elif (name == "false") return <- Result(false)
             if (st.names |> key_exists(name)) return st.names |> get_value(name)
-            return st |> error("unknown variable {name}")
+            return st |> eval_error("unknown variable {name}")
         }
         if (Token(punkt = '(')) {
             var res = expr(st);
-            if (token(st) ?as punkt ?? 0 != ')') return st |> error("expecting )")
+            if (token(st) ?as punkt ?? 0 != ')') return st |> syntax_error("expecting )")
             return <- res
         }
-        if (Token(punkt = $v(any))) return st |> error("unexpected character {to_char(any)}, expecting number or (")  // nolint:STYLE005 (qmatch macro expansion)
+        if (Token(punkt = $v(any))) return st |> syntax_error("unexpected character {to_char(any)}, expecting number or (")  // nolint:STYLE005 (qmatch macro expansion)
     }
-    return st |> error("unexpected token {token}, expecting number or (")
+    return st |> syntax_error("unexpected token {token}, expecting number or (")
 }
 
 [unused_argument(st)]
@@ -325,7 +330,7 @@ def expr_field(var st : TokenStream) : Result {
             oti.offset = -1
             match (result.tinfo) {
                 if (TypeInfo(dimSize = $v(dimSize)) && (dimSize != 0u)) {
-                    return st |> error("can't access field of array")
+                    return st |> eval_error("can't access field of array")
                 }
                 if (TypeInfo(basicType = Type.tStructure)) {
                     oti = getStructFieldOffset(st, field as ident, result)
@@ -340,13 +345,13 @@ def expr_field(var st : TokenStream) : Result {
                     oti = getHandleFieldOffset(st, field as ident, result)
                 }
             }
-            if (oti.offset < 0) return st |> error("unknown field {field} in type {result.tinfo.basicType}")
+            if (oti.offset < 0) return st |> eval_error("unknown field {field} in type {result.tinfo.basicType}")
             let newData = getPD(st, result, oti.offset)
             result.data = newData
             result.tinfo = oti.tinfo
             return result
         } else {
-            return st |> error("expecting field name")
+            return st |> syntax_error("expecting field name")
         }
     } else {
         unput(st, token)
@@ -356,7 +361,7 @@ def expr_field(var st : TokenStream) : Result {
 
 def opDim(var st : TokenStream; index : int64; var result : Result) {
     let dim = result.tinfo |> get_dim(int(result.tinfo.dimSize - 1u))
-    if (index < 0l || index >= int64(dim)) return st |> error("index out of range")
+    if (index < 0l || index >= int64(dim)) return st |> eval_error("index out of range")
     result.tinfo.dimSize--
     let elemSize = get_type_size(unsafe(addr(result.tinfo)))
     result.data = st |> getPD(result, int(index) * elemSize)
@@ -373,16 +378,16 @@ def opDimString(var st : TokenStream; index : int64; var result : Result) {
         }
     }
     let len = length(str)
-    if (index >= int64(len)) return st |> error("index out of range {index} of {len} (string too short)")
+    if (index >= int64(len)) return st |> eval_error("index out of range {index} of {len} (string too short)")
     return Result(int64(character_at(str, int(index)))) // nolint:PERF003 single indexed access, not a loop
 }
 
 def opArray(var st : TokenStream; index : int64; var result : Result) {
     unsafe {
         let pArray = reinterpret<DapiArray?>(getPD(st, result))
-        if (pArray == null) return st |> error("null pointer")
+        if (pArray == null) return st |> eval_error("null pointer")
         let dim = pArray.size
-        if (index < 0l || uint64(index) >= dim) return st |> error("index out of range")
+        if (index < 0l || uint64(index) >= dim) return st |> eval_error("index out of range")
         let pData = reinterpret<int8?>(pArray.data)
         let elemSize = get_type_size(result.tinfo.firstType)
         let offset = index * int64(elemSize)
@@ -395,14 +400,14 @@ def opArray(var st : TokenStream; index : int64; var result : Result) {
 def opTable(var st : TokenStream; index : Result; var result : Result) {
     unsafe {
         let pTable = reinterpret<DapiTable?>(getPD(st, result))
-        if (pTable == null) return st |> error("table - null pointer")
+        if (pTable == null) return st |> eval_error("table - null pointer")
         let pKey = reinterpret<float4?>(getPD(st, index))
-        if (pKey == null) return st |> error("key - null pointer")
+        if (pKey == null) return st |> eval_error("key - null pointer")
         let key = *pKey
         let keyBaseType = result.tinfo.firstType.basicType
         let valueTypeSize = get_type_size(result.tinfo.secondType)
         let elementIndex = get_table_key_index(pTable, key, keyBaseType, valueTypeSize)
-        if (elementIndex == -1) return st |> error("key not found")
+        if (elementIndex == -1) return st |> eval_error("key not found")
         let pValue = (reinterpret<uint8?>(pTable.data)) + elementIndex * valueTypeSize
         result.data = pValue
         result.tinfo = *result.tinfo.secondType
@@ -415,7 +420,7 @@ def expr_at(var st : TokenStream) : Result {
     var token = token(st)
     while (token ?as punkt ?? 0 == '[') {
         let eindex = expr(st);
-        if (token(st) ?as punkt ?? 0 != ']') return st |> error("expecting ]")
+        if (token(st) ?as punkt ?? 0 != ']') return st |> syntax_error("expecting ]")
         var nresult : Result
         match (result.tinfo) {
             if (TypeInfo(basicType = Type.tString, dimSize = 0u)) {
@@ -428,7 +433,7 @@ def expr_at(var st : TokenStream) : Result {
                 nresult = opTable(st, eindex, result)
             }
             if (TypeInfo(dimSize = 0u)) {
-                return st |> error("can't index non-array")
+                return st |> eval_error("can't index non-array")
             }
             if (_) {
                 nresult = opDim(st, st |> getI(eindex), result)
@@ -507,7 +512,7 @@ def expr_mul_div(var st : TokenStream) : Result {
         } elif (try_accept_punkt(st, '/')) {
             let rightValue = expr_unary(st)
             let divisor = st |> getI(rightValue)
-            if (divisor == 0l) return st |> error("runtime error, division by 0")
+            if (divisor == 0l) return st |> eval_error("runtime error, division by 0")
             let dividend = st |> getI(leftValue)
             if (divisor == -1l) {
                 leftValue = Result(-dividend)

--- a/daslib/decs.das
+++ b/daslib/decs.das
@@ -178,7 +178,7 @@ def public operator .(var cmp : ComponentMap; name : string) : ComponentValue& {
 
 def public set(var cv : ComponentValue; val : auto) {
     //! Sets individual component value. Verifies that the value is of the correct type.
-    concept_assert(typeinfo sizeof(val) <= typeinfo sizeof(cv.data), "unsupported component type {typeinfo typename(val)} (its too big)")
+    concept_assert(typeinfo sizeof(val) <= typeinfo sizeof(cv.data), "component type {typeinfo typename(val)} is too big for ComponentValue.data, which holds float4[4]")
     let cval = make_component(cv.name, val)
     assert(cv.info.hash == 0ul || cv.info.hash == cval.info.hash)
     cv = cval
@@ -1186,7 +1186,7 @@ def private make_component(name : string; value : auto(TT)) {
 def public set(var cmp : ComponentMap; name : string; value : auto(TT)) {
     //! Set component value specified by name and type.
     //! If value already exists, it is overwritten. If already existing value type is not the same - panic.
-    concept_assert(typeinfo sizeof(value) <= typeinfo sizeof(cmp[0].data), "unsupported component type {typeinfo typename(value)} (its too big)")
+    concept_assert(typeinfo sizeof(value) <= typeinfo sizeof(cmp[0].data), "component type {typeinfo typename(value)} is too big for ComponentValue.data, which holds float4[4]")
     let cv = make_component(name, value)
     let idx = lower_bound(cmp, ComponentValue(name = name)) <| $(x, y) => x.name < y.name
     if (idx < length(cmp) && cmp[idx].name == name) {

--- a/daslib/json.das
+++ b/daslib/json.das
@@ -112,14 +112,13 @@ def private hex4_codepoint(hex_str : array<uint8>) : uint {
 }
 
 def private fits_int64(num : string) : bool {
-    //! true when the `[+-]?digits` literal `num` is representable as int64.
+    //! true when the `[-]?digits` literal `num` is representable as int64.
     var fits = true
     peek_data(num) $(digits) {
         let n = length(digits)
         var i = 0
-        var negative = false
-        if (i < n && (digits[i] == '+'u8 || digits[i] == '-'u8)) {
-            negative = digits[i] == '-'u8
+        let negative = n > 0 && digits[0] == '-'u8
+        if (negative) {
             i ++
         }
         while (i < n && digits[i] == '0'u8) {
@@ -367,7 +366,7 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                 yield TokenAt(value = Token(_string = string(str)), line = line, row = row)
                 clear(str)
                 next(tin, ahead)
-            } elif (ahead == '+' || ahead == '-' || is_number(ahead)) {
+            } elif (ahead == '-' || is_number(ahead)) {
                 push(str, uint8(ahead))
                 var anyNumbers = is_number(ahead)
                 while (next(tin, ahead, line, row) && is_number(ahead)) {
@@ -402,15 +401,15 @@ def private _lexer(var stext : string implicit) {  // nolint:STYLE038 - one line
                 }
                 if (is_integer && fits_int64(num)) {
                     yield TokenAt(value = Token(_longint = int64(num)), line = line, row = row)
-                } elif (is_integer) {
-                    let wide = to_double(num)
-                    if (wide == 0.0lf) {
+                } else {
+                    var conversion : ConversionResult
+                    var consumed = 0
+                    let wide = double(num, conversion, consumed)
+                    if (conversion != ConversionResult.ok || consumed != length(num)) {
                         yield TokenAt(value = Token(_error = "number {num} is out of range"), line = line, row = row)
                         return false
                     }
                     yield TokenAt(value = Token(_number = wide), line = line, row = row)
-                } else {
-                    yield TokenAt(value = Token(_number = double(num)), line = line, row = row)
                 }
                 clear(str)
                 unsafe {

--- a/daslib/jsonrpc.das
+++ b/daslib/jsonrpc.das
@@ -48,7 +48,7 @@ struct public ParsedRequest {
     method          : string       //!< Method name. Empty when the request was malformed.
     params_json     : string       //!< Raw serialized ``params`` value (e.g. ``"null"``, ``"[1,2]"``, ``"{\"x\":1}"``).
     params          : JsonValue?   //!< Pre-parsed ``params`` JsonValue; null when absent. Saves callers a second ``read_json``. A view into ``document`` — dangling once the request is freed.
-    is_notification : bool         //!< True when the request omits ``id`` (spec §4.1 — MUST NOT send a response).
+    is_notification : bool         //!< True when a WELL-FORMED request omits ``id`` (spec §4.1 — MUST NOT send a response). Never true alongside ``error_envelope``: malformed input is answered with ``"id":null`` (spec §5), so test ``error_envelope`` first and this only after it is empty.
     error_envelope  : string       //!< Pre-built error response for malformed input. Empty when the request was well-formed.
     document        : JsonValue?   //!< Parse tree this request owns; free it with ``free_request``. Null in a batch entry — ``ParsedBatch`` owns the batch document.
 }

--- a/skills/daslang/references/json.md
+++ b/skills/daslang/references/json.md
@@ -84,9 +84,10 @@ key write `js?["value"]`.
 Cases: `_object` (`table<string; JsonValue?>`), `_array` (`array<JsonValue?>`), `_string`
 (`string`), `_number` (`double`), `_longint` (`int64`), `_bool` (`bool`), `_null` (`void?`).
 
-An integer literal is `_longint` only while it fits `int64`; past that it parses as `_number`,
-and past `double` it is a parse error. So a wire format carrying `uint64` ids above
-`INT64_MAX` loses precision — send those as strings.
+An integer literal is `_longint` only while it fits `int64`; past that it parses as `_number`. So a
+wire format carrying `uint64` ids above `INT64_MAX` loses precision — send those as strings. Any
+number the `double` range cannot hold at all (`1e400`, `1e-400`, 400 digits) is a parse error, never
+a panic and never a silent zero.
 
 ## Parsing, writing, embedding
 

--- a/tests/base64/test_base64.das
+++ b/tests/base64/test_base64.das
@@ -52,6 +52,27 @@ def test_decode_rejects_bad_input(t : T?) {
 }
 
 [test]
+def test_decode_url_safe_alphabet(t : T?) {
+    t |> equal(base64_decode("PDw/Pz8+Pj4=").text, "<<???>>>")
+    t |> equal(base64_decode("PDw_Pz8-Pj4").text, "<<???>>>", "- and _ are the URL-safe spelling of + and /")
+    t |> equal(base64_decode("PDw_Pz8-Pj4=").text, "<<???>>>")
+    t |> equal(base64_decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9").text, "\{\"alg\":\"HS256\",\"typ\":\"JWT\"\}")
+}
+
+[test]
+def test_decode_rejects_orphan_quantum(t : T?) {
+    var out : array<uint8>
+    t |> equal(base64_decode("Q", out), -1, "one leftover character cannot carry a byte")
+    t |> equal(length(out), 0)
+    t |> equal(base64_decode("QUJDR", out), -1)
+    t |> equal(base64_decode("QUJDREUJQ", out), -1)
+    t |> equal(base64_decode("QUJDR").size, -1)
+    t |> equal(base64_decode("QUJD", out), 3, "a whole quantum still decodes")
+    t |> equal(base64_decode("QUJDRA", out), 4, "so does a 2-over tail")
+    t |> equal(base64_decode("QUJDREU", out), 5, "and a 3-over tail")
+}
+
+[test]
 def test_decode_empty_input_clears_output(t : T?) {
     var out : array<uint8>
     t |> equal(base64_decode("QUJD", out), 3)

--- a/tests/debug/deval.das
+++ b/tests/debug/deval.das
@@ -101,7 +101,14 @@ def private check_operators(t : T?) {
         (src = "1||nosuchvar", want = "true"),
         (src = "1&&nosuchvar", want = "unknown variable nosuchvar"),
         (src = "0||nosuchvar", want = "unknown variable nosuchvar"),
-        (src = "1&&2/0", want = "runtime error, division by 0")
+        (src = "1&&2/0", want = "runtime error, division by 0"),
+        (src = "1||", want = "unexpected end of stream"),
+        (src = "0&&", want = "unexpected end of stream"),
+        (src = "1||1+", want = "unexpected end of stream"),
+        (src = "0&&]", want = "unexpected character ], expecting number or ("),
+        (src = "1||]", want = "unexpected character ], expecting number or ("),
+        (src = "0&&#", want = "invalid token invalid character #, expecting number or ("),
+        (src = "1||(2", want = "expecting )")
     )
     for (c in cases) {
         t |> equal(context |> eval_test(c.src), c.want, "eval '{c.src}'")

--- a/tests/json/test_json_numbers.das
+++ b/tests/json/test_json_numbers.das
@@ -98,3 +98,45 @@ def test_integers_past_double_range_error(t : T?) {
         t |> success(!empty(error), "the lexer reports the out-of-range number")
     }
 }
+
+def expect_number_error(t : T?; text : string) {
+    var error : string
+    var js = read_json(text, error)
+    t |> success(js == null, "{text} is rejected")
+    t |> success(!empty(error), "{text} reports an error instead of panicking")
+}
+
+[test]
+def test_floats_past_double_range_error(t : T?) {
+    t |> run("exponent overflow") @(t : T?) {
+        expect_number_error(t, "1e400")
+        expect_number_error(t, "-1e999")
+        expect_number_error(t, "2.5e308")
+    }
+    t |> run("exponent underflow") @(t : T?) {
+        expect_number_error(t, "1e-400")
+    }
+    t |> run("inside a document") @(t : T?) {
+        expect_number_error(t, "\{ \"ratio\" : 1e400 \}")
+        expect_number_error(t, "[1, 1e400]")
+    }
+}
+
+[test]
+def test_floats_within_range_still_parse(t : T?) {
+    t |> run("ordinary and extreme representable values") @(t : T?) {
+        for (text in ["3.14", "-0.5", "1.5e10", "2.5E-3", "1.7e308", "-1.7e308", "1e-320", "0.0"]) {
+            var js = parse(t, text)
+            t |> success(js is _number, "{text} is a number")
+        }
+    }
+}
+
+[test]
+def test_leading_plus_is_not_a_number(t : T?) {
+    t |> run("RFC 8259 has no leading plus") @(t : T?) {
+        expect_number_error(t, "+5")
+        expect_number_error(t, "+3.14")
+        expect_number_error(t, "[+1]")
+    }
+}


### PR DESCRIPTION
**Behavior changes: `base64_decode` accepts the URL-safe alphabet (`-`/`_`) and rejects the always-invalid `len % 4 == 1` tail; `read_json` no longer panics on any float shape (`1e400`, `1e-400`, leading `+`) — the last throwing conversions leave the lexer; the DAP watch evaluator reports syntax errors even in a short-circuited operand.**

The Copilot rounds on the two already-merged sweep PRs (#3806, #3811), verified by probe before fixing.

base64: `-` and `_` were absent from the decode table, so real base64url/JWT payloads returned −1 despite the sizing fix (the classic JWT header vector is all-alphanumeric, which is how the gap survived); and a `%4 == 1` length — never valid, a leftover character carries only six bits — decoded "successfully" with the tail dropped. Both fixed red-first; encoding stays standard and padded.

json: the float path still called the throwing `double(num)`, so `1e400` killed the process — the same class the integer arm had closed. Both arms now share the non-throwing builtin conversion (`double(str, result, offset)` — the same primitive `try_to_double` wraps, chosen to keep `daslib/json`'s dependency set unchanged), and the number-start test drops the RFC-forbidden leading `+` that reached another panic. No throwing conversion remains anywhere in the lexer.

debug_eval: the short-circuit mute swallowed syntax errors too — `1||` and `0&&]` evaluated "successfully". The error channel is now split: syntax errors always report, only evaluation errors are muted in a decided operand. Doc texts follow their code: `is_notification` states the well-formed-only semantics, and both oversized-component asserts in decs name the buffer they overflow (a static-assert message provably cannot interpolate sizes — error 30227).

Where to look: `daslib/base64.das`, `daslib/json.das` (`fits_int64`, the shared conversion guard), `daslib/debug_eval.das` (`syntax_error` / `eval_error`).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Red-first throughout: 7 new syntax-through-short-circuit arms, 2 base64url/orphan-tail arms, and 9 float/plus panic arms were red at base; suites now json 392/392, jsonrpc 138/138, base64+bool_array+decs+debug+hash_map 345/345; lint and format clean on every touched file.
- The `+5` hunk is scoped and self-contained (one token in the start test, the dead `+` arm in `fits_int64`) — flagged in case it should split out.

### Not done
- New pre-existing crash found while probing, for the bug-hunt backlog: `string(array<uint8>)` inside string interpolation in a helper function dies with 0xC0000043 on unmodified master.
- Lint candidate now twice-motivated: a throwing string→number conversion on a non-literal argument reachable from a public `read_*`/`parse_*` — would have caught the integer arm, the float arm, and the `+5` path mechanically.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
