### PR TITLE
nightly: sample cap 512 KiB, lint.rst doc-verify red, labs back on the job queue

### DIFF
--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -19,6 +19,7 @@ Lint Tools
 .. das-doc: given struct SomeStruct { value : int64 }
 .. das-doc: given struct Foo { x : int }
 .. das-doc: given struct State { mark : int; claimed : array<int> }
+.. das-doc: given struct Ctx { weights : array<float> }
 .. das-doc: given def compute() : int { return 0 }
 .. das-doc: given def report(ok : bool) { }
 .. das-doc: given def process(v : int) { }

--- a/examples/graphics/path_tracer_lab_opengl_imgui_example.das
+++ b/examples/graphics/path_tracer_lab_opengl_imgui_example.das
@@ -17,8 +17,9 @@ options _allow_imgui_legacy = true
 // daslang-live harness so it live-reloads on desktop and runs in the wasm examples pipeline + the
 // playground. The path tracer header is reused by relative require.
 //
-// (No JobQue mode: with_job_que creates a worker pool whose pthread spawn can't be serviced while
-// main() is busy in the wasm interpreter, and it is perf-equivalent to the Threads mode here anyway.)
+// The band passes run on a persistent job queue created in init(): with_job_que cannot span an
+// externally-driven frame loop, and a per-pass new_thread pays a pthread create/exit round trip
+// through the main thread on every band of every frame.
 
 require math
 require strings
