### PR TITLE
standalone aot: the constructor actually runs init

### DIFF
--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -227,6 +227,30 @@ an entry lands here only when no name, shape, or test can carry it.
   need `sizeof` even untouched, and by-value field types emit depth-first before their
   owner, or the type degrades to a forward declaration.
 
+## aot_standalone
+
+- **The generated constructor IS the init protocol** - a standalone context never calls
+  `Context::runInitScript`, so the ctor reproduces its observable semantics inline:
+  `memset(context.globals, 0, context.getGlobalSize())` mirrors runInitScript's globals
+  memset (`src/runtime/context.cpp`), then the same-TU `__init_script(&context, true)`
+  (signature written by `aot_cpp.das`'s `preVisitGlobalLet` - a daslib-to-daslib pairing,
+  nothing checks agreement), then each `[init]` function directly. Deliberate divergences:
+  `__init_shared` is hardcoded `true` (a fresh standalone context always owns its
+  shared globals), there is no `globalInitStackSize` stack push (init locals are C++
+  locals in AOT), and there is no `!stopFlags` guard between `[init]` calls (a panic
+  propagates out of the ctor instead of soft-stopping the sequence).
+- **Global init order is a pact with the allocator**: `StandaloneContextGen`'s
+  `preVisitGlobalLet` emits required modules' globals via ordered `for_each_module`
+  before the adapter walks the entry module's own - correct only because
+  `ast_allocate_stack.cpp` assigns `var->index` through the same dependency-first
+  module order with the entry module last, and `runInitScript` executes ascending
+  index. `[init]` function order is not re-derived at all: the emitter reads the
+  simulated context's list through rtti `for_each_init_function`, so the C++ late-init
+  sort stays the single source of truth.
+- **Cross-module limits fail loud at emit time**: only main-module, AOT-emitted `[init]`
+  functions can be called from the ctor (required-module and `[no_aot]` ones panic with
+  the reason), because the standalone TU only emits the entry module's function bodies.
+
 ## flatten
 
 - **Predicated lowering carries one live-mask per exit flavor** - `__flat_live` for

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -4140,13 +4140,6 @@ def registerAotCpp(var logs : StringBuilderWriter?; program : ProgramPtr; var co
         delete visitor
     }
 
-    var funInit = false;
-    for (fn in fnn) {
-        if (fn.flags.init) {
-            funInit = true;
-        }
-    }
-
     if (!fnn.empty()) {
         write(*logs, "\n#ifdef _MSC_VER\n#pragma optimize(\"\", off)\n#endif\n");
         write(*logs, "struct AotFunction \{ uint64_t hash; bool is_cmres; void * fn; vec4f (*wrappedFn)(Context*); \};\n");
@@ -4246,9 +4239,10 @@ def public compile_and_simulate(input : string, var access; var mg : ModuleGroup
 }
 
 
-def public fail_on_aot_emit_error(program : ProgramPtr) {
+def public log_aot_emit_errors(program : ProgramPtr) : bool {
+    //! Logs collected emit errors; returns true when the program has any.
     if (!program.flags.macroException && !program.flags.failToCompile) {
-        return
+        return false
     }
     for (err in program.errors) {
         var msg = "{describe(err.at)}: error[{int(err.cerr)}]: {err.what}"
@@ -4260,7 +4254,13 @@ def public fail_on_aot_emit_error(program : ProgramPtr) {
         }
         to_log(LOG_ERROR, "{msg}\n")
     }
-    panic("AOT codegen failed: {length(program.errors)} codegen error(s) during emission (see log)")
+    return true
+}
+
+def public fail_on_aot_emit_error(program : ProgramPtr) {
+    if (log_aot_emit_errors(program)) {
+        panic("AOT codegen failed: {length(program.errors)} codegen error(s) during emission (see log)")
+    }
 }
 
 [export]

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -74,7 +74,45 @@ def writeStandaloneContextMethods(var prog : ProgramPtr; var logs : StringBuilde
     }
 }
 
-def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var tw : StringBuilderWriter, program : ProgramPtr) {   // nolint:STYLE038 - flat emitter - one write per ctor section
+def collectInitFunctionAotNames(program : ProgramPtr; var context : Context) : array<string> {
+    //! In the simulated context's run order (late init last).
+    var initMnhOrder : array<uint64>
+    context |> for_each_init_function($(mnh : uint64) {
+        initMnhOrder |> push(mnh)
+    });
+    var initMnhSet : table<uint64>
+    for (mnh in initMnhOrder) {
+        initMnhSet |> insert(mnh)
+    }
+    var mnhToAotName : table<uint64; string>
+    let thisModule = program.getThisModule
+    program.get_ptr() |> for_each_module_no_order($(pm) {
+        pm |> for_each_module_function($(pfun) {
+            if (pfun.index < 0 || !pfun.flags.used || !(initMnhSet |> key_exists(pfun.getMangledNameHash))) {
+                return
+            }
+            if (pm != thisModule) {
+                macro_error(program, pfun.at, "standalone AOT cannot run [init] function: {pm.name}::{pfun.name} lives outside the main module")
+            } elif (pfun.flags.noAot) {
+                macro_error(program, pfun.at, "standalone AOT cannot run [init] function: {pfun.name} is [no_aot]")
+            } else {
+                mnhToAotName[pfun.getMangledNameHash] = aotFuncName(pfun)
+            }
+        });
+    });
+    var initNames : array<string>
+    for (mnh in initMnhOrder) {
+        let name = mnhToAotName?[mnh] ?? ""
+        if (!empty(name)) {
+            initNames |> push(name)
+        } elif (!program.flags.failToCompile) {
+            macro_error(program, LineInfo(), "standalone AOT cannot run [init] function: mangled name hash {mnh} is not in the emitted program")
+        }
+    }
+    return <- initNames
+}
+
+def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var tw : StringBuilderWriter, program : ProgramPtr; var context : Context) {   // nolint:STYLE038 - flat emitter - one write per ctor section
     var lookupVariableTable : array<Variable?>;
     if (program.totalVariables > 0) {
         program.get_ptr() |> for_each_module_no_order($(pm) {
@@ -106,6 +144,7 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
     }
     write(tw, "     // end totalVariables\n\n");
     write(tw, "    context.allocateGlobalsAndShared();\n");
+    write(tw, "    if ( context.globals ) memset(context.globals, 0, context.getGlobalSize());\n");
     write(tw, "    context.totalVariables = {program.totalVariables}/*totalVariables*/;\n");
     write(tw, "    context.functions = (SimFunction *) context.code->allocate( {program.totalFunctions}/*totalFunctions*/*sizeof(SimFunction) );\n");
     write(tw, "    context.totalFunctions = {program.totalFunctions}/*totalFunctions*/;\n");
@@ -148,23 +187,17 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
         });
     });
 
-    if (program.initSemanticHashWithDep != uint64(0)) {
-        write(tw, "    \{\n");
-        write(tw, "        auto it = getGlobalAotLibrary().find(0x{program.initSemanticHashWithDep:x}/*initSemanticHashWithDep*/);\n");
-        write(tw, "        if ( it != getGlobalAotLibrary().end() ) \{\n");
-        write(tw, "            (it->second)(context);\n");
-        write(tw, "        \}\n");
-        write(tw, "    \}\n");
-    }
-
     if (!empty(initFunctions)) {
-        write(tw, " FillFunction(context, getGlobalAotLibrary(), id_to_funcs);\n");
-        write(tw, "    context.runInitScript();\n");
+        write(tw, "    FillFunction(context, getGlobalAotLibrary(), id_to_funcs);\n");
+    }
+    write(tw, "    __init_script(&context, true);\n");
+    for (initFn in collectInitFunctionAotNames(program, context)) {
+        write(tw, "    {initFn}(&context);\n");
     }
     write(tw, "\}\n");
 }
 
