### PR TITLE
drop std::stable_sort from the compiler: das_stable_sort / sort at the five sites

### DIFF
--- a/src/ast/ast_infer_type_function.cpp
+++ b/src/ast/ast_infer_type_function.cpp
@@ -4,6 +4,7 @@
 #include "daScript/ast/ast_generate.h"
 #include "daScript/ast/ast_infer_type.h"
 #include "daScript/ast/ast_visitor.h"
+#include "daScript/simulate/das_qsort_r.h"
 
 namespace das {
 
@@ -610,7 +611,7 @@ namespace das {
                 }
                 fnm.push_back(make_pair(dist, fn));
             }
-            stable_sort(fnm.begin(), fnm.end(), [](const pair<int, Function *> &a, const pair<int, Function *> &b) { return a.first < b.first; });
+            sort(fnm.begin(), fnm.end(), [](const pair<int, Function *> &a, const pair<int, Function *> &b) { return a.first < b.first; });
             if (fnm[0].first != fnm[1].first) {
                 winners.resize(1);
                 winners[0] = fnm[0].second;
@@ -1836,7 +1837,7 @@ namespace das {
         } else if (functions.size() == 0) {
             // if there is more than one, we pick more specialized
             if (generics.size() > 1) {
-                stable_sort(generics.begin(), generics.end(), [&](const FunctionPtr &f1, const FunctionPtr &f2) { return copmareFunctionSpecialization(f1, f2, expr); });
+                das_stable_sort(generics.data(), generics.data() + generics.size(), [&](const FunctionPtr &f1, const FunctionPtr &f2) { return copmareFunctionSpecialization(f1, f2, expr); });
                 // if one is most specialized, we pick it, otherwise we report all of them
                 if (copmareFunctionSpecialization(generics.front(), generics[1], expr)) {
                     generics.resize(1);

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -12,6 +12,7 @@
 #include "daScript/simulate/runtime_range.h"
 #include "daScript/simulate/runtime_string_delete.h"
 #include "daScript/simulate/hash.h"
+#include "daScript/simulate/das_qsort_r.h"
 
 #include "daScript/simulate/simulate_nodes.h"
 
@@ -3986,7 +3987,7 @@ namespace das
                 allInitFunctions.push_back(&fn);
             }
         }
-        stable_sort(allInitFunctions.begin(), allInitFunctions.end(), [](auto a, auto b) { // sort them, so that late init is last
+        das_stable_sort(allInitFunctions.data(), allInitFunctions.data() + allInitFunctions.size(), [](auto a, auto b) {
             int lateA = a->debugInfo->flags & FuncInfo::flag_late_init;
             int lateB = b->debugInfo->flags & FuncInfo::flag_late_init;
             return lateA < lateB;

--- a/src/simulate/simulate_fn_hash.cpp
+++ b/src/simulate/simulate_fn_hash.cpp
@@ -167,27 +167,29 @@ namespace das {
             }
         }
         using FunAndName = pair<const Function *,string>;
-        vector<FunAndName> getStableDependencies() {
+        vector<FunAndName> getDependenciesByMangledName() {
             vector<FunAndName> vec;
             vec.reserve(functions.size());
             for ( const auto & it : functions ) {
                 vec.emplace_back(make_pair(it,it->getMangledName()));
             }
-            stable_sort(vec.begin(), vec.end(), [&](const FunAndName & a, const FunAndName & b){
+            sort(vec.begin(), vec.end(), [&](const FunAndName & a, const FunAndName & b){
                 return a.second < b.second;
             });
+            DAS_ASSERT(adjacent_find(vec.begin(), vec.end(), [](const FunAndName & a, const FunAndName & b){ return a.second == b.second; }) == vec.end());
             return vec;
         }
         using VarAndName = pair<const Variable *,string>;
-        vector<VarAndName> getStableVariableDependencies() {
+        vector<VarAndName> getVariableDependenciesByMangledName() {
             vector<VarAndName> vec;
             vec.reserve(variables.size());
             for ( const auto & it : variables ) {
                 vec.emplace_back(make_pair(it,it->getMangledName()));
             }
-            stable_sort(vec.begin(), vec.end(), [&](const VarAndName & a, const VarAndName & b){
+            sort(vec.begin(), vec.end(), [&](const VarAndName & a, const VarAndName & b){
                 return a.second < b.second;
             });
+            DAS_ASSERT(adjacent_find(vec.begin(), vec.end(), [](const VarAndName & a, const VarAndName & b){ return a.second == b.second; }) == vec.end());
             return vec;
         }
         das_hash_set<const Function *> functions;
@@ -200,8 +202,8 @@ namespace das {
         program->markExecutableSymbolUse();
         DependencyCollector collector;
         collector.collect(fun);
-        auto vecFunc = collector.getStableDependencies();
-        auto vecVars = collector.getStableVariableDependencies();
+        auto vecFunc = collector.getDependenciesByMangledName();
+        auto vecVars = collector.getVariableDependenciesByMangledName();
         vector<const Function *> tfun;
         tfun.reserve(vecFunc.size());
         for ( auto & fn : vecFunc ) {
@@ -230,7 +232,7 @@ namespace das {
         if ( fun->aotHash != 0 ) return fun->aotHash; // cached
         DependencyCollector collector;
         collector.collect(fun);
-        auto vec = collector.getStableDependencies();
+        auto vec = collector.getDependenciesByMangledName();
         vector<uint64_t> uvec;
         uvec.reserve(vec.size() + 1);
         debug_aot_hash("HASH %s %" PRIx64 "\n", fun->getMangledName().c_str(), fun->hash);
@@ -252,7 +254,7 @@ namespace das {
     string getAotHashComment ( const Function * fun ) {
         DependencyCollector collector;
         collector.collect(fun);
-        auto vec = collector.getStableDependencies();
+        auto vec = collector.getDependenciesByMangledName();
         TextWriter tw;
         tw << fun->getMangledName() << " hash=0x" << HEX << fun->hash;
         for ( const auto & fn : vec ) {
@@ -269,7 +271,7 @@ namespace das {
         for ( const auto & var : globs ) {
             collector.collect(var);
         }
-        auto vec = collector.getStableDependencies();
+        auto vec = collector.getDependenciesByMangledName();
         vector<uint64_t> uvec;
         uvec.reserve(vec.size() + 1);
         uvec.push_back(initHash);

--- a/utils/internal/dasweb-playground/deploy.sh
+++ b/utils/internal/dasweb-playground/deploy.sh
@@ -6,6 +6,8 @@
 # The bundle comes from the builder box (zen4) — from the arc worktree there:
 #
 #   cd ~/daScript-dasweb && git pull --ff-only origin <branch>
+#   # the tree must be configured -DDAS_LLVM_DISABLED=OFF -DDAS_SQLITE_DISABLED=OFF (both default ON):
+#   # release runs `daslang -exe` through dasLLVM, and the bundle ships dasSQLITE
 #   bin/daslang utils/daspkg/main.das -- release --root utils/internal/dasweb-playground --out ~/dasweb_release
 #   SHA=$(git rev-parse --short HEAD)
 #   cd ~/dasweb_release && tar czf dasweb-playground-$SHA.tar.gz dasweb-playground


### PR DESCRIPTION
libstdc++ 12 (Debian 12) marks `std::get_temporary_buffer` deprecated, and its own `std::stable_sort` still calls it without silencing the warning; libstdc++ 13 fixed the header. With clang and the repo's `-Werror`, every `std::stable_sort` in `src/` fails to compile. CI runs on ubuntu-latest (libstdc++ 13+) and never sees it. The zen4 deploy build does.

This change removes `std::stable_sort` from the compiler. The two sorts where stability is load-bearing (generic specialization in `ast_infer_type_function.cpp`, the init-function late flag in `ast_simulate.cpp`) use `das_stable_sort` from `das_qsort_r.h`, the stable merge the runtime already ships; both sort plain pointers, which its `memcpy` relocation requires. The overload-distance sort reads only the minimum and whether it is unique, so it takes the plain `sort` its neighbour `applyLSP` already uses on the same `pair<int, Function*>` shape. The two semantic-hash dependency lists in `simulate_fn_hash.cpp` switch to the unstable `sort` (resolved per config, `std::` or `eastl::`, like the neighbouring sorts). Their input is a pointer-keyed hash set, so `stable_sort` never gave tie order any meaning; and their key, the mangled name, is unique because `Module::addFunction` rejects a duplicate. So the permutation and every hash stay the same. A Debug-only assert checks that uniqueness after each sort, and the two functions are now named for the key (`get*DependenciesByMangledName`), not for the sort.

`deploy.sh` header: the tree must be configured with dasLLVM and dasSQLITE on, because `daspkg release` runs `daslang -exe`.

Where to look: the two `sort` + `DAS_ASSERT` pairs in `simulate_fn_hash.cpp`; `das_stable_sort` at `ast_infer_type_function.cpp:1840` and `ast_simulate.cpp:3990`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Debian 12 + clang-19 + libstdc++ 12 (zen4, the toolchain that fails on master), no warning suppression: `daslang` + `libDaScriptDyn` + the dasHV/dasSQLITE/dasPUGIXML/dasLiveHost modules build; `tests/language` 1713/1713. CI has no such lane.
- Local MSVC: full `tests/` 14057 passed, 0 failed, 9 skipped at the first shape; `tests/language` 1713/1713 re-run after the helper/rename/assert polish.
- Only the mechanical make-pr gates ran locally (sync, REVIEW.das, stamp-reach, ast-verify, jit-smoke); the full preflight chain did not. AOT is left to CI's `test_aot_subset`.
- Codex round at the first shape: no findings.

### Claims - stated, not tested
- `sort` is order-equivalent to the old `stable_sort` in `simulate_fn_hash.cpp`: the input is a pointer-keyed `das_hash_set`, so tie order was never deterministic, and the keys are unique (`Module::addFunction` fatals on a duplicate). Settled by reading, not by a hash-comparison run. A break would surface as `error[50101]` (AOT hash desync) in `test_aot_subset`, or as the new `DAS_ASSERT` firing in a Debug build.

### Not done
- The typed `das_sort` / `das_stable_sort` paths in `das_qsort_r.h` swap through the `using std::swap` ADL idiom, so an EASTL element type (`eastl::pair`) is ambiguous there - the EASTL CI lane surfaced it on the first shape of this PR. No remaining instantiation passes an EASTL type; making the typed paths EASTL-clean is its own change.
- The box copy `/usr/local/sbin/dasweb-deploy.sh` on dasweb-1 still carries the old header; refreshing it needs sudo on the box.
- The audit round's self-review findings on pre-existing `utils/REVIEW.md` and `utils/internal/dasweb-playground/REVIEW.md` text are deferred to the REVIEW.md grooming backlog, per the standing ruling.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
