### PR TITLE
allow 'return void_expr' - void arrow bodies and generic forwarding

### DIFF
--- a/doc/source/reference/language/functions.rst
+++ b/doc/source/reference/language/functions.rst
@@ -95,6 +95,12 @@ The return type may be omitted; it is inferred from the expression:
 
     def succ(x : int) => x + 1
 
+A ``void`` expression works too - the call runs and the function returns nothing:
+
+.. code-block:: das
+
+    def log_point(x : int) => print("{x}\n")
+
 Move-return uses ``=> <-``:
 
 .. code-block:: das

--- a/doc/source/reference/language/statements.rst
+++ b/doc/source/reference/language/statements.rst
@@ -354,6 +354,20 @@ If no expression is given, the function is assumed to return ``void``:
         return
     }
 
+``return`` may also carry a ``void`` expression when the result type is ``void``
+(or a bare ``auto``, which it forces to ``void``): the expression is evaluated
+and the function returns. This is what lets single-expression bodies call
+side-effecting functions:
+
+.. code-block:: das
+
+    def log_twice(msg : string) {
+        return print("{msg}{msg}\n")    // same as: print(...) then return
+    }
+
+Returning a ``void`` expression from a function whose result type is not ``void``
+is an error, as is combining it with move semantics (``return <- void_call()``).
+
 **Move-on-return** transfers ownership of a value using the ``<-`` operator:
 
 .. code-block:: das

--- a/skills/daslang/references/closures.md
+++ b/skills/daslang/references/closures.md
@@ -38,9 +38,10 @@ plain name or a struct field (`h.fn(21)`); anything else - an array element, a c
 var r = radd(v1) $(var a : int&) : int {          // assumed pipe: trailing block = last argument
     return a++
 }
-goo() { print("inside goo\n") }                   // no '$' when the block takes no arguments
+goo() { print("inside goo\n") }                   // a braced no-arg block drops the '$'
 radd(v1, $(var a : int&) : int { return a++; })   // inline argument
 radd(v1, $(a) => a++)                             // arrow body; types inferred from the block type
+goo() $ => print("side effect\n")                 // void arrow body; the arrow form keeps '$' even with no args
 ```
 
 The assumed pipe also works on method calls (`obj.method() { ... }`, `obj->method() { ... }`), and

--- a/skills/daslang/references/functions.md
+++ b/skills/daslang/references/functions.md
@@ -56,7 +56,13 @@ the const away licenses the optimizer to drop the write.
 ```das
 def succ(x : int) => x + 1
 def make_arr() : array<int> => <- [1, 2, 3]      // move-return
