### PR TITLE
the Vulkan prefill closes on llama.cpp's pp512: grouped split-k, hand-laid four-wide decodes, a 32-row last layer, a parallel embed

### DIFF
--- a/modules/REVIEW_SHADER_EMITTERS.md
+++ b/modules/REVIEW_SHADER_EMITTERS.md
@@ -1,12 +1,13 @@
 # Shared emitter rules - dasSpirv and dasMetal
 
-**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist, and both
-emitters' checklists route here: a change under either module, or to any kernel body or
-fixture either emitter compiles, applies this list with that folder's own.** Architecture
-docs: `modules/dasMetal/ARCHITECTURE.md` and `modules/dasSpirv/ARCHITECTURE.md`.
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist. A change
+under either module, or to any kernel body or fixture either emitter compiles, applies this
+list with that folder's own.** Architecture docs: `dasMetal/ARCHITECTURE.md` and
+`dasSpirv/ARCHITECTURE.md`.
 
 **Never put anything that cannot run on the CPU into a kernel body or into a function a kernel
-calls - keep both in ordinary das.** The CPU run of the same body is the test oracle.
+calls - keep both in ordinary das.** The CPU run of the same body is what the tests compare
+against.
 
 **A diff that adds or changes an emitter builtin ships a CPU body that returns what the emitted
 form returns, argument for argument.**
@@ -24,8 +25,9 @@ the emitter's runtime-extent descriptor - `dynamic_extent` on Metal, and on SPIR
 reduction width is the K dimension - the length of the loop the kernel accumulates over; it
 does not fix tiling, so it is not a shape constant.
 
-**A diff that adds a kernel capability needing a runtime shape value ships a specialization
-path, or records in the module's `ARCHITECTURE.md` that the capability cannot have one.** A
+**A diff that makes a kernel need a shape value known only at run time ships a specialization
+path, or records in the emitter's architecture doc - `dasMetal/ARCHITECTURE.md` for a Metal
+kernel, `dasSpirv/ARCHITECTURE.md` for a SPIR-V kernel - that the kernel cannot have one.** A
 specialization path is one compiled variant per constant shape.
 
 **Never check a claim about emitted shape against the das source - check it in the emitted
@@ -34,10 +36,10 @@ parameter attributes, its statement forms - and its stamped shape values (tile, 
 threadgroup sizes).
 
 **A diff that adds a kernel-model capability to one emitter adds it to the other, or records
-the asymmetry in the shared ledger (`modules/dasMetal/ARCHITECTURE.md`).** A kernel-model
+the asymmetry in the shared ledger (`dasMetal/ARCHITECTURE.md`).** A kernel-model
 capability is anything that changes how a kernel is written or how its body is lowered.
 
-**An emitter diff that uses a `daslib/shader_lingua_franca` declaration this emitter does not
-handle ships, in the same change, either that emitter's lowering of the declaration or a test
-showing this emitter rejects the declaration by name.** A declaration in that module is
-available to both emitters.
+**A diff that puts a `daslib/shader_lingua_franca` declaration into a kernel body or fixture an
+emitter compiles, where that emitter does not handle it, ships, in the same change, either
+that emitter's lowering of the declaration or a test showing the emitter rejects the
+declaration by name.** A declaration in that module is available to both emitters.

--- a/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
+++ b/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
@@ -24,7 +24,7 @@ requant and the classifier.
 final layer reads more than the last row - the classifier requantizes row `wlen - 1`, the KV
 mirrors were stored before the FFN, and a later window starts from fresh embeddings - so the
 gate, up and down GEMMs, the activation and the residual step of the last layer take a region
-starting 32 rows below the window's end (`fill_arena_batch_sched`'s `row0`, `ActArgs.base`,
+starting 32 rows below the window's end (`fill_arena_batch_sched`'s `row0`, `ActArgs.elem0`,
 `ArArgs.row0`). Thirty-two, not one, because the s tile's fast path loads a whole 32-row
 column unclamped and the resident prefill's activation planes (`pf_xf`, `pf_hf`) carry no read
 slack past the window - unlike the MoE chain's gathered image and hidden plane, which sec.2.2l

--- a/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
+++ b/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
@@ -20,6 +20,18 @@ buffers.** Every window's rope and attention address the KV mirror at ABSOLUTE p
 window w attends everything the earlier windows stored; only the last window runs the final
 requant and the classifier.
 
+**The last layer's FFN runs on the window's last 32 rows only.** Nothing downstream of the
+final layer reads more than the last row - the classifier requantizes row `wlen - 1`, the KV
+mirrors were stored before the FFN, and a later window starts from fresh embeddings - so the
+gate, up and down GEMMs, the activation and the residual step of the last layer take a region
+starting 32 rows below the window's end (`fill_arena_batch_sched`'s `row0`, `ActArgs.base`,
+`ArArgs.row0`). Thirty-two, not one, because the s tile's fast path loads a whole 32-row
+column unclamped and the resident planes carry no read slack past the window. Rows below the
+slice keep stale gate, up, hidden and residual values that nothing reads. A sliced GEMM never
+splits k: the split-k reduce sums dense partial planes from row 0, so a region starting below
+the window's end would reduce the wrong rows. The slice takes the f16-fed cm2 route only
+(`gu6 && dn6`); the other feeds run the full window.
+
 **The k and v GEMMs merge into ONE dispatch when the layer's q, k and v weight planes are all
 q8 and the k and v planes sit adjacent in the arena.** The bump allocator places them
 back-to-back unless a slab boundary intervenes, so the merged form asks only those two

--- a/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
+++ b/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
@@ -26,11 +26,15 @@ mirrors were stored before the FFN, and a later window starts from fresh embeddi
 gate, up and down GEMMs, the activation and the residual step of the last layer take a region
 starting 32 rows below the window's end (`fill_arena_batch_sched`'s `row0`, `ActArgs.base`,
 `ArArgs.row0`). Thirty-two, not one, because the s tile's fast path loads a whole 32-row
-column unclamped and the resident planes carry no read slack past the window. Rows below the
-slice keep stale gate, up, hidden and residual values that nothing reads. A sliced GEMM never
-splits k: the split-k reduce sums dense partial planes from row 0, so a region starting below
-the window's end would reduce the wrong rows. The slice takes the f16-fed cm2 route only
-(`gu6 && dn6`); the other feeds run the full window.
+column unclamped and the resident prefill's activation planes (`pf_xf`, `pf_hf`) carry no read
+slack past the window - unlike the MoE chain's gathered image and hidden plane, which sec.2.2l
+sizes with 32 rows of slack past their last region. Rows below the
+slice keep stale gate, up, hidden and residual values that nothing reads. The sliced GEMMs do
+not split k: the split-k reduce sums partial planes from row 0, so a region starting below the
+window's end would reduce the wrong rows. The slice takes the f16-fed cm2 route only
+(`gu6 && dn6`); the other feeds run the full window. Only the plain residual step (`cls_ar`)
+and the f16 activation honor the row base: the fused residual twins feed the NEXT layer's
+projections and never run on the last layer, so they index from row 0 by design.
 
 **The k and v GEMMs merge into ONE dispatch when the layer's q, k and v weight planes are all
 q8 and the k and v planes sit adjacent in the arena.** The bump allocator places them
@@ -101,8 +105,8 @@ format's twin looks its grid word up once and takes the four bytes and the four 
 it. The synthesized twin (`DECVEC`, the axis a new format starts on) repeats the whole scalar
 body four times - the lane selects, the scale-plane words, the grid lookup and the sign parity
 - and on the grid formats it lost to the scalar callback for exactly that reason. The twin
-computes each element in the scalar's operation order, so the tile's oracle holds bit for bit
-under either callback.
+computes each element in the scalar's operation order, so the tile's CPU oracle holds under
+either callback; which callback a box runs is the `device ready` line's `four-wide decode`.
 
 ### 2.2l The cm2 tile pick and the coopmat default ladder {#cm2-tile-pick-and-default}
 

--- a/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
+++ b/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
@@ -82,6 +82,16 @@ bytes. The IQ4_XS codebook is the one runtime-indexed read a decode makes: it is
 16-entry `@workgroup` f16 table ahead of the tile loop (the reference exe's shared-memory table-staging form),
 never selected out of a register vector per element.
 
+Every kq format's four-wide twin is hand-laid (`decode_v4`, the template's `DECV4` axis): it
+keeps the same spelling and shares what four consecutive elements share. A K-quant twin reads
+its four quant bytes as two 16-bit lanes and extracts the sub-block's scale pair once; a grid
+format's twin looks its grid word up once and takes the four bytes and the four sign bits from
+it. The synthesized twin (`DECVEC`, the axis a new format starts on) repeats the whole scalar
+body four times - the lane selects, the scale-plane words, the grid lookup and the sign parity
+- and on the grid formats it lost to the scalar callback for exactly that reason. The twin
+computes each element in the scalar's operation order, so the tile's oracle holds bit for bit
+under either callback.
+
 ### 2.2l The cm2 tile pick and the coopmat default ladder {#cm2-tile-pick-and-default}
 
 **The l/m tile pick is a wave-efficiency comparison.** For a GEMM of width `d` over `cnt` rows
@@ -128,9 +138,11 @@ NV_cooperative_matrix2, else mm where it has KHR_cooperative_matrix, else sdot4;
 the extension lands on mm. The same resolver stamps the mode into the `.dlim` flavor
 configuration, so the recorded mode and the running mode cannot drift. The four-wide decode
 callback is NOT in that configuration: a cm2 tile names both callbacks
