### PR TITLE
dasLLAMA: qwen3v Metal tower + image-turn pp to parity

### DIFF
--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -207,15 +207,16 @@ that a question answered for one backend has an obvious address in the other. Th
 - **Backend-only capabilities live in their matching ROLE file, not in new grab-bags** — vulkan's
   weight arena, streamed mirrors, heat cache, host-import, coopmat; metal's blob transform and MTP.
 - **The tower driver owns NO PSOs.** Its kernels (LN, f32 mul_mm, the two gelu flavors,
-  posadd, the gemma4v clamp / rope2d / GEGLU-quick, the gemma3v head restride) live in the kernel home, so `metal_decode_init` compiles and `metal_kernels_release`
+  posadd, the gemma4v clamp / rope2d / GEGLU-quick, the head restride — gemma3v's and, offset-bound, the qwen3v/prefill slicers) live in the kernel home, so `metal_decode_init` compiles and `metal_kernels_release`
   releases them like every other registry PSO; the borrowed prefill builders (`pf_enc_bf16_mm`,
-  `enc_add_bias_rows`, the attention trio via `enc_qk_mm`/`enc_av_mm`) come up through
+  `enc_add_bias_rows`, `enc_rope` — the qwen3v vision NEOX apply — and the attention trio via
+  `enc_qk_mm`/`enc_av_mm`) come up through
   `metal_prefill_pso_init`, prefill's public bring-up seat, and `plane_buffer` in common is
   public for the same wrap-a-plane reason. The tower's own objects (the ones buffer, its
   scratch pool) release through `metal_tower_shutdown`.
 - **The tower driver is a Metal-only role** — Vulkan has no tower twin; audio/vision encodes
-  on the Vulkan tier stay CPU (the gemma4v ViT and gemma3v SigLIP block loops included: on
-  Vulkan and on plain CPU boxes those towers serve their q8 lanes). Likewise the non-causal media span: Metal serves it through
+  on the Vulkan tier stay CPU (the gemma4v ViT, gemma3v SigLIP and qwen3v block loops
+  included: on Vulkan and on plain CPU boxes those towers serve their q8 lanes). Likewise the non-causal media span: Metal serves it through
   `AttnArgs.uend` — including the FUSED image turn (head + media rows + tail as ONE eval, the
   per-query mask through `AttnArgs.ulo`); the Vulkan resident prefill declines span evals
   (`followup_general.md` #23's remaining half) and registers the split-span capability
@@ -225,10 +226,12 @@ that a question answered for one backend has an obvious address in the other. Th
   the per-token table rows `prefill_rope_tables` builds from the grid map, so it serves mrope
   unchanged and registers the seat; an override without it (vulkan builds angles from a scalar
   position) declines the quantum to the CPU loop by name. The deepstack quantum is the third
-  seat (`register_prefill_override_ds_adds`): Metal repacks the wide rows' tails CPU-side into
-  slice-major planes, uploads once, and encodes one `enc_add` at the slice offset after each
-  tapped layer's residual — no new kernel; an override without the seat declines deepstack
-  quanta by name, so Metal serves them and Vulkan does not.
+  seat (`register_prefill_override_ds_adds`): Metal uploads the caller's wide quantum WHOLE
+  (the `Session.wide_src` borrow), slices x and the slice-major ds planes on-device through
+  the offset-bound head restride, and encodes one `enc_add` at the slice offset after each
+  tapped layer's residual — no new kernel (the CPU-side split, `ds_split_quantum`, survives
+  as the CPU-loop fallback and the warm/MTP edge); an override without the seat declines
+  deepstack quanta by name, so Metal serves them and Vulkan does not.
 - **Per-layer FFN widths (MatFormer E-series, at most two — `ffn_second_hidden`) serve on Metal
   only**: the decode and prefill drivers bind the width per layer (dense trunks, no MTP; batch
   keeps the layer-0 hoist behind its uniformity decline). The Vulkan tier has no PLE arm, so
@@ -292,8 +295,11 @@ entry here:**
   Both tiers ENTER from the transformer umbrella (`?das_metal` requires; the single `?vulkan`
   require of the `dasllama_math_vulkan` facade); the inversion that remains is the
   kernels↔common require DIRECTION, and it is why their seam shapes differ.
-- **UMA vs discrete VRAM**: Metal never grows residency machinery (memory is memory); arenas,
-  upload economics, mirrors and hydration are Vulkan's alone.
+- **UMA vs discrete VRAM**: Metal never grows Vulkan's VRAM machinery — arenas, upload
+  economics, mirrors and hydration are Vulkan's alone. Metal's ONE residency artifact is the
+  `MTLResidencySet` pin in `_common` (`DASLLAMA_METAL_RESIDENCY`, §2.12): it pins the served
+  working set so the per-commit tracked-set pass stays warm — a driver-cost shield, not a
+  placement mechanism; memory is still memory.
 - **Lens depth**: both lenses generate `enc_*` builders from kernel classes — Metal via
   `[metal_dispatch]`, Vulkan via `[vk_dispatch]` (per-class set layouts + push constants; the
   class-kernel arc retired the hand-built 6-slot set ladders outright) — and both speak the
@@ -339,9 +345,10 @@ on a shared path is the anti-pattern. Only a genuinely new dataflow earns its ow
   the LayerNorm/RMS row forms, bias and residual row adds, the
   `mm_blob_b`/`mm_bf16_b`/`mm_plane_b` GEMM wrappers, `Clamp`/`read_clamp`,
   `im2col_rgb_patches`, `rope_neox_2d_rows`, `rope_neox_tab_rows`, `avg_pool2d_rows`,
-  `interpolate_grid_bilinear_aa`, `tower_read_conv_pair_folded`, the q8-lane stage readers
-  (`tower_read_gemm_q8`, `tower_stage_q8_zero_rows`/`tower_stage_q8_pad_cols` — the padded pair
-  for FFN widths that are not 32-aligned — and `tower_zero_span`), blocked `attention_bidir` and
+  `interpolate_grid_bilinear_aa`, `tower_read_conv_pair_folded`, the padded stage readers
+  (`tower_read_gemm_q8`, `tower_stage_q8_zero_rows`/`tower_stage_q8_pad_cols` and their f32
+  twins `tower_stage_f32_zero_rows`/`tower_stage_f32_pad_cols` — the load-scope padded
+  stagers for FFN widths that are not 32-aligned — and `tower_zero_span`), blocked `attention_bidir` and
   its per-window form `attention_bidir_windows`, and the encode-stage prof rail. The one home:
   a family file that re-implements one of these is a defect, and nothing here names a family
   type.
@@ -775,6 +782,10 @@ gate is the `--tok` scaling rows, whose instrument (the size-ladder ratio) catch
 contracts cannot.
 
 ### 2.12 The post-CPU-burn GPU ramp cannot be pre-paid — do not build a warm-up
+
+Figures in this section: M1 Max, 2026-08-23 — probes are quiet `-jit` runs with the rig's
+tune manifest; cells are the released `lcpp_bench` exe (`--image --image-think -r 3 -t 8
+--ngl 99`); full tables in `qwen3vl_plan.md` slices M/J.
 
 After a CPU-only phase, the first Metal submission runs degraded — host-side between commit
 and execution, one time per window (probe-verified 2026-08-23): ~40 ms after even a

--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -770,6 +770,23 @@ The tokenizer encode/decode path is sanctioned UNCOVERED by the region contracts
 gate is the `--tok` scaling rows, whose instrument (the size-ladder ratio) catches what the
 contracts cannot.
 
+### 2.12 The post-CPU-burn GPU ramp cannot be pre-paid — do not build a warm-up
+
+After a multi-second CPU-saturating phase (a CPU tower encode), the first sustained-bandwidth
+GPU submission runs degraded for tens of ms (~70 ms on an 8B, scaling with the model's
+bandwidth demand), one time per burn — a memory/GPU governor ramp, host-side between commit
+and execution (probe-verified 2026-08-23). Every cheap remedy is REFUTED by measurement, in
+`PERF_LEDGER.md`'s OPEN entry: empty command buffers and driver round-trips (the driver is
+never asleep — 0.107 ms), `MTLResidencySet` pinning of the whole working set (zero effect),
+single-dispatch kernels, per-page touch kernels, and light pulse-trains held through the burn.
+Only full-weight-stream work absorbs it — meaning the ramp rides whatever heavy work comes
+first, and a warm-up always pays its own cost ON TOP of the ramp it was meant to hide. Do not
+re-attempt a warm-up, a keepalive, or a residency pin against this penalty; the fix that works
+is removing the burn — serve the encoder on the GPU (the Metal tower). A family whose encoder
+stays on the CPU keeps the ramp as a ledgered cost of that arm, not as an engine defect.
+Related, same ledger: merely arming Metal makes a CPU q8 tower encode ~1.7x slower —
+mechanism unnamed, also deleted by a GPU-served tower.
+
 ---
 
 ## 3. Inherited invariants

--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -186,7 +186,7 @@ that a question answered for one backend has an obvious address in the other. Th
 | `dasllama_<gpu>_decode`<br>`dasllama_metal_decode`, `dasllama_vulkan_decode` | the resident token-step driver + decode-time arms | kernel bodies |
 | `dasllama_<gpu>_prefill`<br>`dasllama_metal_prefill`, `dasllama_vulkan_prefill` | the batched prefill driver + batch arms | kernel bodies |
 | `dasllama_<gpu>_shapes`<br>`dasllama_metal_shapes` | PORTABLE servability gates — no GPU C++ require, so any box can bake | device calls |
-| the tower driver<br>`dasllama_metal_tower` | one-shot embedder/encoder encodes (gemma4uv chain, the gemma4v ViT and gemma3v SigLIP block loops, the whisper-class block loop, the conv frontends + the qwen3a padded-weight slab) — no session, no KV, no mirror; registers the gemma4uv, gemma4v, gemma3v, encoder_blocks, tower-conv and qwen3a-conv hooks | kernel bodies, decoder state |
+| the tower driver<br>`dasllama_metal_tower` | one-shot embedder/encoder encodes (gemma4uv chain, the gemma4v ViT, gemma3v SigLIP and qwen3v block loops — qwen3v adds the vision NEOX rope, the fused-qkv weight-offset GEMMs, and the inline deepstack tap + tail merger chains — the whisper-class block loop, the conv frontends + the qwen3a padded-weight slab) — no session, no KV, no mirror; registers the gemma4uv, gemma4v, gemma3v, qwen3v, encoder_blocks, tower-conv and qwen3a-conv hooks | kernel bodies, decoder state |
 | the ASR-decoder driver<br>`dasllama_metal_asr_dec` | the whisper decoder on Metal: the 34B weight blob, the f16 resident cross/self K/V, window-granular cross-KV + decode-step serves; registers the whisper cross-KV and decode hooks (family registries in `dasllama_whisper`) | kernel bodies, LLM session state |
 | the kernel-access lens<br>`dasllama_metal_lens` (Metal), `dasllama_vulkan_dispatch` (Vulkan — the `[vk_dispatch]` macro derives access per class) | the kernel-access macro | anything else |
 
@@ -407,9 +407,13 @@ on a shared path is the anti-pattern. Only a genuinely new dataflow earns its ow
   merger, the decoder adds slice l+1 after layer l. The family token budget [8, 4096] is
   mtmd's, not the gemma-scoped DASLLAMA_VISION_* knobs; image_mean/std (0.5) is
   PREPROCESSING like gemma3v. CPU serving default: the block GEMMs serve as Q8_0 planes
-  (read-time transcode, the gemma3v recipe; the FFN pair pads to ff_pad in the q8 layout
-  ONLY — the exact bf16/f32 lane keeps the file's widths as the parity rail); pin knobs
-  `set_qwen3v_q8`/`reset_qwen3v_q8`, two image tags. Composes `dasllama_tower.das`; owns
+  (read-time transcode, the gemma3v recipe); the exact lane stages EVERYTHING f32-in-blob at
+  ff_pad both dims — blocks, mergers, and taps — because the Metal tower (`register_qwen3v_gpu`,
+  blocks + rope + taps + tail on-device, tap/tail proj outputs land in `ds_stash`/`ds_slice`)
+  and the float-batch tier both read f32 planes, and the same lane is the parity rail (the
+  f32 sites are this charter's sanction, not a fallback). Pin knobs
+  `set_qwen3v_q8`/`reset_qwen3v_q8`, two image tags; the lane policy prefers f32 when the
+  GPU tower or accel serves. Composes `dasllama_tower.das`; owns
   only its layout, the reorder walk, and the block loop. SANCTIONED over the 1 GiB staged-mint line (this family
   and qwen25v): the Omni (2.1 GB) and Qwen2.5-Omni (2.6 GB) mmprojs stage source+image at
   once with no cap — the same shape their audio halves already stage — until
@@ -772,20 +776,22 @@ contracts cannot.
 
 ### 2.12 The post-CPU-burn GPU ramp cannot be pre-paid — do not build a warm-up
 
-After a multi-second CPU-saturating phase (a CPU tower encode), the first sustained-bandwidth
-GPU submission runs degraded for tens of ms (~70 ms on an 8B, scaling with the model's
-bandwidth demand), one time per burn — a memory/GPU governor ramp, host-side between commit
-and execution (probe-verified 2026-08-23). Every cheap remedy is REFUTED by measurement, in
-`PERF_LEDGER.md`'s OPEN entry: empty command buffers and driver round-trips (the driver is
-never asleep — 0.107 ms), `MTLResidencySet` pinning of the whole working set (zero effect),
-single-dispatch kernels, per-page touch kernels, and light pulse-trains held through the burn.
-Only full-weight-stream work absorbs it — meaning the ramp rides whatever heavy work comes
-first, and a warm-up always pays its own cost ON TOP of the ramp it was meant to hide. Do not
-re-attempt a warm-up, a keepalive, or a residency pin against this penalty; the fix that works
-is removing the burn — serve the encoder on the GPU (the Metal tower). A family whose encoder
-stays on the CPU keeps the ramp as a ledgered cost of that arm, not as an engine defect.
-Related, same ledger: merely arming Metal makes a CPU q8 tower encode ~1.7x slower —
-mechanism unnamed, also deleted by a GPU-served tower.
+After a CPU-only phase, the first Metal submission runs degraded — host-side between commit
+and execution, one time per window (probe-verified 2026-08-23): ~40 ms after even a
+tens-of-ms window, saturating ~70-130 ms after multi-second burns, scaling with the model.
+The mechanism is Metal's per-commit dependency pass over the TRACKED working set running
+cold (the same pass that cost ~70 ms/prefill before the weights went untracked — see the
+region-upload comment in `dasllama_metal_common`); making the prefill pools untracked reds
+parity, so the tracking is load-bearing, and the scoped fix is a per-buffer tracking audit.
+Every pre-payment is REFUTED by measurement (`PERF_LEDGER.md`'s OPEN entry): empty command
+buffers and driver round-trips (0.107 ms — never asleep), single-dispatch kernels, per-page
+touch kernels, light pulse-trains through the burn — a warm-up always pays its own cost ON
+TOP of the slack it was meant to hide. Do not re-attempt one. The `MTLResidencySet` pin
+(`DASLLAMA_METAL_RESIDENCY`, on by default) is the ONE measured partial: it holds the
+short-window case (the tower's first submission after its CPU stem, −15 ms/encode) but not
+long windows. The structural fixes are removing the CPU phase (serve encoders on the GPU —
+the Metal tower) and the tracking audit. Related, same ledger: merely arming Metal makes a
+CPU q8 tower encode ~1.7x slower — mechanism unnamed, deleted by a GPU-served tower.
 
 ---
 

--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -84,7 +84,7 @@ Apple GPU backend. Absent on non-Apple builds, where setting them does nothing.
 | `DASLLAMA_METAL_GEMV_TG` | number | 4 | Rows per GEMV threadgroup, clamped 1..32. |
 | `DASLLAMA_METAL_KQ_B8` | flag | on | Single-pass B8 twin for K-quant small-batch mv at B=5..8; 0 is the A/B rail. |
 | `DASLLAMA_METAL_KV_MIRROR_MB` | number | 4096 | Ceiling in MiB for the device-side KV mirror, clamped 64..4096. |
-| `DASLLAMA_METAL_RESIDENCY` | flag | on | Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~40 ms on an image turn); 0 is the A/B rail. |
+| `DASLLAMA_METAL_RESIDENCY` | flag | on | Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~15 ms/encode on the M1 Max released-rig image cell; ARCHITECTURE.md 2.12); 0 is the A/B rail. |
 | `DASLLAMA_METAL_HAZARD_PARANOID` | flag | off | Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect). |
 | `DASLLAMA_METAL_HAZARD_STRICT` | flag | off | Treat every detected hazard as strict, widening barriers (correctness bisect). |
 | `DASLLAMA_METAL_PIPE_DEBUG` | flag | off | Per-step pipeline trace: GPU envelope and true inter-step handoff idle, first steps plus outliers. |

--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -84,6 +84,7 @@ Apple GPU backend. Absent on non-Apple builds, where setting them does nothing.
 | `DASLLAMA_METAL_GEMV_TG` | number | 4 | Rows per GEMV threadgroup, clamped 1..32. |
 | `DASLLAMA_METAL_KQ_B8` | flag | on | Single-pass B8 twin for K-quant small-batch mv at B=5..8; 0 is the A/B rail. |
 | `DASLLAMA_METAL_KV_MIRROR_MB` | number | 4096 | Ceiling in MiB for the device-side KV mirror, clamped 64..4096. |
+| `DASLLAMA_METAL_RESIDENCY` | flag | on | Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~40 ms on an image turn); 0 is the A/B rail. |
 | `DASLLAMA_METAL_HAZARD_PARANOID` | flag | off | Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect). |
 | `DASLLAMA_METAL_HAZARD_STRICT` | flag | off | Treat every detected hazard as strict, widening barriers (correctness bisect). |
 | `DASLLAMA_METAL_PIPE_DEBUG` | flag | off | Per-step pipeline trace: GPU envelope and true inter-step handoff idle, first steps plus outliers. |

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -12,6 +12,29 @@ what it costs today and what the fix would change.
 
 ## Entries
 
+- **OPEN — the qwen Metal image-turn pp reds are the CPU encode's aftermath (measured
+  2026-08-23, M1 Max, the slice-M dig; plan: `qwen3vl_plan.md` slice M).** Record-grade
+  `img:pp` das/lcpp on the honest walk: 3B −12%, 4B −16%, 8B −29%, 30B MoE −41% (unprobed)
+  — while das TEXT prefill at the same padded M is at parity (4B +2.7%, 8B −6.2%) and the
+  whole image-eval machinery (wide ds rows, mrope tables, span mask) prices +10 ms. The
+  mechanism: after the multi-second CPU tower encode, the first ~70 ms (8B; scales with
+  bandwidth demand) of sustained GPU work runs degraded — a memory/GPU governor ramp.
+  Refuted by probe: driver wake (empty cb round-trips in 0.107 ms), MTLResidencySet pinning
+  (146 buffers, zero effect — implemented and reverted), per-page faults (page-touch kernel
+  repays nothing), light pulse-trains through the burn. Only full-weight-stream work absorbs
+  it (a 1-token decode: 100 ms after-burn vs 28 warm), i.e. the ramp rides whatever heavy
+  work comes first — no warm-up can net-win. **The fix is the deferred Metal tower for the
+  qwen ViTs** (also deletes the 2-12 s CPU encodes and the open 1.7x metal-armed-CPU-encode
+  anomaly below). Until a family's tower serves on GPU (qwen25v exact-only, the conformer
+  audio encoders), its media-turn pp keeps the ramp.
+
+- **OPEN — arming Metal makes the CPU q8 tower encode ~1.7x slower (measured 2026-08-23,
+  M1 Max, 8B qwen3v tower: 3.26-3.45 s with MetalMode.required vs 1.90 s on the CPU leg,
+  same t=8).** Reproduces in a quiet -jit probe, so it is not the bench harness. Mechanism
+  unnamed — worker placement / QoS when the Metal queue is live is the suspect class.
+  Costs every Metal-leg image cell ~1.4-1.6 s of encode today; the Metal tower deletes the
+  arm entirely, but the mechanism matters wherever a CPU encoder coexists with Metal serving.
+
 - **RULED AND LANDED — the spliced image prefill trailed llama.cpp on Metal; the fused span
   eval closed it (measured 2026-08-21, M1 Max, the fused-image-span arc).** The record-grade
   gap was das/lcpp **0.52–0.62×** `img:pp` across all three vision models (E2B 687 vs 1101,

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -12,25 +12,29 @@ what it costs today and what the fix would change.
 
 ## Entries
 
-- **OPEN — the qwen Metal image-turn pp reds are the CPU encode's aftermath (measured
-  2026-08-23, M1 Max, the slice-M dig; plan: `qwen3vl_plan.md` slice M).** Record-grade
-  `img:pp` das/lcpp on the honest walk: 3B −12%, 4B −16%, 8B −29%, 30B MoE −41% (unprobed)
-  — while das TEXT prefill at the same padded M is at parity (4B +2.7%, 8B −6.2%) and the
-  whole image-eval machinery (wide ds rows, mrope tables, span mask) prices +10 ms. The
-  mechanism: after the multi-second CPU tower encode, the first ~70 ms (8B; scales with
-  bandwidth demand) of sustained GPU work runs degraded — a memory/GPU governor ramp.
-  Refuted by probe: driver wake (empty cb round-trips in 0.107 ms), MTLResidencySet pinning
-  (146 buffers, zero effect — implemented and reverted), per-page faults (page-touch kernel
-  repays nothing), light pulse-trains through the burn. Only full-weight-stream work absorbs
-  it (a 1-token decode: 100 ms after-burn vs 28 warm), i.e. the ramp rides whatever heavy
-  work comes first — no warm-up can net-win. **The fix is the deferred Metal tower for the
-  qwen ViTs** (also deletes the 2-12 s CPU encodes and the open 1.7x metal-armed-CPU-encode
-  anomaly below). Until a family's tower serves on GPU (qwen25v exact-only, the conformer
-  audio encoders), its media-turn pp keeps the ramp.
+- **OPEN (narrowed by slice J) — the first Metal submission after a CPU-only window repays
+  the per-commit tracked-set pass (measured 2026-08-23, M1 Max; probes = quiet `-jit` runs
+  with the rig's tune manifest, cells = the released `lcpp_bench` exe, `--image --image-think
+  -r 3 -t 8 --ngl 99`; plan: `qwen3vl_plan.md` slices M/J).** The pre-J reds (released-rig
+  cells: 3B −12%, 4B −16%, 8B −29%, 30B −41%) were mostly this: das TEXT prefill at the same
+  padded M is at parity (rig `-p` + `--ref`: 4B +2.7%, 8B −6.2%) and the whole image-eval
+  machinery prices +10 ms (probe). The slice-J Metal tower deleted the multi-second CPU
+  encode burns; the residual (post-J rig cells: 4B/8B −16%, 30B −5%) is a ~40 ms one-time
+  commit→execution slack after ANY CPU-only window. Refuted by probe: driver wake (empty cb
+  round-trips 0.107 ms), per-page faults, light pulse-trains, denormals, affinity, cb-split
+  counts, queue identity. The MTLResidencySet pin (shipped, `DASLLAMA_METAL_RESIDENCY`)
+  holds the SHORT-window case — released-rig A/B ×2: encode 177/180 ms pinned vs 194/194
+  unpinned on the 4B image cell — but not long windows; making the prefill pools untracked
+  reds `test_metal_prefill_parity`, so the tracking is load-bearing. **The scoped fix is a
+  per-buffer tracking audit** (which pool buffers need Metal's tracker vs the capture rail's
+  own barriers). Until then, media-turn pp keeps the slack wherever a CPU window precedes
+  the prefill (qwen25v exact-only and the conformer audio encoders keep the full CPU-burn
+  form).
 
 - **OPEN — arming Metal makes the CPU q8 tower encode ~1.7x slower (measured 2026-08-23,
   M1 Max, 8B qwen3v tower: 3.26-3.45 s with MetalMode.required vs 1.90 s on the CPU leg,
-  same t=8).** Reproduces in a quiet -jit probe, so it is not the bench harness. Mechanism
+  same t=8; probe = a quiet `-jit` run with the rig's tune manifest, leg = the released
+  `lcpp_bench` exe).** Reproduces in the quiet probe, so it is not the bench harness. Mechanism
   unnamed — worker placement / QoS when the Metal queue is live is the suspect class.
   Costs every Metal-leg image cell ~1.4-1.6 s of encode today; the Metal tower deletes the
   arm entirely, but the mechanism matters wherever a CPU encoder coexists with Metal serving.

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -16,7 +16,7 @@ mmproj, or an image or audio fixture) a recorded row or manifest pins, answers t
 `performance/REVIEW.md`.** A test or tool merely opening a stocked model file by name does
 not route.
 
-**Every `dasllama/` change applies `tests/REVIEW.md` for the test obligation it names.**
+**Every `dasllama/` change applies `tests/REVIEW.md`.**
 
 **A GPU kernel, driver, dispatch-class, or K/V-mirror change applies `REVIEW_GPU.md`.**
 
@@ -40,20 +40,22 @@ not thereby pick up the other modality's checklist.
 **A routed file applies BOTH the checklist it routes to and this one; every other file under
 `modules/dasLLAMA/` applies this one.**
 
-**Any kernel work bumps `DASLLAMA_VERSION` (`dasllama/dasllama_version.das`) in the same change.** Kernel
-work is whatever changes the compiled compute a sidecar's winners were measured over: a kernel
-body, a variant set, or a `[tune]` / `[tune_perm]` / `[tune_companion]` grid. `[tune_scope]`
-metadata (`covers=`, `tuner=`, `version_of=`) is not kernel work.
+**Any kernel work bumps `DASLLAMA_VERSION` (`dasllama/dasllama_version.das`) in the same
+change.** Kernel work is whatever changes the generated kernel source, or the set of compiled
+pipeline variants (PSOs) built from it — a kernel body, a variant set, or a `[tune]` /
+`[tune_perm]` / `[tune_companion]` grid. A host-side bind or dispatch-argument change (an
+`@off` binding, a uniform value) is not, and neither is `[tune_scope]` metadata (`covers=`,
+`tuner=`, `version_of=`).
 
 **A `DASLLAMA_VERSION` bump with neither the kernel roster — the set of `[tune]`-scoped
 kernels a sidecar carries winners for — nor sidecar interchangeability changed is a
 defect**: equal versions mean an equal kernel roster and an interchangeable sidecar set
 (the exchange keys validity on version and box).
 
-**A kernel's shape is compile-time; only its data is runtime.** For a given compiled kernel, can
-this value change between dispatches? If yes it is data and belongs in a uniform or a kargs
-struct; if no it is shape and must not reach the kernel as a uniform, a kargs field, or a
-helper parameter.
+**A kernel's shape is compile-time; only its data is runtime.** For a given compiled kernel,
+can this value change between dispatches? If yes it is data and belongs in a uniform, a kargs
+field, or an `@off` bind offset; if no it is shape and must not reach the kernel as a uniform,
+a kargs field, an `@off` bind offset, or a helper parameter.
 
 **Peak memory wins ties against load cost.** A change to an allocation reached from a load,
 bake, or convert path (judge a shared helper at each call site) that trades footprint for speed
@@ -105,10 +107,9 @@ EXECUTED, not skipped.**
 **An override announces itself where it changes the outcome.** An override is an environment
 knob or an exported runtime setter that moves a gate, policy, or threshold off its default;
 a CLI flag is never an override under this rule. Where one changes an observable outcome of
-the run — what it measures, writes, reads, or mints — a printed line names it by its own
-spelling (the env variable name, or the setter's function name); set-but-inert stays silent,
-per-site repeats are fine. Adding one, or giving one a new effect, without the announce is a
-defect.
+the run — what it writes, reads, or mints — a printed line names it by its own spelling (the
+env variable name, or the setter's function name); set-but-inert stays silent, per-site
+repeats are fine. Adding one, or giving one a new effect, without the announce is a defect.
 
 **A self-measured served-turn time — tok/s, a turn wall — entering
 `performance/records/<box>.json` or `PERF_LEDGER.md` comes from the released `lcpp_bench`
@@ -119,8 +120,10 @@ tutorial's printed wall-clock is teaching output, feeding no board.
 
 **A new servable capability gets its cell in the same change**: a board row spawned by
 `performance/gen_bench_records.das`, or a manual `benchmarks/lcpp_bench.das` cell with its own
-`PROFILE.md` section. A modality, a family, or a serving path a user can wait on counts; a new
-family inside an existing cell owes a recorded row on at least one box.
+`PROFILE.md` section. A servable capability is a modality, a family, or a serving path — a
+lane a user's turn can be served through, a q8 or f32 serving lane and a GPU tower included;
+a new family or serving path landing inside an existing cell re-mints that cell's row on at
+least one box instead.
 
 **A timing figure describing a served turn as a whole — tok/s, latency, a whole-turn model
 or engine comparison — is a defect wherever it is written down with no cell behind it: a
@@ -131,9 +134,10 @@ delta, a noise floor, tuner timing — is settled by the sidecar or manifest sta
 
 **A figure measuring one engine stage inside a served turn — a stage wall, a stage share, a
 stage speedup, or a cross-engine comparison of one stage; never a board cell's `pp`/`tg`
-rate — names the harness and flags that produced it in the same sentence (a table heading
-naming them covers its rows), wherever it is written down: a checked-in doc, a ledger, a
-code comment, or a PR description.**
+rate — names the harness and flags that produced it, wherever it is written down: a
+checked-in doc, a ledger, a code comment, or a PR description.** The naming rides the
+figure's own sentence, a table heading that covers the table's rows, or a section-level
+provenance line that covers the paragraphs under it.
 
 **Runtime serves weights out of a mapped `.dlim`.** A live carrier's planes point into
 `parse_image`'s mapping, and going live does no real work — repacking, quantizing, folding,
@@ -227,8 +231,7 @@ which file is the checklist's own).
 **A disk-order → compute-order transform lands per scope: kernel-layout in
 `dasllama/dasllama_repack.das`, load-scope in `dasllama/dasllama_layout.das`.**
 
-**When placement rules disagree on one function, `ARCHITECTURE.md` §1's charter decides; a
-diff that adds or moves such a function lands the charter line with it.**
+**When placement rules disagree on one function, `ARCHITECTURE.md` §1's charter decides.**
 
 **A CPU KV-cache store, read, score dot, or V-accumulate lands in `dasllama/dasllama_kv_codec.das`,
 its format family kept whole.** GPU twins land in their backend kernel file.
@@ -258,13 +261,15 @@ file** — a single-caller helper sanctioned as tower-worthy is ledgered on `ARC
 
 **On the lane that serves the file's own planes, a weight plane's element type follows its
 SOURCE tensors, per weight region — the set of source tensors a carrier stores in one plane
-(a block stack, a merger/projector).** A
-carrier picks each weight region's plane type from that region's own tensors (a shipped
-file mixes types across regions), refuses a weight region whose tensors disagree in a
-message naming the offending tensor and both element types, and never converts silently. A
-lane that requantizes those planes (a q8 block-GEMM lane) is a separate flavor under its own
-image tag, and the load that picks it prints which lane it picked — not a silent conversion
-of the file's own planes.
+(a block stack, a merger/projector).**
+
+**A weight region — the set of source tensors a carrier stores in one plane — whose source
+tensors disagree on element type is refused in a message naming the offending tensor and
+both element types.**
+
+**A lane that requantizes or converts the file's planes (a q8 block-GEMM lane, an f32
+serving restage) is a separate flavor under its own image identity, and the load that picks
+it prints which lane it picked.**
 
 **A harness that prints output for another tool to compare fails loudly when it has nothing to
 print.** A run that ends without its comparison lines — wrong flags, failed load — exits

