### PR TITLE
playground wasm toolchain: nightly roll gated on green CI, and eviction of retired artifacts

### DIFF
--- a/.github/workflows/extended_checks.yml
+++ b/.github/workflows/extended_checks.yml
@@ -651,7 +651,7 @@ jobs:
       if: matrix.target == 'linux'
       run: |
         set -eux
-        for suite in test_buildd_config test_buildd_core test_buildd_client; do
+        for suite in test_buildd_config test_buildd_core test_buildd_client test_roll_toolchain; do
           $BIN/daslang _dasroot_/dastest/dastest.das -- --color --failures-only --test ./utils/internal/dasweb-buildd/$suite.das
         done
 

--- a/utils/internal/dasweb-buildd/README.md
+++ b/utils/internal/dasweb-buildd/README.md
@@ -148,10 +148,40 @@ warms it outside the sandbox with one build of **each** mode, because the page r
 ```bash
 ./roll_toolchain.sh --dry-run     # print the plan, touch nothing
 ./roll_toolchain.sh               # roll to origin/master
+./roll_toolchain.sh --green       # roll to the newest master commit whose CI is green
 ```
 
 It refuses to start if the worktree has modified tracked files, and reports the old and new id.
 Verify afterwards with the browser leg of `utils/internal/dasweb-verify`, which drives the live site.
+
+**Nightly, gated on green.** A toolchain left behind master compiles every sample with old
+daslib and old emitters: a sample that runs in the interpreter and on the CI-built /examples
+cards can still hang in wasm mode, with nothing in the build to say why. `dasweb-buildd-roll.timer`
+runs the roll every night at 04:00 box time with `--green --if-changed`: `--green` walks
+`origin/master` newest-first and takes the first commit whose push-triggered `wasm_build`,
+`build`, `build_eastl` and `extended checks` workflows all passed and on which nothing else
+failed (an in-progress run is not proof); `--if-changed` makes a night with no new green commit
+a no-op, so the service is neither rebuilt nor restarted for nothing. That no-op needs both the
+worktree's HEAD and the `.dasweb-roll-complete` marker the script writes after its last step to
+name the target: a roll that dies after the checkout leaves HEAD at the target with nothing
+rebuilt, and the next night must finish it. The timer runs the copy installed under
+`/usr/local/sbin`, never the one inside the worktree it is about to move, so a change to the
+script is re-installed by hand. The unit runs as the box user, whose restart of the service must
+not prompt for a password:
+
+```bash
+echo 'boris ALL=(root) NOPASSWD: /bin/systemctl restart dasweb-buildd' | sudo tee /etc/sudoers.d/dasweb-buildd-roll
+sudo install -m 755 utils/internal/dasweb-buildd/roll_toolchain.sh /usr/local/sbin/dasweb-roll-toolchain.sh
+sudo install -m 644 utils/internal/dasweb-buildd/dasweb-buildd-roll.service \
+                    utils/internal/dasweb-buildd/dasweb-buildd-roll.timer /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now dasweb-buildd-roll.timer
+systemctl list-timers dasweb-buildd-roll.timer      # next firing
+journalctl -u dasweb-buildd-roll.service -n 50      # last night's roll
+```
+
+`--green` reads the public Actions API unauthenticated (60 requests an hour; one per commit
+walked, at most 30) and needs `jq` on the box. `test_roll_toolchain.das` drives the green
+predicate through `--green-check <runs.json>`, one recorded run shape per branch of the rule.
 
 ## Tests
 

--- a/utils/internal/dasweb-buildd/REVIEW.md
+++ b/utils/internal/dasweb-buildd/REVIEW.md
@@ -21,8 +21,8 @@ returns and deletes what it creates before it ends.**
 **Never let `POST /shutdown` act on a request without checking that the transport peer address
 is loopback.** No header can carry that proof.
 
-**Never write the bearer token into a log line, an error message, or the startup banner - the
-banner reports set or unset and the provenance instead.**
+**Never write the service's configured bearer token into a log line, an error message, or the
+startup banner - the banner reports set or unset and the provenance instead.**
 
 **A diff that assembles a filesystem path from a request- or build-derived name - a bundle
 source or a build output alike - without passing that name through `is_valid_source_filename`,
@@ -71,12 +71,20 @@ re-queues jobs from builders that died - is not a resolution.
 
 **Never retain a route callback with `emplace` - use `push` instead.**
 
-**A diff that changes the behavior of a box-side file - `run_build.sh`, `roll_toolchain.sh`,
-`.das_package`, `watchdog.json`, `dasweb-buildd.toml` - also updates the matching `README.md`
-section (The sandbox / The toolchain-bump protocol / Run), in the same change.**
+**A diff that changes the behavior of a file in this folder other than a `.das` source or its
+test also documents that change in `README.md` - in the section covering that file, or in a new
+section for it - in the same change.**
 
-**Never let a toolchain roll (`roll_toolchain.sh`) move the worktree without rebuilding both
-the cross-compile host and the runtime archive.**
+**A diff that changes a build command line in `run_build.sh` also updates the matching
+cache-warming build in `roll_toolchain.sh`, in the same change.**
+
+**Never let a toolchain roll (`roll_toolchain.sh`) move the worktree without also rebuilding
+`bin/daslang` - the host compiler that emits the emcc link line - and
+`web/output64/lib/*_runtime*.a`.**
+
+**Never let a roll step decide to skip itself by reading the worktree's HEAD alone - it skips
+only on a marker the roll writes after its last step.** A roll that dies after the checkout
+leaves HEAD at the target with nothing rebuilt.
 
 **A diff that changes `Containerfile` also bumps the image tag in `run_build.sh` (`IMAGE=`), in
 the same change.**
