### PR TITLE
jit: --jit-debug describes das locals, and a das name is what a debugger breaks on

### DIFF
--- a/modules/dasLLVM/.das_module
+++ b/modules/dasLLVM/.das_module
@@ -8,6 +8,7 @@ def initialize(project_path : string) {
         "llvm_boost", "llvm_debug", "llvm_jit", "llvm_targets",
         "llvm_dsl",
         "llvm_jit_intrin", "llvm_jit_common", "llvm_jit_lower", "llvm_dll_utils",
+        "llvm_jit_di",
         "llvm_exe", "llvm_macro", "llvm_jit_cli", "llvm_jit_run", "llvm_aot",
         "llvm_env",     // [EnvConfig] environment-knob registry (ENVIRONMENT.md generates from it)
         "llvm_cpu_class",     // the CPU classes profiles are keyed by, and the DAS_JIT_BASELINE target

--- a/modules/dasLLVM/ARCHITECTURE.md
+++ b/modules/dasLLVM/ARCHITECTURE.md
@@ -2,7 +2,8 @@
 
 The design document `REVIEW.md` cites. Numbered sections are the stable reference targets;
 usage and installation live in `README.md`, the debugger rail and its roadmap in `DEBUGGING.md`.
-Companion: `ARCHITECTURE_TARGET_FEATURES.md` (CPU feature truth, the tier gates, the CPU classes).
+Companions: `ARCHITECTURE_TARGET_FEATURES.md` (CPU feature truth, the tier gates, the CPU classes),
+`ARCHITECTURE_DEBUG_INFO.md` (the `--jit-debug` DWARF rail - sec.12).
 
 ## 1. The jit backend pipeline
 
@@ -117,7 +118,9 @@ bitcode and the link runs lld LTO - a dev probe artifact), `DAS_JIT_X64_FORCE_FE
 `DAS_JIT_ARM64_FORCE_FEATURES` (force CPU features past detection - emission, the cache keys,
 and `cpu_supports`-based tune eligibility all follow), `DAS_JIT_BASELINE` (build for a CPU class
 instead of the box - the machine, the gates, the tune ladder and the cache keys all follow;
-`ARCHITECTURE_TARGET_FEATURES.md` sec.10), and the runtime escape API
+`ARCHITECTURE_TARGET_FEATURES.md` sec.10), `--jit-debug` / `-g` (emit DWARF or CodeView debug
+info and promote every argument to a stack slot for it; `ARCHITECTURE_DEBUG_INFO.md` sec.12),
+and the runtime escape API
 `tune_suppress_mint(knob)` (a library `[init]` suppresses the auto/restart mint; the caller
 passes the knob name it acts for). The announce contract: an override announces at the point
 it CHANGES THE OUTCOME - at least one line naming the knob (its env spelling, or the

--- a/modules/dasLLVM/ARCHITECTURE_DEBUG_INFO.md
+++ b/modules/dasLLVM/ARCHITECTURE_DEBUG_INFO.md
@@ -1,0 +1,158 @@
+# dasLLVM architecture - the debug-info rail
+
+Companion of `ARCHITECTURE.md` (contract: `../../ARCHITECTURE_COMMON.md`). Section 12 continues
+that document's numbering. What the rail ships and what is still planned is `DEBUGGING.md`;
+this document is how the emitted metadata is shaped and why.
+
+## 12. One compile unit per generated module {#di-one-cu-per-module}
+
+`--jit-debug` (`policies.jit_debug_info`) arms `LlvmJitFlags.need_di`, and the emitter then
+carries a DIBuilder per generated LLVM module. `daslib/llvm_jit_di.das` owns the DWARF type and
+expression factory - it turns a das `TypeDecl` into a `DIType` and never touches IR;
+`daslib/llvm_jit.das` owns every attachment - subprograms, locations, lexical scopes and the
+`dbg.declare` records. Both reach LLVM only through the C entry points bound in `bindings/`, so
+the rail adds no LLVM header or library dependency anywhere.
+
+The builder belongs to the MODULE, not to the visitor that emits one function. One DIBuilder
+holds one compile unit (LLVM asserts on a second), so a builder per function would mean a
+compile unit per function - and at any optimization level that inlines, the executed copy of a
+function lives inside its CALLER's compile unit as a `DW_TAG_inlined_subroutine`. A debugger
+finds that instance by expanding the compile unit its name index points at; with one CU per
+function the caller's CU never names the callee, so `break hot` resolves only against the
+out-of-line copy the inliner left dead, and never fires. With one CU per module every instance
+of a function - out-of-line and inlined - sits in the same unit as its abstract origin.
+
+The builder is created on first use for a module and finalized once, from `run_jit`
+(`llvm_jit_run.das`), after the last function of that module is emitted and before anything
+reads the module: `DIBuilder::finalize` is what resolves the metadata cycles and temporary nodes
+a module may hold, and the LLVM verifier refuses a module that still carries one. Split mode
+finalizes per partition, each partition being its own module.
+
+The `DICompileUnit`'s own file name is the label `das-jit`; the real `.das` paths hang off the
+per-function `DIFile`s. Its language is `DW_LANG_C_plus_plus`: under `DW_LANG_C` a debugger
+treats an unmangled name as the whole truth about a C symbol and drops the argument types it
+would otherwise print beside a frame.
+
+The `DIType` cache holds one generation per builder. A metadata node belongs to the module its
+builder writes, and a forward declaration - `LLVMDIBuilderCreateForwardDecl`, which is
+`createReplaceableCompositeType` underneath - is a `distinct` node rather than a uniqued one, so
+a node reused under a second builder lands in the wrong module's DIE tree. `di_cache_drop_if_stale` drops
+the whole cache whenever the builder asking is not the builder it was filled for.
+
+A `DIFile` carries the ABSOLUTE source path in its filename field and leaves its directory
+field empty. A debugger resolves the source text through that one string, so a relative name
+lists only from the directory the compile ran in; the directory field stays empty because
+CodeView consumers join the two fields and would print `dir/dir/file`.
+
+The artifact is a real shared object or DLL: the JIT emits an object, links it, and `dlopen`s
+it. A debugger therefore needs no JIT-registration protocol - it reads the DWARF (or the PDB
+lld-link writes on windows) out of a module the dynamic loader already announced. That is why
+the rail is DWARF-shaped rather than built on LLVM's GDB JIT interface, which only the
+in-memory `-jit-no-cache` path would need.
+
+### 12.1 A subprogram is named as the das source names it {#di-subprogram-naming}
+
+A `DISubprogram` carries the das function's own name in `DW_AT_name` and NO
+`DW_AT_linkage_name`. That is what makes `break hot` work. The generated symbol
+(`_anon_...`hot Ci implementation`) is nothing anyone would type, and it is not a mangling any
+debugger can decode - while gdb, for a symbol that has a linkage name, uses that name as the
+lookup key and the das name becomes unreachable. The object symbol table still carries the
+generated symbol, so a debugger that wants it has it, tied to the DIE by address.
+
+Both halves of a generated function pair carry that same das name - the impl and the wrapper
+the interpreter calls. The reason is that the impl is `alwaysinline`: once the wrapper has
+inlined it, the standalone impl body is dead code that still owns a full line table, so a
+breakpoint resolved against the impl alone never fires. Naming both gives the debugger a
+location list that includes the copy that actually runs.
+
+An impl's `DISubprogram` claims local-to-unit only outside split mode. Split mode gives an impl
+external-hidden linkage so a caller in another partition can bind it, and the flag has to match
+the linkage the symbol really has. A wrapper is the exported symbol in either mode, so its
+subprogram never claims it.
+
+A block or lambda body is a generated function too, and the das source has no name for it. Its
+subprogram is named `<host function>_block_at_<line>`, which is also the name a `bt` frame
+prints. Without a subprogram of its own, nothing inside a block body carries a line at all -
+LLVM drops a `!dbg` whose scope is another function.
+
+### 12.2 A variable's location is its stack slot {#di-variable-locations}
+
+Every das local, loop variable and argument gets a `DILocalVariable` plus a `dbg.declare`
+record naming the slot it lives in. `dbg.declare` states an ADDRESS, so the emitter passes the
+`alloca` - or, for a `ref` argument, the incoming pointer, since the parameter value IS the
+variable's address. The one indirect case is a das slot that holds a POINTER to the value
+rather than the value: a `ref` local's `alloca`. Its location is one `DW_OP_deref` past the
+slot, and without that expression a debugger prints the pointer where the value was asked for.
+
+A debug build promotes EVERY argument to a stack slot, the same way `hasMakeBlock` already
+does. A parameter that stays an SSA value has no address for `dbg.declare` to name; with the
+slot in place `SROA` re-promotes it to a register and rewrites the metadata itself, so the
+promotion costs nothing past `-O0` and is what makes `frame variable` answer at every level.
+
+The subprogram is created before the entry block is built, because the entry block is where the
+argument variables are declared and a `DILocalVariable` has to name the scope it belongs to.
+
+**An instruction the emitter hoists or defers carries no stale line.** `break file:line` takes
+the LOWEST address a line owns, so one misattributed instruction moves the stop to somewhere the
+line's own statement has not run. Three shapes are ruled:
+
+- **The prologue carries no location at all** - not the entry block's frame slots, not the
+  argument stores, not the branch that closes it. LLVM marks `prologue_end` at the first
+  instruction that has one, so a location there stops a debugger ahead of the argument stores
+  where every argument reads as garbage. Worse, a frame slot is hoisted to the entry block from
+  wherever the das statement that needs it sits, so a `let` inside a nested block would give its
+  own line to a prologue instruction and `break` on that line would resolve to function entry.
+  `at_function_entry` clears the location around every hoisted slot and restores it after.
+- **A wrapper's entry block is the exception, and carries the declaration line on purpose.**
+  A wrapper holds no das statement - it marshals arguments, calls the impl and returns - so
+  there is no statement whose line it could steal, and a frame for it needs a line to print.
+- **A loop's latch carries the loop's own line**, not the last statement of its body. The latch
+  is emitted after the body and would otherwise inherit that statement's location - and then a
+  breakpoint on the body's last line stops in the PREVIOUS iteration's increment, with every
+  value one step stale.
+
+The first real location a function carries is therefore the one its body's first statement sets.
+
+### 12.3 A das block is a lexical scope {#di-scopes}
+
+Each open das block pushes a `DILexicalBlock` on the scope stack, innermost last, with the
+subprogram at the bottom. A `DILocalVariable` names the scope it was declared in, and that is
+what makes a shadowed name resolve to the right slot instead of the outermost one. The stack is
+per generated function - a nested block body is emitted by its own visitor instance and starts
+clean.
+
+When a block's line info belongs to a different file than its parent scope - what an inlined
+`require`d module produces - the pushed scope is a `DILexicalBlockFile` instead. A `DILocation`
+takes its file from its scope, so without the re-point every line of the included body would be
+reported against the host function's file.
+
+### 12.4 A composite DIType is built with no metadata cycle {#di-composite-types}
+
+A das structure, tuple or variant becomes a real `DW_TAG_structure_type` with one member per
+field, at the field's own byte offset - independent of the `[N x i8]` blob the value has as an
+LLVM type, since DWARF describes the layout the emitted code uses rather than the IR type.
+
+A variant's members are the `int` tag at offset zero and every arm at one shared offset past it -
+that is the layout a das variant has, and the tag says which arm is live.
+
+The metadata is built acyclic, and that is a constraint rather than a preference: only
+`DIBuilder::finalize` can resolve a metadata cycle, the module verifier runs per function long
+before the module is finished, and an unresolved node fails it. Two shapes would close a cycle
+and neither is emitted. A member's scope is the FILE, not the composite that holds it - the DIE
+nesting already says which type a member belongs to. And a pointer field reaching back into the
+type whose members are being built takes a forward declaration of that type as its pointee: the
+declaration shares the definition's unique id, which is what a debugger reconciles the two by.
+
+`LLVMDIBuilderCreateStructType` is the one entry point the generated `bindings/llvm_func.das`
+does not carry, so `llvm_jit_di.das` declares it itself against the same `LLVM.dll`. Its
+das-side name is deliberately distinct from the C spelling, so a regenerated binding that adds
+the plain name cannot collide with it.
+
+The rest of the lattice maps by shape: a workhorse scalar to a `DW_TAG_base_type` with the
+matching DWARF encoding, a `string` to `char *` (which is the shape every debugger already
+prints as text), a vector or range to a vector-of-subrange over its lane scalar, a `dim` to an
+array type with one subrange per dimension, an enumeration to a `DW_TAG_enumeration_type` with
+the entries whose values fold to constants, and everything whose interior the rail does not
+describe - a handled C++ type, a container, a block, a lambda - to a named opaque forward
+declaration of the right size, so a debugger prints the name and the address rather than
+nothing.

