### PR TITLE
Startup papercuts: warm -jit hello 92 -> 60 ms - fusion and hashing gated under jit, cached gc flags, a four-extern llvm_host binding, indexed serializer node refs, fusion table orphaned at exit

### DIFF
--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1166,7 +1166,9 @@ namespace das
         static void Initialize();
         static bool InitializeDependencies ( string & notInitialized );
         static void CollectFileInfo(das::vector<FileInfoPtr> &accesses);
-        static void Shutdown( bool dumpHandleLeaks = true );
+        // resetFusion=false orphans the fusion table: for a host whose process ends right after, the
+        // teardown is time spent on memory the OS reclaims anyway; a host that initializes again must reset
+        static void Shutdown( bool dumpHandleLeaks = true, bool resetFusion = true );
         // Runtime-only shutdown — for standalone exes built with `daslang -exe`,
         // which link libDaScript*_runtime without the fusion engine. See issue #2583.
         static void ShutdownStandalone( bool dumpHandleLeaks = false );

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -284,6 +284,7 @@ namespace das
             uint32_t    flags = 0;
         };
         mutable bool circularGuard = false;   // we prevent circular lookups with this guard. Do not serialize, do not expose to daslang
+        mutable int32_t cachedGcFlags = -1;   // gc flags of the whole structure, -1 until a top-level walk fills it. Not serialized
     };
 
     struct DAS_API Variable : gc_node {
@@ -475,6 +476,7 @@ namespace das
             return hb.getHash();
         }
         virtual int32_t getGcFlags(das_set<Structure *> &, das_set<Annotation *> &) const { return 0; }
