### PR TITLE
ast_verify: a dead decl-init call is not a defect - the func invariant scopes to code that simulates

### DIFF
--- a/daslib/ARCHITECTURE.md
+++ b/daslib/ARCHITECTURE.md
@@ -364,6 +364,14 @@ an entry lands here only when no name, shape, or test can carry it.
 - **The two passes' skip sets are complementary**: pre-infer skips `generated` (filled in
   across passes); post-infer skips only `[template]` bodies and dasbind `[extern]` stubs -
   so generated bodies ARE checked post-infer, by nothing else.
+- **A structure's field-default init tree is a declaration, not code**: it never simulates -
+  the generated ctor carries its own inferred clone, which stays fully checked. Infer types
+  the decl init in place but binds its calls only when construction generates the ctor, so a
+  struct nothing constructs legitimately keeps a typed-but-unbound cross-module ctor call
+  there. The post-infer func invariant therefore tolerates calls inside field inits
+  (`in_field_init`, set/cleared around the field walk); every other invariant (types, ats)
+  still applies to them. The same-module shape resolves eagerly and never had the hole -
+  the selftest fixture is cross-module for exactly that reason.
 - **Each check's licensing C++ site** (the checklist requires one per check; record new ones
   here): `ExprOp1.subexpr` - `SimulateVisitor::visit(ExprOp1*)` dereferences;
   `TypeDecl.dim` entries - `TypeDecl::dimConst` sentinel (`ast_typedecl.h`); `ExprFor`

--- a/daslib/ast_verify.das
+++ b/daslib/ast_verify.das
@@ -979,11 +979,21 @@ class private AstPostInferVerifyVisitor : AstVisitor {
     }
 
     def override canVisitStructureFieldInit(st : StructurePtr) : bool {
-        return !st.flags.isTemplate
+        if (st.flags.isTemplate) {
+            return false
+        }
+        in_field_init = true
+        return true
     }
 
     def override canVisitStructure(st : Structure?) : bool {
         return !st.flags.isTemplate
+    }
+
+    in_field_init : bool
+
+    def override visitStructureField(var _str : StructurePtr; var _decl : FieldDeclaration; _last : bool) : void {
+        in_field_init = false
     }
 
     def need_typed(var slot : ExpressionPtr; what : string; at : LineInfo) : void {
@@ -996,7 +1006,7 @@ class private AstPostInferVerifyVisitor : AstVisitor {
     }
 
     def need_func(fn : Function?; what : string; at : LineInfo) : void {
-        if (fn != null) {
+        if (fn != null || in_field_init) {
             return
         }
         report(at, "{what} has an unresolved func after inference")

--- a/utils/internal/ast-fuzz/selftest/uninstantiated_default.das
+++ b/utils/internal/ast-fuzz/selftest/uninstantiated_default.das
@@ -1,0 +1,15 @@
+options gen2
+require daslib/ast_verify
+require uninstantiated_default_dep
+
+// an unconstructed struct's ctor field default, CROSS-module: infer types the decl init but
+// never binds its ctor func (nothing generates the foreign ctor here) - the post-infer walk
+// must not report it; the same-module shape resolves eagerly and never had the hole
+struct Outer {
+    inner : Inner = Inner()
+}
+
+[export]
+def main {
+    print("uninstantiated-default-ok\n")
+}

--- a/utils/internal/ast-fuzz/selftest/uninstantiated_default_dep.das
+++ b/utils/internal/ast-fuzz/selftest/uninstantiated_default_dep.das
@@ -1,0 +1,6 @@
+options gen2
+module uninstantiated_default_dep shared
+
+struct public Inner {
+    v : int = 1
+}

--- a/utils/internal/ast-fuzz/test_ast_fuzz.das
+++ b/utils/internal/ast-fuzz/test_ast_fuzz.das
@@ -174,3 +174,15 @@ def test_generator_runs_and_classifies(t : T?) {
     t |> success(!died(ec, out), "driver itself crashed or hung (exit {ec})\n{out}")
     t |> success(find(out, "run(s) —") >= 0, "driver produced no summary\n{out}")
 }
+
+[test]
+def test_verifier_tolerates_uninstantiated_field_default(t : T?) {
+    // a cross-module ctor in a field default of a struct nothing constructs: infer types the
+    // decl init but never binds the func - the post-infer walk must not report it
+    var out : string
+    let ec = run([BIN, "utils/internal/ast-fuzz/selftest/uninstantiated_default.das"], out, 60.0)
+    t |> success(!died(ec, out), "compile crashed (exit {ec})\n{out}")
+    t |> success(ec == 0, "the fixture must compile and run (exit {ec})\n{out}")
+    t |> success(find(out, "AST verify") < 0, "no verify report on the dead decl init\n{out}")
+    t |> success(find(out, "uninstantiated-default-ok") >= 0, "the fixture ran to its marker\n{out}")
+}


### PR DESCRIPTION
**Clears the standing extended-checks ast-verify red on any PR touching `dasllama_common.das`, and takes the tree-wide verify sweep to zero findings.**

The post-infer func invariant - every `ExprCall` has its function bound after inference - fired on the one tree that never simulates: a structure's field-default init. Infer types the decl init in place, but binds its constructor call only when a construction site generates the ctor. A struct nothing constructs therefore keeps a typed-but-unbound cross-module ctor call in its declaration; the program compiles and runs, and wherever construction does exist, the generated ctor's own inferred clone stays fully checked. The 12-line reproduction is `struct M { tok : Tokenizer = Tokenizer() }` with `Tokenizer` from another module and `M` never constructed - the exact shape of `dasllama_common.das:722`.

The fix scopes the func check to code that can simulate: a flag set and cleared around the structure field walk tolerates unresolved funcs inside field-init trees. Every other invariant there - types, source locations - still applies, so the master `TypeDecl`-location class stays caught. The same-module shape resolves eagerly and never had the hole, which is why the new selftest fixture is cross-module: it reds with the exact production error on the old verifier and runs clean on this one.

Where to look: `daslib/ast_verify.das` (`need_func` + the field-walk flag), `utils/internal/ast-fuzz/selftest/uninstantiated_default*.das` (the failing-first fixture pair), `daslib/ARCHITECTURE.md` (the decl-init invariant, recorded).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The failing-first control: the fixture reds on the unfixed verifier with `ExprCall 'Inner' has an unresolved func after inference`, and runs clean with the fix.
- The ast-fuzz selftest suite: 15/15 (the 14 existing corruption fixtures still report - the verifier's teeth are intact).
- Tree-wide sweep (`--ast-verify-batch` over `daslib` + `tests`): zero findings. The two historical `TypeDecl at` findings (`generators.das`, `typeAlias.das`) were verified fixed upstream before this change - nothing here masks them.
- `modules/dasLLAMA/dasllama/dasllama_common.das` under plain `--ast-verify`: zero findings.

### Not done
- The nightly has no tree-wide verify cell; with the count at zero, a count-must-be-zero gate there becomes cheap to add - ledgered previously.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
