### PR TITLE
dasLLAMA: an untied Q8 load keeps its Q8_0 token table as quants (IMAGE_VERSION 33)

### DIFF
--- a/modules/dasLLAMA/ARCHITECTURE_IMAGE.md
+++ b/modules/dasLLAMA/ARCHITECTURE_IMAGE.md
@@ -34,6 +34,19 @@ clears them behind the exe gate at batch start and after each model's last cell,
 re-baked from its gguf on demand. Judging stays forbidden; owning the directory for the batch is
 what licenses deletion without judgment.
 
+### 2.1n A planar image never stands in for the blob flavor {#image-flavor-rebake}
+
+A metal-mode load resolves its flavor in order: the blob image under the metal tag maps first; a
+planar image under the plain identity maps next, and serves only when the model cannot take the
+blob form - a shape the drivers decline, or a layout the bind-alignment gate refuses. Otherwise the
+rail drops the mapping and rebakes the blob flavor from the gguf, so a CPU run that minted the planar
+image first never leaves a GPU box serving from the CPU planes; the planar file stays for CPU loads.
+The question the mapped planar image answers is `metal_blob_form_ok` - quant, packing flags, layout
+- and not `metal_blob_eligible`: that one also refuses a mapped model, because the in-place
+transform would write borrowed planes, and the rebake never transforms the mapping. Metal mode pins
+the portable backend, so the packing flags are false there and the form question reduces to shape
+and layout.
+
 ### 2.1a Page alignment is the no-copy contract {#image-page-alignment}
 
 Every plane section starts on a 16 KiB boundary (`IMAGE_PAGE`, the Apple-Silicon page) and the

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -814,6 +814,18 @@ what it costs today and what the fix would change.
   kernels only (default kernels still matched the oracle 24/24) -> moved to the counting prompt
   like Qwen2.5/Phi, oracle-refrozen. fp32/q4 loads and non-Q8_0 embeddings keep the exact old
   path. (Spotted wave 3.)
