### PR TITLE
is_nan / is_finite answer IEEE under fast math (clang 17+ nofpclass, GCC optimize attribute, options fast_math regions)

### DIFF
--- a/include/daScript/simulate/aot.h
+++ b/include/daScript/simulate/aot.h
@@ -28,10 +28,10 @@
 #endif
 
 // options fast_math: per-function fast-math region emitted by the AOT compiler
-// (daslib/aot_cpp.das) around every function of a fast_math program. float_control
-// guards mirror aot_builtin_math.h: clang only outside arm64/e2k/Nintendo, and not
-// on the versions where float_control is broken (<12, 17-18.1). Where no relaxed
-// mode is known-safe the macros are empty and the function stays precise.
+// (daslib/aot_cpp.das) around every function of a fast_math program. float_control is
+// used on clang only outside arm64/e2k/Nintendo, and not on the versions where it is
+// broken (<12, 17-18.1). Where no relaxed mode is known-safe the macros are empty and
+// the function stays precise.
 #if defined(__GNUC__) && !defined(__clang__)
 #define DAS_FAST_MATH_PUSH \
     _Pragma("GCC push_options") \

--- a/include/daScript/simulate/aot_builtin_math.h
+++ b/include/daScript/simulate/aot_builtin_math.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <dag_noise/dag_uint_noise.h>
-#if (__clang_major__ < 12 || (__clang_major__ >= 17 && __clang_major__ <= 18)) && defined(__clang__) && defined(__FAST_MATH__)
+#if defined(__GNUC__) || defined(__clang__)
 #include <cstring> // memcpy
