### PR TITLE
site code-card ruling + REVIEW files never install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2229,3 +2229,23 @@ if(NOT ${DAS_TREE_SITTER_DISABLED})
         DESTINATION tree-sitter-daslang
     )
 endif()
+
+# REVIEW.md / REVIEW.das are repo-internal review machinery and never install;
+# the one exception is REVIEW_COMMON.md at the install root (adopting repos vendor
+# from it). This must stay the LAST install rule in the root CMakeLists so the
+# manifest it checks is complete.
+install(CODE [[
+    set(_review_leaks "")
+    get_filename_component(_root_common "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/REVIEW_COMMON.md" ABSOLUTE)
+    foreach(_f IN LISTS CMAKE_INSTALL_MANIFEST_FILES)
+        get_filename_component(_name "${_f}" NAME)
+        get_filename_component(_f_abs "${_f}" ABSOLUTE)
+        if(_name MATCHES "^REVIEW.*\.(md|das)$" AND NOT _f_abs STREQUAL _root_common)
+            list(APPEND _review_leaks "${_f}")
+        endif()
+    endforeach()
+    if(_review_leaks)
+        list(JOIN _review_leaks "\n  " _review_leaks_text)
+        message(FATAL_ERROR "install carries repo-internal review files:\n  ${_review_leaks_text}")
+    endif()
+]])

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2234,9 +2234,15 @@ endif()
 # the one exception is REVIEW_COMMON.md at the install root (adopting repos vendor
 # from it). This must stay the LAST install rule in the root CMakeLists so the
 # manifest it checks is complete.
