### PR TITLE
Allow specifying order of documentation blocks

### DIFF
--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -21,7 +21,7 @@ require daslib/strings_boost
 require daslib/regex
 require daslib/regex_boost
 
-enum DocumentBlock {
+enum public DocumentBlock {
     Typedefs,
     GlobalConstants,
     Enumerations,

--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -21,6 +21,25 @@ require daslib/strings_boost
 require daslib/regex
 require daslib/regex_boost
 
+enum DocumentBlock {
+    Typedefs,
+    GlobalConstants,
+    Enumerations,
+    Structures,
+    StructureAnnotations,
+    FunctionAnnotations,
+    CallMacros,
+    ReaderMacros,
+    VariantMacros,
+    TypeinfoMacros,
+    Annotations,
+    EnumerationAnnotations,
+    StructureMacros,
+    TypeMacros,
+    Classes,
+    Functions,
+}
+
 let { //! Configuration constants for the RST documentation generator.
     log_documentation = false
     show_hidden_groups = false
@@ -36,6 +55,24 @@ var public {
     strict_struct_fields = true
     group_function_overloads = true
     property_assignment_operator = ":="
+    doc_block_order = [
+        DocumentBlock.Typedefs,
+        DocumentBlock.GlobalConstants,
+        DocumentBlock.Enumerations,
+        DocumentBlock.Structures,
+        DocumentBlock.StructureAnnotations,
+        DocumentBlock.FunctionAnnotations,
+        DocumentBlock.CallMacros,
+        DocumentBlock.ReaderMacros,
+        DocumentBlock.VariantMacros,
+        DocumentBlock.TypeinfoMacros,
+        DocumentBlock.Annotations,
+        DocumentBlock.EnumerationAnnotations,
+        DocumentBlock.StructureMacros,
+        DocumentBlock.TypeMacros,
+        DocumentBlock.Classes,
+        DocumentBlock.Functions
+    ]
 }
 
 var private seen_function_labels : table<string; uint>
@@ -2095,25 +2132,44 @@ def public documents(name : string; mods : array<Module?>; fname : string; var g
         break
     }
 
-    document_typedefs(doc_file, mods)
-    document_global_constants(doc_file, mods)
-    let wasEnums = document_enumerations(doc_file, mods)
-    if (hook.afterEnums != null) {
-        hook.afterEnums |> invoke(doc_file, wasEnums)
+    for (docBlock in doc_block_order) {
+        if (docBlock == DocumentBlock.Typedefs) {
+            document_typedefs(doc_file, mods)
+        } elif (docBlock == DocumentBlock.GlobalConstants) {
+            document_global_constants(doc_file, mods)
+        } elif (docBlock == DocumentBlock.Enumerations) {
+            let wasEnums = document_enumerations(doc_file, mods)
+            if (hook.afterEnums != null) {
+                hook.afterEnums |> invoke(doc_file, wasEnums)
+            }
+        } elif (docBlock == DocumentBlock.Structures) {
+            document_structures(doc_file, mods)
+        } elif (docBlock == DocumentBlock.StructureAnnotations) {
+            document_structure_annotations(doc_file, mods, hook)
+        } elif (docBlock == DocumentBlock.FunctionAnnotations) {
+            document_function_annotations(doc_file, mods, hook)
+        } elif (docBlock == DocumentBlock.CallMacros) {
+            document_call_macros(doc_file, mods)
+        } elif (docBlock == DocumentBlock.ReaderMacros) {
+            document_reader_macros(doc_file, mods)
+        } elif (docBlock == DocumentBlock.VariantMacros) {
+            document_variant_macros(doc_file, mods)
+        } elif (docBlock == DocumentBlock.TypeinfoMacros) {
+            document_typeinfo_macros(doc_file, mods)
+        } elif (docBlock == DocumentBlock.Annotations) {
+            document_annotations(doc_file, mods, hook)
+        } elif (docBlock == DocumentBlock.EnumerationAnnotations) {
+            document_enumeration_annotations(doc_file, mods, hook)
+        } elif (docBlock == DocumentBlock.StructureMacros) {
+            document_structure_macros(doc_file, mods)
+        } elif (docBlock == DocumentBlock.TypeMacros) {
+            document_typemacros(doc_file, mods)
+        } elif (docBlock == DocumentBlock.Classes) {
+            document_classes(doc_file, mods)
+        } elif (docBlock == DocumentBlock.Functions) {
+            document_functions(doc_file, mods, groups)
+        }
     }
-    document_structures(doc_file, mods)
-    document_structure_annotations(doc_file, mods, hook)
-    document_function_annotations(doc_file, mods, hook)
-    document_call_macros(doc_file, mods)
-    document_reader_macros(doc_file, mods)
-    document_variant_macros(doc_file, mods)
-    document_typeinfo_macros(doc_file, mods)
-    document_annotations(doc_file, mods, hook)
-    document_enumeration_annotations(doc_file, mods, hook)
-    document_structure_macros(doc_file, mods)
-    document_typemacros(doc_file, mods)
-    document_classes(doc_file, mods)
-    document_functions(doc_file, mods, groups)
     fwrite(doc_file, "\n")
     fclose(doc_file)
 }


### PR DESCRIPTION
We may want to change the predefined order
(for example, to put classes before structs).
Now it can be done through setting doc_block_order. It also allows for removing not needed blocks if it's the case.

We could alternatively provide a map with priorities, but a priority list is more explicit and already sorted.