### PR TITLE
examples: interp-fallback COI fix, pacman port loop, projection sweep, runtime music gate

### DIFF
--- a/examples/games/arcanoid/main.das
+++ b/examples/games/arcanoid/main.das
@@ -1359,7 +1359,7 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
     glEnable(GL_CULL_FACE)
 
     let aspect = display_h != 0 ? float(display_w) / float(display_h) : 1.0
-    v_projection = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 100.0)
+    v_projection = perspective_rh_minus1_to_1(45.0 * PI / 180.0, aspect, 0.1, 100.0)
     v_view = look_at_rh(
         float3(0.0, 14.0, -4.0),
         float3(0.0, 0.0, 5.0),

--- a/examples/games/asteroids/main.das
+++ b/examples/games/asteroids/main.das
@@ -912,7 +912,7 @@ def update() {   // nolint:STYLE037,STYLE038 - one linear frame: input, simulati
     glEnable(GL_DEPTH_TEST)
 
     let aspect = (display_h != 0 ? float(display_w) / float(display_h) : 1.0)
-    v_projection = perspective_rh_opengl(45.0 * PI / 180.0, aspect, 0.1, 1000.0)
+    v_projection = perspective_rh_minus1_to_1(45.0 * PI / 180.0, aspect, 0.1, 1000.0)
     v_view = look_at_rh(float3(512, 384, 500), float3(512, 384, 0), float3(0, 1, 0))
 
     let dt = get_dt()

--- a/examples/games/boulder-dash/main.das
+++ b/examples/games/boulder-dash/main.das
@@ -877,7 +877,7 @@ def update_music() {
 
 def setup_camera() {
     let aspect = display_h != 0 ? float(display_w) / float(display_h) : 1.0
-    v_projection = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 200.0)
+    v_projection = perspective_rh_minus1_to_1(50.0 * PI / 180.0, aspect, 0.1, 200.0)
     v_view = look_at_rh(CAM_EYE, CAM_TARGET, float3(0.0, 1.0, 0.0))
     f_Eye = CAM_EYE
     let t = get_uptime()

--- a/examples/games/pacman/main.das
+++ b/examples/games/pacman/main.das
@@ -1129,7 +1129,7 @@ def update() {   // nolint:STYLE038 - one linear frame: input, timers, simulatio
     glEnable(GL_CULL_FACE)
 
     let aspect = display_h != 0 ? float(display_w) / float(display_h) : 1.0
-    v_projection = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 200.0)
+    v_projection = perspective_rh_minus1_to_1(50.0 * PI / 180.0, aspect, 0.1, 200.0)
     // Screen shake
     var shake_off = float2(0.0)
     if (shake_timer > 0.0) {

--- a/examples/games/river_run/main.das
+++ b/examples/games/river_run/main.das
@@ -130,7 +130,7 @@ def update() {
     glFrontFace(GL_CCW)
 
     let aspect = (display_h != 0 ? float(display_w) / float(display_h) : 1.0)
-    v_projection = perspective_rh_opengl(50.0 * PI / 180.0, aspect, 0.1, 500.0)
+    v_projection = perspective_rh_minus1_to_1(50.0 * PI / 180.0, aspect, 0.1, 500.0)
     update_camera()
 
     let real_dt = get_dt()

--- a/site/coi-serviceworker.js
+++ b/site/coi-serviceworker.js
@@ -29,11 +29,17 @@
  * Adapted from github.com/gzuidhof/coi-serviceworker (MIT). */
 
 // Only these subtrees get isolated. Root-scoped worker, narrow effect.
+// /files/wasm/ is the interpreter runtime the /examples fallback (_interp.html)
+// spawns its -pthread workers from: a dedicated worker script must itself carry
+// COEP under an isolated owner, or the load dies with ERR_BLOCKED_BY_RESPONSE
+// and the runtime waits on "loading-workers" forever. On a non-isolated page
+// (the landing hero) the extra COEP on these responses is ignored.
 function coiInIsolationScope(url) {
     return url.origin === self.location.origin &&
         (url.pathname === "/examples.html" ||
          url.pathname.indexOf("/examples/") === 0 ||
-         url.pathname.indexOf("/playground") === 0);
+         url.pathname.indexOf("/playground") === 0 ||
+         url.pathname.indexOf("/files/wasm/") === 0);
 }
 
 // /playground is the threaded wasm32 interpreter — it isolates on every engine (gate dropped).

--- a/web/examples/ui/samples/examples/arcanoid/main.das
+++ b/web/examples/ui/samples/examples/arcanoid/main.das
@@ -20,11 +20,10 @@ require strudel/strudel_player
 require daslib/strings_boost
 require live_stub   // playground shim: replaces the live/* + live_host stack (window, clock, no-op [live_command])
 
-// Music is OFF on the web build: the game's strudel music uses the THREADED
-// player (strudel_init/strudel_play), which needs the jobque worker that wasm
-// stubs out. SFX (play_sound_from_pcm) is single-threaded and stays on. Flip to
-// true once the music is ported to main-thread strudel (strudel_tick).
-let MUSIC_ENABLED = false
+// Music uses the THREADED strudel player (strudel_init/strudel_play). The runtime
+// gate in init() turns it on only where the audio backend is threaded — wasm64 and
+// native; a single-threaded backend keeps music off and SFX (play_sound_from_pcm) on.
+var music_enabled = false
 
 // --- Constants ---
 
@@ -271,7 +270,7 @@ def start_gameover_music() {
 
 def update_music() {
     // music off on the web build (threaded strudel)
-    return if (!MUSIC_ENABLED || game_state == prev_music_state)
+    return if (!music_enabled || game_state == prev_music_state)
     let FADE_OUT = 0.8
     let FADE_IN = 0.5
     // Pause: fade down existing tracks, keep them alive
@@ -1320,7 +1319,8 @@ def init() {
         audio_initialized = true
         init_audio_samples()
     }
-    if (MUSIC_ENABLED && !music_initialized) {
+    music_enabled = !audio_is_single_threaded()
+    if (music_enabled && !music_initialized) {
         strudel_init(@@strudel_music_main)
         strudel_set_volume(0.4, 0.0)
         music_initialized = true
@@ -1488,7 +1488,7 @@ def update() {  // nolint:STYLE037,STYLE038 -- game frame: input, sim, and rende
 [export]
 def shutdown() {
     print("Shutting down...\n")
-    if (MUSIC_ENABLED) {
+    if (music_enabled) {
         strudel_shutdown()
     }
     audio_system_finalize(asch.command, asch.next_sid)

--- a/web/examples/ui/samples/examples/boulder-dash/main.das
+++ b/web/examples/ui/samples/examples/boulder-dash/main.das
@@ -20,11 +20,10 @@ require live_stub   // playground shim: replaces the live/* + live_host stack (w
 require cave
 require cave_gen
 
-// Music is OFF on the web build: the game's strudel music uses the THREADED
-// player (strudel_init/strudel_play), which needs the jobque worker that wasm
-// stubs out. SFX (play_sound_from_pcm) is single-threaded and stays on. Flip to
-// true once the music is ported to main-thread strudel (strudel_tick).
-let MUSIC_ENABLED = false
+// Music uses the THREADED strudel player (strudel_init/strudel_play). The runtime
+// gate in init() turns it on only where the audio backend is threaded — wasm64 and
+// native; a single-threaded backend keeps music off and SFX (play_sound_from_pcm) on.
+var music_enabled = false
 
 let CELL_SIZE = 1.0
 let LIGHT_DIR = normalize(float3(-0.28, -0.62, -1.2))
@@ -315,7 +314,7 @@ def start_gameover_music() {
 }
 
 def start_music_for_state() {
-    return if (!MUSIC_ENABLED)
+    return if (!music_enabled)
     if (game_state == GameState.game_over_state) {
         start_gameover_music()
     } elif (game_state == GameState.menu) {
@@ -866,7 +865,7 @@ def sim_playing(dt : float) {
 }
 
 def update_music() {
-    return if (!MUSIC_ENABLED || prev_music_state == game_state)
+    return if (!music_enabled || prev_music_state == game_state)
     stop_all_music(0.2)
     start_music_for_state()
 }
@@ -890,7 +889,8 @@ def init() {
         audio_initialized = true
         init_audio_samples()
     }
-    if (MUSIC_ENABLED && !music_initialized) {
+    music_enabled = !audio_is_single_threaded()
+    if (music_enabled && !music_initialized) {
         strudel_init(@@strudel_music_main)
         strudel_set_volume(0.4, 0.0)
         music_initialized = true
@@ -957,7 +957,7 @@ def update() {
 
 [export]
 def shutdown() {
-    if (MUSIC_ENABLED) {
+    if (music_enabled) {
         strudel_shutdown()
     }
     if (!is_reload()) {

--- a/web/examples/ui/samples/examples/pacman/main.das
+++ b/web/examples/ui/samples/examples/pacman/main.das
@@ -19,11 +19,10 @@ require strudel/strudel_player
 require daslib/strings_boost
 require live_stub   // playground shim: replaces the live/* + live_host stack (window, clock, no-op [live_command])
 
-// Music is OFF on the web build: the game's strudel music uses the THREADED
-// player (strudel_init/strudel_play), which needs the jobque worker that wasm
-// stubs out. SFX (play_sound_from_pcm) is single-threaded and stays on. Flip to
-// true once the music is ported to main-thread strudel (strudel_tick).
-let MUSIC_ENABLED = false
+// Music uses the THREADED strudel player (strudel_init/strudel_play). The runtime
+// gate in init() turns it on only where the audio backend is threaded — wasm64 and
+// native; a single-threaded backend keeps music off and SFX (play_sound_from_pcm) on.
+var music_enabled = false
 
 // ===== Constants =====
 
@@ -226,14 +225,14 @@ def strudel_music_main() {
 }
 
 def stop_all_music(fade : float) {
-    return if (!MUSIC_ENABLED)
+    return if (!music_enabled)
     strudel_command("stop:drums:{fade}")
     strudel_command("stop:bass:{fade}")
     strudel_command("stop:lead:{fade}")
 }
 
 def start_menu_music() {
-    return if (!MUSIC_ENABLED)
+    return if (!music_enabled)
     strudel_set_bpm(120.0lf)
     strudel_command("play:drums:<bd ~ sd ~> <bd [hh hh] sd hh>:0.4")
     strudel_command("note:bass:<[c2 c2] ~ [g2 g2] ~> <[c2 c2] ~ [f2 f2] [g2 g2]>:square:0.25")
@@ -241,7 +240,7 @@ def start_menu_music() {
 }
 
 def start_play_music() {
-    return if (!MUSIC_ENABLED)
+    return if (!music_enabled)
     strudel_set_bpm(140.0lf)
     strudel_command("play:drums:<bd [hh hh] sd [hh hh]> <bd [hh hh] sd [hh cp]>:0.5")
     strudel_command("note:bass:<[c2 c2] [c2 c2] [f2 f2] [g2 g2]> <[c2 c2] [e2 e2] [f2 f2] [e2 e2]>:square:0.28")
@@ -249,7 +248,7 @@ def start_play_music() {
 }
 
 def start_flee_music() {
-    return if (!MUSIC_ENABLED)
+    return if (!music_enabled)
     strudel_set_bpm(180.0lf)
     strudel_command("play:drums:<bd [hh hh hh hh] sd [hh hh]>:0.6")
     strudel_command("note:bass:<[c3 c3 c3 c3] [f3 f3 f3 f3]> <[g3 g3 g3 g3] [e3 e3 f3 g3]>:square:0.3")
@@ -257,7 +256,7 @@ def start_flee_music() {
 }
 
 def start_gameover_music() {
-    return if (!MUSIC_ENABLED)
+    return if (!music_enabled)
     strudel_set_bpm(80.0lf)
     strudel_command("play:drums:<bd ~ ~ ~> <~ ~ bd ~>:0.2")
     strudel_command("note:bass:<c2 ~ bb1 ~> <ab1 ~ g1 ~>:sine:0.3")
@@ -1090,7 +1089,8 @@ def init() {
         audio_initialized = true
         init_audio_samples()
     }
-    if (MUSIC_ENABLED && !music_initialized) {
+    music_enabled = !audio_is_single_threaded()
+    if (music_enabled && !music_initialized) {
         strudel_init(@@strudel_music_main)
         strudel_set_volume(0.4, 0.0)
         music_initialized = true
@@ -1237,19 +1237,23 @@ def update() {  // nolint:STYLE038 -- game frame: input, sim, and render phases 
 
 [export]
 def shutdown() {
-    if (MUSIC_ENABLED) {
+    if (music_enabled) {
         strudel_shutdown()
     }
     audio_system_finalize(asch.command, asch.next_sid)
     live_destroy_window()
 }
 
+// Entry point for the standalone cross-compiled build (daslang -exe → .wasm).
+// eval_main_loop drives the block once per frame: a blocking while-loop natively,
+// emscripten_set_main_loop (rAF) on the web — so the same main runs in the browser
+// without blocking. Returns false to end the loop.
 [export]
 def main() {
     init()
-    while (!exit_requested()) {
+    eval_main_loop() {
         update()
-        maybe_collect_gc()
+        return !exit_requested()
     }
     shutdown()
 }


### PR DESCRIPTION
**Behavior fix: the /examples interpreted fallback no longer hangs at "loading interpreter…" wherever isolation comes from the COI service worker.**

The interpreter runtime lives at `/files/wasm/`, outside the service worker's rewrite scope. The `_interp.html` page gets COEP injected, spawns its `-pthread` workers from `daslang_static.js` — and a dedicated worker script must itself carry COEP under an isolated owner, so Chrome blocks the load (`ERR_BLOCKED_BY_RESPONSE`) and the runtime waits on `loading-workers` forever. The scope now covers `/files/wasm/`. Reproduced locally with the exact block before the fix.

Three more follow-ups from the Boulder Dash arc, all in `examples/`: the pacman playground port gets arcanoid's `eval_main_loop` conversion (its `main()` was still a blocking `while` — the other hang candidate on the interpreted path); the five `examples/games/*` canonical games move off deprecated `perspective_rh_opengl` (w-row bug) to `perspective_rh_minus1_to_1`; and the three game ports replace the hardcoded `MUSIC_ENABLED = false` with the canonical runtime gate `music_enabled = !audio_is_single_threaded()`, so the audio backend decides.

Where to look: `site/coi-serviceworker.js` (scope + why), `web/examples/ui/samples/examples/*/main.das` (ports), `examples/games/*/main.das` (one projection line each).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Worker-script COEP block reproduced locally before the fix (SW-isolated serve, exact `ERR_BLOCKED_BY_RESPONSE` on `daslang_static.js`, runtime stuck on `loading-workers`).
- All five swept games launched under the corrected projection and screenshot-checked; boulder-dash framing re-measured (margins 41/35 px, board center row 362 of 720 — the camera fix from the parent PR survives the projection change).
- All three ports dry-run clean; formatter reports already-formatted.
- The wasm64 boulder-dash card was built end-to-end on this box (`daspkg release wasm`) and played in the browser against a local serve.

### Claims — stated, not tested
- The interp fallback now reaches RUNNING: verified by mechanism (the blocked request is in scope now), not by a green run — the local re-check was interrupted. A break looks like the same eternal "loading interpreter…"; first deploy plus one `?force=interp` click proves it.
- The runtime music gate on the wasm32 interpreter: `audio_is_single_threaded()` decides per backend; which way daslang_static reports — and whether threaded strudel behaves there if it reports threaded — is untested. A break looks like silent or stuttering music in a playground game; SFX are unaffected either way.

### Not done
- `perspective_rh_opengl` call sites in `tutorials/opengl/*` (~15) are deliberately out of scope — teaching content with recordings and prose that names the old function; separate arc if wanted.
- Production serves `require-corp` on `/examples/*` documents but `credentialless` on `/files/wasm/*` — a header mismatch the service worker now papers over when it controls the page; aligning the server config (VPS Caddy) is outside this repo.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
