### PR TITLE
das: serialize: branch writeback on ownership, guard empty read

### DIFF
--- a/src/ast/ast_parse.cpp
+++ b/src/ast/ast_parse.cpp
@@ -1391,15 +1391,11 @@ namespace das {
             size_t len_at = serializer_write->buffer->writingSize();
             *serializer_write << payload_size;
             size_t payload_start = serializer_write->buffer->writingSize();
-            if ( program->thisModule && program->thisModule->name.empty() )  {
-                serializer_write->serializeProgram(program, libGroup);
-            } else if ( program->thisModule.get() == thisModule ) {
-                // the ENTRY program still owns its module (dependency programs released
-                // theirs in addNewModules) - re-attaching via reset(get()) would delete
-                // the module and leave a dangling pointer
+            if ( program->thisModule )  {
+                // the program owns its module (entry script) - write as is, never mutate it
                 serializer_write->serializeProgram(program, libGroup);
             } else {
-                // set thisModule to program
+                // module was moved into the group by addNewModules - reattach for the write
                 program->thisModule.reset(thisModule);
                 serializer_write->serializeProgram(program, libGroup);
                 program->thisModule.release();

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -3087,6 +3087,12 @@ namespace das {
                 }
             }
 
+            if ( program->library.getModules().empty() ) {
+                LOG(LogLevel::warning) << "das: serialize: program '" << program->thisModuleName << "' stream has no modules\n";
+                program->failToCompile = true;
+                return;
+            }
+
             program->thisModule.reset(program->library.getModules().back());
             // the deserialized module is the program's module now — new nodes and the
             // ModuleGcFinalize collect belong on its root


### PR DESCRIPTION
The entry-program crash is already handled: 2f3d4bce1 added the thisModule.get() == thisModule self-reset guard, so a named entry no longer has its live module deleted by reset(same ptr). What is left is the predicate. name.empty() says nothing about ownership, and pointer identity is narrower than the invariant we need: thisModule is a unique_ptr, so reset() deletes whatever it currently holds - ANY program that still owns a module must be written as is. Only a program whose module was moved into the group by addNewModules (thisModule == null) needs the reset/release dance. Three branches collapse into that test.

Reported as a crash in compileDaScript -> markExecutableSymbolUse -> visitModule(null), reading at 0xe0 (Palvella report 00186a2a90); repro was 'module x' in a project main.das plus game_das_enable_serialization on a fresh cache. Both write and read runs pass on the current tree.

Also guard the read path against a stream with zero modules: back() on the empty list is UB; fail the program instead.