### PR TITLE
dasLLAMA: GEMV-tail prefill dispatch + tile-conditional span AV bound

### DIFF
--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -154,6 +154,7 @@ Apple Accelerate / AMX float lane. `DASLLAMA_ACCEL` arms the whole group.
 | `DASLLAMA_MODELS_DIR` | path | unset | Directory holding the .gguf models the probes, benches and tests load. dasllama-server's model catalog downloads here too when set. |
 | `DASLLAMA_CONFIRM_MODEL` | path | auto-resolved from the models dir | Model used by the tuner's confirm gate (FULL path, not a bare filename). Unset: the gate auto-resolves from the models dir - the preferred confirm carrier, else the largest present q8 gguf; the fallback pins only when the box has no q8 model at all. |
 | `DASLLAMA_BATCH_CHUNKS` | text | unset | Override the batched-dispatch chunk count in the 1-core GEMM probe. |
+| `DASLLAMA_PROBE_MODEL` | text | Qwen3VL-8B-Instruct-Q8_0.gguf | Model filename (inside the models dir) the image-turn attribution probe loads. |
 | `DASLLAMA_BATCH_GRID_2D` | number | unset | Use the 2D batch grid in the parity probe. |
 | `DASLLAMA_FOCUS_BACKEND` | text | unset | Restrict the 1-core GEMM probe to one backend. |
 | `DASLLAMA_FOCUS_SHAPE` | text | unset | Restrict the 1-core GEMM probe to one shape. |

--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -74,6 +74,7 @@ Apple GPU backend. Absent on non-Apple builds, where setting them does nothing.
 | `DASLLAMA_METAL_ATTN_D` | flag | on | Fused single-pass decode attention (assumes head_size 128); 0 is the A/B rail to the chunked pair. |
 | `DASLLAMA_METAL_ATTN_SINGLE` | number | 64 | Row count below which attention uses the single-chunk kernel; clamped to 128. |
 | `DASLLAMA_METAL_MULMM` | flag | on | The mul_mm prefill GEMM; 0 falls back to the legacy per-op path. |
+| `DASLLAMA_METAL_MM_TAIL` | flag | on | GEMV-tail prefill dispatch: npos % 32 in [1,8] peels the last M tile's real rows onto the fixed-B GEMV family instead of billing a full 32-row tile; 0 pins the padded-tile path (the A/B rail). |
 | `DASLLAMA_METAL_NCB` | number | ~4 layers/chunk | Command-buffer split: each chunk commits as encoded so the scheduler overlaps chunk k with k-1. |
 | `DASLLAMA_METAL_UNRETAINED` | flag | off | Skip per-dispatch retain/release on the prefill command buffers. |
 | `DASLLAMA_METAL_PF_CAPTURE` | flag | on | Record each prefill chunk as a step graph and replay on a concurrent encoder; 0 is serial-encode rollback. |

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -30,11 +30,18 @@ what it costs today and what the fix would change.
   Results (released exe, r=3, quiet M1 Max, fresh upstream pairs): 8B img:pp 522 -> 552
   tok/s (-7.5% -> -2.2%), 4B img:pp 942 -> 986 (-2.7%), 8B text p321 534.5 -> 566.7 (+7.8%
   ahead); p341/p512 unchanged (remainders outside the window); 30B Omni img:pp 783 (rides -
-  its FFN is MoE, out of tail scope). **OPEN followups: (1) the span-attention tax (~6 ms/turn
-  in-process, the whole remaining probe-visible image cost); (2) the post-encode context
-  residue (~10 ms on 8B - the bench-context image wall exceeds the in-process wall by it);
-  (3) the kq mul_mm sites and the MoE prefill GEMMs take no tail yet (the kq mv twins
-  exist); (4) r in [9,15] via a third mv pass (~12 ms more on the shapes that hit it).**
+  its FFN is MoE, out of tail scope). The span-attention tax split on the finer knockouts
+  (attn_qk/attn_sm/attn_av x span-size scaling): ~3 ms was a CONSTANT AV overhead - with the
+  span armed the AV kernels walked every query tile to np32, dropping the causal limit
+  wholesale; the bound is now tile-conditional (max(uend, causal reach) only where the tile
+  holds span rows - a pure shrink over softmax-zeroed columns, the f16 fused-vs-splice
+  witness reads 0 with it). The 1-row-span tax fell 3.3 -> 0.58 ms (small-media turns win);
+  at the 300-row turn the remaining ~6 ms is INTRINSIC non-causal pairs - the image cell
+  does not move. **OPEN followups: (1) the post-encode context residue (~10 ms on 8B:
+  ~6.7 ms GPU cache aftermath of the per-turn tower encode + ~3.8 ms host commit slack;
+  lever = encode-ahead overlap, shared with the decode per-step-overhead entry); (2) the kq
+  mul_mm sites and the MoE prefill GEMMs take no tail yet (the kq mv twins exist); (3) r in
+  [9,15] via a third mv pass (~12 ms more on the shapes that hit it).**
 
 - **LANDED - the Metal q8 decode GEMV family ran one-row-per-simdgroup with a full-n walk,
   spilling the x vector past L1 from n=4096; the reduction-split form takes every q8 model

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -21,12 +21,18 @@ what it costs today and what the fix would change.
   wide-staging tax" was dead too - the one-process probe (`harness/image_turn_probe.das`,
   three workloads x five skip arms) put the ds-wide quantum at +0.1 ms over narrow and the
   whole in-process image tax at ~+6 ms, all in the attention family. The real structure is
