### PR TITLE
the whole-tree lint and playground nightlies go green: STYLE029/030 keep an umbrella whose hooks ride only through it, LLVM-only programs name the witness, the verifier ignores dastest's start line

### DIFF
--- a/daslib/style_lint.das
+++ b/daslib/style_lint.das
@@ -2188,6 +2188,44 @@ class StyleLintVisitor : AstVisitor {
         }
     }
 
+    //! every module the require reaches, public or not - what vanishes with the require
+    def st029_collect_all_deps(mod : Module?; var reached : table<string; Module?>) : void {
+        module_for_each_dependency(mod) $(dep, _is_pub) {
+            if (dep == null) return
+            let dn = "{dep.name}"
+            if (dn == "" || dn == "$" || dn == "builtin") return
+            if (!key_exists(reached, dn)) {
+                reached |> insert(dn, dep)
+                st029_collect_all_deps(dep, reached)
+            }
+        }
+    }
+
+    def st029_cached_has_hook(mod : Module?; var hook_cache : table<string; bool>) : bool {
+        let mn = "{mod.name}"
+        if (key_exists(hook_cache, mn)) return hook_cache?[mn] ?? false
+        let has = st029_module_has_lifecycle_hook(mod)
+        hook_cache |> insert(mn, has)
+        return has
+    }
+
+    //! true when a lifecycle hook rides only through this require: a hook-bearing module in
+    //! `closure` that no other require of the file reaches, and that `keep` - the module the
+    //! rule would have the file require instead - does not reach either
+    def st029_hook_only_through(closure : table<string; Module?>; hook_reach : table<string; int>;
+                                var keep : Module?) : bool {
+        var kept : table<string; Module?>
+        if (keep != null) {
+            kept |> insert("{keep.name}", keep)
+            st029_collect_all_deps(keep, kept)
+        }
+        for (mn, reach in keys(hook_reach), values(hook_reach)) {
+            if (reach > 1 || !key_exists(closure, mn) || key_exists(kept, mn)) continue
+            return true
+        }
+        return false
+    }
+
     def st029_check_requires(prog : ProgramPtr) : void {
         if (!analyze_requires || this_module == null) return
         let this_name = "{this_module.name}"
@@ -2212,6 +2250,20 @@ class StyleLintVisitor : AstVisitor {
                 if (!key_exists(module_files, fname)) module_files |> insert(fname)
             }
         }
+        // per hook-bearing module, how many of this file's requires reach it - one means it rides only through that require
+        var hook_cache : table<string; bool>
+        var hook_reach : table<string; int>
+        prog |> for_each_require_declaration() $ [unused_argument(req_name, file, pub)] (mod, req_name, file, pub, at) {
+            if (mod == null || at.fileInfo == null || !key_exists(module_files, string(at.fileInfo.name))) return
+            var reached : table<string; Module?>
+            reached |> insert("{mod.name}", mod)
+            st029_collect_all_deps(mod, reached)
+            for (mn, m in keys(reached), values(reached)) {
+                if (st029_cached_has_hook(m, hook_cache)) {
+                    hook_reach[mn] = (hook_reach?[mn] ?? 0) + 1
+                }
+            }
+        }
         prog |> for_each_require_declaration() $ [unused_argument(file)] (mod, req_name, file, pub, at) {
             if (mod == null || pub
                 || at.fileInfo == null || !key_exists(module_files, string(at.fileInfo.name))) return
@@ -2231,12 +2283,16 @@ class StyleLintVisitor : AstVisitor {
                 if (closure?[cm] ?? false) via |> push(cm)
             }
             var line_at = at
+            var reached : table<string; Module?>
+            reached |> insert(mname, mod)
+            st029_collect_all_deps(mod, reached)
             if (used_count == 1 && !empty(via)) {
                 let mods = via[0]
+                return if (st029_hook_only_through(reached, hook_reach, reached?[mods] ?? null))
                 style_warning("STYLE029: require {req_name} is used only for the module it re-exports ({mods}); require it directly and drop {req_name}", line_at)
                 return
             }
-            return if (used_count > 0)
+            return if (used_count > 0 || st029_hook_only_through(reached, hook_reach, null))
             style_warning("STYLE030: require {req_name} is unused - no symbol from it (or a module it re-exports) is referenced; drop it", line_at)
         }
     }

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -2831,7 +2831,10 @@ A non-public ``require X`` whose only referenced symbols come from modules
 that ``X`` re-exports (``require ... public``) — none from ``X`` itself — is
 an indirect dependency. Require those modules directly and drop ``X``. Skipped
 when ``X`` provides macros or an ``[init]`` (requiring it has a side effect
-beyond symbol visibility).
+beyond symbol visibility), and when a lifecycle hook (``[init]``, ``[finalize]``,
+``[before_reload]``, ``[after_reload]``, ``[live_command]``) is reachable only
+through ``X`` - an umbrella whose side-effect requires register arches, say -
+because the direct require would drop the hook.
 
 .. das-doc: fragment
 .. code-block:: das
