### PR TITLE
dasLLAMA: the residency heartbeat + the pushed weights-epoch drop

### DIFF
--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -15,7 +15,7 @@ in two of them will drift:
 | `REVIEW.md` | `/code-review`, and us while writing | criteria checkable against a diff |
 
 **References flow one way: REVIEW cites ARCHITECTURE, never the reverse.** Sections here are
-numbered so they can be cited (`ARCHITECTURE sec.2.2`). Nothing here may cite a REVIEW rule - 
+numbered so they can be cited (`ARCHITECTURE sec.2.2`). Nothing here may cite a REVIEW rule -
 those are unnumbered review criteria by design, and a citation to one is a dangling pointer the
 moment the checklist is reordered.
 
@@ -240,7 +240,7 @@ that a question answered for one backend has an obvious address in the other. Th
   generates `enc_*` builders and MSL globals into the module the class COMPILES in, so co-location
   follows the class - "the builder needs the driver module" is never a placement reason. Prefill's
   prefill-only classes are convergence debt, not precedent.
-- **Retired: the single-pass whisper-decoder attention (`MetalWdecAttn`/`enc_wdec_attn`)** - 
+- **Retired: the single-pass whisper-decoder attention (`MetalWdecAttn`/`enc_wdec_attn`)** -
   deleted in the metal-asr review round (2026-08-17, the `bbatkin/metal-asr` PR; the kernel is
   in git history). The chunked part/comb pair replaced it during bring-up (1470->709 ms on the
   turbo decode) and its `float[1504]` tgmem bound was the only reason for the driver's old