@@ -112,8 +120,11 @@ its line here, with its tests, in the same change.**
 - `buildd_client.das` - the outbound HTTP calls (claim, result upload, announce). Zero
   filesystem beyond handing paths to the multipart uploader.
 - `run_build.sh` - the box-side build recipe and its sandbox invocation; the only place a
-  build command line or a sandbox mount lives.
-- `roll_toolchain.sh` - the box-side toolchain-bump recipe; the only place a roll step lives.
+  sandboxed build invocation or a sandbox mount lives.
+- `roll_toolchain.sh` - the box-side toolchain-bump recipe; the only place a roll step lives,
+  including how the nightly target commit is chosen (`--green`).
+- `dasweb-buildd-roll.service`, `dasweb-buildd-roll.timer` - the nightly roll: the installed
+  copy of `roll_toolchain.sh` with `--green --if-changed`, as the box user. No build logic.
 - `Containerfile` - the sandbox image: only what a system must provide the toolchain;
   anything a read-only mount can supply belongs in `run_build.sh`.
 - `.das_package`, `watchdog.json`, `dasweb-buildd.toml` - packaging and deployment.

--- a/utils/internal/dasweb-buildd/dasweb-buildd-roll.service
+++ b/utils/internal/dasweb-buildd/dasweb-buildd-roll.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=dasweb-buildd toolchain roll to the newest CI-green master
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=boris
+Environment=DASWEB_WASM_WORKTREE=/home/boris/daScript-wasm
+Environment=EMSDK=/home/boris/emsdk
+ExecStart=/bin/bash /usr/local/sbin/dasweb-roll-toolchain.sh --green --if-changed
+TimeoutStartSec=3h

--- a/utils/internal/dasweb-buildd/dasweb-buildd-roll.timer
+++ b/utils/internal/dasweb-buildd/dasweb-buildd-roll.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly dasweb-buildd toolchain roll
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+RandomizedDelaySec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/utils/internal/dasweb-buildd/roll_toolchain.sh
+++ b/utils/internal/dasweb-buildd/roll_toolchain.sh
@@ -21,6 +21,15 @@
 #
 #   ./roll_toolchain.sh                 roll to origin/master
 #   ./roll_toolchain.sh --ref <sha>     roll to a specific commit
+#   ./roll_toolchain.sh --green         roll to the newest origin/master commit
+#                                       whose required CI workflows all passed
+#   ./roll_toolchain.sh --if-changed    exit 0 without touching anything when the
+#                                       last COMPLETED roll already reached the
+#                                       target (the nightly timer's mode)
+#   ./roll_toolchain.sh --green-check <runs.json>
+#                                       exit 0 when the Actions runs in the file
+#                                       make a commit green, 1 otherwise; touches
+#                                       nothing (the predicate's test seam)
 #   ./roll_toolchain.sh --dry-run       print the plan, touch nothing
 #   ./roll_toolchain.sh --skip-restart  build and warm, leave the service alone
 #
@@ -29,6 +38,10 @@
 #   EMSDK                  the pinned emsdk root
 #   HOST_CC / HOST_CXX     compiler for the cross-compile host. Debian 12's bare
 #                          clang is 14 and cannot build the tree; clang-19 can.
+#   DASWEB_GITHUB_REPO     owner/name whose Actions runs --green reads
+#   DASWEB_GREEN_DEPTH     how many origin/master commits --green walks (30)
+#   GITHUB_TOKEN           optional; --green reads the public API unauthenticated
+#                          (60 requests/hour) and sends this as a bearer when set
 set -euo pipefail
 
 WORKTREE="${DASWEB_WASM_WORKTREE:-/home/boris/daScript-wasm}"
@@ -36,22 +49,75 @@ EMSDK_ROOT="${EMSDK:-/home/boris/emsdk}"
 HOST_CC="${HOST_CC:-clang-19}"
 HOST_CXX="${HOST_CXX:-clang++-19}"
 SERVICE="dasweb-buildd"
-REF="origin/master"
+GITHUB_REPO="${DASWEB_GITHUB_REPO:-GaijinEntertainment/daScript}"
+# The workflows a master commit must have passed to count as green.
+REQUIRED_WORKFLOWS='["wasm_build","build","build_eastl","extended checks"]'
+GREEN_DEPTH="${DASWEB_GREEN_DEPTH:-30}"
+# Written after the last roll step. --if-changed skips only when the marker AND
+# the worktree's HEAD both name the target: a roll that died after its checkout
+# leaves HEAD at a target with nothing rebuilt, and a later roll can leave HEAD
+# somewhere the marker never named.
+ROLL_MARKER=".dasweb-roll-complete"
+REF=""
+GREEN=0
+IF_CHANGED=0
+GREEN_CHECK=""
 DRY_RUN=0
 SKIP_RESTART=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --ref)          REF="${2:?--ref needs a commit-ish}"; shift 2 ;;
+        --green)        GREEN=1; shift ;;
+        --if-changed)   IF_CHANGED=1; shift ;;
+        --green-check)  GREEN_CHECK="${2:?--green-check needs a runs.json path}"; shift 2 ;;
         --dry-run)      DRY_RUN=1; shift ;;
         --skip-restart) SKIP_RESTART=1; shift ;;
