### PR TITLE
nano: freestanding port - cortex-m4 cross-compile, and the type-spelling fixes it forced

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -290,6 +290,18 @@ jobs:
       if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && matrix.target != 'windows'
       run: $BIN/daslang ./utils/internal/doc-verify/main.das -- --daslang $BIN/daslang
 
+    - name: "Cross-compile nano for cortex-m4"
+      # nano's drift tripwire - the only freestanding build in CI. Linux only:
+      # one arch catches the drift, and the toolchain is an apt away.
+      if: matrix.target == 'linux'
+      run: |
+        set -eux
+        # newlib and its libstdc++ are only *recommended* by gcc-arm-none-eabi,
+        # so --no-install-recommends leaves a compiler with no C library at all.
+        sudo bash ci/apt_install.sh --no-install-recommends \
+          gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+        ci/nano_arm_build.sh "$BIN/daslang"
+
     - name: "Build standalone executables"
       run: |
         set -eux

--- a/ci/nano_arm_build.sh
+++ b/ci/nano_arm_build.sh
@@ -2,17 +2,9 @@
 # Cross-compile libDaScriptNano and the tier-A standalone example for a
 # cortex-m4, and print the size of what comes out.
 #
-# THIS DOES NOT PASS YET, and it is not wired into CI. It is the acceptance test
-# for the freestanding port, and running it names the work: newlib has no
-# posix_memalign / malloc_usable_size / madvise, its libstdc++ is built without
-# threads so <mutex> declares nothing, its uint32_t is `unsigned long` (which
-# makes every BitfieldAny and vec4<uint32_t> conversion ambiguous), and alloca
-# needs its own include. Those live in platform.h, smart_ptr.h, arraytype.h and
-# vectypes.h - shared headers every platform compiles, which is why the port is
-# its own change rather than a corner of nano.
-#
-# Once it is green it becomes nano's drift tripwire: a change that pulls the
-# compiler, fmt or the host's I/O back into the runtime fails here first.
+# nano's drift tripwire: nothing else in CI builds freestanding, so a change that
+# pulls the compiler, fmt, the host's I/O or a thread primitive back into the
+# minimal runtime fails here first and nowhere else.
 #
 # Usage: ci/nano_arm_build.sh <path-to-daslang> [out-dir]
 # Toolchain: apt-get install gcc-arm-none-eabi

--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -2590,13 +2590,13 @@ class public CppAot : AstVisitor {
     }
     def override visitExprConstBitfield(var c : ExprConstBitfield?) : ExpressionPtr {
         if (c._type.baseType == Type.tBitfield64) {
-            write(*ss, "UINT64_C(0x{c.getValue:x})");
+            write(*ss, "das::Bitfield64(UINT64_C(0x{c.getValue:x}))");
         } elif (c._type.baseType == Type.tBitfield16) {
-            write(*ss, "uint16_t(0x{uint(c.getValue):x})");
+            write(*ss, "das::Bitfield16(uint16_t(0x{uint(c.getValue):x}))");
         } elif (c._type.baseType == Type.tBitfield8) {
-            write(*ss, "uint8_t(0x{uint(c.getValue):x})");
+            write(*ss, "das::Bitfield8(uint8_t(0x{uint(c.getValue):x}))");
         } else {
-            write(*ss, "0x{c.getValue:x}u");
+            write(*ss, "das::Bitfield(0x{c.getValue:x}u)");
         }
         return c;
     }

