### PR TITLE
nightly playground: retry a dropped artifact navigation, and log the run origin

### DIFF
--- a/plans/dasweb_sample_verifier.md
+++ b/plans/dasweb_sample_verifier.md
@@ -185,3 +185,23 @@ with the just-built binary and catches sample rot per-PR. Currently tier 1 runs 
 - Runtime bugs: jobque-on-wasm-interpreter wedge; arcanoid threaded strudel -> tick port.
 - imgui-UI-presence checking (the discarded-draw-list blind spot) - needs a structured
   snapshot rail in the web harness, not v1.
+
+## Ledgered by the artifact-nav-retry arc
+
+- **A `REVIEW.das` gate over `browser/REVIEW.md`'s placement block.** "Every tracked file in
+  the folder has a line, every line names an existing file" is decidable from tree state
+  alone, so a gate retires the manual inventory pass permanently. Ruled out of the retry PR
+  as scope.
+- **The browser leg's `node --test` runs in no per-PR lane** - only
+  `nightly_playground.yml`, so a case the checklist demands is first executed the night after
+  merge. Ruled: CI catches it, no per-PR lane added.
+- **Self-review findings on three checklists this arc did not otherwise touch**, left for
+  whoever next edits them: `dasweb-playground/REVIEW.md` - the dastest-coverage rule's trigger
+  is unsatisfiable for a `caddy.snippet` edit (no dastest can observe a Caddy directive), the
+  five-file placement line leaves `caddy.snippet`'s role to inference, and the structured-line
+  rule names no log surface now that the vhost has one. `dasweb-verify/REVIEW.md` - "answers
+  to `browser/REVIEW.md`" does not say instead-of or in-addition-to, "failure line" is
+  undefined, and "core behavior" names no API. `utils/REVIEW.md` - the local-run-evidence
+  rule enumerates two cases where one property unites them, and a suite no per-PR lane runs
+  is a third case it misses; that trigger was ruled on recently, so widening it is a question,
+  not a fix.

--- a/plans/dasweb_sample_verifier.md
+++ b/plans/dasweb_sample_verifier.md
@@ -195,6 +195,11 @@ with the just-built binary and catches sample rot per-PR. Currently tier 1 runs 
 - **The browser leg's `node --test` runs in no per-PR lane** - only
   `nightly_playground.yml`, so a case the checklist demands is first executed the night after
   merge. Ruled: CI catches it, no per-PR lane added.
+- **NEEDS RULING: the woodpecker damper's two past-the-defaults gates.** One bullet arms a
+  round "only when it materially rewrote logic", the next keeps going "only where failure is
+  silent". A caller who materially rewrote logic in a loud-failure area gets opposite answers.
+  AND or OR is a policy call about how many rounds an arc pays for - Boris's to make, then
+  the two bullets collapse into one.
 - **The woodpecker damper is stated in two places.** `skills/internal/woodpecker.md` says
   "this file owns only the budget", but `skills/internal/make_pr.md` step 0a3 restates it in
   spirit ("Every arc, trivial or not; non-trivial arcs re-round on the fixed tip"). One copy

--- a/plans/dasweb_sample_verifier.md
+++ b/plans/dasweb_sample_verifier.md
@@ -195,6 +195,10 @@ with the just-built binary and catches sample rot per-PR. Currently tier 1 runs 
 - **The browser leg's `node --test` runs in no per-PR lane** - only
   `nightly_playground.yml`, so a case the checklist demands is first executed the night after
   merge. Ruled: CI catches it, no per-PR lane added.
+- **The woodpecker damper is stated in two places.** `skills/internal/woodpecker.md` says
+  "this file owns only the budget", but `skills/internal/make_pr.md` step 0a3 restates it in
+  spirit ("Every arc, trivial or not; non-trivial arcs re-round on the fixed tip"). One copy
+  should survive - the woodpecker's - and the make_pr cell drop to a pointer.
 - **Self-review findings on three checklists this arc did not otherwise touch**, left for
   whoever next edits them: `dasweb-playground/REVIEW.md` - the dastest-coverage rule's trigger
   is unsatisfiable for a `caddy.snippet` edit (no dastest can observe a Caddy directive), the

--- a/skills/internal/woodpecker.md
+++ b/skills/internal/woodpecker.md
@@ -12,29 +12,44 @@ never runs dry - so the damper below is part of the design, not a cost-saving me
 
 ```bash
 # a branch against its base (the normal PR shape)
-codex exec --sandbox read-only -o <report.md> review --base origin/master
+codex exec --sandbox read-only -o <report.md> review --base origin/master 2>&1 | tee <run.log>
 # one commit
-codex exec --sandbox read-only -o <report.md> review --commit <sha>
+codex exec --sandbox read-only -o <report.md> review --commit <sha> 2>&1 | tee <run.log>
+# the round is a skip unless BOTH of these stay quiet
+[ -s <report.md> ] || echo "empty report - harvest from <run.log>"
+grep -q "Review was interrupted" <run.log> && echo "ROUND DID NOT RUN - disclose as skipped"
 ```
+
+A round writes two sinks: the `-o` report file and the tee'd run log. Either can hold the
+findings, and the report file can come back empty on a round that succeeded.
 
 - Global flags go BEFORE the `review` subcommand. `--base` / `--commit` exclude a custom
   prompt - a custom prompt runs the generic agent, not the native reviewer; prefer native.
 - The base is `origin/master`, never local `master` - the checklist rebases branches onto
   `origin/master` and leaves local `master` stale, so a stale base sweeps unrelated
   upstream commits into the review.