-        -h|--help)      sed -n '2,31p' "$0"; exit 0 ;;
+        -h|--help)      awk 'NR > 1 && /^#/ { print; next } NR > 1 { exit }' "$0"; exit 0 ;;
         *)              echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done
+if [ "$GREEN" = 1 ] && [ -n "$REF" ]; then
+    echo "--green and --ref both name the target; pass one" >&2
+    exit 2
+fi
+[ -n "$REF" ] || REF="origin/master"
 
 say()  { printf '\n=== %s\n' "$*"; }
 run()  { if [ "$DRY_RUN" = 1 ]; then printf '  would run: %s\n' "$*"; else "$@"; fi; }
+
+# A commit is green when its push-triggered Actions runs cover every required
+# workflow with success and nothing that ran on it failed. An in-progress
+# required run is not proof, so such a commit is not green yet.
+runs_are_green() {
+    jq -e --argjson need "$REQUIRED_WORKFLOWS" '
+        [.workflow_runs[] | select(.event == "push")] as $runs
+        | ($need - [$runs[] | select(.conclusion == "success") | .name]) == []
+          and ([$runs[] | select(.conclusion != null and .conclusion != "success" and .conclusion != "skipped")] == [])
+    ' >/dev/null
+}
+
+# Walk origin/master newest-first and print the first green commit.
+newest_green_master() {
+    local sha auth=()
+    [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    for sha in $(git rev-list --first-parent -n "$GREEN_DEPTH" origin/master); do
+        if curl -fsS "${auth[@]}" -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/$GITHUB_REPO/actions/runs?head_sha=$sha&per_page=100" \
+                | runs_are_green; then
+            echo "$sha"
+            return 0
+        fi
+    done
+    echo "no green origin/master commit in the last $GREEN_DEPTH" >&2
+    return 1
+}
+
+if [ -n "$GREEN_CHECK" ]; then
+    command -v jq >/dev/null || { echo "--green-check needs jq" >&2; exit 15; }
+    runs_are_green < "$GREEN_CHECK"
+    exit $?
+fi
 
 # .git is a FILE in a linked worktree (a gitdir pointer), so ask git itself.
 git -C "$WORKTREE" rev-parse --git-dir >/dev/null 2>&1 \
@@ -72,14 +138,27 @@ OLD_ID="$(git rev-parse HEAD)"
 # Fetch even under --dry-run: it only moves remote-tracking refs, and without it
 # the printed plan would target whatever origin/master pointed at LAST fetch.
 git fetch origin --quiet
-NEW_ID="$(git rev-parse "$REF")"
+if [ "$GREEN" = 1 ]; then
+    command -v jq >/dev/null || { echo "--green needs jq" >&2; exit 15; }
+    NEW_ID="$(newest_green_master)" || exit 14
+    TARGET_LABEL="newest green origin/master"
+else
+    NEW_ID="$(git rev-parse "$REF")"
+    TARGET_LABEL="$REF"
+fi
+
+if [ "$IF_CHANGED" = 1 ] && [ "$OLD_ID" = "$NEW_ID" ] && [ "$(cat "$ROLL_MARKER" 2>/dev/null)" = "$NEW_ID" ]; then
+    echo "last completed roll already reached ${NEW_ID:0:9} ($TARGET_LABEL); nothing to do"
+    exit 0
+fi
 
 say "toolchain roll"
 printf '  worktree : %s\n  from     : %s\n  to       : %s (%s)\n' \
-    "$WORKTREE" "${OLD_ID:0:9}" "${NEW_ID:0:9}" "$REF"
-# Already-at-target is NOT an early exit: a roll that died mid-way leaves the
-# worktree moved but the rebuild/warm/restart undone, and re-running must finish
-# the job. Every later step is idempotent and cheap when already up to date.
+    "$WORKTREE" "${OLD_ID:0:9}" "${NEW_ID:0:9}" "$TARGET_LABEL"
+# Already-at-target is an early exit only under --if-changed, and only once the
+# marker says that roll completed: a roll that died mid-way leaves the worktree
+# moved but the rebuild/warm/restart undone, and re-running must finish the job.
+# Every later step is idempotent and cheap when already up to date.
 if [ "$OLD_ID" = "$NEW_ID" ]; then
     echo "  worktree already at target — resuming (rebuild/warm/restart are idempotent)"
 fi
@@ -142,7 +221,7 @@ else
         _ "$EMSDK_ROOT" "$WORKTREE" "$WARM" "$RUNTIME_LIB"
 
     echo "  page mode…"
-    # The same .das_package shape write_sample_package (buildd_core.das) writes
+    # The same .das_package shape write_page_package (buildd_core.das) writes
     # for a real page job — a change to either without the other is a defect.
     printf 'options gen2\nrequire daslib/daspkg\n\n[export]\ndef package() {\n    package_name("sample")\n}\n\n[export]\ndef release() {\n    release_name("sample")\n    release_main("main.das")\n}\n' \
         > "$WARM/src/.das_package"
@@ -157,6 +236,7 @@ else
     run sudo systemctl restart "$SERVICE"
     run sleep 3
     run systemctl is-active "$SERVICE"
+    [ "$DRY_RUN" = 1 ] || printf '%s\n' "$NEW_ID" > "$ROLL_MARKER"
 fi
 
 say "rolled ${OLD_ID:0:9} -> ${NEW_ID:0:9}"

--- a/utils/internal/dasweb-buildd/test_roll_toolchain.das
+++ b/utils/internal/dasweb-buildd/test_roll_toolchain.das
@@ -1,0 +1,76 @@
+options gen2
+
+require dastest/testing_boost public
+require daslib/fio
+require daslib/strings_boost
+require strings
+
+//! The green predicate of roll_toolchain.sh through its --green-check seam:
+//! one recorded actions/runs shape per branch of the rule. Needs bash and jq on
+//! the host, which the linux CI lane has; elsewhere the suite skips.
+
+let SCRIPT = "utils/internal/dasweb-buildd/roll_toolchain.sh"
+
+def private tools_present : bool {
+    if (!stat(SCRIPT).is_valid) {
+        return false
+    }
+    let rc = unsafe(popen_argv(["jq", "--version"], 30.0) $(_f) {
+    })
+    return rc == 0
+}
+
+def private green_check(runs_json : string) : int {
+    var err = ""
+    let dir = create_temp_directory("buildd_green_", err)
+    let file = path_join(dir, "runs.json")
+    fwrite(file, runs_json)
+    let rc = unsafe(popen_argv(["bash", SCRIPT, "--green-check", file], 30.0) $(_f) {
+    })
+    rmdir_rec(dir)
+    return rc
+}
+
+def private run_of(name : string; conclusion : string; event : string = "push") : string {
+    let c = conclusion == "null" ? "null" : "\"{conclusion}\""
+    return "\{\"name\":\"{name}\",\"event\":\"{event}\",\"conclusion\":{c}\}"
+}
+
+def private runs_of(items : array<string>) : string {
+    return "\{\"workflow_runs\":[" + join(items, ",") + "]\}"
+}
+
+def private all_required : array<string> {
+    return <- [run_of("wasm_build", "success"), run_of("build", "success"),
+        run_of("build_eastl", "success"), run_of("extended checks", "success")]
+}
+
+[test]
+def test_green_predicate(t : T?) {
+    if (!tools_present()) {
+        t |> skip("bash + jq not on this host, or not run from the repo root")
+        return
+    }
+    t |> run("all required workflows passed") @(tt : T?) {
+        tt |> equal(green_check(runs_of(all_required())), 0)
+    }
+    t |> run("a required workflow missing is not green") @(tt : T?) {
+        tt |> equal(green_check(runs_of([run_of("wasm_build", "success"), run_of("build", "success")])), 1)
+    }
+    t |> run("a required workflow still running is not green") @(tt : T?) {
+        var items <- all_required()
+        items[0] = run_of("wasm_build", "null")
+        tt |> equal(green_check(runs_of(items)), 1)
+    }
+    t |> run("any other workflow failing is not green") @(tt : T?) {
+        var items <- all_required()
+        items |> push(run_of("CodeQL", "failure"))
+        tt |> equal(green_check(runs_of(items)), 1)
+    }
+    t |> run("a skipped extra workflow and a failed pull_request run are ignored") @(tt : T?) {
+        var items <- all_required()
+        items |> push(run_of("Build doc", "skipped"))
+        items |> push(run_of("build", "failure", "pull_request"))
+        tt |> equal(green_check(runs_of(items)), 0)
+    }
+}

--- a/utils/internal/dasweb-playground/README.md
+++ b/utils/internal/dasweb-playground/README.md
@@ -112,6 +112,11 @@ immutable headers. An upload is staged under `blobs/tmp/`, every file verified a
 manifest sha256, and the whole set renamed into place atomically - a half-written artifact is
 never served. `caddy.snippet` carries the 64MB transport cap for `/api/build/*` uploads.
 
+A toolchain the builder no longer announces keeps its tree for a day after its last write - an
+open tab has long re-fetched, and a roll-back finds its cache warm - then an hourly sweep
+removes the tree. Job rows of a toolchain with no tree left go with it, so a roll-back inside
+the day still finds every cached build.
+
 A build's **mode** is decided here at request time by scanning the stored source's requires
 (`detect_build_mode` in `build_queue.das`): a native graphics/audio namespace (glfw, opengl,
 audio, ...) makes it a `page` build - a standalone `sample.{html,js,wasm}` emscripten page,

--- a/utils/internal/dasweb-playground/REVIEW.md
+++ b/utils/internal/dasweb-playground/REVIEW.md
@@ -19,11 +19,11 @@ against the store, is a defect.
 creates.**
 
 **Never remove `set_bind_host("127.0.0.1")`, move it past `start`, or make it conditional - it
-stays between `init` and `start`, so the server binds loopback only.**
+stays between the server object's `init(port)` and `start()` calls, so the server binds loopback
+only.**
 
-**A diff that adds a SQL statement puts it through the `daslib/sql_linq` rail (`_sql` /
-`insert` / `_sql_update`) or bound parameters.** A query assembled by string interpolation or
-`format` from any request-derived value is a defect.
+**A diff that adds a SQL statement puts it through a `daslib/sql_linq` call macro or bound
+parameters.** A query assembled by string interpolation or `format` is a defect.
 
 **A route that accepts a body without a `request_body` limit in `caddy.snippet` in front of it
 is a defect, as is a hash or insert reachable without the size check against the configured
@@ -60,9 +60,10 @@ directory into place after every file's sha256 verifies.**
 instead of taking the builder's word.** A build runs the user's own compile-time code, so
 accepting whatever set the builder sends would let a build put an extra file on this origin.
 
-**Never put SQL, hashing, or policy (size, rate, listing) in a route handler, and never require
-`dashv` in `samples_store.das` - a handler validates transport shape, makes one store call, and
-formats the response, and those three live in `samples_store.das`.**
+**Never put SQL, hashing, or policy (size, rate, listing, retention) in a route handler, and
+never require `dashv` in `samples_store.das` - a handler validates transport shape, makes one
+store call, and formats the response, and SQL, hashing, and policy live in the store and cache
+files the placement block names.**
 
 **Never enable CORS on any route.** The middleware reflects the caller's `Origin` on every route
 at once, which would make stored samples and the operator surface cross-origin readable.
@@ -96,8 +97,9 @@ it.** A failure path that can trigger without leaving a log line is a defect.
 **Never serve the first request before the startup banner has logged the full effective config
 with per-key provenance.**
 
-**Never keep state the `init`/`update`/`shutdown` lifecycle owns anywhere but a module global,
-and never leave a collectable value in a `main`-loop local across `maybe_collect_gc()`.**
+**Never keep state the exported `init`/`update`/`shutdown` lifecycle in `main.das` owns anywhere
+but a module global, and never leave a collectable value in a `main`-loop local across
+`maybe_collect_gc()`.**
 
 **Never create a `SqlRunner` on one thread and use it on another - the store opens inside the
 thread that serves it.**
@@ -127,8 +129,9 @@ its line here, with its tests, in the same change.**
 - `playground_config.das` - the config schema (`ServerArgs`), the defaults/toml/CLI merge with
   per-key provenance, normalization of merged config values, the startup banner payload. No
   HTTP, no SQL, no filesystem beyond reading the config file.
-- `playground_server.das` - the `HvWebServer` class: the route table and handlers. No SQL,
-  no hashing, no policy.
+- `playground_server.das` - the `HvWebServer` class: the route table, the handlers, and
+  `init_server`/`update_server`/`shutdown_server`. No SQL statement, no hashing, no policy
+  constant (size, rate, listing, retention).
 - `samples_store.das` - the store: schema structs, migrations, store operations, content
   hashing, and every policy decision (size cap, rate ceiling, listing). Zero HTTP.
 - `build_queue.das` - the build queue: `BuildJob`/`BuildMeta` schema, the migrations it owns,

--- a/utils/internal/dasweb-playground/build_artifacts.das
+++ b/utils/internal/dasweb-playground/build_artifacts.das
@@ -129,6 +129,66 @@ def clear_stage_dirs(blobs_dir : string) {
     }
 }
 
