### PR TITLE
lcpp reference pin: b10659

### DIFF
--- a/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
+++ b/modules/dasLLAMA/benchmarks/setup_lcpp_ref.das
@@ -17,7 +17,7 @@ require daslib/strings_boost
 // Point lcpp_bench --ref (or LLAMA_BENCH) at the reported binaries.
 
 // bump deliberately; the sha a record carries is what pins its ref, this is just the default
-let DEFAULT_REF_SHA = "3737e41370da1830a44c663f9929a0f27591ffa6"
+let DEFAULT_REF_SHA = "6fdd0ac8907fd973a42b876357823ad2124cd8ed"   // b10659
 
 [CommandLineArgs]
 struct Args {


### PR DESCRIPTION
`DEFAULT_REF_SHA` (`modules/dasLLAMA/benchmarks/setup_lcpp_ref.das`) moves from the pre-M5 `3737e41` to **b10659** (`6fdd0ac8`) - the llama.cpp build the zen2 vulkan work races against. One constant; recorded rows keep the sha they were minted with, so no record or manifest changes.

:robot: Generated with [Claude Code](https://claude.com/claude-code)