### PR TITLE
The site deploy fails on a benchmark record that lost a das lane

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -430,6 +430,20 @@ jobs:
         done
       continue-on-error: true
 
+    - name: "Gate the benchmark records: every das lane on every board"
+      # A record that lost a das lane (an AOT module that never loaded, a runner started
+      # without -jit) renders as a board with no das column and nothing else notices;
+      # the deploy fails on it instead. A platform with no record at all is the fetch
+      # step's tolerance above - only the records that arrived are checked.
+      run: |
+        set -eu
+        records=$(ls site/files/profile_results_*.json 2>/dev/null || true)
+        if [ -z "$records" ]; then
+            echo "::error::no dasProfile record arrived at all"
+            exit 1
+        fi
+        python3 ci/check_profile_records.py $records
+
     - name: "Stage site for deployment"
       run: |
         set -eux

--- a/ci/check_profile_records.py
+++ b/ci/check_profile_records.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Gate the dasProfile records the site deploys: every das lane on every board, or the deploy fails.
+
+A record is profile_results_<platform>.json as borisbat/dasProfile publishes it. The site's
+benchmark boards render whatever lanes the record carries and drop a missing one silently, so a
+capture that lost a das lane (an AOT module that never loaded, a runner started without -jit)
+would ship a board with no das column and nobody would notice. This script fails the deploy
+instead.
+
+Usage: check_profile_records.py <record.json>...   (a missing platform is the fetch step's
+business - only files that exist are checked)
+"""
+import json
+import sys
+
+INTERPRETED = "Interpreted"
+AOT_OR_JIT = "AOT or JIT"
+STARTUP = "Startup"
+STARTUP_ROW = "hello world"
+
+DAS_LANES = {
+    INTERPRETED: ["DAS INTERPRETER"],
+    AOT_OR_JIT: ["DAS AOT", "DAS JIT"],
+}
+DAS_STARTUP_LANES = ["DAS INTERPRETER", "DAS JIT", "DAS EXE"]
+
+
+def lanes_of(rows):
+    return {r.get("language") for r in rows if isinstance(r, dict)}
+
+
+def check_record(path):
+    problems = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            record = json.load(f)
+    except (OSError, ValueError) as e:
+        return [f"{path}: unreadable record: {e}"]
+    for board in (INTERPRETED, AOT_OR_JIT, STARTUP):
+        if not isinstance(record.get(board), dict) or not record[board]:
+            problems.append(f"{path}: board '{board}' is missing or empty")
+    if problems:
+        return problems
+    tests = set(record[INTERPRETED]) | set(record[AOT_OR_JIT])
+    if set(record[INTERPRETED]) != set(record[AOT_OR_JIT]):
+        problems.append(
+            f"{path}: the two boards list different tests: "
+            f"{sorted(set(record[INTERPRETED]) ^ set(record[AOT_OR_JIT]))}")
+    for board, lanes in DAS_LANES.items():
+        for test in sorted(tests):
+            present = lanes_of(record[board].get(test, []))
+            for lane in lanes:
+                if lane not in present:
+                    problems.append(f"{path}: '{board}' / '{test}' has no '{lane}' cell")
+    startup = record[STARTUP].get(STARTUP_ROW)
+    if not isinstance(startup, list):
+        problems.append(f"{path}: '{STARTUP}' has no '{STARTUP_ROW}' row")
+    else:
+        present = lanes_of(startup)
+        for lane in DAS_STARTUP_LANES:
+            if lane not in present:
+                problems.append(f"{path}: '{STARTUP}' / '{STARTUP_ROW}' has no '{lane}' cell")
+    return problems
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    problems = []
+    for path in argv[1:]:
+        problems += check_record(path)
+    for p in problems:
+        print(f"::error::{p}")
+    if problems:
+        print(f"{len(problems)} problem(s): a das lane is missing from a benchmark record - "
+              "the capture is incomplete, not the site")
+        return 1
+    print(f"profile records ok: {len(argv) - 1} file(s), every das lane present on every board")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ci/check_profile_records.py
+++ b/ci/check_profile_records.py
@@ -36,6 +36,8 @@ def check_record(path):
             record = json.load(f)
     except (OSError, ValueError) as e:
         return [f"{path}: unreadable record: {e}"]
+    if not isinstance(record, dict):
+        return [f"{path}: record root is {type(record).__name__}, not an object"]
     for board in (INTERPRETED, AOT_OR_JIT, STARTUP):
         if not isinstance(record.get(board), dict) or not record[board]:
             problems.append(f"{path}: board '{board}' is missing or empty")

--- a/site/README.md
+++ b/site/README.md
@@ -308,7 +308,10 @@ reachable server - see `examples/benchmarks/sql/README.md`.
 The benchmark numbers come from the per-platform records in
 [borisbat/dasProfile](https://github.com/borisbat/dasProfile) -
 `profile_results_<platform>.json` for `darwin`, `linux` and `windows`. CI fetches the latest on
-every publish; a platform with no record upstream is dropped client-side. Local dev:
+every publish; a platform with no record upstream is dropped client-side. A record that arrived
+must carry every das lane on every test (`DAS INTERPRETER`; `DAS AOT` and `DAS JIT`; the three
+das startup launches) or the deploy fails - `ci/check_profile_records.py`, the same check to run
+on a fresh capture before publishing it upstream. Local dev:
 
 ```bash
 for plat in darwin linux windows; do


### PR DESCRIPTION
daslang.io/benchmarks.html renders whatever lanes a dasProfile record carries and drops a missing one silently. A recapture whose AOT module never loaded shipped both AOT or JIT boards with no das column, and nothing noticed.

`ci/check_profile_records.py` reads every `profile_results_<platform>.json` the fetch step brought in and requires `DAS INTERPRETER` on every test of the Interpreted board, `DAS AOT` and `DAS JIT` on every test of the AOT or JIT board, the two boards naming the same tests, and the three das launches on the startup row. `pages.yml` runs it after the fetch, outside the fetch's `continue-on-error`, so a platform with no record upstream is still tolerated and a record with a hole fails the deploy. The site README's dasProfile section says so.

Proven: the record before the broken recapture passes, the broken ones fail with 64 holes named, and the records now on dasProfile main (borisbat/dasProfile#16, where the capture gained the same gate) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)