### PR TITLE
CI: bundle_smoke gets its own sccache slot, seeded by the nightly cron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,10 @@ on:
     #    builds test_aot_subset (tests/language, part of ALL) as a compile+link
     #    gate and runs no AOT tests at all (preflight --full's tests-aot lane is
     #    the pre-push AOT sweep).
-    # bundle_smoke / gcc stay per-PR-only. A manual `workflow_dispatch` runs
-    # the FULL workflow: every per-PR job, both toolchains, the nightly cells,
-    # and the full AOT suite.
+    # gcc stays per-PR-only; bundle_smoke runs on the cron too, which is what
+    # seeds its sccache slot. A manual `workflow_dispatch` runs the FULL
+    # workflow: every per-PR job, both toolchains, the nightly cells, and the
+    # full AOT suite.
     # 02:00 UTC: dead time for EU working hours — the nightly is ~12 jobs and
     # must not compete with daytime PR lanes for runners.
     - cron: '0 2 * * *'
@@ -653,9 +654,17 @@ jobs:
   # still gated at release-cut time in release.yml.
   ###########################################################
     needs: pre_job
-    # Per-PR/push lane (also runs on manual `workflow_dispatch`); skipped only on the nightly `schedule` cron.
-    if: needs.pre_job.outputs.should_skip != 'true' && github.event_name != 'schedule'
+    # Per-PR/push lane and manual dispatch, plus the nightly cron on the canonical repo: the cron
+    # is what seeds this job's sccache slot below (a master push run is usually pre_job-skipped
+    # as a concurrent duplicate of the PR that just merged, so its save rarely lands).
+    if: >-
+      (github.event_name == 'schedule' && github.repository == 'GaijinEntertainment/daScript')
+      || (github.event_name != 'schedule' && needs.pre_job.outputs.should_skip != 'true')
     runs-on: ubuntu-latest
+    # actions: write needed for `gh cache delete` in the sccache refresh step.
+    permissions:
+      contents: read
+      actions: write
     steps:
     - name: "SCM Checkout"
       uses: actions/checkout@v4
@@ -683,6 +692,24 @@ jobs:
           libxinerama-dev \
           libxi-dev
 
+    # Its own sccache slot, same local-disk shape as the matrix cells: the release-modules
+    # configure compiles a surface no matrix cell does (dasHV, dasLLVM, dasAudio, dasSQLITE,
+    # dasGLFW, ...), so a matrix slot would serve it few hits. 2000M holds the full object set.
+    - uses: mozilla-actions/sccache-action@v0.0.10
+    - run: |
+        echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
+        echo "SCCACHE_CACHE_SIZE=2000M" >> $GITHUB_ENV
+        echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+        echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+    # PRs restore read-only; the cron builds cold and saves (the seeder), a master push saves too.
+    - name: "Restore sccache objects"
+      if: github.event_name != 'schedule'
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/sccache
+        key: sccache-bundle-linux-64-Release
+
     - name: "Build: Daslang with release modules"
       run: |
         set -eux
@@ -691,6 +718,19 @@ jobs:
         CC=clang CXX=clang++ cmake --no-warn-unused-cli -B./build -DCMAKE_BUILD_TYPE:STRING=Release \
           -G Ninja $ACTIVE_MODULES
         cmake --build ./build --config Release --parallel
+
+    - name: "Refresh sccache slot"
+      if: github.ref == 'refs/heads/master'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SCKEY: sccache-bundle-linux-64-Release
+      run: gh cache delete "$SCKEY" -R ${{ github.repository }} || true
+    - name: "Save sccache objects"
+      if: github.ref == 'refs/heads/master'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/sccache
+        key: sccache-bundle-linux-64-Release
 
     - name: "Install bundle"
       run: |

--- a/skills/internal/preflight.md
+++ b/skills/internal/preflight.md
@@ -72,7 +72,7 @@ working-tree copy.
 | `doc.yml` | only if `doc/**`, `daslib/**`, `src/builtin/**`, `modules/dasImgui/**`, `modules/dasVulkan/**`, or `modules/dasLLAMA/dasllama/**` changed | the doc gates |
 | `playground-e2e.yml` | only if `site/**` / `web/examples/ui/**` changed | Playwright on the web playground |
 
-> A manual **`workflow_dispatch`** of `build.yml` runs the **whole** workflow - every per-PR job, both nightly toolchains, *and* the full AOT sweep. The cron `schedule` runs the two toolchains + the full build matrix; `bundle_smoke` and `build_linux_gcc` are gated off `schedule`.
+> A manual **`workflow_dispatch`** of `build.yml` runs the **whole** workflow - every per-PR job, both nightly toolchains, *and* the full AOT sweep. The cron `schedule` runs the two toolchains, the full build matrix and `bundle_smoke` (the cron run is what seeds its sccache slot); `build_linux_gcc` is gated off `schedule`.
 
 ## build.yml - the build matrix
 


### PR DESCRIPTION
`bundle_smoke` built for 39 of its 43 minutes on the last PR with no sccache at all: its release-modules configure compiles a surface no matrix cell does, and it never had a slot. It now has one of its own, restored read-only on PRs and saved on master, 2000M so a full object set fits. The job also runs on the nightly cron, since the cron is what reliably seeds a slot (a master push run is usually skipped as a duplicate of the PR that just merged); `build_linux_gcc` stays off the cron.

Where to look: `.github/workflows/build.yml`, the `bundle_smoke` job.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The first run of this PR builds cold (no slot exists yet); the slot lands on the first cron or master push after the merge, and the next PR's `bundle_smoke` wall is the measurement.

### Not done
- The matrix Release cells' build step is the other over-budget cost on a PR that touches core headers; their slots exist and re-seed nightly, so the steady-state read is the next non-core PR.

</details>

:robot: Generated with [Claude Code](https://claude.com/claude-code)