--- a/modules/dasLLVM/ARCHITECTURE_DEBUG_INFO.md
+++ b/modules/dasLLVM/ARCHITECTURE_DEBUG_INFO.md
@@ -126,7 +126,26 @@ When a block's line info belongs to a different file than its parent scope - wha
 takes its file from its scope, so without the re-point every line of the included body would be
 reported against the host function's file.
 
-### 12.4 A composite DIType is built with no metadata cycle {#di-composite-types}
+### 12.4 A das global is described where its address is known {#di-globals}
+
+A das global has no static address: it lives at `context->globals + stackTop`, and the same
+jitted module serves every Context of the program, each with its own base. A
+`DIGlobalVariableExpression` would therefore need one address to stand for all of them, and
+whichever Context wrote it, the value printed in the others would be confidently wrong.
+
+The emitter does not need a static address, because it already computes the right one. Every
+function that touches a global materializes a pointer to it - through `jit_get_global_mnh` at
+the use site, or from `context->globals` in the entry block under `options solid_context` - and
+that pointer is derived from the `ctx` the call actually received. The global is described as a
+variable of that function, located at that pointer, once per function that mentions it. The
+location is per-Context correct by construction.
+
+The cost is scope rather than accuracy: a global reads in any frame whose function touches it,
+and not in a frame that never mentions it. That is the honest shape for a variable whose address
+is a function of the running context, and it is the shape a debugger user experiences anyway -
+the value is asked for from inside a frame.
+
+### 12.5 A composite DIType is built with no metadata cycle {#di-composite-types}
 
 A das structure, tuple or variant becomes a real `DW_TAG_structure_type` with one member per
 field, at the field's own byte offset - independent of the `[N x i8]` blob the value has as an

--- a/modules/dasLLVM/DEBUGGING.md
+++ b/modules/dasLLVM/DEBUGGING.md
@@ -7,18 +7,38 @@ instrument anything, compile in anything, and emit any metadata we want.
 
 ## What ships today
 
-- **`--jit-debug` / `policies.jit_debug_info`** - full debug-info rail (2026-07-19):
-  - impl + wrapper functions get `DISubprogram`s; every expression carries a
+- **`--jit-debug` / `-g` / `policies.jit_debug_info`** - the source-level debug-info rail.
+  How the metadata is shaped and why: `ARCHITECTURE_DEBUG_INFO.md` sec.12.
+  - one `DICompileUnit` per generated module; impl, wrapper and every block/lambda body get a
+    `DISubprogram` named as the das source names them, and every expression carries a
     `DILocation` (file/line/column from the das AST `LineInfo`);
-  - `DICompileUnit` per DIBuilder, `"Debug Info Version"` + `"CodeView"` module flags
-    (CodeView gated on windows triples via `LLVMGetDefaultTargetTriple()` -
-    `host_jit_triple()` is "" on MSVC hosts, it only disambiguates mingw arches);
+  - every das local, loop variable and argument gets a `DILocalVariable` with a real `DIType`
+    (structs and tuples with named members at their own offsets, enums with their entries,
+    `string` as `char *`, vectors as lane arrays, `dim` as an array type), so a debugger reads
+    and prints das values; each das block opens a `DILexicalBlock`;
+  - `"Debug Info Version"` + `"CodeView"` module flags (CodeView gated on windows triples via
+    `LLVMGetDefaultTargetTriple()` - `host_jit_triple()` is "" on MSVC hosts, it only
+    disambiguates mingw arches);
   - lld-link gets `/DEBUG` -> a real PDB lands beside the jitted DLL in
     `.jitted_scripts/`, auto-discovered by cdb/WinDbg/VS via the embedded path;
   - the in-process crash handler (`src/hal/crash_handler.cpp`) resolves jitted frames
     through that PDB with **function name + .das file:line** - `SymFromAddr` +
     `SymGetLineFromAddr64` were always called, they were just starved of data.
   - flag folds into the DLL cache hash; default path is byte-identical, no PDB.
+
+  On a linux or macOS box the jitted artifact is an ordinary `dlopen`ed shared object carrying
+  DWARF, so lldb and gdb need no JIT protocol. What works, verified end to end under lldb and
+  gdb: a breakpoint set by the das function name (`breakpoint set -n hot` / `break hot`),
+  source listing of the `.das` file at the stop, a backtrace of das frames with argument
+  values, `frame variable` / `info locals`, and expression evaluation over das locals
+  (`expr n * 2`). Argument and local values read fully at `--jit-opt-level=0`; at the default
+  O3 the breakpoints and frames still resolve - including into an inlined instance - while
+  values read `<optimized out>` exactly as they do for an optimized C++ build.
+
+  Two things a debugger does not see yet: a das GLOBAL (it lives at `context->globals +
+  stackTop`, not in an LLVM global, so it needs a `DIGlobalVariableExpression` with a computed
+  location), and the interpreted half of a mixed stack (an interpreter frame shows as the
+  `SimNode` eval chain; `--jit-stack` plus `Context::getStackWalk()` is the parallel answer).
 - **`--jit-opt-level=0..3`** - IR pass pipeline honors it, and the DLL path's
   codegen-side target machine follows it too (`write_dll` `codegen_opt_level`);
   `write_exe` / AOT-object emission deliberately stay at 3 (shipped artifacts).
@@ -143,6 +163,7 @@ where the primary structures lie; the shadow buffer is the witness that doesn't.
   after. Remaining blind spot was the runtime DLL's nearest-EXPORT frames - fixed the
   root cause: Release now compiles /Z7 and links /DEBUG /OPT:REF /OPT:ICF
   (CMakeCommon.txt), so every future dump resolves runtime frames with C++ lines.
-  Known cosmetic: jitted-frame paths print the relative dir twice
-  (`utils/dasllama-server/utils/dasllama-server/...`) - DIFile directory + filename
-  both carry it; fix in `get_debug_file_location_by_name`.
+  Cosmetic residue from that night, since fixed: jitted-frame paths printed the
+  relative dir twice (`utils/dasllama-server/utils/dasllama-server/...`) because the
+  DIFile directory and filename both carried it. A DIFile now carries the absolute
+  path with an empty directory (`ARCHITECTURE_DEBUG_INFO.md` sec.12).

--- a/modules/dasLLVM/REVIEW.md
+++ b/modules/dasLLVM/REVIEW.md
@@ -1,8 +1,8 @@
 # dasLLVM Code Review Checklist
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture docs:
-`ARCHITECTURE.md`, `ARCHITECTURE_TARGET_FEATURES.md`. Planned work: `DEBUGGING.md` (sec. Roadmap),
-`fat_mode_plan.md`.
+`ARCHITECTURE.md`, `ARCHITECTURE_TARGET_FEATURES.md`, `ARCHITECTURE_DEBUG_INFO.md`. Planned work:
+`DEBUGGING.md` (sec. Roadmap), `fat_mode_plan.md`.
 
 - **A change under `modules/dasLLVM/` runs the module-owned suite** (command and build gate:
   `tests/README.md` here). The suite is outside the core `tests/` sweep, so no other lane
@@ -34,7 +34,8 @@
   (`daslib/llvm_jit_run.das`) executes - its own body or any callee - also prints an
   `LLVM JIT time:` number for that work: its own line, or the number of a phase that includes
   it, while that phase's line still prints** (phase inventory: `ARCHITECTURE.md` sec.1).
-  Option resolution before the first timer, and log lines, are not work.
+  Only work on the path that reaches the report is timed: option resolution before the first
+  timer, log lines, and failure-path teardown are not.
 
 - **A change that can alter the machine code the JIT's DLL or split-obj cache serves back for
   identical inputs - IR generation, target-machine setup, a `[llvm_code]` generator body, or the
@@ -99,6 +100,21 @@
   recorded path is read by other people and must not name the user who minted it. A host path
   a diff passes to a filesystem call stays raw: no filesystem call resolves `~`.
   `tests/llvm_tune_manifest.das` here asserts a minted sidecar carries no home directory.