-def writeStandaloneContext(var program : ProgramPtr, initFunctions : string, var header : StringBuilderWriter, var source : StringBuilderWriter; cfg : StandaloneContextCfg) {
+def writeStandaloneContext(var program : ProgramPtr, initFunctions : string, var header : StringBuilderWriter, var source : StringBuilderWriter; cfg : StandaloneContextCfg; var context : Context) {
 
     write(header, "\n\n");
     write(header, "class {cfg.class_name} : public Context \{\n");
@@ -174,7 +207,7 @@ def writeStandaloneContext(var program : ProgramPtr, initFunctions : string, var
     write(header, "\};\n");
 
     writeStandaloneContextMethods(program, source, "{cfg.class_name}::", false, cfg);
-    writeStandaloneCtor(cfg, initFunctions, source, program);
+    writeStandaloneCtor(cfg, initFunctions, source, program, context);
 
     write(source, "#ifdef STANDALONE_CONTEXT_TESTS\n");
     write(source, "static Context * registerStandaloneTest ( ) \{\n");
@@ -200,29 +233,26 @@ class StandaloneContextGen : CppAot {
 
     used_functions : table<string>;
 
-    def override visitGlobalLet(prog : ProgramPtr) {
+    def override preVisitGlobalLet(prog : ProgramPtr) {
+        CppAot`preVisitGlobalLet(self, prog);
         var globals : array<Variable?>;
-        prog.get_ptr() |> for_each_module_no_order($(pm) {
+        prog.get_ptr() |> for_each_module($(pm) {
             pm |> for_each_global($(pvar) {
                 if (pvar.index < 0 || !pvar.flags.used
                         || pvar._module == prog.getThisModule) return ;
                 globals.push(pvar);
             });
         });
-
         for (variable in globals) {
             preVisitGlobalLetVariable(variable, false);
             if (variable.init != null) {
                 preVisitGlobalLetVariableInit(variable, variable.init);
                 visit_expression(variable.init, adapter);
-                variable.init := visitGlobalLetVariableInit(variable, variable.init);
             }
             let varn <- visitGlobalLetVariable(variable, false);
         }
-
-        tab --;
-        write(*ss, "\}\n");
     }
+
     def override preVisitProgramBody(var prog : ProgramPtr, that : Module?) {
         declarations = ss |> string_builder_str();
         ss |> string_builder_clear();
@@ -254,7 +284,7 @@ def writeRegistration(var header : StringBuilderWriter;
     write(header, "namespace {cfg.context_name} \{\n");
     write(source, "namespace {cfg.context_name} \{\n");
     dumpRegisterAot(unsafe(addr(source)), program, context, false, cfg.cross_platform);
-    writeStandaloneContext(program, initFunctions, header, source, cfg);
+    writeStandaloneContext(program, initFunctions, header, source, cfg, context);
     write(header, "\} // namespace {cfg.context_name}\n");
     write(source, "\} // namespace {cfg.context_name}\n");
 }
@@ -323,16 +353,15 @@ def genStandaloneSrc(var program : ProgramPtr;
             }
         }
     }
-    fail_on_aot_emit_error(program)
-
     write(source, "namespace {program.thisNamespace} \{\n");
     write(source, "{ctx_generated}");
     write(source, "\} // namespace {program.thisNamespace}\n");
     return initFunctions
 }
 
-def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string>, var pctx : smart_ptr<Context>; cfg : StandaloneContextCfg) {
+def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string>, var pctx : smart_ptr<Context>; cfg : StandaloneContextCfg) : bool {
     //! Runs the standalone AOT visitor on the program to generate C++ source and header files.
+    //! Returns false (writing nothing) when emission collected errors.
     assume context = *pctx;
 
     var pmarker = new PrologueMarker();
@@ -387,6 +416,10 @@ def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string
     }
     }
 
+    if (log_aot_emit_errors(program)) {
+        return false
+    }
+
     let cur_mod = mod.name.empty() ? cfg.context_name : string(mod.name);
     let outputFile = "{cfg.cpp_output_dir}/{cur_mod}.das";
         fopen("{outputFile}.h", "wb") $(fw) {
@@ -403,17 +436,27 @@ def public runStandaloneVisitor(var program : ProgramPtr, modules : array<string
             print("Couldn't create output file {outputFile}.cpp")
         }
     }
+    return true
+}
+
+[export]
+def public standalone_aot(input : string; output_dir : string; cross_platform : bool, paranoid_validation : bool; cop : CodeOfPolicies) {
+    //! Compiles a daslang file and generates standalone AOT C++ code in the given output directory.
+    return standalone_aot(input, output_dir, cross_platform, paranoid_validation, cop) $(var _program : ProgramPtr) {}
 }
 
 [export, unused_argument(paranoid_validation)]
-def public standalone_aot(input : string; output_dir : string; cross_platform : bool, paranoid_validation : bool; cop : CodeOfPolicies) {
+def public standalone_aot(input : string; output_dir : string; cross_platform : bool, paranoid_validation : bool; cop : CodeOfPolicies; before_emit : block<(var program : ProgramPtr) : void>) {
     //! Compiles a daslang file and generates standalone AOT C++ code in the given output directory.
+    //! `before_emit` receives the compiled program, so a driver can read annotations
+    //! without compiling the program a second time.
     let file_name = input |> split_by_chars("/\\") |> back()
     let ctx_name = (file_name |> split("."))[0]
     let cfg = StandaloneContextCfg(context_name = ctx_name,
                                    class_name = "Standalone",
                                    cpp_output_dir = output_dir,
                                    cross_platform = cross_platform)
+    var ok = false
     using() $(var mg : ModuleGroup) {
         var inscope access <- make_file_access("")
         compile_and_simulate(input, access, unsafe(addr(mg)), cop) $(var program : ProgramPtr; var pctx : smart_ptr<Context>) {
@@ -423,9 +466,10 @@ def public standalone_aot(input : string; output_dir : string; cross_platform : 
             } elif (noAotModule) {
                 panic("Standalone context called on non aot module {input}")
             } else {
-                runStandaloneVisitor(program, modules_str, pctx, cfg)
+                before_emit |> invoke(program)
+                ok = runStandaloneVisitor(program, modules_str, pctx, cfg)
             }
         }
     }
-    return true
+    return ok
 }

--- a/doc/reflections/das2rst.das
+++ b/doc/reflections/das2rst.das
@@ -426,7 +426,7 @@ def document_module_rtti(_root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Initialization and finalization", mod, %regex~(using|LineInfo|CodeOfPolicies|RttiValue_nothing)$%%),
         group_by_regex("Type access", mod, %regex~(get_dim|builtin_is_same_type|is_compatible_cast|get_das_type_name|is_same_type|each_dim|arg_types|arg_names|get_type_size|get_type_align)$%%),
-        group_by_regex("Rtti context access", mod, %regex~(get_total_functions|get_total_variables|get_function_info|get_variable_info|get_variable_value|get_function_by_mnh|get_line_info|this_context|context_for_each_function|context_for_each_variable|class_info|type_info)$%%),
+        group_by_regex("Rtti context access", mod, %regex~(get_total_functions|get_total_variables|get_function_info|get_variable_info|get_variable_value|get_function_by_mnh|get_line_info|this_context|context_for_each_function|context_for_each_variable|for_each_init_function|class_info|type_info)$%%),
         group_by_regex("Program access", mod, %regex~(program_for_each_module|program_for_each_registered_module|get_this_module|get_module|has_module)$%%),
         group_by_regex("Module access", mod, %regex~(module_for_each_structure|module_for_each_enumeration|module_for_each_function|module_for_each_generic|module_for_each_global|module_for_each_annotation|module_for_each_dependency)$%%),
         group_by_regex("Annotation access", mod, %regex~(get_annotation_argument_value|add_annotation_argument|get_annotation|get_annotation_argument|resolve_annotation|each_annotation|each_annotation_argument)$%%),

--- a/doc/source/stdlib/handmade/function-rtti-for_each_init_function-0xde92e7e06acdedd7.rst
+++ b/doc/source/stdlib/handmade/function-rtti-for_each_init_function-0xde92e7e06acdedd7.rst
@@ -1,0 +1,1 @@
+Iterates through the ``[init]`` functions of the given ``Context`` in the order the runtime executes them (late init last), yielding each function's mangled name hash.

--- a/include/daScript/simulate/aot_builtin_rtti.h
+++ b/include/daScript/simulate/aot_builtin_rtti.h
@@ -123,6 +123,7 @@ namespace das {
     DAS_API void rtti_builtin_simulate ( const smart_ptr<Program> & program,
         const TBlock<void,bool,smart_ptr_raw<Context>,string> & block, Context * context, LineInfoArg * lineinfo );
 
+    DAS_API void rtti_builtin_context_for_each_init_function ( Context & ctx, const TBlock<void,uint64_t> & block, Context * context, LineInfoArg * at );
     DAS_API void rtti_builtin_program_for_each_module(smart_ptr_raw<Program> prog, const TBlock<void, Module *> & block, Context * context, LineInfoArg * lineinfo);
     DAS_API void rtti_builtin_program_for_each_registered_module(const TBlock<void, Module *> & block, Context * context, LineInfoArg * lineinfo);
 

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -520,6 +520,12 @@ namespace das
         __forceinline int32_t getTotalVariables() const {
             return totalVariables;
         }
+        __forceinline int32_t getTotalInitFunctions() const {
+            return totalInitFunctions;
+        }
+        __forceinline SimFunction * getInitFunction ( int index ) const {
+            return (index>=0 && index<totalInitFunctions) ? initFunctions[index] : nullptr;
+        }
 
         __forceinline uint32_t globalOffsetByMangledName ( uint64_t mnh ) const {
             auto it = tabGMnLookup->find(mnh);

--- a/include/daScript/simulate/standalone_ctx_utils.h
+++ b/include/daScript/simulate/standalone_ctx_utils.h
@@ -62,7 +62,7 @@ namespace das {
      */
     DAS_API MangledNameHash InitAotFunction(const Context &ctx, SimFunction* gfun, const FunctionInfo &info);
     DAS_API SizeDiff InitGlobalVariable(const Context &ctx, GlobalVariable* gvar, const GlobalVarInfo &info);
-    DAS_API void InitGlobalVar(Context &ctx, GlobalVariable* gvar, GlobalVarInfo info);
+    DAS_API void InitGlobalVar(Context &ctx, GlobalVariable* gvar, const GlobalVarInfo &info);
 
     /**
      * Set code, aot, aotFunction for all function in @ref functions

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -1217,7 +1217,19 @@ class CppGenBind : AnyGenBind {
         let spl = string(clang_getTypeSpelling(t))
         if (c.kind == CXTypeKind.Enum) return enum2enum?[spl] ?? spl
         if (t.kind == CXTypeKind.Long || t.kind == CXTypeKind.LongLong || t.kind == CXTypeKind.ULong || t.kind == CXTypeKind.ULongLong) return nspl // fancy type, may differ per platform
+        if (t.kind == CXTypeKind.Pointer) {
+            let pt = clang_getPointeeType(t)
+            if (pt.kind == CXTypeKind.Long || pt.kind == CXTypeKind.LongLong || pt.kind == CXTypeKind.ULong || pt.kind == CXTypeKind.ULongLong) return nspl
+        }
         return spl
+    }
+    def emitDesktopStub(var c : CXCursor; function_cpp_name : string) {
+        // signatures-only stub: links on a host lacking the real symbol, never runs.
+        let macro_proof_name = "({function_cpp_name})"
+        let stub_header = functionHeaderSpelling(c, false, false, false, macro_proof_name, "")
+        var stub_fun_type = clang_getCursorType(c)
+        let is_void = clang_getResultType(stub_fun_type).kind == CXTypeKind.Void
+        fprint(desktop_stub_file, "{stub_header} \{ return{is_void ? "" : " \{\}"}; \}\n")
     }
     def functionHeaderSpelling(var c : CXCursor; isMethod, needMethodQualifier, needArgumentNames : bool; function_name, self_type : string) {
         // TODO: calling convention?
@@ -1420,11 +1432,7 @@ class CppGenBind : AnyGenBind {
             bind_enchantation = " {function_cpp_type} , {function_cpp_name} "
             cpp_enchantation = function_cpp_name
             if (desktop_stub_file != null && emit_desktop_stub(function_name)) {
-                // signatures-only stub: links on a host lacking the real symbol, never runs.
-                // `return ({R})0;` covers void too (`return (void)0;` is legal).
-                let stub_header = functionHeaderSpelling(c, false, false, false, function_cpp_name, "")
-                let res_sp = typeSpelling(clang_getResultType(clang_getCursorType(c)))
-                fprint(desktop_stub_file, "{stub_header} \{ return ({res_sp})0; \}\n")
+                emitDesktopStub(c, function_cpp_name)
             }
         }
         fprint(func_file, from_comment(c))
@@ -1447,13 +1455,14 @@ class CppGenBind : AnyGenBind {
             for (ai in urange(narg)) {
                 let aii = int(isMethod ? ai + 1u : ai)
                 var carg = clang_Cursor_getArgument(c, ai)
-                var cp = getCursorArgType(clang_getCursorType(carg))     // non-canonical
+                var carg_type = clang_getCursorType(carg)
+                var cp = getCursorArgType(carg_type)     // non-canonical
                 // a binder may pin a (function,arg) to its raw C int instead of the enum
                 // retype, to preserve a shipped signature; cp="" -> int + ExprConstInt default
                 if (cp != "" && keep_c_arg_type(das_function_name, string(clang_getCursorSpelling(carg)), aii)) {
                     cp = ""
                 }
-                if (cp != "") {
+                if (cp != "" && cp != typeSpelling(carg_type)) {
                     fprint(func_file, "\n\t\t->arg_type({aii},makeType<{cp}>(lib))")
                 }
                 let cv = getCursorInit(carg, cp)

--- a/modules/dasOpenGL/src/dasOpenGL.desktop_stubs.cpp
+++ b/modules/dasOpenGL/src/dasOpenGL.desktop_stubs.cpp
@@ -8,244 +8,244 @@
 #endif
 #include <GLES3/gl3.h>
 extern "C" {
-void glActiveTexture(unsigned int) { return (void)0; }
-void glAttachShader(unsigned int,unsigned int) { return (void)0; }
-void glBindAttribLocation(unsigned int,unsigned int,const char *) { return (void)0; }
-void glBindBuffer(unsigned int,unsigned int) { return (void)0; }
-void glBindFramebuffer(unsigned int,unsigned int) { return (void)0; }
-void glBindRenderbuffer(unsigned int,unsigned int) { return (void)0; }
-void glBindTexture(unsigned int,unsigned int) { return (void)0; }
-void glBlendColor(float,float,float,float) { return (void)0; }
-void glBlendEquation(unsigned int) { return (void)0; }
-void glBlendEquationSeparate(unsigned int,unsigned int) { return (void)0; }
-void glBlendFunc(unsigned int,unsigned int) { return (void)0; }
-void glBlendFuncSeparate(unsigned int,unsigned int,unsigned int,unsigned int) { return (void)0; }
-unsigned int glCheckFramebufferStatus(unsigned int) { return (unsigned int)0; }
-void glClear(unsigned int) { return (void)0; }
-void glClearColor(float,float,float,float) { return (void)0; }
-void glClearDepthf(float) { return (void)0; }
-void glClearStencil(int) { return (void)0; }
-void glColorMask(unsigned char,unsigned char,unsigned char,unsigned char) { return (void)0; }
-void glCompileShader(unsigned int) { return (void)0; }
-void glCompressedTexImage2D(unsigned int,int,unsigned int,int,int,int,int,const void *) { return (void)0; }
-void glCompressedTexSubImage2D(unsigned int,int,int,int,int,int,unsigned int,int,const void *) { return (void)0; }
-void glCopyTexImage2D(unsigned int,int,unsigned int,int,int,int,int,int) { return (void)0; }
-void glCopyTexSubImage2D(unsigned int,int,int,int,int,int,int,int) { return (void)0; }
-unsigned int glCreateProgram() { return (unsigned int)0; }
-unsigned int glCreateShader(unsigned int) { return (unsigned int)0; }
-void glCullFace(unsigned int) { return (void)0; }
-void glDeleteBuffers(int,const unsigned int *) { return (void)0; }
-void glDeleteFramebuffers(int,const unsigned int *) { return (void)0; }
-void glDeleteProgram(unsigned int) { return (void)0; }
-void glDeleteRenderbuffers(int,const unsigned int *) { return (void)0; }
-void glDeleteShader(unsigned int) { return (void)0; }
-void glDeleteTextures(int,const unsigned int *) { return (void)0; }
-void glDepthFunc(unsigned int) { return (void)0; }
-void glDepthMask(unsigned char) { return (void)0; }
-void glDepthRangef(float,float) { return (void)0; }
-void glDetachShader(unsigned int,unsigned int) { return (void)0; }
-void glDisable(unsigned int) { return (void)0; }
-void glDisableVertexAttribArray(unsigned int) { return (void)0; }
-void glDrawArrays(unsigned int,int,int) { return (void)0; }
-void glDrawElements(unsigned int,int,unsigned int,const void *) { return (void)0; }
-void glEnable(unsigned int) { return (void)0; }
-void glEnableVertexAttribArray(unsigned int) { return (void)0; }
-void glFinish() { return (void)0; }
-void glFlush() { return (void)0; }
-void glFramebufferRenderbuffer(unsigned int,unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glFramebufferTexture2D(unsigned int,unsigned int,unsigned int,unsigned int,int) { return (void)0; }
-void glFrontFace(unsigned int) { return (void)0; }
-void glGenBuffers(int,unsigned int *) { return (void)0; }
-void glGenerateMipmap(unsigned int) { return (void)0; }
-void glGenFramebuffers(int,unsigned int *) { return (void)0; }
-void glGenRenderbuffers(int,unsigned int *) { return (void)0; }
-void glGenTextures(int,unsigned int *) { return (void)0; }
-void glGetActiveAttrib(unsigned int,unsigned int,int,int *,int *,unsigned int *,char *) { return (void)0; }
-void glGetActiveUniform(unsigned int,unsigned int,int,int *,int *,unsigned int *,char *) { return (void)0; }
-void glGetAttachedShaders(unsigned int,int,int *,unsigned int *) { return (void)0; }
-int glGetAttribLocation(unsigned int,const char *) { return (int)0; }
-void glGetBufferParameteriv(unsigned int,unsigned int,int *) { return (void)0; }
-unsigned int glGetError() { return (unsigned int)0; }
-void glGetFloatv(unsigned int,float *) { return (void)0; }
-void glGetFramebufferAttachmentParameteriv(unsigned int,unsigned int,unsigned int,int *) { return (void)0; }
-void glGetIntegerv(unsigned int,int *) { return (void)0; }
-void glGetProgramiv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetProgramInfoLog(unsigned int,int,int *,char *) { return (void)0; }
-void glGetRenderbufferParameteriv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetShaderiv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetShaderInfoLog(unsigned int,int,int *,char *) { return (void)0; }
-void glGetShaderPrecisionFormat(unsigned int,unsigned int,int *,int *) { return (void)0; }
-void glGetShaderSource(unsigned int,int,int *,char *) { return (void)0; }
-const unsigned char * glGetString(unsigned int) { return (const unsigned char *)0; }
-void glGetTexParameterfv(unsigned int,unsigned int,float *) { return (void)0; }
-void glGetTexParameteriv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetUniformfv(unsigned int,int,float *) { return (void)0; }
-void glGetUniformiv(unsigned int,int,int *) { return (void)0; }
-int glGetUniformLocation(unsigned int,const char *) { return (int)0; }
-void glGetVertexAttribfv(unsigned int,unsigned int,float *) { return (void)0; }
-void glGetVertexAttribiv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetVertexAttribPointerv(unsigned int,unsigned int,void **) { return (void)0; }
-void glHint(unsigned int,unsigned int) { return (void)0; }
-unsigned char glIsBuffer(unsigned int) { return (unsigned char)0; }
-unsigned char glIsEnabled(unsigned int) { return (unsigned char)0; }
-unsigned char glIsFramebuffer(unsigned int) { return (unsigned char)0; }
-unsigned char glIsProgram(unsigned int) { return (unsigned char)0; }
-unsigned char glIsRenderbuffer(unsigned int) { return (unsigned char)0; }
-unsigned char glIsShader(unsigned int) { return (unsigned char)0; }
-unsigned char glIsTexture(unsigned int) { return (unsigned char)0; }
-void glLineWidth(float) { return (void)0; }
-void glLinkProgram(unsigned int) { return (void)0; }
-void glPixelStorei(unsigned int,int) { return (void)0; }
-void glPolygonOffset(float,float) { return (void)0; }
-void glReadPixels(int,int,int,int,unsigned int,unsigned int,void *) { return (void)0; }
-void glReleaseShaderCompiler() { return (void)0; }
-void glRenderbufferStorage(unsigned int,unsigned int,int,int) { return (void)0; }
-void glSampleCoverage(float,unsigned char) { return (void)0; }
-void glScissor(int,int,int,int) { return (void)0; }
-void glShaderBinary(int,const unsigned int *,unsigned int,const void *,int) { return (void)0; }
-void glShaderSource(unsigned int,int,const char *const *,const int *) { return (void)0; }
-void glStencilFunc(unsigned int,int,unsigned int) { return (void)0; }
-void glStencilFuncSeparate(unsigned int,unsigned int,int,unsigned int) { return (void)0; }
-void glStencilMask(unsigned int) { return (void)0; }
-void glStencilMaskSeparate(unsigned int,unsigned int) { return (void)0; }
-void glStencilOp(unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glStencilOpSeparate(unsigned int,unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glTexImage2D(unsigned int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return (void)0; }
-void glTexParameterf(unsigned int,unsigned int,float) { return (void)0; }
-void glTexParameterfv(unsigned int,unsigned int,const float *) { return (void)0; }
-void glTexParameteri(unsigned int,unsigned int,int) { return (void)0; }
-void glTexParameteriv(unsigned int,unsigned int,const int *) { return (void)0; }
-void glTexSubImage2D(unsigned int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return (void)0; }
-void glUniform1f(int,float) { return (void)0; }
-void glUniform1fv(int,int,const float *) { return (void)0; }
-void glUniform1i(int,int) { return (void)0; }
-void glUniform1iv(int,int,const int *) { return (void)0; }
-void glUniform2f(int,float,float) { return (void)0; }
-void glUniform2fv(int,int,const float *) { return (void)0; }
-void glUniform2i(int,int,int) { return (void)0; }
-void glUniform2iv(int,int,const int *) { return (void)0; }
-void glUniform3f(int,float,float,float) { return (void)0; }
-void glUniform3fv(int,int,const float *) { return (void)0; }
-void glUniform3i(int,int,int,int) { return (void)0; }
-void glUniform3iv(int,int,const int *) { return (void)0; }
-void glUniform4f(int,float,float,float,float) { return (void)0; }
-void glUniform4fv(int,int,const float *) { return (void)0; }
-void glUniform4i(int,int,int,int,int) { return (void)0; }
-void glUniform4iv(int,int,const int *) { return (void)0; }
-void glUniformMatrix2fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix3fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix4fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUseProgram(unsigned int) { return (void)0; }
-void glValidateProgram(unsigned int) { return (void)0; }
-void glVertexAttrib1f(unsigned int,float) { return (void)0; }
-void glVertexAttrib1fv(unsigned int,const float *) { return (void)0; }
-void glVertexAttrib2f(unsigned int,float,float) { return (void)0; }
-void glVertexAttrib2fv(unsigned int,const float *) { return (void)0; }
-void glVertexAttrib3f(unsigned int,float,float,float) { return (void)0; }
-void glVertexAttrib3fv(unsigned int,const float *) { return (void)0; }
-void glVertexAttrib4f(unsigned int,float,float,float,float) { return (void)0; }
-void glVertexAttrib4fv(unsigned int,const float *) { return (void)0; }
-void glVertexAttribPointer(unsigned int,int,unsigned int,unsigned char,int,const void *) { return (void)0; }
-void glViewport(int,int,int,int) { return (void)0; }
-void glReadBuffer(unsigned int) { return (void)0; }
-void glDrawRangeElements(unsigned int,unsigned int,unsigned int,int,unsigned int,const void *) { return (void)0; }
-void glTexImage3D(unsigned int,int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return (void)0; }
-void glTexSubImage3D(unsigned int,int,int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return (void)0; }
-void glCopyTexSubImage3D(unsigned int,int,int,int,int,int,int,int,int) { return (void)0; }
-void glCompressedTexImage3D(unsigned int,int,unsigned int,int,int,int,int,int,const void *) { return (void)0; }
-void glCompressedTexSubImage3D(unsigned int,int,int,int,int,int,int,int,unsigned int,int,const void *) { return (void)0; }
-void glGenQueries(int,unsigned int *) { return (void)0; }
-void glDeleteQueries(int,const unsigned int *) { return (void)0; }
-unsigned char glIsQuery(unsigned int) { return (unsigned char)0; }
-void glBeginQuery(unsigned int,unsigned int) { return (void)0; }
-void glEndQuery(unsigned int) { return (void)0; }
-void glGetQueryiv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetQueryObjectuiv(unsigned int,unsigned int,unsigned int *) { return (void)0; }
-unsigned char glUnmapBuffer(unsigned int) { return (unsigned char)0; }
-void glGetBufferPointerv(unsigned int,unsigned int,void **) { return (void)0; }
-void glDrawBuffers(int,const unsigned int *) { return (void)0; }
-void glUniformMatrix2x3fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix3x2fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix2x4fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix4x2fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix3x4fv(int,int,unsigned char,const float *) { return (void)0; }
-void glUniformMatrix4x3fv(int,int,unsigned char,const float *) { return (void)0; }
-void glBlitFramebuffer(int,int,int,int,int,int,int,int,unsigned int,unsigned int) { return (void)0; }
-void glRenderbufferStorageMultisample(unsigned int,int,unsigned int,int,int) { return (void)0; }
-void glFramebufferTextureLayer(unsigned int,unsigned int,unsigned int,int,int) { return (void)0; }
-void glBindVertexArray(unsigned int) { return (void)0; }
-void glDeleteVertexArrays(int,const unsigned int *) { return (void)0; }
-void glGenVertexArrays(int,unsigned int *) { return (void)0; }
-unsigned char glIsVertexArray(unsigned int) { return (unsigned char)0; }
-void glGetIntegeri_v(unsigned int,unsigned int,int *) { return (void)0; }
-void glBeginTransformFeedback(unsigned int) { return (void)0; }
-void glEndTransformFeedback() { return (void)0; }
-void glBindBufferBase(unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glTransformFeedbackVaryings(unsigned int,int,const char *const *,unsigned int) { return (void)0; }
-void glGetTransformFeedbackVarying(unsigned int,unsigned int,int,int *,int *,unsigned int *,char *) { return (void)0; }
-void glVertexAttribIPointer(unsigned int,int,unsigned int,int,const void *) { return (void)0; }
-void glGetVertexAttribIiv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetVertexAttribIuiv(unsigned int,unsigned int,unsigned int *) { return (void)0; }
-void glVertexAttribI4i(unsigned int,int,int,int,int) { return (void)0; }
-void glVertexAttribI4ui(unsigned int,unsigned int,unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glVertexAttribI4iv(unsigned int,const int *) { return (void)0; }
-void glVertexAttribI4uiv(unsigned int,const unsigned int *) { return (void)0; }
-void glGetUniformuiv(unsigned int,int,unsigned int *) { return (void)0; }
-int glGetFragDataLocation(unsigned int,const char *) { return (int)0; }
-void glUniform1ui(int,unsigned int) { return (void)0; }
-void glUniform2ui(int,unsigned int,unsigned int) { return (void)0; }
-void glUniform3ui(int,unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glUniform4ui(int,unsigned int,unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glUniform1uiv(int,int,const unsigned int *) { return (void)0; }
-void glUniform2uiv(int,int,const unsigned int *) { return (void)0; }
-void glUniform3uiv(int,int,const unsigned int *) { return (void)0; }
-void glUniform4uiv(int,int,const unsigned int *) { return (void)0; }
-void glClearBufferiv(unsigned int,int,const int *) { return (void)0; }
-void glClearBufferuiv(unsigned int,int,const unsigned int *) { return (void)0; }
-void glClearBufferfv(unsigned int,int,const float *) { return (void)0; }
-void glClearBufferfi(unsigned int,int,float,int) { return (void)0; }
-const unsigned char * glGetStringi(unsigned int,unsigned int) { return (const unsigned char *)0; }
-void glGetUniformIndices(unsigned int,int,const char *const *,unsigned int *) { return (void)0; }
-void glGetActiveUniformsiv(unsigned int,int,const unsigned int *,unsigned int,int *) { return (void)0; }
-unsigned int glGetUniformBlockIndex(unsigned int,const char *) { return (unsigned int)0; }
-void glGetActiveUniformBlockiv(unsigned int,unsigned int,unsigned int,int *) { return (void)0; }
-void glGetActiveUniformBlockName(unsigned int,unsigned int,int,int *,char *) { return (void)0; }
-void glUniformBlockBinding(unsigned int,unsigned int,unsigned int) { return (void)0; }
-void glDrawArraysInstanced(unsigned int,int,int,int) { return (void)0; }
-void glDrawElementsInstanced(unsigned int,int,unsigned int,const void *,int) { return (void)0; }
-__GLsync * glFenceSync(unsigned int,unsigned int) { return (__GLsync *)0; }
-unsigned char glIsSync(__GLsync *) { return (unsigned char)0; }
-void glDeleteSync(__GLsync *) { return (void)0; }
-unsigned int glClientWaitSync(__GLsync *,unsigned int,GLuint64) { return (unsigned int)0; }
-void glWaitSync(__GLsync *,unsigned int,GLuint64) { return (void)0; }
-void glGetInteger64v(unsigned int,GLint64 *) { return (void)0; }
-void glGetSynciv(__GLsync *,unsigned int,int,int *,int *) { return (void)0; }
-void glGetInteger64i_v(unsigned int,unsigned int,GLint64 *) { return (void)0; }
-void glGetBufferParameteri64v(unsigned int,unsigned int,GLint64 *) { return (void)0; }
-void glGenSamplers(int,unsigned int *) { return (void)0; }
-void glDeleteSamplers(int,const unsigned int *) { return (void)0; }
-unsigned char glIsSampler(unsigned int) { return (unsigned char)0; }
-void glBindSampler(unsigned int,unsigned int) { return (void)0; }
-void glSamplerParameteri(unsigned int,unsigned int,int) { return (void)0; }
-void glSamplerParameteriv(unsigned int,unsigned int,const int *) { return (void)0; }
-void glSamplerParameterf(unsigned int,unsigned int,float) { return (void)0; }
-void glSamplerParameterfv(unsigned int,unsigned int,const float *) { return (void)0; }
-void glGetSamplerParameteriv(unsigned int,unsigned int,int *) { return (void)0; }
-void glGetSamplerParameterfv(unsigned int,unsigned int,float *) { return (void)0; }
-void glVertexAttribDivisor(unsigned int,unsigned int) { return (void)0; }
-void glBindTransformFeedback(unsigned int,unsigned int) { return (void)0; }
-void glDeleteTransformFeedbacks(int,const unsigned int *) { return (void)0; }
-void glGenTransformFeedbacks(int,unsigned int *) { return (void)0; }
-unsigned char glIsTransformFeedback(unsigned int) { return (unsigned char)0; }
-void glPauseTransformFeedback() { return (void)0; }
-void glResumeTransformFeedback() { return (void)0; }
-void glGetProgramBinary(unsigned int,int,int *,unsigned int *,void *) { return (void)0; }
-void glProgramBinary(unsigned int,unsigned int,const void *,int) { return (void)0; }
-void glProgramParameteri(unsigned int,unsigned int,int) { return (void)0; }
-void glInvalidateFramebuffer(unsigned int,int,const unsigned int *) { return (void)0; }
-void glInvalidateSubFramebuffer(unsigned int,int,const unsigned int *,int,int,int,int) { return (void)0; }
-void glTexStorage2D(unsigned int,int,unsigned int,int,int) { return (void)0; }
-void glTexStorage3D(unsigned int,int,unsigned int,int,int,int) { return (void)0; }
-void glGetInternalformativ(unsigned int,unsigned int,unsigned int,int,int *) { return (void)0; }
+void (glActiveTexture)(unsigned int) { return; }
+void (glAttachShader)(unsigned int,unsigned int) { return; }
+void (glBindAttribLocation)(unsigned int,unsigned int,const char *) { return; }
+void (glBindBuffer)(unsigned int,unsigned int) { return; }
+void (glBindFramebuffer)(unsigned int,unsigned int) { return; }
+void (glBindRenderbuffer)(unsigned int,unsigned int) { return; }
+void (glBindTexture)(unsigned int,unsigned int) { return; }
+void (glBlendColor)(float,float,float,float) { return; }
+void (glBlendEquation)(unsigned int) { return; }
+void (glBlendEquationSeparate)(unsigned int,unsigned int) { return; }
+void (glBlendFunc)(unsigned int,unsigned int) { return; }
+void (glBlendFuncSeparate)(unsigned int,unsigned int,unsigned int,unsigned int) { return; }
+unsigned int (glCheckFramebufferStatus)(unsigned int) { return {}; }
+void (glClear)(unsigned int) { return; }
+void (glClearColor)(float,float,float,float) { return; }
+void (glClearDepthf)(float) { return; }
+void (glClearStencil)(int) { return; }
+void (glColorMask)(unsigned char,unsigned char,unsigned char,unsigned char) { return; }
+void (glCompileShader)(unsigned int) { return; }
+void (glCompressedTexImage2D)(unsigned int,int,unsigned int,int,int,int,int,const void *) { return; }
+void (glCompressedTexSubImage2D)(unsigned int,int,int,int,int,int,unsigned int,int,const void *) { return; }
+void (glCopyTexImage2D)(unsigned int,int,unsigned int,int,int,int,int,int) { return; }
+void (glCopyTexSubImage2D)(unsigned int,int,int,int,int,int,int,int) { return; }
+unsigned int (glCreateProgram)() { return {}; }
+unsigned int (glCreateShader)(unsigned int) { return {}; }
+void (glCullFace)(unsigned int) { return; }
+void (glDeleteBuffers)(int,const unsigned int *) { return; }
+void (glDeleteFramebuffers)(int,const unsigned int *) { return; }
+void (glDeleteProgram)(unsigned int) { return; }
+void (glDeleteRenderbuffers)(int,const unsigned int *) { return; }
+void (glDeleteShader)(unsigned int) { return; }
+void (glDeleteTextures)(int,const unsigned int *) { return; }
+void (glDepthFunc)(unsigned int) { return; }
+void (glDepthMask)(unsigned char) { return; }
+void (glDepthRangef)(float,float) { return; }
+void (glDetachShader)(unsigned int,unsigned int) { return; }
+void (glDisable)(unsigned int) { return; }
+void (glDisableVertexAttribArray)(unsigned int) { return; }
+void (glDrawArrays)(unsigned int,int,int) { return; }
+void (glDrawElements)(unsigned int,int,unsigned int,const void *) { return; }
+void (glEnable)(unsigned int) { return; }
+void (glEnableVertexAttribArray)(unsigned int) { return; }
+void (glFinish)() { return; }
+void (glFlush)() { return; }
+void (glFramebufferRenderbuffer)(unsigned int,unsigned int,unsigned int,unsigned int) { return; }
+void (glFramebufferTexture2D)(unsigned int,unsigned int,unsigned int,unsigned int,int) { return; }
+void (glFrontFace)(unsigned int) { return; }
+void (glGenBuffers)(int,unsigned int *) { return; }
+void (glGenerateMipmap)(unsigned int) { return; }
+void (glGenFramebuffers)(int,unsigned int *) { return; }
+void (glGenRenderbuffers)(int,unsigned int *) { return; }
+void (glGenTextures)(int,unsigned int *) { return; }
+void (glGetActiveAttrib)(unsigned int,unsigned int,int,int *,int *,unsigned int *,char *) { return; }
+void (glGetActiveUniform)(unsigned int,unsigned int,int,int *,int *,unsigned int *,char *) { return; }
+void (glGetAttachedShaders)(unsigned int,int,int *,unsigned int *) { return; }
+int (glGetAttribLocation)(unsigned int,const char *) { return {}; }
+void (glGetBufferParameteriv)(unsigned int,unsigned int,int *) { return; }
+unsigned int (glGetError)() { return {}; }
+void (glGetFloatv)(unsigned int,float *) { return; }
+void (glGetFramebufferAttachmentParameteriv)(unsigned int,unsigned int,unsigned int,int *) { return; }
+void (glGetIntegerv)(unsigned int,int *) { return; }
+void (glGetProgramiv)(unsigned int,unsigned int,int *) { return; }
+void (glGetProgramInfoLog)(unsigned int,int,int *,char *) { return; }
+void (glGetRenderbufferParameteriv)(unsigned int,unsigned int,int *) { return; }
+void (glGetShaderiv)(unsigned int,unsigned int,int *) { return; }
+void (glGetShaderInfoLog)(unsigned int,int,int *,char *) { return; }
+void (glGetShaderPrecisionFormat)(unsigned int,unsigned int,int *,int *) { return; }
+void (glGetShaderSource)(unsigned int,int,int *,char *) { return; }
+const unsigned char * (glGetString)(unsigned int) { return {}; }
+void (glGetTexParameterfv)(unsigned int,unsigned int,float *) { return; }
+void (glGetTexParameteriv)(unsigned int,unsigned int,int *) { return; }
+void (glGetUniformfv)(unsigned int,int,float *) { return; }
+void (glGetUniformiv)(unsigned int,int,int *) { return; }
+int (glGetUniformLocation)(unsigned int,const char *) { return {}; }
+void (glGetVertexAttribfv)(unsigned int,unsigned int,float *) { return; }
+void (glGetVertexAttribiv)(unsigned int,unsigned int,int *) { return; }
+void (glGetVertexAttribPointerv)(unsigned int,unsigned int,void **) { return; }
+void (glHint)(unsigned int,unsigned int) { return; }
+unsigned char (glIsBuffer)(unsigned int) { return {}; }
+unsigned char (glIsEnabled)(unsigned int) { return {}; }
+unsigned char (glIsFramebuffer)(unsigned int) { return {}; }
+unsigned char (glIsProgram)(unsigned int) { return {}; }
+unsigned char (glIsRenderbuffer)(unsigned int) { return {}; }
+unsigned char (glIsShader)(unsigned int) { return {}; }
+unsigned char (glIsTexture)(unsigned int) { return {}; }
+void (glLineWidth)(float) { return; }
+void (glLinkProgram)(unsigned int) { return; }
+void (glPixelStorei)(unsigned int,int) { return; }
+void (glPolygonOffset)(float,float) { return; }
+void (glReadPixels)(int,int,int,int,unsigned int,unsigned int,void *) { return; }
+void (glReleaseShaderCompiler)() { return; }
+void (glRenderbufferStorage)(unsigned int,unsigned int,int,int) { return; }
+void (glSampleCoverage)(float,unsigned char) { return; }
+void (glScissor)(int,int,int,int) { return; }
+void (glShaderBinary)(int,const unsigned int *,unsigned int,const void *,int) { return; }
+void (glShaderSource)(unsigned int,int,const char *const *,const int *) { return; }
+void (glStencilFunc)(unsigned int,int,unsigned int) { return; }
+void (glStencilFuncSeparate)(unsigned int,unsigned int,int,unsigned int) { return; }
+void (glStencilMask)(unsigned int) { return; }
+void (glStencilMaskSeparate)(unsigned int,unsigned int) { return; }
+void (glStencilOp)(unsigned int,unsigned int,unsigned int) { return; }
+void (glStencilOpSeparate)(unsigned int,unsigned int,unsigned int,unsigned int) { return; }
+void (glTexImage2D)(unsigned int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return; }
+void (glTexParameterf)(unsigned int,unsigned int,float) { return; }
+void (glTexParameterfv)(unsigned int,unsigned int,const float *) { return; }
+void (glTexParameteri)(unsigned int,unsigned int,int) { return; }
+void (glTexParameteriv)(unsigned int,unsigned int,const int *) { return; }
+void (glTexSubImage2D)(unsigned int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return; }
+void (glUniform1f)(int,float) { return; }
+void (glUniform1fv)(int,int,const float *) { return; }
+void (glUniform1i)(int,int) { return; }
+void (glUniform1iv)(int,int,const int *) { return; }
+void (glUniform2f)(int,float,float) { return; }
+void (glUniform2fv)(int,int,const float *) { return; }
+void (glUniform2i)(int,int,int) { return; }
+void (glUniform2iv)(int,int,const int *) { return; }
+void (glUniform3f)(int,float,float,float) { return; }
+void (glUniform3fv)(int,int,const float *) { return; }
+void (glUniform3i)(int,int,int,int) { return; }
+void (glUniform3iv)(int,int,const int *) { return; }
+void (glUniform4f)(int,float,float,float,float) { return; }
+void (glUniform4fv)(int,int,const float *) { return; }
+void (glUniform4i)(int,int,int,int,int) { return; }
+void (glUniform4iv)(int,int,const int *) { return; }
+void (glUniformMatrix2fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix3fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix4fv)(int,int,unsigned char,const float *) { return; }
+void (glUseProgram)(unsigned int) { return; }
+void (glValidateProgram)(unsigned int) { return; }
+void (glVertexAttrib1f)(unsigned int,float) { return; }
+void (glVertexAttrib1fv)(unsigned int,const float *) { return; }
+void (glVertexAttrib2f)(unsigned int,float,float) { return; }
+void (glVertexAttrib2fv)(unsigned int,const float *) { return; }
+void (glVertexAttrib3f)(unsigned int,float,float,float) { return; }
+void (glVertexAttrib3fv)(unsigned int,const float *) { return; }
+void (glVertexAttrib4f)(unsigned int,float,float,float,float) { return; }
+void (glVertexAttrib4fv)(unsigned int,const float *) { return; }
+void (glVertexAttribPointer)(unsigned int,int,unsigned int,unsigned char,int,const void *) { return; }
+void (glViewport)(int,int,int,int) { return; }
+void (glReadBuffer)(unsigned int) { return; }
+void (glDrawRangeElements)(unsigned int,unsigned int,unsigned int,int,unsigned int,const void *) { return; }
+void (glTexImage3D)(unsigned int,int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return; }
+void (glTexSubImage3D)(unsigned int,int,int,int,int,int,int,int,unsigned int,unsigned int,const void *) { return; }
+void (glCopyTexSubImage3D)(unsigned int,int,int,int,int,int,int,int,int) { return; }
+void (glCompressedTexImage3D)(unsigned int,int,unsigned int,int,int,int,int,int,const void *) { return; }
+void (glCompressedTexSubImage3D)(unsigned int,int,int,int,int,int,int,int,unsigned int,int,const void *) { return; }
+void (glGenQueries)(int,unsigned int *) { return; }
+void (glDeleteQueries)(int,const unsigned int *) { return; }
+unsigned char (glIsQuery)(unsigned int) { return {}; }
+void (glBeginQuery)(unsigned int,unsigned int) { return; }
+void (glEndQuery)(unsigned int) { return; }
+void (glGetQueryiv)(unsigned int,unsigned int,int *) { return; }
+void (glGetQueryObjectuiv)(unsigned int,unsigned int,unsigned int *) { return; }
+unsigned char (glUnmapBuffer)(unsigned int) { return {}; }
+void (glGetBufferPointerv)(unsigned int,unsigned int,void **) { return; }
+void (glDrawBuffers)(int,const unsigned int *) { return; }
+void (glUniformMatrix2x3fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix3x2fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix2x4fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix4x2fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix3x4fv)(int,int,unsigned char,const float *) { return; }
+void (glUniformMatrix4x3fv)(int,int,unsigned char,const float *) { return; }
+void (glBlitFramebuffer)(int,int,int,int,int,int,int,int,unsigned int,unsigned int) { return; }
+void (glRenderbufferStorageMultisample)(unsigned int,int,unsigned int,int,int) { return; }
+void (glFramebufferTextureLayer)(unsigned int,unsigned int,unsigned int,int,int) { return; }
+void (glBindVertexArray)(unsigned int) { return; }
+void (glDeleteVertexArrays)(int,const unsigned int *) { return; }
+void (glGenVertexArrays)(int,unsigned int *) { return; }
+unsigned char (glIsVertexArray)(unsigned int) { return {}; }
+void (glGetIntegeri_v)(unsigned int,unsigned int,int *) { return; }
+void (glBeginTransformFeedback)(unsigned int) { return; }
+void (glEndTransformFeedback)() { return; }
+void (glBindBufferBase)(unsigned int,unsigned int,unsigned int) { return; }
+void (glTransformFeedbackVaryings)(unsigned int,int,const char *const *,unsigned int) { return; }
+void (glGetTransformFeedbackVarying)(unsigned int,unsigned int,int,int *,int *,unsigned int *,char *) { return; }
+void (glVertexAttribIPointer)(unsigned int,int,unsigned int,int,const void *) { return; }
+void (glGetVertexAttribIiv)(unsigned int,unsigned int,int *) { return; }
+void (glGetVertexAttribIuiv)(unsigned int,unsigned int,unsigned int *) { return; }
+void (glVertexAttribI4i)(unsigned int,int,int,int,int) { return; }
+void (glVertexAttribI4ui)(unsigned int,unsigned int,unsigned int,unsigned int,unsigned int) { return; }
+void (glVertexAttribI4iv)(unsigned int,const int *) { return; }
+void (glVertexAttribI4uiv)(unsigned int,const unsigned int *) { return; }
+void (glGetUniformuiv)(unsigned int,int,unsigned int *) { return; }
+int (glGetFragDataLocation)(unsigned int,const char *) { return {}; }
+void (glUniform1ui)(int,unsigned int) { return; }
+void (glUniform2ui)(int,unsigned int,unsigned int) { return; }
+void (glUniform3ui)(int,unsigned int,unsigned int,unsigned int) { return; }
+void (glUniform4ui)(int,unsigned int,unsigned int,unsigned int,unsigned int) { return; }
+void (glUniform1uiv)(int,int,const unsigned int *) { return; }
+void (glUniform2uiv)(int,int,const unsigned int *) { return; }
+void (glUniform3uiv)(int,int,const unsigned int *) { return; }
+void (glUniform4uiv)(int,int,const unsigned int *) { return; }
+void (glClearBufferiv)(unsigned int,int,const int *) { return; }
+void (glClearBufferuiv)(unsigned int,int,const unsigned int *) { return; }
+void (glClearBufferfv)(unsigned int,int,const float *) { return; }
+void (glClearBufferfi)(unsigned int,int,float,int) { return; }
+const unsigned char * (glGetStringi)(unsigned int,unsigned int) { return {}; }
+void (glGetUniformIndices)(unsigned int,int,const char *const *,unsigned int *) { return; }
+void (glGetActiveUniformsiv)(unsigned int,int,const unsigned int *,unsigned int,int *) { return; }
+unsigned int (glGetUniformBlockIndex)(unsigned int,const char *) { return {}; }
+void (glGetActiveUniformBlockiv)(unsigned int,unsigned int,unsigned int,int *) { return; }
+void (glGetActiveUniformBlockName)(unsigned int,unsigned int,int,int *,char *) { return; }
+void (glUniformBlockBinding)(unsigned int,unsigned int,unsigned int) { return; }
+void (glDrawArraysInstanced)(unsigned int,int,int,int) { return; }
+void (glDrawElementsInstanced)(unsigned int,int,unsigned int,const void *,int) { return; }
+__GLsync * (glFenceSync)(unsigned int,unsigned int) { return {}; }
+unsigned char (glIsSync)(__GLsync *) { return {}; }
+void (glDeleteSync)(__GLsync *) { return; }
+unsigned int (glClientWaitSync)(__GLsync *,unsigned int,GLuint64) { return {}; }
+void (glWaitSync)(__GLsync *,unsigned int,GLuint64) { return; }
+void (glGetInteger64v)(unsigned int,GLint64 *) { return; }
+void (glGetSynciv)(__GLsync *,unsigned int,int,int *,int *) { return; }
+void (glGetInteger64i_v)(unsigned int,unsigned int,GLint64 *) { return; }
+void (glGetBufferParameteri64v)(unsigned int,unsigned int,GLint64 *) { return; }
+void (glGenSamplers)(int,unsigned int *) { return; }
+void (glDeleteSamplers)(int,const unsigned int *) { return; }
+unsigned char (glIsSampler)(unsigned int) { return {}; }
+void (glBindSampler)(unsigned int,unsigned int) { return; }
+void (glSamplerParameteri)(unsigned int,unsigned int,int) { return; }
+void (glSamplerParameteriv)(unsigned int,unsigned int,const int *) { return; }
+void (glSamplerParameterf)(unsigned int,unsigned int,float) { return; }
+void (glSamplerParameterfv)(unsigned int,unsigned int,const float *) { return; }
+void (glGetSamplerParameteriv)(unsigned int,unsigned int,int *) { return; }
+void (glGetSamplerParameterfv)(unsigned int,unsigned int,float *) { return; }
+void (glVertexAttribDivisor)(unsigned int,unsigned int) { return; }
+void (glBindTransformFeedback)(unsigned int,unsigned int) { return; }
+void (glDeleteTransformFeedbacks)(int,const unsigned int *) { return; }
+void (glGenTransformFeedbacks)(int,unsigned int *) { return; }
+unsigned char (glIsTransformFeedback)(unsigned int) { return {}; }
+void (glPauseTransformFeedback)() { return; }
+void (glResumeTransformFeedback)() { return; }
+void (glGetProgramBinary)(unsigned int,int,int *,unsigned int *,void *) { return; }
+void (glProgramBinary)(unsigned int,unsigned int,const void *,int) { return; }
+void (glProgramParameteri)(unsigned int,unsigned int,int) { return; }
+void (glInvalidateFramebuffer)(unsigned int,int,const unsigned int *) { return; }
+void (glInvalidateSubFramebuffer)(unsigned int,int,const unsigned int *,int,int,int,int) { return; }
+void (glTexStorage2D)(unsigned int,int,unsigned int,int,int) { return; }
+void (glTexStorage3D)(unsigned int,int,unsigned int,int,int,int) { return; }
+void (glGetInternalformativ)(unsigned int,unsigned int,unsigned int,int,int *) { return; }
 }
 #endif

--- a/skills/internal/writing_cpp_tests.md
+++ b/skills/internal/writing_cpp_tests.md
@@ -62,9 +62,11 @@ set_tests_properties(my_stress_test PROPERTIES LABELS "big")
 add_dependencies(test-big my_stress_test)
 ```
 
-Big tests that are C++ executables **don't include doctest** - they keep their own `int main()` returning 0/1 to ctest. They handle `Module::Initialize()` / `Module::Shutdown()` themselves.
+Big tests that are C++ executables **don't include doctest** - they keep their own `int main()` returning 0/1 to ctest.
 
-Big tests are **not in CI yet** (V1) - local-only via `ninja test-big`.
+**A big test's `int main()` owns its module lifetime** - nothing runs `doctest_main.cpp` for it. An exe that resolves modules through the registry calls `Module::Initialize()` / `Module::Shutdown()` itself. An exe whose only context comes from a generated standalone AOT constructor calls neither: that constructor is self-contained and consults no module registry (example: `big/standalone_ctx/`).
+
+A big test is not gated by CI - only the small suite runs there. Run `ninja test-big` locally before pushing one.
 
 ## Doctest assertion cheat sheet
 
@@ -82,7 +84,7 @@ Big tests are **not in CI yet** (V1) - local-only via `ninja test-big`.
 
 ## TEST_CASE / SUBCASE pattern
 
-One `TEST_CASE` per logical scenario. `SUBCASE`s for variations sharing setup. Each SUBCASE re-runs the TEST_CASE body from the top - so per-subcase fresh `Context`/state is automatic.
+One `TEST_CASE` per logical scenario. `SUBCASE`s for variations sharing setup. Each SUBCASE re-runs the TEST_CASE body from the top - so per-subcase fresh `Context`/state is automatic, at the cost of re-running setup per subcase (5 subcases = 5 `compileDaScript` calls).
 
 ```cpp
 TEST_CASE("compile + run my script") {
@@ -97,7 +99,7 @@ TEST_CASE("compile + run my script") {
 
 Don't try to share a `Context` across `TEST_CASE`s - modules can survive (they're process-global), but Context-level state will leak between tests and the leak guard will catch it.
 
-See `tests-cpp/small/test_run_with_catch_clear.cpp` for a 5-subcase example.
+See `tests-cpp/small/test_run_with_catch_clear.cpp` for a multi-subcase example.
 
 ## Environment & init (what's free, what's yours)
 
@@ -107,7 +109,7 @@ See `tests-cpp/small/test_run_with_catch_clear.cpp` for a 5-subcase example.
 
 ## Leak detection (automatic, will fail your test)
 
-The framework auto-checks three counters at the suite-end of every test process:
+The framework auto-checks these counters at the suite-end of every test process:
 
 1. **gc_node count** - AST nodes (TypeDecl, Expression, Function, etc.) tracked by gc_node. Thread-local: only the suite-runner thread's root is sampled, so gc_nodes leaked on a worker thread that isn't joined-and-collected before the test ends are invisible to this check.
 2. **JobQue / Channel / LockBox / Stream / Feature count** - anything in the `JobStatus` tracking list.
@@ -137,12 +139,9 @@ VSCode integration: install `matepek.vscode-catch2-test-adapter`, point at `buil
 
 ## Sanitizers
 
-Build with `-DDAS_USE_SANITIZER=address` (or `undefined`/`ubsan`, `thread`/`tsan`) in the `cmake` step. CI runs three Linux **Release** x86-64 sanitizer lanes - ASAN, TSAN and UBSAN - on every PR, each running the full suite (dastest + test_aot + ctest). Release keeps walltime in budget; Debug + ASAN was prohibitive. If your test fails under a sanitizer, fix the sanitizer error - don't disable.
+Build with `-DDAS_USE_SANITIZER=address` (or `undefined`/`ubsan`, `thread`/`tsan`) in the `cmake` step. CI runs Linux **Release** x86-64 sanitizer lanes - ASAN, TSAN and UBSAN - on every PR, each running the full suite (dastest + test_aot + ctest). Release keeps walltime in budget; Debug + ASAN was prohibitive. If your test fails under a sanitizer, fix the sanitizer error - don't disable.
 
 ## Common gotchas
 
 - `getDasRoot()` derives the root at runtime from the test executable's own path (it walks up past `bin/` / `bin/<config>/`), falling back to `"."` if the exe is not under a `bin` dir. It is not a configure-time constant - moving the binary moves the root. All `.das` fixture loads should use `getDasRoot() + "/tests-cpp/..."`, and tests must therefore run with the repo layout intact, which is why every `add_test` sets `WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}`.
-- Don't put `NEED_*` macros at file scope. They go in `doctest_main.cpp::main()`.
 - The doctest header is large (~7000 lines). Don't include it in non-test code.
-- For SUBCASE-heavy tests, remember the body re-runs from the top - each subcase gets a fresh setup. This is the desired behavior; just be aware of the cost (5 subcases = 5 `compileDaScript` calls).
-- Big-test `int main()`s must call `Module::Initialize()` / `Module::Shutdown()` themselves - they don't go through `doctest_main.cpp`.

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -1102,6 +1102,13 @@ namespace das {
         return context.getTotalVariables();
     }
 
+    void rtti_builtin_context_for_each_init_function ( Context & ctx, const TBlock<void,uint64_t> & block, Context * context, LineInfoArg * at ) {
+        for ( int i=0, is=ctx.getTotalInitFunctions(); i!=is; ++i ) {
+            vec4f args[1] = { cast<uint64_t>::from(ctx.getInitFunction(i)->mangledNameHash) };
+            context->invoke(block, args, nullptr, at);
+        }
+    }
+
     vec4f rtti_contextFunctionInfo ( Context & context, SimNode_CallBase * call, vec4f * args ) {
         Context * ctx = cast<Context *>::to(args[0]);
         int32_t tf = ctx->getTotalFunctions();
@@ -1833,6 +1840,9 @@ namespace das {
             addExtern<DAS_BIND_FUN(rtti_contextTotalVariables)>(*this, lib, "get_total_variables",
                 SideEffects::modifyExternal, "rtti_contextTotalVariables")
                     ->arg("context");
+            addExtern<DAS_BIND_FUN(rtti_builtin_context_for_each_init_function)>(*this, lib, "for_each_init_function",
+                SideEffects::modifyExternal, "rtti_builtin_context_for_each_init_function")
+                    ->args({"ctx","block","context","line"});
             addInterop<rtti_contextFunctionInfo,const FuncInfo &,vec4f,int32_t>(*this, lib, "get_function_info",
                 SideEffects::modifyExternal, "rtti_contextFunctionInfo")
                     ->args({"context","index"});

--- a/tests-cpp/big/standalone_ctx/CMakeLists.txt
+++ b/tests-cpp/big/standalone_ctx/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Big test: a standalone AOT context runs global initializers in declaration
+# order (required modules first), then [init] functions.
+
+set(STANDALONE_CTX_GEN "${CMAKE_CURRENT_BINARY_DIR}/_generated")
+file(MAKE_DIRECTORY "${STANDALONE_CTX_GEN}")
+
+add_custom_command(
+    OUTPUT "${STANDALONE_CTX_GEN}/standalone_init_fixture.das.cpp"
+           "${STANDALONE_CTX_GEN}/standalone_init_fixture.das.h"
+    COMMAND $<TARGET_FILE:daslang>
+        "${PROJECT_SOURCE_DIR}/utils/aot/main.das"
+        -- -ctx "${CMAKE_CURRENT_SOURCE_DIR}/standalone_init_fixture.das"
+        "${STANDALONE_CTX_GEN}/"
+    DEPENDS daslang
+        "${CMAKE_CURRENT_SOURCE_DIR}/standalone_init_fixture.das"
+        "${CMAKE_CURRENT_SOURCE_DIR}/standalone_init_dep.das"
+        "${PROJECT_SOURCE_DIR}/utils/aot/main.das"
+        "${PROJECT_SOURCE_DIR}/daslib/aot_standalone.das"
+        "${PROJECT_SOURCE_DIR}/daslib/aot_cpp.das"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    COMMENT "Standalone AOT: standalone_init_fixture.das"
+    VERBATIM
+)
+
+add_executable(test_standalone_ctx
+    test_standalone_ctx.cpp
+    "${STANDALONE_CTX_GEN}/standalone_init_fixture.das.cpp")
+target_link_libraries(test_standalone_ctx PRIVATE
+    libDaScript ${SRC_LIBRARIES} ${DAS_MODULES_LIBS})
+target_include_directories(test_standalone_ctx PRIVATE "${STANDALONE_CTX_GEN}" ${NEED_MODULES_PATH})
+SETUP_CPP11(test_standalone_ctx)
+set_target_properties(test_standalone_ctx PROPERTIES FOLDER "tests-cpp/big")
+
+add_test(NAME standalone_ctx COMMAND test_standalone_ctx
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_tests_properties(standalone_ctx PROPERTIES LABELS "big")
+add_dependencies(test-big test_standalone_ctx)

--- a/tests-cpp/big/standalone_ctx/standalone_init_dep.das
+++ b/tests-cpp/big/standalone_ctx/standalone_init_dep.das
@@ -1,0 +1,5 @@
+options gen2
+
+module standalone_init_dep public
+
+var g_dep = 30

--- a/tests-cpp/big/standalone_ctx/standalone_init_fixture.das
+++ b/tests-cpp/big/standalone_ctx/standalone_init_fixture.das
@@ -1,0 +1,50 @@
+options gen2
+
+require standalone_init_dep
+
+var g_stamp = 0
+
+def next_stamp : int {
+    g_stamp ++
+    return g_stamp
+}
+
+def read_forward : int {
+    return g_later
+}
+
+var g_first = next_stamp() + g_dep
+var g_second = next_stamp()
+var g_reads_forward = read_forward() + 100
+var g_later = 7
+var g_init_fn_stamp = 0
+
+[init]
+def record_init {
+    g_init_fn_stamp = next_stamp()
+}
+
+[export]
+def get_first : int {
+    return g_first
+}
+
+[export]
+def get_second : int {
+    return g_second
+}
+
+[export]
+def get_init_fn_stamp : int {
+    return g_init_fn_stamp
+}
+
+[export]
+def get_reads_forward : int {
+    return g_reads_forward
+}
+
+[export]
+def get_later : int {
+    return g_later
+}

--- a/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
+++ b/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
@@ -1,0 +1,22 @@
+#include "daScript/daScript.h"
+#include "standalone_init_fixture.das.h"
+
+using namespace das;
+
+int main( int, char * [] ) {
+    standalone_init_fixture::Standalone ctx;
+    TextPrinter tout;
+    int failures = 0;
+    auto expect = [&]( const char * name, int32_t have, int32_t want ) {
+        if ( have != want ) {
+            tout << name << " = " << have << ", expected " << want << "\n";
+            failures ++;
+        }
+    };
+    expect("get_first()", ctx.get_first(), 31);
+    expect("get_second()", ctx.get_second(), 2);
+    expect("get_init_fn_stamp()", ctx.get_init_fn_stamp(), 3);
+    expect("get_reads_forward()", ctx.get_reads_forward(), 100);
+    expect("get_later()", ctx.get_later(), 7);
+    return failures ? 1 : 0;
+}

--- a/tests/aot/_standalone_cross_module_fixture.das
+++ b/tests/aot/_standalone_cross_module_fixture.das
@@ -1,0 +1,10 @@
+options gen2
+
+require _standalone_dep_b
+
+var g_main = g_dep_b + 1
+
+[export]
+def get_main : int {
+    return g_main
+}

--- a/tests/aot/_standalone_dep_a.das
+++ b/tests/aot/_standalone_dep_a.das
@@ -1,0 +1,5 @@
+options gen2
+
+module _standalone_dep_a public
+
+var g_dep_a = 11

--- a/tests/aot/_standalone_dep_b.das
+++ b/tests/aot/_standalone_dep_b.das
@@ -1,0 +1,7 @@
+options gen2
+
+module _standalone_dep_b public
+
+require _standalone_dep_a public
+
+var g_dep_b = g_dep_a + 1

--- a/tests/aot/_standalone_dep_with_init.das
+++ b/tests/aot/_standalone_dep_with_init.das
@@ -1,0 +1,10 @@
+options gen2
+
+module _standalone_dep_with_init public
+
+var g_dep_init = 0
+
+[init]
+def dep_record_init {
+    g_dep_init = 1
+}

--- a/tests/aot/_standalone_foreign_init_fixture.das
+++ b/tests/aot/_standalone_foreign_init_fixture.das
@@ -1,0 +1,8 @@
+options gen2
+
+require _standalone_dep_with_init
+
+[export]
+def get_dep_init : int {
+    return g_dep_init
+}

--- a/tests/aot/_standalone_init_fixture.das
+++ b/tests/aot/_standalone_init_fixture.das
@@ -1,0 +1,22 @@
+options gen2
+
+var g_stamp = 0
+
+def next_stamp : int {
+    g_stamp ++
+    return g_stamp
+}
+
+var g_first = next_stamp()
+var g_second = next_stamp()
+var g_init_fn_stamp = 0
+
+[init]
+def record_init {
+    g_init_fn_stamp = next_stamp()
+}
+
+[export]
+def get_init_stamps : int3 {
+    return int3(g_first, g_second, g_init_fn_stamp)
+}

--- a/tests/aot/test_standalone_emit.das
+++ b/tests/aot/test_standalone_emit.das
@@ -9,17 +9,21 @@ require daslib/rtti
 require strings
 require dastest/testing_boost public
 
+def private standalone_cop(var cop : CodeOfPolicies) {
+    cop.threadlock_context = false
+    cop.aot = false
+    cop.aot_module = true
+    cop.aot_lib = false
+    cop.fail_on_lack_of_aot_export = true
+    cop.ignore_shared_modules = false
+    cop.version_2_syntax = true
+    cop.tune_frozen = true
+}
+
 def private generate_standalone(t : T?; fixture, out_dir : string) : string {
     let input = path_join(get_das_root(), "tests/aot/{fixture}.das")
     using() $(var cop : CodeOfPolicies) {
-        cop.threadlock_context = false
-        cop.aot = false
-        cop.aot_module = true
-        cop.aot_lib = false
-        cop.fail_on_lack_of_aot_export = true
-        cop.ignore_shared_modules = false
-        cop.version_2_syntax = true
-        cop.tune_frozen = true
+        standalone_cop(cop)
         ast_gc_guard() {
             standalone_aot(input, out_dir, false, false, cop)
         }
@@ -74,6 +78,59 @@ def test_standalone_emit(t : T?) {
         t |> success(find(source, "TTuple<") >= 0, "the tuple definition was emitted")
         t |> success(find(source, "AutoTuple<") < 0, "cross-platform spelling leaked into a native emit")
         t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
+    }
+
+    t |> run("the constructor runs the init script and then the [init] functions") @(t : T?) {
+        let source = generate_standalone(t, "_standalone_init_fixture", out_dir)
+        let ctor_pos = find(source, "Standalone::Standalone()")
+        t |> success(ctor_pos >= 0, "constructor was emitted")
+        let init_script_pos = find(source, "__init_script(&context, true);")
+        t |> success(init_script_pos > ctor_pos, "the constructor calls __init_script")
+        let zero_pos = find(source, "memset(context.globals, 0, context.getGlobalSize());")
+        t |> success(zero_pos > ctor_pos && zero_pos < init_script_pos, "globals are zeroed before the init script runs")
+        let tail = slice(source, init_script_pos)
+        t |> success(find(tail, "record_init") >= 0, "the [init] function is called after __init_script")
+        t |> success(find(source, "runInitScript") < 0, "the constructor does not call runInitScript")
+        t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
+    }
+
+    t |> run("required modules' globals emit in dependency order before the entry module's") @(t : T?) {
+        let source = generate_standalone(t, "_standalone_cross_module_fixture", out_dir)
+        let a_pos = find(source, "/*g_dep_a*/")
+        let b_pos = find(source, "/*g_dep_b*/")
+        let main_pos = find(source, "/*g_main*/")
+        t |> success(a_pos >= 0 && b_pos >= 0 && main_pos >= 0, "all three globals were emitted")
+        t |> success(a_pos < b_pos && b_pos < main_pos, "dependency-first order: dep_a, dep_b, entry module")
+    }
+
+    t |> run("a required module's [init] is a collected error, not a crash") @(t : T?) {
+        let input = path_join(get_das_root(), "tests/aot/_standalone_foreign_init_fixture.das")
+        var ok = true
+        using() $(var cop : CodeOfPolicies) {
+            standalone_cop(cop)
+            ast_gc_guard() {
+                ok = standalone_aot(input, out_dir, false, false, cop)
+            }
+        }
+        t |> success(!ok, "standalone_aot reports failure")
+        let generated = path_join(out_dir, "_standalone_foreign_init_fixture.das.cpp")
+        t |> success(!stat(generated).is_valid, "no output is written on failure")
+    }
+
+    t |> run("before_emit receives the compiled program") @(t : T?) {
+        let input = path_join(get_das_root(), "tests/aot/_standalone_novars_fixture.das")
+        var saw_program = false
+        using() $(var cop : CodeOfPolicies) {
+            standalone_cop(cop)
+            ast_gc_guard() {
+                standalone_aot(input, out_dir, false, false, cop) $(var program : ProgramPtr) {
+                    saw_program = program != null
+                }
+            }
+        }
+        t |> success(saw_program, "the before_emit block ran with a non-null program")
+        remove(path_join(out_dir, "_standalone_novars_fixture.das.cpp"))
+        remove(path_join(out_dir, "_standalone_novars_fixture.das.h"))
     }
 
     rmdir(out_dir)

--- a/tests/rtti/test_init_function_order.das
+++ b/tests/rtti/test_init_function_order.das
@@ -1,0 +1,35 @@
+options gen2
+
+require daslib/rtti
+require dastest/testing_boost public
+
+var g_touch = 0
+
+[init]
+def init_alpha {
+    g_touch ++
+}
+
+[init]
+def init_beta {
+    g_touch ++
+}
+
+[init(late = true)]
+def init_gamma_late {
+    g_touch ++
+}
+
+[test]
+def test_init_function_order(t : T?) {
+    var order : array<uint64>
+    this_context() |> for_each_init_function($(mnh : uint64) {
+        order |> push(mnh)
+    })
+    let alpha_pos = find_index(order, get_function_mangled_name_hash(@@init_alpha))
+    let beta_pos = find_index(order, get_function_mangled_name_hash(@@init_beta))
+    let gamma_pos = find_index(order, get_function_mangled_name_hash(@@init_gamma_late))
+    t |> success(alpha_pos >= 0 && beta_pos >= 0 && gamma_pos >= 0, "all three [init] functions are yielded")
+    t |> success(alpha_pos < beta_pos, "plain [init] functions keep declaration order")
+    t |> success(gamma_pos > beta_pos, "[init(late = true)] runs after the plain [init] functions")
+}


### PR DESCRIPTION
**Behavior change: standalone AOT contexts now run initialization — a generated `Standalone` constructor zeroes globals, runs global initializers, then runs `[init]` functions. Regenerate any standalone context after updating.**

A standalone context never ran its initialization. The emitted constructor looked up an init hash nothing ever set, discarded the node it created, and called `runInitScript()`, which is a no-op in a standalone context. Every global stayed zero. On top of that, `InitGlobalVar`'s header declared a by-value parameter while the definition takes a const reference, so a standalone context with globals could not even link. Both were found by reviewing the zephyr_das embedded port, which patches around them.

The constructor now emits `memset` over globals, a direct call to the same-TU `__init_script`, and then each `[init]` function in the simulated context's run order, read through a new rtti builtin `for_each_init_function` so the C++ late-init sort stays the single source of truth. Required modules' globals emit dependency-first, matching interpreter order. An `[init]` in a required module (or `[no_aot]`) is a collected emit error: `standalone_aot` returns false and writes nothing. `standalone_aot` also gains a `before_emit` overload handing the driver the compiled program, so embedders stop compiling twice to read annotations.

cbind desktop stubs now compile for aggregate returns (`return {};` instead of `(T)0`), are immune to same-name function-like macros (parenthesized definition names), and keep platform-varying integer typedefs (`GLint64 *`) instead of desugaring them; identity `->arg_type` rows are no longer emitted. `dasOpenGL.desktop_stubs.cpp` is regenerated with the new emitter.

Where to look: the constructor tail and `collectInitFunctionAotNames` in `daslib/aot_standalone.das`; `typeSpelling` and stub emission in `cbind_boost.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full AOT sweep run locally (nightly-only gate): 12976 tests, 12969 passed, 0 failed, 7 pre-existing skips.
- Run harness `tests-cpp/big/standalone_ctx` proves init order at runtime (dep-module global first, declaration order, `[init]` last, forward-reference zeroing). Big tests are not CI-gated; the CI guard is the structural assertions in `tests/aot/test_standalone_emit.das`, which mutation-tested red on the memset and ordering lines.
- `bind_opengl.das` was re-run locally against libclang 22.1.5; regeneration is now byte-stable except the intended stub change.
- preflight --full green; tests-aot ran separately from a plain shell (DLL-pin skip), cpp-syntax skipped (no clang-cl on PATH).
- Two external review rounds; both P1 findings verified real (cross-module ordering, missing globals zeroing) and fixed with regression tests.

### Claims - stated, not tested
- The cbind aggregate-return stub arm has no in-repo reproducer (no bound header returns a struct from a stubbed function); it ships on reasoning plus the wasm lane compiling the regenerated dasOpenGL stubs per PR.
- The emitted `__init_shared` is hardcoded true; no fixture declares a shared global in a standalone context, so that arm of `das_shared` init is unexercised.
- The `[no_aot]`-in-main-module arm of the init check is verified by reading; the required-module arm has a failing-fixture test.

### Not done
- Whole-program emission for standalone contexts (emit all modules' function bodies into the TU) - the follow-up arc that makes cross-module `[init]` and foreign calls in initializers work instead of failing loud.
- Checklist follow-ups recorded from the review round: widen the simulate REVIEW.md abi-sweep routing to `DAS_API` signature changes; dedup the automated src/builtin rule and widen `review_nttp.das` reach to `jit`/`dasbind`; a `tests-cpp/big` checklist + REVIEW.das; the daslib panic-vs-`#error` ruling for emit drivers.
- Lint candidates: a `DAS_API` declaration/definition parameter comparer (this PR's link bug class); a bind_opengl freshness gate mirroring the bind_clangbind one.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
