### PR TITLE
storyteller: a restart on space stops the clip being read and skips the replaced story's queued speech; a stocked rail test; the checklist fixes its audits returned

### DIFF
--- a/examples/dasLLAMA/storyteller/main.das
+++ b/examples/dasLLAMA/storyteller/main.das
@@ -21,7 +21,9 @@ require strings
 
 // Storyteller. A tiny story model (Karpathy's stories15M, Q8) writes a children's story on
 // screen a few tokens per frame, and KittenTTS reads each finished sentence aloud in a kid's
-// voice while the next one is still being written. Space starts a new story, Escape quits.
+// voice while the next one is still being written. Space starts a new story at any moment - the
+// clip being read stops, and the sentences of the old story still queued for speech are skipped,
+// so the new one is heard at once. Escape quits.
 //
 //   bin/daslang -jit examples/dasLLAMA/storyteller/main.das -- --models <dir>
 //
@@ -57,6 +59,12 @@ struct StoryArgs {
     @clarg_doc = "Stop after this many frames (0 = never) - the smoke rail"
     max_frames : int
 
+    @clarg_doc = "Start another story at this frame, as a space press would (0 = never) - the smoke rail's restart-while-writing check"
+    restart_at : int
+
+    @clarg_doc = "Start another story when this many clips have begun playing, as a space press would (0 = never) - the smoke rail's restart-while-reading check"
+    restart_on_clip : int
+
     @clarg_short = "?"
     @clarg_name = "show-help"
     @clarg_doc = "Show this help and exit"
@@ -82,7 +90,7 @@ enum Phase {
 
 struct Line {
     text : string   //! a sentence for the speech thread; "" asks it to stop
-    story : int     //! which story it belongs to: a clip from an older story is dropped unheard
+    story : int     //! which story it belongs to: the speech thread skips a sentence of a replaced story, and a clip of one that slipped through is dropped unheard
 }
 
 struct Speech {
@@ -103,8 +111,10 @@ var g_stories = 0
 
 var g_say : Stream?               // frame thread -> speech thread: sentences
 var g_speech : Stream?            // speech thread -> frame thread: clips
+var g_story_now : SeqBox?         // frame thread -> speech thread: the story being told, so a queued sentence of an older one is skipped
 var g_speech_done : Channel?
 var g_clips : array<Speech>
+var g_playing_sid = INVALID_SID   // the clip being read; a new story stops it
 var g_elapsed_s = 0.0
 var g_speaking_until = 0.0
 var g_unplayed_sentences = 0
@@ -112,12 +122,14 @@ var g_audio_initialized = false
 var g_asch : AudioSystemChannels
 var g_font : Font?
 var g_frames = 0
+var g_clips_played = 0
+var g_rail_restarted = false      // the smoke rail's restart fires once
 var g_space_was = false
 var display_w = 0
 var display_h = 0
 
-def start_speech_thread(tts_path, voice_pick : string; var say, speech : Stream?; var done : Channel?) {
-    new_thread() <| @capture(= tts_path, = voice_pick, = say, = speech, = done) {
+def start_speech_thread(tts_path, voice_pick : string; var say, speech : Stream?; var now : SeqBox?; var done : Channel?) {
+    new_thread() <| @capture(= tts_path, = voice_pick, = say, = speech, = now, = done) {
         setup_dasllama_jobque()   // the fork-context pool is per context: without it every parallel kernel clones the program
         var inscope m <- load_tts_model(tts_path)
         var inscope c <- caps(m)
@@ -129,6 +141,14 @@ def start_speech_thread(tts_path, voice_pick : string; var say, speech : Stream?
                     running = false
                     return
                 }
+                var current = l.story
+                now |> read() $(story : int) {
+                    current = story
+                }
+                if (l.story < current) {   // a sentence of a story space already replaced: its clip would be dropped unheard, and the synthesis would keep the new story waiting
+                    to_log(LOG_INFO, "storyteller: a sentence of story {l.story} is skipped, story {current} is being told\n")
+                    return
+                }
                 var inscope a <- synthesize(m, l.text, voice, 1.0)
                 var clip = Speech(pcm := a.pcm, rate = a.sample_rate, story = l.story)
                 speech |> push_archive(clip)
@@ -136,6 +156,7 @@ def start_speech_thread(tts_path, voice_pick : string; var say, speech : Stream?
         }
         say |> release()
         speech |> release()
+        now |> seq_box_release()
         done |> notify_and_release()
     }
 }
@@ -154,17 +175,26 @@ def poll_speech() {
             g_clips |> emplace(clip)
         }
     }
-    if (g_elapsed_s >= g_speaking_until && !empty(g_clips)) {
+    return if (g_elapsed_s < g_speaking_until)
+    g_playing_sid = INVALID_SID   // the clip has played out: a restart now has nothing to stop
+    if (!empty(g_clips)) {
         let seconds = float(length(g_clips[0].pcm)) / float(max(g_clips[0].rate, 1))
         var pcm <- g_clips[0].pcm
-        play_sound_from_pcm(g_clips[0].rate, 1, pcm)
+        g_playing_sid = play_sound_from_pcm(g_clips[0].rate, 1, pcm)
         g_clips |> erase(0)
         g_speaking_until = g_elapsed_s + seconds
         g_unplayed_sentences--
+        g_clips_played++
     }
 }
 
 def start_story() {
+    if (g_playing_sid != INVALID_SID) {
+        //! the smoke rail's witness lines, here and below: modules/dasLLAMA/tests/test_storyteller_restart.das reads them word for word
+        to_log(LOG_INFO, "storyteller: the clip of story {g_stories} stops, {g_unplayed_sentences} sentences of it go unheard\n")
+        stop(g_playing_sid, 0.05)
+        g_playing_sid = INVALID_SID
+    }
     delete g_session
     g_session <- create_session(g_model)
     set_seed(g_session, int(ref_time_ticks() % 2147483647l))   // a fresh session samples the same story every time otherwise
@@ -174,6 +204,8 @@ def start_story() {
     g_sentence_pieces |> reserve(64)
     g_ntokens = 0
     g_stories++
+    g_story_now |> publish(g_stories)
+    to_log(LOG_INFO, "storyteller: story {g_stories} starts at frame {g_frames}\n")
     g_clips |> clear()
     g_unplayed_sentences = 0
     g_speaking_until = g_elapsed_s
@@ -315,9 +347,11 @@ def init() {
     allow_cpu_prefill()
     g_say = unsafe(stream_create())
     g_speech = unsafe(stream_create())
+    g_story_now = seq_box_create()
+    g_story_now |> publish(g_stories)
     g_speech_done = unsafe(channel_create())
     g_speech_done |> append(1)
-    start_speech_thread(path_join(g_args.models, g_args.tts_model), g_args.voice, g_say, g_speech, g_speech_done)
+    start_speech_thread(path_join(g_args.models, g_args.tts_model), g_args.voice, g_say, g_speech, g_story_now, g_speech_done)
     if (g_args.autoplay || g_args.smoke) {
         start_story()
     }
@@ -344,7 +378,11 @@ def update() {
     if (glfwGetKey(live_window, GLFW_KEY_ESCAPE) == GLFW_PRESS) {
         glfwSetWindowShouldClose(live_window, 1)
     }
-    if (space_just && g_phase != Phase.writing) {
+    let rail_due = (!g_rail_restarted
+        && ((g_args.restart_at > 0 && g_frames == g_args.restart_at)
+            || (g_args.restart_on_clip > 0 && g_clips_played == g_args.restart_on_clip)))
+    if (space_just || rail_due) {
+        g_rail_restarted ||= rail_due
         start_story()
     }
     if (g_phase == Phase.writing) {
@@ -359,6 +397,7 @@ def update() {
 def shutdown() {
     say("")
     g_speech_done |> join()
+    g_story_now |> seq_box_release()
     unsafe {
         channel_remove(g_speech_done)
         stream_remove(g_say)
@@ -374,9 +413,13 @@ def shutdown() {
     live_destroy_window()
 }
 
+def story_read_out() : bool {
+    return g_phase == Phase.told && g_unplayed_sentences == 0 && g_elapsed_s >= g_speaking_until
+}
+
 def done_for_smoke() : bool {
     return true if (g_args.max_frames > 0 && g_frames >= g_args.max_frames)
-    return g_args.smoke && g_phase == Phase.told && g_unplayed_sentences == 0 && g_elapsed_s >= g_speaking_until
+    return g_args.smoke && story_read_out()
 }
 
 // eval_main_loop drives the block once per frame: a blocking while-loop natively, the
@@ -389,8 +432,12 @@ def main() {
         return false if (done_for_smoke())
         return !exit_requested()
     }
+    let read_out = story_read_out()   // before shutdown: its stop sentinel goes through say(), which counts it as unplayed
     shutdown()
     if (g_args.smoke) {
+        to_log(LOG_INFO, read_out
+            ? "storyteller: story {g_stories} written and read out after {g_frames} frames\n"
+            : "storyteller: the frame cap stopped story {g_stories} after {g_frames} frames\n")
         print("{join(g_wrapped_lines, "\n")}\n")
     }
 }

--- a/modules/dasLLAMA/ENVIRONMENT.md
+++ b/modules/dasLLAMA/ENVIRONMENT.md
@@ -246,6 +246,8 @@ Apple Accelerate / AMX float lane. `DASLLAMA_ACCEL` arms the whole group.
 | `DASLLAMA_TEST_FAMILY` | text | unset | Comma-separated filter restricting which model families run. |
 | `DASLLAMA_LLAMA2C_DIR` | path | unset | Directory of llama2.c reference checkpoints for the forward/decode parity tests. |
 | `DASLLAMA_WHISPER_DIR` | path | unset | Directory of whisper models for the audio tests. |
+| `DISPLAY` | text | unset | Ambient platform variable; read only by the storyteller restart test to tell whether a Linux box has a window server for the example's window. |
+| `WAYLAND_DISPLAY` | text | unset | Ambient platform variable (the Wayland twin of DISPLAY); read only by the storyteller restart test. |
 | `DASLLAMA_CORPUS_DIR` | path | unset | Directory of audio corpus files for the transcription tests. |
 | `TMPDIR` | path | /tmp | Scratch directory for test artifacts; set by the OS on macOS. |
 | `TEMP` | path | unset | Windows scratch-directory fallback when TMPDIR is unset (the test runner's log dir). |

--- a/modules/dasLLAMA/REVIEW.md
+++ b/modules/dasLLAMA/REVIEW.md
@@ -16,8 +16,8 @@ folder's checklist.**
 
 **A diff that writes a measured number down - into `PERF_LEDGER.md`, a checked-in doc, a
 code comment, or a PR body - or adds or changes a serving path, one that serves a weight
-format, modality, family, or backend, or changes what a run with no flags and no environment
-overrides does, applies `REVIEW_MEASUREMENT.md`.**
+format, modality, family, or backend, or changes what a measured or served run with no flags and
+no environment overrides computes, applies `REVIEW_MEASUREMENT.md`.**
 
 **A change to what enters `performance/records/`, or to a provenance manifest, answers to
 `performance/REVIEW.md`.** A change to WHICH model file a recorded row or a manifest pins
@@ -82,11 +82,8 @@ front-end file - one stage of the pass that turns text into phonemes (`dasllama/
 codec, transform, tokenizer, tool-wire, media-IO or registration concern in a new place
 applies `REVIEW_PLACEMENT.md`** - the what-lands-where rules.
 
-**A routed file applies BOTH the checklist it routes to and this one; every other file under
-`modules/dasLLAMA/` applies this one.**
-
-**A diff that puts a `[test]` file requiring any `dasllama/*` module outside `tests/` (beside
-this file) is a defect.**
+**A `[test]` file that requires any `dasllama/*` module and sits under `modules/dasLLAMA/`
+outside `tests/` (beside this file) is a defect - move it into `tests/`.**
 
 **`DASLLAMA_RELEASE` (`dasllama/dasllama_version.das`) is bumped only on a declared release -
 a maintainer ruling that bench comparability is broken.** Recorded performance rows and tune
@@ -215,13 +212,13 @@ finding text states its own rule.
 `ARCHITECTURE_*.md` companion, never `ARCHITECTURE.md` - in the same change.** The line names the check and the names it licenses. A licensed name is one that check does not
 flag. When the check licenses no names, the line says so.
 
-**Checked-in prose this module owns - docs and comments, any language - that is not locating,
-patching, or reproducing work against the reference build describes an upstream mechanism in
-our own terms: no "lifted/ported verbatim from", and no name belonging to the reference build -
-symbol, header, constant, binary, project or organization - write "the reference exe" or
-"upstream" instead.** The reference build is the third-party engine this module measures
-itself against - the checkout `benchmarks/setup_lcpp_ref.das` pins. A symbol the file
-carrying that prose calls or holds as a value is its own name, not attribution.
+**Checked-in text under `modules/dasLLAMA/` - docs, comments, and string data, any language -
+that is not locating, patching, or reproducing work against the reference build describes an
+upstream mechanism in our own terms: no "lifted/ported verbatim from", and no name belonging
+to the reference build - symbol, header, constant, binary, project or organization - write
+"the reference exe" or "upstream" instead.** The reference build is the third-party engine
+this module measures itself against - the checkout `benchmarks/setup_lcpp_ref.das` pins. A
+symbol the file carrying that text calls or holds as a value is its own name, not attribution.
 
 **Prose whose job is to locate, patch, or reproduce work against the reference build names
 that build's binaries and symbols outright, and keeps that naming inside the sentences doing

--- a/modules/dasLLAMA/dasllama/dasllama_env.das
+++ b/modules/dasLLAMA/dasllama/dasllama_env.das
@@ -694,6 +694,14 @@ struct public TestEnv {
     @clarg_doc = "Directory of whisper models for the audio tests."
     whisper_dir : string = ""
 
+    @clarg_env = "DISPLAY"
+    @clarg_doc = "Ambient platform variable; read only by the storyteller restart test to tell whether a Linux box has a window server for the example's window."
+    display : string = ""
+
+    @clarg_env = "WAYLAND_DISPLAY"
+    @clarg_doc = "Ambient platform variable (the Wayland twin of DISPLAY); read only by the storyteller restart test."
+    wayland_display : string = ""
+
     @clarg_path
     @clarg_doc = "Directory of audio corpus files for the transcription tests."
     corpus_dir : string = ""

--- a/modules/dasLLAMA/performance/REVIEW.md
+++ b/modules/dasLLAMA/performance/REVIEW.md
@@ -106,11 +106,15 @@ defect - `--fetch` downloads only.** Each has its own home: a conversion recipe 
 `--convert`, a timing runs in a board cell (`gen_bench_records.das` or a
 `../benchmarks/lcpp_bench.das` cell), and a tune sidecar is written under a `--tune` run.
 
-**A change to a model row's provenance that alters which bytes verify - `bytes`, `sha256`,
-`recipe`, a new row or a new `companions` entry in `model_specs.das` or
-`profile_common.das` - or a change to `fetch_models.das` other than its comments, records
-its settling evidence in the PR description: a `fetch_models.das --` run ending
-`0 pending, 0 failed` on a box that already has the pinned files on disk.**
+**A diff that adds a row or a `companions` entry, or changes a `bytes`, `sha256` or `recipe`
+value, in `model_specs.das` or `profile_common.das` records its settling evidence in the PR
+description: one `fetch_models.das -- -o <name>` run per changed row, on a box holding that
+row's model file, ending `0 pending, 0 failed` with the row reported `ok`, plus one unscoped
+`fetch_models.das --` run in which no row the diff touched is `pending`.** A box stocks only
+some of the rows, so an unscoped run's `pending` count is the box's.
+
+**A diff that changes `fetch_models.das` beyond its comments records its settling evidence in
+the PR description: one unscoped `fetch_models.das --` run ending `0 failed`.**
 
 **A url-only re-pin - a row's `url` changed with its `bytes` and `sha256` unchanged -
 records its settling evidence in the PR description: a fetch through the new url into a

--- a/modules/dasLLAMA/performance/model_specs.das
+++ b/modules/dasLLAMA/performance/model_specs.das
@@ -285,12 +285,16 @@ let TTS_KITTEN_RECIPE = "convert: modules/dasLLAMA/performance/build_tts_data.da
 let TTS_KOKORO_RECIPE = "convert: modules/dasLLAMA/performance/build_tts_data.das -- --root <g2p experiment root> --out <models dir> runs harness/convert_kokoro.py over hexgrad/Kokoro-82M @ f3ff3571791e39611d31c381e3a41a3af07b4987 (kokoro-v1_0.pth + the voice packs into GGUF, f32); THIRD_PARTY_NOTICES.md (repo root) carries the terms"
 let TTS_PACKS_RECIPE = "mint: modules/dasLLAMA/performance/build_tts_data.das -- --root <g2p experiment root> --out <models dir> runs harness/build_g2p_data.py (misaki 0.9.4 gold/silver + CMUdict 0.7a + the g2p_en 2.1.0 GRU + harness/g2p_local_additions.json into tts_g2p.bin) and harness/train_postag.py (UD English-EWT + spaCy-labelled silver prose into tts_postag.bin)"
 let TTS_ORACLE_RECIPE = "mint: modules/dasLLAMA/performance/build_tts_data.das -- --root <g2p experiment root> --out <models dir> runs the PyTorch / ONNX reference per model over the bring-up sentences and dumps every stage the parity rail (tests/_tts_parity.das) compares"
+//! the storyteller example's story model: converted on-box from the llama2.c checkpoint - no registry
+//! serves the gguf, and the converter's output bytes move with its version, so it is presence-gated
+let STORIES15M_RECIPE = "convert: the reference build's llama-convert-llama2c-to-ggml --copy-vocab-from-model tokenizer.bin --llama2c-model stories15M.bin over karpathy/tinyllamas ({HF}/karpathy/tinyllamas: stories15M.bin + tokenizer.bin, the llama2.c checkpoint), then its llama-quantize to Q8_0; bytes are per-converter-version - the gate is the storyteller's smoke rail (tests/test_storyteller_restart.das), which writes and reads a story out of it: a smoke, not a parity check, the toy model pins no reference output"
 
 // The text-model set, ascending size. Absent files skip at run time, so one table serves every
 // box; each view measures/verifies the subset it actually has. Audio models live in
 // [[asr_catalog]] (their provenance rides those specs into [[models_provenance]]).
 def model_specs() : array<ModelSpec> {   // nolint:STYLE038 — flat model-set table, one entry per carrier
     return <- [
+        ModelSpec(file = "stories15M-Q8_0.gguf", recipe = STORIES15M_RECIPE),   // llama2.c's TinyStories writer behind examples/dasLLAMA/storyteller; profiled nowhere
         ModelSpec(file = "SmolLM2-135M-Instruct-Q8_0.gguf", display = "SmolLM2-135M"),
         ModelSpec(file = "Qwen2.5-0.5B-Instruct-Q8_0.gguf", display = "Qwen2.5-0.5B"),
         ModelSpec(file = "Qwen3-0.6B-Q8_0.gguf", display = "Qwen3-0.6B",

--- a/modules/dasLLAMA/tests/CLAUDE.md
+++ b/modules/dasLLAMA/tests/CLAUDE.md
@@ -223,7 +223,7 @@ the device-free rail unit; the serving vulkan census runs on the PC box.
 
 The `kernels` suite (test_metal_{prefill,decode,rope,gemv,misc,attn,gemm}_kernels - model-less
 per-class CPU-oracle units covering the FULL metal kernel census, ~2-3 min) has no arms;
-remember it exists (the hand-bound-gate sync obligation is `REVIEW.md`'s). The misc file also
+remember it exists (the hand-bound-gate sync obligation is `REVIEW_KERNEL_CELLS.md`'s). The misc file also
 carries `test_lens_tgmem_gate` - not a CPU-oracle unit: it spawns two `daslang -compile-only`
 child builds (up to 120 s each) proving the lens refuses a `[metal_dispatch]` class with
 `@workgroup` members and no `tgmem=`, twin fixture as the must-compile control. Shared fixtures
@@ -233,7 +233,8 @@ compares local - a same-arity twin would collide with the shared tagged one. `_m
 is the `[metal_dispatch]` multi-kernel (kernel=) fixture; its gate in the misc file
 dispatches through the GENERATED builders (kn_ rail), not hand binds.
 
-The control obligation for a new gate or bar is `REVIEW.md`'s. Size a poison as a value ADDED
+The control obligation for a new gate is `REVIEW_KERNEL_CELLS.md`'s, for a new or loosened bar
+`REVIEW.md`'s. Size a poison as a value ADDED
 to the expected result, not as a multiple of the tolerance. A tolerance that scales with the
 accumulation length swallows a scaled poison at the kernel's longest dot product, which is
 exactly where a bug hides. Every compare against a derived truth gets its own poison. A

--- a/modules/dasLLAMA/tests/REVIEW.md
+++ b/modules/dasLLAMA/tests/REVIEW.md
@@ -4,6 +4,11 @@
 doc: `CLAUDE.md`. Planned work: `../followup_general.md`, `../followup_vulkan.md`,
 `../followup_metal.md`.
 
+**A kernel-unit cell - a model-less cell that dispatches one kernel class and asserts on its
+output - or a gate that hand-dispatches or hand-binds a kernel, wherever the diff puts it, and
+a diff that changes a `[metal_dispatch]` or `[vk_dispatch]` class's dispatch geometry, kargs,
+or kargs fields, apply `REVIEW_KERNEL_CELLS.md` (beside this file) together with this list.**
+
 **Every PR runs `run.das -- --suite model-free` and `run.das -- --suite stocked` on a box with
 the models stocked, plus every test here the change reaches - never the whole directory.** A
 change reaches a test when it alters anything the test's result depends on - the test file, a
@@ -45,10 +50,11 @@ or skip condition.** A clause that only names the file (a brace list, a suite ro
 nothing to correct.
 
 **A diff that changes `run.das`'s flag surface - a flag, a suite name, an area name, or what a
-flag runs - adds it to or corrects it in `CLAUDE.md`'s "Run suites ONLY through the runner" block
-and `../CLAUDE.md`'s "Test workflow" section in the same change.** Both restate the surface for an
-agent that reads them cold; a copy the code has left behind sends that agent to a flag that no
-longer does what the text says.
+flag does, never the roster of files a suite or area lists - adds it to or corrects it in
+`CLAUDE.md`'s "Run suites ONLY through the runner" block and `../CLAUDE.md`'s "Test workflow"
+section in the same change.** Both documents restate the surface for an agent that reads them
+cold; a copy the code has left behind sends that agent to a flag that no longer does what the
+text says.
 
 **A new test file listed in `run.das`'s `model-free` or `stocked` suite, or in no `run.das`
 suite at all, whose name does not say what it covers, gets a `CLAUDE.md` entry in the same
@@ -79,12 +85,16 @@ matmul picks for a given width and row count, and whether that dispatch splits i
 across partial planes); `utils/dasllama-server/test_worker_dispatch.das` (repo root: worker-local fork pools, shared queue policy).
 
 **A diff that adds a gate whose failure means a documented contract changed, rather than a
-kernel regressing, adds it to the pinned set above in the same change** - as a file when every
+kernel regressing, adds it to the pinned set in the same change** - as a file when every
 cell of it pins, as a named cell otherwise.
 
 **On every platform, a cell that neither asserts nor registers a skip is a defect.** A cell
 that returns without asserting - the module is absent, its models are not stocked, no device
 answered, a capability declined - registers `t |> skip` there; `feint` is a print, not a skip.
+
+**A cell whose claim needs a capability the box may lack - a window server, an audio device, a
+module the build omits - registers `t |> skip` on that fact before it asserts; a cell that reds
+on one instead is a defect.**
 
 **A cell's skip condition keys on a fact the box owns - a device capability, a run-mode knob's
 value, a host toolchain's presence, a compile-time module-presence check
@@ -95,14 +105,20 @@ dump a test wrote).** An artifact condition goes permanently false when its prod
 
 **A test that loads a model above the large tier (`LARGE_TIER_BYTES`, `_model_tier.das`)
 without gating on `DASLLAMA_PARITY_FULL=1` is a defect** - `DASLLAMA_PARITY_FULL=1` is a final
-pre-PR switch, not the iteration loop. In this folder the spelling is `model_available`
-(`_model_tier.das`). A test that cannot require `_model_tier.das` open-codes the same env check.
+pre-PR switch, not the iteration loop.
 
-**A test - or a program a test builds or spawns - whose subject is not the `.dlim` image
-rail never calls `load_model`, `load_model_cached`, or `load_model_image` - it loads each
-carrier through that carrier's own loader.** Decoders: `load_model_`
-(`../dasllama/dasllama_load.das`); other carriers: `load_<family>_tower` / `load_<family>_encoder`
-/ `load_<carrier>_model`; TTS: `load_tts_model` or `load_styletts2`.
+**A cell that gates on a stocked model file - a `.gguf` carrier, its shards, or an mmproj - gates
+through `model_available` (`_model_tier.das`), one call per file; a test that cannot require
+`_model_tier.das` open-codes the same two checks: the file and every sibling shard are present,
+and their total size is under `LARGE_TIER_BYTES` unless `DASLLAMA_PARITY_FULL=1` is set.** Every
+other stocked fixture gates on its own presence.
+
+**A test - or a program a test builds or spawns - whose subject is not the `.dlim` image rail
+never mints or maps an image: it either runs with `DASLLAMA_IMAGE=0` in its environment, or
+calls no `load_model`, `load_model_cached`, or `load_model_image` and loads each carrier through
+that carrier's own loader.** Decoders: `load_model_` (`../dasllama/dasllama_load.das`); other
+carriers: `load_<family>_tower` / `load_<family>_encoder` / `load_<carrier>_model`; TTS:
+`load_tts_model` or `load_styletts2`.
 
 **A predicate whose value the BOX decides (a device capability, a policy default) and that
 therefore cannot differ between two runs on one machine is never tested through its own
@@ -112,21 +128,6 @@ value; test it through the argv it gates or the mode it selects.**
 registry, and never calls it directly.** A registry is the storage a `register_*` call writes
 and a lookup reads at dispatch - a table, a list, or a single hook global - or the `[EnvConfig]`
 env registry.
-
-**A diff that changes a kernel's dispatch geometry - its grid divisor, threadgroup size, or
-threadgroup-memory length - updates every gate that hand-dispatches that kernel, in the same
-change.** A hand-dispatched gate encodes the geometry itself, so a moved divisor leaves the
-gate dispatching the wrong shape with no error.
-
-**A diff that changes a kernel's kargs - the kernel-argument struct, or any buffer binding -
-updates every gate that hand-binds that kernel, in the same change.** A stale hand bind reads
-the wrong buffer and passes on garbage that happens to compare.
-
-**A kernel that gains a kargs field whose non-default value changes what it computes or which
-elements it reads or writes - a branch selector, a row or element base, a stride - ships, in
-the same change, a gate cell that sets that field to a non-default value.** At the default the
-new field has no visible effect: a CPU oracle that ignores it and the kernel that honors it
-agree.
 
 **A new pre-tokenizer family or backend ships its `corpus_case` arm in `test_tokenizer.das`,
 naming the `ggml-vocab-*.gguf` fixture.**
@@ -151,22 +152,6 @@ assert pinning the lane.** Freeform coverage across a pair that rounds different
 forced-feed logits-tolerance form - the same fixed tokens fed to both sides, logits compared
 within a bar. Counting cells - those whose prompt forces a continuation that cannot tie, so
 greedy tokens are fixed - stay token-exact.
-
-**A kernel-unit cell - a model-less cell that dispatches one kernel class and asserts on its
-output - missing a compare against a CPU oracle that can witness the cell's property is a
-defect.**
-
-**A kernel-unit cell fills a GPU output buffer with a sentinel before every dispatch whose
-output it then reads.** An unprefilled output can pass by staying stale - the previous
-dispatch's values, or garbage that happens to sit inside the tolerance bar.
-
-**A cross-dispatch bit-identity compare - comparing the outputs of two dispatches - runs GPU
-against GPU.** No CPU oracle can witness that property.
-
-**A kernel-unit cell whose output buffer is its input buffer, and whose CPU oracle does not
-differ from that input by construction, pairs its compare with an assert that the output
-differs from the input at a known index.** An in-place kernel that never ran leaves the input,
-which can wrongly satisfy a tolerant compare.
 
 **An ASR family with no token-for-token oracle cell is a defect** - the cell compares a
 transcript against a reference leg, external dump or CPU control alike.
@@ -256,11 +241,6 @@ transcendentals is not exact-value: it is not float-portable.
 **An embedding-parity cell that does not name its fixture, or does not log the measured
 maxdiff on green as well as red, is a defect.**
 
-**A kernel-unit cell that dispatches a `[metal_dispatch]` or `[vk_dispatch]` class no cell
-dispatched before ships a control that reds it in the same change.** A control is a run of
-the same gate that must RED - a poisoned input, a poisoned expectation, a disconnected
-mechanism, or a second independent lane; a gate's own reference is never its control.
-
 **A cell that adds or loosens a tolerance bar ships, in the same change, a control that lands
 outside the new bar.** A bar nothing has ever exceeded is not known to discriminate.
 
@@ -269,17 +249,6 @@ change** - the wire-shape pins, the render pins, and a live server case gated on
 smallest GGUF that sits under `LARGE_TIER_BYTES` (`_model_tier.das`) (the file homes are
 `CLAUDE.md`'s "The per-PR suites - model-free and stocked" and "Out-of-folder test files" notes). A family
 whose vocab carries no thinking or tool markers has no format to test.
-
-**A kernel-unit cell whose kernel reads f16 operands and whose oracle is wider-precision
-feeds inputs that are exact in f16.** Otherwise the compare measures input rounding, and the
-bar has to be loosened until it no longer discriminates.
-
-**A gate for a kernel that attends inside a restricted horizon - a window, a sliding span, a
-block-diagonal range - writes its CPU oracle to attend strictly inside that horizon.** A leak
-then reds the ordinary compare, so the gate needs no separate leak control.
-
-**A cell whose only compare is bit-identity between two kernel forms also compares one of the
-two against a CPU oracle, in the same cell.** Two forms can be bit-equal and both wrong.
 
 **A poison control on a tower the Metal driver serves - a run of the gate with the tower's
 weights zeroed, which must RED - zeroes every weight buffer the served route reads.** Which

--- a/modules/dasLLAMA/tests/REVIEW_KERNEL_CELLS.md
+++ b/modules/dasLLAMA/tests/REVIEW_KERNEL_CELLS.md
@@ -1,0 +1,55 @@
+# dasLLAMA tests - Kernel Cells Code Review Checklist
+
+**Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture
+doc: `CLAUDE.md`. Planned work: `../followup_general.md`, `../followup_vulkan.md`,
+`../followup_metal.md`.
+
+**Routed from `REVIEW.md` (beside this file): a diff that checklist routes here applies this
+list together with it.**
+
+**A diff that changes a kernel's dispatch geometry - its grid divisor, threadgroup size, or
+threadgroup-memory length - updates every gate that hand-dispatches that kernel, in the same
+change.** A hand-dispatched gate encodes the geometry itself, so a moved divisor leaves the
+gate dispatching the wrong shape with no error.
+
+**A diff that changes a kernel's kargs - the kernel-argument struct, or any buffer binding -
+updates every gate that hand-binds that kernel, in the same change.** A stale hand bind reads
+the wrong buffer and passes on garbage that happens to compare.
+
+**A kernel that gains a kargs field whose non-default value changes what it computes or which
+elements it reads or writes - a branch selector, a row or element base, a stride - ships, in
+the same change, a gate cell that sets that field to a non-default value.** At the default the
+new field has no visible effect: a CPU oracle that ignores it and the kernel that honors it
+agree.
+
+**A kernel-unit cell - a model-less cell that dispatches one kernel class and asserts on its
+output - missing a compare against a CPU oracle that can witness the cell's property is a
+defect.**
+
+**A kernel-unit cell fills a GPU output buffer with a sentinel before every dispatch whose
+output it then reads.** An unprefilled output can pass by staying stale - the previous
+dispatch's values, or garbage that happens to sit inside the tolerance bar.
+
+**A cross-dispatch bit-identity compare - comparing the outputs of two dispatches - runs GPU
+against GPU.** No CPU oracle can witness that property.
+
+**A kernel-unit cell whose output buffer is its input buffer, and whose CPU oracle does not
+differ from that input by construction, pairs its compare with an assert that the output
+differs from the input at a known index.** An in-place kernel that never ran leaves the input,
+which can wrongly satisfy a tolerant compare.
+
+**A kernel-unit cell that dispatches a `[metal_dispatch]` or `[vk_dispatch]` class no cell
+dispatched before ships a control that reds it in the same change.** A control is a run of
+the same gate that must RED - a poisoned input, a poisoned expectation, a disconnected
+mechanism, or a second independent lane; a gate's own reference is never its control.
+
+**A kernel-unit cell whose kernel reads f16 operands and whose oracle is wider-precision
+feeds inputs that are exact in f16.** Otherwise the compare measures input rounding, and the
+bar has to be loosened until it no longer discriminates.
+
+**A gate for a kernel that attends inside a restricted horizon - a window, a sliding span, a
+block-diagonal range - writes its CPU oracle to attend strictly inside that horizon.** A leak
+then reds the ordinary compare, so the gate needs no separate leak control.
+
+**A cell whose only compare is bit-identity between two kernel forms also compares one of the
+two against a CPU oracle, in the same cell.** Two forms can be bit-equal and both wrong.

--- a/modules/dasLLAMA/tests/run.das
+++ b/modules/dasLLAMA/tests/run.das
@@ -199,6 +199,7 @@ def suite_files(name : string) : array<string> {   // nolint:STYLE038 - a flat s
                     "modules/dasLLAMA/tests/test_qwen25v.das",
                     "modules/dasLLAMA/tests/test_sampling.das",
                     "modules/dasLLAMA/tests/test_scheduler.das",
+                    "modules/dasLLAMA/tests/test_storyteller_restart.das",
                     "modules/dasLLAMA/tests/test_tokenizer.das",
                     "modules/dasLLAMA/tests/test_tts_postag.das",
                     "modules/dasLLAMA/tests/test_tts_g2p.das",
@@ -241,8 +242,8 @@ def area_tests(area : string) : array<string> {
                     "test_qwen3v.das", "test_tower_helpers.das", "test_vision.das", "test_vision_chat.das",
                     "test_vision_embedder.das" ]
     } elif (area == "tts") {
-        return <- [ "test_tts_blocks.das", "test_tts_facade.das", "test_tts_g2p.das", "test_tts_kitten.das",
-                    "test_tts_kokoro.das", "test_tts_postag.das", "test_tts_textnorm.das" ]
+        return <- [ "test_storyteller_restart.das", "test_tts_blocks.das", "test_tts_facade.das", "test_tts_g2p.das",
+                    "test_tts_kitten.das", "test_tts_kokoro.das", "test_tts_postag.das", "test_tts_textnorm.das" ]
     } elif (area == "infra") {
         return <- [ "failed_dasllama_lint_require.das", "failed_dasllama_lint_sidedoor.das", "test_bench_records_schema.das",
                     "test_box_ident.das", "test_box_profile.das", "test_dasllama_lint_contracts.das",
@@ -265,7 +266,7 @@ def area_tests(area : string) : array<string> {
                     "test_q8q8_family.das", "test_quant.das",
                     "test_repack.das", "test_repack_lane_context.das", "test_rmsnorm.das", "test_rope.das", "test_rope_apply.das",
                     "test_sampling.das",
-                    "test_scheduler.das", "test_silu.das", "test_softmax.das", "test_think_split.das", "test_tokenizer.das",
+                    "test_scheduler.das", "test_silu.das", "test_softmax.das", "test_storyteller_restart.das", "test_think_split.das", "test_tokenizer.das",
                     "test_tool_formats.das", "test_unicode.das", "test_vulkan_dec_tail.das", "test_vulkan_kernels.das",
                     "test_vulkan_moe_cm2.das", "test_vulkan_tier.das" ]
     }

--- a/modules/dasLLAMA/tests/test_run_suites.das
+++ b/modules/dasLLAMA/tests/test_run_suites.das
@@ -155,7 +155,7 @@ def test_areas_for_path(t : T?) {
 [test]
 def test_area_plan(t : T?) {
     let tts <- area_plan(["tts"])
-    t |> equal(length(tts.files), 8, "tts plans its seven files and the image file its kitten arm rides")
+    t |> equal(length(tts.files), 9, "tts plans its eight files and the image file its kitten arm rides")
     t |> equal(tts.image_arms, "kitten", "tts owns the kitten image arm")
     t |> equal(tts.files[length(tts.files) - 1], "{TESTS_DIR}/test_model_image.das", "the image file rides last")
     for (i in range(1, length(tts.files) - 1)) {
@@ -177,7 +177,7 @@ def test_area_plan(t : T?) {
     t |> equal(length(suite.files), 1, "a suite run plans the suite table")
     t |> equal(suite.image_arms, "arm12", "a suite run passes --arm through")
     let area <- plan_files(cfg, ["tts"])
-    t |> equal(length(area.files), 8, "an area run plans the area, whatever --suite says")
+    t |> equal(length(area.files), 9, "an area run plans the area, whatever --suite says")
 }
 
 //! the argument contracts: an area run refuses --arm/--full/--suite and an unknown area; a per-PR

--- a/modules/dasLLAMA/tests/test_storyteller_restart.das
+++ b/modules/dasLLAMA/tests/test_storyteller_restart.das
@@ -1,0 +1,164 @@
+options gen2
+options stack = 524288   // every dasLLAMA program root takes this budget (options stack does not unify up from libs)
+options _dasllama_internal = true
+
+require dastest/testing_boost public
+require dasllama/dasllama_env
+require daslib/fio
+require daslib/strings_boost
+require daslib/strings_convert
+require daslib/env_registry
+require math
+require strings
+require _model_tier
+
+// The storyteller's restart rails (examples/dasLLAMA/storyteller/main.das): a space press while a
+// story is being read stops the clip and starts another, and the speech thread skips the queued
+// sentences of the replaced story instead of synthesizing them first. Each cell spawns the example
+// under --smoke - with --restart-on-clip N (a space press as the Nth clip begins) or --restart-at N
+// (a space press at frame N) - and reads the witness lines the example logs; a frame count is
+// the instrument only while the story is being written, since an unthrottled window runs
+// thousands of frames a second once it idles. Model-gated on stories15M-Q8_0.gguf (its ../performance/model_specs.das
+// row names the conversion), kitten-nano.gguf and the front-end packs under models_dir(); a run
+// opens the example's window for up to a minute, so a box without a window server skips, and
+// --null-audio keeps the run silent.
+
+let STOP_LINE = "storyteller: the clip of story 1 stops, "
+let SKIP_LINE = "storyteller: a sentence of story 1 is skipped, story 2 is being told"
+let DONE_LINE = "storyteller: story 2 written and read out"
+let CAP_LINE = "storyteller: the frame cap stopped story 1 after 30 frames"
+let FIRST_START = "storyteller: story 1 starts at frame 0"
+let RESTART_MARK = "storyteller: story 2 starts at frame "
+let CAP_FRAMES = 30
+let NO_CAP = 0   //! a story takes a minute to read out at any frame rate - the spawn's wall clock is the guard
+let PACK_FILES <- ["tts_g2p.bin", "tts_postag.bin"]
+
+def private self_daslang() : string {
+    let argv <- get_command_line_arguments()
+    return find(to_generic_path(argv[0]), "/") < 0 ? argv[0] : get_full_file_name(normalize(argv[0]))
+}
+
+//! the example opens a GLFW window: a Linux box reached over ssh has no window server, and that is the box's fact, not a red
+def private has_window_server() : bool {
+    return get_platform_name() != "linux" || !empty(g_env_test.display) || !empty(g_env_test.wayland_display)
+}
+
+//! the window server and every fixture file, each absence registering its own loud skip
+def private ready(t : T?) : bool {
+    if (!has_window_server()) {
+        t |> skip("no window server (DISPLAY and WAYLAND_DISPLAY unset) - the example opens a window")
+        return false
+    }
+    for (name in ["stories15M-Q8_0.gguf", "kitten-nano.gguf"]) {
+        return false if (!model_available(t, path_join(models_dir(), name)))
+    }
+    for (name in PACK_FILES) {
+        if (!stat(path_join(models_dir(), name)).is_valid) {
+            t |> skip("{name} not present")
+            return false
+        }
+    }
+    return true
+}
+
+//! the example's smoke rail: a space press at frame `restart_at` or as clip `restart_on_clip` begins (0 = none),
+//! a stop at `max_frames` (0 = none); a non-empty `lanes` pins DAS_JOBQUE_THREADS for the child, which slows
+//! the speech thread's model load and starves it
+def private run_storyteller(restart_at, restart_on_clip, max_frames : int; lanes : string; var out : string&) : int {
+    let prev_image = env_value_of("DASLLAMA_IMAGE")
+    let prev_lanes = env_value_of("DAS_JOBQUE_THREADS")
+    set_env_variable("DASLLAMA_IMAGE", "0")   //! never mint a sidecar beside the stocked models
+    if (!empty(lanes)) {
+        set_env_variable("DAS_JOBQUE_THREADS", lanes)
+    }
+    let root = get_das_root()
+    var argv <- [self_daslang(), "-jit", "-dasroot", root, "{root}/examples/dasLLAMA/storyteller/main.das", "--",
+                 "--models", models_dir(), "--smoke", "--max-frames", "{max_frames}", "--null-audio"]
+    if (restart_at > 0) {
+        argv |> push("--restart-at")
+        argv |> push("{restart_at}")
+    }
+    if (restart_on_clip > 0) {
+        argv |> push("--restart-on-clip")
+        argv |> push("{restart_on_clip}")
+    }
+    let rc = run_and_capture(argv, out, 300.0)
+    set_env_variable("DASLLAMA_IMAGE", prev_image)
+    if (!empty(lanes)) {
+        set_env_variable("DAS_JOBQUE_THREADS", prev_lanes)
+    }
+    return rc
+}
+
+def private count_of(hay, needle : string) : int {
+    var n = 0
+    var at = find(hay, needle)
+    while (at >= 0) {
+        n++
+        at = find(hay, needle, at + length(needle))
+    }
+    return n
+}
+
+//! the unheard count the stop line carries; -1 when the line is absent or does not parse
+def private unheard_of(out : string) : int {
+    let at = find(out, STOP_LINE)
+    return -1 if (at < 0)
+    let start = at + length(STOP_LINE)
+    let stop = find(out, " sentence", start)
+    return -1 if (stop < 0)
+    let r = try_to_int(slice(out, start, stop))
+    return r |> is_err ? -1 : r |> unwrap
+}
+
+def private witness(out : string) : string {
+    var inscope lines <- split(out, "\n")
+    return join([for (line in lines); line; where find(line, "storyteller:") >= 0], "\n")
+}
+
+def private tail_of(out : string) : string {
+    return slice(out, max(0, length(out) - 600))
+}
+
+[test]
+def test_restart_while_reading(t : T?) {
+    t |> run("a space press while the story is being read stops its clip, drops its unplayed sentences, and the next story is read out") @(t : T?) {
+        return if (!ready(t))
+        var out = ""
+        let rc = run_storyteller(0, 2, NO_CAP, "", out)   // as story 1's second clip begins: written out, being read
+        t |> equal(0, rc, "the smoke run exits clean: {tail_of(out)}")
+        t |> equal(count_of(out, RESTART_MARK), 1, "one restart:\n{witness(out)}")
+        t |> equal(count_of(out, STOP_LINE), 1, "story 1's clip was playing and stopped once:\n{witness(out)}")
+        t |> success(unheard_of(out) >= 1, "the restart found unplayed sentences of story 1 to drop:\n{witness(out)}")
+        t |> success(find(out, DONE_LINE) >= 0, "story 2 was written and read out to the end:\n{witness(out)}")
+    }
+}
+
+[test]
+def test_restart_skips_the_replaced_story_queue(t : T?) {
+    t |> run("a restart while the speech thread is still loading its model skips the replaced story's queued sentences") @(t : T?) {
+        return if (!ready(t))
+        var out = ""
+        let restart_at = 100   // story 1 is still being written; the starved speech thread has sentences queued
+        let rc = run_storyteller(restart_at, 0, NO_CAP, "2", out)
+        t |> equal(0, rc, "the smoke run exits clean: {tail_of(out)}")
+        t |> equal(count_of(out, "{RESTART_MARK}{restart_at}"), 1, "one restart, at the frame the rail named:\n{witness(out)}")
+        let skipped = count_of(out, SKIP_LINE)
+        t |> success(skipped >= 1, "the speech thread skipped story 1's queued sentences instead of synthesizing them first:\n{witness(out)}")
+        t |> success(find(out, DONE_LINE) >= 0, "story 2 was written and read out to the end:\n{witness(out)}")
+        feint("storyteller restart while starved: {skipped} sentences skipped, unheard {unheard_of(out)}\n")
+    }
+}
+
+[test]
+def test_frame_cap_and_no_restart_by_default(t : T?) {
+    t |> run("the frame cap ends an unread story, and the rail restarts nothing on its own") @(t : T?) {
+        return if (!ready(t))
+        var out = ""
+        let rc = run_storyteller(0, 0, CAP_FRAMES, "", out)
+        t |> equal(0, rc, "the capped run exits clean: {tail_of(out)}")
+        t |> success(find(out, FIRST_START) >= 0, "the first story starts at frame 0:\n{witness(out)}")
+        t |> success(find(out, CAP_LINE) >= 0, "the cap line names the story and the frame it stopped at:\n{witness(out)}")
+        t |> equal(count_of(out, RESTART_MARK), 0, "no --restart-at, no second story:\n{witness(out)}")
+    }
+}


### PR DESCRIPTION
**behavior change: the storyteller restarts on space at any moment - the running story's voice stops and the next one is heard at once.**

**Why.** On dasllama.io's storyteller, spamming space silenced the voice for seconds to minutes and could play two stories at once: a restart never stopped the clip being read, and the speech thread synthesized every queued sentence of every abandoned story before it reached the new one.

**What changes.**
- A new story stops the clip being read: the sound id is kept and `stop` is sent with a short fade.
- A SeqBox carries the current story number to the speech thread, which skips a queued sentence of a replaced story instead of synthesizing it.
- Space starts a new story in every phase, writing included.
- The smoke rail gains `--restart-on-clip N` and `--restart-at N` (a space press as the Nth clip begins, or at frame N) and logs each story's start, the clip stop, the skips, and whether the story was read out; a stocked test spawns it three ways and reads those lines.
- `stories15M-Q8_0.gguf` gets a recipe-only `model_specs` row naming its llama2.c conversion, so the test's fixture has a producer.
- Three dasLLAMA checklists get the rule fixes their audits returned, and `tests/REVIEW.md` splits its kernel-cell rules into the routed `REVIEW_KERNEL_CELLS.md` to stay under the 300-line cap.

**Observable behavior.**
- space while "writing..." is ignored -> starts a new story
- the old clip keeps sounding under the new story's first clip -> the old clip stops
- the new story's speech waits for every abandoned sentence to synthesize -> it starts after at most one in-flight sentence
- `--smoke` prints the story -> it also logs `storyteller: story N starts at frame F`, the clip stop, and `story N written and read out after F frames`
- stocked suite: one more file, skipped without the storyteller model set or a window server; the tts area plans 8 files, not 7

**Where to look.** `start_story` and the speech-thread lambda in `examples/dasLLAMA/storyteller/main.das`; the three cells of `test_storyteller_restart.das` and the witness lines they read.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Browser (CI cannot): the wasm64 build (emsdk 5.0.7, the libc++ + exceptions host) served with the `dasllama-web` release model set, Chrome 153 under Playwright. Eight held space presses at 0.5 s intervals started stories 3 to 10; every restart that found a playing clip logged the stop, 5 to 11 queued sentences were skipped per replaced story, and the last story's first synthesis came 0.1 s after its press. No console errors.
- Native rails on the M5: the new test green on all three cells (129 s); with the two new arms disabled (`if (false && ...)`) the reading cell and the queue cell both went red, the file restored from git afterwards. An unthrottled window ran the loop at thousands of frames a second, which is why the reading cell keys on the second clip beginning rather than on a frame count.
- `fetch_models.das -- -o stories15M` (verify, scoped to the new row): `stories15M-Q8_0.gguf - present; convert: ...` then `1 ok, 0 fetched, 0 pending, 0 failed`, exit 0. The unscoped run ends `48 ok, 0 fetched, 9 pending, 0 failed`; the 9 pending are rows the diff does not touch and this box never stocked (gemma-4-E4B, gemma-4-26B, Qwen3.8-27B UD carriers, kitten-mini, kokoro-82m, tts_g2p_en_us.bin, the three tts_oracle dumps).
- The stocked test wants `stories15M-Q8_0.gguf`, `kitten-nano.gguf`, `tts_g2p.bin` and `tts_postag.bin` at the models root and a window server; it skips honestly elsewhere.
- `run.das -- --suite model-free`: 71 files, 1 red - `test_env_registry.das`, the test's two ambient reads (`DISPLAY`, `WAYLAND_DISPLAY`) undeclared; declared in the registry, `ENVIRONMENT.md` regenerated, the file re-run green (14/14). `run.das -- --suite stocked`: 40 files, 0 failed, 40 cells skipped (absent fixtures and devices, each loud); `test_storyteller_restart.das` 6/6 in 158 s inside it.
- preflight `--full`: 12 passed, 0 failed, 6 skipped (383 s) at the tip before the audit fixes; the lint, review-md, md-ascii and docs gates re-run green on the final shape. Preflight runs neither dasLLAMA suite, so they ran by hand above.
- Woodpecker (the codex native review against origin/master, one round): no findings; its exec trace read every changed file.
- Checklist edits: each edited checklist had a dragon round, its fixes applied, and a fresh cold read that returned only pointer or wording nits on the batch (applied) and pre-existing findings (ledgered below); the routing line's second kind and two dropped positional pointers landed after the cold read, un-dragoned.
- Skipped: the comment harvest and style-hygiene rows (standing ruling), the full review round (a small diff).

### Claims - stated, not tested
- The key predicate no longer gated on the writing phase has no headless instrument; the Playwright run above (presses landing mid-write started a new story every time) is its witness.
- The queue cell relies on the speech thread's model load outlasting 100 frames on two compute lanes; on every rate seen here (60 to 4000 frames a second) that left 3 to 10 sentences to skip, and a box that loads the TTS model in a fraction of a frame's hundred would leave it nothing - it reads as a red with the witness lines printed, never as a silent pass.
- In the browser the stop command's arrival at the mixer is inferred from the log line and the native rail; the page has no audible check.
- The "nothing playing" arm of the stop guard (a restart before any clip started) runs in the queue cell but is not distinguished by an assert.

### Not done
- The dasllama.io page updates when pages.yml redeploys from master.
- The shutdown sentinel still goes through `say("")` and counts as an unplayed sentence; the rail reads its verdict before shutdown instead of changing that.
- Dragon findings on pre-existing rules judged outside this batch: two test-enforced clauses in `tests/REVIEW.md` (the `run.das` `[init]` clause, the suite-census clause) that could delete in favor of `test_run_suites.das`; the records/mtp splits and the REVIEW.das-scope exception in `performance/REVIEW.md`; a timelessness wording in the root checklist.
- Lint candidates the dragons named: a `REVIEW.das` walk for a `[test]` file requiring `dasllama/*` outside `tests/`; `[EnvConfig]` structs absent from `env_markdown()`; `[tune_perm] requires=` names outside `TUNE_KNOWN_FEATURES`; a `CMakeLists.txt` naming a `.das` under `modules/dasLLAMA/tests/`; the records provenance walks (`tune_sha` archives, commit stamps reachable from master, `provenance.dasllama_version`, the reference-row pair).

</details>