+        mutable int32_t cachedGcFlags = -1;   // gc flags of the handled type, -1 until a top-level walk fills it
         virtual bool canAot(das_set<Structure *> &) const { return true; }
         virtual bool canMove() const {
             return !hasNonTrivialCopy();

--- a/include/daScript/ast/ast.h
+++ b/include/daScript/ast/ast.h
@@ -1517,6 +1517,7 @@ namespace das
 
         das_hash_map<TypeInfo *,string>          t2cppTypeName;
         das_hash_map<StructInfo *,string>        s2cppTypeName;
+        bool collectCppNames = true;    // the C++ spellings above are read only through debug_helper_find_*_cppname, by the AOT emitter's own helper; a simulate's helper turns this off
     };
 
     struct CommentReader {

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -136,6 +136,8 @@ namespace das {
         string              cutoffFile;
         string              cutoffReason;
         bool                policyMismatch = false;
+        bool                readJitEnabled = false; // the compile's jit_enabled, for the macro program a served record reinstantiates (the cold path's program carries it)
+        AnnotationArgumentList readOptions;         // the served module's own `options`, for the same macro program (its fusion opt-in reads them)
     // expression lookup
         das_hash_map<uint32_t, Annotation *> rttiHash2Annotation;
     // file info clean up

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -137,7 +137,7 @@ namespace das {
         das_hash_map<const void *, uint32_t>        writeIds;
         vector<uint8_t>                             writtenIds;     // indexed by SerializeNodeId::index
         vector<void *>                              readNodes;      // indexed by SerializeNodeId::index
-        vector<pair<void **, SerializeNodeId>>      pendingRefs;
+        vector<pair<void *, SerializeNodeId>>       pendingRefs;    // storage of a TT * slot, and the number it waits for
         using DataOffset = uint64_t;
         das_hash_map<FileInfo*, DataOffset>                writingFileInfoMap;
         das_hash_map<DataOffset, FileInfo*>                readingFileInfoMap;
@@ -309,7 +309,7 @@ namespace das {
                 ptr = node;
             } else {
                 ptr = ( TT * ) 1;
-                pendingRefs.emplace_back((void **) &ptr, id);
+                pendingRefs.emplace_back(&ptr, id);     // the slot's storage; patch() writes it bytewise, whatever TT is
             }
         }
         template <typename TT>

--- a/include/daScript/ast/ast_serializer.h
+++ b/include/daScript/ast/ast_serializer.h
@@ -81,28 +81,13 @@ namespace das {
         }
     };
 
-    // Composite key for serializer maps. Pairs a raw pointer with a per-
-    // AstSerializer epoch so reused addresses don't collide with prior entries.
-    // Hoisted to namespace das so daslang_hash can be specialized before the
-    // map instantiations inside AstSerializer.
+    // A node's identity in a record: the writer numbers nodes from 1 in first-mention order,
+    // the reader indexes a vector with the number. 0 is the null pointer. Per record - the
+    // tables reset with the maps at the end of every program.
     struct SerializeNodeId {
-        void *  ptr = nullptr;
-        size_t  epoch = 0;
-        bool operator == ( const SerializeNodeId & o ) const noexcept {
-            return ptr == o.ptr && epoch == o.epoch;
-        }
-        bool operator != ( const SerializeNodeId & o ) const noexcept {
-            return !(*this == o);
-        }
-    };
-
-    template <>
-    struct daslang_hash<SerializeNodeId, void> {
-        size_t operator () ( const SerializeNodeId & s ) const noexcept {
-            const uint64_t pmix = (uint64_t(reinterpret_cast<uintptr_t>(s.ptr)) >> 4)
-                                * uint64_t(0x9E3779B97F4A7C15ull);
-            return size_t(pmix ^ (uint64_t(s.epoch) * uint64_t(0xBF58476D1CE4E5B9ull)));
-        }
+        uint32_t index = 0;
+        bool operator == ( const SerializeNodeId & o ) const noexcept { return index == o.index; }
+        bool operator != ( const SerializeNodeId & o ) const noexcept { return index != o.index; }
     };
 
     struct DAS_API AstSerializer {
@@ -145,32 +130,17 @@ namespace das {
         das_hash_set<FileInfo*>   doNotDelete;
     // profile data
         uint64_t totMacroTime = 0;
-    // Per-program epoch for SerializeNodeId. Bumped at the start of each
-    // serialize/deserialize call so reused pointer addresses across program
-    // boundaries don't collide with prior map entries on this persistent
-    // serializer. Must be initialized — uninitialized epoch produces garbage
-    // keys and silent map collisions.
-        size_t                                      epoch = 0;
-    // pointers
-        das_hash_map<SerializeNodeId, ExprBlock*>          exprBlockMap;
+    // node identity (SerializeNodeId): the writer numbers a node at its first mention and
+    // remembers which numbers have had their payload written; the reader keeps the node
+    // each number resolved to, null until its payload is read (a forward reference is
+    // patched in patch()). Per record.
+        das_hash_map<const void *, uint32_t>        writeIds;
+        vector<uint8_t>                             writtenIds;     // indexed by SerializeNodeId::index
+        vector<void *>                              readNodes;      // indexed by SerializeNodeId::index
+        vector<pair<void **, SerializeNodeId>>      pendingRefs;
         using DataOffset = uint64_t;
         das_hash_map<FileInfo*, DataOffset>                writingFileInfoMap;
         das_hash_map<DataOffset, FileInfo*>                readingFileInfoMap;
-        das_hash_map<SerializeNodeId, FileAccess*>         fileAccessMap;
-    // smart pointers
-        das_hash_map<SerializeNodeId, MakeFieldDeclPtr>    smartMakeFieldDeclMap;
-        das_hash_map<SerializeNodeId, EnumerationPtr>      smartEnumerationMap;
-        das_hash_map<SerializeNodeId, StructurePtr>        smartStructureMap;
-        das_hash_map<SerializeNodeId, VariablePtr>         smartVariableMap;
-        das_hash_map<SerializeNodeId, FunctionPtr>         smartFunctionMap;
-        das_hash_map<SerializeNodeId, MakeStructPtr>       smartMakeStructMap;
-        das_hash_map<SerializeNodeId, TypeDeclPtr>         smartTypeDeclMap;
-    // refs
-        vector<pair<ExprBlock**,SerializeNodeId>>          blockRefs;
-        vector<pair<Function **,SerializeNodeId>>          functionRefs;
-        vector<pair<Variable **,SerializeNodeId>>          variableRefs;
-        vector<pair<Structure **,SerializeNodeId>>         structureRefs;
-        vector<pair<Enumeration **,SerializeNodeId>>       enumerationRefs;
         // fieldRefs tuple contains: fieldptr, module, structname, fieldname
         vector<tuple<Structure::FieldDeclarationRef*, Module *, string, string>>       fieldRefs;
         // parsedModules record: fileName, source content hash, source size, program, thisModule, the collector's require names
@@ -262,7 +232,7 @@ namespace das {
         AstSerializer & serializeModule ( Module & module, bool already_exists );
 
         static constexpr uint32_t getVersion () {
-            return 207;   // 207: neither Function nor Variable flags carry a used bit, and neither streams an index (206: the record header carries the requires the parse took; 205: a vector of a handled element streams under the element's module; 204: the record header stamps the source by content hash; the policy stream carries every CodeOfPolicies field)
+            return 208;   // 208: a node reference is the writer's first-mention number as a varint, not a pointer-and-epoch word (207: neither Function nor Variable flags carry a used bit, and neither streams an index; 206: the record header carries the requires the parse took; 205: a vector of a handled element streams under the element's module; 204: the record header stamps the source by content hash; the policy stream carries every CodeOfPolicies field)
         }
 
         void serializeProgram ( ProgramPtr program, ModuleGroup & libGroup ) noexcept;
@@ -332,10 +302,26 @@ namespace das {
         void writeIdentifications ( Variable * & ptr );
         void writeIdentifications ( TypeInfoMacro * & ptr );
 
-        void fillOrPatchLater ( Function * & func, SerializeNodeId id );
-        void fillOrPatchLater ( Enumeration * & ptr, SerializeNodeId id );
-        void fillOrPatchLater ( Structure * & ptr, SerializeNodeId id );
-        void fillOrPatchLater ( Variable * & ptr, SerializeNodeId id );
+        // reading: the node a number resolved to, or a patch-later slot when its payload is still ahead
+        template <typename TT>
+        void fillOrPatchLater ( TT * & ptr, SerializeNodeId id ) {
+            if ( auto node = readNode<TT>(id) ) {
+                ptr = node;
+            } else {
+                ptr = ( TT * ) 1;
+                pendingRefs.emplace_back((void **) &ptr, id);
+            }
+        }
+        template <typename TT>
+        __forceinline TT * readNode ( SerializeNodeId id ) const { return (TT *) readNodes[id.index]; }
+        __forceinline void setReadNode ( SerializeNodeId id, void * node ) { readNodes[id.index] = node; }
+        // writing: has this number's payload gone into the stream already
+        __forceinline bool isWritten ( SerializeNodeId id ) const { return id.index < writtenIds.size() && writtenIds[id.index]; }
+        void markWritten ( SerializeNodeId id ) {
+            if ( id.index >= writtenIds.size() ) writtenIds.resize(id.index + 1, 0);
+            writtenIds[id.index] = 1;
+        }
+        void clearNodeIds ();
 
         auto readModuleAndName () -> pair<Module *, string>;
         auto readModuleAndNameHash () -> pair<Module *, uint64_t>;
@@ -346,7 +332,14 @@ namespace das {
         void findExternal ( Variable * & ptr );
         void findExternal ( TypeInfoMacro * & ptr );
 
-        SerializeNodeId getSerializeId(void *ptr) { return {ptr, epoch}; }
+        // writing: the node's number, assigned at its first mention; reading: a placeholder the
+        // stream overwrites
+        SerializeNodeId getSerializeId ( const void * ptr ) {
+            if ( !writing || !ptr ) return {0};
+            auto & slot = writeIds[ptr];
+            if ( !slot ) slot = uint32_t(writeIds.size());   // the fresh entry counts itself: numbers run from 1
+            return {slot};
+        }
 
         template <typename EnumType>
         void serialize_small_enum ( EnumType & baseType ) {

--- a/include/daScript/simulate/simulate_fusion.h
+++ b/include/daScript/simulate/simulate_fusion.h
@@ -92,11 +92,11 @@ namespace das {
     // function pointers for fusion library decoupling
     // runtime defines these; fusion lib sets them via register_fusion()
     DAS_API extern void (*g_fusionContextFn) ( Context & context, TextWriter & logs, bool enableFusion );
-    DAS_API extern void (*g_resetFusionEngineFn) ();
+    DAS_API extern void (*g_resetFusionEngineFn) ( bool orphan );   // orphan: forget the table without freeing it (a process about to exit)
 
     string fuseName ( const string & name, const string & typeName );
     unique_ptr<FusionEngine> &getFusionEngine();
-    void resetFusionEngine();
+    void resetFusionEngine( bool orphan );
     void createFusionEngine();
     void registerFusion ( const char * OpName, const char * CTypeName, FusionPoint * node );
 

--- a/modules/dasLLVM/.das_module
+++ b/modules/dasLLVM/.das_module
@@ -23,7 +23,7 @@ def initialize(project_path : string) {
         "llvm_tune"           // [tune] framework: perm grids, three modes, the manifest
     ]
     let bindings_paths = [
-        "llvm_const", "llvm_enum", "llvm_func", "llvm_struct",
+        "llvm_const", "llvm_enum", "llvm_func", "llvm_host", "llvm_struct",
     ]
     for (path in daslib_paths) {
         register_native_path("llvm", "daslib/{path}", "{project_path}/daslib/{path}.das")

--- a/modules/dasLLVM/bindings/llvm_host.das
+++ b/modules/dasLLVM/bindings/llvm_host.das
@@ -1,0 +1,14 @@
+require dasbind public
+options gen2
+module llvm_host shared
+
+//! the host queries the jit plan folds into its cache key - the only LLVM the DLL-cache hit path
+//! touches, so the plan requires this and not the full llvm_func binding
+[extern(cdecl, name="LLVMDisposeMessage", library="LLVM.dll")]
+def LLVMDisposeMessage(Message : string implicit) : void {}
+[extern(cdecl, name="LLVMGetDefaultTargetTriple", library="LLVM.dll")]
+def LLVMGetDefaultTargetTriple() : string {}
+[extern(cdecl, name="LLVMGetHostCPUName", library="LLVM.dll")]
+def LLVMGetHostCPUName() : string {}
+[extern(cdecl, name="LLVMGetHostCPUFeatures", library="LLVM.dll")]
+def LLVMGetHostCPUFeatures() : string {}

--- a/modules/dasLLVM/daslib/llvm_jit_plan.das
+++ b/modules/dasLLVM/daslib/llvm_jit_plan.das
@@ -15,7 +15,7 @@ module llvm_jit_plan shared private
 //! a miss; the emitter builds on the same plan and the same install. The three host queries
 //! the key folds - triple, CPU name, CPU features - are the one use of the LLVM bindings here.
 
-require llvm/bindings/llvm_func
+require llvm/bindings/llvm_host
 require llvm/daslib/llvm_dll_utils public
 require llvm/daslib/llvm_env
 require llvm/daslib/llvm_cpu_class

--- a/modules/dasLLVM/daslib/llvm_jit_run.das
+++ b/modules/dasLLVM/daslib/llvm_jit_run.das
@@ -35,7 +35,7 @@ var LINK_WHOLE_LIB = false // when true, standalone exe links against the whole 
 
 // Read by tests-cpp/small/test_jit_emitter_pin.cpp: FNV-1a64 of the emitter sources
 // (normalized to LF; file list in the test)
-let LLVM_JIT_EMITTER_HASH : uint64 = 0x207d30f0b3d7e69dul
+let LLVM_JIT_EMITTER_HASH : uint64 = 0xa2ab0760ed831369ul
 
 def private apply_fast_math_to_module(m : LLVMOpaqueModule?) {
     var fn = LLVMGetFirstFunction(m)

--- a/src/ast/ast_debug_info_helper.cpp
+++ b/src/ast/ast_debug_info_helper.cpp
@@ -298,7 +298,7 @@ namespace das {
         if ( gcf & TypeDecl::gcFlag_stringHeap ) sti->flags |= StructInfo::flag_stringHeapGC;
         sti->count = (uint32_t) st.fields.size();
         sti->size = st.getSizeOf();
-        s2cppTypeName[sti] = describeCppType(tdecl, CpptSubstitureRef::no,CpptSkipRef::yes, CpptSkipConst::yes);
+        if ( collectCppNames ) s2cppTypeName[sti] = describeCppType(tdecl, CpptSubstitureRef::no,CpptSkipRef::yes, CpptSkipConst::yes);
         sti->fields = (VarInfo **) debugInfo->allocate( sizeof(VarInfo *) * sti->count );
         for ( uint32_t i=0, is=sti->count; i!=is; ++i ) {
             auto & var = st.fields[i];
@@ -442,7 +442,7 @@ namespace das {
         }
         info->argNames = nullptr;
         auto argNamesCount = uint32_t(elemType->argNames.size());
-        t2cppTypeName[info] = describeCppType(type, CpptSubstitureRef::no,CpptSkipRef::yes, CpptSkipConst::yes);
+        if ( collectCppNames ) t2cppTypeName[info] = describeCppType(type, CpptSubstitureRef::no,CpptSkipRef::yes, CpptSkipConst::yes);
         if ( argNamesCount ) {
             DAS_ASSERT(info->argCount == 0 || info->argCount == argNamesCount);
             info->argCount = argNamesCount;

--- a/src/ast/ast_module.cpp
+++ b/src/ast/ast_module.cpp
@@ -284,9 +284,14 @@ namespace das {
         setDeferredModuleLoader(nullptr);
 
         clearGlobalAotLibrary();
+        // the standalone runtime links no fusion library and sets no hook; with one, a
+        // shutdown that does not reset orphans the table instead of leaving it to the
+        // thread-local's destructor at exit, which would free it all the same
         if ( resetFusion ) {
             DAS_ASSERTF(g_resetFusionEngineFn, "fusion library not loaded");
-            g_resetFusionEngineFn();
+            g_resetFusionEngineFn(false);
+        } else if ( g_resetFusionEngineFn ) {
+            g_resetFusionEngineFn(true);
         }
         daScriptEnvironment::setBound(nullptr);
         if ( daScriptEnvironment::getOwned() ) {
@@ -295,8 +300,8 @@ namespace das {
         }
     }
 
-    void Module::Shutdown( bool dumpHandleLeaks ) {
-        shutdownInternal(dumpHandleLeaks, /*resetFusion=*/true);
+    void Module::Shutdown( bool dumpHandleLeaks, bool resetFusion ) {
+        shutdownInternal(dumpHandleLeaks, resetFusion);
     }
 
     // Standalone exes built with `daslang -exe` link only libDaScript*_runtime

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3917,7 +3917,12 @@ namespace das
 #if DAS_FUSION
         if ( !folding ) {               // note: only run fusion when not folding
             DAS_ASSERTF(g_fusionContextFn, "fusion library not loaded, add call to NEED_FUSION macro.");
-            g_fusionContextFn(context, logs, options.getBoolOption("fusion", policies.fusion));
+            // under the jit the interpreter's nodes are the fallback, not the product, so a
+            // user context never fuses and a macro context fuses only when its module asks
+            // (options fusion = true); without the jit the option keeps its meaning
+            bool fusion = options.getBoolOption("fusion", policies.fusion);
+            if ( policies.jit_enabled ) fusion = isCompilingMacros && options.getBoolOption("fusion", false);
+            g_fusionContextFn(context, logs, fusion);
             context.relocateCode(true); // this to get better estimate on relocated size. its fust enough
         }
 #else

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -26,7 +26,7 @@ namespace das
 {
     // fusion function pointers (defined here in main lib, set by fusion lib)
     void (*g_fusionContextFn) ( Context & context, TextWriter & logs, bool enableFusion ) = nullptr;
-    void (*g_resetFusionEngineFn) () = nullptr;
+    void (*g_resetFusionEngineFn) ( bool orphan ) = nullptr;
     // ARCHITECTURE.md sec.4
     static __forceinline int32_t programIndexOf ( const Context & context, const Function * fn ) {
         return context.thisProgram ? context.thisProgram->indexOf(fn) : -1;

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -3742,6 +3742,7 @@ namespace das
             context.constStringHeap->setInitialSize(globalStringHeapSize);
         }
         DebugInfoHelper helper(context.debugInfo);
+        helper.collectCppNames = false;     // nothing reads a simulate's C++ spellings (ast.h DebugInfoHelper)
         context.thisHelper = &helper;
         context.globalVariables = (GlobalVariable *) context.code->allocate( totalVariables*sizeof(GlobalVariable) );
         context.globalsSize = 0;

--- a/src/ast/ast_simulate.cpp
+++ b/src/ast/ast_simulate.cpp
@@ -4101,10 +4101,16 @@ namespace das
                 }
             }
         }
-        for ( int i=0, is=context.totalFunctions; i!=is; ++i ) {
-            Function * func = indexToFunction[i];
-            SimFunction & fn = context.functions[i];
-            func->hash = getFunctionHash(func, fn.code, &context);
+        // the semantic hash feeds getFunctionAotHash - the jit's keys, the AOT generator and
+        // linker - which only ever ask about a user program's functions; a macro context is
+        // never asked, and a function it shares with the user program gets hashed by that
+        // program's own simulate
+        if ( !isCompilingMacros ) {
+            for ( int i=0, is=context.totalFunctions; i!=is; ++i ) {
+                Function * func = indexToFunction[i];
+                SimFunction & fn = context.functions[i];
+                func->hash = getFunctionHash(func, fn.code, &context);
+            }
         }
         for (auto pm : library.modules) {
             pm->structures.foreach([&](auto st){

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -548,7 +548,7 @@ namespace das
             hb.update(enumType->baseType);
             for ( auto & e : enumType->list ) {
                 hb.updateString(e.name);
-                wr << *(e.value);
+                hb.update(e.value ? getConstExprIntOrUInt(e.value) : int64_t(-1));   // the folded constant, not the printer's text
             }
         } else if ( annotation ) {
             DAS_ASSERT(annotation->ownSemanticHash!=0);
@@ -604,7 +604,7 @@ namespace das
             hb.update(enumType->baseType);
             for ( auto & e : enumType->list ) {
                 hb.updateString(e.name);
-                wr << *(e.value);
+                hb.update(e.value ? getConstExprIntOrUInt(e.value) : int64_t(-1));   // the folded constant, not the printer's text
             }
         } else if ( annotation ) {
             if ( adep.find(annotation) == adep.end() ) {

--- a/src/ast/ast_typedecl.cpp
+++ b/src/ast/ast_typedecl.cpp
@@ -1595,14 +1595,20 @@ namespace das
 
     int32_t TypeDecl::gcFlags(das_set<Structure *> & dep, das_set<Annotation *> & depA) const {
         int32_t gcf = 0;
+        // a structure's or a handled type's flags are cached on the owner, but only from a
+        // top-level walk: a walk that reaches the owner mid-cycle takes the cycle cut (0 for
+        // an owner already visited) and that partial value must not be what later asks read
         if ( baseType==Type::tStructure ) {
             if ( structType ) {
                 if (dep.find(structType) != dep.end()) return 0;
+                if ( structType->cachedGcFlags >= 0 ) return structType->cachedGcFlags;
+                bool topLevel = dep.empty() && depA.empty();
                 dep.insert(structType);
                 if ( structType->isLambda || structType->isClass ) gcf |= gcFlag_heap | gcFlag_stringHeap;
                 for ( auto fld : structType->fields ) {
                     gcf |= fld.type->gcFlags(dep,depA);
                 }
+                if ( topLevel ) structType->cachedGcFlags = gcf;
             }
         } else if ( baseType==Type::tTuple || baseType==Type::tVariant || baseType == Type::option ) {
             for ( const auto & arg : argTypes ) {
@@ -1618,9 +1624,12 @@ namespace das
             if ( firstType ) gcf |= firstType->gcFlags(dep,depA);
         } else if ( baseType==Type::tHandle ) {
             if (depA.find(annotation) != depA.end()) return 0;
-            depA.insert(annotation);
             auto ann = static_cast<TypeAnnotation *>(annotation);
+            if ( ann->cachedGcFlags >= 0 ) return ann->cachedGcFlags;
+            bool topLevel = dep.empty() && depA.empty();
+            depA.insert(annotation);
             gcf |= ann->getGcFlags(dep,depA);
+            if ( topLevel ) ann->cachedGcFlags = gcf;
         } else if ( baseType==Type::tString ) {
             gcf |= gcFlag_stringHeap;
         } else if ( baseType==Type::tPointer ) {

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -84,31 +84,6 @@ namespace das {
         }
     }
 
-    template <typename TT>
-    void patchRefs ( vector<pair<TT**,SerializeNodeId>> & refs, const das_hash_map<SerializeNodeId, smart_ptr<TT>> & objects) {
-        for ( auto & p : refs ) {
-            auto it = objects.find(p.second);
-            if ( it == objects.end() ) {
-                throw dasException{"ast serializer function ref not found", LineInfo()};
-            } else {
-                *p.first = it->second.get();
-            }
-        }
-        refs.clear();
-    }
-
-    template <typename TT>
-    void patchRefs ( vector<pair<TT**,SerializeNodeId>> & refs, const das_hash_map<SerializeNodeId, TT*> & objects) {
-        for ( auto & p : refs ) {
-            auto it = objects.find(p.second);
-            if ( it == objects.end() ) {
-                throw dasException{"ast serializer function ref not found", LineInfo()};
-            } else {
-                *p.first = it->second;
-            }
-        }
-        refs.clear();
-    }
 
     void throw_formatted_error ( const char * fmt, ... ) {
         va_list args;
@@ -129,21 +104,20 @@ namespace das {
         }                                                   \
     }
 
+    void AstSerializer::clearNodeIds () {
+        writeIds.clear();
+        writtenIds.clear();
+        readNodes.clear();
+        pendingRefs.clear();
+    }
+
     void AstSerializer::patch () {
-        patchRefs(functionRefs, smartFunctionMap);
-        patchRefs(variableRefs, smartVariableMap);
-        patchRefs(structureRefs, smartStructureMap);
-        patchRefs(enumerationRefs, smartEnumerationMap);
-    // finally, patch block refs (differenct container)
-        for ( auto & p : blockRefs ) {
-            auto it = exprBlockMap.find(p.second);
-            if ( it == exprBlockMap.end() ) {
-                throw_formatted_error("ast serializer block ref not found");
-            } else {
-                *p.first = it->second;
-            }
+        for ( auto & p : pendingRefs ) {
+            auto node = readNodes[p.second.index];
+            if ( !node ) throw_formatted_error("ast serializer ref #%u not found", p.second.index);
+            *p.first = node;
         }
-        blockRefs.clear();
+        pendingRefs.clear();
 
         for ( auto & [field, mod, name, fieldname] : fieldRefs ) {
             auto struct_ = moduleLibrary->findStructure(name, mod);
@@ -263,55 +237,16 @@ namespace das {
 
     AstSerializer & AstSerializer::operator << ( SerializeNodeId & value ) {
         dtag(HASH_TAG("SerializeNodeId"));
-        // 64-bit user-space pointers fit in 48 bits (canonical form on x86-64
-        // and AArch64 Linux/macOS — top 16 bits are sign-extended copies of
-        // bit 47, and we only ever see user-space addresses here, so they are
-        // zero — but we mask them on write regardless, since ptr is an identity
-        // key only). Pack a small epoch into those unused top 16 bits so the
-        // common case is a single 8-byte word. Reserve sentinel 0xFFFF for
-        // "epoch overflow" — fall back to a separate adaptive-size write.
-        // 32-bit hosts have no headroom; always emit ptr + adaptive epoch.
-        if constexpr ( sizeof(void *) == 8 ) {
-            constexpr uint64_t kPtrMask  = (uint64_t(1) << 48) - 1;
-            constexpr uint64_t kEpochOverflowTag = 0xFFFFull << 48;
-            if ( writing ) {
-                uintptr_t pbits = reinterpret_cast<uintptr_t>(value.ptr) & kPtrMask;
-                if ( value.epoch < 0xFFFFull ) {
-                    uint64_t packed = (uint64_t(value.epoch) << 48) | uint64_t(pbits);
-                    *this << packed;
-                } else {
-                    uint64_t packed = kEpochOverflowTag | uint64_t(pbits);
-                    *this << packed;
-                    uint32_t epoch32 = uint32_t(value.epoch);
-                    serializeAdaptiveSize32(epoch32);
-                }
+        serializeAdaptiveSize32(value.index);
+        if ( !writing ) {
+            // numbers arrive in first-mention order, so a first sight is exactly the next
+            // slot; anything past it is a corrupt stream, not a resize
+            if ( readNodes.empty() ) readNodes.push_back(nullptr);
+            if ( value.index == readNodes.size() ) {
+                readNodes.push_back(nullptr);
             } else {
-                uint64_t packed = 0;
-                *this << packed;
-                uint64_t topBits = packed & ~kPtrMask;
-                value.ptr = reinterpret_cast<void *>(uintptr_t(packed & kPtrMask));
-                if ( topBits == kEpochOverflowTag ) {
-                    uint32_t epoch32 = 0;
-                    serializeAdaptiveSize32(epoch32);
-                    value.epoch = size_t(epoch32);
-                } else {
-                    value.epoch = size_t(topBits >> 48);
-                }
-            }
-        } else {
-            // 32-bit: pointer fills the word; epoch goes in its own adaptive int.
-            if ( writing ) {
-                uint32_t pbits = uint32_t(reinterpret_cast<uintptr_t>(value.ptr));
-                uint32_t epoch32 = uint32_t(value.epoch);
-                *this << pbits;
-                serializeAdaptiveSize32(epoch32);
-            } else {
-                uint32_t pbits = 0;
-                *this << pbits;
-                uint32_t epoch32 = 0;
-                serializeAdaptiveSize32(epoch32);
-                value.ptr = reinterpret_cast<void *>(uintptr_t(pbits));
-                value.epoch = size_t(epoch32);
+                SERIALIZER_VERIFYF(value.index < readNodes.size(), "corrupt stream: node #%u past the %u numbered so far",
+                    value.index, unsigned(readNodes.size()));
             }
         }
         return *this;
@@ -501,46 +436,6 @@ namespace das {
         *this << ptr->module->nameHash << ptr->name;
     }
 
-    void AstSerializer::fillOrPatchLater ( Function * & func, SerializeNodeId id ) {
-        auto it = smartFunctionMap.find(id);
-        if ( it == smartFunctionMap.end() ) {
-            func = ( Function * ) 1;
-            functionRefs.emplace_back(&func, id);
-        } else {
-            func = it->second;
-        }
-    }
-
-    void AstSerializer::fillOrPatchLater ( Enumeration * & ptr, SerializeNodeId id ) {
-        auto it = smartEnumerationMap.find(id);
-        if ( it == smartEnumerationMap.end() ) {
-            ptr = ( Enumeration * ) 1;
-            enumerationRefs.emplace_back(&ptr, id);
-        } else {
-            ptr = it->second;
-        }
-    }
-
-    void AstSerializer::fillOrPatchLater ( Structure * & ptr, SerializeNodeId id ) {
-        auto it = smartStructureMap.find(id);
-        if ( it == smartStructureMap.end() ) {
-            ptr = ( Structure * ) 1;
-            structureRefs.emplace_back(&ptr, id);
-        } else {
-            ptr = it->second;
-        }
-    }
-
-    void AstSerializer::fillOrPatchLater ( Variable * & ptr, SerializeNodeId id ) {
-        auto it = smartVariableMap.find(id);
-        if ( it == smartVariableMap.end() ) {
-            ptr = ( Variable * ) 1;
-            variableRefs.emplace_back(&ptr, id);
-        } else {
-            ptr = it->second;
-        }
-    }
-
     auto AstSerializer::readModuleAndNameHash () -> pair<Module *, uint64_t> {
         uint64_t moduleNameHash = 0;
         uint64_t mangledNameHash = 0;
@@ -622,7 +517,7 @@ namespace das {
     AstSerializer & AstSerializer::serializePointer ( TT * & ptr ) {
         auto fid = getSerializeId(ptr);
         *this << fid;
-        if ( !fid.ptr ) {
+        if ( !fid.index ) {
             if ( !writing ) ptr = nullptr;
             return *this;
         }
@@ -650,23 +545,22 @@ namespace das {
         }
         auto id = getSerializeId(func);
         *this << id;
-        if ( id.ptr == 0 ) {
+        if ( id.index == 0 ) {
             if ( !writing ) func = nullptr;
             return *this;
         }
         if ( writing ) {
-            if ( smartFunctionMap.find(id) == smartFunctionMap.end() ) {
-                smartFunctionMap[id] = func;
+            if ( !isWritten(id) ) {
+                markWritten(id);
                 func->serialize(*this);
             }
         } else {
-            auto it = smartFunctionMap.find(id);
-            if ( it == smartFunctionMap.end() ) {
-                func = new Function();
-                smartFunctionMap[id] = func;
-                func->serialize(*this);
+            if ( auto node = readNode<Function>(id) ) {
+                func = node;
             } else {
-                func = it->second;
+                func = new Function();
+                setReadNode(id, func);
+                func->serialize(*this);
             }
         }
         if ( func ) {
@@ -718,17 +612,17 @@ namespace das {
         auto id = getSerializeId(type);
         *this << id;
         if ( writing ) {
-            if ( smartTypeDeclMap[id] == nullptr ) {
-                smartTypeDeclMap[id] = type;
+            if ( !isWritten(id) ) {
+                markWritten(id);
                 type->serialize(*this);
             }
         } else {
-            if ( smartTypeDeclMap[id] == nullptr ) {
-                type = new TypeDecl();
-                smartTypeDeclMap[id] = type;
-                type->serialize(*this);
+            if ( auto node = readNode<TypeDecl>(id) ) {
+                type = node;
             } else {
-                type = smartTypeDeclMap[id];
+                type = new TypeDecl();
+                setReadNode(id, type);
+                type->serialize(*this);
             }
         }
         return *this;
@@ -935,23 +829,22 @@ namespace das {
     AstSerializer & AstSerializer::operator << ( StructurePtr & struct_ ) {
         auto id = getSerializeId(struct_);
         *this << id;
-        if ( id.ptr == 0 ) {
+        if ( id.index == 0 ) {
             if ( !writing ) struct_ = nullptr;
             return *this;
         }
         if ( writing ) {
-            if ( smartStructureMap.find(id) == smartStructureMap.end() ) {
-                smartStructureMap[id] = struct_;
+            if ( !isWritten(id) ) {
+                markWritten(id);
                 struct_->serialize(*this);
             }
         } else {
-            auto it = smartStructureMap.find(id);
-            if ( it == smartStructureMap.end() ) {
-                struct_ = new Structure();
-                smartStructureMap[id] = struct_;
-                struct_->serialize(*this);
+            if ( auto node = readNode<Structure>(id) ) {
+                struct_ = node;
             } else {
-                struct_ = it->second;
+                struct_ = new Structure();
+                setReadNode(id, struct_);
+                struct_->serialize(*this);
             }
         }
         return *this;
@@ -984,25 +877,25 @@ namespace das {
         if ( writing ) {
             auto p = getSerializeId(ptr.get());
             *this << p;
-            if ( fileAccessMap[p] == nullptr ) {
-                fileAccessMap[p] = ptr.get();
+            if ( !isWritten(p) ) {
+                markWritten(p);
                 ptr->serialize(*this);
             }
         } else {
             SerializeNodeId p; *this << p;
-            if ( fileAccessMap[p] == nullptr ) {
+            if ( auto node = readNode<FileAccess>(p) ) {
+                ptr.orphan();
+                FileAccessPtr t = node;
+                ptr = t;
+            } else {
                 uint8_t tag = 0; *this << tag;
                 switch ( tag ) {
                     case 0: ptr = make_smart<FileAccess>(); break;
                     case 1: ptr = make_smart<ModuleFileAccess>(); break;
                     default: SERIALIZER_VERIFYF(false, "Unreachable");
                 }
-                fileAccessMap[p] = ptr.get();
+                setReadNode(p, ptr.get());
                 ptr->serialize(*this);
-            } else {
-                ptr.orphan();
-                FileAccessPtr t = fileAccessMap[p];
-                ptr = t;
             }
         }
         return *this;
@@ -1019,8 +912,8 @@ namespace das {
             } else {
                 auto id = getSerializeId(enum_type);
                 *this << id;
-                if ( smartEnumerationMap.find(id) == smartEnumerationMap.end() ) {
-                    smartEnumerationMap[id] = enum_type;
+                if ( !isWritten(id) ) {
+                    markWritten(id);
                     enum_type->serialize(*this);
                 }
             }
@@ -1038,14 +931,13 @@ namespace das {
             } else {
                 SerializeNodeId id;
                 *this << id;
-                SERIALIZER_VERIFYF(id.ptr != 0, "expected non-null enumeration id");
-                auto it = smartEnumerationMap.find(id);
-                if ( it == smartEnumerationMap.end() ) {
-                    enum_type = new Enumeration();
-                    smartEnumerationMap[id] = enum_type;
-                    enum_type->serialize(*this);
+                SERIALIZER_VERIFYF(id.index != 0, "expected non-null enumeration id");
+                if ( auto node = readNode<Enumeration>(id) ) {
+                    enum_type = node;
                 } else {
-                    enum_type = it->second;
+                    enum_type = new Enumeration();
+                    setReadNode(id, enum_type);
+                    enum_type->serialize(*this);
                 }
                 SERIALIZER_VERIFYF(enum_type, "expected to find enumeration");
             }
@@ -1070,23 +962,22 @@ namespace das {
     AstSerializer & AstSerializer::operator << ( VariablePtr & var ) {
         auto id = getSerializeId(var);
         *this << id;
-        if ( id.ptr == 0 ) {
+        if ( id.index == 0 ) {
             if ( !writing ) var = nullptr;
             return *this;
         }
         if ( writing ) {
-            if ( smartVariableMap.find(id) == smartVariableMap.end() ) {
-                smartVariableMap[id] = var;
+            if ( !isWritten(id) ) {
+                markWritten(id);
                 var->serialize(*this);
             }
         } else {
-            auto it = smartVariableMap.find(id);
-            if ( it == smartVariableMap.end() ) {
-                var = new Variable();
-                smartVariableMap[id] = var;
-                var->serialize(*this);
+            if ( auto node = readNode<Variable>(id) ) {
+                var = node;
             } else {
-                var = it->second;
+                var = new Variable();
+                setReadNode(id, var);
+                var->serialize(*this);
             }
         }
         return *this;
@@ -1150,9 +1041,9 @@ namespace das {
         dtag(HASH_TAG("ExprBlock*"));
         auto id = getSerializeId(block);
         *this << id;
-        if ( !writing && id.ptr ) {
-            block = ( ExprBlock * ) 1;
-            blockRefs.emplace_back(&block, id);
+        if ( !writing ) {
+            if ( id.index ) fillOrPatchLater(block, id);
+            else block = nullptr;
         }
         return *this;
     }
@@ -1849,7 +1740,7 @@ namespace das {
             ser << thisBlockId;
         } else {
             SerializeNodeId thisBlockId; ser << thisBlockId;
-            ser.exprBlockMap.emplace(thisBlockId, expr);
+            ser.setReadNode(thisBlockId, expr);
         }
 
         ser << expr->list << expr->finalList << expr->returnType << expr->arguments << expr->stackTop
@@ -2331,7 +2222,7 @@ namespace das {
                     ser << module << mnh;
                 } else {
                     auto fid = ser.getSerializeId(usedFun);
-                    if ( ser.smartFunctionMap.find(fid) == ser.smartFunctionMap.end() )
+                    if ( !ser.isWritten(fid) )
                         LOG(LogLevel::warning) << "das: serialize: [write] unregistered id for function '" << usedFun->name
                             << "' of module '" << usedFun->module->name << "' in use-set of fn '" << f->name << "' - will be unresolvable on read\n";
                     ser << fid;
@@ -2358,9 +2249,9 @@ namespace das {
                     f->useFunctions.emplace(fun);
                 } else {
                     SerializeNodeId fid; ser << fid;
-                    auto fun = ser.smartFunctionMap[fid];
-                    SERIALIZER_VERIFYF(fun, "expected to find function (id %p:%llu, useFunctions[%llu/%llu] of function '%s')",
-                        fid.ptr, (unsigned long long) fid.epoch, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
+                    auto fun = ser.readNode<Function>(fid);
+                    SERIALIZER_VERIFYF(fun, "expected to find function (id #%u, useFunctions[%llu/%llu] of function '%s')",
+                        fid.index, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
                     f->useFunctions.emplace(fun);
                 }
             }
@@ -2383,7 +2274,7 @@ namespace das {
                     ser << module << mnh;
                 } else {
                     auto fid = ser.getSerializeId(usedFun);
-                    if ( ser.smartFunctionMap.find(fid) == ser.smartFunctionMap.end() )
+                    if ( !ser.isWritten(fid) )
                         LOG(LogLevel::warning) << "das: serialize: [write] unregistered id for function '" << usedFun->name
                             << "' of module '" << usedFun->module->name << "' in use-set of global '" << f->name << "' - will be unresolvable on read\n";
                     ser << fid;
@@ -2410,9 +2301,9 @@ namespace das {
                     f->useFunctions.emplace(fun);
                 } else {
                     SerializeNodeId fid; ser << fid;
-                    auto fun = ser.smartFunctionMap[fid];
-                    SERIALIZER_VERIFYF(fun, "expected to find function (id %p:%llu, useFunctions[%llu/%llu] of global '%s')",
-                        fid.ptr, (unsigned long long) fid.epoch, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
+                    auto fun = ser.readNode<Function>(fid);
+                    SERIALIZER_VERIFYF(fun, "expected to find function (id #%u, useFunctions[%llu/%llu] of global '%s')",
+                        fid.index, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
                     f->useFunctions.emplace(fun);
                 }
             }
@@ -2438,7 +2329,7 @@ namespace das {
                     ser << module << varname;
                 } else {
                     auto vid = ser.getSerializeId(use);
-                    if ( ser.smartVariableMap.find(vid) == ser.smartVariableMap.end() )
+                    if ( !ser.isWritten(vid) )
                         LOG(LogLevel::warning) << "das: serialize: [write] unregistered id for variable '" << use->name
                             << "' of module '" << use->module->name << "' in use-set of fn '" << f->name << "' - will be unresolvable on read\n";
                     ser << vid;
@@ -2465,9 +2356,9 @@ namespace das {
                     f->useGlobalVariables.emplace(var);
                 } else {
                     SerializeNodeId vid; ser << vid;
-                    auto var = ser.smartVariableMap[vid];
-                    SERIALIZER_VERIFYF(var, "expected to find variable (id %p:%llu, useGlobalVariables[%llu/%llu] of function '%s')",
-                        vid.ptr, (unsigned long long) vid.epoch, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
+                    auto var = ser.readNode<Variable>(vid);
+                    SERIALIZER_VERIFYF(var, "expected to find variable (id #%u, useGlobalVariables[%llu/%llu] of function '%s')",
+                        vid.index, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
                     f->useGlobalVariables.emplace(var);
                 }
             }
@@ -2490,7 +2381,7 @@ namespace das {
                     ser << module << varname;
                 } else {
                     auto vid = ser.getSerializeId(use);
-                    if ( ser.smartVariableMap.find(vid) == ser.smartVariableMap.end() )
+                    if ( !ser.isWritten(vid) )
                         LOG(LogLevel::warning) << "das: serialize: [write] unregistered id for variable '" << use->name
                             << "' of module '" << use->module->name << "' in use-set of global '" << f->name << "' - will be unresolvable on read\n";
                     ser << vid;
@@ -2517,9 +2408,9 @@ namespace das {
                     f->useGlobalVariables.emplace(var);
                 } else {
                     SerializeNodeId vid; ser << vid;
-                    auto var = ser.smartVariableMap[vid];
-                    SERIALIZER_VERIFYF(var, "expected to find variable (id %p:%llu, useGlobalVariables[%llu/%llu] of global '%s')",
-                        vid.ptr, (unsigned long long) vid.epoch, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
+                    auto var = ser.readNode<Variable>(vid);
+                    SERIALIZER_VERIFYF(var, "expected to find variable (id #%u, useGlobalVariables[%llu/%llu] of global '%s')",
+                        vid.index, (unsigned long long) i, (unsigned long long) size, f->name.c_str());
                     f->useGlobalVariables.emplace(var);
                 }
             }
@@ -2883,23 +2774,11 @@ namespace das {
         }
         // per-record scratch must never survive into the next record: a failed or
         // early-returned record leaves refs whose targets die with it (throwaway root,
-        // `delete deser`), and its same-epoch map entries would make the next record's
-        // patch() resolve those refs INTO FREED MEMORY. The success path cleared the
-        // maps already and patch() cleared the refs - re-clearing is free.
-        blockRefs.clear();
-        functionRefs.clear();
-        variableRefs.clear();
-        structureRefs.clear();
-        enumerationRefs.clear();
+        // `delete deser`), and its node table would make the next record's patch()
+        // resolve those refs INTO FREED MEMORY. The success path cleared the table
+        // already and patch() cleared the refs - re-clearing is free.
         fieldRefs.clear();
-        smartMakeFieldDeclMap.clear();
-        smartEnumerationMap.clear();
-        smartStructureMap.clear();
-        smartVariableMap.clear();
-        smartFunctionMap.clear();
-        smartMakeStructMap.clear();
-        smartTypeDeclMap.clear();
-        exprBlockMap.clear();
+        clearNodeIds();
     }
 
     void AstSerializer::serializeProgramImpl ( ProgramPtr program, ModuleGroup & libGroup ) {
@@ -2916,10 +2795,8 @@ namespace das {
             ser.failed = true;
             return;
         }
-        // Bump epoch so reused pointer addresses across program boundaries
-        // get distinct SerializeNodeIds on this persistent serializer.
-        ser.epoch++;
         ser.builtinHashDrift = false;   // per-record flavor bit, read by the resume path
+        ser.clearNodeIds();             // numbering restarts with every program, on both sides
 
         ser << program->thisNamespace << program->thisModuleName;
 
@@ -3118,14 +2995,8 @@ namespace das {
             }
         }
 
-        // drop ref_counts
-        smartEnumerationMap.clear();
-        smartStructureMap.clear();
-        smartVariableMap.clear();
-        smartFunctionMap.clear();
-        smartMakeStructMap.clear();
-        smartTypeDeclMap.clear();
-        exprBlockMap.clear();
+        // the node table is per program
+        clearNodeIds();
     }
 
     // Serializes the whole script as opposed to just one module
@@ -3158,10 +3029,8 @@ namespace das {
             failToCompile = true;
             return;
         }
-        // Bump epoch so reused pointer addresses across program boundaries
-        // get distinct SerializeNodeIds on this persistent serializer.
-        ser.epoch++;
 
+        ser.clearNodeIds();             // numbering restarts with every program, on both sides
         ser << thisNamespace << thisModuleName;
 
         ser << totalFunctions      << totalVariables << newLambdaIndex;

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -2283,6 +2283,8 @@ namespace das {
                 program->thisModuleGroup = ser.thisModuleGroup;
                 program->thisModuleName.clear();
                 program->library.reset();
+                program->policies.jit_enabled = ser.readJitEnabled;     // the two things the cold path's program also carries
+                program->options = ser.readOptions;
                 program->policies.stack = 64 * 1024;
                 program->thisModule.release();
                 program->thisModule.reset(this_mod);
@@ -2936,6 +2938,8 @@ namespace das {
                 ser.failed = true;
                 return;
             }
+            ser.readJitEnabled = program->policies.jit_enabled;
+            ser.readOptions = program->options;
         }
 
         if ( writing ) {

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -115,7 +115,8 @@ namespace das {
         for ( auto & p : pendingRefs ) {
             auto node = readNodes[p.second.index];
             if ( !node ) throw_formatted_error("ast serializer ref #%u not found", p.second.index);
-            *p.first = node;
+            memcpy(p.first, &node, sizeof(node));   // the slot is some TT *, not a void *; a typed store through void ** would alias it
+
         }
         pendingRefs.clear();
 

--- a/src/builtin/module_builtin_ast_serialize.cpp
+++ b/src/builtin/module_builtin_ast_serialize.cpp
@@ -3038,6 +3038,8 @@ namespace das {
         ser << flags;
 
         ser << options << policies;
+        ser.readJitEnabled = policies.jit_enabled;  // what finalizeModule hands the macro program a served module reinstantiates
+        ser.readOptions = options;
 
     // serialize library
         if ( ser.writing ) {

--- a/src/simulate/simulate_fusion.cpp
+++ b/src/simulate/simulate_fusion.cpp
@@ -133,8 +133,12 @@ namespace das {
         return *g_fusionEngine;
     }
 
-    void resetFusionEngine() {
-        g_fusionEngine->reset();
+    void resetFusionEngine( bool orphan ) {
+        if ( orphan ) {
+            (void) g_fusionEngine->release();   // the thread-local's destructor would otherwise free it all at exit
+        } else {
+            g_fusionEngine->reset();
+        }
     }
 
     void createFusionEngine() {

--- a/tests-cpp/small/test_enum_semantic_hash.cpp
+++ b/tests-cpp/small/test_enum_semantic_hash.cpp
@@ -1,0 +1,33 @@
+// the semantic hash of an enumeration type reads each entry's folded value: two enumerations
+// that differ only in a value hash apart, two spelled the same hash alike
+
+#include <doctest/doctest.h>
+#include "daScript/daScript.h"
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_expressions.h"
+using namespace das;
+
+namespace {
+
+Enumeration * makeEnum ( const string & name, std::initializer_list<pair<const char *, int32_t>> entries ) {
+    auto e = new Enumeration(name);
+    for ( auto & en : entries ) {
+        e->add(en.first, new ExprConstInt(en.second), cppBindingLineInfo());
+    }
+    return e;
+}
+
+}
+
+TEST_CASE("enum semantic hash reads the entry values") {
+    gc_guard guard;
+    TypeDeclPtr ab12 = new TypeDecl(makeEnum("E", {{"A",1},{"B",2}}));
+    TypeDeclPtr ab13 = new TypeDecl(makeEnum("E", {{"A",1},{"B",3}}));
+    TypeDeclPtr ab12again = new TypeDecl(makeEnum("E", {{"A",1},{"B",2}}));
+    TypeDeclPtr ac12 = new TypeDecl(makeEnum("E", {{"A",1},{"C",2}}));
+    CHECK_NE(ab12->getSemanticHash(), ab13->getSemanticHash());
+    CHECK_NE(ab12->getSemanticHash(), ac12->getSemanticHash());
+    CHECK_EQ(ab12->getSemanticHash(), ab12again->getSemanticHash());
+    CHECK_NE(ab12->getOwnSemanticHash(), ab13->getOwnSemanticHash());
+    CHECK_EQ(ab12->getOwnSemanticHash(), ab12again->getOwnSemanticHash());
+}

--- a/tests/module_cache/test_deferred_modules.das
+++ b/tests/module_cache/test_deferred_modules.das
@@ -20,6 +20,16 @@ def descriptor_line(out : string; mod : string) : string {
     return eol < 0 ? rest : slice(rest, 0, eol)
 }
 
+def line_count(text : string; prefix : string) : int {
+    var n = 0
+    for (line in split(text, "\n")) {
+        if (line |> starts_with(prefix)) {
+            n++
+        }
+    }
+    return n
+}
+
 //! the `DOLLAR N` line the dollar.das child prints: the builtin module's function count
 def dollar_count(out : string) : int {
     let marker = "DOLLAR "
@@ -340,6 +350,8 @@ def arms_nameless_rows(t : T?; fx : Fixture) {
         // the real dm row with its name blanked
         let doctored = replace(text, "\t{UNIT_TEST_MODULE}\n", "\t\n")
         t |> success(doctored != text, "the manifest carries the named row: {text}")
+        let depLines = line_count(text, "dep\t")
+        t |> success(depLines > 0, "the manifest carries dep lines: {text}")
         fwrite(fx.utManifest, doctored)
         var eager : string
         t |> success(run_child_reported(t, "eager", child_cmd(fx, fx.plain), eager, "PLAIN"), "the program runs")
@@ -347,7 +359,9 @@ def arms_nameless_rows(t : T?; fx : Fixture) {
         t |> success(find(eager, "{UNIT_TEST_CLASS} <- ") >= 0 && loaded, "the nameless row loads at the scan:\n{eager}")
         // the trace joins the descriptor with "/" whatever the platform, as descriptor_line reads it
         t |> success(find(eager, "{UNIT_TEST_FOLDER}/.das_module: manifest rewritten, 1 row(s) named") >= 0, "the scan writes the name back:\n{eager}")
-        t |> success(find(fread(fx.utManifest), "\t{UNIT_TEST_MODULE}\n") >= 0, "the manifest carries the name again")
+        let healed = fread(fx.utManifest)
+        t |> success(find(healed, "\t{UNIT_TEST_MODULE}\n") >= 0, "the manifest carries the name again")
+        t |> equal(depLines, line_count(healed, "dep\t"), "and every dep line it had: {healed}")
         var lazy : string
         t |> success(run_child_reported(t, "lazy", child_cmd(fx, fx.plain), lazy, "PLAIN"), "the next start runs")
         t |> equal(-1, find(lazy, "{UNIT_TEST_CLASS} <- "), "the next start defers the row and loads nothing:\n{lazy}")

--- a/utils/daslang/main.cpp
+++ b/utils/daslang/main.cpp
@@ -43,6 +43,19 @@ static bool astVerifyRequired = false;
 static bool scopedStackAllocator = true;
 static bool pauseAfterErrors = false;
 static bool quiet = false;
+#ifndef MAIN_FUNC_NAME
+  #define MAIN_FUNC_NAME main
+  // the process ends when this returns: the fusion table is orphaned, not torn down - unless
+  // the build tracks allocations, whose exit audit must see it freed
+  #if DAS_TRACK_ALLOC
+    #define DAS_ORPHAN_FUSION_AT_EXIT false
+  #else
+    #define DAS_ORPHAN_FUSION_AT_EXIT true
+  #endif
+#else
+  // a host's entry point: the host may initialize again, so shutdown resets everything
+  #define DAS_ORPHAN_FUSION_AT_EXIT false
+#endif
 enum class JitMode {
     None,
     Direct,
@@ -271,7 +284,7 @@ int das_aot_main ( int argc, char * argv[] ) {
     daScriptEnvironment::getBound()->g_isInAot = true;
     bool compiled = true;
     compiled = aot_compile(aot_files, dryRun, cross_platform);
-    Module::Shutdown();
+    Module::Shutdown(true, !DAS_ORPHAN_FUSION_AT_EXIT);
     return compiled ? 0 : -1;
 }
 
@@ -772,9 +785,6 @@ void print_help() {
     ;
 }
 
-#ifndef MAIN_FUNC_NAME
-  #define MAIN_FUNC_NAME main
-#endif
 
 #include <inttypes.h>
 
@@ -1165,7 +1175,7 @@ int MAIN_FUNC_NAME ( int argc, char * argv[] ) {
     // destruction (drains job threads) and DLL unload (invalidates the
     // dumpHandleLeaks<T> function pointers registered from shared modules).
     auto shutdown0 = ref_time_ticks();
-    Module::Shutdown(dumpLeaks);
+    Module::Shutdown(dumpLeaks, !DAS_ORPHAN_FUSION_AT_EXIT);
     if ( dumpLeaks ) {
         JobStatus::DumpJobQueLeaks();
     }

--- a/utils/daslang/main.cpp
+++ b/utils/daslang/main.cpp
@@ -46,8 +46,9 @@ static bool quiet = false;
 #ifndef MAIN_FUNC_NAME
   #define MAIN_FUNC_NAME main
   // the process ends when this returns: the fusion table is orphaned, not torn down - unless
-  // the build tracks allocations, whose exit audit must see it freed
-  #if DAS_TRACK_ALLOC
+  // the build tracks allocations, whose exit audit must see it freed, or the browser host,
+  // which calls main once per run
+  #if DAS_TRACK_ALLOC || defined(__EMSCRIPTEN__)
     #define DAS_ORPHAN_FUSION_AT_EXIT false
   #else
     #define DAS_ORPHAN_FUSION_AT_EXIT true

--- a/utils/daslang/main.cpp
+++ b/utils/daslang/main.cpp
@@ -405,7 +405,7 @@ namespace {
             // alongside the already-leaked context (one program per frame)
             if ( g_webloop_defer_module_shutdown ) {
                 g_webloop_defer_module_shutdown = false;
-                if ( drained ) Module::Shutdown(g_webloop_dump_leaks);
+                if ( drained ) Module::Shutdown(g_webloop_dump_leaks, !DAS_ORPHAN_FUSION_AT_EXIT);
             }
         }
     }


### PR DESCRIPTION
**Rebuild required: `Module::Shutdown` gains a second defaulted parameter and the fusion reset hook takes a `bool` - a host or shared module compiled against the old headers must rebuild; module-cache records re-key (version 208) and the JIT DLL cache re-keys with the changed semantic hash.**

**Why.** A warm `daslang -jit hello.das` took 92 ms on an M5 Max, an interpreted one 12.9 ms, most of it on work no hello needs: twelve macro contexts fused, hashed and described for AOT on every start, 1154 LLVM externs parsed on a DLL-cache hit, and a module-cache read that resolved every node reference through a hash map.

**What changes.**
- A structure's and a handled type's gc flags are computed once and cached on the owner; only a top-level walk fills the cache, a walk that reaches the owner mid-cycle takes the cycle cut and stores nothing.
- Under `jit_enabled` no context fuses; a macro module fuses only with `options fusion = true`, and a served module record now carries the compile's `jit_enabled` and the module's `options` so the macro program a record reinstantiates decides the same way as a cold compile.
- A simulate's `DebugInfoHelper` no longer builds the C++ type-name maps; only the AOT emitter's own helper does, which is the only reader.
- A macro context skips the per-function semantic hash; the hash feeds the JIT keys and the AOT linker, which only ask about a user program's functions.
- `llvm_jit_plan` requires a four-extern `llvm_host` binding instead of `llvm_func`, so a DLL-cache hit parses four declarations, not 1154; the emitter pin is re-hashed.
- The serializer numbers a node at its first mention and streams the number as a varint; the reader indexes a vector, forward references patch in `patch()` (a bytewise write, the slot being some `TT *`), and the tables reset at every program start on both sides.
- Enum values hash by their folded constant, not the printer's text.
- `daslang` orphans the fusion table at exit instead of tearing it down (not under `DAS_TRACK_ALLOC`, not under `__EMSCRIPTEN__` where the host calls `main` per run, not for a host with its own `MAIN_FUNC_NAME`); `Module::Shutdown(dumpHandleLeaks, resetFusion)` carries the choice.

**Observable behavior.**
- Warm `-jit` hello on an M5 Max: 92.3 ms -> 59.5 ms; interpreted hello: 12.9 ms -> 10.7 ms.
- dasProfile startup lanes, interpreter / JIT, independent timer: M1 Max 19.0 / 96.2 ms, zen4 26.2 / 120.1 ms (records: borisbat/dasProfile PR 15).
- First start after the upgrade: every module-cache record is a miss and rewrites.
- Under `-jit`, a macro module's interpreter nodes are unfused unless it opts in; without `-jit` nothing changes.

**Where to look.** `ast_simulate.cpp` (the fusion gate and the hash skip), `module_builtin_ast_serialize.cpp` (the node numbering - the forward-reference patch and the per-program reset are the risky spots), `ast_typedecl.cpp` (the top-level-only cache fill).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- Full local preflight green on the pre-rebase tip (24 gates, md-ascii skipped: no `.md` in the diff); the module-owned dasLLVM suite run separately: 112 tests, 112 passed, 0 failed (`--test modules/dasLLVM/tests`, `-jit`).
- Rebased over the deferred-pending-require merge, which carries the same manifest name write-back this branch had; that commit was dropped here and master's kept, with one addition to master's test arm (the rewritten manifest keeps every dep line). Targeted gates on the rebased tip: the small C++ suite, `tests/module_cache`, `tests/language` under `-jit`.
- ABI sweep: every in-tree caller of `Module::Shutdown` uses the defaulted form and rebuilt with the tree; the fusion reset hook has no caller outside `src/`.
- External codex round over the branch: no findings, trace covers every changed file.
- `llvm_host.das` repeats four `[extern]` declarations from the generated `llvm_func.das` by design: the plan needs exactly those four on the cache-hit path, and requiring `llvm_func` parses all 1154.
- Whole-script stream after the carry fix: `dastest --ser` over `tests/language` (255 programs) then `--deser`: 1300 tests, 1300 passed.

### Claims - stated, not tested
- The gc-flags cache is filled only from a top-level walk. A fill from a mid-cycle walk recursed without bound on the test suite while this was built; no single test pins the arm, the suite is the instrument.
- A macro context's functions are never asked for a semantic hash. The detector is the Debug-only assert in `simulate_fn_hash.cpp` on a zero hash, which the nightly Debug lanes reach through the JIT and AOT suites.
- Nothing outside `daslib/aot_cpp.das` reads the C++ type-name maps a `DebugInfoHelper` collects (a tree sweep over `.das`, `.cpp`, `.h`, and the VS Code plugin).
- Under `-jit` an unfused user context behaves as a fused one: the fused nodes are the interpreter's fallback, and no test distinguishes fusion on from off; the JIT suite is the evidence.
- The macro-module `options fusion = true` opt-in has no user in the tree, so the arm that re-enables fusion is unexercised.
- The two serializer rejections - a node number past the count numbered so far, an unresolved reference in `patch()` - have no fixture; they are defensive.
- The fusion table orphaned at exit is observed only where it must not be: the `DAS_TRACK_ALLOC` nightly lane, whose exit audit sees the table freed.

### Not done
- One architecture-doc update held for review: `modules/dasLLVM/ARCHITECTURE_JIT_ENTRY.md` (the host queries now come from `llvm_host`, four externs; the exe sweep's skip list).
- Remaining startup papercuts, measured and left: `Module_BuiltIn` construction (1.6 ms), `allocateStack` re-run on a served AST (3.9 ms), `LineInfo` file lookups, per-node allocation, string reads in the serializer.

</details>