-- Write the report outside the repo (the session scratchpad) or under `logs/`
-  (gitignored) - a bare in-tree filename is exactly the untracked debris the preflight
-  gate rejects.
-- Run it in a tree checked out at the tip you want reviewed, and record that sha with the
-  report - findings are claims about exact bytes, and re-reviews only mean anything
-  against a pinned commit. The recorded sha does not freeze what codex reads: the tree
-  must not change until harvest - launch after the last mutating step, or give the run
-  its own worktree at that sha.
-- No `codex` on PATH? The round is skipped, and the PR body says so - the gate is the
-  disclosure, never a silent pass.
-- A round runs tens of minutes (~25 measured 2026-08): run it in a background Bash and
-  keep working; never sit idle waiting on it. Launch and harvest points are the
+- Write both sinks outside the repo (the session scratchpad) or under `logs/` (gitignored) -
+  a bare in-tree filename is exactly the untracked debris the preflight gate rejects.
+- Run it in a tree checked out at the tip you want reviewed, and pin that sha beside the sink
+  you keep - findings are claims about exact bytes, and re-reviews only mean anything against
+  a pinned commit. The pinned sha does not freeze what codex reads: the tree must not change
+  until harvest - launch after the last mutating step, or give the run its own worktree at
+  that sha.
+- **Harvest from whichever sink holds the findings; when the report is empty the run log is
+  the record.**
+- **Never read the exit status as the verdict: codex exits 0 on a round that never ran.**
+  Expired auth exits 0 having printed `Review was interrupted` and token-refresh errors and
+  nothing else. A round counts as run only when a sink holds P-ranked findings or codex's
+  explicit no-issues line; anything else is a skip.
+- No `codex` on PATH, or a round that did not run? The round is skipped, and the PR body says
+  so - the gate is the disclosure, never a silent pass.
+- A round can finish in under a minute or run for tens of minutes - run it in a background
+  Bash and keep working; never sit idle waiting on it. Launch and harvest points are the
   caller's (see the damper).
+- **Before reporting a round as no-findings, confirm the sink shows it reading the files the
+  diff changed.** Duration says nothing about depth - a one-minute round can read every
+  changed file and run the suite. A truncated capture leaves only the verdict, which reads
+  exactly like a round that did nothing; the exec trace is what tells them apart.
 
 ## The findings loop
 

--- a/skills/internal/woodpecker.md
+++ b/skills/internal/woodpecker.md
@@ -15,19 +15,21 @@ never runs dry - so the damper below is part of the design, not a cost-saving me
 codex exec --sandbox read-only -o <report.md> review --base origin/master 2>&1 | tee <run.log>
 # one commit
 codex exec --sandbox read-only -o <report.md> review --commit <sha> 2>&1 | tee <run.log>
-# the round is a skip unless BOTH of these stay quiet
+# an empty report is not a skip - it moves the harvest to the log
 [ -s <report.md> ] || echo "empty report - harvest from <run.log>"
