### PR TITLE
wasm lifecycle: both browser drivers collect the heap between frames

### DIFF
--- a/history/README.md
+++ b/history/README.md
@@ -150,3 +150,4 @@ listed in the log below - search it first when hunting for a doc.
 - 2026-08-27 `.claude/agents/rescue-bot.md` -> `history/agents/rescue-bot.md` - fresh-scaffolding rescue at the PR gate, superseded by the harvester (make_pr row 0a0)
 - 2026-08-27 `.claude/agents/rescue-sweep-bot.md` -> `history/agents/rescue-sweep-bot.md` - legacy comment-sweep rescue, superseded by harvest-on-first-touch
 - 2026-08-28 `modules/dasVulkan/CLAUDE.md` (the standalone-repo provenance sentence) -> the `dasVulkan/` bullet of this file - archived when CLAUDE.md split into `ARCHITECTURE.md` (the present-tense half) plus agent instructions
+- 2026-08-29 `plans/wasm_lifecycle_gc.md` -> `history/web/wasm_lifecycle_gc.md` - the wasm browser lifecycle had no GC boundary; both C++ drivers now call `Context::collectHeapIfMostlyFree` per frame, shipped with the arc

--- a/history/web/wasm_lifecycle_gc.md
+++ b/history/web/wasm_lifecycle_gc.md
@@ -5,7 +5,7 @@ without bound until the wasm 2 GiB ceiling, then traps. Nothing collects.
 
 ## The defect
 
-`maybe_collect_gc` (`modules/dasLiveHost/live/live_gc.das:15`) states the contract in its own
+`maybe_collect_gc` (`modules/dasLiveHost/live/live_gc.das:19`) states the contract in its own
 doc-comment: the canonical shape - `init`/`update`/`shutdown` plus a standalone `main` loop -
 calls it once per iteration, and under the daslang-live host it self-disables because the host
 collects each frame. So there are exactly two sanctioned GC drivers: the program's own `main`
@@ -23,7 +23,7 @@ The browser lifecycle is a third driver, and it was never given one.
   - `src/builtin/module_jit.cpp:1845` `jit_web_lifecycle_tick` - the standalone cross-compiled
     exe path, which is what an **examples card** runs (`--jit-target=wasm64`). Same shape, same
     omission. This is the driver the measurement below actually exercised.
-  - `src/builtin/module_builtin_runtime.cpp:1948` `main_loop_arg` - `eval_main_loop`'s
+  - `src/builtin/module_builtin_runtime.cpp:1947` `main_loop_arg` - `eval_main_loop`'s
     emscripten arm, used by the ported games. This one is FINE, and it shows why: it invokes a
     daslang block, and those blocks call `maybe_collect_gc()` themselves
     (`examples/games/pacman/main.das:1312`). The GC call survived there because it stayed in
@@ -63,23 +63,32 @@ drives through `web_loop_tick` is affected, which is every graphics card. Sample
 quickly never reach the ceiling, so this reads as "long-running cards wedge" rather than as a
 systematic defect - which is why it survived.
 
-## The fix
+## The fix (shipped)
 
-One collection boundary in the browser tick, matching what the desktop loop body does. Open
-questions to settle before writing it:
+`Context::collectHeapIfMostlyFree(LineInfo * at = nullptr)` - one method, called by both
+drivers after `update()` returns and before the loop-control decision. It is the C++ twin of
+`maybe_collect_gc`, threshold for threshold: collect both heaps when the string heap is more
+than a third unused, else when the heap is more than two thirds unused; otherwise nothing.
+It returns false and touches nothing on a context without `options gc` +
+`options persistent_heap`, so the boundary is inert for every program that did not opt in
+(`heap_collect` would throw there; this must not).
 