--- a/modules/dasLLAMA/REVIEW_GPU.md
+++ b/modules/dasLLAMA/REVIEW_GPU.md
@@ -55,11 +55,14 @@ not count.
 **A cache keyed by a host address carries the span and the form in its key.** A hit must cover
 the request, and different upload forms live in separate tables.
 
-**A backend-only capability goes in that backend's file for the matching role** — the
-per-role files every backend has a twin of: the kernel home, `_common` (device state and
-plumbing), `_decode`, `_prefill`, `_shapes` (portable servability gates), and the
-kernel-access lens. A capability with no matching role gets its own role file; anything else
-is a grab-bag, and a grab-bag file is a defect.
+**A backend-only capability goes in that backend's file for the matching role.** The roles a
+backend's files partition into: the kernel home (`_kernels` on Metal, `_classes` on Vulkan),
+`_common` (device state and plumbing), `_decode`, `_prefill`, `_shapes` (portable
+servability gates), `_tower` (the encoder-tower driver), `_asr_dec` (the ASR-decoder
+driver), and the kernel-access lens (`_lens` on Metal, `_dispatch` on Vulkan); a backend
+carries a role's file only once it has the capability. A capability with no matching role
+gets its own role file — and adds its role to this list and to `ARCHITECTURE.md` §1.5 in
+the same change; anything else is a grab-bag, and a grab-bag file is a defect.
 
 **A GPU family shares ONE device and queue from `dasllama/dasllama_<gpu>_common.das`'s
 init.** A module creating its own is a defect.
@@ -81,9 +84,10 @@ per driver.** A string-typed metal decline is a defect.
 **Decline counting lives in `dasllama/dasllama_metal_common.das`.** A counter beside the
 decline site is a defect.
 
-**A diff that adds or removes a Metal-only or Vulkan-only hook, role, or served path lands its
-`ARCHITECTURE.md` §1.5 edit in the same change — including when §1.5 already carries that class
-of asymmetry, and including §1.5's per-driver lists of registered hooks and borrowed kernels.**
+**A diff that adds, removes, or changes the mechanism of a Metal-only or Vulkan-only hook,
+role, served path, or backend-only capability lands its `ARCHITECTURE.md` §1.5 edit in the
+same change — including when §1.5 already carries that class of asymmetry, and including
+§1.5's per-driver lists of registered hooks and borrowed kernels.**
 §1.5 is the closed list; an asymmetry it does not carry does not exist.
 
 **A Vulkan pipeline is created only by a `[vk_dispatch]`-generated `ensure_*` and torn down by
@@ -92,32 +96,31 @@ of asymmetry, and including §1.5's per-driver lists of registered hooks and bor
 **A buffer bound as one SSBO range stays under `vk_max_storage_range()`, checked where its size
 is NEGOTIATED, not where it binds.** The bind site cannot shrink a buffer that was sized wrong.
 
-**A change to a GPU decode or prefill driver — `dasllama/dasllama_metal_decode.das`,
+**A change to a GPU decode or prefill driver (`dasllama/dasllama_metal_decode.das`,
 `dasllama/dasllama_metal_prefill.das`, `dasllama/dasllama_vulkan_decode.das`,
-`dasllama/dasllama_vulkan_prefill.das`, the servability gate that admits models to them
-(`dasllama/dasllama_metal_shapes.das`), or the resident rail in
-`dasllama/dasllama_gpu_resident.das` (`resident_upload`, `resident_plan`, and the decode,
-batch-decode and prefill overrides it registers) — ships with `harness/parity.das` GPU-vs-CPU
-runs on one q8 and one kq model, with `--kv` matching the armed mirror codec.** The Metal arm is
-`--ngl`; the vulkan arm is `DASLLAMA_GPU=1`, never `--ngl`, and its driver declines
-codec-mismatched sessions silently, so that log must show `resident driver armed`.
+`dasllama/dasllama_vulkan_prefill.das`), to the servability gates in
+`dasllama/dasllama_metal_shapes.das`, or to the residency rail's serving paths in
+`dasllama/dasllama_gpu_resident.das` — the upload, plan, and decode/batch-decode/prefill
+override paths a session runs through, never the bake paths — ships `harness/parity.das`
+GPU-vs-CPU runs on one q8 and one kq model, with `--kv` matching the armed mirror codec.**
 
-**A change to the tower driver `dasllama/dasllama_metal_tower.das` — or to the `AttnArgs`
-kargs struct, or to any kernel class dispatched through `enc_qk_mm`, `enc_softmax`,
-`enc_av_mm`, `pf_enc_bf16_mm`, or `enc_add_bias_rows` — ships two runs: the per-family GPU
-oracle gates `tests/test_gemma4uv.das`, `tests/test_gemma4v.das`, and `tests/test_gemma3v.das`,
-for every family the changed code is reachable from and all three when the change touches
-state or setup the whole driver shares rather than one family's path (any module-level
-`g_tw_*` variable in that file, `metal_tower_init`, or `dasllama_metal_tower_register`); and
-a `tests/test_model_image.das` run with the `mtower` arm, with `metal_tower_stats()`'s encode
-count rising across the run.** The image run is the parity instrument for the families no
-per-family gate file covers.
+**A `harness/parity.das` run arms its backend: the Metal arm is `--ngl`; the Vulkan arm is
+`DASLLAMA_GPU=1`, never `--ngl`, and its log shows `resident driver armed`.** The Vulkan
+driver declines codec-mismatched sessions silently.
 
-**A diff that adds a tower family the Metal tower driver serves — one whose bring-up
-registers a `*_gpu` hook in `dasllama/dasllama_metal_tower.das` — or gives the tower driver a
-newly borrowed kernel class or kargs struct, adds that family's per-family GPU oracle gate
-file, or that borrowed name, in the same change, to the trigger of the rule in this
-checklist that requires the per-family GPU oracle gates and the `mtower` image run.**
+**A change to `dasllama/dasllama_metal_tower.das`, to the `AttnArgs` kargs struct, or to any
+kernel class the tower dispatches — the builders its own kernel classes declare, plus the
+prefill builders it borrows (`enc_qk_mm`, `enc_softmax`, `enc_av_mm`, `pf_enc_bf16_mm`,
+`enc_add_bias_rows`, `enc_rope`) — ships the per-family GPU oracle gate of every family the
+changed code is reachable from (`tests/test_gemma4uv.das`, `tests/test_gemma4v.das`,
+`tests/test_gemma3v.das`, `test_qwen3v_tier1_metal` in `tests/test_qwen3v.das`), ALL of them
+when the change touches state or setup the whole driver shares (any module-level `g_tw_*`
+variable, `metal_tower_init`, or `dasllama_metal_tower_register`); and a
+`tests/test_model_image.das` run with the `mtower` arm, with `metal_tower_stats()`'s encode
+count rising across the run.** A `register_<fam>_gpu` call in `dasllama_metal_tower_register`
+where `dasllama/dasllama_<fam>.das` is a family file names a family; a registered family whose
+gate file this rule does not name, and a prefill builder the tower borrows that this rule
+does not name, are the rule's defects to fix in the same change.
 
 **A change to the bake-trim path in `dasllama/dasllama_gpu_resident.das` (`trim_model_planes`)
 ships a `dasllama-convert --trim` bake plus a serve of the trimmed image, on one q8 and one kq

--- a/modules/dasLLAMA/REVIEW_VISION.md
+++ b/modules/dasLLAMA/REVIEW_VISION.md
@@ -3,12 +3,12 @@
 **Read `REVIEW_COMMON.md` (repo root) first — its contract binds this checklist.** Architecture
 doc: `ARCHITECTURE.md`.
 
-**Routed from `REVIEW.md`: a diff touching `dasllama/dasllama_vision.das`,
-`dasllama/dasllama_vision_io.das`, `dasllama/dasllama_vision_embedder.das`,
-`dasllama/dasllama_tower.das` (the shared encoder-tower home), a vision family file — one
-`dasllama/dasllama_<family>.das` holding a single vision projector family — or an in-process
-path that splices decoded media into a prompt or schedules such a stream, applies this list
-with the master's.**
+**This checklist governs `dasllama/dasllama_vision.das`, `dasllama/dasllama_vision_io.das`,
+`dasllama/dasllama_vision_embedder.das`, `dasllama/dasllama_tower.das` (the shared
+encoder-tower home), a vision family file — one `dasllama/dasllama_<family>.das` holding a
+single vision projector family — and any path that runs inside the program under review, not
+a spawned child process, and splices or schedules a stream carrying decoded media — pixels
+or audio samples; routed files apply this list with `REVIEW.md`'s.**
 
 **A GEMM in a vision family file goes through a shared batch-GEMM entry point — `mm_blob_b`,
 `mm_bf16_b`, `mm_plane_b` (`dasllama/dasllama_tower.das`) or `matmul_q8q8_batch`
@@ -18,7 +18,9 @@ with the master's.**
 carries `@exact_size` when its size follows the input — patch count, pixel count, clip
 frames — and `@scratch` when it is reused across encodes rather than freshly allocated; a
 buffer that is both carries both.** The annotation goes on the declaration, or on the callee
-parameter it grows through. A nolint where an annotation fits is a defect.
+parameter it grows through; a buffer grown ONLY through such a callee — one whose parameter
+carries `@scratch` and that reserves before it resizes — carries none of its own. A nolint
+where an annotation fits is a defect.
 
 **A debug or profiling leg in `dasllama/dasllama_vision_embedder.das` or a vision family file
 is `[cold_path]`.** A nolint where it fits is a defect.
@@ -42,8 +44,10 @@ loop, or splitting command buffers per layer, is not a split, and whether the on
 carries the surrounding head and tail tokens is free.
 
 **A media splice is expressed as two token spans plus a row block, everywhere it appears** — so
-BPE merges never cross the media. The engine, the scheduler, and the server all carry the same
-shape; any other representation at the seam is a defect.
+BPE merges never cross the media. Any other representation at the seam is a defect.
+
+**A change to the media row-block shape re-checks every out-of-module carrier of that shape
+in the same change** — `utils/dasllama-server/openai_server.das`.
 
 **A family gaining an arm for a media kind reaches the layer stack only through
 `forward_prefill_embd`** — a second prefill BODY for it is a defect; a sibling

--- a/modules/dasLLAMA/benchmarks/REVIEW.md
+++ b/modules/dasLLAMA/benchmarks/REVIEW.md
@@ -3,12 +3,11 @@
 **Read `REVIEW_COMMON.md` (repo root) first — its contract binds this checklist.** Architecture
 doc: `../PROFILE.md`.
 
-**A timed rep that runs model or tower kernels — any `eval*` / `generate*` / `forward*` call
-on a `Model`, or any `encode_image*` / `encode_audio*` call on a vision or audio embedder or
-tower, all under `../dasllama/` — calls `tune_gate()` (`../performance/profile_common.das`)
-before its first timed rep**, or it measures fallback kernels silently. Tokenizing and
-detokenizing (`encode` / `encode_` / `decode` / `decode_`, on a `Model` or a `Tokenizer`)
-are not forward passes.
+**A timed rep that runs a forward pass — decoder or encoder kernels, however the rep enters
+them, the shipped facades (`respond_`, `transcribe`) included — calls `tune_gate()`
+(`../performance/profile_common.das`) before its first timed rep**, or it measures fallback
+kernels silently. Tokenizing and detokenizing (`encode` / `encode_` / `decode` / `decode_`,
+on a `Model` or a `Tokenizer`) run no forward pass.
 
 **A kernel A/B lab — a rig whose output selects between two implementations of the same
 compute — times both variants interleaved in one process with one instrument.** A board bench
@@ -43,6 +42,7 @@ tool on a board workload.
 **A number derived by subtracting one measured wall from another prints both raw walls, not
 only the difference.**
 
-**A change to the corpus input of the `--tok` measurement cell (`lcpp_bench.das`) ships
-before/after `--tok` rows from `lcpp_bench.das --tok` for each affected corpus, or a
-statement that the corpus bytes are unchanged.**
+**A change to the timed body or the measured input of a cell whose numbers are reported as
+evidence — a cell that mints rows into `../performance/records/<box>.json`, or the `--tok`
+ladder (`lcpp_bench.das`) — ships comparable before/after rows for each affected cell and
+corpus, or a statement that the measured quantity is unchanged.**

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -452,41 +452,17 @@ def private measure_image_turn(var m : Model; emb : VisionEmbedder; img : Vision
         r.enc_ms = min(r.enc_ms, double(get_time_usec(t_enc)) / 1000.0lf)
         var chat <- create_chat_(m, "", int64(image_turn_steps()))
         set_thinking_(chat, think)   // default off: the timed shape is the answer, not a scratchpad
+        // the SHIPPED walk end to end: the rows seam takes the pre-encoded (possibly
+        // deepstack-wide) rows, respond_ assembles the quantum and runs the stop protocol —
+        // nothing here re-derives what the chat layer already owns
+        add_user_image_rows_(m, chat, rows, r.n_rows, vision_mrope_grid(emb, st))
         add_user_(chat, prompt)
-        var head : array<int64>
-        var tail : array<int64>
-        render_turn_image_(m, chat, head, tail)
-        let dim = m.config.dim
-        let n_head = long_length(head)
-        let npos = n_head + r.n_rows + long_length(tail)
-        var inscope embd : array<float>
-        embd |> ensure_capacity(npos * dim)
-        embd |> resize(npos * dim)
-        embed_text_rows(m, head, embd, 0l)
-        for (i in range64(r.n_rows * dim)) {
-            embd[n_head * dim + i] = rows[i]
-        }
-        embed_text_rows(m, tail, embd, n_head + r.n_rows)
-        var parts : array<string>
-        // the same stop protocol respond_ runs: without it a stray channel marker rides into the
-        // timed text, and the row would price a reply the product would never have shown
-        var stops <- effective_stop_ids_(chat)
-        generate_embd_(m, chat.session, embd, npos, SamplingParams(), int64(image_turn_steps()), n_head, n_head + r.n_rows, vision_mrope_grid(emb, st)) $(id, piece) {
-            for (sid in stops) {
-                return false if (id == sid)
-            }
-            parts |> push(piece)
+        r.text = respond_(m, chat, SamplingParams()) $(_piece : string) {
             return true
         }
-        delete stops
         let sres = stats_(chat.session)
         r.pp_tok_s = max(r.pp_tok_s, sres.prefill_tps)
         r.tg_tok_s = max(r.tg_tok_s, sres.gen_tps)
-        r.text = join(parts, "")
-        delete parts
-        delete embd
-        delete head
-        delete tail
         delete chat
     }
     delete rows

--- a/modules/dasLLAMA/benchmarks/lcpp_bench.das
+++ b/modules/dasLLAMA/benchmarks/lcpp_bench.das
@@ -22,7 +22,7 @@ require dasllama/dasllama_chat   // --image: the chat renderer + the two-span im
 require dasllama/dasllama_vision_embedder   // --image: the vision embedder (any family) + encode_image_
 require dasllama/dasllama_vision   // --image: VisionImage — the decoded-pixel carrier
 require dasllama/dasllama_vision_io   // --image: decode the picture to RGB8
-require dasllama/dasllama_sampling   // --image: generate_embd_ over the spliced prompt
+require dasllama/dasllama_sampling   // --image: SamplingParams + stats_ around the respond_ walk
 require daslib/module_path            // get_this_module_dir — the default prompt corpus beside this bench
 require daslib/jobque_profile   // JOBQUE_PROFILING_ENABLED — --prof refuses on a build without the marker rail
 require ?das_accelerate dasllama/dasllama_math_accelerate   // the --accel leg; Apple-only C++ module

--- a/modules/dasLLAMA/dasllama/dasllama_blocks.das
+++ b/modules/dasLLAMA/dasllama/dasllama_blocks.das
@@ -1535,19 +1535,13 @@ def forward_prefill_embd(t : Model; var s : Session; embd : array<float>; npos, 
     let dim = t.config.dim
     let ts_embed = prof_ticks()
     if (ds_wide) {
-        if (long_length(s.ds_embd) < npos * n_ds * dim) {   // inline: PERF026 can't see @scratch through reserve_resize
-            s.ds_embd |> reserve(npos * n_ds * dim)
-            s.ds_embd |> resize(npos * n_ds * dim)
+        // arm the wide BORROW instead of splitting: a wide-capable override uploads the whole
+        // quantum and extracts slices on the GPU; the CPU fallback splits via ds_split_quantum
+        unsafe {
+            s.wide_src = addr < float const? >(embd[0])
         }
-        for (r in range64(npos)) {
-            let rb = (src_off + r) * stride
-            for (i in range64(dim)) {
-                s.x_b[r * dim + i] = embd[rb + i]
-            }
-            for (i in range64(n_ds * dim)) {
-                s.ds_embd[r * n_ds * dim + i] = embd[rb + dim + i]
-            }
-        }
+        s.wide_stride = stride
+        s.wide_soff = src_off
         s.ds_active = true
     } else {
         let base = src_off * dim
@@ -1577,6 +1571,7 @@ def forward_prefill_embd(t : Model; var s : Session; embd : array<float>; npos, 
     s.attn_uniform_lo = 0l
     s.attn_uniform_end = 0l
     s.ds_active = false
+    s.wide_src = null   // the borrow dies with the call
 }
 
 //! ``embed_text_rows`` at a wider row stride (deepstack quanta): each token's dim-wide

--- a/modules/dasLLAMA/dasllama/dasllama_chat.das
+++ b/modules/dasLLAMA/dasllama/dasllama_chat.das
@@ -734,6 +734,28 @@ def add_user_image_(var c : ChatSession; img : VisionImage) {
     c.image_grid = vision_mrope_grid(c.embedder, c.embedder_scratch)
 }
 
+//! Queue PRE-ENCODED image soft-token rows (what `encode_image` emits — deepstack models:
+//! ``(1+n)·dim``-wide, length-checked) with the family's mrope `grid` ((0,0) = sequential) for
+//! the next respond(). MOVES `rows`; works on a plain chat — no embedder needed.
+def add_user_image_rows_(m : Model; var c : ChatSession; var rows : array<float>; n_rows : int64; grid : int2) {
+    if (c.n_image_rows > 0l) {
+        panic("dasLLAMA chat: one image per turn in v1 - respond() before adding another")
+    }
+    if (c.n_audio_rows > 0l) {
+        panic("dasLLAMA chat: audio already queued this turn - one media kind per turn")
+    }
+    if (empty(c.tmpl.image_pre.parts) || !image_vocab_ok(m, c.tmpl)) {
+        panic("dasLLAMA chat: this model's chat template declares no usable image span markers - it has no vision arm")
+    }
+    let rw = m.config.dim * (1l + m.config.n_deepstack)
+    if (long_length(rows) != n_rows * rw) {
+        panic("dasLLAMA chat: {n_rows} image rows need {n_rows * rw} floats ({m.config.n_deepstack} deepstack slices at dim {m.config.dim}), got {length(rows)}")
+    }
+    c.image_rows <- rows
+    c.n_image_rows = n_rows
+    c.image_grid = grid
+}
+
 //! Queue audio (16 kHz mono f32 PCM) for the next respond() — encoded to soft tokens NOW,
 //! spliced at the head of the next user turn (before its text). Composes with add_user in the
 //! same turn; call inside with_job_que() (the encoder threads its kernels).

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1713,6 +1713,12 @@ struct Session {
     // [npos × n_deepstack·dim] — slice l adds to x_b after layer l while ds_active
     @scratch ds_embd : array<float>
     ds_active : bool
+    // transient, one prefill call: a BORROWED view of the caller's wide quantum (row stride
+    // wide_stride, first row wide_soff) — a wide-capable override uploads it whole and
+    // extracts slices on the GPU; the CPU fallback splits it via ds_split_quantum
+    @do_not_delete wide_src : float const?   // a borrow, never owned
+    wide_stride : int64
+    wide_soff : int64
     // MoE scratch (sized in make_run_state when n_expert > 0; empty for dense arches)
     moe_logits : array<float>   // router logits, then probs (n_expert)
     moe_w : array<float>        // the selected top-k weights (n_expert_used)
@@ -4817,6 +4823,29 @@ def forward_prefill_alloc(t : Model; var s : Session; npos, start_pos : int64) {
 }
 
 // the deepstack add: x_b[r] += ds[r][slice l] for every row (dst dim-wide, ds n_ds·dim-wide)
+//! Split a borrowed wide quantum (`Session.wide_src`) into `x_b` + row-major `ds_embd` — the
+//! CPU-side half of the wide-borrow contract; a no-op with no borrow armed.
+def ds_split_quantum(t : Model; var s : Session; npos : int64) {
+    if (s.wide_src == null) {
+        return
+    }
+    let dim = t.config.dim
+    let n_ds = t.config.n_deepstack
+    let stride = s.wide_stride
+    if (long_length(s.ds_embd) < npos * n_ds * dim) {   // inline: PERF026 can't see @scratch through reserve_resize
+        s.ds_embd |> reserve(npos * n_ds * dim)
+        s.ds_embd |> resize(npos * n_ds * dim)
+    }
+    unsafe {
+        let src = s.wide_src
+        for (r in range64(npos)) {
+            let rb = (s.wide_soff + r) * stride
+            copy_floats(addr(s.x_b[r * dim]), src + rb, dim)
+            copy_floats(addr(s.ds_embd[r * n_ds * dim]), src + rb + dim, n_ds * dim)
+        }
+    }
+}
+
 def private ds_add_slice(var x_b : array<float>; ds : array<float>; l, n_ds, dim, npos : int64) {
     unsafe {
         var xp = addr(x_b[0])
@@ -4882,6 +4911,11 @@ def forward_prefill_body(t : Model; var s : Session; npos, start_pos : int64; sk
         stack_done = invoke(g_prefill_override, t, s, npos, start_pos)
     }
     if (!stack_done) {
+        if (s.ds_active && s.wide_src != null) {   // the wide borrow was for an override that declined
+            let ts_split = prof_ticks()
+            ds_split_quantum(t, s, npos)
+            prof_add("embed", ts_split)
+        }
         blob_only_panic(t, "prefill stack")
         // Metal-capable build about to chew a real prompt on the CPU stack — the silent profiling-time sink, not a serving path; fail loud unless CPU intent was declared.
         if (npos > CPU_PREFILL_PANIC_NPOS && has_prefill_override("metal") && !cpu_prefill_allowed()) {

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -222,7 +222,7 @@ struct public MetalEnv {
     @clarg_doc = "Ceiling in MiB for the device-side KV mirror, clamped 64..4096."
     kv_mirror_mb : int = 4096
 
-    @clarg_doc = "Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~40 ms on an image turn); 0 is the A/B rail."
+    @clarg_doc = "Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~15 ms/encode on the M1 Max released-rig image cell; ARCHITECTURE.md 2.12); 0 is the A/B rail."
     residency : bool = true
 
     @clarg_doc = "Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect)."

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -222,6 +222,9 @@ struct public MetalEnv {
     @clarg_doc = "Ceiling in MiB for the device-side KV mirror, clamped 64..4096."
     kv_mirror_mb : int = 4096
 
+    @clarg_doc = "Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~40 ms on an image turn); 0 is the A/B rail."
+    residency : bool = true
+
     @clarg_doc = "Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect)."
     hazard_paranoid : bool = false
 

--- a/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
@@ -336,25 +336,7 @@ def private g3v_stage_down(m : GGUFMeta; b : array<uint8> | #; name : string; va
         tower_stage_q8_pad_cols(m, b, name, st.qblob, st.qscales, wscratch, rowscratch, wo, d, ff, fp, "dasLLAMA gemma3v q8")
         return
     }
-    if (long_length(rowscratch) < d * ff) {
-        rowscratch |> reserve(d * ff)
-        rowscratch |> resize(d * ff)
-    }
-    gguf_read_tensor_f32(m, b, name, rowscratch, 0l, d * ff)
-    g3v_expand_rows(st.blob, wo, rowscratch, d, ff, fp)
-}
-
-def private g3v_expand_rows(var dst : array<float>; at : int64; src : array<float>; rows, ff, fp : int64) {
-    unsafe {
-        var dp = addr(dst[at])
-        let sp = addr(src[0])
-        for (r in range64(rows)) {
-            memcpy(dp + r * fp, sp + r * ff, ff * 4l)
-            for (i in range64(ff, fp)) {
-                dp[r * fp + i] = 0.0
-            }
-        }
-    }
+    tower_stage_f32_pad_cols(m, b, name, st.blob, rowscratch, wo, d, ff, fp)
 }
 
 // the reads, in layout order — the per-block f32 region is ln1 w/b ln2 w/b, then the six GEMM

--- a/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gemma3v.das
@@ -315,13 +315,10 @@ def private g3v_layout(var t : Gemma3vTower; var off : int64&; var qo : int64&) 
 def private g3v_stage_up(m : GGUFMeta; b : array<uint8> | #; name : string; var st : Gemma3vStaging;
                          @scratch var wscratch : array<float>; wo : int64) {
     let d = st.t.n_embd
-    let file_n = st.t.n_ff * d
-    let served = st.t.ff_pad * d
     if (st.t.q8) {
         tower_stage_q8_zero_rows(m, b, name, st.qblob, st.qscales, wscratch, wo, st.t.n_ff, st.t.ff_pad, d, "dasLLAMA gemma3v q8")
     } else {
-        gguf_read_tensor_f32(m, b, name, st.blob, wo, file_n)
-        tower_zero_span(st.blob, wo + file_n, served - file_n)
+        tower_stage_f32_zero_rows(m, b, name, st.blob, wo, st.t.n_ff, st.t.ff_pad, d)
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -43,7 +43,7 @@ require dasllama/dasllama_load   // the GGUF load walk (load_gguf/load_model_/lo
 // config-derived. A loader change that alters which tensors load leaves a structurally VALID stale
 // image that silently represents a different model; only this version catches it. Mismatch
 // regenerates from the gguf, never migrates.
-let IMAGE_VERSION = 11   // v11: header byte 48 carries the meta-layout fingerprint (layout changes now auto-refuse)
+let IMAGE_VERSION = 12   // v12: qwen3v serves f32+ff_pad exact planes. BUMP ON ANY SERVED-LAYOUT CHANGE: the identity hashes knobs+version+tag, never offset values, so a layout change without a bump maps stale images (three strikes)
 
 //! The metal (blob-only) flavor's identity tag: q8 planes ride the 34B block_q8_0 blob and the
 //! kq scale planes their GPU forms (convert_model_to_metal_blob) — flavors are per-config and

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -43,7 +43,7 @@ require dasllama/dasllama_load   // the GGUF load walk (load_gguf/load_model_/lo
 // config-derived. A loader change that alters which tensors load leaves a structurally VALID stale
 // image that silently represents a different model; only this version catches it. Mismatch
 // regenerates from the gguf, never migrates.
-let IMAGE_VERSION = 12   // v12: qwen3v serves f32+ff_pad exact planes. BUMP ON ANY SERVED-LAYOUT CHANGE: the identity hashes knobs+version+tag, never offset values, so a layout change without a bump maps stale images (three strikes)
+let IMAGE_VERSION = 13   // v13: qwen3v serves f32+ff_pad exact planes, mergers/taps f32 too. BUMP ON ANY SERVED-LAYOUT CHANGE: the identity hashes knobs+version+tag, never offset values, so a layout change without a bump maps stale images (three strikes)
 
 //! The metal (blob-only) flavor's identity tag: q8 planes ride the 34B block_q8_0 blob and the
 //! kq scale planes their GPU forms (convert_model_to_metal_blob) — flavors are per-config and

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -558,16 +558,14 @@ def mirror_release(var mr : KVMirror) {
 //! re-initializes on the next served step; all mirrors rebuild from the CPU caches on demand.
 
 
-// ===== the residency pin (ggml-metal's model) =====
-// Metal re-validates per-commit residency over the referenced working set; the first
-// submission after a CPU-only window repays it (~40 ms on a 4B image turn, scaling with the
-// resident bytes — weights AND the recycled pool buffers). A committed+requested
-// MTLResidencySet keeps the pass a no-op; ggml-metal pins exactly this way.
+// ===== the residency pin (ggml-metal's model; the mechanism + figures: ARCHITECTURE.md 2.12) =====
+// The first submission after a CPU-only window repays the per-commit residency pass over the
+// resident bytes; a committed+requested MTLResidencySet keeps it a no-op.
 var private g_rset : MetalResidencySet?
 var private g_rset_tried = false
 var private g_rset_dirty = false
 var private g_rset_count = 0l
-var private g_rset_seen : table<uint64; bool>   // buffer handles already pinned (pool recycles re-note)
+var private @scratch g_rset_seen : table<uint64; bool>   // buffer handles already pinned - grow-only, reused across evals (pool recycles re-note)
 
 //! Pin one buffer that lives until the next reset (weight regions/planes, pool buffers — the
 //! binding has no remove, so per-session mirrors and the rebuild-prone arena stay out). Cheap
@@ -576,7 +574,7 @@ def residency_note(buf : MetalBuffer?) {
     if (buf == null || g_rset == null) {
         return
     }
-    let key = uint64(intptr(buf))
+    let key = intptr(buf)
     if (g_rset_seen?[key] ?? false) {
         return
     }
@@ -613,8 +611,8 @@ def residency_pinned : int64 => g_rset_count
 //! True when a residency set is live (knob on AND the OS serves the API — macOS 15+).
 def residency_active : bool => g_rset != null
 
-[cold_path]   // rides the region flush/teardown legs: pinned buffers are dying with the regions
-def private residency_reset {
+[cold_path]   // rides the region flush/teardown legs AND both driver shutdowns: pinned buffers die with their pools
+def residency_reset {
     if (g_rset != null) {
         metal_release(g_rset)
         g_rset = null

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -558,6 +558,90 @@ def mirror_release(var mr : KVMirror) {
 //! re-initializes on the next served step; all mirrors rebuild from the CPU caches on demand.
 
 
+// ===== the residency pin (ggml-metal's model) =====
+// Metal re-validates per-commit residency over the referenced working set; the first
+// submission after a CPU-only window repays it (~40 ms on a 4B image turn, scaling with the
+// resident bytes — weights AND the recycled pool buffers). A committed+requested
+// MTLResidencySet keeps the pass a no-op; ggml-metal pins exactly this way.
+var private g_rset : MetalResidencySet?
+var private g_rset_tried = false
+var private g_rset_dirty = false
+var private g_rset_count = 0l
+var private g_rset_seen : table<uint64; bool>   // buffer handles already pinned (pool recycles re-note)
+
+//! Pin one buffer that lives until the next reset (weight regions/planes, pool buffers — the
+//! binding has no remove, so per-session mirrors and the rebuild-prone arena stay out). Cheap
+//! and idempotent; a no-op until `residency_flush` creates the set.
+def residency_note(buf : MetalBuffer?) {
+    if (buf == null || g_rset == null) {
+        return
+    }
+    let key = uint64(intptr(buf))
+    if (g_rset_seen?[key] ?? false) {
+        return
+    }
+    metal_residency_set_add_buffer(g_rset, buf)
+    g_rset_seen[key] = true
+    g_rset_count++
+    g_rset_dirty = true
+}
+
+//! Driver-entry hook: create the set on the first served step, then commit+request any
+//! pending adds. Cheap when clean.
+def residency_flush {
+    if (g_rset == null) {
+        if (g_rset_tried || !g_env_metal.residency) {
+            return
+        }
+        g_rset_tried = true
+        g_rset = metal_new_residency_set(g_dev)
+        if (g_rset == null) {   // the API answers null below macOS 15 - stay on the old behavior
+            return
+        }
+        residency_note(g_signs)
+    }
+    if (g_rset_dirty) {
+        metal_residency_set_commit(g_rset)
+        metal_residency_set_request(g_rset)
+        g_rset_dirty = false
+    }
+}
+
+//! Buffers pinned so far (0 = off or not yet created) — the knob's test witness.
+def residency_pinned : int64 => g_rset_count
+
+//! True when a residency set is live (knob on AND the OS serves the API — macOS 15+).
+def residency_active : bool => g_rset != null
+
+[cold_path]   // rides the region flush/teardown legs: pinned buffers are dying with the regions
+def private residency_reset {
+    if (g_rset != null) {
+        metal_release(g_rset)
+        g_rset = null
+    }
+    unsafe {
+        delete g_rset_seen
+    }
+    g_rset_tried = false
+    g_rset_dirty = false
+    g_rset_count = 0l
+}
+
+//! `pool_acquire` + a residency note: the pin home for every recycled prefill/decode pool
+//! buffer (they live until drain, which rides the reset legs).
+def pool_acquire_pinned(var pool : MetalBufferPool; dev : MetalDevice?; bytes : uint64) : MetalBuffer? {
+    var b = pool_acquire(pool, dev, bytes)
+    residency_note(b)
+    return b
+}
+
+//! The untracked twin (uniforms, upload staging) — same pin, same lifecycle.
+def pool_acquire_untracked_pinned(var pool : MetalBufferPool; dev : MetalDevice?; bytes : uint64) : MetalBuffer? {
+    var b = pool_acquire_untracked(pool, dev, bytes)
+    residency_note(b)
+    return b
+}
+
 [cold_path]   // first touch (or a wider re-touch) of a region — the upload, not the per-dispatch path
 def private region_upload_new(key : uint64; src : void?; bytes : uint64) : MetalBuffer? {
     // UNTRACKED: weights are GPU-read-only (written once, before any commit) — tracking ~450 of them made scheduler dependency analysis the dominant non-GPU cost (~70ms/prefill on 3B)
@@ -565,6 +649,7 @@ def private region_upload_new(key : uint64; src : void?; bytes : uint64) : Metal
     unsafe {
         memcpy(metal_buffer_contents(buf), src, bytes)
     }
+    residency_note(buf)
     g_regions[key] = RegionEntry(buf = buf, bytes = bytes)
     return buf
 }
@@ -595,6 +680,7 @@ def private region_upload_cat3_new(key : uint64; p0 : void?; b0 : uint64; p1 : v
             memcpy(reinterpret<void?>(d + (b0 + b1)), p2, b2)
         }
     }
+    residency_note(buf)
     g_regions_cat3[key] = RegionEntry(buf = buf, bytes = b0 + b1 + b2)
     return buf
 }
@@ -644,6 +730,7 @@ def plane_buffer(dev : MetalDevice?; base : void?; bytes : uint64; mapped : bool
             }
         }
     }
+    residency_note(buf)
     g_regions[key] = RegionEntry(buf = buf, bytes = bytes)
     return buf
 }
@@ -1810,6 +1897,7 @@ def weight_caches_stale() : bool {
 
 [cold_path]   // regions release + retire drain — the shared tail of the flush/teardown legs
 def private regions_release_all {
+    residency_reset()   // pinned buffers are dying with the regions - the set goes first
     for (e in values(g_regions)) {
         if (e.buf != null) {
             metal_release(e.buf)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_decode.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_decode.das
@@ -2001,6 +2001,7 @@ def metal_decode_forward(t : Model; var s : Session; token, pos : int64) : bool 
         }
         return false
     }
+    residency_flush()   // pin/commit before the step's submission (the post-CPU-window slack)
     if (!(g_pre.valid && g_pre.uid == s.uid && g_pre.pos == pos &&
             g_pre.kdt == s.kv_dtype_k && g_pre.s16 == t.wscale_f16 &&
             g_pre.arena_epoch == g_arena_epoch)) {
@@ -2188,6 +2189,7 @@ def metal_batch_decode_forward(t : Model; var ws : BatchWorkspace; var sessions 
         }
         return false
     }
+    residency_flush()   // pin/commit before the step's submission (the post-CPU-window slack)
     // a parked single-stream pre-step may reference a batch row's mirror slice — retire it first
     discard_pre()
     // encode-ahead readiness: with a step in flight, mirror_prepare must stay on its fast path

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -4762,8 +4762,8 @@ class MetalClamp {
 // compacts the AV output back; zero pads keep both directions exact.
 [metal_dispatch(name = "enc_head_restride", pso = "g_pso_head_restride", tg = 64, grid = "total/64", params = "total : int64")]
 class MetalHeadRestride {
-    @ssbo @binding = 0 @role = "read" src : array<float>
-    @ssbo @binding = 1 @role = "write" dst : array<float>
+    @ssbo @binding = 0 @role = "read" @off = "soff" src : array<float>
+    @ssbo @binding = 1 @role = "write" @off = "doff" dst : array<float>
     @uniform @binding = 2 hs_src : uint
     @uniform @binding = 3 hs_dst : uint
     @uniform @binding = 4 total : uint   // npos * n_head * hs_dst

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -2315,6 +2315,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         }
         return false
     }
+    residency_flush()   // pin/commit before the first submission (the post-CPU-window slack)
     let ts_all = ref_time_ticks()
     let c = t.config
     let dim = c.dim
@@ -2375,12 +2376,12 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let bytes_att = uint64(n_heads * mp * nk64 * 4l)   // per-head score slabs: mp queries x nk64 keys
     let bytes_tab = uint64(npos * half * 4l)
     let bytes_tab_sw = uint64(npos * half_sw * 4l)   // the swa pair's row width is ITS class's hs/2
-    var bx = pool_acquire(g_pf_pool, g_dev, bytes_x)
-    var bxb = pool_acquire(g_pf_pool, g_dev, bytes_xb)
-    var bxb2 = pool_acquire(g_pf_pool, g_dev, bytes_x)
-    var bq = pool_acquire(g_pf_pool, g_dev, bytes_q)
-    var bhb = pool_acquire(g_pf_pool, g_dev, bytes_h)
-    var bhb2 = pool_acquire(g_pf_pool, g_dev, bytes_h)
+    var bx = pool_acquire_pinned(g_pf_pool, g_dev, bytes_x)
+    var bxb = pool_acquire_pinned(g_pf_pool, g_dev, bytes_xb)
+    var bxb2 = pool_acquire_pinned(g_pf_pool, g_dev, bytes_x)
+    var bq = pool_acquire_pinned(g_pf_pool, g_dev, bytes_q)
+    var bhb = pool_acquire_pinned(g_pf_pool, g_dev, bytes_h)
+    var bhb2 = pool_acquire_pinned(g_pf_pool, g_dev, bytes_h)
     // MoE (Wave C stage 2b): per-position routing + padded bucket panels (32-row tiles/expert);
     // g4moe adds the router-input/acc panel (bxb2 doubles as the pre_ffn2 expert input — the
     // serial encoder makes the reuse safe)
@@ -2395,16 +2396,16 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let bytes_minv = uint64(mtot * 4l)
     let bytes_mg = uint64(mpad * c.n_ff_exp * 4l)
     let bytes_mdn = uint64(mpad * dim * 4l)
-    var bmlg = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mlg) : null
-    var bmsel = moe ? pool_acquire(g_pf_pool, g_dev, bytes_msel) : null
-    var bmcnt = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mcsr) : null
-    var bmbase = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mcsr) : null
-    var bmbkt = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mbkt) : null
-    var bminv = moe ? pool_acquire(g_pf_pool, g_dev, bytes_minv) : null
-    var bmg = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mg) : null
-    var bmg2 = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mg) : null
-    var bmdn = moe ? pool_acquire(g_pf_pool, g_dev, bytes_mdn) : null
-    var bmg4rt = g4moe ? pool_acquire(g_pf_pool, g_dev, bytes_x) : null
+    var bmlg = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mlg) : null
+    var bmsel = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_msel) : null
+    var bmcnt = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mcsr) : null
+    var bmbase = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mcsr) : null
+    var bmbkt = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mbkt) : null
+    var bminv = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_minv) : null
+    var bmg = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mg) : null
+    var bmg2 = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mg) : null
+    var bmdn = moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_mdn) : null
+    var bmg4rt = g4moe ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_x) : null
     // deltanet scratch (recurrent layers) — GEMM outputs pad to mp rows like every panel
     let cd_dn = dn ? dn_conv_dim(c) : 0l
     let di_dn = dn ? c.ssm_d_inner : 0l