+# this one means the round never ran
 grep -q "Review was interrupted" <run.log> && echo "ROUND DID NOT RUN - disclose as skipped"
 ```
 
 A round writes two sinks: the `-o` report file and the tee'd run log. Either can hold the
 findings, and the report file can come back empty on a round that succeeded.
 
-- Global flags go BEFORE the `review` subcommand. `--base` / `--commit` exclude a custom
-  prompt - a custom prompt runs the generic agent, not the native reviewer; prefer native.
-- The base is `origin/master`, never local `master` - the checklist rebases branches onto
-  `origin/master` and leaves local `master` stale, so a stale base sweeps unrelated
-  upstream commits into the review.
+- Global flags go BEFORE the `review` subcommand. `--base` / `--commit` cannot be combined
+  with a custom prompt - a custom prompt runs the generic agent, not the native reviewer;
+  prefer native.
+- The base is `origin/master`, never local `master` - the `make_pr` checklist rebases
+  branches onto `origin/master` and leaves local `master` stale, so a stale base sweeps
+  unrelated upstream commits into the review.
 - Write both sinks outside the repo (the session scratchpad) or under `logs/` (gitignored) -
   a bare in-tree filename is exactly the untracked debris the preflight gate rejects.
 - Run it in a tree checked out at the tip you want reviewed, and pin that sha beside the sink
@@ -39,17 +41,16 @@ findings, and the report file can come back empty on a round that succeeded.
   the record.**
 - **Never read the exit status as the verdict: codex exits 0 on a round that never ran.**
   Expired auth exits 0 having printed `Review was interrupted` and token-refresh errors and
-  nothing else. A round counts as run only when a sink holds P-ranked findings or codex's
-  explicit no-issues line; anything else is a skip.
+  nothing else. A round counts as run only when a sink holds P-ranked
+  findings (P1 highest) or an exec trace over the diff's files; anything else is a skip.
 - No `codex` on PATH, or a round that did not run? The round is skipped, and the PR body says
   so - the gate is the disclosure, never a silent pass.
 - A round can finish in under a minute or run for tens of minutes - run it in a background
-  Bash and keep working; never sit idle waiting on it. Launch and harvest points are the
-  caller's (see the damper).
-- **Before reporting a round as no-findings, confirm the sink shows it reading the files the
-  diff changed.** Duration says nothing about depth - a one-minute round can read every
-  changed file and run the suite. A truncated capture leaves only the verdict, which reads
-  exactly like a round that did nothing; the exec trace is what tells them apart.
+  Bash and keep working; never sit idle waiting on it.
+- **Before reporting a round as no-findings, confirm the run log's exec trace covers the
+  files the diff changed.** Duration says nothing about depth - a one-minute round can read
+  every changed file and run the suite. A truncated capture leaves only the verdict, which
+  reads exactly like a round that did nothing; the exec trace is what tells them apart.
 
 ## The findings loop
 
@@ -63,16 +64,15 @@ Findings come back P-ranked (P1 highest). Every finding is a hypothesis:
 ## The damper - how many rounds
 
 - **Every `make_pr` arc gets a round, trivial or not** - a round is cheap next to one
-  missed defect. Each caller states its own launch point (`make_pr` step 0a3,
-  `review_round` Phase 2); this file owns only the budget.
+  missed defect. Each caller states its own launch and harvest points
+  (`make_pr` step 0a3, `review_round` Phase 2); this file owns only the budget.
 - **Non-trivial arcs get more than one round by default:** after the findings-driven fix
   batch lands, re-run against the new tip sha. Beyond the defaults, a fix batch re-arms
   a round only when it materially rewrote logic; a batch of doc edits, formatting,
   comment nits, or CI plumbing never re-arms one.
 - **Never loop it to quiescence.** The raw finding rate never reaches zero; past the
-  first round the stream turns tail-heavy and a fix loop chasing it starts minting its
-  own regressions. Judge a round's worth by how many of its findings verify real -
-  never by whether the stream empties.
+  first round most of what comes back is marginal, and a fix loop chasing it introduces
+  regressions of its own. Judge a round's worth by how many of its findings verify real.
 - **Past the defaults, keep going only where failure is silent** - a break no user
   would report. Where failure is loud, users and CI are also detection channels;
   missing a tail bug there is survivable.

--- a/utils/internal/dasweb-playground/README.md
+++ b/utils/internal/dasweb-playground/README.md
@@ -44,6 +44,13 @@ logs is the edge dropping a connection rather than anything the artifact cache d
 forge a line), client addresses are masked to /24 and /32, and it rolls at 32 MiB keeping four
 files for a week.
 
+Validating an edit to the snippet means reassembling the fragment it is, because neither half
+is a Caddyfile on its own: wrap the loose directives in a `daslang.io { }` block with
+`root`/`file_server` after them, uncomment the `run.daslang.io` vhost, and repoint its log at a
+writable path - `caddy validate` opens the file, so `/var/log/caddy` fails anywhere but the
+box. Then `caddy validate --config <file> --adapter caddyfile` and `caddy fmt --diff <file>`,
+both clean, before the deployed Caddyfile is edited to match.
+
 `max_source_bytes` is 524288 (512 KiB). The playground POSTs a multi-file sample as one JSON
 document, so the cap is measured against the whole bundle, not the largest file in it - the
 biggest curated game serializes to roughly 267 KB. Because the deployed toml is operator-owned

--- a/utils/internal/dasweb-playground/README.md
+++ b/utils/internal/dasweb-playground/README.md
@@ -41,8 +41,9 @@ The `run.daslang.io` block in that snippet turns on an access log, which the das
 does not need: this service records every request it answers, so a navigation absent from both
 logs is the edge dropping a connection rather than anything the artifact cache did. Caddy needs
 `/var/log/caddy` to exist and be writable by its user; the log is json (a crafted header cannot
-forge a line), client addresses are masked to /24 and /32, and it rolls at 32 MiB keeping four
-files for a week.
+forge a line), both addresses Caddy records are masked to /24 and /32 with `Authorization`,
+`Cookie` and `X-Forwarded-For` dropped outright, and it rolls at 32 MiB keeping four files for
+a week.
 
 Validating an edit to the snippet means reassembling the fragment it is, because neither half
 is a Caddyfile on its own: wrap the loose directives in a `daslang.io { }` block with

--- a/utils/internal/dasweb-playground/README.md
+++ b/utils/internal/dasweb-playground/README.md
@@ -37,6 +37,13 @@ The public route boundary is `caddy.snippet`, the authoritative copy of what the
 vhost forwards here. It also carries the transport body cap: the service can only bounds-check
 a body already buffered in full, so that limit cannot live in this process.
 
+The `run.daslang.io` block in that snippet turns on an access log, which the daslang.io vhost
+does not need: this service records every request it answers, so a navigation absent from both
+logs is the edge dropping a connection rather than anything the artifact cache did. Caddy needs
+`/var/log/caddy` to exist and be writable by its user; the log is json (a crafted header cannot
+forge a line), client addresses are masked to /24 and /32, and it rolls at 32 MiB keeping four
+files for a week.
+
 `max_source_bytes` is 524288 (512 KiB). The playground POSTs a multi-file sample as one JSON
 document, so the cap is measured against the whole bundle, not the largest file in it - the
 biggest curated game serializes to roughly 267 KB. Because the deployed toml is operator-owned

--- a/utils/internal/dasweb-playground/caddy.snippet
+++ b/utils/internal/dasweb-playground/caddy.snippet
@@ -67,6 +67,35 @@ handle /api/build/* {
 # sets the CORP/COEP headers that embedding under COEP requires.
 #
 #	run.daslang.io {
+#		# The service logs every request it answers, so a navigation missing
+#		# from BOTH logs is the edge closing the connection rather than
+#		# anything the artifact cache did — without this log that case is
+#		# indistinguishable from a request the service simply never got.
+#		# json is the format so a crafted header cannot forge a line, and
+#		# ip_mask keeps a full client address out of the file: this origin is
+#		# public, and nothing here needs to identify a viewer.
+#		log {
+#			output file /var/log/caddy/run.daslang.io.log {
+#				roll_size 32MiB
+#				roll_keep 4
+#				roll_keep_for 168h
+#			}
+#			format filter {
+#				wrap json
+#				fields {
+#					request>remote_ip ip_mask {
+#						ipv4 24
+#						ipv6 32
+#					}
+#					# Neither reaches this origin — the bearer routes live on the
+#					# daslang.io vhost and this one is deliberately cookie-less — so
+#					# dropping them states the property instead of resting on a
+#					# default, and a future route cannot quietly start logging one.
+#					request>headers>Authorization delete
+#					request>headers>Cookie delete
+#				}
+#			}
+#		}
 #		handle /api/build/artifact/* {
 #			# Same reason as every other proxied route: libhv buffers a body in
 #			# full before any handler runs, and the service only registers GET

--- a/utils/internal/dasweb-playground/caddy.snippet
+++ b/utils/internal/dasweb-playground/caddy.snippet
@@ -83,10 +83,19 @@ handle /api/build/* {
 #			format filter {
 #				wrap json
 #				fields {
+#					# BOTH addresses, not just remote_ip: Caddy writes client_ip
+#					# beside it in the same record, and X-Forwarded-For carries a
+#					# third copy in the header map - masking one of the three
+#					# leaves the full address in the file anyway.
 #					request>remote_ip ip_mask {
 #						ipv4 24
 #						ipv6 32
 #					}
+#					request>client_ip ip_mask {
+#						ipv4 24
+#						ipv6 32
+#					}
+#					request>headers>X-Forwarded-For delete
 #					# Neither reaches this origin — the bearer routes live on the
 #					# daslang.io vhost and this one is deliberately cookie-less — so
 #					# dropping them states the property instead of resting on a

--- a/utils/internal/dasweb-verify/browser/REVIEW.md
+++ b/utils/internal/dasweb-verify/browser/REVIEW.md
@@ -3,18 +3,18 @@
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
 doc: `../README.md`.
 
-**A diff that leaves a pure helper in this folder - data in, data out, no playwright, no DOM,
-no network - without a `node:test` case in `protocol.test.mjs` is a defect, wherever the diff
-puts the helper.**
+**A diff that leaves a pure helper in a non-test file in this folder - data in, data out, no
+playwright, no DOM, no network - without a `node:test` case in `protocol.test.mjs` is a defect,
+wherever the diff puts the helper.**
 
-**Never make the verifier take a time budget or an expected-output pattern from a sample
-source - read both from `expectations.json`.** A `// verify:` line in a sample changes the
+**Never make the verifier take a per-sample time budget or an expected-output pattern from a
+sample source - read both from `expectations.json`.** A `// verify:` line in a sample changes the
 sample's content hash and throws away the build-cache entry the nightly depends on.
 
 **Weakening the fail-closed checks in `protocol.test.mjs` is a defect** - a deployed sample
 with no `expectations.json` row stays a FAIL, a name in the deployed manifest but not the repo
 manifest (or the reverse) stays a WARN, and the manifest-coverage case keeps reading the