@@ -61,7 +62,10 @@ enum Mode {
 // rAF), so it can both create threads and stay responsive. Band threads share the surface by raw
 // pointer (shared wasm memory under -pthread; shared address space on desktop).
 
-var g_mode = int(Mode.SingleThread)   // UI render mode
+// Opens on the multi-band jobque path, not SingleThread: both CPU modes dispatch through
+// new_job, but only this one exercises N-way dispatch per frame, so the lab (and the sample
+// verifier that drives it unattended) puts the queue under real load without a UI click.
+var g_mode = int(Mode.Threads)        // UI render mode
 var g_epoch = 0                       // bumped on mode switch; resets the pass
 var g_render_epoch = -1               // epoch the render state machine is synced to (detects switches)
 var g_pass = -1                       // completed accumulation passes (frameCount-1)
@@ -242,7 +246,10 @@ def start_threads_pass(pidx, n : int) {
         let ymin = c * chunk
         let ymax = min((c + 1) * chunk, TRACE_H)
         var st = status
-        new_thread() <| @capture(= pbb, = pepoch, = pray, = my_epoch, = pidx, = ymin, = ymax, = st) {
+        // new_job over the persistent que, NOT a per-pass new_thread: a thread created per band per
+        // frame costs a pthread create/exit round trip through the main thread on emscripten, where
+        // the que's workers are created once and then only signalled.
+        new_job() <| @capture(= pbb, = pepoch, = pray, = my_epoch, = pidx, = ymin, = ymax, = st) {
             worker_band(pbb, pepoch, pray, my_epoch, pidx, ymin, ymax)
             st |> notify_and_release
         }
@@ -442,6 +449,9 @@ def init() {
     // that clamps navigator.hardwareConcurrency (e.g. Vivaldi -> 2 -> get_total_hw_threads() == 1),
     // and capped at the MAX_BANDS ceiling. Drag the slider up to MAX_BANDS to oversubscribe.
     g_max_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
+    // Persistent job queue for the band passes (start_threaded_pass uses new_job). Created once here
+    // so it spans the externally-driven frame loop (emscripten set_main_loop) — a with_job_que block can't.
+    create_job_que()
 }
 
 [export]
@@ -476,6 +486,7 @@ def shutdown() {
         }
         g_threads_status = null
     }
+    destroy_job_que()
     harness_shutdown()
 }
 

--- a/examples/graphics/path_tracer_lab_opengl_imgui_example.das
+++ b/examples/graphics/path_tracer_lab_opengl_imgui_example.das
@@ -56,11 +56,11 @@ enum Mode {
 }
 
 // ----- render state (all main-thread-owned; update() drives the passes) -----
-// Threading is dispatched FROM update() (the main thread), never from a background coordinator:
-// emscripten can't service worker-initiated thread creation while main() is busy, so dispatching the
-// band threads from a background worker would deadlock. The main thread yields between frames (harness
-// rAF), so it can both create threads and stay responsive. Band threads share the surface by raw
-// pointer (shared wasm memory under -pthread; shared address space on desktop).
+// Bands are dispatched FROM update() (the main thread), never from a background coordinator:
+// emscripten cannot service worker-initiated dispatch while main() is busy. The que's workers are
+// created once in init() and only signalled per pass, so a frame costs a signal rather than a
+// pthread create/exit. Band jobs share the surface by raw pointer (shared wasm memory under
+// -pthread; shared address space on desktop).
 
 // Opens on the multi-band jobque path, not SingleThread: both CPU modes dispatch through
 // new_job, but only this one exercises N-way dispatch per frame, so the lab (and the sample
@@ -449,7 +449,7 @@ def init() {
     // that clamps navigator.hardwareConcurrency (e.g. Vivaldi -> 2 -> get_total_hw_threads() == 1),
     // and capped at the MAX_BANDS ceiling. Drag the slider up to MAX_BANDS to oversubscribe.
     g_max_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
-    // Persistent job queue for the band passes (start_threaded_pass uses new_job). Created once here
+    // Persistent job queue for the band passes (start_threads_pass uses new_job). Created once here
     // so it spans the externally-driven frame loop (emscripten set_main_loop) — a with_job_que block can't.
     create_job_que()
 }

--- a/examples/graphics/physarum_lab_opengl_imgui_example.das
+++ b/examples/graphics/physarum_lab_opengl_imgui_example.das
@@ -11,13 +11,13 @@ options _allow_imgui_legacy = true
 // then diffused and decayed. Out of those local rules emerge the organic transport networks the
 // real Physarum polycephalum builds. The simulation never converges, so the window stays alive.
 //
-// The worker-thread slider is the star: it partitions the agents across N background threads, and
-// the agents/sec readout climbs as you add threads. The agent pass is dispatched from update() on
-// the main thread and polled non-blocking next frame — never joined on the main thread — because
-// emscripten cannot service a main-thread block on Web Workers in the browser (the same reason the
-// Path Tracer Lab dispatches from update()). The pass is race-free by construction: a worker only
+// The worker-thread slider is the star: it partitions the agents across N bands of a persistent job
+// queue, and the agents/sec readout climbs as you add bands. The agent pass is dispatched from
+// update() on the main thread and polled non-blocking next frame — never joined on the main thread —
+// because emscripten cannot service a main-thread block on Web Workers in the browser (the same
+// reason the Path Tracer Lab dispatches from update()). The pass is race-free by construction: a worker only
 // READS the shared field (sensing) and writes its OWN slice of the agent array; the deposit
-// (scatter) and the diffuse/decay run on the main thread after the workers join, so no two threads
+// (scatter) and the diffuse/decay run on the main thread once the pass is ready, so no two threads
 // ever write the same memory. Uses the daslang-live harness so it live-reloads on desktop and runs
 // in the wasm examples pipeline + the playground.
 
@@ -327,7 +327,11 @@ def start_update_pass(n : int) {
         let hi = min((c + 1) * chunk, g_agent_count)
         var st = status
         if (lo >= hi) {
-            st |> notify_and_release   // more bands than agents — balance the wait-group, skip the thread
+            // More bands than agents: balance the wait group and skip the job. `notify`, NOT
+            // `notify_and_release` — append() raises the remaining count without taking a
+            // reference, and the per-band reference is the one new_job's capture takes. Releasing
+            // here drops a reference that was never added, and the status goes negative.
+            status |> notify
             continue
         }
         // new_job over the persistent que, NOT a per-pass new_thread: a thread created per band per

--- a/examples/graphics/physarum_lab_opengl_imgui_example.das
+++ b/examples/graphics/physarum_lab_opengl_imgui_example.das
@@ -330,10 +330,10 @@ def start_update_pass(n : int) {
             st |> notify_and_release   // more bands than agents — balance the wait-group, skip the thread
             continue
         }
-        // new_thread per band (the Path Tracer pattern), NOT new_job: the persistent jobque wedges
-        // the interpreted wasm runner (playground), while per-pass threads work on every runner and
-        // map onto the same pre-spawned Web Worker pool in the compiled build.
-        new_thread() <| @capture(= pagents, = pfield, = read_offset, = lo, = hi, = prm, = st) {
+        // new_job over the persistent que, NOT a per-pass new_thread: a thread created per band per
+        // frame costs a pthread create/exit round trip through the main thread on emscripten (~2000
+        // postMessages/s at 4 bands), where the que's workers are created once and then only signalled.
+        new_job() <| @capture(= pagents, = pfield, = read_offset, = lo, = hi, = prm, = st) {
             update_agents_band(pagents, pfield, read_offset, lo, hi, prm)
             st |> notify_and_release
         }
@@ -663,6 +663,9 @@ def init() {
     // Open at the detected core count, floored to 4 so it never looks single-threaded on a browser
     // that clamps navigator.hardwareConcurrency, and capped at MAX_BANDS. Drag the slider up to oversubscribe.
     g_threads = clamp(get_total_hw_threads(), 4, MAX_BANDS)
+    // Persistent job queue for the agent passes (start_update_pass uses new_job). Created once here so it
+    // spans the externally-driven frame loop (emscripten set_main_loop) — a with_job_que block can't.
+    create_job_que()
     if (g_audio_enabled) {
         setup_audio()
     }
@@ -711,6 +714,7 @@ def shutdown() {
             g_audio_owned = false
         }
     }
+    destroy_job_que()
     harness_shutdown()
 }
 

--- a/plans/wasm_lifecycle_gc.md
+++ b/plans/wasm_lifecycle_gc.md
@@ -1,0 +1,88 @@
+# The wasm browser lifecycle has no GC boundary
+
+Every `options gc` program driven by the browser three-call lifecycle grows its heap
+without bound until the wasm 2 GiB ceiling, then traps. Nothing collects.
+
+## The defect
+
+`maybe_collect_gc` (`modules/dasLiveHost/live/live_gc.das:15`) states the contract in its own
+doc-comment: the canonical shape - `init`/`update`/`shutdown` plus a standalone `main` loop -
+calls it once per iteration, and under the daslang-live host it self-disables because the host
+collects each frame. So there are exactly two sanctioned GC drivers: the program's own `main`
+loop, or the live host.
+
+The browser lifecycle is a third driver, and it was never given one.
+
+- `skills/daspkg.md:351` - on wasm the browser lifecycle auto-drives `init`/`update`/`shutdown`
+  per `requestAnimationFrame` and **bypasses `main`**. Intended: a game keeps its plain desktop
+  `main`, with no per-platform edits.
+- `utils/daslang/main.cpp:338` `web_loop_tick` - evaluates `update()`, reads its return value
+  for loop control, reports exceptions. No collection.
+- `is_live_mode()` is false in a card, so `maybe_collect_gc` would not self-disable - it is
+  simply never reached, because the `main` loop that calls it never runs.
+- `options gc` + `options persistent_heap = true` is required for `heap_collect` to work at
+  all, so these programs are explicitly collect-on-demand, and nothing demands.
+
+## Evidence (physarum wasm64 card, local, 2026-08-29)
+
+Heap growth is monotonic and geometric (emscripten grows ~1.2x per step):
+
+    72.5 -> 87 -> 104.5 -> 125.4 -> 150.5 -> 180.7 -> 216.9 -> 374.9 -> 449.8 MB
+
+Roughly 1.2 MB/s, reaching the 2 GiB ceiling in about half an hour, then:
+
+    Cannot enlarge memory, requested 2147766880 bytes, but the limit is 2147483648 bytes!
+    out of heap memory: requested 524288 bytes
+
+repeating for thousands of messages until the module traps. After the trap the page answers
+nothing - even `Module.wasmMemory` throws `RuntimeError: unreachable` - the canvas is frozen
+mid-frame and the HUD holds its last values. That is what the sample verifier reports as a
+wedge, and it is the standing nightly red for Physarum Lab.
+
+Growing the heap is synchronous on the main thread, so a single grow near the ceiling is a long
+stall. A user report of two ~945 ms main-thread freezes in `HandlePostMessage` -> `RunMicrotasks`
+matches two late grows better than any dispatch-side explanation.
+
+## Scope
+
+Not lab-specific and not dispatch-specific. Every `options gc` program the examples pipeline
+drives through `web_loop_tick` is affected, which is every graphics card. Samples that finish
+quickly never reach the ceiling, so this reads as "long-running cards wedge" rather than as a
+systematic defect - which is why it survived.
+
+## The fix
+
+One collection boundary in the browser tick, matching what the desktop loop body does. Open
+questions to settle before writing it:
+
+1. **Where.** In `web_loop_tick` after the `update()` eval, or inside the harness. The tick is
+   the honest home: it is the thing that replaced the `main` loop, so it should carry the
+   `main` loop's duty.
+2. **What.** `maybe_collect_gc`'s thresholds (string heap over 1/3 unused, heap over 2/3
+   unused) exist so a per-frame call stays cheap - it collects only a mostly-free heap. The
+   C++ side should apply the same policy rather than collecting unconditionally, or call the
+   das function when the program exposes it.
+3. **Programs without `options gc`.** `heap_collect` throws without `options gc` +
+   `options persistent_heap`, so the boundary must be a no-op for programs that do not opt in.
+   Check the flags on the context, not the presence of a function.
+4. **Cost.** Verify the collection does not itself introduce a frame stall on a large live
+   heap; the thresholds are meant to prevent that, but they have never run per-frame on a card.
+
+## Verification
+
+- A card that reproduces the growth today (physarum is the fastest) shows a flat or sawtooth
+  heap instead of a monotonic ramp, over a soak long enough to have OOM'd before - 45 minutes
+  at the measured rate gives margin.
+- The nightly playground sweep's Physarum Lab cell goes green and stays green.
+- A no-`options gc` card still runs, proving the no-op path.
+- Desktop is unaffected: its `main` loop keeps calling `maybe_collect_gc` itself.
+
+## Not yet known
+
+Whether the leak rate differs between the per-frame `new_thread` dispatch and the persistent
+job queue. A control run was attempted and was not usable: it was instrumented with
+`-sPTHREADS_DEBUG=1`, which emits about four lines per thread, and at ~464 threads/s the arm
+under test produced 250,000 console messages in minutes. Whatever the answer, it is a rate
+question - the missing boundary is the cause either way. The strudel layer also reports a leak
+of its own on desktop (`potential memory leak detected`), which is a separate thread to pull
+and may be a second, smaller source.

--- a/tests/jobque/test_jobque_jobs.das
+++ b/tests/jobque/test_jobque_jobs.das
@@ -3,6 +3,7 @@ options no_unused_function_arguments = false
 options no_unused_block_arguments = false
 require dastest/testing_boost public
 require daslib/jobque_boost
+require math
 
 // Wrapper struct required by boost helpers (push_clone, for_each_clone, etc.)
 // POD types (int, float) cannot be used with new/delete required by these helpers.
@@ -245,3 +246,116 @@ def test_persistent_job_que(t : T?) {
     }
 }
 
