### PR TITLE
standalone aot: stack and heap options honored; [no_aot] is an emit error

### DIFF
--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -246,7 +246,10 @@ an entry lands here only when no name, shape, or test can carry it.
   `__init_shared` is hardcoded `true` (a fresh standalone context always owns its
   shared globals), there is no separate init stack (init locals are C++ locals in AOT;
   instead the ctor's base `Context(N)` folds the init headroom in: N =
-  `max(options stack, 16384) + globalInitStackSize`, so an `invoke` during init still
+  `max(options stack, 16384) + globalInitStackSize`, mirroring the interpreter's
+  init-stack formula in `src/ast/ast_simulate.cpp` - a pair; `globalInitStackSize`
+  reaches the emitter through the rtti `Program` binding in
+  `src/builtin/module_builtin_rtti.cpp` - so an `invoke` during init still
   has das stack to push a prologue onto), and there is no `!stopFlags` guard between
   `[init]` calls (a panic propagates out of the ctor instead of soft-stopping the
   sequence).
@@ -259,8 +262,9 @@ an entry lands here only when no name, shape, or test can carry it.
   simulated context's list through rtti `for_each_init_function`, so the C++ late-init
   sort stays the single source of truth.
 - **Cross-module limits fail loud at emit time**: only main-module, AOT-emitted `[init]`
-  functions can be called from the ctor (required-module and `[no_aot]` ones panic with
-  the reason), because the standalone TU only emits the entry module's function bodies.
+  functions can be called from the ctor (required-module and `[no_aot]` ones are collected
+  emit errors with the reason), because the standalone TU only emits the entry module's
+  function bodies.
 - **Every used function must have an AOT body** - a standalone context has no
   interpreter, so a used `noAot` function (the `[no_aot]` annotation, or `NoAotMarker`
   finding a type AOT cannot express) is a collected emit error, never a

--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -244,9 +244,12 @@ an entry lands here only when no name, shape, or test can carry it.
   (signature written by `aot_cpp.das`'s `preVisitGlobalLet` - a daslib-to-daslib pairing,
   nothing checks agreement), then each `[init]` function directly. Deliberate divergences:
   `__init_shared` is hardcoded `true` (a fresh standalone context always owns its
-  shared globals), there is no `globalInitStackSize` stack push (init locals are C++
-  locals in AOT), and there is no `!stopFlags` guard between `[init]` calls (a panic
-  propagates out of the ctor instead of soft-stopping the sequence).
+  shared globals), there is no separate init stack (init locals are C++ locals in AOT;
+  instead the ctor's base `Context(N)` folds the init headroom in: N =
+  `max(options stack, 16384) + globalInitStackSize`, so an `invoke` during init still
+  has das stack to push a prologue onto), and there is no `!stopFlags` guard between
+  `[init]` calls (a panic propagates out of the ctor instead of soft-stopping the
+  sequence).
 - **Global init order is a pact with the allocator**: `StandaloneContextGen`'s
   `preVisitGlobalLet` emits required modules' globals via ordered `for_each_module`
   before the adapter walks the entry module's own - correct only because

--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -261,6 +261,12 @@ an entry lands here only when no name, shape, or test can carry it.
 - **Cross-module limits fail loud at emit time**: only main-module, AOT-emitted `[init]`
   functions can be called from the ctor (required-module and `[no_aot]` ones panic with
   the reason), because the standalone TU only emits the entry module's function bodies.