+//! How long a stale toolchain's artifacts outlive their last write.
+let STALE_TOOLCHAIN_GRACE_SECONDS = 24l * 3600l
+
+//! How often the server looks for stale toolchains.
+let TOOLCHAIN_SWEEP_INTERVAL_SECONDS = 3600l
+
+def toolchain_sweep_due(last_sweep : int64; now : int64) : bool {
+    //! True once TOOLCHAIN_SWEEP_INTERVAL_SECONDS have passed since last_sweep;
+    //! a last_sweep of 0 is always due.
+    return last_sweep == 0l || now - last_sweep >= TOOLCHAIN_SWEEP_INTERVAL_SECONDS
+}
+
+def toolchains_on_disk(blobs_dir : string) : array<string> {
+    //! The toolchain ids that have an artifact tree under blobs/ right now.
+    var found : array<string>
+    if (empty(blobs_dir)) {
+        return <- found
+    }
+    dir(blobs_dir) $(name) {
+        if (is_valid_toolchain_id(name) && stat(path_join(blobs_dir, name)).is_dir) {
+            found |> push(name)
+        }
+    }
+    return <- found
+}
+
+def sweep_stale_toolchains(blobs_dir : string; current_toolchain : string; now : int64) : int {
+    //! Removes every blobs/<toolchain>/ tree other than current_toolchain whose
+    //! last write is older than STALE_TOOLCHAIN_GRACE_SECONDS, and nothing at
+    //! all when current_toolchain is empty. Returns how many trees are gone; a
+    //! tree the filesystem refused to remove is logged and not counted.
+    //! blobs/tmp and names that are not toolchain ids are never touched.
+    if (empty(blobs_dir) || empty(current_toolchain)) {
+        return 0
+    }
+    var candidates : array<string>
+    dir(blobs_dir) $(name) {
+        if (name != current_toolchain && is_valid_toolchain_id(name)) {
+            candidates |> push(name)
+        }
+    }
+    var removed = 0
+    for (name in candidates) {
+        let p = path_join(blobs_dir, name)
+        let st = stat(p)
+        if (!st.is_valid || !st.is_dir) continue
+        let age = now - int64(st.mtime)
+        if (age < STALE_TOOLCHAIN_GRACE_SECONDS) continue
+        if (!rmdir_rec(p) || stat(p).is_valid) {
+            logger_error("playground.artifacts", "stale toolchain artifacts not removed",
+                JV((toolchain = name, age_seconds = age)))
+            continue
+        }
+        logger_info("playground.artifacts", "stale toolchain artifacts removed",
+            JV((toolchain = name, age_seconds = age)))
+        removed ++
+    }
+    return removed
+}
+
 var private g_stage_counter = 0
 
 def create_stage_dir(blobs_dir : string) : string {

--- a/utils/internal/dasweb-playground/build_queue.das
+++ b/utils/internal/dasweb-playground/build_queue.das
@@ -188,6 +188,35 @@ def set_current_toolchain(db : SqlRunner; toolchain : string) {
     logger_info("playground.build", "current toolchain set", JV((toolchain = toolchain)))
 }
 
+def forget_stale_toolchain_jobs(db : SqlRunner; current_toolchain : string; toolchains_with_artifacts : array<string>; before : int64) : int {
+    //! Drop every job row minted under a toolchain other than current_toolchain
+    //! that has no artifact tree any more and was queued before `before`;
+    //! nothing when no toolchain is announced. A row whose tree still stands
+    //! stays with it, so a roll-back inside the grace period finds its cache
+    //! warm; a builder claims only its own toolchain's jobs, so a row without a
+    //! tree can never run again, and its sample re-enqueues under the current
+    //! toolchain on its next click. Returns the rows removed.
+    if (empty(current_toolchain)) {
+        return 0
+    }
+    let old <- _sql(db |> select_from(type<BuildJob>) |> _where(_.ToolchainId != current_toolchain && _.QueuedAt < before))
+    var treeless : table<string>
+    for (row in old) {
+        if (find_index(toolchains_with_artifacts, row.ToolchainId) < 0) {
+            treeless |> insert(row.ToolchainId)
+        }
+    }
+    var n = 0
+    for (toolchain in keys(treeless)) {
+        n += db |> _sql_delete(type<BuildJob>, _.ToolchainId == toolchain && _.QueuedAt < before)
+    }
+    if (n > 0) {
+        logger_info("playground.build", "stale toolchain jobs removed",
+            JV((current_toolchain = current_toolchain, queued_before = before, jobs = n)))
+    }
+    return n
+}
+
 def private job_rows(db : SqlRunner; hash : string; toolchain : string) : array<BuildJob> {
     return <- _sql(db |> select_from(type<BuildJob>)
         |> _where(_.Hash == hash && _.ToolchainId == toolchain)

--- a/utils/internal/dasweb-playground/playground_server.das
+++ b/utils/internal/dasweb-playground/playground_server.das
@@ -349,6 +349,7 @@ def private handle_build_toolchain(var req : HttpRequest?; var resp : HttpRespon
         return resp |> JSON(write_json(JV((error = "malformed toolchain id"))), http_status.BAD_REQUEST)
     }
     set_current_toolchain(g_db, toolchain)
+    g_last_toolchain_sweep = 0l   // a roll retires the previous toolchain on the next tick, not within the hour
     let body = write_json(JV((toolchain = toolchain)))
     log_request("POST", "/api/build/toolchain", 200, ip, length(toolchain), length(body), t0)
     return resp |> JSON(body)
@@ -705,6 +706,7 @@ def init_server(port : int; db_path : string; policy : StorePolicy; base_url : s
     g_curated_dir = curated_dir
     g_build = build
     g_stop_requested = false
+    g_last_toolchain_sweep = 0l
     if (!empty(g_build.blobs_dir)) {
         clear_stage_dirs(g_build.blobs_dir)   // a crash mid-upload leaks a stage dir
     }
@@ -741,9 +743,21 @@ def init_server(port : int; db_path : string; policy : StorePolicy; base_url : s
     return true
 }
 
+var private g_last_toolchain_sweep : int64 = 0l
+
+def private evict_stale_toolchains(now : int64) {
+    //! Runs on the serving thread, the one that owns g_db.
+    if (empty(g_build.blobs_dir) || !toolchain_sweep_due(g_last_toolchain_sweep, now)) return
+    g_last_toolchain_sweep = now
+    let toolchain = current_toolchain(g_db)
+    sweep_stale_toolchains(g_build.blobs_dir, toolchain, now)
+    forget_stale_toolchain_jobs(g_db, toolchain, toolchains_on_disk(g_build.blobs_dir), now - STALE_TOOLCHAIN_GRACE_SECONDS)
+}
+
 def update_server : bool {
     //! One tick. Returns false once shutdown was requested.
     return false if (g_server == null)
+    evict_stale_toolchains(current_unix_time())
     g_server->tick()
     if (g_stop_requested) {
         return false

--- a/utils/internal/dasweb-playground/test_build_artifacts.das
+++ b/utils/internal/dasweb-playground/test_build_artifacts.das
@@ -149,3 +149,58 @@ def test_stage_cleanup(t : T?) {
         }
     }
 }
+
+def private place_artifact(blobs : string; toolchain : string; hash : string) {
+    let stage = create_stage_dir(blobs)
+    fwrite(path_join(stage, "sample.wasm"), "bytes")
+    let files <- [ArtifactFile(name = "sample.wasm", sha256 = sha256_hex("bytes"))]
+    finalize_artifact(blobs, toolchain, hash, stage, files)
+}
+
+[test]
+def test_stale_toolchain_sweep(t : T?) {
+    with_temp_blobs() $(blobs) {
+        let stale_tc = "feed5678deadbeef000000000000000000000000"
+        place_artifact(blobs, TC, H1)
+        place_artifact(blobs, stale_tc, H1)
+        let stage = create_stage_dir(blobs)
+        let stray_file = path_join(blobs, "0badf00d0badf00d0badf00d0badf00d0badf00d")
+        fwrite(stray_file, "a file named like a toolchain id")
+        let now = int64(get_clock())
+        let later = now + STALE_TOOLCHAIN_GRACE_SECONDS + 1l
+        t |> run("the grace period is a day") @(tt : T?) {
+            tt |> equal(STALE_TOOLCHAIN_GRACE_SECONDS, 86400l)
+        }
+        t |> run("a stale toolchain inside the grace period stays") @(tt : T?) {
+            tt |> equal(sweep_stale_toolchains(blobs, TC, now), 0)
+            tt |> success(!empty(resolve_artifact_file(blobs, stale_tc, H1, "sample.wasm")), "still served")
+        }
+        t |> run("the trees on disk are the two toolchains, not tmp or the stray file") @(tt : T?) {
+            let on_disk <- toolchains_on_disk(blobs)
+            tt |> equal(length(on_disk), 2)
+            tt |> success(find_index(on_disk, TC) >= 0 && find_index(on_disk, stale_tc) >= 0, "both toolchains listed")
+        }
+        t |> run("past the grace period it goes; the current toolchain, blobs/tmp and a stray file stay") @(tt : T?) {
+            tt |> equal(sweep_stale_toolchains(blobs, TC, later), 1)
+            tt |> equal(length(toolchains_on_disk(blobs)), 1)
+            tt |> equal(resolve_artifact_file(blobs, stale_tc, H1, "sample.wasm"), "")
+            tt |> success(!empty(resolve_artifact_file(blobs, TC, H1, "sample.wasm")), "current toolchain intact")
+            tt |> success(stat(stage).is_valid, "stage root untouched")
+            tt |> success(stat(stray_file).is_valid, "a plain file is not a toolchain tree")
+        }
+        t |> run("no announced toolchain means nothing is swept") @(tt : T?) {
+            place_artifact(blobs, stale_tc, H1)
+            tt |> equal(sweep_stale_toolchains(blobs, "", later), 0)
+            tt |> success(!empty(resolve_artifact_file(blobs, stale_tc, H1, "sample.wasm")), "kept")
+        }
+    }
+}
+
+[test]
+def test_toolchain_sweep_cadence(t : T?) {
+    t |> run("a fresh process sweeps at once, then once per interval") @(tt : T?) {
+        tt |> success(toolchain_sweep_due(0l, 1000l), "first tick is due")
+        tt |> success(!toolchain_sweep_due(1000l, 1000l + TOOLCHAIN_SWEEP_INTERVAL_SECONDS - 1l), "inside the interval")
+        tt |> success(toolchain_sweep_due(1000l, 1000l + TOOLCHAIN_SWEEP_INTERVAL_SECONDS), "at the interval")
+    }
+}

--- a/utils/internal/dasweb-playground/test_build_endpoints.das
+++ b/utils/internal/dasweb-playground/test_build_endpoints.das
@@ -577,3 +577,31 @@ def test_large_artifact_serves_whole(t : T?) {
     remove(upload_src)
     rmdir_rec(blobs)
 }
+
+[test]
+def test_announce_retires_stale_toolchain(t : T?) {
+    var err = ""
+    let blobs = create_temp_directory("dasweb_ep_blobs_", err)
+    let stale_tc = "feed5678deadbeef000000000000000000000000"
+    let stale_tree = path_join(blobs, stale_tc)
+    mkdir_rec(path_join(stale_tree, "1111111111111111111111111111111111111111111111111111111111111111"))
+    fwrite(path_join(path_join(stale_tree, "1111111111111111111111111111111111111111111111111111111111111111"), "sample.wasm"), "old bytes")
+    let back_dated = set_mtime_result(stale_tree, mktime(2000, 1, 1, 0, 0, 0))
+    with_build_server(TEST_TOKEN, blobs) $(base_url) {
+        t |> run("a stale toolchain's tree is gone on the tick after the announce") @(tt : T?) {
+            tt |> success(!(back_dated is error), "back-dated the stale tree")
+            authed_post("{base_url}/api/build/toolchain", TC, TEST_TOKEN) $(resp) {
+                tt |> equal(int(resp.status_code), 200)
+            }
+            var gone = false
+            for (_attempt in range(300)) {
+                gone = !stat(stale_tree).is_valid
+                if (gone) break
+                sleep(10u)
+            }
+            tt |> success(gone, "stale toolchain tree removed")
+            tt |> success(stat(blobs).is_valid, "blobs root untouched")
+        }
+    }
+    rmdir_rec(blobs)
+}

--- a/utils/internal/dasweb-playground/test_build_queue.das
+++ b/utils/internal/dasweb-playground/test_build_queue.das
@@ -269,3 +269,35 @@ def test_queue_positions(t : T?) {
         }
     }
 }
+
+def private no_trees : array<string> {
+    var none : array<string>
+    return <- none
+}
+
+[test]
+def test_forget_stale_toolchain_jobs(t : T?) {
+    with_latest_sqlite(":memory:") $(db) {
+        let stale_tc = "feed5678deadbeef000000000000000000000000"
+        let h2 = "2222222222222222222222222222222222222222222222222222222222222222"
+        enqueue_build(db, H1, TC, BUILD_MODE_MODULE, 1000l)
+        enqueue_build(db, H1, stale_tc, BUILD_MODE_MODULE, 1000l)
+        enqueue_build(db, h2, stale_tc, BUILD_MODE_MODULE, 2000l)
+        t |> run("no announced toolchain purges nothing") @(tt : T?) {
+            tt |> equal(forget_stale_toolchain_jobs(db, "", no_trees(), 5000l), 0)
+        }
+        t |> run("a stale toolchain whose tree still stands keeps its rows") @(tt : T?) {
+            tt |> equal(forget_stale_toolchain_jobs(db, TC, [stale_tc], 5000l), 0)
+        }
+        t |> run("without a tree, only stale rows queued before the cutoff go") @(tt : T?) {
+            tt |> equal(forget_stale_toolchain_jobs(db, TC, no_trees(), 1500l), 1)
+            tt |> equal(forget_stale_toolchain_jobs(db, TC, no_trees(), 1500l), 0)
+            tt |> success(!enqueue_build(db, h2, stale_tc, BUILD_MODE_MODULE, 2500l).created, "the newer stale row is still there")
+            tt |> equal(forget_stale_toolchain_jobs(db, TC, no_trees(), 3000l), 1)
+        }
+        t |> run("the current toolchain keeps its rows; a purged sample re-enqueues fresh") @(tt : T?) {
+            tt |> success(!enqueue_build(db, H1, TC, BUILD_MODE_MODULE, 4000l).created, "current toolchain's job survives")
+            tt |> success(enqueue_build(db, H1, stale_tc, BUILD_MODE_MODULE, 4001l).created, "re-enqueues fresh")
+        }
+    }
+}


### PR DESCRIPTION
**Box change: the build box now rolls its wasm toolchain every night, to the newest master commit whose CI is green; every roll re-keys the artifact cache, so the first click on each sample after a roll pays a real build.**

The playground's wasm mode compiles samples on the build box with a pinned worktree, and that worktree had fallen 16 days and 1091 commits behind master. River Run went black in wasm mode - its SSAO shader needs the dasGlsl for-header fix from Aug 27 - while the interpreter and the CI-built /examples card ran fine, because only the pinned toolchain was old. Nothing rolled it but a person remembering to.

`roll_toolchain.sh` gains `--green`: walk `origin/master` newest-first and take the first commit whose push-triggered `wasm_build`, `build`, `build_eastl` and `extended checks` runs all passed and on which nothing else failed; an in-progress run is not proof. `--if-changed` makes a night with no new green commit a no-op. That no-op needs both the worktree's HEAD and a marker the script writes after its last step to name the target, because a roll that dies after the checkout leaves HEAD at the target with nothing rebuilt and the next night must finish it. `dasweb-buildd-roll.timer` runs the installed copy at 04:00 with both flags. `--green-check <runs.json>` exposes the predicate, and `test_roll_toolchain.das` drives it through one recorded run shape per branch.

The artifact cache was already keyed by toolchain, but nothing evicted a retired one, so every roll left the previous `<toolchain>/` tree on disk forever. `build_artifacts.das` now sweeps trees other than the announced toolchain a day after their last write, `build_queue.das` drops the job rows of other toolchains that have no tree left and were queued before that same cutoff - a row whose tree still stands stays with it, so a roll-back inside the day finds every cached build - and the server runs both hourly on its serving thread, and on the first tick after an announce, so a roll retires its predecessor at once.

Where to look: `runs_are_green` and the `--if-changed` marker in `roll_toolchain.sh`; `sweep_stale_toolchains` in `build_artifacts.das`; `evict_stale_toolchains` and the reset in the announce handler in `playground_server.das`.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The nightly unit ran once under systemd on the build box after install: `last completed roll already reached 8c3bb31b8 (newest green origin/master); nothing to do`, clean exit. The same script rolled the box by hand earlier today (`5178dc4c2` -> `8c3bb31b8`, ~12 min); River Run then ran in wasm mode.
- `test_roll_toolchain.das` needs `bash` + `jq`: 6/6 on the build box (Debian 12), skipped on the Windows dev box. The linux lane of `extended_checks` now runs it.
- Only the mechanical make-pr gates ran locally (sync, REVIEW.das, stamp-reach, dupes, ast-verify); the full preflight chain did not. No AOT surface.
- Two codex rounds. Round one's four findings (noninteractive sudo, rows of a toolchain that never built, predicate coverage, lifecycle coverage) and round two's three (rows purged while their tree is still in grace, the no-op skip needing HEAD as well as the marker, a shell-string spawn in the test probe) are all in this shape; no third round ran.

### Claims - stated, not tested
- `GITHUB_TOKEN` set -> bearer header: never exercised; every run so far was unauthenticated. A break would show as HTTP 401 in the unit's journal.
- The eviction runs `rmdir_rec` on the serving thread ahead of the request tick. One retired toolchain tree is a few dozen files, so `/healthz` stalls for milliseconds at most; a break would show as watchdog health flaps at the top of the hour after a roll.
- Which trees get evicted follows the toolchain the authenticated builder announces; a builder announcing a well-formed but wrong id retires every real toolchain a day later. The builder is the trusted announcer by design (the token is the boundary), so this is accepted, not guarded.

### Not done
- The install is by hand on the box (script to `/usr/local/sbin`, two units, one sudoers line); the README carries the lines. The box has all of it in place as of this PR.
- Self-review findings on pre-existing checklist text from the audit round (a two-read sentence, a duplicated mount rule, the wasm-archive pair, three lint candidates in `utils/internal/dasweb-buildd/REVIEW.md`; the policy-home tail and the two-kinds test rule in `utils/internal/dasweb-playground/REVIEW.md`) are ledgered for the REVIEW.md grooming follow-up.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