+
+// ---- the frame-loop dispatch: one persistent que, polled, never joined ----
+
+// A pass is ready only once every band has notified, so a bounded spin separates
+// "still running" from "wedged" — an unbounded one would hang the suite instead of
+// failing it if a band's notification is ever lost.
+let POLL_LIMIT = 200000000
+
+def private poll_ready(var status : JobStatus?) : bool {
+    for (_i in range(POLL_LIMIT)) {
+        if (status.isReady) {
+            return true
+        }
+    }
+    return false
+}
+
+[test]
+def test_persistent_que_frame_loop(t : T?) {
+    //! The Physarum / Path Tracer Lab dispatch. Their frame loop is driven externally
+    //! (emscripten set_main_loop), so a pass is polled through isReady rather than
+    //! joined, and the que outlives every pass instead of being rebuilt per frame.
+    //! A per-frame new_thread was used here instead for a while; on emscripten that
+    //! costs a pthread create/exit round trip through the main thread per band per
+    //! frame, which is what this shape exists to avoid.
+    t |> run("repeated multi-band passes each land exactly once") @(t : T?) {
+        create_job_que()
+        let N = 64
+        let BANDS = 4
+        let PASSES = 25
+        var data : array<int>
+        data |> resize(N)
+        var pdata : array<int>?
+        unsafe {
+            pdata = addr(data)
+        }
+        var every_pass_ready = true
+        for (_p in range(PASSES)) {
+            var status = job_status_create()
+            status |> append(BANDS)
+            let chunk = (N + BANDS - 1) / BANDS
+            for (c in range(BANDS)) {
+                let lo = c * chunk
+                let hi = min((c + 1) * chunk, N)
+                var st = status
+                new_job() <| @capture(= pdata, = lo, = hi, = st) {
+                    for (i in range(lo, hi)) {
+                        (*pdata)[i] ++
+                    }
+                    st |> notify_and_release
+                }
+            }
+            every_pass_ready = every_pass_ready && poll_ready(status)
+            unsafe {
+                job_status_remove(status)
+            }
+        }
+        t |> success(every_pass_ready, "every pass reached isReady")
+        var advanced = 0
+        for (i in range(N)) {
+            if (data[i] == PASSES) {
+                advanced++
+            }
+        }
+        t |> equal(advanced, N, "every element advanced exactly once per pass")
+        destroy_job_que()
+    }
+}
+
+[test]
+def test_persistent_que_empty_band(t : T?) {
+    t |> run("a band with no work still balances the wait group") @(t : T?) {
+        //! Physarum dispatches MAX_BANDS bands whatever the agent count, so a band
+        //! whose range is empty notifies WITHOUT a job. Miss that and the wait group
+        //! never reaches ready and the frame loop stalls forever.
+        create_job_que()
+        let N = 2
+        let BANDS = 8          // more bands than elements: 6 of them get nothing
+        var data : array<int>
+        data |> resize(N)
+        var pdata : array<int>?
+        unsafe {
+            pdata = addr(data)
+        }
+        var status = job_status_create()
+        status |> append(BANDS)
+        let chunk = (N + BANDS - 1) / BANDS
+        for (c in range(BANDS)) {
+            let lo = c * chunk
+            let hi = min((c + 1) * chunk, N)
+            if (lo >= hi) {
+                // `notify`, NOT `notify_and_release`: append() raises the remaining count without
+                // taking a reference, so releasing here would drop one that was never added.
+                status |> notify
+                continue
+            }
+            var st = status
+            new_job() <| @capture(= pdata, = lo, = hi, = st) {
+                for (i in range(lo, hi)) {
+                    (*pdata)[i] ++
+                }
+                st |> notify_and_release
+            }
+        }
+        t |> success(poll_ready(status), "the wait group balances when bands outnumber work")
+        unsafe {
+            job_status_remove(status)
+        }
+        t |> equal(data[0], 1)
+        t |> equal(data[1], 1)
+        destroy_job_que()
+    }
+}

