### PR TITLE
dasAudio: bound every teardown wait, and drop the last snapshot LockBox

### DIFF
--- a/include/daScript/misc/job_que.h
+++ b/include/daScript/misc/job_que.h
@@ -42,6 +42,7 @@ namespace das {
         bool NotifyAndRelease( LineInfo * at = nullptr );
         bool isReady();
         void Wait();
+        bool WaitFor(int timeoutMs);   // false = timed out; timeoutMs <= 0 polls
         void Clear(uint32_t count = 1);
         int addRef( LineInfo * at = nullptr );
         int releaseRef( LineInfo * at = nullptr );

--- a/include/daScript/simulate/aot_builtin_jobque.h
+++ b/include/daScript/simulate/aot_builtin_jobque.h
@@ -319,6 +319,7 @@ namespace das {
     DAS_API JobStatus * jobStatusCreate( Context * context, LineInfoArg * );
     DAS_API void jobStatusRemove( JobStatus * & ch, Context * context, LineInfoArg * at );
     DAS_API void waitForJob ( JobStatus * status, Context * context, LineInfoArg * at );
+    DAS_API bool waitForJobWithTimeout ( JobStatus * status, int32_t timeoutMs, Context * context, LineInfoArg * at );
     DAS_API void notifyJob ( JobStatus * status, Context * context, LineInfoArg * at );
     DAS_API void notifyAndReleaseJob ( JobStatus * & status, Context * context, LineInfoArg * at );
     DAS_API vec4f channelPush ( Context & context, SimNode_CallBase * call, vec4f * args );

--- a/modules/dasAudio/ARCHITECTURE.md
+++ b/modules/dasAudio/ARCHITECTURE.md
@@ -1,0 +1,39 @@
+# dasAudio Architecture
+
+**Who reads this: me.** Durable facts about why the audio system is shaped the way it is -
+readable cold, no history, no PR numbers.
+
+## The audio callback must never wait on a game thread
+
+`data_callback` (`src/dasAudio.cpp`) runs on miniaudio's realtime thread and has a buffer
+deadline. Any primitive it touches must be wait-free on the writer side, because a game thread
+that owns a lock and then gets descheduled turns into an audio dropout.
+
+That splits the sharing primitives by role:
+
+| role | primitive | why |
+|---|---|---|
+| status snapshots (per sound, system stats, playback time) | `SeqBox` | POD published every mix, read on demand; a reader can never make the mixer wait, and there is nothing to own |
+| PCM buffer handoff (`append_box_to_pcm`) | `LockBox` | passes an `array<float>` by pointer and needs a *consumed* state, so the producer knows when the buffer is reusable - neither is something a snapshot box offers |
+| thread-exit handshakes (`done_status`) | `JobStatus` | a genuine blocking wait is the point |
+
+A snapshot must not be given a `LockBox`: every `LockBox` operation holds its mutex for the whole
+duration of the das block it invokes, so a polling reader and the mixer contend directly.
+
+## A teardown wait that expires leaks on purpose
+
+Every wait in teardown is bounded (`PCM_GRAB_TIMEOUT_MS`, `WORKER_EXIT_TIMEOUT_MS` and their midi
+twins). On expiry the handle is **leaked, not freed**: a queued grab may still reach the box and a
+wedged worker still references its stream and status, so freeing after a timeout trades a hang for
+a use-after-free. A leak is recoverable, the jobque leak dump names it, and the log line says which
+wait gave up. Do not "fix" a timeout path by freeing there.
+
+`SeqBox` is the exception and is released on both paths: its holders drop references in any order
+and the last one deletes, so it needs no agreement with the audio thread.
+
+## The waits cascade
+
+`strudel_init` spawns the worker; the worker runs the caller's function, which calls
+`strudel_play`; `strudel_play` ends in the PCM wait; `done_status` is notified only after all of
+that returns. So an ungrabbed buffer wedges the worker, and a wedged worker wedges
+`strudel_shutdown` on the main thread. This is why the worker-exit budget must exceed the PCM one.

--- a/modules/dasAudio/strudel/strudel_midi_player.das
+++ b/modules/dasAudio/strudel/strudel_midi_player.das
@@ -819,6 +819,9 @@ var private g_midi_files : table<string; MidiFile>  // owns parsed data
 var private g_midi_bank : SampleBank                // module-global sample bank
 var private g_midi_sf2 : SF2File?                   // module-global SF2 soundfont
 var private g_midi_running : bool = false
+
+let private MIDI_PCM_GRAB_TIMEOUT_MS = 2000
+let private MIDI_WORKER_EXIT_TIMEOUT_MS = 5000
 var private g_midi_audio_vis_ptr : void?  // audio vis channel as void* (avoids capture lifecycle)
 
 // ─── Audio Thread Main Loop ───
@@ -1000,8 +1003,11 @@ def private midi_thread_main(sid : uint64; var cmd_stream : Stream?; var done_st
         let MAX_UTIL = int(max_chunk_usec / chunk_budget_usec * 1000.lf)
         to_log(0, "midi {UTILIZATION/10}.{UTILIZATION%10}% avg, {MAX_UTIL/10}.{MAX_UTIL%10}% peak utilization\n")
     }
-    pcm_box |> join()
-    unsafe(lock_box_remove(pcm_box))
+    if (pcm_box |> join(MIDI_PCM_GRAB_TIMEOUT_MS)) {
+        unsafe(lock_box_remove(pcm_box))
+    } else {
+        to_log(LOG_ERROR, "midi: audio thread did not take the final PCM chunk within {MIDI_PCM_GRAB_TIMEOUT_MS}ms; leaking the pcm box\n")
+    }
     unset_status_update(sid)
     status_box |> seq_box_release
     unsafe {
@@ -1151,10 +1157,12 @@ def public midi_shutdown() {
     //! Stop the playback thread and release its stream/status; blocks until the audio thread confirms shutdown.
     if (!g_midi_running || g_midi_cmd_stream == null) return
     g_midi_cmd_stream |> push_archive(MidiCommand(shutdown = true))
-    g_midi_done_status |> join                        // blocks until worker notify_and_release
-    // refcount was 2 after init; worker's release made it 1; stream_remove decrements to 0 and deletes
-    unsafe(stream_remove(g_midi_cmd_stream))
-    unsafe(job_status_remove(g_midi_done_status))
+    if (g_midi_done_status |> join(MIDI_WORKER_EXIT_TIMEOUT_MS)) {
+        unsafe(stream_remove(g_midi_cmd_stream))
+        unsafe(job_status_remove(g_midi_done_status))
+    } else {
+        to_log(LOG_ERROR, "midi: worker thread did not exit within {MIDI_WORKER_EXIT_TIMEOUT_MS}ms; leaking its stream and done status\n")
+    }
     g_midi_running = false
     // release SF2 soundfont (finalizer recursively frees instruments/presets/zones)
     if (g_midi_sf2 != null) {

--- a/modules/dasAudio/strudel/strudel_player.das
+++ b/modules/dasAudio/strudel/strudel_player.das
@@ -63,12 +63,15 @@ var private g_done_status : JobStatus?
 var private g_sf2 : SF2File?
 var private g_sf2_path : string
 var private g_cmd_fn : function<(cmd : string) : void>
-var private g_playback_box : LockBox?
+var private g_playback_box : SeqBox?
 var private g_tracks : array<StrudelTrack?>
 var private g_look_ahead : float = 0.1
 var private g_chunk_seconds : float = 0.05
 var private g_tick_status_box : SeqBox?   // buffer level feedback for strudel_tick
 var private g_tick_pcm_box : LockBox?    // lock box for append_box_to_pcm in main-thread mode
+
+let private PCM_GRAB_TIMEOUT_MS = 2000
+let private WORKER_EXIT_TIMEOUT_MS = 5000
 
 //! Per-track PCM output written by strudel_tick (main-thread mode only), indexed by track index.
 //! Visualizer combinators read this to render per-track waveforms.
@@ -108,13 +111,12 @@ struct private PlaybackTime {
 
 def public strudel_get_playback_time() : tuple<double; double> {
     //! Get current playback wall-clock time and tempo as (wall_time, cps).
-    //! In threaded mode reads from a lockbox; in main-thread mode uses the hardware
-    //! consumed position (smooth, matches what you hear) and lags g_wall_time by the audio buffer depth.
+    //! In threaded mode reads the strudel thread's latest snapshot; in main-thread mode uses the
+    //! hardware consumed position (smooth, matches what you hear) and lags g_wall_time by the audio buffer depth.
     var wt = 0.0lf
     var cp = 0.5lf
     if (g_playback_box != null) {
-        // threaded mode — read from lockbox
-        g_playback_box |> get() $(pt : PlaybackTime#) {
+        g_playback_box |> read() $(pt : PlaybackTime) {
             wt = pt.wall_time
             cp = pt.cps
         }
@@ -768,12 +770,8 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
         let chunkFrames = chunkSamples / 2
         g_wall_samples += int64(chunkFrames)
         g_wall_time = double(g_wall_samples) / double(SAMPLE_RATE)
-        // update playback time for main thread
         if (g_playback_box != null) {
-            g_playback_box |> update() $(var pt : PlaybackTime#) {
-                pt.wall_time = g_wall_time
-                pt.cps = g_cps
-            }
+            g_playback_box |> publish(PlaybackTime(wall_time = g_wall_time, cps = g_cps))
         }
         // buffer level feedback
         var que_len = 0
@@ -795,8 +793,11 @@ def public strudel_play(cmd_fn : function<(cmd : string) : void> = @@strudel_noo
             to_log(0, "strudel mem: heap {mem_heap_cur/1024ul}kb / str {mem_str_cur/1024ul}kb (max heap {mem_heap_max/1024ul}kb / str {mem_str_max/1024ul}kb)\n")
         }
     }
-    pcm_box |> join()
-    unsafe(lock_box_remove(pcm_box))
+    if (pcm_box |> join(PCM_GRAB_TIMEOUT_MS)) {
+        unsafe(lock_box_remove(pcm_box))
+    } else {
+        to_log(LOG_ERROR, "strudel: audio thread did not take the final PCM chunk within {PCM_GRAB_TIMEOUT_MS}ms; leaking the pcm box\n")
+    }
     ma_volume_mixer_uninit(unsafe(addr(mixer)))
     unset_status_update(g_sid)
     status_box |> seq_box_release
@@ -838,9 +839,8 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
         panic("strudel_init: audio system not initialized. Call audio_system_create() first.")
     }
     g_cmd_fn = cmd_fn
-    // create playback time lockbox
     if (g_playback_box == null) {
-        g_playback_box = lock_box_create()
+        g_playback_box = seq_box_create()
     }
     // create command stream and done status (thread-exit signal, wait group of 1).
     // @capture auto-bumps refcount for Stream and JobStatus — no manual add_ref needed.
@@ -882,32 +882,39 @@ def public strudel_init(fn : function<() : void>; cmd_fn : function<(cmd : strin
             set_audio_thread_command_stream(null)
         }
         cmd_st |> release()
-        pb_box |> release()
+        pb_box |> seq_box_release
         done_st |> notify_and_release
+    }
+}
+
+def private shutdown_worker_thread() {
+    return if (g_cmd_stream == null)
+    g_cmd_stream |> push_archive(StrudelCommand(shutdown = true))
+    if (g_done_status |> join(WORKER_EXIT_TIMEOUT_MS)) {
+        unsafe(stream_remove(g_cmd_stream))
+        unsafe(job_status_remove(g_done_status))
+        g_cmd_stream = null
+        g_done_status = null
+    } else {
+        to_log(LOG_ERROR, "strudel: worker thread did not exit within {WORKER_EXIT_TIMEOUT_MS}ms; leaking its stream and done status\n")
+    }
+    if (g_playback_box != null) {
+        g_playback_box |> seq_box_release
     }
 }
 
 def public strudel_shutdown() {
     //! Shut down playback: signal the strudel thread to stop, release stream/status/lockboxes, free all tracks.
     //! Safe to call from the main thread; also finalizes memory/utilization stats.
-    if (g_cmd_stream != null) {
-        g_cmd_stream |> push_archive(StrudelCommand(shutdown = true))
-        // wait for worker thread to exit (notify_and_release on done_status)
-        g_done_status |> join
-        // refcount was 2 after init; worker's release made it 1; *_remove decrements to 0 and deletes
-        unsafe(stream_remove(g_cmd_stream))
-        unsafe(job_status_remove(g_done_status))
-        g_cmd_stream = null
-        g_done_status = null
-        // player box
-        unsafe(lock_box_remove(g_playback_box))
-        g_playback_box = null
-    }
+    shutdown_worker_thread()
     // pcm box (main-thread mode)
     if (g_tick_pcm_box != null) {
-        g_tick_pcm_box |> join()
-        unsafe(lock_box_remove(g_tick_pcm_box))
-        g_tick_pcm_box = null
+        if (g_tick_pcm_box |> join(PCM_GRAB_TIMEOUT_MS)) {
+            unsafe(lock_box_remove(g_tick_pcm_box))
+            g_tick_pcm_box = null
+        } else {
+            to_log(LOG_ERROR, "strudel: audio thread did not take the final tick PCM chunk within {PCM_GRAB_TIMEOUT_MS}ms; leaking the pcm box\n")
+        }
     }
     // status box (main-thread mode: created in strudel_create_channel). No ordering with the
     // audio thread: whichever side drops the last reference deletes the box.

--- a/src/builtin/module_builtin_jobque.cpp
+++ b/src/builtin/module_builtin_jobque.cpp
@@ -1333,6 +1333,12 @@ namespace das {
         status->Wait();
     }
 
+    bool waitForJobWithTimeout ( JobStatus * status, int32_t timeoutMs, Context * context, LineInfoArg * at ) {
+        if ( !status ) context->throw_error_at(at, "waitForJobWithTimeout: status is null");
+        flushPendingForkJobs();     // batched dispatch publishes at the join point
+        return status->WaitFor(timeoutMs);
+    }
+
     void notifyJob ( JobStatus * status, Context * context, LineInfoArg * at ) {
         if ( !status ) context->throw_error_at(at, "notifyJob: status is null");
         if ( !status->Notify() ) context->throw_error_at(at, "notifyJob: nothing to notify");
@@ -1585,6 +1591,9 @@ namespace das {
             addExtern<DAS_BIND_FUN(waitForJob)>(*this, lib,  "join",
                 SideEffects::modifyExternal, "waitForJob")
                     ->args({"job","context","line"});
+            addExtern<DAS_BIND_FUN(waitForJobWithTimeout)>(*this, lib,  "join",
+                SideEffects::modifyExternal, "waitForJobWithTimeout")
+                    ->args({"job","timeout_ms","context","line"});
             addExtern<DAS_BIND_FUN(notifyJob)>(*this, lib,  "notify",
                 SideEffects::modifyExternal, "notifyJob")
                     ->args({"job","context","line"});

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -1071,6 +1071,33 @@ namespace das {
 #endif
     }
 
+    bool JobStatus::WaitFor(int timeoutMs) {
+#if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
+        (void)timeoutMs;
+        return isReady();
+#else
+        if ( timeoutMs <= 0 ) return isReady();
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+        int level = sJoinSpin.load(std::memory_order_relaxed);
+        if ( level > 0 ) {
+            for ( int b = 0; b != level && mRemaining.load(std::memory_order_relaxed) != 0; ++b ) {
+                for ( uint64_t i = 0; mRemaining.load(std::memory_order_relaxed) != 0 && i < 1024ull * 128ull; ++i ) {
+                    jobque_spin_relax();
+                }
+                if ( std::chrono::steady_clock::now() >= deadline ) break;
+            }
+            if ( mRemaining.load() == 0 ) {
+                lock_guard<mutex> guard(mCompleteMutex);
+                return true;
+            }
+        }
+        unique_lock<mutex> lock(mCompleteMutex);
+        return mCond.wait_until(lock, deadline, [this] {
+            return mRemaining==0;
+        });
+#endif
+    }
+
     bool JobStatus::isReady() {
         lock_guard<mutex> guard(mCompleteMutex);
         return mRemaining==0;

--- a/tests-cpp/small/test_jobque_wait_for.cpp
+++ b/tests-cpp/small/test_jobque_wait_for.cpp
@@ -1,0 +1,84 @@
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include "daScript/misc/job_que.h"
+
+#include <chrono>
+#include <thread>
+
+using namespace das;
+
+namespace {
+
+    int64_t elapsedMs ( std::chrono::steady_clock::time_point t0 ) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - t0).count();
+    }
+
+    struct JoinSpinGuard {
+        explicit JoinSpinGuard ( int32_t level ) : saved(JobStatus::sJoinSpin.load()) {
+            JobStatus::sJoinSpin.store(level);
+        }
+        ~JoinSpinGuard () { JobStatus::sJoinSpin.store(saved); }
+        int32_t saved;
+    };
+
+}
+
+TEST_CASE("JobStatus::WaitFor times out when nobody notifies") {
+    JobStatus status(1);
+    auto t0 = std::chrono::steady_clock::now();
+    CHECK_FALSE(status.WaitFor(50));
+    CHECK_GE(elapsedMs(t0), 40);
+    CHECK_FALSE(status.isReady());
+}
+
+TEST_CASE("JobStatus::WaitFor returns once the counter reaches zero") {
+    JobStatus status(1);
+    std::thread worker([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        status.Notify();
+    });
+    auto t0 = std::chrono::steady_clock::now();
+    CHECK(status.WaitFor(5000));
+    CHECK_LT(elapsedMs(t0), 2500);
+    CHECK(status.isReady());
+    worker.join();
+}
+
+TEST_CASE("JobStatus::WaitFor on an already ready status returns immediately") {
+    JobStatus status(0);
+    auto t0 = std::chrono::steady_clock::now();
+    CHECK(status.WaitFor(5000));
+    CHECK_LT(elapsedMs(t0), 1000);
+}
+
+TEST_CASE("JobStatus::WaitFor with a non-positive timeout polls without blocking") {
+    JobStatus status(1);
+    auto t0 = std::chrono::steady_clock::now();
+    CHECK_FALSE(status.WaitFor(0));
+    CHECK_FALSE(status.WaitFor(-1));
+    CHECK_LT(elapsedMs(t0), 1000);
+    status.Notify();
+    CHECK(status.WaitFor(0));
+}
+
+TEST_CASE("JobStatus::WaitFor with the join spin enabled") {
+    SUBCASE("completion during the spin phase is reported") {
+        JoinSpinGuard spin(4);
+        JobStatus status(1);
+        std::thread worker([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            status.Notify();
+        });
+        CHECK(status.WaitFor(5000));
+        CHECK(status.isReady());
+        worker.join();
+    }
+    SUBCASE("the timeout bounds the spin window") {
+        JoinSpinGuard spin(1000);
+        JobStatus status(1);
+        auto t0 = std::chrono::steady_clock::now();
+        CHECK_FALSE(status.WaitFor(50));
+        CHECK_LT(elapsedMs(t0), 3000);
+    }
+}

--- a/tests/jobque/test_jobque_join_timeout.das
+++ b/tests/jobque/test_jobque_join_timeout.das
@@ -1,0 +1,122 @@
+options gen2
+options no_unused_function_arguments = false
+options no_unused_block_arguments = false
+require dastest/testing_boost public
+require daslib/jobque_boost
+require daslib/fio
+
+[test]
+def test_join_timeout_expires(t : T?) {
+    t |> run("join times out when the wait group is never notified") @(t : T?) {
+        with_job_status(1) $(status) {
+            let done = status |> join(50)
+            t |> equal(done, false)
+            t |> equal(status.isReady, false)
+        }
+    }
+}
+
+[test]
+def test_join_timeout_completes(t : T?) {
+    t |> run("join returns true once every job has notified") @(t : T?) {
+        with_job_que() {
+            with_job_status(2) $(status) {
+                for (_i in range(2)) {
+                    new_job() @() {
+                        status |> notify_and_release
+                    }
+                }
+                let done = status |> join(10000)
+                t |> equal(done, true)
+                t |> equal(status.isReady, true)
+            }
+        }
+    }
+}
+
+[test]
+def test_join_timeout_then_success(t : T?) {
+    t |> run("a short join times out, a later join still sees the completion") @(t : T?) {
+        with_job_que() {
+            with_job_status(1) $(status) {
+                new_job() @() {
+                    sleep(250u)
+                    status |> notify_and_release
+                }
+                let tooEarly = status |> join(10)
+                t |> equal(tooEarly, false)
+                let done = status |> join(10000)
+                t |> equal(done, true)
+            }
+        }
+    }
+}
+
+[test]
+def test_join_timeout_flushes_batched_dispatch(t : T?) {
+    t |> run("join publishes the pending batch, same as the untimed join") @(t : T?) {
+        with_job_que() {
+            set_jobque_batch_dispatch(true)
+            with_job_status(2) $(status) {
+                for (_i in range(2)) {
+                    new_job() @() {
+                        status |> notify_and_release
+                    }
+                }
+                let done = status |> join(10000)
+                t |> equal(done, true)
+            }
+            set_jobque_batch_dispatch(false)
+        }
+    }
+}
+
+[test]
+def test_join_zero_timeout_polls(t : T?) {
+    t |> run("join with a non-positive timeout polls instead of waiting") @(t : T?) {
+        with_job_status(1) $(status) {
+            let pending = status |> join(0)
+            t |> equal(pending, false)
+            let stillPending = status |> join(-1)
+            t |> equal(stillPending, false)
+            status |> notify
+            let ready = status |> join(0)
+            t |> equal(ready, true)
+        }
+    }
+}
+
+[test]
+def test_join_timeout_with_join_spin(t : T?) {
+    t |> run("the timeout bounds the wait with the join spin enabled") @(t : T?) {
+        set_jobque_join_spin(2)
+        with_job_status(1) $(status) {
+            let done = status |> join(50)
+            t |> equal(done, false)
+        }
+        set_jobque_join_spin(0)
+    }
+}
+
+[test]
+def test_join_timeout_on_filled_lock_box(t : T?) {
+    t |> run("a filled lock box nobody grabs times out instead of waiting forever") @(t : T?) {
+        with_lock_box() $(box) {
+            t |> equal(box.isReady, true, "a fresh box holds nothing")
+            var payload <- [for (i in range(4)); float(i) * 1.5]
+            box |> fill(payload)
+            t |> equal(box.isReady, false, "fill marks the box full")
+            let taken = box |> join(50)
+            t |> equal(taken, false, "nobody grabbed, so the bounded wait must report failure")
+            var seen = 0.0
+            box |> grab() $(var v : array<float>) {
+                for (x in v) {
+                    seen += x
+                }
+            }
+            t |> equal(seen, 9.0)
+            t |> equal(box.isReady, true)
+            t |> equal(box |> join(50), true, "an emptied box joins immediately")
+        }
+    }
+}


### PR DESCRIPTION
**Header change: every shared module must be rebuilt. A module built against the old headers loads with an ABI-vintage warning and can crash.**

Audio teardown could hang forever. Five waits had no deadline. Three of them wait for the audio thread to take a PCM buffer, and two wait for a worker thread to exit. They also chain: `strudel_init` starts the worker, the worker calls `strudel_play`, and `strudel_play` ends in the PCM wait. The worker signals `done_status` only after all of that returns. So one buffer the audio thread never took would stop the worker, and the stopped worker would stop `strudel_shutdown` on the main thread. The application froze.

Each wait now has a deadline. `JobStatus::WaitFor` adds the bounded form of `Wait`, and it carries the same protocol: the single-threaded wasm case, the join spin window, and the lock the caller needs before it destroys the object. The spin window is charged against the same deadline, so a long window cannot outlive a short timeout. On the das side `join(job, timeout_ms)` returns false when the deadline passes.

When a deadline passes, the handle is leaked on purpose, not freed. A queued grab may still reach the box, and a stopped worker still holds its stream and its status. Freeing there would turn a hang into a use-after-free. A leak is recoverable, the jobque leak dump names it, and the log line says which wait gave up. The one exception is `SeqBox`: its holders drop references in any order and the last one deletes, so it is released on both paths.

Playback time also moves from `LockBox` to `SeqBox`. It is two doubles the worker publishes once per tick and the main thread reads. Nothing is owned and nobody waits, so a main thread reading the clock can no longer make the tick loop wait on a mutex. The remaining `LockBox` in the audio tree is the PCM handoff, which passes an `array<float>` by pointer and needs a consumed state. A snapshot box offers neither.

Where to look: `JobStatus::WaitFor` in `src/misc/job_que.cpp`, `waitForJobWithTimeout` in `src/builtin/module_builtin_jobque.cpp`, `shutdown_worker_thread` and the two timeout constants in `modules/dasAudio/strudel/strudel_player.das`, and `modules/dasAudio/ARCHITECTURE.md` for which primitive each sharing role gets.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full `tests` root sweep: 12904 tests, 22 failed. All 22 are pre-existing and unrelated to this branch. They live in 8 files that run `daslang` as a child process and assert its exit code. Negative control: on clean `master`, rebuilt, a trivial script that only prints still exits 1, and `tests/daslib/build_const_test.das` fails the same 8 of 10.
- AOT and JIT sweeps were not run. AOT code generation in this tree fails for the same reason as the tests above: every generation step runs `daslang` as a child and reads its exit code.
- Per-area runs are green: `tests/jobque` 255, `tests/audio` 14, `tests/strudel_device` 24, `tests/strudel` 652, `ctest -L small` 104.
- Threaded playback checked on real hardware, not only headless: twelve reads of `strudel_get_playback_time` advance in order, shutdown returns, no timeout fires on the healthy path, and the jobque leak count is unchanged.

### Claims - stated, not tested
- The timeout expiry branches are not covered end to end. Forcing a stuck audio thread needs fault injection. Every route tried still drains the queued grab, including a missing sid and a finalize in flight. What is covered is the primitive the integration rests on: a `LockBox` that is filled and never taken ends its bounded wait reporting failure, and the grab still works after, so the timeout consumed nothing. A break would show as a shutdown that hangs again, or as a free on the expiry path.
- The budgets, 2 seconds for a PCM grab and 5 seconds for a worker exit, are chosen from the observed shape rather than measured under load. The audio thread takes a buffer within one mix callback, about 10 milliseconds. The worker budget must exceed the worker's own PCM budget, which is why it is larger.

### Not done
- The PCM handoff keeps its `LockBox`. It transfers ownership of a heap buffer and needs a consumed state, so it is not a snapshot.
- `s |> join` in `audio_system_finalize` is left alone. The audio command stream is created with a remaining count of zero and `Stream::push` does not change that count, so the wait returns at once.
- The root cause of the non-zero exit code from `daslang` is not found. The only `exit(1)` in `utils/daslang/main.cpp` prints a smart-pointer message that does not appear in the output, so the exit happens somewhere else. It is pre-existing and outside this change, but it holds 22 tests red and blocks AOT.

</details>