+- **Every used function must have an AOT body** - a standalone context has no
+  interpreter, so a used `noAot` function (the `[no_aot]` annotation, or `NoAotMarker`
+  finding a type AOT cannot express) is a collected emit error, never a
+  `fnByMangledName` call that would crash at runtime. `prepareProgramForEmission` runs
+  `NoAotMarker` first (the regular AOT paths run it too; standalone must match) and
+  then `checkAllUsedFunctionsCanAot` walks used, non-builtin functions.
 - **Type definitions live in the header, once** - struct/enum definitions (the
   dependency dump plus the entry module's own `declarations` capture) are emitted into
   the `.das.h`, which the `.das.cpp` includes; the source never redefines them. They sit

--- a/daslib/REVIEW.md
+++ b/daslib/REVIEW.md
@@ -94,15 +94,16 @@ growing either overload set without the cap is a silently missed finding, the re
 suggestion that does not compile.
 
 **A diff that adds or changes an emit entry point - a function that runs the emit visitor
-(`CppAot` or its subclass `StandaloneContextGen`, the visitors that write C++) and then
+(`CppAot` or any subclass of it - the visitors that write C++) and then
 returns or writes the generated C++ - keeps the error check ahead of that return
-or write.** The error check is the program's `macroException`/`failToCompile` state, or
-`log_aot_emit_errors` where the emit runs standalone; a codegen exception mid-visit
-leaves partial C++.
+or write.** The error check is the program's `macroException`/`failToCompile` state, read
+directly or through `log_aot_emit_errors`; a codegen exception mid-visit leaves partial
+C++.
 
-**A visitor override in the emit visitor never gates on `macroException`/`failToCompile`.**
-The entry point owns that check; an override that returns early on the error state emits
-truncated C++ that the entry point still writes out as complete.
+**A visitor override in `CppAot` or any subclass of it never gates on
+`macroException`/`failToCompile`.** The function that runs the visitor owns that check; an
+override that returns early on the error state emits truncated C++ that the caller still
+writes out as complete.
 
 **An unreachable emit state writes `#error` into the output, never `panic`** -
 `runMacroFunction` swallows a panic, so the emitter never reports through it.
@@ -114,11 +115,10 @@ spell it are `aotStructName` and the `VarInfo` emitter's inline
 `aotSuffixNameEx(info.name, "_S", ...)`. One site changed alone writes `offsetof`s that
 name a struct declared under a different name.
 
-**A diff that adds or changes a function that runs the emit visitor keeps
-`buildStructEnumCollisions` running before that visitor runs.** It may run in a helper
-(`dumpDependencies` seeds it today): the table decides when a name gets its collision
-suffix, and a run that skips the seeding spells structs differently from the one that
-seeded it.
+**A diff that adds or changes a function that runs `CppAot` or any subclass of it
+keeps `buildStructEnumCollisions` running before that visitor runs - directly or in a
+helper it calls.** The table decides when a name gets its collision suffix, and a run
+that skips the seeding spells structs differently from the run that seeded it.
 
 **`match_error` stores a BORROWED `LineInfo` pointer - pass a pattern node's location,
 never a synthesized access expression's.** Access nodes are cloned per field inside a bare

--- a/daslib/REVIEW.md
+++ b/daslib/REVIEW.md
@@ -94,7 +94,8 @@ growing either overload set without the cap is a silently missed finding, the re
 suggestion that does not compile.
 
 **A diff that adds or changes an emit entry point - a function that runs the emit visitor
-and then returns or writes the generated C++ - keeps the error check ahead of that return
+(`CppAot` or its subclass `StandaloneContextGen`, the visitors that write C++) and then
+returns or writes the generated C++ - keeps the error check ahead of that return
 or write.** The error check is the program's `macroException`/`failToCompile` state, or
 `log_aot_emit_errors` where the emit runs standalone; a codegen exception mid-visit
 leaves partial C++.
@@ -113,10 +114,10 @@ spell it are `aotStructName` and the `VarInfo` emitter's inline
 `aotSuffixNameEx(info.name, "_S", ...)`. One site changed alone writes `offsetof`s that
 name a struct declared under a different name.
 
-**A diff that adds or changes a function that runs the emit visitor calls
-`buildStructEnumCollisions` before that visitor runs.** The duty sits on that function,
-not on each helper it calls to spell a name: the table decides when a name gets its
-collision suffix, and a run that skips it spells structs differently from the one that
+**A diff that adds or changes a function that runs the emit visitor keeps
+`buildStructEnumCollisions` running before that visitor runs.** It may run in a helper
+(`dumpDependencies` seeds it today): the table decides when a name gets its collision
+suffix, and a run that skips the seeding spells structs differently from the one that
 seeded it.
 
 **`match_error` stores a BORROWED `LineInfo` pointer - pass a pattern node's location,

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -558,6 +558,8 @@ def expectsLocalTemp(expr : ExprMakeLocal?) : bool {
 
 class public NoAotMarker : AstVisitor {
     //! AST visitor that marks functions containing non-AOT-compatible types as noAot.
+    //! Run it before anything reads `flags.noAot`. It also mutates the AST: `invoke` of a
+    //! block literal gets `aotSkipMakeBlock`, and a surviving `quote()` logs an error.
     @do_not_delete func : Function? <- null;
 
     def override preVisitTypeDecl(typeDecl : TypeDeclPtr) {

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -556,7 +556,7 @@ def expectsLocalTemp(expr : ExprMakeLocal?) : bool {
     return false
 }
 
-class NoAotMarker : AstVisitor {
+class public NoAotMarker : AstVisitor {
     //! AST visitor that marks functions containing non-AOT-compatible types as noAot.
     @do_not_delete func : Function? <- null;
 

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -122,15 +122,18 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
         });
     }
 
+    let min_init_stack = 16384
     let stack_opt = program._options |> find_arg("stack") ?as tInt ?? int(program.policies.stack)
-    let stack_size = max(stack_opt, 16384) + int(program.globalInitStackSize)
+    let stack_size = max(stack_opt, min_init_stack) + int(program.globalInitStackSize)
     write(tw, "{cfg.class_name}::{cfg.class_name}() : Context({stack_size}/*stack*/) \{\n");
     write(tw, "    auto & context = *this;\n");
     write(tw, "    CodeOfPolicies policies;");
     write(tw, "    policies.debugger = {program.policies.debugger} /*policies.debugger*/;\n");
     write(tw, "    policies.persistent_heap = {program._options |> find_arg("persistent_heap") ?as tBool ?? program.policies.persistent_heap};\n");
-    write(tw, "    policies.heap_size_hint = {program._options |> find_arg("heap_size_hint") ?as tInt ?? int(program.policies.heap_size_hint)};\n");
-    write(tw, "    policies.string_heap_size_hint = {program._options |> find_arg("string_heap_size_hint") ?as tInt ?? int(program.policies.string_heap_size_hint)};\n");
+    let heap_hint = uint(program._options |> find_arg("heap_size_hint") ?as tInt ?? int(program.policies.heap_size_hint))
+    let string_heap_hint = uint(program._options |> find_arg("string_heap_size_hint") ?as tInt ?? int(program.policies.string_heap_size_hint))
+    write(tw, "    policies.heap_size_hint = {heap_hint:d};\n");
+    write(tw, "    policies.string_heap_size_hint = {string_heap_hint:d};\n");
     write(tw, "    policies.track_allocations = {program._options |> find_arg("track_allocations") ?as tBool ?? program.policies.track_allocations};\n");
     write(tw, "    context.setup({program.totalVariables}/*totalVariables*/, {program.globalStringHeapSize:d} /*globalStringHeapSize*/, policies, \{\});\n");
 
@@ -360,6 +363,15 @@ def genStandaloneSrc(var program : ProgramPtr;
     return initFunctions
 }
 
+def private isMarkedNoAot(pfun : Function?) : bool {
+    for (ann in pfun.annotations) {
+        if (ann.annotation.name == "no_aot") {
+            return true
+        }
+    }
+    return false
+}
+
 def private checkAllUsedFunctionsCanAot(program : ProgramPtr) {
     program.get_ptr() |> for_each_module_no_order($(pm) {
         pm |> for_each_module_function($(pfun) {
@@ -367,16 +379,20 @@ def private checkAllUsedFunctionsCanAot(program : ProgramPtr) {
                 return
             }
             if (pfun.flags.noAot) {
-                macro_error(program, pfun.at, "standalone AOT cannot emit function {pfun.name}: it needs the interpreter ([no_aot], or a type AOT cannot express), and a standalone context has none")
+                if (isMarkedNoAot(pfun)) {
+                    macro_error(program, pfun.at, "standalone AOT cannot emit function {pfun.name}: it is [no_aot], and a standalone context has no interpreter")
+                } else {
+                    macro_error(program, pfun.at, "standalone AOT cannot emit function {pfun.name}: it uses a type AOT cannot express, and a standalone context has no interpreter")
+                }
             }
         });
     });
 }
 
 def private prepareProgramForEmission(var program : ProgramPtr; context : Context) : BlockVariableCollector? {
-    var marker = new NoAotMarker();
-    make_visitor(*marker) $(adapter_marker) {
-        visit(program, adapter_marker)
+    var noAotMarker = new NoAotMarker();
+    make_visitor(*noAotMarker) $(adapter_no_aot) {
+        visit(program, adapter_no_aot)
     }
     checkAllUsedFunctionsCanAot(program)
 
@@ -394,7 +410,7 @@ def private prepareProgramForEmission(var program : ProgramPtr; context : Contex
     unsafe {
         delete flags
         delete pmarker
-        delete marker
+        delete noAotMarker
     }
 
     var coll = new BlockVariableCollector();

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -4,6 +4,7 @@ module aot_standalone private
 require daslib/fio
 require daslib/rtti
 require strings
+require math
 
 require daslib/match
 require daslib/strings_boost
@@ -121,13 +122,15 @@ def writeStandaloneCtor(cfg : StandaloneContextCfg; initFunctions : string; var 
         });
     }
 
-    write(tw, "{cfg.class_name}::{cfg.class_name}() \{\n");
+    let stack_opt = program._options |> find_arg("stack") ?as tInt ?? int(program.policies.stack)
+    let stack_size = max(stack_opt, 16384) + int(program.globalInitStackSize)
+    write(tw, "{cfg.class_name}::{cfg.class_name}() : Context({stack_size}/*stack*/) \{\n");
     write(tw, "    auto & context = *this;\n");
     write(tw, "    CodeOfPolicies policies;");
     write(tw, "    policies.debugger = {program.policies.debugger} /*policies.debugger*/;\n");
     write(tw, "    policies.persistent_heap = {program._options |> find_arg("persistent_heap") ?as tBool ?? program.policies.persistent_heap};\n");
-    write(tw, "    policies.heap_size_hint = {program._options |> find_arg("heap_size_hint") ?as tUInt ?? program.policies.heap_size_hint :d};\n");
-    write(tw, "    policies.string_heap_size_hint = {program._options |> find_arg("string_heap_size_hint") ?as tUInt ?? program.policies.string_heap_size_hint :d};\n");
+    write(tw, "    policies.heap_size_hint = {program._options |> find_arg("heap_size_hint") ?as tInt ?? int(program.policies.heap_size_hint)};\n");
+    write(tw, "    policies.string_heap_size_hint = {program._options |> find_arg("string_heap_size_hint") ?as tInt ?? int(program.policies.string_heap_size_hint)};\n");
     write(tw, "    policies.track_allocations = {program._options |> find_arg("track_allocations") ?as tBool ?? program.policies.track_allocations};\n");
     write(tw, "    context.setup({program.totalVariables}/*totalVariables*/, {program.globalStringHeapSize:d} /*globalStringHeapSize*/, policies, \{\});\n");
 

--- a/daslib/aot_standalone.das
+++ b/daslib/aot_standalone.das
@@ -360,7 +360,26 @@ def genStandaloneSrc(var program : ProgramPtr;
     return initFunctions
 }
 
+def private checkAllUsedFunctionsCanAot(program : ProgramPtr) {
+    program.get_ptr() |> for_each_module_no_order($(pm) {
+        pm |> for_each_module_function($(pfun) {
+            if (pfun.index < 0 || !pfun.flags.used || pfun.flags.builtIn) {
+                return
+            }
+            if (pfun.flags.noAot) {
+                macro_error(program, pfun.at, "standalone AOT cannot emit function {pfun.name}: it needs the interpreter ([no_aot], or a type AOT cannot express), and a standalone context has none")
+            }
+        });
+    });
+}
+
 def private prepareProgramForEmission(var program : ProgramPtr; context : Context) : BlockVariableCollector? {
+    var marker = new NoAotMarker();
+    make_visitor(*marker) $(adapter_marker) {
+        visit(program, adapter_marker)
+    }
+    checkAllUsedFunctionsCanAot(program)
+
     var pmarker = new PrologueMarker();
     make_visitor(*pmarker) $(adapter_p) {
         visit(program, adapter_p)
@@ -375,6 +394,7 @@ def private prepareProgramForEmission(var program : ProgramPtr; context : Contex
     unsafe {
         delete flags
         delete pmarker
+        delete marker
     }
 
     var coll = new BlockVariableCollector();

--- a/doc/source/stdlib/handmade/structure_annotation-rtti-Program.rst
+++ b/doc/source/stdlib/handmade/structure_annotation-rtti-Program.rst
@@ -4,6 +4,7 @@ module name
 total number of functions in the program
 total number of variables in the program
 compilation errors and exceptions
+stack size the global init script needs
 size of the global string heap
 whether a visitor walks builtin functions too
 initial semantic hash with dependencies

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -540,6 +540,7 @@ namespace das {
             addField<DAS_BIND_MANAGED_FIELD(totalFunctions)>("totalFunctions");
             addField<DAS_BIND_MANAGED_FIELD(totalVariables)>("totalVariables");
             addField<DAS_BIND_MANAGED_FIELD(globalStringHeapSize)>("globalStringHeapSize");
+            addField<DAS_BIND_MANAGED_FIELD(globalInitStackSize)>("globalInitStackSize");
             addField<DAS_BIND_MANAGED_FIELD(initSemanticHashWithDep)>("initSemanticHashWithDep");
             addField<DAS_BIND_MANAGED_FIELD(visitBuiltinFunctions)>("visitBuiltinFunctions");
             addFieldEx ( "flags", "flags", offsetof(Program, flags), makeProgramFlags() );

--- a/tests-cpp/REVIEW.md
+++ b/tests-cpp/REVIEW.md
@@ -6,7 +6,5 @@ doc: `skills/internal/writing_cpp_tests.md` (repo root).
 **A `*_pin.cpp` file, wherever the diff puts it, answers to the `small/` subfolder's
 checklist.**
 
-**A diff that touches a `big/<name>/` test states its local run result.** CI runs only the
-small suite, so a big test proves itself only on the author's machine. The PR says that
-`ctest -L big` (or the affected test binary) ran and passed; without that line the reviewer
-treats the test as never executed.
+**A test that builds its own executable from its own `CMakeLists.txt`, wherever the diff
+puts it, answers to the `big/` subfolder's checklist.**

--- a/tests-cpp/REVIEW.md
+++ b/tests-cpp/REVIEW.md
@@ -5,3 +5,8 @@ doc: `skills/internal/writing_cpp_tests.md` (repo root).
 
 **A `*_pin.cpp` file, wherever the diff puts it, answers to the `small/` subfolder's
 checklist.**
+
+**A diff that touches a `big/<name>/` test states its local run result.** CI runs only the
+small suite, so a big test proves itself only on the author's machine. The PR says that
+`ctest -L big` (or the affected test binary) ran and passed; without that line the reviewer
+treats the test as never executed.

--- a/tests-cpp/big/REVIEW.md
+++ b/tests-cpp/big/REVIEW.md
@@ -1,0 +1,8 @@
+# tests-cpp/big Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
+doc: `skills/internal/writing_cpp_tests.md` (repo root).
+
+**A diff that touches a test under this folder says in the PR that the test ran and passed
+on the author's machine, naming the command - `ctest -L big` or the test's own binary.** CI
+runs only the small suite, so nothing else proves a big test.

--- a/tests-cpp/big/standalone_ctx/standalone_init_fixture.das
+++ b/tests-cpp/big/standalone_ctx/standalone_init_fixture.das
@@ -1,4 +1,5 @@
 options gen2
+options stack = 262144
 
 require standalone_init_dep
 

--- a/tests-cpp/big/standalone_ctx/standalone_init_fixture.das
+++ b/tests-cpp/big/standalone_ctx/standalone_init_fixture.das
@@ -74,3 +74,34 @@ def pair_sum(p : Pair) : int {
 def flip(m : Mode) : Mode {
     return m == Mode.on ? Mode.off : Mode.on
 }
+
+[export]
+def apply_lambda(x : int) : int {
+    let add3 = @(v : int) : int => v + 3
+    return invoke(add3, invoke(add3, x))
+}
+
+def local_double(x : int) : int {
+    return x + x
+}
+
+[export]
+def call_through_pointer(x : int) : int {
+    let fp = @@local_double
+    return invoke(fp, x)
+}
+
+[export]
+def sum_generator(n : int) : int {
+    var gen <- generator<int> {
+        for (i in range(n)) {
+            yield i
+        }
+        return false
+    }
+    var s = 0
+    for (v in gen) {
+        s += v
+    }
+    return s
+}

--- a/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
+++ b/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
@@ -29,5 +29,8 @@ int main( int, char * [] ) {
     expect("flip(on)", int32_t(ctx.flip(standalone_init_fixture::Mode::on)),
         int32_t(standalone_init_fixture::Mode::off));
     expect("stack.size() honors options stack", ctx.stack.size() >= 262144 ? 1 : 0, 1);
+    expect("apply_lambda(10)", ctx.apply_lambda(10), 16);
+    expect("call_through_pointer(21)", ctx.call_through_pointer(21), 42);
+    expect("sum_generator(5)", ctx.sum_generator(5), 10);
     return failures ? 1 : 0;
 }

--- a/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
+++ b/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
@@ -28,5 +28,6 @@ int main( int, char * [] ) {
     expect("pair_sum(embedder-built Pair)", ctx.pair_sum(embedderPair), 42);
     expect("flip(on)", int32_t(ctx.flip(standalone_init_fixture::Mode::on)),
         int32_t(standalone_init_fixture::Mode::off));
+    expect("stack.size() honors options stack", ctx.stack.size() >= 262144 ? 1 : 0, 1);
     return failures ? 1 : 0;
 }

--- a/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
+++ b/tests-cpp/big/standalone_ctx/test_standalone_ctx.cpp
@@ -28,7 +28,9 @@ int main( int, char * [] ) {
     expect("pair_sum(embedder-built Pair)", ctx.pair_sum(embedderPair), 42);
     expect("flip(on)", int32_t(ctx.flip(standalone_init_fixture::Mode::on)),
         int32_t(standalone_init_fixture::Mode::off));
-    expect("stack.size() honors options stack", ctx.stack.size() >= 262144 ? 1 : 0, 1);
+    constexpr uint32_t kFixtureStackSize = 262144;
+    expect("stack.size() exceeds options stack by the init headroom",
+        ctx.stack.size() > kFixtureStackSize ? 1 : 0, 1);
     expect("apply_lambda(10)", ctx.apply_lambda(10), 16);
     expect("call_through_pointer(21)", ctx.call_through_pointer(21), 42);
     expect("sum_generator(5)", ctx.sum_generator(5), 10);

--- a/tests/aot/_standalone_no_aot_fixture.das
+++ b/tests/aot/_standalone_no_aot_fixture.das
@@ -1,0 +1,11 @@
+options gen2
+
+[no_aot]
+def slow_helper(x : int) : int {
+    return x * 3
+}
+
+[export]
+def use_helper(x : int) : int {
+    return slow_helper(x) + 1
+}

--- a/tests/aot/_standalone_no_aot_fixture.das
+++ b/tests/aot/_standalone_no_aot_fixture.das
@@ -1,11 +1,11 @@
 options gen2
 
 [no_aot]
-def slow_helper(x : int) : int {
+def interpreted_helper(x : int) : int {
     return x * 3
 }
 
 [export]
-def use_helper(x : int) : int {
-    return slow_helper(x) + 1
+def calls_interpreted_helper(x : int) : int {
+    return interpreted_helper(x) + 1
 }

--- a/tests/aot/_standalone_options_fixture.das
+++ b/tests/aot/_standalone_options_fixture.das
@@ -4,6 +4,11 @@ options heap_size_hint = 123456
 options string_heap_size_hint = 234567
 
 [export]
-def stack_probe : int {
+def options_probe : int {
     return 1
+}
+
+[no_aot]
+def unused_interpreted_helper(x : int) : int {
+    return x - 1
 }

--- a/tests/aot/_standalone_small_stack_fixture.das
+++ b/tests/aot/_standalone_small_stack_fixture.das
@@ -1,0 +1,7 @@
+options gen2
+options stack = 4096
+
+[export]
+def small_stack_probe : int {
+    return 1
+}

--- a/tests/aot/_standalone_stack_fixture.das
+++ b/tests/aot/_standalone_stack_fixture.das
@@ -1,0 +1,9 @@
+options gen2
+options stack = 262144
+options heap_size_hint = 123456
+options string_heap_size_hint = 234567
+
+[export]
+def stack_probe : int {
+    return 1
+}

--- a/tests/aot/test_standalone_emit.das
+++ b/tests/aot/test_standalone_emit.das
@@ -20,10 +20,13 @@ def private standalone_cop(var cop : CodeOfPolicies) {
     cop.tune_frozen = true
 }
 
-def private generate_standalone_files(t : T?; fixture, out_dir : string; cross_platform : bool = false) : tuple<header : string; source : string> {
+def private generate_standalone_files(t : T?; fixture, out_dir : string; cross_platform : bool = false; stack_policy : uint = 0u) : tuple<header : string; source : string> {
     let input = path_join(get_das_root(), "tests/aot/{fixture}.das")
     using() $(var cop : CodeOfPolicies) {
         standalone_cop(cop)
+        if (stack_policy != 0u) {
+            cop.stack = stack_policy
+        }
         ast_gc_guard() {
             standalone_aot(input, out_dir, cross_platform, false, cop)
         }
@@ -50,6 +53,20 @@ def private generate_standalone_files(t : T?; fixture, out_dir : string; cross_p
 
 def private generate_standalone_source(t : T?; fixture, out_dir : string) : string {
     return generate_standalone_files(t, fixture, out_dir).source
+}
+
+def private expect_emit_failure(t : T?; fixture, out_dir : string) {
+    let input = path_join(get_das_root(), "tests/aot/{fixture}.das")
+    var ok = true
+    using() $(var cop : CodeOfPolicies) {
+        standalone_cop(cop)
+        ast_gc_guard() {
+            ok = standalone_aot(input, out_dir, false, false, cop)
+        }
+    }
+    t |> success(!ok, "standalone_aot reports failure")
+    let generated = path_join(out_dir, "{fixture}.das.cpp")
+    t |> success(!stat(generated).is_valid, "no output is written on failure")
 }
 
 def private brace_balance(text : string) : int {
@@ -83,11 +100,22 @@ def test_standalone_emit(t : T?) {   // nolint:STYLE038 - flat list of emit subc
     }
 
     t |> run("the context stack and heap hints honor the script's options") @(t : T?) {
-        let source = generate_standalone_source(t, "_standalone_stack_fixture", out_dir)
+        let source = generate_standalone_source(t, "_standalone_options_fixture", out_dir)
         t |> success(find(source, ": Context(262144/*stack*/)") >= 0, "the ctor sizes the stack from options stack")
         t |> success(find(source, "policies.heap_size_hint = 123456;") >= 0, "heap_size_hint comes from the script's options")
         t |> success(find(source, "policies.string_heap_size_hint = 234567;") >= 0, "string_heap_size_hint comes from the script's options")
+        t |> success(find(source, "unused_interpreted_helper") < 0, "an unused [no_aot] function neither blocks emission nor emits")
         t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
+    }
+
+    t |> run("a stack option below the interpreter's floor is raised to it") @(t : T?) {
+        let source = generate_standalone_source(t, "_standalone_small_stack_fixture", out_dir)
+        t |> success(find(source, ": Context(16384/*stack*/)") >= 0, "options stack = 4096 still gets the 16K floor")
+    }
+
+    t |> run("with no stack option the policies' stack size decides") @(t : T?) {
+        let files = generate_standalone_files(t, "_standalone_novars_fixture", out_dir, stack_policy = 32768u)
+        t |> success(find(files.source, ": Context(32768/*stack*/)") >= 0, "the ctor sizes the stack from CodeOfPolicies")
     }
 
     t |> run("forward declarations spell types the way the definitions do") @(t : T?) {
@@ -149,32 +177,12 @@ def test_standalone_emit(t : T?) {   // nolint:STYLE038 - flat list of emit subc
         t |> equal(brace_balance(files.source), 0, "unbalanced braces in the generated C++")
     }
 
-    t |> run("a [no_aot] function is a collected error, not a runtime crash") @(t : T?) {
-        let input = path_join(get_das_root(), "tests/aot/_standalone_no_aot_fixture.das")
-        var ok = true
-        using() $(var cop : CodeOfPolicies) {
-            standalone_cop(cop)
-            ast_gc_guard() {
-                ok = standalone_aot(input, out_dir, false, false, cop)
-            }
-        }
-        t |> success(!ok, "standalone_aot reports failure")
-        let generated = path_join(out_dir, "_standalone_no_aot_fixture.das.cpp")
-        t |> success(!stat(generated).is_valid, "no output is written on failure")
+    t |> run("a used [no_aot] function is a collected error, not a runtime crash") @(t : T?) {
+        expect_emit_failure(t, "_standalone_no_aot_fixture", out_dir)
     }
 
     t |> run("a required module's [init] is a collected error, not a crash") @(t : T?) {
-        let input = path_join(get_das_root(), "tests/aot/_standalone_foreign_init_fixture.das")
-        var ok = true
-        using() $(var cop : CodeOfPolicies) {
-            standalone_cop(cop)
-            ast_gc_guard() {
-                ok = standalone_aot(input, out_dir, false, false, cop)
-            }
-        }
-        t |> success(!ok, "standalone_aot reports failure")
-        let generated = path_join(out_dir, "_standalone_foreign_init_fixture.das.cpp")
-        t |> success(!stat(generated).is_valid, "no output is written on failure")
+        expect_emit_failure(t, "_standalone_foreign_init_fixture", out_dir)
     }
 
     t |> run("before_emit receives the compiled program") @(t : T?) {

--- a/tests/aot/test_standalone_emit.das
+++ b/tests/aot/test_standalone_emit.das
@@ -149,6 +149,20 @@ def test_standalone_emit(t : T?) {   // nolint:STYLE038 - flat list of emit subc
         t |> equal(brace_balance(files.source), 0, "unbalanced braces in the generated C++")
     }
 
+    t |> run("a [no_aot] function is a collected error, not a runtime crash") @(t : T?) {
+        let input = path_join(get_das_root(), "tests/aot/_standalone_no_aot_fixture.das")
+        var ok = true
+        using() $(var cop : CodeOfPolicies) {
+            standalone_cop(cop)
+            ast_gc_guard() {
+                ok = standalone_aot(input, out_dir, false, false, cop)
+            }
+        }
+        t |> success(!ok, "standalone_aot reports failure")
+        let generated = path_join(out_dir, "_standalone_no_aot_fixture.das.cpp")
+        t |> success(!stat(generated).is_valid, "no output is written on failure")
+    }
+
     t |> run("a required module's [init] is a collected error, not a crash") @(t : T?) {
         let input = path_join(get_das_root(), "tests/aot/_standalone_foreign_init_fixture.das")
         var ok = true

--- a/tests/aot/test_standalone_emit.das
+++ b/tests/aot/test_standalone_emit.das
@@ -78,7 +78,15 @@ def test_standalone_emit(t : T?) {   // nolint:STYLE038 - flat list of emit subc
 
     t |> run("a context with no init functions still closes its constructor") @(t : T?) {
         let source = generate_standalone_source(t, "_standalone_novars_fixture", out_dir)
-        t |> success(find(source, "Standalone::Standalone() \{") >= 0, "constructor was emitted")
+        t |> success(find(source, "Standalone::Standalone() : Context(16384/*stack*/) \{") >= 0, "constructor was emitted with the default stack size")
+        t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
+    }
+
+    t |> run("the context stack and heap hints honor the script's options") @(t : T?) {
+        let source = generate_standalone_source(t, "_standalone_stack_fixture", out_dir)
+        t |> success(find(source, ": Context(262144/*stack*/)") >= 0, "the ctor sizes the stack from options stack")
+        t |> success(find(source, "policies.heap_size_hint = 123456;") >= 0, "heap_size_hint comes from the script's options")
+        t |> success(find(source, "policies.string_heap_size_hint = 234567;") >= 0, "string_heap_size_hint comes from the script's options")
         t |> equal(brace_balance(source), 0, "unbalanced braces in the generated C++")
     }
 


### PR DESCRIPTION
**Behavior change for standalone AOT embedders: the generated context now sizes its stack from the script's `options stack`, and the heap hints are honored - regenerate your `.das.h` / `.das.cpp`.**

A standalone context ignored `options stack` (the ctor always got the default 16KB base `Context()`), and `heap_size_hint` / `string_heap_size_hint` were silently dropped - the emitter matched the options as `tUInt`, but int options are stored `tInt`. The generated ctor now passes `max(options stack, 16384) + globalInitStackSize` to the `Context` base, mirroring the interpreter's init-stack formula, so an `invoke` during init still has das stack for its prologue. `Program.globalInitStackSize` is bound into rtti (one line) to feed the emitter.

A used `[no_aot]` function is now a collected emit error instead of a silent `fnByMangledName` call that crashes at runtime - a standalone context has no interpreter to fall back to. `NoAotMarker` now runs on the standalone path too (the regular AOT paths already ran it), so functions forced off AOT by their types get the same error. Lambdas, function pointers through `invoke`, and generators need no special handling - the big C++ test proves them at runtime.

Where to look: `daslib/aot_standalone.das` (`writeStandaloneCtor`, `checkAllUsedFunctionsCanAot`, `prepareProgramForEmission`).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full AOT sweep (nightly-only lane): 12989 tests, 12982 passed, 0 failed, 7 skipped.
- `ctest -L big` ran locally: `standalone_ctx` passed (with the new lambda / function-pointer / generator / stack asserts); `concurrent_init`, `concurrent_init_dyn`, `memory_model_4gb` passed. The two `style_lint` ctest rows fail pre-existing on master too: the lint runner SKIPs its own rule fixture, so the expected STYLE014 output never prints.
- Dir-scoped `test_aot` runs of `tests/gc` and `tests/flatten` fail on clean master exactly as on this branch (a scoping artifact - false reds); the full sweep is green on both. Worth a look as a test-infra defect.
- External codex round at the audit-batch tip: no findings.

### Claims - stated, not tested
- `NoAotMarker`'s type-forced arm has no fixture: types with `canAot == false` live in modules the standalone entry gate already rejects as no-AOT modules. A break would look like a used function with a non-AOT type emitting a `fnByMangledName` call into a context with no interpreter.
- The `set_aot_main_module_name("")` reset and the `pfun.index < 0` / `builtIn` guard terms in the new check stay untested (defensive; no in-repo driver observes them).

### Not done
- Two different contexts' headers sharing a das dependency still cannot be included in one TU (no per-type include guards) - carried from the struct-signatures arc.
- Ledgered: three dragon-specced `daslib/REVIEW.das` gate cells (emit entry points read the error state; no flag reads inside `CppAot`-family overrides; `buildStructEnumCollisions` seeding); a path-filtered CI lane running `ctest -L big` (would replace the new big-test attestation rule); two sql rules move to `REVIEW_LINQ.md`; the `src/builtin` bind-flavor rule deletion question (its gate enforces it in full).

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
