### PR TITLE
dasweb-verify: the stub suite stops impersonating a production drop

### DIFF
--- a/skills/internal/woodpecker.md
+++ b/skills/internal/woodpecker.md
@@ -11,13 +11,18 @@ never runs dry - so the damper below is part of the design, not a cost-saving me
 ## Invocation
 
 ```bash
+# both paths outside the repo - the session scratchpad, or logs/
+report=$SCRATCH/woodpecker.md
+log=$SCRATCH/woodpecker.log
+
 # a branch against its base (the normal PR shape)
-codex exec --sandbox read-only -o <report.md> review --base origin/master 2>&1 | tee <run.log>
+codex exec --sandbox read-only -o "$report" review --base origin/master 2>&1 | tee "$log"
 # one commit
-codex exec --sandbox read-only -o <report.md> review --commit <sha> 2>&1 | tee <run.log>
+codex exec --sandbox read-only -o "$report" review --commit "$sha" 2>&1 | tee "$log"
+
 # either of these means the round never ran - disclose it as skipped
-[ -s <report.md> ] || echo "EMPTY REPORT - no round"
-grep -q "Review was interrupted" <run.log> && echo "INTERRUPTED - no round"
+[ -s "$report" ] || echo "EMPTY REPORT - no round"
+grep -q "Review was interrupted" "$log" && echo "INTERRUPTED - no round"
 ```
 
 A round writes two sinks with different jobs: the `-o` report file holds the verdict and the

--- a/skills/internal/woodpecker.md
+++ b/skills/internal/woodpecker.md
@@ -15,14 +15,14 @@ never runs dry - so the damper below is part of the design, not a cost-saving me
 codex exec --sandbox read-only -o <report.md> review --base origin/master 2>&1 | tee <run.log>
 # one commit
 codex exec --sandbox read-only -o <report.md> review --commit <sha> 2>&1 | tee <run.log>
-# an empty report is not a skip - it moves the harvest to the log
-[ -s <report.md> ] || echo "empty report - harvest from <run.log>"
-# this one means the round never ran
-grep -q "Review was interrupted" <run.log> && echo "ROUND DID NOT RUN - disclose as skipped"
+# either of these means the round never ran - disclose it as skipped
+[ -s <report.md> ] || echo "EMPTY REPORT - no round"
+grep -q "Review was interrupted" <run.log> && echo "INTERRUPTED - no round"
 ```
 
-A round writes two sinks: the `-o` report file and the tee'd run log. Either can hold the
-findings, and the report file can come back empty on a round that succeeded.
+A round writes two sinks with different jobs: the `-o` report file holds the verdict and the
+findings, and the tee'd run log holds the exec trace - what the round actually read and ran.
+The report answers "what did it find", the log answers "did it look".
 
 - Global flags go BEFORE the `review` subcommand. `--base` / `--commit` cannot be combined
   with a custom prompt - a custom prompt runs the generic agent, not the native reviewer;
@@ -32,17 +32,15 @@ findings, and the report file can come back empty on a round that succeeded.
   unrelated upstream commits into the review.
 - Write both sinks outside the repo (the session scratchpad) or under `logs/` (gitignored) -
   a bare in-tree filename is exactly the untracked debris the preflight gate rejects.
-- Run it in a tree checked out at the tip you want reviewed, and pin that sha beside the sink
-  you keep - findings are claims about exact bytes, and re-reviews only mean anything against
-  a pinned commit. The pinned sha does not freeze what codex reads: the tree must not change
+- Run it in a tree checked out at the tip you want reviewed, and pin that sha beside both
+  sinks - findings are claims about exact bytes, and re-reviews only mean anything against a
+  pinned commit. The pinned sha does not freeze what codex reads: the tree must not change
   until harvest - launch after the last mutating step, or give the run its own worktree at
   that sha.
-- **Harvest from whichever sink holds the findings; when the report is empty the run log is
-  the record.**
 - **Never read the exit status as the verdict: codex exits 0 on a round that never ran.**
-  Expired auth exits 0 having printed `Review was interrupted` and token-refresh errors and
-  nothing else. A round counts as run only when a sink holds P-ranked
-  findings (P1 highest) or an exec trace over the diff's files; anything else is a skip.
+  Expired auth exits 0 having printed `Review was interrupted` and token-refresh errors, and
+  leaves the report file empty - so an empty report is a round that did not happen, never a
+  round that found nothing. A round that found nothing still writes its verdict there.
 - No `codex` on PATH, or a round that did not run? The round is skipped, and the PR body says
   so - the gate is the disclosure, never a silent pass.
 - A round can finish in under a minute or run for tens of minutes - run it in a background

--- a/skills/internal/woodpecker.md
+++ b/skills/internal/woodpecker.md
@@ -12,12 +12,13 @@ never runs dry - so the damper below is part of the design, not a cost-saving me
 
 ```bash
 # both paths outside the repo - the session scratchpad, or logs/