--- a/include/daScript/ast/ast_visitor.h
+++ b/include/daScript/ast/ast_visitor.h
@@ -354,7 +354,7 @@ namespace das {
             ctx.thisHelper = &helper;
             ctx.heap = make_unique<LinearHeapAllocator>();
             ctx.stringHeap = make_unique<LinearStringAllocator>();
-            ctx.category = uint32_t(ContextCategory::folding_context);
+            ctx.category = Bitfield(uint32_t(ContextCategory::folding_context));
         }
     protected:
         Context         ctx;

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -245,16 +245,8 @@ namespace das {
     struct BitfieldAny {
         ST value;
         __forceinline BitfieldAny() {}
-        __forceinline BitfieldAny(int32_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(uint32_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(int64_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(uint64_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(int8_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(uint8_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(int16_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(uint16_t v) : value(ST(v)) {}
-        __forceinline BitfieldAny(float v) : value(ST(v)) {}
-        __forceinline BitfieldAny(double v) : value(ST(v)) {}
+        // one candidate cannot be ambiguous, and explicit keeps narrowing at the call site
+        __forceinline explicit BitfieldAny(ST v) : value(v) {}
         __forceinline operator ST &() { return value; }
         __forceinline operator float() const { return float(value); }
         __forceinline operator double() const { return double(value); }

--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -476,10 +476,22 @@ inline void *das_aligned_alloc16(size_t size) {
     p = _aligned_malloc(size, DAS_ALLOC_ALIGNMENT_WIN);
 #else
     p = nullptr;
+#if defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__) || defined(_EMSCRIPTEN_VER)
     if (posix_memalign(&p, das_alloc_alignment(size), size)) {
         DAS_ASSERTF(0, "posix_memalign returned nullptr");
         return nullptr;
     }
+#else
+    // no POSIX: C11 aligned_alloc, which unlike posix_memalign wants size rounded up
+    {
+        const size_t alignment = das_alloc_alignment(size);
+        p = aligned_alloc(alignment, (size + alignment - 1) & ~(alignment - 1));
+        if (!p) {
+            DAS_ASSERTF(0, "aligned_alloc returned nullptr");
+            return nullptr;
+        }
+    }
+#endif
 #if defined(__linux__)
     if (size >= 2*1024*1024) {
         // interior only (size rounded DOWN to 2MB): hinting the partial tail page would back
@@ -501,9 +513,12 @@ inline void das_aligned_free16(void *ptr) {
 }
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
-#elif defined (__linux__) || defined (_EMSCRIPTEN_VER) || defined __HAIKU__ || defined(_WIN32)
-// Windows: <malloc.h> declares _aligned_msize for MSVC and the MinGW-w64 CRT.
+#elif __has_include(<malloc.h>)
+// _aligned_msize on the MS CRT, malloc_usable_size everywhere else including newlib
 #include <malloc.h>
+#endif
+#if __has_include(<alloca.h>)
+#include <alloca.h>
 #endif
 inline size_t das_aligned_memsize(void * ptr){
 #if defined(_WIN32)

--- a/include/daScript/misc/smart_ptr.h
+++ b/include/daScript/misc/smart_ptr.h
@@ -319,6 +319,8 @@ namespace das {
         return reinterpret_cast<T *>(r.get());
     }
 
+    // overridable: a build with no leak reporting opts out of the tracking list and its counter
+    #ifndef DAS_NEW_SMART_PTR_ID
     #define DAS_NEW_SMART_PTR_ID \
     { \
         lock_guard<mutex> guard(ref_count_mutex); \
@@ -328,6 +330,8 @@ namespace das {
         if (ref_count_head) ref_count_head->ref_count_prev = this; \
         ref_count_head = this; \
     }
+    #endif
+    #ifndef DAS_DELETE_SMART_PTR_ID
     #define DAS_DELETE_SMART_PTR_ID \
     { \
         lock_guard<mutex> guard(ref_count_mutex); \
@@ -335,12 +339,21 @@ namespace das {
         else ref_count_head = ref_count_next; \
         if (ref_count_next) ref_count_next->ref_count_prev = ref_count_prev; \
     }
+    #endif
+    #ifndef DAS_TRACK_SMART_PTR_ID
     #define DAS_TRACK_SMART_PTR_ID         if ( ref_count_id==ref_count_track ) os_debug_break();
+    #endif
+    #ifndef DAS_TRACK_SMART_PTR_ID_DTOR
     #define DAS_TRACK_SMART_PTR_ID_DTOR    if ( ref_count_id==ref_count_track_destructor ) os_debug_break();
+    #endif
 
     DAS_API extern atomic<uint64_t> g_smart_ptr_total;
+    #ifndef DAS_SMART_PTR_NEW
     #define DAS_SMART_PTR_NEW     g_smart_ptr_total++;
+    #endif
+    #ifndef DAS_SMART_PTR_DELETE
     #define DAS_SMART_PTR_DELETE  g_smart_ptr_total--;
+    #endif
 
     class DAS_API ptr_ref_count {
     public:

--- a/include/daScript/misc/vectypes.h
+++ b/include/daScript/misc/vectypes.h
@@ -43,15 +43,16 @@ namespace das
         static __forceinline uint64_t y ( vec4f t ) { union { vec4f t; uint64_t T[2]; } temp; temp.t = t; return temp.T[1]; }
     };
 
+    // spelled in the element types vec2/vec3/vec4 actually hold, not in int/unsigned
     __forceinline vec4f vec_loadu_x(const float v) {return v_set_x(v);}
-    __forceinline vec4f vec_loadu_x(const int v) {return v_cast_vec4f(v_seti_x(v));}
-    __forceinline vec4f vec_loadu_x(const unsigned int v) {return v_cast_vec4f(v_seti_x(v));}
+    __forceinline vec4f vec_loadu_x(const int32_t v) {return v_cast_vec4f(v_seti_x(v));}
+    __forceinline vec4f vec_loadu_x(const uint32_t v) {return v_cast_vec4f(v_seti_x(int32_t(v)));}
     __forceinline vec4f vec_load(const float *v) {return v_ld(v);}
-    __forceinline vec4f vec_load(const int *v) {return v_cast_vec4f(v_ldi(v));}
-    __forceinline vec4f vec_load(const unsigned int *v) {return vec_load((const int *)v);}
+    __forceinline vec4f vec_load(const int32_t *v) {return v_cast_vec4f(v_ldi((const int *)v));}
+    __forceinline vec4f vec_load(const uint32_t *v) {return vec_load((const int32_t *)v);}
     __forceinline vec4f vec_loadu(const float *v) {return v_ldu(v);}
-    __forceinline vec4f vec_loadu(const int *v) {return v_cast_vec4f(v_ldui(v));}
-    __forceinline vec4f vec_loadu(const unsigned int *v) {return vec_loadu((const int *)v);}
+    __forceinline vec4f vec_loadu(const int32_t *v) {return v_cast_vec4f(v_ldui((const int *)v));}
+    __forceinline vec4f vec_loadu(const uint32_t *v) {return vec_loadu((const int32_t *)v);}
     __forceinline vec4f vec_loadu3(const float *v)
     {
 #ifdef __clang__
@@ -62,20 +63,20 @@ namespace das
       return v_ldu_p3(v);
 #endif
     }
-    __forceinline vec4f vec_loadu3(const int *v)
+    __forceinline vec4f vec_loadu3(const int32_t *v)
     {
 #ifdef __clang__
       vec4i vv = v_zeroi();
-      memcpy(&vv, v, sizeof(int) * 3);
+      memcpy(&vv, v, sizeof(int32_t) * 3);
       return v_cast_vec4f(vv);
 #else
-      return v_cast_vec4f(v_ldui_p3(v));
+      return v_cast_vec4f(v_ldui_p3((const int *)v));
 #endif
     }
-    __forceinline vec4f vec_loadu3(const unsigned int *v) {return vec_loadu3((const int *)v);}
+    __forceinline vec4f vec_loadu3(const uint32_t *v) {return vec_loadu3((const int32_t *)v);}
     __forceinline vec4f vec_loadu_half(const float *v) {return v_ldu_half(v);}
-    __forceinline vec4f vec_loadu_half(const int *v) {return v_cast_vec4f(v_ldui_half(v));}
-    __forceinline vec4f vec_loadu_half(const unsigned int *v) {return vec_loadu_half((const int *)v);}
+    __forceinline vec4f vec_loadu_half(const int32_t *v) {return v_cast_vec4f(v_ldui_half((const int *)v));}
+    __forceinline vec4f vec_loadu_half(const uint32_t *v) {return vec_loadu_half((const int32_t *)v);}
 
     template <typename TT>
     struct vec2 {

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -1124,6 +1124,25 @@ namespace das {
         }
     };
 
+    // signedness decided here, not by overload, so the negative test compiles away when unsigned
+    template <typename IndexT>
+    __forceinline bool das_dim_index_ok ( IndexT index, int size ) {
+        if ( is_signed<IndexT>::value && index < IndexT(0) ) return false;
+        return uint64_t(index) < uint64_t(size);
+    }
+
+    template <typename IndexT>
+    DAS_NORETURN_PREFIX __forceinline void das_dim_index_error ( IndexT index, int size, Context * __context__ ) DAS_NORETURN_SUFFIX;
+
+    template <typename IndexT>
+    __forceinline void das_dim_index_error ( IndexT index, int size, Context * __context__ ) {
+        if ( is_signed<IndexT>::value ) {
+            __context__->throw_error_ex("index out of range, %lld of %d", (long long)index, size);
+        } else {
+            __context__->throw_error_ex("index out of range, %llu of %d", (unsigned long long)index, size);
+        }
+    }
+
     template <typename TT, int size>
     struct TDim {
         using THIS_TYPE = TDim<TT, size>;
@@ -1136,38 +1155,16 @@ namespace das {
         __forceinline const TT & operator [] ( int32_t index ) const {
             return data[index];
         }
-    // index
-        __forceinline TT & operator () ( int32_t index, Context * __context__ ) {
-            if ( index<0 || uint32_t(index)>=uint32_t(size) ) __context__->throw_error_ex("index out of range, %d of %d", index, size);
+    // index - one candidate per constness, since an index literal is an int by language rule
+        template <typename IndexT, typename = enable_if_t<is_integral<IndexT>::value>>
+        __forceinline TT & operator () ( IndexT index, Context * __context__ ) {
+            if ( !das_dim_index_ok(index, size) ) das_dim_index_error(index, size, __context__);
             return data[index];
         }
-        __forceinline const TT & operator () ( int32_t index, Context * __context__ ) const {
-            if ( index<0 || uint32_t(index)>=uint32_t(size) ) __context__->throw_error_ex("index out of range, %d of %d", index, size);
+        template <typename IndexT, typename = enable_if_t<is_integral<IndexT>::value>>
+        __forceinline const TT & operator () ( IndexT index, Context * __context__ ) const {
+            if ( !das_dim_index_ok(index, size) ) das_dim_index_error(index, size, __context__);
             return data[index];
-        }
-        __forceinline TT & operator () ( uint32_t idx, Context * __context__ ) {
-            if ( idx>=uint32_t(size) ) __context__->throw_error_ex("index out of range, %u of %d", idx, size);
-            return data[idx];
-        }
-        __forceinline const TT & operator () ( uint32_t idx, Context * __context__ ) const {
-            if ( idx>=uint32_t(size) ) __context__->throw_error_ex("index out of range, %u of %d", idx, size);
-            return data[idx];
-        }
-        __forceinline TT & operator () ( int64_t index, Context * __context__ ) {
-            if ( index<0 || uint64_t(index)>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %lld of %d", (long long)index, size);
-            return data[index];
-        }
-        __forceinline const TT & operator () ( int64_t index, Context * __context__ ) const {
-            if ( index<0 || uint64_t(index)>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %lld of %d", (long long)index, size);
-            return data[index];
-        }
-        __forceinline TT & operator () ( uint64_t idx, Context * __context__ ) {
-            if ( idx>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %llu of %d", (unsigned long long)idx, size);
-            return data[idx];
-        }
-        __forceinline const TT & operator () ( uint64_t idx, Context * __context__ ) const {
-            if ( idx>=uint64_t(size) ) __context__->throw_error_ex("index out of range, %llu of %d", (unsigned long long)idx, size);
-            return data[idx];
         }
     // safe index
         static __forceinline TT * safe_index ( THIS_TYPE * that, int32_t index, Context * ) {

--- a/include/daScript/simulate/cast.h
+++ b/include/daScript/simulate/cast.h
@@ -259,26 +259,26 @@ namespace das
 
     template <>
     struct cast <Bitfield> {
-        static __forceinline Bitfield to ( vec4f x )           { return v_extract_xi(v_cast_vec4i(x)); }
+        static __forceinline Bitfield to ( vec4f x )           { return Bitfield(uint32_t(v_extract_xi(v_cast_vec4i(x)))); }
         static __forceinline vec4f from ( Bitfield x )         { return v_cast_vec4f(v_seti_x(x.value)); }
     };
 
 
     template <>
     struct cast <Bitfield8> {
-        static __forceinline Bitfield8 to ( vec4f x )           { return v_extract_xi(v_cast_vec4i(x)); }
+        static __forceinline Bitfield8 to ( vec4f x )           { return Bitfield8(uint8_t(v_extract_xi(v_cast_vec4i(x)))); }
         static __forceinline vec4f from ( Bitfield8 x )         { return v_cast_vec4f(v_seti_x(x.value)); }
     };
 
     template <>
     struct cast <Bitfield16> {
-        static __forceinline Bitfield16 to ( vec4f x )           { return v_extract_xi(v_cast_vec4i(x)); }
+        static __forceinline Bitfield16 to ( vec4f x )           { return Bitfield16(uint16_t(v_extract_xi(v_cast_vec4i(x)))); }
         static __forceinline vec4f from ( Bitfield16 x )         { return v_cast_vec4f(v_seti_x(x.value)); }
     };
 
     template <>
     struct cast <Bitfield64> {
-        static __forceinline Bitfield64 to ( vec4f x )           { return v_extract_xi64(v_cast_vec4i(x)); }
+        static __forceinline Bitfield64 to ( vec4f x )           { return Bitfield64(uint64_t(v_extract_xi64(v_cast_vec4i(x)))); }
         static __forceinline vec4f from ( Bitfield64 x )         { return v_cast_vec4f(v_ldui_half(&x)); }
     };
 

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -860,7 +860,7 @@ namespace das
         mutex                           forkContextPoolMutex;
     public:
         string                          name;
-        Bitfield                        category = 0;
+        Bitfield                        category = Bitfield(0u);
     public:
         vec4f *         abiThisBlockArg;
         vec4f *         abiArg;

--- a/nano/ARCHITECTURE.md
+++ b/nano/ARCHITECTURE.md
@@ -158,19 +158,21 @@ make.
 
 ## Ledgered cases
 
-**nano is not freestanding yet.** It builds where the full runtime builds, on the same
-toolchains, and drops the compiler. Cross-compiling it for a bare-metal target does not work
-today. What stands in the way, measured against arm-none-eabi with newlib: it has no
-`posix_memalign`, `malloc_usable_size` or `madvise`; its libstdc++ is built without threads, so
-`<mutex>` declares nothing and neither `smart_ptr.h`'s ref-count lock nor this folder's
-`contextMutex` compiles; its `uint32_t` is `unsigned long`, which makes every `BitfieldAny`
-conversion and every `vec4<uint32_t>` load ambiguous; and `alloca` needs its own include. Those
-sit in `platform.h`, `smart_ptr.h`, `arraytype.h`, `vectypes.h` and `interop.h` - shared headers
-every platform compiles - so the port is its own change, not a corner of nano.
+**Freestanding costs three shims, all of them in nano's own `das_config.h`.** A toolchain
+built without threads ships `<mutex>` empty, so nano supplies no-op `mutex`, `recursive_mutex`
+and `lock_guard`; `DAS_THREAD_LOCAL` becomes a plain static, because thread-local storage needs
+a runtime the target has none of; and the smart-pointer leak ledger opts out through the
+`DAS_*_SMART_PTR_*` macros, because its counter is a 64-bit atomic that a Cortex-M cannot do and
+arm-none-eabi ships no libatomic for. Each is chosen only when libstdc++ was built without
+gthreads, so a hosted build is untouched.
 
-**`<mutex>` and `<functional>` are still included.** `smart_ptr.h` declares a `static mutex` for
-its ref-count tracking list and `memory_model.h` types its custom-grow hook as `das::function`.
-Shadowing those two headers is part of the freestanding port above.
+**Size is mostly not nano.** On cortex-m4 with `-Os` and `--gc-sections`, the tier-A example
+links to 89,664 bytes of `.text`: about 29 KB is the nano runtime, 10 KB the compiled script,
+and 54 KB the C library. Of that C library the largest single item is the printf machinery
+(`_svfprintf_r`, `_dtoa_r`, `_vfiprintf_r`, ~11.5 KB), reached because the panic path formats
+its message with `vsnprintf`. An integer-only formatter, dropping the heap's `report()`
+virtuals, and resolving libstdc++'s `__throw_*` helpers locally are each worth kilobytes and
+none of them has been done.
 
 **Floats print differently.** The full runtime formats through fmt, which prints the shortest
 round-tripping form; nano prints `%g`. Same value, shorter text. This shows only in log output.

--- a/nano/README.md
+++ b/nano/README.md
@@ -42,9 +42,11 @@ the equivalent program on the full runtime:
 Those numbers include the platform's C runtime, so what they measure is the
 difference nano makes on a host - not an embedded footprint.
 
-**nano does not cross-compile freestanding yet.** It runs on the platforms the
-full runtime runs on, minus the compiler. Building it for a bare-metal target
-needs portability work in the shared headers; `ARCHITECTURE.md` lists what.
+On bare metal it is smaller than any of that suggests. The same `01_pure`
+cross-compiled for a cortex-m4 (`-Os`, `--gc-sections`, arm-none-eabi-gcc 13.2,
+newlib) links to **89,664 bytes** of `.text` - of which the nano runtime is about
+**29 KB**, the compiled script 10 KB, and the C library the remaining 54 KB.
+`ARCHITECTURE.md` says where the C library goes and what is worth trimming.
 
 ## What it leaves out
 

--- a/nano/include/daScript/das_config.h
+++ b/nano/include/daScript/das_config.h
@@ -30,7 +30,52 @@
 #include <setjmp.h>
 
 #include <functional>
+
+// libstdc++ without gthreads - every bare-metal cross-compiler - ships <mutex>
+// empty, and nano is single-threaded there, so its locks are the no-ops they
+// would have been anyway. Any other toolchain gets the real header.
+#if defined(__GLIBCXX__) && !defined(_GLIBCXX_HAS_GTHREADS)
+namespace das {
+    struct mutex {
+        void lock() {}
+        void unlock() {}
+        bool try_lock() { return true; }
+    };
+    struct recursive_mutex {
+        void lock() {}
+        void unlock() {}
+        bool try_lock() { return true; }
+    };
+    template <typename TT> struct lock_guard {
+        explicit lock_guard(TT &) {}
+        lock_guard(const lock_guard &) = delete;
+        lock_guard & operator = (const lock_guard &) = delete;
+    };
+}
+#else
 #include <mutex>
+#endif
+
+#if defined(__GLIBCXX__) && !defined(_GLIBCXX_HAS_GTHREADS)
+// Single-threaded: thread-local storage needs a runtime the target has none of,
+// and the smart-pointer leak ledger needs a 64-bit atomic it cannot do either.
+// Nothing here reads either one - nano reports no leaks.
+// TAG is what gives each declaration its own storage, exactly as the hosted
+// DasThreadLocal uses it - without it every DAS_THREAD_LOCAL of the same type
+// in a translation unit would share one function-local static.
+template <typename TT, unsigned long long TAG> class DasSingleThreaded final {
+public:
+    inline TT & operator * () { static TT value_{}; return value_; }
+    inline TT * operator -> () { return &(**this); }
+};
+#define DAS_THREAD_LOCAL(X)             DasSingleThreaded<X, das::hash_tag_file_name(DAS_FILE_LINE)>
+#define DAS_NEW_SMART_PTR_ID
+#define DAS_DELETE_SMART_PTR_ID
+#define DAS_TRACK_SMART_PTR_ID
+#define DAS_TRACK_SMART_PTR_ID_DTOR
+#define DAS_SMART_PTR_NEW
+#define DAS_SMART_PTR_DELETE
+#endif
 
 namespace das {using namespace std;}
 

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3647,7 +3647,7 @@ namespace das
             macroStackSize = das::max(macroStackSize, 1 * 1024 * 1024);
         }
         thisModule->macroContext = get_context(macroStackSize);
-        thisModule->macroContext->category = uint32_t(das::ContextCategory::macro_context);
+        thisModule->macroContext->category = das::Bitfield(uint32_t(das::ContextCategory::macro_context));
         auto oldAot = policies.aot;
         auto oldHeap = policies.persistent_heap;
         policies.aot = false;


### PR DESCRIPTION
**Behaviour change on every platform: `BitfieldAny` no longer converts implicitly.** Ten constructors become one explicit constructor, so a raw integer assigned to a `Bitfield` is now a compile error. Seven call sites in this tree needed the conversion written down; out-of-tree code that assigns an integer to a bitfield needs the same one-word change.

libDaScriptNano now cross-compiles and links for bare metal. The tier-A standalone example is 89,664 bytes of `.text` on cortex-m4 (`-Os`, `--gc-sections`, arm-none-eabi-gcc 13.2, newlib): about 29 KB of nano runtime, 10 KB of compiled script, and 54 KB of C library. `ci/nano_arm_build.sh` runs in `extended_checks` as the drift tripwire - it is the only freestanding build in CI, so a change that pulls the compiler, fmt, the host's I/O or a thread primitive back into the minimal runtime fails there and nowhere else.

Getting from 588 compile errors to zero was mostly one bug, and it is not nano's. This tree spells the same 32-bit type two ways - fixed-width (`int32_t`) and builtin (`int`) - and each overload set picks one spelling while assuming the other names the same type. That assumption holds on every platform daslang has shipped on, because there `int32_t` IS `int`. It fails on a C library that maps the 32-bit typedefs onto `long`, and it fails in both directions at once: `vec_load`'s builtin-spelled overloads stop matching a fixed-width argument, while `BitfieldAny`'s fixed-width-spelled constructors stop matching a plain `int` and tie between three conversions.

The fixes follow the shape of each case rather than one rule. `vectypes.h` is a rename - its load family serves `vec2`/`vec3`/`vec4`, whose element type is always `float`, `int32_t` or `uint32_t`, so spelling the parameters in those types makes the match exact by construction and changes nothing wherever `int32_t` is `int`. `BitfieldAny` cannot be fixed by spelling, because the caller has an `int` by the language's own rule, so its ten constructors collapse to one explicit constructor. `TDim`'s eight index overloads collapse the same way for the same reason. The AOT emitter now writes bitfield constants as bitfields rather than as the integer behind them.

The rest is ordinary platform work: a C11 `aligned_alloc` arm for targets without `posix_memalign`, `__has_include` instead of a platform list for `<malloc.h>` and `<alloca.h>`, and six `smart_ptr.h` tracking macros made overridable the way `DAS_THREAD_LOCAL` already was. nano's own `das_config.h` supplies no-op locks, a non-TLS `DAS_THREAD_LOCAL` and the smart-pointer opt-out, each chosen only when libstdc++ was built without gthreads, so a hosted build is untouched.

Where to look: the `BitfieldAny` call sites, since that is the one change with a blast radius outside this repo. `cast<Bitfield*>::to` was returning a raw `int32_t` from a function declared to return a bitfield - a silent narrowing that the explicit constructor turned into a compile error.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Cross-compile, which CI could not run before this change: `ci/nano_arm_build.sh` links `nano_01_pure.elf` for cortex-m4. Census run separately with `-fmax-errors=100` over every nano TU to enumerate root causes rather than iterate one error at a time - 588 errors across four causes, now zero.
- Full suite 13979/13988 pass, 0 failed, 9 skipped, re-run after each of the three type changes independently.
- `ctest -L big` (`nano_ctx`, `standalone_ctx`) and `ctest -L small` 109/109 green.
- Every newlib fact was probed, not assumed: `posix_memalign` absent, `malloc_usable_size` present via `<malloc.h>`, `alloca` in `<alloca.h>` only, `aligned_alloc` present, `std::mutex` absent, no libatomic shipped.
- Known red, unrelated and pre-existing: `ctest -L big` also carries `style_lint_style014_long_comment` and `style_lint_style015_long_comment_private`, dead since `utils/lint/main.das` gained an unconditional skip for `utils/lint/tests/` on 2026-07-11. They fail on master too.

### Claims - stated, not tested
- The three freestanding shims are inert on a hosted build: each is inside `#if defined(__GLIBCXX__) && !defined(_GLIBCXX_HAS_GTHREADS)`. Verified by the host build and suite being unchanged; a break would look like a hosted build losing its locks.
- `vectypes.h` is a no-op rename wherever `int32_t` is `int`. Verified by the full suite; a break would look like a vector load selecting a different overload.

### Not done
- Size trimming. The 54 KB of C library is dominated by the printf machinery (`_svfprintf_r`, `_dtoa_r`, `_vfiprintf_r`, 11,528 bytes) reached from the panic path's `vsnprintf`. Two smaller items: the heap's `report()` virtuals (2,076 bytes, never called on nano) and libstdc++'s unwinder (1,216 bytes measured, removable by resolving `std::__throw_*` locally - proven in a scratch build, not landed).
- No example demonstrates a macro doing compile-time work, which is the actual argument for this tier.
- `TDim::operator[]` still takes `int32_t` and is unguarded; only `operator()` was collapsed.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
