### PR TITLE
daslang: class the main thread on Apple (E-core wake fix)

### DIFF
--- a/utils/daslang/main.cpp
+++ b/utils/daslang/main.cpp
@@ -10,6 +10,9 @@
 #include "daScript/ast/ast_serializer.h"
 #include "daScript/misc/crash_handler.h"
 #include "daScript/misc/job_que.h"
+#ifdef __APPLE__
+#include <pthread/qos.h>
+#endif
 #if defined(_WIN32) && defined(_DEBUG)
 #include <crtdbg.h>
 #endif
@@ -711,6 +714,11 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     _set_error_mode(_OUT_TO_STDERR);
 #endif
     install_das_crash_handler();
+#ifdef __APPLE__
+    // class the main thread: unclassed threads wake on an E-core after any block
+    // (~half scalar throughput) - e.g. a jitted benchmark right after codegen
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);
+#endif
     das::arm_alloc_tracking();
     bool isArgAot = false;
     if (argc > 1) {

--- a/utils/daslang/main.cpp
+++ b/utils/daslang/main.cpp
@@ -715,8 +715,6 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
 #endif
     install_das_crash_handler();
 #ifdef __APPLE__
-    // class the main thread: unclassed threads wake on an E-core after any block
-    // (~half scalar throughput) - e.g. a jitted benchmark right after codegen
     pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);
 #endif
     das::arm_alloc_tracking();


### PR DESCRIPTION
macOS schedules by QoS class, and an unclassed thread that blocked - JIT codegen, dlopen, IO - wakes on an efficiency core (~2/3 clock, ~half scalar throughput) until sustained load re-promotes it. daslang's main thread carried no class, so a jitted benchmark right after in-process codegen measured 1.56x slow on an M1 Max: fib loop 3.155ms unclassed vs 2.017ms classed - the P-core arithmetic exactly (6.5M serial adds at 3.2GHz), reproducible across runs. Jobque workers already class themselves (`SetCurrentThreadPriority`, job_que.cpp's Apple section documents the doctrine); this applies the same one line to the main thread at startup.

`#ifdef __APPLE__` only; other platforms unchanged. The pthread call is direct because `das::SetCurrentThreadPriority` is not exported from the dylib on mac.

Found while recapturing dasProfile on the M1 (companion: borisbat/dasProfile#9 - the capture-side prewarm and the spectral-norm vectorizer pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
