### PR TITLE
the cookie-free claim gets a gate: four served trees, one allow-list each

### DIFF
--- a/dastest/README.md
+++ b/dastest/README.md
@@ -89,11 +89,13 @@ Not part of the test runner: `dastest/review_gate.das` is the support library fo
 contract lives in `REVIEW_COMMON.md` at the repo root, vendored by repos that adopt it). It
 provides finding accumulation and the exit verdict (`gate_finding`, `gate_findings`,
 `gate_reset`, `gate_verdict`), the descriptor census (`gate_descriptor_census`, two
-overloads), plus tree-analysis helpers: `das_requires`, `strip_line_comments`,
-`cmake_command_blocks`, `cmake_command_targets`, `cmake_words`, `cmake_args`,
-`cmake_list_entries`, `cmake_test_labels`, `cmake_test_commands`, `is_cmake_keyword`,
-`is_kebab_case`, `find_line`. The CMake helpers match command names case-insensitively, as
-CMake itself does. It lives under
+overloads), the cookie-and-host gate for a served web tree (`gate_web_third_party`, built
+on `html_resource_urls`, `script_urls`, `css_urls` and `url_host`), plus tree-analysis
+helpers: `das_requires`, `strip_line_comments`, `cmake_command_blocks`,
+`cmake_command_targets`, `cmake_words`, `cmake_args`, `cmake_list_entries`,
+`cmake_test_labels`, `cmake_test_commands`, `is_cmake_keyword`, `is_kebab_case`,
+`find_line`. The CMake helpers match command names case-insensitively, as CMake itself
+does. It lives under
 `dastest/` so an installed SDK carries it the same way it carries the test framework -
 dastest itself ships in the SDK as a prebuilt exe, the `DAS_UTILS_SHIPPED_EXES` entry in
 `utils/CMakeLists.txt` (repo root).

--- a/dastest/review_gate.das
+++ b/dastest/review_gate.das
@@ -120,37 +120,57 @@ def private matches_lowered(d; at : int; lowered : array<int>) : bool {
     return true
 }
 
