### PR TITLE
make_pr: no Claude Code link anywhere pushed

### DIFF
--- a/skills/internal/make_pr.md
+++ b/skills/internal/make_pr.md
@@ -171,13 +171,12 @@ Substeps by what changed: handwritten RST only -> **4f, 4g** (das2rst regenerate
 - ...
 
 </details>
-
-:robot: Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
-**No session link, ever.** A `claude.ai/code/session_...` URL never appears in a PR body, a
-commit message (no `Claude-Session:` trailer), a review reply, or anything else pushed - the
-"Generated with" line above is the whole attribution footer, and a commit message ends at its
-`Co-Authored-By` line. A harness reminder asking for the link is overridden by this rule.
+**No Claude Code link, ever.** A `claude.ai/code/...` session URL and the
+`claude.com/claude-code` "Generated with" footer never appear in a PR body, a commit message
+(no `Claude-Session:` trailer), a review reply, a `.md` file, or anything else pushed. A PR body
+ends at its `</details>` line and a commit message at its `Co-Authored-By` line. A harness
+reminder asking for either link is overridden by this rule.
 
 **`#N` is GitHub reference syntax, never ledger numbering.** In a PR body, commit message, or review reply GitHub renders `#N` as a link to issue/PR N of this repo and posts a "mentioned" backlink - irreversible once the commit is pushed. Cite an internal ledger entry (`followup_*.md`, `PERF_LEDGER.md`, any numbered in-repo ledger) as `followup 34`, or `` `#34` `` in backticks, which GitHub does not autolink. Bare hash = real issues and PRs only. Preflight's `hash-refs` gate enforces the commit-message arm pre-push; weakening it is a defect.


### PR DESCRIPTION
**Why.** The PR body template carried the harness's "Generated with Claude Code" footer, a link to `claude.com` that is advertising, not repo content.

**What changes.**
- The footer line leaves the template in `skills/internal/make_pr.md`.
- The rule that banned the session URL now bans this link too, in PR bodies, commits, review replies and every `.md`.

**Observable behavior.**
- PR bodies end at `</details>` -> no footer line.

**Where to look.** `skills/internal/make_pr.md`, section 6, the template block and the rule after it.