-shipped manifest `web/examples/ui/samples/data.json` (repo root).
+repo manifest `web/examples/ui/samples/data.json` (repo root).
 
 **Never make the verifier change a build's hash to force a rebuild - report the cached result
 instead.** A cached FAILED build for identical content and toolchain is a correct verdict, so
@@ -29,19 +29,24 @@ pages, installed with `pollGl: true` - and never on the playground, where
 `site/playground/run-frame.html` (repo root) already polls.** `getError` clears the flag, so
 only one poller per context can see an error.
 
+**Never let importing `runner.mjs` drive a browser - `main()` stays behind the entry-point
+check.** `node --test` imports every file it discovers, so deleting that guard makes the suite
+launch Chromium against the live playground and exit the test runner.
+
 **Placement - one file, one line: a diff keeps each file inside its line, and a new file adds
 its line here, with its tests, in the same change.**
 
 - `runner.mjs` - driving loop: browser lifecycle, page hooks, polling, recovery, plus the
   in-flight stop condition and wedge/drift rows that mirror `protocol.mjs` verdicts.
-- `protocol.mjs` - pure data in, pure data out: expectations lookup, output classification,
-  verdicts, the report. No playwright, no network, no DOM.
+- `protocol.mjs` - pure data in, pure data out: expectations lookup, output and
+  navigation-error classification, verdicts, the report. No playwright, no network, no DOM.
 - `protocol.test.mjs` - the `node:test` suite over the pure helpers. No browser.
-- `runner.test.mjs` - the `node:test` suite over `runner.mjs`'s recovery paths, driven by a
-  stubbed page. No browser, and no assertion about a verdict - `protocol.test.mjs` owns those.
+- `runner.test.mjs` - the `node:test` suite over `runner.mjs`, driven by a stubbed page. No
+  browser, no verdict assertions.
 - `probe.mjs` - browser-side only, installed via `addInitScript`. Self-contained, no node
   API.
 - `expectations.json` - the per-sample table. Data only.
 - `package.json` - module type, the `verify`/`test` scripts, the playwright pin. No
   dependencies beyond playwright.
+- `package-lock.json` - npm's resolution of that pin. Generated; never hand-edited.
 - `.gitignore` - `node_modules/`, `artifacts/`, logs. Data only.

--- a/utils/internal/dasweb-verify/browser/REVIEW.md
+++ b/utils/internal/dasweb-verify/browser/REVIEW.md
@@ -37,6 +37,8 @@ its line here, with its tests, in the same change.**
 - `protocol.mjs` - pure data in, pure data out: expectations lookup, output classification,
   verdicts, the report. No playwright, no network, no DOM.
 - `protocol.test.mjs` - the `node:test` suite over the pure helpers. No browser.
+- `runner.test.mjs` - the `node:test` suite over `runner.mjs`'s recovery paths, driven by a
+  stubbed page. No browser, and no assertion about a verdict - `protocol.test.mjs` owns those.
 - `probe.mjs` - browser-side only, installed via `addInitScript`. Self-contained, no node
   API.
 - `expectations.json` - the per-sample table. Data only.