-//! `text` with every // comment cut to end-of-line (string-literal-aware, so a "//" inside
-//! a quoted URL survives). Use before scanning sources or descriptors: a name mentioned
-//! only in a comment must not count.
-def strip_line_comments(text : string) : string {
+// `script_quotes` widens what opens a string literal from `"` alone to all three script
+// quote styles - the one axis the two comment strippers differ on. A quoted string ends at
+// the line it started on; only a template literal spans lines, so only a backtick carries.
+// Every newline survives, so a line count taken on the result matches the source.
+def private strip_to_line_comment(text : string; script_quotes : bool) : string {
     return build_string() $(var b : StringBuilderWriter) {
-        for (line in split(text, "\n")) {
-            var cut = -1
-            peek_data(line) $(d) {
-                var in_str = false
-                var i = 0
-                while (i < length(d)) {
-                    let c = int(d[i])
-                    if (in_str) {
-                        if (c == '\\') {
-                            i++
-                        } elif (c == '"') {
-                            in_str = false
-                        }
-                    } elif (c == '"') {
-                        in_str = true
-                    } elif (c == '/' && i + 1 < length(d) && int(d[i + 1]) == '/') {
-                        cut = i
-                        break
+        peek_data(text) $(d) {
+            let n = length(d)
+            var quote = 0
+            var in_comment = false
+            var i = 0
+            while (i < n) {
+                let c = int(d[i])
+                if (c == '\n') {
+                    in_comment = false
+                    if (quote != '`') {
+                        quote = 0
                     }
-                    i++
+                    b |> write("\n")
+                } elif (in_comment) {
+                    // dropped
+                } elif (quote != 0) {
+                    if (c == '\\' && i + 1 < n) {
+                        b |> write(slice(d, i, i + 2))
+                        i++
+                    } else {
+                        if (c == quote) {
+                            quote = 0
+                        }
+                        b |> write(slice(d, i, i + 1))
+                    }
+                } elif (c == '"' || (script_quotes && (c == '\'' || c == '`'))) {
+                    quote = c
+                    b |> write(slice(d, i, i + 1))
+                } elif (c == '/' && i + 1 < n && int(d[i + 1]) == '/') {
+                    in_comment = true
+                } else {
+                    b |> write(slice(d, i, i + 1))
                 }
+                i++
             }
-            b |> write(cut >= 0 ? slice(line, 0, cut) : line)
-            b |> write("\n")
         }
     }
+}
+
+//! `text` with every // comment cut to end-of-line (string-literal-aware, so a "//" inside
+//! a quoted URL survives). Use before scanning sources or descriptors: a name mentioned
+//! only in a comment must not count. Only `"` opens a literal - for script text, where a
+//! single quote does too, `script_urls` is the scanner that reads it correctly.
+def strip_line_comments(text : string) : string {
+    return strip_to_line_comment(text, false)
 }
 
 def private quoted_ident_tokens(text : string) : array<string> {
@@ -473,4 +493,381 @@ def cmake_list_entries(text : string; listname : string) : array<string> {
         }
     }
     return <- out
+}
+
+//! Host of an absolute or protocol-relative URL, lowercased - "" when the URL is relative
+//! or when what follows the scheme is not host-shaped. Scheme and host are matched
+//! case-insensitively, as a browser reads them; a bracketed IPv6 literal comes back with
+//! its brackets. Userinfo and port are dropped: an allow-list names hosts.
+def url_host(url : string) : string {
+    var rest = ""
+    peek_data(url) $(u) {
+        if (byte_run_at_ci(u, 0, "https://")) {
+            rest = slice(u, 8, length(u))
+        } elif (byte_run_at_ci(u, 0, "http://")) {
+            rest = slice(u, 7, length(u))
+        } elif (byte_run_at(u, 0, "//")) {
+            rest = slice(u, 2, length(u))
+        }
+    }
+    return "" if (empty(rest))
+    var authority = rest
+    peek_data(rest) $(d) {
+        for (i in range(length(d))) {
+            let c = int(d[i])
+            if (c == '/' || c == '?' || c == '#') {
+                authority = slice(d, 0, i)
+                break
+            }
+        }
+    }
+    let at = authority |> find("@")
+    var host = at >= 0 ? slice(authority, at + 1) : authority
+    if (host |> starts_with("[")) {
+        // a bracketed IPv6 literal carries colons of its own - the port is the one after `]`
+        let close = host |> find("]")
+        return "" if (close < 0)
+        host = slice(host, 0, close + 1)
+    } else {
+        let colon = host |> find(":")
+        if (colon >= 0) {
+            host = slice(host, 0, colon)
+        }
+    }
+    return is_host_shaped(host) ? to_lower(host) : ""
+}
+
+def private is_host_shaped(host : string) : bool {
+    var ok = !empty(host)
+    let bracketed = host |> starts_with("[")
+    peek_data(host) $(d) {
+        for (i in range(length(d))) {
+            let c = int(d[i])
+            continue if (bracketed && (c == '[' || c == ']' || c == ':'))
+            if (!is_alnum(c) && c != '-' && c != '.' && c != '_') {
+                ok = false
+                break
+            }
+        }
+    }
+    return ok
+}
+
+// a URL scheme and an HTML tag name are both case-insensitive to a browser
+def private byte_run_at_ci(d; at : int; lit : string) : bool {
+    var ok = true
+    peek_data(lit) $(l) {
+        let m = length(l)
+        if (at + m > length(d)) {
+            ok = false
+        } else {
+            for (i in range(m)) {
+                if (to_lower_byte(int(d[at + i])) != to_lower_byte(int(l[i]))) {
+                    ok = false
+                    break
+                }
+            }
+        }
+    }
+    return ok
+}
+
+def private byte_run_at(d; at : int; lit : string) : bool {
+    var ok = true
+    peek_data(lit) $(l) {
+        let m = length(l)
+        if (at + m > length(d)) {
+            ok = false
+        } else {
+            for (i in range(m)) {
+                if (int(d[at + i]) != int(l[i])) {
+                    ok = false
+                    break
+                }
+            }
+        }
+    }
+    return ok
+}
+
+def private is_resource_tag(name : string) : bool {
+    return (name == "script" || name == "link" || name == "iframe" || name == "img" ||
+        name == "source" || name == "video" || name == "audio" || name == "embed" ||
+        name == "object")
+}
+
+def private is_url_break_byte(b : int) : bool {
+    return (is_white_space(b) || b == '"' || b == '\'' || b == '`' || b == '<' || b == '>' ||
+        b == ')' || b == ',' || b == ';')
+}
+
+//! Absolute and protocol-relative URLs written as string literals in script text, `//`
+//! comments cut first so a commented-out address does not count. A protocol-relative
+//! literal is recognized by the quote that opens it.
+def script_urls(text : string) : array<string> {
+    var out : array<string>
+    let src = strip_to_line_comment(text, true)
+    peek_data(src) $(d) {
+        let n = length(d)
+        var i = 0
+        while (i < n) {
+            let c = int(d[i])
+            var start = -1
+            if ((c == '"' || c == '\'' || c == '`') && byte_run_at(d, i + 1, "//")) {
+                start = i + 1
+            } elif (byte_run_at_ci(d, i, "http://") || byte_run_at_ci(d, i, "https://")) {
+                start = i
+            }
+            if (start < 0) {
+                i++
+                continue
+            }
+            var e = start
+            while (e < n && !is_url_break_byte(int(d[e]))) {
+                e++
+            }
+            let url = slice(d, start, e)
+            if (!empty(url_host(url))) {
+                out |> push(url)
+            }
+            i = e + 1
+        }
+    }
+    return <- out
+}
+
+def private strip_block_comments(text : string) : string {
+    return build_string() $(var b : StringBuilderWriter) {
+        peek_data(text) $(d) {
+            let n = length(d)
+            var i = 0
+            while (i < n) {
+                let open = d |> find("/*", i)
+                if (open < 0) {
+                    b |> write(slice(d, i, n))
+                    break
+                }
+                b |> write(slice(d, i, open))
+                let close = d |> find("*/", open + 2)
+                break if (close < 0)
+                i = close + 2
+            }
+        }
+    }
+}
+
+//! Absolute and protocol-relative URLs a stylesheet fetches - the address of an `@import`
+//! and of every `url(...)`, quoted or bare, with `/* */` comments cut first so a reference
+//! written in prose does not count. CSS has no `//` comment, so a `//` opened by `(` or a
+//! quote is a protocol-relative address.
+def css_urls(text : string) : array<string> {
+    var out : array<string>
+    peek_data(strip_block_comments(text)) $(d) {
+        let n = length(d)
+        var i = 0
+        while (i < n) {
+            let c = int(d[i])
+            var start = -1
+            if ((c == '(' || c == '"' || c == '\'') && byte_run_at(d, i + 1, "//")) {
+                start = i + 1
+            } elif (byte_run_at_ci(d, i, "http://") || byte_run_at_ci(d, i, "https://")) {
+                start = i
+            }
+            if (start < 0) {
+                i++
+                continue
+            }
+            var e = start
+            while (e < n && !is_url_break_byte(int(d[e]))) {
+                e++
+            }
+            let url = slice(d, start, e)
+            if (!empty(url_host(url))) {
+                out |> push(url)
+            }
+            i = e + 1
+        }
+    }
+    return <- out
+}
+
+// HTML closes script data at `</script` followed by whitespace, `/` or `>` - `</scriptx`
+// is ordinary text, so it must not end the scanned body
+def private is_script_end_tag_at(d; at : int) : bool {
+    return false if (!byte_run_at_ci(d, at, "</script"))
+    let after = at + 8
+    return true if (after >= length(d))
+    let c = int(d[after])
+    return is_white_space(c) || c == '/' || c == '>'
+}
+
+// every attribute value between `from` and `to` - HTML permits an unquoted one, so the
+// value runs to whitespace when no quote opens it
+def private push_tag_urls(d; from : int; to : int; var out : array<string>) {
+    var p = from
+    while (p < to) {
+        if (int(d[p]) != '=') {
+            p++
+            continue
+        }
+        var v = p + 1
+        while (v < to && is_white_space(int(d[v]))) {
+            v++
+        }
+        break if (v >= to)
+        let opener = int(d[v])
+        var vs = v
+        var ve = v
+        if (opener == '"' || opener == '\'') {
+            vs = v + 1
+            ve = vs
+            while (ve < to && int(d[ve]) != opener) {
+                ve++
+            }
+            p = ve + 1
+        } else {
+            while (ve < to && !is_white_space(int(d[ve]))) {
+                ve++
+            }
+            p = ve
+        }
+        push_attribute_urls(slice(d, vs, ve), out)
+    }
+}
+
+// one attribute can carry several addresses - `srcset` writes them comma-separated, each
+// followed by a descriptor (`1x`, `640w`) that is not a URL and drops out on its own
+def private push_attribute_urls(value : string; var out : array<string>) {
+    for (token in split_by_chars(value, " \t\r\n,")) {
+        continue if (empty(token))
+        if (!empty(url_host(token))) {
+            out |> push(token)
+        }
+    }
+}
+
+//! Absolute and protocol-relative URLs a page's markup makes a browser fetch without a
+//! click: every attribute value of a resource tag (script, link, iframe, img, source,
+//! video, audio, embed, object) - quoted or bare, and split so a multi-address `srcset`
+//! yields all of them - plus the URL literals of every inline script body. An
+//! `<a>` or `<meta>` address is left out - a link is a click, not a load. Markup-level on
+//! purpose: a resource tag inside an HTML comment is still reported.
+def html_resource_urls(text : string) : array<string> {
+    var out : array<string>
+    peek_data(text) $(d) {
+        let n = length(d)
+        var i = 0
+        while (i < n) {
+            if (int(d[i]) != '<') {
+                i++
+                continue
+            }
+            var j = i + 1
+            while (j < n && is_alpha(int(d[j]))) {
+                j++
+            }
+            let tag = to_lower(slice(d, i + 1, j))
+            var k = j
+            var quote = 0
+            while (k < n) {
+                let c = int(d[k])
+                if (quote != 0) {
+                    if (c == quote) {
+                        quote = 0
+                    }
+                } elif (c == '"' || c == '\'') {
+                    quote = c
+                } elif (c == '>') {
+                    break
+                }
+                k++
+            }
+            if (is_resource_tag(tag)) {
+                push_tag_urls(d, j, k, out)
+            }
+            if (tag == "script" && k < n) {
+                // no end tag: a browser runs the script to end of file, so the scan does too
+                var close = k + 1
+                while (close < n && !is_script_end_tag_at(d, close)) {
+                    close++
+                }
+                for (url in script_urls(slice(d, k + 1, close))) {
+                    out |> push(url)
+                }
+            }
+            i = k + 1
+        }
+    }
+    return <- out
+}
+
+//! True for a repository rule or architecture document - a `.md` the document system owns,
+//! which no site serves (the SDK bundle gate bans every one of them from an install).
+def private is_rule_document(name : string) : bool {
+    return (name |> starts_with("REVIEW") || name |> starts_with("ARCHITECTURE") ||
+        name == "LAWS.md" || name == "README.md")
+}
+
+def private is_markup_file(name : string) : bool {
+    return (name |> ends_with(".html") || name |> ends_with(".rst") || name |> ends_with(".md"))
+}
+
+// the walker takes basenames, so the rule-document test reads a name, never a path
+def private is_scanned_file(name : string) : bool {
+    return false if (is_rule_document(name))
+    return (is_markup_file(name) || name |> ends_with(".js") || name |> ends_with(".css"))
+}
+
+def private walk_web_files(folder : string; skip_dirs : table<string>; var out : array<string>) {
+    dir(folder) $(name) {
+        return if (name == "." || name == "..")
+        let full = "{folder}/{name}"
+        if (stat(full).is_dir) {
+            if (!key_exists(skip_dirs, name)) {
+                walk_web_files(full, skip_dirs, out)
+            }
+        } elif (is_scanned_file(name)) {
+            out |> push(full)
+        }
+    }
+}
+
+def private resource_urls_of(path : string; text : string) : array<string> {
+    if (is_markup_file(path)) {
+        return <- html_resource_urls(text)
+    }
+    return <- path |> ends_with(".css") ? css_urls(text) : script_urls(text)
+}
+
+//! Cookie-and-host gate for a served web tree: every markup (`.html`, `.rst`, `.md`),
+//! `.js` and `.css` file under `roots`, never descending into a directory named in
+//! `skip_dirs`, is read for `document.cookie` and for a resource host `allowed_hosts` does
+//! not name. Markup contributes its resource tags and inline script bodies, script text its
+//! URL literals, a stylesheet its `@import` and `url(...)` addresses.
+def gate_web_third_party(roots : array<string>; skip_dirs : table<string>; allowed_hosts : table<string>) {
+    var files : array<string>
+    for (root in roots) {
+        walk_web_files(root, skip_dirs, files)
+    }
+    for (path in files) {
+        let text = fread(path)
+        if (empty(text) && stat(path).size > 0ul) {
+            // fread returns "" for both an empty file and a failed read - a gate that cannot
+            // read a file must say so, never pass it
+            gate_finding(path, "unreadable - the gate cannot pass a file it could not read")
+            continue
+        }
+        let cookie_line = find_line(text, "document.cookie")
+        if (cookie_line > 0) {
+            gate_finding(path, cookie_line,
+                "uses document.cookie - this site sets none; keep per-visitor state in localStorage instead")
+        }
+        var inscope urls <- resource_urls_of(path, text)
+        for (url in urls) {
+            let host = url_host(url)
+            continue if (key_exists(allowed_hosts, host))
+            gate_finding(path, find_line(text, url),
+                "reaches {host}, which the gate's allowed-host list does not name - add the host only once its data handling is reviewed")
+        }
+    }
 }

--- a/dastest/tests/test_review_gate.das
+++ b/dastest/tests/test_review_gate.das
@@ -3,6 +3,7 @@ options gen2
 require dastest/testing_boost public
 require strings
 require daslib/fio
+require daslib/strings_boost
 require dastest/review_gate
 
 [test]
@@ -223,4 +224,204 @@ def test_cmake_list_entries(t : T?) {
 
     var inscope shouty <- cmake_list_entries("SET(CAPS a)\nLIST(APPEND CAPS b)\n", "CAPS")
     t |> equal(2, length(shouty), "an uppercase command is read once, not twice")
+}
+
+[test]
+def test_url_host(t : T?) {
+    t |> equal(url_host("https://gc.zgo.at/count.js"), "gc.zgo.at")
+    t |> equal(url_host("http://example.com"), "example.com")
+    t |> equal(url_host("//gc.zgo.at/count.js"), "gc.zgo.at")
+    t |> equal(url_host("https://example.com:8443/x"), "example.com", "port is dropped")
+    t |> equal(url_host("https://user@example.com/x"), "example.com", "userinfo is dropped")
+    t |> equal(url_host("https://example.com?q=1"), "example.com")
+    t |> equal(url_host("https://example.com#frag"), "example.com")
+    t |> equal(url_host("files/github-star.js"), "", "a relative URL has no host")
+    t |> equal(url_host("/doc/index.html"), "", "a rooted path is not protocol-relative")
+    t |> equal(url_host("// a trailing comment"), "", "a comment is not host-shaped")
+    t |> equal(url_host(""), "")
+}
+
+[test]
+def test_script_urls(t : T?) {
+    let src = "var A = 'https://api.github.com/repos/x';\nvar B = \"//gc.zgo.at/count.js\";\n// var C = 'https://commented.example/x';\nfetch(\"http://plain.example/y\");\nvar D = 'files/local.js';\n"
+    var inscope urls <- script_urls(src)
+    t |> equal(3, length(urls), "the commented address and the relative path do not count")
+    t |> equal("https://api.github.com/repos/x", urls[0])
+    t |> equal("//gc.zgo.at/count.js", urls[1])
+    t |> equal("http://plain.example/y", urls[2])
+}
+
+[test]
+def test_html_resource_urls(t : T?) {
+    let page = "<link rel=\"stylesheet\" href=\"https://cdn.example/a.css\" />\n<a href=\"https://clicked.example/page\">link</a>\n<meta property=\"og:image\" content=\"https://meta.example/i.png\" />\n<script data-goatcounter=\"https://beacon.example/count\"\n        async src=\"//gc.zgo.at/count.js\"></script>\n<img src=\"files/local.png\" />\n<script>fetch(\"https://inline.example/x\");</script>\n"
+    var inscope urls <- html_resource_urls(page)
+    var inscope hosts : array<string>
+    hosts |> reserve(length(urls))
+    for (u in urls) {
+        hosts |> push(url_host(u))
+    }
+    t |> equal(4, length(hosts), "an <a> link and a <meta> address are not loads")
+    t |> equal("cdn.example", hosts[0])
+    t |> equal("beacon.example", hosts[1], "a beacon endpoint travels in a data-* attribute")
+    t |> equal("gc.zgo.at", hosts[2])
+    t |> equal("inline.example", hosts[3], "an inline script body is scanned too")
+}
+
+[test]
+def test_gate_web_third_party(t : T?) {
+    let dir_r = create_temp_directory_result("review_gate_web")
+    t |> success(dir_r is value, "temp fixture directory created")
+    if (!(dir_r is value)) {
+        return
+    }
+    let root = unsafe(dir_r.value)
+    t |> success(mkdir("{root}/skipped"))
+    t |> success(fwrite("{root}/ok.html", "<script src=\"https://allowed.example/a.js\"></script>\n"))
+    t |> success(fwrite("{root}/bad.html", "<x>\n<script src=\"https://tracker.example/t.js\"></script>\n"))
+    t |> success(fwrite("{root}/bad.js", "\ndocument.cookie = 'a=1';\n"))
+    t |> success(fwrite("{root}/skipped/ignored.js", "var u = 'https://tracker.example/t.js';\n"))
+    t |> success(fwrite("{root}/notes.txt", "https://tracker.example/t.js\n"))
+    gate_reset()
+    gate_web_third_party([root], {"skipped"}, {"allowed.example"})
+    var inscope fs <- gate_findings()
+    gate_reset()
+    t |> equal(2, length(fs), "only the two scanned files with a defect report")
+    let joined = join(fs, "\n")
+    t |> success(find(joined, "bad.html:2: reaches tracker.example") >= 0, joined)
+    t |> success(find(joined, "bad.js:2: uses document.cookie") >= 0, joined)
+    t |> success(rmdir_rec("{root}"))
+}
+
+[test]
+def test_css_urls(t : T?) {
+    let sheet = "@import url(\"https://fonts.googleapis.com/css2?family=Inter\");\n@font-face \{ src: url(//cdn.example/a.woff2) format('woff2'); \}\nbody \{ background: url('files/local.png'); \}\n/* see http://ie.microsoft.com/testdrive/ for the prefix history */\n"
+    var inscope urls <- css_urls(sheet)
+    t |> equal(2, length(urls), "a local path and an address inside a /* */ comment do not count")
+    t |> equal("https://fonts.googleapis.com/css2?family=Inter", urls[0])
+    t |> equal("//cdn.example/a.woff2", urls[1], "a bare protocol-relative url() counts")
+}
+
+[test]
+def test_gate_web_third_party_file_kinds(t : T?) {
+    let dir_r = create_temp_directory_result("review_gate_kinds")
+    t |> success(dir_r is value, "temp fixture directory created")
+    if (!(dir_r is value)) {
+        return
+    }
+    let root = unsafe(dir_r.value)
+    t |> success(fwrite("{root}/page.rst", ".. raw:: html\n\n   <script src=\"https://tracker.example/t.js\"></script>\n"))
+    t |> success(fwrite("{root}/post.md", "text\n<img src=\"https://tracker.example/pixel.png\" />\n"))
+    t |> success(fwrite("{root}/theme.css", "@import url(\"https://tracker.example/f.css\");\n"))
+    t |> success(fwrite("{root}/REVIEW.md", "**A page that writes document.cookie is a defect.**\n"))
+    t |> success(fwrite("{root}/README.md", "<script src=\"https://tracker.example/t.js\"></script>\n"))
+    gate_reset()
+    let no_skipped_dirs : table<string>
+    gate_web_third_party([root], no_skipped_dirs, {"allowed.example"})
+    var inscope fs <- gate_findings()
+    gate_reset()
+    t |> equal(3, length(fs), "rst, md and css are scanned; a rule document is not a page")
+    let joined = join(fs, "\n")
+    t |> success(find(joined, "page.rst:3: reaches tracker.example") >= 0, joined)
+    t |> success(find(joined, "post.md:2: reaches tracker.example") >= 0, joined)
+    t |> success(find(joined, "theme.css:1: reaches tracker.example") >= 0, joined)
+    t |> success(rmdir_rec("{root}"))
+}
+
+[test]
+def test_html_resource_urls_edges(t : T?) {
+    let page = "<script src=https://bare.example/a.js></script>\n<source srcset=\"https://first.example/a 1x, https://second.example/b 2x\" />\n<img src='https://quoted.example/c.png' />\n"
+    var inscope urls <- html_resource_urls(page)
+    var inscope hosts : array<string>
+    hosts |> reserve(length(urls))
+    for (u in urls) {
+        hosts |> push(url_host(u))
+    }
+    t |> equal(4, length(hosts), "an unquoted value and every entry of a srcset count")
+    t |> equal("bare.example", hosts[0], "HTML permits an unquoted attribute value")
+    t |> equal("first.example", hosts[1])
+    t |> equal("second.example", hosts[2], "a srcset carries more than one address")
+    t |> equal("quoted.example", hosts[3])
+}
+
+[test]
+def test_script_urls_template_literal(t : T?) {
+    let src = "fetch(`//tpl.example/a`);\nfetch(`https://tpl2.example/b`);\n"
+    var inscope urls <- script_urls(src)
+    t |> equal(2, length(urls), "a template literal opens a protocol-relative address too")
+    t |> equal("//tpl.example/a", urls[0])
+    t |> equal("https://tpl2.example/b", urls[1])
+}
+
+[test]
+def test_url_host_is_case_insensitive(t : T?) {
+    t |> equal(url_host("HTTPS://Tracker.Example/x.js"), "tracker.example", "a scheme is case-insensitive")
+    t |> equal(url_host("HtTp://EXAMPLE.COM"), "example.com", "a host is case-insensitive")
+}
+
+[test]
+def test_html_resource_urls_uppercase_script(t : T?) {
+    let page = "<SCRIPT>fetch(\"https://inline.example/x\");</SCRIPT>\n"
+    var inscope urls <- html_resource_urls(page)
+    t |> equal(1, length(urls), "an uppercase closing tag still bounds the inline body")
+    t |> equal("inline.example", url_host(urls[0]))
+}
+
+[test]
+def test_url_host_ipv6_literal(t : T?) {
+    t |> equal(url_host("http://[::1]/t.js"), "[::1]", "a bracketed IPv6 literal is a host")
+    t |> equal(url_host("https://[2001:DB8::1]:8443/x"), "[2001:db8::1]", "the port after the bracket is dropped")
+    t |> equal(url_host("http://[::1"), "", "an unclosed bracket is not host-shaped")
+}
+
+[test]
+def test_script_urls_multiline_template_literal(t : T?) {
+    let src = "const s = `//tpl.example/a\nhttps://tpl2.example/b\n`;\nconst u = \"x\"; // https://commented.example/c\n"
+    var inscope urls <- script_urls(src)
+    t |> equal(2, length(urls), "the second line of a template literal is still inside it; a plain comment still does not count")
+    t |> equal("//tpl.example/a", urls[0])
+    t |> equal("https://tpl2.example/b", urls[1])
+}
+
+[test]
+def test_html_resource_urls_script_end_tag_exact(t : T?) {
+    let page = "<script>var a = \"</scriptx>\"; fetch(\"https://after.example/x\");</script >\n"
+    var inscope urls <- html_resource_urls(page)
+    t |> equal(1, length(urls), "only a real end tag - `</script` then whitespace, `/` or `>` - closes the body")
+    t |> equal("after.example", url_host(urls[0]))
+}
+
+[test]
+def test_gate_web_third_party_unreadable_file(t : T?) {
+    let dir_r = create_temp_directory_result("review_gate_unreadable")
+    t |> success(dir_r is value, "temp fixture directory created")
+    if (!(dir_r is value)) {
+        return
+    }
+    let root = unsafe(dir_r.value)
+    t |> success(fwrite("{root}/empty.js", ""))
+    t |> success(fwrite("{root}/locked.js", "var u = 'https://tracker.example/t.js';\n"))
+    unsafe(system("chmod 000 {root}/locked.js"))
+    if (!empty(fread("{root}/locked.js"))) {
+        unsafe(system("chmod 644 {root}/locked.js"))
+        t |> success(rmdir_rec("{root}"))
+        t |> skip("this platform or user reads a file whose permission bits say no")
+        return
+    }
+    gate_reset()
+    let no_skipped_dirs : table<string>
+    gate_web_third_party([root], no_skipped_dirs, {"allowed.example"})
+    var inscope fs <- gate_findings()
+    gate_reset()
+    unsafe(system("chmod 644 {root}/locked.js"))
+    t |> success(rmdir_rec("{root}"))
+    t |> equal(1, length(fs), "an empty file is scanned and clean; an unreadable one is a finding, never a silent pass")
+    t |> success(find(join(fs, "\n"), "locked.js: unreadable") >= 0, join(fs, "\n"))
+}
+
+[test]
+def test_html_resource_urls_unclosed_script(t : T?) {
+    let page = "<p>x</p>\n<script>fetch(\"https://open.example/x\");\n"
+    var inscope urls <- html_resource_urls(page)
+    t |> equal(1, length(urls), "a script with no end tag runs to end of file in a browser, so it is scanned to end of file")
+    t |> equal("open.example", url_host(urls[0]))
 }

--- a/doc/LAWS.md
+++ b/doc/LAWS.md
@@ -1,0 +1,19 @@
+# LAWS.md - Boris's rulings
+
+Append-only intent provenance for rule-document edits in this folder's documents (the
+mechanism: CLAUDE.md sec. "Boris's rulings get a `LAWS.md` sidecar"). Never groomed,
+compacted, or cited as rules.
+
+- **2026-09-01** (`REVIEW.md`, new): the cookie audit of daslang.io left the served doc tree
+  ungated - its one off-site load is declared in `conf.py`, which no page-level gate reads.
+  Told that closing it meant a new checklist folder, Boris ruled "why not. lets add gates".
+  The checklist exists to carry the gate's two rules; RST prose review stays in its skills.
+
+- **2026-09-01** (`REVIEW.md`): dragon round on the new checklist. `conf.py` resolved
+  against `doc/`, where no such file exists, and naming `html_css_files`/`html_js_files`
+  understated a gate that reads every absolute URL in the file - both replaced by the
+  property. The opening now routes the prose dimension rather than reading as if a
+  prose-only diff escapes the gate.
+
+- **2026-09-01** (`REVIEW.md`): the two gate rules took the site checklist's dragon wording -
+  the weakening rule re-plained, the disclosure rule naming `ALLOWED_HOSTS` directly.

--- a/doc/REVIEW.das
+++ b/doc/REVIEW.das
@@ -1,0 +1,48 @@
+options gen2
+
+require daslib/fio
+require dastest/review_gate
+
+// The mechanical half of doc/REVIEW.md (contract: REVIEW_COMMON.md at the repo root).
+// Run from the repo root: bin/daslang doc/REVIEW.das - exit 0 clean, 1 with findings, 2 when
+// not run from the repo root.
+
+let private CONF = "doc/source/conf.py"
+let private SOURCE_ROOT = "doc/source"
+
+// Hosts a built doc page may reach without a click. daslang.io is where the tree is served
+// (html_baseurl) and jsDelivr serves the DocSearch bundle and its base stylesheet; the theme
+// carries its own fonts and images, so nothing else is fetched off-site.
+let private ALLOWED_HOSTS <- {
+    "daslang.io",
+    "cdn.jsdelivr.net"
+}
+
+// Sphinx writes these into every page's <head> at build time, so an address here is a load
+// no template or stylesheet shows. Read as script text: the URLs are quoted literals, and a
+// `#` comment carrying one is reported too - a commented-out CDN is still a decision to make.
+def private check_conf_hosts {
+    let text = fread(CONF)
+    if (empty(text)) {
+        gate_finding(CONF, "missing or unreadable")
+        return
+    }
+    for (url in script_urls(text)) {
+        let host = url_host(url)
+        continue if (key_exists(ALLOWED_HOSTS, host))
+        gate_finding(CONF, find_line(text, url),
+            "names {host}, which the gate's allowed-host list does not name - add the host only once its data handling is reviewed")
+    }
+}
+
+[export]
+def main() : int {
+    if (!fexist(CONF)) {
+        to_log(LOG_ERROR, "doc/REVIEW.das: run from the repo root\n")
+        return 2
+    }
+    check_conf_hosts()
+    let no_skipped_dirs : table<string>
+    gate_web_third_party([SOURCE_ROOT], no_skipped_dirs, ALLOWED_HOSTS)
+    return gate_verdict("doc")
+}

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -1,0 +1,14 @@
+# doc (the Sphinx manual) Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** RST
+mechanics are `skills/internal/documentation_rst.md` (repo root) and the prose itself is
+`skills/internal/tutorial_prose.md` (repo root); how a page reads is reviewed there, not
+here.
+
+**A diff that makes `REVIEW.das`'s cookie-and-host check read fewer files, or report less
+than it does today with the same `ALLOWED_HOSTS`, is a defect** - the gate bans
+`document.cookie` and reports any resource loaded from a host the list does not name, both
+in what `source/` serves and in the absolute URLs `source/conf.py` declares.
+
+**A diff that adds a host to `REVIEW.das`'s `ALLOWED_HOSTS` states, in the PR body, what a
+reader sends that host and whether the host sets cookies.**

--- a/site-dasllama/LAWS.md
+++ b/site-dasllama/LAWS.md
@@ -1,0 +1,19 @@
+# LAWS.md - Boris's rulings
+
+Append-only intent provenance for rule-document edits in this folder's documents (the
+mechanism: CLAUDE.md sec. "Boris's rulings get a `LAWS.md` sidecar"). Never groomed,
+compacted, or cited as rules.
+
+- **2026-09-01** (`REVIEW.md`): after a cookie audit of daslang.io and dasllama.io found
+  both sites cookie-free but nothing gating a re-introduction, Boris ruled "lets just land
+  review gate" - the checklist keeps only the weakening ban and the allowed-host disclosure
+  duty; the check itself lives in the new `REVIEW.das`.
+
+- **2026-09-01** (`REVIEW.md`): the two gate rules took the site checklist's dragon wording -
+  the weakening rule re-plained, the disclosure rule naming `ALLOWED_HOSTS` directly.
+
+- **2026-09-01** (`REVIEW.md`): the dragon caught the two gate rules contradicting each
+  other - adding a host makes the gate report less, so one diff was both "weakening" (a
+  defect) and "adding a host" (permitted with disclosure). The weakening trigger now reads
+  "with the same `ALLOWED_HOSTS`", which carves the list change out without an exception
+  clause. Applied to all four served-tree checklists.

--- a/site-dasllama/REVIEW.das
+++ b/site-dasllama/REVIEW.das
@@ -1,0 +1,33 @@
+options gen2
+
+require daslib/fio
+require dastest/review_gate
+
+// The mechanical half of site-dasllama/REVIEW.md (contract: REVIEW_COMMON.md at the repo
+// root). Run from the repo root: bin/daslang site-dasllama/REVIEW.das - exit 0 clean, 1 with
+// findings, 2 when not run from the repo root.
+
+let private INDEX_HTML = "site-dasllama/index.html"
+
+// Hosts a page here may reach without a click. dasllama.io and daslang.io are the two sites;
+// gc.zgo.at and the goatcounter endpoint are the cookieless hit counter, and api.github.com
+// serves the star count the deploy stages site/files/github-star.js in to fetch.
+let private ALLOWED_HOSTS <- {
+    "dasllama.io",
+    "daslang.io",
+    "gc.zgo.at",
+    "dasllama.goatcounter.com",
+    "api.github.com"
+}
+
+let private SKIP_DIRS : table<string>
+
+[export]
+def main() : int {
+    if (!fexist(INDEX_HTML)) {
+        to_log(LOG_ERROR, "site-dasllama/REVIEW.das: run from the repo root\n")
+        return 2
+    }
+    gate_web_third_party(["site-dasllama"], SKIP_DIRS, ALLOWED_HOSTS)
+    return gate_verdict("site-dasllama")
+}

--- a/site-dasllama/REVIEW.md
+++ b/site-dasllama/REVIEW.md
@@ -24,6 +24,14 @@ and another engine's - the arithmetic a reader does is not the page's claim.
 **Copy or rendering that lets a row with no reference engine's figure imply parity with a
 reference engine is a defect - an empty ratio cell reads "not raced".**
 
+**A diff that makes `REVIEW.das`'s cookie-and-host check read fewer files, or report less
+than it does today with the same `ALLOWED_HOSTS`, is a defect** - the gate bans
+`document.cookie` and reports any resource a page loads from a host the list does not
+name.
+
+**A diff that adds a host to `REVIEW.das`'s `ALLOWED_HOSTS` states, in the PR body, what a
+visitor sends that host and whether the host sets cookies.**
+
 **A `dl-*` selector that `site/files/dasllama-table.css` (repo root) does not already
 define, declared in any file under this directory, is a defect** - site chrome here uses the
 `dio-` prefix in `files/dasllama-io.css`, and the `dl-*` measurement-table language is that

--- a/site/LAWS.md
+++ b/site/LAWS.md
@@ -22,3 +22,13 @@ compacted, or cited as rules.
   and ("yes") `site/README.md` is blessed as `site/`'s architecture doc (the skill takes a
   carve-out rather than a doc split). The artifact-list and "page"-definition rewrites rode
   along as auditor-identified defects.
+
+- **2026-09-01** (`REVIEW.md`): after a cookie audit of daslang.io and dasllama.io found
+  both sites cookie-free but nothing gating a re-introduction, Boris ruled "lets just land
+  review gate" - the checklist keeps only the weakening ban and the allowed-host disclosure
+  duty; the check itself lives in `REVIEW.das`.
+
+- **2026-09-01** (`REVIEW.md`): dragon round on the two gate rules. The weakening rule was
+  re-plained ("any resource a page loads from a host its allowed list does not name") and
+  the disclosure rule now names `ALLOWED_HOSTS` rather than pointing at its neighbour -
+  rules are unordered, so an adjacency referent points at nothing.

--- a/site/REVIEW.das
+++ b/site/REVIEW.das
@@ -6,10 +6,29 @@ require daslib/strings_boost
 require dastest/review_gate
 
 // The mechanical half of site/REVIEW.md (contract: REVIEW_COMMON.md at the repo root).
-// Run from the repo root: bin/daslang site/REVIEW.das - exit 0 clean, 1 with findings.
+// Run from the repo root: bin/daslang site/REVIEW.das - exit 0 clean, 1 with findings, 2 when
+// not run from the repo root.
 
 let private TABLE_CSS = "site/files/dasllama-table.css"
 let private PAGE_HTML = "site/dasllama.html"
+
+// Hosts a page under this folder may reach without a click. daslang.io is the site itself;
+// the rest are the reviewed third parties - jsDelivr serves the DocSearch bundle, gc.zgo.at
+// and the goatcounter endpoint are the cookieless hit counter, and the github hosts serve the
+// star count, the package index and the source links the pages build.
+let private ALLOWED_HOSTS <- {
+    "daslang.io",
+    "cdn.jsdelivr.net",
+    "gc.zgo.at",
+    "borisbat.goatcounter.com",
+    "api.github.com",
+    "raw.githubusercontent.com",
+    "github.com"
+}
+
+// tests/ is the Playwright harness and doc/ is generated Sphinx output - neither is a page
+// this folder authors, and neither ships from this tree
+let private SKIP_DIRS <- { "tests", "doc", "node_modules" }
 
 //! one top-level selector -> its normalized body. An at-rule (`@media ...`) block is skipped
 //! whole: its nested rules are responsive OVERRIDES of the same selectors by design
@@ -85,5 +104,6 @@ def main() : int {
         return 2
     }
     check_dl_selector_parity()
+    gate_web_third_party(["site"], SKIP_DIRS, ALLOWED_HOSTS)
     return gate_verdict("site")
 }

