### PR TITLE
nightly: the @wasm specs finally get a CI lane

### DIFF
--- a/.github/workflows/nightly_playground.yml
+++ b/.github/workflows/nightly_playground.yml
@@ -102,3 +102,50 @@ jobs:
         path: utils/internal/dasweb-verify/browser/artifacts
         if-no-files-found: ignore
         retention-days: 14
+
+  wasm_specs:
+    # The @wasm cells of the Playwright e2e suite (site/tests/playground). The
+    # per-PR lane stages the site with no runtime and inverts them out, so this
+    # is the only CI that ever executes them - without it they rot silently
+    # (the revive specs shipped broken for eleven days). Only the @wasm tag
+    # runs here: the untagged cells stub production services (share minting,
+    # the wasm build queue) and belong to the staged per-PR lane.
+    if: github.event_name != 'schedule' || github.repository == 'GaijinEntertainment/daScript'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: "SCM Checkout"
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        # deliberately no `cache:` — see the header
+
+    - name: "Install suite dependencies"
+      working-directory: site/tests/playground
+      run: npm ci
+
+    - name: "Install Chromium"
+      working-directory: site/tests/playground
+      run: npx playwright install chromium --with-deps
+
+    - name: "Run @wasm specs against the live playground"
+      working-directory: site/tests/playground
+      env:
+        BASE_URL: ${{ github.event.inputs.base_url || 'https://daslang.io' }}
+      # Serial on purpose: each cell downloads the ~40MB runtime, and parallel
+      # workers sharing one pipe turn tight per-spec budgets into flakes.
+      run: |
+        set -euo pipefail
+        echo "driving ${BASE_URL}"
+        npx playwright test --grep '@wasm' --workers=1
+
+    - name: "Upload Playwright report on failure"
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: wasm-spec-report
+        path: site/tests/playground/playwright-report/
+        if-no-files-found: ignore
+        retention-days: 14

--- a/site/tests/playground/audio.spec.js
+++ b/site/tests/playground/audio.spec.js
@@ -72,7 +72,7 @@ async function loadPlaygroundWithTap(page) {
         () => window.code && typeof window.code.setValue === 'function', null, { timeout: 20_000 });
     await page.waitForFunction(
         () => !!(window.PlaygroundRunner && window.PlaygroundRunner.isReady()),
-        null, { timeout: 30_000 });
+        null, { timeout: 60_000 });
     await page.waitForFunction(
         () => Array.from(document.getElementById('examples').options)
             .some(o => o.text === 'Audio: strudel synth arpeggio'),
@@ -80,31 +80,34 @@ async function loadPlaygroundWithTap(page) {
 }
 
 test('strudel audio sample plays then stops @wasm', async ({ page }) => {
+    test.slow();   // a full runtime compile before the run; parallel-suite load stretches it
     await loadPlaygroundWithTap(page);
     await page.selectOption('#examples', { label: 'Audio: strudel synth arpeggio' });
     await page.waitForFunction(() => window.code.getValue().includes('strudel_tick'), null, { timeout: 15_000 });
 
     await page.click('#run'); // trusted gesture -> installAudioUnlock resumes the context
 
-    // Plays: live Web Audio output becomes non-zero within a few seconds.
-    await expect.poll(() => frameEval(page, () => window.__peak), { timeout: 8_000 }).toBeGreaterThan(0.01);
+    // Plays: live Web Audio output becomes non-zero. Event-driven: the wide
+    // budget only spends when the script compile is squeezed by sibling specs.
+    await expect.poll(() => frameEval(page, () => window.__peak), { timeout: 30_000 }).toBeGreaterThan(0.01);
 
     // Stops on its own (~7s, END_SECONDS): the AudioContext leaves 'running'.
     await expect
         .poll(() => frameEval(page,
             () => window.__states().every(s => s !== 'running') && window.__states().length > 0),
-            { timeout: 12_000 })
+            { timeout: 20_000 })
         .toBe(true);
 });
 
 test('strudel audio sample reports its lifecycle @wasm', async ({ page }) => {
+    test.slow();   // a full runtime compile before the run; parallel-suite load stretches it
     await loadPlaygroundWithTap(page);
     await page.selectOption('#examples', { label: 'Audio: strudel synth arpeggio' });
     await page.waitForFunction(() => window.code.getValue().includes('strudel_tick'), null, { timeout: 15_000 });
     await page.click('#run');
     // init() and the eventual shutdown() both print to the output panel.
     await expect(page.locator('.output_line_text', { hasText: 'playing synth arpeggio' }))
-        .toBeVisible({ timeout: 10_000 });
+        .toBeVisible({ timeout: 30_000 });
     await expect(page.locator('.output_line_text', { hasText: 'strudel: stopped' }))
-        .toBeVisible({ timeout: 15_000 });
+        .toBeVisible({ timeout: 30_000 });
 });

