### PR TITLE
dasLLAMA tutorial 14: the rows-seam block names a budget the page has

### DIFF
--- a/doc/source/reference/tutorials/dasLLAMA_14_vision_chat.rst
+++ b/doc/source/reference/tutorials/dasLLAMA_14_vision_chat.rst
@@ -115,7 +115,7 @@ the spliced turn. That is the path for a scheduler that owns its own embedder:
 
 .. code-block:: das
 
-   var chat2 = create_chat(m, "", N_GEN)
+   var chat2 = create_chat(m, "", 96l)
    add_user_image_rows(m, chat2, img_rows, n_img, grid)
    add_user(chat2, prompt)
 


### PR DESCRIPTION
The pre-encoded-rows block on the vision-chat tutorial page arrived carrying `N_GEN`. That is the companion tutorial's module-level constant, and this page never introduces it: its two other `create_chat` lines both spell the literal `96l`. doc-verify compiles every das block on a page against the `given` list at its top, so the block failed on `error[30838]: can't locate variable 'N_GEN'` and took the page red.

Spelling the literal is the fix rather than adding a `given` line, because it is what the page already does in both other places the generation budget appears.

The extended-checks linux and darwin lanes both die on this one page, out of 3274 pages and 409 with das blocks. That step is nightly-only, so no per-PR lane sees it.

Where to look: one line inside the last `code-block:: das` on the page.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- `doc-verify --page dasLLAMA_14_vision_chat` reports 1 red before and 1 green after, with the `error[30838]` line gone from the report.
- No preflight run and no full doc sweep. The nightly's own sweep already tells us this was the only red page on the current master tip, and the change is one literal inside one code block.

### Not done
- The companion source `tutorials/dasLLAMA/14_vision_chat.das` keeps `N_GEN`, which is correct there: it declares the constant. The page and the source diverge on this one token by design, the same way they already do at the page's two other `create_chat` lines.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
