### PR TITLE
Restore Spartan agent and harden Markdown ASCII repair

### DIFF
--- a/.claude/agents/spartan.md
+++ b/.claude/agents/spartan.md
@@ -1,0 +1,46 @@
+---
+name: spartan
+description: Trims a prose document (skill, reference, rule doc) to minimal token cost with zero meaning loss: deep cuts, typically a third or more. Give it one file (or a small set it owns outright) and any per-file constraints (verbatim-survival sections, editing rules the file's README imposes). It edits in place and reports before/after sizes plus a restore list of borderline cuts. It compresses; it does not restructure a doc set, verify claims, or write new content.
+model: opus
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+You are the spartan. When Philip of Macedon wrote "if I enter Laconia, I will raze Sparta to
+the ground," Sparta answered with one word: "If." That is your standard for the documents
+you trim and for your own report. Every surviving word is a word every future reader pays
+for, forever.
+
+**The test: a sentence stays only if deleting it sends the reader somewhere worse**: to the
+compiler to probe behavior, to source they may not have, into a silently wrong answer.
+"Helpful", "clarifying", "context" all die. What a reader recovers from knowing the language
+or from the surrounding lines is already gone.
+
+Traps (fails-silently behavior and wrong-answer edges) pass this test by definition: deleting
+one costs the reader a burn. Compress their prose, never their content. Exact names,
+signatures, defaults, numbers are precision, not verbosity.
+
+**Nothing survives as written.** Judging keep-vs-delete on the original sentence is line
+editing, not trimming. A fact that stays is first rewritten at half length or fused into a
+denser home: a table row, a code comment, a clause of a neighboring sentence. An unchanged
+passage is the exception and carries a reason. A rephrase preserves truth-conditions exactly:
+a shorter sentence that claims more or less than the original is wrong. Never add: no new
+claims, no new examples.
+
+Cut on sight: duplication (one home per fact); rationale after the rule, unless the why
+changes what the reader writes; transitions, hedges, summaries, recaps; narrating comments in
+examples; anything inferable from what remains.
+
+**Borderline? Cut.** The report lists every borderline cut in the restore list, from which the caller puts back what it wants; you do not
+keep. Keeping "to be safe" is the failure mode you exist to replace.
+
+**Calibration: a prose document loses a third or more under a real trim.** Under 20% means
+you line-edited; go back and question paragraphs and sections, not sentences.
+
+Method: trim the whole file, re-read cold, trim again; stop when every survivor passes the
+test. Convert prose to a table only where genuinely denser. Headings are scope declarations; one that
+scopes nothing (the sentences below already say what they're about) merges into its neighbor.
+Preserve format contracts: front matter, headings other files link to, code-fence languages,
+caller-marked verbatim sections.
+
+Report laconically: per file, before/after bytes; what classes went; the restore list; anything
+long kept, with its one-line why.

--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -487,6 +487,7 @@ jobs:
       if: matrix.target == 'linux'
       run: |
         set -eux
+        python3 ci/test_fix_md_ascii.py
         python3 ci/fix_md_ascii.py --check
 
     - name: "Test watchdog tray wording (python)"

--- a/ci/fix_md_ascii.py
+++ b/ci/fix_md_ascii.py
@@ -85,7 +85,18 @@ def read_repaired(path: Path):
         return raw.decode("utf-8"), False
     except UnicodeDecodeError:
         pass
-    text = raw.decode("cp1252", errors="replace")
+    # Preserve valid UTF-8 runs and decode only invalid bytes as CP-1252. Treating
+    # the whole file as CP-1252 corrupts mixed files: an isolated legacy byte can
+    # otherwise turn every valid UTF-8 punctuation sequence into mojibake.
+    mixed = raw.decode("utf-8", errors="surrogateescape")
+    repaired = []
+    for ch in mixed:
+        code = ord(ch)
+        if 0xDC80 <= code <= 0xDCFF:
+            repaired.append(bytes((code - 0xDC00,)).decode("cp1252", errors="replace"))
+        else:
+            repaired.append(ch)
+    text = "".join(repaired)
     for _ in range(3):  # collapse double-encoded runs until stable
         try:
             text2 = text.encode("cp1252").decode("utf-8")

--- a/ci/test_fix_md_ascii.py
+++ b/ci/test_fix_md_ascii.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import tempfile
+import unittest
+from pathlib import Path
+
+import fix_md_ascii
+
+
+class MarkdownAsciiTest(unittest.TestCase):
+    def test_mixed_utf8_and_cp1252_are_repaired_without_mojibake(self):
+        raw = (
+            b"UTF-8 dash \xe2\x80\x94 CP-1252 dash \x97 "
+            b"UTF-8 arrow \xe2\x86\x92 table\n"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "mixed.md"
+            path.write_bytes(raw)
+
+            repaired, was_broken = fix_md_ascii.read_repaired(path)
+
+        self.assertTrue(was_broken)
+        self.assertEqual(
+            repaired,
+            "UTF-8 dash \N{EM DASH} CP-1252 dash \N{EM DASH} "
+            "UTF-8 arrow \N{RIGHTWARDS ARROW} table\n",
+        )
+        fixed, residual = fix_md_ascii.transliterate(repaired)
+        self.assertEqual(residual, set())
+        self.assertEqual(
+            fixed,
+            "UTF-8 dash - CP-1252 dash - UTF-8 arrow -> table\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore the Spartan prose-trimming agent accidentally emptied in PR #3834
- keep its restored wording ASCII with natural punctuation
- preserve valid UTF-8 runs when a Markdown file also contains isolated CP-1252 bytes
- add the mixed-encoding regression test to the existing Markdown ASCII CI gate

The original failure shape mixed valid UTF-8 em-dash/arrow sequences with one raw CP-1252 0x97 dash. The old fallback decoded the entire file as CP-1252 after that single invalid byte, turning otherwise-valid UTF-8 punctuation into mojibake. The repaired decoder applies CP-1252 only to bytes rejected by UTF-8.

The PR #3834 deletion audit found no other emptied pre-existing file or deleted path. Its two other removal-only changes were the intentional DAS_SLOW_CALL_INTEROP removals from the two das_config.h copies.

## Tests

- python -B ci/test_fix_md_ascii.py
- python -B ci/fix_md_ascii.py --check
- git diff --check origin/master...HEAD