--- a/site/tests/playground/audio.spec.js
+++ b/site/tests/playground/audio.spec.js
@@ -80,7 +80,9 @@ async function loadPlaygroundWithTap(page) {
 }
 
 test('strudel audio sample plays then stops @wasm', async ({ page }) => {
-    test.slow();   // a full runtime compile before the run; parallel-suite load stretches it
+    // The summed per-step budgets exceed test.slow()'s 90s - match the
+    // overall budget to them, like the revive specs.
+    test.setTimeout(240_000);
     await loadPlaygroundWithTap(page);
     await page.selectOption('#examples', { label: 'Audio: strudel synth arpeggio' });
     await page.waitForFunction(() => window.code.getValue().includes('strudel_tick'), null, { timeout: 15_000 });
@@ -100,7 +102,9 @@ test('strudel audio sample plays then stops @wasm', async ({ page }) => {
 });
 
 test('strudel audio sample reports its lifecycle @wasm', async ({ page }) => {
-    test.slow();   // a full runtime compile before the run; parallel-suite load stretches it
+    // The summed per-step budgets exceed test.slow()'s 90s - match the
+    // overall budget to them, like the revive specs.
+    test.setTimeout(240_000);
     await loadPlaygroundWithTap(page);
     await page.selectOption('#examples', { label: 'Audio: strudel synth arpeggio' });
     await page.waitForFunction(() => window.code.getValue().includes('strudel_tick'), null, { timeout: 15_000 });

--- a/site/tests/playground/runtime-revive.spec.js
+++ b/site/tests/playground/runtime-revive.spec.js
@@ -25,7 +25,10 @@ async function setProbeProgram(page) {
 }
 
 test('a dead page revives on the next Run click @wasm', async ({ page }) => {
-    test.slow();   // several full frame lifecycles; parallel-suite load stretches each
+    // Several full frame lifecycles, and the revive re-downloads the ~40MB
+    // runtime - 46s serial against the live site, so test.slow()'s 90s is too
+    // tight once a sibling worker shares the bandwidth.
+    test.setTimeout(240_000);
     await page.addInitScript(() => {
         if (window.top === window) { window.__abortSpares = true; return; }
         try {
@@ -40,7 +43,7 @@ test('a dead page revives on the next Run click @wasm', async ({ page }) => {
 
     // The runner reported the aborts on its way down.
     await expect(page.locator('.output_line_text', { hasText: 'runtime aborted' }).first())
-        .toBeVisible({ timeout: 30_000 });
+        .toBeVisible({ timeout: 120_000 });
 
     // Dead page: the budget is spent, no frame standing by, none on the way —
     // and the Run BUTTON is enabled, because the click is the revive trigger.
@@ -75,14 +78,14 @@ test('a dead page revives on the next Run click @wasm', async ({ page }) => {
     await page.waitForFunction(() => {
         const b = document.getElementById('run');
         return b && !b.disabled && window.PlaygroundRunner && window.PlaygroundRunner.isReady();
-    }, null, { timeout: 60_000 });
+    }, null, { timeout: 120_000 });
     const abortsBefore = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')]
             .filter((e) => e.textContent.includes('runtime aborted')).length);
     await setProbeProgram(page);
     await page.click('#run');
     await expect(page.locator('.output_line_text', { hasText: 'PROBE-OK' }))
-        .toBeVisible({ timeout: 60_000 });
+        .toBeVisible({ timeout: 120_000 });
     const abortsAfter = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')]
             .filter((e) => e.textContent.includes('runtime aborted')).length);
@@ -94,7 +97,10 @@ test('a dead page revives on the next Run click @wasm', async ({ page }) => {
 // the page — warn-and-work, never a dead page. Streaming is stubbed dead for
 // the whole session; the page must come up and run without a single abort.
 test('streaming-compile failure falls back to ArrayBuffer and the page works @wasm', async ({ page }) => {
-    test.slow();   // a full ArrayBuffer compile + a run; parallel-suite load stretches it
+    // A full ArrayBuffer download + compile before the page is up - the ~40MB
+    // fetch dominates against the live site once a sibling worker shares the
+    // bandwidth.
+    test.setTimeout(240_000);
     await page.addInitScript(() => {
         if (window.top !== window) return;   // the parent's compile is the one with the ladder
         WebAssembly.compileStreaming = () => Promise.reject(new TypeError('induced: streaming unavailable'));
@@ -104,11 +110,11 @@ test('streaming-compile failure falls back to ArrayBuffer and the page works @wa
     await page.waitForFunction(() => window.pgSamplesReady === true, null, { timeout: 30_000 });
     await page.waitForFunction(
         () => window.PlaygroundRunner && window.PlaygroundRunner.isReady(),
-        null, { timeout: 60_000 });
+        null, { timeout: 120_000 });
     await setProbeProgram(page);
     await page.click('#run');
     await expect(page.locator('.output_line_text', { hasText: 'PROBE-OK' }))
-        .toBeVisible({ timeout: 60_000 });
+        .toBeVisible({ timeout: 120_000 });
     const lines = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
     expect(lines).not.toContain('runtime aborted');
@@ -122,7 +128,9 @@ test('streaming-compile failure falls back to ArrayBuffer and the page works @wa
 // one ladder, the first spare's request eats the second and aborts, so the
 // rebuilt spare's request is the retry that succeeds.
 test('a failed runtime compile reports itself and the retry recovers @wasm', async ({ page }) => {
-    test.slow();   // two compile attempts + a full run; parallel-suite load stretches each
+    // Two failing ladders then a real compile - up to three ~40MB downloads
+    // against the live site before the run even starts.
+    test.setTimeout(240_000);
     await page.addInitScript(() => {
         if (window.top !== window) return;   // stub the parent page only
         const origStreaming = WebAssembly.compileStreaming.bind(WebAssembly);
@@ -141,17 +149,17 @@ test('a failed runtime compile reports itself and the retry recovers @wasm', asy
 
     // The first spare heard {module: null, error} and reported the real cause.
     await expect(page.locator('.output_line_text', { hasText: 'wasm compile failed: induced compile failure' }))
-        .toBeVisible({ timeout: 30_000 });
+        .toBeVisible({ timeout: 120_000 });
 
     // The rebuilt spare's request re-compiles for real and the page recovers.
     await page.waitForFunction(() => {
         const b = document.getElementById('run');
         return b && !b.disabled && window.PlaygroundRunner && window.PlaygroundRunner.isReady();
-    }, null, { timeout: 60_000 });
+    }, null, { timeout: 120_000 });
     await setProbeProgram(page);
     await page.click('#run');
     await expect(page.locator('.output_line_text', { hasText: 'PROBE-OK' }))
-        .toBeVisible({ timeout: 60_000 });
+        .toBeVisible({ timeout: 120_000 });
     const lines = await page.evaluate(() =>
         [...document.querySelectorAll('#output .output_line_text')].map((e) => e.textContent).join('\n'));
     expect(lines).not.toContain('runtime aborted: run-frame');


### PR DESCRIPTION
The `@wasm` cells of the playground e2e suite get their first CI lane: a `wasm_specs` job in `nightly_playground.yml` runs `npx playwright test --grep '@wasm'` against the live site, next to the sample verifier. Until now no lane executed them at all - the per-PR lane inverts them out - which is how the revive specs shipped broken for eleven days. Only the `@wasm` tag runs there: the untagged cells stub production services (share minting, the wasm build queue) and belong to the staged per-PR lane. The job is serial on purpose - each cell downloads the ~40MB runtime, and parallel workers sharing one pipe turn tight budgets into flakes.

The remainder of the known-red set turned out to be budget flakes, not defects: both audio specs and the three revive specs pass serially and fail only under contention. Their gates get real budgets (`test.setTimeout(240s)` for the download-bound revive specs, wider event-driven polls everywhere) - a wide timeout on an event-driven gate spends nothing when green.

Where to look: `.github/workflows/nightly_playground.yml` (the new job), `site/tests/playground/audio.spec.js` and `runtime-revive.spec.js` (budgets only - no assertion changed).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Dress rehearsal of the exact nightly command (`--grep '@wasm' --workers=1`) against live daslang.io: 13/13 passed, 3.3 min.
- Full staged suite at CI worker count: 64 passed, 1 failed - the ArrayBuffer-compile spec starved by the local single-threaded python server (passes in 1.9s serially, same command); a rig artifact, not a code state. No CI lane runs that combination.
- Both audio specs, red since #3714's stated run, pass serially against staged and live - they were contention flakes all along.

### Not done
- The nightly `wasm_specs` job needs one live run after merge to prove the runner-side path - trigger `workflow_dispatch` on `nightly playground`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