--- a/site/REVIEW.md
+++ b/site/REVIEW.md
@@ -80,6 +80,14 @@ comment is a defect.**
 **A placeholder number a page reader could take for a fact is a defect - mark it as a
 placeholder on the page itself.**
 
+**A diff that makes `REVIEW.das`'s cookie-and-host check read fewer files, or report less
+than it does today with the same `ALLOWED_HOSTS`, is a defect** - the gate bans
+`document.cookie` and reports any resource a page loads from a host the list does not
+name.
+
+**A diff that adds a host to `REVIEW.das`'s `ALLOWED_HOSTS` states, in the PR body, what a
+visitor sends that host and whether the host sets cookies.**
+
 **Weakening `REVIEW.das`'s `dl-*` selector-parity check - the gate that compares each
 selector body defined in BOTH `files/dasllama-table.css` and `dasllama.html`'s inline
 `<style>` - is a defect.**

--- a/web/LAWS.md
+++ b/web/LAWS.md
@@ -1,0 +1,20 @@
+# LAWS.md - Boris's rulings
+
+Append-only intent provenance for rule-document edits in this folder's documents (the
+mechanism: CLAUDE.md sec. "Boris's rulings get a `LAWS.md` sidecar"). Never groomed,
+compacted, or cited as rules.
+
+- **2026-09-01** (`REVIEW.md`, new): the cookie audit's gate walk found the playground shell
+  deployed from `examples/ui/src` (gitignored where it lands under `site/`, so no site-rooted
+  gate sees it in a fresh checkout) and the canvas shell users ship with. Boris ruled "why
+  not. lets add gates"; both surfaces became this folder's gated set.
+
+- **2026-09-01** (`REVIEW.md`): dragon round on the new checklist. The census of served
+  surfaces was wrong - `examples/ui/samples` is staged four ways and is gitignored where it
+  lands, the same reason `examples/ui/src` needed a gate - so the opening states the served
+  property and a new rule makes a diff that serves a tree add it to the gate's root list.
+  The empty-list WHY was moment-pinned and went; "off-site" became "a host its allowed list
+  does not name", which is what the gate actually tests.
+
+- **2026-09-01** (`REVIEW.md`): the two gate rules took the site checklist's dragon wording -
+  the weakening rule re-plained, the disclosure rule naming `ALLOWED_HOSTS` directly.