@@ -616,7 +616,7 @@ reason: flat one-call-per-item runs (a registration or release list with one lin
 GPU kernel bodies whose phases are coupled by barriers, cooperative-matrix ops or register
 residency and so cannot cross a function boundary without changing the shader.
 
-Split only where a real seam exists - genuine duplication, a distinct phase, a self-contained arm - 
+Split only where a real seam exists - genuine duplication, a distinct phase, a self-contained arm -
 and only when the extracted helper stands on its own. Two corollaries this module keeps tripping
 over: **a kargs fold that grows an already-over-cap kernel body is not a reason to abandon the
 fold** (unpacking N fields adds N lines; take the growth and ledger the real seam), and **never
@@ -740,7 +740,7 @@ the documentation and to the registry test. The sanctioned forms beyond a plain 
 - **The config loads once at context init**, so `set_env_variable` mid-process is invisible to
   the running config: arm a child process's environment instead.
 - **A write of a foreign library's knob** (`set_env_variable` with a literal name) is allowed
-  only before that library first reads it, and the name must be a declared `[EnvConfig]` knob - 
+  only before that library first reads it, and the name must be a declared `[EnvConfig]` knob -
   the registry test scans writes too, so a re-spelled name fails it.
 
 `tests/test_env_registry.das` enforces the lot in both directions (declared <-> documented,
@@ -781,28 +781,32 @@ The tokenizer encode/decode path is sanctioned UNCOVERED by the region contracts
 gate is the `--tok` scaling rows, whose instrument (the size-ladder ratio) catches what the
 contracts cannot.
 
-### 2.12 The post-CPU-burn GPU ramp cannot be pre-paid - do not build a warm-up
+### 2.12 The post-CPU-burn GPU ramp - the residency heartbeat holds it; do not build a warm-up
 
 Figures in this section: M1 Max, 2026-08-23 - probes are quiet `-jit` runs with the rig's
 tune manifest; cells are the released `lcpp_bench` exe (`--image --image-think -r 3 -t 8
 --ngl 99`); full tables in `qwen3vl_plan.md` slices M/J.
 
-After a CPU-only phase, the first Metal submission runs degraded - host-side between commit
-and execution, one time per window (probe-verified 2026-08-23): ~40 ms after even a
-tens-of-ms window, saturating ~70-130 ms after multi-second burns, scaling with the model.
-The mechanism is Metal's per-commit dependency pass over the TRACKED working set running
-cold (the same pass that cost ~70 ms/prefill before the weights went untracked - see the
-region-upload comment in `dasllama_metal_common`); making the prefill pools untracked reds
-parity, so the tracking is load-bearing, and the scoped fix is a per-buffer tracking audit.
-Every pre-payment is REFUTED by measurement (`PERF_LEDGER.md`'s OPEN entry): empty command
-buffers and driver round-trips (0.107 ms - never asleep), single-dispatch kernels, per-page
-touch kernels, light pulse-trains through the burn - a warm-up always pays its own cost ON
-TOP of the slack it was meant to hide. Do not re-attempt one. The `MTLResidencySet` pin
-(`DASLLAMA_METAL_RESIDENCY`, on by default) is the ONE measured partial: it holds the
-short-window case (the tower's first submission after its CPU stem, -15 ms/encode) but not
-long windows. The structural fixes are removing the CPU phase (serve encoders on the GPU - 
-the Metal tower) and the tracking audit. Related, same ledger: merely arming Metal makes a
-CPU q8 tower encode ~1.7x slower - mechanism unnamed, deleted by a GPU-served tower.
+After a CPU-only phase, the first Metal submission runs degraded - one time per window,
+entirely in the kernel-side driver window (kernelStart->kernelEnd; queue hand-off and GPU
+execution stay flat - split probe-verified 2026-08-23, `harness/residency_ramp_probe.das` +
+`das_metal_boost`'s `metal_submit_trace`). The long-window mechanism is the OS collecting a
+committed+requested `MTLResidencySet` during inactivity; the fix (SHIPPED, copied from
+ggml-metal) is the residency HEARTBEAT - a dasMetal background thread re-requesting
+residency every 5 ms for `DASLLAMA_METAL_HEARTBEAT_S` (default 180 s, 0 = A/B rail) after
+the last served step, kicked from `residency_flush`. Measured on the qwen3v tower encode:
+3000 ms burn drv 17.7 -> 3.0 ms. The `MTLResidencySet` pin itself
+(`DASLLAMA_METAL_RESIDENCY`, on by default) holds the short-window case (-15 ms/encode on
+the tower's first submission after its CPU stem); the heartbeat holds the long ones.
+REFUTED by measurement (`PERF_LEDGER.md`, the heartbeat entry): every pre-payment - empty
+command buffers and driver round-trips (0.107 ms - never asleep), single-dispatch kernels,
+per-page touch kernels, light pulse-trains through the burn - a warm-up always pays its own
+cost ON TOP of the slack it was meant to hide; do not re-attempt one. Also refuted: a
+whole-map no-copy anchor buffer (page pre-wiring moves nothing) and the once-proposed
+per-buffer tracking audit (resource count is not the lever) - prefill pools simply stay
+tracked (untracked reds parity). The ~1-3 ms window-scaled residual is the driver/GPU
+idle-state wake class, no user-space lever found. Related, same ledger: merely arming Metal
+makes a CPU q8 tower encode ~1.7x slower - mechanism unnamed, deleted by a GPU-served tower.
 
 ---
 

--- a/modules/dasLLAMA/ARCHITECTURE.md
+++ b/modules/dasLLAMA/ARCHITECTURE.md
@@ -209,8 +209,9 @@ that a question answered for one backend has an obvious address in the other. Th
 - **The tower driver owns NO PSOs.** Its kernels (LN, f32 mul_mm, the two gelu flavors,
   posadd, the gemma4v clamp / rope2d / GEGLU-quick, the head restride - gemma3v's and, offset-bound, the qwen3v/prefill slicers) live in the kernel home, so `metal_decode_init` compiles and `metal_kernels_release`
   releases them like every other registry PSO; the borrowed prefill builders (`pf_enc_bf16_mm`,
-  `enc_add_bias_rows`, `enc_rope` - the qwen3v vision NEOX apply - and the attention trio via
-  `enc_qk_mm`/`enc_av_mm`) come up through
+  `enc_add_bias_rows`, `enc_rope` - the qwen3v vision NEOX apply - and the attention trio
+  `enc_qk_mm`/`enc_softmax`/`enc_av_mm`; this list is the closed borrowed set REVIEW_GPU.md's
+  tower rules key on) come up through
   `metal_prefill_pso_init`, prefill's public bring-up seat, and `plane_buffer` in common is
   public for the same wrap-a-plane reason. The tower's own objects (the ones buffer, its
   scratch pool) release through `metal_tower_shutdown`.
@@ -296,10 +297,17 @@ entry here:**
   require of the `dasllama_math_vulkan` facade); the inversion that remains is the
   kernels<->common require DIRECTION, and it is why their seam shapes differ.
 - **UMA vs discrete VRAM**: Metal never grows Vulkan's VRAM machinery - arenas, upload
-  economics, mirrors and hydration are Vulkan's alone. Metal's ONE residency artifact is the
-  `MTLResidencySet` pin in `_common` (`DASLLAMA_METAL_RESIDENCY`, sec.2.12): it pins the served
-  working set so the per-commit tracked-set pass stays warm - a driver-cost shield, not a
+  economics, mirrors and hydration are Vulkan's alone. Metal's residency artifacts are the
+  `MTLResidencySet` pin in `_common` (`DASLLAMA_METAL_RESIDENCY`) plus its keep-alive
+  heartbeat (`DASLLAMA_METAL_HEARTBEAT_S`, a dasMetal background re-request that stops the OS
+  collecting the set over a CPU-only window, sec.2.12) - a driver-cost shield, not a
   placement mechanism; memory is still memory.
+- **The weights-epoch drop is Metal-only.** `bump_weights_epoch`'s listener seat
+  (`register_weights_epoch_listener`) has one subscriber: `_common`'s `metal_weights_drop`,
+  which runs the registered reload preps (`register_reload_prep`; the decode driver registers
+  `discard_pre`), quiesces, and releases the address-keyed region caches. Vulkan's reload
+  story is the unmap notify (`set_moe_gpu_unmap_notify`) - a different seam for a different
+  ownership model.
 - **Lens depth**: both lenses generate `enc_*` builders from kernel classes - Metal via
   `[metal_dispatch]`, Vulkan via `[vk_dispatch]` (per-class set layouts + push constants; the
   class-kernel arc retired the hand-built 6-slot set ladders outright) - and both speak the

--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -85,6 +85,7 @@ Apple GPU backend. Absent on non-Apple builds, where setting them does nothing.
 | `DASLLAMA_METAL_KQ_B8` | flag | on | Single-pass B8 twin for K-quant small-batch mv at B=5..8; 0 is the A/B rail. |
 | `DASLLAMA_METAL_KV_MIRROR_MB` | number | 4096 | Ceiling in MiB for the device-side KV mirror, clamped 64..4096. |
 | `DASLLAMA_METAL_RESIDENCY` | flag | on | Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~15 ms/encode on the M1 Max released-rig image cell; ARCHITECTURE.md 2.12); 0 is the A/B rail. |
+| `DASLLAMA_METAL_HEARTBEAT_S` | number | 180 | Seconds the residency-set heartbeat keeps re-requesting residency after the last served step (a requested set still un-wires over a long CPU-only window; the ggml-metal keep-alive, ARCHITECTURE.md 2.12); 0 disables the heartbeat - the A/B rail. |
 | `DASLLAMA_METAL_HAZARD_PARANOID` | flag | off | Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect). |
 | `DASLLAMA_METAL_HAZARD_STRICT` | flag | off | Treat every detected hazard as strict, widening barriers (correctness bisect). |
 | `DASLLAMA_METAL_PIPE_DEBUG` | flag | off | Per-step pipeline trace: GPU envelope and true inter-step handoff idle, first steps plus outliers. |

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -12,24 +12,30 @@ what it costs today and what the fix would change.
 
 ## Entries
 
-- **OPEN (narrowed by slice J) - the first Metal submission after a CPU-only window repays
-  the per-commit tracked-set pass (measured 2026-08-23, M1 Max; probes = quiet `-jit` runs
-  with the rig's tune manifest, cells = the released `lcpp_bench` exe, `--image --image-think
-  -r 3 -t 8 --ngl 99`; plan: `qwen3vl_plan.md` slices M/J).** The pre-J reds (released-rig
-  cells: 3B -12%, 4B -16%, 8B -29%, 30B -41%) were mostly this: das TEXT prefill at the same
-  padded M is at parity (rig `-p` + `--ref`: 4B +2.7%, 8B -6.2%) and the whole image-eval
-  machinery prices +10 ms (probe). The slice-J Metal tower deleted the multi-second CPU
-  encode burns; the residual (post-J rig cells: 4B/8B -16%, 30B -5%) is a ~40 ms one-time
-  commit->execution slack after ANY CPU-only window. Refuted by probe: driver wake (empty cb
-  round-trips 0.107 ms), per-page faults, light pulse-trains, denormals, affinity, cb-split
-  counts, queue identity. The MTLResidencySet pin (shipped, `DASLLAMA_METAL_RESIDENCY`)
-  holds the SHORT-window case - released-rig A/B x2: encode 177/180 ms pinned vs 194/194
-  unpinned on the 4B image cell - but not long windows; making the prefill pools untracked
-  reds `test_metal_prefill_parity`, so the tracking is load-bearing. **The scoped fix is a
-  per-buffer tracking audit** (which pool buffers need Metal's tracker vs the capture rail's
-  own barriers). Until then, media-turn pp keeps the slack wherever a CPU window precedes
-  the prefill (qwen25v exact-only and the conformer audio encoders keep the full CPU-burn
-  form).
+- **MOSTLY LANDED (was OPEN, narrowed by slice J) - the first Metal submission after a
+  CPU-only window repaid the kernel-side driver window; the residency-set HEARTBEAT removes
+  ~85% of it (measured 2026-08-23, M1 Max; probe = `harness/residency_ramp_probe.das`, the
+  qwen3v Metal tower encode after controlled CPU burns, submission split via
+  `das_metal_boost`'s `metal_submit_trace`; plan: `qwen3vl_plan.md` slices M/J).**
+  The four-timestamp split localized the whole ramp to drv = kernelStart->kernelEnd (queue
+  and GPU execution FLAT): warm 0.11 ms, 200-1000 ms burn ~1.2 ms, 3000 ms burn 17.7 ms.
+  The long-window mechanism is the OS collecting a committed+requested `MTLResidencySet`
+  during inactivity - llama.cpp's comment names it verbatim, and their cure is a background
+  thread re-calling `requestResidency` every 5 ms (`ggml-metal-device.m`). Copied:
+  `metal_residency_set_heartbeat` in dasMetal (5 ms cadence, keep-alive countdown), kicked
+  from `residency_flush` per served step, knob `DASLLAMA_METAL_HEARTBEAT_S` (default 180 s,
+  0 = A/B rail). Probe ladder at the 3000 ms burn (drv ms, x2 each): baseline 17.7/17.8,
+  heartbeat 2.95/3.01, whole-map anchor buffer 18.5/18.1, heartbeat+anchor 2.94/3.00 - the
+  heartbeat takes the win alone. REFUTED by that ladder: the whole-map no-copy anchor (one
+  pinned unbound buffer over the full mapping - page pre-wiring changes NOTHING in either
+  arm, so neither the collect nor the residual is host-page work) and the previously
+  proposed **per-buffer tracking audit** (resource count is not the lever; DEMOTED).
+  Earlier refutations stand: driver wake (empty cb 0.107 ms), per-page faults, light
+  pulse-trains, denormals, affinity, cb-split counts, queue identity; prefill pools stay
+  tracked (untracked reds `test_metal_prefill_parity`). **OPEN residual:** ~1-3 ms drv on
+  the first submission after a multi-hundred-ms window, scaling with window length,
+  insensitive to residency cadence AND page pinning - the driver/GPU idle-state wake class;
+  no user-space lever found (pulse trains already refuted), live with it.
 
 - **OPEN - arming Metal makes the CPU q8 tower encode ~1.7x slower (measured 2026-08-23,
   M1 Max, 8B qwen3v tower: 3.26-3.45 s with MetalMode.required vs 1.90 s on the CPU leg,
@@ -89,7 +95,7 @@ what it costs today and what the fix would change.
   buckets of a `-jit` probe (`gemma4v_encode` on a 624x480 canvas, `DASLLAMA_CPU_PREFILL=1`,
   three reps, direction only): the exact-plane CPU lane through `matmul_bf16_batch`'s per-row
   `dot_bf16` loop costs ~ 1.9 s per encode (GEMMs ~ 90 %, ~ 92 GMAC/s aggregate - ~10x under
-  the q8xq8 prefill kernels), the q8 lane ~ 0.43 s (GEMMs 238 ms, the attention core 163 ms - 
+  the q8xq8 prefill kernels), the q8 lane ~ 0.43 s (GEMMs 238 ms, the attention core 163 ms -
   now the #2 bucket), and the Metal block loop ~ 89 ms with the stem (10 ms) and tail (2 ms) on
   the CPU. Prediction P2 (0.9-1.8 s, >= 12 % of the turn, for the exact CPU lane): the share held
   by a wide margin, the absolute landed just above the band. **Ruled and landed in the arc:** the
@@ -122,7 +128,7 @@ what it costs today and what the fix would change.
   (mapped pages are shared and evictable across processes; a 190 MB owned bf16->f32 widening is
   neither) and zero load-time work - not the load wall. **Both are DONE (2026-08-14, the same arc's slices I and J).** The rail
   landed: the embedder stages, mints and maps like the audio towers, and the prepared image maps
-  with no load-time work (mmap). Plane format settled as **per-GEMM, following each source tensor's on-disk type** - 
+  with no load-time work (mmap). Plane format settled as **per-GEMM, following each source tensor's on-disk type** -
   and the premise that the mmproj is uniformly bf16 was HALF WRONG: gemma-4's shipped "BF16"
   mmproj carries an **F32** patch embedder (26.5M params) and a **BF16** projection (14.7M), so a
   both-or-neither rule bought nothing. Per-GEMM gives 200 MB -> 170 MB with tier-1 unmoved to the
@@ -294,10 +300,10 @@ what it costs today and what the fix would change.
   kernel itself to fuse the activation (ledger-class). Still open from the plan: [tune]
   schedule axes (thin until fusion adds real choices), batch-rail unification (R4), dasMetal
   promotion of the graph/lens machinery;
-  (2) the q51 w2 MoE kernel at 224 wGB/s in-lab - 
+  (2) the q51 w2 MoE kernel at 224 wGB/s in-lab -
   the integer-compose form (q | hbit<<4 pre-convert, replacing the select chain) TESTED + REFUTED
   2026-07-23: 226 vs 224 wGB/s (+1%), bit-exact but the dot stays issue-bound in the shift/mask
-  decode regardless of compose shape; kept as the lab's w2_ic negative control, do not re-chase - 
+  decode regardless of compose shape; kept as the lab's w2_ic negative control, do not re-chase -
   a real q51 win needs a different decode strategy (per-thread multi-block amortization or an
   upload-time qh transpose, both ledger-class); (3) WO ~0.2ms slack; (4) MetalMoeGemvK5 carries the same
   scalar-x block - mechanical sibling of the shipped fix, prove via a lab arm first. Lab kept as
@@ -350,7 +356,7 @@ what it costs today and what the fix would change.
   (dasllama_metal_decode.das:164) is a pure CAPABILITY test - it engages the greedy spec chain for
   any tied-k6 classifier with no BENEFICIAL condition, so a big pure-k6 file eats the spec-chain
   work where it is a net loss. Cost today: gemma4-12B Q6_K B=1 greedy runs 26.81 t/s with spec on
-  vs 27.11 spec-off (~+1%; `DASLLAMA_METAL_SPEC=0` recovers). This was the board's "0.81x" cell - 
+  vs 27.11 spec-off (~+1%; `DASLLAMA_METAL_SPEC=0` recovers). This was the board's "0.81x" cell -
   RE-PAIRED to 0.977 on / 0.988 off in a clean quiet window (the 0.81 was window-skew; spec-on had
   drifted 22.4->26.8). Fix: a size/format beneficial-gate (decline spec on pure-k6 above a
   param/layer threshold, picked at the 4B-wins / 12B-loses crossover) in spec_cls_capable or the
@@ -412,7 +418,7 @@ what it costs today and what the fix would change.
   0.92->0.95, gemma2-2b 0.93->0.96, gemma3-1b 1.22->1.24; parity green (fam-gemma3/gemma4 +
   arm1-basic swiglu regression). STILL OPEN: the batch fuse13 rail (b2/b4 PSOs) keeps the
   hardcoded silu epilogue, and prefill's legacy fused rail (`enc_swiglu_quant` has no gelu twin,
-  and the deferred-W2-add trick has no post-ffn-norm slot, so `fused` stands down entirely - 
+  and the deferred-W2-add trick has no post-ffn-norm slot, so `fused` stands down entirely -
   mm-path prefill, the default, is unaffected).
   (2) *pre_post_norm sites are composed, not fused* - each post-norm is a separate in-place rms
   dispatch before the residual add (+2 dispatches/layer on every path). Fix: a `post_add_rms`
@@ -456,7 +462,7 @@ what it costs today and what the fix would change.
   `embed_forward` primitive - but that breaks the facade-only invariant, so the overload is the
   clean path). Both are backlog; the server is serial and embeddings are low-frequency.
 - **q8 GEMV loses to fp32 on cache-resident weights without VNNI (zen2 whisper decoder,
-  2026-07-08).** Decoder-q8 stage A/B on zen2 tiny/jfk: logits GEMV 3.8x faster (76 MB - 
+  2026-07-08).** Decoder-q8 stage A/B on zen2 tiny/jfk: logits GEMV 3.8x faster (76 MB -
   bandwidth-bound, the q8 win) but per-layer decoder GEMVs +7-21% SLOWER q8 (~2.3 MB mats,
   L2/L3-hot across the serial decode steps; AVX2 int8-dot + per-step requant loses to plain
   FMA when there's no memory traffic to save). Cost today: whisper-tiny zen2 decode leaves
@@ -570,7 +576,7 @@ what it costs today and what the fix would change.
   the w2-input requant moves to 256-row stage-0 groups and the wo-input requant to HEAD GROUPS
   of 256/head_size heads (Qwen3's 128 = head pairs) so every Q8_K quantize covers whole
   superblocks. Gates: dim % 256 for any kq weight, hidden % 256 for a kq down-proj, qd % 256 +
-  head-size divisibility for a kq wo (all real kq models pass). Bit-exact vs the per-op path - 
+  head-size divisibility for a kq wo (all real kq models pass). Bit-exact vs the per-op path -
   test_fused_decode grew a kq arm (Qwen3-4B Q5_K_M = k5+k6+head-pairs, gemma-2-2b Q4_K_M =
   k4+k6+softcap/post-norm; ids + full logits EXACT). Measured (M1 Max steady-state): Q6 tg
   30.5 -> 31.1 (+2.1%), Q5 ~flat (33.8, within run wobble), Q4 control flat; decode_prof
@@ -588,7 +594,7 @@ what it costs today and what the fix would change.
   **THE LESSON (measured, do not re-learn):** pure byte-expanded DRAM planes (no scratch)
   win the same pp but cost tg -30%/-20% on Q5/Q6 - M1 Max decode is DRAM-bound at the
   model level (~90 GB/s effective), so plane bytes ARE decode time; k4 stays nibble-packed
-  everywhere for the same reason. Residual headroom, ledgered: (a) k6 tile 76 vs k4 95 - 
+  everywhere for the same reason. Residual headroom, ledgered: (a) k6 tile 76 vs k4 95 -
   the per-16 SIGNED sub-scale fold pays 2 scale-row sexts + 4 muls per block vs k4/k5's 1;
   (b) k5 unpack still ~6% of production tile (the broadcast+carry deposit - a generated
   NEON tbl/cmtst unpack kernel would close it).
@@ -607,7 +613,7 @@ what it costs today and what the fix would change.
   ~155-158 vs 172 = 0.90x.
 - **DONE RACED (zen2, 2026-07-12 PM^2, 16 affinity-pinned cores both sides, ABBA before=52a22a39b
   after=3d78ca8ef, Qwen3-4B): das WINS Q5 pp 1.84x / Q6 1.32x vs lcpp; the kq v2+v3 arc itself
-  is ~NEUTRAL on the maddubs lattice.** pp512 das-after/lcpp: Q4 161-180 vs 168.3 (~parity - 
+  is ~NEUTRAL on the maddubs lattice.** pp512 das-after/lcpp: Q4 161-180 vs 168.3 (~parity -
   their one AVX2 K-quant repack), Q5 158-161 vs 87.0 (**1.84x**), Q6 128-130 vs 98.0
   (**1.32x**); tg64 ~ lcpp parity all three (19.3/16.6/14.5 vs 19.25/16.87/14.69). ABBA
   before->after: Q4/Q5 pp par-to-+3%, **Q6 pp -4.6%** (135.2->129.0 median), tg within noise
@@ -665,7 +671,7 @@ what it costs today and what the fix would change.
   3072 - an unfused rms+quant pair would re-admit it); GPU-side per-row greedy argmax for the
   batch (the single-stream spec chain already carries the kernel) if greedy batch serving ever
   matters. Sized honestly: closing to lcpp's curve is worth up to ~2.1x at B=4, ~1.7x at B=8,
-  ~1.34x at B=16 on M1. UPDATE (2026-07-14 late): (a) LANDED as the x-staged fixed-B forms - 
+  ~1.34x at B=16 on M1. UPDATE (2026-07-14 late): (a) LANDED as the x-staged fixed-B forms -
   lab b2x 326-363 wGB/s (+40-88%), b4x 188-217 (~2x, above lcpp's ~186 at ne11=4); driver
   same-window A/B B=4 +19.2%, B=2 +1.8% (B=2's step is residual/dispatch-bound: knockout says
   GEMV+cls is 11.7ms of the 16.7ms gpu step at B=2, 21.4 of 27.6 at B=4 - the rest is the
@@ -726,7 +732,7 @@ what it costs today and what the fix would change.
   (Spotted wave 4.)
 - **DONE (MXFP4 arc, 2026-07-02): native-MXFP4 expert stacks + repacked TBL/SDOT kernels + the
   MoE dispatch fuse.** Was: gpt-oss-20b's 4.25-bit expert stacks ran as Q8 (2x resident, 2x
-  decode traffic). Now: the stacks stay as raw nibble + E8M0 planes (mxq/mxs, exact disk bits - 
+  decode traffic). Now: the stacks stay as raw nibble + E8M0 planes (mxq/mxs, exact disk bits -
   the old dequant->requant amax error is gone), decoded in-register by new aarch64_neon
   intrinsics (tbl16_lo/tbl16_hi = vqtbl1q_s8 of the doubled-e2m1 LUT; sdot4_w / sdot4_laneq_w
   take the tbl result as a VALUE) through dot_mx4q8 ([tuned], row-major) and dot_mx4q8_laneq4
@@ -779,7 +785,7 @@ what it costs today and what the fix would change.
   rows => bit-exact vs inline, gated by test_forward), behind `g_decode_attn_par_threshold`
   (profile `runtime.decode_attn_par_threshold`). Quiet-box sweep (M1 Max, inline-vs-threaded
   interleaved at 32..2048 ctx on Llama-3.2-1B and gemma-4-12B): crossover at ~200-260K work on
-  BOTH; below it threading costs <=2%, above it wins reach +74% (1B) / +89% (12B) at 2048 ctx - 
+  BOTH; below it threading costs <=2%, above it wins reach +74% (1B) / +89% (12B) at 2048 ctx -
   the derived 4M default was ~15x too conservative (the 12B ran inline below ctx 512). Default
   is now the measured 262144. (Spotted tune audit, 2026-07-02.)
 - **LOW PRIORITY: `sample_` top-k is O(top_k x vocab) scalar selection.** Each of the top_k
@@ -796,9 +802,9 @@ what it costs today and what the fix would change.
   trustworthy on this box, single-window absolutes swing +/-10-15%). The pre-fuse 4x1 dispatch
   shape measures 63-72 GB/s - the dispatch fuse was worth ~30% and is confirmed load-bearing.
   Follow-up landed: **expert bias vectors fold into the groupn workers' stores** (bp/boffs on the
-  groupn contract; bit-identical to the post-pass add_bias, minus its serial ~36us/layer) - 
+  groupn contract; bit-identical to the post-pass add_bias, minus its serial ~36us/layer) -
   decode 34.7 -> **35.2 t/s @ ctx 8 / 33.8 @ ctx 512** (llama.cpp same-window anchor 41.1 ->
-  0.86x). Also swept: decode-attn threshold 0-vs-262144 under the spinner at ctx 8/512 - 
+  0.86x). Also swept: decode-attn threshold 0-vs-262144 under the spinner at ctx 8/512 -
   a WASH at both depths (the low-ctx attention is memory-latency-bound; threading's dispatch
   cost ~ its serial cost), so the measured default stands; moe_reduce/rope threading rejected
   (~8us/layer each, below dispatch cost). What remains vs llama.cpp is their continuous-polling
@@ -807,7 +813,7 @@ what it costs today and what the fix would change.
 - **MXFP4 grouped prefill pays a per-touched-expert Q8 expansion (~120MB of traffic each, half of
   it the repack scratch copy).** `expand_mx4_region_q8` writes exact row-major Q8 then runs the
   load-time `repack_q8q8_weight` (temp copy + interleave) so the laneq batch GEMM applies. Levers,
-  in effort order: (a) expand DIRECTLY into the interleaved layout (folds the repack's copy away - 
+  in effort order: (a) expand DIRECTLY into the interleaved layout (folds the repack's copy away -
   needs a backend-provided expand-repack, not a layout hardcode in common); (b) a native MXFP4
   batch GEMM (mx4 twin of the laneq 4x4 tile - halves the GEMM's weight streaming too, likely wins
   outright); (c) the `npos * k >= 8 * n_expert` tiny-batch guard is an ESTIMATED breakeven
@@ -822,7 +828,7 @@ what it costs today and what the fix would change.
   speculatively. (Spotted tune audit, 2026-07-02.)
 - **DONE (GEMV hunt, 2026-07-03): the decode "kernel top-end gap" was chunk-count misalignment,
   not the kernel.** A 12-variant GEMV race (`bench_gemv_decode.das` + the matmul_variants decode
-  cells: unroll/ILP/fma-flush/dual-group/inline-scale) proved every kernel micro-opt a wash - 
+  cells: unroll/ILP/fma-flush/dual-group/inline-scale) proved every kernel micro-opt a wash -
   llama.cpp's live M1 kernel (`ggml_gemv_q8_0_4x4_q8_0`; their 4x8 tier needs i8mm) is the same
   shape as `dot_q8q8_laneq4`. The real delta: njobs = `get_total_hw_jobs()*k` sized chunks to the
    7 WORKERS, but 8 lanes serve them (workers + caller - team by design, fifo via main-steal), so
@@ -847,7 +853,7 @@ what it costs today and what the fix would change.
   writing [4xfp16 d | 128 qs] blocks + the GEMV/batch/group3/groupn kernels reading it; (c) the
   element-offset plumbing moves from plane offsets to block strides (loader `w*_off` math, groupn
   offs contracts). Sized: dasLLVM intrinsic + codegen bump, ~4 kernel twins, loader/offset sweep,
-  fixture risk LOW (same math, scales exact fp16 round-trip of what the loader already computes - 
+  fixture risk LOW (same math, scales exact fp16 round-trip of what the loader already computes -
   but the quantizer would store fp16-rounded scales, so oracle fixtures need a refreeze check).
   Expected: cls 1.12x -> ~1.06x, ffn 1.04x -> ~parity; decode e2e ~+2-3%. NOT this PR - needs its
   own arc. (Spotted GEMV hunt, 2026-07-03.)
@@ -882,7 +888,7 @@ group; wording kept.
 - **AMX tile family - arc CLOSED (slice I built it, slice K's SPR session 4 adjudicated it,
   2026-07-05).** amx is 0.36-0.55x the biased-busd512 champion across all four ladder models and
   the best cell ever measured sits below the plain AVX2 maddubs tier; the bill is the kstep=1
-  Q8-scale-boundary fold (~256KB of C-spill per 32-row x 32-token unit vs 64KB of weight traffic - 
+  Q8-scale-boundary fold (~256KB of C-spill per 32-row x 32-token unit vs 64KB of weight traffic -
   codegen, frequency license, and dispatch all separately exonerated). Family stays grid-resident,
   `spr_manifest` unchanged; revisit only on Granite-Rapids-class silicon or a cache-resident
   serving regime. Conditional-only tail: an **amx kstep=2 fold** (K=64 tiles, two scale segments
@@ -903,7 +909,7 @@ group; wording kept.
   plan's "subsume, then delete dasllama_tune's `[tuned]`/box_profile rail" is not done.
 - **OPEN - per-slot perms.** Unimplemented: no per-slot perm plumbing exists in llvm_tune or
   `dasllama_math_gen.das`; the phrase appears only in plan prose and in the unrelated per-slot
-  *backend* pin (`x64_arch.md`, `dasllama_math.das`). What landed instead is per-FORMAT families - 
+  *backend* pin (`x64_arch.md`, `dasllama_math.das`). What landed instead is per-FORMAT families -
   separate `[tune]` brackets for k4 / k5 / k6 / q40 / q8q8 / q51 in `dasllama_math_gen.das`, each
   its own manifest entry. Per-slot perms remains the named escalation if a box ever flips the amx
   end-to-end verdict, or if biased-vs-plain gemv turns out to matter under an amx stamp.
@@ -934,7 +940,7 @@ group; wording kept.
 
 ### From `audio_models_plan.md` (Findings; correctness, not perf)
 
-- **RESOLVED (87ffe39fe) - the v0.3 Mistral `[INST]` template's derived close was ` [/INST]` - 
+- **RESOLVED (87ffe39fe) - the v0.3 Mistral `[INST]` template's derived close was ` [/INST]` -
   wrong for multi-turn.** Fixed: `mistral_instruct_template`'s `assistant_close` is `</s>`, like
   v7-tekken's. Spotted in audio session B while adding `ChatTemplate.assistant_close`.
 
@@ -964,7 +970,7 @@ group; wording kept.
   encoder becomes a measured bottleneck vs mtmd. *(This is the later of the doc's two takes; the
   earlier "q8 the 6 GEMM families + projector at load" phrasing is the same lever, already carried
   by the "Audio arc: the fp32 encoder is the whole ASR cost" entry above.)*
-- prefill 1518 pos (1500 audio) ~ 16.4 s on M1 for the 7B q8 decoder (~93 t/s); decode ~11 t/s - 
+- prefill 1518 pos (1500 audio) ~ 16.4 s on M1 for the 7B q8 decoder (~93 t/s); decode ~11 t/s -
   normal 7B-on-M1 numbers, no audio-specific cost.
 - mel/DFT-GEMM is noise, leave it: single-threaded `gemm_f32`, ~0.13 s per clip, and the
   Mel-as-GEMM twiddle matrices are f32 fblob consts (~410 KB) - quantizing them is noise, skip.

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -76,9 +76,12 @@ file.** A platform-neutral engine file carrying it is a defect.
 more of `dasllama/dasllama_common.das`.**
 
 **No ad-hoc profiling.** A NEW clock read paired with a print or log of the elapsed interval is
-a defect in engine code - instrumentation goes through the sanctioned rails, and a clock whose
-value feeds logic is marked `// clock: control`. The rails, and where free-hand timing is
-legal, are `ARCHITECTURE.md` sec.2.10.
+a defect in an engine file (`dasllama/`) outside a cold one-shot load, bake, map, or
+tokenizer-build progress log - instrumentation goes through the sanctioned rails, listed with
+their reasons in `ARCHITECTURE.md` sec.2.10.
+
+**A clock whose value feeds logic is marked `// clock: control`, in any file under this
+folder** - unmarked it reads as free-hand timing to the ad-hoc-profiling sweep.
 
 **Every new kernel or loop the runtime re-enters per token, per frame, or per prefill
 quantum is COVERED by an annotated region entry** - `[hot_path]`, any of the `[no_alloc]` /
@@ -106,10 +109,11 @@ EXECUTED, not skipped.**
 
 **An override announces itself where it changes the outcome.** An override is an environment
 knob or an exported runtime setter that moves a gate, policy, or threshold off its default;
-a CLI flag is never an override under this rule. Where one changes an observable outcome of
-the run - what it writes, reads, or mints - a printed line names it by its own spelling (the
-env variable name, or the setter's function name); set-but-inert stays silent, per-site
-repeats are fine. Adding one, or giving one a new effect, without the announce is a defect.
+a CLI flag, and a knob whose only effect is timing (an A/B perf rail), are never overrides
+under this rule. Where one changes an observable outcome of the run - what it writes, reads,
+or mints - a printed line names it by its own spelling (the env variable name, or the
+setter's function name); set-but-inert stays silent, per-site repeats are fine. Adding one,
+or giving one a new effect, without the announce is a defect.
 
 **A self-measured served-turn time - tok/s, a turn wall - entering
 `performance/records/<box>.json` or `PERF_LEDGER.md` comes from the released `lcpp_bench`
@@ -221,10 +225,11 @@ a struct the renderer emits but the registry does not is caught by
 **`dasllama/dasllama_unicode.das`'s RANGES/WS tables are generated - retranscoded from llama.cpp's
 `unicode-data.cpp`; hand-editing them is a defect.**
 
-**A diff that adds a file, moves code between files, or changes what a file owns lands the
-`ARCHITECTURE.md` sec.1 edit that keeps the charters true, in the same change.** A per-file
-inventory restated in this checklist is a defect of the checklist (a rule naming what KIND of code lands in
-which file is the checklist's own).
+**A diff that adds a file under `dasllama/`, adds a file beside one `ARCHITECTURE.md` sec.1
+charters by name, moves code between files, or changes what a file owns lands the sec.1 edit
+that keeps the charters true, in the same change.** A per-file inventory restated in this
+checklist is a defect of the checklist (a rule naming what KIND of code lands in which file
+is the checklist's own).
 
 **A tensor format conversion lands in `dasllama/dasllama_convert.das`.**
 
@@ -286,9 +291,11 @@ Benchmarks, harnesses, and tests decode their own fixtures.
 **Engine, HTTP, or writer logic never lands in `dasllama/dasllama_scheduler.das`** - engine logic in
 engine files, HTTP in the server, writer logic in the writer's own file.
 
-**An `[init]`-only side-effect require lives in `dasllama/dasllama_transformer.das`** - arch
-registrations, GPU tiers, every module requiring the engine back; it sits in
-`dasllama/dasllama_common.das` only if engine code needs it.
+**An `[init]`-only side-effect require in an engine file (`dasllama/`) lives in
+`dasllama/dasllama_transformer.das`** - arch registrations, GPU tiers, every module requiring
+the engine back; it sits in `dasllama/dasllama_common.das` only if engine code needs it. A
+program root (test, harness, benchmark, tool) requires the registration module it needs
+directly.
 
 **An architecture file (`dasllama/dasllama_arch_*.das`) is declarative registration only.** An
 architecture that changes a forward loop, or tests a family name on a shared path, is a defect.

--- a/modules/dasLLAMA/REVIEW_GPU.md
+++ b/modules/dasLLAMA/REVIEW_GPU.md
@@ -61,8 +61,8 @@ backend's files partition into: the kernel home (`_kernels` on Metal, `_classes`
 servability gates), `_tower` (the encoder-tower driver), `_asr_dec` (the ASR-decoder
 driver), and the kernel-access lens (`_lens` on Metal, `_dispatch` on Vulkan); a backend
 carries a role's file only once it has the capability. A capability with no matching role
-gets its own role file - and adds its role to this list and to `ARCHITECTURE.md` sec.1.5 in
-the same change; anything else is a grab-bag, and a grab-bag file is a defect.
+gets its own role file - and adds its role to this list in the same change; anything else
+is a grab-bag, and a grab-bag file is a defect.
 
 **A GPU family shares ONE device and queue from `dasllama/dasllama_<gpu>_common.das`'s
 init.** A module creating its own is a defect.
@@ -99,7 +99,8 @@ is NEGOTIATED, not where it binds.** The bind site cannot shrink a buffer that w
 **A change to a GPU decode or prefill driver (`dasllama/dasllama_metal_decode.das`,
 `dasllama/dasllama_metal_prefill.das`, `dasllama/dasllama_vulkan_decode.das`,
 `dasllama/dasllama_vulkan_prefill.das`), to the servability gates in
-`dasllama/dasllama_metal_shapes.das`, or to the residency rail's serving paths in
+`dasllama/dasllama_metal_shapes.das`, to the weight-region cache and residency paths in
+`dasllama/dasllama_metal_common.das`, or to the residency rail's serving paths in
 `dasllama/dasllama_gpu_resident.das` - the upload, plan, and decode/batch-decode/prefill
 override paths a session runs through, never the bake paths - ships `harness/parity.das`
 GPU-vs-CPU runs on one q8 and one kq model, with `--kv` matching the armed mirror codec.**
@@ -109,25 +110,31 @@ GPU-vs-CPU runs on one q8 and one kq model, with `--kv` matching the armed mirro
 driver declines codec-mismatched sessions silently.
 
 **A change to `dasllama/dasllama_metal_tower.das`, to the `AttnArgs` kargs struct, or to any
-kernel class the tower dispatches - the builders its own kernel classes declare, plus the
-prefill builders it borrows (`enc_qk_mm`, `enc_softmax`, `enc_av_mm`, `pf_enc_bf16_mm`,
-`enc_add_bias_rows`, `enc_rope`) - ships the per-family GPU oracle gate of every family the
-changed code is reachable from (`tests/test_gemma4uv.das`, `tests/test_gemma4v.das`,
-`tests/test_gemma3v.das`, `test_qwen3v_tier1_metal` in `tests/test_qwen3v.das`), ALL of them
-when the change touches state or setup the whole driver shares (any module-level `g_tw_*`
-variable, `metal_tower_init`, or `dasllama_metal_tower_register`); and a
-`tests/test_model_image.das` run with the `mtower` arm, with `metal_tower_stats()`'s encode
-count rising across the run.** A `register_<fam>_gpu` call in `dasllama_metal_tower_register`
-where `dasllama/dasllama_<fam>.das` is a family file names a family; a registered family whose
-gate file this rule does not name, and a prefill builder the tower borrows that this rule
-does not name, are the rule's defects to fix in the same change.
+kernel class the tower dispatches or builder it borrows (the borrowed set is the tower entry
+in `ARCHITECTURE.md` sec.1.5) ships the gate of every registered tower hook the changed code
+is reachable from: the family gates `tests/test_gemma4uv.das`, `tests/test_gemma4v.das`,
+`tests/test_gemma3v.das`, and `test_qwen3v_tier1_metal` in `tests/test_qwen3v.das`; the
+encoder-blocks leg's `tests/test_whisper.das`; the conv legs' `tests/test_audio.das` and
+`tests/test_audio_embedder.das`.** A hook registered in `dasllama_metal_tower_register` whose
+gate this rule does not name is the rule's defect to fix in the same change.
+
+**A tower change that touches state or setup the whole driver shares - any module-level
+`g_tw_*` variable, `metal_tower_init`, or `dasllama_metal_tower_register` - ships ALL the
+gates above.**
+
+**A change the tower serves - the driver file, its kargs, a dispatched kernel class, or a
+borrowed builder - ships a `tests/test_model_image.das` run with the `mtower` arm, with
+`metal_tower_stats()`'s encode count rising across the run.**
 
 **A change to the bake-trim path in `dasllama/dasllama_gpu_resident.das` (`trim_model_planes`)
 ships a `dasllama-convert --trim` bake plus a serve of the trimmed image, on one q8 and one kq
 model.** Parity runs never reach it.
 
-**A change to `dasllama/dasllama_metal_asr_dec.das` ships a `tests/test_model_image.das` run
-with the `mtower` arm** - its CPU-vs-GPU transcript cells are that driver's parity instrument.
+**A change to `dasllama/dasllama_metal_asr_dec.das`, or any change to
+`dasllama/dasllama_metal_common.das`, ships a `tests/test_model_image.das` run with the
+`mtower` arm** - its CPU-vs-GPU transcript cells are the ASR-decoder driver's parity
+instrument, and the shared common paths reach that driver with no line of its own file
+touched.
 
 **A kernel that reads or writes the residency rail's `k_mirror`/`v_mirror` slabs leaves
 neither codec unserved: it is stamped from a `[|> template_struct_instance]` codec template

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1516,11 +1516,25 @@ def public weights_epoch() : int64 {
     return g_weights_epoch
 }
 
+// the push half of the contract: caches don't poll for staleness (a poll is a call every
+// consumer must remember), the bump invokes them — dasllama_metal_common subscribes its drop
+var private g_weights_epoch_listeners : array<function<void>>
+
+//! Subscribe a drop-everything reaction to weight-address recycling — for GPU caches keyed by
+//! HOST ADDRESS. Invoked synchronously by every ``bump_weights_epoch`` ([init]-time is the
+//! registration home; bumps only happen at load/map boundaries, never mid-step).
+def public register_weights_epoch_listener(f : function<void>) {
+    g_weights_epoch_listeners |> push(f)
+}
+
 //! The image loader's half of the same contract: mapping a prepared image lands planes at
 //! fresh (possibly recycled) addresses exactly like a gguf load does, so it must move the
 //! epoch too — dasllama_image calls this on every successful load_image.
 def public bump_weights_epoch() {
     g_weights_epoch++
+    for (f in g_weights_epoch_listeners) {
+        invoke(f)
+    }
 }
 //! Resident memory footprint of a loaded model, in bytes, broken down by region. aux_fp32 is the
 //! embedding + norms (always kept); weight_fp32 is the dense big weights (only in fp32 mode — a

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -225,7 +225,7 @@ struct public MetalEnv {
     @clarg_doc = "Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~15 ms/encode on the M1 Max released-rig image cell; ARCHITECTURE.md 2.12); 0 is the A/B rail."
     residency : bool = true
 
-    @clarg_doc = "Seconds the residency-set heartbeat keeps re-requesting residency after the last served step (a requested set still un-wires over a long CPU-only window; the ggml-metal keep-alive, ARCHITECTURE.md 2.12); 0 disables the heartbeat — the A/B rail."
+    @clarg_doc = "Seconds the residency-set heartbeat keeps re-requesting residency after the last served step (a requested set still un-wires over a long CPU-only window; the ggml-metal keep-alive, ARCHITECTURE.md 2.12); 0 disables the heartbeat - the A/B rail."
     heartbeat_s : int = 180
 
     @clarg_doc = "Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect)."

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -225,6 +225,9 @@ struct public MetalEnv {
     @clarg_doc = "Pin the served working set (weight regions, planes, the recycled pool buffers) in an MTLResidencySet, macOS 15+: the per-commit residency pass stays a no-op, so the first submission after a CPU-only window stops repaying it (~15 ms/encode on the M1 Max released-rig image cell; ARCHITECTURE.md 2.12); 0 is the A/B rail."
     residency : bool = true
 
+    @clarg_doc = "Seconds the residency-set heartbeat keeps re-requesting residency after the last served step (a requested set still un-wires over a long CPU-only window; the ggml-metal keep-alive, ARCHITECTURE.md 2.12); 0 disables the heartbeat — the A/B rail."
+    heartbeat_s : int = 180
+
     @clarg_doc = "Barrier at every dispatch instead of at tracker-detected hazards (correctness bisect)."
     hazard_paranoid : bool = false
 

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -603,6 +603,12 @@ def residency_flush {
         metal_residency_set_request(g_rset)
         g_rset_dirty = false
     }
+    if (g_env_metal.heartbeat_s > 0) {
+        // keep-alive kick: a requested set still un-wires over a long CPU-only window, and the
+        // next submission repays the whole tracked-set pass — the background re-request keeps
+        // the pages wired for heartbeat_s after the last served step (ARCHITECTURE.md 2.12)
+        metal_residency_set_heartbeat(g_rset, g_env_metal.heartbeat_s)
+    }
 }
 
 //! Buffers pinned so far (0 = off or not yet created) — the knob's test witness.

--- a/modules/dasLLAMA/dasllama/dasllama_metal_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_common.das
@@ -1890,14 +1890,40 @@ def metal_common_init : bool {
     return true
 }
 
-// ===== the weights-epoch guard =====
-// g_regions keys by host address; a model reload makes those keys lie (see
-// weights_epoch). Drivers flush at entry when the epoch moved, after quiescing in-flight work.
-var g_weight_cache_epoch = -1l
+// ===== the weights-epoch drop =====
+// g_regions keys by host address; a model reload makes those keys lie (see weights_epoch).
+// The bump PUSHES the drop here via the registered listener — drivers never participate.
+var private g_reload_preps : array<function<void>>
 
-def weight_caches_stale() : bool {
-    return weights_epoch() != g_weight_cache_epoch
+//! A driver's extra reload reaction (decode retires its speculative pre-step); runs BEFORE the
+//! shared quiesce+release so an in-flight speculative cb never sees released regions.
+def register_reload_prep(f : function<void>) {
+    g_reload_preps |> push(f)
 }
+
+[init]
+def private metal_weights_listener_register {
+    register_weights_epoch_listener(@@metal_weights_drop)
+}
+
+[cold_path]   // fires only at load/map boundaries (bump_weights_epoch)
+def private metal_weights_drop {
+    for (f in g_reload_preps) {
+        invoke(f)
+        g_reload_preps_run++
+    }
+    finish_pending_step()
+    regions_release_all()
+}
+
+//! Address-keyed weight regions currently cached (both tables) — the epoch-drop test witness.
+def weight_regions_cached() : int64 => int64(length(g_regions) + length(g_regions_cat3))
+
+var private g_reload_preps_run : int64
+
+//! Lifetime count of reload-prep invocations through the drop — the registration witness
+//! (deltas compose across readers): a dropped register_reload_prep line keeps it flat.
+def reload_preps_run() : int64 => g_reload_preps_run
 
 [cold_path]   // regions release + retire drain — the shared tail of the flush/teardown legs
 def private regions_release_all {
@@ -1926,16 +1952,6 @@ def private regions_release_all {
         }
     }
     g_region_retire |> clear()   // released above — delete of array<T?> would double-free the pointees
-}
-
-[cold_path]   // live-reload only
-def weight_caches_flush_on_reload {
-    if (!weight_caches_stale()) {
-        return
-    }
-    finish_pending_step()
-    regions_release_all()
-    g_weight_cache_epoch = weights_epoch()
 }
 
 def metal_common_release {

--- a/modules/dasLLAMA/dasllama/dasllama_metal_decode.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_decode.das
@@ -1097,7 +1097,7 @@ def private finish_draft_step(t : Model; var s : Session; r : StepRes; seam : bo
 def metal_mtp_draft_forward(t : Model; var s : Session; token, pos : int64; seam : bool = false) : bool {
     let c = t.config
     if (g_dev == null || !t.metal_blob || c.n_layer_nextn <= 0l || pos < 1l ||
-            weight_caches_stale() || !key_exists(g_mirrors, s.uid)) {
+            !key_exists(g_mirrors, s.uid)) {
         return false
     }
     finish_pending_step()
@@ -1983,10 +1983,6 @@ def metal_decode_forward(t : Model; var s : Session; token, pos : int64) : bool 
     // mixed batch/single schedules: a pipelined batch step may still own this session's KV row
     // and logits — land it before reading anything session-side (no-op when nothing pends)
     finish_pending_step()
-    if (weight_caches_stale()) {   // a model (re)load may have recycled cached weight addresses
-        discard_pre()
-        weight_caches_flush_on_reload()
-    }
     g_lp_err = false
     var why = decode_decline(t, s, pos)
     if (why == MetalDecodeDecline.none && !metal_decode_init()) {
@@ -2171,10 +2167,6 @@ def private batch_decode_decline(t : Model; ws : BatchWorkspace; sessions : arra
 //! ws.scr.x_b holds the final residuals; false = declined, CPU loop recomputes from clean state.
 [hot_path]
 def metal_batch_decode_forward(t : Model; var ws : BatchWorkspace; var sessions : array<Session?>; nrows : int64) : bool {   // nolint:STYLE037,STYLE038 — the batch step driver; encode/commit/stash share the whole step's state
-    if (weight_caches_stale()) {   // a model (re)load may have recycled cached weight addresses
-        discard_pre()
-        weight_caches_flush_on_reload()
-    }
     var why = batch_decode_decline(t, ws, sessions, nrows)
     if (why == MetalDecodeDecline.none && !metal_decode_init()) {
         why = MetalDecodeDecline.device
@@ -3176,6 +3168,7 @@ def dasllama_metal_decode_register() {
     // shapes decline per call
     register_decode_override("metal", @@metal_decode_forward)
     register_batch_decode_override("metal", @@metal_batch_decode_forward)
+    register_reload_prep(@@discard_pre)   // a reload orphans the speculative pre-step — retire it before the regions drop
     register_mtp_spec_override("metal", @@metal_mtp_spec_eval)
     register_mtp_seam_override("metal", @@metal_mtp_seam_row)
     g_env_logits = g_env_metal.logits

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -2299,7 +2299,6 @@ def private metal_ple_pre_gpu_gate(t : Model; s : Session; npos, start_pos : int
 
 [hot_path]
 def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) : bool {   // nolint:STYLE037,STYLE038 — the prefill step driver; the layer stack's phases are hz-barrier coupled
-    weight_caches_flush_on_reload()
     var why = prefill_decline(t, s, npos, start_pos)
     if (why == MetalPrefillDecline.none && !metal_prefill_init()) {
         why = MetalPrefillDecline.device

--- a/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_tower.das
@@ -84,7 +84,6 @@ def metal_tower_shutdown {
 
 [cold_path]   // per-encode bring-up: the registry/prefill inits are latched-flag cheap
 def private metal_tower_init : bool {
-    weight_caches_flush_on_reload()   // an embedder load/delete recycles staged-blob addresses — the address-keyed regions must not survive it
     // the registry owns the tower PSOs (metal_decode_init compiles them, via the prefill seat)
     if (g_tw_failed || !metal_common_init() || !metal_prefill_pso_init() || g_pso_ln == null) {
         return false

--- a/modules/dasLLAMA/followup_general.md
+++ b/modules/dasLLAMA/followup_general.md
@@ -550,3 +550,17 @@
     quant (SmoothQuant-style per-channel folds baked at stage - needs a calibration set and
     its own gate design). Done = either path serving the Omni-3B encode with a
     poison-discriminating tier-1 gate.
+
+45. **The `tests/msl/_fail_closed/` fixture list and `test_msl_fail_closed.das`'s
+    `check_rejects` calls are hand-synced (37 files, 37 calls, nothing checks).** A fixture
+    added without its needle assert (or an assert whose fixture was deleted) drifts silently.
+    Done = a `modules/dasMetal/REVIEW.das` gate cell (the module has none yet - this creates
+    it): every `_fail_closed/*.das` basename appears as a `check_rejects` argument and vice
+    versa - the list-A-equals-list-B shape.
+
+46. **The `// clock: control` marker (dasllama REVIEW.md's ad-hoc-profiling split) has no
+    mechanical check.** Done = a `REVIEW.das` cell or lint: every `ref_time_ticks()` /
+    `get_time_usec()` occurrence under `dasllama/` whose line carries neither a print of the
+    elapsed interval nor the literal `// clock: control` is a finding; the four marked sites
+    (`dasllama_prefix.das` x2, `dasllama_image.das`, plus the harness ramp probe) are the
+    fixture.

--- a/modules/dasLLAMA/harness/residency_ramp_probe.das
+++ b/modules/dasLLAMA/harness/residency_ramp_probe.das
@@ -1,0 +1,66 @@
+options gen2
+options stack = 524288   // every dasLLAMA program root takes this budget (options stack does not unify up from libs)
+options _dasllama_internal = true
+
+// The post-CPU-window residency-ramp ladder (ARCHITECTURE.md 2.12): run the qwen3v Metal
+// tower encode after controlled CPU-only burns and read the submission split from
+// das_metal_boost's metal_submit_trace — the ramp lives ONLY in drv (kernelStart→kernelEnd).
+// A/B rail: DASLLAMA_METAL_HEARTBEAT_S=0 reproduces the ramp, the default heartbeat holds it.
+
+require math
+require daslib/jobque_boost
+require dasllama/dasllama_qwen3v
+require dasllama/dasllama_metal_tower   // registers the GPU tower hooks ([init]) — without it the load picks the CPU q8 lane
+require dasllama/dasllama_env
+require metal/das_metal_boost
+
+def private cpu_burn(ms : int) {
+    let t0 = ref_time_ticks()
+    var sink = 0.0
+    while (get_time_usec(t0) < ms * 1000) {
+        for (i in range(1000)) {
+            sink += sqrt(float(i))
+        }
+    }
+    to_log(LOG_INFO, "burn {ms} ms done (sink {sink})\n")
+}
+
+[export]
+def main() {
+    with_job_que() {
+        probe()
+    }
+}
+
+def private probe() {
+    var dir = g_env_harness.models_dir
+    if (empty(dir)) {
+        dir = "/Users/borisbatkin/Work/llama.cpp/models/"
+    }
+    let mm = "{dir}mmproj-Qwen3-Omni-30B-A3B-Instruct-bf16.gguf"
+    var tw <- load_qwen3v_tower(mm)
+    var st = Qwen3vState()
+    let w = 640l
+    let h = 480l
+    var planes : array<float>
+    planes |> reserve(w * h * 3l)
+    planes |> resize(w * h * 3l)
+    for (i in range64(w * h * 3l)) {
+        planes[i] = float(i % 251l) / 251.0
+    }
+    var out : array<float>
+    metal_submit_trace = true
+    to_log(LOG_INFO, "== warm x3 ==\n")
+    for (r in range(3)) {
+        let n = qwen3v_encode(tw, st, planes, w, h, out)
+        to_log(LOG_INFO, "encode {r}: {n} tokens\n")
+    }
+    for (burn_ms in [50, 200, 1000, 3000, 3000]) {
+        to_log(LOG_INFO, "== burn {burn_ms} ms ==\n")
+        cpu_burn(burn_ms)
+        qwen3v_encode(tw, st, planes, w, h, out)
+    }
+    delete out
+    delete planes
+    delete tw
+}

--- a/modules/dasLLAMA/harness/residency_ramp_probe.das
+++ b/modules/dasLLAMA/harness/residency_ramp_probe.das
@@ -2,20 +2,22 @@ options gen2
 options stack = 524288   // every dasLLAMA program root takes this budget (options stack does not unify up from libs)
 options _dasllama_internal = true
 
-// The post-CPU-window residency-ramp ladder (ARCHITECTURE.md 2.12): run the qwen3v Metal
-// tower encode after controlled CPU-only burns and read the submission split from
-// das_metal_boost's metal_submit_trace — the ramp lives ONLY in drv (kernelStart→kernelEnd).
+// ATTRIBUTION SWEEP - the post-CPU-window residency-ramp ladder (ARCHITECTURE.md 2.12): its
+// arms attribute the first-submission cost across the drv/queue/gpu split (das_metal_boost's
+// metal_submit_trace) and across CPU-window lengths; it selects between no implementations.
 // A/B rail: DASLLAMA_METAL_HEARTBEAT_S=0 reproduces the ramp, the default heartbeat holds it.
 
 require math
 require daslib/jobque_boost
-require dasllama/dasllama_qwen3v
+require dasllama/dasllama_vision
+require dasllama/dasllama_vision_embedder
 require dasllama/dasllama_metal_tower   // registers the GPU tower hooks ([init]) — without it the load picks the CPU q8 lane
 require dasllama/dasllama_env
 require metal/das_metal_boost
+require ../performance/profile_common.das   // tune_gate — the standing pre-measure stack
 
 def private cpu_burn(ms : int) {
-    let t0 = ref_time_ticks()
+    let t0 = ref_time_ticks()   // clock: control - bounds the burn window, never a reported figure
     var sink = 0.0
     while (get_time_usec(t0) < ms * 1000) {
         for (i in range(1000)) {
@@ -37,30 +39,31 @@ def private probe() {
     if (empty(dir)) {
         dir = "/Users/borisbatkin/Work/llama.cpp/models/"
     }
-    let mm = "{dir}mmproj-Qwen3-Omni-30B-A3B-Instruct-bf16.gguf"
-    var tw <- load_qwen3v_tower(mm)
-    var st = Qwen3vState()
-    let w = 640l
-    let h = 480l
-    var planes : array<float>
-    planes |> reserve(w * h * 3l)
-    planes |> resize(w * h * 3l)
-    for (i in range64(w * h * 3l)) {
-        planes[i] = float(i % 251l) / 251.0
+    var e <- load_vision_embedder("{dir}mmproj-Qwen3-Omni-30B-A3B-Instruct-bf16.gguf")
+    var st = VisionState()
+    var img = VisionImage(width = 640, height = 480)
+    img.rgb |> reserve(640l * 480l * 3l)
+    img.rgb |> resize(640l * 480l * 3l)
+    for (i in range64(long_length(img.rgb))) {
+        img.rgb[i] = uint8(i % 251l)
     }
     var out : array<float>
+    if (!tune_gate()) {   // never measure on fallback winners
+        panic("residency_ramp_probe: tune_gate refused - tune first (or point DAS_TUNE_MANIFEST at a complete sidecar)")
+    }
     metal_submit_trace = true
     to_log(LOG_INFO, "== warm x3 ==\n")
     for (r in range(3)) {
-        let n = qwen3v_encode(tw, st, planes, w, h, out)
+        let n = encode_image_(e, st, img, "ramp", out)
         to_log(LOG_INFO, "encode {r}: {n} tokens\n")
     }
     for (burn_ms in [50, 200, 1000, 3000, 3000]) {
         to_log(LOG_INFO, "== burn {burn_ms} ms ==\n")
         cpu_burn(burn_ms)
-        qwen3v_encode(tw, st, planes, w, h, out)
+        encode_image_(e, st, img, "ramp", out)
     }
     delete out
-    delete planes
-    delete tw
+    delete img
+    delete st
+    delete e
 }

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -346,8 +346,8 @@ images the rig cannot use and purges the flavors the rig depends on. Image-rail 
 
 ## Metal fixtures - driver knobs and the two-model pattern
 
-(REVIEW: "A cell pins every driver hook and serving-lane knob its claim depends on, and
-restores it before returning") The
+(REVIEW: "A cell establishes every driver hook and serving-lane knob its claim depends on,
+and restores it before returning") The
 hooks are on by default: they flip a q8 leg to the GPU silently, and an f32 leg records a
 quant_mode decline that panics under required mode - either way the cell stops measuring what
 its name says. The family serving-lane pins (`set_<family>_q8`) are the same trap in the

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -40,8 +40,9 @@ complete census, the `CLAUDE.md` map is deliberately partial.
 filter mechanics" section in the same change** - an arm the census does not name is
 unreachable to whoever is choosing what to run.
 
-**Weakening `test_program_roots.das` - dropping a root from its sweep, loosening its
-`options stack = 524288` assert, or relaxing its prefill-intent assert - is a defect.**
+**Weakening `test_program_roots.das` - dropping a directory from its `ROOT_DIRS` sweep,
+loosening its `options stack = 524288` assert, or relaxing its prefill-intent assert - is a
+defect.**
 
 **Weakening `test_env_registry.das` is a defect.** It enforces the knob contract that
 `../ENVIRONMENT.md` describes.
@@ -125,12 +126,17 @@ dump.**
 **A test that reads a vision encode oracle dump names the minting arm in its header - the
 backend, the flash-attention setting, and the mmproj precision the dump came from.**
 
-**A cell pins every driver hook and serving-lane knob its claim depends on, and restores it
-before returning** - the hooks have no read-back, so a cell that pins one OFF sets it back
-ON (the driver hooks `set_metal_tower`, `set_metal_wdec`, `set_metal_wdec_step`); a family
-serving-lane pin `set_<family>_q8` is undone with `reset_<family>_q8` - never a runtime
-decline standing in for a pin. The mechanism (why the hooks flip legs silently) is
+**A cell establishes every driver hook and serving-lane knob its claim depends on, and
+restores it before returning** - the hooks have no read-back, so a cell that pins one OFF
+sets it back ON (the driver hooks `set_metal_tower`, `set_metal_wdec`, `set_metal_wdec_step`);
+a family serving-lane pin `set_<family>_q8` is undone with `reset_<family>_q8` - never a
+runtime decline standing in for a pin. The mechanism (why the hooks flip legs silently) is
 `CLAUDE.md`'s "Metal fixtures" section.
+
+**A knob a cell can reach only through the environment is armed in the environment of a
+process started after the arming - a child the cell spawns, or the runner's own - and needs
+no restore; a cell that cannot arm it names in its assert text the value it asserts under.**
+An in-cell set is invisible to the running config, which is read once at context init.
 
 **A cell asserting the UNPINNED default lane compares against the predicates the lane policy
 itself consults - `float_batch_override_active()` and the family's `<family>_gpu_would_serve()`
@@ -154,9 +160,10 @@ shaped exact fixtures.
 **An embedding-parity cell names its fixture and logs the measured maxdiff on green as well
 as red.**
 
-**A new or loosened tolerance bar ships a control the bar reds - a poison, a knockout, or a
-cross-lane witness - in the same change.** A bar nothing has ever exceeded is not known to
-discriminate.
+**A new gate, or a new or loosened tolerance bar, ships a control that reds it - a poison, a
+knockout, a disconnected mechanism, or a cross-lane witness - in the same change.** A bar
+nothing has ever exceeded is not known to discriminate, and a gate that reads state the same
+code path wrote can be a tautology - only the control proves either can fail.
 
 **A family that gains a live thinking or tool format ships its recognition tests in the same
 change** - the wire-shape pins, the render pins, and a live server leg gated on the family's

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -457,6 +457,11 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                     if (api_probe != null) {
                         t |> success(residency_active(), "the residency set is live on an API-serving OS")
                         t |> success(residency_pinned() > 0l, "the served prefill pinned {residency_pinned()} buffers in the residency set")
+                        if (g_env_metal.heartbeat_s > 0) {
+                            t |> success(metal_residency_heartbeat_live(), "the residency heartbeat is armed after a served step")
+                        } else {
+                            t |> success(!metal_residency_heartbeat_live(), "DASLLAMA_METAL_HEARTBEAT_S=0 leaves the heartbeat unarmed")
+                        }
                     } else {
                         t |> skip("MTLResidencySet unavailable (macOS < 15) - the pin witness has no API to observe")
                     }

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -461,6 +461,7 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                             t |> success(metal_residency_heartbeat_live(), "the residency heartbeat is armed after a served step")
                         } else {
                             t |> success(!metal_residency_heartbeat_live(), "DASLLAMA_METAL_HEARTBEAT_S=0 leaves the heartbeat unarmed")
+                            t |> equal(metal_residency_heartbeat_sets(), 0l, "DASLLAMA_METAL_HEARTBEAT_S=0 registers nothing (the kick is skipped, not zero-length)")
                         }
                     } else {
                         t |> skip("MTLResidencySet unavailable (macOS < 15) - the pin witness has no API to observe")
@@ -468,6 +469,14 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                 } else {
                     t |> equal(residency_pinned(), 0l, "DASLLAMA_METAL_RESIDENCY=0 pins nothing")
                 }
+                // the weights-epoch push contract: a bump alone (what every load/map does) drops
+                // the address-keyed region caches — no driver entry participates, so a driver
+                // that never flushes cannot serve a recycled address's stale buffers
+                t |> success(weight_regions_cached() > 0l, "the served prefill cached {weight_regions_cached()} weight regions")
+                let preps0 = reload_preps_run()
+                bump_weights_epoch()
+                t |> equal(weight_regions_cached(), 0l, "a weights-epoch bump alone drops the address-keyed region caches")
+                t |> success(reload_preps_run() > preps0, "the drop ran the registered reload preps (decode's discard_pre reached through the registry)")
             }
 
             // s16 arm (W2): the DEFAULT-load scale plane — blobs read raw f16 scales, the

--- a/modules/dasMetal/REVIEW.md
+++ b/modules/dasMetal/REVIEW.md
@@ -1,21 +1,27 @@
 # dasMetal Code Review Checklist
 
-**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist. Shared
-emitter rules: `modules/REVIEW_SHADER_EMITTERS.md` - apply that list with this one.**
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.**
 Architecture doc: `MASTERPLAN.md`.
+
+**Every change under this folder applies `modules/REVIEW_SHADER_EMITTERS.md` too.**
 
 - **A new emitter capability - an emit site or a newly accepted construct, the default
   entry-point path included - ships a text fixture under `tests/msl/` (repo root) and its own
   census kind, in the same change.** Two forms sharing one kind lets either vanish unseen.
 
-- **A new rejection path ships a `tests/msl/_fail_closed/` (repo root) fixture and asserts
-  its needle in `tests/msl/test_msl_fail_closed.das`, in the same change.**
+- **A new construct the MSL emitter rejects at compile time ships a `tests/msl/_fail_closed/`
+  (repo root) fixture and asserts its needle in `tests/msl/test_msl_fail_closed.das`, in the
+  same change.**
 
-- **A behavioral change ships a CPU-oracle test under `tests/metal/` (repo root).** The oracle builds a
-  fresh kernel instance per simulated thread - kernel state is per-thread; sharing one
-  instance is a defect of the test, not of the kernel.
+- **A kernel behavioral change ships a CPU-oracle test under `tests/metal/` (repo root).** The
+  oracle builds a fresh kernel instance per simulated thread - kernel state is per-thread;
+  sharing one instance is a defect of the test, not of the kernel.
 
-- **Every emit site has a census kind: a new site's kind joins `declared_msl_census`, a
-  removed site's kind leaves it, everywhere it is named.** `test_msl_census.das` checks both
-  directions - every declared kind is emitted by some fixture, every emitted kind is
-  declared. Text has no disassembler; the census is the only coverage proxy.
+- **A new or changed host extern under `src/`, or a changed public function in
+  `metal/das_metal_boost.das`, ships a host-side test under `tests/metal/` (repo root) that
+  `feint`s when no Metal device is present, in the same change.** A dasMetal-only regression
+  must red here, not in a consumer module's suite.
+
+- **Weakening `test_msl_census.das`'s two-direction check - every declared kind emitted by
+  some fixture, every emitted kind declared - is a defect.** Text has no disassembler; the
+  census is the only coverage proxy.

--- a/modules/dasMetal/metal/das_metal_boost.das
+++ b/modules/dasMetal/metal/das_metal_boost.das
@@ -207,6 +207,21 @@ def public with_compute_encoder_timed(queue : MetalCommandQueue?; var error : st
     return with_compute_encoder_timed(queue, error, gpu_ms, encode_ms, blk)
 }
 
+//! The submission-split trace: when armed, every timed submission logs its command buffer's
+//! full timestamp split — drv (kernelStart→kernelEnd: the kernel-side driver window, where the
+//! tracked-set residency pass and page re-wiring live), queue (kernelEnd→GPUStart) and gpu
+//! (GPUStart→GPUEnd). The post-CPU-window residency ramp shows up ONLY in drv, so this is the
+//! instrument that tells set collection from execution cost. Off = one bool test per submission.
+var public metal_submit_trace = false
+
+[cold_path]   // the trace flag's opt-in leg
+def public submit_trace_log(cb : MetalCommandBuffer?; gpu_ms, encode_ms : double) {
+    let ks = metal_command_buffer_kernel_start_time(cb)
+    let ke = metal_command_buffer_kernel_end_time(cb)
+    let gs = metal_command_buffer_gpu_start_time(cb)
+    to_log(LOG_INFO, "metal submit: drv {(ke - ks) * 1000.0lf} ms, queue {(gs - ke) * 1000.0lf} ms, gpu {gpu_ms} ms, encode {encode_ms} ms\n")
+}
+
 //! The 4-out twin: also reports the host-side ENCODE time — the CPU cost of building the command
 //! buffer, measured from block entry through end_encoding (captured just before commit) — for the
 //! encode-CPU vs GPU-window split. The metal_commit hand-off itself falls in neither number.
@@ -221,6 +236,9 @@ def public with_compute_encoder_timed(queue : MetalCommandQueue?; var error : st
     metal_wait_until_completed(cb)
     error = metal_command_buffer_error(cb)
     gpu_ms = (metal_command_buffer_gpu_end_time(cb) - metal_command_buffer_gpu_start_time(cb)) * 1000.0lf
+    if (metal_submit_trace) {
+        submit_trace_log(cb, gpu_ms, encode_ms)
+    }
     metal_release(enc)
     metal_release(cb)
     return empty(error)

--- a/modules/dasMetal/src/dasMetal.h
+++ b/modules/dasMetal/src/dasMetal.h
@@ -78,6 +78,11 @@ namespace das {
     DAS_MOD_API void metal_residency_set_add_buffer ( MetalResidencySet * rset, MetalBuffer * buf, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void metal_residency_set_commit ( MetalResidencySet * rset, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void metal_residency_set_request ( MetalResidencySet * rset, Context * ctx, LineInfoArg * at );
+    // background keep-alive: re-requestResidency every few ms for keep_alive_s after the last
+    // call (a requested set still un-wires over a long CPU-only window; the heartbeat prevents
+    // the collect). Idempotent per set; call again to reset the countdown. Release unregisters.
+    DAS_MOD_API void metal_residency_set_heartbeat ( MetalResidencySet * rset, int32_t keep_alive_s, Context * ctx, LineInfoArg * at );
+    DAS_MOD_API bool metal_residency_heartbeat_live ();
 
     // each registers as a das-side `metal_release` overload; C++ names differ
     // because DAS_BIND_FUN cannot take an overload set

--- a/modules/dasMetal/src/dasMetal.h
+++ b/modules/dasMetal/src/dasMetal.h
@@ -83,6 +83,8 @@ namespace das {
     // the collect). Idempotent per set; call again to reset the countdown. Release unregisters.
     DAS_MOD_API void metal_residency_set_heartbeat ( MetalResidencySet * rset, int32_t keep_alive_s, Context * ctx, LineInfoArg * at );
     DAS_MOD_API bool metal_residency_heartbeat_live ();
+    DAS_MOD_API int64_t metal_residency_heartbeat_sets ();
+    DAS_MOD_API int64_t metal_residency_heartbeat_ticks ();
 
     // each registers as a das-side `metal_release` overload; C++ names differ
     // because DAS_BIND_FUN cannot take an overload set

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -483,6 +483,9 @@ namespace das {
 #if defined(DASMETAL_HAS_RESIDENCY_SETS)
         if ( @available(macOS 15.0, iOS 18.0, *) ) {
             auto & hb = g_rsetHeartbeat;
+            // arm the countdown BEFORE the thread can exist - a fresh thread reading 0 would
+            // take the idle sleep and delay the first keep-alive pass by idle_ms
+            hb.loops_left.store(int64_t(keep_alive_s) * 1000 / ResidencyHeartbeat::interval_ms, std::memory_order_relaxed);
             {
                 std::lock_guard<std::mutex> guard(hb.mx);
                 if ( std::find(hb.sets.begin(), hb.sets.end(), (void *) rset) == hb.sets.end() ) {
@@ -493,7 +496,6 @@ namespace das {
                     hb.thr = std::thread(residency_heartbeat_loop);
                 }
             }
-            hb.loops_left.store(int64_t(keep_alive_s) * 1000 / ResidencyHeartbeat::interval_ms, std::memory_order_relaxed);
         }
 #else
         (void) keep_alive_s;

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -15,6 +15,9 @@
 #include <vector>
 #include <unordered_map>
 #include <map>
+#include <thread>
+#include <chrono>
+#include <algorithm>
 
 #if !__has_feature(objc_arc)
 #error "dasMetal.mm must be compiled with ARC (-fobjc-arc)"
@@ -424,6 +427,76 @@ namespace das {
 #endif
     }
 
+    // ===== residency heartbeat =====
+    // A committed+requested set still un-wires after a long CPU-only window (the OS collects
+    // it); the next submission repays the kernel-side pass over the whole set. ggml-metal's
+    // cure, copied: a background thread re-calls requestResidency on every registered set every
+    // few ms, for keep_alive_s after the last kick. Registered handles are raw (the das side
+    // owns the retain); metal_release_residency_set unregisters under the same mutex before
+    // releasing, so the loop never touches a dead set.
+    struct ResidencyHeartbeat {
+        std::mutex mx;
+        std::vector<void *> sets;
+        std::atomic<bool> stop{false};
+        std::atomic<int64_t> loops_left{0};
+        std::thread thr;
+        bool started = false;
+        static const int interval_ms = 5;
+        ~ResidencyHeartbeat() {
+            stop.store(true, std::memory_order_relaxed);
+            if ( thr.joinable() ) thr.join();
+        }
+    };
+    static ResidencyHeartbeat g_rsetHeartbeat;
+
+    static void residency_heartbeat_loop () {
+#if defined(DASMETAL_HAS_RESIDENCY_SETS)
+        if ( @available(macOS 15.0, iOS 18.0, *) ) {
+            auto & hb = g_rsetHeartbeat;
+            while ( !hb.stop.load(std::memory_order_relaxed) ) {
+                if ( hb.loops_left.load(std::memory_order_relaxed) > 0 ) {
+                    {
+                        std::lock_guard<std::mutex> guard(hb.mx);
+                        for ( void * h : hb.sets ) {
+                            [(__bridge id<MTLResidencySet>) h requestResidency];
+                        }
+                    }
+                    hb.loops_left.fetch_sub(1, std::memory_order_relaxed);
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(ResidencyHeartbeat::interval_ms));
+            }
+        }
+#endif
+    }
+
+    void metal_residency_set_heartbeat ( MetalResidencySet * rset, int32_t keep_alive_s, Context * ctx, LineInfoArg * at ) {
+        if ( !rset ) ctx->throw_error_at(at, "metal_residency_set_heartbeat: null residency set");
+#if defined(DASMETAL_HAS_RESIDENCY_SETS)
+        if ( @available(macOS 15.0, iOS 18.0, *) ) {
+            auto & hb = g_rsetHeartbeat;
+            {
+                std::lock_guard<std::mutex> guard(hb.mx);
+                if ( std::find(hb.sets.begin(), hb.sets.end(), (void *) rset) == hb.sets.end() ) {
+                    hb.sets.push_back((void *) rset);
+                }
+                if ( !hb.started ) {
+                    hb.started = true;
+                    hb.thr = std::thread(residency_heartbeat_loop);
+                }
+            }
+            hb.loops_left.store(int64_t(keep_alive_s) * 1000 / ResidencyHeartbeat::interval_ms, std::memory_order_relaxed);
+        }
+#else
+        (void) keep_alive_s;
+#endif
+    }
+
+    // the heartbeat's test witness: thread running with keep-alive remaining
+    bool metal_residency_heartbeat_live () {
+        std::lock_guard<std::mutex> guard(g_rsetHeartbeat.mx);
+        return g_rsetHeartbeat.started && g_rsetHeartbeat.loops_left.load(std::memory_order_relaxed) > 0;
+    }
+
     void metal_set_pipeline ( MetalComputeEncoder * enc, MetalComputePipeline * pso, Context * ctx, LineInfoArg * at ) {
         if ( !enc ) ctx->throw_error_at(at, "metal_set_pipeline: null encoder");
         if ( !pso ) ctx->throw_error_at(at, "metal_set_pipeline: null pipeline");
@@ -566,7 +639,14 @@ namespace das {
     void metal_release_residency_set ( MetalResidencySet * h ) {
 #if defined(DASMETAL_HAS_RESIDENCY_SETS)
         if ( @available(macOS 15.0, iOS 18.0, *) ) {
-            if ( h ) [(__bridge id<MTLResidencySet>)(void *) h endResidency];
+            if ( h ) {
+                {
+                    std::lock_guard<std::mutex> guard(g_rsetHeartbeat.mx);
+                    auto & v = g_rsetHeartbeat.sets;
+                    v.erase(std::remove(v.begin(), v.end(), (void *) h), v.end());
+                }
+                [(__bridge id<MTLResidencySet>)(void *) h endResidency];
+            }
         }
 #endif
         release_handle(h);
@@ -748,6 +828,11 @@ namespace das {
             addExtern<DAS_BIND_FUN(metal_residency_set_request)>(*this, lib, "metal_residency_set_request",
                 SideEffects::modifyExternal, "metal_residency_set_request")
                     ->args({"residency_set", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_residency_set_heartbeat)>(*this, lib, "metal_residency_set_heartbeat",
+                SideEffects::modifyExternal, "metal_residency_set_heartbeat")
+                    ->args({"residency_set", "keep_alive_s", "context", "at"});
+            addExtern<DAS_BIND_FUN(metal_residency_heartbeat_live)>(*this, lib, "metal_residency_heartbeat_live",
+                SideEffects::accessExternal, "metal_residency_heartbeat_live");
 
             addExtern<DAS_BIND_FUN(metal_release_device)>(*this, lib, "metal_release",
                 SideEffects::modifyExternal, "metal_release_device")->args({"handle"});

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -442,7 +442,7 @@ namespace das {
         std::atomic<int64_t> ticks{0};
         std::thread thr;
         bool started = false;
-        static const int interval_ms = 5;
+        static constexpr int interval_ms = 5;   // constexpr: ODR-used via chrono at -O0, needs the implicit inline definition
         ~ResidencyHeartbeat() {
             stop.store(true, std::memory_order_relaxed);
             if ( thr.joinable() ) thr.join();

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -439,6 +439,7 @@ namespace das {
         std::vector<void *> sets;
         std::atomic<bool> stop{false};
         std::atomic<int64_t> loops_left{0};
+        std::atomic<int64_t> ticks{0};
         std::thread thr;
         bool started = false;
         static const int interval_ms = 5;
@@ -462,6 +463,7 @@ namespace das {
                         }
                     }
                     hb.loops_left.fetch_sub(1, std::memory_order_relaxed);
+                    hb.ticks.fetch_add(1, std::memory_order_relaxed);
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(ResidencyHeartbeat::interval_ms));
             }
@@ -495,6 +497,17 @@ namespace das {
     bool metal_residency_heartbeat_live () {
         std::lock_guard<std::mutex> guard(g_rsetHeartbeat.mx);
         return g_rsetHeartbeat.started && g_rsetHeartbeat.loops_left.load(std::memory_order_relaxed) > 0;
+    }
+
+    // the effect witnesses: sets currently registered (release unregisters; a knob-0 process
+    // never registers), and lifetime loop passes that requested residency (deltas compose)
+    int64_t metal_residency_heartbeat_sets () {
+        std::lock_guard<std::mutex> guard(g_rsetHeartbeat.mx);
+        return (int64_t) g_rsetHeartbeat.sets.size();
+    }
+
+    int64_t metal_residency_heartbeat_ticks () {
+        return g_rsetHeartbeat.ticks.load(std::memory_order_relaxed);
     }
 
     void metal_set_pipeline ( MetalComputeEncoder * enc, MetalComputePipeline * pso, Context * ctx, LineInfoArg * at ) {
@@ -833,6 +846,10 @@ namespace das {
                     ->args({"residency_set", "keep_alive_s", "context", "at"});
             addExtern<DAS_BIND_FUN(metal_residency_heartbeat_live)>(*this, lib, "metal_residency_heartbeat_live",
                 SideEffects::accessExternal, "metal_residency_heartbeat_live");
+            addExtern<DAS_BIND_FUN(metal_residency_heartbeat_sets)>(*this, lib, "metal_residency_heartbeat_sets",
+                SideEffects::accessExternal, "metal_residency_heartbeat_sets");
+            addExtern<DAS_BIND_FUN(metal_residency_heartbeat_ticks)>(*this, lib, "metal_residency_heartbeat_ticks",
+                SideEffects::accessExternal, "metal_residency_heartbeat_ticks");
 
             addExtern<DAS_BIND_FUN(metal_release_device)>(*this, lib, "metal_release",
                 SideEffects::modifyExternal, "metal_release_device")->args({"handle"});

--- a/modules/dasMetal/src/dasMetal.mm
+++ b/modules/dasMetal/src/dasMetal.mm
@@ -443,6 +443,7 @@ namespace das {
         std::thread thr;
         bool started = false;
         static constexpr int interval_ms = 5;   // constexpr: ODR-used via chrono at -O0, needs the implicit inline definition
+        static constexpr int idle_ms = 100;     // the no-window poll - cheap wakeups once the keep-alive expires
         ~ResidencyHeartbeat() {
             stop.store(true, std::memory_order_relaxed);
             if ( thr.joinable() ) thr.join();
@@ -455,7 +456,8 @@ namespace das {
         if ( @available(macOS 15.0, iOS 18.0, *) ) {
             auto & hb = g_rsetHeartbeat;
             while ( !hb.stop.load(std::memory_order_relaxed) ) {
-                if ( hb.loops_left.load(std::memory_order_relaxed) > 0 ) {
+                bool armed = hb.loops_left.load(std::memory_order_relaxed) > 0;
+                if ( armed ) {
                     {
                         std::lock_guard<std::mutex> guard(hb.mx);
                         for ( void * h : hb.sets ) {
@@ -465,7 +467,11 @@ namespace das {
                     hb.loops_left.fetch_sub(1, std::memory_order_relaxed);
                     hb.ticks.fetch_add(1, std::memory_order_relaxed);
                 }
-                std::this_thread::sleep_for(std::chrono::milliseconds(ResidencyHeartbeat::interval_ms));
+                // idle (keep-alive expired) drops to a slow poll - a kick during the long sleep
+                // delays the first re-request by at most idle_ms, and the set was just requested
+                // by the serving step itself, so nothing can collect in that window
+                std::this_thread::sleep_for(std::chrono::milliseconds(
+                    armed ? ResidencyHeartbeat::interval_ms : ResidencyHeartbeat::idle_ms));
             }
         }
 #endif
@@ -473,6 +479,7 @@ namespace das {
 
     void metal_residency_set_heartbeat ( MetalResidencySet * rset, int32_t keep_alive_s, Context * ctx, LineInfoArg * at ) {
         if ( !rset ) ctx->throw_error_at(at, "metal_residency_set_heartbeat: null residency set");
+        if ( keep_alive_s <= 0 ) return;    // non-positive = no-op: nothing registers, no thread starts (the knob-0 contract)
 #if defined(DASMETAL_HAS_RESIDENCY_SETS)
         if ( @available(macOS 15.0, iOS 18.0, *) ) {
             auto & hb = g_rsetHeartbeat;

--- a/tests/metal/test_metal_plumbing.das
+++ b/tests/metal/test_metal_plumbing.das
@@ -95,3 +95,53 @@ def test_host_plumbing(t : T?) {
         }
     }
 }
+
+[test]
+def test_residency_heartbeat(t : T?) {
+    t |> run("residency heartbeat: arm, witness, unregister-on-release; submit trace branch") <| @(t : T?) {
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            with_metal_device() $(dev : MetalDevice?) {
+                if (dev == null) {
+                    feint("no Metal device on this box; heartbeat checks skipped\n")
+                    return
+                }
+                var rset = metal_new_residency_set(dev)
+                if (rset == null) {
+                    feint("MTLResidencySet unavailable (macOS < 15); heartbeat checks skipped\n")
+                    return
+                }
+                metal_residency_set_commit(rset)
+                metal_residency_set_request(rset)
+                let sets0 = metal_residency_heartbeat_sets()
+                let ticks0 = metal_residency_heartbeat_ticks()
+                metal_residency_set_heartbeat(rset, 60)
+                t |> success(metal_residency_heartbeat_live(), "the heartbeat is armed after a kick")
+                t |> equal(metal_residency_heartbeat_sets(), sets0 + 1l, "the kick registered the set")
+                metal_residency_set_heartbeat(rset, 60)
+                t |> equal(metal_residency_heartbeat_sets(), sets0 + 1l, "a second kick does not register a duplicate")
+                let ts = ref_time_ticks()
+                while (get_time_usec(ts) < 30000) {}   // clock: control - bounds the tick window, never a reported figure
+                t |> success(metal_residency_heartbeat_ticks() > ticks0, "the loop requested residency ({metal_residency_heartbeat_ticks() - ticks0} passes in the window)")
+                metal_release(rset)
+                t |> equal(metal_residency_heartbeat_sets(), sets0, "release unregistered the set from the heartbeat collection")
+                // the loop keeps ticking on what remains — surviving 5 ms ticks past the
+                // release is the no-use-after-free witness
+                let ts2 = ref_time_ticks()
+                while (get_time_usec(ts2) < 30000) {}   // clock: control
+                t |> success(metal_residency_heartbeat_live(), "the loop survives ticks past the release (countdown intact)")
+                // the submit-split trace branch: one traced empty submit through the chokepoint
+                var queue = metal_new_command_queue(dev)
+                var terr : string
+                var tms = 0.0lf
+                metal_submit_trace = true
+                let tran = with_compute_encoder_timed(queue, terr, tms) $(enc : MetalComputeEncoder?) {}
+                metal_submit_trace = false
+                t |> success(tran, "a traced submit completes: {terr}")
+                metal_release(queue)
+            }
+            t |> equal(metal_live_object_count(), 0l)
+        } else {
+            feint("das_metal is not built on this platform; nothing to check\n")
+        }
+    }
+}


### PR DESCRIPTION
**Behavior change: a process serving on Metal with the residency pin now runs a small background thread. It re-requests residency every 5 ms for up to DASLLAMA_METAL_HEARTBEAT_S seconds (default 180) after the last served step. Set the knob to 0 to disable.**

Two fixes for state that decays between calls.

First, the post-CPU-window ramp. After a long CPU-only window, the first Metal submission repaid a large driver-side cost. The mechanism is now named: the OS collects a committed MTLResidencySet during inactivity. The fix copies ggml-metal's keep-alive: a dasMetal background thread re-requests residency on a 5 ms cadence, kicked from residency_flush per served step. Measured on the qwen3v Metal tower encode (`harness/residency_ramp_probe.das`, DASLLAMA_METAL_HEARTBEAT_S=0 vs default, M1 Max): drv 17.7 to 3.0 ms at a 3000 ms CPU window. A whole-map anchor buffer and the earlier per-buffer tracking-audit idea were both refuted by the same ladder. The probe and the das_metal_boost submit-split trace stay in the tree as instruments.

Second, the weights-epoch flush is now pushed, not polled. Weight caches key on host addresses, and a reload can land a new model at a dead model's address. The old contract made every Metal driver entry call the flush; the asr_dec driver never did, so a reload could serve stale weights there. Now bump_weights_epoch invokes registered listeners: metal_common drops the region caches (reload preps run first - the decode driver retires its speculative pre-step), and the four driver-entry calls are deleted. No driver participates anymore, so the forgotten-call hole is closed by construction.

Where to look: the ResidencyHeartbeat thread lifecycle in modules/dasMetal/src/dasMetal.mm (release unregisters the set under the heartbeat mutex before endResidency); metal_weights_drop ordering in dasllama_metal_common.das (preps, then quiesce, then release); the deleted stale condition in metal_mtp_draft_forward.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- parity.das GPU-vs-CPU GEN_IDS token-exact MATCH on the counting prompt, q8 (Llama-3.2-1B Q8_0) and native kq (Qwen3-4B Q4_K_M, `--kq 1`), `--ngl 99` vs `--ngl 0`, `--kv f16`, M1 Max. An earlier run on an arbitrary-ids prompt flipped one near-tie at token 21 - the documented high-entropy trap, not a defect; the counting-prompt runs are the evidence.
- Family tower gates after the metal_tower_init edit, all green: test_gemma4uv 4/4, test_gemma4v 12/12, test_gemma3v 6/6, test_qwen3v 12/12 (includes the Metal tower cell), plus the image suite metal+mtower arms (36 passed).
- Runner suites at the change, -jit via run.das: decode arm1+arm9 (arm9 is the reload arm), prefill base, model-free - all green on the M1 Max.
- Negative controls: the epoch cell reds with the listener disconnected (34 regions survive the bump); the reload-prep witness stays flat if the register_reload_prep line is dropped.
- dasMetal host-side coverage: new tests/metal/test_metal_plumbing.das cell over the effect witnesses (metal_residency_heartbeat_sets/ticks) - the kick registers the set, a second kick does not duplicate, the loop actually requests residency in the window, release unregisters, the loop survives ticks past the release, and a traced submit completes.
- The reload-prep registration is witnessed: the epoch cell asserts reload_preps_run rose across the bump, so a dropped register_reload_prep line reds.
- Full preflight intentionally skipped per the localized-scope rule: the diff is confined to dasMetal + dasLLAMA (no core src/, no daslib); the targeted gates above cover every touched path; CI runs the matrix on push.
- Woodpecker (codex) round at 0294821f2: no findings. The later delta is the probe's carrier-API rewrite and audit-driven test/doc additions.

### Claims - stated, not tested
- The 17.7 to 3.0 ms figure is probe-measured (an attribution sweep), not a suite gate. The drv column is kernel-winner-independent, so the box's tune-manifest staleness does not touch it.
- DASLLAMA_METAL_HEARTBEAT_S=0 (the A/B rail) is exercised by the probe; the suite asserts the default arm every run and the zero arm only on an explicit A/B run - env knobs load once per process, so an in-suite flip is not possible.
- bump_weights_epoch never races a serve: bumps happen only at load/map boundaries on the control thread (the server loads all models at startup, before serving). A concurrent load+serve is already out of contract CPU-side (use-after-free on the weight arrays themselves).

### Not done
- The 1-3 ms window-scaled residual (insensitive to residency cadence and to page pinning; the driver/GPU idle-wake class) stays an open PERF_LEDGER note - no user-space lever found.
- Bench records not re-minted: warm bench loops never see the ramp; the win is the first submission after an idle window.
- The reload-prep ORDERING (discard_pre before quiesce and release) is documented but has no distinguishing test - arming a real speculative pre-step across a reload needs the MTP fixture machinery; the prep INVOCATION is witnessed. Likewise the MTP draft after a reload (the deleted stale decline) has no cell that drafts across a load; the mirror key check covers the session-mismatch case.
- The audit round's checklist questions were all ruled and applied in-branch (REVIEW doc edits); two new-check commissions are ledgered as followups 45 and 46 in modules/dasLLAMA/followup_general.md. One dragon pass over the final ruled edit batch is owed - the API was overloaded at push time; it lands in the review loop as .md-only amends if it finds anything.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
