### PR TITLE
gen1-to-gen2: the converter fixtures check out LF everywhere

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,9 @@ daslib/_aot_generated/*.cpp binary
 modules/dasClangBind/src/*.cpp text eol=lf
 modules/dasClangBind/src/*.h text eol=lf
 modules/dasClangBind/src/*.inc text eol=lf
+
+# The v1 -> gen2 converter preserves whatever line endings its input had, and
+# its suite proves that by converting an LF fixture and a CRLF twin it builds
+# from that same fixture. Under autocrlf=true the fixtures check out as CRLF,
+# which fails the LF expectations and gives the twin doubled carriage returns.
+utils/gen1-to-gen2/tests/_fixture_*.das text eol=lf


### PR DESCRIPTION
Four tests in `utils/gen1-to-gen2` fail on Windows and pass everywhere else. The converter preserves whatever line endings its input had, and the suite proves that by converting an LF fixture and then a CRLF twin it builds from that same fixture. A Windows checkout runs with `core.autocrlf=true`, so the fixtures arrive as CRLF: the LF expectations fail, and the twin gets doubled carriage returns because its source was already CRLF.

The four fixtures are pinned to LF in `.gitattributes`, the same way shell scripts and the dasClangBind generated sources already are. Making the tests ending-agnostic was the alternative and it is the wrong one: the suite needs one input whose endings it knows, or the CRLF twin has nothing to be compared against.

This lane is the extended-checks windows cell, which runs on the nightly cron only, so no per-PR lane ever saw it. It has been red since the converter moved to daslang.

Where to look: the one new rule at the end of `.gitattributes`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Reproduced the exact Windows failure on macOS by rewriting the four fixtures to CRLF in place: 81 tests, 77 passed, 4 failed, with the same split the nightly reports - 3 in `test_convert.das`, 1 in `test_stmt.das`. Restoring the fixtures returns 81 of 81.
- End-to-end check of the rule itself: a local clone made with `-c core.autocrlf=true` checks the four fixtures out as LF while every other `.das` in the tree, including `test_convert.das` and `daslib/fio.das`, checks out as CRLF. The rule fires, and it fires only on the fixtures.
- No preflight run. The diff is one line of `.gitattributes` and touches no source.

### Claims - stated, not tested
- CRLF in the test sources themselves is harmless. The nightly runs with both the sources and the fixtures as CRLF and fails exactly the four tests that the CRLF-fixture-only repro fails, so nothing is left over for the sources to explain. A break would look like a fifth failure appearing on the windows lane that this repro does not produce.

### Not done
- No new test. The four existing tests are the test: they fail without this rule on any autocrlf checkout and pass with it.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
