### PR TITLE
The module scan brings every deferred module in when a replayed row stays pending with its artifact on disk

### DIFF
--- a/include/daScript/ast/REVIEW.md
+++ b/include/daScript/ast/REVIEW.md
@@ -3,15 +3,15 @@
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
 `src/ast/ARCHITECTURE.md` (repo root).
 
-- **A diff that changes what a cached JIT DLL binds and the DLL key does not fold - the module a
-  bind registers into or the name it registers under (`vectorHomeModule`,
-  `typeFactory<vector<TT>>::make`, `registerVectorFunctions`, the name a
-  `ManagedVectorAnnotation` or `ManagedStructureAnnotation` takes, `ast_handle.h`), or the field
-  layout of a C++ type das code reads through a binding - bumps `LLVM_JIT_CODEGEN_VERSION` in
-  `modules/dasLLVM/daslib/llvm_jit_plan.das` (repo root), in the same change.** The key folds
-  the codegen version and each function's AST hash, never the module an extern lives in nor a
-  bound type's offsets, so a cached DLL binds the old name or the old offset and crashes on the
-  hit.
+- **A diff that changes what a cached JIT DLL binds - the module a bind registers into or the
+  name it registers under (`vectorHomeModule`, `typeFactory<vector<TT>>::make`,
+  `registerVectorFunctions`, the name a `ManagedVectorAnnotation` or
+  `ManagedStructureAnnotation` takes - all in `ast_handle.h`), or the field layout of a C++ type
+  das code reads through a binding - bumps `LLVM_JIT_CODEGEN_VERSION` in
+  `modules/dasLLVM/daslib/llvm_jit_plan.das` (repo root), in the same change.** The key is built
+  from the codegen version and each function's AST hash, never from the module an extern lives
+  in nor a bound type's offsets, so a cached DLL binds the old name or the old offset and
+  crashes on the hit.
 
 - **A diff that adds a field to `Function` or `Variable` (`ast.h`) holding something one
   program's compile decides - whether the program uses it, the slot it holds in that program's

--- a/include/daScript/ast/dyn_modules.h
+++ b/include/daScript/ast/dyn_modules.h
@@ -46,6 +46,8 @@ DAS_API void defer_dynamic_module(const char * path, const char * cpp_class, int
 DAS_API bool load_deferred_dynamic_module(const char * das_name);
 DAS_API size_t load_all_deferred_dynamic_modules();                 // the count it attempted
 DAS_API bool is_dynamic_module_deferred(const char * das_name);
+DAS_API bool pending_dynamic_module_artifact_present();             // a dlopen-failed row whose file exists: an import the deferred set holds
+DAS_API string registered_dynamic_module_name(const char * path, const char * cpp_class);   // empty while that row's module is not registered
 DAS_API void clear_deferred_dynamic_modules();                      // the rows are the scan's: cleared at scan start and at shutdown
 DAS_CC_API void ignore_dynamic_module_manifests(bool ignore);
 }

--- a/modules/REVIEW.md
+++ b/modules/REVIEW.md
@@ -16,4 +16,6 @@ its code runs, so an unrequired sibling fails the importer's next load.
 only the library import needs it - and the binder emits `initDependencies` from the lists; a hand
 edit of the generated file alone is a defect.** `require_modules` adds the other module to this
 module's type library, so a module that binds the same C++ types twice resolves the fields to
-the other's copies.
+the other's copies; a `require_load_modules` entry the build lacks - a static exe linking only
+what its program requires - is skipped, since without a library import there is no load order
+to keep.