--- a/utils/internal/dasweb-playground/README.md
+++ b/utils/internal/dasweb-playground/README.md
@@ -37,6 +37,15 @@ The public route boundary is `caddy.snippet`, the authoritative copy of what the
 vhost forwards here. It also carries the transport body cap: the service can only bounds-check
 a body already buffered in full, so that limit cannot live in this process.
 
+`max_source_bytes` is 524288 (512 KiB). The playground POSTs a multi-file sample as one JSON
+document, so the cap is measured against the whole bundle, not the largest file in it - the
+biggest curated game serializes to roughly 267 KB. Because the deployed toml is operator-owned
+and `deploy.sh` carries it forward verbatim, raising this default does NOT reach a box whose
+toml already states the old value; that file is edited on the box, and the startup banner's
+`max_source_bytes_src` says whether the running value came from `toml` or `default`. Caddy's
+`request_body max_size` on `/api/samples*` stays above it, so the 413 a user sees is the
+service's, with its JSON error body, rather than the proxy's bare response.
+
 ## Endpoints (port 8101, loopback only - Caddy fronts the internet)
 
 | Route | Behavior |

--- a/utils/internal/dasweb-playground/REVIEW.md
+++ b/utils/internal/dasweb-playground/REVIEW.md
@@ -4,8 +4,7 @@
 `README.md`. Planned work: `plans/dasweb_backend.md`.
 
 **A diff that adds or changes a route, a store operation, or a config or limit behavior covers