+install(CODE "set(_das_docdir \"${DAS_INSTALL_DOCDIR}\")")
 install(CODE [[
     set(_review_leaks "")
-    get_filename_component(_root_common "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/REVIEW_COMMON.md" ABSOLUTE)
+    if(IS_ABSOLUTE "${_das_docdir}")
+        set(_root_common "$ENV{DESTDIR}${_das_docdir}/REVIEW_COMMON.md")
+    else()
+        set(_root_common "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${_das_docdir}/REVIEW_COMMON.md")
+    endif()
+    get_filename_component(_root_common "${_root_common}" ABSOLUTE)
     foreach(_f IN LISTS CMAKE_INSTALL_MANIFEST_FILES)
         get_filename_component(_name "${_f}" NAME)
         get_filename_component(_f_abs "${_f}" ABSOLUTE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2047,6 +2047,7 @@ install(FILES
 # Install dasllama-server (OpenAI-compatible LLM server; JIT-only, runs from the
 # SDK's live toolchain — see its deploy-jit.ps1 for the standalone bundle path)
 file(GLOB DAS_LLAMA_SERVER_FILES ${PROJECT_SOURCE_DIR}/utils/dasllama-server/*.das)
+list(FILTER DAS_LLAMA_SERVER_FILES EXCLUDE REGEX "/REVIEW\\.das$")
 install(FILES ${DAS_LLAMA_SERVER_FILES}
     ${PROJECT_SOURCE_DIR}/utils/dasllama-server/README.md
     ${PROJECT_SOURCE_DIR}/utils/dasllama-server/control.html

--- a/ci/LAWS.md
+++ b/ci/LAWS.md
@@ -1,0 +1,9 @@
+# LAWS.md - Boris's rulings
+
+Append-only intent provenance for rule-document edits in this folder's documents (the
+mechanism: CLAUDE.md sec. "Boris's rulings get a `LAWS.md` sidecar"). Never groomed,
+compacted, or cited as rules.
+
+| Date | Document | The ask |
+|---|---|---|
+| 2026-08-24 | smoke_test_bundle.sh (no-REVIEW gate) | "CMake install skips REVIEW.md and REVIEW.das - its 100% internal" - the dasllama-server glob leak fixed, the bundle smoke gained the check; REVIEW_COMMON.md stays the deliberate exception (adopting repos vendor from it) |

--- a/ci/LAWS.md
+++ b/ci/LAWS.md
@@ -7,3 +7,4 @@ compacted, or cited as rules.
 | Date | Document | The ask |
 |---|---|---|
 | 2026-08-24 | smoke_test_bundle.sh (no-REVIEW gate) | "CMake install skips REVIEW.md and REVIEW.das - its 100% internal" - the dasllama-server glob leak fixed, the bundle smoke gained the check; REVIEW_COMMON.md stays the deliberate exception (adopting repos vendor from it) |
+| 2026-08-24 | CMakeLists.txt (install-manifest check) | "REVIEW.md and REVIEW.das is in more places than dasllama - and should never install anywhere. should probably make it part of CMake install check" - a terminal install(CODE) scans the full install manifest and FATAL_ERRORs on any REVIEW*.md / REVIEW*.das outside root REVIEW_COMMON.md |

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -226,6 +226,18 @@ else
     echo "FAIL (need skills/daslang/{SKILL.md,references/}, .claude/skills/daslang, .claude/agents/dragon.md, REVIEW_COMMON.md, and no skills/internal/)"
     FAIL=$((FAIL + 1))
 fi
+# REVIEW.md / REVIEW.das are 100% internal -- per-folder review machinery never
+# ships. REVIEW_COMMON.md is the one exception: adopting repos vendor from it.
+printf '  %-30s ' "no REVIEW.md/REVIEW.das"
+REVIEW_LEAKS=$(find "$BUNDLE" \( -name "REVIEW*.md" -o -name "REVIEW*.das" \) ! -name "REVIEW_COMMON.md" 2>/dev/null)
+if [[ -z "$REVIEW_LEAKS" ]]; then
+    echo "OK"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL (internal review files in bundle):"
+    echo "$REVIEW_LEAKS" | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+fi
 # No installed file may name a utils/internal/ path -- that class is a shipped
 # tutorial/scaffold invoking a tool the bundle does not carry (found live: the
 # AOT integration scaffolds). skills/ is excluded here: its own gate above owns

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -229,7 +229,7 @@ fi
 # REVIEW.md / REVIEW.das are 100% internal -- per-folder review machinery never
 # ships. REVIEW_COMMON.md is the one exception: adopting repos vendor from it.
 printf '  %-30s ' "no REVIEW.md/REVIEW.das"
-REVIEW_LEAKS=$(find "$BUNDLE" \( -name "REVIEW*.md" -o -name "REVIEW*.das" \) ! -name "REVIEW_COMMON.md" 2>/dev/null)
+REVIEW_LEAKS=$(find "$BUNDLE" \( -name "REVIEW*.md" -o -name "REVIEW*.das" \) ! -path "$BUNDLE/REVIEW_COMMON.md" 2>/dev/null)
 if [[ -z "$REVIEW_LEAKS" ]]; then
     echo "OK"
     PASS=$((PASS + 1))

--- a/site/LAWS.md
+++ b/site/LAWS.md
@@ -8,3 +8,4 @@ compacted, or cited as rules.
 |---|---|---|
 | 2026-08-22 | REVIEW.md (performance_bench.json record rule) | "we need to reprofile linq benchmarks and hook to webpage. [...] add a performance page under daslang.io / performance - separate page, similar how dasllama page is added - only this one will contain the two tables, switch between interpreter and jit" |
 | 2026-08-22 | REVIEW.md (performance_engines.json record rule) | on what was missing from the page's tables: "missing - duckdb and postgresql. [...] there should be implementations already" - the four-engine suite (examples/benchmarks/sql) joins the page as its own board and record |
+| 2026-08-24 | REVIEW.md (code-sample rule) | "if code example appears anywhere on the website, its linked to 'try it on playground' - and its verified to compile and run. here is an example - daslang.io/dasllama.html - code on that card"; on partial snippets: "nop. full examples" |

--- a/site/REVIEW.md
+++ b/site/REVIEW.md
@@ -32,8 +32,10 @@ in the results.md tables, is a defect.
 changing `examples/benchmarks/sql/results.md` in the same change, or that leaves any cell in the
 record differing from the same family-and-lane cell in those results.md tables, is a defect.
 
-**Every code sample shown on a page compiles and runs with the current toolchain.** daslang
-samples are gen2 and compile with the current binary; no pseudo-code presented as code.
+**Every code sample shown on a page is a full program - it compiles and runs with the
+current toolchain, and the page links it to "try it on playground".** daslang samples are
+gen2; a partial snippet shown as a code card, a sample without its playground link, or
+pseudo-code presented as code is a defect.
 
 **A test under `tests/playground/` (this folder) that needs the daslang runtime carries `@wasm` in its
 title.** The per-PR lane stages the site without WASM artifacts and runs the suite with


### PR DESCRIPTION
Two rulings, logged and enforced:

**Website code cards** (`site/REVIEW.md`): every code example shown on a page is a full program - it compiles and runs with the current toolchain, and the page links it to "try it on playground". Partial snippets don't appear as code cards. Ruling logged in `site/LAWS.md`.

**Install never ships review machinery**: the configured install manifest carried exactly one leak - `utils/dasllama-server/REVIEW.das`, swept in by the `*.das` glob - now filtered. `ci/smoke_test_bundle.sh` gained a check failing on any `REVIEW.md`/`REVIEW.das` in the bundle; `REVIEW_COMMON.md` stays the deliberate exception (adopting repos vendor from it, and the shipped review skills route to it). Ruling logged in `ci/LAWS.md` (created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
