### PR TITLE
The wasm job pool floors at four workers, so a browser reporting two cores runs the examples on more than one

### DIFF
--- a/include/daScript/misc/platform.h
+++ b/include/daScript/misc/platform.h
@@ -621,18 +621,28 @@ private:
 #define WIN_EH_NO_ASAN
 #endif
 
-// Upper bound on JobQue worker threads, and therefore on get_total_hw_threads / get_total_hw_jobs.
+// Upper bound on the JobQue's default pool, whose workers get_total_hw_threads / get_total_hw_jobs
+// report: a worker count on a desktop; on wasm the bound counts lanes (below), one more than the
+// workers it yields.
 // On wasm the persistent job pool spawns one Web Worker per thread (navigator.hardwareConcurrency
 // of them without a cap), so cap it at 8 there - inside the 16-worker pthread pool the wasm64
 // builds link, with room for the program's own threads; everywhere else the cores-1 rule in
 // job_que.cpp governs and the cap is effectively off. Override in CMake (-DDAS_MAX_HW_JOBS=N)
-// either way.
+// either way. On wasm both numbers count LANES - the workers plus the computing main, as
+// DAS_JOBQUE_THREADS counts - so the cap of 8 is 7 workers, the pool an 8-core desktop runs, and
+// the floor of 4 is 3 workers: a browser under fingerprint protection (Brave's shields, Firefox's
+// resistFingerprinting) reports two logical cores whatever the box has, and the cores-1 rule
+// would leave one worker; a two-core box is older than any browser that runs the wasm64 build.
+// Override with -DDAS_MIN_WEB_JOBS=N.
 #ifndef DAS_MAX_HW_JOBS
 #if defined(__EMSCRIPTEN__)
 #define DAS_MAX_HW_JOBS 8
 #else
 #define DAS_MAX_HW_JOBS 1024
 #endif
+#endif
+#ifndef DAS_MIN_WEB_JOBS
+#define DAS_MIN_WEB_JOBS 4
 #endif
 
 #include "daScript/misc/smart_ptr.h"

--- a/modules/dasLLAMA/ARCHITECTURE_RUNTIME.md
+++ b/modules/dasLLAMA/ARCHITECTURE_RUNTIME.md
@@ -193,7 +193,9 @@ measurements behind this section and each refuted attempt.
 
 ### 2.18 The CPU worker pool on a hybrid box {#hybrid-pool-policy}
 
-SMT siblings share the FMA and load ports, so the default pool is physical cores - 1 workers. A box
+SMT siblings share the FMA and load ports, so the default pool is (physical cores - 1) workers -
+a cap the engine's `[init]` sets on every platform but a browser, where the reported count can be
+a fingerprint cap of two and the runtime's own floor and cap size the pool (2.18a). A box
 with two core tiers splits on the SECOND tier's KIND: a compute tier (an M5's Super plus Performance
 cores) extends the pool to every core with GEMV capped to the fast tier, while an efficiency tier
 (M1, M4) makes batch barriers wait and gets no worker at all. A compute-grade second tier only
@@ -227,7 +229,12 @@ window and the renderer at 800% CPU, and at 1.4x with the workers parked at ~112
 text, three runs each; team dispatch keeps its small edge there, and the pool still pays (one
 worker reads 0.7x). The engine's `[init]` therefore sets the window to 0 when the platform is
 emscripten (`dasllama_jobque_spin_default`); a box profile's `jobque_spin_us` and the setter still
-override it, and a program reads the value in force through `get_jobque_spin_us`.
+override it, and a program reads the value in force through `get_jobque_spin_us`. The pool's size
+is the runtime's (`src/misc/job_que.cpp`): the browser's reported cores, capped and floored by
+`DAS_MAX_HW_JOBS` and `DAS_MIN_WEB_JOBS` (eight and four unless the build overrides them), minus
+one for the computing main thread - seven workers on a real box, the pool
+an eight-core desktop runs, and three under fingerprint protection, where a browser reports two
+cores whatever the box has; the floor is what keeps such a visitor off a one-worker pool.
 
 ### 2.19 The CPU MoE region list caps a region at 32 rows {#moe-region-split}
 