@@ -2413,25 +2414,35 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let bytes_dn_di = uint64(mp * di_dn * 4l)
     let bytes_dn_h = uint64(mp * nvh_dn * 4l)
     let bytes_dn_qg = uint64(mp * 2l * qd * 4l)
-    var bdnqkv = dn ? pool_acquire(g_pf_pool, g_dev, bytes_dn_cd) : null
-    var bdncv = dn ? pool_acquire(g_pf_pool, g_dev, bytes_dn_cd) : null
-    var bdnz = dn ? pool_acquire(g_pf_pool, g_dev, bytes_dn_di) : null
-    var bdno = dn ? pool_acquire(g_pf_pool, g_dev, bytes_dn_di) : null
-    var bdnb = dn ? pool_acquire(g_pf_pool, g_dev, bytes_dn_h) : null
-    var bdng = dn ? pool_acquire(g_pf_pool, g_dev, bytes_dn_h) : null
-    var bdnqg = c.q_gated ? pool_acquire(g_pf_pool, g_dev, bytes_dn_qg) : null
-    var bdngate = c.q_gated ? pool_acquire(g_pf_pool, g_dev, bytes_q) : null
-    var batt = pool_acquire(g_pf_pool, g_dev, bytes_att)
+    var bdnqkv = dn ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_cd) : null
+    var bdncv = dn ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_cd) : null
+    var bdnz = dn ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_di) : null
+    var bdno = dn ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_di) : null
+    var bdnb = dn ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_h) : null
+    var bdng = dn ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_h) : null
+    var bdnqg = c.q_gated ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_dn_qg) : null
+    var bdngate = c.q_gated ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_q) : null
+    var batt = pool_acquire_pinned(g_pf_pool, g_dev, bytes_att)
     // deepstack (qwen3vl dense): the wide quantum's tail slices upload as PER-SLICE contiguous
     // planes so the per-layer add is the existing enc_add at a slice offset — a repack, no kernel
     let nds = s.ds_active ? c.n_deepstack : 0l
+    // the wide borrow: upload the caller's quantum whole and slice it on-device (bds turns
+    // GPU-written, so it must ride the TRACKED pool); the CPU-split arm survives for the
+    // warm/MTP edge, which reads x_b host-side
+    let wide = nds > 0l && s.wide_src != null
+    let wide_stride = s.wide_stride
     let bytes_ds = uint64(npos * nds * dim * 4l)
-    var bds = nds > 0l ? pool_acquire_untracked(g_pf_upool, g_dev, bytes_ds) : null
-    var bcos = pool_acquire_untracked(g_pf_upool, g_dev, bytes_tab)
-    var bsin = pool_acquire_untracked(g_pf_upool, g_dev, bytes_tab)
+    let bytes_wide = uint64(npos * wide_stride * 4l)
+    var bds : MetalBuffer?
+    if (nds > 0l) {
+        bds = wide ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_ds) : pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_ds)
+    }
+    var bwide = wide ? pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_wide) : null
+    var bcos = pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_tab)
+    var bsin = pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_tab)
     let dual_rope = has_dual_rope(c)
-    var bcos_swa = dual_rope ? pool_acquire_untracked(g_pf_upool, g_dev, bytes_tab_sw) : null
-    var bsin_swa = dual_rope ? pool_acquire_untracked(g_pf_upool, g_dev, bytes_tab_sw) : null
+    var bcos_swa = dual_rope ? pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_tab_sw) : null
+    var bsin_swa = dual_rope ? pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_tab_sw) : null
     var bks & = unsafe(g_pf_bks)
     var bvs & = unsafe(g_pf_bvs)
     bks |> clear()
@@ -2451,8 +2462,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
             continue
         }
         let bytes_kv_l = uint64(kvrows * layer_kv_dim(c, l) * 4l)   // per-layer panels: each class's width
-        bks |> push(pool_acquire(g_pf_pool, g_dev, bytes_kv_l))
-        bvs |> push(pool_acquire(g_pf_pool, g_dev, bytes_kv_l))
+        bks |> push(pool_acquire_pinned(g_pf_pool, g_dev, bytes_kv_l))
+        bvs |> push(pool_acquire_pinned(g_pf_pool, g_dev, bytes_kv_l))
     }
     // E-series PLE: side input uploaded LAYER-major ([l][p][ple] — the flat geglu ⊙ reads layer l's
     // block at one offset); gate outputs pad to mp rows like every GEMM panel
@@ -2468,11 +2479,11 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var bple_proj : MetalBuffer?
     var bple_tok : MetalBuffer?
     if (plef) {
-        bpleg = pool_acquire(g_pf_pool, g_dev, bytes_ple_g)
+        bpleg = pool_acquire_pinned(g_pf_pool, g_dev, bytes_ple_g)
         if (ple_gpu) {
-            bple = pool_acquire(g_pf_pool, g_dev, bytes_ple_side)
-            bple_proj = pool_acquire(g_pf_pool, g_dev, bytes_ple_proj)
-            bple_tok = pool_acquire_untracked(g_pf_upool, g_dev, uint64(npos * 4l))
+            bple = pool_acquire_pinned(g_pf_pool, g_dev, bytes_ple_side)
+            bple_proj = pool_acquire_pinned(g_pf_pool, g_dev, bytes_ple_proj)
+            bple_tok = pool_acquire_untracked_pinned(g_pf_upool, g_dev, uint64(npos * 4l))
             unsafe {
                 var tp = reinterpret<uint?>(metal_buffer_contents(bple_tok))
                 for (p in range64(npos)) {
@@ -2480,7 +2491,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 }
             }
         } else {
-            bple = pool_acquire_untracked(g_pf_upool, g_dev, bytes_ple_side)
+            bple = pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_ple_side)
             unsafe {
                 // transpose s.ple_inp (position-major, p*all + l*ple) into layer-major blocks
                 var dst = reinterpret<float?>(metal_buffer_contents(bple))
@@ -2497,14 +2508,18 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     // upload the embedded rows + this prefill's rope table(s) (built for the chunk's GLOBAL
     // positions — build_rope_table takes start_pos; dual-rope: the sliding class's pair too)
     unsafe {
-        memcpy(metal_buffer_contents(bx), addr < void? >(s.x_b[0]), npos * dim * 4l)
+        if (wide) {   // ONE wide upload; bx and the bds slices extract on-device at encode time
+            memcpy(metal_buffer_contents(bwide), reinterpret<void const?>(s.wide_src + s.wide_soff * wide_stride), npos * wide_stride * 4l)
+        } else {
+            memcpy(metal_buffer_contents(bx), addr < void? >(s.x_b[0]), npos * dim * 4l)
+        }
         memcpy(metal_buffer_contents(bcos), addr < void? >(s.rope_cos[0]), npos * half * 4l)
         memcpy(metal_buffer_contents(bsin), addr < void? >(s.rope_sin[0]), npos * half * 4l)
         if (dual_rope) {
             memcpy(metal_buffer_contents(bcos_swa), addr < void? >(s.rope_cos_swa[0]), npos * half_sw * 4l)
             memcpy(metal_buffer_contents(bsin_swa), addr < void? >(s.rope_sin_swa[0]), npos * half_sw * 4l)
         }
-        if (nds > 0l) {   // [npos × nds·dim] row-major -> slice-major [nds][npos × dim]
+        if (nds > 0l && !wide) {   // the split arm: [npos × nds·dim] row-major -> slice-major [nds][npos × dim]
             var dsp = reinterpret<float?>(metal_buffer_contents(bds))
             let srp = addr<float const?>(s.ds_embd[0])
             for (sl in range64(nds)) {
@@ -2561,6 +2576,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let has_qkn = c.qk_norm
     let vfromk = c.v_from_k_mask != 0ul
     var u_total_dim = uniform_u32(uint(npos * dim))
+    var u_wide_rw = wide ? uniform_u32(uint(wide_stride)) : null
+    var u_wide_dim = wide ? uniform_u32(uint(dim)) : null
     var u_total_h = uniform_u32(uint(npos * hidden))
     var u_total_h2 = hid2 > 0l ? uniform_u32(uint(npos * hid2)) : null
     var u_moe_ne = moe ? uniform_u32(uint(c.n_expert)) : null
@@ -2610,8 +2627,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     let gpu_logits = (!g_pf_logits_cpu && g_pf_env_logits &&
         !tied_f32 &&
         t.wcls_off >= 0l)
-    var bxf = gpu_logits ? pool_acquire(g_pf_pool, g_dev, uint64(dim * 4l)) : null
-    var blog = gpu_logits ? pool_acquire(g_pf_pool, g_dev, uint64(c.vocab_size * 4l)) : null
+    var bxf = gpu_logits ? pool_acquire_pinned(g_pf_pool, g_dev, uint64(dim * 4l)) : null
+    var blog = gpu_logits ? pool_acquire_pinned(g_pf_pool, g_dev, uint64(c.vocab_size * 4l)) : null
     var u_vocab = gpu_logits ? uniform_u32(uint(c.vocab_size)) : null
     var u_flcap = (gpu_logits && c.final_logit_softcap > 0.0) ? uniform_f32(c.final_logit_softcap) : null
     // suppressed token ids pin to -1e30 AFTER the cap (gemma4) — the CPU classifier's order
@@ -2619,7 +2636,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var bsupp : MetalBuffer?
     var u_nsupp : MetalBuffer?
     if (gpu_logits && nsupp > 0l) {
-        bsupp = pool_acquire_untracked(g_pf_upool, g_dev, uint64(nsupp * 4l))
+        bsupp = pool_acquire_untracked_pinned(g_pf_upool, g_dev, uint64(nsupp * 4l))
         unsafe {
             var sp = reinterpret<uint?>(metal_buffer_contents(bsupp))
             for (i in range64(nsupp)) {
@@ -2641,12 +2658,15 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     var u_dim2 : MetalBuffer?
     var u_wm_tot : MetalBuffer?
     if (warm) {
-        bwm_res = pool_acquire(g_pf_pool, g_dev, uint64(npos * dim * 4l))
-        bwm_emb = pool_acquire(g_pf_pool, g_dev, uint64(npos * dim * 4l))
-        bwm_cat = pool_acquire(g_pf_pool, g_dev, uint64(mp * 2l * dim * 4l))
-        bwm_tmp = pool_acquire(g_pf_pool, g_dev, uint64(npos * dim * 4l))
+        bwm_res = pool_acquire_pinned(g_pf_pool, g_dev, uint64(npos * dim * 4l))
+        bwm_emb = pool_acquire_pinned(g_pf_pool, g_dev, uint64(npos * dim * 4l))
+        bwm_cat = pool_acquire_pinned(g_pf_pool, g_dev, uint64(mp * 2l * dim * 4l))
+        bwm_tmp = pool_acquire_pinned(g_pf_pool, g_dev, uint64(npos * dim * 4l))
         u_dim2 = uniform_u32(uint(2l * dim))
         u_wm_tot = uniform_u32(uint(npos * dim))
+        if (wide) {   // this edge reads x_b host-side - split the borrow first
+            ds_split_quantum(t, s, npos)
+        }
         // shifted embeds: row p pairs the NEXT position's embed with hidden p — s.x_b still
         // holds the window's embed panel here; the garbage last row reuses row 0
         unsafe {
@@ -2696,6 +2716,12 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                 enc = cap ? metal_new_compute_encoder_concurrent(cb) : metal_new_compute_encoder(cb)
                 if (cap) {
                     gr_arm(true)
+                }
+            }
+            if (l == 0l && wide) {   // slice the wide quantum on-device: x, then the slice-major ds planes
+                enc_head_restride(enc, bwide, 0ul, bx, 0ul, u_wide_rw, u_wide_dim, u_total_dim, npos * dim)
+                for (sl in range64(nds)) {
+                    enc_head_restride(enc, bwide, uint64((sl + 1l) * dim * 4l), bds, uint64(sl * npos * dim * 4l), u_wide_rw, u_wide_dim, u_total_dim, npos * dim)
                 }
             }
             if (l == 0l && ple_gpu) {
@@ -3344,7 +3370,14 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         pool_release(g_pf_upool, u_wm_tot, 4ul)
     }
     if (nds > 0l) {
-        pool_release(g_pf_upool, bds, bytes_ds)
+        if (wide) {
+            pool_release(g_pf_pool, bds, bytes_ds)
+        } else {
+            pool_release(g_pf_upool, bds, bytes_ds)
+        }
+    }
+    if (bwide != null) {
+        pool_release(g_pf_upool, bwide, bytes_wide)
     }
     pool_release(g_pf_upool, bcos, bytes_tab)
     if (dual_rope) {
@@ -3410,6 +3443,10 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         pool_release(g_pf_upool, u_nsupp, 4ul)
     }
     pool_release(g_pf_upool, u_total_dim, 4ul)
+    if (wide) {
+        pool_release(g_pf_upool, u_wide_rw, 4ul)
+        pool_release(g_pf_upool, u_wide_dim, 4ul)
+    }
     pool_release(g_pf_upool, u_total_h, 4ul)
     if (u_total_h2 != null) {
         pool_release(g_pf_upool, u_total_h2, 4ul)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -1793,6 +1793,7 @@ def public metal_prefill_pso_init : bool {
 //! next served prefill.
 def public metal_prefill_shutdown {   // nolint:STYLE037,STYLE038 — flat one-release-per-PSO list
     kcov_fold()   // PSO pointers recycle across re-init — counts fold into names first
+    residency_reset()   // the set references pooled buffers the drains below release
     pool_drain(g_pf_pool)
     pool_drain(g_pf_upool)
     if (g_pf_pso_moe_mm_q8_t != null) {
@@ -2429,14 +2430,14 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     // the wide borrow: upload the caller's quantum whole and slice it on-device (bds turns
     // GPU-written, so it must ride the TRACKED pool); the CPU-split arm survives for the
     // warm/MTP edge, which reads x_b host-side
-    let wide = nds > 0l && s.wide_src != null
+    let wide = nds > 0l   // a ds quantum always arrives as the wide borrow (forward_prefill_embd arms it with ds_active)
+    if (wide && s.wide_src == null) {
+        panic("metal_prefill_forward: ds_active with no wide borrow - forward_prefill_embd's contract broke")
+    }
     let wide_stride = s.wide_stride
     let bytes_ds = uint64(npos * nds * dim * 4l)
     let bytes_wide = uint64(npos * wide_stride * 4l)
-    var bds : MetalBuffer?
-    if (nds > 0l) {
-        bds = wide ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_ds) : pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_ds)
-    }
+    var bds = wide ? pool_acquire_pinned(g_pf_pool, g_dev, bytes_ds) : null   // GPU-written by the extract - the TRACKED pool
     var bwide = wide ? pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_wide) : null
     var bcos = pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_tab)
     var bsin = pool_acquire_untracked_pinned(g_pf_upool, g_dev, bytes_tab)
@@ -2518,15 +2519,6 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         if (dual_rope) {
             memcpy(metal_buffer_contents(bcos_swa), addr < void? >(s.rope_cos_swa[0]), npos * half_sw * 4l)
             memcpy(metal_buffer_contents(bsin_swa), addr < void? >(s.rope_sin_swa[0]), npos * half_sw * 4l)
-        }
-        if (nds > 0l && !wide) {   // the split arm: [npos × nds·dim] row-major -> slice-major [nds][npos × dim]
-            var dsp = reinterpret<float?>(metal_buffer_contents(bds))
-            let srp = addr<float const?>(s.ds_embd[0])
-            for (sl in range64(nds)) {
-                for (r in range64(npos)) {
-                    copy_floats(dsp + (sl * npos + r) * dim, srp + r * nds * dim + sl * dim, dim)
-                }
-            }
         }
     }
     // continuation: gather the session's existing rows [0, start_pos) into every layer's panel
@@ -2695,6 +2687,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
     // keeps capture order; DASLLAMA_METAL_PF_CAPTURE=0 = the direct serial-encode rollback.
     let cap = g_pf_env_capture
     var cbs & = unsafe(g_pf_cbs)
+    residency_flush()   // commit THIS eval's own notes before its first submission
     cbs |> clear()
     cbs |> reserve(ncb)
     var cb : MetalCommandBuffer?
@@ -3369,12 +3362,8 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
         pool_release(g_pf_upool, u_dim2, 4ul)
         pool_release(g_pf_upool, u_wm_tot, 4ul)
     }
-    if (nds > 0l) {
-        if (wide) {
-            pool_release(g_pf_pool, bds, bytes_ds)
-        } else {
-            pool_release(g_pf_upool, bds, bytes_ds)
-        }
+    if (bds != null) {
+        pool_release(g_pf_pool, bds, bytes_ds)
     }
     if (bwide != null) {
         pool_release(g_pf_upool, bwide, bytes_wide)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
@@ -13,6 +13,7 @@ require dasllama/dasllama_metal_shapes
 require dasllama/dasllama_gemma4uv
 require dasllama/dasllama_gemma4v   // Gemma4vTower/Gemma4vState — the ViT block loop
 require dasllama/dasllama_gemma3v   // Gemma3vTower/Gemma3vState — the SigLIP block loop
+require dasllama/dasllama_qwen3v   // Qwen3vTower/Qwen3vState — the qwen3vl ViT block loop (+ deepstack stashes)
 require dasllama/dasllama_audio   // AudioTower/EncoderState — the whisper-class block loop
 require dasllama/dasllama_qwen3a   // Qwen3aTower — the conv2d frontend hook
 require metal/das_metal_boost
@@ -600,6 +601,180 @@ def private metal_gemma3v_blocks(t : Gemma3vTower; var s : Gemma3vState; npos : 
     return true
 }
 
+// The qwen3vl ViT block loop: gemma3v's dispatch chain + the vision NEOX rope (the prefill's
+// enc_rope on compact q/k, per-row tables uploaded once) + the fused qkv as three
+// weight-offset GEMMs; segments at the tap layers stash each residual for the CPU tap mergers.
+[hot_path]
+def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int64) : bool {   // nolint:STYLE038 — the dispatch chain is the shape
+    if (!g_tw_env_tower) {
+        return tw_decline(MetalTowerDecline.knob)
+    }
+    if (t.q8) {
+        return tw_decline(MetalTowerDecline.quant_mode)
+    }
+    let d = t.n_embd
+    let hs = d / t.n_head
+    let ff = t.ff_pad
+    let hs_pad = hs <= 64l ? 64l : 128l
+    if (d % 64l != 0l || ff % 64l != 0l || hs > 128l || hs % 2l != 0l) {
+        return tw_decline(MetalTowerDecline.shape)
+    }
+    if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
+        return tw_decline(MetalTowerDecline.device)
+    }
+    let mp = (npos + 31l) / 32l * 32l
+    let nk64 = (npos + 63l) / 64l * 64l
+    let dp = t.n_head * hs_pad   // the padded attention width
+    let half = hs / 2l
+    let mapped = t.image_map != null
+    var bblob = plane_buffer(g_dev, unsafe(reinterpret<void?>(plane_at(t.blob, 0l))), uint64(length(t.blob) * 4l), mapped)
+    let bytes_row = uint64(mp * d * 4l)
+    let bytes_rowp = uint64(mp * dp * 4l)
+    let bytes_h = uint64(mp * ff * 4l)
+    let bytes_att = uint64(t.n_head * mp * nk64 * 4l)
+    let bytes_tab = uint64(npos * half * 4l)
+    var bx = pool_acquire(g_tw_pool, g_dev, bytes_row)
+    var bxb = pool_acquire(g_tw_pool, g_dev, bytes_row)
+    var bxb2 = pool_acquire(g_tw_pool, g_dev, bytes_row)
+    var braw = pool_acquire(g_tw_pool, g_dev, bytes_row)   // GEMM output ahead of rope + the head restride
+    var bq = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
+    var bk = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
+    var bv = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
+    var bo_p = pool_acquire(g_tw_pool, g_dev, bytes_rowp)   // padded AV output ahead of the compact
+    var bh = pool_acquire(g_tw_pool, g_dev, bytes_h)
+    var batt = pool_acquire(g_tw_pool, g_dev, bytes_att)
+    var bcos = pool_acquire(g_tw_pool, g_dev, bytes_tab)
+    var bsin = pool_acquire(g_tw_pool, g_dev, bytes_tab)
+    unsafe {
+        var p = reinterpret<uint8?>(metal_buffer_contents(bx))
+        memcpy(p, addr(s.x[0]), npos * d * 4l)
+        if (mp > npos) {   // DEFENSIVE pad zero (controls stay green without it): guards stale-Inf pool reuse
+            var zp = reinterpret<float?>(p + npos * d * 4l)
+            for (i in range64((mp - npos) * d)) {
+                zp[i] = 0.0
+            }
+        }
+        memcpy(metal_buffer_contents(bcos), addr(s.cos_t[0]), npos * half * 4l)
+        memcpy(metal_buffer_contents(bsin), addr(s.sin_t[0]), npos * half * 4l)
+    }
+    var u_d = uniform_u32(uint(d))
+    var u_ff = uniform_u32(uint(ff))
+    var u_hs = uniform_u32(uint(hs))
+    var u_hsp = uniform_u32(uint(hs_pad))
+    var u_eps = uniform_f32(t.eps)
+    var u_totd = uniform_u32(uint(npos * d))
+    var u_totff = uniform_u32(uint(npos * ff))
+    var u_totp = uniform_u32(uint(npos * t.n_head * hs_pad))   // restride total, pad direction
+    var u_totc = uniform_u32(uint(npos * t.n_head * hs))       // restride total, compact direction
+    var u_np_rope = uniform_u32(uint(npos * d / 2l))           // rope pairs over a compact q/k buffer
+    var u_neox = uniform_u32(1u)
+    var u_rot = uniform_u32(uint(hs))                          // full rope across the head
+    var ka = AttnArgs(qd = uint(dp), kv_dim = uint(dp), head_size = uint(hs_pad), kv_mul = 1u,
+        npos = uint(npos), np32 = uint(nk64), scale = 1.0 / sqrt(float(hs)),
+        qoff = 0u, qrows = uint(mp), window = 0u, softcap = 0.0, hass = 0u, uend = uint(npos))
+    // segment ends: after each deepstack tap layer (the tap reads that residual), then the top
+    var seg_end : int64[4]
+    var nseg = 0
+    if (t.ds_l0 >= 0l) {
+        seg_end[nseg] = t.ds_l0 + 1l
+        nseg++
+    }
+    if (t.ds_l1 >= 0l) {
+        seg_end[nseg] = t.ds_l1 + 1l
+        nseg++
+    }
+    if (t.ds_l2 >= 0l) {
+        seg_end[nseg] = t.ds_l2 + 1l
+        nseg++
+    }
+    seg_end[nseg] = t.n_layer
+    nseg++
+    var served = true
+    var l0 = 0l
+    var err = ""
+    for (si in range(nseg)) {
+        let l1 = seg_end[si]
+        if (served && l1 > l0) {
+            let ran = with_compute_encoder(g_queue, err) $(enc : MetalComputeEncoder?) {   // nolint:PERF026 — the error-text fetch runs only on the failure leg
+                for (l in range64(l0, l1)) {
+                    let o = qwen3v_block_offs(t, l)
+                    enc_ln(enc, bx, bblob, uint64(o.ln1_w * 4l), bblob, uint64(o.ln1_b * 4l), bxb, u_d, u_eps, npos)
+                    let wq = uint64(o.w[QWEN3V_GEMM_QKV] * 4l)   // the fused qkv rows: q, then k at d·d, v at 2d·d
+                    enc_f32_mm(enc, bblob, wq, bxb, braw, 0ul, u_d, u_d, mp, d)
+                    enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.qkv_b * 4l), u_d, u_totd, npos * d)
+                    enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
+                    enc_head_restride(enc, braw, bq, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+                    enc_f32_mm(enc, bblob, wq + uint64(d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
+                    enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + d) * 4l), u_d, u_totd, npos * d)
+                    enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
+                    enc_head_restride(enc, braw, bk, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+                    enc_f32_mm(enc, bblob, wq + uint64(2l * d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
+                    enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + 2l * d) * 4l), u_d, u_totd, npos * d)
+                    enc_head_restride(enc, braw, bv, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+                    enc_qk_mm(enc, bq, bk, batt, ka, mp, nk64, t.n_head)
+                    enc_softmax(enc, batt, ka, null, npos, t.n_head)
+                    enc_av_mm(enc, batt, bv, bo_p, ka, mp, t.n_head, hs_pad)
+                    enc_head_restride(enc, bo_p, bxb2, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
+                    enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_O] * 4l), bxb2, bxb, 0ul, u_d, u_d, mp, d)
+                    enc_add_bias_rows(enc, bxb, 0ul, bblob, uint64(o.out_b * 4l), u_d, u_totd, npos * d)
+                    enc_add(enc, bx, 0ul, bxb, 0ul, u_totd, npos * d)
+                    enc_ln(enc, bx, bblob, uint64(o.ln2_w * 4l), bblob, uint64(o.ln2_b * 4l), bxb, u_d, u_eps, npos)
+                    enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_UP] * 4l), bxb, bh, 0ul, u_d, u_ff, mp, ff)
+                    enc_add_bias_rows(enc, bh, 0ul, bblob, uint64(o.up_b * 4l), u_ff, u_totff, npos * ff)
+                    enc_gelu_lut(enc, bh, 0ul, u_totff, npos * ff)
+                    enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_DOWN] * 4l), bh, bxb2, 0ul, u_ff, u_d, mp, d)
+                    enc_add_bias_rows(enc, bxb2, 0ul, bblob, uint64(o.down_b * 4l), u_d, u_totd, npos * d)
+                    enc_add(enc, bx, 0ul, bxb2, 0ul, u_totd, npos * d)
+                }
+            }
+            if (!ran) {
+                served = false
+            } elif (si < nseg - 1) {   // a tap boundary: stash this residual for the CPU tap merger
+                unsafe {
+                    memcpy(addr(s.ds_stash[int64(si) * npos * d]), metal_buffer_contents(bx), uint64(npos * d * 4l))
+                }
+            }
+        }
+        l0 = l1
+    }
+    if (served) {
+        unsafe {
+            memcpy(addr(s.x[0]), metal_buffer_contents(bx), uint64(npos * d * 4l))
+        }
+        g_tower_encodes++
+        g_tower_rows += npos
+        g_tower_blocks += t.n_layer
+    }
+    pool_release(g_tw_pool, bx, bytes_row)
+    pool_release(g_tw_pool, bxb, bytes_row)
+    pool_release(g_tw_pool, bxb2, bytes_row)
+    pool_release(g_tw_pool, braw, bytes_row)
+    pool_release(g_tw_pool, bq, bytes_rowp)
+    pool_release(g_tw_pool, bk, bytes_rowp)
+    pool_release(g_tw_pool, bv, bytes_rowp)
+    pool_release(g_tw_pool, bo_p, bytes_rowp)
+    pool_release(g_tw_pool, bh, bytes_h)
+    pool_release(g_tw_pool, batt, bytes_att)
+    pool_release(g_tw_pool, bcos, bytes_tab)
+    pool_release(g_tw_pool, bsin, bytes_tab)
+    pool_release(g_upool, u_d, 4ul)
+    pool_release(g_upool, u_ff, 4ul)
+    pool_release(g_upool, u_hs, 4ul)
+    pool_release(g_upool, u_hsp, 4ul)
+    pool_release(g_upool, u_eps, 4ul)
+    pool_release(g_upool, u_totd, 4ul)
+    pool_release(g_upool, u_totff, 4ul)
+    pool_release(g_upool, u_totp, 4ul)
+    pool_release(g_upool, u_totc, 4ul)
+    pool_release(g_upool, u_np_rope, 4ul)
+    pool_release(g_upool, u_neox, 4ul)
+    pool_release(g_upool, u_rot, 4ul)
+    if (!served) {
+        return tw_decline(MetalTowerDecline.gpu_error)
+    }
+    return true
+}
+
 // The whisper conv frontend for one mel chunk: im2col + conv GEMMs + bias + GELU + pos-add,
 // one command buffer, s.x readback. BEST-EFFORT inside the tower knob: any decline is a
 // silent false (no counter noise — the CPU conv serves and the blocks still ride the GPU).
