### PR TITLE
nightly lint: a finding in the first pass no longer hides the second

### DIFF
--- a/.github/workflows/nightly_lint.yml
+++ b/.github/workflows/nightly_lint.yml
@@ -12,6 +12,10 @@ name: nightly whole-tree lint
 #      consumed nothing" is a true statement, because every consumer's
 #      instantiations feed one ledger.
 #
+# Both passes run on every build, and the job is red if either found something.
+# They report different defect classes, so stopping at the first would hide the
+# second until some later night when pass 1 happens to be clean.
+#
 # The summary's "skipped" count is coverage: a silent shrink is a regression
 # (dasLLVM, dasSMT/z3, macOS-only files surface there, not as reds).
 
@@ -58,6 +62,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: "Build daslang + shared modules"
+        id: build
         # Broadest module set this runner can build — every module missing here
         # moves its .das files from "linted" to the skipped count, so never
         # shrink this list without saying why here.
@@ -90,6 +95,14 @@ jobs:
             -q --silent -j 0 --disable LINT019
 
       - name: "Stale-nolint pass (single process)"
+        # The two passes find different defect classes, so a finding in the first
+        # must not hide the second: run whenever there is a binary to run, and let
+        # the job fail on either. always() is load-bearing — an `if` with no status
+        # function gets an implicit success() and would skip after a red pass 1.
+        # outcome, not conclusion: outcome is the build's real result, while
+        # conclusion reports success for a failed step that continue-on-error waved
+        # through - and a waved-through build leaves no binary to lint with.
+        if: always() && steps.build.outcome == 'success'
         # -j 1 is load-bearing: the nolint-consumption ledger is per-process.
         run: |
           set -eux


### PR DESCRIPTION
The nightly lint job runs two passes that report different defect classes. The first is a parallel rule pass with the stale-nolint rule disabled. The second is single-process, and it is the only scope where "this suppression consumed nothing" is a true statement, because every consumer's instantiations have to feed one ledger.

The second pass was reached only when the first was clean. A failing step skips every step after it, so a finding in pass one silently withdrew pass two for that night. The stale-nolint rule last reported on the 25th. The 26th went red in pass one, pass two never ran, and nothing would have run it again until a night when pass one happened to be clean. Two of the last week's nightlies were red, so that has already happened twice, and the only way to get a verdict out of pass two was to dispatch the workflow by hand.

Pass two now runs whenever the build produced a binary, and the job is red if either pass found something. A red night costs the full runtime instead of stopping early. That is the price of learning everything that is wrong in one triage round rather than one finding per night, and nothing waits on a nightly.

Where to look: the `if:` on the stale-nolint step. `always()` is load-bearing rather than decorative - a condition with no status function gets an implicit `success()` and would still skip after a red first pass. Gating on the build step rather than on `always()` alone keeps the pass from running with no binary to run.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Tested end to end on this branch, since a green run cannot distinguish the fix from the bug. A temporary file carrying one `LINT003` finding was committed, the workflow was dispatched on the branch, and the run was inspected per step: build `success`, fast pass `failure`, stale-nolint pass **`completed`/`failure`** rather than `skipped`, job red. On the old workflow that third step reads `skipped`. The probe commit was dropped before this PR opened; the branch is the workflow change alone.
- The first attempt at that test was inconclusive and is worth recording, because it is a trap for anyone writing another one. The probe was named with a leading underscore, and `scan_das_files` in `utils/lint/main.das` skips any directory entry whose name starts with `_`, so the whole-tree walk never saw it and the fast pass stayed green. Linting the probe by explicit path did report the finding, which is why it looked valid. A probe has to be validated through a directory walk, the way CI discovers files.

### Claims - stated, not tested
- The runtime cost of a red night is stated from the historical step timings rather than measured on a red run: green nightlies take 112-139 minutes, of which the stale pass is 59-78, and red ones stopped at about 50. A red night should now land in the same 112-139 band.

### Not done
- Neither of the recent reds was preventable by a per-PR gate. Both were findings on files the diff did not touch - one a rule firing on unchanged code, one a complexity count moved by a compiler change - which is the gap this nightly exists to cover. This change makes the nightly report completely; it does not make failures rarer.
- The `_`-prefix skip in `scan_das_files` is broader than the documented fixture convention, which is an underscore-led name that also contains `fixture`, and it happens before the skipped counter, so such files appear in neither the linted count nor the skipped count. The header of this workflow treats that count as coverage. Left alone here.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
