### PR TITLE
site: benchmark comments follow dasProfile's 'native loop' -&gt; 'interop host calls' rename

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -265,7 +265,7 @@
     };
     var state = { platform: "windows", board: "Interpreted", view: "bars", sortCol: -1, sortDesc: false, data: null };
 
-    // "native loop" measures interop only - no playground sample
+    // "interop host calls" measures interop only - no playground sample
     var PLAYGROUND_SLUGS = {
         "sha256": "sha256", "dictionary": "dict", "n-bodies": "nbodies", "mandelbrot": "mandelbrot",
         "spectral norm": "spectral_norm", "exp loop": "exp", "string2float": "f2i",

--- a/site/files/forge.js
+++ b/site/files/forge.js
@@ -499,7 +499,7 @@ def main() {
         'primes loop':          'primes',
         'sort':                 'table_sort',
         'tree':                 'tree',
-        // 'native loop' — C-baseline workload, no playground sample.
+        // 'interop host calls' — C-baseline workload, no playground sample.
     };
 
     function renderFooter() {


### PR DESCRIPTION
Companion to borisbat/dasProfile#13, which renames the 'native loop' benchmark row to 'interop host calls' in the test sources and both platform records (in place — no reprofile).

The site renders whatever names the fetched dasProfile records carry, so the board itself needs no change and picks up the new name at its next deploy. The only daScript-side references were the two comments explaining why that row is excluded from the playground slug maps — `site/benchmarks.html` and `site/files/forge.js` — renamed here.

Two comment lines, no code, no `.das`; pre-PR gates skipped as not applicable (nothing compiles, lints, formats, or tests against this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
