### PR TITLE
the dasllama.io deploy runs the wasm64 probe under node 24 and stops when the probe fails

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,14 @@ jobs:
     - name: "Install CMake and Ninja"
       uses: lukka/get-cmake@latest
 
+    # The wasm64 (MEMORY64) modules emscripten emits refuse to load under a node older than 23
+    # ("This emscripten-generated code requires node v23.0.0"); ubuntu-latest ships 22, and the
+    # DlimConfiguration probe below runs one of those modules under the runner's node.
+    - name: "Install node 24 (the wasm64 probe runs under it)"
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24
+
     # The host daslang now builds with dasGlfw/dasOpenGL ON so it can drive the
     # /examples game cross-compile (daspkg release wasm). dasGlfw's
     # find_package(OpenGL REQUIRED) needs the GL + X11 dev headers.
@@ -349,8 +357,12 @@ jobs:
            && grep -q '"backend"' web/output64/examples/dlim_config/wasm64.json; then
             echo "wasm64 DlimConfiguration probe OK: $(tr -d ' \n' < web/output64/examples/dlim_config/wasm64.json | cut -c1-120)..."
         else
+            # fatal, unlike an example's own build: without the probe no set can be minted, so a
+            # deploy that went on would replace two working pages with placeholders; a red job
+            # leaves the previous deploy live
             rm -f web/output64/examples/dlim_config/wasm64.json
-            echo "WARNING: the wasm64 DlimConfiguration probe failed — no model set can be minted, both dasllama.io example pages will be placeholders this deploy."
+            echo "::error::the wasm64 DlimConfiguration probe failed - no model set can be minted for either dasllama.io example; the deploy stops here so the previous pages stay up"
+            exit 1
         fi
 
     - name: "Compile-gate the curated playground samples"


### PR DESCRIPTION
**Behavior change: `pages.yml` installs node 24 before the wasm64 build, and a failed DlimConfiguration probe now reds the deploy instead of staging two placeholder pages.**

**Why.** The first master deploy after #3984 (run 34435198337) went green and minted nothing: the wasm64 (MEMORY64) module emscripten emits refuses to load under a node older than 23 - `Error: This emscripten-generated code requires node v23.0.0 (detected v22.23.2)` - and ubuntu-latest ships 22. The probe failed, the step logged its warning, and the deploy went on to replace both working example pages with placeholders (their `models/manifest.json` answers 404 right now). A local node 25 had hidden the requirement.

**What changes.**
- `actions/setup-node@v4` with `node-version: 24` runs before the emsdk step; emsdk's own tools use its bundled node, so only the probe changes interpreter.
- The probe's failure branch prints `::error` and exits 1. Unlike one example's build (still non-fatal: the other example and the rest of the site deploy), no probe means no set for either example, so a deploy that continues can only downgrade the site; a red job leaves the previous pages live.

**Observable behavior.**
- master deploy after this merge: both example pages back, with sets minted at IMAGE_VERSION 35 and a `manifest.json` beside each.
- a future probe failure: green job with placeholders -> red job, previous site untouched, the error in the Actions summary.

**Where to look.** `.github/workflows/pages.yml`, the setup-node step and the probe block in step 7.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- `python3 ci/test_ci_matrix.py` OK; preflight `--only ci-matrix,review-md,md-ascii,untracked,hash-refs` all green; the YAML parses. A workflow-only change confined to the deploy job: no full preflight (CI covers the matrix).

### Claims - stated, not tested
- Node 24 satisfies emscripten's `>= 23` check on the runner: the check is the version comparison quoted above, and the same module runs under node 25 locally. The proof is the master deploy after the merge, which this branch cannot run (`github-pages` admits only master).

### Not done
- Making an example's own wasm build failure fatal as well: left as it was (one example's flake should not block the other or the rest of the site).

</details>