### PR TITLE
preflight: bound every cmake --build fan-out to -j / hardware threads

### DIFF
--- a/utils/internal/preflight/main.das
+++ b/utils/internal/preflight/main.das
@@ -56,7 +56,7 @@ struct Config {
     clang : string
 
     @clarg_short = "j"
-    @clarg_doc = "Parallel width for the C++ syntax pass; 0 = hardware threads"
+    @clarg_doc = "Parallel width for the C++ syntax pass and cmake builds; 0 = hardware threads"
     jobs : int
 
     @clarg_doc = "Per-user preflight TOML (default: platform config directory)"
@@ -1168,13 +1168,19 @@ def gate_tests_cpp(ctx : PreflightCtx) : GateResult {
     return run_test_gate("tests-cpp", args, "ctest -L small failures (build tests-cpp-small target if missing)")
 }
 
+//! The build fan-out for every cmake invocation: the user's ``-j`` when set, else hardware
+//! threads. A bare ``--parallel`` is unlimited ``make -j`` on the Makefile generator.
+def cmake_jobs(ctx : PreflightCtx) : string {
+    return "{ctx.jobs > 0 ? ctx.jobs : get_total_hw_threads()}"
+}
+
 def gate_tests_aot(ctx : PreflightCtx) : GateResult {
     let t0 = ref_time_ticks()
     if (empty(ctx.build_dir)) {
         return GateResult(name = "tests-aot", status = GateStatus.Skip, seconds = seconds_since(t0),
             detail = "no configured build dir — cmake -B build first")
     }
-    let b = run_argv(["cmake", "--build", ctx.build_dir, "--config", ctx.config, "--target", "test_aot", "--parallel"])
+    let b = run_argv(["cmake", "--build", ctx.build_dir, "--config", ctx.config, "--target", "test_aot", "--parallel", cmake_jobs(ctx)])
     if (b.rc != 0) {
         // root CMakeLists gates tests/aot out on DAS_AOT_EXAMPLES_DISABLED and
         // 32-bit Windows — an absent target is a config choice, not a failure.
@@ -1210,7 +1216,7 @@ def gate_sequence(ctx : PreflightCtx) : GateResult {
     }
     let b = run_argv(["cmake", "--build", ctx.build_dir, "--config", ctx.config, "--target",
         "dasModuleGlfw", "dasModuleLiveHost", "dasModuleHV", "dasModuleAudio",
-        "dasModulePUGIXML", "dasModuleStbImage", "--parallel"])
+        "dasModulePUGIXML", "dasModuleStbImage", "--parallel", cmake_jobs(ctx)])
     if (b.rc != 0) {
         let lower = to_lower(b.out)
         if (find(lower, "unknown target") >= 0 || find(lower, "no rule to make target") >= 0 || find(lower, "does not exist") >= 0) {
@@ -1258,7 +1264,7 @@ def gate_imgui(ctx : PreflightCtx) : GateResult {
     }
     let b = run_argv(["cmake", "--build", ctx.build_dir, "--config", ctx.config, "--target",
         "daslang-live", "dasModuleLiveHost", "dasModuleGlfw", "dasModuleHV", "dasModuleClipboard",
-        "dasModulePUGIXML", "dasModuleStbImage", "dasModuleImgui", "imguiApp", "imguiAppHeadless", "--parallel"])
+        "dasModulePUGIXML", "dasModuleStbImage", "dasModuleImgui", "imguiApp", "imguiAppHeadless", "--parallel", cmake_jobs(ctx)])
     if (b.rc != 0) {
         let lower = to_lower(b.out)
         if (find(lower, "unknown target") >= 0 || find(lower, "no rule to make target") >= 0 || find(lower, "does not exist") >= 0) {


### PR DESCRIPTION
**Behavior change: preflight's cmake builds now run at `-j` (or hardware threads), not unlimited.**

Preflight passed a bare `--parallel` to its three `cmake --build` calls (the test_aot, sequence, and imgui gates). On the Makefile generator that is `make -j` with no limit. A full test_aot gate on a 10-core Mac spawned 1134 concurrent `-O3` compilers and pushed the load average past 900, stalling every other process on the box. Ninja trees self-limit, so the problem only shows on Makefile trees.

The exposed population is larger than "some Makefile trees": `utils/mcp/setup.das` configures a worktree with no `-G`, so every MCP-bootstrapped worktree is a Makefile tree; only a tree configured by hand with Ninja is safe. The three gates are `--full`-only, which is why a fast-tier preflight never hit this. On master `-j` does not reach the cmake builds at all, so there was no flag to work around it.

The change adds `cmake_jobs(ctx)`: the user's `-j` when set, else `get_total_hw_threads()`, and passes it at all three sites. The `-j` flag doc now says it also covers cmake builds.

Where to look: `utils/internal/preflight/main.das`, `cmake_jobs` and the three `run_argv(["cmake", "--build", ...])` calls below it.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Targeted gates only (localized tooling change): MCP compile_check, lint, format on the file; `preflight --only sequence -j 4` on a built Ninja tree passes, which proves cmake accepts the new `--parallel N` argv.
- Full preflight not run: its test_aot gate is the fork-bomb itself on a Makefile tree, and this change is confined to preflight.
- The overload reproduced independently on a second Makefile worktree (`~/Work/daScript-nightly`, configured by `setup.das`) running the full chain on master.

### Claims - stated, not tested
- On a Makefile tree the fix caps the compiler count at `-j`: follows from cmake mapping `--parallel N` to `make -jN`; not re-run on the Makefile tree that reproduced the overload.

### Not done
- `utils/mcp/setup.das` still configures worktrees with the platform default generator; matching the source tree's generator (or passing `-G Ninja` where available) would remove the exposure for new worktrees regardless of this fix. Follow-up.
- Unrelated trap found in the same field run: `daspkg build --wasm` and a `web/build64` `daslang_static` build overwrite the tree's shared `lib/*.a` with emscripten archives; the next native link fails with `ld: archive member '/' not a mach-o file in lib/libfreetype.a`. A separate wasm output dir or a host-arch check on `lib/*.a` would close it. Follow-up.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