+
+- **A diff that emits an instruction into the entry block of a function whose body das
+  statements emit - the impl half of a pair, or a block body - gives it no debug location, and
+  one it emits into a loop's latch (the block that jumps back to the loop head) gives it the
+  loop's own line** (`daslib/llvm_jit.das`). Those are the two places the emitter fills out of
+  das statement order, and an instruction that keeps whatever location was current when it was
+  emitted moves a `break file:line` stop onto a statement that has not run
+  (`ARCHITECTURE_DEBUG_INFO.md` sec.12.2). The wrapper half's entry block is not such a place:
+  it holds no das statement at all and carries the declaration line on purpose, so a frame for
+  it prints a line.
+
+- **A diff that adds a teardown step to `reset_jit_globals_after_failure`
+  (`daslib/llvm_jit_run.das`) puts it after the `di_finalize()` call.** A DIBuilder writes into
+  the LLVM module it was created for, so finalizing one whose module an earlier step already
+  disposed of reads freed memory.
 
 - **Never call `LLVMSetIsInBounds` - build the GEP in-bounds with `LLVMBuildInBoundsGEP2` (the
   `llvm_boost` wrapper's `inbounds` default) instead.** A constant-folded GEP is a

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -18,6 +18,7 @@ require llvm/daslib/llvm_boost
 require llvm/daslib/llvm_jit_intrin
 require llvm/daslib/llvm_jit_lower
 require llvm/daslib/llvm_jit_common
+require llvm/daslib/llvm_jit_di
 require llvm/daslib/llvm_jit_code
 require llvm/daslib/llvm_cpu_class
 require llvm/daslib/llvm_user_modules  // nolint:STYLE030,LINT019 - side-effect require: [llvm_code] generator modules must be in THIS module's closure so their [init] registration runs in the context that reads the registry; STYLE030 is policy-gated, so the keep only fires under a require-analysis run
@@ -332,8 +333,8 @@ class public LlvmJitVisitor : AstVisitor {
     callBlock : LLVMOpaqueValue?
     g_builder : LLVMOpaqueBuilder?
     g_di_builder : LLVMOpaqueDIBuilder?
-    di_file_location : table<string; LLVMOpaqueMetadata?>
-    di_function : LLVMOpaqueMetadata?
+    di_subprogram : LLVMOpaqueMetadata?
+    di_scopes : array<LLVMOpaqueMetadata?>
     types : PrimitiveTypes -const? -const
     option_no_range_check : bool = false
     option_no_division_check : bool = false
@@ -344,7 +345,6 @@ class public LlvmJitVisitor : AstVisitor {
     has_externals : bool = false
     flags : LlvmJitFlags
     mode : LlvmJitMode
-    own_di : bool = false
     ldu_hint : bool
     attributes : Attributes?
 
@@ -358,25 +358,11 @@ class public LlvmJitVisitor : AstVisitor {
         attributes = attrs
         uid = uids
         if (flags.need_di) {
-            own_di = true
-            g_di_builder = LLVMCreateDIBuilder(g_mod)
-            // One CU per DIBuilder (LLVM asserts on a second). DIBuilder remembers it and
-            // stamps `unit:` on every subprogram definition; per-function DIFiles carry the
-            // real .das paths, so the CU's own file name is just a label.
-            let cu_name = "das-jit"
-            let producer = "daslang jit"
-            let cu_file = LLVMDIBuilderCreateFile(g_di_builder, cu_name, uint64(long_length(cu_name)), "", 0ul)
-            LLVMDIBuilderCreateCompileUnit(g_di_builder, LLVMDWARFSourceLanguage.C, cu_file,
-                producer, uint64(long_length(producer)), 0, "", 0ul, 0u, "", 0ul,
-                LLVMDWARFEmissionKind.LLVMDWARFEmissionFull, 0u, 0, 0, "", 0ul, "", 0ul)
+            g_di_builder = di_begin_module(g_mod)
         }
     }
 
     def finalize {
-        if (own_di && g_di_builder != null) {
-            LLVMDIBuilderFinalize(g_di_builder)
-            LLVMDisposeDIBuilder(g_di_builder)
-        }
         LLVMDisposeBuilder(g_builder)
     }
 
@@ -385,19 +371,41 @@ class public LlvmJitVisitor : AstVisitor {
         return g_di_builder != null
     }
 
+    [arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-subprogram-naming")]
+    def debug_subprogram(dasName : string; at : LineInfo;
+                         arguments : dasvector`ptr`Variable; result : TypeDeclPtr; localToUnit : bool) {
+        let unit = get_debug_file_location(at)
+        let ty = di_subroutine_of(g_di_builder, unit, arguments, result)
+        return LLVMDIBuilderCreateFunction(g_di_builder, unit,
+            dasName, uint64(long_length(dasName)), "", 0ul,
+            unit, at.line, ty, localToUnit ? 1 : 0, 1, at.line,
+            LLVMDIFlags.LLVMDIFlagZero, 0)
+    }
+
+    [arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-subprogram-naming")]
+    def impl_is_local_to_unit() {
+        return !g_jit_split_active
+    }
+
     def debug_before_function(fun : FunctionPtr) {
         if (debug_info_enabled()) {
             clear_builder_location()
-            let unit = get_debug_file_location(fun.at)
-            let implName = uid.get_dll_fn_name(fun).impl()
-            // Untyped subroutine (no param/return DI types yet) — enough for line tables.
-            var ty = LLVMDIBuilderCreateSubroutineType(
-                g_di_builder, unit, null, 0u, LLVMDIFlags.LLVMDIFlagZero)
-            // split mode makes impls external-hidden, so the DISubprogram must not claim local-to-unit
-            di_function = LLVMDIBuilderCreateFunction(g_di_builder, unit,
-                implName, uint64(long_length(implName)), "", 0ul, unit, fun.at.line,
-                ty, g_jit_split_active ? 0 : 1, 1, fun.at.line, LLVMDIFlags.LLVMDIFlagZero, 0)
-            LLVMSetSubprogram(ffunc, di_function)
+            di_subprogram = debug_subprogram("{fun.name}", fun.at, fun.arguments, fun.result, impl_is_local_to_unit())
+            LLVMSetSubprogram(ffunc, di_subprogram)
+            di_scopes |> clear()
+        }
+    }
+
+    def block_das_name(blk : ExprBlock?; func : Function?) {
+        return func != null ? "{func.name}_block_at_{int(blk.at.line)}" : "block_at_{int(blk.at.line)}"
+    }
+
+    def debug_before_block(blk : ExprBlock?; func : Function?) {
+        if (debug_info_enabled()) {
+            clear_builder_location()
+            di_subprogram = debug_subprogram(block_das_name(blk, func), blk.at, blk.arguments, blk.returnType, impl_is_local_to_unit())
+            LLVMSetSubprogram(ffunc, di_subprogram)
+            di_scopes |> clear()
         }
     }
 
@@ -415,27 +423,41 @@ class public LlvmJitVisitor : AstVisitor {
 
     def get_debug_file_location(at : LineInfo) : LLVMOpaqueMetadata? {
         if (debug_info_enabled()) {
-            let filename = at.fileInfo != null ? string(at.fileInfo.name) : ""
-            return get_debug_file_location_by_name(filename)
+            return get_debug_file_location_by_name(at.fileInfo != null ? string(at.fileInfo.name) : "")
         } else {
             return null
         }
     }
 
     def get_debug_file_location_by_name(filename : string) : LLVMOpaqueMetadata? {
-        var meta & = unsafe(di_file_location[filename])
-        if (meta == null) {
-            // filename already carries its path; a non-empty directory would make CodeView
-            // consumers print the dir twice (dir/dir/file) when they join the two fields
-            meta = LLVMDIBuilderCreateFile(g_di_builder, filename, uint64(long_length(filename)), "", 0ul)
+        return di_file_of(g_di_builder, filename)
+    }
+
+    def di_current_scope : LLVMOpaqueMetadata ? {
+        return di_scopes |> empty() ? di_subprogram : di_scopes |> back()
+    }
+
+    [arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-scopes")]
+    def di_push_lexical_block(at : LineInfo) {
+        return if (!debug_info_enabled() || di_subprogram == null)
+        let parent = di_current_scope()
+        let file = get_debug_file_location(at)
+        let parentFile = LLVMDIScopeGetFile(parent)
+        if (file != parentFile && file != null) {
+            di_scopes |> push <| LLVMDIBuilderCreateLexicalBlockFile(g_di_builder, parent, file, 0u)
+        } else {
+            di_scopes |> push <| LLVMDIBuilderCreateLexicalBlock(g_di_builder, parent, file, at.line, at.column)
         }
-        return meta
+    }
+
+    def di_pop_lexical_block {
+        return if (!debug_info_enabled() || di_scopes |> empty())
+        di_scopes |> pop()
     }
 
     def get_debug_location(at : LineInfo) : LLVMOpaqueMetadata? {
         if (debug_info_enabled()) {
-            let file_meta = get_debug_file_location(at)
-            return LLVMDIBuilderCreateDebugLocation(g_ctx, at.line, at.column, di_function, null)
+            return LLVMDIBuilderCreateDebugLocation(g_ctx, at.line, at.column, di_current_scope(), null)
         } else {
             return null
         }
@@ -443,7 +465,7 @@ class public LlvmJitVisitor : AstVisitor {
 
     def set_builder_location(at : LineInfo) {
         if (debug_info_enabled()) {
-            if (di_function != null) {
+            if (di_subprogram != null) {
                 LLVMSetCurrentDebugLocation2(g_builder, get_debug_location(at))
             }
         }
@@ -453,6 +475,43 @@ class public LlvmJitVisitor : AstVisitor {
         if (debug_info_enabled()) {
             LLVMSetCurrentDebugLocation2(g_builder, null)
         }
+    }
+
+    def slot_holds_pointer(v : VariablePtr) {
+        return v._type.flags.ref && !v.flags.aliasCMRES
+    }
+
+    // a local and a parameter differ only in the DILocalVariable they build; argNo is the
+    // parameter's 1-based position, which is what tells the two apart
+    def debug_declare_local(v : VariablePtr; storage : LLVMOpaqueValue?) {
+        debug_declare_variable(v, storage, 0, slot_holds_pointer(v))
+    }
+
+    def debug_declare_parameter(v : VariablePtr; storage : LLVMOpaqueValue?; argNo : int) {
+        debug_declare_variable(v, storage, argNo, false)
+    }
+
+    [arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-variable-locations")]
+    def debug_declare_variable(v : VariablePtr; storage : LLVMOpaqueValue?; argNo : int; storageHoldsPointer : bool) {
+        return if (!debug_info_enabled() || di_subprogram == null || storage == null ||
+                   v == null || v._type == null || v._type.isVoid)
+        let scope = di_current_scope()
+        let file = get_debug_file_location(v.at)
+        let vname = "{v.name}"
+        return if (vname |> empty())
+        var vty = di_type_of(g_di_builder, file, v._type)
+        return if (vty == null)
+        var dv : LLVMOpaqueMetadata?
+        if (argNo > 0) {
+            dv = LLVMDIBuilderCreateParameterVariable(g_di_builder, scope, vname, uint64(long_length(vname)),
+                uint(argNo), file, v.at.line, vty, 1, LLVMDIFlags.LLVMDIFlagZero)
+        } else {
+            dv = LLVMDIBuilderCreateAutoVariable(g_di_builder, scope, vname, uint64(long_length(vname)),
+                file, v.at.line, vty, 1, LLVMDIFlags.LLVMDIFlagZero, 0u)
+        }
+        let expr = storageHoldsPointer ? di_deref_expression(g_di_builder) : di_empty_expression(g_di_builder)
+        LLVMDIBuilderInsertDeclareRecordAtEnd(g_di_builder, storage, dv, expr,
+            get_debug_location(v.at), LLVMGetInsertBlock(g_builder))
     }
 
 // Expression
@@ -799,25 +858,18 @@ class public LlvmJitVisitor : AstVisitor {
             }
         }
         if (generated) {
-            build_wrapper_function(fnmna, fun.arguments, clone_type(fun.result), isCMRES(fun), null, fun.at)
+            build_wrapper_function(fnmna, "{fun.name}", fun.arguments, clone_type(fun.result), isCMRES(fun), null, fun.at)
         }
         ffunc = null
         wfunc = null
         return generated
     }
 
-    def build_wrapper_function(fnmna : DllName; arguments : dasvector`ptr`Variable; var result : TypeDeclPtr; isCmres : bool; captureType : LLVMOpaqueType?; at : LineInfo) {
+    def build_wrapper_function(fnmna : DllName; dasName : string; arguments : dasvector`ptr`Variable; var result : TypeDeclPtr; isCmres : bool; captureType : LLVMOpaqueType?; at : LineInfo) {
         var wentry = LLVMAppendBasicBlockInContext(g_ctx, wfunc, "entry")
         LLVMPositionBuilderAtEnd(g_builder, wentry)
         if (debug_info_enabled()) {
-            // The wrapper needs its own DISubprogram: at O2+ the impl often inlines into
-            // it, and LLVM drops the callee's !dbg when the host has no debug scope.
-            let unit = get_debug_file_location(at)
-            let publName = fnmna.publ()
-            var wty = LLVMDIBuilderCreateSubroutineType(g_di_builder, unit, null, 0u, LLVMDIFlags.LLVMDIFlagZero)
-            let wsp = LLVMDIBuilderCreateFunction(g_di_builder, unit,
-                publName, uint64(long_length(publName)), "", 0ul, unit, at.line,
-                wty, 0, 1, at.line, LLVMDIFlags.LLVMDIFlagZero, 0)
+            let wsp = debug_subprogram(dasName, at, arguments, result, false)
             LLVMSetSubprogram(wfunc, wsp)
             LLVMSetCurrentDebugLocation2(g_builder,
                 LLVMDIBuilderCreateDebugLocation(g_ctx, at.line, at.column, wsp, null))
@@ -939,7 +991,7 @@ class public LlvmJitVisitor : AstVisitor {
         }
         // allocate arguments (promoted to local variables). hasMakeBlock forces always-promote so
         // block-captured argument variables are addressable; could be narrowed to captured-only.
-        var alwaysPromote = false
+        var alwaysPromote = flags.need_di
         if (thisBlock != null && thisBlock.blockFlags.hasMakeBlock) {
             alwaysPromote = true
         } elif (thisFunc != null && thisFunc.flags.hasMakeBlock) {
@@ -951,6 +1003,9 @@ class public LlvmJitVisitor : AstVisitor {
                 LLVMSetAlignment(tryV, 16u)
                 LLVMBuildStore(g_builder, LLVMGetParam(ffunc, uint(ai)), tryV)
                 setV(a, tryV)
+                debug_declare_parameter(a, tryV, ai + 1)
+            } elif (a._type.isRef) {
+                debug_declare_parameter(a, LLVMGetParam(ffunc, uint(ai)), ai + 1)
             }
         }
         // function body
@@ -972,14 +1027,14 @@ class public LlvmJitVisitor : AstVisitor {
         ffunc = LLVMGetNamedFunction(g_mod, fnmna.impl())
         wfunc = LLVMGetNamedFunction(g_mod, fnmna.publ())
         // build wrapper function
-        build_wrapper_function(fnmna, fun.arguments, fun.result, isCMRES(fun), null, fun.at)
+        build_wrapper_function(fnmna, "{fun.name}", fun.arguments, fun.result, isCMRES(fun), null, fun.at)
+        debug_before_function(fun)
         build_function_entry(fun.at, hash(get_mangled_name(fun)),
                              fun.flags.hasMakeBlock || flags.emit_prologue,
                              fun.totalStackSize, fun.arguments)
         process_function_hints(fun.annotations, fun.arguments)
         process_labels(fun.body)
         process_finally(fun.body)
-        debug_before_function(fun)
         set_builder_location(fun.at)
     }
 
@@ -1000,6 +1055,7 @@ class public LlvmJitVisitor : AstVisitor {
 
     def override visitFunction(fun : FunctionPtr) : FunctionPtr {
         LLVMPositionBuilderAtEnd(g_builder, function_entry)
+        clear_builder_location()
         LLVMBuildBr(g_builder, function_body)
         debug_after_function()
         LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS = ldu_hint
@@ -1071,6 +1127,7 @@ class public LlvmJitVisitor : AstVisitor {
 
     def override preVisitExprBlock(var blk : ExprBlock?) : void {
         block_stack |> push(blk)
+        di_push_lexical_block(blk.at)
     }
 
     def override preVisitExprBlockExpression(blk : ExprBlock?; expr : ExpressionPtr) : void {
@@ -1127,6 +1184,7 @@ class public LlvmJitVisitor : AstVisitor {
             jump_to_next_finally(blk)
         }
         block_stack |> pop()
+        di_pop_lexical_block()
         return blk
     }
 
@@ -1182,6 +1240,7 @@ class public LlvmJitVisitor : AstVisitor {
             }
         }
         setV(arg, v_ptr)
+        debug_declare_local(arg, v_ptr)
         if (arg.init == null) {
             LLVMBuildMemSet(g_builder, v_ptr, 0ul, uint64(vsize), uint(valign))
         } elif (make_call_to_cmres(arg.init, v_ptr)) {
@@ -3715,6 +3774,7 @@ class public LlvmJitVisitor : AstVisitor {
     def override visitExprWhile(expr : ExprWhile?) : ExpressionPtr {
         var lblk = loop_stack |> back()
         loop_stack |> pop()
+        set_builder_location(expr.at)
         if (!current_block_terminates()) {
             let backedge = LLVMBuildBr(g_builder, lblk.loop_start)
             attach_loop_metadata(backedge, expr.annotations)
@@ -4033,6 +4093,7 @@ class public LlvmJitVisitor : AstVisitor {
             LLVMSetAlignment(v_ptr, 16u)
             v_ptr = LLVMBuildPointerCast(g_builder, v_ptr, vptrtype, "for_loop_variable_{svar.name}")
             setV(svar, v_ptr)
+            debug_declare_local(svar, v_ptr)
         }
         // initialize its memory with 0 (should we?)
         let vsize = svar._type.isRef ?  typeinfo sizeof(type<void?>) : svar._type.sizeOf
@@ -4240,6 +4301,7 @@ class public LlvmJitVisitor : AstVisitor {
     def override visitExprFor(expr : ExprFor?) : ExpressionPtr {
         var lblk = loop_stack |> back()
         loop_stack |> pop()
+        set_builder_location(expr.at)
         /*
         LOOP_CONTINUE:
             for ( int t=0; t!=totalCount; ++t ){
@@ -6649,7 +6711,8 @@ class public LlvmJitVisitor : AstVisitor {
         ffunc = LLVMGetNamedFunction(g_mod, fnmna.impl())
         wfunc = LLVMGetNamedFunction(g_mod, fnmna.publ())
         // build wrapper function
-        build_wrapper_function(fnmna, thisBlock.arguments, thisBlock.returnType, isCmres, captureType, thisBlock.at)
+        build_wrapper_function(fnmna, block_das_name(thisBlock, func), thisBlock.arguments, thisBlock.returnType, isCmres, captureType, thisBlock.at)
+        debug_before_block(thisBlock, func)
         build_function_entry(expr.at, hash(fnmna),
             thisBlock.blockFlags.hasMakeBlock || flags.emit_prologue,
             SIZE_OF_PROLOGUE, thisBlock.arguments)
@@ -6662,6 +6725,7 @@ class public LlvmJitVisitor : AstVisitor {
     def post_make_block(var blk : ExprBlock?) {
         add_default_terminator(blk)
         LLVMPositionBuilderAtEnd(g_builder, function_entry)
+        clear_builder_location()
         LLVMBuildBr(g_builder, function_body)
         thisBlock = null
         thisFunc = null
@@ -7532,9 +7596,14 @@ class public LlvmJitVisitor : AstVisitor {
 
     def at_function_entry(blk : block) {
         var current_block = LLVMGetInsertBlock(g_builder)
+        let saved_location = debug_info_enabled() ? LLVMGetCurrentDebugLocation2(g_builder) : null
         LLVMPositionBuilderAtEnd(g_builder, function_entry)
+        clear_builder_location()
         invoke(blk)
         LLVMPositionBuilderAtEnd(g_builder, current_block)
+        if (debug_info_enabled()) {
+            LLVMSetCurrentDebugLocation2(g_builder, saved_location)
+        }
     }
 
     def before_function_entry {

--- a/modules/dasLLVM/daslib/llvm_jit.das
+++ b/modules/dasLLVM/daslib/llvm_jit.das
@@ -307,6 +307,7 @@ class public LlvmJitVisitor : AstVisitor {
     heapMkaData : array<LLVMOpaqueValue?>
     v2v : table<Variable?; LLVMOpaqueValue?>
     g2v : table<Variable?; LLVMOpaqueValue?>    //! a solid-context global's entry-block pointer, cleared per LLVM function
+    di_globals : table<Variable?; bool>         //! the globals this function already describes, cleared with g2v
     v2t : table<LLVMOpaqueValue?; LLVMOpaqueType?>
     call2cmres : table<Expression?; LLVMOpaqueValue?>
     ffunc, wfunc : LLVMOpaqueValue?
@@ -489,6 +490,15 @@ class public LlvmJitVisitor : AstVisitor {
 
     def debug_declare_parameter(v : VariablePtr; storage : LLVMOpaqueValue?; argNo : int) {
         debug_declare_variable(v, storage, argNo, false)
+    }
+
+    //! A das global is described once per function that touches it, at the address that
+    //! function computed from its own `ctx` (arch doc sec.12.4).
+    [arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-globals")]
+    def debug_declare_global(v : VariablePtr; slot : LLVMOpaqueValue?) {
+        return if (!debug_info_enabled() || v == null || slot == null || di_globals |> key_exists(v))
+        di_globals[v] = true
+        debug_declare_variable(v, slot, 0, false)
     }
 
     [arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-variable-locations")]
@@ -1022,6 +1032,7 @@ class public LlvmJitVisitor : AstVisitor {
         thisFunc = fun
         uid.reset(fun)
         g2v |> clear()
+        di_globals |> clear()
         ldu_hint = LLVM_JIT_ALLOW_UNALIGNED_VECTOR_READ_OUT_OF_BOUNDS
         let fnmna = uid.get_dll_fn_name(fun)
         ffunc = LLVMGetNamedFunction(g_mod, fnmna.impl())
@@ -6157,6 +6168,7 @@ class public LlvmJitVisitor : AstVisitor {
                 }
                 g2v[expr.variable] = tryV
             }
+            debug_declare_global(expr.variable, tryV)
             if (expr.varFlags.r2v) {
                 setE(expr, LLVMBuildLoadData2Aligned(g_builder, type_to_llvm_type(expr._type), tryV, expr._type.alignOf, "global_var_r2v_{expr.variable.name}"))
             } else {

--- a/modules/dasLLVM/daslib/llvm_jit_di.das
+++ b/modules/dasLLVM/daslib/llvm_jit_di.das
@@ -1,0 +1,338 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options relaxed_pointer_const
+options unsafe_table_lookup = false
+options no_global_variables = false
+// the type factory is exact-type dispatch over the das Type lattice - one arm per base type is the shape
+options _cyclomatic_complexity = 0
+options _function_length = 0
+
+module llvm_jit_di shared private
+
+require llvm/daslib/llvm_boost
+require llvm/bindings/llvm_func
+require llvm/bindings/llvm_struct
+require llvm/bindings/llvm_enum
+require daslib/ast_boost
+require daslib/fio
+require math
+
+//! DWARF type and expression factory for the JIT's debug-info rail.
+
+let public DW_TAG_STRUCTURE_TYPE = 0x13u
+
+let public DW_ATE_BOOLEAN = 0x02u
+let public DW_ATE_FLOAT = 0x04u
+let public DW_ATE_SIGNED = 0x05u
+let public DW_ATE_SIGNED_CHAR = 0x06u
+let public DW_ATE_UNSIGNED = 0x07u
+
+let public DW_OP_DEREF = 0x06ul
+
+[extern(cdecl, name="LLVMDIBuilderCreateStructType", library="LLVM.dll")]
+def private llvm_di_create_struct_type(Builder : LLVMOpaqueDIBuilder? implicit; Scope : LLVMOpaqueMetadata? implicit;
+                                       Name : string implicit; NameLen : uint64; File : LLVMOpaqueMetadata? implicit;
+                                       LineNumber : uint; SizeInBits : uint64; AlignInBits : uint; Flags : LLVMDIFlags;
+                                       DerivedFrom : LLVMOpaqueMetadata? implicit; Elements : LLVMOpaqueMetadata ?? implicit;
+                                       NumElements : uint; RunTimeLang : uint; VTableHolder : LLVMOpaqueMetadata? implicit;
+                                       UniqueId : string implicit; UniqueIdLen : uint64) : LLVMOpaqueMetadata? {}
+
+var private g_di_cache_owner : LLVMOpaqueDIBuilder?
+var private g_di_cache : table<uint64; LLVMOpaqueMetadata?>
+var private g_di_files : table<string; LLVMOpaqueMetadata?>
+var private g_di_composites_in_progress : table<uint64; bool>
+
+var private g_di_module : LLVMOpaqueModule?
+var private g_di_builder : LLVMOpaqueDIBuilder?
+
+[arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-one-cu-per-module")]
+def public di_begin_module(mod : LLVMOpaqueModule?) : LLVMOpaqueDIBuilder? {
+    return g_di_builder if (mod == g_di_module && g_di_builder != null)
+    di_finalize()
+    g_di_module = mod
+    g_di_builder = LLVMCreateDIBuilder(mod)
+    let cu_name = "das-jit"
+    let producer = "daslang jit"
+    let cu_file = LLVMDIBuilderCreateFile(g_di_builder, cu_name, uint64(long_length(cu_name)), "", 0ul)
+    LLVMDIBuilderCreateCompileUnit(g_di_builder, LLVMDWARFSourceLanguage.C_plus_plus, cu_file,
+        producer, uint64(long_length(producer)), 0, "", 0ul, 0u, "", 0ul,
+        LLVMDWARFEmissionKind.LLVMDWARFEmissionFull, 0u, 0, 0, "", 0ul, "", 0ul)
+    di_reset_type_cache(g_di_builder)
+    return g_di_builder
+}
+
+//! Called once per module, after the last function is emitted and before anything reads it.
+def public di_finalize {
+    return if (g_di_builder == null)
+    LLVMDIBuilderFinalize(g_di_builder)
+    LLVMDisposeDIBuilder(g_di_builder)
+    g_di_builder = null
+    g_di_module = null
+    di_reset_type_cache(null)
+}
+
+def private di_reset_type_cache(dib : LLVMOpaqueDIBuilder?) {
+    g_di_cache_owner = dib
+    g_di_cache |> clear()
+    g_di_files |> clear()
+    g_di_composites_in_progress |> clear()
+}
+
+[arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-one-cu-per-module")]
+def private di_cache_drop_if_stale(dib : LLVMOpaqueDIBuilder?) {
+    if (g_di_cache_owner != dib) {
+        di_reset_type_cache(dib)
+    }
+}
+
+def public di_file_of(dib : LLVMOpaqueDIBuilder?; filename : string) : LLVMMetadataRef {
+    return null if (dib == null)
+    di_cache_drop_if_stale(dib)
+    let hit = unsafe(g_di_files?[filename] ?? null)
+    return hit if (hit != null)
+    var full = filename |> empty() ? "unknown_filename" : get_full_file_name(filename)
+    if (full |> empty()) {
+        full = filename
+    }
+    let node = LLVMDIBuilderCreateFile(dib, full, uint64(long_length(full)), "", 0ul)
+    g_di_files[filename] = node
+    return node
+}
+
+def private di_basic(dib : LLVMOpaqueDIBuilder?; name : string; bytes : int; encoding : uint) : LLVMMetadataRef {
+    return LLVMDIBuilderCreateBasicType(dib, name, uint64(long_length(name)),
+        uint64(bytes) * 8ul, encoding, LLVMDIFlags.LLVMDIFlagZero)
+}
+
+def private di_vector_of(dib : LLVMOpaqueDIBuilder?; elem : LLVMMetadataRef; count : int; bytes : int; align : int) : LLVMMetadataRef {
+    var subs <- array<LLVMMetadataRef>(LLVMDIBuilderGetOrCreateSubrange(dib, 0l, int64(count)))
+    return LLVMDIBuilderCreateVectorType(dib, uint64(bytes) * 8ul, uint(align) * 8u,
+        elem, array_data_ptr(subs), 1u)
+}
+
+def private di_scalar_of(dib : LLVMOpaqueDIBuilder?; bt : Type) : LLVMMetadataRef {
+    return di_basic(dib, "int", 4, DW_ATE_SIGNED) if (bt == Type.tInt)
+    return di_basic(dib, "uint", 4, DW_ATE_UNSIGNED) if (bt == Type.tUInt || bt == Type.tBitfield)
+    return di_basic(dib, "int8", 1, DW_ATE_SIGNED) if (bt == Type.tInt8)
+    return di_basic(dib, "uint8", 1, DW_ATE_UNSIGNED) if (bt == Type.tUInt8 || bt == Type.tBitfield8)
+    return di_basic(dib, "int16", 2, DW_ATE_SIGNED) if (bt == Type.tInt16)
+    return di_basic(dib, "uint16", 2, DW_ATE_UNSIGNED) if (bt == Type.tUInt16 || bt == Type.tBitfield16)
+    return di_basic(dib, "int64", 8, DW_ATE_SIGNED) if (bt == Type.tInt64)
+    return di_basic(dib, "uint64", 8, DW_ATE_UNSIGNED) if (bt == Type.tUInt64 || bt == Type.tBitfield64)
+    return di_basic(dib, "float", 4, DW_ATE_FLOAT) if (bt == Type.tFloat)
+    return di_basic(dib, "double", 8, DW_ATE_FLOAT) if (bt == Type.tDouble)
+    return di_basic(dib, "float16", 2, DW_ATE_FLOAT) if (bt == Type.tFloat16)
+    return di_basic(dib, "bool", 1, DW_ATE_BOOLEAN) if (bt == Type.tBool)
+    return null
+}
+
+def private di_lane_shape(bt : Type) : tuple<elem : Type; count : int> {
+    return (elem = Type.tInt, count = 2) if (bt == Type.tInt2 || bt == Type.tRange)
+    return (elem = Type.tInt, count = 3) if (bt == Type.tInt3)
+    return (elem = Type.tInt, count = 4) if (bt == Type.tInt4)
+    return (elem = Type.tUInt, count = 2) if (bt == Type.tUInt2 || bt == Type.tURange)
+    return (elem = Type.tUInt, count = 3) if (bt == Type.tUInt3)
+    return (elem = Type.tUInt, count = 4) if (bt == Type.tUInt4)
+    return (elem = Type.tInt64, count = 2) if (bt == Type.tRange64)
+    return (elem = Type.tUInt64, count = 2) if (bt == Type.tURange64)
+    return (elem = Type.tFloat, count = 2) if (bt == Type.tFloat2)
+    return (elem = Type.tFloat, count = 3) if (bt == Type.tFloat3)
+    return (elem = Type.tFloat, count = 4) if (bt == Type.tFloat4)
+    return (elem = Type.tFloat16, count = 2) if (bt == Type.tHalf2)
+    return (elem = Type.tFloat16, count = 3) if (bt == Type.tHalf3)
+    return (elem = Type.tFloat16, count = 4) if (bt == Type.tHalf4)
+    return (elem = Type.tFloat16, count = 8) if (bt == Type.tHalf8)
+    return (elem = Type.tInt16, count = 2) if (bt == Type.tShort2)
+    return (elem = Type.tInt16, count = 3) if (bt == Type.tShort3)
+    return (elem = Type.tInt16, count = 4) if (bt == Type.tShort4)
+    return (elem = Type.tInt16, count = 8) if (bt == Type.tShort8)
+    return (elem = Type.tUInt16, count = 2) if (bt == Type.tUShort2)
+    return (elem = Type.tUInt16, count = 3) if (bt == Type.tUShort3)
+    return (elem = Type.tUInt16, count = 4) if (bt == Type.tUShort4)
+    return (elem = Type.tUInt16, count = 8) if (bt == Type.tUShort8)
+    return (elem = Type.tInt8, count = 2) if (bt == Type.tByte2)
+    return (elem = Type.tInt8, count = 3) if (bt == Type.tByte3)
+    return (elem = Type.tInt8, count = 4) if (bt == Type.tByte4)
+    return (elem = Type.tInt8, count = 8) if (bt == Type.tByte8)
+    return (elem = Type.tInt8, count = 16) if (bt == Type.tByte16)
+    return (elem = Type.tUInt8, count = 2) if (bt == Type.tUByte2)
+    return (elem = Type.tUInt8, count = 3) if (bt == Type.tUByte3)
+    return (elem = Type.tUInt8, count = 4) if (bt == Type.tUByte4)
+    return (elem = Type.tUInt8, count = 8) if (bt == Type.tUByte8)
+    return (elem = Type.tUInt8, count = 16) if (bt == Type.tUByte16)
+    return (elem = Type.none, count = 0)
+}
+
+def private di_enum_entry_value(e : ExpressionPtr) : tuple<value : int64; known : bool> {
+    return (value = int64((e as ExprConstInt).value), known = true) if (e is ExprConstInt)
+    return (value = int64((e as ExprConstInt8).value), known = true) if (e is ExprConstInt8)
+    return (value = int64((e as ExprConstInt16).value), known = true) if (e is ExprConstInt16)
+    return (value = (e as ExprConstInt64).value, known = true) if (e is ExprConstInt64)
+    return (value = int64((e as ExprConstUInt).value), known = true) if (e is ExprConstUInt)
+    return (value = int64((e as ExprConstUInt8).value), known = true) if (e is ExprConstUInt8)
+    return (value = int64((e as ExprConstUInt16).value), known = true) if (e is ExprConstUInt16)
+    return (value = int64((e as ExprConstUInt64).value), known = true) if (e is ExprConstUInt64)
+    return (value = 0l, known = false)
+}
+
+def private di_enumeration(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; t : TypeDeclPtr) : LLVMMetadataRef {
+    let en = t.enumType
+    let ename = en != null ? "{en.name}" : "enum"
+    var entries : array<LLVMMetadataRef>
+    let unsigned = t.flags.enumStubIsUnsigned || t.isUnsignedInteger
+    if (en != null) {
+        for (ee in en.list) {
+            let folded = di_enum_entry_value(ee.value)
+            continue if (!folded.known)
+            let een = "{ee.name}"
+            entries |> push <| LLVMDIBuilderCreateEnumerator(dib, een, uint64(long_length(een)), folded.value, unsigned ? 1 : 0)
+        }
+    }
+    let base = di_scalar_of(dib, t.baseSizeOf == 8 ? Type.tInt64 : (t.baseSizeOf == 2 ? Type.tInt16 : (t.baseSizeOf == 1 ? Type.tInt8 : Type.tInt)))
+    return LLVMDIBuilderCreateEnumerationType(dib, file, ename, uint64(long_length(ename)),
+        file, en != null ? en.at.line : 0u, uint64(t.sizeOf) * 8ul, uint(t.alignOf) * 8u,
+        array_data_ptr(entries), uint(length(entries)), base)
+}
+
+def private di_opaque(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; name : string; bytes : int; align : int) : LLVMMetadataRef {
+    return LLVMDIBuilderCreateForwardDecl(dib, DW_TAG_STRUCTURE_TYPE, name, uint64(long_length(name)),
+        file, file, 0u, 0u, uint64(bytes) * 8ul, uint(align) * 8u, name, uint64(long_length(name)))
+}
+
+def private di_pointer_to(dib : LLVMOpaqueDIBuilder?; pointee : LLVMMetadataRef; name : string) : LLVMMetadataRef {
+    return LLVMDIBuilderCreatePointerType(dib, pointee, uint64(typeinfo sizeof(type<void?>)) * 8ul,
+        uint(typeinfo alignof(type<void?>)) * 8u, 0u, name, uint64(long_length(name)))
+}
+
+def private di_member(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; scope : LLVMMetadataRef;
+                      mname : string; moffset : int; msize : int; malign : int; mty : LLVMMetadataRef) : LLVMMetadataRef {
+    return LLVMDIBuilderCreateMemberType(dib, scope, mname, uint64(long_length(mname)),
+        file, 0u, uint64(msize) * 8ul, uint(malign) * 8u, uint64(moffset) * 8ul,
+        LLVMDIFlags.LLVMDIFlagZero, mty)
+}
+
+[arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-composite-types")]
+def private di_members_of(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef;
+                          t : TypeDeclPtr; var out : array<LLVMMetadataRef>) {
+    if (t.isStructure && t.structType != null) {
+        for (fld in t.structType.fields) {
+            out |> push <| di_member(dib, file, file, "{fld.name}", fld.offset,
+                fld._type.sizeOf, fld._type.alignOf, di_type_of(dib, file, fld._type))
+        }
+    } elif (t.isTuple || t.isVariant) {
+        let is_variant = t.isVariant
+        if (is_variant) {
+            out |> push <| di_member(dib, file, file, "__tag", 0, 4, 4, di_scalar_of(dib, Type.tInt))
+        }
+        var offset = is_variant ? max(4, t.variantAlign) : 0
+        for (at, an, ai in t.argTypes, t.argNames, count()) {
+            let aname = an |> empty() ? "_{ai}" : "{an}"
+            let aalign = at.alignOf
+            if (!is_variant) {
+                offset = (offset + aalign - 1) & -aalign
+            }
+            out |> push <| di_member(dib, file, file, aname, offset, at.sizeOf, aalign, di_type_of(dib, file, at))
+            if (!is_variant) {
+                offset += at.sizeOf
+            }
+        }
+    }
+}
+
+[arch(at="../ARCHITECTURE_DEBUG_INFO.md#di-composite-types")]
+def private di_composite(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; t : TypeDeclPtr; name : string) : LLVMMetadataRef {
+    let mnh = t.get_mnh
+    let line = t.isStructure && t.structType != null ? t.structType.at.line : 0u
+    g_di_composites_in_progress[mnh] = true
+    var members : array<LLVMMetadataRef>
+    di_members_of(dib, file, t, members)
+    g_di_composites_in_progress |> erase(mnh)
+    return llvm_di_create_struct_type(dib, file, name, uint64(long_length(name)), file, line,
+        uint64(t.sizeOf) * 8ul, uint(t.alignOf) * 8u, LLVMDIFlags.LLVMDIFlagZero, null,
+        array_data_ptr(members), uint(length(members)), 0u, null, name, uint64(long_length(name)))
+}
+
+def private di_fixed_array(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; t : TypeDeclPtr) : LLVMMetadataRef {
+    var subs : array<LLVMMetadataRef>
+    var leaf = t
+    while (leaf.baseType == Type.tFixedArray && leaf.firstType != null) {
+        subs |> push <| LLVMDIBuilderGetOrCreateSubrange(dib, 0l, int64(leaf.fixedDim))
+        leaf = leaf.firstType
+    }
+    return LLVMDIBuilderCreateArrayType(dib, uint64(t.sizeOf) * 8ul, uint(t.alignOf) * 8u,
+        di_type_of(dib, file, leaf), array_data_ptr(subs), uint(length(subs)))
+}
+
+def private di_pointee_of(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; pt : TypeDeclPtr) : LLVMMetadataRef {
+    return null if (pt == null || pt.isVoid)
+    if (g_di_composites_in_progress?[pt.get_mnh] ?? false) {
+        return di_opaque(dib, file, "{describe(pt)}", max(pt.sizeOf, 1), max(pt.alignOf, 1))
+    }
+    return di_type_of(dib, file, pt)
+}
+
+def public di_type_of(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef; t : TypeDeclPtr) : LLVMMetadataRef {
+    return null if (dib == null || t == null || t.isVoid)
+    di_cache_drop_if_stale(dib)
+    let mnh = t.get_mnh
+    let hit = unsafe(g_di_cache?[mnh] ?? null)
+    return hit if (hit != null)
+    var res : LLVMMetadataRef
+    if (t.baseType == Type.tDistinct && t.firstType != null) {
+        res = di_type_of(dib, file, t.firstType)
+    } elif (t.baseType == Type.tFixedArray) {
+        res = di_fixed_array(dib, file, t)
+    } elif (t.isEnum || t.isEnumT) {
+        res = di_enumeration(dib, file, t)
+    } elif (t.isString) {
+        res = di_pointer_to(dib, di_basic(dib, "char", 1, DW_ATE_SIGNED_CHAR), "string")
+    } elif (t.isPointer) {
+        res = di_pointer_to(dib, di_pointee_of(dib, file, t.firstType), "{describe(t)}")
+    } elif (t.isStructure || t.isTuple || t.isVariant) {
+        res = di_composite(dib, file, t, "{describe(t)}")
+    } elif (t.isHandle) {
+        res = di_opaque(dib, file, t.annotation != null ? "{t.annotation.name}" : "handle", t.sizeOf, t.alignOf)
+    } elif (t.baseType == Type.tArray || t.baseType == Type.tTable || t.baseType == Type.tIterator ||
+            t.baseType == Type.tBlock || t.baseType == Type.tFunction || t.baseType == Type.tLambda) {
+        res = di_opaque(dib, file, "{describe(t)}", t.sizeOf, t.alignOf)
+    } else {
+        res = di_scalar_of(dib, t.baseType)
+        if (res == null) {
+            let lanes = di_lane_shape(t.baseType)
+            if (lanes.count != 0) {
+                res = di_vector_of(dib, di_scalar_of(dib, lanes.elem), lanes.count, t.sizeOf, t.alignOf)
+            }
+        }
+        if (res == null) {
+            res = di_opaque(dib, file, "{describe(t)}", max(t.sizeOf, 1), max(t.alignOf, 1))
+        }
+    }
+    g_di_cache[mnh] = res
+    return res
+}
+
+def public di_subroutine_of(dib : LLVMOpaqueDIBuilder?; file : LLVMMetadataRef;
+                            arguments : dasvector`ptr`Variable; result : TypeDeclPtr) : LLVMMetadataRef {
+    var types : array<LLVMMetadataRef>
+    types |> push <| di_type_of(dib, file, result)
+    for (a in arguments) {
+        var ty = di_type_of(dib, file, a._type)
+        if (a._type != null && a._type.isRef && ty != null) {
+            ty = di_pointer_to(dib, ty, "")
+        }
+        types |> push <| ty
+    }
+    return LLVMDIBuilderCreateSubroutineType(dib, file, array_data_ptr(types),
+        uint(length(types)), LLVMDIFlags.LLVMDIFlagZero)
+}
+
+def public di_empty_expression(dib : LLVMOpaqueDIBuilder?) : LLVMMetadataRef {
+    return LLVMDIBuilderCreateExpression(dib, null, 0ul)
+}
+
+def public di_deref_expression(dib : LLVMOpaqueDIBuilder?) : LLVMMetadataRef {
+    var ops <- array<uint64>(DW_OP_DEREF)
+    return LLVMDIBuilderCreateExpression(dib, array_data_ptr(ops), 1ul)
+}

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -10,6 +10,7 @@ require llvm/daslib/llvm_exe
 require llvm/daslib/llvm_aot
 require llvm/daslib/llvm_jit
 require llvm/daslib/llvm_jit_common
+require llvm/daslib/llvm_jit_di
 require llvm/daslib/llvm_jit_intrin
 require llvm/daslib/llvm_jit_cli
 require llvm/daslib/llvm_env
@@ -38,11 +39,11 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x7aul   // a lambda <-> int64/uint64 reinterpret lowers through ptrtoint / inttoptr, not a bitcast (0x79: an intrinsic emitter keys off the declared name, so a module-qualified call (math::sqrt) builds llvm.sqrt.f32; a function <-> int64/uint64 reinterpret extracts and inserts the { ptr } aggregate instead of bitcasting itd flag (0x77: a vector of a handled element type registers into the element's module, so the externs a DLL binds by mangled name moved out of `$` (0x76: a statement after a terminator in the same block list lands in its own dead block instead of after the ret (0x75: the global-offset lookup is memory(none) and emitted at its use site - LLVM dedups and hoists it, an untaken branch never pays it; a solid-context global resolves once per function at entry (0x74: a runtime-only exe emits no register_native_path rows, and a whole-lib exe emits them once (0x73: computed goto lowers to one switch with the trap as its default, not an icmp chain (0x72: policies.fast_math defaults to the host's float flags, so a fast-math host now JITs fast-math (0x71: a CPU class row's cpu is the arch's bare baseline, so a DAS_JIT_BASELINE build enables the row's set and nothing a level implies (0x70: the wasm feature string drops +relaxed-simd and the idot family keeps only the exact extmul + extadd_pairwise lowering on wasm SIMD128 (0x6f: the first wasm idot lowering; 0x6e: the aarch64 SDOT / SMMLA tables gate on DotProd / i8mm, not the arch alone, and the force env reaches the generic exe machine (0x6d: the inline polynomial rail carries NaN: tanh selects the operand back over its ordered clamp, and the sincos quadrant / tan octant convert through llvm.fptosi.sat instead of poisoning on NaN and out-of-range (0x6c: aarch64 vector tan/exp2/log2/log/pow join the inline polynomial rail bit-exactly with the interpreter, sinh/cosh/tanh ride the exp one; 0x6b: aarch64 vector sin/cos ride the inline polynomial; 0x6a: srem/urem for 32-bit %; 0x69: every string argument of an extern is substituted, not just the ones which asked))))
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x7bul   // under --jit-debug every das local, argument and block variable carries a DILocalVariable with a real DIType, a das block opens a DILexicalBlock, a subprogram is named as the das source names it and carries no linkage name, one compile unit covers the whole module, and the prologue and a loop latch carry no stale line
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0xe62f349446ec3d5dul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0x6416ae2fd7f1057bul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 
@@ -371,6 +372,7 @@ def finalize_jit(use_dll : bool; gen_exe : bool; lib_handle : DLLHandle?) : JitS
 // unjittable file instead of the next run_jit inheriting it and cascade-failing.
 [macro_function]
 def reset_jit_globals_after_failure() {
+    di_finalize()
     // --jit-split-modules: drain the stashed partition states (the ambient one is handled below)
     for (p in g_split_parts) {
         dispose_split_part(p, p.ctx != g_ctx)
@@ -395,7 +397,7 @@ def reset_jit_globals_after_failure() {
 // always-on summary (a silent multi-second jit is indistinguishable from a hang) + the
 // log_compile_time per-phase breakdown; both artifact paths report through here
 def private jit_log_report(funcs : array<FunctionPtr>; recompiled : bool; opt_level : int; tier_known : bool;
-                           split : bool; split_parts : int; log_time : bool; totalTime : int64;
+                           split : bool; split_parts : int; debug_info : bool; log_time : bool; totalTime : int64;
                            t_hash, t_init, t_declare, t_probe, t_irgen, t_opt, t_emit, t_install, t_finalize : int) {
     var tuneStamped = 0
     for (fn in funcs) {
@@ -410,8 +412,9 @@ def private jit_log_report(funcs : array<FunctionPtr>; recompiled : bool; opt_le
     let tierTail = tier_known ? ", O{opt_level}" : ""
     // always announce split - a split-built DLL's profile is not comparable to a monolith build
     let splitTail = !split ? "" : (split_parts > 0 ? ", split {split_parts} modules" : ", split")
+    let debugTail = debug_info ? ", --jit-debug" : ""
     let totalDt = double(get_time_usec(totalTime)) / 1000000.0lf
-    to_log(LOG_INFO, "LLVM JIT: {length(funcs)} functions{tuneTail} in {totalDt} sec ({recompiled ? "codegen" : "cache"}{tierTail}{splitTail})\n")
+    to_log(LOG_INFO, "LLVM JIT: {length(funcs)} functions{tuneTail} in {totalDt} sec ({recompiled ? "codegen" : "cache"}{tierTail}{splitTail}{debugTail})\n")
     if (log_time) {
         to_log(LOG_INFO, "LLVM JIT time: hash {jit_sec(t_hash)} init {jit_sec(t_init)} declare {jit_sec(t_declare)} probe {jit_sec(t_probe)} irgen {jit_sec(t_irgen)} optimize {jit_sec(t_opt)} emit+link {jit_sec(t_emit)} install {jit_sec(t_install)} finalize {jit_sec(t_finalize)}\n")
     }
@@ -614,6 +617,7 @@ def private run_split_codegen(prog : Program?; ctx : Context?; funcs : array<Fun
         }
         // the has_externals return is meaningful only on the wasm path, unreachable under split - discard
         irgen_functions(ctx, uids, attrs, buckets[pname], jit_flags, LlvmJitMode.JIT, prog)
+        di_finalize()
         verify_module_or_panic(buckets[pname])
         // fileinfo ctors ride llvm.global_ctors (private; the link appends all, LoadLibrary runs every one)
         generate_global_ctors_dtors(g_prim_t, false)
@@ -993,12 +997,15 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {  // nolint:STYL
                     cli_opts.register_all_modules |> unwrap_or(false))
                 LINK_WHOLE_LIB = res.link_whole_lib
                 if (res.fn == null) {
+                    // before finalize_jit, which disposes the engine that owns g_mod
+                    di_finalize()
                     finalize_jit(use_dll, gen_exe, g_dynamic_lib_handle)
                     // JIT failed. Couldn't create executable.
                     // Still return true, codegen ran correctly.
                     return true
                 }
             }
+            di_finalize()
             verify_module_or_panic(funcs)
             // Offline AOT object: build the self-registration + glob-re-resolution ctors (llvm_aot pass).
             var aot_ctor : LLVMOpaqueValue? = null
@@ -1060,7 +1067,7 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {  // nolint:STYL
             unsafe {
                 delete g_str2v
             }
-            jit_log_report(funcs, true, opt_level, true, false, 0, log_jit_time, totalTime,
+            jit_log_report(funcs, true, opt_level, true, false, 0, debug_info, log_jit_time, totalTime,
                 t_hash, t_init, t_declare, t_probe, t_irgen, t_opt, t_emit, 0, 0)
             return true
         }
@@ -1100,7 +1107,7 @@ def public run_jit(prog : Program?; var ctx : Context?) : bool {  // nolint:STYL
         // so the tier label is asserted only when this run built the DLL or the content-addressed
         // name (which folds opt_level) matched
         let tier_known = recompile_prog || !empty(dll_hash_basename)
-        jit_log_report(funcs, recompile_prog, opt_level, tier_known, jit_split, split_parts, log_jit_time, totalTime,
+        jit_log_report(funcs, recompile_prog, opt_level, tier_known, jit_split, split_parts, debug_info, log_jit_time, totalTime,
             t_hash, t_init, t_declare, t_probe, t_irgen, t_opt, t_emit, t_install, t_finalize)
     } else {
         to_log(LOG_INFO, "LLVM JIT: 0 functions to jit ({length(disabled)} marked no_jit, {visitorDisabled} disabled by content) - the WHOLE program runs interpreted\n")

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -39,11 +39,11 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 // invalidates cached DLLs (e.g. edits to llvm_jit.das, llvm_macro.das, llvm_jit_common.das,
 // runtime helper ABI, default target triple). Cache filenames fold this in, so a bump
 // makes every previously written DLL miss the cache on the next run and get GC'd.
-let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x7bul   // under --jit-debug every das local, argument and block variable carries a DILocalVariable with a real DIType, a das block opens a DILexicalBlock, a subprogram is named as the das source names it and carries no linkage name, one compile unit covers the whole module, and the prologue and a loop latch carry no stale line
+let LLVM_JIT_CODEGEN_VERSION : uint64 = 0x7cul   // under --jit-debug a das global is described too, at the ctx-derived pointer each function computes for it; every das local, argument and block variable carries a DILocalVariable with a real DIType, a das block opens a DILexicalBlock, a subprogram is named as the das source names it and carries no linkage name, one compile unit covers the whole module, and the prologue and a loop latch carry no stale line
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0x6416ae2fd7f1057bul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0x65480ff16be6cbadul
 
 let JIT_FNV_PRIME : uint64 = 1099511628211ul
 

--- a/modules/dasLLVM/tests/_debug_info_root.das
+++ b/modules/dasLLVM/tests/_debug_info_root.das
@@ -1,0 +1,64 @@
+options gen2
+
+// child fixture of llvm_jit_debug_info.das: one function covering every DWARF shape the rail
+// describes - scalars, a struct argument, an enum, a string, a vector local, a nested block,
+// a ref local, a while latch, a fixed array, a container, a tuple, a self-referencing struct
+// reached through a pointer, and a block that captures a local by reference
+
+struct Point {
+    x : float
+    y : float
+}
+
+struct Node {
+    value : int
+    next : Node?
+}
+
+enum Mode {
+    fast
+    slow
+}
+
+def private invoke_block(blk : block<(a : int) : int>) {
+    return invoke(blk, 3)
+}
+
+[export]
+def hot(n : int; scale : float; p : Point; m : Mode; tag : string) : int {
+    var acc = 0
+    var f4 = float4(1.0, 2.0, 3.0, 4.0)
+    f4 = f4 * scale
+    for (i in range(n)) {
+        acc += i * i
+        if (i == n / 2) {
+            let inner = acc + int(scale * p.x)
+            acc += inner % 7
+        }
+    }
+    var acc_ref & = acc
+    acc_ref++
+    var spin = 0
+    while (spin < 3) {
+        spin++
+    }
+    var dim3 : int[3]
+    dim3[1] = spin
+    var xs : array<int>
+    xs |> push(spin)
+    let pair = (spin, scale)
+    var head = Node(value = spin, next = null)
+    let node = unsafe(addr(head))
+    let blocked = invoke_block() $(a : int) : int {
+        acc_ref += a
+        return a * 2
+    }
+    return (acc + dim3[1] + length(xs) + pair._0 + node.value + blocked + int(f4.w)
+        + (m == Mode.slow ? length(tag) : 0))
+}
+
+[export]
+def main {
+    let p = Point(x = 1.5, y = 2.5)
+    print("DEBUG_INFO_ROOT {hot(100, 2.0, p, Mode.slow, "run")}\n")
+}

--- a/modules/dasLLVM/tests/_debug_info_root.das
+++ b/modules/dasLLVM/tests/_debug_info_root.das
@@ -20,12 +20,15 @@ enum Mode {
     slow
 }
 
+var g_calls = 0
+
 def private invoke_block(blk : block<(a : int) : int>) {
     return invoke(blk, 3)
 }
 
 [export]
 def hot(n : int; scale : float; p : Point; m : Mode; tag : string) : int {
+    g_calls++
     var acc = 0
     var f4 = float4(1.0, 2.0, 3.0, 4.0)
     f4 = f4 * scale
@@ -53,7 +56,7 @@ def hot(n : int; scale : float; p : Point; m : Mode; tag : string) : int {
         acc_ref += a
         return a * 2
     }
-    return (acc + dim3[1] + length(xs) + pair._0 + node.value + blocked + int(f4.w)
+    return (acc + g_calls + dim3[1] + length(xs) + pair._0 + node.value + blocked + int(f4.w)
         + (m == Mode.slow ? length(tag) : 0))
 }
 

--- a/modules/dasLLVM/tests/llvm_jit_debug_info.das
+++ b/modules/dasLLVM/tests/llvm_jit_debug_info.das
@@ -166,6 +166,19 @@ def test_locals_and_arguments_are_described(t : T?) {
 }
 
 [test]
+def test_a_global_is_described(t : T?) {
+    t |> run("a das global reads in every function that touches it") @(t : T?) {
+        let out = jit_dump(t, true)
+        //! a global has no static address - it is described at the pointer the function computed
+        //! from its own ctx, so it lands as a variable of that function (arch doc sec.12.4)
+        t |> success(find(out, "!DILocalVariable(name: \"g_calls\"") >= 0,
+            "the fixture's global is described:\n{out_tail(out)}")
+        t |> equal(-1, find(out, "!DIGlobalVariableExpression"),
+            "no static-address global expression - one address cannot stand for every Context")
+    }
+}
+
+[test]
 def test_types_are_described(t : T?) {
     t |> run("a struct, an enum, a string and a vector each reach DWARF as themselves") @(t : T?) {
         let out = jit_dump(t, true)

--- a/modules/dasLLVM/tests/llvm_jit_debug_info.das
+++ b/modules/dasLLVM/tests/llvm_jit_debug_info.das
@@ -1,0 +1,241 @@
+options gen2
+require dastest/testing_boost public
+require daslib/fio
+require daslib/strings_boost
+require strings
+require math
+
+// The --jit-debug rail's DWARF, read off the emitted IR rather than off a debugger.
+// Shape and reasons: ARCHITECTURE_DEBUG_INFO.md sec.12.
+
+let private ROOT = "modules/dasLLVM/tests/_debug_info_root.das"
+
+def private das_exe() : string {
+    let argv <- get_command_line_arguments()
+    return find(to_generic_path(argv[0]), "/") < 0 ? argv[0] : get_full_file_name(normalize(argv[0]))
+}
+
+def private out_tail(s : string) : string {
+    return slice(s, max(0, length(s) - 600))
+}
+
+def private count_of(s : string; needle : string) : int {
+    var n = 0
+    var at = find(s, needle, 0)
+    while (at >= 0) {
+        n++
+        at = find(s, needle, at + length(needle))
+    }
+    return n
+}
+
+//! the dumped IR of one function, by its dumped name - signature line to closing brace
+def private function_ir(dump : string; name : string) : string {
+    let start = find(dump, "`{name}\"(")
+    return "" if (start < 0)
+    let body = slice(dump, start)
+    let close = find(body, "\n}")
+    return close < 0 ? body : slice(body, 0, close)
+}
+
+//! the entry block of a dumped function: everything before its first branch
+def private entry_block_ir(fn_ir : string) : string {
+    let br = find(fn_ir, "\n  br ")
+    return br < 0 ? fn_ir : slice(fn_ir, 0, br)
+}
+
+//! the fixture's own DIFile line, whichever metadata number it landed on
+def private fixture_difile(dump : string) : string {
+    var lines <- split(dump, "\n")
+    for (l in lines) {
+        if (find(l, "!DIFile(filename: \"") >= 0 && find(l, base_name(ROOT)) >= 0) {
+            return "{l}"
+        }
+    }
+    return ""
+}
+
+let private HOT_IMPL = "hot Ci Cf CS`Lt`Point`Gt` CE`Lt`::Mode`Gt` Cs implementation"
+
+let private FIXTURE_FOR_STATEMENT = "for (i in range(n))"
+
+//! the fixture's block nesting: function body > for body > if body
+let private FIXTURE_NESTED_BLOCKS = 3
+
+//! the 1-based line a fixture statement sits on, so a fixture edit moves an assert with it
+//! instead of silently pointing it at the wrong line
+def private fixture_line_of(needle : string) : int {
+    var lines <- split(fread(ROOT), "\n")
+    for (l, ix in lines, count(1)) {
+        if (find(l, needle) >= 0) {
+            return ix
+        }
+    }
+    return -1
+}
+
+let private FIXTURE_ARGS = ["n", "scale", "p", "m", "tag"]
+let private FIXTURE_LOCALS = ["acc", "f4", "i", "inner", "acc_ref", "spin", "dim3", "xs", "pair", "head", "node", "blocked"]
+
+//! one labelled basic block of a dumped function, label line through the blank line after it
+def private named_block_ir(fn_ir : string; block_name : string) : string {
+    let start = find(fn_ir, "\n{block_name}:")
+    return "" if (start < 0)
+    let body = slice(fn_ir, start + 1)
+    let close = find(body, "\n\n")
+    return close < 0 ? body : slice(body, 0, close)
+}
+
+//! the source line of the first !dbg attachment in a piece of IR, -1 when it carries none
+def private dbg_line_of(dump : string; ir : string) : int {
+    let at = find(ir, ", !dbg !")
+    return -1 if (at < 0)
+    let rest = slice(ir, at + length(", !dbg "))
+    let eol = find(rest, "\n")
+    let mdref = eol < 0 ? rest : slice(rest, 0, eol)
+    let decl = find(dump, "\n{mdref} = !DILocation(line: ")
+    return -1 if (decl < 0)
+    let after = slice(dump, decl + length("\n{mdref} = !DILocation(line: "))
+    let comma = find(after, ",")
+    return comma < 0 ? -1 : to_int(slice(after, 0, comma))
+}
+
+def private jit_dump(t : T?; debug_info : bool) : string {
+    var args <- [das_exe(), "-no-module-cache", "-jit", "-jit-no-cache", ROOT, "--",
+                 "--jit-opt-level=0", "--jit-dump"]
+    if (debug_info) {
+        args |> push("--jit-debug")
+    }
+    var out = ""
+    let rc = run_and_capture(args, out, 300.0)
+    t |> equal(0, rc, "the fixture runs under -jit: {out_tail(out)}")
+    t |> success(find(out, "DEBUG_INFO_ROOT ") >= 0, "the fixture printed its witness: {out_tail(out)}")
+    return out
+}
+
+[test]
+def test_debug_info_is_off_by_default(t : T?) {
+    t |> run("no --jit-debug means no debug metadata at all") @(t : T?) {
+        let out = jit_dump(t, false)
+        t |> equal(0, count_of(out, "!DICompileUnit"), "a default run emits no compile unit")
+        t |> equal(0, count_of(out, "!DILocalVariable"), "a default run emits no variable metadata")
+        t |> equal(0, count_of(out, "#dbg_declare("), "a default run emits no dbg records")
+    }
+}
+
+[test]
+def test_one_compile_unit_per_module(t : T?) {
+    t |> run("the whole module shares one compile unit, tagged C++") @(t : T?) {
+        let out = jit_dump(t, true)
+        t |> equal(1, count_of(out, "distinct !DICompileUnit"),
+            "one compile unit per module - a unit per function hides an inlined instance from a debugger's name lookup")
+        t |> success(find(out, "language: DW_LANG_C_plus_plus") >= 0,
+            "DW_LANG_C would make a debugger treat the unmangled name as the whole truth about the symbol")
+    }
+}
+
+[test]
+def test_subprograms_carry_the_das_name(t : T?) {
+    t |> run("a das function is named as its source names it, with no linkage name") @(t : T?) {
+        let out = jit_dump(t, true)
+        t |> equal(2, count_of(out, "!DISubprogram(name: \"hot\""),
+            "both halves of the function pair carry the das name:\n{out_tail(out)}")
+        t |> equal(0, count_of(out, "linkageName:"),
+            "a linkage name becomes the lookup key a debugger matches, and the generated symbol is unreachable by hand")
+        t |> success(find(out, "!DISubprogram(name: \"main\"") >= 0, "main is named too")
+    }
+}
+
+[test]
+def test_locals_and_arguments_are_described(t : T?) {
+    t |> run("every argument and local has a DILocalVariable in a lexical scope") @(t : T?) {
+        let out = jit_dump(t, true)
+        for (arg, ix in FIXTURE_ARGS, count(1)) {
+            t |> success(find(out, "!DILocalVariable(name: \"{arg}\", arg: {ix}") >= 0,
+                "argument {arg} is described as parameter {ix}:\n{out_tail(out)}")
+        }
+        for (loc in FIXTURE_LOCALS) {
+            t |> success(find(out, "!DILocalVariable(name: \"{loc}\"") >= 0,
+                "local {loc} is described:\n{out_tail(out)}")
+        }
+        t |> success(count_of(out, "distinct !DILexicalBlock") >= FIXTURE_NESTED_BLOCKS,
+            "one lexical block per open das block:\n{out_tail(out)}")
+        t |> success(count_of(out, "#dbg_declare(") >= length(FIXTURE_ARGS) + length(FIXTURE_LOCALS),
+            "one dbg record per described argument and local")
+    }
+}
+
+[test]
+def test_types_are_described(t : T?) {
+    t |> run("a struct, an enum, a string and a vector each reach DWARF as themselves") @(t : T?) {
+        let out = jit_dump(t, true)
+        t |> success(find(out, "tag: DW_TAG_structure_type, name: \"Point") >= 0,
+            "the struct is a real structure type, not an opaque blob:\n{out_tail(out)}")
+        t |> success(find(out, "tag: DW_TAG_member, name: \"x\"") >= 0, "member x is named")
+        t |> success(find(out, "tag: DW_TAG_member, name: \"y\"") >= 0 && find(out, "name: \"y\", scope") >= 0,
+            "member y is named")
+        t |> success(find(out, "!DIEnumerator(name: \"slow\", value: 1)") >= 0,
+            "an enum carries its entries, so a debugger prints the name and not the number")
+        t |> success(find(out, "!DIBasicType(name: \"char\", size: 8, encoding: DW_ATE_signed_char)") >= 0,
+            "a das string is char* - the shape every debugger already prints as text")
+        //! a scalar's encoding and a member's byte offset are the two things a debugger prints
+        //! wrong if the factory is wrong, so both are pinned rather than only the shapes
+        t |> success(find(out, "!DIBasicType(name: \"int\", size: 32, encoding: DW_ATE_signed)") >= 0,
+            "int is a signed 32-bit base type:\n{out_tail(out)}")
+        t |> success(find(out, "!DIBasicType(name: \"float\", size: 32, encoding: DW_ATE_float)") >= 0,
+            "float is a 32-bit float base type")
+        t |> success(find(out, "name: \"y\", scope: !") >= 0 && find(out, "offset: 32") >= 0,
+            "a member sits at its own byte offset, not at zero:\n{out_tail(out)}")
+        t |> success(find(out, "tag: DW_TAG_array_type") >= 0 && find(out, "!DISubrange(count: 3") >= 0,
+            "a dim is an array type with one subrange per dimension")
+        t |> success(find(out, "flags: DIFlagFwdDecl") >= 0,
+            "a pointer back into the type under construction takes a forward declaration")
+        t |> success(find(out, "identifier: \"array<int>") >= 0,
+            "a container reaches DWARF as a named opaque declaration")
+        t |> success(find(out, "DW_OP_deref") >= 0,
+            "a ref local's slot holds a pointer, so its location derefs once")
+        t |> success(find(out, "flags: DIFlagVector") >= 0,
+            "float4 is a vector of lanes, not one opaque value:\n{out_tail(out)}")
+        t |> equal(0, count_of(out, "<temporary!>"), "no unresolved placeholder survives into the module")
+    }
+}
+
+[test]
+def test_source_paths_are_absolute(t : T?) {
+    t |> run("a DIFile names an absolute path, so a debugger lists the source from any cwd") @(t : T?) {
+        let out = jit_dump(t, true)
+        let line = fixture_difile(out)
+        t |> success(!empty(line), "the dump carries a DIFile for the fixture:\n{out_tail(out)}")
+        let open = find(line, "\"")
+        let close = find(line, "\"", open + 1)
+        let path = open < 0 || close < 0 ? "" : slice(line, open + 1, close)
+        t |> success(is_absolute(path), "the DIFile filename is absolute, got '{path}'")
+        t |> success(find(line, "directory: \"\"") >= 0,
+            "the directory field stays empty - CodeView consumers join the two and would print dir/dir/file")
+    }
+}
+
+[test]
+def test_hoisted_instructions_carry_no_stale_line(t : T?) {
+    t |> run("the prologue carries no line, and every argument is declared in it") @(t : T?) {
+        let out = jit_dump(t, true)
+        let ir = function_ir(out, HOT_IMPL)
+        t |> success(!empty(ir), "the dump carries hot's implementation:\n{out_tail(out)}")
+        let entry = entry_block_ir(ir)
+        t |> equal(-1, find(entry, ", !dbg !"),
+            "no instruction in the entry block carries a line:\n{entry}")
+        t |> success(count_of(entry, "#dbg_declare(") >= 5,
+            "all five arguments are declared in the entry block:\n{entry}")
+    }
+    t |> run("a loop latch carries the loop's own line, not its body's last statement") @(t : T?) {
+        let out = jit_dump(t, true)
+        let ir = function_ir(out, HOT_IMPL)
+        t |> success(!empty(ir), "the dump carries hot's implementation:\n{out_tail(out)}")
+        let latch = named_block_ir(ir, "for_continue")
+        t |> success(!empty(latch), "the dump carries the for latch:\n{ir}")
+        let forLine = fixture_line_of(FIXTURE_FOR_STATEMENT)
+        t |> success(forLine > 0, "the fixture still carries `{FIXTURE_FOR_STATEMENT}`")
+        t |> equal(forLine, dbg_line_of(out, latch),
+            "the latch reports the `for` line {forLine}:\n{latch}")
+    }
+}

--- a/tests-cpp/small/test_jit_emitter_pin.cpp
+++ b/tests-cpp/small/test_jit_emitter_pin.cpp
@@ -11,12 +11,14 @@
 
 using namespace das;
 
-// files whose text change can alter emitted machine code without changing the user
-// program's AOT hashes. llvm_tune.das stays out by design (selection only);
-// x64_avx/aarch64_neon/f16_cvt are plain das reference bodies, visible to the AOT hash;
-// llvm_aot/llvm_exe emit explicit artifacts, not silently cached DLLs.
+// files whose text change can alter what a silently cached DLL carries - emitted machine code,
+// or the debug metadata beside it - without changing the user program's AOT hashes.
+// llvm_tune.das stays out by design (selection only); x64_avx/aarch64_neon/f16_cvt are plain
+// das reference bodies, visible to the AOT hash; llvm_aot/llvm_exe emit explicit artifacts,
+// not silently cached DLLs.
 static const char * EMITTER_FILES[] = {
     "llvm_jit.das",
+    "llvm_jit_di.das",
     "llvm_jit_common.das",
     "llvm_boost.das",
     "llvm_macro.das",


### PR DESCRIPTION
**Why.** The `--jit-debug` rail emitted line tables and nothing else. A debugger could not break on a das function by name and could not read a das value: a subprogram carried only the generated symbol, and no local, argument or type had any metadata at all.

**What changes.**
- A new pure-das module turns a das `TypeDecl` into a `DIType` - struct and tuple members at their own offsets, enums with their entries, `string` as `char *`, vectors as lanes, `dim` as an array type, everything else as a named opaque declaration.
- Every das local, loop variable and argument gets a `DILocalVariable` and a `dbg.declare`; each das block opens a `DILexicalBlock`; a debug build promotes every argument to a stack slot so `dbg.declare` has an address.
- A `DISubprogram` carries the das name and no linkage name, on both halves of a function pair and on every block or lambda body.
- One DIBuilder, and therefore one compile unit, per generated module instead of per function.
- The prologue and a loop latch no longer keep a stale debug location.

**Observable behavior.**
- `break hot` / `breakpoint set -n hot` did not resolve -> resolves, and hits.
- `info locals` / `frame variable` was empty -> prints das values; `expr n * 2` evaluates.
- `break file.das:25` stopped at the prologue or one loop iteration early -> stops on the statement.
- default runs -> byte-identical; the rail is off unless `--jit-debug` is passed.

**Where to look.** `modules/dasLLVM/daslib/llvm_jit_di.das` is the whole type factory; the risky spots are `di_composite` (the metadata must stay acyclic) and the `di_finalize()` call sites in `llvm_jit_run.das`, including the one on the failure path.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Local-only, cannot be produced by CI: live `lldb` 22.1.8 and `gdb` 16 sessions against a jitted DLL - breakpoint by das function name and by `file.das:line`, das source listed at the stop, a backtrace of das frames with argument values, `info locals` / `frame variable`, and `expr n * 2`. Values read fully at `--jit-opt-level=0`; at the default O3 breakpoints and frames still resolve, including into an inlined instance, while values read `<optimized out>`.
- `modules/dasLLVM/tests`: 100 of 101. The one red is `llvm_vector_math.das` `test_vector_log_special_values`. Control run: with `modules/dasLLVM/daslib/` checked out at `origin/master` and nothing else changed, the same two assertions fail (`log2(0)` expected `-inf` got `-127`; `log2(-4)` expected `-nan` got `2`) - the cell hard-codes the aarch64 inline-polynomial log2 specials and this box is x86_64.
- `tests/jit_tests`: 390 tests, 389 passed, 1 skipped - run twice, once plain and once with `--jit-debug` armed on every compile in the process (one process, many modules), which is the multi-module DIBuilder lifecycle exercise.
- `tests-cpp`: `bin/tests-cpp-small -tc="*emitter*"` - 19 assertions, green against the recomputed `LLVM_JIT_EMITTER_HASH` and the widened `EMITTER_FILES`.
- Deviation - the full `make-pr` preflight chain and the `test_aot` build and sweep were NOT run; this PR opens on the gates listed above plus lint, `dasfmt --verify`, md-ascii and the `REVIEW.das` walk, and leans on CI for the rest.
- Deviation - the `untracked` gate is red on ten files that predate this work and belong to the tree's owner, not to this change.
- `LLVM_JIT_CODEGEN_VERSION` 0x7a -> 0x7b (0x7a went to the lambda-reinterpret change during the rebase), so every cached JIT DLL misses once.

### Claims - stated, not tested
- The Windows CodeView and PDB arm is unchanged in intent but was not exercised: this box is linux, and the `"CodeView"` module flag is gated on a windows triple. A break would show as a jitted frame resolving without a `.das` line in a cdb/WinDbg session.
- macOS is untested. `create_shared_library` ignores its `debugInfo` argument outside MSVC, which is harmless on ELF because DWARF rides through the link, but Mach-O needs `dsymutil` or object retention. A break would show as lldb finding no debug info for the jitted dylib.

### Not done
- A das GLOBAL is still invisible to a debugger: it lives at `context->globals + stackTop` rather than in an LLVM global, so it needs a `DIGlobalVariableExpression` with a computed location.
- The interpreted half of a mixed stack still shows as the `SimNode` eval chain; `--jit-stack` plus `Context::getStackWalk()` is the parallel answer.
- `llvm_jit_di.das` joined `EMITTER_FILES` and its charter widened to "what a silently cached DLL carries", because the cache key folds the debug flag but not the emitter text. The reverse duty - a new file under `modules/dasLLVM/daslib/` joins that list - has no rule yet; it belongs in `modules/dasLLVM/REVIEW.md`.
- The new `reset_jit_globals_after_failure` ordering rule is mechanically decidable from tree state, so it is a `REVIEW.das` gate candidate rather than prose. Left as prose deliberately.
- Three checklist self-review findings are reported and not applied, each riding the damper: `tests-cpp/REVIEW.md`'s architecture-doc slot names a skill file, its lane-claim rule keys on the CI matrix rather than on the diff, and `tests-cpp/small/REVIEW.md`'s pin rule says "widens" of a set-valued pin, which is undecidable in both directions.
</details>
