### PR TITLE
vecmath: sync vendored copy to upstream DagorEngine HEAD + scalar backend for the new contract

### DIFF
--- a/include/daScript/daScriptC.h
+++ b/include/daScript/daScriptC.h
@@ -49,9 +49,10 @@
     typedef float32x4_t vec4f;
     typedef int32x4_t   vec4i;
 #elif defined(_TARGET_SIMD_SCALAR)
-    //shared with vecmath/dag_vecMathDecl.h - keep identical
-    #ifndef DAS_SCALAR_VEC_TYPES_DEFINED
-    #define DAS_SCALAR_VEC_TYPES_DEFINED
+    // shared with vecmath/dag_vecMathDecl.h: same tag names, members and layout - whichever
+    // header is included first defines the pair for both (guard macro is vecmath-owned)
+    #ifndef VECMATH_SCALAR_TYPES_DEFINED
+    #define VECMATH_SCALAR_TYPES_DEFINED
     #ifdef __cplusplus
     struct alignas(16) vec4f_scalar_t { float f[4]; };
     struct alignas(16) vec4i_scalar_t { int32_t i[4]; };

--- a/include/vecmath/CLAUDE.md
+++ b/include/vecmath/CLAUDE.md
@@ -1,89 +1,59 @@
 # vecmath - SIMD Math Library
 
-## Overview
-Platform-abstracted SIMD vector math library. Wraps SSE2/SSSE3/SSE4.1 (x86) and NEON (ARM)
-behind a unified C API. Used pervasively throughout the Dagor Engine for all performance-critical
-math: transforms, physics, BVH traversal, culling, animation, etc.
+Platform-abstracted SIMD math for transforms, physics, BVH traversal, culling and animation:
+one `v_`-prefixed C API over whichever backend the target selects, plus a `vd_`-prefixed double
+layer. The backend ladder is the `#if` chain in `dag_vecMathDecl.h`.
 
-## Key Types (dag_vecMathDecl.h)
-- `vec4f` / `vec3f` -- 128-bit float vector (__m128 on SSE, float32x4_t on NEON)
-- `vec4i` -- 128-bit integer vector (__m128i / int32x4_t)
-- `mat33f` -- 3x3 column-major matrix (3 x vec3f)
-- `mat44f` -- 4x4 column-major matrix (4 x vec4f)
-- `mat43f` -- 4x3 row-major matrix (3 x vec4f, each row is xyzw where w = translation component)
-- `bbox3f` -- AABB {bmin, bmax} as two vec4f
-- `bsph3f` -- bounding sphere {center.xyz, radius.w}
-- `quat4f` -- quaternion as vec4f
-- `plane3f` -- plane {normal.xyz, D.w}
-
-## File Layout
 | File | Contents |
 |------|----------|
-| `dag_vecMathDecl.h` | Type declarations, platform detection, alignment macros |
-| `dag_vecMath.h` | Full API declarations (~900 functions), platform-independent |
-| `dag_vecMath_const.h` | Constants: V_C_HALF, V_C_ONE, V_C_PI, V_C_UNIT_1000, V_CI_MASK*, etc. |
-| `dag_vecMath_pc_sse.h` | SSE implementation of all functions |
-| `dag_vecMath_neon.h` | NEON (ARM) implementation of all functions |
-| `dag_vecMath_common.h` | Shared implementations (bbox, frustum, quat, matrix ops built on core intrinsics) |
-| `dag_vecMath_trig.h` | Polynomial approximations for sin/cos/tan/atan/asin/acos |
+| `dag_vecMathDecl.h` | Types, backend `#if` ladder, alignment macros |
+| `dag_vecMath.h` | The API reference - every `v_` function declared with a comment; grep it by prefix (`v_mat44_`, `v_bbox3_`, `v_quat_`, `v_frustum_`) before hand-rolling |
+| `dag_vecMath_const.h` | Constants (`V_C_*`, `V_CI_MASK*`) |
+| `dag_vecMath_pc_sse.h` / `dag_vecMath_neon.h` / `dag_vecMath_scalar.h` | The three backends |
+| `dag_vecMath_common.h` | Implementations written once on top of the primitives (bbox, frustum, quat, matrix) |
+| `dag_vecMath_trig.h` | Polynomial sin/cos/tan/atan/asin/acos |
+| `dag_vecMath_double.h` | The `vec4d` / `vd_` layer, per-backend arms in one file |
+| `usage.md` | Which call to write, and the correctness traps (mask canonicality, mirrored matrices, FMA contraction, `.w` discipline) |
+| `microarch.md` | Per-instruction cost and target hardware, for when no usage rule answers |
+| `vec4d.md` | Anything `vec4d` / `vd_` |
+| `README.md` / `LICENSE` | Upstream's own; the README is stale in places (says 7 headers, SSE+NEON only) - this file wins |
 
-## Naming Conventions
-- `v_` prefix for all functions
-- `v_splats(float)` -- broadcast scalar to all lanes
-- `v_splatsi(int)` -- broadcast int scalar
-- `v_splat_x/y/z/w(v)` -- broadcast one lane
-- `v_perm_XYZW(v)` -- swizzle/permute (e.g. `v_perm_yzxw`)
-- `v_dot3_x(a,b)` -- dot product result in .x only (faster)
-- `v_dot3(a,b)` -- dot product broadcast to all lanes
-- `v_cross3(a,b)` -- 3D cross product
-- `v_length3/v_length3_x` -- length (broadcast vs .x-only)
-- `v_norm3(v)` -- normalize
-- `v_madd(a,b,c)` -- fused multiply-add: a*b+c
-- `v_rcp(v)` / `v_rcp_est(v)` -- reciprocal (precise / estimate)
-- `v_rsqrt(v)` / `v_rsqrt_est(v)` -- reciprocal sqrt
-- `v_cmp_gt/ge/lt/le/eq(a,b)` -- compare, returns mask (0xFFFFFFFF or 0)
-- `v_and/v_or/v_xor/v_andnot/v_sel/v_btsel` -- bitwise ops and select
-- `v_cast_vec4i/v_cast_vec4f` -- reinterpret cast (no conversion)
-- `v_cvt_vec4i/v_cvt_vec4f` -- convert int<->float
-- `v_half_to_float(v)` / `v_float_to_half_rtne(v)` -- FP16 conversion
-- `v_float_to_half_up/down` -- directional rounding for conservative bounds
-- `v_check_xyz_all_true(v)` -- test mask results
-- `v_signmask(v)` -- extract sign bits as int (1|2|4|8)
+**Read the vendored doc that answers the question before adding or porting a function.** They
+describe the upstream engine, not this repo: their build flags and library references
+(`Point3_vec4`, physJolt, rendInst) are Dagor's, and all three predate the scalar backend, so
+`vec4d.md` still calls `dag_vecMath_double.h` an SSE/AVX-and-NEON file.
 
-## Matrix Operations
-- `v_mat44_mul(dest, m1, m2)` -- 4x4 multiply
-- `v_mat44_inverse(dest, m)` / `v_mat44_inverse43(dest, m)` -- inverse
-- `v_mat44_transpose(dest, src)` -- transpose
-- `v_mat43_transpose_to_mat44(dest, src)` -- row-major 4x3 -> column-major 4x4
-- `v_mat44_mul_vec3p(m, v)` -- transform point (w=1)
-- `v_mat44_mul_vec3v(m, v)` -- transform direction (w=0)
-- `v_mat33_mul_vec3(m, v)` -- 3x3 transform
-- `v_mat43_mul_vec3p(m, v)` -- row-major 4x3 point transform
+**This folder vendors DagorEngine `prog/1stPartyLibs/vecmath/`** - not
+`prog/engine/publicInclude/vecmath/`, a second, non-canonical copy upstream. `CLAUDE.md` is this
+repo's own. Record the synced revision here on every sync; without it "matches upstream" has no
+second operand. Synced: `75723669` (2026-08-25).
 
-## AABB Operations (bbox3f)
-- `v_bbox3_init_empty(b)` / `v_bbox3_init(b, p)` -- create
-- `v_bbox3_add_pt(b, p)` / `v_bbox3_add_box(b, b2)` -- extend
-- `v_bbox3_center(b)` / `v_bbox3_size(b)` -- queries
-- `v_bbox3_test_pt_inside(b, p)` -- containment
-- `v_bbox3_test_box_intersect(b1, b2)` -- overlap
-- `v_bbox3_rotate_init(b, col0, col1, col2, bb)` -- oriented AABB
+**A file that mentions `_TARGET_SIMD_SCALAR`, plus `dag_vecMath_scalar.h`, is fork-local; every
+other file here stays byte-identical to upstream.** A sync replaces the byte-identical set
+wholesale from upstream and re-applies the fork-local hooks on top, so a local edit to a
+byte-identical file is lost without warning - land the change upstream first, or route it through
+a fork-local hook.
 
-## Performance Notes
-- Functions marked VECMATH_FINLINE are always force-inlined
-- VECTORCALL convention used on MSVC/Clang for SSE targets (passes vec4f in registers)
-- `_x` suffix variants (e.g. v_dot3_x) are faster -- result only in .x, no broadcast
-- `_est` variants use hardware estimate + optional Newton-Raphson (faster, less precise)
-- `_unprecise` variants use raw hardware estimate only (fastest, least precise)
-- Avoid v_extract_x/y/z/w in hot loops -- moves data from SIMD to scalar registers
-- .w component of vec3f can be anything (even NaN) for 3D operations
-- v_ldu_p3 loads 4 floats for a 3-component vector (fast but reads 1 extra float)
-- v_ldu_p3_safe only reads exactly 3 floats (slower, use at page boundaries)
+**A sync that brings in new or changed `v_`/`vd_` functions gives each one its scalar arm in the
+same change** - in `dag_vecMath_scalar.h`, or in `dag_vecMath_common.h` if it is written once on
+top of the primitives. Upstream maintains SSE and NEON; nobody but this repo maintains scalar, and
+a missing arm compiles everywhere except the target that selects it.
 
-## Include Path
-```cpp
-#include <vecmath/dag_vecMath.h>        // full API
-#include <vecmath/dag_vecMathDecl.h>    // types only (forward declarations)
-```
+**The scalar backend is auto-selected on targets with no SIMD ISA (Cortex-M, RISC-V without V)
+and forced elsewhere by the CMake option `DAS_VECMATH_SCALAR`, which defines
+`_TARGET_SIMD_SCALAR=1`.** No header tests `DAS_VECMATH_SCALAR` - it exists so the x64 suite can
+validate the backend.
 
-IMPORTANT: This is `prog/1stPartyLibs/vecmath/`, NOT `prog/engine/publicInclude/vecmath/`.
-The 1stPartyLibs version is the correct one used by most engine code.
+**`vec4d` stays a local compute type: never a struct field crossing a TU boundary, never
+serialized.** Its layout is backend- and flag-dependent - one `__m256d` under `__AVX__`, two
+128-bit halves (`.xy`, `.zw`) on SSE without AVX (the default no-`/arch:AVX` x64 build) and on
+NEON, a `double d[4]` on the scalar backend - so it can differ between translation units of one
+binary; `VECMATH_VEC4D_256` reports which one a TU got.
+
+**`vec4f_scalar_t` / `vec4i_scalar_t` are defined identically in `dag_vecMathDecl.h` and in
+`include/daScript/daScriptC.h` (repo root), guarded by `VECMATH_SCALAR_TYPES_DEFINED`.** Whichever
+header is included first defines the pair for both, so a change to tag name, members or alignment
+lands in both files in the same change - otherwise the C API and the C++ API disagree on layout
+with no diagnostic.
+
+Include `<vecmath/dag_vecMath.h>` for the full API, `<vecmath/dag_vecMathDecl.h>` for types only.

--- a/include/vecmath/dag_vecMath.h
+++ b/include/vecmath/dag_vecMath.h
@@ -41,6 +41,19 @@ VECTORCALL VECMATH_FINLINE vec4i v_lduush(const unsigned short *m);
 VECTORCALL VECMATH_FINLINE vec4i v_ldui_half(const void *m);
 VECTORCALL VECMATH_FINLINE vec4f v_ldu_half(const void *m);
 
+//! load 8 floats (4 packed float2) from 16-byte aligned memory into SoA x/y;
+//! a single ld2 on NEON (e.g. an array of xy points or complex numbers)
+VECTORCALL VECMATH_FINLINE void v_ld_soa2(const float *m, vec4f &x, vec4f &y);
+//! load 12 floats (4 packed float3) from 16-byte aligned memory into SoA x/y/z;
+//! a single ld3 on NEON (e.g. a Point3 array to SoA)
+VECTORCALL VECMATH_FINLINE void v_ld_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z);
+//! load 16 floats (4 float4) from 16-byte aligned memory into SoA x/y/z/w; a single ld4 on NEON
+VECTORCALL VECMATH_FINLINE void v_ld_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w);
+//! unaligned variants of the deinterleaving loads
+VECTORCALL VECMATH_FINLINE void v_ldu_soa2(const float *m, vec4f &x, vec4f &y);
+VECTORCALL VECMATH_FINLINE void v_ldu_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z);
+VECTORCALL VECMATH_FINLINE void v_ldu_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w);
+
 //! fetch the cache line that contains address m
 VECMATH_FINLINE void v_prefetch(const void *m);
 
@@ -109,6 +122,16 @@ VECTORCALL VECMATH_FINLINE void v_stu(void *m, vec4f v);
 //! store low 64 bits of vector (.xy) to unaligned memory
 VECTORCALL VECMATH_FINLINE void v_stu_half(void *m, vec4f v);
 
+//! interleaving stores, the inverse of v_ld_soa2/3/4: write SoA lanes back as packed
+//! float2/float3/float4 elements (single st2/st3/st4 on NEON); 16-byte aligned memory
+VECTORCALL VECMATH_FINLINE void v_st_soa2(float *m, vec4f x, vec4f y);
+VECTORCALL VECMATH_FINLINE void v_st_soa3(float *m, vec4f x, vec4f y, vec4f z);
+VECTORCALL VECMATH_FINLINE void v_st_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w);
+//! unaligned variants
+VECTORCALL VECMATH_FINLINE void v_stu_soa2(float *m, vec4f x, vec4f y);
+VECTORCALL VECMATH_FINLINE void v_stu_soa3(float *m, vec4f x, vec4f y, vec4f z);
+VECTORCALL VECMATH_FINLINE void v_stu_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w);
+
 //! store vector to  16-byte aligned memory
 VECTORCALL VECMATH_FINLINE void v_sti(void *m, vec4i v);
 //! store vector to unaligned memory
@@ -126,6 +149,16 @@ VECTORCALL VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b);
 
 //! return signbit mask for each compnent - 1|2|4|8. ith bit is ith float signbit
 VECTORCALL VECMATH_FINLINE int v_signmask(vec4f a);
+//! same result as v_signmask, but input must be a canonical per-lane mask (v_cmp_* result);
+//! cheaper on NEON, identical on SSE
+VECTORCALL VECMATH_FINLINE int v_truemask(vec4f a);
+//! number of true (all-ones) lanes in a canonical mask, 0..4; a horizontal sum, so it avoids
+//! the mask-build plus scalar popcount of __popcount(v_truemask(m))
+VECTORCALL VECMATH_FINLINE int v_count_true(vec4f a);
+//! number of true (all-ones) lanes among x,y,z of a canonical mask, 0..3; the w lane is ignored
+VECTORCALL VECMATH_FINLINE int v_count_true_xyz(vec4f a);
+//! true if any of the 4 lanes has its sign bit set (raw floats, not just masks)
+VECTORCALL VECMATH_FINLINE bool v_is_any_neg_b(vec4f a);
 
 //! bitwise checks for whole register
 VECTORCALL VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a);
@@ -159,6 +192,10 @@ VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi(vec4i a, vec4i b);
 VECTORCALL VECMATH_FINLINE vec4f v_cmp_ge(vec4f a, vec4f b);
 //! component-wise comparison: for C={xyzw}  .C = a.C>b.C ? 0xFFFFFFFF : 0
 VECTORCALL VECMATH_FINLINE vec4f v_cmp_gt(vec4f a, vec4f b);
+//! component-wise comparison of magnitudes: .C = |a.C|>=|b.C| ? 0xFFFFFFFF : 0; single facge on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_abs_ge(vec4f a, vec4f b);
+//! component-wise comparison of magnitudes: .C = |a.C|>|b.C| ? 0xFFFFFFFF : 0; single facgt on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_abs_gt(vec4f a, vec4f b);
 //! component-wise comparison: for C={xyzw}  .C = a.C<=b.C ? 0xFFFFFFFF : 0
 VECTORCALL VECMATH_FINLINE vec4f v_cmp_le(vec4f a, vec4f b);
 //! component-wise comparison: for C={xyzw}  .C = a.C<b.C ? 0xFFFFFFFF : 0
@@ -194,8 +231,9 @@ VECTORCALL VECMATH_FINLINE vec4f v_cast_vec4f(vec4i a);
 
 //! convert to integer using round-to-zero mode
 VECTORCALL VECMATH_FINLINE vec4i v_cvti_vec4i(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a);//works correctly on all correct values (positive). on negative - implementation defined
-VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a);//works same as scalar operations on all values
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a);//truncates, like the cast. correct for [0, 1<<32); on negative - implementation defined
+//! truncates. out of range and NaN differ per platform (SSE wraps like the scalar cast, NEON saturates), as they do in C
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4i v_cvt_vec4i(vec4f a){return v_cvti_vec4i(a);}
 //! convert to float
 VECTORCALL VECMATH_FINLINE vec4f v_cvti_vec4f(vec4i a);
@@ -322,6 +360,8 @@ VECTORCALL VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b);
 VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c);
 //! .x = (a.x * b.x - c.x)
 VECTORCALL VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c);
+//! .x = (c.x - a.x * b.x)
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub_x(vec4f a, vec4f b, vec4f c);
 //! Get middle point between a and b
 VECTORCALL VECMATH_FINLINE vec4f v_midp(vec4f a, vec4f b);
 //! 1/a, very unprecise, fastest available on platform
@@ -339,11 +379,11 @@ VECTORCALL VECMATH_FINLINE vec4f v_rcp_safe(vec4f a, vec4f def = v_zero());
 VECTORCALL VECMATH_FINLINE vec4f v_sqr(vec4f a);
 //! .x = a.x*a.x
 VECTORCALL VECMATH_FINLINE vec4f v_sqr_x(vec4f a);
-//! min(a,b)
+//! min(a,b): per component a < b ? a : b (b wins on NaN), identical on all platforms
 VECTORCALL VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b);
 VECTORCALL VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b);
 VECTORCALL VECMATH_FINLINE vec4i v_minu(vec4i a, vec4i b);
-//! max(a,b)
+//! max(a,b): per component a > b ? a : b (b wins on NaN), identical on all platforms
 VECTORCALL VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b);
 VECTORCALL VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b);
 VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b);
@@ -353,6 +393,8 @@ VECTORCALL VECMATH_FINLINE vec4i v_negi(vec4i a);
 //! fabs(a)
 VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a);
+//! fabs(a - b); single fabd on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_abs_diff(vec4f a, vec4f b);
 
 //! clamp values in [min; max] range component-wise
 VECTORCALL VECMATH_FINLINE vec4f v_clamp(vec4f t, vec4f min_val, vec4f max_val);
@@ -403,17 +445,17 @@ VECTORCALL VECMATH_FINLINE vec4i v_srai(vec4i v, int bits);
 VECTORCALL VECMATH_FINLINE vec4i v_slli_64(vec4i v, int bits);
 //! shift right (unsigned integer, 64-bit lanes). bits is immediate value
 VECTORCALL VECMATH_FINLINE vec4i v_srli_64(vec4i v, int bits);
-//! shift left (unsigned integer). bits is variative value
+//! shift left (unsigned integer). bits is variative value, must be in [0, 31]
 VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, int bits);
-//! shift right (unsigned integer). bits is variative value
+//! shift right (unsigned integer). bits is variative value, must be in [0, 31]
 VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, int bits);
-//! shift right (signed integer). bits is variative value
+//! shift right (signed integer). bits is variative value, must be in [0, 31]
 VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, int bits);
-//! shift left (unsigned integer). bits is variative 64-bit value
+//! shift left (unsigned integer). bits is variative 64-bit value, must be in [0, 31]
 VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits);
-//! shift left (unsigned integer). bits is variative 64-bit value
+//! shift left (unsigned integer). bits is variative 64-bit value, must be in [0, 31]
 VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits);
-//! shift right (signed integer). bits is variative 64-bit value
+//! shift right (signed integer). bits is variative 64-bit value, must be in [0, 31]
 VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits);
 
 //! shift left (unsigned integer)
@@ -434,6 +476,10 @@ VECTORCALL VECMATH_FINLINE vec4i v_xori(vec4i a, vec4i b);
 VECTORCALL VECMATH_FINLINE vec4f v_hand(vec4f a);
 //! .xyzw = x | y | z | w
 VECTORCALL VECMATH_FINLINE vec4f v_hor(vec4f a);
+//! -1 (all bits set) if each of the six canonical masks (v_cmp_* results) has at least one
+//! true lane, 0 otherwise; branchless with no per-plane early-out: the frustum-cull callers
+//! run after coarse (tile/kd) pre-culling, so most boxes reaching it pass all six planes
+VECTORCALL VECMATH_FINLINE int v_is_merge_planes_nout(vec4f m0, vec4f m1, vec4f m2, vec4f m3, vec4f m4, vec4f m5);
 //! .xyzw = x & y & z
 VECTORCALL VECMATH_FINLINE vec4f v_hand3(vec3f a);
 //! .xyzw = x | y | z
@@ -442,10 +488,10 @@ VECTORCALL VECMATH_FINLINE vec4f v_hor3(vec3f a);
 VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a);
 //! .x = x + y + z
 VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec3f a);
-//! return min of .xyzw
+//! return min of .xyzw; NaN lanes give platform-dependent results
 VECTORCALL VECMATH_FINLINE vec4f v_hmin(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4i v_hmini(vec4i a);
-//! return max of .xyzw
+//! return max of .xyzw; NaN lanes give platform-dependent results
 VECTORCALL VECMATH_FINLINE vec4f v_hmax(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4i v_hmaxi(vec4i a);
 //! return min of .xyz
@@ -454,29 +500,51 @@ VECTORCALL VECMATH_FINLINE vec4i v_hmini3(vec4i a);
 //! return max of .xyz
 VECTORCALL VECMATH_FINLINE vec4f v_hmax3(vec3f a);
 VECTORCALL VECMATH_FINLINE vec4i v_hmaxi3(vec4i a);
+//! pairwise min: (min(a.x,a.y), min(a.z,a.w), min(b.x,b.y), min(b.z,b.w)); single fminp on NEON.
+//! NaN lanes give platform-dependent results (finite inputs are identical everywhere)
+VECTORCALL VECMATH_FINLINE vec4f v_min_pairs(vec4f a, vec4f b);
+//! pairwise max: (max(a.x,a.y), max(a.z,a.w), max(b.x,b.y), max(b.z,b.w)); single fmaxp on NEON.
+//! NaN lanes give platform-dependent results (finite inputs are identical everywhere)
+VECTORCALL VECMATH_FINLINE vec4f v_max_pairs(vec4f a, vec4f b);
+//! pairwise add: (a.x+a.y, a.z+a.w, b.x+b.y, b.z+b.w); single faddp on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_add_pairs(vec4f a, vec4f b);
+//! pairwise integer add: (a.x+a.y, a.z+a.w, b.x+b.y, b.z+b.w); single addp on NEON
+VECTORCALL VECMATH_FINLINE vec4i v_addi_pairs(vec4i a, vec4i b);
+//! pairwise signed integer min: (min(a.x,a.y), min(a.z,a.w), min(b.x,b.y), min(b.z,b.w)); single sminp on NEON
+VECTORCALL VECMATH_FINLINE vec4i v_mini_pairs(vec4i a, vec4i b);
+//! pairwise signed integer max: (max(a.x,a.y), max(a.z,a.w), max(b.x,b.y), max(b.z,b.w)); single smaxp on NEON
+VECTORCALL VECMATH_FINLINE vec4i v_maxi_pairs(vec4i a, vec4i b);
 //! return x*y*z*w
 VECTORCALL VECMATH_FINLINE vec4f v_hmul(vec4f a);
 //! return x*y*z
 VECTORCALL VECMATH_FINLINE vec4f v_hmul3(vec3f a);
 
-//! 1/sqrt_est(a), very unprecise, fastest available on platform
+//! 1/sqrt_est(a), very unprecise, fastest available on platform (SSE: ~11.9 bits, NEON: ~8 bits precision)
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_unprecise(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_unprecise_x(vec4f a);
-//! 1/sqrt_est(a), fast estimate with Newton-Raphson refinement
+//! 1/sqrt_est(a), hardware estimate with N-R refinement, faster than IEEE, useful precision, similar between platforms
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_est(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_est_x(vec4f a);
-//! .x = precise 1/sqrt(a)
+//! .x = precise 1/sqrt(a) IEEE-754 precise
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_safe(vec4f a, vec4f def);
 
-//! sqrt_est(a), fast estimate
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a);
-//! sqrt(a), Newton-Raphson refinement
+//! sqrt(a), very unprecise, fastest available on platform (SSE: ~11.9 bits, NEON: ~8 bits precision)
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_unprecise(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_unprecise_x(vec4f a);
+//! sqrt(a), hardware estimate with N-R refinement, faster than IEEE, useful precision, similar between platforms
+//! a=0 returns NaN; use v_sqrt for zero-safe behavior
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_est(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_est_x(vec4f a);
+//! sqrt(a), IEEE-754 precise
 VECTORCALL VECMATH_FINLINE vec4f v_sqrt(vec4f a);
-//! .x = sqrt_est(a.x)
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f a);
-//! .x = sqrt(a.x)
+//! .x = sqrt(a.x), IEEE-754 precise
 VECTORCALL VECMATH_FINLINE vec4f v_sqrt_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_exp(vec4f x);
+VECTORCALL VECMATH_INLINE vec4f v_exp2(vec4f x);
+VECTORCALL VECMATH_FINLINE vec4f v_log(vec4f x);
+VECTORCALL VECMATH_FINLINE vec4f v_pow(vec4f x, vec4f y);
 
 //! cyclic rotate
 VECTORCALL VECMATH_FINLINE vec4f v_rot_1(vec4f a);
@@ -486,39 +554,72 @@ VECTORCALL VECMATH_FINLINE vec4i v_roti_1(vec4i a);
 VECTORCALL VECMATH_FINLINE vec4i v_roti_2(vec4i a);
 VECTORCALL VECMATH_FINLINE vec4i v_roti_3(vec4i a);
 
-//! permutations (mostly used in common implementation)
+//! permutations (mostly used in common implementation), grouped by cost of the NEON lowering;
+//! on SSE almost all cost a single shuffle
+// 1 op on NEON (native zip/uzp/trn/ext/rev64/dup or a single lane insert)
 VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwx(vec4f a); //< alias for v_rot_1()
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zwxy(vec4f a); //< alias for v_rot_2()
 VECTORCALL VECMATH_FINLINE vec4f v_perm_wxyz(vec4f a); //< alias for v_rot_3()
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxzx(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxxx(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyyy(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzzz(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwww(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xayb(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zcwd(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wwyy(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f a);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f a);
+// 2 ops on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxzx(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwyy(vec4f a);
+// 3 ops on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a);
 
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd);
+// two-vector permutations; 1 op on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd); //< uzp1
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd); //< uzp2
+//! transpose pairs: {x,a,z,c} / {y,b,w,d}; single trn1/trn2 on NEON, 2 cheap ops on SSE
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xazc(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ybwd(vec4f xyzw, vec4f abcd);
+//! two-vector lane rotate: {y,z,w,a} / {z,w,a,b} / {w,a,b,c}; single ext on NEON, 1 op on SSE
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwa(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwab(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd);
-VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd);
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd);
+// 2 ops on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd);
+// 3 ops on NEON
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd);
 
+// integer variants: single-source ones use pshufd on SSE (int domain, non-destructive);
+// two-source ones are free bitcasts around the float perms, same cost as the float form
 VECTORCALL VECMATH_FINLINE vec4i v_permi_xzac(vec4i xyzw, vec4i abcd);
 VECTORCALL VECMATH_FINLINE vec4i v_permi_xyab(vec4i xyzw, vec4i abcd);
 VECTORCALL VECMATH_FINLINE vec4i v_permi_xycd(vec4i xyzw, vec4i abcd);
@@ -535,18 +636,6 @@ VECTORCALL VECMATH_FINLINE vec4i v_permi_yyww(vec4i xyzw);
 VECTORCALL VECMATH_FINLINE vec4i v_permi_wwyy(vec4i xyzw);
 VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxw(vec4i xyzw);
 VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxy(vec4i xyzw);
-
-#define v_perm_xyXY v_perm_xyab
-#define v_perm_zwZW v_perm_zwcd
-#define v_perm_xXxX v_perm_xaxa
-#define v_perm_yyYY v_perm_yybb
-#define v_perm_xzXZ v_perm_xzac
-#define v_perm_ywYW v_perm_ywbd
-#define v_perm_YYyx v_perm_bbyx
-#define v_perm_Xyzw v_perm_ayzw
-#define v_perm_xYzw v_perm_xbzw
-#define v_perm_xyZw v_perm_xycw
-#define v_perm_xyzW v_perm_xyzd
 
 
 //! pack 8x 32-bit ints into 8x 16-bit ints
@@ -566,6 +655,7 @@ VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a);
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_lo_i8(vec4i a, vec4i b);
 //! interleave high 8 bytes from a,b: {a8,b8,a9,b9,...,a15,b15}
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_hi_i8(vec4i a, vec4i b);
+
 //! interleave low 4 shorts from a,b: {a0,b0,a1,b1,a2,b2,a3,b3}
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_lo_i16(vec4i a, vec4i b);
 //! interleave high 4 shorts from a,b: {a4,b4,a5,b5,a6,b6,a7,b7}
@@ -578,6 +668,12 @@ VECTORCALL VECMATH_FINLINE vec4i v_interleave_hi_i32(vec4i a, vec4i b);
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_lo_i64(vec4i a, vec4i b);
 //! interleave high int64 from a,b: {a1,b1}
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_hi_i64(vec4i a, vec4i b);
+
+//! dynamic byte shuffle (pshufb semantics on all platforms): for each of the
+//! 16 bytes, result[i] = (k[i] & 0x80) ? 0 : t[k[i] & 15]
+VECTORCALL VECMATH_FINLINE vec4i v_perm_i8(vec4i t, vec4i k);
+//! per-byte compare, returns byte mask (0xFF where equal, 0 elsewhere)
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi8(vec4i a, vec4i b);
 
 
 //
@@ -596,6 +692,8 @@ VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b);
 //! dot product: .x = (a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w)
 VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b);
 //! cross product: a x b; ; a.w,b.w could be anything, even NAN
+//! both products stay rounded (never contracted to FMA): a x a == 0 exactly and
+//! a x b == -(b x a) bitwise, identical on every platform and build
 VECTORCALL VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b);
 
 //! make plane from 3 points
@@ -609,6 +707,10 @@ VECTORCALL VECMATH_FINLINE plane3f v_make_plane_norm(vec3f p0, vec3f norm);
 
 //! transform plane with matrix
 VECTORCALL VECMATH_FINLINE plane3f v_transform_plane(plane3f plane, mat44f_cref transform);
+VECTORCALL VECMATH_FINLINE plane3f v_norm_plane(plane3f in);
+VECTORCALL VECMATH_FINLINE vec3f v_ray_intersect_plane(vec3f A, vec3f B, plane3f P, vec4f &behind, vec4f &t);
+VECTORCALL VECMATH_FINLINE vec3f v_unsafe_ray_intersect_plane(vec3f point, vec3f dir, plane3f P);
+VECTORCALL VECMATH_FINLINE void v_unsafe_two_plane_intersection(plane3f p1, plane3f p2, vec3f &point, vec3f &dir);
 
 //! distance from point b to plane a: .xyzw = (a.x * b.x + a.y * b.y + a.z * b.z + a.w)
 VECTORCALL VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b);
@@ -672,6 +774,11 @@ VECTORCALL VECMATH_FINLINE vec3f v_norm3(vec3f a);
 //! normalize: a/length(a), .z, .w could be anything (even NAN). will return NaN for zero vector
 VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a);
 
+//! estimated normalize: a*rsqrt_est(dot), faster and less precise than v_norm*
+VECTORCALL VECMATH_FINLINE vec4f v_norm4_est(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_norm3_est(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_norm2_est(vec4f a);
+
 //! safe normalize: a/length(a), return def value for zero vector
 VECTORCALL VECMATH_FINLINE vec4f v_norm4_safe(vec4f a, vec4f def);
 VECTORCALL VECMATH_FINLINE vec4f v_norm3_safe(vec3f a, vec3f def);
@@ -698,7 +805,7 @@ VECTORCALL VECMATH_FINLINE bool v_test_xy_finite(vec4f a);
 VECTORCALL VECMATH_FINLINE bool v_test_x_finite(vec4f a);
 //! nans and infs converted to zero
 VECTORCALL VECMATH_FINLINE vec4f v_remove_not_finite(vec4f a);
-//! test that all of .xyz less than limit by absolute value
+//! test that all of .xyz less than limit by absolute value; limit must be non-negative
 VECTORCALL VECMATH_FINLINE bool v_test_xyz_abs_lt(vec3f a, vec3f limit);
 
 
@@ -718,8 +825,6 @@ VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v);
 VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3v(mat43f_cref m, vec3f v);
 //! m * v,  matrix is treated row-major, v.w=1
 VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3p(mat43f_cref m, vec3f v);
-//! scale columns
-VECTORCALL VECMATH_FINLINE void v_mat43_apply_scale(mat44f &m, vec3f scale);
 
   //! transfrom position and apply max scale to radius
 VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_bsph(mat44f_cref m, vec4f bsph);
@@ -736,6 +841,9 @@ VECTORCALL VECMATH_FINLINE quat4f v_quat_mul_quat(quat4f q1, quat4f q2);
 
 //! compute conjugate quaternion
 VECTORCALL VECMATH_FINLINE quat4f v_quat_conjugate(quat4f q);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_180_from_unit(vec3f v0);
+VECTORCALL VECMATH_FINLINE void v_quat_decompose_swing_twist(quat4f q, vec3f dir, quat4f& swing, quat4f& twist);
+VECTORCALL VECMATH_FINLINE void v_quat_decompose_twist_swing(quat4f q, vec3f dir, quat4f& twist, quat4f& swing);
 
 //
 // matrix algebra
@@ -776,18 +884,22 @@ VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_z(mat33f &dest, vec4f ang);
 VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_zyx(mat33f &dest, vec4f ang_xyz);
 
 //! T(m), 4x4 -> 4x4
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f src);
 VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3);
 //! T(m), 3x3 -> 3x3
 VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, vec3f src_col0, vec3f src_col1, vec3f src_col2);
 VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, mat33f_cref src);
-//! T(m), 4x4 -> 3x3, omitting last column. So we can make .w not zero
-//VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, vec4f col3);
+//! T(m), 4x4 -> 3x3 (transpose of the 3x3 part; last column ignored, .w lanes zeroed)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, mat44f src);
 
 //! T(m), 4x4 column major -> 4x3 row major
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f src);
 //! T(m), 4x3 row major -> 4x4 column major
-VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f src);
+//! same from a mat43f in memory, fusing the load and the transpose (single ld4 on NEON).
+//! UNSAFE: reads 16 bytes past m43 - only for mat43f inside bigger arrays/pools, never the
+//! last 48 bytes of an allocation; all .w lanes of the result are undefined
+NO_ASAN_INLINE void v_mat44_load_from_mat43_overread_unsafe(mat44f &dest, const mat43f &m43);
 //! extract rotation/scale transformation from mat44 to mat33
 VECTORCALL VECMATH_FINLINE void v_mat33_from_mat44(mat33f &dest, mat44f_cref m);
 
@@ -843,6 +955,8 @@ VECTORCALL VECMATH_FINLINE void v_mat33_mul33r(mat33f &dest, mat33f_cref m1, mat
 VECTORCALL VECMATH_FINLINE void v_mat44_orthonormalize33(mat44f &dest, mat44f_cref m);
 //! orthonormalize 3x3 matrix
 VECTORCALL VECMATH_FINLINE void v_mat33_orthonormalize(mat33f &dest, mat33f_cref m);
+//! normalize columns of a 3x3 matrix (removes scale, keeps shear)
+VECTORCALL VECMATH_FINLINE void v_mat33_remove_scale(mat33f &dest, mat33f_cref m);
 //! 1/m
 VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m);
 //! 1/m, assuming col1.w=col2.w=col0.w=0, col3=0,0,0,1. Resulting matrix will not conform same assumption (i.e. it will be 43 matrix, not 44)!
@@ -855,6 +969,9 @@ VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m);
 VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43(mat44f &dest, mat44f_cref m);
 //! 1/m == T33(m), col3 = -T33(m)*col3, with m assumed being orthonormal 43 matrix (i.e. col0.w=col1.w=col2.w = 0; col3.w = 1). Resulting matrix will be valid 44 matrix, with col3.w == 1.
 VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43_to44(mat44f &dest, mat44f_cref m);
+
+//! force the affine bottom row: col0..2.w = 0, col3.w = 1 (e.g. after ops leaving .w undefined)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_affine(mat44f &m);
 
 //! 1/m == T(m), with m being orthonormal
 VECTORCALL VECMATH_FINLINE void v_mat33_orthonormal_inverse(mat33f &dest, mat33f_cref m);
@@ -872,10 +989,22 @@ VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_x(mat44f_cref tm);
 //! .xyz = scales of 3 axes
 VECTORCALL VECMATH_FINLINE vec3f v_mat44_scale43_sq(mat44f_cref tm);
 //! apply scale from .xyz to 3 axes
-VECTORCALL VECMATH_FINLINE void v_mat44_apply_scale43(mat44f &tm, vec3f scale);
+VECTORCALL VECMATH_FINLINE void v_mat44_apply_scale33(mat44f &tm, vec3f scale);
+//! normalize columns 0..2 (removes scale, keeps shear and translation col3)
+VECTORCALL VECMATH_FINLINE void v_mat44_remove_scale33(mat44f &dest, mat44f_cref m);
 
 //! stores mat33f to unaligned Matrix3
 VECTORCALL VECMATH_FINLINE void v_mat_33cu_from_mat33(float * __restrict m33, const mat33f& tm);
+
+//! mat44f from 16 floats of unaligned memory holding the four basis vectors in
+//! column order (a TMatrix4 has the same layout)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_44cu(mat44f &tmV, const float *const __restrict m44);
+//! same from 16-byte aligned memory
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_44ca(mat44f &tmV, const float *const __restrict m44);
+//! stores mat44f as 16 floats to unaligned memory (e.g. a TMatrix4)
+VECTORCALL VECMATH_FINLINE void v_mat_44cu_from_mat44(float * __restrict m44, const mat44f &tm);
+//! same to 16-byte aligned memory
+VECTORCALL VECMATH_FINLINE void v_mat_44ca_from_mat44(float * __restrict m44, const mat44f &tm);
 
 //! stores mat44f to aligned TMatrix from mat44f
 VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm);
@@ -883,8 +1012,18 @@ VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, co
 //! stores mat44f to unaligned TMatrix
 VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, const mat44f &tm);
 
-//! mat33f from unaligned Matrix3
+//! stores mat43f to aligned TMatrix; one interleaving store (single st3 on NEON) -
+//! the rows' .w lanes are exactly the translation triple the TMatrix layout ends with
+VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat43(float * __restrict m43, mat43f_cref tm);
+
+//! stores mat43f to unaligned TMatrix
+VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat43(float * __restrict m43, mat43f_cref tm);
+
+//! mat33f from unaligned Matrix3 (9 floats); cols' .w = 0. Reads one float past the matrix
+//! like v_ldu_p3 does
 VECTORCALL VECMATH_FINLINE void v_mat33_make_from_33cu(mat33f &tmV, const float *const __restrict m33);
+//! same, reads exactly the 9 floats; use it only when v_mat33_make_from_33cu can crash
+VECTORCALL VECMATH_FINLINE void v_mat33_make_from_33cu_safe(mat33f &tmV, const float *const __restrict m33);
 
 //! mat44f from unaligned TMatrix
 VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43);
@@ -894,6 +1033,21 @@ VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const
 
 //! mat44f from memaligned TMatrix
 VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43);
+
+//! mat43f (transposed rows) from unaligned TMatrix; TMatrix column triples are exactly
+//! the interleaved form of the rows, so this is one deinterleaving load (single ld3 on NEON)
+VECTORCALL VECMATH_FINLINE void v_mat43_make_from_43cu(mat43f &tmV, const float *const __restrict m43);
+
+//! same, but the rows' .w lanes are undefined (rotation columns only); cheaper on SSE
+VECTORCALL VECMATH_FINLINE void v_mat43_make_from_43cu_unsafe(mat43f &tmV, const float *const __restrict m43);
+VECTORCALL VECMATH_FINLINE void v_mat43_sub(mat43f &dest, mat43f_cref m1, mat43f_cref m2);
+
+//! orthonormal inverse (1/m == T33(m), col3 = -T33(m)*pos) straight from an unaligned TMatrix;
+//! m must be orthonormal; result is a valid 44 matrix (col0..2.w = 0, col3.w = 1)
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse_from_43cu(mat44f &dest, const float *const __restrict m43);
+
+//! same, but all .w lanes of the result are undefined
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse_from_43cu_unsafe(mat44f &dest, const float *const __restrict m43);
 
 //! .xyz = last column of matrix (.w of each row)
 VECTORCALL VECMATH_FINLINE vec3f v_mat43_extract_pos(mat43f_cref mat);
@@ -908,6 +1062,7 @@ VECTORCALL VECMATH_FINLINE void v_bbox3_init_empty(bbox3f &b);
 VECTORCALL VECMATH_FINLINE void v_bbox3_init_ident(bbox3f &b);
 //! init with point
 VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, vec3f p);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_is_empty(bbox3f bbox);
 //! init with bb2 rotated/scaled by 3 column vectors (no translation)
 VECTORCALL VECMATH_FINLINE void v_bbox3_rotate_init(bbox3f &b, vec3f col0, vec3f col1, vec3f col2, bbox3f_cref bb2);
 //! init with bb2 transformed with 3x3 matrix m (rotation/scale only, no translation)
@@ -965,15 +1120,17 @@ VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_intersect(bbox3f b1, bbox3f b2)
 //! tests whether boxes intersect and returns boolean (0 or non-0). safe for above case
 VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_intersect_safe(bbox3f b1, bbox3f b2);
 
-//! tests OBB box1 edges intersect planes of AABB box0 and returns boolean (0 or non-0).
-VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f box1, const mat44f& tm1);
+//! tests whether AABB and OBB intersect and returns boolean (0 or non-0)
+VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect(const bbox3f& box0, const bbox3f& box1, const mat44f& tm1);
+//! same as previous, but assumes that boxes already culled by caller and will likely have intersection
+VECTORCALL inline bool v_bbox3_test_trasformed_box_likely_intersect(const bbox3f& box0, const bbox3f& box1, const mat44f& tm1);
 
-//! tests whether OBB box0 and OBB box1 intersect and returns boolean (0 or non-0).
-VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1);
-VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
-                                                                      vec4f size_factor);
-VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect_rel_tm(bbox3f box0, const mat44f& b0_to_b1,
-                                                                             bbox3f box1, const mat44f& b1_to_b0);
+//! tests whether OBB box0 and OBB box1 intersect and returns boolean (0 or non-0). size_factor fattens
+//! both boxes. assumes boxes may be far apart: rejects distant pairs by bounding spheres before the test.
+//! tm0 must be invertible (well-conditioned); the test is done in box0's frame via inverse(tm0)*tm1.
+//! callers that pre-culled and have a relative matrix should use the box0/box1/tm1 _likely form instead.
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1,
+                                                                      const mat44f& tm1, vec4f size_factor = v_splats(1.0f));
 //! get box = box0 & box1
 VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_get_box_intersection(bbox3f box0, bbox3f box1);
 //! tests whether box intersecs sphere and returns boolean
@@ -1045,24 +1202,24 @@ VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x(vec3f centerA, vec3f
 VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x_scaled(vec3f cA, vec3f extentA, vec3f cB, vec3f extentB, vec3f axis_scale);
 
 //returns point on infinite line which is closes to point
-VECTORCALL VECMATH_FINLINE vec3f closest_point_on_line(vec3f point, vec3f a, vec3f dir);
+VECTORCALL VECMATH_FINLINE vec3f v_closest_point_on_line(vec3f point, vec3f a, vec3f dir);
 //returns point on segment which is closes to point
-VECTORCALL VECMATH_FINLINE vec3f closest_point_on_segment(vec3f point, vec3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec3f v_closest_point_on_segment(vec3f point, vec3f a, vec3f b);
 //distance to line in x component
-VECTORCALL VECMATH_FINLINE vec4f distance_to_line_x(vec3f point, vec3f a, vec3f dir);
+VECTORCALL VECMATH_FINLINE vec4f v_distance_to_line_x(vec3f point, vec3f a, vec3f dir);
 //distance to segment in x component
-VECTORCALL VECMATH_FINLINE vec4f distance_to_seg_x(vec3f point, vec3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_distance_to_seg_x(vec3f point, vec3f a, vec3f b);
 //get closest to c bbox point. return c, if c is inside bbox. undefined for empty boxes
 VECTORCALL VECMATH_FINLINE vec3f v_closest_bbox_point(vec3f bmin, vec3f bmax, vec3f c);
 
 //returns 1 if segment with start, start + dir*tmax intersects box
-VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
+VECTORCALL VECMATH_FINLINE bool v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
 //same as previous but without support of empty bboxes
-VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
+VECTORCALL VECMATH_FINLINE bool v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
 //returns 1 if segment with start, start + dir*tmax intersects box, tmax will contain distance along ray
-VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
+VECTORCALL VECMATH_FINLINE bool v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
 //same as previous but without support of empty bboxes
-VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
+VECTORCALL VECMATH_FINLINE bool v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
 //returns 1 if segment with start, start + end intersects box
 VECTORCALL VECMATH_FINLINE bool v_test_segment_box_intersection(vec3f start, vec3f end, bbox3f box);
 
@@ -1071,13 +1228,13 @@ VECTORCALL VECMATH_FINLINE bool v_test_segment_box_intersection(vec3f start, vec
 // both can be negative
 // ray intersects box if tmax >= max(ray.tmin, tmin) && tmin <= ray.tmax
 VECTORCALL VECMATH_INLINE  vec4f v_ray_box_intersect_dist(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box);
-//approximate distance to box intersection (uses v_rcp_est instead of 1/rayDir). A bit faster, v_rcp_est error is < 1e-12
+//approximate distance to box intersection (uses v_rcp_est instead of 1/rayDir). A bit faster, v_rcp_est is good to ~22 bits
 VECTORCALL VECMATH_INLINE  vec4f v_ray_box_intersect_dist_est(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box);
 
 // return -1 if no intersection found, or box side index in [0; 5]
 // out_at_min and out_at_max in range [0.0; 1.0] set for closest and furthest intersections
 // compiler didn't calculate 'out_at_max' if it's unused
-VECTORCALL inline int v_segment_box_intersection_side(vec3f start, vec3f end, bbox3f box, float& out_at_min, float& out_at_max);
+VECTORCALL inline int v_segment_box_intersection_side(vec3f start, vec3f end, const bbox3f& box, float& out_at_min, float& out_at_max);
 
 // check ray or segment intersection with sphere
 VECTORCALL VECMATH_FINLINE bool v_test_ray_sphere_intersection(vec3f p0, vec3f dir, vec4f len, vec4f sphere_center, vec4f sphere_r2_x);
@@ -1116,29 +1273,48 @@ VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast(vec3f center, vec3f exte
 
 // same as above (and will call v_is_visible_extent_fast), but accepts bbox)
 VECTORCALL VECMATH_FINLINE int v_is_visible_b_fast(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE int v_frustum_intersect(vec3f center, vec3f extent, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE void v_frustum_corners_4(vec4f ax, vec4f ay, vec4f az, vec4f aw, vec4f bx, vec4f by, vec4f bz, vec4f bw, vec4f abx, vec4f aby, vec4f abz, vec4f c, vec4f &px, vec4f &py, vec4f &pz);
+VECTORCALL VECMATH_FINLINE int v_is_frustum_nout_8(const vec4f cs0[4], vec4f cs0_negw, const vec4f cs1[4], vec4f cs1_negw);
+VECTORCALL VECMATH_FINLINE int v_box_frustum_intersect_extent2(vec3f center, vec3f extent, vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2, const vec4f& plane4W2, const vec4f& plane5W2);
+VECTORCALL VECMATH_FINLINE int v_is_visible_b_fast_8planes(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE int v_is_visible_box_extent2(vec3f center, vec3f extent, vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2, const vec4f& plane4W2, const vec4f& plane5W2);
+VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast_8planes(vec3f center, vec3f extent, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE void v_is_transform_box_8(vec3f bmin, vec3f bmax, mat44f_cref clip, vec4f cs0[4], vec4f cs1[4], vec4f &cs0_negw, vec4f &cs1_negw);
+VECTORCALL VECMATH_FINLINE void v_is_transform_points_4(vec4f* dest, vec4f x, vec4f y, vec4f z, mat44f_cref mat);
+VECTORCALL VECMATH_FINLINE void v_is_transform_points_4(vec4f* dest, vec4f x, vec4f y, mat44f_cref mat);
+VECTORCALL VECMATH_FINLINE vec3f v_obb_sat_group_separated(vec3f dist, vec3f ra, vec3f rb);
+VECTORCALL VECMATH_FINLINE void v_is_screen_project_minmax(const vec4f cs[4], vec4f &minXY, vec4f &maxXY);
 
 ///universal visibility function (accepts worldviewproj matrix)
 ///return zero if not visible in frustum or if unclamped bbox screen size is smaller, than threshold. not zero, otherwise
 // also, out screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1)
-VECTORCALL VECMATH_FINLINE int v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip);
+VECTORCALL VECMATH_INLINE int v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip);
 
 /// same as previous but return w min, w max
 /// return zero if not visible in frustum or if bbox screen size is smaller, than threshold. 1, if all vertex are in front of near plane, -1 (and fullscreen rect) otherwise
 /// also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1), minmax_w is wWwW (minw, maxw, minw, maxw)
-VECTORCALL VECMATH_FINLINE int
+VECTORCALL VECMATH_INLINE int
 v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4f &minmax_w, mat44f_cref clip);
 
+/// as v_screen_size_b (the minmax_w form) for a box the caller has ALREADY frustum-classified as at least
+/// partially visible: skips the 6-plane frustum test and the clip-Z transform row entirely (clip z feeds
+/// only the frustum planes; the screen rect and minmax_w read x, y, w). Same FP ops for the shared parts,
+/// so the outputs are bit-identical to v_screen_size_b whenever the contract holds. For a box fully
+/// outside the frustum the outputs are meaningless (but safe to consume) instead of the 0 return.
+VECTORCALL VECMATH_INLINE int
+v_screen_size_visible_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4f &minmax_w, mat44f_cref clip);
 
 ///universal visibility function (accepts worldviewproj matrix)
 ///return zero if not visible. nonzero, otherwise
 ///it is slower than v_is_visible_b_fast, so do not call it if you don't know what are you doing
 ///for branching: (~v_test_vec_x_eqi_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
 ///or use v_is_visible_b (it is faster on SSE)
-VECTORCALL VECMATH_FINLINE vec4f v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_INLINE vec4f v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 
 ///for branching: (~v_test_vec_x_eqi_0( v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
-VECTORCALL VECMATH_FINLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_INLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 //! returns triangle vs sphere intersection
 // last parameter is squared radius!
@@ -1155,12 +1331,17 @@ VECTORCALL VECMATH_INLINE bool v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4
 // Quaternion math
 //
 
-//! make quaternion from 3 normalized columns of 3x3 rotation matrix
+//! make normalized quaternion from any non-degenerate 3x3/4x3 matrix: removes per-column scale,
+//! flips col2 on a mirrored (det < 0) basis and normalizes, so it accepts scaled, sheared and
+//! mirrored matrices. For a known pure rotation use v_quat_from_orthonormal_mat* (faster).
 VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat(vec3f col0, vec3f col1, vec3f col2);
-//! make quaternion from 3x3 rotation matrix (should be not scaled)
 VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat33(mat33f_cref m);
-//! make quaternion from rotation part of 4x4 matrix (should be not scaled)
 VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat43(mat44f_cref m);
+//! faster: REQUIRES orthonormal (scale-free) columns; still returns a normalized quaternion,
+//! but skips scale removal, so it is wrong for scaled input. Use only for known pure rotations.
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_orthonormal_mat(vec3f col0, vec3f col1, vec3f col2);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_orthonormal_mat33(mat33f_cref m);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_orthonormal_mat43(mat44f_cref m);
 
 //! make (unnormalized) quaternion to rotate 'ang' radians around normalized 'v';
 VECTORCALL inline quat4f v_quat_from_unit_vec_ang(vec3f v, vec4f ang);
@@ -1324,6 +1505,7 @@ VECTORCALL VECMATH_FINLINE int v_extract_wi(vec4i v);
 
 //! insert scalar to vector by index
 VECTORCALL VECMATH_FINLINE vec4f v_insert(vec4f v, float x, int idx);
+VECTORCALL VECMATH_FINLINE vec4i v_inserti(vec4i v, int x, int idx);
 
 // sign extend
 VECTORCALL VECMATH_FINLINE vec4f is_neg_special(vec4f a);
@@ -1421,6 +1603,84 @@ VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_rtne(vec4f v);
 VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_down(vec4f v);
 VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_up(vec4f v);
 VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_trunc(vec4f v);
+VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half(vec4f f);
+VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_specials(vec4f f);
+VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_specials_lo(vec4f v);
+VECTORCALL VECMATH_FINLINE vec4f v_sw_half_to_float_specials(vec4i h);
+VECTORCALL VECMATH_FINLINE vec4f v_sw_half_to_float_specials_lo(vec4i a);
+
+//
+// vec4d - 4D double-precision vector (see vec4d in dag_vecMathDecl.h for representation)
+//
+VECTORCALL VECMATH_FINLINE vec4d vd_zero();
+VECTORCALL VECMATH_FINLINE vec4d vd_splats(double a);                             //!< broadcast scalar to all lanes
+//! set lanes x,y,z,w
+VECTORCALL VECMATH_FINLINE vec4d vd_make_vec4d(double x, double y, double z, double w);
+//! aligned load/store of 4 doubles. Both halves are moved separately, so 16-byte alignment is
+//! enough on every build (not 32) - but only the non-AVX build faults on a violation, since on
+//! AVX the pair folds into one unaligned 256-bit move. Use vd_ldu/vd_stu when unsure.
+vec4d vd_ld(const double *m);
+VECTORCALL VECMATH_FINLINE void vd_st(double *m, vec4d a);
+vec4d vd_ldu(const double *m);                                                    //!< unaligned load 4 doubles
+VECTORCALL VECMATH_FINLINE void vd_stu(double *m, vec4d a);                       //!< unaligned store 4 doubles
+//! load DPoint3 layout (3 doubles) fast by one 4x64 bit load; reads 8 bytes past the 3rd, .w = garbage
+NO_ASAN_INLINE vec4d vd_ldu_p3(const double *m);
+//! load 3 doubles safe (.w=0), use it only when vd_ldu_p3 can cause memory access crashes
+NO_ASAN_INLINE vec4d vd_ldu_p3_safe(const double *m);
+//! store DPoint3 layout: writes exactly 3 doubles
+VECTORCALL VECMATH_FINLINE void vd_stu_p3(double *p3, vec4d v);
+VECTORCALL VECMATH_FINLINE vec4d vd_cvt_from_vec4f(vec4f a);                      //!< widen float4 -> double4
+VECTORCALL VECMATH_FINLINE vec4f vd_cvt_to_vec4f(vec4d a);                        //!< narrow double4 -> float4
+VECTORCALL VECMATH_FINLINE vec4d vd_cvt_from_vec4i(vec4i a);                      //!< int4 -> double4, exact
+//! double4 -> int4, truncating toward zero like v_cvt_vec4i; out-of-range input is platform-specific
+VECTORCALL VECMATH_FINLINE vec4i vd_cvt_to_vec4i(vec4d a);
+
+//! read one lane out
+VECTORCALL VECMATH_FINLINE double vd_extract_x(vec4d a);
+VECTORCALL VECMATH_FINLINE double vd_extract_y(vec4d a);
+VECTORCALL VECMATH_FINLINE double vd_extract_z(vec4d a);
+VECTORCALL VECMATH_FINLINE double vd_extract_w(vec4d a);
+//! replace one lane, other lanes are kept
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_x(vec4d a, double x);
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_y(vec4d a, double y);
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_z(vec4d a, double z);
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_w(vec4d a, double w);
+
+VECTORCALL VECMATH_FINLINE vec4d vd_add(vec4d a, vec4d b);
+VECTORCALL VECMATH_FINLINE vec4d vd_sub(vec4d a, vec4d b);
+VECTORCALL VECMATH_FINLINE vec4d vd_mul(vec4d a, vec4d b);
+VECTORCALL VECMATH_FINLINE vec4d vd_div(vec4d a, vec4d b);
+VECTORCALL VECMATH_FINLINE vec4d vd_neg(vec4d a);
+//! min(a,b): per component a < b ? a : b (b wins on NaN), identical on all platforms
+VECTORCALL VECMATH_FINLINE vec4d vd_min(vec4d a, vec4d b);
+//! max(a,b): per component a > b ? a : b (b wins on NaN), identical on all platforms
+VECTORCALL VECMATH_FINLINE vec4d vd_max(vec4d a, vec4d b);
+//! clamp values in [min; max] range component-wise
+VECTORCALL VECMATH_FINLINE vec4d vd_clamp(vec4d t, vec4d min_val, vec4d max_val);
+VECTORCALL VECMATH_FINLINE vec4d vd_sqrt(vec4d a);
+VECTORCALL VECMATH_FINLINE vec4d vd_sqrt_x(vec4d a);                              //!< sqrt of .x only, .yzw undefined
+// no lane-wise 3-component forms: use the 4-component op and ignore .w (see dag_vecMath_double.h)
+
+//! Horizontal sums add lanes left to right, the same association scalar x+y+z+w has, so these
+//! and vd_dot* reproduce scalar double math bit-for-bit when built with -ffp-contract=off
+//! (as the physics libs are). A pairwise tree would be one add shorter but would not match.
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd4(vec4d a);                               //!< x+y+z+w, broadcast to all lanes
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd4_x(vec4d a);                             //!< x+y+z+w in .x
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd3(vec4d a);                               //!< x+y+z (ignores .w), broadcast
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd3_x(vec4d a);                             //!< x+y+z in .x
+
+VECTORCALL VECMATH_FINLINE vec4d vd_dot4(vec4d a, vec4d b);                       //!< xyzw dot, broadcast to all lanes
+VECTORCALL VECMATH_FINLINE vec4d vd_dot4_x(vec4d a, vec4d b);                     //!< xyzw dot in .x
+VECTORCALL VECMATH_FINLINE vec4d vd_dot3(vec4d a, vec4d b);                       //!< xyz dot (ignores .w), broadcast
+VECTORCALL VECMATH_FINLINE vec4d vd_dot3_x(vec4d a, vec4d b);                     //!< xyz dot in .x
+VECTORCALL VECMATH_FINLINE vec4d vd_cross3(vec4d a, vec4d b);                     //!< xyz cross (ignores .w), .w unspecified
+
+VECTORCALL VECMATH_FINLINE vec4d vd_length4_sq(vec4d a);
+VECTORCALL VECMATH_FINLINE vec4d vd_length3_sq(vec4d a);
+VECTORCALL VECMATH_FINLINE vec4d vd_length4(vec4d a);
+VECTORCALL VECMATH_FINLINE vec4d vd_length4_x(vec4d a);
+VECTORCALL VECMATH_FINLINE vec4d vd_length3(vec4d a);
+VECTORCALL VECMATH_FINLINE vec4d vd_length3_x(vec4d a);
 
 #include "dag_vecMath_const.h"
 
@@ -1436,3 +1696,4 @@ VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_trunc(vec4f v);
 
 #include "dag_vecMath_common.h"
 #include "dag_vecMath_trig.h"
+#include "dag_vecMath_double.h"

--- a/include/vecmath/dag_vecMathDecl.h
+++ b/include/vecmath/dag_vecMathDecl.h
@@ -118,6 +118,19 @@ typedef const struct bsph3f& bsph3f_cref;
     operator vec4f() const { return m128f; }
   } vec4i_const;
 
+  //! 4D double vector. On AVX targets it is one 256-bit register; otherwise two 128-bit
+  //! registers (low pair .xy, high pair .zw). The layout differs between AVX and non-AVX
+  //! translation units, so vec4d must stay a local compute type, never a field in a
+  //! header-shared struct that crosses that boundary.
+  #if defined(__AVX__)
+    #include <immintrin.h>
+    typedef __m256d vec4d;
+    #define VECMATH_VEC4D_256 1
+  #else
+    struct vec4d { __m128d xy, zw; };
+    #define VECMATH_VEC4D_256 0
+  #endif
+
 #elif _TARGET_SIMD_NEON // PSP2, iOS
   #include <arm_neon.h>
   typedef float32x4_t vec4f;
@@ -126,12 +139,17 @@ typedef const struct bsph3f& bsph3f_cref;
   typedef const vec4f vec4f_const;
   typedef const vec4i vec4i_const;
 
+  //! see the SSE branch above. NEON is aarch64-only here (ARMv7 has no float64x2_t).
+  struct vec4d { float64x2_t xy, zw; };
+  #define VECMATH_VEC4D_256 0
+
 #elif _TARGET_SIMD_SCALAR
   #include <stdint.h>
 
-  //shared with daScript/daScriptC.h - keep identical
-  #ifndef DAS_SCALAR_VEC_TYPES_DEFINED
-  #define DAS_SCALAR_VEC_TYPES_DEFINED
+  //shared with embedding C API headers (e.g. daScript/daScriptC.h): same tag names, members
+  //and layout - whichever header is included first defines the pair for both
+  #ifndef VECMATH_SCALAR_TYPES_DEFINED
+  #define VECMATH_SCALAR_TYPES_DEFINED
   struct alignas(16) vec4f_scalar_t { float f[4]; };
   struct alignas(16) vec4i_scalar_t { int32_t i[4]; };
   #endif
@@ -149,6 +167,9 @@ typedef const struct bsph3f& bsph3f_cref;
     operator vec4i() const { return m128; }
     operator vec4f() const { return m128f; }
   } vec4i_const;
+
+  struct alignas(16) vec4d { double d[4]; };
+  #define VECMATH_VEC4D_256 0
 
 #else
  !error! unsupported target
@@ -205,6 +226,7 @@ typedef vec4f plane3f;
 namespace eastl
 {
   template <typename Count> inline void uninitialized_value_construct_n(vec4f* , Count){}
+  template <typename Count> inline void uninitialized_value_construct_n(vec4d* , Count){}
 #if !(defined(_M_ARM64) && defined(_MSC_VER) && !defined(__clang__))
   template <typename Count> inline void uninitialized_value_construct_n(vec4i* , Count){}
 #endif

--- a/include/vecmath/dag_vecMath_common.h
+++ b/include/vecmath/dag_vecMath_common.h
@@ -48,10 +48,13 @@ VECTORCALL VECMATH_FINLINE bool v_check_xy_all_false(vec4f a) { return v_extract
 VECTORCALL VECMATH_FINLINE bool v_check_xy_any_true(vec4f a) { return v_extract_xi64(v_cast_vec4i(a)) != 0; }
 
 #if _TARGET_SIMD_SSE
-VECTORCALL VECMATH_FINLINE bool v_check_xz_all_true(vec4f a) { return (v_signmask(a) & 0b101) == 0b101; }
+VECTORCALL VECMATH_FINLINE bool v_check_xz_all_true(vec4f a) { return (v_truemask(a) & 0b101) == 0b101; }
 #else
 VECTORCALL VECMATH_FINLINE bool v_check_xz_all_true(vec4f a) { return v_check_xyzw_all_true(v_perm_xxzz(a)); }
 #endif
+
+//! number of true (all-ones) lanes among x,y,z of a canonical mask, 0..3; the w lane is ignored
+VECTORCALL VECMATH_FINLINE int v_count_true_xyz(vec4f a) { return v_count_true(v_perm_xyzd(a, v_zero())); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_bool_to_mask(bool bool_mask) { return v_cast_vec4f(v_splatsi(bool_mask ? -1 : 0)); }
 VECTORCALL VECMATH_FINLINE vec4f v_bool_to_msbit(bool param) { return v_cast_vec4f(v_splatsi((param ? 1 : 0) << 31)); }
@@ -106,23 +109,9 @@ VECTORCALL VECMATH_FINLINE vec4i v_clampi(vec4i t, vec4i min_val, vec4i max_val)
   return v_maxi(v_mini(t, max_val), min_val);
 }
 
-VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a)
-{
-  vec4f offset = v_btsel(V_C_HALF, a, V_CI_SIGN_MASK);
-  vec4f adjusted = v_add(a, offset);
-  return v_trunc(adjusted);
-}
-
-VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a)
-{
-  vec4f offset = v_btsel(V_C_HALF, a, V_CI_SIGN_MASK);
-  vec4f adjusted = v_add(a, offset);
-  return v_cvt_trunci(adjusted);
-}
-
 VECTORCALL VECMATH_FINLINE vec4f v_cmp_relative_equal(vec4f a, vec4f b, vec4f max_diff, vec4f max_rel_diff)
 {
-  vec4f diff = v_abs(v_sub(a, b));
+  vec4f diff = v_abs_diff(a, b);
   vec4f m = v_max(v_abs(a), v_abs(b));
   return v_cmp_le(diff, v_min(max_diff, v_mul(m, max_rel_diff)));
 }
@@ -170,6 +159,14 @@ VECTORCALL VECMATH_FINLINE vec4f v_rcp_safe(vec4f a, vec4f def)
   return v_sel(v_rcp(a), def, isDiv0);
 }
 
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt(vec4f a) { return v_rcp(v_sqrt(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) { return v_rcp_x(v_sqrt_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_safe(vec4f a, vec4f def)
+{
+  vec4f isDiv0 = v_is_unsafe_positive_divisor(a);
+  return v_sel(v_rsqrt(a), def, isDiv0);
+}
+
 VECTORCALL VECMATH_FINLINE vec4f v_mod(vec4f a, vec4f aDiv)
 {
   vec4f c = v_div(a, aDiv);
@@ -207,38 +204,6 @@ VECTORCALL VECMATH_FINLINE vec4f v_hor3(vec3f a)
 {
   return v_or(v_splat_x(a), v_or(v_splat_y(a), v_splat_z(a)));
 }
-
-VECTORCALL VECMATH_FINLINE vec4f v_hmin(vec4f a)
-{
-  a = v_min(a, v_rot_1(a));
-  return v_min(a, v_rot_2(a));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_hmax(vec4f a)
-{
-  a = v_max(a, v_rot_1(a));
-  return v_max(a, v_rot_2(a));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_hmin3(vec3f a)
-{
-  return v_min(v_splat_x(a), v_min(v_splat_y(a), v_splat_z(a)));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_hmax3(vec3f a)
-{
-  return v_max(v_splat_x(a), v_max(v_splat_y(a), v_splat_z(a)));
-}
-VECTORCALL VECMATH_FINLINE vec4i v_hmini(vec4i a)
-{
-  a = v_mini(a, v_roti_1(a));
-  return v_mini(a, v_roti_2(a));
-}
-VECTORCALL VECMATH_FINLINE vec4i v_hmaxi(vec4i a)
-{
-  a = v_maxi(a, v_roti_1(a));
-  return v_maxi(a, v_roti_2(a));
-}
-VECTORCALL VECMATH_FINLINE vec4i v_hmini3(vec4i a) { return v_mini(v_splat_xi(a), v_mini(v_splat_yi(a), v_splat_zi(a))); }
-VECTORCALL VECMATH_FINLINE vec4i v_hmaxi3(vec4i a) { return v_maxi(v_splat_xi(a), v_maxi(v_splat_yi(a), v_splat_zi(a))); }
-
 VECTORCALL VECMATH_FINLINE vec4f v_hmul(vec4f a)
 {
   a = v_mul(a, v_rot_1(a));
@@ -272,18 +237,33 @@ VECTORCALL VECMATH_FINLINE vec4f v_perm_wxyz(vec4f a) { return v_rot_3(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zcwd(vec4f xyzw, vec4f abcd) { return v_merge_lw(xyzw, abcd); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xayb(vec4f xyzw, vec4f abcd) { return v_merge_hw(xyzw, abcd); }
 
-VECTORCALL VECMATH_FINLINE vec4f v_length4(vec4f a) { return v_sqrt(v_length4_sq(a)); }
-VECTORCALL VECMATH_FINLINE vec3f v_length3(vec3f a) { return v_sqrt(v_length3_sq(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length2(vec4f a) { return v_sqrt(v_length2_sq(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length4_est(vec4f a) { return v_sqrt4_fast(v_length4_sq(a)); }
-VECTORCALL VECMATH_FINLINE vec3f v_length3_est(vec3f a) { return v_sqrt4_fast(v_length3_sq(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length2_est(vec4f a) { return v_sqrt4_fast(v_length2_sq(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length4_x(vec4f a) { return v_sqrt_x(v_length4_sq_x(a)); }
-VECTORCALL VECMATH_FINLINE vec3f v_length3_x(vec3f a) { return v_sqrt_x(v_length3_sq_x(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length2_x(vec4f a) { return v_sqrt_x(v_length2_sq_x(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length4_est_x(vec4f a) { return v_sqrt_fast_x(v_length4_sq_x(a)); }
-VECTORCALL VECMATH_FINLINE vec3f v_length3_est_x(vec3f a) { return v_sqrt_fast_x(v_length3_sq_x(a)); }
-VECTORCALL VECMATH_FINLINE vec4f v_length2_est_x(vec4f a) { return v_sqrt_fast_x(v_length2_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_unprecise(vec4f a)   { return v_mul(a, v_rsqrt_unprecise(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_unprecise_x(vec4f a) { return v_mul_x(a, v_rsqrt_unprecise_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_est(vec4f a)         { return v_mul(a, v_rsqrt_est(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_est_x(vec4f a)       { return v_mul_x(a, v_rsqrt_est_x(a)); }
+
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq(vec4f a) { return v_dot4(a, a); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq(vec3f a) { return v_dot3(a, a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq(vec4f a) { return v_dot2(a, a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_dot4_x(a, a); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a) { return v_dot3_x(a, a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a) { return v_dot2_x(a, a); }
+
+VECTORCALL VECMATH_FINLINE vec4f v_length4_x(vec4f a)     { return v_sqrt_x(v_length4_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_x(vec3f a)     { return v_sqrt_x(v_length3_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_x(vec4f a)     { return v_sqrt_x(v_length2_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_est_x(vec4f a) { return v_sqrt_est_x(v_length4_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_est_x(vec3f a) { return v_sqrt_est_x(v_length3_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_est_x(vec4f a) { return v_sqrt_est_x(v_length2_sq_x(a)); }
+
+// broadcast variants reuse the _x forms: scalar sqrt on lane 0 + splat is never slower
+// than the packed sqrt and is faster on Jaguar consoles and little ARM cores
+VECTORCALL VECMATH_FINLINE vec4f v_length4(vec4f a) { return v_splat_x(v_length4_x(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3(vec3f a) { return v_splat_x(v_length3_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2(vec4f a) { return v_splat_x(v_length2_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_est(vec4f a) { return v_splat_x(v_length4_est_x(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_est(vec3f a) { return v_splat_x(v_length3_est_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_est(vec4f a) { return v_splat_x(v_length2_est_x(a)); }
 
 VECTORCALL VECMATH_FINLINE vec3f v_striple3(vec3f a, vec3f b, vec3f c) { return v_dot3(v_cross3(a, b), c); }
 VECTORCALL VECMATH_FINLINE vec3f v_vtriple3(vec3f a, vec3f b, vec3f c)
@@ -292,6 +272,16 @@ VECTORCALL VECMATH_FINLINE vec3f v_vtriple3(vec3f a, vec3f b, vec3f c)
   vec3f ab = v_dot3(a, b);
   return v_nmsub(c, ab, v_mul(b, ac));
 }
+
+VECTORCALL VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_div(a, v_length4(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_div(a, v_length3(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_div(a, v_length2(a)); }
+
+// _est: a * rsqrt_est(len^2) using the hardware reciprocal-sqrt estimate (+1 NR); no
+// division, faster and less precise than v_norm*.
+VECTORCALL VECMATH_FINLINE vec4f v_norm4_est(vec4f a) { return v_mul(a, v_splat_x(v_rsqrt_est_x(v_length4_sq_x(a)))); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm3_est(vec4f a) { return v_mul(a, v_splat_x(v_rsqrt_est_x(v_length3_sq_x(a)))); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm2_est(vec4f a) { return v_mul(a, v_splat_x(v_rsqrt_est_x(v_length2_sq_x(a)))); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_norm4_safe(vec4f a, vec4f def)
 {
@@ -310,14 +300,6 @@ VECTORCALL VECMATH_FINLINE vec4f v_norm2_safe(vec4f a, vec4f def)
   vec4f lenSq = v_length2_sq(a);
   vec4f len = v_splat_x(v_sqrt_x(lenSq));
   return v_sel(v_div(a, len), def, v_is_unsafe_positive_divisor(lenSq));
-}
-
-VECTORCALL VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b)
-{
-  // (a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x)
-  vec3f yzxw = v_perm_yzxw(a);
-  vec3f bcad = v_perm_yzxw(b);
-  return v_perm_yzxy(v_nmsub(yzxw, b, v_mul(a, bcad)));
 }
 
 VECTORCALL VECMATH_FINLINE void v_mat44_make_persp_forward(mat44f &dest, float wk, float hk, float zn, float zf)
@@ -354,16 +336,101 @@ VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, vec3f col0, vec3
   dest.col2 = v_merge_hw(tmp2, tmp3);
 }
 
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, vec3f col3)
+VECTORCALL VECMATH_FINLINE void v_mat33_from_mat44(mat33f &dest, mat44f_cref m2)
 {
-  vec4f tmp0, tmp1, tmp2, tmp3;
-  tmp0 = v_merge_hw(col0, col2);
-  tmp1 = v_merge_hw(col1, col3);
-  tmp2 = v_merge_lw(col0, col2);
-  tmp3 = v_merge_lw(col1, col3);
-  dest.col0 = v_merge_hw(tmp0, tmp1);
-  dest.col1 = v_merge_lw(tmp0, tmp1);
-  dest.col2 = v_merge_hw(tmp2, tmp3);
+  dest.col0 = m2.col0;
+  dest.col1 = m2.col1;
+  dest.col2 = m2.col2;
+}
+
+// core 4x4 transpose; all other transpose variants delegate to it. the 3-output
+// variants let dead-code elimination drop the unused 4th row (same shuffle count).
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
+{
+  vec4f tmp0 = v_merge_hw(r0, r2);
+  vec4f tmp1 = v_merge_hw(r1, r3);
+  vec4f tmp2 = v_merge_lw(r0, r2);
+  vec4f tmp3 = v_merge_lw(r1, r3);
+  r0 = v_merge_hw(tmp0, tmp1);
+  r1 = v_merge_lw(tmp0, tmp1);
+  r2 = v_merge_hw(tmp2, tmp3);
+  r3 = v_merge_lw(tmp2, tmp3);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, mat44f src)
+{
+  vec4f r3 = v_zero(); // src.col3 is ignored; zero keeps the transposed .w lanes clean
+  v_mat44_transpose(src.col0, src.col1, src.col2, r3);
+  v_mat33_from_mat44(dest, src);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f src)
+{
+  dest = src;
+  v_mat44_transpose(dest.col0, dest.col1, dest.col2, dest.col3);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f src)
+{
+  dest.col0 = src.row0;
+  dest.col1 = src.row1;
+  dest.col2 = src.row2;
+  dest.col3 = V_C_UNIT_0001; // gives bottom row (0,0,0,1) for free -> proper affine 4x4
+  v_mat44_transpose(dest.col0, dest.col1, dest.col2, dest.col3);
+}
+
+NO_ASAN_INLINE void v_mat44_load_from_mat43_overread_unsafe(mat44f &dest, const mat43f &m43)
+{
+#if defined(DAGOR_TSAN_ENABLED) || defined(DAGOR_ASAN_ENABLED) || (_TARGET_SIMD_SSE && !_TARGET_PC_WIN)
+  // non-Windows SSE is the dedicated server (a dev build shipped to production) - never
+  // over-read there; sanitizers take the exact 48-byte transpose too
+  v_mat43_transpose_to_mat44(dest, m43);
+#else
+  // in memory the mat44 columns sit at stride 4 across the mat43f rows - exactly the ld4
+  // access pattern, so the load and the transpose fuse into one instruction on NEON. NEON
+  // (all targets) and the Windows x86-64 dev majority keep the over-read so those developers
+  // hit the same out-of-bounds a NEON build would, instead of it only surfacing to few NEON devs
+  v_ld_soa4((const float *)&m43, dest.col0, dest.col1, dest.col2, dest.col3);
+#endif
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f src)
+{
+  vec4f r3 = src.col3; // mat43f has no 4th row; the transposed row3 is discarded
+  dest.row0 = src.col0;
+  dest.row1 = src.col1;
+  dest.row2 = src.col2;
+  v_mat44_transpose(dest.row0, dest.row1, dest.row2, r3);
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
+{
+  vec4f tmp0 = v_mul(m.col0, v_splat_x(v));
+  vec4f tmp1 = v_mul(m.col1, v_splat_y(v));
+  tmp0 = v_madd(m.col2, v_splat_z(v), tmp0);
+  tmp1 = v_madd(m.col3, v_splat_w(v), tmp1);
+  return v_add(tmp0, tmp1);
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
+{
+  vec4f res = v_mul(m.col0, v_splat_x(v));
+  res = v_madd(m.col1, v_splat_y(v), res);
+  return v_madd(m.col2, v_splat_z(v), res);
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
+{
+  vec4f tmp0 = v_mul(m.col0, v_splat_x(v));
+  vec4f tmp1 = v_madd(m.col1, v_splat_y(v), m.col3);
+  return v_add(v_madd(m.col2, v_splat_z(v), tmp0), tmp1);
+}
+
+VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
+{
+  vec4f res = v_mul(m.col0, v_splat_x(v));
+  res = v_madd(m.col1, v_splat_y(v), res);
+  return v_madd(m.col2, v_splat_z(v), res);
 }
 
 VECTORCALL VECMATH_FINLINE vec4f v_remove_not_finite(vec4f a)
@@ -379,7 +446,7 @@ VECTORCALL VECMATH_FINLINE vec4f v_remove_nan(vec4f a)
 VECTORCALL VECMATH_FINLINE vec4f v_is_nan(vec4f a)
 {
   volatile vec4f v = a;
-#if !defined(_MSC_VER) && !defined(_TARGET_SIMD_SCALAR)
+#if (!defined(_MSC_VER) || defined(__clang__)) && !defined(_TARGET_SIMD_SCALAR)
   return v_cmp_neq(a, v);
 #else
   return v_cmp_neq(a, (vec4f &)v);
@@ -409,7 +476,7 @@ VECTORCALL VECMATH_FINLINE bool v_test_mat44_nan(mat44f m)
 {
   return v_test_xyzw_nan(v_add(v_add(m.col0, m.col1), v_add(m.col2, m.col3)));
 }
-VECTORCALL VECMATH_FINLINE bool v_test_xyz_abs_lt(vec3f a, vec3f limit) { return v_check_xyz_all_true(v_cmp_lt(v_abs(a), limit)); }
+VECTORCALL VECMATH_FINLINE bool v_test_xyz_abs_lt(vec3f a, vec3f limit) { return v_check_xyz_all_true(v_cmp_abs_gt(limit, a)); }
 
 VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, mat33f_cref src)
 {
@@ -427,7 +494,7 @@ VECTORCALL VECMATH_FINLINE void v_mat33_make_from_look(mat33f &dest, vec4f look_
 
 VECTORCALL VECMATH_INLINE  void v_view_matrix_from_tangentZ( vec3f &left, vec3f &up, vec4f vdir )
 {
-  up = v_sel(V_C_UNIT_0010, V_C_UNIT_1000, v_cmp_gt(v_abs(v_splat_z(vdir)), v_splats(0.999f)));
+  up = v_sel(V_C_UNIT_0010, V_C_UNIT_1000, v_cmp_abs_gt(v_splat_z(vdir), v_splats(0.999f)));
   left = v_norm3(v_cross3(up, vdir));
   up = v_cross3(vdir, left);
 }
@@ -494,13 +561,6 @@ VECTORCALL VECMATH_FINLINE void v_mat33_sub(mat33f &dest, mat33f_cref m1, mat33f
   dest.col2 = v_sub(m1.col2, m2.col2);
 }
 
-VECTORCALL VECMATH_FINLINE void v_mat33_from_mat44(mat33f &dest, mat44f_cref m2)
-{
-  dest.col0 = m2.col0;
-  dest.col1 = m2.col1;
-  dest.col2 = m2.col2;
-}
-
 VECTORCALL VECMATH_FINLINE void v_mat33_neg(mat44f &dest, mat44f_cref m)
 {
   vec4f zero = v_zero();
@@ -541,13 +601,6 @@ VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3p(mat43f_cref m, vec3f v)
   mat44f m44;
   v_mat43_transpose_to_mat44(m44, m);
   return v_mat44_mul_vec3p(m44, v);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat43_apply_scale(mat44f &m, vec3f scale)
-{
-  m.col0 = v_mul(m.col0, v_splat_x(scale));
-  m.col1 = v_mul(m.col1, v_splat_y(scale));
-  m.col2 = v_mul(m.col2, v_splat_z(scale));
 }
 
 VECTORCALL VECMATH_FINLINE void v_mat44_mul(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
@@ -652,6 +705,19 @@ VECTORCALL VECMATH_FINLINE void v_mat44_orthonormalize33(mat44f &dest, mat44f_cr
   dest.col1 = c1;
   dest.col0 = c0;
 }
+VECTORCALL VECMATH_FINLINE void v_mat33_remove_scale(mat33f &dest, mat33f_cref m)
+{
+  vec4f sq0 = v_mul(m.col0, m.col0);
+  vec4f sq1 = v_mul(m.col1, m.col1);
+  vec4f sq2 = v_mul(m.col2, m.col2);
+  vec4f dummy = v_zero();
+  v_mat44_transpose(sq0, sq1, sq2, dummy);
+  vec4f invLen = v_rsqrt(v_add(v_add(sq0, sq1), sq2));
+  dest.col0 = v_mul(m.col0, v_splat_x(invLen));
+  dest.col1 = v_mul(m.col1, v_splat_y(invLen));
+  dest.col2 = v_mul(m.col2, v_splat_z(invLen));
+}
+
 VECTORCALL VECMATH_FINLINE void v_mat33_orthonormal_inverse(mat33f &dest, mat33f_cref m)
 {
   v_mat33_transpose(dest, m);
@@ -660,7 +726,7 @@ VECTORCALL VECMATH_FINLINE void v_mat33_orthonormal_inverse(mat33f &dest, mat33f
 VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43(mat44f &dest, mat44f_cref m)
 {
   mat33f m3;
-  v_mat44_transpose_to_mat33(m3, m.col0, m.col1, m.col2, v_zero());
+  v_mat44_transpose_to_mat33(m3, m);
   dest.set33(m3);
   dest.col3 = v_neg(v_mat44_mul_vec3v(dest, m.col3));
 }
@@ -668,14 +734,160 @@ VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43(mat44f &dest, mat4
 VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43_to44(mat44f &dest, mat44f_cref m)
 {
   mat33f m3;
-  v_mat44_transpose_to_mat33(m3, m.col0, m.col1, m.col2, v_zero());
+  v_mat44_transpose_to_mat33(m3, m);
   dest.set33(m3);
   dest.col3 = v_perm_xyzd(v_neg(v_mat44_mul_vec3v(dest, m.col3)), V_C_UNIT_0001);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat43_make_from_43cu(mat43f &tmV, const float *const __restrict m43)
+{
+  v_ldu_soa3(m43, tmV.row0, tmV.row1, tmV.row2);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat43(float * __restrict m43, mat43f_cref tm)
+{
+  v_st_soa3(m43, tm.row0, tm.row1, tm.row2);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat43(float * __restrict m43, mat43f_cref tm)
+{
+  v_stu_soa3(m43, tm.row0, tm.row1, tm.row2);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_make_affine(mat44f &m)
+{
+  m.col0 = v_perm_xyzd(m.col0, v_zero());
+  m.col1 = v_perm_xyzd(m.col1, v_zero());
+  m.col2 = v_perm_xyzd(m.col2, v_zero());
+  m.col3 = v_perm_xyzd(m.col3, V_C_UNIT_0001);
+}
+
+// same, but all .w lanes are undefined
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse_from_43cu_unsafe(mat44f &dest, const float *const __restrict m43)
+{
+  // the deinterleaved rows are the columns of the transposed rotation, with the source
+  // translation left in the .w lanes - exactly what -T33(m)*pos needs
+  v_ldu_soa3(m43, dest.col0, dest.col1, dest.col2);
+  vec4f t = v_mul(dest.col0, v_splat_w(dest.col0));
+  t = v_madd(dest.col1, v_splat_w(dest.col1), t);
+  t = v_madd(dest.col2, v_splat_w(dest.col2), t);
+  dest.col3 = v_neg(t);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse_from_43cu(mat44f &dest, const float *const __restrict m43)
+{
+  v_mat44_orthonormal_inverse_from_43cu_unsafe(dest, m43);
+  v_mat44_make_affine(dest);
 }
 
 VECTORCALL VECMATH_FINLINE vec4f v_mat33_det(mat33f_cref m)
 {
   return v_dot3(m.col2, v_cross3(m.col0, m.col1));
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
+{
+  // adjugate = transpose of the cofactor cross-products, scaled by 1/det
+  vec4f tmp2 = v_cross3(m.col0, m.col1);
+  vec4f tmp0 = v_cross3(m.col1, m.col2);
+  vec4f tmp1 = v_cross3(m.col2, m.col0);
+  vec4f invdet = v_rcp_safe(v_dot3(tmp2, m.col2));
+  mat33f adj;
+  v_mat33_transpose(adj, tmp0, tmp1, tmp2);
+  dest.col0 = v_mul(adj.col0, invdet);
+  dest.col1 = v_mul(adj.col1, invdet);
+  dest.col2 = v_mul(adj.col2, invdet);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
+{
+  vec4f tmp0 = v_perm_xzac(m.col0, m.col1);
+  vec4f tmp1 = v_perm_xzac(m.col2, m.col3);
+  vec4f tmp2 = v_perm_ywbd(m.col0, m.col1);
+  vec4f tmp3 = v_perm_ywbd(m.col2, m.col3);
+  vec4f row0 = v_perm_xzac(tmp0, tmp1);
+  vec4f row1 = v_perm_xzac(tmp3, tmp2);
+  vec4f row2 = v_perm_ywbd(tmp0, tmp1);
+  vec4f row3 = v_perm_ywbd(tmp3, tmp2);
+
+  vec4f minor0, minor1, minor2, minor3, t;
+
+  t = v_perm_yxwz(v_mul(row2, row3));
+  minor0 = v_mul(row1, t);
+  minor1 = v_mul(row0, t);
+  t = v_rot_2(t);
+  minor0 = v_msub(row1, t, minor0);
+  minor1 = v_msub(row0, t, minor1);
+  minor1 = v_rot_2(minor1);
+
+  t = v_perm_yxwz(v_mul(row1, row2));
+  minor0 = v_madd(row3, t, minor0);
+  minor3 = v_mul(row0, t);
+  t = v_rot_2(t);
+  minor0 = v_nmsub(row3, t, minor0);
+  minor3 = v_msub(row0, t, minor3);
+  minor3 = v_rot_2(minor3);
+
+  t = v_perm_yxwz(v_mul(v_rot_2(row1), row3));
+  row2 = v_rot_2(row2);
+  minor0 = v_madd(row2, t, minor0);
+  minor2 = v_mul(row0, t);
+  t = v_rot_2(t);
+  minor0 = v_nmsub(row2, t, minor0);
+  minor2 = v_msub(row0, t, minor2);
+  minor2 = v_rot_2(minor2);
+
+  t = v_perm_yxwz(v_mul(row0, row1));
+  minor2 = v_madd(row3, t, minor2);
+  minor3 = v_msub(row2, t, minor3);
+  t = v_rot_2(t);
+  minor2 = v_msub(row3, t, minor2);
+  minor3 = v_nmsub(row2, t, minor3);
+
+  t = v_perm_yxwz(v_mul(row0, row3));
+  minor1 = v_nmsub(row2, t, minor1);
+  minor2 = v_madd(row1, t, minor2);
+  t = v_rot_2(t);
+  minor1 = v_madd(row2, t, minor1);
+  minor2 = v_nmsub(row1, t, minor2);
+
+  t = v_perm_yxwz(v_mul(row0, row2));
+  minor1 = v_madd(row3, t, minor1);
+  minor3 = v_nmsub(row1, t, minor3);
+  t = v_rot_2(t);
+  minor1 = v_nmsub(row3, t, minor1);
+  minor3 = v_madd(row1, t, minor3);
+
+  vec4f det = v_rcp_safe(v_dot4(row0, minor0));
+  dest.col0 = v_mul(det, minor0);
+  dest.col1 = v_mul(det, minor1);
+  dest.col2 = v_mul(det, minor2);
+  dest.col3 = v_mul(det, minor3);
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
+{
+  vec4f tmp0 = v_perm_xzac(m.col0, m.col1);
+  vec4f tmp1 = v_perm_xzac(m.col2, m.col3);
+  vec4f tmp2 = v_perm_ywbd(m.col0, m.col1);
+  vec4f tmp3 = v_perm_ywbd(m.col2, m.col3);
+  vec4f t0 = v_perm_xzac(tmp0, tmp1);
+  vec4f t1 = v_perm_xzac(tmp3, tmp2);
+  vec4f t2 = v_perm_ywbd(tmp0, tmp1);
+  vec4f t3 = v_perm_ywbd(tmp3, tmp2);
+
+  vec4f t23 = v_perm_yxwz(v_mul(t2, t3));
+  vec4f cof0 = v_mul(t1, t23);
+  cof0 = v_neg(v_nmsub(t1, v_rot_2(t23), cof0));
+  vec4f t12 = v_perm_yxwz(v_mul(t1, t2));
+  cof0 = v_madd(t3, t12, cof0);
+  cof0 = v_nmsub(t3, v_rot_2(t12), cof0);
+  vec4f t1r = v_rot_2(t1);
+  vec4f t2r = v_rot_2(t2);
+  vec4f t1r3 = v_perm_yxwz(v_mul(t1r, t3));
+  cof0 = v_madd(t2r, t1r3, cof0);
+  cof0 = v_nmsub(t2r, v_rot_2(t1r3), cof0);
+  return v_dot4(t0, cof0);
 }
 VECTORCALL VECMATH_FINLINE void v_mat44_inverse43(mat44f &dest, mat44f_cref m)
 {
@@ -707,36 +919,38 @@ VECTORCALL VECMATH_FINLINE vec4f v_mat44_det43(mat44f_cref m)
 {
   return v_dot3(m.col2, v_cross3(m.col0, m.col1));
 }
+VECTORCALL VECMATH_FINLINE vec3f v_mat44_scale43_sq(mat44f_cref tm)
+{
+  // transpose puts col0..col2 x/y/z into rows, so one wide mul + 2 madd yields all
+  // three squared column lengths at once (FMA-friendly, unlike 3 horizontal dots)
+  vec4f r0 = tm.col0, r1 = tm.col1, r2 = tm.col2, r3 = v_zero();
+  v_mat44_transpose(r0, r1, r2, r3);
+  return v_madd(r2, r2, v_madd(r1, r1, v_mul(r0, r0)));
+}
 VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_sq(mat44f_cref tm)
 {
-  vec4f xScaleSq = v_length3_sq(tm.col0);
-  vec4f yScaleSq = v_length3_sq(tm.col1);
-  vec4f zScaleSq = v_length3_sq(tm.col2);
-  return v_max(xScaleSq, v_max(yScaleSq, zScaleSq));
+  // full 4-lane hmax is valid: scale43_sq has w = 0 and squared scales are >= 0
+  return v_hmax(v_mat44_scale43_sq(tm));
 }
-VECTORCALL VECMATH_FINLINE void v_mat44_apply_scale43(mat44f &tm, vec3f scale)
+VECTORCALL VECMATH_FINLINE void v_mat44_apply_scale33(mat44f &tm, vec3f scale)
 {
   tm.col0 = v_mul(tm.col0, v_splat_x(scale));
   tm.col1 = v_mul(tm.col1, v_splat_y(scale));
   tm.col2 = v_mul(tm.col2, v_splat_z(scale));
 }
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43(mat44f_cref tm)
+VECTORCALL VECMATH_FINLINE void v_mat44_remove_scale33(mat44f &dest, mat44f_cref m)
 {
-  return v_sqrt(v_mat44_max_scale43_sq(tm));
+  vec4f invLen = v_rsqrt(v_mat44_scale43_sq(m)); // w lane is rsqrt(0), never read
+  dest = m;
+  v_mat44_apply_scale33(dest, invLen);
 }
 VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_x(mat44f_cref tm)
 {
-  vec4f xScaleSq = v_length3_sq_x(tm.col0);
-  vec4f yScaleSq = v_length3_sq_x(tm.col1);
-  vec4f zScaleSq = v_length3_sq_x(tm.col2);
-  return v_sqrt_x(v_max(xScaleSq, v_max(yScaleSq, zScaleSq)));
+  return v_sqrt_x(v_mat44_max_scale43_sq(tm));
 }
-VECTORCALL VECMATH_FINLINE vec3f v_mat44_scale43_sq(mat44f_cref tm)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43(mat44f_cref tm)
 {
-  vec4f xScaleSq = v_length3_sq(tm.col0);
-  vec4f yScaleSq = v_length3_sq(tm.col1);
-  vec4f zScaleSq = v_length3_sq(tm.col2);
-  return v_perm_xzac(v_perm_xycd(xScaleSq, yScaleSq), zScaleSq);
+  return v_splat_x(v_mat44_max_scale43_x(tm)); // scalar sqrt + splat, see v_length*
 }
 
 VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_bsph(mat44f_cref m, vec4f bsph)
@@ -774,27 +988,17 @@ VECTORCALL VECMATH_FINLINE void v_bbox3_init_ident(bbox3f &b)
 VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, vec3f p) { b.bmin = b.bmax = p; }
 VECTORCALL VECMATH_FINLINE void v_bbox3_rotate_init(bbox3f &b, vec3f col0, vec3f col1, vec3f col2, bbox3f_cref b2)
 {
-  vec4f boxMulM_0_0 = v_mul(v_splat_x(b2.bmin), col0);
-  vec4f boxMulM_0_1 = v_mul(v_splat_x(b2.bmax), col0);
-  vec4f boxMulM_1_0 = v_mul(v_splat_y(b2.bmin), col1);
-  vec4f boxMulM_1_1 = v_mul(v_splat_y(b2.bmax), col1);
-  vec4f boxMulM_2_0 = v_mul(v_splat_z(b2.bmin), col2);
-  vec4f boxMulM_2_1 = v_mul(v_splat_z(b2.bmax), col2);
-
-  vec4f boxSum_0_0 = v_add(boxMulM_1_0, boxMulM_2_0);
-  vec4f boxSum_0_1 = v_add(boxMulM_1_0, boxMulM_2_1);
-  vec4f boxSum_1_0 = v_add(boxMulM_1_1, boxMulM_2_0);
-  vec4f boxSum_1_1 = v_add(boxMulM_1_1, boxMulM_2_1);
-#define COMBINE_BOX(a,b,c) v_add(boxMulM_0_##a, boxSum_##b##_##c)
-  v_bbox3_init(  b, COMBINE_BOX(0, 0, 0));
-  v_bbox3_add_pt(b, COMBINE_BOX(0, 0, 1));
-  v_bbox3_add_pt(b, COMBINE_BOX(0, 1, 0));
-  v_bbox3_add_pt(b, COMBINE_BOX(0, 1, 1));
-  v_bbox3_add_pt(b, COMBINE_BOX(1, 0, 0));
-  v_bbox3_add_pt(b, COMBINE_BOX(1, 0, 1));
-  v_bbox3_add_pt(b, COMBINE_BOX(1, 1, 0));
-  v_bbox3_add_pt(b, COMBINE_BOX(1, 1, 1));
-#undef COMBINE_BOX
+  // AABB of the rotated box: transformed center +/- |M| * half-extent (Ericson RTCD 4.2.6).
+  vec4f center = v_bbox3_center(b2);
+  vec4f extent = v_mul(v_bbox3_size(b2), V_C_HALF);
+  vec4f c = v_mul(col0, v_splat_x(center));
+  c = v_madd(col1, v_splat_y(center), c);
+  c = v_madd(col2, v_splat_z(center), c);
+  vec4f e = v_mul(v_abs(col0), v_splat_x(extent));
+  e = v_madd(v_abs(col1), v_splat_y(extent), e);
+  e = v_madd(v_abs(col2), v_splat_z(extent), e);
+  b.bmin = v_sub(c, e);
+  b.bmax = v_add(c, e);
 }
 
 VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, mat33f_cref m, bbox3f b2)
@@ -941,158 +1145,132 @@ VECTORCALL VECMATH_FINLINE bool v_bbox3_test_pt_inside_xz(bbox3f b, vec3f p)
   return !v_test_vec_x_eqi_0(v_and(m, v_splat_z(m)));
 }
 
-// Checking only planes intersection! You need to test AvsB + BvsA and check inside case for each.
-VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect_no_check(bbox3f box0, bbox3f box1, const mat44f& tm1)
+// One SAT axis separates iff |projection of center offset| > sum of the two boxes' extents on it.
+// All three terms scale linearly with |axis|, so axes need not be normalized: a zero-length axis
+// (parallel edges) yields 0 > 0 and does not separate. The (1 + eps) slack biases the predicate toward
+// reporting intersection, so a just-touching pair is not spuriously separated by float rounding; the
+// bias is conservative (may keep a barely-separated pair) rather than an exactness guarantee. Each vec3f
+// packs one group of 3 sibling axes, so a lane holds one axis' verdict.
+VECTORCALL VECMATH_FINLINE vec3f v_obb_sat_group_separated(vec3f dist, vec3f ra, vec3f rb)
 {
-  vec3f msbit = v_msbit();
-  vec3f elemMask0 = v_cast_vec4f(v_seti_x(-1));
-
-  // testing intersection of 12 edges of box1 with 3 orthogonal planes of box0
-  for (int i = 0; i < 3; i++)
-  {
-    vec3f point0 = v_sel(v_zero(), box1.bmin, elemMask0);
-    vec3f point1 = v_sel(v_zero(), box1.bmax, elemMask0);
-    vec3f elemMask1 = v_perm_xycd(v_perm_xaxa(v_cmp_eqi(elemMask0, v_zero()), v_xor(elemMask0, v_zero())), v_zero()); // take Y on pass 0, and X on others
-    vec3f elemMask2 = v_cmp_eqi(v_or(elemMask0, elemMask1), v_zero());
-    elemMask0 = v_rot_3(elemMask0);
-
-    for (int j = 0; j < 2; j++)
-    {
-      vec3f box1LimJ = v_sel(box1.bmax, box1.bmin, v_cast_vec4f(v_splatsi(j - 1)));
-      point0 = v_sel(point0, box1LimJ, elemMask1);
-      point1 = v_sel(point1, box1LimJ, elemMask1);
-
-      for (int k = 0; k < 2; k++)
-      {
-        vec3f box1LimK = v_sel(box1.bmax, box1.bmin, v_cast_vec4f(v_splatsi(k - 1)));
-        point0 = v_sel(point0, box1LimK, elemMask2);
-        point1 = v_sel(point1, box1LimK, elemMask2);
-
-        // test segment point0-point1 against 3 orthogonal planes of box0
-        vec3f point0l = v_mat44_mul_vec3p(tm1, point0);
-        vec3f point1l = v_mat44_mul_vec3p(tm1, point1);
-        vec3f dir = v_sub(point1l, point0l);
-
-        vec3f dirGE0 = v_cmp_ge(dir, v_zero());
-        vec3f depth = v_sel(v_sub(point0l, box0.bmax),
-                            v_sub(box0.bmin, point0l),
-                            dirGE0);
-        vec3f length = v_abs(dir);
-        vec3f width = v_bbox3_size(box0);
-        vec3f nwidth = v_xor(width, msbit);
-        vec3f selectPi1 = v_and(v_cmp_gt(depth, v_zero()),
-                                v_cmp_lt(depth, length));
-        vec3f selectPi2 = v_and(v_cmp_gt(depth, nwidth),
-                                v_cmp_lt(v_sub(depth, length), nwidth));
-
-        vec3f validMask = v_or(selectPi1, selectPi2);
-        if (v_check_xyz_all_false(validMask))
-          continue;
-
-        vec3f selectMask = v_xor(selectPi1, dirGE0);
-        vec3f lim = v_sel(box0.bmin, box0.bmax, selectMask);
-        vec3f t = v_div(v_sub(lim, point0l), v_and(dir, validMask)); // gen NaN's for invalid
-
-        vec3f px = v_sub(v_lerp_vec4f(v_splat_x(t), point0l, point1l),
-                         v_sel(box0.bmin, box0.bmax, v_splat_x(selectMask)));
-        vec3f py = v_sub(v_lerp_vec4f(v_splat_y(t), point0l, point1l),
-                         v_sel(box0.bmin, box0.bmax, v_splat_y(selectMask)));
-        vec3f pz = v_sub(v_lerp_vec4f(v_splat_z(t), point0l, point1l),
-                         v_sel(box0.bmin, box0.bmax, v_splat_z(selectMask)));
-
-        vec3f selectMaskSign = v_and(selectMask, msbit);
-        vec4f pxpy = v_perm_xycd(v_perm_yzxy(px), v_perm_xzxz(py)); // yzac
-        pxpy = v_xor(pxpy, v_perm_xxyy(selectMaskSign));
-        pz = v_xor(pz, v_splat_z(selectMaskSign));
-
-        vec4f crossXY = v_and(v_cmp_ge(pxpy, v_zero()),
-                              v_cmp_le(pxpy, v_perm_xycd(v_perm_yzxy(width), v_perm_xzxz(width)))); // yzxz
-        vec4f crossZ = v_and(v_cmp_ge(pz, v_zero()),
-                             v_cmp_le(pz, width));
-        uint8_t signMask = uint8_t(v_signmask(crossXY) | (v_signmask(crossZ) << 4));
-        if (signMask & (signMask >> 1) & (1 << 0 | 1 << 2 | 1 << 4))
-          return true;
-      }
-    }
-  }
-
-  return false;
+  return v_cmp_gt(dist, v_mul(v_add(ra, rb), v_splats(1.0000001f)));
 }
 
-VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f box1, const mat44f& tm1)
+// AABB-vs-OBB overlap via the separating axis theorem (Ericson, RTCD 4.4.1), generalized to an arbitrary
+// tm1: B's axes are the columns of tm1 (scale/shear included) with half-extents kept in local space, so
+// no orthonormality is assumed. Returns true when box0 (axis-aligned in this frame) overlaps box1
+// transformed by tm1 into this frame. A complete overlap test in one call, with no pre-reject: this is
+// the _likely variant, for callers that already culled non-overlapping pairs (so almost all reaching here
+// overlap and no axis separates). The 15 axes are evaluated branchlessly in 5 SIMD groups of 3 and OR-ed
+// into a single verdict. It is a float predicate with a conservative tolerance (see v_obb_sat_group_
+// separated), not a bit-exact oracle; validated against a double-precision SAT over randomized and
+// adversarial near-parallel/large-magnitude sweeps without observed false negatives.
+VECTORCALL inline bool v_bbox3_test_trasformed_box_likely_intersect(const bbox3f& box0, const bbox3f& box1, const mat44f& tm1)
 {
-  // fast check for box1 completely inside box0, or not even roughly intersects
+  vec3f hafA = v_mul(v_bbox3_size(box0), V_C_HALF);
+  vec3f hafB = v_mul(v_bbox3_size(box1), V_C_HALF);
+  vec3f t = v_sub(v_mat44_mul_vec3p(tm1, v_bbox3_center(box1)), v_bbox3_center(box0));
+  vec3f aHafBx = v_splat_x(hafB), aHafBy = v_splat_y(hafB), aHafBz = v_splat_z(hafB);
+  vec3f aHafAx = v_splat_x(hafA), aHafAy = v_splat_y(hafA), aHafAz = v_splat_z(hafA);
+
+  vec3f bx = tm1.col0, by = tm1.col1, bz = tm1.col2;
+  vec3f absBx = v_abs(bx), absBy = v_abs(by), absBz = v_abs(bz);
+
+  // A's face normals e_x,e_y,e_z: projections are componentwise, so all 3 axes fit one vec3f.
+  // rowX/Y/Z are B's axes seen per component (rows of [bx by bz]); |L.b_k| on axis e_i reduces to |b_k[i]|.
+  mat33f rows;
+  v_mat33_transpose(rows, bx, by, bz);
+  vec3f rowX = rows.col0, rowY = rows.col1, rowZ = rows.col2;
+  vec3f absRowX = v_abs(rowX), absRowY = v_abs(rowY), absRowZ = v_abs(rowZ);
+  vec3f rbA = v_madd(absBx, aHafBx, v_madd(absBy, aHafBy, v_mul(absBz, aHafBz)));
+  vec3f sep = v_obb_sat_group_separated(v_abs(t), hafA, rbA);
+
+  // B's face normals = cross products of its edge pairs (handles a sheared box as a parallelepiped).
+  // Each is orthogonal to two of B's edges, so B's extent on it collapses to hafB[k]*|det(B)|.
+  vec3f c0 = v_cross3(by, bz), c1 = v_cross3(bz, bx), c2 = v_cross3(bx, by);
+  vec3f absDet = v_abs(v_dot3(bx, c0));
+  mat33f ct;
+  v_mat33_transpose(ct, c0, c1, c2);
+  vec3f distB = v_abs(v_mat33_mul_vec3(ct, t));
+  mat33f absCt = { v_abs(ct.col0), v_abs(ct.col1), v_abs(ct.col2) };
+  vec3f raB = v_mat33_mul_vec3(absCt, hafA);
+  sep = v_or(sep, v_obb_sat_group_separated(distB, raB, v_mul(hafB, absDet)));
+
+  // 9 edge-edge axes e_i x b_j, grouped by i (3 per vec3f, over j). L = e_i x b_j has a zero component,
+  // so dist/ra use the two nonzero rows and rb sums hafB[k]*|L.b_k| over the 3 columns.
+  vec3f tx = v_splat_x(t), ty = v_splat_y(t), tz = v_splat_z(t);
+  // i = x: L = (0, -b_j.z, b_j.y)
+  vec3f dist0 = v_abs_diff(v_mul(rowY, tz), v_mul(rowZ, ty));
+  vec3f ra0 = v_madd(absRowZ, aHafAy, v_mul(absRowY, aHafAz));
+  vec3f rb0 = v_madd(v_abs_diff(v_mul(rowY, v_splat_x(rowZ)), v_mul(rowZ, v_splat_x(rowY))), aHafBx,
+              v_madd(v_abs_diff(v_mul(rowY, v_splat_y(rowZ)), v_mul(rowZ, v_splat_y(rowY))), aHafBy,
+                 v_mul(v_abs_diff(v_mul(rowY, v_splat_z(rowZ)), v_mul(rowZ, v_splat_z(rowY))), aHafBz)));
+  sep = v_or(sep, v_obb_sat_group_separated(dist0, ra0, rb0));
+  // i = y: L = (b_j.z, 0, -b_j.x)
+  vec3f dist1 = v_abs_diff(v_mul(rowZ, tx), v_mul(rowX, tz));
+  vec3f ra1 = v_madd(absRowZ, aHafAx, v_mul(absRowX, aHafAz));
+  vec3f rb1 = v_madd(v_abs_diff(v_mul(rowZ, v_splat_x(rowX)), v_mul(rowX, v_splat_x(rowZ))), aHafBx,
+              v_madd(v_abs_diff(v_mul(rowZ, v_splat_y(rowX)), v_mul(rowX, v_splat_y(rowZ))), aHafBy,
+                 v_mul(v_abs_diff(v_mul(rowZ, v_splat_z(rowX)), v_mul(rowX, v_splat_z(rowZ))), aHafBz)));
+  sep = v_or(sep, v_obb_sat_group_separated(dist1, ra1, rb1));
+  // i = z: L = (-b_j.y, b_j.x, 0)
+  vec3f dist2 = v_abs_diff(v_mul(rowX, ty), v_mul(rowY, tx));
+  vec3f ra2 = v_madd(absRowY, aHafAx, v_mul(absRowX, aHafAy));
+  vec3f rb2 = v_madd(v_abs_diff(v_mul(rowX, v_splat_x(rowY)), v_mul(rowY, v_splat_x(rowX))), aHafBx,
+              v_madd(v_abs_diff(v_mul(rowX, v_splat_y(rowY)), v_mul(rowY, v_splat_y(rowX))), aHafBy,
+                 v_mul(v_abs_diff(v_mul(rowX, v_splat_z(rowY)), v_mul(rowY, v_splat_z(rowX))), aHafBz)));
+  sep = v_or(sep, v_obb_sat_group_separated(dist2, ra2, rb2));
+
+  return v_check_xyz_all_false(sep); // intersecting iff no axis separated
+}
+
+// same as the _likely variant but for callers that have NOT pre-culled the pair: rejects distant pairs
+// with a cheap transformed-AABB test before the SAT. Prefer _likely when the caller already culled.
+VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect(const bbox3f& box0, const bbox3f& box1, const mat44f& tm1)
+{
   bbox3f box1AABB;
   v_bbox3_init(box1AABB, tm1, box1);
-  if (!v_bbox3_test_box_intersect(box0, box1AABB)) // not even intersecting
+  if (!v_bbox3_test_box_intersect(box0, box1AABB))
     return false;
-  if (v_bbox3_test_box_inside(box0, box1AABB)) // fully inside
-    return true;
-  return v_bbox3_test_trasformed_box_intersect_no_check(box0, box1, tm1);
+  return v_bbox3_test_trasformed_box_likely_intersect(box0, box1, tm1);
 }
 
 VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
                                                                       vec4f size_factor)
 {
-  // validate
+  // scale up front (around each box center) so the reject sphere and the SAT operate on the same
+  // boxes; deriving the radius from the pre-scale box would be wrong for off-center boxes when
+  // size_factor < 1. A negative size_factor flips min/max and is rejected by the validity check below.
+  box0 = v_bbox3_scale(box0, size_factor);
+  box1 = v_bbox3_scale(box1, size_factor);
+
+  // validate: any dimension negative (also catches a negative size_factor)
   vec3f width0 = v_bbox3_size(box0);
   vec3f width1 = v_bbox3_size(box1);
-  if (v_signmask(v_or(width0, width1)) & (1 | 2 | 4)) // any of dimensions is negative
+  if (v_check_xyz_any_true(v_cmp_lt(v_min(width0, width1), v_zero())))
     return false;
 
-  // check boundings don't intersect
+  // boxes may be far apart, so reject by bounding spheres first: skips the matrix inverse + SAT
+  // (~half the total cost) for distant pairs. sphere centers are the two column3 positions; the radius
+  // bounds every corner via sum(boxMax_i * |col_i|), which stays conservative under shear -- |tm*corner|
+  // can exceed |tm*boxMax| when tm's columns are not orthogonal (the all-positive corner cancels).
   vec4f box0max = v_max(v_abs(box0.bmin), v_abs(box0.bmax));
   vec4f box1max = v_max(v_abs(box1.bmin), v_abs(box1.bmax));
-  vec4f r0 = v_length3_x(v_mat44_mul_vec3p(tm0, box0max));
-  vec4f r1 = v_length3_x(v_mat44_mul_vec3p(tm1, box1max));
-  vec4f r = v_mul_x(v_add_x(r0, r1), size_factor);
-  vec4f distSq = v_length3_sq_x(v_sub(tm1.col3, tm0.col3));
-  if (v_test_vec_x_gt(distSq, v_mul_x(r, r)))
+  float r0 = v_extract_x(box0max) * v_extract_x(v_length3_x(tm0.col0)) +
+             v_extract_y(box0max) * v_extract_x(v_length3_x(tm0.col1)) +
+             v_extract_z(box0max) * v_extract_x(v_length3_x(tm0.col2));
+  float r1 = v_extract_x(box1max) * v_extract_x(v_length3_x(tm1.col0)) +
+             v_extract_y(box1max) * v_extract_x(v_length3_x(tm1.col1)) +
+             v_extract_z(box1max) * v_extract_x(v_length3_x(tm1.col2));
+  float dist = v_extract_x(v_distance_xyz_x(tm1.col3, tm0.col3));
+  if (dist > r0 + r1)
     return false;
 
-  // bbox intersection check
-  mat44f tm;
-  v_mat44_inverse43(tm, tm0);
-  v_mat44_mul43(tm, tm, tm1);
-  if (v_bbox3_test_trasformed_box_intersect(v_bbox3_scale(box0, size_factor), box1, tm))
-    return true;
-
-  v_mat44_inverse43(tm, tm1);
-  v_mat44_mul43(tm, tm, tm0);
-  if (v_bbox3_test_trasformed_box_intersect(v_bbox3_scale(box1, size_factor), box0, tm)) //-V764 box1, box order is correct
-    return true;
-
-  return false;
-}
-
-VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1)
-{
-  return v_bbox3_test_trasformed_box_intersect(box0, tm0, box1, tm1, V_C_ONE);
-}
-
-VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect_rel_tm(bbox3f box0, const mat44f& b0_to_b1,
-                                                                             bbox3f box1, const mat44f& b1_to_b0)
-{
-  bbox3f box1inb0;
-  v_bbox3_init(box1inb0, b1_to_b0, box1);
-  if (!v_bbox3_test_box_intersect(box0, box1inb0)) // not even intersecting
-    return false;
-  if (v_bbox3_test_box_inside(box0, box1inb0)) // fully inside
-    return true;
-
-  bbox3f box0inb1;
-  v_bbox3_init(box0inb1, b0_to_b1, box0);
-  if (!v_bbox3_test_box_intersect(box1, box0inb1)) // not even intersecting
-    return false;
-  if (v_bbox3_test_box_inside(box1, box0inb1)) // fully inside
-    return true;
-
-  if (v_bbox3_test_trasformed_box_intersect_no_check(box0, box1, b1_to_b0))
-    return true;
-  if (v_bbox3_test_trasformed_box_intersect_no_check(box1, box0, b0_to_b1)) //-V764 box1, box0 order is correct
-    return true;
-
-  return false;
+  // bring box1 into box0's frame and run the exact SAT (boxes already scaled)
+  mat44f b1_to_b0;
+  v_mat44_inverse43(b1_to_b0, tm0);
+  v_mat44_mul43(b1_to_b0, b1_to_b0, tm1);
+  return v_bbox3_test_trasformed_box_likely_intersect(box0, box1, b1_to_b0);
 }
 
 VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_get_box_intersection(bbox3f box0, bbox3f box1)
@@ -1171,8 +1349,8 @@ VECMATH_FINLINE bool v_bsph_test_sph_inside(vec4f sph_a, vec4f sph_a_rad_sq_x, v
 
 VECMATH_FINLINE bool v_bsph_test_box_inside(vec4f sph, vec4f sph_rad_sq_x, bbox3f b)
 {
-  vec4f d1 = v_abs(v_sub(sph, b.bmin));
-  vec4f d2 = v_abs(v_sub(sph, b.bmax));
+  vec4f d1 = v_abs_diff(sph, b.bmin);
+  vec4f d2 = v_abs_diff(sph, b.bmax);
   vec4f r = v_length3_sq_x(v_max(d1, d2));
   return v_test_vec_x_lt(r, sph_rad_sq_x);
 }
@@ -1243,8 +1421,8 @@ VECMATH_FINLINE vec4f v_bsph_bsph_best_sum_unsafe(vec4f a, vec4f b)
 
 VECMATH_FINLINE vec4f v_bsph_bbox_best_sum_unsafe(vec4f bsph, bbox3f bbox)
 {
-  vec3f mind = v_abs(v_sub(bbox.bmin, bsph));
-  vec3f maxd = v_abs(v_sub(bbox.bmax, bsph));
+  vec3f mind = v_abs_diff(bbox.bmin, bsph);
+  vec3f maxd = v_abs_diff(bbox.bmax, bsph);
   vec3f p = v_sel(bbox.bmax, bbox.bmin, v_cmp_ge(mind, maxd));
   return v_bsph_pt_best_sum_unsafe(bsph, p);
 }
@@ -1290,8 +1468,8 @@ VECMATH_FINLINE void v_bsph_add_bsph_unsafe(vec4f& a, vec4f b)
 
 VECMATH_FINLINE void v_bsph_add_bbox_unsafe(vec4f& sph, bbox3f b)
 {
-  vec4f d1 = v_abs(v_sub(sph, b.bmin));
-  vec4f d2 = v_abs(v_sub(sph, b.bmax));
+  vec4f d1 = v_abs_diff(sph, b.bmin);
+  vec4f d2 = v_abs_diff(sph, b.bmax);
   vec4f r = v_length3(v_max(d1, d2));
   sph = v_perm_xyzd(sph, v_max(sph, r));
 }
@@ -1310,7 +1488,9 @@ VECTORCALL VECMATH_FINLINE vec3f v_quat_mul_vec3(quat4f q, vec3f v)
   return v_add(v, v_madd(v_splat_w(q), t, v_cross3(q, t)));//v + q.w * t + v_cross3(q.xyz, t);
 }
 
-VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat(vec3f col0, vec3f col1, vec3f col2)
+// fast path: columns MUST be orthonormal (scale-free). Result is a normalized rotation.
+// For scaled/unnormalized input use v_quat_from_mat*, which removes scale first.
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_orthonormal_mat(vec3f col0, vec3f col1, vec3f col2)
 {
   /* compute quaternion for each case */
   vec4f _yz_ = v_perm_xycd(col1, col2);
@@ -1341,36 +1521,72 @@ VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat(vec3f col0, vec3f col1, vec3f 
 
   vec4f q = v_sel(res0, res1, v_cmp_gt(yy, xx));
   q = v_sel(q, res2, v_and(v_cmp_gt(zz, xx), v_cmp_gt(zz, yy)));
-  return v_norm4(v_sel(q, res3, v_cmp_ge(v_splat_x(diagSum), v_zero())));
+  // no final normalize: 0.5*rsqrt(radicand) already yields a unit quaternion for orthonormal
+  // input (unit to 4e-7, rotation error 1.6e-6)
+  return v_sel(q, res3, v_cmp_ge(v_splat_x(diagSum), v_zero()));
 }
 
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_orthonormal_mat33(mat33f_cref m)
+{
+  return v_quat_from_orthonormal_mat(m.col0, m.col1, m.col2);
+}
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_orthonormal_mat43(mat44f_cref m)
+{
+  return v_quat_from_orthonormal_mat(m.col0, m.col1, m.col2);
+}
+
+// robust path: accepts any non-degenerate matrix. Removes per-column scale (one packed rsqrt via
+// v_mat33_remove_scale), flips col2 on a mirrored basis (det < 0, which a quat cannot represent -
+// same convention v_mat33_decompose uses, folding negative det into scale.z), and normalizes the
+// result, since scale removal does not fix sheared (non-orthogonal) columns.
+// Prefer v_quat_from_orthonormal_mat* for known pure rotations - it skips all three extra steps.
 VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat33(mat33f_cref m)
 {
-  return v_quat_from_mat(m.col0, m.col1, m.col2);
+  mat33f n;
+  v_mat33_remove_scale(n, m);
+  vec4f mirrored = v_cmp_lt(v_mat33_det(m), v_zero());
+  n.col2 = v_sel(n.col2, v_neg(n.col2), mirrored);
+  return v_norm4(v_quat_from_orthonormal_mat(n.col0, n.col1, n.col2));
+}
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat(vec3f col0, vec3f col1, vec3f col2)
+{
+  mat33f m;
+  m.col0 = col0;
+  m.col1 = col1;
+  m.col2 = col2;
+  return v_quat_from_mat33(m);
 }
 VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat43(mat44f_cref m)
 {
   return v_quat_from_mat(m.col0, m.col1, m.col2);
 }
 
+// 180 deg rotation taking a unit v0 to -v0 (opposite-vectors fallback of the arc quaternions);
+// result has w == 0 exactly. The axis is perpendicular to v0 to within |v0.x|, which is bounded
+// by the unsafe-divisor threshold below - a negligible (~1e-19) angular error.
+VECTORCALL VECMATH_FINLINE quat4f v_quat_180_from_unit(vec3f v0)
+{
+  // (v0.y, -v0.x, 0, 0) is exactly perpendicular to v0; its length x^2+y^2 stays >= the
+  // safe-under-squaring threshold unless |v0.x| is tiny, where the exactly-unit X axis (1,0,0,0)
+  // is used - perpendicular to within |v0.x|. The threshold keeps the length safe under FTZ.
+  vec4f perpXY = v_perm_xyab(v_perm_yaxx(v0, v_neg(v0)), v_zero());
+  return v_norm4(v_sel(perpXY, V_C_UNIT_1000, v_is_unsafe_divisor(v_splat_x(v0))));
+}
+
 //! make quaternion to rotate 'v0' to 'v1'; v0 and v1 must be normalized
 VECTORCALL VECMATH_FINLINE quat4f v_quat_from_unit_arc(vec3f v0, vec3f v1)
 {
   vec4f cosAngle = v_dot3(v0, v1);
-  vec4f cosAngleX2Plus2 = v_madd_x(cosAngle, V_C_TWO, V_C_TWO);
-  if (v_extract_x(cosAngleX2Plus2) > 1e-4)
+  vec4f cosAngleX2Plus2 = v_madd_x(cosAngle, V_C_TWO, V_C_TWO); // 2(1+cos) = |(cross, 1+cos)|^2
+  if (v_extract_x(cosAngleX2Plus2) > 1e-4f)
   {
-    vec3f crossVec = v_cross3(v0, v1);
-    vec4f recipCosHalfAngleX2 = v_rsqrt_x(cosAngleX2Plus2);
-    vec4f cosHalfAngleX2 = v_mul_x(recipCosHalfAngleX2, cosAngleX2Plus2);
-    return v_perm_xyzd(
-      v_mul(crossVec, v_splat_x(recipCosHalfAngleX2)),
-      v_splat_x(v_mul_x(cosHalfAngleX2, V_C_HALF)));
+    // q = (cross, 1+cos) normalized by its length sqrt(k)
+    vec4f len = v_splat_x(v_sqrt_x(cosAngleX2Plus2));
+    vec4f onePlusCos = v_splat_x(v_mul_x(cosAngleX2Plus2, V_C_HALF)); // splat so perm_xyzd sees it in .w
+    quat4f q = v_perm_xyzd(v_cross3(v0, v1), onePlusCos);
+    return v_div(q, len);
   }
-  // slow path for opposite vectors
-  if (v_test_vec_x_eq_0(v0))
-    return v_norm4(v_perm_xzbx(v_mul(v0, V_C_UNIT_0010), v_neg(v0)));
-  return v_norm4(v_perm_yaxx(v_mul(v0, V_C_UNIT_0100), v_neg(v0)));
+  return v_quat_180_from_unit(v0); // opposite vectors
 }
 
 //! make quaternion to rotate 'v0' to 'v1'
@@ -1378,20 +1594,17 @@ VECTORCALL VECMATH_FINLINE quat4f v_quat_from_arc(vec3f v0, vec3f v1)
 {
   vec4f inv_len_product = v_rsqrt_x(v_mul_x(v_length3_sq_x(v0), v_length3_sq_x(v1)));
   vec4f cosAngle = v_mul_x(v_dot3(v0, v1), inv_len_product);
-  vec4f cosAngleX2Plus2 = v_madd_x(cosAngle, V_C_TWO, V_C_TWO);
-  if (v_extract_x(cosAngleX2Plus2) > 1e-4)
+  vec4f cosAngleX2Plus2 = v_madd_x(cosAngle, V_C_TWO, V_C_TWO); // 2(1+cos)
+  if (v_extract_x(cosAngleX2Plus2) > 1e-4f)
   {
-    vec3f crossVec = v_cross3(v0, v1);
-    vec4f recipCosHalfAngleX2 = v_rsqrt_x(cosAngleX2Plus2);
-    vec4f cosHalfAngleX2 = v_mul_x(recipCosHalfAngleX2, cosAngleX2Plus2);
-    return v_perm_xyzd(
-      v_mul(crossVec, v_splat_x(v_mul_x(recipCosHalfAngleX2, inv_len_product))),
-      v_splat_x(v_mul_x(cosHalfAngleX2, V_C_HALF)));
+    // cross has magnitude len0*len1*sin, so scale it to unit by inv_len_product before normalizing
+    vec3f crossVec = v_mul(v_cross3(v0, v1), v_splat_x(inv_len_product));
+    vec4f len = v_splat_x(v_sqrt_x(cosAngleX2Plus2));
+    vec4f onePlusCos = v_splat_x(v_mul_x(cosAngleX2Plus2, V_C_HALF)); // splat so perm_xyzd sees it in .w
+    quat4f q = v_perm_xyzd(crossVec, onePlusCos);
+    return v_div(q, len);
   }
-  // slow path for opposite vectors
-  if (v_test_vec_x_eq_0(v0))
-    return v_norm4(v_perm_xzbx(v_mul(v0, V_C_UNIT_0010), v_neg(v0)));
-  return v_norm4(v_perm_yaxx(v_mul(v0, V_C_UNIT_0100), v_neg(v0)));
+  return v_quat_180_from_unit(v_norm3(v0)); // opposite vectors; normalize so the X-axis fallback is valid
 }
 
 //! make quaternion to rotate 'ang' radians around 'v' vector; v must be normalized
@@ -1460,11 +1673,12 @@ VECTORCALL inline quat4f v_quat_slerp(vec4f t, quat4f a, quat4f b)
   }
   b = v_xor(b, v_and(f, v_msbit()));
   vec4f w = v_acos(absF);
-  vec4f invsinw = v_rsqrt(v_sub(V_C_ONE, v_sqr(f)));
-  vec4f s = v_sin(v_mul(w, v_perm_xyab(v_sub(V_C_ONE, t), t)));
+  // pack (1-t, t, 1, 1) so one sin yields both numerators and sin(w); computing sin(w) from the
+  // same polynomial as the numerators cancels error in the ratio
+  vec4f s = v_sin(v_mul(w, v_perm_xyab(v_merge_hw(v_sub(V_C_ONE, t), t), V_C_ONE)));
   vec4f l = v_mul(a, v_splat_x(s));
-  vec4f r = v_mul(b, v_splat_z(s));
-  return v_mul(v_add(l, r), invsinw);
+  vec4f r = v_mul(b, v_splat_y(s));
+  return v_div(v_add(l, r), v_splat_z(s));
 }
 
 VECTORCALL VECMATH_FINLINE quat4f v_quat_qslerp(float t, quat4f l, quat4f r)
@@ -1517,7 +1731,7 @@ VECTORCALL VECMATH_FINLINE void v_quat_decompose_swing_twist(quat4f q, vec3f dir
 {
   // http://www.euclideanspace.com/maths/geometry/rotations/for/decomposition/
   vec3f p = v_mul(v_dot3(q, dir), dir);
-  twist = v_norm4_safe(v_perm_xyzW(p, q), V_C_UNIT_0001);
+  twist = v_norm4_safe(v_perm_xyzd(p, q), V_C_UNIT_0001);
   swing = v_quat_mul_quat(q, v_quat_conjugate(twist));
 }
 
@@ -1527,7 +1741,7 @@ VECTORCALL VECMATH_FINLINE void v_quat_decompose_swing_twist(quat4f q, vec3f dir
 VECTORCALL VECMATH_FINLINE void v_quat_decompose_twist_swing(quat4f q, vec3f dir, quat4f& twist, quat4f& swing)
 {
   vec3f p = v_mul(v_dot3(q, dir), dir);
-  twist = v_norm4_safe(v_perm_xyzW(p, q), V_C_UNIT_0001);
+  twist = v_norm4_safe(v_perm_xyzd(p, q), V_C_UNIT_0001);
   swing = v_quat_mul_quat(v_quat_conjugate(twist), q);
 }
 
@@ -1626,33 +1840,24 @@ VECTORCALL VECMATH_FINLINE void v_mat44_compose(mat44f &dest, vec4f pos, quat4f 
 //! decompose 3x3 matrix to rotation/scale
 VECTORCALL VECMATH_FINLINE void v_mat33_decompose(mat33f_cref tm, quat4f &rot, vec4f &scl)
 {
-  scl = v_mat44_scale43_sq(mat44f{tm.col0, tm.col1, tm.col2});
-  scl = v_sqrt(scl);
+  mat44f m{tm.col0, tm.col1, tm.col2};
+  scl = v_sqrt(v_mat44_scale43_sq(m));
   if (v_test_vec_x_lt_0(v_mat33_det(tm)))
     scl = v_perm_xycw(scl, v_neg(scl));
 
-  vec3f invScl = v_rcp_safe(scl);
-  rot = v_quat_from_mat(
-    v_mul(tm.col0, v_splat_x(invScl)),
-    v_mul(tm.col1, v_splat_y(invScl)),
-    v_mul(tm.col2, v_splat_z(invScl)));
+  // divide scale out; the basis can still be sheared or degenerate, which the
+  // orthonormal path does not tolerate, so keep the contract that rot is unit
+  v_mat44_apply_scale33(m, v_rcp_safe(scl));
+  rot = v_norm4(v_quat_from_orthonormal_mat43(m));
 }
 
 //! decompose 4x4 matrix to position/rotation/scale
 VECTORCALL VECMATH_FINLINE void v_mat4_decompose(mat44f_cref tm, vec3f &pos, quat4f &rot, vec4f &scl)
 {
   pos = tm.col3;
-
-  scl = v_mat44_scale43_sq(tm);
-  scl = v_sqrt(scl);
-  if (v_test_vec_x_lt_0(v_mat44_det43(tm)))
-    scl = v_perm_xycw(scl, v_neg(scl));
-
-  vec3f invScl = v_rcp_safe(scl);
-  rot = v_quat_from_mat(
-    v_mul(tm.col0, v_splat_x(invScl)),
-    v_mul(tm.col1, v_splat_y(invScl)),
-    v_mul(tm.col2, v_splat_z(invScl)));
+  mat33f m3;
+  v_mat33_from_mat44(m3, tm);
+  v_mat33_decompose(m3, rot, scl);
 }
 
 //! make rotational matrix 3x3 to rotate 'ang' radians around 'v'
@@ -1782,7 +1987,7 @@ VECTORCALL VECMATH_FINLINE vec3f v_unsafe_ray_intersect_plane(vec3f point, vec3f
   return v_madd(t, dir, point);
 }
 
-VECTORCALL VECMATH_FINLINE vec3f closest_point_on_segment(vec3f point, vec3f a, vec3f b)
+VECTORCALL VECMATH_FINLINE vec3f v_closest_point_on_segment(vec3f point, vec3f a, vec3f b)
 {
   vec3f ap = v_sub(point, a);
   vec3f ab = v_sub(b, a);
@@ -1791,7 +1996,7 @@ VECTORCALL VECMATH_FINLINE vec3f closest_point_on_segment(vec3f point, vec3f a, 
   return v_madd(v_safediv(ab, lenSq), t, a);
 }
 
-VECTORCALL VECMATH_FINLINE void vis_transform_points_4(vec4f* dest, vec4f x, vec4f y, vec4f z, mat44f_cref mat)
+VECTORCALL VECMATH_FINLINE void v_is_transform_points_4(vec4f* dest, vec4f x, vec4f y, vec4f z, mat44f_cref mat)
 {
 #define COMP(c, attr) \
   vec4f res_ ## c = v_splat_##attr(mat.col3); \
@@ -1806,7 +2011,7 @@ VECTORCALL VECMATH_FINLINE void vis_transform_points_4(vec4f* dest, vec4f x, vec
 #undef COMP
 }
 
-VECTORCALL VECMATH_FINLINE void vis_transform_points_4(vec4f* dest, vec4f x, vec4f y, mat44f_cref mat)
+VECTORCALL VECMATH_FINLINE void v_is_transform_points_4(vec4f* dest, vec4f x, vec4f y, mat44f_cref mat)
 {
 #define COMP(c, attr) \
   vec4f res_ ## c = v_splat_##attr(mat.col3); \
@@ -1820,20 +2025,78 @@ VECTORCALL VECMATH_FINLINE void vis_transform_points_4(vec4f* dest, vec4f x, vec
 #undef COMP
 }
 
-#if _TARGET_SIMD_SSE
-VECTORCALL VECMATH_FINLINE int v_test_vec_mask_eq_0(vec4f v) { return (~unsigned(-_mm_movemask_ps(v))) >> 31; }
-VECTORCALL VECMATH_FINLINE int v_test_vec_mask_neq_0(vec4f v) { return (unsigned(-_mm_movemask_ps(v))) >> 31; }
-#else
-VECTORCALL VECMATH_FINLINE int v_test_vec_mask_eq_0(vec4f v)
+// shared core of the v_is_visible* / v_screen_size_b family
+
+// transform the 8 aabb corners to clip space as two z-slices, each SoA: [xxxx],[yyyy],[zzzz],[wwww]
+// one clip-matrix row applied to 4 xy points at two z levels; the z slices share x and y,
+// so the x/y part is built once and each z is added on top
+VECTORCALL VECMATH_FINLINE void v_is_transform_row_2z(vec4f x, vec4f y, vec4f minz, vec4f maxz,
+  vec4f row_x, vec4f row_y, vec4f row_z, vec4f row_w, vec4f &out0, vec4f &out1)
 {
-  return v_test_vec_x_eqi_0(v_cast_vec4f(v_srli(v_cast_vec4i(v_hor(v)), 31)));
+  vec4f base = v_madd(x, row_x, row_w);
+  base = v_madd(y, row_y, base);
+  out0 = v_madd(minz, row_z, base);
+  out1 = v_madd(maxz, row_z, base);
 }
 
-VECTORCALL VECMATH_FINLINE int v_test_vec_mask_neq_0(vec4f v)
+VECTORCALL VECMATH_FINLINE void v_is_transform_box_8(vec3f bmin, vec3f bmax, mat44f_cref clip,
+  vec4f cs0[4], vec4f cs1[4], vec4f &cs0_negw, vec4f &cs1_negw)
 {
-  return !v_test_vec_mask_eq_0(v);
+  vec4f minmax_x = v_perm_xaxa(bmin, bmax);
+  vec4f minmax_y = v_perm_yybb(bmin, bmax);
+  vec4f minz = v_splat_z(bmin);
+  vec4f maxz = v_splat_z(bmax);
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz,
+    v_splat_x(clip.col0), v_splat_x(clip.col1), v_splat_x(clip.col2), v_splat_x(clip.col3), cs0[0], cs1[0]);
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz,
+    v_splat_y(clip.col0), v_splat_y(clip.col1), v_splat_y(clip.col2), v_splat_y(clip.col3), cs0[1], cs1[1]);
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz,
+    v_splat_z(clip.col0), v_splat_z(clip.col1), v_splat_z(clip.col2), v_splat_z(clip.col3), cs0[2], cs1[2]);
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz,
+    v_splat_w(clip.col0), v_splat_w(clip.col1), v_splat_w(clip.col2), v_splat_w(clip.col3), cs0[3], cs1[3]);
+  cs0_negw = v_neg(cs0[3]);
+  cs1_negw = v_neg(cs1[3]);
 }
-#endif
+
+// mask of the 8 points (two slices) on the inner side of one clip plane, i.e. coord > bound
+VECTORCALL VECMATH_FINLINE vec4f v_is_plane_inside_mask(vec4f coord0, vec4f bound0, vec4f coord1, vec4f bound1)
+{
+  return v_or(v_cmp_gt(coord0, bound0), v_cmp_gt(coord1, bound1));
+}
+
+// -1 if some point is on the inner side of every clip plane (x,y in [-w,w], z in [0,w]), 0 otherwise
+VECTORCALL VECMATH_FINLINE int v_is_frustum_nout_8(const vec4f cs0[4], vec4f cs0_negw, const vec4f cs1[4], vec4f cs1_negw)
+{
+  vec4f inXlo = v_is_plane_inside_mask(cs0[0], cs0_negw, cs1[0], cs1_negw);  // -w <= x
+  vec4f inXhi = v_is_plane_inside_mask(cs0[3], cs0[0],   cs1[3], cs1[0]);    //  x <= w
+  vec4f inYlo = v_is_plane_inside_mask(cs0[1], cs0_negw, cs1[1], cs1_negw);  // -w <= y
+  vec4f inYhi = v_is_plane_inside_mask(cs0[3], cs0[1],   cs1[3], cs1[1]);    //  y <= w
+  vec4f inZlo = v_is_plane_inside_mask(cs0[2], v_zero(), cs1[2], v_zero());  //  0 <= z
+  vec4f inZhi = v_is_plane_inside_mask(cs0[3], cs0[2],   cs1[3], cs1[2]);    //  z <= w
+  return v_is_merge_planes_nout(inXlo, inXhi, inYlo, inYhi, inZlo, inZhi);
+}
+
+// project 4 clip-space points to NDC and reduce to per-lane xy min/max (result still holds 2 points)
+VECTORCALL VECMATH_FINLINE void v_is_screen_project_minmax(const vec4f cs[4], vec4f &minXY, vec4f &maxXY)
+{
+  vec4f inv = v_rcp(cs[3]);
+  vec4f xxxx = v_mul(cs[0], inv);
+  vec4f yyyy = v_mul(cs[1], inv);
+  vec4f point01 = v_merge_hw(xxxx, yyyy);//xy, xy
+  vec4f point23 = v_merge_lw(xxxx, yyyy);//xy, xy
+  minXY = v_min(point01, point23);
+  maxXY = v_max(point01, point23);
+}
+
+// reduce xy min/max to screen_box (minX, maxX, minY, maxY); 0 if smaller than threshold in x or y, else 1
+VECTORCALL VECMATH_FINLINE int v_is_screen_finish(vec4f minXY, vec4f maxXY, vec3f threshold, vec4f &screen_box)
+{
+  minXY = v_min(minXY, v_rot_2(minXY));
+  maxXY = v_max(maxXY, v_rot_2(maxXY));
+  screen_box = v_merge_hw(minXY, maxXY);
+  vec4f tooSmall = v_cmp_ge(threshold, v_sub(maxXY, minXY));
+  return v_check_xy_any_true(tooSmall) ? 0 : 1;
+}
 
 //universal visibility function (accepts worldviewproj matrix)
 
@@ -1841,93 +2104,20 @@ VECTORCALL VECMATH_FINLINE int v_test_vec_mask_neq_0(vec4f v)
 ///really fast, ~0.075 us per test on PS3
 
 ///for branching: (~v_test_vec_x_eqi_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
-VECTORCALL VECMATH_FINLINE vec4f v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_INLINE vec4f v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
-  vec4f zero = v_zero();
-
-  // get aabb points (SoA)
-  vec4f minmax_x = v_perm_xXxX(bmin, bmax);
-  vec4f minmax_y = v_perm_yyYY(bmin, bmax);
-  vec4f minmax_z_0 = v_splat_z(bmin);
-  vec4f minmax_z_1 = v_splat_z(bmax);
-
-  // transform points to clip space
-  vec4f points_cs_0[4];
-  vec4f points_cs_1[4];
-
-  vis_transform_points_4(points_cs_0, minmax_x, minmax_y, minmax_z_0, clip);
-  vis_transform_points_4(points_cs_1, minmax_x, minmax_y, minmax_z_1, clip);
-
-  // calculate -w
-  vec4f points_cs_0_negw = v_neg(points_cs_0[3]);
-  vec4f points_cs_1_negw = v_neg(points_cs_1[3]);
-
-  // for each plane...
-  #define NOUT(a, b, c, d) v_hor(v_or(v_cmp_gt(a, b), v_cmp_gt(c, d)))
-
-  vec4f nout0 = NOUT(points_cs_0[0], points_cs_0_negw, points_cs_1[0], points_cs_1_negw);
-  vec4f nout1 = NOUT(points_cs_0[3], points_cs_0[0], points_cs_1[3], points_cs_1[0]);
-  vec4f nout2 = NOUT(points_cs_0[1], points_cs_0_negw, points_cs_1[1], points_cs_1_negw);
-  vec4f nout3 = NOUT(points_cs_0[3], points_cs_0[1], points_cs_1[3], points_cs_1[1]);
-  vec4f nout4 = NOUT(points_cs_0[2], zero, points_cs_1[2], zero);
-  vec4f nout5 = NOUT(points_cs_0[3], points_cs_0[2], points_cs_1[3], points_cs_1[2]);
-
-  #undef NOUT
-
-  // merge "not outside" flags
-  vec4f nout01 = v_and(nout0, nout1);
-  vec4f nout012 = v_and(nout01, nout2);
-
-  vec4f nout34 = v_and(nout3, nout4);
-  vec4f nout345 = v_and(nout34, nout5);
-
-  vec4f nout = v_and(nout012, nout345);
-
-  return nout;
+  vec4f cs0[4], cs1[4], cs0_negw, cs1_negw;
+  v_is_transform_box_8(bmin, bmax, clip, cs0, cs1, cs0_negw, cs1_negw);
+  // reduce each plane to a bit and broadcast the 0/-1 result once
+  return v_cast_vec4f(v_splatsi(v_is_frustum_nout_8(cs0, cs0_negw, cs1, cs1_negw)));
 }
 
-#if _TARGET_SIMD_SSE
-VECTORCALL VECMATH_FINLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_INLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
-  // get aabb points (SoA)
-  vec4f minmax_x = v_perm_xXxX(bmin, bmax);
-  vec4f minmax_y = v_perm_yyYY(bmin, bmax);
-  vec4f minmax_z_0 = v_splat_z(bmin);
-  vec4f minmax_z_1 = v_splat_z(bmax);
-
-  // transform points to clip space
-  vec4f points_cs_0[4];
-  vec4f points_cs_1[4];
-
-  vis_transform_points_4(points_cs_0, minmax_x, minmax_y, minmax_z_0, clip);
-  vis_transform_points_4(points_cs_1, minmax_x, minmax_y, minmax_z_1, clip);
-
-  // calculate -w
-  vec4f points_cs_0_negw = v_neg(points_cs_0[3]);
-  vec4f points_cs_1_negw = v_neg(points_cs_1[3]);
-
-  // for each plane...
-  #define NOUT(a, b, c, d) (unsigned(-_mm_movemask_ps(v_or(v_cmp_gt(a, b), v_cmp_gt(c, d)))))
-  unsigned nout;
-  nout = (NOUT(points_cs_0[0], points_cs_0_negw, points_cs_1[0], points_cs_1_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[0], points_cs_1[3], points_cs_1[0]));
-  nout &= (NOUT(points_cs_0[1], points_cs_0_negw, points_cs_1[1], points_cs_1_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[1], points_cs_1[3], points_cs_1[1]));
-  nout &= (NOUT(points_cs_0[2], v_zero(), points_cs_1[2], v_zero()));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[2], points_cs_1[3], points_cs_1[2]));
-
-  #undef NOUT
-
-  // merge "not outside" flags
-  return nout>>31;
+  vec4f cs0[4], cs1[4], cs0_negw, cs1_negw;
+  v_is_transform_box_8(bmin, bmax, clip, cs0, cs1, cs0_negw, cs1_negw);
+  return -v_is_frustum_nout_8(cs0, cs0_negw, cs1, cs1_negw); // 0 or 1
 }
-#else
-VECTORCALL VECMATH_FINLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
-{
-  vec4f ret = v_is_visible(bmin, bmax, clip);
-  return (~v_test_vec_x_eqi_0(ret))&1;
-}
-#endif
 
 VECTORCALL VECMATH_FINLINE void v_construct_camplanes(mat44f_cref clip,
   vec4f &camPlanes0, vec4f &camPlanes1, vec4f &camPlanes2, vec4f &camPlanes3, vec4f &camPlanes4, vec4f &camPlanes5)
@@ -1942,19 +2132,55 @@ VECTORCALL VECMATH_FINLINE void v_construct_camplanes(mat44f_cref clip,
   camPlanes5 = m2.col2;  // near if forward depth (far otherwise)
 }
 
+// solve 4 three-plane intersections at once: lane i is the corner of planes (a_i, b_i, c);
+// p = -(a.w*(b x c) + b.w*(c x a) + c.w*(a x b)) / (a . (b x c)), a x b passed in (shared by batches)
+VECTORCALL VECMATH_FINLINE void v_frustum_corners_4(vec4f ax, vec4f ay, vec4f az, vec4f aw,
+  vec4f bx, vec4f by, vec4f bz, vec4f bw, vec4f abx, vec4f aby, vec4f abz, vec4f c,
+  vec4f &px, vec4f &py, vec4f &pz)
+{
+  vec4f cx = v_splat_x(c), cy = v_splat_y(c), cz = v_splat_z(c), cw = v_splat_w(c);
+  vec4f bcx = v_nmsub(bz, cy, v_mul(by, cz)); // b x c
+  vec4f bcy = v_nmsub(bx, cz, v_mul(bz, cx));
+  vec4f bcz = v_nmsub(by, cx, v_mul(bx, cy));
+  vec4f cax = v_nmsub(cz, ay, v_mul(cy, az)); // c x a
+  vec4f cay = v_nmsub(cx, az, v_mul(cz, ax));
+  vec4f caz = v_nmsub(cy, ax, v_mul(cx, ay));
+  vec4f den = v_madd(ax, bcx, v_madd(ay, bcy, v_mul(az, bcz)));
+  vec4f inv = v_rcp(den);
+  px = v_mul(v_nmsub(abx, cw, v_nmsub(cax, bw, v_nmsub(bcx, aw, v_zero()))), inv);
+  py = v_mul(v_nmsub(aby, cw, v_nmsub(cay, bw, v_nmsub(bcy, aw, v_zero()))), inv);
+  pz = v_mul(v_nmsub(abz, cw, v_nmsub(caz, bw, v_nmsub(bcz, aw, v_zero()))), inv);
+}
+
 VECTORCALL VECMATH_FINLINE void v_frustum_box_unsafe(bbox3f& box,
                                  vec4f camPlanes0, vec4f camPlanes1, vec4f camPlanes2,
                                  const vec4f &camPlanes3, const vec4f &camPlanes4, const vec4f &camPlanes5)
 {
-  vec3f invalid;
-  box.bmax = box.bmin = three_plane_intersection(camPlanes5, camPlanes2, camPlanes1, invalid);
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes4, camPlanes2, camPlanes1, invalid));
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes5, camPlanes3, camPlanes1, invalid));
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes4, camPlanes3, camPlanes1, invalid));
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes5, camPlanes2, camPlanes0, invalid));
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes4, camPlanes2, camPlanes0, invalid));
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes5, camPlanes3, camPlanes0, invalid));
-  v_bbox3_add_pt(box, three_plane_intersection(camPlanes4, camPlanes3, camPlanes0, invalid));
+  // the 8 corners are (P5|P4, P2|P3, P1|P0) triples; solve them lane-parallel in two
+  // batches of 4 with a = (P5,P4,P5,P4), b = (P2,P2,P3,P3) and c = P1 / P0
+  vec4f m01 = v_merge_hw(camPlanes5, camPlanes4); // 5x 4x 5y 4y
+  vec4f m23 = v_merge_lw(camPlanes5, camPlanes4); // 5z 4z 5w 4w
+  vec4f ax = v_perm_xyxy(m01), ay = v_perm_zwcd(m01, m01);
+  vec4f az = v_perm_xyxy(m23), aw = v_perm_zwcd(m23, m23);
+  vec4f n01 = v_merge_hw(camPlanes2, camPlanes3); // 2x 3x 2y 3y
+  vec4f n23 = v_merge_lw(camPlanes2, camPlanes3); // 2z 3z 2w 3w
+  vec4f bx = v_perm_xxyy(n01), by = v_perm_zzww(n01);
+  vec4f bz = v_perm_xxyy(n23), bw = v_perm_zzww(n23);
+
+  vec4f abx = v_nmsub(az, by, v_mul(ay, bz)); // a x b
+  vec4f aby = v_nmsub(ax, bz, v_mul(az, bx));
+  vec4f abz = v_nmsub(ay, bx, v_mul(ax, by));
+
+  vec4f px0, py0, pz0, px1, py1, pz1;
+  v_frustum_corners_4(ax, ay, az, aw, bx, by, bz, bw, abx, aby, abz, camPlanes1, px0, py0, pz0);
+  v_frustum_corners_4(ax, ay, az, aw, bx, by, bz, bw, abx, aby, abz, camPlanes0, px1, py1, pz1);
+
+  vec4f minx = v_min(px0, px1), maxx = v_max(px0, px1);
+  vec4f miny = v_min(py0, py1), maxy = v_max(py0, py1);
+  vec4f minz = v_min(pz0, pz1), maxz = v_max(pz0, pz1);
+  // pairwise trees reduce the three components and pack the bound in one go: (x, y, z, z)
+  box.bmin = v_min_pairs(v_min_pairs(minx, miny), v_min_pairs(minz, minz));
+  box.bmax = v_max_pairs(v_max_pairs(maxx, maxy), v_max_pairs(maxz, maxz));
 }
 
 VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
@@ -1969,32 +2195,30 @@ VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
   res03 = v_or(res03, v_add(v_add(v_dot3(center, plane4), r), v_splat_w(plane4)));
   res03 = v_or(res03, v_add(v_add(v_dot3(center, plane5), r), v_splat_w(plane5)));
 
-  return v_test_vec_mask_eq_0(res03);
+  return !v_is_any_neg_b(res03); // inside if no plane distance is negative
 }
 
 VECTORCALL VECMATH_FINLINE int v_sphere_intersect(vec3f center, vec3f r,
                   vec3f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane4, const vec4f& plane5)
 {
-  vec4f res03;
-  res03 = v_madd(v_splat_x(center), plane03X, plane03W);
-  res03 = v_madd(v_splat_y(center), plane03Y, res03);
-  res03 = v_madd(v_splat_z(center), plane03Z, res03);
-  res03 = v_add(res03, r);
-  res03 = v_or(res03, v_add(v_add(v_dot3(center, plane4), r), v_splat_w(plane4)));
-  res03 = v_or(res03, v_add(v_add(v_dot3(center, plane5), r), v_splat_w(plane5)));
+  // the +r and -r bounds share the center's plane distances; compute them once
+  vec4f base = v_madd(v_splat_x(center), plane03X, plane03W);
+  base = v_madd(v_splat_y(center), plane03Y, base);
+  base = v_madd(v_splat_z(center), plane03Z, base);
+  vec4f d4 = v_dot3(center, plane4), w4 = v_splat_w(plane4);
+  vec4f d5 = v_dot3(center, plane5), w5 = v_splat_w(plane5);
 
-  if (v_test_vec_mask_neq_0(res03))
+  vec4f res = v_add(base, r);
+  res = v_or(res, v_add(v_add(d4, r), w4));
+  res = v_or(res, v_add(v_add(d5, r), w5));
+  if (v_is_any_neg_b(res)) // near bound outside a plane -> sphere fully outside
     return 0;
 
-  res03 = v_madd(v_splat_x(center), plane03X, plane03W);
-  res03 = v_madd(v_splat_y(center), plane03Y, res03);
-  res03 = v_madd(v_splat_z(center), plane03Z, res03);
-  res03 = v_sub(res03, r);
-  res03 = v_or(res03, v_add(v_sub(v_dot3(center, plane4), r), v_splat_w(plane4)));
-  res03 = v_or(res03, v_add(v_sub(v_dot3(center, plane5), r), v_splat_w(plane5)));
-
-  return v_test_vec_mask_neq_0(res03) + 1;
+  res = v_sub(base, r);
+  res = v_or(res, v_add(v_sub(d4, r), w4));
+  res = v_or(res, v_add(v_sub(d5, r), w5));
+  return v_is_any_neg_b(res) + 1; // far bound crosses a plane -> intersects, else fully inside
 }
 
 // not 100% correct: OUTSIDE cases may be reported as INTERSECT (in practice this is VERY rare, mostly for huge boxes)
@@ -2010,7 +2234,7 @@ VECTORCALL VECMATH_FINLINE int v_is_visible_box_extent2(vec3f center, vec3f exte
   res03 = v_or(res03, v_add(v_dot3(v_add(v_xor(extent, v_and(plane4W2, signmask)), center), plane4W2), v_splat_w(plane4W2)));
   res03 = v_or(res03, v_add(v_dot3(v_add(v_xor(extent, v_and(plane5W2, signmask)), center), plane5W2), v_splat_w(plane5W2)));
 
-  return v_test_vec_mask_eq_0(res03);
+  return !v_is_any_neg_b(res03); // inside if no plane distance is negative
 }
 
 // not 100% correct: OUTSIDE cases may be reported as INTERSECT (in practice this is VERY rare, mostly for huge boxes)
@@ -2019,24 +2243,33 @@ VECTORCALL VECMATH_FINLINE int v_box_frustum_intersect_extent2(vec3f center, vec
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2,
                   const vec4f& plane4W2, const vec4f& plane5W2)
 {
+  // sign(plane)*extent per axis is the same for the p- and n-vertex; compute it (and the
+  // center splats / plane w) once and reuse across both bounds
   vec4f signmask = v_cast_vec4f(V_CI_SIGN_MASK);
-  vec4f res03;
-  res03 = v_madd(v_add(v_splat_x(center), v_xor(v_splat_x(extent), v_and(plane03X, signmask))), plane03X, plane03W2);
-  res03 = v_madd(v_add(v_splat_y(center), v_xor(v_splat_y(extent), v_and(plane03Y, signmask))), plane03Y, res03);
-  res03 = v_madd(v_add(v_splat_z(center), v_xor(v_splat_z(extent), v_and(plane03Z, signmask))), plane03Z, res03);
-  res03 = v_or(res03, v_add(v_dot3(v_add(v_xor(extent, v_and(plane4W2, signmask)), center), plane4W2), v_splat_w(plane4W2)));
-  res03 = v_or(res03, v_add(v_dot3(v_add(v_xor(extent, v_and(plane5W2, signmask)), center), plane5W2), v_splat_w(plane5W2)));
+  vec4f cx = v_splat_x(center), cy = v_splat_y(center), cz = v_splat_z(center);
+  vec4f eX = v_xor(v_splat_x(extent), v_and(plane03X, signmask));
+  vec4f eY = v_xor(v_splat_y(extent), v_and(plane03Y, signmask));
+  vec4f eZ = v_xor(v_splat_z(extent), v_and(plane03Z, signmask));
+  vec4f e4 = v_xor(extent, v_and(plane4W2, signmask)), w4 = v_splat_w(plane4W2);
+  vec4f e5 = v_xor(extent, v_and(plane5W2, signmask)), w5 = v_splat_w(plane5W2);
 
-  if (v_test_vec_mask_neq_0(res03))
+  vec4f res03;
+  res03 = v_madd(v_add(cx, eX), plane03X, plane03W2);
+  res03 = v_madd(v_add(cy, eY), plane03Y, res03);
+  res03 = v_madd(v_add(cz, eZ), plane03Z, res03);
+  res03 = v_or(res03, v_add(v_dot3(v_add(e4, center), plane4W2), w4));
+  res03 = v_or(res03, v_add(v_dot3(v_add(e5, center), plane5W2), w5));
+
+  if (v_is_any_neg_b(res03)) // p-vertex outside a plane -> box fully outside
     return 0;
 
-  res03 = v_madd(v_sub(v_splat_x(center), v_xor(v_splat_x(extent), v_and(plane03X, signmask))), plane03X, plane03W2);
-  res03 = v_madd(v_sub(v_splat_y(center), v_xor(v_splat_y(extent), v_and(plane03Y, signmask))), plane03Y, res03);
-  res03 = v_madd(v_sub(v_splat_z(center), v_xor(v_splat_z(extent), v_and(plane03Z, signmask))), plane03Z, res03);
-  res03 = v_or(res03, v_add(v_dot3(v_sub(center, v_xor(extent, v_and(plane4W2, signmask))), plane4W2), v_splat_w(plane4W2)));
-  res03 = v_or(res03, v_add(v_dot3(v_sub(center, v_xor(extent, v_and(plane5W2, signmask))), plane5W2), v_splat_w(plane5W2)));
+  res03 = v_madd(v_sub(cx, eX), plane03X, plane03W2);
+  res03 = v_madd(v_sub(cy, eY), plane03Y, res03);
+  res03 = v_madd(v_sub(cz, eZ), plane03Z, res03);
+  res03 = v_or(res03, v_add(v_dot3(v_sub(center, e4), plane4W2), w4));
+  res03 = v_or(res03, v_add(v_dot3(v_sub(center, e5), plane5W2), w5));
 
-  return v_test_vec_mask_neq_0(res03) + 1;
+  return v_is_any_neg_b(res03) + 1;
 }
 
 VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast(vec3f center, vec3f extent, mat44f_cref clip)//center and extent should be multiplied by 2
@@ -2087,8 +2320,7 @@ VECTORCALL VECMATH_FINLINE int v_is_visible_box_extent2(vec3f center, vec3f exte
   res47 = v_madd(v_add(v_splat_y(center), v_xor(v_splat_y(extent), v_and(plane47Y, signmask))), plane47Y, res47);
   res47 = v_madd(v_add(v_splat_z(center), v_xor(v_splat_z(extent), v_and(plane47Z, signmask))), plane47Z, res47);
 
-  int result = v_signmask(v_or(res03, res47));
-  return (~unsigned(-result))>>31;
+  return !v_is_any_neg_b(v_or(res03, res47)); // inside if no plane distance is negative
 }
 
 VECTORCALL VECMATH_FINLINE int v_box_frustum_intersect_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
@@ -2111,13 +2343,10 @@ VECTORCALL VECMATH_FINLINE int v_box_frustum_intersect_extent2(vec3f center, vec
   res47Add = v_madd(v_xor(v_splat_y(extent), v_and(plane47Y, signmask)), plane47Y, res47Add);
   res47Add = v_madd(v_xor(v_splat_z(extent), v_and(plane47Z, signmask)), plane47Z, res47Add);
 
-  int result = v_signmask(v_or(v_add(res03Base, res03Add), v_add(res47Base, res47Add)));
-  if ((unsigned(-result))>>31)
+  if (v_is_any_neg_b(v_or(v_add(res03Base, res03Add), v_add(res47Base, res47Add))))
     return 0;
 
-  result = v_signmask(v_or(v_sub(res03Base, res03Add), v_sub(res47Base, res47Add)));
-  return ((unsigned(-result))>>31) + 1;
-  //*/
+  return v_is_any_neg_b(v_or(v_sub(res03Base, res03Add), v_sub(res47Base, res47Add))) + 1;
 }
 
 VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
@@ -2132,8 +2361,7 @@ VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
   res47 = v_madd(v_splat_y(center), plane47Y, res47);
   res47 = v_madd(v_splat_z(center), plane47Z, res47);
   res03 = v_or(v_add(res03, r), v_add(res47, r));
-  int result = v_signmask(res03);
-  return (~unsigned(-result))>>31;
+  return !v_is_any_neg_b(res03); // inside if no plane distance is negative
 }
 
 VECTORCALL VECMATH_FINLINE int v_sphere_intersect(vec3f center, vec3f r,
@@ -2148,13 +2376,11 @@ VECTORCALL VECMATH_FINLINE int v_sphere_intersect(vec3f center, vec3f r,
   res47 = v_madd(v_splat_y(center), plane47Y, res47);
   res47 = v_madd(v_splat_z(center), plane47Z, res47);
   vec4f resOut = v_or(v_add(res03, r), v_add(res47, r));
-  int result = v_signmask(resOut);
-  if ((unsigned(-result))>>31)
+  if (v_is_any_neg_b(resOut))
     return 0;
 
   vec4f resIn = v_or(v_sub(res03, r), v_sub(res47, r));
-  result = v_signmask(resIn);
-  return ((unsigned(-result))>>31) + 1;
+  return v_is_any_neg_b(resIn) + 1;
 }
 
 VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast_8planes(vec3f center, vec3f extent, mat44f_cref clip)//just correct box extents, not multiplied
@@ -2185,175 +2411,43 @@ alignas(16) static float v_screen_div_eps[4] = {0.0001f,0.0001f,0.0001f,0.0001f}
 ///return zero if not visible in frustum or if bbox screen size is smaller, than threshold. not zero, otherwise
 // also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1)
 
-VECTORCALL VECMATH_FINLINE int v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
+VECTORCALL VECMATH_INLINE int v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
 {
-  // get aabb points (SoA)
-  vec4f minmax_x = v_perm_xXxX(bmin, bmax);
-  vec4f minmax_y = v_perm_yyYY(bmin, bmax);
-  vec4f minmax_z_0 = v_splat_z(bmin);
-  vec4f minmax_z_1 = v_splat_z(bmax);
+  vec4f cs0[4], cs1[4], cs0_negw, cs1_negw;
+  v_is_transform_box_8(bmin, bmax, clip, cs0, cs1, cs0_negw, cs1_negw);
 
-  // transform points to clip space
-  vec4f points_cs_0[4];
-  vec4f points_cs_1[4];
-
-  vis_transform_points_4(points_cs_0, minmax_x, minmax_y, minmax_z_0, clip);
-  vis_transform_points_4(points_cs_1, minmax_x, minmax_y, minmax_z_1, clip);
-
-  // calculate -w
-  vec4f points_cs_0_negw = v_neg(points_cs_0[3]);
-  vec4f points_cs_1_negw = v_neg(points_cs_1[3]);
-
-#if _TARGET_SIMD_SSE
-  #define NOUT(a, b, c, d) (unsigned(-_mm_movemask_ps(v_or(v_cmp_gt(a, b), v_cmp_gt(c, d)))))
-  unsigned nout;
-  nout = (NOUT(points_cs_0[0], points_cs_0_negw, points_cs_1[0], points_cs_1_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[0], points_cs_1[3], points_cs_1[0]));
-  nout &= (NOUT(points_cs_0[1], points_cs_0_negw, points_cs_1[1], points_cs_1_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[1], points_cs_1[3], points_cs_1[1]));
-  nout &= (NOUT(points_cs_0[2], v_zero(), points_cs_1[2], v_zero()));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[2], points_cs_1[3], points_cs_1[2]));
-
-  // merge "not outside" flags
-  if ((nout&(1<<31)) == 0)
+  if (!v_is_frustum_nout_8(cs0, cs0_negw, cs1, cs1_negw)) // outside at least one plane
     return 0;
 
-#else
-  #define NOUT(a, b, c, d) v_hor(v_or(v_cmp_gt(a, b), v_cmp_gt(c, d)))
-  vec4f nout0 = NOUT(points_cs_0[0], points_cs_0_negw, points_cs_1[0], points_cs_1_negw);
-  vec4f nout1 = NOUT(points_cs_0[3], points_cs_0[0], points_cs_1[3], points_cs_1[0]);
-  vec4f nout2 = NOUT(points_cs_0[1], points_cs_0_negw, points_cs_1[1], points_cs_1_negw);
-  vec4f nout3 = NOUT(points_cs_0[3], points_cs_0[1], points_cs_1[3], points_cs_1[1]);
-  vec4f nout4 = NOUT(points_cs_0[2], v_zero(), points_cs_1[2], v_zero());
-  vec4f nout5 = NOUT(points_cs_0[3], points_cs_0[2], points_cs_1[3], points_cs_1[2]);
-
-  // merge "not outside" flags
-  vec4f nout01 = v_and(nout0, nout1);
-  vec4f nout012 = v_and(nout01, nout2);
-
-  vec4f nout34 = v_and(nout3, nout4);
-  vec4f nout345 = v_and(nout34, nout5);
-
-  vec4f nout = v_and(nout012, nout345);
-
-  if (v_test_vec_x_eqi_0(nout)) //"not outside"=0 -> outside=1
-    return 0;
-
-#endif
-  #undef NOUT
   vec4f eps = *(vec4f*)v_screen_div_eps;
-  vec4f valid_cs_0 = v_cmp_gt(points_cs_0[3], eps);
-  vec4f valid_cs_1 = v_cmp_gt(points_cs_1[3], eps);
-  vec4f valid_cs = v_and(valid_cs_0, valid_cs_1);
-
-  #if _TARGET_SIMD_SSE
-  if (_mm_movemask_ps(valid_cs) != 15)
-  #else
-  valid_cs = v_and(valid_cs, v_rot_1(valid_cs));//xy, yz, zw, wx
-  valid_cs = v_and(valid_cs, v_rot_2(valid_cs));//xyzw,yzwx, zwxy, wxyz
-  if (v_test_vec_x_eqi_0(valid_cs))
-  #endif
+  vec4f valid_cs = v_and(v_cmp_gt(cs0[3], eps), v_cmp_gt(cs1[3], eps));
+  if (!v_check_xyzw_all_true(valid_cs))
   {
     screen_box = *(vec4f*)v_screen_full_screen;
     return -1;
   }
 
-  vec4f inv_cs0_3 = v_rcp(points_cs_0[3]);
-  vec4f inv_cs1_3 = v_rcp(points_cs_1[3]);
-  vec4f xxxx0 = v_mul(points_cs_0[0], inv_cs0_3);
-  vec4f xxxx1 = v_mul(points_cs_1[0], inv_cs1_3);
-  vec4f yyyy0 = v_mul(points_cs_0[1], inv_cs0_3);
-  vec4f yyyy1 = v_mul(points_cs_1[1], inv_cs1_3);
-
-  vec4f point01 = v_merge_hw(xxxx0, yyyy0);//xy, xy
-  vec4f point23 = v_merge_lw(xxxx0, yyyy0);//xy, xy
-  vec4f point45 = v_merge_hw(xxxx1, yyyy1);//xy, xy
-  vec4f point67 = v_merge_lw(xxxx1, yyyy1);//xy, xy
-  vec4f minXY = v_min(v_min(point01, point23), v_min(point45, point67));
-  minXY = v_min(minXY, v_rot_2(minXY));
-  vec4f maxXY = v_max(v_max(point01, point23), v_max(point45, point67));
-  maxXY = v_max(maxXY, v_rot_2(maxXY));
-
-  screen_box = v_merge_hw(minXY, maxXY);
-  vec4f screenSizeVisible = v_sub(maxXY, minXY);
-  screenSizeVisible = v_cmp_ge(threshold, screenSizeVisible);
-  #if _TARGET_SIMD_SSE
-  if ((_mm_movemask_ps(screenSizeVisible)&3) != 0)
-    return 0;
-  #else
-  screenSizeVisible = v_or(screenSizeVisible, v_rot_1(screenSizeVisible));
-  if (!v_test_vec_x_eqi_0(screenSizeVisible))
-    return 0;
-  #endif
-  return 1;
+  vec4f min0, max0, min1, max1;
+  v_is_screen_project_minmax(cs0, min0, max0);
+  v_is_screen_project_minmax(cs1, min1, max1);
+  return v_is_screen_finish(v_min(min0, min1), v_max(max0, max1), threshold, screen_box);
 }
 
 ///return zero if not visible in frustum or if bbox screen size is smaller, than threshold. 1, if all vertex are in front of near plane, -1 (and fullscreen rect) otherwise
 // also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1), minmax_w is wWwW (minw, maxw, minw, maxw)
-VECTORCALL VECMATH_FINLINE int
+VECTORCALL VECMATH_INLINE int
   v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4f &minmax_w, mat44f_cref clip)
 {
-  // get aabb points (SoA)
-  vec4f minmax_x = v_perm_xXxX(bmin, bmax);
-  vec4f minmax_y = v_perm_yyYY(bmin, bmax);
-  vec4f minmax_z_0 = v_splat_z(bmin);
-  vec4f minmax_z_1 = v_splat_z(bmax);
+  vec4f cs0[4], cs1[4], cs0_negw, cs1_negw;
+  v_is_transform_box_8(bmin, bmax, clip, cs0, cs1, cs0_negw, cs1_negw);
 
-  // transform points to clip space
-  vec4f points_cs_0[4];
-  vec4f points_cs_1[4];
-
-  vis_transform_points_4(points_cs_0, minmax_x, minmax_y, minmax_z_0, clip);
-  vis_transform_points_4(points_cs_1, minmax_x, minmax_y, minmax_z_1, clip);
-
-  // calculate -w
-  vec4f points_cs_0_negw = v_neg(points_cs_0[3]);
-  vec4f points_cs_1_negw = v_neg(points_cs_1[3]);
-
-#if _TARGET_SIMD_SSE
-  #define NOUT(a, b, c, d) (unsigned(-_mm_movemask_ps(v_or(v_cmp_gt(a, b), v_cmp_gt(c, d)))))
-  unsigned nout;
-  nout = (NOUT(points_cs_0[0], points_cs_0_negw, points_cs_1[0], points_cs_1_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[0], points_cs_1[3], points_cs_1[0]));
-  nout &= (NOUT(points_cs_0[1], points_cs_0_negw, points_cs_1[1], points_cs_1_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[1], points_cs_1[3], points_cs_1[1]));
-  nout &= (NOUT(points_cs_0[2], v_zero(), points_cs_1[2], v_zero()));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[2], points_cs_1[3], points_cs_1[2]));
-
-  // merge "not outside" flags
-  if ((nout&(1<<31)) == 0)
+  if (!v_is_frustum_nout_8(cs0, cs0_negw, cs1, cs1_negw)) // outside at least one plane
     return 0;
 
-#else
-  #define NOUT(a, b, c, d) v_hor(v_or(v_cmp_gt(a, b), v_cmp_gt(c, d)))
-  vec4f nout0 = NOUT(points_cs_0[0], points_cs_0_negw, points_cs_1[0], points_cs_1_negw);
-  vec4f nout1 = NOUT(points_cs_0[3], points_cs_0[0], points_cs_1[3], points_cs_1[0]);
-  vec4f nout2 = NOUT(points_cs_0[1], points_cs_0_negw, points_cs_1[1], points_cs_1_negw);
-  vec4f nout3 = NOUT(points_cs_0[3], points_cs_0[1], points_cs_1[3], points_cs_1[1]);
-  vec4f nout4 = NOUT(points_cs_0[2], v_zero(), points_cs_1[2], v_zero());
-  vec4f nout5 = NOUT(points_cs_0[3], points_cs_0[2], points_cs_1[3], points_cs_1[2]);
-
-  // merge "not outside" flags
-  vec4f nout01 = v_and(nout0, nout1);
-  vec4f nout012 = v_and(nout01, nout2);
-
-  vec4f nout34 = v_and(nout3, nout4);
-  vec4f nout345 = v_and(nout34, nout5);
-
-  vec4f nout = v_and(nout012, nout345);
-
-  if (v_test_vec_x_eqi_0(nout)) //"not outside"=0 -> outside=1
-    return 0;
-
-#endif
-  #undef NOUT
-  vec4f min_w = v_min(points_cs_0[3], points_cs_1[3]);
-  min_w = v_min(min_w, v_rot_2(min_w));
-  min_w = v_min(min_w, v_rot_1(min_w));
-
-  vec4f max_w = v_max(points_cs_0[3], points_cs_1[3]);
-  max_w = v_max(max_w, v_rot_2(max_w));
-  minmax_w = v_perm_xaxa(min_w, v_max(max_w, v_rot_1(max_w)));
+  // horizontal reduce of the 8 corner w's; on NEON these fold to fminv/fmaxv
+  vec4f min_w = v_hmin(v_min(cs0[3], cs1[3]));
+  vec4f max_w = v_hmax(v_max(cs0[3], cs1[3]));
+  minmax_w = v_perm_xaxa(min_w, max_w);
 
   vec4f eps = *(vec4f*)v_screen_div_eps;
   if (v_test_vec_x_lt(min_w, eps))
@@ -2362,34 +2456,47 @@ VECTORCALL VECMATH_FINLINE int
     return -1;
   }
 
-  vec4f inv_cs0_3 = v_rcp(points_cs_0[3]);
-  vec4f inv_cs1_3 = v_rcp(points_cs_1[3]);
-  vec4f xxxx0 = v_mul(points_cs_0[0], inv_cs0_3);
-  vec4f xxxx1 = v_mul(points_cs_1[0], inv_cs1_3);
-  vec4f yyyy0 = v_mul(points_cs_0[1], inv_cs0_3);
-  vec4f yyyy1 = v_mul(points_cs_1[1], inv_cs1_3);
+  vec4f min0, max0, min1, max1;
+  v_is_screen_project_minmax(cs0, min0, max0);
+  v_is_screen_project_minmax(cs1, min1, max1);
+  return v_is_screen_finish(v_min(min0, min1), v_max(max0, max1), threshold, screen_box);
+}
 
-  vec4f point01 = v_merge_hw(xxxx0, yyyy0);//xy, xy
-  vec4f point23 = v_merge_lw(xxxx0, yyyy0);//xy, xy
-  vec4f point45 = v_merge_hw(xxxx1, yyyy1);//xy, xy
-  vec4f point67 = v_merge_lw(xxxx1, yyyy1);//xy, xy
-  vec4f minXY = v_min(v_min(point01, point23), v_min(point45, point67));
-  minXY = v_min(minXY, v_rot_2(minXY));
-  vec4f maxXY = v_max(v_max(point01, point23), v_max(point45, point67));
-  maxXY = v_max(maxXY, v_rot_2(maxXY));
+// as v_screen_size_b above, contract: the box is already frustum-classified as at least partially
+// visible. Only the x, y, w clip rows are computed (clip z is consumed solely by the frustum planes,
+// which are skipped), so the minmax_w / screen rect math is the same FP ops as v_screen_size_b and the
+// outputs are bit-identical whenever the contract holds; a fully-outside box yields meaningless (but
+// safe) outputs instead of the 0 return.
+VECTORCALL VECMATH_INLINE int
+  v_screen_size_visible_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4f &minmax_w, mat44f_cref clip)
+{
+  vec4f minmax_x = v_perm_xaxa(bmin, bmax);
+  vec4f minmax_y = v_perm_yybb(bmin, bmax);
+  vec4f minz = v_splat_z(bmin);
+  vec4f maxz = v_splat_z(bmax);
+  vec4f cs0[4], cs1[4]; // only the x, y, w rows are filled; [2] stays untouched (never read below)
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz, v_splat_x(clip.col0), v_splat_x(clip.col1), v_splat_x(clip.col2),
+    v_splat_x(clip.col3), cs0[0], cs1[0]);
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz, v_splat_y(clip.col0), v_splat_y(clip.col1), v_splat_y(clip.col2),
+    v_splat_y(clip.col3), cs0[1], cs1[1]);
+  v_is_transform_row_2z(minmax_x, minmax_y, minz, maxz, v_splat_w(clip.col0), v_splat_w(clip.col1), v_splat_w(clip.col2),
+    v_splat_w(clip.col3), cs0[3], cs1[3]);
 
-  screen_box = v_merge_hw(minXY, maxXY);
-  vec4f screenSizeVisible = v_sub(maxXY, minXY);
-  screenSizeVisible = v_cmp_ge(threshold, screenSizeVisible);
-  #if _TARGET_SIMD_SSE
-  if ((_mm_movemask_ps(screenSizeVisible)&3) != 0)
-    return 0;
-  #else
-  screenSizeVisible = v_or(screenSizeVisible, v_rot_1(screenSizeVisible));
-  if (!v_test_vec_x_eqi_0(screenSizeVisible))
-    return 0;
-  #endif
-  return 1;
+  vec4f min_w = v_hmin(v_min(cs0[3], cs1[3]));
+  vec4f max_w = v_hmax(v_max(cs0[3], cs1[3]));
+  minmax_w = v_perm_xaxa(min_w, max_w);
+
+  vec4f eps = *(vec4f *)v_screen_div_eps;
+  if (v_test_vec_x_lt(min_w, eps))
+  {
+    screen_box = *(vec4f *)v_screen_full_screen;
+    return -1;
+  }
+
+  vec4f min0, max0, min1, max1;
+  v_is_screen_project_minmax(cs0, min0, max0);
+  v_is_screen_project_minmax(cs1, min1, max1);
+  return v_is_screen_finish(v_min(min0, min1), v_max(max0, max1), threshold, screen_box);
 }
 
 //universal visibility function (accepts worldviewproj matrix)
@@ -2397,89 +2504,35 @@ VECTORCALL VECMATH_FINLINE int
 ///return zero if not visible in frustum or if bbox screen size is smaller, than threshold. not zero, otherwise
 // also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1)
 
-VECTORCALL VECMATH_FINLINE int v_screen_size_b(vec3f box2_xyXY, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
+VECTORCALL VECMATH_INLINE int v_screen_size_b(vec3f box2_xyXY, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
 {
-  // get aabb points (SoA)
+  // get aabb points (SoA); a single z-slice, box2_xyXY is a 2D box
   vec4f minmax_x = v_perm_xzxz(box2_xyXY);
   vec4f minmax_y = v_perm_yyww(box2_xyXY);
 
-  // transform points to clip space
   vec4f points_cs_0[4];
-
-  vis_transform_points_4(points_cs_0, minmax_x, minmax_y, clip);
-
-  // calculate -w
+  v_is_transform_points_4(points_cs_0, minmax_x, minmax_y, clip);
   vec4f points_cs_0_negw = v_neg(points_cs_0[3]);
 
-#if _TARGET_SIMD_SSE
-  #define NOUT(a, b) (unsigned(-_mm_movemask_ps(v_cmp_gt(a, b))))
-  unsigned nout;
-  nout = (NOUT(points_cs_0[0], points_cs_0_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[0]));
-  nout &= (NOUT(points_cs_0[1], points_cs_0_negw));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[1]));
-  nout &= (NOUT(points_cs_0[2], v_zero()));
-  nout &= (NOUT(points_cs_0[3], points_cs_0[2]));
+  vec4f *cs = points_cs_0;
+  if (!v_is_merge_planes_nout(v_cmp_gt(cs[0], points_cs_0_negw),  // -w <= x
+        v_cmp_gt(cs[3], cs[0]),                                  //  x <= w
+        v_cmp_gt(cs[1], points_cs_0_negw),                       // -w <= y
+        v_cmp_gt(cs[3], cs[1]),                                  //  y <= w
+        v_cmp_gt(cs[2], v_zero()),                               //  0 <= z
+        v_cmp_gt(cs[3], cs[2])))                                 //  z <= w
+    return 0; // outside at least one plane
 
-  // merge "not outside" flags
-  if ((nout&(1<<31)) == 0)
-    return 0;
-
-#else
-  #define NOUT(a, b) v_hor(v_cmp_gt(a, b))
-  vec4f nout0 = NOUT(points_cs_0[0], points_cs_0_negw);
-  vec4f nout1 = NOUT(points_cs_0[3], points_cs_0[0]);
-  vec4f nout2 = NOUT(points_cs_0[1], points_cs_0_negw);
-  vec4f nout3 = NOUT(points_cs_0[3], points_cs_0[1]);
-  vec4f nout4 = NOUT(points_cs_0[2], v_zero());
-  vec4f nout5 = NOUT(points_cs_0[3], points_cs_0[2]);
-
-  // merge "not outside" flags
-  vec4f nout01 = v_and(nout0, nout1);
-  vec4f nout012 = v_and(nout01, nout2);
-
-  vec4f nout34 = v_and(nout3, nout4);
-  vec4f nout345 = v_and(nout34, nout5);
-
-  vec4f nout = v_and(nout012, nout345);
-
-  if (v_test_vec_x_eqi_0(nout)) //"not outside"=0 -> outside=1
-    return 0;
-
-#endif
-  #undef NOUT
   vec4f eps = *(vec4f*)v_screen_div_eps;
-  vec4f valid_cs = v_cmp_gt(points_cs_0[3], eps);
-
-  if (!v_test_all_bits_ones(valid_cs))
+  if (!v_test_all_bits_ones(v_cmp_gt(points_cs_0[3], eps)))
   {
     screen_box = *(vec4f*)v_screen_full_screen;
     return -1;
   }
 
-  vec4f inv_cs0_3 = v_rcp(points_cs_0[3]);
-  vec4f xxxx0 = v_mul(points_cs_0[0], inv_cs0_3);
-  vec4f yyyy0 = v_mul(points_cs_0[1], inv_cs0_3);
-
-  vec4f point01 = v_merge_hw(xxxx0, yyyy0);//xy, xy
-  vec4f point23 = v_merge_lw(xxxx0, yyyy0);//xy, xy
-  vec4f minXY = v_min(point01, point23);
-  minXY = v_min(minXY, v_rot_2(minXY));
-  vec4f maxXY = v_max(point01, point23);
-  maxXY = v_max(maxXY, v_rot_2(maxXY));
-
-  screen_box = v_merge_hw(minXY, maxXY);
-  vec4f screenSizeVisible = v_sub(maxXY, minXY);
-  screenSizeVisible = v_cmp_ge(threshold, screenSizeVisible);
-  #if _TARGET_SIMD_SSE
-  if ((_mm_movemask_ps(screenSizeVisible)&3) != 0)
-    return 0;
-  #else
-  screenSizeVisible = v_or(screenSizeVisible, v_rot_1(screenSizeVisible));
-  if (!v_test_vec_x_eqi_0(screenSizeVisible))
-    return 0;
-  #endif
-  return 1;
+  vec4f minXY, maxXY;
+  v_is_screen_project_minmax(points_cs_0, minXY, maxXY);
+  return v_is_screen_finish(minXY, maxXY, threshold, screen_box);
 }
 
 
@@ -2523,27 +2576,27 @@ VECTORCALL VECMATH_INLINE  bool v_segment_test_internal(vec3f lmin_lmax, vec3f& 
   return v_extract_xi(v_cast_vec4i(isect)) != 0;
 }
 
-VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
+VECTORCALL VECMATH_FINLINE bool v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
 {
   vec3f isEmptyBox = v_cmp_gt(box.bmin, box.bmax);
   vec4f at = v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox);
   return v_segment_test_internal(at, t_x);
 }
 
-VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
+VECTORCALL VECMATH_FINLINE bool v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
 {
   vec3f isEmptyBox = v_zero();
   vec4f at = v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox);
   return v_segment_test_internal(at, t_x);
 }
 
-VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
+VECTORCALL VECMATH_FINLINE bool v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
 {
   vec3f isEmptyBox = v_cmp_gt(box.bmin, box.bmax);
   return v_segment_test_internal(v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox), len_x);
 }
 
-VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
+VECTORCALL VECMATH_FINLINE bool v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
 {
   vec3f isEmptyBox = v_zero();
   return v_segment_test_internal(v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox), len_x);
@@ -2556,79 +2609,47 @@ VECTORCALL VECMATH_FINLINE bool v_test_segment_box_intersection(vec3f start, vec
 }
 
 // return -1 if no intersection found, or box side index in [0; 5] and output param 'at' in range [0.0; 1.0] for closest/furthest intersection
-VECTORCALL inline int v_segment_box_intersection_side(vec3f start, vec3f end, bbox3f box, float& out_at_min, float& out_at_max)
+VECTORCALL inline int v_segment_box_intersection_side(vec3f start, vec3f end, const bbox3f& box, float& out_at_min, float& out_at_max)
 {
-  int ret = -1;
-  vec3f fullDir = v_sub(end, start);
+  vec3f dir = v_sub(end, start);
+  vec3f isDiv0 = v_is_unsafe_divisor(dir);
+  vec3f t0 = v_div(v_sub(box.bmin, start), dir);
+  vec3f t1 = v_div(v_sub(box.bmax, start), dir);
 
-  for (int i = 0; i < 2; i++)
-  {
-    vec3f blim = v_sel(box.bmax, box.bmin, v_cast_vec4f(v_splatsi(i == 0 ? -1 : 0)));
-    vec3f v1 = v_sub(start, blim);
-    vec3f v2 = v_sub(v_add(start, fullDir), blim);
-    vec3f numerator = v_sub(blim, start);
-    vec3f valid = v_and(v_cmp_gt(v_abs(fullDir), V_C_EPS_VAL),
-                        v_or(v_cmp_le(v_abs(v2), V_C_EPS_VAL),
-                             v_cmp_le(v_mul(v1, v2), v_zero())));
+  // axis parallel to the segment: unbounded slab if start is inside it,
+  // empty interval [+MAX, -MAX] (guaranteed miss) if outside
+  vec3f outside = v_or(v_cmp_lt(start, box.bmin), v_cmp_gt(start, box.bmax));
+  vec3f parMin = v_sel(v_neg(V_C_MAX_VAL), V_C_MAX_VAL, outside);
+  vec3f parMax = v_sel(V_C_MAX_VAL, v_neg(V_C_MAX_VAL), outside);
+  vec3f tmin3 = v_sel(v_min(t0, t1), parMin, isDiv0);
+  vec3f tmax3 = v_sel(v_max(t0, t1), parMax, isDiv0);
 
-    vec3f at = v_div(numerator, fullDir);
-    valid = v_and(valid, v_cmp_ge(at, v_zero()));
-    if (v_check_xyz_all_false(valid))
-      continue;
+  vec4f vEnter = v_hmax3(tmin3);
+  vec4f vExit = v_hmin3(tmax3);
+  vec4f validEnter = v_and(v_cmp_ge(vEnter, v_zero()), v_cmp_le(vEnter, V_C_ONE));
+  vec4f validExit = v_and(v_cmp_ge(vExit, v_zero()), v_cmp_le(vExit, V_C_ONE));
+  // no face crossing within the segment: miss, or segment fully inside the box
+  if (v_check_xyzw_any_true(v_or(v_cmp_gt(vEnter, vExit), v_not(v_or(validEnter, validExit)))))
+    return -1;
 
-    vec3f p0 = v_madd(fullDir, v_splat_x(at), start);
-    vec3f p1 = v_madd(fullDir, v_splat_y(at), start);
-    vec3f p2 = v_madd(fullDir, v_splat_z(at), start);
+  // side of the first crossing: entry face if the entry is on the segment,
+  // otherwise (start inside the box) the exit face
+  vec4f vSide = v_sel(vExit, vEnter, validEnter);
+  vec3f ref = v_sel(tmax3, tmin3, validEnter);
+  out_at_min = v_extract_x(vSide);
+  out_at_max = v_extract_x(v_sel(vEnter, vExit, validExit));
 
-    vec4f box0min = v_perm_xyab(v_perm_yzwx(box.bmin), v_perm_yzwx(p0));
-    vec4f box0max = v_perm_xyab(v_perm_yzwx(p0), v_perm_yzwx(box.bmax));
-    vec4f box1min = v_perm_xyab(v_perm_zxyw(box.bmin), v_perm_zxyw(p1));
-    vec4f box1max = v_perm_xyab(v_perm_zxyw(p1), v_perm_zxyw(box.bmax));
-    vec4f box2min = v_perm_xyab(box.bmin, p2);
-    vec4f box2max = v_perm_xyab(p2, box.bmax);
-
-    vec3f b0valid = v_cmp_gt(box0max, box0min);
-    vec3f b1valid = v_cmp_gt(box1max, box1min);
-    vec3f b2valid = v_cmp_gt(box2max, box2min);
-
-    b0valid = v_and(b0valid, v_rot_1(b0valid));
-    b1valid = v_and(b1valid, v_rot_1(b1valid));
-    b2valid = v_and(b2valid, v_rot_1(b2valid));
-    b0valid = v_and(b0valid, v_rot_2(b0valid));
-    b1valid = v_and(b1valid, v_rot_2(b1valid));
-    b2valid = v_and(b2valid, v_rot_2(b2valid));
-    vec3f b012valid = v_perm_xyab(v_perm_xaxa(b0valid, b1valid), b2valid);
-    valid = v_and(valid, b012valid);
-    if (v_check_xyz_all_false(valid))
-      continue;
-
-    float tMax = v_extract_x(v_hmax(v_and(at, valid)));
-    vec4f isInit = v_is_neg(v_cast_vec4f(v_seti_x(ret)));
-    out_at_max = v_extract_x(v_sel(v_set_x(out_at_max), v_set_x(tMax), isInit));
-    if (tMax > out_at_max)
-      out_at_max = tMax;
-    at = v_sel(V_C_MAX_VAL, at, valid);
-    vec3f bestMinMask = v_and(v_cmp_le(at, v_perm_yzxw(at)),
-                              v_cmp_le(at, v_perm_zxyw(at)));
-
-    int selectMask = v_signmask(bestMinMask) & (1 | 2 | 4);
-    alignas(16) float at4[4];
-    v_st(at4, at);
+  int axisMask = v_truemask(v_cmp_eq(ref, vSide)) & 0b111;
 #if defined(__clang__) || defined(__GNUC__)
-    int select = __builtin_ctz(selectMask);
+  int axis = __builtin_ctz(axisMask);
 #else
-    unsigned long select;
-    _BitScanForward(&select, selectMask);
+  unsigned long axis;
+  _BitScanForward(&axis, axisMask);
 #endif
-    float bestAt = at4[select];
-    if (ret == -1 || bestAt < out_at_min)
-    {
-      ret = select + i * 3;
-      out_at_min = bestAt;
-    }
-  }
 
-  return ret;
+  // prefer the bmin face on ties (t0 == t1), matching the original scan order
+  int isMax = (~v_truemask(v_cmp_eq(ref, t0)) >> axis) & 1;
+  return axis + isMax * 3;
 }
 
 VECTORCALL VECMATH_FINLINE bool v_test_ray_sphere_intersection(vec3f p0,
@@ -2686,12 +2707,18 @@ VECMATH_FINLINE bool v_ray_sphere_intersection(vec3f start, vec3f dir, vec4f &t_
 
 VECTORCALL VECMATH_FINLINE void v_mat33_make_from_33cu(mat33f &tmV, const float *const __restrict m33)
 {
-  vec4f v0 = v_ldu(m33 + 0);
-  vec4f v1 = v_ldu(m33 + 4);
-  vec4f v2 = v_ldu_x(m33 + 8);
-  tmV.col0 = v0;
-  tmV.col1 = v_perm_wxyz(v_perm_xycd(v1, v0));
-  tmV.col2 = v_perm_zwxy(v_perm_ayzw(v1, v2));
+  // v_ldu_p3 keeps the trailing column read sanitizer-clean
+  tmV.col0 = v_perm_xyzd(v_ldu(m33 + 0), v_zero());
+  tmV.col1 = v_perm_xyzd(v_ldu(m33 + 3), v_zero());
+  tmV.col2 = v_perm_xyzd(v_ldu_p3(m33 + 6), v_zero());
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat33_make_from_33cu_safe(mat33f &tmV, const float *const __restrict m33)
+{
+  // the first two loads stay within the 9 floats, only the tail needs the exact form
+  tmV.col0 = v_perm_xyzd(v_ldu(m33 + 0), v_zero());
+  tmV.col1 = v_perm_xyzd(v_ldu(m33 + 3), v_zero());
+  tmV.col2 = v_perm_xyzd(v_ldu_p3_safe(m33 + 6), v_zero());
 }
 
 VECTORCALL VECMATH_FINLINE void v_mat_44cu_from_mat44(float* __restrict m44, const mat44f& tm)
@@ -2700,6 +2727,14 @@ VECTORCALL VECMATH_FINLINE void v_mat_44cu_from_mat44(float* __restrict m44, con
   v_stu(m44 + 4, tm.col1);
   v_stu(m44 + 8, tm.col2);
   v_stu(m44 + 12, tm.col3);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat_44ca_from_mat44(float* __restrict m44, const mat44f& tm)
+{
+  v_st(m44 + 0, tm.col0);
+  v_st(m44 + 4, tm.col1);
+  v_st(m44 + 8, tm.col2);
+  v_st(m44 + 12, tm.col3);
 }
 
 //mat44f from unaligned 4x4 matrix
@@ -2882,13 +2917,13 @@ VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_to_bbox_2d_x(vec4f bmin, vec4f bm
 
 VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB)
 {
-  vec3f axisDistances = v_max(v_sub(v_abs(v_sub(centerB, centerA)), v_add(extentA, extentB)), v_zero());
+  vec3f axisDistances = v_max(v_sub(v_abs_diff(centerB, centerA), v_add(extentA, extentB)), v_zero());
   return v_dot3_x(axisDistances, axisDistances);
 }
 
 VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x_scaled(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB, vec3f scale)
 {
-  vec3f axisDistances = v_max(v_sub(v_abs(v_sub(centerB, centerA)), v_add(extentA, extentB)), v_zero());
+  vec3f axisDistances = v_max(v_sub(v_abs_diff(centerB, centerA), v_add(extentA, extentB)), v_zero());
   axisDistances = v_mul(axisDistances, scale);
   return v_dot3_x(axisDistances, axisDistances);
 }
@@ -2908,22 +2943,22 @@ VECTORCALL VECMATH_FINLINE vec3f v_closest_bbox_point(vec3f bmin, vec3f bmax, ve
 
 
 //returns point on infinite line which is closes to point
-VECTORCALL VECMATH_FINLINE vec3f closest_point_on_line(vec3f point, vec3f a, vec3f dir)
+VECTORCALL VECMATH_FINLINE vec3f v_closest_point_on_line(vec3f point, vec3f a, vec3f dir)
 {
   vec3f t = v_dot3(v_sub(point, a), dir);// t param along line
   return v_madd(dir, t, a);//pt is point on line
 }
 
-VECTORCALL VECMATH_FINLINE vec4f distance_to_line_x(vec3f point, vec3f a, vec3f dir)
+VECTORCALL VECMATH_FINLINE vec4f v_distance_to_line_x(vec3f point, vec3f a, vec3f dir)
 {
   vec3f pa = v_sub(point, a);
   vec3f t = v_dot3(pa, dir);// t param along line
   return v_length3_x(v_sub(pa, v_mul(dir, t)));
 }
 
-VECTORCALL VECMATH_FINLINE vec4f distance_to_seg_x(vec3f point, vec3f a, vec3f b)
+VECTORCALL VECMATH_FINLINE vec4f v_distance_to_seg_x(vec3f point, vec3f a, vec3f b)
 {
-  vec3f pt = closest_point_on_segment(point, a, b);
+  vec3f pt = v_closest_point_on_segment(point, a, b);
   return v_length3_x(v_sub(point, pt));
 }
 
@@ -3061,11 +3096,23 @@ VECTORCALL VECMATH_FINLINE vec4i v_sw_float_to_half_rtne(vec4f f)
   return final;
 }
 
+// fp16 denormals (zero exponent field): mantissa * 2^-24 through exact int->float and an
+// exact power-of-two scale. The magic-multiply path below would push them through FLOAT
+// denormal arithmetic, making the result depend on the thread's FTZ/DAZ state (flushed to
+// zero in the FTZ+DAZ mode init_math() sets) and disagree with the F16C hardware path,
+// which converts fp16 denormals exactly regardless of MXCSR.
+VECTORCALL VECMATH_FINLINE vec4f v_sw_half_to_float_subnorm(vec4i h)
+{
+  return v_mul(v_cvti_vec4f(v_andi(h, v_splatsi(0x3ff))), v_cast_vec4f(v_splatsi(103 << 23))); // mant * 2^-24, both exact
+}
+
 VECTORCALL VECMATH_FINLINE vec4f v_sw_half_to_float(vec4i h)
 {
   const vec4f magic = v_cast_vec4f(v_splatsi((254 - 15) << 23));
   vec4i oi = v_srl(v_sll(h, 17), 4); // exponent/mantissa bits
-  vec4f of = v_mul(v_cast_vec4f(oi), magic);// exponent adjust
+  vec4f of = v_mul(v_cast_vec4f(oi), magic);// exponent adjust; exact for normals (result >= 2^-14)
+  vec4i isSub = v_cmp_eqi(v_andi(h, v_splatsi(0x7c00)), v_zeroi());
+  of = v_sel(of, v_sw_half_to_float_subnorm(h), v_cast_vec4f(isSub));
   return v_or(of, v_cast_vec4f(v_sll(v_srl(h, 15), 31)));
 }
 
@@ -3074,7 +3121,9 @@ VECTORCALL VECMATH_FINLINE vec4f v_sw_half_to_float_specials(vec4i h)
   const vec4f magic = v_cast_vec4f(v_splatsi((254 - 15) << 23));
   const vec4f was_infnan = v_cast_vec4f(v_splatsi((127 + 16) << 23));
   vec4i oi = v_srl(v_sll(h, 17), 4); // exponent/mantissa bits
-  vec4f of = v_mul(v_cast_vec4f(oi), magic);// exponent adjust
+  vec4f of = v_mul(v_cast_vec4f(oi), magic);// exponent adjust; exact for normals (result >= 2^-14)
+  vec4i isSub = v_cmp_eqi(v_andi(h, v_splatsi(0x7c00)), v_zeroi());
+  of = v_sel(of, v_sw_half_to_float_subnorm(h), v_cast_vec4f(isSub));
   of = v_or(of, v_and(v_cmp_ge(of, was_infnan), v_cast_vec4f(v_splatsi(255 << 23))));
   return v_or(of, v_cast_vec4f(v_sll(v_srl(h, 15), 31)));
 }
@@ -3279,17 +3328,6 @@ VECTORCALL VECMATH_FINLINE vec4i v_permi_xyab(vec4i xyzw, vec4i abcd) { return v
 VECTORCALL VECMATH_FINLINE vec4i v_permi_xycd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xycd(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
 VECTORCALL VECMATH_FINLINE vec4i v_permi_xbzd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xayb(v_perm_xzxz(v_cast_vec4f(xyzw)), v_perm_ywyw(v_cast_vec4f(abcd)))); }
 VECTORCALL VECMATH_FINLINE vec4i v_permi_xyzd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xyzd(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_xzxz(vec4i xyzw) { return v_cast_vec4i(v_perm_xzxz(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_ywyw(vec4i xyzw) { return v_cast_vec4i(v_perm_ywyw(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_xyxy(vec4i xyzw) { return v_cast_vec4i(v_perm_xyxy(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_zwzw(vec4i xyzw) { return v_cast_vec4i(v_perm_zwzw(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_xxyy(vec4i xyzw) { return v_cast_vec4i(v_perm_xxyy(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_zzww(vec4i xyzw) { return v_cast_vec4i(v_perm_zzww(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_xxzz(vec4i xyzw) { return v_cast_vec4i(v_perm_xxzz(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_yyww(vec4i xyzw) { return v_cast_vec4i(v_perm_yyww(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_wwyy(vec4i xyzw) { return v_cast_vec4i(v_perm_wwyy(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxw(vec4i xyzw) { return v_cast_vec4i(v_perm_yzxw(v_cast_vec4f(xyzw))); }
-VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxy(vec4i xyzw) { return v_cast_vec4i(v_perm_yzxy(v_cast_vec4f(xyzw))); }
 
 VECTORCALL VECMATH_INLINE void v_get_bilinear_wrap_addr_pow2(vec4i &uv_idx, vec4f &uv_frac, vec4f uv_wrap, int size_bits, vec4f center_ofs)
 {
@@ -3299,11 +3337,7 @@ VECTORCALL VECMATH_INLINE void v_get_bilinear_wrap_addr_pow2(vec4i &uv_idx, vec4
 // don't use a pixel centered bilinear filtration because it creates shifts for different
   uv_wrap = v_mul(uv_wrap, dmap);
   uv_wrap = v_sub(uv_wrap, center_ofs);
-#if _TARGET_SIMD_SSE >= 4 || (_TARGET_SIMD_SSE && defined(__SSE4_1__))
-  vec4f floored = sse4_floor(uv_wrap);
-#else
   vec4f floored = v_floor(uv_wrap);
-#endif
   vec4i uvIdx = v_cvt_vec4i(floored);
   uv_frac = v_sub(uv_wrap, floored);
 
@@ -3320,11 +3354,7 @@ VECTORCALL VECMATH_INLINE void v_get_bilinear_wrap_addr(vec4i &uv_idx, vec4f &uv
   vec4f dmap = v_cvt_vec4f(dmapi);
 // don't use a pixel centered bilinear filtration because it creates shifts for different
   uv_wrap = v_sub(uv_wrap, v_div(center_ofs, dmap));
-#if _TARGET_SIMD_SSE >= 4 || (_TARGET_SIMD_SSE && defined(__SSE4_1__))
-  uv_wrap = v_mul(v_sub(uv_wrap, sse4_floor(uv_wrap)), dmap);
-#else
   uv_wrap = v_mul(v_sub(uv_wrap, v_floor(uv_wrap)), dmap);
-#endif
   vec4i uvIdx = v_cvt_vec4i(uv_wrap);
   uv_frac = v_sub(uv_wrap, v_cvt_vec4f(uvIdx));
 

--- a/include/vecmath/dag_vecMath_double.h
+++ b/include/vecmath/dag_vecMath_double.h
@@ -1,0 +1,448 @@
+//
+// Dagor Engine 6.5 - 1st party libs
+// Copyright (C) Gaijin Games KFT.  All rights reserved.
+//
+#pragma once
+
+// vec4d - 4D double-precision vector. Include via dag_vecMath.h (needs the platform
+// intrinsics and vec4f already set up). Representation is chosen in dag_vecMathDecl.h:
+// one __m256d on AVX, otherwise two 128-bit halves (.xy low pair, .zw high pair).
+//
+// The math is written on 128-bit / 64x2 halves shared by both x86 representations; only
+// pack/unpack differs.
+//
+// Precision matches scalar DPoint3 exactly: the reductions below add lanes left to right,
+// so vd_dot*/vd_hadd* are bit-identical to the equivalent scalar expression under
+// -ffp-contract=off. Replacing scalar double math with vec4d changes speed, not results.
+// That speed depends mostly on having AVX (one register instead of two): in branchy
+// per-body physics code it is ~1.35x scalar on SSE4.1, ~1.5x on AVX, ~1.7x on AVX2+FMA.
+//
+// There are no lane-wise 3-component forms (no vd_add3/vd_div3/...). For add/sub/mul/neg
+// the packed op yields .w for free, so such a form would emit the same instructions. For
+// div/sqrt the .w lane could be skipped with a scalar op on the high half, but that pays
+// off nowhere we ship: every narrow-divider target (Jaguar, Intel E-cores, Zen2 consoles)
+// has AVX and so takes the single-register path, where there is no separate lane to skip,
+// and on NEON the compiler widens the scalar op back to packed and adds moves to preserve
+// .w. 3-component forms exist only where the math itself differs - vd_hadd3, vd_dot3,
+// vd_cross3, vd_length3.
+
+#ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable: 4714) //function marked as __forceinline not inlined
+#endif
+
+#if _TARGET_SIMD_SSE
+// ------------------------------------------------------------------------------------------------
+// x86 (SSE2 two __m128d / AVX one __m256d)
+// ------------------------------------------------------------------------------------------------
+VECTORCALL VECMATH_FINLINE __m128d vd_lo(vec4d a) {
+#if VECMATH_VEC4D_256
+  return _mm256_castpd256_pd128(a);
+#else
+  return a.xy;
+#endif
+}
+VECTORCALL VECMATH_FINLINE __m128d vd_hi(vec4d a) {
+#if VECMATH_VEC4D_256
+  return _mm256_extractf128_pd(a, 1);
+#else
+  return a.zw;
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_from_halves(__m128d lo, __m128d hi) {
+#if VECMATH_VEC4D_256
+  return _mm256_insertf128_pd(_mm256_castpd128_pd256(lo), hi, 1);
+#else
+  vec4d r; r.xy = lo; r.zw = hi; return r;
+#endif
+}
+
+VECTORCALL VECMATH_FINLINE vec4d vd_zero() {
+#if VECMATH_VEC4D_256
+  return _mm256_setzero_pd();
+#else
+  return vd_from_halves(_mm_setzero_pd(), _mm_setzero_pd());
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_splats(double a) {
+#if VECMATH_VEC4D_256
+  return _mm256_set1_pd(a);
+#else
+  return vd_from_halves(_mm_set1_pd(a), _mm_set1_pd(a));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_make_vec4d(double x, double y, double z, double w) {
+  return vd_from_halves(_mm_set_pd(y, x), _mm_set_pd(w, z));
+}
+
+VECTORCALL VECMATH_FINLINE double vd_extract_x(vec4d a) { return _mm_cvtsd_f64(vd_lo(a)); }
+VECTORCALL VECMATH_FINLINE double vd_extract_y(vec4d a) { __m128d l = vd_lo(a); return _mm_cvtsd_f64(_mm_unpackhi_pd(l, l)); }
+VECTORCALL VECMATH_FINLINE double vd_extract_z(vec4d a) { return _mm_cvtsd_f64(vd_hi(a)); }
+VECTORCALL VECMATH_FINLINE double vd_extract_w(vec4d a) { __m128d h = vd_hi(a); return _mm_cvtsd_f64(_mm_unpackhi_pd(h, h)); }
+
+#if VECMATH_VEC4D_256
+// blend keeps this one instruction (plus the broadcast); going through the halves would
+// cost an extractf128 + insertf128 pair
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_x(vec4d a, double x) { return _mm256_blend_pd(a, _mm256_set1_pd(x), 0x1); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_y(vec4d a, double y) { return _mm256_blend_pd(a, _mm256_set1_pd(y), 0x2); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_z(vec4d a, double z) { return _mm256_blend_pd(a, _mm256_set1_pd(z), 0x4); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_w(vec4d a, double w) { return _mm256_blend_pd(a, _mm256_set1_pd(w), 0x8); }
+#else
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_x(vec4d a, double x) { return vd_from_halves(_mm_move_sd(a.xy, _mm_set_sd(x)), a.zw); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_y(vec4d a, double y) { return vd_from_halves(_mm_unpacklo_pd(a.xy, _mm_set_sd(y)), a.zw); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_z(vec4d a, double z) { return vd_from_halves(a.xy, _mm_move_sd(a.zw, _mm_set_sd(z))); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_w(vec4d a, double w) { return vd_from_halves(a.xy, _mm_unpacklo_pd(a.zw, _mm_set_sd(w))); }
+#endif
+
+// Deliberately no 256-bit branch: the compiler folds the two half moves into a single
+// vmovup/vmovap ymm on AVX, so this is already optimal there. It does mean 16-byte alignment
+// is enough for the aligned forms on every build, and that only the non-AVX build faults on
+// a violation - see the note in dag_vecMath.h.
+NO_ASAN_INLINE vec4d vd_ld(const double *m)  { return vd_from_halves(_mm_load_pd(m),  _mm_load_pd(m + 2)); }
+NO_ASAN_INLINE vec4d vd_ldu(const double *m) { return vd_from_halves(_mm_loadu_pd(m), _mm_loadu_pd(m + 2)); }
+VECTORCALL VECMATH_FINLINE void vd_st(double *m, vec4d a)  { _mm_store_pd(m, vd_lo(a));  _mm_store_pd(m + 2, vd_hi(a)); }
+VECTORCALL VECMATH_FINLINE void vd_stu(double *m, vec4d a) { _mm_storeu_pd(m, vd_lo(a)); _mm_storeu_pd(m + 2, vd_hi(a)); }
+
+// DPoint3 layout: 3 packed doubles. _safe reads exactly 3 (.w = 0); store writes exactly 3.
+NO_ASAN_INLINE vec4d vd_ldu_p3_safe(const double *m) { return vd_from_halves(_mm_loadu_pd(m), _mm_load_sd(m + 2)); }
+VECTORCALL VECMATH_FINLINE void vd_stu_p3(double *p3, vec4d v) { _mm_storeu_pd(p3, vd_lo(v)); _mm_store_sd(p3 + 2, vd_hi(v)); }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_cvt_from_vec4f(vec4f a) {
+#if VECMATH_VEC4D_256
+  return _mm256_cvtps_pd(a);
+#else
+  return vd_from_halves(_mm_cvtps_pd(a), _mm_cvtps_pd(_mm_movehl_ps(a, a)));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4f vd_cvt_to_vec4f(vec4d a) {
+#if VECMATH_VEC4D_256
+  return _mm256_cvtpd_ps(a);
+#else
+  return _mm_movelh_ps(_mm_cvtpd_ps(vd_lo(a)), _mm_cvtpd_ps(vd_hi(a)));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_cvt_from_vec4i(vec4i a) {
+#if VECMATH_VEC4D_256
+  return _mm256_cvtepi32_pd(a);
+#else
+  return vd_from_halves(_mm_cvtepi32_pd(a), _mm_cvtepi32_pd(_mm_unpackhi_epi64(a, a)));
+#endif
+}
+// truncates toward zero, like v_cvt_vec4i; out-of-range input is platform-specific
+VECTORCALL VECMATH_FINLINE vec4i vd_cvt_to_vec4i(vec4d a) {
+#if VECMATH_VEC4D_256
+  return _mm256_cvttpd_epi32(a);
+#else
+  return _mm_unpacklo_epi64(_mm_cvttpd_epi32(vd_lo(a)), _mm_cvttpd_epi32(vd_hi(a)));
+#endif
+}
+
+VECTORCALL VECMATH_FINLINE vec4d vd_add(vec4d a, vec4d b) {
+#if VECMATH_VEC4D_256
+  return _mm256_add_pd(a, b);
+#else
+  return vd_from_halves(_mm_add_pd(a.xy, b.xy), _mm_add_pd(a.zw, b.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_sub(vec4d a, vec4d b) {
+#if VECMATH_VEC4D_256
+  return _mm256_sub_pd(a, b);
+#else
+  return vd_from_halves(_mm_sub_pd(a.xy, b.xy), _mm_sub_pd(a.zw, b.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_mul(vec4d a, vec4d b) {
+#if VECMATH_VEC4D_256
+  return _mm256_mul_pd(a, b);
+#else
+  return vd_from_halves(_mm_mul_pd(a.xy, b.xy), _mm_mul_pd(a.zw, b.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_div(vec4d a, vec4d b) {
+#if VECMATH_VEC4D_256
+  return _mm256_div_pd(a, b);
+#else
+  return vd_from_halves(_mm_div_pd(a.xy, b.xy), _mm_div_pd(a.zw, b.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_neg(vec4d a) {
+  __m128d m = _mm_set1_pd(-0.0);
+  return vd_from_halves(_mm_xor_pd(vd_lo(a), m), _mm_xor_pd(vd_hi(a), m));
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_min(vec4d a, vec4d b) {
+#if VECMATH_VEC4D_256
+  return _mm256_min_pd(a, b);
+#else
+  return vd_from_halves(_mm_min_pd(a.xy, b.xy), _mm_min_pd(a.zw, b.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_max(vec4d a, vec4d b) {
+#if VECMATH_VEC4D_256
+  return _mm256_max_pd(a, b);
+#else
+  return vd_from_halves(_mm_max_pd(a.xy, b.xy), _mm_max_pd(a.zw, b.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_sqrt(vec4d a) {
+#if VECMATH_VEC4D_256
+  return _mm256_sqrt_pd(a);
+#else
+  return vd_from_halves(_mm_sqrt_pd(a.xy), _mm_sqrt_pd(a.zw));
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_sqrt_x(vec4d a) { __m128d lo = vd_lo(a); return vd_from_halves(_mm_sqrt_sd(lo, lo), vd_hi(a)); }
+
+// Lane order is left to right ((x+y)+z)+w, the same association a scalar x+y+z+w has, so
+// vd_dot* reproduce scalar DPoint3 results bit-for-bit (given -ffp-contract=off, which the
+// physics libs already build with). A pairwise tree would save one add of latency but would
+// not match, which is what matters when replacing existing double math.
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd4_x(vec4d a) {
+  __m128d lo = vd_lo(a), hi = vd_hi(a);
+  __m128d s = _mm_add_sd(lo, _mm_unpackhi_pd(lo, lo)); // x+y
+  s = _mm_add_sd(s, hi);                               // +z
+  s = _mm_add_sd(s, _mm_unpackhi_pd(hi, hi));          // +w
+  return vd_from_halves(s, s);
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd4(vec4d a) {
+  __m128d x = vd_lo(vd_hadd4_x(a)), s = _mm_unpacklo_pd(x, x);
+  return vd_from_halves(s, s);
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd3_x(vec4d a) {
+  __m128d lo = vd_lo(a);
+  __m128d s = _mm_add_sd(lo, _mm_unpackhi_pd(lo, lo)); // x+y
+  s = _mm_add_sd(s, vd_hi(a));                         // +z
+  return vd_from_halves(s, s);
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd3(vec4d a) {
+  __m128d x = vd_lo(vd_hadd3_x(a)), s = _mm_unpacklo_pd(x, x);
+  return vd_from_halves(s, s);
+}
+
+VECTORCALL VECMATH_FINLINE vec4d vd_dot4(vec4d a, vec4d b) { return vd_hadd4(vd_mul(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_dot4_x(vec4d a, vec4d b) { return vd_hadd4_x(vd_mul(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_dot3(vec4d a, vec4d b) { return vd_hadd3(vd_mul(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_dot3_x(vec4d a, vec4d b) { return vd_hadd3_x(vd_mul(a, b)); }
+
+// r.x = ay*bz - az*by, r.y = az*bx - ax*bz, r.z = ax*by - ay*bx; .w unspecified
+VECTORCALL VECMATH_FINLINE vec4d vd_cross3(vec4d a, vec4d b) {
+  __m128d a_lo = vd_lo(a), a_hi = vd_hi(a), b_lo = vd_lo(b), b_hi = vd_hi(b);
+  __m128d r_lo = _mm_sub_pd(_mm_mul_pd(_mm_shuffle_pd(a_lo, a_hi, 1), _mm_shuffle_pd(b_hi, b_lo, 0)),
+                            _mm_mul_pd(_mm_shuffle_pd(a_hi, a_lo, 0), _mm_shuffle_pd(b_lo, b_hi, 1)));
+  __m128d r_hi = _mm_sub_pd(_mm_mul_pd(a_lo, _mm_shuffle_pd(b_lo, b_lo, 1)),
+                            _mm_mul_pd(_mm_shuffle_pd(a_lo, a_lo, 1), b_lo));
+  return vd_from_halves(r_lo, r_hi);
+}
+
+#elif _TARGET_SIMD_SCALAR
+// ------------------------------------------------------------------------------------------------
+// scalar per-lane (see dag_vecMath_scalar.h for the contract this follows)
+// ------------------------------------------------------------------------------------------------
+VECMATH_FINLINE vec4d vd_zero() { vec4d r = {0.0, 0.0, 0.0, 0.0}; return r; }
+VECMATH_FINLINE vec4d vd_splats(double a) { vec4d r = {a, a, a, a}; return r; }
+VECMATH_FINLINE vec4d vd_make_vec4d(double x, double y, double z, double w) { vec4d r = {x, y, z, w}; return r; }
+
+VECMATH_FINLINE double vd_extract_x(vec4d a) { return a.d[0]; }
+VECMATH_FINLINE double vd_extract_y(vec4d a) { return a.d[1]; }
+VECMATH_FINLINE double vd_extract_z(vec4d a) { return a.d[2]; }
+VECMATH_FINLINE double vd_extract_w(vec4d a) { return a.d[3]; }
+
+VECMATH_FINLINE vec4d vd_insert_x(vec4d a, double x) { a.d[0] = x; return a; }
+VECMATH_FINLINE vec4d vd_insert_y(vec4d a, double y) { a.d[1] = y; return a; }
+VECMATH_FINLINE vec4d vd_insert_z(vec4d a, double z) { a.d[2] = z; return a; }
+VECMATH_FINLINE vec4d vd_insert_w(vec4d a, double w) { a.d[3] = w; return a; }
+
+NO_ASAN_INLINE vec4d vd_ld(const double *m) { vec4d r; memcpy(&r, m, 32); return r; }
+NO_ASAN_INLINE vec4d vd_ldu(const double *m) { vec4d r; memcpy(&r, m, 32); return r; }
+VECMATH_FINLINE void vd_st(double *m, vec4d a) { memcpy(m, &a, 32); }
+VECMATH_FINLINE void vd_stu(double *m, vec4d a) { memcpy(m, &a, 32); }
+
+NO_ASAN_INLINE vec4d vd_ldu_p3_safe(const double *m) { vec4d r = {m[0], m[1], m[2], 0.0}; return r; }
+VECMATH_FINLINE void vd_stu_p3(double *p3, vec4d v) { memcpy(p3, &v, 24); }
+
+VECMATH_FINLINE vec4d vd_cvt_from_vec4f(vec4f a)
+{
+  vec4d r; for (int k = 0; k < 4; k++) r.d[k] = (double)a.f[k]; return r;
+}
+VECMATH_FINLINE vec4f vd_cvt_to_vec4f(vec4d a)
+{
+  vec4f r; for (int k = 0; k < 4; k++) r.f[k] = (float)a.d[k]; return r;
+}
+VECMATH_FINLINE vec4d vd_cvt_from_vec4i(vec4i a)
+{
+  vec4d r; for (int k = 0; k < 4; k++) r.d[k] = (double)a.i[k]; return r;
+}
+// out of int32 range yields INT32_MIN - mirrors x86 cvttpd2dq so backends agree
+VECMATH_FINLINE vec4i vd_cvt_to_vec4i(vec4d a)
+{
+  vec4i r;
+  for (int k = 0; k < 4; k++)
+  {
+    double v = a.d[k];
+    r.i[k] = (v >= -2147483648.0 && v < 2147483648.0) ? (int32_t)v : INT32_MIN;
+  }
+  return r;
+}
+
+VECMATH_FINLINE vec4d vd_add(vec4d a, vec4d b) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = a.d[k] + b.d[k]; return r; }
+VECMATH_FINLINE vec4d vd_sub(vec4d a, vec4d b) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = a.d[k] - b.d[k]; return r; }
+VECMATH_FINLINE vec4d vd_mul(vec4d a, vec4d b) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = a.d[k] * b.d[k]; return r; }
+VECMATH_FINLINE vec4d vd_div(vec4d a, vec4d b) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = a.d[k] / b.d[k]; return r; }
+VECMATH_FINLINE vec4d vd_neg(vec4d a) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = -a.d[k]; return r; }
+// a < b ? a : b, second operand on NaN and equal incl. +/-0 - same rule as minpd and the float v_min
+VECMATH_FINLINE vec4d vd_min(vec4d a, vec4d b) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = a.d[k] < b.d[k] ? a.d[k] : b.d[k]; return r; }
+VECMATH_FINLINE vec4d vd_max(vec4d a, vec4d b) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = a.d[k] > b.d[k] ? a.d[k] : b.d[k]; return r; }
+VECMATH_FINLINE vec4d vd_sqrt(vec4d a) { vec4d r; for (int k = 0; k < 4; k++) r.d[k] = sqrt(a.d[k]); return r; }
+VECMATH_FINLINE vec4d vd_sqrt_x(vec4d a) { a.d[0] = sqrt(a.d[0]); return a; }
+
+// left to right ((x+y)+z)+w - the same association scalar DPoint3 math has
+VECMATH_FINLINE vec4d vd_hadd4_x(vec4d a) { return vd_splats(((a.d[0] + a.d[1]) + a.d[2]) + a.d[3]); }
+VECMATH_FINLINE vec4d vd_hadd4(vec4d a) { return vd_hadd4_x(a); }
+VECMATH_FINLINE vec4d vd_hadd3_x(vec4d a) { return vd_splats((a.d[0] + a.d[1]) + a.d[2]); }
+VECMATH_FINLINE vec4d vd_hadd3(vec4d a) { return vd_hadd3_x(a); }
+
+VECMATH_FINLINE vec4d vd_dot4(vec4d a, vec4d b) { return vd_hadd4(vd_mul(a, b)); }
+VECMATH_FINLINE vec4d vd_dot4_x(vec4d a, vec4d b) { return vd_hadd4_x(vd_mul(a, b)); }
+VECMATH_FINLINE vec4d vd_dot3(vec4d a, vec4d b) { return vd_hadd3(vd_mul(a, b)); }
+VECMATH_FINLINE vec4d vd_dot3_x(vec4d a, vec4d b) { return vd_hadd3_x(vd_mul(a, b)); }
+
+VECMATH_FINLINE vec4d vd_cross3(vec4d a, vec4d b)
+{
+  vec4d r;
+  r.d[0] = a.d[1] * b.d[2] - a.d[2] * b.d[1];
+  r.d[1] = a.d[2] * b.d[0] - a.d[0] * b.d[2];
+  r.d[2] = a.d[0] * b.d[1] - a.d[1] * b.d[0];
+  r.d[3] = 0.0;
+  return r;
+}
+
+#elif _TARGET_SIMD_NEON
+// ------------------------------------------------------------------------------------------------
+// aarch64 NEON (two float64x2_t halves: .xy and .zw)
+// ------------------------------------------------------------------------------------------------
+VECTORCALL VECMATH_FINLINE float64x2_t vd_lo(vec4d a) { return a.xy; }
+VECTORCALL VECMATH_FINLINE float64x2_t vd_hi(vec4d a) { return a.zw; }
+VECTORCALL VECMATH_FINLINE vec4d vd_from_halves(float64x2_t lo, float64x2_t hi) { vec4d r; r.xy = lo; r.zw = hi; return r; }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_zero() { return vd_from_halves(vdupq_n_f64(0.0), vdupq_n_f64(0.0)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_splats(double a) { return vd_from_halves(vdupq_n_f64(a), vdupq_n_f64(a)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_make_vec4d(double x, double y, double z, double w) {
+  return vd_from_halves(vsetq_lane_f64(y, vdupq_n_f64(x), 1), vsetq_lane_f64(w, vdupq_n_f64(z), 1));
+}
+
+VECTORCALL VECMATH_FINLINE double vd_extract_x(vec4d a) { return vgetq_lane_f64(a.xy, 0); }
+VECTORCALL VECMATH_FINLINE double vd_extract_y(vec4d a) { return vgetq_lane_f64(a.xy, 1); }
+VECTORCALL VECMATH_FINLINE double vd_extract_z(vec4d a) { return vgetq_lane_f64(a.zw, 0); }
+VECTORCALL VECMATH_FINLINE double vd_extract_w(vec4d a) { return vgetq_lane_f64(a.zw, 1); }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_x(vec4d a, double x) { return vd_from_halves(vsetq_lane_f64(x, a.xy, 0), a.zw); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_y(vec4d a, double y) { return vd_from_halves(vsetq_lane_f64(y, a.xy, 1), a.zw); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_z(vec4d a, double z) { return vd_from_halves(a.xy, vsetq_lane_f64(z, a.zw, 0)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_insert_w(vec4d a, double w) { return vd_from_halves(a.xy, vsetq_lane_f64(w, a.zw, 1)); }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_ld(const double *m)  { return vd_from_halves(vld1q_f64(m), vld1q_f64(m + 2)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_ldu(const double *m) { return vd_from_halves(vld1q_f64(m), vld1q_f64(m + 2)); }
+VECTORCALL VECMATH_FINLINE void vd_st(double *m, vec4d a)  { vst1q_f64(m, a.xy); vst1q_f64(m + 2, a.zw); }
+VECTORCALL VECMATH_FINLINE void vd_stu(double *m, vec4d a) { vst1q_f64(m, a.xy); vst1q_f64(m + 2, a.zw); }
+
+// DPoint3 layout: 3 packed doubles. _safe reads exactly 3 (.w = 0); store writes exactly 3.
+NO_ASAN_INLINE vec4d vd_ldu_p3_safe(const double *m) {
+  return vd_from_halves(vld1q_f64(m), vld1q_lane_f64(m + 2, vdupq_n_f64(0.0), 0));
+}
+VECTORCALL VECMATH_FINLINE void vd_stu_p3(double *p3, vec4d v) { vst1q_f64(p3, v.xy); vst1q_lane_f64(p3 + 2, v.zw, 0); }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_cvt_from_vec4f(vec4f a) {
+  return vd_from_halves(vcvt_f64_f32(vget_low_f32(a)), vcvt_f64_f32(vget_high_f32(a)));
+}
+VECTORCALL VECMATH_FINLINE vec4f vd_cvt_to_vec4f(vec4d a) {
+  return vcombine_f32(vcvt_f32_f64(a.xy), vcvt_f32_f64(a.zw));
+}
+// widen s32 to s64 first: going through f32 would lose precision for large ints
+VECTORCALL VECMATH_FINLINE vec4d vd_cvt_from_vec4i(vec4i a) {
+  return vd_from_halves(vcvtq_f64_s64(vmovl_s32(vget_low_s32(a))), vcvtq_f64_s64(vmovl_s32(vget_high_s32(a))));
+}
+// truncates toward zero, like v_cvt_vec4i; out-of-range input is platform-specific
+VECTORCALL VECMATH_FINLINE vec4i vd_cvt_to_vec4i(vec4d a) {
+  return vcombine_s32(vmovn_s64(vcvtq_s64_f64(a.xy)), vmovn_s64(vcvtq_s64_f64(a.zw)));
+}
+
+VECTORCALL VECMATH_FINLINE vec4d vd_add(vec4d a, vec4d b) { return vd_from_halves(vaddq_f64(a.xy, b.xy), vaddq_f64(a.zw, b.zw)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_sub(vec4d a, vec4d b) { return vd_from_halves(vsubq_f64(a.xy, b.xy), vsubq_f64(a.zw, b.zw)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_mul(vec4d a, vec4d b) { return vd_from_halves(vmulq_f64(a.xy, b.xy), vmulq_f64(a.zw, b.zw)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_div(vec4d a, vec4d b) { return vd_from_halves(vdivq_f64(a.xy, b.xy), vdivq_f64(a.zw, b.zw)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_neg(vec4d a) { return vd_from_halves(vnegq_f64(a.xy), vnegq_f64(a.zw)); }
+// compare + select instead of fmin/fmax: matches SSE minpd/maxpd exactly (a < b ? a : b,
+// b wins on NaN and equal incl. +/-0), same reason as the float v_min/v_max
+VECTORCALL VECMATH_FINLINE vec4d vd_min(vec4d a, vec4d b) {
+  return vd_from_halves(vbslq_f64(vcltq_f64(a.xy, b.xy), a.xy, b.xy), vbslq_f64(vcltq_f64(a.zw, b.zw), a.zw, b.zw));
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_max(vec4d a, vec4d b) {
+  return vd_from_halves(vbslq_f64(vcgtq_f64(a.xy, b.xy), a.xy, b.xy), vbslq_f64(vcgtq_f64(a.zw, b.zw), a.zw, b.zw));
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_sqrt(vec4d a) { return vd_from_halves(vsqrtq_f64(a.xy), vsqrtq_f64(a.zw)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_sqrt_x(vec4d a) { return vd_from_halves(vsqrtq_f64(a.xy), a.zw); }
+
+// Left to right ((x+y)+z)+w, matching scalar association; see the x86 note above. faddp
+// would fold the first pair in one instruction but pairs as (x+y),(z+w), which does not match.
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd4_x(vec4d a) {
+  float64x1_t s = vadd_f64(vget_low_f64(a.xy), vget_high_f64(a.xy)); // x+y
+  s = vadd_f64(s, vget_low_f64(a.zw));                               // +z
+  s = vadd_f64(s, vget_high_f64(a.zw));                              // +w
+  float64x2_t r = vcombine_f64(s, s);
+  return vd_from_halves(r, r);
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd4(vec4d a) { return vd_hadd4_x(a); }
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd3_x(vec4d a) {
+  float64x1_t s = vadd_f64(vget_low_f64(a.xy), vget_high_f64(a.xy)); // x+y
+  s = vadd_f64(s, vget_low_f64(a.zw));                               // +z
+  float64x2_t r = vcombine_f64(s, s);
+  return vd_from_halves(r, r);
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_hadd3(vec4d a) { return vd_hadd3_x(a); }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_dot4(vec4d a, vec4d b) { return vd_hadd4(vd_mul(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_dot4_x(vec4d a, vec4d b) { return vd_hadd4_x(vd_mul(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_dot3(vec4d a, vec4d b) { return vd_hadd3(vd_mul(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_dot3_x(vec4d a, vec4d b) { return vd_hadd3_x(vd_mul(a, b)); }
+
+// r.x = ay*bz - az*by, r.y = az*bx - ax*bz, r.z = ax*by - ay*bx; .w unspecified
+VECTORCALL VECMATH_FINLINE vec4d vd_cross3(vec4d a, vec4d b) {
+  float64x2_t a_lo = a.xy, a_hi = a.zw, b_lo = b.xy, b_hi = b.zw;
+  float64x2_t r_lo = vsubq_f64(vmulq_f64(vextq_f64(a_lo, a_hi, 1), vtrn1q_f64(b_hi, b_lo)),
+                               vmulq_f64(vtrn1q_f64(a_hi, a_lo), vextq_f64(b_lo, b_hi, 1)));
+  float64x2_t r_hi = vsubq_f64(vmulq_f64(a_lo, vextq_f64(b_lo, b_lo, 1)),
+                               vmulq_f64(vextq_f64(a_lo, a_lo, 1), b_lo));
+  return vd_from_halves(r_lo, r_hi);
+}
+
+#else
+ !error! unsupported target
+#endif
+
+// ------------------------------------------------------------------------------------------------
+// composed, platform-independent
+// ------------------------------------------------------------------------------------------------
+
+// Fast double[3] load by one 4x64 bit load: reads 8 bytes past the 3 doubles, so the .w lane
+// holds whatever follows. Safe on the stack, but a heap array of packed DPoint3 whose last
+// element ends exactly at a page end crashes on the final load - use vd_ldu_p3_safe there.
+// Same trade-off and the same sanitizer routing as v_ldu_p3 (see dag_vecMath_common.h).
+NO_ASAN_INLINE vec4d vd_ldu_p3(const double *m)
+{
+#if defined(DAGOR_TSAN_ENABLED) || defined(DAGOR_ASAN_ENABLED)
+  return vd_ldu_p3_safe(m);
+#else
+  return vd_ldu(m);
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4d vd_clamp(vec4d t, vec4d min_val, vec4d max_val) { return vd_max(vd_min(t, max_val), min_val); }
+
+VECTORCALL VECMATH_FINLINE vec4d vd_length4_sq(vec4d a) { return vd_dot4(a, a); }
+VECTORCALL VECMATH_FINLINE vec4d vd_length3_sq(vec4d a) { return vd_dot3(a, a); }
+VECTORCALL VECMATH_FINLINE vec4d vd_length4(vec4d a)   { return vd_sqrt(vd_dot4(a, a)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_length4_x(vec4d a) { return vd_sqrt_x(vd_dot4_x(a, a)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_length3(vec4d a)   { return vd_sqrt(vd_dot3(a, a)); }
+VECTORCALL VECMATH_FINLINE vec4d vd_length3_x(vec4d a) { return vd_sqrt_x(vd_dot3_x(a, a)); }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif

--- a/include/vecmath/dag_vecMath_neon.h
+++ b/include/vecmath/dag_vecMath_neon.h
@@ -4,8 +4,6 @@
 //
 #pragma once
 
-#define VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE 1e-16
-
 VECTORCALL VECMATH_FINLINE vec4f v_zero() { return vdupq_n_f32(0); }
 VECTORCALL VECMATH_FINLINE vec4i v_zeroi() { return vdupq_n_u32(0); }
 VECTORCALL VECMATH_FINLINE vec4f v_set_all_bits() { return v_cast_vec4f(vmvnq_u32(vdupq_n_u32(0))); }
@@ -13,6 +11,51 @@ VECTORCALL VECMATH_FINLINE vec4i v_set_all_bitsi() { return vmvnq_u32(vdupq_n_u3
 VECTORCALL VECMATH_FINLINE vec4f v_msbit() { return (vec4f)vdupq_n_u32(0x80000000); }
 VECTORCALL VECMATH_FINLINE vec4f v_ld(const float *m) { return vld1q_f32(m); }
 VECTORCALL VECMATH_FINLINE vec4f v_ldu(const float *m) { return vld1q_f32(m); }
+VECTORCALL VECMATH_FINLINE void v_ld_soa2(const float *m, vec4f &x, vec4f &y)
+{
+  float32x4x2_t r = vld2q_f32(m);
+  x = r.val[0];
+  y = r.val[1];
+}
+VECTORCALL VECMATH_FINLINE void v_ld_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z)
+{
+  float32x4x3_t r = vld3q_f32(m);
+  x = r.val[0];
+  y = r.val[1];
+  z = r.val[2];
+}
+VECTORCALL VECMATH_FINLINE void v_ld_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w)
+{
+  float32x4x4_t r = vld4q_f32(m);
+  x = r.val[0];
+  y = r.val[1];
+  z = r.val[2];
+  w = r.val[3];
+}
+// vld2/3/4q have no alignment requirement
+VECTORCALL VECMATH_FINLINE void v_ldu_soa2(const float *m, vec4f &x, vec4f &y) { v_ld_soa2(m, x, y); }
+VECTORCALL VECMATH_FINLINE void v_ldu_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z) { v_ld_soa3(m, x, y, z); }
+VECTORCALL VECMATH_FINLINE void v_ldu_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w) { v_ld_soa4(m, x, y, z, w); }
+
+VECTORCALL VECMATH_FINLINE void v_st_soa2(float *m, vec4f x, vec4f y)
+{
+  float32x4x2_t r = {{x, y}};
+  vst2q_f32(m, r);
+}
+VECTORCALL VECMATH_FINLINE void v_st_soa3(float *m, vec4f x, vec4f y, vec4f z)
+{
+  float32x4x3_t r = {{x, y, z}};
+  vst3q_f32(m, r);
+}
+VECTORCALL VECMATH_FINLINE void v_st_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w)
+{
+  float32x4x4_t r = {{x, y, z, w}};
+  vst4q_f32(m, r);
+}
+// vst2/3/4q have no alignment requirement
+VECTORCALL VECMATH_FINLINE void v_stu_soa2(float *m, vec4f x, vec4f y) { v_st_soa2(m, x, y); }
+VECTORCALL VECMATH_FINLINE void v_stu_soa3(float *m, vec4f x, vec4f y, vec4f z) { v_st_soa3(m, x, y, z); }
+VECTORCALL VECMATH_FINLINE void v_stu_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w) { v_st_soa4(m, x, y, z, w); }
 VECTORCALL VECMATH_FINLINE vec4f v_ldu_x(const float *m) { return vsetq_lane_f32(*m, v_zero(), 0); } // load x, zero others
 VECTORCALL VECMATH_FINLINE vec4i v_ldi(const int *m) { return vld1q_s32(m); }
 VECTORCALL VECMATH_FINLINE vec4i v_ldui(const int *m) { return vld1q_s32(m); }
@@ -71,26 +114,59 @@ VECTORCALL VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b)
 
 VECTORCALL VECMATH_FINLINE int v_signmask(vec4f a)
 {
+  // arithmetic shift + and: integer vector multiply is slow on little cores and Cortex-A57
   alignas(16) static const uint32_t movemask[4] = {1, 2, 4, 8};
-  vec4i signs = vshrq_n_u32(vreinterpretq_u32_f32(a), 31);
-  vec4i masked = vmulq_u32(signs, vld1q_u32(movemask));
-  return vaddvq_u32(masked);
+  uint32x4_t signs = vreinterpretq_u32_s32(vshrq_n_s32(vreinterpretq_s32_f32(a), 31));
+  return vaddvq_u32(vandq_u32(signs, vld1q_u32(movemask)));
 }
 
+// canonical mask lanes are already all-ones/zero, no sign isolation needed
+VECTORCALL VECMATH_FINLINE int v_truemask(vec4f a)
+{
+  alignas(16) static const uint32_t movemask[4] = {1, 2, 4, 8};
+  return vaddvq_u32(vandq_u32(vreinterpretq_u32_f32(a), vld1q_u32(movemask)));
+}
+VECTORCALL VECMATH_FINLINE int v_count_true(vec4f a)
+{
+  // a true lane is all-ones == -1; one addv sums them, negate for the count
+  return -vaddvq_s32(vreinterpretq_s32_f32(a));
+}
+
+// a lane's sign bit is set iff its bit pattern as a signed int is < 0; sminv beats the positional mask
+VECTORCALL VECMATH_FINLINE bool v_is_any_neg_b(vec4f a)
+{
+  return vminvq_s32(vreinterpretq_s32_f32(a)) < 0;
+}
+
+VECTORCALL VECMATH_FINLINE int v_is_merge_planes_nout(vec4f m0, vec4f m1, vec4f m2, vec4f m3, vec4f m4, vec4f m5)
+{
+  // pairwise max == pairwise OR for canonical masks; the umaxp tree keeps the merge in vector
+  // regs with one vector->GPR crossing, instead of six serialized umaxv+fmov reductions
+  uint32x4_t r01 = vpmaxq_u32(vreinterpretq_u32_f32(m0), vreinterpretq_u32_f32(m1));
+  uint32x4_t r23 = vpmaxq_u32(vreinterpretq_u32_f32(m2), vreinterpretq_u32_f32(m3));
+  uint32x4_t r45 = vpmaxq_u32(vreinterpretq_u32_f32(m4), vreinterpretq_u32_f32(m5));
+  uint32x4_t p0123 = vpmaxq_u32(r01, r23); // (p0, p1, p2, p3)
+  uint32x4_t p4545 = vpmaxq_u32(r45, r45); // (p4, p5, p4, p5)
+  // lanes stay canonical through umaxp/and, so the reduced min is already 0 or all-ones
+  return int(vminvq_u32(vandq_u32(p0123, p4545)));
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_min_pairs(vec4f a, vec4f b) { return vpminq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_max_pairs(vec4f a, vec4f b) { return vpmaxq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_add_pairs(vec4f a, vec4f b) { return vpaddq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_addi_pairs(vec4i a, vec4i b) { return vpaddq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_mini_pairs(vec4i a, vec4i b) { return vpminq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_maxi_pairs(vec4i a, vec4i b) { return vpmaxq_s32(a, b); }
+
+// horizontal reductions keep the test to a single vector->GPR crossing
 VECTORCALL VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a)
 {
-  uint64x2_t u64 = vreinterpretq_u64_f32(a);
-  uint64_t low = vgetq_lane_u64(u64, 0);
-  uint64_t high = vgetq_lane_u64(u64, 1);
-  return (low | high) == 0ULL;
+  return vmaxvq_u32(vreinterpretq_u32_f32(a)) == 0u;
 }
 
 VECTORCALL VECMATH_FINLINE bool v_test_all_bits_ones(vec4f a)
 {
-  uint64x2_t u64 = vreinterpretq_u64_f32(a);
-  uint64_t low = vgetq_lane_u64(u64, 0);
-  uint64_t high = vgetq_lane_u64(u64, 1);
-  return (low & high) == ~0ULL;
+  return vminvq_u32(vreinterpretq_u32_f32(a)) == ~0u;
 }
 
 VECTORCALL VECMATH_FINLINE bool v_test_any_bit_set(vec4f a)
@@ -149,6 +225,10 @@ VECTORCALL VECMATH_FINLINE vec4f v_cast_vec4f(vec4i a) { return vreinterpretq_f3
 VECTORCALL VECMATH_FINLINE vec4f v_floor(vec4f a) { return vrndmq_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_ceil(vec4f a) { return vrndpq_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_trunc(vec4f a) { return vrndq_f32(a); }
+// frinta/fcvtas round ties away from zero natively, one instruction; SSE has no such mode and
+// pays a compare sequence for the same result (dag_vecMath_pc_sse.h)
+VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a) { return vrndaq_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a) { return vcvtaq_s32_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4i v_cvt_trunci(vec4f a) { return v_cvti_vec4i(a); }
 VECTORCALL VECMATH_FINLINE vec4i v_cvt_floori(vec4f a) { return vcvtq_s32_f32(vrndmq_f32(a)); }
 
@@ -166,15 +246,21 @@ VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi_ieee(vec4f a) { return vcvtnq_s32_
 VECTORCALL VECMATH_FINLINE vec4f v_add(vec4f a, vec4f b) { return vaddq_f32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_sub(vec4f a, vec4f b) { return vsubq_f32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_mul(vec4f a, vec4f b) { return vmulq_f32(a, b); }
+#ifndef VECMATH_NO_FMA
+VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c) { return vfmaq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c) { return vfmsq_f32(c, a, b); }
+#else
+// non-fused to match x86 -mno-fma builds; needs -ffp-contract=off and -fno-unsafe-math-optimizations
 VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
-VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
 VECTORCALL VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
+#endif
+VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
 VECTORCALL VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b) { return vaddq_f32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { return vsubq_f32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b) { return vmulq_f32(a, b); }
-VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { return v_madd(a, b, c); }
 VECTORCALL VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
-VECTORCALL VECMATH_FINLINE vec4f v_nmsub_x(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub_x(vec4f a, vec4f b, vec4f c) { return v_nmsub(a, b, c); }
 
 VECTORCALL VECMATH_FINLINE vec4i v_addi(vec4i a, vec4i b) { return vaddq_s32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4i v_subi(vec4i a, vec4i b) { return vsubq_s32(a, b); }
@@ -218,16 +304,38 @@ VECTORCALL VECMATH_FINLINE vec4i v_interleave_lo_i64(vec4i a, vec4i b)
 { return vreinterpretq_s32_u64(vzip1q_u64(vreinterpretq_u64_s32(a), vreinterpretq_u64_s32(b))); }
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_hi_i64(vec4i a, vec4i b)
 { return vreinterpretq_s32_u64(vzip2q_u64(vreinterpretq_u64_s32(a), vreinterpretq_u64_s32(b))); }
+VECTORCALL VECMATH_FINLINE vec4i v_perm_i8(vec4i t, vec4i k)
+{
+  // match pshufb exactly: index bits 4..6 are ignored, bit 7 zeroes the lane
+  // (vqtbl1q returns 0 for any out-of-range index)
+  uint8x16_t ki = vandq_u8(vreinterpretq_u8_s32(k), vdupq_n_u8(0x8F));
+  return vreinterpretq_s32_u8(vqtbl1q_u8(vreinterpretq_u8_s32(t), ki));
+}
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi8(vec4i a, vec4i b)
+{ return vreinterpretq_s32_u8(vceqq_u8(vreinterpretq_u8_s32(a), vreinterpretq_u8_s32(b))); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
 {
-  return v_set_x(vaddvq_f32(a));
+  // dup, not v_set_x: rebuilding a vector around the scalar reduction result costs
+  // an extra zero + insert, while dup is the cheapest way back to a vec4f
+  return vdupq_n_f32(vaddvq_f32(a));
 }
 VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec4f a)
 {
   vec4f s = v_add_x(a, v_splat_y(a));
   return v_add_x(s, v_splat_z(a));
 }
+
+// horizontal min/max via dedicated fminv/fmaxv instructions; the *3 variants first
+// duplicate .z into the unspecified .w lane so the full 4-lane reduction is valid
+VECTORCALL VECMATH_FINLINE vec4f v_hmin(vec4f a) { return vdupq_n_f32(vminvq_f32(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_hmax(vec4f a) { return vdupq_n_f32(vmaxvq_f32(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_hmin3(vec3f a) { return v_hmin(vcopyq_laneq_f32(a, 3, a, 2)); }
+VECTORCALL VECMATH_FINLINE vec4f v_hmax3(vec3f a) { return v_hmax(vcopyq_laneq_f32(a, 3, a, 2)); }
+VECTORCALL VECMATH_FINLINE vec4i v_hmini(vec4i a) { return vdupq_n_s32(vminvq_s32(a)); }
+VECTORCALL VECMATH_FINLINE vec4i v_hmaxi(vec4i a) { return vdupq_n_s32(vmaxvq_s32(a)); }
+VECTORCALL VECMATH_FINLINE vec4i v_hmini3(vec4i a) { return v_hmini(vcopyq_laneq_s32(a, 3, a, 2)); }
+VECTORCALL VECMATH_FINLINE vec4i v_hmaxi3(vec4i a) { return v_hmaxi(vcopyq_laneq_s32(a, 3, a, 2)); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_unprecise(vec4f a) { return vrecpeq_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_iter(vec4f a, vec4f est)
@@ -242,12 +350,17 @@ VECTORCALL VECMATH_FINLINE vec4f v_rcp_unprecise_x(vec4f a) { return vrecpeq_f32
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_est_x(vec4f a) { return v_rcp_est(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_div(vec4f a, vec4f b) { return vdivq_f32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b) { float32x2_t r = vdiv_f32(vget_low_f32(a), vget_low_f32(b)); return vcombine_f32(r, r); }
-VECTORCALL VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b) { return vminq_f32(a, b); }
-VECTORCALL VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b) { return vmaxq_f32(a, b); }
+// compare + select instead of fmin/fmax: matches SSE minps/maxps exactly (a < b ? a : b,
+// b wins on NaN and equal incl. +/-0) so default results stay cross-platform identical
+VECTORCALL VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b) { return vbslq_f32(vcltq_f32(a, b), a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b) { return vbslq_f32(vcgtq_f32(a, b), a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_neg(vec4f a) { return vnegq_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4i v_negi(vec4i a){ return vnegq_s32(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a) { return vabsq_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a) { return vabsq_s32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_abs_diff(vec4f a, vec4f b) { return vabdq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_abs_ge(vec4f a, vec4f b) { return vreinterpretq_f32_u32(vcageq_f32(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_abs_gt(vec4f a, vec4f b) { return vreinterpretq_f32_u32(vcagtq_f32(a, b)); }
 VECTORCALL VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b) { return vmaxq_s32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b) { return vminq_s32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b) { return vmaxq_u32(a, b); }
@@ -268,52 +381,19 @@ VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_est(vec4f a)
   return vmulq_f32(e, vrsqrtsq_f32(vmulq_f32(e, e), a));
 }
 
-VECTORCALL VECMATH_FINLINE float32x2_t v_rsqrt_est_x(float32x2_t a)
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_est_x(vec4f a)
 {
-  float32x2_t e = vrsqrte_f32(a);
-  e = vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), a));
-  return vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), a));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_est_x(vec4f a) { float32x2_t r = v_rsqrt_est_x(vget_low_f32(a)); return vcombine_f32(r, r); }
-
-// Precision ~equal to 1/sqrt on sse
-VECTORCALL VECMATH_FINLINE vec4f v_rsqrt(vec4f a)
-{
-  vec4f e = vrsqrteq_f32(a);
-  e = vmulq_f32(e, vrsqrtsq_f32(vmulq_f32(e, e), a));
-  e = vmulq_f32(e, vrsqrtsq_f32(vmulq_f32(e, e), a));
-  return vmulq_f32(e, vrsqrtsq_f32(vmulq_f32(e, e), a));
+  float32x2_t lo = vget_low_f32(a);
+  float32x2_t e = vrsqrte_f32(lo);
+  e = vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), lo));
+  e = vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), lo));
+  return vcombine_f32(e, e);
 }
 
-VECTORCALL VECMATH_FINLINE float32x2_t v_rsqrt_x(float32x2_t a)
-{
-  float32x2_t e = vrsqrte_f32(a);
-  e = vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), a));
-  return vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), a));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) { float32x2_t r = v_rsqrt_x(vget_low_f32(a)); return vcombine_f32(r, r); }
-
-//sqrt of very small number (~1e-22) returns INF instead of zero, so use bigger threshold (VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE) then 0
-//added for compatibility with SSE implementation
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a)
-{
-  return v_and(v_mul(a, vrsqrteq_f32(a)), v_cmp_gt(a, vdupq_n_f32(VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE)));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt(vec4f a)
-{
-  return vsqrtq_f32(a);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f _a)
-{
-  float32x2_t a = vget_low_f32(_a);
-  float32x2_t r = (float32x2_t)vand_s32((int32x2_t)vmul_f32(a, vrsqrte_f32(a)),
-    vcgt_f32(a, vdup_n_f32(VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE)));
-  return vcombine_f32(r, r);
-}
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt(vec4f a) { return vsqrtq_f32(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_sqrt_x(vec4f _a)
 {
-  float32x2_t a = vget_low_f32(_a);
-  float32x2_t r = (float32x2_t)vsqrt_f32(a);
+  float32x2_t r = vsqrt_f32(vget_low_f32(_a));
   return vcombine_f32(r, r);
 }
 
@@ -324,10 +404,99 @@ VECTORCALL VECMATH_FINLINE vec4i v_roti_1(vec4i a) { return vextq_u32(a, a, 1); 
 VECTORCALL VECMATH_FINLINE vec4i v_roti_2(vec4i a) { return vextq_u32(a, a, 2); }
 VECTORCALL VECMATH_FINLINE vec4i v_roti_3(vec4i a) { return vextq_u32(a, a, 3); }
 
+// clang/gcc lower every shuffle below to optimal ext/zip/trn/uzp/rev (no tbl); grouped by
+// instruction count of the clang aarch64 lowering
+#if defined(__clang__) || defined(__GNUC__)
+// 1 op: native zip/uzp/trn/ext/rev64/dup or a single lane insert
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f v) { return __builtin_shufflevector(v, v, 0, 0, 1, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f v) { return __builtin_shufflevector(v, v, 0, 0, 2, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f v) { return __builtin_shufflevector(v, v, 0, 1, 0, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f v) { return __builtin_shufflevector(v, v, 0, 1, 2, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f v) { return __builtin_shufflevector(v, v, 0, 2, 0, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f v) { return __builtin_shufflevector(v, v, 1, 3, 1, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f v) { return __builtin_shufflevector(v, v, 1, 0, 3, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f v) { return __builtin_shufflevector(v, v, 1, 1, 3, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f v) { return __builtin_shufflevector(v, v, 2, 3, 2, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f v) { return __builtin_shufflevector(v, v, 2, 2, 3, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 6, 7); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 2, 3, 6, 7); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 4, 5); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 4, 1, 2, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 5, 2, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 6, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 2, 7); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 2, 4, 6); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 3, 5, 7); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xazc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 4, 2, 6); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ybwd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 5, 3, 7); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwa(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 2, 3, 4); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 2, 3, 4, 5); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 3, 4, 5, 6); }
+// 2 ops
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a) { return __builtin_shufflevector(a, a, 2, 0, 1, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxzx(vec4f v) { return __builtin_shufflevector(v, v, 2, 0, 2, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwyy(vec4f v) { return __builtin_shufflevector(v, v, 3, 3, 1, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 4, 0, 4); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 1, 5, 5); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 0, 4, 5); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 2, 4, 5); }
+// 3 ops: prefer a 1-2 op pattern above when the layout is free to choose
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 5, 5, 1, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 5, 2, 0, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 6, 4, 0, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 2, 5, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 2, 1, 4); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 4, 0, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 0, 0, 6); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 2, 0, 0, 5); }
+// 4 ops
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 2, 4, 1, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z)
+{
+  return __builtin_shufflevector(__builtin_shufflevector(x, y, 0, 0, 4, 4), z, 0, 2, 4, 4);
+}
+#else
+// hand-written for other compilers (MSVC ARM64); same order and grouping as above
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f v) { return vzip1q_f32(v, v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f v) { return vtrn1q_f32(v, v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f v) { return vdupq_laneq_f64(v, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f v) { return vcopyq_laneq_f32(v, 3, v, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f v) { return vuzp1q_f32(v, v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f v) { return vuzp2q_f32(v, v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f v) { return vrev64q_f32(v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f v) { return vtrn2q_f32(v, v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f v) { return vdupq_laneq_f64(v, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f v) { return vzip2q_f32(v, v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd)
+{
+  return vcombine_f32(vget_low_f32(xyzw), vget_high_f32(abcd));
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd)
+{
+  return vcombine_f32(vget_high_f32(xyzw), vget_high_f32(abcd));
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return vextq_f32(vdupq_laneq_f64(xyzw, 0), abcd, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 0, abcd, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 1, abcd, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 2, abcd, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 3, abcd, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return vuzp1q_f32(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return vuzp2q_f32(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xazc(vec4f xyzw, vec4f abcd) { return vtrn1q_f32(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ybwd(vec4f xyzw, vec4f abcd) { return vtrn2q_f32(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwa(vec4f xyzw, vec4f abcd) { return vextq_f32(xyzw, abcd, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwab(vec4f xyzw, vec4f abcd) { return vextq_f32(xyzw, abcd, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd) { return vextq_f32(xyzw, abcd, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f v) { return vextq_f32(vextq_f32(v, v, 3), v, 2); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a)
 {
   return vuzpq_f32(vextq_f32(a, a, 1), a).val[1];
 }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxzx(vec4f v) { return v_rot_1(vuzp1q_f32(v, v)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwyy(vec4f v) { return v_rot_2(vtrn2q_f32(v, v)); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
@@ -341,161 +510,6 @@ VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd)
   float32x2_t bb = vdup_lane_f32(vget_low_f32(abcd), 1);
   return vcombine_f32(yy, bb);
 }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd)
-{
-  return vcombine_f32(vget_low_f32(xyzw), vget_high_f32(abcd));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd)
-{
-  return vcombine_f32(vget_high_f32(xyzw), vget_high_f32(abcd));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xycx(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2x2_t cx_dy = vzip_f32(vget_high_f32(abcd), xy);
-  float32x2_t cx = cx_dy.val[0];
-  return vcombine_f32(xy, cx);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ycxy(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2_t cd = vget_high_f32(abcd);
-  float32x2_t yc = vext_f32(xy, cd, 1);
-  return vcombine_f32(yc, xy);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd)
-{
-  float32x2x2_t za_wb = vtrn_f32(vget_high_f32(xyzw), vget_low_f32(abcd));
-  float32x2_t za = za_wb.val[0];
-  float32x2_t yx = vrev64_f32(vget_low_f32(xyzw));
-  return vcombine_f32(za, yx);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2_t zw = vget_high_f32(xyzw);
-  float32x2_t ba = vrev64_f32(vget_low_f32(abcd));
-  float32x2x2_t zx_wy = vzip_f32(zw, xy);
-  float32x2x2_t xb_ya = vzip_f32(xy, ba);
-  return vcombine_f32(zx_wy.val[0], xb_ya.val[0]);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2_t cd = vget_high_f32(abcd);
-  return vcombine_f32(vrev64_f32(xy), vzip_f32(xy, cd).val[0]);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t bz = vext_f32(vget_low_f32(abcd), vget_high_f32(xyzw), 1);
-  float32x2_t xx = vdup_lane_f32(vget_low_f32(xyzw), 0);
-  return vcombine_f32(bz, xx);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2_t yx = vrev64_f32(xy);
-  float32x2x2_t xz_yw = vzip_f32(xy, vget_high_f32(xyzw));
-  float32x2x2_t ya_xb = vzip_f32(yx, vget_low_f32(abcd));
-  return vcombine_f32(xz_yw.val[0], ya_xb.val[0]);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t dc = vrev64_f32(vget_high_f32(abcd));
-  float32x2_t xx = vdup_lane_f32(vget_low_f32(xyzw), 0);
-  float32x2_t ca = vext_f32(dc, vget_low_f32(abcd), 1);
-  return vcombine_f32(ca, xx);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2_t ya = vext_f32(xy, vget_low_f32(abcd), 1);
-  float32x2_t xx = vdup_lane_f32(xy, 0);
-  return vcombine_f32(ya, xx);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t bb = vdup_lane_f32(vget_low_f32(abcd), 1);
-  float32x2_t yx = vrev64_f32(vget_low_f32(xyzw));
-  return vcombine_f32(bb, yx);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd)
-{
-  float32x2_t xy = vget_low_f32(xyzw);
-  float32x2_t xz = vzip_f32(xy, vget_high_f32(xyzw)).val[0];
-  float32x2_t bx = vext_f32(vget_low_f32(abcd), xy, 1);
-  return vcombine_f32(xz, bx);
-}
-
-#if defined(__clang__) || defined(__GNUC__)
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f v) { return __builtin_shufflevector(v, v, 1, 0, 3, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 0); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyz(vec4f v) { return __builtin_shufflevector(v, v, 2, 0, 1, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f v) { return __builtin_shufflevector(v, v, 0, 0, 2, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f v) { return __builtin_shufflevector(v, v, 1, 1, 3, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wwyy(vec4f v) { return __builtin_shufflevector(v, v, 3, 3, 1, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f v) { return __builtin_shufflevector(v, v, 0, 1, 0, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f v) { return __builtin_shufflevector(v, v, 2, 3, 2, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f v) { return __builtin_shufflevector(v, v, 0, 2, 0, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxzx(vec4f v) { return __builtin_shufflevector(v, v, 2, 0, 2, 0); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f v) { return __builtin_shufflevector(v, v, 1, 3, 1, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f v) { return __builtin_shufflevector(v, v, 0, 1, 2, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f v) { return __builtin_shufflevector(v, v, 0, 0, 1, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f v) { return __builtin_shufflevector(v, v, 2, 2, 3, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxz(vec4f v) { return __builtin_shufflevector(v, v, 1, 2, 0, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 4, 5); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxaa(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 0, 4, 4); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wwdd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 3, 3, 7, 7); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxba(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 0, 5, 4); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wzdc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 3, 2, 7, 6); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zwba(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 2, 3, 5, 4); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zbwa(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 2, 5, 3, 4); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 2, 4, 6); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 3, 5, 7); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 0, 4, 5); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 2, 4, 5); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_cxyc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 6, 0, 1, 6); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xycc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 6, 6); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzz(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 5, 2, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xbcc(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 5, 6, 6); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 5, 2, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxac(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 1, 0, 4, 6); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 2, 7); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 0, 1, 6, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return __builtin_shufflevector(xyzw, abcd, 4, 1, 2, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z)
-{
-  return __builtin_shufflevector(__builtin_shufflevector(x, y, 0, 0, 4, 4), z, 0, 2, 4, 4);
-}
-#else
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f v) { return vrev64q_f32(v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f v) { return vextq_f32(vextq_f32(v, v, 3), v, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f v) { return vcopyq_laneq_f32(vextq_f32(v, v, 1), 2, v, 0); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f v) { return vzip2q_f32(vzip1q_f32(v, vextq_f32(v, v, 3)), v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyz(vec4f v) { return vextq_f32(vuzp1q_f32(v, v), v, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f v) { return vtrn1q_f32(v, v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f v) { return vtrn2q_f32(v, v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wwyy(vec4f v) { return v_rot_2(vtrn2q_f32(v, v)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f v) { return vdupq_laneq_f64(v, 0); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f v) { return vdupq_laneq_f64(v, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f v) { return vuzp1q_f32(v, v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zxzx(vec4f v) { return v_rot_1(vuzp1q_f32(v, v)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f v) { return vuzp2q_f32(v, v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f v) { return vcopyq_laneq_f32(v, 3, v, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f v) { return vzip1q_f32(v, v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f v) { return vzip2q_f32(v, v); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxz(vec4f v) { return vcopyq_laneq_f32(vuzp1q_f32(v, v), 0, v, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return vextq_f32(vdupq_laneq_f64(xyzw, 0), abcd, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xxaa(vec4f xyzw, vec4f abcd) { return vcombine_f32(vdup_lane_f32(vget_low_f32(xyzw), 0), vdup_lane_f32(vget_low_f32(abcd), 0)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wwdd(vec4f xyzw, vec4f abcd) { return vcombine_f32(vdup_lane_f32(vget_high_f32(xyzw), 1), vdup_lane_f32(vget_high_f32(abcd), 1)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxba(vec4f xyzw, vec4f abcd) { return vrev64q_f32(vextq_f32(vdupq_laneq_f64(xyzw, 0), abcd, 2)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_wzdc(vec4f xyzw, vec4f abcd) { return vrev64q_f32(vcopyq_laneq_u64(abcd, 0, xyzw, 1)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zwba(vec4f xyzw, vec4f abcd) { return vextq_f32(xyzw, vrev64q_f32(abcd), 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_zbwa(vec4f xyzw, vec4f abcd) { return vzip2q_f32(xyzw, vrev64q_f32(vdupq_laneq_f64(abcd, 0))); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return vuzp1q_f32(xyzw, abcd); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return vuzp2q_f32(xyzw, abcd); }
 // (xyzw.x, xyzw.x, abcd.x, abcd.y): low half = duplicate-low of xyzw, high half = unchanged low of abcd.
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd)
 {
@@ -506,17 +520,86 @@ VECTORCALL VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd)
 {
   return vcombine_f32(vext_f32(vget_low_f32(xyzw), vget_high_f32(xyzw), 1), vget_low_f32(abcd));
 }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_cxyc(vec4f xyzw, vec4f abcd) { return v_rot_3(vcombine_f32(vget_low_f32(xyzw), vdup_lane_f32(vget_high_f32(abcd), 0))); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xycc(vec4f xyzw, vec4f abcd) { return vcombine_f32(vget_low_f32(xyzw), vdup_lane_f32(vget_high_f32(abcd), 0)); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzz(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(vcopyq_laneq_f32(xyzw, 1, abcd, 1), 3, xyzw, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xbcc(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(vcopyq_laneq_f32(abcd, 0, xyzw, 0), 3, abcd, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 1, abcd, 1); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_yxac(vec4f xyzw, vec4f abcd) { return vextq_f32(vdupq_laneq_f64(vrev64q_f32(xyzw), 0), vuzp1q_f32(abcd, abcd), 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 3, abcd, 3); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 2, abcd, 2); }
-VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return vcopyq_laneq_f32(xyzw, 0, abcd, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f v) { return vzip2q_f32(vzip1q_f32(v, vextq_f32(v, v, 3)), v); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f v) { return vcopyq_laneq_f32(vextq_f32(v, v, 1), 2, v, 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t bb = vdup_lane_f32(vget_low_f32(abcd), 1);
+  float32x2_t yx = vrev64_f32(vget_low_f32(xyzw));
+  return vcombine_f32(bb, yx);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t bz = vext_f32(vget_low_f32(abcd), vget_high_f32(xyzw), 1);
+  float32x2_t xx = vdup_lane_f32(vget_low_f32(xyzw), 0);
+  return vcombine_f32(bz, xx);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t dc = vrev64_f32(vget_high_f32(abcd));
+  float32x2_t xx = vdup_lane_f32(vget_low_f32(xyzw), 0);
+  float32x2_t ca = vext_f32(dc, vget_low_f32(abcd), 1);
+  return vcombine_f32(ca, xx);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t xy = vget_low_f32(xyzw);
+  float32x2_t xz = vzip_f32(xy, vget_high_f32(xyzw)).val[0];
+  float32x2_t bx = vext_f32(vget_low_f32(abcd), xy, 1);
+  return vcombine_f32(xz, bx);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t xy = vget_low_f32(xyzw);
+  float32x2_t yx = vrev64_f32(xy);
+  float32x2x2_t xz_yw = vzip_f32(xy, vget_high_f32(xyzw));
+  float32x2x2_t ya_xb = vzip_f32(yx, vget_low_f32(abcd));
+  return vcombine_f32(xz_yw.val[0], ya_xb.val[0]);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t xy = vget_low_f32(xyzw);
+  float32x2_t ya = vext_f32(xy, vget_low_f32(abcd), 1);
+  float32x2_t xx = vdup_lane_f32(xy, 0);
+  return vcombine_f32(ya, xx);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t xy = vget_low_f32(xyzw);
+  float32x2_t cd = vget_high_f32(abcd);
+  return vcombine_f32(vrev64_f32(xy), vzip_f32(xy, cd).val[0]);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd)
+{
+  float32x2_t xy = vget_low_f32(xyzw);
+  float32x2_t zw = vget_high_f32(xyzw);
+  float32x2_t ba = vrev64_f32(vget_low_f32(abcd));
+  float32x2x2_t zx_wy = vzip_f32(zw, xy);
+  float32x2x2_t xb_ya = vzip_f32(xy, ba);
+  return vcombine_f32(zx_wy.val[0], xb_ya.val[0]);
+}
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd)
+{
+  float32x2x2_t za_wb = vtrn_f32(vget_high_f32(xyzw), vget_low_f32(abcd));
+  float32x2_t za = za_wb.val[0];
+  float32x2_t yx = vrev64_f32(vget_low_f32(xyzw));
+  return vcombine_f32(za, yx);
+}
 VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z) { return vzip1q_f32(vzip1q_f32(x, z), vzip1q_f32(y, z)); }
 #endif
+
+// integer single-source perms: NEON permutes are typeless, the float forms compile identically
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xzxz(vec4i xyzw) { return v_cast_vec4i(v_perm_xzxz(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_ywyw(vec4i xyzw) { return v_cast_vec4i(v_perm_ywyw(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyxy(vec4i xyzw) { return v_cast_vec4i(v_perm_xyxy(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_zwzw(vec4i xyzw) { return v_cast_vec4i(v_perm_zwzw(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xxyy(vec4i xyzw) { return v_cast_vec4i(v_perm_xxyy(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_zzww(vec4i xyzw) { return v_cast_vec4i(v_perm_zzww(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xxzz(vec4i xyzw) { return v_cast_vec4i(v_perm_xxzz(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_yyww(vec4i xyzw) { return v_cast_vec4i(v_perm_yyww(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_wwyy(vec4i xyzw) { return v_cast_vec4i(v_perm_wwyy(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxw(vec4i xyzw) { return v_cast_vec4i(v_perm_yzxw(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxy(vec4i xyzw) { return v_cast_vec4i(v_perm_yzxy(v_cast_vec4f(xyzw))); }
 
 #if defined(__clang__) || defined(__GNUC__)
 VECTORCALL VECMATH_FINLINE vec3f v_mat43_extract_pos(mat43f_cref mat)
@@ -535,56 +618,6 @@ VECTORCALL VECMATH_FINLINE vec3f v_mat43_extract_pos(mat43f_cref mat)
 }
 #endif
 
-VECTORCALL VECMATH_FINLINE vec4f v_transpose3x(vec4f a, vec4f b, vec4f c)
-{
-  float32x2_t a0b0 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[0];
-  float32x2_t c0c0 = vdup_lane_f32(vget_low_f32(c), 0);
-  return vcombine_f32(a0b0, c0c0);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_transpose3y(vec4f a, vec4f b, vec4f c)
-{
-  float32x2_t a1b1 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[1];
-  float32x2_t c1c1 = vdup_lane_f32(vget_low_f32(c), 1);
-  return vcombine_f32(a1b1, c1c1);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_transpose3z(vec4f a, vec4f b, vec4f c)
-{
-  float32x2_t a2b2 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[0];
-  float32x2_t c2c2 = vdup_lane_f32(vget_high_f32(c), 0);
-  return vcombine_f32(a2b2, c2c2);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_transpose3w(vec4f a, vec4f b, vec4f c)
-{
-  float32x2_t a3b3 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[1];
-  float32x2_t c3c3 = vdup_lane_f32(vget_high_f32(c), 1);
-  return vcombine_f32(a3b3, c3c3);
-}
-
-VECTORCALL VECMATH_FINLINE vec4f v_transpose4x(vec4f a, vec4f b, vec4f c, vec4f d)
-{
-  float32x2_t a0b0 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[0];
-  float32x2_t c0d0 = vtrn_f32(vget_low_f32(c), vget_low_f32(d)).val[0];
-  return vcombine_f32(a0b0, c0d0);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_transpose4y(vec4f a, vec4f b, vec4f c, vec4f d)
-{
-  float32x2_t a1b1 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[1];
-  float32x2_t c1d1 = vtrn_f32(vget_low_f32(c), vget_low_f32(d)).val[1];
-  return vcombine_f32(a1b1, c1d1);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_transpose4z(vec4f a, vec4f b, vec4f c, vec4f d)
-{
-  float32x2_t a2b2 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[0];
-  float32x2_t c2d2 = vtrn_f32(vget_high_f32(c), vget_high_f32(d)).val[0];
-  return vcombine_f32(a2b2, c2d2);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_transpose4w(vec4f a, vec4f b, vec4f c, vec4f d)
-{
-  float32x2_t a3b3 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[1];
-  float32x2_t c3d3 = vtrn_f32(vget_high_f32(c), vget_high_f32(d)).val[1];
-  return vcombine_f32(a3b3, c3d3);
-}
-
 VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b)
 {
   float32x2_t m = vmul_f32(vget_low_f32(a), vget_low_f32(b));
@@ -599,74 +632,40 @@ VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b)
 
 VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b)
 {
-  vec4f m;
-  m = v_mul(a, b);
-  m = v_madd(v_rot_1(a), v_rot_1(b), m);
-  return v_madd(v_rot_2(a), v_rot_2(b), m);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b) { return v_splat_x(v_dot3_x(a, b)); }
-
-VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b)
-{
-  vec4f m;
-  m = v_mul(a, b);
-  m = v_madd(v_rot_1(a), v_rot_1(b), m);
-  return v_add(v_rot_2(m), m);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return v_dot4(a,b); }
-
-VECTORCALL VECMATH_FINLINE vec4f v_length4_sq(vec4f a)
-{
-  vec4f m = v_mul(a, a);
-  vec4f ar1 = v_rot_1(a);
-  m = v_madd(ar1, ar1, m);
-  return v_add(v_rot_2(m), m);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_length4_sq(a); }
-
-VECTORCALL VECMATH_FINLINE float32x2_t v_length4_sq_xd(vec4f a)
-{
-  vec4f m = v_mul(a, a);
-  float32x2_t m2 = vadd_f32(vget_low_f32(m), vget_high_f32(m));
-  return vadd_f32(m2, vext_f32(m2, m2, 1));
+  float32x4_t mul = vmulq_f32(a, b);
+  float32x2_t lo = vget_low_f32(mul);
+  float32x2_t hi = vget_high_f32(mul);
+  float32x2_t xy = vpadd_f32(lo, lo);
+  float32x2_t r = vadd_f32(xy, hi);
+  return vcombine_f32(r, r);
 }
 
-VECTORCALL VECMATH_FINLINE vec3f v_length3_sq(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b)
 {
-  vec4f m = v_mul(a, a);
-  vec4f ar1 = v_rot_1(a), ar2 = v_rot_2(m);
-  m = v_madd(ar1, ar1, m);
-  return v_splat_x(v_add(ar2, m));
-}
-VECTORCALL VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a)
-{
-  return v_length3_sq(a);
-}
-VECTORCALL VECMATH_FINLINE float32x2_t v_length3_sq_xd(vec3f a)
-{
-  vec4f m = v_mul(a, a);
-  float32x2_t ar1 = vget_low_f32(v_rot_1(a)), ar2 = vget_high_f32(m);
-  float32x2_t m2 = vmla_f32(vget_low_f32(m), ar1, ar1);
-  return vadd_f32(ar2, m2);
-}
-VECTORCALL VECMATH_FINLINE float32x2_t v_length2_sq_xd(vec4f a)
-{
-  float32x2_t xy = vget_low_f32(a);
-  float32x2_t m = vmul_f32(xy, xy);
-  return vadd_f32(m, vrev64_f32(m));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_length2_sq(vec4f a)
-{
-   return vdupq_lane_f32(v_length2_sq_xd(a), 0);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a)
-{
-   return vdupq_lane_f32(v_length2_sq_xd(a), 0);
+  float32x4_t mul = vmulq_f32(a, b);
+  float32x2_t lo = vget_low_f32(mul);
+  float32x2_t hi = vget_high_f32(mul);
+  float32x2_t xy = vpadd_f32(lo, lo);
+  float32x2_t r = vadd_f32(xy, hi);
+  return vdupq_lane_f32(r, 0);
 }
 
-VECTORCALL VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length4_sq_xd(a)), 0)); }
-VECTORCALL VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length3_sq_xd(a)), 0)); }
-VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length2_sq_xd(a)), 0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return vdupq_n_f32(vaddvq_f32(vmulq_f32(a, b))); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b) { return vdupq_n_f32(vaddvq_f32(vmulq_f32(a, b))); }
+
+// fmulx is fmul for every finite input (only 0*inf differs) but cannot be contracted into the
+// fsub, so both products stay rounded and a x a is exactly 0. A plain vmulq pair is folded
+// back into fmls whatever -ffp-contract says.
+VECTORCALL VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b)
+{
+  // (a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x)
+  // yzxy, not yzxw: lane 3 of the products is never read, and yzxy is 2 ext where yzxw is 3 ops
+  vec3f ayzx = v_perm_yzxy(a);
+  vec3f byzx = v_perm_yzxy(b);
+  return v_perm_yzxy(vsubq_f32(vmulxq_f32(a, byzx), vmulxq_f32(ayzx, b)));
+}
+
+// v_length*_sq and v_norm2/3/4 live in dag_vecMath_common.h (portable form).
 
 VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return v_add_x(v_dot3_x(a,b), v_rot_3(a)); }
 VECTORCALL VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b) { return v_splat_x(v_plane_dist_x(a,b)); }
@@ -702,23 +701,6 @@ VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, co
   v_stu(m43 + 8, v2);
 }
 
-//mat44f from unaligned TMatrix
-VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43)
-{
-  vec4f v0 = v_ldu(m43 + 0);
-  vec4f v1 = v_ldu(m43 + 4);
-  vec4f v2 = v_ldu(m43 + 8);
-
-  vec4f col1 = vextq_f32(v0, v1, 3);
-  vec4f col2 = vextq_f32(v1, v2, 2);
-  vec4f col3 = vextq_f32(v2, v2, 1);
-
-  tmV.col0 = vsetq_lane_f32(0.f, v0, 3);
-  tmV.col1 = vsetq_lane_f32(0.f, col1, 3);
-  tmV.col2 = vsetq_lane_f32(0.f, col2, 3);
-  tmV.col3 = vsetq_lane_f32(1.f, col3, 3);
-}
-
 // mat44f from unaligned TMatrix
 VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43)
 {
@@ -732,10 +714,23 @@ VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const
   tmV.col3 = vextq_f32(v2, v2, 1);
 }
 
-//mat44f from aligned TMatrix
+// clang fuses the affine fixup into the construction, per instruction the same code as a
+// hand-interleaved version
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43)
+{
+  v_mat44_make_from_43cu_unsafe(tmV, m43);
+  v_mat44_make_affine(tmV);
+}
+
 VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43)
 {
   v_mat44_make_from_43cu(tmV, m43);
+}
+
+// the single ld3 gives the translation in .w for free, no cheaper form exists
+VECTORCALL VECMATH_FINLINE void v_mat43_make_from_43cu_unsafe(mat43f &tmV, const float *const __restrict m43)
+{
+  v_ldu_soa3(m43, tmV.row0, tmV.row1, tmV.row2);
 }
 
 VECTORCALL VECMATH_FINLINE void v_mat44_ident(mat44f &dest)
@@ -765,260 +760,11 @@ VECTORCALL VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest)
   dest.col2 = v_rot_1(dest.col1);
 }
 
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3;
-  tmp0 = v_merge_hw(r0, r2);
-  tmp1 = v_merge_hw(r1, r3);
-  tmp2 = v_merge_lw(r0, r2);
-  tmp3 = v_merge_lw(r1, r3);
-  r0 = v_merge_hw(tmp0, tmp1);
-  r1 = v_merge_lw(tmp0, tmp1);
-  r2 = v_merge_hw(tmp2, tmp3);
-  r3 = v_merge_lw(tmp2, tmp3);
-}
+// v_mat44_transpose*, v_mat43_transpose_to_mat44, v_mat44_transpose_to_mat43 and
+// v_mat44/33_mul_vec* live in dag_vecMath_common.h (portable form, identical to the
+// NEON code that used to be here).
 
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3;
-  tmp0 = v_merge_hw(src.col0, src.col2);
-  tmp1 = v_merge_hw(src.col1, src.col3);
-  tmp2 = v_merge_lw(src.col0, src.col2);
-  tmp3 = v_merge_lw(src.col1, src.col3);
-  dest.col0 = v_merge_hw(tmp0, tmp1);
-  dest.col1 = v_merge_lw(tmp0, tmp1);
-  dest.col2 = v_merge_hw(tmp2, tmp3);
-  dest.col3 = v_merge_lw(tmp2, tmp3);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3;
-  tmp0 = v_merge_hw(src.row0, src.row2);
-  tmp1 = v_merge_hw(src.row1, v_zero());
-  tmp2 = v_merge_lw(src.row0, src.row2);
-  tmp3 = v_merge_lw(src.row1, v_zero());
-  dest.col0 = v_merge_hw(tmp0, tmp1);
-  dest.col1 = v_merge_lw(tmp0, tmp1);
-  dest.col2 = v_merge_hw(tmp2, tmp3);
-  dest.col3 = v_merge_lw(tmp2, tmp3);
-}
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3;
-  tmp0 = v_merge_hw(src.col0, src.col2);
-  tmp1 = v_merge_hw(src.col1, src.col3);
-  tmp2 = v_merge_lw(src.col0, src.col2);
-  tmp3 = v_merge_lw(src.col1, src.col3);
-  dest.row0 = v_merge_hw(tmp0, tmp1);
-  dest.row1 = v_merge_lw(tmp0, tmp1);
-  dest.row2 = v_merge_hw(tmp2, tmp3);
-}
-
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = v_splat_y(v);
-  vec4f zzzz = v_splat_z(v);
-  vec4f wwww = v_splat_w(v);
-  vec4f tmp0, tmp1;
-
-  tmp0 = v_mul(m.col0, xxxx);
-  tmp1 = v_mul(m.col1, yyyy);
-  tmp0 = v_madd(m.col2, zzzz, tmp0);
-  tmp1 = v_madd(m.col3, wwww, tmp1);
-  return v_add(tmp0, tmp1);
-}
-
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec4f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = v_splat_y(v);
-  vec4f zzzz = v_splat_z(v);
-  vec4f res;
-
-  res = v_mul(m.col0, xxxx);
-  res = v_madd(m.col1, yyyy, res);
-  return v_madd(m.col2, zzzz, res);
-}
-
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec4f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = v_splat_y(v);
-  vec4f zzzz = v_splat_z(v);
-  vec4f tmp0, tmp1;
-
-  tmp0 = v_mul(m.col0, xxxx);
-  tmp1 = v_mul(m.col1, yyyy);
-  tmp0 = v_madd(m.col2, zzzz, tmp0);
-  tmp1 = v_add(m.col3, tmp1);
-  return v_add(tmp0, tmp1);
-}
-
-VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = v_splat_y(v);
-  vec4f zzzz = v_splat_z(v);
-  vec4f res;
-
-  res = v_mul(m.col0, xxxx);
-  res = v_madd(m.col1, yyyy, res);
-  return v_madd(m.col2, zzzz, res);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
-{
-  vec4f in0 = m.col0; // AEIM
-  vec4f in1 = m.col1; // BFJN
-  vec4f in2 = m.col2; // CGKO
-  vec4f in3 = m.col3; // DHLP
-
-  vec4f inA0 = v_merge_hw(in0, in1); // ABEF
-  vec4f inA1 = v_merge_hw(in2, in3); // CDGH
-  vec4f inA2 = v_merge_lw(in0, in1); // IJMN
-  vec4f inA3 = v_merge_lw(in2, in3); // KLOP
-
-  // XYZW, ABCD
-  vec4f KKII = v_perm_xxaa(inA3, inA2); // KLOP, IJMN
-  vec4f KIIK = v_rot_1(KKII);
-  vec4f PPNN = v_perm_wwdd(in3, in1);   // DHLP, BFJN
-  vec4f NPPN = v_rot_3(PPNN);
-  vec4f OOMM = v_perm_wwdd(in2, in0);   // CGKO, AEIM
-  vec4f OMMO = v_rot_1(OOMM);
-  vec4f JILK = v_perm_yxba(inA2, inA3); // IJMN, KLOP
-  vec4f LKJI = v_rot_2(JILK);
-  vec4f PONM = v_perm_wzdc(inA3, inA2); // KLOP, IJMN
-  vec4f NMPO = v_rot_2(PONM);
-  vec4f LLJJ = v_perm_yybb(inA3, inA2); // KLOP, IJMN
-  vec4f JLLJ = v_rot_3(LLJJ);
-  vec4f CCAA = v_perm_xxaa(in2, in0);   // CGKO, AEIM
-  vec4f CAAC = v_rot_1(CCAA);
-  vec4f GGEE = v_perm_yybb(in2, in0);   // CGKO, AEIM
-  vec4f GEEG = v_rot_1(GGEE);
-  vec4f BADC = v_perm_yxba(inA0, inA1); // ABEF, CDGH
-  vec4f DCBA = v_perm_yxba(inA1, inA0); // CDGH, ABEF
-  vec4f HGFE = v_perm_wzdc(inA1, inA0); // CDGH, ABEF
-  vec4f FEHG = v_perm_wzdc(inA0, inA1); // ABEF, CDGH
-  vec4f HHFF = v_perm_wwdd(inA1, inA0); // CDGH, ABEF
-  vec4f FHHF = v_rot_3(HHFF);
-  vec4f DDBB = v_perm_xxaa(in3, in1);   // DHLP, BFJN
-  vec4f BDDB = v_rot_3(DDBB);
-
-  vec4f KP_IP_IN_KN = v_mul(KIIK, PPNN);
-  vec4f JP_IO_LN_KM = v_mul(JILK, PONM);
-  vec4f KN_KP_IP_IN = v_mul(KKII, NPPN);
-  vec4f CH_AH_AF_CF = v_mul(CAAC, HHFF);
-  vec4f BH_AG_DF_CE = v_mul(BADC, HGFE);
-  vec4f CF_CH_AH_AF = v_mul(CCAA, FHHF);
-
-  vec4f GHEF = v_perm_zwcd(inA1, inA0); // CDGH, ABEF
-  vec4f FGHE = v_rot_3(GHEF);
-  vec4f HEFG = v_rot_1(GHEF);
-  vec4f CDAB = v_perm_xyab(inA1, inA0); // CDGH, ABEF
-  vec4f BCDA = v_rot_3(CDAB);
-  vec4f DABC = v_rot_1(CDAB);
-  vec4f OPMN = v_perm_zwcd(inA3, inA2); // KLOP, IJMN
-  vec4f NOPM = v_rot_3(OPMN);
-  vec4f PMNO = v_rot_1(OPMN);
-  vec4f KLIJ = v_perm_xyab(inA3, inA2); // KLOP, IJMN
-  vec4f JKLI = v_rot_3(KLIJ);
-  vec4f LIJK = v_rot_1(KLIJ);
-
-  vec4f KP_LO_IP_LM_IN_JM_KN_JO = v_nmsub(LLJJ, OMMO, KP_IP_IN_KN);
-  vec4f JP_LN_IO_KM_LN_JP_KM_IO = v_nmsub(LKJI, NMPO, JP_IO_LN_KM);
-  vec4f KN_JO_KP_LO_IP_LM_IN_JM = v_nmsub(JLLJ, OOMM, KN_KP_IP_IN);
-  vec4f CH_DG_AH_DE_AF_BE_CF_BG = v_nmsub(DDBB, GEEG, CH_AH_AF_CF);
-  vec4f BH_DF_AG_CE_DF_BH_CE_AG = v_nmsub(DCBA, FEHG, BH_AG_DF_CE);
-  vec4f CF_BG_CH_DG_AH_DE_AF_BE = v_nmsub(BDDB, GGEE, CF_CH_AH_AF);
-
-  vec4f tmpA1 = v_mul(FGHE, KP_LO_IP_LM_IN_JM_KN_JO);
-  vec4f tmpB1 = v_nmsub(GHEF, JP_LN_IO_KM_LN_JP_KM_IO, tmpA1);
-  vec4f out1 = v_nmsub(HEFG, KN_JO_KP_LO_IP_LM_IN_JM, tmpB1);
-  vec4f tmpB2 = v_mul(CDAB, JP_LN_IO_KM_LN_JP_KM_IO);
-  vec4f tmpA2 = v_nmsub(BCDA, KP_LO_IP_LM_IN_JM_KN_JO, tmpB2);
-  vec4f out2 = v_madd(DABC, KN_JO_KP_LO_IP_LM_IN_JM, tmpA2);
-  vec4f tmpA3 = v_mul(NOPM, CH_DG_AH_DE_AF_BE_CF_BG);
-  vec4f tmpB3 = v_nmsub(OPMN, BH_DF_AG_CE_DF_BH_CE_AG, tmpA3);
-  vec4f out3 = v_nmsub(PMNO, CF_BG_CH_DG_AH_DE_AF_BE, tmpB3);
-  vec4f tmpB4 = v_mul(KLIJ, BH_DF_AG_CE_DF_BH_CE_AG);
-  vec4f tmpA4 = v_nmsub(JKLI, CH_DG_AH_DE_AF_BE_CF_BG, tmpB4);
-  vec4f out4 = v_madd(LIJK, CF_BG_CH_DG_AH_DE_AF_BE, tmpA4);
-
-  //det
-  vec4f AF_BE_AG_CE_CF_BG_BH_DF = v_perm_zbwa(CH_DG_AH_DE_AF_BE_CF_BG, BH_DF_AG_CE_DF_BH_CE_AG);
-  vec4f KP_LO_JP_LN_IP_LM_IO_KM = v_merge_hw(KP_LO_IP_LM_IN_JM_KN_JO, JP_LN_IO_KM_LN_JP_KM_IO);
-  vec4f CH_DG_AH_DE_BH_DF_AG_CE = v_perm_xyab(CH_DG_AH_DE_AF_BE_CF_BG, BH_DF_AG_CE_DF_BH_CE_AG);
-  vec4f IN_JM_KN_JO_IO_KM_JP_LN = v_perm_zwba(KP_LO_IP_LM_IN_JM_KN_JO, JP_LN_IO_KM_LN_JP_KM_IO);
-  vec4f det0 = v_mul(AF_BE_AG_CE_CF_BG_BH_DF, KP_LO_JP_LN_IP_LM_IO_KM);
-  vec4f det1 = v_madd(CH_DG_AH_DE_BH_DF_AG_CE, IN_JM_KN_JO_IO_KM_JP_LN, det0);
-  vec4f detA0 = v_splat_x(det1);
-  vec4f detA1 = v_splat_y(det1);
-  vec4f detA2 = v_splat_z(det1);
-  vec4f detB0 = v_sub(detA0, detA1);
-  vec4f det = v_sub(detB0, detA2);
-  vec4f invdet = v_rcp_safe(det);
-  /* Multiply the cofactors by the reciprocal of the determinant.
-  */
-  dest.col0 = v_mul(out1, invdet);
-  dest.col1 = v_mul(out2, invdet);
-  dest.col2 = v_mul(out3, invdet);
-  dest.col3 = v_mul(out4, invdet);
-}
-VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
-{
-  vec4f tmp0, tmp1, tmp2, dot, invdet, inv0, inv1, inv2;
-    tmp2 = v_cross3(m.col0, m.col1);
-  tmp0 = v_cross3(m.col1, m.col2);
-  tmp1 = v_cross3(m.col2, m.col0);
-  dot = v_dot3(tmp2, m.col2);
-  invdet = v_rcp_safe(dot);
-  inv0 = v_transpose3x(tmp0, tmp1, tmp2);
-  inv1 = v_transpose3y(tmp0, tmp1, tmp2);
-  inv2 = v_transpose3z(tmp0, tmp1, tmp2);
-  dest.col0 = v_mul(inv0, invdet);
-  dest.col1 = v_mul(inv1, invdet);
-  dest.col2 = v_mul(inv2, invdet);
-}
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3;
-  vec4f cof0;
-  vec4f t0, t1, t2, t3;
-  vec4f t12, t23;
-  vec4f t1r, t2r;
-  vec4f t12r, t23r;
-  vec4f t1r3, t1r3r;
-
-  tmp0 = v_perm_xzac(m.col0, m.col1);
-  tmp1 = v_perm_xzac(m.col2, m.col3);
-  tmp2 = v_perm_ywbd(m.col0, m.col1);
-  tmp3 = v_perm_ywbd(m.col2, m.col3);
-  t0 = v_perm_xzac(tmp0, tmp1);
-  t1 = v_perm_xzac(tmp3, tmp2);
-  t2 = v_perm_ywbd(tmp0, tmp1);
-  t3 = v_perm_ywbd(tmp3, tmp2);
-
-  t23 = v_mul(t2, t3);
-  t23 = v_perm_yxwz(t23);
-  cof0 = v_mul(t1, t23);
-  t23r = v_rot_2(t23);
-  cof0 = v_neg(v_nmsub(t1, t23r, cof0));
-  t12 = v_mul(t1, t2);
-  t12 = v_perm_yxwz(t12);
-  cof0 = v_madd(t3, t12, cof0);
-  t12r = v_rot_2(t12);
-  cof0 = v_nmsub(t3, t12r, cof0);
-  t1r = v_rot_2(t1);
-  t2r = v_rot_2(t2);
-  t1r3 = v_mul(t1r, t3);
-  t1r3 = v_perm_yxwz(t1r3);
-  cof0 = v_madd(t2r, t1r3, cof0);
-  t1r3r = v_rot_2(t1r3);
-  cof0 = v_nmsub(t2r, t1r3r, cof0);
-  return v_dot4(t0, cof0);
-}
+// v_mat33_inverse and v_mat44_det live in dag_vecMath_common.h (portable form).
 
 VECTORCALL VECMATH_FINLINE short v_extract_xi16(vec4i v) { return vgetq_lane_s16(vreinterpretq_s16_s32(v), 0); }
 
@@ -1101,23 +847,19 @@ VECTORCALL VECMATH_FINLINE vec4i v_srai(vec4i v, int bits) { return vshrq_n_s32(
 VECTORCALL VECMATH_FINLINE vec4i v_slli_64(vec4i v, int bits) { return (int32x4_t)vshlq_n_u64((uint64x2_t)v, bits); }
 VECTORCALL VECMATH_FINLINE vec4i v_srli_64(vec4i v, int bits) { return (int32x4_t)vshrq_n_u64((uint64x2_t)v, bits); }
 #endif
+// bits must be in [0, 31]; sshl/ushl still zero-fill (or sign-fill for sra) up to 127, but
+// negative or wider counts alias through the low byte and differ from x86
 VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, int bits)
 {
-  if (bits & ~31)
-    return v_zero();
-  return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(bits)));
+  return vshlq_s32(v, vdupq_n_s32(bits));
 }
 VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, int bits)
 {
-  if (bits & ~31)
-    return v_zero();
-  return vreinterpretq_s64_s32(vshlq_u32(vreinterpretq_s32_s64(v), vdupq_n_s32(-bits)));
+  return (int32x4_t)vshlq_u32((uint32x4_t)v, vdupq_n_s32(-bits));
 }
 VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, int bits)
 {
-  if (bits & ~31)
-    return v_cmp_lti(v, v_zeroi());
-  return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(-bits)));
+  return vshlq_s32(v, vdupq_n_s32(-bits));
 }
 VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits)
 {
@@ -1126,9 +868,7 @@ VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits)
 #else
   int64_t c = (int64_t)vget_low_s64(bits);
 #endif
-  if (c & ~31)
-    return v_zero();
-  return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(c)));
+  return vshlq_s32(v, vdupq_n_s32(c));
 }
 VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits)
 {
@@ -1137,9 +877,7 @@ VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits)
 #else
   int64_t c = (int64_t)vget_low_s64(bits);
 #endif
-  if (c & ~31)
-    return v_zero();
-  return vreinterpretq_s64_s32(vshlq_u32(vreinterpretq_s32_s64(v), vdupq_n_s32(-c)));
+  return (int32x4_t)vshlq_u32((uint32x4_t)v, vdupq_n_s32(-c));
 }
 VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits)
 {
@@ -1148,9 +886,7 @@ VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits)
 #else
   int64_t c = (int64_t)vget_low_s64(bits);
 #endif
-  if (c & ~31)
-    return v_cmp_lti(v, v_zeroi());
-  return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(-c)));
+  return vshlq_s32(v, vdupq_n_s32(-c));
 }
 
 VECTORCALL VECMATH_FINLINE vec4i v_sll(vec4i v, int bits) { return (int32x4_t)vshlq_u32((uint32x4_t)v, (int32x4_t)v_splatsi(bits)); }

--- a/include/vecmath/dag_vecMath_pc_sse.h
+++ b/include/vecmath/dag_vecMath_pc_sse.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #if !defined(_TARGET_PC_LINUX) && !defined(_TARGET_PC_MACOSX) && !defined(_TARGET_PC_WIN)\
- && !defined(_TARGET_PS4) && !defined(_TARGET_PS5)  && !defined(_TARGET_XBOX) && !defined(_TARGET_PC) && !defined(_TARGET_ANDROID)
+ && !defined(_TARGET_C1) && !defined(_TARGET_C2)  && !defined(_TARGET_XBOX) && !defined(_TARGET_PC) && !defined(_TARGET_ANDROID)
   #if __linux__ || __unix__
     #define _TARGET_PC_LINUX 1
   #elif __APPLE__
@@ -57,6 +57,132 @@ NO_ASAN_INLINE vec4i v_ldi(const int *m) { return  _mm_load_si128((const vec4i*)
 NO_ASAN_INLINE vec4i v_ldui(const int *m) { return _mm_loadu_si128((const vec4i*)m); }
 NO_ASAN_INLINE vec4f v_ldu_x(const float *m) { return _mm_load_ss(m); } // load x, zero others
 #endif
+
+VECTORCALL VECMATH_FINLINE void v_ld_soa2(const float *m, vec4f &x, vec4f &y)
+{
+  vec4f a = v_ld(m), b = v_ld(m + 4);
+  x = _mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0));
+  y = _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1));
+}
+
+VECTORCALL VECMATH_FINLINE void v_ld_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z)
+{
+  vec4f x0y0z0x1 = v_ld(m), y1z1x2y2 = v_ld(m + 4), z2x3y3z3 = v_ld(m + 8);
+  vec4f x2y2x3y3 = _mm_shuffle_ps(y1z1x2y2, z2x3y3z3, _MM_SHUFFLE(2, 1, 3, 2));
+  vec4f y0z0y1z1 = _mm_shuffle_ps(x0y0z0x1, y1z1x2y2, _MM_SHUFFLE(1, 0, 2, 1));
+  x = _mm_shuffle_ps(x0y0z0x1, x2y2x3y3, _MM_SHUFFLE(2, 0, 3, 0));
+  y = _mm_shuffle_ps(y0z0y1z1, x2y2x3y3, _MM_SHUFFLE(3, 1, 2, 0));
+  z = _mm_shuffle_ps(y0z0y1z1, z2x3y3z3, _MM_SHUFFLE(3, 0, 3, 1));
+}
+
+VECTORCALL VECMATH_FINLINE void v_ld_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w)
+{
+  vec4f a = v_ld(m), b = v_ld(m + 4), c = v_ld(m + 8), d = v_ld(m + 12);
+  vec4f t0 = _mm_unpacklo_ps(a, b), t1 = _mm_unpackhi_ps(a, b);
+  vec4f t2 = _mm_unpacklo_ps(c, d), t3 = _mm_unpackhi_ps(c, d);
+  x = _mm_movelh_ps(t0, t2);
+  y = _mm_movehl_ps(t2, t0);
+  z = _mm_movelh_ps(t1, t3);
+  w = _mm_movehl_ps(t3, t1);
+}
+
+VECTORCALL VECMATH_FINLINE void v_ldu_soa2(const float *m, vec4f &x, vec4f &y)
+{
+  vec4f a = v_ldu(m), b = v_ldu(m + 4);
+  x = _mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0));
+  y = _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1));
+}
+
+VECTORCALL VECMATH_FINLINE void v_ldu_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z)
+{
+  vec4f x0y0z0x1 = v_ldu(m), y1z1x2y2 = v_ldu(m + 4), z2x3y3z3 = v_ldu(m + 8);
+  vec4f x2y2x3y3 = _mm_shuffle_ps(y1z1x2y2, z2x3y3z3, _MM_SHUFFLE(2, 1, 3, 2));
+  vec4f y0z0y1z1 = _mm_shuffle_ps(x0y0z0x1, y1z1x2y2, _MM_SHUFFLE(1, 0, 2, 1));
+  x = _mm_shuffle_ps(x0y0z0x1, x2y2x3y3, _MM_SHUFFLE(2, 0, 3, 0));
+  y = _mm_shuffle_ps(y0z0y1z1, x2y2x3y3, _MM_SHUFFLE(3, 1, 2, 0));
+  z = _mm_shuffle_ps(y0z0y1z1, z2x3y3z3, _MM_SHUFFLE(3, 0, 3, 1));
+}
+
+VECTORCALL VECMATH_FINLINE void v_ldu_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w)
+{
+  vec4f a = v_ldu(m), b = v_ldu(m + 4), c = v_ldu(m + 8), d = v_ldu(m + 12);
+  vec4f t0 = _mm_unpacklo_ps(a, b), t1 = _mm_unpackhi_ps(a, b);
+  vec4f t2 = _mm_unpacklo_ps(c, d), t3 = _mm_unpackhi_ps(c, d);
+  x = _mm_movelh_ps(t0, t2);
+  y = _mm_movehl_ps(t2, t0);
+  z = _mm_movelh_ps(t1, t3);
+  w = _mm_movehl_ps(t3, t1);
+}
+
+// SoA lanes to 3 packed-float3 registers, the inverse of the v_ldu_soa3 deinterleave
+VECTORCALL VECMATH_FINLINE void v_interleave3(vec4f x, vec4f y, vec4f z, vec4f &e0, vec4f &e1, vec4f &e2)
+{
+  vec4f xy01 = _mm_unpacklo_ps(x, y);
+  vec4f zx01 = _mm_shuffle_ps(z, x, _MM_SHUFFLE(1, 1, 0, 0));
+  e0 = _mm_shuffle_ps(xy01, zx01, _MM_SHUFFLE(2, 0, 1, 0)); // x0 y0 z0 x1
+  vec4f yz1 = _mm_shuffle_ps(y, z, _MM_SHUFFLE(1, 1, 1, 1));
+  vec4f xy2 = _mm_shuffle_ps(x, y, _MM_SHUFFLE(2, 2, 2, 2));
+  e1 = _mm_shuffle_ps(yz1, xy2, _MM_SHUFFLE(2, 0, 2, 0)); // y1 z1 x2 y2
+  vec4f zx23 = _mm_shuffle_ps(z, x, _MM_SHUFFLE(3, 3, 2, 2));
+  vec4f yz23 = _mm_unpackhi_ps(y, z);
+  e2 = _mm_shuffle_ps(zx23, yz23, _MM_SHUFFLE(3, 2, 2, 0)); // z2 x3 y3 z3
+}
+
+// SoA lanes to 4 packed-float4 registers (a transpose), the inverse of the v_ldu_soa4 deinterleave
+VECTORCALL VECMATH_FINLINE void v_interleave4(vec4f x, vec4f y, vec4f z, vec4f w, vec4f &e0, vec4f &e1, vec4f &e2, vec4f &e3)
+{
+  vec4f t0 = _mm_unpacklo_ps(x, y), t1 = _mm_unpackhi_ps(x, y);
+  vec4f t2 = _mm_unpacklo_ps(z, w), t3 = _mm_unpackhi_ps(z, w);
+  e0 = _mm_movelh_ps(t0, t2);
+  e1 = _mm_movehl_ps(t2, t0);
+  e2 = _mm_movelh_ps(t1, t3);
+  e3 = _mm_movehl_ps(t3, t1);
+}
+
+VECTORCALL VECMATH_FINLINE void v_st_soa2(float *m, vec4f x, vec4f y)
+{
+  v_st(m, _mm_unpacklo_ps(x, y));
+  v_st(m + 4, _mm_unpackhi_ps(x, y));
+}
+VECTORCALL VECMATH_FINLINE void v_stu_soa2(float *m, vec4f x, vec4f y)
+{
+  v_stu(m, _mm_unpacklo_ps(x, y));
+  v_stu(m + 4, _mm_unpackhi_ps(x, y));
+}
+VECTORCALL VECMATH_FINLINE void v_st_soa3(float *m, vec4f x, vec4f y, vec4f z)
+{
+  vec4f e0, e1, e2;
+  v_interleave3(x, y, z, e0, e1, e2);
+  v_st(m, e0);
+  v_st(m + 4, e1);
+  v_st(m + 8, e2);
+}
+VECTORCALL VECMATH_FINLINE void v_stu_soa3(float *m, vec4f x, vec4f y, vec4f z)
+{
+  vec4f e0, e1, e2;
+  v_interleave3(x, y, z, e0, e1, e2);
+  v_stu(m, e0);
+  v_stu(m + 4, e1);
+  v_stu(m + 8, e2);
+}
+VECTORCALL VECMATH_FINLINE void v_st_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w)
+{
+  vec4f e0, e1, e2, e3;
+  v_interleave4(x, y, z, w, e0, e1, e2, e3);
+  v_st(m, e0);
+  v_st(m + 4, e1);
+  v_st(m + 8, e2);
+  v_st(m + 12, e3);
+}
+VECTORCALL VECMATH_FINLINE void v_stu_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w)
+{
+  vec4f e0, e1, e2, e3;
+  v_interleave4(x, y, z, w, e0, e1, e2, e3);
+  v_stu(m, e0);
+  v_stu(m + 4, e1);
+  v_stu(m + 8, e2);
+  v_stu(m + 12, e3);
+}
 
 // Always safe loading of float[3], but it uses [one more register (on SSE2) and] one more memory read (slower)
 #if _TARGET_SIMD_SSE >= 4
@@ -122,7 +248,6 @@ VECTORCALL VECMATH_FINLINE vec4i v_make_vec3i(int x, int y, int z)
 VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z)
 { return _mm_shuffle_ps(_mm_shuffle_ps(x, y, _MM_SHUFFLE(0, 0, 0, 0)), z, _MM_SHUFFLE(0, 0, 2, 0)); }
 
-//VECTORCALL VECMATH_FINLINE vec4f v_perm_mask(){ _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(a), mask)); }
 #define V_SHUFFLE(v, mask) _mm_shuffle_ps(v, v, mask)
 #define V_SHUFFLE_REV(v, maskW, maskZ, maskY, maskX) V_SHUFFLE(v, _MM_SHUFFLE(maskW, maskZ, maskY, maskX))
 #define V_SHUFFLE_FWD(v, maskX, maskY, maskZ, maskW) V_SHUFFLE(v, _MM_SHUFFLE(maskW, maskZ, maskY, maskX))
@@ -170,6 +295,40 @@ VECTORCALL VECMATH_FINLINE vec4f v_merge_hw(vec4f a, vec4f b) { return _mm_unpac
 VECTORCALL VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b) { return _mm_unpackhi_ps(a, b); }
 
 VECTORCALL VECMATH_FINLINE int v_signmask(vec4f a) { return _mm_movemask_ps(a); }
+VECTORCALL VECMATH_FINLINE int v_truemask(vec4f a) { return _mm_movemask_ps(a); }
+VECTORCALL VECMATH_FINLINE int v_count_true(vec4f a)
+{
+  // a true lane is all-ones == -1; sum the four lanes and negate
+  __m128i v = _mm_castps_si128(a);
+  v = _mm_add_epi32(v, _mm_shuffle_epi32(v, _MM_SHUFFLE(1, 0, 3, 2)));
+  v = _mm_add_epi32(v, _mm_shuffle_epi32(v, _MM_SHUFFLE(2, 3, 0, 1)));
+  return -_mm_cvtsi128_si32(v);
+}
+VECTORCALL VECMATH_FINLINE bool v_is_any_neg_b(vec4f a) { return _mm_movemask_ps(a) != 0; }
+VECTORCALL VECMATH_FINLINE int v_is_merge_planes_nout(vec4f m0, vec4f m1, vec4f m2, vec4f m3, vec4f m4, vec4f m5)
+{
+  // per-plane movemask merged on scalar ports, effectively free next to the vector work
+  // (a vector merge tree measured ~20% slower); unsigned(-x) has bit 31 set iff x != 0,
+  // so the & chain needs no setcc per plane
+  unsigned nout = unsigned(-_mm_movemask_ps(m0)) & unsigned(-_mm_movemask_ps(m1)) & unsigned(-_mm_movemask_ps(m2))
+                & unsigned(-_mm_movemask_ps(m3)) & unsigned(-_mm_movemask_ps(m4)) & unsigned(-_mm_movemask_ps(m5));
+  return int(nout) >> 31; // arithmetic shift broadcasts bit 31: 0 or -1
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_min_pairs(vec4f a, vec4f b)
+{
+  return _mm_min_ps(_mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0)), _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1)));
+}
+VECTORCALL VECMATH_FINLINE vec4f v_max_pairs(vec4f a, vec4f b)
+{
+  return _mm_max_ps(_mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0)), _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1)));
+}
+// haddps decodes to the same two shuffles plus the add on every core we target, and its lane
+// order is the pairwise one, so the explicit form only schedules better
+VECTORCALL VECMATH_FINLINE vec4f v_add_pairs(vec4f a, vec4f b)
+{
+  return _mm_add_ps(_mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0)), _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1)));
+}
 
 VECTORCALL VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a)
 {
@@ -241,11 +400,11 @@ VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a)
 {
 #if defined(__AVX512F__)//only works on clang/gcc
   return _mm_cvtps_epu32(a);
-#elif _TARGET_64BIT //_mm_cvtss_si64 is x64 instruction
-  return v_make_vec4i(uint32_t(_mm_cvtss_si64(a)),
-                      uint32_t(_mm_cvtss_si64(v_splat_y(a))),
-                      uint32_t(_mm_cvtss_si64(v_splat_z(a))),
-                      uint32_t(_mm_cvtss_si64(v_splat_w(a))));
+#elif _TARGET_64BIT //_mm_cvttss_si64 is x64 instruction. cvtt, not cvt: this truncates like the cast it stands for
+  return v_make_vec4i(uint32_t(_mm_cvttss_si64(a)),
+                      uint32_t(_mm_cvttss_si64(v_splat_y(a))),
+                      uint32_t(_mm_cvttss_si64(v_splat_z(a))),
+                      uint32_t(_mm_cvttss_si64(v_splat_w(a))));
 #else
   return v_make_vec4i(uint32_t(v_extract_x(a)),
                       uint32_t(v_extract_y(a)),
@@ -375,12 +534,26 @@ VECTORCALL VECMATH_FINLINE vec4i v_seli(vec4i a, vec4i b, vec4i c)
 }
 #endif
 
+// roundps has no ties-away-from-zero mode, so decide on the truncated remainder: trunc and the
+// a - trunc(a) that follows are both exact, unlike biasing a by a signed half first (that add
+// can carry into the next integer, e.g. 0.49999997 -> 1). NEON has the mode natively
+VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a)
+{
+  vec4f t = v_trunc(a);
+  vec4f sign = v_and(a, v_cast_vec4f(V_CI_SIGN_MASK));
+  vec4f absFrac = v_xor(v_sub(a, t), sign); // truncation keeps the remainder on a's side of zero
+  vec4f away = v_cmp_ge(absFrac, V_C_HALF);
+  return v_add(t, v_or(v_and(away, V_C_ONE), sign));
+}
+
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a) { return v_cvt_trunci(v_round(a)); }
+
 
 VECTORCALL VECMATH_FINLINE vec4f v_add(vec4f a, vec4f b) { return _mm_add_ps(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_sub(vec4f a, vec4f b) { return _mm_sub_ps(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_mul(vec4f a, vec4f b) { return _mm_mul_ps(a, b); }
 VECTORCALL VECMATH_FINLINE vec4f v_div(vec4f a, vec4f b) { return _mm_div_ps(a, b); }
-#if defined(__FMA__) || (defined(__AVX2__) && defined(_MSC_VER) && !defined(__clang__))
+#if !defined(VECMATH_NO_FMA) && (defined(__FMA__) || (defined(__AVX2__) && defined(_MSC_VER) && !defined(__clang__)))
 VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); }
 VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); } // _ps is better
 VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ps(a, b, c); }
@@ -415,12 +588,28 @@ VECTORCALL VECMATH_FINLINE vec4i v_interleave_lo_i32(vec4i a, vec4i b) { return 
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_hi_i32(vec4i a, vec4i b) { return _mm_unpackhi_epi32(a, b); }
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_lo_i64(vec4i a, vec4i b) { return _mm_unpacklo_epi64(a, b); }
 VECTORCALL VECMATH_FINLINE vec4i v_interleave_hi_i64(vec4i a, vec4i b) { return _mm_unpackhi_epi64(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_perm_i8(vec4i t, vec4i k)
+{
+#if _TARGET_SIMD_SSE >= 3
+  return _mm_shuffle_epi8(t, k);
+#else
+  alignas(16) uint8_t tb[16], kb[16], r[16];
+  _mm_store_si128((__m128i *)tb, t);
+  _mm_store_si128((__m128i *)kb, k);
+  for (int i = 0; i < 16; ++i)
+    r[i] = (kb[i] & 0x80) ? 0 : tb[kb[i] & 15];
+  return _mm_load_si128((const __m128i *)r);
+#endif
+}
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi8(vec4i a, vec4i b) { return _mm_cmpeq_epi8(a, b); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
 {
-#if _TARGET_SIMD_SSE >= 3
-  vec4f s = _mm_hadd_ps(a, a);
-  return _mm_hadd_ps(s, s);
+#if _TARGET_SIMD_SSE >= 4
+  __m128 shuf = _mm_movehdup_ps(a);
+  __m128 sums = _mm_add_ps(a, shuf);
+  shuf = _mm_movehl_ps(shuf, sums);
+  return _mm_add_ss(sums, shuf);
 #else
   vec4f s = v_add(a, v_rot_2(a));
   return v_add_x(s, v_splat_y(s));
@@ -428,9 +617,10 @@ VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
 }
 VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec3f a)
 {
-#if _TARGET_SIMD_SSE >= 3
-  vec4f s = _mm_hadd_ps(a, a);
-  return _mm_add_ss(s, _mm_movehl_ps(a, a));
+#if _TARGET_SIMD_SSE >= 4
+  __m128 shuf = _mm_movehdup_ps(a);
+  __m128 sums = _mm_add_ss(a, shuf);
+  return _mm_add_ss(sums, _mm_movehl_ps(a, a));
 #else
   vec4f s = _mm_add_ss(a, v_splat_y(a));
   return _mm_add_ss(s, _mm_movehl_ps(a, a));
@@ -506,16 +696,19 @@ VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a, vec4i b) { return _mm_packu
 VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a) { return _mm_packus_epi16(a,a); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_unprecise(vec4f a) { return _mm_rcp_ps(a); }
+// Newton step kept as y*(2 - a*y), the form NEON's vrecps computes: the algebraically equal
+// 2y - a*y*y evaluates y*y, which leaves float range long before 1/a does - it overflows below
+// |a| ~ 5e-20 (giving a sign flipped inf) and underflows above |a| ~ 1e19 (giving exactly 2x)
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_est(vec4f a)
 {
   __m128 y0 = _mm_rcp_ps(a);
-  return _mm_sub_ps(_mm_add_ps(y0, y0), _mm_mul_ps(a, _mm_mul_ps(y0, y0)));
+  return _mm_mul_ps(y0, _mm_sub_ps(V_C_TWO, _mm_mul_ps(a, y0)));
 }
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_unprecise_x(vec4f a) { return _mm_rcp_ss(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_rcp_est_x(vec4f a)
 {
   __m128 y0 = _mm_rcp_ss(a);
-  return _mm_sub_ss(_mm_add_ss(y0, y0), _mm_mul_ss(a, _mm_mul_ss(y0, y0)));
+  return _mm_mul_ss(y0, _mm_sub_ss(V_C_TWO, _mm_mul_ss(a, y0)));
 }
 
 VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_unprecise(vec4f a) { return _mm_rsqrt_ps(a); }
@@ -540,9 +733,6 @@ VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_est_x(vec4f a) // Reciprocal square roo
   r = v_mul_x(r, v_set_x(-0.5f));
   return v_mul_x(a, r);
 }
-
-VECTORCALL VECMATH_FINLINE vec4f v_rsqrt(vec4f a) { return v_div(v_sqrt(a), a); }
-VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) { return v_div_x(v_sqrt_x(a), a); }
 
 VECTORCALL VECMATH_FINLINE vec4i sse2_mini(vec4i a, vec4i b)
 {
@@ -609,6 +799,25 @@ VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b) {return sse2_maxu(a, b
 VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a) {return sse2_absi(a);}
 #endif
 
+// SSE has no pairwise integer op: deinterleave the even and odd lanes of both operands (one
+// shufps each - there is no two-source integer shuffle, the float-domain cast is free) and
+// apply the elementwise op
+VECTORCALL VECMATH_FINLINE vec4i v_addi_pairs(vec4i a, vec4i b)
+{
+  vec4f af = v_cast_vec4f(a), bf = v_cast_vec4f(b);
+  return v_addi(v_cast_vec4i(v_perm_xzac(af, bf)), v_cast_vec4i(v_perm_ywbd(af, bf)));
+}
+VECTORCALL VECMATH_FINLINE vec4i v_mini_pairs(vec4i a, vec4i b)
+{
+  vec4f af = v_cast_vec4f(a), bf = v_cast_vec4f(b);
+  return v_mini(v_cast_vec4i(v_perm_xzac(af, bf)), v_cast_vec4i(v_perm_ywbd(af, bf)));
+}
+VECTORCALL VECMATH_FINLINE vec4i v_maxi_pairs(vec4i a, vec4i b)
+{
+  vec4f af = v_cast_vec4f(a), bf = v_cast_vec4f(b);
+  return v_maxi(v_cast_vec4i(v_perm_xzac(af, bf)), v_cast_vec4i(v_perm_ywbd(af, bf)));
+}
+
 VECTORCALL VECMATH_FINLINE vec4f v_neg(vec4f a) {return v_xor(a, v_cast_vec4f(v_splatsi(0x80000000)));}
 VECTORCALL VECMATH_FINLINE vec4i v_negi(vec4i a){ return v_subi(v_cast_vec4i(v_zero()), a); }
 VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a)
@@ -624,9 +833,11 @@ VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a)
   #endif
 }
 
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a) { return _mm_sqrt_ps(a); }
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt(vec4f a) { return _mm_sqrt_ps(a); }
-VECTORCALL VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f a) { return _mm_sqrt_ss(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_abs_diff(vec4f a, vec4f b) { return v_abs(_mm_sub_ps(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_abs_ge(vec4f a, vec4f b) { return _mm_cmpge_ps(v_abs(a), v_abs(b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_abs_gt(vec4f a, vec4f b) { return _mm_cmpgt_ps(v_abs(a), v_abs(b)); }
+
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt(vec4f a)   { return _mm_sqrt_ps(a); }
 VECTORCALL VECMATH_FINLINE vec4f v_sqrt_x(vec4f a) { return _mm_sqrt_ss(a); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_rot_1(vec4f a) { return V_SHUFFLE_REV(a, 0, 3, 2, 1); }
@@ -636,15 +847,70 @@ VECTORCALL VECMATH_FINLINE vec4i v_roti_1(vec4i a) { return _mm_shuffle_epi32(a,
 VECTORCALL VECMATH_FINLINE vec4i v_roti_2(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(1, 0, 3, 2)); }
 VECTORCALL VECMATH_FINLINE vec4i v_roti_3(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(2, 1, 0, 3)); }
 
+// horizontal min/max: 2 shuffles + 2 min/max is the log2 floor for a broadcast
+// reduction on SSE; NEON implements these with dedicated fminv/fmaxv instructions
+VECTORCALL VECMATH_FINLINE vec4f v_hmin(vec4f a)
+{
+  a = v_min(a, v_rot_1(a));
+  return v_min(a, v_rot_2(a));
+}
+VECTORCALL VECMATH_FINLINE vec4f v_hmax(vec4f a)
+{
+  a = v_max(a, v_rot_1(a));
+  return v_max(a, v_rot_2(a));
+}
+VECTORCALL VECMATH_FINLINE vec4f v_hmin3(vec3f a)
+{
+  return v_min(v_splat_x(a), v_min(v_splat_y(a), v_splat_z(a)));
+}
+VECTORCALL VECMATH_FINLINE vec4f v_hmax3(vec3f a)
+{
+  return v_max(v_splat_x(a), v_max(v_splat_y(a), v_splat_z(a)));
+}
+VECTORCALL VECMATH_FINLINE vec4i v_hmini(vec4i a)
+{
+  a = v_mini(a, v_roti_1(a));
+  return v_mini(a, v_roti_2(a));
+}
+VECTORCALL VECMATH_FINLINE vec4i v_hmaxi(vec4i a)
+{
+  a = v_maxi(a, v_roti_1(a));
+  return v_maxi(a, v_roti_2(a));
+}
+VECTORCALL VECMATH_FINLINE vec4i v_hmini3(vec4i a) { return v_mini(v_splat_xi(a), v_mini(v_splat_yi(a), v_splat_zi(a))); }
+VECTORCALL VECMATH_FINLINE vec4i v_hmaxi3(vec4i a) { return v_maxi(v_splat_xi(a), v_maxi(v_splat_yi(a), v_splat_zi(a))); }
+
 VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a) { return V_SHUFFLE_REV(a, 0,0,2,1); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a) { return V_SHUFFLE_REV(a, 1,0,2,1); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a) { return V_SHUFFLE_REV(a, 3,0,2,1); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a) { return V_SHUFFLE_REV(a, 3,1,0,2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f a) { return V_SHUFFLE_REV(a, 2,3,0,1); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f a) { return V_SHUFFLE_REV(a, 1,1,0,0); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f a) { return V_SHUFFLE_REV(a, 3,3,2,2); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(2,0,2,0)); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,1,3,1)); }
+#if _TARGET_SIMD_SSE >= 4
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xazc(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, _mm_moveldup_ps(abcd), 0xA); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ybwd(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(_mm_movehdup_ps(xyzw), abcd, 0xA); }
+#else
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xazc(vec4f xyzw, vec4f abcd)
+{ return _mm_movelh_ps(_mm_unpacklo_ps(xyzw, abcd), _mm_unpackhi_ps(xyzw, abcd)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ybwd(vec4f xyzw, vec4f abcd)
+{ return _mm_movehl_ps(_mm_unpackhi_ps(xyzw, abcd), _mm_unpacklo_ps(xyzw, abcd)); }
+#endif
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwab(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,0,3,2)); }
+#if _TARGET_SIMD_SSE >= 4
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwa(vec4f xyzw, vec4f abcd)
+{ return _mm_castsi128_ps(_mm_alignr_epi8(_mm_castps_si128(abcd), _mm_castps_si128(xyzw), 4)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd)
+{ return _mm_castsi128_ps(_mm_alignr_epi8(_mm_castps_si128(abcd), _mm_castps_si128(xyzw), 12)); }
+#else
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwa(vec4f xyzw, vec4f abcd)
+{ return _mm_shuffle_ps(xyzw, _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(0,0,3,3)), _MM_SHUFFLE(2,0,2,1)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd)
+{ return _mm_shuffle_ps(_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(0,0,3,3)), abcd, _MM_SHUFFLE(2,1,2,0)); }
+#endif
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,0,1,0)); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,2,3,2)); }
 VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(abcd, xyzw, _MM_SHUFFLE(0,1,1,1)); }
@@ -655,7 +921,12 @@ VECTORCALL VECMATH_FINLINE vec4f v_perm_xxab(vec4f xyzw, vec4f abcd) { return _m
 VECTORCALL VECMATH_FINLINE vec4f v_perm_yzab(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,0,2,1)); }
 
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,2,1,0)); }
+#if _TARGET_SIMD_SSE >= 4
+// blend runs on 3 ports where movss is a port 5 shuffle
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 1); }
+#else
 VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return _mm_move_ss(xyzw, abcd); }
+#endif
 
 VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd)
 {
@@ -727,6 +998,19 @@ VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd)
 }
 #endif
 
+// integer single-source perms: pshufd is non-destructive, folds loads and stays in the int domain
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xzxz(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(2, 0, 2, 0)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_ywyw(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(3, 1, 3, 1)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyxy(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(1, 0, 1, 0)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_zwzw(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(3, 2, 3, 2)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xxyy(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(1, 1, 0, 0)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_zzww(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(3, 3, 2, 2)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xxzz(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(2, 2, 0, 0)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_yyww(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(3, 3, 1, 1)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_wwyy(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(1, 1, 3, 3)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxw(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(3, 0, 2, 1)); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_yzxy(vec4i xyzw) { return _mm_shuffle_epi32(xyzw, _MM_SHUFFLE(1, 0, 2, 1)); }
+
 VECTORCALL VECMATH_FINLINE vec4f sse2_dot2(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
@@ -775,12 +1059,32 @@ VECTORCALL VECMATH_FINLINE vec4f sse2_dot4_x(vec4f a, vec4f b)
 VECTORCALL VECMATH_FINLINE vec4f sse2_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse2_dot3_x(a,b), v_splat_w(a)); }
 
 #if _TARGET_SIMD_SSE >= 4 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE4_1__)
-VECTORCALL VECMATH_FINLINE vec4f sse4_dot4(vec4f a, vec4f b) { return _mm_dp_ps(a,b, 0xFF); }
-VECTORCALL VECMATH_FINLINE vec4f sse4_dot4_x(vec4f a, vec4f b) { return _mm_dp_ps(a,b,0xF1); }
-VECTORCALL VECMATH_FINLINE vec4f sse4_dot3(vec4f a, vec4f b) { return _mm_dp_ps(a,b, 0x7F); }
-VECTORCALL VECMATH_FINLINE vec4f sse4_dot3_x(vec4f a, vec4f b) { return _mm_dp_ps(a,b,0x71); }
-VECTORCALL VECMATH_FINLINE vec4f sse4_dot2(vec4f a, vec4f b) { return _mm_dp_ps(a, b, 0x3F); }
-VECTORCALL VECMATH_FINLINE vec4f sse4_dot2_x(vec4f a, vec4f b) { return _mm_dp_ps(a, b, 0x31); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot4_x(vec4f a, vec4f b)
+{
+  // dpps is slower, especially on AMD
+  __m128 mul = _mm_mul_ps(a, b);
+  __m128 shuf = _mm_movehdup_ps(mul);
+  __m128 sums = _mm_add_ps(mul, shuf);
+  shuf = _mm_movehl_ps(shuf, sums);
+  return _mm_add_ss(sums, shuf);
+}
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot4(vec4f a, vec4f b) { return v_splat_x(sse4_dot4_x(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot3_x(vec4f a, vec4f b)
+{
+  // dpps is slower, especially on AMD
+  __m128 mul = _mm_mul_ps(a, b);
+  __m128 shuf = _mm_movehl_ps(mul, mul);
+  __m128 sums = _mm_add_ss(mul, shuf);
+  shuf = _mm_movehdup_ps(mul);
+  return _mm_add_ss(sums, shuf);
+}
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot3(vec4f a, vec4f b) { return v_splat_x(sse4_dot3_x(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot2_x(vec4f a, vec4f b)
+{
+  __m128 mul = _mm_mul_ps(a, b);
+  return _mm_add_ss(mul, _mm_movehdup_ps(mul));
+}
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot2(vec4f a, vec4f b) { return v_splat_x(sse4_dot2_x(a, b)); }
 VECTORCALL VECMATH_FINLINE vec4f sse4_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse4_dot3_x(a,b), v_splat_w(a)); }
 #else // fallback to SSE2
 VECTORCALL VECMATH_FINLINE vec4f sse4_dot4(vec4f a, vec4f b) { return sse2_dot4(a, b); }
@@ -792,18 +1096,6 @@ VECTORCALL VECMATH_FINLINE vec4f sse4_dot2_x(vec4f a, vec4f b) { return sse2_dot
 VECTORCALL VECMATH_FINLINE vec4f sse4_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
 #endif
 
-#if _TARGET_SIMD_SSE >= 3 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE3__)
-VECTORCALL VECMATH_FINLINE vec4f sse3_dot4(vec4f a, vec4f b)
-{
-  vec4f m = _mm_mul_ps(a, b);
-  m = _mm_hadd_ps(m,m);
-  return _mm_hadd_ps(m,m);
-}
-VECTORCALL VECMATH_FINLINE vec4f sse3_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse2_dot3_x(a,b), v_splat_w(a)); }
-#else
-VECTORCALL VECMATH_FINLINE vec4f sse3_dot4(vec4f a, vec4f b) { return sse2_dot4(a, b); }
-VECTORCALL VECMATH_FINLINE vec4f sse3_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
-#endif
 
 
 #if _TARGET_SIMD_SSE >= 4
@@ -814,14 +1106,6 @@ VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b) { return sse4_dot3_x
 VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b) { return sse4_dot2(a,b); }
 VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b) { return sse4_dot2_x(a,b); }
 VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return sse4_plane_dist_x(a,b); }
-#elif _TARGET_SIMD_SSE >= 3
-VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b) { return sse3_dot4(a,b); }
-VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return sse3_dot4(a,b); }
-VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b) { return sse2_dot3(a,b); }
-VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a,b); }
-VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b) { return sse2_dot2(a,b); }
-VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a,b); }
-VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return sse3_plane_dist_x(a,b); }
 #else
 VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b) { return sse2_dot4(a,b); }
 VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return sse2_dot4_x(a,b); }
@@ -832,16 +1116,26 @@ VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x
 VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
 #endif
 
-VECTORCALL VECMATH_FINLINE vec4f v_length4_sq(vec4f a) { return v_dot4(a, a); }
-VECTORCALL VECMATH_FINLINE vec3f v_length3_sq(vec3f a) { return v_dot3(a, a); }
-VECTORCALL VECMATH_FINLINE vec4f v_length2_sq(vec4f a) { return v_dot2(a, a); }
-VECTORCALL VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_dot4_x(a, a); }
-VECTORCALL VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a) { return v_dot3_x(a, a); }
-VECTORCALL VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a) { return v_dot2_x(a, a); }
+// both products must stay rounded so a x a is exactly 0; unprotected, the compiler contracts
+// one mul into the sub and returns the other's rounding error instead
+VECTORCALL VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b)
+{
+  // (a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x)
+#if defined(__FMA__) || (defined(__AVX2__) && defined(_MSC_VER) && !defined(__clang__))
+  // subtract through hsubps: FMA has no horizontal form, so no compiler can contract the
+  // muls into it and both products stay rounded by construction
+  vec4f u = v_mul(V_SHUFFLE_FWD(a, 1, 2, 2, 0), V_SHUFFLE_FWD(b, 2, 1, 0, 2)); // ay*bz az*by az*bx ax*bz
+  vec4f v = v_mul(V_SHUFFLE_FWD(a, 0, 1, 0, 1), V_SHUFFLE_FWD(b, 1, 0, 1, 0)); // ax*by ay*bx ax*by ay*bx
+  return _mm_hsub_ps(u, v);
+#else
+  // without FMA in the target the mul+sub pair cannot be contracted
+  vec3f yzxw = v_perm_yzxw(a);
+  vec3f bcad = v_perm_yzxw(b);
+  return v_perm_yzxy(v_sub(v_mul(a, bcad), v_mul(yzxw, b)));
+#endif
+}
 
-VECTORCALL VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot4_x(a,a)))); }
-VECTORCALL VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot3_x(a,a)))); }
-VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot2_x(a,a)))); }
+// v_length*_sq and v_norm2/3/4 live in dag_vecMath_common.h (portable form).
 
 VECTORCALL VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b)
 {
@@ -862,30 +1156,6 @@ VECTORCALL VECMATH_FINLINE void v_mat_33cu_from_mat33(float * __restrict m33, co
   m33[8] = v_extract_z(tm.col2);
 }
 
-VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f& tm, const float *const __restrict m43)
-{
-  v_mat44_make_from_43cu(tm, m43);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f& tm, const float *const __restrict m43)
-{
-  vec4f v0 = v_ldu(m43 + 0);
-  vec4f v1 = v_ldu(m43 + 4);
-  vec4f v2 = v_ldu(m43 + 8);
-#if _TARGET_SIMD_SSE >= 4
-  tm.col0 = _mm_blend_ps(v0, v_zero(), 1 << 3);
-  tm.col1 = _mm_insert_ps(_mm_shuffle_ps(v1, v1, _MM_SHUFFLE(2, 1, 0, 3)), v0, _MM_MK_INSERTPS_NDX(3, 0, 1 << 3));
-  tm.col2 = _mm_blend_ps(_mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 3, 2)), v_zero(), 1 << 3);
-  tm.col3 = v_rot_1(_mm_move_ss(v2, v_cast_vec4f(v_seti_x(0x3f800000))));
-#else // _TARGET_SIMD_SSE >= 4
-  vec4f v10 = _mm_shuffle_ps(v1, v0, _MM_SHUFFLE(3, 2, 1, 0));
-  tm.col0 = v_and(v0, V_CI_MASK1110);
-  tm.col1 = v_and(_mm_shuffle_ps(v10, v10, _MM_SHUFFLE(2, 1, 0, 3)), V_CI_MASK1110);
-  tm.col2 = v_and(_mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 3, 2)), V_CI_MASK1110);
-  tm.col3 = v_rot_1(_mm_move_ss(v2, v_cast_vec4f(v_seti_x(0x3f800000))));
-#endif // _TARGET_SIMD_SSE >= 4
-}
-
 VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, const mat44f& tm)
 {
   v_mat_43cu_from_mat44(m43, tm);
@@ -900,6 +1170,42 @@ VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const
   tmV.col1 = v_perm_wxyz(v_perm_xycd(v1, v0));
   tmV.col2 = v_perm_zwxy(v_perm_xycd(v2, v1));
   tmV.col3 = v_rot_1(v2);
+}
+
+// hand-interleaved w cleanup: MSVC does not fuse _unsafe + v_mat44_make_affine back into this form
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f& tm, const float *const __restrict m43)
+{
+  vec4f v0 = v_ldu(m43 + 0);
+  vec4f v1 = v_ldu(m43 + 4);
+  vec4f v2 = v_ldu(m43 + 8);
+#if _TARGET_SIMD_SSE >= 4
+  tm.col0 = _mm_blend_ps(v0, v_zero(), 1 << 3);
+  tm.col1 = _mm_insert_ps(_mm_shuffle_ps(v1, v1, _MM_SHUFFLE(2, 1, 0, 3)), v0, _MM_MK_INSERTPS_NDX(3, 0, 1 << 3));
+  tm.col2 = _mm_blend_ps(_mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 3, 2)), v_zero(), 1 << 3);
+  tm.col3 = v_rot_1(_mm_blend_ps(v2, V_C_UNIT_1000, 1)); // pool constant instead of a GPR->vector crossing
+#else // _TARGET_SIMD_SSE >= 4
+  vec4f v10 = _mm_shuffle_ps(v1, v0, _MM_SHUFFLE(3, 2, 1, 0));
+  tm.col0 = v_and(v0, V_CI_MASK1110);
+  tm.col1 = v_and(_mm_shuffle_ps(v10, v10, _MM_SHUFFLE(2, 1, 0, 3)), V_CI_MASK1110);
+  tm.col2 = v_and(_mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 3, 2)), V_CI_MASK1110);
+  tm.col3 = v_rot_1(_mm_move_ss(v2, V_C_UNIT_1000)); // pool constant instead of a GPR->vector crossing
+#endif // _TARGET_SIMD_SSE >= 4
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f& tm, const float *const __restrict m43)
+{
+  v_mat44_make_from_43cu(tm, m43);
+}
+
+VECTORCALL VECMATH_FINLINE void v_mat43_make_from_43cu_unsafe(mat43f &tmV, const float *const __restrict m43)
+{
+  // rows' .w lanes carry junk instead of the translation, which needs fewer shuffles
+  vec4f l0 = v_ldu(m43), l1 = v_ldu(m43 + 4), l2 = v_ldu(m43 + 8);
+  tmV.row0 = _mm_shuffle_ps(l0, l1, _MM_SHUFFLE(2, 2, 3, 0));
+  vec4f t = _mm_shuffle_ps(l0, l1, _MM_SHUFFLE(3, 0, 1, 1));
+  tmV.row1 = _mm_shuffle_ps(t, t, _MM_SHUFFLE(3, 3, 2, 0));
+  vec4f u = _mm_shuffle_ps(l0, l1, _MM_SHUFFLE(1, 1, 2, 2));
+  tmV.row2 = _mm_shuffle_ps(u, l2, _MM_SHUFFLE(0, 0, 2, 0));
 }
 
 VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, const mat44f& tm)
@@ -948,237 +1254,13 @@ VECTORCALL VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest)
   dest.col1 = V_C_UNIT_0100;
   dest.col2 = V_C_UNIT_1000;
 }
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src)
-{
-  __m128 tmp3, tmp2, tmp1, tmp0;
+// v_mat44_transpose*, v_mat43_transpose_to_mat44, v_mat44_transpose_to_mat43 and
+// v_mat44/33_mul_vec* live in dag_vecMath_common.h: the portable form maps to
+// optimal shuffles on both SSE and NEON, so a hw-specific version is not needed.
 
-  tmp0 = _mm_shuffle_ps(src.col0, src.col1, 0x44);
-  tmp2 = _mm_shuffle_ps(src.col0, src.col1, 0xEE);
-  tmp1 = _mm_shuffle_ps(src.col2, src.col3, 0x44);
-  tmp3 = _mm_shuffle_ps(src.col2, src.col3, 0xEE);
+// v_mat33_inverse lives in dag_vecMath_common.h (portable form).
 
-  dest.col0 = _mm_shuffle_ps(tmp0, tmp1, 0x88);
-  dest.col1 = _mm_shuffle_ps(tmp0, tmp1, 0xDD);
-  dest.col2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
-  dest.col3 = _mm_shuffle_ps(tmp2, tmp3, 0xDD);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
-{
-   _MM_TRANSPOSE4_PS(r0, r1, r2, r3);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
-{
-  __m128 tmp3, tmp2, tmp1, tmp0;
-
-  tmp0 = _mm_shuffle_ps(src.row0, src.row1, 0x44);
-  tmp2 = _mm_shuffle_ps(src.row0, src.row1, 0xEE);
-  tmp1 = _mm_shuffle_ps(src.row2, v_zero(), 0x44);
-  tmp3 = _mm_shuffle_ps(src.row2, v_zero(), 0xEE);
-
-  dest.col0 = _mm_shuffle_ps(tmp0, tmp1, 0x88);
-  dest.col1 = _mm_shuffle_ps(tmp0, tmp1, 0xDD);
-  dest.col2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
-  dest.col3 = _mm_shuffle_ps(tmp2, tmp3, 0xDD);
-}
-VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
-{
-  __m128 tmp3, tmp2, tmp1, tmp0;
-
-  tmp0 = _mm_shuffle_ps(src.col0, src.col1, 0x44);
-  tmp2 = _mm_shuffle_ps(src.col0, src.col1, 0xEE);
-  tmp1 = _mm_shuffle_ps(src.col2, src.col3, 0x44);
-  tmp3 = _mm_shuffle_ps(src.col2, src.col3, 0xEE);
-
-  dest.row0 = _mm_shuffle_ps(tmp0, tmp1, 0x88);
-  dest.row1 = _mm_shuffle_ps(tmp0, tmp1, 0xDD);
-  dest.row2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
-}
-
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
-  vec4f zzzz = v_splat_z(v);
-  vec4f wwww = _mm_shuffle_ps(v, v, _MM_SHUFFLE(3,3,3,3));
-
-  return _mm_add_ps(
-    _mm_add_ps(_mm_mul_ps(xxxx, m.col0), _mm_mul_ps(yyyy, m.col1)),
-    _mm_add_ps(_mm_mul_ps(zzzz, m.col2), _mm_mul_ps(wwww, m.col3))
-  );
-}
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
-  vec4f zzzz = v_splat_z(v);
-
-  return _mm_add_ps(_mm_add_ps(_mm_mul_ps(xxxx, m.col0), _mm_mul_ps(yyyy, m.col1)),
-                    _mm_mul_ps(zzzz, m.col2));
-}
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
-  vec4f zzzz = v_splat_z(v);
-
-  return _mm_add_ps(
-    _mm_add_ps(_mm_mul_ps(xxxx, m.col0), _mm_mul_ps(yyyy, m.col1)),
-    _mm_add_ps(_mm_mul_ps(zzzz, m.col2), m.col3)
-  );
-}
-
-VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
-{
-  vec4f xxxx = v_splat_x(v);
-  vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
-  vec4f zzzz = v_splat_z(v);
-
-  return _mm_add_ps(_mm_add_ps(_mm_mul_ps(xxxx, m.col0), _mm_mul_ps(yyyy, m.col1)),
-                    _mm_mul_ps(zzzz, m.col2));
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
-{
-  __m128 minor0, minor1, minor2, minor3;
-  __m128 row0, row1, row2, row3;
-  __m128 det, tmp0, tmp1, tmp2, tmp3;
-
-  tmp0 = _mm_shuffle_ps(m.col0, m.col1, _MM_SHUFFLE(2,0,2,0));
-  tmp1 = _mm_shuffle_ps(m.col2, m.col3, _MM_SHUFFLE(2,0,2,0));
-  tmp2 = _mm_shuffle_ps(m.col0, m.col1, _MM_SHUFFLE(3,1,3,1));
-  tmp3 = _mm_shuffle_ps(m.col2, m.col3, _MM_SHUFFLE(3,1,3,1));
-  row0 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(2,0,2,0));
-  row1 = _mm_shuffle_ps(tmp3, tmp2, _MM_SHUFFLE(2,0,2,0));
-  row2 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(3,1,3,1));
-  row3 = _mm_shuffle_ps(tmp3, tmp2, _MM_SHUFFLE(3,1,3,1));
-
-  tmp1 = _mm_mul_ps(row2, row3);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor0 = _mm_mul_ps(row1, tmp1);
-  minor1 = _mm_mul_ps(row0, tmp1);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor0 = _mm_sub_ps(_mm_mul_ps(row1, tmp1), minor0);
-  minor1 = _mm_sub_ps(_mm_mul_ps(row0, tmp1), minor1);
-  minor1 = V_SHUFFLE(minor1, 0x4E);
-
-  tmp1 = _mm_mul_ps(row1, row2);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor0 = _mm_add_ps(_mm_mul_ps(row3, tmp1), minor0);
-  minor3 = _mm_mul_ps(row0, tmp1);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor0 = _mm_sub_ps(minor0, _mm_mul_ps(row3, tmp1));
-  minor3 = _mm_sub_ps(_mm_mul_ps(row0, tmp1), minor3);
-  minor3 = V_SHUFFLE(minor3, 0x4E);
-
-  tmp1 = _mm_mul_ps(V_SHUFFLE(row1, 0x4E), row3);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  row2 = V_SHUFFLE(row2, 0x4E);
-  minor0 = _mm_add_ps(_mm_mul_ps(row2, tmp1), minor0);
-  minor2 = _mm_mul_ps(row0, tmp1);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor0 = _mm_sub_ps(minor0, _mm_mul_ps(row2, tmp1));
-  minor2 = _mm_sub_ps(_mm_mul_ps(row0, tmp1), minor2);
-  minor2 = V_SHUFFLE(minor2, 0x4E);
-
-  tmp1 = _mm_mul_ps(row0, row1);
-
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor2 = _mm_add_ps(_mm_mul_ps(row3, tmp1), minor2);
-  minor3 = _mm_sub_ps(_mm_mul_ps(row2, tmp1), minor3);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor2 = _mm_sub_ps(_mm_mul_ps(row3, tmp1), minor2);
-  minor3 = _mm_sub_ps(minor3, _mm_mul_ps(row2, tmp1));
-
-  tmp1 = _mm_mul_ps(row0, row3);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor1 = _mm_sub_ps(minor1, _mm_mul_ps(row2, tmp1));
-  minor2 = _mm_add_ps(_mm_mul_ps(row1, tmp1), minor2);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor1 = _mm_add_ps(_mm_mul_ps(row2, tmp1), minor1);
-  minor2 = _mm_sub_ps(minor2, _mm_mul_ps(row1, tmp1));
-
-  tmp1 = _mm_mul_ps(row0, row2);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor1 = _mm_add_ps(_mm_mul_ps(row3, tmp1), minor1);
-  minor3 = _mm_sub_ps(minor3, _mm_mul_ps(row1, tmp1));
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor1 = _mm_sub_ps(minor1, _mm_mul_ps(row3, tmp1));
-  minor3 = _mm_add_ps(_mm_mul_ps(row1, tmp1), minor3);
-
-  det = _mm_mul_ps(row0, minor0);
-  det = _mm_add_ps(V_SHUFFLE(det, 0x4E), det);
-  det = _mm_add_ss(V_SHUFFLE(det, 0xB1), det);
-  tmp1 = v_rcp_safe(det);
-  det = _mm_sub_ss(_mm_add_ss(tmp1, tmp1), _mm_mul_ss(det, _mm_mul_ss(tmp1, tmp1)));
-  det = v_splat_x(det);
-  dest.col0 = _mm_mul_ps(det, minor0);
-  dest.col1 = _mm_mul_ps(det, minor1);
-  dest.col2 = _mm_mul_ps(det, minor2);
-  dest.col3 = _mm_mul_ps(det, minor3);
-}
-
-VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3, tmp4, dot, invdet, inv0, inv1, inv2;
-
-  tmp2 = v_cross3(m.col0, m.col1);
-  tmp0 = v_cross3(m.col1, m.col2);
-  tmp1 = v_cross3(m.col2, m.col0);
-  dot = v_dot3(tmp2, m.col2);
-  invdet = v_rcp_safe(dot);
-
-  tmp3 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(0,2,0,2));
-  tmp4 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(1,3,1,3));
-  inv0 = _mm_shuffle_ps(tmp3, tmp2, _MM_SHUFFLE(3,0,3,1));
-  inv1 = _mm_shuffle_ps(tmp4, tmp2, _MM_SHUFFLE(3,1,3,1));
-  inv2 = _mm_shuffle_ps(tmp3, tmp2, _MM_SHUFFLE(3,2,2,0));
-
-  dest.col0 = _mm_mul_ps(inv0, invdet);
-  dest.col1 = _mm_mul_ps(inv1, invdet);
-  dest.col2 = _mm_mul_ps(inv2, invdet);
-}
-
-VECTORCALL VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
-{
-  __m128 minor0;
-  __m128 row0, row1, row2, row3;
-  __m128 det, tmp0, tmp1, tmp2, tmp3;
-
-  tmp0 = _mm_shuffle_ps(m.col0, m.col1, _MM_SHUFFLE(2,0,2,0));
-  tmp1 = _mm_shuffle_ps(m.col2, m.col3, _MM_SHUFFLE(2,0,2,0));
-  tmp2 = _mm_shuffle_ps(m.col0, m.col1, _MM_SHUFFLE(3,1,3,1));
-  tmp3 = _mm_shuffle_ps(m.col2, m.col3, _MM_SHUFFLE(3,1,3,1));
-  row0 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(2,0,2,0));
-  row1 = _mm_shuffle_ps(tmp3, tmp2, _MM_SHUFFLE(2,0,2,0));
-  row2 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(3,1,3,1));
-  row3 = _mm_shuffle_ps(tmp3, tmp2, _MM_SHUFFLE(3,1,3,1));
-
-  tmp1 = _mm_mul_ps(row2, row3);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor0 = _mm_mul_ps(row1, tmp1);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor0 = _mm_sub_ps(_mm_mul_ps(row1, tmp1), minor0);
-
-  tmp1 = _mm_mul_ps(row1, row2);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  minor0 = _mm_add_ps(_mm_mul_ps(row3, tmp1), minor0);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor0 = _mm_sub_ps(minor0, _mm_mul_ps(row3, tmp1));
-
-  tmp1 = _mm_mul_ps(V_SHUFFLE(row1, 0x4E), row3);
-  tmp1 = V_SHUFFLE(tmp1, 0xB1);
-  row2 = V_SHUFFLE(row2, 0x4E);
-  minor0 = _mm_add_ps(_mm_mul_ps(row2, tmp1), minor0);
-  tmp1 = V_SHUFFLE(tmp1, 0x4E);
-  minor0 = _mm_sub_ps(minor0, _mm_mul_ps(row2, tmp1));
-
-  det = _mm_mul_ps(row0, minor0);
-  det = _mm_add_ps(V_SHUFFLE(det, 0x4E), det);
-  det = _mm_add_ss(V_SHUFFLE(det, 0xB1), det);
-  return det;
-}
+// v_mat44_det lives in dag_vecMath_common.h (portable form).
 
 #if defined(_MSC_VER) && (_MSC_VER < 1600 || (_MSC_VER < 1700 && _TARGET_64BIT)) && !defined(__clang__)
 //due to compiler bug (vc2008-32 and vc2010-64)

--- a/include/vecmath/dag_vecMath_scalar.h
+++ b/include/vecmath/dag_vecMath_scalar.h
@@ -9,8 +9,8 @@
 // _TARGET_SIMD_SCALAR=1 for testing). Semantics follow the SSE backend: compare results are
 // per-lane all-bits/zero masks, v_sel/v_seli and the v_check_*/v_signmask family read only
 // the lane sign bit, v_min/v_max return the second operand on unordered, float->int
-// conversions mirror cvttps/cvtps out-of-range behavior (INT_MIN), and the Cramer's-rule
-// matrix inverse/determinant are transcribed from the SSE backend op for op so rounding matches.
+// conversions mirror cvttps/cvtps out-of-range behavior (INT_MIN). The Cramer's-rule
+// matrix inverse/determinant come from the shared layer in dag_vecMath_common.h.
 
 #include <stdint.h>
 #include <string.h>
@@ -241,14 +241,14 @@ VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a)
 {
   vec4i r;
   for (int k = 0; k < 4; k++)
-    r.i[k] = (int32_t)(uint32_t)(a.f[k] == a.f[k] ? (int64_t)nearbyintf(a.f[k]) : 0);
+    r.i[k] = (int32_t)(uint32_t)(a.f[k] >= -0x1p63f && a.f[k] < 0x1p63f ? (int64_t)a.f[k] : 0); //cvttss: truncate; out of int64 range / NaN -> indefinite -> 0
   return r;
 }
 VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a)
 {
   vec4i r;
   for (int k = 0; k < 4; k++)
-    r.i[k] = (int32_t)(uint32_t)(a.f[k] == a.f[k] ? (int64_t)a.f[k] : 0);
+    r.i[k] = (int32_t)(uint32_t)(a.f[k] >= -0x1p63f && a.f[k] < 0x1p63f ? (int64_t)a.f[k] : 0);
   return r;
 }
 VECMATH_FINLINE vec4f v_cvti_vec4f(vec4i a)
@@ -331,8 +331,8 @@ VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c)
   vec4f r; for (int k = 0; k < 4; k++) r.f[k] = c.f[k] - a.f[k] * b.f[k]; return r;
 }
 VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] + b.f[0]; return r; }
-VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] - b.f[0]; return r; }
 VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] * b.f[0]; return r; }
+VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] - b.f[0]; return r; }
 VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b) { vec4f r = a; r.f[0] = a.f[0] / b.f[0]; return r; }
 VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { vec4f r = a; r.f[0] = a.f[0] * b.f[0] + c.f[0]; return r; }
 VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c) { vec4f r = a; r.f[0] = a.f[0] * b.f[0] - c.f[0]; return r; }
@@ -517,8 +517,6 @@ VECMATH_FINLINE vec4f v_rsqrt_unprecise(vec4f a)
 VECMATH_FINLINE vec4f v_rsqrt_unprecise_x(vec4f a) { vec4f r = a; r.f[0] = 1.f / sqrtf(a.f[0]); return r; }
 VECMATH_FINLINE vec4f v_rsqrt_est(vec4f a) { return v_rsqrt_unprecise(a); }
 VECMATH_FINLINE vec4f v_rsqrt_est_x(vec4f a) { return v_rsqrt_unprecise_x(a); }
-VECMATH_FINLINE vec4f v_rsqrt(vec4f a) { return v_div(v_sqrt(a), a); }
-VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) { return v_div_x(v_sqrt_x(a), a); }
 
 VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b)
 {
@@ -676,17 +674,6 @@ VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b)
 }
 VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return v_add_x(v_dot3_x(a, b), v_splat_w(a)); }
 
-VECMATH_FINLINE vec4f v_length4_sq(vec4f a) { return v_dot4(a, a); }
-VECMATH_FINLINE vec3f v_length3_sq(vec3f a) { return v_dot3(a, a); }
-VECMATH_FINLINE vec4f v_length2_sq(vec4f a) { return v_dot2(a, a); }
-VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_dot4_x(a, a); }
-VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a) { return v_dot3_x(a, a); }
-VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a) { return v_dot2_x(a, a); }
-
-VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot4_x(a, a)))); }
-VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot3_x(a, a)))); }
-VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot2_x(a, a)))); }
-
 VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b)
 {
   return v_splat_x(v_plane_dist_x(a, b));
@@ -755,200 +742,6 @@ VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest)
   dest.col2 = V_C_UNIT_1000;
 }
 
-VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src)
-{
-  vec4f c0 = {src.col0.f[0], src.col1.f[0], src.col2.f[0], src.col3.f[0]};
-  vec4f c1 = {src.col0.f[1], src.col1.f[1], src.col2.f[1], src.col3.f[1]};
-  vec4f c2 = {src.col0.f[2], src.col1.f[2], src.col2.f[2], src.col3.f[2]};
-  vec4f c3 = {src.col0.f[3], src.col1.f[3], src.col2.f[3], src.col3.f[3]};
-  dest.col0 = c0; dest.col1 = c1; dest.col2 = c2; dest.col3 = c3;
-}
-VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
-{
-  mat44f m; m.col0 = r0; m.col1 = r1; m.col2 = r2; m.col3 = r3;
-  v_mat44_transpose(m, m);
-  r0 = m.col0; r1 = m.col1; r2 = m.col2; r3 = m.col3;
-}
-VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
-{
-  vec4f c0 = {src.row0.f[0], src.row1.f[0], src.row2.f[0], 0.f};
-  vec4f c1 = {src.row0.f[1], src.row1.f[1], src.row2.f[1], 0.f};
-  vec4f c2 = {src.row0.f[2], src.row1.f[2], src.row2.f[2], 0.f};
-  vec4f c3 = {src.row0.f[3], src.row1.f[3], src.row2.f[3], 0.f};
-  dest.col0 = c0; dest.col1 = c1; dest.col2 = c2; dest.col3 = c3;
-}
-VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
-{
-  vec4f r0 = {src.col0.f[0], src.col1.f[0], src.col2.f[0], src.col3.f[0]};
-  vec4f r1 = {src.col0.f[1], src.col1.f[1], src.col2.f[1], src.col3.f[1]};
-  vec4f r2 = {src.col0.f[2], src.col1.f[2], src.col2.f[2], src.col3.f[2]};
-  dest.row0 = r0; dest.row1 = r1; dest.row2 = r2;
-}
-
-VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
-{
-  return v_add(
-    v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
-    v_add(v_mul(v_splat_z(v), m.col2), v_mul(v_splat_w(v), m.col3)));
-}
-VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
-{
-  return v_add(v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
-               v_mul(v_splat_z(v), m.col2));
-}
-VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
-{
-  return v_add(
-    v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
-    v_add(v_mul(v_splat_z(v), m.col2), m.col3));
-}
-VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
-{
-  return v_add(v_add(v_mul(v_splat_x(v), m.col0), v_mul(v_splat_y(v), m.col1)),
-               v_mul(v_splat_z(v), m.col2));
-}
-
-// transcription key: V_SHUFFLE 0xB1 = yxwz, 0x4E = zwxy
-VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
-{
-  vec4f minor0, minor1, minor2, minor3;
-  vec4f row0, row1, row2, row3;
-  vec4f det, tmp0, tmp1, tmp2, tmp3;
-
-  tmp0 = v_perm_xzac(m.col0, m.col1);
-  tmp1 = v_perm_xzac(m.col2, m.col3);
-  tmp2 = v_perm_ywbd(m.col0, m.col1);
-  tmp3 = v_perm_ywbd(m.col2, m.col3);
-  row0 = v_perm_xzac(tmp0, tmp1);
-  row1 = v_perm_xzac(tmp3, tmp2);
-  row2 = v_perm_ywbd(tmp0, tmp1);
-  row3 = v_perm_ywbd(tmp3, tmp2);
-
-  tmp1 = v_mul(row2, row3);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor0 = v_mul(row1, tmp1);
-  minor1 = v_mul(row0, tmp1);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor0 = v_sub(v_mul(row1, tmp1), minor0);
-  minor1 = v_sub(v_mul(row0, tmp1), minor1);
-  minor1 = scalar_perm(minor1, 2, 3, 0, 1);
-
-  tmp1 = v_mul(row1, row2);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor0 = v_add(v_mul(row3, tmp1), minor0);
-  minor3 = v_mul(row0, tmp1);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor0 = v_sub(minor0, v_mul(row3, tmp1));
-  minor3 = v_sub(v_mul(row0, tmp1), minor3);
-  minor3 = scalar_perm(minor3, 2, 3, 0, 1);
-
-  tmp1 = v_mul(scalar_perm(row1, 2, 3, 0, 1), row3);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  row2 = scalar_perm(row2, 2, 3, 0, 1);
-  minor0 = v_add(v_mul(row2, tmp1), minor0);
-  minor2 = v_mul(row0, tmp1);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor0 = v_sub(minor0, v_mul(row2, tmp1));
-  minor2 = v_sub(v_mul(row0, tmp1), minor2);
-  minor2 = scalar_perm(minor2, 2, 3, 0, 1);
-
-  tmp1 = v_mul(row0, row1);
-
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor2 = v_add(v_mul(row3, tmp1), minor2);
-  minor3 = v_sub(v_mul(row2, tmp1), minor3);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor2 = v_sub(v_mul(row3, tmp1), minor2);
-  minor3 = v_sub(minor3, v_mul(row2, tmp1));
-
-  tmp1 = v_mul(row0, row3);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor1 = v_sub(minor1, v_mul(row2, tmp1));
-  minor2 = v_add(v_mul(row1, tmp1), minor2);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor1 = v_add(v_mul(row2, tmp1), minor1);
-  minor2 = v_sub(minor2, v_mul(row1, tmp1));
-
-  tmp1 = v_mul(row0, row2);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor1 = v_add(v_mul(row3, tmp1), minor1);
-  minor3 = v_sub(minor3, v_mul(row1, tmp1));
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor1 = v_sub(minor1, v_mul(row3, tmp1));
-  minor3 = v_add(v_mul(row1, tmp1), minor3);
-
-  det = v_mul(row0, minor0);
-  det = v_add(scalar_perm(det, 2, 3, 0, 1), det);
-  det = v_add_x(scalar_perm(det, 1, 0, 3, 2), det);
-  tmp1 = v_rcp_safe(det);
-  det = v_sub_x(v_add_x(tmp1, tmp1), v_mul_x(det, v_mul_x(tmp1, tmp1)));
-  det = v_splat_x(det);
-  dest.col0 = v_mul(det, minor0);
-  dest.col1 = v_mul(det, minor1);
-  dest.col2 = v_mul(det, minor2);
-  dest.col3 = v_mul(det, minor3);
-}
-
-VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
-{
-  vec4f tmp0, tmp1, tmp2, tmp3, tmp4, dot, invdet, inv0, inv1, inv2;
-
-  tmp2 = v_cross3(m.col0, m.col1);
-  tmp0 = v_cross3(m.col1, m.col2);
-  tmp1 = v_cross3(m.col2, m.col0);
-  dot = v_dot3(tmp2, m.col2);
-  invdet = v_rcp_safe(dot);
-
-  tmp3 = scalar_shuffle(tmp0, tmp1, 2, 0, 2, 0);
-  tmp4 = scalar_shuffle(tmp0, tmp1, 3, 1, 3, 1);
-  inv0 = scalar_shuffle(tmp3, tmp2, 1, 3, 0, 3);
-  inv1 = scalar_shuffle(tmp4, tmp2, 1, 3, 1, 3);
-  inv2 = scalar_shuffle(tmp3, tmp2, 0, 2, 2, 3);
-
-  dest.col0 = v_mul(inv0, invdet);
-  dest.col1 = v_mul(inv1, invdet);
-  dest.col2 = v_mul(inv2, invdet);
-}
-
-VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
-{
-  vec4f minor0;
-  vec4f row0, row1, row2, row3;
-  vec4f det, tmp0, tmp1, tmp2, tmp3;
-
-  tmp0 = v_perm_xzac(m.col0, m.col1);
-  tmp1 = v_perm_xzac(m.col2, m.col3);
-  tmp2 = v_perm_ywbd(m.col0, m.col1);
-  tmp3 = v_perm_ywbd(m.col2, m.col3);
-  row0 = v_perm_xzac(tmp0, tmp1);
-  row1 = v_perm_xzac(tmp3, tmp2);
-  row2 = v_perm_ywbd(tmp0, tmp1);
-  row3 = v_perm_ywbd(tmp3, tmp2);
-
-  tmp1 = v_mul(row2, row3);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor0 = v_mul(row1, tmp1);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor0 = v_sub(v_mul(row1, tmp1), minor0);
-
-  tmp1 = v_mul(row1, row2);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  minor0 = v_add(v_mul(row3, tmp1), minor0);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor0 = v_sub(minor0, v_mul(row3, tmp1));
-
-  tmp1 = v_mul(scalar_perm(row1, 2, 3, 0, 1), row3);
-  tmp1 = scalar_perm(tmp1, 1, 0, 3, 2);
-  row2 = scalar_perm(row2, 2, 3, 0, 1);
-  minor0 = v_add(v_mul(row2, tmp1), minor0);
-  tmp1 = scalar_perm(tmp1, 2, 3, 0, 1);
-  minor0 = v_sub(minor0, v_mul(row2, tmp1));
-
-  det = v_mul(row0, minor0);
-  det = v_add(scalar_perm(det, 2, 3, 0, 1), det);
-  det = v_add_x(scalar_perm(det, 1, 0, 3, 2), det);
-  return det;
-}
 
 VECMATH_FINLINE float v_extract_x(vec4f v) { return v.f[0]; }
 VECMATH_FINLINE float v_extract_y(vec4f v) { return v.f[1]; }
@@ -983,3 +776,196 @@ VECMATH_FINLINE int v_test_vec_x_gt_0(vec3f v) { return v_test_vec_x_gt(v, v_zer
 VECMATH_FINLINE int v_test_vec_x_ge_0(vec3f v) { return v_test_vec_x_ge(v, v_zero()); }
 VECMATH_FINLINE int v_test_vec_x_lt_0(vec3f v) { return v_test_vec_x_lt(v, v_zero()); }
 VECMATH_FINLINE int v_test_vec_x_le_0(vec3f v) { return v_test_vec_x_le(v, v_zero()); }
+
+
+VECMATH_FINLINE int v_truemask(vec4f a) { return v_signmask(a); }
+VECMATH_FINLINE int v_count_true(vec4f a)
+{
+  vec4i v = v_cast_vec4i(a);
+  return -(v.i[0] + v.i[1] + v.i[2] + v.i[3]); //canonical lanes are 0 or -1: the signed sum is -0..-4, no overflow
+}
+VECMATH_FINLINE bool v_is_any_neg_b(vec4f a) { return v_signmask(a) != 0; }
+VECMATH_FINLINE int v_is_merge_planes_nout(vec4f m0, vec4f m1, vec4f m2, vec4f m3, vec4f m4, vec4f m5)
+{
+  unsigned nout = (unsigned)-v_signmask(m0) & (unsigned)-v_signmask(m1) & (unsigned)-v_signmask(m2)
+                & (unsigned)-v_signmask(m3) & (unsigned)-v_signmask(m4) & (unsigned)-v_signmask(m5);
+  return int(nout) >> 31;
+}
+
+VECMATH_FINLINE vec4f v_abs_diff(vec4f a, vec4f b) { return v_abs(v_sub(a, b)); }
+VECMATH_FINLINE vec4f v_cmp_abs_ge(vec4f a, vec4f b) { return v_cmp_ge(v_abs(a), v_abs(b)); }
+VECMATH_FINLINE vec4f v_cmp_abs_gt(vec4f a, vec4f b) { return v_cmp_gt(v_abs(a), v_abs(b)); }
+VECMATH_FINLINE vec4i v_cmp_eqi8(vec4i a, vec4i b)
+{
+  uint8_t x[16], y[16], o[16]; memcpy(x, &a, 16); memcpy(y, &b, 16);
+  for (int k = 0; k < 16; k++) o[k] = x[k] == y[k] ? 0xFF : 0;
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+
+VECMATH_FINLINE vec4f v_add_pairs(vec4f a, vec4f b) { return v_add(v_perm_xzac(a, b), v_perm_ywbd(a, b)); }
+VECMATH_FINLINE vec4f v_min_pairs(vec4f a, vec4f b) { return v_min(v_perm_xzac(a, b), v_perm_ywbd(a, b)); }
+VECMATH_FINLINE vec4f v_max_pairs(vec4f a, vec4f b) { return v_max(v_perm_xzac(a, b), v_perm_ywbd(a, b)); }
+VECMATH_FINLINE vec4i v_addi_pairs(vec4i a, vec4i b)
+{
+  vec4f af = v_cast_vec4f(a), bf = v_cast_vec4f(b);
+  return v_addi(v_cast_vec4i(v_perm_xzac(af, bf)), v_cast_vec4i(v_perm_ywbd(af, bf)));
+}
+VECMATH_FINLINE vec4i v_mini_pairs(vec4i a, vec4i b)
+{
+  vec4f af = v_cast_vec4f(a), bf = v_cast_vec4f(b);
+  return v_mini(v_cast_vec4i(v_perm_xzac(af, bf)), v_cast_vec4i(v_perm_ywbd(af, bf)));
+}
+VECMATH_FINLINE vec4i v_maxi_pairs(vec4i a, vec4i b)
+{
+  vec4f af = v_cast_vec4f(a), bf = v_cast_vec4f(b);
+  return v_maxi(v_cast_vec4i(v_perm_xzac(af, bf)), v_cast_vec4i(v_perm_ywbd(af, bf)));
+}
+
+VECMATH_FINLINE vec4f v_hmin(vec4f a)
+{
+  a = v_min(a, v_rot_1(a));
+  return v_min(a, v_rot_2(a));
+}
+VECMATH_FINLINE vec4f v_hmax(vec4f a)
+{
+  a = v_max(a, v_rot_1(a));
+  return v_max(a, v_rot_2(a));
+}
+VECMATH_FINLINE vec4f v_hmin3(vec3f a) { return v_min(v_splat_x(a), v_min(v_splat_y(a), v_splat_z(a))); }
+VECMATH_FINLINE vec4f v_hmax3(vec3f a) { return v_max(v_splat_x(a), v_max(v_splat_y(a), v_splat_z(a))); }
+VECMATH_FINLINE vec4i v_hmini(vec4i a)
+{
+  a = v_mini(a, v_roti_1(a));
+  return v_mini(a, v_roti_2(a));
+}
+VECMATH_FINLINE vec4i v_hmaxi(vec4i a)
+{
+  a = v_maxi(a, v_roti_1(a));
+  return v_maxi(a, v_roti_2(a));
+}
+VECMATH_FINLINE vec4i v_hmini3(vec4i a) { return v_mini(v_splat_xi(a), v_mini(v_splat_yi(a), v_splat_zi(a))); }
+VECMATH_FINLINE vec4i v_hmaxi3(vec4i a) { return v_maxi(v_splat_xi(a), v_maxi(v_splat_yi(a), v_splat_zi(a))); }
+
+VECMATH_FINLINE vec4f v_round(vec4f a)
+{
+  vec4f t = v_trunc(a);
+  vec4f sign = v_and(a, v_cast_vec4f(V_CI_SIGN_MASK));
+  vec4f absFrac = v_xor(v_sub(a, t), sign); // truncation keeps the remainder on a's side of zero
+  vec4f away = v_cmp_ge(absFrac, V_C_HALF);
+  return v_add(t, v_or(v_and(away, V_C_ONE), sign));
+}
+VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a) { return v_cvt_trunci(v_round(a)); }
+
+VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b)
+{
+  vec4f r;
+  r.f[0] = a.f[1] * b.f[2] - a.f[2] * b.f[1];
+  r.f[1] = a.f[2] * b.f[0] - a.f[0] * b.f[2];
+  r.f[2] = a.f[0] * b.f[1] - a.f[1] * b.f[0];
+  r.f[3] = 0.f;
+  return r;
+}
+
+VECMATH_FINLINE vec4f v_perm_yxwz(vec4f a) { return scalar_perm(a, 1, 0, 3, 2); }
+VECMATH_FINLINE vec4f v_perm_zwab(vec4f xyzw, vec4f abcd) { return scalar_shuffle(xyzw, abcd, 2, 3, 0, 1); }
+VECMATH_FINLINE vec4f v_perm_yzwa(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[1], xyzw.f[2], xyzw.f[3], abcd.f[0]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[3], abcd.f[0], abcd.f[1], abcd.f[2]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_xazc(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[0], abcd.f[0], xyzw.f[2], abcd.f[2]}; return r;
+}
+VECMATH_FINLINE vec4f v_perm_ybwd(vec4f xyzw, vec4f abcd)
+{
+  vec4f r = {xyzw.f[1], abcd.f[1], xyzw.f[3], abcd.f[3]}; return r;
+}
+
+VECMATH_FINLINE vec4i scalar_permi(vec4i a, int i0, int i1, int i2, int i3)
+{
+  vec4i r; r.i[0] = a.i[i0]; r.i[1] = a.i[i1]; r.i[2] = a.i[i2]; r.i[3] = a.i[i3]; return r;
+}
+VECMATH_FINLINE vec4i v_permi_xxyy(vec4i a) { return scalar_permi(a, 0, 0, 1, 1); }
+VECMATH_FINLINE vec4i v_permi_xxzz(vec4i a) { return scalar_permi(a, 0, 0, 2, 2); }
+VECMATH_FINLINE vec4i v_permi_xyxy(vec4i a) { return scalar_permi(a, 0, 1, 0, 1); }
+VECMATH_FINLINE vec4i v_permi_xzxz(vec4i a) { return scalar_permi(a, 0, 2, 0, 2); }
+VECMATH_FINLINE vec4i v_permi_ywyw(vec4i a) { return scalar_permi(a, 1, 3, 1, 3); }
+VECMATH_FINLINE vec4i v_permi_yyww(vec4i a) { return scalar_permi(a, 1, 1, 3, 3); }
+VECMATH_FINLINE vec4i v_permi_yzxw(vec4i a) { return scalar_permi(a, 1, 2, 0, 3); }
+VECMATH_FINLINE vec4i v_permi_yzxy(vec4i a) { return scalar_permi(a, 1, 2, 0, 1); }
+VECMATH_FINLINE vec4i v_permi_zwzw(vec4i a) { return scalar_permi(a, 2, 3, 2, 3); }
+VECMATH_FINLINE vec4i v_permi_zzww(vec4i a) { return scalar_permi(a, 2, 2, 3, 3); }
+VECMATH_FINLINE vec4i v_permi_wwyy(vec4i a) { return scalar_permi(a, 3, 3, 1, 1); }
+
+VECMATH_FINLINE vec4i v_perm_i8(vec4i t, vec4i k)
+{
+  uint8_t tb[16], kb[16], o[16]; memcpy(tb, &t, 16); memcpy(kb, &k, 16);
+  for (int i = 0; i < 16; i++) o[i] = (kb[i] & 0x80) ? 0 : tb[kb[i] & 0x0F];
+  vec4i r; memcpy(&r, o, 16); return r;
+}
+
+VECMATH_FINLINE void v_interleave3(vec4f x, vec4f y, vec4f z, vec4f &e0, vec4f &e1, vec4f &e2)
+{
+  vec4f a = {x.f[0], y.f[0], z.f[0], x.f[1]};
+  vec4f b = {y.f[1], z.f[1], x.f[2], y.f[2]};
+  vec4f c = {z.f[2], x.f[3], y.f[3], z.f[3]};
+  e0 = a; e1 = b; e2 = c;
+}
+VECMATH_FINLINE void v_interleave4(vec4f x, vec4f y, vec4f z, vec4f w, vec4f &e0, vec4f &e1, vec4f &e2, vec4f &e3)
+{
+  vec4f a = {x.f[0], y.f[0], z.f[0], w.f[0]};
+  vec4f b = {x.f[1], y.f[1], z.f[1], w.f[1]};
+  vec4f c = {x.f[2], y.f[2], z.f[2], w.f[2]};
+  vec4f d = {x.f[3], y.f[3], z.f[3], w.f[3]};
+  e0 = a; e1 = b; e2 = c; e3 = d;
+}
+
+VECMATH_FINLINE void v_ld_soa2(const float *m, vec4f &x, vec4f &y)
+{
+  vec4f a, b;
+  for (int k = 0; k < 4; k++) { a.f[k] = m[2 * k]; b.f[k] = m[2 * k + 1]; }
+  x = a; y = b;
+}
+VECMATH_FINLINE void v_ldu_soa2(const float *m, vec4f &x, vec4f &y) { v_ld_soa2(m, x, y); }
+VECMATH_FINLINE void v_ld_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z)
+{
+  vec4f a, b, c;
+  for (int k = 0; k < 4; k++) { a.f[k] = m[3 * k]; b.f[k] = m[3 * k + 1]; c.f[k] = m[3 * k + 2]; }
+  x = a; y = b; z = c;
+}
+VECMATH_FINLINE void v_ldu_soa3(const float *m, vec4f &x, vec4f &y, vec4f &z) { v_ld_soa3(m, x, y, z); }
+VECMATH_FINLINE void v_ld_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w)
+{
+  vec4f a, b, c, d;
+  for (int k = 0; k < 4; k++) { a.f[k] = m[4 * k]; b.f[k] = m[4 * k + 1]; c.f[k] = m[4 * k + 2]; d.f[k] = m[4 * k + 3]; }
+  x = a; y = b; z = c; w = d;
+}
+VECMATH_FINLINE void v_ldu_soa4(const float *m, vec4f &x, vec4f &y, vec4f &z, vec4f &w) { v_ld_soa4(m, x, y, z, w); }
+VECMATH_FINLINE void v_st_soa2(float *m, vec4f x, vec4f y)
+{
+  for (int k = 0; k < 4; k++) { m[2 * k] = x.f[k]; m[2 * k + 1] = y.f[k]; }
+}
+VECMATH_FINLINE void v_stu_soa2(float *m, vec4f x, vec4f y) { v_st_soa2(m, x, y); }
+VECMATH_FINLINE void v_st_soa3(float *m, vec4f x, vec4f y, vec4f z)
+{
+  for (int k = 0; k < 4; k++) { m[3 * k] = x.f[k]; m[3 * k + 1] = y.f[k]; m[3 * k + 2] = z.f[k]; }
+}
+VECMATH_FINLINE void v_stu_soa3(float *m, vec4f x, vec4f y, vec4f z) { v_st_soa3(m, x, y, z); }
+VECMATH_FINLINE void v_st_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w)
+{
+  for (int k = 0; k < 4; k++) { m[4 * k] = x.f[k]; m[4 * k + 1] = y.f[k]; m[4 * k + 2] = z.f[k]; m[4 * k + 3] = w.f[k]; }
+}
+VECMATH_FINLINE void v_stu_soa4(float *m, vec4f x, vec4f y, vec4f z, vec4f w) { v_st_soa4(m, x, y, z, w); }
+
+VECMATH_FINLINE void v_mat43_make_from_43cu_unsafe(mat43f &tmV, const float *const __restrict m43)
+{
+  // rows' .w lanes carry junk instead of the translation, mirroring the SSE lane pattern
+  vec4f r0 = {m43[0], m43[3], m43[6], m43[6]};
+  vec4f r1 = {m43[1], m43[4], m43[7], m43[7]};
+  vec4f r2 = {m43[2], m43[5], m43[8], m43[8]};
+  tmV.row0 = r0; tmV.row1 = r1; tmV.row2 = r2;
+}

--- a/include/vecmath/microarch.md
+++ b/include/vecmath/microarch.md
@@ -1,0 +1,178 @@
+# vecmath: per-instruction cost and target hardware
+
+What the machine costs. The API-level rules these costs justify - which vecmath call to write -
+live in `usage.md`, each with its reason, and are actionable without this file. Come here when
+adding or porting a vecmath function, or when squeezing a SIMD hot loop (culling, physics, BVH,
+animation) raises a question no rule answers.
+
+Intrinsics are not exact assembly coding: the compiler treats them as semantics, not fixed
+encodings, and may use equivalent instructions when they are faster; our compilation options
+(fast-math, contraction) deliberately give it that freedom. Everything below is about what is
+actually emitted - when a cost matters, check the disassembly of the hot loop.
+
+## Lane utilization: SoA vs per-vector
+The largest factor here, and the only one with a 4x ceiling rather than a single-digit percentage.
+
+Per-vector 3d math wastes lane width by construction: a vec3f carrying a Point3 does useful work
+in 3 lanes of 4, and an `_x` form does useful work in 1 of 4. Both are the right per-vector choice
+- skipping .w buys nothing, and `_x` is genuinely cheaper on the narrow dividers below - but they
+cap a loop at 75% or 25% of the machine's width however well each individual call is written.
+
+SoA lifts the cap: hold N objects as parallel arrays, one vec4f of x, one of y, one of z, so every
+operation computes 4 objects at once with all four lanes carrying real work. Cross-lane traffic
+disappears with it. A dot product becomes 3 mul + 2 add - no shuffles, no horizontal reduction, no
+.w discipline, and no v_ldu_p3 over-read question, since you load a full vec4f of x rather than a
+3-float point.
+
+Worth doing for algorithms that sweep many elements: culling, particle updates, batch transforms,
+broadphase, ray packets, skinning. Not worth doing for one-off per-object math, or for branchy
+per-body work where each element takes a different path (`vec4d.md` reaches the same conclusion
+from the double-precision side).
+
+SoA does not have to be the storage format, and in practice it usually is not: engine data stays
+in the classic AoS types and the SoA form is built when it is loaded. That is the expected
+pattern, and the deinterleaving loads exist for it - v_ld_soa2/3/4 and v_ldu_soa2/3/4 turn packed
+float2/float3/float4 arrays into SoA lanes as part of the load (one ld2/ld3/ld4 on NEON, a short
+shuffle sequence on SSE), and v_st_soa*/v_stu_soa* interleave back on the way out. vecmath itself
+computes in SoA in many places for the same reason.
+
+The repack is therefore cheap, but it is not free on SSE, so work too short to amortize a
+deinterleave over 4 elements still loses. The other constraint is real: SoA needs branchless
+code, because the 4 elements in flight cannot branch separately - masks and v_sel/v_btsel, which
+is how vecmath is written anyway.
+
+A loop full of v_dot3, horizontal reductions and `_x` forms is usually paying the per-vector tax
+rather than asking to be micro-optimized; the fix is the layout.
+
+## Our target hardware
+- Main build is x86-64 Windows PC client compiled for 64-bit target with SSE 4.1
+- Typical PC is Skylake/Zen or newer with AVX2+FMA; SSE 4.1 is the compatibility floor, not the
+  typical machine, and Skylake (2015) is the old tail - weight optimization toward recent big
+  cores. On desktop hybrids SIMD-heavy threadpool jobs mostly run on P-cores, but laptop and
+  budget chips have few or no P-cores, so the small-core guidance below applies to cheap PCs too
+- Calibrate PC capability against the Steam hardware survey (store.steampowered.com/hwsurvey; June
+  2026: SSE4.1 98%, AVX 97%, AVX2 95%, AVX-512 23%; 6 or 8 physical cores are the most common),
+  keeping in mind our games also run well on machines older than the Steam average
+- Current generation consoles (Xbox Series X/S, PS5) are AMD Zen2: Scarlett builds with
+  -march=znver2 (PS5 Sony clang targets the same CPU), so AVX2 + FMA + BMI2 with real 256-bit
+  datapaths
+- Previous generation consoles (Xbox One, PS4) are AMD Jaguar: Xbox One builds with -march=btver2
+  -mno-bmi2 (PS4 Sony clang targets the same CPU), so AVX but NO FMA and no BMI2, and 256-bit
+  operations are slow (emulated by 2x128)
+- Console performance matters on both generations; both are active platforms
+- Dedicated servers compiled for Linux 64-bit target with -march=haswell (AVX2 + FMA + BMI2; see
+  skyquake/prog/jamfile)
+- Mobile phones (ARMv8, mostly Android) are a first-class production platform - NEON code quality
+  matters as much as SSE
+- Nintendo Switch is aarch64 Cortex-A57 (-mcpu=cortex-a57+fp+simd+crypto+crc): 128-bit ASIMD
+  execution without the A53/A55-style 64-bit split, but the pipes are asymmetric - integer SIMD
+  dual-issues more than FP, 128-bit FP FMA is about one per cycle (half of A76+), 128-bit integer
+  multiply ~0.5/cycle, FP divide blocks for 7-32 cycles
+- We support an SSE2 min-cpu build (very rarely used), but ARMv7 is not supported
+
+The floating-point environment we build with (fast-math, FMA contraction, VECMATH_NO_FMA,
+flushed denormals, relaxed NaN compares) is a caller-visible contract and lives in `usage.md`.
+
+## Scalar vs packed div/sqrt
+On the big cores we target, scalar and packed full-precision div/sqrt have similar throughput,
+but small cores serve lanes from a narrow unit, so the packed form costs up to lanes-times more:
+- AMD Jaguar (XB1/PS4): sqrtss ~16c vs sqrtps ~27c, div similar, neither fully pipelined
+- Intel E-cores (Gracemont in hybrid PCs): narrow divider, packed div/sqrt ~2x worse than scalar
+- ARM little cores (Cortex-A53/A55): 64-bit NEON datapath splits every 128-bit op into 2 uops, so
+  the 2-lane forms sqrt/div use are half cost
+
+This is why broadcast v_length*/v_norm*/v_mat44_max_scale43 route through v_sqrt_x internally.
+Cheap ops (add/mul/min/max/shuffles) have no such penalty on x86; do not contort code to
+scalarize them.
+
+## Instructions we avoid (microcoded or high latency)
+- dpps/dppd: multi-uop and high-latency on every x86 core we care about, worst on Jaguar; explicit
+  mul + shuffle + add sequences schedule better and transfer naturally to NEON.
+- haddps/hsubps: decode to 2 shuffles + add on all x86 cores we target - never beat explicit
+  shuffle + add and they load the shuffle port; NEON pairwise vpadd/faddp IS single and cheap.
+- pmulld (v_muli on SSE4): historically expensive on several Intel big-core generations (cheap
+  on Zen); keep it off critical dependency chains unless measured on the actual target.
+- MXCSR changes (rounding mode etc.): serialize the FP pipeline; use roundps based
+  v_floor/v_ceil/v_round instead of touching control registers.
+- NEON multi-register table lookups (tbl2/tbl3/tbl4): 2-4x cost on little cores; single-register
+  vqtbl1q is fine.
+
+## Port-unique units and domain crossings
+- Skylake-family Intel big cores execute ALL vector shuffles on one port (port 5), while blends
+  and bitwise logic run on 3 ports; movss/movsd register merges count as shuffles, and so does
+  insertps/unpck used to zero or merge a lane, where an and-mask or immediate blend would not.
+  Ice Lake adds a second in-lane shuffle port (cross-lane stays on port 5), Zen always has two,
+  so this is mainly a Skylake-era concern - tuning for one shuffle port never hurts newer cores.
+- FP mul/add/FMA have two ports on big x86 cores, so dependency chains, not ports, are usually the
+  limit: structure reductions as two independent accumulator chains joined at the end (the
+  v_mat44_mul_vec4 pattern).
+- A compile-time vector constant (v_splats(1.f)) is typically a full-width constant-pool load -
+  load-port work; splatting a runtime scalar already in a register costs a shuffle instead.
+  vbroadcastss helps only with a memory source; from a register it is another port 5 shuffle.
+- Register-register moves (movaps) are usually eliminated at rename on big x86 cores, but they
+  cost front-end bandwidth, elimination has limits (errata disabled it on some generations), and
+  Jaguar executes them: do not fear compiler temporaries, but eyeball move-heavy hot loops.
+- Modern ARM big cores (Cortex-A76+, Apple M) have two symmetric 128-bit ASIMD pipes that accept
+  nearly everything; older A57/A72 concentrate FP on one pipe. Shuffle-port pressure is an
+  x86/Intel concern; the scarce NEON resources are the divider and little-core width (see above).
+- Divider/sqrt capacity is scarce on all targets: big x86 cores pipeline FP div/sqrt partially
+  (Skylake divps: ~11c latency, a result per ~3c), ARM cores through A72 block outright (7-32
+  cycles, no overlap), and consecutive independent div/sqrt serialize either way. When all lanes
+  carry real work, batch them into one packed op (the v_mat44_remove_scale33 pattern: one rsqrt
+  for three lengths); when only one lane does, use _x forms (see above).
+- GPR<->vector crossings (movd/pinsr/pextr, umov/fmov on ARM) cost several cycles each way and are
+  especially slow on Jaguar. Keep math in vector registers; extract once at the end. movmskps/ptest
+  results live on the GPR side: fine for branching, avoid feeding them back into vector code.
+- Store-to-load forwarding does not cover a load that overlaps several narrower prior stores, so
+  the load waits for them to reach L1 (see the Point3_vec4 antipattern in `usage.md`).
+- Integer shuffles on float data (and vice versa) can add 1-cycle bypass delays on Jaguar and older
+  Intel cores; prefer same-domain shuffles when an equivalent exists.
+
+## AMD vs Intel
+Most published optimization data is Intel-focused, yet Zen-aware tuning is especially relevant for
+us - current-generation consoles are Zen 2, and AMD is ~45% of CPUs in the Steam Hardware Survey,
+a large and growing share of the gaming-PC audience:
+- several Intel costs simply do not exist on Zen: the single shuffle port (Zen always has two),
+  expensive pmulld (~3-4c on Zen), and variable blends (blendvps, i.e. v_sel) are 1 uop on Zen vs
+  2+ on most Intel cores
+- Zen has separate FP add and FP mul/FMA pipes, so mixed add/mul streams sustain twice the
+  throughput of Skylake-era Intel (which ran both on the same two FMA ports until Golden Cove
+  added dedicated adders)
+- dpps is even worse on AMD than on Intel (already avoided, see above)
+- FMA latency is 5 cycles on Zen1/Zen2 (4 on Zen3+ and Intel big cores): madd dependency chains
+  run a cycle per link slower on current consoles than Intel numbers suggest, so independent
+  accumulators matter even more there
+- AVX2 gathers are many-uop and slow on Zen2: on consoles vgatherdps is no faster than the
+  equivalent scalar loads, so do not port Intel-tuned gather tricks there
+- rcpps/rsqrtps estimate bits differ between AMD and Intel (and NEON differs from both), so
+  _est/_unprecise results are not bit-reproducible across machines; keep estimates out of code
+  that must be deterministic across clients (replays, lockstep)
+- ties between otherwise equal encodings go to the AMD-friendly one; Intel big cores are rarely
+  hurt by it
+
+## Generational drift
+- Per-instruction costs drift between generations; calibrate on the last 2-3 (Intel Golden
+  Cove/Raptor Cove P-cores 2021-2023, Arrow Lake; AMD Zen3/Zen4/Zen5), not on Skylake (2015):
+  - FP add latency dropped from 4c (Skylake ran adds on the FMA units) to 3c on Golden Cove and
+    ~2c on Zen5; FMA stays 4c
+  - div/sqrt got faster every generation; on Zen3+/Alder Lake+ an occasional div or sqrt is rarely
+    worth restructuring around, and _est pays off even less than on Skylake
+  - Intel E-cores: Skymont (Arrow Lake, 2024) roughly doubles Gracemont's SIMD throughput, so the
+    E-core penalty shrinks on the newest parts
+  When a specific cost matters, check uops.info and AMD's per-family Software Optimization Guides
+  (family 17h covers the console Zen2) instead of assuming 'modern x86'.
+- ARM cores drift the same way: Cortex-A76 (2018) doubled big-core NEON throughput (two symmetric
+  128-bit pipes), Cortex-X and Apple M run four; ARMv9 little cores (A510/A520) move past the
+  A53/A55 64-bit-SIMD model, but SIMD width and sharing are configuration dependent - do not
+  extrapolate A53/A55 costs to them; FP divide is much faster and no longer fully blocking from
+  A76 on. Android fleets span all of these, so check the actual core, not 'ARM'.
+- We target ARMv8/AArch64 only - a significant break from ARMv7, so ARM optimization articles from
+  that era are often no longer valid: AArch64 has 32 x 128-bit registers (ARMv7 had 16),
+  IEEE-compliant NEON FP (ARMv7 was flush-to-zero only), FMA, vector div/sqrt (ARMv7 NEON had only
+  estimates) and horizontal reductions always available, and no VFP/NEON mode-switch or NEON-to-GPR
+  pipeline stalls (crossings still cost a few cycles, see above)
+- Full-precision div/sqrt is fast on big x86 cores, so _est variants mostly pay off on small
+  cores, on ARM (where fdiv/fsqrt stay long-latency even on big cores), or when several are in
+  flight; they are not an automatic win. Exception: precise v_rsqrt is sqrt plus div - two ops
+  serializing on the single divider - so v_rsqrt_est keeps a ~2x throughput edge even on big
+  cores until the divider is nearly free (Zen3+/Ice Lake+).

--- a/include/vecmath/usage.md
+++ b/include/vecmath/usage.md
@@ -1,0 +1,218 @@
+# Using vecmath
+
+Platform-abstracted SIMD vector math. Wraps SSE2/SSSE3/SSE4.1 (x86) and NEON (ARM) behind a
+unified C API. Used pervasively throughout the Dagor Engine for all performance-critical math:
+transforms, physics, BVH traversal, culling, animation.
+
+`vecmath/dag_vecMath.h` is the API reference: every `v_`-prefixed function is declared there with
+a comment. Grep it by prefix before writing anything by hand -- what you need probably exists
+(v_mat44_*, v_mat33_*, v_mat43_*, v_quat_*, v_bbox3_*, v_bsph*, v_plane*, v_frustum*, v_ray*,
+v_triangle*).
+
+## Key types
+- `vec4f` / `vec3f` -- 128-bit float vector (__m128 on SSE, float32x4_t on NEON)
+- `vec4i` -- 128-bit integer vector (__m128i / int32x4_t)
+- `mat33f` -- 3x3 column-major matrix (3 x vec3f)
+- `mat44f` -- 4x4 column-major matrix (4 x vec4f)
+- `mat43f` -- 4x3 row-major matrix (3 x vec4f, each row is xyzw where w = translation component)
+- `bbox3f` -- AABB {bmin, bmax} as two vec4f
+- `bsph3f` -- bounding sphere {center.xyz, radius.w}
+- `quat4f` -- quaternion as vec4f
+- `plane3f` -- plane {normal.xyz, D.w}
+
+Double precision (`vec4d`, `vd_`-prefixed) is a separate rarely-used corner: see `vec4d.md`.
+
+## API conventions
+- Suffix scheme:
+  - `_x` -- result in .x only, .yzw are allowed to contain anything (even NaN); cheaper than the
+    broadcast form
+  - `_est` -- hardware estimate refined by Newton-Raphson steps; sequence and step count vary
+    per op and platform to land at similar useful precision (not an automatic win, see
+    `microarch.md`)
+  - `_unprecise` -- raw hardware estimate only (fastest, least precise)
+  - `_safe` -- tolerates edge inputs (zero divisors, page-boundary loads); the divisor check
+    (v_is_unsafe_divisor: |x| < V_C_VERY_SMALL_VAL, 4e-19 ~ sqrt(FLT_MIN)) is tuned to stay safe
+    under squaring: if x passes, x*x does not underflow and 1/(x*x) does not overflow
+- Precision/safety policy: the default (unsuffixed) function is precise and identical on every
+  platform; speed-for-precision variants (_est/_unprecise) are opt-in by name, never the default,
+  since estimates are not bit-reproducible across ISAs. Softer for inputs: defaults assume
+  well-formed data, _safe is only for where edge cases (zero divisor, page-edge load) are real.
+- Basic rcp/sqrt/rsqrt use real division/square-root instructions, never hardware estimate
+  instructions; estimates enter only through the _est/_unprecise variants
+- 3-component ops ignore .w of inputs: it can be anything, even NaN. Most gameplay code safely
+  carries 3d vectors in vec3f with garbage in .w, but some render code requires .w = 0. Same for
+  mat44f holding a 4x3 transform: row3 (the .w lane of the columns) can be anything for gameplay,
+  but the GPU requires 0,0,0,1 there
+- Loads/stores: v_ld/v_st aligned, v_ldu/v_stu unaligned, *i for integer. On modern cores
+  unaligned is as fast as aligned within a cache line, so aligned forms act mostly as a hardware
+  alignment assert. Encodings differ: legacy (non-VEX) SSE load+op memory operands (addps xmm,
+  [mem]) require alignment, so on the SSE4.1 PC build only v_ld folds into the consuming
+  instruction (v_ldu stays a separate movups); VEX operands don't require alignment, both forms
+  fold, and a folded v_ld loses the movaps fault; NEON never checks alignment
+- Deinterleaving loads/stores: v_ld_soa2/3/4 (16-byte aligned) and v_ldu_soa2/3/4 read an array of
+  packed float2/float3/float4 straight into SoA x/y/z/w lanes - 4 elements per call, one ld2/ld3/
+  ld4 on NEON - and v_st_soa*/v_stu_soa* write SoA lanes back interleaved. This is how a classic
+  Point3 array is fed to a batched algorithm without changing its storage
+- Point3/DPoint3 layout has its own load/store ops: v_ldu_p3, v_ldu_p3_safe, v_ldui_p3, v_stu_p3.
+  v_ldu_p3 reads 4 floats for a 3-component vector (fast): harmless on the stack, but a heap
+  array of packed 3-float positions whose last element ends exactly at a page end crashes on the
+  final load - use v_ldu_p3_safe (reads exactly 3, slower) there. ASAN/TSAN builds route v_ldu_p3
+  to the safe path automatically, so sanitizers neither catch nor reproduce the over-read
+- Store ports are scarcer than load ports (big cores sustain 2-3 loads but only 1-2 stores per
+  cycle), and v_stu_p3 issues two store uops (8-byte + 4-byte); when the destination really has
+  writable padding, prefer one full v_st/v_stu. Do not manufacture that padding, see Antipatterns
+- Lane ops: v_splats(float) / v_splatsi(int) broadcast a scalar, v_splat_x/y/z/w broadcast a lane,
+  v_extract_x/y/z/w read a lane out
+- Compares (v_cmp_gt/ge/lt/le/eq) return per-lane masks (all-ones or 0); consume masks with bitwise
+  ops (v_and/v_or/v_xor/v_andnot), branchless selects (v_sel/v_sel_b/v_btsel/v_bbox3_sel), the
+  v_check_*/v_test_* branching helpers, or v_signmask/v_truemask (lane bits as an int)
+- v_cast_* reinterprets bits (free), v_cvt_* converts values (int<->float)
+- FP16: v_half_to_float / v_float_to_half_rtne; _up/_down variants round directionally for
+  conservative bounds
+
+## Prefer the provided forms over hand-rolled sequences
+Each of these families is hand-mapped to the cheapest form on both ISAs. A hand-written
+equivalent is tuned for whichever ISA its author had in mind - almost always SSE - and usually
+loses on the other one. Per-core cost detail behind these rules is in `microarch.md`; the rules
+themselves do not need it.
+
+- Swizzles: v_perm_<lanes> with xyzw lane names; two-vector perms name the second operand's lanes
+  abcd (v_perm_xzac); v_rot_1/2/3 rotate lanes. Prefer them over raw intrinsics or exotic custom
+  shuffles: shufps encodes any lane pattern in one op so SSE code shuffles freely, but NEON has no
+  generic immediate shuffle - clang maps common patterns to ext/zip/uzp/trn/rev and lowers exotic
+  ones to tbl with a loaded index constant. The NEON-native two-vector set is single-instruction
+  there and 1-2 ops on SSE - prefer these patterns when any layout works: zip (v_merge_hw/lw),
+  uzp (v_perm_xzac/ywbd), trn (v_perm_xazc/ybwd), ext (v_perm_yzwa/zwab/wabc). Where the lane
+  pattern allows either, a blend-based perm (v_perm_xbzw etc.) beats a shuffle-based one on
+  Intel big cores, which run all shuffles on a single port
+- Horizontal (cross-lane) reductions have named helpers - v_hmin/v_hmax (+ v_hmini/v_hmaxi and
+  the 3-component forms), v_hadd4_x/v_hadd3_x, v_hand/v_hor (+3), v_hmul/v_hmul3, v_dot3/v_dot4,
+  v_length3/v_length4. Prefer them over a shuffle/rotate + op chain. aarch64 has fminv/fmaxv/
+  sminv/smaxv and integer addv as single instructions with no portable equivalent (float faddv is
+  SVE-only, so vaddvq_f32 compiles to an faddp pair), which is why several of these have
+  NEON-specific implementations; on x86 the obvious hand-written form reaches for haddps, which
+  is on the avoid list and loses to the explicit shuffle + add these helpers use. Note the _x
+  forms (v_hadd4_x, v_dot4_x, v_length4_x) define .x only and are cheaper when you do not need
+  the broadcast
+- Branching on a compare: use the v_check_*/v_test_* helpers rather than v_signmask + integer
+  compare. x86 has movmskps so the signmask idiom is cheap there, but NEON has no movemask
+  instruction and emulates it - with current clang codegen v_signmask(a) == 0b1111 is 10
+  instructions against 5 for v_check_xyzw_all_true(a), where on SSE both are 4. When you do want
+  the bits, prefer v_truemask over v_signmask on compare results: same value, one op cheaper on
+  NEON. Better still, stay branchless
+- When only one lane holds real work, use an _x form (plus v_splat_x if you need it broadcast)
+  instead of a packed div/sqrt: big cores are indifferent, but the small cores we ship on serve
+  lanes from a narrow divider and charge up to lanes-times more. When every lane does carry real
+  work the advice inverts - batch them into a single packed op rather than repeating a scalar one.
+  If a whole loop is built out of one-lane work, the data layout is the ceiling and not the call:
+  see the SoA section of `microarch.md`
+- Matrix-wide operations, not per-column work: v_mat33_remove_scale, v_mat44_remove_scale33,
+  v_mat44_apply_scale33, v_mat44_max_scale43(_sq/_x), v_mat44_scale43_sq, v_mat33_orthonormalize,
+  v_mat44_orthonormalize33, v_mat33_decompose, v_mat4_decompose, the _det/_inverse/
+  _orthonormal_inverse sets. Two reasons. Speed: the matrix-wide form batches what per-column code
+  serializes - three column lengths become one packed rsqrt instead of three trips through the
+  scarce divider. Correctness: the decompose and quat-from-matrix functions apply one shared
+  convention for mirrored input, see below
+
+## Correctness traps
+- Mirrored (det < 0) input has one engine-wide convention: flip col2 and fold the negative into
+  scale.z. It is applied by v_mat33_decompose, v_mat4_decompose and v_quat_from_mat*, each of
+  which tests the determinant itself. Per-column normalization written by hand silently disagrees
+  on mirrored matrices, which is the main correctness reason to use those functions
+- Scale removal is sign-neutral and does NOT canonicalize handedness: v_mat33_remove_scale and
+  v_mat44_remove_scale33 only divide each column by its length, so a mirrored basis comes back
+  mirrored. They are the primitive the functions above build on, not a replacement for them -
+  v_quat_from_mat33 calls v_mat33_remove_scale and then applies the col2 flip itself
+- Matrix functions tolerate aliasing: dest may be an input, so callers can write
+  v_mat44_mul(m, m, rel)
+- v_sel selectors must be canonical per-lane masks (all-ones/zero, as v_cmp_* produce): SSE4.1
+  blendvps reads only the sign bit, but the SSE2 path and NEON vbsl select per bit - a sign-only
+  selector works on the PC build and silently breaks on other targets
+- v_norm* of a zero or near-zero vector produces inf/NaN lanes; v_norm*_safe(a, def) returns def
+  when length^2 fails the unsafe-divisor check
+- quat-from-matrix has two tiers. v_quat_from_orthonormal_mat* are the fast tier: they REQUIRE
+  orthonormal input (wrong for scaled matrices), relying on the 0.5*rsqrt case scaling for unit
+  output (4e-7, rotation 1.6e-6). v_quat_from_mat* are the robust tier for untrusted matrices:
+  per-column scale removal (one packed rsqrt via v_mat33_remove_scale), a col2 flip on mirrored
+  input per the convention above, and a trailing v_norm4, because scale removal makes columns unit
+  but cannot fix sheared (non-orthogonal) columns and the conversion is unit-by-construction only
+  for a truly orthonormal basis
+- Function results are usually fully defined: _x forms define .x only (see suffix scheme) and
+  broadcast forms fill all 4 lanes. The few ops that return a vec3f (v_cross3, v_norm3,
+  v_mat44_scale43_sq, vec3 transforms) leave .w unspecified unless the header comment says
+  otherwise - do not let it leak into 4-component math
+
+## Floating-point environment
+- All platforms build with fast-math semantics: clang platforms pass -ffast-math
+  -ffinite-math-only plus explicit -mrecip=none, Windows and Xbox build with /fp:fast. Either way
+  the compiler may reassociate and contract FP math but must NOT auto-substitute div/sqrt with
+  rcpps/rsqrtps estimates - estimates enter only through the explicit _est/_unprecise API.
+  Finite-math-only also means NaN/Inf tests must defeat the optimizer, which is why v_is_nan and
+  v_is_not_finite use volatile
+- Both clang (fast-math / -ffp-contract=fast) and MSVC since VS2022 (/fp:fast) contract intrinsic
+  mul+add into FMA when the target has FMA; neither contracts under default FP settings.
+  v_madd/v_msub/v_nmsub are the flag-independent spelling: on NEON v_madd is explicit vfmaq_f32,
+  on x86 it uses FMA when the target has it. FMA also rounds differently than mul+add: the product
+  is not rounded before the add - more precise, but a trap in code like a*b + c*d != 0.0, where
+  the result can differ between contracted and non-contracted builds (and so between platforms).
+  Libs that need cross-ISA consistency (physJolt, gamePhys/collision, rendInst) define
+  VECMATH_NO_FMA and build with -mno-fma (x86), -fno-unsafe-math-optimizations and
+  -ffp-contract=off: the define unfuses the explicit vfmaq in v_madd, the flags stop compiler
+  contraction (contract=off alone is not enough under fast-math)
+- A difference of two products is where that bites: fuse one of them and a*b - b*a returns the
+  rounding error of the other instead of 0. v_cross3 defeats contraction on every build with
+  multiplies no compiler can fuse (fmulx on NEON, muls feeding hsubps on FMA-enabled x86 - FMA
+  has no horizontal form), so a x a is exactly 0, antisymmetry is bitwise, and results match
+  across platforms - do not hand-roll a cross product out of v_nmsub.
+  Shuffling the products before the sub is not a substitute: the optimizer moves shuffles across
+  the math and restores the fusable form. Note that merely parallel input is still nonzero: for
+  b = s*a the products meet already-rounded b lanes, which no rounding discipline can cancel
+- NaN semantics are relaxed by fast-math: the compiler assumes ordered inputs and freely mirrors
+  or inverts comparisons (a < b into !(a >= b), reversed or negated cmp predicates) when that
+  encodes better. IEEE comparisons with a NaN operand are all false, so a mirrored form returns
+  the opposite - NaN behavior in the binary can differ from what the code says, and between
+  builds and platforms. Do not rely on compare direction to filter NaNs
+- Denormals are flushed to zero (FTZ/DAZ on x86, FPCR.FZ on ARM), so subnormals never appear in
+  our math: no gradual underflow, the smallest magnitude surviving is FLT_MIN (~1.18e-38)
+- DEV builds compiled by MSVC for 32-bit target with x87 scalar operations and enabled NaN
+  exceptions, but for SSE intrinsics any exceptions are disabled
+
+## Antipatterns
+
+### Point3_vec4 as a transient proxy for aligned load/store
+`Point3_vec4` is `Point3` plus a pad float, aligned to 16 so that v_ld/v_st are legal on it.
+Reaching for it to move a value in or out of a plain `Point3` costs far more than the unaligned
+access it avoids, and the aligned load or store is the cheapest part of the sequence.
+
+```cpp
+// WRONG: the temp burns a stack slot, forces v out of registers, and the
+// read-back copies the 3 floats a second time.
+void store_p3(Point3 &p3, vec3f v)
+{
+  Point3_vec4 tempP4;
+  v_st(&tempP4.x, v);
+  p3 = tempP4;
+}
+
+// RIGHT
+void store_p3(Point3 &p3, vec3f v) { v_stu_p3(&p3.x, v); }
+```
+
+The same in reverse for loads: `v_ldu_p3(&p3.x)`, never a copy into a `Point3_vec4` followed by
+`v_ld`. There the proxy is worse still - three narrow scalar stores feeding one 16-byte load is
+exactly the overlap x86 store-to-load forwarding cannot handle, so the load stalls until they
+retire; a copy routed through GPRs pays the GPR<->vector crossing instead.
+
+This survives review because when the `Point3` is a visible local the compiler often sees through
+the copy and the profile shows nothing. It bites where the hot loops are: array elements, struct
+fields, by-reference parameters, anything across a function boundary.
+
+`Point3_vec4` remains correct as *storage* - a struct field or array element that is genuinely
+aligned, where the padding is intentional and v_ld/v_st on it are free. The antipattern is the
+throwaway temp, not the type.
+
+## Include path
+```cpp
+#include <vecmath/dag_vecMath.h>        // full API
+#include <vecmath/dag_vecMathDecl.h>    // types only (forward declarations)
+```

--- a/include/vecmath/vec4d.md
+++ b/include/vecmath/vec4d.md
@@ -1,0 +1,37 @@
+# vec4d - double-precision vector math
+
+Rarely used: almost all engine math is single precision. This exists for the places that must
+keep `DPoint3` precision (large world coordinates, some physics) and want them vectorized.
+Implementation is `dag_vecMath_double.h` (SSE/AVX and NEON in one file), included via
+`dag_vecMath.h`. The API is `vd_`-prefixed.
+
+## Layout
+One `__m256d` on AVX, else two 128-bit halves (.xy, .zw). The layout therefore differs between
+AVX and non-AVX translation units, so keep `vec4d` a local compute type - do not put it in a
+struct that crosses TU boundaries or gets serialized.
+
+## API shape
+No lane-wise 3-component forms: add/sub/mul/neg get `.w` for free from the packed op, and
+skipping `.w` in a div/sqrt pays off nowhere we ship (every narrow-divider target has AVX and so
+is single-register; NEON re-widens a scalar lane op and adds moves). 3-component forms exist only
+where the math differs: `vd_hadd3`, `vd_dot3`, `vd_cross3`, `vd_length3`.
+
+`vd_ldu_p3`/`vd_ldu_p3_safe`/`vd_stu_p3` mirror the float `v_*_p3` DPoint3-layout ops, including
+the over-read trade-off and sanitizer routing described in `usage.md`.
+
+## Precision
+Unchanged from scalar `DPoint3`: reductions (`vd_hadd*`, `vd_dot*`) add lanes left to right, the
+same association scalar code has, so results are bit-identical (given `-ffp-contract=off`, as the
+physics libs build). Migrating double math to `vec4d` is a speed change, not a numerical one.
+Keep that lane order when editing these functions - it is the property that makes the migration
+reviewable.
+
+## Speed
+Depends mostly on whether the build has AVX, i.e. whether `vec4d` is one register or two. Against
+scalar `DPoint3` in branchy per-body physics code (walker-style, nothing auto-vectorizable):
+~1.35x on SSE2/SSE4.1, ~1.5x on AVX, ~1.7x on AVX2+FMA. The default PC client is SSE4.1 and so
+gets the smallest win; consoles and dedicated servers are AVX2.
+
+In tight loops over arrays `vec4d` is instead ~2x SLOWER, because the compiler already
+auto-vectorizes the scalar version 4 elements at a time - bulk work wants SoA, not per-vector
+`vec4d`.

--- a/tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp
+++ b/tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp
@@ -12,9 +12,13 @@
 #endif
 
 #include <vecmath/dag_vecMath.h>
+// compile pin: daScriptC.h shares vec4f_scalar_t/vec4i_scalar_t with dag_vecMathDecl.h
+// under VECMATH_SCALAR_TYPES_DEFINED - this TU pins the vecmath-first include order
+#include <daScript/daScriptC.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <cmath>
 
 #if defined(EXPECT_SCALAR) && !defined(_TARGET_SIMD_SCALAR)
 #error this target must select the scalar vecmath backend
@@ -58,6 +62,11 @@ static void check_near(const char *name, vec4f v, float x, float y, float z, flo
       return;
     }
 }
+static void check_double(const char *name, double got, double want)
+{
+  if (got != want) { printf("FAIL %s: got %.17g want %.17g\n", name, got, want); g_failed++; }
+}
+
 static void check_int(const char *name, long long got, long long want)
 {
   if (got != want) { printf("FAIL %s: got %lld want %lld\n", name, got, want); g_failed++; }
@@ -269,6 +278,221 @@ int main()
 
   check_lanes("is_nan", v_is_nan(v_make_vec4f(1.f, nanf_v, 3.f, nanf_v)),
               0u, 0xFFFFFFFFu, 0u, 0xFFFFFFFFu);
+
+  check_lanes("add_pairs", v_add_pairs(a, b), f2u(-0.75f), f2u(3.25f), f2u(2.5f), f2u(3.0f));
+  check_lanes("min_pairs", v_min_pairs(a, b), f2u(-2.25f), f2u(-0.5f), f2u(0.5f), f2u(-1.0f));
+  check_lanes("max_pairs", v_max_pairs(a, b), f2u(1.5f), f2u(3.75f), f2u(2.0f), f2u(4.0f));
+  check_lanesi("addi_pairs", v_addi_pairs(v_make_vec4i(1, 2, 30, 40), v_make_vec4i(500, 600, 7000, 8000)),
+               3u, 70u, 1100u, 15000u);
+  check_lanesi("mini_pairs", v_mini_pairs(ia, ib), 0xFFFFFFF9u, 0x88CA6C00u, 0xFFFFFFFBu, 3u);
+  check_lanesi("maxi_pairs", v_maxi_pairs(ia, ib), 3u, 0x1E240u, 11u, 7u);
+
+  check_lanes("hmin", v_hmin(a), f2u(-2.25f), f2u(-2.25f), f2u(-2.25f), f2u(-2.25f));
+  check_lanes("hmax", v_hmax(a), f2u(3.75f), f2u(3.75f), f2u(3.75f), f2u(3.75f));
+  check_lanes("hmin3", v_hmin3(a), f2u(-2.25f), f2u(-2.25f), f2u(-2.25f), f2u(-2.25f));
+  check_lanes("hmax3", v_hmax3(b), f2u(2.0f), f2u(2.0f), f2u(2.0f), f2u(2.0f));
+  check_lanesi("hmini", v_hmini(ia), 0x88CA6C00u, 0x88CA6C00u, 0x88CA6C00u, 0x88CA6C00u);
+  check_lanesi("hmaxi", v_hmaxi(ia), 0x1E240u, 0x1E240u, 0x1E240u, 0x1E240u);
+  check_lanesi("hmini3", v_hmini3(ia), 0xFFFFFFF9u, 0xFFFFFFF9u, 0xFFFFFFF9u, 0xFFFFFFF9u);
+  check_lanesi("hmaxi3", v_hmaxi3(ia), 0x1E240u, 0x1E240u, 0x1E240u, 0x1E240u);
+
+  check_lanes("round_away", v_round(v_make_vec4f(2.5f, -2.5f, 0.4f, -0.6f)),
+              f2u(3.0f), f2u(-3.0f), f2u(0.0f), f2u(-1.0f));
+  check_lanesi("cvt_roundi_away", v_cvt_roundi(v_make_vec4f(2.5f, -2.5f, 0.4f, -0.6f)),
+               3u, 0xFFFFFFFDu, 0u, 0xFFFFFFFFu);
+
+  {
+    vec4f c3 = v_cross3(v_make_vec4f(1, 2, 3, 0), v_make_vec4f(4, 5, 6, 0));
+    check_int("cross3_x", (long long)f2u(v_extract_x(c3)), (long long)f2u(-3.f));
+    check_int("cross3_y", (long long)f2u(v_extract_y(c3)), (long long)f2u(6.f));
+    check_int("cross3_z", (long long)f2u(v_extract_z(c3)), (long long)f2u(-3.f));
+  }
+
+  check_lanes("abs_diff", v_abs_diff(a, b), f2u(0.5f), f2u(2.75f), f2u(4.75f), f2u(4.5f));
+  check_lanes("cmp_abs_ge", v_cmp_abs_ge(a, b), 0u, 0xFFFFFFFFu, 0xFFFFFFFFu, 0u);
+  check_lanes("cmp_abs_gt", v_cmp_abs_gt(a, b), 0u, 0xFFFFFFFFu, 0xFFFFFFFFu, 0u);
+  check_lanes("cmp_abs_gt_ties", v_cmp_abs_gt(a, v_neg(a)), 0u, 0u, 0u, 0u);
+  check_lanesi("cmp_eqi8", v_cmp_eqi8(v_make_vec4i(0x01020304, 0x05060708, -1, 0),
+                                      v_make_vec4i(0x01FF03FF, 0x05060708, -1, 1)),
+               0xFF00FF00u, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFF00u);
+  check_lanesi("cvtu_trunc", v_cvtu_vec4i(v_make_vec4f(1.9f, 0.f, 2.5f, 100.7f)), 1u, 0u, 2u, 100u);
+
+  {
+    const vec4f zOnlyMask = v_cmp_gt(a, b);
+    check_int("truemask", v_truemask(zOnlyMask), 0b0100);
+    check_int("count_true", v_count_true(zOnlyMask), 1);
+    check_int("count_true4", v_count_true(v_set_all_bits()), 4);
+    check_int("is_any_neg_b", v_is_any_neg_b(zOnlyMask) ? 1 : 0, 1);
+    check_int("is_any_neg_b_false", v_is_any_neg_b(v_zero()) ? 1 : 0, 0);
+    check_int("merge_planes_all", v_is_merge_planes_nout(v_set_all_bits(), v_set_all_bits(), v_set_all_bits(),
+                                                         v_set_all_bits(), v_set_all_bits(), v_set_all_bits()), -1);
+    check_int("merge_planes_one_out", v_is_merge_planes_nout(v_set_all_bits(), v_zero(), v_set_all_bits(),
+                                                             v_set_all_bits(), v_set_all_bits(), v_set_all_bits()), 0);
+  }
+
+  check_lanesi("perm_i8", v_perm_i8(v_make_vec4i(0x03020100, 0x07060504, 0x0B0A0908, 0x0F0E0D0C),
+                                    v_make_vec4i(0x00010203, int(0x80808080), 0x0F0F0F0F, 0x04050607)),
+               0x00010203u, 0u, 0x0F0F0F0Fu, 0x04050607u);
+
+  check_lanes("perm_yxwz", v_perm_yxwz(a), f2u(-2.25f), f2u(1.5f), f2u(-0.5f), f2u(3.75f));
+  check_lanes("perm_yzwa", v_perm_yzwa(a, b), f2u(-2.25f), f2u(3.75f), f2u(-0.5f), f2u(2.0f));
+  check_lanes("perm_wabc", v_perm_wabc(a, b), f2u(-0.5f), f2u(2.0f), f2u(0.5f), f2u(-1.0f));
+  check_lanes("perm_xazc", v_perm_xazc(a, b), f2u(1.5f), f2u(2.0f), f2u(3.75f), f2u(-1.0f));
+  check_lanes("perm_ybwd", v_perm_ybwd(a, b), f2u(-2.25f), f2u(0.5f), f2u(-0.5f), f2u(4.0f));
+  check_lanes("perm_zwab", v_perm_zwab(a, b), f2u(3.75f), f2u(-0.5f), f2u(2.0f), f2u(0.5f));
+  check_lanesi("permi_yzxw", v_permi_yzxw(ia), 0xFFFFFFF9u, 0x1E240u, 3u, 0x88CA6C00u);
+  check_lanesi("permi_zwzw", v_permi_zwzw(ia), 0x1E240u, 0x88CA6C00u, 0x1E240u, 0x88CA6C00u);
+  check_lanesi("permi_xxyy", v_permi_xxyy(ia), 3u, 3u, 0xFFFFFFF9u, 0xFFFFFFF9u);
+  check_lanesi("permi_xxzz", v_permi_xxzz(ia), 3u, 3u, 0x1E240u, 0x1E240u);
+  check_lanesi("permi_xyxy", v_permi_xyxy(ia), 3u, 0xFFFFFFF9u, 3u, 0xFFFFFFF9u);
+  check_lanesi("permi_xzxz", v_permi_xzxz(ia), 3u, 0x1E240u, 3u, 0x1E240u);
+  check_lanesi("permi_ywyw", v_permi_ywyw(ia), 0xFFFFFFF9u, 0x88CA6C00u, 0xFFFFFFF9u, 0x88CA6C00u);
+  check_lanesi("permi_yyww", v_permi_yyww(ia), 0xFFFFFFF9u, 0xFFFFFFF9u, 0x88CA6C00u, 0x88CA6C00u);
+  check_lanesi("permi_yzxy", v_permi_yzxy(ia), 0xFFFFFFF9u, 0x1E240u, 3u, 0xFFFFFFF9u);
+  check_lanesi("permi_zzww", v_permi_zzww(ia), 0x1E240u, 0x1E240u, 0x88CA6C00u, 0x88CA6C00u);
+  check_lanesi("permi_wwyy", v_permi_wwyy(ia), 0x88CA6C00u, 0x88CA6C00u, 0xFFFFFFF9u, 0xFFFFFFF9u);
+
+  {
+    alignas(16) float aos[16];
+    for (int k = 0; k < 16; k++) aos[k] = (float)k;
+    vec4f x, y, z, w;
+    v_ldu_soa2(aos, x, y);
+    check_lanes("ldu_soa2_x", x, f2u(0.f), f2u(2.f), f2u(4.f), f2u(6.f));
+    check_lanes("ldu_soa2_y", y, f2u(1.f), f2u(3.f), f2u(5.f), f2u(7.f));
+    v_ld_soa2(aos, x, y);
+    check_lanes("ld_soa2_x", x, f2u(0.f), f2u(2.f), f2u(4.f), f2u(6.f));
+    check_lanes("ld_soa2_y", y, f2u(1.f), f2u(3.f), f2u(5.f), f2u(7.f));
+    v_ldu_soa3(aos, x, y, z);
+    check_lanes("ldu_soa3_x", x, f2u(0.f), f2u(3.f), f2u(6.f), f2u(9.f));
+    check_lanes("ldu_soa3_y", y, f2u(1.f), f2u(4.f), f2u(7.f), f2u(10.f));
+    check_lanes("ldu_soa3_z", z, f2u(2.f), f2u(5.f), f2u(8.f), f2u(11.f));
+    v_ld_soa3(aos, x, y, z);
+    check_lanes("ld_soa3_x", x, f2u(0.f), f2u(3.f), f2u(6.f), f2u(9.f));
+    check_lanes("ld_soa3_z", z, f2u(2.f), f2u(5.f), f2u(8.f), f2u(11.f));
+    v_ldu_soa4(aos, x, y, z, w);
+    check_lanes("ldu_soa4_w", w, f2u(3.f), f2u(7.f), f2u(11.f), f2u(15.f));
+    v_ld_soa4(aos, x, y, z, w);
+    check_lanes("ld_soa4_x", x, f2u(0.f), f2u(4.f), f2u(8.f), f2u(12.f));
+    check_lanes("ld_soa4_w", w, f2u(3.f), f2u(7.f), f2u(11.f), f2u(15.f));
+    alignas(16) float back[16] = {0};
+    v_ld_soa4(aos, x, y, z, w);
+    v_st_soa2(back, x, y);
+    check_int("st_soa2", (long long)f2u(back[5]), (long long)f2u(9.f));
+    v_stu_soa2(back, x, y);
+    check_int("stu_soa2", (long long)f2u(back[2]), (long long)f2u(4.f));
+    v_st_soa3(back, x, y, z);
+    check_int("st_soa3_y", (long long)f2u(back[4]), (long long)f2u(5.f));
+    check_int("st_soa3_hi", (long long)f2u(back[11]), (long long)f2u(14.f));
+    v_stu_soa3(back, x, y, z);
+    check_int("stu_soa3_rt", (long long)f2u(back[3]), (long long)f2u(4.f));
+    check_int("stu_soa3_rt2", (long long)f2u(back[11]), (long long)f2u(14.f));
+    v_st_soa4(back, x, y, z, w);
+    check_int("st_soa4", (long long)f2u(back[6]), (long long)f2u(6.f));
+    v_stu_soa4(back, x, y, z, w);
+    check_int("stu_soa4", (long long)f2u(back[9]), (long long)f2u(9.f));
+#if !defined(_TARGET_SIMD_NEON) // v_interleave3/4 are not part of the NEON backend (it stores SoA via vst3q/vst4q directly)
+    vec4f e0, e1, e2;
+    v_interleave3(x, y, z, e0, e1, e2);
+    check_lanes("interleave3_e0", e0, f2u(0.f), f2u(1.f), f2u(2.f), f2u(4.f));
+    check_lanes("interleave3_e2", e2, f2u(10.f), f2u(12.f), f2u(13.f), f2u(14.f));
+    vec4f i0, i1, i2, i3;
+    v_interleave4(x, y, z, w, i0, i1, i2, i3);
+    check_lanes("interleave4_e0", i0, f2u(0.f), f2u(1.f), f2u(2.f), f2u(3.f));
+    check_lanes("interleave4_e1", i1, f2u(4.f), f2u(5.f), f2u(6.f), f2u(7.f));
+    check_lanes("interleave4_e3", i3, f2u(12.f), f2u(13.f), f2u(14.f), f2u(15.f));
+#endif
+  }
+
+  {
+    const float m43[12] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    mat43f t43;
+    v_mat43_make_from_43cu_unsafe(t43, m43);
+    check_int("mat43_unsafe_r0x", (long long)f2u(v_extract_x(t43.row0)), (long long)f2u(1.f));
+    check_int("mat43_unsafe_r0z", (long long)f2u(v_extract_z(t43.row0)), (long long)f2u(7.f));
+    check_int("mat43_unsafe_r2y", (long long)f2u(v_extract_y(t43.row2)), (long long)f2u(6.f));
+  }
+
+  // vd_min/vd_max second-operand rule holds on every backend by contract - NaN row unguarded
+  {
+    vec4d da = vd_make_vec4d(1.5, -2.25, 3.75, -0.5);
+    vec4d db = vd_make_vec4d(2.0, 0.5, -1.0, 4.0);
+    check_double("vd_extract_y", vd_extract_y(da), -2.25);
+    check_double("vd_add", vd_extract_z(vd_add(da, db)), 2.75);
+    check_double("vd_sub", vd_extract_z(vd_sub(da, db)), 4.75);
+    check_double("vd_mul", vd_extract_w(vd_mul(da, db)), -2.0);
+    check_double("vd_div", vd_extract_x(vd_div(da, db)), 0.75);
+    check_double("vd_neg", vd_extract_x(vd_neg(da)), -1.5);
+    check_double("vd_zero_x", vd_extract_x(vd_zero()), 0.0);
+    check_double("vd_zero_w", vd_extract_w(vd_zero()), 0.0);
+    check_double("vd_min_nan", vd_extract_x(vd_min(vd_splats((double)nanf_v), vd_splats(1.0))), 1.0);
+    check_int("vd_max_tie", std::signbit(vd_extract_x(vd_max(vd_splats(0.0), vd_splats(-0.0)))) ? 1 : 0, 1);
+    check_double("vd_sqrt", vd_extract_y(vd_sqrt(vd_make_vec4d(4, 9, 16, 25))), 3.0);
+    check_double("vd_sqrt_x", vd_extract_x(vd_sqrt_x(vd_make_vec4d(4, 9, 16, 25))), 2.0);
+    vec4d dcl = vd_clamp(da, vd_zero(), vd_splats(1.0));
+    check_double("vd_clamp_x", vd_extract_x(dcl), 1.0);
+    check_double("vd_clamp_y", vd_extract_y(dcl), 0.0);
+    check_double("vd_clamp_z", vd_extract_z(dcl), 1.0);
+#if !defined(_TARGET_SIMD_NEON) // NEON vd_sqrt_x sqrts the whole low half; SSE/scalar preserve .y
+    check_int("vd_sqrt_x_keeps_y", vd_extract_y(vd_sqrt_x(vd_make_vec4d(4, 9, 16, 25))) == 9.0 ? 1 : 0, 1);
+#endif
+    check_double("vd_hadd4_x", vd_extract_x(vd_hadd4_x(da)), 2.5);
+    check_double("vd_hadd3_x", vd_extract_x(vd_hadd3_x(da)), 3.0);
+    check_double("vd_hadd4_bcast", vd_extract_z(vd_hadd4(da)), 2.5);
+    check_double("vd_hadd3_bcast", vd_extract_y(vd_hadd3(da)), 3.0);
+    check_double("vd_hadd4_assoc", vd_extract_x(vd_hadd4_x(vd_make_vec4d(1e16, 1.0, -1e16, 1.0))), 1.0);
+    check_double("vd_hadd3_assoc", vd_extract_x(vd_hadd3_x(vd_make_vec4d(1.0, 1e16, -1e16, 99.0))), 0.0);
+    check_double("vd_dot3", vd_extract_x(vd_dot3(da, db)), -1.875);
+    check_double("vd_dot3_x", vd_extract_x(vd_dot3_x(da, db)), -1.875);
+    check_double("vd_dot4_x", vd_extract_x(vd_dot4_x(da, db)), -3.875);
+    check_double("vd_dot4_bcast", vd_extract_y(vd_dot4(da, db)), -3.875);
+    vec4d dv = vd_make_vec4d(1.0, 2.0, 2.0, 4.0);
+    check_double("vd_length3_sq", vd_extract_y(vd_length3_sq(dv)), 9.0);
+    check_double("vd_length4_sq", vd_extract_z(vd_length4_sq(dv)), 25.0);
+    check_double("vd_length3", vd_extract_x(vd_length3(dv)), 3.0);
+    check_double("vd_length4", vd_extract_y(vd_length4(dv)), 5.0);
+    check_double("vd_length3_x", vd_extract_x(vd_length3_x(dv)), 3.0);
+    check_double("vd_length4_x", vd_extract_x(vd_length4_x(dv)), 5.0);
+    vec4d dc = vd_cross3(vd_make_vec4d(1, 2, 3, 0), vd_make_vec4d(4, 5, 6, 0));
+    check_double("vd_cross3_x", vd_extract_x(dc), -3.0);
+    check_double("vd_cross3_y", vd_extract_y(dc), 6.0);
+    check_double("vd_cross3_z", vd_extract_z(dc), -3.0);
+    check_double("vd_insert_x", vd_extract_x(vd_insert_x(da, 7.5)), 7.5);
+    check_double("vd_insert_y", vd_extract_y(vd_insert_y(da, 7.5)), 7.5);
+    check_double("vd_insert_z", vd_extract_z(vd_insert_z(da, 7.5)), 7.5);
+    check_double("vd_insert_w_w", vd_extract_w(vd_insert_w(da, 7.5)), 7.5);
+    check_double("vd_insert_w_z", vd_extract_z(vd_insert_w(da, 7.5)), 3.75);
+    alignas(32) double dbuf[4] = {10.5, -11.25, 12.75, -13.5};
+    check_double("vd_ld_z", vd_extract_z(vd_ld(dbuf)), 12.75);
+    vd_st(dbuf, da);
+    check_double("vd_st_lo", dbuf[0], 1.5);
+    check_double("vd_st_hi", dbuf[3], -0.5);
+    double ubuf[5];
+    vd_stu(ubuf + 1, db);
+    check_double("vd_stu_lo", ubuf[1], 2.0);
+    check_double("vd_stu_hi", ubuf[4], 4.0);
+    check_double("vd_ldu_y", vd_extract_y(vd_ldu(ubuf + 1)), 0.5);
+    vec4f df = vd_cvt_to_vec4f(da);
+    check_lanes("vd_to_vec4f", df, f2u(1.5f), f2u(-2.25f), f2u(3.75f), f2u(-0.5f));
+    vec4d d2 = vd_cvt_from_vec4f(a);
+    check_int("vd_from_vec4f", vd_extract_z(d2) == 3.75 ? 1 : 0, 1);
+    vec4d di = vd_cvt_from_vec4i(v_make_vec4i(3, -7, 123456, -2000000000));
+    check_int("vd_from_vec4i", vd_extract_w(di) == -2000000000.0 ? 1 : 0, 1);
+#if !defined(_TARGET_SIMD_NEON) // NEON converts saturate; SSE/scalar yield INT32_MIN out of range
+    check_lanesi("vd_to_vec4i_oor", vd_cvt_to_vec4i(vd_make_vec4d(3e9, -3e9, 1.0, -1.0)),
+                 0x80000000u, 0x80000000u, 1u, 0xFFFFFFFFu);
+#endif
+    check_lanesi("vd_to_vec4i", vd_cvt_to_vec4i(vd_make_vec4d(1.9, -2.9, 100.5, -0.5)),
+                 1u, 0xFFFFFFFEu, 100u, 0u);
+    const double p3d[3] = {9.0, 8.0, 7.0};
+    vec4d dp = vd_ldu_p3_safe(p3d);
+    check_double("vd_ldu_p3_x", vd_extract_x(dp), 9.0);
+    check_double("vd_ldu_p3_z", vd_extract_z(dp), 7.0);
+    check_double("vd_ldu_p3_w", vd_extract_w(dp), 0.0);
+    double outd[4] = {0, 0, 0, -1.0};
+    vd_stu_p3(outd, da);
+    check_double("vd_stu_p3_z", outd[2], 3.75);
+    check_double("vd_stu_p3_sentinel", outd[3], -1.0);
+  }
 
   if (g_failed) { printf("%d vecmath backend checks FAILED\n", g_failed); return 1; }
   printf("all vecmath backend checks passed\n");


### PR DESCRIPTION
This syncs our vendored `include/vecmath/` to upstream DagorEngine HEAD (`prog/1stPartyLibs/vecmath` @ `75723669`) and grows the scalar backend from #3859 to cover upstream's larger primitive contract. It is the prerequisite for upstreaming the scalar backend to DagorEngine: the upstream PR will carry these exact bytes, proven here first.

Upstream added ~55 primitives since our vendored copy: pairwise add/min/max, horizontal min/max families, SoA load/store, `v_round` (half away from zero), `v_perm_i8`, the `permi` family, `v_cross3`, and more. The scalar backend implements all of them per-lane with SSE-flavored semantics. Upstream also moved 24 functions into the generic layer, so the scalar file sheds its copies, and changed `v_cvtu_vec4i` from round to truncate - the scalar port follows (caught by an external review round; daScript itself only uses the already-truncating `_ieee` variant). `dag_vecMath_double.h` is newly vendored and gets a scalar `vec4d` arm. One upstream gap is filled: the SSE2/SSE3 arm lacked `v_round_ieee`.

The shared scalar struct definitions between `dag_vecMathDecl.h` and `daScriptC.h` now use one vecmath-owned guard, `VECMATH_SCALAR_TYPES_DEFINED` (renamed from the #3859 spelling, unreleased), and the battery TU includes `daScriptC.h` so the sharing contract is compile-pinned.

The differential battery grows by ~120 rows: the new surface, plus audit-driven rows closing every twin gap (all 11 `permi` swizzles, aligned and unaligned SoA loads/stores at every width, the full `vd_*` arithmetic/load/store/insert/broadcast set, left-to-right `vd_hadd` association pinned with 1e16 catches, out-of-range converts). Rows where NEON legitimately diverges are guarded; portable rows use all-bits masks. `include/vecmath/CLAUDE.md` is refreshed to match the folder (new files, `vec4d`, vendoring provenance).

Where to look: `dag_vecMath_scalar.h` (the additions), the `vec4d` scalar arm in `dag_vecMath_double.h`, `v_cvtu_vec4i` truncation, the guard in `dag_vecMathDecl.h`/`daScriptC.h`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full AOT sweep (local-only gate): 13020 tests, 13013 passed, 0 failed.
- Scalar-forced full suite (`DAS_VECMATH_SCALAR=ON`, separate worktree): 12928 tests, 12919 passed, 0 failed.
- SSE full suite: 13944 tests, 13935 passed, 0 failed.
- M1 (NEON) proactive run: build 100%, full suite 12929 tests, 12920 passed, 0 failed.
- Battery green on 6 arms at the final tip: x86 SSE2 / scalar / SSE4.1+AVX / scalar+AVX, M1 NEON native / scalar.
- Preflight full: 15 passed, 0 failed; skips covered elsewhere (no `.das` in diff; `cpp-syntax` has no local clang - CI covers; `tests-aot` superseded by the full AOT sweep above).
- External review rounds: two codex rounds; round 1 found the `v_cvtu_vec4i` round-vs-truncate divergence (fixed + battery-pinned), its other two findings verified as upstream-verbatim behavior imported by the sync (empty-bbox transform NaN, SSE2 `v_round` out-of-int-range) and left as-is.

### Claims - stated, not tested
- The vendored headers are byte-identical to the prepared upstream DagorEngine branch (hash-compared; the upstream PR is the proof that counts).
- The scalar-forced and SSE full-suite numbers are from the pre-fix-batch tip; the fix batch changed only the unused-by-daScript `v_cvtu_vec4i`, comments, and test rows, so they were not re-run - the 6-arm battery at the final tip is the settling gate.

### Not done
- The upstream DagorEngine PR itself - follows after this merges, from the same bytes.
- Upstream-verbatim edge cases observed but not diverged from: empty-bbox transform yields NaN boxes (old corner path yielded everything-boxes), SSE2 `v_round` mangles values beyond int32 range, and `sse4_dot3_x` associates `(x+z)+y` while SSE2/NEON/scalar associate `(x+y)+z` (cancellation-sensitive inputs differ per backend). Candidates for upstream issues, not for local patches.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