-#include <cmath> // INFINITY
+#include <cstdint>
 #endif
 
 namespace das {
@@ -101,47 +101,32 @@ namespace das {
     __forceinline vec4f degrees_vec(vec4f rad) { return v_mul(rad, v_splats(180.0f / 3.14159265358979323846f)); }
 
 #if defined(__GNUC__) || defined(__clang__)
-#if !defined(__clang__)
-#define DAS_FINITE_MATH __attribute__((optimize("no-finite-math-only")))
-#else
-#define DAS_FINITE_MATH
-#endif
-#if defined(__clang__) && !defined(__arm64__) && !defined(__e2k__) && !defined(__NINTENDO__)
-#pragma float_control(push)
-#pragma float_control(precise, on)
-#endif
-#if (__clang_major__ < 12 || (__clang_major__ >= 17 && __clang_major__ <= 18)) && defined(__clang__) && defined(__FAST_MATH__)
-    //unfortunately older clang versions do not work with float_control, and in clang 17-18.1 it's broken
-    __forceinline DAS_FINITE_MATH bool   fisnan(float  a) { volatile float b = a; return b != a; }
-    __forceinline DAS_FINITE_MATH bool   disnan(double  a) { volatile double b = a; return b != a; }
-    __forceinline DAS_FINITE_MATH bool   fisfinite(float a)
-    {
-      uint32_t i;
-      memcpy(&i, &a, sizeof(a));
-      i &= ~(1 << 31);
-      memcpy(&a, &i, sizeof(a));
-      static volatile float inf = INFINITY;
-      return a != inf;
+    // A finite-math build folds the builtins, and clang 17+ marks every float parameter
+    // nofpclass(nan inf), which folds a plain exponent test too; no pragma or attribute lifts
+    // that from a parameter. A precise build is not safe either: an inlined builtin folds
+    // inside the fast-math region aot.h emits around every `options fast_math` function.
+    // The volatile copy launders the value in every build; the exponent test is integer
+    // math, which fast math leaves alone. Gated by tests-cpp/small/test_isnan_fastmath*.cpp.
+    __forceinline bool fisnan(float a) {
+        volatile float vb = a; float b = vb;
+        uint32_t i; memcpy(&i, &b, sizeof(b));
+        return (i & 0x7F800000u) == 0x7F800000u && (i & 0x007FFFFFu) != 0u;
     }
-    __forceinline DAS_FINITE_MATH bool   disfinite(double a)
-    {
-      uint64_t i;
-      memcpy(&i, &a, sizeof(a));
-      i &= ~(1ull << 63);
-      memcpy(&a, &i, sizeof(a));
-      static volatile double inf = INFINITY;
-      return a != inf;
+    __forceinline bool disnan(double a) {
+        volatile double vb = a; double b = vb;
+        uint64_t i; memcpy(&i, &b, sizeof(b));
+        return (i & 0x7FF0000000000000ull) == 0x7FF0000000000000ull && (i & 0x000FFFFFFFFFFFFFull) != 0ull;
     }
-#else
-    ___noinline DAS_FINITE_MATH inline bool   fisnan(float  a) { return __builtin_isnan(a); }
-    ___noinline DAS_FINITE_MATH inline bool   disnan(double  a) { return __builtin_isnan(a); }
-    ___noinline DAS_FINITE_MATH inline bool   fisfinite(float  a) { return __builtin_isfinite(a); }
-    ___noinline DAS_FINITE_MATH inline bool   disfinite(double  a) { return __builtin_isfinite(a); }
-#endif
-#undef DAS_FINITE_MATH
-#if defined(__clang__) && !defined(__arm64__) && !defined(__e2k__) && !defined(__NINTENDO__)
-#pragma float_control(pop)
-#endif
+    __forceinline bool fisfinite(float a) {
+        volatile float vb = a; float b = vb;
+        uint32_t i; memcpy(&i, &b, sizeof(b));
+        return (i & 0x7F800000u) != 0x7F800000u;
+    }
+    __forceinline bool disfinite(double a) {
+        volatile double vb = a; double b = vb;
+        uint64_t i; memcpy(&i, &b, sizeof(b));
+        return (i & 0x7FF0000000000000ull) != 0x7FF0000000000000ull;
+    }
 #else
     //msvc just does not optimize fast math
     __forceinline bool   fisfinite(float  a) { return isfinite(a); }

--- a/tests-cpp/CMakeLists.txt
+++ b/tests-cpp/CMakeLists.txt
@@ -18,6 +18,15 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/doctest/doctest.cmake)
 # Glob `test_*.cpp` (not `*.cpp`) to skip editor temp files (`.#foo.cpp`, `foo.cpp~`).
 file(GLOB SMALL_SOURCES CONFIGURE_DEPENDS small/test_*.cpp)
 
+# One TU is built the way an embedder builds the runtime - fast math on - so the is_nan /
+# is_finite helpers are gated under the flag that folds them. MSVC is TRUE for clang-cl too.
+if(MSVC)
+    set(DAS_FAST_MATH_FLAG /fp:fast)
+else()
+    set(DAS_FAST_MATH_FLAG -ffast-math)
+endif()
+set_source_files_properties(small/test_isnan_fastmath.cpp PROPERTIES COMPILE_OPTIONS ${DAS_FAST_MATH_FLAG})
+
 add_executable(tests-cpp-small doctest_main.cpp ${SMALL_SOURCES})
 target_link_libraries(tests-cpp-small PRIVATE
     doctest libDaScript ${SRC_LIBRARIES} ${DAS_MODULES_LIBS})

--- a/tests-cpp/small/test_isnan_fastmath.cpp
+++ b/tests-cpp/small/test_isnan_fastmath.cpp
@@ -1,0 +1,55 @@
+// This TU is compiled with the host's fast-math flag (tests-cpp/CMakeLists.txt sets it per
+// source): is_nan / is_finite answer IEEE even in a runtime built -ffast-math / -fp:fast.
+// Without the flag the test would pass precise and prove nothing, so its absence is an error.
+#if !defined(__FAST_MATH__) && !defined(_M_FP_FAST)
+#error "test_isnan_fastmath.cpp must be compiled with -ffast-math / /fp:fast (tests-cpp/CMakeLists.txt)"
+#endif
+#include <doctest/doctest.h>
+#include "daScript/misc/platform.h"
+#include "daScript/misc/vectypes.h"
+
+// The header's precise path defines these `inline`, and the executable also links
+// libDaScript: the linker keeps ONE copy per name, so without unique names this TU would
+// silently test the precise copy from module_builtin_math.cpp.
+#define fisnan    fisnan_fast_math_tu
+#define disnan    disnan_fast_math_tu
+#define fisfinite fisfinite_fast_math_tu
+#define disfinite disfinite_fast_math_tu
+#include "daScript/simulate/aot_builtin_math.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace {
+    // bit patterns, not arithmetic: nothing here is a float operation the compiler could fold
+    // (prefixed: glibc's <math.h> defines SNAN and friends as macros)
+    enum { PAT_QNAN, PAT_NEG_QNAN, PAT_SNAN, PAT_INF, PAT_NEG_INF, PAT_MAX_FINITE, PAT_DENORMAL, PAT_TWO_AND_HALF, PAT_NEG_ZERO, COUNT };
+
+    volatile uint32_t fbits[COUNT] = {
+        0x7FC00000u, 0xFFC00000u, 0x7F800001u, 0x7F800000u, 0xFF800000u,
+        0x7F7FFFFFu, 0x00000001u, 0x40200000u, 0x80000000u,
+    };
+    volatile uint64_t dbits[COUNT] = {
+        0x7FF8000000000000ull, 0xFFF8000000000000ull, 0x7FF0000000000001ull, 0x7FF0000000000000ull, 0xFFF0000000000000ull,
+        0x7FEFFFFFFFFFFFFFull, 0x0000000000000001ull, 0x4004000000000000ull, 0x8000000000000000ull,
+    };
+
+    const bool expect_nan[COUNT]    = { true,  true,  true,  false, false, false, false, false, false };
+    const bool expect_finite[COUNT] = { false, false, false, false, false, true,  true,  true,  true  };
+}
+
+TEST_CASE("is_nan / is_finite honor IEEE under the host's fast-math flag") {
+    float f[COUNT];
+    double d[COUNT];
+    for (int i = 0; i != COUNT; ++i) {
+        uint32_t fb = fbits[i]; memcpy(&f[i], &fb, sizeof(fb));
+        uint64_t db = dbits[i]; memcpy(&d[i], &db, sizeof(db));
+    }
+    for (int i = 0; i != COUNT; ++i) {
+        INFO("pattern index ", i);
+        CHECK_EQ(das::fisnan(f[i]), expect_nan[i]);
+        CHECK_EQ(das::disnan(d[i]), expect_nan[i]);
+        CHECK_EQ(das::fisfinite(f[i]), expect_finite[i]);
+        CHECK_EQ(das::disfinite(d[i]), expect_finite[i]);
+    }
+}

--- a/tests-cpp/small/test_isnan_fastmath_region.cpp
+++ b/tests-cpp/small/test_isnan_fastmath_region.cpp
@@ -1,0 +1,70 @@
+// A precise TU whose checks sit inside the per-function fast-math region the AOT emitter
+// puts around every function of an `options fast_math` program (DAS_FAST_MATH_PUSH/POP in
+// aot.h): is_nan / is_finite still answer IEEE there, on bit-built values.
+#if defined(__FAST_MATH__) || defined(_M_FP_FAST)
+#error "test_isnan_fastmath_region.cpp is the precise-TU half; the fast-math TU is test_isnan_fastmath.cpp"
+#endif
+#include <doctest/doctest.h>
+#include "daScript/misc/platform.h"
+#include "daScript/simulate/simulate.h"
+#include "daScript/simulate/aot.h"
+
+// The header's helpers are `inline`, and the executable also links libDaScript: the linker
+// keeps ONE copy per name, so without unique names this TU could test another TU's copy.
+#define fisnan    fisnan_fast_math_region_tu
+#define disnan    disnan_fast_math_region_tu
+#define fisfinite fisfinite_fast_math_region_tu
+#define disfinite disfinite_fast_math_region_tu
+#include "daScript/simulate/aot_builtin_math.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace {
+    // prefixed: glibc's <math.h> defines SNAN and friends as macros
+    enum { PAT_QNAN, PAT_NEG_QNAN, PAT_SNAN, PAT_INF, PAT_NEG_INF, PAT_MAX_FINITE, PAT_DENORMAL, PAT_TWO_AND_HALF, PAT_NEG_ZERO, COUNT };
+
+    volatile uint32_t fbits[COUNT] = {
+        0x7FC00000u, 0xFFC00000u, 0x7F800001u, 0x7F800000u, 0xFF800000u,
+        0x7F7FFFFFu, 0x00000001u, 0x40200000u, 0x80000000u,
+    };
+    volatile uint64_t dbits[COUNT] = {
+        0x7FF8000000000000ull, 0xFFF8000000000000ull, 0x7FF0000000000001ull, 0x7FF0000000000000ull, 0xFFF0000000000000ull,
+        0x7FEFFFFFFFFFFFFFull, 0x0000000000000001ull, 0x4004000000000000ull, 0x8000000000000000ull,
+    };
+
+    const bool expect_nan[COUNT]    = { true,  true,  true,  false, false, false, false, false, false };
+    const bool expect_finite[COUNT] = { false, false, false, false, false, true,  true,  true,  true  };
+
+    struct Answers { bool fnan[COUNT], dnan[COUNT], ffinite[COUNT], dfinite[COUNT]; };
+
+    DAS_FAST_MATH_PUSH
+    Answers classify_inside_fast_math_region() {
+        float f[COUNT];
+        double d[COUNT];
+        for (int i = 0; i != COUNT; ++i) {
+            uint32_t fb = fbits[i]; memcpy(&f[i], &fb, sizeof(fb));
+            uint64_t db = dbits[i]; memcpy(&d[i], &db, sizeof(db));
+        }
+        Answers a;
+        for (int i = 0; i != COUNT; ++i) {
+            a.fnan[i] = das::fisnan(f[i]);
+            a.dnan[i] = das::disnan(d[i]);
+            a.ffinite[i] = das::fisfinite(f[i]);
+            a.dfinite[i] = das::disfinite(d[i]);
+        }
+        return a;
+    }
+    DAS_FAST_MATH_POP
+}
+
+TEST_CASE("is_nan / is_finite honor IEEE inside an options fast_math AOT region") {
+    const Answers a = classify_inside_fast_math_region();
+    for (int i = 0; i != COUNT; ++i) {
+        INFO("pattern index ", i);
+        CHECK_EQ(a.fnan[i], expect_nan[i]);
+        CHECK_EQ(a.dnan[i], expect_nan[i]);
+        CHECK_EQ(a.ffinite[i], expect_finite[i]);
+        CHECK_EQ(a.dfinite[i], expect_finite[i]);
+    }
+}

--- a/tests/daslib/test_toml.das
+++ b/tests/daslib/test_toml.das
@@ -5,7 +5,6 @@ require daslib/toml
 require daslib/json
 require daslib/json_boost   // ?["key"] ?? default lookups in the write_toml round-trip checks
 require daslib/math_bits
-require math            // is_finite / is_nan, for the finite-math host probe below
 require strings
 
 // IEEE-754 bit-pattern constants, same as daslib/toml.das uses internally —
@@ -223,17 +222,24 @@ def test_array_of_tables(t : T?) {
     }
 }
 