@@ -882,6 +1057,7 @@ def dasllama_metal_tower_register {
     register_gemma4uv_gpu(@@metal_gemma4uv_encode)
     register_gemma4v_gpu(@@metal_gemma4v_blocks, @@metal_tower_serves)
     register_gemma3v_gpu(@@metal_gemma3v_blocks, @@metal_tower_serves)
+    register_qwen3v_gpu(@@metal_qwen3v_blocks, @@metal_tower_serves)
     register_tower_blocks_gpu(@@metal_tower_blocks)
     register_tower_conv_gpu(@@metal_conv_frontend)
     register_qwen3a_conv_gpu(@@metal_q3a_convs)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
@@ -691,7 +691,6 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     var u_totpr = uniform_u32(uint(nout * proj))
     var u_np_rope = uniform_u32(uint(npos * d / 2l))           // rope pairs over a compact q/k buffer
     var u_neox = uniform_u32(1u)
-    var u_rot = uniform_u32(uint(hs))                          // full rope across the head
     var ka = AttnArgs(qd = uint(dp), kv_dim = uint(dp), head_size = uint(hs_pad), kv_mul = 1u,
         npos = uint(npos), np32 = uint(nk64), scale = 1.0 / sqrt(float(hs)),
         qoff = 0u, qrows = uint(mp), window = 0u, softcap = 0.0, hass = 0u, uend = uint(npos))

--- a/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
@@ -601,9 +601,9 @@ def private metal_gemma3v_blocks(t : Gemma3vTower; var s : Gemma3vState; npos : 
     return true
 }
 
-// The qwen3vl ViT block loop: gemma3v's dispatch chain + the vision NEOX rope (the prefill's
-// enc_rope on compact q/k, per-row tables uploaded once) + the fused qkv as three
-// weight-offset GEMMs; segments at the tap layers stash each residual for the CPU tap mergers.
+// The qwen3vl ViT: gemma3v's chain + the vision NEOX rope (enc_rope on compact q/k) + the
+// fused qkv as three weight-offset GEMMs; tap chains encode inline over the live residual
+// (hazard-ordered), the tail merger follows, ONE readback lands proj outputs for the scatter.
 [hot_path]
 def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int64) : bool {   // nolint:STYLE038 — the dispatch chain is the shape
     if (!g_tw_env_tower) {
@@ -615,8 +615,10 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     let d = t.n_embd
     let hs = d / t.n_head
     let ff = t.ff_pad
+    let proj = t.proj_dim
     let hs_pad = hs <= 64l ? 64l : 128l
-    if (d % 64l != 0l || ff % 64l != 0l || hs > 128l || hs % 2l != 0l) {
+    // %4 npos: the x4 merge reshape is the tap/tail GEMMs' row view
+    if (d % 64l != 0l || ff % 64l != 0l || hs > 128l || hs % 2l != 0l || proj % 64l != 0l || npos % 4l != 0l) {
         return tw_decline(MetalTowerDecline.shape)
     }
     if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
@@ -626,13 +628,19 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     let nk64 = (npos + 63l) / 64l * 64l
     let dp = t.n_head * hs_pad   // the padded attention width
     let half = hs / 2l
+    let nout = npos / 4l
+    let mp4 = (nout + 31l) / 32l * 32l
+    let rows_ext = max(mp, mp4 * 4l)   // bx/bxb double as the [nout x 4d] merged view - pad rows beyond mp
     let mapped = t.image_map != null
     var bblob = plane_buffer(g_dev, unsafe(reinterpret<void?>(plane_at(t.blob, 0l))), uint64(length(t.blob) * 4l), mapped)
-    let bytes_row = uint64(mp * d * 4l)
+    let bytes_row = uint64(rows_ext * d * 4l)
     let bytes_rowp = uint64(mp * dp * 4l)
     let bytes_h = uint64(mp * ff * 4l)
     let bytes_att = uint64(t.n_head * mp * nk64 * 4l)
     let bytes_tab = uint64(npos * half * 4l)
+    let bytes_m4 = uint64(mp4 * 4l * d * 4l)
+    let bytes_pr = uint64(mp4 * proj * 4l)
+    let nds = t.n_deepstack
     var bx = pool_acquire(g_tw_pool, g_dev, bytes_row)
     var bxb = pool_acquire(g_tw_pool, g_dev, bytes_row)
     var bxb2 = pool_acquire(g_tw_pool, g_dev, bytes_row)
@@ -645,12 +653,16 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     var batt = pool_acquire(g_tw_pool, g_dev, bytes_att)
     var bcos = pool_acquire(g_tw_pool, g_dev, bytes_tab)
     var bsin = pool_acquire(g_tw_pool, g_dev, bytes_tab)
+    var bm4 = pool_acquire(g_tw_pool, g_dev, bytes_m4)     // tap/tail LN out, the [nout x 4d] merged view
+    var bm4b = pool_acquire(g_tw_pool, g_dev, bytes_m4)    // fc1/mm0 out, GELU'd in place
+    var btail = pool_acquire(g_tw_pool, g_dev, bytes_pr)
+    var btap = nds > 0l ? pool_acquire(g_tw_pool, g_dev, uint64(nds) * bytes_pr) : null
     unsafe {
         var p = reinterpret<uint8?>(metal_buffer_contents(bx))
         memcpy(p, addr(s.x[0]), npos * d * 4l)
-        if (mp > npos) {   // DEFENSIVE pad zero (controls stay green without it): guards stale-Inf pool reuse
+        if (rows_ext > npos) {   // DEFENSIVE pad zero (controls stay green without it): guards stale-Inf pool reuse
             var zp = reinterpret<float?>(p + npos * d * 4l)
-            for (i in range64((mp - npos) * d)) {
+            for (i in range64((rows_ext - npos) * d)) {
                 zp[i] = 0.0
             }
         }
@@ -658,7 +670,9 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
         memcpy(metal_buffer_contents(bsin), addr(s.sin_t[0]), npos * half * 4l)
     }
     var u_d = uniform_u32(uint(d))
+    var u_d4 = uniform_u32(uint(4l * d))
     var u_ff = uniform_u32(uint(ff))
+    var u_pr = uniform_u32(uint(proj))
     var u_hs = uniform_u32(uint(hs))
     var u_hsp = uniform_u32(uint(hs_pad))
     var u_eps = uniform_f32(t.eps)
@@ -666,84 +680,78 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     var u_totff = uniform_u32(uint(npos * ff))
     var u_totp = uniform_u32(uint(npos * t.n_head * hs_pad))   // restride total, pad direction
     var u_totc = uniform_u32(uint(npos * t.n_head * hs))       // restride total, compact direction
+    var u_tot4 = uniform_u32(uint(nout * 4l * d))
+    var u_totpr = uniform_u32(uint(nout * proj))
     var u_np_rope = uniform_u32(uint(npos * d / 2l))           // rope pairs over a compact q/k buffer
     var u_neox = uniform_u32(1u)
     var u_rot = uniform_u32(uint(hs))                          // full rope across the head
     var ka = AttnArgs(qd = uint(dp), kv_dim = uint(dp), head_size = uint(hs_pad), kv_mul = 1u,
         npos = uint(npos), np32 = uint(nk64), scale = 1.0 / sqrt(float(hs)),
         qoff = 0u, qrows = uint(mp), window = 0u, softcap = 0.0, hass = 0u, uend = uint(npos))
-    // segment ends: after each deepstack tap layer (the tap reads that residual), then the top
-    var seg_end : int64[4]
-    var nseg = 0
-    if (t.ds_l0 >= 0l) {
-        seg_end[nseg] = t.ds_l0 + 1l
-        nseg++
-    }
-    if (t.ds_l1 >= 0l) {
-        seg_end[nseg] = t.ds_l1 + 1l
-        nseg++
-    }
-    if (t.ds_l2 >= 0l) {
-        seg_end[nseg] = t.ds_l2 + 1l
-        nseg++
-    }
-    seg_end[nseg] = t.n_layer
-    nseg++
-    var served = true
-    var l0 = 0l
     var err = ""
-    for (si in range(nseg)) {
-        let l1 = seg_end[si]
-        if (served && l1 > l0) {
-            let ran = with_compute_encoder(g_queue, err) $(enc : MetalComputeEncoder?) {   // nolint:PERF026 — the error-text fetch runs only on the failure leg
-                for (l in range64(l0, l1)) {
-                    let o = qwen3v_block_offs(t, l)
-                    enc_ln(enc, bx, bblob, uint64(o.ln1_w * 4l), bblob, uint64(o.ln1_b * 4l), bxb, u_d, u_eps, npos)
-                    let wq = uint64(o.w[QWEN3V_GEMM_QKV] * 4l)   // the fused qkv rows: q, then k at d·d, v at 2d·d
-                    enc_f32_mm(enc, bblob, wq, bxb, braw, 0ul, u_d, u_d, mp, d)
-                    enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.qkv_b * 4l), u_d, u_totd, npos * d)
-                    enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
-                    enc_head_restride(enc, braw, bq, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
-                    enc_f32_mm(enc, bblob, wq + uint64(d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
-                    enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + d) * 4l), u_d, u_totd, npos * d)
-                    enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
-                    enc_head_restride(enc, braw, bk, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
-                    enc_f32_mm(enc, bblob, wq + uint64(2l * d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
-                    enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + 2l * d) * 4l), u_d, u_totd, npos * d)
-                    enc_head_restride(enc, braw, bv, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
-                    enc_qk_mm(enc, bq, bk, batt, ka, mp, nk64, t.n_head)
-                    enc_softmax(enc, batt, ka, null, npos, t.n_head)
-                    enc_av_mm(enc, batt, bv, bo_p, ka, mp, t.n_head, hs_pad)
-                    enc_head_restride(enc, bo_p, bxb2, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
-                    enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_O] * 4l), bxb2, bxb, 0ul, u_d, u_d, mp, d)
-                    enc_add_bias_rows(enc, bxb, 0ul, bblob, uint64(o.out_b * 4l), u_d, u_totd, npos * d)
-                    enc_add(enc, bx, 0ul, bxb, 0ul, u_totd, npos * d)
-                    enc_ln(enc, bx, bblob, uint64(o.ln2_w * 4l), bblob, uint64(o.ln2_b * 4l), bxb, u_d, u_eps, npos)
-                    enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_UP] * 4l), bxb, bh, 0ul, u_d, u_ff, mp, ff)
-                    enc_add_bias_rows(enc, bh, 0ul, bblob, uint64(o.up_b * 4l), u_ff, u_totff, npos * ff)
-                    enc_gelu_lut(enc, bh, 0ul, u_totff, npos * ff)
-                    enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_DOWN] * 4l), bh, bxb2, 0ul, u_ff, u_d, mp, d)
-                    enc_add_bias_rows(enc, bxb2, 0ul, bblob, uint64(o.down_b * 4l), u_d, u_totd, npos * d)
-                    enc_add(enc, bx, 0ul, bxb2, 0ul, u_totd, npos * d)
-                }
-            }
-            if (!ran) {
-                served = false
-            } elif (si < nseg - 1) {   // a tap boundary: stash this residual for the CPU tap merger
-                unsafe {
-                    memcpy(addr(s.ds_stash[int64(si) * npos * d]), metal_buffer_contents(bx), uint64(npos * d * 4l))
-                }
+    let ran = with_compute_encoder(g_queue, err) $(enc : MetalComputeEncoder?) {   // nolint:PERF026 — the error-text fetch runs only on the failure leg
+        for (l in range64(t.n_layer)) {
+            let o = qwen3v_block_offs(t, l)
+            enc_ln(enc, bx, bblob, uint64(o.ln1_w * 4l), bblob, uint64(o.ln1_b * 4l), bxb, u_d, u_eps, npos)
+            let wq = uint64(o.w[QWEN3V_GEMM_QKV] * 4l)   // the fused qkv rows: q, then k at d·d, v at 2d·d
+            enc_f32_mm(enc, bblob, wq, bxb, braw, 0ul, u_d, u_d, mp, d)
+            enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.qkv_b * 4l), u_d, u_totd, npos * d)
+            enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
+            enc_head_restride(enc, braw, bq, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_f32_mm(enc, bblob, wq + uint64(d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
+            enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + d) * 4l), u_d, u_totd, npos * d)
+            enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
+            enc_head_restride(enc, braw, bk, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_f32_mm(enc, bblob, wq + uint64(2l * d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
+            enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + 2l * d) * 4l), u_d, u_totd, npos * d)
+            enc_head_restride(enc, braw, bv, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_qk_mm(enc, bq, bk, batt, ka, mp, nk64, t.n_head)
+            enc_softmax(enc, batt, ka, null, npos, t.n_head)
+            enc_av_mm(enc, batt, bv, bo_p, ka, mp, t.n_head, hs_pad)
+            enc_head_restride(enc, bo_p, bxb2, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
+            enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_O] * 4l), bxb2, bxb, 0ul, u_d, u_d, mp, d)
+            enc_add_bias_rows(enc, bxb, 0ul, bblob, uint64(o.out_b * 4l), u_d, u_totd, npos * d)
+            enc_add(enc, bx, 0ul, bxb, 0ul, u_totd, npos * d)
+            enc_ln(enc, bx, bblob, uint64(o.ln2_w * 4l), bblob, uint64(o.ln2_b * 4l), bxb, u_d, u_eps, npos)
+            enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_UP] * 4l), bxb, bh, 0ul, u_d, u_ff, mp, ff)
+            enc_add_bias_rows(enc, bh, 0ul, bblob, uint64(o.up_b * 4l), u_ff, u_totff, npos * ff)
+            enc_gelu_lut(enc, bh, 0ul, u_totff, npos * ff)
+            enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_DOWN] * 4l), bh, bxb2, 0ul, u_ff, u_d, mp, d)
+            enc_add_bias_rows(enc, bxb2, 0ul, bblob, uint64(o.down_b * 4l), u_d, u_totd, npos * d)
+            enc_add(enc, bx, 0ul, bxb2, 0ul, u_totd, npos * d)
+            let k = l == t.ds_l0 ? 0l : l == t.ds_l1 ? 1l : l == t.ds_l2 ? 2l : -1l
+            if (k >= 0l) {   // the tap merger chain over the live residual's [nout x 4d] merged view
+                let fo = t.ds_f + k * t.ds_f_stride
+                let wo = t.ds_w + k * t.ds_w_stride
+                enc_ln(enc, bx, bblob, uint64(fo * 4l), bblob, uint64((fo + 4l * d) * 4l), bm4, u_d4, u_eps, nout)
+                enc_f32_mm(enc, bblob, uint64(wo * 4l), bm4, bm4b, 0ul, u_d4, u_d4, mp4, 4l * d)
+                enc_add_bias_rows(enc, bm4b, 0ul, bblob, uint64((fo + 8l * d) * 4l), u_d4, u_tot4, nout * 4l * d)
+                enc_gelu_lut(enc, bm4b, 0ul, u_tot4, nout * 4l * d)
+                enc_f32_mm(enc, bblob, uint64((wo + 16l * d * d) * 4l), bm4b, btap, uint64(k * mp4 * proj * 4l), u_d4, u_pr, mp4, proj)
+                enc_add_bias_rows(enc, btap, uint64(k * mp4 * proj * 4l), bblob, uint64((fo + 12l * d) * 4l), u_pr, u_totpr, nout * proj)
             }
         }
-        l0 = l1
+        // the tail: post-LN over [npos x d], then the merger MLP over the [nout x 4d] view
+        enc_ln(enc, bx, bblob, uint64(t.post_ln_w * 4l), bblob, uint64(t.post_ln_b * 4l), bxb, u_d, u_eps, npos)
+        enc_f32_mm(enc, bblob, uint64(t.mm0_w * 4l), bxb, bm4b, 0ul, u_d4, u_d4, mp4, 4l * d)
+        enc_add_bias_rows(enc, bm4b, 0ul, bblob, uint64(t.mm0_b * 4l), u_d4, u_tot4, nout * 4l * d)
+        enc_gelu_lut(enc, bm4b, 0ul, u_tot4, nout * 4l * d)
+        enc_f32_mm(enc, bblob, uint64(t.mm2_w * 4l), bm4b, btail, 0ul, u_d4, u_pr, mp4, proj)
+        enc_add_bias_rows(enc, btail, 0ul, bblob, uint64(t.mm2_b * 4l), u_pr, u_totpr, nout * proj)
     }
