### PR TITLE
deploy: stage benchmarks.html (page 404 after #3841)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -393,6 +393,7 @@ jobs:
         cp site/examples.html _site/
         cp site/dasllama.html _site/
         cp site/performance.html _site/
+        cp site/benchmarks.html _site/
         cp site/robots.txt _site/
         cp site/sitemap.xml _site/
         cp site/google2cfdec88941bbdfc.html _site/   # Search Console ownership token — must stay deployed

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -3,6 +3,7 @@
      both are referenced from robots.txt. -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url><loc>https://daslang.io/</loc></url>
+    <url><loc>https://daslang.io/benchmarks.html</loc></url>
     <url><loc>https://daslang.io/performance.html</loc></url>
     <url><loc>https://daslang.io/dasllama.html</loc></url>
     <url><loc>https://daslang.io/daspkg.html</loc></url>


### PR DESCRIPTION
pages.yml's staging step copies an explicit page list - benchmarks.html was never added, so the deploy went green while the page 404s. One cp line + the sitemap entry. The fresh dasProfile cards are already live (the records vendor step is a glob); this unblocks the page itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