-(`coopmatLoadTensorDecode`'s tenth argument is the template's `DECVEC` axis, on by default and
-off for the formats whose `cm2:<fmt>` probe row shows the synthesized twin losing - iq3s, iq2s
-and iq2xxs today), the device created with `DASLLAMA_VK_DECVEC` and the extension decides which
+(`coopmatLoadTensorDecode`'s tenth argument: the format's own `decode_v4` where the template's
+`DECV4` axis is on - every kq superblock format today, sec.2.2k - else the `DECVEC` axis,
+which synthesizes the twin from the scalar body and is where a new format starts, its
+`cm2:<fmt>` probe row deciding whether a hand-laid twin is owed), the device created with
+`DASLLAMA_VK_DECVEC` and the extension decides which
 one the driver runs, and neither choice shapes an image byte, so the bake identity ignores it
 (the configuration's own rule: a serve-only knob is never a field). `decvec_on` is the run's arm,
 announced on the `device ready` line.

--- a/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
+++ b/modules/dasLLAMA/ARCHITECTURE_GPU_VULKAN.md
@@ -101,6 +101,18 @@ and clamps only the store, so every f16 plane the chain feeds it - the gathered 
 image and the hidden plane - is sized with 32 rows of slack past its last region
 (`ffn_cm2_chunk_rows`).
 
+**The split-k pick counts the dispatch group, not the GEMM.** Long K (2048 and up) on a grid
+that would fill under half the SMs splits the reduction across f32 partial planes that
+`SplitKReduce` sums (three chunks up to two thirds full, at most eight, each chunk 256-aligned
+and a split that would strand an empty tail shed). The grid it measures is the role's own
+workgroups PLUS those of the chain neighbours it runs beside - q with k and v, gate with up
+(`cm2_tiles`, the same pick each neighbour's own dispatch makes) - because the hazard-mask rail
+lets independent roles co-run, while every split role serializes through the one scratch plane
+(`VHZ_SK`) its neighbours would also claim. Counted alone, a 512-wide k or v projection over a
+512-row window fills 16 of 36 SMs and splits in two; counted beside q it runs whole, and k and v
+fill the device together. Split-k is left to the lone role - wo, down, a small model's
+classifier - whose grid nothing else pads.
+
 **The f16 feed admits q8 and every kq superblock format** (`kq_sb`) - the set the cm2 decode
 callbacks cover (sec.2.2k) - and each (format, tile) pair has ONE stamped class. The
 prefill driver reaches them through one dispatcher per stage (`cm2_cls_ensure`, `cm2_cls_set`,

--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -130,6 +130,7 @@ Vulkan GPU backend. Present only where the dasVulkan package is installed.
 | `DASLLAMA_VK_MEMPRIO` | flag | on | Tag allocations high-priority (VK_EXT_memory_priority) so the driver demotes desktop memory, not ours. |
 | `DASLLAMA_VK_FA` | flag | on | Vulkan flash attention: the decode fa kernel pick AND the cm2 prefill fa tile; 0 falls back to the chunked/scalar paths. |
 | `DASLLAMA_VK_KV_MERGE` | flag | on | Merged k|v prefill GEMM - one dispatch over the adjacent k+v arena planes; 0 pins the split k + v dispatches for a same-build A/B. |
+| `DASLLAMA_VK_FFN_SLICE` | flag | on | The last layer's FFN runs on the window's last 32 rows only (the classifier reads one); 0 runs it over the whole window for a same-build A/B. |
 | `DASLLAMA_VK_OVERLAP` | flag | on | Prefill record/execute overlap: the window chain submits in ramped chunks (1,2,4,8 layers) so the GPU starts while the CPU still records; 0 pins the single fenced submit (the per-role GPU profile pins it too, so a chunk gap never bills to a role). |
 | `DASLLAMA_VK_GPU_EMBED` | flag | on | Device-side token-embedding gather for the resident prefill (a tied q8 table gathers from the resident cls plane; a raw f32 table uploads whole under a 512 MB cap); 0 keeps the CPU embed loop. |
 | `DASLLAMA_VK_FULLSG` | flag | off | Pin REQUIRE_FULL_SUBGROUPS on every class pipeline (instrument; measured slower than plain pipelines on the mm_a gate shape, so those are the default). |

--- a/modules/dasLLAMA/HOW_TO_ADD_A_FORMAT.md
+++ b/modules/dasLLAMA/HOW_TO_ADD_A_FORMAT.md
@@ -199,12 +199,16 @@ verbatim; scales the 20 B `KQ_DEV_SSB` row) plus three eight-line width stamps, 
 `cm2_cls_ensure/set/enc` ladders, and `pf_f16_feed` admits it via `kq_sb` automatically. A
 codebook format raises the `IQLUT` axis - a gated `@workgroup` f16 table staged ahead of the
 tile loop (llama.cpp's `init_iq_shmem` form); never select codes out of a register vector per
-element inside a decode callback. The four-wide decode twin comes with the template: its loads
-pass the `DECVEC` axis as `coopmatLoadTensorDecode`'s tenth argument, so the emitter synthesizes
-the vector callback over `decode` and a format authors nothing for it. Run
-`harness/vk_gemm_probe.das -- cm2:<fmt>` with `DASLLAMA_VK_DECVEC` 1 and 0: a format whose row
-loses overrides `DECVEC = false` (iq3s, iq2s, iq2xxs today), and a hand-laid `half4` twin (a
-second `[spirv_decode]` method in that slot) is the lever for it. Gate: a device-form CPU oracle
+element inside a decode callback. The four-wide decode twin is the format's own: a second
+`[spirv_decode] def decode_v4` returning `half4` under `override DECV4 = true`, computing the
+four consecutive elements in the scalar `decode`'s operation order and sharing what they share
+(two 16-bit lanes and one scale extraction for a K-quant, one grid word and its four sign bits
+for a grid format - every kq format today authors one). A format may start on the template's
+`DECVEC` axis, the twin the emitter synthesizes over `decode`, but the synthesized twin repeats
+the scalar body four times and lost to the scalar callback on the grid formats. Run
+`harness/vk_gemm_probe.das -- cm2:<fmt>` (both twin arms in one process): a format whose
+four-wide row loses to its scalar row ships a twin that wins or turns both axes off. Gate: a
+device-form CPU oracle
 (`<fmt>f16_gemm_oracle`) and
 an l/m/s cell in `tests/test_vulkan_kernels.das`. Payoff on the 1B: iq4xs pp512 5161 -> 15334,
 k3 5174 -> 14031 (0.90x / 0.80x llama.cpp's Vulkan, from 0.30x).

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -12,6 +12,18 @@ what it costs today and what the fix would change.
 
 ## Entries
 
+- **OWED ROWS - the Vulkan cm2 prefill's board cells.** `performance/records/zen2.json` carries
+  one das/vulkan cell (Qwen3-4B Q8_0 under `DASLLAMA_COOPMAT=mm`, 2026-07-25) and no cm2 cell,
+  while the Vulkan pp arc (`plans/kernel_parity_pass.md`: the group-aware split-k, the hand-laid
+  four-wide twins, the last-layer slice, the parallel embed) made every Vulkan prefill faster -
+  the Q4_K_M 1B window 27.8 -> 22.1 ms on the `lcpp_bench --for-debug-purposes` rig,
+  stage readings only. `performance/gen_bench_records.das`'s hardware stamp refuses this box
+  while the remote-access daemon runs, so the mint waits for the owner's rig window. Owed: the
+  zen2 vulkan cell re-minted, plus a cm2 cell (the served default on the 5060 Ti) on a 1B kq
+  vehicle, both spawned by `gen_bench_records`, both walls out-of-process, direction-grade
+  against the 07-25 row; done when both rows sit in `performance/records/zen2.json` and the
+  site records are regenerated.
+
 - **OPEN (narrowed) - the gemma3v encode residual after the tower flash: ~0.92x vs the
   pair.** The slab road closed in three landings: the 96 head pad (guarded AV columns,
   668 -> 486 -> 452), then the LIFTED dk72 flash (MetalTowerFlash + the per-head-contiguous

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -9,11 +9,12 @@ the followup ledgers).
 **A dasLLAMA `[test]` file, wherever the diff puts it, answers to this module's
 `tests/REVIEW.md`.**
 
-**A timing rig - a script whose output is a measured wall or rate - wherever the diff puts
-it, answers to this folder's `benchmarks/REVIEW.md`.**
+**A timing rig - a script whose output is a measured wall-clock time or rate - wherever the
+diff puts it, answers to this folder's `benchmarks/REVIEW.md`.**
 
 **A diff that writes a measured number down - into `PERF_LEDGER.md`, a checked-in doc, a
-code comment, or a PR body - or adds a servable capability applies `REVIEW_MEASUREMENT.md`.**
+code comment, or a PR body - or adds or changes a serving path, one that serves a weight
+format, modality, family, or backend, applies `REVIEW_MEASUREMENT.md`.**
 
 **A change to what enters `performance/records/`, or to a provenance manifest, answers to
 `performance/REVIEW.md`.** A change to WHICH model file a recorded row or a manifest pins
@@ -30,8 +31,12 @@ tune-boot path that reaches it, applies `REVIEW_EXCHANGE.md`.**
 **Every `dasllama/` change applies this folder's `tests/REVIEW.md` - open it explicitly: the
 folder walk does not surface it for a `dasllama/`-only diff.**
 
-**A GPU kernel, driver, dispatch-class, or K/V-mirror change - and a GPU kernel A/B race,
-knockout, or hand-binding arm, wherever the diff puts it - applies `REVIEW_GPU.md`.**
+**A GPU kernel, driver, dispatch class (a class a `[metal_dispatch]` or `[vk_dispatch]`
+declares), or K/V-mirror (the device-side copy of the key/value cache a GPU decode reads and
+writes) change - and a GPU kernel A/B race, a knockout (an arm that skips a stage to price
+it), or a hand-binding arm (one that writes buffer or kargs (kernel-argument struct) binding
+numbers as literals instead of taking the kernel class's declared ones), wherever the diff
+puts it - applies `REVIEW_GPU.md`.**
 
 **A kernel body or a function a kernel calls - a `[metal_kernel]` def, a class a
 `[metal_dispatch]` / `[vk_dispatch]` declares, or a fixture either emitter compiles - wherever
@@ -67,12 +72,10 @@ applies `REVIEW_PLACEMENT.md`** - the what-lands-where rules.
 `modules/dasLLAMA/` applies this one.**
 
 **`DASLLAMA_RELEASE` (`dasllama/dasllama_version.das`) is bumped only on a declared release -
-a maintainer ruling that bench comparability is broken - and a bump riding any other diff is
-a defect. A bump whose diff carries no `LAWS.md` entry recording the ruling is a defect
-too.** Routine kernel work never bumps it: tune sidecars and board rows stay valid
-across code changes (a changed kernel keeping a stale sidecar winner is perf-only drift -
-crowns pick among envelope-verified twins), and per-change invalidation lives in the finer
-mechanisms (`IMAGE_VERSION`, the reflected layout fingerprint).
+a maintainer ruling that bench comparability is broken - and the bump's diff carries the
+`LAWS.md` entry recording that ruling.** Recorded performance rows and tune sidecars stay valid across code changes, and
+per-change invalidation lives in the finer mechanisms - `IMAGE_VERSION` and
+`layout_fingerprint()` (`dasllama/dasllama_image.das`).
 
 **A value that cannot change between dispatches of one compiled kernel never reaches that
 kernel as a uniform, a kargs field, an `@off` bind offset, or a helper parameter.** A value
@@ -81,11 +84,8 @@ that can change between dispatches goes in a uniform, a kargs field, or an `@off
 **Weakening `REVIEW.das`'s restore check - the walk over `dasllama/` requiring every
 function-typed global with a declaration initializer to join its file's boot-restore
 `[init]` - is a defect, and so is landing such a global anywhere the walk does not reach.** A
-serialized exe restores globals as data - the function value arrives null, and the first
-invoke to reach it dies at exe runtime while every `-jit` gate stays green (script mode runs
-the declaration initializers). The restore guard (`if (g_x == null) { g_x = @@sentinel }`)
-lets a real registrar win in either `[init]` order; `test_exe_smoke` is the end-to-end
-tripwire for the class.
+serialized exe restores globals as data, so the function value arrives null and the first
+invoke to reach it dies at exe runtime while every `-jit` gate stays green.
 
 **Never reorder or merge the float multiplies in a function that builds a RoPE angle table
 (`dasllama/dasllama_rope.das`) - keep the multiply order the code already has.** A regrouping
@@ -94,19 +94,19 @@ moves the angles in the last bits and flips token-exact fixtures.
 **A diff that changes a kernel-selection predicate in `dasllama/` is based on timing that ran
 both variants interleaved in one process, under one instrument.** The same holds for a
 constant in `dasllama/` whose value was chosen by timing two candidates against each other. A
-reading taken across two processes, or across two commits, says which way the wall moved, not
-which implementation to adopt.
+reading taken across two processes, or across two commits, says which way the wall-clock time
+moved, not which implementation to adopt.
 
 **A change to an allocation reached from a load, bake, or convert path (judge a shared helper
 at each call site) that trades footprint for speed ships the measured pair - peak footprint and
 wall-clock - and a stated decision.**
 
 **A new call to an f32 matmul (`matmul_batch`, `mm_blob_b`, per-head `gemm_f32`, or an f32 GPU
-mm) outside a parity or oracle rail, where a faster-format twin already serves the same weights
-and shape, is a defect - call that twin instead.** Weights with no faster twin (unquantized
-planes) are out of scope; a site that must stay f32 for another reason is ledgered on its own
-file's sec.1 charter line in `ARCHITECTURE_ENGINE.md`, `ARCHITECTURE_GPU.md`, or
-`ARCHITECTURE_MEDIA.md`, not commented into compliance.
+mm) outside a correctness-comparison path (one whose only job is to produce a reference
+result to check another against), where a faster-format twin already serves the same weights
+and shape, is a defect - call that twin instead.** A site that must stay f32 for another
+reason is ledgered on its own file's sec.1 charter line in `ARCHITECTURE_ENGINE.md`,
+`ARCHITECTURE_GPU.md`, or `ARCHITECTURE_MEDIA.md`, not commented into compliance.
 
 **A boot-path prompt (code that runs at startup, before the first request) that reads stdin
 without first proving both stdin and stdout are terminals is a defect - emit the question as
@@ -114,9 +114,9 @@ a `@sidecar` event instead.** A supervised or piped boot must never block on inp
 
 **A NEW clock read paired with a print or log of the elapsed interval is a defect in an engine
 file (`dasllama/`) outside a cold one-shot load, bake, map, or tokenizer-build progress log** -
-instrumentation goes through the sanctioned rails - `profile_tag` / `profile_marker`, `prof_add`,
-`asr_prof_add`, the Vulkan tier's `vk_prof()`-gated ledgers - whose reasons are
-`ARCHITECTURE_MEASUREMENT.md` sec.2.10's.
+instrumentation goes through the profiling rails - `profile_tag` / `profile_marker`, `prof_add`,
+`asr_prof_add`, the Vulkan tier's `vk_prof()`-gated ledgers - and the rails and their reasons
+are `ARCHITECTURE_MEASUREMENT.md` sec.2.10.
 
 **A clock value that changes what the program DOES - control flow, eviction, a generated
 name; not a reported wall or a best-of reduction over reported walls - is marked
@@ -124,7 +124,8 @@ name; not a reported wall or a best-of reduction over reported walls - is marked
 profiling to the sweep that runs over the same tree.
 
 **Every new kernel or loop the runtime re-enters per token, per frame, or per prefill
-quantum is COVERED by an annotated region entry** - `[hot_path]`, any of the `[no_alloc]` /
+quantum - one batch of prompt tokens the prefill path processes in a single pass - is COVERED
+by an annotated region entry** - `[hot_path]`, any of the `[no_alloc]` /
 `[no_env]` / `[no_io]` contracts, or `[cold_path]` on its only reaching entry. Covered means
 an annotated entry reaches it: the contracts arm down the call graph, so an interior
 function carries nothing of its own. A region entry is the outermost such function (a kernel
@@ -133,14 +134,13 @@ reached only from a load, stage, bake, or convert path is not one.
 
 **A new function that no annotated entry reaches but the runtime re-enters per token, per
 frame, or per prefill quantum - a step driver, or a backend entry called from dispatch or
-harness paths - carries its annotation itself; a rename is not new** (annotations follow
-the name in the same change).
+harness paths - carries its annotation itself.** A renamed function is not new: its
+annotation moves with the name in the same change.
 
 **A change to code or data of `encode`/`bpe_encode` or anything they reach in
 `dasllama/dasllama_spm.das` / `dasllama/dasllama_bpe.das` / `dasllama/dasllama_pretok.das`
 ships before/after `--tok` rows (this folder's `benchmarks/lcpp_bench.das`) for the affected
-backend** - the instrument is the scaling ratio across the size ladder, and superlinear is a
-defect.
+backend, and a wall-clock time that grows faster than linearly with input size is a defect.**
 
 **A change to code or data in `dasllama/dasllama_tokenizer.das`, `dasllama/dasllama_spm.das`,
 `dasllama/dasllama_bpe.das`, or `dasllama/dasllama_pretok.das`, or to the special-token or
@@ -163,8 +163,8 @@ docstring, help string, `README.md`, or checked-in document still showing the ol
 default is a defect of the change, not of the docs.** User-facing means anything a consumer
 outside this repo can depend on - what it calls, types, requires, or parses (facade functions,
 CLI flags, environment knobs, file formats, defaults, what the installed SDK lets a program
-`require`) - plus the in-repo rig and tool surface: any output another tool parses, a
-console-only diagnostic not being one.
+`require`) - plus the in-repo rig and tool surface: any output another tool parses. A
+console-only diagnostic is not user-facing.
 
 **Weakening `dasllama_lint` (`dasllama/dasllama_lint.das`) - the compile-time check that a
 consumer requires only this module's public entry modules, matched by the resolved file's
@@ -180,9 +180,10 @@ for several twins - does not fire this rule: the one body left still carries its
 **`options _dasllama_internal` belongs only in a file whose job is to reach engine
 internals: an engine file under `dasllama/`, a test, harness, benchmark, or rig this module
 owns, or a consumer `ARCHITECTURE_ENGINE.md` sec.1.8 names as ruled** - a symbol the facade
-lacks is added to `dasllama/dasllama.das`, not escaped around. A `require ... public` that
-re-exports an engine module OUT of an escaped file, beyond what that consumer's ruled charter
-(`ARCHITECTURE_ENGINE.md` sec.1.8) grants, breaks this rule too.
+lacks is added to `dasllama/dasllama.das`, not reached around with this option. A
+`require ... public` that re-exports an engine module OUT of a file carrying this option,
+beyond what that consumer's ruled charter (`ARCHITECTURE_ENGINE.md` sec.1.8) grants, breaks
+this rule too.
 
 **Weakening `REVIEW.das` (beside this file) is a defect:** dropping a check, adding a name to
 a check's licensed set - the names that check does not flag - or a finding text that no
@@ -194,10 +195,10 @@ the file it checks - in `ARCHITECTURE_ENGINE.md`, `ARCHITECTURE_MEDIA.md`, or
 `ARCHITECTURE_GPU.md`.** The line names the check and the names it licenses. A licensed name
 is one that check does not flag. When the check licenses no names, the line says so.
 
-**Checked-in prose this module owns - docs and comments, any language - that is not locating, patching,
-or reproducing work against the reference build describes an upstream mechanism in our own
-terms: no "lifted/ported verbatim from", and no upstream symbol, header, constant, or binary
-name - write "the reference exe" or "upstream" instead.** The reference build is the
+**Checked-in prose this module owns - docs and comments, any language - that is not locating,
+patching, or reproducing work against the reference build describes an upstream mechanism in
+our own terms: no "lifted/ported verbatim from", and no upstream symbol, header, constant, or
+binary name - write "the reference exe" or "upstream" instead.** The reference build is the
 third-party engine this module measures itself against - the checkout
 `benchmarks/setup_lcpp_ref.das` pins. A symbol the file carrying that prose calls or holds as
 a value is its own name, not attribution.
@@ -205,16 +206,23 @@ a value is its own name, not attribution.
 **A file or line whose job is to locate, patch, or reproduce work against the reference build
 names that build's binaries and symbols outright.** The job decides, not the artifact kind - a
 regeneration path, an env-knob row, a command line in a methodology or how-to document, a
-ledger row naming the compared build, and a source patch applied TO the reference build all
-qualify.
+ledger row whose subject is a reading of the reference build (the compared row, the command
+that reproduces it), and a source patch applied TO the reference build all qualify. A row that
+cites upstream while proposing our own work is not a reading of the reference build, so it
+names no upstream symbol.
+
+**A diff that changes what authoring a new weight format entails - a step added or dropped, a
+file the author must touch, a fixture or probe entry the format must supply, or a gate it must
+pass - updates `HOW_TO_ADD_A_FORMAT.md` in the same change.** The how-to is the next format
+author's whole brief: a step dropped there is a step the next format silently skips.
 
 **Legal attribution never appears in prose - it lives in `THIRD_PARTY_NOTICES.md` and the
 `LICENSE.*` files.**
 
 **A def of `dasllama/dasllama.das` - and a new OVERLOAD of one - is TAUGHT: demonstrated in
 runnable code in a `tutorials/dasLLAMA/*.das` source and narrated on a
-`doc/source/reference/tutorials/dasLLAMA_*.rst` page.** The gate matches def NAMES only, so
-an overload passes on a sibling's tutorial - the reviewer confirms a tutorial calls the NEW
+`doc/source/reference/tutorials/dasLLAMA_*.rst` page.** `REVIEW.das`'s `check_tutorial_floor`
+matches def NAMES only, so an overload passes on a sibling's tutorial - the reviewer confirms a tutorial calls the NEW
 signature, and a mention that only names it (a comment, a passing reference) does not count.
 
 **A NEW `[EnvConfig]` area struct is rendered by `env_markdown()` in the same change.** A
@@ -228,8 +236,9 @@ by retranscoding `$LCPP/src/unicode-data.cpp` (the reference checkout) instead.*
 **A diff that adds a file under `dasllama/`, moves code between files, or changes what a file
 owns lands the sec.1 edit that keeps the charters true - in `ARCHITECTURE_ENGINE.md`,
 `ARCHITECTURE_GPU.md`, or `ARCHITECTURE_MEDIA.md` - in the same change.** A diff that adds
-a file beside one that has its own sec.1 charter line lands that edit too. A module-root doc
-file - a ledger, a plan, `LAWS.md` - has no charter line and lands free.
+a file to any folder where another file has its own sec.1 charter line lands the new file's
+charter line too. A module-root doc
+file - a ledger, a plan, `LAWS.md` - has no charter line and needs no charter edit.
 
 **A diff that adds or removes an `ARCHITECTURE_*.md` companion, or moves a section between
 companions, lands `ARCHITECTURE.md`'s index line and section range and repoints every prose
@@ -238,9 +247,7 @@ LINT026-gated; the prose ones are not, and a prose citation of a section that le
 sends the reader to nothing.
 
 **A diff that moves a family encode stage onto a GPU hook leaves the CPU form in place and
-changes none of its arithmetic - deleting or rewriting the CPU form in the same change is a
-defect.** The hook returns a decline value (`false`, or `-1` for the chunk hooks), and the CPU
-form serves every box with no driver.
+changes none of its arithmetic.** The CPU form serves every box with no driver.
 
 **A diff that writes a CPU feature name in a `requires=` argument that `TUNE_KNOWN_FEATURES`
 (`modules/dasLLVM/daslib/llvm_tune.das`, repo root) does not list adds it there in the same
@@ -253,8 +260,9 @@ the tuning the profile was meant to save.
 root) - is a `def` returning it, never a module global with a declaration initializer (`let`
 or `var`).** A team lane never runs global initializers, so the global reads zero there while
 every single-threaded run reads the right value.
+
 **A `resize` in `dasllama/` of a buffer whose element count scales with a model dimension is
 preceded by a `reserve` of the same count (`reserve_resize` / `grow_resize` / `ensure_length` in
-`dasllama_common.das`, or the pair spelled out) - whatever the size looks like at today's
+`dasllama/dasllama_common.das`, or the pair spelled out) - whatever the size looks like at today's
 shapes.** A model dimension makes the count unbounded, and a bare grow past the heap's
 unreserved-size cap (64 MB) panics the load on the first big model rather than at the call site.

--- a/modules/dasLLAMA/REVIEW_GPU.md
+++ b/modules/dasLLAMA/REVIEW_GPU.md
@@ -82,6 +82,10 @@ wider-row site passes the full stride or dispatches the padded tile.** A split r
 `row x dispatched-width`, so a wider-row caller lands its split rows on top of the row beside
 them.
 
+**A prefill GEMM dispatched at a nonzero start row - a region beginning below the window's
+end - never asks `cm2_split_k` for a split; it encodes unsplit.** The split-k reduce sums dense
+partial planes counted from row 0, so a sliced region would reduce the wrong rows.
+
 **A scratch buffer a dispatch writes is never rebound for a new write before the reader of
 its previous write is encoded - rotate through as many buffers as the chain has dispatches in
 flight between a write and its read.** One shared scratch serializes the whole chain through

--- a/modules/dasLLAMA/REVIEW_GPU.md
+++ b/modules/dasLLAMA/REVIEW_GPU.md
@@ -1,18 +1,20 @@
 # dasLLAMA GPU Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
-docs: `ARCHITECTURE_GPU.md`, `ARCHITECTURE_GPU_PREFILL.md`, `ARCHITECTURE_GPU_VULKAN.md`.
+docs: the `ARCHITECTURE_GPU*.md` companions that `ARCHITECTURE.md` indexes.
 
-**Routed from `REVIEW.md`: a diff touching a GPU kernel, driver, dispatch class, or the K/V
-mirrors applies this list together with `REVIEW.md`.**
+**Routed from `REVIEW.md`: a diff that checklist routes here applies this list together with
+it.**
 
-**A diff touching a GPU kernel A/B race, knockout, or hand-binding arm - or changing a
-kernel class such an arm mirrors (binding numbers, kargs layout, threadgroup memory, staging
-shape, grid or threadgroup geometry) - wherever the diff puts it - applies
-`REVIEW_GPU_RACE.md` too.**
+**A diff touching a GPU kernel timing arm - code that dispatches a kernel to measure it
+rather than to serve a call - or changing a kernel class such an arm mirrors (binding
+numbers, kernel-argument (kargs) layout, threadgroup memory, staging shape, grid or
+threadgroup geometry) - wherever the diff puts it - applies `REVIEW_GPU_RACE.md` too.**
 
 **A diff touching the tower driver (`dasllama/dasllama_metal_tower.das`), a kernel class or
-builder the tower dispatches, or the Metal ASR decoder applies `REVIEW_TOWER.md` too.**
+builder the tower dispatches, the `[metal_dispatch]` emission those builders are generated
+from (`dasllama/dasllama_metal_lens.das`), or the Metal ASR decoder
+(`dasllama/dasllama_metal_asr_dec.das`) applies `REVIEW_TOWER.md` too.**
 
 **A kernel body that emits a function pointer or a vtable into the shader is a defect - splice
 the choice at compile time instead.** A `class template` / `def abstract` / `def override`
@@ -28,9 +30,9 @@ Stamped means the guard is carried by a `@template_constant` - a `static_if` blo
 select on the constant. The instance stamped without the guard shows no guard in its generated
 `*_msl` global.
 
-**Never let a `matmul2d` left or right operand reach the op as `float` outside a kernel class
-stamped `[metal_kernel(float_a_ok=true)]` - convert it in the pass that writes the operand's
-buffer, or in the staging loop that reads it.** A float operand keeps the op off its native
+**Weakening the MSL emitter's refusal to compile an unlicensed float `matmul2d` A operand -
+`[metal_kernel(float_a_ok=true)]` is the license - or its gate
+`tests/test_metal_float_a_gate.das`, is a defect.** A float operand keeps the op off its native
 fast path.
 
 **A diff that stamps a kernel class `[metal_kernel(float_a_ok=true)]` outside the set
@@ -62,10 +64,10 @@ threadgroup-uniform value instead.** A per-thread exit leaves the threadgroup un
 complete the op.
 
 **An encoder that picks a kernel form whose loop carries no bounds or tail guard - stamped
-without one, or generated from a template instance that has none - shows that every address the form touches stays
-inside its buffers' allocations.** One extent dividing evenly is not that showing. A padded
-chunk's walk can run past the live extent, and one poisoned read in a shared tile corrupts
-real rows; a deliberate tail over-read conforms only where the allocation carries the slack.
+without one, or generated from a template instance that has none - shows that every address
+the form touches stays inside its buffers' allocations.** One extent dividing evenly is not
+that showing. A padded chunk's walk can run past the live extent, and one poisoned read in a
+shared tile corrupts real rows.
 
 **Never let a prefill pad output row reach a `matmul2d` or a staged cooperative tile as its B
 operand - stage it as zero, or bound the walk at the live row count.** Pad rows hold recycled
@@ -82,9 +84,9 @@ wider-row site passes the full stride or dispatches the padded tile.** A split r
 `row x dispatched-width`, so a wider-row caller lands its split rows on top of the row beside
 them.
 
-**A prefill GEMM dispatched at a nonzero start row - a region beginning below the window's
-end - never asks `cm2_split_k` for a split; it encodes unsplit.** The split-k reduce sums dense
-partial planes counted from row 0, so a sliced region would reduce the wrong rows.
+**A prefill GEMM dispatched at a nonzero start row never asks `cm2_split_k` for a split - it
+encodes unsplit.** The split-k reduce sums partial planes counted from row 0, so a dispatch
+starting above row 0 would reduce the wrong rows.
 
 **A scratch buffer a dispatch writes is never rebound for a new write before the reader of
 its previous write is encoded - rotate through as many buffers as the chain has dispatches in
@@ -92,17 +94,17 @@ flight between a write and its read.** One shared scratch serializes the whole c
 its write-after-read hazards.
 
 **A diff that adds dispatches to an encoder path to save bandwidth also gates that path on
-work size, in the same change.** The gate's threshold is measured at both ends of the size
-ladder. The small-work regression hides behind the big-work win.
+work size, in the same change.** The gate's threshold is measured at the smallest and the
+largest work size the path serves. The small-work regression hides behind the big-work win.
 
 **A diff that changes a tile, grid, threadgroup, or uniform constant shows the value at that
 constant's authoritative site, in the same change.** An in-body tile constant is confirmed
 literal in the generated `*_msl` global or the SPIR-V dump (`DASLLAMA_VK_SPV_DUMP=<dir>`
-writes every class kernel's words). A grid constant is read off the
-class's `[metal_dispatch]` / `[vk_dispatch]` `grid=` spec, whose `"n/c"` form is a
+writes every class kernel's words). A grid constant is read off the class's
+`[metal_dispatch]` / `[vk_dispatch]` `grid=` spec, whose `"n/c"` form is a
 CEIL-divide; a threadgroup constant off Metal's `tg=` spec or Vulkan's
-`[spirv_kernel(local_size_x=)]`; the spec alone decides. A uniform's value is read at the
-single writer that fills its buffer.
+`[spirv_kernel(local_size_x=)]`. A uniform's value is read at the single writer that fills
+its buffer.
 
 **A kernel twin that binds a different kargs (kernel-argument struct) type than its sibling
 twin, or shifts a shared field to a different binding number, is a defect - even where one
@@ -127,21 +129,21 @@ an `upload_region` upload never written after arming - is a defect unless it car
 
 **`@role = "weight"` on per-encode data - a pooled buffer the host refills each encode - is a
 defect; a per-encode field either omits `@role` or names the access its body performs.**
-`weight` drops the hazard staging.
+`weight` tells the generated builder the buffer needs no per-encode hazard tracking.
 
 **A diff that adds a GPU kernel class under `dasllama/` - a `[metal_kernel]` def, a
 `[vk_dispatch]` declaration, or a new instance of a template carrying one - covers that class
 in `tests/test_kernel_coverage.das`, one of two ways.** Either a census row there dispatches
 the class, or the diff names it in that file's `CENSUS_NEVER_DISPATCHED` with the reason no
-row can reach it - a class in neither place leaves `CENSUS_NEVER_DISPATCHED` claiming coverage the census does not have.
+row can reach it - a class in neither place leaves `CENSUS_NEVER_DISPATCHED` claiming coverage
+the census does not have.
 
-**A new kernel class declared in `dasllama/` carries `[metal_dispatch]` / `[vk_dispatch]`
-with every annotation that backend's generated builder reads - per-field `@binding` /
-`@role` / `@off` / `@default`.** A field carrying none of them is dropped from the bind list
-with no error.
+**Every field of a new kernel class declared in `dasllama/` carries at least one of the
+annotations its `[metal_dispatch]` / `[vk_dispatch]` builder reads - `@binding`, `@role`,
+`@off`, `@default`.** A field carrying none of them is dropped from the bind list with no error.
 
-**Weakening the lens's `@workgroup`/`tgmem=` compile refusal, or its gate
-`test_lens_tgmem_gate` (`tests/test_metal_misc_kernels.das`), is a defect.**
+**Weakening `[metal_dispatch]`'s refusal to compile a `@workgroup` field with no `tgmem=` spec,
+or its gate `test_lens_tgmem_gate` (`tests/test_metal_misc_kernels.das`), is a defect.**
 
 **A kernel field carries `@span` only when every caller binds whole output rows.** A caller
 binding a column tile of a wider row passes the tile width as the kernel's n while its rows
@@ -151,9 +153,8 @@ every row outside the tracked hazard range.
 **A NEW hand-written `enc_*` body is a defect unless it is a wrapper - a format or twin pick, a
 default-filling wrapper, or a composite over generated builders.**
 
-**A hand-rolled bind list on a dispatch that serves a user call - not a race or knockout
-timing arm - in `dasllama/` or `performance/` is a defect: dispatch through the kernel's
-`enc_*` builder instead.** Timing arms answer to `REVIEW_GPU_RACE.md`.
+**A hand-rolled bind list on a dispatch that serves a user call, in `dasllama/` or
+`performance/`, is a defect: dispatch through the kernel's `enc_*` builder instead.**
 
 **A value that reaches the kernel twice device-side - a scalar bound both as a uniform buffer
 and as a kargs field - is a defect.** A `params=` value that the `grid=`/`tg=` spec consumes
@@ -167,8 +168,7 @@ layout the upload produces, in the key too.** A hit must cover the request.
 
 **A diff that lands a kernel class, driver arm, or backend capability in a file whose
 `ARCHITECTURE_GPU.md` sec.1.5 role row does not sanction it extends that row's ledger in the
-same change - or moves the code to the file whose row does.** The role table is the
-criterion; a placement the table does not carry does not exist.
+same change - or moves the code to the file whose row does.**
 
 **A module that creates its own GPU device or queue is a defect - a GPU family shares the one
 device and queue from `dasllama/dasllama_<gpu>_common.das`'s init.**
@@ -183,12 +183,12 @@ own init/release pair.
 **A decline counter beside the decline site is a defect - decline counting lives in
 `dasllama/dasllama_metal_common.das`.**
 
-**A diff that adds or removes a Metal-only or Vulkan-only hook, role, served path, or
-backend-only capability - anything that changes what one backend can serve and the other
-cannot, where one backend serving the same path faster or slower is not such a change - lands
-its `ARCHITECTURE_GPU.md` sec.1.5 edit in the same change - including when
-sec.1.5 already carries that class of asymmetry, and including sec.1.5's per-driver lists of
-registered hooks and borrowed kernels.** sec.1.5 is the closed list; an asymmetry it does not
+**A diff that changes what one backend can serve and the other cannot - a Metal-only or
+Vulkan-only hook, role, served path, or backend-only capability, added or removed - lands its
+`ARCHITECTURE_GPU.md` sec.1.5 edit in the same change.** One backend serving the same path
+faster or slower is not such a change. The duty holds when sec.1.5 already carries that class
+of asymmetry, and it covers sec.1.5's per-driver lists of registered hooks and borrowed
+kernels. sec.1.5 is the closed list of backend asymmetries; an asymmetry it does not
 carry does not exist.
 
 **A hand-written Vulkan pipeline build anywhere in the engine is a defect - a Vulkan pipeline
@@ -202,12 +202,13 @@ bind site cannot shrink a buffer that was sized wrong.
 **A change to code that a served GPU decode or prefill path executes ships GPU-vs-CPU parity
 on one q8 and one kq (K-quant) model with the armed mirror codec.** That code is anything a
 served GPU decode or prefill call executes OR that selects what it executes - a driver, a
-kernel class it dispatches, that class's builder, a servability gate, a kernel crown race, a
-forwarder default, a weight-region or residency path, the tier forwarders and engine seams
-the call routes through; never the bake paths, never a comment. The parity
-run is `harness/parity.das` on either backend, or - on Metal only - the in-suite instruments
-`tests/test_metal_decode_parity.das` / `tests/test_metal_prefill_parity.das` through
-`tests/run.das`.
+kernel class it dispatches, that class's builder, a servability gate, a race that picks which
+kernel serves, a forwarder default, a weight-region or residency path, the tier forwarders
+the call routes through; never the bake paths, never a comment. The parity run is
+`harness/parity.das` on either backend, `benchmarks/lcpp_bench.das --parity`
+(`performance/model_specs.das`'s fixed model list) on either backend, or - on Metal only -
+the in-suite instruments `tests/test_metal_decode_parity.das` /
+`tests/test_metal_prefill_parity.das` through `tests/run.das`.
 
 **Parity evidence counts only when its backend was armed: the Metal arm ran with `--ngl`; the
 Vulkan arm ran with `DASLLAMA_GPU=1` - never `--ngl` - and its log shows the tier that serves
@@ -218,12 +219,12 @@ resident` for the per-op tier).** The Vulkan driver declines codec-mismatched se
 ships a `dasllama-convert --trim` bake plus a serve of the trimmed image, on one q8 and one kq
 (K-quant) model.** Parity runs never reach it.
 
-**Never leave a K/V codec unserved by the kernels that read or write the residency rail's
+**Never leave a K/V codec unserved by the kernels that read or write the whole-model driver's
 `k_mirror`/`v_mirror` slabs, or the decode block's per-layer `DatLayer.k_mir`/`v_mir` pair - a
-K/V codec is the mirror's element type, f16 or f32.** Two
-shapes serve both: instances of one template cover both codecs, or a single-codec kernel has
-a sibling that serves the other codec behind an arming gate that keys on `kv16`. The rail
-serves both codecs, so a codec no kernel covers silently drops that codec's GPU path.
+K/V codec is the mirror's element type, f16 or f32.** Two shapes serve both: instances of one
+template cover both codecs, or a single-codec kernel has a sibling that serves the other codec
+behind an arming gate that keys on `kv16`. The whole-model driver serves both codecs, so a
+codec no kernel covers silently drops that codec's GPU path.
 
 **An f16 store into any GPU-resident K/V that does not clamp to the f16 finite range
 (+/-65504) is a defect.**
@@ -234,7 +235,7 @@ a second time double-frees the panel or overwrites the source's rows.
 
 **A resident override that touches the mirror before gating the session on the armed mirror
 codec and on the flat (non-paged) cache is a defect** - a resident override is a
-decode/prefill hook the whole-model residency rail registers in
+decode/prefill hook `dasllama/dasllama_gpu_resident.das` registers in
 `dasllama/dasllama_common.das`'s override registries.
 
 **An override that byte-copies mirror bytes across codecs is a defect - bytes move only between
@@ -243,7 +244,7 @@ cache.
 
 **Never cache a descriptor set across dispatches in state that `vk_drop_model_state` does not
 clear** - put it in a `*_ready` latch, or in a holder that function already clears in
-`dasllama/dasllama_vulkan_common.das`: `g_rd`, `g_gpu`, the weight arena.
+`dasllama/dasllama_vulkan_common.das`.
 
 **Never read a `[spirv_decode]` callback's quant bytes by indexing `unpack8` of a 32-bit word
 with a runtime value - read them as 16-bit lanes instead: an `int16[N]` block member selected
@@ -252,38 +253,40 @@ compiler pattern-matches only the 16-bit spelling into its block-load path, and 
 select drops the whole kernel off it.
 
 **A diff that changes when the resident prefill that takes token ids rather than embeddings
-(`vk_rdec_prefill_ids` and the resident prefill override that routes to it) accepts a call
-changes the engine's GPU-embed probe - the gate registered through `register_embed_gpu_gate`,
-`vulkan_embed_gpu_gate` in `dasllama/dasllama_gpu_resident.das` - in the same change.** The
-engine skips the CPU embed on a true probe, so a probe that is true where that path declines
-hands the next consumer an unfilled residual stream.
+accepts a call updates the engine's GPU-embed probe in the same change.** That prefill is
+`vk_rdec_prefill_ids` and the resident prefill override that routes to it; the probe is
+`vulkan_embed_gpu_gate` in `dasllama/dasllama_gpu_resident.das`, registered through
+`register_embed_gpu_gate`. The engine skips the CPU embed on a true probe, so a probe that is
+true where that path declines hands the next consumer an unfilled residual stream.
 
 **A module-level variable in a GPU driver file whose value depends on the installed model
 gets a model-swap discharge in the same change that adds it** - the vulkan tier files
 discharge through `moe_gpu_model_marks_save_` / `moe_gpu_model_marks_restore_` /
-`moe_gpu_drop_model_`; the Metal prefill and tower through a registered reload prep. A global
-with no discharge survives a model swap and routes the next model's dispatches at the old
-model's planes.
+`moe_gpu_drop_model_`; the Metal prefill and tower through `register_reload_prep`
+(`dasllama/dasllama_metal_common.das`). A global with no discharge survives a model swap and
+routes the next model's dispatches at the old model's planes.
 
-**A diff that changes how a dev-W resident panel's cache key is built changes both the seed
-site and the lookup site in the same change** - `pf_devw_seed_baked` and
-`pf_devw_resident_panel` in `dasllama/dasllama_metal_prefill.das`. A seed keyed differently
-from the forward never hits, and every baked site silently re-dequantizes.
+**A diff that changes how a dev-W resident panel's cache key is built - a dev-W panel is a
+weight plane dequantized once into a device f16 panel - changes both the seed site and the
+lookup site in the same change** - `pf_devw_seed_baked` and `pf_devw_resident_panel` in
+`dasllama/dasllama_metal_prefill.das`. A seed keyed differently from the forward never hits,
+and every baked site silently re-dequantizes.
 
 **A servability gate in `dasllama/dasllama_metal_shapes.das` never reads process-global
 runtime state - the active kernel backend, a mode toggle - on its mint-time path: such a read
 sits behind the gate's `mint_time` flag, and the mint-time verdict tests the model's own
-fields.** The load selects the repacking CPU backend before the flavor is decided, so a
+fields.** The load selects the repacking CPU backend before the GPU backend is decided, so a
 mint-time read bakes a verdict the drivers do not share.
 
 **A diff that adds a cm2 tile format instance, changes a format's cm2 decode body, or changes a
-format's `DECVEC` constant puts that format's `cm2:<fmt>` probe rows
-(`harness/vk_gemm_probe.das`), both the `DASLLAMA_VK_DECVEC=1` and the `=0` rows, in the PR
-body.** A cm2 tile is the NV_cooperative_matrix2 GEMM class stamped per (weight format, column)
-pair in `dasllama/dasllama_vulkan_classes.das`; its `DECVEC` template constant, on by default,
-runs the four-wide decode callback the emitter builds out of the format's scalar
-`[spirv_decode] def decode`.
+format's four-wide twin (`decode_v4`) or its `DECV4` or `DECVEC` constant puts that format's
+`cm2:<fmt>` probe rows (`harness/vk_gemm_probe.das`), both the `DASLLAMA_VK_DECVEC=1` and the
+`=0` rows, in the PR body.** A cm2 tile is the NV_cooperative_matrix2 GEMM class stamped per
+(weight format, column) pair in `dasllama/dasllama_vulkan_classes.das`.
 
 **A cm2 tile format instance whose `DASLLAMA_VK_DECVEC=1` probe row is slower than its `=0` row
-carries `override DECVEC = false` on that format's class (`dasllama/dasllama_vulkan_classes.das`),
-in the same change.** The four-wide decode wins on some formats and loses on others.
+carries, in the same change, either a four-wide twin that wins - a hand-written `decode_v4`
+under `override DECV4 = true` on that format's class (`dasllama/dasllama_vulkan_classes.das`) -
+or the scalar callback: `override DECV4 = false` and `override DECVEC = false` together.** With
+`DECV4 = true` the class never reads `DECVEC`, so `override DECVEC = false` alone leaves the
+hand-written twin running.

--- a/modules/dasLLAMA/REVIEW_MEASUREMENT.md
+++ b/modules/dasLLAMA/REVIEW_MEASUREMENT.md
@@ -3,62 +3,69 @@
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
 doc: `ARCHITECTURE_MEASUREMENT.md`. Planned work: `PERF_LEDGER.md`.
 
-Figure rules here bind the surfaces this module owns - its ledgers, docs, code comments, and
-the PR body of a diff under it. A number on a served page answers to `site/REVIEW.md` or
-`site-dasllama/REVIEW.md` (repo root) instead.
+Figure rules here bind the surfaces this module owns - its ledgers, its code comments, the PR
+body of a diff under it, and a checked-in doc anywhere in the repo whose subject is this
+module (a file under `plans/` at the repo root included). A number on a served
+page answers to `site/REVIEW.md` or `site-dasllama/REVIEW.md` (repo root) instead.
 
 **A self-measured served-turn time entering `PERF_LEDGER.md` comes from the released
-`lcpp_bench` exe, never from the `-jit` script.** A served-turn time is a tok/s figure or a
-turn wall. The released exe is `benchmarks/lcpp_bench.das` built by `daspkg release`. It is
-spawned by `performance/gen_bench_records.das`, or run by hand where the cell's `PROFILE.md`
-section says so. A `--for-debug-purposes` row is a debug instrument. A tutorial's printed
-wall-clock is teaching output, feeding no board.
+`lcpp_bench` exe, never from the `-jit` script.** A served turn is one whole prefill-plus-decode
+run; a served-turn time is its tok/s figure or turn wall. The released exe is
+`benchmarks/lcpp_bench.das` built by `daspkg release`. A `--for-debug-purposes` row is the
+`-jit` script's own output, so it is never that time.
 
 **A subtraction of two measured walls written into `PERF_LEDGER.md` carries both raw walls
 in the entry.**
 
-**A diff that adds an entry to `PERF_LEDGER.md` names the instrument that produced the entry's
-reading.** The rule fires only for a reading no board cell produced. The entry also tags that
-reading `direction-grade` when the reading compares across two processes or two commits. The
-entry tags the reading `out-of-process` when the wall was measured from outside the benchmark
-process. A reading that is neither carries no tag. A figure taken from another project names
-its source and the report it came from and is tagged `external` - it grounds a lead worth
-chasing, never an adoption decision.
+**A diff that adds a `PERF_LEDGER.md` entry whose reading no board cell produced names the
+instrument that produced it - the script or exe whose output is that wall or rate.** A board
+cell is one `performance/gen_bench_records.das` spawns, or a manual `benchmarks/lcpp_bench.das`
+cell its `PROFILE.md` section documents.
 
-**A diff that adds an entry to `PERF_LEDGER.md` never records the selection timing of one of
-our own `harness/` or race A/B labs.** That timing settles its adoption decision in the lab's
-own report and in the PR that lands the kernel. The ledger learns the winner only through a
-re-measured cell.
+**A `PERF_LEDGER.md` entry tags its reading `direction-grade` when the reading compares across
+two processes or two commits, and `out-of-process` when the wall was measured from outside the
+benchmark process.**
 
-**A new servable capability gets its cell in the same change**: a board row spawned by
-`performance/gen_bench_records.das`, or a manual `benchmarks/lcpp_bench.das` cell with its own
-`PROFILE.md` section. A servable capability is a path no existing cell exercises: one that
-serves a weight format, modality, family, or backend - a q8 or f32 serving lane and a GPU tower
-(a GPU-run vision or audio encoder) included - or one that a run with no flags and no
-environment overrides serves. A kernel or form that only makes a path an existing cell already
-serves faster is not a new capability.
+**A `PERF_LEDGER.md` entry carrying a figure from another project names the source and the
+report it came from and tags it `external`.**
 
-**A diff that makes an already-served path measurably faster re-mints that cell's board row
-(`performance/records/`) on at least one box, in the same change.** The board is the module's
+**A diff never rests an adoption decision on a figure from another project - the decision
+rests on a self-measured board cell.**
+
+**A diff that adds an entry to `PERF_LEDGER.md` never records a selection timing - a timing
+that picks a winner between candidate kernel forms.** That timing settles its adoption
+decision in the report of the run that took it and in the PR that lands the kernel. The
+winner enters the ledger only through a re-measured board cell.
+
+**A new servable capability gets its board cell in the same change.** A servable capability is
+a serving path no existing board cell exercises: a weight format, a modality, a family, or a
+backend - a q8 or f32 serving lane and a GPU tower (a GPU-run vision or audio encoder)
+included - or the path a run with no flags and no environment overrides takes. A kernel or
+form that only speeds up a path an existing cell already exercises is not one.
+
+**A diff that claims to make an already-served path faster, from an author whose box mints
+that path, re-mints a board row (`performance/records/`) that exercises that path, in the
+same change, and names that row in the PR body.** A box mints a path when
+`performance/gen_bench_records.das` mints a row for it on that box rather than refusing or
+skipping it. Where no row exercises the path, the diff mints one. The board is the module's
 public memory of what serving costs; a kernel win that never lands there is invisible to the
 next regression check.
 
+**A diff that claims to make an already-served path faster, from an author whose box does not
+mint that path, names the owed row in `PERF_LEDGER.md` and in the PR body.**
+
 **A timing figure PRESENTED AS A MEASUREMENT of a served turn as a whole - tok/s, latency, a
 whole-turn model or engine comparison - is a defect wherever this module writes it down with
-no cell behind it: a checked-in doc, a ledger, a code comment, or a PR description.** The
-cell states its quant mode and stamps box and engine provenance, so a number can never
-silently describe a format nobody serves or a kernel set nobody ships. A figure labeled as a
-prediction is not a reading - the prediction log is mandated and needs no cell. A bring-up
-log in a how-to or ledger that names harness, flags, box, and the exe or script that ran it,
-at section level, is a stage figure, not a served-turn measurement; the cell it owes is its
-format's board row.
+neither a board cell behind it nor a provenance line, covering its passage or its section,
+naming harness, flags, box, and the exe or script that ran it.** The board cell states its
+quant mode and stamps box and engine provenance, so a number can never silently describe a
+format nobody serves or a kernel set nobody ships. A figure labeled as a prediction is not a
+reading, and this rule does not reach it.
 
 **A figure measuring one engine stage inside a served turn, or any other measured margin -
-a lab margin, a kernel-form delta, a gate knee - names the harness and flags that
-produced it.** A stage figure is a stage wall, a stage share, a stage speedup, or a
-cross-engine comparison of one stage. The rule holds wherever this module writes the figure
-down: a checked-in doc, a ledger, a code comment, or a PR description. A figure a committed
-board cell produced - any metric of the row: `pp`/`tg`, an `img:enc` wall, an `asr:` wall -
-is not a stage figure; naming the record and row is its provenance. The naming sits in the
-figure's own sentence, in a table heading that covers the table's rows, or in a
-section-level provenance line that covers the paragraphs under it.
+a kernel-form delta, a gate knee (the input size at which a gate flips) - names the harness
+and flags that produced it.** A figure measuring one engine stage is a stage wall, a stage
+share, a stage speedup, or a cross-engine comparison of one stage. A figure a committed board
+cell produced - any metric of the row - names the record and row instead of the harness and
+flags. The naming sits in the figure's own sentence, in a table heading that covers the
+table's rows, or in a section-level provenance line that covers the paragraphs under it.

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -5094,6 +5094,22 @@ def attn_out_suffix(t : Model; var s : Session; l : int64; npos : int64) {
 // qk-norm, rope, flash-style attention, wo) as one device chain per window; norm, activation
 // image, KV-store, and residual stay CPU. Numerics: GPU f32 tile accumulation — drift-class vs CPU flash.
 [no_alloc, no_env, no_io, arch(at="../ARCHITECTURE_GPU.md#gpu-backends")]
+//! The CPU embed of a prefill: x_b[p] = the embedding row of tokens[p], the rows across the dispatch lanes
+def private embed_rows(t : Model; var s : Session; tokens : array<int64>; npos : int64) {
+    let dim = t.config.dim
+    let tp = unsafe(addr(t))
+    let tkp = unsafe(addr(tokens[0]))
+    var xp = unsafe(addr(s.x_b[0]))
+    maybe_parallel_for(npos >= 32l, 0, int(npos), get_dispatch_lanes()) $(rb, re) {
+        unsafe {
+            for (p in range(rb, re)) {
+                var dp = xp + int64(p) * dim
+                embed_row(*tp, tkp[p], dp)
+            }
+        }
+    }
+}
+
 def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, start_pos : int64; skip_logits : bool = false) {
     let c = t.config
     if (npos <= 0l) {
@@ -5124,9 +5140,7 @@ def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, sta
         s.embed_gpu_pending = true
     } else {
         s.embed_gpu_pending = false
-        for (p in range64(npos)) {
-            embed_row(t, tokens[p], unsafe(addr(s.x_b[p * dim])))
-        }
+        embed_rows(t, s, tokens, npos)
         if (c.embed_scale != 1.0) {  // Gemma2: scale the embedding by sqrt(dim)
             scale_inplace(unsafe(addr(s.x_b[0])), c.embed_scale, npos * dim)
         }

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -4638,6 +4638,8 @@ var g_kv_store_par_threshold = 256_000l
 // Thread the per-position FFN activation (silu/gelu) once hidden × npos clears this. Lower than the
 // memory-bound passes — each element pays a transcendental (exp/tanh), so the compute justifies threading sooner.
 var g_act_par_threshold = 100_000l
+// Thread the prefill's CPU embed (a dequantized row per token) once dim × npos clears this.
+var g_embed_par_threshold = 64_000l
 
 def set_attn_par_threshold(v : int64) { g_attn_par_threshold = max(v, 0l) }
 def get_attn_par_threshold() : int64 => g_attn_par_threshold
@@ -4651,6 +4653,8 @@ def set_kv_store_par_threshold(v : int64) { g_kv_store_par_threshold = max(v, 0l
 def get_kv_store_par_threshold() : int64 => g_kv_store_par_threshold
 def set_act_par_threshold(v : int64) { g_act_par_threshold = max(v, 0l) }
 def get_act_par_threshold() : int64 => g_act_par_threshold
+def set_embed_par_threshold(v : int64) { g_embed_par_threshold = max(v, 0l) }
+def get_embed_par_threshold() : int64 => g_embed_par_threshold
 
 // Decode attention threads work-proportionally; the M1-measured threshold knob is now owned per
 // box by target_chunk_work.
@@ -5095,7 +5099,7 @@ def private embed_rows(t : Model; var s : Session; tokens : array<int64>; npos :
     let tp = unsafe(addr(t))
     let tkp = unsafe(addr(tokens[0]))
     var xp = unsafe(addr(s.x_b[0]))
-    maybe_parallel_for(npos >= 32l, 0, int(npos), get_dispatch_lanes()) $(rb, re) {
+    maybe_parallel_for(dim * npos >= g_embed_par_threshold, 0, int(npos), get_dispatch_lanes()) $(rb, re) {
         unsafe {
             for (p in range(rb, re)) {
                 var dp = xp + int64(p) * dim

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -1528,7 +1528,7 @@ def dlim_config_sources_register() {
 }
 
 //! The Model's plane pair for a kq format - the dispatcher every plane-form consumer keys on.
-def kq_planes_of(t : Model; fmt : KqFmt; var kq : array<uint8> const?&; var ks : array<uint8> const?&) {   // nolint:STYLE037 — the format ladder
+def kq_planes_of(t : Model; fmt : KqFmt; var kq : array<uint8> const?&; var ks : array<uint8> const?&) {
     unsafe {
         if (fmt == KqFmt.k4) {
             kq = addr(t.k4q)
@@ -5090,11 +5090,6 @@ def attn_out_suffix(t : Model; var s : Session; l : int64; npos : int64) {
     prof_add("act_resid", ts_resid0)
 }
 
-// The GPU arm shared by the std and gated prefill blocks: the whole attention block (GEMMs,
-// qk-norm, rope, flash-style attention, wo) as one device chain per window; norm, activation
-// image, KV-store, and residual stay CPU. Numerics: GPU f32 tile accumulation — drift-class vs CPU flash.
-[no_alloc, no_env, no_io, arch(at="../ARCHITECTURE_GPU.md#gpu-backends")]
-//! The CPU embed of a prefill: x_b[p] = the embedding row of tokens[p], the rows across the dispatch lanes
 def private embed_rows(t : Model; var s : Session; tokens : array<int64>; npos : int64) {
     let dim = t.config.dim
     let tp = unsafe(addr(t))
@@ -5110,6 +5105,10 @@ def private embed_rows(t : Model; var s : Session; tokens : array<int64>; npos :
     }
 }
 
+// The GPU arm shared by the std and gated prefill blocks: the whole attention block (GEMMs,
+// qk-norm, rope, flash-style attention, wo) as one device chain per window; norm, activation
+// image, KV-store, and residual stay CPU. Numerics: GPU f32 tile accumulation — drift-class vs CPU flash.
+[no_alloc, no_env, no_io, arch(at="../ARCHITECTURE_GPU.md#gpu-backends")]
 def forward_prefill(t : Model; var s : Session; tokens : array<int64>; npos, start_pos : int64; skip_logits : bool = false) {
     let c = t.config
     if (npos <= 0l) {

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -348,6 +348,9 @@ struct public VulkanEnv {
     @clarg_doc = "Merged k|v prefill GEMM - one dispatch over the adjacent k+v arena planes; 0 pins the split k + v dispatches for a same-build A/B."
     vk_kv_merge : bool = true
 
+    @clarg_doc = "The last layer's FFN runs on the window's last 32 rows only (the classifier reads one); 0 runs it over the whole window for a same-build A/B."
+    vk_ffn_slice : bool = true
+
     @clarg_doc = "Prefill record/execute overlap: the window chain submits in ramped chunks (1,2,4,8 layers) so the GPU starts while the CPU still records; 0 pins the single fenced submit (the per-role GPU profile pins it too, so a chunk gap never bills to a role)."
     vk_overlap : bool = true
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -315,9 +315,8 @@ var g_dispatch_caller_lane = true
 def public set_dispatch_caller_lane(v : bool) { g_dispatch_caller_lane = v }
 def public get_dispatch_caller_lane() : bool { return g_dispatch_caller_lane }
 def public get_dispatch_lanes() : int {
-    // Que-less process: the calling thread is the only lane, so every shaper answers "inline".
-    // (The work-proportional shapers evaluate eagerly at the dispatch sites — the old bool-gated
-    // form only read this in its parallel arm, so que-less small-matmul callers never noticed.)
+    // Que-less process: the calling thread is the only lane, so every shaper answers "inline"
+    // (the bool-gated form never reaches its parallel arm without a queue either).
     if (!is_job_que_available()) {
         return 1
     }

--- a/modules/dasLLAMA/dasllama/dasllama_par.das
+++ b/modules/dasLLAMA/dasllama/dasllama_par.das
@@ -16,11 +16,12 @@ require daslib/templates_boost
 require daslib/macro_boost
 
 //! `maybe_parallel_for(parallel, range_begin, range_end, num_jobs) $(rb, re) { ... }` —
-//! parallel_for with a leading runtime `parallel` flag. When `parallel` is true it threads the
-//! work across `num_jobs` chunks exactly like parallel_for; when false it runs the SAME block once,
-//! inline on the calling thread (no job dispatch, no wait group). Lets a kernel gate on a runtime
-//! size threshold without duplicating its loop body across an if/else. The block takes just the
-//! chunk bounds `(rb, re)` — no `wg`/`notify_and_release` ceremony; the parallel arm adds it.
+//! parallel_for with a leading runtime `parallel` flag. When `parallel` is true and a job queue is
+//! up it threads the work across `num_jobs` chunks exactly like parallel_for; when false, or in a
+//! process with no job queue, it runs the SAME block once, inline on the calling thread (no job
+//! dispatch, no wait group). Lets a kernel gate on a runtime size threshold without duplicating
+//! its loop body across an if/else. The block takes just the chunk bounds `(rb, re)` — no
+//! `wg`/`notify_and_release` ceremony; the parallel arm adds it.
 [tag_function(tag_maybe_parallel_for), unused_argument(parallel, range_begin, range_end, num_jobs, blk)]
 def maybe_parallel_for(parallel : bool; range_begin, range_end : int; num_jobs : int;
                        blk : block<(rb : int; re : int) : void>) {
@@ -111,7 +112,7 @@ class private MaybeParallelForMacro : AstFunctionAnnotation {
             call.arguments[4], call.at)
         var inlArm <- mpf_inline_arm(call.arguments[1], call.arguments[2], call.arguments[4], call.at)
         var qb = qmacro_block() {
-            if ($e(call.arguments[0])) {
+            if ($e(call.arguments[0]) && is_job_que_available()) {
                 $b(parArm)
             } else {
                 $b(inlArm)

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
@@ -4810,6 +4810,7 @@ class template KqCm2BatchT : MoeCmBase {
     @template_constant STILE : bool = false               // the 32-row column's partial-column fast path
     @template_constant BLKW : uint = 256u                 // elements per weight block
     @template_constant DECVEC : bool = true               //!< the four-wide decode twin rides the loads; false serves the scalar callback only
+    @template_constant DECV4 : bool = false               //!< the format's hand-laid `decode_v4` is the twin instead of the synthesized one
     @template_constant IQLUT : bool = false               // stage the iq4nl codebook into workgroup memory
     @workgroup @template_gate = IQLUT iq4lut : float16[16]   // kvalues_iq4nl as f16
     @template_constant IQ3GRID : bool = false             // stage the 2 KB iq3s grid into workgroup memory
@@ -4909,14 +4910,22 @@ class template KqCm2BatchT : MoeCmBase {
                 var k = 0u
                 for (_i in range(int(pa.n / 512u))) {
                     for [unroll] (_j in range(8)) {
-                        coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                        static_if (DECV4) {
+                            coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, self.decode_v4)
+                        } else {
+                            coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                        }
                         coopmatLoadTensor(b, xf16, 0u, flb, t0, BN, k, 64u, tv)
                         acc = coopmatMulAdd(a, b, acc)
                         k += 64u
                     }
                 }
                 while (k < pa.n) {
-                    coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                    static_if (DECV4) {
+                        coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, self.decode_v4)
+                    } else {
+                        coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                    }
                     coopmatLoadTensor(b, xf16, 0u, flb, t0, BN, k, 64u, tv)
                     acc = coopmatMulAdd(a, b, acc)
                     k += 64u
@@ -4930,14 +4939,22 @@ class template KqCm2BatchT : MoeCmBase {
             var k = k0
             for (_i in range(int((k1 - k0) / 512u))) {
                 for [unroll] (_j in range(8)) {
-                    coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                    static_if (DECV4) {
+                        coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, self.decode_v4)
+                    } else {
+                        coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                    }
                     coopmatLoadTensor(b, xf16, 0u, flb, t0, BN, k, 64u, tv)
                     acc = coopmatMulAdd(a, b, acc)
                     k += 64u
                 }
             }
             while (k < k1) {
-                coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                static_if (DECV4) {
+                    coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, self.decode_v4)
+                } else {
+                    coopmatLoadTensorDecode(a, wq, wblk0, fla, m0, 128u, k, 64u, self.decode, DECVEC)
+                }
                 coopmatLoadTensor(b, xf16, 0u, flb, t0, BN, k, 64u, tv)
                 acc = coopmatMulAdd(a, b, acc)
                 k += 64u
@@ -5024,6 +5041,7 @@ class template Q8Cm2T : KqCm2BatchT {
 class template K4Cm2T : KqCm2BatchT {
     typedef BLK = VkK4Blk
     typedef ST = uint
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK4Blk; bc, cib : uint2) : float16 {
@@ -5038,12 +5056,29 @@ class template K4Cm2T : KqCm2BatchT {
         let mn = (ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu
         return float16(dm.x * float(sc) * float(q) - dm.y * float(mn))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK4Blk; bc, cib : uint2) : half4 {
+        let g = cib.y >> 5u
+        let e = cib.y & 31u
+        let li = int((g * 16u + (e & 15u)) >> 1u)
+        let l0 = uint(int(blk.qs[li])) & 0xFFFFu
+        let l1 = uint(int(blk.qs[li + 1])) & 0xFFFFu
+        let sh = (e >> 4u) * 4u
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dm = unpackHalf2x16(ws[srow])
+        let sc = dm.x * float((ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        let mn = dm.y * float((ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        return half4(float4(sc * float((l0 >> sh) & 0xFu) - mn, sc * float((l0 >> (sh + 8u)) & 0xFu) - mn,
+            sc * float((l1 >> sh) & 0xFu) - mn, sc * float((l1 >> (sh + 8u)) & 0xFu) - mn))
+    }
 }
 
 [ |> template_struct_instance]
 class template K6Cm2T : KqCm2BatchT {
     typedef BLK = VkK6Blk
     typedef ST = uint
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK6Blk; bc, cib : uint2) : float16 {
@@ -5062,12 +5097,38 @@ class template K6Cm2T : KqCm2BatchT {
         let d = unpackHalf2x16(ws[srow + 4u]).x
         return float16(d * float(sc) * float(q6))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK6Blk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let bu = e >> 5u
+        let hh = (e >> 4u) & 1u
+        let j = e & 15u
+        let li = int((bu * 16u + j) >> 1u)
+        let l0 = uint(int(blk.ql[li])) & 0xFFFFu
+        let l1 = uint(int(blk.ql[li + 1])) & 0xFFFFu
+        let hi = int(((bu >> 2u) * 32u + hh * 16u + j) >> 1u)
+        let h0 = uint(int(blk.qh[hi])) & 0xFFFFu
+        let h1 = uint(int(blk.qh[hi + 1])) & 0xFFFFu
+        let ls = hh * 4u
+        let hs = (bu & 3u) * 2u
+        let q0 = int(((l0 >> ls) & 0xFu) | (((h0 >> hs) & 3u) << 4u)) - 32
+        let q1 = int(((l0 >> (ls + 8u)) & 0xFu) | (((h0 >> (hs + 8u)) & 3u) << 4u)) - 32
+        let q2 = int(((l1 >> ls) & 0xFu) | (((h1 >> hs) & 3u) << 4u)) - 32
+        let q3 = int(((l1 >> (ls + 8u)) & 0xFu) | (((h1 >> (hs + 8u)) & 3u) << 4u)) - 32
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let sidx = e >> 4u
+        let sc = int(ws[srow + (sidx >> 2u)] << ((3u - (sidx & 3u)) * 8u)) >> 24
+        let ds = unpackHalf2x16(ws[srow + 4u]).x * float(sc)
+        return half4(float4(ds * float(q0), ds * float(q1), ds * float(q2), ds * float(q3)))
+    }
 }
 
 [ |> template_struct_instance]
 class template K5Cm2T : KqCm2BatchT {
     typedef BLK = VkK5Blk
     typedef ST = uint
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK5Blk; bc, cib : uint2) : float16 {
@@ -5086,12 +5147,36 @@ class template K5Cm2T : KqCm2BatchT {
         let mn = (ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu
         return float16(dm.x * float(sc) * float(q) - dm.y * float(mn))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK5Blk; bc, cib : uint2) : half4 {
+        let g = cib.y >> 5u
+        let e = cib.y & 31u
+        let j = e & 15u
+        let li = int((g * 16u + j) >> 1u)
+        let l0 = uint(int(blk.qs[li])) & 0xFFFFu
+        let l1 = uint(int(blk.qs[li + 1])) & 0xFFFFu
+        let hidx = g * 4u + (j >> 2u)
+        let hby = uint(int(unpack8(blk.qh[int(hidx >> 1u)])[int(hidx & 1u)])) & 0xFFu
+        let sh = (e >> 4u) * 4u
+        let hb = hby >> sh
+        let q0 = ((l0 >> sh) & 0xFu) | ((hb & 1u) << 4u)
+        let q1 = ((l0 >> (sh + 8u)) & 0xFu) | (((hb >> 1u) & 1u) << 4u)
+        let q2 = ((l1 >> sh) & 0xFu) | (((hb >> 2u) & 1u) << 4u)
+        let q3 = ((l1 >> (sh + 8u)) & 0xFu) | (((hb >> 3u) & 1u) << 4u)
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dm = unpackHalf2x16(ws[srow])
+        let sc = dm.x * float((ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        let mn = dm.y * float((ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        return half4(float4(sc * float(q0) - mn, sc * float(q1) - mn, sc * float(q2) - mn, sc * float(q3) - mn))
+    }
 }
 
 [ |> template_struct_instance]
 class template Q40Cm2T : KqCm2BatchT {
     typedef BLK = VkK4Blk   // the same 128-nibble lane view - q40 rows land in the k/k+16 device pairing too
     typedef ST = uint
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK4Blk; bc, cib : uint2) : float16 {
@@ -5105,6 +5190,21 @@ class template Q40Cm2T : KqCm2BatchT {
         let d = (g & 1u) == 0u ? dp.x : dp.y
         return float16(d * (float(q) - 8.0))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK4Blk; bc, cib : uint2) : half4 {
+        let g = cib.y >> 5u
+        let e = cib.y & 31u
+        let li = int((g * 16u + (e & 15u)) >> 1u)
+        let l0 = uint(int(blk.qs[li])) & 0xFFFFu
+        let l1 = uint(int(blk.qs[li + 1])) & 0xFFFFu
+        let sh = (e >> 4u) * 4u
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dp = unpackHalf2x16(ws[srow + (g >> 1u)])
+        let d = (g & 1u) == 0u ? dp.x : dp.y
+        return half4(float4(d * (float((l0 >> sh) & 0xFu) - 8.0), d * (float((l0 >> (sh + 8u)) & 0xFu) - 8.0),
+            d * (float((l1 >> sh) & 0xFu) - 8.0), d * (float((l1 >> (sh + 8u)) & 0xFu) - 8.0)))
+    }
 }
 
 [ |> template_struct_instance]
@@ -5112,6 +5212,7 @@ class template Iq4xsCm2T : KqCm2BatchT {
     typedef BLK = VkK4Blk   // the iq4xs plane is the k/k+16 pairing verbatim - the k4 lane view fits
     typedef ST = uint
     override IQLUT = true
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK4Blk; bc, cib : uint2) : float16 {
@@ -5125,12 +5226,29 @@ class template Iq4xsCm2T : KqCm2BatchT {
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         return float16(d * float(sc) * float(iq4lut[int(q)]))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK4Blk; bc, cib : uint2) : half4 {
+        let g = cib.y >> 5u
+        let e = cib.y & 31u
+        let li = int((g * 16u + (e & 15u)) >> 1u)
+        let l0 = uint(int(blk.qs[li])) & 0xFFFFu
+        let l1 = uint(int(blk.qs[li + 1])) & 0xFFFFu
+        let sh = (e >> 4u) * 4u
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let d = unpackHalf2x16(ws[srow]).x
+        let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
+        let ds = d * float(sc)
+        return half4(float4(ds * float(iq4lut[int((l0 >> sh) & 0xFu)]), ds * float(iq4lut[int((l0 >> (sh + 8u)) & 0xFu)]),
+            ds * float(iq4lut[int((l1 >> sh) & 0xFu)]), ds * float(iq4lut[int((l1 >> (sh + 8u)) & 0xFu)])))
+    }
 }
 
 [ |> template_struct_instance]
 class template K3Cm2T : KqCm2BatchT {
     typedef BLK = VkK3Blk
     typedef ST = uint
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK3Blk; bc, cib : uint2) : float16 {
@@ -5147,12 +5265,36 @@ class template K3Cm2T : KqCm2BatchT {
         let d = unpackHalf2x16(ws[srow + 4u]).x
         return float16(d * float(sc) * float(q3))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK3Blk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let g = e >> 5u
+        let l = e & 31u
+        let qi = int(((g >> 2u) * 32u + l) >> 1u)
+        let q0w = uint(int(blk.qs[qi])) & 0xFFFFu
+        let q1w = uint(int(blk.qs[qi + 1])) & 0xFFFFu
+        let hi = int(l >> 1u)
+        let h0w = uint(int(blk.hm[hi])) & 0xFFFFu
+        let h1w = uint(int(blk.hm[hi + 1])) & 0xFFFFu
+        let qs2 = (g & 3u) * 2u
+        let q3_0 = int((q0w >> qs2) & 3u) - (((h0w >> g) & 1u) == 0u ? 4 : 0)
+        let q3_1 = int((q0w >> (qs2 + 8u)) & 3u) - (((h0w >> (g + 8u)) & 1u) == 0u ? 4 : 0)
+        let q3_2 = int((q1w >> qs2) & 3u) - (((h1w >> g) & 1u) == 0u ? 4 : 0)
+        let q3_3 = int((q1w >> (qs2 + 8u)) & 3u) - (((h1w >> (g + 8u)) & 1u) == 0u ? 4 : 0)
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let sidx = e >> 4u
+        let sc = int(ws[srow + (sidx >> 2u)] << ((3u - (sidx & 3u)) * 8u)) >> 24
+        let ds = unpackHalf2x16(ws[srow + 4u]).x * float(sc)
+        return half4(float4(ds * float(q3_0), ds * float(q3_1), ds * float(q3_2), ds * float(q3_3)))
+    }
 }
 
 [ |> template_struct_instance]
 class template K2Cm2T : KqCm2BatchT {
     typedef BLK = VkK2Blk
     typedef ST = uint
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK2Blk; bc, cib : uint2) : float16 {
@@ -5167,6 +5309,24 @@ class template K2Cm2T : KqCm2BatchT {
         let pb = (ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu
         return float16(dm.x * float(pb & 15u) * float(q) - dm.y * float(pb >> 4u))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK2Blk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let g = e >> 4u
+        let l = e & 15u
+        let qi = int(((g >> 3u) * 32u + (g & 1u) * 16u + l) >> 1u)
+        let q0w = uint(int(blk.qs[qi])) & 0xFFFFu
+        let q1w = uint(int(blk.qs[qi + 1])) & 0xFFFFu
+        let qs2 = ((g >> 1u) & 3u) * 2u
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dm = unpackHalf2x16(ws[srow])
+        let pb = (ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu
+        let sc = dm.x * float(pb & 15u)
+        let mn = dm.y * float(pb >> 4u)
+        return half4(float4(sc * float((q0w >> qs2) & 3u) - mn, sc * float((q0w >> (qs2 + 8u)) & 3u) - mn,
+            sc * float((q1w >> qs2) & 3u) - mn, sc * float((q1w >> (qs2 + 8u)) & 3u) - mn))
+    }
 }
 
 [ |> template_struct_instance]
@@ -5174,7 +5334,7 @@ class template Iq3sCm2T : KqCm2BatchT {
     typedef BLK = VkIq3sBlk
     typedef ST = uint
     override IQ3GRID = true
-    override DECVEC = false
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkIq3sBlk; bc, cib : uint2) : float16 {
@@ -5194,6 +5354,31 @@ class template Iq3sCm2T : KqCm2BatchT {
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         return float16(d * float(sc) * (((sgb >> (((r >> 2u) & 1u) * 4u + (r & 3u))) & 1u) != 0u ? -gb : gb))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkIq3sBlk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let g = e >> 5u
+        let r = e & 31u
+        let wj = r >> 2u
+        let qi = g * 8u + wj
+        let qb = uint(int(unpack8(blk.qs[int(qi >> 1u)])[int(qi & 1u)])) & 0xFFu
+        let qh = uint(int(unpack8(blk.qh[int(g >> 1u)])[int(g & 1u)])) & 0xFFu
+        let si = g * 4u + (r >> 3u)
+        let sgb = uint(int(unpack8(blk.sg[int(si >> 1u)])[int(si & 1u)])) & 0xFFu
+        let gw = iq3s_gridc[qb | ((qh << (8u - wj)) & 256u)]
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let d = unpackHalf2x16(ws[srow]).x
+        let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
+        let ds = d * float(sc)
+        let s = sgb >> (((r >> 2u) & 1u) * 4u)
+        let g0 = float(gw & 0xFFu)
+        let g1 = float((gw >> 8u) & 0xFFu)
+        let g2 = float((gw >> 16u) & 0xFFu)
+        let g3 = float(gw >> 24u)
+        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+    }
 }
 
 [ |> template_struct_instance]
@@ -5201,6 +5386,7 @@ class template Iq3xxsCm2T : KqCm2BatchT {
     typedef BLK = VkIq3xxsBlk
     typedef ST = uint
     override IQ3XGRID = true
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkIq3xxsBlk; bc, cib : uint2) : float16 {
@@ -5227,6 +5413,38 @@ class template Iq3xxsCm2T : KqCm2BatchT {
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         return float16(d * float(sc) * (((sgb >> (r & 7u)) & 1u) != 0u ? -gb : gb))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkIq3xxsBlk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let g = e >> 5u
+        let r = e & 31u
+        let wj = r >> 2u
+        let qi = g * 8u + wj
+        let qb = uint(int(unpack8(blk.qs[int(qi >> 1u)])[int(qi & 1u)])) & 0xFFu
+        let l = r >> 3u
+        let bl = 7u * l
+        let a0i = g * 4u + (bl >> 3u)
+        let b0 = uint(int(unpack8(blk.ax[int(a0i >> 1u)])[int(a0i & 1u)])) & 0xFFu
+        let b1 = uint(int(unpack8(blk.ax[int((a0i + 1u) >> 1u)])[int((a0i + 1u) & 1u)])) & 0xFFu
+        let sidx = ((b0 | (b1 << 8u)) >> (bl & 7u)) & 127u
+        var tt = sidx ^ (sidx >> 4u)
+        tt = tt ^ (tt >> 2u)
+        tt = tt ^ (tt >> 1u)
+        let sgb = sidx | ((tt & 1u) << 7u)
+        let gw = iq3x_gridc[qb]
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let d = unpackHalf2x16(ws[srow]).x
+        let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
+        let ds = d * float(sc)
+        let s = sgb >> (r & 7u)
+        let g0 = float(gw & 0xFFu)
+        let g1 = float((gw >> 8u) & 0xFFu)
+        let g2 = float((gw >> 16u) & 0xFFu)
+        let g3 = float(gw >> 24u)
+        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+    }
 }
 
 [ |> template_struct_instance]
@@ -5234,6 +5452,7 @@ class template Iq4nlCm2T : KqCm2BatchT {
     typedef BLK = VkK4Blk   // q40's nibble plane verbatim - the k4 lane view fits
     typedef ST = uint
     override IQLUT = true
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkK4Blk; bc, cib : uint2) : float16 {
@@ -5247,6 +5466,21 @@ class template Iq4nlCm2T : KqCm2BatchT {
         let d = (g & 1u) == 0u ? dp.x : dp.y
         return float16(d * float(iq4lut[int(q)]))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkK4Blk; bc, cib : uint2) : half4 {
+        let g = cib.y >> 5u
+        let e = cib.y & 31u
+        let li = int((g * 16u + (e & 15u)) >> 1u)
+        let l0 = uint(int(blk.qs[li])) & 0xFFFFu
+        let l1 = uint(int(blk.qs[li + 1])) & 0xFFFFu
+        let sh = (e >> 4u) * 4u
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dp = unpackHalf2x16(ws[srow + (g >> 1u)])
+        let d = (g & 1u) == 0u ? dp.x : dp.y
+        return half4(float4(d * float(iq4lut[int((l0 >> sh) & 0xFu)]), d * float(iq4lut[int((l0 >> (sh + 8u)) & 0xFu)]),
+            d * float(iq4lut[int((l1 >> sh) & 0xFu)]), d * float(iq4lut[int((l1 >> (sh + 8u)) & 0xFu)])))
+    }
 }
 
 [ |> template_struct_instance]
@@ -5254,7 +5488,7 @@ class template Iq2sCm2T : KqCm2BatchT {
     typedef BLK = VkIq2sBlk
     typedef ST = uint
     override IQ2SGRID = true
-    override DECVEC = false
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkIq2sBlk; bc, cib : uint2) : float16 {
@@ -5275,12 +5509,39 @@ class template Iq2sCm2T : KqCm2BatchT {
         let sc = (ws[srow + 1u + (si >> 2u)] >> ((si & 3u) * 8u)) & 0xFFu
         return float16(d * float(sc) * (((sgb >> j) & 1u) != 0u ? -gb : gb))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkIq2sBlk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let g = e >> 5u
+        let r = e & 31u
+        let l = r >> 3u
+        let j = r & 7u
+        let qi = g * 4u + l
+        let qb = uint(int(unpack8(blk.qs[int(qi >> 1u)])[int(qi & 1u)])) & 0xFFu
+        let qh = uint(int(unpack8(blk.qh[int(g >> 1u)])[int(g & 1u)])) & 0xFFu
+        let sgb = uint(int(unpack8(blk.sg[int(qi >> 1u)])[int(qi & 1u)])) & 0xFFu
+        let gw = iq2s_gridc[(qb | ((qh << (8u - 2u * l)) & 0x300u)) * 2u + (j >> 2u)]
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let d = unpackHalf2x16(ws[srow]).x
+        let si = g * 2u + (r >> 4u)
+        let sc = (ws[srow + 1u + (si >> 2u)] >> ((si & 3u) * 8u)) & 0xFFu
+        let ds = d * float(sc)
+        let s = sgb >> j
+        let g0 = float(gw & 0xFFu)
+        let g1 = float((gw >> 8u) & 0xFFu)
+        let g2 = float((gw >> 16u) & 0xFFu)
+        let g3 = float(gw >> 24u)
+        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+    }
 }
 
 class template Iq2xsCm2T : KqCm2BatchT {
     typedef BLK = VkIq2xsBlk
     typedef ST = uint
     override IQ2XSGRID = true
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkIq2xsBlk; bc, cib : uint2) : float16 {
@@ -5301,13 +5562,39 @@ class template Iq2xsCm2T : KqCm2BatchT {
         let sc = (ws[srow + 1u + (si >> 2u)] >> ((si & 3u) * 8u)) & 0xFFu
         return float16(dv * float(sc) * (((sgb >> j) & 1u) != 0u ? -gb : gb))
     }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkIq2xsBlk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let wi = e >> 3u
+        let j = e & 7u
+        let w16 = uint(int(blk.qs[int(wi)])) & 0xFFFFu
+        let sidx = w16 >> 9u
+        var tt = sidx ^ (sidx >> 4u)
+        tt = tt ^ (tt >> 2u)
+        tt = tt ^ (tt >> 1u)
+        let sgb = sidx | ((tt & 1u) << 7u)
+        let gw = iq2xs_gridc[(w16 & 511u) * 2u + (j >> 2u)]
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dv = unpackHalf2x16(ws[srow]).x
+        let si = e >> 4u
+        let sc = (ws[srow + 1u + (si >> 2u)] >> ((si & 3u) * 8u)) & 0xFFu
+        let ds = dv * float(sc)
+        let s = sgb >> j
+        let g0 = float(gw & 0xFFu)
+        let g1 = float((gw >> 8u) & 0xFFu)
+        let g2 = float((gw >> 16u) & 0xFFu)
+        let g3 = float(gw >> 24u)
+        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+    }
 }
 
 class template Iq2xxsCm2T : KqCm2BatchT {
     typedef BLK = VkIq2xxsBlk
     typedef ST = uint
     override IQ2XXSGRID = true
-    override DECVEC = false
+    override DECV4 = true
 
     [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
     def decode(blk : VkIq2xxsBlk; bc, cib : uint2) : float16 {
@@ -5333,6 +5620,38 @@ class template Iq2xxsCm2T : KqCm2BatchT {
         let dv = unpackHalf2x16(ws[srow]).x
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         return float16(dv * float(sc) * (((sgb >> j) & 1u) != 0u ? -gb : gb))
+    }
+
+    [spirv_decode, arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-decode-16bit-lanes")]
+    def decode_v4(blk : VkIq2xxsBlk; bc, cib : uint2) : half4 {
+        let e = cib.y
+        let g = e >> 5u
+        let r = e & 31u
+        let l = r >> 3u
+        let j = r & 7u
+        let qi = g * 8u + l
+        let qb = uint(int(unpack8(blk.qs[int(qi >> 1u)])[int(qi & 1u)])) & 0xFFu
+        let bl = 7u * l
+        let a0i = g * 8u + 4u + (bl >> 3u)
+        let b0 = uint(int(unpack8(blk.qs[int(a0i >> 1u)])[int(a0i & 1u)])) & 0xFFu
+        let b1 = uint(int(unpack8(blk.qs[int((a0i + 1u) >> 1u)])[int((a0i + 1u) & 1u)])) & 0xFFu
+        let sidx = ((b0 | (b1 << 8u)) >> (bl & 7u)) & 127u
+        var tt = sidx ^ (sidx >> 4u)
+        tt = tt ^ (tt >> 2u)
+        tt = tt ^ (tt >> 1u)
+        let sgb = sidx | ((tt & 1u) << 7u)
+        let gw = iq2xxs_gridc[qb * 2u + (j >> 2u)]
+        let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
+        let dv = unpackHalf2x16(ws[srow]).x
+        let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
+        let ds = dv * float(sc)
+        let s = sgb >> j
+        let g0 = float(gw & 0xFFu)
+        let g1 = float((gw >> 8u) & 0xFFu)
+        let g2 = float((gw >> 16u) & 0xFFu)
+        let g3 = float(gw >> 24u)
+        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
@@ -37,6 +37,7 @@ struct ArArgs {
     woff : uint     // norm-weight row base in wn (the driver's norms plane is shared per-layer)
     eps : float
     ascale : float
+    row0 : uint     // first row of the dispatch (the last layer's FFN slice starts below the window's end)
 }
 
 // the shared Q8_0 quantize pieces (pure — the amax fold is subgroup-wide)
@@ -123,7 +124,7 @@ class ClsArAddRms : ArBase {
 
     [spirv_kernel(local_size_x = 256, name = "cls_ar_spv")]
     def run {
-        let base = gl_WorkGroupID.x * pa.dim
+        let base = (gl_WorkGroupID.x + pa.row0) * pa.dim
         let ss = accum_row(base)
         let inv = rms_inv(ss)
         var k = gl_LocalInvocationID.x
@@ -310,6 +311,7 @@ struct ActArgs {
     nelem : uint   // element count (4-wide kernels; always a 32-multiple, the guard is exact)
     gelu : uint    // activation select: 0 = silu, else tanh-gelu
     nblk : uint    // 32-block / superblock count (the requant kernels' guard)
+    base : uint    // element base (the f16 route's last-layer slice; a 32-multiple)
 }
 
 // the one activation formula (silu or tanh-gelu on v, times u) — the classes' act_mul
@@ -412,8 +414,8 @@ class ActF16 {
 
     [spirv_kernel(local_size_x = 256, name = "actf16_cls_spv")]
     def run {
-        let e = gl_GlobalInvocationID.x * 4u
-        if (e < pa.nelem) {
+        let e = pa.base + gl_GlobalInvocationID.x * 4u
+        if (e < pa.base + pa.nelem) {
             outh[e] = float16(clamp(act_mul(gate[e], up[e]), -65504.0, 65504.0))
             outh[e + 1u] = float16(clamp(act_mul(gate[e + 1u], up[e + 1u]), -65504.0, 65504.0))
             outh[e + 2u] = float16(clamp(act_mul(gate[e + 2u], up[e + 2u]), -65504.0, 65504.0))

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
@@ -37,7 +37,7 @@ struct ArArgs {
     woff : uint     // norm-weight row base in wn (the driver's norms plane is shared per-layer)
     eps : float
     ascale : float
-    row0 : uint     // first row of the dispatch (the last layer's FFN slice starts below the window's end)
+    row0 : uint
 }
 
 // the shared Q8_0 quantize pieces (pure — the amax fold is subgroup-wide)
@@ -122,7 +122,7 @@ class ArBase : RmsWgBase {
 class ClsArAddRms : ArBase {
     @ssbo @binding = 3 yo : array<float>   // the normed output rows
 
-    [spirv_kernel(local_size_x = 256, name = "cls_ar_spv")]
+    [spirv_kernel(local_size_x = 256, name = "cls_ar_spv"), arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
     def run {
         let base = (gl_WorkGroupID.x + pa.row0) * pa.dim
         let ss = accum_row(base)
@@ -311,7 +311,7 @@ struct ActArgs {
     nelem : uint   // element count (4-wide kernels; always a 32-multiple, the guard is exact)
     gelu : uint    // activation select: 0 = silu, else tanh-gelu
     nblk : uint    // 32-block / superblock count (the requant kernels' guard)
-    base : uint    // element base (the f16 route's last-layer slice; a 32-multiple)
+    base : uint    // element base; a 32-multiple
 }
 
 // the one activation formula (silu or tanh-gelu on v, times u) — the classes' act_mul
@@ -412,7 +412,7 @@ class ActF16 {
 
     def act_mul(v, u : float) : float => act_mul_sel(v, u, pa.gelu)
 
-    [spirv_kernel(local_size_x = 256, name = "actf16_cls_spv")]
+    [spirv_kernel(local_size_x = 256, name = "actf16_cls_spv"), arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
     def run {
         let e = pa.base + gl_GlobalInvocationID.x * 4u
         if (e < pa.base + pa.nelem) {

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_classes.das
@@ -311,7 +311,7 @@ struct ActArgs {
     nelem : uint   // element count (4-wide kernels; always a 32-multiple, the guard is exact)
     gelu : uint    // activation select: 0 = silu, else tanh-gelu
     nblk : uint    // 32-block / superblock count (the requant kernels' guard)
-    base : uint    // element base; a 32-multiple
+    elem0 : uint   // a 32-multiple; ActF16 only - the requant classes ignore it
 }
 
 // the one activation formula (silu or tanh-gelu on v, times u) — the classes' act_mul
@@ -414,8 +414,8 @@ class ActF16 {
 
     [spirv_kernel(local_size_x = 256, name = "actf16_cls_spv"), arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
     def run {
-        let e = pa.base + gl_GlobalInvocationID.x * 4u
-        if (e < pa.base + pa.nelem) {
+        let e = pa.elem0 + gl_GlobalInvocationID.x * 4u
+        if (e < pa.elem0 + pa.nelem) {
             outh[e] = float16(clamp(act_mul(gate[e], up[e]), -65504.0, 65504.0))
             outh[e + 1u] = float16(clamp(act_mul(gate[e + 1u], up[e + 1u]), -65504.0, 65504.0))
             outh[e + 2u] = float16(clamp(act_mul(gate[e + 2u], up[e + 2u]), -65504.0, 65504.0))
@@ -4811,7 +4811,7 @@ class template KqCm2BatchT : MoeCmBase {
     @template_constant BN : uint = 256u                   // the token column
     @template_constant STILE : bool = false               // the 32-row column's partial-column fast path
     @template_constant BLKW : uint = 256u                 // elements per weight block
-    @template_constant DECVEC : bool = true               //!< the four-wide decode twin rides the loads; false serves the scalar callback only
+    @template_constant DECVEC : bool = true               //!< when DECV4 is off: the synthesized four-wide twin rides the loads; false serves the scalar callback only
     @template_constant DECV4 : bool = false               //!< the format's hand-laid `decode_v4` is the twin instead of the synthesized one
     @template_constant IQLUT : bool = false               // stage the iq4nl codebook into workgroup memory
     @workgroup @template_gate = IQLUT iq4lut : float16[16]   // kvalues_iq4nl as f16
@@ -5069,10 +5069,10 @@ class template K4Cm2T : KqCm2BatchT {
         let sh = (e >> 4u) * 4u
         let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
         let dm = unpackHalf2x16(ws[srow])
-        let sc = dm.x * float((ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
-        let mn = dm.y * float((ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
-        return half4(float4(sc * float((l0 >> sh) & 0xFu) - mn, sc * float((l0 >> (sh + 8u)) & 0xFu) - mn,
-            sc * float((l1 >> sh) & 0xFu) - mn, sc * float((l1 >> (sh + 8u)) & 0xFu) - mn))
+        let ds = dm.x * float((ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        let dmn = dm.y * float((ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        return half4(float4(ds * float((l0 >> sh) & 0xFu) - dmn, ds * float((l0 >> (sh + 8u)) & 0xFu) - dmn,
+            ds * float((l1 >> sh) & 0xFu) - dmn, ds * float((l1 >> (sh + 8u)) & 0xFu) - dmn))
     }
 }
 
@@ -5168,9 +5168,9 @@ class template K5Cm2T : KqCm2BatchT {
         let q3 = ((l1 >> (sh + 8u)) & 0xFu) | (((hb >> 3u) & 1u) << 4u)
         let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
         let dm = unpackHalf2x16(ws[srow])
-        let sc = dm.x * float((ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
-        let mn = dm.y * float((ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
-        return half4(float4(sc * float(q0) - mn, sc * float(q1) - mn, sc * float(q2) - mn, sc * float(q3) - mn))
+        let ds = dm.x * float((ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        let dmn = dm.y * float((ws[srow + 3u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu)
+        return half4(float4(ds * float(q0) - dmn, ds * float(q1) - dmn, ds * float(q2) - dmn, ds * float(q3) - dmn))
     }
 }
 
@@ -5324,10 +5324,10 @@ class template K2Cm2T : KqCm2BatchT {
         let srow = (wg_blk0 + bc.x * (pa.n >> 8u) + bc.y) * 5u
         let dm = unpackHalf2x16(ws[srow])
         let pb = (ws[srow + 1u + (g >> 2u)] >> ((g & 3u) * 8u)) & 0xFFu
-        let sc = dm.x * float(pb & 15u)
-        let mn = dm.y * float(pb >> 4u)
-        return half4(float4(sc * float((q0w >> qs2) & 3u) - mn, sc * float((q0w >> (qs2 + 8u)) & 3u) - mn,
-            sc * float((q1w >> qs2) & 3u) - mn, sc * float((q1w >> (qs2 + 8u)) & 3u) - mn))
+        let ds = dm.x * float(pb & 15u)
+        let dmn = dm.y * float(pb >> 4u)
+        return half4(float4(ds * float((q0w >> qs2) & 3u) - dmn, ds * float((q0w >> (qs2 + 8u)) & 3u) - dmn,
+            ds * float((q1w >> qs2) & 3u) - dmn, ds * float((q1w >> (qs2 + 8u)) & 3u) - dmn))
     }
 }
 
@@ -5373,13 +5373,13 @@ class template Iq3sCm2T : KqCm2BatchT {
         let d = unpackHalf2x16(ws[srow]).x
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         let ds = d * float(sc)
-        let s = sgb >> (((r >> 2u) & 1u) * 4u)
+        let sgn = sgb >> (((r >> 2u) & 1u) * 4u)
         let g0 = float(gw & 0xFFu)
         let g1 = float((gw >> 8u) & 0xFFu)
         let g2 = float((gw >> 16u) & 0xFFu)
         let g3 = float(gw >> 24u)
-        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
-            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+        return half4(float4(ds * ((sgn & 1u) != 0u ? -g0 : g0), ds * (((sgn >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((sgn >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((sgn >> 3u) & 1u) != 0u ? -g3 : g3)))
     }
 }
 
@@ -5439,13 +5439,13 @@ class template Iq3xxsCm2T : KqCm2BatchT {
         let d = unpackHalf2x16(ws[srow]).x
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         let ds = d * float(sc)
-        let s = sgb >> (r & 7u)
+        let sgn = sgb >> (r & 7u)
         let g0 = float(gw & 0xFFu)
         let g1 = float((gw >> 8u) & 0xFFu)
         let g2 = float((gw >> 16u) & 0xFFu)
         let g3 = float(gw >> 24u)
-        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
-            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+        return half4(float4(ds * ((sgn & 1u) != 0u ? -g0 : g0), ds * (((sgn >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((sgn >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((sgn >> 3u) & 1u) != 0u ? -g3 : g3)))
     }
 }
 
@@ -5529,13 +5529,13 @@ class template Iq2sCm2T : KqCm2BatchT {
         let si = g * 2u + (r >> 4u)
         let sc = (ws[srow + 1u + (si >> 2u)] >> ((si & 3u) * 8u)) & 0xFFu
         let ds = d * float(sc)
-        let s = sgb >> j
+        let sgn = sgb >> j
         let g0 = float(gw & 0xFFu)
         let g1 = float((gw >> 8u) & 0xFFu)
         let g2 = float((gw >> 16u) & 0xFFu)
         let g3 = float(gw >> 24u)
-        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
-            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+        return half4(float4(ds * ((sgn & 1u) != 0u ? -g0 : g0), ds * (((sgn >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((sgn >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((sgn >> 3u) & 1u) != 0u ? -g3 : g3)))
     }
 }
 
@@ -5582,13 +5582,13 @@ class template Iq2xsCm2T : KqCm2BatchT {
         let si = e >> 4u
         let sc = (ws[srow + 1u + (si >> 2u)] >> ((si & 3u) * 8u)) & 0xFFu
         let ds = dv * float(sc)
-        let s = sgb >> j
+        let sgn = sgb >> j
         let g0 = float(gw & 0xFFu)
         let g1 = float((gw >> 8u) & 0xFFu)
         let g2 = float((gw >> 16u) & 0xFFu)
         let g3 = float(gw >> 24u)
-        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
-            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+        return half4(float4(ds * ((sgn & 1u) != 0u ? -g0 : g0), ds * (((sgn >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((sgn >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((sgn >> 3u) & 1u) != 0u ? -g3 : g3)))
     }
 }
 
@@ -5647,13 +5647,13 @@ class template Iq2xxsCm2T : KqCm2BatchT {
         let dv = unpackHalf2x16(ws[srow]).x
         let sc = int(ws[srow + 1u + (g >> 2u)] << ((3u - (g & 3u)) * 8u)) >> 24
         let ds = dv * float(sc)
-        let s = sgb >> j
+        let sgn = sgb >> j
         let g0 = float(gw & 0xFFu)
         let g1 = float((gw >> 8u) & 0xFFu)
         let g2 = float((gw >> 16u) & 0xFFu)
         let g3 = float(gw >> 24u)
-        return half4(float4(ds * ((s & 1u) != 0u ? -g0 : g0), ds * (((s >> 1u) & 1u) != 0u ? -g1 : g1),
-            ds * (((s >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((s >> 3u) & 1u) != 0u ? -g3 : g3)))
+        return half4(float4(ds * ((sgn & 1u) != 0u ? -g0 : g0), ds * (((sgn >> 1u) & 1u) != 0u ? -g1 : g1),
+            ds * (((sgn >> 2u) & 1u) != 0u ? -g2 : g2), ds * (((sgn >> 3u) & 1u) != 0u ? -g3 : g3)))
     }
 }
 

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_common.das
@@ -151,12 +151,12 @@ def cm2_tile_cols(d, cnt : int64) : int64 {
     return tiles_m * waves_l > tiles_l * waves_m ? 128l : 256l
 }
 
+//! workgroups a (d, cnt) GEMM takes at the token column `tc`
+def cm2_tiles_at(d, cnt, tc : int64) : int64 => ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc)
+
 //! workgroups a (d, cnt) GEMM takes at its own tile pick
 [arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-tile-pick-and-default")]
-def cm2_tiles(d, cnt : int64) : int64 {
-    let tc = cm2_tile_cols(d, cnt)
-    return ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc)
-}
+def cm2_tiles(d, cnt : int64) : int64 => cm2_tiles_at(d, cnt, cm2_tile_cols(d, cnt))
 
 //! Returns (chunks, 256-aligned chunk); (1, 0) = off. `sib_tiles` = the workgroups of the roles this one co-runs beside.
 [arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-tile-pick-and-default")]
@@ -167,7 +167,7 @@ def cm2_split_k(d, cnt, n, tc : int64; sib_tiles : int64 = 0l) : tuple<nsplit : 
     if (forced > 0l) {
         sk = forced
     } elif (cores != 0l && n >= 2048l && d >= 128l && cnt >= tc) {
-        let tiles = ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc) + sib_tiles
+        let tiles = cm2_tiles_at(d, cnt, tc) + sib_tiles
         if (tiles <= cores / 2l) {
             sk = cores / tiles
         } elif (tiles <= cores * 2l / 3l) {

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_common.das
@@ -152,6 +152,7 @@ def cm2_tile_cols(d, cnt : int64) : int64 {
 }
 
 //! workgroups a (d, cnt) GEMM takes at its own tile pick
+[arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-tile-pick-and-default")]
 def cm2_tiles(d, cnt : int64) : int64 {
     let tc = cm2_tile_cols(d, cnt)
     return ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc)

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_common.das
@@ -151,16 +151,22 @@ def cm2_tile_cols(d, cnt : int64) : int64 {
     return tiles_m * waves_l > tiles_l * waves_m ? 128l : 256l
 }
 
-// the split-k heuristic: long K on an under-half-full grid splits the reduction across
-// f32 partial planes (SplitKReduce sums them). Returns (chunks, 256-aligned chunk); (1, 0) = off
-def cm2_split_k(d, cnt, n, tc : int64) : tuple<nsplit : int64; ksplit : int64> {
+//! workgroups a (d, cnt) GEMM takes at its own tile pick
+def cm2_tiles(d, cnt : int64) : int64 {
+    let tc = cm2_tile_cols(d, cnt)
+    return ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc)
+}
+
+//! Returns (chunks, 256-aligned chunk); (1, 0) = off. `sib_tiles` = the workgroups of the roles this one co-runs beside.
+[arch(at="../ARCHITECTURE_GPU_VULKAN.md#cm2-tile-pick-and-default")]
+def cm2_split_k(d, cnt, n, tc : int64; sib_tiles : int64 = 0l) : tuple<nsplit : int64; ksplit : int64> {
     let forced = cm2_splitk_env()
     let cores = int64(g_gpu.sm_count)
     var sk = 1l
     if (forced > 0l) {
         sk = forced
     } elif (cores != 0l && n >= 2048l && d >= 128l && cnt >= tc) {
-        let tiles = ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc)
+        let tiles = ((d + 127l) / 128l) * ((cnt + tc - 1l) / tc) + sib_tiles
         if (tiles <= cores / 2l) {
             sk = cores / tiles
         } elif (tiles <= cores * 2l / 3l) {

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
@@ -318,7 +318,7 @@ def private pf_kv_merged(l, dim, kvd : int64) : bool {
 // one prefill GEMM role on the class rail: schedule fill + a per-(role, variant) cached set +
 // BatchArgs push. kq formats take the kq tile family, else the q8 router (whose variant moves
 // with wlen — the last window is shorter).
-[arch(at="../ARCHITECTURE_RUNTIME.md#activation-scale-lattice")]
+[arch(at="../ARCHITECTURE_RUNTIME.md#activation-scale-lattice"), arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
 def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : int;
                         wq, ws, ab, sb, yb : uint64; wqn, wsn, an, sn, yn : int64;
                         abit, ybit : uint; n, d, blk, wlen : int64; f16feed : bool; sib_tiles : int64 = 0l; row0 : int64 = 0l) {
@@ -328,7 +328,7 @@ def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : i
     var cm2_tc = 0l
     if (f16feed) {
         cm2_tc = batch_tile_edges(fmt, d, wlen, true).tc
-        if (row0 == 0l) {   // a sliced region never splits k: the reduce sums dense planes from row 0
+        if (row0 == 0l) {
             let sp = cm2_split_k(d, wlen, n, cm2_tc, sib_tiles)
             nsplit = sp.nsplit
             ksplit = sp.ksplit

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
@@ -321,14 +321,14 @@ def private pf_kv_merged(l, dim, kvd : int64) : bool {
 [arch(at="../ARCHITECTURE_RUNTIME.md#activation-scale-lattice")]
 def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : int;
                         wq, ws, ab, sb, yb : uint64; wqn, wsn, an, sn, yn : int64;
-                        abit, ybit : uint; n, d, blk, wlen : int64; f16feed : bool) {
+                        abit, ybit : uint; n, d, blk, wlen : int64; f16feed : bool; sib_tiles : int64 = 0l) {
     // cm2 tile + split picks (pure in d/wlen/n/sm_count) — computed once, fed to fill AND enc
     var nsplit = 1l
     var ksplit = 0l
     var cm2_tc = 0l
     if (f16feed) {
         cm2_tc = batch_tile_edges(fmt, d, wlen, true).tc
-        let sp = cm2_split_k(d, wlen, n, cm2_tc)
+        let sp = cm2_split_k(d, wlen, n, cm2_tc, sib_tiles)
         nsplit = sp.nsplit
         ksplit = sp.ksplit
     }
@@ -778,18 +778,21 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                 let xsb = fq6 ? g_rd.dummy : g_rd.pf_xs
                 let xqn = fq6 ? np * dim * 2l : np * dim
                 let xsn = fq6 ? 256l : np * (dim / 32l) * 4l
-                pf_gemm_enc(raw, h, b + 1, g_rd.layers[l].fq, pq.wq, pq.ws, xqb, xsb, g_rd.pf_q,
-                    pq.wqb, pq.wsb, xqn, xsn, np * qd * 4l, VHZ_XQ, VHZ_Q, dim, qd, g_rd.layers[l].bq, wlen, fq6)
                 let kv_merged = pf_kv_merged(l, dim, kvd)
+                let tq = cm2_tiles(qd, wlen)
+                let tkv = cm2_tiles(kvd, wlen)
+                pf_gemm_enc(raw, h, b + 1, g_rd.layers[l].fq, pq.wq, pq.ws, xqb, xsb, g_rd.pf_q,
+                    pq.wqb, pq.wsb, xqn, xsn, np * qd * 4l, VHZ_XQ, VHZ_Q, dim, qd, g_rd.layers[l].bq, wlen, fq6,
+                    kv_merged ? cm2_tiles(2l * kvd, wlen) : 2l * tkv)
                 if (kv_merged) {
                     pf_gemm_enc(raw, h, b + 2, g_rd.layers[l].fk, pk.wq, pk.ws, xqb, xsb, g_rd.pf_kv,
-                        pk.wqb, pk.wsb, xqn, xsn, np * 2l * kvd * 4l, VHZ_XQ, VHZ_KVK | VHZ_KVV, dim, 2l * kvd, g_rd.layers[l].bk, wlen, fq6)
+                        pk.wqb, pk.wsb, xqn, xsn, np * 2l * kvd * 4l, VHZ_XQ, VHZ_KVK | VHZ_KVV, dim, 2l * kvd, g_rd.layers[l].bk, wlen, fq6, tq)
                     pfq_ts(raw)   // the v stamp: the merged GEMM's cost lands on k's delta
                 } else {
                     pf_gemm_enc(raw, h, b + 2, g_rd.layers[l].fk, pk.wq, pk.ws, xqb, xsb, g_rd.pf_kv,
-                        pk.wqb, pk.wsb, xqn, xsn, np * 2l * kvd * 4l, VHZ_XQ, VHZ_KVK, dim, kvd, g_rd.layers[l].bk, wlen, fq6)
+                        pk.wqb, pk.wsb, xqn, xsn, np * 2l * kvd * 4l, VHZ_XQ, VHZ_KVK, dim, kvd, g_rd.layers[l].bk, wlen, fq6, tq + tkv)
                     pf_gemm_enc(raw, h, b + 3, g_rd.layers[l].fv, pv.wq, pv.ws, xqb, xsb, g_rd.pf_v,
-                        pv.wqb, pv.wsb, xqn, xsn, np * kvd * 4l, VHZ_XQ, VHZ_VST, dim, kvd, g_rd.layers[l].bv, wlen, fq6)
+                        pv.wqb, pv.wsb, xqn, xsn, np * kvd * 4l, VHZ_XQ, VHZ_VST, dim, kvd, g_rd.layers[l].bv, wlen, fq6, tq + tkv)
                     vhz_dep(raw, h, VHZ_VST, VHZ_KVV, true)
                     cmd_copy_range(raw, g_rd.pf_v, 0l, g_rd.pf_kv, wlen * kvd * 4l, wlen * kvd * 4l)   // v into pf_kv's v half
                 }
@@ -898,10 +901,11 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                 let gsb = gu6 ? g_rd.dummy : g_rd.pf_xs
                 let gqn = gu6 ? np * dim * 2l : np * dim
                 let gsn = gu6 ? 256l : np * (dim / 32l) * 4l
+                let tgu = cm2_tiles(hid, wlen)
                 pf_gemm_enc(raw, h, b + 10, g_rd.layers[l].f1, p1.wq, p1.ws, gqb, gsb, g_rd.pf_gate,
-                    p1.wqb, p1.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_GATE, dim, hid, g_rd.layers[l].b1, wlen, gu6)
+                    p1.wqb, p1.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_GATE, dim, hid, g_rd.layers[l].b1, wlen, gu6, tgu)
                 pf_gemm_enc(raw, h, b + 11, g_rd.layers[l].f3, p3.wq, p3.ws, gqb, gsb, g_rd.pf_up,
-                    p3.wqb, p3.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_UP, dim, hid, g_rd.layers[l].b3, wlen, gu6)
+                    p3.wqb, p3.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_UP, dim, hid, g_rd.layers[l].b3, wlen, gu6, tgu)
                 if (dn6) {
                     var pc12 = ActArgs(nelem = uint(wlen * hid), gelu = 0u, nblk = uint(wlen * hid / 32l))
                     enc_actf16_cls(raw, h, g_rd.pf_sets[b + 12], pc12, (wlen * hid / 4l + 255l) / 256l)

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
@@ -321,18 +321,20 @@ def private pf_kv_merged(l, dim, kvd : int64) : bool {
 [arch(at="../ARCHITECTURE_RUNTIME.md#activation-scale-lattice")]
 def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : int;
                         wq, ws, ab, sb, yb : uint64; wqn, wsn, an, sn, yn : int64;
-                        abit, ybit : uint; n, d, blk, wlen : int64; f16feed : bool; sib_tiles : int64 = 0l) {
+                        abit, ybit : uint; n, d, blk, wlen : int64; f16feed : bool; sib_tiles : int64 = 0l; row0 : int64 = 0l) {
     // cm2 tile + split picks (pure in d/wlen/n/sm_count) — computed once, fed to fill AND enc
     var nsplit = 1l
     var ksplit = 0l
     var cm2_tc = 0l
     if (f16feed) {
         cm2_tc = batch_tile_edges(fmt, d, wlen, true).tc
-        let sp = cm2_split_k(d, wlen, n, cm2_tc, sib_tiles)
-        nsplit = sp.nsplit
-        ksplit = sp.ksplit
+        if (row0 == 0l) {   // a sliced region never splits k: the reduce sums dense planes from row 0
+            let sp = cm2_split_k(d, wlen, n, cm2_tc, sib_tiles)
+            nsplit = sp.nsplit
+            ksplit = sp.ksplit
+        }
     }
-    let groups = int64(fill_arena_batch_sched(g_rd.pf_meta[idx], d, blk, wlen, fmt, f16feed, nsplit))
+    let groups = int64(fill_arena_batch_sched(g_rd.pf_meta[idx], d, blk, wlen, fmt, f16feed, nsplit, row0))
     var pc = BatchArgs(n = uint(n), d = uint(d), map_off = 4u, ksplit = nsplit > 1l ? uint(ksplit) : 0u)
     if (f16feed) {
         // native fmt-0 decode-in-load; a split pick reroutes the GEMM into the scratch planes
@@ -901,14 +903,16 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                 let gsb = gu6 ? g_rd.dummy : g_rd.pf_xs
                 let gqn = gu6 ? np * dim * 2l : np * dim
                 let gsn = gu6 ? 256l : np * (dim / 32l) * 4l
-                let tgu = cm2_tiles(hid, wlen)
+                let ffn_row0 = l + 1l == g_rd.n_layers && gu6 && dn6 ? max(wlen - 32l, 0l) : 0l
+                let ffn_rows = wlen - ffn_row0
+                let tgu = cm2_tiles(hid, ffn_rows)
                 pf_gemm_enc(raw, h, b + 10, g_rd.layers[l].f1, p1.wq, p1.ws, gqb, gsb, g_rd.pf_gate,
-                    p1.wqb, p1.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_GATE, dim, hid, g_rd.layers[l].b1, wlen, gu6, tgu)
+                    p1.wqb, p1.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_GATE, dim, hid, g_rd.layers[l].b1, ffn_rows, gu6, tgu, ffn_row0)
                 pf_gemm_enc(raw, h, b + 11, g_rd.layers[l].f3, p3.wq, p3.ws, gqb, gsb, g_rd.pf_up,
-                    p3.wqb, p3.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_UP, dim, hid, g_rd.layers[l].b3, wlen, gu6, tgu)
+                    p3.wqb, p3.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_UP, dim, hid, g_rd.layers[l].b3, ffn_rows, gu6, tgu, ffn_row0)
                 if (dn6) {
-                    var pc12 = ActArgs(nelem = uint(wlen * hid), gelu = 0u, nblk = uint(wlen * hid / 32l))
-                    enc_actf16_cls(raw, h, g_rd.pf_sets[b + 12], pc12, (wlen * hid / 4l + 255l) / 256l)
+                    var pc12 = ActArgs(nelem = uint(ffn_rows * hid), gelu = 0u, nblk = uint(ffn_rows * hid / 32l), base = uint(ffn_row0 * hid))
+                    enc_actf16_cls(raw, h, g_rd.pf_sets[b + 12], pc12, (ffn_rows * hid / 4l + 255l) / 256l)
                 } elif (dnk) {
                     var pc12 = ActArgs(nelem = uint(wlen * hid), gelu = 0u, nblk = uint(wlen * hid / 256l))
                     enc_q8k_actrq_cls(raw, h, g_rd.pf_sets[b + 12], pc12, (wlen * hid / 8l + 255l) / 256l)
@@ -923,9 +927,9 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                 let hqn = dn6 ? np * hid * 2l : np * hid
                 let hsn = dn6 ? 256l : np * (hid / 32l) * 4l
                 pf_gemm_enc(raw, h, b + 13, g_rd.layers[l].f2, p2.wq, p2.ws, hqb, hsb, g_rd.pf_ffnout,
-                    p2.wqb, p2.wsb, hqn, hsn, np * dim * 4l, VHZ_HQ, VHZ_FFO, hid, dim, g_rd.layers[l].b2, wlen, dn6)
+                    p2.wqb, p2.wsb, hqn, hsn, np * dim * 4l, VHZ_HQ, VHZ_FFO, hid, dim, g_rd.layers[l].b2, ffn_rows, dn6, 0l, ffn_row0)
                 let nxt = l + 1l < g_rd.n_layers ? (l + 1l) * 2l * dim : nlfin   // nolint:LINT021 — composed from int64 layout offsets
-                var pc14 = ArArgs(dim = uint(dim), add_on = 1u, woff = uint(nxt), eps = g_rd.eps, ascale = 1.0)
+                var pc14 = ArArgs(dim = uint(dim), add_on = 1u, woff = uint(nxt), eps = g_rd.eps, ascale = 1.0, row0 = uint(ffn_row0))
                 let next_qkv6 = l + 1l < g_rd.n_layers && pf_qkv6(l + 1l)
                 if (l + 1l < g_rd.n_layers && pf_qkv_feed_fused(l + 1l)) {
                     if (next_qkv6) {
@@ -934,7 +938,7 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                         enc_cls_ar_rq_b(raw, h, g_rd.pf_arq_sets[int(l * 2l + 1l)], pc14, wlen)
                     }
                 } else {
-                    enc_cls_ar(raw, h, g_rd.pf_sets[b + 14], pc14, wlen)
+                    enc_cls_ar(raw, h, g_rd.pf_sets[b + 14], pc14, ffn_rows)
                 }
                 pfq_ts(raw)
             }
@@ -1090,7 +1094,7 @@ def vk_arena_ffn(var y : array<float>; blk1, blk3, blk2 : int64; n, nfe : int64;
 // single-region batch schedule over an arena block: 4-word record at 0, all tiles map to region
 // 0 at map_off = 4. Returns the dispatch workgroup count. `cm2l` must match the dispatched
 // class's tile rule (batch_tile_edges); `nsplit` stacks split-k planes onto the same map.
-def private fill_arena_batch_sched(hb : HostBuf; d, blk, npos : int64; fmt : int; cm2l : bool = false; nsplit : int64 = 1l) : uint {
+def private fill_arena_batch_sched(hb : HostBuf; d, blk, npos : int64; fmt : int; cm2l : bool = false; nsplit : int64 = 1l; row0 : int64 = 0l) : uint {
     let te = batch_tile_edges(fmt, d, npos, cm2l)
     let wtiles = (d + te.td - 1l) / te.td
     let rtiles = (npos + te.tc - 1l) / te.tc
@@ -1099,7 +1103,7 @@ def private fill_arena_batch_sched(hb : HostBuf; d, blk, npos : int64; fmt : int
     unsafe {
         var mp = reinterpret<uint?>(hb.mapped)
         mp[0] = uint(arena_local_blk(blk))   // slab-local block base (already in fmt units)
-        mp[1] = 0u          // rb0 - r0
+        mp[1] = uint(row0)  // rb0 - r0
         mp[2] = uint(npos)  // cnt
         mp[3] = 0u          // wg base
         for (g in range64(total)) {

--- a/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
+++ b/modules/dasLLAMA/dasllama/dasllama_vulkan_prefill.das
@@ -315,32 +315,50 @@ def private pf_kv_merged(l, dim, kvd : int64) : bool {
     return g_rd.layers[l].bv == g_rd.layers[l].bk + kvd * (dim / 32l)
 }
 
+//! Test hook: false runs every layer's FFN over the whole window (the slice's A/B arm)
+var g_pf_ffn_slice = true
+
+//! The first row of a layer's FFN dispatches: the last layer's, on the f16-fed cm2 route, starts 32 rows below the window's end
+[arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
+def pf_ffn_slice_row0(l, n_layers, wlen : int64; f16_gate, f16_down : bool) : int64 {
+    return g_pf_ffn_slice && g_env_vulkan.vk_ffn_slice && l + 1l == n_layers && f16_gate && f16_down ? max(wlen - 32l, 0l) : 0l
+}
+
+//! A cm2 role's tile column and split pick; a region starting above row 0 never splits
+[arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
+def pf_split_pick(fmt : int; d, rows, n, row0, sib_tiles : int64) : tuple<tc : int64; nsplit : int64; ksplit : int64> {
+    let tc = batch_tile_edges(fmt, d, rows, true).tc
+    if (row0 != 0l) {
+        return (tc = tc, nsplit = 1l, ksplit = 0l)
+    }
+    let sp = cm2_split_k(d, rows, n, tc, sib_tiles)
+    return (tc = tc, nsplit = sp.nsplit, ksplit = sp.ksplit)
+}
+
 // one prefill GEMM role on the class rail: schedule fill + a per-(role, variant) cached set +
 // BatchArgs push. kq formats take the kq tile family, else the q8 router (whose variant moves
-// with wlen — the last window is shorter).
+// with the dispatched row count — the last window is shorter, the last layer's FFN is sliced).
 [arch(at="../ARCHITECTURE_RUNTIME.md#activation-scale-lattice"), arch(at="../ARCHITECTURE_GPU_VULKAN.md#vk-prefill-window-chain")]
 def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : int;
                         wq, ws, ab, sb, yb : uint64; wqn, wsn, an, sn, yn : int64;
-                        abit, ybit : uint; n, d, blk, wlen : int64; f16feed : bool; sib_tiles : int64 = 0l; row0 : int64 = 0l) {
-    // cm2 tile + split picks (pure in d/wlen/n/sm_count) — computed once, fed to fill AND enc
+                        abit, ybit : uint; n, d, blk, rows : int64; f16feed : bool; sib_tiles : int64 = 0l; row0 : int64 = 0l) {
+    // the tile pick and the split pick — computed once, fed to fill AND enc
     var nsplit = 1l
     var ksplit = 0l
     var cm2_tc = 0l
     if (f16feed) {
-        cm2_tc = batch_tile_edges(fmt, d, wlen, true).tc
-        if (row0 == 0l) {
-            let sp = cm2_split_k(d, wlen, n, cm2_tc, sib_tiles)
-            nsplit = sp.nsplit
-            ksplit = sp.ksplit
-        }
+        let sp = pf_split_pick(fmt, d, rows, n, row0, sib_tiles)
+        cm2_tc = sp.tc
+        nsplit = sp.nsplit
+        ksplit = sp.ksplit
     }
-    let groups = int64(fill_arena_batch_sched(g_rd.pf_meta[idx], d, blk, wlen, fmt, f16feed, nsplit, row0))
+    let groups = int64(fill_arena_batch_sched(g_rd.pf_meta[idx], d, blk, rows, fmt, f16feed, nsplit, row0))
     var pc = BatchArgs(n = uint(n), d = uint(d), map_off = 4u, ksplit = nsplit > 1l ? uint(ksplit) : 0u)
     if (f16feed) {
         // native fmt-0 decode-in-load; a split pick reroutes the GEMM into the scratch planes
         let split = nsplit > 1l
         if (split) {
-            verify(nsplit * wlen * d * 4l <= g_rd.pf_splitk_bytes, "vk prefill: split-k planes exceed the scratch bound")
+            verify(nsplit * rows * d * 4l <= g_rd.pf_splitk_bytes, "vk prefill: split-k planes exceed the scratch bound")
         }
         let yob = split ? g_rd.pf_splitk : yb
         let yon = split ? g_rd.pf_splitk_bytes : yn
@@ -363,8 +381,8 @@ def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : i
                     fixed_array(g_rd.pf_splitk_bytes, yn),
                     fixed_array(VHZ_SK, ybit))
             }
-            var pcr = SkRedArgs(nelem = uint(wlen * d), k = uint(nsplit))
-            enc_splitk_reduce_cls(raw, h, g_rd.pf_cls_gemm[rkey], pcr, (wlen * d + 1_023l) / 1_024l)
+            var pcr = SkRedArgs(nelem = uint(rows * d), k = uint(nsplit))
+            enc_splitk_reduce_cls(raw, h, g_rd.pf_cls_gemm[rkey], pcr, (rows * d + 1_023l) / 1_024l)
         }
     } elif (kq_sb(fmt)) {
         // the role's format is static, so the slot never collides with the q8 router's variants
@@ -379,7 +397,7 @@ def private pf_gemm_enc(raw : VkCommandBuffer; var h : VkHaz; idx : int; fmt : i
         }
         kq_batch_cls_enc_for(fmt, q40cm, raw, h, g_rd.pf_cls_gemm[key], pc, groups)
     } else {
-        let v = q8_batch_cls_variant(q8_batch_tile_for(d, wlen), q8_batch_aligned(d, wlen))
+        let v = q8_batch_cls_variant(q8_batch_tile_for(d, rows), q8_batch_aligned(d, rows))
         let key = idx * 16 + v
         if (!key_exists(g_rd.pf_cls_gemm, key)) {
             verify(q8_batch_cls_ensure(v), "vk prefill: the q8 batch class rail must engage")
@@ -903,7 +921,7 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                 let gsb = gu6 ? g_rd.dummy : g_rd.pf_xs
                 let gqn = gu6 ? np * dim * 2l : np * dim
                 let gsn = gu6 ? 256l : np * (dim / 32l) * 4l
-                let ffn_row0 = l + 1l == g_rd.n_layers && gu6 && dn6 ? max(wlen - 32l, 0l) : 0l
+                let ffn_row0 = pf_ffn_slice_row0(l, g_rd.n_layers, wlen, gu6, dn6)
                 let ffn_rows = wlen - ffn_row0
                 let tgu = cm2_tiles(hid, ffn_rows)
                 pf_gemm_enc(raw, h, b + 10, g_rd.layers[l].f1, p1.wq, p1.ws, gqb, gsb, g_rd.pf_gate,
@@ -911,7 +929,7 @@ def private pf_run(x_batch : array<float>; ids : array<int64>; use_ids : bool; e
                 pf_gemm_enc(raw, h, b + 11, g_rd.layers[l].f3, p3.wq, p3.ws, gqb, gsb, g_rd.pf_up,
                     p3.wqb, p3.wsb, gqn, gsn, np * hid * 4l, VHZ_XQ, VHZ_UP, dim, hid, g_rd.layers[l].b3, ffn_rows, gu6, tgu, ffn_row0)
                 if (dn6) {
-                    var pc12 = ActArgs(nelem = uint(ffn_rows * hid), gelu = 0u, nblk = uint(ffn_rows * hid / 32l), base = uint(ffn_row0 * hid))
+                    var pc12 = ActArgs(nelem = uint(ffn_rows * hid), gelu = 0u, nblk = uint(ffn_rows * hid / 32l), elem0 = uint(ffn_row0 * hid))
                     enc_actf16_cls(raw, h, g_rd.pf_sets[b + 12], pc12, (ffn_rows * hid / 4l + 255l) / 256l)
                 } elif (dnk) {
                     var pc12 = ActArgs(nelem = uint(wlen * hid), gelu = 0u, nblk = uint(wlen * hid / 256l))
@@ -1093,7 +1111,7 @@ def vk_arena_ffn(var y : array<float>; blk1, blk3, blk2 : int64; n, nfe : int64;
 
 // single-region batch schedule over an arena block: 4-word record at 0, all tiles map to region
 // 0 at map_off = 4. Returns the dispatch workgroup count. `cm2l` must match the dispatched
-// class's tile rule (batch_tile_edges); `nsplit` stacks split-k planes onto the same map.
+// class's tile rule; `nsplit` stacks split-k planes; `row0` (word 1) never pairs with `nsplit > 1`.
 def private fill_arena_batch_sched(hb : HostBuf; d, blk, npos : int64; fmt : int; cm2l : bool = false; nsplit : int64 = 1l; row0 : int64 = 0l) : uint {
     let te = batch_tile_edges(fmt, d, npos, cm2l)
     let wtiles = (d + te.td - 1l) / te.td

--- a/modules/dasLLAMA/followup_vulkan.md
+++ b/modules/dasLLAMA/followup_vulkan.md
@@ -585,8 +585,9 @@ module) is independent and can land any time - it is pure structure.
     when `rdec_set_emb` placed a q8 tied plane or the f32 table fit under `RDEC_EMB_F32_CAP`;
     a kq tied plane (Llama-3.2-1B Q4_K_M ties a q6_K classifier) keeps the CPU embed, which the
     host profile put at 2.2 ms of a 25.7 ms window before the embed went parallel (2026-09-02,
-    `JOBQUE_PROFILING=1 lcpp_bench --prof`). llama.cpp gathers on the device (GET_ROWS, 6 us)
-    and skips the 4 MB x upload. Lever: an `emb_gather_kq_cls` per format reading the arena's
+    `JOBQUE_PROFILING=1 lcpp_bench --prof`). llama.cpp gathers on the device (GET_ROWS, 6 us in
+    its `GGML_VK_PERF_LOGGER=1` op rows) and skips the 4 MB x upload. Lever: an
+    `emb_gather_kq_cls` per format reading the arena's
     superblock planes with the cm2 decode's `(blk, bc, cib)` math (the tile classes own those
     methods; a gather class needs the same members or a shared free decode), then
     `rdec_set_emb` for `cls_kq`. Done = the embed bucket gone and the x upload out of prep on

--- a/modules/dasLLAMA/followup_vulkan.md
+++ b/modules/dasLLAMA/followup_vulkan.md
@@ -575,3 +575,8 @@ module) is independent and can land any time - it is pure structure.
     rate. Done = the three formats' probe rows at or above their scalar rate with the twin on.
     Related: the e2e A/B on the same box (`benchmarks/lcpp_bench.das`, ten reps) spreads 3-11%
     per row, so the probe row is the verdict and the e2e is the confirmation, never the reverse.
+    CLOSED (2026-09-02, the hand-laid twins commit on bbatkin/vk-mirror-bench): every kq format
+    carries a `decode_v4` (the template's `DECV4` axis), not just the three; the grid formats'
+    twins do one grid lookup per four elements and beat the scalar arm by 30-65% at the tile
+    (iq3s 43-48 vs 29-30 TF/s at the gate shape, iq2s 49-50 vs 30-32, iq2xxs 44-46 vs 34-35);
+    the `DECVEC` opt-outs are gone. Rows in `plans/kernel_parity_pass.md`.

--- a/modules/dasLLAMA/followup_vulkan.md
+++ b/modules/dasLLAMA/followup_vulkan.md
@@ -580,3 +580,14 @@ module) is independent and can land any time - it is pure structure.
     twins do one grid lookup per four elements and beat the scalar arm by 30-65% at the tile
     (iq3s 43-48 vs 29-30 TF/s at the gate shape, iq2s 49-50 vs 30-32, iq2xxs 44-46 vs 34-35);
     the `DECVEC` opt-outs are gone. Rows in `plans/kernel_parity_pass.md`.
+
+37. **Device embed gather over a kq tied plane.** `vulkan_embed_gpu_gate` admits a model only
+    when `rdec_set_emb` placed a q8 tied plane or the f32 table fit under `RDEC_EMB_F32_CAP`;
+    a kq tied plane (Llama-3.2-1B Q4_K_M ties a q6_K classifier) keeps the CPU embed, which the
+    host profile put at 2.2 ms of a 25.7 ms window before the embed went parallel (2026-09-02,
+    `JOBQUE_PROFILING=1 lcpp_bench --prof`). llama.cpp gathers on the device (GET_ROWS, 6 us)
+    and skips the 4 MB x upload. Lever: an `emb_gather_kq_cls` per format reading the arena's
+    superblock planes with the cm2 decode's `(blk, bc, cib)` math (the tile classes own those
+    methods; a gather class needs the same members or a shared free decode), then
+    `rdec_set_emb` for `cls_kq`. Done = the embed bucket gone and the x upload out of prep on
+    the Q4_K_M window, parity pregate token-for-token on Q8_0 and a kq vehicle.

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -1,7 +1,7 @@
 # dasLLAMA tests Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
-doc: `CLAUDE.md`. Planned work: `../followup_general.md`, `../followup_vulkan.md`.
+doc: `CLAUDE.md`. Planned work: the parent folder's `../followup_*.md` ledgers.
 
 **Every PR runs `run.das -- --suite model-free`, plus every test here the change reaches - never
 the whole directory.** A change reaches a test when it alters anything the test's result
@@ -10,15 +10,13 @@ corpus it reads, or a name it asserts on; a comment-only edit reaches none.
 
 **Leaving a test file out of every `run.das` suite is a defect, unless the file's header
 states why its cells cannot hold under `DASLLAMA_CPU_PREFILL=1`.** `DASLLAMA_CPU_PREFILL=1` is
-what the runner arms for `model-free`. The listing lands in the same change that adds the
-file, and the file skips honestly when its models are absent.
+what the runner arms for every suite.
 
-**Listing a test file that `DASLLAMA_CPU_PREFILL=1` disarms in any `run.das` suite is a defect,
-and so is leaving that fact out of the file's header.**
+**Listing a test file whose cells cannot hold under `DASLLAMA_CPU_PREFILL=1` in any `run.das`
+suite is a defect, and so is leaving that fact out of the file's header.**
 
 **Invoking dastest directly on a test file in a `run.das` model suite (every suite but
-`model-free`) is a defect; such a file runs only through `run.das`. A `model-free` file runs
-through the runner or under plain dastest.**
+`model-free`) is a defect. A `model-free` file runs through the runner or under plain dastest.**
 
 **Every test RUN runs under `-jit` - never the interpreter, never AOT.** A compile-only CI lane
 passes dastest's `--compile-only`. Under the interpreter a model-gated suite's cells skip, and
@@ -27,11 +25,13 @@ a run of skips is not the coverage the suite owes.
 **A diff that puts a `[test]` file requiring any `dasllama/*` module outside this folder is a
 defect.** Out-of-folder instances are ledgered in `CLAUDE.md`'s "Out-of-folder test files" note.
 
-**A diff that registers a test file in this folder in a `CMakeLists.txt` is a defect.**
+**A diff that registers a test file in this folder in a `CMakeLists.txt` is a defect - a
+`run.das` suite listing is the only registration these files get.**
 
-**A diff that adds, removes or re-lanes a gate in a file whose `CLAUDE.md` paragraph LISTS
-its gates updates that paragraph in the same change.** A paragraph that only names the file
-(a brace list, a suite roster) carries nothing to update and does not fire this rule.
+**A diff that adds a gate, removes a gate, or moves a gate to another suite or arm, in a file
+whose `CLAUDE.md` paragraph LISTS its gates, updates that paragraph in the same change.** A
+paragraph that only names the file (a brace list, a suite roster) carries nothing to update
+and does not fire this rule.
 
 **A new test file listed in `run.das`'s `model-free` suite, or in no `run.das` suite at all,
 whose name does not say what it covers, gets a `CLAUDE.md` entry in the same change** -
@@ -52,13 +52,17 @@ softcap, sink (`hass`) and span cells; `test_site_records.das` (the byte-compare
 `site/files/dasllama/bench_records.json` (repo root) against a fresh `merge_site_records`
 run); `test_exchange_schema.das` and `test_bench_records_schema.das` (the
 `write_bench_records` output, corpus sweeps included); `test_scheduler.das`'s media-stream
-bypass check (no cached hit at `prefix_attach`, no donated pages at `donate_stream`). A gate
-that pins a contract joins this list in the same change.
+bypass check (no cached hit at `prefix_attach`, no donated pages at `donate_stream`);
+`test_vulkan_kernels.das`'s tile-pick cell (which tile the Vulkan matmul picks for a given
+width and row count, and whether that dispatch splits its reduction across partial planes).
+A gate whose failure means a documented contract changed, rather than a kernel regressing, joins
+this list in the same change - as a file when
+every cell of it pins, as a named cell otherwise.
 
-**A test that silently vanishes on one platform is a defect, and so is a zero-assertion pass -
-a test passes or skips explicitly on every platform.** A cell that returns without asserting -
-the module is absent, no device answered, a capability declined - registers `t |> skip` there;
-`feint` is a print, not a skip.
+**A test passes or skips explicitly on every platform - a cell that neither asserts nor
+registers a skip is a defect.** A cell that returns without asserting -
+the module is absent, its models are not stocked, no device answered, a capability declined -
+registers `t |> skip` there; `feint` is a print, not a skip.
 
 **A skip gate keys on a fact the box owns - a device capability, a run-mode knob's value, a
 host toolchain's presence, a compile-time module-presence check
@@ -67,8 +71,9 @@ file, an mmproj, an oracle dump - a model gate); never on the existence of an ar
 repo's build or a previous test run produced (a mint, a generated binary, a dump a test
 wrote).** An artifact gate goes permanently false when its producer moves.
 
-**A test that loads a model over 6 GiB without gating on `DASLLAMA_PARITY_FULL=1` is a
-defect** - that gate is a final pre-PR gate, not the iteration loop. In this folder the
+**A test that loads a model above the large tier (`LARGE_TIER_BYTES`, `_model_tier.das`)
+without gating on `DASLLAMA_PARITY_FULL=1` is a defect** - that gate is a final pre-PR gate,
+not the iteration loop. In this folder the
 spelling is `model_available` (`_model_tier.das`). A test that cannot require
 `_model_tier.das` open-codes the same env check.
 
@@ -80,14 +85,13 @@ family or carrier loaders.
 
 **A predicate whose value the BOX decides (a device capability, a policy default) and that
 therefore cannot differ between two runs on one machine is never tested through its own
-value; test it through the argv it gates or the mode it selects.** An argument-keyed pure
-function is outside this rule - its value pins are real tests.
+value; test it through the argv it gates or the mode it selects.**
 
 **A test for an added, moved, or edited registration reaches the registered thing through its
 registry, and never calls it directly.** The registries this governs: the arch registrations
 (`register_decode_override` and its sibling `register_*` hooks), the `[EnvConfig]` env
 registry, and the format/backend dispatch tables. A new registry joins that list in the same
-change. A `[metal_dispatch]` declaration is not one of them.
+change.
 
 **A diff that changes a kernel's dispatch geometry - its grid divisor, threadgroup size, or
 threadgroup-memory length - updates every gate that hand-dispatches that kernel, in the same
@@ -98,8 +102,11 @@ gate dispatching the wrong shape with no error.
 updates every gate that hand-binds that kernel, in the same change.** A stale hand bind reads
 the wrong buffer and passes on garbage that happens to compare.
 
-**A kernel that gains an in-body branch keyed on a kargs field ships, in the same change, a
-gate cell that sets that field to the value selecting the new branch.**
+**A kernel that gains a kargs field whose non-default value changes what it computes or which
+elements it reads or writes - a branch selector, a row or element base, a stride - ships, in
+the same change, a gate cell that sets that field to a non-default value.** At the default the
+new field has no visible effect: a CPU oracle that ignores it and the kernel that honors it
+agree.
 
 **A new pre-tokenizer family or backend ships its `corpus_case` arm in `test_tokenizer.das`,
 naming the `ggml-vocab-*.gguf` fixture.**
@@ -117,7 +124,9 @@ difference.
 a defect.** A resize cap is not evidence.
 
 **A freeform token-parity cell is a defect.** Freeform coverage uses the forced-feed
-logits-tolerance form. Counting cells stay token-exact.
+logits-tolerance form - the same fixed tokens fed to both sides, logits compared within a bar.
+Counting cells - those whose prompt forces a continuation that cannot tie, so greedy tokens
+are fixed - stay token-exact.
 
 **A kernel-unit cell - a model-less cell that dispatches one kernel class and asserts on its
 output - missing a compare against a CPU oracle that can witness the cell's property is a
@@ -130,10 +139,10 @@ dispatch's values, or garbage that happens to sit inside the tolerance bar.
 **A cross-dispatch bit-identity compare - comparing the outputs of two dispatches - runs GPU
 against GPU.** No CPU oracle can witness that property.
 
-**A kernel-unit cell whose output plane is its input plane, and whose compare is not paired
-with an assert that the output differs from the input at a known index, is a defect.** This
-applies when the cell's CPU oracle does not differ from the input by construction. An in-place
-kernel that never ran leaves the input, which can wrongly satisfy a tolerant compare.
+**A kernel-unit cell whose output buffer is its input buffer, and whose CPU oracle does not
+differ from that input by construction, pairs its compare with an assert that the output
+differs from the input at a known index.** An in-place kernel that never ran leaves the input,
+which can wrongly satisfy a tolerant compare.
 
 **An ASR family with no token-for-token oracle cell is a defect** - the cell compares a
 transcript against a reference leg, external dump or CPU control alike.
@@ -151,12 +160,10 @@ the backend, the flash-attention setting, and the mmproj precision the dump came
 defect.**
 
 **A cell that does not establish every process-wide driver setter and serving-lane knob its
-claim depends on, and restore each to the value it had on entry before returning, is a
-defect.** This holds even when the claim needs the knob at its DEFAULT value. The Vulkan
-tier's installs (`install_moe_gpu_tier` and the `set_moe_gpu_*_hook(s)` seats) are one-way
-and establish-only - `ARCHITECTURE_GPU.md` sec.1.5 sanctions them. The environment can carry
-a knob either way. The mechanism (why the hooks flip legs silently) is `CLAUDE.md`'s "Metal
-fixtures" section.
+claim depends on, and restore each knob it set in-process to the value it had on entry before
+returning, is a defect.** This holds even when the claim needs the knob at its DEFAULT value.
+The mechanism
+(why the hooks flip legs silently) is `CLAUDE.md`'s "Metal fixtures" section.
 
 **A cell claiming a family serving lane that does not pin it through the family's own lane
 knobs - `set_<family>_q8` / `reset_<family>_q8`, canary's `set_canary_enc_q8` /
@@ -168,29 +175,34 @@ lane the box's policy picked.
 **A cell that loads a media carrier under a lane pin - a `set_<family>_q8`-class knob, or a
 `set_metal_tensor_crowns` / `pin_metal_tensor_crowns` pin - and whose subject is not that lane
 knob itself mints in memory through the family's `stage_*` + `mint_*` pair, never through a
-`.dlim`-baking loader (`load_<family>_tower` / `load_<family>_encoder` / `load_model*`).** A
-disk bake under a pinned lane GC-purges the serving lane's `.dlim` beside the model, and the
-next direct-image load in another suite panics on the wrong identity. A cell whose subject is
-the lane knob (`load_asr_model` under `set_asr_tower_fp32`) keeps the facade loader: the image
-identity folds the pin, so minting around it would unmake the claim.
+`.dlim`-baking loader (`load_<family>_tower` / `load_<family>_encoder` / `load_<carrier>_model` /
+`load_model` / `load_model_cached` / `load_model_image`).** A disk bake under a pinned lane
+GC-purges the serving lane's `.dlim` beside the model, and the next direct-image load in
+another suite panics on the wrong identity.
 
-**A CPU-vs-GPU arm that does not run a PLANAR model for its CPU stages, and that model's
-`blob_twin(t, path, seq_cap)` for override-selected stages, is a defect.** One session spans
-both models, because sessions are geometry-bound. A decline-reason cell keeps the planar
-model.
+**A cell whose subject IS the lane knob (`load_asr_model` under `set_asr_tower_fp32`) loads
+through the `.dlim`-baking loader, never around it.** The pin is part of what the image
+identity records.
+
+**A CPU-vs-GPU arm that does not run a PLANAR model - the non-blob form, the only one CPU
+inference reads - for its CPU stages, and that model's blob twin (`blob_twin(t, path,
+seq_cap)`, `test_metal_decode_parity.das`) for the stages a decode override selects, is a
+defect.** One session spans the planar model and its blob twin, because sessions are
+geometry-bound. A cell whose subject is why the GPU lane declined keeps the planar model and
+needs no twin.
 
 **A diff that adds a model-loading block to a `run.das` MODEL suite (every suite the
 `--family` filter reaches - not the model-free suite) tags it with its family.** The family
 tag is the token passed to `family_on(t, name)` (`_model_tier.das`). An untagged block
 silently joins every family's gate.
 
-**No CPU-control batch parity runs against the 70B.** The batched code paths get their parity
-on small models, through pins.
+**No CPU-control batch parity runs against `Llama-3.3-70B-Instruct-Q4_K_M.gguf`.** The
+batched code paths get their parity on small models, through pins.
 
 **Setting a knob a cell can reach only through the environment after the process that reads it
 starts is a defect - set it before that process starts.** That process is a child the cell
-spawns, or the runner's own. Such a knob needs no restore. An in-cell set is invisible to the
-running config, which is read once at context init.
+spawns, or the runner's own. An in-cell set is invisible to the running config, which is read
+once at context init.
 
 **A cell that cannot set an environment-read knob before its reader starts, and whose assert
 text does not name the value it asserts under, is a defect.** An environment-read knob is one
@@ -203,21 +215,21 @@ GPU tower move the default per box, so the assert is on the lane the policy sele
 one predicate's own value.
 
 **A cell that encodes, preprocesses, or asserts on media bytes an encoder consumes - pixels
-or audio samples, not a `.dlim` model image - with no model loaded is a defect when it does
-not build its fixture procedurally and pin its expectations in-repo.**
+or audio samples, not a `.dlim` model image - with no model loaded builds its fixture
+procedurally and pins its expectations in-repo.**
 
 **An image a test feeds an embedder that the test does not build, and that
 `DASLLAMA_VISION_DUMP` cannot preview, is a defect** - a red never requires adding
 instrumentation before a human can see what the model consumed.
 
 **An audio clip a test feeds an embedder that the test does not build, and that is not one of
-the checked-in fixtures beside the models (`jfk.wav`, `gemma4a_test2.wav` - the sanctioned ASR
-corpus), is a defect** - the same reason: a clip nobody else can play makes a red unreadable.
+the checked-in fixtures beside the models (`jfk.wav`, `gemma4a_test2.wav`), is a defect** - a
+clip nobody else can play makes a red unreadable. A newly checked-in clip joins this list in
+the same change.
 
 **A tier-1 media fixture - one an embedder-parity cell regenerates in-test and compares
 against an oracle dump - with no exact-value generator is a defect.** A generator running libm
-transcendentals is not exact-value: it is not float-portable. Orientation coverage uses shaped
-exact fixtures.
+transcendentals is not exact-value: it is not float-portable.
 
 **An embedding-parity cell that does not name its fixture, or does not log the measured
 maxdiff on green as well as red, is a defect.**
@@ -233,10 +245,10 @@ can fail.
 **A family that gains a live thinking or tool format ships its recognition tests in the same
 change** - the wire-shape pins, the render pins, and a live server leg gated on the family's
 smallest GGUF that runs on the small tier (the file homes are `CLAUDE.md`'s "Model-free /
-no-arm tests" and "Out-of-folder test files" notes). A family whose vocab lacks the markers
-has no format to test.
+no-arm tests" and "Out-of-folder test files" notes). A family whose vocab carries no thinking
+or tool markers has no format to test.
 
-**A kernel-unit gate whose kernel reads f16 operands and whose oracle is wider-precision
+**A kernel-unit cell whose kernel reads f16 operands and whose oracle is wider-precision
 feeds inputs that are exact in f16.** Otherwise the compare measures input rounding, and the
 bar has to be loosened until it no longer discriminates.
 
@@ -247,15 +259,19 @@ then reds the ordinary compare, so the gate needs no separate leak control.
 **A cell whose only compare is bit-identity between two kernel forms also compares one of the
 two against a CPU oracle, in the same cell.** Two forms can be bit-equal and both wrong.
 
-**A poison leg on a tower the Metal driver serves reaches every plane the served route reads -
-a blob-only poison on a twin-serving route is laundered.** Which planes those are is the
-route's to say: a twin-W route reads the baked halfword twin (`wblob`), so poisoning that
-plane alone is a valid control there, while a route reading both planes needs both zeroed. A
-poison the served route never reads passes on a broken kernel.
+**A poison leg on a tower the Metal driver serves reaches every weight buffer the served route
+reads.** Which buffers those are depends on the route: a twin-W route reads the baked halfword
+twin (`wblob`), so poisoning that buffer alone is a valid control there, while a route reading
+both buffers needs both zeroed. A poison the served route never reads passes on a broken
+kernel.
 
-**An ASR cell comparing transcripts across two serving lanes asserts TOKEN equality; a cell
-comparing a crowned lane against its tensor twin asserts WORD equality, because the twins'
-rounding legitimately flips tokens.** A crowned lane is the raced kernel form a tune sidecar
-arms as the serving one; its tensor twin is the same kernel written on Metal's tensor
-primitives. A cell that cannot hold its grade converts to the forced-feed logits-tolerance
-form - never to a looser text compare.
+**An ASR cell comparing transcripts across two serving lanes, other than a tune-armed kernel
+form against its Metal-tensor twin, asserts TOKEN equality.**
+
+**An ASR cell comparing a crowned lane against its tensor twin asserts WORD equality** - the
+twins' rounding legitimately flips tokens. A crowned lane is the raced kernel form a tune
+sidecar arms as the serving one; its tensor twin is the same kernel written on Metal's tensor
+primitives.
+
+**An ASR transcript cell that cannot assert the equality its comparison calls for converts to
+a forced-feed logits compare within a tolerance bar - never to a looser text compare.**

--- a/modules/dasLLAMA/tests/test_par_indexed.das
+++ b/modules/dasLLAMA/tests/test_par_indexed.das
@@ -77,6 +77,25 @@ def indexed_storm(t : T?; rounds : int) {
 }
 
 [test]
+def test_maybe_parallel_for_bool_no_que(t : T?) {
+    t |> run("no job que - a true flag runs the bool form inline, one invoke over the whole range") @(t : T?) {
+        let before = get_disp_inline()
+        var acc : array<int>
+        acc |> resize(2)   // [invokes, elements covered]
+        var pa = unsafe(addr(acc[0]))
+        maybe_parallel_for(true, 3, 19, 8) $(rb, re) {
+            unsafe {
+                pa[0]++
+                pa[1] += re - rb
+            }
+        }
+        t |> equal(acc[0], 1, "one invoke")
+        t |> equal(acc[1], 16, "the whole range in that invoke")
+        t |> equal(get_disp_inline() - before, 1l, "counted as an inline run")
+    }
+}
+
+[test]
 def test_maybe_parallel_for_indexed(t : T?) {
     t |> run("no job que - inline as slot 0") @(t : T?) {
         single_invoke_round(t, 8, 32)

--- a/modules/dasLLAMA/tests/test_parity_pregate.das
+++ b/modules/dasLLAMA/tests/test_parity_pregate.das
@@ -7,6 +7,10 @@ require dastest/testing_boost public
 require ../benchmarks/lcpp_bench.das   // parity_check — the board pregate's verdict, driven with a controlled spec
 require ../performance/model_specs.das   // spec_by_file — the table rows the pregate binds
 require dasllama/dasllama_common       // get_kquant_native — the mode the kq arm must restore
+require dasllama/dasllama_load          // load_model_ — the slice cell loads its own carrier
+require dasllama/dasllama_gpu_resident  // moe_gpu_resident_active — the slice cell needs the driver armed
+require ?vulkan dasllama/dasllama_vulkan_prefill   // g_pf_ffn_slice — the slice's A/B arm
+require daslib/jobque_boost             // with_job_que — a 512-token prefill dispatches its CPU stages as jobs
 require daslib/fio
 require _model_tier                    // models_dir + model_available (presence/size gate)
 
@@ -65,5 +69,67 @@ def test_parity_pregate_kq_native(t : T?) {
         let before = get_kquant_native()
         t |> success(parity_check(path, spec), "the kq-native load reproduces the pinned continuation")
         t |> equal(get_kquant_native(), before, "the pregate restores the kq-native mode it flipped")
+    }
+}
+
+// The last layer's FFN slice against the whole window: one 512-token prefill each way on the
+// resident Vulkan driver, logits exact - the frozen fixtures' 5-20-token prompts never reach it.
+[test]
+def test_parity_last_layer_slice(t : T?) {
+    t |> run("the last layer's 32-row FFN slice reproduces the whole window's logits bit for bit") @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            if (!jit_enabled()) {
+                t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+                return
+            }
+            var inscope spec <- spec_by_file("Llama-3.2-1B-Instruct-Q8_0.gguf")
+            let path = path_join(models_dir(), spec.file)
+            if (!model_available(t, path)) return
+            var t8 <- load_model_(path, QuantMode.q8)
+            if (!moe_gpu_resident_active()) {
+                t |> skip("the resident Vulkan driver is not armed (DASLLAMA_GPU=1 on a coopmat2 device)")
+                delete t8
+                return
+            }
+            let plen = 512l
+            var prompt : array<int64>
+            prompt |> resize(int(plen))
+            for (i in range(int(plen))) {
+                prompt[i] = 1000l + ((int64(i) * 17l + 999l * 131l) % 5000l)
+            }
+            var want : array<float>
+            var got : array<float>
+            var served_whole = false
+            var served_slice = false
+            with_job_que() {
+                g_pf_ffn_slice = false
+                var s0 <- make_run_state(t8.config, KVDtype.f16, KVDtype.f16)
+                forward_prefill(t8, s0, prompt, plen, 0l)
+                served_whole = s0.rdec_gen != 0l   // the driver stamps the session it served; a declined call leaves 0
+                want := s0.logits
+                delete s0
+                g_pf_ffn_slice = true
+                var s1 <- make_run_state(t8.config, KVDtype.f16, KVDtype.f16)
+                forward_prefill(t8, s1, prompt, plen, 0l)
+                served_slice = s1.rdec_gen != 0l
+                got := s1.logits
+                delete s1
+            }
+            t |> success(served_whole && served_slice, "both arms were served by the resident driver, not the CPU rail")
+            var bad = 0
+            for (w, g in want, got) {
+                if (w != g) {
+                    bad++
+                }
+            }
+            t |> success(length(want) == int(t8.config.vocab_size) && bad == 0,
+                "the sliced last layer reproduces the whole window ({bad} of {length(want)} logits diverge)")
+            delete want
+            delete got
+            delete prompt
+            delete t8
+        } else {
+            t |> skip("dasVulkan not present")
+        }
     }
 }

--- a/modules/dasLLAMA/tests/test_vulkan_kernels.das
+++ b/modules/dasLLAMA/tests/test_vulkan_kernels.das
@@ -192,7 +192,7 @@ def test_vkd_cls_ar_row0(t0 : T?) {
     t0 |> run("cls_ar with a row base lands on the rows from row0 and leaves the rows below untouched") <| @(t : T?) {
         static_if (typeinfo builtin_module_exists(vulkan)) {
             if (!ensure_cls_ar()) {
-                feint("no Vulkan device - skipping\n")
+                t |> skip("no Vulkan device, or the cls_ar pipeline failed to build")
                 return
             }
             let dim = 1024
@@ -293,7 +293,7 @@ def test_vkd_cls_ar_row0(t0 : T?) {
             delete xc
             delete ysent
         } else {
-            feint("dasVulkan not present - skipping\n")
+            t |> skip("dasVulkan not present")
         }
     }
 }
@@ -303,7 +303,7 @@ def test_vkd_actf16_base(t0 : T?) {
     t0 |> run("actf16 with an element base == the same row dispatched from zero; the halves below the base keep their sentinel") <| @(t : T?) {
         static_if (typeinfo builtin_module_exists(vulkan)) {
             if (!ensure_actf16_cls()) {
-                feint("no Vulkan device - skipping\n")
+                t |> skip("no Vulkan device, or the actf16 pipeline failed to build")
                 return
             }
             let nelem = 2048
@@ -379,7 +379,7 @@ def test_vkd_actf16_base(t0 : T?) {
             delete h0
             delete h1
         } else {
-            feint("dasVulkan not present - skipping\n")
+            t |> skip("dasVulkan not present")
         }
     }
 }

--- a/modules/dasLLAMA/tests/test_vulkan_kernels.das
+++ b/modules/dasLLAMA/tests/test_vulkan_kernels.das
@@ -13,6 +13,7 @@ require ?vulkan vulkan/vulkan_boost
 require ?vulkan dasllama/dasllama_vulkan_common
 require ?vulkan dasllama/dasllama_env   // g_env_vulkan.coopmat - the resolved-default ladder cell pins and restores it
 require ?vulkan dasllama/dasllama_vulkan_classes
+require ?vulkan dasllama/dasllama_vulkan_prefill
 require ?vulkan dasllama/dasllama_vulkan_seams
 require ?vulkan dasllama/dasllama_kqformat
 require ?vulkan daslib/shader_lingua_franca   // gl_GlobalInvocationID — the CPU replay drives it per lane (only vulkan-guarded arms replay)
@@ -180,6 +181,203 @@ def test_vkd_ar_class(t0 : T?) {
             delete yc
             delete xc
             delete ysent
+        } else {
+            feint("dasVulkan not present - skipping\n")
+        }
+    }
+}
+
+[test]
+def test_vkd_cls_ar_row0(t0 : T?) {
+    t0 |> run("cls_ar with a row base lands on the rows from row0 and leaves the rows below untouched") <| @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            if (!ensure_cls_ar()) {
+                feint("no Vulkan device - skipping\n")
+                return
+            }
+            let dim = 1024
+            let rows = 3
+            let row0 = 1
+            let total = dim * rows
+            let bytes = int64(total) * 4l
+            let wbytes = int64(dim) * 4l
+            let eps = 1e-5
+            var x : array<float>
+            var a : array<float>
+            var w : array<float>
+            x |> resize(total)
+            a |> resize(total)
+            w |> resize(dim)
+            for (i in range(total)) {
+                x[i] = float((i * 37) % 101) * 0.11 - 5.0
+                a[i] = float((i * 13) % 89) * 0.07 - 3.0
+            }
+            for (i in range(dim)) {
+                w[i] = 0.5 + float(i % 17) * 0.05
+            }
+            // the reference: the seam row by row from row0; rows below keep x and a sentinel y
+            var x2 := x
+            var y2 : array<float>
+            y2 |> resize(total)
+            for (i in range(total)) {
+                y2[i] = -999.25
+            }
+            for (r in range(row0, rows)) {
+                var xr : array<float>
+                var ar : array<float>
+                var yr : array<float>
+                xr |> resize(dim)
+                ar |> resize(dim)
+                yr |> resize(dim)
+                for (i in range(dim)) {
+                    xr[i] = x[r * dim + i]
+                    ar[i] = a[r * dim + i]
+                }
+                vk_add_rms(xr, ar, w, yr, int64(dim), eps, 1.0, true)
+                for (i in range(dim)) {
+                    x2[r * dim + i] = xr[i]
+                    y2[r * dim + i] = yr[i]
+                }
+                delete xr
+                delete ar
+                delete yr
+            }
+            let xd = make_device_buf(bytes)
+            let ad = make_device_buf(bytes)
+            let wd = make_device_buf(wbytes)
+            let yd = make_device_buf(bytes)
+            var host = make_host_buf(bytes, true, [cached = true])
+            var yc : array<float>
+            var xc : array<float>
+            yc |> resize(total)
+            xc |> resize(total)
+            var ysent : array<float>
+            ysent |> resize(total)
+            for (i in range(total)) {
+                ysent[i] = -999.25
+            }
+            unsafe {
+                upload_region_at(yd, 0l, addr<uint8 const?>(ysent[0]), bytes)
+                upload_region_at(xd, 0l, addr<uint8 const?>(x[0]), bytes)
+                upload_region_at(ad, 0l, addr<uint8 const?>(a[0]), bytes)
+                upload_region_at(wd, 0l, addr<uint8 const?>(w[0]), wbytes)
+                var s = set_cls_ar(fixed_array(xd, ad, wd, yd), fixed_array(bytes, bytes, wbytes, bytes), fixed_array(1u, 2u, 4u, 8u))
+                var raw = alloc_cmd()
+                let begin = VkCommandBufferBeginInfo()
+                vk_check(vkBeginCommandBuffer(raw, begin), null)
+                var h : VkHaz
+                var pc = ArArgs(dim = uint(dim), add_on = 1u, eps = eps, ascale = 1.0, row0 = uint(row0))
+                enc_cls_ar(raw, h, s, pc, int64(rows - row0))
+                vhz_dep(raw, h, 8u | 1u, 0u, true)
+                cmd_copy_whole(raw, yd, host.buf, bytes)
+                vk_check(vkEndCommandBuffer(raw), null)
+                submit_wait(raw)
+                memcpy(addr<void?>(yc[0]), host.mapped, bytes)
+                var raw2 = alloc_cmd()
+                vk_check(vkBeginCommandBuffer(raw2, begin), null)
+                cmd_copy_whole(raw2, xd, host.buf, bytes)
+                vk_check(vkEndCommandBuffer(raw2), null)
+                submit_wait(raw2)
+                memcpy(addr<void?>(xc[0]), host.mapped, bytes)
+            }
+            let bad_y = mismatch_exact(yc, y2)
+            let bad_x = mismatch_exact(xc, x2)
+            t |> success(bad_y == 0, "normed rows from row0 bit-exact, the row below still the sentinel ({bad_y} of {total} diverge)")
+            t |> success(bad_x == 0, "residual rows from row0 bit-exact, the row below untouched ({bad_x} of {total} diverge)")
+            delete x
+            delete a
+            delete w
+            delete x2
+            delete y2
+            delete yc
+            delete xc
+            delete ysent
+        } else {
+            feint("dasVulkan not present - skipping\n")
+        }
+    }
+}
+
+[test]
+def test_vkd_actf16_base(t0 : T?) {
+    t0 |> run("actf16 with an element base == the same row dispatched from zero; the halves below the base keep their sentinel") <| @(t : T?) {
+        static_if (typeinfo builtin_module_exists(vulkan)) {
+            if (!ensure_actf16_cls()) {
+                feint("no Vulkan device - skipping\n")
+                return
+            }
+            let nelem = 2048
+            let total = nelem * 2
+            let g_bytes = int64(total) * 4l
+            let h_bytes = int64(total) * 2l
+            var gh : array<float>
+            var uh : array<float>
+            gh |> resize(total)
+            uh |> resize(total)
+            for (i in range(total)) {
+                gh[i] = float((i * 29) % 61) * 0.06 - 1.9
+                uh[i] = float((i * 43) % 83) * 0.05 - 2.1
+            }
+            // arm 0: the second row's data at the front, base 0; arm 1: the plane as is, base nelem
+            var g0 : array<float>
+            var u0 : array<float>
+            g0 |> resize(total)
+            u0 |> resize(total)
+            for (i in range(nelem)) {
+                g0[i] = gh[nelem + i]
+                u0[i] = uh[nelem + i]
+            }
+            var hsent : array<uint>
+            hsent |> resize(total / 2)
+            for (i in range(total / 2)) {
+                hsent[i] = 0xFC00FC00u
+            }
+            let gd = make_device_buf(g_bytes)
+            let ud = make_device_buf(g_bytes)
+            let hd = make_device_buf(h_bytes)
+            var host = make_host_buf(h_bytes, true, [cached = true])
+            var h0 : array<uint>
+            var h1 : array<uint>
+            h0 |> resize(total / 2)
+            h1 |> resize(total / 2)
+            for (arm in range(2)) {
+                unsafe {
+                    upload_region_at(gd, 0l, addr<uint8 const?>(arm == 0 ? g0[0] : gh[0]), g_bytes)
+                    upload_region_at(ud, 0l, addr<uint8 const?>(arm == 0 ? u0[0] : uh[0]), g_bytes)
+                    upload_region_at(hd, 0l, addr<uint8 const?>(hsent[0]), h_bytes)
+                    var sc = set_actf16_cls(fixed_array(gd, ud, hd), fixed_array(g_bytes, g_bytes, h_bytes), fixed_array(1u, 2u, 4u))
+                    var raw = alloc_cmd()
+                    let begin = VkCommandBufferBeginInfo()
+                    vk_check(vkBeginCommandBuffer(raw, begin), null)
+                    var h : VkHaz
+                    var pc = ActArgs(nelem = uint(nelem), gelu = 1u, nblk = 0u, elem0 = arm == 0 ? 0u : uint(nelem))
+                    enc_actf16_cls(raw, h, sc, pc, int64((nelem / 4 + 255) / 256))
+                    vhz_dep(raw, h, 4u, 0u, true)
+                    cmd_copy_whole(raw, hd, host.buf, h_bytes)
+                    vk_check(vkEndCommandBuffer(raw), null)
+                    submit_wait(raw)
+                    memcpy(addr<void?>(arm == 0 ? h0[0] : h1[0]), host.mapped, h_bytes)
+                }
+            }
+            var bad_row = 0
+            var bad_sent = 0
+            for (i in range(nelem / 2)) {
+                if (h1[nelem / 2 + i] != h0[i]) {
+                    bad_row++
+                }
+                if (h1[i] != 0xFC00FC00u) {
+                    bad_sent++
+                }
+            }
+            t |> success(bad_row == 0, "the based row equals the same row dispatched from zero ({bad_row} of {nelem / 2} words diverge)")
+            t |> success(bad_sent == 0, "the halves below the base keep the sentinel ({bad_sent} of {nelem / 2} words written)")
+            delete gh
+            delete uh
+            delete g0
+            delete u0
+            delete hsent
+            delete h0
+            delete h1
         } else {
             feint("dasVulkan not present - skipping\n")
         }
@@ -1342,7 +1540,7 @@ def test_vkd_cm_batch_family(t0 : T?) {
                 y_ref |> resize(rows * d)
                 q8_gemm_oracle(wqh, wsh, xqh, xsh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm batch variant {v}: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm batch variant {v}: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm batch variant {v} matches the CPU oracle ({bad} of {rows * d} off)")
                 delete sched
                 delete y_ref
@@ -1460,7 +1658,7 @@ def test_vkd_kq_q40_cm_batch(t0 : T?) {
             y_ref |> resize(rows * d)
             kq_gemm_oracle(int(KqFmt.q40), wqh, wsuh, xqh, xsh, sched, 2, n, d, y_ref)
             let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-            to_log(LOG_INFO, "q40 cm batch: {bad} of {rows * d} off the oracle\n")
+            to_log(LOG_INFO, "q40 cm batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
             t |> success(bad == 0, "q40 cm batch matches the CPU oracle ({bad} of {rows * d} off)")
             delete sched
             delete y_ref
@@ -1566,7 +1764,7 @@ def test_vkd_cm2l_batch(t0 : T?) {
             y_ref |> resize(rows * d)
             q8f16_gemm_oracle(wqh, wsh, xfh, sched, 2, n, d, y_ref)
             let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-            to_log(LOG_INFO, "cm2 l-tile batch: {bad} of {rows * d} off the oracle\n")
+            to_log(LOG_INFO, "cm2 l-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
             t |> success(bad == 0, "cm2 l-tile batch matches the CPU oracle ({bad} of {rows * d} off)")
             delete sched
             delete y_ref
@@ -1685,7 +1883,7 @@ def test_vkd_cm2_decode_vector_pair(t0 : T?) {
                     memcpy(addr<void?>(y_cls[0]), host.mapped, y_bytes)
                     let bad = mismatch_bars(y_cls, y_ref, 2e-2, floor)
                     let what = arm == 0 ? "stripped (scalar callback)" : (twin_device ? "the four-wide twin" : "the twin stamp on a device without the callback")
-                    to_log(LOG_INFO, "cm2 decode pair, {what}: {bad} of {rows * d} off the oracle\n")
+                    to_log(LOG_INFO, "cm2 decode pair, {what}: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                     t |> success(bad == 0, "{what} matches the CPU oracle ({bad} of {rows * d} off)")
                     var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                     y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -1816,7 +2014,7 @@ def test_vkd_k4_cm2_batch(t0 : T?) {
                 }
                 k4f16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 k4 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 k4 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 k4 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -1945,7 +2143,7 @@ def test_vkd_k5_cm2_batch(t0 : T?) {
                 }
                 k5f16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 k5 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 k5 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 k5 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2073,7 +2271,7 @@ def test_vkd_q40_cm2_batch(t0 : T?) {
                 }
                 q40f16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 q40 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 q40 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 q40 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2200,7 +2398,7 @@ def test_vkd_k2_cm2_batch(t0 : T?) {
                 }
                 k2f16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 k2 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 k2 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 k2 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2328,7 +2526,7 @@ def test_vkd_iq4nl_cm2_batch(t0 : T?) {
                 }
                 iq4nlf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq4nl {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq4nl {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq4nl {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2456,7 +2654,7 @@ def test_vkd_iq4xs_cm2_batch(t0 : T?) {
                 }
                 iq4xsf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq4xs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq4xs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq4xs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2583,7 +2781,7 @@ def test_vkd_k3_cm2_batch(t0 : T?) {
                 }
                 k3f16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 k3 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 k3 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 k3 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2711,7 +2909,7 @@ def test_vkd_iq3s_cm2_batch(t0 : T?) {
                 }
                 iq3sf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq3s {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq3s {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq3s {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2839,7 +3037,7 @@ def test_vkd_iq2s_cm2_batch(t0 : T?) {
                 }
                 iq2sf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq2s {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq2s {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq2s {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -2967,7 +3165,7 @@ def test_vkd_iq2xs_cm2_batch(t0 : T?) {
                 }
                 iq2xsf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq2xs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq2xs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq2xs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -3095,7 +3293,7 @@ def test_vkd_iq2xxs_cm2_batch(t0 : T?) {
                 }
                 iq2xxsf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq2xxs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq2xxs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq2xxs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -3223,7 +3421,7 @@ def test_vkd_iq3xxs_cm2_batch(t0 : T?) {
                 }
                 iq3xxsf16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 iq3xxs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 iq3xxs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 iq3xxs {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -3350,7 +3548,7 @@ def test_vkd_k6_cm2_batch(t0 : T?) {
                 }
                 k6f16_gemm_oracle(wqh, wsuh, xfh, sched, 2, n, d, y_ref)
                 let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-                to_log(LOG_INFO, "cm2 k6 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle\n")
+                to_log(LOG_INFO, "cm2 k6 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
                 t |> success(bad == 0, "cm2 k6 {ml == 0 ? "l" : (ml == 1 ? "m" : "s")}-tile matches the CPU oracle ({bad} of {rows * d} off)")
                 var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
                 y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -3459,7 +3657,7 @@ def test_vkd_cm2m_batch(t0 : T?) {
             y_ref |> resize(rows * d)
             q8f16_gemm_oracle(wqh, wsh, xfh, sched, 2, n, d, y_ref)
             let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-            to_log(LOG_INFO, "cm2 m-tile batch: {bad} of {rows * d} off the oracle\n")
+            to_log(LOG_INFO, "cm2 m-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
             t |> success(bad == 0, "cm2 m-tile batch matches the CPU oracle ({bad} of {rows * d} off)")
             delete sched
             delete y_ref
@@ -3563,7 +3761,7 @@ def test_vkd_cm2s_batch(t0 : T?) {
             y_ref |> resize(rows * d)
             q8f16_gemm_oracle(wqh, wsh, xfh, sched, 2, n, d, y_ref)
             let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-            to_log(LOG_INFO, "cm2 s-tile batch: {bad} of {rows * d} off the oracle\n")
+            to_log(LOG_INFO, "cm2 s-tile batch: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
             t |> success(bad == 0, "cm2 s-tile batch matches the CPU oracle ({bad} of {rows * d} off)")
             var y_poison := y_cls   // the bar's control: one element pushed past both bars must red
             y_poison[0] += 1.0 + 2.0 * max_abs(y_ref)
@@ -3676,7 +3874,7 @@ def test_vkd_cm2l_split(t0 : T?) {
             y_ref |> resize(rows * d)
             q8f16_gemm_oracle(wqh, wsh, xfh, sched, 1, n, d, y_ref)
             let bad = mismatch_bars(y_cls, y_ref, 2e-2, 4e-3 * max_abs(y_ref))
-            to_log(LOG_INFO, "cm2 l-tile split-k: {bad} of {rows * d} off the oracle\n")
+            to_log(LOG_INFO, "cm2 l-tile split-k: {bad} of {rows * d} off the oracle, {g_gpu.decvec_on ? "four-wide twin" : "scalar callback"}\n")
             t |> success(bad == 0, "cm2 l-tile split-k matches the CPU oracle ({bad} of {rows * d} off)")
             delete sched
             delete y_ref
@@ -6555,6 +6753,10 @@ def test_vk_coopmat_default_and_tile_pick(t0 : T?) {
                 t |> skip("no Vulkan device for the tile pick (it reads the device's SM count)")
                 return
             }
+            if (g_env_vulkan.cm2_tile != 0l || g_env_vulkan.cm2_splitk != 0l) {
+                t |> skip("DASLLAMA_CM2_TILE or DASLLAMA_CM2_SPLITK is set - the picks below are forced, not the heuristic")
+                return
+            }
             let saved_sm = g_gpu.sm_count
             g_gpu.sm_count = 36
             t |> equal(cm2_tile_cols(3072l, 128l), 128l)    // a short window never takes the half-empty l column
@@ -6566,8 +6768,14 @@ def test_vk_coopmat_default_and_tile_pick(t0 : T?) {
             t |> equal(cm2_tile_cols(768l, 65l), 128l)      // past it an m column is more than half full
             t |> equal(cm2_tiles(512l, 512l), 16l)                             // the 1B k/v shape: four m columns of four
             t |> equal(cm2_split_k(512l, 512l, 2048l, 128l).nsplit, 2l)        // ... alone it fills under half the SMs: split in two
-            t |> equal(cm2_split_k(512l, 512l, 2048l, 128l, 80l).nsplit, 1l)   // ... beside q and its twin (96 in the group): never
+            t |> equal(cm2_split_k(512l, 512l, 2048l, 128l, 80l).nsplit, 1l)   // ... beside q and the other kv projection (96 in the group): never
             t |> equal(cm2_split_k(2048l, 512l, 2048l, 128l).nsplit, 1l)       // the 1B q shape: 64 workgroups, no split
+            t |> equal(pf_split_pick(int(KqFmt.k4), 2048l, 32l, 8192l, 0l, 0l).nsplit, 2l)     // the sliced down shape from row 0 would split in two
+            t |> equal(pf_split_pick(int(KqFmt.k4), 2048l, 32l, 8192l, 480l, 0l).nsplit, 1l)   // ... from row 480 it never splits
+            t |> equal(pf_ffn_slice_row0(15l, 16l, 512l, true, true), 480l)   // the last layer on the f16 route starts 32 rows below the window's end
+            t |> equal(pf_ffn_slice_row0(15l, 16l, 20l, true, true), 0l)      // a window under 32 rows runs whole
+            t |> equal(pf_ffn_slice_row0(14l, 16l, 512l, true, true), 0l)     // an earlier layer runs whole
+            t |> equal(pf_ffn_slice_row0(15l, 16l, 512l, false, true), 0l)    // a feed off the f16 route runs whole
             g_gpu.sm_count = 0
             t |> equal(cm2_tile_cols(3072l, 64l), 32l)      // unknown SM count: the bucket rule still fires
             t |> equal(cm2_tile_cols(3072l, 100l), 128l)    // unknown SM count: the short-window rule still fires

--- a/modules/dasLLAMA/tests/test_vulkan_kernels.das
+++ b/modules/dasLLAMA/tests/test_vulkan_kernels.das
@@ -6564,6 +6564,10 @@ def test_vk_coopmat_default_and_tile_pick(t0 : T?) {
             t |> equal(cm2_tile_cols(768l, 32l), 32l)       // the expert-bucket shape (30B-A3B pp512: ~32 rows per region) takes s
             t |> equal(cm2_tile_cols(768l, 64l), 32l)       // ... up to the half-m edge
             t |> equal(cm2_tile_cols(768l, 65l), 128l)      // past it an m column is more than half full
+            t |> equal(cm2_tiles(512l, 512l), 16l)                             // the 1B k/v shape: four m columns of four
+            t |> equal(cm2_split_k(512l, 512l, 2048l, 128l).nsplit, 2l)        // ... alone it fills under half the SMs: split in two
+            t |> equal(cm2_split_k(512l, 512l, 2048l, 128l, 80l).nsplit, 1l)   // ... beside q and its twin (96 in the group): never
+            t |> equal(cm2_split_k(2048l, 512l, 2048l, 128l).nsplit, 1l)       // the 1B q shape: 64 workgroups, no split
             g_gpu.sm_count = 0
             t |> equal(cm2_tile_cols(3072l, 64l), 32l)      // unknown SM count: the bucket rule still fires
             t |> equal(cm2_tile_cols(3072l, 100l), 128l)    // unknown SM count: the short-window rule still fires

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1207,4 +1207,48 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   18786-19457 tok/s. THE GPU WINDOW NOW READS 0.99x OF llama.cpp's 22302 us. LESSON for the
   next slice-shaped change: the tier suite's small model never reaches the split-k branch -
   a golden-output witness at the 1B shapes is the parity pregate (frozen fixture, Q8_0 has
-  one) or the bench's sanity argmax/logit against a recorded value.
+  one) or the bench's sanity argmax/logit against a recorded value. Q8_0 with the slice:
+  parity pregate 40/40 token-for-token, window 19954 us, pp512 23827 tok/s - past llama.cpp's
+  20237 tok/s on that vehicle.
+
+- 2026-09-02: Vulkan gap 1 (d), the host budget measured. `JOBQUE_PROFILING=1 lcpp_bench
+  --prof` on the Q4_K_M window: wall 25728 us against a 22.1 ms GPU window; buckets embed 2179
+  us (the CPU `embed_row` over 512 tokens plus the 4 MB x upload), rope_build 152, alloc 17;
+  the driver's own prep 460 and record 570 sit outside the buckets. llama.cpp gathers the
+  embedding on the device (GET_ROWS, 6 us). The device gather rail exists
+  (`vk_rdec_prefill_ids`, `vk_rdec_set_emb`) but the embed gate keeps this model on the CPU
+  embed: the gather kernel serves q8 tied planes and the f32 table only, and the 1B ties a
+  q6_K plane (followup_vulkan 37 = the kq gather). Landed instead, the cheap half:
+  `forward_prefill`'s embed loop runs across the dispatch lanes (`maybe_parallel_for` with
+  hoisted raw pointers - a parallel block cannot capture the model). Embed bucket 2179 -> 295
+  us, profiled window wall 25728 -> 24106. Timed windows after (two runs that read 24.3-24.4 ms
+  GPU were drift - wo, gate, down and act inflated together - and a bracket brought the same
+  binary back): GPU 22065-22118 us, pp512 20812-20822 tok/s, sanity argmax 319 / tg logit
+  8.516193, Q8_0 parity 40/40. llama.cpp on the same box, same driver, four-wide decode: pp512
+  20309 tok/s. Q4_K_M 1B pp512 stands at 1.025x of llama.cpp; the day's ladder on the window:
+  27.8 ms (morning) -> 27.2 (group-aware split-k) -> 22.9 (hand-laid twins) -> 22.1 (last-layer
+  slice), wall 15.3k -> 20.8k tok/s (embed parallel). Left on the table: the kq device gather
+  (embed 295 us + the 4 MB x upload inside prep 460), rope_build 151 us, record 570 us.
+
+- 2026-09-02: the ten-vehicle board on the branch tip (`lcpp_bench --for-debug-purposes --plen
+  512 --ngen 128 --reps 6`, the bench's mean +- sd) against the llama.cpp rows above (vector
+  build, medians of six, same box and driver):
+
+  | format | pp512 ours | pp512 llama.cpp | ratio | tg128 ours | tg128 llama.cpp | ratio |
+  |---|---|---|---|---|---|---|
+  | Q4_K_M | 21023 +- 296 | 20309 | 1.04 | 338.0 | 354.2 | 0.95 |
+  | Q3_K_L | 16984 +- 1031 | 18883 | 0.90 | 351.0 | 332.7 | 1.06 |
+  | Q2_K | 21824 +- 395 | 19684 | 1.11 | 410.0 | 400.7 | 1.02 |
+  | IQ4_XS | 19443 +- 1874 | 19515 | 1.00 | 321.5 | 331.4 | 0.97 |
+  | IQ4_NL | 22042 +- 435 | 20488 | 1.08 | 326.1 | 344.8 | 0.95 |
+  | IQ3_M | 17692 +- 677 | 19638 | 0.90 | 267.2 | 306.4 | 0.87 |
+  | IQ3_XXS | 19684 +- 513 | 19488 | 1.01 | 347.5 | 355.4 | 0.98 |
+  | IQ2_XS | 21828 +- 284 | 20011 | 1.09 | 183.0 | 329.4 | 0.56 |
+  | IQ2_XXS | 18870 +- 409 | 20052 | 0.94 | 278.6 | 390.8 | 0.71 |
+  | Q8_0 | 23974 +- 172 | 20237 | 1.19 | 233.5 +- 42 | 249.9 | 0.93 |
+
+  pp512 (this arc's gap 1): seven of ten at or past 1.0 from a 0.67-0.90 start; the three below
+  are Q3_K_L 0.90 (a 6% spread on our side), IQ3_M 0.90 and IQ2_XXS 0.94 - the k3, iq3s and
+  iq2xxs tiles, whose per-shape reference rows (llama.cpp's perf-logger MUL_MAT rows per format)
+  are the next mirror-bench pass. tg128 is gap 3 (the grid tg tails: IQ2_XS 0.56, IQ2_XXS 0.71,
+  IQ3_M 0.87; followup_vulkan 35), untouched by this arc.

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1151,3 +1151,42 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   workgroups unsplit costs the same 921 us as split in two over 32: the split never bought the
   lone role anything on this box. Drift note: a plain window ranged 27.6-30.2 ms across the hour
   (wo, down and rope_kv drift together), so every A/B on this box is bracketed by plain runs.
+
+- 2026-09-02: Vulkan gap 1 (a), the scale hoist measured and killed for k6; the lever is the twin
+  body. The probe's `k6x` ladder at the 3B q6k shapes (l tile, TF/s, gate | down): constant
+  decode 60.1 | 42.3, nibble-only compose 47.3 | 36.1, full compose without scale reads 38.7 |
+  30.0, shipped 38.5 | 28.3. The scale plane costs 0-6%; the decode compose costs a third of the
+  ceiling. Same rows un-barriered (16 dispatches overlapping): 45.3 | 48.6 - the lone-dispatch
+  wave tail at the 3B shapes (down: 40 tiles on 36 SMs) is worth as much as the decode, a 3B
+  story, not the 1B's (its down GEMM is 32 l-tiles in one wave). So delta 1 (shAscales) is dead
+  for k6 and untested for k4, because the cheaper lever came first: the synthesized four-wide twin
+  repeats the whole scalar body four times, and a HAND-LAID twin shares what four consecutive
+  elements share. The template gains a `DECV4` axis (the format's own `decode_v4` rides the loads
+  instead of the synthesized twin); k4's twin reads its four nibbles as two 16-bit lanes and
+  extracts `(d*sc, dmin*mn)` once, scalar operation order kept. `cm2:k4`, two rounds, hand-laid
+  twin | stripped (TF/s): gate l 47.0/45.4 | 33.9/35.4, gate m 48.1/40.1 | 26.7/27.4, down l
+  37.6/33.4 | 25.6, down m 43.0/38.1 | 23.2, q/wo l 52.4/48.2 | 36.0. Against the synthesized
+  twin's rows above (gate l 41.4/40.8, down l 31.5): +10-19% at the tile. Oracle suite 88/88
+  under the hand-laid twin (bit-exact). The Q4_K_M window with the k4 twin alone, two runs (us):
+  q 1382 (was 1688), k+v 912-1050 (1140), wo 1297 (1553), gate 5612 (6658), up 4782 (5905),
+  down 5345-5836 (6396), window 22852-23500 (27183-27289), pp512 18176-18722 tok/s (16045-16190,
+  +14%). The window now sits at 1.02-1.05x of llama.cpp's 22302; the wall (0.92x of 20309 tok/s)
+  carries the host gap, item 4. The same twin for the other K-quants, `cm2:<fmt>` two rounds,
+  l tile ms/dispatch hand-laid | stripped (gate, down, q/wo): k6 0.569-0.572 | 0.748, 0.780-0.784
+  | 1.015-1.034, 0.214 | 0.291 (gate 44.8 TF/s against the synthesized twin's 38.5, +16%; down
+  32.7 against 28.3); k5 0.552-0.559 | 0.831-0.838, 0.725-0.730 | 1.102-1.108, 0.210-0.213 |
+  0.324; k3 0.524-0.538 | 0.658-0.676, 0.723 | 0.902-0.905, 0.212-0.215 | 0.276; k2 0.484-0.491
+  | 0.651-0.662, 0.660-0.664 | 0.887-0.897, 0.199-0.200 | 0.273-0.274. The m tile follows the
+  same sign on every row. Every K-quant's hand-laid twin beats the stripped arm by 25-50% where
+  the synthesized one managed 7-37%. The rest, l tile TF/s hand-laid | stripped (gate, down,
+  q/wo; two rounds): q40 51.0-51.6 | 44.8-45.2, 39.3-40.1 | 34.9-35.1, 56.3-58.0 | 48.8-49.0;
+  iq4xs 46.3-48.9 | 39.1-39.3, 37.5 | 30.1, 53.0-53.5 | 42.8; iq4nl 44.2-51.8 | 44.5-44.6, 39.9
+  | 34.5, 55.8-56.5 | 48.1-48.3; iq3xxs 46.5-47.4 | 28.1-29.0, 34.5 | 21.1, 48.4-50.5 |
+  30.3-30.5; iq3s 43.4-48.1 | 29.2-30.1, 36.1-36.3 | 22.5-22.6, 50.6-51.3 | 32.4-32.5; iq2s
+  48.9-50.4 | 30.2-32.5, 35.8-35.9 | 23.6-24.0, 51.1-52.6 | 33.2-33.3; iq2xxs 43.6-45.8 |
+  33.8-35.2, 32.5-32.6 | 25.4, 45.8-46.2 | 35.4-35.5; iq2xs 47.9-53.4 | 35.1-37.8, 37.5 |
+  28.0, 52.6-52.7 | 38.1-38.2. Every grid format's hand-laid twin wins 30-65% where the
+  synthesized one was flat (iq3xxs, iq2xs) or lost (iq3s, iq2s, iq2xxs): the grid lookup and
+  the sign parity are per four elements, and the synthesized twin ran them four times. The
+  three `DECVEC` opt-outs are retired; followup_vulkan 36 closes with this. All thirteen kq
+  formats now ship a hand-laid twin.

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1136,8 +1136,10 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   our_prof_q4km.log.
 
 - 2026-09-02: Vulkan gap 1 (b) landed - the split-k pick counts the dispatch group. The force-knob
-  sweep on the Q4_K_M window (`DASLLAMA_CM2_TILE` x `DASLLAMA_CM2_SPLITK`, plain runs bracketing
-  every arm) showed the k and v roles' 2.2x was not the tile: with split-k off and the same m
+  sweep on the Q4_K_M window (`DASLLAMA_CM2_TILE` x `DASLLAMA_CM2_SPLITK` over `lcpp_bench
+  --for-debug-purposes --plen 512 --ngen 0 --reps 2` under `DASLLAMA_GPU=1 DASLLAMA_GPU_PROF=1`,
+  the per-role stamps of the last window, plain runs bracketing every arm; every window figure
+  in the bullets below is that rig's) showed the k and v roles' 2.2x was not the tile: with split-k off and the same m
   tile, k+v fell from 1917 to 1264 us, because k and v stop serializing through the shared
   split-k scratch and co-run under the hazard rail (the v stamp then reads only v's tail, 184 us).
   Forced split-k 4 or 8 and the s tile run 2-3x slower on every big role (one 512x8192 f32 plane
@@ -1218,7 +1220,8 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   embedding on the device (GET_ROWS, 6 us). The device gather rail exists
   (`vk_rdec_prefill_ids`, `vk_rdec_set_emb`) but the embed gate keeps this model on the CPU
   embed: the gather kernel serves q8 tied planes and the f32 table only, and the 1B ties a
-  q6_K plane (followup_vulkan 37 = the kq gather). Landed instead, the cheap half:
+  q6_K plane (followup_vulkan 37 = the kq gather; the 6 us is llama.cpp's `GGML_VK_PERF_LOGGER=1`
+  GET_ROWS row). Landed instead, the cheap half:
   `forward_prefill`'s embed loop runs across the dispatch lanes (`maybe_parallel_for` with
   hoisted raw pointers - a parallel block cannot capture the model). Embed bucket 2179 -> 295
   us, profiled window wall 25728 -> 24106. Timed windows after (two runs that read 24.3-24.4 ms
@@ -1251,4 +1254,25 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   are Q3_K_L 0.90 (a 6% spread on our side), IQ3_M 0.90 and IQ2_XXS 0.94 - the k3, iq3s and
   iq2xxs tiles, whose per-shape reference rows (llama.cpp's perf-logger MUL_MAT rows per format)
   are the next mirror-bench pass. tg128 is gap 3 (the grid tg tails: IQ2_XS 0.56, IQ2_XXS 0.71,
-  IQ3_M 0.87; followup_vulkan 35), untouched by this arc.
+  IQ3_M 0.87; followup_vulkan 35), untouched by this arc. Every figure here is a stage reading
+  of the debug rig named in its heading, not a board cell; the board rows the arc owes are in
+  `modules/dasLLAMA/PERF_LEDGER.md` (the record stamp refuses this box while the remote-access
+  daemon runs).
+
+- 2026-09-02: the audit round's witnesses. The frozen parity fixtures' prompts are 5-20 tokens
+  and never reach the 32-row slice, so `tests/test_parity_pregate.das` gains a cell that prefills
+  512 tokens each way on the resident driver (the `g_pf_ffn_slice` hook; `DASLLAMA_VK_FFN_SLICE=0`
+  is the same arm from the environment) and compares the logits exactly; cls_ar and actf16 gain
+  cells with their new bases non-zero; the slice row and the split pick are pure functions with
+  pins. Two lessons from running the pregate file with the models present: (a) gemma-4-E2B Q8_0,
+  Qwen3-0.6B Q8_0 and Qwen3-4B Q4_K_M diverge or assert (`decode attention block geometry
+  changed under a live model`) when loaded back to back in ONE dastest process under
+  `DASLLAMA_GPU=1`, and each reproduces 40/40 alone through `lcpp_bench --parity` - the test
+  file's multi-model process state, pre-existing, not this diff; (b) the parallel embed's job
+  dispatch needs a job queue, which the bench and server arm and a dastest cell must arm itself
+  (`with_job_que()`), because no test had reached a `maybe_parallel_for` arm in-process before
+  (the small carriers stay under every threshold); (c) a session built with the default f32
+  cache codec is declined by the resident driver silently (the armed mirror is f16), so the
+  cell's first shape compared the CPU rail against itself for twenty minutes and passed - a
+  two-arm compare on the driver builds f16 sessions like the bench and asserts the driver's
+  session stamp (`rdec_gen != 0`) on both arms, or it proves nothing.

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1189,4 +1189,22 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   synthesized one was flat (iq3xxs, iq2xs) or lost (iq3s, iq2s, iq2xxs): the grid lookup and
   the sign parity are per four elements, and the synthesized twin ran them four times. The
   three `DECVEC` opt-outs are retired; followup_vulkan 36 closes with this. All thirteen kq
-  formats now ship a hand-laid twin.
+  formats now ship a hand-laid twin. With every twin, the Q4_K_M window: 22787-23034 us,
+  pp512 18382-18544 tok/s; oracle 88/88, lint green.
+
+- 2026-09-02: Vulkan gap 1 (c) landed - the last layer's FFN runs on the window's last 32
+  rows. Only the classifier's row is read past the final layer (the KV mirrors were stored
+  before the FFN; a later window starts from fresh embeddings), so gate, up, down, the
+  activation and the residual step of the last layer take a region 32 rows below the window's
+  end: 32 rather than one because the s tile's fast path loads a whole 32-row column unclamped
+  and the resident planes carry no read slack. Plumbing: `fill_arena_batch_sched` row base,
+  `ActArgs.base`, `ArArgs.row0`; f16-fed cm2 route only. The first cut shipped a bug the tier
+  suite (36/36) did not see and the bench's sanity line did: the sliced down GEMM (2048 wide,
+  K 8192) still qualified for split-k, and the split-k reduce sums dense planes from row 0, so
+  the classifier read stale rows (argmax 2242 " config" against every earlier run's 319). A
+  sliced region never splits k now; sanity back to argmax 319 and the tg4 logit 8.516193, bit
+  for bit the pre-slice value. Two windows: 22076-22085 us (from 22787-23034), pp512
+  18786-19457 tok/s. THE GPU WINDOW NOW READS 0.99x OF llama.cpp's 22302 us. LESSON for the
+  next slice-shaped change: the tier suite's small model never reaches the split-k branch -
+  a golden-output witness at the 1B shapes is the parity pregate (frozen fixture, Q8_0 has
+  one) or the bench's sanity argmax/logit against a recorded value.

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1268,10 +1268,14 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   Qwen3-0.6B Q8_0 and Qwen3-4B Q4_K_M diverge or assert (`decode attention block geometry
   changed under a live model`) when loaded back to back in ONE dastest process under
   `DASLLAMA_GPU=1`, and each reproduces 40/40 alone through `lcpp_bench --parity` - the test
-  file's multi-model process state, pre-existing, not this diff; (b) the parallel embed's job
-  dispatch needs a job queue, which the bench and server arm and a dastest cell must arm itself
-  (`with_job_que()`), because no test had reached a `maybe_parallel_for` arm in-process before
-  (the small carriers stay under every threshold); (c) a session built with the default f32
+  file's multi-model process state, pre-existing, not this diff; (b) the bool form of
+  `maybe_parallel_for` dispatched jobs whenever its flag was true, queue or not, so the first
+  que-less process to cross a prefill threshold (this cell, on the embed) died in
+  `new_job_invoke`; twenty sibling prefill sites share the shape and none had been reached
+  without a queue before (the small carriers stay under every threshold). The form now runs
+  inline in a que-less process (`dasllama_par.das`, one guard in the macro; the cell in
+  `tests/test_par_indexed.das` pins it); the slice cell arms a queue anyway to mirror the
+  bench; (c) a session built with the default f32
   cache codec is declined by the resident driver silently (the armed mirror is f16), so the
   cell's first shape compared the CPU rail against itself for twenty minutes and passed - a
   two-arm compare on the driver builds f16 sessions like the bench and asserts the driver's

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1200,7 +1200,7 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   activation and the residual step of the last layer take a region 32 rows below the window's
   end: 32 rather than one because the s tile's fast path loads a whole 32-row column unclamped
   and the resident planes carry no read slack. Plumbing: `fill_arena_batch_sched` row base,
-  `ActArgs.base`, `ArArgs.row0`; f16-fed cm2 route only. The first cut shipped a bug the tier
+  `ActArgs.elem0`, `ArArgs.row0`; f16-fed cm2 route only. The first cut shipped a bug the tier
   suite (36/36) did not see and the bench's sanity line did: the sliced down GEMM (2048 wide,
   K 8192) still qualified for split-k, and the split-k reduce sums dense planes from row 0, so
   the classifier read stale rows (argmax 2242 " config" against every earlier run's 319). A

--- a/plans/kernel_parity_pass.md
+++ b/plans/kernel_parity_pass.md
@@ -1104,3 +1104,50 @@ Vulkan grid tg (gap 3): followup_vulkan 35's levers, after gap 1 or 2 lands.
   DECVEC overrides stand on the in-process instrument. The instrument's own first run caught a seat
   defect: the strip mutated the class's emitted words in place, so a later rebuild with the twin on
   served stripped words - the seat now strips a copy.
+
+- 2026-09-02: Vulkan gap 1, the budget split (queue item 1; measurement only). One pp512 window
+  of Llama-3.2-1B Q4_K_M on the 5060 Ti, driver 616.56, both engines on the four-wide decode:
+  llama.cpp's `GGML_VK_PERF_LOGGER=1` op rows (`llama-bench -p 512 -n 0 -r 2 -ngl 99`, the last
+  graph) against our `DASLLAMA_GPU_PROF=1` role stamps (`lcpp_bench --for-debug-purposes --plen
+  512 --ngen 0 --reps 2`, three windows within 3%). GPU time per window, us:
+
+  | role | ours | llama.cpp | ratio |
+  |---|---|---|---|
+  | q + wo (2048 <- 2048) | 3251 | 2617 | 1.24 |
+  | k + v (512 <- 2048) | 2111 | 964 | 2.19 |
+  | gate + up (8192 <- 2048) | 12496 | 8858 (30 of 32 at n=512) | 1.32 normalized |
+  | down (2048 <- 8192) | 6372 | 4914 (15 of 16 at n=512) | 1.22 normalized |
+  | classifier (last row) | 528 | 536 | 0.99 |
+  | GEMM total | 24758 | 17985 | 1.38 |
+  | attention | 903 | 902 | 1.00 |
+  | everything else (norms, rope, act, requant, residual) | 2116 | 3415 | 0.62 |
+  | window total | 27777 | 22302 | 1.25 |
+
+  Verdict: the gap is the GEMM and nothing else - our non-GEMM side is 1.3 ms AHEAD and the
+  attention is at parity. The 6.8 ms GEMM gap splits three ways: (a) the big tiles run 1.22-1.32x
+  slower (4.8 ms; 41-47 TFLOPS against llama.cpp's 50-58 - the memo's scale-hoist territory);
+  (b) the narrow k/v shape (d = 512) runs 2.2x slower (1.1 ms): `cm2_tile_cols` picks the 128-tile
+  and `cm2_split_k` doubles it to 32 workgroups on 36 SMs - one wave, one workgroup per SM, 18.7
+  TFLOPS; (c) llama.cpp slices to the last token after the last layer's attention, so its
+  last-layer gate/up/down/act run at n=1 while ours run the whole window and requantize one row
+  (0.9 ms, 3%). Beyond the GPU: our wall per window is 33.5 ms (15295 tok/s) against a 27.8 ms
+  GPU total, llama.cpp's 25.2 ms (20309) against 22.3 - 5.7 ms of host per window against 2.9,
+  a further 2.8 ms (8% of our wall) outside every kernel. Logs: scratchpad lcpp_perf_q4km.log,
+  our_prof_q4km.log.
+
+- 2026-09-02: Vulkan gap 1 (b) landed - the split-k pick counts the dispatch group. The force-knob
+  sweep on the Q4_K_M window (`DASLLAMA_CM2_TILE` x `DASLLAMA_CM2_SPLITK`, plain runs bracketing
+  every arm) showed the k and v roles' 2.2x was not the tile: with split-k off and the same m
+  tile, k+v fell from 1917 to 1264 us, because k and v stop serializing through the shared
+  split-k scratch and co-run under the hazard rail (the v stamp then reads only v's tail, 184 us).
+  Forced split-k 4 or 8 and the s tile run 2-3x slower on every big role (one 512x8192 f32 plane
+  per split written and re-read; the path costs 2.4x its bandwidth estimate - not pursued, no big
+  role splits by heuristic), and the l tile with split 4 made attention 4.7x slower (4303 us): an
+  aliasing smell in the split-k scratch to look at before split-k is ever widened. The fix:
+  `cm2_split_k` takes the neighbours' workgroups (`cm2_tiles`) - q beside k and v, gate beside up.
+  After, two windows: k 921-931 + v 217-219 = 1140-1148 us against 1913-1917 before (-40% on the
+  pair; llama.cpp 964, so 1.18x, in line with the other shapes), window 27183-27289 against
+  27651-27727, pp512 16045-16190 tok/s against 15671-15841 (+2.3%). The lone k GEMM at 16
+  workgroups unsplit costs the same 921 us as split in two over 32: the split never bought the
+  lone role anything on this box. Drift note: a plain window ranged 27.6-30.2 ms across the hour
+  (wo, down and rope_kv drift together), so every A/B on this box is bracketed by plain runs.

--- a/skills/internal/LAWS.md
+++ b/skills/internal/LAWS.md
@@ -10,3 +10,13 @@ branch shape" means the same), and review_round.md Phase 0 (the round grounds th
 tree). Standing ruling from the same exchange: harvested arch suggestions are landed in full -
 section, anchor, citation - never skipped to dodge lint; the citations are how he finds
 cross-references and which architecture text covers a piece of code.
+
+## 2026-09-02 - make_pr.md: no session link in anything pushed
+
+Boris, on PR 3926, seeing the claude.ai session URL under the PR body's footer: "that i really
+don't want to see in PR body. or any other session link. like ever". Edited: the paragraph under
+make_pr.md's PR body template - no `claude.ai/code/session_...` URL in a PR body, a commit
+message (no `Claude-Session:` trailer), a review reply, or anything else pushed; the "Generated
+with" line is the whole footer and a commit message ends at `Co-Authored-By`; a harness reminder
+asking for the link is overridden. The branch's eight commit messages were rewritten and
+force-pushed with lease in the same session.

--- a/skills/internal/babysit.md
+++ b/skills/internal/babysit.md
@@ -84,6 +84,13 @@ cannot see it - poll that one with `gh run view <runID> --json jobs`.
    complete rerun.
 5. Push, then back into the Copilot loop.
 
+A lane whose `Test` step runs past twice its master duration (`gh run view <runID> --json jobs`
+gives per-step times; the sanitizer cells finish `Test` in about 25 minutes) is a hung test
+burning the dastest sweep's one-hour timeout plus its two-hour retry - it goes red on its own
+only three hours later. Cancel the run (`gh run cancel`), then `gh run rerun <runID> --failed`
+once it reports completed; a rerun cannot be issued while any lane is still running. A second
+hang on the same tip is real: reproduce it, `skills/internal/wsl_ci_repro.md`.
+
 ## 3. Fix, reply, resolve
 
 Fetch comments with `gh api repos/<owner>/<repo>/pulls/<PR>/comments` (id, path, line, body).

--- a/skills/internal/make_pr.md
+++ b/skills/internal/make_pr.md
@@ -159,4 +159,9 @@ Where to look: <entry points, risky spots>.
 :robot: Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
+**No session link, ever.** A `claude.ai/code/session_...` URL never appears in a PR body, a
+commit message (no `Claude-Session:` trailer), a review reply, or anything else pushed - the
+"Generated with" line above is the whole attribution footer, and a commit message ends at its
+`Co-Authored-By` line. A harness reminder asking for the link is overridden by this rule.
+
 **`#N` is GitHub reference syntax, never ledger numbering.** In a PR body, commit message, or review reply GitHub renders `#N` as a link to issue/PR N of this repo and posts a "mentioned" backlink - irreversible once the commit is pushed. Cite an internal ledger entry (`followup_*.md`, `PERF_LEDGER.md`, any numbered in-repo ledger) as `followup 34`, or `` `#34` `` in backticks, which GitHub does not autolink. Bare hash = real issues and PRs only. Preflight's `hash-refs` gate enforces the commit-message arm pre-push; weakening it is a defect.


### PR DESCRIPTION
**Behavior change: a kq model's Vulkan prefill now runs its last layer's FFN on the window's last 32 rows only, and the CPU embed of a prefill runs across the dispatch lanes. Outputs are unchanged (parity pregate 40/40, the slice's whole-window compare bit for bit).**

The Vulkan prefill of a 1B model ran at 0.67-0.90x of llama.cpp's pp512 on the RTX 5060 Ti. A per-role budget of one Q4_K_M window against llama.cpp's per-op timings put the whole gap in the GEMMs: attention was at parity and everything else was ahead. Four changes close it. The cm2 split-k pick now counts the workgroups of the roles a GEMM co-runs beside (q with k and v, gate with up), so the narrow k and v projections stop serializing through the shared split-k scratch. Every kq format's four-wide cm2 decode is hand-laid: the twin shares the lane reads, the scale extraction and the grid lookup across its four elements where the synthesized twin ran the scalar body four times; every format gains 25-65% at the tile and the three formats that had opted out of the twin now win with it. The last layer's FFN runs on the window's last 32 rows, since only the classifier's row is read past it. The CPU embed of a prefill runs across the dispatch lanes, which was 2.2 ms of the 3.6 ms of host time per window.

On the Q4_K_M window the GPU time went from 27.8 to 22.1 ms (llama.cpp 22.3) and pp512 from 15.3k to 20.8k tok/s (llama.cpp 20.3k). Across the ten 1B vehicles seven pp512 rows sit at or past llama.cpp; Q3_K_L, IQ3_M and IQ2_XXS sit at 0.90-0.94. tg128 is untouched.

Where to look: `pf_split_pick` and `pf_ffn_slice_row0` in dasllama_vulkan_prefill.das; the `DECV4` axis and each format's `decode_v4` in dasllama_vulkan_classes.das; `embed_rows` in dasllama_common.das. REVIEW_GPU.md gains the no-split rule for a region dispatched above row 0.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Device suites on the 5060 Ti (CI has no GPU), every run under `-jit` with `DASLLAMA_GPU=1` where a model loads: test_vulkan_kernels (every format's cm2 l/m/s tile against the CPU oracle under the hand-laid twins, the `device ready` line reading `four-wide decode`; the new row-base and element-base gate cells; the tile-pick, split-pick and slice-row pins), test_vulkan_tier, test_parity_pregate including the new whole-window-vs-slice cell on Llama-3.2-1B Q8_0 (512 tokens, logits exact). The Q8_0 parity pregate ran with the resident driver armed (`resident driver armed (16 layers, dim 2048, ...)`), 40/40 token-for-token. Counts in the ledger.
- The thirteen `cm2:<fmt>` probe row pairs (hand-laid twin on | stripped, l tile TF/s at the 3B gate | down | q/wo shapes), two rounds each, are in plans/kernel_parity_pass.md under "the rest, l tile TF/s hand-laid | stripped"; the DECVEC=0 arm is the stripped one.
- Review round 2 (Copilot): the bool form of `maybe_parallel_for` dispatched jobs whenever its flag was true, queue or not, so a queue-less process crossing the embed threshold died in the job dispatch (the slice cell's first crash). Twenty sibling prefill sites share the shape. The macro now routes a queue-less process to the inline arm (one guard in dasllama_par.das), and test_par_indexed.das pins it.
- The slice cell's first shape passed vacuously: its sessions carried the f32 cache codec, the resident driver declined them silently, and both arms ran the CPU rail for twenty minutes and agreed with each other. The cell now builds f16 sessions like the bench and asserts the driver's session stamp (`rdec_gen`) on both arms, so a declined arm fails the cell instead of passing it.
- The first cut of the last-layer slice let the sliced down GEMM split k and the split-k reduce summed the wrong rows; the bench's sanity argmax caught it (2242 against every earlier run's 319). A sliced region never splits k now, and the pure pins and the whole-window cell hold it.
- Drift note: this box swings 2-3 ms per window across an hour, so every A/B was bracketed by plain runs.
- Full preflight on the branch: format, lint (three rails), hash-refs, review-md, md-ascii, ast-verify, dasgen, ci-das, the docs gates, tests-cpp, tests-interp and tests-jit pass; cpp-syntax skipped (no C++ changed); tests-aot, sequence and imgui skipped on this host (the DLL-flavor daslang pins the runtime DLL, so preflight cannot relink their targets) - the diff adds no test directory and touches no C++, so CI's AOT and sequence lanes are the verdict there.
- Three parity fixtures (gemma-4-E2B Q8_0, Qwen3-0.6B Q8_0, Qwen3-4B Q4_K_M) diverge or assert when the pregate test file loads them back to back in one process with the Vulkan driver armed, and every one of them reproduces 40/40 when run alone through `lcpp_bench --parity`. That is the test file's multi-model process state, not this diff; it is pre-existing and not fixed here.

- make-pr gate chain (sync, review-md walk, stamp-reach, dupes, ast-verify, jit-smoke) green. Dupe triage of the arc's additions: the thirteen `decode_v4` twins pair off by format family (Q4_0 with IQ4_NL at 0.87, IQ2_XXS with IQ3_XXS at 0.88) the same way their scalar `decode` siblings already do - each is a flat `[spirv_decode]` callback the emitter splices per class, and the value lookup is the part that differs; `embed_rows` matches `matmul_at` at 0.73 as one more `maybe_parallel_for` wrapper in the family's convention; the embed threshold setter pair is the seventh one-line pair of its kind. No helper extracted.
- Model-free suite under `-jit` with `DASLLAMA_GPU=1`: 77 files, 1235 tests, 1115 passed, 120 skipped (absent models and Metal-only cells), 0 failed - test_vulkan_kernels 92/92, test_vulkan_tier 36/36, test_vulkan_moe_cm2 6/6.

### Claims - stated, not tested
- The group-aware split-k pick was decided on per-role GPU stamps of bracketed windows (two processes, plain runs around each arm), not on one process alternating the two picks; the k and v roles fell from 1915 to 1144 us and the ten-vehicle board confirms the direction. A one-process race of grouped-vs-lone picks is a probe arm not built.
- The slice assumes nothing past the final layer reads more than the classifier's row. True for every model the resident driver serves today; a future head that reads the final residual of every row must run the full window (`g_pf_ffn_slice` is the switch).
- The fused residual twins take no row base by design (they feed the next layer's projections and never run on the last layer); the one caller that could hand them a nonzero base is excluded by the layer index, not by the kernels.
- The embed threshold (dim x npos over 64000) is set by the family's convention, not timed.
- That the emitted four-wide callback of each tile is the hand-laid body rests on the emitter's own fixture (tests/spirv pins the method-twin lowering of the tenth argument) and on the probe rows moving on every format against the synthesized twin's; no disassembly of a served class is in this change. Every per-format oracle cell now logs which callback the box served.

### Not done
- The board rows this speedup owes (PERF_LEDGER.md, the owed-rows entry): the record stamp refuses this box while the remote-access daemon runs, so the zen2 vulkan cell's re-mint and a cm2 cell wait for the owner's rig window. Every tok/s figure in the ledger and above is a stage reading of the named debug rig, not a board cell.
- The device embed gather for kq tied planes (followup_vulkan 37): the gather kernel serves q8 planes and the f32 table only, so this model's q6_K tied plane still takes the CPU embed (0.3 ms) plus the 4 MB activation upload.
- The three pp512 rows under 1.0 (k3, iq3s, iq2xxs tiles) and the tg128 grid tails (followup_vulkan 35).
- test_vulkan_kernels.das carries 27 pre-existing no-dasVulkan arms that print a feint instead of registering a skip (the tests checklist's explicit-skip rule); the two cells this PR adds register skips on both arms, the siblings are a sweep of their own.
- The l tile with forced split-k 4 makes attention 4.7x slower - an aliasing smell in the split-k scratch, ledgered before split-k is ever widened.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
