### PR TITLE
vecmath: scalar per-lane backend - auto-selected when no SIMD ISA, forceable via DAS_VECMATH_SCALAR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,13 @@ option(DAS_ENABLE_PIC "Build static libs as position-independent code (UNIX, req
 # (all daslang targets, every config) and libhv's BUILD_FOR_MT (modules/dasHV) in
 # lockstep, so no target can disagree on /MT vs /MD. See CMakeCommon.txt.
 option(DAS_USE_STATIC_STD_LIBS "Link the static MSVC runtime (/MT); OFF = dynamic (/MD)" OFF)
+# Forces vecmath's scalar per-lane backend on SIMD-capable hosts. The backend is
+# auto-selected on targets with no SIMD ISA (Cortex-M, RISC-V without V); this knob
+# exists so the full test suite can validate it on x64.
+option(DAS_VECMATH_SCALAR "Force the scalar (non-SIMD) vecmath backend" OFF)
+if(DAS_VECMATH_SCALAR)
+    add_compile_definitions(_TARGET_SIMD_SCALAR=1)
+endif()
 # Upper bound on JobQue worker threads (caps get_total_hw_threads / get_total_hw_jobs and the
 # persistent job pool). Empty = platform.h default: 4 on wasm (keeps a web build from spawning one
 # Web Worker per logical core), effectively uncapped elsewhere (the cores-1 rule governs).

--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -22,7 +22,7 @@
 #define DAS_CC_API
 #endif
 //if target is not defined, try to auto-detect target
-#ifndef _TARGET_SIMD_SSE
+#if !defined(_TARGET_SIMD_SSE) && !defined(_TARGET_SIMD_SCALAR)
     #if __SSE4_1__ || defined(__AVX__) || defined(__AVX2__)
         #define _TARGET_SIMD_SSE 4
     #elif __SSSE3__
@@ -32,9 +32,11 @@
     #endif
 #endif
 
-#if !defined(_TARGET_SIMD_SSE) && !defined(_TARGET_SIMD_NEON)
+#if !defined(_TARGET_SIMD_SSE) && !defined(_TARGET_SIMD_NEON) && !defined(_TARGET_SIMD_SCALAR)
     #if defined(__ARM_NEON) || defined(__ARM_NEON__)
         #define _TARGET_SIMD_NEON 1
+    #else
+        #define _TARGET_SIMD_SCALAR 1
     #endif
 #endif
 
@@ -46,6 +48,23 @@
     #include <arm_neon.h>
     typedef float32x4_t vec4f;
     typedef int32x4_t   vec4i;
+#elif defined(_TARGET_SIMD_SCALAR)
+    //shared with vecmath/dag_vecMathDecl.h - keep identical
+    #ifndef DAS_SCALAR_VEC_TYPES_DEFINED
+    #define DAS_SCALAR_VEC_TYPES_DEFINED
+    #ifdef __cplusplus
+    struct alignas(16) vec4f_scalar_t { float f[4]; };
+    struct alignas(16) vec4i_scalar_t { int32_t i[4]; };
+    #elif defined(_MSC_VER)
+    typedef struct __declspec(align(16)) vec4f_scalar_t { float f[4]; } vec4f_scalar_t;
+    typedef struct __declspec(align(16)) vec4i_scalar_t { int32_t i[4]; } vec4i_scalar_t;
+    #else
+    typedef struct vec4f_scalar_t { float f[4]; } __attribute__((aligned(16))) vec4f_scalar_t;
+    typedef struct vec4i_scalar_t { int32_t i[4]; } __attribute__((aligned(16))) vec4i_scalar_t;
+    #endif
+    #endif
+    typedef vec4f_scalar_t vec4f;
+    typedef vec4i_scalar_t vec4i;
 #else
     #error unsupported target
 #endif

--- a/include/vecmath/dag_vecMath.h
+++ b/include/vecmath/dag_vecMath.h
@@ -1428,6 +1428,8 @@ VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_trunc(vec4f v);
   #include "dag_vecMath_pc_sse.h"
 #elif _TARGET_SIMD_NEON
   #include "dag_vecMath_neon.h"
+#elif _TARGET_SIMD_SCALAR
+  #include "dag_vecMath_scalar.h"
 #else
  !error! unsupported target
 #endif

--- a/include/vecmath/dag_vecMathDecl.h
+++ b/include/vecmath/dag_vecMathDecl.h
@@ -56,7 +56,9 @@ typedef const struct bsph3f& bsph3f_cref;
 #endif
 
 #ifndef VECTORCALL
-  #if _TARGET_PC_MACOSX && __SSE__
+  #if defined(_TARGET_SIMD_SCALAR)
+    #define VECTORCALL
+  #elif _TARGET_PC_MACOSX && __SSE__
     #define VECTORCALL [[clang::vectorcall]]
   #elif (defined(_MSC_VER) || defined(__clang__)) && defined(_WIN32) && __SSE__
       //__vectorcall is faster on msvc, even on x64 target
@@ -74,7 +76,7 @@ typedef const struct bsph3f& bsph3f_cref;
 #endif
 
 //if target is not defined, try to auto-detect target
-#ifndef _TARGET_SIMD_SSE
+#if !defined(_TARGET_SIMD_SSE) && !defined(_TARGET_SIMD_SCALAR)
   #if __SSE4_1__ || defined(__AVX__) || defined(__AVX2__)
     #define _TARGET_SIMD_SSE 4
   #elif __SSSE3__
@@ -90,9 +92,11 @@ typedef const struct bsph3f& bsph3f_cref;
   #endif
 #endif
 
-#if !defined(_TARGET_SIMD_SSE) && !defined(_TARGET_SIMD_NEON)
+#if !defined(_TARGET_SIMD_SSE) && !defined(_TARGET_SIMD_NEON) && !defined(_TARGET_SIMD_SCALAR)
   #if defined(__ARM_NEON) || defined(__ARM_NEON__)
     #define _TARGET_SIMD_NEON 1
+  #else
+    #define _TARGET_SIMD_SCALAR 1
   #endif
 #endif
 
@@ -121,6 +125,30 @@ typedef const struct bsph3f& bsph3f_cref;
   typedef int32x4_t   vec4i;
   typedef const vec4f vec4f_const;
   typedef const vec4i vec4i_const;
+
+#elif _TARGET_SIMD_SCALAR
+  #include <stdint.h>
+
+  //shared with daScript/daScriptC.h - keep identical
+  #ifndef DAS_SCALAR_VEC_TYPES_DEFINED
+  #define DAS_SCALAR_VEC_TYPES_DEFINED
+  struct alignas(16) vec4f_scalar_t { float f[4]; };
+  struct alignas(16) vec4i_scalar_t { int32_t i[4]; };
+  #endif
+  typedef vec4f_scalar_t vec4f;
+  typedef vec4f_scalar_t vec3f;
+  typedef vec4i_scalar_t vec4i;
+
+  typedef const vec4f vec4f_const;
+
+  typedef const union alignas(16) _vec4i_const_name
+  {
+    unsigned m128_u32[4];
+    vec4i m128;
+    vec4f m128f;
+    operator vec4i() const { return m128; }
+    operator vec4f() const { return m128f; }
+  } vec4i_const;
 
 #else
  !error! unsupported target

--- a/include/vecmath/dag_vecMath_common.h
+++ b/include/vecmath/dag_vecMath_common.h
@@ -379,7 +379,7 @@ VECTORCALL VECMATH_FINLINE vec4f v_remove_nan(vec4f a)
 VECTORCALL VECMATH_FINLINE vec4f v_is_nan(vec4f a)
 {
   volatile vec4f v = a;
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(_TARGET_SIMD_SCALAR)
   return v_cmp_neq(a, v);
 #else
   return v_cmp_neq(a, (vec4f &)v);
@@ -3299,7 +3299,7 @@ VECTORCALL VECMATH_INLINE void v_get_bilinear_wrap_addr_pow2(vec4i &uv_idx, vec4
 // don't use a pixel centered bilinear filtration because it creates shifts for different
   uv_wrap = v_mul(uv_wrap, dmap);
   uv_wrap = v_sub(uv_wrap, center_ofs);
-#if _TARGET_SIMD_SSE >= 4 || defined(__SSE4_1__)
+#if _TARGET_SIMD_SSE >= 4 || (_TARGET_SIMD_SSE && defined(__SSE4_1__))
   vec4f floored = sse4_floor(uv_wrap);
 #else
   vec4f floored = v_floor(uv_wrap);
@@ -3320,7 +3320,7 @@ VECTORCALL VECMATH_INLINE void v_get_bilinear_wrap_addr(vec4i &uv_idx, vec4f &uv
   vec4f dmap = v_cvt_vec4f(dmapi);
 // don't use a pixel centered bilinear filtration because it creates shifts for different
   uv_wrap = v_sub(uv_wrap, v_div(center_ofs, dmap));
-#if _TARGET_SIMD_SSE >= 4 || defined(__SSE4_1__)
+#if _TARGET_SIMD_SSE >= 4 || (_TARGET_SIMD_SSE && defined(__SSE4_1__))
   uv_wrap = v_mul(v_sub(uv_wrap, sse4_floor(uv_wrap)), dmap);
 #else
   uv_wrap = v_mul(v_sub(uv_wrap, v_floor(uv_wrap)), dmap);

--- a/include/vecmath/dag_vecMath_const.h
+++ b/include/vecmath/dag_vecMath_const.h
@@ -14,7 +14,7 @@
 
 #define REPLICATE(v) v, v, v, v
 
-#if _TARGET_SIMD_SSE
+#if _TARGET_SIMD_SSE || _TARGET_SIMD_SCALAR
   DECL_VEC_CONST vec4f_const V_C_HALF = { REPLICATE(0.5f) };
   DECL_VEC_CONST vec4f_const V_C_HALF_MINUS_EPS = { REPLICATE(0.5f - 1.192092896e-07f * 32) };
   DECL_VEC_CONST vec4f_const V_C_ONE = { REPLICATE(1.0f) };

--- a/include/vecmath/dag_vecMath_pc_sse.h
+++ b/include/vecmath/dag_vecMath_pc_sse.h
@@ -361,6 +361,7 @@ VECTORCALL VECMATH_FINLINE vec4i v_cvt_ceili(vec4f a) {return sse2_cvt_ceili(a);
 VECTORCALL VECMATH_FINLINE vec4i v_cvt_trunci(vec4f a) { return v_cvti_vec4i(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_floor(vec4f a) { return sse2_floor(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_ceil(vec4f a) { return sse2_ceil(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_round_ieee(vec4f a) { return sse2_round_ieee(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_trunc(vec4f a) { return v_cvti_vec4f(v_cvti_vec4i(a)); }
 VECTORCALL VECMATH_FINLINE vec4f v_sel(vec4f a, vec4f b, vec4f c)
 {

--- a/include/vecmath/dag_vecMath_scalar.h
+++ b/include/vecmath/dag_vecMath_scalar.h
@@ -1,0 +1,985 @@
+//
+// Dagor Engine 6.5 - 1st party libs
+// Copyright (C) Gaijin Games KFT.  All rights reserved.
+//
+#pragma once
+
+// Scalar per-lane backend: implements the same primitive contract as dag_vecMath_pc_sse.h /
+// dag_vecMath_neon.h for targets with no SIMD ISA (Cortex-M, RISC-V without V, forced via
+// _TARGET_SIMD_SCALAR=1 for testing). Semantics follow the SSE backend: compare results are
+// per-lane all-bits/zero masks, v_sel/v_seli and the v_check_*/v_signmask family read only
+// the lane sign bit, v_min/v_max return the second operand on unordered, float->int
+// conversions mirror cvttps/cvtps out-of-range behavior (INT_MIN), and the Cramer's-rule
+// matrix inverse/determinant are transcribed from the SSE backend op for op so rounding matches.
+
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+VECMATH_FINLINE float scalar_u2f(uint32_t u) { float r; memcpy(&r, &u, 4); return r; }
+VECMATH_FINLINE uint32_t scalar_f2u(float f) { uint32_t r; memcpy(&r, &f, 4); return r; }
+VECMATH_FINLINE float scalar_fmask(bool c) { return scalar_u2f(c ? 0xFFFFFFFFu : 0u); }
+VECMATH_FINLINE int scalar_sign(float f) { return int(scalar_f2u(f) >> 31); }
+
+VECMATH_FINLINE int scalar_trunc_to_int(float f)
+{
+  if (!(f >= -2147483648.0f && f < 2147483648.0f))
+    return INT32_MIN;
+  return (int)f;
+}
+VECMATH_FINLINE int scalar_round_to_int(float f)
+{
+  float r = nearbyintf(f);
+  if (!(r >= -2147483648.0f && r < 2147483648.0f))
+    return INT32_MIN;
+  return (int)r;
+}
+
+VECMATH_FINLINE vec4f scalar_perm(vec4f a, int i0, int i1, int i2, int i3)
+{
+  vec4f r; r.f[0] = a.f[i0]; r.f[1] = a.f[i1]; r.f[2] = a.f[i2]; r.f[3] = a.f[i3]; return r;
+}
+VECMATH_FINLINE vec4f scalar_shuffle(vec4f a, vec4f b, int i0, int i1, int i2, int i3)
+{
+  vec4f r; r.f[0] = a.f[i0]; r.f[1] = a.f[i1]; r.f[2] = b.f[i2]; r.f[3] = b.f[i3]; return r;
+}
+
+VECMATH_FINLINE vec4f v_zero() { vec4f r = {0.f, 0.f, 0.f, 0.f}; return r; }
+VECMATH_FINLINE vec4i v_zeroi() { vec4i r = {0, 0, 0, 0}; return r; }
+VECMATH_FINLINE vec4i v_set_all_bitsi() { vec4i r = {-1, -1, -1, -1}; return r; }
+VECMATH_FINLINE vec4f v_set_all_bits() { return v_cast_vec4f(v_set_all_bitsi()); }
+VECMATH_FINLINE vec4f v_msbit() { return (const vec4f &)V_CI_SIGN_MASK; }
+VECMATH_FINLINE vec4f v_splats(float a) { vec4f r = {a, a, a, a}; return r; }
+VECMATH_FINLINE vec4i v_splatsi(int a) { vec4i r = {a, a, a, a}; return r; }
+VECMATH_FINLINE vec4f v_set_x(float a) { vec4f r = {a, 0.f, 0.f, 0.f}; return r; }
+VECMATH_FINLINE vec4i v_seti_x(int a) { vec4i r = {a, 0, 0, 0}; return r; }
+
+NO_ASAN_INLINE vec4f v_ld(const float *m) { vec4f r; memcpy(&r, m, 16); return r; }
+NO_ASAN_INLINE vec4f v_ldu(const float *m) { vec4f r; memcpy(&r, m, 16); return r; }
+NO_ASAN_INLINE vec4i v_ldi(const int *m) { vec4i r; memcpy(&r, m, 16); return r; }
+NO_ASAN_INLINE vec4i v_ldui(const int *m) { vec4i r; memcpy(&r, m, 16); return r; }
+NO_ASAN_INLINE vec4f v_ldu_x(const float *m) { vec4f r = {*m, 0.f, 0.f, 0.f}; return r; }
+
+VECMATH_FINLINE vec4i v_ldui_half(const void *m) { vec4i r = {0, 0, 0, 0}; memcpy(&r, m, 8); return r; }
+VECMATH_FINLINE vec4f v_ldu_half(const void *m) { return v_cast_vec4f(v_ldui_half(m)); }
+VECMATH_FINLINE void v_prefetch(const void *m) { (void)m; }
+
+NO_ASAN_INLINE vec3f v_ldu_p3_safe(const float *m) { vec4f r = {m[0], m[1], m[2], 0.f}; return r; }
+NO_ASAN_INLINE vec4i v_ldui_p3_safe(const int *m) { vec4i r = {m[0], m[1], m[2], 0}; return r; }
+
+VECMATH_FINLINE vec4i v_ldush(const signed short *m)
+{
+  vec4i r; r.i[0] = m[0]; r.i[1] = m[1]; r.i[2] = m[2]; r.i[3] = m[3]; return r;
+}
+VECMATH_FINLINE vec4i v_lduush(const unsigned short *m)
+{
+  vec4i r; r.i[0] = m[0]; r.i[1] = m[1]; r.i[2] = m[2]; r.i[3] = m[3]; return r;
+}
+
+VECMATH_FINLINE vec4i v_cvt_lo_ush_vec4i(vec4i a)
+{
+  uint16_t h[8]; memcpy(h, &a, 16);
+  vec4i r; r.i[0] = h[0]; r.i[1] = h[1]; r.i[2] = h[2]; r.i[3] = h[3]; return r;
+}
+VECMATH_FINLINE vec4i v_cvt_hi_ush_vec4i(vec4i a)
+{
+  uint16_t h[8]; memcpy(h, &a, 16);
+  vec4i r; r.i[0] = h[4]; r.i[1] = h[5]; r.i[2] = h[6]; r.i[3] = h[7]; return r;
+}
+VECMATH_FINLINE vec4i v_cvt_lo_ssh_vec4i(vec4i a)
+{
+  int16_t h[8]; memcpy(h, &a, 16);
+  vec4i r; r.i[0] = h[0]; r.i[1] = h[1]; r.i[2] = h[2]; r.i[3] = h[3]; return r;
+}
+VECMATH_FINLINE vec4i v_cvt_hi_ssh_vec4i(vec4i a)
+{
+  int16_t h[8]; memcpy(h, &a, 16);
+  vec4i r; r.i[0] = h[4]; r.i[1] = h[5]; r.i[2] = h[6]; r.i[3] = h[7]; return r;
+}
+
+VECMATH_FINLINE vec4i v_cvt_byte_vec4i(uint32_t a)
+{
+  vec4i r; r.i[0] = a & 0xFF; r.i[1] = (a >> 8) & 0xFF; r.i[2] = (a >> 16) & 0xFF; r.i[3] = (a >> 24) & 0xFF; return r;
+}
+
+VECMATH_FINLINE vec4f v_make_vec4f(float x, float y, float z, float w) { vec4f r = {x, y, z, w}; return r; }
+VECMATH_FINLINE vec4i v_make_vec4i(int x, int y, int z, int w) { vec4i r = {x, y, z, w}; return r; }
+VECMATH_FINLINE vec4f v_make_vec3f(float x, float y, float z) { vec4f r = {x, y, z, z}; return r; }
+VECMATH_FINLINE vec4i v_make_vec3i(int x, int y, int z) { vec4i r = {x, y, z, z}; return r; }
+VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z) { vec4f r = {x.f[0], y.f[0], z.f[0], z.f[0]}; return r; }
+
+VECMATH_FINLINE vec4f v_perm_xxzz(vec4f b) { return scalar_perm(b, 0, 0, 2, 2); }
+VECMATH_FINLINE vec4f v_perm_xyxy(vec4f b) { return scalar_perm(b, 0, 1, 0, 1); }
+VECMATH_FINLINE vec4f v_perm_wwyy(vec4f b) { return scalar_perm(b, 3, 3, 1, 1); }
+VECMATH_FINLINE vec4f v_perm_yyww(vec4f b) { return scalar_perm(b, 1, 1, 3, 3); }
+VECMATH_FINLINE vec4f v_perm_xzxz(vec4f b) { return scalar_perm(b, 0, 2, 0, 2); }
+VECMATH_FINLINE vec4f v_perm_zxzx(vec4f b) { return scalar_perm(b, 2, 0, 2, 0); }
+VECMATH_FINLINE vec4f v_perm_zwzw(vec4f b) { return scalar_perm(b, 2, 3, 2, 3); }
+VECMATH_FINLINE vec4f v_perm_ywyw(vec4f b) { return scalar_perm(b, 1, 3, 1, 3); }
+VECMATH_FINLINE vec4f v_perm_xyzz(vec4f b) { return scalar_perm(b, 0, 1, 2, 2); }
+
+VECMATH_FINLINE vec4f v_splat_x(vec4f a) { return scalar_perm(a, 0, 0, 0, 0); }
+VECMATH_FINLINE vec4f v_splat_y(vec4f a) { return scalar_perm(a, 1, 1, 1, 1); }
+VECMATH_FINLINE vec4f v_splat_z(vec4f a) { return scalar_perm(a, 2, 2, 2, 2); }
+VECMATH_FINLINE vec4f v_splat_w(vec4f a) { return scalar_perm(a, 3, 3, 3, 3); }
+
+VECMATH_FINLINE vec4i v_splat_xi(vec4i a) { vec4i r = {a.i[0], a.i[0], a.i[0], a.i[0]}; return r; }
+VECMATH_FINLINE vec4i v_splat_yi(vec4i a) { vec4i r = {a.i[1], a.i[1], a.i[1], a.i[1]}; return r; }
+VECMATH_FINLINE vec4i v_splat_zi(vec4i a) { vec4i r = {a.i[2], a.i[2], a.i[2], a.i[2]}; return r; }
+VECMATH_FINLINE vec4i v_splat_wi(vec4i a) { vec4i r = {a.i[3], a.i[3], a.i[3], a.i[3]}; return r; }
+
+VECMATH_FINLINE void v_st(void *m, vec4f v) { memcpy(m, &v, 16); }
+VECMATH_FINLINE void v_stu(void *m, vec4f v) { memcpy(m, &v, 16); }
+VECMATH_FINLINE void v_sti(void *m, vec4i v) { memcpy(m, &v, 16); }
+VECMATH_FINLINE void v_stui(void *m, vec4i v) { memcpy(m, &v, 16); }
+VECMATH_FINLINE void v_stui_half(void *m, vec4i v) { memcpy(m, &v, 8); }
+VECMATH_FINLINE void v_stu_half(void *m, vec4f v) { memcpy(m, &v, 8); }
+VECMATH_FINLINE void v_stu_p3(float *p3, vec3f v) { memcpy(p3, &v, 12); }
+VECMATH_FINLINE void v_stui_p3(int *p3, vec4i v) { memcpy(p3, &v, 12); }
+
+VECMATH_FINLINE vec4f v_merge_hw(vec4f a, vec4f b) { vec4f r = {a.f[0], b.f[0], a.f[1], b.f[1]}; return r; }
+VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b) { vec4f r = {a.f[2], b.f[2], a.f[3], b.f[3]}; return r; }
+
+VECMATH_FINLINE int v_signmask(vec4f a)
+{
+  return scalar_sign(a.f[0]) | (scalar_sign(a.f[1]) << 1) | (scalar_sign(a.f[2]) << 2) | (scalar_sign(a.f[3]) << 3);
+}
+
+VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a)
+{
+  return (scalar_f2u(a.f[0]) | scalar_f2u(a.f[1]) | scalar_f2u(a.f[2]) | scalar_f2u(a.f[3])) == 0;
+}
+VECMATH_FINLINE bool v_test_all_bits_ones(vec4f a)
+{
+  return (scalar_f2u(a.f[0]) & scalar_f2u(a.f[1]) & scalar_f2u(a.f[2]) & scalar_f2u(a.f[3])) == 0xFFFFFFFFu;
+}
+VECMATH_FINLINE bool v_test_any_bit_set(vec4f a) { return !v_test_all_bits_zeros(a); }
+
+VECMATH_FINLINE bool v_check_xyzw_all_true(vec4f a) { return v_signmask(a) == 0b1111; }
+VECMATH_FINLINE bool v_check_xyzw_all_false(vec4f a) { return v_signmask(a) == 0; }
+VECMATH_FINLINE bool v_check_xyzw_any_true(vec4f a) { return v_signmask(a) != 0; }
+
+VECMATH_FINLINE bool v_check_xyz_all_true(vec4f a) { return (v_signmask(a) & 0b111) == 0b111; }
+VECMATH_FINLINE bool v_check_xyz_all_false(vec4f a) { return (v_signmask(a) & 0b111) == 0; }
+VECMATH_FINLINE bool v_check_xyz_any_true(vec4f a) { return (v_signmask(a) & 0b111) != 0; }
+
+VECMATH_FINLINE vec4f is_neg_special(vec4f a) { return v_cast_vec4f(v_srai(v_cast_vec4i(a), 31)); }
+
+VECMATH_FINLINE vec4f v_cmp_eq(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_fmask(a.f[k] == b.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_cmp_neq(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_fmask(!(a.f[k] == b.f[k])); return r;
+}
+VECMATH_FINLINE vec4i v_cmp_eqi(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = a.i[k] == b.i[k] ? -1 : 0; return r;
+}
+VECMATH_FINLINE vec4f v_cmp_eqi(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_fmask(scalar_f2u(a.f[k]) == scalar_f2u(b.f[k])); return r;
+}
+VECMATH_FINLINE vec4f v_cmp_ge(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_fmask(a.f[k] >= b.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_cmp_gt(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_fmask(a.f[k] > b.f[k]); return r;
+}
+VECMATH_FINLINE vec4i v_cmp_lti(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = a.i[k] < b.i[k] ? -1 : 0; return r;
+}
+VECMATH_FINLINE vec4i v_cmp_gti(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = a.i[k] > b.i[k] ? -1 : 0; return r;
+}
+
+VECMATH_FINLINE vec4f v_and(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_u2f(scalar_f2u(a.f[k]) & scalar_f2u(b.f[k])); return r;
+}
+VECMATH_FINLINE vec4f v_andnot(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_u2f(~scalar_f2u(a.f[k]) & scalar_f2u(b.f[k])); return r;
+}
+VECMATH_FINLINE vec4f v_or(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_u2f(scalar_f2u(a.f[k]) | scalar_f2u(b.f[k])); return r;
+}
+VECMATH_FINLINE vec4f v_xor(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_u2f(scalar_f2u(a.f[k]) ^ scalar_f2u(b.f[k])); return r;
+}
+VECMATH_FINLINE vec4f v_not(vec4f v) { return v_xor(v, v_set_all_bits()); }
+VECMATH_FINLINE vec4f v_btsel(vec4f a, vec4f b, vec4f c)
+{
+  vec4f r;
+  for (int k = 0; k < 4; k++)
+    r.f[k] = scalar_u2f((scalar_f2u(c.f[k]) & scalar_f2u(b.f[k])) | (~scalar_f2u(c.f[k]) & scalar_f2u(a.f[k])));
+  return r;
+}
+VECMATH_FINLINE vec4i v_btseli(vec4i a, vec4i b, vec4i c)
+{
+  vec4i r;
+  for (int k = 0; k < 4; k++)
+    r.i[k] = (int32_t)(((uint32_t)c.i[k] & (uint32_t)b.i[k]) | (~(uint32_t)c.i[k] & (uint32_t)a.i[k]));
+  return r;
+}
+
+VECMATH_FINLINE vec4i v_cast_vec4i(vec4f a) { vec4i r; memcpy(&r, &a, 16); return r; }
+VECMATH_FINLINE vec4f v_cast_vec4f(vec4i a) { vec4f r; memcpy(&r, &a, 16); return r; }
+
+VECMATH_FINLINE vec4i v_cvti_vec4i(vec4f a)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = scalar_trunc_to_int(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a)
+{
+  vec4i r;
+  for (int k = 0; k < 4; k++)
+    r.i[k] = (int32_t)(uint32_t)(a.f[k] == a.f[k] ? (int64_t)nearbyintf(a.f[k]) : 0);
+  return r;
+}
+VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a)
+{
+  vec4i r;
+  for (int k = 0; k < 4; k++)
+    r.i[k] = (int32_t)(uint32_t)(a.f[k] == a.f[k] ? (int64_t)a.f[k] : 0);
+  return r;
+}
+VECMATH_FINLINE vec4f v_cvti_vec4f(vec4i a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = (float)a.i[k]; return r;
+}
+VECMATH_FINLINE vec4f v_cvtu_vec4f(vec4i v)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = (float)(uint32_t)v.i[k]; return r;
+}
+VECMATH_FINLINE vec4f v_cvtu_vec4f_ieee(vec4i v)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = (float)(uint32_t)v.i[k]; return r;
+}
+VECMATH_FINLINE vec4i v_cvt_roundi_ieee(vec4f a)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = scalar_round_to_int(a.f[k]); return r;
+}
+
+VECMATH_FINLINE vec4i v_cvt_floori(vec4f a)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = scalar_trunc_to_int(floorf(a.f[k])); return r;
+}
+VECMATH_FINLINE vec4i v_cvt_ceili(vec4f a)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = scalar_trunc_to_int(ceilf(a.f[k])); return r;
+}
+VECMATH_FINLINE vec4i v_cvt_trunci(vec4f a) { return v_cvti_vec4i(a); }
+VECMATH_FINLINE vec4f v_floor(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = floorf(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_ceil(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = ceilf(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_round_ieee(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = nearbyintf(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_trunc(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = truncf(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_sel(vec4f a, vec4f b, vec4f c)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = (scalar_f2u(c.f[k]) >> 31) ? b.f[k] : a.f[k]; return r;
+}
+VECMATH_FINLINE vec4i v_seli(vec4i a, vec4i b, vec4i c)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = ((uint32_t)c.i[k] >> 31) ? b.i[k] : a.i[k]; return r;
+}
+
+VECMATH_FINLINE vec4f v_add(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] + b.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_sub(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] - b.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_mul(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] * b.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_div(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] / b.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] * b.f[k] + c.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] * b.f[k] - c.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = c.f[k] - a.f[k] * b.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] + b.f[0]; return r; }
+VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] - b.f[0]; return r; }
+VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] * b.f[0]; return r; }
+VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] / b.f[0]; return r; }
+VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { vec4f r = a; r.f[0] = a.f[0] * b.f[0] + c.f[0]; return r; }
+VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c) { vec4f r = a; r.f[0] = a.f[0] * b.f[0] - c.f[0]; return r; }
+VECMATH_FINLINE vec4f v_nmsub_x(vec4f a, vec4f b, vec4f c) { vec4f r = c; r.f[0] = c.f[0] - a.f[0] * b.f[0]; return r; }
+VECMATH_FINLINE vec4i v_addi(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)((uint32_t)a.i[k] + (uint32_t)b.i[k]); return r;
+}
+VECMATH_FINLINE vec4i v_subi(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)((uint32_t)a.i[k] - (uint32_t)b.i[k]); return r;
+}
+
+VECMATH_FINLINE vec4i v_addi16(vec4i a, vec4i b)
+{
+  uint16_t x[8], y[8]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 8; k++) x[k] = (uint16_t)(x[k] + y[k]);
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+VECMATH_FINLINE vec4i v_subi16(vec4i a, vec4i b)
+{
+  uint16_t x[8], y[8]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 8; k++) x[k] = (uint16_t)(x[k] - y[k]);
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+VECMATH_FINLINE vec4i v_muli16(vec4i a, vec4i b)
+{
+  uint16_t x[8], y[8]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 8; k++) x[k] = (uint16_t)((uint32_t)x[k] * y[k]);
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+VECMATH_FINLINE vec4i v_mulhi16(vec4i a, vec4i b)
+{
+  int16_t x[8], y[8]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 8; k++) x[k] = (int16_t)(((int32_t)x[k] * y[k]) >> 16);
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+VECMATH_FINLINE vec4i v_madd_i16(vec4i a, vec4i b)
+{
+  int16_t x[8], y[8]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  vec4i r;
+  //the sum wraps at 0x8000*0x8000*2 like pmaddwd does - keep it defined without -fwrapv
+  for (int k = 0; k < 4; k++)
+    r.i[k] = (int32_t)((uint32_t)((int32_t)x[2 * k] * y[2 * k]) + (uint32_t)((int32_t)x[2 * k + 1] * y[2 * k + 1]));
+  return r;
+}
+VECMATH_FINLINE vec4i v_splatsi16(int v)
+{
+  uint16_t x[8]; for (int k = 0; k < 8; k++) x[k] = (uint16_t)v;
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+
+VECMATH_FINLINE vec4i scalar_interleave8(vec4i a, vec4i b, int base)
+{
+  uint8_t x[16], y[16], o[16]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 8; k++) { o[2 * k] = x[base + k]; o[2 * k + 1] = y[base + k]; }
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+VECMATH_FINLINE vec4i scalar_interleave16(vec4i a, vec4i b, int base)
+{
+  uint16_t x[8], y[8], o[8]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 4; k++) { o[2 * k] = x[base + k]; o[2 * k + 1] = y[base + k]; }
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+VECMATH_FINLINE vec4i v_interleave_lo_i8(vec4i a, vec4i b) { return scalar_interleave8(a, b, 0); }
+VECMATH_FINLINE vec4i v_interleave_hi_i8(vec4i a, vec4i b) { return scalar_interleave8(a, b, 8); }
+VECMATH_FINLINE vec4i v_interleave_lo_i16(vec4i a, vec4i b) { return scalar_interleave16(a, b, 0); }
+VECMATH_FINLINE vec4i v_interleave_hi_i16(vec4i a, vec4i b) { return scalar_interleave16(a, b, 4); }
+VECMATH_FINLINE vec4i v_interleave_lo_i32(vec4i a, vec4i b) { vec4i r = {a.i[0], b.i[0], a.i[1], b.i[1]}; return r; }
+VECMATH_FINLINE vec4i v_interleave_hi_i32(vec4i a, vec4i b) { vec4i r = {a.i[2], b.i[2], a.i[3], b.i[3]}; return r; }
+VECMATH_FINLINE vec4i v_interleave_lo_i64(vec4i a, vec4i b) { vec4i r = {a.i[0], a.i[1], b.i[0], b.i[1]}; return r; }
+VECMATH_FINLINE vec4i v_interleave_hi_i64(vec4i a, vec4i b) { vec4i r = {a.i[2], a.i[3], b.i[2], b.i[3]}; return r; }
+
+VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
+{
+  vec4f s = v_add(a, v_rot_2(a));
+  return v_add_x(s, v_splat_y(s));
+}
+VECMATH_FINLINE vec4f v_hadd3_x(vec3f a)
+{
+  vec4f r = a;
+  r.f[0] = (a.f[0] + a.f[1]) + a.f[2];
+  return r;
+}
+
+VECMATH_FINLINE vec4i v_slli(vec4i v, int bits)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = bits >= 32 ? 0 : (int32_t)((uint32_t)v.i[k] << bits); return r;
+}
+VECMATH_FINLINE vec4i v_srli(vec4i v, int bits)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = bits >= 32 ? 0 : (int32_t)((uint32_t)v.i[k] >> bits); return r;
+}
+VECMATH_FINLINE vec4i v_srai(vec4i v, int bits)
+{
+  int b = bits > 31 ? 31 : bits;
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = v.i[k] >> b; return r;
+}
+VECMATH_FINLINE vec4i v_slli_64(vec4i v, int bits)
+{
+  uint64_t x[2]; memcpy(x, &v, 16);
+  x[0] = bits >= 64 ? 0 : x[0] << bits; x[1] = bits >= 64 ? 0 : x[1] << bits;
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+VECMATH_FINLINE vec4i v_srli_64(vec4i v, int bits)
+{
+  uint64_t x[2]; memcpy(x, &v, 16);
+  x[0] = bits >= 64 ? 0 : x[0] >> bits; x[1] = bits >= 64 ? 0 : x[1] >> bits;
+  vec4i r; memcpy(&r, x, 16); return r;
+}
+VECMATH_FINLINE vec4i v_slli_n(vec4i v, int bits) { return v_slli(v, bits); }
+VECMATH_FINLINE vec4i v_srli_n(vec4i v, int bits) { return v_srli(v, bits); }
+VECMATH_FINLINE vec4i v_srai_n(vec4i v, int bits) { return v_srai(v, bits); }
+VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits) { uint64_t c[2]; memcpy(c, &bits, 16); return v_slli(v, c[0] > 63 ? 64 : (int)c[0]); }
+VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits) { uint64_t c[2]; memcpy(c, &bits, 16); return v_srli(v, c[0] > 63 ? 64 : (int)c[0]); }
+VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits) { uint64_t c[2]; memcpy(c, &bits, 16); return v_srai(v, c[0] > 63 ? 64 : (int)c[0]); }
+
+VECMATH_FINLINE vec4i v_sll(vec4i v, int bits) { return v_slli(v, bits); }
+VECMATH_FINLINE vec4i v_srl(vec4i v, int bits) { return v_srli(v, bits); }
+VECMATH_FINLINE vec4i v_sra(vec4i v, int bits) { return v_srai(v, bits); }
+
+VECMATH_FINLINE vec4i v_ori(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)((uint32_t)a.i[k] | (uint32_t)b.i[k]); return r;
+}
+VECMATH_FINLINE vec4i v_andi(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)((uint32_t)a.i[k] & (uint32_t)b.i[k]); return r;
+}
+VECMATH_FINLINE vec4i v_andnoti(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)(~(uint32_t)a.i[k] & (uint32_t)b.i[k]); return r;
+}
+VECMATH_FINLINE vec4i v_xori(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)((uint32_t)a.i[k] ^ (uint32_t)b.i[k]); return r;
+}
+
+VECMATH_FINLINE int16_t scalar_sat_i16(int32_t v) { return (int16_t)(v < -32768 ? -32768 : (v > 32767 ? 32767 : v)); }
+VECMATH_FINLINE uint16_t scalar_sat_u16(int32_t v) { return (uint16_t)(v < 0 ? 0 : (v > 65535 ? 65535 : v)); }
+VECMATH_FINLINE uint8_t scalar_sat_u8(int16_t v) { return (uint8_t)(v < 0 ? 0 : (v > 255 ? 255 : v)); }
+
+VECMATH_FINLINE vec4i v_packs(vec4i a, vec4i b)
+{
+  int16_t o[8];
+  for (int k = 0; k < 4; k++) { o[k] = scalar_sat_i16(a.i[k]); o[k + 4] = scalar_sat_i16(b.i[k]); }
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+VECMATH_FINLINE vec4i v_packs(vec4i a) { return v_packs(a, a); }
+VECMATH_FINLINE vec4i v_packus(vec4i a, vec4i b)
+{
+  uint16_t o[8];
+  for (int k = 0; k < 4; k++) { o[k] = scalar_sat_u16(a.i[k]); o[k + 4] = scalar_sat_u16(b.i[k]); }
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+VECMATH_FINLINE vec4i v_packus(vec4i a) { return v_packus(a, a); }
+VECMATH_FINLINE vec4i v_packus16(vec4i a, vec4i b)
+{
+  int16_t x[8], y[8]; uint8_t o[16]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 8; k++) { o[k] = scalar_sat_u8(x[k]); o[k + 8] = scalar_sat_u8(y[k]); }
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+VECMATH_FINLINE vec4i v_packus16(vec4i a) { return v_packus16(a, a); }
+
+VECMATH_FINLINE vec4i v_muli(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (int32_t)((uint32_t)a.i[k] * (uint32_t)b.i[k]); return r;
+}
+
+VECMATH_FINLINE vec4f v_rcp_unprecise(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = 1.f / a.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_rcp_est(vec4f a) { return v_rcp_unprecise(a); }
+VECMATH_FINLINE vec4f v_rcp_unprecise_x(vec4f a) { vec4f r = a; r.f[0] = 1.f / a.f[0]; return r; }
+VECMATH_FINLINE vec4f v_rcp_est_x(vec4f a) { return v_rcp_unprecise_x(a); }
+
+VECMATH_FINLINE vec4f v_rsqrt_unprecise(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = 1.f / sqrtf(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_rsqrt_unprecise_x(vec4f a) { vec4f r = a; r.f[0] = 1.f / sqrtf(a.f[0]); return r; }
+VECMATH_FINLINE vec4f v_rsqrt_est(vec4f a) { return v_rsqrt_unprecise(a); }
+VECMATH_FINLINE vec4f v_rsqrt_est_x(vec4f a) { return v_rsqrt_unprecise_x(a); }
+VECMATH_FINLINE vec4f v_rsqrt(vec4f a) { return v_div(v_sqrt(a), a); }
+VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) { return v_div_x(v_sqrt_x(a), a); }
+
+VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] < b.f[k] ? a.f[k] : b.f[k]; return r;
+}
+VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = a.f[k] > b.f[k] ? a.f[k] : b.f[k]; return r;
+}
+VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = a.i[k] < b.i[k] ? a.i[k] : b.i[k]; return r;
+}
+VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = a.i[k] > b.i[k] ? a.i[k] : b.i[k]; return r;
+}
+VECMATH_FINLINE vec4i v_minu(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (uint32_t)a.i[k] < (uint32_t)b.i[k] ? a.i[k] : b.i[k]; return r;
+}
+VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = (uint32_t)a.i[k] > (uint32_t)b.i[k] ? a.i[k] : b.i[k]; return r;
+}
+VECMATH_FINLINE vec4i v_absi(vec4i a)
+{
+  vec4i r; for (int k = 0; k < 4; k++) r.i[k] = a.i[k] < 0 ? (int32_t)(0u - (uint32_t)a.i[k]) : a.i[k]; return r;
+}
+
+VECMATH_FINLINE vec4f v_neg(vec4f a) { return v_xor(a, v_cast_vec4f(v_splatsi(0x80000000))); }
+VECMATH_FINLINE vec4i v_negi(vec4i a) { return v_subi(v_cast_vec4i(v_zero()), a); }
+VECMATH_FINLINE vec4f v_abs(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = scalar_u2f(scalar_f2u(a.f[k]) & 0x7FFFFFFFu); return r;
+}
+
+VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = sqrtf(a.f[k]); return r;
+}
+VECMATH_FINLINE vec4f v_sqrt(vec4f a) { return v_sqrt4_fast(a); }
+VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f a) { vec4f r = a; r.f[0] = sqrtf(a.f[0]); return r; }
+VECMATH_FINLINE vec4f v_sqrt_x(vec4f a) { return v_sqrt_fast_x(a); }
+
+VECMATH_FINLINE vec4f v_rot_1(vec4f a) { return scalar_perm(a, 1, 2, 3, 0); }
+VECMATH_FINLINE vec4f v_rot_2(vec4f a) { return scalar_perm(a, 2, 3, 0, 1); }
+VECMATH_FINLINE vec4f v_rot_3(vec4f a) { return scalar_perm(a, 3, 0, 1, 2); }
+VECMATH_FINLINE vec4i v_roti_1(vec4i a) { vec4i r = {a.i[1], a.i[2], a.i[3], a.i[0]}; return r; }
+VECMATH_FINLINE vec4i v_roti_2(vec4i a) { vec4i r = {a.i[2], a.i[3], a.i[0], a.i[1]}; return r; }
+VECMATH_FINLINE vec4i v_roti_3(vec4i a) { vec4i r = {a.i[3], a.i[0], a.i[1], a.i[2]}; return r; }
+
+VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a) { return scalar_perm(a, 1, 2, 0, 0); }
+VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a) { return scalar_perm(a, 1, 2, 0, 1); }
+VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a) { return scalar_perm(a, 1, 2, 0, 3); }
+VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a) { return scalar_perm(a, 2, 0, 1, 3); }
+VECMATH_FINLINE vec4f v_perm_xxyy(vec4f a) { return scalar_perm(a, 0, 0, 1, 1); }
+VECMATH_FINLINE vec4f v_perm_zzww(vec4f a) { return scalar_perm(a, 2, 2, 3, 3); }
+
+VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 0, 2, 0, 2); }
+VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 1, 3, 1, 3); }
+VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 0, 1, 0, 1); }
+VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 2, 3, 2, 3); }
+VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd) { return scalar_shuffle(abcd, xyzw, 1, 1, 1, 0); }
+VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[0], abcd.f[0], xyzw.f[0], abcd.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 1, 1, 1, 1); }
+VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 0, 0, 0, 1); }
+VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 1, 2, 0, 1); }
+
+VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 0, 1, 2, 3); }
+VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = xyzw; r.f[0] = abcd.f[0]; return r;
+}
+
+VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[0], xyzw.f[2], abcd.f[1], xyzw.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[0], xyzw.f[2], xyzw.f[1], abcd.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[1], xyzw.f[0], xyzw.f[0], abcd.f[2]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[1], abcd.f[0], xyzw.f[0], xyzw.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[2], xyzw.f[0], xyzw.f[0], abcd.f[1]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[2], abcd.f[0], xyzw.f[1], xyzw.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {abcd.f[1], xyzw.f[2], xyzw.f[0], xyzw.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {abcd.f[2], abcd.f[0], xyzw.f[0], xyzw.f[0]}; return r;
+}
+
+VECMATH_FINLINE vec3f v_mat43_extract_pos(mat43f_cref mat)
+{
+  vec4f r = {mat.row0.f[3], mat.row1.f[3], mat.row2.f[3], mat.row2.f[0]}; return r;
+}
+
+VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = xyzw; r.f[1] = abcd.f[1]; return r;
+}
+VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = xyzw; r.f[2] = abcd.f[2]; return r;
+}
+VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = xyzw; r.f[3] = abcd.f[3]; return r;
+}
+
+VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b)
+{
+  float d = (a.f[0] * b.f[0] + a.f[1] * b.f[1]) + (a.f[2] * b.f[2] + a.f[3] * b.f[3]);
+  return v_splats(d);
+}
+VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b)
+{
+  vec4f r = {(a.f[0] * b.f[0] + a.f[1] * b.f[1]) + (a.f[2] * b.f[2] + a.f[3] * b.f[3]), 0.f, 0.f, 0.f}; return r;
+}
+VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b)
+{
+  float d = (a.f[0] * b.f[0] + a.f[1] * b.f[1]) + a.f[2] * b.f[2];
+  return v_splats(d);
+}
+VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b)
+{
+  vec4f r = {(a.f[0] * b.f[0] + a.f[1] * b.f[1]) + a.f[2] * b.f[2], 0.f, 0.f, 0.f}; return r;
+}
+VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b)
+{
+  return v_splats(a.f[0] * b.f[0] + a.f[1] * b.f[1]);
+}
+VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b)
+{
+  vec4f r = {a.f[0] * b.f[0] + a.f[1] * b.f[1], 0.f, 0.f, 0.f}; return r;
+}
+VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return v_add_x(v_dot3_x(a, b), v_splat_w(a)); }
+
+VECMATH_FINLINE vec4f v_length4_sq(vec4f a) { return v_dot4(a, a); }
+VECMATH_FINLINE vec3f v_length3_sq(vec3f a) { return v_dot3(a, a); }
+VECMATH_FINLINE vec4f v_length2_sq(vec4f a) { return v_dot2(a, a); }
+VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_dot4_x(a, a); }
+VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a) { return v_dot3_x(a, a); }
+VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a) { return v_dot2_x(a, a); }
+
+VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot4_x(a, a)))); }
+VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot3_x(a, a)))); }
+VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot2_x(a, a)))); }
+
+VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b)
+{
+  return v_splat_x(v_plane_dist_x(a, b));
+}
+
+VECMATH_FINLINE void v_mat_33cu_from_mat33(float * __restrict m33, const mat33f &tm)
+{
+  v_stu_p3(m33 + 0, tm.col0);
+  v_stu_p3(m33 + 3, tm.col1);
+  v_stu_p3(m33 + 6, tm.col2);
+}
+
+VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f &tm, const float *const __restrict m43)
+{
+  vec4f c0 = {m43[0], m43[1], m43[2], 0.f};
+  vec4f c1 = {m43[3], m43[4], m43[5], 0.f};
+  vec4f c2 = {m43[6], m43[7], m43[8], 0.f};
+  vec4f c3 = {m43[9], m43[10], m43[11], 1.f};
+  tm.col0 = c0; tm.col1 = c1; tm.col2 = c2; tm.col3 = c3;
+}
+VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f &tm, const float *const __restrict m43)
+{
+  v_mat44_make_from_43cu(tm, m43);
+}
+VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43)
+{
+  v_mat44_make_from_43cu(tmV, m43);
+}
+
+VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, const mat44f &tm)
+{
+  v_stu_p3(m43 + 0, tm.col0);
+  v_stu_p3(m43 + 3, tm.col1);
+  v_stu_p3(m43 + 6, tm.col2);
+  v_stu_p3(m43 + 9, tm.col3);
+}
+VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm)
+{
+  v_mat_43cu_from_mat44(m43, tm);
+}
+
+VECMATH_FINLINE void v_mat44_ident(mat44f &dest)
+{
+  dest.col0 = V_C_UNIT_1000;
+  dest.col1 = V_C_UNIT_0100;
+  dest.col2 = V_C_UNIT_0010;
+  dest.col3 = V_C_UNIT_0001;
+}
+VECMATH_FINLINE void v_mat44_ident_swapxz(mat44f &dest)
+{
+  dest.col0 = V_C_UNIT_0010;
+  dest.col1 = V_C_UNIT_0100;
+  dest.col2 = V_C_UNIT_1000;
+  dest.col3 = V_C_UNIT_0001;
+}
+VECMATH_FINLINE void v_mat33_ident(mat33f &dest)
+{
+  dest.col0 = V_C_UNIT_1000;
+  dest.col1 = V_C_UNIT_0100;
+  dest.col2 = V_C_UNIT_0010;
+}
+VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest)
+{
+  dest.col0 = V_C_UNIT_0010;
+  dest.col1 = V_C_UNIT_0100;
+  dest.col2 = V_C_UNIT_1000;
+}
+
+VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src)
+{
+  vec4f c0 = {src.col0.f[0], src.col1.f[0], src.col2.f[0], src.col3.f[0]};
+  vec4f c1 = {src.col0.f[1], src.col1.f[1], src.col2.f[1], src.col3.f[1]};
+  vec4f c2 = {src.col0.f[2], src.col1.f[2], src.col2.f[2], src.col3.f[2]};
+  vec4f c3 = {src.col0.f[3], src.col1.f[3], src.col2.f[3], src.col3.f[3]};
+  dest.col0 = c0; dest.col1 = c1; dest.col2 = c2; dest.col3 = c3;
+}
+VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
+{
+  mat44f m; m.col0 = r0; m.col1 = r1; m.col2 = r2; m.col3 = r3;
+  v_mat44_transpose(m, m);
+  r0 = m.col0; r1 = m.col1; r2 = m.col2; r3 = m.col3;
+}
+VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
+{
+  vec4f c0 = {src.row0.f[0], src.row1.f[0], src.row2.f[0], 0.f};
+  vec4f c1 = {src.row0.f[1], src.row1.f[1], src.row2.f[1], 0.f};
+  vec4f c2 = {src.row0.f[2], src.row1.f[2], src.row2.f[2], 0.f};
+  vec4f c3 = {src.row0.f[3], src.row1.f[3], src.row2.f[3], 0.f};
+  dest.col0 = c0; dest.col1 = c1; dest.col2 = c2; dest.col3 = c3;
+}
+VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
+{
+  vec4f r0 = {src.col0.f[0], src.col1.f[0], src.col2.f[0], src.col3.f[0]};
+  vec4f r1 = {src.col0.f[1], src.col1.f[1], src.col2.f[1], src.col3.f[1]};
+  vec4f r2 = {src.col0.f[2], src.col1.f[2], src.col2.f[2], src.col3.f[2]};
+  dest.row0 = r0; dest.row1 = r1; dest.row2 = r2;
+}
+
+VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
+{
+  return v_add(
+    v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
+    v_add(v_mul(v_splat_z(v), m.col2), v_mul(v_splat_w(v), m.col3)));
+}
+VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
+{
+  return v_add(v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
+               v_mul(v_splat_z(v), m.col2));
+}
+VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
+{
+  return v_add(
+    v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
+    v_add(v_mul(v_splat_z(v), m.col2), m.col3));
+}
+VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
+{
+  return v_add(v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
+               v_mul(v_splat_z(v), m.col2));
+}
+
+// transcription key: V_SHUFFLE 0xB1 = yxwz, 0x4E = zwxy
+VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
+{
+  vec4f minor0, minor1, minor2, minor3;
+  vec4f row0, row1, row2, row3;
+  vec4f det, tmp0, tmp1, tmp2, tmp3;
+
+  tmp0 = v_perm_xzac(m.col0, m.col1);
+  tmp1 = v_perm_xzac(m.col2, m.col3);
+  tmp2 = v_perm_ywbd(m.col0, m.col1);
+  tmp3 = v_perm_ywbd(m.col2, m.col3);
+  row0 = v_perm_xzac(tmp0, tmp1);
+  row1 = v_perm_xzac(tmp3, tmp2);
+  row2 = v_perm_ywbd(tmp0, tmp1);
+  row3 = v_perm_ywbd(tmp3, tmp2);
+
+  tmp1 = v_mul(row2, row3);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor0 = v_mul(row1, tmp1);
+  minor1 = v_mul(row0, tmp1);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor0 = v_sub(v_mul(row1, tmp1), minor0);
+  minor1 = v_sub(v_mul(row0, tmp1), minor1);
+  minor1 = scalar_perm(minor1, 2, 3, 0, 1);
+
+  tmp1 = v_mul(row1, row2);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor0 = v_add(v_mul(row3, tmp1), minor0);
+  minor3 = v_mul(row0, tmp1);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor0 = v_sub(minor0, v_mul(row3, tmp1));
+  minor3 = v_sub(v_mul(row0, tmp1), minor3);
+  minor3 = scalar_perm(minor3, 2, 3, 0, 1);
+
+  tmp1 = v_mul(scalar_perm(row1, 2, 3, 0, 1), row3);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  row2 = scalar_perm(row2, 2, 3, 0, 1);
+  minor0 = v_add(v_mul(row2, tmp1), minor0);
+  minor2 = v_mul(row0, tmp1);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor0 = v_sub(minor0, v_mul(row2, tmp1));
+  minor2 = v_sub(v_mul(row0, tmp1), minor2);
+  minor2 = scalar_perm(minor2, 2, 3, 0, 1);
+
+  tmp1 = v_mul(row0, row1);
+
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor2 = v_add(v_mul(row3, tmp1), minor2);
+  minor3 = v_sub(v_mul(row2, tmp1), minor3);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor2 = v_sub(v_mul(row3, tmp1), minor2);
+  minor3 = v_sub(minor3, v_mul(row2, tmp1));
+
+  tmp1 = v_mul(row0, row3);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor1 = v_sub(minor1, v_mul(row2, tmp1));
+  minor2 = v_add(v_mul(row1, tmp1), minor2);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor1 = v_add(v_mul(row2, tmp1), minor1);
+  minor2 = v_sub(minor2, v_mul(row1, tmp1));
+
+  tmp1 = v_mul(row0, row2);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor1 = v_add(v_mul(row3, tmp1), minor1);
+  minor3 = v_sub(minor3, v_mul(row1, tmp1));
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor1 = v_sub(minor1, v_mul(row3, tmp1));
+  minor3 = v_add(v_mul(row1, tmp1), minor3);
+
+  det = v_mul(row0, minor0);
+  det = v_add(scalar_perm(det, 2, 3, 0, 1), det);
+  det = v_add_x(scalar_perm(det, 1, 0, 3, 2), det);
+  tmp1 = v_rcp_safe(det);
+  det = v_sub_x(v_add_x(tmp1, tmp1), v_mul_x(det, v_mul_x(tmp1, tmp1)));
+  det = v_splat_x(det);
+  dest.col0 = v_mul(det, minor0);
+  dest.col1 = v_mul(det, minor1);
+  dest.col2 = v_mul(det, minor2);
+  dest.col3 = v_mul(det, minor3);
+}
+
+VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
+{
+  vec4f tmp0, tmp1, tmp2, tmp3, tmp4, dot, invdet, inv0, inv1, inv2;
+
+  tmp2 = v_cross3(m.col0, m.col1);
+  tmp0 = v_cross3(m.col1, m.col2);
+  tmp1 = v_cross3(m.col2, m.col0);
+  dot = v_dot3(tmp2, m.col2);
+  invdet = v_rcp_safe(dot);
+
+  tmp3 = scalar_shuffle(tmp0, tmp1, 2, 0, 2, 0);
+  tmp4 = scalar_shuffle(tmp0, tmp1, 3, 1, 3, 1);
+  inv0 = scalar_shuffle(tmp3, tmp2, 1, 3, 0, 3);
+  inv1 = scalar_shuffle(tmp4, tmp2, 1, 3, 1, 3);
+  inv2 = scalar_shuffle(tmp3, tmp2, 0, 2, 2, 3);
+
+  dest.col0 = v_mul(inv0, invdet);
+  dest.col1 = v_mul(inv1, invdet);
+  dest.col2 = v_mul(inv2, invdet);
+}
+
+VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
+{
+  vec4f minor0;
+  vec4f row0, row1, row2, row3;
+  vec4f det, tmp0, tmp1, tmp2, tmp3;
+
+  tmp0 = v_perm_xzac(m.col0, m.col1);
+  tmp1 = v_perm_xzac(m.col2, m.col3);
+  tmp2 = v_perm_ywbd(m.col0, m.col1);
+  tmp3 = v_perm_ywbd(m.col2, m.col3);
+  row0 = v_perm_xzac(tmp0, tmp1);
+  row1 = v_perm_xzac(tmp3, tmp2);
+  row2 = v_perm_ywbd(tmp0, tmp1);
+  row3 = v_perm_ywbd(tmp3, tmp2);
+
+  tmp1 = v_mul(row2, row3);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor0 = v_mul(row1, tmp1);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor0 = v_sub(v_mul(row1, tmp1), minor0);
+
+  tmp1 = v_mul(row1, row2);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  minor0 = v_add(v_mul(row3, tmp1), minor0);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor0 = v_sub(minor0, v_mul(row3, tmp1));
+
+  tmp1 = v_mul(scalar_perm(row1, 2, 3, 0, 1), row3);
+  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
+  row2 = scalar_perm(row2, 2, 3, 0, 1);
+  minor0 = v_add(v_mul(row2, tmp1), minor0);
+  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
+  minor0 = v_sub(minor0, v_mul(row2, tmp1));
+
+  det = v_mul(row0, minor0);
+  det = v_add(scalar_perm(det, 2, 3, 0, 1), det);
+  det = v_add_x(scalar_perm(det, 1, 0, 3, 2), det);
+  return det;
+}
+
+VECMATH_FINLINE float v_extract_x(vec4f v) { return v.f[0]; }
+VECMATH_FINLINE float v_extract_y(vec4f v) { return v.f[1]; }
+VECMATH_FINLINE float v_extract_z(vec4f v) { return v.f[2]; }
+VECMATH_FINLINE float v_extract_w(vec4f v) { return v.f[3]; }
+
+VECMATH_FINLINE int v_extract_xi(vec4i v) { return v.i[0]; }
+VECMATH_FINLINE int v_extract_yi(vec4i v) { return v.i[1]; }
+VECMATH_FINLINE int v_extract_zi(vec4i v) { return v.i[2]; }
+VECMATH_FINLINE int v_extract_wi(vec4i v) { return v.i[3]; }
+VECMATH_FINLINE int64_t v_extract_xi64(vec4i v) { int64_t r; memcpy(&r, &v.i[0], 8); return r; }
+VECMATH_FINLINE int64_t v_extract_yi64(vec4i v) { int64_t r; memcpy(&r, &v.i[2], 8); return r; }
+
+VECMATH_FINLINE vec4i v_splatsi64(int64_t a)
+{
+  vec4i r; memcpy(&r.i[0], &a, 8); memcpy(&r.i[2], &a, 8); return r;
+}
+
+VECMATH_FINLINE short v_extract_xi16(vec4i v) { return (short)(v.i[0] & 0xFFFF); }
+
+VECMATH_FINLINE int v_test_vec_x_eqi(vec3f v, vec3f a) { return scalar_f2u(v.f[0]) == scalar_f2u(a.f[0]) ? 1 : 0; }
+VECMATH_FINLINE int v_test_vec_x_eqi_0(vec3f v) { return scalar_f2u(v.f[0]) == 0 ? 1 : 0; }
+
+VECMATH_FINLINE int v_test_vec_x_eq(vec3f v, vec3f a) { return v.f[0] == a.f[0] ? 1 : 0; }
+VECMATH_FINLINE int v_test_vec_x_gt(vec3f v, vec3f a) { return v.f[0] > a.f[0] ? 1 : 0; }
+VECMATH_FINLINE int v_test_vec_x_ge(vec3f v, vec3f a) { return v.f[0] >= a.f[0] ? 1 : 0; }
+VECMATH_FINLINE int v_test_vec_x_lt(vec3f v, vec3f a) { return v.f[0] < a.f[0] ? 1 : 0; }
+VECMATH_FINLINE int v_test_vec_x_le(vec3f v, vec3f a) { return v.f[0] <= a.f[0] ? 1 : 0; }
+
+VECMATH_FINLINE int v_test_vec_x_eq_0(vec3f v) { return v_test_vec_x_eq(v, v_zero()); }
+VECMATH_FINLINE int v_test_vec_x_gt_0(vec3f v) { return v_test_vec_x_gt(v, v_zero()); }
+VECMATH_FINLINE int v_test_vec_x_ge_0(vec3f v) { return v_test_vec_x_ge(v, v_zero()); }
+VECMATH_FINLINE int v_test_vec_x_lt_0(vec3f v) { return v_test_vec_x_lt(v, v_zero()); }
+VECMATH_FINLINE int v_test_vec_x_le_0(vec3f v) { return v_test_vec_x_le(v, v_zero()); }