-report=$SCRATCH/woodpecker.md
-log=$SCRATCH/woodpecker.log
+report=${SCRATCH:-/tmp}/woodpecker.md
+log=${SCRATCH:-/tmp}/woodpecker.log
 
 # a branch against its base (the normal PR shape)
 codex exec --sandbox read-only -o "$report" review --base origin/master 2>&1 | tee "$log"
 # one commit
+sha=$(git rev-parse HEAD)
 codex exec --sandbox read-only -o "$report" review --commit "$sha" 2>&1 | tee "$log"
 
 # either of these means the round never ran - disclose it as skipped

--- a/utils/internal/dasweb-verify/browser/runner.test.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.test.mjs
@@ -26,19 +26,36 @@ function stubbed(outcomes) {
     return { artifacts, calls };
 }
 
+// Every retry here prints the production line, and a nightly log is grepped for
+// exactly that string to count how often the edge dropped a connection. Test
+// output on stdout would be counted as production drops, so no case may let the
+// line escape: drive every retry through this, and assert on what it captured.
+async function captureStderr(fn) {
+    const written = [];
+    const real = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => { written.push(String(chunk)); return true; };
+    try {
+        await fn();
+    } finally {
+        process.stderr.write = real;
+    }
+    return written;
+}
+
 const ARTIFACT_URL = 'https://run.daslang.io/api/build/artifact/a/b/sample.html';
 const drop = () => new Error(`page.goto: net::ERR_CONNECTION_CLOSED at ${ARTIFACT_URL}`);
 const refused = () => new Error(`page.goto: net::ERR_CONNECTION_REFUSED at ${ARTIFACT_URL}`);
 
 test('a dropped navigation is retried, and the retry asks for the same url', async () => {
     const { artifacts, calls } = stubbed([drop(), {}]);
-    await artifacts.load(ARTIFACT_URL);
+    await captureStderr(() => artifacts.load(ARTIFACT_URL));
     assert.deepEqual(calls, [ARTIFACT_URL, ARTIFACT_URL]);
 });
 
 test('the retry is spent once — a second drop fails the row', async () => {
     const { artifacts, calls } = stubbed([drop(), drop(), {}]);
-    await assert.rejects(artifacts.load(ARTIFACT_URL), /ERR_CONNECTION_CLOSED/);
+    await captureStderr(() =>
+        assert.rejects(artifacts.load(ARTIFACT_URL), /ERR_CONNECTION_CLOSED/));
     assert.equal(calls.length, 2);
 });
 
@@ -67,7 +84,7 @@ test('page errors from the dropped attempt do not survive into the retry', async
             return {};
         },
     };
-    await artifacts.load(ARTIFACT_URL);
+    await captureStderr(() => artifacts.load(ARTIFACT_URL));
     assert.deepEqual(artifacts.pageErrors, ['error from attempt 2']);
 });
 