-1. **Where.** In `web_loop_tick` after the `update()` eval, or inside the harness. The tick is
-   the honest home: it is the thing that replaced the `main` loop, so it should carry the
-   `main` loop's duty.
-2. **What.** `maybe_collect_gc`'s thresholds (string heap over 1/3 unused, heap over 2/3
-   unused) exist so a per-frame call stays cheap - it collects only a mostly-free heap. The
-   C++ side should apply the same policy rather than collecting unconditionally, or call the
-   das function when the program exposes it.
-3. **Programs without `options gc`.** `heap_collect` throws without `options gc` +
-   `options persistent_heap`, so the boundary must be a no-op for programs that do not opt in.
-   Check the flags on the context, not the presence of a function.
-4. **Cost.** Verify the collection does not itself introduce a frame stall on a large live
-   heap; the thresholds are meant to prevent that, but they have never run per-frame on a card.
+The four questions, as settled:
+
+1. **Where** - in the ticks themselves. The tick is what replaced the `main` loop, so it
+   carries the `main` loop's duty. Both ticks call it only on the keep-going path; a frame
+   that ends the loop goes straight to `shutdown()`.
+2. **What** - `maybe_collect_gc`'s thresholds exactly, so desktop and web collect on the
+   same policy and a program cannot behave differently by platform.
+3. **Opt-out** - the `persistent`/`gcEnabled` flags on the context, read directly; no
+   function presence is consulted.
+4. **Cost** - a collection is cheap by construction when the thresholds admit it (a mostly-free
+   heap has little live data to walk); the physarum soak below shows no frame-rate change.
+
+Covered by `tests-cpp/small/test_lifecycle_gc.cpp`: 200 frames of a 64 KB junk array grow the
+heap past 6 MB, one call reclaims it more than fourfold, a second pass holds, and a context
+without `options gc` declines without throwing. The tick sites are `__EMSCRIPTEN__`-only and
+have no native test; the browser measurements below are their proof.
 
 ## The desktop control (run 2026-08-29)
 
@@ -90,24 +99,33 @@ that would have made the missing boundary irrelevant - if the growth were LIVE d
 would reclaim nothing and desktop would climb too. It does not. The heap is collectable garbage,
 and the only difference is who calls the collector.
 
-## Verification
+## Verification (run 2026-08-29, local Chromium, both drivers)
 
-- A card that reproduces the growth today (physarum is the fastest) shows a flat or sawtooth
-  heap instead of a monotonic ramp, over a soak long enough to have OOM'd before - 45 minutes
-  at the measured rate gives margin.
-- The playground arm measured separately, since it is the other driver. Physarum in the
-  interpreted playground is the same program through `web_loop_tick`; it should show the same
-  ramp before the fix and the same flattening after.
-- The nightly playground sweep's Physarum Lab cell goes green and stays green.
-- A no-`options gc` card still runs, proving the no-op path.
-- Desktop is unaffected: its `main` loop keeps calling `maybe_collect_gc` itself.
+A minimal fixture (`options gc` + `persistent_heap`, `update()` allocating one 64 KB array and
+a short string per frame, nothing retained) through each driver, before and after:
 
-## Not yet known
+| driver | before | after |
+|---|---|---|
+| interpreter (`web_loop_tick`, `daslang_static`) | 64 KB/frame, 3.8 MB -> 2002 MB by frame 32,040, page at 4.2 GB | flat at 68 KB through frame 18,900 |
+| native control (`main` loop + `maybe_collect_gc`) | - | flat at 68 KB through frame 1,800 |
 
