### PR TITLE
dasLLAMA: qwen3v tower q8 serving lane — CPU encode 4.2-5.3x, dense towers at mtmd-clip parity

### DIFF
--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -339,7 +339,9 @@ on a shared path is the anti-pattern. Only a genuinely new dataflow earns its ow
   the LayerNorm/RMS row forms, bias and residual row adds, the
   `mm_blob_b`/`mm_bf16_b`/`mm_plane_b` GEMM wrappers, `Clamp`/`read_clamp`,
   `im2col_rgb_patches`, `rope_neox_2d_rows`, `rope_neox_tab_rows`, `avg_pool2d_rows`,
-  `interpolate_grid_bilinear_aa`, `tower_read_conv_pair_folded`, blocked `attention_bidir` and
+  `interpolate_grid_bilinear_aa`, `tower_read_conv_pair_folded`, the q8-lane stage readers
+  (`tower_read_gemm_q8`, `tower_stage_q8_zero_rows`/`tower_stage_q8_pad_cols` — the padded pair
+  for FFN widths that are not 32-aligned — and `tower_zero_span`), blocked `attention_bidir` and
   its per-window form `attention_bidir_windows`, and the encode-stage prof rail. The one home:
   a family file that re-implements one of these is a defect, and nothing here names a family
   type.
@@ -404,8 +406,11 @@ on a shared path is the anti-pattern. Only a genuinely new dataflow earns its ow
   proj_dim slice, and the output rows widen to (1+n_deepstack)·proj_dim — slice 0 = the main
   merger, the decoder adds slice l+1 after layer l. The family token budget [8, 4096] is
   mtmd's, not the gemma-scoped DASLLAMA_VISION_* knobs; image_mean/std (0.5) is
