### PR TITLE
nightly: the RelWithDebInfo lane gets a watchdog it can finish under

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -660,11 +660,22 @@ jobs:
           -DCMAKE_C_COMPILER_LAUNCHER=sccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
           -DDAS_LLVM_DISABLED=${{ env.das_llvm_disabled }} \
+          -DDAS_TEST_TIMEOUT=3600 \
           -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
         cmake --build ./build --config RelWithDebInfo --parallel
 
+    # No isolated retry on this lane, and a doubled watchdog on the one pass it
+    # does run. This is the DAS_TRACK_ALLOC build with the free list off, so its
+    # sweep costs about twice a plain Release one, and the hosted Windows runner
+    # swings another ~1.4x night to night: the same ~12.9k tests came in at 1092s
+    # in July and were still only 9472 deep when the 1800s watchdog fired in
+    # August. Isolated mode fares far worse — 1339 worker subprocesses over 6
+    # threads got ~44% through in 6453s, so a retry there cannot finish inside any
+    # budget worth granting it; every firing so far burned ~1.8h and still went
+    # red. One pass with room to finish is the signal; a flake here is re-run by
+    # hand.
     - name: "Test: interpreter"
-      run: cmake --build ./build --config RelWithDebInfo --target run_tests_interpreter || cmake --build ./build --config RelWithDebInfo --target run_tests_interpreter_isolated
+      run: cmake --build ./build --config RelWithDebInfo --target run_tests_interpreter
 
     - name: "Small C++ Tests"
       run: ctest --test-dir build --build-config RelWithDebInfo -L small --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,21 +7,31 @@
 # retry: `ninja run_tests_X || ninja run_tests_X_isolated`.
 # cmake has no OR/retry primitive inside a single target, so the `||` lives in CI.
 # NOTE: --timeout is dastest's GLOBAL suite watchdog (wall clock for the whole
-# run), not per test. The interpreter pair is sized for the slowest lane,
-# windows-32 Debug on the 4-core hosted runner (~16 min as of 2026-07).
+# run), not per test. The defaults below fit every lane whose interpreter sweep
+# lands well inside them; a lane that needs more says so at configure time via
+# -DDAS_TEST_TIMEOUT / -DDAS_TEST_TIMEOUT_ISOLATED rather than inflating the
+# budget everywhere - a watchdog only catches a hang while it is still tight.
+# The RelWithDebInfo Windows nightly is the lane that needs it: DAS_TRACK_ALLOC
+# with the free list off roughly doubles the sweep, and the hosted runner adds
+# another ~1.4x of its own variance on top.
 if(NOT DAS_TOOLS_DISABLED)
+    set(DAS_TEST_TIMEOUT 1800 CACHE STRING
+        "dastest global suite watchdog, seconds, for run_tests_interpreter")
+    set(DAS_TEST_TIMEOUT_ISOLATED 5400 CACHE STRING
+        "dastest global suite watchdog, seconds, for run_tests_interpreter_isolated")
+
     set(_DAS_DASTEST  ${PROJECT_SOURCE_DIR}/dastest/dastest.das)
     set(_DAS_TEST_DIR ${PROJECT_SOURCE_DIR}/tests)
     set(_DAS_TEST_COMMON --color --failures-only --test ${_DAS_TEST_DIR})
 
     add_custom_target(run_tests_interpreter
-        COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -- ${_DAS_TEST_COMMON} --timeout 1800
+        COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -- ${_DAS_TEST_COMMON} --timeout ${DAS_TEST_TIMEOUT}
         DEPENDS daslang
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Running tests (interpreter)"
     )
     add_custom_target(run_tests_interpreter_isolated
-        COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -- ${_DAS_TEST_COMMON} --isolated-mode --timeout 5400
+        COMMAND $<TARGET_FILE:daslang> ${_DAS_DASTEST} -- ${_DAS_TEST_COMMON} --isolated-mode --timeout ${DAS_TEST_TIMEOUT_ISOLATED}
         DEPENDS daslang
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Running tests (interpreter, isolated retry)"


### PR DESCRIPTION
The Windows RelWithDebInfo nightly has been failing on its interpreter step, and the cause is the budget, not the tests. `--timeout` is dastest's global suite watchdog for a whole run. That lane is the heap-tracking build: `DAS_TRACK_ALLOC` with the free list off costs about twice a plain Release sweep, and the hosted runner swings about 1.4x from night to night on top of that. The same roughly 12.9k tests finished in 1092s on July 28 and were still only 9472 deep when the 1800s watchdog fired on August 26. Four of the last five nightlies died there with zero test failures reported.

Rather than raise the budget for every lane, the two interpreter watchdogs become cache variables at their current values, and this one lane configures `-DDAS_TEST_TIMEOUT=3600`. A watchdog only catches a hang while it stays tight, so the lanes that fit inside 1800s keep it.

The isolated retry is removed on this lane only. Isolated mode runs 1339 worker subprocesses over 6 threads and reached about 44 percent in 6453s, so no budget worth granting lets it finish. Every firing so far burned about 1.8 hours and still ended red, and its timeout report buries the first pass output that names the actual failing test.

Where to look: the new cache variables in `tests/CMakeLists.txt`, and the configure plus test steps of `build_windows_relwithdebinfo_nightly` in `.github/workflows/build.yml`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Configure-level check, both directions: a default configure emits `--timeout 1800` for `run_tests_interpreter` and `--timeout 5400` for the isolated target; a configure with `-DDAS_TEST_TIMEOUT=3600` emits 3600 for the first and leaves the isolated one at 5400. The AOT targets keep their own 1800.
- No preflight run. The diff changes one CMake variable and one workflow job; it touches no source, no `.das`, and no test.

### Claims - stated, not tested
- 3600s is enough for this lane. Derived from the observed worst rate, 9472 tests in 1800s on August 26, which extrapolates to about 2450s for the full sweep. A break looks like the same step timing out again, and the report will say how many tests it reached.
- Removing the isolated retry loses no real signal here. It rests on the retry never once having completed on this lane in the runs examined, not on a run that proves it would have passed. A break looks like a flaky test reddening the nightly where the retry would have absorbed it.

### Not done
- On August 26 this lane timed out at 9472 of 12879 tests and the job still reported success: the watchdog printed its report, then the process exited 0 with no `exit(N)` line and no isolated retry. Not reproducible here, 3 of 3 macOS runs exit 1, so the mechanism is unnamed and nothing is guessed at. Raising the budget makes firings rare; the observation is ledgered.
- dastest ignores an unknown command-line flag silently and exits 0. A typo such as `--timout 1800` therefore runs the whole suite with no watchdog at all and reports green, which is the same class of silent loss this PR exists to make rarer. Surfaced while triaging the review comment on the new cache variables; off this PR's surface, so it is ledgered rather than fixed here. A well-formed but non-numeric value is already safe: dastest names the flag and exits 1.
- Last night's other nightly failures are unrelated to this change and have their own fixes: the daspkg index sweep broke because `dasDuckDB` stopped compiling against master when the location-less `TypeDecl(Type)` constructor was removed, fixed in `borisbat/dasDuckDB` pull request 4; extended checks broke on a CRLF fixture problem and a doc-verify page, fixed in pull requests 3878 and 3879.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
