### PR TITLE
Fix const initializer mismatch folding crash

### DIFF
--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -561,7 +561,15 @@ namespace das {
         if ( expr->rtti_isVar() ) { // global variable which happens to be constant
             auto var = static_cast<ExprVar *>(expr);
             auto variable = var->variable;
-            if ( variable && variable->init && variable->type->isConst() && variable->type->isFoldable() ) {
+            // A failed declaration can leave the declared type and initializer type
+            // mismatched while inference continues to collect diagnostics.  Do not
+            // substitute that initializer as the value of the declared type: an int
+            // initializer cloned into a string expression, for example, would make
+            // infer-time string folding interpret the integer bits as a pointer.
+            const bool matchingInitType = variable && variable->init && variable->init->type
+                && variable->type->isSameType(*variable->init->type,
+                    RefMatters::no, ConstMatters::no, TemporaryMatters::no);
+            if ( matchingInitType && variable->type->isConst() && variable->type->isFoldable() ) {
                 if ( /*!var->local &&*/ // this is an interesting question. should we allow local const to be folded?
                     !var->argument &&
                     !var->block ) {

--- a/tests/language/failed_const_init_type_folding.das
+++ b/tests/language/failed_const_init_type_folding.das
@@ -1,0 +1,9 @@
+// A mismatched const initializer must not be substituted into expressions as
+// though it had the declared type while the compiler is collecting errors.
+options gen2
+expect 30344
+
+def f {
+    let x : string = 2
+    var z = x + x
+}


### PR DESCRIPTION
## Summary

- prevent infer-time constant substitution when a variable's declared type does not match its initializer type
- keep compilation in diagnostic recovery instead of evaluating mismatched bits as the declared representation
- add a regression for `let x : string = 2; var z = x + x`

## Root cause

After reporting the invalid initializer, inference continued to collect diagnostics. Constant propagation treated `x` as a foldable string based on its declared type, but cloned its integer initializer. String `+` folding then interpreted integer value `2` as a string pointer and crashed in `strlen`.

## Verification

- exact reproducer now exits with diagnostic 30344 instead of an access violation
- focused failure and constant-folding suite: 58 tests passed
- independent TDD audit: no blocking findings; six nearby mismatch variants all exited with diagnostic 30344 without crashing
- Release `daslang` target built successfully