-// A host built -ffinite-math-only folds is_nan/is_finite and the nan compares, so a nan
-// round-trip cannot be observed there - the three tests below skip on such a host.
-def private host_folds_non_finite() : bool {
-    let inf = 1.0 / 0.0     // nolint:LINT006 — deliberate: the probe needs a real inf
-    return is_finite(inf) || !is_nan(-(inf / inf))  // nolint:LINT007 — inf/inf is how a nan is produced here
+[sideeffects]
+def private opaque(x : double) : double {
+    return x
+}
+
+// A host built -ffinite-math-only folds the nan compares the three tests below rely on, so
+// they skip there. The probe is a compare, never is_nan: is_nan / is_finite answer IEEE on
+// every host (tests/math/inf_and_nan.das holds them to it).
+def private host_folds_nan_compares() : bool {
+    let a = opaque(uint64_bits_to_double(0x7FF8000000000000ul))
+    let b = opaque(uint64_bits_to_double(0x7FF8000000000000ul))
+    return a == b || !(a != b)
 }
 
 [test]
 def test_inf_nan(t : T?) {
-    if (host_folds_non_finite()) {
-        t |> skip("host runtime is built -ffinite-math-only: nan/inf values fold")
+    if (host_folds_nan_compares()) {
+        t |> skip("host runtime is built -ffinite-math-only: nan compares fold")
         return
     }
 
@@ -335,8 +341,8 @@ def test_alphanum_bare_key(t : T?) {
 
 [test]
 def test_inf_nan_still_work_as_values(t : T?) {
-    if (host_folds_non_finite()) {
-        t |> skip("host runtime is built -ffinite-math-only: nan/inf values fold")
+    if (host_folds_nan_compares()) {
+        t |> skip("host runtime is built -ffinite-math-only: nan compares fold")
         return
     }
 
@@ -689,8 +695,8 @@ def test_write_toml_tiny_huge_floats(t : T?) {
 
 [test]
 def test_write_toml_non_finite(t : T?) {
-    if (host_folds_non_finite()) {
-        t |> skip("host runtime is built -ffinite-math-only: nan/inf values fold")
+    if (host_folds_nan_compares()) {
+        t |> skip("host runtime is built -ffinite-math-only: nan compares fold")
         return
     }
 

--- a/tests/math/inf_and_nan.das
+++ b/tests/math/inf_and_nan.das
@@ -7,11 +7,14 @@ let neg_inf = -1.0 / 0.0    // nolint:LINT006
 let neg_nan = inf / inf     // nolint:LINT007 — inf/inf is how a nan is produced here
 let nan = -(inf / inf)      // nolint:LINT007
 
-// A host may build the runtime with -ffinite-math-only (dagor does). That folds the
-// is_finite / is_nan builtins and every nan comparison to a constant, so the IEEE
-// semantics below are not the ones that host asked for - detect it and skip.
-def private host_folds_non_finite() : bool {
-    return is_finite(inf) || !is_nan(nan)
+// A host may build the runtime with -ffinite-math-only (dagor does). That folds every nan
+// comparison to a constant, so the compare semantics below are not the ones that host
+// asked for - detect it and skip. is_nan / is_finite are exempt: they answer IEEE on every
+// host (test_is_nan_and_is_finite_hold_on_every_host), so the probe is a compare, never is_nan.
+def private host_folds_nan_compares() : bool {
+    let a = opaque(unsafe(reinterpret<double>(0x7FF8000000000000ul)))
+    let b = opaque(unsafe(reinterpret<double>(0x7FF8000000000000ul)))
+    return a == b || !(a != b)
 }
 
 [sideeffects]
@@ -76,8 +79,8 @@ def test_abs_clears_the_sign_of_zero(t : T?) {
 
 [test]
 def test_inf_and_nan(t : T?) {
-    if (host_folds_non_finite()) {
-        t |> skip("host runtime is built -ffinite-math-only: is_finite/is_nan and nan compares fold")
+    if (host_folds_nan_compares()) {
+        t |> skip("host runtime is built -ffinite-math-only: nan compares fold")
         return
     }
     t |> run("inf and neg inf") @@(t : T?) {
@@ -138,6 +141,51 @@ def test_inf_and_nan(t : T?) {
         t |> success(!geq(nan, 1.))
         t |> success(!geq(inf, nan))
         t |> success(!geq(nan, inf))
+    }
+}
+
+// bit-built values, so no arithmetic a finite-math host could fold; this test never skips
+[test]
+def test_is_nan_and_is_finite_hold_on_every_host(t : T?) {
+    t |> run("float") @@(t : T?) {
+        let fnan = opaque(unsafe(reinterpret<float>(0x7FC00000u)))
+        let fneg_nan = opaque(unsafe(reinterpret<float>(0xFFC00000u)))
+        let finf = opaque(unsafe(reinterpret<float>(0x7F800000u)))
+        let fneg_inf = opaque(unsafe(reinterpret<float>(0xFF800000u)))
+        let fmax = opaque(unsafe(reinterpret<float>(0x7F7FFFFFu)))
+        let fone = opaque(1.0f)
+        t |> success(is_nan(fnan))
+        t |> success(is_nan(fneg_nan))
+        t |> success(!is_nan(finf))
+        t |> success(!is_nan(fneg_inf))
+        t |> success(!is_nan(fmax))
+        t |> success(!is_nan(fone))
+        t |> success(!is_finite(fnan))
+        t |> success(!is_finite(fneg_nan))
+        t |> success(!is_finite(finf))
+        t |> success(!is_finite(fneg_inf))
+        t |> success(is_finite(fmax))
+        t |> success(is_finite(fone))
+    }
+    t |> run("double") @@(t : T?) {
+        let dnan = opaque(unsafe(reinterpret<double>(0x7FF8000000000000ul)))
+        let dneg_nan = opaque(unsafe(reinterpret<double>(0xFFF8000000000000ul)))
+        let dinf = opaque(unsafe(reinterpret<double>(0x7FF0000000000000ul)))
+        let dneg_inf = opaque(unsafe(reinterpret<double>(0xFFF0000000000000ul)))
+        let dmax = opaque(unsafe(reinterpret<double>(0x7FEFFFFFFFFFFFFFul)))
+        let done = opaque(1.0lf)
+        t |> success(is_nan(dnan))
+        t |> success(is_nan(dneg_nan))
+        t |> success(!is_nan(dinf))
+        t |> success(!is_nan(dneg_inf))
+        t |> success(!is_nan(dmax))
+        t |> success(!is_nan(done))
+        t |> success(!is_finite(dnan))
+        t |> success(!is_finite(dneg_nan))
+        t |> success(!is_finite(dinf))
+        t |> success(!is_finite(dneg_inf))
+        t |> success(is_finite(dmax))
+        t |> success(is_finite(done))
     }
 }
 


### PR DESCRIPTION
**Behavior change: `is_nan` and `is_finite` now answer IEEE in a runtime or AOT unit built with fast math (`-ffast-math`, `-ffinite-math-only`, clang-cl `-fp:fast`), and inside `options fast_math` AOT functions. No rebuild is required beyond picking up the header.**

A host that builds daslang with clang 17 or newer and fast math got `is_nan(nan) == false` and `is_finite(inf) == true`. The builtins fold under finite-math-only, and clang marks every float parameter `nofpclass(nan inf)`, so even a plain exponent test on the argument folds; `float_control(precise, on)` restores NaN handling for a function body but cannot lift the attribute from a parameter, which is why the old clang 17-18 special case did not help on 19 and later. GCC was also wrong: under `-ffinite-math-only` its `optimize("no-finite-math-only")` attribute keeps `is_nan` right but leaves `is_finite(nan)` true. And a precise runtime was not safe either once the helpers inline: the AOT emitter wraps every function of an `options fast_math` program in a GCC `optimize("fast-math")` region, and an inlined `__builtin_isnan` folds there.

The four helpers in `aot_builtin_math.h` are now one implementation on GCC and clang in every build: a `volatile` copy of the argument, then an integer test of the exponent field. The copy launders whatever the compiler believes about the value; the test is integer math, which fast math does not touch. MSVC keeps `isnan` / `isfinite`, which it does not fold. The precise-build cost moves from a `noinline` call per query to an inlined store, load, and two integer ops with no call, so the shipped build gets cheaper, not dearer.

Two tests skipped on exactly this bug: `tests/math/inf_and_nan.das` and three cases in `tests/daslib/test_toml.das` probed `is_finite(inf) || !is_nan(nan)` and called a hit "the host's own configuration". The probe is now a NaN compare on bit-built values (the compare really does fold on such a host; the two queries must not), and `inf_and_nan.das` gains a test of `is_nan` / `is_finite` on bit-built values that never skips.

Where to look: `include/daScript/simulate/aot_builtin_math.h` (the four helpers), `tests-cpp/small/test_isnan_fastmath.cpp` (a TU compiled per-source with `-ffast-math` / `/fp:fast`) and `tests-cpp/small/test_isnan_fastmath_region.cpp` (a precise TU with the checks inside `DAS_FAST_MATH_PUSH`). Both TUs rename the helpers through `#define` before the include, because the executable also links libDaScript and the linker keeps one copy per `inline` name; without the rename the fast-math TU was observed passing against the precise copy.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Standalone repro (bit-built nan/inf/finite through the real header), old header vs this one. Old header wrong cells / new header wrong cells, whole TU under fast math: clang-cl 21.1.8 `-fp:fast` on Windows 6/0, Homebrew clang 22 and Apple clang (arm64) 6/0, clang 18 (WSL x86-64) 2/0 with `-ffast-math` and 6/0 with `-ffinite-math-only`, GCC 12 and GCC 13 2/0 (`is_finite(nan)`), clang 14 0/0, MSVC 19 `/fp:fast` 0/0. Precise TU with the checks inside the `options fast_math` region: GCC 12 was 0 wrong on the old header and 2 wrong with `__forceinline` builtins, GCC 13 6 wrong; 0 wrong with the volatile launder on every compiler above.
- The in-suite fast-math gate was observed red at the old header and green at this one on the macOS build (`bin/tests-cpp-small --test-case="*fast-math*"`). Real lanes for it: Linux GCC and the Linux/macOS clang lanes, `ctest -L small`. On the Windows MSVC lane `/fp:fast` sets no finite-math assumption, so that cell passes without exercising anything; the TU `#error`s if built without the flag, so losing the per-source flag is loud. The region TU's real lane is Linux GCC (and x86-64 clang); on arm64 clang, e2k and Nintendo `DAS_FAST_MATH_PUSH` is empty and the test is a precise pass.
- `tests/math/inf_and_nan.das` and `tests/daslib/test_toml.das` on the precise local build: interpreter and `-jit`, 0 skipped.
- A runtime built `-ffast-math` (fresh clone in WSL on x86-64, GCC 13 and clang 18 giving identical numbers): with this header `inf_and_nan.das` 7 passed / 1 skipped and `test_toml.das` 104 passed / 3 skipped, the skips being exactly the four compare-guarded tests, so the new probe fires on a real finite-math host and the never-skipping test passes there. Same build with master's header: `inf_and_nan.das` 2 failed. Note for anyone repeating the clang build: the repo's `-Werror` trips on clang's `-Wnan-infinity-disabled` in `debug_print.h` under `-ffast-math`, which is unrelated to this change; the run silenced that one warning.
- `ctest -L small` locally: 115 green with both new TUs; full preflight 22 passed, 0 failed, 1 skipped (`md-ascii`, no markdown changed).

### Claims - stated, not tested
- Per-query cost in the shipped precise build goes down (a `noinline` call replaced by an inlined store/load and two integer ops). Not measured; a break would look like a regression on an AOT loop that is nothing but `is_nan` calls, and the alternative (keeping the builtins for precise builds) is the one the `options fast_math` region rules out.
- `is_nan(x)` where `x` is the result of the region's own arithmetic under `options fast_math` may still see a folded `x` (fast math is allowed to fold `x / x`); the queries are only promised to honor the bits they are given.

### Not done
- The auditor-proposed wording changes to `tests-cpp/REVIEW.md` (a test whose subject compiles to an unexercised implementation on some lane) and `include/daScript/simulate/REVIEW.md` (which build flavor judges hot-path cost), and the `writing_cpp_tests.md` line saying a small test needs no CMake edit. Rule-document edits, left for a separate ruling.
- A `tests-cpp/REVIEW.das` gate that every path named in a `set_source_files_properties` line exists (a moved or renamed fast-math TU would silently build precise).

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)