-Whether the leak rate differs between the per-frame `new_thread` dispatch and the persistent
-job queue. A control run was attempted and was not usable: it was instrumented with
-`-sPTHREADS_DEBUG=1`, which emits about four lines per thread, and at ~464 threads/s the arm
-under test produced 250,000 console messages in minutes. Whatever the answer, it is a rate
-question - the missing boundary is the cause either way. The strudel layer also reports a leak
-of its own on desktop (`potential memory leak detected`), which is a separate thread to pull
-and may be a second, smaller source.
+Physarum itself on the compiled card (`jit_web_lifecycle_tick`), after: main-context heap flat
+at 14.2 MB across 25,200 sim frames, with transient bumps to 16.4 MB that collect within one
+sample; string heap flat at 52 bytes. Total page memory by
+`performance.measureUserAgentSpecificMemory()` held at 480-481 MB over the soak, where the
+pre-fix rate of ~1.2 MB/s would have added over 100 MB in the first 88 seconds alone. Main
+context was the whole leak; the strudel layer and the job-clone contexts contributed nothing
+measurable.
+
+Still owed: the nightly playground sweep's Physarum Lab cell going green and staying green,
+which is the only instrument that runs unattended.
+
+## Resolved on the way
+
+Whether the leak rate differed between the per-frame `new_thread` dispatch and the persistent
+job queue was never settled - the control run was instrumented with `-sPTHREADS_DEBUG=1` and
+drowned in its own logging. It no longer matters: the cause was the missing boundary, and with
+it in place the card holds flat under the job queue. The job-clone contexts were also cleared
+by reading: the non-pooled path frees each clone with the job, the pooled path calls
+`restartHeaps()` on reuse. Strudel's own desktop leak report (`potential memory leak
+detected`, ~99 KB) is real but tiny and separate; it did not show in the browser totals.

--- a/include/daScript/simulate/simulate.h
+++ b/include/daScript/simulate/simulate.h
@@ -758,6 +758,7 @@ namespace das
         void relocateCode( bool pwh = false );
         void announceCreation();
         void collectHeap(LineInfo * at, bool stringHeap, bool validate);
+        bool collectHeapIfMostlyFree(LineInfo * at = nullptr);
         void reportAnyHeap(LineInfo * at, bool sth, bool rgh, bool rghOnly, bool errorsOnly);
         void instrumentFunction ( SimFunction * , bool isInstrumenting, uint64_t userData, bool threadLocal );
         void instrumentContextNode ( const Block & blk, bool isInstrumenting, Context * context, LineInfo * line );

--- a/modules/dasLiveHost/live/live_gc.das
+++ b/modules/dasLiveHost/live/live_gc.das
@@ -6,9 +6,13 @@ module live_gc shared public
 //! Standalone-loop GC boundary, UI-neutral. The canonical application shape
 //! (``init``/``update``/``shutdown`` + a standalone ``main`` loop) calls
 //! :func:`maybe_collect_gc` once per iteration; under the daslang-live host it
-//! self-disables (the host collects each frame). Lives beside the live_host
-//! module so windowless applications (servers, tools) get the boundary without
-//! a GLFW dependency; ``live/glfw_live`` re-exports it for its callers.
+//! self-disables (the host collects each frame). In the browser the ``main``
+//! loop never runs - the lifecycle drives ``update`` per frame from C++ - and
+//! that driver applies the same thresholds itself
+//! (``Context::collectHeapIfMostlyFree``), so a program needs no per-platform
+//! edit. Lives beside the live_host module so windowless applications
+//! (servers, tools) get the boundary without a GLFW dependency;
+//! ``live/glfw_live`` re-exports it for its callers.
 
 require live_host
 

--- a/plans/wasm_lifecycle_gc.md
+++ b/plans/wasm_lifecycle_gc.md
@@ -16,14 +16,27 @@ The browser lifecycle is a third driver, and it was never given one.
 - `skills/daspkg.md:351` - on wasm the browser lifecycle auto-drives `init`/`update`/`shutdown`
   per `requestAnimationFrame` and **bypasses `main`**. Intended: a game keeps its plain desktop
   `main`, with no per-platform edits.
-- `utils/daslang/main.cpp:338` `web_loop_tick` - evaluates `update()`, reads its return value
-  for loop control, reports exceptions. No collection.
+- There are THREE browser-lifecycle drivers, and two of them collect nothing:
+  - `utils/daslang/main.cpp:338` `web_loop_tick` - the interpreter-in-wasm path, which is what
+    the **playground** runs. Evaluates `update()`, reads its return value for loop control,
+    reports exceptions. No collection.
+  - `src/builtin/module_jit.cpp:1845` `jit_web_lifecycle_tick` - the standalone cross-compiled
+    exe path, which is what an **examples card** runs (`--jit-target=wasm64`). Same shape, same
+    omission. This is the driver the measurement below actually exercised.
+  - `src/builtin/module_builtin_runtime.cpp:1948` `main_loop_arg` - `eval_main_loop`'s
+    emscripten arm, used by the ported games. This one is FINE, and it shows why: it invokes a
+    daslang block, and those blocks call `maybe_collect_gc()` themselves
+    (`examples/games/pacman/main.das:1312`). The GC call survived there because it stayed in
+    das; it was lost in exactly the two drivers that replaced `main` from the C++ side.
+
+  The fix therefore has two sites, not one, and they must be verified separately - a card and
+  the playground are different code paths, so confirming one says nothing about the other.
 - `is_live_mode()` is false in a card, so `maybe_collect_gc` would not self-disable - it is
   simply never reached, because the `main` loop that calls it never runs.
 - `options gc` + `options persistent_heap = true` is required for `heap_collect` to work at
   all, so these programs are explicitly collect-on-demand, and nothing demands.
 
-## Evidence (physarum wasm64 card, local, 2026-08-29)
+## Evidence (physarum wasm64 card - the jit_web_lifecycle_tick driver, local, 2026-08-29)
 
 Heap growth is monotonic and geometric (emscripten grows ~1.2x per step):
 
@@ -68,11 +81,23 @@ questions to settle before writing it:
 4. **Cost.** Verify the collection does not itself introduce a frame stall on a large live
    heap; the thresholds are meant to prevent that, but they have never run per-frame on a card.
 
+## The desktop control (run 2026-08-29)
+
+The same source on desktop, where the program's own `main` loop calls `maybe_collect_gc()`
+every frame, holds flat: RSS 419 MB across a three-minute run, `STAT RN` at 131.8% CPU
+throughout, so the process was working rather than stalled. That rules out the one hypothesis
+that would have made the missing boundary irrelevant - if the growth were LIVE data, collection
+would reclaim nothing and desktop would climb too. It does not. The heap is collectable garbage,
+and the only difference is who calls the collector.
+
 ## Verification
 
 - A card that reproduces the growth today (physarum is the fastest) shows a flat or sawtooth
   heap instead of a monotonic ramp, over a soak long enough to have OOM'd before - 45 minutes
   at the measured rate gives margin.
+- The playground arm measured separately, since it is the other driver. Physarum in the
+  interpreted playground is the same program through `web_loop_tick`; it should show the same
+  ramp before the fix and the same flattening after.
 - The nightly playground sweep's Physarum Lab cell goes green and stays green.
 - A no-`options gc` card still runs, proving the no-op path.
 - Desktop is unaffected: its `main` loop keeps calling `maybe_collect_gc` itself.

--- a/src/builtin/module_jit.cpp
+++ b/src/builtin/module_jit.cpp
@@ -1850,6 +1850,7 @@ namespace {
         } else {
             ((void(*)(das::Context*))lc->updateFn)(lc->ctx);
         }
+        if ( keepGoing ) lc->ctx->collectHeapIfMostlyFree();
         if ( !keepGoing ) {
             emscripten_cancel_main_loop();
             if ( lc->shutdownFn ) ((void(*)(das::Context*))lc->shutdownFn)(lc->ctx);

--- a/src/simulate/simulate_gc.cpp
+++ b/src/simulate/simulate_gc.cpp
@@ -932,6 +932,23 @@ namespace das
         Context * ctx = nullptr;
     };
 
+    bool Context::collectHeapIfMostlyFree ( LineInfo * at ) {
+        if ( !persistent || !gcEnabled ) return false;
+        uint64_t sUsed = stringHeap->bytesAllocated();
+        uint64_t sTotal = stringHeap->totalAlignedMemoryAllocated();
+        if ( sTotal > 0 && sUsed * 3 < sTotal * 2 ) {
+            collectHeap(at, true, false);
+            return true;
+        }
+        uint64_t hUsed = heap->bytesAllocated();
+        uint64_t hTotal = heap->totalAlignedMemoryAllocated();
+        if ( hTotal > 0 && hUsed * 3 < hTotal ) {
+            collectHeap(at, true, false);
+            return true;
+        }
+        return false;
+    }
+
     void Context::collectHeap ( LineInfo * at, bool sheap, bool validate ) {
         // refuse unattributable frames BEFORE marking - the error path must leave both
         // heaps unmarked. the check is owner-tagged positions (LINEINFO_FRAME_POS_TAG):

--- a/tests-cpp/small/test_lifecycle_gc.cpp
+++ b/tests-cpp/small/test_lifecycle_gc.cpp
@@ -1,0 +1,68 @@
+#include <doctest/doctest.h>
+
+#include "daScript/daScript.h"
+
+using namespace das;
+
+namespace {
+    struct Fixture {
+        TextPrinter tout;
+        ModuleGroup libGroup;
+        ProgramPtr program;
+        unique_ptr<Context> ctx;
+        SimFunction * updateFn = nullptr;
+
+        bool load ( const char * rel ) {
+            auto fAccess = make_smart<FsFileAccess>();
+            program = compileDaScript(getDasRoot() + rel, fAccess, tout, libGroup);
+            if ( !program || program->failed() ) return false;
+            ctx = make_unique<Context>(program->getContextStackSize());
+            if ( !program->simulate(*ctx, tout) ) return false;
+            if ( auto initFn = ctx->findFunction("init") ) {
+                ctx->runWithCatchAndClear([&](){ ctx->callOrFastcall(initFn, nullptr, nullptr); });
+            }
+            updateFn = ctx->findFunction("update");
+            return updateFn != nullptr;
+        }
+
+        bool frames ( int n ) {
+            return ctx->runWithCatchAndClear([&](){
+                for ( int i = 0; i != n; ++i ) ctx->callOrFastcall(updateFn, nullptr, nullptr);
+            });
+        }
+    };
+}
+
+TEST_CASE("collectHeapIfMostlyFree reclaims a gc context's per-frame garbage") {
+    Fixture f;
+    REQUIRE(f.load("/tests-cpp/small/test_lifecycle_gc.das"));
+    REQUIRE(f.ctx->persistent);
+    REQUIRE(f.ctx->gcEnabled);
+
+    REQUIRE(f.frames(200));
+    uint64_t grown = f.ctx->heap->bytesAllocated();
+    CHECK_MESSAGE(grown > uint64_t(200) * 16384 * sizeof(float) / 2,
+        "200 frames of a 64 KB junk array should have grown the heap past 6 MB, got ", grown);
+
+    CHECK(f.ctx->collectHeapIfMostlyFree());
+    uint64_t after = f.ctx->heap->bytesAllocated();
+    CHECK_MESSAGE(after * 4 < grown,
+        "a collection should have reclaimed the junk: before ", grown, " after ", after);
+
+    REQUIRE(f.frames(200));
+    CHECK(f.ctx->collectHeapIfMostlyFree());
+    CHECK_MESSAGE(f.ctx->heap->bytesAllocated() * 4 < grown,
+        "the boundary must hold across repeated passes, not once");
+}
+
+TEST_CASE("collectHeapIfMostlyFree is a no-op on a context that did not opt in") {
+    Fixture f;
+    REQUIRE(f.load("/tests-cpp/small/test_lifecycle_gc_nogc.das"));
+    REQUIRE_FALSE(f.ctx->gcEnabled);
+
+    REQUIRE(f.frames(50));
+    bool ranClean = f.ctx->runWithCatchAndClear([&](){
+        CHECK_FALSE(f.ctx->collectHeapIfMostlyFree());
+    });
+    CHECK_MESSAGE(ranClean, "a non-gc context must decline quietly, never throw");
+}

--- a/tests-cpp/small/test_lifecycle_gc.das
+++ b/tests-cpp/small/test_lifecycle_gc.das
@@ -1,0 +1,21 @@
+options gen2
+options gc
+options persistent_heap = true
+
+var g_frame = 0
+var g_keep : array<float>
+
+[export]
+def init() {
+    g_keep |> resize(1024)
+}
+
+[export]
+def update() {
+    var junk : array<float>
+    junk |> resize(16384)
+    junk[0] = float(g_frame)
+    let s = "frame {g_frame} " + "pad" + string(g_frame * 7)
+    g_keep[g_frame % 1024] = junk[0] + float(length(s))
+    g_frame++
+}

--- a/tests-cpp/small/test_lifecycle_gc_nogc.das
+++ b/tests-cpp/small/test_lifecycle_gc_nogc.das
@@ -1,0 +1,11 @@
+options gen2
+
+var g_frame = 0
+
+[export]
+def update() {
+    var junk : array<float>
+    junk |> resize(1024)
+    junk[0] = float(g_frame)
+    g_frame++
+}

--- a/utils/daslang/main.cpp
+++ b/utils/daslang/main.cpp
@@ -351,6 +351,7 @@ namespace {
             }
         }
         // void update(): runs until the page closes or the next run stops it.
+        if ( keepGoing ) loop->ctx->collectHeapIfMostlyFree();
         if ( !keepGoing ) stop_browser_loop();
     }
 


### PR DESCRIPTION
**Behavior change: every `options gc` program run in the browser now collects its heap between frames, on both the playground and the compiled-card path.** A program that leaked to the 2 GiB wasm ceiling and trapped now holds flat. Nothing changes for a program without `options gc`, and nothing changes on desktop.

Physarum Lab wedged in the browser after about half an hour, and the nightly sample sweep has reported it as a wedge. The cause was not in the sample. On the web the browser lifecycle drives `init`, `update` and `shutdown` per frame and bypasses the program's `main` loop by design. The `main` loop is where a daslang program calls `maybe_collect_gc`, and the two C++ drivers that replaced it on the web - `web_loop_tick` for the interpreter, which the playground runs, and `jit_web_lifecycle_tick` for the cross-compiled exe, which an examples card runs - never collected at all. With `options gc` and `options persistent_heap` these programs are collect-on-demand, and nothing demanded.

The fix is one method, `Context::collectHeapIfMostlyFree`, called by both drivers after `update()` returns. It is the C++ twin of `maybe_collect_gc` with the same thresholds, so desktop and web collect on one policy. It does nothing on a context that did not opt in.

Measured in Chromium with a fixture that allocates 64 KB per frame and keeps nothing: the interpreter driver went from 64 KB per frame, reaching 2 GB by frame 32,040, to flat at 68 KB through frame 18,900. Physarum on the compiled card held its main-context heap at 14.2 MB across 25,200 frames and its total page memory at 480 MB over the soak, where the old rate would have added over 200 MB. The main context was the whole leak; strudel and the job-clone contexts contributed nothing measurable.

Where to look: `Context::collectHeapIfMostlyFree` in `src/simulate/simulate_gc.cpp`, the one-line call in each of the two ticks, and `tests-cpp/small/test_lifecycle_gc.cpp`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The two tick sites are `__EMSCRIPTEN__`-only and have no native test. Their proof is the browser measurement above, run locally on the wasm64 `daslang_static` and the wasm64 physarum card, both rebuilt with this change; no CI lane builds or runs either. The method they call is covered natively by the new small test, 2 cases, 15 assertions, in the 106-case `tests-cpp-small` run.
- Native control for the same fixture, `main` loop calling `maybe_collect_gc` every frame: flat at 68 KB, matching the fixed interpreter driver exactly.

### Claims - stated, not tested
- The nightly playground sweep's Physarum Lab cell should go green and stay green. That is the only unattended instrument for this, and it runs on the deployed runtime, which does not carry this change until the next deploy. A break looks like the cell still reporting a wedge after a deploy that includes this commit.
- The interpreter measurement ran on a local `daslang_static` that linked 100 MB rather than the 46 MB of an earlier local build of the same target. A heap-growth measurement does not depend on link size, but the difference is not explained.

### Not done
- `make-pr`'s dupes gate cannot run on this diff, and the chain then exits 0 without reaching preflight. Adding `.das` fixtures under `tests-cpp/small/` widens the dupes corpus to that directory, where `test_compilation_callback_fail.das` fails to compile on purpose; detect-dupe refuses a partial export, throws, and `make-pr` reports success anyway. The remaining gates were run one at a time (`review-md`, `ast-verify`, `jit-smoke` green) and preflight was run directly. Two defects: an exception in a gate must not exit 0, and a deliberately failing fixture must not sink the corpus. Dupes triage for the two new fixtures is by hand - they are the lab's dispatch shape on purpose.
- `daspkg`: an in-tree module that also declares `release_wasm_build` - dasImgui - has two producers for one archive name in the wasm lib dir. `daspkg build --wasm` stages the `daslang_static` variant, and `ensure_external_wasm_archives` then sees every declared archive present and skips the module's own build, so a card links an archive without `jit_register_Module_dasIMGUI` and fails. Worked around here by evicting the four; needs its own fix.
- The plan doc that opened this arc (`plans/wasm_lifecycle_gc.md`, landed in the previous PR) closes with its results and moves to `history/web/`.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