-  the M staircase: 8B text p320 = 551 ms (10 tile-rows), p321 = 599, p352 = 600 - one
+  the M staircase: 8B text p320 = 551 ms (10 tile-rows), p321 = 599, p352 = 600 (released
+  exe walls, the bench's own driver lines) - one
   tile-row = ~48 ms, and the image turn (321 = 10x32+1) bills it for ONE real row. The tail
   dispatches floor(npos/32) tiles + the remainder rows on the mv GEMVs; a lone row rides the
-  reduction-split decode GEMV - the mv forms idle half their lanes on it (measured: mv-only
-  tail -24 ms, the r==1 reroute -8.6 more). The mv_b2 store now gates on nrows (it
-  phantom-wrote row 1 at nrows == 1 - off the end of an exactly-full KV panel).
+  reduction-split decode GEMV - the mv forms idle half their lanes on it (probe before/after
+  across the two commits, direction-grade, tokens wall 599.2 -> 575.4 -> 566.8 ms: the
+  mv-only tail -24, the r==1 reroute -8.6).
+  Per-form reduction alignment gates the peel (the b4 stripe reads whole 128-quant rounds;
+  kdim % 128 != 0 keeps the padded tile - dims 576/896/1152 misread otherwise,
+  device-probed), and r >= 2 always takes the b4 form (b2's stripe needs % 256). The mv_b2
+  store now gates on nrows - defensive: at nrows == 1 it phantom-wrote its second row, an
+  unread pad row or an off-the-buffer write depending on which batch path sized y.
   Results (released exe, r=3, quiet M1 Max, fresh upstream pairs): 8B img:pp 522 -> 552
   tok/s (-7.5% -> -2.2%), 4B img:pp 942 -> 986 (-2.7%), 8B text p321 534.5 -> 566.7 (+7.8%
   ahead); p341/p512 unchanged (remainders outside the window); 30B Omni img:pp 783 (rides -
@@ -37,11 +43,20 @@ what it costs today and what the fix would change.
   holds span rows - a pure shrink over softmax-zeroed columns, the f16 fused-vs-splice
   witness reads 0 with it). The 1-row-span tax fell 3.3 -> 0.58 ms (small-media turns win);
   at the 300-row turn the remaining ~6 ms is INTRINSIC non-causal pairs - the image cell
-  does not move. **OPEN followups: (1) the post-encode context residue (~10 ms on 8B:
-  ~6.7 ms GPU cache aftermath of the per-turn tower encode + ~3.8 ms host commit slack;
+  does not move. The stage/split figures here are `harness/image_turn_probe.das` readings
+  (one process, best-of-3, the `DASLLAMA_METAL_PREFILL_SKIP` arms) - direction-grade; the
+  Results line above is the record-grade board. **OPEN followups: (1) the post-encode
+  context residue (~10 ms on 8B - the bench-context image eval vs the probe's in-process
+  wall: gpu 577 vs 570.3 ms = ~6.7 GPU cache aftermath of the per-turn tower encode, and
+  total-minus-gpu 5.6 vs 1.8 ms = ~3.8 host commit slack;
   lever = encode-ahead overlap, shared with the decode per-step-overhead entry); (2) the kq
   mul_mm sites and the MoE prefill GEMMs take no tail yet (the kq mv twins exist); (3) r in
-  [9,15] via a third mv pass (~12 ms more on the shapes that hit it).**
+  [9,15] via a third mv pass (~12 ms more on the shapes that hit it); (4) PRE-EXISTING: the
+  batch-DECODE mv rail dispatches the same unguarded-stripe kernels with no reduction
+  alignment clause - B in [2,8] on a model whose dim/qd/hidden is % 128 != 0 (576/896/1152
+  class) misreads; its fix wants a failing test first, own arc; (5) the b2/b4 y binding
+  carries no @span, so each peeled site pays a conservative whole-buffer barrier -
+  correctness-neutral, but it confounds per-r timing comparisons.**
 
 - **LANDED - the Metal q8 decode GEMV family ran one-row-per-simdgroup with a full-n walk,
   spilling the x vector past L1 from n=4096; the reduction-split form takes every q8 model

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -12,6 +12,30 @@ what it costs today and what the fix would change.
 
 ## Entries
 
+- **LANDED - the mul_mm prefill billed ceil-32 M tiles, so an npos just past a tile boundary
+  paid a whole extra tile-row of wall for rows nothing reads; the GEMV-tail dispatch peels
+  npos % 32 in [1,8] onto the fixed-B mv family (measured 2026-08-24, M1 Max, the qwen
+  img:pp chase; plan: `qwen_pp_plan.md`).** The dig that got here killed two prior theories:
+  the "8B small-M text GEMM gap" (-6% at p341) was the cold-first-process page tax - the warm
+  re-run prices das +2.1% AHEAD (never conclude from run 1, struck AGAIN); and the "4B
+  wide-staging tax" was dead too - the one-process probe (`harness/image_turn_probe.das`,
+  three workloads x five skip arms) put the ds-wide quantum at +0.1 ms over narrow and the
+  whole in-process image tax at ~+6 ms, all in the attention family. The real structure is
+  the M staircase: 8B text p320 = 551 ms (10 tile-rows), p321 = 599, p352 = 600 - one
+  tile-row = ~48 ms, and the image turn (321 = 10x32+1) bills it for ONE real row. The tail
+  dispatches floor(npos/32) tiles + the remainder rows on the mv GEMVs; a lone row rides the
+  reduction-split decode GEMV - the mv forms idle half their lanes on it (measured: mv-only
+  tail -24 ms, the r==1 reroute -8.6 more). The mv_b2 store now gates on nrows (it
+  phantom-wrote row 1 at nrows == 1 - off the end of an exactly-full KV panel).
+  Results (released exe, r=3, quiet M1 Max, fresh upstream pairs): 8B img:pp 522 -> 552
+  tok/s (-7.5% -> -2.2%), 4B img:pp 942 -> 986 (-2.7%), 8B text p321 534.5 -> 566.7 (+7.8%
+  ahead); p341/p512 unchanged (remainders outside the window); 30B Omni img:pp 783 (rides -
+  its FFN is MoE, out of tail scope). **OPEN followups: (1) the span-attention tax (~6 ms/turn
+  in-process, the whole remaining probe-visible image cost); (2) the post-encode context
+  residue (~10 ms on 8B - the bench-context image wall exceeds the in-process wall by it);
+  (3) the kq mul_mm sites and the MoE prefill GEMMs take no tail yet (the kq mv twins
+  exist); (4) r in [9,15] via a third mv pass (~12 ms more on the shapes that hit it).**
+
 - **LANDED - the Metal q8 decode GEMV family ran one-row-per-simdgroup with a full-n walk,
   spilling the x vector past L1 from n=4096; the reduction-split form takes every q8 model
   (measured 2026-08-24, M1 Max, the decode-tg chase).** The dig: qwen3vl text cells were

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -2,14 +2,14 @@
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
 `ARCHITECTURE.md`. Planned work: `followup_general.md`, `followup_vulkan.md`; the perf
-backlog is `PERF_LEDGER.md` - a performance followup files there, everything else in the
-two followup files.
+backlog is `PERF_LEDGER.md` - a performance followup goes there, everything else in the
+two followup ledgers.
 
 **A dasLLAMA `[test]` file, wherever the diff puts it, answers to this module's
 `tests/REVIEW.md`.**
 
-**A timing rig - a script whose output is a measured wall or rate - and any kernel A/B lab,
-wherever the diff puts them, answer to `benchmarks/REVIEW.md`.**
+**A timing rig - a script whose output is a measured wall or rate - wherever the diff puts
+it, answers to `benchmarks/REVIEW.md`.**
 
 **A change to what enters `performance/records/` or its manifests, an exchange change - the client or
 schema for the sidecar exchange that boxes download tune winners from and submit winners
@@ -108,14 +108,14 @@ template strings any of them look up, records a `tests/test_tokenizer.das` run w
 EXECUTED, not skipped.**
 
 **An override announces itself where it changes the outcome.** An override is an environment
-knob or an exported runtime setter that moves a gate, policy, or threshold off its default;
-a CLI flag, and a knob that changes only WHEN work happens - never what the run writes,
-reads, mints, or computes - are not overrides under this rule. A knob that moves computed
-numerics is an override even when its purpose is timing (two GEMM forms of the same math
-differ in float terms). Where one changes an observable outcome of the run,
-a printed line names it by its own spelling (the env variable name, or the
-setter's function name); set-but-inert stays silent, per-site repeats are fine. Adding one,
-or giving one a new effect, without the announce is a defect.
+knob or an exported runtime setter that moves a gate, policy, or threshold off its default
+and thereby changes what the run writes, reads, mints, or computes - including a knob or
+setter whose purpose is timing when it moves computed numerics, since two GEMM forms of
+the same math differ in float terms. A knob or setter that changes only WHEN work happens
+is not an override, and a CLI flag is never one. A run that engages one prints a line
+naming it by its own spelling (the env variable name, or the setter's function name);
+set-but-inert stays silent, per-site repeats are fine. Adding one, or giving one a new
+effect, without the announce is a defect.
 
 **A self-measured served-turn time - tok/s, a turn wall - entering
 `performance/records/<box>.json` or `PERF_LEDGER.md` comes from the released `lcpp_bench`
@@ -123,6 +123,9 @@ exe - `benchmarks/lcpp_bench.das` built by `daspkg release`, spawned by
 `performance/gen_bench_records.das` or run by hand where the cell's `PROFILE.md` section says
 so - never from the `-jit` script** (a `--for-debug-purposes` row is a debug instrument). A
 tutorial's printed wall-clock is teaching output, feeding no board.
+
+**A subtraction of two measured walls written into `PERF_LEDGER.md` carries both raw walls
+in the entry.**
 
 **A new servable capability gets its cell in the same change**: a board row spawned by
 `performance/gen_bench_records.das`, or a manual `benchmarks/lcpp_bench.das` cell with its own
@@ -140,9 +143,9 @@ delta, a noise floor, tuner timing - is settled by the sidecar or manifest stamp
 
 **A figure measuring one engine stage inside a served turn - a stage wall, a stage share, a
 stage speedup, or a cross-engine comparison of one stage; never a board cell's `pp`/`tg`
-rate or the whole wall of a `-p`/`-n` bench cell (those take the cell rule above) - names
-the harness and flags that produced it, wherever it is written down: a
-checked-in doc, a ledger, a code comment, or a PR description.** The naming rides the
+rate and never the whole wall of a `benchmarks/lcpp_bench.das` `-p`/`-n` cell - names the
+harness and flags that produced it, wherever it is written down: a checked-in doc, a
+ledger, a code comment, or a PR description.** The naming rides the
 figure's own sentence, a table heading that covers the table's rows, or a section-level
 provenance line that covers the paragraphs under it.
 
@@ -217,11 +220,12 @@ the same change.**
 **An upstream mechanism is described in our own terms, not attributed** - no
 "lifted/ported verbatim from" and no upstream symbol, header, or constant names in a `.md`
 file or a `.das` comment; state what the code does and why its shape wins. Provenance is
-not attribution: a path naming where checked-in data is regenerated FROM, and the
-measurement surface naming the reference binary a number was taken against (the yardstick
-docs and the env knobs that point at it), both stay; everywhere else prose writes "the
-reference exe" / "upstream". Legal attribution
-lives in `THIRD_PARTY_NOTICES.md` and the `LICENSE.*` files, so prose never carries it.
+not attribution: a path naming where checked-in data is regenerated FROM, an env-knob row
+in `ENVIRONMENT.md` whose value locates the reference binary, and a command line or flag
+list in `METHODOLOGY.md`, `PROFILE.md`, or `BRINGUP.md`, all name the binary outright;
+every other `.md` line and `.das` comment writes "the reference exe" or "upstream". Legal
+attribution lives in `THIRD_PARTY_NOTICES.md` and the `LICENSE.*` files, so prose never
+carries it.
 
 **A def of `dasllama/dasllama.das` - and a new OVERLOAD of one - is TAUGHT: demonstrated in
 runnable code in a `tutorials/dasLLAMA/*.das` source and narrated on a

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -1,7 +1,9 @@
 # dasLLAMA Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
-`ARCHITECTURE.md`. Planned work: `followup_general.md`, `followup_vulkan.md`.
+`ARCHITECTURE.md`. Planned work: `followup_general.md`, `followup_vulkan.md`; the perf
+backlog is `PERF_LEDGER.md` - a performance followup files there, everything else in the
+two followup files.
 
 **A dasLLAMA `[test]` file, wherever the diff puts it, answers to this module's
 `tests/REVIEW.md`.**
@@ -77,8 +79,10 @@ a defect in an engine file (`dasllama/`) outside a cold one-shot load, bake, map
 tokenizer-build progress log - instrumentation goes through the sanctioned rails, listed with
 their reasons in `ARCHITECTURE.md` sec.2.10.
 
-**A clock whose value feeds logic is marked `// clock: control`, in any file under this
-folder** - unmarked it reads as free-hand timing to the ad-hoc-profiling sweep.
+**A clock value that changes what the program DOES - control flow, eviction, a generated
+name; not a reported wall or a best-of reduction over reported walls - is marked
+`// clock: control`, in an engine file (`dasllama/`)** - unmarked it reads as free-hand
+timing to the ad-hoc-profiling sweep, which runs over the same tree.
 
 **Every new kernel or loop the runtime re-enters per token, per frame, or per prefill
 quantum is COVERED by an annotated region entry** - `[hot_path]`, any of the `[no_alloc]` /
@@ -105,9 +109,11 @@ EXECUTED, not skipped.**
 
 **An override announces itself where it changes the outcome.** An override is an environment
 knob or an exported runtime setter that moves a gate, policy, or threshold off its default;
-a CLI flag, and a knob whose only effect is timing (an A/B perf rail), are never overrides
-under this rule. Where one changes an observable outcome of the run - what it writes, reads,
-or mints - a printed line names it by its own spelling (the env variable name, or the
+a CLI flag, and a knob that changes only WHEN work happens - never what the run writes,
+reads, mints, or computes - are not overrides under this rule. A knob that moves computed
+numerics is an override even when its purpose is timing (two GEMM forms of the same math
+differ in float terms). Where one changes an observable outcome of the run,
+a printed line names it by its own spelling (the env variable name, or the
 setter's function name); set-but-inert stays silent, per-site repeats are fine. Adding one,
 or giving one a new effect, without the announce is a defect.
 
@@ -134,7 +140,8 @@ delta, a noise floor, tuner timing - is settled by the sidecar or manifest stamp
 
 **A figure measuring one engine stage inside a served turn - a stage wall, a stage share, a
 stage speedup, or a cross-engine comparison of one stage; never a board cell's `pp`/`tg`
-rate - names the harness and flags that produced it, wherever it is written down: a
+rate or the whole wall of a `-p`/`-n` bench cell (those take the cell rule above) - names
+the harness and flags that produced it, wherever it is written down: a
 checked-in doc, a ledger, a code comment, or a PR description.** The naming rides the
 figure's own sentence, a table heading that covers the table's rows, or a section-level
 provenance line that covers the paragraphs under it.
@@ -209,8 +216,11 @@ the same change.**
 
 **An upstream mechanism is described in our own terms, not attributed** - no
 "lifted/ported verbatim from" and no upstream symbol, header, or constant names in a `.md`
-file or a `.das` comment; state what the code does and why its shape wins. A path naming
-where checked-in data is regenerated FROM is provenance, not attribution; legal attribution
+file or a `.das` comment; state what the code does and why its shape wins. Provenance is
+not attribution: a path naming where checked-in data is regenerated FROM, and the
+measurement surface naming the reference binary a number was taken against (the yardstick
+docs and the env knobs that point at it), both stay; everywhere else prose writes "the
+reference exe" / "upstream". Legal attribution
 lives in `THIRD_PARTY_NOTICES.md` and the `LICENSE.*` files, so prose never carries it.
 
 **A def of `dasllama/dasllama.das` - and a new OVERLOAD of one - is TAUGHT: demonstrated in

--- a/modules/dasLLAMA/REVIEW_GPU.md
+++ b/modules/dasLLAMA/REVIEW_GPU.md
@@ -15,11 +15,12 @@ is asked by `prefill_decline` / `decode_decline`, never by a caps predicate.** A
 reports the session's setup progress - rather than the CALL, its row count or its span
 shape - is a defect however it is derived.
 
-**A claim about a shape constant is checked against what the kernel is compiled and dispatched
-with, never against the das that computes the value.** An in-body tile constant is confirmed
+**A shape claim is settled at the site the device reads it, never at the das that computes
+the value.** An in-body tile constant is confirmed
 literal in the generated `*_msl` global or the SPIR-V dump; a grid or threadgroup constant is
 read off the class's `[metal_dispatch]` / `[vk_dispatch]` `grid=`/`tg=` spec, whose `"n/c"`
-form is a CEIL-divide - the spec alone decides, no builder read needed.
+form is a CEIL-divide - the spec alone decides, no builder read needed; a uniform's value is
+read at the single writer that fills its buffer.
 
 **Kernel twins - kernel classes whose bodies differ on one stamp axis - bind the same kargs
 (kernel-argument struct) type at the same binding numbers**, even where one twin ignores a
@@ -87,11 +88,14 @@ per driver.** A string-typed metal decline is a defect.
 **Decline counting lives in `dasllama/dasllama_metal_common.das`.** A counter beside the
 decline site is a defect.
 
-**A diff that adds, removes, or changes the mechanism of a Metal-only or Vulkan-only hook,
-role, served path, or backend-only capability lands its `ARCHITECTURE.md` sec.1.5 edit in the
+**A diff that adds or removes a Metal-only or Vulkan-only hook, role, served path, or
+backend-only capability - anything that changes what one backend can serve and the other
+cannot - lands its `ARCHITECTURE.md` sec.1.5 edit in the
 same change - including when sec.1.5 already carries that class of asymmetry, and including
 sec.1.5's per-driver lists of registered hooks and borrowed kernels.**
-sec.1.5 is the closed list; an asymmetry it does not carry does not exist.
+sec.1.5 is the closed list; an asymmetry it does not carry does not exist. A change that
+alters HOW an already-ledgered served path computes, without moving what either backend
+serves, does not fire this rule.
 
 **A Vulkan pipeline is created only by a `[vk_dispatch]`-generated `ensure_*` and torn down by
 `vk_drop_model_state`.** A hand-written pipeline build anywhere else in the engine is a defect.
@@ -114,17 +118,16 @@ runs, or the in-suite instruments (`tests/test_metal_decode_parity.das` /
 `DASLLAMA_GPU=1`, never `--ngl`, and its log shows `resident driver armed`.** The Vulkan
 driver declines codec-mismatched sessions silently.
 
-**A change to `dasllama/dasllama_metal_tower.das`, to the `AttnArgs` kargs struct, or to any
-kernel class the tower dispatches or builder it borrows (`pf_enc_bf16_mm`,
-`enc_add_bias_rows`, `enc_rope`, `enc_qk_mm`, `enc_softmax`, `enc_av_mm`) ships the gate of
-every registered tower hook the changed code is reachable from: the family gates
-`tests/test_gemma4uv.das`, `tests/test_gemma4v.das`, `tests/test_gemma3v.das`, and
+**A change to `dasllama/dasllama_metal_tower.das`, to the `AttnArgs` kargs struct, to any
+kernel class the tower dispatches (a builder it borrows changes the classes that builder
+dispatches), or to state the whole driver shares (a module-level `g_tw_*` variable,
+`metal_tower_init`, `dasllama_metal_tower_register` - reachable from every hook) runs the
+gate of every registered tower hook the changed code is reachable from.** The gates: the
+family gates `tests/test_gemma4uv.das`, `tests/test_gemma4v.das`, `tests/test_gemma3v.das`, and
 `test_qwen3v_tier1_metal` in `tests/test_qwen3v.das`; the encoder-blocks leg's
 `tests/test_whisper.das`; the conv legs' `tests/test_audio.das` and
 `tests/test_audio_embedder.das`; plus a `tests/test_model_image.das` run with the `mtower`
-arm, `metal_tower_stats()`'s encode count rising across the run. State or setup the whole
-driver shares - a module-level `g_tw_*` variable, `metal_tower_init`,
-`dasllama_metal_tower_register` - is reachable from every hook.** A hook registered in
+arm, `metal_tower_stats()`'s encode count rising across the run. A hook registered in
 `dasllama_metal_tower_register`, or a builder the tower borrows, that this rule does not
 name is the rule's defect to fix in the same change.
 
@@ -132,11 +135,12 @@ name is the rule's defect to fix in the same change.
 ships a `dasllama-convert --trim` bake plus a serve of the trimmed image, on one q8 and one kq
 model.** Parity runs never reach it.
 
-**A change to `dasllama/dasllama_metal_asr_dec.das`, or any change to
+**A change to `dasllama/dasllama_metal_asr_dec.das`, to any kernel class the ASR decoder
+dispatches or builder it borrows, or any change to
 `dasllama/dasllama_metal_common.das`, ships a `tests/test_model_image.das` run with the
 `mtower` arm** - its CPU-vs-GPU transcript cells are the ASR-decoder driver's parity
-instrument, and the shared common paths reach that driver with no line of its own file
-touched.
+instrument, and the shared common paths and borrowed kernels reach that driver with no line
+of its own file touched.
 
 **A kernel that reads or writes the residency rail's `k_mirror`/`v_mirror` slabs leaves
 neither K/V codec - the mirror's element type, f16 or f32 - unserved**: both codecs covered

--- a/modules/dasLLAMA/REVIEW_GPU.md
+++ b/modules/dasLLAMA/REVIEW_GPU.md
@@ -15,12 +15,12 @@ is asked by `prefill_decline` / `decode_decline`, never by a caps predicate.** A
 reports the session's setup progress - rather than the CALL, its row count or its span
 shape - is a defect however it is derived.
 
-**A shape claim is settled at the site the device reads it, never at the das that computes
-the value.** An in-body tile constant is confirmed
+**A shape claim is settled at the one site that is authoritative for that kind of constant,
+never by tracing the das that computes the value.** An in-body tile constant is confirmed
 literal in the generated `*_msl` global or the SPIR-V dump; a grid or threadgroup constant is
 read off the class's `[metal_dispatch]` / `[vk_dispatch]` `grid=`/`tg=` spec, whose `"n/c"`
 form is a CEIL-divide - the spec alone decides, no builder read needed; a uniform's value is
-read at the single writer that fills its buffer.
+read at the single writer that fills its buffer, and nowhere upstream of it.
 
 **Kernel twins - kernel classes whose bodies differ on one stamp axis - bind the same kargs
 (kernel-argument struct) type at the same binding numbers**, even where one twin ignores a
@@ -90,12 +90,10 @@ decline site is a defect.
 
 **A diff that adds or removes a Metal-only or Vulkan-only hook, role, served path, or
 backend-only capability - anything that changes what one backend can serve and the other
-cannot - lands its `ARCHITECTURE.md` sec.1.5 edit in the
-same change - including when sec.1.5 already carries that class of asymmetry, and including
-sec.1.5's per-driver lists of registered hooks and borrowed kernels.**
-sec.1.5 is the closed list; an asymmetry it does not carry does not exist. A change that
-alters HOW an already-ledgered served path computes, without moving what either backend
-serves, does not fire this rule.
+cannot - lands its `ARCHITECTURE.md` sec.1.5 edit in the same change - including when
+sec.1.5 already carries that class of asymmetry, and including sec.1.5's per-driver lists
+of registered hooks and borrowed kernels.**
+sec.1.5 is the closed list; an asymmetry it does not carry does not exist.
 
 **A Vulkan pipeline is created only by a `[vk_dispatch]`-generated `ensure_*` and torn down by
 `vk_drop_model_state`.** A hand-written pipeline build anywhere else in the engine is a defect.
@@ -119,28 +117,27 @@ runs, or the in-suite instruments (`tests/test_metal_decode_parity.das` /
 driver declines codec-mismatched sessions silently.
 
 **A change to `dasllama/dasllama_metal_tower.das`, to the `AttnArgs` kargs struct, to any
-kernel class the tower dispatches (a builder it borrows changes the classes that builder
-dispatches), or to state the whole driver shares (a module-level `g_tw_*` variable,
-`metal_tower_init`, `dasllama_metal_tower_register` - reachable from every hook) runs the
-gate of every registered tower hook the changed code is reachable from.** The gates: the
+kernel class the tower dispatches or builder the tower borrows, or to state the whole
+driver shares (a module-level `g_tw_*` variable, `metal_tower_init`,
+`dasllama_metal_tower_register` - reachable from every hook) runs the gate of every
+registered tower hook the changed code is reachable from.** The gates: the
 family gates `tests/test_gemma4uv.das`, `tests/test_gemma4v.das`, `tests/test_gemma3v.das`, and
 `test_qwen3v_tier1_metal` in `tests/test_qwen3v.das`; the encoder-blocks leg's
 `tests/test_whisper.das`; the conv legs' `tests/test_audio.das` and
 `tests/test_audio_embedder.das`; plus a `tests/test_model_image.das` run with the `mtower`
 arm, `metal_tower_stats()`'s encode count rising across the run. A hook registered in
-`dasllama_metal_tower_register`, or a builder the tower borrows, that this rule does not
-name is the rule's defect to fix in the same change.
+`dasllama_metal_tower_register` that this rule's gates do not cover is the rule's defect to
+fix in the same change.
 
 **A change to the bake-trim path in `dasllama/dasllama_gpu_resident.das` (`trim_model_planes`)
 ships a `dasllama-convert --trim` bake plus a serve of the trimmed image, on one q8 and one kq
 model.** Parity runs never reach it.
 
-**A change to `dasllama/dasllama_metal_asr_dec.das`, to any kernel class the ASR decoder
-dispatches or builder it borrows, or any change to
-`dasllama/dasllama_metal_common.das`, ships a `tests/test_model_image.das` run with the
-`mtower` arm** - its CPU-vs-GPU transcript cells are the ASR-decoder driver's parity
-instrument, and the shared common paths and borrowed kernels reach that driver with no line
-of its own file touched.
+**A change to `dasllama/dasllama_metal_asr_dec.das`, to `dasllama/dasllama_metal_common.das`,
+or to any kernel class the ASR decoder dispatches or builder the ASR decoder borrows, ships
+a `tests/test_model_image.das` run with the `mtower` arm** - its CPU-vs-GPU transcript cells
+are the ASR-decoder driver's parity instrument, and the shared common paths and borrowed
+kernels reach that driver with no line of its own file touched.
 
 **A kernel that reads or writes the residency rail's `k_mirror`/`v_mirror` slabs leaves
 neither K/V codec - the mirror's element type, f16 or f32 - unserved**: both codecs covered

--- a/modules/dasLLAMA/benchmarks/REVIEW.md
+++ b/modules/dasLLAMA/benchmarks/REVIEW.md
@@ -11,9 +11,11 @@ measures fallback kernels silently. Tokenizing and detokenizing (`encode` / `enc
 that dispatches only pipelines the lab compiled itself never enters that path - nothing to
 gate.
 
-**A kernel A/B lab - a rig whose output selects between two implementations of the same
-compute - times both variants interleaved in one process with one instrument.** A board bench
-cell that picks a kernel tier by flag is not an A/B lab.
+**Timing whose output selects between two implementations of the same compute times both
+variants interleaved in one process with one instrument - whatever rig produced it and
+however the variant is chosen** (a knob flipped across two processes, or two runs at two
+commits, is a direction-grade reading, never the selection evidence). A board bench
+cell re-measured for the record is not selection timing.
 
 **An A/B arm whose timing is reported as adoptable evidence is first shown bit-exact against
 the lab's baseline arm or its CPU reference over the sampled region** (the report's
@@ -24,12 +26,14 @@ reported as evidence without that compare is a defect.
 line.**
 
 **A knockout or sweep instrument - one whose arms ATTRIBUTE cost across stages rather than
-select between two implementations - says so in its header: a line naming it an attribution
-sweep and naming what its arms attribute.** Without it the instrument reads as a lab and is
+select between two implementations - carries the literal header label "ATTRIBUTION SWEEP"
+and names what its arms attribute.** Without it the instrument reads as a lab and is
 deleted with a decision it never made.
 
-**A kernel A/B lab's numbers stay out of `../performance/records/<box>.json` and
-`../PERF_LEDGER.md`** - they settle the adoption decision in the lab's own report and the PR
+**What may enter `../PERF_LEDGER.md`: re-measured board rows, out-of-process observations,
+and direction-grade instrument readings ONLY when the entry names the instrument and marks
+the grade; what may enter `../performance/records/<box>.json`: board rows alone.** Lab
+selection numbers settle the adoption decision in the lab's own report and the PR
 that lands the kernel; the board learns the winner only through a re-measured cell row.
 
 **An out-of-process observer - a script that measures a benchmark process from outside -
@@ -42,8 +46,9 @@ repository does not build - a third-party reference tool - into
 the reference cells of `../performance/gen_bench_records.das`, the cells that time such a
 tool on a board workload.
 
-**A number derived by subtracting one measured wall from another prints both raw walls, not
-only the difference.**
+**A number derived by subtracting one measured wall from another carries both raw walls
+beside it - in the report line an instrument prints, and in any subtraction written into
+`../PERF_LEDGER.md` whose raw walls appear nowhere else in the entry.**
 
 **A change to the timed body or the measured input of a cell whose numbers are reported as
 evidence - a cell that mints rows into `../performance/records/<box>.json`, or the `--tok`

--- a/modules/dasLLAMA/benchmarks/REVIEW.md
+++ b/modules/dasLLAMA/benchmarks/REVIEW.md
@@ -11,30 +11,34 @@ measures fallback kernels silently. Tokenizing and detokenizing (`encode` / `enc
 that dispatches only pipelines the lab compiled itself never enters that path - nothing to
 gate.
 
-**Timing whose output selects between two implementations of the same compute times both
-variants interleaved in one process with one instrument - whatever rig produced it and
-however the variant is chosen** (a knob flipped across two processes, or two runs at two
-commits, is a direction-grade reading, never the selection evidence). A board bench
-cell re-measured for the record is not selection timing.
+**A choice between two implementations of the same compute is made only on timing that ran
+both variants interleaved in one process under one instrument, whatever rig produced it and
+whichever knob picks the variant inside that process.** A reading taken across two
+processes or across two commits is direction-grade - it says which way the wall moved, not
+which implementation to adopt - and using one to make the choice is a defect. A board bench
+cell re-measured for the record makes no choice and is not selection timing.
 
 **An A/B arm whose timing is reported as adoptable evidence is first shown bit-exact against
 the lab's baseline arm or its CPU reference over the sampled region** (the report's
 "bit-exact vs ..." line), the baseline arm itself answering to the CPU reference; an arm
 reported as evidence without that compare is a defect.
 
-**An A/B arm that skips the bit-exact compare against the CPU reference - a timing-only arm - says so in its report
-line.**
+**An A/B arm that skips the bit-exact compare against the CPU reference - a timing-only
+arm - says so in its report line.**
 
 **A knockout or sweep instrument - one whose arms ATTRIBUTE cost across stages rather than
-select between two implementations - carries the literal header label "ATTRIBUTION SWEEP"
-and names what its arms attribute.** Without it the instrument reads as a lab and is
-deleted with a decision it never made.
+select between two implementations - carries the literal text `ATTRIBUTION SWEEP` in its
+file header comment, on a line that also names what its arms attribute.** Without it the
+instrument reads as a lab and is deleted with a decision it never made.
 
-**What may enter `../PERF_LEDGER.md`: re-measured board rows, out-of-process observations,
-and direction-grade instrument readings ONLY when the entry names the instrument and marks
-the grade; what may enter `../performance/records/<box>.json`: board rows alone.** Lab
-selection numbers settle the adoption decision in the lab's own report and the PR
-that lands the kernel; the board learns the winner only through a re-measured cell row.
+**A lab's selection timings never enter `../PERF_LEDGER.md` or
+`../performance/records/<box>.json`** - they settle the adoption decision in the lab's own
+report and the PR that lands the kernel; the board learns the winner only through a
+re-measured cell row.
+
+**A direction-grade reading from an instrument under this folder enters `../PERF_LEDGER.md`
+only in an entry that names the instrument that produced it and calls the reading
+direction-grade, and never enters `../performance/records/<box>.json`.**
 
 **An out-of-process observer - a script that measures a benchmark process from outside -
 measures only what a process cannot measure about itself; its numbers may enter
@@ -46,9 +50,8 @@ repository does not build - a third-party reference tool - into
 the reference cells of `../performance/gen_bench_records.das`, the cells that time such a
 tool on a board workload.
 
-**A number derived by subtracting one measured wall from another carries both raw walls
-beside it - in the report line an instrument prints, and in any subtraction written into
-`../PERF_LEDGER.md` whose raw walls appear nowhere else in the entry.**
+**An instrument under this folder that prints a number formed by subtracting one measured
+wall from another prints both raw walls on that report line.**
 
 **A change to the timed body or the measured input of a cell whose numbers are reported as
 evidence - a cell that mints rows into `../performance/records/<box>.json`, or the `--tok`

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -386,6 +386,9 @@ struct public HarnessEnv {
     @clarg_doc = "Override the batched-dispatch chunk count in the 1-core GEMM probe."
     batch_chunks : string = ""
 
+    @clarg_doc = "Model filename (inside the models dir) the image-turn attribution probe loads."
+    probe_model : string = "Qwen3VL-8B-Instruct-Q8_0.gguf"
+
     @clarg_doc = "Use the 2D batch grid in the parity probe."
     batch_grid_2d : Option<int>
 

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -190,6 +190,9 @@ struct public MetalEnv {
     @clarg_doc = "The mul_mm prefill GEMM; 0 falls back to the legacy per-op path."
     mulmm : bool = true
 
+    @clarg_doc = "GEMV-tail prefill dispatch: npos % 32 in [1,8] peels the last M tile's real rows onto the fixed-B GEMV family instead of billing a full 32-row tile; 0 pins the padded-tile path (the A/B rail)."
+    mm_tail : bool = true
+
     @clarg_default_doc = "~4 layers/chunk"
     @clarg_doc = "Command-buffer split: each chunk commits as encoded so the scheduler overlaps chunk k with k-1."
     ncb : int = 0

--- a/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_kernels.das
@@ -1932,7 +1932,7 @@ class MetalQ8MvB2 {
             s += simd_shuffle_down(s, 4u)
             s += simd_shuffle_down(s, 2u)
             s += simd_shuffle_down(s, 1u)
-            if (tx == 0u && row0 < ka.ddim) {
+            if (tx == 0u && row0 < ka.ddim && uint(b) < ka.nrows) {
                 y[uint(b) * ka.ys + row0] = s
             }
         }
@@ -3671,8 +3671,8 @@ def metal_decode_init : bool {   // nolint:STYLE038 — a flat compile_pso per k
 
 // ===== encoders =====
 
-def enc_gemv(enc : MetalComputeEncoder?; bw : MetalBuffer?; boff : uint64; bx, by, bn, bd : MetalBuffer?; d : int64; yoff : uint64 = 0ul) {
-    enc_gemv_c(enc, bw, boff, bw, bx, by, yoff, bn, bd, d, 1l)
+def enc_gemv(enc : MetalComputeEncoder?; bw : MetalBuffer?; boff : uint64; bx, by, bn, bd : MetalBuffer?; d : int64; yoff : uint64 = 0ul; xoff : uint64 = 0ul) {
+    enc_gemv_c(enc, bw, boff, bw, bx, xoff, by, yoff, bn, bd, d, 1l)
 }
 
 // K-quant site GEMV — the per-format twin of enc_gemv over the kq plane pair
@@ -6386,8 +6386,8 @@ class template MetalQ8GemvT {
 class MetalQ8Gemv {
     @ssbo @binding = 0 @role = "weight" @off = "boff" wsh : array<float16> // 34B-block W blob, half-scale view (block b at 17*b)
     @ssbo @binding = 1 @role = "weight" @off = "boff" wqb : array<int8>    // the same blob buffer, byte view (quants at 34*b + 2)
-    @ssbo @binding = 2 x : array<float4>    // [n] f32 vector, float4 view
-    @ssbo @binding = 3 @off = "yoff" @span = "d*np*4" y : array<float>     // [d] outputs (np = 1 on this form)
+    @ssbo @binding = 2 @role = "read" @off = "xoff" x : array<float4>    // [n] f32 vector, float4 view
+    @ssbo @binding = 3 @role = "write" @off = "yoff" @span = "d*np*4" y : array<float>     // [d] outputs (np = 1 on this form)
     @uniform @binding = 4 ndim : uint       // n (reduction dim, % 32)
     @uniform @binding = 5 ddim : uint       // d (output rows)
     @workgroup red : float[64]              // [2 rows][32 lanes] cross-sg partials

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -1740,6 +1740,12 @@ def public set_metal_prefill_mulmm_legacy(v : bool) {
     g_mm_legacy = v
 }
 
+//! A/B seat: the GEMV-tail prefill dispatch (small npos % 32 remainders peel onto the mv
+//! family) vs the padded-tile path — `DASLLAMA_METAL_MM_TAIL`'s setter twin. Default on.
+def public set_metal_prefill_mm_tail(v : bool) {
+    g_pf_env_mm_tail = v
+}
+
 //! The prefill knockout rail as an in-process setter (timing attribution — served output is
 //! GARBAGE while non-empty): the `DASLLAMA_METAL_PREFILL_SKIP` families above; `""` restores
 //! full math. Switchable between measurement windows, same contract as `set_metal_decode_skip`.
@@ -2083,10 +2089,57 @@ def private prefill_decline_caps(t : Model; npos : int64; span : bool = false) :
 }
 
 
-// the production mul_mm dispatch: W blob bound twice (half-scale + byte views), raw f32 X,
-// grid (mp/32 token tiles, d/64 output tiles). Requires d % 64 == 0 and mp % 32 == 0.
-// yoff places the K/V outputs past a continuation's existing panel rows.
-def private enc_gemm_mm(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; wboff : uint64; bx, by, bk, bn : MetalBuffer?; mp, d : int64; yoff : uint64 = 0ul) {
+// The GEMV-tail row cap: npos % 32 remainders up to this many rows peel onto the fixed-B mv
+// family (two dispatches past 4). Above it the padded tile is cheaper than 3+ weight streams.
+let private MM_TAIL_MAX = 8l
+
+var private g_pf_tail_sites = 0l
+var private g_pf_tail_rows = 0l
+
+//! GEMV-tail engage counters: (sites, rows) peeled since load — the gates' anti-vacuous witness.
+def public metal_prefill_tail_stats() : tuple<sites : int64; rows : int64> {
+    return (sites = g_pf_tail_sites, rows = g_pf_tail_rows)
+}
+
+// the peeled rows [row0, row0+r) of one mul_mm site as fixed-B GEMVs: y rows at stride d (every
+// mul_mm site's bn uniform equals its grid width d — a wider fused-row site must NOT take the
+// tail); r == 1 rides the reduction-split decode GEMV (the mv forms idle half their lanes on it).
+def private enc_gemm_mm_tail(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; wboff : uint64;
+                             bx, by, bk, bn : MetalBuffer?; yoff : uint64; kdim, d, row0, r : int64) {
+    g_pf_tail_sites++
+    g_pf_tail_rows += r
+    let xoff = uint64(row0 * kdim * 4l)
+    let yo = yoff + uint64(row0 * d * 4l)
+    if (r == 1l) {
+        enc_gemv(enc, bwblob, wboff, bx, by, bk, bn, d, yo, xoff)
+        return
+    }
+    var ka = Q8MvArgs(ndim = uint(kdim), ddim = uint(d), nrows = uint(min(r, 4l)),
+        xs4 = uint(kdim / 4l), ys = uint(d))
+    enc_mv_b(enc, r > 2l, bwblob, wboff, bx, by, ka, xoff, yo)
+    if (r > 4l) {
+        ka.nrows = uint(r - 4l)
+        enc_mv_b(enc, true, bwblob, wboff, bx, by, ka, xoff + uint64(4l * kdim * 4l), yo + uint64(4l * d * 4l))
+    }
+}
+
+// the production mul_mm dispatch: W blob bound twice (half-scale + byte views), raw f32 X, grid
+// (mp/32 token tiles, d/64 output tiles); yoff places K/V outputs past a continuation's panel rows.
+// kdim/npos arm the GEMV tail: full tiles + the npos % 32 remainder rows on the mv family.
+def private enc_gemm_mm(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; wboff : uint64; bx, by, bk, bn : MetalBuffer?; mp, d : int64; yoff : uint64 = 0ul; kdim : int64 = 0l; npos : int64 = 0l) {
+    let r = npos % 32l
+    if (g_pf_env_mm_tail && npos > 0l && r >= 1l && r <= MM_TAIL_MAX && kdim % 32l == 0l && d % 8l == 0l) {
+        let nfull = npos - r
+        if (nfull > 0l) {
+            if (g_pf_mm_tensor) {
+                enc_gemm_mm_t_c(enc, bwblob, wboff, bwblob, bx, by, yoff, bk, bn, nfull, d)
+            } else {
+                enc_gemm_mm_c(enc, bwblob, wboff, bwblob, bx, by, yoff, bk, bn, nfull, d)
+            }
+        }
+        enc_gemm_mm_tail(enc, bwblob, wboff, bx, by, bk, bn, yoff, kdim, d, nfull, r)
+        return
+    }
     if (g_pf_mm_tensor) {
         enc_gemm_mm_t_c(enc, bwblob, wboff, bwblob, bx, by, yoff, bk, bn, mp, d)
     } else {
@@ -2745,7 +2798,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     pf_enc_cat2(enc, bwm_cat, bxb, bxb2, u_dim, u_wm_tot, npos * dim)
                     if (t.mtp_ehproj_fmt == KqFmt.q8) {
                         let behp = blob_of(g_dev, t, t.mtp_ehproj_off)
-                        enc_gemm_mm(enc, behp.buf, behp.boff, bwm_cat, bx, u_dim2, u_dim, mp, dim)
+                        enc_gemm_mm(enc, behp.buf, behp.boff, bwm_cat, bx, u_dim2, u_dim, mp, dim, 0ul, 2l * dim, npos)
                     } else {
                         pf_enc_kq_site_mm(enc, t, t.mtp_ehproj_fmt, t.mtp_ehproj_off, dim, bwm_cat, bx, u_dim2, u_dim, mp)
                     }
@@ -2782,9 +2835,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     // sequential scan (state walks the whole window in-kernel) -> gated out-norm -> out-proj
                     if (g_pf_skip != "gemm") {
                         let bwqkv = blob_of(g_dev, t, t.dnqkv_offs[l])
-                        enc_gemm_mm(enc, bwqkv.buf, bwqkv.boff, bxb, bdnqkv, u_dim, u_dn_cd, mp, cd_dn)
+                        enc_gemm_mm(enc, bwqkv.buf, bwqkv.boff, bxb, bdnqkv, u_dim, u_dn_cd, mp, cd_dn, 0ul, dim, npos)
                         let bwz = blob_of(g_dev, t, t.dngate_offs[l])
-                        enc_gemm_mm(enc, bwz.buf, bwz.boff, bxb, bdnz, u_dim, u_dn_di, mp, di_dn)
+                        enc_gemm_mm(enc, bwz.buf, bwz.boff, bxb, bdnz, u_dim, u_dn_di, mp, di_dn, 0ul, dim, npos)
                         if (t.dn_ba_f32) {
                             // F32-on-disk β/α (35B): fblob slabs ride the router-b f32 GEMV
                             var bw_bt = upload_region(addr < void? >(t.fblob[t.dn_betaf_off + l * dim * nvh_dn]), uint64(dim * nvh_dn * 4l))
@@ -2815,7 +2868,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     }
                     if (g_pf_skip != "gemm") {
                         let bwo = blob_of(g_dev, t, t.dnout_offs[l])
-                        enc_gemm_mm(enc, bwo.buf, bwo.boff, bdno, bxb2, u_dn_di, u_dim, mp, dim)
+                        enc_gemm_mm(enc, bwo.buf, bwo.boff, bdno, bxb2, u_dn_di, u_dim, mp, dim, 0ul, di_dn, npos)
                     }
                     dnli++
                 }
@@ -2832,7 +2885,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                                 pf_enc_kq_site_mm(enc, t, fq, t.wq_offs[l], 2l * qd_l, bxb, bdnqg, u_dim, u_dn_qd2, mp)
                             } else {
                                 let bwqb = blob_of(g_dev, t, t.wq_offs[l])
-                                enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l)
+                                enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l, 0ul, dim, npos)
                             }
                             enc_dn_deint(enc, bdnqg, bq, bdngate,
                                 DnDeintArgs(hs = uint(hs_l), qd = uint(qd_l), qs = uint(qd_l)), qd_l, npos)
@@ -2840,21 +2893,21 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             pf_enc_kq_site_mm(enc, t, fq, t.wq_offs[l], qd_l, bxb, bq, u_dim, u_qd_l, mp)
                         } else {
                             let bwqb = blob_of(g_dev, t, t.wq_offs[l])
-                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l)
+                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l, 0ul, dim, npos)
                         }
                         if (!kvsh) {
                             if (fk != KqFmt.q8) {
                                 pf_enc_kq_site_mm(enc, t, fk, t.wk_offs[l], kvd_l, bxb, bks[l], u_dim, u_kvd_l, mp, koff)
                             } else {
                                 let bwkb = blob_of(g_dev, t, t.wk_offs[l])
-                                enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                                enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff, dim, npos)
                             }
                             if (has_wv) {
                                 if (fv != KqFmt.q8) {
                                     pf_enc_kq_site_mm(enc, t, fv, t.wv_offs[l], kvd_l, bxb, bvs[l], u_dim, u_kvd_l, mp, koff)
                                 } else {
                                     let bwvb = blob_of(g_dev, t, t.wv_offs[l])
-                                    enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                                    enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff, dim, npos)
                                 }
                             }
                         }
@@ -2862,18 +2915,18 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         let bwqb = blob_of(g_dev, t, t.wq_offs[l])
                         if (c.q_gated) {
                             // 2x-wide packed [q|gate] projection, deinterleaved into the q panel + gate rows
-                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l)
+                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bdnqg, u_dim, u_dn_qd2, mp, 2l * qd_l, 0ul, dim, npos)
                             enc_dn_deint(enc, bdnqg, bq, bdngate,
                                 DnDeintArgs(hs = uint(hs_l), qd = uint(qd_l), qs = uint(qd_l)), qd_l, npos)
                         } else {
-                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l)
+                            enc_gemm_mm(enc, bwqb.buf, bwqb.boff, bxb, bq, u_dim, u_qd_l, mp, qd_l, 0ul, dim, npos)
                         }
                         if (!kvsh) {   // shared layers have no K/V tensors (offs -1)
                             let bwkb = blob_of(g_dev, t, t.wk_offs[l])
-                            enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                            enc_gemm_mm(enc, bwkb.buf, bwkb.boff, bxb, bks[l], u_dim, u_kvd_l, mp, kvd_l, koff, dim, npos)
                             if (has_wv) {
                                 let bwvb = blob_of(g_dev, t, t.wv_offs[l])
-                                enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff)
+                                enc_gemm_mm(enc, bwvb.buf, bwvb.boff, bxb, bvs[l], u_dim, u_kvd_l, mp, kvd_l, koff, dim, npos)
                             }
                         }
                     }
@@ -2973,7 +3026,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         pf_enc_kq_site_mm(enc, t, fo, t.wo_offs[l], dim, bxb, bxb2, u_qd_l, u_dim, mp)
                     } else {
                         let bwob = blob_of(g_dev, t, t.wo_offs[l])
-                        enc_gemm_mm(enc, bwob.buf, bwob.boff, bxb, bxb2, u_qd_l, u_dim, mp, dim)
+                        enc_gemm_mm(enc, bwob.buf, bwob.boff, bxb, bxb2, u_qd_l, u_dim, mp, dim, 0ul, qd_l, npos)
                     }
                     if (c.attn_out_bias) {
                         var bwo_b = upload_region(unsafe(addr < void? >(t.bo[l * dim])), uint64(dim * 4l))
@@ -3041,9 +3094,9 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         if (nsh > 0l) {
                             // shexp gate/up: dense q8 mul_mm at the wsh planes (bhb/bhb2 sized max(hidden, nsh))
                             let bwsh1 = blob_of(g_dev, t, t.wsh1_off + l * dim * nsh)
-                            enc_gemm_mm(enc, bwsh1.buf, bwsh1.boff, bxb, bhb, u_dim, u_moe_nsh, mp, nsh)
+                            enc_gemm_mm(enc, bwsh1.buf, bwsh1.boff, bxb, bhb, u_dim, u_moe_nsh, mp, nsh, 0ul, dim, npos)
                             let bwsh3 = blob_of(g_dev, t, t.wsh3_off + l * dim * nsh)
-                            enc_gemm_mm(enc, bwsh3.buf, bwsh3.boff, bxb, bhb2, u_dim, u_moe_nsh, mp, nsh)
+                            enc_gemm_mm(enc, bwsh3.buf, bwsh3.boff, bxb, bhb2, u_dim, u_moe_nsh, mp, nsh, 0ul, dim, npos)
                         }
                     }
                 }
@@ -3078,7 +3131,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         if (nsh > 0l) {
                             // shexp down into bxb2 (free post-residual) — bxb still feeds the reduce
                             let bwsh2 = blob_of(g_dev, t, t.wsh2_off + l * dim * nsh)
-                            enc_gemm_mm(enc, bwsh2.buf, bwsh2.boff, bhb, bxb2, u_moe_nsh, u_dim, mp, dim)
+                            enc_gemm_mm(enc, bwsh2.buf, bwsh2.boff, bhb, bxb2, u_moe_nsh, u_dim, mp, dim, 0ul, nsh, npos)
                         }
                     }
                     if (!pf_skip_moe_reduce()) {
@@ -3104,19 +3157,19 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                             pf_enc_kq_site_mm(enc, t, f1, t.w1_offs[l], hid_l, bxb, bhb, u_dim, u_hid_l, mp)
                         } else {
                             let bw1b = blob_of(g_dev, t, t.w1_offs[l])
-                            enc_gemm_mm(enc, bw1b.buf, bw1b.boff, bxb, bhb, u_dim, u_hid_l, mp, hid_l)
+                            enc_gemm_mm(enc, bw1b.buf, bw1b.boff, bxb, bhb, u_dim, u_hid_l, mp, hid_l, 0ul, dim, npos)
                         }
                         if (f3 != KqFmt.q8) {
                             pf_enc_kq_site_mm(enc, t, f3, t.w3_offs[l], hid_l, bxb, bhb2, u_dim, u_hid_l, mp)
                         } else {
                             let bw3b = blob_of(g_dev, t, t.w3_offs[l])
-                            enc_gemm_mm(enc, bw3b.buf, bw3b.boff, bxb, bhb2, u_dim, u_hid_l, mp, hid_l)
+                            enc_gemm_mm(enc, bw3b.buf, bw3b.boff, bxb, bhb2, u_dim, u_hid_l, mp, hid_l, 0ul, dim, npos)
                         }
                     } else {
                         let bw1b = blob_of(g_dev, t, t.w1_offs[l])
                         let bw3b = blob_of(g_dev, t, t.w3_offs[l])
-                        enc_gemm_mm(enc, bw1b.buf, bw1b.boff, bxb, bhb, u_dim, u_hid_l, mp, hid_l)
-                        enc_gemm_mm(enc, bw3b.buf, bw3b.boff, bxb, bhb2, u_dim, u_hid_l, mp, hid_l)
+                        enc_gemm_mm(enc, bw1b.buf, bw1b.boff, bxb, bhb, u_dim, u_hid_l, mp, hid_l, 0ul, dim, npos)
+                        enc_gemm_mm(enc, bw3b.buf, bw3b.boff, bxb, bhb2, u_dim, u_hid_l, mp, hid_l, 0ul, dim, npos)
                     }
                 }
                 if ((!moe || g4moe) && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
@@ -3132,7 +3185,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                         pf_enc_kq_site_mm(enc, t, f2, t.w2_offs[l], dim, bhb, bxb, u_hid_l, u_dim, mp)
                     } else {
                         let bw2b = blob_of(g_dev, t, t.w2_offs[l])
-                        enc_gemm_mm(enc, bw2b.buf, bw2b.boff, bhb, bxb, u_hid_l, u_dim, mp, dim)
+                        enc_gemm_mm(enc, bw2b.buf, bw2b.boff, bhb, bxb, u_hid_l, u_dim, mp, dim, 0ul, hid_l, npos)
                     }
                 }
                 if (g4moe && g_pf_skip != "ew" && g_pf_skip != "nongemm") {
@@ -3155,14 +3208,14 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
                     }
                     if (g_pf_skip != "gemm") {
                         let bwpg = blob_of(g_dev, t, t.ple_gate_off + l * dim * ple_n)
-                        enc_gemm_mm(enc, bwpg.buf, bwpg.boff, bx, bpleg, u_dim, u_ple, mp, ple_n)
+                        enc_gemm_mm(enc, bwpg.buf, bwpg.boff, bx, bpleg, u_dim, u_ple, mp, ple_n, 0ul, dim, npos)
                     }
                     if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                         enc_geglu(enc, bpleg, 0ul, bple, uint64(l * npos * ple_n * 4l), u_ple_tot, npos * ple_n)
                     }
                     if (g_pf_skip != "gemm") {
                         let bwpp = blob_of(g_dev, t, t.ple_proj_off + l * ple_n * dim)
-                        enc_gemm_mm(enc, bwpp.buf, bwpp.boff, bpleg, bxb, u_ple, u_dim, mp, dim)
+                        enc_gemm_mm(enc, bwpp.buf, bwpp.boff, bpleg, bxb, u_ple, u_dim, mp, dim, 0ul, ple_n, npos)
                     }
                     if (g_pf_skip != "ew" && g_pf_skip != "nongemm") {
                         var bw_pn = upload_region(addr < void? >(t.fblob[t.ple_post_off + l * dim]), uint64(dim * 4l))
@@ -3477,6 +3530,7 @@ def metal_prefill_forward(t : Model; var s : Session; npos, start_pos : int64) :
 // Knobs resolved once at [init]. They were read per prefill call, and get_env_variable allocates
 // its result in the context heap on every call — see PERF027.
 var private g_pf_env_mulmm = true
+var private g_pf_env_mm_tail = true
 var private g_pf_env_span = true
 var private g_pf_env_logits = true
 var private g_pf_env_attn = true
@@ -3493,6 +3547,7 @@ def dasllama_metal_prefill_register() {
     register_prefill_override_ds_adds("metal")   // the per-layer slice adds encode via enc_add over the uploaded slice planes
     register_ple_gpu_gate(@@metal_ple_pre_gpu_gate)
     g_pf_env_mulmm = g_env_metal.mulmm
+    g_pf_env_mm_tail = g_env_metal.mm_tail
     g_pf_env_span = g_env_metal.span
     g_pf_env_logits = g_env_metal.logits
     g_pf_env_attn = g_env_metal.attn

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -1305,8 +1305,11 @@ class MetalAttnAV {
         let lid = gl_LocalInvocationID.x
         let sg = gl_SubgroupID
         let kvhoff = (h / ka.kv_mul) * ka.head_size
-        // causal: P rows here are zero past qoff+qi0+31; uniform span: softmax zeroed [uend, np32)
-        let jlimit = ka.uend > 0u ? ka.np32 : min(ka.qoff + qi0 + 32u, ka.np32)
+        // P rows are zero past each row's live length, so the walk bound is the tile's max:
+        // causal reach, lifted to uend only when the tile holds span rows (causal-only tiles
+        // above the span keep their short walk)
+        let creach = ka.qoff + qi0 + 32u
+        let jlimit = min(ka.uend > 0u && ka.qoff + qi0 < ka.uend && creach > ka.ulo ? max(ka.uend, creach) : creach, ka.np32)
         let qm = (sg / 2u) * 16u
         let qn = (sg % 2u) * 16u
         var c00 : simdgroup_float8x8
@@ -1513,8 +1516,10 @@ class MetalAttnAVMmT {
         let h = gl_WorkGroupID.z
         let kvhoff = (h / ka.kv_mul) * ka.head_size
         let lid = gl_LocalInvocationID.x
-        // P rows here are zero past qoff+mBase+31; uniform span: softmax zeroed [uend, np32)
-        let klimit = ka.uend > 0u ? ka.np32 : min(ka.qoff + mBase + 32u, ka.np32)
+        // the tile-max walk bound: causal reach, lifted to uend only when the tile holds span
+        // rows (P is softmax-zeroed past each row's live length either way)
+        let creach = ka.qoff + mBase + 32u
+        let klimit = min(ka.uend > 0u && ka.qoff + mBase < ka.uend && creach > ka.ulo ? max(ka.uend, creach) : creach, ka.np32)
         var acc : float[2048]
         var cp = unsafe(addr(xb[mBase * ka.qd + h * ka.head_size + vBase]))
         tmm2d_tg_begin(acc, 32u, 64u, 4u, 32u)
@@ -1571,8 +1576,10 @@ class MetalAttnAVMm : MetalMmTileBase {
         let bB = (sg / 2u) * 128u
         var ma : simdgroup_half8x8[4]
         var mb : simdgroup_half8x8[2]
-        // causal: P rows here are zero past qoff+mBase+31; uniform span: softmax zeroed [uend, np32)
-        let klimit = ka.uend > 0u ? ka.np32 : min(ka.qoff + mBase + 32u, ka.np32)
+        // the tile-max walk bound: causal reach, lifted to uend only when the tile holds span
+        // rows (P is softmax-zeroed past each row's live length either way)
+        let creach = ka.qoff + mBase + 32u
+        let klimit = min(ka.uend > 0u && ka.qoff + mBase < ka.uend && creach > ka.ulo ? max(ka.uend, creach) : creach, ka.np32)
         var kb = 0u
         while (kb * 32u < klimit) {
             let posg = kb * 32u + pr

--- a/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_metal_prefill.das
@@ -2110,7 +2110,7 @@ def public metal_prefill_tail_stats() : tuple<sites : int64; rows : int64> {
 
 // the peeled rows [row0, row0+r) of one mul_mm site as fixed-B GEMVs: y rows at stride d (every
 // mul_mm site's bn uniform equals its grid width d — a wider fused-row site must NOT take the
-// tail); r == 1 rides the reduction-split decode GEMV (the mv forms idle half their lanes on it).
+// tail); r == 1 rides the reduction-split GEMV, r >= 2 the b4 form only (b2's stripe needs % 256).
 def private enc_gemm_mm_tail(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; wboff : uint64;
                              bx, by, bk, bn : MetalBuffer?; yoff : uint64; kdim, d, row0, r : int64) {
     g_pf_tail_sites++
@@ -2123,7 +2123,7 @@ def private enc_gemm_mm_tail(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; 
     }
     var ka = Q8MvArgs(ndim = uint(kdim), ddim = uint(d), nrows = uint(min(r, 4l)),
         xs4 = uint(kdim / 4l), ys = uint(d))
-    enc_mv_b(enc, r > 2l, bwblob, wboff, bx, by, ka, xoff, yo)
+    enc_mv_b(enc, true, bwblob, wboff, bx, by, ka, xoff, yo)
     if (r > 4l) {
         ka.nrows = uint(r - 4l)
         enc_mv_b(enc, true, bwblob, wboff, bx, by, ka, xoff + uint64(4l * kdim * 4l), yo + uint64(4l * d * 4l))
@@ -2135,7 +2135,9 @@ def private enc_gemm_mm_tail(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; 
 // kdim/npos arm the GEMV tail: full tiles + the npos % 32 remainder rows on the mv family.
 def private enc_gemm_mm(enc : MetalComputeEncoder?; bwblob : MetalBuffer?; wboff : uint64; bx, by, bk, bn : MetalBuffer?; mp, d : int64; yoff : uint64 = 0ul; kdim : int64 = 0l; npos : int64 = 0l) {
     let r = npos % 32l
-    if (g_pf_env_mm_tail && npos > 0l && r >= 1l && r <= MM_TAIL_MAX && kdim % 32l == 0l && d % 8l == 0l) {
+    // per-form reduction alignment: the gemv walks per-block; the b4 stripe reads whole 128-quant rounds
+    let align_ok = r == 1l ? kdim % 32l == 0l : kdim % 128l == 0l
+    if (g_pf_env_mm_tail && npos > 0l && r >= 1l && r <= MM_TAIL_MAX && align_ok && d % 8l == 0l) {
         let nfull = npos - r
         if (nfull > 0l) {
             if (g_pf_mm_tensor) {
@@ -3555,6 +3557,9 @@ def dasllama_metal_prefill_register() {
     register_ple_gpu_gate(@@metal_ple_pre_gpu_gate)
     g_pf_env_mulmm = g_env_metal.mulmm
     g_pf_env_mm_tail = g_env_metal.mm_tail
+    if (!g_pf_env_mm_tail) {
+        to_log(LOG_WARNING, "dasLLAMA metal prefill: DASLLAMA_METAL_MM_TAIL=0 - small npos % 32 remainders bill the padded tile (numerics move with the form)\n")
+    }
     g_pf_env_span = g_env_metal.span
     g_pf_env_logits = g_env_metal.logits
     g_pf_env_attn = g_env_metal.attn

--- a/modules/dasLLAMA/dasllama/dasllama_version.das
+++ b/modules/dasLLAMA/dasllama/dasllama_version.das
@@ -9,4 +9,4 @@ require dasllama/dasllama_lint public
 //! dasLLAMA's release counter — decoupled from the daslang version and LLVM_JIT_CODEGEN_VERSION.
 //! ANY kernel work bumps it (REVIEW.md): equal versions mean an equal kernel roster, and the
 //! sidecar exchange keys validity on (version, box). Bench records and sidecar provenance carry it.
-let DASLLAMA_VERSION = 8   // v8: the reduction-split q8 decode GEMV family (MetalQ8Gemv + qkv_rs + w13sw)
+let DASLLAMA_VERSION = 9   // v9: the GEMV-tail prefill dispatch (small npos % 32 remainders peel onto the mv family) + the mv_b2 store gate

--- a/modules/dasLLAMA/harness/image_turn_probe.das
+++ b/modules/dasLLAMA/harness/image_turn_probe.das
@@ -1,0 +1,111 @@
+options gen2
+options persistent_heap
+options stack = 524288   // every dasLLAMA program root takes this budget (options stack does not unify up from libs)
+options _dasllama_internal = true
+
+require dasllama/dasllama_transformer   // umbrella fires each arch [init] registration
+require dasllama/dasllama_common
+require dasllama/dasllama_math
+require dasllama/dasllama_blocks
+require dasllama/dasllama_load
+require dasllama/dasllama_image   // nolint:STYLE030,LINT019 — load_model_cached, used only inside the das_metal static_if half
+require dasllama/dasllama_env
+require ?das_metal dasllama/dasllama_metal_prefill
+require ../performance/profile_common.das   // tune_gate + apply_box_profile_runtime — the standing pre-measure stack
+require daslib/jobque_boost
+require daslib/fio
+require math
+
+// The IMAGE-TURN attribution probe: one loaded model, npos=321 (the coco turn shape), three
+// workloads — plain tokens, a narrow embd quantum with the mrope span, and the ds-wide
+// quantum — crossed with the DASLLAMA_METAL_PREFILL_SKIP knockout arms, all in ONE process.
+// Splits the image-turn tax over text into its (mrope+span) and (ds-wide) halves, then
+// attributes whichever half carries it across stage families. Direction-grade, output GARBAGE
+// on the skip arms by contract.
+
+let NPOS = 321l
+let SPAN_LO = 4l
+let SPAN_HI = 304l   // 300 media rows, the 20x15 coco grid
+let GRID_X = 20l
+let GRID_Y = 15l
+let REPS = 3
+
+def measure_tokens(tr : Model; reps : int) : double {
+    var best = 1.0e30lf
+    for (_r in range(reps)) {
+        var s <- make_run_state(tr.config)
+        var toks : array<int64>
+        toks |> reserve(NPOS)
+        for (i in range64(NPOS)) {
+            toks |> push(100l + i % 5000l)
+        }
+        let t0 = ref_time_ticks()
+        eval_(tr, s, toks)
+        let ms = double(get_time_usec(t0)) / 1000.0lf
+        if (ms < best) {
+            best = ms
+        }
+        delete toks
+        delete s
+    }
+    return best
+}
+
+def measure_span(tr : Model; wide : bool; reps : int) : double {
+    let dim = tr.config.dim
+    let stride = wide ? (1l + tr.config.n_deepstack) * dim : dim
+    var best = 1.0e30lf
+    for (_r in range(reps)) {
+        var s <- make_run_state(tr.config)
+        var embd : array<float>
+        embd |> resize(NPOS * stride)
+        for (i in range64(NPOS * stride)) {
+            embd[i] = 0.01 * sin(float(i % 1024l))
+        }
+        let t0 = ref_time_ticks()
+        eval_embd_span_mrope_(tr, s, embd, NPOS, SPAN_LO, SPAN_HI, GRID_X, GRID_Y)
+        let ms = double(get_time_usec(t0)) / 1000.0lf
+        if (ms < best) {
+            best = ms
+        }
+        delete embd
+        delete s
+    }
+    return best
+}
+
+[export]
+def main {
+    let env = g_env_harness.models_dir
+    let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+    let mname = get_env_variable("PROBE_MODEL")
+    let path = path_join(mdir, empty(mname) ? "Qwen3VL-8B-Instruct-Q8_0.gguf" : mname)
+    static_if (typeinfo builtin_module_exists(das_metal)) {
+        set_metal_mode(MetalMode.required)   // before load — pins the metal serving, same as the bench's --ngl leg
+        var tr <- load_model_cached(path, QuantMode.q8)
+        if (!tr.metal_blob) {
+            panic("image_turn_probe: the mapped flavor is not metal_blob - wrong leg")
+        }
+        tr.config.seq_len = 2048l
+        apply_box_profile_runtime()
+        if (!tune_gate()) {   // never measure on fallback winners
+            panic("image_turn_probe: tune_gate refused - point DAS_TUNE_MANIFEST at a complete sidecar")
+        }
+        with_job_que() {
+            setup_dasllama_jobque_()
+            measure_tokens(tr, 1)   // warm: JIT + first touch + schedule compile
+            for (arm in ["", "gemm", "attn", "ew", "nongemm"]) {
+                set_metal_prefill_skip(arm)
+                let t = measure_tokens(tr, REPS)
+                let nsp = measure_span(tr, false, REPS)
+                let wsp = measure_span(tr, true, REPS)
+                let tag = empty(arm) ? "full" : arm
+                print("PROBE {tag}: tokens {t} ms | narrow-span {nsp} ms | wide-span {wsp} ms | narrow-tax {nsp - t} | wide-tax {wsp - t}\n")
+            }
+            set_metal_prefill_skip("")
+        }
+        delete tr
+    } else {
+        print("image_turn_probe: no das_metal on this build - nothing to probe\n")
+    }
+}

--- a/modules/dasLLAMA/harness/image_turn_probe.das
+++ b/modules/dasLLAMA/harness/image_turn_probe.das
@@ -51,7 +51,8 @@ def measure_tokens(tr : Model; reps : int) : double {
     return best
 }
 
-def measure_span(tr : Model; wide : bool; reps : int) : double {
+def measure_span(tr : Model; wide : bool; reps : int; lo : int64 = SPAN_LO; hi : int64 = SPAN_HI;
+                 gx : int64 = GRID_X; gy : int64 = GRID_Y) : double {
     let dim = tr.config.dim
     let stride = wide ? (1l + tr.config.n_deepstack) * dim : dim
     var best = 1.0e30lf
@@ -63,7 +64,7 @@ def measure_span(tr : Model; wide : bool; reps : int) : double {
             embd[i] = 0.01 * sin(float(i % 1024l))
         }
         let t0 = ref_time_ticks()
-        eval_embd_span_mrope_(tr, s, embd, NPOS, SPAN_LO, SPAN_HI, GRID_X, GRID_Y)
+        eval_embd_span_mrope_(tr, s, embd, NPOS, lo, hi, gx, gy)
         let ms = double(get_time_usec(t0)) / 1000.0lf
         if (ms < best) {
             best = ms
@@ -101,6 +102,17 @@ def main {
                 let wsp = measure_span(tr, true, REPS)
                 let tag = empty(arm) ? "full" : arm
                 print("PROBE {tag}: tokens {t} ms | narrow-span {nsp} ms | wide-span {wsp} ms | narrow-tax {nsp - t} | wide-tax {wsp - t}\n")
+            }
+            // the span-tax split: which attention STAGE carries it (the per-stage knockouts),
+            // and how it scales with span size (span of 1 row = the constant/overhead part,
+            // 300 rows = overhead + the intrinsic non-causal pairs)
+            for (arm in ["", "attn_qk", "attn_sm", "attn_av"]) {
+                set_metal_prefill_skip(arm)
+                let t = measure_tokens(tr, REPS)
+                let s300 = measure_span(tr, false, REPS)
+                let s1 = measure_span(tr, false, REPS, SPAN_LO, SPAN_LO + 1l, 1l, 1l)
+                let tag = empty(arm) ? "split-full" : arm
+                print("SPLIT {tag}: tokens {t} ms | span300 {s300} ms | span1 {s1} ms | tax300 {s300 - t} | tax1 {s1 - t}\n")
             }
             set_metal_prefill_skip("")
         }

--- a/modules/dasLLAMA/harness/image_turn_probe.das
+++ b/modules/dasLLAMA/harness/image_turn_probe.das
@@ -9,14 +9,14 @@ require dasllama/dasllama_math
 require dasllama/dasllama_blocks
 require dasllama/dasllama_load
 require dasllama/dasllama_image   // nolint:STYLE030,LINT019 — load_model_cached, used only inside the das_metal static_if half
-require dasllama/dasllama_env
+require dasllama/dasllama_env   // nolint:STYLE030,LINT019 — g_env_harness, read only inside the das_metal static_if half
 require ?das_metal dasllama/dasllama_metal_prefill
 require ../performance/profile_common.das   // tune_gate + apply_box_profile_runtime — the standing pre-measure stack
 require daslib/jobque_boost
-require daslib/fio
+require daslib/fio   // nolint:STYLE030,LINT019 — path_join, used only inside the das_metal static_if half
 require math
 
-// The IMAGE-TURN attribution probe: one loaded model, npos=321 (the coco turn shape), three
+// An ATTRIBUTION SWEEP: one loaded model, npos=321 (the coco turn shape), three
 // workloads — plain tokens, a narrow embd quantum with the mrope span, and the ds-wide
 // quantum — crossed with the DASLLAMA_METAL_PREFILL_SKIP knockout arms, all in ONE process.
 // Splits the image-turn tax over text into its (mrope+span) and (ds-wide) halves, then
@@ -77,11 +77,10 @@ def measure_span(tr : Model; wide : bool; reps : int; lo : int64 = SPAN_LO; hi :
 
 [export]
 def main {
-    let env = g_env_harness.models_dir
-    let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
-    let mname = get_env_variable("PROBE_MODEL")
-    let path = path_join(mdir, empty(mname) ? "Qwen3VL-8B-Instruct-Q8_0.gguf" : mname)
     static_if (typeinfo builtin_module_exists(das_metal)) {
+        let env = g_env_harness.models_dir
+        let mdir = empty(env) ? "/Users/borisbatkin/Work/llama.cpp/models/" : env
+        let path = path_join(mdir, g_env_harness.probe_model)
         set_metal_mode(MetalMode.required)   // before load — pins the metal serving, same as the bench's --ngl leg
         var tr <- load_model_cached(path, QuantMode.q8)
         if (!tr.metal_blob) {

--- a/modules/dasLLAMA/qwen_pp_plan.md
+++ b/modules/dasLLAMA/qwen_pp_plan.md
@@ -17,7 +17,13 @@ and the reduction-split decode GEMV arc (merged). Scope = the two ruled levers:
 Released rig exe (`performance/_rig/dasllama-bench.app/.../dasllama-bench.exe`), quiet box,
 r=3 t=8, `--ngl 99`; models + ref binary paths per `METHODOLOGY.md`. Image cells:
 `--image` + `--image-mmproj` + `--image-think` on the coco fixture. Text-M control: `-p 341`
-(same ceil-32 pad = 352 as the image turn's npos 321).
+(same ceil-32 pad = 352 as the image turn's npos 321). Every in-process/stage figure below
+("the probe") is `harness/image_turn_probe.das` under `-jit` (best-of-3 walls per arm;
+knockout arms = `DASLLAMA_METAL_PREFILL_SKIP`; model = `DASLLAMA_PROBE_MODEL`, default the
+8B) — direction-grade by contract, never board rows. Figures quoted as before/after across
+commits are two probe runs at the two tips, not an in-process A/B; the in-process
+tail-on/off compare lives in the parity arm (token-exact — bit-exactness is impossible by
+design across the f16-tile and f32-dot GEMM forms).
 
 ## Predictions (BEFORE the phase-0 runs)
 
@@ -51,8 +57,9 @@ r=3 t=8, `--ngl 99`; models + ref binary paths per `METHODOLOGY.md`. Image cells
 | post-encode context residue | ~10 ms | ~7 ms |
 | das image wall vs ref image wall | 615.5 vs 568.6 (−7.6%) | 340.7 vs ~318 (−7%) |
 
-Ref image mints (fresh, warm): 8B mtmd prefill 568.6 ms / 321 rows (564.6 tok/s), encode
-500 ms (das encode 255.8 — 2x ahead); ref decode 32.2 tok/s (das 38.7 — +20%).
+Ref image mints (fresh, warm): the 8B ref image turn's prefill 568.6 ms / 321 rows
+(564.6 tok/s), encode 500 ms (das encode 255.8 — 2x ahead); ref decode 32.2 tok/s (das
+38.7 — +20%).
 
 ## The lever (proposed, not yet ruled)
 
@@ -72,9 +79,13 @@ MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
 - [x] RULING: the GEMV-tail dispatch lever (approved).
 - [x] Implemented: enc_gemm_mm peels npos % 32 in [1,8] onto the mv family (r == 1 rides the
       reduction-split GEMV — the mv forms idle half their lanes on a lone row, measured: the
-      mv-only tail bought 24 ms, the r==1 reroute 8.6 more). DASLLAMA_METAL_MM_TAIL knob +
-      setter + engage counters; DASLLAMA_VERSION 9; the mv_b2 store now gates on nrows (it
-      phantom-wrote row 1 at nrows == 1 — an off-the-end write on an exactly-full KV panel).
+      mv-only tail bought 24 ms, the r==1 reroute 8.6 more). Per-form reduction alignment
+      gates the peel — the b4 stripe reads whole 128-quant rounds, so kdim % 128 != 0 keeps
+      the padded tile (dims like 576/896/1152 misread otherwise — device-probed), and r >= 2
+      always takes the b4 form (b2's stripe needs % 256). DASLLAMA_METAL_MM_TAIL knob +
+      setter + engage counters; DASLLAMA_VERSION 9; the mv_b2 store now gates on nrows —
+      defensive: at nrows == 1 it phantom-wrote its second row, which the batch rail's two
+      sizing paths make either an unread pad row or an off-the-buffer write.
       Probe (8B, one process, npos=321): tokens 599.2 -> 566.8 ms, wide-span 605.3 -> 572.6.
 - [x] Gates: mm-tail parity arm (residues 257/321%32==1 and 261/%32==5, token-exact, tail-off
       A/B, engage counters; y-offset poison control REDS it), kernels suite 7/7.
@@ -99,3 +110,9 @@ MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
 - [ ] Followups: post-encode residue (~10 ms: ~6.7 GPU cache aftermath + ~3.8 host slack;
       lever = encode-ahead overlap, shared with the decode submission-overhead arc), kq
       mul_mm + MoE prefill tails (the mv_kq twins exist), r in [9,15] via a third mv pass.
+      Review-round harvest: (a) the batch-DECODE mv rail carries the same unguarded stripe
+      widths with no alignment clause (pre-existing — B in [2,8] on a dim % 128 != 0 model
+      misreads; own arc, failing test first); (b) u_dn_qd2 is built from qd, not qd_l — a
+      latent bn != d exception if a hetero q-gated arch ever lands (unreachable today);
+      (c) the b2/b4 y binding carries no @span, so every peeled site pays a conservative
+      whole-buffer barrier — correctness-neutral, confounds per-r timing comparisons.

--- a/modules/dasLLAMA/qwen_pp_plan.md
+++ b/modules/dasLLAMA/qwen_pp_plan.md
@@ -78,7 +78,10 @@ MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
       Probe (8B, one process, npos=321): tokens 599.2 -> 566.8 ms, wide-span 605.3 -> 572.6.
 - [x] Gates: mm-tail parity arm (residues 257/321%32==1 and 261/%32==5, token-exact, tail-off
       A/B, engage counters; y-offset poison control REDS it), kernels suite 7/7.
-- [ ] base + batch gates; rig re-release; the image board + text cells re-measured
-      record-grade; PERF_LEDGER entry.
+- [x] base + batch gates green; rig re-released; the board re-measured record-grade
+      (released exe, r=3, quiet box, fresh upstream pairs): 8B img:pp 522 -> 552 tok/s
+      (-7.5% -> -2.2% vs 564.6), 4B img:pp 942 -> 986 (-2.7% vs 1013.2), 8B text p321
+      534.5 -> 566.7 (+7.8% ahead of 525.9), p341/p512 unchanged, 30B Omni 783 (rides).
+      PERF_LEDGER entry in.
 - [ ] Followups: span-attn tax (~6 ms), post-encode residue (~10 ms), kq mul_mm + MoE prefill
       tails (the mv_kq twins exist), r in [9,15] via a third mv pass (marginal ~12 ms).

--- a/modules/dasLLAMA/qwen_pp_plan.md
+++ b/modules/dasLLAMA/qwen_pp_plan.md
@@ -1,16 +1,16 @@
-# qwen img:pp remainder — the two levers (ACTIVE)
+# qwen img:pp remainder - the two levers (ACTIVE)
 
 Successor of the qwen3vl arc's slice M/J (plan archived: `history/dasLLAMA/qwen3vl_plan.md`)
 and the reduction-split decode GEMV arc (merged). Scope = the two ruled levers:
 
-1. **4B lever** — the image-turn residual (~25 ms at the bench shape; text at parity).
+1. **4B lever** - the image-turn residual (~25 ms at the bench shape; text at parity).
    Candidate mechanism: the wide quantum's staging/eval path (upload, restride, tracked-pool
-   dependency pass) — attribution OPEN on current master, must re-pin first.
-2. **8B lever** — the small-M prefill GEMM: text pp at p512 is parity, p341 is −6.2%.
-   The mulmm at dim-4096, M≈352-pad shapes; tile/tune territory, image-blind.
+   dependency pass) - attribution OPEN on current master, must re-pin first.
+2. **8B lever** - the small-M prefill GEMM: text pp at p512 is parity, p341 is -6.2%.
+   The mulmm at dim-4096, M~352-pad shapes; tile/tune territory, image-blind.
 
-30B (−4%) rides whatever falls out. Board context (rig, Metal, image cells): 4B −7%,
-8B −7%, 30B −4% vs the ref pairs at equal turn shape (321 rows both engines).
+30B (-4%) rides whatever falls out. Board context (rig, Metal, image cells): 4B -7%,
+8B -7%, 30B -4% vs the ref pairs at equal turn shape (321 rows both engines).
 
 ## Protocol
 
@@ -20,30 +20,30 @@ r=3 t=8, `--ngl 99`; models + ref binary paths per `METHODOLOGY.md`. Image cells
 (same ceil-32 pad = 352 as the image turn's npos 321). Every in-process/stage figure below
 ("the probe") is `harness/image_turn_probe.das` under `-jit` (best-of-3 walls per arm;
 knockout arms = `DASLLAMA_METAL_PREFILL_SKIP`; model = `DASLLAMA_PROBE_MODEL`, default the
-8B) — direction-grade by contract, never board rows. Figures quoted as before/after across
+8B) - direction-grade by contract, never board rows. Figures quoted as before/after across
 commits are two probe runs at the two tips, not an in-process A/B; the in-process
-tail-on/off compare lives in the parity arm (token-exact — bit-exactness is impossible by
+tail-on/off compare lives in the parity arm (token-exact - bit-exactness is impossible by
 design across the f16-tile and f32-dot GEMM forms).
 
 ## Predictions (BEFORE the phase-0 runs)
 
-- **P1** 8B text p341 vs ref: das −6±2% (the 8B image gap IS the text gap at that M).
-  **SCORED: WRONG — artifact.** First-process read 524.7 (−5.8%) reproduced the prediction,
-  but the warm re-run prices 568.3 ± 0.3 = **+2.1% AHEAD** (ref 556.8); the deficit was the
-  cold-first-process page tax (the ledgered trap, struck again — and it back-explains the
-  slice-M "−6.2% p341" control). There is NO 8B small-M text GEMM gap; the 8B lever as
+- **P1** 8B text p341 vs ref: das -6+/-2% (the 8B image gap IS the text gap at that M).
+  **SCORED: WRONG - artifact.** First-process read 524.7 (-5.8%) reproduced the prediction,
+  but the warm re-run prices 568.3 +/- 0.3 = **+2.1% AHEAD** (ref 556.8); the deficit was the
+  cold-first-process page tax (the ledgered trap, struck again - and it back-explains the
+  slice-M "-6.2% p341" control). There is NO 8B small-M text GEMM gap; the 8B lever as
   planned (phase 2, dim-4096 mulmm) is DEAD.
-- **P2** 4B text p341 vs ref: parity ±3%. **SCORED: CORRECT** — 1037.9 ± 0.8 vs ref 1010.6
+- **P2** 4B text p341 vs ref: parity +/-3%. **SCORED: CORRECT** - 1037.9 +/- 0.8 vs ref 1010.6
   = +2.7% (first-process run, no cold tax visible; 4B pages were still warm).
 - **P3** 4B img:pp vs its own text control at equal pad: das image ~20-30 ms slower
-  (the image-specific residual survives on master). **SCORED: PARTIAL** — bench context:
+  (the image-specific residual survives on master). **SCORED: PARTIAL** - bench context:
   4B +12.7 ms, 8B +16.1 ms over own text at equal pad; but in ONE process (the probe) the
-  image-shaped quantum costs only ~+6 ms — the rest is the post-encode context residue.
-- **P4** the GEMM-family Δ carries the image tax. **SCORED: WRONG** — the probe knockouts
+  image-shaped quantum costs only ~+6 ms - the rest is the post-encode context residue.
+- **P4** the GEMM-family Delta carries the image tax. **SCORED: WRONG** - the probe knockouts
   put the whole in-process +6 ms in the ATTENTION family (skip-attn deletes it; skip-gemm
-  leaves it); ds-wide staging is FREE (wide == narrow to 0.1 ms — the slice-J borrow verdict
+  leaves it); ds-wide staging is FREE (wide == narrow to 0.1 ms - the slice-J borrow verdict
   reconfirmed).
-- **P5** 8B small-M GEMM rate deficit. **SCORED: WRONG twice** — the p341 text "gap" was the
+- **P5** 8B small-M GEMM rate deficit. **SCORED: WRONG twice** - the p341 text "gap" was the
   cold-page artifact, and the true structure is the ceil-32 M-tile STAIRCASE: p320 = 551 ms
   (10 tile-rows), p321 = 599 ms (11 tile-rows), p352 = 600 ms (flat). One tile-row = ~48 ms
   on 8B; the image turn (npos=321) bills a whole tile-row for ONE real row.
@@ -55,22 +55,22 @@ design across the f16-tile and f32-dot GEMM forms).
 | dead last-M-tile (31 pad rows) | ~42 ms | ~23 ms |
 | span-attention tax (probe, in-process) | ~6 ms | (unprobed, expect ~4) |
 | post-encode context residue | ~10 ms | ~7 ms |
-| das image wall vs ref image wall | 615.5 vs 568.6 (−7.6%) | 340.7 vs ~318 (−7%) |
+| das image wall vs ref image wall | 615.5 vs 568.6 (-7.6%) | 340.7 vs ~318 (-7%) |
 
 Ref image mints (fresh, warm): the 8B ref image turn's prefill 568.6 ms / 321 rows
-(564.6 tok/s), encode 500 ms (das encode 255.8 — 2x ahead); ref decode 32.2 tok/s (das
-38.7 — +20%).
+(564.6 tok/s), encode 500 ms (das encode 255.8 - 2x ahead); ref decode 32.2 tok/s (das
+38.7 - +20%).
 
 ## The lever (proposed, not yet ruled)
 
-**GEMV-tail dispatch** — zero new kernels: inside `enc_gemm_mm`, when `npos % 32` lands in
+**GEMV-tail dispatch** - zero new kernels: inside `enc_gemm_mm`, when `npos % 32` lands in
 [1, 8], dispatch `floor(npos/32)` mul_mm tile-rows + the remainder rows through the existing
-fixed-B `mv_b2/b4` GEMV family at x/y row offsets (built for offsets — the fused-row
+fixed-B `mv_b2/b4` GEMV family at x/y row offsets (built for offsets - the fused-row
 segment sites). Cost model: the tail tile-row is compute-bound (~48 ms on 8B), the GEMV
-tail streams the weights once (~12 ms) → net ~36 ms (8B) / ~23 ms (4B). Projection with all
+tail streams the weights once (~12 ms) -> net ~36 ms (8B) / ~23 ms (4B). Projection with all
 three terms closed: 8B ~563 vs 568.6 (das leads), 4B ~315 vs ~318 (das leads). Also buys
 every text pp at npos%32 in [1,8]. Follow-ups: the kq mul_mm twins (kq mv_b exists), the
-MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
+MoE prefill (30B -4%), the span-attn +6 ms, the ~10 ms post-encode residue.
 
 ## Ladder
 
@@ -78,12 +78,12 @@ MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
 - [x] Attribution: probe (3 workloads x 5 skip arms, one process) + the M staircase.
 - [x] RULING: the GEMV-tail dispatch lever (approved).
 - [x] Implemented: enc_gemm_mm peels npos % 32 in [1,8] onto the mv family (r == 1 rides the
-      reduction-split GEMV — the mv forms idle half their lanes on a lone row, measured: the
+      reduction-split GEMV - the mv forms idle half their lanes on a lone row, measured: the
       mv-only tail bought 24 ms, the r==1 reroute 8.6 more). Per-form reduction alignment
-      gates the peel — the b4 stripe reads whole 128-quant rounds, so kdim % 128 != 0 keeps
-      the padded tile (dims like 576/896/1152 misread otherwise — device-probed), and r >= 2
+      gates the peel - the b4 stripe reads whole 128-quant rounds, so kdim % 128 != 0 keeps
+      the padded tile (dims like 576/896/1152 misread otherwise - device-probed), and r >= 2
       always takes the b4 form (b2's stripe needs % 256). DASLLAMA_METAL_MM_TAIL knob +
-      setter + engage counters; DASLLAMA_VERSION 9; the mv_b2 store now gates on nrows —
+      setter + engage counters; DASLLAMA_VERSION 9; the mv_b2 store now gates on nrows -
       defensive: at nrows == 1 it phantom-wrote its second row, which the batch rail's two
       sizing paths make either an unread pad row or an off-the-buffer write.
       Probe (8B, one process, npos=321): tokens 599.2 -> 566.8 ms, wide-span 605.3 -> 572.6.
@@ -96,23 +96,23 @@ MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
       PERF_LEDGER entry in.
 - [x] Followup 1 (span-attn tax) split and fixed: the AV kernels dropped the causal walk
       bound wholesale when the span was armed (`jlimit = np32`); now tile-conditional
-      (`max(uend, causal reach)` only where the tile holds span rows — a pure shrink over
+      (`max(uend, causal reach)` only where the tile holds span rows - a pure shrink over
       softmax-zeroed columns, bit-neutral). Probe: tax1 3.3 -> 0.58 ms (the constant
-      overhead deleted — small-span turns win up to ~3 ms); tax300 unchanged within noise —
+      overhead deleted - small-span turns win up to ~3 ms); tax300 unchanged within noise -
       at the real 300-row span the extra walk was nearly free, the remaining ~6 ms is
       INTRINSIC non-causal pairs + softmax length. The image cell does not move from this.
       GATE LESSON: the span-fused f16 fused-vs-splice witness (bit-identity bar 1e-4) reds
-      under the GEMV tail — a splice chunk with npos % 32 in the tail window serves its
+      under the GEMV tail - a splice chunk with npos % 32 in the tail window serves its
       remainder rows on f32-dot GEMVs while the fused eval stays f16-tile; the witness now
       pins the tail OFF for both legs (it isolates the MASK; the tail has its own arm). The
-      tail commit's gate scope missed this — bit-identity witnesses belong in the
+      tail commit's gate scope missed this - bit-identity witnesses belong in the
       change-affects set of ANY GEMM-numerics change.
 - [ ] Followups: post-encode residue (~10 ms: ~6.7 GPU cache aftermath + ~3.8 host slack;
       lever = encode-ahead overlap, shared with the decode submission-overhead arc), kq
       mul_mm + MoE prefill tails (the mv_kq twins exist), r in [9,15] via a third mv pass.
       Review-round harvest: (a) the batch-DECODE mv rail carries the same unguarded stripe
-      widths with no alignment clause (pre-existing — B in [2,8] on a dim % 128 != 0 model
-      misreads; own arc, failing test first); (b) u_dn_qd2 is built from qd, not qd_l — a
+      widths with no alignment clause (pre-existing - B in [2,8] on a dim % 128 != 0 model
+      misreads; own arc, failing test first); (b) u_dn_qd2 is built from qd, not qd_l - a
       latent bn != d exception if a hetero q-gated arch ever lands (unreachable today);
       (c) the b2/b4 y binding carries no @span, so every peeled site pays a conservative
-      whole-buffer barrier — correctness-neutral, confounds per-r timing comparisons.
+      whole-buffer barrier - correctness-neutral, confounds per-r timing comparisons.

--- a/modules/dasLLAMA/qwen_pp_plan.md
+++ b/modules/dasLLAMA/qwen_pp_plan.md
@@ -1,0 +1,84 @@
+# qwen img:pp remainder — the two levers (ACTIVE)
+
+Successor of the qwen3vl arc's slice M/J (plan archived: `history/dasLLAMA/qwen3vl_plan.md`)
+and the reduction-split decode GEMV arc (merged). Scope = the two ruled levers:
+
+1. **4B lever** — the image-turn residual (~25 ms at the bench shape; text at parity).
+   Candidate mechanism: the wide quantum's staging/eval path (upload, restride, tracked-pool
+   dependency pass) — attribution OPEN on current master, must re-pin first.
+2. **8B lever** — the small-M prefill GEMM: text pp at p512 is parity, p341 is −6.2%.
+   The mulmm at dim-4096, M≈352-pad shapes; tile/tune territory, image-blind.
+
+30B (−4%) rides whatever falls out. Board context (rig, Metal, image cells): 4B −7%,
+8B −7%, 30B −4% vs the ref pairs at equal turn shape (321 rows both engines).
+
+## Protocol
+
+Released rig exe (`performance/_rig/dasllama-bench.app/.../dasllama-bench.exe`), quiet box,
+r=3 t=8, `--ngl 99`; models + ref binary paths per `METHODOLOGY.md`. Image cells:
+`--image` + `--image-mmproj` + `--image-think` on the coco fixture. Text-M control: `-p 341`
+(same ceil-32 pad = 352 as the image turn's npos 321).
+
+## Predictions (BEFORE the phase-0 runs)
+
+- **P1** 8B text p341 vs ref: das −6±2% (the 8B image gap IS the text gap at that M).
+  **SCORED: WRONG — artifact.** First-process read 524.7 (−5.8%) reproduced the prediction,
+  but the warm re-run prices 568.3 ± 0.3 = **+2.1% AHEAD** (ref 556.8); the deficit was the
+  cold-first-process page tax (the ledgered trap, struck again — and it back-explains the
+  slice-M "−6.2% p341" control). There is NO 8B small-M text GEMM gap; the 8B lever as
+  planned (phase 2, dim-4096 mulmm) is DEAD.
+- **P2** 4B text p341 vs ref: parity ±3%. **SCORED: CORRECT** — 1037.9 ± 0.8 vs ref 1010.6
+  = +2.7% (first-process run, no cold tax visible; 4B pages were still warm).
+- **P3** 4B img:pp vs its own text control at equal pad: das image ~20-30 ms slower
+  (the image-specific residual survives on master). **SCORED: PARTIAL** — bench context:
+  4B +12.7 ms, 8B +16.1 ms over own text at equal pad; but in ONE process (the probe) the
+  image-shaped quantum costs only ~+6 ms — the rest is the post-encode context residue.
+- **P4** the GEMM-family Δ carries the image tax. **SCORED: WRONG** — the probe knockouts
+  put the whole in-process +6 ms in the ATTENTION family (skip-attn deletes it; skip-gemm
+  leaves it); ds-wide staging is FREE (wide == narrow to 0.1 ms — the slice-J borrow verdict
+  reconfirmed).
+- **P5** 8B small-M GEMM rate deficit. **SCORED: WRONG twice** — the p341 text "gap" was the
+  cold-page artifact, and the true structure is the ceil-32 M-tile STAIRCASE: p320 = 551 ms
+  (10 tile-rows), p321 = 599 ms (11 tile-rows), p352 = 600 ms (flat). One tile-row = ~48 ms
+  on 8B; the image turn (npos=321) bills a whole tile-row for ONE real row.
+
+## The re-derived gap (warm, current master, vs fresh ref mints)
+
+| term | 8B | 4B |
+|---|---|---|
+| dead last-M-tile (31 pad rows) | ~42 ms | ~23 ms |
+| span-attention tax (probe, in-process) | ~6 ms | (unprobed, expect ~4) |
+| post-encode context residue | ~10 ms | ~7 ms |
+| das image wall vs ref image wall | 615.5 vs 568.6 (−7.6%) | 340.7 vs ~318 (−7%) |
+
+Ref image mints (fresh, warm): 8B mtmd prefill 568.6 ms / 321 rows (564.6 tok/s), encode
+500 ms (das encode 255.8 — 2x ahead); ref decode 32.2 tok/s (das 38.7 — +20%).
+
+## The lever (proposed, not yet ruled)
+
+**GEMV-tail dispatch** — zero new kernels: inside `enc_gemm_mm`, when `npos % 32` lands in
+[1, 8], dispatch `floor(npos/32)` mul_mm tile-rows + the remainder rows through the existing
+fixed-B `mv_b2/b4` GEMV family at x/y row offsets (built for offsets — the fused-row
+segment sites). Cost model: the tail tile-row is compute-bound (~48 ms on 8B), the GEMV
+tail streams the weights once (~12 ms) → net ~36 ms (8B) / ~23 ms (4B). Projection with all
+three terms closed: 8B ~563 vs 568.6 (das leads), 4B ~315 vs ~318 (das leads). Also buys
+every text pp at npos%32 in [1,8]. Follow-ups: the kq mul_mm twins (kq mv_b exists), the
+MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
+
+## Ladder
+
+- [x] Phase 0: text-M controls + fresh image cells + fresh ref mints (above).
+- [x] Attribution: probe (3 workloads x 5 skip arms, one process) + the M staircase.
+- [x] RULING: the GEMV-tail dispatch lever (approved).
+- [x] Implemented: enc_gemm_mm peels npos % 32 in [1,8] onto the mv family (r == 1 rides the
+      reduction-split GEMV — the mv forms idle half their lanes on a lone row, measured: the
+      mv-only tail bought 24 ms, the r==1 reroute 8.6 more). DASLLAMA_METAL_MM_TAIL knob +
+      setter + engage counters; DASLLAMA_VERSION 9; the mv_b2 store now gates on nrows (it
+      phantom-wrote row 1 at nrows == 1 — an off-the-end write on an exactly-full KV panel).
+      Probe (8B, one process, npos=321): tokens 599.2 -> 566.8 ms, wide-span 605.3 -> 572.6.
+- [x] Gates: mm-tail parity arm (residues 257/321%32==1 and 261/%32==5, token-exact, tail-off
+      A/B, engage counters; y-offset poison control REDS it), kernels suite 7/7.
+- [ ] base + batch gates; rig re-release; the image board + text cells re-measured
+      record-grade; PERF_LEDGER entry.
+- [ ] Followups: span-attn tax (~6 ms), post-encode residue (~10 ms), kq mul_mm + MoE prefill
+      tails (the mv_kq twins exist), r in [9,15] via a third mv pass (marginal ~12 ms).

--- a/modules/dasLLAMA/qwen_pp_plan.md
+++ b/modules/dasLLAMA/qwen_pp_plan.md
@@ -83,5 +83,19 @@ MoE prefill (30B −4%), the span-attn +6 ms, the ~10 ms post-encode residue.
       (-7.5% -> -2.2% vs 564.6), 4B img:pp 942 -> 986 (-2.7% vs 1013.2), 8B text p321
       534.5 -> 566.7 (+7.8% ahead of 525.9), p341/p512 unchanged, 30B Omni 783 (rides).
       PERF_LEDGER entry in.
-- [ ] Followups: span-attn tax (~6 ms), post-encode residue (~10 ms), kq mul_mm + MoE prefill
-      tails (the mv_kq twins exist), r in [9,15] via a third mv pass (marginal ~12 ms).
+- [x] Followup 1 (span-attn tax) split and fixed: the AV kernels dropped the causal walk
+      bound wholesale when the span was armed (`jlimit = np32`); now tile-conditional
+      (`max(uend, causal reach)` only where the tile holds span rows — a pure shrink over
+      softmax-zeroed columns, bit-neutral). Probe: tax1 3.3 -> 0.58 ms (the constant
+      overhead deleted — small-span turns win up to ~3 ms); tax300 unchanged within noise —
+      at the real 300-row span the extra walk was nearly free, the remaining ~6 ms is
+      INTRINSIC non-causal pairs + softmax length. The image cell does not move from this.
+      GATE LESSON: the span-fused f16 fused-vs-splice witness (bit-identity bar 1e-4) reds
+      under the GEMV tail — a splice chunk with npos % 32 in the tail window serves its
+      remainder rows on f32-dot GEMVs while the fused eval stays f16-tile; the witness now
+      pins the tail OFF for both legs (it isolates the MASK; the tail has its own arm). The
+      tail commit's gate scope missed this — bit-identity witnesses belong in the
+      change-affects set of ANY GEMM-numerics change.
+- [ ] Followups: post-encode residue (~10 ms: ~6.7 GPU cache aftermath + ~3.8 host slack;
+      lever = encode-ahead overlap, shared with the decode submission-overhead arc), kq
+      mul_mm + MoE prefill tails (the mv_kq twins exist), r in [9,15] via a third mv pass.

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -41,9 +41,11 @@ never mask a red.
 
 Arm names - decode parity: `arm1-basic arm2-hybrid arm3-step arm4-paged arm5-rewind
 arm6-churn arm7-q8kv arm7b-tq4kv arm8-s16 arm9-reload arm10-kq arm11-depth arm12-dim
-arm13-conc arm14-poison` (arm14 = the shared-region collision gate: a foreign GPU prefill must
+arm13-conc arm14-poison` (mm-tail in the prefill list below = the GEMV-tail residue shapes:
+npos % 32 == 1 rides the reduction-split GEMV, == 5 the mv b4 + pair leg - token parity +
+tail-off A/B + engage counters) (arm14 = the shared-region collision gate: a foreign GPU prefill must
 not degrade a later forced-feed decode - Qwen2.5-0.5B, its own `[test]` block),
-batch test: `batch` (whole test), `batchB7-partd`, `batchB8-kq`. Prefill parity: `base s16
+batch test: `batch` (whole test), `batchB7-partd`, `batchB8-kq`. Prefill parity: `base mm-tail s16
 kq cont span span-fused span-mrope span-ds dim qkv` (span = the non-causal media eval shape, head + embd span,
 per codec; span-fused = the image turn's ONE-eval shape - causal head + media rows + causal
 tail through the per-query mask, one GPU prefill, with a same-backend fused-vs-splice logits

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -41,12 +41,17 @@ never mask a red.
 
 Arm names - decode parity: `arm1-basic arm2-hybrid arm3-step arm4-paged arm5-rewind
 arm6-churn arm7-q8kv arm7b-tq4kv arm8-s16 arm9-reload arm10-kq arm11-depth arm12-dim
-arm13-conc arm14-poison` (mm-tail in the prefill list below = the GEMV-tail residue shapes:
-npos % 32 == 1 rides the reduction-split GEMV, == 5 the mv b4 + pair leg - token parity +
-tail-off A/B + engage counters) (arm14 = the shared-region collision gate: a foreign GPU prefill must
+arm13-conc arm14-poison` (arm14 = the shared-region collision gate: a foreign GPU prefill must
 not degrade a later forced-feed decode - Qwen2.5-0.5B, its own `[test]` block),
 batch test: `batch` (whole test), `batchB7-partd`, `batchB8-kq`. Prefill parity: `base mm-tail s16
-kq cont span span-fused span-mrope span-ds dim qkv` (span = the non-causal media eval shape, head + embd span,
+kq cont span span-fused span-mrope span-ds dim qkv` (mm-tail = the GEMV-tail residue peel -
+four fixtures, npos % 32 == 1 (the lone row rides the reduction-split GEMV), == 2 (the b4
+form at 2 rows), == 5 (two b4 dispatches, 4 rows + 1) and npos == 5 (the pure-tail leg,
+no mul_mm at all) - token parity vs the all-CPU control, the tail-off A/B twin, and the
+peeled sites/rows counters as the anti-vacuous witness; plus the SmolLM2 alignment-guard
+leg - dim 576 fails the b4 stripe's % 128, so npos % 32 == 2 must refuse the tail while
+== 1 still rides the gemv, counters only (greedy token equality is not a valid instrument
+on a 135M); span = the non-causal media eval shape, head + embd span,
 per codec; span-fused = the image turn's ONE-eval shape - causal head + media rows + causal
 tail through the per-query mask, one GPU prefill, with a same-backend fused-vs-splice logits
 witness on poison-calibrated per-codec bars; span-mrope = the qwen grid-roped turn - one GPU

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -49,10 +49,11 @@ four fixtures, npos % 32 == 1 (the lone row rides the reduction-split GEMV), == 
 form at 2 rows), == 5 (two b4 dispatches, 4 rows + 1) and npos == 5 (the pure-tail leg,
 no mul_mm at all) - token parity vs the all-CPU control, the tail-off A/B twin, and the
 peeled sites/rows counters as the anti-vacuous witness; plus the SmolLM2 alignment-guard
-leg - dim 576 fails the b4 stripe's % 128, so npos % 32 == 2 must refuse the tail while
-== 1 still rides the gemv, counters only (greedy token equality is not a valid instrument
-on a 135M); span = the non-causal media eval shape, head + embd span,
-per codec; span-fused = the image turn's ONE-eval shape - causal head + media rows + causal
+leg - the guard is per mul_mm site on that site's K width (b4 needs % 128, the gemv % 32),
+so at npos % 32 == 2 the 576-wide sites must refuse while exactly the hidden-kdim w2 site
+(1536) peels per layer, and == 1 rides the gemv everywhere; counters only (greedy token
+equality is not a valid instrument on a 135M); span = the non-causal media eval shape,
+head + embd span, per codec; span-fused = the image turn's ONE-eval shape - causal head + media rows + causal
 tail through the per-query mask, one GPU prefill, with a same-backend fused-vs-splice logits
 witness on poison-calibrated per-codec bars; span-mrope = the qwen grid-roped turn - one GPU
 prefill via the per-row-table capability, token-exact vs the all-CPU control, plus a
@@ -324,7 +325,7 @@ the chat, the caption, and the zeroed-slices decoder control: tails zeroed on th
 must move the prefill logits, measured 10.4 - a caption alone cannot see a decoder that
 ignores the slices), the rows-seam cell (same 4B pair - pre-encoded wide rows through
 `add_user_image_rows_` on a plain chat reproduce the embedder walk token-for-token; the seam
-lcpp_bench prices, where a hand-splice once fed deepstack decoders a narrow scrambled span),
+lcpp_bench prices, where a hand-splice can feed deepstack decoders a narrow scrambled span),
 the Qwen2.5-Omni-3B qwen25v pair (small tier - the window ViT + the
 qwen2vl NON-interleaved MROPE decoder; the vocab spells the span markers
 `<|vision_bos|>`/`<|vision_eos|>`, resolved by the chat layer's vocab-driven fallback)

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -94,10 +94,11 @@ the arch registrations (`register_decode_override` and its sibling `register_*` 
 declaration is not one of them.
 
 **A hand-bound kernel gate dispatches the geometry and threadgroup memory its production
-encoder does** - a change to a kernel's `[metal_dispatch]` `tg`, `grid`, or `tgmem`, to a
-field's `@binding`, or to its kargs struct's layout, updates every gate that hand-binds that
-kernel in the same change (the mechanism - why a missed tgmem fails silently - is
-`CLAUDE.md`'s "Arm filter mechanics" section).
+encoder does** - a change to anything a kernel dispatches with, binds, or reads from its
+kargs updates every gate that hand-binds that kernel in the same change, and a new in-body
+branch keyed on a kargs field needs a gate cell that arms the field (the mechanism - why a
+missed tgmem fails silently - is `CLAUDE.md`'s "Arm filter mechanics" section, the
+kernel-gate paragraph).
 
 **A new pre-tokenizer family or backend ships its `corpus_case` arm in `test_tokenizer.das`,
 naming the `ggml-vocab-*.gguf` fixture.**
@@ -138,8 +139,9 @@ dump.**
 backend, the flash-attention setting, and the mmproj precision the dump came from.**
 
 **A cell establishes every driver hook and serving-lane knob its claim depends on, and
-restores it before returning** - the hooks have no read-back, so a cell that pins one OFF
-sets it back ON (the driver hooks `set_metal_tower`, `set_metal_wdec`, `set_metal_wdec_step`);
+restores it before returning** - a hook here is any process-wide setter with no read-back,
+so a cell that pins one OFF sets it back ON, and a cell whose claim needs the DEFAULT
+establishes that default too (the environment can carry the knob either way);
 a family serving-lane pin `set_<family>_q8` is undone with `reset_<family>_q8` - never a
 runtime decline standing in for a pin. The mechanism (why the hooks flip legs silently) is
 `CLAUDE.md`'s "Metal fixtures" section.

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -95,10 +95,11 @@ declaration is not one of them.
 
 **A hand-bound kernel gate dispatches the geometry and threadgroup memory its production
 encoder does** - a change to anything a kernel dispatches with, binds, or reads from its
-kargs updates every gate that hand-binds that kernel in the same change, and a new in-body
-branch keyed on a kargs field needs a gate cell that arms the field (the mechanism - why a
-missed tgmem fails silently - is `CLAUDE.md`'s "Arm filter mechanics" section, the
-kernel-gate paragraph).
+kargs updates every gate that hand-binds that kernel in the same change (the mechanism -
+why a missed tgmem fails silently - is `CLAUDE.md`'s "Arm filter mechanics" section).
+
+**A kernel that gains an in-body branch keyed on a kargs field ships, in the same change, a
+gate cell that sets that field to the value selecting the new branch.**
 
 **A new pre-tokenizer family or backend ships its `corpus_case` arm in `test_tokenizer.das`,
 naming the `ggml-vocab-*.gguf` fixture.**
@@ -140,11 +141,11 @@ backend, the flash-attention setting, and the mmproj precision the dump came fro
 
 **A cell establishes every driver hook and serving-lane knob its claim depends on, and
 restores it before returning** - a hook here is any process-wide setter with no read-back,
-so a cell that pins one OFF sets it back ON, and a cell whose claim needs the DEFAULT
-establishes that default too (the environment can carry the knob either way);
-a family serving-lane pin `set_<family>_q8` is undone with `reset_<family>_q8` - never a
-runtime decline standing in for a pin. The mechanism (why the hooks flip legs silently) is
-`CLAUDE.md`'s "Metal fixtures" section.
+so a cell that changes one sets it back to its default before returning, and a cell whose
+claim needs the DEFAULT establishes that default too (the environment can carry the knob
+either way); a family serving-lane pin `set_<family>_q8` is undone with
+`reset_<family>_q8` - never a runtime decline standing in for a pin. The mechanism (why the
+hooks flip legs silently) is `CLAUDE.md`'s "Metal fixtures" section.
 
 **A knob a cell can reach only through the environment is armed in the environment of a
 process started after the arming - a child the cell spawns, or the runner's own - and needs

--- a/modules/dasLLAMA/tests/test_metal_gemv_kernels.das
+++ b/modules/dasLLAMA/tests/test_metal_gemv_kernels.das
@@ -644,9 +644,10 @@ def private gemv_b_gate(t : T?; dev, queue; bwidth, ndim, ddim, ys : int) {
     delete want
 }
 
-// MetalQ8MvB2/B4 (streamed skinny form, 64-thread tg, n % 256): X rows at float4 stride xs4,
-// b4 stores gate on nrows (the b<nrows pad columns compute and discard, x reads clamp to the
-// last live row). b2 always writes both columns — B=1 rides an unread y row by design.
+// MetalQ8MvB2/B4 (streamed skinny form, 64-thread tg; b2 walks 256-quant stripes, b4 128):
+// X rows at float4 stride xs4; BOTH forms gate stores on nrows — pad columns compute and
+// discard (b4's x2/x3 clamp; the x1 phantom read stays in the padded x rows), so rows past
+// nrows keep the sentinel and the compare asserts it.
 def private q8_mv_b_gate(t : T?; dev, queue; bwidth, ndim, ddim, nrows, xs4, ys : int) {
     let tag = "q8_mv_b{bwidth} n={ndim} d={ddim} nr={nrows} xs4={xs4} ys={ys}"
     var err : string
@@ -659,19 +660,18 @@ def private q8_mv_b_gate(t : T?; dev, queue; bwidth, ndim, ddim, nrows, xs4, ys 
     var wdeq : array<float>
     q8_blob_fill(ddim, ndim / 32, blob, wdeq)
     var xf : array<float>
-    q8_x_fill(nrows * xs4 * 4, xf)
-    let nwr = bwidth == 2 ? 2 : nrows   // b2 stores both columns unconditionally
+    q8_x_fill(max(nrows, 2) * xs4 * 4, xf)   // the unclamped x1 phantom read needs a row-1 backing
+    let nwr = bwidth == 2 ? 2 : 4   // the form's column count: rows past nrows must stay sentinel
     var want : array<float>
     want |> resize(nwr * ys)
     for (i in range(nwr * ys)) {
         want[i] = -1000.0
     }
-    for (b in range(nwr)) {
-        let src = min(b, nrows - 1)     // the b4 pad-column x clamp
+    for (b in range(nrows)) {
         for (r in range(ddim)) {
             var acc = 0.0lf
             for (c in range(ndim)) {
-                acc += double(wdeq[r * ndim + c]) * double(xf[src * xs4 * 4 + c])
+                acc += double(wdeq[r * ndim + c]) * double(xf[b * xs4 * 4 + c])
             }
             want[b * ys + r] = float(acc)
         }
@@ -757,6 +757,10 @@ def test_metal_kq_gemv_kernels(t : T?) {
                 q8_mv_b_gate(t, dev, queue, 2, 256, 8, 2, 68, 20)
                 q8_mv_b_gate(t, dev, queue, 4, 512, 11, 3, 128, 11)
                 q8_mv_b_gate(t, dev, queue, 4, 256, 8, 4, 64, 8)
+                // the store-gate controls: nrows=1 on b2 (row 1 must stay sentinel — the
+                // ungated kernel phantom-wrote it) and nrows=2 on b4 (the GEMV tail's r==2 shape)
+                q8_mv_b_gate(t, dev, queue, 2, 512, 11, 1, 128, 11)
+                q8_mv_b_gate(t, dev, queue, 4, 512, 11, 2, 128, 11)
                 metal_release(queue)
             }
             t |> equal(metal_log_leaks_if_any(), 0l)

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -479,13 +479,20 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                 t |> success(reload_preps_run() > preps0, "the drop ran the registered reload preps (decode's discard_pre reached through the registry)")
             }
 
-            // mm-tail arm: the GEMV-tail residue shapes — npos % 32 == 1 (the reduction-split
-            // GEMV leg) and == 5 (the mv b4 + pair leg). Token parity vs the all-CPU control,
-            // the tail-off A/B twin, and the engage counter as the anti-vacuous witness.
+            // mm-tail arm: the GEMV-tail residue fixtures — npos % 32 == 1 (the reduction-split
+            // GEMV leg), == 2 (the b4 form at nrows 2) and == 5 (two b4 dispatches, 4 rows + 1).
+            // Token parity vs the all-CPU control, the tail-off A/B twin, and the engage
+            // counters as the anti-vacuous witness; the SmolLM2 leg below pins the alignment
+            // guard (dim 576 fails the b4 stripe's % 128 — r >= 2 must keep the padded tile).
             if (arm_on(t, "mm-tail")) {
                 pin_kernel_backend("portable")
                 set_wscale_f16(false)
-                for (nres in [257l, 261l]) {
+                set_metal_prefill_mm_tail(true)   // establish the knob the engage claim depends on (no read-back)
+                if (long_length(prompt) < 261l) {
+                    t |> skip("counting prompt tokenized under 261 - the residue fixtures cannot slice")
+                    return
+                }
+                for (nres in [5l, 257l, 258l, 261l]) {   // 5 = the pure-tail leg (nfull == 0, no mul_mm at all)
                     var sl : array<int64>
                     sl |> reserve(nres)
                     for (i in range64(nres)) {
@@ -517,6 +524,46 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                     log_gen_texts(tr, "mm-tail-off/{nres}", cpu_r, gpu_p)
                     t |> success(same(cpu_r, gpu_p), "npos={nres}: the tail-off twin matches the control too (A/B)")
                     delete sl
+                }
+                // the alignment-guard leg: SmolLM2's dim 576 fails the b4 stripe's % 128, so
+                // r >= 2 must REFUSE the tail (the padded tile serves) while r == 1 (% 32-clean)
+                // still rides the gemv. Counters only — greedy token equality is not a valid
+                // instrument on a 135M (near-ties flip under cross-backend noise).
+                let spath = path_join(models_dir(), "SmolLM2-135M-Instruct-Q8_0.gguf")
+                if (model_available(t, spath)) {
+                    var trs <- load_model_(spath, QuantMode.q8)
+                    if (trs.config.seq_len > 2048l) {
+                        trs.config.seq_len = 2048l
+                    }
+                    var trsg <- blob_twin(t, spath, 2048l)
+                    let sprompt <- encode(trs, counting_prompt(), true, false)
+                    t |> success(select_prefill_override("metal"), "override registered (mm-tail smol)")
+                    for (nres in [65l, 66l]) {
+                        var ssl : array<int64>
+                        ssl |> reserve(nres)
+                        for (i in range64(nres)) {
+                            ssl |> push(sprompt[i])
+                        }
+                        let sserved0 = metal_prefill_stats().prefills
+                        let stail0 = metal_prefill_tail_stats()
+                        var sgot <- continuation(trsg, trs, ssl, 4)
+                        let sserved = metal_prefill_stats().prefills - sserved0
+                        let sdsites = metal_prefill_tail_stats().sites - stail0.sites
+                        if (sserved > 0l) {
+                            if (nres % 32l == 1l) {
+                                t |> success(sdsites > 0l, "smol npos={nres}: the gemv leg engaged on the % 32-clean dim ({sdsites} sites)")
+                            } else {
+                                t |> equal(sdsites, 0l, "smol npos={nres}: the alignment guard refused the tail (dim 576 % 128 != 0)")
+                            }
+                        } else {
+                            feint("metal prefill declined on smol; the alignment-guard leg skipped\n")
+                        }
+                        delete ssl
+                        delete sgot
+                    }
+                    select_prefill_override("")
+                    delete trs
+                    delete trsg
                 }
                 clear_kernel_backend_pin()
                 select_kernel_backend(prior_backend)

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -479,6 +479,50 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                 t |> success(reload_preps_run() > preps0, "the drop ran the registered reload preps (decode's discard_pre reached through the registry)")
             }
 
+            // mm-tail arm: the GEMV-tail residue shapes — npos % 32 == 1 (the reduction-split
+            // GEMV leg) and == 5 (the mv b4 + pair leg). Token parity vs the all-CPU control,
+            // the tail-off A/B twin, and the engage counter as the anti-vacuous witness.
+            if (arm_on(t, "mm-tail")) {
+                pin_kernel_backend("portable")
+                set_wscale_f16(false)
+                for (nres in [257l, 261l]) {
+                    var sl : array<int64>
+                    sl |> reserve(nres)
+                    for (i in range64(nres)) {
+                        sl |> push(prompt[i])
+                    }
+                    let cpu_r <- continuation(tr, tr, sl, 24)
+                    t |> success(select_prefill_override("metal"), "override registered (mm-tail {nres})")
+                    let served0 = metal_prefill_stats().prefills
+                    let tail0 = metal_prefill_tail_stats()
+                    let gpu_r <- continuation(trg, tr, sl, 24)
+                    let served = metal_prefill_stats().prefills - served0
+                    let dsites = metal_prefill_tail_stats().sites - tail0.sites
+                    let drows = metal_prefill_tail_stats().rows - tail0.rows
+                    set_metal_prefill_mm_tail(false)
+                    let tail1 = metal_prefill_tail_stats()
+                    let gpu_p <- continuation(trg, tr, sl, 24)
+                    set_metal_prefill_mm_tail(true)
+                    select_prefill_override("")
+                    if (served == 0l) {
+                        delete sl
+                        feint("metal prefill declined (no Metal device?); mm-tail parity skipped\n")
+                        continue
+                    }
+                    t |> success(dsites > 0l, "npos={nres}: the GEMV tail engaged ({dsites} sites, {drows} rows)")
+                    t |> equal(drows, dsites * (nres % 32l), "npos={nres}: every peeled site carried the {nres % 32l}-row remainder")
+                    t |> equal(metal_prefill_tail_stats().sites - tail1.sites, 0l, "npos={nres}: tail off - the padded-tile path serves")
+                    log_gen_texts(tr, "mm-tail/{nres}", cpu_r, gpu_r)
+                    t |> success(same(cpu_r, gpu_r), "npos={nres}: 24-token continuation matches the all-CPU control (GEMV tail)")
+                    log_gen_texts(tr, "mm-tail-off/{nres}", cpu_r, gpu_p)
+                    t |> success(same(cpu_r, gpu_p), "npos={nres}: the tail-off twin matches the control too (A/B)")
+                    delete sl
+                }
+                clear_kernel_backend_pin()
+                select_kernel_backend(prior_backend)
+                set_wscale_f16(prior_wscale)
+            }
+
             // s16 arm (W2): the DEFAULT-load scale plane — blobs read raw f16 scales, the
             // classifier GEMV takes its halfword twin; a fresh load owns fresh weight regions.
             // The restores above un-pinned the backend — re-pin row-major (the donor contract)

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -488,11 +488,10 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                 pin_kernel_backend("portable")
                 set_wscale_f16(false)
                 set_metal_prefill_mm_tail(true)   // establish the knob the engage claim depends on (no read-back)
-                if (long_length(prompt) < 261l) {
-                    t |> skip("counting prompt tokenized under 261 - the residue fixtures cannot slice")
-                    return
-                }
                 for (nres in [5l, 257l, 258l, 261l]) {   // 5 = the pure-tail leg (nfull == 0, no mul_mm at all)
+                    if (nres > long_length(prompt)) {
+                        continue   // a fixture the counting prompt cannot slice; the others still run
+                    }
                     var sl : array<int64>
                     sl |> reserve(nres)
                     for (i in range64(nres)) {
@@ -538,7 +537,10 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                     var trsg <- blob_twin(t, spath, 2048l)
                     let sprompt <- encode(trs, counting_prompt(), true, false)
                     t |> success(select_prefill_override("metal"), "override registered (mm-tail smol)")
-                    for (nres in [65l, 66l]) {
+                    var ssites : int64[2]
+                    var sserved_all = true
+                    for (li in range(2)) {
+                        let nres = li == 0 ? 65l : 66l
                         var ssl : array<int64>
                         ssl |> reserve(nres)
                         for (i in range64(nres)) {
@@ -547,19 +549,20 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                         let sserved0 = metal_prefill_stats().prefills
                         let stail0 = metal_prefill_tail_stats()
                         var sgot <- continuation(trsg, trs, ssl, 4)
-                        let sserved = metal_prefill_stats().prefills - sserved0
-                        let sdsites = metal_prefill_tail_stats().sites - stail0.sites
-                        if (sserved > 0l) {
-                            if (nres % 32l == 1l) {
-                                t |> success(sdsites > 0l, "smol npos={nres}: the gemv leg engaged on the % 32-clean dim ({sdsites} sites)")
-                            } else {
-                                t |> equal(sdsites, 0l, "smol npos={nres}: the alignment guard refused the tail (dim 576 % 128 != 0)")
-                            }
-                        } else {
-                            feint("metal prefill declined on smol; the alignment-guard leg skipped\n")
-                        }
+                        sserved_all &&= metal_prefill_stats().prefills - sserved0 > 0l
+                        ssites[li] = metal_prefill_tail_stats().sites - stail0.sites
                         delete ssl
                         delete sgot
+                    }
+                    if (sserved_all) {
+                        // per-site guard: at r == 1 every q8 site peels (% 32 holds for 576 and
+                        // 1536 alike); at r == 2 only the hidden-kdim w2 site (1536 % 128 == 0)
+                        // may peel - the six 576-kdim sites per layer must refuse
+                        t |> success(ssites[0] > 0l, "smol npos=65: the gemv leg engaged ({ssites[0]} sites)")
+                        t |> success(ssites[1] < ssites[0], "smol npos=66: the alignment guard refused the 576-kdim sites ({ssites[1]} of {ssites[0]})")
+                        t |> equal(ssites[1] * 7l, ssites[0], "smol npos=66: exactly the one hidden-kdim site per layer peeled")
+                    } else {
+                        feint("metal prefill declined on smol; the alignment-guard leg skipped\n")
                     }
                     select_prefill_override("")
                     delete trs

--- a/modules/dasLLAMA/tests/test_metal_prefill_parity.das
+++ b/modules/dasLLAMA/tests/test_metal_prefill_parity.das
@@ -703,12 +703,18 @@ def test_metal_prefill_parity(t : T?) {   // nolint:STYLE038 — flat arm list, 
                         "{kdt} fused turn served as ONE GPU prefill")
                     // same-backend mask witness: fused vs the three-eval splice on the GPU run
                     // row-identical math, so the prefill logits must agree at the bit-noise
-                    // floor — a mask defect on ANY row moves its KV and lands here
+                    // floor — a mask defect on ANY row moves its KV and lands here. The GEMV
+                    // tail is pinned OFF for both legs: a splice chunk whose npos % 32 lands in
+                    // the tail window would serve its remainder rows on the f32-dot GEMVs while
+                    // the fused eval stays f16-tile mul_mm — a GEMM-form spread the f16 bar
+                    // cannot absorb, and the tail has its own arm (mm-tail)
+                    set_metal_prefill_mm_tail(false)
                     var lg_fused <- span_fused_prefill_logits(trfg, fhead, fmedia, ftail, kdt)
                     set_span_fuse(false)
                     set_metal_prefill_min_npos(1l)   // the splice's short head/tail ride the GPU too
                     let pfsp0 = metal_prefill_stats().prefills
                     var lg_splice <- span_fused_prefill_logits(trfg, fhead, fmedia, ftail, kdt)
+                    set_metal_prefill_mm_tail(true)
                     // the reference must actually BE the splice: three GPU prefills, or the
                     // witness collapses onto its own subject (an always-fused mutant passes)
                     t |> success(metal_prefill_stats().prefills - pfsp0 == 3l,


### PR DESCRIPTION
**Prefill numerics move on prompts whose length % 32 is 1..8: the last rows run a different GEMM form of the same math, within every codec tolerance bar. DASLLAMA_VERSION is now 9.**

The Metal mul_mm prefill bills ceil-32 M tiles. A prompt one row past a tile boundary pays a whole extra tile-row of GPU wall for rows nothing reads. The image turn is the worst case: its 321 rows are 10x32+1, so one real row bills a full ~48 ms tile on the 8B. This change peels small remainders (npos % 32 in 1..8) onto the fixed-B GEMV family: the full tiles run as before, the remainder rows run as GEMVs. A lone row rides the reduction-split GEMV; 2..8 rows ride the b4 form, which needs the site's reduction width to be a multiple of 128 - misaligned sites keep the padded tile. The knob is DASLLAMA_METAL_MM_TAIL, default on, with engage counters.

Second fix in the same arc: with a media span armed, the AV attention kernels walked every query tile to the full padded K extent. The walk bound is now per tile - causal reach, lifted to the span end only where the tile holds span rows. This is a pure shrink over softmax-zeroed columns; the span-fused witness reads maxdiff exactly 0 with it. The mv_b2 store now gates on nrows - it phantom-wrote a second row at nrows equal 1.

Board (released exe, quiet M1 Max, r=3, fresh reference pairs, warm): 8B image prefill 522 to 552 tok/s (-7.5% to -2.2% vs the reference), 4B 942 to 986 (-2.7%), 8B text p321 534.5 to 566.7 (+7.8% ahead); p341/p512 unchanged; 30B Omni rides (its FFN is MoE, outside the tail scope).

Where to look: `dasllama/dasllama_metal_prefill.das` (enc_gemm_mm and enc_gemm_mm_tail, the three AV walk bounds), `dasllama/dasllama_metal_kernels.das` (MetalQ8Gemv bindings, the mv_b2 store gate), `tests/test_metal_prefill_parity.das` (the mm-tail arm).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local battery beyond CI, all through run.das under -jit: prefill parity arms (mm-tail with the SmolLM2 alignment-guard leg, base, kq, all four span arms), the decode batch arm, the model-less kernels suite 7/7, the model-free suite 68/68. The alignment guard is mutation-proven red-first: a weakened gate reds the smol leg. The tail's per-leg controls (gemv xoff poison, second-dispatch deletion, knob neuter) each red exactly their own cell.
- The seven Metal tower gates plus the mtower arm ran because the AV bound is live on every tower encode: gemma4uv 4/4, gemma4v 12/12, gemma3v 6/6, qwen3v 12/12, whisper 35/35 (under DASLLAMA_CPU_PREFILL=1 - its audio-oracle cell claims a CPU prefill by design), audio 23/23, audio_embedder 5/5, test_model_image mtower 33 passed.
- The b2/b4 stripe misread on misaligned widths was verified on the device: standalone kernel probes at n=576/896 read 14/16 and 21/24 rows wrong against an f64 oracle; aligned controls read 0.
- preflight --full ran once; its three reds were a stale local binary (five tests green after an incremental rebuild) and one Linux-lane lint warning, each fix validated with the targeted gate.

### Claims - stated, not tested
- The Metal-4 tensor twins (the tail after the tensor mul_mm; the AV mm tensor form) are compile-covered only - the m4 box was unreachable. Settling run: crown mulmm_q8 on the m4, run the mm-tail arm and the prefill-kernels file there. A break shows as the mm-tail arm red on the m4.
- The non-llama enc_gemm_mm sites (deltanet, MoE shared-expert, PLE, MTP eh_proj) carry the tail with kdim/npos verified by read at all 22 sites; no parity fixture pins a small residue on those archs. A wrong kdim would red the family parity cells at residue-hitting prompt lengths.

### Not done
- The batch-DECODE mv rail dispatches the same unguarded-stripe kernels with no alignment clause - pre-existing, B in 2..8 on a model whose width is not a multiple of 128 misreads; ledgered for its own arc with a failing test first.
- PERF_LEDGER followups: the post-encode context residue (~10 ms), the kq mul_mm and MoE prefill tails, remainders 9..15, and the b2/b4 y binding's missing span (a conservative whole-buffer barrier per peeled site - correctness-neutral).

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)