### PR TITLE
dasweb-verify: expectations row for the linq_cars sample

### DIFF
--- a/utils/internal/dasweb-verify/browser/expectations.json
+++ b/utils/internal/dasweb-verify/browser/expectations.json
@@ -48,6 +48,7 @@
     "Functions": { "kind": "console", "stdout": "^hello$" },
     "Macros (multi-file)": { "kind": "console", "stdout": "Section 3: mixed sources" },
     "Tests": { "kind": "console", "action": "test", "modes": ["interpreter"], "stdout": "SUCCESS!" },
+    "Linq: group by + average": { "kind": "console", "stdout": "Vaz: avg 1200" },
 
     "Dictionary (benchmark)": { "kind": "console", "stdout": "^\"dictionary\", " },
     "SHA-256 (benchmark)": { "kind": "console", "stdout": "^\"sha256\", " },


### PR DESCRIPTION
One line: the expectations row for the new `linq_cars` playground sample. The verifier's coverage gate rightly turned the nightly red - a deployed sample with no row is a FAIL by design, and #3849 shipped the sample without one.

The other nightly red, the three games wedging in interpreter mode, needed no code: it does not reproduce on today's deploy. Full-sweep dispatches from this branch are 81/81 with the games interpreting at ~9.5s - far inside the stock 45s budget - both alone and in full-sweep context. The Aug 23-24 wedge was deploy-state, flushed when #3849's sample add busted the wasm cache key and forced a full rebuild: the exact artifact class this verifier exists to catch, and it caught it. A budget bump was tried, proved nothing, and was reverted - it would only have weakened the gate.

Where to look: `utils/internal/dasweb-verify/browser/expectations.json`, the one added row.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Protocol unit tests: 20/20 locally (the coverage gate goes green with the row).
- Full nightly sweep dispatched from this branch, twice (with and without the tried budget bump): both jobs green, 81 passed 0 failed, games interpreter ~9.5s.

### Claims - stated, not tested
- The wedge's root cause is attributed to stale deploy artifacts, not proven: no artifact from the red runs survives to inspect. If the wedge returns on a future nightly, the isolated-games dispatch (`workflow_dispatch` with filter `Game:`, mode `interpreter`) is the 3-minute discriminator between deploy-state and sweep-interaction.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
