### PR TITLE
nightly reds: daslang-live loads live_host, pinvoke panic leak, Windows 64 KB pipe, LINT030 argument order, CRLF/tsan/fast-math lanes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,13 @@ modules/dasClangBind/src/*.cpp text eol=lf
 modules/dasClangBind/src/*.h text eol=lf
 modules/dasClangBind/src/*.inc text eol=lf
 
+# tree-sitter generated artifacts: the folder's gate regenerates them in a scratch copy and
+# compares bytes; `tree-sitter generate` writes LF, so a CRLF checkout under autocrlf=true
+# reads as every line changed.
+tree-sitter-daslang/src/*.c text eol=lf
+tree-sitter-daslang/src/*.json text eol=lf
+tree-sitter-daslang/src/tree_sitter/*.h text eol=lf
+
 # The v1 -> gen2 converter preserves whatever line endings its input had, and
 # its suite proves that by converting an LF fixture and a CRLF twin it builds
 # from that same fixture. Under autocrlf=true the fixtures check out as CRLF,

--- a/.github/tsan_suppressions.txt
+++ b/.github/tsan_suppressions.txt
@@ -25,3 +25,9 @@ race:hv::WebSocketClient::close
 # thread may parse the next pipelined message while the tick thread still fills the
 # previous response object (#3428).
 race:HttpHandler::onMessageComplete
+
+# libdbus's own global locks, taken in one order by dbus_bus_get_private (the Linux tray's
+# create) and the reverse by dbus_connection_close / unref (its destroy), both on the main
+# thread: a lock-order report on the library's internals, which the tray neither holds nor
+# can reorder. libdbus is dlopened, not instrumented, so the module name is the frame.
+deadlock:libdbus-1.so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,10 @@ diagnostic in any tier.
 - **`exit(N)` does not set the process exit code under the daslang CLI.** It unwinds as an
   abnormal termination and the process reports 1, whatever `N` was - a supervisor or shell sees a
   crash. A code the parent must read comes from `def main() : int { return N }`.
+- **The order a call's arguments are evaluated in is not defined.** The interpreter and the JIT
+  go left to right; the AOT C++ goes the C++ compiler's way, and MSVC and clang-cl go right to
+  left - `f(g(x), x)` with `g` writing `x` by reference reads the old `x` on Windows AOT and the
+  new one everywhere else. Run the writing call as a statement of its own (LINT030).
 
 ### Code style - prefer idiomatic forms
 
@@ -288,6 +292,7 @@ diagnostic in any tier.
 | `range(int(n64))` / `urange(uint(u64))` | `range64(n64)` / `urange64(u64)` | LINT020. Vector components and `string` index stay 32-bit |
 | a 64-bit local whose every use sits under `int(...)` | narrow once at the declaration, or lift the sinks to 64-bit | LINT021 |
 | `def f(var why : string)` written on a path but never read | `var why : string&` - a by-value copy's write never reaches the caller | LINT023 |
+| `report(run(cmd, out), out)` - an argument reads what a sibling call writes by ref | `let rc = run(cmd, out); report(rc, out)` | LINT030 (ships OFF; arm with `options _lint = "LINT030"`): argument evaluation order is not defined across tiers |
 | bare `resize(need)` on an input-scaled buffer (frames, pixels, vocab) | declare it `@exact_size`; then `reserve`/`ensure_capacity` before every `resize` (or size it through `reserve_resize`-style helpers) | PERF032 - the annotation is a lint contract; the guard panics only when the big input arrives |
 | `-const` `-&` `-[]` `-#` `==const` `==&` on a **concrete** cast target | drop the contract | STYLE036: substitution contracts act only while a generic binds - inert on concrete targets |
 | `slice(s, i, j)` / `chop(s, i, n)` in a loop over an outer string | `peek_data(s) $(d)` and slice the view | PERF031: each call re-strlens the whole source - O(n^2); every haystack op has a byte-view twin |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,10 +248,9 @@ diagnostic in any tier.
 - **`exit(N)` does not set the process exit code under the daslang CLI.** It unwinds as an
   abnormal termination and the process reports 1, whatever `N` was - a supervisor or shell sees a
   crash. A code the parent must read comes from `def main() : int { return N }`.
-- **The order a call's arguments are evaluated in is not defined.** The interpreter and the JIT
-  go left to right; the AOT C++ goes the C++ compiler's way, and MSVC and clang-cl go right to
-  left - `f(g(x), x)` with `g` writing `x` by reference reads the old `x` on Windows AOT and the
-  new one everywhere else. Run the writing call as a statement of its own: `let r = g(x); f(r, x)`.
+- **The order a call's arguments are evaluated in is not defined**, and it differs between
+  tiers - `f(g(x), x)` with `g` writing `x` by reference reads the old `x` on one tier and the
+  new one on another. Run the writing call as a statement of its own: `let r = g(x); f(r, x)`.
   LINT030 finds the shape and ships OFF - arm it with `options _lint = "LINT030"`.
 
 ### Code style - prefer idiomatic forms

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,8 @@ diagnostic in any tier.
 - **The order a call's arguments are evaluated in is not defined.** The interpreter and the JIT
   go left to right; the AOT C++ goes the C++ compiler's way, and MSVC and clang-cl go right to
   left - `f(g(x), x)` with `g` writing `x` by reference reads the old `x` on Windows AOT and the
-  new one everywhere else. Run the writing call as a statement of its own (LINT030).
+  new one everywhere else. Run the writing call as a statement of its own: `let r = g(x); f(r, x)`.
+  LINT030 finds the shape and ships OFF - arm it with `options _lint = "LINT030"`.
 
 ### Code style - prefer idiomatic forms
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,6 @@ diagnostic in any tier.
 | `range(int(n64))` / `urange(uint(u64))` | `range64(n64)` / `urange64(u64)` | LINT020. Vector components and `string` index stay 32-bit |
 | a 64-bit local whose every use sits under `int(...)` | narrow once at the declaration, or lift the sinks to 64-bit | LINT021 |
 | `def f(var why : string)` written on a path but never read | `var why : string&` - a by-value copy's write never reaches the caller | LINT023 |
-| `report(run(cmd, out), out)` - an argument reads what a sibling call writes by ref | `let rc = run(cmd, out); report(rc, out)` | LINT030 (ships OFF; arm with `options _lint = "LINT030"`): argument evaluation order is not defined across tiers |
 | bare `resize(need)` on an input-scaled buffer (frames, pixels, vocab) | declare it `@exact_size`; then `reserve`/`ensure_capacity` before every `resize` (or size it through `reserve_resize`-style helpers) | PERF032 - the annotation is a lint contract; the guard panics only when the big input arrives |
 | `-const` `-&` `-[]` `-#` `==const` `==&` on a **concrete** cast target | drop the contract | STYLE036: substitution contracts act only while a generic binds - inert on concrete targets |
 | `slice(s, i, j)` / `chop(s, i, n)` in a loop over an outer string | `peek_data(s) $(d)` and slice the view | PERF031: each call re-strlens the whole source - O(n^2); every haystack op has a byte-view twin |

--- a/daslib/ARCHITECTURE_LINT.md
+++ b/daslib/ARCHITECTURE_LINT.md
@@ -132,6 +132,19 @@ Companion to `ARCHITECTURE.md` in this folder; section numbers are unique across
   sits in any `daslib/` folder (`lint029_source_exempt`, `daslib/lint_config.das`):
   library code lives on the builder/state idiom (`var self`, `var writer`), so the
   purity contract binds application code only.
+- **LINT030 keeps one frame per call on a stack and reads mentions off the ordinary walk.**
+  `preVisitExprCall` pushes the frame, `preVisitExprCallArgument` advances its slot, and
+  `preVisitExprVar` records every variable read into the slot being walked - only at the
+  frame's own closure depth, since a lambda argument's body runs later. On `visitExprCall` the
+  frame pops, each argument that is a call is asked which mentioned variables it writes through
+  a mutable by-reference parameter (a bare variable in a `var` slot of `&`, array, table or
+  struct type), and the frame's mentions flow into the parent frame's current slot, so a read
+  buried in a deeper call still counts for the outer argument list. A mention that is the
+  outer call's own by-reference argument is not a read - the callee sees the final state
+  whatever the order. The rule fires once per writing argument, on the outer call, and ships
+  default-off beside LINT029 (`seed_default_disabled`): a `var` parameter is read as a write
+  contract, so callees that take `var` to hand out a pointer or advance a builder make the
+  tree's library code a sweep of its own.
 - **Closure bodies are per-rule, not global.** LINT010 counts a closure body as a branch
   (it may run later or never - writes inside must not kill outside stores, reads inside
   must not keep an outside init live); LINT021 counts the same body as an escape - a

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -161,6 +161,14 @@ struct private Lint030Mention {
     @do_not_delete v : Variable const?
 }
 
+//! a variable a call somewhere inside argument `slot` writes through a mutable by-reference
+//! parameter; `callee` names that call for the finding
+struct private Lint030Write {
+    slot : int
+    @do_not_delete v : Variable const?
+    callee : string
+}
+
 //! one call whose argument list the walk is inside: `slot` is the argument being walked,
 //! `closure_depth` the depth the call sits at, so a read inside a lambda argument - run later,
 //! not at the call - is not a mention
@@ -169,6 +177,7 @@ struct private Lint030Frame {
     slot : int
     closure_depth : int
     mentions : array<Lint030Mention>
+    writes : array<Lint030Write>
 }
 
 class LintVisitor : AstVisitor {
@@ -364,6 +373,7 @@ class LintVisitor : AstVisitor {
         lint021_poison_depth = 0
         lint021_closure_depth = 0
         lint023_deferred_depth = 0
+        lint030_frames |> clear()
         flow_jumps = false
         if (fun.moreFlags.isTemplate) {
             noLint = true
@@ -841,24 +851,23 @@ class LintVisitor : AstVisitor {
         return fname == "max" || fname == "abs"
     }
 
-    def private lint030_as_call(e : Expression?) : ExprCall? {
-        return e is ExprCall ? e as ExprCall : null
-    }
-
     def private lint030_bare_var(e : Expression?) : Variable const? {
         return e is ExprVar ? (e as ExprVar).variable : null
     }
 
-    //! whether `inner` writes `v` through a mutable by-reference parameter: the bare variable in
-    //! a slot the callee declares `var` on a `&`, array, table or struct type
-    def private lint030_writes_var(inner : ExprCall?; v : Variable const?) : bool {
-        return false if (inner.func == null)
-        for (k in range(min(length(inner.arguments), length(inner.func.arguments)))) {
-            let p = inner.func.arguments[k]
+    //! the variables `call` writes through a mutable by-reference parameter - a bare variable
+    //! in a slot the callee declares `var` on a `&` or a type the compiler passes by reference
+    //! (`isRefType`) - recorded into `slot` of the frame that holds `call` as an argument
+    def private lint030_note_writes(call : ExprCall const?; slot : int; var into : array<Lint030Write>) : void {
+        return if (call.func == null)
+        for (k in range(min(length(call.arguments), length(call.func.arguments)))) {
+            let p = call.func.arguments[k]
             continue if (p._type == null || p._type.flags.constant || !(p._type.flags.ref || p._type.isRefType))
-            return true if (lint030_bare_var(inner.arguments[k]) == v)
+            let v = lint030_bare_var(call.arguments[k])
+            if (v != null) {
+                into |> push(Lint030Write(slot = slot, v = v, callee = "{call.name}"))
+            }
         }
-        return false
     }
 
     //! whether argument `slot` of `call` is `v` itself handed over by reference: the callee then
@@ -871,12 +880,13 @@ class LintVisitor : AstVisitor {
 
     def private lint030_check(frame : Lint030Frame) : void {
         return if (noLint || genericDepth > 0 || frame.call == null)
-        for (i in range(length(frame.call.arguments))) {
-            let inner = lint030_as_call(frame.call.arguments[i])
-            continue if (inner == null)
+        var reported : table<int>
+        for (w in frame.writes) {
+            continue if (key_exists(reported, w.slot))
             for (m in frame.mentions) {
-                continue if (m.slot == i || !lint030_writes_var(inner, m.v) || lint030_passed_by_ref(frame.call, m.slot, m.v))
-                lint_error("LINT030: argument {m.slot + 1} reads `{m.v.name}` while the call `{inner.name}(...)` in argument {i + 1} writes it by reference - the order arguments are evaluated in is not defined, so the read sees the value before or after the write by the compiler's choice; run the writing call as a statement of its own first", frame.call.at)
+                continue if (m.slot == w.slot || m.v != w.v || lint030_passed_by_ref(frame.call, m.slot, m.v))
+                lint_error("LINT030: argument {m.slot + 1} reads `{m.v.name}` while the call `{w.callee}(...)` in argument {w.slot + 1} writes it by reference - the order arguments are evaluated in is not defined, so the read sees the value before or after the write by the compiler's choice; run the writing call as a statement of its own first", frame.call.at)
+                reported |> insert(w.slot)
                 break
             }
         }
@@ -916,10 +926,15 @@ class LintVisitor : AstVisitor {
             lint030_check(frame)
             if (!empty(lint030_frames)) {
                 let parent = length(lint030_frames) - 1
-                if (lint030_frames[parent].slot >= 0) {
+                let slot = lint030_frames[parent].slot
+                if (slot >= 0 && frame.closure_depth == lint030_frames[parent].closure_depth) {
                     for (m in frame.mentions) {
-                        lint030_frames[parent].mentions |> push(Lint030Mention(slot = lint030_frames[parent].slot, v = m.v))
+                        lint030_frames[parent].mentions |> push(Lint030Mention(slot = slot, v = m.v))
                     }
+                    for (w in frame.writes) {
+                        lint030_frames[parent].writes |> push(Lint030Write(slot = slot, v = w.v, callee = w.callee))
+                    }
+                    lint030_note_writes(expr, slot, lint030_frames[parent].writes)
                 }
             }
         }

--- a/daslib/lint.das
+++ b/daslib/lint.das
@@ -14,6 +14,7 @@ require daslib/strings_boost
 require daslib/ast_boost
 require daslib/strings_boost
 require daslib/lint_config
+require math
 
 [lint_macro]
 class LintEverything : AstPassMacro {
@@ -154,7 +155,24 @@ struct private Lint023Candidate {
     disqualified : bool
 }
 
+//! a variable read somewhere inside argument `slot` of the call a frame tracks
+struct private Lint030Mention {
+    slot : int
+    @do_not_delete v : Variable const?
+}
+
+//! one call whose argument list the walk is inside: `slot` is the argument being walked,
+//! `closure_depth` the depth the call sits at, so a read inside a lambda argument - run later,
+//! not at the call - is not a mention
+struct private Lint030Frame {
+    @do_not_delete call : ExprCall const?
+    slot : int
+    closure_depth : int
+    mentions : array<Lint030Mention>
+}
+
 class LintVisitor : AstVisitor {
+    lint030_frames : array<Lint030Frame>
     @do_not_delete lint014_candidates : array<Variable const?>
     lint023_candidates : array<Lint023Candidate>
     lint023_store_nodes : table<uint64>
@@ -823,7 +841,55 @@ class LintVisitor : AstVisitor {
         return fname == "max" || fname == "abs"
     }
 
+    def private lint030_as_call(e : Expression?) : ExprCall? {
+        return e is ExprCall ? e as ExprCall : null
+    }
+
+    def private lint030_bare_var(e : Expression?) : Variable const? {
+        return e is ExprVar ? (e as ExprVar).variable : null
+    }
+
+    //! whether `inner` writes `v` through a mutable by-reference parameter: the bare variable in
+    //! a slot the callee declares `var` on a `&`, array, table or struct type
+    def private lint030_writes_var(inner : ExprCall?; v : Variable const?) : bool {
+        return false if (inner.func == null)
+        for (k in range(min(length(inner.arguments), length(inner.func.arguments)))) {
+            let p = inner.func.arguments[k]
+            continue if (p._type == null || p._type.flags.constant || !(p._type.flags.ref || p._type.isRefType))
+            return true if (lint030_bare_var(inner.arguments[k]) == v)
+        }
+        return false
+    }
+
+    //! whether argument `slot` of `call` is `v` itself handed over by reference: the callee then
+    //! sees the variable's final state whatever the order, so that read is not a dependency
+    def private lint030_passed_by_ref(call : ExprCall const?; slot : int; v : Variable const?) : bool {
+        return false if (call.func == null || slot >= length(call.func.arguments))
+        let p = call.func.arguments[slot]
+        return p._type != null && (p._type.flags.ref || p._type.isRefType) && lint030_bare_var(call.arguments[slot]) == v
+    }
+
+    def private lint030_check(frame : Lint030Frame) : void {
+        return if (noLint || genericDepth > 0 || frame.call == null)
+        for (i in range(length(frame.call.arguments))) {
+            let inner = lint030_as_call(frame.call.arguments[i])
+            continue if (inner == null)
+            for (m in frame.mentions) {
+                continue if (m.slot == i || !lint030_writes_var(inner, m.v) || lint030_passed_by_ref(frame.call, m.slot, m.v))
+                lint_error("LINT030: argument {m.slot + 1} reads `{m.v.name}` while the call `{inner.name}(...)` in argument {i + 1} writes it by reference - the order arguments are evaluated in is not defined, so the read sees the value before or after the write by the compiler's choice; run the writing call as a statement of its own first", frame.call.at)
+                break
+            }
+        }
+    }
+
+    def override preVisitExprCallArgument(_expr : ExprCall?; _arg : ExpressionPtr; _last : bool) : void {
+        if (!empty(lint030_frames)) {
+            lint030_frames[length(lint030_frames) - 1].slot++
+        }
+    }
+
     def override preVisitExprCall(expr : ExprCall?) : void {
+        lint030_frames |> emplace(Lint030Frame(call = expr, slot = -1, closure_depth = lint021_closure_depth))
         var kind = Lint021CallKind.plain
         if (!noLint && genericDepth == 0) {
             if (lint021_is_narrow_cast(expr)) {
@@ -844,6 +910,19 @@ class LintVisitor : AstVisitor {
     }
 
     def override visitExprCall(var expr : ExprCall?) : ExpressionPtr {
+        if (!empty(lint030_frames)) {
+            var frame <- lint030_frames[length(lint030_frames) - 1]
+            lint030_frames |> pop()
+            lint030_check(frame)
+            if (!empty(lint030_frames)) {
+                let parent = length(lint030_frames) - 1
+                if (lint030_frames[parent].slot >= 0) {
+                    for (m in frame.mentions) {
+                        lint030_frames[parent].mentions |> push(Lint030Mention(slot = lint030_frames[parent].slot, v = m.v))
+                    }
+                }
+            }
+        }
         if (!empty(lint021_call_kind)) {
             let kind = lint021_call_kind |> back()
             lint021_call_kind |> pop()
@@ -1149,6 +1228,12 @@ class LintVisitor : AstVisitor {
     def override preVisitExprVar(expr : ExprVar?) : void {
         if (lint022_generic_sweep) {
             lint022_refs.names |> insert("{expr.name}")
+        }
+        if (!empty(lint030_frames)) {
+            let top = length(lint030_frames) - 1
+            if (lint030_frames[top].slot >= 0 && lint030_frames[top].closure_depth == lint021_closure_depth) {
+                lint030_frames[top].mentions |> push(Lint030Mention(slot = lint030_frames[top].slot, v = expr.variable))
+            }
         }
         if (noLint || genericDepth > 0) return
         if (key_exists(lint023_store_nodes, intptr(expr))) {

--- a/daslib/lint_config.das
+++ b/daslib/lint_config.das
@@ -108,9 +108,9 @@ def public load_lint_config_from_path(path : string; var disabled_codes : table<
     }
 }
 
-//! Seeds ``disabled_codes`` with the canonical default-off rule set (STYLE005 and LINT029). Call before ``load_lint_config`` so that a ``STYLE005 = true`` directive in ``.lint_config`` can re-enable it.
+//! Seeds ``disabled_codes`` with the canonical default-off rule set (STYLE005, LINT029 and LINT030). Call before ``load_lint_config`` so that a ``STYLE005 = true`` directive in ``.lint_config`` can re-enable it.
 def public seed_default_disabled(var disabled_codes : table<string>) : void {
-    for (code in ["STYLE005", "LINT029"]) {
+    for (code in ["STYLE005", "LINT029", "LINT030"]) {
         if (!key_exists(disabled_codes, code)) {
             disabled_codes |> insert(code)
         }

--- a/doc/reflections/gen_module_examples.py
+++ b/doc/reflections/gen_module_examples.py
@@ -34,7 +34,7 @@ without explicit ``require``. It includes:
 - Pointer and memory operations (``intptr``, ``malloc``, ``free``)
 - Profiling (``profile``)
 - Type conversion (``string``)""",
-    "require builtin",
+    "",
     example="""\
     [export]
     def main() {
@@ -1360,9 +1360,12 @@ def format_module_doc(name, desc, require_line, example=None, after_require=""):
     lines = []
     lines.append(desc.strip())
     lines.append("")
-    lines.append(f'All functions and symbols are in "{name}" module, use require to get access to it. ::')
-    lines.append("")
-    lines.append(f"    {require_line}")
+    if require_line:
+        lines.append(f'All functions and symbols are in "{name}" module, use require to get access to it. ::')
+        lines.append("")
+        lines.append(f"    {require_line}")
+    else:
+        lines.append(f'The {name} module is part of every daslang program: nothing needs to ``require`` it.')
     lines.append("")
 
     if after_require:

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -1202,9 +1202,10 @@ The order a call's arguments are evaluated in is not defined, and it differs
 between tiers. A call whose argument list nests a call that writes a variable
 by reference — a ``var`` parameter on a ``&``, an array, a table or a struct —
 beside another argument that reads the same variable therefore answers
-differently per tier: ``pair(bump(x), x)`` is ``1,1`` on one and ``1,0`` on
-another. The rule fires on the outer call. The fix is to run the writing call
-as a statement of its own and pass its result.
+differently per tier: with ``x`` at ``0``, the read of ``x`` in
+``pair(bump(x), x)`` sees ``1`` on one tier and ``0`` on another, and the call
+below returns ``11`` or ``10``. The rule fires on the outer call. The fix is to
+run the writing call as a statement of its own and pass its result.
 
 The rule ships **off**, like LINT029: the tree carries the shape in library
 code whose callees take ``var`` to hand out a pointer or advance a builder,
@@ -1212,8 +1213,11 @@ and a sweep of those is its own arc. Arm it on a file with
 ``options _lint = "LINT030"``, or for a tree with ``LINT030 = true`` in
 ``.lint_config``.
 
-A read inside a lambda or block argument does not count — the body runs
-later, not while the arguments are evaluated. A variable the outer call takes
+A read inside a lambda body does not count, and neither does one inside a
+block the outer call itself takes — that body runs inside the callee, after
+every argument is evaluated. A block handed to a nested call in a sibling
+argument runs while that argument is evaluated, so its reads do count. A
+variable the outer call takes
 by reference is not a read either: the callee sees its final state whatever
 the order. A variable the nested call reaches through a field or an index is
 not seen; only a bare variable in a mutable by-reference slot is.

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -1198,15 +1198,13 @@ names and ``[unused_argument]`` are skipped.
 LINT030 — an argument reads what a sibling call writes
 ======================================================
 
-The order a call's arguments are evaluated in is not defined. The interpreter
-and the JIT go left to right; the AOT C++ goes whichever way the C++ compiler
-does, and MSVC and clang-cl go right to left. A call whose argument list nests
-a call that writes a variable by reference — a ``var`` parameter on a ``&``, an
-array, a table or a struct — beside another argument that reads the same
-variable therefore answers differently per tier: ``pair(bump(x), x)`` is
-``1,1`` interpreted and ``1,0`` under AOT on Windows. The rule fires on the
-outer call. The fix is to run the writing call as a statement of its own and
-pass its result.
+The order a call's arguments are evaluated in is not defined, and it differs
+between tiers. A call whose argument list nests a call that writes a variable
+by reference — a ``var`` parameter on a ``&``, an array, a table or a struct —
+beside another argument that reads the same variable therefore answers
+differently per tier: ``pair(bump(x), x)`` is ``1,1`` on one and ``1,0`` on
+another. The rule fires on the outer call. The fix is to run the writing call
+as a statement of its own and pass its result.
 
 The rule ships **off**, like LINT029: the tree carries the shape in library
 code whose callees take ``var`` to hand out a pointer or advance a builder,

--- a/doc/source/reference/language/lint.rst
+++ b/doc/source/reference/language/lint.rst
@@ -1195,6 +1195,54 @@ names and ``[unused_argument]`` are skipped.
         return <- r
     }
 
+LINT030 — an argument reads what a sibling call writes
+======================================================
+
+The order a call's arguments are evaluated in is not defined. The interpreter
+and the JIT go left to right; the AOT C++ goes whichever way the C++ compiler
+does, and MSVC and clang-cl go right to left. A call whose argument list nests
+a call that writes a variable by reference — a ``var`` parameter on a ``&``, an
+array, a table or a struct — beside another argument that reads the same
+variable therefore answers differently per tier: ``pair(bump(x), x)`` is
+``1,1`` interpreted and ``1,0`` under AOT on Windows. The rule fires on the
+outer call. The fix is to run the writing call as a statement of its own and
+pass its result.
+
+The rule ships **off**, like LINT029: the tree carries the shape in library
+code whose callees take ``var`` to hand out a pointer or advance a builder,
+and a sweep of those is its own arc. Arm it on a file with
+``options _lint = "LINT030"``, or for a tree with ``LINT030 = true`` in
+``.lint_config``.
+
+A read inside a lambda or block argument does not count — the body runs
+later, not while the arguments are evaluated. A variable the outer call takes
+by reference is not a read either: the callee sees its final state whatever
+the order. A variable the nested call reaches through a field or an index is
+not seen; only a bare variable in a mutable by-reference slot is.
+
+.. das-doc: alt
+.. code-block:: das
+
+    def bump(var x : int&) : int {
+        x++
+        return x
+    }
+
+    def pair(a, b : int) : int {
+        return a * 10 + b
+    }
+
+    // Flagged — x is read beside the call that writes it
+    def order_dependent(var x : int) : int {
+        return pair(bump(x), x)   // LINT030
+    }
+
+    // The write is a statement of its own; the read follows it on every tier
+    def sequenced(var x : int) : int {
+        let bumped = bump(x)
+        return pair(bumped, x)
+    }
+
 .. _perf_lint:
 
 -----------------

--- a/doc/source/stdlib/handmade/module-builtin.rst
+++ b/doc/source/stdlib/handmade/module-builtin.rst
@@ -8,11 +8,7 @@ without explicit ``require``. It includes:
 - Profiling (``profile``)
 - Type conversion (``string``)
 
-All functions and symbols are in "builtin" module, use require to get access to it.
-
-.. code-block:: das
-
-    require builtin
+The builtin module is part of every daslang program: nothing needs to ``require`` it.
 
 Example:
 

--- a/examples/daslive/hello_stdio/main.das
+++ b/examples/daslive/hello_stdio/main.das
@@ -5,7 +5,7 @@ options gc
 require live/glfw_live
 require opengl/opengl_boost
 require live/live_commands
-require live/live_api_stdio // nolint:STYLE030 — load-bearing for stdio JSON-RPC transport agent
+require live/live_api_stdio // load-bearing for stdio JSON-RPC transport agent
 require daslib/json
 require daslib/json_boost
 require live_host

--- a/modules/dasLLAMA/ARCHITECTURE_IMAGE.md
+++ b/modules/dasLLAMA/ARCHITECTURE_IMAGE.md
@@ -200,10 +200,11 @@ The closure, per file in sorted name order: every `Archive` serializer body (a t
 layout helpers `pad_to_page`, `plane_end`, `image_total_bytes`, `w_append`, `w_zeros`,
 `w_header`, `store_u32` and `store_u64`, and the declaration lines of the layout constants
 `IMAGE_PAGE`, `IMAGE_HEADER_BYTES`, `SECTION_TABLE_SLACK`, `DWRITE_STAGING_BAND` and
-`METAL_BAND_BLOCKS`. Comments are stripped first, so re-wording one moves nothing. A body runs
-from its `def` line to the column-0 `}` that closes it, or, for a `def ... => expr` one-liner, to
-the end of that one line. Each piece folds into one FNV-1a hash keyed by its file name, so moving
-a serializer between files changes the stamp.
+`METAL_BAND_BLOCKS`. Comments are stripped first, so re-wording one moves nothing, and CRLF
+line ends fold to LF before anything is hashed, so a checkout under `autocrlf` stamps as the
+LF tree does. A body runs from its `def` line to the column-0 `}` that closes it, or, for a
+`def ... => expr` one-liner, to the end of that one line. Each piece folds into one FNV-1a hash
+keyed by its file name, so moving a serializer between files changes the stamp.
 
 The closure is wider than the byte-moving set on purpose. The two staging bands only decide how
 many bytes a writer stages per pass, and `store_u32` writes header scalars rather than plane

--- a/modules/dasLLAMA/REVIEW.das
+++ b/modules/dasLLAMA/REVIEW.das
@@ -585,8 +585,6 @@ def private is_layout_function(header : string) : bool {
     return name == "build_image" || name == "parse_image" || find(name, "_prepare") >= 0
 }
 
-// the file's text with CRLF folded to LF: the stamp hashes source text, and a checkout under
-// autocrlf reads every line one byte longer
 def private read_lf(path : string) : string {
     return replace(fread(path), "\r\n", "\n")
 }

--- a/modules/dasLLAMA/REVIEW.das
+++ b/modules/dasLLAMA/REVIEW.das
@@ -585,11 +585,17 @@ def private is_layout_function(header : string) : bool {
     return name == "build_image" || name == "parse_image" || find(name, "_prepare") >= 0
 }
 
+// the file's text with CRLF folded to LF: the stamp hashes source text, and a checkout under
+// autocrlf reads every line one byte longer
+def private read_lf(path : string) : string {
+    return replace(fread(path), "\r\n", "\n")
+}
+
 // the declaration lines of the layout constants a file declares, in file order
 def private layout_constant_lines(path : string) : array<tuple<line : int; body : string>> {
     var out : array<tuple<line : int; body : string>>
     var line_no = 0
-    for (raw in split(strip_line_comments(fread(path)), "\n")) {
+    for (raw in split(strip_line_comments(read_lf(path)), "\n")) {
         line_no++
         var rest = ""
         if (raw |> starts_with("let private ")) {
@@ -613,7 +619,7 @@ def private function_bodies(path : string; pick : block<(header : string) : bool
     var inscope lines : array<string>
     var header_line = 0
     var line_no = 0
-    for (raw in split(strip_line_comments(fread(path)), "\n")) {
+    for (raw in split(strip_line_comments(read_lf(path)), "\n")) {
         line_no++
         if (raw |> starts_with("def ")) {
             if (header_line > 0) {
@@ -697,7 +703,7 @@ def private check_meta_tripwires {
 [arch(at = "ARCHITECTURE_IMAGE.md#image-layout-stamp")]
 def private check_image_layout_stamp {
     var version = -1
-    for (line in split(fread(IMAGE_FILE), "\n")) {
+    for (line in split(read_lf(IMAGE_FILE), "\n")) {
         if (line |> starts_with("let IMAGE_VERSION = ")) {
             version = try_to_int(ident_prefix(slice(line, length("let IMAGE_VERSION = ")))) ?? -1
         }

--- a/modules/dasLLAMA/dasllama/dasllama_asr.das
+++ b/modules/dasLLAMA/dasllama/dasllama_asr.das
@@ -21,7 +21,7 @@ require dasllama/dasllama_qwen3a public
 require dasllama/dasllama_parakeet public
 require dasllama/dasllama_canary public
 require dasllama/dasllama_gemma4a public
-require dasllama/dasllama_transformer   // nolint:STYLE029 — the qwen3a decoder is a full LLM; umbrella fires arch [init]s
+require dasllama/dasllama_transformer   // the qwen3a decoder is a full LLM; umbrella fires arch [init]s
 
 // The uniform ASR surface: one loader that sniffs the file format, one verb set that
 // dispatches — NO family names in the public API. Every verb arm is a one-call forward

--- a/modules/dasLLAMA/tests/test_arch_registry.das
+++ b/modules/dasLLAMA/tests/test_arch_registry.das
@@ -3,7 +3,7 @@ options stack = 524288   // every dasLLAMA program root takes this budget (optio
 options _dasllama_internal = true
 
 require dastest/testing_boost public
-require dasllama/dasllama_transformer   // nolint:STYLE029 — umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
+require dasllama/dasllama_transformer   // umbrella fires each arch [init] registration; requiring dasllama_common directly would drop them
 
 // The arch registry must self-populate at [init]: every supported architecture registered with its
 // block kernels + a well-formed chat template — a user turn carrying a content slot, a generation

--- a/skills/daslang/references/functions.md
+++ b/skills/daslang/references/functions.md
@@ -106,6 +106,11 @@ argument, `take(type<int>, 1, 2)`, against a parameter declared `t : type<auto(T
 `[unused_argument(t)]` - a `type<>` parameter occupies no stack and cannot be read); take
 `default<T>` when the body needs a value.
 
+**The order arguments are evaluated in is not defined.** The interpreter and the JIT go left
+to right; AOT follows the C++ compiler, which on MSVC and clang-cl is right to left. So
+`f(g(x), x)` with `g` writing `x` by reference reads the old `x` on one tier and the new on
+another. Run the writing call as a statement of its own and pass its result.
+
 Defaults between the explicit arguments and a trailing block are padded automatically:
 
 ```das

--- a/skills/daslang/references/functions.md
+++ b/skills/daslang/references/functions.md
@@ -106,8 +106,7 @@ argument, `take(type<int>, 1, 2)`, against a parameter declared `t : type<auto(T
 `[unused_argument(t)]` - a `type<>` parameter occupies no stack and cannot be read); take
 `default<T>` when the body needs a value.
 
-**The order arguments are evaluated in is not defined.** The interpreter and the JIT go left
-to right; AOT follows the C++ compiler, which on MSVC and clang-cl is right to left. So
+**The order arguments are evaluated in is not defined**, and it differs between tiers. So
 `f(g(x), x)` with `g` writing `x` by reference reads the old `x` on one tier and the new on
 another. Run the writing call as a statement of its own and pass its result.
 

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -117,3 +117,14 @@ shared library at test time - not wasm, Android or iOS, none of which walks `tes
 dastest's `--ser`/`--deser` sweep, because a deserialized program never applies `[extern]` and
 so never manufactures the `__dasbind__` function it names in the `dasbind` module; a 64-bit
 desktop tree without the library fails the suite instead of skipping it.
+
+## 4. A message that crosses the panic jump
+
+`Context::throw_error_at` formats into a stack buffer and jumps; without C++ exceptions the
+jump is a `longjmp`, which unwinds nothing, so a heap-owning local alive at the call - a
+`string` a builtin built its message in - leaks the allocation on every panic a `try`/`recover`
+catches, and the ASan lane reports it. A builtin that composes a message in a `string` before
+the throw (`pinvoke_named`, `pinvoke_impl2_core` in `module_builtin_debugger.cpp`) goes through
+`throw_pinvoke_error`: the text moves to a stack buffer, the string's storage is released, and
+the throw runs with nothing owning heap on the frame. The same discipline is the `FMT_THROW`
+stash in `das_config.h`, where the temporary dies when the stash statement ends.

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -128,3 +128,15 @@ the throw (`pinvoke_named`, `pinvoke_impl2_core` in `module_builtin_debugger.cpp
 `throw_pinvoke_error`: the text moves to a stack buffer, the string's storage is released, and
 the throw runs with nothing owning heap on the frame. The same discipline is the `FMT_THROW`
 stash in `das_config.h`, where the temporary dies when the stash statement ends.
+
+## 5. A spawned child's stdout pipe
+
+`spawn_process` (`module_builtin_fio.cpp`) hands the child one pipe for stdout and stderr and
+never blocks on it: `process_drain` takes what the pipe holds and returns, and the caller decides
+when to come back - the watchdog every 250 ms. The pipe's capacity is therefore the child's
+write budget between two drains, and a child that fills it blocks until the next one; it is also
+the most a single drain hands the caller, which is what the caller's heap sees between two
+collects. A POSIX pipe carries 64 KB by default, and Windows sizes an anonymous pipe at 4 KB
+when asked for the default - a chatty child under the watchdog's tick moved 16 KB a second
+there - so the Windows pipe is created at the POSIX capacity, and every platform drains the
+same bursts.

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -123,11 +123,14 @@ desktop tree without the library fails the suite instead of skipping it.
 `Context::throw_error_at` formats into a stack buffer and jumps; without C++ exceptions the
 jump is a `longjmp`, which unwinds nothing, so a heap-owning local alive at the call - a
 `string` a builtin built its message in - leaks the allocation on every panic a `try`/`recover`
-catches, and the ASan lane reports it. A builtin that composes a message in a `string` before
-the throw (`pinvoke_named`, `pinvoke_impl2_core` in `module_builtin_debugger.cpp`) goes through
-`throw_pinvoke_error`: the text moves to a stack buffer, the string's storage is released, and
-the throw runs with nothing owning heap on the frame. The same discipline is the `FMT_THROW`
-stash in `das_config.h`, where the temporary dies when the stash statement ends.
+catches, and the ASan lane reports it. A builtin that composes its message in a `string` before
+the throw releases it first: the text moves to a stack buffer of `throw_error_at`'s own size,
+the string's storage is swapped away, and the throw runs with nothing owning heap on the frame.
+The pinvoke family - `pinvoke_named`, `pinvoke_impl2_core` and `pinvoke_impl3` in
+`module_builtin_debugger.cpp` - does it through `throw_pinvoke_error`; the `[extern]` binder's
+refusal (`crash_and_burn` in `module_builtin_dasbind.cpp`, thrown at the first call) does it
+inline. The same discipline is the `FMT_THROW` stash in `das_config.h`, where the temporary dies
+when the stash statement ends.
 
 ## 5. A spawned child's stdout pipe
 

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -129,8 +129,8 @@ the string's storage is swapped away, and the throw runs with nothing owning hea
 The pinvoke family - `pinvoke_named`, `pinvoke_impl2_core` and `pinvoke_impl3` in
 `module_builtin_debugger.cpp` - does it through `throw_pinvoke_error`; the `[extern]` binder's
 refusal (`crash_and_burn` in `module_builtin_dasbind.cpp`, thrown at the first call) does it
-inline. The same discipline is the `FMT_THROW` stash in `das_config.h`, where the temporary dies
-when the stash statement ends.
+inline. The same discipline is the `FMT_THROW` stash in `include/daScript/das_config.h`, where
+the temporary dies when the stash statement ends.
 
 ## 5. A spawned child's stdout pipe
 
@@ -140,6 +140,6 @@ when to come back - the watchdog every 250 ms. The pipe's capacity is therefore 
 write budget between two drains, and a child that fills it blocks until the next one; it is also
 the most a single drain hands the caller, which is what the caller's heap sees between two
 collects. A POSIX pipe carries 64 KB by default, and Windows sizes an anonymous pipe at 4 KB
-when asked for the default - a chatty child under the watchdog's tick moved 16 KB a second
-there - so the Windows pipe is created at the POSIX capacity, and every platform drains the
-same bursts.
+when asked for the default - a chatty child under the watchdog's tick writes 16 KB a second
+into one of those, four pipes' worth between two drains - so the Windows pipe is created at the
+POSIX capacity, and every platform drains the same bursts.

--- a/src/builtin/ARCHITECTURE.md
+++ b/src/builtin/ARCHITECTURE.md
@@ -140,6 +140,6 @@ when to come back - the watchdog every 250 ms. The pipe's capacity is therefore 
 write budget between two drains, and a child that fills it blocks until the next one; it is also
 the most a single drain hands the caller, which is what the caller's heap sees between two
 collects. A POSIX pipe carries 64 KB by default, and Windows sizes an anonymous pipe at 4 KB
-when asked for the default - a chatty child under the watchdog's tick writes 16 KB a second
-into one of those, four pipes' worth between two drains - so the Windows pipe is created at the
-POSIX capacity, and every platform drains the same bursts.
+when asked for the default - a chatty child under the watchdog's tick moves at most 16 KB a
+second through one of those, the pipe's 4 KB four drains a second - so the Windows pipe is
+created at the POSIX capacity, and every platform drains the same bursts.

--- a/src/builtin/REVIEW.das
+++ b/src/builtin/REVIEW.das
@@ -3,7 +3,7 @@ options gen2
 require strings
 require daslib/strings_boost
 require daslib/fio
-require ./review_nttp // nolint:STYLE030 — compile-time gate, no runtime symbol to reference
+require ./review_nttp // compile-time gate, no runtime symbol to reference
 require dastest/review_gate
 
 // The mechanical half of src/builtin/REVIEW.md (contract: REVIEW_COMMON.md at the

--- a/src/builtin/REVIEW.md
+++ b/src/builtin/REVIEW.md
@@ -63,3 +63,7 @@
   the binary, the command line, the environment names, or which script arguments count - updates
   the cache-key paragraph of `ARCHITECTURE.md` in the same change.** The key is what stops a
   native-compiled module serving a cross compile, so a wrong description of it gets trusted.
+
+- **A diff that changes C++ whose comment cites a section of `ARCHITECTURE.md`
+  (`// src/builtin/ARCHITECTURE.md sec.N`) updates that section in the same change.** C++ carries
+  no `[arch]` annotation, so nothing but this rule keeps a cited section true.

--- a/src/builtin/REVIEW.md
+++ b/src/builtin/REVIEW.md
@@ -64,6 +64,7 @@
   the cache-key paragraph of `ARCHITECTURE.md` in the same change.** The key is what stops a
   native-compiled module serving a cross compile, so a wrong description of it gets trusted.
 
-- **A diff that changes C++ whose comment cites a section of `ARCHITECTURE.md`
-  (`// src/builtin/ARCHITECTURE.md sec.N`) updates that section in the same change.** C++ carries
-  no `[arch]` annotation, so nothing but this rule keeps a cited section true.
+- **A diff that changes C++ whose comment cites a section of an architecture document - this
+  folder's (`// src/builtin/ARCHITECTURE.md sec.N`) or another's (`// src/ast/ARCHITECTURE.md
+  sec.N`) - updates that section in the same change.** C++ carries no `[arch]` annotation, so
+  nothing but this rule keeps a cited section true.

--- a/src/builtin/module_builtin_dasbind.cpp
+++ b/src/builtin/module_builtin_dasbind.cpp
@@ -389,7 +389,12 @@ FastCallWrapper getExtraWrapper ( int nargs, int res, int perm ) {
                     crash_and_burn = "internal error. missing BoundFunction";
                 }
             });
-            if ( !crash_and_burn.empty() ) context.throw_error_at(debugInfo, "%s",crash_and_burn.c_str());
+            if ( !crash_and_burn.empty() ) {
+                char message[8192];   // src/builtin/ARCHITECTURE.md sec.4
+                snprintf(message, sizeof(message), "%s", crash_and_burn.c_str());
+                string().swap(crash_and_burn);
+                context.throw_error_at(debugInfo, "%s", message);
+            }
         }
         DAS_EVAL_ABI vec4f eval ( Context & context ) override {
             DAS_PROFILE_NODE

--- a/src/builtin/module_builtin_debugger.cpp
+++ b/src/builtin/module_builtin_debugger.cpp
@@ -1140,6 +1140,15 @@ namespace debugger {
 
     // pinvoke(context,"function",....)
 
+    // src/builtin/ARCHITECTURE.md sec.4
+    DAS_NORETURN_PREFIX static void throw_pinvoke_error ( Context & context, const LineInfo & at, string & text ) DAS_NORETURN_SUFFIX;
+    static void throw_pinvoke_error ( Context & context, const LineInfo & at, string & text ) {
+        char message[8192];
+        snprintf(message, sizeof(message), "%s", text.c_str());
+        string().swap(text);
+        context.throw_error_at(at, "%s", message);
+    }
+
     static bool pinvoke_named ( Context & context, SimNode_CallBase * call, vec4f * args, vec4f & res, bool tryLock ) {
         auto invCtx = cast<Context *>::to(args[0]);
         if ( !invCtx ) context.throw_error_at(call->debugInfo, "pinvoke with null context");
@@ -1193,7 +1202,7 @@ namespace debugger {
         } else {
             invCtx->threadlock_context(body);
         }
-        if ( !exText.empty() ) context.throw_error_at(exAt, "%s", exText.c_str());
+        if ( !exText.empty() ) throw_pinvoke_error(context, exAt, exText);
         return true;
     }
 
@@ -1239,7 +1248,7 @@ namespace debugger {
                 exText = invCtx->exception;
             }
         });
-        if ( !exText.empty() ) context.throw_error_at(exAt, "%s", exText.c_str());
+        if ( !exText.empty() ) throw_pinvoke_error(context, exAt, exText);
         return res;
     }
 
@@ -1279,7 +1288,7 @@ namespace debugger {
                 exText = invCtx->exception;
             }
         });
-        if ( !exText.empty() ) context.throw_error_at(exAt, "%s", exText.c_str());
+        if ( !exText.empty() ) throw_pinvoke_error(context, exAt, exText);
         return res;
     }
 

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -1806,7 +1806,8 @@ namespace das {
         sa.bInheritHandle = TRUE;
         sa.lpSecurityDescriptor = NULL;
         HANDLE hRead = NULL, hWrite = NULL;
-        if ( !CreatePipe(&hRead, &hWrite, &sa, 0) ) {
+        const DWORD spawnPipeBytes = 64 * 1024;   // src/builtin/ARCHITECTURE.md sec.5
+        if ( !CreatePipe(&hRead, &hWrite, &sa, spawnPipeBytes) ) {
             context->throw_error_at(at, "spawn_process: CreatePipe failed");
             return nullptr;
         }

--- a/tests-cpp/CMakeLists.txt
+++ b/tests-cpp/CMakeLists.txt
@@ -34,6 +34,9 @@ else()
     set(DAS_PRECISE_MATH_FLAG -fno-fast-math)
 endif()
 set_source_files_properties(small/test_isnan_fastmath_region.cpp PROPERTIES COMPILE_OPTIONS ${DAS_PRECISE_MATH_FLAG})
+# the byte-for-byte compare against fmt reads fmt's own float printing, which a fast-math TU
+# folds (NaN as inf, -0 as 0): the reference is only a reference under precise math
+set_source_files_properties(small/test_float2string.cpp PROPERTIES COMPILE_OPTIONS ${DAS_PRECISE_MATH_FLAG})
 
 add_executable(tests-cpp-small doctest_main.cpp ${SMALL_SOURCES})
 target_link_libraries(tests-cpp-small PRIVATE

--- a/tests-cpp/big/vecmath_backend/CMakeLists.txt
+++ b/tests-cpp/big/vecmath_backend/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Lives under big/ because each arm is a standalone exe (the scalar-forced TU's
 # vec4f is a different type than the one libDaScript was compiled with, so
 # neither arm can link libDaScript or join the small glob exe), but labelled
-# "small" so the per-PR CI lane runs both backends.
+# "small" so the per-PR CI lane runs both backends. Both arms pin precise math: the rows
+# assert IEEE NaN, tie and out-of-range answers, which a fast-math build is free to fold.
 
 add_executable(test_vecmath_scalar test_vecmath_backend.cpp)
 target_compile_definitions(test_vecmath_scalar PRIVATE _TARGET_SIMD_SCALAR=1 EXPECT_SCALAR=1)
+target_compile_options(test_vecmath_scalar PRIVATE ${DAS_PRECISE_MATH_FLAG})
 target_include_directories(test_vecmath_scalar PRIVATE ${PROJECT_SOURCE_DIR}/include)
 SETUP_CPP11(test_vecmath_scalar)
 set_target_properties(test_vecmath_scalar PROPERTIES FOLDER "tests-cpp/big")
@@ -20,6 +22,7 @@ add_dependencies(test-small test_vecmath_scalar)
 if(NOT DAS_VECMATH_SCALAR)
     add_executable(test_vecmath_native test_vecmath_backend.cpp)
     target_compile_definitions(test_vecmath_native PRIVATE EXPECT_NATIVE=1)
+    target_compile_options(test_vecmath_native PRIVATE ${DAS_PRECISE_MATH_FLAG})
     target_include_directories(test_vecmath_native PRIVATE ${PROJECT_SOURCE_DIR}/include)
     SETUP_CPP11(test_vecmath_native)
     set_target_properties(test_vecmath_native PROPERTIES FOLDER "tests-cpp/big")

--- a/tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp
+++ b/tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp
@@ -5,6 +5,10 @@
 // to match (NaN/tie ordering, sign-bit select, out-of-range converts, shift
 // counts past the lane width) - NEON diverges there by its own contract.
 
+#if defined(__FAST_MATH__) || defined(_M_FP_FAST)
+#error "the rows pin IEEE answers a fast-math build may fold; both arms are pinned to precise math in CMakeLists.txt"
+#endif
+
 #ifndef _MSC_VER
 #ifndef __forceinline
 #define __forceinline inline

--- a/tests-cpp/small/test_float2string.cpp
+++ b/tests-cpp/small/test_float2string.cpp
@@ -1,3 +1,6 @@
+#if defined(__FAST_MATH__) || defined(_M_FP_FAST)
+#error "test_float2string.cpp compares against fmt, whose float printing a fast-math TU folds; it is pinned to precise math in tests-cpp/CMakeLists.txt"
+#endif
 #include <doctest/doctest.h>
 #include "daScript/daScript.h"
 #include "daScript/misc/float2string.h"

--- a/tests/.das_test
+++ b/tests/.das_test
@@ -77,8 +77,9 @@ def can_visit_folder(folder_name : string; var result : bool?) {
         *result = has_module("minfft")
         return
     }
+    // test_host_ready.das polls the spawned host over dasHV's client
     if (folder_name == "live_host") {
-        *result = has_module("live_host")
+        *result = has_module("live_host") && has_module("dashv")
         return
     }
     if (folder_name == "strudel") {

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@ Every `.das` file in this directory tree is listed below, grouped by subdirector
 | test_lifecycle.das | Lifecycle functions - get_dt, get_uptime, get_fps, is_paused/set_paused, exit_requested, is_reload, is_live_mode | |
 | test_commands.das | Live command dispatch - [live_command] registration, JSON dispatch, args passing, null return, error handling | |
 | test_live_vars.das | `@live` variable viewer - annotation, archive round-trip, type coverage (int, float, string, bool) | |
+| test_host_ready.das | daslang-live spawned beside the running daslang on `_fixture_host_ready.das` serves `/status` and ends on `/shutdown` - the LiveHost module loads before the host reads its exports | |
 
 ## algorithm/
 

--- a/tests/fio/test_process.das
+++ b/tests/fio/test_process.das
@@ -2,6 +2,7 @@ options gen2
 options no_aot
 
 require dastest/testing_boost public
+require math
 require daslib/fio
 
 // argv[0] is the running interpreter (dastest is launched as `daslang dastest/dastest.das ...`),
@@ -31,12 +32,19 @@ def make_temp_root(t : T?; prefix : string) : string {
     return tmp as value
 }
 
+//! a deadline on a child's startup or exit, never a claim about speed: a Debug host compiles
+//! what the child requires several times slower, so the deadline stretches threefold there,
+//! never past five minutes
+def guard(seconds : float) : float {
+    return shared_module_extension() == "_debug.shared_module" ? min(seconds * 3.0, 300.0) : seconds
+}
+
 // drain until the child's ready file appears; the file event drives it, the clock only guards
 def wait_for_ready(t : T?; var p : process; ready : string) {
     let started = ref_time_ticks()
     while (!fexist(ready)) {
         unsafe(process_drain(p) $(_line) {})
-        if (get_time_usec(started) > 15000000) {
+        if (float(get_time_usec(started)) > guard(15.0) * 1000000.0) {
             t |> failure("child never signaled ready")
             return
         }
@@ -66,7 +74,7 @@ def test_process_lifecycle(t : T?) {
             unsafe(process_drain(p) $(line) {
                 lines |> push(clone_string(line))
             })
-            if (get_time_usec(started) > 15000000) {
+            if (float(get_time_usec(started)) > guard(15.0) * 1000000.0) {
                 t |> failure("child never signaled ready")
                 break
             }
@@ -84,7 +92,7 @@ def test_process_lifecycle(t : T?) {
         t |> success(pid > 0, "pid is positive: {pid}")
         t |> success(unsafe(process_alive(pid)), "process_alive is true while running")
         t |> success(fwrite(release, "go"), "wrote the release event")
-        t |> equal(unsafe(process_wait(p, 5.0)), 7, "child exited with its own code")
+        t |> equal(unsafe(process_wait(p, guard(5.0))), 7, "child exited with its own code")
         t |> success(!unsafe(process_alive(pid)), "process_alive is false after exit")
         unsafe(close_process(p))
         let cleanup = rmdir_rec_result(root_dir)
@@ -145,7 +153,7 @@ def test_process_terminate(t : T?) {
         let started = ref_time_ticks()
         while (!fexist(ready)) {
             unsafe(process_drain(p) $(_line) {})
-            if (get_time_usec(started) > 15000000) {
+            if (float(get_time_usec(started)) > guard(15.0) * 1000000.0) {
                 t |> failure("child never signaled ready")
                 break
             }
@@ -154,7 +162,7 @@ def test_process_terminate(t : T?) {
         let pid = unsafe(process_pid(p))
         t |> equal(unsafe(process_wait(p, 0.2)), process_running, "wait answers process_running when the timeout passes first")
         unsafe(process_terminate(p))
-        let rc = unsafe(process_wait(p, 5.0))
+        let rc = unsafe(process_wait(p, guard(5.0)))
         t |> success(rc != process_running, "child stopped after terminate (rc={rc})")
         t |> success(!unsafe(process_alive(pid)), "process_alive is false after terminate")
         unsafe(close_process(p))

--- a/tests/live_host/_fixture_host_ready.das
+++ b/tests/live_host/_fixture_host_ready.das
@@ -1,0 +1,18 @@
+options gen2
+options persistent_heap
+options gc
+
+require live/live_api
+require live_host
+
+[export]
+def init() {
+}
+
+[export]
+def update() {
+}
+
+[export]
+def shutdown() {
+}

--- a/tests/live_host/test_host_ready.das
+++ b/tests/live_host/test_host_ready.das
@@ -1,0 +1,96 @@
+options gen2
+options no_aot
+options no_unused_block_arguments = false
+
+require dastest/testing_boost public
+require daslib/fio
+require daslib/command_line
+require daslib/strings_boost
+require dashv/dashv_boost
+require strings
+
+//! daslang-live serves its HTTP API on the port its argv names. The host reads the LiveHost
+//! shared module's lifecycle exports before any require names that module, so a module scan
+//! that defers it has to bring it in first - otherwise live mode never turns on, no server
+//! starts, and every client waits out its ready budget.
+
+let PORT = 19390
+
+//! the daslang-live beside the daslang running dastest; empty where the tree has not built it
+def private live_exe() : string {
+    let beside = path_join(dir_name(get_full_file_name(get_das_exe())), "daslang-live{get_platform_name() == "windows" ? ".exe" : ""}")
+    return fexist(beside) ? beside : ""
+}
+
+def private status_answers() : bool {
+    var ok = false
+    with_http_request() $(var req) {
+        req.method = http_method.GET
+        req.url := "http://127.0.0.1:{PORT}/status"
+        request(req) $(resp) {
+            ok = resp != null && int(resp.status_code) == 200
+        }
+    }
+    return ok
+}
+
+def private post_shutdown() {
+    with_http_request() $(var req) {
+        req.method = http_method.POST
+        req.url := "http://127.0.0.1:{PORT}/shutdown"
+        request(req) $(_resp) {
+        }
+    }
+}
+
+//! seconds until /status answers, draining the host's stdout meanwhile; -1 past the deadline
+//! or once the host is gone
+def private wait_ready(var host : process; seconds : float; var lines : array<string>) : float {
+    let started = ref_time_ticks()
+    while (float(get_time_usec(started)) < seconds * 1000000.0) {
+        unsafe(process_drain(host) $(line) {
+            lines |> push(line)
+        })
+        if (unsafe(process_poll(host)) != process_running) return -1.0
+        if (status_answers()) return float(get_time_usec(started)) / 1000000.0
+        sleep(250u)
+    }
+    return -1.0
+}
+
+//! the exit code once the host ends, draining its stdout meanwhile; process_running past the deadline
+def private wait_exit_draining(var host : process; seconds : float; var lines : array<string>) : int {
+    let started = ref_time_ticks()
+    while (float(get_time_usec(started)) < seconds * 1000000.0) {
+        unsafe(process_drain(host) $(line) {
+            lines |> push(line)
+        })
+        let rc = unsafe(process_poll(host))
+        if (rc != process_running) return rc
+        sleep(20u)
+    }
+    return process_running
+}
+
+[test]
+def test_host_serves_status(t : T?) {
+    let exe = live_exe()
+    if (empty(exe)) {
+        t |> skip("no daslang-live beside {get_das_exe()}")
+        return
+    }
+    t |> run("/status answers within the ready budget, and /shutdown ends the host with 0") @(t : T?) {
+        let script = path_join(get_das_root(), "tests/live_host/_fixture_host_ready.das")
+        let no_env : array<string>
+        var host = unsafe(spawn_process([exe, "--live-port={PORT}", script], get_das_root(), no_env))
+        var lines : array<string>
+        let ready = wait_ready(host, 30.0, lines)
+        t |> success(ready >= 0.0, "daslang-live did not serve /status within 30 s:\n{join(lines, "\n")}")
+        post_shutdown()
+        let rc = wait_exit_draining(host, 20.0, lines)
+        unsafe {
+            close_process(host)
+        }
+        t |> equal(rc, 0, "the host exited with 0 after /shutdown:\n{join(lines, "\n")}")
+    }
+}

--- a/tests/live_host/test_host_ready.das
+++ b/tests/live_host/test_host_ready.das
@@ -14,7 +14,8 @@ require strings
 //! that defers it has to bring it in first - otherwise live mode never turns on, no server
 //! starts, and every client waits out its ready budget.
 
-let PORT = 19390
+let PORT_FIRST = 19390
+let PORT_SPAN = 20
 
 //! the daslang-live beside the daslang running dastest; empty where the tree has not built it
 def private live_exe() : string {
@@ -22,11 +23,11 @@ def private live_exe() : string {
     return fexist(beside) ? beside : ""
 }
 
-def private status_answers() : bool {
+def private status_answers(port : int) : bool {
     var ok = false
     with_http_request() $(var req) {
         req.method = http_method.GET
-        req.url := "http://127.0.0.1:{PORT}/status"
+        req.url := "http://127.0.0.1:{port}/status"
         request(req) $(resp) {
             ok = resp != null && int(resp.status_code) == 200
         }
@@ -34,10 +35,19 @@ def private status_answers() : bool {
     return ok
 }
 
-def private post_shutdown() {
+//! the first port of the span no host answers on, so a /status answer is this test's own child
+//! and its /shutdown reaches nothing else; -1 when every port has a host
+def private free_port() : int {
+    for (port in range(PORT_FIRST, PORT_FIRST + PORT_SPAN)) {
+        if (!status_answers(port)) return port
+    }
+    return -1
+}
+
+def private post_shutdown(port : int) {
     with_http_request() $(var req) {
         req.method = http_method.POST
-        req.url := "http://127.0.0.1:{PORT}/shutdown"
+        req.url := "http://127.0.0.1:{port}/shutdown"
         request(req) $(_resp) {
         }
     }
@@ -45,14 +55,14 @@ def private post_shutdown() {
 
 //! seconds until /status answers, draining the host's stdout meanwhile; -1 past the deadline
 //! or once the host is gone
-def private wait_ready(var host : process; seconds : float; var lines : array<string>) : float {
+def private wait_ready(var host : process; port : int; seconds : float; var lines : array<string>) : float {
     let started = ref_time_ticks()
     while (float(get_time_usec(started)) < seconds * 1000000.0) {
         unsafe(process_drain(host) $(line) {
             lines |> push(line)
         })
         if (unsafe(process_poll(host)) != process_running) return -1.0
-        if (status_answers()) return float(get_time_usec(started)) / 1000000.0
+        if (status_answers(port)) return float(get_time_usec(started)) / 1000000.0
         sleep(250u)
     }
     return -1.0
@@ -79,18 +89,25 @@ def test_host_serves_status(t : T?) {
         t |> skip("no daslang-live beside {get_das_exe()}")
         return
     }
+    let port = free_port()
+    if (port < 0) {
+        t |> skip("a host answers on every port from {PORT_FIRST} to {PORT_FIRST + PORT_SPAN - 1}")
+        return
+    }
     t |> run("/status answers within the ready budget, and /shutdown ends the host with 0") @(t : T?) {
         let script = path_join(get_das_root(), "tests/live_host/_fixture_host_ready.das")
         let no_env : array<string>
-        var host = unsafe(spawn_process([exe, "--live-port={PORT}", script], get_das_root(), no_env))
+        var host = unsafe(spawn_process([exe, "--live-port={port}", script], get_das_root(), no_env))
         var lines : array<string>
-        let ready = wait_ready(host, 30.0, lines)
+        let ready = wait_ready(host, port, 30.0, lines)
         t |> success(ready >= 0.0, "daslang-live did not serve /status within 30 s:\n{join(lines, "\n")}")
-        post_shutdown()
-        let rc = wait_exit_draining(host, 20.0, lines)
-        unsafe {
-            close_process(host)
+        if (ready >= 0.0) {
+            post_shutdown(port)
+            let rc = wait_exit_draining(host, 20.0, lines)
+            t |> equal(rc, 0, "the host exited with 0 after /shutdown:\n{join(lines, "\n")}")
         }
-        t |> equal(rc, 0, "the host exited with 0 after /shutdown:\n{join(lines, "\n")}")
+        unsafe {
+            close_process(host)   //! ends a child that never became ready
+        }
     }
 }

--- a/tests/module_cache/ARCHITECTURE.md
+++ b/tests/module_cache/ARCHITECTURE.md
@@ -102,11 +102,11 @@ this document states what the folder is and why its tests take the shape they do
   `_common` already): the binary to spawn (`das_exe`),
   the scan-trace command prefix (`trace_prefix`), the stderr-joining child run (`run_child`),
   the failure report that echoes the child's output (`report_child`), and the two joined
-  (`run_child_reported`), which every test calls as a statement of its own: a `run_child(cmd,
-  out)` nested beside `out` in one argument list is an evaluation-order dependency the AOT tier
-  hands to the C++ compiler, and MSVC and clang-cl read `out` before the run, so the report
-  saw an empty output on every Windows AOT host. A test whose child needs a different spawn
-  shape - an argv spawn, an environment variable - keeps that one helper local.
+  (`run_child_reported`), which every test calls as a statement of its own: the order a call's
+  arguments are evaluated in is not defined (LINT030), and a `run_child(cmd, out)` nested
+  beside `out` in one argument list read an empty output on every Windows AOT host. A test
+  whose child needs a different spawn shape - an argv spawn, an environment variable - keeps
+  that one helper local.
 
 ## 2. Why every case is a spawned process
 

--- a/tests/module_cache/ARCHITECTURE.md
+++ b/tests/module_cache/ARCHITECTURE.md
@@ -100,10 +100,13 @@ this document states what the folder is and why its tests take the shape they do
 - `_mc_common.das` - the spawn helpers every test here shares (the name is the folder's, since
   a sweep worker holds every shared module it met under one name and `tests/linq` has a
   `_common` already): the binary to spawn (`das_exe`),
-  the scan-trace command prefix (`trace_prefix`), the stderr-joining child run (`run_child`)
-  and the failure report that echoes the child's output (`report_child`). A test whose child
-  needs a different spawn shape - an argv spawn, an environment variable - keeps that one
-  helper local.
+  the scan-trace command prefix (`trace_prefix`), the stderr-joining child run (`run_child`),
+  the failure report that echoes the child's output (`report_child`), and the two joined
+  (`run_child_reported`), which every test calls as a statement of its own: a `run_child(cmd,
+  out)` nested beside `out` in one argument list is an evaluation-order dependency the AOT tier
+  hands to the C++ compiler, and MSVC and clang-cl read `out` before the run, so the report
+  saw an empty output on every Windows AOT host. A test whose child needs a different spawn
+  shape - an argv spawn, an environment variable - keeps that one helper local.
 
 ## 2. Why every case is a spawned process
 

--- a/tests/module_cache/ARCHITECTURE.md
+++ b/tests/module_cache/ARCHITECTURE.md
@@ -102,11 +102,10 @@ this document states what the folder is and why its tests take the shape they do
   `_common` already): the binary to spawn (`das_exe`),
   the scan-trace command prefix (`trace_prefix`), the stderr-joining child run (`run_child`),
   the failure report that echoes the child's output (`report_child`), and the two joined
-  (`run_child_reported`), which every test calls as a statement of its own: the order a call's
-  arguments are evaluated in is not defined (LINT030), and a `run_child(cmd, out)` nested
-  beside `out` in one argument list read an empty output on every Windows AOT host. A test
-  whose child needs a different spawn shape - an argv spawn, an environment variable - keeps
-  that one helper local.
+  (`run_child_reported`): the order a call's arguments are evaluated in is not defined
+  (LINT030), and a `run_child(cmd, out)` nested beside `out` in one argument list reads an
+  empty output on a Windows AOT host. A test whose child needs a different spawn shape - an
+  argv spawn, an environment variable - keeps that one helper local.
 
 ## 2. Why every case is a spawned process
 

--- a/tests/module_cache/REVIEW.md
+++ b/tests/module_cache/REVIEW.md
@@ -16,3 +16,9 @@
 
 - **A test in this folder writes only under a directory it created for this process - its own
   files and its children's - and removes that directory.**
+
+- **A test in this folder runs a child as a statement of its own - `run_child_reported`,
+  `run_driver_reported`, or the run's result bound to a local before the compare - never as an
+  argument beside the `out` it writes, and carries `options _lint = "LINT030"`.** The order a
+  call's arguments are evaluated in is not defined, so a nested run reads its output empty on a
+  Windows AOT host and full everywhere else.

--- a/tests/module_cache/_mc_common.das
+++ b/tests/module_cache/_mc_common.das
@@ -41,9 +41,8 @@ def report_child(t : T?; phase : string; rc : int; out : string; marker : string
 }
 
 //! runs `cmd` and reports it as report_child does; `out` keeps the child's output for the
-//! caller's own reads. The run is a statement of its own: `run_child(cmd, out)` nested beside
-//! `out` in one argument list is read before or after the run by the C++ compiler's choice
-//! under AOT, and MSVC reads `out` first.
+//! caller's own reads. The run is a statement of its own, since the order a call's arguments
+//! are evaluated in is not defined (LINT030).
 def run_child_reported(t : T?; phase : string; cmd : string; var out : string&; marker : string) : bool {
     let rc = run_child(cmd, out)
     return report_child(t, phase, rc, out, marker)

--- a/tests/module_cache/_mc_common.das
+++ b/tests/module_cache/_mc_common.das
@@ -39,3 +39,12 @@ def report_child(t : T?; phase : string; rc : int; out : string; marker : string
     }
     return ok
 }
+
+//! runs `cmd` and reports it as report_child does; `out` keeps the child's output for the
+//! caller's own reads. The run is a statement of its own: `run_child(cmd, out)` nested beside
+//! `out` in one argument list is read before or after the run by the C++ compiler's choice
+//! under AOT, and MSVC reads `out` first.
+def run_child_reported(t : T?; phase : string; cmd : string; var out : string&; marker : string) : bool {
+    let rc = run_child(cmd, out)
+    return report_child(t, phase, rc, out, marker)
+}

--- a/tests/module_cache/test_default_cache_path.das
+++ b/tests/module_cache/test_default_cache_path.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public
@@ -27,6 +28,13 @@ def run(cmd : string; var output : string&) : int {
             output = fread(f)
         }
     }))
+}
+
+//! run, reported as run_child_reported reports: the run is its own statement, never an
+//! argument beside the `out` it writes
+def run_reported(t : T?; phase : string; cmd : string; var out : string&; marker : string) : bool {
+    let rc = run(cmd, out)
+    return report_child(t, phase, rc, out, marker)
 }
 
 let CACHE_DIR = ".jitted_scripts/module_cache"
@@ -100,10 +108,10 @@ def test_fallback_verdict_names_the_cutoff(t : T?) {
     fwrite(path_join(tmp, "mc_root.das"), "options gen2\nrequire mc_leaf_a\nrequire mc_leaf_b\n[export]\ndef main \{\n    print(\"MARK_verdict \{leaf_a() + leaf_b()\}\\n\")\n\}\n")
     let cmd = "{das_exe()} -dasroot {get_das_root()} -module-cache {path_join(tmp, "explicit.dascache")} {path_join(tmp, "mc_root.das")}"
     var cold : string
-    t |> success(report_child(t, "verdict cold", run(cmd, cold), cold, "ser: wrote"), "the cold run writes the explicit cache")
+    t |> success(run_reported(t, "verdict cold", cmd, cold, "ser: wrote"), "the cold run writes the explicit cache")
     fwrite(leafB, "options gen2\nmodule mc_leaf_b\ndef leaf_b() : int \{\n    return 20\n\}\n")
     var warm : string
-    t |> success(report_child(t, "verdict warm", run(cmd, warm), warm, "MARK_verdict 21"), "the edited leaf is recompiled")
+    t |> success(run_reported(t, "verdict warm", cmd, warm, "MARK_verdict 21"), "the edited leaf is recompiled")
     //! two served: daslib/builtin's record and mc_leaf_a's, then the cutoff at mc_leaf_b
     t |> success(find(warm, "deser: FALLBACK - 2 module(s) served from cache") >= 0, "the verdict counts the modules served before the cutoff:\n{warm}")
     t |> success(find(warm, "mc_leaf_b.das") >= 0 && find(warm, "(file changed)") >= 0, "the verdict names the cutoff file and its reason:\n{warm}")
@@ -127,16 +135,16 @@ def test_policy_change_refuses_the_cache(t : T?) {
     let base = "{das_exe()} -dasroot {get_das_root()}"
     let tail = "-module-cache {path_join(tmp, "explicit.dascache")} {path_join(tmp, "mc_pol_root.das")}"
     var cold : string
-    t |> success(report_child(t, "policy cold", run("{base} {tail}", cold), cold, "ser: wrote"), "the cold run writes the explicit cache")
+    t |> success(run_reported(t, "policy cold", "{base} {tail}", cold, "ser: wrote"), "the cold run writes the explicit cache")
     var same : string
-    t |> success(report_child(t, "policy same", run("{base} {tail}", same), same, "deser: clean"), "the same policies serve every module")
+    t |> success(run_reported(t, "policy same", "{base} {tail}", same, "deser: clean"), "the same policies serve every module")
     var changed : string
-    t |> success(report_child(t, "policy changed", run("{base} -no-lint {tail}", changed), changed, "MARK_policy 3"), "a -no-lint run over the plain run's cache still executes")
+    t |> success(run_reported(t, "policy changed", "{base} -no-lint {tail}", changed, "MARK_policy 3"), "a -no-lint run over the plain run's cache still executes")
     t |> success(find(changed, "compile policies changed at") >= 0 && find(changed, "mc_pol_leaf.das") >= 0, "the leaf's record names the policy change:\n{changed}")
     t |> success(find(changed, "deser: partial") >= 0, "the mismatch reparses in place rather than cutting the stream:\n{changed}")
     t |> success(find(changed, "ser: wrote") >= 0, "the cache is rewritten under the new policies")
     var rewritten : string
-    t |> success(report_child(t, "policy rewritten", run("{base} -no-lint {tail}", rewritten), rewritten, "deser: clean"), "the rewritten cache serves the -no-lint compile")
+    t |> success(run_reported(t, "policy rewritten", "{base} -no-lint {tail}", rewritten, "deser: clean"), "the rewritten cache serves the -no-lint compile")
     var err : string
     rmdir_rec(tmp, err)
 }
@@ -158,14 +166,14 @@ def test_source_stamp_is_content(t : T?) {
     fwrite(path_join(tmp, "mc_stamp_root.das"), "options gen2\nrequire mc_stamp_leaf\n[export]\ndef main \{\n    print(\"MARK_stamp \{leaf()\}\\n\")\n\}\n")
     let cmd = "{das_exe()} -dasroot {get_das_root()} -module-cache {path_join(tmp, "explicit.dascache")} {path_join(tmp, "mc_stamp_root.das")}"
     var cold : string
-    t |> success(report_child(t, "stamp cold", run(cmd, cold), cold, "ser: wrote"), "the cold run writes the explicit cache")
+    t |> success(run_reported(t, "stamp cold", cmd, cold, "ser: wrote"), "the cold run writes the explicit cache")
     sleep(1100u)    //! past the mtime's one-second grain, so the rewrite below moves the mtime
     fwrite(leaf, leafSrc)
     var touched : string
-    t |> success(report_child(t, "stamp touched", run(cmd, touched), touched, "deser: clean"), "a rewrite that leaves the bytes alone still serves every module:\n{touched}")
+    t |> success(run_reported(t, "stamp touched", cmd, touched, "deser: clean"), "a rewrite that leaves the bytes alone still serves every module:\n{touched}")
     fwrite(leaf, "options gen2\nmodule mc_stamp_leaf\ndef leaf() : int \{\n    return 3\n\}\n")
     var edited : string
-    t |> success(report_child(t, "stamp edited", run(cmd, edited), edited, "MARK_stamp 3"), "a same-size edit is recompiled")
+    t |> success(run_reported(t, "stamp edited", cmd, edited, "MARK_stamp 3"), "a same-size edit is recompiled")
     //! daslib/builtin's record serves first, so the cutoff verdict takes its served-count form
     t |> success(find(edited, "deser: FALLBACK - 1 module(s) served from cache") >= 0 && find(edited, "mc_stamp_leaf.das") >= 0 && find(edited, "(file changed)") >= 0, "the same-size edit is a cutoff at the leaf:\n{edited}")
     t |> success(find(edited, "ser: file content changed") >= 0, "the loud cache names the content change:\n{edited}")
@@ -188,9 +196,9 @@ def test_source_derived_syntax_policy_serves(t : T?) {
     fwrite(path_join(tmp, "mc_gen2_root.das"), "options gen2\nrequire mc_gen2_leaf\n[export]\ndef main \{\n    print(\"MARK_gen2 \{leaf()\}\\n\")\n\}\n")
     let cmd = "{das_exe()} -dasroot {get_das_root()} -v1syntax -module-cache {path_join(tmp, "explicit.dascache")} {path_join(tmp, "mc_gen2_root.das")}"
     var cold : string
-    t |> success(report_child(t, "gen2 cold", run(cmd, cold), cold, "MARK_gen2 5"), "a -v1syntax host compiles a module that opts into gen2")
+    t |> success(run_reported(t, "gen2 cold", cmd, cold, "MARK_gen2 5"), "a -v1syntax host compiles a module that opts into gen2")
     var warm : string
-    t |> success(report_child(t, "gen2 warm", run(cmd, warm), warm, "deser: clean"), "the warm run serves the gen2 module - no policy mismatch on a source-derived flag:\n{warm}")
+    t |> success(run_reported(t, "gen2 warm", cmd, warm, "deser: clean"), "the warm run serves the gen2 module - no policy mismatch on a source-derived flag:\n{warm}")
     var err : string
     rmdir_rec(tmp, err)
 }
@@ -285,11 +293,11 @@ def test_source_lines_survive_the_cache(t : T?) {
     remove_cache_files("mc_src_root")
     let cmd = "{das_exe()} -dasroot {get_das_root()} {root}"
     var cold : string
-    t |> success(report_child(t, "marked cold", run(cmd, cold), cold, "MARK_src 7"), "the cold run compiles past the marked variable")
+    t |> success(run_reported(t, "marked cold", cmd, cold, "MARK_src 7"), "the cold run compiles past the marked variable")
     // the root changes so it re-parses and its lint pass runs, while the marked module is served
     fwrite(root, "options gen2\nrequire daslib/lint\nrequire mc_marked\n[export]\ndef main \{\n    print(\"MARK_src2 \{marked(7)\}\\n\")\n\}\n")
     var warm : string
-    t |> success(report_child(t, "marked warm", run(cmd, warm), warm, "MARK_src2 7"), "the warm run still sees the nolint marker on the served module")
+    t |> success(run_reported(t, "marked warm", cmd, warm, "MARK_src2 7"), "the warm run still sees the nolint marker on the served module")
     t |> success(find(warm, "LINT003") < 0, "no LINT003 leaks through a served module:\n{warm}")
     remove_cache_files("mc_src_root")
     var err : string
@@ -427,20 +435,20 @@ def test_default_cache_evicts_to_the_limit(t : T?) {
         fwrite(path_join(tmp, "{stem}.das"), "options gen2\n[export]\ndef main \{\n    print(\"MARK_{stem}\\n\")\n\}\n")
     }
     var out : string
-    t |> success(report_child(t, "evict a", run("{base} {path_join(tmp, "ev_a.das")}", out), out, "MARK_ev_a"), "the first root writes its record")
+    t |> success(run_reported(t, "evict a", "{base} {path_join(tmp, "ev_a.das")}", out, "MARK_ev_a"), "the first root writes its record")
     let one = record_size_in(cacheDir, "ev_a")
     t |> success(one > 0ul && 2ul * one <= 1048576ul && 3ul * one > 1048576ul, "a hello record ({one} bytes) sizes so that two fit the 1 MB limit and three do not - retune the limit if daslib grew")
     sleep(1100u)    //! past the mtime's one-second grain, so the records order by age
-    t |> success(report_child(t, "evict b", run("{base} {path_join(tmp, "ev_b.das")}", out), out, "MARK_ev_b"), "the second root writes its record")
+    t |> success(run_reported(t, "evict b", "{base} {path_join(tmp, "ev_b.das")}", out, "MARK_ev_b"), "the second root writes its record")
     sleep(1100u)
-    t |> success(report_child(t, "evict c", run("{base} {path_join(tmp, "ev_c.das")}", out), out, "MARK_ev_c"), "the third root writes its record")
+    t |> success(run_reported(t, "evict c", "{base} {path_join(tmp, "ev_c.das")}", out, "MARK_ev_c"), "the third root writes its record")
     t |> equal(records_in(cacheDir, "ev_a"), 0, "the oldest record went when the third pushed the directory past the limit")
     t |> equal(records_in(cacheDir, "ev_b"), 1, "the middle record stays")
     t |> equal(records_in(cacheDir, "ev_c"), 1, "the record just written stays")
     sleep(1100u)
-    t |> success(report_child(t, "evict b warm", run("{base} {path_join(tmp, "ev_b.das")}", out), out, "MARK_ev_b"), "a warm run reads the second record")
+    t |> success(run_reported(t, "evict b warm", "{base} {path_join(tmp, "ev_b.das")}", out, "MARK_ev_b"), "a warm run reads the second record")
     sleep(1100u)
-    t |> success(report_child(t, "evict d", run("{base} {path_join(tmp, "ev_d.das")}", out), out, "MARK_ev_d"), "a fourth root writes its record")
+    t |> success(run_reported(t, "evict d", "{base} {path_join(tmp, "ev_d.das")}", out, "MARK_ev_d"), "a fourth root writes its record")
     t |> equal(records_in(cacheDir, "ev_b"), 1, "the record the warm run read counted as fresh and survived")
     t |> equal(records_in(cacheDir, "ev_c"), 0, "the record no run touched since was the oldest and went")
     t |> equal(records_in(cacheDir, "ev_d"), 1, "the record just written stays")
@@ -448,7 +456,7 @@ def test_default_cache_evicts_to_the_limit(t : T?) {
     for (stem in ["ev_a", "ev_b", "ev_c"]) {
         let cachePath = path_join(explicitDir, "{stem}.dascache")
         let script = path_join(tmp, "{stem}.das")
-        t |> success(report_child(t, "explicit {stem}", run("{base} -module-cache {cachePath} {script}", out), out, "ser: wrote"), "an explicit cache writes under the limit too")
+        t |> success(run_reported(t, "explicit {stem}", "{base} -module-cache {cachePath} {script}", out, "ser: wrote"), "an explicit cache writes under the limit too")
     }
     var explicitFiles = 0
     fio::dir(explicitDir) $(name) {

--- a/tests/module_cache/test_default_cache_path.das
+++ b/tests/module_cache/test_default_cache_path.das
@@ -170,7 +170,8 @@ def test_source_stamp_is_content(t : T?) {
     sleep(1100u)    //! past the mtime's one-second grain, so the rewrite below moves the mtime
     fwrite(leaf, leafSrc)
     var touched : string
-    t |> success(run_reported(t, "stamp touched", cmd, touched, "deser: clean"), "a rewrite that leaves the bytes alone still serves every module:\n{touched}")
+    let touched_ok = run_reported(t, "stamp touched", cmd, touched, "deser: clean")
+    t |> success(touched_ok, "a rewrite that leaves the bytes alone still serves every module:\n{touched}")
     fwrite(leaf, "options gen2\nmodule mc_stamp_leaf\ndef leaf() : int \{\n    return 3\n\}\n")
     var edited : string
     t |> success(run_reported(t, "stamp edited", cmd, edited, "MARK_stamp 3"), "a same-size edit is recompiled")
@@ -198,7 +199,8 @@ def test_source_derived_syntax_policy_serves(t : T?) {
     var cold : string
     t |> success(run_reported(t, "gen2 cold", cmd, cold, "MARK_gen2 5"), "a -v1syntax host compiles a module that opts into gen2")
     var warm : string
-    t |> success(run_reported(t, "gen2 warm", cmd, warm, "deser: clean"), "the warm run serves the gen2 module - no policy mismatch on a source-derived flag:\n{warm}")
+    let warm_ok = run_reported(t, "gen2 warm", cmd, warm, "deser: clean")
+    t |> success(warm_ok, "the warm run serves the gen2 module - no policy mismatch on a source-derived flag:\n{warm}")
     var err : string
     rmdir_rec(tmp, err)
 }
@@ -243,13 +245,15 @@ def test_aot_generation_reads_cached_modules(t : T?) {
     fwrite(fixture, "options gen2\nrequire daslib/strings_boost\n[export]\ndef main \{\n    print(join([\"a\", \"b\"], \",\"))\n\}\n")
     let gen = "{das_exe()} -dasroot {root} {path_join(root, "utils/aot/main.das")} -- -aot {fixture}"
     var cold : string
-    t |> equal(run("{gen} {path_join(tmp, "cold.cpp")}", cold), 0, "the cold generator run exits clean:\n{cold}")
+    let cold_rc = run("{gen} {path_join(tmp, "cold.cpp")}", cold)
+    t |> equal(cold_rc, 0, "the cold generator run exits clean:\n{cold}")
     let coldCpp = fread(path_join(tmp, "cold.cpp"))
     let coldHashes = count_lines_with(coldCpp, "hash=")
     t |> success(coldHashes > 0, "the cold run emits functions")
     t |> success(find(coldCpp, "AOT disabled due to this module") < 0, "no module reads as AOT-disabled on the cold run")
     var warm : string
-    t |> equal(run("{gen} {path_join(tmp, "warm.cpp")}", warm), 0, "the warm generator run exits clean:\n{warm}")
+    let warm_rc = run("{gen} {path_join(tmp, "warm.cpp")}", warm)
+    t |> equal(warm_rc, 0, "the warm generator run exits clean:\n{warm}")
     let warmCpp = fread(path_join(tmp, "warm.cpp"))
     t |> success(find(warmCpp, "AOT disabled due to this module") < 0, "no module reads as AOT-disabled when the generator's modules came from the cache")
     t |> equal(count_lines_with(warmCpp, "hash="), coldHashes, "the warm run emits the same functions as the cold run")

--- a/tests/module_cache/test_deferred_modules.das
+++ b/tests/module_cache/test_deferred_modules.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public

--- a/tests/module_cache/test_deferred_modules.das
+++ b/tests/module_cache/test_deferred_modules.das
@@ -175,44 +175,44 @@ def has_shared_modules(dir : string; names : array<string>) : bool {
 def arms_deferred(t : T?; fx : Fixture) {
     t |> run("a cold start loads the module to record its name, and a guard reads it available") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "cold", run_child(child_cmd(fx, fx.guarded), out), out, "GUARD true"), "the cold start runs, and the guard takes its target")
+        t |> success(run_child_reported(t, "cold", child_cmd(fx, fx.guarded), out, "GUARD true"), "the cold start runs, and the guard takes its target")
         t |> equal("compiled (no manifest), manifest written (1 row(s))", descriptor_line(out, UNIT_TEST_FOLDER), "the copied descriptor compiles and records:\n{out}")
         t |> success(find(out, "{UNIT_TEST_CLASS} <- ") >= 0 && find(out, ": loaded") >= 0, "the recording start loads the module:\n{out}")
     }
     t |> run("a warm start defers the module and loads nothing for a program that requires nothing") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "warm", run_child(child_cmd(fx, fx.plain), out), out, "PLAIN"), "the warm start runs the program")
+        t |> success(run_child_reported(t, "warm", child_cmd(fx, fx.plain), out, "PLAIN"), "the warm start runs the program")
         let line = descriptor_line(out, UNIT_TEST_FOLDER)
         t |> success(line |> starts_with("replayed 1 row(s) in ") && find(line, ", deferred 1)") >= 0, "the descriptor replays its one row deferred:\n{out}")
         t |> equal(-1, find(out, "{UNIT_TEST_CLASS} <- "), "nothing loads the shared module:\n{out}")
     }
     t |> run("the first require naming a deferred module loads it, and the program calls into it") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "uses", run_child(child_cmd(fx, fx.uses), out), out, "LENGTH 5"), "the program calls the module's function")
+        t |> success(run_child_reported(t, "uses", child_cmd(fx, fx.uses), out, "LENGTH 5"), "the program calls the module's function")
         t |> success(find(out, "[module] require {UNIT_TEST_MODULE}: loading the deferred {UNIT_TEST_CLASS}") >= 0, "the trace names the require that loaded it:\n{out}")
         t |> success(find(out, "{UNIT_TEST_CLASS} <- ") >= 0 && find(out, ": loaded") >= 0, "the shared module loads:\n{out}")
     }
     t |> run("builtin_module_exists loads a waiting module, with no require naming it") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "exists", run_child(child_cmd(fx, fx.exists), out), out, "EXISTS true"), "the build has the module")
+        t |> success(run_child_reported(t, "exists", child_cmd(fx, fx.exists), out, "EXISTS true"), "the build has the module")
         t |> success(find(out, "[module] require {UNIT_TEST_MODULE}: loading the deferred {UNIT_TEST_CLASS}") >= 0, "the question loaded it:\n{out}")
     }
     t |> run("has_module answers true for a waiting module and loads nothing") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "has_module", run_child(child_cmd(fx, fx.hasModule), out), out, "HAS true"), "the build has the module")
+        t |> success(run_child_reported(t, "has_module", child_cmd(fx, fx.hasModule), out, "HAS true"), "the build has the module")
         t |> equal(-1, find(out, "{UNIT_TEST_CLASS} <- "), "nothing loads the shared module:\n{out}")
     }
     t |> run("a lazy start and an eager start build the same builtin module") @(t : T?) {
         var lazy : string
-        t |> success(report_child(t, "dollar lazy", run_child(child_cmd(fx, fx.dollar), lazy), lazy, "DOLLAR "), "the lazy start counts")
+        t |> success(run_child_reported(t, "dollar lazy", child_cmd(fx, fx.dollar), lazy, "DOLLAR "), "the lazy start counts")
         var eager : string
-        t |> success(report_child(t, "dollar eager", run_child(child_cmd(fx, fx.dollar, "-ignore-manifest"), eager), eager, "DOLLAR "), "the eager start counts")
+        t |> success(run_child_reported(t, "dollar eager", child_cmd(fx, fx.dollar, "-ignore-manifest"), eager, "DOLLAR "), "the eager start counts")
         t |> success(dollar_count(lazy) > 0, "the count is a count:\n{lazy}")
         t |> equal(dollar_count(lazy), dollar_count(eager), "a C++ module's load registers nothing into $:\nlazy:\n{lazy}\neager:\n{eager}")
     }
     t |> run("a compile of a string, which walks no prerequisites, meets the waiting module at its require") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "nested", run_child(child_cmd(fx, fx.nested), out), out, "NESTED true"), "the nested program compiles")
+        t |> success(run_child_reported(t, "nested", child_cmd(fx, fx.nested), out, "NESTED true"), "the nested program compiles")
         t |> success(find(out, "[module] require {UNIT_TEST_MODULE}: loading the deferred {UNIT_TEST_CLASS}") >= 0, "the parser's require loaded it:\n{out}")
     }
 }
@@ -220,20 +220,20 @@ def arms_deferred(t : T?; fx : Fixture) {
 def arms_guards_and_caches(t : T?; fx : Fixture) {
     t |> run("a require guard loads a waiting module, whatever else the compile requires") @(t : T?) {
         var alone : string
-        t |> success(report_child(t, "guarded", run_child(child_cmd(fx, fx.guarded), alone), alone, "GUARD true"), "the guard alone takes its target")
+        t |> success(run_child_reported(t, "guarded", child_cmd(fx, fx.guarded), alone, "GUARD true"), "the guard alone takes its target")
         t |> success(find(alone, "[module] require {UNIT_TEST_MODULE}: loading the deferred {UNIT_TEST_CLASS}") >= 0, "the guard loaded the module:\n{alone}")
         var after : string
-        t |> success(report_child(t, "guarded after", run_child(child_cmd(fx, fx.guardedAfter), after), after, "GUARD true"), "a require above the guard")
+        t |> success(run_child_reported(t, "guarded after", child_cmd(fx, fx.guardedAfter), after, "GUARD true"), "a require above the guard")
         var before : string
-        t |> success(report_child(t, "guarded before", run_child(child_cmd(fx, fx.guardedBefore), before), before, "GUARD true"), "a require below the guard")
+        t |> success(run_child_reported(t, "guarded before", child_cmd(fx, fx.guardedBefore), before, "GUARD true"), "a require below the guard")
         var dep : string
-        t |> success(report_child(t, "guarded dep", run_child(child_cmd(fx, fx.guardedDep), dep), dep, "GUARD true"), "a guard inside a module walked before the entry's own require")
+        t |> success(run_child_reported(t, "guarded dep", child_cmd(fx, fx.guardedDep), dep, "GUARD true"), "a guard inside a module walked before the entry's own require")
     }
     t |> run("-ignore-manifest compiles every descriptor, loads every C++ module on start, and writes no manifest") @(t : T?) {
         remove_result(fx.manifest)
         remove_result(fx.utManifest)
         var out : string
-        t |> success(report_child(t, "ignore", run_child(child_cmd(fx, fx.plain, "-ignore-manifest"), out), out, "PLAIN"), "the program runs")
+        t |> success(run_child_reported(t, "ignore", child_cmd(fx, fx.plain, "-ignore-manifest"), out, "PLAIN"), "the program runs")
         t |> equal("compiled (manifests ignored)", descriptor_line(out, UNIT_TEST_FOLDER), "the copied descriptor compiles:\n{out}")
         t |> equal("compiled (manifests ignored)", descriptor_line(out, "deferred_probe"), "the pure-das descriptor compiles:\n{out}")
         t |> success(find(out, "{UNIT_TEST_CLASS} <- ") >= 0 && find(out, ": loaded") >= 0, "the shared module loads on start:\n{out}")
@@ -241,7 +241,7 @@ def arms_guards_and_caches(t : T?; fx : Fixture) {
     }
     t |> run("a deferred row whose artifact is gone brings every deferred module in, and the require fails as on a cold start") @(t : T?) {
         var warm : string
-        t |> success(report_child(t, "rewarm", run_child(child_cmd(fx, fx.plain), warm), warm, "PLAIN"), "a cold start rewrites the manifest")
+        t |> success(run_child_reported(t, "rewarm", child_cmd(fx, fx.plain), warm, "PLAIN"), "a cold start rewrites the manifest")
         let text = fread(fx.utManifest)
         t |> success(find(text, "\ndm\t") >= 0, "the manifest carries the dm row: {text}")
         fwrite(fx.utManifest, replace(text, UNIT_TEST_ARTIFACT, "absent"))
@@ -256,10 +256,10 @@ def arms_guards_and_caches(t : T?; fx : Fixture) {
     t |> run("a module cache written by an eager start serves a lazy start, and -log-compile-time shows the reads and the timeline") @(t : T?) {
         let cache = "-module-cache \"{path_join(fx.tmp, "mc.bin")}\""
         var cold : string
-        t |> success(report_child(t, "cold cache", run_child(child_cmd(fx, fx.plain, "-ignore-manifest -log-compile-time", cache), cold), cold, "PLAIN"), "the eager start writes the cache")
+        t |> success(run_child_reported(t, "cold cache", child_cmd(fx, fx.plain, "-ignore-manifest -log-compile-time", cache), cold, "PLAIN"), "the eager start writes the cache")
         t |> success(find(cold, "startup: main total") >= 0 && find(cold, "\tmodule scan") >= 0 && find(cold, "\tshutdown ") >= 0, "the timeline prints its laps:\n{cold}")
         var warm : string
-        t |> success(report_child(t, "warm cache", run_child(child_cmd(fx, fx.plain, "-log-compile-time", cache), warm), warm, "PLAIN"), "the lazy start, which loads no C++ module, runs")
+        t |> success(run_child_reported(t, "warm cache", child_cmd(fx, fx.plain, "-log-compile-time", cache), warm, "PLAIN"), "the lazy start, which loads no C++ module, runs")
         t |> equal(-1, find(warm, "cumulative hash"), "a builtin module's hash does not depend on the loaded set:\n{warm}")
         t |> success(find(warm, "cache read took") >= 0, "the lazy start reads the eager start's records:\n{warm}")
     }
@@ -271,9 +271,9 @@ def arms_guards_and_caches(t : T?; fx : Fixture) {
         let stream = path_join(fx.tmp, "tests.ser")
         let dastest = path_join(get_das_root(), "dastest/dastest.das")
         var wrote : string
-        t |> success(report_child(t, "ser", run_child("{child_cmd(fx, dastest)} -- --test \"{testsDir}\" --ser \"{stream}\"", wrote), wrote, "Serialized 1 programs"), "the writer serializes the test program")
+        t |> success(run_child_reported(t, "ser", "{child_cmd(fx, dastest)} -- --test \"{testsDir}\" --ser \"{stream}\"", wrote, "Serialized 1 programs"), "the writer serializes the test program")
         var read : string
-        t |> success(report_child(t, "deser", run_child("{child_cmd(fx, dastest)} -- --test \"{testsDir}\" --deser \"{stream}\"", read), read, "1 tests, 0 error(s)"), "the reader runs the test from the stream")
+        t |> success(run_child_reported(t, "deser", "{child_cmd(fx, dastest)} -- --test \"{testsDir}\" --deser \"{stream}\"", read, "1 tests, 0 error(s)"), "the reader runs the test from the stream")
         t |> success(find(read, "[module] require {UNIT_TEST_MODULE}: loading the deferred {UNIT_TEST_CLASS}") >= 0, "the reader loaded the module the stream names:\n{read}")
     }
 }
@@ -287,7 +287,7 @@ def arm_fallback(t : T?; fx : Fixture) {
     }
     t |> run("a module whose C++ dependencies are deferred too brings every deferred module in") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "app", run_child(child_cmd(fx, fx.app), out), out, "APP"), "the program compiles against imgui_app")
+        t |> success(run_child_reported(t, "app", child_cmd(fx, fx.app), out, "APP"), "the program compiles against imgui_app")
         t |> success(find(out, "[module] require imgui_app: loading the deferred Module_imgui_app") >= 0, "imgui_app loads at its require:\n{out}")
         t |> success(find(out, "[module] loading every deferred module (") >= 0, "its initDependencies asks for glfw and imgui, so the rest loads:\n{out}")
     }
@@ -295,14 +295,14 @@ def arm_fallback(t : T?; fx : Fixture) {
         let imguiDir = copy_module(fx, "dasImgui", ["dasModuleImgui", "imguiApp", "imguiAppHeadless"])
         copy_module(fx, "dasGlfw", ["dasModuleGlfw"])
         var cold : string
-        t |> success(report_child(t, "half-warm cold", run_child(child_cmd(fx, fx.plain), cold), cold, "PLAIN"), "the copies record their manifests")
+        t |> success(run_child_reported(t, "half-warm cold", child_cmd(fx, fx.plain), cold, "PLAIN"), "the copies record their manifests")
         if (!copy_loaded(cold, imguiDir, "imguiApp")) {
             to_log(LOG_INFO, "test_deferred_modules: the copied imguiApp does not load from {imguiDir} - its libraries sit outside the copy - so the half-warm arm has nothing to observe\n")
             return
         }
         remove_result(path_join(imguiDir, ".das_module.manifest"))
         var out : string
-        t |> success(report_child(t, "half-warm", run_child(child_cmd(fx, fx.plain), out), out, "PLAIN"), "the program runs with imgui_app loaded on start and glfw waiting")
+        t |> success(run_child_reported(t, "half-warm", child_cmd(fx, fx.plain), out, "PLAIN"), "the program runs with imgui_app loaded on start and glfw waiting")
         if (!copy_loaded(out, imguiDir, "imguiApp")) {
             to_log(LOG_INFO, "test_deferred_modules: the copied imguiApp did not load on the half-warm start - its libraries sit outside the copy - so initialize had nothing to bring in:\n{out}\n")
             return

--- a/tests/module_cache/test_descriptor_manifest.das
+++ b/tests/module_cache/test_descriptor_manifest.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public

--- a/tests/module_cache/test_descriptor_manifest.das
+++ b/tests/module_cache/test_descriptor_manifest.das
@@ -94,7 +94,7 @@ def with_line_inserted(lines : array<string>; idx : int; text : string) : string
 def expect_rewrite(t : T?; cmd : string; manifest : string; text : string; why : string) {
     fwrite(manifest, text)
     var out : string
-    t |> success(report_child(t, why, run_child(cmd, out), out, "PROBE 42"), "'{why}': the require resolves without the manifest")
+    t |> success(run_child_reported(t, why, cmd, out, "PROBE 42"), "'{why}': the require resolves without the manifest")
     t |> equal("compiled ({why}), manifest written (1 row(s))", probe_line(out), "'{why}' recompiles and rewrites:\n{out}")
 }
 
@@ -148,7 +148,7 @@ def arms_record_and_replay(t : T?; fx : Fixture) {
     let manifest = fx.manifest
     t |> run("the first start compiles the descriptor and writes its manifest") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "cold", run_child(cmd, out), out, "PROBE 42"), "the require resolves through the compiled descriptor")
+        t |> success(run_child_reported(t, "cold", cmd, out, "PROBE 42"), "the require resolves through the compiled descriptor")
         t |> equal("compiled (no manifest), manifest written (1 row(s))", probe_line(out), "the trace says compiled and written:\n{out}")
         t |> success(stat(manifest).is_valid, "the manifest sits beside the descriptor")
         let text = fread(manifest)
@@ -165,13 +165,13 @@ def arms_record_and_replay(t : T?; fx : Fixture) {
     }
     t |> run("a descriptor that does not compile gets no manifest, and the run goes on") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "broken", run_child(cmd, out), out, "PROBE 42"), "the other module's require still resolves")
+        t |> success(run_child_reported(t, "broken", cmd, out, "PROBE 42"), "the other module's require still resolves")
         t |> equal("compiled with errors, no manifest", probe_line(out, "broken_probe"), "the trace names the failure:\n{out}")
         t |> success(!stat(path_join(fx.brokenDir, ".das_module.manifest")).is_valid, "nothing was written for it")
     }
     t |> run("the second start replays the manifest and never compiles the descriptor") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "warm", run_child(cmd, out), out, "PROBE 42"), "the require resolves through the replayed rows")
+        t |> success(run_child_reported(t, "warm", cmd, out, "PROBE 42"), "the require resolves through the replayed rows")
         t |> equal("replayed 1 row(s) (deferred 0)", probe_line(out), "the trace says replayed:\n{out}")
         t |> equal("replayed 1 row(s) (deferred 0)", probe_line(out, "dm_probe"), "the dm row replays too:\n{out}")
         t |> success(count_of(out, "Module_Absent <- ") >= 1, "the replayed dm row retries its dlopen:\n{out}")
@@ -179,10 +179,10 @@ def arms_record_and_replay(t : T?; fx : Fixture) {
     t |> run("an edited descriptor recompiles once and is replayed again after") @(t : T?) {
         fwrite(fx.descriptor, "{DESCRIPTOR}// edited\n")
         var out : string
-        t |> success(report_child(t, "edited", run_child(cmd, out), out, "PROBE 42"), "the edited descriptor still resolves the require")
+        t |> success(run_child_reported(t, "edited", cmd, out, "PROBE 42"), "the edited descriptor still resolves the require")
         t |> equal("compiled (descriptor changed), manifest written (1 row(s))", probe_line(out), "the stamp mismatch recompiles and rewrites:\n{out}")
         var again : string
-        t |> success(report_child(t, "edited warm", run_child(cmd, again), again, "PROBE 42"), "the rewritten manifest resolves the require")
+        t |> success(run_child_reported(t, "edited warm", cmd, again, "PROBE 42"), "the rewritten manifest resolves the require")
         t |> equal("replayed 1 row(s) (deferred 0)", probe_line(again), "the rewritten manifest replays:\n{again}")
     }
 }
@@ -195,7 +195,7 @@ def arms_rejections(t : T?; fx : Fixture) {
         let endAt = find(text, "\nend\t")
         fwrite(manifest, slice(text, 0, endAt + 1))   //! drop the end line - a write that died before its rename
         var out : string
-        t |> success(report_child(t, "damaged", run_child(cmd, out), out, "PROBE 42"), "the damaged manifest is not replayed")
+        t |> success(run_child_reported(t, "damaged", cmd, out, "PROBE 42"), "the damaged manifest is not replayed")
         t |> equal("compiled (no end line), manifest written (1 row(s))", probe_line(out), "the trace names the damage:\n{out}")
     }
     t |> run("every other rejection: no row of a manifest the reader cannot vouch for is replayed") @(t : T?) {
@@ -235,28 +235,28 @@ def arms_rejections(t : T?; fx : Fixture) {
         fwrite(helper, HELPER)
         fwrite(fx.descriptor, DESCRIPTOR_DEP)
         var out : string
-        t |> success(report_child(t, "dep", run_child(cmd, out), out, "PROBE 42"), "the require resolves through the helper's answer")
+        t |> success(run_child_reported(t, "dep", cmd, out, "PROBE 42"), "the require resolves through the helper's answer")
         t |> equal("compiled (descriptor changed), manifest written (1 row(s))", probe_line(out), "the dep descriptor compiles once:\n{out}")
         t |> success(find(fread(manifest), "/helper.das\t") >= 0, "the helper is stamped in the manifest, by the path the require resolved: {fread(manifest)}")
         var warm : string
-        t |> success(report_child(t, "dep warm", run_child(cmd, warm), warm, "PROBE 42"), "the dep descriptor replays")
+        t |> success(run_child_reported(t, "dep warm", cmd, warm, "PROBE 42"), "the dep descriptor replays")
         t |> equal("replayed 1 row(s) (deferred 0)", probe_line(warm), "an unchanged helper replays:\n{warm}")
         fwrite(helper, "{HELPER}// edited\n")
         var edited : string
-        t |> success(report_child(t, "dep edited", run_child(cmd, edited), edited, "PROBE 42"), "the require resolves after the helper edit")
+        t |> success(run_child_reported(t, "dep edited", cmd, edited, "PROBE 42"), "the require resolves after the helper edit")
         t |> equal("compiled (dependency changed), manifest written (1 row(s))", probe_line(edited), "the helper's stamp mismatch recompiles the descriptor:\n{edited}")
         var again : string
-        t |> success(report_child(t, "dep edited warm", run_child(cmd, again), again, "PROBE 42"), "the rewritten manifest resolves the require")
+        t |> success(run_child_reported(t, "dep edited warm", cmd, again, "PROBE 42"), "the rewritten manifest resolves the require")
         t |> equal("replayed 1 row(s) (deferred 0)", probe_line(again), "the rewritten manifest replays:\n{again}")
     }
     t |> run("a cross-compile target is part of the key: a --jit-target run never replays a native manifest") @(t : T?) {
         //! dasOpenGL's descriptor registers its module only when get_cross_platform_name() says emscripten -
         //! an argv input, so a native manifest must not serve a --jit-target run, nor the other way round
         var out : string
-        t |> success(report_child(t, "target", run_child("{cmd} -- --jit-target=wasm32-unknown-emscripten", out), out, "PROBE 42"), "the require resolves under the target")
+        t |> success(run_child_reported(t, "target", "{cmd} -- --jit-target=wasm32-unknown-emscripten", out, "PROBE 42"), "the require resolves under the target")
         t |> equal("compiled (compile target), manifest written (1 row(s))", probe_line(out), "the target keys the manifest apart:\n{out}")
         var back : string
-        t |> success(report_child(t, "native again", run_child(cmd, back), back, "PROBE 42"), "the native run resolves the require")
+        t |> success(run_child_reported(t, "native again", cmd, back, "PROBE 42"), "the native run resolves the require")
         t |> equal("compiled (compile target), manifest written (1 row(s))", probe_line(back), "the native run keys apart from the target's manifest:\n{back}")
     }
 }
@@ -267,19 +267,19 @@ def arms_opt_out_and_write_failures(t : T?; fx : Fixture) {
     t |> run("no_manifest() inside the descriptor makes it run on every start") @(t : T?) {
         fwrite(fx.descriptor, DESCRIPTOR_OPT_OUT)
         var out : string
-        t |> success(report_child(t, "opt-out", run_child(cmd, out), out, "PROBE 42"), "the opted-out descriptor resolves the require")
+        t |> success(run_child_reported(t, "opt-out", cmd, out, "PROBE 42"), "the opted-out descriptor resolves the require")
         t |> equal("compiled (descriptor changed), no_manifest recorded", probe_line(out), "the first run records the opt-out:\n{out}")
         let text = fread(manifest)
         t |> success(find(text, "\nno_manifest\n") >= 0 && find(text, "\nnp\t") < 0, "the manifest carries the flag and no rows: {text}")
         var again : string
-        t |> success(report_child(t, "opt-out warm", run_child(cmd, again), again, "PROBE 42"), "the opted-out descriptor resolves the require again")
+        t |> success(run_child_reported(t, "opt-out warm", cmd, again, "PROBE 42"), "the opted-out descriptor resolves the require again")
         t |> equal("compiled (no_manifest)", probe_line(again), "every later start compiles it:\n{again}")
     }
     t |> run("a recorded argument the format cannot carry leaves the manifest unwritten") @(t : T?) {
         fwrite(fx.descriptor, DESCRIPTOR_TABBED)
         let before = fread(manifest)
         var out : string
-        t |> success(report_child(t, "tabbed", run_child(cmd, out), out, "PROBE 42"), "the descriptor still resolves the require")
+        t |> success(run_child_reported(t, "tabbed", cmd, out, "PROBE 42"), "the descriptor still resolves the require")
         t |> equal("compiled (descriptor changed), manifest not written: a recorded argument contains a tab or newline", probe_line(out), "the trace names the field:\n{out}")
         t |> equal(before, fread(manifest), "the stale manifest is left as it was")
     }
@@ -288,12 +288,12 @@ def arms_opt_out_and_write_failures(t : T?; fx : Fixture) {
         remove_result(manifest)
         mkdir_result(fx.manifestTmp)   //! a directory where the .tmp goes: the create fails on every platform, root or not
         var out : string
-        t |> success(report_child(t, "no tmp", run_child(cmd, out), out, "PROBE 42"), "the require resolves without a manifest")
+        t |> success(run_child_reported(t, "no tmp", cmd, out, "PROBE 42"), "the require resolves without a manifest")
         t |> success(probe_line(out) |> starts_with("compiled (no manifest), manifest not written: cannot create "), "the trace names the create failure:\n{out}")
         rmdir_result(fx.manifestTmp)
         mkdir_result(manifest)   //! a directory where the manifest goes: the rename fails
         var again : string
-        t |> success(report_child(t, "no rename", run_child(cmd, again), again, "PROBE 42"), "the require resolves without a manifest")
+        t |> success(run_child_reported(t, "no rename", cmd, again, "PROBE 42"), "the require resolves without a manifest")
         t |> success(find(probe_line(again), ", manifest not written: cannot rename ") >= 0, "the trace names the rename failure:\n{again}")
         t |> success(!stat(fx.manifestTmp).is_valid, "the failed rename left no .tmp behind")
         rmdir_result(manifest)

--- a/tests/module_cache/test_generic_instance_origin.das
+++ b/tests/module_cache/test_generic_instance_origin.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public

--- a/tests/module_cache/test_macro_dep_invalidate.das
+++ b/tests/module_cache/test_macro_dep_invalidate.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public

--- a/tests/module_cache/test_module_groups.das
+++ b/tests/module_cache/test_module_groups.das
@@ -80,6 +80,13 @@ def run_driver(fx : Fixture; script : string; var out : string&; cache : string 
     return run_child("{fx.cmdPrefix} {cache} \"{script}\"", out)
 }
 
+//! run_driver, reported as run_child_reported reports: the run is its own statement, never an
+//! argument beside the `out` it writes
+def run_driver_reported(t : T?; phase : string; fx : Fixture; script : string; var out : string&; marker : string; cache : string = "-no-module-cache") : bool {
+    let rc = run_driver(fx, script, out, cache)
+    return report_child(t, phase, rc, out, marker)
+}
+
 //! the scan trace line for a module's descriptor; a replay verdict keeps its deferred count and
 //! drops the two timings
 def descriptor_verdict(out : string; mod : string) : string {
@@ -113,7 +120,7 @@ def arms_expand(t : T?; fx : Fixture) {
     let useGroup = write_driver(fx, "use_group.das", "require [probe_group]", "alpha_value() + beta_value()")
     t |> run("a cold start compiles the descriptors and the group brings both members in, a member row's guard the build lacks left out") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "cold", run_driver(fx, useGroup, out), out, "PROBE 11"), "both members resolve")
+        t |> success(run_driver_reported(t, "cold", fx, useGroup, out, "PROBE 11"), "both members resolve")
         t |> equal("compiled (no manifest), manifest written (3 row(s))", descriptor_verdict(out, "grp_alpha"), "alpha's manifest carries its path row and its two group rows:\n{out}")
         let manifest = fread(path_join(fx.alphaDir, ".das_module.manifest"))
         t |> success(find(manifest, "\ngrp\tprobe_group\tgrp_alpha/alpha\tmath\n") >= 0, "the group row is written with its guard:\n{manifest}")
@@ -121,7 +128,7 @@ def arms_expand(t : T?; fx : Fixture) {
     }
     t |> run("a warm start replays the group rows and the group still brings both members in") @(t : T?) {
         var out : string
-        t |> success(report_child(t, "warm", run_driver(fx, useGroup, out), out, "PROBE 11"), "both members resolve from the replayed rows")
+        t |> success(run_driver_reported(t, "warm", fx, useGroup, out, "PROBE 11"), "both members resolve from the replayed rows")
         t |> equal("replayed 3 row(s) (deferred 0)", descriptor_verdict(out, "grp_alpha"), "alpha's descriptor replays:\n{out}")
         t |> equal("replayed 3 row(s) (deferred 0)", descriptor_verdict(out, "grp_beta"), "beta's descriptor replays:\n{out}")
         t |> equal("replayed 2 row(s) (deferred 0)", descriptor_verdict(out, "grp_delta"), "delta's guarded row and its duplicate of alpha's replay:\n{out}")
@@ -129,20 +136,20 @@ def arms_expand(t : T?; fx : Fixture) {
     t |> run("`require[group]` with no space, and the group name on its own line, are the same require") @(t : T?) {
         var out : string
         let script = write_driver(fx, "use_nospace.das", "require[probe_group]", "alpha_value() + beta_value()")
-        t |> success(report_child(t, "no space", run_driver(fx, script, out), out, "PROBE 11"), "the collector and the parser read the spelling alike")
+        t |> success(run_driver_reported(t, "no space", fx, script, out, "PROBE 11"), "the collector and the parser read the spelling alike")
         let multi = write_driver(fx, "use_multiline.das", "require [\n    probe_group\n]", "alpha_value() + beta_value()")
-        t |> success(report_child(t, "multi-line", run_driver(fx, multi, out), out, "PROBE 11"), "a newline inside the brackets is nothing to the walk, as to the parser")
+        t |> success(run_driver_reported(t, "multi-line", fx, multi, out, "PROBE 11"), "a newline inside the brackets is nothing to the walk, as to the parser")
     }
     t |> run("a member row's path guard is resolved as the require's would be, in the walk, the parser and the calls") @(t : T?) {
         var out : string
         let taken = write_driver(fx, "use_path_group.das", "require [path_group]", "alpha_value()")
-        t |> success(report_child(t, "path guard taken", run_driver(fx, taken, out), out, "PROBE 1"), "alpha's row, guarded on a path the fixture has, joins")
+        t |> success(run_driver_reported(t, "path guard taken", fx, taken, out, "PROBE 1"), "alpha's row, guarded on a path the fixture has, joins")
         let dropped = write_driver(fx, "use_path_group_dropped.das", "require [path_group]", "beta_value()")
         let rc = run_driver(fx, dropped, out)
         t |> success(rc != 0 && find(out, "beta_value") >= 0, "beta's row, guarded on a path the fixture lacks, is dropped: rc={rc}\n{out}")
         let calls = path_join(fx.tmp, "use_path_calls.das")
         fwrite(calls, CALL_PATH_GROUP)
-        t |> success(report_child(t, "path calls", run_driver(fx, calls, out), out, "PROBE done"), "call_module_group over the path-guarded group runs")
+        t |> success(run_driver_reported(t, "path calls", fx, calls, out, "PROBE done"), "call_module_group over the path-guarded group runs")
         t |> success(find(out, "ENTRY alpha 3") >= 0 && find(out, "ENTRY beta") < 0, "the calls take the same members the require took:\n{out}")
     }
     t |> run("a guard the build lacks drops the group; a guard the build has takes it") @(t : T?) {
@@ -151,19 +158,19 @@ def arms_expand(t : T?; fx : Fixture) {
         let rc = run_driver(fx, dropped, out)
         t |> success(rc != 0 && find(out, "alpha_value") >= 0, "with the group dropped nothing declares alpha_value: rc={rc}\n{out}")
         let taken = write_driver(fx, "use_guard_present.das", "require ?math [probe_group]", "alpha_value() + beta_value()")
-        t |> success(report_child(t, "guard taken", run_driver(fx, taken, out), out, "PROBE 11"), "the guarded group expands")
+        t |> success(run_driver_reported(t, "guard taken", fx, taken, out, "PROBE 11"), "the guarded group expands")
     }
     t |> run("a group nothing registered adds nothing") @(t : T?) {
         var out : string
         let script = write_driver(fx, "use_empty.das", "require [nobody_registered_here]", "0")
-        t |> success(report_child(t, "empty", run_driver(fx, script, out), out, "PROBE 0"), "the program compiles with no dependency added")
+        t |> success(run_driver_reported(t, "empty", fx, script, out, "PROBE 0"), "the program compiles with no dependency added")
     }
     t |> run("`public` on the group re-exports every member; without it the members stay private") @(t : T?) {
         var out : string
         let viaPublic = write_driver(fx, "use_public.das", "require mid", "alpha_value() + beta_value()")
-        t |> success(report_child(t, "public", run_driver(fx, viaPublic, out), out, "PROBE 11"), "a module requiring the group public re-exports the members")
+        t |> success(run_driver_reported(t, "public", fx, viaPublic, out, "PROBE 11"), "a module requiring the group public re-exports the members")
         let viaTab = write_driver(fx, "use_public_tab.das", "require mid_tab", "alpha_value() + beta_value()")
-        t |> success(report_child(t, "public after a tab", run_driver(fx, viaTab, out), out, "PROBE 11"), "the collector reads `public` after any whitespace, as the parser does")
+        t |> success(run_driver_reported(t, "public after a tab", fx, viaTab, out, "PROBE 11"), "the collector reads `public` after any whitespace, as the parser does")
         let viaPrivate = write_driver(fx, "use_private.das", "require mid_private", "alpha_value()")
         let rc = run_driver(fx, viaPrivate, out)
         t |> success(rc != 0 && find(out, "alpha_value") >= 0, "a private group require keeps the members out of the requirer's requirer: rc={rc}\n{out}")
@@ -181,7 +188,7 @@ def arms_calls(t : T?; fx : Fixture) {
         var out : string
         let script = path_join(fx.tmp, "use_call.das")
         fwrite(script, CALL_GROUP)
-        t |> success(report_child(t, "call", run_driver(fx, script, out), out, "PROBE done"), "the expansion compiles and runs")
+        t |> success(run_driver_reported(t, "call", fx, script, out, "PROBE done"), "the expansion compiles and runs")
         let alphaAt = find(out, "ENTRY alpha 7")
         let betaAt = find(out, "ENTRY beta 7")
         t |> success(alphaAt >= 0 && betaAt >= 0 && alphaAt < betaAt, "both entries ran with the argument, alpha first:\n{out}")
@@ -196,11 +203,11 @@ def arms_calls(t : T?; fx : Fixture) {
         t |> success(rc != 0 && find(out, "call_module_group expects") >= 0, "a call without the entry name is a macro error: rc={rc}\n{out}")
         let sideEffect = path_join(fx.tmp, "use_call_side_effect.das")
         fwrite(sideEffect, CALL_GROUP_SIDE_EFFECT)
-        t |> success(report_child(t, "side effect", run_driver(fx, sideEffect, out), out, "PROBE 1"), "an argument with a side effect is evaluated once for every member")
+        t |> success(run_driver_reported(t, "side effect", fx, sideEffect, out, "PROBE 1"), "an argument with a side effect is evaluated once for every member")
         t |> success(find(out, "ENTRY alpha 1") >= 0 && find(out, "ENTRY beta 1") >= 0, "every member receives the one value:\n{out}")
         let shadow = path_join(fx.tmp, "use_call_shadow.das")
         fwrite(shadow, CALL_GROUP_SHADOW)
-        t |> success(report_child(t, "shadow", run_driver(fx, shadow, out), out, "PROBE 1 5"), "the bound argument's name is the expansion's own, so a caller's local of the plain spelling is untouched")
+        t |> success(run_driver_reported(t, "shadow", fx, shadow, out, "PROBE 1 5"), "the bound argument's name is the expansion's own, so a caller's local of the plain spelling is untouched")
     }
     t |> run("a descriptor registering an empty member is refused by name, and the run goes on") @(t : T?) {
         var out : string
@@ -233,13 +240,13 @@ def arm_cache_stamps_the_expansion(t : T?; fx : Fixture) {
         let script = write_driver(fx, "use_cache.das", "require grp_beta/beta\nrequire mid", "alpha_value()")
         fwrite(path_join(fx.betaDir, ".das_module"), DESCRIPTOR_BETA_OUTSIDE)
         var out : string
-        t |> success(report_child(t, "cache write", run_driver(fx, script, out, cache), out, "PROBE 1"), "the cache is written with beta outside the group")
-        t |> success(report_child(t, "cache serve", run_driver(fx, script, out, cache), out, "PROBE 1"), "the unchanged tree serves")
+        t |> success(run_driver_reported(t, "cache write", fx, script, out, "PROBE 1", cache), "the cache is written with beta outside the group")
+        t |> success(run_driver_reported(t, "cache serve", fx, script, out, "PROBE 1", cache), "the unchanged tree serves")
         t |> success(find(out, "FALLBACK") < 0, "nothing cuts the unchanged tree off:\n{out}")
         fwrite(path_join(fx.betaDir, ".das_module"), DESCRIPTOR_BETA)
-        t |> success(report_child(t, "member joined", run_driver(fx, script, out, cache), out, "PROBE 1"), "the run with beta in the group still answers")
+        t |> success(run_driver_reported(t, "member joined", fx, script, out, "PROBE 1", cache), "the run with beta in the group still answers")
         t |> success(find(out, "re-parsed from") >= 0 && find(out, "mid.das") >= 0 && find(out, "(require set changed)") >= 0, "the requirer's record is the cutoff, named with its reason:\n{out}")
-        t |> success(report_child(t, "rewritten", run_driver(fx, script, out, cache), out, "PROBE 1"), "the rewritten cache serves again")
+        t |> success(run_driver_reported(t, "rewritten", fx, script, out, "PROBE 1", cache), "the rewritten cache serves again")
         t |> success(find(out, "FALLBACK") < 0, "the rewritten cache carries the grown expansion:\n{out}")
     }
 }

--- a/tests/module_cache/test_module_groups.das
+++ b/tests/module_cache/test_module_groups.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public

--- a/tests/module_cache/test_require_module_now.das
+++ b/tests/module_cache/test_require_module_now.das
@@ -147,15 +147,15 @@ def test_require_module_now_children(t : T?) {
         let cacheFile = path_join(tmp, "late.dascache")
         let cached = "{das_exe()} -dasroot {get_das_root()} -module-cache \"{cacheFile}\" \"{script}\""
         var out : string
-        t |> success(report_child(t, "cold", run_child(cached, out), out, "LATE 42"), "the cold run answers through the late module")
+        t |> success(run_child_reported(t, "cold", cached, out, "LATE 42"), "the cold run answers through the late module")
         t |> success(find(out, "compiler took") >= 0 && find(out, "mc_late_mod") >= 0, "the cold run compiles the fixture:\n{out}")
         t |> equal(count_prefix(tmp, "late~"), 0, "no cache of the late walk's own sits beside the host's")
         let coldSize = long_length(fread(cacheFile))
-        t |> success(report_child(t, "warm", run_child(cached, out), out, "LATE 42"), "the warm run answers through the late module")
+        t |> success(run_child_reported(t, "warm", cached, out, "LATE 42"), "the warm run answers through the late module")
         t |> success(find(out, "cache read took") >= 0 && find(out, "mc_late_mod") >= 0 && find(out, "compiler took") < 0, "the warm run serves the fixture from the host's cache:\n{out}")
         t |> equal(long_length(fread(cacheFile)), coldSize, "the warm run rewrites nothing")
         let uncached = "{das_exe()} -dasroot {get_das_root()} -no-module-cache \"{script}\""
-        t |> success(report_child(t, "no cache", run_child(uncached, out), out, "LATE 42"), "the run with no module cache answers too")
+        t |> success(run_child_reported(t, "no cache", uncached, out, "LATE 42"), "the run with no module cache answers too")
         t |> success(find(out, "compiler took") >= 0 && find(out, "cache read took") < 0, "with no module cache the late walk compiles:\n{out}")
         let running = path_join(tmp, "use_running.das")
         fwrite(running, running_driver())
@@ -180,12 +180,12 @@ def test_require_module_now_children(t : T?) {
         let cacheFile = path_join(tmp, "nested.dascache")
         let cached = "{das_exe()} -dasroot {get_das_root()} -module-cache \"{cacheFile}\" \"{script}\""
         var out : string
-        t |> success(report_child(t, "cold", run_child(cached, out), out, "LATE 42"), "the macro's late require answers on the cold run")
+        t |> success(run_child_reported(t, "cold", cached, out, "LATE 42"), "the macro's late require answers on the cold run")
         let coldSize = long_length(fread(cacheFile))
-        t |> success(report_child(t, "warm", run_child(cached, out), out, "LATE 42"), "the warm run answers")
+        t |> success(run_child_reported(t, "warm", cached, out, "LATE 42"), "the warm run answers")
         t |> success(find(out, "FALLBACK") < 0 && find(out, "module order changed") < 0, "the warm read is not cut by the nested walk's modules:\n{out}")
         t |> equal(long_length(fread(cacheFile)), coldSize, "the warm run rewrites nothing")
-        t |> success(report_child(t, "warm again", run_child(cached, out), out, "LATE 42"), "the second warm run answers")
+        t |> success(run_child_reported(t, "warm again", cached, out, "LATE 42"), "the second warm run answers")
         t |> success(find(out, "FALLBACK") < 0, "the second warm read is clean too:\n{out}")
         fwrite(script, macro_driver("    let y : int = \"not an int\"\n"))
         let rc = run_child(cached, out)

--- a/tests/module_cache/test_require_module_now.das
+++ b/tests/module_cache/test_require_module_now.das
@@ -1,4 +1,5 @@
 options gen2
+options _lint = "LINT030"   // a child run is never an argument beside the out it writes
 options indenting = 4
 
 require dastest/testing_boost public

--- a/tests/watchdog/test_watchdog.das
+++ b/tests/watchdog/test_watchdog.das
@@ -2,6 +2,7 @@ options gen2
 options no_aot
 
 require dastest/testing_boost public
+require math
 require daslib/fio
 require daslib/json_boost
 require daslib/strings_boost
@@ -19,6 +20,13 @@ def das_exe() : string {
 
 def fixture_path() : string {
     return path_join(get_das_root(), "tests/watchdog/_fixture_watchdog_child.das")
+}
+
+//! a deadline on a child's startup or exit, never a claim about speed: a Debug host compiles
+//! what the child requires several times slower, so the deadline stretches threefold there,
+//! never past five minutes
+def guard(seconds : float) : float {
+    return shared_module_extension() == "_debug.shared_module" ? min(seconds * 3.0, 300.0) : seconds
 }
 
 def make_temp(t : T?; prefix : string) : string {
@@ -94,7 +102,7 @@ def run_bounded(t : T?; var sup : Supervisor?; seconds : float) : int {
             t |> failure("supervision did not end within {seconds} s: {event_names(read_events(sup.cfg.log))}")
             sup->request_stop()
             let grace = ref_time_ticks()
-            while (!sup->tick() && get_time_usec(grace) < 30000000) {
+            while (!sup->tick() && float(get_time_usec(grace)) < guard(30.0) * 1000000.0) {
                 sleep(50u)
             }
             break
@@ -113,7 +121,7 @@ def jit_runs() : bool {
     var code : int
     unsafe {
         var p = spawn_process(argv, "", no_env)
-        code = process_wait(p, 60.0)
+        code = process_wait(p, guard(60.0))
         close_process(p)
     }
     return code == 2
@@ -281,10 +289,10 @@ def spawn_tray_watchdog(root, url, mode : string; env : array<string>) : process
     return unsafe(spawn_process(argv, root, env))
 }
 
-//! `unavailable`, `ready` (the child runs under a live icon), or empty after 30 s.
+//! `unavailable`, `ready` (the child runs under a live icon), or empty after the 30 s guard.
 def wait_for_tray(var wd : process; log_path : string) : string {
     let started = ref_time_ticks()
-    while (get_time_usec(started) < 30000000) {
+    while (float(get_time_usec(started)) < guard(30.0) * 1000000.0) {
         unsafe(process_drain(wd) $(_line) {
         })
         let events <- read_events(log_path)
@@ -340,7 +348,7 @@ def with_tray_watchdog(t : T?; url, mode : string; env : array<string>; blk : bl
 //! Ends a parked run the way an operator's Shutdown would on a platform the test cannot click.
 def stop_parked_run(t : T?; var wd : process; root : string) {
     fwrite(tray_stop_file(root), "stop\n")
-    t |> equal(wait_exit_draining(wd, 30.0), 0, "supervision ended with 0 once the child left on the stop file")
+    t |> equal(wait_exit_draining(wd, guard(30.0)), 0, "supervision ended with 0 once the child left on the stop file")
     let events <- read_events(tray_log_path(root))
     t |> equal(count_event(events, "intentional_shutdown"), 1)
     t |> equal(count_event(events, "watchdog_stopped"), 1)
@@ -381,7 +389,7 @@ def test_tray_shutdown_over_private_bus(t : T?) {
                 let tooltip = dbus_send_to(address, dest, true, "/StatusNotifierItem", "org.freedesktop.DBus.Properties.Get", ["string:org.kde.StatusNotifierItem", "string:ToolTip"])
                 dump_has(t, tooltip, "wdtray - running", "the tooltip carries the same line")
                 dbus_send_to(address, dest, false, "/MenuBar", "com.canonical.dbusmenu.Event", ["int32:{TRAY_SHUTDOWN_ID}", "string:clicked", "variant:int32:0", "uint32:0"])
-                t |> equal(wait_exit_draining(wd, 30.0), 0, "supervision ended with 0 after the tray's Shutdown")
+                t |> equal(wait_exit_draining(wd, guard(30.0)), 0, "supervision ended with 0 after the tray's Shutdown")
                 let events <- read_events(tray_log_path(root))
                 t |> equal(count_event(events, "tray_started"), 1)
                 t |> equal(count_event(events, "tray_shutdown_requested"), 1)
@@ -461,7 +469,7 @@ def test_tray_supervision_completes(t : T?) {
     t |> run("crash-then-ok under --tray ends with 0 with or without an icon") @(t : T?) {
         let no_env : array<string>
         with_tray_watchdog(t, "", "crash-then-ok", no_env) $(var wd; root; verdict) {
-            t |> equal(wait_exit_draining(wd, 60.0), 0, "supervision ended with 0 (tray {verdict})")
+            t |> equal(wait_exit_draining(wd, guard(60.0)), 0, "supervision ended with 0 (tray {verdict})")
             let events <- read_events(tray_log_path(root))
             t |> equal(count_event(events, "child_started"), 2)
             t |> equal(count_event(events, "crash"), 1)
@@ -493,7 +501,7 @@ def test_heaps_stay_bounded_under_a_chatty_child(t : T?) {
         argv |> push_from(child_args(state_dir, "chatty"))
         let no_env : array<string>
         var wd = unsafe(spawn_process(argv, root, no_env))
-        t |> equal(wait_exit_draining(wd, 120.0), 0, "supervision ended with 0")
+        t |> equal(wait_exit_draining(wd, guard(120.0)), 0, "supervision ended with 0")
         unsafe {
             close_process(wd)
         }
@@ -895,7 +903,7 @@ def test_supervise_crash_then_clean_exit(t : T?) {
         var sup = watchdog_start(program_mode_args(root, state_dir, "crash-then-ok"), root, 0, code)
         t |> success(sup != null, "supervision started (code {code})")
         if (sup == null) return
-        t |> equal(run_bounded(t, sup, 60.0), 0, "supervision ends with 0 after the child's clean exit")
+        t |> equal(run_bounded(t, sup, guard(60.0)), 0, "supervision ends with 0 after the child's clean exit")
         let events <- read_events(sup.cfg.log)
         t |> equal(count_event(events, "child_started"), 2, "the child ran twice: {event_names(events)}")
         t |> equal(event_int(events, "crash", "code"), 9, "the first exit was reported as a crash")
@@ -936,7 +944,7 @@ def test_supervise_config_restart(t : T?) {
         var sup = watchdog_start(program_mode_args(root, state_dir, "config-restart"), root, 0, code)
         t |> success(sup != null, "supervision started (code {code})")
         if (sup == null) return
-        t |> equal(run_bounded(t, sup, 60.0), 0)
+        t |> equal(run_bounded(t, sup, guard(60.0)), 0)
         let events <- read_events(sup.cfg.log)
         t |> equal(count_event(events, "config_restart_relaunch"), 1, "{event_names(events)}")
         t |> equal(count_event(events, "crash"), 0, "no crash was reported")
@@ -964,7 +972,7 @@ def test_supervise_tune_bootstrap(t : T?) {
         var sup = watchdog_start(args, root, 0, code)
         t |> success(sup != null, "supervision started (code {code})")
         if (sup == null) return
-        t |> equal(run_bounded(t, sup, 60.0), 0)
+        t |> equal(run_bounded(t, sup, guard(60.0)), 0)
         let events <- read_events(sup.cfg.log)
         t |> equal(count_event(events, "tune_bootstrap_complete"), 1, "{event_names(events)}")
         t |> equal(count_event(events, "crash"), 0)
@@ -992,7 +1000,7 @@ def test_supervise_tune_abort_backs_off(t : T?) {
         var sup = watchdog_start(args, root, 0, code)
         t |> success(sup != null, "supervision started (code {code})")
         if (sup == null) return
-        t |> equal(run_bounded(t, sup, 60.0), 0)
+        t |> equal(run_bounded(t, sup, guard(60.0)), 0)
         let events <- read_events(sup.cfg.log)
         t |> equal(count_event(events, "tune_incomplete"), 1, "{event_names(events)}")
         t |> equal(count_event(events, "tune_bootstrap_complete"), 0, "no marker, no bootstrap")
@@ -1022,7 +1030,7 @@ def test_request_stop_terminates_with_no_shutdown(t : T?) {
         if (sup == null) return
         var parked = false
         let started = ref_time_ticks()
-        while (!parked && get_time_usec(started) < 15000000) {
+        while (!parked && float(get_time_usec(started)) < guard(15.0) * 1000000.0) {
             sup->tick()
             for (ev in read_events(sup.cfg.log)) {
                 if ((ev?["event"] ?? "") == "child" && (ev?["message"] ?? "") == "parked") {
@@ -1034,7 +1042,7 @@ def test_request_stop_terminates_with_no_shutdown(t : T?) {
         sup->request_stop()
         var done = false
         let stop_started = ref_time_ticks()
-        while (!done && get_time_usec(stop_started) < 15000000) {
+        while (!done && float(get_time_usec(stop_started)) < guard(15.0) * 1000000.0) {
             done = sup->tick()
         }
         t |> success(done, "supervision ended after the stop request")
@@ -1068,7 +1076,7 @@ def test_request_stop_uses_the_stop_file(t : T?) {
         if (sup == null) return
         var parked = false
         let started = ref_time_ticks()
-        while (!parked && get_time_usec(started) < 15000000) {
+        while (!parked && float(get_time_usec(started)) < guard(15.0) * 1000000.0) {
             sup->tick()
             for (ev in read_events(sup.cfg.log)) {
                 if ((ev?["event"] ?? "") == "child" && (ev?["message"] ?? "") == "parked") {
@@ -1080,7 +1088,7 @@ def test_request_stop_uses_the_stop_file(t : T?) {
         sup->request_stop()
         var done = false
         let stop_started = ref_time_ticks()
-        while (!done && get_time_usec(stop_started) < 15000000) {
+        while (!done && float(get_time_usec(stop_started)) < guard(15.0) * 1000000.0) {
             done = sup->tick()
         }
         t |> success(done, "supervision ended after the stop request")

--- a/utils/daslang-live/main.cpp
+++ b/utils/daslang-live/main.cpp
@@ -1018,6 +1018,8 @@ int main(int argc, char * argv[]) {
 #endif
     Module::Initialize();
 
+    if (auto loader = getDeferredModuleLoader()) loader("live_host");
+
     // Load live_host DLL functions
     if (!load_live_host_functions()) {
         tout << "WARNING: live_host module not found — lifecycle functions will use defaults\n";

--- a/utils/internal/review-md/test_walkers.das
+++ b/utils/internal/review-md/test_walkers.das
@@ -187,6 +187,11 @@ def test_dasllama_gate_fixtures(t : T?) {
     let after_tail = spawn_at(fixture, [path_join(fixture, "modules/dasLLAMA/REVIEW.das")])
     t |> equal(0, after_tail.rc, "a line the one-liner's window must not absorb left the stamp alone: {after_tail.out}")
 
+    // the same closure checked out with CRLF line ends stamps as the LF one does
+    write_at(t, fixture, "modules/dasLLAMA/dasllama/dasllama_image.das", replace(dasllama_image_text("64l", "cur", "2"), "\n", "\r\n"))
+    let crlf = spawn_at(fixture, [path_join(fixture, "modules/dasLLAMA/REVIEW.das")])
+    t |> equal(0, crlf.rc, "a CRLF checkout of the closure keeps the stamp: {crlf.out}")
+
     // one violation per miss class - the needle list is the census
     write_at(t, fixture, "modules/dasLLAMA/dasllama/dasllama.das",
         "options gen2\n\ndef covered_fn() \{\n\}\n\ndef hidden_fn() \{\n\}\n\ndef bound_fn() \{\n\}\n")

--- a/utils/lint/tests/lint030_argument_order.das
+++ b/utils/lint/tests/lint030_argument_order.das
@@ -6,7 +6,7 @@ options _lint = "LINT030"   // the rule ships default-off; the fixture arms it
 // interpreter and the JIT go left to right, the AOT C++ goes whichever way the compiler
 // does - so the read sees the value before or after the write by the tier's choice.
 
-expect 50503:6
+expect 50503:7
 
 require daslib/lint
 
@@ -31,6 +31,19 @@ def pair(a, b : int) : int {
 
 def report(rc : int; text : string) : bool {
     return rc == 0 && !empty(text)
+}
+
+def take_ref(s : string&; rc : int) : int {
+    return rc + length(s)
+}
+
+def bump_copy(var x : int) : int {
+    x++
+    return x
+}
+
+def call_block(blk : block<(q : int) : int>) : int {
+    return invoke(blk, 1)
 }
 
 // === Positives - a sibling argument reads what the nested call writes ===
@@ -61,6 +74,12 @@ def bad_writer_in_expression(var x : int) : int {
     return pair(1 + bump(x), x)   // LINT030
 }
 
+// a block handed to a nested call runs while that argument is evaluated - its reads are the
+// argument's, unlike a block the outer call itself takes (below), which runs after every argument
+def bad_block_invoked_by_sibling(var x : int) : int {
+    return pair(bump(x), call_block($(q : int) : int { return x + q }))   // LINT030
+}
+
 // === Negatives ===
 
 // the write is a statement of its own, the read comes after it
@@ -79,10 +98,27 @@ def good_other_variable(var x : int; y : int) : int {
     return pair(bump(x), y)
 }
 
+// the outer call takes the written variable by reference - the callee sees its final state
+// whatever the order
+def good_outer_takes_by_ref() : int {
+    var out : string
+    return take_ref(out, fill(out))
+}
+
+// the nested call writes its own copy - a by-value parameter reaches nothing of the caller's
+def good_by_value_parameter(var x : int) : int {
+    return pair(bump_copy(x), x)
+}
+
 // a lambda argument runs later, not while the arguments are evaluated
 def good_lambda_reads_later(var x : int) : int {
     let read = @(y : int) : int { return y }
     return pair(bump(x), invoke(read, 0))
+}
+
+// a marked site is the author's call
+def good_marked(var x : int) : int {
+    return pair(bump(x), x)   // nolint:LINT030
 }
 
 // a call inside a block argument's body runs later too - its reads stay inside the block

--- a/utils/lint/tests/lint030_argument_order.das
+++ b/utils/lint/tests/lint030_argument_order.das
@@ -6,7 +6,7 @@ options _lint = "LINT030"   // the rule ships default-off; the fixture arms it
 // interpreter and the JIT go left to right, the AOT C++ goes whichever way the compiler
 // does - so the read sees the value before or after the write by the tier's choice.
 
-expect 50503:5
+expect 50503:6
 
 require daslib/lint
 
@@ -56,6 +56,11 @@ def bad_array(var xs : array<int>) : int {
     return pair(grow(xs), length(xs))   // LINT030
 }
 
+// the writing call sits inside an expression, not at the argument's root
+def bad_writer_in_expression(var x : int) : int {
+    return pair(1 + bump(x), x)   // LINT030
+}
+
 // === Negatives ===
 
 // the write is a statement of its own, the read comes after it
@@ -78,4 +83,18 @@ def good_other_variable(var x : int; y : int) : int {
 def good_lambda_reads_later(var x : int) : int {
     let read = @(y : int) : int { return y }
     return pair(bump(x), invoke(read, 0))
+}
+
+// a call inside a block argument's body runs later too - its reads stay inside the block
+def good_block_call_reads_later(var x : int) : int {
+    var seen : int
+    pair(bump(x), 0) |> with_value() $(v : int) {
+        seen = pair(x, v)
+    }
+    return seen
+}
+
+def with_value(v : int; blk : block<(v : int) : void>) : int {
+    invoke(blk, v)
+    return v
 }

--- a/utils/lint/tests/lint030_argument_order.das
+++ b/utils/lint/tests/lint030_argument_order.das
@@ -2,9 +2,9 @@ options gen2
 options auto_inline_functions = false   // lint fixtures assert SOURCE shapes; splices rewrite them
 options _lint = "LINT030"   // the rule ships default-off; the fixture arms it
 // LINT030: a call whose argument list reads a variable that a nested call in another
-// argument writes by reference. The order arguments are evaluated in is not defined - the
-// interpreter and the JIT go left to right, the AOT C++ goes whichever way the compiler
-// does - so the read sees the value before or after the write by the tier's choice.
+// argument writes by reference. The order arguments are evaluated in is not defined and
+// differs between tiers, so the read sees the value before or after the write by the tier's
+// choice.
 
 expect 50503:7
 

--- a/utils/lint/tests/lint030_argument_order.das
+++ b/utils/lint/tests/lint030_argument_order.das
@@ -1,0 +1,81 @@
+options gen2
+options auto_inline_functions = false   // lint fixtures assert SOURCE shapes; splices rewrite them
+options _lint = "LINT030"   // the rule ships default-off; the fixture arms it
+// LINT030: a call whose argument list reads a variable that a nested call in another
+// argument writes by reference. The order arguments are evaluated in is not defined - the
+// interpreter and the JIT go left to right, the AOT C++ goes whichever way the compiler
+// does - so the read sees the value before or after the write by the tier's choice.
+
+expect 50503:5
+
+require daslib/lint
+
+def bump(var x : int&) : int {
+    x++
+    return x
+}
+
+def fill(var s : string&) : int {
+    s = "filled"
+    return 0
+}
+
+def grow(var xs : array<int>) : int {
+    xs |> push(1)
+    return length(xs)
+}
+
+def pair(a, b : int) : int {
+    return a * 10 + b
+}
+
+def report(rc : int; text : string) : bool {
+    return rc == 0 && !empty(text)
+}
+
+// === Positives - a sibling argument reads what the nested call writes ===
+
+def bad_read_after(var x : int) : int {
+    return pair(bump(x), x)   // LINT030
+}
+
+def bad_read_before(var x : int) : int {
+    return pair(x, bump(x))   // LINT030
+}
+
+def bad_out_parameter() : bool {
+    var out : string
+    return report(fill(out), out)   // LINT030
+}
+
+def bad_read_in_expression(var x : int) : int {
+    return pair(bump(x), x + 1)   // LINT030
+}
+
+def bad_array(var xs : array<int>) : int {
+    return pair(grow(xs), length(xs))   // LINT030
+}
+
+// === Negatives ===
+
+// the write is a statement of its own, the read comes after it
+def good_sequenced(var x : int) : int {
+    let bumped = bump(x)
+    return pair(bumped, x)
+}
+
+// every argument only reads
+def good_read_only(x : int) : int {
+    return pair(pair(x, x), x)
+}
+
+// the nested call writes one variable, the sibling reads another
+def good_other_variable(var x : int; y : int) : int {
+    return pair(bump(x), y)
+}
+
+// a lambda argument runs later, not while the arguments are evaluated
+def good_lambda_reads_later(var x : int) : int {
+    let read = @(y : int) : int { return y }
+    return pair(bump(x), invoke(read, 0))
+}


### PR DESCRIPTION
**Behavior change: a Windows `spawn_process` child gets a 64 KB stdout pipe (was the 4 KB default), and `daslang-live` loads the LiveHost shared module before reading its exports - rebuild `daslang-live` and the modules.**

**Why.** Four nightly workflows were red. The dasImgui lane lost every playwright test since the lazy module scan (daslang-live read the LiveHost exports before anything loaded the module, so live mode never turned on); the ASan lane leaked 87 bytes per caught pinvoke panic; the Windows AOT host read an empty child output in every module_cache test; the Windows lanes throttled a chatty watchdog child to 16 KB/s; the tsan lane tripped on libdbus's own lock order; the extended checks read CRLF checkouts as changed bytes; the fastmath lane compared float printing against a fast-math fmt.

**What changes.**
- daslang-live asks the deferred-module loader for `live_host` before the dlsym; `tests/live_host/test_host_ready.das` spawns it on a port nothing answers on and polls `/status`; the folder's gate in `tests/.das_test` asks for dasHV too.
- The pinvoke family (`pinvoke_named`, `pinvoke_impl2_core`, `pinvoke_impl3`) and the `[extern]` binder's refusal move their message to the stack and free the string before `throw_error_at` (`src/builtin/ARCHITECTURE.md` sec.4).
- `spawn_process` on Windows creates the child's pipe at the POSIX 64 KB (sec.5).
- The order a call's arguments are evaluated in is not defined: LINT030 (`daslib/lint.das`, ships off) flags a sibling argument reading what a nested call writes by reference; the module_cache tests sequence every child run and arm the rule per file.
- The dasllama image-stamp gate folds CRLF before hashing; the tree-sitter artifacts get `eol=lf`.
- `.github/tsan_suppressions.txt` names libdbus's module as the frame of its create/close lock-order report.
- `test_float2string.cpp` and both vecmath backend arms pin precise math and `#error` otherwise.
- The watchdog and process tests scale their startup deadlines threefold on a Debug host, capped at five minutes.
- Four stale `nolint` markers go; the builtin module's page stops telling readers to `require builtin`.

**Observable behavior.**
- dasImgui nightly: 45 of 81 tests red -> green; a playwright host is ready in under a second.
- Windows AOT host, `tests/module_cache`: 11 red cells -> 40 passed, 7 host skips.
- Windows watchdog chatty arm: 96 s (fails at 120 on a 4-core runner) -> 9 s Release, 56 s Debug.
- ASan lane: `LeakSanitizer: 87 byte(s)` -> clean.
- tsan lane `test_tray_menu_over_private_bus`: child exit 66 -> 0.
- extended checks Windows: two red gates -> green on the same checkout; linux/darwin doc-verify: 1 red page -> green.
- fastmath lane: 4 failed ctest entries -> pass.
- whole-tree lint: 4 stale nolints -> 0 issues.

**Where to look.** `daslib/lint.das` (the LINT030 frame stack) and `src/builtin/module_builtin_fio.cpp` (the pipe size) are the two places that change runtime shape; the rest is tests, gates and docs.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Preflight on the tip: the fast tier and the docs, tests-cpp, tests-interp, tests-jit, tests-aot and utils-tests lanes all green; the lint lane run again after the last document edits.
- Windows: a worktree on zen2 (`D:\Work\das-nightly`, Release Ninja; `das-nightly-dbg`, Debug) - `test_aot.exe` on `tests/module_cache` 40 passed / 7 skipped; `tests/watchdog/test_watchdog.das` 46 Release and 46 Debug, `tests/fio/test_process.das` 6 and 6; the chatty arm 96 s -> 9 s; the image-stamp gate reproduced the Windows hash by converting the dasllama folder to CRLF and read OK after the fold.
- Linux tsan: the daslinux VM (Debian arm64, `-DDAS_USE_SANITIZER=tsan`) reproduced the exit 66 with the libdbus lock-order report, then 12 passed with no report under the suppressions file.
- Mac: `tests/live_host` 86, `tests/module_cache` 61, `tests/debug_agent` 54, `tests/module_tests` 47, `tests/lint` 84, `tests/watchdog` 47, `tests/fio/test_process` 6; ctest `float2string|double2string|vecmath` 4/4; doc-verify green on `module-builtin.rst` and `lint.rst`; `utils/lint` and `dasllama` gates OK.
- The live_host regression test fails at 50 s on the old `daslang-live` and passes at 0.8 s on the new one.
- `vecmath_scalar`, `vecmath_native`, `float2string` and `double2string` run for real on every non-fastmath lane through `ctest -L small`; on the fastmath lane their TUs are now precise-math while the library stays fast-math. Proof the pin takes under `-ffast-math`: `clang++ -ffast-math -D_TARGET_SIMD_SCALAR=1 -DEXPECT_SCALAR=1 -Iinclude tests-cpp/big/vecmath_backend/test_vecmath_backend.cpp` stops at the `#error`, and with `-fno-fast-math` appended (the CMake line's effect) both arms build and pass.
- `modules/dasLLAMA` changes are two dropped `nolint` markers and the stamp gate's CRLF fold; the module's `--suite model-free` / `--suite stocked` runs were not made for them - the gate itself ran (`REVIEW.das dasllama: OK` on the LF tree, and OK on the same folder converted to CRLF).
- Two codex rounds. The first's two LINT030 findings (a writer nested in an expression, a call inside a lambda argument leaking its reads) are fixed and pinned in the fixture. The second, on the reworked tip, found one thing: the live-host test's fixed port and unconditional `/shutdown` could end an unrelated host - it now probes for a port nothing answers on and shuts down only a child that reported ready.
- The fixture's negatives each answer to a control: with the by-reference-to-the-outer-call exclusion forced false the fixture fails on `take_ref(out, fill(out))`; the `nolint` marker case and the by-value-parameter case stay silent on the tip. The CRLF case in `utils/internal/review-md/test_walkers.das` fails with the gate's line-end fold reverted (the stamp finding fires on the CRLF copy) and passes with it.
- What the doc pages tell a reader to type exists and works: `lint.rst`'s LINT030 section names `options _lint = "LINT030"` and `LINT030 = true` in `.lint_config` - `utils/lint/main.das` on the page's own example fires `LINT030: argument 2 reads x while the call bump(...) in argument 1 writes it by reference` under the first spelling and stays silent on the sequenced form, and the `.lint_config` re-enable is the `CODE = true` directive `daslib/lint_config.das` erases the default-off seed on; `module-builtin.rst` says nothing needs a `require`, and doc-verify compiles the page's example with none - `utils/internal/doc-verify/main.das --page reference/language/lint` and `--page stdlib/handmade/module-builtin` both green.

### Claims - stated, not tested
- The CI Windows Debug runner is slower than the Debug tree the guards were measured on (zen2); the threefold scale is sized from the CI logs (a JIT child reached codegen at 59 s against a 60 s deadline), not from a run on that runner.
- The 64 KB pipe matches POSIX; a 1 MB pipe passed the lines in 4 s but pushed the string-heap gauge past the chatty arm's 2 MB bar, since one drain is what the heap holds between collects. No assertion tells the 4 KB pipe from the 64 KB one - the chatty arm's deadline is the only witness, and it widens on a Debug host.
- Four guards in the rule are defensive and no fixture reaches them: a call with no resolved function, a mention outside any argument slot, a by-value non-const parameter whose argument is a bare variable (the compiler wraps those in a ref-to-value node), and the visitor's own `noLint` flag.

### Not done
- LINT030 ships off: a tree sweep with it armed found about 90 library sites on the shape (`daslib/faker.das` twin draws, the dasLLAMA gemm emitter parts and kv accessors, `array_data_ptr` beside `length` in dasLLVM, the spirv emitter) - a sweep of its own.
- The whole-tree lint's fast pass and the Windows Debug nightly re-prove themselves on the next cron.
- `tests/module_cache/REVIEW.md` asks every test there to carry `options _lint = "LINT030"`; no `REVIEW.das` gate checks it yet - eight files comply today, the gate is a follow-up.
- No CI row compiles the rule fixtures under `utils/lint/tests` (`utils/lint/REVIEW.das` checks that each rule id has one; the linter skips the folder; nothing runs their `expect` counts) - true of every fixture there, LINT030's included. A row of its own.

</details>
