### PR TITLE
playground specs: run a pinned probe, not the default sample

### DIFF
--- a/site/tests/playground/runtime-revive.spec.js
+++ b/site/tests/playground/runtime-revive.spec.js
@@ -16,6 +16,14 @@
 
 const { test, expect } = require('@playwright/test');
 
+// Pin the editor to a known tiny program before a run whose output is
+// asserted: the default sample (data.json[0]) is whatever the playground
+// features that month — a GL demo prints no output lines at all.
+const PROBE_SRC = 'options gen2\n[export]\ndef main {\n    print("PROBE-OK\\n")\n}\n';
+async function setProbeProgram(page) {
+    await page.evaluate((src) => { window.code.getDoc().setValue(src); }, PROBE_SRC);
+}
+
 test('a dead page revives on the next Run click @wasm', async ({ page }) => {
     test.slow();   // several full frame lifecycles; parallel-suite load stretches each
     await page.addInitScript(() => {
@@ -63,8 +71,7 @@ test('a dead page revives on the next Run click @wasm', async ({ page }) => {
         .toBeVisible({ timeout: 15_000 });
 
     // The revived spare comes up for real, the next Run actually executes the
-    // program (the default sample prints "Hello World"), and no further abort
-    // joined the output.
+    // program, and no further abort joined the output.
     await page.waitForFunction(() => {
         const b = document.getElementById('run');
         return b && !b.disabled && window.PlaygroundRunner && window.PlaygroundRunner.isReady();
@@ -72,8 +79,9 @@ test('a dead page revives on the next Run click @wasm', async ({ page }) => {
     const abortsBefore = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')]
             .filter((e) => e.textContent.includes('runtime aborted')).length);
+    await setProbeProgram(page);
     await page.click('#run');
-    await expect(page.locator('.output_line_text', { hasText: 'Hello World' }))
+    await expect(page.locator('.output_line_text', { hasText: 'PROBE-OK' }))
         .toBeVisible({ timeout: 60_000 });
     const abortsAfter = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')]
@@ -97,8 +105,9 @@ test('streaming-compile failure falls back to ArrayBuffer and the page works @wa
     await page.waitForFunction(
         () => window.PlaygroundRunner && window.PlaygroundRunner.isReady(),
         null, { timeout: 60_000 });
+    await setProbeProgram(page);
     await page.click('#run');
-    await expect(page.locator('.output_line_text', { hasText: 'Hello World' }))
+    await expect(page.locator('.output_line_text', { hasText: 'PROBE-OK' }))
         .toBeVisible({ timeout: 60_000 });
     const lines = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
@@ -139,11 +148,10 @@ test('a failed runtime compile reports itself and the retry recovers @wasm', asy
         const b = document.getElementById('run');
         return b && !b.disabled && window.PlaygroundRunner && window.PlaygroundRunner.isReady();
     }, null, { timeout: 60_000 });
-    const before = await page.evaluate(() => document.querySelectorAll('#output .output_line').length);
+    await setProbeProgram(page);
     await page.click('#run');
-    await page.waitForFunction(
-        (n) => document.querySelectorAll('#output .output_line').length > n,
-        before, { timeout: 60_000 });
+    await expect(page.locator('.output_line_text', { hasText: 'PROBE-OK' }))
+        .toBeVisible({ timeout: 60_000 });
     const lines = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
     expect(lines).not.toContain('runtime aborted: run-frame');

--- a/site/tests/playground/shared-module.spec.js
+++ b/site/tests/playground/shared-module.spec.js
@@ -14,6 +14,11 @@
 
 const { test, expect } = require('@playwright/test');
 
+// Pin the editor to a known tiny program before the counted runs: the default
+// sample (data.json[0]) is whatever the playground features that month — a GL
+// demo prints no output lines at all.
+const PROBE_SRC = 'options gen2\n[export]\ndef main {\n    print("PROBE-OK\\n")\n}\n';
+
 // Gate on the runner's own readiness, not the Run button: the button is
 // re-gated on state *changes*, so mid-run it can briefly hold a stale enabled
 // state while isReady() is false.
@@ -37,6 +42,7 @@ test('a session of runs compiles the runtime once, not once per run @wasm', asyn
     await page.locator('.CodeMirror').waitFor({ state: 'visible' });
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
     await waitForRunReady(page);
+    await page.evaluate((src) => { window.code.getDoc().setValue(src); }, PROBE_SRC);
 
     // The page is up and a frame is standing by — from here on, no run may
     // cost another fetch (= another compile) of the runtime.
@@ -50,11 +56,11 @@ test('a session of runs compiles the runtime once, not once per run @wasm', asyn
     await runAndWaitForOutput(page);
     await waitForRunReady(page);
 
-    // Both runs actually executed: the default sample prints "Hello World"
-    // once per run. (A weaker any-output check would accept a status line.)
+    // Both runs actually executed: the probe prints once per run. (A weaker
+    // any-output check would accept a status line.)
     const lines = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
-    expect((lines.match(/Hello World/g) || []).length).toBe(2);
+    expect((lines.match(/PROBE-OK/g) || []).length).toBe(2);
     expect(lines).not.toContain('runtime aborted');
 
     expect(lateWasmFetches).toBe(0);


### PR DESCRIPTION
Four `@wasm` playground specs were broken since #3714: the three revive specs and the shared-module compile counter asserted `Hello World` from the default sample, but the default sample (`data.json[0]`) has been the GL rotating triangle since June - a program that prints no output lines. The assertion was hardened to that text in #3714's last commit, after its stated suite run, so the specs were born broken; no CI lane runs `@wasm` specs, so nothing caught it. The final Run in each spec now pins the editor to a tiny probe program and asserts its exact output (`PROBE-OK`, counted twice in the shared-module spec). This also unties the specs from `data.json` ordering, so featuring a new sample first can never break them again.

Where to look: `site/tests/playground/runtime-revive.spec.js`, `site/tests/playground/shared-module.spec.js` - the `PROBE_SRC` helper and the four final-phase asserts.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- WASM-staged Playwright suite (local-only gate, no per-PR wasm lane), deployed daslang.io runtime, CI worker count: 64 passed, 1 failed. The one red is `audio.spec.js:100`, known-red since #3714's own stated run (negative-controlled there); untouched here.
- The four fixed specs pass in 2-5s each - the old runs spent 30-60s in assertion timeouts.

### Not done
- `audio.spec.js:100` stays red - separate defect, separate arc.
- No CI lane runs `@wasm` specs (per-PR is `--grep-invert`, nightly is the sample verifier) - a master-only wasm-staged lane is still the open follow-up from #3714.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
