### PR TITLE
nightly lint: suppress the STYLE037 hit, and the bind scan reaches dasbind

### DIFF
--- a/src/builtin/review_nttp.das
+++ b/src/builtin/review_nttp.das
@@ -7,6 +7,7 @@ require daslib/macro_boost
 require math // nolint:STYLE030 — coverage require: pulls the module into the scanned registry
 require strings
 require jit // nolint:STYLE030 — coverage require
+require dasbind // coverage require: not a policy module, so the scan asserts its binds stay non-NTTP
 require daslib/fio // nolint:STYLE030 — coverage require
 require daslib/rtti // coverage require
 require daslib/jobque_boost // coverage require

--- a/utils/internal/dasgen/gen_type_conformance.das
+++ b/utils/internal/dasgen/gen_type_conformance.das
@@ -239,7 +239,7 @@ def emit_bitops_section(var writer; spec : TypeSpec) {
 
 // lane-matched converts + saturating narrows — mirrors the das_sv_cvt/das_sv_cvt_sat
 // registration matrix (module_builtin_vector_ctor.cpp)
-def emit_convert_section(var writer; spec : TypeSpec) {
+def emit_convert_section(var writer; spec : TypeSpec) {  // nolint:STYLE037 — one emit arm per lane family, an irreducible dispatch in a codegen emitter
     let n = spec.arity
     assume fam = spec.family
     let isIntNarrow = (fam == "short" || fam == "byte" || fam == "ushort" || fam == "ubyte") && n <= 4


### PR DESCRIPTION
The nightly whole-tree lint is red on one finding: `emit_convert_section` in the type-conformance generator reports cyclomatic complexity 22 against a limit of 20.

Nothing about that function changed. Neither it nor `daslib/style_lint.das` differs between the last green nightly and the red one. What moved is the count, not the code: the metric is computed on the AST after inference, so a compiler change to what does and does not inline shifts it. Refactoring a working emitter to move a number that tracks inlining would not survive the next such change, so the function is suppressed on its `def` line with the reason. The shape is a dispatch with one emit arm per lane family, which is what the rule's escape exists for.

The second commit is the follow-up ledgered when the bind-flavor gate gained `jit`. `dasbind` is bound under `src/builtin` and was the last module the scan could not reach, so its three binds were checked in neither direction. It gets a coverage require and deliberately no entry in the policy list, because that is how the rule states a module is not NTTP - the scan's other direction then reports any bind there that turns Inline. No checklist prose is added for it: the require is the statement, and the gate enforces it.

Where to look: the `nolint` tail comment on `emit_convert_section`, and the `require dasbind` line in `review_nttp.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Both nightly lint passes were run locally over the workflow's exact path set. Every finding they report - 159 compile failures and 94 warnings - is in a gitignored file: locally daspkg-installed package copies under `examples/*/modules/` and `utils/find-dupe/modules/`, which CI does not have. Filtered against `git ls-files`, the tracked tree reports zero findings. That local-only content is also the whole gap between the 4330 files linted here and the 3837 CI reports.
- The `dasbind` coverage require is negative-controlled: moving `dasbind` into the policy list makes the gate name all three of its binds, so the scan demonstrably reaches them; with it outside the list the gate is green, which is the assertion the change is for.
- The last nightly ran before four other merges landed, so its clean result did not cover them. The local sweep above does.

### Claims - stated, not tested
- Which compiler change moved the complexity count is not identified. It reproduces deterministically at 22 across repeated runs, and the resolution is the same either way, so the bisect was not run.

### Not done
- `foreign_module_code` in `daslib/style_lint.das` - the suppression check both metric rules share - walks the `fromGeneric` chain and dereferences the origin's module. That pointer could dangle before the module-cache fix landed, which would make these rules fire or not fire unpredictably on any build older than it. Sound on master now; noted rather than changed.
- No `DAS_GC_DEBUG` lane. Still ledgered from the previous change.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