+- **DONE (2026-09-05): the UNTIED Q8 embedding keeps its Q8_0 quants too (`Model.emb_q8`).**
+  `cls_q8` had coupled "tied classifier on the disk quants" with "no fp32 table", so a Q8 load
+  of a model with its own `output.weight` still decoded `token_embd` to fp32 into fblob: vocab x
+  dim x 4 bytes of RAM and image on every untied model (37 MB on stories15M, 1.56 GB on the
+  152k-vocab Qwen3-4B, 1.24 GB on Qwen3-30B-A3B - sized, not measured). Now any Q8 load of a
+  Q8_0 `token_embd` transcodes the LINEAR copy at emb_q8_off and drops the table; tied models are
+  unchanged (`cls_q8` = tied && emb_q8). Rows bit-identical to the fp32 decode
+  (`test_parity_untied_emb_q8_rows`); stories15M's image 51 MB -> 26.6 MB, mint + map + token-exact
+  (image suite arm `untied`). IMAGE_VERSION 33: every image re-mints once. Vulkan's device embed
+  gather has no untied-q8 arm yet (the f32-upload arm declines, the CPU embed loop serves);
+  the Metal blob flavor's untied-q8 leg is untested on this box. (Spotted by the storyteller's
+  wasm download budget.)
 - **DONE (perf pass, 2026-07-02): V-from-K layers fuse the K->V copy with the weightless V-norm.**
   Decode (mm_qkv) and prefill both rmsnorm k->v out-of-place when v_norm is on (bit-identical to
   copy + in-place norm; the block's v_norm step skips those layers). (Spotted wave 3.)

--- a/modules/dasLLAMA/PERF_LEDGER.md
+++ b/modules/dasLLAMA/PERF_LEDGER.md
@@ -817,15 +817,16 @@ what it costs today and what the fix would change.
 - **DONE (2026-09-05): the UNTIED Q8 embedding keeps its Q8_0 quants too (`Model.emb_q8`).**
   `cls_q8` had coupled "tied classifier on the disk quants" with "no fp32 table", so a Q8 load
   of a model with its own `output.weight` still decoded `token_embd` to fp32 into fblob: vocab x
-  dim x 4 bytes of RAM and image on every untied model (37 MB on stories15M, 1.56 GB on the
-  152k-vocab Qwen3-4B, 1.24 GB on Qwen3-30B-A3B - sized, not measured). Now any Q8 load of a
-  Q8_0 `token_embd` transcodes the LINEAR copy at emb_q8_off and drops the table; tied models are
-  unchanged (`cls_q8` = tied && emb_q8). Rows bit-identical to the fp32 decode
+  dim x 4 bytes of RAM and image on every untied model (37 MB on stories15M, 262 MB on
+  TinyLlama-1.1B, 394 MB on Phi-3.5-mini, 1.24 GB on the 152k-vocab Qwen3-30B-A3B - sized, not
+  measured; Qwen3-4B, Llama-3.2, Qwen2.5, gemma-3 and SmolLM2 are tied and never carried it). Now
+  any Q8 load of a Q8_0 `token_embd` transcodes the LINEAR copy at emb_q8_off and drops the table;
+  tied models are unchanged (`cls_q8` = tied && emb_q8). Rows bit-identical to the fp32 decode
   (`test_parity_untied_emb_q8_rows`); stories15M's image 51 MB -> 26.6 MB, mint + map + token-exact
-  (image suite arm `untied`). IMAGE_VERSION 33: every image re-mints once. Vulkan's device embed
-  gather has no untied-q8 arm yet (the f32-upload arm declines, the CPU embed loop serves);
-  the Metal blob flavor's untied-q8 leg is untested on this box. (Spotted by the storyteller's
-  wasm download budget.)
+  (image suite arm `untied`); the Metal blob flavor carries the copy on TinyLlama (arm
+  `metal-untied`). IMAGE_VERSION 33: every image re-mints once. Vulkan's device embed gather has
+  no untied-q8 arm yet (the f32-upload arm declines, the CPU embed loop serves). (Spotted by the
+  storyteller's wasm download budget.)
 - **DONE (perf pass, 2026-07-02): V-from-K layers fuse the K->V copy with the weightless V-norm.**
   Decode (mm_qkv) and prefill both rmsnorm k->v out-of-place when v_norm is on (bit-identical to
   copy + in-place norm; the block's v_norm step skips those layers). (Spotted wave 3.)

--- a/modules/dasLLAMA/REVIEW.das
+++ b/modules/dasLLAMA/REVIEW.das
@@ -544,8 +544,8 @@ let private IMAGE_FILE = "modules/dasLLAMA/dasllama/dasllama_image.das"
 // every *_prepare mint, the layout helpers and the layout constants' declaration lines, hashed
 // in file order. A closure change with IMAGE_VERSION unmoved is red; the finding prints the
 // value to re-stamp with.
-let private IMAGE_LAYOUT_STAMP_VERSION = 32
-let private IMAGE_LAYOUT_STAMP_HASH = 0x1326fdc547a28a5aul
+let private IMAGE_LAYOUT_STAMP_VERSION = 33
+let private IMAGE_LAYOUT_STAMP_HASH = 0x16cc08ecdcac17c4ul
 
 // The helpers that decide WHERE bytes land: the page pad, the plane and total sizing, the
 // writer's append / zero-fill / header patch, and the header's scalar stores. Changing one

--- a/modules/dasLLAMA/dasllama/dasllama_common.das
+++ b/modules/dasLLAMA/dasllama/dasllama_common.das
@@ -835,8 +835,8 @@ struct ArchBlocks {
 }
 
 //! The whole model. `fblob` holds the fp32 embedding + norm weights; the big 2D weights live in
-//! exactly one of wblob (fp32) / qblob+qscales (Q8) / q4blob+q4scales (Q4) per `quant`. For
-//! shared_weights, cls_q8 (tied Q8_0) drops the fp32 table: classifier + embedding both read qblob.
+//! exactly one of wblob (fp32) / qblob+qscales (Q8) / q4blob+q4scales (Q4) per `quant`. A Q8 load of
+//! a Q8_0 embedding (emb_q8) drops the fp32 table: rows read qblob; tied (cls_q8), the classifier reads it too.
 struct Model {
     config : Config = Config()
     arch : string = ""              // GGUF general.architecture, resolved at load — drives the chat template
@@ -1048,10 +1048,12 @@ struct Model {
     wsh2_off : int64        // ffn_down_shexp: layers x (n_ff_shexp x dim)
     wsh3_off : int64        // ffn_up_shexp:   layers x (dim x n_ff_shexp)
     wcls_off : int64
-    // Tied-classifier Q8: the classifier lives in qblob at wcls_off (repacked) and the fp32
-    // embedding table is NOT in fblob — token rows dequant from the second, LINEAR transcode at
-    // emb_q8_off. Set only by load_gguf for shared_weights + QuantMode.q8 + Q8_0 token_embd on disk.
+    // Tied-classifier Q8: the classifier lives in qblob at wcls_off (repacked); set only by
+    // load_gguf for shared_weights + QuantMode.q8 + Q8_0 token_embd on disk.
     cls_q8 : bool = false
+    // Q8 embedding: the fp32 table is NOT in fblob — token rows dequant from the LINEAR transcode
+    // at emb_q8_off. Any QuantMode.q8 load of a Q8_0 token_embd, tied (cls_q8 implies it) or not.
+    emb_q8 : bool = false
     emb_q8_off : int64
     quant : QuantMode
     rope_freqs : array<float>   // per-pair RoPE scaling (Llama-3.1 NTK-by-parts); empty = none
@@ -4188,12 +4190,12 @@ def private dequant_embq_row(t : Model; off, n : int64; var dst : float?) {
     }
 }
 
-// Copy token `token`'s embedding row into dst — from fp32 fblob, or (cls_q8) dequanted from the
+// Copy token `token`'s embedding row into dst — from fp32 fblob, or (emb_q8) dequanted from the
 // linear Q8 copy at emb_q8_off (embq when trimmed), or (cls_kq) from the K-quant plane at
 // wcls_off (embq/embs when trimmed). Rows are whole superblocks (the K-quant row invariant).
 def embed_row(t : Model; token : int64; var dst : float?) {   // nolint:STYLE037,STYLE038 — a KqFmt ladder x trimmed/repacked; arms differ only in the plane pair and its strides
     let dim = t.config.dim
-    if (t.cls_q8) {
+    if (t.emb_q8) {
         if (t.planes_trimmed) {
             dequant_embq_row(t, token * dim, dim, dst)
         } else {

--- a/modules/dasLLAMA/dasllama/dasllama_gpu_resident.das
+++ b/modules/dasLLAMA/dasllama/dasllama_gpu_resident.das
@@ -239,7 +239,7 @@ def trim_model_planes(var t : Model) : bool {   // nolint:STYLE037,STYLE038 — 
     }
     let dim = t.config.dim
     let vocab = t.config.vocab_size
-    if (t.cls_q8) {
+    if (t.emb_q8) {
         // mblob-style 34B interleaved blocks over the emb region (dequant_embq_row's layout)
         let nb = vocab * dim / 32l
         t.embq |> reserve_resize(nb * 34l)   // vocab-scaled: ~600 MB at a 248k-vocab 27B, one grow
@@ -629,7 +629,7 @@ def resident_upload(t : Model; seq_cap : int64; rkdt : KVDtype) : bool {   // no
     let emb_q8_want = (g_env_vulkan.vk_gpu_embed && rdec_prefill_ids_installed()
         && c.shared_weights && t.cls_q8 && cls_fmt == KqFmt.q8)
     let emb_f32_want = (g_env_vulkan.vk_gpu_embed && rdec_prefill_ids_installed()
-        && !t.cls_q8 && !cls_kq(t) && !t.planes_trimmed
+        && !t.emb_q8 && !cls_kq(t) && !t.planes_trimmed   // an untied q8 table has no f32 copy to upload: the CPU embed loop serves it
         && resident_plan(t, seq_cap, rkdt, rkdt).emb_f32_bytes > 0l)   // the plan counted it at this context
     var planes : array<tuple<n : int64; rows : int64; f : KqFmt>>
     planes |> reserve(c.n_layers * 7l + 1l)

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -38,7 +38,7 @@ require dasllama/dasllama_load
 // WhisperModel.enc) contribute their planes under dotted names ("enc.fblob"); string-array
 // fields ride the meta blob via serialize_strings — raw string pointers can't be planes.
 
-let IMAGE_VERSION = 32   // the TTS AdaIN/AdaLayerNorm affines are vec-only: their tiled `wt` twin no longer rides the blob
+let IMAGE_VERSION = 33   // an untied Q8 load keeps its Q8_0 token table as quants (emb_q8): the fp32 copy left fblob, a linear q8 copy joined qblob
 
 //! The metal (blob-only) flavor's identity tag: q8 planes ride the 34B block_q8_0 blob and the
 //! kq scale planes their GPU forms (convert_model_to_metal_blob) — flavors are per-config and
@@ -723,6 +723,7 @@ def serialize_image_meta(var arch : Archive; var t : Model) {
     arch |> serialize_raw(t.wsh3_off)
     arch |> serialize_raw(t.wcls_off)
     arch |> serialize_raw(t.cls_q8)
+    arch |> serialize_raw(t.emb_q8)
     arch |> serialize_raw(t.emb_q8_off)
     arch |> serialize_raw(t.quant)
     arch |> serialize_raw(t.dn_conv_off)
@@ -741,7 +742,7 @@ def serialize_image_meta(var arch : Archive; var t : Model) {
 }
 
 // the 3 deliberate skips: blocks, image_map, image_bytes
-let IMAGE_META_FIELDS = 75 + 3
+let IMAGE_META_FIELDS = 76 + 3
 
 // the tokenizer's tripwires: the SentencePiece backend's five serialized meta fields + its three
 // derived tables (lookup, pair_merge, bkey_id); the BPE backend's seven (merge_rank rides as the

--- a/modules/dasLLAMA/dasllama/dasllama_image.das
+++ b/modules/dasLLAMA/dasllama/dasllama_image.das
@@ -1624,9 +1624,10 @@ def load_model_cached(path : string; mode : QuantMode = QuantMode.fp32;
         let img = image_path_for(path, "", qs)
         if (load_model_image(img, t, "", qs)) {
             vulkan_bake_flavor(t, path, vk_tag)
-            //! metal_blob_eligible must agree, or the rebake below refuses and re-mints the SAME
-            //! planar file every load (a repacking backend passes the mint-time shape gate)
-            if (!(want_metal && metal_model_servable(t) && metal_blob_eligible(t))) {
+            //! the layout gate must agree, or the rebake below refuses and re-mints the SAME planar
+            //! file every load (a repacking backend passes the mint-time shape gate); the mapping's
+            //! borrowed planes are not the question - the rebake reads the gguf, never this mapping
+            if (!(want_metal && metal_model_servable(t) && metal_blob_form_ok(t))) {
                 to_log(LOG_INFO, "dasLLAMA: prepared image mapped in {get_time_usec(ts_img) / 1000} ms - {img}\n")
                 return <- t
             }

--- a/modules/dasLLAMA/dasllama/dasllama_layout.das
+++ b/modules/dasLLAMA/dasllama/dasllama_layout.das
@@ -100,16 +100,11 @@ def private metal_blob_layout_ok(t : Model) : bool {
         (!t.emb_q8 || metal_blob_off_ok(t.emb_q8_off, KqFmt.q8)))
 }
 
-//! Can `t` take the blob form? The refusal half of the transform, split out so the image writer
-//! can commit to the metal flavor without first building the blob plane in RAM.
-def metal_blob_eligible(t : Model) : bool {
+//! Can `t`'s LAYOUT take the blob form - the packing flags and the bind-alignment gate, ownership
+//! aside? The question a mapped planar image answers before the rail rebakes the metal flavor.
+[arch(at = "../ARCHITECTURE_IMAGE.md#image-flavor-rebake")]
+def metal_blob_form_ok(t : Model) : bool {
     if (t.quant != QuantMode.q8 || t.kq_repacked || t.mx4_repacked || kernel_backend_needs_repack(active_kernel_backend())) {
-        return false
-    }
-    if (t.image_map != null) {
-        // image-backed planes are borrowed READ-ONLY views — the in-place k4s/k5s/k6s
-        // rewrites would fault. Transform an owned load (load_model_ / DASLLAMA_IMAGE=0).
-        to_log(LOG_WARNING, "dasLLAMA: metal-blob transform declined - the model is image-mapped (borrowed planes); transform an owned gguf load\n")
         return false
     }
     if (!metal_blob_layout_ok(t)) {
@@ -117,6 +112,18 @@ def metal_blob_eligible(t : Model) : bool {
         return false
     }
     return true
+}
+
+//! Can THIS `t` take the blob form in place? The refusal half of the transform, split out so the
+//! image writer can commit to the metal flavor without first building the blob plane in RAM.
+def metal_blob_eligible(t : Model) : bool {
+    if (t.image_map != null) {
+        // image-backed planes are borrowed READ-ONLY views — the in-place k4s/k5s/k6s
+        // rewrites would fault. Transform an owned load (load_model_ / DASLLAMA_IMAGE=0).
+        to_log(LOG_WARNING, "dasLLAMA: metal-blob transform declined - the model is image-mapped (borrowed planes); transform an owned gguf load\n")
+        return false
+    }
+    return metal_blob_form_ok(t)
 }
 
 //! Block count of the blob plane and its stride — the 34B gguf-native block_q8_0, which is the

--- a/modules/dasLLAMA/dasllama/dasllama_layout.das
+++ b/modules/dasLLAMA/dasllama/dasllama_layout.das
@@ -97,7 +97,7 @@ def private metal_blob_layout_ok(t : Model) : bool {
     }
     let cls_fmt = c.shared_weights ? t.emb_fmt : t.wcls_fmt
     return (metal_blob_off_ok(t.wcls_off, cls_fmt) &&
-        (!t.cls_q8 || metal_blob_off_ok(t.emb_q8_off, KqFmt.q8)))
+        (!t.emb_q8 || metal_blob_off_ok(t.emb_q8_off, KqFmt.q8)))
 }
 
 //! Can `t` take the blob form? The refusal half of the transform, split out so the image writer

--- a/modules/dasLLAMA/dasllama/dasllama_load.das
+++ b/modules/dasLLAMA/dasllama/dasllama_load.das
@@ -189,7 +189,7 @@ def private layout_offsets(var t : Model) : LayoutSizes {   // nolint:STYLE037,S
     let layers = c.n_layers + c.n_layer_nextn
     var fo = 0l
     var bf16 = 0l
-    if (t.cls_q8 || cls_kq(t)) {
+    if (t.emb_q8 || cls_kq(t)) {
         t.tok_emb_off = -1l   // no fp32 embedding table — rows dequant from emb_q8_off / the kq plane
     } else {
         t.tok_emb_off = fo
@@ -432,6 +432,11 @@ def private layout_offsets(var t : Model) : LayoutSizes {   // nolint:STYLE037,S
         }
     } else {
         t.wcls_off = kq_take(cur, t.wcls_fmt, c.vocab_size * dim)
+        if (t.emb_q8) {
+            // untied Q8: the embedding's own linear copy, beside the separately quantized classifier
+            t.emb_q8_off = cur.wo
+            cur.wo += c.vocab_size * dim
+        }
     }
     if (c.n_layer_nextn > 0l) {   // MTP/NextN extras (the block's standard tensors rode the walks above)
         t.mtp_ehproj_off = kq_take(cur, t.mtp_ehproj_fmt, 2l * dim * dim)
@@ -2078,11 +2083,11 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
         }
         // a separate output.weight means the classifier is not tied to the embeddings
         t.config.shared_weights = gguf_find_tensor(m, "output.weight") < 0
-        // tied Q8 loads of a Q8_0 embedding matmul the classifier on the DISK quants (the reference
-        // arithmetic) and drop the fp32 table — see Model.cls_q8. Other disk types keep the exact
-        // fp32 path (a requantized classifier would drift from the oracle for no parity gain).
-        t.cls_q8 = (t.config.shared_weights && mode == QuantMode.q8
-            && gguf_tensor_type(m, "token_embd.weight") == GGML_TYPE_Q8_0)
+        // a Q8 load of a Q8_0 embedding keeps the table as its disk quants (Model.emb_q8: rows dequant on
+        // demand to the values the fp32 decode would hold); tied, the classifier matmuls those quants too (Model.cls_q8).
+        // Other disk types keep the exact fp32 path (a requantized classifier would drift from the oracle for no parity gain).
+        t.emb_q8 = mode == QuantMode.q8 && gguf_tensor_type(m, "token_embd.weight") == GGML_TYPE_Q8_0
+        t.cls_q8 = t.config.shared_weights && t.emb_q8
         // ssm_beta/ssm_alpha disk type routes their matmul (must precede layout_offsets): F32
         // files keep them fp32 in fblob (their matmul runs in f32); quantized files ride qblob.
         // Also before detect_kq_formats — the dn tags demote on grouped (qwen3next) files.
@@ -2334,10 +2339,10 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
             t.qscales |> reserve(sz.pleq8_n / 32l)
             t.qscales |> resize(sz.pleq8_n / 32l)
         }
-        // embedding + norms -> fblob (decoded to fp32 from whatever the disk type is); cls_q8 /
+        // embedding + norms -> fblob (decoded to fp32 from whatever the disk type is); emb_q8 /
         // cls_kq keep the embedding out of fblob — the quantized copies transcode with the big
         // weights below
-        if (!t.cls_q8 && !cls_kq(t)) {
+        if (!t.emb_q8 && !cls_kq(t)) {
             gguf_read_tensor_f32(m, bytes, "token_embd.weight", t.fblob, t.tok_emb_off, vocab * dim)
         }
         // gpt-oss names its pre-FFN norm post_attention_norm (same graph role as ffn_norm)
@@ -2571,6 +2576,10 @@ def private load_gguf_parsed(var t : Model; m : GGUFMeta; bytes : array<uint8> |
         }
         if (!t.config.shared_weights) {
             load_big(m, bytes, "output.weight", t, t.wcls_off, vocab * dim, scratch, 0l, t.wcls_fmt)
+            if (t.emb_q8) {
+                // untied Q8: the embedding's linear copy the row reads dequant from (never repacked)
+                load_big(m, bytes, "token_embd.weight", t, t.emb_q8_off, vocab * dim, scratch)
+            }
         } elif (t.cls_q8) {
             // tied Q8: classifier copy (repacked below) + the linear copy embedding rows read.
             // Through load_big (its q8 arm is the same transcode) so the streaming plan records both.

--- a/modules/dasLLAMA/dasllama/dasllama_par.das
+++ b/modules/dasLLAMA/dasllama/dasllama_par.das
@@ -55,7 +55,7 @@ var g_disp_chunks = 0l   // chunks (jobs) pushed across those dispatches
 var g_disp_inline = 0l   // maybe_parallel_for calls that ran inline instead
 var private g_jobque_checked = false
 
-[arch(at="../ARCHITECTURE_RUNTIME.md#jobque-policy")]
+[arch(at="../ARCHITECTURE_RUNTIME.md#jobque-policy"), cold_path]   // runs once, on the first dispatch: its log line is not the kernels' hot path
 def private check_jobque_configured() {
     return if (!is_job_que_available())   // no queue: the arms run inline, nothing to configure
     g_jobque_checked = true

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -152,7 +152,7 @@ blob twin's CPU batch fallback would trip the blob-only panic).
 The `image` suite (test_model_image - the prepared-image .dlim rail): `mechanics` (synthetic
 carrier, model-free - runs with no model stocked; also the layout fingerprint and the dev-W
 bake tables, whose rebuild-not-append contract and per-format key arithmetic are pure taxonomy
-over a job list) `smol untied metal gemma tower whisper voxtral
+over a job list) `smol untied metal metal-untied gemma tower whisper voxtral
 parakeet qwen3a canary canary-dec gemma4a gemma4uv gemma4uv-metal gemma4v gemma3v gemma4e
 mtower`; `gemma4e` is the E2B metal-blob
 mint+map arm - the PLE go-live tripwire (`ple_check_table`, which panics when the per-layer
@@ -181,7 +181,11 @@ required-mode, step-floor and shutdown-re-arm contract; the voxtral arm re-saves
 5.4 GB image from cold every run by design (it IS the >2 GiB-plane IO coverage); the `metal`
 arm mints/maps the blob-only metal flavor (SmolLM2) incl. the CPU-tripwire and a
 teacher-forced logits-tolerance parity cell (greedy token equality is NOT a valid bar on a
-135M - genuine near-ties flip on ~0.02 gaps under ~0.75 cross-backend noise). The ASR-family
+135M - genuine near-ties flip on ~0.02 gaps under ~0.75 cross-backend noise); `metal-untied`
+is its untied twin on TinyLlama-1.1B - the blob plane carrying the classifier AND the
+embedding's linear q8 copy (`emb_q8` without `cls_q8`): the layout gate admits the copy, cold
+mint and warm map keep the q8 table with no fp32 copy, GPU serve, the same teacher-forced bar
+(`--arm metal` and `--arm untied` both select it - substring match). The ASR-family
 arms (`parakeet` transcript-exact, `qwen3a`/`canary`/`gemma4a` element-exact planes,
 `canary-dec` = the opt-in fp32 Model rail, token-exact) re-save their images from cold each
 run like the voxtral arm. The canary arm carries both lanes: the f32 element-exact cell and
@@ -638,7 +642,7 @@ panic cell uses it.
 model blocks tagged with a listed family run - `family_on(t, name)` in
 `_model_tier.das`, EXACT token match, loud `t |> skip` like the arm filter. Model-free blocks
 carry no tag and always run. Family tokens: `llama` (`--suite decode`, `prefill`, `matrix` and
-`coverage`, plus the image `smol`, `untied` and `metal` arms and the `image-vulkan` `vulkan` arm),
+`coverage`, plus the image `smol`, `untied`, `metal` and `metal-untied` arms and the `image-vulkan` `vulkan` arm),
 `qwen2`, `qwen3`, `phi3`,
 `gemma2`, `gemma3`, `gemma4`, `qwen3moe`, `gemma4moe`, `gptoss`, `qwen35`, `qwen35moe`, `qwen2moe` (the support-matrix family cells), `gemma`,
 `ultravox`, `whisper`, `voxtral`, `parakeet`, `qwen3a`, `canary`, `gemma4a` (image suite arms),

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -152,7 +152,7 @@ blob twin's CPU batch fallback would trip the blob-only panic).
 The `image` suite (test_model_image - the prepared-image .dlim rail): `mechanics` (synthetic
 carrier, model-free - runs with no model stocked; also the layout fingerprint and the dev-W
 bake tables, whose rebuild-not-append contract and per-format key arithmetic are pure taxonomy
-over a job list) `smol metal gemma tower whisper voxtral
+over a job list) `smol untied metal gemma tower whisper voxtral
 parakeet qwen3a canary canary-dec gemma4a gemma4uv gemma4uv-metal gemma4v gemma3v gemma4e
 mtower`; `gemma4e` is the E2B metal-blob
 mint+map arm - the PLE go-live tripwire (`ple_check_table`, which panics when the per-layer
@@ -638,7 +638,7 @@ panic cell uses it.
 model blocks tagged with a listed family run - `family_on(t, name)` in
 `_model_tier.das`, EXACT token match, loud `t |> skip` like the arm filter. Model-free blocks
 carry no tag and always run. Family tokens: `llama` (`--suite decode`, `prefill`, `matrix` and
-`coverage`, plus the image `smol` and `metal` arms and the `image-vulkan` `vulkan` arm),
+`coverage`, plus the image `smol`, `untied` and `metal` arms and the `image-vulkan` `vulkan` arm),
 `qwen2`, `qwen3`, `phi3`,
 `gemma2`, `gemma3`, `gemma4`, `qwen3moe`, `gemma4moe`, `gptoss`, `qwen35`, `qwen35moe`, `qwen2moe` (the support-matrix family cells), `gemma`,
 `ultravox`, `whisper`, `voxtral`, `parakeet`, `qwen3a`, `canary`, `gemma4a` (image suite arms),

--- a/modules/dasLLAMA/tests/run.das
+++ b/modules/dasLLAMA/tests/run.das
@@ -264,7 +264,7 @@ def area_image_arms(area : string) : string {
     } elif (area == "vision") {
         return "gemma4uv,gemma4v,gemma3v,gemma4e,tower"
     } elif (area == "llm") {
-        return "mechanics,smol,metal"
+        return "mechanics,smol,untied,metal"
     }
     return ""
 }

--- a/modules/dasLLAMA/tests/test_model_image.das
+++ b/modules/dasLLAMA/tests/test_model_image.das
@@ -490,6 +490,26 @@ def test_model_image_roundtrip(t : T?) {
         }
         text_image_roundtrip(t, path, 24)
     }
+    // the untied twin: a separate output.weight, so the image carries the classifier plane AND
+    // the embedding's own linear q8 copy (emb_q8) with no fp32 table - the smol arm never sees that layout
+    t |> run("stories15M q8 (untied): gguf load vs mapped image, token-for-token") @(t : T?) {
+        if (!family_on(t, "llama") || !arm_on(t, "untied")) return
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "stories15M-Q8_0.gguf")
+        if (!model_available(t, path)) {
+            return
+        }
+        text_image_roundtrip(t, path, 24)
+        var m <- load_model(path, QuantMode.q8)
+        t |> success(m.emb_q8 && !m.cls_q8 && m.tok_emb_off < 0l, "the mapped image serves the untied q8 table with no fp32 copy")
+        let img_bytes = int64(stat(image_path_for(path)).size)
+        let table_f32 = m.config.vocab_size * m.config.dim * 4l
+        t |> success(img_bytes < table_f32 + int64(stat(path).size), "the image ({img_bytes >> 20l} MB) is smaller than the gguf plus an f32 table: no f32 table rode along")
+        delete m
+    }
 }
 
 // ===== the metal (blob-only) flavor =====

--- a/modules/dasLLAMA/tests/test_model_image.das
+++ b/modules/dasLLAMA/tests/test_model_image.das
@@ -648,6 +648,64 @@ def test_metal_flavor_image(tst : T?) {
             select_kernel_backend(prior_backend)
         }
     }
+    // the untied twin on the blob flavor: TinyLlama carries its own output.weight, so the blob plane
+    // holds the classifier AND the embedding's linear q8 copy (emb_q8 without cls_q8) - the layout
+    // the SmolLM2 cell never reaches: the blob gate admits the copy, the transform carries it into
+    // mblob, and embed_row reads it there
+    tst |> run("TinyLlama-1.1B q8 (untied): metal flavor - blob mint + map + GPU serve on the emb_q8 table") @(t : T?) {
+        static_if (typeinfo builtin_module_exists(das_metal)) {
+            if (!family_on(t, "llama") || !arm_on(t, "metal-untied")) return
+            if (!jit_enabled()) {
+                t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+                return
+            }
+            if (!has_decode_override("metal")) {
+                t |> skip("metal overrides not registered")
+                return
+            }
+            let path = path_join(models_dir(), "tinyllama-1.1b-chat-v1.0.Q8_0.gguf")
+            if (!model_available(t, path)) {
+                return
+            }
+            let prior_backend = active_kernel_backend()
+            pin_kernel_backend("portable")
+            set_metal_mode(MetalMode.off)
+            var tc <- load_model(path, QuantMode.q8)
+            t |> success(!tc.metal_blob && tc.emb_q8 && !tc.cls_q8, "CPU-mode load stays planar and serves the untied q8 table")
+            let table_floats = tc.config.vocab_size * tc.config.dim
+            var prompt <- counting_ids(tc)
+            var g_cpu <- gen_ids(tc, prompt, 16)
+            delete tc
+            let img_m = image_path_for(path, METAL_IMAGE_TAG)
+            remove(img_m)
+            set_metal_mode(MetalMode.when_available)
+            var tm <- load_model(path, QuantMode.q8)
+            t |> success(tm.metal_blob, "metal-mode load is blob-form - the layout gate admits the untied emb_q8 copy")
+            t |> success(tm.image_map != null && stat(img_m).is_valid, "cold metal load saved and serves the metal-flavor image")
+            t |> success(tm.emb_q8 && !tm.cls_q8 && tm.tok_emb_off < 0l && long_length(tm.fblob) < table_floats,
+                "the blob flavor keeps the untied q8 table and no fp32 copy (fblob {long_length(tm.fblob)} floats against a {table_floats}-float table)")
+            var g_mint <- gen_ids(tm, prompt, 16)   // every token's embedding row read from the blob copy
+            var tp <- load_model_(path, QuantMode.q8)
+            let np = long_length(prompt)
+            var teach <- [for (i in range64(np - 1l, long_length(g_cpu))); g_cpu[i]]
+            let maxd = forced_logits_maxd(tp, tm, prompt, teach, "TinyLlama metal forced")
+            t |> success(maxd < 4.0, "teacher-forced GPU logits within 4.0 of the CPU control (maxd {maxd})")
+            delete teach
+            delete tp
+            delete tm
+            var tw <- load_model(path, QuantMode.q8)
+            t |> success(tw.image_map != null && tw.metal_blob && tw.emb_q8 && !tw.cls_q8, "warm metal load maps the blob image with the untied q8 table")
+            var g_map <- gen_ids(tw, prompt, 16)
+            t |> success(count_mismatch(g_mint, g_map) == 0l, "mint vs mapped tokens")
+            delete tw
+            delete g_cpu
+            delete g_mint
+            delete g_map
+            delete prompt
+            clear_kernel_backend_pin()
+            select_kernel_backend(prior_backend)
+        }
+    }
 }
 
 [test]

--- a/modules/dasLLAMA/tests/test_model_image.das
+++ b/modules/dasLLAMA/tests/test_model_image.das
@@ -505,9 +505,11 @@ def test_model_image_roundtrip(t : T?) {
         text_image_roundtrip(t, path, 24)
         var m <- load_model(path, QuantMode.q8)
         t |> success(m.emb_q8 && !m.cls_q8 && m.tok_emb_off < 0l, "the mapped image serves the untied q8 table with no fp32 copy")
+        // the whole image is smaller than the f32 table alone (27 MB against 37 MB on stories15M): an
+        // image that still carried the table could not be, whatever else it packs
         let img_bytes = int64(stat(image_path_for(path)).size)
         let table_f32 = m.config.vocab_size * m.config.dim * 4l
-        t |> success(img_bytes < table_f32 + int64(stat(path).size), "the image ({img_bytes >> 20l} MB) is smaller than the gguf plus an f32 table: no f32 table rode along")
+        t |> success(img_bytes < table_f32, "the image ({img_bytes >> 20l} MB) is smaller than the f32 table it no longer carries ({table_f32 >> 20l} MB)")
         delete m
     }
 }

--- a/modules/dasLLAMA/tests/test_parity.das
+++ b/modules/dasLLAMA/tests/test_parity.das
@@ -105,6 +105,57 @@ def test_parity_tied_cls_q8_rows(t : T?) {
     }
 }
 
+// emb_q8 invariant, the untied half: a Q8 load of a Q8_0 embedding with a SEPARATE output.weight drops the
+// fp32 table too (rows dequant from the linear transcode at emb_q8_off, bit-identical to the fp32 decode);
+// without it an untied model carries vocab x dim floats, 1.5 GB on a 152k-vocab 4B. stories15M is the smallest untied Q8_0 file.
+[test]
+def test_parity_untied_emb_q8_rows(t : T?) {
+    t |> run("untied Q8 load: emb_q8 embedding rows bit-match the fp32 table, no fp32 table kept") @(t : T?) {
+        if (!jit_enabled()) {
+            t |> skip("interpreted (dasLLAMA model tests are JIT-only)")
+            return
+        }
+        let path = path_join(models_dir(), "stories15M-Q8_0.gguf")
+        if (!model_available(t, path)) return
+        var t32 <- load_gguf(path, QuantMode.fp32)
+        var t8 <- load_gguf(path, QuantMode.q8)
+        t |> success(!t32.emb_q8 && t32.tok_emb_off >= 0l, "fp32 load keeps the fblob table")
+        t |> success(!t8.config.shared_weights, "the fixture is untied (output.weight on disk)")
+        t |> success(!t8.cls_q8, "untied: the classifier flag stays off")
+        t |> success(t8.emb_q8, "untied Q8_0 load takes the emb_q8 path")
+        t |> success(t8.tok_emb_off < 0l, "no fp32 table in fblob")
+        t |> success(t8.emb_q8_off != t8.wcls_off, "the embedding copy is not the classifier plane")
+        let dim = t8.config.dim
+        var bad = 0l
+        for (token in [0l, 1l, 1000l, t8.config.vocab_size - 1l]) {
+            for (i in range64(dim)) {
+                let el = t8.emb_q8_off + token * dim + i
+                let want = t32.fblob[t32.tok_emb_off + token * dim + i]
+                let sc = t8.wscale_f16 ? f16_to_f32(uint(t8.qscales16[el / 32l])) : t8.qscales[el / 32l]
+                if (float(t8.qblob[el]) * sc != want) {
+                    bad++
+                }
+            }
+        }
+        t |> success(bad == 0l, "embedding rows bit-identical ({bad} mismatches)")
+        // the row reader the forward pass uses agrees with the raw plane arithmetic
+        var inscope row : array<float>
+        row |> resize(dim)
+        unsafe {
+            embed_row(t8, 1000l, addr(row[0]))
+        }
+        var bad_row = 0l
+        for (i in range64(dim)) {
+            if (row[i] != t32.fblob[t32.tok_emb_off + 1000l * dim + i]) {
+                bad_row++
+            }
+        }
+        t |> success(bad_row == 0l, "embed_row reads the same values ({bad_row} mismatches)")
+        delete t32
+        delete t8
+    }
+}
+
 // the deltanet-plane engage count for one plane kind — a silently-demoted tag would otherwise
 // pass the parity green on the q8 fallback rail
 def private dn_kq_engaged(fmts : array<KqFmt>) : int64 {


### PR DESCRIPTION
**Behavior change: `IMAGE_VERSION` moves to 33 - every prepared `.dlim` re-mints once on its next load.**

**Why.** An untied Q8 model kept its token-embedding table as f32 in `fblob`, vocab x dim floats: 37 MB on stories15M, 1.24 GB on the 152k-vocab Qwen3-30B-A3B. The flag that dropped the table (`cls_q8`) also meant "the tied classifier matmuls the Q8 quants", so a model with its own `output.weight` never took it.

**What changes.**
- `Model.emb_q8` names the embedding half alone: a Q8 load of a Q8_0 `token_embd` keeps the linear q8 copy at `emb_q8_off` and no f32 table, tied or untied; `cls_q8` keeps its classifier meaning (`cls_q8` = tied and `emb_q8`).
- The layout carves the copy in the untied branch, the loader skips the f32 read and transcodes `token_embd` beside `output.weight`.
- `embed_row`, the trim rail's `embq` build and the Metal blob eligibility gate read `emb_q8`; the image meta serializes it.
- The image rail's planar-to-blob rebake works again. Since the review-round fix batch of 2026-08-29 a metal-mode load that found a planar image mapped it and asked `metal_blob_eligible`, which refuses every mapped model, so the blob flavor was never rebaked and a GPU box served from the CPU planes for the rest of the process. The layout question is now `metal_blob_form_ok` (quant, packing flags, alignment); `metal_blob_eligible` keeps the in-place-transform refusal on top of it. The `metal` image arm was red on master for this; it caught the untied cell first.

**Observable behavior.**
- metal-mode load with a planar image already on disk -> the blob flavor is rebaked from the gguf and the GPU serves (was: planar mapped, CPU served, silently).
- untied Q8 load -> no f32 embedding table: stories15M's image 51 MB -> 26.6 MB; TinyLlama-1.1B drops 262 MB, Phi-3.5-mini 394 MB, Qwen3-30B-A3B 1.24 GB (sized, not measured). Tied models (Qwen3-4B, Llama-3.2, SmolLM2) never carried the table and are unchanged.
- any existing `.dlim` -> re-mints once on its next load (version 32 -> 33).
- Vulkan device embed on an untied q8 model -> the f32-upload arm declines, the CPU embed loop serves.

**Where to look.** `layout_offsets` and the untied `load_big` branch in `dasllama_load.das`, `embed_row` in `dasllama_common.das`; the rebake decision in `load_model_cached` (`dasllama_image.das`) and `metal_blob_form_ok` in `dasllama_layout.das`, with the rule in `ARCHITECTURE_IMAGE.md` 2.1n.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- `test_parity_untied_emb_q8_rows` (new): stories15M q8 rows bit-identical to the fp32 decode, no table kept, `embed_row` agrees.
- image suite arm `untied` (new): stories15M mint, map, token-for-token, image smaller than gguf plus an f32 table.
- image suite arm `metal-untied` (new): TinyLlama-1.1B on the Metal blob flavor - the layout gate admits the untied emb_q8 copy, cold mint + warm map keep the q8 table with no f32 copy, GPU serve, teacher-forced logits vs the CPU control (GPU greedy picks equal the CPU continuation on the counting prompt).
- image suite arm `metal` (existing): red before the rebake fix, green after - its CPU control mints the planar image first, which is the shape the rebake serves.
- The full preflight's fast tier went red once on lint: master's fresh jobque tripwire logs from a hot-path callee, which the hot-path lint walked into every kernel. Fixed here by marking that first-dispatch check a cold path; lint rerun green on all three rails. The lane gates (docs, tests-cpp, interp, JIT, AOT) did not rerun locally and are CI's; the dasLLAMA module gates (`model-free`, `stocked`) ran locally.
- Not run: Vulkan (no device here).

### Claims - stated, not tested
- Vulkan's device-side embed gather has no untied-q8 arm; the f32-upload arm now declines on `emb_q8` and the CPU embed loop serves. A break would show as a prefill on an untied q8 model under `DASLLAMA_VK_GPU_EMBED` reading an f32 table that is no longer there.

### Not done
- A Vulkan gather over the linear q8 copy for untied models.

</details>