-it with a dastest test in this directory, in the same change.** `main.das` and `admin.das` stay
-argv/dispatch glue over tested modules, so they need no test of their own.
+it with a dastest test in this directory, in the same change.**
 
 **Never register a `[test]` file in a `CMakeLists.txt`, and never put one under the repo-root
 `tests/` tree - `[test]` files live in this directory and require their siblings by bare name.**
@@ -30,6 +29,10 @@ stays between `init` and `start`, so the server binds loopback only.**
 is a defect, as is a hash or insert reachable without the size check against the configured
 cap.** The service can only check a body already buffered in full.
 
+**A `max_source_bytes` at or above the `request_body max_size` standing in front of
+`/api/samples*` in `caddy.snippet` is a defect.** Whichever limit is lower produces the 413, and
+under the proxy's the caller gets a bare response instead of the service's JSON error body.
+
 **Never use a request body whose byte count disagrees with its string length - read the body as
 bytes and reject the mismatch.** A das string ends at the first NUL, so a body used without that
 guard can be stored truncated under a hash that does not describe it.
@@ -44,8 +47,10 @@ cross-origin POST to a proxied route.
 
 **A remote-builder route (`/api/build/toolchain`, `/api/build/next`, `/api/build/result`) that
 does not authenticate by the config bearer token compared with `constant_time_equal` is a
