### PR TITLE
site: render GFM-style lists in posts; surface NEW chips on collapsed nav

### DIFF
--- a/site/blog/build_blog.py
+++ b/site/blog/build_blog.py
@@ -207,6 +207,31 @@ def normalize_indent_code_blocks(md_body: str) -> str:
     return ''.join(out_lines)
 
 
+# GFM — where the posts are drafted and previewed — lets a list start on
+# the line right after a paragraph; Python-Markdown requires a blank line
+# and otherwise swallows the bullets into the paragraph text. Insert the
+# blank only when the previous line is a plain column-0 paragraph line:
+# indented lines are list continuations, and a blank there would turn a
+# tight list loose. Ordered lists interrupt only at "1." (CommonMark rule).
+LIST_INTERRUPT_RE = re.compile(r'^ {0,3}(?:[-*+]|1\.)\s')
+LIST_ITEM_RE = re.compile(r'^ {0,3}(?:[-*+]|\d+\.)\s')
+
+def normalize_list_spacing(md_body: str) -> str:
+    out = []
+    in_fence = False
+    prev = ''
+    for line in md_body.splitlines():
+        if line.lstrip().startswith('```'):
+            in_fence = not in_fence
+        elif (not in_fence and LIST_INTERRUPT_RE.match(line)
+              and prev.strip() and prev == prev.lstrip()
+              and not LIST_ITEM_RE.match(prev)):
+            out.append('')
+        out.append(line)
+        prev = line
+    return '\n'.join(out)
+
+
 def split_excerpt(md_body: str) -> tuple[str, str]:
     """Split on <!-- more -->. Returns (excerpt, full)."""
     if '<!-- more -->' in md_body:
