### PR TITLE
WIP: ast-verify batch walks each module once, and the swizzle type gets a location

### DIFF
--- a/.github/workflows/fatman.yml
+++ b/.github/workflows/fatman.yml
@@ -51,7 +51,9 @@ jobs:
           set -eux
           # dasImgui and dasVulkan are in-tree — only the imgui dependents are external
           git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiImplot.git    modules/dasImguiImplot
-          git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiNodeEditor.git modules/dasImguiNodeEditor
+          # TEMPORARY, revert before merge: the fork branch of borisbat/dasImguiNodeEditor#44,
+          # which stops the glue calling the TypeDecl(Type) constructor this PR removes
+          git clone --depth 1 --recurse-submodules -b aleksisch/typedecl-binding-location https://github.com/aleksisch/dasImguiNodeEditor.git modules/dasImguiNodeEditor
 
       - name: "Configure (externals absorbed by the modules glob)"
         run: |

--- a/.github/workflows/wasmboy.yml
+++ b/.github/workflows/wasmboy.yml
@@ -48,7 +48,9 @@ jobs:
           set -eux
           # dasImgui is in-tree (modules/dasImgui) — only its dependents are external
           git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiImplot.git    modules/dasImguiImplot
-          git clone --depth 1 --recurse-submodules https://github.com/borisbat/dasImguiNodeEditor.git modules/dasImguiNodeEditor
+          # TEMPORARY, revert before merge: the fork branch of borisbat/dasImguiNodeEditor#44,
+          # which stops the glue calling the TypeDecl(Type) constructor this PR removes
+          git clone --depth 1 --recurse-submodules -b aleksisch/typedecl-binding-location https://github.com/aleksisch/dasImguiNodeEditor.git modules/dasImguiNodeEditor
 
       - name: "Configure + build the threaded playground interpreter (daslang_static; the same config pages.yml deploys)"
         run: |

--- a/daslib/ast_verify.das
+++ b/daslib/ast_verify.das
@@ -20,8 +20,9 @@ module ast_verify shared private
 //! pass right after it happens, and each post-infer firing sweeps every module.
 //! ``--ast-verify-batch`` is the CI gate: no pre-infer checks (a tree a macro breaks
 //! mid-inference crashes the compiler instead of being repaired - the gates count that as red),
-//! and each post-infer firing checks only the module being compiled: the tree handed to
-//! lint/fold/codegen is valid, at a fraction of the cost. Under the CLI force-include every
+//! and the module being compiled is walked once, on the firing right before the finished tree's
+//! first consumer - the ~10 post-infer firings per module all walk one tree, and paying for one of
+//! them is what makes the gate cheap enough for many files. Under the CLI force-include every
 //! non-builtin module compiles after the verifier registered, so each is still checked once as
 //! the module being compiled (the verifier's own requires are promoted builtin - neither mode
 //! walks those); a module read from a module cache, or required before a source
@@ -1369,9 +1370,9 @@ def public verify_module_after_infer(prog : ProgramPtr; mod : Module?) : int {
 
 [post_infer_macro]
 class AstPostInferVerifyMacro : AstPassMacro {
-    //! Fires before every consumer of the finished tree (after each inference run, lint, every
-    //! optimizer round). Plain mode also sweeps every OTHER non-builtin module (a source ``require``
-    //! parses the ones before it unverified); under the CLI force-include each was verified as thisMod.
+    //! Fires once per inference leg, before the first pass that reads the finished tree. Plain
+    //! mode also sweeps every OTHER non-builtin module; batch mode checks only the module being
+    //! compiled. The tree every later pass leaves behind belongs to [[AstSimulateVerifyMacro]].
     def override apply(prog : ProgramPtr; mod : Module?) : bool {
         if (mod == null || mod.moduleFlags.builtIn) {
             return true
@@ -1514,6 +1515,29 @@ class AstGcRootVerifyMacro : AstPassMacro {
         if (mod != null && (prog._options |> find_arg("_ast_verify_gc_root") ?as tBool ?? false)) {
             verify_module_gc_root(prog, mod)
         }
+        return true
+    }
+}
+
+
+[simulate_macro]
+class AstSimulateVerifyMacro : AstSimulateMacro {
+    //! The last look at the tree: simulate runs after lint, folding, every optimizer round and
+    //! every codegen-prep pass, so whatever they and the user's own macros left behind is checked
+    //! here. Not reached under -compile-only, which never simulates.
+    def override preSimulate(_prog : Program?; _ctx : Context?) : bool {
+        let mod = compiling_module()
+        if (mod != null && !mod.moduleFlags.builtIn) {
+            if (batch_mode()) {
+                verify_module_after_infer(compiling_program(), mod)
+            } else {
+                verify_program_after_infer(compiling_program(), mod)
+            }
+        }
+        return true
+    }
+
+    def override simulate(_prog : Program?; _ctx : Context?) : bool {
         return true
     }
 }

--- a/doc/source/reference/language/macros.rst
+++ b/doc/source/reference/language/macros.rst
@@ -834,8 +834,9 @@ node. Reach for it first, not last::
 That form re-checks before every inference pass, so a break is caught on the
 pass right after it happens, and after inference it sweeps every module on each
 firing. ``--ast-verify-batch`` is the CI gate form for many files: no pre-infer
-checks, and after inference only the module being compiled is checked - the
-tree handed to lint, folding and codegen is valid, at a fraction of the cost.
+checks, and the module being compiled is walked once, right after inference -
+so the tree handed to lint, folding and codegen is valid, at a fraction of the
+cost.
 
 Without it, a macro that leaves a variable untyped crashes:
 

--- a/include/daScript/ast/ast_handle.h
+++ b/include/daScript/ast/ast_handle.h
@@ -892,7 +892,7 @@ namespace das
     void addConstant ( Module & mod, const string & name, const TT & value ) {
         VariablePtr pVar = new Variable();
         pVar->name = name;
-        pVar->type = new TypeDecl((Type)ToBasicType<TT>::type);
+        pVar->type = new TypeDecl((Type)ToBasicType<TT>::type, cppBindingLineInfo());
         pVar->type->constant = true;
         pVar->init = Program::makeConst(LineInfo(),pVar->type,cast<TT>::from(value));
         pVar->init->type = new TypeDecl(*pVar->type);
@@ -905,7 +905,7 @@ namespace das
     __forceinline void addConstant ( Module & mod, const string & name, const string & value ) {
         VariablePtr pVar = new Variable();
         pVar->name = name;
-        pVar->type = new TypeDecl(Type::tString);
+        pVar->type = new TypeDecl(Type::tString, cppBindingLineInfo());
         pVar->type->constant = true;
         pVar->init = new ExprConstString(LineInfo(),value);
         pVar->init->type = new TypeDecl(*pVar->type);

--- a/include/daScript/ast/ast_typedecl.h
+++ b/include/daScript/ast/ast_typedecl.h
@@ -56,9 +56,11 @@ namespace das {
         TypeDecl() { gc_magic = GC_MAGIC_TYPEDECL; }
         TypeDecl(const TypeDecl & decl);
         TypeDecl & operator = (const TypeDecl & decl) = delete;
-        TypeDecl(Type tt) : baseType(tt) { gc_magic = GC_MAGIC_TYPEDECL; }
+        TypeDecl(Type tt, const LineInfo & att) : baseType(tt), at(att) { gc_magic = GC_MAGIC_TYPEDECL; }
         TypeDecl(Structure * sp) : baseType(Type::tStructure), structType(sp) { gc_magic = GC_MAGIC_TYPEDECL; }
+        TypeDecl(Structure * sp, const LineInfo & att) : baseType(Type::tStructure), structType(sp), at(att) { gc_magic = GC_MAGIC_TYPEDECL; }
         TypeDecl(Enumeration * ep);
+        TypeDecl(Enumeration * ep, const LineInfo & att);
         TypeDeclPtr visit ( Visitor & vis );
         friend StringWriter& operator<< (StringWriter& stream, const TypeDecl & decl);
         string getMangledName ( bool fullName=false ) const;
@@ -437,8 +439,7 @@ namespace das {
     template <>
     struct typeFactory<EnumStub8> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tEnumeration8);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tEnumeration8, cppBindingLineInfo());
             t->enumStubBinding = true;
             return t;
         }
@@ -447,8 +448,7 @@ namespace das {
     template <>
     struct typeFactory<EnumStub16> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tEnumeration16);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tEnumeration16, cppBindingLineInfo());
             t->enumStubBinding = true;
             return t;
         }
@@ -457,8 +457,7 @@ namespace das {
     template <>
     struct typeFactory<EnumStub64> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tEnumeration64);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tEnumeration64, cppBindingLineInfo());
             t->enumStubBinding = true;
             return t;
         }
@@ -467,8 +466,7 @@ namespace das {
     template <>
     struct typeFactory<EnumStub8u> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tEnumeration8);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tEnumeration8, cppBindingLineInfo());
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
             return t;
@@ -478,8 +476,7 @@ namespace das {
     template <>
     struct typeFactory<EnumStub16u> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tEnumeration16);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tEnumeration16, cppBindingLineInfo());
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
             return t;
@@ -489,8 +486,7 @@ namespace das {
     template <>
     struct typeFactory<EnumStub64u> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tEnumeration64);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tEnumeration64, cppBindingLineInfo());
             t->enumStubBinding = true;
             t->enumStubIsUnsigned = true;
             return t;
@@ -500,8 +496,7 @@ namespace das {
     template <>
     struct typeFactory<char *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tString);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tString, cppBindingLineInfo());
             return t;
         }
     };
@@ -509,8 +504,7 @@ namespace das {
     template <>
     struct typeFactory<const char *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tString);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tString, cppBindingLineInfo());
             t->constant = true;
             return t;
         }
@@ -519,8 +513,7 @@ namespace das {
     template <typename TT>
     struct typeFactory<smart_ptr<TT>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tPointer);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tPointer, cppBindingLineInfo());
             t->firstType = typeFactory<TT>::make(lib);
             t->smartPtr = true;
             t->smartPtrNative = true;
@@ -531,8 +524,7 @@ namespace das {
     template <typename TT>
     struct typeFactory<smart_ptr_raw<TT>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tPointer);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tPointer, cppBindingLineInfo());
             t->firstType = typeFactory<TT>::make(lib);
             t->smartPtr = true;
             return t;
@@ -542,8 +534,7 @@ namespace das {
     template <>
     struct typeFactory<Array *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tArray);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tArray, cppBindingLineInfo());
             return t;
         }
     };
@@ -551,8 +542,7 @@ namespace das {
     template <>
     struct typeFactory<Iterator *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tIterator);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tIterator, cppBindingLineInfo());
             return t;
         }
     };
@@ -560,8 +550,7 @@ namespace das {
     template <>
     struct typeFactory<const Iterator *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tIterator);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tIterator, cppBindingLineInfo());
             t->constant = true;
             return t;
         }
@@ -570,8 +559,7 @@ namespace das {
     template <>
     struct typeFactory<Table *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tTable);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tTable, cppBindingLineInfo());
             return t;
         }
     };
@@ -579,8 +567,7 @@ namespace das {
     template <>
     struct typeFactory<Context *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::fakeContext);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::fakeContext, cppBindingLineInfo());
             return t;
         }
     };
@@ -588,8 +575,7 @@ namespace das {
     template <>
     struct typeFactory<LineInfoArg *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::fakeLineInfo);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::fakeLineInfo, cppBindingLineInfo());
             return t;
         }
     };
@@ -597,8 +583,7 @@ namespace das {
     template <typename ResultType, typename ...Args>
     struct typeFactory<TBlock<ResultType,Args...>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tBlock);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tBlock, cppBindingLineInfo());
             t->firstType = typeFactory<ResultType>::make(lib);
             t->argTypes = { typeFactory<Args>::make(lib)... };
             return t;
@@ -607,8 +592,7 @@ namespace das {
     template <typename ResultType, typename ...Args>
     struct typeFactory<TFunc<ResultType,Args...>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tFunction);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tFunction, cppBindingLineInfo());
             t->firstType = typeFactory<ResultType>::make(lib);
             t->argTypes = { typeFactory<Args>::make(lib)... };
             return t;
@@ -618,8 +602,7 @@ namespace das {
     template <typename ResultType, typename ...Args>
     struct typeFactory<TLambda<ResultType,Args...>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tLambda);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tLambda, cppBindingLineInfo());
             t->firstType = typeFactory<ResultType>::make(lib);
             t->argTypes = { typeFactory<Args>::make(lib)... };
             return t;
@@ -662,8 +645,7 @@ namespace das {
     template <typename TT>
     struct typeFactory<TArray<TT>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tArray);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tArray, cppBindingLineInfo());
             t->firstType = typeFactory<TT>::make(lib);
             return t;
         }
@@ -675,8 +657,7 @@ namespace das {
     // FIXED_ARRAY_REWORK.md, 1c: wrap an element type in a tFixedArray node, hoisting the
     // canonical qualifiers — ref/const/temporary live on the outermost FA node only
     inline TypeDeclPtr makeFixedArrayTypeDecl ( int32_t size, TypeDeclPtr element ) {
-        auto fa = new TypeDecl(Type::tFixedArray);
-        fa->at = cppBindingLineInfo();
+        auto fa = new TypeDecl(Type::tFixedArray, cppBindingLineInfo());
         fa->fixedDim = size;
         fa->firstType = element;
         fa->ref = element->ref;             element->ref = false;
@@ -698,8 +679,7 @@ namespace das {
     template <typename TK, typename TV>
     struct typeFactory<TTable<TK,TV>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tTable);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tTable, cppBindingLineInfo());
             t->firstType = typeFactory<TK>::make(lib);
             t->secondType = typeFactory<TV>::make(lib);
             return t;
@@ -712,8 +692,7 @@ namespace das {
     template <typename TT>
     struct typeFactory<TSequence<TT>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tIterator);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tIterator, cppBindingLineInfo());
             t->firstType = typeFactory<TT>::make(lib);
             return t;
         }
@@ -735,8 +714,7 @@ namespace das {
     template <typename TT>
     struct typeFactory<TT *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto pt = new TypeDecl(Type::tPointer);
-            pt->at = cppBindingLineInfo();
+            auto pt = new TypeDecl(Type::tPointer, cppBindingLineInfo());
             if ( !is_void<TT>::value ) {
                 pt->firstType = typeFactory<TT>::make(lib);
             }
@@ -747,8 +725,7 @@ namespace das {
     template <typename TT>
     struct typeFactory<const TT *> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto pt = new TypeDecl(Type::tPointer);
-            pt->at = cppBindingLineInfo();
+            auto pt = new TypeDecl(Type::tPointer, cppBindingLineInfo());
             if ( !is_void<TT>::value ) {
                 pt->firstType = typeFactory<TT>::make(lib);
                 pt->firstType->constant = true;
@@ -789,8 +766,7 @@ namespace das {
     template <typename FT, typename ST>
     struct typeFactory<pair<FT,ST>> {
         static ___noinline TypeDeclPtr make(const ModuleLibrary & lib) {
-            auto t = new TypeDecl(Type::tTuple);
-            t->at = cppBindingLineInfo();
+            auto t = new TypeDecl(Type::tTuple, cppBindingLineInfo());
             t->argTypes.push_back(typeFactory<FT>::make(lib));
             t->argTypes.push_back(typeFactory<ST>::make(lib));
             return t;
@@ -843,7 +819,11 @@ namespace das {
 
     class DAS_API MangledNameParser {
     public:
+        // a mangled name has no source of its own; the caller says where the reconstructed
+        // types come from - a das call site, or the binding that supplied the string
+        explicit MangledNameParser ( const LineInfo & att ) : at(att) {}
         virtual ~MangledNameParser () = default;
+        LineInfo at;
     protected:
         virtual void error ( const string &, const char * );
         string parseAnyName ( const char * & ch, bool allowModule );

--- a/modules/dasImgui/src/cb_dasIMGUI.h
+++ b/modules/dasImgui/src/cb_dasIMGUI.h
@@ -7,7 +7,7 @@ namespace das {
 
 template <> struct typeFactory<ImColor> {
 	static TypeDeclPtr make(const ModuleLibrary &) {
-		auto t = new TypeDecl(Type::tFloat4);
+		auto t = new TypeDecl(Type::tFloat4, cppBindingLineInfo());
 		t->alias = "ImColor";
 		t->aotAlias = true;
 		return t;
@@ -25,7 +25,7 @@ struct cast_arg<const ImColor &> {
 
 template <> struct typeFactory<ImVec2> {
 	static TypeDeclPtr make(const ModuleLibrary &) {
-		auto t = new TypeDecl(Type::tFloat2);
+		auto t = new TypeDecl(Type::tFloat2, cppBindingLineInfo());
 		t->alias = "ImVec2";
 		t->aotAlias = true;
 		return t;
@@ -42,7 +42,7 @@ template <> struct cast_arg<const ImVec2 &> {
 
 template <> struct typeFactory<ImVec4> {
 	static TypeDeclPtr make(const ModuleLibrary &) {
-		auto t = new TypeDecl(Type::tFloat4);
+		auto t = new TypeDecl(Type::tFloat4, cppBindingLineInfo());
 		t->alias = "ImVec4";
 		t->aotAlias = true;
 		return t;
@@ -82,7 +82,7 @@ template<> struct WrapArgType<const ImVec4&> { using type = const WrapArgType<Im
 static_assert(sizeof(ImRect) == sizeof(float) * 4, "ImRect must be 4 contiguous floats to alias float4");
 template <> struct typeFactory<ImRect> {
 	static TypeDeclPtr make(const ModuleLibrary &) {
-		auto t = new TypeDecl(Type::tFloat4);
+		auto t = new TypeDecl(Type::tFloat4, cppBindingLineInfo());
 		t->alias = "ImRect";
 		t->aotAlias = true;
 		return t;

--- a/modules/dasSQLITE/src/dasSQLITE.main.cpp
+++ b/modules/dasSQLITE/src/dasSQLITE.main.cpp
@@ -113,7 +113,7 @@ void Module_dasSQLITE::initMain() {
         // ok, lets fix up everything returning uint8? into returning string# and make it unsafe operation
         if ( pfn->result->isPointer() && pfn->result->firstType &&
                 pfn->result->firstType->baseType==Type::tUInt8 ) {
-            pfn->result = new TypeDecl(Type::tString);
+            pfn->result = new TypeDecl(Type::tString, pfn->at);
             pfn->result->constant = true;
             pfn->result->temporary = true;
             pfn->unsafeOperation = true;

--- a/modules/dasUnitTest/test_handles.cpp
+++ b/modules/dasUnitTest/test_handles.cpp
@@ -16,7 +16,7 @@ namespace das {
     template <>
     struct typeFactory<Point3> {
         static TypeDeclPtr make(const ModuleLibrary &) {
-            auto t = new TypeDecl(Type::tFloat3);
+            auto t = new TypeDecl(Type::tFloat3, cppBindingLineInfo("Point3"));
             t->alias = "Point3";
             t->aotAlias = true;
             return t;
@@ -47,7 +47,7 @@ namespace das {
   template <>
   struct typeFactory<SampleVariant> {
       static TypeDeclPtr make(const ModuleLibrary & library ) {
-          auto vtype = new TypeDecl(Type::tVariant);
+          auto vtype = new TypeDecl(Type::tVariant, cppBindingLineInfo());
           vtype->alias = "SampleVariant";
           vtype->aotAlias = true;
           vtype->addVariant("i_value", typeFactory<decltype(SampleVariant::i_value)>::make(library));
@@ -136,7 +136,7 @@ struct CheckRange : StructureAnnotation {
         // this is here for the 'example' purposes
         // lets add a sample 'dummy' field
         if (args.getBoolOption("dummy",false) && !st->findField("dummy")) {
-            st->fields.emplace_back("dummy", new TypeDecl(Type::tInt),
+            st->fields.emplace_back("dummy", new TypeDecl(Type::tInt, cppBindingLineInfo()),
                 nullptr /*init*/, AnnotationArgumentList(), false /*move_to_init*/, LineInfo());
             st->fieldLookup.clear();
         }
@@ -244,7 +244,7 @@ struct CheckEidFunctionAnnotation : TransformFunctionAnnotation {
             if (!starg->getValue().empty()) {
                 auto hv = hash_blockz64((uint8_t *)starg->text.c_str());
                 auto hconst = new ExprConstUInt64(arg->at, hv);
-                hconst->type = new TypeDecl(Type::tUInt64);
+                hconst->type = new TypeDecl(Type::tUInt64, cppBindingLineInfo());
                 hconst->type->constant = true;
                 auto newCall = static_cast<ExprCallFunc*>(call->clone());
                 newCall->arguments.insert(newCall->arguments.begin() + 2, hconst);
@@ -313,11 +313,11 @@ struct EventRegistrator : StructureAnnotation {
     EventRegistrator() : StructureAnnotation("event") {}
     bool touch ( const StructurePtr & st, ModuleGroup & /*libGroup*/,
         const AnnotationArgumentList & /*args*/, string & /*err*/ ) override {
-        st->fields.emplace(st->fields.begin(), "eventFlags", new TypeDecl(Type::tUInt16),
+        st->fields.emplace(st->fields.begin(), "eventFlags", new TypeDecl(Type::tUInt16, cppBindingLineInfo()),
             ExpressionPtr(), AnnotationArgumentList(), false, st->at);
-        st->fields.emplace(st->fields.begin(), "eventSize", new TypeDecl(Type::tUInt16),
+        st->fields.emplace(st->fields.begin(), "eventSize", new TypeDecl(Type::tUInt16, cppBindingLineInfo()),
             ExpressionPtr(), AnnotationArgumentList(), false, st->at);
-        st->fields.emplace(st->fields.begin(), "eventType", new TypeDecl(Type::tUInt64),
+        st->fields.emplace(st->fields.begin(), "eventType", new TypeDecl(Type::tUInt64, cppBindingLineInfo()),
             ExpressionPtr(), AnnotationArgumentList(), false, st->at);
         return true;
     }

--- a/modules/dasVulkan/generator/vk_emit.das
+++ b/modules/dasVulkan/generator/vk_emit.das
@@ -470,7 +470,7 @@ def public emit_flags(reg : VkRegistry; em : EmitModel; out_dir : string; var he
             guard_open(f, b.guard, b.protect)
             fprint(f, "TypeDeclPtr makeVkFlags_{b.flags_name}() {OB}\n")
             let bft = b.is64 ? "Type::tBitfield64" : "Type::tBitfield"
-            fprint(f, "    auto ft = new TypeDecl({bft});\n")
+            fprint(f, "    auto ft = new TypeDecl({bft}, cppBindingLineInfo());\n")
             fprint(f, "    ft->alias = \"{b.flags_name}\";\n")
             if (!empty(b.bit_names)) {
                 fprint(f, "    ft->argNames = {OB} ")

--- a/modules/dasVulkan/src/dasVULKAN.gen_flags.cpp
+++ b/modules/dasVulkan/src/dasVULKAN.gen_flags.cpp
@@ -6,7 +6,7 @@ namespace das {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkFramebufferCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkFramebufferCreateFlags";
     ft->argNames = { "imageless" };
     return ft;
@@ -15,7 +15,7 @@ TypeDeclPtr makeVkFlags_VkFramebufferCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkQueryPoolCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkQueryPoolCreateFlags";
     ft->argNames = { "reset_khr" };
     return ft;
@@ -24,7 +24,7 @@ TypeDeclPtr makeVkFlags_VkQueryPoolCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkRenderPassCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkRenderPassCreateFlags";
     ft->argNames = { "_b0", "transform_qcom", "per_layer_fragment_density_valve" };
     return ft;
@@ -33,7 +33,7 @@ TypeDeclPtr makeVkFlags_VkRenderPassCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkSamplerCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSamplerCreateFlags";
     ft->argNames = { "subsampled_ext", "subsampled_coarse_reconstruction_ext", "non_seamless_cube_map_ext", "descriptor_buffer_capture_replay_ext", "image_processing_qcom" };
     return ft;
@@ -42,7 +42,7 @@ TypeDeclPtr makeVkFlags_VkSamplerCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineLayoutCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineLayoutCreateFlags";
     ft->argNames = { "_b0", "independent_sets_ext", "no_task_shader_khr" };
     return ft;
@@ -51,7 +51,7 @@ TypeDeclPtr makeVkFlags_VkPipelineLayoutCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineCacheCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCacheCreateFlags";
     ft->argNames = { "externally_synchronized", "_b1", "_b2", "internally_synchronized_merge_khr" };
     return ft;
@@ -60,7 +60,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCacheCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineDepthStencilStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineDepthStencilStateCreateFlags";
     ft->argNames = { "rasterization_order_attachment_depth_access_ext", "rasterization_order_attachment_stencil_access_ext" };
     return ft;
@@ -69,7 +69,7 @@ TypeDeclPtr makeVkFlags_VkPipelineDepthStencilStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineDynamicStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineDynamicStateCreateFlags";
     return ft;
 }
@@ -77,7 +77,7 @@ TypeDeclPtr makeVkFlags_VkPipelineDynamicStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineColorBlendStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineColorBlendStateCreateFlags";
     ft->argNames = { "rasterization_order_attachment_access_ext" };
     return ft;
@@ -86,7 +86,7 @@ TypeDeclPtr makeVkFlags_VkPipelineColorBlendStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineMultisampleStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineMultisampleStateCreateFlags";
     return ft;
 }
@@ -94,7 +94,7 @@ TypeDeclPtr makeVkFlags_VkPipelineMultisampleStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineRasterizationStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineRasterizationStateCreateFlags";
     return ft;
 }
@@ -102,7 +102,7 @@ TypeDeclPtr makeVkFlags_VkPipelineRasterizationStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineViewportStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineViewportStateCreateFlags";
     return ft;
 }
@@ -110,7 +110,7 @@ TypeDeclPtr makeVkFlags_VkPipelineViewportStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineTessellationStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineTessellationStateCreateFlags";
     return ft;
 }
@@ -118,7 +118,7 @@ TypeDeclPtr makeVkFlags_VkPipelineTessellationStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineInputAssemblyStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineInputAssemblyStateCreateFlags";
     return ft;
 }
@@ -126,7 +126,7 @@ TypeDeclPtr makeVkFlags_VkPipelineInputAssemblyStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineVertexInputStateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineVertexInputStateCreateFlags";
     return ft;
 }
@@ -134,7 +134,7 @@ TypeDeclPtr makeVkFlags_VkPipelineVertexInputStateCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineShaderStageCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineShaderStageCreateFlags";
     ft->argNames = { "allow_varying_subgroup_size", "require_full_subgroups" };
     return ft;
@@ -143,7 +143,7 @@ TypeDeclPtr makeVkFlags_VkPipelineShaderStageCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkDescriptorSetLayoutCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDescriptorSetLayoutCreateFlags";
     ft->argNames = { "push_descriptor", "update_after_bind_pool", "host_only_pool_ext", "_b3", "descriptor_buffer_ext", "embedded_immutable_samplers_ext", "per_stage_nv", "indirect_bindable_nv" };
     return ft;
@@ -152,7 +152,7 @@ TypeDeclPtr makeVkFlags_VkDescriptorSetLayoutCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkBufferViewCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkBufferViewCreateFlags";
     return ft;
 }
@@ -160,7 +160,7 @@ TypeDeclPtr makeVkFlags_VkBufferViewCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkInstanceCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkInstanceCreateFlags";
     ft->argNames = { "enumerate_portability_khr" };
     return ft;
@@ -169,7 +169,7 @@ TypeDeclPtr makeVkFlags_VkInstanceCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkDeviceCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceCreateFlags";
     return ft;
 }
@@ -177,7 +177,7 @@ TypeDeclPtr makeVkFlags_VkDeviceCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkDeviceQueueCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceQueueCreateFlags";
     ft->argNames = { "protected", "_b1", "internally_synchronized_khr" };
     return ft;
@@ -186,7 +186,7 @@ TypeDeclPtr makeVkFlags_VkDeviceQueueCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkQueueFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkQueueFlags";
     ft->argNames = { "graphics", "compute", "transfer", "sparse_binding", "protected", "video_decode_khr", "video_encode_khr", "_b7", "optical_flow_nv", "_b9", "data_graph_arm" };
     return ft;
@@ -195,7 +195,7 @@ TypeDeclPtr makeVkFlags_VkQueueFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkMemoryPropertyFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMemoryPropertyFlags";
     ft->argNames = { "device_local", "host_visible", "host_coherent", "host_cached", "lazily_allocated", "protected", "device_coherent_amd", "device_uncached_amd", "rdma_capable_nv" };
     return ft;
@@ -204,7 +204,7 @@ TypeDeclPtr makeVkFlags_VkMemoryPropertyFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkMemoryHeapFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMemoryHeapFlags";
     ft->argNames = { "device_local", "multi_instance", "_b2", "tile_memory_qcom" };
     return ft;
@@ -213,7 +213,7 @@ TypeDeclPtr makeVkFlags_VkMemoryHeapFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkAccessFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAccessFlags";
     ft->argNames = { "indirect_command_read", "index_read", "vertex_attribute_read", "uniform_read", "input_attachment_read", "shader_read", "shader_write", "color_attachment_read", "color_attachment_write", "depth_stencil_attachment_read", "depth_stencil_attachment_write", "transfer_read", "transfer_write", "host_read", "host_write", "memory_read", "memory_write", "command_preprocess_read_ext", "command_preprocess_write_ext", "color_attachment_read_noncoherent_ext", "conditional_rendering_read_ext", "acceleration_structure_read_khr", "acceleration_structure_write_khr", "fragment_shading_rate_attachment_read_khr", "fragment_density_map_read_ext", "transform_feedback_write_ext", "transform_feedback_counter_read_ext", "transform_feedback_counter_write_ext" };
     return ft;
@@ -222,7 +222,7 @@ TypeDeclPtr makeVkFlags_VkAccessFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkBufferUsageFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkBufferUsageFlags";
     ft->argNames = { "transfer_src", "transfer_dst", "uniform_texel_buffer", "storage_texel_buffer", "uniform_buffer", "storage_buffer", "index_buffer", "vertex_buffer", "indirect_buffer", "conditional_rendering_ext", "shader_binding_table_khr", "transform_feedback_buffer_ext", "transform_feedback_counter_buffer_ext", "video_decode_src_khr", "video_decode_dst_khr", "video_encode_dst_khr", "video_encode_src_khr", "shader_device_address", "_b18", "acceleration_structure_build_input_read_only_khr", "acceleration_structure_storage_khr", "sampler_descriptor_buffer_ext", "resource_descriptor_buffer_ext", "micromap_build_input_read_only_ext", "micromap_storage_ext", "execution_graph_scratch_amdx", "push_descriptors_descriptor_buffer_ext", "tile_memory_qcom", "descriptor_heap_ext" };
     return ft;
@@ -231,7 +231,7 @@ TypeDeclPtr makeVkFlags_VkBufferUsageFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkBufferCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkBufferCreateFlags";
     ft->argNames = { "sparse_binding", "sparse_residency", "sparse_aliased", "protected", "device_address_capture_replay", "descriptor_buffer_capture_replay_ext", "video_profile_independent_khr" };
     return ft;
@@ -240,7 +240,7 @@ TypeDeclPtr makeVkFlags_VkBufferCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkShaderStageFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkShaderStageFlags";
     ft->argNames = { "vertex", "tessellation_control", "tessellation_evaluation", "geometry", "fragment", "compute", "task_ext", "mesh_ext", "raygen_khr", "any_hit_khr", "closest_hit_khr", "miss_khr", "intersection_khr", "callable_khr", "subpass_shading_huawei", "_b15", "_b16", "_b17", "_b18", "cluster_culling_huawei" };
     return ft;
@@ -249,7 +249,7 @@ TypeDeclPtr makeVkFlags_VkShaderStageFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkImageUsageFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkImageUsageFlags";
     ft->argNames = { "transfer_src", "transfer_dst", "sampled", "storage", "color_attachment", "depth_stencil_attachment", "transient_attachment", "input_attachment", "fragment_shading_rate_attachment_khr", "fragment_density_map_ext", "video_decode_dst_khr", "video_decode_src_khr", "video_decode_dpb_khr", "video_encode_dst_khr", "video_encode_src_khr", "video_encode_dpb_khr", "_b16", "_b17", "invocation_mask_huawei", "attachment_feedback_loop_ext", "sample_weight_qcom", "sample_block_match_qcom", "host_transfer", "tensor_aliasing_arm", "_b24", "video_encode_quantization_delta_map_khr", "video_encode_emphasis_map_khr", "tile_memory_qcom" };
     return ft;
@@ -258,7 +258,7 @@ TypeDeclPtr makeVkFlags_VkImageUsageFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkImageCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkImageCreateFlags";
     ft->argNames = { "sparse_binding", "sparse_residency", "sparse_aliased", "mutable_format", "cube_compatible", "_2d_array_compatible", "split_instance_bind_regions", "block_texel_view_compatible", "extended_usage", "disjoint", "alias", "protected", "sample_locations_compatible_depth_ext", "corner_sampled_nv", "subsampled_ext", "fragment_density_map_offset_ext", "descriptor_heap_capture_replay_ext", "_2d_view_compatible_ext", "multisampled_render_to_single_sampled_ext", "_b19", "video_profile_independent_khr", "_b21", "alias_single_layer_descriptor_khr" };
     return ft;
@@ -267,7 +267,7 @@ TypeDeclPtr makeVkFlags_VkImageCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkImageViewCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkImageViewCreateFlags";
     ft->argNames = { "fragment_density_map_dynamic_ext", "fragment_density_map_deferred_ext", "descriptor_buffer_capture_replay_ext" };
     return ft;
@@ -276,7 +276,7 @@ TypeDeclPtr makeVkFlags_VkImageViewCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCreateFlags";
     ft->argNames = { "disable_optimization", "allow_derivatives", "derivative", "view_index_from_device_index", "dispatch_base", "defer_compile_nv", "capture_statistics_khr", "capture_internal_representations_khr", "fail_on_pipeline_compile_required", "early_return_on_failure", "link_time_optimization_ext", "library_khr", "ray_tracing_skip_triangles_khr", "ray_tracing_skip_aabbs_khr", "ray_tracing_no_null_any_hit_shaders_khr", "ray_tracing_no_null_closest_hit_shaders_khr", "ray_tracing_no_null_miss_shaders_khr", "ray_tracing_no_null_intersection_shaders_khr", "indirect_bindable_nv", "ray_tracing_shader_group_handle_capture_replay_khr", "ray_tracing_allow_motion_nv", "rendering_fragment_shading_rate_attachment_khr", "rendering_fragment_density_map_attachment_ext", "retain_link_time_optimization_info_ext", "ray_tracing_opacity_micromap_ext", "color_attachment_feedback_loop_ext", "depth_stencil_attachment_feedback_loop_ext", "no_protected_access", "ray_tracing_displacement_micromap_nv", "descriptor_buffer_ext", "protected_access_only" };
     return ft;
@@ -285,7 +285,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkColorComponentFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkColorComponentFlags";
     ft->argNames = { "r", "g", "b", "a" };
     return ft;
@@ -294,7 +294,7 @@ TypeDeclPtr makeVkFlags_VkColorComponentFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkFenceCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkFenceCreateFlags";
     ft->argNames = { "signaled" };
     return ft;
@@ -303,7 +303,7 @@ TypeDeclPtr makeVkFlags_VkFenceCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkSemaphoreCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSemaphoreCreateFlags";
     return ft;
 }
@@ -311,7 +311,7 @@ TypeDeclPtr makeVkFlags_VkSemaphoreCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkFormatFeatureFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkFormatFeatureFlags";
     ft->argNames = { "sampled_image", "storage_image", "storage_image_atomic", "uniform_texel_buffer", "storage_texel_buffer", "storage_texel_buffer_atomic", "vertex_buffer", "color_attachment", "color_attachment_blend", "depth_stencil_attachment", "blit_src", "blit_dst", "sampled_image_filter_linear", "sampled_image_filter_cubic_ext", "transfer_src", "transfer_dst", "sampled_image_filter_minmax", "midpoint_chroma_samples", "sampled_image_ycbcr_conversion_linear_filter", "sampled_image_ycbcr_conversion_separate_reconstruction_filter", "sampled_image_ycbcr_conversion_chroma_reconstruction_explicit", "sampled_image_ycbcr_conversion_chroma_reconstruction_explicit_forceable", "disjoint", "cosited_chroma_samples", "fragment_density_map_ext", "video_decode_output_khr", "video_decode_dpb_khr", "video_encode_input_khr", "video_encode_dpb_khr", "acceleration_structure_vertex_buffer_khr", "fragment_shading_rate_attachment_khr" };
     return ft;
@@ -320,7 +320,7 @@ TypeDeclPtr makeVkFlags_VkFormatFeatureFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkQueryControlFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkQueryControlFlags";
     ft->argNames = { "precise" };
     return ft;
@@ -329,7 +329,7 @@ TypeDeclPtr makeVkFlags_VkQueryControlFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkQueryResultFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkQueryResultFlags";
     ft->argNames = { "_64", "wait", "with_availability", "partial", "with_status_khr" };
     return ft;
@@ -338,7 +338,7 @@ TypeDeclPtr makeVkFlags_VkQueryResultFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkShaderModuleCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkShaderModuleCreateFlags";
     return ft;
 }
@@ -346,7 +346,7 @@ TypeDeclPtr makeVkFlags_VkShaderModuleCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkEventCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkEventCreateFlags";
     ft->argNames = { "device_only" };
     return ft;
@@ -355,7 +355,7 @@ TypeDeclPtr makeVkFlags_VkEventCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkCommandPoolCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCommandPoolCreateFlags";
     ft->argNames = { "transient", "reset_command_buffer", "protected" };
     return ft;
@@ -364,7 +364,7 @@ TypeDeclPtr makeVkFlags_VkCommandPoolCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkCommandPoolResetFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCommandPoolResetFlags";
     ft->argNames = { "release_resources" };
     return ft;
@@ -373,7 +373,7 @@ TypeDeclPtr makeVkFlags_VkCommandPoolResetFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkCommandBufferResetFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCommandBufferResetFlags";
     ft->argNames = { "release_resources" };
     return ft;
@@ -382,7 +382,7 @@ TypeDeclPtr makeVkFlags_VkCommandBufferResetFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkCommandBufferUsageFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCommandBufferUsageFlags";
     ft->argNames = { "one_time_submit", "render_pass_continue", "simultaneous_use" };
     return ft;
@@ -391,7 +391,7 @@ TypeDeclPtr makeVkFlags_VkCommandBufferUsageFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkQueryPipelineStatisticFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkQueryPipelineStatisticFlags";
     ft->argNames = { "input_assembly_vertices", "input_assembly_primitives", "vertex_shader_invocations", "geometry_shader_invocations", "geometry_shader_primitives", "clipping_invocations", "clipping_primitives", "fragment_shader_invocations", "tessellation_control_shader_patches", "tessellation_evaluation_shader_invocations", "compute_shader_invocations", "task_shader_invocations_ext", "mesh_shader_invocations_ext", "cluster_culling_shader_invocations_huawei" };
     return ft;
@@ -400,7 +400,7 @@ TypeDeclPtr makeVkFlags_VkQueryPipelineStatisticFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkMemoryMapFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMemoryMapFlags";
     ft->argNames = { "placed_ext" };
     return ft;
@@ -409,7 +409,7 @@ TypeDeclPtr makeVkFlags_VkMemoryMapFlags() {
 
 #if defined(VK_VERSION_1_4)
 TypeDeclPtr makeVkFlags_VkMemoryUnmapFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMemoryUnmapFlags";
     ft->argNames = { "reserve_ext" };
     return ft;
@@ -418,7 +418,7 @@ TypeDeclPtr makeVkFlags_VkMemoryUnmapFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkImageAspectFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkImageAspectFlags";
     ft->argNames = { "color", "depth", "stencil", "metadata", "plane_0", "plane_1", "plane_2", "memory_plane_0_ext", "memory_plane_1_ext", "memory_plane_2_ext", "memory_plane_3_ext" };
     return ft;
@@ -427,7 +427,7 @@ TypeDeclPtr makeVkFlags_VkImageAspectFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkSparseMemoryBindFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSparseMemoryBindFlags";
     ft->argNames = { "metadata" };
     return ft;
@@ -436,7 +436,7 @@ TypeDeclPtr makeVkFlags_VkSparseMemoryBindFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkSparseImageFormatFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSparseImageFormatFlags";
     ft->argNames = { "single_miptail", "aligned_mip_size", "nonstandard_block_size" };
     return ft;
@@ -445,7 +445,7 @@ TypeDeclPtr makeVkFlags_VkSparseImageFormatFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkSubpassDescriptionFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSubpassDescriptionFlags";
     ft->argNames = { "per_view_attributes_nvx", "per_view_position_x_only_nvx", "fragment_region_ext", "custom_resolve_ext", "rasterization_order_attachment_color_access_ext", "rasterization_order_attachment_depth_access_ext", "rasterization_order_attachment_stencil_access_ext", "enable_legacy_dithering_ext", "tile_shading_apron_qcom" };
     return ft;
@@ -454,7 +454,7 @@ TypeDeclPtr makeVkFlags_VkSubpassDescriptionFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkPipelineStageFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineStageFlags";
     ft->argNames = { "top_of_pipe", "draw_indirect", "vertex_input", "vertex_shader", "tessellation_control_shader", "tessellation_evaluation_shader", "geometry_shader", "fragment_shader", "early_fragment_tests", "late_fragment_tests", "color_attachment_output", "compute_shader", "transfer", "bottom_of_pipe", "host", "all_graphics", "all_commands", "command_preprocess_ext", "conditional_rendering_ext", "task_shader_ext", "mesh_shader_ext", "ray_tracing_shader_khr", "fragment_shading_rate_attachment_khr", "fragment_density_process_ext", "transform_feedback_ext", "acceleration_structure_build_khr" };
     return ft;
@@ -463,7 +463,7 @@ TypeDeclPtr makeVkFlags_VkPipelineStageFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkSampleCountFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSampleCountFlags";
     ft->argNames = { "_1", "_2", "_4", "_8", "_16", "_32", "_64" };
     return ft;
@@ -472,7 +472,7 @@ TypeDeclPtr makeVkFlags_VkSampleCountFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkAttachmentDescriptionFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAttachmentDescriptionFlags";
     ft->argNames = { "may_alias", "resolve_skip_transfer_function_khr", "resolve_enable_transfer_function_khr" };
     return ft;
@@ -481,7 +481,7 @@ TypeDeclPtr makeVkFlags_VkAttachmentDescriptionFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkStencilFaceFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkStencilFaceFlags";
     ft->argNames = { "front", "back" };
     return ft;
@@ -490,7 +490,7 @@ TypeDeclPtr makeVkFlags_VkStencilFaceFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkCullModeFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCullModeFlags";
     ft->argNames = { "front", "back" };
     return ft;
@@ -499,7 +499,7 @@ TypeDeclPtr makeVkFlags_VkCullModeFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkDescriptorPoolCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDescriptorPoolCreateFlags";
     ft->argNames = { "free_descriptor_set", "update_after_bind", "host_only_ext", "allow_overallocation_sets_nv", "allow_overallocation_pools_nv" };
     return ft;
@@ -508,7 +508,7 @@ TypeDeclPtr makeVkFlags_VkDescriptorPoolCreateFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkDescriptorPoolResetFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDescriptorPoolResetFlags";
     return ft;
 }
@@ -516,7 +516,7 @@ TypeDeclPtr makeVkFlags_VkDescriptorPoolResetFlags() {
 
 #if defined(VK_VERSION_1_0)
 TypeDeclPtr makeVkFlags_VkDependencyFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDependencyFlags";
     ft->argNames = { "by_region", "view_local", "device_group", "feedback_loop_ext", "_b4", "queue_family_ownership_transfer_use_all_stages_khr", "asymmetric_event_khr" };
     return ft;
@@ -525,7 +525,7 @@ TypeDeclPtr makeVkFlags_VkDependencyFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkSubgroupFeatureFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSubgroupFeatureFlags";
     ft->argNames = { "basic", "vote", "arithmetic", "ballot", "shuffle", "shuffle_relative", "clustered", "quad", "partitioned_ext", "rotate", "rotate_clustered" };
     return ft;
@@ -534,7 +534,7 @@ TypeDeclPtr makeVkFlags_VkSubgroupFeatureFlags() {
 
 #if defined(VK_NV_device_generated_commands)
 TypeDeclPtr makeVkFlags_VkIndirectCommandsLayoutUsageFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkIndirectCommandsLayoutUsageFlagsNV";
     ft->argNames = { "explicit_preprocess_nv", "indexed_sequences_nv", "unordered_sequences_nv" };
     return ft;
@@ -543,7 +543,7 @@ TypeDeclPtr makeVkFlags_VkIndirectCommandsLayoutUsageFlagsNV() {
 
 #if defined(VK_NV_device_generated_commands)
 TypeDeclPtr makeVkFlags_VkIndirectStateFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkIndirectStateFlagsNV";
     ft->argNames = { "flag_frontface_nv" };
     return ft;
@@ -552,7 +552,7 @@ TypeDeclPtr makeVkFlags_VkIndirectStateFlagsNV() {
 
 #if defined(VK_KHR_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkGeometryFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkGeometryFlagsKHR";
     ft->argNames = { "opaque_khr", "no_duplicate_any_hit_invocation_khr" };
     return ft;
@@ -561,7 +561,7 @@ TypeDeclPtr makeVkFlags_VkGeometryFlagsKHR() {
 
 #if defined(VK_KHR_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkGeometryInstanceFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkGeometryInstanceFlagsKHR";
     ft->argNames = { "triangle_facing_cull_disable_khr", "triangle_flip_facing_khr", "force_opaque_khr", "force_no_opaque_khr", "force_opacity_micromap_2_state_ext", "disable_opacity_micromaps_ext" };
     return ft;
@@ -570,7 +570,7 @@ TypeDeclPtr makeVkFlags_VkGeometryInstanceFlagsKHR() {
 
 #if defined(VK_NV_cluster_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureGeometryFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkClusterAccelerationStructureGeometryFlagsNV";
     ft->argNames = { "cull_disable_nv", "no_duplicate_anyhit_invocation_nv", "opaque_nv" };
     return ft;
@@ -579,7 +579,7 @@ TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureGeometryFlagsNV() {
 
 #if defined(VK_NV_cluster_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureClusterFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkClusterAccelerationStructureClusterFlagsNV";
     ft->argNames = { "allow_disable_opacity_micromaps_nv" };
     return ft;
@@ -588,7 +588,7 @@ TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureClusterFlagsNV() {
 
 #if defined(VK_NV_cluster_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureAddressResolutionFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkClusterAccelerationStructureAddressResolutionFlagsNV";
     ft->argNames = { "indirected_dst_implicit_data_nv", "indirected_scratch_data_nv", "indirected_dst_address_array_nv", "indirected_dst_sizes_array_nv", "indirected_src_infos_array_nv", "indirected_src_infos_count_nv" };
     return ft;
@@ -597,7 +597,7 @@ TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureAddressResolutionFlagsNV()
 
 #if defined(VK_KHR_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkBuildAccelerationStructureFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkBuildAccelerationStructureFlagsKHR";
     ft->argNames = { "allow_update_khr", "allow_compaction_khr", "prefer_fast_trace_khr", "prefer_fast_build_khr", "low_memory_khr", "motion_nv", "allow_opacity_micromap_update_ext", "allow_disable_opacity_micromaps_ext", "allow_opacity_micromap_data_update_ext", "allow_displacement_micromap_update_nv", "_b10", "allow_data_access_khr", "allow_cluster_opacity_micromaps_nv" };
     return ft;
@@ -606,7 +606,7 @@ TypeDeclPtr makeVkFlags_VkBuildAccelerationStructureFlagsKHR() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkPrivateDataSlotCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPrivateDataSlotCreateFlags";
     return ft;
 }
@@ -614,7 +614,7 @@ TypeDeclPtr makeVkFlags_VkPrivateDataSlotCreateFlags() {
 
 #if defined(VK_KHR_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkAccelerationStructureCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAccelerationStructureCreateFlagsKHR";
     ft->argNames = { "device_address_capture_replay_khr", "_b1", "motion_nv", "descriptor_buffer_capture_replay_ext" };
     return ft;
@@ -623,7 +623,7 @@ TypeDeclPtr makeVkFlags_VkAccelerationStructureCreateFlagsKHR() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkDescriptorUpdateTemplateCreateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDescriptorUpdateTemplateCreateFlags";
     return ft;
 }
@@ -631,7 +631,7 @@ TypeDeclPtr makeVkFlags_VkDescriptorUpdateTemplateCreateFlags() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkPipelineCreationFeedbackFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCreationFeedbackFlags";
     ft->argNames = { "valid", "application_pipeline_cache_hit", "base_pipeline_acceleration" };
     return ft;
@@ -640,7 +640,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCreationFeedbackFlags() {
 
 #if defined(VK_KHR_performance_query)
 TypeDeclPtr makeVkFlags_VkPerformanceCounterDescriptionFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPerformanceCounterDescriptionFlagsKHR";
     ft->argNames = { "performance_impacting_khr", "concurrently_impacted_khr" };
     return ft;
@@ -649,7 +649,7 @@ TypeDeclPtr makeVkFlags_VkPerformanceCounterDescriptionFlagsKHR() {
 
 #if defined(VK_KHR_performance_query)
 TypeDeclPtr makeVkFlags_VkAcquireProfilingLockFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAcquireProfilingLockFlagsKHR";
     return ft;
 }
@@ -657,7 +657,7 @@ TypeDeclPtr makeVkFlags_VkAcquireProfilingLockFlagsKHR() {
 
 #if defined(VK_VERSION_1_2)
 TypeDeclPtr makeVkFlags_VkSemaphoreWaitFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSemaphoreWaitFlags";
     ft->argNames = { "any" };
     return ft;
@@ -666,7 +666,7 @@ TypeDeclPtr makeVkFlags_VkSemaphoreWaitFlags() {
 
 #if defined(VK_AMD_pipeline_compiler_control)
 TypeDeclPtr makeVkFlags_VkPipelineCompilerControlFlagsAMD() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCompilerControlFlagsAMD";
     return ft;
 }
@@ -674,7 +674,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCompilerControlFlagsAMD() {
 
 #if defined(VK_AMD_shader_core_properties2)
 TypeDeclPtr makeVkFlags_VkShaderCorePropertiesFlagsAMD() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkShaderCorePropertiesFlagsAMD";
     return ft;
 }
@@ -682,7 +682,7 @@ TypeDeclPtr makeVkFlags_VkShaderCorePropertiesFlagsAMD() {
 
 #if defined(VK_NV_device_diagnostics_config)
 TypeDeclPtr makeVkFlags_VkDeviceDiagnosticsConfigFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceDiagnosticsConfigFlagsNV";
     ft->argNames = { "enable_shader_debug_info_nv", "enable_resource_tracking_nv", "enable_automatic_checkpoints_nv", "enable_shader_error_reporting_nv" };
     return ft;
@@ -691,7 +691,7 @@ TypeDeclPtr makeVkFlags_VkDeviceDiagnosticsConfigFlagsNV() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkAccessFlags2() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkAccessFlags2";
     ft->argNames = { "indirect_command_read", "index_read", "vertex_attribute_read", "uniform_read", "input_attachment_read", "shader_read", "shader_write", "color_attachment_read", "color_attachment_write", "depth_stencil_attachment_read", "depth_stencil_attachment_write", "transfer_read", "transfer_write", "host_read", "host_write", "memory_read", "memory_write", "command_preprocess_read_ext", "command_preprocess_write_ext", "color_attachment_read_noncoherent_ext", "conditional_rendering_read_ext", "acceleration_structure_read_khr", "acceleration_structure_write_khr", "fragment_shading_rate_attachment_read_khr", "fragment_density_map_read_ext", "transform_feedback_write_ext", "transform_feedback_counter_read_ext", "transform_feedback_counter_write_ext", "_b28", "_b29", "_b30", "_b31", "shader_sampled_read", "shader_storage_read", "shader_storage_write", "video_decode_read_khr", "video_decode_write_khr", "video_encode_read_khr", "video_encode_write_khr", "invocation_mask_read_huawei", "shader_binding_table_read_khr", "descriptor_buffer_read_ext", "optical_flow_read_nv", "optical_flow_write_nv", "micromap_read_ext", "micromap_write_ext", "_b46", "data_graph_read_arm", "data_graph_write_arm", "_b49", "_b50", "shader_tile_attachment_read_qcom", "shader_tile_attachment_write_qcom", "_b53", "_b54", "memory_decompression_read_ext", "memory_decompression_write_ext", "sampler_heap_read_ext", "resource_heap_read_ext" };
     return ft;
@@ -700,7 +700,7 @@ TypeDeclPtr makeVkFlags_VkAccessFlags2() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkPipelineStageFlags2() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkPipelineStageFlags2";
     ft->argNames = { "top_of_pipe", "draw_indirect", "vertex_input", "vertex_shader", "tessellation_control_shader", "tessellation_evaluation_shader", "geometry_shader", "fragment_shader", "early_fragment_tests", "late_fragment_tests", "color_attachment_output", "compute_shader", "all_transfer", "bottom_of_pipe", "host", "all_graphics", "all_commands", "command_preprocess_ext", "conditional_rendering_ext", "task_shader_ext", "mesh_shader_ext", "ray_tracing_shader_khr", "fragment_shading_rate_attachment_khr", "fragment_density_process_ext", "transform_feedback_ext", "acceleration_structure_build_khr", "video_decode_khr", "video_encode_khr", "acceleration_structure_copy_khr", "optical_flow_nv", "micromap_build_ext", "_b31", "copy", "resolve", "blit", "clear", "index_input", "vertex_attribute_input", "pre_rasterization_shaders", "subpass_shader_huawei", "invocation_mask_huawei", "cluster_culling_shader_huawei", "data_graph_arm", "_b43", "convert_cooperative_vector_matrix_nv", "memory_decompression_ext", "copy_indirect_khr" };
     return ft;
@@ -709,7 +709,7 @@ TypeDeclPtr makeVkFlags_VkPipelineStageFlags2() {
 
 #if defined(VK_NV_ray_tracing_motion_blur)
 TypeDeclPtr makeVkFlags_VkAccelerationStructureMotionInfoFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAccelerationStructureMotionInfoFlagsNV";
     return ft;
 }
@@ -717,7 +717,7 @@ TypeDeclPtr makeVkFlags_VkAccelerationStructureMotionInfoFlagsNV() {
 
 #if defined(VK_NV_ray_tracing_motion_blur)
 TypeDeclPtr makeVkFlags_VkAccelerationStructureMotionInstanceFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAccelerationStructureMotionInstanceFlagsNV";
     return ft;
 }
@@ -725,7 +725,7 @@ TypeDeclPtr makeVkFlags_VkAccelerationStructureMotionInstanceFlagsNV() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkFormatFeatureFlags2() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkFormatFeatureFlags2";
     ft->argNames = { "sampled_image", "storage_image", "storage_image_atomic", "uniform_texel_buffer", "storage_texel_buffer", "storage_texel_buffer_atomic", "vertex_buffer", "color_attachment", "color_attachment_blend", "depth_stencil_attachment", "blit_src", "blit_dst", "sampled_image_filter_linear", "sampled_image_filter_cubic", "transfer_src", "transfer_dst", "sampled_image_filter_minmax", "midpoint_chroma_samples", "sampled_image_ycbcr_conversion_linear_filter", "sampled_image_ycbcr_conversion_separate_reconstruction_filter", "sampled_image_ycbcr_conversion_chroma_reconstruction_explicit", "sampled_image_ycbcr_conversion_chroma_reconstruction_explicit_forceable", "disjoint", "cosited_chroma_samples", "fragment_density_map_ext", "video_decode_output_khr", "video_decode_dpb_khr", "video_encode_input_khr", "video_encode_dpb_khr", "acceleration_structure_vertex_buffer_khr", "fragment_shading_rate_attachment_khr", "storage_read_without_format", "storage_write_without_format", "sampled_image_depth_comparison", "weight_image_qcom", "weight_sampled_image_qcom", "block_matching_qcom", "box_filter_sampled_qcom", "linear_color_attachment_nv", "tensor_shader_arm", "optical_flow_image_nv", "optical_flow_vector_nv", "optical_flow_cost_nv", "tensor_image_aliasing_arm", "_b44", "_b45", "host_image_transfer", "_b47", "tensor_data_graph_arm", "video_encode_quantization_delta_map_khr", "video_encode_emphasis_map_khr", "acceleration_structure_radius_buffer_nv", "depth_copy_on_compute_queue_khr", "depth_copy_on_transfer_queue_khr", "stencil_copy_on_compute_queue_khr", "stencil_copy_on_transfer_queue_khr", "data_graph_optical_flow_image_arm", "data_graph_optical_flow_vector_arm", "data_graph_optical_flow_cost_arm", "copy_image_indirect_dst_khr" };
     return ft;
@@ -734,7 +734,7 @@ TypeDeclPtr makeVkFlags_VkFormatFeatureFlags2() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkRenderingFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkRenderingFlags";
     ft->argNames = { "contents_secondary_command_buffers", "suspending", "resuming", "enable_legacy_dithering_ext", "contents_inline_khr", "per_layer_fragment_density_valve", "fragment_region_ext", "custom_resolve_ext", "local_read_concurrent_access_control_khr" };
     return ft;
@@ -743,7 +743,7 @@ TypeDeclPtr makeVkFlags_VkRenderingFlags() {
 
 #if defined(VK_EXT_memory_decompression)
 TypeDeclPtr makeVkFlags_VkMemoryDecompressionMethodFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkMemoryDecompressionMethodFlagsEXT";
     ft->argNames = { "gdeflate_1_0_ext" };
     return ft;
@@ -752,7 +752,7 @@ TypeDeclPtr makeVkFlags_VkMemoryDecompressionMethodFlagsEXT() {
 
 #if defined(VK_KHR_device_fault)
 TypeDeclPtr makeVkFlags_VkDeviceFaultFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceFaultFlagsKHR";
     ft->argNames = { "flag_device_lost_khr", "flag_memory_address_khr", "flag_instruction_address_khr", "flag_vendor_khr", "flag_watchdog_timeout_khr", "flag_overflow_khr" };
     return ft;
@@ -761,7 +761,7 @@ TypeDeclPtr makeVkFlags_VkDeviceFaultFlagsKHR() {
 
 #if defined(VK_EXT_opacity_micromap)
 TypeDeclPtr makeVkFlags_VkBuildMicromapFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkBuildMicromapFlagsEXT";
     ft->argNames = { "prefer_fast_trace_ext", "prefer_fast_build_ext", "allow_compaction_ext" };
     return ft;
@@ -770,7 +770,7 @@ TypeDeclPtr makeVkFlags_VkBuildMicromapFlagsEXT() {
 
 #if defined(VK_EXT_opacity_micromap)
 TypeDeclPtr makeVkFlags_VkMicromapCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMicromapCreateFlagsEXT";
     ft->argNames = { "device_address_capture_replay_ext" };
     return ft;
@@ -779,7 +779,7 @@ TypeDeclPtr makeVkFlags_VkMicromapCreateFlagsEXT() {
 
 #if defined(VK_EXT_device_generated_commands)
 TypeDeclPtr makeVkFlags_VkIndirectCommandsLayoutUsageFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkIndirectCommandsLayoutUsageFlagsEXT";
     ft->argNames = { "explicit_preprocess_ext", "unordered_sequences_ext" };
     return ft;
@@ -788,7 +788,7 @@ TypeDeclPtr makeVkFlags_VkIndirectCommandsLayoutUsageFlagsEXT() {
 
 #if defined(VK_EXT_device_generated_commands)
 TypeDeclPtr makeVkFlags_VkIndirectCommandsInputModeFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkIndirectCommandsInputModeFlagsEXT";
     ft->argNames = { "vulkan_index_buffer_ext", "dxgi_index_buffer_ext" };
     return ft;
@@ -797,7 +797,7 @@ TypeDeclPtr makeVkFlags_VkIndirectCommandsInputModeFlagsEXT() {
 
 #if defined(VK_LUNARG_direct_driver_loading)
 TypeDeclPtr makeVkFlags_VkDirectDriverLoadingFlagsLUNARG() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDirectDriverLoadingFlagsLUNARG";
     return ft;
 }
@@ -805,7 +805,7 @@ TypeDeclPtr makeVkFlags_VkDirectDriverLoadingFlagsLUNARG() {
 
 #if defined(VK_VERSION_1_4)
 TypeDeclPtr makeVkFlags_VkPipelineCreateFlags2() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkPipelineCreateFlags2";
     ft->argNames = { "disable_optimization", "allow_derivatives", "derivative", "view_index_from_device_index", "dispatch_base", "defer_compile_nv", "capture_statistics_khr", "capture_internal_representations_khr", "fail_on_pipeline_compile_required", "early_return_on_failure", "link_time_optimization_ext", "library_khr", "ray_tracing_skip_triangles_khr", "ray_tracing_skip_aabbs_khr", "ray_tracing_no_null_any_hit_shaders_khr", "ray_tracing_no_null_closest_hit_shaders_khr", "ray_tracing_no_null_miss_shaders_khr", "ray_tracing_no_null_intersection_shaders_khr", "indirect_bindable_nv", "ray_tracing_shader_group_handle_capture_replay_khr", "ray_tracing_allow_motion_nv", "rendering_fragment_shading_rate_attachment_khr", "rendering_fragment_density_map_attachment_ext", "retain_link_time_optimization_info_ext", "ray_tracing_opacity_micromap_ext", "color_attachment_feedback_loop_ext", "depth_stencil_attachment_feedback_loop_ext", "no_protected_access", "ray_tracing_displacement_micromap_nv", "descriptor_buffer_ext", "protected_access_only", "capture_data_khr", "execution_graph_amdx", "ray_tracing_allow_spheres_and_linear_swept_spheres_nv", "enable_legacy_dithering_ext", "_b35", "descriptor_heap_ext", "disallow_opacity_micromap_arm", "indirect_bindable_ext", "instrument_shaders_arm", "per_layer_fragment_density_valve", "_b41", "_b42", "_64_indexing_ext" };
     return ft;
@@ -814,7 +814,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCreateFlags2() {
 
 #if defined(VK_VERSION_1_4)
 TypeDeclPtr makeVkFlags_VkBufferUsageFlags2() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkBufferUsageFlags2";
     ft->argNames = { "transfer_src", "transfer_dst", "uniform_texel_buffer", "storage_texel_buffer", "uniform_buffer", "storage_buffer", "index_buffer", "vertex_buffer", "indirect_buffer", "conditional_rendering_ext", "shader_binding_table_khr", "transform_feedback_buffer_ext", "transform_feedback_counter_buffer_ext", "video_decode_src_khr", "video_decode_dst_khr", "video_encode_dst_khr", "video_encode_src_khr", "shader_device_address", "_b18", "acceleration_structure_build_input_read_only_khr", "acceleration_structure_storage_khr", "sampler_descriptor_buffer_ext", "resource_descriptor_buffer_ext", "micromap_build_input_read_only_ext", "micromap_storage_ext", "execution_graph_scratch_amdx", "push_descriptors_descriptor_buffer_ext", "tile_memory_qcom", "descriptor_heap_ext", "data_graph_foreign_descriptor_arm", "_b30", "preprocess_buffer_ext", "memory_decompression_ext", "compressed_data_dgf1_amdx" };
     return ft;
@@ -823,7 +823,7 @@ TypeDeclPtr makeVkFlags_VkBufferUsageFlags2() {
 
 #if defined(VK_KHR_copy_memory_indirect)
 TypeDeclPtr makeVkFlags_VkAddressCopyFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAddressCopyFlagsKHR";
     ft->argNames = { "device_local_khr", "sparse_khr", "protected_khr" };
     return ft;
@@ -832,7 +832,7 @@ TypeDeclPtr makeVkFlags_VkAddressCopyFlagsKHR() {
 
 #if defined(VK_ARM_tensors)
 TypeDeclPtr makeVkFlags_VkTensorCreateFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkTensorCreateFlagsARM";
     ft->argNames = { "mutable_format_arm", "protected_arm", "descriptor_buffer_capture_replay_arm", "descriptor_heap_capture_replay_arm" };
     return ft;
@@ -841,7 +841,7 @@ TypeDeclPtr makeVkFlags_VkTensorCreateFlagsARM() {
 
 #if defined(VK_ARM_tensors)
 TypeDeclPtr makeVkFlags_VkTensorUsageFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkTensorUsageFlagsARM";
     ft->argNames = { "_b0", "shader_arm", "transfer_src_arm", "transfer_dst_arm", "image_aliasing_arm", "data_graph_arm" };
     return ft;
@@ -850,7 +850,7 @@ TypeDeclPtr makeVkFlags_VkTensorUsageFlagsARM() {
 
 #if defined(VK_EXT_descriptor_heap)
 TypeDeclPtr makeVkFlags_VkTensorViewCreateFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkTensorViewCreateFlagsARM";
     ft->argNames = { "descriptor_buffer_capture_replay_arm" };
     return ft;
@@ -859,7 +859,7 @@ TypeDeclPtr makeVkFlags_VkTensorViewCreateFlagsARM() {
 
 #if defined(VK_ARM_data_graph)
 TypeDeclPtr makeVkFlags_VkDataGraphPipelineSessionCreateFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkDataGraphPipelineSessionCreateFlagsARM";
     ft->argNames = { "protected_arm", "optical_flow_cache_arm" };
     return ft;
@@ -868,7 +868,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphPipelineSessionCreateFlagsARM() {
 
 #if defined(VK_ARM_data_graph)
 TypeDeclPtr makeVkFlags_VkDataGraphPipelineDispatchFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkDataGraphPipelineDispatchFlagsARM";
     return ft;
 }
@@ -876,7 +876,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphPipelineDispatchFlagsARM() {
 
 #if defined(VK_VALVE_video_encode_rgb_conversion)
 TypeDeclPtr makeVkFlags_VkVideoEncodeRgbModelConversionFlagsVALVE() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeRgbModelConversionFlagsVALVE";
     ft->argNames = { "rgb_identity_valve", "ycbcr_identity_valve", "ycbcr_709_valve", "ycbcr_601_valve", "ycbcr_2020_valve" };
     return ft;
@@ -885,7 +885,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeRgbModelConversionFlagsVALVE() {
 
 #if defined(VK_VALVE_video_encode_rgb_conversion)
 TypeDeclPtr makeVkFlags_VkVideoEncodeRgbRangeCompressionFlagsVALVE() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeRgbRangeCompressionFlagsVALVE";
     ft->argNames = { "full_range_valve", "narrow_range_valve" };
     return ft;
@@ -894,7 +894,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeRgbRangeCompressionFlagsVALVE() {
 
 #if defined(VK_VALVE_video_encode_rgb_conversion)
 TypeDeclPtr makeVkFlags_VkVideoEncodeRgbChromaOffsetFlagsVALVE() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeRgbChromaOffsetFlagsVALVE";
     ft->argNames = { "cosited_even_valve", "midpoint_valve" };
     return ft;
@@ -903,7 +903,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeRgbChromaOffsetFlagsVALVE() {
 
 #if defined(VK_EXT_descriptor_heap)
 TypeDeclPtr makeVkFlags_VkSpirvResourceTypeFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSpirvResourceTypeFlagsEXT";
     ft->argNames = { "sampler_ext", "sampled_image_ext", "read_only_image_ext", "read_write_image_ext", "combined_sampled_image_ext", "uniform_buffer_ext", "read_only_storage_buffer_ext", "read_write_storage_buffer_ext", "acceleration_structure_ext", "tensor_arm" };
     return ft;
@@ -912,7 +912,7 @@ TypeDeclPtr makeVkFlags_VkSpirvResourceTypeFlagsEXT() {
 
 #if defined(VK_KHR_device_address_commands)
 TypeDeclPtr makeVkFlags_VkAddressCommandFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkAddressCommandFlagsKHR";
     ft->argNames = { "protected_khr", "fully_bound_khr", "storage_buffer_usage_khr", "unknown_storage_buffer_usage_khr", "transform_feedback_buffer_usage_khr", "unknown_transform_feedback_buffer_usage_khr" };
     return ft;
@@ -921,7 +921,7 @@ TypeDeclPtr makeVkFlags_VkAddressCommandFlagsKHR() {
 
 #if defined(VK_KHR_surface)
 TypeDeclPtr makeVkFlags_VkCompositeAlphaFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCompositeAlphaFlagsKHR";
     ft->argNames = { "opaque_khr", "pre_multiplied_khr", "post_multiplied_khr", "inherit_khr" };
     return ft;
@@ -930,7 +930,7 @@ TypeDeclPtr makeVkFlags_VkCompositeAlphaFlagsKHR() {
 
 #if defined(VK_KHR_display)
 TypeDeclPtr makeVkFlags_VkDisplayPlaneAlphaFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDisplayPlaneAlphaFlagsKHR";
     ft->argNames = { "opaque_khr", "global_khr", "per_pixel_khr", "per_pixel_premultiplied_khr" };
     return ft;
@@ -939,7 +939,7 @@ TypeDeclPtr makeVkFlags_VkDisplayPlaneAlphaFlagsKHR() {
 
 #if defined(VK_KHR_surface)
 TypeDeclPtr makeVkFlags_VkSurfaceTransformFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSurfaceTransformFlagsKHR";
     ft->argNames = { "identity_khr", "rotate_90_khr", "rotate_180_khr", "rotate_270_khr", "horizontal_mirror_khr", "horizontal_mirror_rotate_90_khr", "horizontal_mirror_rotate_180_khr", "horizontal_mirror_rotate_270_khr", "inherit_khr" };
     return ft;
@@ -948,7 +948,7 @@ TypeDeclPtr makeVkFlags_VkSurfaceTransformFlagsKHR() {
 
 #if defined(VK_KHR_swapchain)
 TypeDeclPtr makeVkFlags_VkSwapchainCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSwapchainCreateFlagsKHR";
     ft->argNames = { "split_instance_bind_regions_khr", "protected_khr", "mutable_format_khr", "deferred_memory_allocation_khr", "_b4", "_b5", "present_id_2_khr", "present_wait_2_khr", "_b8", "present_timing_ext" };
     return ft;
@@ -957,7 +957,7 @@ TypeDeclPtr makeVkFlags_VkSwapchainCreateFlagsKHR() {
 
 #if defined(VK_KHR_display)
 TypeDeclPtr makeVkFlags_VkDisplayModeCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDisplayModeCreateFlagsKHR";
     return ft;
 }
@@ -965,7 +965,7 @@ TypeDeclPtr makeVkFlags_VkDisplayModeCreateFlagsKHR() {
 
 #if defined(VK_KHR_display)
 TypeDeclPtr makeVkFlags_VkDisplaySurfaceCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDisplaySurfaceCreateFlagsKHR";
     return ft;
 }
@@ -973,7 +973,7 @@ TypeDeclPtr makeVkFlags_VkDisplaySurfaceCreateFlagsKHR() {
 
 #if defined(VK_KHR_wayland_surface) && defined(VK_USE_PLATFORM_WAYLAND_KHR)
 TypeDeclPtr makeVkFlags_VkWaylandSurfaceCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkWaylandSurfaceCreateFlagsKHR";
     return ft;
 }
@@ -981,7 +981,7 @@ TypeDeclPtr makeVkFlags_VkWaylandSurfaceCreateFlagsKHR() {
 
 #if defined(VK_KHR_win32_surface) && defined(VK_USE_PLATFORM_WIN32_KHR)
 TypeDeclPtr makeVkFlags_VkWin32SurfaceCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkWin32SurfaceCreateFlagsKHR";
     return ft;
 }
@@ -989,7 +989,7 @@ TypeDeclPtr makeVkFlags_VkWin32SurfaceCreateFlagsKHR() {
 
 #if defined(VK_KHR_xlib_surface) && defined(VK_USE_PLATFORM_XLIB_KHR)
 TypeDeclPtr makeVkFlags_VkXlibSurfaceCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkXlibSurfaceCreateFlagsKHR";
     return ft;
 }
@@ -997,7 +997,7 @@ TypeDeclPtr makeVkFlags_VkXlibSurfaceCreateFlagsKHR() {
 
 #if defined(VK_EXT_metal_surface) && defined(VK_USE_PLATFORM_METAL_EXT)
 TypeDeclPtr makeVkFlags_VkMetalSurfaceCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMetalSurfaceCreateFlagsEXT";
     return ft;
 }
@@ -1005,7 +1005,7 @@ TypeDeclPtr makeVkFlags_VkMetalSurfaceCreateFlagsEXT() {
 
 #if defined(VK_EXT_headless_surface)
 TypeDeclPtr makeVkFlags_VkHeadlessSurfaceCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkHeadlessSurfaceCreateFlagsEXT";
     return ft;
 }
@@ -1013,7 +1013,7 @@ TypeDeclPtr makeVkFlags_VkHeadlessSurfaceCreateFlagsEXT() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkPeerMemoryFeatureFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPeerMemoryFeatureFlags";
     ft->argNames = { "copy_src", "copy_dst", "generic_src", "generic_dst" };
     return ft;
@@ -1022,7 +1022,7 @@ TypeDeclPtr makeVkFlags_VkPeerMemoryFeatureFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkMemoryAllocateFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkMemoryAllocateFlags";
     ft->argNames = { "device_mask", "device_address", "device_address_capture_replay", "zero_initialize_ext" };
     return ft;
@@ -1031,7 +1031,7 @@ TypeDeclPtr makeVkFlags_VkMemoryAllocateFlags() {
 
 #if defined(VK_KHR_swapchain)
 TypeDeclPtr makeVkFlags_VkDeviceGroupPresentModeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceGroupPresentModeFlagsKHR";
     ft->argNames = { "local_khr", "remote_khr", "sum_khr", "local_multi_device_khr" };
     return ft;
@@ -1040,7 +1040,7 @@ TypeDeclPtr makeVkFlags_VkDeviceGroupPresentModeFlagsKHR() {
 
 #if defined(VK_EXT_debug_report)
 TypeDeclPtr makeVkFlags_VkDebugReportFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDebugReportFlagsEXT";
     ft->argNames = { "information_ext", "warning_ext", "performance_warning_ext", "error_ext", "debug_ext" };
     return ft;
@@ -1049,7 +1049,7 @@ TypeDeclPtr makeVkFlags_VkDebugReportFlagsEXT() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkCommandPoolTrimFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkCommandPoolTrimFlags";
     return ft;
 }
@@ -1057,7 +1057,7 @@ TypeDeclPtr makeVkFlags_VkCommandPoolTrimFlags() {
 
 #if defined(VK_NV_external_memory_capabilities)
 TypeDeclPtr makeVkFlags_VkExternalMemoryHandleTypeFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalMemoryHandleTypeFlagsNV";
     ft->argNames = { "opaque_win32_nv", "opaque_win32_kmt_nv", "d3d11_image_nv", "d3d11_image_kmt_nv" };
     return ft;
@@ -1066,7 +1066,7 @@ TypeDeclPtr makeVkFlags_VkExternalMemoryHandleTypeFlagsNV() {
 
 #if defined(VK_NV_cluster_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureIndexFormatFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkClusterAccelerationStructureIndexFormatFlagsNV";
     ft->argNames = { "_8bit_nv", "_16bit_nv", "_32bit_nv" };
     return ft;
@@ -1075,7 +1075,7 @@ TypeDeclPtr makeVkFlags_VkClusterAccelerationStructureIndexFormatFlagsNV() {
 
 #if defined(VK_NV_external_memory_capabilities)
 TypeDeclPtr makeVkFlags_VkExternalMemoryFeatureFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalMemoryFeatureFlagsNV";
     ft->argNames = { "dedicated_only_nv", "exportable_nv", "importable_nv" };
     return ft;
@@ -1084,7 +1084,7 @@ TypeDeclPtr makeVkFlags_VkExternalMemoryFeatureFlagsNV() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkExternalMemoryHandleTypeFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalMemoryHandleTypeFlags";
     ft->argNames = { "opaque_fd", "opaque_win32", "opaque_win32_kmt", "d3d11_texture", "d3d11_texture_kmt", "d3d12_heap", "d3d12_resource", "host_allocation_ext", "host_mapped_foreign_memory_ext", "dma_buf_ext", "android_hardware_buffer_android", "zircon_vmo_fuchsia", "rdma_address_nv", "_b13", "screen_buffer_qnx", "oh_native_buffer_ohos", "mtlbuffer_ext", "mtltexture_ext", "mtlheap_ext" };
     return ft;
@@ -1093,7 +1093,7 @@ TypeDeclPtr makeVkFlags_VkExternalMemoryHandleTypeFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkExternalMemoryFeatureFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalMemoryFeatureFlags";
     ft->argNames = { "dedicated_only", "exportable", "importable" };
     return ft;
@@ -1102,7 +1102,7 @@ TypeDeclPtr makeVkFlags_VkExternalMemoryFeatureFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkExternalSemaphoreHandleTypeFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalSemaphoreHandleTypeFlags";
     ft->argNames = { "opaque_fd", "opaque_win32", "opaque_win32_kmt", "d3d12_fence", "sync_fd", "_b5", "_b6", "zircon_event_fuchsia" };
     return ft;
@@ -1111,7 +1111,7 @@ TypeDeclPtr makeVkFlags_VkExternalSemaphoreHandleTypeFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkExternalSemaphoreFeatureFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalSemaphoreFeatureFlags";
     ft->argNames = { "exportable", "importable" };
     return ft;
@@ -1120,7 +1120,7 @@ TypeDeclPtr makeVkFlags_VkExternalSemaphoreFeatureFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkSemaphoreImportFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSemaphoreImportFlags";
     ft->argNames = { "temporary" };
     return ft;
@@ -1129,7 +1129,7 @@ TypeDeclPtr makeVkFlags_VkSemaphoreImportFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkExternalFenceHandleTypeFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalFenceHandleTypeFlags";
     ft->argNames = { "opaque_fd", "opaque_win32", "opaque_win32_kmt", "sync_fd" };
     return ft;
@@ -1138,7 +1138,7 @@ TypeDeclPtr makeVkFlags_VkExternalFenceHandleTypeFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkExternalFenceFeatureFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExternalFenceFeatureFlags";
     ft->argNames = { "exportable", "importable" };
     return ft;
@@ -1147,7 +1147,7 @@ TypeDeclPtr makeVkFlags_VkExternalFenceFeatureFlags() {
 
 #if defined(VK_VERSION_1_1)
 TypeDeclPtr makeVkFlags_VkFenceImportFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkFenceImportFlags";
     ft->argNames = { "temporary" };
     return ft;
@@ -1156,7 +1156,7 @@ TypeDeclPtr makeVkFlags_VkFenceImportFlags() {
 
 #if defined(VK_EXT_display_surface_counter)
 TypeDeclPtr makeVkFlags_VkSurfaceCounterFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSurfaceCounterFlagsEXT";
     ft->argNames = { "vblank_ext" };
     return ft;
@@ -1165,7 +1165,7 @@ TypeDeclPtr makeVkFlags_VkSurfaceCounterFlagsEXT() {
 
 #if defined(VK_NV_viewport_swizzle)
 TypeDeclPtr makeVkFlags_VkPipelineViewportSwizzleStateCreateFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineViewportSwizzleStateCreateFlagsNV";
     return ft;
 }
@@ -1173,7 +1173,7 @@ TypeDeclPtr makeVkFlags_VkPipelineViewportSwizzleStateCreateFlagsNV() {
 
 #if defined(VK_EXT_discard_rectangles)
 TypeDeclPtr makeVkFlags_VkPipelineDiscardRectangleStateCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineDiscardRectangleStateCreateFlagsEXT";
     return ft;
 }
@@ -1181,7 +1181,7 @@ TypeDeclPtr makeVkFlags_VkPipelineDiscardRectangleStateCreateFlagsEXT() {
 
 #if defined(VK_NV_fragment_coverage_to_color)
 TypeDeclPtr makeVkFlags_VkPipelineCoverageToColorStateCreateFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCoverageToColorStateCreateFlagsNV";
     return ft;
 }
@@ -1189,7 +1189,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCoverageToColorStateCreateFlagsNV() {
 
 #if defined(VK_NV_framebuffer_mixed_samples)
 TypeDeclPtr makeVkFlags_VkPipelineCoverageModulationStateCreateFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCoverageModulationStateCreateFlagsNV";
     return ft;
 }
@@ -1197,7 +1197,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCoverageModulationStateCreateFlagsNV() {
 
 #if defined(VK_NV_coverage_reduction_mode)
 TypeDeclPtr makeVkFlags_VkPipelineCoverageReductionStateCreateFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineCoverageReductionStateCreateFlagsNV";
     return ft;
 }
@@ -1205,7 +1205,7 @@ TypeDeclPtr makeVkFlags_VkPipelineCoverageReductionStateCreateFlagsNV() {
 
 #if defined(VK_EXT_validation_cache)
 TypeDeclPtr makeVkFlags_VkValidationCacheCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkValidationCacheCreateFlagsEXT";
     return ft;
 }
@@ -1213,7 +1213,7 @@ TypeDeclPtr makeVkFlags_VkValidationCacheCreateFlagsEXT() {
 
 #if defined(VK_EXT_debug_utils)
 TypeDeclPtr makeVkFlags_VkDebugUtilsMessageSeverityFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDebugUtilsMessageSeverityFlagsEXT";
     ft->argNames = { "verbose_ext", "_b1", "_b2", "_b3", "info_ext", "_b5", "_b6", "_b7", "warning_ext", "_b9", "_b10", "_b11", "error_ext" };
     return ft;
@@ -1222,7 +1222,7 @@ TypeDeclPtr makeVkFlags_VkDebugUtilsMessageSeverityFlagsEXT() {
 
 #if defined(VK_EXT_debug_utils)
 TypeDeclPtr makeVkFlags_VkDebugUtilsMessageTypeFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDebugUtilsMessageTypeFlagsEXT";
     ft->argNames = { "general_ext", "validation_ext", "performance_ext", "device_address_binding_ext" };
     return ft;
@@ -1231,7 +1231,7 @@ TypeDeclPtr makeVkFlags_VkDebugUtilsMessageTypeFlagsEXT() {
 
 #if defined(VK_EXT_debug_utils)
 TypeDeclPtr makeVkFlags_VkDebugUtilsMessengerCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDebugUtilsMessengerCreateFlagsEXT";
     return ft;
 }
@@ -1239,7 +1239,7 @@ TypeDeclPtr makeVkFlags_VkDebugUtilsMessengerCreateFlagsEXT() {
 
 #if defined(VK_EXT_debug_utils)
 TypeDeclPtr makeVkFlags_VkDebugUtilsMessengerCallbackDataFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDebugUtilsMessengerCallbackDataFlagsEXT";
     return ft;
 }
@@ -1247,7 +1247,7 @@ TypeDeclPtr makeVkFlags_VkDebugUtilsMessengerCallbackDataFlagsEXT() {
 
 #if defined(VK_EXT_device_memory_report)
 TypeDeclPtr makeVkFlags_VkDeviceMemoryReportFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceMemoryReportFlagsEXT";
     return ft;
 }
@@ -1255,7 +1255,7 @@ TypeDeclPtr makeVkFlags_VkDeviceMemoryReportFlagsEXT() {
 
 #if defined(VK_EXT_conservative_rasterization)
 TypeDeclPtr makeVkFlags_VkPipelineRasterizationConservativeStateCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineRasterizationConservativeStateCreateFlagsEXT";
     return ft;
 }
@@ -1263,7 +1263,7 @@ TypeDeclPtr makeVkFlags_VkPipelineRasterizationConservativeStateCreateFlagsEXT()
 
 #if defined(VK_VERSION_1_2)
 TypeDeclPtr makeVkFlags_VkDescriptorBindingFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDescriptorBindingFlags";
     ft->argNames = { "update_after_bind", "update_unused_while_pending", "partially_bound", "variable_descriptor_count" };
     return ft;
@@ -1272,7 +1272,7 @@ TypeDeclPtr makeVkFlags_VkDescriptorBindingFlags() {
 
 #if defined(VK_EXT_conditional_rendering)
 TypeDeclPtr makeVkFlags_VkConditionalRenderingFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkConditionalRenderingFlagsEXT";
     ft->argNames = { "inverted_ext" };
     return ft;
@@ -1281,7 +1281,7 @@ TypeDeclPtr makeVkFlags_VkConditionalRenderingFlagsEXT() {
 
 #if defined(VK_VERSION_1_2)
 TypeDeclPtr makeVkFlags_VkResolveModeFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkResolveModeFlags";
     ft->argNames = { "sample_zero", "average", "min", "max", "external_format_downsample_android", "custom_ext" };
     return ft;
@@ -1290,7 +1290,7 @@ TypeDeclPtr makeVkFlags_VkResolveModeFlags() {
 
 #if defined(VK_EXT_transform_feedback)
 TypeDeclPtr makeVkFlags_VkPipelineRasterizationStateStreamCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineRasterizationStateStreamCreateFlagsEXT";
     return ft;
 }
@@ -1298,7 +1298,7 @@ TypeDeclPtr makeVkFlags_VkPipelineRasterizationStateStreamCreateFlagsEXT() {
 
 #if defined(VK_EXT_depth_clip_enable)
 TypeDeclPtr makeVkFlags_VkPipelineRasterizationDepthClipStateCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPipelineRasterizationDepthClipStateCreateFlagsEXT";
     return ft;
 }
@@ -1306,7 +1306,7 @@ TypeDeclPtr makeVkFlags_VkPipelineRasterizationDepthClipStateCreateFlagsEXT() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkToolPurposeFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkToolPurposeFlags";
     ft->argNames = { "validation", "profiling", "tracing", "additional_features", "modifying_features", "debug_reporting_ext", "debug_markers_ext" };
     return ft;
@@ -1315,7 +1315,7 @@ TypeDeclPtr makeVkFlags_VkToolPurposeFlags() {
 
 #if defined(VK_VERSION_1_3)
 TypeDeclPtr makeVkFlags_VkSubmitFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkSubmitFlags";
     ft->argNames = { "protected" };
     return ft;
@@ -1324,7 +1324,7 @@ TypeDeclPtr makeVkFlags_VkSubmitFlags() {
 
 #if defined(VK_VERSION_1_4)
 TypeDeclPtr makeVkFlags_VkHostImageCopyFlags() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkHostImageCopyFlags";
     ft->argNames = { "memcpy" };
     return ft;
@@ -1333,7 +1333,7 @@ TypeDeclPtr makeVkFlags_VkHostImageCopyFlags() {
 
 #if defined(VK_NV_partitioned_acceleration_structure)
 TypeDeclPtr makeVkFlags_VkPartitionedAccelerationStructureInstanceFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPartitionedAccelerationStructureInstanceFlagsNV";
     ft->argNames = { "flag_triangle_facing_cull_disable_nv", "flag_triangle_flip_facing_nv", "flag_force_opaque_nv", "flag_force_no_opaque_nv", "flag_enable_explicit_bounding_box_nv" };
     return ft;
@@ -1342,7 +1342,7 @@ TypeDeclPtr makeVkFlags_VkPartitionedAccelerationStructureInstanceFlagsNV() {
 
 #if defined(VK_EXT_graphics_pipeline_library)
 TypeDeclPtr makeVkFlags_VkGraphicsPipelineLibraryFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkGraphicsPipelineLibraryFlagsEXT";
     ft->argNames = { "vertex_input_interface_ext", "pre_rasterization_shaders_ext", "fragment_shader_ext", "fragment_output_interface_ext" };
     return ft;
@@ -1351,7 +1351,7 @@ TypeDeclPtr makeVkFlags_VkGraphicsPipelineLibraryFlagsEXT() {
 
 #if defined(VK_EXT_image_compression_control)
 TypeDeclPtr makeVkFlags_VkImageCompressionFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkImageCompressionFlagsEXT";
     ft->argNames = { "fixed_rate_default_ext", "fixed_rate_explicit_ext", "disabled_ext" };
     return ft;
@@ -1360,7 +1360,7 @@ TypeDeclPtr makeVkFlags_VkImageCompressionFlagsEXT() {
 
 #if defined(VK_EXT_image_compression_control)
 TypeDeclPtr makeVkFlags_VkImageCompressionFixedRateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkImageCompressionFixedRateFlagsEXT";
     ft->argNames = { "_1bpc_ext", "_2bpc_ext", "_3bpc_ext", "_4bpc_ext", "_5bpc_ext", "_6bpc_ext", "_7bpc_ext", "_8bpc_ext", "_9bpc_ext", "_10bpc_ext", "_11bpc_ext", "_12bpc_ext", "_13bpc_ext", "_14bpc_ext", "_15bpc_ext", "_16bpc_ext", "_17bpc_ext", "_18bpc_ext", "_19bpc_ext", "_20bpc_ext", "_21bpc_ext", "_22bpc_ext", "_23bpc_ext", "_24bpc_ext" };
     return ft;
@@ -1369,7 +1369,7 @@ TypeDeclPtr makeVkFlags_VkImageCompressionFixedRateFlagsEXT() {
 
 #if defined(VK_EXT_metal_objects) && defined(VK_USE_PLATFORM_METAL_EXT)
 TypeDeclPtr makeVkFlags_VkExportMetalObjectTypeFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkExportMetalObjectTypeFlagsEXT";
     ft->argNames = { "metal_device_ext", "metal_command_queue_ext", "metal_buffer_ext", "metal_texture_ext", "metal_iosurface_ext", "metal_shared_event_ext" };
     return ft;
@@ -1378,7 +1378,7 @@ TypeDeclPtr makeVkFlags_VkExportMetalObjectTypeFlagsEXT() {
 
 #if defined(VK_KHR_maintenance10)
 TypeDeclPtr makeVkFlags_VkRenderingAttachmentFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkRenderingAttachmentFlagsKHR";
     ft->argNames = { "input_attachment_feedback_khr", "resolve_skip_transfer_function_khr", "resolve_enable_transfer_function_khr" };
     return ft;
@@ -1387,7 +1387,7 @@ TypeDeclPtr makeVkFlags_VkRenderingAttachmentFlagsKHR() {
 
 #if defined(VK_KHR_maintenance10)
 TypeDeclPtr makeVkFlags_VkResolveImageFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkResolveImageFlagsKHR";
     ft->argNames = { "skip_transfer_function_khr", "enable_transfer_function_khr" };
     return ft;
@@ -1396,7 +1396,7 @@ TypeDeclPtr makeVkFlags_VkResolveImageFlagsKHR() {
 
 #if defined(VK_EXT_device_address_binding_report)
 TypeDeclPtr makeVkFlags_VkDeviceAddressBindingFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDeviceAddressBindingFlagsEXT";
     ft->argNames = { "internal_object_ext" };
     return ft;
@@ -1405,7 +1405,7 @@ TypeDeclPtr makeVkFlags_VkDeviceAddressBindingFlagsEXT() {
 
 #if defined(VK_NV_optical_flow)
 TypeDeclPtr makeVkFlags_VkOpticalFlowGridSizeFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkOpticalFlowGridSizeFlagsNV";
     ft->argNames = { "_1x1_nv", "_2x2_nv", "_4x4_nv", "_8x8_nv" };
     return ft;
@@ -1414,7 +1414,7 @@ TypeDeclPtr makeVkFlags_VkOpticalFlowGridSizeFlagsNV() {
 
 #if defined(VK_NV_optical_flow)
 TypeDeclPtr makeVkFlags_VkOpticalFlowUsageFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkOpticalFlowUsageFlagsNV";
     ft->argNames = { "input_nv", "output_nv", "hint_nv", "cost_nv", "global_flow_nv" };
     return ft;
@@ -1423,7 +1423,7 @@ TypeDeclPtr makeVkFlags_VkOpticalFlowUsageFlagsNV() {
 
 #if defined(VK_NV_optical_flow)
 TypeDeclPtr makeVkFlags_VkOpticalFlowSessionCreateFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkOpticalFlowSessionCreateFlagsNV";
     ft->argNames = { "enable_hint_nv", "enable_cost_nv", "enable_global_flow_nv", "allow_regions_nv", "both_directions_nv" };
     return ft;
@@ -1432,7 +1432,7 @@ TypeDeclPtr makeVkFlags_VkOpticalFlowSessionCreateFlagsNV() {
 
 #if defined(VK_NV_optical_flow)
 TypeDeclPtr makeVkFlags_VkOpticalFlowExecuteFlagsNV() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkOpticalFlowExecuteFlagsNV";
     ft->argNames = { "disable_temporal_hints_nv" };
     return ft;
@@ -1441,7 +1441,7 @@ TypeDeclPtr makeVkFlags_VkOpticalFlowExecuteFlagsNV() {
 
 #if defined(VK_EXT_frame_boundary)
 TypeDeclPtr makeVkFlags_VkFrameBoundaryFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkFrameBoundaryFlagsEXT";
     ft->argNames = { "frame_end_ext" };
     return ft;
@@ -1450,7 +1450,7 @@ TypeDeclPtr makeVkFlags_VkFrameBoundaryFlagsEXT() {
 
 #if defined(VK_KHR_surface_maintenance1)
 TypeDeclPtr makeVkFlags_VkPresentScalingFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPresentScalingFlagsKHR";
     ft->argNames = { "one_to_one_khr", "aspect_ratio_stretch_khr", "stretch_khr" };
     return ft;
@@ -1459,7 +1459,7 @@ TypeDeclPtr makeVkFlags_VkPresentScalingFlagsKHR() {
 
 #if defined(VK_KHR_surface_maintenance1)
 TypeDeclPtr makeVkFlags_VkPresentGravityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPresentGravityFlagsKHR";
     ft->argNames = { "min_khr", "max_khr", "centered_khr" };
     return ft;
@@ -1468,7 +1468,7 @@ TypeDeclPtr makeVkFlags_VkPresentGravityFlagsKHR() {
 
 #if defined(VK_EXT_shader_object)
 TypeDeclPtr makeVkFlags_VkShaderCreateFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkShaderCreateFlagsEXT";
     ft->argNames = { "link_stage_ext", "allow_varying_subgroup_size_ext", "require_full_subgroups_ext", "no_task_shader_ext", "dispatch_base_ext", "fragment_shading_rate_attachment_ext", "fragment_density_map_attachment_ext", "indirect_bindable_ext", "_b8", "_b9", "descriptor_heap_ext", "instrument_shader_arm", "_b12", "_b13", "_b14", "_64_indexing_ext", "_b16", "_b17", "independent_sets_khr" };
     return ft;
@@ -1477,7 +1477,7 @@ TypeDeclPtr makeVkFlags_VkShaderCreateFlagsEXT() {
 
 #if defined(VK_QCOM_tile_shading)
 TypeDeclPtr makeVkFlags_VkTileShadingRenderPassFlagsQCOM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkTileShadingRenderPassFlagsQCOM";
     ft->argNames = { "enable_qcom", "per_tile_execution_qcom" };
     return ft;
@@ -1486,7 +1486,7 @@ TypeDeclPtr makeVkFlags_VkTileShadingRenderPassFlagsQCOM() {
 
 #if defined(VK_ARM_scheduling_controls)
 TypeDeclPtr makeVkFlags_VkPhysicalDeviceSchedulingControlsFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkPhysicalDeviceSchedulingControlsFlagsARM";
     ft->argNames = { "shader_core_count_arm", "dispatch_parameters_arm" };
     return ft;
@@ -1495,7 +1495,7 @@ TypeDeclPtr makeVkFlags_VkPhysicalDeviceSchedulingControlsFlagsARM() {
 
 #if defined(VK_EXT_present_timing)
 TypeDeclPtr makeVkFlags_VkPresentStageFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPresentStageFlagsEXT";
     ft->argNames = { "queue_operations_end_ext", "request_dequeued_ext", "image_first_pixel_out_ext", "image_first_pixel_visible_ext" };
     return ft;
@@ -1504,7 +1504,7 @@ TypeDeclPtr makeVkFlags_VkPresentStageFlagsEXT() {
 
 #if defined(VK_EXT_present_timing)
 TypeDeclPtr makeVkFlags_VkPastPresentationTimingFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPastPresentationTimingFlagsEXT";
     ft->argNames = { "allow_partial_results_ext", "allow_out_of_order_results_ext" };
     return ft;
@@ -1513,7 +1513,7 @@ TypeDeclPtr makeVkFlags_VkPastPresentationTimingFlagsEXT() {
 
 #if defined(VK_EXT_present_timing)
 TypeDeclPtr makeVkFlags_VkPresentTimingInfoFlagsEXT() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPresentTimingInfoFlagsEXT";
     ft->argNames = { "present_at_relative_time_ext", "present_at_nearest_refresh_cycle_ext" };
     return ft;
@@ -1522,7 +1522,7 @@ TypeDeclPtr makeVkFlags_VkPresentTimingInfoFlagsEXT() {
 
 #if defined(VK_ARM_performance_counters_by_region)
 TypeDeclPtr makeVkFlags_VkPerformanceCounterDescriptionFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkPerformanceCounterDescriptionFlagsARM";
     return ft;
 }
@@ -1530,7 +1530,7 @@ TypeDeclPtr makeVkFlags_VkPerformanceCounterDescriptionFlagsARM() {
 
 #if defined(VK_ARM_shader_instrumentation)
 TypeDeclPtr makeVkFlags_VkShaderInstrumentationValuesFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkShaderInstrumentationValuesFlagsARM";
     return ft;
 }
@@ -1538,7 +1538,7 @@ TypeDeclPtr makeVkFlags_VkShaderInstrumentationValuesFlagsARM() {
 
 #if defined(VK_ARM_data_graph_instruction_set_tosa)
 TypeDeclPtr makeVkFlags_VkDataGraphTOSAQualityFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDataGraphTOSAQualityFlagsARM";
     ft->argNames = { "accelerated_arm", "conformant_arm", "experimental_arm", "deprecated_arm" };
     return ft;
@@ -1547,7 +1547,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphTOSAQualityFlagsARM() {
 
 #if defined(VK_ARM_data_graph_optical_flow)
 TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowGridSizeFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDataGraphOpticalFlowGridSizeFlagsARM";
     ft->argNames = { "_1x1_arm", "_2x2_arm", "_4x4_arm", "_8x8_arm" };
     return ft;
@@ -1556,7 +1556,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowGridSizeFlagsARM() {
 
 #if defined(VK_ARM_data_graph_optical_flow)
 TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowImageUsageFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDataGraphOpticalFlowImageUsageFlagsARM";
     ft->argNames = { "input_arm", "output_arm", "hint_arm", "cost_arm" };
     return ft;
@@ -1565,7 +1565,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowImageUsageFlagsARM() {
 
 #if defined(VK_ARM_data_graph_optical_flow)
 TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowCreateFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDataGraphOpticalFlowCreateFlagsARM";
     ft->argNames = { "enable_hint_arm", "enable_cost_arm", "_b2", "_b3", "_b4", "_b5", "_b6", "_b7", "_b8", "_b9", "_b10", "_b11", "_b12", "_b13", "_b14", "_b15", "_b16", "_b17", "_b18", "_b19", "_b20", "_b21", "_b22", "_b23", "_b24", "_b25", "_b26", "_b27", "_b28", "_b29", "reserved_30_arm" };
     return ft;
@@ -1574,7 +1574,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowCreateFlagsARM() {
 
 #if defined(VK_ARM_data_graph_optical_flow)
 TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowExecuteFlagsARM() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkDataGraphOpticalFlowExecuteFlagsARM";
     ft->argNames = { "disable_temporal_hints_arm", "input_unchanged_arm", "reference_unchanged_arm", "input_is_previous_reference_arm", "reference_is_previous_input_arm" };
     return ft;
@@ -1583,7 +1583,7 @@ TypeDeclPtr makeVkFlags_VkDataGraphOpticalFlowExecuteFlagsARM() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoCodecOperationFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoCodecOperationFlagsKHR";
     ft->argNames = { "decode_h264_khr", "decode_h265_khr", "decode_av1_khr", "decode_vp9_khr", "_b4", "_b5", "_b6", "_b7", "_b8", "_b9", "_b10", "_b11", "_b12", "_b13", "_b14", "_b15", "encode_h264_khr", "encode_h265_khr", "encode_av1_khr" };
     return ft;
@@ -1592,7 +1592,7 @@ TypeDeclPtr makeVkFlags_VkVideoCodecOperationFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoCapabilityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoCapabilityFlagsKHR";
     ft->argNames = { "protected_content_khr", "separate_reference_images_khr" };
     return ft;
@@ -1601,7 +1601,7 @@ TypeDeclPtr makeVkFlags_VkVideoCapabilityFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoSessionCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoSessionCreateFlagsKHR";
     ft->argNames = { "protected_content_khr", "allow_encode_parameter_optimizations_khr", "inline_queries_khr", "allow_encode_quantization_delta_map_khr", "allow_encode_emphasis_map_khr", "inline_session_parameters_khr" };
     return ft;
@@ -1610,7 +1610,7 @@ TypeDeclPtr makeVkFlags_VkVideoSessionCreateFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoSessionParametersCreateFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoSessionParametersCreateFlagsKHR";
     ft->argNames = { "quantization_map_compatible_khr" };
     return ft;
@@ -1619,7 +1619,7 @@ TypeDeclPtr makeVkFlags_VkVideoSessionParametersCreateFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoBeginCodingFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoBeginCodingFlagsKHR";
     return ft;
 }
@@ -1627,7 +1627,7 @@ TypeDeclPtr makeVkFlags_VkVideoBeginCodingFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoEndCodingFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEndCodingFlagsKHR";
     return ft;
 }
@@ -1635,7 +1635,7 @@ TypeDeclPtr makeVkFlags_VkVideoEndCodingFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoCodingControlFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoCodingControlFlagsKHR";
     ft->argNames = { "reset_khr", "encode_rate_control_khr", "encode_quality_level_khr" };
     return ft;
@@ -1644,7 +1644,7 @@ TypeDeclPtr makeVkFlags_VkVideoCodingControlFlagsKHR() {
 
 #if defined(VK_KHR_video_decode_queue)
 TypeDeclPtr makeVkFlags_VkVideoDecodeUsageFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoDecodeUsageFlagsKHR";
     ft->argNames = { "transcoding_khr", "offline_khr", "streaming_khr" };
     return ft;
@@ -1653,7 +1653,7 @@ TypeDeclPtr makeVkFlags_VkVideoDecodeUsageFlagsKHR() {
 
 #if defined(VK_KHR_video_decode_queue)
 TypeDeclPtr makeVkFlags_VkVideoDecodeCapabilityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoDecodeCapabilityFlagsKHR";
     ft->argNames = { "dpb_and_output_coincide_khr", "dpb_and_output_distinct_khr" };
     return ft;
@@ -1662,7 +1662,7 @@ TypeDeclPtr makeVkFlags_VkVideoDecodeCapabilityFlagsKHR() {
 
 #if defined(VK_KHR_video_decode_queue)
 TypeDeclPtr makeVkFlags_VkVideoDecodeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoDecodeFlagsKHR";
     return ft;
 }
@@ -1670,7 +1670,7 @@ TypeDeclPtr makeVkFlags_VkVideoDecodeFlagsKHR() {
 
 #if defined(VK_KHR_video_decode_h264)
 TypeDeclPtr makeVkFlags_VkVideoDecodeH264PictureLayoutFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoDecodeH264PictureLayoutFlagsKHR";
     ft->argNames = { "video_decode_h264_picture_layout_interlaced_interleaved_lines_khr", "video_decode_h264_picture_layout_interlaced_separate_planes_khr" };
     return ft;
@@ -1679,7 +1679,7 @@ TypeDeclPtr makeVkFlags_VkVideoDecodeH264PictureLayoutFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeFlagsKHR";
     ft->argNames = { "with_quantization_delta_map_khr", "with_emphasis_map_khr", "intra_refresh_khr" };
     return ft;
@@ -1688,7 +1688,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeUsageFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeUsageFlagsKHR";
     ft->argNames = { "transcoding_khr", "streaming_khr", "recording_khr", "conferencing_khr" };
     return ft;
@@ -1697,7 +1697,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeUsageFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeContentFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeContentFlagsKHR";
     ft->argNames = { "camera_khr", "desktop_khr", "rendered_khr" };
     return ft;
@@ -1706,7 +1706,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeContentFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeCapabilityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeCapabilityFlagsKHR";
     ft->argNames = { "preceding_externally_encoded_bytes_khr", "insufficient_bitstream_buffer_range_detection_khr", "quantization_delta_map_khr", "emphasis_map_khr" };
     return ft;
@@ -1715,7 +1715,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeCapabilityFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeFeedbackFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeFeedbackFlagsKHR";
     ft->argNames = { "bitstream_buffer_offset_khr", "bitstream_bytes_written_khr", "bitstream_has_overrides_khr" };
     return ft;
@@ -1724,7 +1724,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeFeedbackFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeRateControlFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeRateControlFlagsKHR";
     return ft;
 }
@@ -1732,7 +1732,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeRateControlFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_queue)
 TypeDeclPtr makeVkFlags_VkVideoEncodeRateControlModeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeRateControlModeFlagsKHR";
     ft->argNames = { "disabled_khr", "cbr_khr", "vbr_khr" };
     return ft;
@@ -1741,7 +1741,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeRateControlModeFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_intra_refresh)
 TypeDeclPtr makeVkFlags_VkVideoEncodeIntraRefreshModeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeIntraRefreshModeFlagsKHR";
     ft->argNames = { "per_picture_partition_khr", "block_based_khr", "block_row_based_khr", "block_column_based_khr" };
     return ft;
@@ -1750,7 +1750,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeIntraRefreshModeFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoChromaSubsamplingFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoChromaSubsamplingFlagsKHR";
     ft->argNames = { "monochrome_khr", "_420_khr", "_422_khr", "_444_khr" };
     return ft;
@@ -1759,7 +1759,7 @@ TypeDeclPtr makeVkFlags_VkVideoChromaSubsamplingFlagsKHR() {
 
 #if defined(VK_KHR_video_queue)
 TypeDeclPtr makeVkFlags_VkVideoComponentBitDepthFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoComponentBitDepthFlagsKHR";
     ft->argNames = { "_8_khr", "_b1", "_10_khr", "_b3", "_12_khr" };
     return ft;
@@ -1768,7 +1768,7 @@ TypeDeclPtr makeVkFlags_VkVideoComponentBitDepthFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h264)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH264CapabilityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH264CapabilityFlagsKHR";
     ft->argNames = { "video_encode_h264_capability_hrd_compliance_khr", "video_encode_h264_capability_prediction_weight_table_generated_khr", "video_encode_h264_capability_row_unaligned_slice_khr", "video_encode_h264_capability_different_slice_type_khr", "video_encode_h264_capability_b_frame_in_l0_list_khr", "video_encode_h264_capability_b_frame_in_l1_list_khr", "video_encode_h264_capability_per_picture_type_min_max_qp_khr", "video_encode_h264_capability_per_slice_constant_qp_khr", "video_encode_h264_capability_generate_prefix_nalu_khr", "video_encode_h264_capability_mb_qp_diff_wraparound_khr", "video_encode_h264_capability_b_picture_intra_refresh_khr" };
     return ft;
@@ -1777,7 +1777,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH264CapabilityFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h264)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH264StdFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH264StdFlagsKHR";
     ft->argNames = { "video_encode_h264_std_separate_color_plane_flag_set_khr", "video_encode_h264_std_qpprime_y_zero_transform_bypass_flag_set_khr", "video_encode_h264_std_scaling_matrix_present_flag_set_khr", "video_encode_h264_std_chroma_qp_index_offset_khr", "video_encode_h264_std_second_chroma_qp_index_offset_khr", "video_encode_h264_std_pic_init_qp_minus26_khr", "video_encode_h264_std_weighted_pred_flag_set_khr", "video_encode_h264_std_weighted_bipred_idc_explicit_khr", "video_encode_h264_std_weighted_bipred_idc_implicit_khr", "video_encode_h264_std_transform_8x8_mode_flag_set_khr", "video_encode_h264_std_direct_spatial_mv_pred_flag_unset_khr", "video_encode_h264_std_entropy_coding_mode_flag_unset_khr", "video_encode_h264_std_entropy_coding_mode_flag_set_khr", "video_encode_h264_std_direct_8x8_inference_flag_unset_khr", "video_encode_h264_std_constrained_intra_pred_flag_set_khr", "video_encode_h264_std_deblocking_filter_disabled_khr", "video_encode_h264_std_deblocking_filter_enabled_khr", "video_encode_h264_std_deblocking_filter_partial_khr", "_b18", "video_encode_h264_std_slice_qp_delta_khr", "video_encode_h264_std_different_slice_qp_delta_khr" };
     return ft;
@@ -1786,7 +1786,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH264StdFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h264)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH264RateControlFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH264RateControlFlagsKHR";
     ft->argNames = { "video_encode_h264_rate_control_attempt_hrd_compliance_khr", "video_encode_h264_rate_control_regular_gop_khr", "video_encode_h264_rate_control_reference_pattern_flat_khr", "video_encode_h264_rate_control_reference_pattern_dyadic_khr", "video_encode_h264_rate_control_temporal_layer_pattern_dyadic_khr" };
     return ft;
@@ -1795,7 +1795,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH264RateControlFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h265)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH265CapabilityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH265CapabilityFlagsKHR";
     ft->argNames = { "video_encode_h265_capability_hrd_compliance_khr", "video_encode_h265_capability_prediction_weight_table_generated_khr", "video_encode_h265_capability_row_unaligned_slice_segment_khr", "video_encode_h265_capability_different_slice_segment_type_khr", "video_encode_h265_capability_b_frame_in_l0_list_khr", "video_encode_h265_capability_b_frame_in_l1_list_khr", "video_encode_h265_capability_per_picture_type_min_max_qp_khr", "video_encode_h265_capability_per_slice_segment_constant_qp_khr", "video_encode_h265_capability_multiple_tiles_per_slice_segment_khr", "video_encode_h265_capability_multiple_slice_segments_per_tile_khr", "video_encode_h265_capability_cu_qp_diff_wraparound_khr", "video_encode_h265_capability_b_picture_intra_refresh_khr" };
     return ft;
@@ -1804,7 +1804,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH265CapabilityFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h265)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH265StdFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH265StdFlagsKHR";
     ft->argNames = { "video_encode_h265_std_separate_color_plane_flag_set_khr", "video_encode_h265_std_sample_adaptive_offset_enabled_flag_set_khr", "video_encode_h265_std_scaling_list_data_present_flag_set_khr", "video_encode_h265_std_pcm_enabled_flag_set_khr", "video_encode_h265_std_sps_temporal_mvp_enabled_flag_set_khr", "video_encode_h265_std_init_qp_minus26_khr", "video_encode_h265_std_weighted_pred_flag_set_khr", "video_encode_h265_std_weighted_bipred_flag_set_khr", "video_encode_h265_std_log2_parallel_merge_level_minus2_khr", "video_encode_h265_std_sign_data_hiding_enabled_flag_set_khr", "video_encode_h265_std_transform_skip_enabled_flag_set_khr", "video_encode_h265_std_transform_skip_enabled_flag_unset_khr", "video_encode_h265_std_pps_slice_chroma_qp_offsets_present_flag_set_khr", "video_encode_h265_std_transquant_bypass_enabled_flag_set_khr", "video_encode_h265_std_constrained_intra_pred_flag_set_khr", "video_encode_h265_std_entropy_coding_sync_enabled_flag_set_khr", "video_encode_h265_std_deblocking_filter_override_enabled_flag_set_khr", "video_encode_h265_std_dependent_slice_segments_enabled_flag_set_khr", "video_encode_h265_std_dependent_slice_segment_flag_set_khr", "video_encode_h265_std_slice_qp_delta_khr", "video_encode_h265_std_different_slice_qp_delta_khr" };
     return ft;
@@ -1813,7 +1813,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH265StdFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h265)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH265RateControlFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH265RateControlFlagsKHR";
     ft->argNames = { "video_encode_h265_rate_control_attempt_hrd_compliance_khr", "video_encode_h265_rate_control_regular_gop_khr", "video_encode_h265_rate_control_reference_pattern_flat_khr", "video_encode_h265_rate_control_reference_pattern_dyadic_khr", "video_encode_h265_rate_control_temporal_sub_layer_pattern_dyadic_khr" };
     return ft;
@@ -1822,7 +1822,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH265RateControlFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h265)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH265CtbSizeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH265CtbSizeFlagsKHR";
     ft->argNames = { "video_encode_h265_ctb_size_16_khr", "video_encode_h265_ctb_size_32_khr", "video_encode_h265_ctb_size_64_khr" };
     return ft;
@@ -1831,7 +1831,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH265CtbSizeFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_h265)
 TypeDeclPtr makeVkFlags_VkVideoEncodeH265TransformBlockSizeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeH265TransformBlockSizeFlagsKHR";
     ft->argNames = { "video_encode_h265_transform_block_size_4_khr", "video_encode_h265_transform_block_size_8_khr", "video_encode_h265_transform_block_size_16_khr", "video_encode_h265_transform_block_size_32_khr" };
     return ft;
@@ -1840,7 +1840,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeH265TransformBlockSizeFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_av1)
 TypeDeclPtr makeVkFlags_VkVideoEncodeAV1CapabilityFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeAV1CapabilityFlagsKHR";
     ft->argNames = { "video_encode_av1_capability_per_rate_control_group_min_max_q_index_khr", "video_encode_av1_capability_generate_obu_extension_header_khr", "video_encode_av1_capability_primary_reference_cdf_only_khr", "video_encode_av1_capability_frame_size_override_khr", "video_encode_av1_capability_motion_vector_scaling_khr", "video_encode_av1_capability_compound_prediction_intra_refresh_khr" };
     return ft;
@@ -1849,7 +1849,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeAV1CapabilityFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_av1)
 TypeDeclPtr makeVkFlags_VkVideoEncodeAV1StdFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeAV1StdFlagsKHR";
     ft->argNames = { "video_encode_av1_std_uniform_tile_spacing_flag_set_khr", "video_encode_av1_std_skip_mode_present_unset_khr", "video_encode_av1_std_primary_ref_frame_khr", "video_encode_av1_std_delta_q_khr" };
     return ft;
@@ -1858,7 +1858,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeAV1StdFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_av1)
 TypeDeclPtr makeVkFlags_VkVideoEncodeAV1RateControlFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeAV1RateControlFlagsKHR";
     ft->argNames = { "video_encode_av1_rate_control_regular_gop_khr", "video_encode_av1_rate_control_temporal_layer_pattern_dyadic_khr", "video_encode_av1_rate_control_reference_pattern_flat_khr", "video_encode_av1_rate_control_reference_pattern_dyadic_khr" };
     return ft;
@@ -1867,7 +1867,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeAV1RateControlFlagsKHR() {
 
 #if defined(VK_KHR_video_encode_av1)
 TypeDeclPtr makeVkFlags_VkVideoEncodeAV1SuperblockSizeFlagsKHR() {
-    auto ft = new TypeDecl(Type::tBitfield);
+    auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
     ft->alias = "VkVideoEncodeAV1SuperblockSizeFlagsKHR";
     ft->argNames = { "video_encode_av1_superblock_size_64_khr", "video_encode_av1_superblock_size_128_khr" };
     return ft;
@@ -1876,7 +1876,7 @@ TypeDeclPtr makeVkFlags_VkVideoEncodeAV1SuperblockSizeFlagsKHR() {
 
 #if defined(VK_KHR_maintenance8)
 TypeDeclPtr makeVkFlags_VkAccessFlags3KHR() {
-    auto ft = new TypeDecl(Type::tBitfield64);
+    auto ft = new TypeDecl(Type::tBitfield64, cppBindingLineInfo());
     ft->alias = "VkAccessFlags3KHR";
     return ft;
 }

--- a/skills/das_macros.md
+++ b/skills/das_macros.md
@@ -13,7 +13,7 @@ the moment a macro misbehaves. Which entry point depends on how much of the tree
 | Call | Use when |
 |---|---|
 | `daslang --ast-verify file.das` | first move on any unexplained crash - checks the module being compiled before each infer pass, so a break is reported on the pass right after it happens (`options log_infer_passes` shows the pass), repaired so the scan finishes, and the compile fails with every finding printed; after inference it sweeps every module on each firing. `require daslib/ast_verify` pins the same per-pass check in the source; `verify_module(prog, mod)` runs it at the end of your `apply()` |
-| `daslang --ast-verify-batch file.das` | the cheap form for gating many files (CI): no pre-infer checks, and post-infer only the module being compiled. A tree a macro breaks mid-inference then surfaces as a compiler crash, which a batch gate must count as a failure |
+| `daslang --ast-verify-batch file.das` | the cheap form for gating many files (CI): no pre-infer checks, and the module being compiled is walked once, right after inference (the ~10 post-infer firings per module all walk one tree). A tree a macro breaks mid-inference then surfaces as a compiler crash, which a batch gate must count as a failure |
 | `verify_expression(expr)` | you BUILD and RETURN a subtree - call / for-loop / variant / reader macros run inside inference, where the module-level form cannot see your result yet |
 | `verify_function(fn)` | you BUILD a function - `add_function` mangles the signature immediately, so a malformed result or argument type crashes there, before any pass could run |
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -52,7 +52,7 @@ namespace das {
     }
 
     TypeDeclPtr Enumeration::makeBaseType() const {
-        return new TypeDecl(baseType);
+        return new TypeDecl(baseType, at);
     }
 
     Type Enumeration::getEnumType() const {
@@ -80,16 +80,16 @@ namespace das {
         switch (baseType) {
         case Type::tInt8:
         case Type::tUInt8:
-            res = new TypeDecl(Type::tEnumeration8); break;
+            res = new TypeDecl(Type::tEnumeration8, at); break;
         case Type::tInt16:
         case Type::tUInt16:
-            res = new TypeDecl(Type::tEnumeration16); break;
+            res = new TypeDecl(Type::tEnumeration16, at); break;
         case Type::tInt:
         case Type::tUInt:
-            res = new TypeDecl(Type::tEnumeration); break;
+            res = new TypeDecl(Type::tEnumeration, at); break;
         case Type::tInt64:
         case Type::tUInt64:
-            res = new TypeDecl(Type::tEnumeration64); break;
+            res = new TypeDecl(Type::tEnumeration64, at); break;
         default:
             DAS_ASSERTF(0, "we should not be here. unsupported enumeration base type.");
             return nullptr;
@@ -1777,8 +1777,7 @@ namespace das {
     TypeDeclPtr ExprBlock::makeBlockType () const {
         // the block's own location stands for every slot copied here - an inferred block type
         // or argument type has none of its own, and this is where the copy is allocated
-        auto eT = new TypeDecl(Type::tBlock);
-        eT->at = at;
+        auto eT = new TypeDecl(Type::tBlock, at);
         eT->constant = true;
         if ( type ) {
             eT->firstType = new TypeDecl(*type);

--- a/src/ast/ast_allocate_stack.cpp
+++ b/src/ast/ast_allocate_stack.cpp
@@ -1089,11 +1089,11 @@ namespace das {
         w->arguments.push_back(inner);
         auto fakeContext = new ExprFakeContext(inner->at);
         fakeContext->generated = true;
-        fakeContext->type = new TypeDecl(Type::fakeContext);
+        fakeContext->type = new TypeDecl(Type::fakeContext, fakeContext->at);
         w->arguments.push_back(fakeContext);
         auto fakeLineInfo = new ExprFakeLineInfo(inner->at);
         fakeLineInfo->generated = true;
-        fakeLineInfo->type = new TypeDecl(Type::fakeLineInfo);
+        fakeLineInfo->type = new TypeDecl(Type::fakeLineInfo, fakeLineInfo->at);
         w->arguments.push_back(fakeLineInfo);
         return w;
     }

--- a/src/ast/ast_const_folding.cpp
+++ b/src/ast/ast_const_folding.cpp
@@ -439,7 +439,7 @@ namespace das {
             expr->type->ref = b4ref;
             auto res = debug_value(value, pTypeInfo, PrintFlags::string_builder);
             auto sim = new ExprConstString(expr->at, res);
-            sim->type = new TypeDecl(Type::tString);
+            sim->type = new TypeDecl(Type::tString, sim->at);
             sim->constexpression = true;
             sim->foldedNonConst = !expr->type->constant;
             sim->at = encloseAt(expr);
@@ -481,7 +481,7 @@ namespace das {
         if ( expr->elements.size()==0 ) {
             // empty string builder is "" string
             auto estr = new ExprConstString(expr->at,"");
-            estr->type = new TypeDecl(Type::tString);
+            estr->type = new TypeDecl(Type::tString, estr->at);
             estr->constexpression = true;
             estr->foldedNonConst = !expr->type->constant;
             reportFolding();
@@ -665,8 +665,8 @@ namespace das {
                             }
                         }
                         auto vecType = swz->type->getVectorType(baseType, int(fields.size()));
-                        auto constValue = program->makeConst(expr->at, new TypeDecl(vecType), resData);
-                        constValue->type = new TypeDecl(vecType);
+                        auto constValue = program->makeConst(expr->at, new TypeDecl(vecType, expr->at), resData);
+                        constValue->type = new TypeDecl(vecType, constValue->at);
                         constValue->type->at = expr->at;
                         return constValue;
                     }
@@ -1314,7 +1314,7 @@ namespace das {
                     if ( auto notFn = findBuiltinOperator("!", expr->subexpr->type) ) {
                         auto notE = new ExprOp1(expr->at, "!", expr->subexpr);
                         notE->func = notFn;
-                        notE->type = new TypeDecl(Type::tBool);
+                        notE->type = new TypeDecl(Type::tBool, notE->at);
                         reportFolding();
                         return notE;
                     }

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -268,7 +268,7 @@ namespace das {
         Function & fakeFunc = *fakeFuncPtr;
         fakeFunc.name = "invoke " + blk->describe();
         fakeFunc.at = at;
-        gc_local<TypeDecl> voidType(new TypeDecl(Type::tVoid));
+        gc_local<TypeDecl> voidType(new TypeDecl(Type::tVoid, at));
         fakeFunc.result = blk->firstType ? blk->firstType : (TypeDecl*)voidType;
         fakeFunc.totalStackSize = sizeof(Prologue);
         for ( size_t ai=0, ais=blk->argTypes.size(); ai!=ais; ++ ai ) {

--- a/src/ast/ast_generate.cpp
+++ b/src/ast/ast_generate.cpp
@@ -69,7 +69,7 @@ namespace das {
         auto compName = "__acomp_" + to_string(expr->at.line) + "_" + to_string(expr->at.column);
         auto pClosure = new ExprBlock();
         pClosure->at = expr->subexpr->at;
-        pClosure->returnType = new TypeDecl(Type::autoinfer);
+        pClosure->returnType = new TypeDecl(Type::autoinfer, pClosure->at);
         pClosure->generated = true;
         // temp : Array<expr->subexpr->type>
         auto pVar = new Variable();
@@ -77,8 +77,7 @@ namespace das {
         pVar->can_shadow = true;
         pVar->at = expr->at;
         pVar->name = compName;
-        pVar->type = new TypeDecl(Type::tArray);
-        pVar->type->at = expr->at;
+        pVar->type = new TypeDecl(Type::tArray, expr->at);
         pVar->type->constant = false;
         pVar->type->removeConstant = true;
         pVar->type->firstType = new TypeDecl(*expr->subexpr->type);
@@ -163,7 +162,7 @@ namespace das {
     ExpressionPtr generateComprehensionIterator ( ExprArrayComprehension * expr ) {
         auto pClosure = new ExprBlock();
         pClosure->at = expr->subexpr->at;
-        pClosure->returnType = new TypeDecl(Type::autoinfer);
+        pClosure->returnType = new TypeDecl(Type::autoinfer, pClosure->at);
         // yield subexpr
         auto pYield = new ExprYield(expr->at, expr->subexpr->clone());
         if ( !expr->subexpr->type->canCopy() ) {
@@ -211,7 +210,7 @@ namespace das {
         auto pAt = new ExprField(at, a, b, no_promo);
         pInvoke->arguments.push_back(pAt);
         pInvoke->isInvokeMethod = true;
-        auto pTypeAuto = new ExprTypeDecl(at, new TypeDecl(Type::autoinfer));
+        auto pTypeAuto = new ExprTypeDecl(at, new TypeDecl(Type::autoinfer, at));
         pTypeAuto->typeexpr->at = at;
         pInvoke->arguments.push_back(pTypeAuto);
         return pInvoke;
@@ -220,8 +219,7 @@ namespace das {
     /* a->b(args) is short for invoke(type<callStruct>.b, cast<auto> deref(a), args)  */
     ExprInvoke * makeInvokeMethod ( const LineInfo & at, Structure * callStruct, Expression * a, const string & b ) {
         auto pInvoke = new ExprInvoke(at, "invoke");
-        auto callType = new TypeDecl(Type::tStructure);
-        callType->at = at;
+        auto callType = new TypeDecl(Type::tStructure, at);
         callType->structType = callStruct;
         auto callTypeExpr = new ExprTypeDecl(at, callType);
         auto pAt = new ExprField(at, callTypeExpr, b);
@@ -229,7 +227,7 @@ namespace das {
         pInvoke->isInvokeMethod = true;
         auto pCast = new ExprCast();
         pCast->at = at;
-        pCast->castType = new TypeDecl(Type::autoinfer);
+        pCast->castType = new TypeDecl(Type::autoinfer, pCast->at);
         pCast->subexpr = new ExprPtr2Ref(at,a);
         pCast->subexpr->alwaysSafe = true;
         pInvoke->arguments.push_back(pCast);
@@ -267,7 +265,7 @@ namespace das {
         fn->privateFunction = isPrivate;
         fn->name = str->name;
         fn->at = fn->atDecl = str->at;
-        fn->result = new TypeDecl(str);
+        fn->result = new TypeDecl(str, fn->at);
         fn->result->at = str->at;
         if ( str->isClass ) {
             fn->isClassMethod = true;
@@ -356,13 +354,13 @@ namespace das {
     FunctionPtr makeClone ( Structure * str ) {
         auto varA = new Variable();
         varA->name = "a";
-        varA->type = new TypeDecl(str);
+        varA->type = new TypeDecl(str, varA->at);
         varA->type->at = str->at;
         varA->type->isExplicit = true;
         varA->at = str->at;
         auto varB = new Variable();
         varB->name = "b";
-        varB->type = new TypeDecl(str);
+        varB->type = new TypeDecl(str, varB->at);
         varB->type->at = str->at;
         varB->type->constant = str->canCloneFromConst();    // allow to clone from const
         varB->type->implicit = true;
@@ -418,7 +416,7 @@ namespace das {
             auto vsiz = new Variable();
             vsiz->at = at;
             vsiz->name = "__size";
-            vsiz->type = new TypeDecl(Type::autoinfer);
+            vsiz->type = new TypeDecl(Type::autoinfer, vsiz->at);
             if ( !vsiz->type->at.fileInfo ) vsiz->type->at = vsiz->at;
             vsiz->type->constant = true;
             auto crs = new ExprCall(at,"class_rtti_size");
@@ -433,7 +431,7 @@ namespace das {
             invk->arguments.push_back(pAt);
             auto pCast = new ExprCast();
             pCast->at = at;
-            pCast->castType = new TypeDecl(Type::autoinfer);
+            pCast->castType = new TypeDecl(Type::autoinfer, pCast->at);
             auto THISAA = new ExprVar(at, "__this");
             pCast->subexpr = new ExprPtr2Ref(at,THISAA);
             pCast->subexpr->alwaysSafe = true;
@@ -464,8 +462,7 @@ namespace das {
         fb->at = at;
         fb->list.push_back(ife);
         pFunc->body = fb;
-        pFunc->result = new TypeDecl(Type::tVoid);
-        pFunc->result->at = pFunc->at;
+        pFunc->result = new TypeDecl(Type::tVoid, pFunc->at);
         auto cTHIS = new Variable();
         cTHIS->name = "__this";
         cTHIS->at = at;
@@ -542,12 +539,11 @@ namespace das {
         mz->arguments.push_back(lvar);
         fb->list.push_back(mz);
         pFunc->body = fb;
-        pFunc->result = new TypeDecl(Type::tVoid);
-        pFunc->result->at = pFunc->at;
+        pFunc->result = new TypeDecl(Type::tVoid, pFunc->at);
         auto cTHIS = new Variable();
         cTHIS->at = ls->at;
         cTHIS->name = "__this";
-        cTHIS->type = new TypeDecl(ls);
+        cTHIS->type = new TypeDecl(ls, cTHIS->at);
         cTHIS->type->at = ls->at;
         cTHIS->type->isExplicit = true;
         pFunc->arguments.push_back(cTHIS);
@@ -605,14 +601,12 @@ namespace das {
         delit1->alwaysSafe = true;
         fb->list.push_back(delit1);
         // function goo
-        pFunc->result = new TypeDecl(Type::tVoid);
-        pFunc->result->at = pFunc->at;
+        pFunc->result = new TypeDecl(Type::tVoid, pFunc->at);
         auto cTHIS = new Variable();
         cTHIS->at = ls->at;
         cTHIS->name = "__this";
-        cTHIS->type = new TypeDecl(Type::tPointer);
-        cTHIS->type->at = ls->at;
-        cTHIS->type->firstType = new TypeDecl(ls);
+        cTHIS->type = new TypeDecl(Type::tPointer, ls->at);
+        cTHIS->type->firstType = new TypeDecl(ls, cTHIS->at);
         cTHIS->type->firstType->at = ls->at;
         cTHIS->type->isExplicit = true;
         pFunc->arguments.push_back(cTHIS);
@@ -690,7 +684,7 @@ namespace das {
         cTHIS->generated = true;
         cTHIS->at = block->at;
         cTHIS->name = "__this";
-        cTHIS->type = new TypeDecl(ls);
+        cTHIS->type = new TypeDecl(ls, cTHIS->at);
         cTHIS->type->at = ls->at;
         cTHIS->type->isExplicit = true;
         pFunc->arguments.push_back(cTHIS);
@@ -739,24 +733,20 @@ namespace das {
         pStruct->fields.emplace_back("__lambda", btd, nullptr, AnnotationArgumentList(), false, block->at);
         pStruct->fields.back().generated = true;
         pStruct->fields.back().type->sanitize();
-        auto finFunc = new TypeDecl(Type::tFunction);
-        finFunc->at = block->at;
-        auto finArg = new TypeDecl(Type::tPointer);
-        finArg->at = block->at;
+        auto finFunc = new TypeDecl(Type::tFunction, block->at);
+        auto finArg = new TypeDecl(Type::tPointer, block->at);
         finArg->firstType = new TypeDecl(pStruct);
         finArg->firstType->at = block->at;
         finArg->constant = false;
         finArg->removeConstant = true;
         finFunc->argTypes.push_back(finArg);
         finFunc->argNames.push_back("__this");
-        finFunc->firstType = new TypeDecl(Type::tVoid);
-        finFunc->firstType->at = block->at;
+        finFunc->firstType = new TypeDecl(Type::tVoid, block->at);
         pStruct->fields.emplace_back("__finalize", finFunc, nullptr, AnnotationArgumentList(), false, block->at);
         pStruct->fields.back().generated = true;
         pStruct->fields.back().type->sanitize();
         if ( needYield ) {
-            auto yt = new TypeDecl(Type::tInt);
-            yt->at = block->at;
+            auto yt = new TypeDecl(Type::tInt, block->at);
             pStruct->fields.emplace_back("__yield", yt, nullptr, AnnotationArgumentList(), false, block->at);
             auto & fldb = pStruct->fields.back();
             fldb.generated = true;
@@ -776,8 +766,7 @@ namespace das {
             if ( isCaptureAsRef(var) || mode==CaptureMode::capture_by_reference ) {
                 td->ref = false;
                 td->constant = var->type->constant;
-                auto ptd = new TypeDecl(Type::tPointer);
-                ptd->at = var->at;
+                auto ptd = new TypeDecl(Type::tPointer, var->at);
                 ptd->firstType = td;
                 td = ptd;
                 pStruct->fields.emplace_back(var->name, td, nullptr, AnnotationArgumentList(), false, var->at);
@@ -1156,8 +1145,7 @@ namespace das {
             if ( !vtd->at.fileInfo ) vtd->at = var->at;
             bool isRef = vtd->ref;
             if ( isRef ) {
-                auto pvtd = new TypeDecl(Type::tPointer);
-                pvtd->at = var->at;
+                auto pvtd = new TypeDecl(Type::tPointer, var->at);
                 pvtd->firstType = vtd;
                 vtd->ref = false;
                 vtd = pvtd;
@@ -1311,7 +1299,7 @@ namespace das {
             bvar->generated = true;
             bvar->at = expr->at;
             bvar->name = breakFlag;
-            bvar->type = new TypeDecl(Type::tBool);
+            bvar->type = new TypeDecl(Type::tBool, bvar->at);
             if ( !bvar->type->at.fileInfo ) bvar->type->at = bvar->at;
             bvar->init = new ExprConstBool(expr->at, false);
             leqt->variables.push_back(bvar);
@@ -1327,7 +1315,7 @@ namespace das {
             rvar->generated = true;
             rvar->at = expr->at;
             rvar->name = returnFlag;
-            rvar->type = new TypeDecl(Type::tBool);
+            rvar->type = new TypeDecl(Type::tBool, rvar->at);
             if ( !rvar->type->at.fileInfo ) rvar->type->at = rvar->at;
             if ( !rvar->type->at.fileInfo ) rvar->type->at = rvar->at;
             rvar->init = new ExprConstBool(expr->at, false);
@@ -1416,7 +1404,7 @@ namespace das {
     }
 
     ExpressionPtr makeCounterRef ( const LineInfo & at, const string & pVarName, const TypeDeclPtr & elemType ) {
-        auto ptrT = new TypeDecl(Type::tPointer);
+        auto ptrT = new TypeDecl(Type::tPointer, at);
         ptrT->at = at;
         ptrT->firstType = new TypeDecl(*elemType);
         ptrT->firstType->at = at;
@@ -1488,7 +1476,7 @@ namespace das {
         lvar->generated = true;
         lvar->at = expr->at;
         lvar->name = loopVar;
-        lvar->type = new TypeDecl(Type::tBool);
+        lvar->type = new TypeDecl(Type::tBool, lvar->at);
         if ( !lvar->type->at.fileInfo ) lvar->type->at = lvar->at;
         lvar->init = new ExprConstBool(expr->at, true);
         leqt->variables.push_back(lvar);
@@ -1503,7 +1491,7 @@ namespace das {
             bvar->generated = true;
             bvar->at = expr->at;
             bvar->name = breakFlag;
-            bvar->type = new TypeDecl(Type::tBool);
+            bvar->type = new TypeDecl(Type::tBool, bvar->at);
             if ( !bvar->type->at.fileInfo ) bvar->type->at = bvar->at;
             bvar->init = new ExprConstBool(expr->at, false);
             bleqt->variables.push_back(bvar);
@@ -1519,7 +1507,7 @@ namespace das {
             rvar->generated = true;
             rvar->at = expr->at;
             rvar->name = returnFlag;
-            rvar->type = new TypeDecl(Type::tBool);
+            rvar->type = new TypeDecl(Type::tBool, rvar->at);
             if ( !rvar->type->at.fileInfo ) rvar->type->at = rvar->at;
             rvar->init = new ExprConstBool(expr->at, false);
             rleqt->variables.push_back(rvar);
@@ -1560,8 +1548,7 @@ namespace das {
                 svar->generated = true;
                 svar->at = expr->at;
                 svar->name = srcName + "_temp_var";
-                svar->type = new TypeDecl(Type::autoinfer);
-                svar->type->at = svar->at;
+                svar->type = new TypeDecl(Type::autoinfer, svar->at);
                 svar->init_via_move = true;
                 svar->init = src->clone();
                 tempLet->variables.push_back(svar);
@@ -1576,8 +1563,7 @@ namespace das {
             svar->generated = true;
             svar->at = expr->at;
             svar->name = srcName;
-            svar->type = new TypeDecl(Type::autoinfer);
-            svar->type->at = svar->at;
+            svar->type = new TypeDecl(Type::autoinfer, svar->at);
             svar->init_via_move = !plainRange;
             if ( src->type->isGoodIteratorType() || plainRange ) {
                 svar->init = src->clone();
@@ -1604,8 +1590,7 @@ namespace das {
             srcv->name = srcVarName;
             if ( iterv->type->ref ) {
                 srcv->do_not_delete = true;
-                srcv->type = new TypeDecl(Type::tPointer);
-                srcv->type->at = srcv->at;
+                srcv->type = new TypeDecl(Type::tPointer, srcv->at);
                 srcv->type->firstType = new TypeDecl(*iterv->type);
                 if ( !srcv->type->firstType->at.fileInfo ) srcv->type->firstType->at = srcv->at;
                 srcv->type->firstType->constant |= src->type->constant;
@@ -1628,10 +1613,8 @@ namespace das {
             auto adri = new ExprRef2Ptr(expr->at, vit0);
             adri->generated = true;     // lowering artifact, not user source (STYLE034 guard)
             adri->alwaysSafe = true;
-            auto pvoid = new TypeDecl(Type::tPointer);
-            pvoid->at = expr->at;
-            pvoid->firstType = new TypeDecl(Type::tVoid);
-            pvoid->firstType->at = expr->at;
+            auto pvoid = new TypeDecl(Type::tPointer, expr->at);
+            pvoid->firstType = new TypeDecl(Type::tVoid, expr->at);
             auto rein = new ExprCast(expr->at, adri, pvoid);
             rein->generated = true;
             rein->reinterpret = true;
@@ -1772,8 +1755,7 @@ namespace das {
         fn->privateFunction = true;
         fn->name = "clone";
         fn->at = fn->atDecl = at;
-        fn->result = new TypeDecl(Type::tVoid);
-        fn->result->at = fn->at;
+        fn->result = new TypeDecl(Type::tVoid, fn->at);
         auto arg0 = new Variable();
         arg0->at = at;
         arg0->name = "dest";
@@ -1813,8 +1795,7 @@ namespace das {
         fn->generated = true;
         fn->name = "finalize";
         fn->at = fn->atDecl = at;
-        fn->result = new TypeDecl(Type::tVoid);
-        fn->result->at = fn->at;
+        fn->result = new TypeDecl(Type::tVoid, fn->at);
         auto arg0 = new Variable();
         arg0->at = at;
         arg0->name = "__this";
@@ -1859,8 +1840,7 @@ namespace das {
         fn->privateFunction = true;
         fn->name = "clone";
         fn->at = fn->atDecl = at;
-        fn->result = new TypeDecl(Type::tVoid);
-        fn->result->at = fn->at;
+        fn->result = new TypeDecl(Type::tVoid, fn->at);
         auto arg0 = new Variable();
         arg0->at = at;
         arg0->name = "dest";
@@ -1924,8 +1904,7 @@ namespace das {
         fn->generated = true;
         fn->name = "finalize";
         fn->at = fn->atDecl = at;
-        fn->result = new TypeDecl(Type::tVoid);
-        fn->result->at = fn->at;
+        fn->result = new TypeDecl(Type::tVoid, fn->at);
         auto arg0 = new Variable();
         arg0->at = at;
         arg0->name = "__this";
@@ -1988,8 +1967,7 @@ namespace das {
         fn->privateFunction = true;
         fn->name = "clone";
         fn->at = fn->atDecl = at;
-        fn->result = new TypeDecl(Type::tVoid);
-        fn->result->at = fn->at;
+        fn->result = new TypeDecl(Type::tVoid, fn->at);
         auto arg0 = new Variable();
         arg0->at = at;
         arg0->name = "dest";
@@ -2236,7 +2214,7 @@ namespace das {
         func->at = method->at;
         func->atDecl = method->at;
         func->name = baseClass->name;
-        func->result = new TypeDecl(baseClass);
+        func->result = new TypeDecl(baseClass, func->at);
         func->result->at = func->at;
         func->isClassMethod = true;
         func->classParent = baseClass;
@@ -2304,10 +2282,8 @@ namespace das {
             fd->parentType = fd->type->isAuto();
             fd->generated = true;
         } else {
-            auto pvoid = new TypeDecl(Type::tPointer);
-            pvoid->at = baseClass->at;
-            pvoid->firstType = new TypeDecl(Type::tVoid);
-            pvoid->firstType->at = baseClass->at;
+            auto pvoid = new TypeDecl(Type::tPointer, baseClass->at);
+            pvoid->firstType = new TypeDecl(Type::tVoid, baseClass->at);
             baseClass->fields.emplace_back(
                 "__rtti",
                 pvoid,
@@ -2329,14 +2305,12 @@ namespace das {
         ExpressionPtr finit = new ExprAddr(baseClass->at, (baseClass->isTemplate ? "_::" : "__::") + fname);
         if ( baseClass->parent ) {
             auto fd = (Structure::FieldDeclaration *) baseClass->findField("__finalize");
-            auto castT = new TypeDecl(Type::autoinfer);
-            castT->at = baseClass->at;
+            auto castT = new TypeDecl(Type::autoinfer, baseClass->at);
             fd->init = new ExprCast(baseClass->at, finit, castT);
             fd->parentType = fd->type->isAuto();
             fd->generated = true;
         } else {
-            auto finT = new TypeDecl(Type::autoinfer);
-            finT->at = baseClass->at;
+            auto finT = new TypeDecl(Type::autoinfer, baseClass->at);
             baseClass->fields.emplace_back(
                 "__finalize",
                 finT,
@@ -2353,8 +2327,7 @@ namespace das {
         func->at = baseClass->at;
         func->atDecl = baseClass->at;
         func->name = fname;
-        func->result = new TypeDecl(Type::tVoid);
-        func->result->at = func->at;
+        func->result = new TypeDecl(Type::tVoid, func->at);
         func->isClassMethod = true;
         func->classParent = baseClass;
         func->isTemplate = baseClass->isTemplate;
@@ -2412,8 +2385,7 @@ namespace das {
         auto block = new ExprBlock();
         block->at = mks->at;
         block->isClosure = true;
-        block->returnType = new TypeDecl(Type::tVoid);
-        block->returnType->at = block->at;
+        block->returnType = new TypeDecl(Type::tVoid, block->at);
         // only one argument, and its 'self'
         auto mkBaseT = mks->makeType;
         while ( mkBaseT->baseType==Type::tFixedArray && mkBaseT->firstType ) mkBaseT = mkBaseT->firstType;

--- a/src/ast/ast_handle.cpp
+++ b/src/ast/ast_handle.cpp
@@ -256,7 +256,7 @@ namespace das {
                     if ( tp->rtti_isBasicStructureAnnotation() ) {
                         auto bs = static_cast<BasicStructureAnnotation*>(tp);
                         if ( !bs->validationNeverFails ) {
-                            auto cppt = new TypeDecl(Type::tHandle);
+                            auto cppt = new TypeDecl(Type::tHandle, cppBindingLineInfo(tp->name.c_str()));
                             cppt->annotation = bs;
                             auto cppn = describeCppType(cppt);
                             logs << "//\t" << cppn << " aka " << tp->name << "\n";

--- a/src/ast/ast_infer_type.cpp
+++ b/src/ast/ast_infer_type.cpp
@@ -326,7 +326,7 @@ namespace das {
             program->stickyError("malformed AST, structure field '" + decl.name + "' is missing its type",
                   "likely a macro-generated declaration; set its type to auto to request inference", "",
                   decl.at, CompilationError::internal_field);
-            decl.type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+            decl.type = new TypeDecl(Type::autoinfer, decl.at);  // repair in place; the sticky error still fails the compile
             decl.type->at = decl.at;
         }
         if (decl.type->isAuto() && !decl.init) {
@@ -494,7 +494,7 @@ namespace das {
                 getOrCreateDummy(thisModule);
             }
         }
-        auto tt = new TypeDecl(Type::tStructure);
+        auto tt = new TypeDecl(Type::tStructure, var->at);
         tt->structType = var;
         if (isCircularType(tt)) {
             var->circular = true;
@@ -511,7 +511,7 @@ namespace das {
             program->stickyError("malformed AST, global variable '" + var->name + "' is missing its type",
                   "likely a macro-generated declaration; set its type to auto to request inference", "",
                   var->at, CompilationError::internal_variable);
-            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+            var->type = new TypeDecl(Type::autoinfer, var->at);  // repair in place; the sticky error still fails the compile
             var->type->at = var->at;
         }
         if (noUnsafeUninitializedStructs && !var->init && var->type->unsafeInit()) {
@@ -719,7 +719,7 @@ namespace das {
             program->stickyError("malformed AST, function '" + f->name + "' is missing its result type",
                   "likely a macro-generated function; set result to auto to request inference", "",
                   f->at, CompilationError::internal_function);
-            f->result = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+            f->result = new TypeDecl(Type::autoinfer, f->at);  // repair in place; the sticky error still fails the compile
             f->result->at = f->at;
         }
         for (auto it = f->arguments.begin(); it != f->arguments.end();) {
@@ -760,7 +760,7 @@ namespace das {
             program->stickyError("malformed AST, function argument '" + var->name + "' is missing its type",
                   "likely a macro-generated declaration; set its type to auto to request inference", "",
                   var->at, CompilationError::internal_variable);
-            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+            var->type = new TypeDecl(Type::autoinfer, var->at);  // repair in place; the sticky error still fails the compile
             var->type->at = var->at;
         }
         if (var->type->isAlias()) {
@@ -836,8 +836,7 @@ namespace das {
         // if function got no 'result', function is a void function
         if (!func->hasReturn && canFoldResult) {
             if (func->result->isAuto()) {
-                func->result = new TypeDecl(Type::tVoid);
-                func->result->at = func->at;
+                func->result = new TypeDecl(Type::tVoid, func->at);
                 reportAstChanged();
             } else if (!func->result->isVoid()) {
                 error("function does not return a value", "", "",
@@ -1014,11 +1013,11 @@ namespace das {
                 TypeDecl::clone(c->type, cB->bitfieldType);
                 c->type->ref = false;
             } else {
-                c->type = new TypeDecl(c->baseType);
+                c->type = new TypeDecl(c->baseType, c->at);
             }
             c->type->constant = isConstantType(c);
         } else if (c->baseType == Type::tPointer) {
-            c->type = new TypeDecl(c->baseType);
+            c->type = new TypeDecl(c->baseType, c->at);
             auto cptr = static_cast<ExprConstPtr *>(c);
             c->type->smartPtr = cptr->isSmartPtr;
             if (cptr->ptrType) {
@@ -1028,7 +1027,7 @@ namespace das {
                 c->type->constant = false; // true;
             }
         } else {
-            c->type = new TypeDecl(c->baseType);
+            c->type = new TypeDecl(c->baseType, c->at);
             c->type->constant = isConstantType(c);
         }
         return Visitor::visit(c);
@@ -1178,7 +1177,7 @@ namespace das {
             // however having auto or alias in the result may cause problems, so we swap it to void
             // and then swap it back to whatever it was
             auto retT = expr->funcType->firstType;
-            expr->funcType->firstType = new TypeDecl(Type::tVoid);
+            expr->funcType->firstType = new TypeDecl(Type::tVoid, expr->at);
             if (expr->funcType->isAlias()) {
                 auto aT = inferAlias(expr->funcType);
                 if (aT) {
@@ -1212,8 +1211,7 @@ namespace das {
             expr->func = fns.back();
             expr->func->addr = true;
             expr->func->fastCall = false;
-            expr->type = new TypeDecl(Type::tFunction);
-            expr->type->at = expr->at;
+            expr->type = new TypeDecl(Type::tFunction, expr->at);
             expr->type->firstType = new TypeDecl(*expr->func->result);
             if ( !expr->type->firstType->at.fileInfo ) expr->type->firstType->at = expr->at;
             expr->type->argTypes.reserve(expr->func->arguments.size());
@@ -1351,7 +1349,7 @@ namespace das {
                     }
                 }
             }
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = new TypeDecl(*expr->subexpr->type);
             expr->type->firstType->ref = false;
             expr->type->constant |= expr->subexpr->type->constant;
@@ -1513,7 +1511,7 @@ namespace das {
             }
         }
 
-        expr->type = new TypeDecl(Type::tVoid);
+        expr->type = new TypeDecl(Type::tVoid, expr->at);
         return Visitor::visit(expr);
     }
     void InferTypes::preVisit(ExprAssert *expr) {
@@ -1547,7 +1545,7 @@ namespace das {
             error("assert comment must be string constant", "", "",
                   expr->at, CompilationError::invalid_assert_comment_type);
         }
-        expr->type = new TypeDecl(Type::tVoid);
+        expr->type = new TypeDecl(Type::tVoid, expr->at);
         return Visitor::visit(expr);
     }
     ExpressionPtr InferTypes::visit(ExprQuote *expr) {
@@ -1557,10 +1555,8 @@ namespace das {
             return Visitor::visit(expr);
         }
         // infer
-        expr->type = new TypeDecl(Type::tPointer);
-        expr->type->at = expr->at;
-        expr->type->firstType = new TypeDecl(Type::tHandle);
-        expr->type->firstType->at = expr->at;
+        expr->type = new TypeDecl(Type::tPointer, expr->at);
+        expr->type->firstType = new TypeDecl(Type::tHandle, expr->at);
         expr->type->firstType->annotation = (TypeAnnotation *)Module::require("ast_core")->findAnnotation("Expression");
         // mark quote as noAot, unless daslib/quote lowering will replace it
         // (aot_macros or jit_enabled policy, or per-module `options aot_macros` — same gate
@@ -1664,7 +1660,7 @@ namespace das {
                     // arg 1 becomes cast<auto> deref(field.value)
                     auto pCast = new ExprCast();
                     pCast->at = expr->at;
-                    pCast->castType = new TypeDecl(Type::autoinfer);
+                    pCast->castType = new TypeDecl(Type::autoinfer, pCast->at);
                     pCast->subexpr = new ExprPtr2Ref(expr->at, eField->value);
                     pCast->subexpr->alwaysSafe = true;
                     expr->arguments[1] = pCast;
@@ -1708,7 +1704,7 @@ namespace das {
                                 }
                             }
                             vector<TypeDeclPtr> argTypes;
-                            auto selfType = new TypeDecl(Type::tStructure);
+                            auto selfType = new TypeDecl(Type::tStructure, func->classParent->at);
                             selfType->structType = func->classParent;
                             argTypes.push_back(selfType);
                             for (size_t i = 2; i != expr->arguments.size(); ++i) {
@@ -2094,7 +2090,7 @@ namespace das {
             if (!containerType->firstType->isSameType(*valueType, RefMatters::no, ConstMatters::no, TemporaryMatters::no))
                 error("key must be of the same type as table<key,...>", "", "",
                       expr->at, CompilationError::invalid_table_key_type);
-            expr->type = new TypeDecl(Type::tBool);
+            expr->type = new TypeDecl(Type::tBool, expr->at);
         } else {
             error("first argument must be fully qualified table", "", "",
                   expr->at, CompilationError::invalid_table_argument_type);
@@ -2126,7 +2122,7 @@ namespace das {
             if (!containerType->firstType->isSameType(*valueType, RefMatters::no, ConstMatters::no, TemporaryMatters::no))
                 error("key must be of the same type as table<key,...>", "", "",
                       expr->at, CompilationError::invalid_table_key_type);
-            expr->type = new TypeDecl(Type::tBool);
+            expr->type = new TypeDecl(Type::tBool, expr->at);
         } else {
             error("first argument must be fully qualified table", "", "",
                   expr->at, CompilationError::invalid_table_argument_type);
@@ -2158,7 +2154,7 @@ namespace das {
             if (!containerType->firstType->isSameType(*valueType, RefMatters::no, ConstMatters::no, TemporaryMatters::no))
                 error("key must be of the same type as table<key,...>", "", "",
                       expr->at, CompilationError::invalid_table_key_type);
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = new TypeDecl(*containerType->secondType);
         } else {
             error("first argument must be fully qualified table", "", "",
@@ -2192,7 +2188,7 @@ namespace das {
             if (!containerType->firstType->isSameType(*valueType, RefMatters::no, ConstMatters::no, TemporaryMatters::no))
                 error("key must be of the same type as table<key,...>", "", "",
                       expr->at, CompilationError::invalid_table_key_type);
-            expr->type = new TypeDecl(Type::tBool);
+            expr->type = new TypeDecl(Type::tBool, expr->at);
         } else {
             error("first argument must be fully qualified table", "", "",
                   expr->at, CompilationError::invalid_table_argument_type);
@@ -2940,7 +2936,7 @@ namespace das {
                     // Struct finalize substitution via base type matches at the immediate parent
                     // even when only an ancestor defines `def operator delete`.
                     while (baseStruct) {
-                        auto baseType = new TypeDecl(Type::tStructure);
+                        auto baseType = new TypeDecl(Type::tStructure, baseStruct->at);
                         baseType->structType = baseStruct;
                         vector<TypeDeclPtr> argTypes;
                         argTypes.push_back(baseType);
@@ -3219,7 +3215,7 @@ namespace das {
         if (expr->ascType) {
             TypeDecl::clone(expr->type, expr->ascType);
         } else {
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = new TypeDecl(*expr->subexpr->type);
             expr->type->firstType->ref = false;
             if (expr->type->firstType->baseType == Type::tHandle) {
@@ -3305,16 +3301,14 @@ namespace das {
                 error("invalid syntax for 'new' of class, expected syntax: 'new " + describeType(expr->typeexpr) + "()'", "", "",
                       expr->at, CompilationError::invalid_new_class_syntax);
             }
-            auto pt = new TypeDecl(Type::tPointer);
-            pt->at = expr->at;
+            auto pt = new TypeDecl(Type::tPointer, expr->at);
             pt->firstType = new TypeDecl(*baseT);
             if ( !pt->firstType->at.fileInfo ) pt->firstType->at = expr->at;
             expr->type = wrapNewDimChain(pt);
             expr->name = baseT->structType->getMangledName();
         } else if (baseT->baseType == Type::tHandle) {
             if (baseT->annotation->canNew()) {
-                auto pt = new TypeDecl(Type::tPointer);
-                pt->at = expr->at;
+                auto pt = new TypeDecl(Type::tPointer, expr->at);
                 pt->firstType = new TypeDecl(*baseT);
                 if ( !pt->firstType->at.fileInfo ) pt->firstType->at = expr->at;
                 pt->smartPtr = baseT->annotation->isSmart();
@@ -3330,8 +3324,7 @@ namespace das {
                       expr->at, CompilationError::invalid_new_type);
                 return Visitor::visit(expr);
             }
-            auto pt = new TypeDecl(Type::tPointer);
-            pt->at = expr->at;
+            auto pt = new TypeDecl(Type::tPointer, expr->at);
             pt->firstType = new TypeDecl(*baseT);
             if ( !pt->firstType->at.fileInfo ) pt->firstType->at = expr->at;
             expr->type = wrapNewDimChain(pt);
@@ -3342,8 +3335,7 @@ namespace das {
                       expr->at, CompilationError::invalid_new_type);
                 return Visitor::visit(expr);
             }
-            auto pt = new TypeDecl(Type::tPointer);
-            pt->at = expr->at;
+            auto pt = new TypeDecl(Type::tPointer, expr->at);
             pt->firstType = new TypeDecl(*baseT);
             if ( !pt->firstType->at.fileInfo ) pt->firstType->at = expr->at;
             expr->type = wrapNewDimChain(pt);
@@ -3537,7 +3529,7 @@ namespace das {
                       expr->index->at, CompilationError::invalid_index_type);
                 return Visitor::visit(expr);
             } else if (seT->isVectorType()) {
-                expr->type = new TypeDecl(seT->getVectorBaseType());
+                expr->type = new TypeDecl(seT->getVectorBaseType(), expr->at);
                 expr->type->ref = seT->ref;
                 expr->type->constant = seT->constant;
             } else {
@@ -3585,7 +3577,7 @@ namespace das {
                           expr->index->at, CompilationError::invalid_table_safe_index_type);
                     return Visitor::visit(expr);
                 }
-                expr->type = new TypeDecl(Type::tPointer);
+                expr->type = new TypeDecl(Type::tPointer, expr->at);
                 expr->type->firstType = new TypeDecl(*seT->secondType);
                 expr->type->constant |= seT->constant;
             } else if (seT->isHandle()) {
@@ -3608,15 +3600,15 @@ namespace das {
                           expr->index->at, CompilationError::invalid_index_type);
                     return Visitor::visit(expr);
                 } else if (seT->isVectorType()) {
-                    expr->type = new TypeDecl(Type::tPointer);
-                    expr->type->firstType = new TypeDecl(seT->getVectorBaseType());
+                    expr->type = new TypeDecl(Type::tPointer, expr->at);
+                    expr->type->firstType = new TypeDecl(seT->getVectorBaseType(), expr->at);
                     expr->type->firstType->constant = seT->constant;
                 } else if (seT->isGoodArrayType()) {
                     if (!safeExpression(expr)) {
                         error("safe-index of array<> must be inside the 'unsafe' block", "", "",
                               expr->at, CompilationError::unsafe_array_safe_index);
                     }
-                    expr->type = new TypeDecl(Type::tPointer);
+                    expr->type = new TypeDecl(Type::tPointer, expr->at);
                     expr->type->firstType = new TypeDecl(*seT->firstType);
                     expr->type->firstType->constant |= seT->constant;
                 } else if (seT->baseType==Type::tFixedArray) {
@@ -3625,7 +3617,7 @@ namespace das {
                               expr->subexpr->at, CompilationError::not_resolved_yet_array_dimension);
                         return Visitor::visit(expr);
                     } else {
-                        expr->type = new TypeDecl(Type::tPointer);
+                        expr->type = new TypeDecl(Type::tPointer, expr->at);
                         expr->type->firstType = new TypeDecl(*seT->firstType);
                         expr->type->firstType->constant |= seT->constant;
                     }
@@ -3657,7 +3649,7 @@ namespace das {
                 return Visitor::visit(expr);
             }
             auto seT = expr->subexpr->type;
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = new TypeDecl(*seT->firstType);
             expr->type->firstType->constant |= seT->constant;
         } else if (expr->subexpr->type->isGoodTableType()) {
@@ -3676,7 +3668,7 @@ namespace das {
                       expr->index->at, CompilationError::cant_safe_index_table);
                 return Visitor::visit(expr);
             }
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = new TypeDecl(*seT->secondType);
             expr->type->constant |= seT->constant;
         } else if (expr->subexpr->type->baseType==Type::tFixedArray) {
@@ -3694,7 +3686,7 @@ namespace das {
                 error("type dimensions are not resolved yet: '" + describeType(seT) + "'", "", "",
                       expr->subexpr->at, CompilationError::not_resolved_yet_array_dimension);
             }
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = new TypeDecl(*seT->firstType);
             expr->type->firstType->constant |= seT->constant;
         } else if (expr->subexpr->type->isVectorType() && expr->subexpr->type->isRef()) {
@@ -3704,8 +3696,8 @@ namespace das {
                 return Visitor::visit(expr);
             }
             const auto &seT = expr->subexpr->type;
-            expr->type = new TypeDecl(Type::tPointer);
-            expr->type->firstType = new TypeDecl(seT->getVectorBaseType());
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
+            expr->type->firstType = new TypeDecl(seT->getVectorBaseType(), expr->at);
             expr->type->firstType->constant = seT->constant;
         } else {
             error("type can't be safe-indexed: '" + describeType(expr->subexpr->type) + "'", "", "",
@@ -3760,7 +3752,7 @@ namespace das {
             program->stickyError("malformed AST, block argument '" + var->name + "' is missing its type",
                   "likely a macro-generated declaration; set its type to auto to request inference", "",
                   var->at, CompilationError::internal_variable);
-            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+            var->type = new TypeDecl(Type::autoinfer, var->at);  // repair in place; the sticky error still fails the compile
             var->type->at = var->at;
         }
         if (!var->can_shadow && !program->policies.allow_block_variable_shadowing) {
@@ -3895,10 +3887,8 @@ namespace das {
                 }
             }
             if (!block->hasReturn && canFoldResult && block->type->isAuto()) {
-                block->returnType = new TypeDecl(Type::tVoid);
-                block->returnType->at = block->at;
-                block->type = new TypeDecl(Type::tVoid);
-                block->type->at = block->at;
+                block->returnType = new TypeDecl(Type::tVoid, block->at);
+                block->type = new TypeDecl(Type::tVoid, block->at);
                 setBlockCopyMoveFlags(block);
                 reportAstChanged();
             }
@@ -3950,7 +3940,7 @@ namespace das {
         } else {
             auto bt = valT->getVectorBaseType();
             auto rt = valT->isRange() ? TypeDecl::getRangeType(bt, int(expr->fields.size())) : TypeDecl::getVectorType(bt, int(expr->fields.size()));
-            expr->type = new TypeDecl(rt);
+            expr->type = new TypeDecl(rt, expr->at);
             expr->type->constant = valT->constant;
             expr->type->ref = valT->ref;
             if (expr->type->ref) {
@@ -4041,7 +4031,7 @@ namespace das {
         expr->skipQQ = expr->type->isPointer();
         if (!expr->skipQQ) {
             auto fieldType = expr->type;
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = fieldType;
         }
         expr->type->constant |= valT->constant || expr->value->type->constant;
@@ -4077,7 +4067,7 @@ namespace das {
             return Visitor::visit(expr);
         }
         expr->fieldIndex = index;
-        expr->type = new TypeDecl(Type::tBool);
+        expr->type = new TypeDecl(Type::tBool, expr->at);
         return Visitor::visit(expr);
     }
     ExpressionPtr InferTypes::visit(ExprField *expr) {
@@ -4339,7 +4329,7 @@ namespace das {
             }
         } else if (expr->fieldIndex != -1) {
             if (valT->isBitfield()) {
-                expr->type = new TypeDecl(Type::tBool);
+                expr->type = new TypeDecl(Type::tBool, expr->at);
             } else {
                 auto tupleT = valT->isPointer() ? valT->firstType : valT;
                 auto & tt = tupleT->argTypes[expr->fieldIndex];
@@ -4359,7 +4349,7 @@ namespace das {
                 collectMissingOperators(".", mf, true);
                 if (!mf.empty()) {
                     reportDualFunctionNotFound(".`" + expr->name, "field '" + expr->name + "' not found in " + describeType(valT),
-                                               expr->at, mf, {valT}, {valT, new TypeDecl(Type::tString)}, true, false, true,
+                                               expr->at, mf, {valT}, {valT, new TypeDecl(Type::tString, expr->at)}, true, false, true,
                                                CompilationError::cant_get_field, 0, "");
                 } else {
                     error("field '" + expr->name + "' not found in " + describeType(valT), "", "",
@@ -4393,7 +4383,7 @@ namespace das {
                 collectMissingOperators("?.", mf, true);
                 if (!mf.empty()) {
                     reportDualFunctionNotFound("?.`" + expr->name, "can only safe dereference a variant or a pointer to a tuple, a structure or a handle " + describeType(valT),
-                                               expr->at, mf, {expr->value->type}, {expr->value->type, new TypeDecl(Type::tString)}, true, false, true,
+                                               expr->at, mf, {expr->value->type}, {expr->value->type, new TypeDecl(Type::tString, expr->at)}, true, false, true,
                                                CompilationError::invalid_safe_dereference_type, 0, "");
                 } else {
                     error("can only safe dereference a variant or a pointer to a tuple, a structure or a handle " + describeType(valT), "", "",
@@ -4460,7 +4450,7 @@ namespace das {
         expr->skipQQ = expr->type->isPointer();
         if (!expr->skipQQ) {
             auto fieldType = expr->type;
-            expr->type = new TypeDecl(Type::tPointer);
+            expr->type = new TypeDecl(Type::tPointer, expr->at);
             expr->type->firstType = fieldType;
         }
         expr->type->constant |= valT->constant;
@@ -5236,11 +5226,11 @@ namespace das {
                 pVar->type = new TypeDecl(*src->type->firstType);
                 pVar->type->ref = true;
             } else if (src->type->isRange()) {
-                pVar->type = new TypeDecl(src->type->getRangeBaseType());
+                pVar->type = new TypeDecl(src->type->getRangeBaseType(), pVar->at);
                 pVar->type->ref = false;
                 pVar->type->constant = true;
             } else if (src->type->isString()) {
-                pVar->type = new TypeDecl(Type::tInt);
+                pVar->type = new TypeDecl(Type::tInt, pVar->at);
                 pVar->type->ref = false;
                 pVar->type->constant = true;
             } else if (src->type->isHandle() && src->type->annotation->isIterable()) {
@@ -5428,7 +5418,7 @@ namespace das {
             program->stickyError("malformed AST, variable '" + var->name + "' is missing its type",
                   "likely a macro-generated declaration; set its type to auto to request inference", "",
                   var->at, CompilationError::internal_variable);
-            var->type = new TypeDecl(Type::autoinfer);  // repair in place; the sticky error still fails the compile
+            var->type = new TypeDecl(Type::autoinfer, var->at);  // repair in place; the sticky error still fails the compile
             var->type->at = var->at;
         }
         if (var->type && var->type->isExprType()) {
@@ -6089,7 +6079,7 @@ namespace das {
         if (func && func->isClassMethod && func->classParent && expr->name == "super") {
             if (auto baseClass = func->classParent->parent) {
                 vector<TypeDeclPtr> argumentTypes;
-                auto selfType = new TypeDecl(Type::tStructure);
+                auto selfType = new TypeDecl(Type::tStructure, func->classParent->at);
                 selfType->structType = func->classParent;
                 argumentTypes.reserve(1 + expr->arguments.size());
                 argumentTypes.push_back(selfType);
@@ -6387,7 +6377,7 @@ namespace das {
         }
     }
     ExpressionPtr InferTypes::visit(ExprStringBuilder *expr) {
-        expr->type = new TypeDecl(Type::tString);
+        expr->type = new TypeDecl(Type::tString, expr->at);
         return evalAndFoldStringBuilder(expr);
     }
 

--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -2128,7 +2128,7 @@ namespace das {
         }
     }
     ExpressionPtr InferTypes::inferGenericOperatorWithName(const string &opN, const LineInfo &expr_at, ExpressionPtr arg0, const string &arg1, InferCallError err) {
-        auto conststring = new TypeDecl(Type::tString);
+        auto conststring = new TypeDecl(Type::tString, expr_at);
         conststring->constant = true;
         auto fieldName = new ExprConstString(expr_at, arg1);
         fieldName->type = conststring;

--- a/src/ast/ast_infer_type_helper.cpp
+++ b/src/ast/ast_infer_type_helper.cpp
@@ -409,7 +409,7 @@ namespace das {
             if (!aT) {
                 auto bT = nameToBasicType(decl->alias);
                 if (bT != Type::none) {
-                    aT = new TypeDecl(bT);
+                    aT = new TypeDecl(bT, decl->at);
                 }
             }
             if (aT) {
@@ -1094,8 +1094,7 @@ namespace das {
                     return true;
                 }
             } else {
-                resType = new TypeDecl(Type::tVoid);
-                resType->at = expr->at;
+                resType = new TypeDecl(Type::tVoid, expr->at);
                 reportAstChanged();
                 return true;
             }

--- a/src/ast/ast_infer_type_make.cpp
+++ b/src/ast/ast_infer_type_make.cpp
@@ -18,7 +18,7 @@ namespace das {
                     // the generator contract fixes the block result to bool; pinning a bare
                     // auto here keeps return-type diagnostics at the offending return site
                     if (blk->returnType && blk->returnType->baseType == Type::autoinfer) {
-                        blk->returnType = new TypeDecl(Type::tBool);
+                        blk->returnType = new TypeDecl(Type::tBool, blk->at);
                         blk->returnType->at = blk->at;
                     }
                 }
@@ -90,8 +90,7 @@ namespace das {
                         if (!expr->iterType->isVoid()) {
                             auto yva = new Variable();
                             if (expr->iterType->ref) {
-                                yva->type = new TypeDecl(Type::tPointer);
-                                yva->type->at = block->at;
+                                yva->type = new TypeDecl(Type::tPointer, block->at);
                                 yva->type->firstType = new TypeDecl(*expr->iterType);
                                 if ( !yva->type->firstType->at.fileInfo ) yva->type->firstType->at = block->at;
                                 yva->type->firstType->ref = false;
@@ -1133,7 +1132,7 @@ namespace das {
         if (expr->type->isString()) {
             reportAstChanged();
             auto ecs = new ExprConstString(expr->at);
-            ecs->type = new TypeDecl(Type::tString);
+            ecs->type = new TypeDecl(Type::tString, ecs->at);
             return ecs;
         } else if (expr->type->isEnumT()) {
             auto f0 = expr->type->enumType->find(0, "");
@@ -1301,8 +1300,7 @@ namespace das {
                         expr->at, CompilationError::mismatching_tuple_argument_count);
                 return Visitor::visit(expr);
             }
-            auto mkt = new TypeDecl(Type::tTuple);
-            mkt->at = expr->at;
+            auto mkt = new TypeDecl(Type::tTuple, expr->at);
             for (size_t ai = 0; ai != argCount; ++ai) {
                 const auto &val = expr->values[ai];
                 const auto &argT = expr->recordType->argTypes[ai];
@@ -1323,8 +1321,7 @@ namespace das {
             }
             expr->makeType = mkt;
         } else {
-            auto mkt = new TypeDecl(Type::tTuple);
-            mkt->at = expr->at;
+            auto mkt = new TypeDecl(Type::tTuple, expr->at);
             for (auto &val : expr->values) {
                 auto valT = new TypeDecl(*val->type);
                 valT->at = expr->at;
@@ -1573,8 +1570,7 @@ namespace das {
         if (expr->gen2 && expr->makeArrayOnHeap) {
             // heap array literal: type directly as array<T> (not the stack fixed array); codegen
             // builds it on the heap, and to_array_move/to_table_move resolve their array<T> overload.
-            resT = new TypeDecl(Type::tArray);
-            resT->at = expr->at;
+            resT = new TypeDecl(Type::tArray, expr->at);
             resT->constant = false;
             resT->removeConstant = true;
             resT->firstType = new TypeDecl(*expr->recordType);

--- a/src/ast/ast_infer_type_op.cpp
+++ b/src/ast/ast_infer_type_op.cpp
@@ -725,7 +725,7 @@ namespace das {
             pLet->generated = true;
             auto pVar = new Variable();
             pVar->at = expr->left->at;
-            pVar->type = new TypeDecl(Type::autoinfer);
+            pVar->type = new TypeDecl(Type::autoinfer, pVar->at);
             pVar->type->ref = true;
             pVar->name = "_pod_inscope_temp_" + to_string(pVar->at.line) + "_" + to_string(pVar->at.column);
             pVar->init = expr->left->clone();
@@ -1068,9 +1068,9 @@ namespace das {
     ExpressionPtr InferTypes::visit(ExprTryCatch *expr) {
         if (jitEnabled()) {
             auto tryBlock = new ExprMakeBlock(expr->try_block->at, expr->try_block);
-            ((ExprBlock *)tryBlock->block)->returnType = new TypeDecl(Type::autoinfer);
+            ((ExprBlock *)tryBlock->block)->returnType = new TypeDecl(Type::autoinfer, expr->try_block->at);
             auto catchBlock = new ExprMakeBlock(expr->catch_block->at, expr->catch_block);
-            ((ExprBlock *)catchBlock->block)->returnType = new TypeDecl(Type::autoinfer);
+            ((ExprBlock *)catchBlock->block)->returnType = new TypeDecl(Type::autoinfer, expr->catch_block->at);
             auto ccall = new ExprCall(expr->at, "builtin_try_recover");
             ccall->arguments.push_back(tryBlock);
             ccall->arguments.push_back(catchBlock);

--- a/src/ast/ast_infer_type_report.cpp
+++ b/src/ast/ast_infer_type_report.cpp
@@ -83,7 +83,7 @@ namespace das {
             if (!aT) {
                 auto bT = nameToBasicType(decl->alias);
                 if (bT != Type::none) {
-                    aT = new TypeDecl(bT);
+                    aT = new TypeDecl(bT, decl->at);
                 }
             }
             if (!aT) {

--- a/src/ast/ast_inline.cpp
+++ b/src/ast/ast_inline.cpp
@@ -1134,8 +1134,7 @@ namespace das {
             var->name = name;
             var->at = at;
             var->generated = true;
-            var->type = new TypeDecl(Type::autoinfer);
-            var->type->at = at;
+            var->type = new TypeDecl(Type::autoinfer, at);
             var->type->constant = isConst;
             var->type->removeConstant = !isConst;
             var->type->ref = isRef;

--- a/src/ast/ast_inscope_pod.cpp
+++ b/src/ast/ast_inscope_pod.cpp
@@ -128,7 +128,7 @@ namespace das {
                     auto podVar = new Variable();
                     podVar->at = expr->sources[i]->at;
                     podVar->name = "`pod`source`" + expr->iterators[i];
-                    podVar->type = new TypeDecl(Type::autoinfer);
+                    podVar->type = new TypeDecl(Type::autoinfer, podVar->at);
                     podVar->init = move(expr->sources[i]);
                     podVar->init_via_move = true;
                     podVar->pod_delete = true;

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -1170,8 +1170,7 @@ namespace das {
     }
 
     TypeDeclPtr ModuleLibrary::makeStructureType ( const string & name ) const {
-        auto t = new TypeDecl(Type::tStructure);
-        t->at = cppBindingLineInfo(name.c_str());
+        auto t = new TypeDecl(Type::tStructure, cppBindingLineInfo(name.c_str()));
         auto structs = findStructure(name,nullptr);
         if ( structs.size()==1 ) {
             t->structType = structs.back();
@@ -1196,8 +1195,7 @@ namespace das {
     }
 
     TypeDeclPtr ModuleLibrary::makeHandleType ( const string & name ) const {
-        auto t = new TypeDecl(Type::tHandle);
-        t->at = cppBindingLineInfo(name.c_str());
+        auto t = new TypeDecl(Type::tHandle, cppBindingLineInfo(name.c_str()));
         auto handles = findAnnotation(name,nullptr);
 #if DAS_ALLOW_ANNOTATION_LOOKUP
         bool need_require = false;
@@ -1258,8 +1256,7 @@ namespace das {
             return nullptr;
         }
         auto dann = static_cast<DistinctTypeAnnotation *>(handles.back());
-        auto t = new TypeDecl(Type::tDistinct);
-        t->at = cppBindingLineInfo(name.c_str());
+        auto t = new TypeDecl(Type::tDistinct, cppBindingLineInfo(name.c_str()));
         t->annotation = dann;
         if ( dann->underlyingType ) {
             t->firstType = new TypeDecl(*dann->underlyingType);

--- a/src/ast/ast_optimize.cpp
+++ b/src/ast/ast_optimize.cpp
@@ -23,7 +23,6 @@ namespace das {
             last = program->optimizationRefFolding(optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REF FOLDING: " << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
-            applyPostInferMacros(program);                                if ( program->failed() ) break;
             last = program->optimizationUnused(logs, optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REMOVE UNUSED:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
@@ -43,7 +42,6 @@ namespace das {
             if ( log ) logs << "DEAD STORES:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;
             // this is here again for a reason
-            applyPostInferMacros(program);                                if ( program->failed() ) break;
             last = program->optimizationUnused(logs, optimizationRound);    if ( program->failed() ) break;  any |= last;
             if ( log ) logs << "REMOVE UNUSED:" << (last ? "optimized" : "nothing") << "\n";
             if ( logPass ) logs << *program;

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -1084,8 +1084,9 @@ namespace das {
                 *totInfer += inferLegT;
             }
             if ( !program->failed() ) {
-                // buildAccessFlags is the FIRST pass to read the finished tree, and it
-                // dereferences expr->type unguarded - so the verifier has to precede it
+                // the only post-infer firing: inference just finished, and buildAccessFlags -
+                // the first pass to read the tree - dereferences expr->type unguarded.
+                // What later passes and user macros rewrite belongs to a [simulate_macro]
                 applyPostInferMacros(program.get());
                 program->buildAccessFlags(logs);    // this is used by the lint pass
                 if ( program->patchAnnotations() ) {
@@ -1149,9 +1150,6 @@ namespace das {
             }
             if ( !program->failed() ) {
                 program->normalizeOptionTypes();
-                // lint / folding / codegen are the first consumers of the finished tree, and
-                // they dereference expr->type unguarded - so this is where a verifier can see it
-                applyPostInferMacros(program.get());
                 if (!program->failed())
                     program->lint(logs, libGroup);
                 if ( policies.macro_context_collect ) libGroup.collectMacroContexts();
@@ -1163,7 +1161,6 @@ namespace das {
                         callCompilationCallback(moduleName, fileName, "optimize");
                         optimizeProgram(program.get(),logs,libGroup);
                     } else {
-                        applyPostInferMacros(program.get());
                         program->buildAccessFlags(logs);
                     }
                 }

--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -1420,9 +1420,9 @@ namespace das {
         ss << fileName;
         auto rtti_require = new Variable();
         rtti_require->name = "__rtti_require";
-        rtti_require->type = new TypeDecl(Type::tString);
+        rtti_require->type = new TypeDecl(Type::tString, rtti_require->at);
         rtti_require->init = new ExprConstString(ss.str());
-        rtti_require->init->type = new TypeDecl(Type::tString);
+        rtti_require->init->type = new TypeDecl(Type::tString, rtti_require->init->at);
         rtti_require->used = true;
         rtti_require->private_variable = true;
         res->thisModule->addVariable(rtti_require);

--- a/src/ast/ast_program.cpp
+++ b/src/ast/ast_program.cpp
@@ -283,7 +283,7 @@ namespace das {
                             at,CompilationError::invalid_distinct_type);
                         return nullptr;
                     }
-                    auto pTD = new TypeDecl(Type::tDistinct);
+                    auto pTD = new TypeDecl(Type::tDistinct, at);
                     pTD->annotation = dann;
                     if ( dann->underlyingType ) {
                         pTD->firstType = new TypeDecl(*dann->underlyingType);
@@ -291,7 +291,7 @@ namespace das {
                     pTD->at = at;
                     return pTD;
                 } else if ( handles.back()->rtti_isHandledTypeAnnotation() ) {
-                    auto pTD = new TypeDecl(Type::tHandle);
+                    auto pTD = new TypeDecl(Type::tHandle, at);
                     pTD->annotation = static_cast<TypeAnnotation *>(handles.back());
                     pTD->at = at;
                     return pTD;
@@ -330,7 +330,7 @@ namespace das {
                 return nullptr;
             }
         } else {
-            auto tt = new TypeDecl(Type::alias);
+            auto tt = new TypeDecl(Type::alias, at);
             tt->alias = name;
             tt->at = at;
             return tt;

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -718,7 +718,7 @@ namespace das
             // lets set variant index
             uint32_t voffset = mkv->extraOffset + index*stride;
             auto vconst = new ExprConstInt(mkv->at, int32_t(fieldVariant));
-            vconst->type = new TypeDecl(Type::tInt);
+            vconst->type = new TypeDecl(Type::tInt, vconst->at);
             setE(vconst, context.code->makeNode<SimNode_ConstValue>(vconst->at, vconst->value));
             SimNode * svi;
             if ( mkv->useCMRES ) {
@@ -870,7 +870,7 @@ namespace das
             string fakeName = "__makelocal";
             auto fakeVariable = new Variable();
             fakeVariable->name = fakeName;
-            fakeVariable->type = new TypeDecl(Type::tHandle);
+            fakeVariable->type = new TypeDecl(Type::tHandle, fakeVariable->at);
             fakeVariable->type->annotation = ann;
             fakeVariable->at = mks->at;
             if ( mks->useCMRES ) {
@@ -896,9 +896,9 @@ namespace das
             if ( mks->useStackRef && total > 1 ) {
                 // if its stackRef with multiple indices, its actually var[total], and lookup is var[index]
                 indexExpr = new ExprConstInt(mks->at, 0);
-                indexExpr->type = new TypeDecl(Type::tInt);
+                indexExpr->type = new TypeDecl(Type::tInt, indexExpr->at);
                 fakeExpr = new ExprAt(mks->at, fakeExpr, indexExpr);
-                fakeExpr->type = new TypeDecl(Type::tHandle);
+                fakeExpr->type = new TypeDecl(Type::tHandle, fakeExpr->at);
                 fakeExpr->type->annotation = ann;
                 fakeExpr->type->ref = true;
             }
@@ -2019,7 +2019,7 @@ namespace das
             if ( expr->r2v ) {
                 setE(expr, sv_trySimulate(expr, 0, expr->type));
             } else {
-                gc_local<TypeDecl> noneType = new TypeDecl(Type::none);
+                gc_local<TypeDecl> noneType = new TypeDecl(Type::none, expr->at);
                 setE(expr, sv_trySimulate(expr, 0, noneType));
             }
         }
@@ -2348,7 +2348,7 @@ namespace das
             if ( expr->r2v ) {
                 setE(expr, sv_trySimulate(expr, 0, expr->type));
             } else {
-                gc_local<TypeDecl> noneType = new TypeDecl(Type::none);
+                gc_local<TypeDecl> noneType = new TypeDecl(Type::none, expr->at);
                 setE(expr, sv_trySimulate(expr, 0, noneType));
             }
         }
@@ -2365,7 +2365,7 @@ namespace das
             if ( expr->r2v ) {
                 setE(expr, sv_trySimulate(expr, 0, expr->type));
             } else {
-                gc_local<TypeDecl> noneType = new TypeDecl(Type::none);
+                gc_local<TypeDecl> noneType = new TypeDecl(Type::none, expr->at);
                 setE(expr, sv_trySimulate(expr, 0, noneType));
             }
         }
@@ -2598,7 +2598,7 @@ namespace das
             if ( expr->r2v ) {
                 setE(expr, sv_trySimulate(expr, 0, expr->type));
             } else {
-                gc_local<TypeDecl> noneType = new TypeDecl(Type::none);
+                gc_local<TypeDecl> noneType = new TypeDecl(Type::none, expr->at);
                 setE(expr, sv_trySimulate(expr, 0, noneType));
             }
         } else if ( expr->argument) {

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -71,6 +71,12 @@ namespace das
         gc_magic = GC_MAGIC_TYPEDECL;
     }
 
+    TypeDecl::TypeDecl(Enumeration * ep, const LineInfo & att)
+        : baseType(ep->getEnumType()), enumType(ep), at(att)
+    {
+        gc_magic = GC_MAGIC_TYPEDECL;
+    }
+
     LineInfo TypeDecl::getDeclarationLocation() const {
         if ( !at.empty() ) return at;
         switch ( baseType ) {
@@ -3774,7 +3780,7 @@ namespace das
         aMain.first = td;
         aMain.second |= viaPointer;
         if ( td->isBaseVectorType() ) {
-            auto bt = new TypeDecl(td->getVectorBaseType());
+            auto bt = new TypeDecl(td->getVectorBaseType(), td->at);
             auto & aSub = aliases[bt->getMangledName()];
             aSub.first = bt;
             aSub.second |= viaPointer;
@@ -4329,7 +4335,7 @@ namespace das
                 ch ++;
                 int di = atoi(numT.c_str());
                 if ( neg ) di = -di;
-                auto pt = new TypeDecl(Type::tFixedArray);
+                auto pt = new TypeDecl(Type::tFixedArray, at);
                 pt->fixedDim = di;
                 // fullName remove-suffixes emitted right after this node's [d] land back on it
                 for ( ;; ) {
@@ -4372,7 +4378,7 @@ namespace das
             };
             case 'H': {
                 ch ++;
-                auto pt = new TypeDecl(Type::tHandle);
+                auto pt = new TypeDecl(Type::tHandle, at);
                 auto annName = parseAnyNameInBrackets(ch,true);
                 auto ann = library.findAnnotation(annName,thisModule);
                 if ( thisModule && ann.size()==0 ) {
@@ -4399,7 +4405,7 @@ namespace das
             };
             case 'Q': {
                 ch ++;
-                auto pt = new TypeDecl(Type::tDistinct);
+                auto pt = new TypeDecl(Type::tDistinct, at);
                 auto annName = parseAnyNameInBrackets(ch,true);
                 auto ann = library.findAnnotation(annName,thisModule);
                 if ( thisModule && ann.size()==0 ) {
@@ -4426,7 +4432,7 @@ namespace das
             case 'S': {
                 ch ++;
                 auto sname = parseAnyNameInBrackets(ch,true);
-                auto pt = new TypeDecl(Type::tStructure);
+                auto pt = new TypeDecl(Type::tStructure, at);
                 auto stt = library.findStructure(sname, thisModule);
                 if ( thisModule && stt.size()==0 ) {
                     if ( auto tstt = thisModule->findStructure(sname) ) {
@@ -4471,15 +4477,15 @@ namespace das
                 TypeDeclPtr pt = nullptr;
                 if ( *ch=='8' ) {
                     ch ++;
-                    pt = new TypeDecl(Type::tEnumeration8);
+                    pt = new TypeDecl(Type::tEnumeration8, at);
                 } else if ( ch[0]=='1' && ch[1]=='6' ) {
                     ch += 2;
-                    pt = new TypeDecl(Type::tEnumeration16);
+                    pt = new TypeDecl(Type::tEnumeration16, at);
                 } else if ( ch[0]=='6' && ch[1]=='4' ) {
                     ch += 2;
-                    pt = new TypeDecl(Type::tEnumeration64);
+                    pt = new TypeDecl(Type::tEnumeration64, at);
                 } else {
-                    pt = new TypeDecl(Type::tEnumeration);
+                    pt = new TypeDecl(Type::tEnumeration, at);
                 }
                 if ( *ch=='<' ) {
                     auto sname = parseAnyNameInBrackets(ch,true);
@@ -4502,66 +4508,66 @@ namespace das
                 return pt;
             };
             case '_': {
-                        if ( ch[1]=='c' )                   { ch+=2; return new TypeDecl(Type::fakeContext); }
-                else    if ( ch[1]=='l' )                   { ch+=2; return new TypeDecl(Type::fakeLineInfo); }
+                        if ( ch[1]=='c' )                   { ch+=2; return new TypeDecl(Type::fakeContext, at); }
+                else    if ( ch[1]=='l' )                   { ch+=2; return new TypeDecl(Type::fakeLineInfo, at); }
                 else                                        { error("unsupported mangled name format - expecting fake...", ch); return new TypeDecl(); }
             }
             case 'i': {
-                        if ( ch[1]=='2' )                   { ch+=2; return new TypeDecl(Type::tInt2); }
-                else    if ( ch[1]=='3' )                   { ch+=2; return new TypeDecl(Type::tInt3); }
-                else    if ( ch[1]=='4' )                   { ch+=2; return new TypeDecl(Type::tInt4); }
-                else    if ( ch[1]=='8' )                   { ch+=2; return new TypeDecl(Type::tInt8); }
-                else    if ( ch[1]=='1' && ch[2]=='6' )     { ch+=3; return new TypeDecl(Type::tInt16); }
-                else    if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tInt64); }
-                else                                        { ch+=1; return new TypeDecl(Type::tInt); }
+                        if ( ch[1]=='2' )                   { ch+=2; return new TypeDecl(Type::tInt2, at); }
+                else    if ( ch[1]=='3' )                   { ch+=2; return new TypeDecl(Type::tInt3, at); }
+                else    if ( ch[1]=='4' )                   { ch+=2; return new TypeDecl(Type::tInt4, at); }
+                else    if ( ch[1]=='8' )                   { ch+=2; return new TypeDecl(Type::tInt8, at); }
+                else    if ( ch[1]=='1' && ch[2]=='6' )     { ch+=3; return new TypeDecl(Type::tInt16, at); }
+                else    if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tInt64, at); }
+                else                                        { ch+=1; return new TypeDecl(Type::tInt, at); }
             }
             case 'u': {
-                        if ( ch[1]=='2' )                   { ch+=2; return new TypeDecl(Type::tUInt2); }
-                else    if ( ch[1]=='3' )                   { ch+=2; return new TypeDecl(Type::tUInt3); }
-                else    if ( ch[1]=='4' )                   { ch+=2; return new TypeDecl(Type::tUInt4); }
-                else    if ( ch[1]=='8' )                   { ch+=2; return new TypeDecl(Type::tUInt8); }
-                else    if ( ch[1]=='1' && ch[2]=='6' )     { ch+=3; return new TypeDecl(Type::tUInt16); }
-                else    if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tUInt64); }
-                else                                        { ch+=1; return new TypeDecl(Type::tUInt); }
+                        if ( ch[1]=='2' )                   { ch+=2; return new TypeDecl(Type::tUInt2, at); }
+                else    if ( ch[1]=='3' )                   { ch+=2; return new TypeDecl(Type::tUInt3, at); }
+                else    if ( ch[1]=='4' )                   { ch+=2; return new TypeDecl(Type::tUInt4, at); }
+                else    if ( ch[1]=='8' )                   { ch+=2; return new TypeDecl(Type::tUInt8, at); }
+                else    if ( ch[1]=='1' && ch[2]=='6' )     { ch+=3; return new TypeDecl(Type::tUInt16, at); }
+                else    if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tUInt64, at); }
+                else                                        { ch+=1; return new TypeDecl(Type::tUInt, at); }
             }
             case 'f': {
-                        if ( ch[1]=='2' )                   { ch+=2; return new TypeDecl(Type::tFloat2); }
-                else    if ( ch[1]=='3' )                   { ch+=2; return new TypeDecl(Type::tFloat3); }
-                else    if ( ch[1]=='4' )                   { ch+=2; return new TypeDecl(Type::tFloat4); }
-                else                                        { ch+=1; return new TypeDecl(Type::tFloat); }
-            case '.':   ch++; return new TypeDecl(Type::autoinfer);
-            case '|':   ch++; return new TypeDecl(Type::option);
-            case 'D':   ch++; return new TypeDecl(Type::typeDecl);
-            case '^':   ch++; return new TypeDecl(Type::typeMacro);
-            case '*':   ch++; return new TypeDecl(Type::anyArgument);
-            case 'L':   ch++; return new TypeDecl(Type::alias);
-            case 'A':   ch++; return new TypeDecl(Type::tArray);
-            case 'T':   ch++; return new TypeDecl(Type::tTable);
-            case 'G':   ch++; return new TypeDecl(Type::tIterator);
-            case '$':   ch++; return new TypeDecl(Type::tBlock);
-            case 'U':   ch++; return new TypeDecl(Type::tTuple);
-            case 'V':   ch++; return new TypeDecl(Type::tVariant);
+                        if ( ch[1]=='2' )                   { ch+=2; return new TypeDecl(Type::tFloat2, at); }
+                else    if ( ch[1]=='3' )                   { ch+=2; return new TypeDecl(Type::tFloat3, at); }
+                else    if ( ch[1]=='4' )                   { ch+=2; return new TypeDecl(Type::tFloat4, at); }
+                else                                        { ch+=1; return new TypeDecl(Type::tFloat, at); }
+            case '.':   ch++; return new TypeDecl(Type::autoinfer, at);
+            case '|':   ch++; return new TypeDecl(Type::option, at);
+            case 'D':   ch++; return new TypeDecl(Type::typeDecl, at);
+            case '^':   ch++; return new TypeDecl(Type::typeMacro, at);
+            case '*':   ch++; return new TypeDecl(Type::anyArgument, at);
+            case 'L':   ch++; return new TypeDecl(Type::alias, at);
+            case 'A':   ch++; return new TypeDecl(Type::tArray, at);
+            case 'T':   ch++; return new TypeDecl(Type::tTable, at);
+            case 'G':   ch++; return new TypeDecl(Type::tIterator, at);
+            case '$':   ch++; return new TypeDecl(Type::tBlock, at);
+            case 'U':   ch++; return new TypeDecl(Type::tTuple, at);
+            case 'V':   ch++; return new TypeDecl(Type::tVariant, at);
             case 't':   {
-                        if ( ch[1]=='8' )                   { ch+=2; return new TypeDecl(Type::tBitfield8); }
-                else    if ( ch[1]=='1' && ch[2]=='6' )     { ch+=3; return new TypeDecl(Type::tBitfield16); }
-                else    if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tBitfield64); }
-                else                                        { ch++; return new TypeDecl(Type::tBitfield); }
+                        if ( ch[1]=='8' )                   { ch+=2; return new TypeDecl(Type::tBitfield8, at); }
+                else    if ( ch[1]=='1' && ch[2]=='6' )     { ch+=3; return new TypeDecl(Type::tBitfield16, at); }
+                else    if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tBitfield64, at); }
+                else                                        { ch++; return new TypeDecl(Type::tBitfield, at); }
             }
             case 'r':   {
-                        if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tRange64); }
-                else                                        { ch+=1; return new TypeDecl(Type::tRange); }
+                        if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tRange64, at); }
+                else                                        { ch+=1; return new TypeDecl(Type::tRange, at); }
             }
             case 'z':   {
-                        if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tURange64); }
-                else                                        { ch+=1; return new TypeDecl(Type::tURange); }
+                        if ( ch[1]=='6' && ch[2]=='4' )     { ch+=3; return new TypeDecl(Type::tURange64, at); }
+                else                                        { ch+=1; return new TypeDecl(Type::tURange, at); }
             }
-            case 'd':   ch++; return new TypeDecl(Type::tDouble);
-            case 's':   ch++; return new TypeDecl(Type::tString);
-            case 'v':   ch++; return new TypeDecl(Type::tVoid);
-            case 'b':   ch++; return new TypeDecl(Type::tBool);
+            case 'd':   ch++; return new TypeDecl(Type::tDouble, at);
+            case 's':   ch++; return new TypeDecl(Type::tString, at);
+            case 'v':   ch++; return new TypeDecl(Type::tVoid, at);
+            case 'b':   ch++; return new TypeDecl(Type::tBool, at);
             case '?':   {
                 ch++;
-                auto pt = new TypeDecl(Type::tPointer);
+                auto pt = new TypeDecl(Type::tPointer, at);
                 if ( *ch=='M' ) {
                     pt->smartPtr = true;
                     pt->smartPtrNative = false;
@@ -4576,10 +4582,10 @@ namespace das
             case '@':   {
                 if ( ch[1]=='@' ) {
                     ch+=2;
-                    return new TypeDecl(Type::tFunction);
+                    return new TypeDecl(Type::tFunction, at);
                 } else {
                     ch++;
-                    return new TypeDecl(Type::tLambda);
+                    return new TypeDecl(Type::tLambda, at);
                 }
             };
             case '&': {
@@ -4668,11 +4674,6 @@ namespace das
         }
         error("unsupported mangled name format symbol", ch);
         return new TypeDecl();
-    }
-
-    TypeDeclPtr parseTypeFromMangledName ( const char * & ch, const ModuleLibrary & library, Module * thisModule ) {
-        MangledNameParser parser;
-        return parser.parseTypeFromMangledName(ch, library, thisModule);
     }
 
     bool hasImplicit ( const TypeDeclPtr & type ) {

--- a/src/ast/ast_unused.cpp
+++ b/src/ast/ast_unused.cpp
@@ -1000,7 +1000,7 @@ namespace das {
                             } else if ( expr->type->baseType==Type::tString ) {
                                 reportFolding();
                                 auto exprV = new ExprConstString(expr->at);
-                                exprV->type = new TypeDecl(Type::tString);
+                                exprV->type = new TypeDecl(Type::tString, exprV->at);
                                 exprV->type->constant = true;
                                 return exprV;
                             } else {

--- a/src/builtin/module_builtin.cpp
+++ b/src/builtin/module_builtin.cpp
@@ -272,7 +272,7 @@ namespace das
         // `half` spells float16 without reserving the identifier (audit: `half` is a common
         // local name — 107 uses in-tree; an alias coexists with same-named locals)
         {
-            auto halfT = new TypeDecl(Type::tFloat16);
+            auto halfT = new TypeDecl(Type::tFloat16, cppBindingLineInfo());
             halfT->alias = "half";
             addAlias(halfT);
         }

--- a/src/builtin/module_builtin_ast.cpp
+++ b/src/builtin/module_builtin_ast.cpp
@@ -694,15 +694,14 @@ namespace das {
             context->throw_error_at(at, "%s, near %s", err.c_str(), ch );
         }
     public:
+        MangledNameParserCtx ( const LineInfo & att ) : MangledNameParser(att) {}
         Context *   context = nullptr;
-        LineInfo *  at = nullptr;
     };
 
     TypeDeclPtr parseMangledNameFn ( const char * txt, ModuleGroup & lib, Module * thisModule, Context * context, LineInfoArg * at ) {
         if ( !txt ) context->throw_error_at(at, "can't parse empty mangled name");
-        MangledNameParserCtx parser;
+        MangledNameParserCtx parser(*at);
         parser.context = context;
-        parser.at = at;
         return parser.parseTypeFromMangledName(txt, lib, thisModule);
     }
 

--- a/src/builtin/module_builtin_ast_flags.cpp
+++ b/src/builtin/module_builtin_ast_flags.cpp
@@ -18,35 +18,35 @@ using namespace das;
 namespace das {
 
     TypeDeclPtr makeExprLetFlagsFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprLetFlags";
         ft->argNames = { "inScope", "hasEarlyOut", "itTupleExpansion" };
         return ft;
     }
 
     TypeDeclPtr makeExprGenFlagsFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprGenFlags";
         ft->argNames = { "alwaysSafe", "generated", "userSaidItsSafe" };
         return ft;
     }
 
     TypeDeclPtr makeExprFlagsFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprFlags";
         ft->argNames = { "constexpression", "noSideEffects", "noNativeSideEffects", "isForLoopSource", "isCallArgument" };
         return ft;
     }
 
     TypeDeclPtr makeExprPrintFlagsFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprPrintFlags";
         ft->argNames = { "topLevel", "argLevel", "bottomLevel" };
         return ft;
     }
 
     TypeDeclPtr makeExprBlockFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprBlockFlags";
         ft->argNames = { "isClosure", "hasReturn", "copyOnReturn", "moveOnReturn",
             "inTheLoop", "finallyBeforeBody", "finallyDisabled","aotSkipMakeBlock",
@@ -56,21 +56,21 @@ namespace das {
     }
 
     TypeDeclPtr makeMakeFieldDeclFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "MakeFieldDeclFlags";
         ft->argNames = { "moveSemantics", "cloneSemantics" };
         return ft;
     }
 
     TypeDeclPtr makeExprAtFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprAtFlags";
         ft->argNames = { "r2v", "r2cr", "write", "no_promotion", "under_clone", "under_deref", "no_bound_check" };
         return ft;
     }
 
     TypeDeclPtr makeExprMakeLocalFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprMakeLocalFlags";
         ft->argNames = { "useStackRef", "useCMRES", "doesNotNeedSp",
             "doesNotNeedInit", "initAllFields", "alwaysAlias" };
@@ -78,7 +78,7 @@ namespace das {
     }
 
     TypeDeclPtr makeExprMakeStructFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprMakeStructFlags";
         ft->argNames = { "useInitializer", "isNewHandle", "usedInitializer", "nativeClassInitializer",
             "isNewClass", "forceClass", "forceStruct", "forceVariant", "forceTuple", "alwaysUseInitializer",
@@ -87,20 +87,20 @@ namespace das {
     }
 
     TypeDeclPtr makeExprAscendFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprAscendFlags";
         ft->argNames = { "useStackRef", "needTypeInfo", "allocate_on_stack" };
         return ft;
     }
 
     TypeDeclPtr makeExprCastFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprCastFlags";
         ft->argNames = { "upcastCast", "reinterpretCast", "fromAddrSugar" };
         return ft;
     }
     TypeDeclPtr makeExprVarFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprVarFlags";
         ft->argNames = { "local", "argument", "_block",
             "thisBlock", "r2v", "r2cr", "write", "under_clone" };
@@ -108,35 +108,35 @@ namespace das {
     }
 
    TypeDeclPtr makeExprFieldDerefFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprFieldDerefFlags";
         ft->argNames = { "unsafeDeref", "ignoreCaptureConst" };
         return ft;
     }
 
     TypeDeclPtr makeExprFieldFieldFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprFieldFieldFlags";
         ft->argNames = { "r2v", "r2cr", "write", "no_promotion", "under_clone" };
         return ft;
     }
 
     TypeDeclPtr makeExprSwizzleFieldFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprSwizzleFieldFlags";
         ft->argNames = { "r2v", "r2cr", "write", "no_promotion" };
         return ft;
     }
 
     TypeDeclPtr makeExprYieldFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprYieldFlags";
         ft->argNames = { "moveSemantics" };
         return ft;
     }
 
     TypeDeclPtr makeExprReturnFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprReturnFlags";
         ft->argNames = { "moveSemantics", "returnReference", "returnInBlock", "takeOverRightStack",
         "returnCallCMRES", "returnCMRES", "fromYield", "fromComprehension" };
@@ -144,14 +144,14 @@ namespace das {
     }
 
     TypeDeclPtr makeExprMakeBlockFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ExprMakeBlockFlags";
         ft->argNames = { "isLambda", "isLocalFunction" };
         return ft;
     }
 
     TypeDeclPtr makeTypeDeclFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "TypeDeclFlags";
         ft->argNames = { "ref", "constant", "temporary", "_implicit",
             "removeRef", "removeConstant", "removeDim",
@@ -163,7 +163,7 @@ namespace das {
     }
 
     TypeDeclPtr makeFieldDeclarationFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "FieldDeclarationFlags";
         ft->argNames = { "moveSemantics", "parentType", "capturedConstant",
             "generated", "capturedRef", "doNotDelete", "privateField", "_sealed",
@@ -172,7 +172,7 @@ namespace das {
     }
 
     TypeDeclPtr makeStructureFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "StructureFlags";
         ft->argNames = { "isClass", "genCtor", "cppLayout", "cppLayoutNotPod",
             "generated", "persistent", "isLambda", "privateStructure",
@@ -184,7 +184,7 @@ namespace das {
     }
 
     TypeDeclPtr makeFunctionFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "FunctionFlags";
         ft->argNames = {
             "builtIn", "policyBased", "callBased", "interopFn", "hasReturn", "copyOnReturn", "moveOnReturn", "exports",
@@ -196,7 +196,7 @@ namespace das {
     }
 
     TypeDeclPtr makeMoreFunctionFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "MoreFunctionFlags";
         ft->argNames = {
             "macroFunction", "needStringCast", "aotHashDeppendsOnArguments", "lateInit", "requestJit",
@@ -210,7 +210,7 @@ namespace das {
     }
 
     TypeDeclPtr makeMoreFunctionFlags2() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "MoreFunctionFlags2";
         ft->argNames = {
             "localFunction", "tempStringResult", "mayQueueTempString", "needCallerStackFrame",
@@ -220,7 +220,7 @@ namespace das {
     }
 
     TypeDeclPtr makeFunctionSideEffectFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "FunctionSideEffectFlags";
         ft->argNames = { "_unsafe", "userScenario","modifyExternal",
             "modifyArgument","accessGlobal","invoke"
@@ -229,7 +229,7 @@ namespace das {
     }
 
     TypeDeclPtr makeVariableFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "VariableFlags";
         ft->argNames = { "init_via_move", "init_via_clone", "used", "aliasCMRES",
             "marked_used", "global_shared", "do_not_delete", "generated", "capture_as_ref",
@@ -240,7 +240,7 @@ namespace das {
     }
 
     TypeDeclPtr makeVariableAccessFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "VariableAccessFlags";
         ft->argNames = { "access_extern", "access_get", "access_ref",
             "access_init", "access_pass", "access_fold" };
@@ -248,35 +248,35 @@ namespace das {
     }
 
     TypeDeclPtr makeVariableAccessInfoFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "VariableAccessInfoFlags";
         ft->argNames = { "access_info_pass_mutable" };
         return ft;
     }
 
     TypeDeclPtr makeExprCopyFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "CopyFlags";
         ft->argNames = { "allowCopyTemp", "takeOverRightStack", "allowConstantLValue" };
         return ft;
     }
 
     TypeDeclPtr makeExprMoveFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "MoveFlags";
         ft->argNames = { "takeOverRightStack", "allowConstantLValue", "podDelete" };
         return ft;
     }
 
     TypeDeclPtr makeExprIfFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "IfFlags";
         ft->argNames = { "isStatic", "doNotFold" };
         return ft;
     }
 
     TypeDeclPtr makeExprStringBuilderFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "StringBuilderFlags";
         ft->argNames = { "isTempString" };
         return ft;

--- a/src/builtin/module_builtin_math.cpp
+++ b/src/builtin/module_builtin_math.cpp
@@ -233,7 +233,7 @@ namespace das {
             const char * fieldNames [] = {"x","y","z","w"};
             for ( int r=0; r!=RowC; ++r ) {
                 this->addFieldEx(fieldNames[r], "m[" + to_string(r) + "]", r*ColC*sizeof(float),
-                    new TypeDecl(TypeDecl::getVectorType(Type::tFloat, ColC)));
+                    new TypeDecl(TypeDecl::getVectorType(Type::tFloat, ColC), cppBindingLineInfo()));
             }
         }
         virtual bool isIndexable ( const TypeDeclPtr & decl ) const override {
@@ -243,7 +243,7 @@ namespace das {
             auto decl = idx->type;
             if ( !decl->isIndex() ) return nullptr;
             auto bt = TypeDecl::getVectorType(Type::tFloat, ColC);
-            auto pt = new TypeDecl(bt);
+            auto pt = new TypeDecl(bt, idx->at);
             pt->ref = true;
             return pt;
         }
@@ -268,7 +268,7 @@ namespace das {
         }
         virtual SimNode * simulateGetAt ( Context & context, const LineInfo & at, const TypeDeclPtr &,
                                          ExpressionPtr rv, ExpressionPtr idx, uint32_t ofs ) const override {
-            gc_local<TypeDecl> none = new TypeDecl(Type::none);
+            gc_local<TypeDecl> none = new TypeDecl(Type::none, cppBindingLineInfo());
             if ( auto tnode = trySimulate(context, rv, idx, none.ptr, ofs) ) {
                 return tnode;
             } else {
@@ -281,7 +281,7 @@ namespace das {
         virtual SimNode * simulateGetAtR2V ( Context & context, const LineInfo & at, const TypeDeclPtr & readType,
                                             ExpressionPtr rv, ExpressionPtr idx, uint32_t ofs ) const override {
             auto r2vType = readType->baseType;
-            gc_local<TypeDecl> r2vTypeDecl = new TypeDecl(r2vType);
+            gc_local<TypeDecl> r2vTypeDecl = new TypeDecl(r2vType, cppBindingLineInfo());
             if ( auto tnode = trySimulate(context, rv, idx, r2vTypeDecl.ptr, ofs) ) {
                 return tnode;
             } else {

--- a/src/builtin/module_builtin_rtti.cpp
+++ b/src/builtin/module_builtin_rtti.cpp
@@ -370,7 +370,7 @@ namespace das {
     template <>
     struct typeFactory<RttiValue> {
         static TypeDeclPtr make(const ModuleLibrary & library ) {
-            auto vtype = new TypeDecl(Type::tVariant);
+            auto vtype = new TypeDecl(Type::tVariant, cppBindingLineInfo());
             vtype->alias = "RttiValue";
             vtype->aotAlias = false;
             vtype->addVariant("tBool",   typeFactory<RttiValue::NthType<RttiBool>>::make(library));
@@ -390,7 +390,7 @@ namespace das {
     };
 
     TypeDeclPtr makeModuleFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ModuleFlags";
         ft->argNames = {
             "builtIn", "promoted", "isPublic", "isModule", "isSolidContext",
@@ -448,7 +448,7 @@ namespace das {
     };
 
     TypeDeclPtr makeContextCategoryFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "context_category_flags";
         ft->argNames = { "dead", "debug_context", "thread_clone", "job_clone", "opengl",
             "debugger_tick", "debugger_attached", "macro_context", "folding_context", "audio" };
@@ -494,7 +494,7 @@ namespace das {
     };
 
     TypeDeclPtr makeSimFunctionFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "SimFunctionFlags";
         ft->argNames = { "aot", "fastcall", "builtin", "jit", "unsafe", "cmres", "pinvoke" };
         return ft;
@@ -524,7 +524,7 @@ namespace das {
     };
 
     TypeDeclPtr makeProgramFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "ProgramFlags";
         ft->argNames = { "failToCompile", "_unsafe", "isCompiling", "isSimulating",
             "isCompilingMacros", "needMacroModule", "promoteToBuiltin",
@@ -584,7 +584,7 @@ namespace das {
     };
 
     TypeDeclPtr makeAnnotationDeclarationFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "AnnotationDeclarationFlags";
         ft->argNames = { "inherited" };
         return ft;
@@ -777,7 +777,7 @@ namespace das {
 
 
     TypeDeclPtr makeStructInfoFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "StructInfoFlags";
         ft->argNames = { "_class", "_lambda", "heapGC", "stringHeapGC" };
         return ft;
@@ -810,7 +810,7 @@ namespace das {
     }
 
     TypeDeclPtr makeTypeInfoFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "TypeInfoFlags";
         ft->argNames = { "ref", "refType", "canCopy", "isPod", "isRawPod", "isConst", "isTemp", "isImplicit",
             "refValue", "hasInitValue", "isSmartPtr", "isSmartPtrNative", "isHandled",
@@ -877,7 +877,7 @@ namespace das {
     };
 
     TypeDeclPtr makeLocalVariableInfoFlagsFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "LocalVariableInfoFlags";
         ft->argNames = { "cmres" };
         return ft;

--- a/src/builtin/module_builtin_runtime.cpp
+++ b/src/builtin/module_builtin_runtime.cpp
@@ -1697,7 +1697,7 @@ namespace das
     };
 
     TypeDeclPtr makePrintFlags() {
-        auto ft = new TypeDecl(Type::tBitfield);
+        auto ft = new TypeDecl(Type::tBitfield, cppBindingLineInfo());
         ft->alias = "print_flags";
         ft->argNames = { "escapeString", "namesAndDimensions", "typeQualifiers", "refAddresses", "singleLine", "fixedPoint", "fullTypeInfo" };
         return ft;

--- a/src/misc/daScriptC.cpp
+++ b/src/misc/daScriptC.cpp
@@ -677,7 +677,7 @@ void das_module_bind_interop_function_n ( das_module * mod, das_module_group * l
     auto fn = new CFunction(name_string.c_str(), *(ModuleLibrary *)lib, cpp_name_string.c_str(), fun);
     fn->setSideEffects((das::SideEffects) sideffects);
     vector <TypeDeclPtr> arguments;
-    MangledNameParser parser;
+    MangledNameParser parser(cppBindingLineInfo(name_string.c_str()));
     const char * arg = args_string.c_str();
     while ( *arg ) {
         auto tt = parser.parseTypeFromMangledName(arg, *(ModuleLibrary*)lib,(Module *)mod);
@@ -706,7 +706,7 @@ void das_module_bind_interop_function_unaligned_n ( das_module * mod, das_module
     auto fn = new CFunction_Unaligned(name_string.c_str(), *(ModuleLibrary *)lib, cpp_name_string.c_str(), fun);
     fn->setSideEffects((das::SideEffects) sideffects);
     vector <TypeDeclPtr> arguments;
-    MangledNameParser parser;
+    MangledNameParser parser(cppBindingLineInfo(name_string.c_str()));
     const char * arg = args_string.c_str();
     while ( *arg ) {
         auto tt = parser.parseTypeFromMangledName(arg, *(ModuleLibrary*)lib,(Module *)mod);
@@ -728,7 +728,7 @@ void das_module_bind_alias_n ( das_module * mod, das_module_group * lib,
                                const char * tname, size_t tname_length ) {
     auto alias_name = string_from_range(aname, aname_length, "aname");
     auto type_name = c_string_from_range(tname, tname_length, "tname");
-    MangledNameParser parser;
+    MangledNameParser parser(cppBindingLineInfo(alias_name.c_str()));
     auto tt = type_name.c_str();
     auto at = parser.parseTypeFromMangledName(tt, *(ModuleLibrary*)lib,(Module *)mod);
     DAS_ASSERT(at->alias.empty() && "already an alias");
@@ -783,7 +783,7 @@ void das_structure_add_field_n ( das_structure * st, das_module * mod, das_modul
     auto name_string = string_from_range(name, name_length, "name");
     auto cpp_name_string = string_from_range(cppname, cppname_length, "cppname");
     auto type_name = c_string_from_range(tname, tname_length, "tname");
-    MangledNameParser parser;
+    MangledNameParser parser(cppBindingLineInfo(name_string.c_str()));
     auto tt = type_name.c_str();
     auto at = parser.parseTypeFromMangledName(tt, *(ModuleLibrary*)lib,(Module *)mod);
     ((CStructureAnnotation *)st)->addFieldEx(name_string, cpp_name_string, checked_u32(offset, "offset"), at);

--- a/src/parser/ds2_parser.cpp
+++ b/src/parser/ds2_parser.cpp
@@ -1161,71 +1161,71 @@ static const yytype_int16 yyrline[] =
     1762,  1773,  1777,  1780,  1788,  1788,  1788,  1791,  1797,  1800,
     1804,  1808,  1815,  1822,  1828,  1832,  1836,  1839,  1842,  1850,
     1853,  1861,  1867,  1868,  1869,  1873,  1874,  1878,  1879,  1883,
-    1888,  1896,  1903,  1916,  1920,  1923,  1933,  1933,  1933,  1936,
-    1936,  1936,  1941,  1941,  1941,  1949,  1949,  1949,  1955,  1965,
-    1976,  1991,  1994,  1997,  2000,  2006,  2007,  2015,  2027,  2028,
-    2029,  2033,  2034,  2035,  2036,  2037,  2041,  2046,  2054,  2055,
-    2059,  2066,  2070,  2077,  2078,  2079,  2080,  2081,  2082,  2083,
-    2084,  2088,  2089,  2090,  2091,  2092,  2093,  2094,  2095,  2096,
-    2097,  2098,  2099,  2100,  2101,  2102,  2103,  2104,  2105,  2106,
-    2107,  2108,  2112,  2118,  2125,  2137,  2143,  2151,  2159,  2170,
-    2182,  2186,  2193,  2196,  2196,  2196,  2201,  2201,  2201,  2215,
-    2219,  2223,  2227,  2233,  2241,  2247,  2255,  2263,  2274,  2283,
-    2289,  2297,  2297,  2297,  2304,  2308,  2317,  2325,  2333,  2337,
-    2340,  2348,  2349,  2350,  2357,  2358,  2359,  2360,  2361,  2362,
-    2363,  2364,  2365,  2366,  2367,  2368,  2369,  2370,  2371,  2372,
-    2373,  2374,  2375,  2376,  2377,  2378,  2379,  2380,  2381,  2382,
-    2383,  2384,  2385,  2386,  2387,  2388,  2389,  2390,  2391,  2392,
-    2398,  2399,  2400,  2401,  2402,  2417,  2426,  2427,  2428,  2429,
-    2430,  2431,  2432,  2433,  2434,  2435,  2436,  2437,  2438,  2439,
-    2440,  2440,  2440,  2448,  2449,  2450,  2455,  2458,  2458,  2458,
-    2461,  2466,  2470,  2470,  2470,  2475,  2482,  2488,  2492,  2492,
-    2492,  2497,  2500,  2506,  2506,  2506,  2513,  2518,  2522,  2522,
-    2522,  2527,  2530,  2536,  2536,  2536,  2543,  2548,  2549,  2550,
-    2551,  2552,  2553,  2554,  2555,  2556,  2558,  2562,  2563,  2568,
-    2574,  2580,  2589,  2592,  2595,  2604,  2605,  2606,  2607,  2608,
-    2609,  2610,  2614,  2618,  2622,  2626,  2630,  2634,  2638,  2642,
-    2646,  2651,  2655,  2660,  2664,  2669,  2676,  2677,  2681,  2682,
-    2683,  2687,  2688,  2692,  2693,  2694,  2698,  2699,  2703,  2715,
-    2718,  2719,  2723,  2723,  2742,  2741,  2756,  2755,  2772,  2784,
-    2793,  2803,  2804,  2805,  2806,  2807,  2811,  2814,  2823,  2824,
-    2828,  2831,  2835,  2848,  2857,  2858,  2862,  2865,  2869,  2882,
-    2883,  2887,  2893,  2899,  2908,  2911,  2918,  2921,  2927,  2928,
-    2929,  2933,  2934,  2938,  2945,  2950,  2959,  2965,  2969,  2980,
-    2987,  2996,  2999,  3002,  3009,  3013,  3019,  3031,  3034,  3039,
-    3051,  3052,  3056,  3057,  3058,  3062,  3065,  3068,  3068,  3088,
-    3091,  3091,  3109,  3114,  3122,  3123,  3127,  3130,  3143,  3160,
-    3161,  3162,  3167,  3167,  3193,  3194,  3201,  3214,  3215,  3216,
-    3220,  3230,  3233,  3239,  3240,  3244,  3245,  3249,  3250,  3254,
-    3256,  3261,  3254,  3277,  3278,  3282,  3283,  3287,  3293,  3294,
-    3295,  3296,  3300,  3301,  3302,  3306,  3309,  3315,  3317,  3322,
-    3315,  3343,  3350,  3355,  3364,  3370,  3374,  3385,  3386,  3387,
-    3388,  3389,  3390,  3391,  3392,  3393,  3394,  3395,  3396,  3397,
-    3398,  3399,  3400,  3401,  3402,  3403,  3404,  3405,  3406,  3407,
-    3408,  3409,  3410,  3411,  3412,  3413,  3414,  3415,  3416,  3417,
-    3418,  3419,  3420,  3421,  3422,  3423,  3424,  3425,  3426,  3427,
-    3428,  3429,  3430,  3431,  3432,  3433,  3434,  3438,  3439,  3440,
-    3441,  3442,  3443,  3444,  3445,  3449,  3460,  3464,  3471,  3483,
-    3490,  3496,  3505,  3510,  3520,  3530,  3540,  3553,  3554,  3555,
-    3556,  3557,  3561,  3565,  3565,  3565,  3579,  3580,  3584,  3589,
-    3596,  3599,  3602,  3605,  3611,  3614,  3628,  3629,  3633,  3634,
-    3635,  3636,  3637,  3637,  3637,  3641,  3646,  3653,  3660,  3660,
-    3667,  3667,  3674,  3678,  3682,  3687,  3692,  3697,  3702,  3706,
-    3710,  3715,  3719,  3723,  3728,  3728,  3728,  3734,  3741,  3741,
-    3741,  3746,  3746,  3746,  3752,  3752,  3752,  3757,  3763,  3763,
-    3763,  3768,  3768,  3768,  3777,  3783,  3783,  3783,  3788,  3788,
-    3788,  3797,  3803,  3803,  3803,  3808,  3808,  3808,  3817,  3817,
-    3817,  3823,  3823,  3823,  3832,  3835,  3846,  3862,  3864,  3869,
-    3874,  3862,  3900,  3902,  3907,  3913,  3900,  3939,  3941,  3946,
-    3951,  3939,  3992,  3993,  3994,  3995,  3996,  3997,  3998,  4002,
-    4003,  4004,  4005,  4006,  4010,  4017,  4024,  4030,  4036,  4043,
-    4050,  4056,  4065,  4068,  4074,  4082,  4087,  4094,  4099,  4105,
-    4106,  4110,  4111,  4115,  4115,  4115,  4123,  4123,  4123,  4130,
-    4130,  4130,  4141,  4141,  4141,  4148,  4148,  4148,  4159,  4165,
-    4165,  4165,  4179,  4200,  4200,  4200,  4210,  4210,  4210,  4224,
-    4224,  4224,  4238,  4247,  4247,  4247,  4268,  4275,  4275,  4275,
-    4285,  4288,  4299,  4305,  4328,  4336,  4358,  4384,  4385,  4389,
-    4390,  4395,  4398,  4408
+    1888,  1896,  1903,  1915,  1919,  1922,  1932,  1932,  1932,  1935,
+    1935,  1935,  1940,  1940,  1940,  1948,  1948,  1948,  1954,  1964,
+    1975,  1990,  1993,  1996,  1999,  2005,  2006,  2014,  2026,  2027,
+    2028,  2032,  2033,  2034,  2035,  2036,  2040,  2045,  2053,  2054,
+    2058,  2065,  2069,  2076,  2077,  2078,  2079,  2080,  2081,  2082,
+    2083,  2087,  2088,  2089,  2090,  2091,  2092,  2093,  2094,  2095,
+    2096,  2097,  2098,  2099,  2100,  2101,  2102,  2103,  2104,  2105,
+    2106,  2107,  2111,  2117,  2124,  2136,  2142,  2150,  2158,  2169,
+    2181,  2185,  2192,  2195,  2195,  2195,  2200,  2200,  2200,  2213,
+    2217,  2221,  2225,  2231,  2239,  2245,  2253,  2261,  2272,  2281,
+    2287,  2295,  2295,  2295,  2302,  2306,  2315,  2323,  2331,  2335,
+    2338,  2346,  2347,  2348,  2355,  2356,  2357,  2358,  2359,  2360,
+    2361,  2362,  2363,  2364,  2365,  2366,  2367,  2368,  2369,  2370,
+    2371,  2372,  2373,  2374,  2375,  2376,  2377,  2378,  2379,  2380,
+    2381,  2382,  2383,  2384,  2385,  2386,  2387,  2388,  2389,  2390,
+    2396,  2397,  2398,  2399,  2400,  2415,  2424,  2425,  2426,  2427,
+    2428,  2429,  2430,  2431,  2432,  2433,  2434,  2435,  2436,  2437,
+    2438,  2438,  2438,  2446,  2447,  2448,  2453,  2456,  2456,  2456,
+    2459,  2464,  2468,  2468,  2468,  2473,  2480,  2486,  2490,  2490,
+    2490,  2495,  2498,  2504,  2504,  2504,  2511,  2516,  2520,  2520,
+    2520,  2525,  2528,  2534,  2534,  2534,  2541,  2546,  2547,  2548,
+    2549,  2550,  2551,  2552,  2553,  2554,  2556,  2560,  2561,  2566,
+    2572,  2578,  2587,  2590,  2593,  2602,  2603,  2604,  2605,  2606,
+    2607,  2608,  2612,  2616,  2620,  2624,  2628,  2632,  2636,  2640,
+    2644,  2649,  2653,  2658,  2662,  2667,  2674,  2675,  2679,  2680,
+    2681,  2685,  2686,  2690,  2691,  2692,  2696,  2697,  2701,  2713,
+    2716,  2717,  2721,  2721,  2740,  2739,  2754,  2753,  2770,  2782,
+    2791,  2801,  2802,  2803,  2804,  2805,  2809,  2812,  2821,  2822,
+    2826,  2829,  2833,  2846,  2855,  2856,  2860,  2863,  2867,  2880,
+    2881,  2885,  2890,  2895,  2903,  2906,  2913,  2916,  2922,  2923,
+    2924,  2928,  2929,  2933,  2940,  2945,  2954,  2960,  2964,  2975,
+    2982,  2991,  2994,  2997,  3004,  3008,  3014,  3025,  3028,  3033,
+    3044,  3045,  3049,  3050,  3051,  3055,  3058,  3061,  3061,  3081,
+    3084,  3084,  3102,  3107,  3115,  3116,  3120,  3123,  3136,  3153,
+    3154,  3155,  3160,  3160,  3186,  3187,  3194,  3207,  3208,  3209,
+    3213,  3223,  3226,  3232,  3233,  3237,  3238,  3242,  3243,  3247,
+    3249,  3254,  3247,  3270,  3271,  3275,  3276,  3280,  3286,  3287,
+    3288,  3289,  3293,  3294,  3295,  3299,  3302,  3308,  3310,  3315,
+    3308,  3336,  3343,  3348,  3357,  3363,  3367,  3378,  3379,  3380,
+    3381,  3382,  3383,  3384,  3385,  3386,  3387,  3388,  3389,  3390,
+    3391,  3392,  3393,  3394,  3395,  3396,  3397,  3398,  3399,  3400,
+    3401,  3402,  3403,  3404,  3405,  3406,  3407,  3408,  3409,  3410,
+    3411,  3412,  3413,  3414,  3415,  3416,  3417,  3418,  3419,  3420,
+    3421,  3422,  3423,  3424,  3425,  3426,  3427,  3431,  3432,  3433,
+    3434,  3435,  3436,  3437,  3438,  3442,  3453,  3457,  3464,  3476,
+    3483,  3489,  3498,  3503,  3513,  3523,  3533,  3546,  3547,  3548,
+    3549,  3550,  3554,  3558,  3558,  3558,  3572,  3573,  3577,  3582,
+    3589,  3592,  3595,  3598,  3604,  3607,  3621,  3622,  3626,  3627,
+    3628,  3629,  3630,  3630,  3630,  3634,  3639,  3646,  3653,  3653,
+    3660,  3660,  3667,  3671,  3675,  3680,  3685,  3690,  3695,  3699,
+    3703,  3708,  3712,  3716,  3721,  3721,  3721,  3727,  3734,  3734,
+    3734,  3739,  3739,  3739,  3745,  3745,  3745,  3750,  3756,  3756,
+    3756,  3761,  3761,  3761,  3770,  3776,  3776,  3776,  3781,  3781,
+    3781,  3790,  3796,  3796,  3796,  3801,  3801,  3801,  3810,  3810,
+    3810,  3816,  3816,  3816,  3825,  3828,  3839,  3855,  3857,  3862,
+    3867,  3855,  3893,  3895,  3900,  3906,  3893,  3932,  3934,  3939,
+    3944,  3932,  3985,  3986,  3987,  3988,  3989,  3990,  3991,  3995,
+    3996,  3997,  3998,  3999,  4003,  4010,  4017,  4023,  4029,  4036,
+    4043,  4049,  4058,  4061,  4067,  4075,  4080,  4087,  4092,  4098,
+    4099,  4103,  4104,  4108,  4108,  4108,  4116,  4116,  4116,  4123,
+    4123,  4123,  4133,  4133,  4133,  4140,  4140,  4140,  4151,  4157,
+    4157,  4157,  4170,  4189,  4189,  4189,  4199,  4199,  4199,  4212,
+    4212,  4212,  4225,  4234,  4234,  4234,  4254,  4261,  4261,  4261,
+    4271,  4274,  4285,  4291,  4314,  4322,  4342,  4367,  4368,  4372,
+    4373,  4378,  4381,  4391
 };
 #endif
 
@@ -7262,7 +7262,7 @@ yyreduce:
 
   case 178: /* optional_function_type: %empty  */
         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yyloc));
     }
     break;
@@ -8380,8 +8380,7 @@ yyreduce:
 
   case 402: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                         {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-5]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-5])));
         typeDecl->ref = (yyvsp[-3].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameList),tokAt(scanner,(yylsp[-5])),typeDecl,(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -8634,7 +8633,7 @@ yyreduce:
   case 442: /* expr_full_block_assumed_piped: '{' expressions '}'  */
                                    {
         // block span is brace-to-brace (@$), not the statements' span (@block)
-        (yyval.pExpression) = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,new TypeDecl(Type::autoinfer),(yyvsp[-1].pExpression),tokAt(scanner,(yyloc)),tokAt(scanner,(yyloc)),LineInfo());
+        (yyval.pExpression) = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc))),(yyvsp[-1].pExpression),tokAt(scanner,(yyloc)),tokAt(scanner,(yyloc)),LineInfo());
     }
     break;
 
@@ -8888,8 +8887,7 @@ yyreduce:
   case 488: /* func_addr_expr: "@@" '<' $@34 optional_function_argument_list optional_function_type '>' $@35 func_addr_name  */
                                                                                                                                                                                        {
         auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value));
-        expr->funcType = new TypeDecl(Type::tFunction);
-        expr->funcType->at = expr->at;
+        expr->funcType = new TypeDecl(Type::tFunction, expr->at);
         expr->funcType->firstType = (yyvsp[-3].pTypeDecl);
         if ( (yyvsp[-4].pVarDeclList) ) {
             varDeclToTypeDecl(scanner, expr->funcType, (yyvsp[-4].pVarDeclList));
@@ -9412,7 +9410,7 @@ yyreduce:
 
   case 580: /* expr_no_bracket: expr_no_bracket "is" basic_type_declaration  */
                                                                           {
-        auto vdecl = new TypeDecl((yyvsp[0].type));
+        auto vdecl = new TypeDecl((yyvsp[0].type), tokAt(scanner,(yyloc)));
         vdecl->at = tokAt(scanner,(yylsp[0]));
         (yyval.pExpression) = new ExprIs(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),vdecl);
     }
@@ -9443,7 +9441,7 @@ yyreduce:
 
   case 585: /* expr_no_bracket: expr_no_bracket "!is" basic_type_declaration  */
                                                                          {
-        auto vdecl = new TypeDecl((yyvsp[0].type));
+        auto vdecl = new TypeDecl((yyvsp[0].type), tokAt(scanner,(yyloc)));
         vdecl->at = tokAt(scanner,(yylsp[0]));
         auto isx = new ExprIs(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),vdecl);
         isx->no_promotion = true;
@@ -9685,7 +9683,7 @@ yyreduce:
   case 624: /* expr_generator: "generator" '<' type_declaration_no_options '>' optional_capture_list optional_emit_semis expression_block  */
                                                                                                                                                   {
         auto closure = new ExprMakeBlock(tokAt(scanner,(yylsp[0])),(yyvsp[0].pExpression));
-        ((ExprBlock *)(yyvsp[0].pExpression))->returnType = new TypeDecl(Type::autoinfer);
+        ((ExprBlock *)(yyvsp[0].pExpression))->returnType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pExpression) = ast_makeGenerator(scanner,(yyvsp[-4].pTypeDecl),(yyvsp[-2].pCaptList),closure,tokAt(scanner,(yylsp[-6])),tokAt(scanner,(yylsp[-2])));
     }
     break;
@@ -9991,7 +9989,7 @@ yyreduce:
                                      {
             auto na = new vector<VariableNameAndPosition>();
             na->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1]))));
-            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none), (yyvsp[-1].pExpression));
+            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none, tokAt(scanner,(yyloc))), (yyvsp[-1].pExpression));
             decl->pTypeDecl->isTag = true;
             (yyval.pVarDecl) = decl;
         }
@@ -10119,8 +10117,7 @@ yyreduce:
 
   case 691: /* variable_declaration_no_type: variable_name_with_pos_list  */
                                           {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,(yylsp[0]));
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[0])));
         autoT->ref = false;
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[0].pNameWithPosList),autoT,nullptr);
     }
@@ -10128,8 +10125,7 @@ yyreduce:
 
   case 692: /* variable_declaration_no_type: variable_name_with_pos_list '&'  */
                                               {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,(yylsp[-1]));
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-1])));
         autoT->ref = true;
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-1].pNameWithPosList),autoT,nullptr);
     }
@@ -10137,8 +10133,7 @@ yyreduce:
 
   case 693: /* variable_declaration_no_type: variable_name_with_pos_list copy_or_move expr  */
                                                                        {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-2]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-2])));
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),typeDecl,(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
     }
@@ -10302,8 +10297,7 @@ yyreduce:
 
   case 716: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                 {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-4]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-4])));
         typeDecl->ref = (yyvsp[-3].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),typeDecl,(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -10328,8 +10322,7 @@ yyreduce:
 
   case 719: /* global_let_variable_declaration: global_let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr SEMICOLON  */
                                                                                                                        {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-4]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-4])));
         typeDecl->ref = (yyvsp[-3].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),typeDecl,(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -10994,7 +10987,7 @@ yyreduce:
                                  {
         (yyval.pTypeDecl) = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
         if ( !(yyval.pTypeDecl) ) {
-            (yyval.pTypeDecl) = new TypeDecl(Type::tVoid);
+            (yyval.pTypeDecl) = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
         }
         delete (yyvsp[0].s);
@@ -11003,7 +10996,7 @@ yyreduce:
 
   case 846: /* auto_type_declaration: "auto"  */
                        {
-        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
@@ -11011,7 +11004,7 @@ yyreduce:
   case 847: /* auto_type_declaration: "auto" '(' "name" ')'  */
                                             {
         das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
-        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
         (yyval.pTypeDecl)->alias = *(yyvsp[-1].s);
         delete (yyvsp[-1].s);
@@ -11020,11 +11013,11 @@ yyreduce:
 
   case 848: /* auto_type_declaration: "$t" '(' expr ')'  */
                                           {
-        (yyval.pTypeDecl) = new TypeDecl(Type::alias);
+        (yyval.pTypeDecl) = new TypeDecl(Type::alias, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
         (yyval.pTypeDecl)->alias = "``MACRO``TAG``";
         (yyval.pTypeDecl)->isTag = true;
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = tokAt(scanner, (yylsp[-1]));
         (yyval.pTypeDecl)->firstType->typeMacroExpr.push_back((yyvsp[-1].pExpression));
     }
@@ -11140,7 +11133,7 @@ yyreduce:
 
   case 862: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' '>'  */
                                                                           {
-            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-2].type));
+            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-2].type), tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-2]));
     }
     break;
@@ -11155,7 +11148,7 @@ yyreduce:
 
   case 865: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' $@64 bitfield_bits '>' $@65  */
                                                                                                                                                              {
-            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-5].type));
+            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-5].type), tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->argNames = *(yyvsp[-2].pNameList);
             auto maxBits = (yyval.pTypeDecl)->maxBitfieldBits();
             if ( (yyval.pTypeDecl)->argNames.size()>maxBits ) {
@@ -11170,7 +11163,7 @@ yyreduce:
   case 868: /* table_type_pair: type_declaration  */
                                       {
         (yyval.aTypePair).firstType = (yyvsp[0].pTypeDecl);
-        (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid);
+        (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.aTypePair).secondType->at = (yyval.aTypePair).firstType->at;
     }
     break;
@@ -11234,7 +11227,7 @@ yyreduce:
     break;
 
   case 878: /* type_declaration_no_options_no_dim: basic_type_declaration  */
-                                                            { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type)); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
+                                                            { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type), tokAt(scanner,(yyloc))); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
     break;
 
   case 879: /* type_declaration_no_options_no_dim: auto_type_declaration  */
@@ -11266,7 +11259,7 @@ yyreduce:
 
   case 885: /* type_declaration_no_options_no_dim: "typedecl" '(' expr ')'  */
                                                {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]),(yylsp[-1]));
         (yyval.pTypeDecl)->typeMacroExpr.push_back((yyvsp[-1].pExpression));
     }
@@ -11274,7 +11267,7 @@ yyreduce:
 
   case 886: /* type_declaration_no_options_no_dim: name_in_namespace '(' optional_expr_list ')'  */
                                                                       {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]), (yylsp[-1]));
         (yyval.pTypeDecl)->typeMacroExpr = sequenceToList((yyvsp[-1].pExpression));
         (yyval.pTypeDecl)->typeMacroExpr.insert((yyval.pTypeDecl)->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-3])), *(yyvsp[-3].s)));
@@ -11284,7 +11277,7 @@ yyreduce:
 
   case 887: /* type_declaration_no_options_no_dim: '$' name_in_namespace optional_expr_list_in_braces  */
                                                                             {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-1]), (yylsp[0]));
         (yyval.pTypeDecl)->typeMacroExpr = sequenceToList((yyvsp[0].pExpression));
         (yyval.pTypeDecl)->typeMacroExpr.insert((yyval.pTypeDecl)->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-1])), *(yyvsp[-1].s)));
@@ -11298,7 +11291,7 @@ yyreduce:
 
   case 889: /* type_declaration_no_options_no_dim: name_in_namespace '<' $@68 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                          {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
         (yyval.pTypeDecl)->typeMacroExpr = typesAndSequenceToList((yyvsp[-2].pTypeDeclList),(yyvsp[0].pExpression));
         (yyval.pTypeDecl)->typeMacroExpr.insert((yyval.pTypeDecl)->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-5])), *(yyvsp[-5].s)));
@@ -11312,7 +11305,7 @@ yyreduce:
 
   case 891: /* type_declaration_no_options_no_dim: '$' name_in_namespace '<' $@69 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                              {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
         (yyval.pTypeDecl)->typeMacroExpr = typesAndSequenceToList((yyvsp[-2].pTypeDeclList),(yyvsp[0].pExpression));
         (yyval.pTypeDecl)->typeMacroExpr.insert((yyval.pTypeDecl)->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-5])), *(yyvsp[-5].s)));
@@ -11404,7 +11397,7 @@ yyreduce:
 
   case 903: /* type_declaration_no_options_no_dim: type_declaration_no_options '?'  */
                                                   {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-1].pTypeDecl);
     }
@@ -11420,7 +11413,7 @@ yyreduce:
 
   case 906: /* type_declaration_no_options_no_dim: "smart_ptr" '<' $@70 type_declaration '>' $@71  */
                                                                                                                                 {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->smartPtr = true;
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
@@ -11429,9 +11422,9 @@ yyreduce:
 
   case 907: /* type_declaration_no_options_no_dim: type_declaration_no_options "??"  */
                                                  {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = tokAt(scanner,(yylsp[-1]));
         (yyval.pTypeDecl)->firstType->firstType = (yyvsp[-1].pTypeDecl);
     }
@@ -11447,7 +11440,7 @@ yyreduce:
 
   case 910: /* type_declaration_no_options_no_dim: "array" '<' $@72 type_declaration '>' $@73  */
                                                                                                                             {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tArray);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tArray, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11463,7 +11456,7 @@ yyreduce:
 
   case 913: /* type_declaration_no_options_no_dim: "table" '<' $@74 table_type_pair '>' $@75  */
                                                                                                                       {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tTable);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tTable, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].aTypePair).firstType;
         (yyval.pTypeDecl)->secondType = (yyvsp[-2].aTypePair).secondType;
@@ -11480,7 +11473,7 @@ yyreduce:
 
   case 916: /* type_declaration_no_options_no_dim: "iterator" '<' $@76 type_declaration '>' $@77  */
                                                                                                                                   {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tIterator);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tIterator, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11488,9 +11481,9 @@ yyreduce:
 
   case 917: /* type_declaration_no_options_no_dim: "block"  */
                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = (yyval.pTypeDecl)->at;
     }
     break;
@@ -11505,7 +11498,7 @@ yyreduce:
 
   case 920: /* type_declaration_no_options_no_dim: "block" '<' $@78 type_declaration '>' $@79  */
                                                                                                                                {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11521,7 +11514,7 @@ yyreduce:
 
   case 923: /* type_declaration_no_options_no_dim: "block" '<' $@80 optional_function_argument_list optional_function_type '>' $@81  */
                                                                                                                                                                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
         if ( (yyvsp[-3].pVarDeclList) ) {
@@ -11533,9 +11526,9 @@ yyreduce:
 
   case 924: /* type_declaration_no_options_no_dim: "function"  */
                            {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = (yyval.pTypeDecl)->at;
     }
     break;
@@ -11550,7 +11543,7 @@ yyreduce:
 
   case 927: /* type_declaration_no_options_no_dim: "function" '<' $@82 type_declaration '>' $@83  */
                                                                                                                                  {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11566,7 +11559,7 @@ yyreduce:
 
   case 930: /* type_declaration_no_options_no_dim: "function" '<' $@84 optional_function_argument_list optional_function_type '>' $@85  */
                                                                                                                                                                           {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
         if ( (yyvsp[-3].pVarDeclList) ) {
@@ -11578,9 +11571,9 @@ yyreduce:
 
   case 931: /* type_declaration_no_options_no_dim: "lambda"  */
                          {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = (yyval.pTypeDecl)->at;
     }
     break;
@@ -11595,7 +11588,7 @@ yyreduce:
 
   case 934: /* type_declaration_no_options_no_dim: "lambda" '<' $@86 type_declaration '>' $@87  */
                                                                                                                                {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11611,7 +11604,7 @@ yyreduce:
 
   case 937: /* type_declaration_no_options_no_dim: "lambda" '<' $@88 optional_function_argument_list optional_function_type '>' $@89  */
                                                                                                                                                                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
         if ( (yyvsp[-3].pVarDeclList) ) {
@@ -11631,7 +11624,7 @@ yyreduce:
 
   case 940: /* type_declaration_no_options_no_dim: "tuple" '<' $@90 tuple_type_list '>' $@91  */
                                                                                                                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tTuple);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tTuple, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-2].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
@@ -11648,7 +11641,7 @@ yyreduce:
 
   case 943: /* type_declaration_no_options_no_dim: "variant" '<' $@92 variant_type_list '>' $@93  */
                                                                                                                             {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tVariant);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tVariant, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-2].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
@@ -11667,7 +11660,7 @@ yyreduce:
             (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[0].pTypeDecl));
         } else {
-            (yyval.pTypeDecl) = new TypeDecl(Type::option);
+            (yyval.pTypeDecl) = new TypeDecl(Type::option, tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[-2].pTypeDecl));
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[0].pTypeDecl));
@@ -11682,7 +11675,7 @@ yyreduce:
             (yyval.pTypeDecl)->argTypes.push_back(new TypeDecl(*(yyvsp[-2].pTypeDecl)->argTypes.back()));
             (yyvsp[-2].pTypeDecl)->argTypes.back()->temporary ^= true;
         } else {
-            (yyval.pTypeDecl) = new TypeDecl(Type::option);
+            (yyval.pTypeDecl) = new TypeDecl(Type::option, tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[-2].pTypeDecl));
             (yyval.pTypeDecl)->argTypes.push_back(new TypeDecl(*(yyvsp[-2].pTypeDecl)));
@@ -11727,7 +11720,7 @@ yyreduce:
 
   case 951: /* tuple_alias_declaration: "tuple" $@94 optional_public_or_private_alias "name" optional_emit_semis $@95 '{' $@96 tuple_alias_type_list optional_semis $@97 '}'  */
           {
-        auto vtype = new TypeDecl(Type::tTuple);
+        auto vtype = new TypeDecl(Type::tTuple, tokAt(scanner,(yyloc)));
         vtype->alias = *(yyvsp[-8].s);
         vtype->at = tokAt(scanner,(yylsp[-8]));
         vtype->isPrivateAlias = !(yyvsp[-9].b);
@@ -11782,7 +11775,7 @@ yyreduce:
 
   case 956: /* variant_alias_declaration: "variant" $@98 optional_public_or_private_alias "name" optional_emit_semis $@99 '{' $@100 variant_alias_type_list optional_semis $@101 '}'  */
           {
-        auto vtype = new TypeDecl(Type::tVariant);
+        auto vtype = new TypeDecl(Type::tVariant, tokAt(scanner,(yyloc)));
         vtype->alias = *(yyvsp[-8].s);
         vtype->at = tokAt(scanner,(yylsp[-8]));
         vtype->isPrivateAlias = !(yyvsp[-9].b);
@@ -11836,7 +11829,7 @@ yyreduce:
 
   case 961: /* bitfield_alias_declaration: "bitfield" $@102 optional_public_or_private_alias "name" bitfield_basic_type_declaration optional_emit_commas $@103 '{' $@104 bitfield_alias_bits optional_commas $@105 '}'  */
           {
-        auto btype = new TypeDecl((yyvsp[-8].type));
+        auto btype = new TypeDecl((yyvsp[-8].type), tokAt(scanner,(yyloc)));
         btype->alias = *(yyvsp[-9].s);
         btype->at = tokAt(scanner,(yylsp[-9]));
         btype->isPrivateAlias = !(yyvsp[-10].b);
@@ -12104,8 +12097,7 @@ yyreduce:
 
   case 1001: /* make_struct_decl: "variant" '<' $@110 variant_type_list '>' $@111 '(' use_initializer make_variant_dim ')'  */
                                                                                                                                                                                   {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,(yylsp[-9]));
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,(yylsp[-9])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-6].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-6].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
@@ -12157,7 +12149,7 @@ yyreduce:
                                                                     {
         auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-4])));
         mkt->values = sequenceToList((yyvsp[-2].pExpression));
-        mkt->makeType = new TypeDecl(Type::autoinfer);
+        mkt->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pExpression) = mkt;
     }
     break;
@@ -12172,8 +12164,7 @@ yyreduce:
 
   case 1011: /* make_tuple_call: "tuple" '<' $@116 tuple_type_list '>' $@117 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                                                  {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,(yylsp[-9]));
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,(yylsp[-9])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-6].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-6].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
@@ -12189,7 +12180,7 @@ yyreduce:
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-2])));
             mka->values = sequenceToList((yyvsp[-1].pExpression));
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
             mka->gen2 = true;
             auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),"to_array_move");
             tam->arguments.push_back(mka);
@@ -12197,10 +12188,8 @@ yyreduce:
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,(yylsp[-2]));
-            mks->makeType = new TypeDecl(Type::tArray);
-            mks->makeType->at = mks->at;
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->firstType->at = mks->at;
+            mks->makeType = new TypeDecl(Type::tArray, mks->at);
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, mks->at);
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             (yyval.pExpression) = mks;
@@ -12239,8 +12228,7 @@ yyreduce:
 
   case 1018: /* make_dim_decl: "array" "tuple" '<' $@120 tuple_type_list '>' $@121 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                      {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,(yylsp[-10]));
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,(yylsp[-10])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-6].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-6].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
@@ -12264,8 +12252,7 @@ yyreduce:
 
   case 1021: /* make_dim_decl: "array" "variant" '<' $@122 variant_type_list '>' $@123 '(' make_variant_dim ')'  */
                                                                                                                                                                       {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,(yylsp[-9]));
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,(yylsp[-9])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-5].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-5].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
@@ -12283,7 +12270,7 @@ yyreduce:
                                                                    {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         mka->gen2 = true;
         auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-4])),"to_array_move");
         tam->arguments.push_back(mka);
@@ -12312,8 +12299,7 @@ yyreduce:
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,(yylsp[-8]));
-            msd->makeType = new TypeDecl(Type::tArray);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tArray, msd->at);
             msd->makeType->firstType = (yyvsp[-5].pTypeDecl);
             msd->at = tokAt(scanner,(yylsp[-5]));
             msd->useInitializer = true;
@@ -12327,7 +12313,7 @@ yyreduce:
                                                                          {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         mka->gen2 = true;
         (yyval.pExpression) = mka;
     }
@@ -12375,16 +12361,16 @@ yyreduce:
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
             mka->values = sequenceToList((yyvsp[-1].pExpression));
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-4])),"to_table_move");
             ttm->arguments.push_back(mka);
             (yyval.pExpression) = ttm;
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,(yylsp[-4]));
-            mks->makeType = new TypeDecl(Type::tTable);
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->secondType = new TypeDecl(Type::autoinfer);
+            mks->makeType = new TypeDecl(Type::tTable, tokAt(scanner,(yyloc)));
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-4])));
+            mks->makeType->secondType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[0])));
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             (yyval.pExpression) = mks;
@@ -12396,7 +12382,7 @@ yyreduce:
                                                                              {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-4])),"to_table_move");
         ttm->arguments.push_back(mka);
         (yyval.pExpression) = ttm;
@@ -12415,11 +12401,9 @@ yyreduce:
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,(yylsp[-6]));
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = (yyvsp[-4].pTypeDecl);
-            msd->makeType->secondType = new TypeDecl(Type::tVoid);
-            msd->makeType->secondType->at = tokAt(scanner,(yylsp[-6]));
+            msd->makeType->secondType = new TypeDecl(Type::tVoid, tokAt(scanner,(yylsp[-6])));
             msd->at = tokAt(scanner,(yylsp[-6]));
             msd->useInitializer = true;
             msd->alwaysUseInitializer = true;
@@ -12433,7 +12417,7 @@ yyreduce:
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-8])));
             mka->values = sequenceToList((yyvsp[-1].pExpression));
-            mka->makeType = new TypeDecl(Type::tTuple);
+            mka->makeType = new TypeDecl(Type::tTuple, tokAt(scanner,(yyloc)));
             mka->makeType->argTypes.push_back((yyvsp[-6].pTypeDecl));
             mka->makeType->argTypes.push_back((yyvsp[-4].pTypeDecl));
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-8])),"to_table_move");
@@ -12442,8 +12426,7 @@ yyreduce:
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,(yylsp[-8]));
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = (yyvsp[-6].pTypeDecl);
             msd->makeType->secondType = (yyvsp[-4].pTypeDecl);
             msd->at = tokAt(scanner,(yylsp[-8]));

--- a/src/parser/ds2_parser.ypp
+++ b/src/parser/ds2_parser.ypp
@@ -1372,7 +1372,7 @@ optional_function_argument_list
 
 optional_function_type
     :   {
-        $$ = new TypeDecl(Type::autoinfer);
+        $$ = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@$);
     }
     |   ':' type_declaration[typeDecl]  {
@@ -1901,8 +1901,7 @@ tuple_expansion_variable_declaration
         $$->atEnd = tokAt(scanner,@init);
     }
     |   '(' tuple_expansion[list] ')' optional_ref[ref] copy_or_move_or_clone[com] expr[init] SEMICOLON {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -2069,7 +2068,7 @@ expr_full_block_assumed_piped
     }
     |   '{' expressions[block] '}' {
         // block span is brace-to-brace (@$), not the statements' span (@block)
-        $$ = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,new TypeDecl(Type::autoinfer),$block,tokAt(scanner,@$),tokAt(scanner,@$),LineInfo());
+        $$ = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,new TypeDecl(Type::autoinfer, tokAt(scanner,@$)),$block,tokAt(scanner,@$),tokAt(scanner,@$),LineInfo());
     }
     ;
 
@@ -2200,8 +2199,7 @@ func_addr_expr
     }
     |   DOUBLE_AT '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } func_addr_name[faddr] {
         auto expr = (ExprAddr *) ($faddr->rtti_isAddr() ? $faddr : (((ExprTag *) $faddr)->value));
-        expr->funcType = new TypeDecl(Type::tFunction);
-        expr->funcType->at = expr->at;
+        expr->funcType = new TypeDecl(Type::tFunction, expr->at);
         expr->funcType->firstType = $result;
         if ( $list ) {
             varDeclToTypeDecl(scanner, expr->funcType, $list);
@@ -2459,7 +2457,7 @@ expr_no_bracket
         $$ = new ExprIs(tokAt(scanner,@loc),$subexpr,$decl);
     }
     |   expr_no_bracket[subexpr] DAS_IS[loc] basic_type_declaration[decl] {
-        auto vdecl = new TypeDecl($decl);
+        auto vdecl = new TypeDecl($decl, tokAt(scanner,@$));
         vdecl->at = tokAt(scanner,@decl);
         $$ = new ExprIs(tokAt(scanner,@loc),$subexpr,vdecl);
     }
@@ -2473,7 +2471,7 @@ expr_no_bracket
         $$ = isx;
     }
     |   expr_no_bracket[subexpr] NOTIS[loc] basic_type_declaration[decl] {
-        auto vdecl = new TypeDecl($decl);
+        auto vdecl = new TypeDecl($decl, tokAt(scanner,@$));
         vdecl->at = tokAt(scanner,@decl);
         auto isx = new ExprIs(tokAt(scanner,@loc),$subexpr,vdecl);
         isx->no_promotion = true;
@@ -2594,7 +2592,7 @@ expr_generator
     }
     |   DAS_GENERATOR[loc] '<' type_declaration_no_options[typeDecl] '>' optional_capture_list[clist] optional_emit_semis expression_block[block] {
         auto closure = new ExprMakeBlock(tokAt(scanner,@block),$block);
-        ((ExprBlock *)$block)->returnType = new TypeDecl(Type::autoinfer);
+        ((ExprBlock *)$block)->returnType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$ = ast_makeGenerator(scanner,$typeDecl,$clist,closure,tokAt(scanner,@loc),tokAt(scanner,@clist));
     }
     ;
@@ -2793,7 +2791,7 @@ function_argument_declaration_type
     |   MTAG_A '(' expr[subexpr] ')' {
             auto na = new vector<VariableNameAndPosition>();
             na->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,@subexpr)));
-            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none), $subexpr);
+            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none, tokAt(scanner,@$)), $subexpr);
             decl->pTypeDecl->isTag = true;
             $$ = decl;
         }
@@ -2885,20 +2883,17 @@ copy_or_move
 
 variable_declaration_no_type        /* this one can have uninitialized variable which has no type */
     :   variable_name_with_pos_list[list] {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,@list);
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         autoT->ref = false;
         $$ = new VariableDeclaration($list,autoT,nullptr);
     }
     |   variable_name_with_pos_list[list] '&' {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,@list);
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         autoT->ref = true;
         $$ = new VariableDeclaration($list,autoT,nullptr);
     }
     |   variable_name_with_pos_list[list] copy_or_move[com] expr[init] {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         $$ = new VariableDeclaration($list,typeDecl,$init);
         $$->init_via_move = $com;
     }
@@ -3017,8 +3012,7 @@ let_variable_declaration    /* let x; is prohibited. this one can't have uniniti
         $$->atEnd = tokAt(scanner,@init);
     }
     |   let_variable_name_with_pos_list[list] optional_ref[ref] copy_or_move_or_clone[com] expr[init] SEMICOLON {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -3037,8 +3031,7 @@ global_let_variable_declaration    /* let x; is prohibited. this one can't have 
         $$->init_via_clone = ($com & CorM_CLONE) !=0;
     }
     |   global_let_variable_name_with_pos_list[list] optional_ref[ref] copy_or_move_or_clone[com] expr[init] SEMICOLON {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -3449,7 +3442,7 @@ structure_type_declaration
     :   name_in_namespace[name]  {
         $$ = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,@name),*$name);
         if ( !$$ ) {
-            $$ = new TypeDecl(Type::tVoid);
+            $$ = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
             $$->at = tokAt(scanner,@name);
         }
         delete $name;
@@ -3458,22 +3451,22 @@ structure_type_declaration
 
 auto_type_declaration
     :   DAS_TAUTO[loc] {
-        $$ = new TypeDecl(Type::autoinfer);
+        $$ = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
     }
     |   DAS_TAUTO[loc] '(' NAME[alias] ')'  {
         das_checkName(scanner,*$alias,tokAt(scanner,@alias));
-        $$ = new TypeDecl(Type::autoinfer);
+        $$ = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->alias = *$alias;
         delete $alias;
     }
     |   MTAG_T[loc] '(' expr[subexpr] ')' {
-        $$ = new TypeDecl(Type::alias);
+        $$ = new TypeDecl(Type::alias, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->alias = "``MACRO``TAG``";
         $$->isTag = true;
-        $$->firstType = new TypeDecl(Type::autoinfer);
+        $$->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->firstType->at = tokAt(scanner, @subexpr);
         $$->firstType->typeMacroExpr.push_back($subexpr);
     }
@@ -3559,11 +3552,11 @@ bitfield_basic_type_declaration
 
 bitfield_type_declaration
     :   DAS_TBITFIELD bitfield_basic_type_declaration[basicType] '<' '>'  {
-            $$ = new TypeDecl($basicType);
+            $$ = new TypeDecl($basicType, tokAt(scanner,@$));
             $$->at = tokAt(scanner,@basicType);
     }
     |   DAS_TBITFIELD bitfield_basic_type_declaration[basicType] '<' { yyextra->das_arrow_depth ++; } bitfield_bits[nl] '>' { yyextra->das_arrow_depth --; } {
-            $$ = new TypeDecl($basicType);
+            $$ = new TypeDecl($basicType, tokAt(scanner,@$));
             $$->argNames = *$nl;
             auto maxBits = $$->maxBitfieldBits();
             if ( $$->argNames.size()>maxBits ) {
@@ -3583,7 +3576,7 @@ c_or_s
 table_type_pair
     :   type_declaration[keyTypeDecl] {
         $$.firstType = $keyTypeDecl;
-        $$.secondType = new TypeDecl(Type::tVoid);
+        $$.secondType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$.secondType->at = $$.firstType->at;
     }
     |   type_declaration[keyTypeDecl] c_or_s type_declaration[valueTypeDecl] {
@@ -3630,7 +3623,7 @@ optional_expr_list_in_braces
     ;
 
 type_declaration_no_options_no_dim
-    :   basic_type_declaration[basicType]                   { $$ = new TypeDecl($basicType); $$->at = tokAt(scanner,@basicType); }
+    :   basic_type_declaration[basicType]                   { $$ = new TypeDecl($basicType, tokAt(scanner,@$)); $$->at = tokAt(scanner,@basicType); }
     |   auto_type_declaration[typeDecl]                     { $$ = $typeDecl; }
     |   bitfield_type_declaration[typeDecl]                 { $$ = $typeDecl; }
     |   structure_type_declaration[typeDecl]                { $$ = $typeDecl; }
@@ -3639,33 +3632,33 @@ type_declaration_no_options_no_dim
         $$ = $typeDecl;
     }
     |   DAS_TYPEDECL[td] '(' expr[subexpr] ')' {
-        $$ = new TypeDecl(Type::typeDecl);
+        $$ = new TypeDecl(Type::typeDecl, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@td,@subexpr);
         $$->typeMacroExpr.push_back($subexpr);
     }
     |   name_in_namespace[name] '(' optional_expr_list[arguments] ')' {
-        $$ = new TypeDecl(Type::typeMacro);
+        $$ = new TypeDecl(Type::typeMacro, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@name, @arguments);
         $$->typeMacroExpr = sequenceToList($arguments);
         $$->typeMacroExpr.insert($$->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
         delete $name;
     }
     |   '$' name_in_namespace[name] optional_expr_list_in_braces[arguments] {
-        $$ = new TypeDecl(Type::typeMacro);
+        $$ = new TypeDecl(Type::typeMacro, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@name, @arguments);
         $$->typeMacroExpr = sequenceToList($arguments);
         $$->typeMacroExpr.insert($$->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
         delete $name;
     }
     |   name_in_namespace[name] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options_list[declL] '>' optional_expr_list_in_braces[arguments] {
-        $$ = new TypeDecl(Type::typeMacro);
+        $$ = new TypeDecl(Type::typeMacro, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@name, @arguments);
         $$->typeMacroExpr = typesAndSequenceToList($declL,$arguments);
         $$->typeMacroExpr.insert($$->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
         delete $name;
     }
     |   '$' name_in_namespace[name] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options_list[declL] '>' optional_expr_list_in_braces[arguments] {
-        $$ = new TypeDecl(Type::typeMacro);
+        $$ = new TypeDecl(Type::typeMacro, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@name, @arguments);
         $$->typeMacroExpr = typesAndSequenceToList($declL,$arguments);
         $$->typeMacroExpr.insert($$->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
@@ -3721,52 +3714,52 @@ type_declaration_no_options_no_dim
         $$ = $typeDecl;
     }
     |   type_declaration_no_options[typeDecl] '?' {
-        $$ = new TypeDecl(Type::tPointer);
+        $$ = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@typeDecl);
         $$->firstType = $typeDecl;
     }
     |   DAS_SMART_PTR[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tPointer);
+        $$ = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->smartPtr = true;
         $$->firstType = $typeDecl;
     }
     |   type_declaration_no_options[typeDecl] QQ {
-        $$ = new TypeDecl(Type::tPointer);
+        $$ = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@typeDecl);
-        $$->firstType = new TypeDecl(Type::tPointer);
+        $$->firstType = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->firstType->at = tokAt(scanner,@typeDecl);
         $$->firstType->firstType = $typeDecl;
     }
     |   DAS_ARRAY[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tArray);
+        $$ = new TypeDecl(Type::tArray, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $typeDecl;
     }
     |   DAS_TABLE[loc] '<' { yyextra->das_arrow_depth ++; } table_type_pair[ttp] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tTable);
+        $$ = new TypeDecl(Type::tTable, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $ttp.firstType;
         $$->secondType = $ttp.secondType;
     }
     |   DAS_ITERATOR[loc] '<'  { yyextra->das_arrow_depth ++; } type_declaration[itTypeDecl] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tIterator);
+        $$ = new TypeDecl(Type::tIterator, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $itTypeDecl;
     }
     |   DAS_TBLOCK[loc] {
-        $$ = new TypeDecl(Type::tBlock);
+        $$ = new TypeDecl(Type::tBlock, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
-        $$->firstType = new TypeDecl(Type::tVoid);
+        $$->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$->firstType->at = $$->at;
     }
     |   DAS_TBLOCK[loc] '<'  { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tBlock);
+        $$ = new TypeDecl(Type::tBlock, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $blockType;
     }
     |   DAS_TBLOCK[loc] '<'  { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tBlock);
+        $$ = new TypeDecl(Type::tBlock, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $result;
         if ( $list ) {
@@ -3775,18 +3768,18 @@ type_declaration_no_options_no_dim
         }
     }
     |   DAS_TFUNCTION[loc] {
-        $$ = new TypeDecl(Type::tFunction);
+        $$ = new TypeDecl(Type::tFunction, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
-        $$->firstType = new TypeDecl(Type::tVoid);
+        $$->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$->firstType->at = $$->at;
     }
     |   DAS_TFUNCTION[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tFunction);
+        $$ = new TypeDecl(Type::tFunction, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $blockType;
     }
     |   DAS_TFUNCTION[loc] '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tFunction);
+        $$ = new TypeDecl(Type::tFunction, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $result;
         if ( $list ) {
@@ -3795,18 +3788,18 @@ type_declaration_no_options_no_dim
         }
     }
     |   DAS_TLAMBDA[loc] {
-        $$ = new TypeDecl(Type::tLambda);
+        $$ = new TypeDecl(Type::tLambda, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
-        $$->firstType = new TypeDecl(Type::tVoid);
+        $$->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$->firstType->at = $$->at;
     }
     |   DAS_TLAMBDA[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tLambda);
+        $$ = new TypeDecl(Type::tLambda, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $blockType;
     }
     |   DAS_TLAMBDA[loc] '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tLambda);
+        $$ = new TypeDecl(Type::tLambda, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $result;
         if ( $list ) {
@@ -3815,13 +3808,13 @@ type_declaration_no_options_no_dim
         }
     }
     |   DAS_TTUPLE[loc] '<' { yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tTuple);
+        $$ = new TypeDecl(Type::tTuple, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         varDeclToTypeDecl(scanner, $$, $list, true);
         deleteVariableDeclarationList($list);
     }
     |   DAS_TVARIANT[loc] '<' { yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tVariant);
+        $$ = new TypeDecl(Type::tVariant, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         varDeclToTypeDecl(scanner, $$, $list, true);
         deleteVariableDeclarationList($list);
@@ -3837,7 +3830,7 @@ type_declaration
             $$ = $list;
             $$->argTypes.push_back($rest);
         } else {
-            $$ = new TypeDecl(Type::option);
+            $$ = new TypeDecl(Type::option, tokAt(scanner,@$));
             $$->at = tokRangeAt(scanner,@list,@rest);
             $$->argTypes.push_back($list);
             $$->argTypes.push_back($rest);
@@ -3849,7 +3842,7 @@ type_declaration
             $$->argTypes.push_back(new TypeDecl(*$list->argTypes.back()));
             $list->argTypes.back()->temporary ^= true;
         } else {
-            $$ = new TypeDecl(Type::option);
+            $$ = new TypeDecl(Type::option, tokAt(scanner,@$));
             $$->at = tokRangeAt(scanner,@list,@rest);
             $$->argTypes.push_back($list);
             $$->argTypes.push_back(new TypeDecl(*$list));
@@ -3878,7 +3871,7 @@ tuple_alias_declaration
         }
         yyextra->pop_nesteds();
     } '}' {
-        auto vtype = new TypeDecl(Type::tTuple);
+        auto vtype = new TypeDecl(Type::tTuple, tokAt(scanner,@$));
         vtype->alias = *$vname;
         vtype->at = tokAt(scanner,@vname);
         vtype->isPrivateAlias = !$pubA;
@@ -3917,7 +3910,7 @@ variant_alias_declaration
         }
         yyextra->pop_nesteds();
     } '}' {
-        auto vtype = new TypeDecl(Type::tVariant);
+        auto vtype = new TypeDecl(Type::tVariant, tokAt(scanner,@$));
         vtype->alias = *$vname;
         vtype->at = tokAt(scanner,@vname);
         vtype->isPrivateAlias = !$pubA;
@@ -3955,7 +3948,7 @@ bitfield_alias_declaration
         }
         yyextra->pop_nesteds();
     } '}' {
-        auto btype = new TypeDecl($basicType);
+        auto btype = new TypeDecl($basicType, tokAt(scanner,@$));
         btype->alias = *$vname;
         btype->at = tokAt(scanner,@vname);
         btype->isPrivateAlias = !$pubA;
@@ -4128,8 +4121,7 @@ make_struct_decl
         $$ = $msd;
     }
     |   DAS_TVARIANT [loc] '<' { yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] make_variant_dim[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -4159,12 +4151,11 @@ make_tuple_call
     :   DAS_TTUPLE[loc] '(' expr_list[arguments] optional_comma ')' {
         auto mkt = new ExprMakeTuple(tokAt(scanner,@loc));
         mkt->values = sequenceToList($arguments);
-        mkt->makeType = new TypeDecl(Type::autoinfer);
+        mkt->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$ = mkt;
     }
     |   DAS_TTUPLE [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -4180,7 +4171,7 @@ make_dim_decl
         if ( $arguments ) {
             auto mka = new ExprMakeArray(tokAt(scanner,@loc));
             mka->values = sequenceToList($arguments);
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
             mka->gen2 = true;
             auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
             tam->arguments.push_back(mka);
@@ -4188,10 +4179,8 @@ make_dim_decl
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,@loc);
-            mks->makeType = new TypeDecl(Type::tArray);
-            mks->makeType->at = mks->at;
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->firstType->at = mks->at;
+            mks->makeType = new TypeDecl(Type::tArray, mks->at);
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, mks->at);
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             $$ = mks;
@@ -4208,8 +4197,7 @@ make_dim_decl
         $$ = tam;
     }
     |   DAS_ARRAY [loc] DAS_TTUPLE '<' { yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -4222,8 +4210,7 @@ make_dim_decl
         $$ = tam;
     }
     |   DAS_ARRAY [loc] DAS_TVARIANT '<' { yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' make_variant_dim[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -4238,7 +4225,7 @@ make_dim_decl
     |   DAS_ARRAY[loc] '(' expr_list[arguments] optional_comma ')' {
         auto mka = new ExprMakeArray(tokAt(scanner,@loc));
         mka->values = sequenceToList($arguments);
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         mka->gen2 = true;
         auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
         tam->arguments.push_back(mka);
@@ -4256,8 +4243,7 @@ make_dim_decl
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,@loc);
-            msd->makeType = new TypeDecl(Type::tArray);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tArray, msd->at);
             msd->makeType->firstType = $mkt;
             msd->at = tokAt(scanner,@mkt);
             msd->useInitializer = true;
@@ -4268,7 +4254,7 @@ make_dim_decl
     |   DAS_FIXED_ARRAY[loc] '(' expr_list[arguments] optional_comma ')' {
         auto mka = new ExprMakeArray(tokAt(scanner,@loc));
         mka->values = sequenceToList($arguments);
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         mka->gen2 = true;
         $$ = mka;
     }
@@ -4307,16 +4293,16 @@ make_table_decl
         if ( $arguments ) {
             auto mka = new ExprMakeArray(tokAt(scanner,@loc));
             mka->values = sequenceToList($arguments);
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
             ttm->arguments.push_back(mka);
             $$ = ttm;
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,@loc);
-            mks->makeType = new TypeDecl(Type::tTable);
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->secondType = new TypeDecl(Type::autoinfer);
+            mks->makeType = new TypeDecl(Type::tTable, tokAt(scanner,@$));
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,@loc));
+            mks->makeType->secondType = new TypeDecl(Type::autoinfer, tokAt(scanner,@5));
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             $$ = mks;
@@ -4328,7 +4314,7 @@ make_table_call
     :   DAS_TABLE[loc] '(' expr_map_tuple_list[arguments] optional_comma ')' {
         auto mka = new ExprMakeArray(tokAt(scanner,@loc));
         mka->values = sequenceToList($arguments);
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
         ttm->arguments.push_back(mka);
         $$ = ttm;
@@ -4344,11 +4330,9 @@ make_table_call
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,@loc);
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = $decl;
-            msd->makeType->secondType = new TypeDecl(Type::tVoid);
-            msd->makeType->secondType->at = tokAt(scanner,@loc);
+            msd->makeType->secondType = new TypeDecl(Type::tVoid, tokAt(scanner,@loc));
             msd->at = tokAt(scanner,@loc);
             msd->useInitializer = true;
             msd->alwaysUseInitializer = true;
@@ -4359,7 +4343,7 @@ make_table_call
         if ( $arguments ) {
             auto mka = new ExprMakeArray(tokAt(scanner,@loc));
             mka->values = sequenceToList($arguments);
-            mka->makeType = new TypeDecl(Type::tTuple);
+            mka->makeType = new TypeDecl(Type::tTuple, tokAt(scanner,@$));
             mka->makeType->argTypes.push_back($decl);
             mka->makeType->argTypes.push_back($to_decl);
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
@@ -4368,8 +4352,7 @@ make_table_call
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,@loc);
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = $decl;
             msd->makeType->secondType = $to_decl;
             msd->at = tokAt(scanner,@loc);

--- a/src/parser/ds_parser.cpp
+++ b/src/parser/ds_parser.cpp
@@ -1139,70 +1139,70 @@ static const yytype_int16 yyrline[] =
     1624,  1627,  1631,  1635,  1642,  1649,  1655,  1659,  1663,  1666,
     1669,  1677,  1680,  1683,  1691,  1694,  1702,  1705,  1708,  1716,
     1722,  1723,  1724,  1728,  1729,  1733,  1734,  1738,  1743,  1751,
-    1757,  1763,  1769,  1775,  1784,  1793,  1802,  1814,  1817,  1823,
-    1823,  1823,  1826,  1826,  1826,  1831,  1831,  1831,  1839,  1839,
-    1839,  1845,  1855,  1866,  1879,  1889,  1900,  1915,  1918,  1924,
-    1925,  1933,  1945,  1946,  1947,  1951,  1952,  1953,  1954,  1955,
-    1959,  1964,  1972,  1973,  1974,  1978,  1983,  1990,  1997,  1997,
-    2006,  2007,  2008,  2009,  2010,  2011,  2012,  2013,  2017,  2018,
-    2019,  2020,  2021,  2022,  2023,  2024,  2025,  2026,  2027,  2028,
-    2029,  2030,  2031,  2032,  2033,  2034,  2035,  2039,  2040,  2041,
-    2042,  2047,  2048,  2049,  2050,  2051,  2052,  2053,  2054,  2055,
-    2056,  2057,  2058,  2059,  2060,  2061,  2062,  2063,  2068,  2074,
-    2085,  2091,  2102,  2106,  2113,  2116,  2116,  2116,  2121,  2121,
-    2121,  2135,  2139,  2143,  2149,  2157,  2165,  2171,  2179,  2179,
-    2179,  2186,  2190,  2199,  2207,  2215,  2219,  2222,  2228,  2229,
-    2230,  2231,  2232,  2233,  2234,  2235,  2236,  2237,  2238,  2239,
-    2240,  2241,  2242,  2243,  2244,  2245,  2246,  2247,  2248,  2249,
-    2250,  2251,  2252,  2253,  2254,  2255,  2256,  2257,  2258,  2259,
-    2260,  2261,  2262,  2263,  2269,  2270,  2271,  2272,  2273,  2288,
-    2297,  2298,  2299,  2300,  2301,  2302,  2303,  2304,  2305,  2306,
-    2307,  2308,  2311,  2314,  2315,  2318,  2318,  2318,  2321,  2326,
-    2330,  2334,  2334,  2334,  2339,  2342,  2346,  2346,  2346,  2351,
-    2354,  2355,  2356,  2357,  2358,  2359,  2360,  2361,  2362,  2364,
-    2368,  2369,  2374,  2378,  2379,  2380,  2381,  2382,  2383,  2384,
-    2388,  2392,  2396,  2400,  2404,  2408,  2412,  2416,  2420,  2427,
-    2428,  2429,  2433,  2434,  2435,  2439,  2440,  2444,  2445,  2446,
-    2450,  2451,  2455,  2466,  2469,  2472,  2472,  2476,  2476,  2495,
-    2494,  2510,  2509,  2523,  2532,  2544,  2553,  2563,  2564,  2565,
-    2566,  2567,  2571,  2574,  2583,  2584,  2588,  2591,  2594,  2609,
-    2618,  2619,  2623,  2626,  2629,  2642,  2643,  2647,  2653,  2659,
-    2668,  2671,  2678,  2681,  2687,  2688,  2689,  2693,  2694,  2698,
-    2705,  2710,  2719,  2725,  2729,  2740,  2744,  2750,  2756,  2765,
-    2777,  2780,  2783,  2783,  2803,  2804,  2808,  2809,  2810,  2814,
-    2817,  2817,  2836,  2839,  2842,  2857,  2876,  2877,  2878,  2883,
-    2883,  2909,  2910,  2914,  2915,  2915,  2919,  2920,  2921,  2925,
-    2935,  2940,  2935,  2952,  2957,  2952,  2972,  2973,  2977,  2978,
-    2982,  2988,  2989,  2990,  2991,  2995,  2996,  2997,  3001,  3004,
-    3010,  3015,  3010,  3035,  3042,  3047,  3056,  3062,  3066,  3077,
+    1757,  1763,  1769,  1775,  1783,  1791,  1799,  1810,  1813,  1819,
+    1819,  1819,  1822,  1822,  1822,  1827,  1827,  1827,  1835,  1835,
+    1835,  1841,  1851,  1862,  1875,  1885,  1896,  1911,  1914,  1920,
+    1921,  1929,  1941,  1942,  1943,  1947,  1948,  1949,  1950,  1951,
+    1955,  1960,  1968,  1969,  1970,  1974,  1979,  1986,  1993,  1993,
+    2002,  2003,  2004,  2005,  2006,  2007,  2008,  2009,  2013,  2014,
+    2015,  2016,  2017,  2018,  2019,  2020,  2021,  2022,  2023,  2024,
+    2025,  2026,  2027,  2028,  2029,  2030,  2031,  2035,  2036,  2037,
+    2038,  2043,  2044,  2045,  2046,  2047,  2048,  2049,  2050,  2051,
+    2052,  2053,  2054,  2055,  2056,  2057,  2058,  2059,  2064,  2070,
+    2081,  2087,  2098,  2102,  2109,  2112,  2112,  2112,  2117,  2117,
+    2117,  2130,  2134,  2138,  2144,  2152,  2160,  2166,  2174,  2174,
+    2174,  2181,  2185,  2194,  2202,  2210,  2214,  2217,  2223,  2224,
+    2225,  2226,  2227,  2228,  2229,  2230,  2231,  2232,  2233,  2234,
+    2235,  2236,  2237,  2238,  2239,  2240,  2241,  2242,  2243,  2244,
+    2245,  2246,  2247,  2248,  2249,  2250,  2251,  2252,  2253,  2254,
+    2255,  2256,  2257,  2258,  2264,  2265,  2266,  2267,  2268,  2283,
+    2292,  2293,  2294,  2295,  2296,  2297,  2298,  2299,  2300,  2301,
+    2302,  2303,  2306,  2309,  2310,  2313,  2313,  2313,  2316,  2321,
+    2325,  2329,  2329,  2329,  2334,  2337,  2341,  2341,  2341,  2346,
+    2349,  2350,  2351,  2352,  2353,  2354,  2355,  2356,  2357,  2359,
+    2363,  2364,  2369,  2373,  2374,  2375,  2376,  2377,  2378,  2379,
+    2383,  2387,  2391,  2395,  2399,  2403,  2407,  2411,  2415,  2422,
+    2423,  2424,  2428,  2429,  2430,  2434,  2435,  2439,  2440,  2441,
+    2445,  2446,  2450,  2461,  2464,  2467,  2467,  2471,  2471,  2490,
+    2489,  2505,  2504,  2518,  2527,  2539,  2548,  2558,  2559,  2560,
+    2561,  2562,  2566,  2569,  2578,  2579,  2583,  2586,  2589,  2604,
+    2613,  2614,  2618,  2621,  2624,  2637,  2638,  2642,  2647,  2652,
+    2660,  2663,  2670,  2673,  2679,  2680,  2681,  2685,  2686,  2690,
+    2697,  2702,  2711,  2717,  2721,  2732,  2736,  2742,  2748,  2756,
+    2767,  2770,  2773,  2773,  2793,  2794,  2798,  2799,  2800,  2804,
+    2807,  2807,  2826,  2829,  2832,  2847,  2866,  2867,  2868,  2873,
+    2873,  2899,  2900,  2904,  2905,  2905,  2909,  2910,  2911,  2915,
+    2925,  2930,  2925,  2942,  2947,  2942,  2962,  2963,  2967,  2968,
+    2972,  2978,  2979,  2980,  2981,  2985,  2986,  2987,  2991,  2994,
+    3000,  3005,  3000,  3025,  3032,  3037,  3046,  3052,  3056,  3067,
+    3068,  3069,  3070,  3071,  3072,  3073,  3074,  3075,  3076,  3077,
     3078,  3079,  3080,  3081,  3082,  3083,  3084,  3085,  3086,  3087,
     3088,  3089,  3090,  3091,  3092,  3093,  3094,  3095,  3096,  3097,
     3098,  3099,  3100,  3101,  3102,  3103,  3104,  3105,  3106,  3107,
-    3108,  3109,  3110,  3111,  3112,  3113,  3114,  3115,  3116,  3117,
-    3118,  3119,  3120,  3121,  3122,  3123,  3124,  3125,  3126,  3130,
-    3131,  3132,  3133,  3134,  3135,  3136,  3137,  3141,  3152,  3156,
-    3163,  3175,  3182,  3188,  3197,  3202,  3205,  3215,  3228,  3229,
-    3230,  3231,  3232,  3236,  3240,  3240,  3240,  3254,  3255,  3259,
-    3264,  3271,  3274,  3280,  3281,  3282,  3283,  3284,  3294,  3297,
-    3297,  3297,  3301,  3306,  3313,  3313,  3320,  3324,  3328,  3333,
-    3338,  3343,  3348,  3352,  3356,  3361,  3365,  3369,  3374,  3374,
-    3374,  3380,  3387,  3387,  3387,  3392,  3392,  3392,  3398,  3398,
-    3398,  3403,  3409,  3409,  3409,  3414,  3414,  3414,  3423,  3429,
-    3429,  3429,  3434,  3434,  3434,  3443,  3449,  3449,  3449,  3454,
-    3454,  3454,  3463,  3463,  3463,  3469,  3469,  3469,  3478,  3481,
-    3492,  3508,  3508,  3513,  3518,  3508,  3543,  3543,  3548,  3554,
-    3543,  3579,  3579,  3584,  3589,  3579,  3629,  3630,  3631,  3632,
-    3633,  3637,  3644,  3651,  3657,  3663,  3670,  3677,  3683,  3692,
-    3695,  3701,  3709,  3714,  3721,  3726,  3733,  3738,  3744,  3745,
-    3749,  3750,  3755,  3756,  3760,  3761,  3765,  3766,  3770,  3771,
-    3772,  3776,  3777,  3778,  3782,  3783,  3787,  3793,  3800,  3808,
-    3815,  3823,  3832,  3832,  3832,  3840,  3840,  3840,  3847,  3847,
-    3847,  3858,  3858,  3858,  3869,  3872,  3878,  3892,  3898,  3904,
-    3910,  3910,  3910,  3924,  3929,  3936,  3957,  3962,  3969,  3969,
-    3969,  3979,  3979,  3979,  3993,  3993,  3993,  4007,  4016,  4016,
-    4016,  4037,  4044,  4044,  4044,  4054,  4059,  4066,  4069,  4075,
-    4094,  4106,  4114,  4136,  4162,  4163,  4167,  4168,  4173,  4176,
-    4179,  4182,  4185,  4188
+    3108,  3109,  3110,  3111,  3112,  3113,  3114,  3115,  3116,  3120,
+    3121,  3122,  3123,  3124,  3125,  3126,  3127,  3131,  3142,  3146,
+    3153,  3165,  3172,  3178,  3187,  3192,  3195,  3205,  3218,  3219,
+    3220,  3221,  3222,  3226,  3230,  3230,  3230,  3244,  3245,  3249,
+    3254,  3261,  3264,  3270,  3271,  3272,  3273,  3274,  3284,  3287,
+    3287,  3287,  3291,  3296,  3303,  3303,  3310,  3314,  3318,  3323,
+    3328,  3333,  3338,  3342,  3346,  3351,  3355,  3359,  3364,  3364,
+    3364,  3370,  3377,  3377,  3377,  3382,  3382,  3382,  3388,  3388,
+    3388,  3393,  3399,  3399,  3399,  3404,  3404,  3404,  3413,  3419,
+    3419,  3419,  3424,  3424,  3424,  3433,  3439,  3439,  3439,  3444,
+    3444,  3444,  3453,  3453,  3453,  3459,  3459,  3459,  3468,  3471,
+    3482,  3498,  3498,  3503,  3508,  3498,  3533,  3533,  3538,  3544,
+    3533,  3569,  3569,  3574,  3579,  3569,  3619,  3620,  3621,  3622,
+    3623,  3627,  3634,  3641,  3647,  3653,  3660,  3667,  3673,  3682,
+    3685,  3691,  3699,  3704,  3711,  3716,  3723,  3728,  3734,  3735,
+    3739,  3740,  3745,  3746,  3750,  3751,  3755,  3756,  3760,  3761,
+    3762,  3766,  3767,  3768,  3772,  3773,  3777,  3783,  3790,  3798,
+    3805,  3813,  3822,  3822,  3822,  3830,  3830,  3830,  3837,  3837,
+    3837,  3847,  3847,  3847,  3858,  3861,  3867,  3881,  3887,  3893,
+    3899,  3899,  3899,  3912,  3917,  3924,  3943,  3948,  3955,  3955,
+    3955,  3965,  3965,  3965,  3978,  3978,  3978,  3991,  4000,  4000,
+    4000,  4020,  4027,  4027,  4027,  4037,  4042,  4049,  4052,  4058,
+    4077,  4088,  4096,  4116,  4141,  4142,  4146,  4147,  4152,  4155,
+    4158,  4161,  4164,  4167
 };
 #endif
 
@@ -7764,7 +7764,7 @@ yyreduce:
 
   case 144: /* optional_function_type: %empty  */
         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yyloc));
     }
     break;
@@ -8539,7 +8539,7 @@ yyreduce:
                                                            {
         auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),*(yyvsp[-2].s));
         pCall->arguments.push_back((yyvsp[-1].pExpression));
-        auto resT = new TypeDecl(Type::autoinfer);
+        auto resT = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         auto blk = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,resT,(yyvsp[0].pExpression),tokAt(scanner,(yylsp[0])),tokAt(scanner,(yylsp[0])),LineInfo());
         pCall->arguments.push_back(blk);
         delete (yyvsp[-2].s);
@@ -8952,8 +8952,7 @@ yyreduce:
 
   case 383: /* tuple_expansion_variable_declaration: "[[" tuple_expansion ']' ']' optional_ref copy_or_move_or_clone expr semicolon  */
                                                                                                                 {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-6]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-6])));
         typeDecl->ref = (yyvsp[-3].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-6].pNameList),tokAt(scanner,(yylsp[-6])),typeDecl,(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -8964,8 +8963,7 @@ yyreduce:
 
   case 384: /* tuple_expansion_variable_declaration: "[[" tuple_expansion ']' ']' optional_ref copy_or_move_or_clone expr_pipe  */
                                                                                                            {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-5]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-5])));
         typeDecl->ref = (yyvsp[-2].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameList),tokAt(scanner,(yylsp[-5])),typeDecl,(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-1].i) & CorM_MOVE) !=0;
@@ -8976,8 +8974,7 @@ yyreduce:
 
   case 385: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr semicolon  */
                                                                                                         {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-5]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-5])));
         typeDecl->ref = (yyvsp[-3].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-5].pNameList),tokAt(scanner,(yylsp[-5])),typeDecl,(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -8988,8 +8985,7 @@ yyreduce:
 
   case 386: /* tuple_expansion_variable_declaration: '(' tuple_expansion ')' optional_ref copy_or_move_or_clone expr_pipe  */
                                                                                                    {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-4]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-4])));
         typeDecl->ref = (yyvsp[-2].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameList),tokAt(scanner,(yylsp[-4])),typeDecl,(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-1].i) & CorM_MOVE) !=0;
@@ -9257,7 +9253,7 @@ yyreduce:
                                             {
         ExprBlock * closure = (ExprBlock *) (yyvsp[0].pExpression);
         (yyval.pExpression) = new ExprMakeBlock(tokAt(scanner,(yylsp[0])),(yyvsp[0].pExpression));
-        closure->returnType = new TypeDecl(Type::autoinfer);
+        closure->returnType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
     }
     break;
 
@@ -9561,8 +9557,7 @@ yyreduce:
   case 490: /* func_addr_expr: '@' '@' '<' $@26 optional_function_argument_list optional_function_type '>' $@27 func_addr_name  */
                                                                                                                                                                                      {
         auto expr = (ExprAddr *) ((yyvsp[0].pExpression)->rtti_isAddr() ? (yyvsp[0].pExpression) : (((ExprTag *) (yyvsp[0].pExpression))->value));
-        expr->funcType = new TypeDecl(Type::tFunction);
-        expr->funcType->at = expr->at;
+        expr->funcType = new TypeDecl(Type::tFunction, expr->at);
         expr->funcType->firstType = (yyvsp[-3].pTypeDecl);
         if ( (yyvsp[-4].pVarDeclList) ) {
             varDeclToTypeDecl(scanner, expr->funcType, (yyvsp[-4].pVarDeclList));
@@ -9989,7 +9984,7 @@ yyreduce:
 
   case 568: /* expr: expr "is" basic_type_declaration  */
                                                                {
-        auto vdecl = new TypeDecl((yyvsp[0].type));
+        auto vdecl = new TypeDecl((yyvsp[0].type), tokAt(scanner,(yyloc)));
         vdecl->at = tokAt(scanner,(yylsp[0]));
         (yyval.pExpression) = new ExprIs(tokAt(scanner,(yylsp[-1])),(yyvsp[-2].pExpression),vdecl);
     }
@@ -10402,7 +10397,7 @@ yyreduce:
                                      {
             auto na = new vector<VariableNameAndPosition>();
             na->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,(yylsp[-1]))));
-            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none), (yyvsp[-1].pExpression));
+            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none, tokAt(scanner,(yyloc))), (yyvsp[-1].pExpression));
             decl->pTypeDecl->isTag = true;
             (yyval.pVarDecl) = decl;
         }
@@ -10530,8 +10525,7 @@ yyreduce:
 
   case 657: /* variable_declaration_no_type: variable_name_with_pos_list  */
                                           {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,(yylsp[0]));
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[0])));
         autoT->ref = false;
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[0].pNameWithPosList),autoT,nullptr);
     }
@@ -10539,8 +10533,7 @@ yyreduce:
 
   case 658: /* variable_declaration_no_type: variable_name_with_pos_list '&'  */
                                               {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,(yylsp[-1]));
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-1])));
         autoT->ref = true;
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-1].pNameWithPosList),autoT,nullptr);
     }
@@ -10548,8 +10541,7 @@ yyreduce:
 
   case 659: /* variable_declaration_no_type: variable_name_with_pos_list copy_or_move expr  */
                                                                        {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-2]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-2])));
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-2].pNameWithPosList),typeDecl,(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move = (yyvsp[-1].b);
     }
@@ -10684,8 +10676,7 @@ yyreduce:
 
   case 678: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr semicolon  */
                                                                                                                 {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-4]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-4])));
         typeDecl->ref = (yyvsp[-3].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-4].pNameWithPosList),typeDecl,(yyvsp[-1].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-2].i) & CorM_MOVE) !=0;
@@ -10696,8 +10687,7 @@ yyreduce:
 
   case 679: /* let_variable_declaration: let_variable_name_with_pos_list optional_ref copy_or_move_or_clone expr_pipe  */
                                                                                                            {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,(yylsp[-3]));
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-3])));
         typeDecl->ref = (yyvsp[-2].b);
         (yyval.pVarDecl) = new VariableDeclaration((yyvsp[-3].pNameWithPosList),typeDecl,(yyvsp[0].pExpression));
         (yyval.pVarDecl)->init_via_move  = ((yyvsp[-1].i) & CorM_MOVE) !=0;
@@ -11351,7 +11341,7 @@ yyreduce:
                                  {
         (yyval.pTypeDecl) = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,(yylsp[0])),*(yyvsp[0].s));
         if ( !(yyval.pTypeDecl) ) {
-            (yyval.pTypeDecl) = new TypeDecl(Type::tVoid);
+            (yyval.pTypeDecl) = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
         }
         delete (yyvsp[0].s);
@@ -11360,7 +11350,7 @@ yyreduce:
 
   case 798: /* auto_type_declaration: "auto"  */
                        {
-        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
     }
     break;
@@ -11368,7 +11358,7 @@ yyreduce:
   case 799: /* auto_type_declaration: "auto" '(' "name" ')'  */
                                             {
         das_checkName(scanner,*(yyvsp[-1].s),tokAt(scanner,(yylsp[-1])));
-        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
         (yyval.pTypeDecl)->alias = *(yyvsp[-1].s);
         delete (yyvsp[-1].s);
@@ -11377,11 +11367,11 @@ yyreduce:
 
   case 800: /* auto_type_declaration: "$t" '(' expr ')'  */
                                           {
-        (yyval.pTypeDecl) = new TypeDecl(Type::alias);
+        (yyval.pTypeDecl) = new TypeDecl(Type::alias, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-3]));
         (yyval.pTypeDecl)->alias = "``MACRO``TAG``";
         (yyval.pTypeDecl)->isTag = true;
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::autoinfer);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = tokAt(scanner, (yylsp[-1]));
         (yyval.pTypeDecl)->firstType->typeMacroExpr.push_back((yyvsp[-1].pExpression));
     }
@@ -11477,7 +11467,7 @@ yyreduce:
 
   case 813: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' '>'  */
                                                                           {
-            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-2].type));
+            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-2].type), tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-2]));
     }
     break;
@@ -11492,7 +11482,7 @@ yyreduce:
 
   case 816: /* bitfield_type_declaration: "bitfield" bitfield_basic_type_declaration '<' $@50 bitfield_bits '>' $@51  */
                                                                                                                                                              {
-            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-5].type));
+            (yyval.pTypeDecl) = new TypeDecl((yyvsp[-5].type), tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->argNames = *(yyvsp[-2].pNameList);
             auto maxBits = (yyval.pTypeDecl)->maxBitfieldBits();
             if ( (yyval.pTypeDecl)->argNames.size()>maxBits ) {
@@ -11507,7 +11497,7 @@ yyreduce:
   case 819: /* table_type_pair: type_declaration  */
                                       {
         (yyval.aTypePair).firstType = (yyvsp[0].pTypeDecl);
-        (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid);
+        (yyval.aTypePair).secondType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.aTypePair).secondType->at = (yyval.aTypePair).firstType->at;
     }
     break;
@@ -11532,7 +11522,7 @@ yyreduce:
     break;
 
   case 823: /* type_declaration_no_options: basic_type_declaration  */
-                                                            { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type)); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
+                                                            { (yyval.pTypeDecl) = new TypeDecl((yyvsp[0].type), tokAt(scanner,(yyloc))); (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0])); }
     break;
 
   case 824: /* type_declaration_no_options: auto_type_declaration  */
@@ -11583,7 +11573,7 @@ yyreduce:
 
   case 832: /* type_declaration_no_options: "typedecl" '(' expr ')'  */
                                                {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeDecl, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-3]),(yylsp[-1]));
         (yyval.pTypeDecl)->typeMacroExpr.push_back((yyvsp[-1].pExpression));
     }
@@ -11591,7 +11581,7 @@ yyreduce:
 
   case 833: /* type_declaration_no_options: '$' name_in_namespace optional_expr_list_in_braces  */
                                                                             {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-1]), (yylsp[0]));
         (yyval.pTypeDecl)->typeMacroExpr = sequenceToList((yyvsp[0].pExpression));
         (yyval.pTypeDecl)->typeMacroExpr.insert((yyval.pTypeDecl)->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-1])), *(yyvsp[-1].s)));
@@ -11605,7 +11595,7 @@ yyreduce:
 
   case 835: /* type_declaration_no_options: '$' name_in_namespace '<' $@54 type_declaration_no_options_list '>' optional_expr_list_in_braces  */
                                                                                                                                                              {
-        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro);
+        (yyval.pTypeDecl) = new TypeDecl(Type::typeMacro, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-5]), (yylsp[0]));
         (yyval.pTypeDecl)->typeMacroExpr = typesAndSequenceToList((yyvsp[-2].pTypeDeclList),(yyvsp[0].pExpression));
         (yyval.pTypeDecl)->typeMacroExpr.insert((yyval.pTypeDecl)->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,(yylsp[-5])), *(yyvsp[-5].s)));
@@ -11697,7 +11687,7 @@ yyreduce:
 
   case 847: /* type_declaration_no_options: type_declaration_no_options '?'  */
                                                   {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-1].pTypeDecl);
     }
@@ -11713,7 +11703,7 @@ yyreduce:
 
   case 850: /* type_declaration_no_options: "smart_ptr" '<' $@55 type_declaration '>' $@56  */
                                                                                                                                 {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->smartPtr = true;
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
@@ -11722,9 +11712,9 @@ yyreduce:
 
   case 851: /* type_declaration_no_options: type_declaration_no_options "??"  */
                                                  {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-1]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tPointer);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tPointer, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = tokAt(scanner,(yylsp[-1]));
         (yyval.pTypeDecl)->firstType->firstType = (yyvsp[-1].pTypeDecl);
     }
@@ -11740,7 +11730,7 @@ yyreduce:
 
   case 854: /* type_declaration_no_options: "array" '<' $@57 type_declaration '>' $@58  */
                                                                                                                             {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tArray);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tArray, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11756,7 +11746,7 @@ yyreduce:
 
   case 857: /* type_declaration_no_options: "table" '<' $@59 table_type_pair '>' $@60  */
                                                                                                                       {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tTable);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tTable, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].aTypePair).firstType;
         (yyval.pTypeDecl)->secondType = (yyvsp[-2].aTypePair).secondType;
@@ -11773,7 +11763,7 @@ yyreduce:
 
   case 860: /* type_declaration_no_options: "iterator" '<' $@61 type_declaration '>' $@62  */
                                                                                                                                   {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tIterator);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tIterator, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11781,9 +11771,9 @@ yyreduce:
 
   case 861: /* type_declaration_no_options: "block"  */
                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = (yyval.pTypeDecl)->at;
     }
     break;
@@ -11798,7 +11788,7 @@ yyreduce:
 
   case 864: /* type_declaration_no_options: "block" '<' $@63 type_declaration '>' $@64  */
                                                                                                                                {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11814,7 +11804,7 @@ yyreduce:
 
   case 867: /* type_declaration_no_options: "block" '<' $@65 optional_function_argument_list optional_function_type '>' $@66  */
                                                                                                                                                                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tBlock, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
         if ( (yyvsp[-3].pVarDeclList) ) {
@@ -11826,9 +11816,9 @@ yyreduce:
 
   case 868: /* type_declaration_no_options: "function"  */
                            {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = (yyval.pTypeDecl)->at;
     }
     break;
@@ -11843,7 +11833,7 @@ yyreduce:
 
   case 871: /* type_declaration_no_options: "function" '<' $@67 type_declaration '>' $@68  */
                                                                                                                                  {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11859,7 +11849,7 @@ yyreduce:
 
   case 874: /* type_declaration_no_options: "function" '<' $@69 optional_function_argument_list optional_function_type '>' $@70  */
                                                                                                                                                                           {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tFunction, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
         if ( (yyvsp[-3].pVarDeclList) ) {
@@ -11871,9 +11861,9 @@ yyreduce:
 
   case 875: /* type_declaration_no_options: "lambda"  */
                          {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[0]));
-        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid);
+        (yyval.pTypeDecl)->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->firstType->at = (yyval.pTypeDecl)->at;
     }
     break;
@@ -11888,7 +11878,7 @@ yyreduce:
 
   case 878: /* type_declaration_no_options: "lambda" '<' $@71 type_declaration '>' $@72  */
                                                                                                                                {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
     }
@@ -11904,7 +11894,7 @@ yyreduce:
 
   case 881: /* type_declaration_no_options: "lambda" '<' $@73 optional_function_argument_list optional_function_type '>' $@74  */
                                                                                                                                                                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tLambda, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-6]));
         (yyval.pTypeDecl)->firstType = (yyvsp[-2].pTypeDecl);
         if ( (yyvsp[-3].pVarDeclList) ) {
@@ -11924,7 +11914,7 @@ yyreduce:
 
   case 884: /* type_declaration_no_options: "tuple" '<' $@75 tuple_type_list '>' $@76  */
                                                                                                                         {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tTuple);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tTuple, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-2].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
@@ -11941,7 +11931,7 @@ yyreduce:
 
   case 887: /* type_declaration_no_options: "variant" '<' $@77 variant_type_list '>' $@78  */
                                                                                                                             {
-        (yyval.pTypeDecl) = new TypeDecl(Type::tVariant);
+        (yyval.pTypeDecl) = new TypeDecl(Type::tVariant, tokAt(scanner,(yyloc)));
         (yyval.pTypeDecl)->at = tokAt(scanner,(yylsp[-5]));
         varDeclToTypeDecl(scanner, (yyval.pTypeDecl), (yyvsp[-2].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-2].pVarDeclList));
@@ -11960,7 +11950,7 @@ yyreduce:
             (yyval.pTypeDecl) = (yyvsp[-2].pTypeDecl);
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[0].pTypeDecl));
         } else {
-            (yyval.pTypeDecl) = new TypeDecl(Type::option);
+            (yyval.pTypeDecl) = new TypeDecl(Type::option, tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[-2].pTypeDecl));
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[0].pTypeDecl));
@@ -11975,7 +11965,7 @@ yyreduce:
             (yyval.pTypeDecl)->argTypes.push_back(new TypeDecl(*(yyvsp[-2].pTypeDecl)->argTypes.back()));
             (yyvsp[-2].pTypeDecl)->argTypes.back()->temporary ^= true;
         } else {
-            (yyval.pTypeDecl) = new TypeDecl(Type::option);
+            (yyval.pTypeDecl) = new TypeDecl(Type::option, tokAt(scanner,(yyloc)));
             (yyval.pTypeDecl)->at = tokRangeAt(scanner,(yylsp[-2]),(yylsp[0]));
             (yyval.pTypeDecl)->argTypes.push_back((yyvsp[-2].pTypeDecl));
             (yyval.pTypeDecl)->argTypes.push_back(new TypeDecl(*(yyvsp[-2].pTypeDecl)));
@@ -12017,7 +12007,7 @@ yyreduce:
 
   case 895: /* tuple_alias_declaration: "tuple" optional_public_or_private_alias $@79 "name" $@80 open_block $@81 tuple_alias_type_list $@82 close_block  */
                   {
-        auto vtype = new TypeDecl(Type::tTuple);
+        auto vtype = new TypeDecl(Type::tTuple, tokAt(scanner,(yyloc)));
         vtype->alias = *(yyvsp[-6].s);
         vtype->at = tokAt(scanner,(yylsp[-6]));
         vtype->isPrivateAlias = !(yyvsp[-8].b);
@@ -12069,7 +12059,7 @@ yyreduce:
 
   case 900: /* variant_alias_declaration: "variant" optional_public_or_private_alias $@83 "name" $@84 open_block $@85 variant_alias_type_list $@86 close_block  */
                   {
-        auto vtype = new TypeDecl(Type::tVariant);
+        auto vtype = new TypeDecl(Type::tVariant, tokAt(scanner,(yyloc)));
         vtype->alias = *(yyvsp[-6].s);
         vtype->at = tokAt(scanner,(yylsp[-6]));
         vtype->isPrivateAlias = !(yyvsp[-8].b);
@@ -12120,7 +12110,7 @@ yyreduce:
 
   case 905: /* bitfield_alias_declaration: "bitfield" optional_public_or_private_alias $@87 "name" $@88 bitfield_basic_type_declaration open_block $@89 bitfield_alias_bits $@90 close_block  */
                   {
-        auto btype = new TypeDecl((yyvsp[-5].type));
+        auto btype = new TypeDecl((yyvsp[-5].type), tokAt(scanner,(yyloc)));
         btype->alias = *(yyvsp[-7].s);
         btype->at = tokAt(scanner,(yylsp[-7]));
         btype->isPrivateAlias = !(yyvsp[-9].b);
@@ -12446,8 +12436,7 @@ yyreduce:
 
   case 960: /* make_struct_decl: "variant" '<' $@95 variant_type_list '>' $@96 '(' use_initializer make_variant_dim ')'  */
                                                                                                                                                                                                                         {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,(yylsp[-9]));
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,(yylsp[-9])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-6].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-6].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
@@ -12525,7 +12514,7 @@ yyreduce:
                                                                     {
         auto mkt = new ExprMakeTuple(tokAt(scanner,(yylsp[-4])));
         mkt->values = sequenceToList((yyvsp[-2].pExpression));
-        mkt->makeType = new TypeDecl(Type::autoinfer);
+        mkt->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         (yyval.pExpression) = mkt;
     }
     break;
@@ -12540,8 +12529,7 @@ yyreduce:
 
   case 972: /* make_tuple_call: "tuple" '<' $@99 tuple_type_list '>' $@100 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                                                  {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,(yylsp[-9]));
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,(yylsp[-9])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-6].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-6].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
@@ -12572,7 +12560,7 @@ yyreduce:
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-2])));
             mka->values = sequenceToList((yyvsp[-1].pExpression));
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
             mka->gen2 = true;
             auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),"to_array_move");
             tam->arguments.push_back(mka);
@@ -12580,10 +12568,8 @@ yyreduce:
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,(yylsp[-2]));
-            mks->makeType = new TypeDecl(Type::tArray);
-            mks->makeType->at = mks->at;
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->firstType->at = mks->at;
+            mks->makeType = new TypeDecl(Type::tArray, mks->at);
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, mks->at);
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             (yyval.pExpression) = mks;
@@ -12640,8 +12626,7 @@ yyreduce:
 
   case 983: /* make_dim_decl: "array" "tuple" '<' $@103 tuple_type_list '>' $@104 '(' use_initializer optional_make_struct_dim_decl ')'  */
                                                                                                                                                                                                      {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,(yylsp[-10]));
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,(yylsp[-10])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-6].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-6].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-10]));
@@ -12665,8 +12650,7 @@ yyreduce:
 
   case 986: /* make_dim_decl: "array" "variant" '<' $@105 variant_type_list '>' $@106 '(' make_variant_dim ')'  */
                                                                                                                                                                       {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,(yylsp[-9]));
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,(yylsp[-9])));
         varDeclToTypeDecl(scanner, mkt, (yyvsp[-5].pVarDeclList), true);
         deleteVariableDeclarationList((yyvsp[-5].pVarDeclList));
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-9]));
@@ -12684,7 +12668,7 @@ yyreduce:
                                                                    {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         mka->gen2 = true;
         auto tam = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-4])),"to_array_move");
         tam->arguments.push_back(mka);
@@ -12713,8 +12697,7 @@ yyreduce:
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,(yylsp[-8]));
-            msd->makeType = new TypeDecl(Type::tArray);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tArray, msd->at);
             msd->makeType->firstType = (yyvsp[-5].pTypeDecl);
             msd->at = tokAt(scanner,(yylsp[-5]));
             msd->useInitializer = true;
@@ -12728,7 +12711,7 @@ yyreduce:
                                                                          {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-4])));
         mka->values = sequenceToList((yyvsp[-2].pExpression));
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         mka->gen2 = true;
         (yyval.pExpression) = mka;
     }
@@ -12784,16 +12767,16 @@ yyreduce:
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-2])));
             mka->values = sequenceToList((yyvsp[-1].pExpression));
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),"to_table_move");
             ttm->arguments.push_back(mka);
             (yyval.pExpression) = ttm;
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,(yylsp[-2]));
-            mks->makeType = new TypeDecl(Type::tTable);
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->secondType = new TypeDecl(Type::autoinfer);
+            mks->makeType = new TypeDecl(Type::tTable, tokAt(scanner,(yyloc)));
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[-2])));
+            mks->makeType->secondType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yylsp[0])));
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             (yyval.pExpression) = mks;
@@ -12803,11 +12786,10 @@ yyreduce:
 
   case 1000: /* make_table_decl: "{{" make_table optional_trailing_semicolon_cur_cur  */
                                                                           {
-        auto mkt = new TypeDecl(Type::tFixedArray);
+        auto mkt = new TypeDecl(Type::tFixedArray, tokAt(scanner,(yyloc)));
         mkt->fixedDim = TypeDecl::dimAuto;
         mkt->at = tokAt(scanner,(yylsp[-2]));
-        mkt->firstType = new TypeDecl(Type::autoinfer);
-        mkt->firstType->at = mkt->at;
+        mkt->firstType = new TypeDecl(Type::autoinfer, mkt->at);
         ((ExprMakeArray *)(yyvsp[-1].pExpression))->makeType = mkt;
         (yyvsp[-1].pExpression)->at = tokAt(scanner,(yylsp[-2]));
         auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-2])),"to_table_move");
@@ -12820,7 +12802,7 @@ yyreduce:
                                                                        {
         auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-3])));
         mka->values = sequenceToList((yyvsp[-1].pExpression));
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,(yyloc)));
         auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-3])),"to_table_move");
         ttm->arguments.push_back(mka);
         (yyval.pExpression) = ttm;
@@ -12839,11 +12821,9 @@ yyreduce:
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,(yylsp[-6]));
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = (yyvsp[-4].pTypeDecl);
-            msd->makeType->secondType = new TypeDecl(Type::tVoid);
-            msd->makeType->secondType->at = tokAt(scanner,(yylsp[-6]));
+            msd->makeType->secondType = new TypeDecl(Type::tVoid, tokAt(scanner,(yylsp[-6])));
             msd->at = tokAt(scanner,(yylsp[-6]));
             msd->useInitializer = true;
             msd->alwaysUseInitializer = true;
@@ -12857,7 +12837,7 @@ yyreduce:
         if ( (yyvsp[-1].pExpression) ) {
             auto mka = new ExprMakeArray(tokAt(scanner,(yylsp[-8])));
             mka->values = sequenceToList((yyvsp[-1].pExpression));
-            mka->makeType = new TypeDecl(Type::tTuple);
+            mka->makeType = new TypeDecl(Type::tTuple, tokAt(scanner,(yyloc)));
             mka->makeType->argTypes.push_back((yyvsp[-6].pTypeDecl));
             mka->makeType->argTypes.push_back((yyvsp[-4].pTypeDecl));
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,(yylsp[-8])),"to_table_move");
@@ -12866,8 +12846,7 @@ yyreduce:
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,(yylsp[-8]));
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = (yyvsp[-6].pTypeDecl);
             msd->makeType->secondType = (yyvsp[-4].pTypeDecl);
             msd->at = tokAt(scanner,(yylsp[-8]));

--- a/src/parser/ds_parser.ypp
+++ b/src/parser/ds_parser.ypp
@@ -1190,7 +1190,7 @@ optional_function_argument_list
 
 optional_function_type
     :   {
-        $$ = new TypeDecl(Type::autoinfer);
+        $$ = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@$);
     }
     |   ':' type_declaration[typeDecl]  {
@@ -1487,7 +1487,7 @@ expr_keyword
     :   KEYWORD[kwd] expr[subexpr] expression_block[block] {
         auto pCall = yyextra->g_Program->makeCall(tokAt(scanner,@kwd),*$kwd);
         pCall->arguments.push_back($subexpr);
-        auto resT = new TypeDecl(Type::autoinfer);
+        auto resT = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         auto blk = ast_makeBlock(scanner,0,nullptr,nullptr,nullptr,resT,$block,tokAt(scanner,@block),tokAt(scanner,@block),LineInfo());
         pCall->arguments.push_back(blk);
         delete $kwd;
@@ -1773,8 +1773,7 @@ tuple_expansion_variable_declaration
         $$->isTupleExpansion = true;
     }
     |   BRABRAB tuple_expansion[list] ']' ']' optional_ref[ref] copy_or_move_or_clone[com] expr[init] semicolon {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -1782,8 +1781,7 @@ tuple_expansion_variable_declaration
         $$->isTupleExpansion = true;
     }
     |   BRABRAB tuple_expansion[list] ']' ']' optional_ref[ref] copy_or_move_or_clone[com] expr_pipe[init] {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -1791,8 +1789,7 @@ tuple_expansion_variable_declaration
         $$->isTupleExpansion = true;
     }
     |   '(' tuple_expansion[list] ')' optional_ref[ref] copy_or_move_or_clone[com] expr[init] semicolon {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -1800,8 +1797,7 @@ tuple_expansion_variable_declaration
         $$->isTupleExpansion = true;
     }
     |   '(' tuple_expansion[list] ')' optional_ref[ref] copy_or_move_or_clone[com] expr_pipe[init] {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,tokAt(scanner,@list),typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -1978,7 +1974,7 @@ expr_block
     :   expression_block[block]             {
         ExprBlock * closure = (ExprBlock *) $block;
         $$ = new ExprMakeBlock(tokAt(scanner,@block),$block);
-        closure->returnType = new TypeDecl(Type::autoinfer);
+        closure->returnType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
     }
     |   block_or_lambda[bal] optional_annotation_list[annL] optional_capture_list[clist] optional_function_argument_list[list]
                                 optional_function_type[result] block_or_simple_block[block] {
@@ -2120,8 +2116,7 @@ func_addr_expr
     }
     |   '@' '@' '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } func_addr_name[faddr] {
         auto expr = (ExprAddr *) ($faddr->rtti_isAddr() ? $faddr : (((ExprTag *) $faddr)->value));
-        expr->funcType = new TypeDecl(Type::tFunction);
-        expr->funcType->at = expr->at;
+        expr->funcType = new TypeDecl(Type::tFunction, expr->at);
         expr->funcType->firstType = $result;
         if ( $list ) {
             varDeclToTypeDecl(scanner, expr->funcType, $list);
@@ -2319,7 +2314,7 @@ expr
         $$ = new ExprIs(tokAt(scanner,@loc),$subexpr,$decl);
     }
     |   expr[subexpr] DAS_IS[loc] basic_type_declaration[decl] {
-        auto vdecl = new TypeDecl($decl);
+        auto vdecl = new TypeDecl($decl, tokAt(scanner,@$));
         vdecl->at = tokAt(scanner,@decl);
         $$ = new ExprIs(tokAt(scanner,@loc),$subexpr,vdecl);
     }
@@ -2553,7 +2548,7 @@ function_argument_declaration_type
     |   MTAG_A '(' expr[subexpr] ')' {
             auto na = new vector<VariableNameAndPosition>();
             na->push_back(VariableNameAndPosition("``MACRO``TAG``","",tokAt(scanner,@subexpr)));
-            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none), $subexpr);
+            auto decl = new VariableDeclaration(na, new TypeDecl(Type::none, tokAt(scanner,@$)), $subexpr);
             decl->pTypeDecl->isTag = true;
             $$ = decl;
         }
@@ -2645,20 +2640,17 @@ copy_or_move
 
 variable_declaration_no_type        /* this one can have uninitialized variable which has no type */
     :   variable_name_with_pos_list[list] {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,@list);
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         autoT->ref = false;
         $$ = new VariableDeclaration($list,autoT,nullptr);
     }
     |   variable_name_with_pos_list[list] '&' {
-        auto autoT = new TypeDecl(Type::autoinfer);
-        autoT->at = tokAt(scanner,@list);
+        auto autoT = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         autoT->ref = true;
         $$ = new VariableDeclaration($list,autoT,nullptr);
     }
     |   variable_name_with_pos_list[list] copy_or_move[com] expr[init] {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         $$ = new VariableDeclaration($list,typeDecl,$init);
         $$->init_via_move = $com;
     }
@@ -2754,8 +2746,7 @@ let_variable_declaration    /* let x; is prohibited. this one can't have uniniti
         $$->atEnd = tokAt(scanner,@init);
     }
     |   let_variable_name_with_pos_list[list] optional_ref[ref] copy_or_move_or_clone[com] expr[init] semicolon {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -2763,8 +2754,7 @@ let_variable_declaration    /* let x; is prohibited. this one can't have uniniti
         $$->atEnd = tokAt(scanner,@init);
     }
     |   let_variable_name_with_pos_list[list] optional_ref[ref] copy_or_move_or_clone[com] expr_pipe[init] {
-        auto typeDecl = new TypeDecl(Type::autoinfer);
-        typeDecl->at = tokAt(scanner,@list);
+        auto typeDecl = new TypeDecl(Type::autoinfer, tokAt(scanner,@list));
         typeDecl->ref = $ref;
         $$ = new VariableDeclaration($list,typeDecl,$init);
         $$->init_via_move  = ($com & CorM_MOVE) !=0;
@@ -3141,7 +3131,7 @@ structure_type_declaration
     :   name_in_namespace[name]  {
         $$ = yyextra->g_Program->makeTypeDeclaration(tokAt(scanner,@name),*$name);
         if ( !$$ ) {
-            $$ = new TypeDecl(Type::tVoid);
+            $$ = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
             $$->at = tokAt(scanner,@name);
         }
         delete $name;
@@ -3150,22 +3140,22 @@ structure_type_declaration
 
 auto_type_declaration
     :   DAS_TAUTO[loc] {
-        $$ = new TypeDecl(Type::autoinfer);
+        $$ = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
     }
     |   DAS_TAUTO[loc] '(' NAME[alias] ')'  {
         das_checkName(scanner,*$alias,tokAt(scanner,@alias));
-        $$ = new TypeDecl(Type::autoinfer);
+        $$ = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->alias = *$alias;
         delete $alias;
     }
     |   MTAG_T[loc] '(' expr[subexpr] ')' {
-        $$ = new TypeDecl(Type::alias);
+        $$ = new TypeDecl(Type::alias, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->alias = "``MACRO``TAG``";
         $$->isTag = true;
-        $$->firstType = new TypeDecl(Type::autoinfer);
+        $$->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$->firstType->at = tokAt(scanner, @subexpr);
         $$->firstType->typeMacroExpr.push_back($subexpr);
     }
@@ -3234,11 +3224,11 @@ bitfield_basic_type_declaration
 
 bitfield_type_declaration
     :   DAS_TBITFIELD bitfield_basic_type_declaration[basicType] '<' '>'  {
-            $$ = new TypeDecl($basicType);
+            $$ = new TypeDecl($basicType, tokAt(scanner,@$));
             $$->at = tokAt(scanner,@basicType);
     }
     |   DAS_TBITFIELD bitfield_basic_type_declaration[basicType] '<' { yyextra->das_arrow_depth ++; } bitfield_bits[nl] '>' { yyextra->das_arrow_depth --; } {
-            $$ = new TypeDecl($basicType);
+            $$ = new TypeDecl($basicType, tokAt(scanner,@$));
             $$->argNames = *$nl;
             auto maxBits = $$->maxBitfieldBits();
             if ( $$->argNames.size()>maxBits ) {
@@ -3258,7 +3248,7 @@ c_or_s
 table_type_pair
     :   type_declaration[keyTypeDecl] {
         $$.firstType = $keyTypeDecl;
-        $$.secondType = new TypeDecl(Type::tVoid);
+        $$.secondType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$.secondType->at = $$.firstType->at;
     }
     |   type_declaration[keyTypeDecl] c_or_s type_declaration[valueTypeDecl] {
@@ -3277,7 +3267,7 @@ dim_list
     ;
 
 type_declaration_no_options
-    :   basic_type_declaration[basicType]                   { $$ = new TypeDecl($basicType); $$->at = tokAt(scanner,@basicType); }
+    :   basic_type_declaration[basicType]                   { $$ = new TypeDecl($basicType, tokAt(scanner,@$)); $$->at = tokAt(scanner,@basicType); }
     |   auto_type_declaration[typeDecl]                     { $$ = $typeDecl; }
     |   bitfield_type_declaration[typeDecl]                 { $$ = $typeDecl; }
     |   structure_type_declaration[typeDecl]                { $$ = $typeDecl; }
@@ -3299,19 +3289,19 @@ type_declaration_no_options
         $$ = $typeDecl;
     }
     |   DAS_TYPEDECL[td] '(' expr[subexpr] ')' {
-        $$ = new TypeDecl(Type::typeDecl);
+        $$ = new TypeDecl(Type::typeDecl, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@td,@subexpr);
         $$->typeMacroExpr.push_back($subexpr);
     }
     |   '$' name_in_namespace[name] optional_expr_list_in_braces[arguments] {
-        $$ = new TypeDecl(Type::typeMacro);
+        $$ = new TypeDecl(Type::typeMacro, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@name, @arguments);
         $$->typeMacroExpr = sequenceToList($arguments);
         $$->typeMacroExpr.insert($$->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
         delete $name;
     }
     |   '$' name_in_namespace[name] '<' { yyextra->das_arrow_depth ++; } type_declaration_no_options_list[declL] '>' optional_expr_list_in_braces[arguments] {
-        $$ = new TypeDecl(Type::typeMacro);
+        $$ = new TypeDecl(Type::typeMacro, tokAt(scanner,@$));
         $$->at = tokRangeAt(scanner,@name, @arguments);
         $$->typeMacroExpr = typesAndSequenceToList($declL,$arguments);
         $$->typeMacroExpr.insert($$->typeMacroExpr.begin(), new ExprConstString(tokAt(scanner,@name), *$name));
@@ -3367,52 +3357,52 @@ type_declaration_no_options
         $$ = $typeDecl;
     }
     |   type_declaration_no_options[typeDecl] '?' {
-        $$ = new TypeDecl(Type::tPointer);
+        $$ = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@typeDecl);
         $$->firstType = $typeDecl;
     }
     |   DAS_SMART_PTR[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tPointer);
+        $$ = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->smartPtr = true;
         $$->firstType = $typeDecl;
     }
     |   type_declaration_no_options[typeDecl] QQ {
-        $$ = new TypeDecl(Type::tPointer);
+        $$ = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@typeDecl);
-        $$->firstType = new TypeDecl(Type::tPointer);
+        $$->firstType = new TypeDecl(Type::tPointer, tokAt(scanner,@$));
         $$->firstType->at = tokAt(scanner,@typeDecl);
         $$->firstType->firstType = $typeDecl;
     }
     |   DAS_ARRAY[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[typeDecl] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tArray);
+        $$ = new TypeDecl(Type::tArray, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $typeDecl;
     }
     |   DAS_TABLE[loc] '<' { yyextra->das_arrow_depth ++; } table_type_pair[ttp] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tTable);
+        $$ = new TypeDecl(Type::tTable, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $ttp.firstType;
         $$->secondType = $ttp.secondType;
     }
     |   DAS_ITERATOR[loc] '<'  { yyextra->das_arrow_depth ++; } type_declaration[itTypeDecl] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tIterator);
+        $$ = new TypeDecl(Type::tIterator, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $itTypeDecl;
     }
     |   DAS_TBLOCK[loc] {
-        $$ = new TypeDecl(Type::tBlock);
+        $$ = new TypeDecl(Type::tBlock, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
-        $$->firstType = new TypeDecl(Type::tVoid);
+        $$->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$->firstType->at = $$->at;
     }
     |   DAS_TBLOCK[loc] '<'  { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tBlock);
+        $$ = new TypeDecl(Type::tBlock, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $blockType;
     }
     |   DAS_TBLOCK[loc] '<'  { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tBlock);
+        $$ = new TypeDecl(Type::tBlock, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $result;
         if ( $list ) {
@@ -3421,18 +3411,18 @@ type_declaration_no_options
         }
     }
     |   DAS_TFUNCTION[loc] {
-        $$ = new TypeDecl(Type::tFunction);
+        $$ = new TypeDecl(Type::tFunction, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
-        $$->firstType = new TypeDecl(Type::tVoid);
+        $$->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$->firstType->at = $$->at;
     }
     |   DAS_TFUNCTION[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tFunction);
+        $$ = new TypeDecl(Type::tFunction, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $blockType;
     }
     |   DAS_TFUNCTION[loc] '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tFunction);
+        $$ = new TypeDecl(Type::tFunction, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $result;
         if ( $list ) {
@@ -3441,18 +3431,18 @@ type_declaration_no_options
         }
     }
     |   DAS_TLAMBDA[loc] {
-        $$ = new TypeDecl(Type::tLambda);
+        $$ = new TypeDecl(Type::tLambda, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
-        $$->firstType = new TypeDecl(Type::tVoid);
+        $$->firstType = new TypeDecl(Type::tVoid, tokAt(scanner,@$));
         $$->firstType->at = $$->at;
     }
     |   DAS_TLAMBDA[loc] '<' { yyextra->das_arrow_depth ++; } type_declaration[blockType] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tLambda);
+        $$ = new TypeDecl(Type::tLambda, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $blockType;
     }
     |   DAS_TLAMBDA[loc] '<' { yyextra->das_arrow_depth ++; } optional_function_argument_list[list] optional_function_type[result] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tLambda);
+        $$ = new TypeDecl(Type::tLambda, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         $$->firstType = $result;
         if ( $list ) {
@@ -3461,13 +3451,13 @@ type_declaration_no_options
         }
     }
     |   DAS_TTUPLE[loc] '<' { yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tTuple);
+        $$ = new TypeDecl(Type::tTuple, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         varDeclToTypeDecl(scanner, $$, $list, true);
         deleteVariableDeclarationList($list);
     }
     |   DAS_TVARIANT[loc] '<' { yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } {
-        $$ = new TypeDecl(Type::tVariant);
+        $$ = new TypeDecl(Type::tVariant, tokAt(scanner,@$));
         $$->at = tokAt(scanner,@loc);
         varDeclToTypeDecl(scanner, $$, $list, true);
         deleteVariableDeclarationList($list);
@@ -3483,7 +3473,7 @@ type_declaration
             $$ = $list;
             $$->argTypes.push_back($rest);
         } else {
-            $$ = new TypeDecl(Type::option);
+            $$ = new TypeDecl(Type::option, tokAt(scanner,@$));
             $$->at = tokRangeAt(scanner,@list,@rest);
             $$->argTypes.push_back($list);
             $$->argTypes.push_back($rest);
@@ -3495,7 +3485,7 @@ type_declaration
             $$->argTypes.push_back(new TypeDecl(*$list->argTypes.back()));
             $list->argTypes.back()->temporary ^= true;
         } else {
-            $$ = new TypeDecl(Type::option);
+            $$ = new TypeDecl(Type::option, tokAt(scanner,@$));
             $$->at = tokRangeAt(scanner,@list,@rest);
             $$->argTypes.push_back($list);
             $$->argTypes.push_back(new TypeDecl(*$list));
@@ -3521,7 +3511,7 @@ tuple_alias_declaration
             for ( auto & crd : yyextra->g_CommentReaders ) crd->afterTupleEntries(atvname);
         }
     } close_block {
-        auto vtype = new TypeDecl(Type::tTuple);
+        auto vtype = new TypeDecl(Type::tTuple, tokAt(scanner,@$));
         vtype->alias = *$vname;
         vtype->at = tokAt(scanner,@vname);
         vtype->isPrivateAlias = !$pubA;
@@ -3557,7 +3547,7 @@ variant_alias_declaration
             for ( auto & crd : yyextra->g_CommentReaders ) crd->afterVariantEntries(atvname);
         }
     } close_block {
-        auto vtype = new TypeDecl(Type::tVariant);
+        auto vtype = new TypeDecl(Type::tVariant, tokAt(scanner,@$));
         vtype->alias = *$vname;
         vtype->at = tokAt(scanner,@vname);
         vtype->isPrivateAlias = !$pubA;
@@ -3592,7 +3582,7 @@ bitfield_alias_declaration
             for ( auto & crd : yyextra->g_CommentReaders ) crd->afterBitfieldEntries(atvname);
         }
     } close_block {
-        auto btype = new TypeDecl($basicType);
+        auto btype = new TypeDecl($basicType, tokAt(scanner,@$));
         btype->alias = *$vname;
         btype->at = tokAt(scanner,@vname);
         btype->isPrivateAlias = !$pubA;
@@ -3845,8 +3835,7 @@ make_struct_decl
         $$ = $msd;
     }
     |   DAS_TVARIANT [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] make_variant_dim[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -3904,12 +3893,11 @@ make_tuple_call
     :   DAS_TTUPLE[loc] '(' expr_list[arguments] optional_comma ')' {
         auto mkt = new ExprMakeTuple(tokAt(scanner,@loc));
         mkt->values = sequenceToList($arguments);
-        mkt->makeType = new TypeDecl(Type::autoinfer);
+        mkt->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         $$ = mkt;
     }
     |   DAS_TTUPLE [loc] '<' { yyextra->das_force_oxford_comma=true; yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -3937,7 +3925,7 @@ make_dim_decl
         if ( $arguments ) {
             auto mka = new ExprMakeArray(tokAt(scanner,@loc));
             mka->values = sequenceToList($arguments);
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
             mka->gen2 = true;
             auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
             tam->arguments.push_back(mka);
@@ -3945,10 +3933,8 @@ make_dim_decl
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,@loc);
-            mks->makeType = new TypeDecl(Type::tArray);
-            mks->makeType->at = mks->at;
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->firstType->at = mks->at;
+            mks->makeType = new TypeDecl(Type::tArray, mks->at);
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, mks->at);
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             $$ = mks;
@@ -3977,8 +3963,7 @@ make_dim_decl
         $$ = tam;
     }
     |   DAS_ARRAY [loc] DAS_TTUPLE '<' { yyextra->das_arrow_depth ++; } tuple_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' use_initializer[init] optional_make_struct_dim_decl[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tTuple);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tTuple, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -3991,8 +3976,7 @@ make_dim_decl
         $$ = tam;
     }
     |   DAS_ARRAY [loc] DAS_TVARIANT '<' { yyextra->das_arrow_depth ++; } variant_type_list[list] '>' { yyextra->das_arrow_depth --; } '(' make_variant_dim[msd] ')'  {
-        auto mkt = new TypeDecl(Type::tVariant);
-        mkt->at = tokAt(scanner,@loc);
+        auto mkt = new TypeDecl(Type::tVariant, tokAt(scanner,@loc));
         varDeclToTypeDecl(scanner, mkt, $list, true);
         deleteVariableDeclarationList($list);
         $msd->at = tokAt(scanner,@loc);
@@ -4007,7 +3991,7 @@ make_dim_decl
     |   DAS_ARRAY[loc] '(' expr_list[arguments] optional_comma ')' {
         auto mka = new ExprMakeArray(tokAt(scanner,@loc));
         mka->values = sequenceToList($arguments);
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         mka->gen2 = true;
         auto tam = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_array_move");
         tam->arguments.push_back(mka);
@@ -4025,8 +4009,7 @@ make_dim_decl
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,@loc);
-            msd->makeType = new TypeDecl(Type::tArray);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tArray, msd->at);
             msd->makeType->firstType = $mkt;
             msd->at = tokAt(scanner,@mkt);
             msd->useInitializer = true;
@@ -4037,7 +4020,7 @@ make_dim_decl
     |   DAS_FIXED_ARRAY[loc] '(' expr_list[arguments] optional_comma ')' {
         auto mka = new ExprMakeArray(tokAt(scanner,@loc));
         mka->values = sequenceToList($arguments);
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         mka->gen2 = true;
         $$ = mka;
     }
@@ -4076,27 +4059,26 @@ make_table_decl
         if ( $arguments ) {
             auto mka = new ExprMakeArray(tokAt(scanner,@loc));
             mka->values = sequenceToList($arguments);
-            mka->makeType = new TypeDecl(Type::autoinfer);
+            mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
             ttm->arguments.push_back(mka);
             $$ = ttm;
         } else {
             auto mks = new ExprMakeStruct();
             mks->at = tokAt(scanner,@loc);
-            mks->makeType = new TypeDecl(Type::tTable);
-            mks->makeType->firstType = new TypeDecl(Type::autoinfer);
-            mks->makeType->secondType = new TypeDecl(Type::autoinfer);
+            mks->makeType = new TypeDecl(Type::tTable, tokAt(scanner,@$));
+            mks->makeType->firstType = new TypeDecl(Type::autoinfer, tokAt(scanner,@loc));
+            mks->makeType->secondType = new TypeDecl(Type::autoinfer, tokAt(scanner,@3));
             mks->useInitializer = true;
             mks->alwaysUseInitializer = true;
             $$ = mks;
         }
     }
     |   CBRCBRB [loc] make_table[mka] optional_trailing_semicolon_cur_cur {
-        auto mkt = new TypeDecl(Type::tFixedArray);
+        auto mkt = new TypeDecl(Type::tFixedArray, tokAt(scanner,@$));
         mkt->fixedDim = TypeDecl::dimAuto;
         mkt->at = tokAt(scanner,@loc);
-        mkt->firstType = new TypeDecl(Type::autoinfer);
-        mkt->firstType->at = mkt->at;
+        mkt->firstType = new TypeDecl(Type::autoinfer, mkt->at);
         ((ExprMakeArray *)$mka)->makeType = mkt;
         $mka->at = tokAt(scanner,@loc);
         auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
@@ -4106,7 +4088,7 @@ make_table_decl
     |   DAS_TABLE[loc] '(' optional_expr_map_tuple_list[arguments] ')' {
         auto mka = new ExprMakeArray(tokAt(scanner,@loc));
         mka->values = sequenceToList($arguments);
-        mka->makeType = new TypeDecl(Type::autoinfer);
+        mka->makeType = new TypeDecl(Type::autoinfer, tokAt(scanner,@$));
         auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
         ttm->arguments.push_back(mka);
         $$ = ttm;
@@ -4122,11 +4104,9 @@ make_table_decl
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,@loc);
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = $decl;
-            msd->makeType->secondType = new TypeDecl(Type::tVoid);
-            msd->makeType->secondType->at = tokAt(scanner,@loc);
+            msd->makeType->secondType = new TypeDecl(Type::tVoid, tokAt(scanner,@loc));
             msd->at = tokAt(scanner,@loc);
             msd->useInitializer = true;
             msd->alwaysUseInitializer = true;
@@ -4137,7 +4117,7 @@ make_table_decl
         if ( $arguments ) {
             auto mka = new ExprMakeArray(tokAt(scanner,@loc));
             mka->values = sequenceToList($arguments);
-            mka->makeType = new TypeDecl(Type::tTuple);
+            mka->makeType = new TypeDecl(Type::tTuple, tokAt(scanner,@$));
             mka->makeType->argTypes.push_back($decl);
             mka->makeType->argTypes.push_back($to_decl);
             auto ttm = yyextra->g_Program->makeCall(tokAt(scanner,@loc),"to_table_move");
@@ -4146,8 +4126,7 @@ make_table_decl
         } else {
             auto msd = new ExprMakeStruct();
             msd->at = tokAt(scanner,@loc);
-            msd->makeType = new TypeDecl(Type::tTable);
-            msd->makeType->at = msd->at;
+            msd->makeType = new TypeDecl(Type::tTable, msd->at);
             msd->makeType->firstType = $decl;
             msd->makeType->secondType = $to_decl;
             msd->at = tokAt(scanner,@loc);

--- a/src/parser/parser_impl.cpp
+++ b/src/parser/parser_impl.cpp
@@ -30,8 +30,7 @@ namespace das {
     }
 
     static TypeDecl * makeFixedArrayNode ( Expression * dimExpr, const LineInfo & at ) {
-        auto fa = new TypeDecl(Type::tFixedArray);
-        fa->at = at;
+        auto fa = new TypeDecl(Type::tFixedArray, at);
         if ( dimExpr ) {
             fa->fixedDim = TypeDecl::dimConst;
             if ( dimExpr->rtti_isConstant() ) {                // note: this shortcut is here so we don`t get extra infer pass on every array
@@ -736,7 +735,7 @@ namespace das {
                 func->name = yyextra->g_thisStructure->name + "`" + func->name;
                 auto vars = new vector<VariableNameAndPosition>();
                 vars->emplace_back(VariableNameAndPosition(varName,"",func->at));
-                TypeDecl * funcType = new TypeDecl(Type::tFunction);
+                TypeDecl * funcType = new TypeDecl(Type::tFunction, func->at);
                 funcType->at = func->at;
                 swap ( funcType->firstType, func->result );
                 funcType->argTypes.reserve ( func->arguments.size() );
@@ -837,15 +836,15 @@ namespace das {
                     vars->emplace_back(VariableNameAndPosition(varName,"",func->at));
                     Expression * finit = new ExprAddr(func->at, inThisModule(func->name));
                     if ( ovr == OVERRIDE_OVERRIDE ) {
-                        finit = new ExprCast(func->at, finit, new TypeDecl(Type::autoinfer));
+                        finit = new ExprCast(func->at, finit, new TypeDecl(Type::autoinfer, func->at));
                     } else if ( ovr == OVERRIDE_SEALED ) {
                         if ( yyextra->g_thisStructure->findField(varName) ) { // only if we are actually overriding a field
-                            finit = new ExprCast(func->at, finit, new TypeDecl(Type::autoinfer));
+                            finit = new ExprCast(func->at, finit, new TypeDecl(Type::autoinfer, func->at));
                         }
                     }
                     VariableDeclaration * decl = new VariableDeclaration(
                         vars,
-                        new TypeDecl(Type::autoinfer),
+                        new TypeDecl(Type::autoinfer, func->at),
                         finit
                     );
                     decl->override = ovr == OVERRIDE_OVERRIDE;

--- a/tests-cpp/small/test_fixed_array_interop.cpp
+++ b/tests-cpp/small/test_fixed_array_interop.cpp
@@ -43,7 +43,7 @@ TEST_CASE("typeFactory produces tFixedArray chains") {
         CHECK_EQ(nested->describe(), "int[3][4]");
     }
     SUBCASE("const element hoists to the FA head (canonical form)") {
-        auto elem = new TypeDecl(Type::tInt);
+        auto elem = new TypeDecl(Type::tInt, cppBindingLineInfo());
         elem->constant = true;
         auto t = makeFixedArrayTypeDecl(4, elem);
         CHECK(bool(t->constant));
@@ -72,7 +72,7 @@ TEST_CASE("makeTypeInfo flattens tFixedArray chains byte-equal to dim-vector inp
     }
     SUBCASE("head qualifiers ride into the flattened flags") {
         DebugInfoHelper faHelp;
-        auto fa = makeFixedArrayTypeDecl(4, new TypeDecl(Type::tInt));
+        auto fa = makeFixedArrayTypeDecl(4, new TypeDecl(Type::tInt, cppBindingLineInfo()));
         fa->constant = true;
         auto faInfo = faHelp.makeTypeInfo(nullptr, fa);
         CHECK((faInfo->flags & TypeInfo::flag_isConst) != 0u);

--- a/tests-cpp/small/test_fixed_array_parser.cpp
+++ b/tests-cpp/small/test_fixed_array_parser.cpp
@@ -46,14 +46,14 @@ TypeDecl * checkChain ( TypeDecl * t, std::initializer_list<int32_t> dims, Type 
 }
 
 TypeDecl * makeFA ( int32_t d, TypeDecl * elem ) {
-    auto fa = new TypeDecl(Type::tFixedArray);
+    auto fa = new TypeDecl(Type::tFixedArray, cppBindingLineInfo());
     fa->fixedDim = d;
     fa->firstType = elem;
     return fa;
 }
 
 TypeDecl * makeFAChain ( Type bt, std::initializer_list<int32_t> dims ) {
-    auto t = new TypeDecl(bt);
+    auto t = new TypeDecl(bt, cppBindingLineInfo());
     TypeDecl * result = t;
     for ( auto it = rbegin(dims); it != rend(dims); ++it ) {
         result = makeFA(*it, result);
@@ -63,7 +63,7 @@ TypeDecl * makeFAChain ( Type bt, std::initializer_list<int32_t> dims ) {
 
 TypeDeclPtr reparse ( const string & mangled ) {
     ModuleLibrary lib;
-    MangledNameParser parser;
+    MangledNameParser parser(cppBindingLineInfo("test_fixed_array_parser"));
     const char * ch = mangled.c_str();
     auto t = parser.parseTypeFromMangledName(ch, lib, nullptr);
     CHECK_EQ(*ch, 0);    // consumed the whole name
@@ -275,7 +275,7 @@ TEST_CASE("mangled name parse builds tFixedArray and round-trips the emit") {
         CHECK_EQ(t->getMangledName(true), full);
     }
     SUBCASE("FA nested in containers round-trips") {
-        auto arr = new TypeDecl(Type::tArray);
+        auto arr = new TypeDecl(Type::tArray, cppBindingLineInfo());
         arr->firstType = makeFAChain(Type::tInt,{4});
         auto t = reparse(arr->getMangledName());
         CHECK(t->isSameType(*arr, RefMatters::yes, ConstMatters::yes, TemporaryMatters::yes));

--- a/tests-cpp/small/test_fixed_array_typedecl.cpp
+++ b/tests-cpp/small/test_fixed_array_typedecl.cpp
@@ -11,14 +11,14 @@ using namespace das;
 namespace {
 
 TypeDecl * makeFA ( int32_t d, TypeDecl * elem ) {
-    auto fa = new TypeDecl(Type::tFixedArray);
+    auto fa = new TypeDecl(Type::tFixedArray, cppBindingLineInfo());
     fa->fixedDim = d;
     fa->firstType = elem;
     return fa;
 }
 
 TypeDecl * makeFAChain ( Type bt, std::initializer_list<int32_t> dims ) {
-    auto t = new TypeDecl(bt);
+    auto t = new TypeDecl(bt, cppBindingLineInfo());
     TypeDecl * result = t;
     for ( auto it = rbegin(dims); it != rend(dims); ++it ) {
         result = makeFA(*it, result);
@@ -85,9 +85,9 @@ TEST_CASE("tFixedArray identity") {
     auto f44a = makeFAChain(Type::tFloat,{4,4});
     auto f44b = makeFAChain(Type::tFloat,{4,4});
     auto f34  = makeFAChain(Type::tFloat,{3,4});
-    auto justInt = new TypeDecl(Type::tInt);
-    auto arrInt = new TypeDecl(Type::tArray);
-    arrInt->firstType = new TypeDecl(Type::tInt);
+    auto justInt = new TypeDecl(Type::tInt, cppBindingLineInfo());
+    auto arrInt = new TypeDecl(Type::tArray, cppBindingLineInfo());
+    arrInt->firstType = new TypeDecl(Type::tInt, cppBindingLineInfo());
     auto same = [](TypeDecl * a, TypeDecl * b) {
         return a->isSameType(*b, RefMatters::yes, ConstMatters::yes, TemporaryMatters::yes);
     };
@@ -110,7 +110,7 @@ TEST_CASE("tFixedArray identity") {
 TEST_CASE("tFixedArray lifecycle and hashes") {
     gc_guard guard;
     SUBCASE("copy constructor deep-copies the new fields") {
-        auto src = makeFA(TypeDecl::dimConst, new TypeDecl(Type::tInt));
+        auto src = makeFA(TypeDecl::dimConst, new TypeDecl(Type::tInt, cppBindingLineInfo()));
         src->fixedDimExpr = new ExprConstInt(7);
         auto copy = new TypeDecl(*src);
         CHECK_EQ(copy->fixedDim, TypeDecl::dimConst);
@@ -120,7 +120,7 @@ TEST_CASE("tFixedArray lifecycle and hashes") {
         CHECK_EQ(copy->firstType->baseType, Type::tInt);
     }
     SUBCASE("static clone deep-copies the new fields") {
-        auto src = makeFA(TypeDecl::dimConst, new TypeDecl(Type::tInt));
+        auto src = makeFA(TypeDecl::dimConst, new TypeDecl(Type::tInt, cppBindingLineInfo()));
         src->fixedDimExpr = new ExprConstInt(7);
         TypeDeclPtr dest = nullptr;
         TypeDecl::clone(dest, src);
@@ -134,7 +134,7 @@ TEST_CASE("tFixedArray lifecycle and hashes") {
         auto i3 = makeFAChain(Type::tInt,{3});
         auto f4 = makeFAChain(Type::tFloat,{4});
         auto i44 = makeFAChain(Type::tInt,{4,4});
-        auto justInt = new TypeDecl(Type::tInt);
+        auto justInt = new TypeDecl(Type::tInt, cppBindingLineInfo());
         CHECK_NE(i4->getSemanticHash(), i3->getSemanticHash());
         CHECK_NE(i4->getSemanticHash(), f4->getSemanticHash());
         CHECK_NE(i4->getSemanticHash(), i44->getSemanticHash());
@@ -181,7 +181,7 @@ TEST_CASE("tFixedArray classification") {
         auto faA = makeFAChain(Type::tInt,{TypeDecl::dimAuto});
         CHECK(faA->isAuto());
         CHECK_FALSE(faA->isAutoArrayResolved());
-        auto faElemAuto = makeFA(4, new TypeDecl(Type::autoinfer));
+        auto faElemAuto = makeFA(4, new TypeDecl(Type::autoinfer, cppBindingLineInfo()));
         CHECK(faElemAuto->isAuto());
     }
     SUBCASE("dimConst registers as expression type") {

--- a/tests-cpp/small/test_fully_sealed.cpp
+++ b/tests-cpp/small/test_fully_sealed.cpp
@@ -9,21 +9,21 @@ using namespace das;
 TEST_CASE("isFullySealed checks secondType independently of firstType") {
     gc_guard guard;
     SUBCASE("sealed key, unsealed value") {
-        auto t = new TypeDecl(Type::tTable);
-        t->firstType = new TypeDecl(Type::tInt);
-        t->secondType = new TypeDecl(Type::autoinfer);
+        auto t = new TypeDecl(Type::tTable, cppBindingLineInfo());
+        t->firstType = new TypeDecl(Type::tInt, cppBindingLineInfo());
+        t->secondType = new TypeDecl(Type::autoinfer, cppBindingLineInfo());
         CHECK_FALSE(t->isFullySealed());
     }
     SUBCASE("unsealed key, sealed value") {
-        auto t = new TypeDecl(Type::tTable);
-        t->firstType = new TypeDecl(Type::autoinfer);
-        t->secondType = new TypeDecl(Type::tFloat);
+        auto t = new TypeDecl(Type::tTable, cppBindingLineInfo());
+        t->firstType = new TypeDecl(Type::autoinfer, cppBindingLineInfo());
+        t->secondType = new TypeDecl(Type::tFloat, cppBindingLineInfo());
         CHECK_FALSE(t->isFullySealed());
     }
     SUBCASE("both sealed") {
-        auto t = new TypeDecl(Type::tTable);
-        t->firstType = new TypeDecl(Type::tInt);
-        t->secondType = new TypeDecl(Type::tFloat);
+        auto t = new TypeDecl(Type::tTable, cppBindingLineInfo());
+        t->firstType = new TypeDecl(Type::tInt, cppBindingLineInfo());
+        t->secondType = new TypeDecl(Type::tFloat, cppBindingLineInfo());
         CHECK(t->isFullySealed());
     }
 }

--- a/tests/typer_errors/failed_default_argument_mismatch.das
+++ b/tests/typer_errors/failed_default_argument_mismatch.das
@@ -9,7 +9,7 @@
 // broken default errors as 30511 instead.) The 30254 reports twice - each of its two
 // sites carries its own location, so location-keyed dedupe keeps both.
 options gen2
-expect 30161, 30254, 30254, 30511, 30511
+expect 30161, 30254, 30511, 30511
 
 tuple var0 {}
 

--- a/tutorials/integration/cpp/15_custom_annotations.cpp
+++ b/tutorials/integration/cpp/15_custom_annotations.cpp
@@ -82,7 +82,7 @@ struct AddFieldAnnotation : StructureAnnotation {
         if (!st->findField("id")) {
             st->fields.emplace_back(
                 "id",                               // field name
-                new TypeDecl(Type::tInt),    // type: int
+                new TypeDecl(Type::tInt, cppBindingLineInfo()),    // type: int
                 nullptr,                            // no initializer
                 AnnotationArgumentList(),           // no field annotations
                 false,                              // no move semantics


### PR DESCRIPTION
**WIP** - opening early for direction, not for merge. Two commits, one arc: the per-file cost of `--ast-verify-batch` and the one compiler defect that stood between the tree and a repo-wide verify gate.

## 1. `ast_verify`: batch mode walks each module once

The post-infer macro fires ~10 times per module - once per infer leg, once before `lint`, twice per optimizer round - and every firing walked the same tree. Instrumented, one `modules/dasLLAMA/tests/test_model_image.das` compile was **1282 firings, 10.6M node visits, 2.26M TypeDecl visits**.

Batch mode now walks a module on the first of those firings, through a one-slot `(program, module)` memo that a `[post_compile_macro]` clears so nothing carries into the next module. `need_type_at` also stops calling `describe()` on a type that already has a location - `need_at` reads that text only when `at` is unset.

Plain `--ast-verify` is untouched: still a walk before every inference pass, still a sweep of every module on each firing.

| `test_model_image.das` | wall | peak RSS |
|---|---|---|
| no verifier | 10.2 s | 0.71 GB |
| `--ast-verify-batch` before | 14.3 s (+42%) | 1.61 GB (+127%) |
| `--ast-verify-batch` after | **10.5 s (+3.5%)** | **0.78 GB (+10%)** |

Full `tests/` sweep (1651 files, 16-way): **224 s -> 154 s**, findings byte-identical.

## 2. `infer`: the swizzle result type carries its source location

`InferTypes::visit(ExprSwizzle*)` minted the result TypeDecl without stamping `at`, so `addr(v.x)` on a vector produced a `float?` whose pointee type had no location. Four lines, no macros:

```das
def probe : bool {
    var v = float4(1.0f)
    let p = unsafe(addr(v.x))     // AST verify: TypeDecl float has no source location (at is unset)
    return p != null
}
```

`addr(s.a)` on a struct field is clean, and an `int` local is clean - the vector component was the hole. Nothing crashed and no diagnostic degraded (the only consumer of `TypeDecl::at` is the `assume` alias-clash hint), but the verifier made it `error[50503]` on **266 files repo-wide** - every file that reaches dasImgui's `color_picker4` / `edit_color_picker4`.

Pinned in `tests/language/vec_swizzle.das`, which now requires `daslib/ast_verify` (the `super_finalize.das` idiom, so a finding is a compile error) plus `test_swizzle_addr` writing through `addr()` of a `float4` and an `int3` component. Negative control: with the stamp reverted the file is `1 tests, 0 passed, 1 errors`.

## What this buys, measured over all 4040 compilable `.das` in the tree

| | files reporting |
|---|---|
| before | 266 |
| after | **2** |

Zero crashes, zero timeouts. The two survivors are pre-existing and the same "unset `at`" class, left alone here: the generator lowering's lambda captured-type decl (`tests/language/generators.das`) and a block argument's alias-bearing TypeDecl (`tests/language/typeAlias.das`). Those two are what stand between the tree and a green repo-wide gate.

## Gates

- `tests/language` 1680/1680
- full `tests/` sweep: 12892 tests, 12883 passed, 0 failed, 9 skipped
- `utils/internal/ast-fuzz/test_ast_fuzz.das` 14/14
- `utils/lint` and `das-fmt --verify` clean on both touched `.das`

## Open, and why this is WIP

- **`CHANGELIST.md` not written** - entries here carry PR numbers and land in batches.
- The verifier is no longer what makes a sweep expensive: per-process over 4040 files is **1029 s with** the verifier vs **1129 s without** (16-way; the delta is page-cache noise). The cost is one process per file re-parsing `daslib`. One process, no verifier, single-threaded: **274 s / 2.0 GB**. So re-enabling the tree-wide sweep per PR wants an in-process driver, and that is a separate arc - it needs `CodeOfPolicies::macro_context_collect` (off by default, set nowhere in-tree) or chunking, because a reused macro context's heap grows ~3.7 MB per compile.
- Should `#3637`'s nightly-only sweep move back onto every PR once that driver exists, and should it cover `modules/` and `examples/` (never verified until now)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