+def log_point(x : int) => print("{x}\n")         // void body: the call runs, nothing is returned
 ```
+
+The same rule applies to an explicit `return`: `return void_call()` is legal when the result
+type is void (or a bare `auto`, which it forces to void) and means "evaluate, then return".
+It is an error when the result type is non-void - including a structured auto like `auto?` -
+or with move semantics (`return <- void_call()`).
 
 The body must **start on the `=>` line**; to wrap, open a paren there and break inside it:
 

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -4738,6 +4738,21 @@ namespace das {
                 TypeDecl::clone(expr->returnType, func->result);
             }
         }
+        if (expr->subexpr && expr->subexpr->type && expr->subexpr->type->isVoid() && !expr->moveSemantics) {
+            const auto & resT = blocks.size() ? blocks.back()->type : func->result;
+            if (resT && resT->isVoid()) {
+                // lower 'return void_expr' to { void_expr; return; } so the backends
+                // never see a value-carrying return of void
+                auto blk = new ExprBlock();
+                blk->isCollapseable = true;
+                blk->at = expr->at;
+                blk->list.push_back(expr->subexpr);
+                blk->list.push_back(new ExprReturn(expr->at, nullptr));
+                scopes.back()->needCollapse = true;
+                reportAstChanged();
+                return blk;
+            }
+        }
         expr->type = new TypeDecl();
         if (forceInscopePod && func) {
             if (returnCount == 0)

--- a/src/ast/ast_infer_type_helper.cpp
+++ b/src/ast/ast_infer_type_helper.cpp
@@ -1050,9 +1050,23 @@ namespace das {
     }
     bool InferTypes::inferReturnType(TypeDeclPtr &resType, ExprReturn *expr) {
         if (expr->subexpr && expr->subexpr->type && expr->subexpr->type->isVoid()) {
-            error("returning void value", "", "",
-                  expr->at, CompilationError::invalid_result);
-            return false;
+            // 'return void_expr' is legal when the result is void, or a bare auto which the
+            // generic machinery below resolves to void (structured autos like auto? reject
+            // there); visit(ExprReturn) then lowers it to { void_expr; return; }
+            if (resType->isVoid() || resType->baseType == Type::autoinfer) {
+                if (expr->moveSemantics) {
+                    error("can't return void value via move", "", "",
+                          expr->at, CompilationError::invalid_result);
+                    return false;
+                }
+                if (resType->isVoid()) {
+                    return false;
+                }
+            } else if (!resType->isAuto()) {
+                error("returning void value, expecting " + describeType(resType), "", "",
+                      expr->at, CompilationError::invalid_result);
+                return false;
+            }
         }
         if (resType->isAuto()) {
             if (expr->subexpr) {

--- a/src/ast/ast_infer_type_make.cpp
+++ b/src/ast/ast_infer_type_make.cpp
@@ -15,6 +15,12 @@ namespace das {
                 if (mb->block->rtti_isBlock()) {
                     auto blk = (ExprBlock *)(mb->block);
                     blk->isGeneratorBlock = true;
+                    // the generator contract fixes the block result to bool; pinning a bare
+                    // auto here keeps return-type diagnostics at the offending return site
+                    if (blk->returnType && blk->returnType->baseType == Type::autoinfer) {
+                        blk->returnType = new TypeDecl(Type::tBool);
+                        blk->returnType->at = blk->at;
+                    }
                 }
             }
         }

--- a/tests/language/failed_return_void_expression.das
+++ b/tests/language/failed_return_void_expression.das
@@ -1,0 +1,39 @@
+options gen2
+expect 30220 : 4    // returning void value into a non-void result, via move, and inside a generator block
+expect 30343 : 1    // structured auto result (auto?) never collapses to void
+expect 30407 : 1
+
+require dastest/testing_boost public
+
+var g_hits = 0
+
+def bump_by(n : int) {
+    g_hits += n
+}
+
+def take_int_block(a : block<(x : int) : int>) : int {
+    return a(1)
+}
+
+def fail_int_result(n : int) : int {
+    return bump_by(n)
+}
+
+def fail_move_void(n : int) : void {
+    return <- bump_by(n)
+}
+
+def fail_int_block(n : int) : int {
+    return take_int_block() $(x) : int => bump_by(x)
+}
+
+def fail_structured_auto(n : int) : auto? {
+    return bump_by(n)
+}
+
+def fail_generator : iterator<int> {
+    return generator<int>() <| $ {
+        yield 1
+        return bump_by(1)
+    }
+}

--- a/tests/language/return_void_expression.das
+++ b/tests/language/return_void_expression.das
@@ -1,0 +1,136 @@
+options gen2
+require dastest/testing_boost public
+
+var g_hits = 0
+
+def bump() {
+    g_hits++
+}
+
+def bump_by(n : int) {
+    g_hits += n
+}
+
+def call_void(a : block<(x : int) : void>) {
+    a(3)
+}
+
+def ret_void_explicit(n : int) : void {
+    return bump_by(n)
+}
+
+def ret_void_auto(n : int) {
+    return bump_by(n)
+}
+
+def ret_void_early(n : int) {
+    if (n > 0) {
+        return bump_by(n)
+    }
+    bump_by(-1)
+}
+
+def ret_void_pipe(n : int) {
+    return n |> bump_by()
+}
+
+def ret_void_fn_arrow(n : int) => bump_by(n)
+
+def forward_void(blk : block<() : void>) {
+    return blk()
+}
+
+def forward_generic(blk) {
+    return blk()
+}
+
+def mixed_result(n : int) : int {
+    call_void() $(x) => bump_by(x)
+    return g_hits + n
+}
+
+[test]
+def test_return_void_expression(t : T?) {
+    t |> run("block arrow with void body") @(t : T?) {
+        g_hits = 0
+        call_void() $(x) => bump_by(x)
+        t |> equal(g_hits, 3)
+    }
+
+    t |> run("block arrow with explicit void result") @(t : T?) {
+        g_hits = 0
+        call_void() $(x : int) : void => bump_by(x)
+        t |> equal(g_hits, 3)
+    }
+
+    t |> run("lambda arrow with void body") @(t : T?) {
+        g_hits = 0
+        let f = @(x : int) => bump_by(x)
+        invoke(f, 5)
+        t |> equal(g_hits, 5)
+    }
+
+    t |> run("local function arrow with void body") @(t : T?) {
+        g_hits = 0
+        let f = @@(x : int) => bump_by(x)
+        invoke(f, 7)
+        t |> equal(g_hits, 7)
+    }
+
+    t |> run("explicit return of a void call") @(t : T?) {
+        g_hits = 0
+        ret_void_explicit(11)
+        t |> equal(g_hits, 11)
+    }
+
+    t |> run("auto result forced to void") @(t : T?) {
+        g_hits = 0
+        ret_void_auto(13)
+        t |> equal(g_hits, 13)
+        let fp : function<(n : int) : void> = @@ret_void_auto
+        g_hits = 0
+        invoke(fp, 2)
+        t |> equal(g_hits, 2)
+    }
+
+    t |> run("early-out return of a void call") @(t : T?) {
+        g_hits = 0
+        ret_void_early(17)
+        t |> equal(g_hits, 17)
+        g_hits = 0
+        ret_void_early(0)
+        t |> equal(g_hits, -1)
+    }
+
+    t |> run("pipe into void call in return position") @(t : T?) {
+        g_hits = 0
+        ret_void_pipe(19)
+        t |> equal(g_hits, 19)
+    }
+
+    t |> run("named function arrow body with void call") @(t : T?) {
+        g_hits = 0
+        ret_void_fn_arrow(23)
+        t |> equal(g_hits, 23)
+    }
+}
+
+[test]
+def test_return_void_forwarding(t : T?) {
+    t |> run("forwarding a void block result") @(t : T?) {
+        g_hits = 0
+        forward_void() $ => bump()
+        t |> equal(g_hits, 1)
+    }
+
+    t |> run("generic forwarding of a void block") @(t : T?) {
+        g_hits = 0
+        forward_generic() $ => bump()
+        t |> equal(g_hits, 1)
+    }
+
+    t |> run("void block inside a non-void function") @(t : T?) {
+        g_hits = 0
+        t |> equal(mixed_result(10), 13)
+    }
+}


### PR DESCRIPTION
`return <void expression>` now compiles when the enclosing result type is void, or a bare `auto`, which it resolves to void like any other inferred type. This makes void bodies work in every single-expression arrow form - `$(x) => print("{x}\n")`, `@(x) =>`, `@@(x) =>`, `def f(x) =>` - and lets generic forwarders like `def apply(blk) { return blk(); }` accept void blocks. A structured auto result (`auto?`, `tuple<auto;int>`) still rejects through the regular generic-infer path. A non-void result reports error 30220 and now names the expected type. `return <- void_call()` stays an error.

Accepted forms are lowered during inference to `{ void_expr; return; }`, so the interpreter, JIT, and AOT never see a value-carrying void return. Generator blocks now pin their undeclared return type to bool at the make-generator site, so a void return inside one reports at the offending line instead of a mislocated two-error cascade.

Where to look: `inferReturnType` in `src/ast/ast_infer_type_helper.cpp` (the typing rule), `visit(ExprReturn)` in `src/ast/ast_infer_type.cpp` (the lowering), `preVisit(ExprMakeGenerator)` in `src/ast/ast_infer_type_make.cpp` (the bool pin).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full local preflight (21 gates, including the full AOT sweep, docs, sequence smoke, imgui) ran green once at the pre-review tip; the review fix batch (structured-auto rejection, generator pin) was re-validated with targeted gates: lint on all three rails, format, ast-verify, cpp-syntax, the docs chain with sphinx, the new test file interp+JIT, the full interp test sweep, tests/language under JIT, and a `test_aot_subset` rebuild.
- Negative control on the lowering: with the rewrite guard disabled and the compiler rebuilt, every happy-path test arm still passes interp and JIT - see Claims.
- Two external codex review rounds, both clean: one at the pre-fix tip, one at the final tip.

### Claims - stated, not tested
- The infer-time lowering to `{ void_expr; return; }` is defense-in-depth: no test distinguishes it (the guard-disabled build stays green), and it exists so allocate-stack, the backends, and post-infer macros never see a value-carrying void return - a shape none of them was written for. A break would surface as backend divergence on shapes outside the suite.
- The `!moveSemantics` conjunct on the lowering guard is shadowed by the earlier helper error and untestable by construction; kept as defense against error-path reordering.
- `[nodiscard]` on a void-returning function is not re-checked through `return f()` (the pre-lowering pass marks the call consumed). Treated as intended: `return f()` is an explicit consumption spelling, and no stdlib `[nodiscard]` function returns void.

### Not done
- CHANGELIST entry - lands with the next release-audit batch.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