-defect, as is one that logs, echoes, or short-circuit-compares the token.** An empty configured
-token disables the surface, never opens it.
+defect, as is one that logs, echoes, or short-circuit-compares the token.**
+
+**A remote-builder route (`/api/build/toolchain`, `/api/build/next`, `/api/build/result`) that
+answers anything but a refusal while the configured bearer token is empty is a defect.**
 
 **Never assemble an artifact-cache path from anything but components validated in
 `build_artifacts`, and never land an upload in the served tree other than by renaming a stage
@@ -81,9 +86,9 @@ admin endpoint to the public route set.**
 **Never put a secret - a token or a credential - in a log line, a response body, or an error
 message.**
 
-**A route that does not emit one structured line - method, path, status, duration, client ip,
-bytes - is a defect; `GET /healthz` emits none.** The watchdog polls `/healthz` every few
-seconds, and logging it would bury the signal.
+**A route other than `GET /healthz` that does not emit one structured line - method, path,
+status, duration, client ip, bytes - is a defect, as is a diff that gives `GET /healthz` a log
+line.** The watchdog polls it every few seconds, and logging it would bury the signal.
 
 **A diff that adds a store mutation or a job/state transition also emits a structured line for
 it.** A failure path that can trigger without leaving a log line is a defect.
@@ -106,9 +111,9 @@ thread that serves it.**
 **Never ship a file an operator edits on the box with plain `release_include` - ship it with
 `release_include_if_missing` and have `deploy.sh` carry it forward across upgrades.**
 
-**Never put a production value in the checked-in `dasweb-playground.toml` - it holds
-development values.** The config file is discovered automatically beside the module, so a
-production path in it makes an in-repo run open the live database.
+**Never put an absolute path, a secret, or a public origin in the checked-in
+`dasweb-playground.toml`; use the development equivalent.** The config file is discovered
+automatically beside the module, so whatever it names is what an in-repo run opens.
 
 **A diff that edits a shipped `[sql_migration]` body is a defect - a schema change adds a new
 version instead.**
@@ -138,5 +143,6 @@ its line here, with its tests, in the same change.**
   reads the filesystem; no store mutation that bypasses `samples_store` functions.
 - `admin.das` - operator CLI (listing curation). Talks to the store the same way the server
   does; no second implementation of a store operation.
+- `test_*.das` - the dastest suites for the files above.
 - `.das_package`, `watchdog.json`, `dasweb-playground.toml`, `deploy.sh`, `caddy.snippet` -
   packaging, deployment, and the public route boundary.

