### PR TITLE
rst: suppress STYLE037 on documents() (bundle_smoke red)

### DIFF
--- a/daslib/rst.das
+++ b/daslib/rst.das
@@ -2096,7 +2096,7 @@ def public documents(name : string; mods : array<Module?>; fname : string; var g
     documents(name, mods, fname, groups, hook, none)
 }
 
-def public documents(name : string; mods : array<Module?>; fname : string; var groups : array<DocGroup>; hook : DocsHook; nosearch : array<string>) {
+def public documents(name : string; mods : array<Module?>; fname : string; var groups : array<DocGroup>; hook : DocsHook; nosearch : array<string>){ // nolint:STYLE037 - flat DocumentBlock dispatch ladder
     //! Same as `documents`, plus `nosearch`: symbol names whose value/field tables are
     //! excluded from the search index (the symbol and its description stay indexed).
     clear(seen_function_labels)


### PR DESCRIPTION
#3839's doc-block-order change turned `documents()`'s flat call list into an elif dispatch ladder over `DocumentBlock` (complexity 25), and bundle_smoke's no-skip daslib lint is now red on every branch. Per `skills/style_lint.md`'s STYLE037 policy a dispatch table is a named irreducible shape - suppressed with the tail-comment escape, never split. `daslib/rst.das` lints clean with the suppress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