--- a/modules/dasLLAMA/dasllama/dasllama_math.das
+++ b/modules/dasLLAMA/dasllama/dasllama_math.das
@@ -281,6 +281,9 @@ def setup_dasllama_jobque_() {
 
 [init, arch(at="../ARCHITECTURE_RUNTIME.md#hybrid-pool-policy")]
 def dasllama_jobque_threads_cap() {
+    if (get_running_platform_name() == "emscripten") {   // a browser's core count can be a fingerprint cap of 2: the runtime's floor and cap size the pool there
+        return
+    }
     let cores = get_total_hw_cores()
     set_jobque_threads_cap(max(cores - 1, 1))
     let perf = get_total_perf_cores()

--- a/src/misc/job_que.cpp
+++ b/src/misc/job_que.cpp
@@ -117,7 +117,17 @@ namespace das {
 #if defined(__APPLE__)
         if ( int good = apple_perf_core_count() ) def = max(1, good - 1);
 #endif
+#if defined(__EMSCRIPTEN__)
+#if DAS_MIN_WEB_JOBS > DAS_MAX_HW_JOBS
+#error "DAS_MIN_WEB_JOBS above DAS_MAX_HW_JOBS: the wasm pool's floor cannot exceed its cap"
+#endif
+#if DAS_MIN_WEB_JOBS < 2
+#error "DAS_MIN_WEB_JOBS below 2: the floor counts lanes, the computing main among them, and a pool needs one worker"
+#endif
+        if ( def == 0 ) def = max(DAS_MIN_WEB_JOBS, min(DAS_MAX_HW_JOBS, hw)) - 1;   // lanes floored and capped, the computing main among them: platform.h beside DAS_MAX_HW_JOBS
+#else
         if ( def == 0 ) def = max(1, min(DAS_MAX_HW_JOBS, hw - 1));
+#endif
         if ( int cap = JobQue::get_default_threads_cap() ) def = max(1, min(def, cap));
         return def;
     }


### PR DESCRIPTION
**Behavior change: a browser that reports two cores now gets three job workers instead of one, and a browser reporting more than eight gets seven instead of eight.**

**Why.** A browser under fingerprint protection (Brave's shields, Firefox's `resistFingerprinting`) reports `navigator.hardwareConcurrency` = 2 whatever the machine has. The wasm pool sizes itself as cores minus one, so such a visitor ran the parrot lab, storyteller and storywish on one web worker, and the lab's job slider could not go above 1.

**What changes.**
- `DAS_MIN_WEB_JOBS` (4, `platform.h` beside the cap, overridable in CMake) floors the wasm pool; the emscripten arm of the default rule is `max(floor, min(cap, cores)) - 1`: both numbers count lanes, the workers plus the computing main thread, as `DAS_JOBQUE_THREADS` does, and the minus one is applied once after the clamp. The cap of 8 is therefore seven workers, the pool an eight-core desktop runs.
- A build-time `#error` refuses a floor above the cap.
- The explicit `DAS_JOBQUE_THREADS` override, a requested count and the sticky cap keep their meaning; only the default rule changes, and only in the wasm build.
- dasLLAMA's `[init]` that caps the pool at physical cores minus one (the SMT-sibling rule) stands down in a browser: that count is the same untrusted number, and its cap ran after the floor and undid it.
- The dasLLAMA runtime doc's hybrid-pool and browser-workers sections state both rules the lab panel shows.

**Observable behavior.**
- Brave or Firefox with fingerprint protection, any of the three dasllama.io examples: `job queue (1 workers in the pool)`, slider stuck at 1 -> `3 workers in the pool`, slider to 3.
- Chrome on a box with more than eight cores: `8 workers in the pool` -> `7 workers in the pool`, the eight-core desktop's pool; a report of four to eight cores keeps cores - 1, and a report of two or three is floored to four lanes, three workers.
- A real two-core box: three workers plus the computing main thread on two cores, which oversubscribes it; a box that old is not a target of the wasm64 build.

**Where to look.** `jobque_thread_count` in `src/misc/job_que.cpp`, one `#if defined(__EMSCRIPTEN__)` arm; the define and its reason in `include/daScript/misc/platform.h`; the early return in `dasllama_jobque_threads_cap` (`dasllama_math.das`).

<details>
<summary>Validation, claims, ledger</summary>

### Validation
- The change sits in an `#if defined(__EMSCRIPTEN__)` arm no desktop test reaches; it was settled on the wasm rail: the parrot release rebuilt from this branch and loaded in Chrome with `navigator.hardwareConcurrency` pinned to 2 by an init script shows `cores 2` and `job queue (3 workers in the pool)`; the same page without the pin shows `cores 10` and 7 workers.
- The comment harvest, the style-hygiene audit, the review round and the codex round were not run on this diff (three files, one arm).

### Claims - stated, not tested
- The desktop rule is byte-for-byte the old one under `#else`, and the engine's cap `[init]` runs unchanged on every platform but emscripten; the jobque folder passes locally, no dasLLAMA suite was re-run for a guarded early return. A break would show desktop pools sized differently, which every dasLLAMA timing would report.
- The first release from this branch still showed one worker under the pin: the runtime floor was in, and the engine's cap `[init]` undid it. That is how the second change was found; the release with both shows three under the pin and seven without.

### Not done
- The lab has no control to raise the pool above the reported count by hand; the floor is the fix for the fingerprint case, and a real count above four still governs.

</details>