--- a/modules/dasStbImage/src/aot_builtin_raster.h
+++ b/modules/dasStbImage/src/aot_builtin_raster.h
@@ -11,8 +11,8 @@ namespace das {
 
     __forceinline vec4f v_gather ( const void * _ptr, vec4f index ) {
         // read 4 floats from memory, using 4 uint32_t indices
-        #if defined(__AVX2__)
-            // note: this is not faster than the scalar version
+        #if defined(__AVX2__) && !defined(_TARGET_SIMD_SCALAR)
+            // note: no faster than the per-lane fallback below
             return (_mm_i32gather_ps((const float *) _ptr, v_cast_vec4i(index), 4));
         #else
             auto ptr = (const int32_t *) _ptr;

--- a/skills/internal/writing_cpp_tests.md
+++ b/skills/internal/writing_cpp_tests.md
@@ -44,7 +44,7 @@ Rebuild - `cmake --build build`. The new test appears in `ctest -N` automaticall
 
 ## Adding a big test
 
-A "big" test is anything the single doctest exe can't host: a custom `int main()` (C++ or C), custom link deps, multiple link variants (static + dynamic), or no compiled source at all - `big/style_lint/` is just a `CMakeLists.txt` that registers ctest entries running a daslang script with a `PASS_REGULAR_EXPRESSION`. What makes it "big" is owning its own CMakeLists and carrying `LABELS "big"`. The canonical C++ example is `tests-cpp/big/concurrent_init/` - it has a thread-startup-barrier harness and is built as both `test_concurrent_init` (static) and `test_concurrent_init_dyn` (dynamic).
+A "big" test is anything the single doctest exe can't host: a custom `int main()` (C++ or C), custom link deps, multiple link variants (static + dynamic), or no compiled source at all - `big/style_lint/` is just a `CMakeLists.txt` that registers ctest entries running a daslang script with a `PASS_REGULAR_EXPRESSION`. What makes it "big" is owning its own CMakeLists. The ctest LABEL, not the folder, decides which lane runs it: the default is `LABELS "big"` with `add_dependencies(test-big <exe>)`. A dir that must run on every PR carries `LABELS "small"` with `add_dependencies(test-small <exe>)` instead, so the local small run builds it. Ledgered small-labelled dir: `big/vecmath_backend/` - its scalar arm compiles vecmath with a different `vec4f` than libDaScript was built with, so it cannot link libDaScript and cannot join the small glob exe. The canonical C++ example is `tests-cpp/big/concurrent_init/` - it has a thread-startup-barrier harness and is built as both `test_concurrent_init` (static) and `test_concurrent_init_dyn` (dynamic).
 
 To add one:
 
@@ -66,7 +66,7 @@ Big tests that are C++ executables **don't include doctest** - they keep their o
 
 **A big test's `int main()` owns its module lifetime** - nothing runs `doctest_main.cpp` for it. An exe that resolves modules through the registry calls `Module::Initialize()` / `Module::Shutdown()` itself. An exe whose only context comes from a generated standalone AOT constructor calls neither: that constructor is self-contained and consults no module registry (example: `big/standalone_ctx/`).
 
-A big test is not gated by CI - only the small suite runs there. Run `ninja test-big` locally before pushing one.
+A big-labelled test is not gated by CI - only the small suite runs there. Run `ninja test-big` locally before pushing one.
 
 ## Doctest assertion cheat sheet
 

--- a/tests-cpp/REVIEW.md
+++ b/tests-cpp/REVIEW.md
@@ -4,7 +4,7 @@
 doc: `skills/internal/writing_cpp_tests.md` (repo root).
 
 **A `*_pin.cpp` file, wherever the diff puts it, answers to the `small/` subfolder's
-checklist.**
+checklist as well as this one.**
 
-**A test that builds its own executable from its own `CMakeLists.txt`, wherever the diff
-puts it, answers to the `big/` subfolder's checklist.**
+**A test that owns its own `CMakeLists.txt`, wherever the diff puts it, answers to the
+`big/` subfolder's checklist as well as this one.**

--- a/tests-cpp/big/REVIEW.md
+++ b/tests-cpp/big/REVIEW.md
@@ -3,6 +3,7 @@
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
 doc: `skills/internal/writing_cpp_tests.md` (repo root).
 
-**A diff that touches a test under this folder says in the PR that the test ran and passed
-on the author's machine, naming the command - `ctest -L big` or the test's own binary.** CI
-runs only the small suite, so nothing else proves a big test.
+**A diff that touches a test under this folder whose ctest labels include `big` says in the
+PR that the test ran and passed on the author's machine, naming the command - `ctest -L big`
+or the test's own binary.** CI runs `ctest -L small` only, so nothing else proves a
+big-labelled test.

--- a/tests-cpp/big/vecmath_backend/CMakeLists.txt
+++ b/tests-cpp/big/vecmath_backend/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Lives under big/ because each arm is a standalone exe (the scalar-forced TU's
+# vec4f is a different type than the one libDaScript was compiled with, so
+# neither arm can link libDaScript or join the small glob exe), but labelled
+# "small" so the per-PR CI lane runs both backends.
+
+add_executable(test_vecmath_scalar test_vecmath_backend.cpp)
+target_compile_definitions(test_vecmath_scalar PRIVATE _TARGET_SIMD_SCALAR=1 EXPECT_SCALAR=1)
+target_include_directories(test_vecmath_scalar PRIVATE ${PROJECT_SOURCE_DIR}/include)
+SETUP_CPP11(test_vecmath_scalar)
+set_target_properties(test_vecmath_scalar PROPERTIES FOLDER "tests-cpp/big")
+
+add_test(NAME vecmath_scalar COMMAND test_vecmath_scalar
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_tests_properties(vecmath_scalar PROPERTIES LABELS "small")
+add_dependencies(test-small test_vecmath_scalar)
+
+# The native arm only exists where a native SIMD backend can be selected: under
+# DAS_VECMATH_SCALAR (or on a host with no SIMD ISA) its EXPECT_NATIVE tripwire
+# would fail the build by design.
+if(NOT DAS_VECMATH_SCALAR)
+    add_executable(test_vecmath_native test_vecmath_backend.cpp)
+    target_compile_definitions(test_vecmath_native PRIVATE EXPECT_NATIVE=1)
+    target_include_directories(test_vecmath_native PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    SETUP_CPP11(test_vecmath_native)
+    set_target_properties(test_vecmath_native PROPERTIES FOLDER "tests-cpp/big")
+
+    add_test(NAME vecmath_native COMMAND test_vecmath_native
+             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    set_tests_properties(vecmath_native PROPERTIES LABELS "small")
+    add_dependencies(test-small test_vecmath_native)
+endif()

--- a/tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp
+++ b/tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp
@@ -1,0 +1,276 @@
+// Backend-agnostic vecmath battery, built once per backend (see CMakeLists.txt);
+// standalone on purpose - linking libDaScript (compiled with the native vec4f)
+// into a scalar-forced TU would mix two vec4f ABIs in one binary. Rows guarded
+// with !_TARGET_SIMD_NEON pin SSE-flavored semantics the scalar backend promises
+// to match (NaN/tie ordering, sign-bit select, out-of-range converts, shift
+// counts past the lane width) - NEON diverges there by its own contract.
+
+#ifndef _MSC_VER
+#ifndef __forceinline
+#define __forceinline inline
+#endif
+#endif
+
+#include <vecmath/dag_vecMath.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#if defined(EXPECT_SCALAR) && !defined(_TARGET_SIMD_SCALAR)
+#error this target must select the scalar vecmath backend
+#endif
+#if defined(EXPECT_NATIVE) && defined(_TARGET_SIMD_SCALAR)
+#error this target must select the native SIMD vecmath backend
+#endif
+
+static int g_failed = 0;
+
+static unsigned lane_bits(vec4f v, int k) { unsigned u[4]; memcpy(u, &v, 16); return u[k]; }
+static unsigned lane_bitsi(vec4i v, int k) { unsigned u[4]; memcpy(u, &v, 16); return u[k]; }
+
+static void check_lanes(const char *name, vec4f v, unsigned x, unsigned y, unsigned z, unsigned w)
+{
+  unsigned e[4] = {x, y, z, w};
+  for (int k = 0; k < 4; k++)
+    if (lane_bits(v, k) != e[k]) {
+      printf("FAIL %s lane %d: got %08x want %08x\n", name, k, lane_bits(v, k), e[k]);
+      g_failed++;
+      return;
+    }
+}
+static void check_lanesi(const char *name, vec4i v, unsigned x, unsigned y, unsigned z, unsigned w)
+{
+  unsigned e[4] = {x, y, z, w};
+  for (int k = 0; k < 4; k++)
+    if (lane_bitsi(v, k) != e[k]) {
+      printf("FAIL %s lane %d: got %08x want %08x\n", name, k, lane_bitsi(v, k), e[k]);
+      g_failed++;
+      return;
+    }
+}
+static void check_near(const char *name, vec4f v, float x, float y, float z, float w, float tol)
+{
+  float e[4] = {x, y, z, w}, g[4]; memcpy(g, &v, 16);
+  for (int k = 0; k < 4; k++)
+    if (!(fabsf(g[k] - e[k]) <= tol)) {
+      printf("FAIL %s lane %d: got %g want %g (tol %g)\n", name, k, g[k], e[k], tol);
+      g_failed++;
+      return;
+    }
+}
+static void check_int(const char *name, long long got, long long want)
+{
+  if (got != want) { printf("FAIL %s: got %lld want %lld\n", name, got, want); g_failed++; }
+}
+static unsigned f2u(float f) { unsigned u; memcpy(&u, &f, 4); return u; }
+
+int main()
+{
+  const vec4f a = v_make_vec4f(1.5f, -2.25f, 3.75f, -0.5f);
+  const vec4f b = v_make_vec4f(2.0f, 0.5f, -1.0f, 4.0f);
+  const vec4i ia = v_make_vec4i(3, -7, 123456, -2000000000);
+  const vec4i ib = v_make_vec4i(-5, 11, 7, 3);
+  const float nanf_v = nanf("");
+
+  check_lanes("add", v_add(a, b), f2u(3.5f), f2u(-1.75f), f2u(2.75f), f2u(3.5f));
+  check_lanes("sub", v_sub(a, b), f2u(-0.5f), f2u(-2.75f), f2u(4.75f), f2u(-4.5f));
+  check_lanes("mul", v_mul(a, b), f2u(3.0f), f2u(-1.125f), f2u(-3.75f), f2u(-2.0f));
+  check_lanes("div", v_div(a, b), f2u(0.75f), f2u(-4.5f), f2u(-3.75f), f2u(-0.125f));
+  check_lanes("madd", v_madd(a, b, b), f2u(5.0f), f2u(-0.625f), f2u(-4.75f), f2u(2.0f));
+  check_lanes("nmsub", v_nmsub(a, b, b), f2u(-1.0f), f2u(1.625f), f2u(2.75f), f2u(6.0f));
+  check_lanes("sqrt", v_sqrt(v_make_vec4f(4.0f, 9.0f, 2.25f, 0.0f)), f2u(2.0f), f2u(3.0f), f2u(1.5f), f2u(0.0f));
+  // no -0.0f lane: pc_sse's clang arm (v_max(v_neg(a), a)) keeps -0 where the bit-mask arms clear it
+  check_lanes("abs", v_abs(v_make_vec4f(-1.5f, 1.5f, -37.5f, 0.0f)), f2u(1.5f), f2u(1.5f), f2u(37.5f), 0u);
+  check_lanes("neg", v_neg(v_make_vec4f(-1.5f, 1.5f, 0.0f, -0.0f)), f2u(1.5f), f2u(-1.5f), 0x80000000u, 0u);
+
+  check_int("add_x", (long long)f2u(v_extract_x(v_add_x(a, b))), (long long)f2u(3.5f));
+  check_int("nmsub_x", (long long)f2u(v_extract_x(v_nmsub_x(a, b, b))), (long long)f2u(-1.0f));
+  check_int("sqrt_x", (long long)f2u(v_extract_x(v_sqrt_x(v_make_vec4f(4.0f, 5.0f, 6.0f, 7.0f)))), (long long)f2u(2.0f));
+#if !defined(_TARGET_SIMD_NEON)
+  check_lanes("add_x_keeps_yzw", v_add_x(a, b), f2u(3.5f), f2u(-2.25f), f2u(3.75f), f2u(-0.5f));
+  check_lanes("nmsub_x_keeps_c_yzw", v_nmsub_x(a, b, b), f2u(-1.0f), f2u(0.5f), f2u(-1.0f), f2u(4.0f));
+  check_lanes("sqrt_x_keeps_yzw", v_sqrt_x(v_make_vec4f(4.0f, 5.0f, 6.0f, 7.0f)), f2u(2.0f), f2u(5.0f), f2u(6.0f), f2u(7.0f));
+#endif
+
+  check_lanes("min", v_min(a, b), f2u(1.5f), f2u(-2.25f), f2u(-1.0f), f2u(-0.5f));
+  check_lanes("max", v_max(a, b), f2u(2.0f), f2u(0.5f), f2u(3.75f), f2u(4.0f));
+#if !defined(_TARGET_SIMD_NEON)
+  check_lanes("min_second_operand_on_nan", v_min(v_splats(nanf_v), v_splats(1.0f)), f2u(1.0f), f2u(1.0f), f2u(1.0f), f2u(1.0f));
+  check_lanes("max_second_operand_on_tie", v_max(v_splats(0.0f), v_splats(-0.0f)), 0x80000000u, 0x80000000u, 0x80000000u, 0x80000000u);
+#endif
+
+  const vec4f halves = v_make_vec4f(2.5f, -2.5f, 3.5f, -3.5f);
+  check_lanes("floor", v_floor(halves), f2u(2.0f), f2u(-3.0f), f2u(3.0f), f2u(-4.0f));
+  check_lanes("ceil", v_ceil(halves), f2u(3.0f), f2u(-2.0f), f2u(4.0f), f2u(-3.0f));
+  check_lanes("trunc", v_trunc(halves), f2u(2.0f), f2u(-2.0f), f2u(3.0f), f2u(-3.0f));
+  check_lanes("round_ieee", v_round_ieee(halves), f2u(2.0f), f2u(-2.0f), f2u(4.0f), f2u(-4.0f));
+
+  check_lanesi("cvtt", v_cvti_vec4i(a), 1u, 0xFFFFFFFEu, 3u, 0u);
+  check_lanesi("cvtr", v_cvt_roundi_ieee(halves), 2u, 0xFFFFFFFEu, 4u, 0xFFFFFFFCu);
+#if !defined(_TARGET_SIMD_NEON)
+  check_lanesi("cvtt_ovf", v_cvti_vec4i(v_make_vec4f(3e9f, -3e9f, nanf_v, 100.75f)),
+               0x80000000u, 0x80000000u, 0x80000000u, 100u);
+  check_lanesi("cvtr_ovf", v_cvt_roundi_ieee(v_make_vec4f(3e9f, -3e9f, nanf_v, 100.5f)),
+               0x80000000u, 0x80000000u, 0x80000000u, 100u);
+#endif
+  check_lanesi("cvt_floori", v_cvt_floori(halves), 2u, 0xFFFFFFFDu, 3u, 0xFFFFFFFCu);
+  check_lanes("cvti2f", v_cvti_vec4f(ia), f2u(3.0f), f2u(-7.0f), f2u(123456.0f), f2u(-2000000000.0f));
+  check_lanes("cvtu2f", v_cvtu_vec4f_ieee(v_make_vec4i(-1, 5, 0, 65536)),
+              f2u(4294967296.0f), f2u(5.0f), 0u, f2u(65536.0f));
+
+  check_lanes("cmp_gt", v_cmp_gt(a, b), 0u, 0u, 0xFFFFFFFFu, 0u);
+  check_lanes("cmp_eq", v_cmp_eq(a, v_make_vec4f(1.5f, 0.f, 3.75f, 0.f)), 0xFFFFFFFFu, 0u, 0xFFFFFFFFu, 0u);
+  check_lanes("cmp_eqi_f", v_cmp_eqi(v_splats(nanf_v), v_splats(nanf_v)),
+              0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu);
+  check_lanes("cmp_ge_nan_false", v_cmp_ge(v_splats(nanf_v), v_splats(nanf_v)), 0u, 0u, 0u, 0u);
+  check_lanes("cmp_neq_nan_true", v_cmp_neq(v_splats(nanf_v), v_splats(nanf_v)),
+              0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu);
+  check_lanesi("cmp_lti", v_cmp_lti(ia, ib), 0u, 0xFFFFFFFFu, 0u, 0xFFFFFFFFu);
+  check_lanesi("cmp_gti", v_cmp_gti(ia, ib), 0xFFFFFFFFu, 0u, 0xFFFFFFFFu, 0u);
+  check_lanesi("cmp_eqi", v_cmp_eqi(ia, v_make_vec4i(3, 0, 123456, 0)), 0xFFFFFFFFu, 0u, 0xFFFFFFFFu, 0u);
+
+  check_lanes("sel_mask", v_sel(a, b, v_cmp_gt(a, b)), f2u(1.5f), f2u(-2.25f), f2u(-1.0f), f2u(-0.5f));
+#if !defined(_TARGET_SIMD_NEON)
+  const vec4f signs = v_make_vec4f(-1.0f, 1.0f, -0.0f, 0.0f);
+  check_lanes("sel_reads_sign_bit_only", v_sel(a, b, signs), f2u(2.0f), f2u(-2.25f), f2u(-1.0f), f2u(-0.5f));
+#endif
+  check_int("signmask", v_signmask(v_make_vec4f(-1.0f, 1.0f, -0.0f, 0.0f)), 0b0101);
+  check_int("check_xyz", v_check_xyz_all_true(v_cast_vec4f(v_make_vec4i(-1, -1, -1, 0))) ? 1 : 0, 1);
+  check_int("check_xyz_false_dir", v_check_xyz_all_true(v_cast_vec4f(v_make_vec4i(-1, 0, -1, -1))) ? 1 : 0, 0);
+  check_int("check_xyz_all_false", v_check_xyz_all_false(v_cast_vec4f(v_make_vec4i(0, 0, 0, -1))) ? 1 : 0, 1);
+  check_int("check_xyz_any_true", v_check_xyz_any_true(v_cast_vec4f(v_make_vec4i(0, -1, 0, 0))) ? 1 : 0, 1);
+  check_int("check_xyzw_all_true", v_check_xyzw_all_true(v_cast_vec4f(v_make_vec4i(-1, -1, -1, 0))) ? 1 : 0, 0);
+  check_int("check_xyzw_all_false", v_check_xyzw_all_false(v_zero()) ? 1 : 0, 1);
+  check_int("check_xyzw_any_true", v_check_xyzw_any_true(v_cast_vec4f(v_make_vec4i(0, 0, 0, -1))) ? 1 : 0, 1);
+#if !defined(_TARGET_SIMD_NEON)
+  check_int("check_xyz_reads_sign_bits", v_check_xyz_all_true(v_make_vec4f(-1.f, -1.f, -1.f, 0.f)) ? 1 : 0, 1);
+#endif
+  check_int("all_bits_zeros", v_test_all_bits_zeros(v_zero()) ? 1 : 0, 1);
+  check_int("all_bits_zeros_false_dir", v_test_all_bits_zeros(v_cast_vec4f(v_make_vec4i(0, 0, 1, 0))) ? 1 : 0, 0);
+  check_int("all_bits_ones", v_test_all_bits_ones(v_set_all_bits()) ? 1 : 0, 1);
+  check_int("all_bits_ones_false_dir", v_test_all_bits_ones(v_cast_vec4f(v_make_vec4i(-1, -1, -2, -1))) ? 1 : 0, 0);
+  check_int("any_bit_set", v_test_any_bit_set(v_cast_vec4f(v_make_vec4i(0, 0, 0, 1))) ? 1 : 0, 1);
+  check_int("any_bit_set_false_dir", v_test_any_bit_set(v_zero()) ? 1 : 0, 0);
+  check_int("test_vec_x_eq", v_test_vec_x_eq(a, v_make_vec4f(1.5f, 9.f, 9.f, 9.f)), 1);
+  check_int("test_vec_x_lt", v_test_vec_x_lt(a, b), 1);
+  check_int("test_vec_x_le_0", v_test_vec_x_le_0(v_make_vec4f(-0.5f, 1.f, 1.f, 1.f)), 1);
+  check_int("test_vec_x_ge_0_false_dir", v_test_vec_x_ge_0(v_make_vec4f(-0.5f, 1.f, 1.f, 1.f)), 0);
+  check_int("test_vec_x_eqi_0", v_test_vec_x_eqi_0(v_zero()), 1);
+
+  check_lanes("and", v_and(v_splats(3.0f), v_splats(2.0f)), f2u(2.0f), f2u(2.0f), f2u(2.0f), f2u(2.0f));
+  check_lanes("xor_self", v_xor(a, a), 0u, 0u, 0u, 0u);
+  check_lanes("not_zero", v_not(v_zero()), 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu);
+  check_lanes("btsel", v_btsel(a, b, v_cast_vec4f(v_make_vec4i(0, -1, 0, -1))),
+              f2u(1.5f), f2u(0.5f), f2u(3.75f), f2u(4.0f));
+
+  check_lanesi("addi", v_addi(ia, ib), 0xFFFFFFFEu, 4u, 0x1E247u, 0x88CA6C03u);
+  check_lanesi("muli", v_muli(v_make_vec4i(100000, -3, 7, 1 << 30), v_make_vec4i(100000, 5, -7, 4)),
+               0x540BE400u, 0xFFFFFFF1u, 0xFFFFFFCFu, 0u);
+  check_lanesi("mini", v_mini(ia, ib), 0xFFFFFFFBu, 0xFFFFFFF9u, 7u, 0x88CA6C00u);
+  check_lanesi("minu", v_minu(ia, ib), 3u, 11u, 7u, 3u);
+  check_lanesi("maxi", v_maxi(ia, ib), 3u, 11u, 0x1E240u, 3u);
+  check_lanesi("maxu", v_maxu(ia, ib), 0xFFFFFFFBu, 0xFFFFFFF9u, 0x1E240u, 0x88CA6C00u);
+#if !defined(_TARGET_SIMD_NEON)
+  check_lanesi("seli_sign_bit", v_seli(ia, ib, v_make_vec4i(-1, 0, INT32_MIN, 1)),
+               0xFFFFFFFBu, 0xFFFFFFF9u, 7u, 0x88CA6C00u);
+#endif
+  check_lanesi("absi", v_absi(v_make_vec4i(-3, 3, INT32_MIN, 0)), 3u, 3u, 0x80000000u, 0u);
+  check_lanesi("slli", v_slli(ia, 3), 24u, 0xFFFFFFC8u, 0xF1200u, 0x46536000u);
+  check_lanesi("srli", v_srli(ia, 3), 0u, 0x1FFFFFFFu, 0x3C48u, 0x11194D80u);
+  check_lanesi("srai", v_srai(ia, 3), 0u, 0xFFFFFFFFu, 0x3C48u, 0xF1194D80u);
+#if !defined(_TARGET_SIMD_NEON)
+  check_lanesi("slli_ge32_zeroes", v_slli(ia, 32), 0u, 0u, 0u, 0u);
+  check_lanesi("srli_ge32_zeroes", v_srli(ia, 32), 0u, 0u, 0u, 0u);
+  check_lanesi("srai_gt31_sign_fills", v_srai(ia, 40), 0u, 0xFFFFFFFFu, 0u, 0xFFFFFFFFu);
+#endif
+  check_lanesi("packs", v_packs(v_make_vec4i(70000, -70000, 5, -5)),
+               0x80007FFFu, 0xFFFB0005u, 0x80007FFFu, 0xFFFB0005u);
+  check_lanesi("packus", v_packus(v_make_vec4i(70000, -70000, 5, 65535)),
+               0x0000FFFFu, 0xFFFF0005u, 0x0000FFFFu, 0xFFFF0005u);
+  check_lanesi("packus16", v_packus16(v_packs(v_make_vec4i(300, -5, 100, 255))),
+               0xFF6400FFu, 0xFF6400FFu, 0xFF6400FFu, 0xFF6400FFu);
+  check_lanesi("madd_i16_wraps", v_madd_i16(v_splatsi16(-32768), v_splatsi16(-32768)),
+               0x80000000u, 0x80000000u, 0x80000000u, 0x80000000u);
+
+  check_lanes("splat_y", v_splat_y(a), f2u(-2.25f), f2u(-2.25f), f2u(-2.25f), f2u(-2.25f));
+  check_lanes("splat_z", v_splat_z(a), f2u(3.75f), f2u(3.75f), f2u(3.75f), f2u(3.75f));
+  check_lanes("splat_w", v_splat_w(a), f2u(-0.5f), f2u(-0.5f), f2u(-0.5f), f2u(-0.5f));
+  check_lanes("rot_1", v_rot_1(a), f2u(-2.25f), f2u(3.75f), f2u(-0.5f), f2u(1.5f));
+  check_lanes("rot_2", v_rot_2(a), f2u(3.75f), f2u(-0.5f), f2u(1.5f), f2u(-2.25f));
+  check_lanes("rot_3", v_rot_3(a), f2u(-0.5f), f2u(1.5f), f2u(-2.25f), f2u(3.75f));
+  check_lanes("perm_yzxw", v_perm_yzxw(a), f2u(-2.25f), f2u(3.75f), f2u(1.5f), f2u(-0.5f));
+  check_lanes("perm_xzac", v_perm_xzac(a, b), f2u(1.5f), f2u(3.75f), f2u(2.0f), f2u(-1.0f));
+  check_lanes("perm_ayzw", v_perm_ayzw(a, b), f2u(2.0f), f2u(-2.25f), f2u(3.75f), f2u(-0.5f));
+  check_lanes("merge_hw", v_merge_hw(a, b), f2u(1.5f), f2u(2.0f), f2u(-2.25f), f2u(0.5f));
+  check_lanesi("interleave_lo32", v_interleave_lo_i32(ia, ib), 3u, 0xFFFFFFFBu, 0xFFFFFFF9u, 11u);
+  check_int("extract_z", (long long)f2u(v_extract_z(a)), (long long)f2u(3.75f));
+  check_int("extract_wi", v_extract_wi(ia), -2000000000);
+  check_int("extract_xi64", v_extract_xi64(v_splatsi64(0x123456789abcdef0ll)), 0x123456789abcdef0ll);
+
+  {
+    const float p3[3] = {9.f, 8.f, 7.f};
+    check_lanes("ldu_p3_safe", v_ldu_p3_safe(p3), f2u(9.f), f2u(8.f), f2u(7.f), 0u);
+    float out[4] = {0, 0, 0, -1.f};
+    v_stu_p3(out, a);
+    check_int("stu_p3_w_untouched", (long long)f2u(out[3]), (long long)f2u(-1.f));
+    check_int("stu_p3_z", (long long)f2u(out[2]), (long long)f2u(3.75f));
+    const short sh[4] = {-1, 2, -3, 4};
+    check_lanesi("ldush", v_ldush(sh), 0xFFFFFFFFu, 2u, 0xFFFFFFFDu, 4u);
+    check_lanesi("lduush", v_lduush((const unsigned short *)sh), 0xFFFFu, 2u, 0xFFFDu, 4u);
+  }
+
+  check_near("dot3", v_dot3(a, b), 1.875f - 3.75f, 1.875f - 3.75f, 1.875f - 3.75f, 1.875f - 3.75f, 1e-6f);
+  {
+    float dx = v_extract_x(v_dot4_x(a, b)); // only .x is contract for _x ops; yzw differ per SSE tier
+    if (!(fabsf(dx - -3.875f) <= 1e-5f)) { printf("FAIL dot4_x: %g\n", dx); g_failed++; }
+  }
+  {
+    float hx = v_extract_x(v_hadd4_x(a));
+    if (!(fabsf(hx - 2.5f) <= 1e-6f)) { printf("FAIL hadd4_x: %g\n", hx); g_failed++; }
+  }
+
+  //tolerance covers the SIMD backends' rcpps/rsqrtps estimates; the scalar backend computes these exactly
+  check_near("rcp_est", v_rcp_est(b), 0.5f, 2.0f, -1.0f, 0.25f, 2e-3f);
+  check_near("rsqrt_est", v_rsqrt_est(v_make_vec4f(4.f, 16.f, 1.f, 64.f)), 0.5f, 0.25f, 1.f, 0.125f, 2e-3f);
+  check_near("norm3", v_norm3(v_make_vec4f(3.f, 0.f, 4.f, 0.f)), 0.6f, 0.f, 0.8f, 0.f, 1e-5f);
+
+  {
+    mat44f m;
+    m.col0 = v_make_vec4f(2, 0, 0, 0);
+    m.col1 = v_make_vec4f(0, 3, 0, 0);
+    m.col2 = v_make_vec4f(1, 0, 4, 0);
+    m.col3 = v_make_vec4f(5, 6, 7, 1);
+    float det_x = v_extract_x(v_mat44_det(m));
+    if (!(fabsf(det_x - 24.f) <= 1e-4f)) { printf("FAIL det: %g\n", det_x); g_failed++; }
+    mat44f inv, id;
+    v_mat44_inverse(inv, m);
+    v_mat44_mul(id, m, inv);
+    check_near("inv_id0", id.col0, 1.f, 0.f, 0.f, 0.f, 1e-5f);
+    check_near("inv_id1", id.col1, 0.f, 1.f, 0.f, 0.f, 1e-5f);
+    check_near("inv_id2", id.col2, 0.f, 0.f, 1.f, 0.f, 1e-5f);
+    check_near("inv_id3", id.col3, 0.f, 0.f, 0.f, 1.f, 1e-5f);
+    mat44f t;
+    v_mat44_transpose(t, m);
+    check_lanes("transpose0", t.col0, f2u(2.f), 0u, f2u(1.f), f2u(5.f));
+    check_lanes("transpose1", t.col1, 0u, f2u(3.f), 0u, f2u(6.f));
+    check_lanes("transpose2", t.col2, 0u, 0u, f2u(4.f), f2u(7.f));
+    check_lanes("transpose3", t.col3, 0u, 0u, 0u, f2u(1.f));
+    check_lanes("mul_vec3p", v_mat44_mul_vec3p(m, v_make_vec4f(1, 2, 3, 0)),
+                f2u(10.f), f2u(12.f), f2u(19.f), f2u(1.f));
+  }
+
+  check_near("sin", v_sin(v_make_vec4f(0.f, 1.5707963f, 3.1415926f, -1.5707963f)), 0.f, 1.f, 0.f, -1.f, 1e-5f);
+  check_near("cos", v_cos(v_make_vec4f(0.f, 1.5707963f, 3.1415926f, -1.5707963f)), 1.f, 0.f, -1.f, 0.f, 1e-5f);
+
+  check_lanes("h2f", v_half_to_float(v_make_vec4i(0x3C00, 0x4000, 0xC000, 0x3555)),
+              f2u(1.0f), f2u(2.0f), f2u(-2.0f), f2u(0.33325195f));
+  check_lanesi("f2h", v_float_to_half_rtne(v_make_vec4f(1.0f, -2.0f, 0.5f, 65504.f)),
+               0x3C00u, 0xC000u, 0x3800u, 0x7BFFu);
+
+  check_lanes("is_nan", v_is_nan(v_make_vec4f(1.f, nanf_v, 3.f, nanf_v)),
+              0u, 0xFFFFFFFFu, 0u, 0xFFFFFFFFu);
+
+  if (g_failed) { printf("%d vecmath backend checks FAILED\n", g_failed); return 1; }
+  printf("all vecmath backend checks passed\n");
+  return 0;
+}


### PR DESCRIPTION
vecmath gains a third backend: `dag_vecMath_scalar.h`, a per-lane implementation of the full primitive contract (270 public `v_*` functions). It is selected automatically on targets with no SIMD ISA - Cortex-M, RISC-V without V - where the header today stops at `!error! unsupported target`, and can be forced on x64 with `-DDAS_VECMATH_SCALAR=ON`. Nothing changes for SSE and NEON builds; the selection edits are inert there. This is the first carve of the daslang-nano arc: the nano runtime reuses vecmath as-is instead of faking `vec4f`, so no vector type or operation is lost on embedded targets.

Semantics follow the SSE backend at the contract level: same all-bits compare masks, sign-bit-only `v_sel`, minps second-operand NaN/tie rule, `cvttps` INT_MIN out-of-range, `pmaddwd` wrap. The generic layers (`_common`, `_trig`) already had non-SSE arms and compile unchanged. A new two-arm test (`tests-cpp/big/vecmath_backend/`, ctest label `small`) builds one battery per backend and asserts the same values on both; each arm carries a compile-time tripwire that fails the build if the wrong backend got selected. The battery also runs on the SSE2 tier, which exposed a pre-existing gap fixed here: `v_round_ieee` was only defined in the SSE4 arm.

The new test is the first `big/`-folder dir labelled `small` (its arms must run per-PR, and the scalar arm cannot link libDaScript, so it cannot join the small glob exe). The audit found that case unledgered and the `big/` checklist's run-claim rule keyed on the folder instead of the label; `tests-cpp/big/REVIEW.md`, `tests-cpp/REVIEW.md` and `skills/internal/writing_cpp_tests.md` are updated in the same change.

Where to look: `include/vecmath/dag_vecMath_scalar.h` (the backend), `dag_vecMathDecl.h` (selection + the scalar `vec4f`), `include/daScript/daScriptC.h` (its own copy of the type selection, shared struct definition), `tests-cpp/big/vecmath_backend/`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full das test suite on a scalar-forced x64 build (separate worktree, `-DDAS_VECMATH_SCALAR=ON`): 12899 tests, 12890 passed, 0 failed, 9 skipped - run three times across the branch, last at the final tip.
- Full AOT sweep on the untouched SSE side: 12991 tests, 12984 passed, 0 failed, 7 skipped.
- Both battery arms ran and passed locally: `ctest -R "vecmath_(scalar|native)"` under MSVC (`test_vecmath_scalar.exe` and `test_vecmath_native.exe`, each printing `all vecmath backend checks passed`), plus GCC builds at SSE2, SSE4.1, scalar, and scalar+`-mavx` tiers (the last settles the `__SSE4_1__` dispatch guard fix in `_common`), plus a negative control - `EXPECT_SCALAR` without the backend define fails to compile.
- The battery caught two real bugs during development: `v_min`/`v_max` had the minps operand order reversed (NaN/tie lanes), and `v_madd_i16` relied on signed-overflow UB where `pmaddwd` wraps (both fixed, both now pinned by named cases).
- `cpp-syntax` preflight gate skipped: no local clang; CI runs it.

### Claims - stated, not tested
- The auto-select arm on a real no-SIMD toolchain (arm-none-eabi) compiles but has no gate yet; the nano arc's next PR adds an arm-none-eabi CI cross-compile step that becomes the standing tripwire.
- Estimate ops (`v_rcp_est`, `v_rsqrt_est`) are exact on scalar where SSE uses vendor lookup tables; this sits inside the existing AMD-vs-Intel-vs-Rosetta variance envelope, asserted with tolerance only.
- Of the 270 primitives, 95 are value-pinned by the battery, ~62 more are exercised by the das suite through `sim_policy`; the remaining ~131 (mostly `v_perm_*`/`v_interleave_*` data movement nothing calls yet) are compile-verified only.

### Not done
- No CI lane sets `DAS_VECMATH_SCALAR`; the scalar-forced suite run is local-only until a lane is agreed (candidate: nightly x64). The per-PR battery rows are the standing per-commit gate.
- The five `v_fc16_*` hardware half-float wrappers are not implemented; halves route through vecmath's existing software emulation (values pinned by the battery).
- Upstream DagorEngine has no scalar backend either; upstreaming this file is possible but not filed.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
