### PR TITLE
jit binds are NTTP, and the bind-flavor gate now reaches the module

### DIFF
--- a/.github/workflows/nightly_lint.yml
+++ b/.github/workflows/nightly_lint.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           set -eux
           ./bin/daslang utils/lint/main.das -- \
-            daslib utils modules tutorials examples tests \
+            daslib utils modules tutorials examples tests src \
             -q --silent -j 0 --disable LINT019
 
       - name: "Stale-nolint pass (single process)"
@@ -94,5 +94,5 @@ jobs:
         run: |
           set -eux
           ./bin/daslang utils/lint/main.das -- \
-            daslib utils modules tutorials examples tests \
+            daslib utils modules tutorials examples tests src \
             -q --silent -j 1

--- a/include/daScript/simulate/ARCHITECTURE.md
+++ b/include/daScript/simulate/ARCHITECTURE.md
@@ -35,8 +35,8 @@ correctness required it, and the alternative that was rejected.
   call in place of a direct, potentially inlined one - measured at 3-4.5% on loops that
   are nothing but extern calls, noise on real programs (dasProfile lane medians >=1.00).
   Binds that need the old profile opt into the NTTP flavor (`addExternInline` ->
-  `SimNode_ExtFuncCallInline`; builtin/math/strings bind that way by policy -
-  `src/builtin/REVIEW.md`). The cmres and ref flavors have no NTTP twin yet, so those
+  `SimNode_ExtFuncCallInline`; the modules `src/builtin/REVIEW.md` names bind that
+  way by policy). The cmres and ref flavors have no NTTP twin yet, so those
   binds pay the indirect call unconditionally. Cross-slot and lattice typed reads route
   through the base as `cast<Carrier>::to(this->eval(ctx))` - a second virtual dispatch
   plus a vec4f round-trip on paths that are rare by construction (the compiler emits the

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -14,11 +14,13 @@ flavors exist, and the choice is per bind:
   node instantiation per function; buys direct-call/inlined dispatch. Functions bound this
   way carry `Function::moreFlags2.nttp`, which `daslib/only_nttp.das` and tooling key on.
 
-The policy: **builtin (`$`), math, and strings bind NTTP; every other module binds
-per-signature.** The trio is on every interpreter hot path, its bind count is bounded, and
-misjudgment is one-sided - a needlessly-NTTP cold function costs ~1KB of binary, a missed
-hot one costs a few percent forever. Exempt by construction, because the NTTP entry points
-cannot express them: cmres binds (a struct/array/tuple-shaped result the callee writes
+The policy: **the modules `REVIEW.md` names bind NTTP; every other module binds
+per-signature.** Those modules are on interpreter hot paths, their bind count is bounded,
+and misjudgment is one-sided - a needlessly-NTTP cold function costs ~1KB of binary, a
+missed hot one costs a few percent forever. The list lives in the rule and in the gate that
+enforces it (`review_nttp.das`); repeating it here is how it goes stale. Exempt by
+construction, because the NTTP entry points cannot express them: cmres binds (a
+struct/array/tuple-shaped result the callee writes
 into the caller's result slot - `SimNode_ExtFuncCallAndCopyOrMove`), ref-returning binds
 (`SimNode_ExtFuncCallRef`), and interop binds (`addInterop`, raw argument array).
 

--- a/src/builtin/REVIEW.das
+++ b/src/builtin/REVIEW.das
@@ -1,12 +1,65 @@
 options gen2
 
+require strings
+require daslib/strings_boost
+require daslib/fio
 require ./review_nttp // nolint:STYLE030 — compile-time gate, no runtime symbol to reference
 require dastest/review_gate
 
 // The mechanical half of src/builtin/REVIEW.md (contract: REVIEW_COMMON.md at the
 // repo root). Run from the repo root: bin/daslang src/builtin/REVIEW.das.
 
+// The text between the first `opening` and the next `closing` after it, empty when
+// either marker is missing - a missing marker is a finding, never a silent pass.
+def private segment(text, opening, closing : string) : string {
+    let a = find(text, opening)
+    return "" if (a < 0)
+    let rest = slice(text, a + length(opening))
+    let b = find(rest, closing)
+    return b < 0 ? "" : slice(rest, 0, b)
+}
+
+// Split on a delimiter that comes in pairs and keep what sits between each pair:
+// backticks in the rule prose, double quotes in the gate's array literal.
+def private delimited(seg, delim : string) : array<string> {
+    var out : array<string>
+    var inscope parts <- split(seg, delim)
+    for (p, i in parts, count()) {
+        out |> push(p) if (i % 2 == 1)
+    }
+    return <- out
+}
+
+// The Inline module list lives in two places by necessity: the rule is what a reviewer
+// applies without reading code, review_nttp.das is what enforces it. A split between them
+// makes the reviewer report a defect the gate cannot see, or miss one it does.
+def private check_inline_module_list {
+    let rule_list = segment(fread("src/builtin/REVIEW.md"), "The Inline modules are", ".")
+    let gate_list = segment(fread("src/builtin/review_nttp.das"), "let inlineOnlyModules <- [", "]")
+    var inscope from_rule <- delimited(rule_list, "`")
+    var inscope from_gate <- delimited(gate_list, "\"")
+    if (empty(from_rule)) {
+        gate_finding("src/builtin/REVIEW.md", "no Inline module list found - the rule names it as \"The Inline modules are `a`, `b` ... .\"")
+        return
+    }
+    if (empty(from_gate)) {
+        gate_finding("src/builtin/review_nttp.das", "no inlineOnlyModules found - the gate's policy list is a literal array of module names")
+        return
+    }
+    for (m in from_rule) {
+        if (find_index(from_gate, m) < 0) {
+            gate_finding("src/builtin/review_nttp.das", "REVIEW.md names {m} an Inline module; inlineOnlyModules does not")
+        }
+    }
+    for (m in from_gate) {
+        if (find_index(from_rule, m) < 0) {
+            gate_finding("src/builtin/REVIEW.md", "inlineOnlyModules carries {m}; the rule's Inline module list does not name it")
+        }
+    }
+}
+
 [export]
 def main {
+    check_inline_module_list()
     return gate_verdict("src/builtin")
 }

--- a/src/builtin/REVIEW.md
+++ b/src/builtin/REVIEW.md
@@ -3,17 +3,18 @@
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
 `ARCHITECTURE.md`.
 
-- **A bind added or changed under this folder binds by module.** In builtin (`$`), math,
-  and strings, a bind whose result is a plain value - not a reference, and not a result
-  the callee writes into the caller's result slot - and that is not an interop bind
-  (`addInterop`) uses `addExternInline` or `addExternInlineEx`; every other module uses
-  an `addExtern...` entry point whose name does not contain `Inline`. Binds of the generic
-  container and equality helpers declared in `include/daScript/ast/ast_handle.h` (repo
-  root) - the `das_vector_*`, `das_equ*`, `das_nequ*`, `das_handle_equ*` and
-  `das_handle_nequ*` families - belong to that header, not to the module that
-  instantiates them, and this rule does not decide their flavor. These three modules run
-  on every interpreter step, so each of their binds gets its own node the callee inlines
-  into, while elsewhere binds share one node per signature to keep binaries small.
+- **A bind added or changed under this folder binds by module.** The Inline modules are
+  `$` (builtin), `math`, `strings` and `jit`. In those, a bind whose result is a plain
+  value - not a reference, and not a result the callee writes into the caller's result
+  slot - and that is not an interop bind (`addInterop`) uses `addExternInline` or
+  `addExternInlineEx`; every other module uses an `addExtern...` entry point whose name
+  does not contain `Inline`. Binds of the generic container and equality helpers declared
+  in `include/daScript/ast/ast_handle.h` (repo root) - the `das_vector_*`, `das_equ*`,
+  `das_nequ*`, `das_handle_equ*` and `das_handle_nequ*` families - belong to that header,
+  not to the module that instantiates them, and this rule does not decide their flavor.
+  Binds in the Inline modules sit on interpreted inner loops, so each gets its own node the
+  callee inlines into, while elsewhere binds share one node per signature to keep binaries
+  small.
 
 - **Weakening `src/builtin/REVIEW.das`'s bind-flavor scan is a defect** - a bind the gate
   reports is fixed by switching the bind, never by editing the gate and never by dropping

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -11,7 +11,7 @@
 
 #include "daScript/ast/ast.h"                     // astTypeInfo
 #include "daScript/ast/ast_handle.h"              // addConstant
-#include "daScript/ast/ast_interop.h"             // addExtern
+#include "daScript/ast/ast_interop.h"             // addExternInline
 
 #include "daScript/simulate/aot.h"
 #include "daScript/simulate/aot_builtin_jit.h"
@@ -1517,166 +1517,166 @@ extern "C" {
             lib.addBuiltInModule();
             addBuiltinDependency(lib, Module::require("rtti_core"));
             addBuiltinDependency(lib, Module::require("ast_core"));
-            addExtern<DAS_BIND_FUN(das_invoke_code)>(*this, lib, "invoke_code",
+            addExternInline<DAS_BIND_FUN(das_invoke_code)>(*this, lib, "invoke_code",
                 SideEffects::worstDefault, "das_invoke_code")
                     ->args({"code","arguments","cmres","context"})->unsafeOperation = true;
-            addExtern<DAS_BIND_FUN(das_instrument_jit)>(*this, lib, "instrument_jit",
+            addExternInline<DAS_BIND_FUN(das_instrument_jit)>(*this, lib, "instrument_jit",
                 SideEffects::worstDefault, "das_instrument_jit")
                     ->args({"code","function","at", "context"})->unsafeOperation = true;
-            addExtern<DAS_BIND_FUN(das_remove_jit)>(*this, lib, "remove_jit",
+            addExternInline<DAS_BIND_FUN(das_remove_jit)>(*this, lib, "remove_jit",
                 SideEffects::worstDefault, "das_remove_jit")
                     ->args({"function"})->unsafeOperation = true;
-            addExtern<DAS_BIND_FUN(das_has_jit_fastpath)>(*this, lib, "has_jit_fastpath",
+            addExternInline<DAS_BIND_FUN(das_has_jit_fastpath)>(*this, lib, "has_jit_fastpath",
                 SideEffects::none, "das_has_jit_fastpath")
                     ->args({"function"});
-            addExtern<DAS_BIND_FUN(das_instrument_line_info)>(*this, lib, "instrument_line_info",
+            addExternInline<DAS_BIND_FUN(das_instrument_line_info)>(*this, lib, "instrument_line_info",
                 SideEffects::worstDefault, "das_instrument_line_info")
                     ->args({"info","context","at"});
-            addExtern<DAS_BIND_FUN(das_get_jit_exception)>(*this, lib, "get_jit_exception",
+            addExternInline<DAS_BIND_FUN(das_get_jit_exception)>(*this, lib, "get_jit_exception",
                 SideEffects::none, "das_get_jit_exception");
-            addExtern<DAS_BIND_FUN(das_get_jit_call_or_fastcall)>(*this, lib, "get_jit_call_or_fastcall",
+            addExternInline<DAS_BIND_FUN(das_get_jit_call_or_fastcall)>(*this, lib, "get_jit_call_or_fastcall",
                 SideEffects::none, "das_get_jit_call_or_fastcall");
-            addExtern<DAS_BIND_FUN(das_get_jit_call_with_cmres)>(*this, lib, "get_jit_call_with_cmres",
+            addExternInline<DAS_BIND_FUN(das_get_jit_call_with_cmres)>(*this, lib, "get_jit_call_with_cmres",
                 SideEffects::none, "das_get_jit_call_with_cmres");
-            addExtern<DAS_BIND_FUN(das_get_jit_invoke_block)>(*this, lib, "get_jit_invoke_block",
+            addExternInline<DAS_BIND_FUN(das_get_jit_invoke_block)>(*this, lib, "get_jit_invoke_block",
                 SideEffects::none, "das_get_jit_invoke_block");
-            addExtern<DAS_BIND_FUN(das_get_jit_invoke_block_with_cmres)>(*this, lib, "get_jit_invoke_block_with_cmres",
+            addExternInline<DAS_BIND_FUN(das_get_jit_invoke_block_with_cmres)>(*this, lib, "get_jit_invoke_block_with_cmres",
                 SideEffects::none, "das_get_jit_invoke_block_with_cmres");
-            addExtern<DAS_BIND_FUN(das_get_jit_string_builder)>(*this, lib, "get_jit_string_builder",
+            addExternInline<DAS_BIND_FUN(das_get_jit_string_builder)>(*this, lib, "get_jit_string_builder",
                 SideEffects::none, "das_get_jit_string_builder");
-            addExtern<DAS_BIND_FUN(das_get_jit_string_builder_temp)>(*this, lib, "get_jit_string_builder_temp",
+            addExternInline<DAS_BIND_FUN(das_get_jit_string_builder_temp)>(*this, lib, "get_jit_string_builder_temp",
                 SideEffects::none, "das_get_jit_string_builder_temp");
-            addExtern<DAS_BIND_FUN(das_get_jit_simnode_interop)>(*this, lib, "get_jit_simnode_interop",
+            addExternInline<DAS_BIND_FUN(das_get_jit_simnode_interop)>(*this, lib, "get_jit_simnode_interop",
                 SideEffects::none, "das_get_jit_simnode_interop");
-            addExtern<DAS_BIND_FUN(das_get_jit_free_simnode_interop)>(*this, lib, "get_jit_free_simnode_interop",
+            addExternInline<DAS_BIND_FUN(das_get_jit_free_simnode_interop)>(*this, lib, "get_jit_free_simnode_interop",
                 SideEffects::none, "das_get_jit_free_simnode_interop");
-            addExtern<DAS_BIND_FUN(das_get_jit_init_extern_function)>(*this, lib, "get_jit_init_extern_function",
+            addExternInline<DAS_BIND_FUN(das_get_jit_init_extern_function)>(*this, lib, "get_jit_init_extern_function",
                 SideEffects::none, "get_jit_init_extern_function");
-            addExtern<DAS_BIND_FUN(das_get_jit_get_global_mnh)>(*this, lib, "get_jit_get_global_mnh",
+            addExternInline<DAS_BIND_FUN(das_get_jit_get_global_mnh)>(*this, lib, "get_jit_get_global_mnh",
                 SideEffects::none, "das_get_jit_get_global_mnh");
-            addExtern<DAS_BIND_FUN(das_get_jit_get_shared_mnh)>(*this, lib, "get_jit_get_shared_mnh",
+            addExternInline<DAS_BIND_FUN(das_get_jit_get_shared_mnh)>(*this, lib, "get_jit_get_shared_mnh",
                 SideEffects::none, "das_get_jit_get_shared_mnh");
-            addExtern<DAS_BIND_FUN(das_get_jit_get_handled_field_offset)>(*this, lib, "get_jit_get_handled_field_offset",
+            addExternInline<DAS_BIND_FUN(das_get_jit_get_handled_field_offset)>(*this, lib, "get_jit_get_handled_field_offset",
                 SideEffects::none, "das_get_jit_get_handled_field_offset");
-            addExtern<DAS_BIND_FUN(das_get_jit_check_handled_type_size)>(*this, lib, "get_jit_check_handled_type_size",
+            addExternInline<DAS_BIND_FUN(das_get_jit_check_handled_type_size)>(*this, lib, "get_jit_check_handled_type_size",
                 SideEffects::none, "das_get_jit_check_handled_type_size");
-            addExtern<DAS_BIND_FUN(das_get_jit_check_handled_field_offset)>(*this, lib, "get_jit_check_handled_field_offset",
+            addExternInline<DAS_BIND_FUN(das_get_jit_check_handled_field_offset)>(*this, lib, "get_jit_check_handled_field_offset",
                 SideEffects::none, "das_get_jit_check_handled_field_offset");
-            addExtern<DAS_BIND_FUN(das_get_jit_handled_abi_check_report)>(*this, lib, "get_jit_handled_abi_check_report",
+            addExternInline<DAS_BIND_FUN(das_get_jit_handled_abi_check_report)>(*this, lib, "get_jit_handled_abi_check_report",
                 SideEffects::none, "das_get_jit_handled_abi_check_report");
-            addExtern<DAS_BIND_FUN(das_get_jit_alloc_heap)>(*this, lib, "get_jit_alloc_heap",
+            addExternInline<DAS_BIND_FUN(das_get_jit_alloc_heap)>(*this, lib, "get_jit_alloc_heap",
                 SideEffects::none, "das_get_jit_alloc_heap");
-            addExtern<DAS_BIND_FUN(das_get_jit_alloc_persistent)>(*this, lib, "get_jit_alloc_persistent",
+            addExternInline<DAS_BIND_FUN(das_get_jit_alloc_persistent)>(*this, lib, "get_jit_alloc_persistent",
                 SideEffects::none, "das_get_jit_alloc_persistent");
-            addExtern<DAS_BIND_FUN(das_get_jit_free_heap)>(*this, lib, "get_jit_free_heap",
+            addExternInline<DAS_BIND_FUN(das_get_jit_free_heap)>(*this, lib, "get_jit_free_heap",
                 SideEffects::none, "das_get_jit_free_heap");
-            addExtern<DAS_BIND_FUN(das_get_jit_free_persistent)>(*this, lib, "get_jit_free_persistent",
+            addExternInline<DAS_BIND_FUN(das_get_jit_free_persistent)>(*this, lib, "get_jit_free_persistent",
                 SideEffects::none, "das_get_jit_free_persistent");
-            addExtern<DAS_BIND_FUN(das_get_jit_array_lock)>(*this, lib, "get_jit_array_lock",
+            addExternInline<DAS_BIND_FUN(das_get_jit_array_lock)>(*this, lib, "get_jit_array_lock",
                 SideEffects::none, "das_get_jit_array_lock");
-            addExtern<DAS_BIND_FUN(das_get_jit_array_unlock)>(*this, lib, "get_jit_array_unlock",
+            addExternInline<DAS_BIND_FUN(das_get_jit_array_unlock)>(*this, lib, "get_jit_array_unlock",
                 SideEffects::none, "das_get_jit_array_unlock");
-            addExtern<DAS_BIND_FUN(das_get_jit_table_lock)>(*this, lib, "get_jit_table_lock",
+            addExternInline<DAS_BIND_FUN(das_get_jit_table_lock)>(*this, lib, "get_jit_table_lock",
                 SideEffects::none, "das_get_jit_table_lock");
-            addExtern<DAS_BIND_FUN(das_get_jit_table_unlock)>(*this, lib, "get_jit_table_unlock",
+            addExternInline<DAS_BIND_FUN(das_get_jit_table_unlock)>(*this, lib, "get_jit_table_unlock",
                 SideEffects::none, "das_get_jit_table_unlock");
-            addExtern<DAS_BIND_FUN(das_get_jit_array_resize)>(*this, lib, "get_jit_array_resize",
+            addExternInline<DAS_BIND_FUN(das_get_jit_array_resize)>(*this, lib, "get_jit_array_resize",
                 SideEffects::none, "das_get_jit_array_resize");
-            addExtern<DAS_BIND_FUN(das_get_jit_table_at)>(*this, lib, "get_jit_table_at",
+            addExternInline<DAS_BIND_FUN(das_get_jit_table_at)>(*this, lib, "get_jit_table_at",
                 SideEffects::none, "das_get_jit_table_at");
-            addExtern<DAS_BIND_FUN(das_get_jit_table_erase)>(*this, lib, "get_jit_table_erase",
+            addExternInline<DAS_BIND_FUN(das_get_jit_table_erase)>(*this, lib, "get_jit_table_erase",
                 SideEffects::none, "das_get_jit_table_erase");
-            addExtern<DAS_BIND_FUN(das_get_jit_table_find)>(*this, lib, "get_jit_table_find",
+            addExternInline<DAS_BIND_FUN(das_get_jit_table_find)>(*this, lib, "get_jit_table_find",
                 SideEffects::none, "das_get_jit_table_find");
-            addExtern<DAS_BIND_FUN(das_get_jit_string_table_at_with_hash)>(*this, lib, "get_jit_string_table_at_with_hash",
+            addExternInline<DAS_BIND_FUN(das_get_jit_string_table_at_with_hash)>(*this, lib, "get_jit_string_table_at_with_hash",
                 SideEffects::none, "das_get_jit_string_table_at_with_hash");
-            addExtern<DAS_BIND_FUN(das_get_jit_string_table_at_after_packed_miss)>(*this, lib, "get_jit_string_table_at_after_packed_miss",
+            addExternInline<DAS_BIND_FUN(das_get_jit_string_table_at_after_packed_miss)>(*this, lib, "get_jit_string_table_at_after_packed_miss",
                 SideEffects::none, "das_get_jit_string_table_at_after_packed_miss");
-            addExtern<DAS_BIND_FUN(das_get_global_variable_offset)>(*this, lib, "get_global_variable_offset",
+            addExternInline<DAS_BIND_FUN(das_get_global_variable_offset)>(*this, lib, "get_global_variable_offset",
                 SideEffects::none, "das_get_global_variable_offset");
-            addExtern<DAS_BIND_FUN(das_get_global_variable_mnh)>(*this, lib, "get_global_variable_mnh",
+            addExternInline<DAS_BIND_FUN(das_get_global_variable_mnh)>(*this, lib, "get_global_variable_mnh",
                 SideEffects::none, "das_get_global_variable_mnh");
-            addExtern<DAS_BIND_FUN(das_get_global_variable_debug_info)>(*this, lib, "get_global_variable_debug_info",
+            addExternInline<DAS_BIND_FUN(das_get_global_variable_debug_info)>(*this, lib, "get_global_variable_debug_info",
                 SideEffects::none, "das_get_global_variable_debug_info");
-            addExtern<DAS_BIND_FUN(das_get_global_variable_shared)>(*this, lib, "get_global_variable_shared",
+            addExternInline<DAS_BIND_FUN(das_get_global_variable_shared)>(*this, lib, "get_global_variable_shared",
                 SideEffects::none, "das_get_global_variable_shared");
-            addExtern<DAS_BIND_FUN(das_get_context_globals_size)>(*this, lib, "get_context_globals_size",
+            addExternInline<DAS_BIND_FUN(das_get_context_globals_size)>(*this, lib, "get_context_globals_size",
                 SideEffects::none, "das_get_context_globals_size");
-            addExtern<DAS_BIND_FUN(das_get_context_shared_size)>(*this, lib, "get_context_shared_size",
+            addExternInline<DAS_BIND_FUN(das_get_context_shared_size)>(*this, lib, "get_context_shared_size",
                 SideEffects::none, "das_get_context_shared_size");
-            addExtern<DAS_BIND_FUN(das_get_jit_str_cmp)>(*this, lib, "get_jit_str_cmp",
+            addExternInline<DAS_BIND_FUN(das_get_jit_str_cmp)>(*this, lib, "get_jit_str_cmp",
                 SideEffects::none, "das_get_jit_str_cmp");
-            addExtern<DAS_BIND_FUN(das_get_jit_str_cat)>(*this, lib, "get_jit_str_cat",
+            addExternInline<DAS_BIND_FUN(das_get_jit_str_cat)>(*this, lib, "get_jit_str_cat",
                 SideEffects::none, "das_get_jit_str_cat");
-            addExtern<DAS_BIND_FUN(das_get_jit_prologue)>(*this, lib, "get_jit_prologue",
+            addExternInline<DAS_BIND_FUN(das_get_jit_prologue)>(*this, lib, "get_jit_prologue",
                 SideEffects::none, "das_get_jit_prologue");
-            addExtern<DAS_BIND_FUN(das_get_jit_epilogue)>(*this, lib, "get_jit_epilogue",
+            addExternInline<DAS_BIND_FUN(das_get_jit_epilogue)>(*this, lib, "get_jit_epilogue",
                 SideEffects::none, "das_get_jit_epilogue");
-            addExtern<DAS_BIND_FUN(das_get_jit_make_block)>(*this, lib, "get_jit_make_block",
+            addExternInline<DAS_BIND_FUN(das_get_jit_make_block)>(*this, lib, "get_jit_make_block",
                 SideEffects::none, "das_get_jit_make_block");
-            addExtern<DAS_BIND_FUN(das_get_jit_ad_by_sid)>(*this, lib, "get_jit_ad_by_sid",
+            addExternInline<DAS_BIND_FUN(das_get_jit_ad_by_sid)>(*this, lib, "get_jit_ad_by_sid",
                 SideEffects::none, "das_get_jit_ad_by_sid");
-            addExtern<DAS_BIND_FUN(das_get_jit_debug)>(*this, lib, "get_jit_debug",
+            addExternInline<DAS_BIND_FUN(das_get_jit_debug)>(*this, lib, "get_jit_debug",
                 SideEffects::none, "das_get_jit_debug");
-            addExtern<DAS_BIND_FUN(das_get_jit_iterator_iterate)>(*this, lib, "get_jit_iterator_iterate",
+            addExternInline<DAS_BIND_FUN(das_get_jit_iterator_iterate)>(*this, lib, "get_jit_iterator_iterate",
                 SideEffects::none, "das_get_jit_iterator_iterate");
-            addExtern<DAS_BIND_FUN(das_get_jit_iterator_delete)>(*this, lib, "get_jit_iterator_delete",
+            addExternInline<DAS_BIND_FUN(das_get_jit_iterator_delete)>(*this, lib, "get_jit_iterator_delete",
                 SideEffects::none, "das_get_jit_iterator_delete");
-            addExtern<DAS_BIND_FUN(das_get_jit_iterator_first)>(*this, lib, "get_jit_iterator_first",
+            addExternInline<DAS_BIND_FUN(das_get_jit_iterator_first)>(*this, lib, "get_jit_iterator_first",
                 SideEffects::none, "das_get_jit_iterator_first");
-            addExtern<DAS_BIND_FUN(das_get_jit_iterator_next)>(*this, lib, "get_jit_iterator_next",
+            addExternInline<DAS_BIND_FUN(das_get_jit_iterator_next)>(*this, lib, "get_jit_iterator_next",
                 SideEffects::none, "das_get_jit_iterator_next");
-            addExtern<DAS_BIND_FUN(das_get_jit_iterator_close)>(*this, lib, "get_jit_iterator_close",
+            addExternInline<DAS_BIND_FUN(das_get_jit_iterator_close)>(*this, lib, "get_jit_iterator_close",
                 SideEffects::none, "das_get_jit_iterator_close");
-            addExtern<DAS_BIND_FUN(das_get_jit_ast_typedecl)>(*this, lib, "get_jit_ast_typedecl",
+            addExternInline<DAS_BIND_FUN(das_get_jit_ast_typedecl)>(*this, lib, "get_jit_ast_typedecl",
                 SideEffects::none, "das_get_jit_ast_typedecl");
-            addExtern<DAS_BIND_FUN(das_get_jit_new)>(*this, lib,  "get_jit_new",
+            addExternInline<DAS_BIND_FUN(das_get_jit_new)>(*this, lib,  "get_jit_new",
                 SideEffects::none, "das_get_jit_new")->args({"ann"});
-            addExtern<DAS_BIND_FUN(das_get_jit_delete)>(*this, lib,  "get_jit_delete",
+            addExternInline<DAS_BIND_FUN(das_get_jit_delete)>(*this, lib,  "get_jit_delete",
                 SideEffects::none, "das_get_jit_delete")->args({"ann"});
-            addExtern<DAS_BIND_FUN(das_get_jit_clone)>(*this, lib, "get_jit_clone",
+            addExternInline<DAS_BIND_FUN(das_get_jit_clone)>(*this, lib, "get_jit_clone",
                 SideEffects::none, "das_get_jit_clone")->args({"ann"});
-            addExtern<DAS_BIND_FUN(das_get_jit_debug_enter)>(*this, lib,  "get_jit_debug_enter",
+            addExternInline<DAS_BIND_FUN(das_get_jit_debug_enter)>(*this, lib,  "get_jit_debug_enter",
                 SideEffects::none, "das_get_jit_debug_enter");
-            addExtern<DAS_BIND_FUN(das_get_jit_debug_exit)>(*this, lib,  "get_jit_debug_exit",
+            addExternInline<DAS_BIND_FUN(das_get_jit_debug_exit)>(*this, lib,  "get_jit_debug_exit",
                 SideEffects::none, "das_get_jit_debug_exit");
-            addExtern<DAS_BIND_FUN(das_get_jit_debug_line)>(*this, lib,  "get_jit_debug_line",
+            addExternInline<DAS_BIND_FUN(das_get_jit_debug_line)>(*this, lib,  "get_jit_debug_line",
                 SideEffects::none, "das_get_jit_debug_line");
-            addExtern<DAS_BIND_FUN(das_get_jit_initialize_fileinfo)>(*this, lib,  "get_jit_initialize_fileinfo",
+            addExternInline<DAS_BIND_FUN(das_get_jit_initialize_fileinfo)>(*this, lib,  "get_jit_initialize_fileinfo",
                 SideEffects::none, "das_get_jit_initialize_fileinfo");
-            addExtern<DAS_BIND_FUN(das_get_jit_free_fileinfo)>(*this, lib,  "get_jit_free_fileinfo",
+            addExternInline<DAS_BIND_FUN(das_get_jit_free_fileinfo)>(*this, lib,  "get_jit_free_fileinfo",
                 SideEffects::none, "das_get_jit_free_fileinfo");
-            addExtern<DAS_BIND_FUN(das_recreate_fileinfo_name)>(*this, lib,  "recreate_fileinfo_name",
+            addExternInline<DAS_BIND_FUN(das_recreate_fileinfo_name)>(*this, lib,  "recreate_fileinfo_name",
                 SideEffects::worstDefault, "das_recreate_fileinfo_name");
-            addExtern<DAS_BIND_FUN(loadDynamicLibrary)>(*this, lib,  "load_dynamic_library",
+            addExternInline<DAS_BIND_FUN(loadDynamicLibrary)>(*this, lib,  "load_dynamic_library",
                 SideEffects::worstDefault, "loadDynamicLibrary")
                     ->args({"filename"});
-            addExtern<DAS_BIND_FUN(getFunctionAddress)>(*this, lib,  "get_function_address",
+            addExternInline<DAS_BIND_FUN(getFunctionAddress)>(*this, lib,  "get_function_address",
                 SideEffects::worstDefault, "getFunctionAddress")
                     ->args({"library","name"});
-            addExtern<DAS_BIND_FUN(closeLibrary)>(*this, lib,  "close_dynamic_library",
+            addExternInline<DAS_BIND_FUN(closeLibrary)>(*this, lib,  "close_dynamic_library",
                 SideEffects::worstDefault, "closeLibrary")
                     ->args({"library"});
-            addExtern<DAS_BIND_FUN(create_shared_library)>(*this, lib,  "create_shared_library",
+            addExternInline<DAS_BIND_FUN(create_shared_library)>(*this, lib,  "create_shared_library",
                 SideEffects::worstDefault, "create_shared_library")
                     ->args({"objFilePath","libraryName","dasLib","customLinker","extraLinkerArgs","isShared","linkWholeLib","debugInfo","context"});
-            addExtern<DAS_BIND_FUN(jit_par_emit_begin)>(*this, lib,  "jit_par_emit_begin",
+            addExternInline<DAS_BIND_FUN(jit_par_emit_begin)>(*this, lib,  "jit_par_emit_begin",
                 SideEffects::worstDefault, "jit_par_emit_begin");
-            addExtern<DAS_BIND_FUN(jit_par_emit_add)>(*this, lib,  "jit_par_emit_add",
+            addExternInline<DAS_BIND_FUN(jit_par_emit_add)>(*this, lib,  "jit_par_emit_add",
                 SideEffects::worstDefault, "jit_par_emit_add")
                     ->args({"mod","tm","pbo","pipeline","objPath"});
-            addExtern<DAS_BIND_FUN(jit_par_emit_run)>(*this, lib,  "jit_par_emit_run",
+            addExternInline<DAS_BIND_FUN(jit_par_emit_run)>(*this, lib,  "jit_par_emit_run",
                 SideEffects::worstDefault, "jit_par_emit_run")
                     ->args({"threads","fileType","fnRunPasses","fnVerifyModule","fnEmitToFile","fnGetErrorMessage","fnDisposeErrorMessage","fnDisposeMessage","logTimes","context"});
-            addExtern<DAS_BIND_FUN(host_jit_triple)>(*this, lib, "host_jit_triple",
+            addExternInline<DAS_BIND_FUN(host_jit_triple)>(*this, lib, "host_jit_triple",
                 SideEffects::none, "host_jit_triple");
-            addExtern<DAS_BIND_FUN(link_wasm)>(*this, lib,  "link_wasm",
+            addExternInline<DAS_BIND_FUN(link_wasm)>(*this, lib,  "link_wasm",
                 SideEffects::worstDefault, "link_wasm")
                     ->args({"objFilePath","wasmPath","runtimeLibPath","customEmcc","memory64","context"});
-            addExtern<DAS_BIND_FUN(jit_set_jit_state)>(*this, lib,  "set_jit_state",
+            addExternInline<DAS_BIND_FUN(jit_set_jit_state)>(*this, lib,  "set_jit_state",
                 SideEffects::worstDefault, "jit_set_jit_state")
                     ->args({"context","shared_lib","llvm_ee","llvm_ctx"});
-            addExtern<DAS_BIND_FUN(jit_get_jit_state)>(*this, lib,  "get_jit_state",
+            addExternInline<DAS_BIND_FUN(jit_get_jit_state)>(*this, lib,  "get_jit_state",
                 SideEffects::worstDefault, "jit_get_jit_state")
                     ->args({"block","context","at"});
             addConstant<uint32_t>(*this, "SIZE_OF_PROLOGUE", uint32_t(sizeof(Prologue)));

--- a/src/builtin/review_nttp.das
+++ b/src/builtin/review_nttp.das
@@ -5,13 +5,14 @@ require daslib/ast
 require daslib/ast_boost
 require daslib/macro_boost
 require math // nolint:STYLE030 — coverage require: pulls the module into the scanned registry
-require strings // nolint:STYLE030 — coverage require
+require strings
+require jit // nolint:STYLE030 — coverage require
 require daslib/fio // nolint:STYLE030 — coverage require
-require daslib/rtti // nolint:STYLE030 — coverage require
-require daslib/jobque_boost // nolint:STYLE030 — coverage require
+require daslib/rtti // coverage require
+require daslib/jobque_boost // coverage require
 require daslib/network // nolint:STYLE030 — coverage require
 require daslib/uriparser_boost // nolint:STYLE030 — coverage require
-require daslib/debug // nolint:STYLE030 — coverage require
+require daslib/debug // coverage require
 
 // Bind flavor exists only in the compiled module registry, so this check runs at
 // compile time; the policy and its exemptions are src/builtin/REVIEW.md's rule.
@@ -34,25 +35,33 @@ def private is_shared_generic_helper(cppName : string) : bool {
 
 [_macro]
 def check_nttp_policy {
-    let inlineOnlyModules <- {"$", "math", "strings"}
+    // the list is the single source of truth: membership, the finding text, and the
+    // coverage check below all read it, so adding a module cannot leave one of them stale
+    let inlineOnlyModules <- ["$", "math", "strings", "jit"]
+    let policyNames = build_string() $(writer) {
+        for (name, idx in inlineOnlyModules, count()) {
+            writer |> write(idx > 0 ? ", " : "")
+            writer |> write(name)
+        }
+    }
     var matched : table<string>
     program_for_each_module(compiling_program()) $(mod) {
-        let inInlineOnly = inlineOnlyModules |> key_exists("{mod.name}")
+        let inInlineOnly = find_index(inlineOnlyModules, "{mod.name}") >= 0
         if (inInlineOnly) {
             matched |> insert("{mod.name}")
         }
         for_each_function(mod, "") $(func) {
             return if (!is_plain_value_bind(func) || is_shared_generic_helper("{(func as BuiltInFunction).cppName}"))
             if (inInlineOnly && !func.moreFlags2.nttp) {
-                macro_error(compiling_program(), func.at, "REVIEW policy: {mod.name}::{func.name} is not bound with addExternInline; builtin/math/strings binds are NTTP")
+                macro_error(compiling_program(), func.at, "REVIEW policy: {mod.name}::{func.name} is not bound with addExternInline; every plain-value bind in {policyNames} is NTTP")
             } elif (!inInlineOnly && func.moreFlags2.nttp) {
-                macro_error(compiling_program(), func.at, "REVIEW policy: {mod.name}::{func.name} is bound with addExternInline; only builtin/math/strings binds are NTTP")
+                macro_error(compiling_program(), func.at, "REVIEW policy: {mod.name}::{func.name} is bound with addExternInline; only {policyNames} binds are NTTP")
             }
         }
     }
     // fail closed: a policy module name that matched nothing means the scan
     // silently skipped it (typo or module rename) — the gate must not stay green
-    for (name in keys(inlineOnlyModules)) {
+    for (name in inlineOnlyModules) {
         if (!(matched |> key_exists(name))) {
             panic("review_nttp: policy module '{name}' not found in the scanned registry — gate coverage is broken")
         }

--- a/utils/REVIEW.md
+++ b/utils/REVIEW.md
@@ -16,18 +16,16 @@ the decision in that tool's own `REVIEW.md`, wherever the tool's directory sits,
 change** - a removed entry's decision record is the one thing the gate cannot see. A tool
 deleted outright records it beside the list in `CMakeLists.txt` instead.
 
-**A new or changed test under a `utils/` tool whose load-bearing assertions CI can run - the
-assertions that prove the change, not a skip-path assertion - ships in the same change with
-the CI row that runs them**: a row in `.github/workflows/extended_checks.yml` (repo root), a
-`DAS_UTILS_TO_TEST` entry in `CMakeLists.txt` (beside this file) that the `run_utils_tests`
-row builds, or the tool's own workflow for a browser suite. A row that only compile-checks
-the test (`dastest --compile-only`) is not that row. A test whose assertions no row runs
-passes review once and never runs again.
+**A new or changed test for a `utils/` tool whose load-bearing assertions a CI lane can run -
+the assertions that prove the change, not a skip-path assertion - is covered, wherever the
+diff puts it, by a CI row that executes them, added in the same change if none already
+covers it.** A row that only compile-checks the test (`dastest --compile-only`) does not
+execute them, and a test whose assertions no row runs passes review once and never runs
+again.
 
-**A test whose load-bearing assertions CI cannot run - they need an artifact the lane lacks:
-a model file, a GPU, a network service - has a compile-only row in
-`.github/workflows/extended_checks.yml` (repo root) or the tool's own workflow.**
+**A test for a `utils/` tool whose load-bearing assertions no CI lane can run - they need
+something no CI machine has - ships with a CI row that compile-checks it.**
 
-**A new or changed test that takes a compile-only row ships with its executed run recorded
-in the PR description**: the machine the assertions ran on, the gate it satisfied (the model
-file, GPU, or service present), and the pass count.
+**A new or changed test for a `utils/` tool that takes a compile-only row ships with its
+executed run recorded in the PR description**: the machine the assertions ran on, what that
+machine had that CI lacks, and the pass count.


### PR DESCRIPTION
All 74 binds in the `jit` module move from `addExtern` to `addExternInline`, so each gets its own interpreter node the callee inlines into instead of sharing one node per signature. This returns the module to the flavor builtin, math and strings already use. The binds are called from the JIT emitter as it walks the program it is compiling, and that emitter runs interpreted.

The rule that governs bind flavor could not see the module at all. Its gate scans the compiled module registry, and the gate's reach is exactly the set of modules it requires. It never required `jit`, so those 74 binds were never checked in either direction. Adding `jit` to the coverage requires and to the policy list closes that.

The module list used to live in four places: the rule, the gate, and two architecture documents that restated it. Adding one module made both architecture documents contradict the rule. They now point at the rule instead of repeating it, which leaves two copies, and `REVIEW.das` checks those two against each other so they cannot drift in silence.

Linting the one changed script turned up four `nolint` comments that suppress nothing, sitting on master. They survived because no lint lane covered `src/` - the whole-tree lint listed every other source root. `src/` holds three `.das` files and all three are clean once the dead suppressions go.

Separately, `utils/REVIEW.md`'s three test rules said "a test under a `utils/` tool" while the same file's routing says a tool's files are reviewed by what the file IS, not where it sits. They now key on the same thing the routing does. The three rules also enumerated the CI rows that count as running a test; they now state the property those rows share, which is that the row executes the assertions rather than only compile-checking them.

Where to look: `check_inline_module_list` in `src/builtin/REVIEW.das` for the new cross-check, and the `Inline modules` clause in `src/builtin/REVIEW.md` that it reads.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full `tests/` suite 14006 passed, 0 failed, 0 errors, 3 skipped; `tests/jit_tests` 362/362 both warm and cold, with `.jitted_scripts` deleted so every DLL was regenerated and relinked.
- `test_aot_subset` over `tests/language` 1699/1699 with no `error[50101]`, which is what would show if the bind flavor moved an AOT hash.
- The new `REVIEW.das` cell is negative-controlled four ways: a module named only in the rule, a module carried only by the gate, the rule's list clause renamed, and the gate's array renamed. Each turns the gate red, and the last is a compile error rather than a silent pass.
- The `jit` policy addition is negative-controlled by reverting one bind to `addExtern`: the gate names that bind.
- The lint-lane addition is negative-controlled by running the CI step over `src/` with master's script in place, which reports exactly the four dead suppressions.
- Not run: `preflight --full`. The changed surface is one C++ file whose edit is mechanical, one script, and four documents; the gates that cover them were run directly.

### Claims - stated, not tested
- The performance rationale in the rule - that these modules' binds sit on interpreted inner loops - comes from reading the emitter's call sites, not from a measurement of this change. The conversion returns `jit` to parity with the other three rather than making a new bet, and a needlessly-inlined cold bind costs about a kilobyte.
- `LLVM_JIT_CODEGEN_VERSION` is deliberately not bumped. The emitter works off AST expressions and never names the extern-call node type, and jit bind addresses are patched into the generated DLL at load rather than baked into it. The cold run is the evidence.

### Not done
- No `DAS_GC_DEBUG` lane. There is none in the tree today, and the `Function::gc_collect` walk added in the previous change is still invisible to every build CI runs. It is a compile-time macro, so a lane costs a full extra build; ledgered for a nightly job of its own.
- A test that belongs to a `utils/` tool but lives outside `utils/` still surfaces no checklist, because discovery is a folder walk and neither `tests/` nor `tests/dastest/` carries one. The rule wording now covers such a test once the checklist is surfaced, which happens whenever the diff also touches the tool.
- `dastest` is a shipped tool governed by `utils/REVIEW.md` whose directory sits at the repo root, so "a `utils/` tool" reads two ways for it. Left as is.
- `module_builtin_dasbind.cpp` is bound under `src/builtin` and is still outside the gate's coverage requires, so its binds are unscanned.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
