### PR TITLE
bitfields: exact-width implicit, cross-width explicit - the freestanding ctor collapse meets AOT

### DIFF
--- a/daslib/aot_cpp.das
+++ b/daslib/aot_cpp.das
@@ -1708,6 +1708,14 @@ class public CppAot : AstVisitor {
             var init_val = isLocalVec(variable._type) ? "v_zero()" : "0";
             if (variable._type.baseType == Type.tFloat16) {
                 init_val = "float16_t(0.f)";
+            } elif (variable._type.baseType == Type.tBitfield64) {
+                init_val = "das::Bitfield64(UINT64_C(0))";
+            } elif (variable._type.baseType == Type.tBitfield16) {
+                init_val = "das::Bitfield16(uint16_t(0))";
+            } elif (variable._type.baseType == Type.tBitfield8) {
+                init_val = "das::Bitfield8(uint8_t(0))";
+            } elif (variable._type.baseType == Type.tBitfield) {
+                init_val = "das::Bitfield(0u)";
             }
             write(*ss, "{cvname} = {init_val}");
         } else {

--- a/include/daScript/misc/arraytype.h
+++ b/include/daScript/misc/arraytype.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 namespace das {
     struct SimNode;
     struct TypeInfo;
@@ -245,8 +247,13 @@ namespace das {
     struct BitfieldAny {
         ST value;
         __forceinline BitfieldAny() {}
-        // one candidate cannot be ambiguous, and explicit keeps narrowing at the call site
-        __forceinline explicit BitfieldAny(ST v) : value(v) {}
+        // exactly ST converts implicitly (bitfield math decays to ST through operator ST&,
+        // and every cast/call boundary must convert back); every other type converts only
+        // through an explicit cast, so implicit narrowing - int included - dies at the call site
+        template <typename QQ, typename std::enable_if<std::is_same<QQ,ST>::value,int>::type = 0>
+        __forceinline BitfieldAny(QQ v) : value(v) {}
+        template <typename QQ, typename std::enable_if<!std::is_same<QQ,ST>::value,int>::type = 0>
+        __forceinline explicit BitfieldAny(QQ v) : value(ST(v)) {}
         __forceinline operator ST &() { return value; }
         __forceinline operator float() const { return float(value); }
         __forceinline operator double() const { return double(value); }

--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -134,10 +134,10 @@ namespace das {
     // special bitfield8 operations
     __forceinline bool __bitfield8_eq  ( Bitfield8 left, Bitfield8 right ) { return left.value == right.value; }
     __forceinline bool __bitfield8_neq ( Bitfield8 left, Bitfield8 right ) { return left.value != right.value; }
-    __forceinline Bitfield8 __bitfield8_not ( Bitfield8 value ) { return Bitfield8(~value.value); }
-    __forceinline Bitfield8 __bitfield8_and ( Bitfield8 left, Bitfield8 right ) { return Bitfield8(left.value & right.value); }
-    __forceinline Bitfield8 __bitfield8_or  ( Bitfield8 left, Bitfield8 right ) { return Bitfield8(left.value | right.value); }
-    __forceinline Bitfield8 __bitfield8_xor ( Bitfield8 left, Bitfield8 right ) { return Bitfield8(left.value ^ right.value); }
+    __forceinline Bitfield8 __bitfield8_not ( Bitfield8 value ) { return Bitfield8(uint8_t(~value.value)); }
+    __forceinline Bitfield8 __bitfield8_and ( Bitfield8 left, Bitfield8 right ) { return Bitfield8(uint8_t(left.value & right.value)); }
+    __forceinline Bitfield8 __bitfield8_or  ( Bitfield8 left, Bitfield8 right ) { return Bitfield8(uint8_t(left.value | right.value)); }
+    __forceinline Bitfield8 __bitfield8_xor ( Bitfield8 left, Bitfield8 right ) { return Bitfield8(uint8_t(left.value ^ right.value)); }
     __forceinline void __bitfield8_setand ( Bitfield8 & left, Bitfield8 right ) { left.value &= right.value; }
     __forceinline void __bitfield8_setor  ( Bitfield8 & left, Bitfield8 right ) { left.value |= right.value; }
     __forceinline void __bitfield8_setxor ( Bitfield8 & left, Bitfield8 right ) { left.value ^= right.value; }
@@ -145,10 +145,10 @@ namespace das {
     // special bitfield16 operations
     __forceinline bool __bitfield16_eq  ( Bitfield16 left, Bitfield16 right ) { return left.value == right.value; }
     __forceinline bool __bitfield16_neq ( Bitfield16 left, Bitfield16 right ) { return left.value != right.value; }
-    __forceinline Bitfield16 __bitfield16_not ( Bitfield16 value ) { return Bitfield16(~value.value); }
-    __forceinline Bitfield16 __bitfield16_and ( Bitfield16 left, Bitfield16 right ) { return Bitfield16(left.value & right.value); }
-    __forceinline Bitfield16 __bitfield16_or  ( Bitfield16 left, Bitfield16 right ) { return Bitfield16(left.value | right.value); }
-    __forceinline Bitfield16 __bitfield16_xor ( Bitfield16 left, Bitfield16 right ) { return Bitfield16(left.value ^ right.value); }
+    __forceinline Bitfield16 __bitfield16_not ( Bitfield16 value ) { return Bitfield16(uint16_t(~value.value)); }
+    __forceinline Bitfield16 __bitfield16_and ( Bitfield16 left, Bitfield16 right ) { return Bitfield16(uint16_t(left.value & right.value)); }
+    __forceinline Bitfield16 __bitfield16_or  ( Bitfield16 left, Bitfield16 right ) { return Bitfield16(uint16_t(left.value | right.value)); }
+    __forceinline Bitfield16 __bitfield16_xor ( Bitfield16 left, Bitfield16 right ) { return Bitfield16(uint16_t(left.value ^ right.value)); }
     __forceinline void __bitfield16_setand ( Bitfield16 & left, Bitfield16 right ) { left.value &= right.value; }
     __forceinline void __bitfield16_setor  ( Bitfield16 & left, Bitfield16 right ) { left.value |= right.value; }
     __forceinline void __bitfield16_setxor ( Bitfield16 & left, Bitfield16 right ) { left.value ^= right.value; }


### PR DESCRIPTION
**Master's full AOT build is red since the freestanding port merged; per-PR CI cannot see it, and tonight's nightly would have been the first witness.**

The freestanding port collapsed `BitfieldAny`'s ten conversion constructors into one `explicit` exact-width constructor. Direct-initialization sites kept compiling, but every copy-initialization boundary in generated AOT code broke: a zero-initialized bitfield local (`Bitfield8 b = 0;`), and every `cast<Bitfield>::from(expr)` where bitfield math had decayed to its storage type through `operator ST&`. The full `test_aot` target is nightly-only, so the first `preflight --full` after the merge found the ~30 red TUs.

The fix keeps the port's intent with a two-constructor shape: the exact-width constructor is implicit, because bitfield math decays to `ST` and every cast and call boundary must convert back; every other width converts only through an explicit cast, so implicit narrowing still dies at the call site while the interpreter's `SimNode_Cast` - a das-level explicit cast - keeps every numeric width. The `aot.h` 8/16-bit helper bodies spell their narrowing (integral promotion turns `~uint8_t` into `int`), and the AOT emitter's zero-default local init emits the constructor form per width instead of a bare `0`.

Where to look: `include/daScript/misc/arraytype.h` (the constructor pair), `include/daScript/simulate/aot.h` (the eight helper bodies), `daslib/aot_cpp.das` (the zero-init spellings).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full `test_aot` (~1900 AOT TUs) compiles and links with zero errors on macOS arm64.
- The full AOT suite: 13060 tests, 13059 passed, 0 failed, 1 skipped (the two `error[50503]` lines in the transcript are expected-failure fixtures asserting those exact errors).

### Claims - stated, not tested
- The cortex-m4 cross-compile was not re-run here; the shape adds no header dependency (`__forceinline` template constructor only), so the freestanding build should be unaffected. A break would surface in `ci/nano_arm_build.sh`.

### Not done
- The `bbatkin/metal-nax-shapes` branch carries this fix as a content-identical commit so its own full-AOT gate is green; the merge dedupes when this lands.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
