### PR TITLE
the nightly runs the big C++ tests - ctest -L big after the AOT sweep on every Release cell; the two style_lint fixture tests that were red on master lint their fixtures again and run per PR as small

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -431,6 +431,12 @@ jobs:
       # TUs — the single biggest CI cost) via the run_tests_aot dependency and
       # sweeps all of tests/. Nightly + manual dispatch only; per-PR lanes get
       # the test_aot_subset compile+link gate from the Build step instead.
+      # Then the big C++ tests (tests-cpp/big): a generated standalone context
+      # linked and run, the nano context, concurrent init, the C API split init.
+      # Their binaries are in the default build every lane makes, but every
+      # per-PR ctest is -L small, so only this step executes a generated
+      # context. memory_model_4gb allocates a real 4 GB chunk and stays
+      # local-only.
       if: matrix.cmake_preset == 'Release' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       run: |
         set -eux
@@ -451,6 +457,7 @@ jobs:
             cmake --build ./build --config ${{ matrix.cmake_preset }} --target run_tests_aot
             ;;
         esac
+        ctest --test-dir build --build-config ${{ matrix.cmake_preset }} -L big -E memory_model_4gb --output-on-failure
 
   ###########################################################
   build_windows_relwithdebinfo_nightly:

--- a/daslib/lint_config.das
+++ b/daslib/lint_config.das
@@ -428,15 +428,15 @@ def public is_lint_fixture_name(base : string) : bool {
 
 let public LINT_SKIP_HEADER_LINES = 16
 
-//! Content-based skip probe shared by the CLI runner and the MCP lint tool: ``expect <code>``
-//! files declare intentional compile errors (dastest), and a header ``// lint-skip-file: <reason>``
-//! opts a policy-conflicted file out entirely. Returns the skip reason, or "" to lint the file.
-def public lint_file_skip_reason(file : string) : string {
+//! Content-based skip probe shared by the CLI runner and the MCP lint tool. An ``expect <code>`` file
+//! (intentional compile errors) skips while ``expect_skips`` holds - a caller linting rule fixtures passes false;
+//! a header ``// lint-skip-file: <reason>`` opts a file out whatever the caller. Returns the skip reason, or "" to lint.
+def public lint_file_skip_reason(file : string; expect_skips : bool = true) : string {
     let text = fread(file)
     return "" if (empty(text))
     for (line, ln in split(text, "\n"), count()) {
         let trimmed = line |> strip
-        return "(intentional compile errors via `expect`)" if (trimmed |> starts_with("expect "))
+        return "(intentional compile errors via `expect`)" if (expect_skips && trimmed |> starts_with("expect "))
         if (ln < LINT_SKIP_HEADER_LINES && trimmed |> starts_with("// lint-skip-file")) {
             let colon = find(trimmed, ":")
             let reason = colon >= 0 ? strip(slice(trimmed, colon + 1)) : ""

--- a/skills/internal/writing_cpp_tests.md
+++ b/skills/internal/writing_cpp_tests.md
@@ -66,7 +66,7 @@ Big tests that are C++ executables **don't include doctest** - they keep their o
 
 **A big test's `int main()` owns its module lifetime** - nothing runs `doctest_main.cpp` for it. An exe that resolves modules through the registry calls `Module::Initialize()` / `Module::Shutdown()` itself. An exe whose only context comes from a generated standalone AOT constructor calls neither: a context that reaches no C++ module beyond the builtin one consults no registry (example: `big/standalone_ctx/test_standalone_ctx.cpp`), and one that does registers what it links itself and shuts it down when the last context is destroyed (example: `examples/standalone/06_full_runtime/`, which doubles as a small-lane test; `big/standalone_ctx/test_standalone_modules.cpp` puts two such contexts in one binary). A test that registered the builtin module - `NEED_ALL_DEFAULT_MODULES` or `NEED_MODULE(Module_BuiltIn)` - owns the registry: it registers every module the context links and calls `Module::Initialize()` before constructing it; a module it missed stops the program at construction, by name (`standalone_modules_host_partial` pins that as a `WILL_FAIL` test).
 
-A big-labelled test is not gated by CI - only the small suite runs there. Run `ninja test-big` locally before pushing one.
+A big-labelled test runs in CI only on the nightly and on a manual full-workflow run (`ctest -L big -E memory_model_4gb` on the Release cells); every per-PR ctest is `-L small`. Run `ctest -L big` locally before pushing one and say so in the PR (`tests-cpp/big/REVIEW.md`).
 
 ## Doctest assertion cheat sheet
 

--- a/tests-cpp/big/REVIEW.md
+++ b/tests-cpp/big/REVIEW.md
@@ -5,5 +5,5 @@ doc: `skills/internal/writing_cpp_tests.md` (repo root).
 
 **A diff that touches a test whose ctest labels include `big` says in the PR that the test
 ran and passed on the author's machine, naming the command - `ctest -L big` or the test's
-own binary.** CI runs `ctest -L small` only, so no other run shows that a big-labelled test
-passes.
+own binary.** Per-PR CI runs `ctest -L small` only; `-L big` runs on the nightly and on a
+manual full-workflow run, so a PR's own lanes never show that a big-labelled test passes.

--- a/tests-cpp/big/style_lint/CMakeLists.txt
+++ b/tests-cpp/big/style_lint/CMakeLists.txt
@@ -1,6 +1,7 @@
-# Big test: utils/lint must surface STYLE014/STYLE015 on the canonical
-# comment-hygiene fixtures. Catches regressions in the option/flag plumbing
-# and the scan_long_comment_blocks pass.
+# utils/lint must surface STYLE014/STYLE015 on the canonical comment-hygiene
+# fixtures. Catches regressions in the option/flag plumbing and the
+# scan_long_comment_blocks pass. Labelled small: each run is one lint of one
+# fixture, well under a second, so every per-PR ctest runs it.
 
 file(GLOB STYLE_LINT_FIXTURES CONFIGURE_DEPENDS
     ${PROJECT_SOURCE_DIR}/utils/lint/tests/style014_*.das
@@ -15,8 +16,8 @@ foreach(_fixture ${STYLE_LINT_FIXTURES})
                 -- --comment-hygiene true --lint-fixtures true ${_fixture}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     set_tests_properties(style_lint_${_name} PROPERTIES
-        LABELS "big;style_lint"
+        LABELS "small;style_lint"
         PASS_REGULAR_EXPRESSION "STYLE014|STYLE015")
 endforeach()
 
-add_dependencies(test-big daslang)
+add_dependencies(test-small daslang)

--- a/utils/lint/main.das
+++ b/utils/lint/main.das
@@ -417,7 +417,8 @@ def normalize_rule_list(raw : array<string>; var dest : table<string>) : string 
 }
 
 def set_skip_reason(file : string; lint_fixtures : bool; var result : LintResult) : bool {
-    let content_skip = lint_file_skip_reason(file)
+    // --lint-fixtures lifts the `expect` skip; a lint-skip-file directive always wins
+    let content_skip = lint_file_skip_reason(file, !lint_fixtures)
     if (!empty(content_skip)) {
         result.skip_reason = content_skip
         return true
@@ -425,7 +426,7 @@ def set_skip_reason(file : string; lint_fixtures : bool; var result : LintResult
     // the lint tool's own rule fixtures violate rules BY DESIGN (warning-expectation
     // files carry no `expect` directive, so the content skip above misses them).
     // --lint-fixtures is how this tool's OWN tests ask to see those findings, so it
-    // lifts both arms; normalize() emits the platform's preferred separator.
+    // lifts this arm too; normalize() emits the platform's preferred separator.
     if (!lint_fixtures && (normalize(file) |> replace("\\", "/") |> find("utils/lint/tests/") >= 0
             || is_lint_fixture_name(base_name(file)))) {
         result.skip_reason = "(lint rule fixture)"


### PR DESCRIPTION
**Why.** Every per-PR and nightly ctest in CI is `-L small`, so the big-labelled C++ tests - a generated standalone context linked and run, the nano context, concurrent init, the C API split init - are built by the default target on every lane and executed on none. v0.6.4-RC2 shipped a `-ctx` whose generated code did not link and, once linked, never ran its initializers (#3967); `tests-cpp/big/standalone_ctx` shows both, and no lane ran it.

**What changes.**
- The nightly "Slow Release Tests" step runs `ctest -L big -E memory_model_4gb` after the AOT sweep, on every Release cell the step already covers - Linux, macOS and Windows, sanitizer cells included. No extra build: the binaries are already in the default target. `memory_model_4gb` allocates a real 4 GB chunk and stays local-only, as its CMakeLists says.
- Running the set showed the two `style_lint` fixture tests red on master: the lint CLI's content skip for an `expect` file fired before the `--lint-fixtures` override the comment beside it promised, so both fixtures were skipped and neither STYLE014 nor STYLE015 was ever printed. `lint_file_skip_reason` takes an `expect_skips` flag (default true, so the MCP lint tool is unchanged) that the CLI clears under `--lint-fixtures`; a `// lint-skip-file` directive keeps winning whatever the caller, which `tests/lint/test_stale_nolint.das` pins.
- Those two tests are relabelled `small`: each is one sub-second lint of one fixture, so every per-PR ctest runs them and the lint fix has a per-PR row.
- `tests-cpp/big/REVIEW.md` states the contract as it now is: per-PR CI runs `-L small`, the nightly runs `-L big` after the merge.

**Observable behavior.**
- A generated standalone context that does not link, or does not initialize, goes unnoticed until a release -> fails the next nightly on every platform.
- `daslang utils/lint/main.das -- --lint-fixtures true <expect fixture>`: skipped -> linted, findings printed. Without the flag an `expect` file is still skipped.
- Per-PR CI: two sub-second lint tests added to the small set; nothing else changes.

**Where to look.** `.github/workflows/build.yml`, the "Slow Release Tests" step - the `ctest` line sits after the `case`, so every arm, the 32-bit Windows one included, runs it; `utils/lint/main.das` `set_skip_reason`, one condition.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The exact nightly command, locally (macOS arm64, Release): `ctest --test-dir build --build-config Release -L big -E memory_model_4gb --output-on-failure` - 6 of 6 pass in 21 s (standalone_ctx, nano_ctx, concurrent_init, concurrent_init_dyn, capi_split_init, cpp_module_pull). Before the lint fix and relabel the same command was 6 of 8, the two style_lint tests failing on a skipped fixture.
- `ctest -L small -R style_lint`: 2 of 2 after the relabel; `tests/lint/test_stale_nolint.das` 7 of 7, its `lint-skip-file` arm being the one a first cut of this fix broke on the modules lane.
- Negative control on the lint fix: the fixture without `--lint-fixtures` still reports SKIP; with it, two STYLE014 findings.
- `python3 ci/test_ci_matrix.py`: 18 tests OK; the workflow parses.
- Preflight fast tier on the tip: 10 gates pass, 0 fail, 3 skip as not reached (format, lint on both rails, hash-refs, review-md, md-ascii, ast-verify, ci-das, ci-matrix, compile-sweep over 760 roots).
- The codex round ran over the branch at its tip, read the workflow file, and returned no findings.
- The dragon read `tests-cpp/big/REVIEW.md` twice: the first round corrected the rationale (a manual full-workflow run can target a PR branch), the fresh cold read after it is all-OK, and it found the sentence in `skills/internal/writing_cpp_tests.md` that this change made false, fixed here.
- The comment harvest and style-hygiene rows were skipped by standing instruction.

### Lint candidate
- A PR gate that maps each changed path to its `CMakeLists.txt` `LABELS` and fails a `big` hit whose PR body names no `ctest -L big` run; `tests-cpp/REVIEW.das` already parses those labels. Not written here.

### Claims - stated, not tested
- The Windows and sanitizer cells were not run here; the step's `case` arms and env exports are unchanged, and the added line uses the same `ctest --test-dir build --build-config` shape the RelWithDebInfo nightly already uses. A big test that fails under a sanitizer shows up on the first nightly, which is the point.
- The 32-bit Windows arm skips the AOT sweep but runs the big set: its binaries come from the same Build step that already generates and compiles the watchdog's `-ctx` context on that lane.

### Not done
- lookibed's proposed `tests-cpp/big/standalone_module_global` (a required module owning initialized globals, linked and run) is a real gap beside master's emit-only test and is not added here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
