### PR TITLE
module-cache: generic instances keep their origin generic across serialization

### DIFF
--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -252,7 +252,7 @@ namespace das {
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
         static constexpr uint32_t getVersion () {
-            return 116;   // 116: inline splices carry the host call-site line (gc locals-walk honesty)
+            return 117;   // 117: Function::fromGeneric round-trips (generic-instance origin)
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;

--- a/src/ast/ast_annotations.cpp
+++ b/src/ast/ast_annotations.cpp
@@ -172,6 +172,17 @@ namespace das
 
     void Program::normalizeOptionTypes () {
         NormalizeOptionTypes::run(this);
+        // the pass rewrote option types in place - Module::generics is keyed by the mangled
+        // name the generic was filed under, so re-file them or every lookup by name misses
+        auto oldGenerics = das::move(thisModule->generics);
+        thisModule->genericsByName.clear();
+        oldGenerics.foreach([&](FunctionPtr fn){
+            if ( !thisModule->addGeneric(fn, true) ) {
+                fn->module = thisModule.get();  // addGeneric leaves it null when the insert fails
+                error("duplicate generic after option-type normalization\n", fn->getMangledName(), "",
+                    fn->at, CompilationError::already_declared_function);
+            }
+        });
     }
 
     void Program::fixupAnnotations() {

--- a/src/ast/ast_gc_collect.cpp
+++ b/src/ast/ast_gc_collect.cpp
@@ -81,6 +81,7 @@ namespace das {
         for ( auto & arg : arguments ) if ( arg ) arg->gc_collect(target, from);
         if ( body ) body->gc_collect(target, from);
         for ( auto & ann : annotations ) if ( ann ) ann->gc_collect(target, from);
+        if ( fromGeneric ) fromGeneric->gc_collect(target, from);
     }
 
     // ---- leaf expressions (no extra fields beyond Expression) ----

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -1898,7 +1898,7 @@ namespace das {
                                 auto it = options.find(argType);
                                 if (it != options.end()) {
                                     auto optionType = argType->argTypes[it->second];
-                                    defaultRef[ai] = optionType->ref;
+                                    defaultRef[ai] = optionType->ref || argType->ref;
                                 }
                             } else {
                                 defaultRef[ai] = argType->ref;

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -303,7 +303,7 @@ namespace das
         if ( autoT->baseType==Type::option ) {
             for ( size_t i=0, is=autoT->argTypes.size(); i!=is; ++i ) {
                 // we copy type qualifiers for each option
-                auto & TT = autoT->argTypes[i];
+                TypeDeclPtr TT = new TypeDecl(*autoT->argTypes[i]);
                 TT->ref = TT->ref || autoT->ref;
                 TT->constant = TT->constant || autoT->constant;
                 TT->temporary = TT->temporary || autoT->temporary;

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -1496,6 +1496,19 @@ namespace das {
 
 // function
 
+    // a function has a restorable identity only while its module still lists it
+    static bool moduleListsFunction ( Function * fn ) {
+        if ( !fn || !fn->module ) return false;
+        auto hName = hash64z(fn->name.c_str());
+        if ( auto it = fn->module->functionsByName.find(hName) ) {
+            for ( auto & f : it->second ) if ( f==fn ) return true;
+        }
+        if ( auto it = fn->module->genericsByName.find(hName) ) {
+            for ( auto & f : it->second ) if ( f==fn ) return true;
+        }
+        return false;
+    }
+
     void Function::serialize ( AstSerializer & ser ) {
         ser.tag(HASH_TAG("Function"));
         ser << name;
@@ -1511,7 +1524,14 @@ namespace das {
         ser << classParentCross;
         if ( classParentCross ) ser.serializePointer(classParent);
         else                    ser << classParent;
-        //ser << fromGeneric;
+        // usually another module's generic, so it binds by name - see Structure::serialize
+        // (parent). an origin its module no longer lists has no identity to write
+        if ( ser.writing ) {
+            Function * origin = moduleListsFunction(fromGeneric) ? fromGeneric : nullptr;
+            ser.serializePointer(origin);
+        } else {
+            ser.serializePointer(fromGeneric);
+        }
         ser << index         << totalStackSize  << totalGenLabel;
         ser << at            << atDecl          << module;
         ser << hash          << aotHash;  // do not serialize inferStack
@@ -2563,7 +2583,19 @@ namespace das {
 
     void Module::serialize ( AstSerializer & ser, bool already_exists ) {
         ser.tag(HASH_TAG("Module"));
+        // builtIn / promoted say whether this module is linked into daScriptEnvironment::modules,
+        // which is a fact about the running process, not about the stream. Restoring them hands
+        // back a module that claims to be a promoted builtin without ever having been linked, and
+        // the next promoteToBuiltin trips its own assert on it
+        const bool selfBuiltIn = builtIn;
+        const bool selfPromoted = promoted;
+        if ( ser.writing ) {
+            builtIn = false;
+            promoted = false;
+        }
         ser << name << nameHash << moduleFlags << inlineTempIndex;
+        builtIn = selfBuiltIn;
+        promoted = selfPromoted;
         ser << annotationData << requireModule;
         // das-declared distinct types round-trip with the module (C++-module annotations
         // re-register on load, parser-created ones don't). they stream BEFORE aliasTypes and
@@ -3229,7 +3261,6 @@ namespace das {
                             throw;
                         }
                         if ( activeWasThisModule ) activeRoot = &throwaway_root;
-                        mod->builtIn = false; // suppress assert
                         mod->promoteToBuiltin(nullptr, promotedRequire);
                     }
                 } else {

--- a/tests/aot/CMakeLists.txt
+++ b/tests/aot/CMakeLists.txt
@@ -388,7 +388,7 @@ set(DAS_AOT_SUITES
     class_boost daslib dasgltf daspeg data_walker debug debug_agent decs dynamic_cast_rtti fio
     fixed_array flatten fs functional gc glsl handle_types hash_map interfaces jit
     jobque json jsonrpc language linq lint long_array_table loops lpipe lsp
-    macro_boost macro_call match math mcp md_boost module_tests option promote quote
+    macro_boost macro_call match math mcp md_boost module_cache module_tests option promote quote
     reader_macro regex rtti safe_addr soa spoof strings stbimage table_packed template
     tests type_lattice type_traits typemacro uri with_boost delegate)
 foreach(_s IN LISTS DAS_AOT_SUITES)

--- a/tests/module_cache/_fixtures/mc_generic_origin_drv.das
+++ b/tests/module_cache/_fixtures/mc_generic_origin_drv.das
@@ -1,0 +1,10 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost
+require mc_generic_origin_mod
+
+[test]
+def test_go(t : T?) {
+    t |> equal(go(1, 2.0f), 2, "two words")
+}

--- a/tests/module_cache/_fixtures/mc_generic_origin_mod.das
+++ b/tests/module_cache/_fixtures/mc_generic_origin_mod.das
@@ -1,0 +1,27 @@
+options gen2
+options indenting = 4
+
+module mc_generic_origin_mod
+
+// Both put() overloads instance the same builtin `push` generic, so the second call site
+// resolves through the locked generic-instance name __::builtin`push`<hash>. Recovering
+// that call needs every candidate in the library to carry its origin generic, which is
+// what a module restored from -module-cache used to lose.
+def word(v : float) : uint {
+    return unsafe(reinterpret<uint>(v))
+}
+
+def put(var words : array<uint>; v : float) {
+    words |> push(word(v))
+}
+
+def put(var words : array<uint>; v : int) {
+    words |> push(unsafe(reinterpret<uint>(v)))
+}
+
+def public go(a : int; b : float) : int {
+    var words : array<uint>
+    put(words, a)
+    put(words, b)
+    return length(words)
+}

--- a/tests/module_cache/test_generic_instance_origin.das
+++ b/tests/module_cache/test_generic_instance_origin.das
@@ -1,0 +1,72 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+
+require strings
+require daslib/fio
+
+// argv[0] is the running interpreter; dastest is invoked as
+// `daslang(.exe) dastest/dastest.das ...`, so argv[0] is the daslang binary to spawn.
+def das_exe() : string {
+    let args <- get_command_line_arguments()
+    return empty(args) ? "" : args[0]
+}
+
+
+def run_argv(args : array<string>; var output : string&) : int {
+    return unsafe(popen_argv(args, 300.0, $(f) {
+        if (f != null) {
+            output = fread(f)
+        }
+    }))
+}
+
+
+// A child that dies takes its diagnosis with it unless the parent prints what it said - the
+// exit code alone turns a one-line answer into an exit-code hunt. Echo the child's output on
+// any failure, and only then.
+def report_child(t : T?; phase : string; rc : int; out : string; marker : string) : bool {
+    let ok = rc == 0 && find(out, marker) >= 0
+    if (!ok) {
+        t |> failure("{phase} child: rc={rc}, marker '{marker}' {find(out, marker) >= 0 ? "found" : "MISSING"}")
+        t |> failure("{phase} child output follows:\n{out}")
+    }
+    return ok
+}
+
+
+// A generic instance restored from the module cache must keep its origin generic
+// (Function::fromGeneric). The child host restores its own module graph from the cache and
+// then compiles a fresh program in the same process - a null origin on any restored
+// instance disables generic-instance call recovery library-wide, and the fixture stops
+// compiling on the warm run with error[30341] while the cold run is fine.
+[test]
+def test_generic_instance_origin(t : T?) {
+    var terr : string
+    let tmp = create_temp_directory("das_mc_origin", terr)
+    if (empty(tmp)) {
+        t |> failure("create_temp_directory: {terr}")
+        return
+    }
+    let root = get_das_root()
+    let argv <- [das_exe(), "-dasroot", root, "-module-cache", "{tmp}/mc.bin",
+        "{root}/dastest/dastest.das", "--", "--test",
+        "{root}/tests/module_cache/_fixtures/mc_generic_origin_drv.das"]
+    var cold : string
+    let coldRc = run_argv(argv, cold)
+    let coldOk = report_child(t, "cold", coldRc, cold, "ser: wrote")
+    t |> success(coldOk, "cold run wrote the cache and passed")
+    var warm : string
+    let warmRc = run_argv(argv, warm)
+    // the verdict guards the vacuous pass: a cache that silently fell back to parsing would
+    // pass this test without ever restoring a module
+    var warmOk = report_child(t, "warm", warmRc, warm, "deser: clean")
+    if (find(warm, "30341") >= 0) {
+        t |> failure("warm run lost generic-instance recovery (error[30341])")
+        warmOk = false
+    }
+    t |> success(warmOk, "warm run served every module from the cache and passed")
+    var err : string
+    rmdir_rec(tmp, err)
+}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -166,6 +166,7 @@ SET(DAS_UTILS_TO_TEST
     find-dupe/tests
     gen1-to-gen2/tests
     internal/hygiene
+    internal/preflight/tests
     internal/ast-fuzz
     internal/requirefix
     internal/test-release

--- a/utils/internal/preflight/compile_db.das
+++ b/utils/internal/preflight/compile_db.das
@@ -1,0 +1,122 @@
+options gen2
+options indenting = 4
+
+// compile_commands.json reader for preflight's cpp-syntax gate. Lives beside main.das as a
+// module so the tokenizer can be tested directly - its failure mode (a mangled path) is
+// silent, and it only bites on a platform the author may not be running.
+
+module compile_db shared
+
+require daslib/fio
+require strings
+
+
+struct CcEntry {
+    directory : string
+    command : string
+    file : string
+}
+
+
+// compile_commands.json writes each command shell-quoted: a define can carry escaped quotes
+// (-DX=\"y\") and a path can carry spaces, so splitting on whitespace mangles both.
+def public cc_tokenize(cmd : string) : array<string> {
+    var out : array<string>
+    peek_data(cmd) $(data) {
+        let n = length(data)
+        var cur : array<uint8>
+        var in_quote = false
+        var started = false
+        var i = 0
+        while (i < n) {
+            let c = int(data[i])
+            // a backslash escapes ONLY a quote or another backslash. Everywhere else it is a
+            // literal - on Windows every path in the database is full of them, and consuming
+            // them as escapes turns C:\src\x.cpp into C:srcx.cpp. A token with spaces arrives
+            // quoted, so nothing else needs escaping here
+            if (c == '\\' && i + 1 < n && (int(data[i + 1]) == '"' || int(data[i + 1]) == '\\')) {
+                cur |> push(data[i + 1])
+                started = true
+                i += 2
+            } elif (c == '"') {
+                in_quote = !in_quote
+                started = true
+                i++
+            } elif (!in_quote && (c == ' ' || c == '\t')) {
+                if (started) {
+                    out |> push(string(cur))
+                    cur |> clear()
+                    started = false
+                }
+                i++
+            } else {
+                cur |> push(data[i])
+                started = true
+                i++
+            }
+        }
+        if (started) {
+            out |> push(string(cur))
+        }
+    }
+    return <- out
+}
+
+
+// "compile this one file to that one object" - the switches a syntax-only sweep over MANY
+// files must not inherit. Both spellings: clang-cl writes the output path JOINED (/Fo<obj>,
+// /Fd<pdb>, /Fp<pch>), and a joined switch reaching a multi-file argv makes clang-cl reject
+// the whole sweep for naming one output for many inputs - which reads like a source error.
+def public cc_is_compile_switch(a : string) : bool {
+    if (a == "-c" || a == "/c" || a == "-MD" || a == "-MMD"
+        || a == "/showIncludes" || a == "-showIncludes") {
+        return true
+    }
+    for (p in ["/Fo", "-Fo", "/Fd", "-Fd", "/Fp", "-Fp"]) {
+        return true if (a |> starts_with(p))
+    }
+    return false
+}
+
+
+// The exact flags CMake compiles each TU with, keyed by absolute source path. The gate's own
+// include list is a hand-rolled approximation: it models neither build-generated headers
+// (tests-cpp/big/standalone_ctx/_generated) nor per-module include dirs, and false-fails any
+// TU that needs one. This reflects the LOCAL configure's module ON/OFF set rather than CI's
+// all-modules-on lane - still strictly closer than the approximation, which models no module
+// include dirs at all. Empty table = fall back to the hand list.
+def public load_compile_commands(build_dir : string; want_cl : bool) : table<string; array<string>> {
+    var out : table<string; array<string>>
+    return <- out if (empty(build_dir))
+    let raw = fread(path_join(build_dir, "compile_commands.json"))
+    return <- out if (empty(raw))
+    var db : array<CcEntry>
+    return <- out if (!sscan_json(raw, db))
+    for (e in db) {
+        let argv <- cc_tokenize(e.command)
+        continue if (length(argv) < 2)
+        // the format allows `file` relative to `directory`; the caller looks up by absolute
+        // path, and a miss falls back silently
+        let file_abs = is_absolute(e.file) ? e.file : path_join(e.directory, e.file)
+        // the entry's compiler flavor has to match the binary the gate runs, or its flag
+        // spelling is wrong for it
+        let entry_is_cl = argv[0] |> ends_with("cl") || argv[0] |> ends_with("cl.exe")
+        continue if (entry_is_cl != want_cl)
+        var flags : array<string>
+        flags |> reserve(length(argv))
+        var i = 1
+        while (i < length(argv)) {
+            let a = argv[i]
+            if (a == "-o" || a == "-MT" || a == "-MF") {
+                i += 2
+            } elif (a == e.file || a == file_abs || cc_is_compile_switch(a)) {
+                i++
+            } else {
+                flags |> push(a)
+                i++
+            }
+        }
+        out[file_abs] <- flags
+    }
+    return <- out
+}

--- a/utils/internal/preflight/main.das
+++ b/utils/internal/preflight/main.das
@@ -28,6 +28,7 @@ require ../../common/parallel_workers.das
 require ../../common/git_signature.das
 require ../../../dastest/worker_policy.das
 require config
+require compile_db
 
 
 [CommandLineArgs]
@@ -707,7 +708,79 @@ def gate_ast_verify(ctx : PreflightCtx) : GateResult {
         output = output)
 }
 
-def gate_cpp_syntax(ctx : PreflightCtx) : GateResult { // nolint:STYLE038
+// One clang argv per group of TUs that share a flag set. Flags come from compile_commands
+// when the build tree has an entry for the TU, else from the hand-rolled include list.
+def private build_sweep_argvs(ctx : PreflightCtx; in_scope : array<string>) : tuple<argvs : array<array<string>>; from_db : int> {
+    // parse + analyze only, warnings off: this gate reports errors, and a -Werror carried in
+    // from the real compile line must not promote a warning into one
+    var syntax_flags : array<string>
+    if (ctx.clang_is_cl) {
+        syntax_flags <- ["/Zs", "/W0"]                  // nolint:PERF030 — fresh empty target, branch-initialized
+    } else {
+        syntax_flags <- ["-fsyntax-only", "-w"]         // nolint:PERF030 — fresh empty target, branch-initialized
+    }
+    var fallback_flags : array<string>
+    if (ctx.clang_is_cl) {
+        fallback_flags <- ["/EHsc", "/std:c++17"]       // nolint:PERF030 — fresh empty target, branch-initialized
+    } else {
+        fallback_flags <- ["-std=c++17"]                // nolint:PERF030 — fresh empty target, branch-initialized
+    }
+    var includes <- ["include", "3rdparty/fmt/include", "3rdparty/uriparser/include", "tests-cpp/3rdparty"]
+    if (!empty(ctx.build_dir)) {
+        // configure-time generated headers (modules/external_*.inc) — without
+        // this root, TUs like src/simulate/fs_file_info.cpp false-fail
+        includes |> push(path_join(ctx.build_dir, "include"))
+    }
+    fallback_flags |> reserve(length(fallback_flags) + length(includes))
+    for (inc in includes) {
+        fallback_flags |> push("-I{inc}")
+    }
+    var cc <- load_compile_commands(ctx.build_dir, ctx.clang_is_cl)
+    let cwd = getcwd()
+    // run_chunk_workers spawns one thread per argv, so per-TU flags must not become per-TU
+    // argvs: group the sweep by identical flag set first (the whole tree collapses to a
+    // handful of sets), then chunk inside each group
+    var groups : table<string; array<string>>
+    var group_flags : table<string; array<string>>
+    var from_db = 0
+    for (f in in_scope) {
+        let abs = path_join(cwd, f)
+        var flags : array<string>
+        if (cc |> key_exists(abs)) {
+            flags := cc[abs]
+            from_db++
+        } else {
+            flags := fallback_flags
+        }
+        let key = join(flags, "\n")
+        if (!(group_flags |> key_exists(key))) {
+            var gf : array<string>
+            gf := flags
+            group_flags[key] <- gf
+            groups[key] |> reserve(length(in_scope))
+        }
+        groups[key] |> push(f)
+    }
+    let workers = compute_worker_count(length(in_scope), ctx.jobs)
+    let total = length(in_scope)
+    var argvs : array<array<string>>
+    argvs |> reserve(workers + length(group_flags))
+    for (key, files in keys(groups), values(groups)) {
+        let share = max(1, (workers * length(files) + total - 1) / total)
+        let chunks <- chunk_files(files, share)
+        for (chunk in chunks) {
+            var av : array<string>
+            av |> reserve(1 + length(group_flags[key]) + length(syntax_flags) + length(chunk))
+            av |> push(ctx.clang)
+            av |> push_from(group_flags[key], syntax_flags, chunk)
+            argvs |> emplace(av)
+        }
+    }
+    return <- (argvs <- argvs, from_db = from_db)
+}
+
+
+def gate_cpp_syntax(ctx : PreflightCtx) : GateResult {
     let t0 = ref_time_ticks()
     if (empty(ctx.changed_cpp) && ctx.changed_hdr == 0) {
         return GateResult(name = "cpp-syntax", status = GateStatus.Skip, seconds = seconds_since(t0),
@@ -753,34 +826,9 @@ def gate_cpp_syntax(ctx : PreflightCtx) : GateResult { // nolint:STYLE038
         return GateResult(name = "cpp-syntax", status = GateStatus.Skip, seconds = seconds_since(t0),
             detail = "changed C++ is outside src/include/tests-cpp ({join(skipped, ", ")}) — needs module/external deps; no local clang gate compiles it, CI's clang-cl lane does")
     }
-    var flags : array<string>
-    if (ctx.clang_is_cl) {
-        flags <- ["/Zs", "/EHsc", "/std:c++17", "/W0"]   // nolint:PERF030 — fresh empty target, branch-initialized
-    } else {
-        flags <- ["-fsyntax-only", "-std=c++17", "-w"]   // nolint:PERF030 — fresh empty target, branch-initialized
-    }
-    var includes <- ["include", "3rdparty/fmt/include", "3rdparty/uriparser/include", "tests-cpp/3rdparty"]
-    if (!empty(ctx.build_dir)) {
-        // configure-time generated headers (modules/external_*.inc) — without
-        // this root, TUs like src/simulate/fs_file_info.cpp false-fail
-        includes |> push(path_join(ctx.build_dir, "include"))
-    }
-    let workers = compute_worker_count(length(in_scope), ctx.jobs)
-    let chunks <- chunk_files(in_scope, workers)
-    var argvs : array<array<string>>
-    argvs |> reserve(length(chunks))
-    for (chunk in chunks) {
-        var av : array<string>
-        av |> reserve(1 + length(flags) + length(includes) + length(chunk))
-        av |> push(ctx.clang)
-        av |> push_from(flags)
-        for (inc in includes) {
-            av |> push("-I{inc}")
-        }
-        av |> push_from(chunk)
-        argvs |> emplace(av)
-    }
-    var results <- run_chunk_workers(argvs)
+    let sweep <- build_sweep_argvs(ctx, in_scope)
+    let from_db = sweep.from_db
+    var results <- run_chunk_workers(sweep.argvs)
     var failed = false
     for (r in results) {
         if (r.exit_code != 0) {
@@ -796,6 +844,7 @@ def gate_cpp_syntax(ctx : PreflightCtx) : GateResult { // nolint:STYLE038
         }
     }
     var detail = "{sweep_note}{length(in_scope)} file(s) via {ctx.clang}"
+    detail = "{detail}; {from_db} from compile_commands, {length(in_scope) - from_db} via the fallback include list"
     if (!empty(skipped)) {
         detail = "{detail}; out of scope: {join(skipped, ", ")}"
     }

--- a/utils/internal/preflight/tests/test_compile_db.das
+++ b/utils/internal/preflight/tests/test_compile_db.das
@@ -1,0 +1,78 @@
+options gen2
+options indenting = 4
+
+require dastest/testing_boost public
+
+require ../compile_db.das
+
+
+// The tokenizer's failure mode is silent: a mangled path yields a token that simply does not
+// name the file it should, and the gate then reports an error against the wrong input - or a
+// spurious one. Windows is the case the author is least likely to be running, so it is pinned
+// here rather than left to a red CI lane.
+[test]
+def test_cc_tokenize_windows_paths(t : T?) {
+    t |> run("a backslash path survives intact") @(t : T?) {
+        let tok <- cc_tokenize("clang-cl -IC:\\src\\daScript\\include C:\\src\\x.cpp")
+        t |> equal(length(tok), 3)
+        t |> equal(tok[0], "clang-cl")
+        t |> equal(tok[1], "-IC:\\src\\daScript\\include")
+        t |> equal(tok[2], "C:\\src\\x.cpp")
+    }
+    t |> run("a trailing backslash is kept") @(t : T?) {
+        let tok <- cc_tokenize("cl -IC:\\src\\")
+        t |> equal(length(tok), 2)
+        t |> equal(tok[1], "-IC:\\src\\")
+    }
+}
+
+
+// A per-file output switch that survives into the grouped argv makes clang-cl reject the
+// sweep for naming one output for many inputs, and the gate reports that as if the source
+// were broken. The joined MSVC spellings are the ones a POSIX-only author misses.
+[test]
+def test_cc_is_compile_switch(t : T?) {
+    t |> run("msvc spellings are stripped") @(t : T?) {
+        t |> success(cc_is_compile_switch("/c"), "/c")
+        t |> success(cc_is_compile_switch("/FoC:\\build\\x.obj"), "joined /Fo")
+        t |> success(cc_is_compile_switch("-FoC:\\build\\x.obj"), "joined -Fo")
+        t |> success(cc_is_compile_switch("/Fdvc140.pdb"), "joined /Fd")
+        t |> success(cc_is_compile_switch("/showIncludes"), "/showIncludes")
+    }
+    t |> run("gnu spellings are stripped") @(t : T?) {
+        t |> success(cc_is_compile_switch("-c"), "-c")
+        t |> success(cc_is_compile_switch("-MD"), "-MD")
+    }
+    t |> run("real flags are kept") @(t : T?) {
+        t |> success(!cc_is_compile_switch("/I../include"), "include dir")
+        t |> success(!cc_is_compile_switch("-DFOO=1"), "define")
+        t |> success(!cc_is_compile_switch("/std:c++17"), "std")
+        t |> success(!cc_is_compile_switch("-fno-rtti"), "codegen flag")
+    }
+}
+
+
+[test]
+def test_cc_tokenize_quoting(t : T?) {
+    t |> run("an escaped quote in a define becomes a literal quote") @(t : T?) {
+        let tok <- cc_tokenize("clang++ -DDAS_INSTALL_BINDIR=\\\"/usr/local/bin\\\" -c a.cpp")
+        t |> equal(length(tok), 4)
+        t |> equal(tok[1], "-DDAS_INSTALL_BINDIR=\"/usr/local/bin\"")
+    }
+    t |> run("a quoted token keeps its spaces") @(t : T?) {
+        let tok <- cc_tokenize("clang++ \"-IC:/Program Files/x\" a.cpp")
+        t |> equal(length(tok), 3)
+        t |> equal(tok[1], "-IC:/Program Files/x")
+    }
+    t |> run("an escaped backslash collapses to one") @(t : T?) {
+        let tok <- cc_tokenize("clang++ -DX=\\\\ a.cpp")
+        t |> equal(length(tok), 3)
+        t |> equal(tok[1], "-DX=\\")
+    }
+    t |> run("runs of whitespace do not mint empty tokens") @(t : T?) {
+        let tok <- cc_tokenize("  clang++   -c    a.cpp  ")
+        t |> equal(length(tok), 3)
+        t |> equal(tok[0], "clang++")
+        t |> equal(tok[2], "a.cpp")
+    }
+}


### PR DESCRIPTION
**Module-cache format change: the stream version goes 116 to 117, so existing `-module-cache` and `-deser` files are stale and rewrite themselves on the next run.**

A function restored from a module cache came back with no origin generic, because `Function::fromGeneric` was commented out of `Function::serialize`. Type inference recovers a call locked to a generic-instance family by renaming it to the origin generic, and that recovery needs every candidate to have an origin. One restored instance anywhere in the module set disabled it for the whole library, so a call that compiled from cold failed on a warm run with `error[30341]`. Reported in #3863 with a repro; that repro is now a regression test.

Four separate defects had to be fixed together before the field could round-trip. The serializer now writes the origin. `Function::gc_collect` now walks it - it did not, so the per-pass infer collect could sweep an origin that nothing else referenced and leave the instance pointing at freed memory, which is why serializing the field crashed on the write run rather than the read. And `Program::normalizeOptionTypes` now re-files the module's generics: it rewrites option types in place, after the parser has filed each generic under its mangled name, so every generic with an option argument answered to a key that no longer matched itself and could not be found by name. That last one is not new - it has been true on every compile since that pass existed, and it is what degraded the cache to a partial read once the origin started being written.

The fourth surfaced only once this branch had a test for a warm cache run. `Module::serialize` round-tripped `builtIn` and `promoted` through `moduleFlags`. Those two say whether a module is linked into the running process's module list, which is not a fact the stream can carry: a restored module came back claiming to be a promoted builtin it had never been linked as, and the next promotion hit its own assert. Every Debug build aborted on any warm `-module-cache` run, on master as much as here. Nothing covered it because nothing else in the suite runs a warm cache. A workaround that existed only for this - clearing the flag right before promoting - is gone with it.

The second commit is independent and only shares this branch because it unblocks the first. Preflight's `cpp-syntax` gate compiled every translation unit with one hand-written include list, which is an approximation of what CMake passes. Any file needing an include directory outside that list failed for a reason that had nothing to do with its source - concretely a header the standalone AOT emitter generates into the build tree, which made the gate red for any change touching a core header. It now reads the exact per-file flags from `compile_commands.json`, and keeps the old list as a fallback.

Where to look: `Function::serialize` in `module_builtin_ast_serialize.cpp` for the write-side null rule, `normalizeOptionTypes` in `ast_annotations.cpp` for the re-file, and `compile_db.das` for the compile-database reader.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full local AOT sweep (`test_aot` over `tests`) green - per-PR CI only builds `test_aot_subset`, so this is the only pre-merge check for the new `module_cache` suite registration.
- The regression test is negative-controlled four ways: separate mutations of the write rule, the not-listed rule, the re-file, and the module-flags fix each turn it red. It is also the first test in the suite to run a warm module cache, which is how the Debug abort surfaced at all.
- `preflight --full` (21 gates) was green at `771bbb205`. Later commits add comment removals, the clang-cl switch filter, the module-flags fix and the test's child-output reporting; each was validated with the targeted gates - `cpp-syntax`, the module-cache test on both Debug and Release, `tests/language`, `tests/daslib`, the preflight tests and the lint gate - rather than a second full run.
- The Debug lane is the one that catches the module-flags defect; Release has no assert there. Both were run locally for the module-cache suite.
- The clang-cl arms of the `cpp-syntax` gate cannot run here. They are exercised only by CI's Windows lane.

### Claims - stated, not tested
- `defaultRef[ai] = optionType->ref || argType->ref` in `ast_infer_type_function.cpp` folds the outer option's ref back in, now that the matcher works on a copy instead of mutating the declaration. The condition it changes fires zero times across `tests/language`, `tests/option`, `tests/linq`, `tests/daslib` and `tests/module_cache`, and the one input found that reaches the line behaves the same either way. Verified by reading both readers of the options map instead: the other one derives alias bindings and is insensitive to these flags. A break would show up as a generic instance whose argument is by-value where it should be by-reference.
- `Function::gc_collect` walking the origin is proven necessary only under `DAS_GC_DEBUG`, where removing it segfaults the cold run on poisoned memory. No build CI runs would catch a regression of it.
- The duplicate-generic error path in `normalizeOptionTypes` has no test. Two constructed collisions both kept distinct keys, so no input is known that reaches it.

### Not done
- The origin of a `[template]` clone can outlive its module listing, and such an origin is written as null rather than repointed. Fixing that at the source means having unused-symbol removal clear or repoint `fromGeneric`, which changes `getOrigin` results late in compilation; ledgered rather than attempted here.
- The option-qualifier push now exists in two places: the normalization pass and the matcher's copy. The second is redundant for anything that went through the pass and survives only for option types built by macros afterwards.
- A `DAS_GC_DEBUG` lane over the new suite would defend the collect fix. An older CI job may already cover this; to be checked separately.
- `module_jit.cpp` binds are not covered by the bind-flavor scan, and `utils/REVIEW.md`'s test rules trigger on file location while the checklist's own routing says otherwise. Both are queued for a follow-up.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