--- a/modules/dasClangBind/cbind/cbind_boost.das
+++ b/modules/dasClangBind/cbind/cbind_boost.das
@@ -980,7 +980,7 @@ class CppGenBind : AnyGenBind {
     nsst2st : table<string; string>
     st2nsst : table<string; string>
     require_modules : array<string>
-    require_load_modules : array<string>    //! required before this module initializes, but their types stay out of this module's library
+    require_load_modules : array<string>    //! initialized before this module when the build has them - a static link without one initializes as before - and their types stay out of this module's library
     alias2type : table<string; string>
     enums_with_flags : table<string; bool>
     abstract_class : array<bool>
@@ -1766,8 +1766,7 @@ class CppGenBind : AnyGenBind {
         }
         for (rm in require_load_modules) {
             module_cpp_file |> fwrite("\tauto mod_{rm} = Module::require(\"{rm}\");\n")
-            module_cpp_file |> fwrite("\tif ( !mod_{rm} ) return false;\n")
-            module_cpp_file |> fwrite("\tif ( !mod_{rm}->initDependencies() ) return false;\n")
+            module_cpp_file |> fwrite("\tif ( mod_{rm} && !mod_{rm}->initDependencies() ) return false;\n")
         }
         module_cpp_file |> fwrite("\tinitialized = true;\n")
         module_cpp_file |> fwrite("\tlib.addModule(this);\n")

--- a/modules/dasImgui/src/dasIMGUI.cpp
+++ b/modules/dasImgui/src/dasIMGUI.cpp
@@ -18,8 +18,7 @@ Module_dasIMGUI::Module_dasIMGUI() : Module("imgui") {
 bool Module_dasIMGUI::initDependencies() {
 	if ( initialized ) return true;
 	auto mod_clipboard_core = Module::require("clipboard_core");
-	if ( !mod_clipboard_core ) return false;
-	if ( !mod_clipboard_core->initDependencies() ) return false;
+	if ( mod_clipboard_core && !mod_clipboard_core->initDependencies() ) return false;
 	initialized = true;
 	lib.addModule(this);
 	lib.addBuiltInModule();

--- a/skills/daspkg.md
+++ b/skills/daspkg.md
@@ -335,7 +335,7 @@ daspkg release wasm --root examples/games/arcanoid --out _release
 ### Prerequisites
 
 - **emsdk active** - `emcc` + `cmake` on PATH (CI activates `emsdk_env` first).
-- **wasm64 archives** - from `daspkg build --wasm` (in `web/output64/lib`, or pass `--wasm-lib-dir`).
+- **wasm64 archives** - from `daspkg build --wasm` (in `web/output64/lib`, or pass `--wasm-lib-dir`). A module with a `release_wasm_build` hook (dasImgui) builds its archives on demand only while one of its declared archives is missing from that directory - a staged archive never refreshes, so after a change to that module's C++ delete its staged `liblib*.a` before `release wasm`, or the app links the stale one.
 - **Host shared modules** (graphics examples only) - the host daslang must have `modules/dasGlfw/dasModuleGlfw.shared_module` + `modules/dasOpenGL/dasModuleOpenGL.shared_module` present, or GL silently falls back to the broken dasbind path (black canvas + runtime "Failed to find @dasbind::glCreateShader"). Guard before release: the cross-compile log must show `NEED_MODULE(Module_dasOpenGL) for opengl` (native), not a `@dasbind` binding. Pure compute scripts need no shared modules.
 
 ### `release()` hooks for web

--- a/src/ast/ARCHITECTURE.md
+++ b/src/ast/ARCHITECTURE.md
@@ -113,7 +113,17 @@ dumps its leftovers on the thread root, and a collect stops at a node owned by a
 after the load every module, not only the new ones, collects from that root, since a
 constructor registers into modules that exist already, and the rest is swept. A `dm` row
 with no name - the recording start's load failed - replays as recorded, so the Quiet deferral
-and the post-scan retry of a sibling `DT_NEEDED` dlopen behave as on a compiled start. A
+and the post-scan retry of a sibling `DT_NEEDED` dlopen behave as on a compiled start. A row
+still pending after that retry whose artifact is on disk failed on something other than a
+missing file - on a platform that resolves a library's imports at load (Windows, Linux without
+a RUNPATH), a sibling a deferred row holds, which the retry alone can never bring in - so the
+scan brings every deferred module in and runs the retry once more, the set an eager start has;
+a pending row whose artifact is absent stays pending and silent, as Quiet means, so a build
+without a module's artifact pays nothing for it. A replayed nameless row whose module is
+registered by the end of the scan - loaded at the scan, or by that fallback - gets the module's
+name written back into its manifest (the same key and dependency stamps, the row named), so the
+next start defers it as a start that recorded a clean load would; a row that never loads stays
+nameless. A
 require guard (`require ?mod`) and `builtin_module_exists` ask whether the build has the
 module (`guardModuleAvailable`): linked in, or waiting in a manifest row, which the guard
 loads then - so `require ?das_metal metal/das_metal_boost` still means "on a build with
@@ -165,9 +175,10 @@ re-parses the modules that require the group. With
 (shared module load <sec>, deferred K)`, `compiled (<why>), manifest written (N row(s))`,
 `compiled (no_manifest)`, `compiled (manifests ignored)`, or why a manifest was not written -
 and a deferred load prints `[module] require <name>: loading the deferred <class>`, the
-fallback `[module] loading every deferred module (K)`. A replayed descriptor's time is its
-manifest read plus its rows, and the second number is the share the `.shared_module` dlopen and
-module constructor took.
+fallback `[module] loading every deferred module (K)`, and the scan's own fallback announces
+itself first with `[module] a pending module's artifact exists - loading every deferred module`.
+A replayed descriptor's time is its manifest read plus its rows, and the second number is the
+share the `.shared_module` dlopen and module constructor took.
 
 ## 3. A require after the walk (`requireModuleNow`, `ast_parse.cpp`)
 

--- a/src/ast/REVIEW.md
+++ b/src/ast/REVIEW.md
@@ -4,15 +4,22 @@
 `ARCHITECTURE.md`.
 
 - **Weakening `REVIEW.das` (beside this file) is a defect:** dropping its scan of the prints in
-  `trySerializeProgramModule` (`ast_parse.cpp`, `ARCHITECTURE.md` sec.1) or of the cache-read
-  lines elsewhere in that file, or a finding text that no longer names what failed. What the gate
-  enforces is read from the gate itself.
+  `trySerializeProgramModule` (`ast_parse.cpp`, `ARCHITECTURE.md` sec.1) or of the module-cache
+  read diagnostics elsewhere in that file, or a finding text that no longer names what failed.
+  What the gate enforces is read from the gate itself.
 
-- **A diff that adds a module-cache read diagnostic outside `trySerializeProgramModule`, or moves
-  one out of it - into a helper it calls, or another function - extends `REVIEW.das`'s scan to the
-  new home in the same change, and the line prints only when the user asked: the serializer's
-  `quietCache` off, or `log_module_compile_time` set.** A print the gate does not scan is a print
-  nobody checks, and an ungated line there is output every user of the default cache sees.
+- **A diff that adds a module-cache read diagnostic outside `trySerializeProgramModule`
+  (`ast_parse.cpp`), or moves one out of it - into a helper it calls, or another function -
+  extends `REVIEW.das`'s scan to the new home in the same change, and prints the line only when
+  the serializer's `quietCache` is off or `log_module_compile_time` is set.** A module-cache read
+  diagnostic is a line reporting one record read of the module cache, the kind
+  `trySerializeProgramModule` prints; the module scan's `[module]` trace is not one. A print the
+  gate does not scan is a print nobody checks, and an ungated line there is output every user of
+  the default cache sees.
+
+- **A diff that adds a `[module]` line to the module scan's trace (`dyn_modules.cpp`) prints it
+  only behind `trace_scan()`, the switch `DAS_TRACE_MODULE_LOAD` sets.** The scan runs on every
+  start, so a line outside the switch is output every user sees.
 
 - **A diff that changes what a manifest written by an earlier binary replays to - a field added,
   removed, reordered or re-typed in `read_manifest` or `write_manifest` (`dyn_modules.cpp`), a

--- a/src/ast/dyn_modules.cpp
+++ b/src/ast/dyn_modules.cpp
@@ -108,9 +108,16 @@ static bool trace_scan() {
 
 enum class ManifestVerdict { Missing, Stale, Damaged, OptOut, Replay };
 
+struct DepStamp {
+    string path;
+    uint32_t size = 0;
+    uint64_t hash = 0;
+};
+
 struct ManifestRead {
     ManifestVerdict verdict = ManifestVerdict::Missing;
     das::vector<DynModuleManifestRow> rows;
+    das::vector<DepStamp> deps;     // the key's dependency stamps, verified against the files - a rewrite carries them
     string why;
 };
 
@@ -135,12 +142,6 @@ static string hex64(uint64_t v) {
     snprintf(buf, sizeof(buf), "%016llx", (unsigned long long) v);
     return buf;
 }
-
-struct DepStamp {
-    string path;
-    uint32_t size = 0;
-    uint64_t hash = 0;
-};
 
 // one hash per file per FileAccess, however many descriptors share it
 static bool dep_stamp(const smart_ptr<FileAccess> & fa, const string & path, uint32_t & size, uint64_t & hash) {
@@ -260,6 +261,7 @@ static ManifestRead read_manifest(const string & file, uint32_t descSize, uint64
             uint64_t hash = 0;
             if ( !dep_stamp(fa, fields[1], size, hash) ) return stale("dependency missing");
             if ( fields[2] != to_string(size) || fields[3] != hex64(hash) ) return stale("dependency changed");
+            res.deps.push_back(DepStamp{fields[1], size, hash});
         } else if ( kind == "np" ) {
             if ( fields.size() != 4 ) return damaged("np field count");
             DynModuleManifestRow row;
@@ -353,6 +355,38 @@ static bool write_manifest(const string & file, uint32_t descSize, uint64_t desc
 #endif
 }
 
+// src/ast/ARCHITECTURE.md sec.2 - a replayed manifest with a nameless dm row, kept until the scan ends
+struct NamelessRowsManifest {
+    string descriptor, file;
+    uint32_t descSize = 0;
+    uint64_t descHash = 0;
+    ManifestKey key;
+    das::vector<DepStamp> deps;
+    das::vector<DynModuleManifestRow> rows;
+};
+static das::vector<NamelessRowsManifest> g_nameless_manifests;
+
+static void name_replayed_rows() {
+    for ( auto & m : g_nameless_manifests ) {
+        size_t named = 0;
+        for ( auto & row : m.rows ) {
+            if ( !row.dynamic || !row.c.empty() ) continue;
+            auto name = registered_dynamic_module_name(row.a.c_str(), row.b.c_str());
+            if ( name.empty() ) continue;
+            row.c = name;
+            named ++;
+        }
+        if ( named == 0 ) continue;
+        string why;
+        const bool written = write_manifest(m.file, m.descSize, m.descHash, m.key, m.deps, m.rows, false, why);
+        if ( trace_scan() ) {
+            LOG(LogLevel::info) << "[module] descriptor " << m.descriptor
+                << (written ? ": manifest rewritten, " + to_string(named) + " row(s) named" : ": manifest not rewritten: " + why) << "\n";
+        }
+    }
+    g_nameless_manifests.clear();
+}
+
 static Result init_dyn_modules(smart_ptr<FileAccess> fa, string path, TextWriter &tout, bool debug = false) {
     const auto mod_filename = path + "/" + MODULE_SUFFIX;
     if (debug) {
@@ -386,6 +420,13 @@ static Result init_dyn_modules(smart_ptr<FileAccess> fa, string path, TextWriter
     if ( mr.verdict == ManifestVerdict::Replay ) {
         int64_t dllUsec = 0;
         size_t deferred = 0;
+        bool nameless = false;
+        for ( auto & row : mr.rows ) {
+            nameless |= row.dynamic && row.c.empty();
+        }
+        if ( nameless ) {   // src/ast/ARCHITECTURE.md sec.2 - named at the end of the scan once the module registered
+            g_nameless_manifests.push_back({mod_filename, manifest, len, stamp, key, mr.deps, mr.rows});
+        }
         for ( auto & row : mr.rows ) {
             if ( row.group ) {
                 replay_module_group(row.a.c_str(), row.b.c_str(), row.c.c_str());
@@ -645,6 +686,7 @@ bool require_dynamic_modules(FileAccessPtr file_access,
                              const das::vector<das::string> &disabled_modules,
                              das::TextWriter &tout) {
     clear_deferred_dynamic_modules();
+    g_nameless_manifests.clear();
     setDeferredModuleLoader(&load_deferred_module_for_require);
     // Explicitly-disabled modules (case-insensitive on every platform) are never
     // loaded/registered — keeps a native-only module out of a wasm cross-compile.
@@ -693,6 +735,14 @@ bool require_dynamic_modules(FileAccessPtr file_access,
     // before its dependency — its register_dynamic_module dlopen then fails and is
     // deferred. Retry the deferred set in fixed-point passes so order stops mattering.
     retry_pending_dynamic_modules();
+    // src/ast/ARCHITECTURE.md sec.2 - still pending with its artifact on disk: an import a deferred row holds
+    if ( pending_dynamic_module_artifact_present() ) {
+        if ( trace_scan() ) {
+            LOG(LogLevel::info) << "[module] a pending module's artifact exists - loading every deferred module\n";
+        }
+        load_all_deferred_dynamic_modules();
+    }
+    name_replayed_rows();
     return all_good;
 }
 

--- a/src/builtin/REVIEW.md
+++ b/src/builtin/REVIEW.md
@@ -64,6 +64,11 @@
   the cache-key paragraph of `ARCHITECTURE.md` in the same change.** The key is what stops a
   native-compiled module serving a cross compile, so a wrong description of it gets trusted.
 
+- **A diff that adds a `std::filesystem` call in `module_builtin_fio.cpp` passes every path into
+  it through `das_to_path` and every path out of it through `path_to_das`.** On Windows a path
+  built from a narrow string decodes through the ANSI codepage, so a UTF-8 name the codepage
+  cannot represent is misread on the way in and throws on the way out.
+
 - **A diff that changes C++ whose comment cites a section of an architecture document - this
   folder's (`// src/builtin/ARCHITECTURE.md sec.N`) or another's (`// src/ast/ARCHITECTURE.md
   sec.N`) - updates that section in the same change.** C++ carries no `[arch]` annotation, so

--- a/src/builtin/module_builtin_fio.cpp
+++ b/src/builtin/module_builtin_fio.cpp
@@ -318,6 +318,8 @@ namespace das {
     DAS_API bool load_deferred_dynamic_module ( const char * ) GENERATE_IO_STUB_RET
     DAS_API size_t load_all_deferred_dynamic_modules () GENERATE_IO_STUB_RET
     DAS_API bool is_dynamic_module_deferred ( const char * ) GENERATE_IO_STUB_RET
+    DAS_API bool pending_dynamic_module_artifact_present () GENERATE_IO_STUB_RET
+    DAS_API string registered_dynamic_module_name ( const char *, const char * ) GENERATE_IO_STUB_RET
     DAS_API void clear_deferred_dynamic_modules () GENERATE_IO_STUB
 
 #undef GENERATE_IO_STUB
@@ -2325,6 +2327,19 @@ namespace das {
         return on;
     }
 
+    // Debug builds produce _debug.shared_module; rewrite the path so that
+    // .das_module files don't need per-config conditional logic.
+    static string dynamic_module_actual_path ( const char * path ) {
+        string actualPath(path);
+#ifndef NDEBUG
+        auto pos = actualPath.rfind(".shared_module");
+        if ( pos != string::npos && pos + 14 == actualPath.size() ) {
+            actualPath.insert(pos, "_debug");
+        }
+#endif
+        return actualPath;
+    }
+
     // Returns DLL handle, nullptr on failure. on_error governs LOAD failures only:
     // Quiet defers a failed dlopen to retry_pending_dynamic_modules() (sibling-dep
     // ordering). A loadable-but-broken artifact (registrator missing, build-id
@@ -2340,15 +2355,7 @@ namespace das {
             row.on_error = on_error;
             g_manifest_rows.push_back(das::move(row));
         }
-        string actualPath(path);
-#ifndef NDEBUG
-        // Debug builds produce _debug.shared_module; rewrite the path so that
-        // .das_module files don't need per-config conditional logic.
-        auto pos = actualPath.rfind(".shared_module");
-        if ( pos != string::npos && pos + 14 == actualPath.size() ) {
-            actualPath.insert(pos, "_debug");
-        }
-#endif
+        string actualPath = dynamic_module_actual_path(path);
         auto lib = loadDynamicLibrary(actualPath.c_str());
         // Capture the dlopen error once, before anything else can clear it.
         string dlErr = lib ? string() : getDynamicLibraryError();
@@ -2418,6 +2425,15 @@ namespace das {
     }
     void *register_dynamic_module_silent(const char *path, const char *mod_name, Context * context, LineInfoArg * at ) {
         return register_dynamic_module(path, mod_name, static_cast<int>(RegisterOnError::Quiet), context, at);
+    }
+
+    // the das-visible name a registered module took, by the path and class its row carries; empty while it is not registered
+    DAS_API string registered_dynamic_module_name ( const char * path, const char * cpp_class ) {
+        if ( !path || !cpp_class ) return string();
+        for ( const auto & [p, c, n] : g_registered_dynamic_modules ) {
+            if ( p == path && c == cpp_class ) return n;
+        }
+        return string();
     }
 
     DAS_API void replay_dynamic_module ( const char * path, const char * cpp_class, int on_error ) {
@@ -2498,6 +2514,17 @@ namespace das {
                 }
             }
         }
+    }
+
+    // src/ast/ARCHITECTURE.md sec.2 - a pending row whose artifact is on disk failed on something
+    // other than a missing file: on a platform that resolves imports at load, a sibling the
+    // deferred set still holds
+    DAS_API bool pending_dynamic_module_artifact_present() {
+        for (auto & pr : g_pending_dynamic_modules) {
+            std::error_code ec;
+            if (std::filesystem::exists(das_to_path(dynamic_module_actual_path(get<0>(pr).c_str()).c_str()), ec) && !ec) return true;
+        }
+        return false;
     }
 
     // One line per still-pending (dlopen-failed) module: "  Module_Glfw <- <path> (<dlerror>)"
@@ -2819,7 +2846,7 @@ namespace das {
         std::ofstream ofs(p, std::ios::binary);
         if ( !ofs ) return nullptr;
         ofs.close();
-        auto s = p.string();
+        auto s = path_to_das(p);
         return ctx->allocateString(s.data(), uint32_t(s.size()), at);
     }
 
@@ -2833,7 +2860,7 @@ namespace das {
             if ( ec ) error = ec_to_string(ec, ctx, at);
             return nullptr;
         }
-        auto s = p.string();
+        auto s = path_to_das(p);
         return ctx->allocateString(s.data(), uint32_t(s.size()), at);
     }
 
@@ -2841,7 +2868,7 @@ namespace das {
         error = nullptr;
         if ( !path ) { error = empty_path_error(ctx, at); return false; }
         std::error_code ec;
-        auto si = std::filesystem::space(path, ec);
+        auto si = std::filesystem::space(das_to_path(path), ec);
         if ( ec ) { error = ec_to_string(ec, ctx, at); return false; }
         info.capacity = si.capacity;
         info.free = si.free;

--- a/tests/REVIEW.md
+++ b/tests/REVIEW.md
@@ -2,6 +2,12 @@
 
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.**
 
+**A test answers to its kind's checklist wherever the diff puts it:** a module-scan,
+descriptor-manifest, module-cache or deferred-load test to `module_cache/REVIEW.md`; a test that
+runs a dasMetal kernel class or creates any Metal object to `metal/REVIEW.md`; an MSL emitter
+fixture or census test to `msl/REVIEW.md`; a SPIR-V emitter `*_words` fixture or census test to
+`spirv/REVIEW.md`; a test that calls `tick_debug_agent` to `debug_agent/REVIEW.md`.
+
 - **A diff that widens the `dasbind` skip in `.das_test` or drops a probe shape from
   `dasbind/test_extern_abi.das` is a defect.** The suite is the only check of which register or
   stack slot an interpreted `[extern]` call puts each argument in - the JIT never takes that

--- a/tests/module_cache/ARCHITECTURE.md
+++ b/tests/module_cache/ARCHITECTURE.md
@@ -44,8 +44,13 @@ this document states what the folder is and why its tests take the shape they do
   the guard sits in a module walked earlier;
   `-ignore-manifest` compiles every descriptor, loads every C++ module on start and writes no
   manifest; a manifest row hand-edited to an absent artifact makes the require bring every
-  deferred module in and then fail on the missing prerequisite; a module cache an eager start
-  wrote serves a lazy start, with `-log-compile-time` printing the reads and the startup
+  deferred module in and then fail on the missing prerequisite; a nameless `dm` row added by
+  hand whose path is a file that exists and is no shared module fails at the scan and, its
+  artifact present, makes the scan bring every deferred module in before any require; the real
+  `dm` row with its name blanked loads at the scan, gets its name written back, and the next start
+  defers it; a module
+  cache an eager start wrote serves a lazy start, with `-log-compile-time` printing the reads
+  and the startup
   timeline; a dastest `--ser` stream of a test requiring the module is read by a `--deser`
   child that nothing made require it, and the reader loads it; and, where the tree holds dasImgui and dasGlfw, `require imgui_app` brings every
   deferred module in because its `initDependencies` asks for two more, and a half-warm tree -

--- a/tests/module_cache/REVIEW.md
+++ b/tests/module_cache/REVIEW.md
@@ -3,12 +3,10 @@
 **Read `REVIEW_COMMON.md` (repo root) first - its contract binds this checklist.** Architecture doc:
 `ARCHITECTURE.md`.
 
-- **Editing an assertion literal, or the helper that produces the text a test in this folder
-  compares a spawned child's output or the files it wrote against, so it accepts an output the
-  old text rejected is a defect; re-pinning a count or the fixed words of the scan-trace
-  `[module] descriptor ...` line or the cache's verdict line to the child's new true output is
-  not.** A child's output is the only instrument a human has for what the cache and the scan
-  served.
+- **A diff that changes an assertion literal, or the helper producing the text a test in this
+  folder compares a spawned child's output or the files it wrote against, so the compare accepts
+  text the child does not truly emit is a defect.** A child's output is the only instrument a
+  human has for what the cache and the module scan served.
 
 - **A helper that trims a child's line before the compare drops only its elapsed times - every
   other field on the line, a count included, stays in the compared text.** A dropped field is

--- a/tests/module_cache/test_deferred_modules.das
+++ b/tests/module_cache/test_deferred_modules.das
@@ -311,6 +311,49 @@ def arm_fallback(t : T?; fx : Fixture) {
     }
 }
 
+//! the dm rows a recording start whose load failed leaves - nameless - and what the scan makes of them
+def arms_nameless_rows(t : T?; fx : Fixture) {
+    let utDir = path_join(path_join(fx.tmp, "modules"), UNIT_TEST_FOLDER)
+    t |> run("a replayed row whose artifact exists but does not load brings every deferred module in at the scan") @(t : T?) {
+        var warm : string
+        t |> success(run_child_reported(t, "rewarm", child_cmd(fx, fx.plain), warm, "PLAIN"), "a cold start rewrites the manifest")
+        let text = fread(fx.utManifest)
+        // a nameless dm row whose path is a file that exists and is no shared module
+        let descriptor = path_join(utDir, ".das_module")
+        let doctored = replace(text, "\nend\t1\n", "\ndm\t{descriptor}\tModule_Unloadable\t0\t\nend\t2\n")
+        t |> success(doctored != text, "the manifest carries its one row: {text}")
+        fwrite(fx.utManifest, doctored)
+        var out : string
+        t |> success(run_child_reported(t, "pending", child_cmd(fx, fx.plain), out, "PLAIN"), "the program runs")
+        t |> success(find(out, "Module_Unloadable <- {descriptor} : FAILED") >= 0, "the row's load fails at the scan:\n{out}")
+        t |> success(find(out, "[module] a pending module's artifact exists - loading every deferred module") >= 0, "the present artifact brings the deferred set in:\n{out}")
+        // the trace's path is the row's as recorded, so its separators are the descriptor's, not path_join's
+        let loaded = find(out, "{UNIT_TEST_ARTIFACT}.shared_module : loaded") >= 0 || find(out, "{UNIT_TEST_ARTIFACT}_debug.shared_module : loaded") >= 0
+        t |> success(find(out, "{UNIT_TEST_CLASS} <- ") >= 0 && loaded, "the deferred module loads on start:\n{out}")
+        t |> success(find(out, ": manifest rewritten, ") < 0, "a row that never loads stays nameless:\n{out}")
+        remove_result(fx.utManifest)
+    }
+    t |> run("a replayed nameless row whose module loads gets its name written back, and the next start defers it") @(t : T?) {
+        var warm : string
+        t |> success(run_child_reported(t, "rewarm", child_cmd(fx, fx.plain), warm, "PLAIN"), "a cold start rewrites the manifest")
+        let text = fread(fx.utManifest)
+        // the real dm row with its name blanked
+        let doctored = replace(text, "\t{UNIT_TEST_MODULE}\n", "\t\n")
+        t |> success(doctored != text, "the manifest carries the named row: {text}")
+        fwrite(fx.utManifest, doctored)
+        var eager : string
+        t |> success(run_child_reported(t, "eager", child_cmd(fx, fx.plain), eager, "PLAIN"), "the program runs")
+        let loaded = find(eager, "{UNIT_TEST_ARTIFACT}.shared_module : loaded") >= 0 || find(eager, "{UNIT_TEST_ARTIFACT}_debug.shared_module : loaded") >= 0
+        t |> success(find(eager, "{UNIT_TEST_CLASS} <- ") >= 0 && loaded, "the nameless row loads at the scan:\n{eager}")
+        // the trace joins the descriptor with "/" whatever the platform, as descriptor_line reads it
+        t |> success(find(eager, "{UNIT_TEST_FOLDER}/.das_module: manifest rewritten, 1 row(s) named") >= 0, "the scan writes the name back:\n{eager}")
+        t |> success(find(fread(fx.utManifest), "\t{UNIT_TEST_MODULE}\n") >= 0, "the manifest carries the name again")
+        var lazy : string
+        t |> success(run_child_reported(t, "lazy", child_cmd(fx, fx.plain), lazy, "PLAIN"), "the next start runs")
+        t |> equal(-1, find(lazy, "{UNIT_TEST_CLASS} <- "), "the next start defers the row and loads nothing:\n{lazy}")
+    }
+}
+
 //! the arms share one root and run in this order
 [test]
 def test_deferred_modules(t : T?) {
@@ -332,6 +375,7 @@ def test_deferred_modules(t : T?) {
     let fx = make_fixture(tmp, artifact)
     arms_deferred(t, fx)
     arms_guards_and_caches(t, fx)
+    arms_nameless_rows(t, fx)
     arm_fallback(t, fx)
     var err : string
     rmdir_rec(tmp, err)


### PR DESCRIPTION
**Why.** On Windows the primary test sweep fails `tests/module_cache/test_deferred_modules.das` on master and on every PR, and the isolated retry hides it. A dasImgui manifest recorded on a start whose load failed carries nameless rows; they replay as an eager dlopen that fails again on every start, because the clipboard library they import waits in a deferred row that nothing brings in.

**What changes.**
- After the scan's pending retry, a row still pending whose artifact exists on disk makes the scan load every deferred module and run the retry once more.
- A pending row whose artifact is absent stays pending and silent, so a build without a module's artifact pays nothing.
- A replayed nameless row whose module is registered by the end of the scan gets the module's name written back into its manifest (same key and dependency stamps), so the next start defers it instead of loading it eagerly on every start.
- The scan announces the fallback in its trace, and the `_debug` path rewrite the load and the check share lives in one helper.
- Three `std::filesystem` boundaries in `module_builtin_fio.cpp` that bypassed the module's UTF-8 path pair go through it: the disk-space query's path in, and the two temp-path results out.
- `skills/daspkg.md` says that a module's on-demand wasm archive builds only while one of its declared archives is missing, so a staged archive never refreshes after a C++ change until it is deleted - the trap that linked a stale imgui archive into the first local re-release.
- The binder's `require_load_modules` emission initializes the named module first only when the build has it; imgui's `initDependencies` no longer fails on a build without `clipboard_core`. The browser exe links only what its program requires, and parrot never requires clipboard, so the live parrot page died at start with "Unable to initialize some modules: imgui" since the dependency landed.

**Observable behavior.**
- Windows primary sweep: `test_deferred_modules.das` red, green only on the isolated retry -> green on the primary sweep.
- A tree whose manifest set disagrees (an importer eager, its import deferred): `require imgui_app` fails "missing prerequisite" -> the module loads at the scan and the require resolves.
- Scan trace: a new line `[module] a pending module's artifact exists - loading every deferred module` before the fallback's own line, and `[module] descriptor <path>: manifest rewritten, N row(s) named` when a nameless row is named.
- A tree whose manifest carries a nameless row for a module that loads: every start loads it eagerly -> one eager start, then the row waits like any other.
- Windows, a temp-file prefix or a disk-space path the ANSI codepage cannot represent: a throw on the way out or the wrong directory read -> the UTF-8 name, as the rest of the module.
- dasllama.io parrot page: the exe exits -1 at start ("Unable to initialize some modules: imgui_app_headless imgui_app imgui") -> the lab starts.

**Where to look.** `require_dynamic_modules` in `src/ast/dyn_modules.cpp` (the one call after the retry) and `pending_dynamic_module_artifact_present` in `src/builtin/module_builtin_fio.cpp`; the new arm in `test_deferred_modules.das` pins the trace.

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The scan-end fallback arm was red on the unchanged binary on exactly its two fix assertions and green after the change; the deferred-modules file and the module-cache folder pass locally.
- The write-back arm was added after the first CI round, in a fresh worktree with no pre-change binary to run it against; without the write-back its last assertion fails by shape (the second start loads the module again), which the first CI round showed in the isolated retry as two older arms losing their lazy load on a tree with a nameless imgui manifest.
- The Windows proof is CI's: the primary sweep of the Windows 64 lane, which fails this file on master today. On the first tip the Windows 32 lane went red on the new arm's last assertion alone - its path compare joined with backslashes while the trace prints the row's recorded path with the descriptor's forward slashes; the same log shows the fallback firing there ("loading every deferred module (17)", the UnitTest module loaded on start). The assertion now anchors on the artifact's basename.
- The one full preflight run had two lane reds while the audits' probe children ran on the same tree: `tests/module_cache/test_default_cache_path.das` in the interpreter lane (its file counts in the shared default cache directory were off by one) and `tests/fio/perf_time.das` in the JIT lane (a timing test under the AOT build's load). Both pass in isolation on the same binary.
- The comment harvest and the style-hygiene audit were not run on this diff.
- Five checklists changed on their auditors' self-review findings; each got one dragon pass, and the dragons' replacement texts were applied as written (rewrapped) without a cold re-read. `modules/REVIEW.md` gained one clause afterwards (what a missing load-only requirement means) with no dragon pass.
- The browser fix was settled on the wasm rail: the imgui wasm archive rebuilt from the changed binding, the parrot release re-linked and re-minted, and the page started in Chrome from the local server with the lab rendered and no init error in the console.
- The external codex round ran on the tip (its trace read every changed file) and reported no findings; its report file came back empty, the verdict is in the run log only.
- `src/ast/ARCHITECTURE.md` sec.2 gained two sentences; its twelve other C++ citers (`dyn_modules.cpp`, `ast_parse.cpp`, `parser_impl.cpp`, `module_builtin_fio.cpp`) were re-read against the amended section and each still names a statement the amendment did not touch.

### Claims - stated, not tested
- The import-at-load case itself (a Windows DLL whose import sits in a deferred row) is reproduced by CI, not locally: a macOS dylib resolves its imports by install name, so the local arm pins the mechanism with a row whose file exists and is no shared module. A break would show the Windows primary sweep red on this file again.
- The imgui-without-clipboard case exists only in a static exe that links no clipboard module - the browser build; every desktop build links clipboard beside imgui, so no desktop test reaches the branch. It was settled on the wasm rail: the parrot release rebuilt locally starts in Chrome. A break would show the page's console line above again.
- On a Debug build the presence check tests the `_debug.shared_module` spelling, through the same helper the load uses; no Debug arm exercises a row naming the Release spelling with only the Debug twin on disk. A break would leave such a tree pending and silent.
- The three re-routed filesystem boundaries differ only for a Windows name outside the ANSI codepage, and no test drives them with one. A break would show `create_temp_file` throwing, or `disk_space` reading another directory, on such a name.
- The trace-off arm of the announcement (silent when `DAS_TRACE_MODULE_LOAD` is unset) and the `error_code` guard on the exists call (an error reads as absent) have no test; both are output-only or fail-closed.

### Not done
- A single deferred load at a require does not rerun the pending retry. With the scan resolving the state before any require, no reachable case is left for it.
- The two new duties (`src/builtin/REVIEW.md`: every `std::filesystem` path through `das_to_path` / `path_to_das`; `src/ast/REVIEW.md`: a `[module]` scan-trace line only behind `trace_scan()`) land as rules; the `REVIEW.das` gates that would enforce them are not written - five sites each, a gate is not worth its code yet.
- `tests/REVIEW.md` routes by kind to its five subfolder checklists now; it still names no architecture doc, because `tests/` has none and its one rule carries its reason inline - whether to write one is a ruling, not this change.

</details>