--- a/utils/internal/dasweb-playground/caddy.snippet
+++ b/utils/internal/dasweb-playground/caddy.snippet
@@ -14,7 +14,7 @@ handle /api/samples* {
 	# libhv imposes no transport cap of its own — an unbounded chunked POST
 	# would grow the process to the size of the body before any handler runs.
 	# This is the only place that limit can exist. Keep it comfortably above
-	# max_source_bytes (262144) so the service, not the proxy, produces the
+	# max_source_bytes (524288) so the service, not the proxy, produces the
 	# 413 that the playground surfaces to the user.
 	request_body {
 		max_size 1MB

--- a/utils/internal/dasweb-playground/dasweb-playground.toml
+++ b/utils/internal/dasweb-playground/dasweb-playground.toml
@@ -9,7 +9,7 @@
 port = 8101
 db = "samples.db"
 base_url = "http://127.0.0.1:8101"
-max_source_bytes = 262144
+max_source_bytes = 524288
 max_inserts_per_ip_hour = 100
 curated_dir = ""
 # wasm build pipeline; the deployed toml carries the real token and

--- a/utils/internal/dasweb-playground/playground_config.das
+++ b/utils/internal/dasweb-playground/playground_config.das
@@ -27,7 +27,7 @@ struct ServerArgs {
     base_url : string = "https://daslang.io"
 
     @clarg_doc = "Reject sources larger than this many bytes"
-    max_source_bytes : int = 262144
+    max_source_bytes : int = 524288
 
     @clarg_doc = "Per-IP sample-insert ceiling per hour"
     max_inserts_per_ip_hour : int = 100

--- a/utils/internal/dasweb-playground/samples_store.das
+++ b/utils/internal/dasweb-playground/samples_store.das
@@ -68,7 +68,7 @@ def samples_migration_003(db : SqlRunner) {
 
 struct StorePolicy {
     //! Every limit the store enforces; the launcher fills it from config.
-    max_source_bytes : int = 262144
+    max_source_bytes : int = 524288
     max_inserts_per_ip_hour : int = 100
 }
 

--- a/utils/internal/dasweb-playground/test_playground_config.das
+++ b/utils/internal/dasweb-playground/test_playground_config.das
@@ -20,7 +20,7 @@ def test_defaults_and_toml(t : T?) {
         t |> success(apply_config_text(cfg, "# empty\n", args, sources, err), "empty toml parses")
         t |> equal(cfg.port, 8101)
         t |> equal(cfg.base_url, "https://daslang.io")
-        t |> equal(cfg.max_source_bytes, 262144)
+        t |> equal(cfg.max_source_bytes, 524288)
     }
     t |> run("toml overrides defaults and records provenance") @(t : T?) {
         var cfg = ServerArgs()
@@ -53,7 +53,7 @@ def test_defaults_and_toml(t : T?) {
         let args <- no_args()
         t |> success(!apply_config_text(cfg, "max_source_bytes = \"256k\"\n", args, sources, err), "string for a number fails")
         t |> success(find(err, "max_source_bytes") >= 0, "error names the key")
-        t |> equal(cfg.max_source_bytes, 262144)   // default stands
+        t |> equal(cfg.max_source_bytes, 524288)   // default stands
     }
     t |> run("a number where a string belongs is an error") @(t : T?) {
         var cfg = ServerArgs()

--- a/utils/internal/dasweb-playground/test_samples_store.das
+++ b/utils/internal/dasweb-playground/test_samples_store.das
@@ -158,6 +158,27 @@ def test_rejections(t : T?) {
 }
 
 [test]
+def test_default_cap_admits_a_multi_file_bundle(t : T?) {
+    //! Regression: the playground POSTs a multi-file sample as one JSON
+    //! document, so the cap is measured against the whole bundle rather than
+    //! any one file. River Run's twelve sources serialize to ~267 KB, which the
+    //! old 256 KiB default refused with a 413 - the wasm build failed before the
+    //! builder ever saw the sample. Asserted against the SHIPPED default, not
+    //! `test_policy`, because that default is the thing that was wrong.
+    with_latest_sqlite(":memory:") $(db) {
+        let pol = StorePolicy()
+        t |> run("a 300 KB bundle stores") @(tt : T?) {
+            let bundle = repeat("x", 300 * 1024)
+            tt |> equal(put_sample(db, bundle, "10.0.0.1", pol, 1000l).status, PutStatus.ok)
+        }
+        t |> run("the cap still bites one byte over") @(tt : T?) {
+            let over = repeat("x", pol.max_source_bytes + 1)
+            tt |> equal(put_sample(db, over, "10.0.0.2", pol, 1010l).status, PutStatus.too_large)
+        }
+    }
+}
+
+[test]
 def test_rate_ceiling(t : T?) {
     with_latest_sqlite(":memory:") $(db) {
         let pol = test_policy()   // 3 per hour


### PR DESCRIPTION
**Deploy step: the sample-store cap fix does not reach dasweb-1 on its own. Someone must set `max_source_bytes = 524288` in the box's `dasweb-playground.toml` and restart the service.** `deploy.sh` snapshots that file and copies it back over the shipped one, so the box keeps its current value across upgrades.

Three nightly lanes were red. This fixes all three.

The playground sweep failed on River Run. The playground sends a multi-file sample as one JSON document, so the store measures its cap against the whole bundle rather than the largest file in it. River Run's twelve sources serialize to 267,383 bytes against a 262,144 byte cap, so the sample was refused with a 413 and never reached the builder. The cap moves to 524288. Caddy's own body limit on that route stays at 1MB, above it, so a user still sees the service's JSON error rather than the proxy's bare response.

The extended-checks doc sweep failed on `lint.rst`. Its LINT026 example uses a type the page never introduces, so doc-verify compiled the block and reported an undefined argument type. The page now introduces that type the way it already introduces five others.

Both graphics labs dispatched their per-frame bands with `new_thread`, creating and destroying one OS thread per band per frame. On emscripten each of those is a pthread create and exit proxied through the main thread. Measured on the compiled wasm64 physarum card at four bands, that is 1021 scheduled postMessages per second and 40.31 ms of main-thread time per update; over a persistent job queue the same work is 6 per second and 8.41 ms, at the same step rate. Both labs go back to `new_job` over a queue created once in `init()`. The path tracer now opens on its threaded mode, so the queue is exercised without a click.

Where to look: `samples_store.das` and `playground_config.das` for the cap, `start_update_pass` in physarum and `start_threads_pass` in the path tracer for the dispatch, and the two new tests in `tests/jobque/test_jobque_jobs.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Two gates were re-run by hand rather than through preflight. This worktree is a Makefile tree, where preflight's `tests-aot`, `sequence` and `imgui` gates each pass a bare `--parallel` to cmake, which is `make -j` with no limit; that is the subject of a separate open PR. Run bounded instead: `cmake --build build --config Release --target test_aot -j 10`, then the AOT suite - 13097 tests, 13090 passed, 0 failed, 7 skipped - and the imgui target set at `-j 10`, which builds clean. Both had failed the full run for an unrelated reason: a wasm card build earlier in the session had overwritten 13 native archives in `lib/` with emscripten ones, so the linker rejected them. Deleted and rebuilt native; neither failure touched this diff.
- doc-verify is a nightly-only gate, so per-PR CI will not re-prove the `lint.rst` fix. Run locally, before and after: `1 green, 1 red` without the added line, `2 green, 0 red` with it.
- The wasm64 card measurements and 60-second soaks are local-only; no CI lane builds or runs those cards. Path tracer 7200 rAFs at 120fps, largest frame gap 14 ms; physarum 6284 rAFs at 105fps, largest gap 48 ms; no gap over 100 ms in either.
- The jobque restoration was checked against the interpreter-in-wasm runtime as well, since that is where the persistent queue was previously reported to wedge. Three arms ran clean there: a queue plus one job, 200 passes of 4 jobs with real work, and the same again with a live audio system.

### Claims - stated, not tested
- The deployed box still refuses River Run until its own toml is edited. Verified by reading `deploy.sh`, which snapshots `dasweb-playground.toml` before unpacking and copies it back afterwards. A break looks like the startup banner reporting `max_source_bytes: 262144` with `max_source_bytes_src: "toml"`, and the playground sweep staying red on River Run.
- The lab changes ship no test that fails without them. The only automated instrument that loads those files compiles and simulates them; it never calls `init`, `update` or `shutdown`, so the dispatch change, the queue lifecycle and the path tracer's new default mode are all invisible to it. They are covered by that compile gate and by the nightly sample sweep.
- The band-skip refcount fix is not reachable as either lab is configured. An empty band needs `n(n-1) >= A`, which with a 16-band ceiling caps `A` at 240, while the agents slider floors at 1000. The jobque semantic behind the fix is covered by a new test with a negative control; the lab line carrying it is not. The path tracer has no equivalent path and needs none.

### Not done
- Physarum still wedges if left running long enough, and this change does not fix that. The cause is now traced and written up as `plans/wasm_lifecycle_gc.md`, added here. The wasm heap grows without bound at roughly 1.2 MB per second, reaches the 2 GiB ceiling in about half an hour, and then repeats `Cannot enlarge memory` until the module traps; after that the page is frozen and answers nothing, which is what the sample verifier sees as a wedge. Growing the heap is a synchronous main-thread operation, so the long stalls users report near the ceiling are the growth itself. Whether the leak predates this change is NOT established: the control run was instrumented with pthread logging, which the per-thread arm emits about four lines per thread for, so the two arms were not comparable. The strudel layer reports a leak of its own on desktop, which is the first thread to pull. Own arc.
- This folder has a `REVIEW.md` and no `REVIEW.das`. Five of its rules are decidable from tree state alone, including the cap-below-proxy-limit ordering this change adds. That gate would have caught this failure mode with no reviewer involved, and is worth writing separately.
- `utils/REVIEW.md` carries three self-review findings of its own: a rule whose only trigger is `utils/watchdog/watchdog.py` but which sits two levels above it, a paragraph packing three routing checks, and a clause whose trigger is a file outside `utils/`. Left out deliberately; unrelated to anything here.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