@@ -75,14 +92,8 @@ test('page errors from the dropped attempt do not survive into the retry', async
 // losing it, or losing the net error inside it, must fail something.
 test('the retry names the sample and the net error on stderr', async () => {
     const { artifacts } = stubbed([drop(), {}]);
-    const written = [];
-    const real = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (chunk) => { written.push(String(chunk)); return true; };
-    try {
-        await artifacts.load(ARTIFACT_URL, 'OpenGL: cube swarm (instancing)');
-    } finally {
-        process.stderr.write = real;
-    }
+    const written = await captureStderr(() =>
+        artifacts.load(ARTIFACT_URL, 'OpenGL: cube swarm (instancing)'));
     assert.equal(written.length, 1);
     assert.match(written[0], /OpenGL: cube swarm \(instancing\).*artifact navigation dropped.*ERR_CONNECTION_CLOSED/);
 });
@@ -92,7 +103,7 @@ test('the retry waits before asking again', async () => {
     let attempt = 0;
     artifacts.page = { async goto() { attempt++; if (attempt === 1) throw drop(); return {}; } };
     const t0 = Date.now();
-    await artifacts.load(ARTIFACT_URL);
+    await captureStderr(() => artifacts.load(ARTIFACT_URL));
     assert.ok(Date.now() - t0 >= 100, `retried after ${Date.now() - t0}ms, expected a wait`);
 });
 

--- a/utils/internal/dasweb-verify/browser/runner.test.mjs
+++ b/utils/internal/dasweb-verify/browser/runner.test.mjs
@@ -27,9 +27,9 @@ function stubbed(outcomes) {
 }
 
 // Every retry here prints the production line, and a nightly log is grepped for
-// exactly that string to count how often the edge dropped a connection. Test
-// output on stdout would be counted as production drops, so no case may let the
-// line escape: drive every retry through this, and assert on what it captured.
+// exactly that string to count how often the edge dropped a connection, and the
+// job log carries stderr too - so a case that lets the line escape is counted as
+// a production drop. Drive every retry through this, and assert on what it caught.
 async function captureStderr(fn) {
     const written = [];
     const real = process.stderr.write.bind(process.stderr);


### PR DESCRIPTION
The nightly verifier prints one line when it retries a dropped artifact navigation, and that line is how often the edge dropped a connection gets counted - a nightly log is grepped for exactly that string. Four cases in the stub suite drive a retry, and each printed the same line on the same stream. A run with no drops at all reported four, from the suite's own output with a fixture URL and an empty sample name.

Every retry in the suite now goes through one capture helper, which returns what was written so the case that asserts on the line keeps asserting on it. Nothing in `runner.mjs` changes - production emits exactly what it emitted before. The fix is that the tests stop counterfeiting it.

The second commit corrects the woodpecker skill. It gained a rule saying `-o <report.md>` can come back empty on a round that succeeded; that is false, and the measurement behind it was `wc -l` on a file with no trailing newline. Every report from a round that ran holds its verdict, and the one empty report came from an auth failure that reviewed nothing - so emptiness is a reliable skip detector, which is a simpler rule than the fallback it replaces.

Where to look: `captureStderr` in `runner.test.mjs`, and the guard lines in the woodpecker skill's invocation block.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local only, because no per-PR lane runs this suite: `node --test` in `utils/internal/dasweb-verify/browser` on macOS arm64, node v25.9.0, 30 passed 0 failed, and zero retry lines escaping to stdout.
- Controlled both directions. Removing one capture lets exactly one line escape. Removing the production write still fails the case that names the sample - so quieting the suite did not make the assertion vacuous, which is the failure this shape invites.
- External round clean at the tip, with its exec trace confirmed over the changed file rather than inferred from the verdict.
- Preflight fast tier - 3 passed, 0 failed, 4 skipped, with zero `.das` and zero C++ changed.

### Claims - stated, not tested
- Production output is unchanged. Verified by reading the diff rather than by a test: no line of `runner.mjs` is touched, and the assertion on the emitted line is unchanged. A break would look like the nightly log losing the retry lines entirely.

### Not done
- No mechanical guard stops a future case from printing the line again; the helper's comment says why it exists, and the negative control is what catches it. A test that asserts on the suite's own stdout would be self-referential.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)