@@ -252,6 +277,7 @@ def render_post(entry: Entry, prev: Entry | None, next: Entry | None, md, posts_
     body_md = expand_post_links(entry.body_md, posts_by_slug)
     body_md = normalize_rst_code_blocks(body_md)
     body_md = normalize_indent_code_blocks(body_md)
+    body_md = normalize_list_spacing(body_md)
     md.reset()
     body_html = md.convert(body_md)
     tags_html = ''
@@ -322,7 +348,7 @@ def render_index(posts: list[Entry], md) -> str:
     items = []
     for p in posts:
         md.reset()
-        excerpt_html = md.convert(p.excerpt_md) if p.excerpt_md else ''
+        excerpt_html = md.convert(normalize_list_spacing(p.excerpt_md)) if p.excerpt_md else ''
         tags_html = '<br>'.join(html.escape(t) for t in p.tags) if p.tags else html.escape(p.tag)
         items.append(f"""        <div class="forge-blog-item">
             <div class="forge-blog-item__date">{html.escape(p.date)}</div>
@@ -388,7 +414,7 @@ def render_changelist(news: list[Entry]) -> str:
 
 def render_news_page(entry: Entry, md) -> str:
     md.reset()
-    body_html = md.convert(entry.body_md)
+    body_html = md.convert(normalize_list_spacing(entry.body_md))
     return f"""    <article class="forge-post">
         <div class="forge-container">
             <div class="forge-post__meta">

--- a/site/files/blog-counter.js
+++ b/site/files/blog-counter.js
@@ -66,8 +66,33 @@
         var chip = document.createElement('span');
         chip.className = 'forge-blog-chip';
         chip.textContent = (count > 9 ? '9+' : count) + ' NEW';
-        anchor.appendChild(chip);
-        anchor.classList.add('forge-blog-link');
+        var label = anchor.querySelector('.forge-nav__menu-label');
+        if (label) {
+            label.appendChild(chip);
+        } else {
+            anchor.appendChild(chip);
+            anchor.classList.add('forge-blog-link');
+        }
+        badgeCollapsedNav(anchor);
+    }
+
+    /* A chip inside a closed dropdown (or, on mobile, behind the burger)
+     * is invisible — mirror it as a dot on every collapsed shell above it. */
+    function badgeCollapsedNav(anchor) {
+        var group = anchor.closest('.forge-nav__group');
+        var trigger = group && group.querySelector('.forge-nav__trigger');
+        if (trigger && !trigger.querySelector('.forge-nav__dot')) {
+            var dot = document.createElement('span');
+            dot.className = 'forge-nav__dot';
+            trigger.insertBefore(dot, trigger.querySelector('.forge-nav__chev'));
+        }
+        var nav = anchor.closest('.forge-nav');
+        var burger = nav && nav.querySelector('.forge-nav__burger');
+        if (burger && !burger.querySelector('.forge-nav__dot')) {
+            var bdot = document.createElement('span');
+            bdot.className = 'forge-nav__dot';
+            burger.appendChild(bdot);
+        }
     }
 
     function update(data) {

--- a/site/files/nav-dropdown.css
+++ b/site/files/nav-dropdown.css
@@ -107,6 +107,22 @@
     line-height: 1.2;
 }
 
+/* Unseen-content dot, injected by blog-counter.js / news-counter.js when a
+   "N NEW" chip sits inside a closed dropdown (or behind the mobile burger). */
+.forge-nav__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--amber);
+    flex: none;
+}
+.forge-nav__burger { position: relative; }
+.forge-nav__burger .forge-nav__dot {
+    position: absolute;
+    top: -3px;
+    right: -3px;
+}
+
 /* Mobile: inside the collapsed `.forge-nav.is-open` panel, flatten each
    group into a static labelled block (no floating dropdown). */
 @media (max-width: 767px) {

--- a/site/files/news-counter.js
+++ b/site/files/news-counter.js
@@ -58,16 +58,54 @@
         var chip = document.createElement('span');
         chip.className = 'forge-blog-chip';
         chip.textContent = (count > 9 ? '9+' : count) + ' NEW';
-        anchor.appendChild(chip);
-        anchor.classList.add('forge-blog-link');
+        var label = anchor.querySelector('.forge-nav__menu-label');
+        if (label) {
+            label.appendChild(chip);
+        } else {
+            anchor.appendChild(chip);
+            anchor.classList.add('forge-blog-link');
+        }
+        badgeCollapsedNav(anchor);
+    }
+
+    /* A chip inside a closed dropdown (or, on mobile, behind the burger)
+     * is invisible — mirror it as a dot on every collapsed shell above it. */
+    function badgeCollapsedNav(anchor) {
+        var group = anchor.closest('.forge-nav__group');
+        var trigger = group && group.querySelector('.forge-nav__trigger');
+        if (trigger && !trigger.querySelector('.forge-nav__dot')) {
+            var dot = document.createElement('span');
+            dot.className = 'forge-nav__dot';
+            trigger.insertBefore(dot, trigger.querySelector('.forge-nav__chev'));
+        }
+        var nav = anchor.closest('.forge-nav');
+        var burger = nav && nav.querySelector('.forge-nav__burger');
+        if (burger && !burger.querySelector('.forge-nav__dot')) {
+            var bdot = document.createElement('span');
+            bdot.className = 'forge-nav__dot';
+            burger.appendChild(bdot);
+        }
     }
 
     function clearChips() {
         var chips = document.querySelectorAll('.forge-nav__links a .forge-blog-chip');
         for (var i = 0; i < chips.length; i++) {
-            var parent = chips[i].parentNode;
-            if (parent && parent.hash === '#news') {
+            var anchor = chips[i].closest('a');
+            if (anchor && anchor.hash === '#news') {
                 chips[i].remove();
+            }
+        }
+        unbadgeCollapsedNav();
+    }
+
+    /* Drop any dot whose shell no longer holds a chip (the blog chip may
+     * still be alive in the same dropdown — then the dot stays). */
+    function unbadgeCollapsedNav() {
+        var dots = document.querySelectorAll('.forge-nav__dot');
+        for (var i = 0; i < dots.length; i++) {
+            var shell = dots[i].closest('.forge-nav__group') || dots[i].closest('.forge-nav');
+            if (shell && !shell.querySelector('.forge-blog-chip')) {
+                dots[i].remove();
             }
         }
     }


### PR DESCRIPTION
Two daslang.io fixes, both visible on the freshly published NO COMMENT post.

**1. Bullet lists were swallowed into paragraphs.** Posts are drafted and previewed in GFM, where a list may start on the line right after a paragraph; Python-Markdown demands a blank line first and otherwise inlines the `* ...` lines into the paragraph text. `build_blog.py` now inserts the missing blank line (`normalize_list_spacing`, applied to post bodies, index excerpts, and news pages). Guards: fenced blocks skipped; only a plain column-0 paragraph line can be interrupted (indented continuations and 4-space code stay untouched, so existing tight lists stay tight); ordered lists interrupt only at `1.` per the CommonMark rule.

Old-vs-new build diff over all 44 posts + 42 news entries: 8 posts change, every one a previously-swallowed list now rendering as a real `<ul>` (`no-comment`, `better-safe`, `daslang-it-is`, `data-initialization`, `for-loop-noise`, `groundhash-day`, `running-it-live`, `something-about-jit`); everything else byte-identical.

**2. The "N NEW" chip was invisible in the collapsed nav.** Since the nav moved to dropdowns, the blog/news links — and their chips — sit inside the closed "community" menu, so a new post announced itself to nobody. Now:
- the chip renders inside `.forge-nav__menu-label` (same row as the label, like the static NEW pill), instead of being appended to the column-flex anchor where `forge-blog-link`'s inline-flex would also mangle the item layout;
- an amber dot mirrors the chip on the collapsed shells above it: the "community ●" trigger on desktop and the burger corner on mobile;
- clearing (visiting /blog/, clicking news) removes a dot only when its shell holds no remaining chip — one unseen source keeps the dot alive.

Verified in a live browser against a local build: fresh visitor sees the trigger dot + both "1 NEW" chips in the opened dropdown; burger dot at 390px; news click clears its chip but keeps the dot while blog is unseen; after visiting /blog/ everything is clean.

Playwright no-WASM suite: 45 playground specs fail locally because this tree has no vendored playground sources (fixture times out waiting for `.CodeMirror`; `main.js` etc. are gitignored and unstaged — the README's documented state). The failures are environmental setup, upstream of anything this diff touches; the per-PR `playground-e2e` lane stages the site properly and gates for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