--- a/web/REVIEW.das
+++ b/web/REVIEW.das
@@ -1,0 +1,30 @@
+options gen2
+
+require daslib/fio
+require dastest/review_gate
+
+// The mechanical half of web/REVIEW.md (contract: REVIEW_COMMON.md at the repo root).
+// Run from the repo root: bin/daslang web/REVIEW.das - exit 0 clean, 1 with findings, 2 when
+// not run from the repo root.
+
+// Every authored tree under this folder that the deploy or `daspkg release --web` copies
+// into a page a visitor loads. Everything else here is emsdk, a build tree, or a generated
+// output that no diff hand-edits.
+let private DEPLOYED_ROOTS <- ["web/examples/ui/src", "web/examples/ui/samples", "web/templates"]
+
+// Empty on purpose: neither shell fetches anything off-site, and a browser opening a page
+// built from them contacts only the host that served it.
+let private ALLOWED_HOSTS : table<string>
+
+[export]
+def main() : int {
+    for (root in DEPLOYED_ROOTS) {
+        if (!fexist(root)) {
+            to_log(LOG_ERROR, "web/REVIEW.das: run from the repo root\n")
+            return 2
+        }
+    }
+    let no_skipped_dirs : table<string>
+    gate_web_third_party(DEPLOYED_ROOTS, no_skipped_dirs, ALLOWED_HOSTS)
+    return gate_verdict("web")
+}