@@ -2848,8 +2851,9 @@ STYLE030 — entirely-unused ``require``
 
 A non-public ``require X`` where no symbol from ``X`` (or any module it
 re-exports) is referenced anywhere in the file. Remove it. Skipped when ``X``
-provides any macro or an ``[init]``, or only re-exports builtins used through
-it. Suppress a deliberate keep with ``// nolint:STYLE030``.
+provides any macro or an ``[init]``, when a lifecycle hook is reachable only
+through ``X`` (as for STYLE029), or when ``X`` only re-exports builtins used
+through it. Suppress a deliberate keep with ``// nolint:STYLE030``.
 
 .. das-doc: alt
 .. code-block:: das

--- a/modules/dasLLAMA/benchmarks/matmul/kq_kernel_bench.das
+++ b/modules/dasLLAMA/benchmarks/matmul/kq_kernel_bench.das
@@ -11,6 +11,7 @@ require dasllama/dasllama_math_gen
 require dasllama/dasllama_math
 require dasllama/dasllama_kqformat
 require dasllama/dasllama_gemm_schema
+require llvm   // nolint:STYLE030 - the witness, unguarded on purpose: the `_variants()` registries this bench runs exist only with dasLLVM, so a host without it skips this program as missing its prerequisite
 require llvm/daslib/llvm_env
 require math
 require strings

--- a/modules/dasLLAMA/dasllama/dasllama_fat_start.das
+++ b/modules/dasLLAMA/dasllama/dasllama_fat_start.das
@@ -9,7 +9,7 @@ require dasllama/dasllama_common
 require dasllama/dasllama_math   // the runtime knob getters the snapshot records
 require dasllama/dasllama_par    // get_total_hw_jobs - the advisory "threads" entry
 require daslib/json_boost
-require daslib/strings_boost
+require daslib/strings_boost   // nolint:STYLE030,LINT019 - join, used only inside the llvm_tune static_if half
 require ?llvm llvm/daslib/llvm_tune
 require ?das_metal dasllama/dasllama_metal_prefill  // metal_tensor_race (Apple static_if half)
 require ?das_metal dasllama/dasllama_metal_kernels  // metal_tensor_race_decode (Apple static_if half)

--- a/modules/dasLLAMA/harness/gen_probe.das
+++ b/modules/dasLLAMA/harness/gen_probe.das
@@ -6,7 +6,7 @@ options _dasllama_internal = true
 // Greedy continuation probe: renders one user turn through the model's chat template (thinking
 // off), prints the rendered prompt and the greedy continuation - the text two engines must agree on
 // before their speculative acceptance rates can be compared.
-require dasllama/dasllama_transformer   // umbrella fires each arch [init] registration
+require dasllama/dasllama_transformer   // nolint:STYLE029,LINT019 — umbrella fires each arch [init] registration; on a host without dasMetal only dasllama_common's symbols remain, the das_metal half reaches the generation API it re-exports
 require dasllama/dasllama_common
 require dasllama/dasllama_math   // setup_dasllama_jobque_
 require dasllama/dasllama_image   // load_model_cached - the .dlim rail

--- a/modules/dasLLAMA/harness/gen_tune_probe.das
+++ b/modules/dasLLAMA/harness/gen_tune_probe.das
@@ -42,6 +42,7 @@ require dasllama/dasllama_gemm_schema
 require dasllama/dasllama_convert
 require dasllama/dasllama_gguf   // transcode_q*k_superblock — the kq fixture pack rail
 require daslib/f16_cvt   // f32_to_f16 — the kq fixtures pack disk superblock headers
+require llvm   // nolint:STYLE030 - the witness, unguarded on purpose: the `_variants()` registries this probe races exist only with dasLLVM, so a host without it skips this program as missing its prerequisite
 require llvm/daslib/llvm_tune
 require daslib/tune             // [tune_policy] - inert without dasLLVM
 require daslib/random

--- a/modules/dasLLAMA/harness/gen_x64_emission_probe.das
+++ b/modules/dasLLAMA/harness/gen_x64_emission_probe.das
@@ -15,6 +15,7 @@ options _dasllama_internal = true
 // per-variant instruction-count gates).
 
 require dasllama/dasllama_math_gen