--- a/utils/internal/dasweb-verify/browser/protocol.mjs
+++ b/utils/internal/dasweb-verify/browser/protocol.mjs
@@ -46,6 +46,24 @@ export function isProgramStderrEcho(text) {
     return String(text).startsWith('[das:err] ');
 }
 
+// Chromium net errors that mean the connection died with NO response delivered,
+// so the request never reached the origin and nothing about the artifact is in
+// question. An artifact URL is immutable (source hash x toolchain id), so asking
+// again asks for the same bytes. Every other navigation failure says something
+// real and stays a FAIL: a refused connection is an origin that is down, an
+// aborted one is a navigation superseded, and a timeout is already a wedge.
+export const TRANSPORT_DROPS = [
+    'net::ERR_CONNECTION_CLOSED',
+    'net::ERR_CONNECTION_RESET',
+    'net::ERR_EMPTY_RESPONSE',
+    'net::ERR_SOCKET_NOT_CONNECTED',
+];
+
+export function isTransportDrop(text) {
+    const s = String(text);
+    return TRANSPORT_DROPS.some((code) => s.includes(code));
+}
+
 export function normalizeColor(color) {
     if (!color) return '';
     const m = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color);

--- a/utils/internal/dasweb-verify/browser/protocol.test.mjs
+++ b/utils/internal/dasweb-verify/browser/protocol.test.mjs
@@ -227,6 +227,7 @@ test('a dropped connection is retryable, every other navigation failure is not',
         'page.goto: net::ERR_CONNECTION_CLOSED at https://run.daslang.io/api/build/artifact/a/b/sample.html'), true);
     assert.equal(P.isTransportDrop('page.goto: net::ERR_CONNECTION_RESET at https://run.daslang.io/x'), true);
     assert.equal(P.isTransportDrop('net::ERR_EMPTY_RESPONSE'), true);
+    assert.equal(P.isTransportDrop('page.goto: net::ERR_SOCKET_NOT_CONNECTED at https://run.daslang.io/x'), true);
     assert.equal(P.isTransportDrop('page.goto: net::ERR_CONNECTION_REFUSED at https://run.daslang.io/x'), false);
     assert.equal(P.isTransportDrop('page.goto: net::ERR_ABORTED at https://run.daslang.io/x'), false);
     assert.equal(P.isTransportDrop('page.goto: net::ERR_NAME_NOT_RESOLVED at https://run.daslang.io/x'), false);

--- a/utils/internal/dasweb-verify/browser/protocol.test.mjs
+++ b/utils/internal/dasweb-verify/browser/protocol.test.mjs
@@ -222,6 +222,17 @@ test('program stderr echoed to the console is not a page error', () => {
     assert.equal(P.isProgramStderrEcho('Blocking on the main thread is very dangerous'), false);
 });
 