-    if (served) {
+    var served = false
+    if (ran) {
         unsafe {
-            memcpy(addr(s.x[0]), metal_buffer_contents(bx), uint64(npos * d * 4l))
+            memcpy(addr(s.ds_slice[0]), metal_buffer_contents(btail), uint64(nout * proj * 4l))
+            for (k in range64(nds)) {
+                memcpy(addr(s.ds_stash[k * nout * proj]),
+                       reinterpret<uint8?>(metal_buffer_contents(btap)) + k * mp4 * proj * 4l, uint64(nout * proj * 4l))
+            }
         }
         g_tower_encodes++
         g_tower_rows += npos
         g_tower_blocks += t.n_layer
+        served = true
     }
     pool_release(g_tw_pool, bx, bytes_row)
     pool_release(g_tw_pool, bxb, bytes_row)
@@ -757,8 +765,16 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     pool_release(g_tw_pool, batt, bytes_att)
     pool_release(g_tw_pool, bcos, bytes_tab)
     pool_release(g_tw_pool, bsin, bytes_tab)
+    pool_release(g_tw_pool, bm4, bytes_m4)
+    pool_release(g_tw_pool, bm4b, bytes_m4)
+    pool_release(g_tw_pool, btail, bytes_pr)
+    if (btap != null) {
+        pool_release(g_tw_pool, btap, uint64(nds) * bytes_pr)
+    }
     pool_release(g_upool, u_d, 4ul)
+    pool_release(g_upool, u_d4, 4ul)
     pool_release(g_upool, u_ff, 4ul)
+    pool_release(g_upool, u_pr, 4ul)
     pool_release(g_upool, u_hs, 4ul)
     pool_release(g_upool, u_hsp, 4ul)
     pool_release(g_upool, u_eps, 4ul)
@@ -766,6 +782,8 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     pool_release(g_upool, u_totff, 4ul)
     pool_release(g_upool, u_totp, 4ul)
     pool_release(g_upool, u_totc, 4ul)
+    pool_release(g_upool, u_tot4, 4ul)
+    pool_release(g_upool, u_totpr, 4ul)
     pool_release(g_upool, u_np_rope, 4ul)
     pool_release(g_upool, u_neox, 4ul)
     pool_release(g_upool, u_rot, 4ul)

--- a/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
@@ -67,6 +67,7 @@ def private tw_decline(why : MetalTowerDecline) : bool {
 //! leak-gate rail, beside metal_decode_shutdown. The borrowed and registry PSOs are owned by
 //! their homes; lazily re-initializes on the next served encode.
 def metal_tower_shutdown {
+    residency_reset()   // the set references pooled buffers the drain below releases
     if (g_tw_ones != null) {
         metal_release(g_tw_ones)
         g_tw_ones = null
@@ -83,6 +84,7 @@ def metal_tower_shutdown {
 
 [cold_path]   // per-encode bring-up: the registry/prefill inits are latched-flag cheap
 def private metal_tower_init : bool {
+    weight_caches_flush_on_reload()   // an embedder load/delete recycles staged-blob addresses — the address-keyed regions must not survive it
     // the registry owns the tower PSOs (metal_decode_init compiles them, via the prefill seat)
     if (g_tw_failed || !metal_common_init() || !metal_prefill_pso_init() || g_pso_ln == null) {
         return false
@@ -693,6 +695,7 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     var ka = AttnArgs(qd = uint(dp), kv_dim = uint(dp), head_size = uint(hs_pad), kv_mul = 1u,
         npos = uint(npos), np32 = uint(nk64), scale = 1.0 / sqrt(float(hs)),
         qoff = 0u, qrows = uint(mp), window = 0u, softcap = 0.0, hass = 0u, uend = uint(npos))
+    residency_flush()   // commit THIS encode's own notes before its first submission
     var err = ""
     let ran = with_compute_encoder(g_queue, err) $(enc : MetalComputeEncoder?) {   // nolint:PERF026 — the error-text fetch runs only on the failure leg
         for (l in range64(t.n_layer)) {
@@ -701,11 +704,11 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
             let wq = uint64(o.w[QWEN3V_GEMM_QKV] * 4l)   // the fused qkv rows: q, then k at d·d, v at 2d·d
             enc_f32_mm(enc, bblob, wq, bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.qkv_b * 4l), u_d, u_totd, npos * d)
-            enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
+            enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, null, npos * d / 2l)
             enc_head_restride(enc, braw, 0ul, bq, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_f32_mm(enc, bblob, wq + uint64(d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + d) * 4l), u_d, u_totd, npos * d)
-            enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
+            enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, null, npos * d / 2l)
             enc_head_restride(enc, braw, 0ul, bk, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_f32_mm(enc, bblob, wq + uint64(2l * d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + 2l * d) * 4l), u_d, u_totd, npos * d)
@@ -791,7 +794,6 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     pool_release(g_upool, u_totpr, 4ul)
     pool_release(g_upool, u_np_rope, 4ul)
     pool_release(g_upool, u_neox, 4ul)
-    pool_release(g_upool, u_rot, 4ul)
     if (!served) {
         return tw_decline(MetalTowerDecline.gpu_error)
     }

--- a/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
@@ -115,12 +115,13 @@ def private metal_gemma4uv_encode(t : Gemma4uvEmbedder; var s : Gemma4uvState; n
     if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
         return tw_decline(MetalTowerDecline.device)
     }
+    residency_flush()   // pin/commit before the first submission (the post-CPU-window slack)
     let mp = (npos + 31l) / 32l * 32l
     let mapped = t.image_map != null
     var bblob = plane_buffer(g_dev, unsafe(reinterpret<void?>(plane_at(t.blob, 0l))), uint64(length(t.blob) * 4l), mapped)
-    var bx0 = pool_acquire(g_tw_pool, g_dev, uint64(mp * t.patch_dim * 4l))
-    var bx1 = pool_acquire(g_tw_pool, g_dev, uint64(mp * d * 4l))
-    var bout = pool_acquire(g_tw_pool, g_dev, uint64(mp * t.proj_dim * 4l))
+    var bx0 = pool_acquire_pinned(g_tw_pool, g_dev, uint64(mp * t.patch_dim * 4l))
+    var bx1 = pool_acquire_pinned(g_tw_pool, g_dev, uint64(mp * d * 4l))
+    var bout = pool_acquire_pinned(g_tw_pool, g_dev, uint64(mp * t.proj_dim * 4l))
     unsafe {
         var p = reinterpret<uint8?>(metal_buffer_contents(bx0))
         memcpy(p, addr(s.x0[0]), npos * t.patch_dim * 4l)
@@ -207,6 +208,7 @@ def private metal_tower_blocks(t : AudioTower; var s : EncoderState; npos : int6
     if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
         return tw_decline(MetalTowerDecline.device)
     }
+    residency_flush()   // pin/commit before the first submission (the post-CPU-window slack)
     let mp = (npos + 31l) / 32l * 32l
     let nk64 = (npos + 63l) / 64l * 64l
     let ff = t.n_ff
@@ -215,14 +217,14 @@ def private metal_tower_blocks(t : AudioTower; var s : EncoderState; npos : int6
     let bytes_row = uint64(mp * d * 4l)
     let bytes_h = uint64(mp * ff * 4l)
     let bytes_att = uint64(t.n_head * mp * nk64 * 4l)
-    var bx = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb2 = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bq = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bk = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bv = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bh = pool_acquire(g_tw_pool, g_dev, bytes_h)
-    var batt = pool_acquire(g_tw_pool, g_dev, bytes_att)
+    var bx = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb2 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bq = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bk = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bv = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bh = pool_acquire_pinned(g_tw_pool, g_dev, bytes_h)
+    var batt = pool_acquire_pinned(g_tw_pool, g_dev, bytes_att)
     unsafe {
         var p = reinterpret<uint8?>(metal_buffer_contents(bx))
         memcpy(p, addr(s.x[0]), npos * d * 4l)
@@ -324,6 +326,7 @@ def private metal_gemma4v_blocks(t : Gemma4vTower; var s : Gemma4vState; npos : 
     if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
         return tw_decline(MetalTowerDecline.device)
     }
+    residency_flush()   // pin/commit before the first submission (the post-CPU-window slack)
     let mp = (npos + 31l) / 32l * 32l
     let nk64 = (npos + 63l) / 64l * 64l
     let pairs = hs / 4l   // rotated pairs per rope axis = one packed table row
@@ -334,16 +337,16 @@ def private metal_gemma4v_blocks(t : Gemma4vTower; var s : Gemma4vState; npos : 
     let bytes_h = uint64(mp * ff * 4l)
     let bytes_att = uint64(t.n_head * mp * nk64 * 4l)
     let bytes_tabs = uint64(npos * 4l * pairs * 4l)
-    var bx = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb2 = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bq = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bk = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bv = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bhg = pool_acquire(g_tw_pool, g_dev, bytes_h)
-    var bhu = pool_acquire(g_tw_pool, g_dev, bytes_h)
-    var batt = pool_acquire(g_tw_pool, g_dev, bytes_att)
-    var btabs = pool_acquire(g_tw_pool, g_dev, bytes_tabs)
+    var bx = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb2 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bq = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bk = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bv = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bhg = pool_acquire_pinned(g_tw_pool, g_dev, bytes_h)
+    var bhu = pool_acquire_pinned(g_tw_pool, g_dev, bytes_h)
+    var batt = pool_acquire_pinned(g_tw_pool, g_dev, bytes_att)
+    var btabs = pool_acquire_pinned(g_tw_pool, g_dev, bytes_tabs)
     unsafe {
         var p = reinterpret<uint8?>(metal_buffer_contents(bx))
         memcpy(p, addr(s.x[0]), npos * d * 4l)
@@ -495,6 +498,7 @@ def private metal_gemma3v_blocks(t : Gemma3vTower; var s : Gemma3vState; npos : 
     if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
         return tw_decline(MetalTowerDecline.device)
     }
+    residency_flush()   // pin/commit before the first submission (the post-CPU-window slack)
     let mp = (npos + 31l) / 32l * 32l
     let nk64 = (npos + 63l) / 64l * 64l
     let dp = t.n_head * hs_pad   // the padded attention width
@@ -504,16 +508,16 @@ def private metal_gemma3v_blocks(t : Gemma3vTower; var s : Gemma3vState; npos : 
     let bytes_rowp = uint64(mp * dp * 4l)
     let bytes_h = uint64(mp * ff * 4l)
     let bytes_att = uint64(t.n_head * mp * nk64 * 4l)
-    var bx = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb2 = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var braw = pool_acquire(g_tw_pool, g_dev, bytes_row)   // GEMM output ahead of the head restride
-    var bq = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
-    var bk = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
-    var bv = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
-    var bo_p = pool_acquire(g_tw_pool, g_dev, bytes_rowp)   // padded AV output ahead of the compact
-    var bh = pool_acquire(g_tw_pool, g_dev, bytes_h)
-    var batt = pool_acquire(g_tw_pool, g_dev, bytes_att)
+    var bx = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb2 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var braw = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)   // GEMM output ahead of the head restride
+    var bq = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)
+    var bk = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)
+    var bv = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)
+    var bo_p = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)   // padded AV output ahead of the compact
+    var bh = pool_acquire_pinned(g_tw_pool, g_dev, bytes_h)
+    var batt = pool_acquire_pinned(g_tw_pool, g_dev, bytes_att)
     unsafe {
         var p = reinterpret<uint8?>(metal_buffer_contents(bx))
         memcpy(p, addr(s.x[0]), npos * d * 4l)
@@ -543,17 +547,17 @@ def private metal_gemma3v_blocks(t : Gemma3vTower; var s : Gemma3vState; npos : 
             enc_ln(enc, bx, bblob, uint64(o.ln1_w * 4l), bblob, uint64(o.ln1_b * 4l), bxb, u_d, u_eps, npos)
             enc_f32_mm(enc, bblob, uint64(o.w[GEMMA3V_GEMM_Q] * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.b[GEMMA3V_GEMM_Q] * 4l), u_d, u_totd, npos * d)
-            enc_head_restride(enc, braw, bq, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_head_restride(enc, braw, 0ul, bq, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_f32_mm(enc, bblob, uint64(o.w[GEMMA3V_GEMM_K] * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.b[GEMMA3V_GEMM_K] * 4l), u_d, u_totd, npos * d)
-            enc_head_restride(enc, braw, bk, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_head_restride(enc, braw, 0ul, bk, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_f32_mm(enc, bblob, uint64(o.w[GEMMA3V_GEMM_V] * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.b[GEMMA3V_GEMM_V] * 4l), u_d, u_totd, npos * d)
-            enc_head_restride(enc, braw, bv, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_head_restride(enc, braw, 0ul, bv, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_qk_mm(enc, bq, bk, batt, ka, mp, nk64, t.n_head)
             enc_softmax(enc, batt, ka, null, npos, t.n_head)
             enc_av_mm(enc, batt, bv, bo_p, ka, mp, t.n_head, hs_pad)
-            enc_head_restride(enc, bo_p, bxb2, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
+            enc_head_restride(enc, bo_p, 0ul, bxb2, 0ul, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
             enc_f32_mm(enc, bblob, uint64(o.w[GEMMA3V_GEMM_O] * 4l), bxb2, bxb, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, bxb, 0ul, bblob, uint64(o.b[GEMMA3V_GEMM_O] * 4l), u_d, u_totd, npos * d)
             enc_add(enc, bx, 0ul, bxb, 0ul, u_totd, npos * d)
@@ -624,6 +628,7 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     if (!metal_tower_init()) {   // per-encode: re-arms after any shutdown seat
         return tw_decline(MetalTowerDecline.device)
     }
+    residency_flush()   // pin/commit before the first submission (the post-CPU-window slack)
     let mp = (npos + 31l) / 32l * 32l
     let nk64 = (npos + 63l) / 64l * 64l
     let dp = t.n_head * hs_pad   // the padded attention width
@@ -641,22 +646,22 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
     let bytes_m4 = uint64(mp4 * 4l * d * 4l)
     let bytes_pr = uint64(mp4 * proj * 4l)
     let nds = t.n_deepstack
-    var bx = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var bxb2 = pool_acquire(g_tw_pool, g_dev, bytes_row)
-    var braw = pool_acquire(g_tw_pool, g_dev, bytes_row)   // GEMM output ahead of rope + the head restride
-    var bq = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
-    var bk = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
-    var bv = pool_acquire(g_tw_pool, g_dev, bytes_rowp)
-    var bo_p = pool_acquire(g_tw_pool, g_dev, bytes_rowp)   // padded AV output ahead of the compact
-    var bh = pool_acquire(g_tw_pool, g_dev, bytes_h)
-    var batt = pool_acquire(g_tw_pool, g_dev, bytes_att)
-    var bcos = pool_acquire(g_tw_pool, g_dev, bytes_tab)
-    var bsin = pool_acquire(g_tw_pool, g_dev, bytes_tab)
-    var bm4 = pool_acquire(g_tw_pool, g_dev, bytes_m4)     // tap/tail LN out, the [nout x 4d] merged view
-    var bm4b = pool_acquire(g_tw_pool, g_dev, bytes_m4)    // fc1/mm0 out, GELU'd in place
-    var btail = pool_acquire(g_tw_pool, g_dev, bytes_pr)
-    var btap = nds > 0l ? pool_acquire(g_tw_pool, g_dev, uint64(nds) * bytes_pr) : null
+    var bx = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var bxb2 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)
+    var braw = pool_acquire_pinned(g_tw_pool, g_dev, bytes_row)   // GEMM output ahead of rope + the head restride
+    var bq = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)
+    var bk = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)
+    var bv = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)
+    var bo_p = pool_acquire_pinned(g_tw_pool, g_dev, bytes_rowp)   // padded AV output ahead of the compact
+    var bh = pool_acquire_pinned(g_tw_pool, g_dev, bytes_h)
+    var batt = pool_acquire_pinned(g_tw_pool, g_dev, bytes_att)
+    var bcos = pool_acquire_pinned(g_tw_pool, g_dev, bytes_tab)
+    var bsin = pool_acquire_pinned(g_tw_pool, g_dev, bytes_tab)
+    var bm4 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_m4)     // tap/tail LN out, the [nout x 4d] merged view
+    var bm4b = pool_acquire_pinned(g_tw_pool, g_dev, bytes_m4)    // fc1/mm0 out, GELU'd in place
+    var btail = pool_acquire_pinned(g_tw_pool, g_dev, bytes_pr)
+    var btap = nds > 0l ? pool_acquire_pinned(g_tw_pool, g_dev, uint64(nds) * bytes_pr) : null
     unsafe {
         var p = reinterpret<uint8?>(metal_buffer_contents(bx))
         memcpy(p, addr(s.x[0]), npos * d * 4l)
@@ -697,18 +702,18 @@ def private metal_qwen3v_blocks(t : Qwen3vTower; var s : Qwen3vState; npos : int
             enc_f32_mm(enc, bblob, wq, bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64(o.qkv_b * 4l), u_d, u_totd, npos * d)
             enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
-            enc_head_restride(enc, braw, bq, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_head_restride(enc, braw, 0ul, bq, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_f32_mm(enc, bblob, wq + uint64(d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + d) * 4l), u_d, u_totd, npos * d)
             enc_rope(enc, braw, 0ul, bcos, bsin, u_d, u_hs, u_np_rope, u_neox, u_rot, npos * d / 2l)
-            enc_head_restride(enc, braw, bk, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_head_restride(enc, braw, 0ul, bk, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_f32_mm(enc, bblob, wq + uint64(2l * d * d * 4l), bxb, braw, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, braw, 0ul, bblob, uint64((o.qkv_b + 2l * d) * 4l), u_d, u_totd, npos * d)
-            enc_head_restride(enc, braw, bv, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
+            enc_head_restride(enc, braw, 0ul, bv, 0ul, u_hs, u_hsp, u_totp, npos * t.n_head * hs_pad)
             enc_qk_mm(enc, bq, bk, batt, ka, mp, nk64, t.n_head)
             enc_softmax(enc, batt, ka, null, npos, t.n_head)
             enc_av_mm(enc, batt, bv, bo_p, ka, mp, t.n_head, hs_pad)
-            enc_head_restride(enc, bo_p, bxb2, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
+            enc_head_restride(enc, bo_p, 0ul, bxb2, 0ul, u_hsp, u_hs, u_totc, npos * t.n_head * hs)
             enc_f32_mm(enc, bblob, uint64(o.w[QWEN3V_GEMM_O] * 4l), bxb2, bxb, 0ul, u_d, u_d, mp, d)
             enc_add_bias_rows(enc, bxb, 0ul, bblob, uint64(o.out_b * 4l), u_d, u_totd, npos * d)
             enc_add(enc, bx, 0ul, bxb, 0ul, u_totd, npos * d)
@@ -818,11 +823,11 @@ def private metal_conv_frontend(t : AudioTower; var s : EncoderState; mel : MelC
     let bytes_y1 = uint64(mp1 * d * 4l)
     let bytes_x2 = uint64(mp2 * 3l * d * 4l)
     let bytes_xo = uint64(mp2 * d * 4l)
-    var bmel = pool_acquire(g_tw_pool, g_dev, bytes_mel)
-    var bx1 = pool_acquire(g_tw_pool, g_dev, bytes_x1)
-    var by1 = pool_acquire(g_tw_pool, g_dev, bytes_y1)
-    var bx2 = pool_acquire(g_tw_pool, g_dev, bytes_x2)
-    var bxo = pool_acquire(g_tw_pool, g_dev, bytes_xo)
+    var bmel = pool_acquire_pinned(g_tw_pool, g_dev, bytes_mel)
+    var bx1 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_x1)
+    var by1 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_y1)
+    var bx2 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_x2)
+    var bxo = pool_acquire_pinned(g_tw_pool, g_dev, bytes_xo)
     unsafe {
         memcpy(metal_buffer_contents(bmel), addr(mel.data[0]), bytes_mel)
     }
@@ -978,11 +983,11 @@ def private metal_q3a_convs(t : Qwen3aTower; win : MelChunk; n_chunks : int64; v
     let bytes_y1 = uint64(3200l * ncp * 4l)
     let bytes_y2 = uint64(800l * ncp * 4l)
     let bytes_y3 = uint64(n_chunks * mp3 * ncp * 4l)
-    var bxin = pool_acquire(g_tw_pool, g_dev, bytes_xin)
-    var bcol = pool_acquire(g_tw_pool, g_dev, bytes_col)
-    var by1 = pool_acquire(g_tw_pool, g_dev, bytes_y1)
-    var by2 = pool_acquire(g_tw_pool, g_dev, bytes_y2)
-    var by3 = pool_acquire(g_tw_pool, g_dev, bytes_y3)
+    var bxin = pool_acquire_pinned(g_tw_pool, g_dev, bytes_xin)
+    var bcol = pool_acquire_pinned(g_tw_pool, g_dev, bytes_col)
+    var by1 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_y1)
+    var by2 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_y2)
+    var by3 = pool_acquire_pinned(g_tw_pool, g_dev, bytes_y3)
     unsafe {   // the per-chunk [ih][iw] extract from the window's mel-major plane, straight into the mapped slab
         var p = reinterpret<float?>(metal_buffer_contents(bxin))
         for (ci in range64(n_chunks)) {

--- a/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
@@ -29,7 +29,8 @@ require math
 //! the files carry no ClippableLinear sidecars. Oracle: llama-mtmd-debug -p encode on the
 //! f32-widened mmproj (`qwen3vl_plan.md`, dumps in models/qwen3vl-vision-oracle/).
 //! CPU serving default: the block GEMMs serve as Q8_0 planes (read-time transcode, the
-//! gemma3v recipe); the exact bf16/f32 lane is the parity rail.
+//! gemma3v recipe); the f32 exact lane serves the Metal tower / float-batch tier and is the
+//! parity rail.
 
 let QWEN3V_ROPE_THETA = 10000.0   // models/qwen3vl.cpp hardcodes it — not in the gguf
 // the family's dynamic-resolution token budget (mtmd set_limit_image_tokens for qwen)
@@ -59,10 +60,10 @@ struct Qwen3vTower {
     blk_bf16 : bool
     mm_bf16 : bool
     // q8: the 4·n_layer block GEMMs SERVE as Q8_0 planes (read-time transcode) and layer_w
-    // indexes qblob; the FFN pair serves padded to ff_pad (n_ff is not 32-aligned). The exact
-    // lane serves the file's widths — only the q8 layout pads.
+    // indexes qblob; the exact lane serves them as f32 in blob (the Metal tower / float-batch
+    // read). The FFN pair serves padded to ff_pad in BOTH lanes (n_ff is not 32-aligned).
     q8 : bool
-    ff_pad : int64       // n_ff rounded up to 64 — the q8 lane's served FFN width
+    ff_pad : int64       // n_ff rounded up to 64 — the served FFN width, both lanes
     blob : PlaneF = PlaneF()
     wblob : PlaneU16 = PlaneU16()
     qblob : PlaneI8 = PlaneI8()
@@ -77,7 +78,7 @@ struct Qwen3vTower {
     mm2_b : int64
     layer_f : int64      // per-block f32 region; stride: ln1 w+b, ln2 w+b [d ×4], qkv_b [3d], out_b [d], up_b [ff_pad, zero tail], down_b [d]
     layer_f_stride : int64
-    layer_w : int64      // per-block GEMM region (qblob when q8, wblob when blk_bf16, else blob); stride layer_w_stride
+    layer_w : int64      // per-block GEMM region (qblob when q8, else f32 in blob); stride layer_w_stride
     layer_w_stride : int64
     // deepstack (dense Qwen3-VL): up to three tap mergers — output rows widen to
     // (1+n_deepstack)·proj_dim; 0 taps = the Omni tower, narrow rows
@@ -112,6 +113,7 @@ struct Qwen3vState {
     @exact_size ds_slice : array<float>  // deepstack tap / main-merger staging [nout × proj]
     @scratch @exact_size pos_rs : array<float>   // the pos table resized to the grid [npos × d]
     @exact_size cos_t : array<float>; @exact_size sin_t : array<float>
+    @exact_size ds_stash : array<float>  // GPU arm: the residual at each tap layer [n_ds × npos × d]
     @scratch @exact_size xqi : array<int8>    // q8 lane: the requantized GEMM input, grown per site
     @scratch @exact_size xsi : array<float>   // its per-32-block scales
     @scratch pos2 : array<int2>      // per reordered row: (patch row, patch column)
@@ -143,6 +145,7 @@ def finalize(var s : Qwen3vState) {
     delete s.m0
     delete s.ds_mid
     delete s.ds_slice
+    delete s.ds_stash
     delete s.pos_rs
     delete s.cos_t
     delete s.sin_t
@@ -232,21 +235,35 @@ def private register_qwen3v_image_tags {
     register_image_family_tag(QWEN3V_TAG_Q8)
 }
 
-// the lane policy follows the fastest GEMM path on the box: the armed accelerate float-batch
-// tier wants the file's planes; else q8. No Metal tower serves this family yet, so there is
-// no driver clause. A pin overrides.
+// the lane policy follows the fastest GEMM path on the box: the Metal tower or the armed
+// accelerate float-batch tier wants f32 planes; else q8. A pin overrides.
 enum private Q3vLane {
     unset    // the policy decides
-    exact    // the file's planes
+    exact    // f32 planes
     q8
 }
 var private g_q3v_q8_pin = Q3vLane.unset
+
+typedef Qwen3vGpuBlocksFn = function<(t : Qwen3vTower; var s : Qwen3vState; npos : int64) : bool>
+typedef Qwen3vGpuServesFn = function<() : bool>
+var private g_q3v_gpu : Qwen3vGpuBlocksFn
+var private g_q3v_gpu_serves : Qwen3vGpuServesFn
+var private g_q3v_gpu_set = false
+
+//! The Metal tower's qwen3v block-loop seat ([init]): the blocks fn runs the stack over `s.x`
+//! (rope tables prebuilt) and fills `s.ds_stash` at the tap layers — false = decline, the CPU
+//! loop serves; `serves` answers the knob so the lane policy can prefer f32 planes.
+def register_qwen3v_gpu(fn : Qwen3vGpuBlocksFn; serves : Qwen3vGpuServesFn) {
+    g_q3v_gpu = fn
+    g_q3v_gpu_serves = serves
+    g_q3v_gpu_set = true
+}
 
 def private q3v_serve_q8() : bool {
     if (g_q3v_q8_pin != Q3vLane.unset) {
         return g_q3v_q8_pin == Q3vLane.q8
     }
-    return !float_batch_override_active()
+    return !((g_q3v_gpu_set && invoke(g_q3v_gpu_serves)) || float_batch_override_active())
 }
 
 //! Pin the qwen3v tower's block-GEMM format for subsequent loads: q8 (the CPU serving default)
@@ -263,17 +280,22 @@ def reset_qwen3v_q8() {
 //! Would the next load serve the block GEMMs as q8 — the pin when set, the policy otherwise.
 def qwen3v_serves_q8() : bool => q3v_serve_q8()
 
+//! Would the registered GPU tower take the f32 lane — the policy's driver clause, for tests.
+def qwen3v_gpu_would_serve() : bool => g_q3v_gpu_set && invoke(g_q3v_gpu_serves)
+
 def private q3v_tag() : string => q3v_serve_q8() ? QWEN3V_TAG_Q8 : QWEN3V_TAG
 
 // the lane changes what a load mints and serves, so the load says which and why
 def private q3v_announce_lane() {
-    var why = "the CPU default (no accelerate tier)"
+    var why = "the CPU default (DASLLAMA_METAL_TOWER off / no accelerate tier)"
     if (g_q3v_q8_pin != Q3vLane.unset) {
         why = "pinned via set_qwen3v_q8"
+    } elif (g_q3v_gpu_set && invoke(g_q3v_gpu_serves)) {
+        why = "DASLLAMA_METAL_TOWER on: the Metal tower serves f32 planes"
     } elif (float_batch_override_active()) {
-        why = "DASLLAMA_ACCEL on: the float-batch tier serves the file's planes"
+        why = "DASLLAMA_ACCEL on: the float-batch tier serves f32 planes"
     }
-    to_log(LOG_INFO, "dasLLAMA qwen3v: block GEMM lane {q3v_serve_q8() ? "q8" : "exact planes"} - {why}\n")
+    to_log(LOG_INFO, "dasLLAMA qwen3v: block GEMM lane {q3v_serve_q8() ? "q8" : "f32 planes"} - {why}\n")
 }
 
 // the block GEMM tensors in QWEN3V_GEMM_* order; every per-GEMM list follows it
@@ -328,8 +350,7 @@ def private q3v_verify_tensors(m : GGUFMeta; t : Qwen3vTower; gemm_sizes : array
 
 def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&; var qo : int64&) {
     let d = t.n_embd
-    let ff = t.n_ff
-    let ffs = t.q8 ? t.ff_pad : ff   // the served FFN width — only the q8 layout pads
+    let ffs = t.ff_pad   // the served FFN width, BOTH lanes: %64 fits Metal tiles, %32 quantizes
     t.patch_w = off; off += t.patch_dim * d
     t.patch_b = off; off += d
     t.pos_w = off; off += t.pos_side * t.pos_side * d
@@ -346,7 +367,9 @@ def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&;
         t.layer_w = qo
         qo += t.n_layer * t.layer_w_stride
     } else {
-        t.layer_w = take_cursor(t.blk_bf16, off, woff, t.n_layer * t.layer_w_stride)
+        // f32-in-blob whatever the file dtype — the Metal tower / float-batch read f32 planes
+        t.layer_w = off
+        off += t.n_layer * t.layer_w_stride
     }
     if (t.n_deepstack > 0l) {
         t.ds_f_stride = 12l * d + t.proj_dim
@@ -401,7 +424,14 @@ def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwe
         for (g in range64(QWEN3V_GEMMS)) {
             let wname = "{p}.{Q3V_BLK_GEMM_NAMES[g]}.weight"
             if (!st.t.q8) {
-                tower_read_gemm(m, bytes, wname, st.wblob, st.blob, st.t.blk_bf16, wo, gemm_sizes[g])
+                if (g == QWEN3V_GEMM_UP) {
+                    gguf_read_tensor_f32(m, bytes, wname, st.blob, wo, ff * d)
+                    tower_zero_span(st.blob, wo + ff * d, (st.t.ff_pad - ff) * d)   // zero pad rows
+                } elif (g == QWEN3V_GEMM_DOWN) {
+                    tower_stage_f32_pad_cols(m, bytes, wname, st.blob, rowscratch, wo, d, ff, st.t.ff_pad)
+                } else {
+                    gguf_read_tensor_f32(m, bytes, wname, st.blob, wo, gemm_sizes[g])
+                }
             } elif (g == QWEN3V_GEMM_UP) {
                 tower_stage_q8_zero_rows(m, bytes, wname, st.qblob, st.qscales, wscratch, wo, ff, st.t.ff_pad, d, "dasLLAMA qwen3v q8")
             } elif (g == QWEN3V_GEMM_DOWN) {
@@ -506,7 +536,7 @@ def stage_qwen3v_tower(path : string) : Qwen3vStaging {
         st.t.ff_pad = (st.t.n_ff + 63l) / 64l * 64l   // %64 fits future GPU tiles, %32 quantizes
         let file_sizes <- q3v_gemm_sizes(d, st.t.n_ff)
         q3v_verify_tensors(m, st.t, file_sizes)
-        let serve_sizes <- q3v_gemm_sizes(d, st.t.q8 ? st.t.ff_pad : st.t.n_ff)
+        let serve_sizes <- q3v_gemm_sizes(d, st.t.ff_pad)   // both lanes pad the FFN pair
         var off = 0l
         var woff = 0l
         var qo = 0l
@@ -578,7 +608,7 @@ def mint_qwen3v_tower(var st : Qwen3vStaging; var out : Qwen3vTower) {
 // the bind walk skips a missing section silently, so the flag=>plane invariant must be checked
 // once the carrier is live, or the kernel derefs null
 def private q3v_check_planes(t : Qwen3vTower; src : string) {
-    if (((t.blk_bf16 && !t.q8) || t.mm_bf16) && empty(t.wblob)) {
+    if (t.mm_bf16 && empty(t.wblob)) {
         panic("dasLLAMA qwen3v: '{src}' declares bf16 planes but carries no wblob section - the image is corrupt or hand-edited")
     }
     if (t.q8 && (empty(t.qblob) || empty(t.qscales))) {
@@ -635,7 +665,7 @@ def qwen3v_block_offs(t : Qwen3vTower; l : int64) : Qwen3vBlockOffs {
     let fo = t.layer_f + l * t.layer_f_stride
     var o = Qwen3vBlockOffs(ln1_w = fo, ln1_b = fo + d, ln2_w = fo + 2l * d, ln2_b = fo + 3l * d,
         qkv_b = fo + 4l * d, out_b = fo + 7l * d, up_b = fo + 8l * d, down_b = fo + 8l * d + t.ff_pad)
-    let sizes <- q3v_gemm_sizes(d, t.q8 ? t.ff_pad : t.n_ff)   // the SERVED sizes — the q8 FFN pair pads
+    let sizes <- q3v_gemm_sizes(d, t.ff_pad)   // the SERVED sizes — the FFN pair pads both lanes
     var at = t.layer_w + l * t.layer_w_stride
     for (g in range64(QWEN3V_GEMMS)) {
         o.w[g] = at
@@ -652,7 +682,7 @@ def private q3v_gemm_blk(var y : array<float>; t : Qwen3vTower; var s : Qwen3vSt
         requant_rows_q8_sized(x, n, npos, s.xqi, s.xsi)
         matmul_q8q8_batch(y, t.qblob, t.qscales, off, s.xqi, s.xsi, n, d_out, npos)
     } else {
-        mm_plane_b(y, t.blk_bf16, t.wblob, t.blob, off, x, n, d_out, npos)
+        mm_plane_b(y, false, t.wblob, t.blob, off, x, n, d_out, npos)   // exact lane = f32 in blob
     }
 }
 
@@ -677,7 +707,7 @@ def private q3v_split_qkv(var s : Qwen3vState; d, npos : int64) {
 // one pre-LN block over the residual stream s.x (npos rows)
 def private q3v_block(t : Qwen3vTower; var s : Qwen3vState; l, npos : int64) {
     let d = t.n_embd
-    let ff = t.q8 ? t.ff_pad : t.n_ff   // the served FFN width — the q8 pad lanes are zero by construction
+    let ff = t.ff_pad   // the served FFN width — the pad lanes are zero by construction
     let hd = d / t.n_head
     let o = qwen3v_block_offs(t, l)
     var tp = ref_time_ticks()
@@ -726,7 +756,7 @@ def private q3v_stem(t : Qwen3vTower; var s : Qwen3vState; planes : array<float>
     ensure_length(s.qq, npos * d)
     ensure_length(s.kk, npos * d)
     ensure_length(s.vv, npos * d)
-    ensure_length(s.hu, npos * (t.q8 ? t.ff_pad : t.n_ff))
+    ensure_length(s.hu, npos * t.ff_pad)
     ensure_length(s.m0, (npos / 4l) * 4l * d)
     mm_plane_b(s.xn, false, t.wblob, t.blob, t.patch_w, s.x0, t.patch_dim, d, npos)
     var pos_base = t.pos_w
@@ -757,14 +787,14 @@ def private q3v_stem(t : Qwen3vTower; var s : Qwen3vState; planes : array<float>
 //! The soft-token row width this tower emits: proj_dim, widened by the deepstack slices.
 def qwen3v_row_width(t : Qwen3vTower) : int64 => t.proj_dim * (1l + t.n_deepstack)
 
-// one deepstack tap merger over the CURRENT residual stream (rows merge-adjacent, so the ×4
+// one deepstack tap merger over the tap layer's residual `x` (rows merge-adjacent, so the ×4
 // reshape is flat): LayerNorm → fc1 → GELU → fc2 into the wide out at slice k+1
-def private q3v_deepstack_tap(t : Qwen3vTower; var s : Qwen3vState; k, npos : int64; var out : array<float>) {
+def private q3v_deepstack_tap(t : Qwen3vTower; var s : Qwen3vState; x : array<float>; k, npos : int64; var out : array<float>) {
     let d = t.n_embd
     let nout = npos / 4l
     let fo = t.ds_f + k * t.ds_f_stride
     let wo = t.ds_w + k * t.ds_w_stride
-    layernorm_batch(s.ds_mid, s.x, t.blob, fo, fo + 4l * d, 4l * d, nout, t.eps)
+    layernorm_batch(s.ds_mid, x, t.blob, fo, fo + 4l * d, 4l * d, nout, t.eps)
     mm_plane_b(s.m0, t.mm_bf16, t.wblob, t.blob, wo, s.ds_mid, 4l * d, 4l * d, nout)
     add_bias_rows(s.m0, t.blob, fo + 8l * d, 4l * d, nout)
     gelu_tanh_lut_batch(s.m0, 4l * d, nout)
@@ -822,12 +852,28 @@ def qwen3v_encode(t : Qwen3vTower; var s : Qwen3vState; planes : array<float>; w
         ensure_length(s.ds_mid, (npos / 4l) * 4l * t.n_embd)
         ensure_length(s.ds_slice, (npos / 4l) * t.proj_dim)
     }
-    for (l in range64(t.n_layer)) {
-        q3v_block(t, s, l, npos)
+    var gpu_served = false
+    if (!t.q8 && g_q3v_gpu_set && invoke(g_q3v_gpu_serves)) {
         if (nds > 0l) {
-            let k = l == t.ds_l0 ? 0l : l == t.ds_l1 ? 1l : l == t.ds_l2 ? 2l : -1l
-            if (k >= 0l) {
-                q3v_deepstack_tap(t, s, k, npos, out)
+            ensure_length(s.ds_stash, nds * npos * t.n_embd)
+        }
+        gpu_served = invoke(g_q3v_gpu, t, s, npos)   // the block stack over s.x; tap residuals into ds_stash
+    }
+    if (gpu_served) {
+        for (k in range64(nds)) {
+            unsafe {   // stash slice k -> the xb2 scratch: the tap reads a plain [npos × d] source
+                memcpy(addr(s.xb2[0]), addr(s.ds_stash[k * npos * t.n_embd]), npos * t.n_embd * 4l)
+            }
+            q3v_deepstack_tap(t, s, s.xb2, k, npos, out)
+        }
+    } else {
+        for (l in range64(t.n_layer)) {
+            q3v_block(t, s, l, npos)
+            if (nds > 0l) {
+                let k = l == t.ds_l0 ? 0l : l == t.ds_l1 ? 1l : l == t.ds_l2 ? 2l : -1l
+                if (k >= 0l) {
+                    q3v_deepstack_tap(t, s, s.x, k, npos, out)
+                }
             }
         }
     }

--- a/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
@@ -427,8 +427,7 @@ def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwe
             let wname = "{p}.{Q3V_BLK_GEMM_NAMES[g]}.weight"
             if (!st.t.q8) {
                 if (g == QWEN3V_GEMM_UP) {
-                    gguf_read_tensor_f32(m, bytes, wname, st.blob, wo, ff * d)
-                    tower_zero_span(st.blob, wo + ff * d, (st.t.ff_pad - ff) * d)   // zero pad rows
+                    tower_stage_f32_zero_rows(m, bytes, wname, st.blob, wo, ff, st.t.ff_pad, d)
                 } elif (g == QWEN3V_GEMM_DOWN) {
                     tower_stage_f32_pad_cols(m, bytes, wname, st.blob, rowscratch, wo, d, ff, st.t.ff_pad)
                 } else {

--- a/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
+++ b/modules/dasLLAMA/dasllama/dasllama_qwen3v.das
@@ -65,7 +65,7 @@ struct Qwen3vTower {
     q8 : bool
     ff_pad : int64       // n_ff rounded up to 64 — the served FFN width, both lanes
     blob : PlaneF = PlaneF()
-    wblob : PlaneU16 = PlaneU16()
+    wblob : PlaneU16 = PlaneU16()   // empty since the f32 unification - kept for the meta/section shape
     qblob : PlaneI8 = PlaneI8()
     qscales : PlaneF = PlaneF()
     patch_w : int64      // [n_embd × patch_dim] f32 — W0 + W1 folded (stills eval both convs on one frame)
@@ -113,7 +113,7 @@ struct Qwen3vState {
     @exact_size ds_slice : array<float>  // deepstack tap / main-merger staging [nout × proj]
     @scratch @exact_size pos_rs : array<float>   // the pos table resized to the grid [npos × d]
     @exact_size cos_t : array<float>; @exact_size sin_t : array<float>
-    @exact_size ds_stash : array<float>  // GPU arm: the residual at each tap layer [n_ds × npos × d]
+    @exact_size ds_stash : array<float>  // GPU arm: each tap merger's proj output [n_ds × nout × proj]
     @scratch @exact_size xqi : array<int8>    // q8 lane: the requantized GEMM input, grown per site
     @scratch @exact_size xsi : array<float>   // its per-32-block scales
     @scratch pos2 : array<int2>      // per reordered row: (patch row, patch column)
@@ -250,9 +250,9 @@ var private g_q3v_gpu : Qwen3vGpuBlocksFn
 var private g_q3v_gpu_serves : Qwen3vGpuServesFn
 var private g_q3v_gpu_set = false
 
-//! The Metal tower's qwen3v block-loop seat ([init]): the blocks fn runs the stack over `s.x`
-//! (rope tables prebuilt) and fills `s.ds_stash` at the tap layers — false = decline, the CPU
-//! loop serves; `serves` answers the knob so the lane policy can prefer f32 planes.
+//! The Metal tower's qwen3v seat ([init]): the fn runs blocks + tap mergers + the tail on the
+//! GPU, landing proj outputs in `s.ds_stash`/`s.ds_slice` (caller-sized) — false = decline,
+//! the CPU loop serves; `serves` answers the knob so the lane policy can prefer f32 planes.
 def register_qwen3v_gpu(fn : Qwen3vGpuBlocksFn; serves : Qwen3vGpuServesFn) {
     g_q3v_gpu = fn
     g_q3v_gpu_serves = serves
@@ -348,6 +348,7 @@ def private q3v_verify_tensors(m : GGUFMeta; t : Qwen3vTower; gemm_sizes : array
     }
 }
 
+[unused_argument(woff)]   // the f32 unification left no wblob planes; the cursor stays for the stage's shape
 def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&; var qo : int64&) {
     let d = t.n_embd
     let ffs = t.ff_pad   // the served FFN width, BOTH lanes: %64 fits Metal tiles, %32 quantizes
@@ -356,9 +357,9 @@ def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&;
     t.pos_w = off; off += t.pos_side * t.pos_side * d
     t.post_ln_w = off; off += d
     t.post_ln_b = off; off += d
-    t.mm0_w = take_cursor(t.mm_bf16, off, woff, 16l * d * d)
+    t.mm0_w = off; off += 16l * d * d   // merger/tap GEMMs stage f32-in-blob like the blocks
     t.mm0_b = off; off += 4l * d
-    t.mm2_w = take_cursor(t.mm_bf16, off, woff, 4l * d * t.proj_dim)
+    t.mm2_w = off; off += 4l * d * t.proj_dim
     t.mm2_b = off; off += t.proj_dim
     t.layer_f_stride = 4l * d + 3l * d + d + t.ff_pad + d   // the up-bias slot is ff_pad both lanes (zero tail)
     t.layer_f = off; off += t.n_layer * t.layer_f_stride
@@ -375,7 +376,8 @@ def private q3v_layout(var t : Qwen3vTower; var off : int64&; var woff : int64&;
         t.ds_f_stride = 12l * d + t.proj_dim
         t.ds_f = off; off += t.n_deepstack * t.ds_f_stride
         t.ds_w_stride = 16l * d * d + 4l * d * t.proj_dim
-        t.ds_w = take_cursor(t.mm_bf16, off, woff, t.n_deepstack * t.ds_w_stride)
+        t.ds_w = off
+        off += t.n_deepstack * t.ds_w_stride
     }
 }
 
@@ -391,9 +393,9 @@ def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwe
     gguf_read_tensor_f32(m, bytes, "v.position_embd.weight", st.blob, st.t.pos_w, st.t.pos_side * st.t.pos_side * d)
     gguf_read_tensor_f32(m, bytes, "v.post_ln.weight", st.blob, st.t.post_ln_w, d)
     gguf_read_tensor_f32(m, bytes, "v.post_ln.bias", st.blob, st.t.post_ln_b, d)
-    tower_read_gemm(m, bytes, "mm.0.weight", st.wblob, st.blob, st.t.mm_bf16, st.t.mm0_w, 16l * d * d)
+    gguf_read_tensor_f32(m, bytes, "mm.0.weight", st.blob, st.t.mm0_w, 16l * d * d)
     gguf_read_tensor_f32(m, bytes, "mm.0.bias", st.blob, st.t.mm0_b, 4l * d)
-    tower_read_gemm(m, bytes, "mm.2.weight", st.wblob, st.blob, st.t.mm_bf16, st.t.mm2_w, 4l * d * st.t.proj_dim)
+    gguf_read_tensor_f32(m, bytes, "mm.2.weight", st.blob, st.t.mm2_w, 4l * d * st.t.proj_dim)
     gguf_read_tensor_f32(m, bytes, "mm.2.bias", st.blob, st.t.mm2_b, st.t.proj_dim)
     for (k in range64(st.t.n_deepstack)) {
         let dl = k == 0l ? st.t.ds_l0 : k == 1l ? st.t.ds_l1 : st.t.ds_l2
@@ -404,8 +406,8 @@ def private q3v_read_planes(m : GGUFMeta; bytes : array<uint8> | #; var st : Qwe
         gguf_read_tensor_f32(m, bytes, "{p}.fc1.bias", st.blob, dfo, 4l * d); dfo += 4l * d
         gguf_read_tensor_f32(m, bytes, "{p}.fc2.bias", st.blob, dfo, st.t.proj_dim)
         let dwo = st.t.ds_w + k * st.t.ds_w_stride
-        tower_read_gemm(m, bytes, "{p}.fc1.weight", st.wblob, st.blob, st.t.mm_bf16, dwo, 16l * d * d)
-        tower_read_gemm(m, bytes, "{p}.fc2.weight", st.wblob, st.blob, st.t.mm_bf16, dwo + 16l * d * d, 4l * d * st.t.proj_dim)
+        gguf_read_tensor_f32(m, bytes, "{p}.fc1.weight", st.blob, dwo, 16l * d * d)
+        gguf_read_tensor_f32(m, bytes, "{p}.fc2.weight", st.blob, dwo + 16l * d * d, 4l * d * st.t.proj_dim)
     }
     for (l in range64(st.t.n_layer)) {
         let p = "v.blk.{l}"
@@ -608,9 +610,6 @@ def mint_qwen3v_tower(var st : Qwen3vStaging; var out : Qwen3vTower) {
 // the bind walk skips a missing section silently, so the flag=>plane invariant must be checked
 // once the carrier is live, or the kernel derefs null
 def private q3v_check_planes(t : Qwen3vTower; src : string) {
-    if (t.mm_bf16 && empty(t.wblob)) {
-        panic("dasLLAMA qwen3v: '{src}' declares bf16 planes but carries no wblob section - the image is corrupt or hand-edited")
-    }
     if (t.q8 && (empty(t.qblob) || empty(t.qscales))) {
         panic("dasLLAMA qwen3v: '{src}' declares q8 block GEMMs but carries no qblob/qscales sections - the image is corrupt or hand-edited")
     }
@@ -795,19 +794,19 @@ def private q3v_deepstack_tap(t : Qwen3vTower; var s : Qwen3vState; x : array<fl
     let fo = t.ds_f + k * t.ds_f_stride
     let wo = t.ds_w + k * t.ds_w_stride
     layernorm_batch(s.ds_mid, x, t.blob, fo, fo + 4l * d, 4l * d, nout, t.eps)
-    mm_plane_b(s.m0, t.mm_bf16, t.wblob, t.blob, wo, s.ds_mid, 4l * d, 4l * d, nout)
+    mm_plane_b(s.m0, false, t.wblob, t.blob, wo, s.ds_mid, 4l * d, 4l * d, nout)
     add_bias_rows(s.m0, t.blob, fo + 8l * d, 4l * d, nout)
     gelu_tanh_lut_batch(s.m0, 4l * d, nout)
-    mm_plane_b(s.ds_slice, t.mm_bf16, t.wblob, t.blob, wo + 16l * d * d, s.m0, 4l * d, t.proj_dim, nout)
+    mm_plane_b(s.ds_slice, false, t.wblob, t.blob, wo + 16l * d * d, s.m0, 4l * d, t.proj_dim, nout)
     add_bias_rows(s.ds_slice, t.blob, fo + 12l * d, t.proj_dim, nout)
     q3v_scatter_slice(t, s.ds_slice, out, k + 1l, nout)
 }
 
-// copy a [nout × proj] slice into the wide out rows at slice index `sl`
-def private q3v_scatter_slice(t : Qwen3vTower; src : array<float>; var out : array<float>; sl, nout : int64) {
+// copy a [nout × proj] slice (at `soff` in src) into the wide out rows at slice index `sl`
+def private q3v_scatter_slice(t : Qwen3vTower; src : array<float>; var out : array<float>; sl, nout : int64; soff : int64 = 0l) {
     let w = qwen3v_row_width(t)
     unsafe {
-        let sp = addr<float const?>(src[0])
+        let sp = addr<float const?>(src[soff])
         var op = addr(out[0])
         for (r in range64(nout)) {
             copy_floats(op + r * w + sl * t.proj_dim, sp + r * t.proj_dim, t.proj_dim)
@@ -821,11 +820,11 @@ def private q3v_tail(t : Qwen3vTower; var s : Qwen3vState; npos : int64; var out
     let d = t.n_embd
     let nout = npos / 4l
     layernorm_batch(s.xb, s.x, t.blob, t.post_ln_w, t.post_ln_b, d, npos, t.eps)
-    mm_plane_b(s.m0, t.mm_bf16, t.wblob, t.blob, t.mm0_w, s.xb, 4l * d, 4l * d, nout)
+    mm_plane_b(s.m0, false, t.wblob, t.blob, t.mm0_w, s.xb, 4l * d, 4l * d, nout)
     add_bias_rows(s.m0, t.blob, t.mm0_b, 4l * d, nout)
     gelu_tanh_lut_batch(s.m0, 4l * d, nout)
     ensure_length(out, nout * t.proj_dim)
-    mm_plane_b(out, t.mm_bf16, t.wblob, t.blob, t.mm2_w, s.m0, 4l * d, t.proj_dim, nout)
+    mm_plane_b(out, false, t.wblob, t.blob, t.mm2_w, s.m0, 4l * d, t.proj_dim, nout)
     add_bias_rows(out, t.blob, t.mm2_b, t.proj_dim, nout)
     return nout
 }
@@ -854,18 +853,28 @@ def qwen3v_encode(t : Qwen3vTower; var s : Qwen3vState; planes : array<float>; w
     }
     var gpu_served = false
     if (!t.q8 && g_q3v_gpu_set && invoke(g_q3v_gpu_serves)) {
+        let nout4 = npos / 4l
+        ensure_length(s.ds_slice, nout4 * t.proj_dim)
         if (nds > 0l) {
-            ensure_length(s.ds_stash, nds * npos * t.n_embd)
+            ensure_length(s.ds_stash, nds * nout4 * t.proj_dim)
         }
-        gpu_served = invoke(g_q3v_gpu, t, s, npos)   // the block stack over s.x; tap residuals into ds_stash
+        gpu_served = invoke(g_q3v_gpu, t, s, npos)   // blocks + taps + tail on GPU: proj outputs land in ds_stash/ds_slice
     }
     if (gpu_served) {
-        for (k in range64(nds)) {
-            unsafe {   // stash slice k -> the xb2 scratch: the tap reads a plain [npos × d] source
-                memcpy(addr(s.xb2[0]), addr(s.ds_stash[k * npos * t.n_embd]), npos * t.n_embd * 4l)
+        let nout4 = npos / 4l
+        if (nds > 0l) {
+            for (k in range64(nds)) {
+                q3v_scatter_slice(t, s.ds_stash, out, k + 1l, nout4, k * nout4 * t.proj_dim)
             }
-            q3v_deepstack_tap(t, s, s.xb2, k, npos, out)
+            q3v_scatter_slice(t, s.ds_slice, out, 0l, nout4)
+        } else {
+            ensure_length(out, nout4 * t.proj_dim)
+            unsafe {
+                memcpy(addr(out[0]), addr(s.ds_slice[0]), nout4 * t.proj_dim * 4l)
+            }
         }
+        asr_prof_add("q3v.tail", tp)
+        return nout4
     } else {
         for (l in range64(t.n_layer)) {
             q3v_block(t, s, l, npos)

--- a/modules/dasLLAMA/dasllama/dasllama_scheduler.das
+++ b/modules/dasLLAMA/dasllama/dasllama_scheduler.das
@@ -58,7 +58,7 @@ struct PendingReq {
     // MEDIA splice (images today; audio rides the same fields): `n_media` embedding rows that
     // prefill BETWEEN prompt[media_at-1] and prompt[media_at] — the render seam hands the two
     // token spans and the encoder hands the rows. Zero rows = an ordinary text request.
-    media_embd : array<float>               // n_media * model.config.dim soft-token rows
+    media_embd : array<float>               // n_media rows: dim-wide (audio), dim*(1+n_deepstack)-wide (images — what encode_image emits)
     n_media : int64
     media_at : int64                        // prompt index the rows splice at (0 <= media_at <= |prompt|)
     media_non_causal : bool                 // the rows attend each other in full (gemma vision); audio is causal
@@ -194,8 +194,12 @@ def submit(model : Model; var sch : Scheduler; var req : PendingReq) : bool {
         if (req.media_at < 0l || req.media_at > np) {
             panic("dasllama_scheduler: media splice at {req.media_at} outside the {np}-token prompt (stream {req.id})")
         }
-        if (long_length(req.media_embd) < req.n_media * model.config.dim) {
-            panic("dasllama_scheduler: {req.n_media} media rows need {req.n_media * model.config.dim} floats, got {length(req.media_embd)} (stream {req.id})")
+        // image rows on a deepstack decoder must arrive (1+n)·dim-wide (what the tower's
+        // encode_image emits) — a narrow feed would silently skip the per-layer slice adds
+        let media_ds = req.media_non_causal ? model.config.n_deepstack : 0l
+        let media_need = req.n_media * model.config.dim * (1l + media_ds)
+        if (long_length(req.media_embd) != media_need) {
+            panic("dasllama_scheduler: {req.n_media} media rows need {media_need} floats ({media_ds} deepstack slices at dim {model.config.dim}), got {length(req.media_embd)} (stream {req.id})")
         }
         if (min(req.media_grid.x, req.media_grid.y) < 0 || ((req.media_grid.x > 0) != (req.media_grid.y > 0))) {
             panic("dasllama_scheduler: media_grid {req.media_grid} is neither (0,0) nor a positive grid (stream {req.id})")

--- a/modules/dasLLAMA/dasllama/dasllama_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_tower.das
@@ -382,6 +382,28 @@ def tower_repack_q8_blocks(var qblob : array<int8>; var qscales : array<float>;
     }
 }
 
+//! The f32 twin of ``tower_stage_q8_pad_cols``: stage a ``[rows × ff]`` GEMM into its padded
+//! ``[rows × fp]`` f32 region — each file row lands first, then ``fp − ff`` zero tail columns
+//! (the pads multiply the up GEMM's zero pad outputs, bit-identical).
+def tower_stage_f32_pad_cols(m : GGUFMeta; b : array<uint8> | #; name : string; var blob : array<float>;
+                             @scratch var rowscratch : array<float>; wo, rows, ff, fp : int64) {
+    if (long_length(rowscratch) < rows * ff) {
+        rowscratch |> reserve(rows * ff)
+        rowscratch |> resize(rows * ff)
+    }
+    gguf_read_tensor_f32(m, b, name, rowscratch, 0l, rows * ff)
+    unsafe {
+        var dp = addr(blob[wo])
+        let sp = addr(rowscratch[0])
+        for (r in range64(rows)) {
+            memcpy(dp + r * fp, sp + r * ff, ff * 4l)
+            for (i in range64(ff, fp)) {
+                dp[r * fp + i] = 0.0
+            }
+        }
+    }
+}
+
 //! Zero ``n`` floats at ``at`` — pad tails of staged planes.
 def tower_zero_span(var a : array<float>; at, n : int64) {
     if (n <= 0l) {

--- a/modules/dasLLAMA/dasllama/dasllama_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_tower.das
@@ -382,6 +382,15 @@ def tower_repack_q8_blocks(var qblob : array<int8>; var qscales : array<float>;
     }
 }
 
+//! The f32 twin of ``tower_stage_q8_zero_rows``: stage a ``[file_rows × width]`` GEMM into its
+//! padded region — the file's rows land first, then ``pad_rows − file_rows`` zero weight rows
+//! (the pad outputs are exactly zero).
+def tower_stage_f32_zero_rows(m : GGUFMeta; b : array<uint8> | #; name : string; var blob : array<float>;
+                              wo, file_rows, pad_rows, width : int64) {
+    gguf_read_tensor_f32(m, b, name, blob, wo, file_rows * width)
+    tower_zero_span(blob, wo + file_rows * width, (pad_rows - file_rows) * width)
+}
+
 //! The f32 twin of ``tower_stage_q8_pad_cols``: stage a ``[rows × ff]`` GEMM into its padded
 //! ``[rows × fp]`` f32 region — each file row lands first, then ``fp − ff`` zero tail columns
 //! (the pads multiply the up GEMM's zero pad outputs, bit-identical).

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -803,3 +803,16 @@ P31 (pool pins remove the slack) WRONG for pp, RIGHT for enc.
 From the arc's start: enc 2194/3446/6411 → 179/257/241 (12-27x); pp −16/−29/−41% →
 −16/−16/−5%. das leads every qwen3v Metal encode; the pp residual is ONE named mechanism
 with a scoped fix.
+
+**Validation-round catch (make_pr battery): the tower missed the weights-epoch flush.**
+`test_vision_chat` deepstack cell red — the cats turn captioned a nonexistent eye, CPU lane
+green. Root cause: `plane_buffer`/`upload_region` key resident regions by HOST ADDRESS with a
+`weights_epoch` guard that decode (`metal_decode.das:1986`) and prefill
+(`metal_prefill_forward` entry) honor — the tower never called it, so a deleted gemma
+embedder's mapped blob address, recycled by the next qwen3v mmap, served GEMMA weights to the
+qwen3v encode (probe: gemma3v encode → qwen3v encode = every row wrong, maxdiff 1571; without
+the warm-up encode = float noise, 3 rows ≤0.134). Latent since the first tower family —
+exposed by qwen3v being the first cross-family GPU tower sequence in one process. Fix:
+`weight_caches_flush_on_reload()` at `metal_tower_init` entry (the prefill's exact seam).
+Regression witness: the deepstack cell itself (red without the line, green with — both
+proven). Re-gate: vision_chat 16/16, qwen3v 12/12, gemma4uv/4v/3v, mtower — all green.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -653,3 +653,36 @@ Metal tower deletes it too.
 25. Wired at the prefill seam (fire when > ~1 s since the last Metal submission), the
     re-measured Metal img:pp lands 8B −7..−13% vs ref (from −29%) and 4B −3..−9% (from
     −16%); CPU cells and tg unchanged.
+
+#### Slice M warm-up verdict (2026-08-23): the penalty cannot be pre-paid — the tower is the fix
+
+Probe ladder on the 8B (each arm = encode, then the warm-up variant, then the timed span
+eval; clean eval 609 ms, after-encode 680 ms):
+
+| warm-up variant | own cost | eval after | verdict |
+|---|---|---|---|
+| empty command buffer (async) | ~0 | 678.6 | nothing |
+| empty cb + wait (round trip 0.107 ms!) | ~0 | 678.5 | the driver was never asleep |
+| MTLResidencySet pin (146 buffers incl. the blob, active) | 0 | 679.4 | residency is not the mechanism |
+| 1-thread real kernel (async) | ~0 | 678.0 | execution alone is not the trigger |
+| page-touch kernel (1 load / 16 KB page, whole blob) | 17-23 ms | 675.2 | page faults are not the mechanism |
+| 1-token decode (streams ALL weight bytes) | ~100 ms (28 warm) | **608.4** | full repay — rides the ramp itself |
+| 32-row prefill | ~148 ms | 608.9 | same |
+| page-touch pulse train through the encode (real thread) | — | 684.0 | light load does not hold the domain |
+
+**The operational law:** after a multi-second CPU-saturating phase, the first ~70 ms (8B; ~
+scales with the model's bandwidth demand) of sustained-bandwidth GPU work runs degraded —
+a memory/GPU governor ramp, not residency, not paging, not driver wake. It is one-time per
+burn, is absorbed by whatever heavy work runs first, and cannot be pre-paid by anything
+cheaper than the ramp itself; a synchronous warm-up always nets a loss (own cost rides on
+top). Scored: **P23 CORRECT** (empty repays nothing), **P24 HALF** (the full-stream warm-up
+repays 100% but costs ~100 ms, 2.5x the predicted bound — because it IS the ramp),
+**P25 VOID** (no warm-up lever exists to wire; the residency machinery was implemented,
+measured at zero effect, and reverted — the probe ledger above is what it bought).
+
+**Consequence:** the das Metal image-turn pp gap on CPU-encoding models is the price of the
+CPU tower, not of the prefill lane (das text prefill = parity; the eval machinery = +10 ms).
+The remedy is slice J's deferred **Metal tower for the qwen ViTs** — GPU encodes keep the
+domain loaded, delete the 2-12 s CPU encodes AND the ramp, and also delete the still-open
+1.7x metal-armed-CPU-encode anomaly. Until a family's tower serves on GPU (qwen25v, the
+conformer audio encoders), its image/audio-turn pp keeps the ramp — ledgered.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -765,3 +765,41 @@ ds-WIDE decoder tax (+23/+13 ms wide-quantum staging in the PREFILL) + span atte
 decoder-side lever (dasllama_metal_prefill), not tower work; the no-ds 30B hitting parity is
 the discriminating witness. P28 rescored: enc BEAT the band; pp within ±8% on the no-ds
 model only. Captions correct on all three.
+
+#### Slice J round 3 (2026-08-23): the parity hunt — wide borrow, residency pin, and the named residual
+
+**Landed:** (1) the WIDE BORROW — `forward_prefill_embd` arms a borrowed view of the caller's
+wide quantum instead of splitting it (Session.wide_src/stride/soff; `ds_split_quantum` is the
+CPU fallback's lazy half and the warm/MTP edge's); the Metal prefill uploads the quantum WHOLE
+and slices it on-device via `enc_head_restride` (which gained src/dst offsets — dispatch-time
+binds, no MSL change); bds turns tracked when GPU-written. (2) the RESIDENCY PIN v2 —
+MTLResidencySet over weight regions/planes + every recycled pool buffer
+(`pool_acquire_pinned` twins, seen-table idempotence, reset rides regions_release_all;
+DASLLAMA_METAL_RESIDENCY=0 is the A/B rail, witness cell in test_metal_prefill_parity):
+**measured A/B ×2: encode −15 ms reproducible (177/180 vs 194/194) — the tower's first
+submission after its CPU stem; pp unmoved.** Gates: parity + attn_span (hazard-strict) +
+qwen3v 12/12.
+
+**The pp residual, fully audited (the probe ladder):** the das GPU work at the exact bench
+turn shape = 333 ms (963 tok/s, text-parity); the bench context adds a ~40 ms one-time
+commit→execution slack on the first submission after ANY CPU-only window (ncb-invariant,
+affinity-invariant, mint-invariant, unpindable — pools pinned changed nothing; denormals,
+page faults, queue identity, decode aftermath, assemble bursts all REFUTED by probe). The
+tracked-pools→untracked experiment REDDED parity — the hazard tracking is load-bearing, so
+the per-commit dependency pass (line-563 lore: ~70 ms/prefill before the weights went
+untracked) stays, and runs cold after CPU windows. **The remaining fix is a per-buffer
+tracking audit** (which pool buffers need Metal's tracking vs the capture rail's own
+barriers) — its own slice. P30 (wide borrow recovers the gap) WRONG — the split was ~2 ms;
+P31 (pool pins remove the slack) WRONG for pp, RIGHT for enc.
+
+**The final board (released rig, Metal, r=3, honest walk):**
+
+| model | enc das | enc ref | das vs ref | img:pp das | ref | gap |
+|---|---|---|---|---|---|---|
+| 4B (ds) | **178.8 ms** | ~250 | **+40%** | 851.8 | ~1009 | −16% |
+| 8B (ds) | **257.1 ms** | ~508 | **+98%** | 473.7 | ~566 | −16% |
+| 30B | **240.5 ms** | ~250 | +4% | 776.8 | ~815 | −5% |
+
+From the arc's start: enc 2194/3446/6411 → 179/257/241 (12-27x); pp −16/−29/−41% →
+−16/−16/−5%. das leads every qwen3v Metal encode; the pp residual is ONE named mechanism
+with a scoped fix.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -517,3 +517,139 @@ form). Cells stamp `(qwen3v q8)`. Qwen2.5-Omni-3B unmeasured — no q8 lane (sli
     "within 1.5x either side"), and the 30B lead is 39x (predicted past 30x). qwen25v VOID.
 16. **CORRECT so far**: captions unchanged-quality on all three measured models (+ the 4B
     chat-suite caption). 4 of 4 checked, 0 flips.
+
+### Slice M — the Metal image-turn pp gap (dig opened 2026-08-23; Boris: separate PR)
+
+**Target:** slice J's Metal `img:pp` reds — das/lcpp 3B −12%, 4B −16%, 8B −30%, 30B MoE
+−41% — while das leads or ties every gemma Metal image cell post-3815.
+
+**FOUND FIRST (before any timing): the bench's image cell feeds deepstack decoders a NARROW
+scrambled span.** `measure_image_turn` copies `n_rows * dim` floats into an `npos * dim`
+buffer, but a qwen3v ds tower emits `n_rows × dim*(1+n_ds)` wide rows (probe: the 4B mmproj
+scans n_deepstack=3, row_width=10240, nout=300, len/nout=10240). The copy flattens the first
+75 wide rows into 300 narrow slots: content scrambled, ds adds never active (`embd_is_ds_wide`
+keys on length), das doing LESS prefill work than the lcpp leg it lost to. Every 4B/8B
+img:pp/img:tg cell in the J sweep priced that walk; the clean captions survived on content
+redundancy — the greedy-tie gate lesson's third strike. Blast radius: plan figures only (no
+cards ruled, nothing committed to records/). 30B and qwen25o have no ds slices → their cells
+stand. Fix: the chat gains `add_user_image_rows_` (pre-encoded rows in, width-checked), the
+bench drives `respond_` through it — the cell prices the literal shipped walk, and the
+hand-splice divergence class dies.
+
+### Slice M predictions (18 registered before the row-width probe ran; 19-22 before any
+### re-measurement or decomposition; das vs llama.cpp, M1 Max t=8, coco fixture)
+
+18. The scramble hypothesis: the 4B mmproj scans ds=3 and emits wide rows, so the bench
+    span is scrambled and ds-less. **SCORED: CORRECT** (probe above; called before running).
+19. On the fixed bench the das 4B/8B img:pp cells get SLOWER — the Metal gap widens by
+    3-10 points (ds adds + 4x embd staging) — and at least one of the two models' captions
+    changes text vs the scrambled run. CPU img:pp moves the same direction; enc unchanged.
+20. The dominant term of the (fixed) 4B/8B Metal pp gap is NOT image plumbing: a text-only
+    control at matched npos (~320) on the same decoders reproduces >= 2/3 of the gap, and
+    skip-family knockouts attribute >= 60% of the das wall to the gemm family.
+21. The gap shrinks with M: at npos 512+ das text prefill on the VL-4B/8B decoders is within
+    +/-5% of lcpp (the board's dense text history) — short-M efficiency, not raw throughput.
+22. The 30B MoE −41% is its own mechanism — the MoE expert batched-prefill path: knockouts
+    attribute >= 50% of its das wall to the moe/gemm family, and its per-token deficit vs
+    lcpp at image-turn M is >= 1.5x the dense models'.
+
+#### Slice M progress (2026-08-23)
+
+**Fix landed (uncommitted yet): the bench prices the shipped walk.** The chat gained
+`add_user_image_rows_` (pre-encoded rows in, exact-width panic against `dim*(1+n_ds)`,
+one-media-kind + marker checks; `respond_` consumes them identically to the embedder walk —
+`test_vision_chat_rows_seam` pins token-for-token parity on the 4B ds pair). The bench's
+`measure_image_turn` now drives create_chat_ → add_user_image_rows_ → respond_ — the
+hand-splice, its private stop protocol, and the narrow copy are gone. The scheduler's media
+guard tightened to exact width (narrow image rows on a ds decoder now panic — the same silent
+class through the server seam; two new panic cells in test_scheduler). Sibling find:
+test_audio_embedder's dlim scan took the FIRST sibling by directory order and grabbed the
+gemma4v vision image — now selects by baked `gemma4a-` family tag (pre-existing red the
+vision re-mints exposed).
+
+**Re-measure (released rig rebuilt --quick, same J protocol, r=3 t=8):** the honest walk
+timings are statistically UNCHANGED — 4B Metal img:pp 841.1 (J scrambled 847.6; a first
+688.0 run was an outlier, re-run confirmed), 8B Metal 402.1 (396.0), 3B control 1231.0
+(1229.9), 4B CPU 251.3 (250.9), 8B CPU 136.4 (139.3). tg unchanged everywhere. Captions on
+the fixed span now match the chat walk (pink couch/blanket, richer detail) where the
+scrambled span said red. **P18 CORRECT; P19 WRONG on cost** (predicted 3-10 point widening;
+ds staging + wide upload price ≈ 0 — 3 enc_adds and ~15 MB staging on a 400-850 ms wall);
+the caption-changes half was right. **Consequences: the J gap magnitudes stand on the honest
+walk, and deepstack staging is EXONERATED as the 8B suspect — the −30% exists with ds adds
+active and cost-free.** Metal-leg encode note: both VL Metal cells now ride the q8 tower
+(enc 4B 2194 ms / 8B 3446 ms vs CPU-leg 1085/1902 — the Metal-leg CPU encode runs ~2x the
+CPU-leg's; unexplained, parked — encode is slice-J/L territory).
+
+#### Slice M decomposition (2026-08-23, released rig, 4B/3B Metal; walls at ~equal mp pad)
+
+**Turn shapes verified equal both engines** (Boris's "same formats" check): das image npos =
+4 head + 300 rows + 17 tail = **321**; the mtmd ref's repriced rows = 41 + (300−20) = 321.
+Both engines KV f16; llama-bench/mtmd fa auto(on for Metal); same Q8_0 gguf (das planar
+repack = the das lane by design). llama.cpp build 98c4764b6 (2026-08-13).
+
+**Text-M control (rig -p + --ref, same padded GEMM shapes as the image turn):** das text
+prefill is at parity — 4B p341 das 1038.3 vs ref 1011.3 (+2.7%), p512 +1.3%; 8B p341 −6.2%,
+p512 +0.3%; 3B p412 −5.3% (cv 4.6%, over bar — flag). **P20/P21 land WRONG in the
+informative direction: the image gap does NOT reproduce in text** — das's own image turn runs
+~16% below das text at the same padded M (4B: wall 381.6 vs 328.4 ms), while lcpp's image
+turn runs AT its text rate. The mechanism is das-side, image-turn-specific.
+
+**Span-fuse A/B:** fused 841.1 vs splice 687.7 (DASLLAMA_SPAN_FUSE=0) — the fuse works,
++22%. ⚠ the first fixed-cell run measured 688.0 ≈ the splice number exactly with NO
+SPAN_FUSE set and fused announce absent — unexplained single occurrence, parked (if a
+silent fuse-decline exists it is worth a witness).
+
+**Knockout ladders (DASLLAMA_METAL_PREFILL_SKIP, walls in ms, image−text at equal mp):**
+
+| model | total Δ | gemm Δ | attn Δ | ew Δ | nongemm Δ | floor Δ (all-gemm-skipped) |
+|---|---|---|---|---|---|---|
+| 4B (ds) | +53 | **+23** | +4.4 | −1.6 | +7.3 | **+30** (51.4 vs 21.4) |
+| 3B (no ds) | +18 | **≈0** (298.3 vs 299.6) | — | — | — | **+19** (36.4 vs 17.4) |
+
+Two mechanisms:
+1. **The staging floor (every mrope model, +19..30 ms/turn):** survives skipping every GPU
+   kernel family — the embd quantum's CPU-side assemble + upload + per-turn setup (wide
+   splice, ds repack, mrope tables/positions). lcpp pays no such delta.
+2. **The ds-wide gemm tax (deepstack models only, ~7.5% of gemm):** same padded shapes, same
+   weights, +23 ms of gemm — only on the wide-quantum models; the 3B control acquits mrope
+   and the span mask. Suspect: the wide quantum's x staging / slice-0 split path.
+Attention's non-causal span block is real but small (+4.4 ms ≈ the extra 300² pairs).
+Consistency: 3B −5.3% text − 5.6% floor ≈ its −12% cell; 4B par text − 16% overhead ≈ −16%.
+8B ladder running; 30B MoE arm unprobed (P22 open).
+
+#### Slice M mechanism (2026-08-23, stage-stats probe, 8B, synthetic wide quantum)
+
+The image-turn overhead is NOT in the eval: tokens / narrow-embd / wide-mrope-span all run
+~600-609 ms in a quiet process (gpu_us ≈ wall; the whole wide+ds+mrope quantum costs +10 ms
+over tokens). The bench-context penalty reproduces by running the CPU tower ENCODE first:
+**wide-span-after-encode = 680 ms, +70 ms with gpu_us up only 4 ms — host-side latency
+between submit and execution on the FIRST Metal submission after the burn.** A 400 ms idle
+cooldown recovers nothing; **a sacrificial second eval after the same encode runs clean
+(608.9 ms)** — a one-time residency/driver-state repayment, not thermal, not scheduler decay.
+Every real image turn pays it because every turn starts with the CPU encode; lcpp never pays
+it (their mmproj encodes on the GPU). Knockout floors scale with pool size: 3B +19, 4B +30,
+8B +133 ms.
+
+**The qwen Metal img:pp gap decomposes as:** post-encode first-submission penalty (dominant,
+scales with model) + ds-wide gemm tax (+13-23 ms, 4B/8B) + non-causal span attention (+4 ms,
+intrinsic) + text-lane ≈ parity. 30B MoE (−41%) unprobed — its 6.4 s burn + biggest pools
+fit the same profile; a MoE-lane term may remain (P22 open).
+
+**Levers:** (1) the slice-J Metal tower for qwen ViTs deletes the burn AND its aftermath —
+one fix for both enc (2-12 s → sub-second) and most of the pp gap; (2) available today: a
+tiny warm-up submission between encode and prefill eats the one-time penalty on the das side
+(~70 ms back on 8B) — a real serving-path improvement, not bench cosmetics; (3) the ds-wide
+gemm staging tax, small follow-up. ALSO FOUND, unexplained: arming Metal makes the CPU q8
+tower encode ~1.7x slower (probe 3.26 s vs CPU-leg 1.90 s on the 8B) — its own dig; the
+Metal tower deletes it too.
+
+### Slice M warm-up lever (Boris 2026-08-23: "lets do warmup and see how it turns out");
+### predictions 23-25 registered BEFORE the warm-up probes
+
+23. The empty-command-buffer warm-up repays under 30% of the +70 ms (the post-encode eval
+    stays >= 650 ms on the 8B): the cost is residency of the big buffers, not driver wake.
+24. A 1-position throwaway prefill as the warm-up repays >= 80% (following eval <= 620 ms);
+    its own GPU cost <= 40 ms, hideable behind the real quantum's CPU staging.
+25. Wired at the prefill seam (fire when > ~1 s since the last Metal submission), the
+    re-measured Metal img:pp lands 8B −7..−13% vs ref (from −29%) and 4B −3..−9% (from
+    −16%); CPU cells and tg unchanged.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -740,3 +740,28 @@ the prefill), so the §2.12 ramp re-arms. **The named next lever: the taps + tai
 the GPU chain** (same dispatch vocabulary over the flat-reinterpreted merged rows) — cuts
 the enc gap vs mtmd AND deletes the trailing burn that keeps pp from parity. P29 untested
 (qwen25v arm not re-run).
+
+#### Slice J round 2 (2026-08-23): taps + tail merger on the GPU chain
+
+The tap chains encode INLINE over the live residual (hazard tracking orders them against the
+next block's writes — the segments and stashes died), the tail merger follows the loop, and
+ONE readback lands compact proj outputs for the CPU scatter. The merger/tap planes unified to
+f32-in-blob (the bf16 GEMM arm dies; the Omni tail widens 61 MB) → IMAGE_VERSION 13. The
+[nout × 4d] merged view doubles the row buffers' size demand (rows_ext = max(mp, 4·ceil32(nout))).
+test_qwen3v 12/12 unchanged bars.
+
+**Measured (released rig, Metal leg, r=3; "before" = pre-J):**
+
+| model | enc before → NOW | ref enc | img:pp before → NOW | ref pp |
+|---|---|---|---|---|
+| 4B (ds) | 2194 → **193 ms** (11.4x) | ~250 | 841 → 847 (−16%) | ~1009 |
+| 8B (ds) | 3446 → **277 ms** (12.4x) | ~508 | 402 → **468** (−17%) | ~566 |
+| 30B (no ds) | 6411 → **240 ms** (26.7x) | ~250 | 481 → **779** (−4%) | ~815 |
+
+**das now LEADS every qwen3v Metal encode**, and the 30B image pp is at parity — its −41%
+was almost entirely the §2.12 ramp (P22 scores WRONG: no MoE-lane mechanism remained once
+the burn died). The 4B/8B pp residual (−16/−17%) matches the slice-M non-ramp terms — the
+ds-WIDE decoder tax (+23/+13 ms wide-quantum staging in the PREFILL) + span attention — a
+decoder-side lever (dasllama_metal_prefill), not tower work; the no-ds 30B hitting parity is
+the discriminating witness. P28 rescored: enc BEAT the band; pp within ±8% on the no-ds
+model only. Captions correct on all three.

--- a/modules/dasLLAMA/qwen3vl_plan.md
+++ b/modules/dasLLAMA/qwen3vl_plan.md
@@ -686,3 +686,57 @@ The remedy is slice J's deferred **Metal tower for the qwen ViTs** — GPU encod
 domain loaded, delete the 2-12 s CPU encodes AND the ramp, and also delete the still-open
 1.7x metal-armed-CPU-encode anomaly. Until a family's tower serves on GPU (qwen25v, the
 conformer audio encoders), its image/audio-turn pp keeps the ramp — ledgered.
+
+### Slice J (opened 2026-08-23, Boris: "lets do J - and see where we are at"): the qwen3v
+### Metal tower — predictions 26-29 registered BEFORE implementation
+
+Design (the gemma3v recipe, converged): the exact lane re-stages the block GEMMs as
+**f32-in-blob at ff_pad both dims** (gemma3v's "%64 fits Metal tiles, %32 quantizes" law;
+bf16 blk lane retired — mergers/taps keep their planes); `q3v_serve_q8` gains the
+gpu-serves clause + `register_qwen3v_gpu` hook, so the lane ladder matches g3v: q8 CPU
+default / f32 exact when the Metal tower or accel serves. The Metal encode: stem + reorder +
+pos stay CPU; the block loop rides `metal_gemma3v_blocks`' dispatch chain + `enc_rope`
+(NEOX, per-token table rows = `s.cos_t/s.sin_t` uploaded once per grid) on q/k compact
+before head-restride; the fused qkv serves as THREE `enc_f32_mm` at weight row offsets
+(0, d*d, 2d*d); shapes pass the existing gates (d 1152%64=0, ff_pad 4352%64=0, hs 72 →
+hs_pad 128). Deepstack taps + the tail merger ride the same chain on GPU — the ×4 merge
+reshape is a flat reinterpretation of the row buffer, so tap input = the residual buffer
+read as [npos/4 × 4d]; compact tap/tail outputs read back and scatter into the wide out on
+the CPU. Identity: verify the layout change shifts the dlim identity (offsets serialize);
+if the meta hash misses it, bump the family tag — the slice-L stale-dlim lesson.
+
+26. The qwen3v Metal blocks land with ZERO new Metal kernels — enc_rope covers the vision
+    rope, weight-offset GEMMs cover the fused qkv, the existing LN/mm/gelu chain covers the
+    taps and tail.
+27. Tier-1 exact cells pass on the FIRST honest run after the f32 re-stage at equal-or-
+    tighter maxdiff than the bf16 lane's; the likely red, if any, is the rope table
+    addressing against the merge reorder, not the GEMM chain.
+28. Measured 4B Metal encode (coco, 300 tok): 250-500 ms (today 2194 ms; mtmd Metal ~250);
+    the Metal-leg img:pp recovers to within +/-8% of lcpp — the burn and its ramp gone.
+29. The 1.7x metal-armed-CPU-encode anomaly goes moot on qwen3v and stays reproducible on
+    qwen25v — it rides the CPU-encode-under-Metal context, not the family.
+
+#### Slice J checkpoint (2026-08-23, released rig, Metal cells, r=3, coco)
+
+**LANDED (branch, 12/12 test_qwen3v):** the qwen3v Metal tower — the exact lane re-staged
+f32+ff_pad both dims (IMAGE_VERSION 12: the identity hashes knobs+version+tag, never offset
+values — a served-layout change without a bump maps stale images, third strike, rule now on
+the constant), `register_qwen3v_gpu` + the lane's driver clause, `metal_qwen3v_blocks`
+(gemma3v's chain + enc_rope NEOX on compact q/k + the fused qkv as three weight-offset GEMMs
++ tap-layer segments stashing residuals for the CPU tap mergers — ZERO new Metal kernels,
+P26 CORRECT). Tier-1: CPU f32 floor moved (ff_pad regroups the down GEMM's accumulation;
+red448 3.2e-3 → TIER1_REL 1.5e-2 with a LIVE exact zero-layer poison, excess 0.87); the
+Metal arm gates on its own GPU bars (the gemma3v f16-tile precedent; gray stays off the
+GPU-ds set — the q8-ds precedent; engage evidence +6 encodes/+153 blocks/0 declines).
+P27 HALF: first-honest-run needed the bar recalibrations, and the miss was accumulation
+grouping + the ds-gray tap slices, not rope.
+
+**Measured (das Metal leg, before → after):** 4B enc 2194 → **512 ms** (4.3x; mtmd Metal
+~250), 8B enc 3446 → **752 ms** (4.6x; ref ~508). img:pp: 8B 402 → **445** (−29% → −21% vs
+ref ~566); 4B 841 → **849** (−16% unchanged). tg unchanged; captions correct both models
+(pink couch). **P28 HALF**: enc inside the predicted band, pp did NOT fully recover — the
+encode still ENDS with a CPU burst (the taps + tail merger: ~8.6 GFLOP all-core right before
+the prefill), so the §2.12 ramp re-arms. **The named next lever: the taps + tail merger onto
+the GPU chain** (same dispatch vocabulary over the flat-reinterpreted merged rows) — cuts
+the enc gap vs mtmd AND deletes the trailing burn that keeps pp from parity. P29 untested
+(qwen25v arm not re-run).

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -238,21 +238,28 @@ restride to the attention tiles' 128 on the driver). Skips honestly without the 
 `test_qwen3v.das` — the qwen3v tower tier-1 parity vs the `-p encode` dumps minted on
 f32-widened mmprojs, CPU (`qwen3vl-vision-oracle/mint.sh` + `mint_4b.sh`): the Omni leg
 (`qwen3vl_merger` no deepstack) on seven fixtures (cb96 = the pos-table downscale arm,
-cb640x320 = the merge-reorder/transposed-grid gate) at 2e-4 + 1e-2·token-rms, plus the
+cb640x320 = the merge-reorder/transposed-grid gate) at 2e-4 + 1.5e-2·token-rms (the ff_pad
+width regroups the down GEMM's f32 accumulation; the live exact-lane zero-layer poison reds
+the bar at 0.87), plus the
 merged-patch-grid panic gate; and the Qwen3-VL 4B DEEPSTACK leg (taps 5/11/17, wide
 10240-float rows) on four fixtures at 2e-4 + 4e-2·rms — the 4B dumps carry q1/q2/q3 quarter-offset probe
 fields — the compare applies them when the dump has them — hitting each concatenated
 slice's first element (a skipped-tap poison lands at 6.9–9.7 on them, 600×; mean+v0..v3
-alone are BLIND to a zeroed slice). The q8 serving lane (the CPU policy default when no
-accelerate float-batch tier is active) gets its own cells, each bar carrying its own
+alone are BLIND to a zeroed slice). The q8 serving lane (the CPU policy default when
+neither the Metal tower nor the accelerate float-batch tier serves —
+`qwen3v_gpu_would_serve()` is the driver clause) gets its own cells, each bar carrying its own
 must-EXCEED poison leg — a block's qblob region zeroed through the staging planes, scored
 by `encode_excess`: the Omni leg on gray448 + cb448 + cb96 at its measured 5.2e-1·rms bar,
 poisoned at a mid-stack block; the deepstack leg on cb448 + cb96 at 6.5e-1, poisoned at
 the TAP-1 block so the zero hits both the main path and a served slice — gray's tap-slice
 probes measure 7.9·rms because the taps sample mid-network residuals, so gray stays on the
 exact lane's set, and the proof that the served slices still carry signal is the
-zeroed-slices decoder control in `test_vision_chat.das`; and a model-free lane-knob cell.
-The model-gated cells skip honestly without the mmprojs or dumps.
+zeroed-slices decoder control in `test_vision_chat.das`; a METAL tower cell (both towers,
+tower pinned ON, its own GPU bars 4e-2 / 8e-2·rms per the gemma3v f16-tile precedent, gray
+off the GPU-ds set like the q8-ds cell, engage proven by encode/block counter deltas per
+GATED fixture, and its own GPU-lane zero-layer poison); and a model-free lane-knob cell.
+The model-gated cells skip honestly without the mmprojs or dumps (the metal cell counts its
+gated fixtures and skips when the dumps are absent).
 `test_qwen25v.das` — the qwen25v tower (Qwen2.5-Omni's window-attention ViT, projector
 `qwen2.5o`) tier-1 parity vs the `-p encode` dumps minted on the f32-widened dual-tower
 mmproj, CPU (`qwen3vl-vision-oracle/mint_25o.sh`): five fixtures, four of them shaped —
@@ -340,7 +347,7 @@ images the rig cannot use and purges the flavors the rig depends on. Image-rail 
 ## Metal fixtures — driver knobs and the two-model pattern
 
 (REVIEW: "A cell pins every driver hook and serving-lane knob its claim depends on, and
-restores it after") The
+restores it before returning") The
 hooks are on by default: they flip a q8 leg to the GPU silently, and an f32 leg records a
 quant_mode decline that panics under required mode — either way the cell stops measuring what
 its name says. The family serving-lane pins (`set_<family>_q8`) are the same trap in the

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -308,7 +308,10 @@ projection 3840 — large tier, `DASLLAMA_PARITY_FULL=1`), and the Qwen3-Omni qw
 grid advance), the Qwen3-VL 4B deepstack pair (small tier — wide 10240-float rows through
 the chat, the caption, and the zeroed-slices decoder control: tails zeroed on the same rows
 must move the prefill logits, measured 10.4 — a caption alone cannot see a decoder that
-ignores the slices), the Qwen2.5-Omni-3B qwen25v pair (small tier — the window ViT + the
+ignores the slices), the rows-seam cell (same 4B pair — pre-encoded wide rows through
+`add_user_image_rows_` on a plain chat reproduce the embedder walk token-for-token; the seam
+lcpp_bench prices, where a hand-splice once fed deepstack decoders a narrow scrambled span),
+the Qwen2.5-Omni-3B qwen25v pair (small tier — the window ViT + the
 qwen2vl NON-interleaved MROPE decoder; the vocab spells the span markers
 `<|vision_bos|>`/`<|vision_eos|>`, resolved by the chat layer's vocab-driven fallback)
 plus the `test_omni_showcase` cell in the same file (one Omni session: an image turn, then a text turn

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -126,16 +126,17 @@ dump.**
 backend, the flash-attention setting, and the mmproj precision the dump came from.**
 
 **A cell pins every driver hook and serving-lane knob its claim depends on, and restores it
-after** — the Metal driver hooks `set_metal_tower`, `set_metal_wdec`, `set_metal_wdec_step`
-(OFF for a CPU-served or f32-decoder claim) and the family serving-lane pins
-`set_<family>_q8` (false for an exact-plane claim, true for a q8 claim) — never a runtime
+before returning** — the hooks have no read-back, so a cell that pins one OFF sets it back
+ON (the driver hooks `set_metal_tower`, `set_metal_wdec`, `set_metal_wdec_step`); a family
+serving-lane pin `set_<family>_q8` is undone with `reset_<family>_q8` — never a runtime
 decline standing in for a pin. The mechanism (why the hooks flip legs silently) is
 `CLAUDE.md`'s "Metal fixtures" section.
 
-**A cell asserting the UNPINNED default lane compares against
-`float_batch_override_active()`, never against a hardcoded lane** — the accelerate
-float-batch tier moves the default per box; the assert is on the lane the tier selects, not
-on the predicate's own value.
+**A cell asserting the UNPINNED default lane compares against the predicates the lane policy
+itself consults — `float_batch_override_active()` and the family's `<family>_gpu_would_serve()`
+where one exists — never against a hardcoded lane**; the accelerate tier and the GPU tower move the
+default per box, and the assert is on the lane the policy selects, not on one predicate's
+own value.
 
 **A cell that encodes, preprocesses, or asserts on media bytes an encoder consumes — pixels
 or audio samples, not a `.dlim` model image — with no model loaded builds its fixture

--- a/modules/dasLLAMA/tests/test_audio_embedder.das
+++ b/modules/dasLLAMA/tests/test_audio_embedder.das
@@ -5,6 +5,7 @@ options _dasllama_internal = true
 
 require dastest/testing_boost public
 require dasllama/dasllama_audio_embedder
+require dasllama/dasllama_image   // image_family_tag — the per-arm dlim selection
 require daslib/fio
 require strings
 require _model_tier   // models_dir() + model_available() gate
@@ -66,12 +67,17 @@ def test_audio_embedder_gemma4a_arm(t : T?) {
         delete st
         var image_path = ""
         dir(models_dir()) $(name) {
+            // the mmproj bakes one dlim PER ARM (gemma4a audio, gemma4v vision) — select by the
+            // baked family tag, or directory order hands this audio cell a vision image
             if (empty(image_path) && starts_with(name, "{base_name(mm)}.0x") && ends_with(name, ".dlim")) {
-                image_path = path_join(models_dir(), name)
+                let cand = path_join(models_dir(), name)
+                if (image_family_tag(cand) |> starts_with("gemma4a-")) {
+                    image_path = cand
+                }
             }
         }
         if (empty(image_path)) {
-            t |> skip("no prepared {base_name(mm)}.0x*.dlim beside the mmproj - the direct image route needs a baked image")
+            t |> skip("no prepared gemma4a-tagged {base_name(mm)}.0x*.dlim beside the mmproj - the direct image route needs a baked image")
         } else {
             t |> equal(audio_probe_proj_dim(image_path), 0l, "the gguf probe answers 0 on a .dlim by pinned contract")
             var inscope ei <- load_audio_embedder(image_path)

--- a/modules/dasLLAMA/tests/test_audio_embedder.das
+++ b/modules/dasLLAMA/tests/test_audio_embedder.das
@@ -68,7 +68,9 @@ def test_audio_embedder_gemma4a_arm(t : T?) {
         var image_path = ""
         dir(models_dir()) $(name) {
             // the mmproj bakes one dlim PER ARM (gemma4a audio, gemma4v vision) — select by the
-            // baked family tag, or directory order hands this audio cell a vision image
+            // baked family tag, or directory order hands this audio cell a vision image. The
+            // load above already minted the gemma4a arm when the image rail is on, so this
+            // scan only skips under DASLLAMA_IMAGE=0 — a model gate, not an artifact gate
             if (empty(image_path) && starts_with(name, "{base_name(mm)}.0x") && ends_with(name, ".dlim")) {
                 let cand = path_join(models_dir(), name)
                 if (image_family_tag(cand) |> starts_with("gemma4a-")) {

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -9,6 +9,7 @@ require dasllama/dasllama_math   // set_wscale_f16 — the resident path reads t
 require dasllama/dasllama_layout   // convert_model_to_metal_blob — the blob-flavor transform
 require ?das_metal dasllama/dasllama_metal_prefill  // min-npos setter + stats + the shutdown/leak rail
 require ?das_metal dasllama/dasllama_metal_decode  // decode shutdown (the kq/quantized-KV arms touch the decode driver)
+require dasllama/dasllama_env   // g_env_metal.residency — the pin witness reads the knob it asserts
 require ?das_metal metal/das_metal_boost  // metal_live_object_count for the leak gate
 require daslib/jobque_boost
 require daslib/fio   // nolint:STYLE030,LINT019 — used only inside the Apple static_if half
@@ -443,6 +444,17 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                     return
                 }
                 t |> success(same(cpu, gpu), "40-token continuation matches the CPU control (blob mul_mm, f32 activations)")
+                // the residency witness: a served prefill under the default knob pins the working
+                // set (the measured win is the tower's first submission after its CPU stem)
+                if (g_env_metal.residency) {
+                    if (residency_active()) {
+                        t |> success(residency_pinned() > 0l, "the served prefill pinned {residency_pinned()} buffers in the residency set")
+                    } else {
+                        t |> skip("MTLResidencySet unavailable (macOS < 15) - the pin witness has no API to observe")
+                    }
+                } else {
+                    t |> equal(residency_pinned(), 0l, "DASLLAMA_METAL_RESIDENCY=0 pins nothing")
+                }
             }
 
             // s16 arm (W2): the DEFAULT-load scale plane — blobs read raw f16 scales, the

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -9,7 +9,9 @@ require dasllama/dasllama_math   // set_wscale_f16 — the resident path reads t
 require dasllama/dasllama_layout   // convert_model_to_metal_blob — the blob-flavor transform
 require ?das_metal dasllama/dasllama_metal_prefill  // min-npos setter + stats + the shutdown/leak rail
 require ?das_metal dasllama/dasllama_metal_decode  // decode shutdown (the kq/quantized-KV arms touch the decode driver)
-require dasllama/dasllama_env   // g_env_metal.residency — the pin witness reads the knob it asserts
+require ?das_metal dasllama/dasllama_metal_common   // g_dev + residency_* — the pin witness probes the API directly
+require ?das_metal das_metal   // metal_new_residency_set/metal_release — the availability probe
+require dasllama/dasllama_env   // nolint:STYLE030,LINT019 — g_env_metal.residency, read only inside the das_metal static_if half
 require ?das_metal metal/das_metal_boost  // metal_live_object_count for the leak gate
 require daslib/jobque_boost
 require daslib/fio   // nolint:STYLE030,LINT019 — used only inside the Apple static_if half
@@ -445,9 +447,15 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                 }
                 t |> success(same(cpu, gpu), "40-token continuation matches the CPU control (blob mul_mm, f32 activations)")
                 // the residency witness: a served prefill under the default knob pins the working
-                // set (the measured win is the tower's first submission after its CPU stem)
+                // set. Availability probes the API DIRECTLY, so a dead machinery cannot hide
+                // behind the macOS-<15 skip on a box whose OS serves the API.
+                var api_probe = metal_new_residency_set(dasllama_metal_common::g_dev)
+                if (api_probe != null) {
+                    metal_release(api_probe)
+                }
                 if (g_env_metal.residency) {
-                    if (residency_active()) {
+                    if (api_probe != null) {
+                        t |> success(residency_active(), "the residency set is live on an API-serving OS")
                         t |> success(residency_pinned() > 0l, "the served prefill pinned {residency_pinned()} buffers in the residency set")
                     } else {
                         t |> skip("MTLResidencySet unavailable (macOS < 15) - the pin witness has no API to observe")

--- a/modules/dasLLAMA/tests/test_qwen3v.das
+++ b/modules/dasLLAMA/tests/test_qwen3v.das
@@ -21,11 +21,12 @@ require _vision_oracle   // the mtmd dump parser, fixture generators, per-token 
 
 let private TIER1_ABS = 2e-4
 // x token rms. Poison-calibrated: 27 blocks whose GELU rides ggml's f16 LUT quantize the
-// summation-order drift between das GEMMs and the reference's to a measured 0.6-2.7e-3 floor
-// (the solid-color fixtures sit at low rms, where the floor shows; preproc, the pos-table
-// antialias resize, and the rope tables are each independently bit-exact vs their references).
-// A swapped rope-ladder poison lands at 0.71-0.85 maxdiff - 300x this bar.
-let private TIER1_REL = 1e-2
+// summation-order drift between das GEMMs and the reference's to a measured floor of
+// 0.6-3.2e-3 (the ff_pad width regroups the down GEMM's f32 accumulation - red448 tops the
+// set; the solid-color fixtures sit at low rms, where the floor shows; preproc, the
+// pos-table antialias resize, and the rope tables are each independently bit-exact vs their
+// references). The live zero-layer poison leg below reds this bar at 100x+.
+let private TIER1_REL = 1.5e-2
 
 // the deepstack leg runs FOUR GELU-LUT'd merger chains per wide row (main + three taps) where
 // the Omni runs one, and the q-probes read individual slice values - the compounded
@@ -36,6 +37,16 @@ let private TIER1_REL_DS = 4e-2
 // x token rms - the q8 serving lane vs the f32 oracle: measured 0.42 x rms worst (gray448) -
 // the qwen ViT's mid-network outlier channels roughly double gemma3v's 0.22-0.25 q8 floor.
 // The zero-layer poison leg proves the bar still discriminates; the caption is the product gate.
+// the Metal tower legs: the f32 mulmm stages f16 tiles (the gemma3v precedent, its own
+// TIER1_REL_GPU = 4e-2), so the GPU chain's floor runs ~6x the CPU chain's on the low-rms
+// uniform fixtures - measured 8.9e-3 worst on the Omni (gray448). The deepstack leg reads
+// mid-network tap slices where that noise arrives unwashed by the final post-LN, so - the
+// q8-ds precedent one bar up - the uniform gray fixture stays on the CPU set only and the
+// GPU-ds legs run the structured fixtures (measured 0.8-1.0e-2). The live poison legs red
+// these bars at 10-150x (exact zero-layer 0.87, q8 zero-layer 0.73, zeroed tap 11.4).
+let private TIER1_REL_GPU = 4e-2
+let private TIER1_REL_GPU_DS = 8e-2
+
 let private TIER1_REL_Q8 = 5.2e-1
 // the deepstack q8 leg reads tap slices SAMPLED MID-NETWORK (blocks 5/11/17), where the q8
 // outlier noise arrives unwashed by the final post-LN: cb fixtures measure 0.51 x rms; the
@@ -90,7 +101,7 @@ def test_qwen3v_tier1(t : T?) {
         tt |> equal(int(tw.n_ff), 4304, "ffn width")
         tt |> equal(int(tw.proj_dim), 2048, "soft-token width")
         tt |> equal(int(tw.pos_side), 48, "pos-table side")
-        tt |> success(tw.blk_bf16 && tw.mm_bf16, "block and merger GEMMs bf16 as the file has them")
+        tt |> success(tw.blk_bf16 && tw.mm_bf16, "the file carries bf16 GEMMs (the exact lane serves the blocks f32)")
         tt |> gate_encode(tw, st, "cb", 96, 96, "encode.cb96.log")   // 9 tokens: the pos-table DOWNSCALE arm
         tt |> gate_encode(tw, st, "gray", 448, 448, "encode.gray448.log")
         tt |> gate_encode(tw, st, "cb", 448, 448, "encode.cb448.log")
@@ -111,8 +122,72 @@ def test_qwen3v_tier1(t : T?) {
             ragged_tripped = true
         }
         tt |> success(ragged_tripped, "a canvas off the 32 px merged-patch grid panics by name")
+        // negative control for the exact bar: layer 13's f32 layer_w region zeroed through the
+        // staging planes must red the same fixture on the same bar (the loosened-bar rule)
+        var o = OracleEncode()
+        if (load_oracle_encode(path_join(path_join(models_dir(), "qwen3vl-vision-oracle"), "encode.gray448.log"), o)) {
+            set_qwen3v_q8(false)
+            var inscope pst <- stage_qwen3v_tower(mm)
+            reset_qwen3v_q8()
+            let base = pst.t.layer_w + 13l * pst.t.layer_w_stride
+            for (i in range64(pst.t.layer_w_stride)) {
+                pst.blob[base + i] = 0.0
+            }
+            var ptw = Qwen3vTower()
+            mint_qwen3v_tower(pst, ptw)
+            let planes <- make_planes("gray", 448, 448)
+            var pout : array<float>
+            with_job_que() {
+                setup_dasllama_jobque_()
+                qwen3v_encode(ptw, st, planes, 448l, 448l, pout)
+            }
+            let excess = encode_excess(pout, int(qwen3v_row_width(ptw)), o, TIER1_ABS, TIER1_REL)
+            to_log(LOG_INFO, "qwen3v exact poison leg: zero layer 13 -> excess {excess} over the bar\n")
+            tt |> success(excess > 0.0, "a zeroed mid-layer f32 region reds the exact bar (excess {excess})")
+            delete pout
+            delete ptw
+        }
         delete st
         delete tw
+    }
+}
+
+// The Metal tower arm: the SAME fixtures and bars, tower pinned ON — the GPU chain's parity
+// gate, with engage evidence (encode/block counter deltas), never "the model ran".
+[test]
+def test_qwen3v_tier1_metal(t : T?) {
+    t |> run("tier-1 on the Metal tower (Omni-30B narrow + 4B deepstack)") @(tt : T?) {
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            let mm = path_join(models_dir(), "mmproj-Qwen3-Omni-30B-A3B-Instruct-bf16.gguf")
+            let mm4 = path_join(models_dir(), "mmproj-Qwen3VL-4B-Instruct-F16.gguf")
+            if (!model_available(tt, mm) || !model_available(tt, mm4)) {
+                return
+            }
+            set_qwen3v_q8(false)   // the Metal tower serves the f32 exact planes
+            var tw <- load_qwen3v_tower(mm)
+            var tw4 <- load_qwen3v_tower(mm4)
+            reset_qwen3v_q8()
+            set_metal_tower(true)
+            var st = Qwen3vState()
+            let s0 = metal_tower_stats()
+            tt |> gate_encode(tw, st, "gray", 448, 448, "encode.gray448.log", TIER1_REL_GPU)
+            tt |> gate_encode(tw, st, "cb", 448, 448, "encode.cb448.log", TIER1_REL_GPU)
+            tt |> gate_encode(tw, st, "cb", 640, 320, "encode.cb640x320.log", TIER1_REL_GPU)
+            var st4 = Qwen3vState()
+            tt |> gate_encode(tw4, st4, "cb", 448, 448, "encode4b.cb448.log", TIER1_REL_GPU_DS)
+            tt |> gate_encode(tw4, st4, "cb", 640, 320, "encode4b.cb640x320.log", TIER1_REL_GPU_DS)
+            tt |> gate_encode(tw4, st4, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_GPU_DS)
+            let s1 = metal_tower_stats()
+            to_log(LOG_INFO, "qwen3v metal tier-1: +{s1.encodes - s0.encodes} encodes, +{s1.blocks - s0.blocks} blocks, +{s1.declines - s0.declines} declines\n")
+            tt |> success(s1.encodes - s0.encodes >= 6l, "every encode served on the Metal tower ({s1.encodes - s0.encodes} of 6)")
+            tt |> equal(s1.blocks - s0.blocks, 3l * 27l + 3l * 24l, "the block counters advanced (3 Omni x 27 + 3 deepstack x 24)")
+            delete st
+            delete st4
+            delete tw
+            delete tw4
+        } else {
+            tt |> skip("no das_metal on this build - the Metal tower arm has no device to serve")
+        }
     }
 }
 
@@ -264,12 +339,12 @@ def test_qwen3v_tier1_q8_deepstack(t : T?) {
 [test]
 def test_qwen3v_lane_knob(t : T?) {
     t |> run("the q8 lane pin and policy default") @(tt : T?) {
-        tt |> equal(qwen3v_serves_q8(), !float_batch_override_active(), "the policy default follows the accelerate tier")
+        tt |> equal(qwen3v_serves_q8(), !(qwen3v_gpu_would_serve() || float_batch_override_active()), "the policy default follows the Metal tower and the accelerate tier")
         set_qwen3v_q8(true)
         tt |> success(qwen3v_serves_q8(), "pinned q8")
         set_qwen3v_q8(false)
         tt |> success(!qwen3v_serves_q8(), "pinned exact")
         reset_qwen3v_q8()   // from the EXACT pin, so a no-op reset cannot pass as the (q8) policy default
-        tt |> equal(qwen3v_serves_q8(), !float_batch_override_active(), "reset returns to the policy default")
+        tt |> equal(qwen3v_serves_q8(), !(qwen3v_gpu_would_serve() || float_batch_override_active()), "reset returns to the policy default")
     }
 }

--- a/modules/dasLLAMA/tests/test_qwen3v.das
+++ b/modules/dasLLAMA/tests/test_qwen3v.das
@@ -122,6 +122,9 @@ def test_qwen3v_tier1(t : T?) {
             ragged_tripped = true
         }
         tt |> success(ragged_tripped, "a canvas off the 32 px merged-patch grid panics by name")
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            set_metal_tower(true)   // restore the module default the pin above flipped
+        }
         // negative control for the exact bar: layer 13's f32 layer_w region zeroed through the
         // staging planes must red the same fixture on the same bar (the loosened-bar rule)
         var o = OracleEncode()
@@ -170,17 +173,60 @@ def test_qwen3v_tier1_metal(t : T?) {
             set_metal_tower(true)
             var st = Qwen3vState()
             let s0 = metal_tower_stats()
-            tt |> gate_encode(tw, st, "gray", 448, 448, "encode.gray448.log", TIER1_REL_GPU)
-            tt |> gate_encode(tw, st, "cb", 448, 448, "encode.cb448.log", TIER1_REL_GPU)
-            tt |> gate_encode(tw, st, "cb", 640, 320, "encode.cb640x320.log", TIER1_REL_GPU)
+            var omni_gated = 0l
+            var ds_gated = 0l
+            if (tt |> gate_encode(tw, st, "gray", 448, 448, "encode.gray448.log", TIER1_REL_GPU)) {
+                omni_gated++
+            }
+            if (tt |> gate_encode(tw, st, "cb", 448, 448, "encode.cb448.log", TIER1_REL_GPU)) {
+                omni_gated++
+            }
+            if (tt |> gate_encode(tw, st, "cb", 640, 320, "encode.cb640x320.log", TIER1_REL_GPU)) {
+                omni_gated++
+            }
             var st4 = Qwen3vState()
-            tt |> gate_encode(tw4, st4, "cb", 448, 448, "encode4b.cb448.log", TIER1_REL_GPU_DS)
-            tt |> gate_encode(tw4, st4, "cb", 640, 320, "encode4b.cb640x320.log", TIER1_REL_GPU_DS)
-            tt |> gate_encode(tw4, st4, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_GPU_DS)
+            if (tt |> gate_encode(tw4, st4, "cb", 448, 448, "encode4b.cb448.log", TIER1_REL_GPU_DS)) {
+                ds_gated++
+            }
+            if (tt |> gate_encode(tw4, st4, "cb", 640, 320, "encode4b.cb640x320.log", TIER1_REL_GPU_DS)) {
+                ds_gated++
+            }
+            if (tt |> gate_encode(tw4, st4, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_GPU_DS)) {
+                ds_gated++
+            }
             let s1 = metal_tower_stats()
-            to_log(LOG_INFO, "qwen3v metal tier-1: +{s1.encodes - s0.encodes} encodes, +{s1.blocks - s0.blocks} blocks, +{s1.declines - s0.declines} declines\n")
-            tt |> success(s1.encodes - s0.encodes >= 6l, "every encode served on the Metal tower ({s1.encodes - s0.encodes} of 6)")
-            tt |> equal(s1.blocks - s0.blocks, 3l * 27l + 3l * 24l, "the block counters advanced (3 Omni x 27 + 3 deepstack x 24)")
+            to_log(LOG_INFO, "qwen3v metal tier-1: +{s1.encodes - s0.encodes} encodes, +{s1.blocks - s0.blocks} blocks, +{s1.declines - s0.declines} declines ({omni_gated}+{ds_gated} fixtures gated)\n")
+            if (omni_gated + ds_gated == 0l) {
+                tt |> skip("no oracle dumps present - the GPU parity fixtures all skipped")
+            } else {
+                tt |> success(s1.encodes - s0.encodes >= omni_gated + ds_gated, "every gated encode served on the Metal tower")
+                tt |> equal(s1.blocks - s0.blocks, omni_gated * 27l + ds_gated * 24l, "the block counters advanced per gated fixture")
+            }
+            // negative control for the GPU bars: the same zero-layer-13 poison, GPU-served,
+            // must red TIER1_REL_GPU (the loosened-bar rule wants the control ON THIS lane)
+            var po = OracleEncode()
+            if (load_oracle_encode(path_join(path_join(models_dir(), "qwen3vl-vision-oracle"), "encode.gray448.log"), po)) {
+                set_qwen3v_q8(false)
+                var inscope pst <- stage_qwen3v_tower(mm)
+                reset_qwen3v_q8()
+                let base = pst.t.layer_w + 13l * pst.t.layer_w_stride
+                for (i in range64(pst.t.layer_w_stride)) {
+                    pst.blob[base + i] = 0.0
+                }
+                var ptw = Qwen3vTower()
+                mint_qwen3v_tower(pst, ptw)
+                let planes <- make_planes("gray", 448, 448)
+                var pout : array<float>
+                with_job_que() {
+                    setup_dasllama_jobque_()
+                    qwen3v_encode(ptw, st, planes, 448l, 448l, pout)
+                }
+                let excess = encode_excess(pout, int(qwen3v_row_width(ptw)), po, TIER1_ABS, TIER1_REL_GPU)
+                to_log(LOG_INFO, "qwen3v GPU-lane poison leg: zero layer 13 -> excess {excess} over the GPU bar\n")
+                tt |> success(excess > 0.0, "a zeroed mid-layer reds the GPU bar on the GPU-served lane (excess {excess})")
+                delete pout
+                delete ptw
+            }
             delete st
             delete st4
             delete tw
@@ -219,6 +265,9 @@ def test_qwen3v_tier1_deepstack(t : T?) {
         tt |> gate_encode(tw, st, "cb", 448, 448, "encode4b.cb448.log", TIER1_REL_DS)
         tt |> gate_encode(tw, st, "cb", 640, 320, "encode4b.cb640x320.log", TIER1_REL_DS)   // non-square: merge-reorder + transposed-grid
         tt |> gate_encode(tw, st, "cb", 96, 96, "encode4b.cb96.log", TIER1_REL_DS)   // 9 tokens: the pos-table DOWNSCALE arm
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            set_metal_tower(true)   // restore the module default the pin above flipped
+        }
         delete st
         delete tw
     }

--- a/modules/dasLLAMA/tests/test_scheduler.das
+++ b/modules/dasLLAMA/tests/test_scheduler.das
@@ -760,7 +760,7 @@ def test_scheduler_media_splice(t : T?) {   // nolint:STYLE038 — one model loa
 // ===== media validation: submit refuses malformed shapes by panic =====
 
 [test]
-def test_scheduler_media_validation(t : T?) {
+def test_scheduler_media_validation(t : T?) {   // nolint:STYLE038 — one flat story: each malformed shape probes the same submit guard
     t |> run("submit panics on malformed media shapes (needs SmolLM2-135M)") @(t : T?) {
         if (model_missing(t)) {
             return
@@ -812,6 +812,28 @@ def test_scheduler_media_validation(t : T?) {
                 tripped = true
             }
             t |> success(tripped, "media rows with n_media == 0 panic instead of dropping silently")
+            tripped = false
+            try {
+                var bad <- PendingReq(id = 13l, params = greedy, max_new = 4l, media_at = 1l, n_media = 2l)
+                bad.prompt := prompt
+                bad.media_embd |> resize(3l * m.config.dim)   // oversized: the exact-width guard refuses slop
+                submit(m, sch, bad)
+            } recover {
+                tripped = true
+            }
+            t |> success(tripped, "oversized media rows panic")
+            tripped = false
+            try {
+                m.config.n_deepstack = 3l   // a deepstack decoder: image rows arrive (1+n)·dim-wide
+                var bad <- PendingReq(id = 14l, params = greedy, max_new = 4l, media_at = 1l, n_media = 2l, media_non_causal = true)
+                bad.prompt := prompt
+                bad.media_embd |> resize(2l * m.config.dim)   // narrow feed = the slice adds would silently skip
+                submit(m, sch, bad)
+            } recover {
+                tripped = true
+            }
+            m.config.n_deepstack = 0l
+            t |> success(tripped, "narrow image rows on a deepstack decoder panic")
             unsafe {
                 delete sch
             }

--- a/modules/dasLLAMA/tests/test_vision_chat.das
+++ b/modules/dasLLAMA/tests/test_vision_chat.das
@@ -434,6 +434,58 @@ def test_vision_chat_deepstack(t : T?) {   // nolint:STYLE038 — one sequential
     }
 }
 
+// The bench shape: pre-encoded rows injected into a PLAIN chat (no embedder attached) must
+// walk the very turn the embedder chat walks — lcpp_bench prices this seam, and a hand-splice
+// here once fed deepstack decoders a narrow scrambled span that still captioned the cats.
+[test]
+def test_vision_chat_rows_seam(t : T?) {
+    t |> run("pre-encoded wide rows through add_user_image_rows_ reproduce the embedder walk") @(tt : T?) {
+        let mm = path_join(models_dir(), MM_4B)
+        let dec = path_join(models_dir(), DEC_4B)
+        let cats = path_join(models_dir(), CATS)
+        if (!model_available(tt, mm) || !model_available(tt, dec)) {
+            return
+        }
+        if (!stat(cats).is_valid) {
+            tt |> skip("{CATS} not present - fetch it into the models dir (gemma4-vision-oracle/mint.sh documents the URL)")
+            return
+        }
+        let img <- load_image_rgb(cats)
+        var m <- load_model_(dec, QuantMode.q8)
+        allow_cpu_prefill()
+        with_job_que() {
+            setup_dasllama_jobque_()
+            var params = SamplingParams()
+            params.temp = 0.0
+            var emb <- load_vision_embedder(mm)
+            var chat1 <- create_chat_(m, emb, "", 24l)
+            add_user_image_(chat1, img)
+            add_user_(chat1, "describe this image")
+            let r1 = respond_(m, chat1, params) $(piece : string) {
+                return true
+            }
+            delete chat1
+            var emb2 <- load_vision_embedder(mm)
+            var st = VisionState()
+            var rows : array<float>
+            let nr = encode_image(emb2, st, img, "rows-seam", rows)
+            var chat2 <- create_chat_(m, "", 24l)
+            add_user_image_rows_(m, chat2, rows, nr, vision_mrope_grid(emb2, st))
+            add_user_(chat2, "describe this image")
+            let r2 = respond_(m, chat2, params) $(piece : string) {
+                return true
+            }
+            to_log(LOG_INFO, "rows-seam replies: embedder '{replace(r1, "\n", "\\n")}' vs rows '{replace(r2, "\n", "\\n")}'\n")
+            tt |> equal(r1, r2, "greedy replies match token-for-token")
+            delete chat2
+            delete rows
+            delete st
+            delete emb2
+        }
+        delete m
+    }
+}
+
 [test]
 def test_vision_chat_qwen25o(t : T?) {
     t |> run("the Qwen2.5-Omni image turn: window ViT + the NON-interleaved MROPE decoder, then the caption") @(tt : T?) {

--- a/modules/dasLLAMA/tests/test_vision_chat.das
+++ b/modules/dasLLAMA/tests/test_vision_chat.das
@@ -477,6 +477,35 @@ def test_vision_chat_rows_seam(t : T?) {
             }
             to_log(LOG_INFO, "rows-seam replies: embedder '{replace(r1, "\n", "\\n")}' vs rows '{replace(r2, "\n", "\\n")}'\n")
             tt |> equal(r1, r2, "greedy replies match token-for-token")
+            // the seam's guards: a wrong-width quantum and a second image both refuse by panic
+            var tripped = false
+            try {
+                var chat3 <- create_chat_(m, "", 8l)
+                var bad : array<float>
+                bad |> resize(nr * m.config.dim)   // narrow rows on a deepstack decoder - the old bench defect's exact shape
+                add_user_image_rows_(m, chat3, bad, nr, int2(20, 15))
+                delete bad
+                delete chat3
+            } recover {
+                tripped = true
+            }
+            tt |> success(tripped, "narrow rows on a deepstack decoder panic at the seam")
+            tripped = false
+            try {
+                var rows3 : array<float>
+                let nr3 = encode_image(emb2, st, img, "rows-seam-2", rows3)
+                var chat4 <- create_chat_(m, "", 8l)
+                add_user_image_rows_(m, chat4, rows3, nr3, vision_mrope_grid(emb2, st))
+                var rows4 : array<float>
+                let nr4 = encode_image(emb2, st, img, "rows-seam-3", rows4)
+                add_user_image_rows_(m, chat4, rows4, nr4, vision_mrope_grid(emb2, st))
+                delete rows4
+                delete rows3
+                delete chat4
+            } recover {
+                tripped = true
+            }
+            tt |> success(tripped, "a second image before respond() panics at the seam")
             delete chat2
             delete rows
             delete st


### PR DESCRIPTION
**Behavior change: a qwen3v vision model's prepared image is re-minted at a new layout version, and the exact-lane 4B image grows from 753 MB to 1581 MB on disk. Users on that lane get one slow first load.**

The qwen3v image turn ran its encoder on the CPU, so a served image turn was slower than llama.cpp on Metal by 16 to 41 percent. This change moves that encoder to the GPU. It adds no new kernels: it reuses the gemma3v dispatch chain and one rope builder borrowed from the prefill driver, fuses the qkv projection into three offset GEMMs, and runs the deepstack taps and the tail merger inline over a reshaped view of the live residual, all in one command buffer per encode.

Two smaller changes ride along. A deepstack media quantum used to be split on the CPU before upload; the prefill driver now borrows the wide rows whole and slices them on the device through a new bind offset, so no MSL changed. And every weight region and pooled buffer is now pinned in a Metal residency set, which takes 15 ms off each encode.

Encode time drops 12 to 27 times against where this arc started, and daslang now leads llama.cpp on every qwen3v Metal encode: 179 ms against 250 for the 4B, 257 against 508 for the 8B, 241 against 250 for the 30B. The whole image turn is now 16, 16 and 5 percent behind, from 16, 29 and 41. The remaining gap is one measured mechanism, written up in ARCHITECTURE 2.12: the first GPU submission after a CPU-only window pays a one-time 40 ms cost inside Metal's own per-commit tracking pass. Every cheap remedy was tried and refuted. The fix that remains is a per-buffer tracking audit, which is its own change.

This work also uncovered an existing bug. The Metal tower never flushed its address-keyed weight cache when weights were reloaded, though the decode and prefill drivers both did. When one vision model is freed and another maps at the same address, the tower served the wrong model's weights. It has been latent since the first tower family and only surfaced now, because qwen3v is the first case where two GPU towers run in one process.

Where to look: `metal_qwen3v_blocks` and `metal_tower_init` in `dasllama/dasllama_metal_tower.das`, the wide-borrow arm in `dasllama/dasllama_metal_prefill.das`, the residency block in `dasllama/dasllama_metal_common.das`, and the GPU seam in `dasllama/dasllama_qwen3v.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- `harness/parity.das` GPU-vs-CPU is local-only: q8 (Llama-3.2-1B) and kq (gemma-4-12B Q4_K_M, the pinned counting prompt) are token-identical across arms, and the kq arms both reproduce the frozen `ev_gemma4_dense` oracle continuation verbatim.
- The stale-weights fix is negative-controlled: `test_vision_chat`'s deepstack cell fails without the flush line and passes with it, both runs proven.
- Stage timings come from the released `lcpp_bench` rig on the M1 Max, three reps; the probe ladders behind each figure are in `qwen3vl_plan.md`. No board records or model cards were minted for the four measured qwen vision models.
- The Metal tower re-gate ran after the flush fix: `test_vision_chat`, `test_qwen3v`, `test_gemma4uv`, `test_gemma4v`, `test_gemma3v`, and the image suite's `mtower` arm.

### Claims — stated, not tested
- The warm/MTP path combined with a wide deepstack quantum is unreachable today, because no model carries both NextN and deepstack. The CPU split arm covers the code; a break would show as a wrong-width panic at the prefill seam.
- The tower's shape declines, the `rows_ext` buffer sizing edges, the override announce lines, and the literal `IMAGE_VERSION` value have no direct cells. A break in the sizing edge would show as a GPU-side out-of-bounds on a non-multiple-of-four token count; a wrong version literal would show as a stale image being served instead of re-minted.
- The restride bind offsets are covered through the deepstack tier-1 slice-value walk, not a dedicated offset unit. A wrong offset would move every slice's values, which that walk measures.

### Not done
- The per-buffer Metal tracking audit that would close the remaining image-turn gap.
- Five lint and REVIEW.das checks proposed during review are ledgered as follow-up work: a tower family-gate census, an audio/stbimage require fence, an `options _dasllama_internal` license set, a test pin-without-restore pairing check, and a check that every Metal driver entry calls the weights-epoch flush — the exact hole the bug above lived in.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
