### PR TITLE
the SDK installs the generated binding tables the shipped aot_builtin_ast.h includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1820,6 +1820,13 @@ file(GLOB DAS_BUILTIN_HEADERS ${PROJECT_SOURCE_DIR}/src/builtin/*.h)
 install(FILES ${DAS_BUILTIN_HEADERS}
     DESTINATION include/daScript/builtin
 )
+# The generated binding tables: the shipped aot_builtin_ast.h includes ast_gen.inc, so without it
+# an SDK consumer's AOT translation unit that touches the ast module fails to compile.
+install(FILES
+    ${PROJECT_SOURCE_DIR}/include/daScript/builtin/ast_gen.inc
+    ${PROJECT_SOURCE_DIR}/include/daScript/builtin/debugapi_gen.inc
+    DESTINATION include/daScript/builtin
+)
 
 # libDaScriptNano ships as sources, not as a built library: an embedder cross-
 # compiles it for their own target with their own flags, which is the whole

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -201,6 +201,21 @@ for entry in "${SHIPPED_EXE_TESTS[@]}"; do
 done
 
 echo
+echo "Shipped headers' includes:"
+# A shipped header that includes a file the install rule leaves out compiles in the tree and
+# fails in every SDK consumer; each pair below is a shipped header and a file it includes.
+for pair in "include/daScript/simulate/aot_builtin_ast.h:include/daScript/builtin/ast_gen.inc"; do
+    header="${pair%%:*}"; inc="${pair##*:}"
+    if [[ -f "$BUNDLE/$header" && -f "$BUNDLE/$inc" ]]; then
+        printf '  %-52s OK\n' "$inc"
+        PASS=$((PASS + 1))
+    else
+        printf '  %-52s MISSING (included by %s)\n' "$inc" "$header"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo
 echo "Runtime launch:"
 run_check "mcp.das (empty stdin)" bash -c \
     "'$DASLANG' utils/mcp/main.das < /dev/null"


### PR DESCRIPTION
**Behavior change: an installed SDK carries `include/daScript/builtin/ast_gen.inc` and `debugapi_gen.inc`; an SDK consumer's AOT translation unit that touches the ast module compiles again.**

**Why.** The shipped `include/daScript/simulate/aot_builtin_ast.h` includes `daScript/builtin/ast_gen.inc`, and the install rules never carried the two generated `.inc` files under `include/daScript/builtin/` - only `src/builtin/*.h` lands there. The tree compiles such a unit from its own include directory, so nothing in the repo could see it; dasProfile's AOT companion module on a Debian box did: `fatal error: 'daScript/builtin/ast_gen.inc' file not found`.

**What changes.**
- `CMakeLists.txt` installs the two `.inc` files beside the builtin headers.
- `ci/smoke_test_bundle.sh` gains a section over shipped-header includes, one line per (header, include) pair, MISSING when the bundle lacks the include.

**Observable behavior.**
- `cmake --install` prefix: `include/daScript/builtin/` gains `ast_gen.inc` and `debugapi_gen.inc`.
- The bundle smoke test prints `include/daScript/builtin/ast_gen.inc OK`, and MISSING against a bundle installed from master.

**Where to look.** The install rule next to `DAS_BUILTIN_HEADERS` in `CMakeLists.txt`; the "Shipped headers' includes" section in the smoke test.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- A scratch `cmake --install` from this branch carries both files; the smoke check reads OK on it and MISSING with `ast_gen.inc` removed.
- Found on zen4 building dasProfile against a fresh SDK from master; the M5's build had passed the same step, why is not established.

### Not done
- `DASTargets.cmake` exports absolute source-tree paths for the glfw and hv static libraries (`modules/dasGlfw/glfw/$<CONFIG>/lib/libglfw3.a`, `modules/dasHV/hv/...`) - an SDK moved to another machine links those targets against paths that are not there. Seen while reading the exports, not touched here.

</details>