--- a/web/REVIEW.md
+++ b/web/REVIEW.md
@@ -1,0 +1,20 @@
+# web (the WASM build and its shells) Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** A file
+under this folder is served when the deploy (`.github/workflows/pages.yml`, repo root) or
+`daspkg release --web` copies it into a page a visitor loads.
+
+**A playground UI file - an `examples/ui/src` script or stylesheet, or an
+`examples/ui/samples` bundle - answers to `examples/ui/REVIEW.md`, wherever the diff puts
+it.**
+
+**A diff that makes `REVIEW.das`'s cookie-and-host check read fewer files, or report less
+than it does today with the same `ALLOWED_HOSTS`, is a defect** - the gate bans
+`document.cookie` and reports any resource the files under its root list load from a host
+the list does not name.
+
+**A diff that makes a tree under this folder served adds that tree to `REVIEW.das`'s root
+list, in the same change.**
+
+**A diff that adds a host to `REVIEW.das`'s `ALLOWED_HOSTS` states, in the PR body, what a
+visitor sends that host and whether the host sets cookies.**


### PR DESCRIPTION
An audit of daslang.io and dasllama.io found that neither site sets a cookie, and that
nothing stopped the next embed from walking that back. This adds the gate. Sixteen live
pages were loaded in a fresh browser context each: no cookie jar entry, no `Set-Cookie` on
any response including third-party subresources, no service worker, no IndexedDB. What the
sites do store is six functional localStorage keys, none of which leaves the browser.