-  PREPROCESSING like gemma3v. Composes `dasllama_tower.das`; owns only its layout, the
-  reorder walk, and the block loop. SANCTIONED over the 1 GiB staged-mint line (this family
+  PREPROCESSING like gemma3v. CPU serving default: the block GEMMs serve as Q8_0 planes
+  (read-time transcode, the gemma3v recipe; the FFN pair pads to ff_pad in the q8 layout
+  ONLY — the exact bf16/f32 lane keeps the file's widths as the parity rail); pin knobs
+  `set_qwen3v_q8`/`reset_qwen3v_q8`, two image tags. Composes `dasllama_tower.das`; owns
+  only its layout, the reorder walk, and the block loop. SANCTIONED over the 1 GiB staged-mint line (this family
   and qwen25v): the Omni (2.1 GB) and Qwen2.5-Omni (2.6 GB) mmprojs stage source+image at
   once with no cap — the same shape their audio halves already stage — until
   `followup_general.md` 24's streaming mint covers towers.
@@ -418,7 +423,12 @@ on a shared path is the anti-pattern. Only a genuinely new dataflow earns its ow
   block attends in full, and the merger un-sorts back to group-row-major. Its decoder is the
   `qwen2vl` arch whose plain MROPE reads the rope sections as contiguous ranges
   (`Config.mrope_interleaved` false → `build_rope_tabs_mrope`; the qwen3vl family sets the
-  flag and keeps the interleaved walk).
+  flag and keeps the interleaved walk). This tower serves the file's planes ONLY — no q8
+  lane: its residual rows carry the Qwen2-VL-lineage outlier channels that per-32-block
+  activation requant cannot represent (a q8q8 lane measures 2.0 x rms vs the oracle, where a
+  DELETED layer measures less — the gate cannot discriminate; the weights themselves
+  quantize fine at 0.007 x rms, and a float-activation q8 GEMM wins nothing on these
+  compute-bound shapes since the CPU speedup IS the int8xint8 dot).
 - **`dasllama_vision_embedder.das`** — the vision carrier: `VisionEmbedder` / `VisionState`, the
   `AsrModel` shape for vision — one union through every seam, the family sniffed from the mmproj
   (`clip.vision.projector_type`, or a `.dlim`'s baked tag) at load, one-line arms. Outside a

--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -766,6 +766,9 @@ interior kernels stay bare. A new function needs the annotation itself only when
 entry reaches it: a new entry point carries it, and a new backend entry (kernel-backend
 override, batch donor) carries it too, because backends are also reached from un-annotated
 harness paths. Reused buffers take `@scratch`; debug and profiling legs take `[cold_path]`.
+The tokenizer encode/decode path is sanctioned UNCOVERED by the region contracts — its perf
+gate is the `--tok` scaling rows, whose instrument (the size-ladder ratio) catches what the
+contracts cannot.
 
 ---
 

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -3,13 +3,17 @@
 **Read `REVIEW_COMMON.md` (repo root) first — its contract binds this checklist.** Architecture doc:
 `ARCHITECTURE.md`. Planned work: `followup_general.md`, `followup_vulkan.md`.
 
-**`tests/`, `benchmarks/`, and `performance/` carry their own checklists, and they govern by
-KIND, not location:** a dasLLAMA `[test]` file, wherever the diff puts it, answers to this
-module's `tests/REVIEW.md`; a timing rig — a script whose output is a measured wall or rate — and any
-kernel A/B lab, wherever the diff puts them, answer to `benchmarks/REVIEW.md`; a change to what
-enters `performance/records/` or its manifests, an exchange or provenance-manifest change,
-and a diff naming a model file (a `.gguf`, a `.dlim`, an mmproj, or an image or audio fixture
-a model row pins) anywhere under the module, answer to `performance/REVIEW.md`.
+**A dasLLAMA `[test]` file, wherever the diff puts it, answers to this module's
+`tests/REVIEW.md`.**
+
+**A timing rig — a script whose output is a measured wall or rate — and any kernel A/B lab,
+wherever the diff puts them, answer to `benchmarks/REVIEW.md`.**
+
+**A change to what enters `performance/records/` or its manifests, an exchange or
+provenance-manifest change, or a change to WHICH model file (a `.gguf`, a `.dlim`, an
+mmproj, or an image or audio fixture) a recorded row or manifest pins, answers to
+`performance/REVIEW.md`.** A test or tool merely opening a stocked model file by name does
+not route.
 
 **Every `dasllama/` change applies `tests/REVIEW.md` for the test obligation it names.**
 
@@ -31,9 +35,6 @@ schedules such a stream, applies `REVIEW_VISION.md`.**
 **A `dasllama/dasllama_tower.das` change — the shared encoder-tower home — applies
 `REVIEW_AUDIO.md` and `REVIEW_VISION.md`;** a family file that only CALLS a shared rail does
 not thereby pick up the other modality's checklist.
-
-**A change to the tune sidecar's schema or emitter, wherever it lands, answers to
-`modules/dasLLVM/REVIEW.md`.**
 
 **A routed file applies BOTH the checklist it routes to and this one; every other file under
 `modules/dasLLAMA/` applies this one.**
@@ -75,18 +76,19 @@ a defect in engine code — instrumentation goes through the sanctioned rails, a
 value feeds logic is marked `// clock: control`. The rails, and where free-hand timing is
 legal, are `ARCHITECTURE.md` §2.10.
 
-**Every new kernel or mid-runtime loop is COVERED by an annotated region entry** — `[hot_path]`,
-any of the `[no_alloc]` / `[no_env]` / `[no_io]` contracts, or `[cold_path]` on its only
-reaching entry (a one-time transform is covered by being declared cold). Covered means an annotated entry
-reaches it: the contracts arm down the call graph, so an interior function carries nothing of
-its own. A region entry is the outermost function the runtime re-enters per token, per frame,
-or per prefill quantum (a kernel `*_encode` / `*_decode`, a step driver, the CPU decoder's
-`forward_*` entries); the tokenizer encode/decode path is out of scope
-(`ARCHITECTURE.md` §2.11).
+**Every new kernel or loop the runtime re-enters per token, per frame, or per prefill
+quantum is COVERED by an annotated region entry** — `[hot_path]`, any of the `[no_alloc]` /
+`[no_env]` / `[no_io]` contracts, or `[cold_path]` on its only reaching entry. Covered means
+an annotated entry reaches it: the contracts arm down the call graph, so an interior
+function carries nothing of its own. A region entry is the outermost such function (a kernel
+`*_encode` / `*_decode`, a step driver, the CPU decoder's `forward_*` entries); a loop
+reached only from a load, stage, bake, or convert path is not one, and the tokenizer
+encode/decode path's sanction is `ARCHITECTURE.md` §2.11's.
 
-**A new function that no annotated entry reaches but the runtime enters — a step driver, or
-a backend entry called from dispatch or harness paths — carries its annotation itself; a
-rename is not new** (annotations follow the name in the same change).
+**A new function that no annotated entry reaches but the runtime re-enters per token, per
+frame, or per prefill quantum — a step driver, or a backend entry called from dispatch or
+harness paths — carries its annotation itself; a rename is not new** (annotations follow
+the name in the same change).
 
 **A change to `encode`/`bpe_encode` or anything they reach in `dasllama/dasllama_spm.das` /
 `dasllama/dasllama_bpe.das` / `dasllama/dasllama_pretok.das` ships before/after `--tok` rows
@@ -99,11 +101,12 @@ template strings any of them look up, records a `tests/test_tokenizer.das` run w
 EXECUTED, not skipped.**
 
 **An override announces itself where it changes the outcome.** An override is an environment
-knob — an env variable or its programmatic setter — that moves a gate, policy, or threshold
-off its default; a CLI flag is never an override under this rule. Where one changes an
-observable outcome of the run — what it measures, writes, reads, or mints — a printed line
-names it by the env spelling; set-but-inert stays silent, per-site repeats are fine. Adding
-one, or giving one a new effect, without the announce is a defect.
+knob or an exported runtime setter that moves a gate, policy, or threshold off its default;
+a CLI flag is never an override under this rule. Where one changes an observable outcome of
+the run — what it measures, writes, reads, or mints — a printed line names it by its own
+spelling (the env variable name, or the setter's function name); set-but-inert stays silent,
+per-site repeats are fine. Adding one, or giving one a new effect, without the announce is a
+defect.
 
 **A self-measured served-turn time — tok/s, a turn wall — entering
 `performance/records/<box>.json` or `PERF_LEDGER.md` comes from the released `lcpp_bench`
@@ -117,16 +120,17 @@ tutorial's printed wall-clock is teaching output, feeding no board.
 `PROFILE.md` section. A modality, a family, or a serving path a user can wait on counts; a new
 family inside an existing cell owes a recorded row on at least one box.
 
-**A timing figure describing served output — tok/s, latency, a model-level comparison — is a
-defect wherever it is written down with no cell behind it: a checked-in doc, a ledger, a code
-comment, or a PR description.** The cell states its quant mode and stamps box and engine
-provenance, so a number can never silently describe a format nobody serves or a kernel set
-nobody ships. A rig-internal measurement margin — a crown delta, a noise floor, tuner
-timing — is settled by the sidecar or manifest stamp it rides in.
+**A timing figure describing a served turn as a whole — tok/s, latency, a whole-turn model
+or engine comparison — is a defect wherever it is written down with no cell behind it: a
+checked-in doc, a ledger, a code comment, or a PR description.** The cell states its quant
+mode and stamps box and engine provenance, so a number can never silently describe a format
+nobody serves or a kernel set nobody ships. A rig-internal measurement margin — a crown
+delta, a noise floor, tuner timing — is settled by the sidecar or manifest stamp it rides in.
 
-**A figure measuring one engine stage inside a served turn — a stage wall, a stage share, or
-a stage speedup, never a board cell's `pp`/`tg` rate — names the harness and flags that
-produced it in the same sentence, wherever it is written down: a checked-in doc, a ledger, a
+**A figure measuring one engine stage inside a served turn — a stage wall, a stage share, a
+stage speedup, or a cross-engine comparison of one stage; never a board cell's `pp`/`tg`
+rate — names the harness and flags that produced it in the same sentence (a table heading
+naming them covers its rows), wherever it is written down: a checked-in doc, a ledger, a
 code comment, or a PR description.**
 
 **Runtime serves weights out of a mapped `.dlim`.** A live carrier's planes point into
@@ -253,11 +257,15 @@ helper was built for is fine; the code stays family-blind.
 file** — a single-caller helper sanctioned as tower-worthy is ledgered on `ARCHITECTURE.md`
 §1's tower charter line, not argued in review.
 
-**A weight plane's element type follows its SOURCE tensors, per weight region — the set of
-source tensors a carrier stores in one plane (a block stack, a merger/projector).** A
+**On the lane that serves the file's own planes, a weight plane's element type follows its
+SOURCE tensors, per weight region — the set of source tensors a carrier stores in one plane
+(a block stack, a merger/projector).** A
 carrier picks each weight region's plane type from that region's own tensors (a shipped
 file mixes types across regions), refuses a weight region whose tensors disagree in a
-message naming the offending tensor and both element types, and never converts silently.
+message naming the offending tensor and both element types, and never converts silently. A
+lane that requantizes those planes (a q8 block-GEMM lane) is a separate flavor under its own
+image tag, and the load that picks it prints which lane it picked — not a silent conversion
+of the file's own planes.
 
 **A harness that prints output for another tool to compare fails loudly when it has nothing to
 print.** A run that ends without its comparison lines — wrong flags, failed load — exits

--- a/modules/dasLLAMA/REVIEW_VISION.md
+++ b/modules/dasLLAMA/REVIEW_VISION.md
@@ -1,22 +1,24 @@
-# dasLLAMA vision and media rules
+# dasLLAMA Vision Code Review Checklist
 
-**Routed from `REVIEW.md`: a diff touching a media splice or its eval shape
-(any `eval_embd_span*` entry in `dasllama/dasllama_blocks.das`, `forward_prefill_embd`'s
-span bounds, or `encode_image_`),
-`dasllama/dasllama_vision.das`, `dasllama/dasllama_vision_io.das`, a media-carrying
-scheduler path, `dasllama/dasllama_vision_embedder.das`, `dasllama/dasllama_tower.das` (with
-`REVIEW_AUDIO.md` — the shared encoder-tower home serves both), or a vision family file — one
-`dasllama/dasllama_<family>.das` holding a single vision projector family — applies this list
-with the master's.** `REVIEW_COMMON.md` (repo root) binds this file too. Architecture doc:
-`ARCHITECTURE.md`.
+**Read `REVIEW_COMMON.md` (repo root) first — its contract binds this checklist.** Architecture
+doc: `ARCHITECTURE.md`.
+
+**Routed from `REVIEW.md`: a diff touching `dasllama/dasllama_vision.das`,
+`dasllama/dasllama_vision_io.das`, `dasllama/dasllama_vision_embedder.das`,
+`dasllama/dasllama_tower.das` (the shared encoder-tower home), a vision family file — one
+`dasllama/dasllama_<family>.das` holding a single vision projector family — or an in-process
+path that splices decoded media into a prompt or schedules such a stream, applies this list
+with the master's.**
 
 **A GEMM in a vision family file goes through a shared batch-GEMM entry point — `mm_blob_b`,
 `mm_bf16_b`, `mm_plane_b` (`dasllama/dasllama_tower.das`) or `matmul_q8q8_batch`
 (`dasllama/dasllama_math.das`).** A hand-written dot-product loop beside them is a defect.
 
-**A per-encode reused buffer in `dasllama/dasllama_vision_embedder.das` or a vision family
-file is `@scratch` — on its declaration, or on the callee parameter it grows through.** A
-nolint where the annotation fits is a defect.
+**A per-encode buffer in `dasllama/dasllama_vision_embedder.das` or a vision family file
+carries `@exact_size` when its size follows the input — patch count, pixel count, clip
+frames — and `@scratch` when it is reused across encodes rather than freshly allocated; a
+buffer that is both carries both.** The annotation goes on the declaration, or on the callee
+parameter it grows through. A nolint where an annotation fits is a defect.
 
 **A debug or profiling leg in `dasllama/dasllama_vision_embedder.das` or a vision family file
 is `[cold_path]`.** A nolint where it fits is a defect.
@@ -28,9 +30,10 @@ clamp where the file carries none.
 
 **A vision family whose forward applies no clamp at all says so in its file header.**
 
-**A tower piece two tower families both need lives in `dasllama/dasllama_tower.das`** (the
-encoder-tower home — its inventory is `ARCHITECTURE.md` §1.7); a family file that re-implements
-one is a defect.
+**Code two tower families both need — compute, stage/read, or load-orchestration code that
+names no family type — lives in `dasllama/dasllama_tower.das` (the encoder-tower home); a
+second copy in a family file is a defect.** Per-family serving state — a family's exported
+runtime setter and the module global it writes — stays in the family file.
 
 **A media splice's rows reach `forward_prefill_embd` in ONE call** — splitting them across
 calls, or letting a driver chunk them by row, is a defect: the span bounds are call-relative,

--- a/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
@@ -11,7 +11,6 @@ require daslib/apply
 require daslib/archive
 require dasllama/dasllama_gguf
 require dasllama/dasllama_math   // matmul_q8q8_batch + the backend repack — the q8 block-GEMM lane
-require dasllama/dasllama_convert   // quantize_q8_0_into — the q8 lane's read-time transcode
 require dasllama/dasllama_common   // apply_box_profile_runtime for the tower-image identity
 require dasllama/dasllama_image   // the dlim rail: mapped planes, no allocation or work at load
 require dasllama/dasllama_plane public   // PlaneF/PlaneI8 — re-exported so requirers can delete a tower
@@ -311,30 +310,6 @@ def private g3v_layout(var t : Gemma3vTower; var off : int64&; var qo : int64&) 
     }
 }
 
-// q8 GEMM read: the file's f16 tensor widens to f32 scratch, then quantizes to Q8_0 straight
-// into qblob/qscales at the 32-aligned region (wo/32 indexes the scales)
-def private g3v_read_gemm_q8(m : GGUFMeta; b : array<uint8> | #; name : string; var st : Gemma3vStaging;
-                             @scratch var wscratch : array<float>; wo, n_elem : int64) {
-    if (n_elem % 32l != 0l || wo % 32l != 0l) {
-        panic("dasLLAMA gemma3v q8: GEMM tensor '{name}' ({n_elem} elements at {wo}) is not 32-aligned")
-    }
-    if (long_length(wscratch) < n_elem) {
-        wscratch |> reserve(n_elem)
-        wscratch |> resize(n_elem)
-    }
-    gguf_read_tensor_f32(m, b, name, wscratch, 0l, n_elem)
-    quantize_q8_0_into(wscratch, n_elem, st.qblob, st.qscales, wo, wo / 32l)
-}
-
-def private g3v_zero_span(var a : array<float>; at, n : int64) {
-    unsafe {
-        var p = addr(a[at])
-        for (i in range64(n)) {
-            p[i] = 0.0
-        }
-    }
-}
-
 // stage the up GEMM into its padded region: the file's [ff × d] rows land first, then ff_pad−ff
 // zero weight rows — the pad outputs are exactly zero
 def private g3v_stage_up(m : GGUFMeta; b : array<uint8> | #; name : string; var st : Gemma3vStaging;
@@ -343,16 +318,10 @@ def private g3v_stage_up(m : GGUFMeta; b : array<uint8> | #; name : string; var 
     let file_n = st.t.n_ff * d
     let served = st.t.ff_pad * d
     if (st.t.q8) {
-        if (long_length(wscratch) < served) {
-            wscratch |> reserve(served)
-            wscratch |> resize(served)
-        }
-        gguf_read_tensor_f32(m, b, name, wscratch, 0l, file_n)
-        g3v_zero_span(wscratch, file_n, served - file_n)
-        quantize_q8_0_into(wscratch, served, st.qblob, st.qscales, wo, wo / 32l)
+        tower_stage_q8_zero_rows(m, b, name, st.qblob, st.qscales, wscratch, wo, st.t.n_ff, st.t.ff_pad, d, "dasLLAMA gemma3v q8")
     } else {
         gguf_read_tensor_f32(m, b, name, st.blob, wo, file_n)
-        g3v_zero_span(st.blob, wo + file_n, served - file_n)
+        tower_zero_span(st.blob, wo + file_n, served - file_n)
     }
 }
 
@@ -363,22 +332,16 @@ def private g3v_stage_down(m : GGUFMeta; b : array<uint8> | #; name : string; va
     let d = st.t.n_embd
     let ff = st.t.n_ff
     let fp = st.t.ff_pad
-    let served = d * fp
+    if (st.t.q8) {
+        tower_stage_q8_pad_cols(m, b, name, st.qblob, st.qscales, wscratch, rowscratch, wo, d, ff, fp, "dasLLAMA gemma3v q8")
+        return
+    }
     if (long_length(rowscratch) < d * ff) {
         rowscratch |> reserve(d * ff)
         rowscratch |> resize(d * ff)
     }
     gguf_read_tensor_f32(m, b, name, rowscratch, 0l, d * ff)
-    if (st.t.q8) {
-        if (long_length(wscratch) < served) {
-            wscratch |> reserve(served)
-            wscratch |> resize(served)
-        }
-        g3v_expand_rows(wscratch, 0l, rowscratch, d, ff, fp)
-        quantize_q8_0_into(wscratch, served, st.qblob, st.qscales, wo, wo / 32l)
-    } else {
-        g3v_expand_rows(st.blob, wo, rowscratch, d, ff, fp)
-    }
+    g3v_expand_rows(st.blob, wo, rowscratch, d, ff, fp)
 }
 
 def private g3v_expand_rows(var dst : array<float>; at : int64; src : array<float>; rows, ff, fp : int64) {
@@ -427,14 +390,14 @@ def private g3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Gem
             } elif (g == GEMMA3V_GEMM_DOWN) {
                 g3v_stage_down(m, bytes, wname, st, wscratch, rowscratch, wo)
             } elif (st.t.q8) {
-                g3v_read_gemm_q8(m, bytes, wname, st, wscratch, wo, gemm_sizes[g])
+                tower_read_gemm_q8(m, bytes, wname, st.qblob, st.qscales, wscratch, wo, gemm_sizes[g], "dasLLAMA gemma3v q8")
             } else {
                 gguf_read_tensor_f32(m, bytes, wname, st.blob, wo, gemm_sizes[g])
             }
             wo += gemm_sizes[g]
             gguf_read_tensor_f32(m, bytes, "{p}.{names[g]}.bias", st.blob, fo, bias_sizes[g])
             if (g == GEMMA3V_GEMM_UP) {
-                g3v_zero_span(st.blob, fo + ff, fp - ff)   // the padded up bias: zero tail
+                tower_zero_span(st.blob, fo + ff, fp - ff)   // the padded up bias: zero tail
                 fo += fp
             } else {
                 fo += bias_sizes[g]

--- a/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
@@ -426,21 +426,13 @@ def private g3v_read_projection(m : GGUFMeta; bytes : array<uint8> | #; var st :
     delete pscratch
 }
 
-// repack every block GEMM region for the active backend's q8q8 kernels — per-row alignment (the
-// region's input width) keeps blocks from straddling rows
 def private g3v_repack_all(var st : Gemma3vStaging; gemm_sizes : array<int64>) {
-    if (!st.t.q8 || !select_matmul_backend_for_load_()) {
+    if (!st.t.q8) {
         return
     }
     let d = st.t.n_embd
     let widths <- [ d, d, d, d, d, st.t.ff_pad ]   // q k v o up down: the input width of each
-    for (l in range64(st.t.n_layer)) {
-        var wo = st.t.layer_w + l * st.t.layer_w_stride
-        for (g in range64(GEMMA3V_GEMMS)) {
-            repack_q8q8_weight(st.qblob, st.qscales, wo, widths[g], gemm_sizes[g] / widths[g])
-            wo += gemm_sizes[g]
-        }
-    }
+    tower_repack_q8_blocks(st.qblob, st.qscales, st.t.layer_w, st.t.layer_w_stride, st.t.n_layer, widths, gemm_sizes)
 }
 
 //! Read the tower off an mmproj gguf into owned staging arrays — the mint side of the image rail,

--- a/modules/dasLLAMA/dasllama/dasllama_gemma4v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma4v.das
@@ -394,23 +394,14 @@ def private g4v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Gem
     }
 }
 
-// repack every block GEMM region for the active backend's q8q8 kernels — per-row alignment (the
-// region's input width), not just n_elem, keeps blocks from straddling rows; without a selected
-// backend matmul_q8q8_batch reads the flat Q8_0 image as-is
 def private g4v_repack_all(var st : Gemma4vStaging; gemm_sizes : array<int64>) {
-    if (!st.t.q8 || !select_matmul_backend_for_load_()) {
+    if (!st.t.q8) {
         return
     }
     let d = st.t.n_embd
     let ff = st.t.n_ff
     let widths <- [ d, d, d, d, d, d, ff ]   // q k v o gate up down: the input width of each
-    for (l in range64(st.t.n_layer)) {
-        var wo = st.t.layer_w + l * st.t.layer_w_stride
-        for (g in range64(GEMMA4V_GEMMS)) {
-            repack_q8q8_weight(st.qblob, st.qscales, wo, widths[g], gemm_sizes[g] / widths[g])
-            wo += gemm_sizes[g]
-        }
-    }
+    tower_repack_q8_blocks(st.qblob, st.qscales, st.t.layer_w, st.t.layer_w_stride, st.t.n_layer, widths, gemm_sizes)
 }
 
 //! Read the tower off an mmproj gguf into owned staging arrays — the mint side of the image rail,

--- a/modules/dasLLAMA/dasllama/dasllama_gemma4v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma4v.das
@@ -11,7 +11,6 @@ require daslib/apply
 require daslib/archive
 require dasllama/dasllama_gguf
 require dasllama/dasllama_math   // matmul_q8q8_batch + the backend repack — the q8 block-GEMM lane
-require dasllama/dasllama_convert   // quantize_q8_0_into / requant_rows_q8
 require dasllama/dasllama_common   // apply_box_profile_runtime for the tower-image identity
 require dasllama/dasllama_image   // the dlim rail: mapped planes, no allocation or work at load
 require dasllama/dasllama_plane public   // PlaneF/PlaneU16 — re-exported so requirers can delete a tower
@@ -384,7 +383,7 @@ def private g4v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Gem
         for (g in range64(GEMMA4V_GEMMS)) {
             let base = "{p}.{G4V_BLK_GEMM_NAMES[g]}"
             if (st.t.q8) {
-                g4v_read_gemm_q8(m, bytes, "{base}.weight", st, wscratch, wo, gemm_sizes[g])
+                tower_read_gemm_q8(m, bytes, "{base}.weight", st.qblob, st.qscales, wscratch, wo, gemm_sizes[g], "dasLLAMA gemma4v q8")
             } else {
                 tower_read_gemm(m, bytes, "{base}.weight", st.wblob, st.blob, st.t.blk_bf16, wo, gemm_sizes[g])
             }
@@ -393,21 +392,6 @@ def private g4v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Gem
             fo += GEMMA4V_CLAMP_F
         }
     }
-}
-
-// q8 GEMM read: the file's tensor (bf16 or f32) widens to f32 scratch, then quantizes to Q8_0
-// straight into qblob/qscales at the 32-aligned region (wo/32 indexes the scales)
-def private g4v_read_gemm_q8(m : GGUFMeta; b : array<uint8> | #; name : string; var st : Gemma4vStaging;
-                             @scratch var wscratch : array<float>; wo, n_elem : int64) {
-    if (n_elem % 32l != 0l || wo % 32l != 0l) {
-        panic("dasLLAMA gemma4v q8: GEMM tensor '{name}' ({n_elem} elements at {wo}) is not 32-aligned")
-    }
-    if (long_length(wscratch) < n_elem) {
-        wscratch |> reserve(n_elem)
-        wscratch |> resize(n_elem)
-    }
-    gguf_read_tensor_f32(m, b, name, wscratch, 0l, n_elem)
-    quantize_q8_0_into(wscratch, n_elem, st.qblob, st.qscales, wo, wo / 32l)
 }
 
 // repack every block GEMM region for the active backend's q8q8 kernels — per-row alignment (the

--- a/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
@@ -75,7 +75,7 @@ struct Qwen3vTower {
     mm0_b : int64
     mm2_w : int64        // [4·n_embd → proj_dim]
     mm2_b : int64
-    layer_f : int64      // per-block f32 region; stride: ln1 w+b, ln2 w+b [d ×4], qkv_b [3d], out_b [d], up_b [ff], down_b [d]
+    layer_f : int64      // per-block f32 region; stride: ln1 w+b, ln2 w+b [d ×4], qkv_b [3d], out_b [d], up_b [ff_pad, zero tail], down_b [d]
     layer_f_stride : int64
     layer_w : int64      // per-block GEMM region (qblob when q8, wblob when blk_bf16, else blob); stride layer_w_stride
     layer_w_stride : int64
@@ -269,7 +269,7 @@ def private q3v_tag() : string => q3v_serve_q8() ? QWEN3V_TAG_Q8 : QWEN3V_TAG
 def private q3v_announce_lane() {
     var why = "the CPU default (no accelerate tier)"
     if (g_q3v_q8_pin != Q3vLane.unset) {
-        why = "pinned"
+        why = "pinned via set_qwen3v_q8"
     } elif (float_batch_override_active()) {
         why = "DASLLAMA_ACCEL on: the float-batch tier serves the file's planes"
     }
@@ -416,21 +416,13 @@ def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwe
     delete rowscratch
 }
 
-// repack every block GEMM region for the active backend's q8q8 kernels — per-row alignment (the
-// region's input width) keeps blocks from straddling rows
 def private q3v_repack_all(var st : Qwen3vStaging; gemm_sizes : array<int64>) {
-    if (!st.t.q8 || !select_matmul_backend_for_load_()) {
+    if (!st.t.q8) {
         return
     }
     let d = st.t.n_embd
     let widths <- [ d, d, d, st.t.ff_pad ]   // qkv o up down: the input width of each
-    for (l in range64(st.t.n_layer)) {
-        var wo = st.t.layer_w + l * st.t.layer_w_stride
-        for (g in range64(QWEN3V_GEMMS)) {
-            repack_q8q8_weight(st.qblob, st.qscales, wo, widths[g], gemm_sizes[g] / widths[g])
-            wo += gemm_sizes[g]
-        }
-    }
+    tower_repack_q8_blocks(st.qblob, st.qscales, st.t.layer_w, st.t.layer_w_stride, st.t.n_layer, widths, gemm_sizes)
 }
 
 // collect the deepstack tap layers from the TENSOR list, never the metadata (is_deepstack_layers
@@ -460,6 +452,7 @@ def private q3v_scan_deepstack(m : GGUFMeta; var t : Qwen3vTower; path : string)
 //! rail. No staged-size cap: the Omni mmproj (2.1 GB, both towers in one file) already stages
 //! its audio half the same way; the streaming mint is followup_general #24's item.
 def stage_qwen3v_tower(path : string) : Qwen3vStaging {
+    q3v_announce_lane()   // the lane decides what this stage MINTS - announce on every entry
     var st = Qwen3vStaging()
     st.t.q8 = q3v_serve_q8()
     let f = fopen(path, "rb")

--- a/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
@@ -28,6 +28,8 @@ require math
 //! the output rows widen to (1+n_deepstack)·proj_dim (slice 0 = the main merger). No clamp —
 //! the files carry no ClippableLinear sidecars. Oracle: llama-mtmd-debug -p encode on the
 //! f32-widened mmproj (`qwen3vl_plan.md`, dumps in models/qwen3vl-vision-oracle/).
+//! CPU serving default: the block GEMMs serve as Q8_0 planes (read-time transcode, the
+//! gemma3v recipe); the exact bf16/f32 lane is the parity rail.
 
 let QWEN3V_ROPE_THETA = 10000.0   // models/qwen3vl.cpp hardcodes it — not in the gguf
 // the family's dynamic-resolution token budget (mtmd set_limit_image_tokens for qwen)
@@ -56,8 +58,15 @@ struct Qwen3vTower {
     // of two on-disk tensors is a computed plane, not the file's bytes)
     blk_bf16 : bool
     mm_bf16 : bool
+    // q8: the 4·n_layer block GEMMs SERVE as Q8_0 planes (read-time transcode) and layer_w
+    // indexes qblob; the FFN pair serves padded to ff_pad (n_ff is not 32-aligned). The exact
+    // lane serves the file's widths — only the q8 layout pads.
+    q8 : bool
+    ff_pad : int64       // n_ff rounded up to 64 — the q8 lane's served FFN width
     blob : PlaneF = PlaneF()
     wblob : PlaneU16 = PlaneU16()
+    qblob : PlaneI8 = PlaneI8()
+    qscales : PlaneF = PlaneF()
     patch_w : int64      // [n_embd × patch_dim] f32 — W0 + W1 folded (stills eval both convs on one frame)
     patch_b : int64      // [n_embd]
     pos_w : int64        // [pos_side² × n_embd] f32, row = y·side + x
@@ -68,7 +77,7 @@ struct Qwen3vTower {
     mm2_b : int64
     layer_f : int64      // per-block f32 region; stride: ln1 w+b, ln2 w+b [d ×4], qkv_b [3d], out_b [d], up_b [ff], down_b [d]
     layer_f_stride : int64
-    layer_w : int64      // per-block GEMM region (wblob when blk_bf16, else blob); stride layer_w_stride
+    layer_w : int64      // per-block GEMM region (qblob when q8, wblob when blk_bf16, else blob); stride layer_w_stride
     layer_w_stride : int64
     // deepstack (dense Qwen3-VL): up to three tap mergers — output rows widen to
     // (1+n_deepstack)·proj_dim; 0 taps = the Omni tower, narrow rows
@@ -103,6 +112,8 @@ struct Qwen3vState {
     @exact_size ds_slice : array<float>  // deepstack tap / main-merger staging [nout × proj]
     @scratch @exact_size pos_rs : array<float>   // the pos table resized to the grid [npos × d]
     @exact_size cos_t : array<float>; @exact_size sin_t : array<float>
+    @scratch @exact_size xqi : array<int8>    // q8 lane: the requantized GEMM input, grown per site
+    @scratch @exact_size xsi : array<float>   // its per-32-block scales
     @scratch pos2 : array<int2>      // per reordered row: (patch row, patch column)
     grid_w : int64
     grid_h : int64
@@ -135,12 +146,14 @@ def finalize(var s : Qwen3vState) {
     delete s.pos_rs
     delete s.cos_t
     delete s.sin_t
+    delete s.xqi
+    delete s.xsi
     delete s.pos2
 }
 
-// serialize_image_meta(Qwen3vTower) covers 33 fields; image_map + image_bytes are deliberate
+// serialize_image_meta(Qwen3vTower) covers 35 fields; image_map + image_bytes are deliberate
 // skips (the two planes are sections, not meta)
-let private QWEN3V_META_FIELDS = 33 + 2
+let private QWEN3V_META_FIELDS = 35 + 2
 
 def private serialize_image_meta(var arch : Archive; var t : Qwen3vTower) {
     verify(count_meta_fields(t) == QWEN3V_META_FIELDS)   // grew Qwen3vTower? extend this list
@@ -156,6 +169,8 @@ def private serialize_image_meta(var arch : Archive; var t : Qwen3vTower) {
     arch |> serialize_raw(t.eps)
     arch |> serialize_raw(t.blk_bf16)
     arch |> serialize_raw(t.mm_bf16)
+    arch |> serialize_raw(t.q8)
+    arch |> serialize_raw(t.ff_pad)
     arch |> serialize_raw(t.patch_w)
     arch |> serialize_raw(t.patch_b)
     arch |> serialize_raw(t.pos_w)
@@ -187,6 +202,8 @@ struct Qwen3vStaging {
     t : Qwen3vTower = Qwen3vTower()
     blob : array<float>
     wblob : array<uint16>
+    qblob : array<int8>       // q8 lane: the block GEMMs as Q8_0 (repacked for the active backend)
+    qscales : array<float>
 }
 
 def private serialize_image_meta(var arch : Archive; var st : Qwen3vStaging) {
@@ -196,17 +213,67 @@ def private serialize_image_meta(var arch : Archive; var st : Qwen3vStaging) {
 def finalize(var st : Qwen3vStaging) {
     delete st.blob
     delete st.wblob
+    delete st.qblob
+    delete st.qscales
     delete st.t
 }
 
 [unused_argument(st)]
 def private image_post_load(var st : Qwen3vStaging) {}
 
+// two lanes: "qwen3v-q8" serves the block GEMMs as Q8_0 (the CPU serving default); "qwen3v"
+// keeps every plane as the file has it (the parity rail)
 let private QWEN3V_TAG = "qwen3v"
+let private QWEN3V_TAG_Q8 = "qwen3v-q8"
 
 [init]
 def private register_qwen3v_image_tags {
     register_image_family_tag(QWEN3V_TAG)
+    register_image_family_tag(QWEN3V_TAG_Q8)
+}
+
+// the lane policy follows the fastest GEMM path on the box: the armed accelerate float-batch
+// tier wants the file's planes; else q8. No Metal tower serves this family yet, so there is
+// no driver clause. A pin overrides.
+enum private Q3vLane {
+    unset    // the policy decides
+    exact    // the file's planes
+    q8
+}
+var private g_q3v_q8_pin = Q3vLane.unset
+
+def private q3v_serve_q8() : bool {
+    if (g_q3v_q8_pin != Q3vLane.unset) {
+        return g_q3v_q8_pin == Q3vLane.q8
+    }
+    return !float_batch_override_active()
+}
+
+//! Pin the qwen3v tower's block-GEMM format for subsequent loads: q8 (the CPU serving default)
+//! vs the file's own planes (the parity rail). Each lane is its own prepared image.
+//! ``reset_qwen3v_q8`` returns to the policy default.
+def set_qwen3v_q8(on : bool) {
+    g_q3v_q8_pin = on ? Q3vLane.q8 : Q3vLane.exact
+}
+
+def reset_qwen3v_q8() {
+    g_q3v_q8_pin = Q3vLane.unset
+}
+
+//! Would the next load serve the block GEMMs as q8 — the pin when set, the policy otherwise.
+def qwen3v_serves_q8() : bool => q3v_serve_q8()
+
+def private q3v_tag() : string => q3v_serve_q8() ? QWEN3V_TAG_Q8 : QWEN3V_TAG
+
+// the lane changes what a load mints and serves, so the load says which and why
+def private q3v_announce_lane() {
+    var why = "the CPU default (no accelerate tier)"
+    if (g_q3v_q8_pin != Q3vLane.unset) {
+        why = "pinned"
+    } elif (float_batch_override_active()) {
+        why = "DASLLAMA_ACCEL on: the float-batch tier serves the file's planes"
+    }
+    to_log(LOG_INFO, "dasLLAMA qwen3v: block GEMM lane {q3v_serve_q8() ? "q8" : "exact planes"} - {why}\n")
 }
 
 // the block GEMM tensors in QWEN3V_GEMM_* order; every per-GEMM list follows it
@@ -259,9 +326,10 @@ def private q3v_verify_tensors(m : GGUFMeta; t : Qwen3vTower; gemm_sizes : array
     }
 }
 
-def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&) {
+def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&; var qo : int64&) {
     let d = t.n_embd
     let ff = t.n_ff
+    let ffs = t.q8 ? t.ff_pad : ff   // the served FFN width — only the q8 layout pads
     t.patch_w = off; off += t.patch_dim * d
     t.patch_b = off; off += d
     t.pos_w = off; off += t.pos_side * t.pos_side * d
@@ -271,10 +339,15 @@ def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&)
     t.mm0_b = off; off += 4l * d
     t.mm2_w = take_cursor(t.mm_bf16, off, woff, 4l * d * t.proj_dim)
     t.mm2_b = off; off += t.proj_dim
-    t.layer_f_stride = 4l * d + 3l * d + d + ff + d
+    t.layer_f_stride = 4l * d + 3l * d + d + t.ff_pad + d   // the up-bias slot is ff_pad both lanes (zero tail)
     t.layer_f = off; off += t.n_layer * t.layer_f_stride
-    t.layer_w_stride = 4l * d * d + 2l * d * ff
-    t.layer_w = take_cursor(t.blk_bf16, off, woff, t.n_layer * t.layer_w_stride)
+    t.layer_w_stride = 4l * d * d + 2l * d * ffs
+    if (t.q8) {
+        t.layer_w = qo
+        qo += t.n_layer * t.layer_w_stride
+    } else {
+        t.layer_w = take_cursor(t.blk_bf16, off, woff, t.n_layer * t.layer_w_stride)
+    }
     if (t.n_deepstack > 0l) {
         t.ds_f_stride = 12l * d + t.proj_dim
         t.ds_f = off; off += t.n_deepstack * t.ds_f_stride
@@ -283,9 +356,13 @@ def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&)
     }
 }
 
+// gemm_sizes here are the SERVED sizes (the q8 lane's FFN pair at ff_pad); the file expectations
+// were checked with the file's own sizes in q3v_verify_tensors
 def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwen3vStaging; gemm_sizes : array<int64>) {
     let d = st.t.n_embd
     let ff = st.t.n_ff
+    var wscratch : array<float>   // the q8 transcode's f32 staging, one GEMM at a time
+    var rowscratch : array<float>   // the down GEMM's unpadded file rows ahead of the expand
     tower_read_conv_pair_folded(m, bytes, "v.patch_embd.weight", st.blob, st.t.patch_w, st.t.patch_dim * d)
     gguf_read_tensor_f32(m, bytes, "v.patch_embd.bias", st.blob, st.t.patch_b, d)
     gguf_read_tensor_f32(m, bytes, "v.position_embd.weight", st.blob, st.t.pos_w, st.t.pos_side * st.t.pos_side * d)
@@ -316,11 +393,41 @@ def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwe
         gguf_read_tensor_f32(m, bytes, "{p}.ln2.bias", st.blob, fo, d); fo += d
         gguf_read_tensor_f32(m, bytes, "{p}.attn_qkv.bias", st.blob, fo, 3l * d); fo += 3l * d
         gguf_read_tensor_f32(m, bytes, "{p}.attn_out.bias", st.blob, fo, d); fo += d
-        gguf_read_tensor_f32(m, bytes, "{p}.ffn_up.bias", st.blob, fo, ff); fo += ff
+        gguf_read_tensor_f32(m, bytes, "{p}.ffn_up.bias", st.blob, fo, ff)
+        tower_zero_span(st.blob, fo + ff, st.t.ff_pad - ff)   // the padded up bias: zero tail
+        fo += st.t.ff_pad
         gguf_read_tensor_f32(m, bytes, "{p}.ffn_down.bias", st.blob, fo, d)
         var wo = st.t.layer_w + l * st.t.layer_w_stride
         for (g in range64(QWEN3V_GEMMS)) {
-            tower_read_gemm(m, bytes, "{p}.{Q3V_BLK_GEMM_NAMES[g]}.weight", st.wblob, st.blob, st.t.blk_bf16, wo, gemm_sizes[g])
+            let wname = "{p}.{Q3V_BLK_GEMM_NAMES[g]}.weight"
+            if (!st.t.q8) {
+                tower_read_gemm(m, bytes, wname, st.wblob, st.blob, st.t.blk_bf16, wo, gemm_sizes[g])
+            } elif (g == QWEN3V_GEMM_UP) {
+                tower_stage_q8_zero_rows(m, bytes, wname, st.qblob, st.qscales, wscratch, wo, ff, st.t.ff_pad, d, "dasLLAMA qwen3v q8")
+            } elif (g == QWEN3V_GEMM_DOWN) {
+                tower_stage_q8_pad_cols(m, bytes, wname, st.qblob, st.qscales, wscratch, rowscratch, wo, d, ff, st.t.ff_pad, "dasLLAMA qwen3v q8")
+            } else {
+                tower_read_gemm_q8(m, bytes, wname, st.qblob, st.qscales, wscratch, wo, gemm_sizes[g], "dasLLAMA qwen3v q8")
+            }
+            wo += gemm_sizes[g]
+        }
+    }
+    delete wscratch
+    delete rowscratch
+}
+
+// repack every block GEMM region for the active backend's q8q8 kernels — per-row alignment (the
+// region's input width) keeps blocks from straddling rows
+def private q3v_repack_all(var st : Qwen3vStaging; gemm_sizes : array<int64>) {
+    if (!st.t.q8 || !select_matmul_backend_for_load_()) {
+        return
+    }
+    let d = st.t.n_embd
+    let widths <- [ d, d, d, st.t.ff_pad ]   // qkv o up down: the input width of each
+    for (l in range64(st.t.n_layer)) {
+        var wo = st.t.layer_w + l * st.t.layer_w_stride
+        for (g in range64(QWEN3V_GEMMS)) {
+            repack_q8q8_weight(st.qblob, st.qscales, wo, widths[g], gemm_sizes[g] / widths[g])
             wo += gemm_sizes[g]
         }
     }
@@ -354,6 +461,7 @@ def private q3v_scan_deepstack(m : GGUFMeta; var t : Qwen3vTower; path : string)
 //! its audio half the same way; the streaming mint is followup_general #24's item.
 def stage_qwen3v_tower(path : string) : Qwen3vStaging {
     var st = Qwen3vStaging()
+    st.t.q8 = q3v_serve_q8()
     let f = fopen(path, "rb")
     if (f == null) {
         panic("dasLLAMA: cannot open mmproj gguf '{path}'")
@@ -402,14 +510,20 @@ def stage_qwen3v_tower(path : string) : Qwen3vStaging {
         }
         st.t.blk_bf16 = gguf_tensor_type(m, "v.blk.0.attn_qkv.weight") == GGML_TYPE_BF16
         st.t.mm_bf16 = gguf_tensor_type(m, "mm.0.weight") == GGML_TYPE_BF16
-        let gemm_sizes <- q3v_gemm_sizes(d, st.t.n_ff)
-        q3v_verify_tensors(m, st.t, gemm_sizes)
+        st.t.ff_pad = (st.t.n_ff + 63l) / 64l * 64l   // %64 fits future GPU tiles, %32 quantizes
+        let file_sizes <- q3v_gemm_sizes(d, st.t.n_ff)
+        q3v_verify_tensors(m, st.t, file_sizes)
+        let serve_sizes <- q3v_gemm_sizes(d, st.t.q8 ? st.t.ff_pad : st.t.n_ff)
         var off = 0l
         var woff = 0l
-        q3v_layout(st.t, off, woff)
+        var qo = 0l
+        q3v_layout(st.t, off, woff, qo)
         st.blob |> reserve_resize(off)
         st.wblob |> reserve_resize(woff)
-        q3v_read_planes(m, bytes, st, gemm_sizes)
+        st.qblob |> reserve_resize(qo)
+        st.qscales |> reserve_resize(qo / 32l)
+        q3v_read_planes(m, bytes, st, serve_sizes)
+        q3v_repack_all(st, serve_sizes)
     }
     fclose(f)
     return <- st
@@ -418,23 +532,31 @@ def stage_qwen3v_tower(path : string) : Qwen3vStaging {
 //! Load the qwen3v tower, image-backed (`dasllama_gemma4v`'s load shape: a prepared `.dlim`
 //! maps and every plane borrows; missing or stale, one is minted from the source mmproj).
 def load_qwen3v_tower(path : string) : Qwen3vTower {
+    var tag = q3v_tag()
+    // a .dlim named directly: no mmproj to regenerate from, so a wrong identity panics; the lane is
+    // the file's (its baked tag), not the pin's - a served tower reads its q8 flag from the meta
     if (path |> ends_with(".dlim")) {
+        let baked = image_family_tag(path)
+        if (baked == QWEN3V_TAG || baked == QWEN3V_TAG_Q8) {
+            tag = baked
+        }
         apply_box_profile_runtime()
         let ts_img = ref_time_ticks()
         var t = Qwen3vTower()
-        if (!load_image(path, t, QWEN3V_TAG)) {
-            panic("dasLLAMA: '{path}' is not a prepared qwen3v-tower image for this box/knobs (identity {image_identity(QWEN3V_TAG)}) - regenerate it from the source mmproj gguf")
+        if (!load_image(path, t, tag)) {
+            panic("dasLLAMA: '{path}' is not a prepared qwen3v-tower image for this box/knobs (identity {image_identity(tag)}) - regenerate it from the source mmproj gguf")
         }
         to_log(LOG_INFO, "dasLLAMA: prepared qwen3v-tower image mapped in {get_time_usec(ts_img) / 1000} ms - {path}\n")
         q3v_check_planes(t, path)
         return <- t
     }
+    q3v_announce_lane()
     if (g_env_engine.image) {
-        apply_box_profile_runtime()
-        let img = image_path_for(path, QWEN3V_TAG)
+        apply_box_profile_runtime()   // a backend pin must precede the identity (it names the backend)
+        let img = image_path_for(path, tag)
         let ts_img = ref_time_ticks()
         var t = Qwen3vTower()
-        if (load_image(img, t, QWEN3V_TAG)) {
+        if (load_image(img, t, tag)) {
             to_log(LOG_INFO, "dasLLAMA: prepared qwen3v-tower image mapped in {get_time_usec(ts_img) / 1000} ms - {img}\n")
             q3v_check_planes(t, img)
             return <- t
@@ -442,8 +564,8 @@ def load_qwen3v_tower(path : string) : Qwen3vTower {
         delete t
         var inscope st <- stage_qwen3v_tower(path)
         var built = Qwen3vTower()
-        if (cache_via_image_staged(st, built, img, QWEN3V_TAG)) {
-            dlim_gc_stale(path, QWEN3V_TAG)
+        if (cache_via_image_staged(st, built, img, tag)) {
+            dlim_gc_stale(path, tag)   // the fresh bake ON DISK proves its lane's siblings dead
         }
         q3v_check_planes(built, img)
         return <- built
@@ -457,12 +579,17 @@ def load_qwen3v_tower(path : string) : Qwen3vTower {
 
 //! Mint a served tower from a staged read WITHOUT touching disk — the off-rail control for suites.
 def mint_qwen3v_tower(var st : Qwen3vStaging; var out : Qwen3vTower) {
-    cache_via_image_staged(st, out, "", QWEN3V_TAG)
+    cache_via_image_staged(st, out, "", st.t.q8 ? QWEN3V_TAG_Q8 : QWEN3V_TAG)
 }
 
+// the bind walk skips a missing section silently, so the flag=>plane invariant must be checked
+// once the carrier is live, or the kernel derefs null
 def private q3v_check_planes(t : Qwen3vTower; src : string) {
-    if ((t.blk_bf16 || t.mm_bf16) && empty(t.wblob)) {
+    if (((t.blk_bf16 && !t.q8) || t.mm_bf16) && empty(t.wblob)) {
         panic("dasLLAMA qwen3v: '{src}' declares bf16 planes but carries no wblob section - the image is corrupt or hand-edited")
+    }
+    if (t.q8 && (empty(t.qblob) || empty(t.qscales))) {
+        panic("dasLLAMA qwen3v: '{src}' declares q8 block GEMMs but carries no qblob/qscales sections - the image is corrupt or hand-edited")
     }
 }
 
@@ -512,17 +639,28 @@ struct Qwen3vBlockOffs {
 
 def qwen3v_block_offs(t : Qwen3vTower; l : int64) : Qwen3vBlockOffs {
     let d = t.n_embd
-    let ff = t.n_ff
     let fo = t.layer_f + l * t.layer_f_stride
     var o = Qwen3vBlockOffs(ln1_w = fo, ln1_b = fo + d, ln2_w = fo + 2l * d, ln2_b = fo + 3l * d,
-        qkv_b = fo + 4l * d, out_b = fo + 7l * d, up_b = fo + 8l * d, down_b = fo + 8l * d + ff)
-    let sizes <- q3v_gemm_sizes(d, ff)
+        qkv_b = fo + 4l * d, out_b = fo + 7l * d, up_b = fo + 8l * d, down_b = fo + 8l * d + t.ff_pad)
+    let sizes <- q3v_gemm_sizes(d, t.q8 ? t.ff_pad : t.n_ff)   // the SERVED sizes — the q8 FFN pair pads
     var at = t.layer_w + l * t.layer_w_stride
     for (g in range64(QWEN3V_GEMMS)) {
         o.w[g] = at
         at += sizes[g]
     }
     return o
+}
+
+// one block GEMM on the lane the load picked: requant + the q8q8 batch kernel when q8, the
+// file's bf16/f32 plane otherwise
+def private q3v_gemm_blk(var y : array<float>; t : Qwen3vTower; var s : Qwen3vState; off : int64;
+                         x : array<float>; n, d_out, npos : int64) {
+    if (t.q8) {
+        requant_rows_q8_sized(x, n, npos, s.xqi, s.xsi)
+        matmul_q8q8_batch(y, t.qblob, t.qscales, off, s.xqi, s.xsi, n, d_out, npos)
+    } else {
+        mm_plane_b(y, t.blk_bf16, t.wblob, t.blob, off, x, n, d_out, npos)
+    }
 }
 
 // split the fused qkv rows [npos × 3d] into contiguous q/k/v [npos × d]
@@ -546,14 +684,14 @@ def private q3v_split_qkv(var s : Qwen3vState; d, npos : int64) {
 // one pre-LN block over the residual stream s.x (npos rows)
 def private q3v_block(t : Qwen3vTower; var s : Qwen3vState; l, npos : int64) {
     let d = t.n_embd
-    let ff = t.n_ff
+    let ff = t.q8 ? t.ff_pad : t.n_ff   // the served FFN width — the q8 pad lanes are zero by construction
     let hd = d / t.n_head
     let o = qwen3v_block_offs(t, l)
     var tp = ref_time_ticks()
     layernorm_batch(s.xb, s.x, t.blob, o.ln1_w, o.ln1_b, d, npos, t.eps)
     asr_prof_add("q3v.norm", tp)
     tp = ref_time_ticks()
-    mm_plane_b(s.qkv, t.blk_bf16, t.wblob, t.blob, o.w[QWEN3V_GEMM_QKV], s.xb, d, 3l * d, npos)
+    q3v_gemm_blk(s.qkv, t, s, o.w[QWEN3V_GEMM_QKV], s.xb, d, 3l * d, npos)
     add_bias_rows(s.qkv, t.blob, o.qkv_b, 3l * d, npos)
     asr_prof_add("q3v.attn_mm", tp)
     tp = ref_time_ticks()
@@ -565,7 +703,7 @@ def private q3v_block(t : Qwen3vTower; var s : Qwen3vState; l, npos : int64) {
     attention_bidir(s.xb2, s.qq, s.kk, s.vv, s.hp, s.att, npos, d, t.n_head, 1.0 / sqrt(float(hd)))
     asr_prof_add("q3v.attn_core", tp)
     tp = ref_time_ticks()
-    mm_plane_b(s.xb, t.blk_bf16, t.wblob, t.blob, o.w[QWEN3V_GEMM_O], s.xb2, d, d, npos)
+    q3v_gemm_blk(s.xb, t, s, o.w[QWEN3V_GEMM_O], s.xb2, d, d, npos)
     add_bias_rows(s.xb, t.blob, o.out_b, d, npos)
     add_inplace_rows(s.x, s.xb, npos * d)
     asr_prof_add("q3v.attn_mm", tp)
@@ -573,10 +711,10 @@ def private q3v_block(t : Qwen3vTower; var s : Qwen3vState; l, npos : int64) {
     layernorm_batch(s.xb, s.x, t.blob, o.ln2_w, o.ln2_b, d, npos, t.eps)
     asr_prof_add("q3v.norm", tp)
     tp = ref_time_ticks()
-    mm_plane_b(s.hu, t.blk_bf16, t.wblob, t.blob, o.w[QWEN3V_GEMM_UP], s.xb, d, ff, npos)
+    q3v_gemm_blk(s.hu, t, s, o.w[QWEN3V_GEMM_UP], s.xb, d, ff, npos)
     add_bias_rows(s.hu, t.blob, o.up_b, ff, npos)
     gelu_tanh_lut_batch(s.hu, ff, npos)
-    mm_plane_b(s.xb, t.blk_bf16, t.wblob, t.blob, o.w[QWEN3V_GEMM_DOWN], s.hu, ff, d, npos)
+    q3v_gemm_blk(s.xb, t, s, o.w[QWEN3V_GEMM_DOWN], s.hu, ff, d, npos)
     add_bias_rows(s.xb, t.blob, o.down_b, d, npos)
     add_inplace_rows(s.x, s.xb, npos * d)
     asr_prof_add("q3v.ffn", tp)
@@ -595,7 +733,7 @@ def private q3v_stem(t : Qwen3vTower; var s : Qwen3vState; planes : array<float>
     ensure_length(s.qq, npos * d)
     ensure_length(s.kk, npos * d)
     ensure_length(s.vv, npos * d)
-    ensure_length(s.hu, npos * t.n_ff)
+    ensure_length(s.hu, npos * (t.q8 ? t.ff_pad : t.n_ff))
     ensure_length(s.m0, (npos / 4l) * 4l * d)
     mm_plane_b(s.xn, false, t.wblob, t.blob, t.patch_w, s.x0, t.patch_dim, d, npos)
     var pos_base = t.pos_w

--- a/modules/dasLLAMA/dasllama/dasllama_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_tower.das
@@ -294,6 +294,87 @@ def tower_read_gemm(m : GGUFMeta; b : array<uint8> | #; name : string; var wblob
     }
 }
 
+//! Read one GEMM weight transcoded to Q8_0 — the q8 serving lane's read: the file's tensor
+//! (any f32-widenable type) widens into ``wscratch``, then quantizes into qblob/qscales at the
+//! 32-aligned region (``wo/32`` indexes the scales). ``family`` names the panic.
+def tower_read_gemm_q8(m : GGUFMeta; b : array<uint8> | #; name : string; var qblob : array<int8>;
+                       var qscales : array<float>; @scratch var wscratch : array<float>;
+                       wo, n_elem : int64; family : string) {
+    if (n_elem % 32l != 0l || wo % 32l != 0l) {
+        panic("{family}: GEMM tensor '{name}' ({n_elem} elements at {wo}) is not 32-aligned")
+    }
+    if (long_length(wscratch) < n_elem) {   // inline: PERF026 can't see @scratch through reserve_resize
+        wscratch |> reserve(n_elem)
+        wscratch |> resize(n_elem)
+    }
+    gguf_read_tensor_f32(m, b, name, wscratch, 0l, n_elem)
+    quantize_q8_0_into(wscratch, n_elem, qblob, qscales, wo, wo / 32l)
+}
+
+//! Stage a [file_rows × width] GEMM into a q8 region padded to [pad_rows × width] with zero
+//! rows appended — their quantized outputs are exactly zero, so a non-32-aligned FFN's up/gate
+//! half can emit the padded width its down partner consumes.
+def tower_stage_q8_zero_rows(m : GGUFMeta; b : array<uint8> | #; name : string; var qblob : array<int8>;
+                             var qscales : array<float>; @scratch var wscratch : array<float>;
+                             wo, file_rows, pad_rows, width : int64; family : string) {
+    let file_n = file_rows * width
+    let served = pad_rows * width
+    if (served % 32l != 0l || wo % 32l != 0l) {
+        panic("{family}: GEMM tensor '{name}' ({served} served elements at {wo}) is not 32-aligned")
+    }
+    if (long_length(wscratch) < served) {
+        wscratch |> reserve(served)
+        wscratch |> resize(served)
+    }
+    gguf_read_tensor_f32(m, b, name, wscratch, 0l, file_n)
+    tower_zero_span(wscratch, file_n, served - file_n)
+    quantize_q8_0_into(wscratch, served, qblob, qscales, wo, wo / 32l)
+}
+
+//! Stage a [rows × ff] GEMM into a q8 region with each row zero-padded to [rows × fp] — the
+//! down half: the pad columns multiply the up pad's zero outputs, so the padded dot is exact.
+def tower_stage_q8_pad_cols(m : GGUFMeta; b : array<uint8> | #; name : string; var qblob : array<int8>;
+                            var qscales : array<float>; @scratch var wscratch : array<float>;
+                            @scratch var rowscratch : array<float>; wo, rows, ff, fp : int64; family : string) {
+    let served = rows * fp
+    if (served % 32l != 0l || wo % 32l != 0l) {
+        panic("{family}: GEMM tensor '{name}' ({served} served elements at {wo}) is not 32-aligned")
+    }
+    if (long_length(rowscratch) < rows * ff) {
+        rowscratch |> reserve(rows * ff)
+        rowscratch |> resize(rows * ff)
+    }
+    gguf_read_tensor_f32(m, b, name, rowscratch, 0l, rows * ff)
+    if (long_length(wscratch) < served) {
+        wscratch |> reserve(served)
+        wscratch |> resize(served)
+    }
+    unsafe {
+        var dp = addr(wscratch[0])
+        let sp = addr(rowscratch[0])
+        for (r in range64(rows)) {
+            memcpy(dp + r * fp, sp + r * ff, ff * 4l)
+            for (i in range64(ff, fp)) {
+                dp[r * fp + i] = 0.0
+            }
+        }
+    }
+    quantize_q8_0_into(wscratch, served, qblob, qscales, wo, wo / 32l)
+}
+
+//! Zero ``n`` floats at ``at`` — pad tails of staged planes.
+def tower_zero_span(var a : array<float>; at, n : int64) {
+    if (n <= 0l) {
+        return
+    }
+    unsafe {
+        var p = addr(a[at])
+        for (i in range64(n)) {
+            p[i] = 0.0
+        }
+    }
+}
+
 //! Read a temporal patch-conv PAIR folded for still images: conv0(img) + conv1(img) = (W0+W1)·img,
 //! so ``base`` lands at ``off`` and ``base.1`` accumulates into the same plane region.
 def tower_read_conv_pair_folded(m : GGUFMeta; b : array<uint8> | #; base : string;

--- a/modules/dasLLAMA/dasllama/dasllama_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_tower.das
@@ -319,8 +319,9 @@ def tower_stage_q8_zero_rows(m : GGUFMeta; b : array<uint8> | #; name : string; 
                              wo, file_rows, pad_rows, width : int64; family : string) {
     let file_n = file_rows * width
     let served = pad_rows * width
-    if (served % 32l != 0l || wo % 32l != 0l) {
-        panic("{family}: GEMM tensor '{name}' ({served} served elements at {wo}) is not 32-aligned")
+    // the row width itself must quantize: repack and the row requant both take n % 32 == 0
+    if (width % 32l != 0l || served % 32l != 0l || wo % 32l != 0l) {
+        panic("{family}: GEMM tensor '{name}' ({served} served elements, width {width}, at {wo}) is not 32-aligned")
     }
     if (long_length(wscratch) < served) {
         wscratch |> reserve(served)
@@ -337,8 +338,9 @@ def tower_stage_q8_pad_cols(m : GGUFMeta; b : array<uint8> | #; name : string; v
                             var qscales : array<float>; @scratch var wscratch : array<float>;
                             @scratch var rowscratch : array<float>; wo, rows, ff, fp : int64; family : string) {
     let served = rows * fp
-    if (served % 32l != 0l || wo % 32l != 0l) {
-        panic("{family}: GEMM tensor '{name}' ({served} served elements at {wo}) is not 32-aligned")
+    // the padded row width itself must quantize: repack and the row requant both take n % 32 == 0
+    if (fp % 32l != 0l || served % 32l != 0l || wo % 32l != 0l) {
+        panic("{family}: GEMM tensor '{name}' ({served} served elements, padded width {fp}, at {wo}) is not 32-aligned")
     }
     if (long_length(rowscratch) < rows * ff) {
         rowscratch |> reserve(rows * ff)
@@ -360,6 +362,24 @@ def tower_stage_q8_pad_cols(m : GGUFMeta; b : array<uint8> | #; name : string; v
         }
     }
     quantize_q8_0_into(wscratch, served, qblob, qscales, wo, wo / 32l)
+}
+
+//! Repack every block-GEMM region of a staged q8 layout for the active backend's q8q8 kernels —
+//! per-row alignment (each region's input width, ``widths``/``sizes`` in the family's GEMM
+//! order) keeps blocks from straddling rows; no repack backend selected = the flat image serves.
+def tower_repack_q8_blocks(var qblob : array<int8>; var qscales : array<float>;
+                           layer_w, layer_w_stride, n_layer : int64;
+                           widths : array<int64>; sizes : array<int64>) {
+    if (!select_matmul_backend_for_load_()) {
+        return
+    }
+    for (l in range64(n_layer)) {
+        var wo = layer_w + l * layer_w_stride
+        for (w, sz in widths, sizes) {
+            repack_q8q8_weight(qblob, qscales, wo, w, sz / w)
+            wo += sz
+        }
+    }
 }
 
 //! Zero ``n`` floats at ``at`` — pad tails of staged planes.

--- a/modules/dasLLAMA/dasllama/dasllama_vision_embedder.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vision_embedder.das
@@ -110,7 +110,8 @@ def vision_family(e : VisionEmbedder) : string {
 //! The tower's precision half of an image cell's ``<tower>/<decoder>`` exec_fmt stamp (the ASR
 //! spelling): "f32" = every plane as the file has it (exact), "q8" = the Q8_0 block-GEMM lane.
 def vision_exec_fmt(e : VisionEmbedder) : string {
-    if ((e.kind == VisionKind.gemma4v && e.gemma4v.q8) || (e.kind == VisionKind.gemma3v && e.gemma3v.q8)) {
+    if ((e.kind == VisionKind.gemma4v && e.gemma4v.q8) || (e.kind == VisionKind.gemma3v && e.gemma3v.q8)
+            || (e.kind == VisionKind.qwen3v && e.qwen3v.q8)) {
         return "q8"
     }
     return "f32"
@@ -157,7 +158,7 @@ def load_vision_embedder(path : string) : VisionEmbedder {
         e.gemma3v <- load_gemma3v_tower(path)
         return <- e
     }
-    if (proj == "qwen3vl_merger" || proj == "qwen3v") {   // the gguf spells qwen3vl_merger; the image lane bakes qwen3v
+    if (proj == "qwen3vl_merger" || proj == "qwen3v" || proj == "qwen3v-q8") {   // the gguf spells qwen3vl_merger; the two image lanes bake qwen3v*
         var e = VisionEmbedder(kind = VisionKind.qwen3v)
         e.qwen3v <- load_qwen3v_tower(path)
         return <- e

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -540,7 +540,9 @@
     per-file env plumbing) or a cold-mint arm in the tier-1 gates, so a loader mutation reds
     on any box.
 
-44. **The qwen25v (Qwen2.5-Omni/VL window ViT) CPU encode stays ~4.6x behind mtmd's clip —
+44. **The qwen25v (Qwen2.5-Omni/VL window ViT) CPU encode stays ~4.6x behind mtmd's clip
+    (released `lcpp_bench --image` vs patched llama-mtmd-cli, CPU, --image-think, r=3, t=8,
+    M1 Max) —
     the tower is ruled exact-only (ARCHITECTURE.md 1.7b: per-32-block activation requant
     cannot represent its outlier rows; a q8q8 lane measured 2.0 x rms where a deleted layer
     measures less).** Two honest paths if that encode ever matters: the Metal tower for the

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -539,3 +539,12 @@
     at context init, immutably — by design). Done = a `DASLLAMA_IMAGE=0` leg (runner or
     per-file env plumbing) or a cold-mint arm in the tier-1 gates, so a loader mutation reds
     on any box.
+
+44. **The qwen25v (Qwen2.5-Omni/VL window ViT) CPU encode stays ~4.6x behind mtmd's clip —
+    the tower is ruled exact-only (ARCHITECTURE.md 1.7b: per-32-block activation requant
+    cannot represent its outlier rows; a q8q8 lane measured 2.0 x rms where a deleted layer
+    measures less).** Two honest paths if that encode ever matters: the Metal tower for the
+    qwen ViT families (the same slice the qwen3v towers await), or outlier-aware activation
+    quant (SmoothQuant-style per-channel folds baked at stage — needs a calibration set and
+    its own gate design). Done = either path serving the Omni-3B encode with a
+    poison-discriminating tier-1 gate.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -446,7 +446,8 @@ while mtmd offloads the mmproj to Metal unless told not to.
     the prediction's frame ("crashes") was looking at the wrong hazard.
 
 ### Slice L — the CPU encode gap: qwen towers get the q8 block-GEMM lane (predictions
-### registered 2026-08-22 BEFORE implementation; the agreed first post-merge slice)
+### registered 2026-08-22 BEFORE implementation; the agreed first post-merge slice; every
+### enc figure below = released `lcpp_bench --image`, CPU, --image-think, r=3, t=8, M1 Max)
 
 Design: port gemma3v's q8 serving lane (Q8_0 transcode at read, requant + q8q8 batch at
 encode, its own image tag, pin knobs, policy = q8 unless the accelerate float-batch tier is

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -444,3 +444,58 @@ while mtmd offloads the mmproj to Metal unless told not to.
     crashes" held literally but missed the real failure mode: TWO silent-wrong classes (the
     grid never passed; the suppress-form derail) — the sweep's value was finding them, and
     the prediction's frame ("crashes") was looking at the wrong hazard.
+
+### Slice L — the CPU encode gap: qwen towers get the q8 block-GEMM lane (predictions
+### registered 2026-08-22 BEFORE implementation; the agreed first post-merge slice)
+
+Design: port gemma3v's q8 serving lane (Q8_0 transcode at read, requant + q8q8 batch at
+encode, its own image tag, pin knobs, policy = q8 unless the accelerate float-batch tier is
+armed) to dasllama_qwen3v + dasllama_qwen25v. Block GEMMs only; conv/mergers/deepstack stay
+on file planes. qwen3v ff=4304 is not 32-aligned → the gemma3v ff_pad treatment (zero up
+rows / down cols), Q8 LANE ONLY so the exact bf16 lane stays byte-identical to today.
+tower_read_gemm_q8 hoists into dasllama_tower (g3v+g4v+two new = four copies otherwise).
+
+14. The q8 lane speeds the das CPU encode 3.5–5.5× per qwen tower (gemma4v's measured 4.8×
+    CPU-tower factor, same block-GEMM dominance): Omni-30B enc 6.3→1.2–1.8 s, VL-4B
+    5.1→1.0–1.5 s, VL-8B ~6→1.1–1.7 s, Omni-3B 12.1→2.2–3.5 s.
+15. Post-change das CPU enc vs mtmd's clip CPU enc: das lands within 1.5× either side on the
+    three dense towers (from 4.6–5.3× behind), and the 30B lead (mtmd 59 s collapse) widens
+    past 30×.
+16. Greedy coco captions at the bench prompt change on at most 1 of the 4 models vs the
+    exact lane (gemma experience: the q8 tower is caption-stable; near-ties may flip).
+17. Tier-1 q8 error vs the f32 oracle lands 0.15–0.35 × token rms on both qwen towers
+    (gemma3v measured 0.22–0.25 at 27 blocks; qwen3v is 27 blocks, qwen25v 32 windowed).
+
+#### Slice L findings (2026-08-22, the tier-1 + probe round BEFORE any perf measurement)
+
+The port went in as designed for BOTH towers; the tier-1 gates then split them:
+
+- **qwen3v (Omni-30B + VL dense): SHIPS.** q8 error 0.42 x rms worst (gray448; cb fixtures
+  0.1-0.3) — roughly double gemma3v's 0.22-0.25 floor, the qwen ViT's outlier channels.
+  Bar 5.2e-1; the zero-layer-13 poison reds it by +0.73 (2.4x discrimination). Deepstack q8
+  cells run cb-only at 6.5e-1 (the uniform gray fixture measures 7.9 x rms on the tap-slice
+  probes — taps sample mid-network residuals where the outlier noise arrives unwashed); the
+  zeroed-slices decoder control (10.4) is the gate that proves the slices still carry.
+  Captions: VL-4B deepstack q8 caption full and correct.
+- **qwen25v (Omni-3B): DOES NOT SHIP — the lane is reverted, exact serving stays.** The q8q8
+  lane measured 2.0 x rms vs the oracle, and the zero-layer poison sat BELOW any bar wide
+  enough to admit the clean encode (excess -0.38): the gate cannot distinguish q8 noise from
+  a deleted layer. Localization: weights are fine (weight-only Q8 rounding = 0.0067 x rms);
+  per-site chains on random x are fine (q8q8 3-7% worst-element, down float-x 2.4%); the
+  disease is per-32-block ACTIVATION requant on the Qwen2-VL-lineage ViT's outlier rows
+  (±100 channels), at every site — the gated-FFN down input (silu(gate)·up) worst (its
+  float-activation form, `matmul_q8_batch` w8xf32, recovered only 2.0 -> 1.38 x rms; probed,
+  then removed with the lane). An all-float-activation q8 lane wins nothing on CPU: these
+  GEMMs are compute-bound and the 4-5x IS the int8xint8 SIMD. Options if the Omni-3B CPU
+  encode ever matters: outlier-aware activation quant (SmoothQuant-style folds, needs
+  calibration) or the Metal tower (the planned other factor).
+
+Prediction scoring (14-17):
+14. **HALF.** The mechanism and the recipe landed, but only for qwen3v; qwen25v excluded
+    (unpredicted — the prediction assumed all qwen towers quantize alike; the Qwen2-VL
+    activation-outlier lore was known and not priced in). Speedups not yet measured.
+15. Not yet measurable (perf round pending); qwen25v arm VOID (no q8 lane).
+16. On track — VL-4B q8 caption unchanged-quality; full sweep pending.
+17. **WRONG on both sides**: qwen3v landed ABOVE the band (0.42 vs 0.15-0.35) and qwen25v
+    landed at 2.0 — the band assumed gemma-like activation statistics; the per-family
+    outlier ladder (gemma 0.25 -> qwen3v 0.42 -> qwen25v 2.0) was the real story.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -499,3 +499,20 @@ Prediction scoring (14-17):
 17. **WRONG on both sides**: qwen3v landed ABOVE the band (0.42 vs 0.15-0.35) and qwen25v
     landed at 2.0 — the band assumed gemma-like activation statistics; the per-family
     outlier ladder (gemma 0.25 -> qwen3v 0.42 -> qwen25v 2.0) was the real story.
+
+#### Slice L measurement (2026-08-22, released rig, CPU cells, --image-think, r=3, t=8, M1 Max)
+
+| model | das enc J (exact) | das enc now (q8) | speedup | vs mtmd clip CPU (J) |
+|---|---|---|---|---|
+| Qwen3VL-4B | 5.1 s | **1.084 s** | 4.7x | ~1.11 s — TIE (das -2%) |
+| Qwen3VL-8B | ~10 s | **1.895 s** | ~5.3x | ~1.89 s — TIE |
+| Qwen3-Omni-30B | 6.3 s | **1.496 s** | 4.2x | 59 s — das 39x ahead |
+
+Captions all correct at template-default thinking (cats + couch + remotes; the 30B its terse
+form). Cells stamp `(qwen3v q8)`. Qwen2.5-Omni-3B unmeasured — no q8 lane (slice-L findings).
+
+14. **CORRECT** (for the towers that shipped): 4.2-5.3x inside the 3.5-5.5x band.
+15. **CORRECT** (for the shipped towers): the dense pairs land at mtmd-clip parity (predicted
+    "within 1.5x either side"), and the 30B lead is 39x (predicted past 30x). qwen25v VOID.
+16. **CORRECT so far**: captions unchanged-quality on all three measured models (+ the 4B
+    chat-suite caption). 4 of 4 checked, 0 flips.

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -243,7 +243,13 @@ merged-patch-grid panic gate; and the Qwen3-VL 4B DEEPSTACK leg (taps 5/11/17, w
 10240-float rows) on four fixtures at 2e-4 + 4e-2·rms — the 4B dumps carry q1/q2/q3 quarter-offset probe
 fields — the compare applies them when the dump has them — hitting each concatenated
 slice's first element (a skipped-tap poison
-lands at 6.9–9.7 on them, 600×; mean+v0..v3 alone are BLIND to a zeroed slice). Skips
+lands at 6.9–9.7 on them, 600×; mean+v0..v3 alone are BLIND to a zeroed slice). The q8
+serving lane (the CPU default) gets its own cells: the Omni leg on its measured 5.2e-1·rms
+bar with a zero-layer staging-poison must-EXCEED leg (`encode_excess`), the deepstack leg
+cb-only at 6.5e-1 (gray's tap-slice probes measure 7.9·rms — taps sample mid-network
+residuals; the zeroed-slices decoder control in test_vision_chat carries that claim), and a
+model-free lane-knob cell; exact-lane cells pin `set_qwen3v_q8(false)`. qwen25v has NO q8
+lane by ruling (ARCHITECTURE.md 1.7b: activation outliers). Skips
 honestly without the mmprojs or dumps.
 `test_qwen25v.das` — the qwen25v tower (Qwen2.5-Omni's window-attention ViT, projector
 `qwen2.5o`) tier-1 parity vs the `-p encode` dumps minted on the f32-widened dual-tower

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -75,9 +75,9 @@ builders) live in `_metal_kernel_common.das`; `test_metal_prefill_kernels.das` k
 mismatch compares local — a same-arity twin would collide with the shared tagged one.
 `_mtl_toy.das` is the `[metal_dispatch]` multi-kernel (kernel=) fixture — its gate in
 the misc file dispatches through the GENERATED builders (kn_ rail), not hand binds.
-A new gate gets a NEGATIVE CONTROL before its first commit (poison the oracle → red
-with dumps → revert); size an additive poison to beat rel·env at the longest dot, and give
-every derived-truth compare its own poison. A kernel with `@workgroup` state needs
+The control obligation for a new gate or bar is `REVIEW.md`'s (a control the bar reds, same
+change); the sizing mechanics: an additive poison beats rel·env at the longest dot, and
+every derived-truth compare gets its own poison. A kernel with `@workgroup` state needs
 `metal_set_threadgroup_memory_length` in the gate exactly as in its production encoder —
 missing tgmem reads garbage silently.
 The `image` suite (test_model_image — the prepared-image .dlim rail): `mechanics` (synthetic
@@ -242,31 +242,37 @@ cb640x320 = the merge-reorder/transposed-grid gate) at 2e-4 + 1e-2·token-rms, p
 merged-patch-grid panic gate; and the Qwen3-VL 4B DEEPSTACK leg (taps 5/11/17, wide
 10240-float rows) on four fixtures at 2e-4 + 4e-2·rms — the 4B dumps carry q1/q2/q3 quarter-offset probe
 fields — the compare applies them when the dump has them — hitting each concatenated
-slice's first element (a skipped-tap poison
-lands at 6.9–9.7 on them, 600×; mean+v0..v3 alone are BLIND to a zeroed slice). The q8
-serving lane (the CPU default) gets its own cells: the Omni leg on its measured 5.2e-1·rms
-bar with a zero-layer staging-poison must-EXCEED leg (`encode_excess`), the deepstack leg
-cb-only at 6.5e-1 (gray's tap-slice probes measure 7.9·rms — taps sample mid-network
-residuals; the zeroed-slices decoder control in test_vision_chat carries that claim), and a
-model-free lane-knob cell; exact-lane cells pin `set_qwen3v_q8(false)`. qwen25v has NO q8
-lane by ruling (ARCHITECTURE.md 1.7b: activation outliers). Skips
-honestly without the mmprojs or dumps.
+slice's first element (a skipped-tap poison lands at 6.9–9.7 on them, 600×; mean+v0..v3
+alone are BLIND to a zeroed slice). The q8 serving lane (the CPU policy default when no
+accelerate float-batch tier is active) gets its own cells, each bar carrying its own
+must-EXCEED poison leg — a block's qblob region zeroed through the staging planes, scored
+by `encode_excess`: the Omni leg on gray448 + cb448 + cb96 at its measured 5.2e-1·rms bar,
+poisoned at a mid-stack block; the deepstack leg on cb448 + cb96 at 6.5e-1, poisoned at
+the TAP-1 block so the zero hits both the main path and a served slice — gray's tap-slice
+probes measure 7.9·rms because the taps sample mid-network residuals, so gray stays on the
+exact lane's set, and the proof that the served slices still carry signal is the
+zeroed-slices decoder control in `test_vision_chat.das`; and a model-free lane-knob cell.
+The model-gated cells skip honestly without the mmprojs or dumps.
 `test_qwen25v.das` — the qwen25v tower (Qwen2.5-Omni's window-attention ViT, projector
 `qwen2.5o`) tier-1 parity vs the `-p encode` dumps minted on the f32-widened dual-tower
 mmproj, CPU (`qwen3vl-vision-oracle/mint_25o.sh`): five fixtures, four of them shaped —
 cb112 = the single-window arm, cb448 = four full windows, cb616x336 = ragged window edges, and quad448 = the WINDOW
 DISCRIMINATOR (four exact-value quadrants; uniform/periodic fixtures make every window
 statistically identical, so an all-full-attention poison hides under them — quad reds it at
-10.7 vs the 2e-4 + 1e-2·rms bar) — plus the merged-patch-grid panic gate. Skips honestly
-without the mmproj or dumps.
-`_vision_oracle.das` is the shared dump parser / fixture generator /
-per-token compare all vision tier-1 tests use (the `quad` generator and the q1/q2/q3
-quarter-offset probe fields live here).
+10.7 vs the 2e-4 + 1e-2·rms bar) — plus the merged-patch-grid panic gate. No q8 lane in
+this tower, so no q8-lane cells (`../ARCHITECTURE.md`, the `dasllama_qwen25v.das` entry).
+Skips honestly without the mmproj or dumps.
+`_vision_oracle.das` is the shared dump parser / fixture generator / per-token compare /
+over-bar scorer (the must-EXCEED half of a poison leg) all vision tier-1 tests use (the
+`quad` generator and the q1/q2/q3 quarter-offset probe fields live here).
 `test_audio_embedder.das` — model-free: the `AudioEmbedder` carrier's own arms — the no-audio
 refusals and the probe's 0-not-panic contract; model-gated: the gemma4a arm on the E2B mmproj,
 carrying the padding-contract cell (a 320-sample clip encodes to exactly 1 soft token).
-`test_vision_embedder.das` — model-free: the `VisionEmbedder` carrier's own arms — the sniffed
-family tag and the none-carrier refusals — over constructed carriers.
+`test_vision_embedder.das` — model-free: the `VisionEmbedder` carrier's own arms over
+constructed carriers — the text-only (none) shape, the loader's refusals by name (missing
+file, audio-only mmproj), and the `vision_exec_fmt` lane stamp (the qwen3v q8 flag reaching
+it; qwen25v exact-only); model-gated: the gemma4uv arm on the 12B mmproj — the sniffed
+family tag, the 48 px align, the 3840 projection width.
 `test_ple_check.das` — model-free: the PLE go-live tripwire (`ple_check_table`) on synthetic
 Model shells — short plane trips per format arm, full plane passes, non-PLE exempt.
 `test_ple_modes.das` — suite-less, model-gated (E2B Q8_0 + Q4_K_M, small tier): the PLE
@@ -330,12 +336,12 @@ images the rig cannot use and purges the flavors the rig depends on. Image-rail 
 
 ## Metal fixtures — driver knobs and the two-model pattern
 
-(REVIEW: "A cell whose claim is a CPU-served or f32-decoder leg pins every default-ON driver
-hook OFF for that leg — `set_metal_tower(false)`, `set_metal_wdec(false)`,
-`set_metal_wdec_step(false)` — and restores it after") The
+(REVIEW: "A cell pins every driver hook and serving-lane knob its claim depends on, and
+restores it after") The
 hooks are on by default: they flip a q8 leg to the GPU silently, and an f32 leg records a
 quant_mode decline that panics under required mode — either way the cell stops measuring what
-its name says.
+its name says. The family serving-lane pins (`set_<family>_q8`) are the same trap in the
+other direction: an unpinned lane cell measures whichever lane the box's policy picked.
 
 The Metal drivers serve ONLY blob-form models (`convert_model_to_metal_blob` /
 metal-flavor images), and CPU inference on a blob model PANICS. Every CPU-vs-GPU arm

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -28,10 +28,12 @@ instances are ledgered in `CLAUDE.md`'s "Out-of-folder test files" note.
 
 **A test file in this folder is registered in no `CMakeLists.txt`.**
 
-**A `model-free`-listed or suite-less test file whose name does not name what it covers has
-an accurate `CLAUDE.md` entry, kept true in the same change** — added when such a file is
-added, corrected when a mapped file's coverage is renamed or re-scoped; `run.das`'s
-`model-free` list is the complete census, the `CLAUDE.md` map is deliberately partial.
+**A change that re-scopes a test file with a `CLAUDE.md` entry keeps that entry true in the
+same change.**
+
+**A new `model-free`-listed or suite-less test file whose name does not say what it covers
+gets a `CLAUDE.md` entry in the same change** — `run.das`'s `model-free` list is the
+complete census, the `CLAUDE.md` map is deliberately partial.
 
 **A new, renamed, or dropped arm name — the literal passed to `arm_on(t, name)`
 (`_model_tier.das`), what `--arm` matches — updates the arm census in `CLAUDE.md`'s "Arm
@@ -83,8 +85,8 @@ test.
 one machine — is tested through the argv it gates or the mode it selects**, never through the
 predicate's value.
 
-**A moved or edited registration's test observes reachability** — the registered thing is
-reached through the registry, not called directly.
+**An added, moved, or edited registration's test observes reachability** — the registered
+thing is reached through the registry, not called directly.
 
 **A new pre-tokenizer family or backend ships its `corpus_case` arm in `test_tokenizer.das`,
 naming the `ggml-vocab-*.gguf` fixture.**
@@ -123,10 +125,17 @@ dump.**
 **A test that reads a vision encode oracle dump names the minting arm in its header — the
 backend, the flash-attention setting, and the mmproj precision the dump came from.**
 
-**A cell whose claim is a CPU-served or f32-decoder leg pins every default-ON driver hook OFF
-for that leg — `set_metal_tower(false)`, `set_metal_wdec(false)`, `set_metal_wdec_step(false)`
-— and restores it after** — never relies on the driver's runtime decline. The mechanism (why
-the hooks flip legs silently) is `CLAUDE.md`'s "Metal fixtures" section.
+**A cell pins every driver hook and serving-lane knob its claim depends on, and restores it
+after** — the Metal driver hooks `set_metal_tower`, `set_metal_wdec`, `set_metal_wdec_step`
+(OFF for a CPU-served or f32-decoder claim) and the family serving-lane pins
+`set_<family>_q8` (false for an exact-plane claim, true for a q8 claim) — never a runtime
+decline standing in for a pin. The mechanism (why the hooks flip legs silently) is
+`CLAUDE.md`'s "Metal fixtures" section.
+
+**A cell asserting the UNPINNED default lane compares against
+`float_batch_override_active()`, never against a hardcoded lane** — the accelerate
+float-batch tier moves the default per box; the assert is on the lane the tier selects, not
+on the predicate's own value.
 
 **A cell that encodes, preprocesses, or asserts on media bytes an encoder consumes — pixels
 or audio samples, not a `.dlim` model image — with no model loaded builds its fixture
@@ -143,6 +152,10 @@ shaped exact fixtures.
 
 **An embedding-parity cell names its fixture and logs the measured maxdiff on green as well
 as red.**
+
+**A new or loosened tolerance bar ships a control the bar reds — a poison, a knockout, or a
+cross-lane witness — in the same change.** A bar nothing has ever exceeded is not known to
+discriminate.
 
 **A family that gains a live thinking or tool format ships its recognition tests in the same
 change** — the wire-shape pins, the render pins, and a live server leg gated on the family's

--- a/modules/dasLLAMA/tests/_vision_oracle.das
+++ b/modules/dasLLAMA/tests/_vision_oracle.das
@@ -118,6 +118,34 @@ def make_planes(kind : string; w, h : int) : array<float> {
 }
 
 
+// the compare's walk without the assert: the worst excess over the bar (<= 0 means every
+// token holds it) - the must-EXCEED half of a poison leg, where compare_encode would red
+def encode_excess(out : array<float>; d : int; o : OracleEncode; abs_tol, rel_tol : float) : float {
+    var max_excess = -1e30
+    for (p in range(o.npos)) {
+        var sq = 0.0
+        var mean = 0.0
+        for (i in range(d)) {
+            mean += out[p * d + i]
+            sq += out[p * d + i] * out[p * d + i]
+        }
+        mean /= float(d)
+        let bound = abs_tol + rel_tol * sqrt(sq / float(d))
+        var diffs <- [ abs(mean - o.means[p]), abs(out[p * d + 0] - o.v0[p]), abs(out[p * d + 1] - o.v1[p]),
+                       abs(out[p * d + 2] - o.v2[p]), abs(out[p * d + 3] - o.v3[p]) ]
+        if (length(o.q1) == o.npos) {
+            diffs |> push(abs(out[p * d + d / 4] - o.q1[p]))
+            diffs |> push(abs(out[p * d + d / 2] - o.q2[p]))
+            diffs |> push(abs(out[p * d + 3 * (d / 4)] - o.q3[p]))
+        }
+        for (diff in diffs) {
+            max_excess = max(max_excess, diff - bound)
+        }
+        delete diffs
+    }
+    return max_excess
+}
+
 // the per-token compare: mean and v0..v3 of every token against the dump, on the bar
 // abs_tol + rel_tol * token_rms (token_rms = sqrt(mean(out[p]^2)) per token); logs the maxdiff under tag
 def compare_encode(t : T?; tag : string; out : array<float>; d : int; o : OracleEncode; abs_tol, rel_tol : float) : float {

--- a/modules/dasLLAMA/tests/test_qwen3v.das
+++ b/modules/dasLLAMA/tests/test_qwen3v.das
@@ -31,6 +31,17 @@ let private TIER1_REL = 1e-2
 // lands at 6.9-9.7 on the same probes, 600x this bar)
 let private TIER1_REL_DS = 4e-2
 
+// x token rms - the q8 serving lane vs the f32 oracle: measured 0.42 x rms worst (gray448) -
+// the qwen ViT's mid-network outlier channels roughly double gemma3v's 0.22-0.25 q8 floor.
+// The zero-layer poison leg proves the bar still discriminates; the caption is the product gate.
+let private TIER1_REL_Q8 = 5.2e-1
+// the deepstack q8 leg reads tap slices SAMPLED MID-NETWORK (blocks 5/11/17), where the q8
+// outlier noise arrives unwashed by the final post-LN: cb fixtures measure 0.51 x rms; the
+// uniform gray fixture measures 7.9 x rms on the q1/q2/q3 slice probes and stays on the EXACT
+// lane's set only - the zeroed-slices decoder control in test_vision_chat is the gate that
+// proves the served slices still carry their signal
+let private TIER1_REL_Q8_DS = 6.5e-1
+
 def private gate_encode(t : T?; tw : Qwen3vTower; var st : Qwen3vState; kind : string; w, h : int; logname : string;
                         rel : float = TIER1_REL) : bool {
     var o = OracleEncode()
@@ -61,11 +72,14 @@ def test_qwen3v_tier1(t : T?) {
         if (!model_available(tt, mm)) {
             return
         }
+        set_qwen3v_q8(false)   // the exact-plane lane; the q8 serving lane is its own test
         var tw <- load_qwen3v_tower(mm)
+        reset_qwen3v_q8()
         static_if (typeinfo builtin_module_exists(das_metal)) {
             set_metal_tower(false)   // this gate owns the CPU chain - the dumps are CPU-minted
         }
         var st = Qwen3vState()
+        tt |> success(!tw.q8, "exact-plane lane")
         tt |> equal(int(tw.patch), 16, "patch")
         tt |> equal(int(tw.merge), 2, "spatial merge")
         tt |> equal(int(tw.n_embd), 1152, "tower width")
@@ -107,11 +121,14 @@ def test_qwen3v_tier1_deepstack(t : T?) {
         if (!model_available(tt, mm)) {
             return
         }
+        set_qwen3v_q8(false)   // the exact-plane lane; the q8 serving lane is its own test
         var tw <- load_qwen3v_tower(mm)
+        reset_qwen3v_q8()
         static_if (typeinfo builtin_module_exists(das_metal)) {
             set_metal_tower(false)   // this gate owns the CPU chain - the dumps are CPU-minted
         }
         var st = Qwen3vState()
+        tt |> success(!tw.q8, "exact-plane lane")
         tt |> equal(int(tw.n_embd), 1024, "tower width")
         tt |> equal(int(tw.n_layer), 24, "blocks")
         tt |> equal(int(tw.n_ff), 4096, "ffn width")
@@ -127,5 +144,92 @@ def test_qwen3v_tier1_deepstack(t : T?) {
         tt |> gate_encode(tw, st, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_DS)   // 9 tokens: the pos-table DOWNSCALE arm
         delete st
         delete tw
+    }
+}
+
+// The q8 serving lane (the CPU default): the same dumps on their own scale-relative bars.
+[test]
+def test_qwen3v_tier1_q8(t : T?) {
+    t |> run("tier-1 on the q8 block-GEMM lane (the serving default, Omni-30B)") @(tt : T?) {
+        let mm = path_join(models_dir(), "mmproj-Qwen3-Omni-30B-A3B-Instruct-bf16.gguf")
+        if (!model_available(tt, mm)) {
+            return
+        }
+        set_qwen3v_q8(true)   // a CPU-lane claim pins the covering knob, never relies on the policy
+        var tw <- load_qwen3v_tower(mm)
+        reset_qwen3v_q8()
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            set_metal_tower(false)   // this gate owns the CPU chain - the dumps are CPU-minted
+        }
+        var st = Qwen3vState()
+        tt |> success(tw.q8, "q8 lane loaded")
+        tt |> equal(int(tw.ff_pad), 4352, "ffn served at the layout's padded width")
+        tt |> gate_encode(tw, st, "gray", 448, 448, "encode.gray448.log", TIER1_REL_Q8)
+        tt |> gate_encode(tw, st, "cb", 448, 448, "encode.cb448.log", TIER1_REL_Q8)
+        tt |> gate_encode(tw, st, "cb", 96, 96, "encode.cb96.log", TIER1_REL_Q8)
+        // negative control: layer 13's qblob region zeroed through the staging planes (the
+        // gemma4v knockout shape) must red the same fixture on the same bar
+        var o = OracleEncode()
+        if (load_oracle_encode(path_join(path_join(models_dir(), "qwen3vl-vision-oracle"), "encode.gray448.log"), o)) {
+            set_qwen3v_q8(true)
+            var inscope pst <- stage_qwen3v_tower(mm)
+            reset_qwen3v_q8()
+            let base = pst.t.layer_w + 13l * pst.t.layer_w_stride
+            for (i in range64(pst.t.layer_w_stride)) {
+                pst.qblob[base + i] = int8(0)
+            }
+            var ptw = Qwen3vTower()
+            mint_qwen3v_tower(pst, ptw)
+            let planes <- make_planes("gray", 448, 448)
+            var pout : array<float>
+            with_job_que() {
+                setup_dasllama_jobque_()
+                qwen3v_encode(ptw, st, planes, 448l, 448l, pout)
+            }
+            let excess = encode_excess(pout, int(qwen3v_row_width(ptw)), o, TIER1_ABS, TIER1_REL_Q8)
+            to_log(LOG_INFO, "qwen3v q8 poison leg: zero layer 13 -> excess {excess} over the bar\n")
+            tt |> success(excess > 0.0, "a zeroed mid-layer qblob region reds the bar (excess {excess})")
+            delete pout
+            delete ptw
+        }
+        delete st
+        delete tw
+    }
+}
+
+[test]
+def test_qwen3v_tier1_q8_deepstack(t : T?) {
+    t |> run("tier-1 deepstack on the q8 block-GEMM lane (Qwen3-VL 4B)") @(tt : T?) {
+        let mm = path_join(models_dir(), "mmproj-Qwen3VL-4B-Instruct-F16.gguf")
+        if (!model_available(tt, mm)) {
+            return
+        }
+        set_qwen3v_q8(true)   // a CPU-lane claim pins the covering knob, never relies on the policy
+        var tw <- load_qwen3v_tower(mm)
+        reset_qwen3v_q8()
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            set_metal_tower(false)   // this gate owns the CPU chain - the dumps are CPU-minted
+        }
+        var st = Qwen3vState()
+        tt |> success(tw.q8, "q8 lane loaded")
+        tt |> gate_encode(tw, st, "cb", 448, 448, "encode4b.cb448.log", TIER1_REL_Q8_DS)
+        tt |> gate_encode(tw, st, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_Q8_DS)
+        delete st
+        delete tw
+    }
+}
+
+// the lane policy itself - model-free: default q8 (no accelerate tier in a test child), the
+// pin flips it either way, reset returns to the policy
+[test]
+def test_qwen3v_lane_knob(t : T?) {
+    t |> run("the q8 lane pin and policy default") @(tt : T?) {
+        tt |> success(qwen3v_serves_q8(), "the CPU default serves q8")
+        set_qwen3v_q8(false)
+        tt |> success(!qwen3v_serves_q8(), "pinned exact")
+        set_qwen3v_q8(true)
+        tt |> success(qwen3v_serves_q8(), "pinned q8")
+        reset_qwen3v_q8()
+        tt |> success(qwen3v_serves_q8(), "reset returns to the policy default")
     }
 }

--- a/modules/dasLLAMA/tests/test_qwen3v.das
+++ b/modules/dasLLAMA/tests/test_qwen3v.das
@@ -5,6 +5,8 @@ options _dasllama_internal = true
 
 require dastest/testing_boost public
 require dasllama/dasllama_qwen3v
+require dasllama/dasllama_image   // image_path_for - the baked-tag sniff cell locates the q8 .dlim
+require dasllama/dasllama_vision_embedder   // load_vision_embedder - the sniff cell routes the baked tag
 require dasllama/dasllama_math   // setup_dasllama_jobque_
 require daslib/jobque_boost
 require daslib/fio
@@ -192,6 +194,16 @@ def test_qwen3v_tier1_q8(t : T?) {
             delete pout
             delete ptw
         }
+        // the q8-lane .dlim's baked tag routes through the carrier sniff (the qwen3v-q8 arm)
+        let img = image_path_for(mm, "qwen3v-q8")
+        if (stat(img).is_valid) {
+            var inscope e <- load_vision_embedder(img)
+            tt |> equal(vision_family(e), "qwen3v", "the baked q8 tag sniffs to the qwen3v arm")
+            tt |> equal(vision_exec_fmt(e), "q8", "the carrier stamps the q8 lane")
+        }
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            set_metal_tower(true)
+        }
         delete st
         delete tw
     }
@@ -214,22 +226,50 @@ def test_qwen3v_tier1_q8_deepstack(t : T?) {
         tt |> success(tw.q8, "q8 lane loaded")
         tt |> gate_encode(tw, st, "cb", 448, 448, "encode4b.cb448.log", TIER1_REL_Q8_DS)
         tt |> gate_encode(tw, st, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_Q8_DS)
+        // negative control for THIS bar: the same zero-layer knockout must red it (tap 1's
+        // block, so the poison hits both the main path and a served slice)
+        var o = OracleEncode()
+        if (load_oracle_encode(path_join(path_join(models_dir(), "qwen3vl-vision-oracle"), "encode4b.cb448.log"), o)) {
+            set_qwen3v_q8(true)
+            var inscope pst <- stage_qwen3v_tower(mm)
+            reset_qwen3v_q8()
+            let base = pst.t.layer_w + pst.t.ds_l1 * pst.t.layer_w_stride
+            for (i in range64(pst.t.layer_w_stride)) {
+                pst.qblob[base + i] = int8(0)
+            }
+            var ptw = Qwen3vTower()
+            mint_qwen3v_tower(pst, ptw)
+            let planes <- make_planes("cb", 448, 448)
+            var pout : array<float>
+            with_job_que() {
+                setup_dasllama_jobque_()
+                qwen3v_encode(ptw, st, planes, 448l, 448l, pout)
+            }
+            let excess = encode_excess(pout, int(qwen3v_row_width(ptw)), o, TIER1_ABS, TIER1_REL_Q8_DS)
+            to_log(LOG_INFO, "qwen3v deepstack q8 poison leg: zero the tap-1 block -> excess {excess} over the bar\n")
+            tt |> success(excess > 0.0, "a zeroed tap block reds the deepstack bar (excess {excess})")
+            delete pout
+            delete ptw
+        }
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            set_metal_tower(true)
+        }
         delete st
         delete tw
     }
 }
 
-// the lane policy itself - model-free: default q8 (no accelerate tier in a test child), the
-// pin flips it either way, reset returns to the policy
+// the lane policy itself - model-free: the default follows the box's accelerate tier (q8 when
+// the tier is off), the pin flips it either way, reset returns to the policy
 [test]
 def test_qwen3v_lane_knob(t : T?) {
     t |> run("the q8 lane pin and policy default") @(tt : T?) {
-        tt |> success(qwen3v_serves_q8(), "the CPU default serves q8")
-        set_qwen3v_q8(false)
-        tt |> success(!qwen3v_serves_q8(), "pinned exact")
+        tt |> equal(qwen3v_serves_q8(), !float_batch_override_active(), "the policy default follows the accelerate tier")
         set_qwen3v_q8(true)
         tt |> success(qwen3v_serves_q8(), "pinned q8")
-        reset_qwen3v_q8()
-        tt |> success(qwen3v_serves_q8(), "reset returns to the policy default")
+        set_qwen3v_q8(false)
+        tt |> success(!qwen3v_serves_q8(), "pinned exact")
+        reset_qwen3v_q8()   // from the EXACT pin, so a no-op reset cannot pass as the (q8) policy default
+        tt |> equal(qwen3v_serves_q8(), !float_batch_override_active(), "reset returns to the policy default")
     }
 }

--- a/modules/dasLLAMA/tests/test_vision_embedder.das
+++ b/modules/dasLLAMA/tests/test_vision_embedder.das
@@ -57,6 +57,20 @@ def test_vision_embedder_none(t : T?) {
 }
 
 [test]
+def test_vision_embedder_exec_fmt(t : T?) {
+    t |> run("the qwen3v q8 flag reaches the exec_fmt stamp") @(t : T?) {
+        var e3 = VisionEmbedder(kind = VisionKind.qwen3v)
+        t |> equal(vision_exec_fmt(e3), "f32", "qwen3v exact stamps f32")
+        e3.qwen3v.q8 = true
+        t |> equal(vision_exec_fmt(e3), "q8", "qwen3v q8 stamps q8")
+        var e25 = VisionEmbedder(kind = VisionKind.qwen25v)
+        t |> equal(vision_exec_fmt(e25), "f32", "qwen25v stamps f32 - the outlier ViT serves exact only")
+        delete e3
+        delete e25
+    }
+}
+
+[test]
 def test_vision_embedder_gemma4uv_arms(t : T?) {
     t |> run("the 12B mmproj sniffs as gemma4uv and reports its geometry") @(t : T?) {
         let mm = path_join(models_dir(), "mmproj-gemma-4-12B-it-BF16.gguf")


### PR DESCRIPTION
The qwen3v vision tower (Qwen3-Omni and dense Qwen3-VL) now serves its block GEMMs as Q8_0 planes on the CPU — the same recipe gemma3v and gemma4v already use. The CPU image encode drops 4.2–5.3x: Qwen3VL-4B 5.1 s → 1.08 s, 8B ~10 s → 1.89 s (both now match llama.cpp's clip encode), Qwen3-Omni-30B 6.3 s → 1.50 s, where mtmd's own CPU encode takes 59 s (released `lcpp_bench --image`, CPU, `--image-think`, r=3, t=8, M1 Max). The exact bf16/f32 lane stays byte-identical and remains the parity rail; only the q8 layout pads the FFN pair to a 32-aligned width. The shared q8 stage readers and the repack loop move to `dasllama_tower.das`; gemma3v and gemma4v now use them.

The qwen25v tower (Qwen2.5-Omni/VL) deliberately gets NO q8 lane. Its residual rows carry activation outliers that per-32-block requant cannot represent: a q8q8 lane measured 2.0x rms against the oracle, where a DELETED layer measures less — the gate cannot discriminate. The weights themselves quantize fine (0.007x rms), and a float-activation q8 GEMM wins nothing on these compute-bound shapes. The ruling and evidence are in `ARCHITECTURE.md` 1.7b; the residual encode gap is ledgered as followup 44.

Where to look: `dasllama_qwen3v.das` (the lane, its layout, the q8-only ff_pad), `dasllama_tower.das` (the hoisted stage readers and their row-width guards), `test_qwen3v.das` (the q8 tier-1 cells, each bar with its own zero-block poison leg).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Every dasLLAMA suite the change reaches ran locally under `-jit` (CI does not run the model suites): the model-free suite plus test_qwen3v, test_gemma3v, test_gemma4v, test_gemma4uv, test_qwen25v, test_vision_embedder, test_vision_chat, test_tower_helpers — 77 tests, 0 failed, 4 honest large-tier skips.
- The full gguf STAGE path (layout, padded stagers, the four-arm GEMM dispatch, repack, file-vs-serve size split) was additionally validated cold — `DASLLAMA_IMAGE=0` on test_qwen3v and test_gemma3v — because a stocked `.dlim` silently bypasses it (followup 43).
- Both q8 bars are poison-discriminating: the Omni bar (5.2e-1·rms) reds a zeroed mid-stack block by +0.73; the deepstack bar (6.5e-1) reds a zeroed tap block by +11.4. A TDD mutation round also confirmed the transcode and the zero-span guard red cold (the 4B's ff_pad == n_ff edge makes that guard load-bearing against an OOB).
- Chat captions on the q8 default are correct on all four checked carriers (VL-4B and Omni-3B chat suites; VL-4B/8B/Omni-30B bench cells), and the VL-4B zeroed-slices decoder control still measures 10.4.
- REVIEW_AUDIO.md was applied to the `dasllama_tower.das` diff by hand: the @scratch rule is compliant (the stagers' scratch params carry it), every other rule N/A.
- Peak-footprint direction at stage: the q8 image is ~3x smaller than the exact one (Omni mint logs: 517 MB vs 1581 MB written), and the stage adds only transient f32 scratch of at most one GEMM region (~20 MB); no new peak.
- preflight --full: 18/20 gates green; the two red gates (tests-interp, tests-jit) both point at one untouched language test (`cant_rpipe_into_operator.das`, an expected-compile-failure file) that PASSES in a targeted run — a parallel-suite flake, not this diff.

### Claims — stated, not tested
- The q8 lane has a bench cell behind every figure (`lcpp_bench --image` drove all measurements), but NO committed records row: official cards for the qwen vision models are withheld by explicit ruling — the figures live in `qwen3vl_plan.md` with their harness named.
- `mint_qwen3v_tower`'s in-memory tag ternary has no observable consumer (an in-memory image never writes its tag anywhere readable); the disk path's tag IS covered by the baked-tag sniff cell. A break would surface as that cell's family/exec_fmt asserts failing on the next mint.
- `q3v_check_planes`' corrupt-image rejections and the three 32-alignment panics in the hoisted stagers are defensive guards with no fixture, the same pre-existing pattern as the gemma towers' checks; the alignment guards are unreachable on every shipped carrier (verified against the three mmproj headers: widths 1152/1024, ff_pad 4352/4096/3456 — all 32-aligned).
- The lane-announce log lines (three `why` arms) are log-only and unasserted, matching the gemma3v/gemma4v pattern.

### Not done
- The qwen25v (Omni-3B) CPU encode stays ~4.6x behind mtmd's clip — exact-only serving by the outlier ruling; followup 44 records the two honest paths (the Metal tower for the qwen ViT families, or calibrated outlier-aware activation quant).
- Metal image-turn prefill (das trails 12–41%) is a separate PR by ruling; the 8B-vs-4B delta names the deepstack Metal cell as the first suspect.
- The image identity hash does not cover the repack POLICY (which regions repack for the backend) — a policy change ships with stale-`.dlim` deletion by hand today. Surfaced during development; worth folding into the identity if a second policy change ever lands.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)