### PR TITLE
river run: craft orientation fixes + seamless zone transitions; news entry

### DIFF
--- a/examples/games/river_run/gameplay.das
+++ b/examples/games/river_run/gameplay.das
@@ -202,8 +202,8 @@ def spawn_enemy_boat(pos : float3) {
     }
 }
 
-def spawn_enemy_plane(pos : float3) {
-    let spd = PLANE_SPEED * section_speed_mult()
+def spawn_enemy_plane(pos : float3; section : int) {
+    let spd = PLANE_SPEED * section_speed_mult_for(section)
     create_entity() @(eid, cmp) {
         apply_decs_template(cmp, EnemyPlane(
             pos = pos,
@@ -233,7 +233,7 @@ def spawn_fuel_depot(pos : float3) {
     }
 }
 
-def spawn_bridge(pos : float3) {
+def spawn_bridge(pos : float3; section : int) {
     let seg = sample_river_segment(pos.y)
     let bounds = (
         seg.split
@@ -260,7 +260,7 @@ def spawn_bridge(pos : float3) {
     )
     let bridge_health = min(
         BRIDGE_HEALTH_MAX,
-        BRIDGE_HEALTH_MIN + current_section / BRIDGE_HEALTH_STEP_SECTIONS
+        BRIDGE_HEALTH_MIN + section / BRIDGE_HEALTH_STEP_SECTIONS
     )
     create_entity() @(eid, cmp) {
         apply_decs_template(cmp, Bridge(
@@ -404,23 +404,25 @@ def find_safe_respawn_pos(from_pos : float3) : float3 {
     return float3(x, from_pos.y, PLAYER_Z)
 }
 
-def spawn_section_objects() {
-    // Determine a Y range ahead of player to place objects
-    let base_y = player_pos.y + 40.0
-    let section_mult = float(min(current_section + 1, 5))
-    spawn_section_bridges(base_y, section_mult)
+// Populate one section band of world starting at base_y. Bands are anchored to
+// zone boundaries and spawned a full section before the player can reach them
+// -- past the fog and the far plane -- so a zone's content is already standing
+// out there by the time it comes into view, instead of popping in mid-screen.
+def spawn_section_objects(section : int; base_y : float) {
+    let section_mult = float(min(section + 1, 5))
+    spawn_section_bridges(section, base_y, section_mult)
     spawn_section_islands(base_y, section_mult)
     spawn_section_trees(base_y)
     spawn_section_houses(base_y)
     spawn_section_depots(base_y)
-    spawn_section_enemies(base_y, section_mult)
+    spawn_section_enemies(section, base_y, section_mult)
 }
 
-def spawn_section_bridges(base_y, section_mult : float) {
+def spawn_section_bridges(section : int; base_y, section_mult : float) {
     let bridge_count = int(1.0 + section_mult * 0.4)
     for (i in range(bridge_count)) {
         let by = base_y + SECTION_LENGTH * (float(i + 1) / float(bridge_count + 1))
-        spawn_bridge(float3(0.0, by, BRIDGE_Z))
+        spawn_bridge(float3(0.0, by, BRIDGE_Z), section)
     }
     commit()
 }
@@ -593,10 +595,10 @@ def boat_spot_blocked(candidate : float3) : bool {
 }
 
 // Enemies — staggered ahead
-def spawn_section_enemies(base_y, section_mult : float) {
+def spawn_section_enemies(section : int; base_y, section_mult : float) {
     let boat_count = int(2.0 + section_mult * 1.0)
-    let plane_count = (current_section >= 1 ? int(1.0 + section_mult * 0.6) : 0)
-    let heli_count = (current_section >= 2 ? int(section_mult * 0.5) : 0)
+    let plane_count = (section >= 1 ? int(1.0 + section_mult * 0.6) : 0)
+    let heli_count = (section >= 2 ? int(section_mult * 0.5) : 0)
 
     for (_i in range(boat_count)) {
         for (_try in range(10)) {
@@ -614,7 +616,7 @@ def spawn_section_enemies(base_y, section_mult : float) {
         let ey = base_y + random_range(5.0, SECTION_LENGTH - 5.0)
         let bounds = river_clamp_x_for(ey, random_sign() * 20.0)
         let side_x = (random_f() < 0.5 ? bounds.x - 3.0 : bounds.y + 3.0)
-        spawn_enemy_plane(float3(side_x, ey, PLANE_Z))
+        spawn_enemy_plane(float3(side_x, ey, PLANE_Z), section)
     }
     for (_i in range(heli_count)) {
         let ey = base_y + random_range(15.0, SECTION_LENGTH - 15.0)
@@ -661,7 +663,10 @@ def reset_game() {
 
     global_rng_seed = uint(get_uptime() * 1000.0)
     init_river()
-    spawn_section_objects()
+    // Populate the opening section and the one after it, so the first horizon
+    // is already continuous; each crossing then tops up one section ahead.
+    spawn_section_objects(0, player_pos.y + 40.0)
+    spawn_section_objects(1, player_pos.y + SECTION_LENGTH + 40.0)
     game_state = GameState.playing
 }
 
@@ -849,8 +854,10 @@ def update_section() {
         if (current_section >= MAX_SECTIONS) {
             game_state = GameState.win_state
             restart_input_lock = 1.5
-        } else {
-            spawn_section_objects()
+        } elif (current_section + 1 < MAX_SECTIONS) {
+            // The section just entered was populated a boundary ago; extend the
+            // world by the NEXT one, still beyond the fog and the far plane.
+            spawn_section_objects(current_section + 1, player_pos.y + (SECTION_LENGTH - section_dist) + 40.0)
         }
     }
 }
@@ -1518,9 +1525,32 @@ def private jet_palette() {
 // Craft bank into a turn. Purely cosmetic, but it is most of what makes the
 // helicopter feel like it is being flown rather than slid.
 def private player_orientation() : float4 {
-    let roll = clamp(-player_vel.x * 0.075, -0.55, 0.55)
+    let roll = clamp(player_vel.x * 0.075, -0.55, 0.55)
     let pitch = clamp((player_fwd_speed - PLAYER_FWD_SPEED_MIN) * 0.018, 0.0, 0.22)
     return quat_mul(quat_y_rot(roll), quat_x_rot(-pitch))
+}
+
+// Enemy craft face where they are going (boats, jets) or the player
+// (helicopters). The models are authored nose toward +Y, so facing is a
+// quarter or half turn around Z. Heel, bob and bank compose on top in model
+// space; the heli drift is the one world-space lean -- it tracks the player
+// along world X, and under the half turn a model-space roll would lean the
+// wrong way. Shadows use the same orientation.
+def private boat_orientation(patrol_dir, pos_x, game_time : float) : float4 {
+    let face = quat_z_rot(-patrol_dir * PI * 0.5)
+    let heel = quat_y_rot(patrol_dir * 0.14)
+    let bob = quat_x_rot(sin(game_time * 1.7 + pos_x) * 0.05)
+    return quat_mul(face, quat_mul(heel, bob))
+}
+
+def private plane_orientation(vel_x : float) : float4 {
+    let dir = (vel_x >= 0.0 ? 1.0 : -1.0)
+    return quat_mul(quat_z_rot(-dir * PI * 0.5), quat_y_rot(dir * 0.30))
+}
+
+def private enemy_heli_orientation(drift_x : float) : float4 {
+    let drift = quat_y_rot(clamp(drift_x * 0.06, -0.45, 0.45))
+    return quat_mul(drift, quat_z_rot(PI))
 }
 
 // --- Shadow map pass ---
@@ -1529,24 +1559,24 @@ def private player_orientation() : float4 {
 // shadows are gone: props now shade each other and the banks.
 
 // Aircraft and boats: the movers, whose shadows track the action.
-def private shadow_cast_craft() {
+def private shadow_cast_craft(game_time : float) {
     if (player_respawn_timer <= PLAYER_RESPAWN_BLINK) {
         draw_shadow_caster(player_pos, float3(PLAYER_SIZE * 1.85), player_orientation())
         geo_heli |> draw_geometry_fragment()
     }
 
     query() $(b : EnemyBoat) {
-        draw_shadow_caster(b.pos, float3(BOAT_SIZE * 1.25), quat_z_rot(b.patrol_dir * 0.12))
+        draw_shadow_caster(b.pos, float3(BOAT_SIZE * 1.25), boat_orientation(b.patrol_dir, b.pos.x, game_time))
         geo_gunboat |> draw_geometry_fragment()
     }
 
     query() $(p : EnemyPlane) {
-        draw_shadow_caster(p.pos, float3(PLANE_SIZE * 1.35))
+        draw_shadow_caster(p.pos, float3(PLANE_SIZE * 1.35), plane_orientation(p.vel.x))
         geo_jet |> draw_geometry_fragment()
     }
 
     query() $(h : EnemyHelicopter) {
-        draw_shadow_caster(h.pos, float3(ENEMY_HELI_SIZE * 1.7), quat_y_rot(sin(h.hover_phase) * 0.2))
+        draw_shadow_caster(h.pos, float3(ENEMY_HELI_SIZE * 1.7), enemy_heli_orientation(h.target_x - h.pos.x))
         geo_heli |> draw_geometry_fragment()
     }
 
@@ -1613,11 +1643,11 @@ def private shadow_cast_obstacles() {
     }
 }
 
-def render_shadow_casters() {
+def render_shadow_casters(game_time : float) {
     glUseProgram(shadow_program)
     active_program = shadow_program
     render_river_shadow()
-    shadow_cast_craft()
+    shadow_cast_craft(game_time)
     shadow_cast_scenery()
     shadow_cast_obstacles()
 }
@@ -1647,24 +1677,19 @@ def render_enemies(game_time : float) {
 
     query() $(b : EnemyBoat) {
         boat_palette()
-        // Heel the hull into its patrol direction and let it ride the swell.
-        let heel = quat_y_rot(b.patrol_dir * 0.14)
-        let bob = quat_x_rot(sin(game_time * 1.7 + b.pos.x) * 0.05)
-        draw_prop(b.pos, float3(BOAT_SIZE * 1.25), float3(1.0), quat_mul(heel, bob), MAT_HULL)
+        draw_prop(b.pos, float3(BOAT_SIZE * 1.25), float3(1.0), boat_orientation(b.patrol_dir, b.pos.x, game_time), MAT_HULL)
         geo_gunboat |> draw_geometry_fragment()
     }
 
     query() $(p : EnemyPlane) {
         jet_palette()
-        let bank = quat_y_rot(clamp(p.vel.x * 0.10, -0.5, 0.5))
-        draw_prop(p.pos, float3(PLANE_SIZE * 1.35), float3(1.0), bank, MAT_METAL)
+        draw_prop(p.pos, float3(PLANE_SIZE * 1.35), float3(1.0), plane_orientation(p.vel.x), MAT_METAL)
         geo_jet |> draw_geometry_fragment()
     }
 
     query() $(h : EnemyHelicopter) {
         enemy_heli_palette()
-        let drift = quat_y_rot(clamp((h.target_x - h.pos.x) * 0.06, -0.45, 0.45))
-        draw_prop(h.pos, float3(ENEMY_HELI_SIZE * 1.7), float3(1.0), drift, MAT_HULL)
+        draw_prop(h.pos, float3(ENEMY_HELI_SIZE * 1.7), float3(1.0), enemy_heli_orientation(h.target_x - h.pos.x), MAT_HULL)
         geo_heli |> draw_geometry_fragment()
     }
 

--- a/examples/games/river_run/main.das
+++ b/examples/games/river_run/main.das
@@ -274,7 +274,7 @@ def render_frame(game_time : float) {
     apply_environment(game_time)
 
     begin_shadow_pass()
-    render_shadow_casters()
+    render_shadow_casters(game_time)
     end_shadow_pass()
 
     begin_scene_pass(env_now.horizon_color)

--- a/examples/games/river_run/river.das
+++ b/examples/games/river_run/river.das
@@ -7,23 +7,23 @@ require rr_globals public
 // River is defined by a ring of RiverSegment, each with left/right bank X at a world Y.
 // Banks are rendered as a triangle strip rebuilt each frame.
 
-def river_section_amplitude() : float {
-    return 1.5 + float(min(current_section, 5)) * 0.5
+def river_section_amplitude(sec : int) : float {
+    return 1.5 + float(min(sec, 5)) * 0.5
 }
 
-def river_section_frequency() : float {
-    return 0.018 + float(min(current_section, 6)) * 0.003
+def river_section_frequency(sec : int) : float {
+    return 0.018 + float(min(sec, 6)) * 0.003
 }
 
-def river_target_half_width() : float {
-    let s = float(min(current_section, 8))
+def river_target_half_width(sec : int) : float {
+    let s = float(min(sec, 8))
     // Start wider/easier in section 0 and gradually narrow with progression.
     let base = (RIVER_HALF_WIDTH_MAX + 1.15) - s * 0.33
     return clamp(base, RIVER_HALF_WIDTH_MIN + 0.75, RIVER_HALF_WIDTH_MAX + 1.8)
 }
 
-def pick_split_half() : float {
-    let s = float(min(current_section, 9))
+def pick_split_half(sec : int) : float {
+    let s = float(min(sec, 9))
     // Section 0 keeps split center narrow (wider channels); later sections can narrow channels more.
     let min_half = 0.68 + s * 0.09
     let max_half = min(3.15, 1.42 + s * 0.17)
@@ -48,6 +48,8 @@ def init_river() {
     river_split_hold = 0.0
     river_first_split_pending = true
     river_first_split_start_y = player_pos.y + random_range(95.0, 150.0)
+    river_ripple_phase = 0.0
+    river_ripple_amp = river_section_amplitude(0)
 
     for (_i in range(RIVER_SEGMENTS_COUNT)) {
         advance_river_one()
@@ -56,34 +58,38 @@ def init_river() {
 }
 
 def advance_river_one() {
+    // Shape parameters follow the section that OWNS this segment's Y, not the
+    // one the player is in -- the ring runs a couple of sections ahead, and the
+    // river has to change character at the zone boundary, not at the player.
+    let sec = section_for_y(river_gen_y)
     // Gradually drift center and width toward targets
     river_center_x += (river_center_target - river_center_x) * 0.15
     river_half_width += (river_width_target - river_half_width) * 0.12
 
     // Occasionally pick new targets
     if (random_f() < 0.12) {
-        let max_drift = RIVER_CENTER_DRIFT_MAX - float(min(current_section, 5)) * 0.3
+        let max_drift = RIVER_CENTER_DRIFT_MAX - float(min(sec, 5)) * 0.3
         river_center_target = random_range(-max_drift, max_drift)
     }
     if (random_f() < 0.12) {
-        let lo = max(RIVER_HALF_WIDTH_MIN + 0.6, river_target_half_width() - 2.2)
-        let hi = min(RIVER_HALF_WIDTH_MAX + 2.2, river_target_half_width() + 2.4)
+        let lo = max(RIVER_HALF_WIDTH_MIN + 0.6, river_target_half_width(sec) - 2.2)
+        let hi = min(RIVER_HALF_WIDTH_MAX + 2.2, river_target_half_width(sec) + 2.4)
         river_width_target = random_range(lo, hi)
     }
 
     // Force one split in section 0 once we get away from spawn.
     if (river_first_split_pending && river_gen_y >= river_first_split_start_y) {
         river_split_target = true
-        river_split_half = pick_split_half()
+        river_split_half = pick_split_half(sec)
         river_split_hold = random_range(90.0, 170.0)
         river_first_split_pending = false
     }
 
     // Split / merge events are allowed from section 0 onward.
-    let split_chance = 0.035 + float(min(current_section, 6)) * 0.008
+    let split_chance = 0.035 + float(min(sec, 6)) * 0.008
     if (!river_first_split_pending && !river_split_target && river_split_blend <= 0.01 && random_f() < split_chance) {
         river_split_target = true
-        river_split_half = pick_split_half()
+        river_split_half = pick_split_half(sec)
         river_split_hold = random_range(90.0, 190.0)
     }
     if (river_split_target && river_split_blend >= 0.99) {
@@ -93,7 +99,7 @@ def advance_river_one() {
         }
     }
     if (river_split_target && random_f() < 0.10) {
-        river_split_half = pick_split_half()
+        river_split_half = pick_split_half(sec)
     }
 
     let split_speed = 0.10
@@ -105,16 +111,16 @@ def advance_river_one() {
     }
 
     // Add sine wave ripple on top
-    let amp = river_section_amplitude()
-    let freq = river_section_frequency()
-    let ripple = sin(river_gen_y * freq) * amp
+    river_ripple_amp += (river_section_amplitude(sec) - river_ripple_amp) * 0.06
+    river_ripple_phase += river_section_frequency(sec) * SEGMENT_LENGTH
+    let ripple = sin(river_ripple_phase) * river_ripple_amp
 
     let center_line = river_center_x + ripple
     let left_x = center_line - river_half_width
     let right_x = center_line + river_half_width
 
     // Early sections guarantee roomier split channels; later sections may get tighter.
-    let min_channel_half = max(2.1, 3.25 - float(min(current_section, 8)) * 0.14)
+    let min_channel_half = max(2.1, 3.25 - float(min(sec, 8)) * 0.14)
     let max_split_half = max(river_half_width - min_channel_half, 0.0)
     let split_wave = 0.9 + 0.1 * sin(river_gen_y * 0.03)
     let split_half = min(max_split_half, river_split_half * river_split_blend * split_wave)

--- a/examples/games/river_run/rr_globals.das
+++ b/examples/games/river_run/rr_globals.das
@@ -41,7 +41,9 @@ let RIVER_HALF_WIDTH_MAX = 7.0
 let RIVER_HALF_WIDTH_MIN = 3.0
 let RIVER_CENTER_DRIFT_MAX = 3.5
 let SEGMENT_LENGTH = 6.0
-let RIVER_SEGMENTS_COUNT = 52
+// Enough ring to keep real segments under everything prespawned one full
+// section ahead (advance keeps ~4 segments behind the player).
+let RIVER_SEGMENTS_COUNT = 96
 let SECTION_LENGTH = 240.0
 let MAX_SECTIONS = 10
 
@@ -340,6 +342,10 @@ var @live river_split_half = 0.0
 var @live river_split_hold = 0.0
 var @live river_first_split_pending = true
 var @live river_first_split_start_y = 0.0
+// Ripple phase is integrated segment by segment (and the amplitude eased), so
+// a per-section frequency change bends the river instead of stepping it.
+var @live river_ripple_phase = 0.0
+var @live river_ripple_amp = 1.5
 
 var tick_dt = 0.0
 // Effect-inspection rig: with fx_freeze set, the world and its particles both
@@ -615,8 +621,22 @@ def get_fog_color() : float3 {
     return env_now.fog_color
 }
 
+def section_speed_mult_for(section : int) : float {
+    return 1.0 + float(section) * 0.15
+}
+
 def section_speed_mult() : float {
-    return 1.0 + float(current_section) * 0.15
+    return section_speed_mult_for(current_section)
+}
+
+// Which section owns a world Y, anchored to the next boundary ahead of the
+// player -- prespawned content and river generation agree on zone edges.
+def section_for_y(world_y : float) : int {
+    let ahead = world_y - (player_pos.y + (SECTION_LENGTH - section_dist))
+    if (ahead < 0.0) {
+        return current_section
+    }
+    return min(current_section + 1 + int(ahead / SECTION_LENGTH), MAX_SECTIONS - 1)
 }
 
 def add_screen_shake(amount : float) {

--- a/examples/games/river_run/rr_live.das
+++ b/examples/games/river_run/rr_live.das
@@ -136,7 +136,7 @@ def cmd_set_section(input : JsonValue?) : JsonValue? {
     current_section = clamp(args.section, 0, MAX_SECTIONS - 1)
     section_dist = 0.0
     set_env_immediate(section_idx())
-    spawn_section_objects()
+    spawn_section_objects(current_section, player_pos.y + 40.0)
     commit()
     return JV(args)
 }
@@ -207,13 +207,13 @@ def cmd_spawn(input : JsonValue?) : JsonValue? {
     if (args.kind == SpawnKind.boat) {
         spawn_enemy_boat(float3(x, y, BOAT_Z))
     } elif (args.kind == SpawnKind.plane) {
-        spawn_enemy_plane(float3(x, y, PLANE_Z))
+        spawn_enemy_plane(float3(x, y, PLANE_Z), current_section)
     } elif (args.kind == SpawnKind.heli) {
         spawn_enemy_heli(float3(x, y, ENEMY_HELI_Z))
     } elif (args.kind == SpawnKind.depot) {
         spawn_fuel_depot(float3(x, y, FUEL_DEPOT_Z))
     } elif (args.kind == SpawnKind.bridge) {
-        spawn_bridge(float3(0.0, y, BRIDGE_Z))
+        spawn_bridge(float3(0.0, y, BRIDGE_Z), current_section)
     } elif (args.kind == SpawnKind.island) {
         spawn_island(float3(x, y, ISLAND_Z))
     } elif (args.kind == SpawnKind.tree) {

--- a/site/_news/2026-08-27-while-we-wait-for-0-6-4-play-river-run.md
+++ b/site/_news/2026-08-27-while-we-wait-for-0-6-4-play-river-run.md
@@ -1,0 +1,6 @@
+---
+date: 2026-08-27
+tag: examples
+title: While we wait for 0.6.4 - there is a new classic to play. River Run - fly the gunship, thread the bridges, watch the fuel.
+link: /examples.html?example=river_run
+---

--- a/web/examples/ui/samples/examples/river_run/gameplay.das
+++ b/web/examples/ui/samples/examples/river_run/gameplay.das
@@ -202,8 +202,8 @@ def spawn_enemy_boat(pos : float3) {
     }
 }
 
-def spawn_enemy_plane(pos : float3) {
-    let spd = PLANE_SPEED * section_speed_mult()
+def spawn_enemy_plane(pos : float3; section : int) {
+    let spd = PLANE_SPEED * section_speed_mult_for(section)
     create_entity() @(eid, cmp) {
         apply_decs_template(cmp, EnemyPlane(
             pos = pos,
@@ -233,7 +233,7 @@ def spawn_fuel_depot(pos : float3) {
     }
 }
 
-def spawn_bridge(pos : float3) {
+def spawn_bridge(pos : float3; section : int) {
     let seg = sample_river_segment(pos.y)
     let bounds = (
         seg.split
@@ -260,7 +260,7 @@ def spawn_bridge(pos : float3) {
     )
     let bridge_health = min(
         BRIDGE_HEALTH_MAX,
-        BRIDGE_HEALTH_MIN + current_section / BRIDGE_HEALTH_STEP_SECTIONS
+        BRIDGE_HEALTH_MIN + section / BRIDGE_HEALTH_STEP_SECTIONS
     )
     create_entity() @(eid, cmp) {
         apply_decs_template(cmp, Bridge(
@@ -404,23 +404,25 @@ def find_safe_respawn_pos(from_pos : float3) : float3 {
     return float3(x, from_pos.y, PLAYER_Z)
 }
 
-def spawn_section_objects() {
-    // Determine a Y range ahead of player to place objects
-    let base_y = player_pos.y + 40.0
-    let section_mult = float(min(current_section + 1, 5))
-    spawn_section_bridges(base_y, section_mult)
+// Populate one section band of world starting at base_y. Bands are anchored to
+// zone boundaries and spawned a full section before the player can reach them
+// -- past the fog and the far plane -- so a zone's content is already standing
+// out there by the time it comes into view, instead of popping in mid-screen.
+def spawn_section_objects(section : int; base_y : float) {
+    let section_mult = float(min(section + 1, 5))
+    spawn_section_bridges(section, base_y, section_mult)
     spawn_section_islands(base_y, section_mult)
     spawn_section_trees(base_y)
     spawn_section_houses(base_y)
     spawn_section_depots(base_y)
-    spawn_section_enemies(base_y, section_mult)
+    spawn_section_enemies(section, base_y, section_mult)
 }
 
-def spawn_section_bridges(base_y, section_mult : float) {
+def spawn_section_bridges(section : int; base_y, section_mult : float) {
     let bridge_count = int(1.0 + section_mult * 0.4)
     for (i in range(bridge_count)) {
         let by = base_y + SECTION_LENGTH * (float(i + 1) / float(bridge_count + 1))
-        spawn_bridge(float3(0.0, by, BRIDGE_Z))
+        spawn_bridge(float3(0.0, by, BRIDGE_Z), section)
     }
     commit()
 }
@@ -593,10 +595,10 @@ def boat_spot_blocked(candidate : float3) : bool {
 }
 
 // Enemies — staggered ahead
-def spawn_section_enemies(base_y, section_mult : float) {
+def spawn_section_enemies(section : int; base_y, section_mult : float) {
     let boat_count = int(2.0 + section_mult * 1.0)
-    let plane_count = (current_section >= 1 ? int(1.0 + section_mult * 0.6) : 0)
-    let heli_count = (current_section >= 2 ? int(section_mult * 0.5) : 0)
+    let plane_count = (section >= 1 ? int(1.0 + section_mult * 0.6) : 0)
+    let heli_count = (section >= 2 ? int(section_mult * 0.5) : 0)
 
     for (_i in range(boat_count)) {
         for (_try in range(10)) {
@@ -614,7 +616,7 @@ def spawn_section_enemies(base_y, section_mult : float) {
         let ey = base_y + random_range(5.0, SECTION_LENGTH - 5.0)
         let bounds = river_clamp_x_for(ey, random_sign() * 20.0)
         let side_x = (random_f() < 0.5 ? bounds.x - 3.0 : bounds.y + 3.0)
-        spawn_enemy_plane(float3(side_x, ey, PLANE_Z))
+        spawn_enemy_plane(float3(side_x, ey, PLANE_Z), section)
     }
     for (_i in range(heli_count)) {
         let ey = base_y + random_range(15.0, SECTION_LENGTH - 15.0)
@@ -661,7 +663,10 @@ def reset_game() {
 
     global_rng_seed = uint(get_uptime() * 1000.0)
     init_river()
-    spawn_section_objects()
+    // Populate the opening section and the one after it, so the first horizon
+    // is already continuous; each crossing then tops up one section ahead.
+    spawn_section_objects(0, player_pos.y + 40.0)
+    spawn_section_objects(1, player_pos.y + SECTION_LENGTH + 40.0)
     game_state = GameState.playing
 }
 
@@ -849,8 +854,10 @@ def update_section() {
         if (current_section >= MAX_SECTIONS) {
             game_state = GameState.win_state
             restart_input_lock = 1.5
-        } else {
-            spawn_section_objects()
+        } elif (current_section + 1 < MAX_SECTIONS) {
+            // The section just entered was populated a boundary ago; extend the
+            // world by the NEXT one, still beyond the fog and the far plane.
+            spawn_section_objects(current_section + 1, player_pos.y + (SECTION_LENGTH - section_dist) + 40.0)
         }
     }
 }
@@ -1518,9 +1525,32 @@ def private jet_palette() {
 // Craft bank into a turn. Purely cosmetic, but it is most of what makes the
 // helicopter feel like it is being flown rather than slid.
 def private player_orientation() : float4 {
-    let roll = clamp(-player_vel.x * 0.075, -0.55, 0.55)
+    let roll = clamp(player_vel.x * 0.075, -0.55, 0.55)
     let pitch = clamp((player_fwd_speed - PLAYER_FWD_SPEED_MIN) * 0.018, 0.0, 0.22)
     return quat_mul(quat_y_rot(roll), quat_x_rot(-pitch))
+}
+
+// Enemy craft face where they are going (boats, jets) or the player
+// (helicopters). The models are authored nose toward +Y, so facing is a
+// quarter or half turn around Z. Heel, bob and bank compose on top in model
+// space; the heli drift is the one world-space lean -- it tracks the player
+// along world X, and under the half turn a model-space roll would lean the
+// wrong way. Shadows use the same orientation.
+def private boat_orientation(patrol_dir, pos_x, game_time : float) : float4 {
+    let face = quat_z_rot(-patrol_dir * PI * 0.5)
+    let heel = quat_y_rot(patrol_dir * 0.14)
+    let bob = quat_x_rot(sin(game_time * 1.7 + pos_x) * 0.05)
+    return quat_mul(face, quat_mul(heel, bob))
+}
+
+def private plane_orientation(vel_x : float) : float4 {
+    let dir = (vel_x >= 0.0 ? 1.0 : -1.0)
+    return quat_mul(quat_z_rot(-dir * PI * 0.5), quat_y_rot(dir * 0.30))
+}
+
+def private enemy_heli_orientation(drift_x : float) : float4 {
+    let drift = quat_y_rot(clamp(drift_x * 0.06, -0.45, 0.45))
+    return quat_mul(drift, quat_z_rot(PI))
 }
 
 // --- Shadow map pass ---
@@ -1529,24 +1559,24 @@ def private player_orientation() : float4 {
 // shadows are gone: props now shade each other and the banks.
 
 // Aircraft and boats: the movers, whose shadows track the action.
-def private shadow_cast_craft() {
+def private shadow_cast_craft(game_time : float) {
     if (player_respawn_timer <= PLAYER_RESPAWN_BLINK) {
         draw_shadow_caster(player_pos, float3(PLAYER_SIZE * 1.85), player_orientation())
         geo_heli |> draw_geometry_fragment()
     }
 
     query() $(b : EnemyBoat) {
-        draw_shadow_caster(b.pos, float3(BOAT_SIZE * 1.25), quat_z_rot(b.patrol_dir * 0.12))
+        draw_shadow_caster(b.pos, float3(BOAT_SIZE * 1.25), boat_orientation(b.patrol_dir, b.pos.x, game_time))
         geo_gunboat |> draw_geometry_fragment()
     }
 
     query() $(p : EnemyPlane) {
-        draw_shadow_caster(p.pos, float3(PLANE_SIZE * 1.35))
+        draw_shadow_caster(p.pos, float3(PLANE_SIZE * 1.35), plane_orientation(p.vel.x))
         geo_jet |> draw_geometry_fragment()
     }
 
     query() $(h : EnemyHelicopter) {
-        draw_shadow_caster(h.pos, float3(ENEMY_HELI_SIZE * 1.7), quat_y_rot(sin(h.hover_phase) * 0.2))
+        draw_shadow_caster(h.pos, float3(ENEMY_HELI_SIZE * 1.7), enemy_heli_orientation(h.target_x - h.pos.x))
         geo_heli |> draw_geometry_fragment()
     }
 
@@ -1613,11 +1643,11 @@ def private shadow_cast_obstacles() {
     }
 }
 
-def render_shadow_casters() {
+def render_shadow_casters(game_time : float) {
     glUseProgram(shadow_program)
     active_program = shadow_program
     render_river_shadow()
-    shadow_cast_craft()
+    shadow_cast_craft(game_time)
     shadow_cast_scenery()
     shadow_cast_obstacles()
 }
@@ -1647,24 +1677,19 @@ def render_enemies(game_time : float) {
 
     query() $(b : EnemyBoat) {
         boat_palette()
-        // Heel the hull into its patrol direction and let it ride the swell.
-        let heel = quat_y_rot(b.patrol_dir * 0.14)
-        let bob = quat_x_rot(sin(game_time * 1.7 + b.pos.x) * 0.05)
-        draw_prop(b.pos, float3(BOAT_SIZE * 1.25), float3(1.0), quat_mul(heel, bob), MAT_HULL)
+        draw_prop(b.pos, float3(BOAT_SIZE * 1.25), float3(1.0), boat_orientation(b.patrol_dir, b.pos.x, game_time), MAT_HULL)
         geo_gunboat |> draw_geometry_fragment()
     }
 
     query() $(p : EnemyPlane) {
         jet_palette()
-        let bank = quat_y_rot(clamp(p.vel.x * 0.10, -0.5, 0.5))
-        draw_prop(p.pos, float3(PLANE_SIZE * 1.35), float3(1.0), bank, MAT_METAL)
+        draw_prop(p.pos, float3(PLANE_SIZE * 1.35), float3(1.0), plane_orientation(p.vel.x), MAT_METAL)
         geo_jet |> draw_geometry_fragment()
     }
 
     query() $(h : EnemyHelicopter) {
         enemy_heli_palette()
-        let drift = quat_y_rot(clamp((h.target_x - h.pos.x) * 0.06, -0.45, 0.45))
-        draw_prop(h.pos, float3(ENEMY_HELI_SIZE * 1.7), float3(1.0), drift, MAT_HULL)
+        draw_prop(h.pos, float3(ENEMY_HELI_SIZE * 1.7), float3(1.0), enemy_heli_orientation(h.target_x - h.pos.x), MAT_HULL)
         geo_heli |> draw_geometry_fragment()
     }
 

--- a/web/examples/ui/samples/examples/river_run/main.das
+++ b/web/examples/ui/samples/examples/river_run/main.das
@@ -276,7 +276,7 @@ def render_frame(game_time : float) {
     apply_environment(game_time)
 
     begin_shadow_pass()
-    render_shadow_casters()
+    render_shadow_casters(game_time)
     end_shadow_pass()
 
     begin_scene_pass(env_now.horizon_color)

--- a/web/examples/ui/samples/examples/river_run/river.das
+++ b/web/examples/ui/samples/examples/river_run/river.das
@@ -7,23 +7,23 @@ require rr_globals public
 // River is defined by a ring of RiverSegment, each with left/right bank X at a world Y.
 // Banks are rendered as a triangle strip rebuilt each frame.
 
-def river_section_amplitude() : float {
-    return 1.5 + float(min(current_section, 5)) * 0.5
+def river_section_amplitude(sec : int) : float {
+    return 1.5 + float(min(sec, 5)) * 0.5
 }
 
-def river_section_frequency() : float {
-    return 0.018 + float(min(current_section, 6)) * 0.003
+def river_section_frequency(sec : int) : float {
+    return 0.018 + float(min(sec, 6)) * 0.003
 }
 
-def river_target_half_width() : float {
-    let s = float(min(current_section, 8))
+def river_target_half_width(sec : int) : float {
+    let s = float(min(sec, 8))
     // Start wider/easier in section 0 and gradually narrow with progression.
     let base = (RIVER_HALF_WIDTH_MAX + 1.15) - s * 0.33
     return clamp(base, RIVER_HALF_WIDTH_MIN + 0.75, RIVER_HALF_WIDTH_MAX + 1.8)
 }
 
-def pick_split_half() : float {
-    let s = float(min(current_section, 9))
+def pick_split_half(sec : int) : float {
+    let s = float(min(sec, 9))
     // Section 0 keeps split center narrow (wider channels); later sections can narrow channels more.
     let min_half = 0.68 + s * 0.09
     let max_half = min(3.15, 1.42 + s * 0.17)
@@ -48,6 +48,8 @@ def init_river() {
     river_split_hold = 0.0
     river_first_split_pending = true
     river_first_split_start_y = player_pos.y + random_range(95.0, 150.0)
+    river_ripple_phase = 0.0
+    river_ripple_amp = river_section_amplitude(0)
 
     for (_i in range(RIVER_SEGMENTS_COUNT)) {
         advance_river_one()
@@ -56,34 +58,38 @@ def init_river() {
 }
 
 def advance_river_one() {
+    // Shape parameters follow the section that OWNS this segment's Y, not the
+    // one the player is in -- the ring runs a couple of sections ahead, and the
+    // river has to change character at the zone boundary, not at the player.
+    let sec = section_for_y(river_gen_y)
     // Gradually drift center and width toward targets
     river_center_x += (river_center_target - river_center_x) * 0.15
     river_half_width += (river_width_target - river_half_width) * 0.12
 
     // Occasionally pick new targets
     if (random_f() < 0.12) {
-        let max_drift = RIVER_CENTER_DRIFT_MAX - float(min(current_section, 5)) * 0.3
+        let max_drift = RIVER_CENTER_DRIFT_MAX - float(min(sec, 5)) * 0.3
         river_center_target = random_range(-max_drift, max_drift)
     }
     if (random_f() < 0.12) {
-        let lo = max(RIVER_HALF_WIDTH_MIN + 0.6, river_target_half_width() - 2.2)
-        let hi = min(RIVER_HALF_WIDTH_MAX + 2.2, river_target_half_width() + 2.4)
+        let lo = max(RIVER_HALF_WIDTH_MIN + 0.6, river_target_half_width(sec) - 2.2)
+        let hi = min(RIVER_HALF_WIDTH_MAX + 2.2, river_target_half_width(sec) + 2.4)
         river_width_target = random_range(lo, hi)
     }
 
     // Force one split in section 0 once we get away from spawn.
     if (river_first_split_pending && river_gen_y >= river_first_split_start_y) {
         river_split_target = true
-        river_split_half = pick_split_half()
+        river_split_half = pick_split_half(sec)
         river_split_hold = random_range(90.0, 170.0)
         river_first_split_pending = false
     }
 
     // Split / merge events are allowed from section 0 onward.
-    let split_chance = 0.035 + float(min(current_section, 6)) * 0.008
+    let split_chance = 0.035 + float(min(sec, 6)) * 0.008
     if (!river_first_split_pending && !river_split_target && river_split_blend <= 0.01 && random_f() < split_chance) {
         river_split_target = true
-        river_split_half = pick_split_half()
+        river_split_half = pick_split_half(sec)
         river_split_hold = random_range(90.0, 190.0)
     }
     if (river_split_target && river_split_blend >= 0.99) {
@@ -93,7 +99,7 @@ def advance_river_one() {
         }
     }
     if (river_split_target && random_f() < 0.10) {
-        river_split_half = pick_split_half()
+        river_split_half = pick_split_half(sec)
     }
 
     let split_speed = 0.10
@@ -105,16 +111,16 @@ def advance_river_one() {
     }
 
     // Add sine wave ripple on top
-    let amp = river_section_amplitude()
-    let freq = river_section_frequency()
-    let ripple = sin(river_gen_y * freq) * amp
+    river_ripple_amp += (river_section_amplitude(sec) - river_ripple_amp) * 0.06
+    river_ripple_phase += river_section_frequency(sec) * SEGMENT_LENGTH
+    let ripple = sin(river_ripple_phase) * river_ripple_amp
 
     let center_line = river_center_x + ripple
     let left_x = center_line - river_half_width
     let right_x = center_line + river_half_width
 
     // Early sections guarantee roomier split channels; later sections may get tighter.
-    let min_channel_half = max(2.1, 3.25 - float(min(current_section, 8)) * 0.14)
+    let min_channel_half = max(2.1, 3.25 - float(min(sec, 8)) * 0.14)
     let max_split_half = max(river_half_width - min_channel_half, 0.0)
     let split_wave = 0.9 + 0.1 * sin(river_gen_y * 0.03)
     let split_half = min(max_split_half, river_split_half * river_split_blend * split_wave)

--- a/web/examples/ui/samples/examples/river_run/rr_globals.das
+++ b/web/examples/ui/samples/examples/river_run/rr_globals.das
@@ -31,7 +31,9 @@ let RIVER_HALF_WIDTH_MAX = 7.0
 let RIVER_HALF_WIDTH_MIN = 3.0
 let RIVER_CENTER_DRIFT_MAX = 3.5
 let SEGMENT_LENGTH = 6.0
-let RIVER_SEGMENTS_COUNT = 52
+// Enough ring to keep real segments under everything prespawned one full
+// section ahead (advance keeps ~4 segments behind the player).
+let RIVER_SEGMENTS_COUNT = 96
 let SECTION_LENGTH = 240.0
 let MAX_SECTIONS = 10
 
@@ -330,6 +332,10 @@ var @live river_split_half = 0.0
 var @live river_split_hold = 0.0
 var @live river_first_split_pending = true
 var @live river_first_split_start_y = 0.0
+// Ripple phase is integrated segment by segment (and the amplitude eased), so
+// a per-section frequency change bends the river instead of stepping it.
+var @live river_ripple_phase = 0.0
+var @live river_ripple_amp = 1.5
 
 var tick_dt = 0.0
 // Effect-inspection rig: with fx_freeze set, the world and its particles both
@@ -605,8 +611,22 @@ def get_fog_color() : float3 {
     return env_now.fog_color
 }
 
+def section_speed_mult_for(section : int) : float {
+    return 1.0 + float(section) * 0.15
+}
+
 def section_speed_mult() : float {
-    return 1.0 + float(current_section) * 0.15
+    return section_speed_mult_for(current_section)
+}
+
+// Which section owns a world Y, anchored to the next boundary ahead of the
+// player -- prespawned content and river generation agree on zone edges.
+def section_for_y(world_y : float) : int {
+    let ahead = world_y - (player_pos.y + (SECTION_LENGTH - section_dist))
+    if (ahead < 0.0) {
+        return current_section
+    }
+    return min(current_section + 1 + int(ahead / SECTION_LENGTH), MAX_SECTIONS - 1)
 }
 
 def add_screen_shake(amount : float) {


### PR DESCRIPTION
River Run had three visual defects. Enemies did not face their direction of travel: the models are authored nose toward +Y, but boats and jets move along X and enemy helicopters face away from the player. The player helicopter banked away from its sideways motion because the roll sign was inverted. And each zone's objects spawned only 40 units ahead at the boundary crossing, so a whole section of bridges, scenery and enemies popped in mid-screen.

The fix gives each enemy an orientation helper (face the motion, or face the player, with the cosmetic lean composed in model space), flips the player roll sign, and makes zone content seamless: each section band is anchored to its zone boundary and spawned one full section early, past the fog and the 420-unit far plane. The river segment ring grows from 52 to 96 segments so real bank geometry exists under everything prespawned. River generation now derives its per-section shape parameters from the section that owns each segment's Y, and the meander ripple is phase-integrated, so a parameter change bends the river at the boundary instead of stepping the banks. The playground port carries the same changes; a `_news` entry announces the game while 0.6.4 is in the works.

Where to look: `examples/games/river_run/gameplay.das` (orientation helpers, prespawn scheduling), `river.das` (zone-anchored generation, ripple), `rr_globals.das` (`section_for_y`, ring size). Shadow casters use the same orientations as the render pass, with `game_time` threaded through for the boat bob.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- WASM-staged Playwright suite (`site/tests/playground/`): 63 passed, 2 failed on the first full run. Runtime artifacts: deployed `playground/daslang_static.{js,wasm}` fetched from daslang.io (this change does not feed `web/output/daslang_static.*`); sample sources staged from this branch. The two failures are outside this change: `runtime-revive` streaming-fallback passed on rerun (init timeout under parallel load), `audio.spec.js` strudel-audio fails persistently in this deployed-runtime-on-local-staging environment on files this diff does not touch.
- The changed river_run playground sample was driven end to end in that staging: compiles under the wasm interpreter, title screen renders, in-game river runs with dressed banks, enemies and HUD, zero page errors.
- Native run verified visually on macOS (orientation, banking, and zone transitions watched in game).
- Woodpecker round at the branch tip (64a09c168): no findings.
- Targeted dupes run over the river_run corpus: the new helpers (`section_for_y`, orientation helpers) match nothing.
- The make-pr `dupes` gate itself is red on this tree for a pre-existing reason: its auto-scoping tries to compile `examples/games/sequence/modules/das-cards/*.das` standalone (8 failures) plus one more in another shard, all untouched by this diff.

### Claims - stated, not tested
- 22 changed branches in example-game code ship with no automated instrument; river_run has no dastest rig and the orientation helpers are private. The only gates are the post-merge wasm compile in pages.yml and the nightly headless boot/paint smoke of the deployed sample. Verification was visual plus the playground drive above. A break would show as wrong facing/bank direction or as content popping at zone boundaries.
- Entity count roughly doubles (two content bands live instead of one). No draw culling was added; at this example's scale the extra distant draws are clipped at the far plane.

### Not done
- A GL-free test seam (lifting `section_for_y`, the quaternion orientation helpers and the river shape parameters into a pure module with table-driven asserts, boulder-dash style) is a candidate follow-up; not done in this change.
- The dupes-gate scoping failure on `sequence/modules/das-cards` is left for its own fix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