`gate_web_third_party` reads every markup, script and stylesheet file under a served tree
for `document.cookie` and for a host its allow-list does not name. Markup contributes its
resource tags and inline script bodies, script text its URL literals, a stylesheet its
`@import` and `url(...)` addresses. A link the visitor must click is not a load, so `a` and
`meta` are left out; a `data-*` attribute of a resource tag is one, which is how a beacon
endpoint is caught rather than only its `src`. Schemes, host names and tag names are read
case-insensitively, attribute values quoted or bare, and a multi-address `srcset` splits.

Four gates, because the served set is wider than the two site folders. `site/` and
`site-dasllama/` carry the pages. `doc/` adds `source/conf.py`: Sphinx writes
`html_css_files` and `html_js_files` into every page head, so that list is a load no
template shows. `web/` covers the two playground trees the deploy stages into `site/` -
both are gitignored where they land, so no site-rooted gate would see them in a fresh
checkout - plus the canvas shell `daspkg release --web` wraps user programs in. The `web/`
allow-list is empty: those trees fetch nothing off-site.

Where to look: `gate_web_third_party` and the scanners under it in `dastest/review_gate.das`;
the allow-list in each of the four `REVIEW.das` files.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Fast preflight only (format, lint, hash-refs, review-md, md-ascii, ast-verify; cpp-syntax
  skipped, no C++ changed). No full tier: the diff adds no engine, macro, JIT or AOT
  surface. CI re-proves the rest.
