### PR TITLE
playground: keep threaded game music out of interpreter

### DIFF
--- a/web/examples/ui/samples/examples/arcanoid/main.das
+++ b/web/examples/ui/samples/examples/arcanoid/main.das
@@ -20,9 +20,9 @@ require strudel/strudel_player
 require daslib/strings_boost
 require live_stub   // playground shim: replaces the live/* + live_host stack (window, clock, no-op [live_command])
 
-// Music uses the THREADED strudel player (strudel_init/strudel_play). The runtime
-// gate in init() turns it on only where the audio backend is threaded — wasm64 and
-// native; a single-threaded backend keeps music off and SFX (play_sound_from_pcm) on.
+// Music uses the THREADED strudel player (strudel_init/strudel_play). The playground
+// interpreter shares the renderer's runtime and cannot host that worker safely; only
+// standalone builds may enable it, and only with a threaded audio backend. SFX stay on.
 var music_enabled = false
 
 // --- Constants ---
@@ -1319,7 +1319,7 @@ def init() {
         audio_initialized = true
         init_audio_samples()
     }
-    music_enabled = !audio_is_single_threaded()
+    music_enabled = is_standalone_exe() && !audio_is_single_threaded()
     if (music_enabled && !music_initialized) {
         strudel_init(@@strudel_music_main)
         strudel_set_volume(0.4, 0.0)

--- a/web/examples/ui/samples/examples/boulder-dash/main.das
+++ b/web/examples/ui/samples/examples/boulder-dash/main.das
@@ -21,9 +21,9 @@ require cave
 require cave_gen
 require sfx_gen
 
-// Music uses the THREADED strudel player (strudel_init/strudel_play). The runtime
-// gate in init() turns it on only where the audio backend is threaded — wasm64 and
-// native; a single-threaded backend keeps music off and SFX (play_sound_from_pcm) on.
+// Music uses the THREADED strudel player (strudel_init/strudel_play). The playground
+// interpreter shares the renderer's runtime and cannot host that worker safely; only
+// standalone builds may enable it, and only with a threaded audio backend. SFX stay on.
 var music_enabled = false
 
 let CELL_SIZE = 1.0
@@ -833,7 +833,7 @@ def init() {
         audio_initialized = true
         init_audio_samples()
     }
-    music_enabled = !audio_is_single_threaded()
+    music_enabled = is_standalone_exe() && !audio_is_single_threaded()
     if (music_enabled && !music_initialized) {
         strudel_init(@@strudel_music_main)
         strudel_set_volume(0.4, 0.0)

--- a/web/examples/ui/samples/examples/pacman/main.das
+++ b/web/examples/ui/samples/examples/pacman/main.das
@@ -19,9 +19,9 @@ require strudel/strudel_player
 require daslib/strings_boost
 require live_stub   // playground shim: replaces the live/* + live_host stack (window, clock, no-op [live_command])
 
-// Music uses the THREADED strudel player (strudel_init/strudel_play). The runtime
-// gate in init() turns it on only where the audio backend is threaded — wasm64 and
-// native; a single-threaded backend keeps music off and SFX (play_sound_from_pcm) on.
+// Music uses the THREADED strudel player (strudel_init/strudel_play). The playground
+// interpreter shares the renderer's runtime and cannot host that worker safely; only
+// standalone builds may enable it, and only with a threaded audio backend. SFX stay on.
 var music_enabled = false
 
 // ===== Constants =====
@@ -1089,7 +1089,7 @@ def init() {
         audio_initialized = true
         init_audio_samples()
     }
-    music_enabled = !audio_is_single_threaded()
+    music_enabled = is_standalone_exe() && !audio_is_single_threaded()
     if (music_enabled && !music_initialized) {
         strudel_init(@@strudel_music_main)
         strudel_set_volume(0.4, 0.0)


### PR DESCRIPTION
## Summary

- keep the threaded Strudel player out of the playground interpreter for Arcanoid, Pac-Man, and Boulder Dash
- require both a standalone build and a threaded audio backend before starting game music
- preserve SFX in interpreter mode and threaded music in standalone WASM builds

The Aug 24 nightly wedged all three game samples in interpreter mode after their web sources switched from compile-time music-off to the audio-backend-only runtime gate. The playground interpreter uses a threaded Emscripten host, so `audio_is_single_threaded()` alone returns false even though starting the sample's threaded Strudel worker from that interpreted context wedges the renderer.

Failing run: https://github.com/GaijinEntertainment/daScript/actions/runs/32691156339

## Validation

- curated compile verifier, filtered to `Game:`: 3 passed, 0 failed
- staged nightly browser runner, interpreter `Game:` filter: 3 passed, 0 failed
- dasweb browser protocol tests: 20 passed, 0 failed
- live production WASM build service, exact patched sources: all three generated artifacts booted with audio, advanced frames/draws, and reported no build, GL, or browser errors
  - Arcanoid: https://run.daslang.io/api/build/artifact/5178dc4c257ba9c9e4dba3a8dfe468c84f2c053d/5b0cb8772a9099d82fbc784932ce66f1a48790e99de3b30050dae41da14fc9e2/sample.html
  - Pac-Man: https://run.daslang.io/api/build/artifact/5178dc4c257ba9c9e4dba3a8dfe468c84f2c053d/a2bf70c6db11bc97d50890000d4d9dacc5c09bdb68a7574e5b41c4c9e77a765c/sample.html
  - Boulder Dash: https://run.daslang.io/api/build/artifact/5178dc4c257ba9c9e4dba3a8dfe468c84f2c053d/24f1f57db6231b2ad9d9e571ea804b60ced9c25d5d753a93e8c26a2fde014083/sample.html
- WASM-staged site Playwright using the current production `daslang_static.js`/`.wasm`: 50 non-WASM tests passed; 8 of 12 runtime tests passed. The four remaining timeouts are the three `runtime-revive` cases and the `shared-module` session case; none loads the changed game samples.
- `git diff --check`: clean