+test('a dropped connection is retryable, every other navigation failure is not', () => {
+    assert.equal(P.isTransportDrop(
+        'page.goto: net::ERR_CONNECTION_CLOSED at https://run.daslang.io/api/build/artifact/a/b/sample.html'), true);
+    assert.equal(P.isTransportDrop('page.goto: net::ERR_CONNECTION_RESET at https://run.daslang.io/x'), true);
+    assert.equal(P.isTransportDrop('net::ERR_EMPTY_RESPONSE'), true);
+    assert.equal(P.isTransportDrop('page.goto: net::ERR_CONNECTION_REFUSED at https://run.daslang.io/x'), false);
+    assert.equal(P.isTransportDrop('page.goto: net::ERR_ABORTED at https://run.daslang.io/x'), false);
+    assert.equal(P.isTransportDrop('page.goto: net::ERR_NAME_NOT_RESOLVED at https://run.daslang.io/x'), false);
+    assert.equal(P.isTransportDrop('page stopped answering evaluate'), false);
+});
+
 test('every expectations row resolves, and the shipped manifest is fully covered', async () => {
     const table = JSON.parse(await readFile(path.join(HERE, 'expectations.json'), 'utf8'));
     for (const name of Object.keys(table.samples)) {

--- a/utils/internal/dasweb-verify/browser/runner.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.mjs
@@ -345,7 +345,7 @@ export class Artifacts {
         await this.open();
     }
 
-    async load(url) {
+    async load(url, name = '') {
         if (!this.page) await this.open();
         for (let attempt = 1; ; attempt++) {
             this.pageErrors.length = 0;
@@ -360,7 +360,7 @@ export class Artifacts {
                 // Retries stay on stdout/stderr rather than in the report: a
                 // silent retry would hide the edge losing connections, and the
                 // rate is the only measurement we have of it.
-                process.stderr.write(`  artifact navigation dropped, retrying: ${why.split('\n')[0]}\n`);
+                process.stderr.write(`  ${name}: artifact navigation dropped, retrying: ${why.split('\n')[0]}\n`);
             }
             await new Promise((r) => setTimeout(r, ARTIFACT_NAV_RETRY_MS));
         }
@@ -452,7 +452,7 @@ async function verifyWasm(pg, artifacts, row, index) {
     }
 
     await pg.dropArtifactFrame();
-    await artifacts.load(artifactUrl);
+    await artifacts.load(artifactUrl, row.name);
     const startedAt = Date.now();
     const deadline = startedAt + spec.budget_ms;
     while (Date.now() < deadline) {

--- a/utils/internal/dasweb-verify/browser/runner.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.mjs
@@ -116,7 +116,7 @@ async function evaluateIn(target, fn, arg, ms = EVALUATE_MS) {
     return r.value;
 }
 
-class WedgeError extends Error {
+export class WedgeError extends Error {
     constructor() {
         super('page stopped answering evaluate');
         this.wedge = true;
@@ -305,7 +305,7 @@ class Playground {
 // installed there and only there: run-frame.html already polls glGetError on
 // the playground side, and getError CLEARS the flag, so a second poller would
 // steal half the errors.
-class Artifacts {
+export class Artifacts {
     constructor(browser, cfg) {
         this.browser = browser;
         this.cfg = cfg;
@@ -592,7 +592,14 @@ async function main() {
     return P.exitCodeFor(rows);
 }
 
-main().then((code) => process.exit(code), (e) => {
-    process.stderr.write(`dasweb-verify: ${e && e.stack ? e.stack : e}\n`);
-    process.exit(1);
-});
+// Importing this module must not drive a browser: `node --test` imports every
+// file it discovers, and runner.test.mjs drives the recovery paths with a stub.
+const INVOKED_DIRECTLY = process.argv[1] !== undefined
+    && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (INVOKED_DIRECTLY) {
+    main().then((code) => process.exit(code), (e) => {
+        process.stderr.write(`dasweb-verify: ${e && e.stack ? e.stack : e}\n`);
+        process.exit(1);
+    });
+}

--- a/utils/internal/dasweb-verify/browser/runner.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.mjs
@@ -40,6 +40,14 @@ const EVALUATE_MS = 20000;
 const EVALUATE_FLOOR_MS = 5000;
 // The playground tab itself must come up well inside this or the run is moot.
 const PAGE_READY_MS = 90000;
+// A keep-alive connection the origin closes exactly as Chromium reuses it fails
+// the navigation before any request reaches the service — it appears in no
+// server log, and one such drop out of ~41 wasm navigations reds the whole
+// nightly. The artifact URL is content-addressed and immutable, so the second
+// attempt asks for the same bytes; only P.TRANSPORT_DROPS is retried, and a
+// genuinely broken artifact fails both attempts identically.
+const ARTIFACT_NAV_ATTEMPTS = 2;
+const ARTIFACT_NAV_RETRY_MS = 1000;
 
 function parseArgs(argv) {
     const cfg = {
@@ -339,10 +347,23 @@ class Artifacts {
 
     async load(url) {
         if (!this.page) await this.open();
-        this.pageErrors.length = 0;
-        const nav = await withDeadline(
-            this.page.goto(url, { waitUntil: 'commit', timeout: 120000 }), 130000, 'artifact-goto');
-        if (nav.wedge) throw new WedgeError();
+        for (let attempt = 1; ; attempt++) {
+            this.pageErrors.length = 0;
+            try {
+                const nav = await withDeadline(
+                    this.page.goto(url, { waitUntil: 'commit', timeout: 120000 }), 130000, 'artifact-goto');
+                if (nav.wedge) throw new WedgeError();
+                return;
+            } catch (e) {
+                const why = String(e && e.message ? e.message : e);
+                if (attempt >= ARTIFACT_NAV_ATTEMPTS || !P.isTransportDrop(why)) throw e;
+                // Retries stay on stdout/stderr rather than in the report: a
+                // silent retry would hide the edge losing connections, and the
+                // rate is the only measurement we have of it.
+                process.stderr.write(`  artifact navigation dropped, retrying: ${why.split('\n')[0]}\n`);
+            }
+            await new Promise((r) => setTimeout(r, ARTIFACT_NAV_RETRY_MS));
+        }
     }
 
     async readProbe(ms) {

--- a/utils/internal/dasweb-verify/browser/runner.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.mjs
@@ -116,7 +116,7 @@ async function evaluateIn(target, fn, arg, ms = EVALUATE_MS) {
     return r.value;
 }
 
-export class WedgeError extends Error {
+class WedgeError extends Error {
     constructor() {
         super('page stopped answering evaluate');
         this.wedge = true;
@@ -362,7 +362,9 @@ export class Artifacts {
                 // rate is the only measurement we have of it.
                 process.stderr.write(`  ${name}: artifact navigation dropped, retrying: ${why.split('\n')[0]}\n`);
             }
-            await new Promise((r) => setTimeout(r, ARTIFACT_NAV_RETRY_MS));
+            // Injectable so the stub suite does not pay the real wait; production
+            // cfg carries no such key, so the default is what the nightly uses.
+            await new Promise((r) => setTimeout(r, this.cfg.navRetryMs ?? ARTIFACT_NAV_RETRY_MS));
         }
     }
 

--- a/utils/internal/dasweb-verify/browser/runner.test.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.test.mjs
@@ -1,13 +1,19 @@
 // node --test  (run from this directory)
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import { Artifacts } from './runner.mjs';
+
+const run = promisify(execFile);
+const RUNNER = fileURLToPath(new URL('./runner.mjs', import.meta.url));
 
 // A stubbed page: goto() replays a scripted sequence and records what it was
 // asked for. No playwright, no browser, no network — the driving loop's own
 // recovery is what is under test, not anything Chromium does.
 function stubbed(outcomes) {
-    const artifacts = new Artifacts(null, {});
+    const artifacts = new Artifacts(null, { navRetryMs: 0 });
     const calls = [];
     artifacts.page = {
         async goto(url) {
@@ -20,38 +26,38 @@ function stubbed(outcomes) {
     return { artifacts, calls };
 }
 
-const URL = 'https://run.daslang.io/api/build/artifact/a/b/sample.html';
-const drop = () => new Error(`page.goto: net::ERR_CONNECTION_CLOSED at ${URL}`);
-const refused = () => new Error(`page.goto: net::ERR_CONNECTION_REFUSED at ${URL}`);
+const ARTIFACT_URL = 'https://run.daslang.io/api/build/artifact/a/b/sample.html';
+const drop = () => new Error(`page.goto: net::ERR_CONNECTION_CLOSED at ${ARTIFACT_URL}`);
+const refused = () => new Error(`page.goto: net::ERR_CONNECTION_REFUSED at ${ARTIFACT_URL}`);
 
 test('a dropped navigation is retried, and the retry asks for the same url', async () => {
     const { artifacts, calls } = stubbed([drop(), {}]);
-    await artifacts.load(URL);
-    assert.deepEqual(calls, [URL, URL]);
+    await artifacts.load(ARTIFACT_URL);
+    assert.deepEqual(calls, [ARTIFACT_URL, ARTIFACT_URL]);
 });
 
 test('the retry is spent once — a second drop fails the row', async () => {
     const { artifacts, calls } = stubbed([drop(), drop(), {}]);
-    await assert.rejects(artifacts.load(URL), /ERR_CONNECTION_CLOSED/);
+    await assert.rejects(artifacts.load(ARTIFACT_URL), /ERR_CONNECTION_CLOSED/);
     assert.equal(calls.length, 2);
 });
 
 test('a navigation failure that is not a transport drop is never retried', async () => {
     const { artifacts, calls } = stubbed([refused(), {}]);
-    await assert.rejects(artifacts.load(URL), /ERR_CONNECTION_REFUSED/);
+    await assert.rejects(artifacts.load(ARTIFACT_URL), /ERR_CONNECTION_REFUSED/);
     assert.equal(calls.length, 1);
 });
 
 test('a clean navigation costs exactly one attempt', async () => {
     const { artifacts, calls } = stubbed([{}]);
-    await artifacts.load(URL);
+    await artifacts.load(ARTIFACT_URL);
     assert.equal(calls.length, 1);
 });
 
 // The verdict merges artifacts.pageErrors (verifyWasm), so an error raised by
 // the attempt that never landed would fail a row the retry rescued.
 test('page errors from the dropped attempt do not survive into the retry', async () => {
-    const artifacts = new Artifacts(null, {});
+    const artifacts = new Artifacts(null, { navRetryMs: 0 });
     let attempt = 0;
     artifacts.page = {
         async goto() {
@@ -61,6 +67,40 @@ test('page errors from the dropped attempt do not survive into the retry', async
             return {};
         },
     };
-    await artifacts.load(URL);
+    await artifacts.load(ARTIFACT_URL);
     assert.deepEqual(artifacts.pageErrors, ['error from attempt 2']);
+});
+
+// The line is the only measurement of how often the edge drops a connection, so
+// losing it, or losing the net error inside it, must fail something.
+test('the retry names the sample and the net error on stderr', async () => {
+    const { artifacts } = stubbed([drop(), {}]);
+    const written = [];
+    const real = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => { written.push(String(chunk)); return true; };
+    try {
+        await artifacts.load(ARTIFACT_URL, 'OpenGL: cube swarm (instancing)');
+    } finally {
+        process.stderr.write = real;
+    }
+    assert.equal(written.length, 1);
+    assert.match(written[0], /OpenGL: cube swarm \(instancing\).*artifact navigation dropped.*ERR_CONNECTION_CLOSED/);
+});
+
+test('the retry waits before asking again', async () => {
+    const artifacts = new Artifacts(null, { navRetryMs: 120 });
+    let attempt = 0;
+    artifacts.page = { async goto() { attempt++; if (attempt === 1) throw drop(); return {}; } };
+    const t0 = Date.now();
+    await artifacts.load(ARTIFACT_URL);
+    assert.ok(Date.now() - t0 >= 100, `retried after ${Date.now() - t0}ms, expected a wait`);
+});
+
+// main() is behind an entry-point check so `node --test` can import this module.
+// If that check ever reads false when the nightly spawns the file, the verify
+// step exits 0 having verified nothing — green by construction, forever.
+// `--help` returns before any fetch or browser launch, so this costs no network.
+test('invoked directly, runner.mjs still reaches main()', async () => {
+    const { stdout } = await run(process.execPath, [RUNNER, '--help']);
+    assert.match(stdout, /^dasweb-verify browser leg/);
 });

--- a/utils/internal/dasweb-verify/browser/runner.test.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.test.mjs
@@ -1,0 +1,66 @@
+// node --test  (run from this directory)
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Artifacts } from './runner.mjs';
+
+// A stubbed page: goto() replays a scripted sequence and records what it was
+// asked for. No playwright, no browser, no network — the driving loop's own
+// recovery is what is under test, not anything Chromium does.
+function stubbed(outcomes) {
+    const artifacts = new Artifacts(null, {});
+    const calls = [];
+    artifacts.page = {
+        async goto(url) {
+            calls.push(url);
+            const next = outcomes.shift();
+            if (next instanceof Error) throw next;
+            return next;
+        },
+    };
+    return { artifacts, calls };
+}
+
+const URL = 'https://run.daslang.io/api/build/artifact/a/b/sample.html';
+const drop = () => new Error(`page.goto: net::ERR_CONNECTION_CLOSED at ${URL}`);
+const refused = () => new Error(`page.goto: net::ERR_CONNECTION_REFUSED at ${URL}`);
+
+test('a dropped navigation is retried, and the retry asks for the same url', async () => {
+    const { artifacts, calls } = stubbed([drop(), {}]);
+    await artifacts.load(URL);
+    assert.deepEqual(calls, [URL, URL]);
+});
+
+test('the retry is spent once — a second drop fails the row', async () => {
+    const { artifacts, calls } = stubbed([drop(), drop(), {}]);
+    await assert.rejects(artifacts.load(URL), /ERR_CONNECTION_CLOSED/);
+    assert.equal(calls.length, 2);
+});
+
+test('a navigation failure that is not a transport drop is never retried', async () => {
+    const { artifacts, calls } = stubbed([refused(), {}]);
+    await assert.rejects(artifacts.load(URL), /ERR_CONNECTION_REFUSED/);
+    assert.equal(calls.length, 1);
+});
+
+test('a clean navigation costs exactly one attempt', async () => {
+    const { artifacts, calls } = stubbed([{}]);
+    await artifacts.load(URL);
+    assert.equal(calls.length, 1);
+});
+
+// The verdict merges artifacts.pageErrors (verifyWasm), so an error raised by
+// the attempt that never landed would fail a row the retry rescued.
+test('page errors from the dropped attempt do not survive into the retry', async () => {
+    const artifacts = new Artifacts(null, {});
+    let attempt = 0;
+    artifacts.page = {
+        async goto() {
+            attempt++;
+            artifacts.pageErrors.push(`error from attempt ${attempt}`);
+            if (attempt === 1) throw drop();
+            return {};
+        },
+    };
+    await artifacts.load(URL);
+    assert.deepEqual(artifacts.pageErrors, ['error from attempt 2']);
+});


### PR DESCRIPTION
The nightly playground verifier went red on two of five nights, each time with one wasm cell failing `page.goto: net::ERR_CONNECTION_CLOSED` on an artifact URL. The playground service has no record of either request. On 2026-09-01 the artifact was built, stored and served `200` three seconds before the navigation that failed; the service had one uptime spanning both nights, and the artifact eviction sweep ran nineteen minutes later and took 200 ms. The connection was closed at the edge, before any request reached the service, and one such drop out of roughly 41 wasm navigations reds the whole run.

`Artifacts.load` now retries once, and only for the net errors that mean no response was ever delivered. The artifact URL is content-addressed and immutable, so the second attempt asks for the same bytes; a broken artifact fails both attempts the same way, and a refused connection, an aborted navigation and a wedge all still fail the row. The retry writes a line naming the sample to stderr rather than passing silently, because the rate of those lines is the only measurement of the edge we have.

The `run.daslang.io` vhost gains an access log, which is what made this a five-command dig: the service logs every request it answers, so a navigation missing from both logs is the edge - but with no log on that vhost the two cases were indistinguishable. Client addresses are masked, `Authorization`, `Cookie` and `X-Forwarded-For` are dropped, and rotation is bounded so the log cannot fill the disk the database and blobs share.

This does not explain why the edge closes those connections. It stops one drop from redding a night, and it makes the next occurrence diagnosable in one command.

Where to look: `Artifacts.load` in `runner.mjs` (the retry and what it refuses to retry), `isTransportDrop` in `protocol.mjs` (the net errors that qualify), and the `format filter` block in `caddy.snippet` (what the log does and does not record).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local only, because no per-PR lane runs this suite: `node --test` in `utils/internal/dasweb-verify/browser` on macOS arm64, node v25.9.0, 30 passed 0 failed. CI's cell is node 22 and runs it nightly. The suite needs nothing this machine has that CI lacks; the reason for running it here is scheduling, not capability.
- Every new test negative-controlled - `ARTIFACT_NAV_ATTEMPTS` 2 to 3, dropping the `isTransportDrop` guard, removing the retry, hoisting the `pageErrors` reset, deleting the one unread list entry, removing the stderr line, zeroing the backoff, and forcing the entry-point guard false. Each fails exactly the case that names it.
- Against production, which CI does not do per-PR: the previously failing cell run through the edited code, `OpenGL: cube swarm (instancing) [wasm] PASS`, three times across the change.
- Caddy config checked with a caddy CI does not have: `caddy validate --adapter caddyfile` clean and `caddy fmt --diff` empty on the reassembled fragment, caddy 2.11.4.
- The masking was probed, not assumed. Masking `request>remote_ip` alone left `client_ip` unmasked and `X-Forwarded-For` verbatim in the header map; with both addresses masked and the header dropped, `Accept` and `User-Agent` are the only headers logged.
- Preflight fast tier only - 4 passed, 0 failed, 3 skipped, the skips being lint, ast-verify and cpp-syntax with zero `.das` and zero C++ changed. The full tier adds nothing this diff can exercise.
- External review round clean at the reviewed tip: it read the whole diff, read `runner.mjs` at both revisions, ran the suite, and reported no findings.

### Claims - stated, not tested
- The drops are an edge-level connection close, not anything the service did. Verified by elimination rather than by observing the close: the artifact served `200` seconds earlier, the service never restarted, the eviction sweep is minutes away and milliseconds long, and every request the service answers is logged while these are absent. A break in this reasoning would look like the same failure continuing with the new access log also showing no request - which would put the close below Caddy, at TLS or the network.
- The retry is safe because the URL is immutable. If that ever stopped being true - a mutable artifact path, a cache that rewrites under the same key - the retry could mask a real failure. Nothing in the artifact cache allows it today; the URL is source hash by toolchain id.

### Not done
- The root cause of the drops. The access log is the instrument for the next occurrence, not an answer.
- No per-PR lane runs `node --test` for this folder, so these cases first execute the night after merge. Ruled: CI catches it, no lane added.
- Ledgered in `plans/dasweb_sample_verifier.md`: a `REVIEW.das` gate over the placement block; self-review findings on three checklists this arc does not otherwise touch; and the woodpecker damper being stated in two documents.
- The woodpecker skill fix rides along rather than going separately - this arc surfaced it, and both failure modes it closes were hit here.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)