+require llvm   // nolint:STYLE030 - the witness, unguarded on purpose: the `_variants()` registries below exist only with dasLLVM, so a host without it skips this program as missing its prerequisite
 
 [export]
 def main {

--- a/modules/dasLLAMA/harness/image_turn_probe.das
+++ b/modules/dasLLAMA/harness/image_turn_probe.das
@@ -11,7 +11,7 @@ require dasllama/dasllama_load
 require dasllama/dasllama_image   // nolint:STYLE030,LINT019 — load_model_cached, used only inside the das_metal static_if half
 require dasllama/dasllama_env   // nolint:STYLE030,LINT019 — g_env_harness, read only inside the das_metal static_if half
 require ?das_metal dasllama/dasllama_metal_prefill
-require ../performance/profile_common.das   // tune_gate + apply_box_profile_runtime — the standing pre-measure stack
+require ../performance/profile_common.das   // nolint:STYLE029,LINT019 — tune_gate + apply_box_profile_runtime, the standing pre-measure stack, used only inside the das_metal static_if half
 require daslib/jobque_boost
 require daslib/fio   // nolint:STYLE030,LINT019 — path_join, used only inside the das_metal static_if half
 require math

--- a/modules/dasLLAMA/harness/mtp_ruler.das
+++ b/modules/dasLLAMA/harness/mtp_ruler.das
@@ -9,7 +9,7 @@ options _dasllama_internal = true
 // prompt raw through /completion (greedy, fixed n, ignore_eos), its timings read back. The identical
 // continuation text is the control that makes the two acceptance columns comparable; llama-bench has
 // no speculative arm and llama-cli re-wraps a raw prompt as a chat turn, which is why the server.
-require dasllama/dasllama_transformer   // umbrella fires each arch [init] registration
+require dasllama/dasllama_transformer   // nolint:STYLE029,LINT019 — umbrella fires each arch [init] registration; on a host without dasMetal only dasllama_common's symbols remain, the das_metal half reaches the generation API it re-exports
 require dasllama/dasllama_common
 require dasllama/dasllama_math   // setup_dasllama_jobque_
 require dasllama/dasllama_image   // load_model_cached - the .dlim rail

--- a/modules/dasLLVM/tests/llvm_tune_modes_client.das
+++ b/modules/dasLLVM/tests/llvm_tune_modes_client.das
@@ -26,7 +26,7 @@ def modes_add(a, b : int) : int {
 [export]
 def main {
     static_if (typeinfo module_exists(llvm_tune)) {
-        var n = 2  // nolint:LINT003 — var defeats const-fold so the calls survive to codegen
+        var n = 2  // nolint:LINT003,LINT019 — var defeats const-fold so the calls survive to codegen; the line sits in the llvm_tune static_if half, so a host without dasLLVM never compiles it
         var vs <- modes_add_variants()
         for (v in vs) {
             print("VARIANT {v._0} -> {invoke(v._1, n, 3)}\n")
@@ -42,7 +42,7 @@ def main {
 
 [test]
 def test_modes_client_fallback(t : T?) {
-    var n = 2  // nolint:LINT003 — var defeats const-fold so the calls survive to codegen
+    var n = 2  // nolint:LINT003,LINT019 — var defeats const-fold so the calls survive to codegen; the line sits in the llvm_tune static_if half, so a host without dasLLVM never compiles it
     let r = modes_add(n, 3)
     t |> success(r == 6 || r == 5)  // stamped fallback k1 tier (jit) or reference tier
     let kv = modes_kv()

--- a/modules/dasLLVM/tests/llvm_tune_scope_client_docs.das
+++ b/modules/dasLLVM/tests/llvm_tune_scope_client_docs.das
@@ -1,7 +1,7 @@
 options gen2
 
 require llvm_tune_scope_client_lib
-require llvm_tune_scope_client_lib2 // nolint:STYLE029 — intentionally loads the second tune scope
+require llvm_tune_scope_client_lib2 // nolint:STYLE029,STYLE030,LINT019 — intentionally loads the second tune scope; nothing of it is referenced on a host without dasLLVM
 
 // A documentation root compiles the source API but neither stamps winners nor
 // runs tune policy, even when the environment requests the strict error flavor.

--- a/utils/dasllama-server/openai_server.das
+++ b/utils/dasllama-server/openai_server.das
@@ -3833,7 +3833,7 @@ def private handle_config_save(var req : HttpRequest?; var resp : HttpResponse?)
 
 // ===== the exchange surface (GET /exchange + the apply/submit/retune levers) =====
 
-def private exchange_absent(var resp : HttpResponse?) : http_status {   // nolint:LINT022 — reached only from the no-framework static_if arm, which a build with dasLLVM drops
+def private exchange_absent(var resp : HttpResponse?) : http_status {   // nolint:LINT022,LINT019 — reached only from the no-framework static_if arm, which a build with dasLLVM drops; on a host without dasLLVM the arm compiles and the rule is silent
     return resp |> JSON(error_body("the sidecar exchange is not in this build (no tune framework)", "not_found"), http_status.NOT_FOUND)
 }
 
@@ -3912,7 +3912,7 @@ def private handle_exchange_matches(var req : HttpRequest?; var resp : HttpRespo
 
 // A fat release bakes one kernel clone per CPU class and never tunes, so the exchange has nothing
 // to apply, share or redo on it; the read-only status and matches stay, the levers answer this.
-def private fat_exe_exchange_refusal(var resp : HttpResponse?) : http_status {
+def private fat_exe_exchange_refusal(var resp : HttpResponse?) : http_status {   // nolint:LINT012,LINT022,LINT019 — resp and every caller sit in llvm_tune static_if halves; a host without dasLLVM compiles the bare-OK arm alone
     static_if (typeinfo module_exists(llvm_tune)) {
         if (!tune_fat_built()) return http_status.OK
         return resp |> JSON(error_body("this is a fat release: the kernels are baked per CPU class, so there is no tune of this box to share, apply or redo - the SDK's daslang -jit run tunes the box", "invalid_request_error"), http_status.BAD_REQUEST)

--- a/utils/internal/dasweb-verify/browser/expectations.json
+++ b/utils/internal/dasweb-verify/browser/expectations.json
@@ -48,7 +48,10 @@
     "Loops": { "kind": "console", "stdout": "0123456789" },
     "Functions": { "kind": "console", "stdout": "^hello$" },
     "Macros (multi-file)": { "kind": "console", "stdout": "Section 3: mixed sources" },
-    "Tests": { "kind": "console", "action": "test", "modes": ["interpreter"], "stdout": "SUCCESS!" },
+    "Tests": {
+      "kind": "console", "action": "test", "modes": ["interpreter"], "stdout": "SUCCESS!",
+      "ignore": ["^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z run \\d+/\\d+: "]
+    },
     "Linq: group by + average": { "kind": "console", "stdout": "Vaz: avg 1200" },
 
     "Dictionary (benchmark)": { "kind": "console", "stdout": "^\"dictionary\", " },

--- a/utils/lint/tests/_style029_umbrella.das
+++ b/utils/lint/tests/_style029_umbrella.das
@@ -1,0 +1,13 @@
+options gen2
+
+module _style029_umbrella
+
+// Umbrella: re-exports the leaf publicly and carries a hook-only module as a
+// side-effect require. Requiring it for the leaf's symbols alone is load-bearing -
+// `require _style029_leaf` instead would drop the hook.
+require _style029_leaf public
+require _style030_finalize_only   // the hook rides only through this umbrella
+
+def style029_umbrella_value() : int {
+    return 2
+}

--- a/utils/lint/tests/_style030_hook_umbrella.das
+++ b/utils/lint/tests/_style030_hook_umbrella.das
@@ -1,0 +1,11 @@
+options gen2
+
+module _style030_hook_umbrella
+
+// Umbrella the client references nothing from: its one job is the hook-only
+// module it requires as a side effect, so dropping it drops the hook.
+require _style030_init_only
+
+def style030_hook_umbrella_value() : int {
+    return 3
+}

--- a/utils/lint/tests/_style030_init_only.das
+++ b/utils/lint/tests/_style030_init_only.das
@@ -1,0 +1,11 @@
+options gen2
+// Helper for style030_unused_require.das: an [init]-only module that nothing
+// requires directly - it is reached only through _style030_hook_umbrella.
+module _style030_init_only shared private
+
+var private armed = 0
+
+[init]
+def arm_hook {
+    armed ++
+}

--- a/utils/lint/tests/style029_transitive_require.das
+++ b/utils/lint/tests/style029_transitive_require.das
@@ -2,7 +2,8 @@ options gen2
 options auto_inline_functions = false   // lint fixtures assert SOURCE shapes; splices rewrite them
 // STYLE029: 'require X' used only for ONE module X re-exports — require it
 // directly and drop X. Silent when >=2 re-exports are used (aggregation
-// facade, e.g. daslib/ast) or the single used re-export is builtin.
+// facade, e.g. daslib/ast), the single used re-export is builtin, or a
+// lifecycle hook is reachable only through X (dropping X would drop it).
 
 expect 31209:1
 
@@ -10,6 +11,7 @@ require daslib/style_lint
 require _style029_proxy        // only leaf used — FIRES
 require _style029_direct       // used directly — silent
 require _style029_mixed_proxy  // math + leaf both used — silent
+require _style029_umbrella     // only leaf used, but the [finalize] hook rides only through it — silent
 
 [export]
 def use_them(v : float) : int {

--- a/utils/lint/tests/style030_unused_require.das
+++ b/utils/lint/tests/style030_unused_require.das
@@ -10,6 +10,7 @@ options auto_inline_functions = false   // lint fixtures assert SOURCE shapes; s
 //     type/pass/capture/simulate) — fires by syntax / installs a pass, leaving
 //     no traceable symbol reference
 //   * X has an [init] function (side effects on load)
+//   * a lifecycle hook is reachable only through X (dropping X drops it)
 //   * builtin facade re-exports (no source file) don't count as "used"
 //
 // Without a recompile-verify (which a lint pass can't do), the macro guard is
@@ -23,6 +24,7 @@ require daslib/ast_verify       // [post_rewrite_macro]/[post_compile_macro]/[si
 require _style030_unused        // genuinely unused source module (FIRES)
 require _style029_direct        // used directly — must NOT fire
 require _style030_finalize_only // lifecycle-hook-only module ([finalize]) — must NOT fire
+require _style030_hook_umbrella // nothing referenced, but its [init] dependency is reached only through it — must NOT fire
 
 [export]
 def use_them() : int {


### PR DESCRIPTION
**Why.** Two nightly lanes were red. The whole-tree lint lane - a host without dasLLVM, dasMetal or dasVulkan - failed three LLVM-only dasLLAMA programs on a missing tune `_variants()` registry and warned on fifteen platform-half sites; eleven of them are the dasllama umbrella require, which STYLE029 reads as transitive-only there because the arch `[init]` registrations it exists for ride through its non-public side-effect requires. The lint tool exits red on warnings alone. The playground lane failed the Tests sample on dastest's timestamped stderr start line, which the verifier classes as an error.

**What changes.**
- STYLE029 and STYLE030 stay silent when a lifecycle hook (`[init]`, `[finalize]`, ...) is reachable only through the flagged require: the direct require the rule proposes would drop the hook. Fixtures pin both arms; `lint.rst` says so.
- The three LLVM-only dasLLAMA programs that walk a tune `_variants()` registry `require llvm` unguarded, so a host without dasLLVM skips them as missing a prerequisite instead of failing on the registry.
- The remaining platform-half sites carry `nolint:...,LINT019` naming the half.
- The playground verifier's Tests row ignores the `<iso-time> run N/M: <file>` line.

**Observable behavior.**
- whole-tree lint nightly: 3 errors + 13 to 16 warnings -> zero on the changed set under the Linux-lane mirror.
- playground nightly: Tests [interpreter] FAIL -> PASS against production.
- A file requiring an umbrella only for one re-exported module's symbols keeps its STYLE029 unless a hook rides only through the umbrella.

**Where to look.** `st029_hook_only_through` and the `hook_reach` count in `daslib/style_lint.das`: a hook reached by exactly one of the file's requires rides only through it, and the module the rule would substitute must not reach it either.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Lint lane mirror: every file the nightly named, linted with `--disable-module dasLLVM --disable-module dasMetal --disable-module dasVulkan` (reproduced all 3 errors and 14 warnings before the change; the three programs SKIP as missing a prerequisite and the rest PASS after) and plainly on a Mac (PASS both before and after). `utils/lint/tests` and `tests/lint` under dastest: 202 passed. The two extended fixtures fail without the rule change (the umbrella cases fire) and pass with it. Preflight `lint` (host and linux-mirror rails) and `review-md` gates green on the changed set.
- Playground: `node runner.mjs --base-url https://daslang.io --filter Tests --mode interpreter` reproduced the FAIL against production and passes with the ignore row; the verifier's 30 `node --test` cases pass.
- `sphinx-build -W` over `doc/source` succeeds with the `lint.rst` edit.
- Targeted gates instead of the full preflight: a lint rule, fixtures, comment lines and a JSON row.

### Not done
- The other nightly reds are separate: the Windows AOT-host `tests/module_cache/test_default_cache_path.das` children (empty output, rc 0, every nightly since 2026-09-04), the Windows watchdog string-heap bound, the MinGW isolated-mode sharing violation, the tsan `test_tray` Quit exit code.

</details>