- Every allow-list entry negative-controlled by removing it and confirming a real call site
  fires - `examples.js:15`, `daspkg.js:6`, `github-star.js:50`, `index.html:12` for `site/`,
  `source/conf.py:173` and `:182` for `doc/`. No entry is dead weight.
- Each scanner arm controlled with a planted defect at the reviewed commit: a tracker
  `script` tag and a `document.cookie` write in `index.html`; a `script` inside an RST
  `.. raw:: html` block; `@import url("https://fonts.googleapis.com/...")` in
  `doc/source/_static/custom.css`; a pixel URL and a cookie write in
  `web/examples/ui/src/main.js`.
- Five parsing bypasses found by external review, each reproduced by a test that fails at
  the reviewed commit before its fix: unquoted attribute values, multi-address `srcset`,
  protocol-relative URLs in template literals, uppercase URL schemes, and an uppercase
  `</SCRIPT>` closing tag.
- 16 gates green tree-wide (`utils/internal/review-md/all.das`), dastest 43/43.

### Claims - stated, not tested
- The live-browser sweep that motivated the gate is a one-time measurement, not a test: 16
  pages across both sites, fresh context each, cookies and storage read after `networkidle`
  plus a forced DocSearch query. Nothing in CI re-runs it. A break would show as a cookie
  appearing on a page whose sources the gate still passes - possible only through a host
  already on an allow-list, or through the doc tree's generated output, which is gitignored
  and therefore outside every gate.
- `web/examples/ui/samples` is a gate root that reads nothing today: the tree holds `.das`
  and `.json` only, and its three `.md` files are rule documents the walker skips. It is
  listed so the first `.html`, `.js` or `.css` sample added there is gated on arrival, not
  because it closes a live hole.

### Not done
- `site/doc` (generated Sphinx output) and `site/tests` (the Playwright harness) are not
  walked. The first is gitignored, so it does not exist in a fresh checkout; its inputs are
  gated at `doc/source` instead.
- The `document.cookie` check reads markup as text, so a blog post that quotes the API in a
  code sample would be a finding. None does today.
- No gate covers a host once it is on an allow-list. The disclosure rule in each checklist
  is the only thing standing behind that decision.
- A `.das.assets.json` sidecar is not scanned. The two that exist carry relative paths only.
- The rule-document round raised defects in rules this PR did not write - `site/REVIEW.md`'s
  duplicated receipt tail and undefined "editor content", `site-dasllama/REVIEW.md`'s
  three-file page census and two rules carrying two triggers each - plus six automation
  candidates. All are reported to the author rather than rewritten here.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
