### PR TITLE
performance.html: the code card gets its playground button

### DIFF
--- a/site/performance.html
+++ b/site/performance.html
@@ -188,7 +188,8 @@
                     <div class="forge-terminal__dots"><span class="forge-terminal__dot forge-terminal__dot--red"></span><span class="forge-terminal__dot forge-terminal__dot--amber"></span><span class="forge-terminal__dot forge-terminal__dot--green"></span></div>
                     <div class="forge-terminal__label">query.das</div>
                 </div>
-                <pre class="forge-hero__code" style="display:block"><code class="language-daslang">require daslib/linq_boost
+                <pre class="forge-hero__code" style="display:block"><code class="language-daslang">options gen2
+require daslib/linq_boost
 
 struct Car {
     brand : string
@@ -225,7 +226,7 @@ def main {
                         <div class="ok" id="pf-hero-foot">  ✓ same chain, engine or container · measured 2026-08-22</div>
                     </div>
                     <div class="forge-bench__playground-link">
-                        <a href="/playground/?example=linq_cars">try <span class="forge-bench__playground-test">query.das</span> on the playground →</a>
+                        <a href="/playground/?example=linq_cars">try <span class="forge-bench__playground-test">this query</span> on the playground →</a>
                     </div>
                 </div>
             </div>

--- a/site/performance.html
+++ b/site/performance.html
@@ -224,6 +224,9 @@ def main {
                         <div><span class="metric">sqlite&nbsp;</span> <span class="amber" id="pf-hero-sql">291.1 ns/op</span> <span class="dim" id="pf-hero-sql-i">· interp 289.8</span></div>
                         <div class="ok" id="pf-hero-foot">  ✓ same chain, engine or container · measured 2026-08-22</div>
                     </div>
+                    <div class="forge-bench__playground-link">
+                        <a href="/playground/?example=linq_cars">try <span class="forge-bench__playground-test">query.das</span> on the playground →</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/site/tests/playground/linq-sample.spec.js
+++ b/site/tests/playground/linq-sample.spec.js
@@ -1,18 +1,18 @@
 // The "Linq: group by + average" sample — the code card on performance.html,
-// deep-linked from its "try query.das on the playground" button as
-// ?example=linq_cars. The loading half (slug resolves, the sample lands in
-// the editor) runs in any tier; the run half is @wasm.
+// deep-linked from its "try this query on the playground" button as
+// ?example=linq_cars. The run half is tagged @wasm so the no-WASM CI gate
+// skips it.
 
 const { test, expect } = require('./fixtures.js');
 
-async function waitReady(page) {
+async function waitSamplesReady(page) {
     await page.waitForFunction(() => !!window.pgState, null, { timeout: 10_000 });
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 15_000 });
 }
 
 test('linq_cars deep-link loads the sample into the editor', async ({ playground }) => {
     await playground.goto('/playground/?example=linq_cars');
-    await waitReady(playground);
+    await waitSamplesReady(playground);
     await expect.poll(
         () => playground.evaluate(() => window.pgState.files['main.das'].getValue()),
         { timeout: 10_000 }
@@ -23,7 +23,7 @@ test('linq_cars deep-link loads the sample into the editor', async ({ playground
 
 test('linq_cars sample runs successfully under WASM @wasm', async ({ playground }) => {
     await playground.goto('/playground/?example=linq_cars');
-    await waitReady(playground);
+    await waitSamplesReady(playground);
     await playground.waitForFunction(
         () => !!(window.PlaygroundRunner && window.PlaygroundRunner.isReady()),
         null,
@@ -36,9 +36,15 @@ test('linq_cars sample runs successfully under WASM @wasm', async ({ playground 
         .toBeVisible({ timeout: 15_000 });
 });
 
-test('performance.html hero links the sample to the playground', async ({ page }) => {
+test('performance.html hero links the sample and shows its exact program', async ({ page }) => {
     await page.goto('/performance.html');
     const link = page.locator('.forge-terminal .forge-bench__playground-link a');
     await expect(link).toHaveAttribute('href', '/playground/?example=linq_cars');
     await expect(link).toContainText('on the playground');
+    // The card IS the sample — the site rule ("every code sample is a full
+    // program, linked to the playground") checked, not described.
+    const card = await page.locator('.forge-hero__code code').textContent();
+    const sample = await page.evaluate(() =>
+        fetch('/playground/samples/examples/linq_cars.das').then(r => r.text()));
+    expect(sample.replace(/\r\n/g, '\n').trim()).toBe(card.replace(/\r\n/g, '\n').trim());
 });

--- a/site/tests/playground/linq-sample.spec.js
+++ b/site/tests/playground/linq-sample.spec.js
@@ -1,0 +1,44 @@
+// The "Linq: group by + average" sample — the code card on performance.html,
+// deep-linked from its "try query.das on the playground" button as
+// ?example=linq_cars. The loading half (slug resolves, the sample lands in
+// the editor) runs in any tier; the run half is @wasm.
+
+const { test, expect } = require('./fixtures.js');
+
+async function waitReady(page) {
+    await page.waitForFunction(() => !!window.pgState, null, { timeout: 10_000 });
+    await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 15_000 });
+}
+
+test('linq_cars deep-link loads the sample into the editor', async ({ playground }) => {
+    await playground.goto('/playground/?example=linq_cars');
+    await waitReady(playground);
+    await expect.poll(
+        () => playground.evaluate(() => window.pgState.files['main.das'].getValue()),
+        { timeout: 10_000 }
+    ).toContain('require daslib/linq_boost');
+    const text = await playground.evaluate(() => window.pgState.files['main.das'].getValue());
+    expect(text).toContain('_group_by(_.brand)');
+});
+
+test('linq_cars sample runs successfully under WASM @wasm', async ({ playground }) => {
+    await playground.goto('/playground/?example=linq_cars');
+    await waitReady(playground);
+    await playground.waitForFunction(
+        () => !!(window.PlaygroundRunner && window.PlaygroundRunner.isReady()),
+        null,
+        { timeout: 30_000 }
+    );
+    await playground.locator('#run').click();
+    await expect(playground.locator('.output_line_text', { hasText: 'Ka: avg 900' }))
+        .toBeVisible({ timeout: 15_000 });
+    await expect(playground.locator('.output_line_text', { hasText: 'Vaz: avg 1200' }))
+        .toBeVisible({ timeout: 15_000 });
+});
+
+test('performance.html hero links the sample to the playground', async ({ page }) => {
+    await page.goto('/performance.html');
+    const link = page.locator('.forge-terminal .forge-bench__playground-link a');
+    await expect(link).toHaveAttribute('href', '/playground/?example=linq_cars');
+    await expect(link).toContainText('on the playground');
+});

--- a/web/examples/ui/samples/data.json
+++ b/web/examples/ui/samples/data.json
@@ -108,6 +108,10 @@
       "files" : ["examples/tests.das"]
     },
     {
+      "name" : "Linq: group by + average",
+      "files" : ["examples/linq_cars.das"]
+    },
+    {
       "name" : "Dictionary (benchmark)",
       "files" : ["examples/dict.das"]
     },

--- a/web/examples/ui/samples/examples/linq_cars.das
+++ b/web/examples/ui/samples/examples/linq_cars.das
@@ -1,0 +1,21 @@
+require daslib/linq_boost
+
+struct Car {
+    brand : string
+    price : float
+}
+
+[export]
+def main {
+    var cars <- [Car(brand = "Ka", price = 900.0),
+                 Car(brand = "Vaz", price = 1200.0)]
+    let stats <- _fold(each(cars)
+        ._group_by(_.brand)
+        ._select((Brand = _._0,
+                  Avg = _._1 |> select($(c : Car) => c.price)
+                             |> average()))
+        .to_array())
+    for (s in stats) {
+        print("{s.Brand}: avg {s.Avg}\n")
+    }
+}

--- a/web/examples/ui/samples/examples/linq_cars.das
+++ b/web/examples/ui/samples/examples/linq_cars.das
@@ -1,3 +1,4 @@
+options gen2
 require daslib/linq_boost
 
 struct Car {


### PR DESCRIPTION
The code card on `/performance.html` had no "try it on playground" link, and nothing verified that its program runs. The site rule says every code sample is a full program, verified to compile and run, and linked to the playground. Now the card's program ships as a real playground sample ("Linq: group by + average", slug `linq_cars`), the card links it with the same footer the front page uses, and a spec asserts the card and the served sample are byte-identical - so the rule is tested, not described. The card gains one line, `options gen2`, to match the sample convention.

Where to look: `site/performance.html` (the card + link), `web/examples/ui/samples/` (the sample + its `data.json` entry), `site/tests/playground/linq-sample.spec.js` (deep-link load, `@wasm` run with the exact card output, card-sample parity).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- WASM-staged Playwright suite (local-only gate, no per-PR wasm lane), deployed daslang.io runtime, CI worker count: 60 passed, 5 failed - all five pre-existing. `audio.spec.js:100` was red in #3714's own stated run. `runtime-revive.spec.js` (3) + `shared-module.spec.js:34` fail identically against live daslang.io with zero local changes (control run); their final phase expects the default sample to print `Hello World`, but the default sample has been the GL triangle since June.
- Native control: `bin/daslang` prints exactly the card output (`Ka: avg 900` / `Vaz: avg 1200`); the new `@wasm` spec prints the same in the playground.

### Not done
- The four broken revive/shared-module specs are not fixed here - follow-up.
- `web/examples/ui/samples/examples/` has no `.lint_config`, and the comment-hygiene skill does not state the no-config default for teaching folders - deferred to the hygiene-tuning session.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
